### PR TITLE
feat(core): validate declared services in topo

### DIFF
--- a/packages/core/src/__tests__/validate-topo.test.ts
+++ b/packages/core/src/__tests__/validate-topo.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import { z } from 'zod';
 
 import { Result } from '../result.js';
+import { service } from '../service.js';
 import { topo } from '../topo.js';
 import type { TopoIssue } from '../validate-topo.js';
 import { validateTopo } from '../validate-topo.js';
@@ -25,6 +26,7 @@ const mockTrail = (
       error?: string;
     }[];
     output?: z.ZodType;
+    services?: readonly ReturnType<typeof service>[];
   }
 ) => ({
   follow: Object.freeze([...(overrides?.follow ?? [])]),
@@ -32,8 +34,14 @@ const mockTrail = (
   input: z.object({ name: z.string() }),
   kind: 'trail' as const,
   run: noop,
+  services: Object.freeze([...(overrides?.services ?? [])]),
   ...overrides,
 });
+
+const mockService = (id: string) =>
+  service(id, {
+    create: () => Result.ok({ id }),
+  });
 
 const mockEvent = (id: string, from?: readonly string[]) => ({
   from,
@@ -138,6 +146,38 @@ describe('validateTopo', () => {
 
       const result = validateTopo(app);
       expect(result.isOk()).toBe(true);
+    });
+  });
+
+  describe('service declarations', () => {
+    test('trail declaring a registered service passes', () => {
+      const db = mockService('db.main');
+      const app = topo('app', {
+        db,
+        show: mockTrail('entity.show', {
+          services: [db],
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isOk()).toBe(true);
+    });
+
+    test('trail declaring a missing service fails', () => {
+      const db = mockService('db.main');
+      const app = topo('app', {
+        show: mockTrail('entity.show', {
+          services: [db],
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isErr()).toBe(true);
+
+      const issues = extractIssues(result);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]?.rule).toBe('service-exists');
+      expect(issues[0]?.message).toContain('db.main');
     });
   });
 
@@ -261,8 +301,12 @@ describe('validateTopo', () => {
   });
 
   test('collects multiple issues', () => {
+    const db = mockService('db.main');
     const app = topo('app', {
       broken: mockTrail('entity.broken', { follow: ['entity.missing'] }),
+      missingService: mockTrail('entity.missing-service', {
+        services: [db],
+      }),
       show: mockTrail('entity.show', {
         examples: [{ input: { name: 123 }, name: 'Bad' }],
       }),
@@ -273,6 +317,6 @@ describe('validateTopo', () => {
     expect(result.isErr()).toBe(true);
 
     const issues = extractIssues(result);
-    expect(issues).toHaveLength(3);
+    expect(issues).toHaveLength(4);
   });
 });

--- a/packages/core/src/validate-topo.ts
+++ b/packages/core/src/validate-topo.ts
@@ -113,6 +113,27 @@ const checkFollows = (
   return issues;
 };
 
+const checkServices = (
+  trails: ReadonlyMap<string, AnyTrail>,
+  topo: Topo
+): TopoIssue[] => {
+  const issues: TopoIssue[] = [];
+
+  for (const [id, trail] of trails) {
+    for (const declaredService of trail.services) {
+      if (!topo.hasService(declaredService.id)) {
+        issues.push({
+          message: `Service "${declaredService.id}" is not in the topo`,
+          rule: 'service-exists',
+          trailId: id,
+        });
+      }
+    }
+  }
+
+  return issues;
+};
+
 const checkOneExample = (
   id: string,
   example: {
@@ -192,6 +213,7 @@ const checkEventOrigins = (
 export const validateTopo = (topo: Topo): Result<void, ValidationError> => {
   const issues = [
     ...checkFollows(topo.trails, topo),
+    ...checkServices(topo.trails, topo),
     ...checkExamples(topo.trails),
     ...checkEventOrigins(topo.events, topo),
   ];

--- a/packages/warden/src/__tests__/service-declarations.test.ts
+++ b/packages/warden/src/__tests__/service-declarations.test.ts
@@ -95,6 +95,27 @@ trail('entity.show', {
 
       expect(diagnostics.length).toBe(0);
     });
+
+    test('recognizes ctx.service(db) lookups by declared service object', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [db],
+  run: async (_input, ctx) => {
+    return Result.ok(ctx.service(db));
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
   });
 
   describe('error cases', () => {
@@ -136,6 +157,52 @@ trail('entity.show', {
       expect(diagnostics.length).toBe(1);
       expect(diagnostics[0]?.severity).toBe('error');
       expect(diagnostics[0]?.message).toContain("ctx.service('db.main')");
+    });
+
+    test('unresolved imported service declarations do not suppress lookup diagnostics', () => {
+      const code = `
+import { Result, trail } from '@ontrails/core';
+import { db } from './services';
+
+// const db = service('db.main', {
+//   create: () => Result.ok({ source: 'factory' }),
+// });
+
+trail('entity.show', {
+  services: [db],
+  run: async (_input, ctx) => {
+    return Result.ok(ctx.service('db.main'));
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain("ctx.service('db.main')");
+    });
+
+    test('ctx.service(db) without a declaration produces an error', () => {
+      const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  run: async (_input, ctx) => {
+    return Result.ok(ctx.service(db));
+  },
+});
+`;
+
+      const diagnostics = serviceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain('ctx.service(db)');
     });
   });
 
@@ -235,5 +302,17 @@ trail('entity.show', {
 
       expect(diagnostics.length).toBe(0);
     });
+  });
+
+  test('skips test files', () => {
+    const code = `
+trail('entity.show', {
+  run: async (_input, ctx) => {
+    return Result.ok(ctx.service('db.main'));
+  },
+});
+`;
+
+    expect(serviceDeclarations.check(code, 'entity.test.ts')).toEqual([]);
   });
 });

--- a/packages/warden/src/rules/service-declarations.ts
+++ b/packages/warden/src/rules/service-declarations.ts
@@ -36,6 +36,7 @@ interface DeclaredService {
 interface CalledServices {
   readonly fromNames: ReadonlySet<string>;
   readonly lookupIds: ReadonlySet<string>;
+  readonly lookupNames: ReadonlySet<string>;
 }
 
 const MEMBER_TYPES = new Set(['StaticMemberExpression', 'MemberExpression']);
@@ -115,20 +116,11 @@ const extractDeclaredService = (
 const extractDeclaredServices = (
   config: AstNode,
   serviceIdsByName: ReadonlyMap<string, string>
-): readonly DeclaredService[] => {
-  const elements = getServiceElements(config);
-
-  const declared: DeclaredService[] = [];
-
-  for (const element of elements) {
+): readonly DeclaredService[] =>
+  getServiceElements(config).flatMap((element) => {
     const service = extractDeclaredService(element, serviceIdsByName);
-    if (service) {
-      declared.push(service);
-    }
-  }
-
-  return declared;
-};
+    return service ? [service] : [];
+  });
 
 // ---------------------------------------------------------------------------
 // Called service extraction
@@ -169,24 +161,32 @@ const extractFirstIdentifierArg = (node: AstNode): string | null => {
   return identifierName(firstArg);
 };
 
+const extractCallInfo = (
+  node: AstNode
+): { callee: AstNode; firstArgName: string | null } | null => {
+  const callee = extractCallCallee(node);
+  return callee
+    ? {
+        callee,
+        firstArgName: extractFirstIdentifierArg(node),
+      }
+    : null;
+};
+
 /** Extract `db.from(ctx)` object names. */
 const extractFromCallName = (
   node: AstNode,
   ctxNames: ReadonlySet<string>
 ): string | null => {
-  const callee = extractCallCallee(node);
-  if (!callee) {
-    return null;
-  }
+  const call = extractCallInfo(node);
+  const pair = call ? extractMemberPair(call.callee) : null;
 
-  const pair = extractMemberPair(callee);
-  if (!pair || pair.propName !== 'from') {
-    return null;
-  }
-
-  const ctxName = extractFirstIdentifierArg(node);
-
-  return ctxName && ctxNames.has(ctxName) ? pair.objName : null;
+  return pair &&
+    pair.propName === 'from' &&
+    call?.firstArgName &&
+    ctxNames.has(call.firstArgName)
+    ? pair.objName
+    : null;
 };
 
 /** Check if a callee is a member-style `ctx.service(...)` call. */
@@ -196,6 +196,28 @@ const isMemberServiceCall = (
 ): boolean => {
   const pair = extractMemberPair(callee);
   return !!pair && ctxNames.has(pair.objName) && pair.propName === 'service';
+};
+
+/** Extract `ctx.service(db)` and destructured `service(db)` lookup names. */
+const extractLookupServiceName = (
+  node: AstNode,
+  ctxNames: ReadonlySet<string>,
+  serviceAliases: ReadonlySet<string>
+): string | null => {
+  const callee = extractCallCallee(node);
+  if (!callee) {
+    return null;
+  }
+
+  if (isMemberServiceCall(callee, ctxNames)) {
+    return extractFirstIdentifierArg(node);
+  }
+
+  if (serviceAliases.has(identifierName(callee) ?? '')) {
+    return extractFirstIdentifierArg(node);
+  }
+
+  return null;
 };
 
 /** Extract `ctx.service('id')` and destructured `service('id')` lookup IDs. */
@@ -213,7 +235,9 @@ const extractLookupServiceId = (
     return extractFirstStringArg(node);
   }
 
-  if (serviceAliases.has(identifierName(callee) ?? '')) {
+  const calleeName = identifierName(callee);
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  if (calleeName && serviceAliases.has(calleeName) && args?.length === 1) {
     return extractFirstStringArg(node);
   }
 
@@ -280,6 +304,7 @@ const collectServiceAliases = (
 const extractCalledServices = (config: AstNode): CalledServices => {
   const fromNames = new Set<string>();
   const lookupIds = new Set<string>();
+  const lookupNames = new Set<string>();
 
   for (const body of findRunBodies(config)) {
     const ctxNames = buildCtxNames(body);
@@ -295,10 +320,19 @@ const extractCalledServices = (config: AstNode): CalledServices => {
       if (lookupId) {
         lookupIds.add(lookupId);
       }
+
+      const lookupName = extractLookupServiceName(
+        node,
+        ctxNames,
+        serviceAliases
+      );
+      if (lookupName) {
+        lookupNames.add(lookupName);
+      }
     });
   }
 
-  return { fromNames, lookupIds };
+  return { fromNames, lookupIds, lookupNames };
 };
 
 // ---------------------------------------------------------------------------
@@ -334,6 +368,19 @@ const buildUndeclaredLookupDiagnostic = (
   severity: 'error',
 });
 
+const buildUndeclaredLookupNameDiagnostic = (
+  trailId: string,
+  serviceName: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}": ctx.service(${serviceName}) called but '${serviceName}' is not declared in services`,
+  rule: 'service-declarations',
+  severity: 'error',
+});
+
 const buildUnusedDiagnostic = (
   trailId: string,
   declaredService: DeclaredService,
@@ -357,7 +404,8 @@ const serviceWasUsed = (
 ): boolean => {
   if (
     declaredService.name &&
-    calledServices.fromNames.has(declaredService.name)
+    (calledServices.fromNames.has(declaredService.name) ||
+      calledServices.lookupNames.has(declaredService.name))
   ) {
     return true;
   }
@@ -406,8 +454,24 @@ const reportUndeclaredLookupCalls = (
   line: number,
   calledServices: CalledServices,
   declaredIds: ReadonlySet<string>,
+  declaredNames: ReadonlySet<string>,
   diagnostics: WardenDiagnostic[]
 ): void => {
+  for (const serviceName of calledServices.lookupNames) {
+    // Name-based lookup checks remain reliable even when an imported service ID
+    // cannot be resolved locally.
+    if (!declaredNames.has(serviceName)) {
+      diagnostics.push(
+        buildUndeclaredLookupNameDiagnostic(
+          trailId,
+          serviceName,
+          filePath,
+          line
+        )
+      );
+    }
+  }
+
   for (const serviceId of calledServices.lookupIds) {
     if (!declaredIds.has(serviceId)) {
       diagnostics.push(
@@ -446,7 +510,8 @@ const hasNoServiceActivity = (
 ): boolean =>
   declaredServices.length === 0 &&
   calledServices.fromNames.size === 0 &&
-  calledServices.lookupIds.size === 0;
+  calledServices.lookupIds.size === 0 &&
+  calledServices.lookupNames.size === 0;
 
 const analyzeTrailServices = (
   def: { config: AstNode; start: number },
@@ -500,6 +565,7 @@ const checkTrailDefinition = (
     line,
     calledServices,
     declaredIds,
+    declaredNames,
     diagnostics
   );
   reportUnusedDeclarations(


### PR DESCRIPTION
## Context
Topo validation should fail early when trails declare services the app does not actually register, and the declarations rule should understand that project context.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Added service existence checks to `validateTopo()`.
- Updated service-declarations rule coverage to cooperate with project-level service knowledge.
- Added regression coverage for valid and invalid declared services.

## How To Test
- `bun test packages/core/src/__tests__/validate-topo.test.ts packages/warden/src/__tests__/service-declarations.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-82
