### PR TITLE
chore(core)!: remove Surface type literal from core [TRL-63]

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,7 +34,6 @@ export type {
   ProgressCallback,
   ProgressEvent,
   Logger,
-  Surface,
 } from './types.js';
 
 // Context factory

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -54,5 +54,3 @@ export interface TrailContext {
   readonly env?: Record<string, string | undefined> | undefined;
   readonly [key: string]: unknown;
 }
-
-export type Surface = 'cli' | 'mcp' | 'http' | 'ws';


### PR DESCRIPTION
## Summary

- Removes `Surface` type literal (`'cli' | 'mcp' | 'http' | 'ws'`) from `@ontrails/core`
- Core shouldn't enumerate which surfaces exist — this violates the hexagonal principle
- No code actually imports or uses this type

## Changes

- `packages/core/src/types.ts` — removed `Surface` type definition
- `packages/core/src/index.ts` — removed `Surface` from re-exports

## Test plan

- [ ] `bun run typecheck` passes (no consumers)
- [ ] All tests pass