### PR TITLE
feat(testing): propagate service mocks through follows

### DIFF
--- a/packages/testing/src/__tests__/examples.test.ts
+++ b/packages/testing/src/__tests__/examples.test.ts
@@ -152,7 +152,6 @@ const undeclaredServiceTrail = trail('service.undeclared.examples', {
   run: (_input, ctx) =>
     Result.ok({ source: undeclaredDbService.from(ctx).source }),
 });
-
 const followedDbService = service('db.mock.examples.follow', {
   create: () => Result.ok({ source: 'factory' }),
   mock: () => ({ source: 'mock' }),

--- a/packages/testing/src/__tests__/follows.test.ts
+++ b/packages/testing/src/__tests__/follows.test.ts
@@ -1,7 +1,7 @@
 import { describe } from 'bun:test';
 
 import type { AnyTrail, TrailContext } from '@ontrails/core';
-import { Result, trail } from '@ontrails/core';
+import { InternalError, Result, service, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { testFollows } from '../follows.js';
@@ -228,5 +228,362 @@ describe('testFollows: nested follow chain (A → B → C)', () => {
       },
     ],
     { trails: nestedTrailsMap }
+  );
+});
+
+const mockDbService = service('db.mock.follows', {
+  create: () => Result.ok({ source: 'factory' }),
+  mock: () => ({ source: 'mock' }),
+});
+
+const serviceLeafTrail = trail('service.leaf', {
+  description: 'Leaf trail that reads from a service',
+  input: z.object({}),
+  output: z.object({ childSource: z.string() }),
+  run: (_input, ctx) =>
+    Result.ok({ childSource: mockDbService.from(ctx).source }),
+  services: [mockDbService],
+});
+
+const serviceRootTrail = trail('service.root', {
+  description: 'Root trail that reads from a service and follows a child trail',
+  follow: ['service.leaf'],
+  input: z.object({}),
+  output: z.object({ childSource: z.string(), rootSource: z.string() }),
+  run: async (_input, ctx: TrailContext) => {
+    if (!ctx.follow) {
+      return Result.err(new Error('follow not available'));
+    }
+    const childResult = await ctx.follow<{ childSource: string }>(
+      'service.leaf',
+      {}
+    );
+    if (childResult.isErr()) {
+      return childResult;
+    }
+
+    return Result.ok({
+      childSource: childResult.value.childSource,
+      rootSource: mockDbService.from(ctx).source,
+    });
+  },
+  services: [mockDbService],
+});
+
+const serviceTrailsMap = new Map<string, AnyTrail>([
+  ['service.leaf', serviceLeafTrail],
+]);
+
+const statefulMockDbService = service('db.mock.follows.stateful', {
+  create: () => Result.ok({ count: 0 }),
+  mock: () => ({ count: 0 }),
+});
+
+const statefulServiceLeafTrail = trail('service.stateful.leaf', {
+  description: 'Leaf trail that observes the current mock service state',
+  input: z.object({}),
+  output: z.object({ childCount: z.number() }),
+  run: (_input, ctx) =>
+    Result.ok({ childCount: statefulMockDbService.from(ctx).count }),
+  services: [statefulMockDbService],
+});
+
+const statefulServiceRootTrail = trail('service.stateful.root', {
+  description:
+    'Root trail that mutates a mocked service and follows a child trail',
+  follow: ['service.stateful.leaf'],
+  input: z.object({}),
+  output: z.object({ childCount: z.number(), rootCount: z.number() }),
+  run: async (_input, ctx: TrailContext) => {
+    if (!ctx.follow) {
+      return Result.err(new Error('follow not available'));
+    }
+
+    const statefulService = statefulMockDbService.from(ctx);
+    statefulService.count += 1;
+
+    const childResult = await ctx.follow<{ childCount: number }>(
+      'service.stateful.leaf',
+      {}
+    );
+    if (childResult.isErr()) {
+      return childResult;
+    }
+
+    return Result.ok({
+      childCount: childResult.value.childCount,
+      rootCount: statefulService.count,
+    });
+  },
+  services: [statefulMockDbService],
+});
+
+const statefulServiceTrailsMap = new Map<string, AnyTrail>([
+  ['service.stateful.leaf', statefulServiceLeafTrail],
+]);
+
+const scenarioStateService = service('db.mock.scenarios', {
+  create: () => Result.ok({ count: 0 }),
+  mock: () => ({ count: 0 }),
+});
+
+const scenarioLeafTrail = trail('service.scenario.leaf', {
+  description: 'Leaf trail that reads mutable scenario state',
+  input: z.object({}),
+  output: z.object({ count: z.number() }),
+  run: (_input, ctx) =>
+    Result.ok({ count: scenarioStateService.from(ctx).count }),
+  services: [scenarioStateService],
+});
+
+const scenarioRootTrail = trail('service.scenario.root', {
+  description: 'Root trail that mutates scenario state and follows a leaf',
+  follow: ['service.scenario.leaf'],
+  input: z.object({}),
+  output: z.object({ count: z.number() }),
+  run: async (_input, ctx: TrailContext) => {
+    if (!ctx.follow) {
+      return Result.err(new Error('follow not available'));
+    }
+
+    const state = scenarioStateService.from(ctx);
+    state.count += 1;
+
+    const leafResult = await ctx.follow<{ count: number }>(
+      'service.scenario.leaf',
+      {}
+    );
+    if (leafResult.isErr()) {
+      return leafResult;
+    }
+
+    return Result.ok({ count: leafResult.value.count });
+  },
+  services: [scenarioStateService],
+});
+
+const scenarioTrailsMap = new Map<string, AnyTrail>([
+  ['service.scenario.leaf', scenarioLeafTrail],
+]);
+
+const transformedFollowLeafTrail = trail('follow.transformed.leaf', {
+  description: 'Leaf trail in a transformed follow chain',
+  input: z.object({ value: z.number() }),
+  output: z.object({ value: z.number() }),
+  run: (input: { value: number }) => Result.ok({ value: input.value }),
+});
+
+const transformedFollowRootTrail = trail('follow.transformed.root', {
+  description: 'Root trail that transforms input once before following',
+  follow: ['follow.transformed.leaf'],
+  input: z
+    .object({ value: z.string() })
+    .transform(({ value }) => ({ value: Number(value) + 1 })),
+  output: z.object({ root: z.number() }),
+  run: async (input: { value: number }, ctx: TrailContext) => {
+    if (!ctx.follow) {
+      return Result.err(new Error('follow not available'));
+    }
+
+    const leafResult = await ctx.follow<{ value: number }>(
+      'follow.transformed.leaf',
+      { value: input.value }
+    );
+    if (leafResult.isErr()) {
+      return leafResult;
+    }
+
+    return Result.ok({ root: leafResult.value.value });
+  },
+});
+
+const transformedFollowTrailsMap = new Map<string, AnyTrail>([
+  ['follow.transformed.leaf', transformedFollowLeafTrail],
+]);
+
+const undeclaredFollowService = service('db.undeclared.follows', {
+  create: () => Result.ok({ source: 'factory' }),
+  mock: () => ({ source: 'mock' }),
+});
+
+const undeclaredServiceLeafTrail = trail('service.undeclared.leaf', {
+  description: 'Leaf trail that declares the shared service',
+  input: z.object({}),
+  output: z.object({ childSource: z.string() }),
+  run: (_input, ctx) =>
+    Result.ok({ childSource: undeclaredFollowService.from(ctx).source }),
+  services: [undeclaredFollowService],
+});
+
+const undeclaredServiceRootTrail = trail('service.undeclared.root', {
+  description: 'Root trail that uses a service without declaring it',
+  follow: ['service.undeclared.leaf'],
+  input: z.object({}),
+  output: z.object({ childSource: z.string(), rootSource: z.string() }),
+  run: async (_input, ctx: TrailContext) => {
+    if (!ctx.follow) {
+      return Result.err(new Error('follow not available'));
+    }
+
+    const childResult = await ctx.follow<{ childSource: string }>(
+      'service.undeclared.leaf',
+      {}
+    );
+    if (childResult.isErr()) {
+      return childResult;
+    }
+
+    return Result.ok({
+      childSource: childResult.value.childSource,
+      rootSource: undeclaredFollowService.from(ctx).source,
+    });
+  },
+});
+
+const undeclaredServiceTrailsMap = new Map<string, AnyTrail>([
+  ['service.undeclared.leaf', undeclaredServiceLeafTrail],
+]);
+
+const unrelatedFollowService = service('db.unrelated.follows', {
+  create: () => Result.ok({ source: 'factory' }),
+  mock: () => {
+    throw new Error('unrelated mock should not be resolved');
+  },
+});
+
+const unrelatedServiceTrail = trail('service.unrelated', {
+  description: 'Trail that should not be traversed or mocked',
+  input: z.object({}),
+  output: z.object({ source: z.string() }),
+  run: (_input, ctx) =>
+    Result.ok({ source: unrelatedFollowService.from(ctx).source }),
+  services: [unrelatedFollowService],
+});
+
+const unrelatedServiceTrailsMap = new Map<string, AnyTrail>([
+  ['service.unrelated', unrelatedServiceTrail],
+]);
+
+describe('testFollows service mocks', () => {
+  // eslint-disable-next-line jest/require-hook
+  testFollows(
+    serviceRootTrail,
+    [
+      {
+        description: 'propagates auto-resolved service mocks through follow',
+        expectValue: { childSource: 'mock', rootSource: 'mock' },
+        input: {},
+      },
+    ],
+    { trails: serviceTrailsMap }
+  );
+});
+
+describe('testFollows service mocks are fresh per scenario', () => {
+  // eslint-disable-next-line jest/require-hook
+  testFollows(
+    scenarioRootTrail,
+    [
+      {
+        description: 'first scenario sees a fresh mutable service',
+        expectValue: { count: 1 },
+        input: {},
+      },
+      {
+        description: 'second scenario also sees a fresh mutable service',
+        expectValue: { count: 1 },
+        input: {},
+      },
+    ],
+    { trails: scenarioTrailsMap }
+  );
+});
+
+describe('testFollows explicit service overrides', () => {
+  // eslint-disable-next-line jest/require-hook
+  testFollows(
+    serviceRootTrail,
+    [
+      {
+        description: 'propagates explicit service overrides through follow',
+        expectValue: { childSource: 'override', rootSource: 'override' },
+        input: {},
+      },
+    ],
+    {
+      services: { 'db.mock.follows': { source: 'override' } },
+      trails: serviceTrailsMap,
+    }
+  );
+});
+
+describe('testFollows raw transformed input', () => {
+  // eslint-disable-next-line jest/require-hook
+  testFollows(
+    transformedFollowRootTrail,
+    [
+      {
+        description: 'raw scenario input is only transformed once',
+        expectValue: { root: 2 },
+        input: { value: '1' },
+      },
+    ],
+    { trails: transformedFollowTrailsMap }
+  );
+});
+
+describe('testFollows service declarations', () => {
+  // eslint-disable-next-line jest/require-hook
+  testFollows(
+    undeclaredServiceRootTrail,
+    [
+      {
+        description: 'fails when the root trail omits a required service',
+        expectErr: InternalError,
+        expectErrMessage: undeclaredFollowService.id,
+        input: {},
+      },
+    ],
+    { trails: undeclaredServiceTrailsMap }
+  );
+});
+
+describe('testFollows only resolves mocks for trails under test', () => {
+  // eslint-disable-next-line jest/require-hook
+  testFollows(
+    serviceRootTrail,
+    [
+      {
+        description: 'unrelated service mocks are not resolved',
+        expectValue: { childSource: 'mock', rootSource: 'mock' },
+        input: {},
+      },
+    ],
+    {
+      trails: new Map<string, AnyTrail>([
+        ...serviceTrailsMap.entries(),
+        ...unrelatedServiceTrailsMap.entries(),
+      ]),
+    }
+  );
+});
+
+describe('testFollows fresh service mocks per scenario', () => {
+  // eslint-disable-next-line jest/require-hook
+  testFollows(
+    statefulServiceRootTrail,
+    [
+      {
+        description: 'first scenario gets a fresh service mock',
+        expectValue: { childCount: 1, rootCount: 1 },
+        input: {},
+      },
+      {
+        description: 'second scenario also gets a fresh service mock',
+        expectValue: { childCount: 1, rootCount: 1 },
+        input: {},
+      },
+    ],
+    { trails: statefulServiceTrailsMap }
   );
 });

--- a/packages/testing/src/follows.ts
+++ b/packages/testing/src/follows.ts
@@ -7,8 +7,14 @@
 
 import { describe, expect, test } from 'bun:test';
 
-import type { AnyTrail, FollowFn, TrailContext } from '@ontrails/core';
+import type {
+  AnyTrail,
+  FollowFn,
+  ServiceOverrideMap,
+  TrailContext,
+} from '@ontrails/core';
 import {
+  executeTrail,
   InternalError,
   Result,
   ValidationError,
@@ -19,9 +25,8 @@ import {
   assertErrorMatch,
   assertFullMatch,
   assertSchemaMatch,
-  expectOk,
 } from './assertions.js';
-import { mergeTestContext } from './context.js';
+import { mergeServiceOverrides, mergeTestContext } from './context.js';
 import type { FollowScenario } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -32,6 +37,58 @@ interface FollowRecord {
   readonly id: string;
   readonly input: unknown;
 }
+
+const collectDeclaredServices = (
+  trailDef: AnyTrail,
+  trailsMap: ReadonlyMap<string, AnyTrail> | undefined
+): AnyTrail['services'] => {
+  const seenServiceIds = new Set<string>();
+  const seenTrailIds = new Set<string>();
+  const services: AnyTrail['services'][number][] = [];
+
+  const collect = (candidate: AnyTrail): void => {
+    for (const declaredService of candidate.services) {
+      if (seenServiceIds.has(declaredService.id)) {
+        continue;
+      }
+      seenServiceIds.add(declaredService.id);
+      services.push(declaredService);
+    }
+  };
+
+  const visit = (candidate: AnyTrail): void => {
+    if (seenTrailIds.has(candidate.id)) {
+      return;
+    }
+    seenTrailIds.add(candidate.id);
+    collect(candidate);
+    for (const followedId of candidate.follow) {
+      const followedTrail = trailsMap?.get(followedId);
+      if (followedTrail) {
+        visit(followedTrail);
+      }
+    }
+  };
+
+  visit(trailDef);
+  return services;
+};
+
+const resolveMockServices = async (
+  trailDef: AnyTrail,
+  trailsMap: ReadonlyMap<string, AnyTrail> | undefined
+): Promise<ServiceOverrideMap> => {
+  const services: Record<string, unknown> = {};
+
+  for (const declaredService of collectDeclaredServices(trailDef, trailsMap)) {
+    if (!declaredService.mock) {
+      continue;
+    }
+    services[declaredService.id] = await declaredService.mock();
+  }
+
+  return services;
+};
 
 // ---------------------------------------------------------------------------
 // Injection helpers
@@ -91,6 +148,7 @@ const executeFromMap = (
   input: unknown,
   trailsMap: ReadonlyMap<string, AnyTrail> | undefined,
   ctx: TrailContext,
+  services: ServiceOverrideMap | undefined,
   follow?: FollowFn
 ): Result<unknown, Error> | Promise<Result<unknown, Error>> | undefined => {
   const trailDef = trailsMap?.get(id);
@@ -98,12 +156,11 @@ const executeFromMap = (
     return undefined;
   }
 
-  const validated = validateInput(trailDef.input, input);
-  if (validated.isErr()) {
-    return validated;
-  }
   const nestedCtx = follow ? { ...ctx, follow } : ctx;
-  return trailDef.run(validated.value, nestedCtx);
+  return executeTrail(trailDef, input, {
+    ctx: nestedCtx,
+    services,
+  });
 };
 
 // ---------------------------------------------------------------------------
@@ -118,7 +175,8 @@ const createRecordingFollow = (
   scenario: FollowScenario,
   trailsMap: ReadonlyMap<string, AnyTrail> | undefined,
   baseFollow: FollowFn | undefined,
-  ctx: TrailContext
+  ctx: TrailContext,
+  services: ServiceOverrideMap | undefined
 ): FollowFn => {
   // The generic O on FollowFn is erased at runtime; the cast is safe
   // because callers narrow via isOk/isErr before accessing the value.
@@ -139,6 +197,7 @@ const createRecordingFollow = (
       input,
       trailsMap,
       ctx,
+      services,
       follow as FollowFn
     );
     if (executed !== undefined) {
@@ -217,7 +276,8 @@ const handleValidationError = (
 const buildTestContext = (
   scenario: FollowScenario,
   ctx: Partial<TrailContext> | undefined,
-  trailsMap: ReadonlyMap<string, AnyTrail> | undefined
+  trailsMap: ReadonlyMap<string, AnyTrail> | undefined,
+  services: ServiceOverrideMap | undefined
 ): { trace: FollowRecord[]; testCtx: TrailContext } => {
   const trace: FollowRecord[] = [];
   const baseCtx = mergeTestContext(ctx);
@@ -226,7 +286,8 @@ const buildTestContext = (
     scenario,
     trailsMap,
     baseCtx.follow,
-    baseCtx
+    baseCtx,
+    services
   );
   return { testCtx: { ...baseCtx, follow }, trace };
 };
@@ -235,15 +296,24 @@ const runScenario = async (
   trailDef: AnyTrail,
   scenario: FollowScenario,
   ctx: Partial<TrailContext> | undefined,
-  trailsMap: ReadonlyMap<string, AnyTrail> | undefined
+  trailsMap: ReadonlyMap<string, AnyTrail> | undefined,
+  services: ServiceOverrideMap | undefined
 ): Promise<void> => {
   const validated = validateInput(trailDef.input, scenario.input);
   if (handleValidationError(validated, scenario)) {
     return;
   }
 
-  const { trace, testCtx } = buildTestContext(scenario, ctx, trailsMap);
-  const result = await trailDef.run(expectOk(validated), testCtx);
+  const { trace, testCtx } = buildTestContext(
+    scenario,
+    ctx,
+    trailsMap,
+    services
+  );
+  const result = await executeTrail(trailDef, scenario.input, {
+    ctx: testCtx,
+    services,
+  });
   assertFollowTrace(trace, scenario);
   assertScenarioResult(result, scenario, trailDef);
 };
@@ -256,6 +326,12 @@ const runScenario = async (
 export interface TestFollowOptions {
   /** Partial context overrides. */
   readonly ctx?: Partial<TrailContext> | undefined;
+  /**
+   * Explicit service overrides merged on top of auto-resolved mocks for every
+   * scenario. Values are passed by reference — provide immutable objects, or
+   * use `mock()` on the service definition to get a fresh instance per run.
+   */
+  readonly services?: ServiceOverrideMap | undefined;
   /** Map of trail ID to trail definition, used for injectFromExample. */
   readonly trails?: ReadonlyMap<string, AnyTrail> | undefined;
 }
@@ -284,7 +360,18 @@ export const testFollows = (
     test.each([...scenarios])(
       '$description',
       async (scenario: FollowScenario) => {
-        await runScenario(trailDef, scenario, options?.ctx, options?.trails);
+        const services = mergeServiceOverrides(
+          await resolveMockServices(trailDef, options?.trails),
+          options?.ctx,
+          options?.services
+        );
+        await runScenario(
+          trailDef,
+          scenario,
+          options?.ctx,
+          options?.trails,
+          services
+        );
       }
     );
   });


### PR DESCRIPTION
## Context
Follow-based composition should get the same service behavior as root trail execution, without leaking mock state between scenarios.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Propagated resolved service overrides through `testFollows()` and nested follow execution.
- Recreated mock services per scenario to prevent shared mutable state.
- Added regressions for undeclared service dependencies and follow-chain mock propagation.

## How To Test
- `bun test packages/testing/src/__tests__/follows.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-80
