### PR TITLE
docs: accept ADR-009 and align service docs

### DIFF
--- a/.claude/rules/coding-conventions.md
+++ b/.claude/rules/coding-conventions.md
@@ -33,6 +33,7 @@ TSDoc explains the contract of exported APIs. Start there before reaching for in
 - Describe the contract a helper or surface exposes, especially derived names, validation boundaries, and `Result` behavior.
 - For APIs that return `Result`, document the success shape and the error types callers should expect.
 - Prefer examples that mirror how agents or surface adapters will actually consume the API.
+- For service definitions, document the `create` factory's dependencies and the type it produces. Document `dispose` if cleanup is non-trivial. Skip `mock` TSDoc unless the mock behavior differs significantly from the real implementation.
 
 ## Code Shape Patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Use the project language consistently:
 - `follow`, not route (for composition declaration and runtime invocation)
 - `blaze`, not serve or mount
 - `surface`, not transport or adapter
+- `service`, not dependency or provider
 `mount` is reserved for cross-app composition. See `docs/vocabulary.md` for the full vocabulary guide.
 
 ## Trail Rules
@@ -72,6 +73,10 @@ Use the project language consistently:
 - Use `detours` for recovery strategies instead of inline retry logic.
 - Prefer the most specific `TrailsError` subclass available.
 - Keep error taxonomy behavior aligned across surfaces so CLI, HTTP, and JSON-RPC mappings stay coherent.
+- Trails that use external dependencies declare them with `services: [...]`.
+- Access services through `db.from(ctx)` or `ctx.service()`, never by constructing dependencies inline.
+- Keep `follow` declarations for composition and `services` declarations for infrastructure — they serve different purposes.
+- Every service should define a `mock` factory so `testAll(app)` works without configuration.
 
 ## Shared Conventions
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Each declaration you add to a trail unlocks derived behavior across every surfac
 | `intent: 'destroy'` | MCP `destructiveHint`, CLI auto-adds `--dry-run`, HTTP DELETE |
 | `examples` | Tests (happy + error path), agent guidance, documentation |
 | `follow` | Composition graph, cycle detection, follow coverage in tests |
+| `services: [db]` | Singleton lifecycle, test mock auto-resolution, warden governance |
 | `detours` | Recovery paths, warden validates targets exist |
 
 The value isn't any single feature. It's that they multiply — each declaration makes every surface smarter without additional wiring.

--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -1,6 +1,6 @@
 # trails-demo
 
-A complete working application built with the Trails framework. It demonstrates every core concept: trails, composition via `follow`, an event, examples, metadata, detours, idempotent upsert, and blazing on CLI, MCP, and HTTP surfaces.
+A complete working application built with the Trails framework. It demonstrates every core concept: trails, composition via `follow`, a first-class service dependency, an event, examples, metadata, detours, idempotent upsert, and blazing on CLI, MCP, and HTTP surfaces.
 
 ## What this app does
 
@@ -17,6 +17,8 @@ Entity management -- a small CRUD + search system with enough depth to exercise 
 | `demo.upsert` | Idempotent key-value store example | `idempotent: true` |
 
 Plus one event: `entity.updated` (triggered by `entity.add` and `entity.delete`).
+
+Plus one service: `demo.entity-store` (the in-memory entity store used by the entity and search trails).
 
 ## Running the CLI
 
@@ -78,12 +80,15 @@ This exposes MCP tools: `demo_entity_show`, `demo_entity_add`, `demo_entity_dele
 ### Trail definition: `entity.show`
 
 ```typescript
+import { entityStoreService } from '../src/services/entity-store.js';
+
 export const show = trail('entity.show', {
   description: 'Show an entity by name',
   input: z.object({ name: z.string() }),
   output: entitySchema,
   intent: 'read',
   detours: { NotFoundError: ['search'] },
+  services: [entityStoreService],
   examples: [
     {
       name: 'Show entity by name',
@@ -99,6 +104,7 @@ export const show = trail('entity.show', {
     },
   ],
   run: async (input, ctx) => {
+    const store = entityStoreService.from(ctx);
     /* ... */
   },
 });
@@ -137,13 +143,15 @@ export const onboard = trail('entity.onboard', {
 ```typescript
 import { testAll } from '@ontrails/testing';
 import { app } from '../src/app.js';
-import { createStore } from '../src/store.js';
+import {
+  createMockEntityStore,
+  entityStoreService,
+} from '../src/services/entity-store.js';
 
 testAll(app, () => ({
-  store: createStore([
-    { name: 'Alpha', tags: ['core'], type: 'concept' },
-    { name: 'Deletable', tags: ['temp'], type: 'tool' },
-  ]),
+  services: {
+    [entityStoreService.id]: createMockEntityStore(),
+  },
 }));
 ```
 
@@ -154,7 +162,7 @@ testAll(app, () => ({
 3. **`testContracts`** -- output schema verification for every success example.
 4. **`testDetours`** -- detour targets reference real trails in the topo.
 
-Pass a factory function (not a plain object) when the context contains mutable state like an in-memory store, so each test gets a fresh copy.
+Pass a factory function (not a plain object) when your explicit service overrides contain mutable state like an in-memory store, so each test gets a fresh copy.
 
 ### Progressive assertion
 
@@ -165,7 +173,10 @@ Pass a factory function (not a plain object) when the context contains mutable s
 ### Custom scenarios
 
 ```typescript
+import { createStore } from '../src/store.js';
 import { testTrail } from '@ontrails/testing';
+import { entityStoreService } from '../src/services/entity-store.js';
+
 testTrail(
   show,
   [
@@ -175,7 +186,13 @@ testTrail(
       expectErr: NotFoundError,
     },
   ],
-  { store }
+  {
+    extensions: {
+      [entityStoreService.id]: createStore([
+        { name: 'Alpha', tags: ['core'], type: 'concept' },
+      ]),
+    },
+  }
 );
 ```
 
@@ -220,4 +237,4 @@ Checks governance rules: every trail has examples, destructive trails declare `i
 trails survey
 ```
 
-Produces a machine-readable map of all trails and events with their schemas, metadata, and relationships.
+Produces a machine-readable map of all trails, events, and services with their schemas, metadata, and relationships.

--- a/docs/adr/009-services.md
+++ b/docs/adr/009-services.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 created: 2026-03-30
 updated: 2026-03-30
 author: '@galligan'

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,7 +15,7 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [006](006-shared-execution-pipeline.md) | Shared Execution Pipeline | Accepted |
 | [007](007-governance-as-trails.md) | Governance as Trails | Accepted |
 | [008](008-deterministic-surface-derivation.md) | Deterministic Surface Derivation | Accepted |
-| [009](009-services.md) | Services as a First-Class Primitive | Proposed |
+| [009](009-services.md) | Services as a First-Class Primitive | Accepted |
 
 ## Format
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,13 +10,16 @@ Canonical public surface. For naming conventions and decision history, see `docs
 // Definitions
 trail(id, spec)                    // define a unit of work (with optional follow for composition)
 event(id, spec)                    // define a payload schema with provenance
-topo(name, ...modules)             // assemble into a queryable topology
+service(id, spec)                  // define a first-class service dependency
+createServiceLookup(getContext)    // bind ctx.service() to a specific context snapshot
+topo(name, ...modules)             // assemble trails, events, and services into a queryable topology
 // Topo methods: .get(id), .has(id), .list(), .listEvents(), .ids(), .count
+//               .getService(id), .hasService(id), .listServices(), .serviceIds(), .serviceCount
 
 // Types
-Trail<I, O>, Event<T>, Topo, Intent
-TrailSpec<I, O>, EventSpec<T>, TrailExample<I, O>
-AnyTrail, AnyEvent
+Trail<I, O>, Event<T>, Service<T>, Topo, Intent
+TrailSpec<I, O>, EventSpec<T>, ServiceSpec<T>, TrailExample<I, O>
+AnyTrail, AnyEvent, AnyService, ServiceContext, ServiceOverrideMap
 
 // Type utilities
 TrailInput<T>                      // extract input type from a Trail
@@ -39,11 +42,11 @@ ErrorCategory, isTrailsError(value?), isRetryable(error)
 // Implementation & context
 Implementation<I, O>              // (input, ctx) => Result | Promise<Result>
 TrailContext, createTrailContext(overrides?)
-FollowFn, ProgressCallback, ProgressEvent, Logger, Surface
+FollowFn, ServiceLookup, ProgressCallback, ProgressEvent, Logger, Surface
 
 // Execution pipeline
-executeTrail(trail, rawInput, options?) // shared execution pipeline: validate → compose layers → run; used by all surfaces
-dispatch(topo, id, input, options?)    // look up and execute a trail by ID; returns Result, never throws
+executeTrail(trail, rawInput, options?) // validate → resolve context → resolve services → compose layers → run
+dispatch(topo, id, input, options?)    // look up and execute a trail by ID; accepts ctx/services overrides
 DispatchOptions
 
 // Layers
@@ -145,9 +148,10 @@ OpenApiOptions, OpenApiSpec, OpenApiServer
 
 ```typescript
 // Test runners
-testAll(topo, ctx?)
-testExamples(topo, ctx?), testTrail(trail, scenarios, ctx?)
-testContracts(topo, ctx?), testDetours(topo, ctx?)
+testAll(topo, ctxOrFactory?)
+testExamples(topo, ctxOrFactory?), testTrail(trail, scenarios, ctx?)
+testFollows(trail, scenarios, options?)
+testContracts(topo, ctxOrFactory?), testDetours(topo)
 
 // Assertion helpers
 expectOk(result), expectErr(result)
@@ -159,7 +163,8 @@ createTestContext(options?), createTestLogger()
 createFollowContext(options?)      // minimal context for testing trail composition via ctx.follow()
 createCliHarness(topo, options?), createMcpHarness(topo, options?)
 
-TestScenario, HikeScenario, TestLogger, TestTrailContextOptions, TestHikeOptions
+TestExecutionOptions, TestFollowOptions
+TestScenario, FollowScenario, TestLogger, TestTrailContextOptions
 CliHarness, CliHarnessOptions, CliHarnessResult
 McpHarness, McpHarnessOptions, McpHarnessResult
 ```
@@ -168,7 +173,7 @@ McpHarness, McpHarnessOptions, McpHarnessResult
 
 ```typescript
 runWarden(options?), formatWardenReport(report), checkDrift(rootDir, topo?)
-wardenRules                        // ReadonlyMap<string, WardenRule> — 11 AST-based rules
+wardenRules                        // ReadonlyMap<string, WardenRule> — 13 AST-based rules
 wardenTopo                         // pre-built Topo of all warden trails
 runWardenTrails(filePath, sourceCode, options?) // run warden rules against a single file
 formatGitHubAnnotations(report), formatJson(report), formatSummary(report)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,6 +92,7 @@ These are boundaries the compiler enforces on the implementation at development 
 | `Result<T, Error>` | Implementation cannot throw — must return `Result.ok()` or `Result.err()` |
 | `TrailContext` interface | Implementation receives only the fields the framework provides |
 | `follow: [...]` on trails | Declares the composition graph; warden verifies `ctx.follow()` calls match |
+| `services: [...]` on trails | Declares infrastructure dependencies; warden verifies `service.from(ctx)` / `ctx.service()` usage match |
 
 ### Inferred — detected by static analysis, best-effort
 
@@ -194,9 +195,10 @@ Clean DAG. Core at the center. No cycles. Surface adapters depend only on core. 
 CLI input ("myapp entity show --name Alpha")
   -> Commander parses args/flags
   -> CLI adapter matches to trail via CliCommand model
-  -> Layers run (auth, rate limit, telemetry)
   -> Zod validates input against trail's schema
-  -> TrailContext created (requestId, logger, signal)
+  -> TrailContext created (requestId, logger, signal, env, cwd)
+  -> Declared services resolved into ctx
+  -> Layers run (auth, rate limit, telemetry)
   -> implementation(validatedInput, ctx) called
   -> Result returned
   -> Layers post-process
@@ -210,6 +212,7 @@ MCP tool call ({ name: "myapp_entity_show", arguments: { name: "Alpha" } })
   -> MCP adapter matches to trail
   -> Zod validates input
   -> TrailContext created
+  -> Declared services resolved into ctx
   -> Same implementation(validatedInput, ctx) called
   -> Same Result returned
   -> Result mapped to MCP tool response
@@ -222,6 +225,7 @@ HTTP request (GET /entity/show?name=Alpha)
   -> Hono matches route derived from trail ID
   -> Zod validates input (query params for GET, JSON body for POST/DELETE)
   -> TrailContext created
+  -> Declared services resolved into ctx
   -> Same implementation(validatedInput, ctx) called
   -> Same Result returned
   -> Result mapped to JSON response with status code from error taxonomy
@@ -249,6 +253,8 @@ All surfaces -- CLI, MCP, HTTP, and `dispatch()` -- delegate to the same `execut
 ```text
 executeTrail(trail, rawInput, options?)
   -> Zod validates rawInput against trail's input schema
+  -> TrailContext resolved from options/createContext
+  -> Declared services resolved into ctx
   -> Layers composed via composeLayers()
   -> implementation(validatedInput, ctx) called
   -> Result returned

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -168,6 +168,10 @@ That single `testAll(app)` call runs the full governance suite:
 
 No separate test files for the happy path. The examples ARE the tests.
 
+If your app declares services with `mock` factories, `testAll(app)` and
+`testExamples(app)` pick them up automatically. Use explicit `services`
+overrides only when you need a specific fake or fresh mutable state.
+
 For finer control, use `testExamples(app)` to run only example assertions without structural checks:
 
 ```typescript

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -241,6 +241,35 @@ export const addAndDouble = trail('math.add-and-double', {
 
 Trails declare their composition dependencies with `follow` and invoke them with `ctx.follow()`. The warden linter verifies these match.
 
+## Using Services
+
+When a trail needs an external dependency — a database, cache, or API client — declare it as a service:
+
+```typescript
+import { service, trail, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+const db = service('db', {
+  create: () => Result.ok(createPool(process.env.DATABASE_URL)),
+  mock: () => createMockPool(),
+  dispose: (pool) => pool.end(),
+});
+
+export const listUsers = trail('user.list', {
+  services: [db],
+  input: z.object({}),
+  output: z.object({ users: z.array(UserSchema) }),
+  intent: 'read',
+  run: async (input, ctx) => {
+    const pool = db.from(ctx);
+    const rows = await pool.query('SELECT * FROM users');
+    return Result.ok({ users: rows });
+  },
+});
+```
+
+The `services: [db]` declaration tells the topo which infrastructure this trail depends on. Access the service instance through `db.from(ctx)` for typed access. When you run `testAll(app)`, the framework automatically resolves `mock` factories — no configuration needed for example-based tests.
+
 ## What's Next
 
 - [Architecture](./architecture.md) -- How the hexagonal model works

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -8,15 +8,15 @@
 
 **OpenAPI generation (`@ontrails/schema`).** `generateOpenApiSpec()` produces a complete OpenAPI 3.1 spec from the topo. The topo already carries everything OpenAPI needs.
 
-## Near-term (v1.1–v1.2)
+**Services (`service()` and trail `services: [...]`).** Trails now declare infrastructure dependencies explicitly. `executeTrail()` resolves app-scoped singletons before layers and implementations run. Testing can auto-resolve `mock` factories, and survey / schema tooling exposes the full service graph.
 
-**Services and dependency injection.** Trails that declare which services they use via `ctx.services`. The framework provides only declared services. `intent: 'read'` narrows the projection to read-only methods at the type level. Testing mocks only what the trail declares.
+## Near-term (v1.1–v1.2)
 
 **Auth and permit model.** The `permit` field on TrailContext gets a full design: scopes, roles, per-surface resolution (bearer tokens for HTTP, session tokens for MCP, local keyring for CLI). Scope enforcement as a layer. Resource-level auth stays in the implementation — the framework provides identity, the app provides policy.
 
 ## Mid-term (v1.3+)
 
-**Derived dependency graphs.** Instead of hand-maintaining `follow` declarations, the framework infers them from `ctx.follow()` calls in the implementation via static analysis. Same for service dependencies from `ctx.services` references. The surface lock captures the derived graph. Changes show up in diffs.
+**Derived dependency graphs.** Instead of hand-maintaining `follow` declarations, the framework infers them from `ctx.follow()` calls in the implementation via static analysis. The same idea could eventually extend beyond today's declared `services: [...]` model to richer service capability inference. The surface lock captures the graph. Changes show up in diffs.
 
 **Implementation synthesis from examples.** For trails with comprehensive examples that fully specify behavior (pure transformations, mapping logic, validation rules), an agent could synthesize the implementation from the examples alone. The examples become the source of truth; the code becomes the derived artifact.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@
 - **[ADR-006: Shared Execution Pipeline](./adr/006-shared-execution-pipeline.md)** — One `executeTrail`, Result-returning builders
 - **[ADR-007: Governance as Trails](./adr/007-governance-as-trails.md)** — Warden rules are trails, AST-based analysis
 - **[ADR-008: Deterministic Surface Derivation](./adr/008-deterministic-surface-derivation.md)** — Explicit lookup tables for every surface
-- **[ADR-009: Services as a First-Class Primitive](./adr/009-services.md)** *(proposed)* — Dependency declarations, lifecycle, testing, governance
+- **[ADR-009: Services as a First-Class Primitive](./adr/009-services.md)** — Dependency declarations, lifecycle, testing, governance
 
 ## What's next?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@
 
 - **[Architecture](./architecture.md)** — Hexagonal model, package layers, how data flows from trail to surface
 - **[API Reference](./api-reference.md)** — Every public export across all packages
+- **[Services Guide](./services.md)** — Define dependencies, declare them on trails, test with mock factories
 - **[Testing Guide](./testing.md)** — TDD with examples, `testAll()`, contract testing, surface harnesses
 
 ## Adding a surface?

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,0 +1,155 @@
+# Services
+
+Trails implementations are pure functions -- input in, `Result` out. But real implementations need databases, API clients, caches, and queues. Without a dependency mechanism, every trail constructs its own connections inline. Tests can't swap them, the framework can't manage lifecycle, and governance can't see what a trail actually needs. Services fill that gap. They make dependencies declarative, injectable, and governable.
+
+## Defining a Service
+
+Use `service()` to create a typed service definition:
+
+```typescript
+import { service, Result } from '@ontrails/core';
+
+const db = service('db.main', {
+  create: (svc) => Result.ok(openDatabase(svc.env?.DATABASE_URL)),
+  dispose: (conn) => conn.close(),
+  health: (conn) => conn.ping(),
+  mock: () => createInMemoryDb(),
+  description: 'Primary database connection',
+});
+```
+
+The type of the service instance is inferred from the `create` factory return. No manual generic needed.
+
+| Field | Purpose |
+| --- | --- |
+| `create` | Factory returning `Result<T, Error>`. Receives a `ServiceContext` with `env`, `cwd`, and `workspaceRoot` only -- not the full `TrailContext`. |
+| `dispose` | Optional cleanup on shutdown. Database pools close, API clients disconnect. |
+| `health` | Optional readiness probe. Feeds into `survey --brief` and operational checks. |
+| `mock` | Optional test factory. When present, `testExamples(app)` uses it automatically. |
+| `description` | Human-readable label for survey output and agent introspection. |
+
+The `create` factory receives `ServiceContext` -- a narrow subset of `TrailContext` -- because services are singletons resolved once per process. Request-scoped fields like `requestId` would be stale after the first resolution.
+
+## Declaring Services on a Trail
+
+Add services to the trail spec with the `services` array:
+
+```typescript
+import { trail, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+const search = trail('search', {
+  services: [db],
+  intent: 'read',
+  input: z.object({ query: z.string() }),
+  output: z.array(z.object({ id: z.string(), title: z.string() })),
+  run: async (input, ctx) => {
+    const conn = db.from(ctx);
+    const results = await conn.search(input.query);
+    return Result.ok(results);
+  },
+});
+```
+
+The `services` array is a flat set of service objects, parallel to `follow` for trail composition. Service objects carry their type from the factory return, so `db.from(ctx)` infers the correct type at the call site.
+
+## Accessing Services
+
+The primary access pattern uses the service definition as a typed accessor:
+
+```typescript
+const conn = db.from(ctx); // typed as the return of create()
+```
+
+The escape hatch for dynamic or string-based access:
+
+```typescript
+const conn = ctx.service<Database>('db.main');
+```
+
+Both resolve the same way at runtime. Prefer `db.from(ctx)` -- it carries the type automatically.
+
+## Service Lifecycle
+
+Services are app-scoped singletons in v1. Created once on first resolution, cached for the process lifetime, disposed on shutdown.
+
+Resolution happens eagerly during `executeTrail`, after input validation and before layer composition:
+
+1. Validate input
+2. Resolve context
+3. **Resolve services** (create singletons or retrieve cached)
+4. Compose layers
+5. Execute implementation
+
+This means failures surface at the boundary -- a missing `DATABASE_URL` fails before the implementation runs, not on line 47. It also means layers can access services via `db.from(ctx)` because resolution is already complete.
+
+Shutdown signaling differs by surface. CLI tools dispose after the command completes. Long-running servers (MCP, HTTP) dispose on `SIGTERM`/`SIGINT`. The surface's `blaze()` owns the lifecycle.
+
+## Testing with Services
+
+Services with a `mock` factory auto-resolve during `testAll`, `testExamples`, and `testContracts`:
+
+```typescript
+import { testAll } from '@ontrails/testing';
+import { app } from '../app';
+
+// db.mock() is used automatically -- no configuration
+testAll(app);
+```
+
+Override explicitly when you need specific behavior:
+
+```typescript
+testAll(app, () => ({
+  services: { 'db.main': createSpecialTestDb() },
+}));
+```
+
+Pass a factory (the `() => ({...})` form) when overrides contain mutable state, so each test gets a fresh instance. This prevents test pollution from shared in-memory stores.
+
+The same override mechanism works with `dispatch` and `blaze`:
+
+```typescript
+dispatch(app, 'search', input, {
+  services: { 'db.main': testDb },
+});
+
+blaze(app, {
+  services: { 'db.main': stagingDb },
+});
+```
+
+See [Testing](./testing.md) for the full testing API.
+
+## Topo Registration
+
+Services register alongside trails through `topo()`:
+
+```typescript
+import { topo } from '@ontrails/core';
+import * as entityTrails from './trails/entity';
+import * as services from './services';
+
+const app = topo('myapp', entityTrails, services);
+// app.services -- Map<id, Service>
+```
+
+`topo()` scans module exports for objects with `kind: 'service'`, the same way it discovers trails and events. Duplicate service IDs fail topo construction.
+
+Namespace service IDs with dots for packs and multi-service apps: `db.primary`, `entity.store`, `cache.redis`.
+
+## Governance
+
+The warden provides two service-related rules:
+
+**`service-declarations`** -- validates that `db.from(ctx)` and `ctx.service(...)` calls inside the implementation match the declared `services: [...]` array. Undeclared usage is an error. Unused declarations are a warning.
+
+**`service-exists`** -- validates that every service referenced in trail declarations exists in the topo. Same pattern as `valid-detour-refs`.
+
+Both follow the established AST analysis pattern used by `follow-declarations`.
+
+## Design Rationale
+
+Services complete the trail contract. A trail now declares what it takes (input), what it produces (output), what it composes (follow), and what it needs (services). The full dependency graph -- trails, services, events -- is queryable through survey.
+
+For the complete design decision, tradeoffs, and future directions (request-scoped services, composable config, intent-based type narrowing), see [ADR-009: Services as a First-Class Primitive](./adr/009-services.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -59,6 +59,31 @@ import { app } from '../app';
 testAll(app);
 ```
 
+When trails declare services, the testing helpers respect them in two ways:
+
+- Services with a `mock` factory auto-resolve during `testAll`, `testExamples`, and `testContracts`.
+- Explicit `services` overrides let you inject a specific test double when you need one.
+
+```typescript
+import { service, Result } from '@ontrails/core';
+import { testAll } from '@ontrails/testing';
+import { app } from '../app';
+
+const db = service('db.main', {
+  create: () => Result.ok(connectToDatabase()),
+  mock: () => createInMemoryDb(),
+});
+
+// `db` must be part of `app`'s topo for auto-resolution to work.
+testAll(app); // auto-resolves db.main from db.mock()
+
+testAll(app, () => ({
+  services: { 'db.main': createInMemoryDb() },
+}));
+```
+
+Pass a factory when your explicit overrides contain mutable state, so each test gets a fresh instance.
+
 Generates a `governance` describe block containing:
 
 - **Topo validation** via `validateTopo` (follow targets exist, no recursive follow, event origins, example schema validation, output schema presence)
@@ -228,6 +253,8 @@ const ctx = createTestContext({
 ```
 
 Defaults: deterministic request ID, test logger (captures entries), non-aborted signal.
+
+If you need a service override at the context level, pass it through `services` to `testAll()` / `testExamples()` / `testContracts()`, or attach it to `extensions` under the service ID when calling a single trail helper like `testTrail()`. `testTrail()` accepts a raw context object, so service injection there bypasses the normal pipeline resolution step and goes directly through `extensions`.
 
 ### `createFollowContext(options?)`
 

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -85,12 +85,13 @@ The `follow` declaration is verified by the warden linter against actual `ctx.fo
 
 ### `topo` (the data structure)
 
-The internal collection of all trails -- the topography. The data structure that surfaces read, schema tools inspect, and `ctx.follow()` dispatches through. The `topo()` function returns a `Topo` object with `.trails`, `.events` maps, and `.get()`, `.has()`, `.list()` accessors.
+The internal collection of all trails -- the topography. The data structure that surfaces read, schema tools inspect, and `ctx.follow()` dispatches through. The `topo()` function returns a `Topo` object with `.trails`, `.events`, and `.services` maps, plus `.get()`, `.has()`, `.list()`, `.getService()`, `.hasService()`, and `.listServices()` accessors.
 
 ```typescript
 const app = topo('myapp', entityModule);
 app.trails; // ReadonlyMap of trail ID -> Trail
 app.list(); // All trails
+app.services; // ReadonlyMap of service ID -> Service
 ```
 
 Most developers never interact with the topo directly. Use "the app" or "the trail collection" in introductory material.

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -124,6 +124,34 @@ Arbitrary metadata for tooling and filtering. Declared as `metadata` on the trai
 
 Error recovery and fallback paths when a trail fails. Declared as `detours` on the trail spec.
 
+### `service`
+
+An infrastructure dependency definition with lifecycle management and built-in testing support. Services wrap databases, caches, APIs, or any external resource a trail needs.
+
+```typescript
+const db = service('db', {
+  create: () => Result.ok(createPool(process.env.DATABASE_URL)),
+  mock: () => createMockPool(),
+  dispose: (pool) => pool.end(),
+});
+```
+
+Trails declare their service dependencies with `services: [...]` on the trail spec:
+
+```typescript
+const list = trail('entity.list', {
+  services: [db],
+  input: z.object({}),
+  output: EntityListSchema,
+  run: async (input, ctx) => {
+    const pool = db.from(ctx);
+    // ...
+  },
+});
+```
+
+Access services through `db.from(ctx)` for typed access or `ctx.service()` for dynamic lookup. The `mock` factory enables `testAll(app)` to run without real infrastructure.
+
 ## Reserved Terms (designed, not yet shipped)
 
 These are reserved for planned features. The naming is directional and may evolve.
@@ -146,7 +174,7 @@ These use plain language because the concepts are universal.
 | Term | Concept | Why not branded |
 | --- | --- | --- |
 | `config` | Configuration | Every framework has config |
-| `services` | Service definitions | Universal infrastructure concept |
+| `services` | Service declarations on a trail spec | The array syntax is standard; `service()` itself is branded |
 | `health` | Health checks | Standard ops terminology |
 | `Result` | Success/failure return | Standard in Rust, Haskell, Swift |
 | `Layer` | Cross-cutting surface wrapper | Standard middleware concept |
@@ -170,9 +198,10 @@ When introducing Trails to someone new, introduce terms in this order:
 **Intermediate (composition and enrichment):**
 
 1. `follow` -- declare which trails a trail composes (`follow: [...]`) and invoke them at runtime (`ctx.follow()`)
-2. `event()` -- define events the app can emit
-3. `metadata` -- annotate trails with metadata
-4. `detours` -- define fallback paths when a trail fails
+2. `service()` -- define infrastructure dependencies with lifecycle and mock support
+3. `event()` -- define events the app can emit
+4. `metadata` -- annotate trails with metadata
+5. `detours` -- define fallback paths when a trail fails
 
 **Advanced (introspection and observability):**
 

--- a/docs/why-trails.md
+++ b/docs/why-trails.md
@@ -77,6 +77,16 @@ Pure trails can return `Result` directly. Trails with `follow` and I/O-bound tra
 
 ---
 
+## The Services Problem
+
+Pure trail functions are great until they need a database. The typical escape hatch — constructing clients inline or importing singletons — couples implementations to concrete infrastructure and makes testing painful.
+
+Trails solves this with `service()` declarations. A service defines its factory, a `mock` factory for tests, and an optional `dispose` hook for cleanup. Trails declare their dependencies with `services: [...]` and access them through `db.from(ctx)`. The framework manages the lifecycle, surfaces can inspect the dependency graph, and `testAll(app)` resolves mocks automatically.
+
+The result: implementations stay pure (input in, `Result` out), infrastructure is declared rather than imported, and the entire app remains testable without configuration.
+
+---
+
 ## The Information Architecture
 
 Every piece of information in a Trails app has a clear ownership model. Six categories, from what you write to what the system learns. (See [Architecture](./architecture.md#information-architecture) for the full reference tables.)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,6 +74,10 @@ Flags come from the Zod schema automatically. No manual flag definitions.
 
 Dotted trail IDs create subcommand groups: `entity.show` becomes `myapp entity show`.
 
+## Service resolution
+
+Declared services on each trail are resolved into the context before the implementation runs.
+
 ## Layers
 
 - **`autoIterateLayer`** -- adds `--all` for paginated trails, collects all pages

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -43,6 +43,7 @@ const onboard = trail('entity.onboard', {
 | --- | --- |
 | `trail(id, spec)` | Define a unit of work with typed input and `Result` output; use `follow` for composition |
 | `event(id, spec)` | Define a server-originated push with a typed data schema |
+| `service(id, spec)` | Define an infrastructure dependency with `create`, `dispose`, and optional `mock` |
 | `topo(name, ...modules)` | Collect trail modules into a queryable topology |
 | `validateTopo(topo)` | Structural validation: follow targets exist, no cycles, examples parse, output schemas present |
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -60,6 +60,10 @@ Trail IDs map to paths: `entity.show` becomes `/entity/show`. Dots become slashe
 
 `buildHttpRoutes` detects when two trails would produce the same `(method, path)` pair and returns `Result.err(ValidationError)` describing both trail IDs. The `blaze()` Hono adapter throws on collision.
 
+## Service resolution
+
+Declared services on each trail are resolved into the context before the implementation runs.
+
 ## AbortSignal propagation
 
 The `execute` function on each `HttpRouteDefinition` accepts an optional `AbortSignal`. The Hono adapter extracts `signal` from `c.req.raw` and passes it to `execute`, so client disconnects propagate into trail execution.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -67,6 +67,10 @@ No manual annotation definitions. The contract is the source of truth.
 
 Trail IDs become MCP tool names with the app prefix: `entity.show` in app `myapp` becomes `myapp_entity_show`. Dots and hyphens become underscores, everything lowercase.
 
+## Service resolution
+
+Declared services on each trail are resolved into the context before the implementation runs.
+
 ## Progress bridge
 
 Implementations report progress through `ctx.progress`. On MCP, these bridge to `notifications/progress` when the client sends a `progressToken`:

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -19,7 +19,7 @@ if (diff.hasBreaking) {
 }
 ```
 
-The surface map captures every trail's input/output schemas (as JSON Schema), intent and metadata, follow graph, and example counts. The hash goes into `surface.lock` -- a single committed line that CI can check for drift.
+The surface map captures every trail's input/output schemas (as JSON Schema), intent and metadata, follow graph, declared services, example counts, and the registered service inventory. The hash goes into `surface.lock` -- a single committed line that CI can check for drift.
 
 ## API
 
@@ -48,7 +48,10 @@ The diff classifies every change by severity:
 | Safety property changed | warning |
 | Trail deprecated | warning |
 | Follow changed | warning |
+| Declared services changed | warning |
+| Service removed | breaking |
 | Trail added | info |
+| Service added | info |
 | Optional input field added | info |
 | Output field added | info |
 

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -1,8 +1,8 @@
 # @ontrails/warden
 
-AST-based code convention rules for Trails. 10 lint rules that catch contract violations at development time, plus surface lock drift detection and CI formatters.
+AST-based code convention rules for Trails. 13 lint rules that catch contract violations at development time, plus surface lock drift detection and CI formatters.
 
-Structural checks (follow target existence, recursive follow, example schema validation) live in `validateTopo()` from `@ontrails/core`. Warden handles the code-level rules that need AST analysis.
+Structural checks (follow target existence, declared service existence, recursive follow, example schema validation) live in `validateTopo()` from `@ontrails/core`. Warden handles the code-level rules that need AST analysis.
 
 ## Usage
 
@@ -38,6 +38,8 @@ console.log(formatWardenReport(report));
 | `no-direct-impl-in-route` | warn | Direct `.run()` calls inside trail bodies with `follow` |
 | `prefer-schema-inference` | warn | Redundant field overrides already derivable from the schema |
 | `follow-declarations` | error/warn | `ctx.follow()` calls that drift from declared `follow: [...]` |
+| `service-declarations` | error/warn | `service.from(ctx)` / `ctx.service()` usage that drifts from declared `services: [...]` |
+| `service-exists` | error | Declared or referenced service IDs that do not resolve in project context |
 | `valid-describe-refs` | warn | `@see` refs in `.describe()` that do not resolve |
 
 ## Drift detection
@@ -84,6 +86,7 @@ console.log(wardenTopo.ids()); // ['warden.rule.no-throw-in-implementation', ...
 // Run all rule trails against a source file
 const diagnostics = await runWardenTrails(filePath, sourceCode, {
   knownTrailIds: myApp.ids(),
+  knownServiceIds: myApp.serviceIds(),
 });
 ```
 


### PR DESCRIPTION
## Context
This final stack layer accepts ADR-009 and updates the docs so the shipped behavior, vocabulary, and testing guidance all describe services consistently.

> Stack note: review this PR against its Graphite parent for the incremental change.

## What Changed
- Accepted ADR-009 and aligned the docs with the final service shape.
- Updated API, testing, getting-started, architecture, and vocabulary references.
- Refreshed the demo, schema, and warden READMEs to show services in normal usage.

## How To Test
- `bun run lint`
- `bun run typecheck`
- Review the docs for services flow and terminology consistency.

Closes: TRL-85
