### PR TITLE
feat(core): add dispatch() for headless trail execution [TRL-50]

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -45,6 +45,10 @@ FollowFn, ProgressCallback, ProgressEvent, Logger, Surface
 Layer                              // wrap(trail, implementation) → implementation
 composeLayers(layers, trail, implementation)
 
+// Dispatch — headless surface
+dispatch(topo, id, input, options?) // look up and execute a trail by ID; returns Result, never throws
+DispatchOptions
+
 // Validation
 validateInput(schema, data)        // → Result<T, ValidationError>
 validateOutput(schema, data)       // → Result<T, ValidationError>

--- a/packages/core/src/__tests__/dispatch.test.ts
+++ b/packages/core/src/__tests__/dispatch.test.ts
@@ -1,0 +1,154 @@
+/* oxlint-disable require-await -- trail implementations satisfy async interface without awaiting */
+import { describe, test, expect } from 'bun:test';
+
+import { z } from 'zod';
+
+import { dispatch } from '../dispatch';
+import { InternalError, NotFoundError, ValidationError } from '../errors';
+import type { Layer } from '../layer';
+import { Result } from '../result';
+import { topo } from '../topo';
+import { trail } from '../trail';
+import type { TrailContext } from '../types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const echoTrail = trail('echo', {
+  input: z.object({ value: z.string() }),
+  output: z.object({ value: z.string() }),
+  run: (input) => Result.ok({ value: input.value }),
+});
+
+const throwingTrail = trail('throws', {
+  input: z.object({}),
+  run: () => {
+    throw new Error('kaboom');
+  },
+});
+
+const testTopo = topo('test', { echoTrail, throwingTrail });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('dispatch', () => {
+  describe('happy path', () => {
+    test('dispatches by ID and returns Result.ok with expected value', async () => {
+      const result = await dispatch(testTopo, 'echo', { value: 'hello' });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ value: 'hello' });
+    });
+  });
+
+  describe('not found', () => {
+    test('returns NotFoundError for unknown trail ID', async () => {
+      const result = await dispatch(testTopo, 'nonexistent', {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(NotFoundError);
+      expect(result.error.message).toContain('nonexistent');
+      expect(result.error.message).toContain('test');
+    });
+  });
+
+  describe('validation', () => {
+    test('returns ValidationError for invalid input', async () => {
+      const result = await dispatch(testTopo, 'echo', { value: 42 });
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe('layers', () => {
+    test('layer composition works through dispatch', async () => {
+      const log: string[] = [];
+      const layer: Layer = {
+        name: 'test-layer',
+        wrap(_trail, impl) {
+          return async (input, ctx) => {
+            log.push('before');
+            const r = await impl(input, ctx);
+            log.push('after');
+            return r;
+          };
+        },
+      };
+
+      const result = await dispatch(
+        testTopo,
+        'echo',
+        { value: 'x' },
+        { layers: [layer] }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(log).toEqual(['before', 'after']);
+    });
+  });
+
+  describe('context', () => {
+    test('context overrides work through dispatch', async () => {
+      let capturedCtx: TrailContext | undefined;
+      const ctxTrail = trail('ctx-dispatch-test', {
+        input: z.object({}),
+        run: (_input, ctx) => {
+          capturedCtx = ctx;
+          return Result.ok(null);
+        },
+      });
+
+      const ctxTopo = topo('ctx-test', { ctxTrail });
+      await dispatch(
+        ctxTopo,
+        'ctx-dispatch-test',
+        {},
+        { ctx: { requestId: 'override-id' } }
+      );
+
+      expect(capturedCtx?.requestId).toBe('override-id');
+    });
+
+    test('createContext factory works through dispatch', async () => {
+      let capturedCtx: TrailContext | undefined;
+      const ctxTrail = trail('factory-dispatch-test', {
+        input: z.object({}),
+        run: (_input, ctx) => {
+          capturedCtx = ctx;
+          return Result.ok(null);
+        },
+      });
+
+      const ctxTopo = topo('factory-test', { ctxTrail });
+      const customCtx: TrailContext = {
+        cwd: '/custom',
+        requestId: 'factory-id',
+        signal: new AbortController().signal,
+      };
+
+      await dispatch(
+        ctxTopo,
+        'factory-dispatch-test',
+        {},
+        { createContext: () => customCtx }
+      );
+
+      expect(capturedCtx?.requestId).toBe('factory-id');
+      expect(capturedCtx?.cwd).toBe('/custom');
+    });
+  });
+
+  describe('error handling', () => {
+    test('never throws — exceptions become InternalError', async () => {
+      const result = await dispatch(testTopo, 'throws', {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(InternalError);
+      expect(result.error.message).toBe('kaboom');
+    });
+  });
+});

--- a/packages/core/src/dispatch.ts
+++ b/packages/core/src/dispatch.ts
@@ -1,0 +1,66 @@
+/**
+ * Headless trail execution — the "no-surface" surface.
+ *
+ * Looks up a trail by ID in a topo, then delegates to `executeTrail`.
+ * Returns a `Result` and never throws.
+ */
+
+import type { Topo } from './topo.js';
+import type { TrailContext } from './types.js';
+import type { Layer } from './layer.js';
+import { executeTrail } from './execute.js';
+import { NotFoundError } from './errors.js';
+import { Result } from './result.js';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/** Options forwarded to `executeTrail` from `dispatch`. */
+export interface DispatchOptions {
+  /** Partial context overrides merged on top of the base context. */
+  readonly ctx?: Partial<TrailContext> | undefined;
+  /** AbortSignal override (takes final precedence over ctx and factory). */
+  readonly signal?: AbortSignal | undefined;
+  /** Layers to compose around the implementation. */
+  readonly layers?: readonly Layer[] | undefined;
+  /** Factory that produces a base TrailContext (takes precedence over defaults). */
+  readonly createContext?:
+    | (() => TrailContext | Promise<TrailContext>)
+    | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// dispatch()
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a trail by ID from a topo without mounting a surface.
+ *
+ * Resolves the trail from the topo, then runs it through the standard
+ * `executeTrail` pipeline. Returns `Result.err(NotFoundError)` if the
+ * trail ID is not registered. Never throws — unexpected exceptions are
+ * returned as `Result.err(InternalError)`.
+ *
+ * @example
+ * ```typescript
+ * const result = await dispatch(myTopo, 'greet', { name: 'Alice' });
+ * if (result.isOk()) console.log(result.value);
+ * ```
+ */
+export const dispatch = (
+  topo: Topo,
+  id: string,
+  input: unknown,
+  options?: DispatchOptions
+): Promise<Result<unknown, Error>> => {
+  const trail = topo.get(id);
+  if (trail === undefined) {
+    return Promise.resolve(
+      Result.err(
+        new NotFoundError(`Trail "${id}" not found in topo "${topo.name}"`)
+      )
+    );
+  }
+  return executeTrail(trail, input, options);
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,10 @@ export type { Field, FieldOverride } from './derive.js';
 export { executeTrail } from './execute.js';
 export type { ExecuteTrailOptions } from './execute.js';
 
+// Dispatch
+export { dispatch } from './dispatch.js';
+export type { DispatchOptions } from './dispatch.js';
+
 // Validation
 export {
   validateInput,


### PR DESCRIPTION
## Summary

- Adds `dispatch(topo, id, input, options?)` to `@ontrails/core` — the "no-surface" surface
- Looks up a trail by ID, delegates to `executeTrail`, returns Result
- Never throws — unknown trail IDs return `NotFoundError`, exceptions become `InternalError`
- Closes the loop: CLI, MCP, HTTP, and now programmatic consumers all go through the same validated pipeline

## Changes

- **New:** `packages/core/src/dispatch.ts` (66 LOC) — topo lookup + delegation to `executeTrail`
- **New:** `packages/core/src/__tests__/dispatch.test.ts` — 7 tests
- `packages/core/src/index.ts` — exports `dispatch` and `DispatchOptions`
- `docs/api-reference.md` — documented

## Usage

```typescript
const result = await dispatch(app, 'search', { query: 'test' });
if (result.isOk()) console.log(result.value);
```

## Test plan

- [ ] Happy path: dispatch by ID returns expected value
- [ ] Unknown ID returns `NotFoundError`
- [ ] Invalid input returns validation error
- [ ] Layers compose through dispatch
- [ ] Context overrides propagate
- [ ] Thrown exceptions become `InternalError`