### PR TITLE
test(cli): verify exception catching via centralized executeTrail [TRL-53]

### DIFF
--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -239,4 +239,20 @@ describe('buildCliCommands', () => {
     await commands[0]?.execute({}, { 'sort-order': 'asc' });
     expect(receivedInput).toEqual({ sortOrder: 'asc' });
   });
+
+  test('returns InternalError when run function throws', async () => {
+    const throwing = trail('throw.test', {
+      input: z.object({}),
+      output: z.object({}),
+      run: () => {
+        throw new Error('unexpected kaboom');
+      },
+    });
+    const app = makeApp(throwing);
+    const commands = buildCliCommands(app);
+    const cmd = requireCommand(commands);
+    const result = await cmd.execute({}, {});
+    expect(result.isErr()).toBe(true);
+    expect(result.error.message).toContain('unexpected kaboom');
+  });
 });


### PR DESCRIPTION
## Summary

- Adds explicit test verifying CLI catches thrown exceptions via the centralized `executeTrail` pipeline
- Before TRL-56, CLI's `executeTrail` had no try/catch — a thrown exception would crash the process
- Now covered by the shared pipeline's catch block, returning `Result.err(InternalError)`

## Changes

- `packages/cli/src/__tests__/build.test.ts` — 1 new test: trail that throws → `result.isErr()` with error message preserved

## Test plan

- [ ] Trail that throws returns `InternalError` result (not an uncaught exception)
- [ ] No code changes needed — test confirms centralized pipeline works for CLI