### PR TITLE
feat(surfaces): thread service overrides through blaze

### DIFF
--- a/packages/cli/src/__tests__/blaze.test.ts
+++ b/packages/cli/src/__tests__/blaze.test.ts
@@ -70,8 +70,12 @@ describe('blaze', () => {
     expect(() =>
       buildCliCommands(app, { onResult: defaultOnResult })
     ).not.toThrow();
-    const opts: Parameters<typeof blaze>[1] = { validate: false };
+    const opts: Parameters<typeof blaze>[1] = {
+      services: {},
+      validate: false,
+    };
     expect(opts.validate).toBe(false);
+    expect(opts.services).toEqual({});
   });
 
   test('blaze returns a Promise (async signature)', () => {

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 
-import { Result, createTrailContext, trail, topo } from '@ontrails/core';
+import {
+  Result,
+  createTrailContext,
+  service,
+  trail,
+  topo,
+} from '@ontrails/core';
 import type { TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -19,6 +25,13 @@ const makeApp = (...trails: AnyTrail[]) => {
   }
   return topo('test-app', mod);
 };
+
+const dbService = service('db.main', {
+  create: () =>
+    Result.ok({
+      name: 'factory',
+    }),
+});
 
 const requireCommand = (commands: ReturnType<typeof buildCliCommands>) => {
   const [command] = commands;
@@ -254,5 +267,25 @@ describe('buildCliCommands', () => {
     const result = await cmd.execute({}, {});
     expect(result.isErr()).toBe(true);
     expect(result.error.message).toContain('unexpected kaboom');
+  });
+});
+
+describe('buildCliCommands service overrides', () => {
+  test('forwards service overrides into executeTrail', async () => {
+    const t = trail('service-test', {
+      input: z.object({}),
+      output: z.object({ name: z.string() }),
+      run: (_input, ctx) =>
+        Result.ok({ name: dbService.from(ctx).name as string }),
+      services: [dbService],
+    });
+    const app = makeApp(t);
+    const commands = buildCliCommands(app, {
+      services: { 'db.main': { name: 'override' } },
+    });
+
+    const result = await commands[0]?.execute({}, {});
+    expect(result?.isOk()).toBe(true);
+    expect(result?.unwrap()).toEqual({ name: 'override' });
   });
 });

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -2,7 +2,15 @@
  * Build framework-agnostic CliCommand[] from an App's topology.
  */
 
-import type { Field, Layer, Result, Topo, TrailContext } from '@ontrails/core';
+import type {
+  Field,
+  Layer,
+  Result,
+  ServiceOverrideMap,
+  Topo,
+  TrailContext,
+  TrailContextInit,
+} from '@ontrails/core';
 import { deriveFields, executeTrail } from '@ontrails/core';
 
 import type { AnyTrail, CliCommand, CliFlag } from './command.js';
@@ -24,11 +32,14 @@ export interface ActionResultContext {
 
 /** Options for buildCliCommands. */
 export interface BuildCliCommandsOptions {
-  createContext?: (() => TrailContext | Promise<TrailContext>) | undefined;
+  createContext?:
+    | (() => TrailContextInit | Promise<TrailContextInit>)
+    | undefined;
   layers?: Layer[] | undefined;
   onResult?: ((ctx: ActionResultContext) => Promise<void>) | undefined;
   presets?: CliFlag[][] | undefined;
   resolveInput?: InputResolver | undefined;
+  services?: ServiceOverrideMap | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -146,6 +157,7 @@ const createExecute =
       createContext: options?.createContext,
       ctx: ctxOverrides,
       layers: options?.layers,
+      services: options?.services,
     });
 
     // Pass validated (coerced/transformed) input to onResult on success,

--- a/packages/cli/src/commander/blaze.ts
+++ b/packages/cli/src/commander/blaze.ts
@@ -2,7 +2,12 @@
  * The one-liner convenience for wiring an App to Commander.
  */
 
-import type { Layer, Topo, TrailContext } from '@ontrails/core';
+import type {
+  Layer,
+  ServiceOverrideMap,
+  Topo,
+  TrailContextInit,
+} from '@ontrails/core';
 import { validateTopo } from '@ontrails/core';
 
 import type { ActionResultContext } from '../build.js';
@@ -18,13 +23,16 @@ import { toCommander } from './to-commander.js';
 // ---------------------------------------------------------------------------
 
 export interface BlazeCliOptions {
-  createContext?: (() => TrailContext | Promise<TrailContext>) | undefined;
+  createContext?:
+    | (() => TrailContextInit | Promise<TrailContextInit>)
+    | undefined;
   description?: string | undefined;
   layers?: Layer[] | undefined;
   name?: string | undefined;
   onResult?: ((ctx: ActionResultContext) => Promise<void>) | undefined;
   presets?: CliFlag[][] | undefined;
   resolveInput?: InputResolver | undefined;
+  services?: ServiceOverrideMap | undefined;
   /** Set to `false` to skip topo validation at startup. Defaults to `true`. */
   validate?: boolean | undefined;
   version?: string | undefined;
@@ -72,6 +80,7 @@ export const blaze = async (
     onResult: options.onResult ?? defaultOnResult,
     presets: options.presets,
     resolveInput: options.resolveInput,
+    services: options.services,
   });
 
   const commanderOpts: ToCommanderOptions = {

--- a/packages/core/src/__tests__/dispatch.test.ts
+++ b/packages/core/src/__tests__/dispatch.test.ts
@@ -7,6 +7,7 @@ import { dispatch } from '../dispatch';
 import { InternalError, NotFoundError, ValidationError } from '../errors';
 import type { Layer } from '../layer';
 import { Result } from '../result';
+import { service } from '../service';
 import { topo } from '../topo';
 import { trail } from '../trail';
 import type { TrailContext, TrailContextInit } from '../types';
@@ -41,6 +42,32 @@ describe('dispatch', () => {
 
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toEqual({ value: 'hello' });
+    });
+
+    test('passes service overrides through to executeTrail', async () => {
+      const id = `dispatch.service.${Bun.randomUUIDv7()}`;
+      const db = service(id, {
+        create: () => Result.ok({ source: 'factory' }),
+      });
+      const searchTrail = trail('search', {
+        input: z.object({}),
+        output: z.object({ source: z.string() }),
+        run: (_input, ctx) => Result.ok({ source: db.from(ctx).source }),
+        services: [db],
+      });
+      const searchTopo = topo('service-test', { searchTrail });
+
+      const result = await dispatch(
+        searchTopo,
+        'search',
+        {},
+        {
+          services: { [id]: { source: 'override' } },
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ source: 'override' });
     });
   });
 

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -4,6 +4,7 @@ import {
   InternalError,
   NotFoundError,
   Result,
+  service,
   ValidationError,
   trail,
   topo,
@@ -57,6 +58,13 @@ const internalMetaTrail = trail('secret', {
   input: z.object({}),
   metadata: { internal: true },
   run: () => Result.ok({ ok: true }),
+});
+
+const dbService = service('db.main', {
+  create: () =>
+    Result.ok({
+      source: 'factory',
+    }),
 });
 
 // ---------------------------------------------------------------------------
@@ -313,6 +321,28 @@ describe('buildHttpRoutes', () => {
       await route?.execute({});
       expect(capturedRequestId).toBeDefined();
       expect(capturedRequestId).not.toBe('');
+    });
+
+    test('forwards service overrides into executeTrail', async () => {
+      const serviceTrail = trail('service.check', {
+        input: z.object({}),
+        output: z.object({ source: z.string() }),
+        run: (_input, ctx) =>
+          Result.ok({ source: dbService.from(ctx).source as string }),
+        services: [dbService],
+      });
+
+      const app = topo('testapp', { serviceTrail });
+      const buildResult = buildHttpRoutes(app, {
+        services: { 'db.main': { source: 'override' } },
+      });
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
+
+      const result = await route?.execute({});
+      expect(result?.isOk()).toBe(true);
+      expect(result?.value).toEqual({ source: 'override' });
     });
   });
 

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -7,7 +7,13 @@
  */
 
 import { Result, ValidationError, executeTrail } from '@ontrails/core';
-import type { Layer, Topo, Trail, TrailContext } from '@ontrails/core';
+import type {
+  Layer,
+  ServiceOverrideMap,
+  Topo,
+  Trail,
+  TrailContextInit,
+} from '@ontrails/core';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -16,9 +22,10 @@ import type { Layer, Topo, Trail, TrailContext } from '@ontrails/core';
 export interface BuildHttpRoutesOptions {
   readonly basePath?: string | undefined;
   readonly createContext?:
-    | (() => TrailContext | Promise<TrailContext>)
+    | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
   readonly layers?: readonly Layer[] | undefined;
+  readonly services?: ServiceOverrideMap | undefined;
 }
 
 export type HttpMethod = 'GET' | 'POST' | 'DELETE';
@@ -100,6 +107,7 @@ const createExecute =
       createContext: options.createContext,
       ctx: requestId === undefined ? undefined : { requestId },
       layers,
+      services: options.services,
       signal,
     });
 

--- a/packages/http/src/hono/__tests__/blaze.test.ts
+++ b/packages/http/src/hono/__tests__/blaze.test.ts
@@ -4,6 +4,7 @@ import {
   InternalError,
   NotFoundError,
   Result,
+  service,
   trail,
   topo,
 } from '@ontrails/core';
@@ -49,6 +50,13 @@ const internalTrail = trail('crash', {
   description: 'Always fails with internal error',
   input: z.object({}),
   run: () => Result.err(new InternalError('Something broke')),
+});
+
+const dbService = service('db.main', {
+  create: () =>
+    Result.ok({
+      source: 'factory',
+    }),
 });
 
 // ---------------------------------------------------------------------------
@@ -489,6 +497,29 @@ describe('blaze (Hono adapter)', () => {
       const res = await request(hono, 'GET', '/ctx/custom');
       expect(res.status).toBe(200);
       expect(contextUsed).toBe(true);
+    });
+
+    test('service overrides reach the trail through blaze()', async () => {
+      const serviceTrail = trail('service.check', {
+        input: z.object({}),
+        intent: 'read',
+        output: z.object({ source: z.string() }),
+        run: (_input, ctx) =>
+          Result.ok({ source: dbService.from(ctx).source as string }),
+        services: [dbService],
+      });
+
+      const app = topo('testapp', { dbService, serviceTrail });
+      const hono = await blaze(app, {
+        serve: false,
+        services: { 'db.main': { source: 'override' } },
+      });
+
+      const res = await request(hono, 'GET', '/service/check');
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json.data.source).toBe('override');
     });
   });
 });

--- a/packages/http/src/hono/blaze.ts
+++ b/packages/http/src/hono/blaze.ts
@@ -11,7 +11,12 @@
  */
 
 import { isTrailsError, statusCodeMap, validateTopo } from '@ontrails/core';
-import type { Layer, Topo, TrailContext } from '@ontrails/core';
+import type {
+  Layer,
+  ServiceOverrideMap,
+  Topo,
+  TrailContextInit,
+} from '@ontrails/core';
 import { Hono } from 'hono';
 import type { Context as HonoContext } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
@@ -27,12 +32,13 @@ import { buildHttpRoutes } from '../build.js';
 export interface BlazeHttpOptions {
   readonly basePath?: string | undefined;
   readonly createContext?:
-    | (() => TrailContext | Promise<TrailContext>)
+    | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
   readonly hostname?: string | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly name?: string | undefined;
   readonly port?: number | undefined;
+  readonly services?: ServiceOverrideMap | undefined;
   /** Set false to return the Hono app without starting a server. */
   readonly serve?: boolean | undefined;
   /** Set to `false` to skip topo validation at startup. Defaults to `true`. */
@@ -320,6 +326,7 @@ export const blaze = async (
     basePath: options.basePath,
     createContext: options.createContext,
     layers: options.layers,
+    services: options.services,
   });
 
   if (routesResult.isErr()) {

--- a/packages/mcp/src/__tests__/blaze.test.ts
+++ b/packages/mcp/src/__tests__/blaze.test.ts
@@ -83,6 +83,14 @@ describe('blaze', () => {
     expect(['resolved', 'timeout']).toContain(result);
   });
 
+  test('BlazeMcpOptions accepts service overrides', () => {
+    const opts: Parameters<typeof blaze>[1] = {
+      services: {},
+      validate: false,
+    };
+    expect(opts.services).toEqual({});
+  });
+
   test('createMcpServer registers tools that can be listed', () => {
     const echoTrail = trail('echo', {
       description: 'Echo',

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { Result, createBlobRef, trail, topo } from '@ontrails/core';
+import { Result, createBlobRef, service, trail, topo } from '@ontrails/core';
 import type { Layer } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -43,6 +43,13 @@ const exampleTrail = trail('with.examples', {
   ],
   input: z.object({ name: z.string() }),
   run: (input) => Result.ok({ greeting: `hello ${input.name}` }),
+});
+
+const dbService = service('db.main', {
+  create: () =>
+    Result.ok({
+      source: 'factory',
+    }),
 });
 
 const noExtra: McpExtra = {};
@@ -312,6 +319,28 @@ describe('buildMcpTools', () => {
 
       await tool.handler({}, noExtra);
       expect(contextUsed).toBe(true);
+    });
+
+    test('service overrides are forwarded to executeTrail', async () => {
+      const serviceTrail = trail('service.check', {
+        input: z.object({}),
+        output: z.object({ source: z.string() }),
+        run: (_input, ctx) =>
+          Result.ok({ source: dbService.from(ctx).source as string }),
+        services: [dbService],
+      });
+
+      const tool = requireOnlyTool(
+        buildTools(topo('myapp', { serviceTrail }), {
+          services: { 'db.main': { source: 'override' } },
+        })
+      );
+
+      const result = await tool.handler({}, noExtra);
+      expect(result?.isError).toBeUndefined();
+      expect(parseJsonContent(result?.content[0])).toEqual({
+        source: 'override',
+      });
     });
   });
 

--- a/packages/mcp/src/blaze.ts
+++ b/packages/mcp/src/blaze.ts
@@ -14,7 +14,12 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { Layer, Topo, TrailContext } from '@ontrails/core';
+import type {
+  Layer,
+  ServiceOverrideMap,
+  Topo,
+  TrailContextInit,
+} from '@ontrails/core';
 import { validateTopo } from '@ontrails/core';
 
 import type { McpToolDefinition } from './build.js';
@@ -27,7 +32,7 @@ import { connectStdio } from './stdio.js';
 
 export interface BlazeMcpOptions {
   readonly createContext?:
-    | (() => TrailContext | Promise<TrailContext>)
+    | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
   readonly excludeTrails?: readonly string[] | undefined;
   readonly includeTrails?: readonly string[] | undefined;
@@ -39,6 +44,7 @@ export interface BlazeMcpOptions {
       }
     | undefined;
   readonly transport?: 'stdio' | undefined;
+  readonly services?: ServiceOverrideMap | undefined;
   /** Set to `false` to skip topo validation at startup. Defaults to `true`. */
   readonly validate?: boolean | undefined;
 }
@@ -145,6 +151,7 @@ export const blaze = async (
     excludeTrails: options.excludeTrails,
     includeTrails: options.includeTrails,
     layers: options.layers,
+    services: options.services,
   });
 
   if (toolsResult.isErr()) {

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -13,7 +13,14 @@ import {
   isBlobRef,
   zodToJsonSchema,
 } from '@ontrails/core';
-import type { BlobRef, Layer, Topo, Trail, TrailContext } from '@ontrails/core';
+import type {
+  BlobRef,
+  Layer,
+  ServiceOverrideMap,
+  Topo,
+  Trail,
+  TrailContextInit,
+} from '@ontrails/core';
 
 import type { McpAnnotations } from './annotations.js';
 import { deriveAnnotations } from './annotations.js';
@@ -26,11 +33,12 @@ import { deriveToolName } from './tool-name.js';
 
 export interface BuildMcpToolsOptions {
   readonly createContext?:
-    | (() => TrailContext | Promise<TrailContext>)
+    | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
   readonly excludeTrails?: readonly string[] | undefined;
   readonly includeTrails?: readonly string[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
+  readonly services?: ServiceOverrideMap | undefined;
 }
 
 export interface McpToolDefinition {
@@ -214,6 +222,7 @@ const createHandler =
       createContext: options.createContext,
       ctx: progressCb === undefined ? undefined : { progress: progressCb },
       layers,
+      services: options.services,
       signal: extra.signal,
     });
     if (result.isOk()) {


### PR DESCRIPTION
## Context
Once core can resolve services, each surface needs a consistent way to pass explicit overrides into runtime execution.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Threaded `serviceOverrides` through the CLI, HTTP, and MCP build/blaze paths.
- Added surface-level tests proving overrides reach the executed trails.
- Covered the default validation path in Hono `blaze()` with declared services present.

## How To Test
- `bun test packages/cli/src/__tests__/build.test.ts packages/http/src/__tests__/build.test.ts packages/http/src/hono/__tests__/blaze.test.ts packages/mcp/src/__tests__/build.test.ts packages/core/src/__tests__/dispatch.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-78
