### PR TITLE
feat(warden): add service declarations rule

### DIFF
--- a/packages/warden/src/__tests__/service-declarations.test.ts
+++ b/packages/warden/src/__tests__/service-declarations.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from 'bun:test';
+
+import { serviceDeclarations } from '../rules/service-declarations.js';
+
+const TEST_FILE = 'test.ts';
+
+describe('service-declarations', () => {
+  describe('clean cases', () => {
+    test('declared services match service.from(ctx) usage', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [db],
+  run: async (_input, ctx) => {
+    return Result.ok({ source: db.from(ctx).source });
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('local helper named service() is not treated as ctx lookup', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [db],
+  run: async (_input, ctx) => {
+    const service = (id: string) => id;
+    return Result.ok({
+      resolved: service('db.main'),
+      source: db.from(ctx).source,
+    });
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('declared services match ctx.service() usage', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [db],
+  run: async (_input, ctx) => {
+    const resolved = ctx.service('db.main');
+    return Result.ok(resolved);
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('recognizes destructured service() calls', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [db],
+  run: async (_input, ctx) => {
+    const { service } = ctx;
+    return Result.ok(service('db.main'));
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('error cases', () => {
+    test('service.from(ctx) without a declaration produces an error', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  run: async (_input, ctx) => {
+    return Result.ok({ source: db.from(ctx).source });
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.rule).toBe('service-declarations');
+      expect(diagnostics[0]?.message).toContain('db.from(ctx)');
+      expect(diagnostics[0]?.message).toContain('not declared in services');
+    });
+
+    test('ctx.service() without a declaration produces an error', () => {
+      const code = `
+trail('entity.show', {
+  run: async (_input, ctx) => {
+    return Result.ok(ctx.service('db.main'));
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain("ctx.service('db.main')");
+    });
+  });
+
+  describe('warn cases', () => {
+    test('declared but unused service produces a warning', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [db],
+  run: async () => {
+    return Result.ok({ ok: true });
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+      expect(diagnostics[0]?.rule).toBe('service-declarations');
+      expect(diagnostics[0]?.message).toContain("'db' declared in services");
+      expect(diagnostics[0]?.message).toContain('never used');
+    });
+  });
+
+  describe('single-object overload', () => {
+    test('recognizes trail({ id, services, run }) form', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail({
+  id: 'entity.show',
+  services: [db],
+  run: async (_input, ctx) => {
+    return Result.ok({ source: db.from(ctx).source });
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('context parameter naming', () => {
+    test('recognizes database.from(context) when second param is named context', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const database = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [database],
+  run: async (_input, context) => {
+    return Result.ok(database.from(context));
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('nested run false positives', () => {
+    test('metadata.run does not trigger false positives', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [db],
+  metadata: { run: async () => ctx.service('phantom') },
+  run: async (_input, ctx) => {
+    return Result.ok(db.from(ctx));
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 11 rule trails', () => {
-    expect(wardenTopo.count).toBe(11);
+  test('contains all 12 rule trails', () => {
+    expect(wardenTopo.count).toBe(12);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -26,6 +26,7 @@ export { noSyncResultAssumption } from './rules/no-sync-result-assumption.js';
 export { implementationReturnsResult } from './rules/implementation-returns-result.js';
 export { noThrowInDetourTarget } from './rules/no-throw-in-detour-target.js';
 export { preferSchemaInference } from './rules/prefer-schema-inference.js';
+export { serviceDeclarations } from './rules/service-declarations.js';
 export { validDescribeRefs } from './rules/valid-describe-refs.js';
 
 // Rule registry
@@ -62,6 +63,7 @@ export {
   preferSchemaInferenceTrail,
   ruleInput,
   ruleOutput,
+  serviceDeclarationsTrail,
   validDescribeRefsTrail,
   validDetourRefsTrail,
 } from './trails/index.js';

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -39,8 +39,26 @@ export const parse = (filePath: string, sourceCode: string): AstNode | null => {
 // Walker
 // ---------------------------------------------------------------------------
 
+type WalkFn = (node: unknown, visit: (node: AstNode) => void) => void;
+
+const walkChildren = (
+  node: AstNode,
+  visit: (node: AstNode) => void,
+  recurse: WalkFn
+): void => {
+  for (const val of Object.values(node)) {
+    if (Array.isArray(val)) {
+      for (const item of val) {
+        recurse(item, visit);
+      }
+    } else if (val && typeof val === 'object' && (val as AstNode).type) {
+      recurse(val, visit);
+    }
+  }
+};
+
 /** Walk an AST node tree, calling `visit` on every node. */
-export const walk = (node: unknown, visit: (node: AstNode) => void): void => {
+export const walk: WalkFn = (node, visit) => {
   if (!node || typeof node !== 'object') {
     return;
   }
@@ -48,15 +66,44 @@ export const walk = (node: unknown, visit: (node: AstNode) => void): void => {
   if (n.type) {
     visit(n);
   }
-  for (const val of Object.values(n)) {
-    if (Array.isArray(val)) {
-      for (const item of val) {
-        walk(item, visit);
-      }
-    } else if (val && typeof val === 'object' && (val as AstNode).type) {
-      walk(val, visit);
+  walkChildren(n, visit, walk);
+};
+
+const NESTED_SCOPE_TYPES = new Set([
+  'ArrowFunctionExpression',
+  'FunctionExpression',
+  'FunctionDeclaration',
+]);
+
+const walkScopeInner: WalkFn = (node, visit) => {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  const n = node as AstNode;
+  if (n.type) {
+    visit(n);
+    if (NESTED_SCOPE_TYPES.has(n.type)) {
+      return;
     }
   }
+  walkChildren(n, visit, walkScopeInner);
+};
+
+/**
+ * Walk an AST node tree without descending into nested function scopes.
+ * The root node is always traversed; only inner function boundaries are skipped.
+ * Useful for service-access analysis where inner functions may shadow
+ * the trail context parameter name.
+ */
+export const walkScope: WalkFn = (node, visit) => {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  const n = node as AstNode;
+  if (n.type) {
+    visit(n);
+  }
+  walkChildren(n, visit, walkScopeInner);
 };
 
 // ---------------------------------------------------------------------------
@@ -72,6 +119,119 @@ export const offsetToLine = (sourceCode: string, offset: number): number => {
     }
   }
   return line;
+};
+
+/** Get the name of an Identifier node, or null. */
+export const identifierName = (node: AstNode | undefined): string | null => {
+  if (node?.type !== 'Identifier') {
+    return null;
+  }
+  return (node as unknown as { name?: string }).name ?? null;
+};
+
+/** Check if a node is a string literal. */
+export const isStringLiteral = (node: AstNode | undefined): node is AstNode => {
+  if (!node) {
+    return false;
+  }
+  if (node.type === 'StringLiteral') {
+    return true;
+  }
+  if (node.type === 'Literal') {
+    return typeof (node as unknown as { value?: unknown }).value === 'string';
+  }
+  return false;
+};
+
+/** Extract the string value from a string literal node. */
+export const getStringValue = (node: AstNode): string | null => {
+  const val = (node as unknown as { value?: unknown }).value;
+  return typeof val === 'string' ? val : null;
+};
+
+/** Extract a string literal value, or null when the node is not a string. */
+export const extractStringLiteral = (
+  node: AstNode | undefined
+): string | null =>
+  node && isStringLiteral(node) ? getStringValue(node) : null;
+
+/** Extract the first string argument from a CallExpression. */
+export const extractFirstStringArg = (node: AstNode): string | null => {
+  if (node.type !== 'CallExpression') {
+    return null;
+  }
+
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  const [firstArg] = args ?? [];
+  return extractStringLiteral(firstArg);
+};
+
+const isServiceCall = (node: AstNode | undefined): boolean =>
+  !!node &&
+  node.type === 'CallExpression' &&
+  identifierName((node as unknown as { callee?: AstNode }).callee) ===
+    'service';
+
+const extractBindingName = (node: AstNode | undefined): string | null => {
+  if (!node) {
+    return null;
+  }
+  if (node.type === 'Identifier') {
+    return identifierName(node);
+  }
+  if (node.type === 'AssignmentPattern') {
+    return identifierName((node as unknown as { left?: AstNode }).left);
+  }
+  return null;
+};
+
+/** Collect `const foo = service('id', ...)` bindings from a parsed file. */
+export const collectNamedServiceIds = (
+  ast: AstNode
+): ReadonlyMap<string, string> => {
+  const ids = new Map<string, string>();
+
+  walk(ast, (node) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+
+    const { id, init } = node as unknown as {
+      readonly id?: AstNode;
+      readonly init?: AstNode;
+    };
+    if (!isServiceCall(init)) {
+      return;
+    }
+
+    const name = extractBindingName(id);
+    const serviceId = init ? extractFirstStringArg(init) : null;
+    if (name && serviceId) {
+      ids.set(name, serviceId);
+    }
+  });
+
+  return ids;
+};
+
+/** Collect all inline `service('id', ...)` definition IDs from a parsed file. */
+export const collectServiceDefinitionIds = (
+  ast: AstNode
+): ReadonlySet<string> => {
+  const ids = new Set<string>();
+
+  walk(ast, (node) => {
+    if (!isServiceCall(node)) {
+      return;
+    }
+
+    const id = extractFirstStringArg(node);
+    if (id) {
+      ids.add(id);
+    }
+  });
+
+  return ids;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -7,6 +7,7 @@ import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
+import { serviceDeclarations } from './service-declarations.js';
 import type { WardenRule } from './types.js';
 import { validDescribeRefs } from './valid-describe-refs.js';
 import { validDetourRefs } from './valid-detour-refs.js';
@@ -29,6 +30,7 @@ export { noSyncResultAssumption } from './no-sync-result-assumption.js';
 export { implementationReturnsResult } from './implementation-returns-result.js';
 export { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 export { preferSchemaInference } from './prefer-schema-inference.js';
+export { serviceDeclarations } from './service-declarations.js';
 export { validDescribeRefs } from './valid-describe-refs.js';
 
 /** All built-in warden rules, keyed by rule name. */
@@ -39,6 +41,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [noThrowInImplementation.name, noThrowInImplementation],
   [contextNoSurfaceTypes.name, contextNoSurfaceTypes],
   [followDeclarations.name, followDeclarations],
+  [serviceDeclarations.name, serviceDeclarations],
   [preferSchemaInference.name, preferSchemaInference],
   [validDescribeRefs.name, validDescribeRefs],
   [validDetourRefs.name, validDetourRefs],

--- a/packages/warden/src/rules/service-declarations.ts
+++ b/packages/warden/src/rules/service-declarations.ts
@@ -1,0 +1,552 @@
+/**
+ * Validates that service access matches the declared `services` array.
+ *
+ * Statically analyzes trail run functions to find `db.from(ctx)` and
+ * `ctx.service('db.main')` calls and compares them against the declared
+ * `services: [...]` array in the trail config. Reports errors for undeclared
+ * access and warnings for unused declarations.
+ */
+
+import {
+  collectNamedServiceIds,
+  extractFirstStringArg,
+  findConfigProperty,
+  findRunBodies,
+  findTrailDefinitions,
+  getStringValue,
+  identifierName,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  walkScope,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Service declaration extraction
+// ---------------------------------------------------------------------------
+
+interface DeclaredService {
+  readonly id: string | null;
+  readonly name: string | null;
+}
+
+interface CalledServices {
+  readonly fromNames: ReadonlySet<string>;
+  readonly lookupIds: ReadonlySet<string>;
+}
+
+const MEMBER_TYPES = new Set(['StaticMemberExpression', 'MemberExpression']);
+
+/** Extract object and property Identifier names from a MemberExpression. */
+const extractMemberPair = (
+  callee: AstNode
+): { objName: string; propName: string } | null => {
+  if (!MEMBER_TYPES.has(callee.type)) {
+    return null;
+  }
+
+  const objName = identifierName(
+    (callee as unknown as { object?: AstNode }).object
+  );
+  const propName = identifierName(
+    (callee as unknown as { property?: AstNode }).property
+  );
+
+  return objName && propName ? { objName, propName } : null;
+};
+
+/** Check if a node is an inline `service('id', ...)` call. */
+const isInlineServiceCall = (node: AstNode): boolean => {
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+  return (
+    identifierName((node as unknown as { callee?: AstNode }).callee) ===
+    'service'
+  );
+};
+
+/** Get `services` array elements from a trail config. */
+const getServiceElements = (config: AstNode): readonly AstNode[] => {
+  const servicesProp = findConfigProperty(config, 'services');
+  if (!servicesProp) {
+    return [];
+  }
+
+  const arrayNode = servicesProp.value;
+  if (!arrayNode || (arrayNode as AstNode).type !== 'ArrayExpression') {
+    return [];
+  }
+
+  const elements = (arrayNode as AstNode)['elements'] as
+    | readonly AstNode[]
+    | undefined;
+  return elements ?? [];
+};
+
+/** Extract one declared service from a `services` array element. */
+const extractDeclaredService = (
+  element: AstNode,
+  serviceIdsByName: ReadonlyMap<string, string>
+): DeclaredService | null => {
+  if (element.type === 'Identifier') {
+    const name = identifierName(element);
+    return {
+      id: name ? (serviceIdsByName.get(name) ?? null) : null,
+      name,
+    };
+  }
+
+  if (isStringLiteral(element)) {
+    return { id: getStringValue(element), name: null };
+  }
+
+  if (isInlineServiceCall(element)) {
+    return { id: extractFirstStringArg(element), name: null };
+  }
+
+  return null;
+};
+
+/** Extract declared services from a trail config's `services` array. */
+const extractDeclaredServices = (
+  config: AstNode,
+  serviceIdsByName: ReadonlyMap<string, string>
+): readonly DeclaredService[] => {
+  const elements = getServiceElements(config);
+
+  const declared: DeclaredService[] = [];
+
+  for (const element of elements) {
+    const service = extractDeclaredService(element, serviceIdsByName);
+    if (service) {
+      declared.push(service);
+    }
+  }
+
+  return declared;
+};
+
+// ---------------------------------------------------------------------------
+// Called service extraction
+// ---------------------------------------------------------------------------
+
+/** Extract the second parameter name from a run function node. */
+const extractContextParamName = (runBody: AstNode): string | null => {
+  const params = runBody['params'] as readonly AstNode[] | undefined;
+  if (!params || params.length < 2) {
+    return null;
+  }
+  return identifierName(params[1]);
+};
+
+/** Build the set of context parameter names to match against. */
+const buildCtxNames = (body: AstNode): ReadonlySet<string> => {
+  const ctxNames = new Set(['ctx', 'context']);
+  const paramName = extractContextParamName(body);
+  if (paramName) {
+    ctxNames.add(paramName);
+  }
+  return ctxNames;
+};
+
+/** Extract a CallExpression callee, or null. */
+const extractCallCallee = (node: AstNode): AstNode | null => {
+  if (node.type !== 'CallExpression') {
+    return null;
+  }
+  return ((node as unknown as { callee?: AstNode }).callee ??
+    null) as AstNode | null;
+};
+
+/** Extract the first identifier argument from a CallExpression. */
+const extractFirstIdentifierArg = (node: AstNode): string | null => {
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  const [firstArg] = args ?? [];
+  return identifierName(firstArg);
+};
+
+/** Extract `db.from(ctx)` object names. */
+const extractFromCallName = (
+  node: AstNode,
+  ctxNames: ReadonlySet<string>
+): string | null => {
+  const callee = extractCallCallee(node);
+  if (!callee) {
+    return null;
+  }
+
+  const pair = extractMemberPair(callee);
+  if (!pair || pair.propName !== 'from') {
+    return null;
+  }
+
+  const ctxName = extractFirstIdentifierArg(node);
+
+  return ctxName && ctxNames.has(ctxName) ? pair.objName : null;
+};
+
+/** Check if a callee is a member-style `ctx.service(...)` call. */
+const isMemberServiceCall = (
+  callee: AstNode,
+  ctxNames: ReadonlySet<string>
+): boolean => {
+  const pair = extractMemberPair(callee);
+  return !!pair && ctxNames.has(pair.objName) && pair.propName === 'service';
+};
+
+/** Extract `ctx.service('id')` and destructured `service('id')` lookup IDs. */
+const extractLookupServiceId = (
+  node: AstNode,
+  ctxNames: ReadonlySet<string>,
+  serviceAliases: ReadonlySet<string>
+): string | null => {
+  const callee = extractCallCallee(node);
+  if (!callee) {
+    return null;
+  }
+
+  if (isMemberServiceCall(callee, ctxNames)) {
+    return extractFirstStringArg(node);
+  }
+
+  if (serviceAliases.has(identifierName(callee) ?? '')) {
+    return extractFirstStringArg(node);
+  }
+
+  return null;
+};
+
+/** Collect local aliases for the service accessor (e.g. `const { service } = ctx`). */
+const collectServiceAliases = (
+  body: AstNode,
+  ctxNames: ReadonlySet<string>
+): ReadonlySet<string> => {
+  const aliases = new Set<string>();
+
+  const extractAliasNames = (
+    pattern: AstNode | undefined
+  ): readonly string[] => {
+    if (pattern?.type !== 'ObjectPattern') {
+      return [];
+    }
+
+    const properties = pattern['properties'] as readonly AstNode[] | undefined;
+    return (properties ?? []).flatMap((property) => {
+      if (property.type !== 'Property') {
+        return [];
+      }
+
+      const keyName = identifierName(
+        (property as unknown as { key?: AstNode }).key
+      );
+      if (keyName !== 'service') {
+        return [];
+      }
+
+      const alias =
+        identifierName((property as unknown as { value?: AstNode }).value) ??
+        keyName;
+      return [alias];
+    });
+  };
+
+  walkScope(body, (node) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+
+    const { id, init } = node as unknown as {
+      readonly id?: AstNode;
+      readonly init?: AstNode;
+    };
+    const initName = identifierName(init);
+    if (!initName || !ctxNames.has(initName)) {
+      return;
+    }
+
+    for (const alias of extractAliasNames(id)) {
+      aliases.add(alias);
+    }
+  });
+
+  return aliases;
+};
+
+/** Walk run bodies and collect service access that can be resolved statically. */
+const extractCalledServices = (config: AstNode): CalledServices => {
+  const fromNames = new Set<string>();
+  const lookupIds = new Set<string>();
+
+  for (const body of findRunBodies(config)) {
+    const ctxNames = buildCtxNames(body);
+    const serviceAliases = collectServiceAliases(body, ctxNames);
+
+    walkScope(body, (node) => {
+      const fromName = extractFromCallName(node, ctxNames);
+      if (fromName) {
+        fromNames.add(fromName);
+      }
+
+      const lookupId = extractLookupServiceId(node, ctxNames, serviceAliases);
+      if (lookupId) {
+        lookupIds.add(lookupId);
+      }
+    });
+  }
+
+  return { fromNames, lookupIds };
+};
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+const renderDeclaredService = (service: DeclaredService): string =>
+  service.name ?? service.id ?? '<unknown>';
+
+const buildUndeclaredFromDiagnostic = (
+  trailId: string,
+  serviceName: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}": ${serviceName}.from(ctx) called but '${serviceName}' is not declared in services`,
+  rule: 'service-declarations',
+  severity: 'error',
+});
+
+const buildUndeclaredLookupDiagnostic = (
+  trailId: string,
+  serviceId: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}": ctx.service('${serviceId}') called but '${serviceId}' is not declared in services`,
+  rule: 'service-declarations',
+  severity: 'error',
+});
+
+const buildUnusedDiagnostic = (
+  trailId: string,
+  declaredService: DeclaredService,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}": '${renderDeclaredService(declaredService)}' declared in services but never used`,
+  rule: 'service-declarations',
+  severity: 'warn',
+});
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+const serviceWasUsed = (
+  declaredService: DeclaredService,
+  calledServices: CalledServices
+): boolean => {
+  if (
+    declaredService.name &&
+    calledServices.fromNames.has(declaredService.name)
+  ) {
+    return true;
+  }
+
+  if (declaredService.id && calledServices.lookupIds.has(declaredService.id)) {
+    return true;
+  }
+
+  return false;
+};
+
+const buildDeclaredNames = (
+  declaredServices: readonly DeclaredService[]
+): ReadonlySet<string> =>
+  new Set(
+    declaredServices.flatMap((service) => (service.name ? [service.name] : []))
+  );
+
+const buildDeclaredIds = (
+  declaredServices: readonly DeclaredService[]
+): ReadonlySet<string> =>
+  new Set(
+    declaredServices.flatMap((service) => (service.id ? [service.id] : []))
+  );
+
+const reportUndeclaredFromCalls = (
+  trailId: string,
+  filePath: string,
+  line: number,
+  calledServices: CalledServices,
+  declaredNames: ReadonlySet<string>,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  for (const serviceName of calledServices.fromNames) {
+    if (!declaredNames.has(serviceName)) {
+      diagnostics.push(
+        buildUndeclaredFromDiagnostic(trailId, serviceName, filePath, line)
+      );
+    }
+  }
+};
+
+const reportUndeclaredLookupCalls = (
+  trailId: string,
+  filePath: string,
+  line: number,
+  calledServices: CalledServices,
+  declaredIds: ReadonlySet<string>,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  for (const serviceId of calledServices.lookupIds) {
+    if (!declaredIds.has(serviceId)) {
+      diagnostics.push(
+        buildUndeclaredLookupDiagnostic(trailId, serviceId, filePath, line)
+      );
+    }
+  }
+};
+
+const reportUnusedDeclarations = (
+  trailId: string,
+  filePath: string,
+  line: number,
+  declaredServices: readonly DeclaredService[],
+  calledServices: CalledServices,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  for (const declaredService of declaredServices) {
+    if (serviceWasUsed(declaredService, calledServices)) {
+      continue;
+    }
+
+    if (declaredService.name && declaredService.id === null) {
+      continue;
+    }
+
+    diagnostics.push(
+      buildUnusedDiagnostic(trailId, declaredService, filePath, line)
+    );
+  }
+};
+
+const hasNoServiceActivity = (
+  declaredServices: readonly DeclaredService[],
+  calledServices: CalledServices
+): boolean =>
+  declaredServices.length === 0 &&
+  calledServices.fromNames.size === 0 &&
+  calledServices.lookupIds.size === 0;
+
+const analyzeTrailServices = (
+  def: { config: AstNode; start: number },
+  sourceCode: string,
+  serviceIdsByName: ReadonlyMap<string, string>
+): {
+  readonly calledServices: CalledServices;
+  readonly declaredIds: ReadonlySet<string>;
+  readonly declaredNames: ReadonlySet<string>;
+  readonly declaredServices: readonly DeclaredService[];
+  readonly line: number;
+} => {
+  const declaredServices = extractDeclaredServices(
+    def.config,
+    serviceIdsByName
+  );
+  return {
+    calledServices: extractCalledServices(def.config),
+    declaredIds: buildDeclaredIds(declaredServices),
+    declaredNames: buildDeclaredNames(declaredServices),
+    declaredServices,
+    line: offsetToLine(sourceCode, def.start),
+  };
+};
+
+const checkTrailDefinition = (
+  def: { id: string; config: AstNode; start: number },
+  filePath: string,
+  sourceCode: string,
+  serviceIdsByName: ReadonlyMap<string, string>,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  const { calledServices, declaredIds, declaredNames, declaredServices, line } =
+    analyzeTrailServices(def, sourceCode, serviceIdsByName);
+
+  if (hasNoServiceActivity(declaredServices, calledServices)) {
+    return;
+  }
+
+  reportUndeclaredFromCalls(
+    def.id,
+    filePath,
+    line,
+    calledServices,
+    declaredNames,
+    diagnostics
+  );
+  reportUndeclaredLookupCalls(
+    def.id,
+    filePath,
+    line,
+    calledServices,
+    declaredIds,
+    diagnostics
+  );
+  reportUnusedDeclarations(
+    def.id,
+    filePath,
+    line,
+    declaredServices,
+    calledServices,
+    diagnostics
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Rule
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates that service access aligns with declared `services` arrays.
+ */
+export const serviceDeclarations: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isTestFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const diagnostics: WardenDiagnostic[] = [];
+    const serviceIdsByName = collectNamedServiceIds(ast);
+
+    for (const def of findTrailDefinitions(ast)) {
+      checkTrailDefinition(
+        def,
+        filePath,
+        sourceCode,
+        serviceIdsByName,
+        diagnostics
+      );
+    }
+
+    return diagnostics;
+  },
+  description:
+    'Ensure service.from(ctx) and ctx.service() calls match the declared services array in trail definitions.',
+  name: 'service-declarations',
+  severity: 'error',
+};

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -7,6 +7,7 @@ export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.j
 export { noThrowInDetourTargetTrail } from './no-throw-in-detour-target.trail.js';
 export { noThrowInImplementationTrail } from './no-throw-in-implementation.trail.js';
 export { preferSchemaInferenceTrail } from './prefer-schema-inference.trail.js';
+export { serviceDeclarationsTrail } from './service-declarations.trail.js';
 export { validDescribeRefsTrail } from './valid-describe-refs.trail.js';
 export { validDetourRefsTrail } from './valid-detour-refs.trail.js';
 

--- a/packages/warden/src/trails/service-declarations.trail.ts
+++ b/packages/warden/src/trails/service-declarations.trail.ts
@@ -1,0 +1,25 @@
+import { serviceDeclarations } from '../rules/service-declarations.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const serviceDeclarationsTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        sourceCode: `const db = service("db.main", {
+  create: () => Result.ok({ source: "factory" }),
+});
+
+trail("entity.show", {
+  services: [db],
+  run: async (_input, ctx) => {
+    return Result.ok(db.from(ctx));
+  }
+})`,
+      },
+      name: 'Matched service declarations and usage',
+    },
+  ],
+  rule: serviceDeclarations,
+});


### PR DESCRIPTION
## Context
Now that trails can declare `services`, governance needs to verify those declarations match actual `service.from(ctx)` and `ctx.service()` usage.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Added the `service-declarations` warden rule and trail.
- Covered direct, destructured, and object-based service access patterns.
- Surfaced both missing declarations as errors and unused declarations as warnings.

## How To Test
- `bun test packages/warden/src/__tests__/service-declarations.test.ts packages/warden/src/__tests__/trails.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-81
