### PR TITLE
fix(http): detect route path collisions and return Result from buildHttpRoutes() [TRL-55]

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -11,6 +11,7 @@ Canonical public surface. For naming conventions and decision history, see `docs
 trail(id, spec)                    // define a unit of work (with optional follow for composition)
 event(id, spec)                    // define a payload schema with provenance
 topo(name, ...modules)             // assemble into a queryable topology
+// Topo methods: .get(id), .has(id), .list(), .listEvents(), .ids(), .count
 
 // Types
 Trail<I, O>, Event<T>, Topo, Intent

--- a/packages/core/src/__tests__/topo.test.ts
+++ b/packages/core/src/__tests__/topo.test.ts
@@ -117,6 +117,31 @@ describe('topo', () => {
 });
 
 // ---------------------------------------------------------------------------
+// topo accessors
+// ---------------------------------------------------------------------------
+
+describe('topo accessors', () => {
+  test('ids() returns all trail IDs', () => {
+    const a = mockTrail('alpha');
+    const b = mockTrail('beta');
+    const app = topo('test', { a, b });
+    expect(app.ids().toSorted()).toEqual(['alpha', 'beta']);
+  });
+
+  test('count returns number of trails', () => {
+    const a = mockTrail('alpha');
+    const app = topo('test', { a });
+    expect(app.count).toBe(1);
+  });
+
+  test('empty topo has zero count and empty ids', () => {
+    const app = topo('empty');
+    expect(app.count).toBe(0);
+    expect(app.ids()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Topo
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/topo.ts
+++ b/packages/core/src/topo.ts
@@ -14,8 +14,10 @@ export interface Topo {
   readonly name: string;
   readonly trails: ReadonlyMap<string, AnyTrail>;
   readonly events: ReadonlyMap<string, AnyEvent>;
+  readonly count: number;
   get(id: string): AnyTrail | undefined;
   has(id: string): boolean;
+  ids(): string[];
   list(): AnyTrail[];
   listEvents(): AnyEvent[];
 }
@@ -43,12 +45,17 @@ const createTopo = (
   trails: ReadonlyMap<string, AnyTrail>,
   events: ReadonlyMap<string, AnyEvent>
 ): Topo => ({
+  count: trails.size,
   events,
   get(id: string): AnyTrail | undefined {
     return trails.get(id);
   },
   has(id: string): boolean {
     return trails.has(id);
+  },
+
+  ids(): string[] {
+    return [...trails.keys()];
   },
 
   list(): AnyTrail[] {

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -4,6 +4,7 @@ import {
   InternalError,
   NotFoundError,
   Result,
+  ValidationError,
   trail,
   topo,
 } from '@ontrails/core';
@@ -66,24 +67,30 @@ describe('buildHttpRoutes', () => {
   describe('method derivation', () => {
     test('intent: read maps to GET', () => {
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
+      expect(result.isOk()).toBe(true);
+      const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.method).toBe('GET');
     });
 
     test('intent: destroy maps to DELETE', () => {
       const app = topo('testapp', { deleteTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
+      expect(result.isOk()).toBe(true);
+      const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.method).toBe('DELETE');
     });
 
     test('default intent (write) maps to POST', () => {
       const app = topo('testapp', { createTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
+      expect(result.isOk()).toBe(true);
+      const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.method).toBe('POST');
     });
@@ -92,61 +99,70 @@ describe('buildHttpRoutes', () => {
   describe('path derivation', () => {
     test('dotted ID becomes slashed path', () => {
       const app = topo('testapp', { createTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
-      expect(routes[0]?.path).toBe('/item/create');
+      expect(result.isOk()).toBe(true);
+      expect(result.value[0]?.path).toBe('/item/create');
     });
 
     test('simple ID becomes /id', () => {
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
-      expect(routes[0]?.path).toBe('/echo');
+      expect(result.isOk()).toBe(true);
+      expect(result.value[0]?.path).toBe('/echo');
     });
 
     test('basePath is prepended', () => {
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app, { basePath: '/api/v1' });
+      const result = buildHttpRoutes(app, { basePath: '/api/v1' });
 
-      expect(routes[0]?.path).toBe('/api/v1/echo');
+      expect(result.isOk()).toBe(true);
+      expect(result.value[0]?.path).toBe('/api/v1/echo');
     });
 
     test('basePath trailing slash is normalized', () => {
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app, { basePath: '/api/v1/' });
+      const result = buildHttpRoutes(app, { basePath: '/api/v1/' });
 
-      expect(routes[0]?.path).toBe('/api/v1/echo');
+      expect(result.isOk()).toBe(true);
+      expect(result.value[0]?.path).toBe('/api/v1/echo');
     });
   });
 
   describe('input source derivation', () => {
     test('GET routes use query input source', () => {
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
-      expect(routes[0]?.inputSource).toBe('query');
+      expect(result.isOk()).toBe(true);
+      expect(result.value[0]?.inputSource).toBe('query');
     });
 
     test('POST routes use body input source', () => {
       const app = topo('testapp', { createTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
-      expect(routes[0]?.inputSource).toBe('body');
+      expect(result.isOk()).toBe(true);
+      expect(result.value[0]?.inputSource).toBe('body');
     });
 
     test('DELETE routes use body input source', () => {
       const app = topo('testapp', { deleteTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
-      expect(routes[0]?.inputSource).toBe('body');
+      expect(result.isOk()).toBe(true);
+      expect(result.value[0]?.inputSource).toBe('body');
     });
   });
 
   describe('filtering', () => {
     test('internal trails are skipped', () => {
       const app = topo('testapp', { echoTrail, internalMetaTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
+      expect(result.isOk()).toBe(true);
+      const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.trailId).toBe('echo');
     });
@@ -155,24 +171,28 @@ describe('buildHttpRoutes', () => {
   describe('route definition shape', () => {
     test('includes trail reference', () => {
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
-      expect(routes[0]?.trail).toBe(echoTrail);
+      expect(result.isOk()).toBe(true);
+      expect(result.value[0]?.trail).toBe(echoTrail);
     });
 
     test('execute is a function', () => {
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app);
+      const result = buildHttpRoutes(app);
 
-      expect(typeof routes[0]?.execute).toBe('function');
+      expect(result.isOk()).toBe(true);
+      expect(typeof result.value[0]?.execute).toBe('function');
     });
   });
 
   describe('execute', () => {
     test('returns ok Result on valid input', async () => {
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app);
-      const [route] = routes;
+      const buildResult = buildHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
 
       const result = await route?.execute({ message: 'hello' });
       expect(result?.isOk()).toBe(true);
@@ -181,8 +201,10 @@ describe('buildHttpRoutes', () => {
 
     test('returns err Result on invalid input', async () => {
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app);
-      const [route] = routes;
+      const buildResult = buildHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
 
       const result = await route?.execute({});
       expect(result?.isErr()).toBe(true);
@@ -190,8 +212,10 @@ describe('buildHttpRoutes', () => {
 
     test('returns err Result from trail error', async () => {
       const app = topo('testapp', { notFoundTrail });
-      const routes = buildHttpRoutes(app);
-      const [route] = routes;
+      const buildResult = buildHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
 
       const result = await route?.execute({ id: 'missing' });
       expect(result?.isErr()).toBe(true);
@@ -200,8 +224,10 @@ describe('buildHttpRoutes', () => {
 
     test('returns err Result from internal error', async () => {
       const app = topo('testapp', { internalTrail });
-      const routes = buildHttpRoutes(app);
-      const [route] = routes;
+      const buildResult = buildHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
 
       const result = await route?.execute({});
       expect(result?.isErr()).toBe(true);
@@ -216,8 +242,10 @@ describe('buildHttpRoutes', () => {
         },
       });
       const app = topo('testapp', { throwingTrail });
-      const routes = buildHttpRoutes(app);
-      const [route] = routes;
+      const buildResult = buildHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
 
       const result = await route?.execute({});
       expect(result?.isErr()).toBe(true);
@@ -227,12 +255,14 @@ describe('buildHttpRoutes', () => {
 
     test('returns err Result when createContext throws', async () => {
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app, {
+      const buildResult = buildHttpRoutes(app, {
         createContext: () => {
           throw new Error('context creation failed');
         },
       });
-      const [route] = routes;
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
 
       const result = await route?.execute({ message: 'hi' });
       expect(result?.isErr()).toBe(true);
@@ -253,8 +283,10 @@ describe('buildHttpRoutes', () => {
       });
 
       const app = topo('testapp', { ctxTrail });
-      const routes = buildHttpRoutes(app);
-      const [route] = routes;
+      const buildResult = buildHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
 
       await route?.execute({}, 'custom-req-123');
       expect(capturedRequestId).toBe('custom-req-123');
@@ -273,8 +305,10 @@ describe('buildHttpRoutes', () => {
       });
 
       const app = topo('testapp', { ctxTrail });
-      const routes = buildHttpRoutes(app);
-      const [route] = routes;
+      const buildResult = buildHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
 
       await route?.execute({});
       expect(capturedRequestId).toBeDefined();
@@ -299,8 +333,10 @@ describe('buildHttpRoutes', () => {
       };
 
       const app = topo('testapp', { echoTrail });
-      const routes = buildHttpRoutes(app, { layers: [testLayer] });
-      const [route] = routes;
+      const buildResult = buildHttpRoutes(app, { layers: [testLayer] });
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
 
       const result = await route?.execute({ message: 'hi' });
       expect(result?.isOk()).toBe(true);
@@ -323,18 +359,88 @@ describe('buildHttpRoutes', () => {
       });
 
       const app = topo('testapp', { ctxTrail });
-      const routes = buildHttpRoutes(app, {
+      const buildResult = buildHttpRoutes(app, {
         createContext: () => ({
           custom: true,
           requestId: 'test-id',
           signal: new AbortController().signal,
         }),
       });
-      const [route] = routes;
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
 
       const result = await route?.execute({});
       expect(result?.isOk()).toBe(true);
       expect(contextUsed).toBe(true);
+    });
+  });
+
+  describe('collision detection', () => {
+    test('returns err on duplicate (path, method) pair', () => {
+      // "entity.show" derives path /entity/show (dots become slashes)
+      // "entity/show" derives path /entity/show (slashes are preserved)
+      // Both have intent: read -> GET, so they collide on GET /entity/show
+      const dotTrail = trail('entity.show', {
+        description: 'Show entity (dot notation)',
+        input: z.object({}),
+        intent: 'read',
+        run: () => Result.ok({ dot: true }),
+      });
+      const slashTrail = trail('entity/show', {
+        description: 'Show entity (slash notation)',
+        input: z.object({}),
+        intent: 'read',
+        run: () => Result.ok({ slash: true }),
+      });
+      const app = topo('testapp', { dotTrail, slashTrail });
+      const result = buildHttpRoutes(app);
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error?.message).toContain('GET /entity/show');
+    });
+
+    test('same path with different methods is allowed', () => {
+      // "item.resource" derives GET /item/resource (intent: read)
+      // "item/resource" derives POST /item/resource (default intent: write)
+      // Same path, different methods — no collision
+      const getItem = trail('item.resource', {
+        description: 'Get item',
+        input: z.object({}),
+        intent: 'read',
+        run: () => Result.ok({ get: true }),
+      });
+      const createItem = trail('item/resource', {
+        description: 'Create item',
+        input: z.object({ name: z.string() }),
+        run: () => Result.ok({ created: true }),
+      });
+      const app = topo('testapp', { createItem, getItem });
+      const result = buildHttpRoutes(app);
+
+      expect(result.isOk()).toBe(true);
+      expect(result.value).toHaveLength(2);
+    });
+
+    test('collision error message identifies both trail IDs', () => {
+      const dotTrail = trail('entity.show', {
+        description: 'Trail one',
+        input: z.object({}),
+        intent: 'read',
+        run: () => Result.ok({ one: true }),
+      });
+      const slashTrail = trail('entity/show', {
+        description: 'Trail two',
+        input: z.object({}),
+        intent: 'read',
+        run: () => Result.ok({ two: true }),
+      });
+      const app = topo('testapp', { dotTrail, slashTrail });
+      const result = buildHttpRoutes(app);
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error?.message).toContain('entity');
     });
   });
 });

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -9,6 +9,7 @@
 import {
   InternalError,
   Result,
+  ValidationError,
   composeLayers,
   createTrailContext,
   validateInput,
@@ -160,6 +161,55 @@ const buildRoute = (
 };
 
 // ---------------------------------------------------------------------------
+// Collision detection
+// ---------------------------------------------------------------------------
+
+/** Derive the lookup key for (method, path) collision detection. */
+const routeKey = (route: HttpRouteDefinition): `${string} ${string}` =>
+  `${route.method} ${route.path}`;
+
+/** Register a route, checking for (path, method) collisions. */
+const registerRoute = (
+  route: HttpRouteDefinition,
+  seenRoutes: Map<string, string>,
+  routes: HttpRouteDefinition[]
+): Result<void, Error> => {
+  const key = routeKey(route);
+  const existingId = seenRoutes.get(key);
+  if (existingId !== undefined) {
+    return Result.err(
+      new ValidationError(
+        `HTTP route collision: trails "${existingId}" and "${route.trailId}" both derive ${route.method} ${route.path}`
+      )
+    );
+  }
+  seenRoutes.set(key, route.trailId);
+  routes.push(route);
+  return Result.ok();
+};
+
+/** Accumulate route definitions, returning early on the first collision. */
+const accumulateRoutes = (
+  trails: Trail<unknown, unknown>[],
+  basePath: string,
+  layers: readonly Layer[],
+  options: BuildHttpRoutesOptions
+): Result<HttpRouteDefinition[], Error> => {
+  const routes: HttpRouteDefinition[] = [];
+  const seenRoutes = new Map<string, string>();
+
+  for (const trail of trails) {
+    const route = buildRoute(trail, basePath, layers, options);
+    const registered = registerRoute(route, seenRoutes, routes);
+    if (registered.isErr()) {
+      return registered;
+    }
+  }
+
+  return Result.ok(routes);
+};
+
+// ---------------------------------------------------------------------------
 // Builder
 // ---------------------------------------------------------------------------
 
@@ -171,15 +221,15 @@ const buildRoute = (
  * - A path derived from the trail ID (dots become slashes)
  * - An input source derived from the method (GET -> query, others -> body)
  * - An `execute` function that validates, layers, and runs the implementation
+ *
+ * Returns `Result.err(ValidationError)` if two trails derive the same
+ * (method, path) pair. Returns `Result.ok(routes)` on success.
  */
 export const buildHttpRoutes = (
   app: Topo,
   options: BuildHttpRoutesOptions = {}
-): HttpRouteDefinition[] => {
+): Result<HttpRouteDefinition[], Error> => {
   const basePath = (options.basePath ?? '').replace(/\/+$/, '');
   const layers = options.layers ?? [];
-
-  return eligibleTrails(app).map((trail) =>
-    buildRoute(trail, basePath, layers, options)
-  );
+  return accumulateRoutes(eligibleTrails(app), basePath, layers, options);
 };

--- a/packages/http/src/hono/blaze.ts
+++ b/packages/http/src/hono/blaze.ts
@@ -224,12 +224,17 @@ export const blaze = async (
 
   registerErrorHandler(hono);
 
-  const routes = buildHttpRoutes(app, {
+  const routesResult = buildHttpRoutes(app, {
     basePath: options.basePath,
     createContext: options.createContext,
     layers: options.layers,
   });
-  registerRoutes(hono, routes);
+
+  if (routesResult.isErr()) {
+    throw routesResult.error;
+  }
+
+  registerRoutes(hono, routesResult.value);
 
   if (options.serve !== false) {
     Bun.serve({

--- a/packages/mcp/src/__tests__/blaze.test.ts
+++ b/packages/mcp/src/__tests__/blaze.test.ts
@@ -5,18 +5,32 @@ import { z } from 'zod';
 
 import { createMcpServer } from '../blaze.js';
 import { buildMcpTools } from '../build.js';
+import type { McpToolDefinition } from '../build.js';
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-const requireTool = (tools: ReturnType<typeof buildMcpTools>, name: string) => {
+const requireTool = (tools: McpToolDefinition[], name: string) => {
   const tool = tools.find((entry) => entry.name === name);
   expect(tool).toBeDefined();
   if (!tool) {
     throw new Error(`Expected tool: ${name}`);
   }
   return tool;
+};
+
+/**
+ * Unwrap buildMcpTools result, throwing on error so test failures surface clearly.
+ */
+const buildTools = (
+  ...args: Parameters<typeof buildMcpTools>
+): McpToolDefinition[] => {
+  const result = buildMcpTools(...args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
 };
 
 const createIntegrationTools = () => {
@@ -34,7 +48,7 @@ const createIntegrationTools = () => {
     run: (_input) => Result.ok({ deleted: true }),
   });
 
-  return buildMcpTools(topo('myapp', { deleteTrail, greetTrail }));
+  return buildTools(topo('myapp', { deleteTrail, greetTrail }));
 };
 
 describe('blaze', () => {
@@ -47,7 +61,7 @@ describe('blaze', () => {
     });
 
     const app = topo('testapp', { echoTrail });
-    const tools = buildMcpTools(app);
+    const tools = buildTools(app);
     const server = createMcpServer(tools, {
       name: 'testapp',
       version: '0.1.0',
@@ -72,7 +86,7 @@ describe('blaze', () => {
     });
 
     const app = topo('testapp', { echoTrail, searchTrail });
-    const tools = buildMcpTools(app);
+    const tools = buildTools(app);
 
     expect(tools).toHaveLength(2);
 

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -5,7 +5,7 @@ import type { Layer } from '@ontrails/core';
 import { z } from 'zod';
 
 import { buildMcpTools } from '../build.js';
-import type { McpExtra } from '../build.js';
+import type { McpExtra, McpToolDefinition } from '../build.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -47,7 +47,7 @@ const exampleTrail = trail('with.examples', {
 
 const noExtra: McpExtra = {};
 
-const requireTool = (tools: ReturnType<typeof buildMcpTools>, name: string) => {
+const requireTool = (tools: McpToolDefinition[], name: string) => {
   const tool = tools.find((entry) => entry.name === name);
   expect(tool).toBeDefined();
   if (!tool) {
@@ -56,7 +56,7 @@ const requireTool = (tools: ReturnType<typeof buildMcpTools>, name: string) => {
   return tool;
 };
 
-const requireOnlyTool = (tools: ReturnType<typeof buildMcpTools>) => {
+const requireOnlyTool = (tools: McpToolDefinition[]) => {
   expect(tools).toHaveLength(1);
   const [tool] = tools;
   expect(tool).toBeDefined();
@@ -64,6 +64,20 @@ const requireOnlyTool = (tools: ReturnType<typeof buildMcpTools>) => {
     throw new Error('Expected one MCP tool');
   }
   return tool;
+};
+
+/**
+ * Unwrap buildMcpTools result for success-path tests.
+ * Throws if the result is an error so test failures surface clearly.
+ */
+const buildTools = (
+  ...args: Parameters<typeof buildMcpTools>
+): McpToolDefinition[] => {
+  const result = buildMcpTools(...args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
 };
 
 const parseJsonContent = (
@@ -81,7 +95,7 @@ describe('buildMcpTools', () => {
   describe('discovery', () => {
     test('builds tools from a single-trail app', () => {
       const app = topo('myapp', { echoTrail });
-      const tools = buildMcpTools(app);
+      const tools = buildTools(app);
 
       expect(tools).toHaveLength(1);
       expect(requireOnlyTool(tools).name).toBe('myapp_echo');
@@ -89,7 +103,7 @@ describe('buildMcpTools', () => {
 
     test('builds tools from a multi-trail app', () => {
       const app = topo('myapp', { deleteTrail, echoTrail, failTrail });
-      const tools = buildMcpTools(app);
+      const tools = buildTools(app);
 
       expect(tools).toHaveLength(3);
       const names = tools.map((t) => t.name);
@@ -100,14 +114,14 @@ describe('buildMcpTools', () => {
 
     test('tool names follow derivation rules', () => {
       const app = topo('myapp', { deleteTrail });
-      const tools = buildMcpTools(app);
+      const tools = buildTools(app);
 
       expect(requireOnlyTool(tools).name).toBe('myapp_item_delete');
     });
 
     test('input schema is valid JSON Schema', () => {
       const app = topo('myapp', { echoTrail });
-      const schema = requireOnlyTool(buildMcpTools(app)).inputSchema;
+      const schema = requireOnlyTool(buildTools(app)).inputSchema;
 
       expect(schema['type']).toBe('object');
       expect(schema['properties']).toBeDefined();
@@ -117,7 +131,7 @@ describe('buildMcpTools', () => {
 
     test('annotations are correctly derived', () => {
       const app = topo('myapp', { deleteTrail, echoTrail });
-      const tools = buildMcpTools(app);
+      const tools = buildTools(app);
 
       expect(requireTool(tools, 'myapp_echo').annotations?.readOnlyHint).toBe(
         true
@@ -134,7 +148,7 @@ describe('buildMcpTools', () => {
   describe('handler execution', () => {
     test('handler validates input and returns isError on invalid', async () => {
       const app = topo('myapp', { echoTrail });
-      const tool = requireOnlyTool(buildMcpTools(app));
+      const tool = requireOnlyTool(buildTools(app));
 
       const result = await tool.handler({ notMessage: 123 }, noExtra);
       expect(result?.isError).toBe(true);
@@ -144,7 +158,7 @@ describe('buildMcpTools', () => {
 
     test('handler calls implementation and returns result as text content', async () => {
       const app = topo('myapp', { echoTrail });
-      const tool = requireOnlyTool(buildMcpTools(app));
+      const tool = requireOnlyTool(buildTools(app));
 
       const result = await tool.handler({ message: 'hello' }, noExtra);
       expect(result?.isError).toBeUndefined();
@@ -156,7 +170,7 @@ describe('buildMcpTools', () => {
 
     test('handler maps errors to isError content', async () => {
       const app = topo('myapp', { failTrail });
-      const tool = requireOnlyTool(buildMcpTools(app));
+      const tool = requireOnlyTool(buildTools(app));
 
       const result = await tool.handler({ reason: 'broken' }, noExtra);
       expect(result?.isError).toBe(true);
@@ -171,9 +185,7 @@ describe('buildMcpTools', () => {
         },
       });
 
-      const tool = requireOnlyTool(
-        buildMcpTools(topo('myapp', { throwTrail }))
-      );
+      const tool = requireOnlyTool(buildTools(topo('myapp', { throwTrail })));
       const result = await tool.handler({}, noExtra);
 
       expect(result?.isError).toBe(true);
@@ -184,7 +196,7 @@ describe('buildMcpTools', () => {
   describe('filters', () => {
     test('include filter limits which trails become tools', () => {
       const app = topo('myapp', { deleteTrail, echoTrail, failTrail });
-      const tools = buildMcpTools(app, {
+      const tools = buildTools(app, {
         includeTrails: ['echo'],
       });
 
@@ -194,7 +206,7 @@ describe('buildMcpTools', () => {
 
     test('exclude filter removes specific trails', () => {
       const app = topo('myapp', { deleteTrail, echoTrail, failTrail });
-      const tools = buildMcpTools(app, {
+      const tools = buildTools(app, {
         excludeTrails: ['fail'],
       });
 
@@ -205,7 +217,7 @@ describe('buildMcpTools', () => {
 
     test('include takes precedence over exclude', () => {
       const app = topo('myapp', { deleteTrail, echoTrail, failTrail });
-      const tools = buildMcpTools(app, {
+      const tools = buildTools(app, {
         excludeTrails: ['fail'],
         includeTrails: ['echo', 'fail'],
       });
@@ -234,7 +246,7 @@ describe('buildMcpTools', () => {
       };
 
       const app = topo('myapp', { echoTrail });
-      const tool = requireOnlyTool(buildMcpTools(app, { layers: [testLayer] }));
+      const tool = requireOnlyTool(buildTools(app, { layers: [testLayer] }));
 
       await tool.handler({ message: 'hi' }, noExtra);
       expect(calls).toEqual(['before', 'after']);
@@ -252,9 +264,7 @@ describe('buildMcpTools', () => {
       });
 
       const controller = new AbortController();
-      const tool = requireOnlyTool(
-        buildMcpTools(topo('myapp', { signalTrail }))
-      );
+      const tool = requireOnlyTool(buildTools(topo('myapp', { signalTrail })));
 
       await tool.handler({}, { signal: controller.signal });
       expect(capturedSignal).toBe(controller.signal);
@@ -262,7 +272,7 @@ describe('buildMcpTools', () => {
 
     test('description includes first example input when present', () => {
       const app = topo('myapp', { exampleTrail });
-      const tool = requireOnlyTool(buildMcpTools(app));
+      const tool = requireOnlyTool(buildTools(app));
 
       expect(tool.description).toContain('A trail with examples');
       expect(tool.description).toContain('"name":"world"');
@@ -282,7 +292,7 @@ describe('buildMcpTools', () => {
 
       const app = topo('myapp', { ctxTrail });
       const tool = requireOnlyTool(
-        buildMcpTools(app, {
+        buildTools(app, {
           createContext: () => ({
             custom: true,
             requestId: 'test-id',
@@ -311,7 +321,7 @@ describe('buildMcpTools', () => {
           ),
       });
 
-      const tool = requireOnlyTool(buildMcpTools(topo('myapp', { blobTrail })));
+      const tool = requireOnlyTool(buildTools(topo('myapp', { blobTrail })));
       const result = await tool.handler({}, noExtra);
 
       expect(result?.content[0]?.type).toBe('image');
@@ -333,7 +343,7 @@ describe('buildMcpTools', () => {
           ),
       });
 
-      const tool = requireOnlyTool(buildMcpTools(topo('myapp', { blobTrail })));
+      const tool = requireOnlyTool(buildTools(topo('myapp', { blobTrail })));
       const result = await tool.handler({}, noExtra);
 
       expect(result?.content[0]?.type).toBe('resource');
@@ -362,7 +372,7 @@ describe('buildMcpTools', () => {
           ),
       });
 
-      const tool = requireOnlyTool(buildMcpTools(topo('myapp', { blobTrail })));
+      const tool = requireOnlyTool(buildTools(topo('myapp', { blobTrail })));
       const result = await tool.handler({}, noExtra);
 
       expect(result?.content[0]?.type).toBe('image');
@@ -372,7 +382,7 @@ describe('buildMcpTools', () => {
   });
 
   describe('tool-name collision detection', () => {
-    test('throws on trails that produce the same derived tool name', () => {
+    test('returns Err on trails that produce the same derived tool name', () => {
       const dotTrail = trail('foo.bar', {
         input: z.object({}),
         run: () => Result.ok({ ok: true }),
@@ -383,10 +393,12 @@ describe('buildMcpTools', () => {
       });
 
       const app = topo('myapp', { dotTrail, underscoreTrail });
-      expect(() => buildMcpTools(app)).toThrow(/tool-name collision/i);
+      const result = buildMcpTools(app);
+      expect(result.isErr()).toBe(true);
+      expect(result.error?.message).toMatch(/tool-name collision/i);
     });
 
-    test('throws on trails where hyphen and underscore collide', () => {
+    test('returns Err on trails where hyphen and underscore collide', () => {
       const hyphenTrail = trail('foo-bar', {
         input: z.object({}),
         run: () => Result.ok({ ok: true }),
@@ -397,10 +409,12 @@ describe('buildMcpTools', () => {
       });
 
       const app = topo('myapp', { hyphenTrail, underscoreTrail });
-      expect(() => buildMcpTools(app)).toThrow(/tool-name collision/i);
+      const result = buildMcpTools(app);
+      expect(result.isErr()).toBe(true);
+      expect(result.error?.message).toMatch(/tool-name collision/i);
     });
 
-    test('does not throw when trail names are distinct after normalization', () => {
+    test('returns Ok when trail names are distinct after normalization', () => {
       const fooTrail = trail('foo', {
         input: z.object({}),
         run: () => Result.ok({ ok: true }),
@@ -411,7 +425,8 @@ describe('buildMcpTools', () => {
       });
 
       const app = topo('myapp', { barTrail, fooTrail });
-      expect(() => buildMcpTools(app)).not.toThrow();
+      const result = buildMcpTools(app);
+      expect(result.isOk()).toBe(true);
     });
   });
 
@@ -426,9 +441,7 @@ describe('buildMcpTools', () => {
         run: (input) => Result.ok({ greeting: `Hello, ${input.name}!` }),
       });
 
-      const tool = requireOnlyTool(
-        buildMcpTools(topo('testapp', { greetTrail }))
-      );
+      const tool = requireOnlyTool(buildTools(topo('testapp', { greetTrail })));
 
       expect(tool).toMatchObject({
         annotations: {

--- a/packages/mcp/src/blaze.ts
+++ b/packages/mcp/src/blaze.ts
@@ -130,14 +130,18 @@ export const blaze = async (
   app: Topo,
   options: BlazeMcpOptions = {}
 ): Promise<void> => {
-  const tools = buildMcpTools(app, {
+  const toolsResult = buildMcpTools(app, {
     createContext: options.createContext,
     excludeTrails: options.excludeTrails,
     includeTrails: options.includeTrails,
     layers: options.layers,
   });
 
-  const server = createMcpServer(tools, {
+  if (toolsResult.isErr()) {
+    throw toolsResult.error;
+  }
+
+  const server = createMcpServer(toolsResult.value, {
     name: options.serverInfo?.name ?? app.name,
     version: options.serverInfo?.version ?? '0.1.0',
   });

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -7,6 +7,8 @@
  */
 
 import {
+  Result,
+  ValidationError,
   composeLayers,
   createTrailContext,
   isBlobRef,
@@ -332,16 +334,19 @@ const registerTool = (
   options: BuildMcpToolsOptions,
   nameToTrailId: Map<string, string>,
   tools: McpToolDefinition[]
-): void => {
+): Result<void, Error> => {
   const toolName = deriveToolName(app.name, trailItem.id);
   const existingId = nameToTrailId.get(toolName);
   if (existingId !== undefined) {
-    throw new Error(
-      `MCP tool-name collision: trails "${existingId}" and "${trailItem.id}" both derive the tool name "${toolName}"`
+    return Result.err(
+      new ValidationError(
+        `MCP tool-name collision: trails "${existingId}" and "${trailItem.id}" both derive the tool name "${toolName}"`
+      )
     );
   }
   nameToTrailId.set(toolName, trailItem.id);
   tools.push(buildToolDefinition(app, trailItem, layers, options));
+  return Result.ok();
 };
 
 /** Filter topo items to eligible trails. */
@@ -360,14 +365,24 @@ const eligibleTrails = (
 export const buildMcpTools = (
   app: Topo,
   options: BuildMcpToolsOptions = {}
-): McpToolDefinition[] => {
+): Result<McpToolDefinition[], Error> => {
   const layers = options.layers ?? [];
   const tools: McpToolDefinition[] = [];
   const nameToTrailId = new Map<string, string>();
 
   for (const trailItem of eligibleTrails(app, options)) {
-    registerTool(app, trailItem, layers, options, nameToTrailId, tools);
+    const registered = registerTool(
+      app,
+      trailItem,
+      layers,
+      options,
+      nameToTrailId,
+      tools
+    );
+    if (registered.isErr()) {
+      return registered;
+    }
   }
 
-  return tools;
+  return Result.ok(tools);
 };

--- a/packages/testing/src/harness-mcp.ts
+++ b/packages/testing/src/harness-mcp.ts
@@ -31,9 +31,12 @@ import type {
  * ```
  */
 export const createMcpHarness = (options: McpHarnessOptions): McpHarness => {
-  const tools = buildMcpTools(options.app);
+  const toolsResult = buildMcpTools(options.app);
+  if (toolsResult.isErr()) {
+    throw toolsResult.error;
+  }
   const toolMap = new Map<string, McpToolDefinition>();
-  for (const tool of tools) {
+  for (const tool of toolsResult.value) {
     toolMap.set(tool.name, tool);
   }
 


### PR DESCRIPTION
## Summary

- Adds (path, method) collision detection to `buildHttpRoutes()` and changes return type to `Result<HttpRouteDefinition[], Error>`
- Mirrors the MCP collision detection pattern from the previous PR
- Prevents silent route overwrites — two trails deriving the same `GET /entity/show` now return a clear error

## Changes

- `packages/http/src/build.ts` — new `routeKey`, `registerRoute`, `accumulateRoutes` helpers; `buildHttpRoutes` returns `Result`
- `packages/http/src/hono/blaze.ts` — unwraps Result at surface boundary
- `packages/http/src/__tests__/build.test.ts` — 3 collision tests; all existing tests updated to unwrap Result

## Test plan

- [ ] Duplicate (path, method) returns `Result.err(ValidationError)` with both trail IDs
- [ ] Same path with different methods is allowed
- [ ] Existing HTTP tests pass unchanged