### PR TITLE
feat(demo): convert demo app to use services

### DIFF
--- a/apps/trails-demo/__tests__/entity.test.ts
+++ b/apps/trails-demo/__tests__/entity.test.ts
@@ -7,6 +7,7 @@
 import { NotFoundError, AlreadyExistsError } from '@ontrails/core';
 import { testTrail } from '@ontrails/testing';
 
+import { entityStoreService } from '../src/services/entity-store.js';
 import { createStore } from '../src/store.js';
 import { show, add, remove, list } from '../src/trails/entity.js';
 
@@ -18,6 +19,12 @@ const store = createStore([
   { name: 'Alpha', tags: ['core'], type: 'concept' },
   { name: 'Beta', tags: ['automation'], type: 'tool' },
 ]);
+
+const ctx = {
+  extensions: {
+    [entityStoreService.id]: store,
+  },
+};
 
 // ---------------------------------------------------------------------------
 // entity.show
@@ -33,7 +40,7 @@ testTrail(
       input: { name: 'alpha' },
     },
   ],
-  { extensions: { store } }
+  ctx
 );
 
 // ---------------------------------------------------------------------------
@@ -55,7 +62,7 @@ testTrail(
       input: { name: 'Alpha', type: 'concept' },
     },
   ],
-  { extensions: { store } }
+  ctx
 );
 
 // ---------------------------------------------------------------------------
@@ -72,7 +79,7 @@ testTrail(
       input: { name: 'does-not-exist' },
     },
   ],
-  { extensions: { store } }
+  ctx
 );
 
 // ---------------------------------------------------------------------------
@@ -94,5 +101,5 @@ testTrail(
       input: { type: 'nonexistent-type' },
     },
   ],
-  { extensions: { store } }
+  ctx
 );

--- a/apps/trails-demo/__tests__/examples.test.ts
+++ b/apps/trails-demo/__tests__/examples.test.ts
@@ -6,14 +6,6 @@
 import { testAll } from '@ontrails/testing';
 
 import { app } from '../src/app.js';
-import { createStore } from '../src/store.js';
 
 // oxlint-disable-next-line require-hook -- testAll registers tests at module level by design
-testAll(app, () => ({
-  extensions: {
-    store: createStore([
-      { name: 'Alpha', tags: ['core'], type: 'concept' },
-      { name: 'Deletable', tags: ['temp'], type: 'tool' },
-    ]),
-  },
-}));
+testAll(app);

--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -23,6 +23,7 @@ import { z } from 'zod';
 
 import { app } from '../src/app.js';
 import * as entityEvents from '../src/events/entity-events.js';
+import * as demoServices from '../src/services/entity-store.js';
 import * as entity from '../src/trails/entity.js';
 import * as kv from '../src/trails/kv.js';
 import * as onboard from '../src/trails/onboard.js';
@@ -35,7 +36,7 @@ import * as search from '../src/trails/search.js';
 describe('surface map generation', () => {
   const surfaceMap = generateSurfaceMap(app);
 
-  test('contains all expected trail IDs', () => {
+  test('contains all expected trail, event, and service IDs', () => {
     const ids = surfaceMap.entries.map((e) => e.id);
 
     expect(ids).toContain('entity.show');
@@ -46,10 +47,11 @@ describe('surface map generation', () => {
     expect(ids).toContain('entity.onboard');
     expect(ids).toContain('entity.updated');
     expect(ids).toContain('demo.upsert');
+    expect(ids).toContain('demo.entity-store');
   });
 
-  test('has exactly 8 entries (7 trails + 1 event)', () => {
-    expect(surfaceMap.entries).toHaveLength(8);
+  test('has exactly 9 entries (7 trails + 1 event + 1 service)', () => {
+    expect(surfaceMap.entries).toHaveLength(9);
   });
 
   test('entries are sorted alphabetically by id', () => {
@@ -61,7 +63,7 @@ describe('surface map generation', () => {
   test('each entry has the expected fields', () => {
     for (const entry of surfaceMap.entries) {
       expect(entry.id).toBeString();
-      expect(entry.kind).toBeOneOf(['trail', 'event']);
+      expect(entry.kind).toBeOneOf(['trail', 'event', 'service']);
       expect(entry.exampleCount).toBeNumber();
       expect(Array.isArray(entry.surfaces)).toBe(true);
     }
@@ -107,6 +109,19 @@ describe('surface map generation', () => {
     if (updatedEntry) {
       expect(updatedEntry.kind).toBe('event');
       expect(updatedEntry.input).toBeDefined();
+    }
+  });
+
+  test('service entries include their description', () => {
+    const serviceEntry = surfaceMap.entries.find(
+      (e) => e.id === 'demo.entity-store'
+    );
+    expect(serviceEntry).toBeDefined();
+    if (serviceEntry) {
+      expect(serviceEntry.kind).toBe('service');
+      expect(serviceEntry.description).toBe(
+        'In-memory entity store used by the demo trails app.'
+      );
     }
   });
 });
@@ -178,6 +193,7 @@ const makeModifiedShow = (inputSchema: z.ZodType) =>
         updatedAt: '',
       });
     },
+    services: [demoServices.entityStoreService],
   });
 
 /** Diff the baseline app against a modified app. */
@@ -197,7 +213,9 @@ describe('breaking change detection', () => {
       { ...entity, show: modifiedShow },
       search,
       onboard,
-      entityEvents
+      entityEvents,
+      kv,
+      demoServices
     );
 
     expect(diff.hasBreaking).toBe(true);
@@ -213,7 +231,7 @@ describe('breaking change detection', () => {
   });
 
   test('removed trail is detected as breaking', () => {
-    const diff = diffAgainst(entity, onboard, entityEvents);
+    const diff = diffAgainst(entity, onboard, entityEvents, kv, demoServices);
 
     expect(diff.hasBreaking).toBe(true);
     const searchRemoved = diff.breaking.find((e) => e.id === 'search');
@@ -240,9 +258,15 @@ describe('non-breaking change detection', () => {
       run: (input) => Result.ok({ name: input.name, updated: true }),
     });
 
-    const diff = diffAgainst(entity, search, onboard, entityEvents, kv, {
-      update,
-    });
+    const diff = diffAgainst(
+      entity,
+      search,
+      onboard,
+      entityEvents,
+      kv,
+      demoServices,
+      { update }
+    );
     expect(diff.hasBreaking).toBe(false);
 
     const addedEntry = diff.info.find((e) => e.id === 'entity.update');
@@ -262,7 +286,8 @@ describe('non-breaking change detection', () => {
       search,
       onboard,
       entityEvents,
-      kv
+      kv,
+      demoServices
     );
     expect(diff.hasBreaking).toBe(false);
 

--- a/apps/trails-demo/__tests__/onboard.test.ts
+++ b/apps/trails-demo/__tests__/onboard.test.ts
@@ -15,6 +15,7 @@ import {
 import { expectErr } from '@ontrails/testing';
 import type { Trail, TrailContext } from '@ontrails/core';
 
+import { entityStoreService } from '../src/services/entity-store.js';
 import type { EntityStore } from '../src/store.js';
 import { createStore } from '../src/store.js';
 import { add } from '../src/trails/entity.js';
@@ -48,7 +49,9 @@ const createFollowFn = (ctx: TrailContext) => {
 };
 
 const makeCtx = (store: EntityStore): TrailContext => {
-  const base = createTrailContext({ extensions: { store } });
+  const base = createTrailContext({
+    extensions: { [entityStoreService.id]: store },
+  });
   const ctx: TrailContext = { ...base, follow: createFollowFn(base) };
   return ctx;
 };

--- a/apps/trails-demo/bin/demo.ts
+++ b/apps/trails-demo/bin/demo.ts
@@ -10,21 +10,8 @@
  */
 
 import { blaze } from '@ontrails/cli/commander';
-import { createTrailContext } from '@ontrails/core';
 
 import { app } from '../src/app.js';
-import { createStore } from '../src/store.js';
-
-const store = createStore([
-  { name: 'Alpha', tags: ['core'], type: 'concept' },
-  { name: 'Beta', tags: ['automation'], type: 'tool' },
-  { name: 'Gamma', tags: ['workflow'], type: 'pattern' },
-]);
 
 // oxlint-disable-next-line require-hook -- CLI entry point, not a test file
-blaze(app, {
-  createContext: () =>
-    createTrailContext({
-      extensions: { store },
-    }),
-});
+blaze(app);

--- a/apps/trails-demo/src/app.ts
+++ b/apps/trails-demo/src/app.ts
@@ -5,9 +5,18 @@
 import { topo } from '@ontrails/core';
 
 import * as entityEvents from './events/entity-events.js';
+import * as demoServices from './services/entity-store.js';
 import * as entity from './trails/entity.js';
 import * as kv from './trails/kv.js';
 import * as onboard from './trails/onboard.js';
 import * as search from './trails/search.js';
 
-export const app = topo('demo', entity, search, onboard, entityEvents, kv);
+export const app = topo(
+  'demo',
+  demoServices,
+  entity,
+  search,
+  onboard,
+  entityEvents,
+  kv
+);

--- a/apps/trails-demo/src/http.ts
+++ b/apps/trails-demo/src/http.ts
@@ -5,22 +5,10 @@
  *   bun run src/http.ts
  */
 
-import { createTrailContext } from '@ontrails/core';
 import { blaze } from '@ontrails/http/hono';
 
 import { app } from './app.js';
-import { createStore } from './store.js';
-
-const store = createStore([
-  { name: 'Alpha', tags: ['core'], type: 'concept' },
-  { name: 'Beta', tags: ['automation'], type: 'tool' },
-  { name: 'Gamma', tags: ['workflow'], type: 'pattern' },
-]);
 
 await blaze(app, {
-  createContext: () =>
-    createTrailContext({
-      extensions: { store },
-    }),
   port: 3000,
 });

--- a/apps/trails-demo/src/mcp.ts
+++ b/apps/trails-demo/src/mcp.ts
@@ -5,22 +5,10 @@
  *   bun run src/mcp.ts
  */
 
-import { createTrailContext } from '@ontrails/core';
 import { blaze } from '@ontrails/mcp';
 
 import { app } from './app.js';
-import { createStore } from './store.js';
-
-const store = createStore([
-  { name: 'Alpha', tags: ['core'], type: 'concept' },
-  { name: 'Beta', tags: ['automation'], type: 'tool' },
-  { name: 'Gamma', tags: ['workflow'], type: 'pattern' },
-]);
 
 await blaze(app, {
-  createContext: () =>
-    createTrailContext({
-      extensions: { store },
-    }),
   serverInfo: { name: 'demo', version: '0.1.0' },
 });

--- a/apps/trails-demo/src/services/entity-store.ts
+++ b/apps/trails-demo/src/services/entity-store.ts
@@ -1,0 +1,28 @@
+/**
+ * Service-backed entity store for the trails-demo app.
+ *
+ * Keeps runtime defaults and test mocks close to the service definition so
+ * trails and helpers can resolve the same dependency model everywhere.
+ */
+
+import { Result, service } from '@ontrails/core';
+import { createStore } from '../store.js';
+
+const runtimeSeed = [
+  { name: 'Alpha', tags: ['core'], type: 'concept' },
+  { name: 'Beta', tags: ['automation'], type: 'tool' },
+  { name: 'Gamma', tags: ['workflow'], type: 'pattern' },
+] as const;
+
+const mockSeed = [
+  { name: 'Alpha', tags: ['core'], type: 'concept' },
+  { name: 'Deletable', tags: ['temp'], type: 'tool' },
+] as const;
+
+export const createMockEntityStore = () => createStore(mockSeed);
+
+export const entityStoreService = service('demo.entity-store', {
+  create: () => Result.ok(createStore(runtimeSeed)),
+  description: 'In-memory entity store used by the demo trails app.',
+  mock: () => createMockEntityStore(),
+});

--- a/apps/trails-demo/src/trails/entity.ts
+++ b/apps/trails-demo/src/trails/entity.ts
@@ -11,10 +11,9 @@ import {
   NotFoundError,
   AlreadyExistsError,
 } from '@ontrails/core';
-import type { TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
-import type { EntityStore } from '../store.js';
+import { entityStoreService } from '../services/entity-store.js';
 
 // ---------------------------------------------------------------------------
 // Shared schemas
@@ -35,17 +34,6 @@ const entitySummarySchema = z.object({
   tags: z.array(z.string()),
   type: z.string(),
 });
-
-// ---------------------------------------------------------------------------
-// Helper: extract store from context
-// ---------------------------------------------------------------------------
-
-const getStore = (ctx: TrailContext): EntityStore =>
-  ctx.extensions?.['store'] as EntityStore;
-
-// ---------------------------------------------------------------------------
-// entity.show
-// ---------------------------------------------------------------------------
 
 export const show = trail('entity.show', {
   description: 'Show an entity by name',
@@ -71,7 +59,7 @@ export const show = trail('entity.show', {
   intent: 'read',
   output: entitySchema,
   run: (input, ctx) => {
-    const store = getStore(ctx);
+    const store = entityStoreService.from(ctx);
     const entity = store.get(input.name);
     if (!entity) {
       return Result.err(new NotFoundError(`Entity "${input.name}" not found`));
@@ -85,6 +73,7 @@ export const show = trail('entity.show', {
       updatedAt: entity.updatedAt,
     });
   },
+  services: [entityStoreService],
 });
 
 // ---------------------------------------------------------------------------
@@ -117,7 +106,7 @@ export const add = trail('entity.add', {
   }),
   output: entitySchema,
   run: (input, ctx) => {
-    const store = getStore(ctx);
+    const store = entityStoreService.from(ctx);
     const existing = store.get(input.name);
     if (existing) {
       return Result.err(
@@ -138,6 +127,7 @@ export const add = trail('entity.add', {
       updatedAt: entity.updatedAt,
     });
   },
+  services: [entityStoreService],
 });
 
 // ---------------------------------------------------------------------------
@@ -168,13 +158,14 @@ export const remove = trail('entity.delete', {
     name: z.string(),
   }),
   run: (input, ctx) => {
-    const store = getStore(ctx);
+    const store = entityStoreService.from(ctx);
     const deleted = store.delete(input.name);
     if (!deleted) {
       return Result.err(new NotFoundError(`Entity "${input.name}" not found`));
     }
     return Result.ok({ deleted: true, name: input.name });
   },
+  services: [entityStoreService],
 });
 
 // ---------------------------------------------------------------------------
@@ -206,7 +197,7 @@ export const list = trail('entity.list', {
     total: z.number(),
   }),
   run: (input, ctx) => {
-    const store = getStore(ctx);
+    const store = entityStoreService.from(ctx);
     const listOptions: { limit?: number; offset?: number; type?: string } = {
       limit: input.limit,
       offset: input.offset,
@@ -225,4 +216,5 @@ export const list = trail('entity.list', {
       total: entities.length,
     });
   },
+  services: [entityStoreService],
 });

--- a/apps/trails-demo/src/trails/search.ts
+++ b/apps/trails-demo/src/trails/search.ts
@@ -7,7 +7,7 @@
 import { trail, Result } from '@ontrails/core';
 import { z } from 'zod';
 
-import type { EntityStore } from '../store.js';
+import { entityStoreService } from '../services/entity-store.js';
 
 // ---------------------------------------------------------------------------
 // search
@@ -45,7 +45,7 @@ export const search = trail('search', {
     total: z.number(),
   }),
   run: (input, ctx) => {
-    const store = ctx.extensions?.['store'] as EntityStore;
+    const store = entityStoreService.from(ctx);
     const results = store.search(input.query);
     const limited = results.slice(0, input.limit);
     return Result.ok({
@@ -59,4 +59,5 @@ export const search = trail('search', {
       total: results.length,
     });
   },
+  services: [entityStoreService],
 });


### PR DESCRIPTION
## Context
The demo app should use first-class services end to end so the stack proves out in a realistic app instead of only framework tests.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Introduced an `entity-store` service for the demo app.
- Rewired demo trails to resolve storage through services instead of surface-specific extensions.
- Removed the legacy surface-only store wiring and updated demo governance and tests accordingly.

## How To Test
- `bun test apps/trails-demo`
- `bun run lint`
- `bun run typecheck`

Closes: TRL-84
