### PR TITLE
feat(config): wire ServiceSpec.config into service creation [TRL-91]

### DIFF
--- a/packages/config/src/__tests__/compose.test.ts
+++ b/packages/config/src/__tests__/compose.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { collectServiceConfigs } from '../compose.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('collectServiceConfigs', () => {
+  test('extracts config schemas from services that declare them', () => {
+    const dbSchema = z.object({ url: z.string().url() });
+    const cacheSchema = z.object({ ttl: z.number() });
+
+    const services = [
+      { config: dbSchema, id: 'db.main' },
+      { config: cacheSchema, id: 'cache.main' },
+    ];
+
+    const entries = collectServiceConfigs(services);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toEqual({ schema: dbSchema, serviceId: 'db.main' });
+    expect(entries[1]).toEqual({
+      schema: cacheSchema,
+      serviceId: 'cache.main',
+    });
+  });
+
+  test('excludes services without config', () => {
+    const schema = z.object({ url: z.string() });
+
+    const services = [
+      { config: schema, id: 'db.main' },
+      { id: 'counter.main' },
+      { config: undefined, id: 'logger.main' },
+    ];
+
+    const entries = collectServiceConfigs(services);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.serviceId).toBe('db.main');
+  });
+
+  test('returns empty array when no services have config', () => {
+    const services = [{ id: 'counter.main' }, { id: 'logger.main' }];
+
+    const entries = collectServiceConfigs(services);
+
+    expect(entries).toEqual([]);
+  });
+
+  test('returns empty array for empty input', () => {
+    const entries = collectServiceConfigs([]);
+
+    expect(entries).toEqual([]);
+  });
+});

--- a/packages/config/src/compose.ts
+++ b/packages/config/src/compose.ts
@@ -1,0 +1,46 @@
+/**
+ * Config composition utilities for services.
+ *
+ * Collects config schemas from service declarations so they can be
+ * composed into a unified config structure via `defineConfig`.
+ */
+
+import type { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A service config schema entry extracted from a service declaration. */
+export interface ServiceConfigEntry {
+  readonly serviceId: string;
+  readonly schema: z.ZodType;
+}
+
+/** Minimal shape needed to extract config from a service-like object. */
+interface ServiceWithOptionalConfig {
+  readonly id: string;
+  readonly config?: z.ZodType | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect config schemas from services that declare them.
+ *
+ * Returns entries keyed by service ID for composition into `defineConfig`.
+ * Services without a `config` schema are excluded.
+ */
+export const collectServiceConfigs = (
+  services: readonly ServiceWithOptionalConfig[]
+): ServiceConfigEntry[] =>
+  services
+    .filter(
+      (
+        svc
+      ): svc is ServiceWithOptionalConfig & { readonly config: z.ZodType } =>
+        svc.config !== undefined
+    )
+    .map((svc) => ({ schema: svc.config, serviceId: svc.id }));

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,6 +7,7 @@ export {
   type ResolveOptions,
 } from './app-config.js';
 export { collectConfigMeta } from './collect.js';
+export { collectServiceConfigs, type ServiceConfigEntry } from './compose.js';
 export { defineConfig, type DefineConfigOptions } from './define-config.js';
 export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
 export {

--- a/packages/core/src/__tests__/service-config.test.ts
+++ b/packages/core/src/__tests__/service-config.test.ts
@@ -1,0 +1,180 @@
+/* oxlint-disable require-await -- trail implementations satisfy async interface without awaiting */
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { executeTrail } from '../execute.js';
+import { Result } from '../result.js';
+import { service } from '../service.js';
+import { trail } from '../trail.js';
+import type { ServiceContext } from '../service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const nextId = (name: string): string =>
+  `test.svc-config.${name}.${Bun.randomUUIDv7()}`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ServiceContext.config', () => {
+  test('service with config schema receives validated config in svc.config', async () => {
+    const id = nextId('typed-config');
+    let capturedConfig: unknown;
+
+    const db = service(id, {
+      config: z.object({ poolSize: z.number(), url: z.string().url() }),
+      create: (svc: ServiceContext<{ url: string; poolSize: number }>) => {
+        capturedConfig = svc.config;
+        return Result.ok({ connected: true });
+      },
+    });
+
+    const dbTrail = trail('svc-config.typed', {
+      input: z.object({}),
+      output: z.object({ connected: z.boolean() }),
+      run: (_input, ctx) => Result.ok({ connected: db.from(ctx).connected }),
+      services: [db],
+    });
+
+    const result = await executeTrail(
+      dbTrail,
+      {},
+      {
+        configValues: {
+          [id]: { poolSize: 5, url: 'https://example.com' },
+        },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(capturedConfig).toEqual({ poolSize: 5, url: 'https://example.com' });
+  });
+
+  test('service without config still works — svc.config is undefined', async () => {
+    const id = nextId('no-config');
+    let capturedConfig: unknown = 'sentinel';
+
+    const counter = service(id, {
+      create: (svc) => {
+        capturedConfig = svc.config;
+        return Result.ok(42);
+      },
+    });
+
+    const counterTrail = trail('svc-config.no-config', {
+      input: z.object({}),
+      run: (_input, ctx) => Result.ok({ value: counter.from(ctx) }),
+      services: [counter],
+    });
+
+    const result = await executeTrail(counterTrail, {});
+
+    expect(result.isOk()).toBe(true);
+    expect(capturedConfig).toBeUndefined();
+  });
+
+  test('config validation failure returns Result.err at service creation time', async () => {
+    const id = nextId('invalid-config');
+
+    const db = service(id, {
+      config: z.object({ url: z.string().url() }),
+      create: () => Result.ok({ connected: true }),
+    });
+
+    const dbTrail = trail('svc-config.invalid', {
+      input: z.object({}),
+      run: () => Result.ok(null),
+      services: [db],
+    });
+
+    const result = await executeTrail(
+      dbTrail,
+      {},
+      {
+        configValues: {
+          [id]: { url: 'not-a-url' },
+        },
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error.message).toContain(id);
+  });
+
+  test('missing configValues for a service with config schema returns Result.err', async () => {
+    const id = nextId('missing-config');
+
+    const db = service(id, {
+      config: z.object({ url: z.string().url() }),
+      create: () => Result.ok({ connected: true }),
+    });
+
+    const dbTrail = trail('svc-config.missing', {
+      input: z.object({}),
+      run: () => Result.ok(null),
+      services: [db],
+    });
+
+    const result = await executeTrail(dbTrail, {});
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error.message).toContain(id);
+  });
+
+  test('service override bypasses config validation', async () => {
+    const id = nextId('override-bypass');
+
+    const db = service(id, {
+      config: z.object({ url: z.string().url() }),
+      create: () => Result.ok({ connected: true }),
+    });
+
+    const dbTrail = trail('svc-config.override', {
+      input: z.object({}),
+      output: z.object({ value: z.number() }),
+      run: (_input, ctx) => Result.ok({ value: db.from(ctx) as number }),
+      services: [db],
+    });
+
+    // Provide the service via overrides without any configValues — should NOT fail
+    const result = await executeTrail(dbTrail, {}, { services: { [id]: 42 } });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ value: 42 });
+  });
+  test('config values passed through ExecuteTrailOptions.configValues', async () => {
+    const id = nextId('options-config');
+    const captures: unknown[] = [];
+
+    const svc = service(id, {
+      config: z.object({ key: z.string() }),
+      create: (ctx: ServiceContext<{ key: string }>) => {
+        captures.push(ctx.config);
+        return Result.ok({ key: ctx.config.key });
+      },
+    });
+
+    const svcTrail = trail('svc-config.options', {
+      input: z.object({}),
+      output: z.object({ key: z.string() }),
+      run: (_input, ctx) => Result.ok({ key: svc.from(ctx).key }),
+      services: [svc],
+    });
+
+    const result = await executeTrail(
+      svcTrail,
+      {},
+      {
+        configValues: { [id]: { key: 'hello' } },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ key: 'hello' });
+    expect(captures).toEqual([{ key: 'hello' }]);
+  });
+});

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -8,11 +8,7 @@
 
 import type { AnyTrail } from './trail.js';
 import type { Layer } from './layer.js';
-import type {
-  AnyService,
-  ServiceContext,
-  ServiceOverrideMap,
-} from './service.js';
+import type { ServiceOverrideMap } from './service.js';
 import type { TrailContext, TrailContextInit } from './types.js';
 
 import { composeLayers } from './layer.js';
@@ -20,6 +16,7 @@ import { createTrailContext } from './context.js';
 import { InternalError } from './errors.js';
 import { Result } from './result.js';
 import { createServiceLookup } from './service.js';
+import { resolveServices } from './service-config.js';
 import { validateInput } from './validation.js';
 
 type MutableTrailContext = {
@@ -44,6 +41,10 @@ export interface ExecuteTrailOptions {
     | undefined;
   /** Explicit service instance overrides keyed by service ID. */
   readonly services?: ServiceOverrideMap | undefined;
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  readonly configValues?:
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -87,213 +88,17 @@ const resolveContext = async (
   return resolved as TrailContext;
 };
 
-const singletonServices = new WeakMap<AnyService, Map<string, unknown>>();
-
-/** In-flight service creation promises, keyed by service × context. */
-const pendingCreations = new WeakMap<
-  AnyService,
-  Map<string, Promise<Result<unknown, Error>>>
->();
-
-const hasOwnServiceOverride = (
-  overrides: ServiceOverrideMap | undefined,
-  id: string
-): overrides is ServiceOverrideMap =>
-  overrides !== undefined && Object.hasOwn(overrides, id);
-
-const toServiceContext = (ctx: TrailContext): ServiceContext => ({
-  cwd: ctx.cwd,
-  env: ctx.env,
-  workspaceRoot: ctx.workspaceRoot,
-});
-
-const toServiceContextKey = (ctx: ServiceContext): string =>
-  JSON.stringify({
-    cwd: ctx.cwd,
-    env: Object.entries(ctx.env ?? {}).toSorted(([left], [right]) =>
-      left.localeCompare(right)
-    ),
-    workspaceRoot: ctx.workspaceRoot,
-  });
-
-const toInternalServiceError = (id: string, error: unknown): InternalError => {
-  const cause = error instanceof Error ? error : undefined;
-  const message = cause?.message ?? String(error);
-  return new InternalError(`Service "${id}" failed to resolve: ${message}`, {
-    ...(cause ? { cause } : {}),
-    context: { serviceId: id },
-  });
-};
-
-const getCachedSingletonService = (
-  declaredService: AnyService,
-  serviceContext: ServiceContext
-): { readonly found: boolean; readonly value: unknown } => {
-  const scopedCache = singletonServices.get(declaredService);
-  if (scopedCache === undefined) {
-    return { found: false, value: undefined };
-  }
-
-  const key = toServiceContextKey(serviceContext);
-  if (!scopedCache.has(key)) {
-    return { found: false, value: undefined };
-  }
-
-  return {
-    found: true,
-    value: scopedCache.get(key),
-  };
-};
-
-const getProvidedService = (
-  ctx: TrailContext,
-  overrides: ServiceOverrideMap | undefined,
-  declaredService: AnyService,
-  serviceContext: ServiceContext
-): Result<unknown, Error> | undefined => {
-  const { id } = declaredService;
-  if (hasOwnServiceOverride(overrides, id)) {
-    return Result.ok(overrides[id]);
-  }
-
-  if (Object.hasOwn(ctx.extensions ?? {}, id)) {
-    return Result.ok(ctx.extensions?.[id]);
-  }
-
-  const cached = getCachedSingletonService(declaredService, serviceContext);
-  if (cached.found) {
-    return Result.ok(cached.value);
-  }
-
-  return undefined;
-};
-
-const getSingletonServiceCache = (
-  declaredService: AnyService
-): Map<string, unknown> => {
-  const existing = singletonServices.get(declaredService);
-  if (existing !== undefined) {
-    return existing;
-  }
-
-  const created = new Map<string, unknown>();
-  singletonServices.set(declaredService, created);
-  return created;
-};
-
-const doCreateServiceInstance = async (
-  declaredService: AnyService,
-  serviceContext: ServiceContext
-): Promise<Result<unknown, Error>> => {
-  try {
-    const created = await declaredService.create(serviceContext);
-    if (created.isErr()) {
-      return Result.err(created.error);
-    }
-
-    const instance = created.unwrap();
-    getSingletonServiceCache(declaredService).set(
-      toServiceContextKey(serviceContext),
-      instance
-    );
-    return Result.ok(instance);
-  } catch (error: unknown) {
-    return Result.err(toInternalServiceError(declaredService.id, error));
-  }
-};
-
-const trackPendingCreation = (
-  declaredService: AnyService,
-  key: string,
-  promise: Promise<Result<unknown, Error>>
-): void => {
-  const pending = pendingCreations.get(declaredService);
-  if (pending) {
-    pending.set(key, promise);
-  } else {
-    pendingCreations.set(declaredService, new Map([[key, promise]]));
-  }
-};
-
-/**
- * Deduplicates concurrent creation of the same service singleton.
- * If a creation is already in flight for this service × context key,
- * returns the existing promise instead of spawning a second factory call.
- */
-const createServiceInstance = async (
-  declaredService: AnyService,
-  serviceContext: ServiceContext
-): Promise<Result<unknown, Error>> => {
-  const key = toServiceContextKey(serviceContext);
-  const inflight = pendingCreations.get(declaredService)?.get(key);
-  if (inflight) {
-    return inflight;
-  }
-
-  const promise = doCreateServiceInstance(declaredService, serviceContext);
-  trackPendingCreation(declaredService, key, promise);
-
-  try {
-    return await promise;
-  } finally {
-    pendingCreations.get(declaredService)?.delete(key);
-  }
-};
-
-const resolveServiceInstance = async (
-  declaredService: AnyService,
-  ctx: TrailContext,
-  serviceContext: ServiceContext,
-  overrides?: ServiceOverrideMap
-): Promise<Result<unknown, Error>> =>
-  getProvidedService(ctx, overrides, declaredService, serviceContext) ??
-  (await createServiceInstance(declaredService, serviceContext));
-
-const withResolvedServices = (
-  ctx: TrailContext,
-  resolvedServices: Record<string, unknown>
-): TrailContext => {
-  const extensions = { ...ctx.extensions, ...resolvedServices };
-  const resolvedCtx = { ...ctx, extensions } as MutableTrailContext;
-  resolvedCtx.service = createServiceLookup(() => resolvedCtx);
-  return resolvedCtx;
-};
-
-const resolveServices = async (
-  trail: AnyTrail,
-  ctx: TrailContext,
-  overrides?: ServiceOverrideMap
-): Promise<Result<TrailContext, Error>> => {
-  if (trail.services.length === 0) {
-    return Result.ok(ctx);
-  }
-
-  const resolvedServices: Record<string, unknown> = {};
-  const serviceContext = toServiceContext(ctx);
-
-  for (const declaredService of trail.services) {
-    const resolved = await resolveServiceInstance(
-      declaredService,
-      ctx,
-      serviceContext,
-      overrides
-    );
-    if (resolved.isErr()) {
-      return resolved;
-    }
-
-    resolvedServices[declaredService.id] = resolved.unwrap();
-  }
-
-  return Result.ok(withResolvedServices(ctx, resolvedServices));
-};
-
 const prepareContext = async (
   trail: AnyTrail,
   options?: ExecuteTrailOptions
 ): Promise<Result<TrailContext, Error>> => {
   const baseCtx = await resolveContext(options);
-  return await resolveServices(trail, baseCtx, options?.services);
+  return await resolveServices(
+    trail,
+    baseCtx,
+    options?.services,
+    options?.configValues
+  );
 };
 
 const runTrail = async (

--- a/packages/core/src/service-config.ts
+++ b/packages/core/src/service-config.ts
@@ -1,0 +1,309 @@
+/**
+ * Service resolution pipeline.
+ *
+ * Extracted from execute.ts to keep both modules under the 400 LOC ceiling.
+ * Handles config validation, singleton caching, concurrent-creation dedup,
+ * and the full resolve-or-create flow for declared services.
+ */
+
+import type {
+  AnyService,
+  ServiceContext,
+  ServiceOverrideMap,
+} from './service.js';
+import type { AnyTrail } from './trail.js';
+import type { TrailContext } from './types.js';
+
+import { InternalError, ValidationError } from './errors.js';
+import { Result } from './result.js';
+import { createServiceLookup } from './service.js';
+
+type MutableTrailContext = {
+  -readonly [K in keyof TrailContext]: TrailContext[K];
+};
+
+type ConfigValues = Readonly<Record<string, Record<string, unknown>>>;
+
+// ---------------------------------------------------------------------------
+// Singleton caches
+// ---------------------------------------------------------------------------
+
+const singletonServices = new WeakMap<AnyService, Map<string, unknown>>();
+
+/** In-flight service creation promises, keyed by service x context. */
+const pendingCreations = new WeakMap<
+  AnyService,
+  Map<string, Promise<Result<unknown, Error>>>
+>();
+
+// ---------------------------------------------------------------------------
+// Context helpers
+// ---------------------------------------------------------------------------
+
+const toServiceContext = (
+  ctx: TrailContext,
+  config?: unknown
+): ServiceContext => ({
+  config,
+  cwd: ctx.cwd,
+  env: ctx.env,
+  workspaceRoot: ctx.workspaceRoot,
+});
+
+const toServiceContextKey = (ctx: ServiceContext): string =>
+  JSON.stringify({
+    config: ctx.config,
+    cwd: ctx.cwd,
+    env: Object.entries(ctx.env ?? {}).toSorted(([left], [right]) =>
+      left.localeCompare(right)
+    ),
+    workspaceRoot: ctx.workspaceRoot,
+  });
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+/** Validate and resolve a service's config from the provided configValues map. */
+const resolveServiceConfig = (
+  declaredService: AnyService,
+  configValues?: ConfigValues
+): Result<unknown, Error> => {
+  if (declaredService.config === undefined) {
+    return Result.ok();
+  }
+  const raw = configValues?.[declaredService.id];
+  if (raw === undefined) {
+    return Result.err(
+      new ValidationError(
+        `Service "${declaredService.id}" declares a config schema but no config was provided`
+      )
+    );
+  }
+  const parsed = declaredService.config.safeParse(raw);
+  if (!parsed.success) {
+    return Result.err(
+      new ValidationError(
+        `Service "${declaredService.id}" config validation failed: ${parsed.error.message}`
+      )
+    );
+  }
+  return Result.ok(parsed.data);
+};
+
+// ---------------------------------------------------------------------------
+// Override / cache lookups
+// ---------------------------------------------------------------------------
+
+const hasOwnServiceOverride = (
+  overrides: ServiceOverrideMap | undefined,
+  id: string
+): overrides is ServiceOverrideMap =>
+  overrides !== undefined && Object.hasOwn(overrides, id);
+
+const getCachedSingletonService = (
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): { readonly found: boolean; readonly value: unknown } => {
+  const scopedCache = singletonServices.get(declaredService);
+  if (scopedCache === undefined) {
+    return { found: false, value: undefined };
+  }
+
+  const key = toServiceContextKey(serviceContext);
+  if (!scopedCache.has(key)) {
+    return { found: false, value: undefined };
+  }
+
+  return {
+    found: true,
+    value: scopedCache.get(key),
+  };
+};
+
+const getProvidedService = (
+  ctx: TrailContext,
+  overrides: ServiceOverrideMap | undefined,
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): Result<unknown, Error> | undefined => {
+  const { id } = declaredService;
+  if (hasOwnServiceOverride(overrides, id)) {
+    return Result.ok(overrides[id]);
+  }
+
+  if (Object.hasOwn(ctx.extensions ?? {}, id)) {
+    return Result.ok(ctx.extensions?.[id]);
+  }
+
+  const cached = getCachedSingletonService(declaredService, serviceContext);
+  if (cached.found) {
+    return Result.ok(cached.value);
+  }
+
+  return undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Instance creation
+// ---------------------------------------------------------------------------
+
+const toInternalServiceError = (id: string, error: unknown): InternalError => {
+  const cause = error instanceof Error ? error : undefined;
+  const message = cause?.message ?? String(error);
+  return new InternalError(`Service "${id}" failed to resolve: ${message}`, {
+    ...(cause ? { cause } : {}),
+    context: { serviceId: id },
+  });
+};
+
+const getSingletonServiceCache = (
+  declaredService: AnyService
+): Map<string, unknown> => {
+  const existing = singletonServices.get(declaredService);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const created = new Map<string, unknown>();
+  singletonServices.set(declaredService, created);
+  return created;
+};
+
+const doCreateServiceInstance = async (
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): Promise<Result<unknown, Error>> => {
+  try {
+    const created = await declaredService.create(serviceContext);
+    if (created.isErr()) {
+      return Result.err(created.error);
+    }
+
+    const instance = created.unwrap();
+    getSingletonServiceCache(declaredService).set(
+      toServiceContextKey(serviceContext),
+      instance
+    );
+    return Result.ok(instance);
+  } catch (error: unknown) {
+    return Result.err(toInternalServiceError(declaredService.id, error));
+  }
+};
+
+const trackPendingCreation = (
+  declaredService: AnyService,
+  key: string,
+  promise: Promise<Result<unknown, Error>>
+): void => {
+  const pending = pendingCreations.get(declaredService);
+  if (pending) {
+    pending.set(key, promise);
+  } else {
+    pendingCreations.set(declaredService, new Map([[key, promise]]));
+  }
+};
+
+/**
+ * Deduplicates concurrent creation of the same service singleton.
+ * If a creation is already in flight for this service x context key,
+ * returns the existing promise instead of spawning a second factory call.
+ */
+const createServiceInstance = async (
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): Promise<Result<unknown, Error>> => {
+  const key = toServiceContextKey(serviceContext);
+  const inflight = pendingCreations.get(declaredService)?.get(key);
+  if (inflight) {
+    return inflight;
+  }
+
+  const promise = doCreateServiceInstance(declaredService, serviceContext);
+  trackPendingCreation(declaredService, key, promise);
+
+  try {
+    return await promise;
+  } finally {
+    pendingCreations.get(declaredService)?.delete(key);
+  }
+};
+
+/** Validate config and resolve a single declared service. */
+const resolveDeclaredService = async (
+  declaredService: AnyService,
+  ctx: TrailContext,
+  overrides: ServiceOverrideMap | undefined,
+  configValues: ConfigValues | undefined
+): Promise<Result<unknown, Error>> => {
+  // Check overrides/extensions/cache first — skip config validation
+  // entirely when a service instance is already provided.
+  const serviceContextForLookup = toServiceContext(ctx);
+  const provided = getProvidedService(
+    ctx,
+    overrides,
+    declaredService,
+    serviceContextForLookup
+  );
+  if (provided !== undefined) {
+    return provided;
+  }
+
+  // No provided instance — validate config and create via factory.
+  const configResult = resolveServiceConfig(declaredService, configValues);
+  if (configResult.isErr()) {
+    return configResult;
+  }
+
+  const serviceContext = toServiceContext(ctx, configResult.value);
+  return await createServiceInstance(declaredService, serviceContext);
+};
+
+// ---------------------------------------------------------------------------
+// Full trail service resolution
+// ---------------------------------------------------------------------------
+
+const withResolvedServices = (
+  ctx: TrailContext,
+  resolvedServices: Record<string, unknown>
+): TrailContext => {
+  const extensions = { ...ctx.extensions, ...resolvedServices };
+  const resolvedCtx = { ...ctx, extensions } as MutableTrailContext;
+  resolvedCtx.service = createServiceLookup(() => resolvedCtx);
+  return resolvedCtx;
+};
+
+/**
+ * Resolve all declared services for a trail.
+ *
+ * Validates per-service config, checks overrides and caches, and creates
+ * new instances as needed. Returns an enriched context with all service
+ * instances injected into extensions.
+ */
+export const resolveServices = async (
+  trail: AnyTrail,
+  ctx: TrailContext,
+  overrides?: ServiceOverrideMap,
+  configValues?: ConfigValues
+): Promise<Result<TrailContext, Error>> => {
+  if (trail.services.length === 0) {
+    return Result.ok(ctx);
+  }
+
+  const resolvedServices: Record<string, unknown> = {};
+
+  for (const declaredService of trail.services) {
+    const resolved = await resolveDeclaredService(
+      declaredService,
+      ctx,
+      overrides,
+      configValues
+    );
+    if (resolved.isErr()) {
+      return resolved;
+    }
+    resolvedServices[declaredService.id] = resolved.unwrap();
+  }
+
+  return Result.ok(withResolvedServices(ctx, resolvedServices));
+};

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -7,23 +7,29 @@ import type { z } from 'zod';
  * Stable process-scoped fields available when constructing a service.
  *
  * Services are app-level singletons, so they intentionally do not receive the
- * full per-request TrailContext.
+ * full per-request TrailContext. When a service declares a `config` schema,
+ * the validated config is passed as `svc.config`.
  */
-export type ServiceContext = Pick<
+export type ServiceContext<C = unknown> = Pick<
   TrailContext,
   'cwd' | 'env' | 'workspaceRoot'
->;
+> & {
+  readonly config: C;
+};
 
 /**
  * Everything needed to describe a service before a factory is introduced.
+ *
+ * When `config` is a Zod schema, the `create` callback receives
+ * `ServiceContext<C>` with the validated config value.
  */
-export interface ServiceSpec<T> {
+export interface ServiceSpec<T, C = unknown> {
   /** Create the service instance from stable process-scoped context. */
   readonly create: (
-    svc: ServiceContext
+    svc: ServiceContext<C>
   ) => Result<T, Error> | Promise<Result<T, Error>>;
-  /** Reserved config schema for follow-up config composition work. */
-  readonly config?: z.ZodType | undefined;
+  /** Config schema — when present, config is validated and passed to `create`. */
+  readonly config?: z.ZodType<C> | undefined;
   /** Optional cleanup performed when the hosting surface shuts down. */
   readonly dispose?: ((service: T) => void | Promise<void>) | undefined;
   /** Optional operational readiness probe for introspection tooling. */


### PR DESCRIPTION
## Summary

- `ServiceContext<C>` gains typed `config` field (backward compatible — defaults to `unknown`)
- `ServiceSpec<T, C>` threads the config type to the `create` function
- `executeTrail` resolves config from `configValues` option, validates through the service's Zod schema before calling `create`
- `resolveServices` extracted to `service-config.ts` to keep `execute.ts` under 400 LOC
- `collectServiceConfigs()` utility extracts config schemas from services for composition

## Test plan

- [ ] 5 new tests for config-aware service creation, backward compat, validation failure
- [ ] 592 existing core tests pass unchanged
- [ ] `bun test` passes in both `packages/core/` and `packages/config/`

Closes https://linear.app/outfitter/issue/TRL-91/composable-service-config-via-servicespecconfig

In-collaboration-with: [Claude Code](https://claude.com/claude-code)