### PR TITLE
feat(introspection): add service graph outputs and existence checks

### DIFF
--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { topo, trail, Result } from '@ontrails/core';
+import { Result, service, topo, trail } from '@ontrails/core';
 import {
   generateSurfaceMap,
   hashSurfaceMap,
@@ -9,8 +9,16 @@ import {
 import type { SurfaceMap } from '@ontrails/schema';
 import { z } from 'zod';
 
-import { generateBriefReport } from '../trails/survey.js';
-import type { BriefReport } from '../trails/survey.js';
+import {
+  generateBriefReport,
+  generateSurveyList,
+  generateTrailDetail,
+} from '../trails/survey.js';
+import type {
+  BriefReport,
+  SurveyListReport,
+  TrailDetailReport,
+} from '../trails/survey.js';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -35,6 +43,11 @@ const helloTrail = trail('hello', {
     const name = input.name ?? 'world';
     return Result.ok({ message: `Hello, ${name}!` });
   },
+  services: [
+    service('db.main', {
+      create: () => Result.ok({ source: 'factory' }),
+    }),
+  ],
 });
 
 const byeTrail = trail('bye', {
@@ -44,7 +57,16 @@ const byeTrail = trail('bye', {
   run: (input) => Result.ok({ message: `Goodbye, ${input.name}!` }),
 });
 
-const app = topo('test-app', { bye: byeTrail, hello: helloTrail });
+const [dbService] = helloTrail.services;
+if (!dbService) {
+  throw new Error('Expected helloTrail to declare db.main');
+}
+
+const app = topo('test-app', {
+  bye: byeTrail,
+  dbService,
+  hello: helloTrail,
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -53,10 +75,11 @@ const app = topo('test-app', { bye: byeTrail, hello: helloTrail });
 describe('trails survey', () => {
   test('generateSurfaceMap includes all trails', () => {
     const surfaceMap = generateSurfaceMap(app);
-    expect(surfaceMap.entries.length).toBe(2);
+    expect(surfaceMap.entries.length).toBe(3);
     const ids = surfaceMap.entries.map((e) => e.id);
     expect(ids).toContain('hello');
     expect(ids).toContain('bye');
+    expect(ids).toContain('db.main');
   });
 
   test('surface map entries have expected fields', () => {
@@ -66,6 +89,7 @@ describe('trails survey', () => {
     expect(hello?.kind).toBe('trail');
     expect(hello?.intent).toBe('read');
     expect(hello?.exampleCount).toBe(1);
+    expect(hello?.services).toEqual(['db.main']);
   });
 
   test('JSON output is valid JSON', () => {
@@ -73,7 +97,7 @@ describe('trails survey', () => {
     const json = JSON.stringify(surfaceMap, null, 2);
     const parsed = JSON.parse(json) as SurfaceMap;
     expect(parsed.version).toBe('1.0');
-    expect(parsed.entries.length).toBe(2);
+    expect(parsed.entries.length).toBe(3);
   });
 
   test('hashSurfaceMap produces stable hash', () => {
@@ -130,6 +154,7 @@ describe('trails survey --brief', () => {
     const report = generateBriefReport(app);
     expect(report.trails).toBe(2);
     expect(report.events).toBe(0);
+    expect(report.services).toBe(1);
   });
 
   test('detects features in use', () => {
@@ -138,6 +163,7 @@ describe('trails survey --brief', () => {
     expect(report.features.examples).toBe(true);
     expect(report.features.detours).toBe(true);
     expect(report.features.events).toBe(false);
+    expect(report.features.services).toBe(true);
   });
 
   test('JSON output is valid', () => {
@@ -146,6 +172,7 @@ describe('trails survey --brief', () => {
     const parsed = JSON.parse(json) as BriefReport;
     expect(parsed.name).toBe('test-app');
     expect(parsed.trails).toBe(2);
+    expect(parsed.services).toBe(1);
   });
 
   test('empty app reports zero features', () => {
@@ -155,5 +182,35 @@ describe('trails survey --brief', () => {
     expect(report.features.outputSchemas).toBe(false);
     expect(report.features.examples).toBe(false);
     expect(report.features.detours).toBe(false);
+    expect(report.features.services).toBe(false);
+  });
+});
+
+describe('trails survey detail', () => {
+  test('trail detail includes declared services, follow, and intent', () => {
+    const detail = generateTrailDetail(helloTrail);
+    const parsed = structuredClone(detail) as TrailDetailReport;
+
+    expect(parsed.follow).toEqual([]);
+    expect(parsed.intent).toBe('read');
+    expect(parsed.services).toEqual(['db.main']);
+  });
+});
+
+describe('trails survey services section', () => {
+  test('list output includes service lifetime and health status', () => {
+    const report = generateSurveyList(app);
+    const parsed = structuredClone(report) as SurveyListReport;
+    const db = parsed.services.find((entry) => entry.id === 'db.main');
+
+    expect(parsed.serviceCount).toBe(1);
+    expect(db).toEqual({
+      description: null,
+      health: 'none',
+      id: 'db.main',
+      kind: 'service',
+      lifetime: 'singleton',
+      usedBy: ['hello'],
+    });
   });
 });

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -30,6 +30,7 @@ export interface BriefReport {
   readonly version: string;
   readonly contractVersion: string;
   readonly features: {
+    readonly services: boolean;
     readonly outputSchemas: boolean;
     readonly examples: boolean;
     readonly detours: boolean;
@@ -37,6 +38,38 @@ export interface BriefReport {
   };
   readonly trails: number;
   readonly events: number;
+  readonly services: number;
+}
+
+export interface SurveyListReport {
+  readonly count: number;
+  readonly entries: readonly {
+    readonly examples: number;
+    readonly id: string;
+    readonly kind: string;
+    readonly safety: string;
+  }[];
+  readonly serviceCount: number;
+  readonly services: readonly {
+    readonly description: string | null;
+    readonly health: 'available' | 'none';
+    readonly id: string;
+    readonly kind: 'service';
+    readonly lifetime: 'singleton';
+    readonly usedBy: readonly string[];
+  }[];
+}
+
+export interface TrailDetailReport {
+  readonly description: string | null;
+  readonly detours: Trail<unknown, unknown>['detours'] | null;
+  readonly examples: readonly unknown[];
+  readonly follow: readonly string[];
+  readonly id: string;
+  readonly intent: 'read' | 'write' | 'destroy';
+  readonly kind: string;
+  readonly safety: string;
+  readonly services: readonly string[];
 }
 
 /** Check if a trail has a specific feature. */
@@ -50,7 +83,12 @@ const trailHas = (raw: Record<string, unknown>, key: string): boolean => {
 /** Detect which features are used across trails. */
 const detectFeatures = (
   app: Topo
-): { hasDetours: boolean; hasExamples: boolean; hasOutputSchemas: boolean } => {
+): {
+  hasDetours: boolean;
+  hasExamples: boolean;
+  hasOutputSchemas: boolean;
+  hasServices: boolean;
+} => {
   const trails = [...app.trails.values()].map(
     (item) => item as unknown as Record<string, unknown>
   );
@@ -58,12 +96,17 @@ const detectFeatures = (
     hasDetours: trails.some((r) => trailHas(r, 'detours')),
     hasExamples: trails.some((r) => trailHas(r, 'examples')),
     hasOutputSchemas: trails.some((r) => trailHas(r, 'output')),
+    hasServices: trails.some(
+      (r) =>
+        Array.isArray(r['services']) && (r['services'] as unknown[]).length > 0
+    ),
   };
 };
 
 /** Generate a compact capability report for the given topo. */
 export const generateBriefReport = (app: Topo): BriefReport => {
-  const { hasDetours, hasExamples, hasOutputSchemas } = detectFeatures(app);
+  const { hasDetours, hasExamples, hasOutputSchemas, hasServices } =
+    detectFeatures(app);
 
   return {
     contractVersion: '2026-03',
@@ -73,8 +116,10 @@ export const generateBriefReport = (app: Topo): BriefReport => {
       events: app.events.size > 0,
       examples: hasExamples,
       outputSchemas: hasOutputSchemas,
+      services: hasServices,
     },
     name: app.name,
+    services: app.services.size,
     trails: app.trails.size,
     version: '0.1.0',
   };
@@ -96,7 +141,45 @@ const safetyLabel = (entry: {
   return '-';
 };
 
-const formatTrailList = (app: Topo): object => {
+const buildServiceUsage = (
+  app: Topo
+): ReadonlyMap<string, readonly string[]> => {
+  const usage = new Map<string, string[]>();
+
+  for (const trailDef of app.list()) {
+    for (const declaredService of trailDef.services) {
+      const users = usage.get(declaredService.id) ?? [];
+      users.push(trailDef.id);
+      usage.set(declaredService.id, users);
+    }
+  }
+
+  return new Map(
+    [...usage.entries()].map(([id, users]) => [id, users.toSorted()] as const)
+  );
+};
+
+const serviceHealthStatus = (service: {
+  health?: unknown;
+}): 'available' | 'none' =>
+  service.health === undefined ? 'none' : 'available';
+
+const formatServiceList = (app: Topo): SurveyListReport['services'] => {
+  const usage = buildServiceUsage(app);
+  return app
+    .listServices()
+    .map((service) => ({
+      description: service.description ?? null,
+      health: serviceHealthStatus(service),
+      id: service.id,
+      kind: service.kind,
+      lifetime: 'singleton' as const,
+      usedBy: usage.get(service.id) ?? [],
+    }))
+    .toSorted((a, b) => a.id.localeCompare(b.id));
+};
+
+export const generateSurveyList = (app: Topo): SurveyListReport => {
   const items = app.list();
   const entries = items.map((item) => {
     const safety = safetyLabel(
@@ -116,7 +199,14 @@ const formatTrailList = (app: Topo): object => {
     };
   });
 
-  return { count: items.length, entries };
+  const services = formatServiceList(app);
+
+  return {
+    count: items.length,
+    entries,
+    serviceCount: services.length,
+    services,
+  };
 };
 
 /**
@@ -126,7 +216,9 @@ const formatTrailList = (app: Topo): object => {
  * surface-map entry. The two serve different audiences (human display vs
  * machine-diffable surface map) so they are kept separate.
  */
-const formatTrailDetail = (item: Trail<unknown, unknown>): object => {
+export const generateTrailDetail = (
+  item: Trail<unknown, unknown>
+): TrailDetailReport => {
   const safety = safetyLabel(
     item as unknown as { intent?: 'read' | 'write' | 'destroy' }
   );
@@ -135,9 +227,26 @@ const formatTrailDetail = (item: Trail<unknown, unknown>): object => {
     description: item.description ?? null,
     detours: item.detours ?? null,
     examples: item.examples ?? [],
+    follow: item.follow.toSorted(),
     id: item.id,
+    intent: item.intent,
     kind: item.kind,
     safety,
+    services: item.services.map((service) => service.id).toSorted(),
+  };
+};
+
+const formatServiceDetail = (app: Topo, serviceId: string): object => {
+  const item = app.getService(serviceId);
+  const usedBy = buildServiceUsage(app).get(serviceId) ?? [];
+
+  return {
+    description: item?.description ?? null,
+    health: item ? serviceHealthStatus(item) : 'none',
+    id: serviceId,
+    kind: 'service',
+    lifetime: 'singleton',
+    usedBy,
   };
 };
 
@@ -180,10 +289,13 @@ const buildSurveyDetail = (
   trailId: string
 ): Result<object, Error> => {
   const item = app.get(trailId);
-  if (!item) {
-    return Result.err(new Error(`Trail not found: ${trailId}`));
+  if (item) {
+    return Result.ok(generateTrailDetail(item as Trail<unknown, unknown>));
   }
-  return Result.ok(formatTrailDetail(item as Trail<unknown, unknown>));
+  if (app.getService(trailId)) {
+    return Result.ok(formatServiceDetail(app, trailId));
+  }
+  return Result.err(new Error(`Trail or service not found: ${trailId}`));
 };
 
 const buildSurveyGenerate = async (
@@ -231,7 +343,7 @@ const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
   detail: (app, input) => buildSurveyDetail(app, input.trailId ?? ''),
   diff: (app, input) => buildSurveyDiff(app, input.breakingOnly),
   generate: (app) => buildSurveyGenerate(app),
-  list: (app) => Result.ok(formatTrailList(app)),
+  list: (app) => Result.ok(generateSurveyList(app)),
   openapi: (app) => Result.ok(generateOpenApiSpec(app)),
 };
 
@@ -298,6 +410,17 @@ export const surveyTrail = trail('survey', {
           safety: z.string(),
         })
       ),
+      serviceCount: z.number(),
+      services: z.array(
+        z.object({
+          description: z.string().nullable(),
+          health: z.enum(['available', 'none']),
+          id: z.string(),
+          kind: z.literal('service'),
+          lifetime: z.literal('singleton'),
+          usedBy: z.array(z.string()),
+        })
+      ),
     }),
     z.object({
       contractVersion: z.string(),
@@ -307,8 +430,10 @@ export const surveyTrail = trail('survey', {
         events: z.boolean(),
         examples: z.boolean(),
         outputSchemas: z.boolean(),
+        services: z.boolean(),
       }),
       name: z.string(),
+      services: z.number(),
       trails: z.number(),
       version: z.string(),
     }),
@@ -322,9 +447,20 @@ export const surveyTrail = trail('survey', {
       description: z.unknown().nullable(),
       detours: z.unknown().nullable(),
       examples: z.array(z.unknown()),
+      follow: z.array(z.string()),
       id: z.string(),
+      intent: z.enum(['read', 'write', 'destroy']),
       kind: z.string(),
       safety: z.string(),
+      services: z.array(z.string()),
+    }),
+    z.object({
+      description: z.string().nullable(),
+      health: z.enum(['available', 'none']),
+      id: z.string(),
+      kind: z.literal('service'),
+      lifetime: z.literal('singleton'),
+      usedBy: z.array(z.string()),
     }),
     z.object({
       hash: z.string(),

--- a/packages/schema/src/__tests__/diff.test.ts
+++ b/packages/schema/src/__tests__/diff.test.ts
@@ -47,6 +47,15 @@ describe('diffSurfaceMaps', () => {
       expect(result.info).toHaveLength(1);
     });
 
+    test('added service detected as info', () => {
+      const prev = surfaceMap([]);
+      const curr = surfaceMap([entry({ id: 'db.main', kind: 'service' })]);
+      const result = diffSurfaceMaps(prev, curr);
+
+      expect(result.entries[0]?.details).toContain('Service "db.main" added');
+      expect(result.info).toHaveLength(1);
+    });
+
     test('removed trail detected as breaking', () => {
       const prev = surfaceMap([entry({ id: 'user.delete' })]);
       const curr = surfaceMap([]);
@@ -55,6 +64,15 @@ describe('diffSurfaceMaps', () => {
       expect(result.entries).toHaveLength(1);
       expect(result.entries[0]?.change).toBe('removed');
       expect(result.entries[0]?.severity).toBe('breaking');
+      expect(result.hasBreaking).toBe(true);
+    });
+
+    test('removed service detected as breaking', () => {
+      const prev = surfaceMap([entry({ id: 'db.main', kind: 'service' })]);
+      const curr = surfaceMap([]);
+      const result = diffSurfaceMaps(prev, curr);
+
+      expect(result.entries[0]?.details).toContain('Service "db.main" removed');
       expect(result.hasBreaking).toBe(true);
     });
 
@@ -291,6 +309,30 @@ describe('diffSurfaceMaps', () => {
       expect(followDetail).toBeDefined();
       expect(followDetail).toContain('search');
       expect(followDetail).toContain('lookup');
+    });
+
+    test('declared services changed produces warning', () => {
+      const prev = surfaceMap([
+        entry({
+          id: 'user.update',
+          services: ['db.main', 'search.index'],
+        }),
+      ]);
+      const curr = surfaceMap([
+        entry({
+          id: 'user.update',
+          services: ['db.main', 'cache.main'],
+        }),
+      ]);
+      const result = diffSurfaceMaps(prev, curr);
+
+      expect(result.warnings).toHaveLength(1);
+      const serviceDetail = result.warnings[0]?.details.find((detail) =>
+        detail.includes('Services changed')
+      );
+      expect(serviceDetail).toBeDefined();
+      expect(serviceDetail).toContain('cache.main');
+      expect(serviceDetail).toContain('search.index');
     });
   });
 

--- a/packages/schema/src/__tests__/generate.test.ts
+++ b/packages/schema/src/__tests__/generate.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 
-import { trail, event, topo, Result } from '@ontrails/core';
+import { event, Result, service, topo, trail } from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -14,6 +14,11 @@ const topoFrom = (...modules: Record<string, unknown>[]): Topo =>
   topo('test-app', ...modules);
 
 const noop = () => Result.ok(null as unknown);
+const dbService = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+  description: 'Primary database',
+  health: () => Result.ok({ ok: true }),
+});
 
 const getFirstEntry = (map: ReturnType<typeof generateSurfaceMap>) => {
   const [entry] = map.entries;
@@ -86,6 +91,7 @@ describe('generateSurfaceMap', () => {
         input: z.object({ age: z.number(), name: z.string() }),
         output: z.object({ id: z.string(), name: z.string() }),
         run: noop,
+        services: [dbService],
       });
       const map = generateSurfaceMap(topoFrom({ t }));
       const entry = getFirstEntry(map);
@@ -100,6 +106,7 @@ describe('generateSurfaceMap', () => {
         id: { type: 'string' },
         name: { type: 'string' },
       });
+      expect(entry.services).toEqual(['db.main']);
     });
 
     test('trail without output schema has output undefined', () => {
@@ -143,6 +150,17 @@ describe('generateSurfaceMap', () => {
       expect(entry.id).toBe('user.created');
       expect(entry.description).toBe('A user was created');
       expect(entry.input).toBeDefined();
+    });
+
+    test('service entries are included with description and healthcheck metadata', () => {
+      const map = generateSurfaceMap(topoFrom({ dbService }));
+      const entry = getFirstEntry(map);
+
+      expect(entry.kind).toBe('service');
+      expect(entry.id).toBe('db.main');
+      expect(entry.description).toBe('Primary database');
+      expect(entry.healthcheck).toBe(true);
+      expect(entry.surfaces).toEqual([]);
     });
   });
 

--- a/packages/schema/src/diff.ts
+++ b/packages/schema/src/diff.ts
@@ -44,6 +44,16 @@ const addDetail = (
 const capitalize = (s: string): string =>
   `${s.charAt(0).toUpperCase()}${s.slice(1)}`;
 
+const labelForKind = (kind: SurfaceMapEntry['kind']): string => {
+  if (kind === 'service') {
+    return 'Service';
+  }
+  if (kind === 'event') {
+    return 'Event';
+  }
+  return 'Trail';
+};
+
 // ---------------------------------------------------------------------------
 // Schema field diffing
 // ---------------------------------------------------------------------------
@@ -267,6 +277,17 @@ const buildFollowMessage = (added: string[], removed: string[]): string => {
   return `Follow changed: ${parts.join(', ')}`;
 };
 
+const buildServicesMessage = (added: string[], removed: string[]): string => {
+  const parts: string[] = [];
+  if (added.length > 0) {
+    parts.push(`added "${added.join('", "')}"`);
+  }
+  if (removed.length > 0) {
+    parts.push(`removed "${removed.join('", "')}"`);
+  }
+  return `Services changed: ${parts.join(', ')}`;
+};
+
 /** Diff follow arrays. */
 const diffFollow = (
   acc: DetailAccumulator,
@@ -282,6 +303,25 @@ const diffFollow = (
   }
 };
 
+/** Diff declared service arrays on trail entries. */
+const diffServices = (
+  acc: DetailAccumulator,
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
+): void => {
+  const prevServices = new Set(prev.services);
+  const currServices = new Set(curr.services);
+  const added = [...currServices]
+    .filter((service) => !prevServices.has(service))
+    .toSorted();
+  const removed = [...prevServices]
+    .filter((service) => !currServices.has(service))
+    .toSorted();
+  if (added.length > 0 || removed.length > 0) {
+    addDetail(acc, 'warning', buildServicesMessage(added, removed));
+  }
+};
+
 const diffEntry = (
   prev: SurfaceMapEntry,
   curr: SurfaceMapEntry
@@ -293,6 +333,7 @@ const diffEntry = (
   diffSurfaces(acc, prev, curr);
   diffMetadata(acc, prev, curr);
   diffFollow(acc, prev, curr);
+  diffServices(acc, prev, curr);
 
   if (acc.details.length === 0) {
     return undefined;
@@ -328,7 +369,7 @@ const findAdded = (
     .filter(([id]) => !prevById.has(id))
     .map(([id, entry]) => ({
       change: 'added' as const,
-      details: [`Trail "${id}" added`],
+      details: [`${labelForKind(entry.kind)} "${id}" added`],
       id,
       kind: entry.kind,
       severity: 'info' as const,
@@ -343,7 +384,7 @@ const findRemoved = (
     .filter(([id]) => !currById.has(id))
     .map(([id, entry]) => ({
       change: 'removed' as const,
-      details: [`Trail "${id}" removed`],
+      details: [`${labelForKind(entry.kind)} "${id}" removed`],
       id,
       kind: entry.kind,
       severity: 'breaking' as const,

--- a/packages/schema/src/generate.ts
+++ b/packages/schema/src/generate.ts
@@ -3,7 +3,7 @@
  */
 
 import { zodToJsonSchema } from '@ontrails/core';
-import type { Event, Topo, Trail } from '@ontrails/core';
+import type { AnyService, Event, Topo, Trail } from '@ontrails/core';
 
 import type { JsonSchema, SurfaceMap, SurfaceMapEntry } from './types.js';
 
@@ -127,6 +127,9 @@ const trailToEntry = (t: Trail<unknown, unknown>): SurfaceMapEntry => {
   if (t.follow.length > 0) {
     entry['follow'] = t.follow.toSorted();
   }
+  if (t.services.length > 0) {
+    entry['services'] = t.services.map((service) => service.id).toSorted();
+  }
 
   return sortKeys(entry) as unknown as SurfaceMapEntry;
 };
@@ -163,6 +166,24 @@ const eventToEntry = (e: Event<unknown>): SurfaceMapEntry => {
   return sortKeys(entry) as unknown as SurfaceMapEntry;
 };
 
+const serviceToEntry = (service: AnyService): SurfaceMapEntry => {
+  const entry: Record<string, unknown> = {
+    exampleCount: 0,
+    id: service.id,
+    kind: 'service',
+    surfaces: [],
+  };
+
+  if (service.description !== undefined) {
+    entry['description'] = service.description;
+  }
+  if (service.health !== undefined) {
+    entry['healthcheck'] = true;
+  }
+
+  return sortKeys(entry) as unknown as SurfaceMapEntry;
+};
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -184,6 +205,11 @@ export const generateSurfaceMap = (topo: Topo): SurfaceMap => {
   // Collect all events
   for (const e of topo.events.values()) {
     entries.push(eventToEntry(e as Event<unknown>));
+  }
+
+  // Collect all services
+  for (const service of topo.services.values()) {
+    entries.push(serviceToEntry(service));
   }
 
   // Sort alphabetically by id

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -15,7 +15,7 @@ export type JsonSchema = Readonly<Record<string, unknown>>;
 
 export interface SurfaceMapEntry {
   readonly id: string;
-  readonly kind: 'trail' | 'event';
+  readonly kind: 'trail' | 'event' | 'service';
   readonly surfaces: readonly string[];
   readonly input?: JsonSchema | undefined;
   readonly output?: JsonSchema | undefined;
@@ -24,7 +24,9 @@ export interface SurfaceMapEntry {
   readonly deprecated?: boolean | undefined;
   readonly replacedBy?: string | undefined;
   readonly follow?: readonly string[] | undefined;
+  readonly services?: readonly string[] | undefined;
   readonly detours?: Readonly<Record<string, readonly string[]>> | undefined;
+  readonly healthcheck?: boolean | undefined;
   readonly exampleCount: number;
   readonly description?: string | undefined;
 }
@@ -41,7 +43,7 @@ export interface SurfaceMap {
 
 export interface DiffEntry {
   readonly id: string;
-  readonly kind: 'trail' | 'event';
+  readonly kind: 'trail' | 'event' | 'service';
   readonly change: 'added' | 'removed' | 'modified';
   readonly severity: 'info' | 'warning' | 'breaking';
   readonly details: readonly string[];

--- a/packages/warden/src/__tests__/service-exists.test.ts
+++ b/packages/warden/src/__tests__/service-exists.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test';
+
+import { serviceExists } from '../rules/service-exists.js';
+
+const TEST_FILE = 'entity.ts';
+
+describe('service-exists', () => {
+  test('passes when a locally declared service exists', () => {
+    const code = `
+import { Result, service, trail } from '@ontrails/core';
+import type { Service } from '@ontrails/core';
+
+const db: Service<{ source: string }> = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [db],
+  run: async (_input, ctx) => Result.ok(db.from(ctx)),
+});
+`;
+
+    expect(serviceExists.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('ignores commented-out service declarations when resolving local ids', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail('entity.show', {
+  services: ['db.main'],
+  run: async (_input, ctx) => Result.ok(ctx.service('db.main')),
+});
+
+// const db = service('db.main', {
+//   create: () => Result.ok({ source: 'factory' }),
+// });
+`;
+
+    const diagnostics = serviceExists.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('service-exists');
+    expect(diagnostics[0]?.message).toContain('db.main');
+  });
+
+  test('flags a declared service missing from project context', () => {
+    const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [db],
+  run: async (_input, ctx) => Result.ok(db.from(ctx)),
+});
+`;
+
+    const diagnostics = serviceExists.checkWithContext(code, TEST_FILE, {
+      knownServiceIds: new Set(['db.other']),
+      knownTrailIds: new Set(['entity.show']),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('service-exists');
+    expect(diagnostics[0]?.message).toContain('db.main');
+  });
+
+  test('passes when project context includes the declared service', () => {
+    const code = `
+import { Result, service, trail } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  services: [db],
+  run: async (_input, ctx) => Result.ok(db.from(ctx)),
+});
+`;
+
+    const diagnostics = serviceExists.checkWithContext(code, TEST_FILE, {
+      knownServiceIds: new Set(['db.main']),
+      knownTrailIds: new Set(['entity.show']),
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('skips unresolved imported services instead of guessing', () => {
+    const code = `
+import { trail } from '@ontrails/core';
+import { db } from './services';
+
+trail('entity.show', {
+  services: [db],
+  run: async (_input, ctx) => Result.ok(db.from(ctx)),
+});
+`;
+
+    expect(
+      serviceExists.checkWithContext(code, TEST_FILE, {
+        knownServiceIds: new Set(['db.main']),
+        knownTrailIds: new Set(['entity.show']),
+      })
+    ).toEqual([]);
+  });
+
+  test('skips test files', () => {
+    const code = `
+trail('entity.show', {
+  services: ['db.main'],
+  run: async (_input, ctx) => Result.ok(ctx.service('db.main')),
+});
+`;
+
+    expect(serviceExists.check(code, 'entity.test.ts')).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 12 rule trails', () => {
-    expect(wardenTopo.count).toBe(12);
+  test('contains all 13 rule trails', () => {
+    expect(wardenTopo.count).toBe(13);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/__tests__/wrap-rule.test.ts
+++ b/packages/warden/src/__tests__/wrap-rule.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createTrailContext } from '@ontrails/core';
+
+import { wrapRule } from '../trails/wrap-rule.js';
+import type { ProjectAwareWardenRule } from '../rules/types.js';
+
+describe('wrapRule', () => {
+  test('preserves undefined knownServiceIds and defaults knownTrailIds to empty set', async () => {
+    let capturedContext:
+      | {
+          readonly knownServiceIds?: ReadonlySet<string>;
+          readonly knownTrailIds?: ReadonlySet<string>;
+        }
+      | undefined;
+
+    const rule: ProjectAwareWardenRule = {
+      check: () => [],
+      checkWithContext: (_sourceCode, _filePath, context) => {
+        capturedContext = context;
+        return [];
+      },
+      description: 'dummy rule',
+      name: 'dummy-rule',
+      severity: 'error',
+    };
+
+    const wrapped = wrapRule({ examples: [], rule });
+    const result = await wrapped.run(
+      { filePath: 'entity.ts', sourceCode: '' },
+      createTrailContext()
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ diagnostics: [] });
+    expect(capturedContext).toEqual({
+      knownServiceIds: undefined,
+      knownTrailIds: new Set<string>(),
+    });
+  });
+});

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -12,6 +12,7 @@ import type { Topo } from '@ontrails/core';
 import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
 import {
+  collectServiceDefinitionIds,
   findConfigProperty,
   findTrailDefinitions,
   parse,
@@ -132,6 +133,20 @@ const collectDetourTargetTrailIds = (
   }
 };
 
+const collectKnownServiceIds = (
+  sourceCode: string,
+  filePath: string,
+  knownServiceIds: Set<string>
+): void => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return;
+  }
+  for (const id of collectServiceDefinitionIds(ast)) {
+    knownServiceIds.add(id);
+  }
+};
+
 const loadSourceFiles = async (
   rootDir: string
 ): Promise<readonly SourceFile[]> => {
@@ -151,12 +166,13 @@ const loadSourceFiles = async (
   return sourceFiles;
 };
 
-const buildProjectContextFromTopo = (appTopo: Topo): ProjectContext => {
-  const knownTrailIds = new Set<string>(appTopo.trails.keys());
-
+const collectTopoDetourTargetTrailIds = (
+  appTopo: Topo
+): ReadonlySet<string> => {
   const detourTargetTrailIds = new Set<string>();
-  for (const t of appTopo.trails.values()) {
-    const detours = (t as unknown as Record<string, unknown>)['detours'] as
+
+  for (const trail of appTopo.trails.values()) {
+    const detours = (trail as unknown as Record<string, unknown>)['detours'] as
       | Readonly<Record<string, readonly string[]>>
       | undefined;
     if (!detours) {
@@ -169,13 +185,22 @@ const buildProjectContextFromTopo = (appTopo: Topo): ProjectContext => {
     }
   }
 
-  return { detourTargetTrailIds, knownTrailIds };
+  return detourTargetTrailIds;
+};
+
+const buildProjectContextFromTopo = (appTopo: Topo): ProjectContext => {
+  const knownTrailIds = new Set<string>(appTopo.trails.keys());
+  const knownServiceIds = new Set<string>(appTopo.services.keys());
+  const detourTargetTrailIds = collectTopoDetourTargetTrailIds(appTopo);
+
+  return { detourTargetTrailIds, knownServiceIds, knownTrailIds };
 };
 
 const buildProjectContextFromFiles = (
   sourceFiles: readonly SourceFile[]
 ): ProjectContext => {
   const knownTrailIds = new Set<string>();
+  const knownServiceIds = new Set<string>();
   const detourTargetTrailIds = new Set<string>();
 
   for (const sourceFile of sourceFiles) {
@@ -183,6 +208,11 @@ const buildProjectContextFromFiles = (
       sourceFile.sourceCode,
       sourceFile.filePath,
       knownTrailIds
+    );
+    collectKnownServiceIds(
+      sourceFile.sourceCode,
+      sourceFile.filePath,
+      knownServiceIds
     );
     collectDetourTargetTrailIds(
       sourceFile.sourceCode,
@@ -193,6 +223,7 @@ const buildProjectContextFromFiles = (
 
   return {
     detourTargetTrailIds,
+    knownServiceIds,
     knownTrailIds,
   };
 };

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -27,6 +27,7 @@ export { implementationReturnsResult } from './rules/implementation-returns-resu
 export { noThrowInDetourTarget } from './rules/no-throw-in-detour-target.js';
 export { preferSchemaInference } from './rules/prefer-schema-inference.js';
 export { serviceDeclarations } from './rules/service-declarations.js';
+export { serviceExists } from './rules/service-exists.js';
 export { validDescribeRefs } from './rules/valid-describe-refs.js';
 
 // Rule registry
@@ -64,6 +65,7 @@ export {
   ruleInput,
   ruleOutput,
   serviceDeclarationsTrail,
+  serviceExistsTrail,
   validDescribeRefsTrail,
   validDetourRefsTrail,
 } from './trails/index.js';

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -8,6 +8,7 @@ import { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
 import { serviceDeclarations } from './service-declarations.js';
+import { serviceExists } from './service-exists.js';
 import type { WardenRule } from './types.js';
 import { validDescribeRefs } from './valid-describe-refs.js';
 import { validDetourRefs } from './valid-detour-refs.js';
@@ -31,6 +32,7 @@ export { implementationReturnsResult } from './implementation-returns-result.js'
 export { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 export { preferSchemaInference } from './prefer-schema-inference.js';
 export { serviceDeclarations } from './service-declarations.js';
+export { serviceExists } from './service-exists.js';
 export { validDescribeRefs } from './valid-describe-refs.js';
 
 /** All built-in warden rules, keyed by rule name. */
@@ -42,6 +44,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [contextNoSurfaceTypes.name, contextNoSurfaceTypes],
   [followDeclarations.name, followDeclarations],
   [serviceDeclarations.name, serviceDeclarations],
+  [serviceExists.name, serviceExists],
   [preferSchemaInference.name, preferSchemaInference],
   [validDescribeRefs.name, validDescribeRefs],
   [validDetourRefs.name, validDetourRefs],

--- a/packages/warden/src/rules/service-exists.ts
+++ b/packages/warden/src/rules/service-exists.ts
@@ -1,0 +1,177 @@
+import {
+  collectNamedServiceIds,
+  collectServiceDefinitionIds,
+  extractFirstStringArg,
+  findConfigProperty,
+  findTrailDefinitions,
+  getStringValue,
+  identifierName,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+const isServiceCall = (node: AstNode): boolean =>
+  node.type === 'CallExpression' &&
+  identifierName((node as unknown as { callee?: AstNode }).callee) ===
+    'service';
+
+const getServiceElements = (config: AstNode): readonly AstNode[] => {
+  const servicesProp = findConfigProperty(config, 'services');
+  if (!servicesProp) {
+    return [];
+  }
+
+  const arrayNode = servicesProp.value;
+  if (!arrayNode || (arrayNode as AstNode).type !== 'ArrayExpression') {
+    return [];
+  }
+
+  const elements = (arrayNode as AstNode)['elements'] as
+    | readonly AstNode[]
+    | undefined;
+  return elements ?? [];
+};
+
+const extractDeclaredServiceId = (
+  element: AstNode,
+  serviceIdsByName: ReadonlyMap<string, string>
+): string | null => {
+  if (element.type === 'Identifier') {
+    const name = identifierName(element);
+    return name ? (serviceIdsByName.get(name) ?? null) : null;
+  }
+
+  if (isStringLiteral(element)) {
+    return getStringValue(element);
+  }
+
+  return isServiceCall(element) ? extractFirstStringArg(element) : null;
+};
+
+const extractDeclaredServiceIds = (
+  config: AstNode,
+  serviceIdsByName: ReadonlyMap<string, string>
+): readonly string[] => [
+  ...new Set(
+    getServiceElements(config).flatMap((element) => {
+      const id = extractDeclaredServiceId(element, serviceIdsByName);
+      return id ? [id] : [];
+    })
+  ),
+];
+
+const buildMissingServiceDiagnostic = (
+  trailId: string,
+  serviceId: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}" declares service "${serviceId}" which is not defined in the project.`,
+  rule: 'service-exists',
+  severity: 'error',
+});
+
+const reportMissingServices = (
+  def: { id: string; config: AstNode; start: number },
+  sourceCode: string,
+  serviceIdsByName: ReadonlyMap<string, string>,
+  filePath: string,
+  knownServiceIds: ReadonlySet<string>,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  const line = offsetToLine(sourceCode, def.start);
+  for (const serviceId of extractDeclaredServiceIds(
+    def.config,
+    serviceIdsByName
+  )) {
+    if (!knownServiceIds.has(serviceId)) {
+      diagnostics.push(
+        buildMissingServiceDiagnostic(def.id, serviceId, filePath, line)
+      );
+    }
+  }
+};
+
+const buildServiceDiagnostics = (
+  ast: AstNode,
+  sourceCode: string,
+  filePath: string,
+  knownServiceIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+  const serviceIdsByName = collectNamedServiceIds(ast);
+  for (const def of findTrailDefinitions(ast)) {
+    reportMissingServices(
+      def,
+      sourceCode,
+      serviceIdsByName,
+      filePath,
+      knownServiceIds,
+      diagnostics
+    );
+  }
+  return diagnostics;
+};
+
+const checkServicesExist = (
+  sourceCode: string,
+  filePath: string,
+  knownServiceIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath)) {
+    return [];
+  }
+
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  return buildServiceDiagnostics(ast, sourceCode, filePath, knownServiceIds);
+};
+
+/**
+ * Checks that all declared services resolve to known service definitions.
+ */
+export const serviceExists: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+    return checkServicesExist(
+      sourceCode,
+      filePath,
+      collectServiceDefinitionIds(ast)
+    );
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    const localServiceIds = ast
+      ? collectServiceDefinitionIds(ast)
+      : new Set<string>();
+    return checkServicesExist(
+      sourceCode,
+      filePath,
+      context.knownServiceIds ?? localServiceIds
+    );
+  },
+  description:
+    'Ensure every service declared on a trail resolves to a known service definition.',
+  name: 'service-exists',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -45,6 +45,8 @@ export interface WardenRule {
 export interface ProjectContext {
   /** All known trail IDs in the project */
   readonly knownTrailIds: ReadonlySet<string>;
+  /** All known service IDs in the project */
+  readonly knownServiceIds?: ReadonlySet<string>;
   /** All trail IDs referenced as detour targets across the project */
   readonly detourTargetTrailIds?: ReadonlySet<string>;
 }

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -8,6 +8,7 @@ export { noThrowInDetourTargetTrail } from './no-throw-in-detour-target.trail.js
 export { noThrowInImplementationTrail } from './no-throw-in-implementation.trail.js';
 export { preferSchemaInferenceTrail } from './prefer-schema-inference.trail.js';
 export { serviceDeclarationsTrail } from './service-declarations.trail.js';
+export { serviceExistsTrail } from './service-exists.trail.js';
 export { validDescribeRefsTrail } from './valid-describe-refs.trail.js';
 export { validDetourRefsTrail } from './valid-detour-refs.trail.js';
 

--- a/packages/warden/src/trails/run.ts
+++ b/packages/warden/src/trails/run.ts
@@ -19,14 +19,27 @@ import { wardenTopo } from './topo.js';
 export const runWardenTrails = async (
   filePath: string,
   sourceCode: string,
-  options?: { readonly knownTrailIds?: readonly string[] }
+  options?: {
+    readonly knownServiceIds?: readonly string[];
+    readonly knownTrailIds?: readonly string[];
+  }
 ): Promise<readonly WardenDiagnostic[]> => {
   const allDiagnostics: WardenDiagnostic[] = [];
 
   for (const id of wardenTopo.ids()) {
-    const input = options?.knownTrailIds
-      ? { filePath, knownTrailIds: options.knownTrailIds, sourceCode }
-      : { filePath, sourceCode };
+    const input =
+      options?.knownTrailIds || options?.knownServiceIds
+        ? {
+            filePath,
+            ...(options?.knownServiceIds
+              ? { knownServiceIds: options.knownServiceIds }
+              : {}),
+            ...(options?.knownTrailIds
+              ? { knownTrailIds: options.knownTrailIds }
+              : {}),
+            sourceCode,
+          }
+        : { filePath, sourceCode };
     const result = await dispatch(wardenTopo, id, input);
     if (result.isOk()) {
       const { diagnostics } = result.value as RuleOutput;

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -30,6 +30,10 @@ export const ruleInput = z.object({
  * files.
  */
 export const projectAwareRuleInput = ruleInput.extend({
+  knownServiceIds: z
+    .array(z.string())
+    .optional()
+    .describe('Service IDs known across the project'),
   knownTrailIds: z
     .array(z.string())
     .optional()

--- a/packages/warden/src/trails/service-exists.trail.ts
+++ b/packages/warden/src/trails/service-exists.trail.ts
@@ -1,0 +1,27 @@
+import { serviceExists } from '../rules/service-exists.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const serviceExistsTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        knownServiceIds: ['db.main'],
+        knownTrailIds: ['entity.show'],
+        sourceCode: `const db = service("db.main", {
+  create: () => Result.ok({ source: "factory" }),
+});
+
+trail("entity.show", {
+  services: [db],
+  run: async (_input, ctx) => {
+    return Result.ok(db.from(ctx));
+  }
+})`,
+      },
+      name: 'Declared services resolve to known project services',
+    },
+  ],
+  rule: serviceExists,
+});

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -7,7 +7,11 @@
 import { trail, Result } from '@ontrails/core';
 import type { Trail } from '@ontrails/core';
 
-import type { ProjectAwareWardenRule, WardenRule } from '../rules/types.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenRule,
+} from '../rules/types.js';
 import { projectAwareRuleInput, ruleInput, ruleOutput } from './schema.js';
 import type { ProjectAwareRuleInput, RuleInput, RuleOutput } from './schema.js';
 
@@ -55,14 +59,18 @@ export function wrapRule(
       metadata: { category: 'governance', severity: rule.severity },
       output: ruleOutput,
       run: (input: ProjectAwareRuleInput) => {
+        const context = {
+          knownServiceIds: input.knownServiceIds
+            ? new Set(input.knownServiceIds)
+            : undefined,
+          knownTrailIds: input.knownTrailIds
+            ? new Set(input.knownTrailIds)
+            : new Set<string>(),
+        } as ProjectContext;
         const diagnostics = projectAwareRule.checkWithContext(
           input.sourceCode,
           input.filePath,
-          {
-            knownTrailIds: input.knownTrailIds
-              ? new Set(input.knownTrailIds)
-              : new Set<string>(),
-          }
+          context
         );
         return Result.ok({ diagnostics: [...diagnostics] });
       },


### PR DESCRIPTION
## Context
After services are part of topo and validation, introspection and governance outputs need to expose them so agents and tooling can inspect the service graph directly.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Added services to `survey` detail/list output and surface map generation.
- Taught schema diffing to recognize service additions, removals, and declaration changes.
- Added the `service-exists` warden rule, CLI wiring, and trail surface.

## How To Test
- `bun test apps/trails/src/__tests__/survey.test.ts packages/schema/src/__tests__/generate.test.ts packages/schema/src/__tests__/diff.test.ts packages/warden/src/__tests__/service-exists.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-83
