### PR TITLE
feat(core): register services in topo

### DIFF
--- a/packages/core/src/__tests__/topo.test.ts
+++ b/packages/core/src/__tests__/topo.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import { ValidationError } from '../errors.js';
 import { Result } from '../result.js';
+import { service } from '../service.js';
 import { topo } from '../topo.js';
 
 // ---------------------------------------------------------------------------
@@ -28,6 +29,12 @@ const mockEvent = (id: string) => ({
   payload: z.object({ payload: z.string() }),
 });
 
+const mockService = (id: string) =>
+  service(id, {
+    create: () => Result.ok({ id }),
+    description: `${id} service`,
+  });
+
 // ---------------------------------------------------------------------------
 // topo()
 // ---------------------------------------------------------------------------
@@ -50,6 +57,7 @@ describe('topo', () => {
     test('auto-scans exports by kind discriminant', () => {
       const mod = {
         event1: mockEvent('e1'),
+        service1: mockService('s1'),
         trail1: mockTrail('t1'),
         trail2: mockTrail('t2', ['t1']),
       };
@@ -57,6 +65,7 @@ describe('topo', () => {
 
       expect(t.trails.size).toBe(2);
       expect(t.events.size).toBe(1);
+      expect(t.services.size).toBe(1);
     });
 
     test('collects from multiple modules', () => {
@@ -81,6 +90,7 @@ describe('topo', () => {
 
       expect(t.trails.size).toBe(1);
       expect(t.events.size).toBe(0);
+      expect(t.services.size).toBe(0);
     });
 
     test('trail with follow registers correctly', () => {
@@ -90,6 +100,14 @@ describe('topo', () => {
       expect(t.trails.size).toBe(1);
       const registered = t.trails.get('trail-1');
       expect(registered?.follow).toEqual(['trail-2']);
+    });
+
+    test('collects services from modules', () => {
+      const mod = { db: mockService('db.main') };
+      const t = topo('app', mod);
+
+      expect(t.services.size).toBe(1);
+      expect(t.services.get('db.main')).toBe(mod.db);
     });
   });
 
@@ -113,6 +131,16 @@ describe('topo', () => {
         'Duplicate event ID: "dup"'
       );
     });
+
+    test('rejects duplicate service IDs', () => {
+      const mod1 = { a: mockService('dup') };
+      const mod2 = { b: mockService('dup') };
+
+      expect(() => topo('app', mod1, mod2)).toThrow(ValidationError);
+      expect(() => topo('app', mod1, mod2)).toThrow(
+        'Duplicate service ID: "dup"'
+      );
+    });
   });
 });
 
@@ -134,10 +162,26 @@ describe('topo accessors', () => {
     expect(app.count).toBe(1);
   });
 
+  test('serviceCount returns number of services', () => {
+    const db = mockService('db.main');
+    const cache = mockService('cache.main');
+    const app = topo('test', { cache, db });
+    expect(app.serviceCount).toBe(2);
+  });
+
   test('empty topo has zero count and empty ids', () => {
     const app = topo('empty');
     expect(app.count).toBe(0);
     expect(app.ids()).toEqual([]);
+    expect(app.serviceCount).toBe(0);
+    expect(app.serviceIds()).toEqual([]);
+  });
+
+  test('serviceIds() returns all service IDs', () => {
+    const db = mockService('db.main');
+    const cache = mockService('cache.main');
+    const app = topo('test', { cache, db });
+    expect(app.serviceIds().toSorted()).toEqual(['cache.main', 'db.main']);
   });
 });
 
@@ -148,6 +192,7 @@ describe('topo accessors', () => {
 describe('Topo', () => {
   const mod = {
     e1: mockEvent('event-1'),
+    s1: mockService('service-1'),
     t1: mockTrail('trail-1'),
     t2: mockTrail('trail-2'),
     t3: mockTrail('trail-3', ['trail-1']),
@@ -188,6 +233,26 @@ describe('Topo', () => {
     });
   });
 
+  describe('getService()', () => {
+    test('retrieves service by ID', () => {
+      expect(app.getService('service-1')).toBe(mod.s1);
+    });
+
+    test('returns undefined for unknown service ID', () => {
+      expect(app.getService('missing-service')).toBeUndefined();
+    });
+  });
+
+  describe('hasService()', () => {
+    test('returns true for known service', () => {
+      expect(app.hasService('service-1')).toBe(true);
+    });
+
+    test('returns false for unknown service', () => {
+      expect(app.hasService('missing-service')).toBe(false);
+    });
+  });
+
   describe('listing', () => {
     test('list() returns all trails (with and without follow)', () => {
       const items = app.list();
@@ -201,6 +266,12 @@ describe('Topo', () => {
       const items = app.listEvents();
       expect(items).toHaveLength(1);
       expect(items).toContain(mod.e1);
+    });
+
+    test('listServices() returns all services', () => {
+      const items = app.listServices();
+      expect(items).toHaveLength(1);
+      expect(items).toContain(mod.s1);
     });
   });
 });

--- a/packages/core/src/topo.ts
+++ b/packages/core/src/topo.ts
@@ -4,6 +4,8 @@
 
 import { ValidationError } from './errors.js';
 import type { AnyEvent } from './event.js';
+import type { AnyService } from './service.js';
+import { isService } from './service.js';
 import type { AnyTrail } from './trail.js';
 
 // ---------------------------------------------------------------------------
@@ -14,19 +16,25 @@ export interface Topo {
   readonly name: string;
   readonly trails: ReadonlyMap<string, AnyTrail>;
   readonly events: ReadonlyMap<string, AnyEvent>;
+  readonly services: ReadonlyMap<string, AnyService>;
   readonly count: number;
+  readonly serviceCount: number;
   get(id: string): AnyTrail | undefined;
+  getService(id: string): AnyService | undefined;
   has(id: string): boolean;
+  hasService(id: string): boolean;
   ids(): string[];
+  serviceIds(): string[];
   list(): AnyTrail[];
   listEvents(): AnyEvent[];
+  listServices(): AnyService[];
 }
 
 // ---------------------------------------------------------------------------
 // Kind discriminant check
 // ---------------------------------------------------------------------------
 
-type Registrable = AnyTrail | AnyEvent;
+type Registrable = AnyTrail | AnyEvent | AnyService;
 
 const isRegistrable = (value: unknown): value is Registrable => {
   if (typeof value !== 'object' || value === null) {
@@ -43,15 +51,22 @@ const isRegistrable = (value: unknown): value is Registrable => {
 const createTopo = (
   name: string,
   trails: ReadonlyMap<string, AnyTrail>,
-  events: ReadonlyMap<string, AnyEvent>
+  events: ReadonlyMap<string, AnyEvent>,
+  services: ReadonlyMap<string, AnyService>
 ): Topo => ({
   count: trails.size,
   events,
   get(id: string): AnyTrail | undefined {
     return trails.get(id);
   },
+  getService(id: string): AnyService | undefined {
+    return services.get(id);
+  },
   has(id: string): boolean {
     return trails.has(id);
+  },
+  hasService(id: string): boolean {
+    return services.has(id);
   },
 
   ids(): string[] {
@@ -65,9 +80,17 @@ const createTopo = (
   listEvents(): AnyEvent[] {
     return [...events.values()];
   },
+  listServices(): AnyService[] {
+    return [...services.values()];
+  },
 
   name,
+  serviceCount: services.size,
+  serviceIds(): string[] {
+    return [...services.keys()];
+  },
 
+  services,
   trails,
 });
 
@@ -79,7 +102,8 @@ const createTopo = (
 const register = (
   value: Registrable,
   trails: Map<string, AnyTrail>,
-  events: Map<string, AnyEvent>
+  events: Map<string, AnyEvent>,
+  services: Map<string, AnyService>
 ): void => {
   const { id } = value as { id: string };
   const registrars: Record<string, () => void> = {
@@ -88,6 +112,12 @@ const register = (
         throw new ValidationError(`Duplicate event ID: "${id}"`);
       }
       events.set(id, value as AnyEvent);
+    },
+    service: () => {
+      if (services.has(id)) {
+        throw new ValidationError(`Duplicate service ID: "${id}"`);
+      }
+      services.set(id, value as AnyService);
     },
     trail: () => {
       if (trails.has(id)) {
@@ -99,20 +129,34 @@ const register = (
   registrars[value.kind]?.();
 };
 
+const registerModuleValues = (
+  mod: Record<string, unknown>,
+  trails: Map<string, AnyTrail>,
+  events: Map<string, AnyEvent>,
+  services: Map<string, AnyService>
+): void => {
+  for (const value of Object.values(mod)) {
+    if (isService(value)) {
+      register(value, trails, events, services);
+      continue;
+    }
+    if (isRegistrable(value)) {
+      register(value, trails, events, services);
+    }
+  }
+};
+
 export const topo = (
   name: string,
   ...modules: Record<string, unknown>[]
 ): Topo => {
   const trails = new Map<string, AnyTrail>();
   const events = new Map<string, AnyEvent>();
+  const services = new Map<string, AnyService>();
 
   for (const mod of modules) {
-    for (const value of Object.values(mod)) {
-      if (isRegistrable(value)) {
-        register(value, trails, events);
-      }
-    }
+    registerModuleValues(mod, trails, events, services);
   }
 
-  return createTopo(name, trails, events);
+  return createTopo(name, trails, events, services);
 };


### PR DESCRIPTION
## Context
Topos need to discover services alongside trails and events so the app model can register them centrally before execution, validation, and introspection build on top.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Taught `topo()` to accept and register declared services.
- Added topo coverage for service discovery and duplicate handling.
- Kept registration incremental so later branches can layer execution and governance on top.

## How To Test
- `bun test packages/core/src/__tests__/topo.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-75
