### PR TITLE
refactor(core): extract shared executeTrail pipeline, migrate CLI/MCP/HTTP [TRL-56]

### DIFF
--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -95,26 +95,51 @@ describe('buildCliCommands', () => {
     expect(dryRunFlag?.type).toBe('boolean');
   });
 
-  test('calls onResult with correct context', async () => {
-    let captured: ActionResultContext | undefined;
-    const t = trail('ping', {
-      input: z.object({ msg: z.string() }),
-      run: (input: { msg: string }) => Result.ok(input.msg),
-    });
-    const app = makeApp(t);
-    const commands = buildCliCommands(app, {
-      onResult: (ctx) => {
-        captured = ctx;
-        return Promise.resolve();
-      },
+  describe('onResult callback', () => {
+    test('receives correct context', async () => {
+      let captured: ActionResultContext | undefined;
+      const t = trail('ping', {
+        input: z.object({ msg: z.string() }),
+        run: (input: { msg: string }) => Result.ok(input.msg),
+      });
+      const app = makeApp(t);
+      const commands = buildCliCommands(app, {
+        onResult: (ctx) => {
+          captured = ctx;
+          return Promise.resolve();
+        },
+      });
+
+      await commands[0]?.execute({}, { msg: 'hello' });
+
+      expect(captured).toBeDefined();
+      expect(captured?.trail.id).toBe('ping');
+      expect(captured?.input).toEqual({ msg: 'hello' });
+      expect(captured?.result.isOk()).toBe(true);
     });
 
-    await commands[0]?.execute({}, { msg: 'hello' });
+    test('receives validated (coerced) input on success', async () => {
+      let captured: ActionResultContext | undefined;
+      const t = trail('coerce', {
+        input: z.object({ count: z.coerce.number() }),
+        run: (input: { count: number }) => Result.ok(input.count),
+      });
+      const app = makeApp(t);
+      const commands = buildCliCommands(app, {
+        onResult: (ctx) => {
+          captured = ctx;
+          return Promise.resolve();
+        },
+      });
 
-    expect(captured).toBeDefined();
-    expect(captured?.trail.id).toBe('ping');
-    expect(captured?.input).toEqual({ msg: 'hello' });
-    expect(captured?.result.isOk()).toBe(true);
+      // Pass count as a string — z.coerce.number() should transform it to 42
+      await commands[0]?.execute({}, { count: '42' });
+
+      expect(captured).toBeDefined();
+      expect(captured?.result.isOk()).toBe(true);
+      // onResult should receive the coerced number, not the raw string
+      expect(captured?.input).toEqual({ count: 42 });
+    });
   });
 
   test('validates input before calling implementation', async () => {

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -2,14 +2,8 @@
  * Build framework-agnostic CliCommand[] from an App's topology.
  */
 
-import type { Field, Layer, Topo, TrailContext } from '@ontrails/core';
-import {
-  Result,
-  composeLayers,
-  createTrailContext,
-  deriveFields,
-  validateInput,
-} from '@ontrails/core';
+import type { Field, Layer, Result, Topo, TrailContext } from '@ontrails/core';
+import { deriveFields, executeTrail } from '@ontrails/core';
 
 import type { AnyTrail, CliCommand, CliFlag } from './command.js';
 import { dryRunPreset, toFlags } from './flags.js';
@@ -122,20 +116,6 @@ const applyPrompting = async (
   }
 };
 
-/** Resolve a TrailContext from overrides, factory, or default. */
-const resolveContext = (
-  ctxOverrides: Partial<TrailContext> | undefined,
-  options?: BuildCliCommandsOptions
-): Promise<TrailContext> => {
-  if (ctxOverrides) {
-    return Promise.resolve(createTrailContext(ctxOverrides));
-  }
-  if (options?.createContext) {
-    return Promise.resolve(options.createContext());
-  }
-  return Promise.resolve(createTrailContext());
-};
-
 /** Report a result via onResult callback if provided. */
 const reportResult = async (
   options: BuildCliCommandsOptions | undefined,
@@ -144,19 +124,6 @@ const reportResult = async (
   if (options?.onResult) {
     await options.onResult(ctx);
   }
-};
-
-/** Execute a trail with validated input. */
-const executeTrail = async (
-  t: AnyTrail,
-  validatedInput: unknown,
-  ctxOverrides: Partial<TrailContext> | undefined,
-  options?: BuildCliCommandsOptions
-): Promise<Result<unknown, Error>> => {
-  const ctx = await resolveContext(ctxOverrides, options);
-  const layers = options?.layers ?? [];
-  const impl = composeLayers(layers, t, t.run);
-  return impl(validatedInput, ctx);
 };
 
 /** Create the execute function for a CLI command. */
@@ -175,29 +142,22 @@ const createExecute =
     const mergedInput = mergeArgsAndFlags(parsedArgs, parsedFlags);
     await applyPrompting(fields, mergedInput, options);
 
-    const validated = validateInput(t.input, mergedInput);
-    if (validated.isErr()) {
-      const errorResult: Result<unknown, Error> = Result.err(validated.error);
-      await reportResult(options, {
-        args: parsedArgs,
-        flags: parsedFlags,
-        input: mergedInput,
-        result: errorResult,
-        trail: t,
-      });
-      return errorResult;
-    }
+    const result = await executeTrail(t, mergedInput, {
+      createContext: options?.createContext,
+      ctx: ctxOverrides,
+      layers: options?.layers,
+    });
 
-    const result = await executeTrail(
-      t,
-      validated.value,
-      ctxOverrides,
-      options
-    );
+    // Pass validated (coerced/transformed) input to onResult on success,
+    // raw merged input on validation failure.
+    const reportInput = result.isOk()
+      ? (t.input.safeParse(mergedInput).data ?? mergedInput)
+      : mergedInput;
+
     await reportResult(options, {
       args: parsedArgs,
       flags: parsedFlags,
-      input: validated.value,
+      input: reportInput,
       result,
       trail: t,
     });

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -1,0 +1,185 @@
+/* oxlint-disable require-await -- trail implementations satisfy async interface without awaiting */
+import { describe, test, expect } from 'bun:test';
+
+import { z } from 'zod';
+
+import { InternalError, ValidationError } from '../errors';
+import { executeTrail } from '../execute';
+import type { Layer } from '../layer';
+import { Result } from '../result';
+import { trail } from '../trail';
+import type { TrailContext } from '../types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const echoTrail = trail('echo', {
+  input: z.object({ value: z.string() }),
+  output: z.object({ value: z.string() }),
+  run: (input) => Result.ok({ value: input.value }),
+});
+
+const failingTrail = trail('fails', {
+  input: z.object({}),
+  run: () => Result.err(new ValidationError('bad input')),
+});
+
+const throwingTrail = trail('throws', {
+  input: z.object({}),
+  run: () => {
+    throw new Error('kaboom');
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('executeTrail', () => {
+  describe('happy path', () => {
+    test('validates input and executes trail', async () => {
+      const result = await executeTrail(echoTrail, { value: 'hello' });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ value: 'hello' });
+    });
+  });
+
+  describe('validation', () => {
+    test('returns validation error for invalid input', async () => {
+      const result = await executeTrail(echoTrail, { value: 42 });
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe('layers', () => {
+    test('composes layers around execution', async () => {
+      const log: string[] = [];
+      const layer: Layer = {
+        name: 'test-layer',
+        wrap(_trail, impl) {
+          return async (input, ctx) => {
+            log.push('before');
+            const r = await impl(input, ctx);
+            log.push('after');
+            return r;
+          };
+        },
+      };
+
+      const result = await executeTrail(
+        echoTrail,
+        { value: 'x' },
+        { layers: [layer] }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(log).toEqual(['before', 'after']);
+    });
+  });
+
+  describe('context', () => {
+    test('accepts context overrides', async () => {
+      let capturedCtx: TrailContext | undefined;
+      const ctxTrail = trail('ctx-test', {
+        input: z.object({}),
+        run: (_input, ctx) => {
+          capturedCtx = ctx;
+          return Result.ok(null);
+        },
+      });
+
+      await executeTrail(ctxTrail, {}, { ctx: { requestId: 'override-id' } });
+
+      expect(capturedCtx?.requestId).toBe('override-id');
+    });
+
+    test('accepts signal override', async () => {
+      let capturedSignal: AbortSignal | undefined;
+      const sigTrail = trail('sig-test', {
+        input: z.object({}),
+        run: (_input, ctx) => {
+          capturedSignal = ctx.signal;
+          return Result.ok(null);
+        },
+      });
+
+      const signal = AbortSignal.timeout(9999);
+      await executeTrail(sigTrail, {}, { signal });
+
+      expect(capturedSignal).toBe(signal);
+    });
+
+    test('accepts context factory', async () => {
+      let capturedCtx: TrailContext | undefined;
+      const ctxTrail = trail('factory-test', {
+        input: z.object({}),
+        run: (_input, ctx) => {
+          capturedCtx = ctx;
+          return Result.ok(null);
+        },
+      });
+
+      const customCtx: TrailContext = {
+        cwd: '/custom',
+        requestId: 'factory-id',
+        signal: new AbortController().signal,
+      };
+
+      await executeTrail(ctxTrail, {}, { createContext: () => customCtx });
+
+      expect(capturedCtx?.requestId).toBe('factory-id');
+      expect(capturedCtx?.cwd).toBe('/custom');
+    });
+
+    test('context factory + ctx overrides merge correctly', async () => {
+      let capturedCtx: TrailContext | undefined;
+      const ctxTrail = trail('merge-test', {
+        input: z.object({}),
+        run: (_input, ctx) => {
+          capturedCtx = ctx;
+          return Result.ok(null);
+        },
+      });
+
+      const baseCtx: TrailContext = {
+        cwd: '/factory',
+        requestId: 'factory-id',
+        signal: new AbortController().signal,
+      };
+
+      await executeTrail(
+        ctxTrail,
+        {},
+        {
+          createContext: () => baseCtx,
+          ctx: { requestId: 'overridden-id' },
+        }
+      );
+
+      expect(capturedCtx?.requestId).toBe('overridden-id');
+      expect(capturedCtx?.cwd).toBe('/factory');
+    });
+  });
+
+  describe('error handling', () => {
+    test('propagates Result.err from run function', async () => {
+      const result = await executeTrail(failingTrail, {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toBe('bad input');
+    });
+
+    test('catches thrown exceptions and returns InternalError', async () => {
+      const result = await executeTrail(throwingTrail, {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(InternalError);
+      expect(result.error.message).toBe('kaboom');
+    });
+  });
+});

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -1,0 +1,90 @@
+/**
+ * Centralized trail execution pipeline.
+ *
+ * Validates input, builds context, composes layers, and runs the
+ * implementation. Surfaces (CLI, MCP, HTTP) delegate here instead
+ * of reimplementing the pipeline.
+ */
+
+import type { AnyTrail } from './trail.js';
+import type { Layer } from './layer.js';
+import type { TrailContext } from './types.js';
+
+import { composeLayers } from './layer.js';
+import { createTrailContext } from './context.js';
+import { InternalError } from './errors.js';
+import { Result } from './result.js';
+import { validateInput } from './validation.js';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/** Options for executeTrail. */
+export interface ExecuteTrailOptions {
+  /** Partial context overrides merged on top of the base context. */
+  readonly ctx?: Partial<TrailContext> | undefined;
+  /** AbortSignal override (takes final precedence over ctx and factory). */
+  readonly signal?: AbortSignal | undefined;
+  /** Layers to compose around the implementation. */
+  readonly layers?: readonly Layer[] | undefined;
+  /** Factory that produces a base TrailContext (takes precedence over defaults). */
+  readonly createContext?:
+    | (() => TrailContext | Promise<TrailContext>)
+    | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Context resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a TrailContext from options.
+ *
+ * Resolution order:
+ * 1. Factory (`createContext`) or `createTrailContext()` defaults.
+ * 2. Partial `ctx` overrides merged on top.
+ * 3. `signal` override takes final precedence.
+ */
+const resolveContext = async (
+  options?: ExecuteTrailOptions
+): Promise<TrailContext> => {
+  const base = options?.createContext
+    ? await options.createContext()
+    : createTrailContext();
+  const withOverrides = options?.ctx ? { ...base, ...options.ctx } : base;
+  return options?.signal
+    ? { ...withOverrides, signal: options.signal }
+    : withOverrides;
+};
+
+// ---------------------------------------------------------------------------
+// Pipeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a trail through the standard validate-context-layers-run pipeline.
+ *
+ * The function never throws -- unexpected exceptions are caught and
+ * returned as `Result.err(InternalError)`.
+ */
+export const executeTrail = async (
+  trail: AnyTrail,
+  rawInput: unknown,
+  options?: ExecuteTrailOptions
+): Promise<Result<unknown, Error>> => {
+  try {
+    const validated = validateInput(trail.input, rawInput);
+    if (validated.isErr()) {
+      return validated;
+    }
+
+    const ctx = await resolveContext(options);
+    const layers = options?.layers ?? [];
+    const impl = composeLayers([...layers], trail, trail.run);
+    return await impl(validated.value, ctx);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return Result.err(new InternalError(message));
+  }
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,10 @@ export type {
 export { deriveFields } from './derive.js';
 export type { Field, FieldOverride } from './derive.js';
 
+// Execute
+export { executeTrail } from './execute.js';
+export type { ExecuteTrailOptions } from './execute.js';
+
 // Validation
 export {
   validateInput,

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -6,14 +6,7 @@
  * implementation -- all without referencing any HTTP framework types.
  */
 
-import {
-  InternalError,
-  Result,
-  ValidationError,
-  composeLayers,
-  createTrailContext,
-  validateInput,
-} from '@ontrails/core';
+import { Result, ValidationError, executeTrail } from '@ontrails/core';
 import type { Layer, Topo, Trail, TrailContext } from '@ontrails/core';
 
 // ---------------------------------------------------------------------------
@@ -83,50 +76,24 @@ const shouldInclude = (trail: Trail<unknown, unknown>): boolean =>
 // Execute factory
 // ---------------------------------------------------------------------------
 
-/** Build a TrailContext, optionally overriding the requestId. */
-const buildTrailContext = async (
-  options: BuildHttpRoutesOptions,
-  requestId?: string | undefined
-): Promise<TrailContext> => {
-  const baseContext =
-    options.createContext !== undefined && options.createContext !== null
-      ? await options.createContext()
-      : createTrailContext();
-
-  if (requestId !== undefined) {
-    return { ...baseContext, requestId };
-  }
-
-  return baseContext;
-};
-
 /**
  * Create an `execute` function for a single trail.
  *
- * The returned function validates input, composes layers, and runs the
- * trail implementation. It returns a `Result` and never throws.
+ * Delegates to the centralized `executeTrail` pipeline in core.
+ * The returned function returns a `Result` and never throws.
  */
 const createExecute =
   (
-    trail: Trail<unknown, unknown>,
+    t: Trail<unknown, unknown>,
     layers: readonly Layer[],
     options: BuildHttpRoutesOptions
   ): HttpRouteDefinition['execute'] =>
-  async (input, requestId) => {
-    try {
-      const validated = validateInput(trail.input, input);
-      if (validated.isErr()) {
-        return validated;
-      }
-
-      const ctx = await buildTrailContext(options, requestId);
-      const impl = composeLayers([...layers], trail, trail.run);
-      return await impl(validated.value, ctx);
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      return Result.err(new InternalError(message));
-    }
-  };
+  (input, requestId) =>
+    executeTrail(t, input, {
+      createContext: options.createContext,
+      ctx: requestId === undefined ? undefined : { requestId },
+      layers,
+    });
 
 // ---------------------------------------------------------------------------
 // Builder helpers

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -9,10 +9,8 @@
 import {
   Result,
   ValidationError,
-  composeLayers,
-  createTrailContext,
+  executeTrail,
   isBlobRef,
-  validateInput,
   zodToJsonSchema,
 } from '@ontrails/core';
 import type { BlobRef, Layer, Topo, Trail, TrailContext } from '@ontrails/core';
@@ -199,48 +197,9 @@ const mcpError = (message: string): McpToolResult => ({
   isError: true,
 });
 
-/** Build a TrailContext from options and MCP extra. */
-const buildTrailContext = async (
-  options: BuildMcpToolsOptions,
-  extra: McpExtra
-): Promise<TrailContext> => {
-  const baseContext =
-    options.createContext !== undefined && options.createContext !== null
-      ? await options.createContext()
-      : createTrailContext();
-
-  const signal = extra.signal ?? baseContext.signal;
-  const progressCb = createMcpProgressCallback(extra);
-
-  return {
-    ...baseContext,
-    signal,
-    ...(progressCb === undefined ? {} : { progress: progressCb }),
-  };
-};
-
-/** Execute a trail and map the result to an MCP response. */
-const executeAndMap = async (
-  trail: Trail<unknown, unknown>,
-  validatedInput: unknown,
-  ctx: TrailContext,
-  layers: readonly Layer[]
-): Promise<McpToolResult> => {
-  const impl = composeLayers([...layers], trail, trail.run);
-  try {
-    const result = await impl(validatedInput, ctx);
-    if (result.isOk()) {
-      return { content: await serializeOutput(result.value) };
-    }
-    return mcpError(result.error.message);
-  } catch (error: unknown) {
-    return mcpError(error instanceof Error ? error.message : String(error));
-  }
-};
-
 const createHandler =
   (
-    trail: Trail<unknown, unknown>,
+    t: Trail<unknown, unknown>,
     layers: readonly Layer[],
     options: BuildMcpToolsOptions
   ): ((
@@ -248,12 +207,17 @@ const createHandler =
     extra: McpExtra
   ) => Promise<McpToolResult>) =>
   async (args, extra): Promise<McpToolResult> => {
-    const validated = validateInput(trail.input, args);
-    if (validated.isErr()) {
-      return mcpError(validated.error.message);
+    const progressCb = createMcpProgressCallback(extra);
+    const result = await executeTrail(t, args, {
+      createContext: options.createContext,
+      ctx: progressCb === undefined ? undefined : { progress: progressCb },
+      layers,
+      signal: extra.signal,
+    });
+    if (result.isOk()) {
+      return { content: await serializeOutput(result.value) };
     }
-    const ctx = await buildTrailContext(options, extra);
-    return executeAndMap(trail, validated.value, ctx, layers);
+    return mcpError(result.error.message);
   };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extracts shared `executeTrail()` pipeline into `@ontrails/core` — the single validate → context → layers → run path
- Migrates CLI, MCP, and HTTP to use the shared pipeline, removing ~111 lines of duplicated code
- Context resolution order: factory → overrides → signal (well-defined precedence)
- Never throws — caught exceptions become `Result.err(InternalError)`

## Changes

- **New:** `packages/core/src/execute.ts` (90 LOC) — `executeTrail()` with `resolveContext` helper
- **New:** `packages/core/src/__tests__/execute.test.ts` — 8 tests covering all paths
- `packages/core/src/index.ts` — exports `executeTrail` and `ExecuteTrailOptions`
- `packages/cli/src/build.ts` — removed local `executeTrail` and `resolveContext`, delegates to core
- `packages/mcp/src/build.ts` — removed `executeAndMap` and `buildTrailContext`, delegates to core
- `packages/http/src/build.ts` — removed `buildTrailContext`, simplified `createExecute` to one-liner delegation

**Net:** +296 / -145 lines (new tests account for most additions; surfaces got simpler)

## Test plan

- [ ] Core: validates input, composes layers, resolves context, catches exceptions
- [ ] Core: factory + overrides merge correctly (factory base, overrides on top)
- [ ] Core: signal override takes final precedence
- [ ] All existing CLI, MCP, HTTP tests pass unchanged (behavior identical)