### PR TITLE
feat(core): add topo.ids() and topo.count accessors [TRL-51]

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -11,6 +11,7 @@ Canonical public surface. For naming conventions and decision history, see `docs
 trail(id, spec)                    // define a unit of work (with optional follow for composition)
 event(id, spec)                    // define a payload schema with provenance
 topo(name, ...modules)             // assemble into a queryable topology
+// Topo methods: .get(id), .has(id), .list(), .listEvents(), .ids(), .count
 
 // Types
 Trail<I, O>, Event<T>, Topo, Intent

--- a/packages/core/src/__tests__/topo.test.ts
+++ b/packages/core/src/__tests__/topo.test.ts
@@ -117,6 +117,31 @@ describe('topo', () => {
 });
 
 // ---------------------------------------------------------------------------
+// topo accessors
+// ---------------------------------------------------------------------------
+
+describe('topo accessors', () => {
+  test('ids() returns all trail IDs', () => {
+    const a = mockTrail('alpha');
+    const b = mockTrail('beta');
+    const app = topo('test', { a, b });
+    expect(app.ids().toSorted()).toEqual(['alpha', 'beta']);
+  });
+
+  test('count returns number of trails', () => {
+    const a = mockTrail('alpha');
+    const app = topo('test', { a });
+    expect(app.count).toBe(1);
+  });
+
+  test('empty topo has zero count and empty ids', () => {
+    const app = topo('empty');
+    expect(app.count).toBe(0);
+    expect(app.ids()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Topo
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/topo.ts
+++ b/packages/core/src/topo.ts
@@ -14,8 +14,10 @@ export interface Topo {
   readonly name: string;
   readonly trails: ReadonlyMap<string, AnyTrail>;
   readonly events: ReadonlyMap<string, AnyEvent>;
+  readonly count: number;
   get(id: string): AnyTrail | undefined;
   has(id: string): boolean;
+  ids(): string[];
   list(): AnyTrail[];
   listEvents(): AnyEvent[];
 }
@@ -43,12 +45,17 @@ const createTopo = (
   trails: ReadonlyMap<string, AnyTrail>,
   events: ReadonlyMap<string, AnyEvent>
 ): Topo => ({
+  count: trails.size,
   events,
   get(id: string): AnyTrail | undefined {
     return trails.get(id);
   },
   has(id: string): boolean {
     return trails.has(id);
+  },
+
+  ids(): string[] {
+    return [...trails.keys()];
   },
 
   list(): AnyTrail[] {


### PR DESCRIPTION
## Summary

- Adds `ids(): string[]` and `count: number` accessors to the `Topo` interface
- Improves readability for topo inspection code — `app.ids()` instead of `[...app.trails.keys()]`

## Changes

- `packages/core/src/topo.ts` — added to interface and `createTopo` implementation
- `packages/core/src/__tests__/topo.test.ts` — 3 tests (ids, count, empty topo)
- `docs/api-reference.md` — documented

## Test plan

- [ ] `ids()` returns all registered trail IDs
- [ ] `count` matches `trails.size`
- [ ] Empty topo returns `[]` and `0`