### PR TITLE
refactor(http): make write → POST mapping explicit in intent-to-method lookup [TRL-58]

### DIFF
--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -53,14 +53,16 @@ export interface HttpRouteDefinition {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** Derive HTTP method from trail intent. */
-const deriveMethod = (trail: Trail<unknown, unknown>): HttpMethod => {
-  const intentToMethod: Record<string, HttpMethod> = {
-    destroy: 'DELETE',
-    read: 'GET',
-  };
-  return intentToMethod[trail.intent] ?? 'POST';
+/** Explicit intent → HTTP method mapping. */
+const intentToMethod: Record<string, HttpMethod> = {
+  destroy: 'DELETE',
+  read: 'GET',
+  write: 'POST',
 };
+
+/** Derive HTTP method from trail intent. */
+const deriveMethod = (trail: Trail<unknown, unknown>): HttpMethod =>
+  intentToMethod[trail.intent] ?? 'POST';
 
 /** Derive HTTP path from trail ID: `entity.show` -> `/entity/show`. */
 const derivePath = (basePath: string, trailId: string): string => {
@@ -190,7 +192,7 @@ const accumulateRoutes = (
  * Build HTTP route definitions from a topo.
  *
  * Each trail becomes an HttpRouteDefinition with:
- * - An HTTP method derived from intent (read -> GET, destroy -> DELETE, default -> POST)
+ * - An HTTP method derived from intent (read -> GET, write -> POST, destroy -> DELETE)
  * - A path derived from the trail ID (dots become slashes)
  * - An input source derived from the method (GET -> query, others -> body)
  * - An `execute` function that validates, layers, and runs the implementation


### PR DESCRIPTION
## Summary

- Makes the `write → POST` mapping explicit in the HTTP route builder's intent-to-method lookup table
- Previously `POST` was an implicit fallback; now all three intents are declared: `read → GET`, `write → POST`, `destroy → DELETE`
- Same behavior, clearer intent

## Changes

- `packages/http/src/build.ts` — extracted `intentToMethod` lookup table with all three mappings; simplified `deriveMethod` to a one-liner
- Updated TSDoc to list all three mappings explicitly

Note: `packages/schema/src/openapi.ts` already had the explicit mapping — no change needed there.

## Test plan

- [ ] All existing HTTP tests pass unchanged (behavior identical)
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes