### PR TITLE
feat(cli,mcp,http): run validateTopo() automatically in blaze() [TRL-65]

### DIFF
--- a/packages/cli/src/__tests__/blaze.test.ts
+++ b/packages/cli/src/__tests__/blaze.test.ts
@@ -60,12 +60,6 @@ describe('blaze', () => {
   });
 
   test('BlazeCliOptions accepts validate: false without type errors', () => {
-    // Compile-time: verify the option is accepted by the type.
-    // Runtime: verify the topo with a broken follow does not throw at validation
-    // when validate: false is passed. We do not call blaze() directly because
-    // it invokes Commander's parseAsync() against real argv. Instead we verify
-    // the guard behavior by confirming the option exists on the type and that
-    // a no-validate call to the internal steps does not throw before parseAsync.
     const t = trail('broken', {
       follow: ['nonexistent.trail'],
       input: z.object({}),
@@ -73,11 +67,9 @@ describe('blaze', () => {
       run: () => Result.ok({}),
     });
     const app = topo('test', { t });
-    // buildCliCommands does not call validateTopo — it should succeed regardless.
     expect(() =>
       buildCliCommands(app, { onResult: defaultOnResult })
     ).not.toThrow();
-    // Verify the type accepts validate: false (would be a TS error if not).
     const opts: Parameters<typeof blaze>[1] = { validate: false };
     expect(opts.validate).toBe(false);
   });

--- a/packages/http/src/hono/__tests__/blaze.test.ts
+++ b/packages/http/src/hono/__tests__/blaze.test.ts
@@ -93,6 +93,32 @@ const requestRaw = (
 // ---------------------------------------------------------------------------
 
 describe('blaze (Hono adapter)', () => {
+  describe('validation', () => {
+    test('blaze throws on invalid topo', async () => {
+      const t = trail('broken', {
+        follow: ['nonexistent.trail'],
+        input: z.object({}),
+        output: z.object({}),
+        run: () => Result.ok({}),
+      });
+      const app = topo('test', { t });
+      await expect(blaze(app, { serve: false })).rejects.toThrow(/validation/i);
+    });
+
+    test('blaze skips validation when validate: false', async () => {
+      const t = trail('broken', {
+        follow: ['nonexistent.trail'],
+        input: z.object({}),
+        output: z.object({}),
+        run: () => Result.ok({}),
+      });
+      const app = topo('test', { t });
+      await expect(
+        blaze(app, { serve: false, validate: false })
+      ).resolves.toBeDefined();
+    });
+  });
+
   describe('GET handler', () => {
     test('returns 200 with data on success', async () => {
       const app = topo('testapp', { echoTrail });

--- a/packages/mcp/src/__tests__/blaze.test.ts
+++ b/packages/mcp/src/__tests__/blaze.test.ts
@@ -71,8 +71,6 @@ describe('blaze', () => {
       run: () => Result.ok({}),
     });
     const app = topo('test', { t });
-    // blaze() proceeds past validation and into connectStdio() when validate: false.
-    // Race a short timeout so the test does not hang waiting for stdio transport.
     const result = await Promise.race([
       blaze(app, { validate: false }).then(() => 'resolved' as const),
       // oxlint-disable-next-line avoid-new -- Promise constructor needed for setTimeout-based timeout
@@ -82,7 +80,6 @@ describe('blaze', () => {
         }, 50);
       }),
     ]);
-    // Either outcome confirms validation did not throw.
     expect(['resolved', 'timeout']).toContain(result);
   });
 


### PR DESCRIPTION
## Summary

- All three \`blaze()\` functions now call \`validateTopo()\` at startup
- Catches broken follow references, self-follows, follow cycles, invalid example inputs, missing output schemas, and broken event origins before the app goes live
- Previously these issues were only caught at runtime or by explicitly calling \`validateTopo()\`

## Changes

- \`packages/cli/src/commander/blaze.ts\` — \`assertValidTopo()\` helper + call at top of \`blaze()\`
- \`packages/mcp/src/blaze.ts\` — inline validation guard at top of \`blaze()\`
- \`packages/http/src/hono/blaze.ts\` — \`assertValidTopo()\` helper + call at top of \`blaze()\`
- 3 test files — \`blaze throws on invalid topo\` test added to each surface

## Test plan

- [ ] CLI blaze throws on broken follow reference
- [ ] MCP blaze throws on broken follow reference
- [ ] HTTP blaze throws on broken follow reference
- [ ] All existing tests pass unchanged