### PR TITLE
feat(core): add services to trail specs

### DIFF
--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -3,6 +3,7 @@ import { describe, test, expect } from 'bun:test';
 import { z } from 'zod';
 
 import { Result } from '../result';
+import { service } from '../service';
 import { trail } from '../trail';
 import type { TrailContext } from '../types';
 
@@ -10,6 +11,16 @@ const stubCtx: TrailContext = {
   requestId: 'test-123',
   signal: AbortSignal.timeout(5000),
 };
+
+const dbService = service('db.main', {
+  create: () =>
+    Result.ok({
+      query(sql: string) {
+        return sql.length;
+      },
+    }),
+  description: 'Primary database service',
+});
 
 describe('trail()', () => {
   const inputSchema = z.object({ name: z.string() });
@@ -125,6 +136,36 @@ describe('trail()', () => {
     });
   });
 
+  describe('services', () => {
+    test('defaults to empty frozen array when omitted', () => {
+      const minimal = trail('bare', {
+        input: z.object({}),
+        run: () => Result.ok(),
+      });
+      expect(minimal.services).toEqual([]);
+      expect(Object.isFrozen(minimal.services)).toBe(true);
+    });
+
+    test('preserves declared service objects', () => {
+      const withServices = trail('search', {
+        input: z.object({}),
+        run: () => Result.ok(),
+        services: [dbService],
+      });
+      expect(withServices.services).toEqual([dbService]);
+      expect(withServices.services[0]).toBe(dbService);
+    });
+
+    test('services array is frozen', () => {
+      const withServices = trail('search', {
+        input: z.object({}),
+        run: () => Result.ok(),
+        services: [dbService],
+      });
+      expect(Object.isFrozen(withServices.services)).toBe(true);
+    });
+  });
+
   describe('intent and idempotent', () => {
     test('intent defaults to write', () => {
       const minimal = trail('bare', {
@@ -183,10 +224,12 @@ describe('trail()', () => {
         output: outputSchema,
         run: (input: { name: string }, _ctx: TrailContext) =>
           Result.ok({ greeting: `Hi, ${input.name}` }),
+        services: [dbService],
       });
       expect(t.description).toBe('A full trail');
       expect(t.intent).toBe('read');
       expect(t.examples).toHaveLength(1);
+      expect(t.services).toEqual([dbService]);
     });
 
     test('implementation is callable', async () => {

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -2,6 +2,7 @@ import type { z } from 'zod';
 
 import type { FieldOverride } from './derive.js';
 import type { Result } from './result.js';
+import type { AnyService } from './service.js';
 import type { Implementation, TrailContext } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -56,6 +57,8 @@ export interface TrailSpec<I, O> {
   readonly fields?: Readonly<Record<string, FieldOverride>> | undefined;
   /** IDs of downstream trails this trail may invoke via ctx.follow() */
   readonly follow?: readonly string[] | undefined;
+  /** Services this trail may access via service.from(ctx) */
+  readonly services?: readonly AnyService[] | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -68,13 +71,15 @@ export type Intent = 'read' | 'write' | 'destroy';
 /** A fully-defined trail — the unit of work in the Trails system */
 export interface Trail<I, O> extends Omit<
   TrailSpec<I, O>,
-  'run' | 'follow' | 'intent'
+  'run' | 'follow' | 'intent' | 'services'
 > {
   readonly kind: 'trail';
   readonly id: string;
   readonly run: Implementation<I, O>;
   /** IDs of downstream trails this trail may invoke via ctx.follow() (always present, default []) */
   readonly follow: readonly string[];
+  /** Services this trail may access via service.from(ctx) (always present, default []) */
+  readonly services: readonly AnyService[];
   /** What this trail does to the world (always present, default 'write') */
   readonly intent: Intent;
 }
@@ -122,7 +127,13 @@ export function trail<I, O>(
     throw new TypeError('trail() requires a spec when an id is provided');
   }
 
-  const { run, follow: rawFollow, intent: rawIntent, ...spec } = resolved.spec;
+  const {
+    run,
+    follow: rawFollow,
+    intent: rawIntent,
+    services: rawServices,
+    ...spec
+  } = resolved.spec;
 
   return Object.freeze({
     ...spec,
@@ -131,6 +142,7 @@ export function trail<I, O>(
     intent: rawIntent ?? 'write',
     kind: 'trail' as const,
     run: async (input: I, ctx: TrailContext) => await run(input, ctx),
+    services: Object.freeze([...(rawServices ?? [])]),
   });
 }
 


### PR DESCRIPTION
## Context
Trails need an explicit place to declare service dependencies before runtime resolution, test helpers, and governance rules can reason about them.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Added a `services` field to trail definitions and spec typing.
- Covered the declaration behavior in core trail tests.
- Preserved existing trail ergonomics while making service dependencies explicit.

## How To Test
- `bun test packages/core/src/__tests__/trail.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-76
