### PR TITLE
feat(config): implement resolution stack and defineConfig [TRL-90]

### DIFF
--- a/packages/config/src/__tests__/define-config.test.ts
+++ b/packages/config/src/__tests__/define-config.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+import { defineConfig } from '../define-config.js';
+
+const schema = z.object({
+  debug: z.boolean().default(false),
+  host: z.string().default('localhost'),
+  port: z.number().default(3000),
+});
+
+describe('defineConfig', () => {
+  test('returns an object with schema, base, and loadouts', () => {
+    const base = { host: 'example.com' };
+    const loadouts = { production: { port: 443 } };
+
+    const config = defineConfig({ base, loadouts, schema });
+
+    expect(config.schema).toBe(schema);
+    expect(config.base).toBe(base);
+    expect(config.loadouts).toBe(loadouts);
+  });
+
+  test('resolve() uses TRAILS_ENV to select loadout', async () => {
+    const config = defineConfig({
+      base: { host: 'example.com' },
+      loadouts: {
+        production: { host: 'prod.example.com', port: 443 },
+        test: { host: 'test.example.com', port: 9999 },
+      },
+      schema,
+    });
+
+    const result = await config.resolve({
+      env: { TRAILS_ENV: 'production' },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().host).toBe('prod.example.com');
+    expect(result.unwrap().port).toBe(443);
+  });
+
+  test('resolve() with explicit loadout option overrides TRAILS_ENV', async () => {
+    const config = defineConfig({
+      base: { host: 'example.com' },
+      loadouts: {
+        production: { host: 'prod.example.com' },
+        test: { host: 'test.example.com' },
+      },
+      schema,
+    });
+
+    const result = await config.resolve({
+      env: { TRAILS_ENV: 'production' },
+      loadout: 'test',
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().host).toBe('test.example.com');
+  });
+
+  test('envFromNodeEnv maps NODE_ENV to TRAILS_ENV when unset', async () => {
+    const config = defineConfig({
+      base: { host: 'example.com' },
+      envFromNodeEnv: true,
+      loadouts: {
+        production: { host: 'prod.example.com', port: 443 },
+      },
+      schema,
+    });
+
+    const result = await config.resolve({
+      env: { NODE_ENV: 'production' },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().host).toBe('prod.example.com');
+    expect(result.unwrap().port).toBe(443);
+  });
+
+  test('envFromNodeEnv does not override explicit TRAILS_ENV', async () => {
+    const config = defineConfig({
+      base: { host: 'example.com' },
+      envFromNodeEnv: true,
+      loadouts: {
+        production: { host: 'prod.example.com' },
+        test: { host: 'test.example.com' },
+      },
+      schema,
+    });
+
+    const result = await config.resolve({
+      env: { NODE_ENV: 'production', TRAILS_ENV: 'test' },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().host).toBe('test.example.com');
+  });
+
+  test('test loadout works when TRAILS_ENV=test', async () => {
+    const config = defineConfig({
+      base: { port: 8080 },
+      loadouts: {
+        test: { debug: true, port: 0 },
+      },
+      schema,
+    });
+
+    const result = await config.resolve({
+      env: { TRAILS_ENV: 'test' },
+    });
+
+    expect(result.isOk()).toBe(true);
+    const value = result.unwrap();
+    expect(value.debug).toBe(true);
+    expect(value.port).toBe(0);
+  });
+
+  describe('local overrides', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'trails-define-config-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { force: true, recursive: true });
+    });
+
+    test('applies local overrides from .trails/config/local.ts', async () => {
+      const configDir = join(tempDir, '.trails', 'config');
+      await mkdir(configDir, { recursive: true });
+      await Bun.write(
+        join(configDir, 'local.ts'),
+        'export default { port: 4444 };'
+      );
+
+      const config = defineConfig({
+        base: { host: 'example.com' },
+        schema,
+      });
+
+      const result = await config.resolve({
+        cwd: tempDir,
+        env: {},
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().port).toBe(4444);
+    });
+
+    test('local overrides applied between loadout and env', async () => {
+      const configDir = join(tempDir, '.trails', 'config');
+      await mkdir(configDir, { recursive: true });
+      await Bun.write(
+        join(configDir, 'local.js'),
+        'export default { port: 5555 };'
+      );
+
+      const config = defineConfig({
+        base: { port: 8080 },
+        loadouts: {
+          dev: { port: 9090 },
+        },
+        schema,
+      });
+
+      // Local overrides should win over loadout (9090)
+      const result = await config.resolve({
+        cwd: tempDir,
+        env: { TRAILS_ENV: 'dev' },
+        loadout: 'dev',
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().port).toBe(5555);
+    });
+
+    test('skips local overrides when TRAILS_ENV=test', async () => {
+      const configDir = join(tempDir, '.trails', 'config');
+      await mkdir(configDir, { recursive: true });
+      await Bun.write(
+        join(configDir, 'local.ts'),
+        'export default { port: 4444 };'
+      );
+
+      const config = defineConfig({
+        base: { port: 8080 },
+        schema,
+      });
+
+      const result = await config.resolve({
+        cwd: tempDir,
+        env: { TRAILS_ENV: 'test' },
+      });
+
+      expect(result.isOk()).toBe(true);
+      // Should NOT apply local overrides, so port stays at base 8080
+      expect(result.unwrap().port).toBe(8080);
+    });
+  });
+});

--- a/packages/config/src/__tests__/resolve.test.ts
+++ b/packages/config/src/__tests__/resolve.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { env } from '../extensions.js';
+import { resolveConfig } from '../resolve.js';
+
+const baseSchema = z.object({
+  debug: z.boolean().default(false),
+  host: z.string().default('localhost'),
+  port: z.number().default(3000),
+});
+
+describe('resolveConfig', () => {
+  describe('schema defaults', () => {
+    test('applies schema defaults when no other source provides values', () => {
+      const result = resolveConfig({ schema: baseSchema });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({
+        debug: false,
+        host: 'localhost',
+        port: 3000,
+      });
+    });
+  });
+
+  describe('base config', () => {
+    test('overrides schema defaults', () => {
+      const result = resolveConfig({
+        base: { host: 'example.com', port: 8080 },
+        schema: baseSchema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.host).toBe('example.com');
+      expect(value.port).toBe(8080);
+      // Schema default preserved for unspecified fields
+      expect(value.debug).toBe(false);
+    });
+  });
+
+  describe('loadouts', () => {
+    test('overrides base config for matching loadout', () => {
+      const result = resolveConfig({
+        base: { host: 'example.com', port: 8080 },
+        loadout: 'production',
+        loadouts: {
+          production: { host: 'prod.example.com', port: 443 },
+        },
+        schema: baseSchema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.host).toBe('prod.example.com');
+      expect(value.port).toBe(443);
+      expect(value.debug).toBe(false);
+    });
+
+    test('silently ignores unrecognized loadout (base only)', () => {
+      const result = resolveConfig({
+        base: { host: 'example.com' },
+        loadout: 'staging',
+        loadouts: {
+          production: { host: 'prod.example.com' },
+        },
+        schema: baseSchema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().host).toBe('example.com');
+    });
+  });
+
+  describe('local overrides', () => {
+    test('deep-merge on top of loadout', () => {
+      const nestedSchema = z.object({
+        db: z
+          .object({
+            host: z.string().default('localhost'),
+            port: z.number().default(5432),
+          })
+          .default({}),
+      });
+
+      const result = resolveConfig({
+        base: { db: { host: 'db.example.com', port: 5432 } },
+        loadout: 'production',
+        loadouts: {
+          production: { db: { host: 'prod-db.example.com' } },
+        },
+        localOverrides: { db: { port: 9999 } },
+        schema: nestedSchema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.db.host).toBe('prod-db.example.com');
+      expect(value.db.port).toBe(9999);
+    });
+  });
+
+  describe('env var overrides', () => {
+    test('overrides all other sources', () => {
+      const schema = z.object({
+        host: env(z.string(), 'APP_HOST').default('localhost'),
+        port: env(z.number(), 'APP_PORT').default(3000),
+      });
+
+      const result = resolveConfig({
+        base: { host: 'example.com', port: 8080 },
+        env: { APP_HOST: 'env-host.example.com', APP_PORT: '9090' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.host).toBe('env-host.example.com');
+      expect(value.port).toBe(9090);
+    });
+
+    test('coerces string to number', () => {
+      const schema = z.object({
+        port: env(z.number(), 'PORT').default(3000),
+      });
+
+      const result = resolveConfig({
+        env: { PORT: '8080' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().port).toBe(8080);
+    });
+
+    test('coerces string to boolean', () => {
+      const schema = z.object({
+        debug: env(z.boolean(), 'DEBUG').default(false),
+        verbose: env(z.boolean(), 'VERBOSE').default(false),
+      });
+
+      const trueValues = resolveConfig({
+        env: { DEBUG: 'true', VERBOSE: '1' },
+        schema,
+      });
+      expect(trueValues.isOk()).toBe(true);
+      expect(trueValues.unwrap().debug).toBe(true);
+      expect(trueValues.unwrap().verbose).toBe(true);
+
+      const falseValues = resolveConfig({
+        env: { DEBUG: 'false', VERBOSE: '0' },
+        schema,
+      });
+      expect(falseValues.isOk()).toBe(true);
+      expect(falseValues.unwrap().debug).toBe(false);
+      expect(falseValues.unwrap().verbose).toBe(false);
+    });
+  });
+
+  describe('validation', () => {
+    test('missing required field returns Result.err', () => {
+      const schema = z.object({
+        required: z.string(),
+      });
+
+      const result = resolveConfig({ schema });
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('mutation safety', () => {
+    test('repeated resolve() calls do not mutate the original base', () => {
+      const schema = z.object({
+        host: env(z.string(), 'APP_HOST').default('localhost'),
+      });
+      const base = { host: 'dev-host' };
+
+      const first = resolveConfig({
+        base,
+        env: { APP_HOST: 'env-host' },
+        schema,
+      });
+      expect(first.isOk()).toBe(true);
+      expect(first.unwrap().host).toBe('env-host');
+
+      const second = resolveConfig({ base, schema });
+      expect(second.isOk()).toBe(true);
+      expect(second.unwrap().host).toBe('dev-host');
+      expect(base.host).toBe('dev-host');
+    });
+  });
+
+  describe('full stack', () => {
+    test('all 5 sources compose correctly', () => {
+      const schema = z.object({
+        apiUrl: env(z.string(), 'API_URL').default('http://localhost'),
+        debug: env(z.boolean(), 'DEBUG').default(false),
+        local: z.string().default('default-local'),
+        name: z.string().default('app'),
+        port: z.number().default(3000),
+      });
+
+      const result = resolveConfig({
+        // base overrides name
+        base: { name: 'my-app', port: 8080 },
+        // env overrides debug and apiUrl
+        env: { API_URL: 'https://api.prod.com', DEBUG: 'true' },
+        // loadout overrides port
+        loadout: 'production',
+        loadouts: { production: { port: 443 } },
+        // local overrides local
+        localOverrides: { local: 'my-local-value' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      // Schema default
+      // (nothing left at just default — name was overridden by base)
+      // Base
+      expect(value.name).toBe('my-app');
+      // Loadout overrides base port
+      expect(value.port).toBe(443);
+      // Local overrides
+      expect(value.local).toBe('my-local-value');
+      // Env overrides
+      expect(value.apiUrl).toBe('https://api.prod.com');
+      expect(value.debug).toBe(true);
+    });
+  });
+});

--- a/packages/config/src/define-config.ts
+++ b/packages/config/src/define-config.ts
@@ -1,0 +1,133 @@
+/**
+ * Trails-specific config wrapper — `appConfig('trails', ...)` with
+ * framework conventions for loadout selection and local overrides.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { z } from 'zod';
+
+import { appConfig } from './app-config.js';
+import { resolveConfig } from './resolve.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for defining a Trails app config. */
+export interface DefineConfigOptions<T extends z.ZodType> {
+  readonly schema: T;
+  readonly base?: Partial<z.infer<T>>;
+  readonly loadouts?: Record<string, Partial<z.infer<T>>>;
+  /** When true, fall back to `NODE_ENV` when `TRAILS_ENV` is unset. */
+  readonly envFromNodeEnv?: boolean;
+}
+
+/** Options passed to `resolve()` on a defined config. */
+interface DefineConfigResolveOptions {
+  readonly loadout?: string;
+  readonly env?: Record<string, string | undefined>;
+  /** Working directory for local overrides discovery. Defaults to `process.cwd()`. */
+  readonly cwd?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Local overrides discovery
+// ---------------------------------------------------------------------------
+
+const LOCAL_OVERRIDE_CANDIDATES = ['local.ts', 'local.js'] as const;
+
+/**
+ * Discover and synchronously import a `.trails/config/local.{ts,js}` file.
+ *
+ * Skipped when `TRAILS_ENV=test` for hermetic test environments.
+ */
+const discoverLocalOverrides = async (
+  cwd: string,
+  envRecord: Record<string, string | undefined>
+): Promise<Record<string, unknown> | undefined> => {
+  if (envRecord['TRAILS_ENV'] === 'test') {
+    return undefined;
+  }
+
+  for (const filename of LOCAL_OVERRIDE_CANDIDATES) {
+    const candidate = join(cwd, '.trails', 'config', filename);
+    if (existsSync(candidate)) {
+      const mod: Record<string, unknown> = await import(candidate);
+      return (mod['default'] ?? mod) as Record<string, unknown>;
+    }
+  }
+
+  return undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Define Trails app config.
+ *
+ * This is `appConfig('trails', ...)` with the framework's own conventions:
+ * `TRAILS_ENV` selects the loadout. When `envFromNodeEnv` is true,
+ * `NODE_ENV` is used as a fallback when `TRAILS_ENV` is unset.
+ *
+ * @example
+ * ```ts
+ * const config = defineConfig({
+ *   schema: z.object({
+ *     port: z.number().default(3000),
+ *     debug: z.boolean().default(false),
+ *   }),
+ *   base: { port: 8080 },
+ *   loadouts: {
+ *     production: { debug: false },
+ *     test: { debug: true, port: 0 },
+ *   },
+ * });
+ *
+ * const result = config.resolve();
+ * ```
+ */
+export const defineConfig = <T extends z.ZodType>(
+  options: DefineConfigOptions<T>
+) => {
+  const config = appConfig('trails', {
+    formats: ['toml', 'json'],
+    schema: options.schema,
+  });
+
+  return {
+    ...config,
+    base: options.base,
+    loadouts: options.loadouts,
+    resolve: async (resolveOpts?: DefineConfigResolveOptions) => {
+      const envRecord =
+        resolveOpts?.env ?? (process.env as Record<string, string | undefined>);
+
+      if (
+        options.envFromNodeEnv &&
+        envRecord['TRAILS_ENV'] === undefined &&
+        envRecord['NODE_ENV'] !== undefined
+      ) {
+        envRecord['TRAILS_ENV'] = envRecord['NODE_ENV'];
+      }
+
+      const cwd = resolveOpts?.cwd ?? process.cwd();
+      const localOverrides = await discoverLocalOverrides(cwd, envRecord);
+
+      return resolveConfig({
+        base: options.base as Record<string, unknown> | undefined,
+        env: envRecord,
+        loadout: resolveOpts?.loadout ?? envRecord['TRAILS_ENV'],
+        loadouts: options.loadouts as
+          | Record<string, Record<string, unknown>>
+          | undefined,
+        localOverrides,
+        schema: options.schema,
+      });
+    },
+    schema: options.schema,
+  };
+};

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -6,7 +6,16 @@ export {
   type ConfigFormat,
   type ResolveOptions,
 } from './app-config.js';
-export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
 export { collectConfigMeta } from './collect.js';
+export { defineConfig, type DefineConfigOptions } from './define-config.js';
+export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
+export {
+  clearConfigState,
+  type ConfigState,
+  getConfigState,
+  registerConfigState,
+} from './registry.js';
+export { deepMerge } from './merge.js';
+export { resolveConfig, type ResolveConfigOptions } from './resolve.js';
 export { configCheck } from './trails/config-check.js';
 export { configDescribe } from './trails/config-describe.js';

--- a/packages/config/src/merge.ts
+++ b/packages/config/src/merge.ts
@@ -1,0 +1,43 @@
+/**
+ * Simple recursive deep merge for config objects.
+ *
+ * - Objects merge recursively
+ * - Arrays replace (no concatenation)
+ * - Primitives replace
+ * - `undefined` values in source are skipped
+ */
+
+/** Check whether a value is a plain object (not array, null, or class instance). */
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.getPrototypeOf(value) === Object.prototype;
+
+/**
+ * Deep-merge `source` into `target`, returning a new object.
+ *
+ * Does not mutate either input. Undefined values in source are skipped,
+ * preserving the target's value at that key.
+ */
+export const deepMerge = (
+  target: Record<string, unknown>,
+  source: Record<string, unknown>
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = { ...target };
+
+  for (const [key, sourceValue] of Object.entries(source)) {
+    if (sourceValue === undefined) {
+      continue;
+    }
+
+    const targetValue = result[key];
+
+    result[key] =
+      isPlainObject(targetValue) && isPlainObject(sourceValue)
+        ? deepMerge(targetValue, sourceValue)
+        : sourceValue;
+  }
+
+  return result;
+};

--- a/packages/config/src/resolve.ts
+++ b/packages/config/src/resolve.ts
@@ -1,0 +1,276 @@
+/**
+ * Config resolution engine — merges config from multiple sources through
+ * a deterministic stack: defaults → base → loadout → local → env.
+ */
+
+import type { z } from 'zod';
+
+import { Result } from '@ontrails/core';
+
+import { collectConfigMeta } from './collect.js';
+import { deepMerge } from './merge.js';
+import { zodDef } from './zod-utils.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for resolving config through the full stack. */
+export interface ResolveConfigOptions<T extends z.ZodType> {
+  readonly schema: T;
+  readonly base?: Record<string, unknown> | undefined;
+  readonly loadouts?: Record<string, Record<string, unknown>> | undefined;
+  readonly loadout?: string | undefined;
+  readonly localOverrides?: Record<string, unknown> | undefined;
+  readonly env?: Record<string, string | undefined> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Env coercion helpers (defined before consumers)
+// ---------------------------------------------------------------------------
+
+/** Boolean string values we accept from environment variables. */
+const BOOL_TRUE = new Set(['true', '1']);
+const BOOL_FALSE = new Set(['false', '0']);
+
+/** Primitive type names we can coerce env strings into. */
+const PRIMITIVE_TYPES = new Set(['number', 'boolean', 'string']);
+
+/** Try to advance one level through a Zod wrapper, returning the inner type or undefined. */
+const unwrapOne = (
+  schema: z.ZodType
+): { typeName: string | undefined; inner: z.ZodType | undefined } => {
+  const def = zodDef(schema);
+  return {
+    inner: def['innerType'] as z.ZodType | undefined,
+    typeName: def['type'] as string | undefined,
+  };
+};
+
+/** Unwrap ZodDefault / ZodOptional / ZodNullable to find the base type name. */
+const resolveBaseTypeName = (schema: z.ZodType): string => {
+  let current: z.ZodType = schema;
+
+  for (let depth = 0; depth < 10; depth += 1) {
+    const { typeName, inner } = unwrapOne(current);
+    if (typeName && PRIMITIVE_TYPES.has(typeName)) {
+      return typeName;
+    }
+    if (!inner) {
+      break;
+    }
+    current = inner;
+  }
+
+  return 'string';
+};
+
+/** Coerce a boolean env string. Returns the original string if unrecognized. */
+const coerceBooleanEnv = (raw: string): unknown => {
+  if (BOOL_TRUE.has(raw)) {
+    return true;
+  }
+  if (BOOL_FALSE.has(raw)) {
+    return false;
+  }
+  return raw;
+};
+
+/** Coerce env var lookup table keyed by base type name. */
+const ENV_COERCERS: Record<string, (raw: string) => unknown> = {
+  boolean: coerceBooleanEnv,
+  number: Number,
+};
+
+/** Coerce a string env value to the type expected by the schema field. */
+const coerceEnvValue = (raw: string, schema: z.ZodType): unknown => {
+  const coercer = ENV_COERCERS[resolveBaseTypeName(schema)];
+  return coercer ? coercer(raw) : raw;
+};
+
+// ---------------------------------------------------------------------------
+// Path utilities
+// ---------------------------------------------------------------------------
+
+/** Navigate one step of a nested object, creating an intermediate if needed. */
+const navigateOrCreate = (
+  current: Record<string, unknown>,
+  key: string
+): Record<string, unknown> => {
+  const next = current[key];
+  if (typeof next === 'object' && next !== null && !Array.isArray(next)) {
+    return next as Record<string, unknown>;
+  }
+  const nested: Record<string, unknown> = {};
+  current[key] = nested;
+  return nested;
+};
+
+/** Ensure a nested path exists in an object, creating intermediates as needed. */
+const ensurePath = (
+  obj: Record<string, unknown>,
+  parts: readonly string[]
+): Record<string, unknown> => {
+  let current = obj;
+  for (const part of parts) {
+    current = navigateOrCreate(current, part);
+  }
+  return current;
+};
+
+/** Set a value at a dot-separated path in a plain object. */
+const setAtPath = (
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown
+): void => {
+  const parts = path.split('.');
+  const parent = ensurePath(obj, parts.slice(0, -1));
+  parent[parts.at(-1) as string] = value;
+};
+
+/** Resolve one step of a Zod shape walk: find the field schema for a key. */
+const resolveShapeStep = (
+  current: z.ZodType,
+  key: string
+): z.ZodType | undefined => {
+  const shape = zodDef(current)['shape'] as
+    | Record<string, z.ZodType>
+    | undefined;
+  return shape?.[key];
+};
+
+/** Walk a Zod schema shape to find the field at a dot-separated path. */
+const getFieldSchema = (
+  schema: z.ZodType,
+  path: string
+): z.ZodType | undefined => {
+  let current: z.ZodType = schema;
+  for (const part of path.split('.')) {
+    const next = resolveShapeStep(current, part);
+    if (!next) {
+      return undefined;
+    }
+    current = next;
+  }
+  return current;
+};
+
+// ---------------------------------------------------------------------------
+// Env overlay
+// ---------------------------------------------------------------------------
+
+/** Coerce and set a single env override into the result object. */
+const applyOneEnvOverride = (
+  result: Record<string, unknown>,
+  schema: z.ZodType,
+  path: string,
+  envValue: string
+): void => {
+  const fieldSchema = getFieldSchema(schema, path);
+  const coerced = fieldSchema
+    ? coerceEnvValue(envValue, fieldSchema)
+    : envValue;
+  setAtPath(result, path, coerced);
+};
+
+/** Resolve a single env binding: look up the var, apply if present. */
+const resolveEnvBinding = (
+  result: Record<string, unknown>,
+  schema: z.ZodType,
+  path: string,
+  envVar: string,
+  envVars: Record<string, string | undefined>
+): void => {
+  const envValue = envVars[envVar];
+  if (envValue !== undefined) {
+    applyOneEnvOverride(result, schema, path, envValue);
+  }
+};
+
+/** Apply env var overrides based on schema metadata. */
+const applyEnvOverrides = (
+  merged: Record<string, unknown>,
+  schema: z.ZodType,
+  envVars: Record<string, string | undefined>
+): Record<string, unknown> => {
+  if (zodDef(schema)['type'] !== 'object') {
+    return merged;
+  }
+
+  const meta = collectConfigMeta(
+    schema as z.ZodObject<Record<string, z.ZodType>>
+  );
+  const result = deepMerge({}, merged);
+
+  for (const [path, fieldMeta] of meta) {
+    if (fieldMeta.env) {
+      resolveEnvBinding(result, schema, path, fieldMeta.env, envVars);
+    }
+  }
+
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// Merge pipeline
+// ---------------------------------------------------------------------------
+
+/** Apply the layered merge: base → loadout → local overrides. */
+const mergeLayers = (
+  base: Record<string, unknown> | undefined,
+  loadouts: Record<string, Record<string, unknown>> | undefined,
+  loadout: string | undefined,
+  localOverrides: Record<string, unknown> | undefined
+): Record<string, unknown> => {
+  let merged: Record<string, unknown> = {};
+  if (base) {
+    merged = deepMerge(merged, base);
+  }
+
+  const selected = loadout && loadouts ? loadouts[loadout] : undefined;
+  if (selected) {
+    merged = deepMerge(merged, selected);
+  }
+
+  if (localOverrides) {
+    merged = deepMerge(merged, localOverrides);
+  }
+  return merged;
+};
+
+/** Format Zod issues into a human-readable error message. */
+const formatValidationError = (
+  issues: readonly { path: PropertyKey[]; message: string }[]
+): string =>
+  `Config validation failed: ${issues.map((i) => `${String(i.path.join('.'))}: ${i.message}`).join(', ')}`;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve config through the full stack: defaults → base → loadout → local → env.
+ * Returns `Result.ok` with the validated config, or `Result.err` on validation failure.
+ */
+export const resolveConfig = <T extends z.ZodType>(
+  options: ResolveConfigOptions<T>
+): Result<z.infer<T>, Error> => {
+  let merged = mergeLayers(
+    options.base,
+    options.loadouts,
+    options.loadout,
+    options.localOverrides
+  );
+
+  if (options.env) {
+    merged = applyEnvOverrides(merged, options.schema, options.env);
+  }
+
+  const parsed = options.schema.safeParse(merged);
+  if (parsed.success) {
+    return Result.ok(parsed.data as z.infer<T>);
+  }
+
+  return Result.err(new Error(formatValidationError(parsed.error.issues)));
+};


### PR DESCRIPTION
## Summary

- Five-layer config resolution: schema defaults → base → loadout → local overrides → environment variables
- `resolveConfig()` merges all sources and validates through Zod schema
- Env var coercion: string → number, string → boolean based on schema type
- `defineConfig()` wraps `appConfig('trails')` with `TRAILS_ENV` loadout selection
- `deepMerge` utility for recursive object merging (arrays replace, primitives replace, undefined skipped)

## Test plan

- [ ] 14 tests covering each resolution layer, precedence, coercion, and full-stack composition
- [ ] `bun test` passes in `packages/config/`

Closes https://linear.app/outfitter/issue/TRL-90/config-resolution-stack-and-defineconfig

In-collaboration-with: [Claude Code](https://claude.com/claude-code)