### PR TITLE
feat(core): add service resolution to executeTrail pipeline

### DIFF
--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -57,6 +57,18 @@ describe('createTrailContext', () => {
     expect(ctx.extensions?.['nested']).toEqual({ key: 'value' });
   });
 
+  test('provides a service accessor backed by extensions', () => {
+    const widget = { id: 'widget-1' };
+    const ctx = createTrailContext({
+      extensions: { 'widget.main': widget },
+    });
+
+    expect(ctx.service('widget.main')).toBe(widget);
+    expect(ctx.service<{ id: string }>({ id: 'widget.main' }).id).toBe(
+      'widget-1'
+    );
+  });
+
   test('each call generates a unique requestId', () => {
     const a = createTrailContext();
     const b = createTrailContext();

--- a/packages/core/src/__tests__/dispatch.test.ts
+++ b/packages/core/src/__tests__/dispatch.test.ts
@@ -9,7 +9,7 @@ import type { Layer } from '../layer';
 import { Result } from '../result';
 import { topo } from '../topo';
 import { trail } from '../trail';
-import type { TrailContext } from '../types';
+import type { TrailContext, TrailContextInit } from '../types';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -124,7 +124,7 @@ describe('dispatch', () => {
       });
 
       const ctxTopo = topo('factory-test', { ctxTrail });
-      const customCtx: TrailContext = {
+      const customCtx: TrailContextInit = {
         cwd: '/custom',
         requestId: 'factory-id',
         signal: new AbortController().signal,

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -8,8 +8,9 @@ import { executeTrail } from '../execute';
 import { createTrailContext } from '../context';
 import type { Layer } from '../layer';
 import { Result } from '../result';
+import { service } from '../service';
 import { trail } from '../trail';
-import type { TrailContext } from '../types';
+import type { TrailContext, TrailContextInit } from '../types';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -33,6 +34,76 @@ const throwingTrail = trail('throws', {
   },
 });
 
+const nextServiceId = (name: string): string =>
+  `test.service.${name}.${Bun.randomUUIDv7()}`;
+
+const createResolvedValueService = (
+  id: string,
+  onCreate: () => void,
+  value: number
+) =>
+  service(id, {
+    create: () => {
+      onCreate();
+      return Result.ok({ value });
+    },
+  });
+
+const createEagerServiceTrail = (
+  id: string,
+  counter: ReturnType<typeof createResolvedValueService>,
+  onRun: (value: number) => void
+) =>
+  trail('service.eager', {
+    input: z.object({}),
+    output: z.object({ total: z.number() }),
+    run: (_input, ctx) => {
+      const fromAccessor = ctx.service<{ value: number }>(id);
+      const fromDefinition = counter.from(ctx);
+      onRun(fromDefinition.value);
+      return Result.ok({ total: fromAccessor.value + 1 });
+    },
+    services: [counter],
+  });
+
+const createServiceProbeLayer = (
+  counter: ReturnType<typeof createResolvedValueService>,
+  onResolve: (value: number) => void
+): Layer => ({
+  name: 'uses-service',
+  wrap(_trail, impl) {
+    return async (input, ctx) => {
+      onResolve(ctx.service<{ value: number }>(counter).value);
+      return await impl(input, ctx);
+    };
+  },
+});
+
+const createSingletonService = (id: string, onCreate: () => number) =>
+  service(id, {
+    create: () => Result.ok({ createdAtCall: onCreate() }),
+  });
+
+const createSingletonTrail = (
+  singleton: ReturnType<typeof createSingletonService>
+) =>
+  trail('service.singleton', {
+    input: z.object({}),
+    output: z.object({ createdAtCall: z.number() }),
+    run: (_input, ctx) =>
+      Result.ok({
+        createdAtCall: singleton.from(ctx).createdAtCall,
+      }),
+    services: [singleton],
+  });
+
+const unwrapExecution = async (
+  target: ReturnType<typeof createSingletonTrail>
+) => {
+  const result = await executeTrail(target, {});
+  return result.unwrap();
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -44,6 +115,112 @@ describe('executeTrail', () => {
 
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toEqual({ value: 'hello' });
+    });
+
+    test('eagerly resolves declared services before layers and implementation run', async () => {
+      const id = nextServiceId('eager');
+      const captures = {
+        createCalls: 0,
+        layerResolved: undefined as number | undefined,
+        runResolved: undefined as number | undefined,
+      };
+      const counter = createResolvedValueService(
+        id,
+        () => {
+          captures.createCalls += 1;
+        },
+        41
+      );
+      const layeredTrail = createEagerServiceTrail(id, counter, (value) => {
+        captures.runResolved = value;
+      });
+      const layer = createServiceProbeLayer(counter, (value) => {
+        captures.layerResolved = value;
+      });
+
+      const result = await executeTrail(layeredTrail, {}, { layers: [layer] });
+
+      expect(result.unwrap()).toEqual({ total: 42 });
+      expect(captures.createCalls).toBe(1);
+      expect(captures.layerResolved).toBe(41);
+      expect(captures.runResolved).toBe(41);
+    });
+
+    test('awaits async service factories before running the trail', async () => {
+      const db = service(nextServiceId('async-factory'), {
+        create: async () => {
+          await Bun.sleep(0);
+          return Result.ok({ source: 'async-factory' });
+        },
+      });
+      const serviceTrail = trail('service.async-factory', {
+        input: z.object({}),
+        output: z.object({ source: z.string() }),
+        run: (_input, ctx) =>
+          Result.ok({ source: db.from(ctx).source as string }),
+        services: [db],
+      });
+
+      const result = await executeTrail(serviceTrail, {});
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ source: 'async-factory' });
+    });
+
+    test('reuses cached singleton services across executions', async () => {
+      const id = nextServiceId('singleton');
+      const captures = { createCalls: 0 };
+      const singleton = createSingletonService(id, () => {
+        captures.createCalls += 1;
+        return captures.createCalls;
+      });
+      const singletonTrail = createSingletonTrail(singleton);
+
+      const outputs = [
+        await unwrapExecution(singletonTrail),
+        await unwrapExecution(singletonTrail),
+      ];
+
+      expect(outputs).toEqual([{ createdAtCall: 1 }, { createdAtCall: 1 }]);
+      expect(captures.createCalls).toBe(1);
+    });
+
+    test('scopes cached singleton services to compatible service contexts', async () => {
+      const id = nextServiceId('singleton-context');
+      const envAwareService = service(id, {
+        create: (ctx) => Result.ok({ value: String(ctx.env?.VAL) }),
+      });
+      const envAwareTrail = trail('service.singleton-context', {
+        input: z.object({}),
+        output: z.object({ value: z.string() }),
+        run: (_input, ctx) =>
+          Result.ok({ value: envAwareService.from(ctx).value }),
+        services: [envAwareService],
+      });
+
+      const first = await executeTrail(
+        envAwareTrail,
+        {},
+        {
+          createContext: () =>
+            createTrailContext({
+              env: { VAL: 'first' },
+            }),
+        }
+      );
+      const second = await executeTrail(
+        envAwareTrail,
+        {},
+        {
+          createContext: () =>
+            createTrailContext({
+              env: { VAL: 'second' },
+            }),
+        }
+      );
+
+      expect(first.unwrap()).toEqual({ value: 'first' });
+      expect(second.unwrap()).toEqual({ value: 'second' });
     });
   });
 
@@ -124,7 +301,7 @@ describe('executeTrail', () => {
         },
       });
 
-      const customCtx: TrailContext = {
+      const customCtx: TrailContextInit = {
         cwd: '/custom',
         requestId: 'factory-id',
         signal: new AbortController().signal,
@@ -146,7 +323,7 @@ describe('executeTrail', () => {
         },
       });
 
-      const baseCtx: TrailContext = {
+      const baseCtx: TrailContextInit = {
         cwd: '/factory',
         requestId: 'factory-id',
         signal: new AbortController().signal,
@@ -186,6 +363,71 @@ describe('executeTrail', () => {
       );
       expect(captured?.extensions).toEqual({ store: 'db', userId: '123' });
     });
+
+    test('rebinds ctx.service after merging extension overrides from createContext', async () => {
+      let resolvedSource: string | undefined;
+      const db = service(nextServiceId('context-override'), {
+        create: () => Result.ok({ source: 'factory' }),
+      });
+      const serviceTrail = trail('ctx.service.override', {
+        input: z.object({}),
+        output: z.object({ source: z.string() }),
+        run: (_input, ctx) => {
+          resolvedSource = ctx.service<{ source: string }>(db).source;
+          return Result.ok({ source: resolvedSource });
+        },
+        services: [db],
+      });
+
+      const result = await executeTrail(
+        serviceTrail,
+        {},
+        {
+          createContext: () =>
+            createTrailContext({
+              extensions: {
+                [db.id]: { source: 'factory-context' },
+              },
+            }),
+          ctx: {
+            extensions: {
+              [db.id]: { source: 'override-context' },
+            },
+          },
+        }
+      );
+
+      expect(result.unwrap()).toEqual({ source: 'override-context' });
+      expect(resolvedSource).toBe('override-context');
+    });
+
+    test('context factory seeds the service accessor when omitted', async () => {
+      let capturedCtx: TrailContext | undefined;
+      const id = nextServiceId('factory-seed');
+      const widget = { id: 'widget-1' };
+      const widgetTrail = trail('service.factory-seed', {
+        input: z.object({}),
+        run: (_input, ctx) => {
+          capturedCtx = ctx;
+          return Result.ok(null);
+        },
+        services: [],
+      });
+
+      await executeTrail(
+        widgetTrail,
+        {},
+        {
+          createContext: () => ({
+            extensions: { [id]: widget },
+            requestId: 'seeded-service',
+            signal: new AbortController().signal,
+          }),
+        }
+      );
+
+      expect(capturedCtx?.service(id)).toBe(widget);
+    });
   });
 
   describe('error handling', () => {
@@ -203,6 +445,79 @@ describe('executeTrail', () => {
       expect(result.isErr()).toBe(true);
       expect(result.error).toBeInstanceOf(InternalError);
       expect(result.error.message).toBe('kaboom');
+    });
+
+    test('short-circuits when a service factory returns Result.err', async () => {
+      const failingService = service(nextServiceId('factory-error'), {
+        create: () =>
+          Result.err(new ValidationError('DATABASE_URL is required')),
+      });
+      let ran = false;
+      const serviceTrail = trail('service.factory-error', {
+        input: z.object({}),
+        run: () => {
+          ran = true;
+          return Result.ok(null);
+        },
+        services: [failingService],
+      });
+
+      const result = await executeTrail(serviceTrail, {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toBe('DATABASE_URL is required');
+      expect(ran).toBe(false);
+    });
+
+    test('wraps thrown service factory exceptions with the service ID in context', async () => {
+      const explodingService = service(nextServiceId('factory-throw'), {
+        create: () => {
+          throw new Error('boom');
+        },
+      });
+      const serviceTrail = trail('service.factory-throw', {
+        input: z.object({}),
+        run: () => Result.ok(null),
+        services: [explodingService],
+      });
+
+      const result = await executeTrail(serviceTrail, {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(InternalError);
+      expect(result.error.message).toContain(explodingService.id);
+      expect(result.error.context).toEqual({ serviceId: explodingService.id });
+    });
+
+    test('prefers explicit service overrides over cached or created instances', async () => {
+      const id = nextServiceId('override');
+      let createCalls = 0;
+      const db = service(id, {
+        create: () => {
+          createCalls += 1;
+          return Result.ok({ source: 'factory' });
+        },
+      });
+      const serviceTrail = trail('service.override', {
+        input: z.object({}),
+        output: z.object({ source: z.string() }),
+        run: (_input, ctx) =>
+          Result.ok({ source: db.from(ctx).source as string }),
+        services: [db],
+      });
+
+      const result = await executeTrail(
+        serviceTrail,
+        {},
+        {
+          services: { [id]: { source: 'override' } },
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ source: 'override' });
+      expect(createCalls).toBe(0);
     });
   });
 });

--- a/packages/core/src/__tests__/layer.test.ts
+++ b/packages/core/src/__tests__/layer.test.ts
@@ -3,16 +3,17 @@ import { describe, test, expect } from 'bun:test';
 
 import { z } from 'zod';
 
+import { createTrailContext } from '../context';
 import { composeLayers } from '../layer';
 import type { Layer } from '../layer';
 import { Result } from '../result';
 import { trail } from '../trail';
 import type { TrailContext } from '../types';
 
-const stubCtx: TrailContext = {
+const stubCtx: TrailContext = createTrailContext({
   requestId: 'test-layer',
   signal: AbortSignal.timeout(5000),
-};
+});
 
 const echoTrail = trail('echo', {
   input: z.object({ value: z.string() }),

--- a/packages/core/src/__tests__/service.test.ts
+++ b/packages/core/src/__tests__/service.test.ts
@@ -100,6 +100,9 @@ describe('service types', () => {
 
   test('Service carries identity alongside the shared spec fields', async () => {
     const service: Service<number> = {
+      from(ctx) {
+        return ctx.service(this);
+      },
       id: 'counter.main',
       kind: 'service',
       ...counterServiceSpec,

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -2,15 +2,16 @@ import { describe, test, expect } from 'bun:test';
 
 import { z } from 'zod';
 
+import { createTrailContext } from '../context';
 import { Result } from '../result';
 import { service } from '../service';
 import { trail } from '../trail';
 import type { TrailContext } from '../types';
 
-const stubCtx: TrailContext = {
+const stubCtx: TrailContext = createTrailContext({
   requestId: 'test-123',
   signal: AbortSignal.timeout(5000),
-};
+});
 
 const dbService = service('db.main', {
   create: () =>

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,4 +1,9 @@
-import type { TrailContext } from './types.js';
+import { createServiceLookup } from './service.js';
+import type { TrailContext, TrailContextInit } from './types.js';
+
+type MutableTrailContext = {
+  -readonly [K in keyof TrailContext]: TrailContext[K];
+};
 
 /**
  * Create a TrailContext with sensible defaults.
@@ -8,11 +13,15 @@ import type { TrailContext } from './types.js';
  * - All other fields come from `overrides`
  */
 export const createTrailContext = (
-  overrides?: Partial<TrailContext>
-): TrailContext => ({
-  cwd: process.cwd(),
-  env: process.env as Record<string, string | undefined>,
-  requestId: Bun.randomUUIDv7(),
-  signal: new AbortController().signal,
-  ...overrides,
-});
+  overrides?: Partial<TrailContextInit>
+): TrailContext => {
+  const ctx = {
+    cwd: process.cwd(),
+    env: process.env as Record<string, string | undefined>,
+    requestId: Bun.randomUUIDv7(),
+    signal: new AbortController().signal,
+    ...overrides,
+  } as MutableTrailContext;
+  ctx.service = overrides?.service ?? createServiceLookup(() => ctx);
+  return ctx;
+};

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -8,13 +8,23 @@
 
 import type { AnyTrail } from './trail.js';
 import type { Layer } from './layer.js';
-import type { TrailContext } from './types.js';
+import type {
+  AnyService,
+  ServiceContext,
+  ServiceOverrideMap,
+} from './service.js';
+import type { TrailContext, TrailContextInit } from './types.js';
 
 import { composeLayers } from './layer.js';
 import { createTrailContext } from './context.js';
 import { InternalError } from './errors.js';
 import { Result } from './result.js';
+import { createServiceLookup } from './service.js';
 import { validateInput } from './validation.js';
+
+type MutableTrailContext = {
+  -readonly [K in keyof TrailContext]: TrailContext[K];
+};
 
 // ---------------------------------------------------------------------------
 // Options
@@ -23,15 +33,17 @@ import { validateInput } from './validation.js';
 /** Options for executeTrail. */
 export interface ExecuteTrailOptions {
   /** Partial context overrides merged on top of the base context. */
-  readonly ctx?: Partial<TrailContext> | undefined;
+  readonly ctx?: Partial<TrailContextInit> | undefined;
   /** AbortSignal override (takes final precedence over ctx and factory). */
   readonly signal?: AbortSignal | undefined;
   /** Layers to compose around the implementation. */
   readonly layers?: readonly Layer[] | undefined;
   /** Factory that produces a base TrailContext (takes precedence over defaults). */
   readonly createContext?:
-    | (() => TrailContext | Promise<TrailContext>)
+    | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
+  /** Explicit service instance overrides keyed by service ID. */
+  readonly services?: ServiceOverrideMap | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,9 +61,10 @@ export interface ExecuteTrailOptions {
 const resolveContext = async (
   options?: ExecuteTrailOptions
 ): Promise<TrailContext> => {
-  const base = options?.createContext
+  const seed = options?.createContext
     ? await options.createContext()
     : createTrailContext();
+  const base = seed.service ? seed : createTrailContext(seed);
   const withOverrides = options?.ctx
     ? {
         ...base,
@@ -59,9 +72,238 @@ const resolveContext = async (
         extensions: { ...base.extensions, ...options.ctx.extensions },
       }
     : base;
-  return options?.signal
+  const resolved = options?.signal
     ? { ...withOverrides, signal: options.signal }
     : withOverrides;
+  if (
+    options?.ctx?.extensions !== undefined ||
+    resolved.service === undefined
+  ) {
+    const bound = { ...resolved } as MutableTrailContext;
+    bound.service = createServiceLookup(() => bound);
+    return bound;
+  }
+
+  return resolved as TrailContext;
+};
+
+const singletonServices = new WeakMap<AnyService, Map<string, unknown>>();
+
+/** In-flight service creation promises, keyed by service × context. */
+const pendingCreations = new WeakMap<
+  AnyService,
+  Map<string, Promise<Result<unknown, Error>>>
+>();
+
+const hasOwnServiceOverride = (
+  overrides: ServiceOverrideMap | undefined,
+  id: string
+): overrides is ServiceOverrideMap =>
+  overrides !== undefined && Object.hasOwn(overrides, id);
+
+const toServiceContext = (ctx: TrailContext): ServiceContext => ({
+  cwd: ctx.cwd,
+  env: ctx.env,
+  workspaceRoot: ctx.workspaceRoot,
+});
+
+const toServiceContextKey = (ctx: ServiceContext): string =>
+  JSON.stringify({
+    cwd: ctx.cwd,
+    env: Object.entries(ctx.env ?? {}).toSorted(([left], [right]) =>
+      left.localeCompare(right)
+    ),
+    workspaceRoot: ctx.workspaceRoot,
+  });
+
+const toInternalServiceError = (id: string, error: unknown): InternalError => {
+  const cause = error instanceof Error ? error : undefined;
+  const message = cause?.message ?? String(error);
+  return new InternalError(`Service "${id}" failed to resolve: ${message}`, {
+    ...(cause ? { cause } : {}),
+    context: { serviceId: id },
+  });
+};
+
+const getCachedSingletonService = (
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): { readonly found: boolean; readonly value: unknown } => {
+  const scopedCache = singletonServices.get(declaredService);
+  if (scopedCache === undefined) {
+    return { found: false, value: undefined };
+  }
+
+  const key = toServiceContextKey(serviceContext);
+  if (!scopedCache.has(key)) {
+    return { found: false, value: undefined };
+  }
+
+  return {
+    found: true,
+    value: scopedCache.get(key),
+  };
+};
+
+const getProvidedService = (
+  ctx: TrailContext,
+  overrides: ServiceOverrideMap | undefined,
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): Result<unknown, Error> | undefined => {
+  const { id } = declaredService;
+  if (hasOwnServiceOverride(overrides, id)) {
+    return Result.ok(overrides[id]);
+  }
+
+  if (Object.hasOwn(ctx.extensions ?? {}, id)) {
+    return Result.ok(ctx.extensions?.[id]);
+  }
+
+  const cached = getCachedSingletonService(declaredService, serviceContext);
+  if (cached.found) {
+    return Result.ok(cached.value);
+  }
+
+  return undefined;
+};
+
+const getSingletonServiceCache = (
+  declaredService: AnyService
+): Map<string, unknown> => {
+  const existing = singletonServices.get(declaredService);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const created = new Map<string, unknown>();
+  singletonServices.set(declaredService, created);
+  return created;
+};
+
+const doCreateServiceInstance = async (
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): Promise<Result<unknown, Error>> => {
+  try {
+    const created = await declaredService.create(serviceContext);
+    if (created.isErr()) {
+      return Result.err(created.error);
+    }
+
+    const instance = created.unwrap();
+    getSingletonServiceCache(declaredService).set(
+      toServiceContextKey(serviceContext),
+      instance
+    );
+    return Result.ok(instance);
+  } catch (error: unknown) {
+    return Result.err(toInternalServiceError(declaredService.id, error));
+  }
+};
+
+const trackPendingCreation = (
+  declaredService: AnyService,
+  key: string,
+  promise: Promise<Result<unknown, Error>>
+): void => {
+  const pending = pendingCreations.get(declaredService);
+  if (pending) {
+    pending.set(key, promise);
+  } else {
+    pendingCreations.set(declaredService, new Map([[key, promise]]));
+  }
+};
+
+/**
+ * Deduplicates concurrent creation of the same service singleton.
+ * If a creation is already in flight for this service × context key,
+ * returns the existing promise instead of spawning a second factory call.
+ */
+const createServiceInstance = async (
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): Promise<Result<unknown, Error>> => {
+  const key = toServiceContextKey(serviceContext);
+  const inflight = pendingCreations.get(declaredService)?.get(key);
+  if (inflight) {
+    return inflight;
+  }
+
+  const promise = doCreateServiceInstance(declaredService, serviceContext);
+  trackPendingCreation(declaredService, key, promise);
+
+  try {
+    return await promise;
+  } finally {
+    pendingCreations.get(declaredService)?.delete(key);
+  }
+};
+
+const resolveServiceInstance = async (
+  declaredService: AnyService,
+  ctx: TrailContext,
+  serviceContext: ServiceContext,
+  overrides?: ServiceOverrideMap
+): Promise<Result<unknown, Error>> =>
+  getProvidedService(ctx, overrides, declaredService, serviceContext) ??
+  (await createServiceInstance(declaredService, serviceContext));
+
+const withResolvedServices = (
+  ctx: TrailContext,
+  resolvedServices: Record<string, unknown>
+): TrailContext => {
+  const extensions = { ...ctx.extensions, ...resolvedServices };
+  const resolvedCtx = { ...ctx, extensions } as MutableTrailContext;
+  resolvedCtx.service = createServiceLookup(() => resolvedCtx);
+  return resolvedCtx;
+};
+
+const resolveServices = async (
+  trail: AnyTrail,
+  ctx: TrailContext,
+  overrides?: ServiceOverrideMap
+): Promise<Result<TrailContext, Error>> => {
+  if (trail.services.length === 0) {
+    return Result.ok(ctx);
+  }
+
+  const resolvedServices: Record<string, unknown> = {};
+  const serviceContext = toServiceContext(ctx);
+
+  for (const declaredService of trail.services) {
+    const resolved = await resolveServiceInstance(
+      declaredService,
+      ctx,
+      serviceContext,
+      overrides
+    );
+    if (resolved.isErr()) {
+      return resolved;
+    }
+
+    resolvedServices[declaredService.id] = resolved.unwrap();
+  }
+
+  return Result.ok(withResolvedServices(ctx, resolvedServices));
+};
+
+const prepareContext = async (
+  trail: AnyTrail,
+  options?: ExecuteTrailOptions
+): Promise<Result<TrailContext, Error>> => {
+  const baseCtx = await resolveContext(options);
+  return await resolveServices(trail, baseCtx, options?.services);
+};
+
+const runTrail = async (
+  trail: AnyTrail,
+  input: unknown,
+  ctx: TrailContext,
+  layers: readonly Layer[]
+): Promise<Result<unknown, Error>> => {
+  const impl = composeLayers([...layers], trail, trail.run);
+  return await impl(input, ctx);
 };
 
 // ---------------------------------------------------------------------------
@@ -85,10 +327,17 @@ export const executeTrail = async (
       return validated;
     }
 
-    const ctx = await resolveContext(options);
-    const layers = options?.layers ?? [];
-    const impl = composeLayers([...layers], trail, trail.run);
-    return await impl(validated.value, ctx);
+    const resolvedCtx = await prepareContext(trail, options);
+    if (resolvedCtx.isErr()) {
+      return resolvedCtx;
+    }
+
+    return await runTrail(
+      trail,
+      validated.value,
+      resolvedCtx.value,
+      options?.layers ?? []
+    );
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     return Result.err(new InternalError(message));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,21 +30,29 @@ export type { ErrorCategory } from './errors.js';
 export type {
   Implementation,
   TrailContext,
+  TrailContextInit,
   FollowFn,
   ProgressCallback,
   ProgressEvent,
   Logger,
+  ServiceLookup,
 } from './types.js';
 
 // Context factory
 export { createTrailContext } from './context.js';
 
 // Service
-export { findDuplicateServiceId, isService, service } from './service.js';
+export {
+  createServiceLookup,
+  findDuplicateServiceId,
+  isService,
+  service,
+} from './service.js';
 export type {
   AnyService,
   Service,
   ServiceContext,
+  ServiceOverrideMap,
   ServiceSpec,
 } from './service.js';
 

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -1,6 +1,6 @@
 import { NotFoundError } from './errors.js';
 import type { Result } from './result.js';
-import type { TrailContext } from './types.js';
+import type { ServiceLookup, TrailContext } from './types.js';
 import type { z } from 'zod';
 
 /**
@@ -60,8 +60,38 @@ export interface Service<T> extends ServiceSpec<T> {
 // oxlint-disable-next-line no-explicit-any -- existential type for heterogeneous service collections
 export type AnyService = Service<any>;
 
-const getServiceInstance = (ctx: TrailContext, id: string): unknown =>
-  ctx.extensions?.[id];
+/** Explicit runtime overrides keyed by service ID. */
+export type ServiceOverrideMap = Readonly<Record<string, unknown>>;
+
+const getServiceId = <T>(
+  serviceOrId: string | Pick<Service<T>, 'id'>
+): string => (typeof serviceOrId === 'string' ? serviceOrId : serviceOrId.id);
+
+const getServiceInstance = <T>(
+  ctx: Pick<TrailContext, 'extensions'>,
+  serviceOrId: string | Pick<Service<T>, 'id'>
+): T => {
+  const id = getServiceId(serviceOrId);
+  return ctx.extensions?.[id] as T;
+};
+
+const hasServiceInstance = (
+  ctx: Pick<TrailContext, 'extensions'>,
+  serviceOrId: string | Pick<AnyService, 'id'>
+): boolean => Object.hasOwn(ctx.extensions ?? {}, getServiceId(serviceOrId));
+
+/** Create a `ctx.service(...)` accessor bound to a concrete context snapshot. */
+export const createServiceLookup = (
+  getContext: () => Pick<TrailContext, 'extensions'>
+): ServiceLookup =>
+  ((serviceOrId: string | Pick<AnyService, 'id'>) => {
+    const id = getServiceId(serviceOrId);
+    const ctx = getContext();
+    if (!hasServiceInstance(ctx, id)) {
+      throw new NotFoundError(`Service "${id}" not found in trail context`);
+    }
+    return getServiceInstance(ctx, id);
+  }) as ServiceLookup;
 
 /**
  * Create a typed service definition.
@@ -73,10 +103,8 @@ export const service = <T>(id: string, spec: ServiceSpec<T>): Service<T> =>
   Object.freeze({
     ...spec,
     from(ctx: TrailContext): T {
-      if (!Object.hasOwn(ctx.extensions ?? {}, id)) {
-        throw new NotFoundError(`Service "${id}" not found in trail context`);
-      }
-      return getServiceInstance(ctx, id) as T;
+      const lookup = ctx.service ?? createServiceLookup(() => ctx);
+      return lookup(this);
     },
     id,
     kind: 'service' as const,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,6 +17,11 @@ export type FollowFn = <O>(
   input: unknown
 ) => Promise<Result<O, Error>>;
 
+/** Resolve a service instance from the current trail context. */
+export type ServiceLookup = <T = unknown>(
+  serviceOrId: { readonly id: string } | string
+) => T;
+
 /** Callback for reporting progress from long-running trails */
 export type ProgressCallback = (event: ProgressEvent) => void;
 
@@ -53,4 +58,10 @@ export interface TrailContext {
   readonly cwd?: string | undefined;
   readonly env?: Record<string, string | undefined> | undefined;
   readonly extensions?: Readonly<Record<string, unknown>> | undefined;
+  readonly service?: ServiceLookup | undefined;
 }
+
+/** Input shape used to seed a runtime TrailContext before resolution. */
+export type TrailContextInit = Omit<TrailContext, 'service'> & {
+  readonly service?: ServiceLookup | undefined;
+};

--- a/packages/testing/src/context.ts
+++ b/packages/testing/src/context.ts
@@ -3,10 +3,14 @@
  */
 
 import type { FollowFn, TrailContext } from '@ontrails/core';
-import { Result } from '@ontrails/core';
+import { Result, createServiceLookup } from '@ontrails/core';
 
 import { createTestLogger } from './logger.js';
 import type { TestTrailContextOptions } from './types.js';
+
+type MutableTrailContext = {
+  -readonly [K in keyof TrailContext]: TrailContext[K];
+};
 
 // ---------------------------------------------------------------------------
 // createTestContext
@@ -21,13 +25,18 @@ import type { TestTrailContextOptions } from './types.js';
  */
 export const createTestContext = (
   overrides?: TestTrailContextOptions
-): TrailContext => ({
-  env: overrides?.env ?? { TRAILS_ENV: 'test' },
-  logger: overrides?.logger ?? createTestLogger(),
-  requestId: overrides?.requestId ?? 'test-request-001',
-  signal: overrides?.signal ?? new AbortController().signal,
-  workspaceRoot: overrides?.cwd ?? process.cwd(),
-});
+): TrailContext => {
+  const ctx = {
+    env: overrides?.env ?? { TRAILS_ENV: 'test' },
+    extensions: undefined,
+    logger: overrides?.logger ?? createTestLogger(),
+    requestId: overrides?.requestId ?? 'test-request-001',
+    signal: overrides?.signal ?? new AbortController().signal,
+    workspaceRoot: overrides?.cwd ?? process.cwd(),
+  } as MutableTrailContext;
+  ctx.service = createServiceLookup(() => ctx);
+  return ctx;
+};
 
 // ---------------------------------------------------------------------------
 // createFollowContext


### PR DESCRIPTION
## Context
This is the first runtime slice of the stack: `executeTrail()` now resolves declared services, caches compatible singletons, and threads service-aware context through execution.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Added service resolution and context merging inside `executeTrail()`.
- Scoped singleton caching to compatible service contexts and covered override and error behavior.
- Aligned `dispatch()`, layers, and testing context helpers with the new execution model.

## How To Test
- `bun test packages/core/src/__tests__/execute.test.ts packages/core/src/__tests__/dispatch.test.ts packages/core/src/__tests__/context.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-77
