### PR TITLE
fix(http): wire request AbortSignal through to trail context [TRL-54]

### DIFF
--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -37,10 +37,15 @@ export interface HttpRouteDefinition {
    *
    * The caller is responsible for parsing raw input from the request and
    * mapping the Result to an HTTP response. This function is framework-agnostic.
+   *
+   * @param signal - Optional AbortSignal from the HTTP request. When provided,
+   *   it takes final precedence over any context factory signal, allowing
+   *   client-initiated cancellation to propagate into trail execution.
    */
   readonly execute: (
     input: unknown,
-    requestId?: string | undefined
+    requestId?: string | undefined,
+    signal?: AbortSignal | undefined
   ) => Promise<Result<unknown, Error>>;
 }
 
@@ -88,11 +93,12 @@ const createExecute =
     layers: readonly Layer[],
     options: BuildHttpRoutesOptions
   ): HttpRouteDefinition['execute'] =>
-  (input, requestId) =>
+  (input, requestId, signal) =>
     executeTrail(t, input, {
       createContext: options.createContext,
       ctx: requestId === undefined ? undefined : { requestId },
       layers,
+      signal,
     });
 
 // ---------------------------------------------------------------------------

--- a/packages/http/src/hono/__tests__/blaze.test.ts
+++ b/packages/http/src/hono/__tests__/blaze.test.ts
@@ -289,6 +289,60 @@ describe('blaze (Hono adapter)', () => {
     });
   });
 
+  describe('AbortSignal', () => {
+    test('passes request AbortSignal to trail context', async () => {
+      let capturedSignal: AbortSignal | undefined;
+
+      const signalTrail = trail('signal.check', {
+        input: z.object({}),
+        intent: 'read',
+        output: z.object({ ok: z.boolean() }),
+        run: (_input, ctx) => {
+          capturedSignal = ctx.signal;
+          return Result.ok({ ok: true });
+        },
+      });
+
+      const app = topo('testapp', { signalTrail });
+      const hono = await blaze(app, { serve: false });
+
+      const res = await request(hono, 'GET', '/signal/check');
+      expect(res.status).toBe(200);
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    });
+
+    test('signal is aborted when request is cancelled', async () => {
+      let capturedSignal: AbortSignal | undefined;
+
+      const signalTrail = trail('signal.aborted', {
+        input: z.object({}),
+        intent: 'read',
+        output: z.object({ ok: z.boolean() }),
+        run: (_input, ctx) => {
+          capturedSignal = ctx.signal;
+          return Result.ok({ ok: true });
+        },
+      });
+
+      const app = topo('testapp', { signalTrail });
+      const hono = await blaze(app, { serve: false });
+
+      const controller = new AbortController();
+      controller.abort();
+
+      // Pass the pre-aborted signal directly in the Request.
+      // Hono's fetch propagates Request.signal into c.req.raw.signal.
+      const res = await hono.fetch(
+        new Request('http://localhost/signal/aborted', {
+          method: 'GET',
+          signal: controller.signal,
+        })
+      );
+      expect(res.status).toBe(200);
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+  });
+
   describe('context', () => {
     test('X-Request-ID header is used for requestId', async () => {
       let capturedRequestId: string | undefined;

--- a/packages/http/src/hono/blaze.ts
+++ b/packages/http/src/hono/blaze.ts
@@ -152,9 +152,10 @@ const createHonoHandler =
     }
 
     const requestId = c.req.header('X-Request-ID') ?? undefined;
+    const { signal } = c.req.raw;
 
     try {
-      const result = await route.execute(rawInput, requestId);
+      const result = await route.execute(rawInput, requestId, signal);
       return mapResultToResponse(result, c);
     } catch (error: unknown) {
       return handleCaughtError(error, c);


### PR DESCRIPTION
## Summary

- Wires the HTTP request's `AbortSignal` through to trail context so cancelled requests stop trail execution
- Previously, the HTTP adapter created a fresh default signal — client disconnects were invisible to trails

## Changes

- `packages/http/src/build.ts` — `HttpRouteDefinition.execute` accepts optional `signal` parameter; threaded to `executeTrail`
- `packages/http/src/hono/blaze.ts` — extracts `c.req.raw.signal` and passes it through
- `packages/http/src/hono/__tests__/blaze.test.ts` — 2 tests: signal is an AbortSignal instance; pre-aborted signal propagates correctly

## Test plan

- [ ] Trail receives an AbortSignal from the request context
- [ ] Pre-aborted request signal propagates as `ctx.signal.aborted === true`
- [ ] Existing HTTP tests pass unchanged