### PR TITLE
fix(testing): execute examples and contracts through service pipeline

### DIFF
--- a/packages/testing/src/__tests__/all.test.ts
+++ b/packages/testing/src/__tests__/all.test.ts
@@ -1,0 +1,64 @@
+import { describe } from 'bun:test';
+
+import { Result, service, trail, topo } from '@ontrails/core';
+import { z } from 'zod';
+
+import { testAll } from '../all.js';
+
+const mockDbService = service('db.mock.all', {
+  create: () => Result.ok({ source: 'factory' }),
+  mock: () => ({ source: 'mock' }),
+});
+
+const mockedTrail = trail('service.mocked.all', {
+  description: 'Trail that uses a mocked service through testAll',
+  examples: [
+    {
+      expected: { source: 'mock' },
+      input: {},
+      name: 'Uses auto-resolved service mock',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ source: z.string() }),
+  run: (_input, ctx) => Result.ok({ source: mockDbService.from(ctx).source }),
+  services: [mockDbService],
+});
+
+const overrideTrail = trail('service.override.all', {
+  description: 'Trail that prefers explicit overrides over mock factories',
+  examples: [
+    {
+      expected: { source: 'override' },
+      input: {},
+      name: 'Explicit service override wins',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ source: z.string() }),
+  run: (_input, ctx) => Result.ok({ source: mockDbService.from(ctx).source }),
+  services: [mockDbService],
+});
+
+describe('testAll service mocks', () => {
+  // eslint-disable-next-line jest/require-hook
+  testAll(
+    topo('test-all-service-mock-app', {
+      mockDbService,
+      mockedTrail,
+    } as Record<string, unknown>)
+  );
+});
+
+describe('testAll explicit service overrides', () => {
+  // eslint-disable-next-line jest/require-hook
+  testAll(
+    topo('test-all-service-override-app', {
+      mockDbService,
+      overrideTrail,
+    } as Record<string, unknown>),
+    {
+      services: { 'db.mock.all': { source: 'override' } },
+    }
+  );
+});

--- a/packages/testing/src/__tests__/context.test.ts
+++ b/packages/testing/src/__tests__/context.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 
-import { Result } from '@ontrails/core';
+import { Result, service, topo } from '@ontrails/core';
 
-import { createFollowContext, createTestContext } from '../context.js';
+import {
+  createFollowContext,
+  createTestContext,
+  mergeTestContext,
+  resolveMockServices,
+} from '../context.js';
 import type { TestLogger } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -12,11 +17,12 @@ import type { TestLogger } from '../types.js';
 describe('createTestContext', () => {
   test('produces a valid TrailContext with no args', () => {
     const ctx = createTestContext();
+    expect(ctx.cwd).toBe(process.cwd());
     expect(ctx.requestId).toBe('test-request-001');
     expect(ctx.signal).toBeDefined();
     expect(ctx.signal.aborted).toBe(false);
     expect(ctx.logger).toBeDefined();
-    expect(ctx.workspaceRoot).toBeDefined();
+    expect(ctx.workspaceRoot).toBe(process.cwd());
   });
 
   test('default logger is a TestLogger', () => {
@@ -49,6 +55,7 @@ describe('createTestContext', () => {
 
   test('overrides cwd', () => {
     const ctx = createTestContext({ cwd: '/tmp/test' });
+    expect(ctx.cwd).toBe('/tmp/test');
     expect(ctx.workspaceRoot).toBe('/tmp/test');
   });
 
@@ -91,5 +98,53 @@ describe('createFollowContext', () => {
     const follow = createFollowContext();
     const result = await follow('any.id', {});
     expect(result.isErr()).toBe(true);
+  });
+});
+
+describe('mergeTestContext', () => {
+  test('merges service overrides into extensions and the service accessor', () => {
+    const ctx = mergeTestContext(
+      {
+        extensions: { existing: true },
+      },
+      { 'db.main': { source: 'mock' } }
+    );
+
+    expect(ctx.extensions).toEqual({
+      'db.main': { source: 'mock' },
+      existing: true,
+    });
+    expect(ctx.service<{ source: string }>('db.main').source).toBe('mock');
+  });
+});
+
+describe('resolveMockServices', () => {
+  test('creates fresh mock services for each invocation', async () => {
+    let mockCalls = 0;
+    const mockable = service(`service.mock.${Bun.randomUUIDv7()}`, {
+      create: () => Result.ok({ source: 'factory' }),
+      mock: () => {
+        mockCalls += 1;
+        return Promise.resolve({ source: 'mock' });
+      },
+    });
+    const app = topo('mock-app', { mockable } as Record<string, unknown>);
+
+    const first = await resolveMockServices(app);
+    const second = await resolveMockServices(app);
+
+    expect(first).toEqual({ [mockable.id]: { source: 'mock' } });
+    expect(second).toEqual(first);
+    expect(second[mockable.id]).not.toBe(first[mockable.id]);
+    expect(mockCalls).toBe(2);
+  });
+
+  test('skips services without mock factories', async () => {
+    const plain = service(`service.plain.${Bun.randomUUIDv7()}`, {
+      create: () => Result.ok({ source: 'factory' }),
+    });
+    const app = topo('plain-app', { plain } as Record<string, unknown>);
+
+    expect(await resolveMockServices(app)).toEqual({});
   });
 });

--- a/packages/testing/src/__tests__/contracts.test.ts
+++ b/packages/testing/src/__tests__/contracts.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'bun:test';
 
-import { Result, trail, topo } from '@ontrails/core';
+import { Result, service, trail, topo } from '@ontrails/core';
 import { z } from 'zod';
 
 import { testContracts } from '../contracts.js';
@@ -57,6 +57,63 @@ const compositionTrail = trail('composition.valid', {
     Result.ok({ total: input.a + input.b }),
 });
 
+const transformedInputTrail = trail('contract.transformed', {
+  examples: [
+    {
+      expected: { value: 2 },
+      input: { value: '1' },
+      name: 'Raw contract input is only transformed once',
+    },
+  ],
+  input: z
+    .object({ value: z.string() })
+    .transform(({ value }) => ({ value: Number(value) + 1 })),
+  output: z.object({ value: z.number() }),
+  run: (input: { value: number }) => Result.ok({ value: input.value }),
+});
+
+const undeclaredContractDbService = service('db.undeclared.contracts', {
+  create: () => Result.ok({ source: 'factory' }),
+  mock: () => ({ source: 'mock' }),
+});
+
+const undeclaredContractTrail = trail('service.undeclared.contracts', {
+  examples: [
+    {
+      expected: { hasInjectedService: false },
+      input: {},
+      name: 'Undeclared services are not preloaded into contract contexts',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ hasInjectedService: z.literal(false) }),
+  run: (_input, ctx) =>
+    Result.ok({
+      hasInjectedService:
+        ctx.extensions?.[undeclaredContractDbService.id] !== undefined,
+    }),
+});
+
+const ctxOverrideContractService = service('db.mock.contracts', {
+  create: () => Result.ok({ source: 'factory' }),
+  mock: () => ({ source: 'mock' }),
+});
+
+const ctxOverrideContractTrail = trail('service.ctx.contracts', {
+  examples: [
+    {
+      expected: { source: 'ctx' },
+      input: {},
+      name: 'Context extensions beat auto-resolved contract mocks',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ source: z.literal('ctx') }),
+  run: (_input, ctx) =>
+    Result.ok({ source: ctxOverrideContractService.from(ctx).source }),
+  services: [ctxOverrideContractService],
+});
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -90,5 +147,39 @@ describe('testContracts: validates composition trail output schemas', () => {
   // eslint-disable-next-line jest/require-hook
   testContracts(
     topo('test-app', { compositionTrail } as Record<string, unknown>)
+  );
+});
+
+describe('testContracts: raw transformed input', () => {
+  // eslint-disable-next-line jest/require-hook
+  testContracts(
+    topo('transformed-contract-app', {
+      transformedInputTrail,
+    } as Record<string, unknown>)
+  );
+});
+
+describe('testContracts: context extension overrides', () => {
+  // eslint-disable-next-line jest/require-hook
+  testContracts(
+    topo('ctx-contract-app', {
+      ctxOverrideContractService,
+      ctxOverrideContractTrail,
+    } as Record<string, unknown>),
+    {
+      ctx: {
+        extensions: { 'db.mock.contracts': { source: 'ctx' } },
+      },
+    }
+  );
+});
+
+describe('testContracts service declarations', () => {
+  // eslint-disable-next-line jest/require-hook
+  testContracts(
+    topo('undeclared-contract-service-app', {
+      undeclaredContractDbService,
+      undeclaredContractTrail,
+    } as Record<string, unknown>)
   );
 });

--- a/packages/testing/src/__tests__/examples.test.ts
+++ b/packages/testing/src/__tests__/examples.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'bun:test';
 
-import { NotFoundError, Result, trail, topo } from '@ontrails/core';
+import { NotFoundError, Result, service, trail, topo } from '@ontrails/core';
 import { z } from 'zod';
 
 import { testExamples } from '../examples.js';
@@ -65,6 +65,137 @@ const entityTrail = trail('entity.show', {
 const noExamplesTrail = trail('noexamples', {
   input: z.object({ x: z.number() }),
   run: (input: { x: number }) => Result.ok(input.x * 2),
+});
+
+const mockDbService = service('db.mock.examples', {
+  create: () => Result.ok({ source: 'factory' }),
+  mock: () => ({ source: 'mock' }),
+});
+
+const mockServiceTrail = trail('service.mocked', {
+  description: 'Trail that reads from a mocked service',
+  examples: [
+    {
+      expected: { source: 'mock' },
+      input: {},
+      name: 'Uses auto-resolved service mock',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ source: z.string() }),
+  run: (_input, ctx) => Result.ok({ source: mockDbService.from(ctx).source }),
+  services: [mockDbService],
+});
+
+const explicitOverrideTrail = trail('service.override', {
+  description: 'Trail whose service mock can be overridden explicitly',
+  examples: [
+    {
+      expected: { source: 'override' },
+      input: {},
+      name: 'Explicit service override wins over mock factory',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ source: z.string() }),
+  run: (_input, ctx) => Result.ok({ source: mockDbService.from(ctx).source }),
+  services: [mockDbService],
+});
+
+const transformedInputTrail = trail('example.transformed', {
+  description: 'Trail whose input schema transforms once',
+  examples: [
+    {
+      expected: { value: 2 },
+      input: { value: '1' },
+      name: 'Raw example input is only transformed once',
+    },
+  ],
+  input: z
+    .object({ value: z.string() })
+    .transform(({ value }) => ({ value: Number(value) + 1 })),
+  output: z.object({ value: z.number() }),
+  run: (input: { value: number }) => Result.ok({ value: input.value }),
+});
+
+const ctxOverrideTrail = trail('service.ctx-override', {
+  description: 'Trail whose service mock can be overridden by ctx.extensions',
+  examples: [
+    {
+      expected: { source: 'ctx' },
+      input: {},
+      name: 'Context extensions beat auto-resolved mock services',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ source: z.string() }),
+  run: (_input, ctx) => Result.ok({ source: mockDbService.from(ctx).source }),
+  services: [mockDbService],
+});
+
+const undeclaredDbService = service('db.undeclared.examples', {
+  create: () => Result.ok({ source: 'factory' }),
+  mock: () => ({ source: 'mock' }),
+});
+
+const undeclaredServiceTrail = trail('service.undeclared.examples', {
+  description: 'Trail that uses a service without declaring it',
+  examples: [
+    {
+      error: 'InternalError',
+      input: {},
+      name: 'Undeclared services stay unavailable during example execution',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ source: z.string() }),
+  run: (_input, ctx) =>
+    Result.ok({ source: undeclaredDbService.from(ctx).source }),
+});
+
+const followedDbService = service('db.mock.examples.follow', {
+  create: () => Result.ok({ source: 'factory' }),
+  mock: () => ({ source: 'mock' }),
+});
+
+const followedLeafTrail = trail('service.follow.leaf', {
+  description: 'Leaf trail that resolves a service inside a follow chain',
+  input: z.object({}),
+  output: z.object({ childSource: z.string() }),
+  run: (_input, ctx) =>
+    Result.ok({ childSource: followedDbService.from(ctx).source }),
+  services: [followedDbService],
+});
+
+const followedRootTrail = trail('service.follow.root', {
+  description: 'Root trail that follows a child trail using services',
+  examples: [
+    {
+      expected: { childSource: 'mock', rootSource: 'mock' },
+      input: {},
+      name: 'Propagates service mocks through follow execution',
+    },
+  ],
+  follow: ['service.follow.leaf'],
+  input: z.object({}),
+  output: z.object({ childSource: z.string(), rootSource: z.string() }),
+  run: async (_input, ctx) => {
+    if (!ctx.follow) {
+      return Result.err(new Error('follow not available'));
+    }
+    const childResult = await ctx.follow<{ childSource: string }>(
+      'service.follow.leaf',
+      {}
+    );
+    if (childResult.isErr()) {
+      return childResult;
+    }
+    return Result.ok({
+      childSource: childResult.value.childSource,
+      rootSource: followedDbService.from(ctx).source,
+    });
+  },
+  services: [followedDbService],
 });
 
 // ---------------------------------------------------------------------------
@@ -163,6 +294,63 @@ describe('testExamples skips trails with no examples', () => {
   });
 });
 
+describe('testExamples service mocks', () => {
+  // eslint-disable-next-line jest/require-hook
+  testExamples(
+    topo('service-mock-app', {
+      mockDbService,
+      mockServiceTrail,
+    } as Record<string, unknown>)
+  );
+});
+
+describe('testExamples explicit service overrides', () => {
+  // eslint-disable-next-line jest/require-hook
+  testExamples(
+    topo('service-override-app', {
+      explicitOverrideTrail,
+      mockDbService,
+    } as Record<string, unknown>),
+    {
+      services: { 'db.mock.examples': { source: 'override' } },
+    }
+  );
+});
+
+describe('testExamples raw transformed input', () => {
+  // eslint-disable-next-line jest/require-hook
+  testExamples(
+    topo('transformed-input-app', {
+      transformedInputTrail,
+    } as Record<string, unknown>)
+  );
+});
+
+describe('testExamples context extension overrides', () => {
+  // eslint-disable-next-line jest/require-hook
+  testExamples(
+    topo('ctx-override-app', {
+      ctxOverrideTrail,
+      mockDbService,
+    } as Record<string, unknown>),
+    {
+      ctx: {
+        extensions: { 'db.mock.examples': { source: 'ctx' } },
+      },
+    }
+  );
+});
+
+describe('testExamples service declarations', () => {
+  // eslint-disable-next-line jest/require-hook
+  testExamples(
+    topo('undeclared-service-app', {
+      undeclaredDbService,
+      undeclaredServiceTrail,
+    } as Record<string, unknown>)
+  );
+});
+
 describe('testExamples follow coverage for composition trails', () => {
   // eslint-disable-next-line jest/require-hook
   testExamples(
@@ -170,6 +358,17 @@ describe('testExamples follow coverage for composition trails', () => {
       addTrail,
       onboardTrail,
       relateTrail,
+    } as Record<string, unknown>)
+  );
+});
+
+describe('testExamples service mocks through follow', () => {
+  // eslint-disable-next-line jest/require-hook
+  testExamples(
+    topo('service-follow-app', {
+      followedDbService,
+      followedLeafTrail,
+      followedRootTrail,
     } as Record<string, unknown>)
   );
 });

--- a/packages/testing/src/all.ts
+++ b/packages/testing/src/all.ts
@@ -11,6 +11,7 @@ import type { Topo, TrailContext } from '@ontrails/core';
 import { validateTopo } from '@ontrails/core';
 
 import { testContracts } from './contracts.js';
+import type { TestExecutionOptions } from './context.js';
 import { testDetours } from './detours.js';
 import { testExamples } from './examples.js';
 
@@ -37,7 +38,10 @@ import { testExamples } from './examples.js';
  */
 export const testAll = (
   topo: Topo,
-  ctxOrFactory?: Partial<TrailContext> | (() => Partial<TrailContext>)
+  ctxOrFactory?:
+    | Partial<TrailContext>
+    | TestExecutionOptions
+    | (() => Partial<TrailContext> | TestExecutionOptions)
 ): void => {
   describe('governance', () => {
     test('topo validates', () => {

--- a/packages/testing/src/context.ts
+++ b/packages/testing/src/context.ts
@@ -2,7 +2,12 @@
  * Test context factory for creating TrailContext instances suitable for testing.
  */
 
-import type { FollowFn, TrailContext } from '@ontrails/core';
+import type {
+  FollowFn,
+  ServiceOverrideMap,
+  Topo,
+  TrailContext,
+} from '@ontrails/core';
 import { Result, createServiceLookup } from '@ontrails/core';
 
 import { createTestLogger } from './logger.js';
@@ -26,13 +31,15 @@ type MutableTrailContext = {
 export const createTestContext = (
   overrides?: TestTrailContextOptions
 ): TrailContext => {
+  const cwd = overrides?.cwd ?? process.cwd();
   const ctx = {
+    cwd,
     env: overrides?.env ?? { TRAILS_ENV: 'test' },
     extensions: undefined,
     logger: overrides?.logger ?? createTestLogger(),
     requestId: overrides?.requestId ?? 'test-request-001',
     signal: overrides?.signal ?? new AbortController().signal,
-    workspaceRoot: overrides?.cwd ?? process.cwd(),
+    workspaceRoot: cwd,
   } as MutableTrailContext;
   ctx.service = createServiceLookup(() => ctx);
   return ctx;
@@ -44,6 +51,11 @@ export const createTestContext = (
 
 export interface CreateFollowContextOptions {
   readonly responses?: Record<string, Result<unknown, Error>> | undefined;
+}
+
+export interface TestExecutionOptions {
+  readonly ctx?: Partial<TrailContext> | undefined;
+  readonly services?: ServiceOverrideMap | undefined;
 }
 
 /**
@@ -78,15 +90,61 @@ export const createFollowContext = (
   };
 };
 
+const isTestExecutionOptions = (
+  input: Partial<TrailContext> | TestExecutionOptions | undefined
+): input is TestExecutionOptions =>
+  input !== undefined &&
+  (Object.hasOwn(input, 'ctx') || Object.hasOwn(input, 'services'));
+
+export const normalizeTestExecutionOptions = (
+  input?: Partial<TrailContext> | TestExecutionOptions
+): TestExecutionOptions =>
+  isTestExecutionOptions(input) ? input : { ctx: input };
+
+export const mergeServiceOverrides = (
+  autoResolved: ServiceOverrideMap,
+  ctx: Partial<TrailContext> | undefined,
+  explicit: ServiceOverrideMap | undefined
+): ServiceOverrideMap => ({
+  ...autoResolved,
+  ...ctx?.extensions,
+  ...explicit,
+});
+
+const buildMockServices = async (app: Topo): Promise<ServiceOverrideMap> => {
+  const services: Record<string, unknown> = {};
+  for (const declaredService of app.listServices()) {
+    if (!declaredService.mock) {
+      continue;
+    }
+    services[declaredService.id] = await declaredService.mock();
+  }
+  return services;
+};
+
+export const resolveMockServices = async (
+  app: Topo
+): Promise<ServiceOverrideMap> => await buildMockServices(app);
+
 /**
  * Merge a Partial<TrailContext> into a test context.
  * Used internally when the public API accepts Partial<TrailContext>.
  */
-export const mergeTestContext = (ctx?: Partial<TrailContext>): TrailContext => {
-  if (ctx === undefined) {
-    return createTestContext();
-  }
-
+export const mergeTestContext = (
+  ctx?: Partial<TrailContext>,
+  services?: ServiceOverrideMap
+): TrailContext => {
   const base = createTestContext();
-  return { ...base, ...ctx };
+  const extensions = {
+    ...base.extensions,
+    ...ctx?.extensions,
+    ...services,
+  };
+  const merged = {
+    ...base,
+    ...ctx,
+    extensions: Object.keys(extensions).length === 0 ? undefined : extensions,
+  } as MutableTrailContext;
+  merged.service = createServiceLookup(() => merged);
+  return merged;
 };

--- a/packages/testing/src/contracts.ts
+++ b/packages/testing/src/contracts.ts
@@ -9,11 +9,17 @@
 import { describe, test } from 'bun:test';
 
 import type { Topo, TrailExample, Trail, TrailContext } from '@ontrails/core';
-import { formatZodIssues, validateInput } from '@ontrails/core';
+import { executeTrail, formatZodIssues, validateInput } from '@ontrails/core';
 import type { z } from 'zod';
 
 import { expectOk } from './assertions.js';
-import { mergeTestContext } from './context.js';
+import {
+  mergeServiceOverrides,
+  mergeTestContext,
+  normalizeTestExecutionOptions,
+  resolveMockServices,
+} from './context.js';
+import type { TestExecutionOptions } from './context.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -22,13 +28,13 @@ import { mergeTestContext } from './context.js';
 /** Check if a trail requires follow() but the context doesn't provide it. */
 const needsFollowContext = (
   t: unknown,
-  resolveCtx: () => Partial<TrailContext> | undefined
+  resolveCtx: () => Partial<TrailContext> | TestExecutionOptions | undefined
 ): boolean => {
   const spec = t as { follow?: readonly string[] };
   if (!spec.follow || spec.follow.length === 0) {
     return false;
   }
-  return !resolveCtx()?.follow;
+  return !normalizeTestExecutionOptions(resolveCtx()).ctx?.follow;
 };
 
 const validateOutputSchema = (
@@ -58,9 +64,12 @@ const validateOutputSchema = (
  */
 export const testContracts = (
   app: Topo,
-  ctxOrFactory?: Partial<TrailContext> | (() => Partial<TrailContext>)
+  ctxOrFactory?:
+    | Partial<TrailContext>
+    | TestExecutionOptions
+    | (() => Partial<TrailContext> | TestExecutionOptions)
 ): void => {
-  const resolveCtx =
+  const resolveInput =
     typeof ctxOrFactory === 'function' ? ctxOrFactory : () => ctxOrFactory;
   const allEntries = app.list() as Trail<unknown, unknown>[];
 
@@ -72,7 +81,7 @@ export const testContracts = (
       if (t.examples === undefined || t.examples.length === 0) {
         return;
       }
-      if (needsFollowContext(t, resolveCtx)) {
+      if (needsFollowContext(t, resolveInput)) {
         return;
       }
 
@@ -82,12 +91,21 @@ export const testContracts = (
       test.each(successExamples)(
         'contract: $name',
         async (example: TrailExample<unknown, unknown>) => {
-          const testCtx = mergeTestContext(resolveCtx());
+          const resolved = normalizeTestExecutionOptions(resolveInput());
+          const services = mergeServiceOverrides(
+            await resolveMockServices(app),
+            resolved.ctx,
+            resolved.services
+          );
+          const testCtx = mergeTestContext(resolved.ctx);
 
           const validated = validateInput(t.input, example.input);
-          const validatedInput = expectOk(validated);
+          expectOk(validated);
 
-          const result = await t.run(validatedInput, testCtx);
+          const result = await executeTrail(t, example.input, {
+            ctx: testCtx,
+            services,
+          });
           const resultValue = expectOk(result);
 
           validateOutputSchema(outputSchema, resultValue, t.id, example.name);

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -11,6 +11,7 @@ import { describe, expect, test } from 'bun:test';
 
 import type {
   FollowFn,
+  ServiceOverrideMap,
   Topo,
   TrailExample,
   Trail,
@@ -29,6 +30,7 @@ import {
   NotFoundError,
   PermissionError,
   RateLimitError,
+  executeTrail,
   Result,
   TimeoutError,
   TrailsError,
@@ -41,9 +43,14 @@ import {
   assertErrorMatch,
   assertFullMatch,
   assertSchemaMatch,
-  expectOk,
 } from './assertions.js';
-import { mergeTestContext } from './context.js';
+import {
+  mergeServiceOverrides,
+  mergeTestContext,
+  normalizeTestExecutionOptions,
+  resolveMockServices,
+} from './context.js';
+import type { TestExecutionOptions } from './context.js';
 
 // ---------------------------------------------------------------------------
 // Error class name -> constructor map
@@ -128,16 +135,19 @@ const runExample = async (
   t: Trail<unknown, unknown>,
   example: TrailExample<unknown, unknown>,
   output: z.ZodType | undefined,
-  testCtx: TrailContext
+  testCtx: TrailContext,
+  services?: ServiceOverrideMap
 ): Promise<void> => {
   const validated = validateInput(t.input, example.input);
 
   if (handleValidationError(validated, example)) {
     return;
   }
-  const validatedInput = expectOk(validated);
 
-  const result = await t.run(validatedInput, testCtx);
+  const result = await executeTrail(t, example.input, {
+    ctx: testCtx,
+    services,
+  });
   assertProgressiveMatch(result, example, output);
 };
 
@@ -156,7 +166,8 @@ const createCoverageFollow = (
   called: Set<string>,
   baseFollow: FollowFn | undefined,
   topo: Topo,
-  ctx: TrailContext
+  ctx: TrailContext,
+  services?: ServiceOverrideMap
 ): FollowFn => {
   const follow = (id: string, input: unknown) => {
     called.add(id);
@@ -167,11 +178,10 @@ const createCoverageFollow = (
 
     const trailDef = topo.get(id);
     if (trailDef !== undefined) {
-      const validated = validateInput(trailDef.input, input);
-      if (validated.isErr()) {
-        return Promise.resolve(validated);
-      }
-      return Promise.resolve(trailDef.run(validated.value, { ...ctx, follow }));
+      return executeTrail(trailDef, input, {
+        ctx: { ...ctx, follow },
+        services,
+      });
     }
 
     return Promise.resolve(Result.ok());
@@ -188,19 +198,28 @@ const runCompositionExample = async (
   output: z.ZodType | undefined,
   baseCtx: TrailContext,
   called: Set<string>,
-  topo: Topo
+  topo: Topo,
+  services?: ServiceOverrideMap
 ): Promise<void> => {
   const validated = validateInput(trailDef.input, example.input);
 
   if (handleValidationError(validated, example)) {
     return;
   }
-  const validatedInput = expectOk(validated);
 
-  const follow = createCoverageFollow(called, baseCtx.follow, topo, baseCtx);
+  const follow = createCoverageFollow(
+    called,
+    baseCtx.follow,
+    topo,
+    baseCtx,
+    services
+  );
   const testCtx: TrailContext = { ...baseCtx, follow };
 
-  const result = await trailDef.run(validatedInput, testCtx);
+  const result = await executeTrail(trailDef, example.input, {
+    ctx: testCtx,
+    services,
+  });
   assertProgressiveMatch(result, example, output);
 };
 
@@ -221,9 +240,12 @@ const runCompositionExample = async (
  */
 export const testExamples = (
   app: Topo,
-  ctxOrFactory?: Partial<TrailContext> | (() => Partial<TrailContext>)
+  ctxOrFactory?:
+    | Partial<TrailContext>
+    | TestExecutionOptions
+    | (() => Partial<TrailContext> | TestExecutionOptions)
 ): void => {
-  const resolveCtx =
+  const resolveInput =
     typeof ctxOrFactory === 'function' ? ctxOrFactory : () => ctxOrFactory;
   const allTrails = app.list() as Trail<unknown, unknown>[];
 
@@ -244,8 +266,14 @@ export const testExamples = (
       test.each([...examples])(
         'example: $name',
         async (example: TrailExample<unknown, unknown>) => {
-          const testCtx = mergeTestContext(resolveCtx());
-          await runExample(t, example, output, testCtx);
+          const resolved = normalizeTestExecutionOptions(resolveInput());
+          const services = mergeServiceOverrides(
+            await resolveMockServices(app),
+            resolved.ctx,
+            resolved.services
+          );
+          const testCtx = mergeTestContext(resolved.ctx);
+          await runExample(t, example, output, testCtx, services);
         }
       );
     });
@@ -264,8 +292,22 @@ export const testExamples = (
       test.each([...examples])(
         'example: $name',
         async (example: TrailExample<unknown, unknown>) => {
-          const baseCtx = mergeTestContext(resolveCtx());
-          await runCompositionExample(t, example, output, baseCtx, called, app);
+          const resolved = normalizeTestExecutionOptions(resolveInput());
+          const services = mergeServiceOverrides(
+            await resolveMockServices(app),
+            resolved.ctx,
+            resolved.services
+          );
+          const baseCtx = mergeTestContext(resolved.ctx);
+          await runCompositionExample(
+            t,
+            example,
+            output,
+            baseCtx,
+            called,
+            app,
+            services
+          );
         }
       );
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -25,6 +25,7 @@ export { createMcpHarness } from './harness-mcp.js';
 
 // Types
 export type { CreateFollowContextOptions } from './context.js';
+export type { TestExecutionOptions } from './context.js';
 export type { TestFollowOptions } from './follows.js';
 
 export type {


### PR DESCRIPTION
## Context
The testing helpers should exercise the same service resolution path as production, including mock factories, override precedence, and undeclared-service failures.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Taught `testExamples()`, `testContracts()`, and `testAll()` to resolve services through `executeTrail()`.
- Auto-resolved `service.mock` factories while still honoring explicit overrides.
- Fixed test context defaults so `cwd` and merged service accessors match runtime behavior.

## How To Test
- `bun test packages/testing/src/__tests__/examples.test.ts packages/testing/src/__tests__/contracts.test.ts packages/testing/src/__tests__/all.test.ts packages/testing/src/__tests__/context.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-79
