### PR TITLE
fix(http,schema,mcp,testing): error codes, empty body, follow context, trail ref, idempotent demo [TRL-57]

### DIFF
--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -24,6 +24,7 @@ import { z } from 'zod';
 import { app } from '../src/app.js';
 import * as entityEvents from '../src/events/entity-events.js';
 import * as entity from '../src/trails/entity.js';
+import * as kv from '../src/trails/kv.js';
 import * as onboard from '../src/trails/onboard.js';
 import * as search from '../src/trails/search.js';
 
@@ -44,10 +45,11 @@ describe('surface map generation', () => {
     expect(ids).toContain('search');
     expect(ids).toContain('entity.onboard');
     expect(ids).toContain('entity.updated');
+    expect(ids).toContain('demo.upsert');
   });
 
-  test('has exactly 7 entries (6 trails + 1 event)', () => {
-    expect(surfaceMap.entries).toHaveLength(7);
+  test('has exactly 8 entries (7 trails + 1 event)', () => {
+    expect(surfaceMap.entries).toHaveLength(8);
   });
 
   test('entries are sorted alphabetically by id', () => {
@@ -238,7 +240,9 @@ describe('non-breaking change detection', () => {
       run: (input) => Result.ok({ name: input.name, updated: true }),
     });
 
-    const diff = diffAgainst(entity, search, onboard, entityEvents, { update });
+    const diff = diffAgainst(entity, search, onboard, entityEvents, kv, {
+      update,
+    });
     expect(diff.hasBreaking).toBe(false);
 
     const addedEntry = diff.info.find((e) => e.id === 'entity.update');
@@ -257,7 +261,8 @@ describe('non-breaking change detection', () => {
       { ...entity, show: modifiedShow },
       search,
       onboard,
-      entityEvents
+      entityEvents,
+      kv
     );
     expect(diff.hasBreaking).toBe(false);
 
@@ -302,7 +307,7 @@ describe('topo validation', () => {
       const trailDef = t as { examples?: readonly unknown[] };
       exampleCount += trailDef.examples?.length ?? 0;
     }
-    // 5 trails x 2 examples each + 1 onboard trail x 1 example = 11
-    expect(exampleCount).toBe(11);
+    // 5 trails x 2 examples each + 1 onboard trail x 1 example + 1 kv trail x 1 example = 12
+    expect(exampleCount).toBe(12);
   });
 });

--- a/apps/trails-demo/src/app.ts
+++ b/apps/trails-demo/src/app.ts
@@ -6,7 +6,8 @@ import { topo } from '@ontrails/core';
 
 import * as entityEvents from './events/entity-events.js';
 import * as entity from './trails/entity.js';
+import * as kv from './trails/kv.js';
 import * as onboard from './trails/onboard.js';
 import * as search from './trails/search.js';
 
-export const app = topo('demo', entity, search, onboard, entityEvents);
+export const app = topo('demo', entity, search, onboard, entityEvents, kv);

--- a/apps/trails-demo/src/trails/kv.ts
+++ b/apps/trails-demo/src/trails/kv.ts
@@ -1,0 +1,33 @@
+/**
+ * Key-value trail -- demonstrates the `idempotent` flag.
+ *
+ * An idempotent upsert: calling it multiple times with the same input
+ * produces the same result with no side effects.
+ */
+
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// demo.upsert
+// ---------------------------------------------------------------------------
+
+export const upsert = trail('demo.upsert', {
+  description: 'Upsert a key-value pair (idempotent)',
+  examples: [
+    {
+      description:
+        'Store a value under a key; repeating produces the same result',
+      expected: { key: 'theme', value: 'dark' },
+      input: { key: 'theme', value: 'dark' },
+      name: 'Upsert a key-value pair',
+    },
+  ],
+  idempotent: true,
+  input: z.object({
+    key: z.string().describe('Item key'),
+    value: z.string().describe('Item value'),
+  }),
+  output: z.object({ key: z.string(), value: z.string() }),
+  run: (input) => Result.ok({ key: input.key, value: input.value }),
+});

--- a/packages/http/src/hono/__tests__/blaze.test.ts
+++ b/packages/http/src/hono/__tests__/blaze.test.ts
@@ -142,6 +142,26 @@ describe('blaze (Hono adapter)', () => {
       const json = await res.json();
       expect(json.error.category).toBe('validation');
     });
+
+    test('POST with empty input schema succeeds without a body', async () => {
+      const emptyWriteTrail = trail('empty.write', {
+        input: z.object({}),
+        intent: 'write',
+        output: z.object({ ok: z.boolean() }),
+        run: () => Result.ok({ ok: true }),
+      });
+
+      const app = topo('testapp', { emptyWriteTrail });
+      const hono = await blaze(app, { serve: false });
+
+      // No body, no Content-Type header — mirrors a client that obeys the
+      // OpenAPI spec (no requestBody declared for empty-input POST routes).
+      const res = await hono.request('/empty/write', { method: 'POST' });
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json).toEqual({ data: { ok: true } });
+    });
   });
 
   describe('DELETE handler', () => {
@@ -237,7 +257,7 @@ describe('blaze (Hono adapter)', () => {
 
       const json = await res.json();
       expect(json.error.message).toBe('Invalid JSON in request body');
-      expect(json.error.code).toBe('validation');
+      expect(json.error.code).toBe('ValidationError');
       expect(json.error.category).toBe('validation');
     });
 

--- a/packages/http/src/hono/blaze.ts
+++ b/packages/http/src/hono/blaze.ts
@@ -60,6 +60,16 @@ const parseQueryParams = (c: HonoContext): Record<string, unknown> => {
 /** Sentinel indicating a JSON parse failure. */
 const JSON_PARSE_ERROR = Symbol('JSON_PARSE_ERROR');
 
+/** Return true when the request has no body content. */
+const isEmptyBody = (c: HonoContext): boolean => {
+  const contentLength = c.req.header('Content-Length');
+  if (contentLength !== undefined) {
+    return Number.parseInt(contentLength, 10) === 0;
+  }
+  // No Content-Length header — treat as empty when Content-Type is also absent.
+  return c.req.header('Content-Type') === undefined;
+};
+
 /** Read input from request based on input source. */
 const readInput = async (
   c: HonoContext,
@@ -67,6 +77,9 @@ const readInput = async (
 ): Promise<unknown> => {
   if (inputSource === 'query') {
     return parseQueryParams(c);
+  }
+  if (isEmptyBody(c)) {
+    return {};
   }
   try {
     return await c.req.json();
@@ -143,7 +156,7 @@ const createHonoHandler =
         {
           error: {
             category: 'validation',
-            code: 'validation',
+            code: 'ValidationError',
             message: 'Invalid JSON in request body',
           },
         },

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -143,6 +143,16 @@ describe('buildMcpTools', () => {
         requireTool(tools, 'myapp_item_delete').annotations?.destructiveHint
       ).toBe(true);
     });
+
+    test('trailId identifies the source trail', () => {
+      const app = topo('myapp', { deleteTrail, echoTrail });
+      const tools = buildTools(app);
+
+      expect(requireTool(tools, 'myapp_echo').trailId).toBe('echo');
+      expect(requireTool(tools, 'myapp_item_delete').trailId).toBe(
+        'item.delete'
+      );
+    });
   });
 
   describe('handler execution', () => {

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -42,6 +42,8 @@ export interface McpToolDefinition {
   ) => Promise<McpToolResult>;
   readonly inputSchema: Record<string, unknown>;
   readonly name: string;
+  /** The trail ID this tool was derived from. */
+  readonly trailId: string;
 }
 
 export interface McpExtra {
@@ -287,6 +289,7 @@ const buildToolDefinition = (
     handler: createHandler(trail, layers, options),
     inputSchema: zodToJsonSchema(trail.input),
     name: deriveToolName(app.name, trail.id),
+    trailId: trail.id,
   };
 };
 

--- a/packages/schema/src/__tests__/openapi.test.ts
+++ b/packages/schema/src/__tests__/openapi.test.ts
@@ -150,6 +150,20 @@ describe('generateOpenApiSpec', () => {
   });
 
   describe('request body', () => {
+    test('omits requestBody for empty input schema', () => {
+      const t = trail('action.trigger', {
+        input: z.object({}),
+        run: noop,
+      });
+      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const op = spec.paths['/action/trigger']?.['post'] as Record<
+        string,
+        unknown
+      >;
+
+      expect(op['requestBody']).toBeUndefined();
+    });
+
     test('POST input schema becomes requestBody', () => {
       const t = trail('entity.create', {
         input: z.object({ name: z.string() }),

--- a/packages/schema/src/openapi.ts
+++ b/packages/schema/src/openapi.ts
@@ -167,6 +167,13 @@ const buildInputSpec = (
     return params.length > 0 ? { parameters: params } : {};
   }
 
+  const properties = inputSchema['properties'] as
+    | Record<string, unknown>
+    | undefined;
+  if (properties !== undefined && Object.keys(properties).length === 0) {
+    return {};
+  }
+
   return {
     requestBody: {
       content: { 'application/json': { schema: inputSchema } },

--- a/packages/testing/src/__tests__/context.test.ts
+++ b/packages/testing/src/__tests__/context.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 
-import { createTestContext } from '../context.js';
+import { Result } from '@ontrails/core';
+
+import { createFollowContext, createTestContext } from '../context.js';
 import type { TestLogger } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -56,5 +58,38 @@ describe('createTestContext', () => {
     });
     const env = ctx['env'] as Record<string, string>;
     expect(env).toEqual({ CUSTOM: '1', NODE_ENV: 'test' });
+  });
+});
+
+describe('createFollowContext', () => {
+  test('returns configured ok response for registered id', async () => {
+    const follow = createFollowContext({
+      responses: { 'entity.add': Result.ok({ id: '1', name: 'Alpha' }) },
+    });
+    const result = await follow('entity.add', { name: 'Alpha' });
+    expect(result.unwrap()).toEqual({ id: '1', name: 'Alpha' });
+  });
+
+  test('returns configured err response for registered id', async () => {
+    const err = new Error('conflict');
+    const follow = createFollowContext({
+      responses: { 'entity.add': Result.err(err) },
+    });
+    const result = await follow('entity.add', {});
+    expect(result.isErr()).toBe(true);
+    expect(result.error?.message).toBe('conflict');
+  });
+
+  test('returns err with descriptive message for unregistered id', async () => {
+    const follow = createFollowContext();
+    const result = await follow('unknown.trail', {});
+    expect(result.isErr()).toBe(true);
+    expect(result.error?.message).toContain('unknown.trail');
+  });
+
+  test('no options defaults to empty responses', async () => {
+    const follow = createFollowContext();
+    const result = await follow('any.id', {});
+    expect(result.isErr()).toBe(true);
   });
 });

--- a/packages/testing/src/context.ts
+++ b/packages/testing/src/context.ts
@@ -2,7 +2,8 @@
  * Test context factory for creating TrailContext instances suitable for testing.
  */
 
-import type { TrailContext } from '@ontrails/core';
+import type { FollowFn, TrailContext } from '@ontrails/core';
+import { Result } from '@ontrails/core';
 
 import { createTestLogger } from './logger.js';
 import type { TestTrailContextOptions } from './types.js';
@@ -27,6 +28,46 @@ export const createTestContext = (
   signal: overrides?.signal ?? new AbortController().signal,
   workspaceRoot: overrides?.cwd ?? process.cwd(),
 });
+
+// ---------------------------------------------------------------------------
+// createFollowContext
+// ---------------------------------------------------------------------------
+
+export interface CreateFollowContextOptions {
+  readonly responses?: Record<string, Result<unknown, Error>> | undefined;
+}
+
+/**
+ * Create a mock `FollowFn` for testing composite trails.
+ *
+ * Returns preconfigured `Result` values keyed by trail ID. Calls to
+ * unregistered IDs return `Result.err` with a descriptive message.
+ *
+ * @example
+ * ```ts
+ * const follow = createFollowContext({
+ *   responses: { 'entity.add': Result.ok({ id: '1', name: 'Alpha' }) },
+ * });
+ * const ctx = { ...createTestContext(), follow };
+ * ```
+ */
+export const createFollowContext = (
+  options?: CreateFollowContextOptions
+): FollowFn => {
+  const responses = options?.responses ?? {};
+  return <O>(id: string, _input: unknown): Promise<Result<O, Error>> => {
+    const response = responses[id];
+    if (response === undefined) {
+      return Promise.resolve(
+        Result.err(new Error(`No mock response for follow("${id}")`)) as Result<
+          O,
+          Error
+        >
+      );
+    }
+    return Promise.resolve(response as Result<O, Error>);
+  };
+};
 
 /**
  * Merge a Partial<TrailContext> into a test context.

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -16,7 +16,7 @@ export {
 } from './assertions.js';
 
 // Mock factories
-export { createTestContext } from './context.js';
+export { createFollowContext, createTestContext } from './context.js';
 export { createTestLogger } from './logger.js';
 
 // Surface harnesses
@@ -24,6 +24,7 @@ export { createCliHarness } from './harness-cli.js';
 export { createMcpHarness } from './harness-mcp.js';
 
 // Types
+export type { CreateFollowContextOptions } from './context.js';
 export type { TestFollowOptions } from './follows.js';
 
 export type {


### PR DESCRIPTION
## Summary

Batch of 5 smaller fixes across HTTP, OpenAPI, MCP, testing, and demo:

1. **Error code consistency** — JSON parse error in Hono adapter used \`code: 'validation'\`, now \`'ValidationError'\` matching all other error responses
2. **Empty input body** — OpenAPI spec no longer emits \`requestBody: { required: true }\` for \`z.object({})\` inputs
3. **\`createFollowContext\`** — new testing helper for mocking \`ctx.follow()\` in composite trail tests
4. **\`trailId\` on \`McpToolDefinition\`** — tools now expose which trail they came from, enabling introspection
5. **Idempotent demo trail** — \`demo.upsert\` with \`idempotent: true\` showcases the feature in the demo app

## Changes

- \`packages/http/src/hono/blaze.ts\` — error code fix
- \`packages/schema/src/openapi.ts\` — skip requestBody for empty input
- \`packages/testing/src/context.ts\` — \`createFollowContext\` factory
- \`packages/testing/src/index.ts\` — export
- \`packages/mcp/src/build.ts\` — \`trailId\` on McpToolDefinition
- \`apps/trails-demo/src/trails/kv.ts\` — new idempotent demo trail
- \`apps/trails-demo/src/app.ts\` — register kv module
- Test files updated for each fix

## Test plan

- [ ] Malformed JSON returns \`code: 'ValidationError'\`
- [ ] Empty input POST omits requestBody in OpenAPI spec
- [ ] \`createFollowContext\` returns configured responses and errors for unconfigured IDs
- [ ] \`McpToolDefinition.trailId\` matches the source trail ID
- [ ] Demo governance tests pass with new trail