### PR TITLE
feat(config): add doctor, introspection, provenance, and config.ref [TRL-93]

### DIFF
--- a/packages/config/src/__tests__/describe.test.ts
+++ b/packages/config/src/__tests__/describe.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { deprecated, env, secret } from '../extensions.js';
+import { describeConfig } from '../describe.js';
+
+describe('describeConfig', () => {
+  describe('basic field descriptions', () => {
+    test('returns path, type, and required for each field', () => {
+      const schema = z.object({
+        debug: z.boolean(),
+        host: z.string(),
+        port: z.number(),
+      });
+
+      const fields = describeConfig(schema);
+
+      expect(fields).toHaveLength(3);
+      const host = fields.find((f) => f.path === 'host');
+      expect(host?.type).toBe('string');
+      expect(host?.required).toBe(true);
+
+      const port = fields.find((f) => f.path === 'port');
+      expect(port?.type).toBe('number');
+      expect(port?.required).toBe(true);
+    });
+  });
+
+  describe('Zod describe() metadata', () => {
+    test('includes description from .describe()', () => {
+      const schema = z.object({
+        host: z.string().describe('The server hostname'),
+      });
+
+      const fields = describeConfig(schema);
+      const host = fields.find((f) => f.path === 'host');
+      expect(host?.description).toBe('The server hostname');
+    });
+  });
+
+  describe('config metadata', () => {
+    test('includes env, secret, deprecated from metadata', () => {
+      const schema = z.object({
+        apiKey: secret(env(z.string(), 'API_KEY')),
+        legacyMode: deprecated(z.boolean(), 'Use "mode" instead').default(
+          false
+        ),
+      });
+
+      const fields = describeConfig(schema);
+
+      const apiKey = fields.find((f) => f.path === 'apiKey');
+      expect(apiKey?.env).toBe('API_KEY');
+      expect(apiKey?.secret).toBe(true);
+
+      const legacy = fields.find((f) => f.path === 'legacyMode');
+      expect(legacy?.deprecated).toBe('Use "mode" instead');
+    });
+  });
+
+  describe('defaults', () => {
+    test('detects default values', () => {
+      const schema = z.object({
+        debug: z.boolean().default(false),
+        port: z.number().default(3000),
+      });
+
+      const fields = describeConfig(schema);
+
+      const port = fields.find((f) => f.path === 'port');
+      expect(port?.default).toBe(3000);
+      expect(port?.required).toBe(false);
+
+      const debug = fields.find((f) => f.path === 'debug');
+      expect(debug?.default).toBe(false);
+    });
+  });
+
+  describe('nested objects', () => {
+    test('handles nested object schemas with dot paths', () => {
+      const schema = z.object({
+        db: z.object({
+          host: z.string(),
+          port: z.number().default(5432),
+        }),
+      });
+
+      const fields = describeConfig(schema);
+
+      const dbHost = fields.find((f) => f.path === 'db.host');
+      expect(dbHost?.type).toBe('string');
+      expect(dbHost?.required).toBe(true);
+
+      const dbPort = fields.find((f) => f.path === 'db.port');
+      expect(dbPort?.type).toBe('number');
+      expect(dbPort?.default).toBe(5432);
+    });
+  });
+
+  describe('constraints', () => {
+    test('detects enum values', () => {
+      const schema = z.object({
+        env: z.enum(['development', 'production', 'test']),
+      });
+
+      const fields = describeConfig(schema);
+      const envField = fields.find((f) => f.path === 'env');
+      expect(envField?.type).toBe('enum');
+      expect(envField?.constraints?.values).toEqual([
+        'development',
+        'production',
+        'test',
+      ]);
+    });
+
+    test('detects number min/max constraints', () => {
+      const schema = z.object({
+        port: z.number().min(1).max(65_535),
+      });
+
+      const fields = describeConfig(schema);
+      const port = fields.find((f) => f.path === 'port');
+      expect(port?.constraints?.min).toBe(1);
+      expect(port?.constraints?.max).toBe(65_535);
+    });
+  });
+
+  describe('optional fields', () => {
+    test('marks optional fields as not required', () => {
+      const schema = z.object({
+        host: z.string(),
+        nickname: z.string().optional(),
+      });
+
+      const fields = describeConfig(schema);
+      const nickname = fields.find((f) => f.path === 'nickname');
+      expect(nickname?.required).toBe(false);
+    });
+  });
+});

--- a/packages/config/src/__tests__/doctor.test.ts
+++ b/packages/config/src/__tests__/doctor.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { deprecated, env } from '../extensions.js';
+import { checkConfig } from '../doctor.js';
+
+const schema = z.object({
+  debug: z.boolean().default(false),
+  host: z.string(),
+  port: z.number().default(3000),
+});
+
+describe('checkConfig', () => {
+  describe('valid fields', () => {
+    test('reports status "valid" for present and valid fields', () => {
+      const result = checkConfig(schema, { host: 'localhost', port: 8080 });
+
+      const hostDiag = result.diagnostics.find((d) => d.path === 'host');
+      expect(hostDiag?.status).toBe('valid');
+      expect(hostDiag?.value).toBe('localhost');
+    });
+  });
+
+  describe('missing required fields', () => {
+    test('reports status "missing" for absent required fields', () => {
+      const result = checkConfig(schema, { port: 8080 });
+
+      const hostDiag = result.diagnostics.find((d) => d.path === 'host');
+      expect(hostDiag?.status).toBe('missing');
+      expect(hostDiag?.message).toContain('host');
+    });
+  });
+
+  describe('default fields', () => {
+    test('reports status "default" when field uses schema default', () => {
+      const result = checkConfig(schema, { host: 'localhost' });
+
+      const portDiag = result.diagnostics.find((d) => d.path === 'port');
+      expect(portDiag?.status).toBe('default');
+      expect(portDiag?.value).toBe(3000);
+
+      const debugDiag = result.diagnostics.find((d) => d.path === 'debug');
+      expect(debugDiag?.status).toBe('default');
+      expect(debugDiag?.value).toBe(false);
+    });
+  });
+
+  describe('invalid fields', () => {
+    test('reports status "invalid" with message for wrong-type values', () => {
+      const result = checkConfig(schema, {
+        host: 'localhost',
+        port: 'not-a-number',
+      });
+
+      const portDiag = result.diagnostics.find((d) => d.path === 'port');
+      expect(portDiag?.status).toBe('invalid');
+      expect(portDiag?.message).toBeDefined();
+    });
+  });
+
+  describe('deprecated fields', () => {
+    test('reports status "deprecated" with migration message', () => {
+      const deprecatedSchema = z.object({
+        host: z.string(),
+        legacyMode: deprecated(z.boolean(), 'Use "mode" instead').default(
+          false
+        ),
+      });
+
+      const result = checkConfig(deprecatedSchema, {
+        host: 'localhost',
+        legacyMode: true,
+      });
+
+      const legacyDiag = result.diagnostics.find(
+        (d) => d.path === 'legacyMode'
+      );
+      expect(legacyDiag?.status).toBe('deprecated');
+      expect(legacyDiag?.message).toContain('Use "mode" instead');
+    });
+  });
+
+  describe('valid flag', () => {
+    test('returns valid: true when no missing or invalid fields', () => {
+      const result = checkConfig(schema, { host: 'localhost', port: 8080 });
+      expect(result.valid).toBe(true);
+    });
+
+    test('returns valid: false when required field is missing', () => {
+      const result = checkConfig(schema, { port: 8080 });
+      expect(result.valid).toBe(false);
+    });
+
+    test('returns valid: false when field is invalid', () => {
+      const result = checkConfig(schema, {
+        host: 'localhost',
+        port: 'bad',
+      });
+      expect(result.valid).toBe(false);
+    });
+
+    test('returns valid: true when deprecated fields are present', () => {
+      const deprecatedSchema = z.object({
+        host: z.string(),
+        legacyMode: deprecated(z.boolean(), 'Use "mode" instead').default(
+          false
+        ),
+      });
+
+      const result = checkConfig(deprecatedSchema, {
+        host: 'localhost',
+        legacyMode: true,
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('env resolution', () => {
+    test('treats env-provided value as valid', () => {
+      const envSchema = z.object({
+        host: env(z.string(), 'APP_HOST'),
+      });
+
+      const result = checkConfig(
+        envSchema,
+        {},
+        { env: { APP_HOST: 'envhost' } }
+      );
+      const hostDiag = result.diagnostics.find((d) => d.path === 'host');
+      expect(hostDiag?.status).toBe('valid');
+      expect(hostDiag?.value).toBe('envhost');
+    });
+
+    test('resolves env vars for nested schema fields', () => {
+      const nestedSchema = z.object({
+        db: z.object({
+          host: env(z.string(), 'DB_HOST'),
+          port: z.number().default(5432),
+        }),
+      });
+
+      const result = checkConfig(
+        nestedSchema,
+        { db: {} },
+        { env: { DB_HOST: 'dbhost.local' } }
+      );
+      const dbHostDiag = result.diagnostics.find((d) => d.path === 'db.host');
+      expect(dbHostDiag?.status).toBe('valid');
+      expect(dbHostDiag?.value).toBe('dbhost.local');
+    });
+  });
+});

--- a/packages/config/src/__tests__/explain.test.ts
+++ b/packages/config/src/__tests__/explain.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { env, secret } from '../extensions.js';
+import { explainConfig } from '../explain.js';
+
+const schema = z.object({
+  debug: z.boolean().default(false),
+  host: z.string().default('localhost'),
+  port: z.number().default(3000),
+});
+
+describe('explainConfig', () => {
+  describe('default source', () => {
+    test('reports "default" when no other source provides value', () => {
+      const entries = explainConfig({
+        resolved: { debug: false, host: 'localhost', port: 3000 },
+        schema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.source).toBe('default');
+      expect(host?.value).toBe('localhost');
+    });
+  });
+
+  describe('base overrides default', () => {
+    test('reports "base" when base provides value', () => {
+      const entries = explainConfig({
+        base: { host: 'base.example.com' },
+        resolved: { debug: false, host: 'base.example.com', port: 3000 },
+        schema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.source).toBe('base');
+      expect(host?.value).toBe('base.example.com');
+    });
+  });
+
+  describe('loadout overrides base', () => {
+    test('reports "loadout" when loadout provides winning value', () => {
+      const entries = explainConfig({
+        base: { host: 'base.example.com' },
+        loadout: { host: 'loadout.example.com' },
+        resolved: { debug: false, host: 'loadout.example.com', port: 3000 },
+        schema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.source).toBe('loadout');
+      expect(host?.value).toBe('loadout.example.com');
+    });
+  });
+
+  describe('local overrides loadout', () => {
+    test('reports "local" when local provides winning value', () => {
+      const entries = explainConfig({
+        base: { host: 'base.example.com' },
+        loadout: { host: 'loadout.example.com' },
+        local: { host: 'local.example.com' },
+        resolved: { debug: false, host: 'local.example.com', port: 3000 },
+        schema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.source).toBe('local');
+    });
+  });
+
+  describe('env overrides everything', () => {
+    test('reports "env" when env provides winning value', () => {
+      const envSchema = z.object({
+        host: env(z.string(), 'APP_HOST').default('localhost'),
+        port: z.number().default(3000),
+      });
+
+      const entries = explainConfig({
+        base: { host: 'base.example.com' },
+        env: { APP_HOST: 'env.example.com' },
+        resolved: { host: 'env.example.com', port: 3000 },
+        schema: envSchema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.source).toBe('env');
+      expect(host?.value).toBe('env.example.com');
+    });
+  });
+
+  describe('secret redaction', () => {
+    test('redacts secret fields', () => {
+      const secretSchema = z.object({
+        apiKey: secret(env(z.string(), 'API_KEY')),
+        host: z.string().default('localhost'),
+      });
+
+      const entries = explainConfig({
+        env: { API_KEY: 'super-secret-key' },
+        resolved: { apiKey: 'super-secret-key', host: 'localhost' },
+        schema: secretSchema,
+      });
+
+      const apiKey = entries.find((e) => e.path === 'apiKey');
+      expect(apiKey?.redacted).toBe(true);
+      expect(apiKey?.value).toBe('[REDACTED]');
+    });
+
+    test('does not redact non-secret fields', () => {
+      const entries = explainConfig({
+        resolved: { debug: false, host: 'localhost', port: 3000 },
+        schema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.redacted).toBe(false);
+    });
+  });
+});

--- a/packages/config/src/__tests__/ref.test.ts
+++ b/packages/config/src/__tests__/ref.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+
+import { configRef, isConfigRef } from '../ref.js';
+
+describe('configRef', () => {
+  test('creates a marker object with __configRef flag', () => {
+    const ref = configRef('db.host');
+    expect(ref.__configRef).toBe(true);
+    expect(ref.path).toBe('db.host');
+  });
+
+  test('creates distinct refs for different paths', () => {
+    const ref1 = configRef('db.host');
+    const ref2 = configRef('db.port');
+    expect(ref1.path).not.toBe(ref2.path);
+  });
+});
+
+describe('isConfigRef', () => {
+  test('returns true for configRef markers', () => {
+    const ref = configRef('db.host');
+    expect(isConfigRef(ref)).toBe(true);
+  });
+
+  test('returns false for plain objects', () => {
+    expect(isConfigRef({ path: 'db.host' })).toBe(false);
+  });
+
+  test('returns false for non-objects', () => {
+    expect(isConfigRef('db.host')).toBe(false);
+    expect(isConfigRef(42)).toBe(false);
+    expect(isConfigRef(null)).toBe(false);
+    expect(isConfigRef()).toBe(false);
+  });
+});

--- a/packages/config/src/describe.ts
+++ b/packages/config/src/describe.ts
@@ -1,0 +1,252 @@
+/**
+ * Config introspection — describe all fields in a schema without values.
+ *
+ * Returns a structured catalog suitable for CLI rendering or agent inspection.
+ */
+
+import { globalRegistry } from 'zod';
+import type { z } from 'zod';
+
+import { collectConfigMeta } from './collect.js';
+import { isZodObject, zodDef } from './zod-utils.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Description of a single config field. */
+export interface FieldDescription {
+  readonly path: string;
+  readonly type: string;
+  readonly description?: string;
+  readonly default?: unknown;
+  readonly required: boolean;
+  readonly env?: string;
+  readonly secret?: boolean;
+  readonly deprecated?: string;
+  readonly constraints?: Record<string, unknown>;
+}
+
+/** Accumulated state while unwrapping Zod wrappers. */
+interface UnwrapState {
+  hasDefault: boolean;
+  defaultValue: unknown;
+  isOptional: boolean;
+}
+
+/** Unwrap result carrying both base schema and accumulated metadata. */
+interface UnwrapResult {
+  readonly base: z.ZodType;
+  readonly hasDefault: boolean;
+  readonly defaultValue: unknown;
+  readonly isOptional: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before consumers — satisfies no-use-before-define)
+// ---------------------------------------------------------------------------
+
+/** Read the description from the Zod global registry. */
+const getDescription = (schema: z.ZodType): string | undefined => {
+  const meta = globalRegistry.get(schema);
+  return meta?.description as string | undefined;
+};
+
+/** Handle a single unwrap step; returns updated inner type and state, or null to stop. */
+const unwrapStep = (
+  def: Record<string, unknown>,
+  state: UnwrapState
+): { inner: z.ZodType; state: UnwrapState } | null => {
+  const typeName = def['type'] as string;
+
+  if (typeName === 'default') {
+    return {
+      inner: def['innerType'] as z.ZodType,
+      state: { ...state, defaultValue: def['defaultValue'], hasDefault: true },
+    };
+  }
+
+  if (typeName === 'optional') {
+    return {
+      inner: def['innerType'] as z.ZodType,
+      state: { ...state, isOptional: true },
+    };
+  }
+
+  if (typeName === 'nullable') {
+    return { inner: def['innerType'] as z.ZodType, state };
+  }
+
+  return null;
+};
+
+/** Unwrap through default/optional/nullable wrappers to find the base type. */
+const unwrapSchema = (schema: z.ZodType): UnwrapResult => {
+  let current = schema;
+  let state: UnwrapState = {
+    defaultValue: undefined,
+    hasDefault: false,
+    isOptional: false,
+  };
+
+  for (let depth = 0; depth < 10; depth += 1) {
+    const result = unwrapStep(zodDef(current), state);
+    if (!result) {
+      break;
+    }
+    current = result.inner;
+    ({ state } = result);
+  }
+
+  return { base: current, ...state };
+};
+
+/** Resolve the user-facing type name from a base Zod schema. */
+const resolveTypeName = (schema: z.ZodType): string => {
+  const typeName = zodDef(schema)['type'] as string;
+  const typeMap: Record<string, string> = {
+    boolean: 'boolean',
+    enum: 'enum',
+    number: 'number',
+    string: 'string',
+  };
+  return typeMap[typeName] ?? typeName;
+};
+
+/** Extract enum values from an enum def. */
+const extractEnumConstraints = (
+  def: Record<string, unknown>
+): Record<string, unknown> | undefined => {
+  const entries = def['entries'] as Record<string, string> | undefined;
+  if (!entries) {
+    return undefined;
+  }
+  return { values: Object.values(entries) };
+};
+
+/** Extract min/max from a number schema's properties. */
+const extractNumberConstraints = (
+  schema: z.ZodType
+): Record<string, unknown> | undefined => {
+  const result: Record<string, unknown> = {};
+  const numSchema = schema as unknown as {
+    minValue?: number;
+    maxValue?: number;
+  };
+
+  if (numSchema.minValue !== undefined && numSchema.minValue !== null) {
+    result['min'] = numSchema.minValue;
+  }
+  if (numSchema.maxValue !== undefined && numSchema.maxValue !== null) {
+    result['max'] = numSchema.maxValue;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+};
+
+/** Extract constraints from a base schema (min, max, enum values). */
+const extractConstraints = (
+  schema: z.ZodType
+): Record<string, unknown> | undefined => {
+  const def = zodDef(schema);
+  const typeName = def['type'] as string;
+
+  if (typeName === 'enum') {
+    return extractEnumConstraints(def);
+  }
+  if (typeName === 'number') {
+    return extractNumberConstraints(schema);
+  }
+  return undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Schema walking
+// ---------------------------------------------------------------------------
+
+/** Entry for iterative schema walk. */
+interface WalkEntry {
+  readonly schema: z.ZodType;
+  readonly prefix: string;
+}
+
+/** Build a single FieldDescription from a leaf schema and its metadata. */
+const buildFieldDescription = (
+  path: string,
+  fieldSchema: z.ZodType,
+  configMeta: Map<
+    string,
+    { env?: string; secret?: boolean; deprecated?: string }
+  >
+): FieldDescription => {
+  const { base, defaultValue, hasDefault, isOptional } =
+    unwrapSchema(fieldSchema);
+  const meta = configMeta.get(path);
+  const description = getDescription(base) ?? getDescription(fieldSchema);
+  const constraints = extractConstraints(base);
+
+  return {
+    ...(constraints ? { constraints } : {}),
+    ...(hasDefault ? { default: defaultValue } : {}),
+    ...(meta?.deprecated ? { deprecated: meta.deprecated } : {}),
+    ...(description ? { description } : {}),
+    ...(meta?.env ? { env: meta.env } : {}),
+    path,
+    required: !hasDefault && !isOptional,
+    ...(meta?.secret ? { secret: meta.secret } : {}),
+    type: resolveTypeName(base),
+  };
+};
+
+/** Walk one level of an object shape, collecting leaves and queuing nested objects. */
+const walkShapeLevel = (
+  shape: Record<string, z.ZodType>,
+  prefix: string,
+  configMeta: Map<
+    string,
+    { env?: string; secret?: boolean; deprecated?: string }
+  >,
+  results: FieldDescription[],
+  queue: WalkEntry[]
+): void => {
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (isZodObject(fieldSchema)) {
+      queue.push({ prefix: path, schema: fieldSchema });
+    } else {
+      results.push(buildFieldDescription(path, fieldSchema, configMeta));
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Describe all fields in a schema without needing a config file.
+ *
+ * Returns a structured catalog suitable for CLI rendering or agent inspection.
+ */
+export const describeConfig = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): readonly FieldDescription[] => {
+  const configMeta = collectConfigMeta(schema);
+  const queue: WalkEntry[] = [];
+  const results: FieldDescription[] = [];
+
+  walkShapeLevel(
+    schema.shape as Record<string, z.ZodType>,
+    '',
+    configMeta,
+    results,
+    queue
+  );
+
+  for (let entry = queue.pop(); entry; entry = queue.pop()) {
+    const nested = zodDef(entry.schema)['shape'] as Record<string, z.ZodType>;
+    walkShapeLevel(nested, entry.prefix, configMeta, results, queue);
+  }
+
+  return results;
+};

--- a/packages/config/src/doctor.ts
+++ b/packages/config/src/doctor.ts
@@ -1,0 +1,219 @@
+/**
+ * Config doctor — structured diagnostics for a config object against a schema.
+ *
+ * Reports which fields are valid, missing, using defaults, deprecated, or invalid.
+ */
+
+import type { z } from 'zod';
+
+import { collectConfigMeta } from './collect.js';
+import { getAtPath, isZodObject, zodDef } from './zod-utils.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Diagnostic status for a single config field. */
+export interface ConfigDiagnostic {
+  readonly path: string;
+  readonly status: 'valid' | 'missing' | 'invalid' | 'deprecated' | 'default';
+  readonly message: string;
+  readonly value?: unknown;
+}
+
+/** Aggregated result from checking config against a schema. */
+export interface CheckResult {
+  readonly diagnostics: readonly ConfigDiagnostic[];
+  readonly valid: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before consumers)
+// ---------------------------------------------------------------------------
+
+/** Check if a schema wraps a ZodDefault. */
+const isDefaultWrapper = (schema: z.ZodType): boolean =>
+  zodDef(schema)['type'] === 'default';
+
+/** Check if a schema wraps a ZodOptional. */
+const isOptionalWrapper = (schema: z.ZodType): boolean =>
+  zodDef(schema)['type'] === 'optional';
+
+/** Get the default value from a ZodDefault wrapper. */
+const getDefaultValue = (schema: z.ZodType): unknown =>
+  zodDef(schema)['defaultValue'];
+
+/** Set a value at a dot-separated path, creating intermediate objects. */
+const setAtPath = (
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown
+): void => {
+  const parts = path.split('.');
+  let current: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const part = parts[i] as string;
+    const next = current[part];
+    const nested =
+      typeof next === 'object' && next !== null
+        ? (next as Record<string, unknown>)
+        : {};
+    current[part] = nested;
+    current = nested;
+  }
+  const lastPart = parts.at(-1) as string;
+  current[lastPart] = value;
+};
+
+/** Build values object with env overrides applied. */
+const applyEnvToValues = (
+  values: Record<string, unknown>,
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  envVars: Record<string, string | undefined>
+): Record<string, unknown> => {
+  const meta = collectConfigMeta(schema);
+  const result = structuredClone(values) as Record<string, unknown>;
+  for (const [path, fieldMeta] of meta) {
+    if (fieldMeta.env && envVars[fieldMeta.env] !== undefined) {
+      setAtPath(result, path, envVars[fieldMeta.env]);
+    }
+  }
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// Schema walking
+// ---------------------------------------------------------------------------
+
+/** Entry for the iterative schema walk queue. */
+interface WalkEntry {
+  readonly schema: z.ZodType;
+  readonly path: string;
+}
+
+/** Validate a single field value against its schema. */
+const validateFieldValue = (
+  path: string,
+  fieldSchema: z.ZodType,
+  value: unknown
+): ConfigDiagnostic => {
+  const result = fieldSchema.safeParse(value);
+  if (result.success) {
+    return { message: 'OK', path, status: 'valid', value };
+  }
+  const issue = result.error?.issues?.[0];
+  const msg = issue ? issue.message : 'Invalid value';
+  return { message: msg, path, status: 'invalid', value };
+};
+
+/** Classify a single field and produce a diagnostic. */
+const classifyField = (
+  path: string,
+  fieldSchema: z.ZodType,
+  values: Record<string, unknown>,
+  deprecatedMeta: Map<string, string>
+): ConfigDiagnostic => {
+  const value = getAtPath(values, path);
+  const deprecationMsg = deprecatedMeta.get(path);
+
+  if (deprecationMsg && value !== undefined) {
+    return { message: deprecationMsg, path, status: 'deprecated', value };
+  }
+
+  if (value === undefined && isDefaultWrapper(fieldSchema)) {
+    return {
+      message: 'Using default value',
+      path,
+      status: 'default',
+      value: getDefaultValue(fieldSchema),
+    };
+  }
+
+  if (value === undefined && !isOptionalWrapper(fieldSchema)) {
+    return {
+      message: `Required field "${path}" is missing`,
+      path,
+      status: 'missing',
+    };
+  }
+
+  return validateFieldValue(path, fieldSchema, value);
+};
+
+/** Collect deprecated metadata paths from config meta. */
+const collectDeprecatedPaths = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): Map<string, string> => {
+  const meta = collectConfigMeta(schema);
+  const result = new Map<string, string>();
+  for (const [path, fieldMeta] of meta) {
+    if (fieldMeta.deprecated) {
+      result.set(path, fieldMeta.deprecated);
+    }
+  }
+  return result;
+};
+
+/** Walk an object shape and enqueue leaf fields or nested objects. */
+const walkShape = (
+  schema: z.ZodType,
+  prefix: string,
+  queue: WalkEntry[],
+  leaves: WalkEntry[]
+): void => {
+  const shape = zodDef(schema)['shape'] as Record<string, z.ZodType>;
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (isZodObject(fieldSchema)) {
+      queue.push({ path, schema: fieldSchema });
+    } else {
+      leaves.push({ path, schema: fieldSchema });
+    }
+  }
+};
+
+/** Collect all leaf fields from a schema, walking nested objects iteratively. */
+const collectLeaves = (schema: z.ZodType): WalkEntry[] => {
+  const queue: WalkEntry[] = [];
+  const leaves: WalkEntry[] = [];
+  walkShape(schema, '', queue, leaves);
+
+  for (let entry = queue.pop(); entry; entry = queue.pop()) {
+    walkShape(entry.schema, entry.path, queue, leaves);
+  }
+
+  return leaves;
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check a config object against a schema and return structured diagnostics.
+ *
+ * Reports which fields are valid, missing, using defaults, deprecated, or invalid.
+ */
+export const checkConfig = <T extends z.ZodType>(
+  schema: T,
+  values: Record<string, unknown>,
+  options?: { readonly env?: Record<string, string | undefined> }
+): CheckResult => {
+  const objSchema = schema as unknown as z.ZodObject<Record<string, z.ZodType>>;
+  const effectiveValues = options?.env
+    ? applyEnvToValues(values, objSchema, options.env)
+    : values;
+
+  const deprecatedMeta = collectDeprecatedPaths(objSchema);
+  const leaves = collectLeaves(objSchema);
+
+  const diagnostics = leaves.map((leaf) =>
+    classifyField(leaf.path, leaf.schema, effectiveValues, deprecatedMeta)
+  );
+
+  const valid = diagnostics.every(
+    (d) => d.status !== 'missing' && d.status !== 'invalid'
+  );
+
+  return { diagnostics, valid };
+};

--- a/packages/config/src/explain.ts
+++ b/packages/config/src/explain.ts
@@ -1,0 +1,176 @@
+/**
+ * Config provenance — show which source won for each config field.
+ *
+ * Used for debugging: answers "where did this value come from?"
+ */
+
+import type { z } from 'zod';
+
+import { collectConfigMeta } from './collect.js';
+import { isLikelySecret } from './secret-heuristics.js';
+import { getAtPath, isZodObject, zodDef } from './zod-utils.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Provenance entry describing the source of a resolved config value. */
+export interface ProvenanceEntry {
+  readonly path: string;
+  readonly value: unknown;
+  readonly source: 'default' | 'base' | 'loadout' | 'local' | 'env';
+  readonly redacted: boolean;
+}
+
+/** Options for explaining config provenance. */
+export interface ExplainConfigOptions<T extends z.ZodType> {
+  readonly schema: T;
+  readonly base?: Record<string, unknown>;
+  readonly loadout?: Record<string, unknown>;
+  readonly local?: Record<string, unknown>;
+  readonly env?: Record<string, string | undefined>;
+  readonly resolved: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before consumers)
+// ---------------------------------------------------------------------------
+
+/** Build a map of path → env var name from config metadata. */
+const buildEnvMap = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): Map<string, string> => {
+  const meta = collectConfigMeta(schema);
+  const result = new Map<string, string>();
+  for (const [path, fieldMeta] of meta) {
+    if (fieldMeta.env) {
+      result.set(path, fieldMeta.env);
+    }
+  }
+  return result;
+};
+
+/** Build a set of paths marked as secret from config metadata. */
+const buildSecretSet = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): Set<string> => {
+  const meta = collectConfigMeta(schema);
+  const result = new Set<string>();
+  for (const [path, fieldMeta] of meta) {
+    if (fieldMeta.secret) {
+      result.add(path);
+    }
+  }
+  return result;
+};
+
+/** Source layers in reverse precedence order for winner detection. */
+type SourceLayer = readonly [
+  name: ProvenanceEntry['source'],
+  values: Record<string, unknown> | undefined,
+];
+
+/** Determine which source provided the winning value for a given path. */
+const determineSource = (
+  path: string,
+  resolved: Record<string, unknown>,
+  layers: readonly SourceLayer[],
+  envMap: Map<string, string>,
+  envVars: Record<string, string | undefined> | undefined
+): ProvenanceEntry['source'] => {
+  if (envVars && envMap.has(path)) {
+    const envVar = envMap.get(path);
+    if (envVar && envVars[envVar] !== undefined) {
+      return 'env';
+    }
+  }
+
+  const resolvedValue = getAtPath(resolved, path);
+  for (const [name, values] of layers) {
+    if (values && getAtPath(values, path) === resolvedValue) {
+      return name;
+    }
+  }
+
+  return 'default';
+};
+
+// ---------------------------------------------------------------------------
+// Schema walking
+// ---------------------------------------------------------------------------
+
+/** Entry for iterative schema walk. */
+interface WalkEntry {
+  readonly schema: z.ZodType;
+  readonly prefix: string;
+}
+
+/** Collect all leaf field paths from an object schema. */
+const collectLeafPaths = (schema: z.ZodType, prefix: string): string[] => {
+  const paths: string[] = [];
+  const queue: WalkEntry[] = [{ prefix, schema }];
+
+  for (let entry = queue.pop(); entry; entry = queue.pop()) {
+    const shape = zodDef(entry.schema)['shape'] as Record<string, z.ZodType>;
+    for (const [key, fieldSchema] of Object.entries(shape)) {
+      const path = entry.prefix ? `${entry.prefix}.${key}` : key;
+      if (isZodObject(fieldSchema)) {
+        queue.push({ prefix: path, schema: fieldSchema });
+      } else {
+        paths.push(path);
+      }
+    }
+  }
+
+  return paths;
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Show which source won for each config field.
+ *
+ * Used for debugging — answers "where did this value come from?"
+ *
+ */
+export const explainConfig = <T extends z.ZodType>(
+  options: ExplainConfigOptions<T>
+): readonly ProvenanceEntry[] => {
+  const objSchema = options.schema as unknown as z.ZodObject<
+    Record<string, z.ZodType>
+  >;
+  const envMap = buildEnvMap(objSchema);
+  const secretSet = buildSecretSet(objSchema);
+
+  const layers: readonly SourceLayer[] = [
+    ['local', options.local],
+    ['loadout', options.loadout],
+    ['base', options.base],
+  ];
+
+  const paths = collectLeafPaths(objSchema, '');
+
+  return paths.map((path) => {
+    const source = determineSource(
+      path,
+      options.resolved,
+      layers,
+      envMap,
+      options.env
+    );
+    const envVarName = envMap.get(path);
+    const isSecret =
+      secretSet.has(path) ||
+      (envVarName !== undefined && isLikelySecret(envVarName));
+    const rawValue = getAtPath(options.resolved, path);
+
+    return {
+      path,
+      redacted: isSecret,
+      source,
+      value: isSecret ? '[REDACTED]' : rawValue,
+    };
+  });
+};

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -9,7 +9,18 @@ export {
 export { collectConfigMeta } from './collect.js';
 export { collectServiceConfigs, type ServiceConfigEntry } from './compose.js';
 export { defineConfig, type DefineConfigOptions } from './define-config.js';
+export { describeConfig, type FieldDescription } from './describe.js';
+export {
+  checkConfig,
+  type CheckResult,
+  type ConfigDiagnostic,
+} from './doctor.js';
 export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
+export {
+  explainConfig,
+  type ExplainConfigOptions,
+  type ProvenanceEntry,
+} from './explain.js';
 export {
   generateEnvExample,
   generateExample,
@@ -22,6 +33,7 @@ export {
   registerConfigState,
 } from './registry.js';
 export { deepMerge } from './merge.js';
+export { configRef, isConfigRef, type ConfigRef } from './ref.js';
 export { resolveConfig, type ResolveConfigOptions } from './resolve.js';
 export { configCheck } from './trails/config-check.js';
 export { configDescribe } from './trails/config-describe.js';

--- a/packages/config/src/ref.ts
+++ b/packages/config/src/ref.ts
@@ -1,0 +1,33 @@
+/**
+ * Lazy config reference markers for trail input defaults.
+ *
+ * A `ConfigRef` is a marker object that can be embedded as a trail input
+ * default. The resolution stack detects it at invocation time and replaces
+ * it with the live config value at the given path.
+ */
+
+/** Marker object representing a lazy reference to a config field. */
+export interface ConfigRef {
+  readonly __configRef: true;
+  readonly path: string;
+}
+
+/**
+ * Create a lazy reference to a config field for use as a trail input default.
+ *
+ * The reference is resolved at invocation time, not at declaration time.
+ *
+ */
+export const configRef = (path: string): ConfigRef => ({
+  __configRef: true,
+  path,
+});
+
+/**
+ * Type guard: detect whether an unknown value is a `ConfigRef` marker.
+ */
+export const isConfigRef = (value?: unknown): value is ConfigRef =>
+  typeof value === 'object' &&
+  value !== null &&
+  '__configRef' in value &&
+  (value as Record<string, unknown>)['__configRef'] === true;


### PR DESCRIPTION
## Summary

- `checkConfig()` — structured diagnostics per field (valid/missing/default/invalid/deprecated). Handles nested schemas with env vars correctly via `setAtPath`.
- `describeConfig()` — field catalog with type, description, env, secret, deprecated, defaults, constraints. No config file needed.
- `explainConfig()` — provenance showing which source won per field (default/base/loadout/local/env) with secret redaction
- `configRef()` + `isConfigRef()` — lazy marker objects connecting config fields to trail input defaults

## Test plan

- [ ] 30 tests across doctor, describe, explain, and ref modules
- [ ] Nested env var resolution tested (regression from P2-1 fix)
- [ ] `bun test` passes in `packages/config/`

Closes https://linear.app/outfitter/issue/TRL-93/config-doctor-introspection-provenance-and-configref

In-collaboration-with: [Claude Code](https://claude.com/claude-code)