### PR TITLE
feat(core): add service factory helpers

### DIFF
--- a/packages/core/src/__tests__/service.test.ts
+++ b/packages/core/src/__tests__/service.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, test } from 'bun:test';
 import { z } from 'zod';
 
-import { Result } from '../index.js';
-import type { Service, ServiceContext, ServiceSpec } from '../index.js';
+import {
+  Result,
+  createTrailContext,
+  findDuplicateServiceId,
+  isService,
+  service as defineService,
+} from '../index.js';
+import type {
+  Service,
+  ServiceContext,
+  ServiceSpec,
+  TrailContext,
+} from '../index.js';
 
 const serviceCtx: ServiceContext = {
   cwd: '/tmp/trails',
@@ -22,6 +33,13 @@ const counterServiceSpec: ServiceSpec<number> = {
   metadata: { domain: 'data' },
   mock: () => 1,
 };
+
+const resolvedServiceCtx = (id: string, instance: unknown): TrailContext =>
+  createTrailContext({
+    extensions: { [id]: instance },
+    requestId: `${id}-request`,
+    signal: new AbortController().signal,
+  });
 
 describe('service types', () => {
   test('ServiceContext exposes the stable process-scoped fields', () => {
@@ -94,5 +112,83 @@ describe('service types', () => {
     expect(created.isOk()).toBe(true);
     expect(created.unwrap()).toBe(3);
     expect(await service.mock?.()).toBe(1);
+  });
+});
+
+describe('service()', () => {
+  test('returns a frozen service object with kind and id', () => {
+    const counter = defineService('counter.main', counterServiceSpec);
+
+    expect(counter.kind).toBe('service');
+    expect(counter.id).toBe('counter.main');
+    expect(Object.isFrozen(counter)).toBe(true);
+  });
+
+  test('infers the service type through from(ctx)', () => {
+    const db = defineService('db.main', {
+      create: () =>
+        Result.ok({
+          query(sql: string) {
+            return sql.length;
+          },
+        }),
+      description: 'Typed database service',
+    });
+
+    const store = {
+      query(sql: string) {
+        return sql.length;
+      },
+    };
+    const ctx = resolvedServiceCtx('db.main', store);
+
+    const resolved = db.from(ctx);
+    expect(resolved.query('select 1')).toBe(8);
+  });
+
+  test('from(ctx) throws when the service is missing', () => {
+    const counter = defineService('counter.main', counterServiceSpec);
+    const ctx = createTrailContext({
+      requestId: 'missing-service',
+      signal: new AbortController().signal,
+    });
+
+    expect(() => counter.from(ctx)).toThrow(
+      'Service "counter.main" not found in trail context'
+    );
+  });
+
+  test('from(ctx) returns undefined when the service key exists with an undefined value', () => {
+    const optional = defineService<undefined>('optional.main', {
+      create: () => Result.ok<undefined>(),
+    });
+    const ctx = createTrailContext({
+      extensions: { [optional.id]: undefined },
+      requestId: 'undefined-service',
+      signal: new AbortController().signal,
+    });
+
+    expect(optional.from(ctx)).toBeUndefined();
+  });
+});
+
+describe('service helpers', () => {
+  test('isService identifies service definitions', () => {
+    const counter = defineService('counter.main', counterServiceSpec);
+
+    expect(isService(counter)).toBe(true);
+    expect(isService({ id: 'counter.main', kind: 'trail' })).toBe(false);
+    expect(isService(null)).toBe(false);
+  });
+
+  test('findDuplicateServiceId returns the first repeated ID', () => {
+    const first = defineService('counter.main', counterServiceSpec);
+    const duplicate = defineService('counter.main', counterServiceSpec);
+    const other = defineService('counter.secondary', counterServiceSpec);
+
+    expect(findDuplicateServiceId([first, other])).toBeUndefined();
+    expect(findDuplicateServiceId([first, other, duplicate])).toBe(
+      'counter.main'
+    );
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export type {
 export { createTrailContext } from './context.js';
 
 // Service
+export { findDuplicateServiceId, isService, service } from './service.js';
 export type {
   AnyService,
   Service,

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from './errors.js';
 import type { Result } from './result.js';
 import type { TrailContext } from './types.js';
 import type { z } from 'zod';
@@ -46,6 +47,8 @@ export interface ServiceSpec<T> {
 export interface Service<T> extends ServiceSpec<T> {
   readonly kind: 'service';
   readonly id: string;
+  /** Read the resolved service instance from a trail context. */
+  from(ctx: TrailContext): T;
 }
 
 /**
@@ -56,3 +59,53 @@ export interface Service<T> extends ServiceSpec<T> {
  */
 // oxlint-disable-next-line no-explicit-any -- existential type for heterogeneous service collections
 export type AnyService = Service<any>;
+
+const getServiceInstance = (ctx: TrailContext, id: string): unknown =>
+  ctx.extensions?.[id];
+
+/**
+ * Create a typed service definition.
+ *
+ * The service object is inert until a later execution branch resolves concrete
+ * instances into TrailContext extensions.
+ */
+export const service = <T>(id: string, spec: ServiceSpec<T>): Service<T> =>
+  Object.freeze({
+    ...spec,
+    from(ctx: TrailContext): T {
+      if (!Object.hasOwn(ctx.extensions ?? {}, id)) {
+        throw new NotFoundError(`Service "${id}" not found in trail context`);
+      }
+      return getServiceInstance(ctx, id) as T;
+    },
+    id,
+    kind: 'service' as const,
+  });
+
+/** Narrow unknown values to service definitions during topo discovery. */
+export const isService = (value: unknown): value is AnyService => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const v = value as { kind?: unknown; id?: unknown };
+  return v.kind === 'service' && typeof v.id === 'string';
+};
+
+/**
+ * Return the first duplicate service ID in a collection, if any.
+ *
+ * This supports later topo registration without each caller duplicating the
+ * same scan logic.
+ */
+export const findDuplicateServiceId = (
+  services: readonly Pick<AnyService, 'id'>[]
+): string | undefined => {
+  const seen = new Set<string>();
+  for (const candidate of services) {
+    if (seen.has(candidate.id)) {
+      return candidate.id;
+    }
+    seen.add(candidate.id);
+  }
+  return undefined;
+};


### PR DESCRIPTION
## Context
This PR builds the service factory layer on top of the base types so apps can define concrete services with a stable creation API and type-safe access from trail context.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Expanded the core `service()` helper behavior used to define concrete services.
- Added inference and metadata coverage for factory-defined services.
- Exported the factory primitive for the downstream topo and trail wiring work.

## How To Test
- `bun test packages/core/src/__tests__/service.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-74
