### PR TITLE
feat(config): add Zod extensions for env, secret, deprecated [TRL-88]

### DIFF
--- a/packages/config/src/__tests__/extensions.test.ts
+++ b/packages/config/src/__tests__/extensions.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test';
+import { z, globalRegistry } from 'zod';
+
+import { env, secret, deprecated } from '../extensions.js';
+import type { ConfigFieldMeta } from '../extensions.js';
+import { collectConfigMeta } from '../collect.js';
+
+describe('env()', () => {
+  test('attaches env var name to schema metadata', () => {
+    const schema = env(z.string(), 'DATABASE_URL');
+    const meta = globalRegistry.get(schema) as ConfigFieldMeta | undefined;
+
+    expect(meta).toBeDefined();
+    expect(meta?.env).toBe('DATABASE_URL');
+  });
+});
+
+describe('secret()', () => {
+  test('attaches secret flag to schema metadata', () => {
+    const schema = secret(z.string());
+    const meta = globalRegistry.get(schema) as ConfigFieldMeta | undefined;
+
+    expect(meta).toBeDefined();
+    expect(meta?.secret).toBe(true);
+  });
+});
+
+describe('deprecated()', () => {
+  test('attaches deprecation message to schema metadata', () => {
+    const schema = deprecated(z.string(), 'Use NEW_VAR instead');
+    const raw = globalRegistry.get(schema) as
+      | Record<string, unknown>
+      | undefined;
+
+    expect(raw).toBeDefined();
+    // Zod 4 reserves `deprecated` as boolean, so the message is stored
+    // under `deprecationMessage` and the boolean flag is set.
+    expect(raw?.['deprecated']).toBe(true);
+    expect(raw?.['deprecationMessage']).toBe('Use NEW_VAR instead');
+  });
+});
+
+describe('wrapper ordering', () => {
+  test('metadata survives through .default() when applied BEFORE the transform', () => {
+    const schema = env(z.string(), 'HOST').default('localhost');
+    // Metadata lives on the inner type, not the wrapper
+    const innerMeta = globalRegistry.get(schema.def.innerType) as
+      | ConfigFieldMeta
+      | undefined;
+
+    expect(innerMeta).toBeDefined();
+    expect(innerMeta?.env).toBe('HOST');
+  });
+
+  test('metadata is NOT on the wrapper when applied AFTER .default()', () => {
+    // Applying env() after .default() attaches metadata to the ZodDefault wrapper,
+    // but collectConfigMeta walks .def.innerType — so the inner string has no metadata.
+    const schema = env(z.string().default('localhost'), 'HOST');
+    // The wrapper itself has the metadata
+    const wrapperMeta = globalRegistry.get(schema) as
+      | ConfigFieldMeta
+      | undefined;
+    expect(wrapperMeta?.env).toBe('HOST');
+
+    // But the inner type does NOT
+    const innerMeta = globalRegistry.get(schema.def.innerType) as
+      | ConfigFieldMeta
+      | undefined;
+    expect(innerMeta?.env).toBeUndefined();
+  });
+});
+
+describe('composition', () => {
+  test('multiple wrappers compose: secret(env()) has both env and secret', () => {
+    const schema = secret(env(z.string(), 'DB_URL'));
+    const meta = globalRegistry.get(schema) as ConfigFieldMeta | undefined;
+
+    expect(meta).toBeDefined();
+    expect(meta?.env).toBe('DB_URL');
+    expect(meta?.secret).toBe(true);
+  });
+});
+
+describe('describe() preservation', () => {
+  test('.describe() text is preserved alongside custom metadata', () => {
+    const schema = env(z.string().describe('The database host'), 'DB_HOST');
+    const meta = globalRegistry.get(schema) as
+      | Record<string, unknown>
+      | undefined;
+
+    expect(meta).toBeDefined();
+    expect(meta?.env).toBe('DB_HOST');
+    expect(meta?.description).toBe('The database host');
+  });
+});
+
+describe('collectConfigMeta()', () => {
+  test('walks an object schema and returns all field metadata', () => {
+    const schema = z.object({
+      apiKey: secret(env(z.string(), 'API_KEY')),
+      host: env(z.string(), 'HOST').default('localhost'),
+      oldVar: deprecated(z.string(), 'Use newVar instead').optional(),
+      port: env(z.number(), 'PORT'),
+    });
+
+    const meta = collectConfigMeta(schema);
+
+    expect(meta.get('host')).toEqual({ env: 'HOST' });
+    expect(meta.get('port')).toEqual({ env: 'PORT' });
+    expect(meta.get('apiKey')).toEqual({ env: 'API_KEY', secret: true });
+    expect(meta.get('oldVar')).toEqual({ deprecated: 'Use newVar instead' });
+  });
+
+  test('handles nested objects with dot-separated paths', () => {
+    const schema = z.object({
+      cache: z.object({
+        ttl: env(z.number(), 'CACHE_TTL').default(3600),
+      }),
+      db: z.object({
+        host: env(z.string(), 'DB_HOST'),
+        password: secret(env(z.string(), 'DB_PASSWORD')),
+      }),
+    });
+
+    const meta = collectConfigMeta(schema);
+
+    expect(meta.get('db.host')).toEqual({ env: 'DB_HOST' });
+    expect(meta.get('db.password')).toEqual({
+      env: 'DB_PASSWORD',
+      secret: true,
+    });
+    expect(meta.get('cache.ttl')).toEqual({ env: 'CACHE_TTL' });
+  });
+});

--- a/packages/config/src/collect.ts
+++ b/packages/config/src/collect.ts
@@ -1,0 +1,110 @@
+import { globalRegistry } from 'zod';
+import type { z } from 'zod';
+
+import type { ConfigFieldMeta } from './extensions.js';
+import { isZodObject } from './zod-utils.js';
+
+/** Config meta keys we look for in Zod registry entries. */
+const META_EXTRACTORS: readonly {
+  test: (raw: Record<string, unknown>) => boolean;
+  extract: (raw: Record<string, unknown>) => Partial<ConfigFieldMeta>;
+}[] = [
+  {
+    extract: (r) => ({ env: r['env'] as string }),
+    test: (r) => typeof r['env'] === 'string',
+  },
+  {
+    extract: () => ({ secret: true }),
+    test: (r) => r['secret'] === true,
+  },
+  {
+    extract: (r) => ({ deprecated: r['deprecationMessage'] as string }),
+    test: (r) => typeof r['deprecationMessage'] === 'string',
+  },
+];
+
+/**
+ * Pick only `ConfigFieldMeta` keys from a raw registry entry.
+ * Uses a lookup table to stay under the max-statements limit.
+ */
+const pickConfigMeta = (
+  raw: Record<string, unknown> | undefined
+): ConfigFieldMeta | undefined => {
+  if (!raw) {return undefined;}
+
+  const parts = META_EXTRACTORS.filter((e) => e.test(raw)).map((e) =>
+    e.extract(raw)
+  );
+  return parts.length > 0
+    ? (Object.assign({}, ...parts) as ConfigFieldMeta)
+    : undefined;
+};
+
+/**
+ * Extract `ConfigFieldMeta` from a schema, unwrapping through
+ * `.default()`, `.optional()`, `.nullable()` wrappers as needed.
+ */
+const extractConfigMeta = (schema: z.ZodType): ConfigFieldMeta | undefined => {
+  let current: z.ZodType | undefined = schema;
+
+  while (current) {
+    const meta = pickConfigMeta(globalRegistry.get(current));
+    if (meta) {return meta;}
+
+    const def = current.def as unknown as Record<string, unknown>;
+    current = def['innerType'] as z.ZodType | undefined;
+  }
+
+  return undefined;
+};
+
+/** Entry in the iterative work queue for schema walking. */
+interface WalkEntry {
+  readonly schema: z.ZodObject<Record<string, z.ZodType>>;
+  readonly prefix: string;
+}
+
+/** Process one level of an object schema, queuing nested objects. */
+const walkObjectShape = (
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  prefix: string,
+  result: Map<string, ConfigFieldMeta>,
+  queue: WalkEntry[]
+): void => {
+  const shape = schema.shape as Record<string, z.ZodType>;
+
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    if (isZodObject(fieldSchema)) {
+      queue.push({
+        prefix: path,
+        schema: fieldSchema as z.ZodObject<Record<string, z.ZodType>>,
+      });
+    } else {
+      const meta = extractConfigMeta(fieldSchema);
+      if (meta) {result.set(path, meta);}
+    }
+  }
+};
+
+/**
+ * Walk a Zod object schema and collect `ConfigFieldMeta` for each field.
+ *
+ * Handles unwrapping `.default()`, `.optional()`, `.nullable()` wrappers
+ * that don't carry inner metadata forward. Recurses into nested `ZodObject`
+ * fields using dot-separated paths.
+ */
+export const collectConfigMeta = (
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  prefix = ''
+): Map<string, ConfigFieldMeta> => {
+  const result = new Map<string, ConfigFieldMeta>();
+  const queue: WalkEntry[] = [{ prefix, schema }];
+
+  for (let entry = queue.pop(); entry; entry = queue.pop()) {
+    walkObjectShape(entry.schema, entry.prefix, result, queue);
+  }
+
+  return result;
+};

--- a/packages/config/src/extensions.ts
+++ b/packages/config/src/extensions.ts
@@ -1,0 +1,51 @@
+import type { z } from 'zod';
+
+/** Metadata shape stored on Zod schemas via `.meta()`. */
+export interface ConfigFieldMeta {
+  readonly env?: string;
+  readonly secret?: boolean;
+  readonly deprecated?: string;
+}
+
+/**
+ * Bind a schema field to an environment variable.
+ *
+ * Must be called BEFORE `.default()`, `.optional()`, or other transforms
+ * so that the metadata lives on the inner type where `collectConfigMeta`
+ * can find it by unwrapping wrappers.
+ */
+export const env = <T extends z.ZodType>(schema: T, varName: string): T =>
+  schema.meta({ ...schema.meta(), env: varName }) as T;
+
+/**
+ * Mark a schema field as sensitive. Redacted in survey, explain, and logs.
+ *
+ * Must be called BEFORE `.default()`, `.optional()`, or other transforms.
+ */
+export const secret = <T extends z.ZodType>(schema: T): T =>
+  schema.meta({ ...schema.meta(), secret: true }) as T;
+
+/**
+ * Mark a schema field as deprecated with migration guidance.
+ *
+ * Stores **two** meta keys: `deprecated: true` and `deprecationMessage: string`.
+ * This indirection exists because Zod 4's `GlobalMeta` types `deprecated` as
+ * `boolean | undefined` — there is no way to attach a migration message to the
+ * standard key. We set `deprecated: true` so Zod-native tooling (schema
+ * serializers, OpenAPI generators) recognises the field as deprecated, and store
+ * the human-readable message under `deprecationMessage` for our own
+ * `collectConfigMeta` / survey / explain surfaces.
+ *
+ * Must be called BEFORE `.default()`, `.optional()`, or other transforms
+ * so that the metadata lives on the inner type where `collectConfigMeta`
+ * can find it by unwrapping wrappers.
+ */
+export const deprecated = <T extends z.ZodType>(
+  schema: T,
+  message: string
+): T =>
+  schema.meta({
+    ...schema.meta(),
+    deprecated: true,
+    deprecationMessage: message,
+  }) as T;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,4 @@
-// Placeholder — exports land in subsequent PRs.
-export type { ConfigPlaceholder as _ConfigPlaceholder } from './types.js';
+export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
+export { collectConfigMeta } from './collect.js';
 export { configCheck } from './trails/config-check.js';
 export { configDescribe } from './trails/config-describe.js';

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,4 +1,0 @@
-/** Internal placeholder — replaced by real types in TRL-88+. */
-export interface ConfigPlaceholder {
-  readonly __brand: 'config';
-}

--- a/packages/config/src/zod-utils.ts
+++ b/packages/config/src/zod-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared Zod introspection helpers used by config resolution, doctor,
+ * describe, explain, and collect modules.
+ */
+
+import type { z } from 'zod';
+
+/** Extract the Zod def record from any ZodType. */
+export const zodDef = (schema: z.ZodType): Record<string, unknown> =>
+  schema.def as unknown as Record<string, unknown>;
+
+/** Check if a schema is a ZodObject by inspecting its def. */
+export const isZodObject = (
+  schema: z.ZodType
+): schema is z.ZodObject<Record<string, z.ZodType>> => {
+  const def = zodDef(schema);
+  return def['type'] === 'object' && 'shape' in def;
+};
+
+/** Read a value at a dot-separated path from a plain object. */
+export const getAtPath = (
+  obj: Record<string, unknown>,
+  path: string
+): unknown => {
+  let current: unknown = obj;
+  for (const part of path.split('.')) {
+    if (typeof current !== 'object' || current === null) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+};


### PR DESCRIPTION
## Summary

- Wrapper functions (`env()`, `secret()`, `deprecated()`) that attach config metadata to Zod schemas via Zod 4's `globalRegistry` + `.meta()` API
- `collectConfigMeta()` walks object schemas, unwraps `.default()`/`.optional()` wrappers, and returns `Map<path, ConfigFieldMeta>`
- Shared `zod-utils.ts` with `zodDef`, `isZodObject`, `getAtPath` helpers used across config modules
- Critical constraint documented: metadata helpers must be called BEFORE transforms

## Test plan

- [ ] 9 tests covering all extensions, composition, ordering constraint, and collectConfigMeta
- [ ] `bun test` passes in `packages/config/`

Closes https://linear.app/outfitter/issue/TRL-88/zod-extensions-env-secret-deprecated-describe

In-collaboration-with: [Claude Code](https://claude.com/claude-code)