### PR TITLE
refactor(cli,mcp,http): remove vestigial kind checks from build files [TRL-59]

### DIFF
--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -209,17 +209,11 @@ export const buildCliCommands = (
 ): CliCommand[] => {
   const commands: CliCommand[] = [];
 
-  for (const item of app.list()) {
-    if (item.kind !== 'trail') {
+  for (const trail of app.list()) {
+    if (trail.metadata?.['internal'] === true) {
       continue;
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const t = item as AnyTrail;
-    if (t.metadata?.['internal'] === true) {
-      continue;
-    }
-    commands.push(toCliCommand(t, options));
+    commands.push(toCliCommand(trail, options));
   }
 
   return commands;

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -109,12 +109,7 @@ const createExecute =
 
 /** Filter topo items to eligible trails. */
 const eligibleTrails = (app: Topo): Trail<unknown, unknown>[] =>
-  app
-    .list()
-    .filter(
-      (item): item is Trail<unknown, unknown> =>
-        item.kind === 'trail' && shouldInclude(item)
-    );
+  app.list().filter((trail) => shouldInclude(trail));
 
 /** Build a single route definition from a trail. */
 const buildRoute = (

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -321,13 +321,7 @@ const eligibleTrails = (
   app: Topo,
   options: BuildMcpToolsOptions
 ): Trail<unknown, unknown>[] =>
-  app
-    .list()
-    .filter(
-      (item): item is Trail<unknown, unknown> =>
-        item.kind === 'trail' &&
-        shouldInclude(item as Trail<unknown, unknown>, options)
-    );
+  app.list().filter((trail) => shouldInclude(trail, options));
 
 export const buildMcpTools = (
   app: Topo,


### PR DESCRIPTION
## Summary

- Removes dead `item.kind !== 'trail'` / `item.kind === 'trail'` checks from CLI, MCP, and HTTP build files
- Since hikes were removed, `app.list()` only returns trails — these checks were always true
- Simplifies the filter functions and removes unnecessary type casts

## Changes

- `packages/cli/src/build.ts` — removed `kind` guard and `as AnyTrail` cast
- `packages/mcp/src/build.ts` — simplified `eligibleTrails()` filter
- `packages/http/src/build.ts` — simplified `eligibleTrails()` filter

## Test plan

- [ ] All existing tests pass unchanged (behavior identical)