### PR TITLE
feat(config): implement appConfig primitive with discovery [TRL-89]

### DIFF
--- a/packages/config/src/__tests__/app-config.test.ts
+++ b/packages/config/src/__tests__/app-config.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { z } from 'zod';
+
+import { appConfig } from '../app-config.js';
+import { describeConfig } from '../describe.js';
+import { checkConfig } from '../doctor.js';
+import { configRef } from '../ref.js';
+
+const testSchema = z.object({
+  output: z.string().describe('Output directory').default('./output'),
+  verbose: z.boolean().default(false),
+});
+
+describe('appConfig()', () => {
+  describe('creation', () => {
+    test('returns an object with the provided name', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      expect(config.name).toBe('myapp');
+    });
+
+    test('returns the provided schema', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      expect(config.schema).toBe(testSchema);
+    });
+
+    test('defaults formats to toml, json, yaml when not specified', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      expect(config.formats).toEqual(['toml', 'json', 'yaml']);
+    });
+
+    test('uses provided formats', () => {
+      const config = appConfig('myapp', {
+        formats: ['json', 'jsonc'],
+        schema: testSchema,
+      });
+      expect(config.formats).toEqual(['json', 'jsonc']);
+    });
+
+    test('defaults dotfile to false when not specified', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      expect(config.dotfile).toBe(false);
+    });
+
+    test('uses provided dotfile value', () => {
+      const config = appConfig('myapp', {
+        dotfile: true,
+        schema: testSchema,
+      });
+      expect(config.dotfile).toBe(true);
+    });
+  });
+
+  describe('resolve() with explicit path', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'trails-config-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { force: true, recursive: true });
+    });
+
+    test('reads and validates a JSON config file', async () => {
+      const filePath = join(tempDir, 'myapp.config.json');
+      await Bun.write(
+        filePath,
+        JSON.stringify({ output: './dist', verbose: true })
+      );
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ path: filePath });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ output: './dist', verbose: true });
+    });
+
+    test('reads and validates a TOML config file', async () => {
+      const filePath = join(tempDir, 'myapp.config.toml');
+      await Bun.write(filePath, 'output = "./build"\nverbose = true\n');
+
+      const config = appConfig('myapp', {
+        formats: ['toml'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ path: filePath });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ output: './build', verbose: true });
+    });
+
+    test('applies schema defaults for missing fields', async () => {
+      const filePath = join(tempDir, 'myapp.config.json');
+      await Bun.write(filePath, JSON.stringify({}));
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ path: filePath });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ output: './output', verbose: false });
+    });
+
+    test('returns Result.err when file does not exist', async () => {
+      const filePath = join(tempDir, 'nonexistent.json');
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ path: filePath });
+
+      expect(result.isErr()).toBe(true);
+    });
+
+    test('returns Result.err when file has invalid content', async () => {
+      const filePath = join(tempDir, 'myapp.config.json');
+      await Bun.write(
+        filePath,
+        JSON.stringify({ output: 42, verbose: 'not-a-bool' })
+      );
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ path: filePath });
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('resolve() with discovery', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'trails-config-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { force: true, recursive: true });
+    });
+
+    test('discovers config file in cwd', async () => {
+      const filePath = join(tempDir, 'myapp.config.json');
+      await Bun.write(filePath, JSON.stringify({ output: './found' }));
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().output).toBe('./found');
+    });
+
+    test('discovers config file by walking up directories', async () => {
+      const nested = join(tempDir, 'a', 'b', 'c');
+      await mkdir(nested, { recursive: true });
+
+      const filePath = join(tempDir, 'myapp.config.json');
+      await Bun.write(filePath, JSON.stringify({ output: './parent' }));
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: nested });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().output).toBe('./parent');
+    });
+
+    test('tries formats in order', async () => {
+      await Bun.write(
+        join(tempDir, 'myapp.config.toml'),
+        'output = "./from-toml"\n'
+      );
+      await Bun.write(
+        join(tempDir, 'myapp.config.json'),
+        JSON.stringify({ output: './from-json' })
+      );
+
+      const config = appConfig('myapp', {
+        formats: ['toml', 'json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().output).toBe('./from-toml');
+    });
+
+    test('returns Result.err when no config file found', async () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('file naming conventions', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'trails-config-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { force: true, recursive: true });
+    });
+
+    test('dotfile: true searches for .myapprc.* files', async () => {
+      await Bun.write(
+        join(tempDir, '.myapprc.json'),
+        JSON.stringify({ output: './dotfile' })
+      );
+
+      const config = appConfig('myapp', {
+        dotfile: true,
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().output).toBe('./dotfile');
+    });
+
+    test('dotfile: false searches for myapp.config.* files', async () => {
+      await Bun.write(
+        join(tempDir, 'myapp.config.json'),
+        JSON.stringify({ output: './standard' })
+      );
+
+      const config = appConfig('myapp', {
+        dotfile: false,
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().output).toBe('./standard');
+    });
+
+    test('dotfile: true does NOT find myapp.config.* files', async () => {
+      await Bun.write(
+        join(tempDir, 'myapp.config.json'),
+        JSON.stringify({ output: './nope' })
+      );
+
+      const config = appConfig('myapp', {
+        dotfile: true,
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('method delegations', () => {
+    test('describe() returns same result as describeConfig(schema)', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      const methodResult = config.describe();
+      const standaloneResult = describeConfig(testSchema);
+
+      expect(methodResult).toEqual(standaloneResult);
+    });
+
+    test('check() returns same result as checkConfig(schema, values)', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      const values = { output: './dist', verbose: true };
+
+      const methodResult = config.check(values);
+      const standaloneResult = checkConfig(testSchema, values);
+
+      expect(methodResult).toEqual(standaloneResult);
+    });
+
+    test('ref() returns same result as configRef(path)', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      const methodResult = config.ref('output');
+      const standaloneResult = configRef('output');
+
+      expect(methodResult).toEqual(standaloneResult);
+    });
+
+    test('explain() delegates to explainConfig with bound schema', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      const resolved = { output: './dist', verbose: true };
+
+      const result = config.explain({ resolved });
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]?.path).toBeDefined();
+      expect(result[0]?.source).toBeDefined();
+    });
+  });
+});

--- a/packages/config/src/app-config.ts
+++ b/packages/config/src/app-config.ts
@@ -1,0 +1,260 @@
+/**
+ * App config factory — declare a config contract once, discover and validate at runtime.
+ */
+
+import { dirname, join } from 'node:path';
+
+import { NotFoundError, Result, ValidationError } from '@ontrails/core';
+import type { z } from 'zod';
+
+import type { CheckResult } from './doctor.js';
+import { checkConfig } from './doctor.js';
+import type { FieldDescription } from './describe.js';
+import { describeConfig } from './describe.js';
+import type { ExplainConfigOptions, ProvenanceEntry } from './explain.js';
+import { explainConfig } from './explain.js';
+import type { ConfigRef } from './ref.js';
+import { configRef } from './ref.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Supported config file formats. */
+export type ConfigFormat = 'toml' | 'json' | 'jsonc' | 'yaml';
+
+/** Options for creating an app config. */
+export interface AppConfigOptions<T extends z.ZodType> {
+  readonly schema: T;
+  readonly formats?: readonly ConfigFormat[];
+  readonly dotfile?: boolean;
+}
+
+/** Options for resolving (discovering + parsing) a config file. */
+export interface ResolveOptions {
+  /** Working directory for discovery. Defaults to `process.cwd()`. */
+  readonly cwd?: string;
+  /** Explicit file path — skips discovery when provided. */
+  readonly path?: string;
+}
+
+/** Options for the `explain()` method on AppConfig, excluding schema. */
+export type AppConfigExplainOptions = Omit<
+  ExplainConfigOptions<z.ZodType>,
+  'schema'
+>;
+
+/** The resolved config contract returned by `appConfig()`. */
+export interface AppConfig<T extends z.ZodType> {
+  readonly name: string;
+  readonly schema: T;
+  readonly formats: readonly ConfigFormat[];
+  readonly dotfile: boolean;
+  resolve(options?: ResolveOptions): Promise<Result<z.infer<T>, Error>>;
+
+  /** Describe all fields in the schema without needing values. */
+  describe(): readonly FieldDescription[];
+
+  /** Check a config object against the schema and return diagnostics. */
+  check(
+    values: Record<string, unknown>,
+    options?: { readonly env?: Record<string, string | undefined> }
+  ): CheckResult;
+
+  /** Show which source won for each config field. */
+  explain(options: AppConfigExplainOptions): readonly ProvenanceEntry[];
+
+  /** Create a lazy reference to a config field for use as a trail input default. */
+  ref(fieldPath: string): ConfigRef;
+}
+
+// ---------------------------------------------------------------------------
+// Default values
+// ---------------------------------------------------------------------------
+
+const DEFAULT_FORMATS: readonly ConfigFormat[] = ['toml', 'json', 'yaml'];
+
+// ---------------------------------------------------------------------------
+// Internal helpers (defined before consumers — no-use-before-define)
+// ---------------------------------------------------------------------------
+
+/** Build the config filename for a given format. */
+const configFileName = (
+  name: string,
+  format: ConfigFormat,
+  dotfile: boolean
+): string => (dotfile ? `.${name}rc.${format}` : `${name}.config.${format}`);
+
+/** Check whether a file exists at the given path. */
+const fileExists = (filePath: string): Promise<boolean> =>
+  Bun.file(filePath).exists();
+
+/** Read and parse a config file using Bun's native import. */
+const readConfigFile = async (
+  filePath: string
+): Promise<Result<unknown, Error>> => {
+  const exists = await fileExists(filePath);
+  if (!exists) {
+    return Result.err(
+      new NotFoundError(`Config file not found: ${filePath}`, {
+        context: { path: filePath },
+      })
+    );
+  }
+
+  try {
+    // Bun natively imports TOML, JSON, JSONC, and YAML — result has `.default`
+    const mod: Record<string, unknown> = await import(filePath);
+    return Result.ok(mod['default'] ?? mod);
+  } catch (error) {
+    return Result.err(
+      new ValidationError(`Failed to parse config file: ${filePath}`, {
+        cause: error instanceof Error ? error : new Error(String(error)),
+        context: { path: filePath },
+      })
+    );
+  }
+};
+
+/** Validate parsed data against a Zod schema. */
+const validateConfig = <T extends z.ZodType>(
+  schema: T,
+  data: unknown,
+  filePath: string
+): Result<z.infer<T>, Error> => {
+  const parsed = schema.safeParse(data);
+  if (parsed.success) {
+    return Result.ok(parsed.data as z.infer<T>);
+  }
+  return Result.err(
+    new ValidationError(`Config validation failed: ${filePath}`, {
+      context: {
+        issues: parsed.error.issues,
+        path: filePath,
+      },
+    })
+  );
+};
+
+/** Check all format candidates in a single directory. */
+const findInDir = async (
+  dir: string,
+  name: string,
+  formats: readonly ConfigFormat[],
+  dotfile: boolean
+): Promise<string | undefined> => {
+  for (const format of formats) {
+    const candidate = join(dir, configFileName(name, format, dotfile));
+    if (await fileExists(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+};
+
+/** Walk up from `startDir` looking for any matching config filename. */
+const discoverConfigFile = async (
+  name: string,
+  formats: readonly ConfigFormat[],
+  dotfile: boolean,
+  startDir: string
+): Promise<string | undefined> => {
+  let dir = startDir;
+
+  for (let depth = 0; depth < 64; depth += 1) {
+    const found = await findInDir(dir, name, formats, dotfile);
+    if (found !== undefined) {
+      return found;
+    }
+    const parent = dirname(dir);
+    // Reached filesystem root
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+
+  return undefined;
+};
+
+/** Resolve a config file — either from an explicit path or via discovery. */
+const resolveConfig = async <T extends z.ZodType>(
+  name: string,
+  schema: T,
+  formats: readonly ConfigFormat[],
+  dotfile: boolean,
+  options?: ResolveOptions
+): Promise<Result<z.infer<T>, Error>> => {
+  const filePath =
+    options?.path ??
+    (await discoverConfigFile(
+      name,
+      formats,
+      dotfile,
+      options?.cwd ?? process.cwd()
+    ));
+
+  if (filePath === undefined) {
+    return Result.err(
+      new NotFoundError(`No config file found for "${name}"`, {
+        context: { dotfile, formats: [...formats], name },
+      })
+    );
+  }
+
+  const readResult = await readConfigFile(filePath);
+  if (readResult.isErr()) {
+    return readResult;
+  }
+
+  return validateConfig(schema, readResult.value, filePath);
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Declare a config contract for an app.
+ *
+ * The returned `AppConfig` exposes `resolve()` to discover, parse, and validate
+ * a config file matching the app name and format conventions.
+ *
+ * @example
+ * ```ts
+ * const config = appConfig('myapp', {
+ *   schema: z.object({
+ *     output: z.string().default('./output'),
+ *     verbose: z.boolean().default(false),
+ *   }),
+ * });
+ *
+ * const result = await config.resolve();
+ * if (result.isOk()) console.log(result.value.output);
+ * ```
+ */
+export const appConfig = <T extends z.ZodType>(
+  name: string,
+  options: AppConfigOptions<T>
+): AppConfig<T> => {
+  const formats = options.formats ?? DEFAULT_FORMATS;
+  const dotfile = options.dotfile ?? false;
+
+  const { schema } = options;
+
+  return {
+    check: (values, checkOpts) => checkConfig(schema, values, checkOpts),
+    describe: () =>
+      describeConfig(
+        schema as unknown as z.ZodObject<Record<string, z.ZodType>>
+      ),
+    dotfile,
+    explain: (explainOpts) => explainConfig({ ...explainOpts, schema }),
+    formats,
+    name,
+    ref: (fieldPath) => configRef(fieldPath),
+    resolve: (resolveOptions?: ResolveOptions) =>
+      resolveConfig(name, schema, formats, dotfile, resolveOptions),
+    schema,
+  };
+};

--- a/packages/config/src/collect.ts
+++ b/packages/config/src/collect.ts
@@ -30,7 +30,9 @@ const META_EXTRACTORS: readonly {
 const pickConfigMeta = (
   raw: Record<string, unknown> | undefined
 ): ConfigFieldMeta | undefined => {
-  if (!raw) {return undefined;}
+  if (!raw) {
+    return undefined;
+  }
 
   const parts = META_EXTRACTORS.filter((e) => e.test(raw)).map((e) =>
     e.extract(raw)
@@ -49,7 +51,9 @@ const extractConfigMeta = (schema: z.ZodType): ConfigFieldMeta | undefined => {
 
   while (current) {
     const meta = pickConfigMeta(globalRegistry.get(current));
-    if (meta) {return meta;}
+    if (meta) {
+      return meta;
+    }
 
     const def = current.def as unknown as Record<string, unknown>;
     current = def['innerType'] as z.ZodType | undefined;
@@ -83,7 +87,9 @@ const walkObjectShape = (
       });
     } else {
       const meta = extractConfigMeta(fieldSchema);
-      if (meta) {result.set(path, meta);}
+      if (meta) {
+        result.set(path, meta);
+      }
     }
   }
 };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,11 @@
+export {
+  appConfig,
+  type AppConfig,
+  type AppConfigExplainOptions,
+  type AppConfigOptions,
+  type ConfigFormat,
+  type ResolveOptions,
+} from './app-config.js';
 export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
 export { collectConfigMeta } from './collect.js';
 export { configCheck } from './trails/config-check.js';


### PR DESCRIPTION
## Summary

- `appConfig()` factory declares a config contract: name, Zod schema, supported formats, dotfile convention
- `resolve()` discovers config files by walking up from cwd — supports TOML, JSON, JSONC, YAML via Bun native imports (zero deps)
- File conventions: `.myapprc.*` (dotfile) or `myapp.config.*` (standard)
- Validates through Zod schema, returns `Result`

## Test plan

- [ ] 18 tests covering creation, defaults, resolve with explicit path, discovery, format priority, validation errors
- [ ] `bun test` passes in `packages/config/`

Closes https://linear.app/outfitter/issue/TRL-89/core-appconfig-primitive-and-discovery

In-collaboration-with: [Claude Code](https://claude.com/claude-code)