### PR TITLE
fix(core,http,schema,testing): codex review sweep — 5 bug fixes

### DIFF
--- a/packages/core/src/__tests__/validation.test.ts
+++ b/packages/core/src/__tests__/validation.test.ts
@@ -280,4 +280,36 @@ describe('zodToJsonSchema', () => {
       expect(zodToJsonSchema(z.any())).toEqual({});
     });
   });
+
+  describe('default values', () => {
+    test('preserves static defaults as-is', () => {
+      const schema = z.string().default('hello');
+      expect(zodToJsonSchema(schema)).toEqual({
+        default: 'hello',
+        type: 'string',
+      });
+    });
+
+    test('memoizes functional defaults for deterministic output', () => {
+      let counter = 0;
+      const schema = z.string().default(() => {
+        counter += 1;
+        return `id-${counter}`;
+      });
+      const first = zodToJsonSchema(schema);
+      const second = zodToJsonSchema(schema);
+      // Both calls return the same memoized value
+      expect(first).toEqual(second);
+      // The default was evaluated exactly once (counter incremented once)
+      expect(first['default']).toBe('id-1');
+      expect(counter).toBe(1);
+    });
+
+    test('produces identical output across calls for functional defaults', () => {
+      const schema = z.string().default(() => `id-${Date.now()}`);
+      const first = zodToJsonSchema(schema);
+      const second = zodToJsonSchema(schema);
+      expect(first).toEqual(second);
+    });
+  });
 });

--- a/packages/core/src/__tests__/validation.test.ts
+++ b/packages/core/src/__tests__/validation.test.ts
@@ -307,12 +307,16 @@ describe('zodToJsonSchema', () => {
       expect(result).toEqual({ default: 'constant', type: 'string' });
     });
 
-    test('produces identical output across calls for dynamic defaults', () => {
-      const schema = z.string().default(() => `id-${Date.now()}`);
+    test('produces identical output across repeated calls', () => {
+      let counter = 0;
+      const schema = z.string().default(() => {
+        counter += 1;
+        return `id-${counter}`;
+      });
       const first = zodToJsonSchema(schema);
       const second = zodToJsonSchema(schema);
+      // Key invariant: repeated calls always produce the same schema
       expect(first).toEqual(second);
-      expect(first['default']).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/__tests__/validation.test.ts
+++ b/packages/core/src/__tests__/validation.test.ts
@@ -307,6 +307,20 @@ describe('zodToJsonSchema', () => {
       expect(result).toEqual({ default: 'constant', type: 'string' });
     });
 
+    test('preserves stable functional defaults that return equivalent objects', () => {
+      const schema = z
+        .object({ key: z.string() })
+        .default(() => ({ key: 'val' }));
+      const result = zodToJsonSchema(schema);
+      expect(result['default']).toEqual({ key: 'val' });
+    });
+
+    test('preserves stable functional defaults that return equivalent arrays', () => {
+      const schema = z.array(z.string()).default(() => ['a', 'b']);
+      const result = zodToJsonSchema(schema);
+      expect(result['default']).toEqual(['a', 'b']);
+    });
+
     test('produces identical output across repeated calls', () => {
       let counter = 0;
       const schema = z.string().default(() => {

--- a/packages/core/src/__tests__/validation.test.ts
+++ b/packages/core/src/__tests__/validation.test.ts
@@ -290,26 +290,29 @@ describe('zodToJsonSchema', () => {
       });
     });
 
-    test('memoizes functional defaults for deterministic output', () => {
+    test('omits dynamic defaults that produce different values', () => {
       let counter = 0;
       const schema = z.string().default(() => {
         counter += 1;
         return `id-${counter}`;
       });
-      const first = zodToJsonSchema(schema);
-      const second = zodToJsonSchema(schema);
-      // Both calls return the same memoized value
-      expect(first).toEqual(second);
-      // The default was evaluated exactly once (counter incremented once)
-      expect(first['default']).toBe('id-1');
-      expect(counter).toBe(1);
+      const result = zodToJsonSchema(schema);
+      expect(result).toEqual({ type: 'string' });
+      expect(result['default']).toBeUndefined();
     });
 
-    test('produces identical output across calls for functional defaults', () => {
+    test('preserves stable functional defaults that return constant values', () => {
+      const schema = z.string().default(() => 'constant');
+      const result = zodToJsonSchema(schema);
+      expect(result).toEqual({ default: 'constant', type: 'string' });
+    });
+
+    test('produces identical output across calls for dynamic defaults', () => {
       const schema = z.string().default(() => `id-${Date.now()}`);
       const first = zodToJsonSchema(schema);
       const second = zodToJsonSchema(schema);
       expect(first).toEqual(second);
+      expect(first['default']).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -104,13 +104,20 @@ export const validateOutput = <T>(
 const DYNAMIC_DEFAULT = Symbol('DYNAMIC_DEFAULT');
 const defaultValueCache = new WeakMap<object, unknown>();
 
-/** Read a Zod v4 default getter twice and decide if it's stable. */
+/** Read a Zod v4 default getter twice and decide if it's stable.
+ *  Uses Object.is for primitives and JSON.stringify for objects/arrays. */
 const resolveDefault = (def: Record<string, unknown>): unknown => {
   try {
     const a = def['defaultValue'];
     const b = def['defaultValue'];
-    return Object.is(a, b) ? a : DYNAMIC_DEFAULT;
+    if (Object.is(a, b)) {
+      return a;
+    }
+    // Object/array defaults produce new references each call but may
+    // still be structurally identical (e.g. `() => ({ key: 'val' })`).
+    return JSON.stringify(a) === JSON.stringify(b) ? a : DYNAMIC_DEFAULT;
   } catch {
+    // BigInt, circular refs, or other non-serializable defaults
     return DYNAMIC_DEFAULT;
   }
 };

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -151,10 +151,21 @@ export const zodToJsonSchema: JsonSchemaConverter = (
     default: (value) => {
       const inner = value._zod.def['innerType'] as unknown as z.ZodType;
       const innerSchema = zodToJsonSchema(inner);
+      // Zod v4 wraps all defaults in a getter. For dynamic defaults
+      // (functions that return new values each call), two accesses
+      // produce different results. Omit those to keep schemas stable.
       if (!defaultValueCache.has(value._zod.def)) {
-        defaultValueCache.set(value._zod.def, value._zod.def['defaultValue']);
+        const first = value._zod.def['defaultValue'];
+        const second = value._zod.def['defaultValue'];
+        defaultValueCache.set(
+          value._zod.def,
+          JSON.stringify(first) === JSON.stringify(second) ? first : undefined
+        );
       }
-      innerSchema['default'] = defaultValueCache.get(value._zod.def);
+      const cached = defaultValueCache.get(value._zod.def);
+      if (cached !== undefined) {
+        innerSchema['default'] = cached;
+      }
       return innerSchema;
     },
     enum: (value) => {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -95,13 +95,25 @@ export const validateOutput = <T>(
 // ---------------------------------------------------------------------------
 
 /**
- * Memoizes Zod default values per schema instance. Zod v4 wraps `defaultValue`
- * in a getter that re-evaluates function defaults on every access, which makes
- * repeated `zodToJsonSchema` calls nondeterministic for schemas like
- * `z.string().default(() => Bun.randomUUIDv7())`. Reading the value once and
- * caching it here keeps schema exports stable.
+ * Sentinel indicating a dynamic default that should be omitted from schema
+ * exports. Zod v4 wraps all defaults in getters; dynamic ones (functions)
+ * produce new values on each access. We detect this by reading the getter
+ * twice and comparing with `Object.is`. If values differ, the default is
+ * dynamic and we cache this sentinel to skip it in future calls.
  */
+const DYNAMIC_DEFAULT = Symbol('DYNAMIC_DEFAULT');
 const defaultValueCache = new WeakMap<object, unknown>();
+
+/** Read a Zod v4 default getter twice and decide if it's stable. */
+const resolveDefault = (def: Record<string, unknown>): unknown => {
+  try {
+    const a = def['defaultValue'];
+    const b = def['defaultValue'];
+    return Object.is(a, b) ? a : DYNAMIC_DEFAULT;
+  } catch {
+    return DYNAMIC_DEFAULT;
+  }
+};
 
 /**
  * Convert common Zod types to a JSON Schema object.
@@ -151,19 +163,11 @@ export const zodToJsonSchema: JsonSchemaConverter = (
     default: (value) => {
       const inner = value._zod.def['innerType'] as unknown as z.ZodType;
       const innerSchema = zodToJsonSchema(inner);
-      // Zod v4 wraps all defaults in a getter. For dynamic defaults
-      // (functions that return new values each call), two accesses
-      // produce different results. Omit those to keep schemas stable.
       if (!defaultValueCache.has(value._zod.def)) {
-        const first = value._zod.def['defaultValue'];
-        const second = value._zod.def['defaultValue'];
-        defaultValueCache.set(
-          value._zod.def,
-          JSON.stringify(first) === JSON.stringify(second) ? first : undefined
-        );
+        defaultValueCache.set(value._zod.def, resolveDefault(value._zod.def));
       }
       const cached = defaultValueCache.get(value._zod.def);
-      if (cached !== undefined) {
+      if (cached !== DYNAMIC_DEFAULT) {
         innerSchema['default'] = cached;
       }
       return innerSchema;

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -95,6 +95,15 @@ export const validateOutput = <T>(
 // ---------------------------------------------------------------------------
 
 /**
+ * Memoizes Zod default values per schema instance. Zod v4 wraps `defaultValue`
+ * in a getter that re-evaluates function defaults on every access, which makes
+ * repeated `zodToJsonSchema` calls nondeterministic for schemas like
+ * `z.string().default(() => Bun.randomUUIDv7())`. Reading the value once and
+ * caching it here keeps schema exports stable.
+ */
+const defaultValueCache = new WeakMap<object, unknown>();
+
+/**
  * Convert common Zod types to a JSON Schema object.
  *
  * Uses Zod v4's `_zod.def` and `_zod.traits` for introspection.
@@ -142,9 +151,10 @@ export const zodToJsonSchema: JsonSchemaConverter = (
     default: (value) => {
       const inner = value._zod.def['innerType'] as unknown as z.ZodType;
       const innerSchema = zodToJsonSchema(inner);
-      const rawDefault = value._zod.def['defaultValue'];
-      innerSchema['default'] =
-        typeof rawDefault === 'function' ? rawDefault() : rawDefault;
+      if (!defaultValueCache.has(value._zod.def)) {
+        defaultValueCache.set(value._zod.def, value._zod.def['defaultValue']);
+      }
+      innerSchema['default'] = defaultValueCache.get(value._zod.def);
       return innerSchema;
     },
     enum: (value) => {

--- a/packages/http/src/hono/__tests__/blaze.test.ts
+++ b/packages/http/src/hono/__tests__/blaze.test.ts
@@ -333,6 +333,57 @@ describe('blaze (Hono adapter)', () => {
       const json = await res.json();
       expect(json.data.tags).toEqual(['a', 'b']);
     });
+
+    test('single value is wrapped in array when schema expects z.array()', async () => {
+      const tagsTrail = trail('tags.single', {
+        input: z.object({ tags: z.array(z.string()) }),
+        intent: 'read',
+        run: (input) => Result.ok({ tags: input.tags }),
+      });
+
+      const app = topo('testapp', { tagsTrail });
+      const hono = await blaze(app, { serve: false });
+
+      const res = await request(hono, 'GET', '/tags/single?tags=foo');
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json.data.tags).toEqual(['foo']);
+    });
+
+    test('single value stays scalar when schema expects a string', async () => {
+      const nameTrail = trail('name.check', {
+        input: z.object({ name: z.string() }),
+        intent: 'read',
+        run: (input) => Result.ok({ name: input.name }),
+      });
+
+      const app = topo('testapp', { nameTrail });
+      const hono = await blaze(app, { serve: false });
+
+      const res = await request(hono, 'GET', '/name/check?name=bar');
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json.data.name).toBe('bar');
+    });
+
+    test('optional array field with single value is wrapped in array', async () => {
+      const optArrayTrail = trail('opt.array', {
+        input: z.object({ ids: z.array(z.string()).optional() }),
+        intent: 'read',
+        run: (input) => Result.ok({ ids: input.ids }),
+      });
+
+      const app = topo('testapp', { optArrayTrail });
+      const hono = await blaze(app, { serve: false });
+
+      const res = await request(hono, 'GET', '/opt/array?ids=one');
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json.data.ids).toEqual(['one']);
+    });
   });
 
   describe('AbortSignal', () => {

--- a/packages/http/src/hono/blaze.ts
+++ b/packages/http/src/hono/blaze.ts
@@ -15,6 +15,7 @@ import type { Layer, Topo, TrailContext } from '@ontrails/core';
 import { Hono } from 'hono';
 import type { Context as HonoContext } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
+import type { z } from 'zod';
 
 import type { HttpMethod, HttpRouteDefinition } from '../build.js';
 import { buildHttpRoutes } from '../build.js';
@@ -42,10 +43,64 @@ export interface BlazeHttpOptions {
 // Request parsing
 // ---------------------------------------------------------------------------
 
+/**
+ * Build a set of field names that the input schema expects as arrays.
+ *
+ * Inspects the Zod v4 `_zod.def` internals to find top-level array fields.
+ * Returns an empty set when the schema is not an object or cannot be inspected.
+ */
+interface ZodDef {
+  _zod: { def: Record<string, unknown> };
+}
+
+/** Unwrap optional/default wrappers to reach the underlying Zod type name. */
+const unwrapZodType = (node: ZodDef): string => {
+  let current = node;
+  while (
+    (current._zod.def['type'] as string) === 'optional' ||
+    (current._zod.def['type'] as string) === 'default'
+  ) {
+    current = current._zod.def['innerType'] as ZodDef;
+  }
+  return current._zod.def['type'] as string;
+};
+
+/** Extract the object shape from a Zod schema, or undefined if not an object. */
+const extractShape = (
+  schema: z.ZodType
+): Record<string, ZodDef> | undefined => {
+  const s = schema as unknown as ZodDef;
+  if ((s._zod.def['type'] as string) !== 'object') {
+    return undefined;
+  }
+  return s._zod.def['shape'] as Record<string, ZodDef> | undefined;
+};
+
+/** Collect top-level field names whose underlying type is array. */
+const collectArrayKeys = (
+  inputSchema: z.ZodType | undefined
+): ReadonlySet<string> => {
+  const shape = inputSchema ? extractShape(inputSchema) : undefined;
+  if (!shape) {
+    return new Set();
+  }
+  const keys = new Set<string>();
+  for (const [key, value] of Object.entries(shape)) {
+    if (unwrapZodType(value) === 'array') {
+      keys.add(key);
+    }
+  }
+  return keys;
+};
+
 /** Parse query params into a plain object, preserving raw strings for Zod. */
-const parseQueryParams = (c: HonoContext): Record<string, unknown> => {
+const parseQueryParams = (
+  c: HonoContext,
+  inputSchema?: z.ZodType | undefined
+): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
   const url = new URL(c.req.url);
+  const arrayKeys = collectArrayKeys(inputSchema);
 
   for (const key of url.searchParams.keys()) {
     // Already collected via getAll
@@ -53,7 +108,7 @@ const parseQueryParams = (c: HonoContext): Record<string, unknown> => {
       continue;
     }
     const all = url.searchParams.getAll(key);
-    result[key] = all.length > 1 ? all : all[0];
+    result[key] = all.length > 1 || arrayKeys.has(key) ? all : all[0];
   }
 
   return result;
@@ -75,10 +130,11 @@ const isEmptyBody = (c: HonoContext): boolean => {
 /** Read input from request based on input source. */
 const readInput = async (
   c: HonoContext,
-  inputSource: 'query' | 'body'
+  inputSource: 'query' | 'body',
+  inputSchema?: z.ZodType | undefined
 ): Promise<unknown> => {
   if (inputSource === 'query') {
-    return parseQueryParams(c);
+    return parseQueryParams(c, inputSchema);
   }
   if (isEmptyBody(c)) {
     return {};
@@ -151,7 +207,7 @@ const handleCaughtError = (error: unknown, c: HonoContext): Response => {
 const createHonoHandler =
   (route: HttpRouteDefinition) =>
   async (c: HonoContext): Promise<Response> => {
-    const rawInput = await readInput(c, route.inputSource);
+    const rawInput = await readInput(c, route.inputSource, route.trail.input);
 
     if (rawInput === JSON_PARSE_ERROR) {
       return c.json(

--- a/packages/schema/src/__tests__/openapi.test.ts
+++ b/packages/schema/src/__tests__/openapi.test.ts
@@ -181,6 +181,42 @@ describe('generateOpenApiSpec', () => {
       const content = body['content'] as Record<string, unknown>;
       expect(content['application/json']).toBeDefined();
     });
+
+    test('requestBody required is false when all input fields are optional', () => {
+      const t = trail('entity.update', {
+        input: z.object({
+          name: z.string().optional(),
+          tag: z.string().optional(),
+        }),
+        run: noop,
+      });
+      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const op = spec.paths['/entity/update']?.['post'] as Record<
+        string,
+        unknown
+      >;
+      const body = op['requestBody'] as Record<string, unknown>;
+
+      expect(body['required']).toBe(false);
+    });
+
+    test('requestBody required is true when input has required fields', () => {
+      const t = trail('entity.create', {
+        input: z.object({
+          name: z.string(),
+          tag: z.string().optional(),
+        }),
+        run: noop,
+      });
+      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const op = spec.paths['/entity/create']?.['post'] as Record<
+        string,
+        unknown
+      >;
+      const body = op['requestBody'] as Record<string, unknown>;
+
+      expect(body['required']).toBe(true);
+    });
   });
 
   describe('responses', () => {

--- a/packages/schema/src/openapi.ts
+++ b/packages/schema/src/openapi.ts
@@ -152,6 +152,11 @@ const errorResponsesFromExamples = (
 // Operation builder — split into focused helpers
 // ---------------------------------------------------------------------------
 
+/** True when the JSON Schema has at least one required property. */
+const schemaHasRequiredFields = (schema: JsonSchema): boolean =>
+  Array.isArray(schema['required']) &&
+  (schema['required'] as unknown[]).length > 0;
+
 /** Build the input portion of an operation (parameters or requestBody). */
 const buildInputSpec = (
   t: Trail<unknown, unknown>,
@@ -177,7 +182,7 @@ const buildInputSpec = (
   return {
     requestBody: {
       content: { 'application/json': { schema: inputSchema } },
-      required: true,
+      required: schemaHasRequiredFields(inputSchema),
     },
   };
 };

--- a/packages/schema/src/openapi.ts
+++ b/packages/schema/src/openapi.ts
@@ -152,10 +152,17 @@ const errorResponsesFromExamples = (
 // Operation builder — split into focused helpers
 // ---------------------------------------------------------------------------
 
-/** True when the JSON Schema has at least one required property. */
-const schemaHasRequiredFields = (schema: JsonSchema): boolean =>
-  Array.isArray(schema['required']) &&
-  (schema['required'] as unknown[]).length > 0;
+/** True when the body is required — non-object schemas are always required,
+ *  object schemas are required only when they have at least one required property. */
+const isBodyRequired = (schema: JsonSchema): boolean => {
+  if (schema['type'] !== 'object') {
+    return true;
+  }
+  return (
+    Array.isArray(schema['required']) &&
+    (schema['required'] as unknown[]).length > 0
+  );
+};
 
 /** Build the input portion of an operation (parameters or requestBody). */
 const buildInputSpec = (
@@ -182,7 +189,7 @@ const buildInputSpec = (
   return {
     requestBody: {
       content: { 'application/json': { schema: inputSchema } },
-      required: schemaHasRequiredFields(inputSchema),
+      required: isBodyRequired(inputSchema),
     },
   };
 };

--- a/packages/testing/src/__tests__/examples.test.ts
+++ b/packages/testing/src/__tests__/examples.test.ts
@@ -173,3 +173,69 @@ describe('testExamples follow coverage for composition trails', () => {
     } as Record<string, unknown>)
   );
 });
+
+// ---------------------------------------------------------------------------
+// Nested follow chain: A → B → C
+// ---------------------------------------------------------------------------
+
+const leafTrail = trail('step.leaf', {
+  description: 'Leaf trail in a nested chain',
+  input: z.object({ value: z.string() }),
+  output: z.object({ leaf: z.string() }),
+  run: (input: { value: string }) => Result.ok({ leaf: input.value }),
+});
+
+const middleTrail = trail('step.middle', {
+  description: 'Middle trail that follows the leaf',
+  follow: ['step.leaf'],
+  input: z.object({ value: z.string() }),
+  output: z.object({ middle: z.string() }),
+  run: async (input: { value: string }, ctx) => {
+    if (!ctx.follow) {
+      return Result.err(new Error('follow not available'));
+    }
+    const leafResult = await ctx.follow<{ leaf: string }>('step.leaf', input);
+    if (leafResult.isErr()) {
+      return leafResult;
+    }
+    return Result.ok({ middle: leafResult.value.leaf });
+  },
+});
+
+const rootTrail = trail('step.root', {
+  description: 'Root trail that follows the middle trail',
+  examples: [
+    {
+      expected: { root: 'hello' },
+      input: { value: 'hello' },
+      name: 'Nested follow chain A→B→C',
+    },
+  ],
+  follow: ['step.middle'],
+  input: z.object({ value: z.string() }),
+  output: z.object({ root: z.string() }),
+  run: async (input: { value: string }, ctx) => {
+    if (!ctx.follow) {
+      return Result.err(new Error('follow not available'));
+    }
+    const midResult = await ctx.follow<{ middle: string }>(
+      'step.middle',
+      input
+    );
+    if (midResult.isErr()) {
+      return midResult;
+    }
+    return Result.ok({ root: midResult.value.middle });
+  },
+});
+
+describe('testExamples nested follow chain (A → B → C)', () => {
+  // eslint-disable-next-line jest/require-hook
+  testExamples(
+    topo('nested-chain-app', {
+      leafTrail,
+      middleTrail,
+      rootTrail,
+    } as Record<string, unknown>)
+  );
+});

--- a/packages/testing/src/__tests__/follows.test.ts
+++ b/packages/testing/src/__tests__/follows.test.ts
@@ -161,3 +161,72 @@ describe('testFollows: expectValue', () => {
     opts
   );
 });
+
+// ---------------------------------------------------------------------------
+// Nested follow chain: A → B → C
+// ---------------------------------------------------------------------------
+
+const leafTrail = trail('step.leaf', {
+  description: 'Leaf trail in a nested chain',
+  input: z.object({ value: z.string() }),
+  output: z.object({ leaf: z.string() }),
+  run: (input: { value: string }) => Result.ok({ leaf: input.value }),
+});
+
+const middleTrail = trail('step.middle', {
+  description: 'Middle trail that follows the leaf',
+  follow: ['step.leaf'],
+  input: z.object({ value: z.string() }),
+  output: z.object({ middle: z.string() }),
+  run: async (input: { value: string }, ctx: TrailContext) => {
+    if (!ctx.follow) {
+      return Result.err(new Error('follow not available'));
+    }
+    const leafResult = await ctx.follow<{ leaf: string }>('step.leaf', input);
+    if (leafResult.isErr()) {
+      return leafResult;
+    }
+    return Result.ok({ middle: leafResult.value.leaf });
+  },
+});
+
+const nestedRootTrail = trail('step.root', {
+  description: 'Root trail that follows the middle trail',
+  follow: ['step.middle'],
+  input: z.object({ value: z.string() }),
+  output: z.object({ root: z.string() }),
+  run: async (input: { value: string }, ctx: TrailContext) => {
+    if (!ctx.follow) {
+      return Result.err(new Error('follow not available'));
+    }
+    const midResult = await ctx.follow<{ middle: string }>(
+      'step.middle',
+      input
+    );
+    if (midResult.isErr()) {
+      return midResult;
+    }
+    return Result.ok({ root: midResult.value.middle });
+  },
+});
+
+const nestedTrailsMap = new Map<string, AnyTrail>([
+  ['step.leaf', leafTrail],
+  ['step.middle', middleTrail],
+]);
+
+describe('testFollows: nested follow chain (A → B → C)', () => {
+  // eslint-disable-next-line jest/require-hook
+  testFollows(
+    nestedRootTrail,
+    [
+      {
+        description: 'nested ctx.follow works through A → B → C',
+        expectOk: true,
+        expectValue: { root: 'hello' },
+        input: { value: 'hello' },
+      },
+    ],
+    { trails: nestedTrailsMap }
+  );
+});

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -171,7 +171,7 @@ const createCoverageFollow = (
       if (validated.isErr()) {
         return Promise.resolve(validated);
       }
-      return Promise.resolve(trailDef.run(validated.value, ctx));
+      return Promise.resolve(trailDef.run(validated.value, { ...ctx, follow }));
     }
 
     return Promise.resolve(Result.ok());

--- a/packages/testing/src/follows.ts
+++ b/packages/testing/src/follows.ts
@@ -90,7 +90,8 @@ const executeFromMap = (
   id: string,
   input: unknown,
   trailsMap: ReadonlyMap<string, AnyTrail> | undefined,
-  ctx: TrailContext
+  ctx: TrailContext,
+  follow?: FollowFn
 ): Result<unknown, Error> | Promise<Result<unknown, Error>> | undefined => {
   const trailDef = trailsMap?.get(id);
   if (trailDef === undefined) {
@@ -101,7 +102,8 @@ const executeFromMap = (
   if (validated.isErr()) {
     return validated;
   }
-  return trailDef.run(validated.value, ctx);
+  const nestedCtx = follow ? { ...ctx, follow } : ctx;
+  return trailDef.run(validated.value, nestedCtx);
 };
 
 // ---------------------------------------------------------------------------
@@ -132,7 +134,13 @@ const createRecordingFollow = (
       return baseFollow(id, input);
     }
 
-    const executed = executeFromMap(id, input, trailsMap, ctx);
+    const executed = executeFromMap(
+      id,
+      input,
+      trailsMap,
+      ctx,
+      follow as FollowFn
+    );
     if (executed !== undefined) {
       return Promise.resolve(executed);
     }


### PR DESCRIPTION
## Summary

Bug fixes surfaced through 3 rounds of Codex code review, covering correctness issues across core, HTTP, schema, and testing packages.

**P1 — Fixed:**
- **Nondeterministic schema export from functional defaults** — `zodToJsonSchema` now detects dynamic defaults via `Object.is` comparison and omits them from exported schemas. Static functional defaults (constant return values) are preserved. Handles BigInt and other non-serializable types safely.

**P2 — Fixed:**
- **Single query values rejected for array fields** — `?tags=foo` now correctly becomes `["foo"]` when the input schema expects `z.array()`. The Hono adapter inspects the Zod schema shape at parse time.
- **OpenAPI always marked request bodies as required** — Object schemas with all-optional fields now produce `required: false`. Non-object schemas (z.string, z.array) remain `required: true`.
- **Nested follow context missing in test helpers** — `testExamples` and `testFollows` now propagate the recording follow wrapper through A→B→C chains, so nested `ctx.follow()` calls work correctly.

**P3 — Deferred:**
- Defaulted object schemas not unwrapped in array key detection (rare edge case)

## Test plan

- [x] All existing tests pass
- [x] New tests for each fix (validation defaults, query array wrapping, OpenAPI body required, nested follow chains)
- [x] Full lint, typecheck, format clean
- [x] 3 rounds of Codex review — only P3s remaining