### PR TITLE
docs: update all docs, READMEs, and plugin references for beta.8 changes

### DIFF
--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -1,6 +1,6 @@
 # trails-demo
 
-A complete working application built with the Trails framework. It demonstrates every core concept: trails, composition via `follow`, an event, examples, metadata, detours, and blazing on both CLI and MCP surfaces.
+A complete working application built with the Trails framework. It demonstrates every core concept: trails, composition via `follow`, an event, examples, metadata, detours, idempotent upsert, and blazing on CLI, MCP, and HTTP surfaces.
 
 ## What this app does
 
@@ -14,6 +14,7 @@ Entity management -- a small CRUD + search system with enough depth to exercise 
 | `entity.list` | List entities with optional type filter | `intent: 'read'` |
 | `search` | Full-text search across entities | `intent: 'read'` |
 | `entity.onboard` | Composition: create + verify searchable | `follow: ['entity.add', 'search']` |
+| `demo.upsert` | Idempotent key-value store example | `idempotent: true` |
 
 Plus one event: `entity.updated` (triggered by `entity.add` and `entity.delete`).
 
@@ -59,6 +60,9 @@ curl -X POST http://localhost:3000/entity/add -H 'Content-Type: application/json
 
 # Destructive trail (DELETE)
 curl -X DELETE http://localhost:3000/entity/delete -H 'Content-Type: application/json' -d '{"name":"Deletable"}'
+
+# Idempotent upsert (POST — repeating produces the same result)
+curl -X POST http://localhost:3000/demo/upsert -H 'Content-Type: application/json' -d '{"key":"theme","value":"dark"}'
 ```
 
 ## Running the MCP server
@@ -67,7 +71,7 @@ curl -X DELETE http://localhost:3000/entity/delete -H 'Content-Type: application
 bun run src/mcp.ts
 ```
 
-This exposes MCP tools: `demo_entity_show`, `demo_entity_add`, `demo_entity_delete`, `demo_entity_list`, `demo_search`, `demo_entity_onboard`.
+This exposes MCP tools: `demo_entity_show`, `demo_entity_add`, `demo_entity_delete`, `demo_entity_list`, `demo_search`, `demo_entity_onboard`, `demo_demo_upsert`.
 
 ## Understanding the code
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -41,13 +41,14 @@ Implementation<I, O>              // (input, ctx) => Result | Promise<Result>
 TrailContext, createTrailContext(overrides?)
 FollowFn, ProgressCallback, ProgressEvent, Logger, Surface
 
+// Execution pipeline
+executeTrail(trail, rawInput, options?) // shared execution pipeline: validate → compose layers → run; used by all surfaces
+dispatch(topo, id, input, options?)    // look up and execute a trail by ID; returns Result, never throws
+DispatchOptions
+
 // Layers
 Layer                              // wrap(trail, implementation) → implementation
 composeLayers(layers, trail, implementation)
-
-// Dispatch — headless surface
-dispatch(topo, id, input, options?) // look up and execute a trail by ID; returns Result, never throws
-DispatchOptions
 
 // Validation
 validateInput(schema, data)        // → Result<T, ValidationError>
@@ -105,21 +106,22 @@ autoIterateLayer, dateShortcutsLayer
 
 ```typescript
 blaze(topo, options?)              // one-liner
-buildMcpTools(topo, options?)      // escape hatch step 1
+buildMcpTools(topo, options?)      // escape hatch step 1; returns Result<McpToolDefinition[], Error>
 connectStdio(server)               // escape hatch step 2
 deriveToolName(appName, trailId)   // tool name derivation
 deriveAnnotations(trail)           // MCP annotations from intent and metadata
 createMcpProgressCallback(extra)   // progress bridge
 
 BlazeMcpOptions, BuildMcpToolsOptions
-McpToolDefinition, McpToolResult, McpContent, McpExtra, McpAnnotations
+McpToolDefinition,                 // includes trailId: string
+McpToolResult, McpContent, McpExtra, McpAnnotations
 ```
 
 ## `@ontrails/http`
 
 ```typescript
 blaze(topo, options?)              // one-liner HTTP server
-buildHttpRoutes(topo, options?)    // escape hatch: route definitions without server
+buildHttpRoutes(topo, options?)    // escape hatch: route definitions without server; returns Result<HttpRouteDefinition[], Error>
 
 BlazeHttpOptions, BuildHttpRoutesOptions
 HttpMethod, HttpRouteDefinition
@@ -154,6 +156,7 @@ assertErrorMatch(result, errorClass)
 
 // Factories
 createTestContext(options?), createTestLogger()
+createFollowContext(options?)      // minimal context for testing trail composition via ctx.follow()
 createCliHarness(topo, options?), createMcpHarness(topo, options?)
 
 TestScenario, HikeScenario, TestLogger, TestTrailContextOptions, TestHikeOptions
@@ -166,6 +169,8 @@ McpHarness, McpHarnessOptions, McpHarnessResult
 ```typescript
 runWarden(options?), formatWardenReport(report), checkDrift(rootDir, topo?)
 wardenRules                        // ReadonlyMap<string, WardenRule> — 11 AST-based rules
+wardenTopo                         // pre-built Topo of all warden trails
+runWardenTrails(filePath, sourceCode, options?) // run warden rules against a single file
 formatGitHubAnnotations(report), formatJson(report), formatSummary(report)
 
 WardenOptions, WardenReport, WardenDiagnostic, WardenSeverity, DriftResult

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,6 +229,33 @@ HTTP request (GET /entity/show?name=Alpha)
 
 The implementation is identical. Only the edges change.
 
+### Headless Execution via `dispatch()`
+
+`dispatch()` is the headless path -- no surface adapter needed:
+
+```text
+dispatch(topo, 'entity.show', { name: 'Alpha' }, options?)
+  -> topo.get(id) looks up the trail
+  -> executeTrail(trail, rawInput, options) runs the shared pipeline
+  -> Result returned, never throws
+```
+
+This is useful for server-side composition, background workers, and test harnesses that need to invoke trails by ID without wiring a surface.
+
+### The Shared `executeTrail()` Pipeline
+
+All surfaces -- CLI, MCP, HTTP, and `dispatch()` -- delegate to the same `executeTrail()` function in `@ontrails/core`:
+
+```text
+executeTrail(trail, rawInput, options?)
+  -> Zod validates rawInput against trail's input schema
+  -> Layers composed via composeLayers()
+  -> implementation(validatedInput, ctx) called
+  -> Result returned
+```
+
+This guarantees consistent validation, layer ordering, and error handling regardless of which surface initiated the call.
+
 ## Error Taxonomy
 
 13 error classes across 10 categories. Each maps to CLI exit codes, HTTP status codes, JSON-RPC codes, and retryability:

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -144,9 +144,13 @@ import { buildHttpRoutes } from '@ontrails/http';
 import { Hono } from 'hono';
 
 const hono = new Hono();
-const routes = buildHttpRoutes(app, { basePath: '/api' });
+const routesResult = buildHttpRoutes(app, { basePath: '/api' });
 
-for (const route of routes) {
+if (routesResult.isErr()) {
+  throw routesResult.error; // ValidationError if route collisions are detected
+}
+
+for (const route of routesResult.value) {
   const method = route.method.toLowerCase() as 'get' | 'post' | 'delete';
   hono[method](route.path, async (c) => {
     const input =
@@ -164,6 +168,26 @@ export default hono;
 ```
 
 This gives you full control over the HTTP framework while still deriving routes from the topo.
+
+`buildHttpRoutes()` returns `Result<HttpRouteDefinition[], Error>`. If two trails resolve to the same method + path (e.g. two trails both map to `POST /entity/add`), it returns a `ValidationError` describing the collision instead of silently overwriting a route.
+
+## AbortSignal Propagation
+
+The HTTP request's abort signal is forwarded to `TrailContext.signal`. If the client disconnects or cancels the request mid-flight, the implementation's signal is aborted.
+
+```typescript
+const longTask = trail('report.generate', {
+  run: async (input, ctx) => {
+    for (const chunk of data) {
+      if (ctx.signal?.aborted) {
+        return Result.err(new CancelledError('Request cancelled'));
+      }
+      await processChunk(chunk);
+    }
+    return Result.ok({ report: '...' });
+  },
+});
+```
 
 ## Example: Full HTTP Entry Point
 

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -190,15 +190,21 @@ For advanced use cases, build the tool definitions directly:
 ```typescript
 import { buildMcpTools } from '@ontrails/mcp';
 
-const tools = buildMcpTools(app, {
+const result = buildMcpTools(app, {
   includeTrails: ['entity.show', 'search'],
 });
 
-// tools is McpToolDefinition[] -- register them with your own MCP server instance
-for (const tool of tools) {
+if (result.isErr()) {
+  throw result.error;
+}
+
+// result.value is McpToolDefinition[] -- register them with your own MCP server instance
+for (const tool of result.value) {
   server.registerTool(tool.name, tool.handler, {
     inputSchema: tool.inputSchema,
     annotations: tool.annotations,
   });
 }
 ```
+
+Each `McpToolDefinition` includes a `trailId` field containing the original trail ID (e.g. `'entity.show'`). This is useful for logging, filtering, or routing when managing tool definitions outside of `blaze()`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -229,6 +229,29 @@ const ctx = createTestContext({
 
 Defaults: deterministic request ID, test logger (captures entries), non-aborted signal.
 
+### `createFollowContext(options?)`
+
+Creates a mock `FollowFn` for testing composite trails that call `ctx.follow()`. Pre-configure responses per trail ID:
+
+```typescript
+import { createFollowContext, createTestContext } from '@ontrails/testing';
+import { Result } from '@ontrails/core';
+
+const follow = createFollowContext({
+  responses: {
+    'user.get': Result.ok({ name: 'Alice' }),
+    'user.validate': Result.ok({ valid: true }),
+  },
+});
+
+const ctx = { ...createTestContext(), follow };
+const result = await onboardTrail.run({ name: 'Delta' }, ctx);
+
+expect(result.isOk()).toBe(true);
+```
+
+Calls to unregistered trail IDs return an error Result. If you need real execution instead of mocked responses, use `dispatch()` from `@ontrails/core`.
+
 ### `createTestLogger()`
 
 A logger that captures entries in memory:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,14 +46,50 @@ const onboard = trail('entity.onboard', {
 | `topo(name, ...modules)` | Collect trail modules into a queryable topology |
 | `validateTopo(topo)` | Structural validation: follow targets exist, no cycles, examples parse, output schemas present |
 
+### Execution
+
+| Export | What it does |
+| --- | --- |
+| `executeTrail(trail, rawInput, options?)` | Centralized execution pipeline: validates input, builds context, composes layers, runs the implementation. Never throws -- exceptions become `Result.err(InternalError)`. |
+| `dispatch(topo, id, input, options?)` | Headless trail execution by ID. Looks up the trail in the topo, then delegates to `executeTrail`. Returns `Result.err(NotFoundError)` if the ID is not registered. |
+
+```typescript
+// executeTrail — surface adapters use this directly
+const result = await executeTrail(greet, { name: 'Alice' });
+
+// dispatch — no-surface execution by trail ID
+const result = await dispatch(app, 'greet', { name: 'Alice' });
+if (result.isOk()) console.log(result.value);
+```
+
+### Topo accessors
+
+Beyond the `trail(id, spec)` builder, `Topo` exposes these accessors:
+
+| Accessor | What it returns |
+| --- | --- |
+| `topo.ids()` | `string[]` of all registered trail IDs |
+| `topo.count` | Number of registered trails |
+| `topo.get(id)` | The `Trail` with that ID, or `undefined` |
+| `topo.has(id)` | Whether a trail ID is registered |
+| `topo.list()` | All registered trails as an array |
+
 ### Type utilities
 
 | Export | What it does |
 | --- | --- |
 | `TrailInput<T>` | Extract the input type from a `Trail` |
 | `TrailOutput<T>` | Extract the output type from a `Trail` |
+| `TrailResult<T>` | `Result<TrailOutput<T>, Error>` -- the Result type for a trail's output |
 | `inputOf(trail)` | Get the input Zod schema from a trail instance |
 | `outputOf(trail)` | Get the output Zod schema (or `undefined`) from a trail instance |
+
+### Execution option types
+
+| Type | What it describes |
+| --- | --- |
+| `ExecuteTrailOptions` | Options for `executeTrail`: `ctx`, `signal`, `layers`, `createContext` |
+| `DispatchOptions` | Same shape as `ExecuteTrailOptions`; forwarded by `dispatch` |
 
 ### Result
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -1,0 +1,84 @@
+# @ontrails/http
+
+HTTP surface adapter. One `blaze()` call turns a topo into a Hono-based HTTP server with routes, input validation, and error mapping -- all derived from the trail contracts.
+
+## Usage
+
+```typescript
+import { trail, topo, Result } from '@ontrails/core';
+import { blaze } from '@ontrails/http/hono';
+import { z } from 'zod';
+
+const greet = trail('greet', {
+  input: z.object({ name: z.string().describe('Who to greet') }),
+  output: z.object({ message: z.string() }),
+  intent: 'read',
+  run: (input) => Result.ok({ message: `Hello, ${input.name}!` }),
+});
+
+const app = topo('myapp', { greet });
+await blaze(app, { port: 3000 });
+```
+
+This starts a Hono-based HTTP server. The `greet` trail becomes `GET /greet?name=...` because its `intent` is `'read'`.
+
+For more control, build the routes yourself:
+
+```typescript
+import { buildHttpRoutes } from '@ontrails/http';
+
+const result = buildHttpRoutes(app);
+if (result.isErr()) throw result.error; // ValidationError on route collision
+for (const route of result.value) {
+  console.log(`${route.method} ${route.path} → ${route.trailId}`);
+}
+```
+
+`buildHttpRoutes` returns `Result<HttpRouteDefinition[], Error>` rather than a bare array. It returns `Result.err(ValidationError)` if two trails derive the same `(method, path)` pair.
+
+## API
+
+| Export | What it does |
+| --- | --- |
+| `buildHttpRoutes(app, options?)` | Build framework-agnostic route definitions from a topo |
+| `blaze(app, options?)` (`@ontrails/http/hono`) | Start a Hono HTTP server with all trails as routes |
+
+## Route derivation
+
+Trail intent maps directly to HTTP method and input source:
+
+| Trail field | HTTP method | Input source |
+| --- | --- | --- |
+| `intent: 'read'` | `GET` | Query string |
+| `intent: 'write'` | `POST` | JSON body |
+| `intent: 'destroy'` | `DELETE` | JSON body |
+| (none) | `POST` | JSON body |
+
+Trail IDs map to paths: `entity.show` becomes `/entity/show`. Dots become slashes, everything lowercase.
+
+## Collision detection
+
+`buildHttpRoutes` detects when two trails would produce the same `(method, path)` pair and returns `Result.err(ValidationError)` describing both trail IDs. The `blaze()` Hono adapter throws on collision.
+
+## AbortSignal propagation
+
+The `execute` function on each `HttpRouteDefinition` accepts an optional `AbortSignal`. The Hono adapter extracts `signal` from `c.req.raw` and passes it to `execute`, so client disconnects propagate into trail execution.
+
+## `HttpRouteDefinition`
+
+Each route definition produced by `buildHttpRoutes` includes:
+
+| Field | Type | What it is |
+| --- | --- | --- |
+| `method` | `'GET' \| 'POST' \| 'DELETE'` | HTTP method |
+| `path` | `string` | Derived path (e.g. `/entity/show`) |
+| `trailId` | `string` | The trail ID this route was derived from |
+| `inputSource` | `'query' \| 'body'` | Where to read input |
+| `trail` | `Trail` | The original trail definition |
+| `execute` | `(input, requestId?, signal?) => Promise<Result>` | Validates, layers, and runs the implementation |
+
+## Installation
+
+```bash
+bun add @ontrails/http hono
+```

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -26,14 +26,17 @@ For more control, build the tools yourself:
 ```typescript
 import { buildMcpTools } from '@ontrails/mcp';
 
-const tools = buildMcpTools(app);
-for (const tool of tools) {
+const result = buildMcpTools(app);
+if (result.isErr()) throw result.error; // ValidationError on tool-name collision
+for (const tool of result.value) {
   server.registerTool(tool.name, tool.handler, {
     inputSchema: tool.inputSchema,
     annotations: tool.annotations,
   });
 }
 ```
+
+`buildMcpTools` returns `Result<McpToolDefinition[], Error>` rather than a bare array. It returns `Result.err(ValidationError)` if two trails derive the same MCP tool name. Each `McpToolDefinition` includes a `trailId` field that records which trail the tool was derived from.
 
 ## API
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -32,6 +32,7 @@ testDetours(app);    // Verify detour targets exist
 | `testTrail(trail, scenarios)` | Custom scenarios for edge cases, error paths, and follow chains |
 | `testContracts(topo, ctx?)` | Validate output against declared schemas |
 | `testDetours(topo)` | Verify every detour target exists in the topo |
+| `createFollowContext(options?)` | Mock `FollowFn` for testing composite trails; returns preconfigured `Result` values keyed by trail ID |
 | `createTestContext(options?)` | `TrailContext` with sensible test defaults |
 | `createTestLogger()` | Logger that captures entries in memory for assertions |
 | `createCliHarness(options)` | Execute CLI commands in-process, capture stdout/stderr |
@@ -66,6 +67,24 @@ testTrail(onboardTrail, [
   { description: 'add fails', input: { name: 'Alpha' }, expectErr: AlreadyExistsError },
 ]);
 ```
+
+When you need to isolate a composite trail and stub out its dependencies, use `createFollowContext`:
+
+```typescript
+import { createFollowContext, createTestContext } from '@ontrails/testing';
+import { Result } from '@ontrails/core';
+
+const follow = createFollowContext({
+  responses: {
+    'entity.add': Result.ok({ id: '1', name: 'Delta', type: 'tool' }),
+    'search': Result.ok({ results: [] }),
+  },
+});
+const ctx = { ...createTestContext(), follow };
+const result = await onboardTrail.run({ name: 'Delta', type: 'tool' }, ctx);
+```
+
+Calls to unregistered trail IDs return `Result.err` with a descriptive message, so missing stubs fail loudly.
 
 ## Surface harnesses
 

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -71,6 +71,24 @@ CI formatters for structured output:
 import { formatGitHubAnnotations, formatJson, formatSummary } from '@ontrails/warden';
 ```
 
+## Trail-based API
+
+Every built-in warden rule is also available as a composable trail. This makes rules queryable, testable, and invocable through any Trails surface.
+
+```typescript
+import { wardenTopo, runWardenTrails } from '@ontrails/warden';
+
+// Inspect the warden rule trails
+console.log(wardenTopo.ids()); // ['warden.rule.no-throw-in-implementation', ...]
+
+// Run all rule trails against a source file
+const diagnostics = await runWardenTrails(filePath, sourceCode, {
+  knownTrailIds: myApp.ids(),
+});
+```
+
+To wrap a custom rule as a trail, use `wrapRule` (imported from `@ontrails/warden/trails/wrap-rule`). This is the same factory used internally to build all built-in rule trails.
+
 ## API
 
 | Export | What it does |
@@ -79,6 +97,8 @@ import { formatGitHubAnnotations, formatJson, formatSummary } from '@ontrails/wa
 | `formatWardenReport(report)` | Human-readable report |
 | `checkDrift(app)` | Check if `surface.lock` matches the current topo |
 | `wardenRules` | Registry of all built-in rules |
+| `wardenTopo` | `Topo` of all built-in rule trails (one per rule) |
+| `runWardenTrails(filePath, sourceCode, options?)` | Dispatch all rule trails for a file, collect diagnostics |
 | `formatGitHubAnnotations(report)` | GitHub Actions annotation format |
 | `formatJson(report)` | Machine-readable JSON |
 | `formatSummary(report)` | Compact summary line |

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -26,7 +26,10 @@ const app = topo('myapp', greetModule);
 blaze(app);              // CLI — from @ontrails/cli/commander
 await blaze(app);        // MCP — from @ontrails/mcp
 
-// 4. Test
+// 4. Headless execution (no surface needed)
+const result = await dispatch(app, 'greet', { name: 'Alice' });
+
+// 5. Test
 testAll(app);            // Examples + governance in one line
 ```
 
@@ -126,7 +129,7 @@ See [cli-surface.md](references/cli-surface.md), [mcp-surface.md](references/mcp
 
 **TDD workflow**: Define trail with examples → run tests (red) → implement (green) → refactor.
 
-Edge cases go in `testTrail(trail, scenarios)`. Surface integration uses `createCliHarness()` / `createMcpHarness()`.
+Edge cases go in `testTrail(trail, scenarios)`. Use `createFollowContext()` to mock `ctx.follow` for composite trail unit tests. Surface integration uses `createCliHarness()` / `createMcpHarness()`.
 
 See [testing-patterns.md](references/testing-patterns.md) for the full testing API.
 

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -77,7 +77,7 @@ Warden uses inference to verify declarations match actual code. The surface map 
 
 ### Foundation
 
-`@ontrails/core` — only external dependency is `zod`. Contains Result, error taxonomy, `trail()`/`event()`, `topo()`, validation, layers, and adapter port interfaces.
+`@ontrails/core` — only external dependency is `zod`. Contains Result, error taxonomy, `trail()`/`event()`, `topo()`, validation, layers, adapter port interfaces, `executeTrail()` (the shared pipeline), and `dispatch()` (headless execution by trail ID).
 
 ### Surface Adapters (left side)
 
@@ -121,18 +121,28 @@ Warden uses inference to verify declarations match actual code. The surface map 
 
 ## Data Flow
 
+### Shared Execution Pipeline
+
+All surfaces delegate to `executeTrail(trail, rawInput, options)` from `@ontrails/core`. It is the single implementation of the validate-context-layers-run pipeline:
+
+```text
+executeTrail(trail, rawInput, options)
+  -> Zod validates input against trail's schema  -> Result.err(ValidationError) on failure
+  -> TrailContext created (requestId, logger, signal)
+  -> Layers composed around implementation
+  -> implementation(validatedInput, ctx) called
+  -> Result returned (never throws)
+```
+
+Surfaces only differ in how they parse inbound requests and map Results to their response format.
+
 ### CLI Request Path
 
 ```text
 CLI input ("myapp entity show --name Alpha")
   -> Commander parses args/flags
   -> CLI adapter matches trail via CliCommand model
-  -> Layers run (auth, rate limit, telemetry)
-  -> Zod validates input against trail's schema
-  -> TrailContext created (requestId, logger, signal)
-  -> implementation(validatedInput, ctx) called
-  -> Result returned
-  -> Layers post-process
+  -> Delegates to executeTrail(trail, parsedInput, { layers, ... })
   -> Result mapped to exit code + stdout
 ```
 
@@ -141,11 +151,8 @@ CLI input ("myapp entity show --name Alpha")
 ```text
 MCP tool call ({ name: "myapp_entity_show", arguments: { name: "Alpha" } })
   -> MCP adapter matches trail
-  -> Zod validates input
-  -> TrailContext created
-  -> Same implementation(validatedInput, ctx) called
-  -> Same Result returned
-  -> Result mapped to MCP tool response
+  -> Delegates to executeTrail(trail, args, { layers, signal, ... })
+  -> Result mapped to MCP tool response (content[], isError)
 ```
 
 ### HTTP Request Path
@@ -153,14 +160,23 @@ MCP tool call ({ name: "myapp_entity_show", arguments: { name: "Alpha" } })
 ```text
 HTTP request (GET /entity/show?name=Alpha)
   -> Hono matches route derived from trail ID
-  -> Zod validates input (query params for GET, JSON body for POST/DELETE)
-  -> TrailContext created
-  -> Same implementation(validatedInput, ctx) called
-  -> Same Result returned
+  -> Parses input (query params for GET, JSON body for POST/DELETE)
+  -> Delegates to executeTrail(trail, parsedInput, { layers, ... })
   -> Result mapped to JSON response with status code from error taxonomy
 ```
 
-The implementation is identical. Only the edges change.
+### Headless Execution (no surface)
+
+`dispatch(topo, id, input, options)` from `@ontrails/core` is the "no-surface" path. It resolves a trail by ID from the topo, then delegates to `executeTrail`. Returns `Result.err(NotFoundError)` if the ID is not registered.
+
+```text
+dispatch(myTopo, 'entity.show', { name: 'Alpha' })
+  -> Resolves trail from topo by ID
+  -> Delegates to executeTrail(trail, input, options)
+  -> Result returned
+```
+
+The implementation is identical across all paths. Only the edges change.
 
 ## Error Taxonomy
 

--- a/plugin/skills/trails/references/cli-surface.md
+++ b/plugin/skills/trails/references/cli-surface.md
@@ -109,6 +109,10 @@ blaze(app, {
 });
 ```
 
+## Execution Pipeline
+
+The CLI surface delegates to `executeTrail()` from `@ontrails/core` — the same pipeline used by MCP, HTTP, and `dispatch()`. Input is validated by Zod before the implementation runs. Layers are applied in order. The Result is mapped to an exit code and stdout/stderr by the surface; implementations never call `process.exit()` directly.
+
 ## Escape Hatch
 
 For full control over the Commander.js program, use `buildCliCommands()` to get the command tree, then call `toCommander()`:

--- a/plugin/skills/trails/references/common-pitfalls.md
+++ b/plugin/skills/trails/references/common-pitfalls.md
@@ -33,7 +33,7 @@ run: async (input) => {
 
 **Why it's wrong:** Direct calls bypass the framework pipeline. Input isn't validated, layers don't run, and traces aren't recorded.
 
-**Fix:** In composite trails, use `ctx.follow(myTrail, input)`. In tests, use `testAll()` or the test harness.
+**Fix:** In composite trails, use `ctx.follow('trail.id', input)` (pass the string ID, not the trail object). In tests, use `testAll()` or the test harness.
 
 ## 4. Missing output schema
 
@@ -75,11 +75,11 @@ input: z.object({
 
 ```typescript
 trail('onboard', {
-  follow: [createUser, sendWelcome], // must match ctx.follow() calls
+  follow: ['user.create', 'user.welcome'], // must match ctx.follow() calls
   run: async (input, ctx) => {
-    const user = await ctx.follow(createUser, input);
+    const user = await ctx.follow('user.create', input);
     if (user.isErr()) return user;
-    return ctx.follow(sendWelcome, { userId: user.value.id });
+    return ctx.follow('user.welcome', { userId: user.value.id });
   },
 });
 ```

--- a/plugin/skills/trails/references/contract-patterns.md
+++ b/plugin/skills/trails/references/contract-patterns.md
@@ -138,3 +138,25 @@ Trails that compose others use `follow` and `ctx.follow()`.
 ```typescript
 const result = await ctx.follow('entity.add', { name: 'Beta', type: 'tool' });
 if (result.isErr()) return result;
+```
+
+## Type Utilities
+
+`@ontrails/core` exports three type utilities for extracting types from trail definitions without duplicating them:
+
+| Utility | Returns |
+|---------|---------|
+| `TrailInput<T>` | The validated input type for trail `T` |
+| `TrailOutput<T>` | The successful output type for trail `T` |
+| `TrailResult<T>` | `Result<TrailOutput<T>, Error>` — the full return type |
+
+```typescript
+import type { TrailInput, TrailOutput, TrailResult } from '@ontrails/core';
+import { myTrail } from './trails/entity.js';
+
+type Input = TrailInput<typeof myTrail>;   // z.infer<typeof myTrail.input>
+type Output = TrailOutput<typeof myTrail>; // z.infer<typeof myTrail.output>
+type RunResult = TrailResult<typeof myTrail>; // Result<Output, Error>
+```
+
+Use `TrailResult<T>` to type function return values that forward a trail's result without repeating the output shape.

--- a/plugin/skills/trails/references/error-taxonomy.md
+++ b/plugin/skills/trails/references/error-taxonomy.md
@@ -103,7 +103,7 @@ const restored = deserializeError(json);
 // Full TrailsError instance with correct prototype chain
 ```
 
-## Error Composition in Hikes
+## Error Composition in Composite Trails
 
 Propagate upstream errors directly. Wrap only when adding context:
 

--- a/plugin/skills/trails/references/mcp-surface.md
+++ b/plugin/skills/trails/references/mcp-surface.md
@@ -74,15 +74,25 @@ await blaze(app, {
 
 ## Escape Hatch
 
-For manual tool definition or custom MCP server configuration, use `buildMcpTools()`:
+For manual tool definition or custom MCP server configuration, use `buildMcpTools()`. It returns `Result<McpToolDefinition[], Error>` — check for errors before using the array (name collisions produce a `ValidationError`):
 
 ```typescript
 import { buildMcpTools } from '@ontrails/mcp';
 import { app } from './app';
 
-const tools = buildMcpTools(app);
-// tools is an array of MCP tool definitions
+const toolsResult = buildMcpTools(app);
+if (toolsResult.isErr()) throw new Error(toolsResult.error.message);
+const tools = toolsResult.value;
 // Wire into your own MCP server setup
 ```
+
+Each `McpToolDefinition` includes:
+
+- `name` — derived tool name (`appName_trail_id`)
+- `inputSchema` — JSON Schema from the trail's Zod input
+- `annotations` — MCP hints derived from trail intent
+- `description` — trail description with first example appended
+- `handler` — async function that runs the full `executeTrail` pipeline
+- `trailId` — the original trail ID this tool was derived from (useful for filtering and introspection)
 
 This gives you the raw tool definitions to register manually while still benefiting from automatic schema derivation and annotation mapping.

--- a/plugin/skills/trails/references/testing-patterns.md
+++ b/plugin/skills/trails/references/testing-patterns.md
@@ -121,6 +121,43 @@ Applied automatically per example based on which fields are present:
 
 Error class names: `ValidationError`, `NotFoundError`, `AlreadyExistsError`, `ConflictError`, `AuthError`, `PermissionError`, `TimeoutError`, `NetworkError`, `RateLimitError`, `InternalError`, `AmbiguousError`, `CancelledError`, `AssertionError`.
 
+## `createFollowContext()` -- Mock Follow for Composite Trails
+
+When unit-testing a composite trail in isolation (without a full topo), use `createFollowContext()` to provide preconfigured `Result` responses for each `ctx.follow()` call:
+
+```typescript
+import { Result } from '@ontrails/core';
+import { createFollowContext, createTestContext } from '@ontrails/testing';
+
+const follow = createFollowContext({
+  responses: {
+    'entity.add': Result.ok({ id: '1', name: 'Alpha' }),
+    'entity.relate': Result.ok({ linked: true }),
+  },
+});
+
+const ctx = { ...createTestContext(), follow };
+
+const result = await onboardTrail.run({ name: 'Alpha' }, ctx);
+expect(result.isOk()).toBe(true);
+```
+
+Calls to IDs not registered in `responses` return `Result.err` with a descriptive message, making missing mocks visible immediately.
+
+## `dispatch()` -- Headless Testing Against a Topo
+
+For integration-style tests that verify the full pipeline (validation, layers, implementation) without mounting a surface, use `dispatch()` from `@ontrails/core`:
+
+```typescript
+import { dispatch } from '@ontrails/core';
+import { app } from '../src/app.js';
+
+const result = await dispatch(app, 'entity.show', { name: 'Alpha' });
+expect(result.isOk()).toBe(true);
+```
+
+`dispatch()` returns `Result.err(NotFoundError)` if the trail ID is not in the topo, making it useful for verifying topo completeness as well.
+
 ## Test Context
 
 ```typescript


### PR DESCRIPTION
## Summary

Comprehensive docs update covering all APIs added in the backlog sweep (PRs #1-#11):

- `executeTrail()` and `dispatch()` documented across core README, api-reference, architecture, and plugin references
- `TrailResult<T>`, `topo.ids()`, `topo.count` added to core docs
- `buildMcpTools()` and `buildHttpRoutes()` updated to show `Result` return types with unwrapping examples
- `McpToolDefinition.trailId` documented in MCP surface docs
- `createFollowContext()` added to testing docs and plugin references
- Warden trail-based API (`wardenTopo`, `runWardenTrails`) documented
- HTTP AbortSignal propagation section added
- Route collision detection documented
- New `packages/http/README.md` created
- Plugin skill references updated (architecture, testing-patterns, contract-patterns, mcp-surface, cli-surface, common-pitfalls, error-taxonomy)

## Files changed

18 modified, 1 new (`packages/http/README.md`)

## Test plan

- [ ] All markdown linting passes
- [ ] No code changes — docs only
- [ ] Typecheck passes (unchanged)