### PR TITLE
feat(config): complete trifecta with service, layer, trail, workspace [TRL-94]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
         run: bun apps/ci/bin/ci.ts --format github --fail-on error
         continue-on-error: true
 
-  ci-summary:
-    name: CI
+  ci-gate:
+    name: CI Gate
     if: always()
     needs: [build, lint, typecheck, test, governance]
     runs-on: ubuntu-latest
@@ -135,6 +135,6 @@ jobs:
           echo "| Test | \`${{ needs.test.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Governance | \`${{ needs.governance.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Check for failures
+      - name: Require all jobs to pass
         if: contains(needs.*.result, 'failure') && !cancelled()
         run: exit 1

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "apps/trails": {
       "name": "@ontrails/trails",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.11",
       "bin": {
         "trails": "./bin/trails.ts",
       },
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "@ontrails/cli",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.11",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -88,16 +88,24 @@
         "commander",
       ],
     },
+    "packages/config": {
+      "name": "@ontrails/config",
+      "version": "1.0.0-beta.11",
+      "peerDependencies": {
+        "@ontrails/core": "workspace:^",
+        "zod": "catalog:",
+      },
+    },
     "packages/core": {
       "name": "@ontrails/core",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.11",
       "peerDependencies": {
         "zod": "catalog:",
       },
     },
     "packages/http": {
       "name": "@ontrails/http",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.11",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -111,14 +119,14 @@
     },
     "packages/logging": {
       "name": "@ontrails/logging",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.11",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
       },
     },
     "packages/mcp": {
       "name": "@ontrails/mcp",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.11",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -129,7 +137,7 @@
     },
     "packages/schema": {
       "name": "@ontrails/schema",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.11",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -137,7 +145,7 @@
     },
     "packages/testing": {
       "name": "@ontrails/testing",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.11",
       "peerDependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
@@ -148,7 +156,7 @@
     },
     "packages/warden": {
       "name": "@ontrails/warden",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.11",
       "devDependencies": {
         "@ontrails/testing": "workspace:^",
         "@oxc-project/types": "^0.122.0",
@@ -236,6 +244,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@ontrails/cli": ["@ontrails/cli@workspace:packages/cli"],
+
+    "@ontrails/config": ["@ontrails/config@workspace:packages/config"],
 
     "@ontrails/core": ["@ontrails/core@workspace:packages/core"],
 

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   Result,
+  SURFACE_KEY,
   createTrailContext,
   service,
   trail,
@@ -221,20 +222,30 @@ describe('buildCliCommands', () => {
 
   test('uses provided createContext factory', async () => {
     let usedRequestId: string | undefined;
+    let usedCustom = false;
+    let usedSurface = false;
     const t = trail('ctx-test', {
       input: z.object({}),
       run: (_input: Record<string, never>, ctx: TrailContext) => {
         usedRequestId = ctx.requestId;
+        usedCustom = ctx.extensions?.['custom'] === true;
+        usedSurface = ctx.extensions?.[SURFACE_KEY] === 'cli';
         return Result.ok('ok');
       },
     });
     const app = makeApp(t);
     const commands = buildCliCommands(app, {
-      createContext: () => createTrailContext({ requestId: 'custom-123' }),
+      createContext: () =>
+        createTrailContext({
+          extensions: { custom: true },
+          requestId: 'custom-123',
+        }),
     });
 
     await commands[0]?.execute({}, {});
     expect(usedRequestId).toBe('custom-123');
+    expect(usedCustom).toBe(true);
+    expect(usedSurface).toBe(true);
   });
 
   test('converts kebab-case flags back to camelCase for input', async () => {

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -11,7 +11,7 @@ import type {
   TrailContext,
   TrailContextInit,
 } from '@ontrails/core';
-import { deriveFields, executeTrail } from '@ontrails/core';
+import { SURFACE_KEY, deriveFields, executeTrail } from '@ontrails/core';
 
 import type { AnyTrail, CliCommand, CliFlag } from './command.js';
 import { dryRunPreset, toFlags } from './flags.js';
@@ -137,6 +137,17 @@ const reportResult = async (
   }
 };
 
+/** Merge context overrides with the CLI surface marker. */
+const withCliSurface = (
+  ctxOverrides: Partial<TrailContext> | undefined
+): Partial<TrailContext> => ({
+  ...ctxOverrides,
+  extensions: {
+    ...ctxOverrides?.extensions,
+    [SURFACE_KEY]: 'cli' as const,
+  },
+});
+
 /** Create the execute function for a CLI command. */
 const createExecute =
   (
@@ -155,7 +166,7 @@ const createExecute =
 
     const result = await executeTrail(t, mergedInput, {
       createContext: options?.createContext,
-      ctx: ctxOverrides,
+      ctx: withCliSurface(ctxOverrides),
       layers: options?.layers,
       services: options?.services,
     });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ontrails/config",
+  "version": "1.0.0-beta.11",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@ontrails/core": "workspace:^",
+    "zod": "catalog:"
+  }
+}

--- a/packages/config/src/__tests__/app-config.test.ts
+++ b/packages/config/src/__tests__/app-config.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { z } from 'zod';
+
+import { appConfig } from '../app-config.js';
+import { describeConfig } from '../describe.js';
+import { checkConfig } from '../doctor.js';
+import { configRef } from '../ref.js';
+
+const testSchema = z.object({
+  output: z.string().describe('Output directory').default('./output'),
+  verbose: z.boolean().default(false),
+});
+
+describe('appConfig()', () => {
+  describe('creation', () => {
+    test('returns an object with the provided name', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      expect(config.name).toBe('myapp');
+    });
+
+    test('returns the provided schema', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      expect(config.schema).toBe(testSchema);
+    });
+
+    test('defaults formats to toml, json, yaml when not specified', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      expect(config.formats).toEqual(['toml', 'json', 'yaml']);
+    });
+
+    test('uses provided formats', () => {
+      const config = appConfig('myapp', {
+        formats: ['json', 'jsonc'],
+        schema: testSchema,
+      });
+      expect(config.formats).toEqual(['json', 'jsonc']);
+    });
+
+    test('defaults dotfile to false when not specified', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      expect(config.dotfile).toBe(false);
+    });
+
+    test('uses provided dotfile value', () => {
+      const config = appConfig('myapp', {
+        dotfile: true,
+        schema: testSchema,
+      });
+      expect(config.dotfile).toBe(true);
+    });
+  });
+
+  describe('resolve() with explicit path', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'trails-config-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { force: true, recursive: true });
+    });
+
+    test('reads and validates a JSON config file', async () => {
+      const filePath = join(tempDir, 'myapp.config.json');
+      await Bun.write(
+        filePath,
+        JSON.stringify({ output: './dist', verbose: true })
+      );
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ path: filePath });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ output: './dist', verbose: true });
+    });
+
+    test('reads and validates a TOML config file', async () => {
+      const filePath = join(tempDir, 'myapp.config.toml');
+      await Bun.write(filePath, 'output = "./build"\nverbose = true\n');
+
+      const config = appConfig('myapp', {
+        formats: ['toml'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ path: filePath });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ output: './build', verbose: true });
+    });
+
+    test('applies schema defaults for missing fields', async () => {
+      const filePath = join(tempDir, 'myapp.config.json');
+      await Bun.write(filePath, JSON.stringify({}));
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ path: filePath });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ output: './output', verbose: false });
+    });
+
+    test('returns Result.err when file does not exist', async () => {
+      const filePath = join(tempDir, 'nonexistent.json');
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ path: filePath });
+
+      expect(result.isErr()).toBe(true);
+    });
+
+    test('returns Result.err when file has invalid content', async () => {
+      const filePath = join(tempDir, 'myapp.config.json');
+      await Bun.write(
+        filePath,
+        JSON.stringify({ output: 42, verbose: 'not-a-bool' })
+      );
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ path: filePath });
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('resolve() with discovery', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'trails-config-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { force: true, recursive: true });
+    });
+
+    test('discovers config file in cwd', async () => {
+      const filePath = join(tempDir, 'myapp.config.json');
+      await Bun.write(filePath, JSON.stringify({ output: './found' }));
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().output).toBe('./found');
+    });
+
+    test('discovers config file by walking up directories', async () => {
+      const nested = join(tempDir, 'a', 'b', 'c');
+      await mkdir(nested, { recursive: true });
+
+      const filePath = join(tempDir, 'myapp.config.json');
+      await Bun.write(filePath, JSON.stringify({ output: './parent' }));
+
+      const config = appConfig('myapp', {
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: nested });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().output).toBe('./parent');
+    });
+
+    test('tries formats in order', async () => {
+      await Bun.write(
+        join(tempDir, 'myapp.config.toml'),
+        'output = "./from-toml"\n'
+      );
+      await Bun.write(
+        join(tempDir, 'myapp.config.json'),
+        JSON.stringify({ output: './from-json' })
+      );
+
+      const config = appConfig('myapp', {
+        formats: ['toml', 'json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().output).toBe('./from-toml');
+    });
+
+    test('returns Result.err when no config file found', async () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('file naming conventions', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'trails-config-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { force: true, recursive: true });
+    });
+
+    test('dotfile: true searches for .myapprc.* files', async () => {
+      await Bun.write(
+        join(tempDir, '.myapprc.json'),
+        JSON.stringify({ output: './dotfile' })
+      );
+
+      const config = appConfig('myapp', {
+        dotfile: true,
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().output).toBe('./dotfile');
+    });
+
+    test('dotfile: false searches for myapp.config.* files', async () => {
+      await Bun.write(
+        join(tempDir, 'myapp.config.json'),
+        JSON.stringify({ output: './standard' })
+      );
+
+      const config = appConfig('myapp', {
+        dotfile: false,
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().output).toBe('./standard');
+    });
+
+    test('dotfile: true does NOT find myapp.config.* files', async () => {
+      await Bun.write(
+        join(tempDir, 'myapp.config.json'),
+        JSON.stringify({ output: './nope' })
+      );
+
+      const config = appConfig('myapp', {
+        dotfile: true,
+        formats: ['json'],
+        schema: testSchema,
+      });
+      const result = await config.resolve({ cwd: tempDir });
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('method delegations', () => {
+    test('describe() returns same result as describeConfig(schema)', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      const methodResult = config.describe();
+      const standaloneResult = describeConfig(testSchema);
+
+      expect(methodResult).toEqual(standaloneResult);
+    });
+
+    test('check() returns same result as checkConfig(schema, values)', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      const values = { output: './dist', verbose: true };
+
+      const methodResult = config.check(values);
+      const standaloneResult = checkConfig(testSchema, values);
+
+      expect(methodResult).toEqual(standaloneResult);
+    });
+
+    test('ref() returns same result as configRef(path)', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      const methodResult = config.ref('output');
+      const standaloneResult = configRef('output');
+
+      expect(methodResult).toEqual(standaloneResult);
+    });
+
+    test('explain() delegates to explainConfig with bound schema', () => {
+      const config = appConfig('myapp', { schema: testSchema });
+      const resolved = { output: './dist', verbose: true };
+
+      const result = config.explain({ resolved });
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]?.path).toBeDefined();
+      expect(result[0]?.source).toBeDefined();
+    });
+  });
+});

--- a/packages/config/src/__tests__/app-config.test.ts
+++ b/packages/config/src/__tests__/app-config.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { z } from 'zod';
 
+import type { AppConfig } from '../app-config.js';
 import { appConfig } from '../app-config.js';
 import { describeConfig } from '../describe.js';
 import { checkConfig } from '../doctor.js';
@@ -13,6 +14,24 @@ const testSchema = z.object({
   output: z.string().describe('Output directory').default('./output'),
   verbose: z.boolean().default(false),
 });
+
+const createJsonConfig = () =>
+  appConfig('myapp', {
+    formats: ['json'],
+    schema: testSchema,
+  });
+
+const writeJsonConfig = (filePath: string, output: string) =>
+  Bun.write(filePath, JSON.stringify({ output }));
+
+const resolveOutput = async (
+  config: AppConfig<typeof testSchema>,
+  filePath: string
+): Promise<string> => {
+  const result = await config.resolve({ path: filePath });
+  expect(result.isOk()).toBe(true);
+  return result.unwrap().output;
+};
 
 describe('appConfig()', () => {
   describe('creation', () => {
@@ -71,10 +90,7 @@ describe('appConfig()', () => {
         JSON.stringify({ output: './dist', verbose: true })
       );
 
-      const config = appConfig('myapp', {
-        formats: ['json'],
-        schema: testSchema,
-      });
+      const config = createJsonConfig();
       const result = await config.resolve({ path: filePath });
 
       expect(result.isOk()).toBe(true);
@@ -99,23 +115,31 @@ describe('appConfig()', () => {
       const filePath = join(tempDir, 'myapp.config.json');
       await Bun.write(filePath, JSON.stringify({}));
 
-      const config = appConfig('myapp', {
-        formats: ['json'],
-        schema: testSchema,
-      });
+      const config = createJsonConfig();
       const result = await config.resolve({ path: filePath });
 
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toEqual({ output: './output', verbose: false });
     });
 
+    test('re-reads config files after they change on disk', async () => {
+      const filePath = join(tempDir, 'myapp.config.json');
+      await writeJsonConfig(filePath, './first');
+
+      const config = createJsonConfig();
+
+      expect(await resolveOutput(config, filePath)).toBe('./first');
+
+      await Bun.sleep(10);
+      await writeJsonConfig(filePath, './second');
+
+      expect(await resolveOutput(config, filePath)).toBe('./second');
+    });
+
     test('returns Result.err when file does not exist', async () => {
       const filePath = join(tempDir, 'nonexistent.json');
 
-      const config = appConfig('myapp', {
-        formats: ['json'],
-        schema: testSchema,
-      });
+      const config = createJsonConfig();
       const result = await config.resolve({ path: filePath });
 
       expect(result.isErr()).toBe(true);
@@ -128,10 +152,7 @@ describe('appConfig()', () => {
         JSON.stringify({ output: 42, verbose: 'not-a-bool' })
       );
 
-      const config = appConfig('myapp', {
-        formats: ['json'],
-        schema: testSchema,
-      });
+      const config = createJsonConfig();
       const result = await config.resolve({ path: filePath });
 
       expect(result.isErr()).toBe(true);
@@ -151,12 +172,9 @@ describe('appConfig()', () => {
 
     test('discovers config file in cwd', async () => {
       const filePath = join(tempDir, 'myapp.config.json');
-      await Bun.write(filePath, JSON.stringify({ output: './found' }));
+      await writeJsonConfig(filePath, './found');
 
-      const config = appConfig('myapp', {
-        formats: ['json'],
-        schema: testSchema,
-      });
+      const config = createJsonConfig();
       const result = await config.resolve({ cwd: tempDir });
 
       expect(result.isOk()).toBe(true);

--- a/packages/config/src/__tests__/compose.test.ts
+++ b/packages/config/src/__tests__/compose.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { collectServiceConfigs } from '../compose.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('collectServiceConfigs', () => {
+  test('extracts config schemas from services that declare them', () => {
+    const dbSchema = z.object({ url: z.string().url() });
+    const cacheSchema = z.object({ ttl: z.number() });
+
+    const services = [
+      { config: dbSchema, id: 'db.main' },
+      { config: cacheSchema, id: 'cache.main' },
+    ];
+
+    const entries = collectServiceConfigs(services);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toEqual({ schema: dbSchema, serviceId: 'db.main' });
+    expect(entries[1]).toEqual({
+      schema: cacheSchema,
+      serviceId: 'cache.main',
+    });
+  });
+
+  test('excludes services without config', () => {
+    const schema = z.object({ url: z.string() });
+
+    const services = [
+      { config: schema, id: 'db.main' },
+      { id: 'counter.main' },
+      { config: undefined, id: 'logger.main' },
+    ];
+
+    const entries = collectServiceConfigs(services);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.serviceId).toBe('db.main');
+  });
+
+  test('returns empty array when no services have config', () => {
+    const services = [{ id: 'counter.main' }, { id: 'logger.main' }];
+
+    const entries = collectServiceConfigs(services);
+
+    expect(entries).toEqual([]);
+  });
+
+  test('returns empty array for empty input', () => {
+    const entries = collectServiceConfigs([]);
+
+    expect(entries).toEqual([]);
+  });
+});

--- a/packages/config/src/__tests__/config-check.test.ts
+++ b/packages/config/src/__tests__/config-check.test.ts
@@ -117,6 +117,39 @@ describe('config.check trail', () => {
       expect(value.diagnostics[0]?.status).toBe('valid');
     });
 
+    test('deep merges nested input overrides with resolved values', async () => {
+      const schema = z.object({
+        db: z.object({
+          host: z.string(),
+          port: z.number(),
+        }),
+      });
+      const state: ConfigState = {
+        resolved: { db: { host: 'localhost', port: 5432 } },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configCheck.run(
+        { values: { db: { port: 6543 } } },
+        ctx
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().valid).toBe(true);
+      expect(result.unwrap().diagnostics).toEqual([
+        expect.objectContaining({
+          path: 'db.host',
+          status: 'valid',
+          value: 'localhost',
+        }),
+        expect.objectContaining({
+          path: 'db.port',
+          status: 'valid',
+          value: 6543,
+        }),
+      ]);
+    });
+
     test('reports default status for fields using defaults', async () => {
       const schema = z.object({
         port: z.number().default(3000),

--- a/packages/config/src/__tests__/config-check.test.ts
+++ b/packages/config/src/__tests__/config-check.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'bun:test';
+import { createServiceLookup } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { configCheck } from '../trails/config-check.js';
+import type { ConfigState } from '../registry.js';
+
+/**
+ * Build a TrailContext with configService resolved in extensions.
+ */
+const buildCtx = (state: ConfigState): TrailContext => {
+  const extensions = { config: state };
+  const ctx: TrailContext = {
+    cwd: '/tmp',
+    env: {},
+    extensions,
+    requestId: 'test',
+    service: undefined as unknown as TrailContext['service'],
+    signal: AbortSignal.timeout(5000),
+    workspaceRoot: '/tmp',
+  };
+  const withLookup = {
+    ...ctx,
+    service: createServiceLookup(() => withLookup),
+  };
+  return withLookup;
+};
+
+describe('config.check trail', () => {
+  describe('identity', () => {
+    test('has id "config.check"', () => {
+      expect(configCheck.id).toBe('config.check');
+    });
+
+    test('has kind "trail"', () => {
+      expect(configCheck.kind).toBe('trail');
+    });
+
+    test('has intent "read"', () => {
+      expect(configCheck.intent).toBe('read');
+    });
+
+    test('has infrastructure metadata', () => {
+      expect(configCheck.metadata).toEqual({ category: 'infrastructure' });
+    });
+
+    test('has output schema', () => {
+      expect(configCheck.output).toBeDefined();
+    });
+
+    test('declares configService dependency', () => {
+      expect(configCheck.services).toBeDefined();
+      expect(configCheck.services?.length).toBe(1);
+    });
+  });
+
+  describe('examples', () => {
+    test('has at least one example', () => {
+      expect(configCheck.examples?.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('wired behavior', () => {
+    test('reports valid when all required fields present', async () => {
+      const schema = z.object({
+        host: z.string().default('localhost'),
+        port: z.number().default(3000),
+      });
+      const state: ConfigState = {
+        resolved: { host: 'localhost', port: 3000 },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configCheck.run({ values: {} }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(true);
+      expect(value.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    test('reports missing for required fields without values', async () => {
+      const schema = z.object({
+        host: z.string(),
+        port: z.number(),
+      });
+      const state: ConfigState = {
+        resolved: {},
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configCheck.run({ values: {} }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(false);
+      const missing = value.diagnostics.filter((d) => d.status === 'missing');
+      expect(missing.length).toBe(2);
+    });
+
+    test('uses input values when provided to override resolved', async () => {
+      const schema = z.object({
+        port: z.number(),
+      });
+      const state: ConfigState = {
+        resolved: {},
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configCheck.run({ values: { port: 8080 } }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(true);
+      expect(value.diagnostics.length).toBe(1);
+      expect(value.diagnostics[0]?.status).toBe('valid');
+    });
+
+    test('reports default status for fields using defaults', async () => {
+      const schema = z.object({
+        port: z.number().default(3000),
+      });
+      const state: ConfigState = {
+        resolved: {},
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configCheck.run({ values: {} }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const defaults = result
+        .unwrap()
+        .diagnostics.filter((d) => d.status === 'default');
+      expect(defaults.length).toBe(1);
+    });
+  });
+});

--- a/packages/config/src/__tests__/config-describe.test.ts
+++ b/packages/config/src/__tests__/config-describe.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from 'bun:test';
+import { createServiceLookup } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { configDescribe } from '../trails/config-describe.js';
+import { env, secret } from '../extensions.js';
+import type { ConfigState } from '../registry.js';
+
+/**
+ * Build a TrailContext with configService resolved in extensions.
+ */
+const buildCtx = (state: ConfigState): TrailContext => {
+  const extensions = { config: state };
+  const ctx: TrailContext = {
+    cwd: '/tmp',
+    env: {},
+    extensions,
+    requestId: 'test',
+    service: undefined as unknown as TrailContext['service'],
+    signal: AbortSignal.timeout(5000),
+    workspaceRoot: '/tmp',
+  };
+  const withLookup = {
+    ...ctx,
+    service: createServiceLookup(() => withLookup),
+  };
+  return withLookup;
+};
+
+describe('config.describe trail', () => {
+  describe('identity', () => {
+    test('has id "config.describe"', () => {
+      expect(configDescribe.id).toBe('config.describe');
+    });
+
+    test('has kind "trail"', () => {
+      expect(configDescribe.kind).toBe('trail');
+    });
+
+    test('has intent "read"', () => {
+      expect(configDescribe.intent).toBe('read');
+    });
+
+    test('has infrastructure metadata', () => {
+      expect(configDescribe.metadata).toEqual({ category: 'infrastructure' });
+    });
+
+    test('has output schema', () => {
+      expect(configDescribe.output).toBeDefined();
+    });
+
+    test('declares configService dependency', () => {
+      expect(configDescribe.services).toBeDefined();
+      expect(configDescribe.services?.length).toBe(1);
+    });
+  });
+
+  describe('examples', () => {
+    test('has at least one example', () => {
+      expect(configDescribe.examples?.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('wired behavior', () => {
+    test('returns one field description per schema field', async () => {
+      const schema = z.object({
+        host: z.string().default('localhost'),
+        port: z.number().default(3000),
+      });
+      const state: ConfigState = {
+        resolved: { host: 'localhost', port: 3000 },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configDescribe.run({}, ctx);
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().fields.length).toBe(2);
+    });
+
+    test('includes path and type for each field', async () => {
+      const schema = z.object({
+        host: z.string().default('localhost'),
+        port: z.number().default(3000),
+      });
+      const state: ConfigState = {
+        resolved: { host: 'localhost', port: 3000 },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configDescribe.run({}, ctx);
+      const { fields } = result.unwrap();
+
+      expect(fields[0]?.path).toBe('host');
+      expect(fields[0]?.type).toBe('string');
+      expect(fields[1]?.path).toBe('port');
+      expect(fields[1]?.type).toBe('number');
+    });
+
+    test('includes env annotation when present', async () => {
+      const schema = z.object({
+        port: env(z.number(), 'PORT').default(3000),
+      });
+      const state: ConfigState = {
+        resolved: { port: 3000 },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configDescribe.run({}, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const [field] = result.unwrap().fields;
+      expect(field?.env).toBe('PORT');
+    });
+
+    test('includes secret annotation when present', async () => {
+      const schema = z.object({
+        token: secret(z.string()).default('tok'),
+      });
+      const state: ConfigState = {
+        resolved: { token: 'tok' },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configDescribe.run({}, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const [field] = result.unwrap().fields;
+      expect(field?.secret).toBe(true);
+    });
+
+    test('reports required status correctly', async () => {
+      const schema = z.object({
+        optional: z.string().optional(),
+        required: z.string(),
+        withDefault: z.string().default('val'),
+      });
+      const state: ConfigState = {
+        resolved: { required: 'x', withDefault: 'val' },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configDescribe.run({}, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const { fields } = result.unwrap();
+      const findField = (path: string) => fields.find((f) => f.path === path);
+      expect(findField('required')?.required).toBe(true);
+      expect(findField('optional')?.required).toBe(false);
+      expect(findField('withDefault')?.required).toBe(false);
+    });
+  });
+});

--- a/packages/config/src/__tests__/config-explain.test.ts
+++ b/packages/config/src/__tests__/config-explain.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test';
+import { createServiceLookup } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { configExplain } from '../trails/config-explain.js';
+import { env } from '../extensions.js';
+import type { ConfigState } from '../registry.js';
+
+/**
+ * Build a TrailContext with configService resolved in extensions.
+ */
+const buildCtx = (state: ConfigState): TrailContext => {
+  const extensions = { config: state };
+  const ctx: TrailContext = {
+    cwd: '/tmp',
+    env: {},
+    extensions,
+    requestId: 'test',
+    service: undefined as unknown as TrailContext['service'],
+    signal: AbortSignal.timeout(5000),
+    workspaceRoot: '/tmp',
+  };
+  const withLookup = {
+    ...ctx,
+    service: createServiceLookup(() => withLookup),
+  };
+  return withLookup;
+};
+
+describe('config.explain trail', () => {
+  describe('identity', () => {
+    test('has id "config.explain"', () => {
+      expect(configExplain.id).toBe('config.explain');
+    });
+
+    test('has kind "trail"', () => {
+      expect(configExplain.kind).toBe('trail');
+    });
+
+    test('has intent "read"', () => {
+      expect(configExplain.intent).toBe('read');
+    });
+
+    test('has infrastructure metadata', () => {
+      expect(configExplain.metadata).toEqual({ category: 'infrastructure' });
+    });
+
+    test('has output schema', () => {
+      expect(configExplain.output).toBeDefined();
+    });
+
+    test('declares configService dependency', () => {
+      expect(configExplain.services).toBeDefined();
+      expect(configExplain.services?.length).toBe(1);
+    });
+  });
+
+  describe('examples', () => {
+    test('has at least one example', () => {
+      expect(configExplain.examples?.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('wired behavior', () => {
+    test('returns provenance entries for all fields', async () => {
+      const schema = z.object({
+        host: z.string().default('localhost'),
+        port: z.number().default(3000),
+      });
+      const state: ConfigState = {
+        resolved: { host: 'localhost', port: 3000 },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configExplain.run({ path: '' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.entries.length).toBe(2);
+      expect(value.entries[0]?.path).toBe('host');
+      expect(value.entries[0]?.source).toBe('default');
+      expect(value.entries[1]?.path).toBe('port');
+    });
+
+    test('filters entries by path prefix', async () => {
+      const schema = z.object({
+        db: z.object({
+          host: z.string().default('localhost'),
+          port: z.number().default(5432),
+        }),
+        name: z.string().default('app'),
+      });
+      const state: ConfigState = {
+        resolved: { db: { host: 'localhost', port: 5432 }, name: 'app' },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configExplain.run({ path: 'db' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.entries.length).toBe(2);
+      expect(value.entries[0]?.path).toBe('db.host');
+    });
+
+    test('shows base layer as source when base provides value', async () => {
+      const schema = z.object({
+        port: z.number().default(3000),
+      });
+      const state: ConfigState = {
+        base: { port: 8080 },
+        resolved: { port: 8080 },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configExplain.run({ path: '' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const [entry] = result.unwrap().entries;
+      expect(entry?.source).toBe('base');
+      expect(entry?.value).toBe(8080);
+    });
+
+    test('shows env as source when env provides value', async () => {
+      const schema = z.object({
+        token: env(z.string(), 'TOKEN').default('fallback'),
+      });
+      const state: ConfigState = {
+        env: { TOKEN: 'real-secret' },
+        resolved: { token: 'real-secret' },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configExplain.run({ path: '' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const [entry] = result.unwrap().entries;
+      expect(entry?.source).toBe('env');
+    });
+  });
+});

--- a/packages/config/src/__tests__/config-explain.test.ts
+++ b/packages/config/src/__tests__/config-explain.test.ts
@@ -104,6 +104,31 @@ describe('config.explain trail', () => {
       expect(value.entries[0]?.path).toBe('db.host');
     });
 
+    test('does not match sibling roots that only share a prefix', async () => {
+      const schema = z.object({
+        db: z.object({
+          host: z.string().default('localhost'),
+        }),
+        dbReplica: z.object({
+          host: z.string().default('replica.local'),
+        }),
+      });
+      const state: ConfigState = {
+        resolved: {
+          db: { host: 'localhost' },
+          dbReplica: { host: 'replica.local' },
+        },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configExplain.run({ path: 'db' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().entries).toEqual([
+        expect.objectContaining({ path: 'db.host' }),
+      ]);
+    });
+
     test('shows base layer as source when base provides value', async () => {
       const schema = z.object({
         port: z.number().default(3000),

--- a/packages/config/src/__tests__/config-init.test.ts
+++ b/packages/config/src/__tests__/config-init.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServiceLookup } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { env } from '../extensions.js';
+import type { ConfigState } from '../registry.js';
+import { configInit } from '../trails/config-init.js';
+
+/**
+ * Build a TrailContext with configService resolved in extensions.
+ */
+const buildCtx = (state: ConfigState): TrailContext => {
+  const extensions = { config: state };
+  const ctx: TrailContext = {
+    cwd: '/tmp',
+    env: {},
+    extensions,
+    requestId: 'test',
+    service: undefined as unknown as TrailContext['service'],
+    signal: AbortSignal.timeout(5000),
+    workspaceRoot: '/tmp',
+  };
+  const withLookup = {
+    ...ctx,
+    service: createServiceLookup(() => withLookup),
+  };
+  return withLookup;
+};
+
+const testSchema = z.object({
+  host: z.string().default('localhost'),
+  port: z.number().default(3000),
+});
+
+const testState: ConfigState = {
+  resolved: { host: 'localhost', port: 3000 },
+  schema: testSchema,
+};
+
+describe('config.init trail', () => {
+  describe('identity', () => {
+    test('has id "config.init"', () => {
+      expect(configInit.id).toBe('config.init');
+    });
+
+    test('has kind "trail"', () => {
+      expect(configInit.kind).toBe('trail');
+    });
+
+    test('has intent "write"', () => {
+      expect(configInit.intent).toBe('write');
+    });
+
+    test('has infrastructure metadata', () => {
+      expect(configInit.metadata).toEqual({ category: 'infrastructure' });
+    });
+
+    test('has output schema', () => {
+      expect(configInit.output).toBeDefined();
+    });
+
+    test('declares configService dependency', () => {
+      expect(configInit.services).toBeDefined();
+      expect(configInit.services?.length).toBe(1);
+    });
+  });
+
+  describe('examples', () => {
+    test('has at least one example', () => {
+      expect(configInit.examples?.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('wired behavior', () => {
+    test('generates TOML output by default', async () => {
+      const ctx = buildCtx(testState);
+      const result = await configInit.run({ format: 'toml' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.format).toBe('toml');
+      expect(value.content).toContain('host');
+      expect(value.content).toContain('port');
+      expect(value.content.length).toBeGreaterThan(0);
+    });
+
+    test('generates JSON output when requested', async () => {
+      const ctx = buildCtx(testState);
+      const result = await configInit.run({ format: 'json' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.format).toBe('json');
+      expect(value.content).toContain('"host"');
+      expect(value.content).toContain('"port"');
+    });
+
+    test('generates YAML output when requested', async () => {
+      const ctx = buildCtx(testState);
+      const result = await configInit.run({ format: 'yaml' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.format).toBe('yaml');
+      expect(value.content).toContain('host:');
+    });
+
+    test('generates JSONC output when requested', async () => {
+      const ctx = buildCtx(testState);
+      const result = await configInit.run({ format: 'jsonc' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.format).toBe('jsonc');
+      expect(value.content).toContain('"host"');
+    });
+
+    test('output content is non-empty for schema with fields', async () => {
+      const ctx = buildCtx(testState);
+      const result = await configInit.run({ format: 'toml' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().content.trim().length).toBeGreaterThan(0);
+    });
+
+    test('returns content without writtenFiles when dir is not provided', async () => {
+      const ctx = buildCtx(testState);
+      const result = await configInit.run({ format: 'toml' }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().writtenFiles).toBeUndefined();
+    });
+  });
+
+  describe('artifact generation', () => {
+    let tempDir: string;
+
+    const envSchema = z.object({
+      host: env(z.string(), 'APP_HOST').default('localhost'),
+      port: z.number().default(3000),
+    });
+
+    const envState: ConfigState = {
+      resolved: { host: 'localhost', port: 3000 },
+      schema: envSchema,
+    };
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'trails-config-init-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { force: true, recursive: true });
+    });
+
+    test('writes .schema.json when dir is provided', async () => {
+      const ctx = buildCtx(envState);
+      const result = await configInit.run(
+        { dir: tempDir, format: 'toml' },
+        ctx
+      );
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.writtenFiles).toBeDefined();
+      expect(value.writtenFiles).toContainEqual(join(tempDir, '.schema.json'));
+
+      const schemaContent = await readFile(
+        join(tempDir, '.schema.json'),
+        'utf8'
+      );
+      const parsed = JSON.parse(schemaContent);
+      expect(parsed['$schema']).toBe(
+        'https://json-schema.org/draft/2020-12/schema'
+      );
+    });
+
+    test('writes .env.example when schema has env bindings', async () => {
+      const ctx = buildCtx(envState);
+      const result = await configInit.run(
+        { dir: tempDir, format: 'toml' },
+        ctx
+      );
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.writtenFiles).toContainEqual(join(tempDir, '.env.example'));
+
+      const envContent = await readFile(join(tempDir, '.env.example'), 'utf8');
+      expect(envContent).toContain('APP_HOST');
+    });
+
+    test('still returns content alongside written files', async () => {
+      const ctx = buildCtx(envState);
+      const result = await configInit.run(
+        { dir: tempDir, format: 'json' },
+        ctx
+      );
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.content.length).toBeGreaterThan(0);
+      expect(value.format).toBe('json');
+    });
+  });
+});

--- a/packages/config/src/__tests__/config-layer.test.ts
+++ b/packages/config/src/__tests__/config-layer.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { Result } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { configLayer } from '../config-layer.js';
+
+const stubTrail = {
+  description: undefined,
+  detours: undefined,
+  examples: undefined,
+  fields: undefined,
+  follow: [],
+  id: 'test.stub',
+  idempotent: undefined,
+  input: z.object({}),
+  intent: 'read' as const,
+  kind: 'trail' as const,
+  metadata: undefined,
+  output: undefined,
+  run: (_input: unknown, _ctx: TrailContext) => Result.ok({}),
+  services: [],
+};
+
+describe('configLayer', () => {
+  describe('identity', () => {
+    test('has name "config"', () => {
+      expect(configLayer.name).toBe('config');
+    });
+
+    test('has a description', () => {
+      expect(configLayer.description).toBeDefined();
+    });
+  });
+
+  describe('wrap', () => {
+    test('passes through to the base implementation', async () => {
+      const impl = (_input: unknown, _ctx: TrailContext) =>
+        Result.ok({ called: true });
+
+      const wrapped = configLayer.wrap(stubTrail, impl);
+      const ctx = {
+        cwd: '/tmp',
+        env: {},
+        workspaceRoot: '/tmp',
+      } as TrailContext;
+      const result = await wrapped({}, ctx);
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ called: true });
+    });
+  });
+});

--- a/packages/config/src/__tests__/config-service.test.ts
+++ b/packages/config/src/__tests__/config-service.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { configService } from '../config-service.js';
+import type { ConfigState } from '../registry.js';
+import { clearConfigState, registerConfigState } from '../registry.js';
+
+/** Stub ServiceContext for create calls. */
+const stubSvcCtx = {
+  config: undefined,
+  cwd: '/tmp',
+  env: {},
+  workspaceRoot: '/tmp',
+};
+
+describe('configService', () => {
+  afterEach(() => {
+    clearConfigState();
+  });
+
+  describe('identity', () => {
+    test('has id "config"', () => {
+      expect(configService.id).toBe('config');
+    });
+
+    test('has kind "service"', () => {
+      expect(configService.kind).toBe('service');
+    });
+
+    test('has infrastructure metadata', () => {
+      expect(configService.metadata).toEqual({ category: 'infrastructure' });
+    });
+
+    test('has description', () => {
+      expect(configService.description).toBeDefined();
+    });
+  });
+
+  describe('mock', () => {
+    test('returns a ConfigState with empty schema and resolved', () => {
+      const value = configService.mock?.() as ConfigState;
+      expect(value).toBeDefined();
+      expect(value.resolved).toEqual({});
+      expect(value.schema).toBeDefined();
+    });
+  });
+
+  describe('create', () => {
+    test('returns Result.ok with registered ConfigState', async () => {
+      const schema = z.object({ port: z.number().default(3000) });
+      const state: ConfigState = { resolved: { port: 3000 }, schema };
+      registerConfigState(state);
+
+      const result = await configService.create(stubSvcCtx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap() as ConfigState;
+      expect(value.resolved).toEqual({ port: 3000 });
+      expect(value.schema).toBe(schema);
+    });
+
+    test('includes optional layer data when present', async () => {
+      const schema = z.object({ port: z.number() });
+      const state: ConfigState = {
+        base: { port: 8080 },
+        local: { port: 3000 },
+        resolved: { port: 3000 },
+        schema,
+      };
+      registerConfigState(state);
+
+      const result = await configService.create(stubSvcCtx);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap() as ConfigState;
+      expect(value.base).toEqual({ port: 8080 });
+      expect(value.local).toEqual({ port: 3000 });
+    });
+
+    test('returns Result.err when no state is registered', async () => {
+      const result = await configService.create(stubSvcCtx);
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error.message).toContain('Config state not registered');
+    });
+  });
+});

--- a/packages/config/src/__tests__/define-config.test.ts
+++ b/packages/config/src/__tests__/define-config.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+import { defineConfig } from '../define-config.js';
+
+const schema = z.object({
+  debug: z.boolean().default(false),
+  host: z.string().default('localhost'),
+  port: z.number().default(3000),
+});
+
+describe('defineConfig', () => {
+  test('returns an object with schema, base, and loadouts', () => {
+    const base = { host: 'example.com' };
+    const loadouts = { production: { port: 443 } };
+
+    const config = defineConfig({ base, loadouts, schema });
+
+    expect(config.schema).toBe(schema);
+    expect(config.base).toBe(base);
+    expect(config.loadouts).toBe(loadouts);
+  });
+
+  test('resolve() uses TRAILS_ENV to select loadout', async () => {
+    const config = defineConfig({
+      base: { host: 'example.com' },
+      loadouts: {
+        production: { host: 'prod.example.com', port: 443 },
+        test: { host: 'test.example.com', port: 9999 },
+      },
+      schema,
+    });
+
+    const result = await config.resolve({
+      env: { TRAILS_ENV: 'production' },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().host).toBe('prod.example.com');
+    expect(result.unwrap().port).toBe(443);
+  });
+
+  test('resolve() with explicit loadout option overrides TRAILS_ENV', async () => {
+    const config = defineConfig({
+      base: { host: 'example.com' },
+      loadouts: {
+        production: { host: 'prod.example.com' },
+        test: { host: 'test.example.com' },
+      },
+      schema,
+    });
+
+    const result = await config.resolve({
+      env: { TRAILS_ENV: 'production' },
+      loadout: 'test',
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().host).toBe('test.example.com');
+  });
+
+  test('envFromNodeEnv maps NODE_ENV to TRAILS_ENV when unset', async () => {
+    const config = defineConfig({
+      base: { host: 'example.com' },
+      envFromNodeEnv: true,
+      loadouts: {
+        production: { host: 'prod.example.com', port: 443 },
+      },
+      schema,
+    });
+
+    const result = await config.resolve({
+      env: { NODE_ENV: 'production' },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().host).toBe('prod.example.com');
+    expect(result.unwrap().port).toBe(443);
+  });
+
+  test('envFromNodeEnv does not override explicit TRAILS_ENV', async () => {
+    const config = defineConfig({
+      base: { host: 'example.com' },
+      envFromNodeEnv: true,
+      loadouts: {
+        production: { host: 'prod.example.com' },
+        test: { host: 'test.example.com' },
+      },
+      schema,
+    });
+
+    const result = await config.resolve({
+      env: { NODE_ENV: 'production', TRAILS_ENV: 'test' },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().host).toBe('test.example.com');
+  });
+
+  test('test loadout works when TRAILS_ENV=test', async () => {
+    const config = defineConfig({
+      base: { port: 8080 },
+      loadouts: {
+        test: { debug: true, port: 0 },
+      },
+      schema,
+    });
+
+    const result = await config.resolve({
+      env: { TRAILS_ENV: 'test' },
+    });
+
+    expect(result.isOk()).toBe(true);
+    const value = result.unwrap();
+    expect(value.debug).toBe(true);
+    expect(value.port).toBe(0);
+  });
+
+  describe('local overrides', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'trails-define-config-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { force: true, recursive: true });
+    });
+
+    test('applies local overrides from .trails/config/local.ts', async () => {
+      const configDir = join(tempDir, '.trails', 'config');
+      await mkdir(configDir, { recursive: true });
+      await Bun.write(
+        join(configDir, 'local.ts'),
+        'export default { port: 4444 };'
+      );
+
+      const config = defineConfig({
+        base: { host: 'example.com' },
+        schema,
+      });
+
+      const result = await config.resolve({
+        cwd: tempDir,
+        env: {},
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().port).toBe(4444);
+    });
+
+    test('local overrides applied between loadout and env', async () => {
+      const configDir = join(tempDir, '.trails', 'config');
+      await mkdir(configDir, { recursive: true });
+      await Bun.write(
+        join(configDir, 'local.js'),
+        'export default { port: 5555 };'
+      );
+
+      const config = defineConfig({
+        base: { port: 8080 },
+        loadouts: {
+          dev: { port: 9090 },
+        },
+        schema,
+      });
+
+      // Local overrides should win over loadout (9090)
+      const result = await config.resolve({
+        cwd: tempDir,
+        env: { TRAILS_ENV: 'dev' },
+        loadout: 'dev',
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().port).toBe(5555);
+    });
+
+    test('skips local overrides when TRAILS_ENV=test', async () => {
+      const configDir = join(tempDir, '.trails', 'config');
+      await mkdir(configDir, { recursive: true });
+      await Bun.write(
+        join(configDir, 'local.ts'),
+        'export default { port: 4444 };'
+      );
+
+      const config = defineConfig({
+        base: { port: 8080 },
+        schema,
+      });
+
+      const result = await config.resolve({
+        cwd: tempDir,
+        env: { TRAILS_ENV: 'test' },
+      });
+
+      expect(result.isOk()).toBe(true);
+      // Should NOT apply local overrides, so port stays at base 8080
+      expect(result.unwrap().port).toBe(8080);
+    });
+  });
+});

--- a/packages/config/src/__tests__/define-config.test.ts
+++ b/packages/config/src/__tests__/define-config.test.ts
@@ -12,6 +12,39 @@ const schema = z.object({
   port: z.number().default(3000),
 });
 
+type EnvKey = 'NODE_ENV' | 'TRAILS_ENV';
+
+interface EnvSnapshot {
+  readonly NODE_ENV: string | undefined;
+  readonly TRAILS_ENV: string | undefined;
+}
+
+const readEnvSnapshot = (): EnvSnapshot => ({
+  NODE_ENV: process.env.NODE_ENV,
+  TRAILS_ENV: process.env.TRAILS_ENV,
+});
+
+const setEnvVar = (key: EnvKey, value: string | undefined): void => {
+  if (value === undefined) {
+    if (key === 'NODE_ENV') {
+      delete process.env.NODE_ENV;
+    } else {
+      delete process.env.TRAILS_ENV;
+    }
+    return;
+  }
+  if (key === 'NODE_ENV') {
+    process.env.NODE_ENV = value;
+  } else {
+    process.env.TRAILS_ENV = value;
+  }
+};
+
+const restoreEnv = (snapshot: EnvSnapshot): void => {
+  setEnvVar('NODE_ENV', snapshot.NODE_ENV);
+  setEnvVar('TRAILS_ENV', snapshot.TRAILS_ENV);
+};
+
 describe('defineConfig', () => {
   test('returns an object with schema, base, and loadouts', () => {
     const base = { host: 'example.com' };
@@ -79,6 +112,31 @@ describe('defineConfig', () => {
     expect(result.isOk()).toBe(true);
     expect(result.unwrap().host).toBe('prod.example.com');
     expect(result.unwrap().port).toBe(443);
+  });
+
+  test('envFromNodeEnv does not mutate process.env', async () => {
+    const snapshot = readEnvSnapshot();
+    setEnvVar('TRAILS_ENV', undefined);
+    setEnvVar('NODE_ENV', 'production');
+
+    try {
+      const config = defineConfig({
+        base: { host: 'example.com' },
+        envFromNodeEnv: true,
+        loadouts: {
+          production: { host: 'prod.example.com', port: 443 },
+        },
+        schema,
+      });
+
+      const result = await config.resolve();
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().host).toBe('prod.example.com');
+      expect(process.env.TRAILS_ENV).toBeUndefined();
+    } finally {
+      restoreEnv(snapshot);
+    }
   });
 
   test('envFromNodeEnv does not override explicit TRAILS_ENV', async () => {

--- a/packages/config/src/__tests__/describe.test.ts
+++ b/packages/config/src/__tests__/describe.test.ts
@@ -95,6 +95,24 @@ describe('describeConfig', () => {
       expect(dbPort?.type).toBe('number');
       expect(dbPort?.default).toBe(5432);
     });
+
+    test('unwraps optional nested object schemas before walking', () => {
+      const schema = z.object({
+        db: z
+          .object({
+            host: z.string(),
+            port: z.number().default(5432),
+          })
+          .optional(),
+      });
+
+      const fields = describeConfig(schema);
+
+      expect(fields).toEqual([
+        expect.objectContaining({ path: 'db.host', required: true }),
+        expect.objectContaining({ default: 5432, path: 'db.port' }),
+      ]);
+    });
   });
 
   describe('constraints', () => {

--- a/packages/config/src/__tests__/describe.test.ts
+++ b/packages/config/src/__tests__/describe.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { deprecated, env, secret } from '../extensions.js';
+import { describeConfig } from '../describe.js';
+
+describe('describeConfig', () => {
+  describe('basic field descriptions', () => {
+    test('returns path, type, and required for each field', () => {
+      const schema = z.object({
+        debug: z.boolean(),
+        host: z.string(),
+        port: z.number(),
+      });
+
+      const fields = describeConfig(schema);
+
+      expect(fields).toHaveLength(3);
+      const host = fields.find((f) => f.path === 'host');
+      expect(host?.type).toBe('string');
+      expect(host?.required).toBe(true);
+
+      const port = fields.find((f) => f.path === 'port');
+      expect(port?.type).toBe('number');
+      expect(port?.required).toBe(true);
+    });
+  });
+
+  describe('Zod describe() metadata', () => {
+    test('includes description from .describe()', () => {
+      const schema = z.object({
+        host: z.string().describe('The server hostname'),
+      });
+
+      const fields = describeConfig(schema);
+      const host = fields.find((f) => f.path === 'host');
+      expect(host?.description).toBe('The server hostname');
+    });
+  });
+
+  describe('config metadata', () => {
+    test('includes env, secret, deprecated from metadata', () => {
+      const schema = z.object({
+        apiKey: secret(env(z.string(), 'API_KEY')),
+        legacyMode: deprecated(z.boolean(), 'Use "mode" instead').default(
+          false
+        ),
+      });
+
+      const fields = describeConfig(schema);
+
+      const apiKey = fields.find((f) => f.path === 'apiKey');
+      expect(apiKey?.env).toBe('API_KEY');
+      expect(apiKey?.secret).toBe(true);
+
+      const legacy = fields.find((f) => f.path === 'legacyMode');
+      expect(legacy?.deprecated).toBe('Use "mode" instead');
+    });
+  });
+
+  describe('defaults', () => {
+    test('detects default values', () => {
+      const schema = z.object({
+        debug: z.boolean().default(false),
+        port: z.number().default(3000),
+      });
+
+      const fields = describeConfig(schema);
+
+      const port = fields.find((f) => f.path === 'port');
+      expect(port?.default).toBe(3000);
+      expect(port?.required).toBe(false);
+
+      const debug = fields.find((f) => f.path === 'debug');
+      expect(debug?.default).toBe(false);
+    });
+  });
+
+  describe('nested objects', () => {
+    test('handles nested object schemas with dot paths', () => {
+      const schema = z.object({
+        db: z.object({
+          host: z.string(),
+          port: z.number().default(5432),
+        }),
+      });
+
+      const fields = describeConfig(schema);
+
+      const dbHost = fields.find((f) => f.path === 'db.host');
+      expect(dbHost?.type).toBe('string');
+      expect(dbHost?.required).toBe(true);
+
+      const dbPort = fields.find((f) => f.path === 'db.port');
+      expect(dbPort?.type).toBe('number');
+      expect(dbPort?.default).toBe(5432);
+    });
+  });
+
+  describe('constraints', () => {
+    test('detects enum values', () => {
+      const schema = z.object({
+        env: z.enum(['development', 'production', 'test']),
+      });
+
+      const fields = describeConfig(schema);
+      const envField = fields.find((f) => f.path === 'env');
+      expect(envField?.type).toBe('enum');
+      expect(envField?.constraints?.values).toEqual([
+        'development',
+        'production',
+        'test',
+      ]);
+    });
+
+    test('detects number min/max constraints', () => {
+      const schema = z.object({
+        port: z.number().min(1).max(65_535),
+      });
+
+      const fields = describeConfig(schema);
+      const port = fields.find((f) => f.path === 'port');
+      expect(port?.constraints?.min).toBe(1);
+      expect(port?.constraints?.max).toBe(65_535);
+    });
+  });
+
+  describe('optional fields', () => {
+    test('marks optional fields as not required', () => {
+      const schema = z.object({
+        host: z.string(),
+        nickname: z.string().optional(),
+      });
+
+      const fields = describeConfig(schema);
+      const nickname = fields.find((f) => f.path === 'nickname');
+      expect(nickname?.required).toBe(false);
+    });
+  });
+});

--- a/packages/config/src/__tests__/doctor.test.ts
+++ b/packages/config/src/__tests__/doctor.test.ts
@@ -148,5 +148,25 @@ describe('checkConfig', () => {
       expect(dbHostDiag?.status).toBe('valid');
       expect(dbHostDiag?.value).toBe('dbhost.local');
     });
+
+    test('walks optional nested object schemas for env overrides', () => {
+      const nestedSchema = z.object({
+        db: z
+          .object({
+            host: env(z.string(), 'DB_HOST'),
+          })
+          .optional(),
+      });
+
+      const result = checkConfig(
+        nestedSchema,
+        {},
+        { env: { DB_HOST: 'dbhost.local' } }
+      );
+      const dbHostDiag = result.diagnostics.find((d) => d.path === 'db.host');
+
+      expect(dbHostDiag?.status).toBe('valid');
+      expect(dbHostDiag?.value).toBe('dbhost.local');
+    });
   });
 });

--- a/packages/config/src/__tests__/doctor.test.ts
+++ b/packages/config/src/__tests__/doctor.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { deprecated, env } from '../extensions.js';
+import { checkConfig } from '../doctor.js';
+
+const schema = z.object({
+  debug: z.boolean().default(false),
+  host: z.string(),
+  port: z.number().default(3000),
+});
+
+describe('checkConfig', () => {
+  describe('valid fields', () => {
+    test('reports status "valid" for present and valid fields', () => {
+      const result = checkConfig(schema, { host: 'localhost', port: 8080 });
+
+      const hostDiag = result.diagnostics.find((d) => d.path === 'host');
+      expect(hostDiag?.status).toBe('valid');
+      expect(hostDiag?.value).toBe('localhost');
+    });
+  });
+
+  describe('missing required fields', () => {
+    test('reports status "missing" for absent required fields', () => {
+      const result = checkConfig(schema, { port: 8080 });
+
+      const hostDiag = result.diagnostics.find((d) => d.path === 'host');
+      expect(hostDiag?.status).toBe('missing');
+      expect(hostDiag?.message).toContain('host');
+    });
+  });
+
+  describe('default fields', () => {
+    test('reports status "default" when field uses schema default', () => {
+      const result = checkConfig(schema, { host: 'localhost' });
+
+      const portDiag = result.diagnostics.find((d) => d.path === 'port');
+      expect(portDiag?.status).toBe('default');
+      expect(portDiag?.value).toBe(3000);
+
+      const debugDiag = result.diagnostics.find((d) => d.path === 'debug');
+      expect(debugDiag?.status).toBe('default');
+      expect(debugDiag?.value).toBe(false);
+    });
+  });
+
+  describe('invalid fields', () => {
+    test('reports status "invalid" with message for wrong-type values', () => {
+      const result = checkConfig(schema, {
+        host: 'localhost',
+        port: 'not-a-number',
+      });
+
+      const portDiag = result.diagnostics.find((d) => d.path === 'port');
+      expect(portDiag?.status).toBe('invalid');
+      expect(portDiag?.message).toBeDefined();
+    });
+  });
+
+  describe('deprecated fields', () => {
+    test('reports status "deprecated" with migration message', () => {
+      const deprecatedSchema = z.object({
+        host: z.string(),
+        legacyMode: deprecated(z.boolean(), 'Use "mode" instead').default(
+          false
+        ),
+      });
+
+      const result = checkConfig(deprecatedSchema, {
+        host: 'localhost',
+        legacyMode: true,
+      });
+
+      const legacyDiag = result.diagnostics.find(
+        (d) => d.path === 'legacyMode'
+      );
+      expect(legacyDiag?.status).toBe('deprecated');
+      expect(legacyDiag?.message).toContain('Use "mode" instead');
+    });
+  });
+
+  describe('valid flag', () => {
+    test('returns valid: true when no missing or invalid fields', () => {
+      const result = checkConfig(schema, { host: 'localhost', port: 8080 });
+      expect(result.valid).toBe(true);
+    });
+
+    test('returns valid: false when required field is missing', () => {
+      const result = checkConfig(schema, { port: 8080 });
+      expect(result.valid).toBe(false);
+    });
+
+    test('returns valid: false when field is invalid', () => {
+      const result = checkConfig(schema, {
+        host: 'localhost',
+        port: 'bad',
+      });
+      expect(result.valid).toBe(false);
+    });
+
+    test('returns valid: true when deprecated fields are present', () => {
+      const deprecatedSchema = z.object({
+        host: z.string(),
+        legacyMode: deprecated(z.boolean(), 'Use "mode" instead').default(
+          false
+        ),
+      });
+
+      const result = checkConfig(deprecatedSchema, {
+        host: 'localhost',
+        legacyMode: true,
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('env resolution', () => {
+    test('treats env-provided value as valid', () => {
+      const envSchema = z.object({
+        host: env(z.string(), 'APP_HOST'),
+      });
+
+      const result = checkConfig(
+        envSchema,
+        {},
+        { env: { APP_HOST: 'envhost' } }
+      );
+      const hostDiag = result.diagnostics.find((d) => d.path === 'host');
+      expect(hostDiag?.status).toBe('valid');
+      expect(hostDiag?.value).toBe('envhost');
+    });
+
+    test('resolves env vars for nested schema fields', () => {
+      const nestedSchema = z.object({
+        db: z.object({
+          host: env(z.string(), 'DB_HOST'),
+          port: z.number().default(5432),
+        }),
+      });
+
+      const result = checkConfig(
+        nestedSchema,
+        { db: {} },
+        { env: { DB_HOST: 'dbhost.local' } }
+      );
+      const dbHostDiag = result.diagnostics.find((d) => d.path === 'db.host');
+      expect(dbHostDiag?.status).toBe('valid');
+      expect(dbHostDiag?.value).toBe('dbhost.local');
+    });
+  });
+});

--- a/packages/config/src/__tests__/explain.test.ts
+++ b/packages/config/src/__tests__/explain.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { env, secret } from '../extensions.js';
+import { explainConfig } from '../explain.js';
+
+const schema = z.object({
+  debug: z.boolean().default(false),
+  host: z.string().default('localhost'),
+  port: z.number().default(3000),
+});
+
+describe('explainConfig', () => {
+  describe('default source', () => {
+    test('reports "default" when no other source provides value', () => {
+      const entries = explainConfig({
+        resolved: { debug: false, host: 'localhost', port: 3000 },
+        schema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.source).toBe('default');
+      expect(host?.value).toBe('localhost');
+    });
+  });
+
+  describe('base overrides default', () => {
+    test('reports "base" when base provides value', () => {
+      const entries = explainConfig({
+        base: { host: 'base.example.com' },
+        resolved: { debug: false, host: 'base.example.com', port: 3000 },
+        schema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.source).toBe('base');
+      expect(host?.value).toBe('base.example.com');
+    });
+  });
+
+  describe('loadout overrides base', () => {
+    test('reports "loadout" when loadout provides winning value', () => {
+      const entries = explainConfig({
+        base: { host: 'base.example.com' },
+        loadout: { host: 'loadout.example.com' },
+        resolved: { debug: false, host: 'loadout.example.com', port: 3000 },
+        schema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.source).toBe('loadout');
+      expect(host?.value).toBe('loadout.example.com');
+    });
+  });
+
+  describe('local overrides loadout', () => {
+    test('reports "local" when local provides winning value', () => {
+      const entries = explainConfig({
+        base: { host: 'base.example.com' },
+        loadout: { host: 'loadout.example.com' },
+        local: { host: 'local.example.com' },
+        resolved: { debug: false, host: 'local.example.com', port: 3000 },
+        schema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.source).toBe('local');
+    });
+  });
+
+  describe('env overrides everything', () => {
+    test('reports "env" when env provides winning value', () => {
+      const envSchema = z.object({
+        host: env(z.string(), 'APP_HOST').default('localhost'),
+        port: z.number().default(3000),
+      });
+
+      const entries = explainConfig({
+        base: { host: 'base.example.com' },
+        env: { APP_HOST: 'env.example.com' },
+        resolved: { host: 'env.example.com', port: 3000 },
+        schema: envSchema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.source).toBe('env');
+      expect(host?.value).toBe('env.example.com');
+    });
+  });
+
+  describe('secret redaction', () => {
+    test('redacts secret fields', () => {
+      const secretSchema = z.object({
+        apiKey: secret(env(z.string(), 'API_KEY')),
+        host: z.string().default('localhost'),
+      });
+
+      const entries = explainConfig({
+        env: { API_KEY: 'super-secret-key' },
+        resolved: { apiKey: 'super-secret-key', host: 'localhost' },
+        schema: secretSchema,
+      });
+
+      const apiKey = entries.find((e) => e.path === 'apiKey');
+      expect(apiKey?.redacted).toBe(true);
+      expect(apiKey?.value).toBe('[REDACTED]');
+    });
+
+    test('does not redact non-secret fields', () => {
+      const entries = explainConfig({
+        resolved: { debug: false, host: 'localhost', port: 3000 },
+        schema,
+      });
+
+      const host = entries.find((e) => e.path === 'host');
+      expect(host?.redacted).toBe(false);
+    });
+  });
+});

--- a/packages/config/src/__tests__/explain.test.ts
+++ b/packages/config/src/__tests__/explain.test.ts
@@ -86,6 +86,26 @@ describe('explainConfig', () => {
       expect(host?.source).toBe('env');
       expect(host?.value).toBe('env.example.com');
     });
+
+    test('walks optional nested object schemas for env-backed entries', () => {
+      const envSchema = z.object({
+        db: z
+          .object({
+            host: env(z.string(), 'DB_HOST').default('localhost'),
+          })
+          .optional(),
+      });
+
+      const entries = explainConfig({
+        env: { DB_HOST: 'env.example.com' },
+        resolved: { db: { host: 'env.example.com' } },
+        schema: envSchema,
+      });
+
+      const host = entries.find((entry) => entry.path === 'db.host');
+      expect(host?.source).toBe('env');
+      expect(host?.value).toBe('env.example.com');
+    });
   });
 
   describe('secret redaction', () => {

--- a/packages/config/src/__tests__/extensions.test.ts
+++ b/packages/config/src/__tests__/extensions.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test';
+import { z, globalRegistry } from 'zod';
+
+import { env, secret, deprecated } from '../extensions.js';
+import type { ConfigFieldMeta } from '../extensions.js';
+import { collectConfigMeta } from '../collect.js';
+
+describe('env()', () => {
+  test('attaches env var name to schema metadata', () => {
+    const schema = env(z.string(), 'DATABASE_URL');
+    const meta = globalRegistry.get(schema) as ConfigFieldMeta | undefined;
+
+    expect(meta).toBeDefined();
+    expect(meta?.env).toBe('DATABASE_URL');
+  });
+});
+
+describe('secret()', () => {
+  test('attaches secret flag to schema metadata', () => {
+    const schema = secret(z.string());
+    const meta = globalRegistry.get(schema) as ConfigFieldMeta | undefined;
+
+    expect(meta).toBeDefined();
+    expect(meta?.secret).toBe(true);
+  });
+});
+
+describe('deprecated()', () => {
+  test('attaches deprecation message to schema metadata', () => {
+    const schema = deprecated(z.string(), 'Use NEW_VAR instead');
+    const raw = globalRegistry.get(schema) as
+      | Record<string, unknown>
+      | undefined;
+
+    expect(raw).toBeDefined();
+    // Zod 4 reserves `deprecated` as boolean, so the message is stored
+    // under `deprecationMessage` and the boolean flag is set.
+    expect(raw?.['deprecated']).toBe(true);
+    expect(raw?.['deprecationMessage']).toBe('Use NEW_VAR instead');
+  });
+});
+
+describe('wrapper ordering', () => {
+  test('metadata survives through .default() when applied BEFORE the transform', () => {
+    const schema = env(z.string(), 'HOST').default('localhost');
+    // Metadata lives on the inner type, not the wrapper
+    const innerMeta = globalRegistry.get(schema.def.innerType) as
+      | ConfigFieldMeta
+      | undefined;
+
+    expect(innerMeta).toBeDefined();
+    expect(innerMeta?.env).toBe('HOST');
+  });
+
+  test('metadata is NOT on the wrapper when applied AFTER .default()', () => {
+    // Applying env() after .default() attaches metadata to the ZodDefault wrapper,
+    // but collectConfigMeta walks .def.innerType — so the inner string has no metadata.
+    const schema = env(z.string().default('localhost'), 'HOST');
+    // The wrapper itself has the metadata
+    const wrapperMeta = globalRegistry.get(schema) as
+      | ConfigFieldMeta
+      | undefined;
+    expect(wrapperMeta?.env).toBe('HOST');
+
+    // But the inner type does NOT
+    const innerMeta = globalRegistry.get(schema.def.innerType) as
+      | ConfigFieldMeta
+      | undefined;
+    expect(innerMeta?.env).toBeUndefined();
+  });
+});
+
+describe('composition', () => {
+  test('multiple wrappers compose: secret(env()) has both env and secret', () => {
+    const schema = secret(env(z.string(), 'DB_URL'));
+    const meta = globalRegistry.get(schema) as ConfigFieldMeta | undefined;
+
+    expect(meta).toBeDefined();
+    expect(meta?.env).toBe('DB_URL');
+    expect(meta?.secret).toBe(true);
+  });
+});
+
+describe('describe() preservation', () => {
+  test('.describe() text is preserved alongside custom metadata', () => {
+    const schema = env(z.string().describe('The database host'), 'DB_HOST');
+    const meta = globalRegistry.get(schema) as
+      | Record<string, unknown>
+      | undefined;
+
+    expect(meta).toBeDefined();
+    expect(meta?.env).toBe('DB_HOST');
+    expect(meta?.description).toBe('The database host');
+  });
+});
+
+describe('collectConfigMeta()', () => {
+  test('walks an object schema and returns all field metadata', () => {
+    const schema = z.object({
+      apiKey: secret(env(z.string(), 'API_KEY')),
+      host: env(z.string(), 'HOST').default('localhost'),
+      oldVar: deprecated(z.string(), 'Use newVar instead').optional(),
+      port: env(z.number(), 'PORT'),
+    });
+
+    const meta = collectConfigMeta(schema);
+
+    expect(meta.get('host')).toEqual({ env: 'HOST' });
+    expect(meta.get('port')).toEqual({ env: 'PORT' });
+    expect(meta.get('apiKey')).toEqual({ env: 'API_KEY', secret: true });
+    expect(meta.get('oldVar')).toEqual({ deprecated: 'Use newVar instead' });
+  });
+
+  test('handles nested objects with dot-separated paths', () => {
+    const schema = z.object({
+      cache: z.object({
+        ttl: env(z.number(), 'CACHE_TTL').default(3600),
+      }),
+      db: z.object({
+        host: env(z.string(), 'DB_HOST'),
+        password: secret(env(z.string(), 'DB_PASSWORD')),
+      }),
+    });
+
+    const meta = collectConfigMeta(schema);
+
+    expect(meta.get('db.host')).toEqual({ env: 'DB_HOST' });
+    expect(meta.get('db.password')).toEqual({
+      env: 'DB_PASSWORD',
+      secret: true,
+    });
+    expect(meta.get('cache.ttl')).toEqual({ env: 'CACHE_TTL' });
+  });
+});

--- a/packages/config/src/__tests__/generate.test.ts
+++ b/packages/config/src/__tests__/generate.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { deprecated, env, secret } from '../extensions.js';
+import {
+  generateEnvExample,
+  generateExample,
+  generateJsonSchema,
+} from '../generate/index.js';
+
+/** Shared test schema used across generator tests. */
+const testSchema = z.object({
+  host: env(z.string().describe('The server hostname'), 'HOST').default(
+    'localhost'
+  ),
+  port: env(z.number().describe('The server port'), 'PORT').default(3000),
+  verbose: z.boolean().describe('Enable verbose logging').default(false),
+});
+
+/** Schema with deprecated and secret fields. */
+const annotatedSchema = z.object({
+  apiKey: secret(env(z.string().describe('API authentication key'), 'API_KEY')),
+  oldEndpoint: deprecated(
+    env(z.string().describe('Legacy API endpoint'), 'OLD_ENDPOINT'),
+    'Use newEndpoint instead'
+  ),
+});
+
+/** Schema with nested objects. */
+const nestedSchema = z.object({
+  db: z.object({
+    host: env(z.string().describe('Database host'), 'DB_HOST').default(
+      'localhost'
+    ),
+    port: env(z.number().describe('Database port'), 'DB_PORT').default(5432),
+  }),
+  server: z.object({
+    name: z.string().describe('Server name').default('app'),
+  }),
+});
+
+describe('generateExample()', () => {
+  describe('TOML format', () => {
+    test('produces valid TOML with comments for descriptions', () => {
+      const result = generateExample(testSchema, 'toml');
+
+      expect(result).toContain('# The server hostname');
+      expect(result).toContain('host = "localhost"');
+      expect(result).toContain('# The server port');
+      expect(result).toContain('port = 3000');
+      expect(result).toContain('# Enable verbose logging');
+      expect(result).toContain('verbose = false');
+    });
+
+    test('annotates deprecated fields in TOML', () => {
+      const result = generateExample(annotatedSchema, 'toml');
+
+      expect(result).toContain('# DEPRECATED: Use newEndpoint instead');
+    });
+
+    test('handles nested objects as TOML sections', () => {
+      const result = generateExample(nestedSchema, 'toml');
+
+      expect(result).toContain('[db]');
+      expect(result).toContain('[server]');
+      expect(result).toContain('host = "localhost"');
+      expect(result).toContain('port = 5432');
+    });
+  });
+
+  describe('JSON format', () => {
+    test('produces valid JSON without comments', () => {
+      const result = generateExample(testSchema, 'json');
+      const parsed = JSON.parse(result);
+
+      expect(parsed).toEqual({
+        host: 'localhost',
+        port: 3000,
+        verbose: false,
+      });
+    });
+
+    test('handles nested objects', () => {
+      const result = generateExample(nestedSchema, 'json');
+      const parsed = JSON.parse(result);
+
+      expect(parsed).toHaveProperty('db');
+      expect(parsed).toHaveProperty('server');
+      expect(parsed.db.host).toBe('localhost');
+    });
+  });
+
+  describe('JSONC format', () => {
+    test('produces JSON with // comments for descriptions', () => {
+      const result = generateExample(testSchema, 'jsonc');
+
+      expect(result).toContain('// The server hostname');
+      expect(result).toContain('"host"');
+      expect(result).toContain('"localhost"');
+    });
+
+    test('annotates deprecated fields in JSONC', () => {
+      const result = generateExample(annotatedSchema, 'jsonc');
+
+      expect(result).toContain('// DEPRECATED: Use newEndpoint instead');
+    });
+  });
+
+  describe('YAML format', () => {
+    test('produces valid YAML with comments for descriptions', () => {
+      const result = generateExample(testSchema, 'yaml');
+
+      expect(result).toContain('# The server hostname');
+      expect(result).toContain('host: "localhost"');
+      expect(result).toContain('# The server port');
+      expect(result).toContain('port: 3000');
+      expect(result).toContain('# Enable verbose logging');
+      expect(result).toContain('verbose: false');
+    });
+
+    test('annotates deprecated fields in YAML', () => {
+      const result = generateExample(annotatedSchema, 'yaml');
+
+      expect(result).toContain('# DEPRECATED: Use newEndpoint instead');
+    });
+
+    test('handles nested objects', () => {
+      const result = generateExample(nestedSchema, 'yaml');
+
+      expect(result).toContain('db:');
+      expect(result).toContain('  host: "localhost"');
+      expect(result).toContain('server:');
+    });
+  });
+});
+
+describe('generateJsonSchema()', () => {
+  test('produces valid JSON Schema with $schema, type, and properties', () => {
+    const result = generateJsonSchema(testSchema);
+
+    expect(result.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    expect(result.type).toBe('object');
+    expect(result.properties).toBeDefined();
+  });
+
+  test('includes title and description from options', () => {
+    const result = generateJsonSchema(testSchema, {
+      description: 'Server configuration',
+      title: 'ServerConfig',
+    });
+
+    expect(result.title).toBe('ServerConfig');
+    expect(result.description).toBe('Server configuration');
+  });
+
+  test('includes descriptions from .describe()', () => {
+    const result = generateJsonSchema(testSchema);
+    const props = result.properties as Record<string, Record<string, unknown>>;
+
+    expect(props['host']?.description).toBe('The server hostname');
+    expect(props['port']?.description).toBe('The server port');
+  });
+
+  test('includes defaults', () => {
+    const result = generateJsonSchema(testSchema);
+    const props = result.properties as Record<string, Record<string, unknown>>;
+
+    expect(props['host']?.default).toBe('localhost');
+    expect(props['port']?.default).toBe(3000);
+    expect(props['verbose']?.default).toBe(false);
+  });
+
+  test('maps string, number, boolean, and enum types correctly', () => {
+    const enumSchema = z.object({
+      color: z.enum(['red', 'green', 'blue']).describe('The color'),
+      count: z.number().describe('A count'),
+      enabled: z.boolean().describe('Toggle'),
+      name: z.string().describe('A name'),
+    });
+
+    const result = generateJsonSchema(enumSchema);
+    const props = result.properties as Record<string, Record<string, unknown>>;
+
+    expect(props['name']?.type).toBe('string');
+    expect(props['count']?.type).toBe('number');
+    expect(props['enabled']?.type).toBe('boolean');
+    expect(props['color']?.enum).toEqual(['red', 'green', 'blue']);
+  });
+
+  test('marks deprecated fields', () => {
+    const result = generateJsonSchema(annotatedSchema);
+    const props = result.properties as Record<string, Record<string, unknown>>;
+
+    expect(props['oldEndpoint']?.deprecated).toBe(true);
+  });
+
+  test('lists required fields (those without defaults or optional)', () => {
+    const result = generateJsonSchema(annotatedSchema);
+
+    expect(result.required).toContain('apiKey');
+    expect(result.required).toContain('oldEndpoint');
+  });
+
+  test('recurses into nested object fields', () => {
+    const result = generateJsonSchema(nestedSchema);
+    const props = result.properties as Record<string, Record<string, unknown>>;
+
+    expect(props['db']?.type).toBe('object');
+    const dbProps = props['db']?.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(dbProps['host']?.type).toBe('string');
+    expect(dbProps['host']?.description).toBe('Database host');
+    expect(dbProps['port']?.type).toBe('number');
+
+    expect(props['server']?.type).toBe('object');
+    const serverProps = props['server']?.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(serverProps['name']?.type).toBe('string');
+  });
+});
+
+describe('generateEnvExample()', () => {
+  test('lists env vars with type info', () => {
+    const result = generateEnvExample(testSchema);
+
+    expect(result).toContain('HOST=');
+    expect(result).toContain('PORT=');
+    expect(result).toContain('string');
+    expect(result).toContain('number');
+  });
+
+  test('annotates secrets', () => {
+    const result = generateEnvExample(annotatedSchema);
+
+    expect(result).toContain('API_KEY=');
+    expect(result).toContain('secret');
+  });
+
+  test('shows defaults as comments', () => {
+    const result = generateEnvExample(testSchema);
+
+    expect(result).toContain('default: "localhost"');
+    expect(result).toContain('default: 3000');
+  });
+
+  test('returns empty string when no env vars are present', () => {
+    const noEnvSchema = z.object({
+      name: z.string(),
+      verbose: z.boolean().default(false),
+    });
+
+    const result = generateEnvExample(noEnvSchema);
+
+    expect(result).toBe('');
+  });
+});

--- a/packages/config/src/__tests__/ref.test.ts
+++ b/packages/config/src/__tests__/ref.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+
+import { configRef, isConfigRef } from '../ref.js';
+
+describe('configRef', () => {
+  test('creates a marker object with __configRef flag', () => {
+    const ref = configRef('db.host');
+    expect(ref.__configRef).toBe(true);
+    expect(ref.path).toBe('db.host');
+  });
+
+  test('creates distinct refs for different paths', () => {
+    const ref1 = configRef('db.host');
+    const ref2 = configRef('db.port');
+    expect(ref1.path).not.toBe(ref2.path);
+  });
+});
+
+describe('isConfigRef', () => {
+  test('returns true for configRef markers', () => {
+    const ref = configRef('db.host');
+    expect(isConfigRef(ref)).toBe(true);
+  });
+
+  test('returns false for plain objects', () => {
+    expect(isConfigRef({ path: 'db.host' })).toBe(false);
+  });
+
+  test('returns false for non-objects', () => {
+    expect(isConfigRef('db.host')).toBe(false);
+    expect(isConfigRef(42)).toBe(false);
+    expect(isConfigRef(null)).toBe(false);
+    expect(isConfigRef()).toBe(false);
+  });
+});

--- a/packages/config/src/__tests__/resolve.test.ts
+++ b/packages/config/src/__tests__/resolve.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { env } from '../extensions.js';
+import { resolveConfig } from '../resolve.js';
+
+const baseSchema = z.object({
+  debug: z.boolean().default(false),
+  host: z.string().default('localhost'),
+  port: z.number().default(3000),
+});
+
+describe('resolveConfig', () => {
+  describe('schema defaults', () => {
+    test('applies schema defaults when no other source provides values', () => {
+      const result = resolveConfig({ schema: baseSchema });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({
+        debug: false,
+        host: 'localhost',
+        port: 3000,
+      });
+    });
+  });
+
+  describe('base config', () => {
+    test('overrides schema defaults', () => {
+      const result = resolveConfig({
+        base: { host: 'example.com', port: 8080 },
+        schema: baseSchema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.host).toBe('example.com');
+      expect(value.port).toBe(8080);
+      // Schema default preserved for unspecified fields
+      expect(value.debug).toBe(false);
+    });
+  });
+
+  describe('loadouts', () => {
+    test('overrides base config for matching loadout', () => {
+      const result = resolveConfig({
+        base: { host: 'example.com', port: 8080 },
+        loadout: 'production',
+        loadouts: {
+          production: { host: 'prod.example.com', port: 443 },
+        },
+        schema: baseSchema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.host).toBe('prod.example.com');
+      expect(value.port).toBe(443);
+      expect(value.debug).toBe(false);
+    });
+
+    test('silently ignores unrecognized loadout (base only)', () => {
+      const result = resolveConfig({
+        base: { host: 'example.com' },
+        loadout: 'staging',
+        loadouts: {
+          production: { host: 'prod.example.com' },
+        },
+        schema: baseSchema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().host).toBe('example.com');
+    });
+  });
+
+  describe('local overrides', () => {
+    test('deep-merge on top of loadout', () => {
+      const nestedSchema = z.object({
+        db: z
+          .object({
+            host: z.string().default('localhost'),
+            port: z.number().default(5432),
+          })
+          .default({}),
+      });
+
+      const result = resolveConfig({
+        base: { db: { host: 'db.example.com', port: 5432 } },
+        loadout: 'production',
+        loadouts: {
+          production: { db: { host: 'prod-db.example.com' } },
+        },
+        localOverrides: { db: { port: 9999 } },
+        schema: nestedSchema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.db.host).toBe('prod-db.example.com');
+      expect(value.db.port).toBe(9999);
+    });
+  });
+
+  describe('env var overrides', () => {
+    test('overrides all other sources', () => {
+      const schema = z.object({
+        host: env(z.string(), 'APP_HOST').default('localhost'),
+        port: env(z.number(), 'APP_PORT').default(3000),
+      });
+
+      const result = resolveConfig({
+        base: { host: 'example.com', port: 8080 },
+        env: { APP_HOST: 'env-host.example.com', APP_PORT: '9090' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.host).toBe('env-host.example.com');
+      expect(value.port).toBe(9090);
+    });
+
+    test('coerces string to number', () => {
+      const schema = z.object({
+        port: env(z.number(), 'PORT').default(3000),
+      });
+
+      const result = resolveConfig({
+        env: { PORT: '8080' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().port).toBe(8080);
+    });
+
+    test('coerces string to boolean', () => {
+      const schema = z.object({
+        debug: env(z.boolean(), 'DEBUG').default(false),
+        verbose: env(z.boolean(), 'VERBOSE').default(false),
+      });
+
+      const trueValues = resolveConfig({
+        env: { DEBUG: 'true', VERBOSE: '1' },
+        schema,
+      });
+      expect(trueValues.isOk()).toBe(true);
+      expect(trueValues.unwrap().debug).toBe(true);
+      expect(trueValues.unwrap().verbose).toBe(true);
+
+      const falseValues = resolveConfig({
+        env: { DEBUG: 'false', VERBOSE: '0' },
+        schema,
+      });
+      expect(falseValues.isOk()).toBe(true);
+      expect(falseValues.unwrap().debug).toBe(false);
+      expect(falseValues.unwrap().verbose).toBe(false);
+    });
+  });
+
+  describe('validation', () => {
+    test('missing required field returns Result.err', () => {
+      const schema = z.object({
+        required: z.string(),
+      });
+
+      const result = resolveConfig({ schema });
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('mutation safety', () => {
+    test('repeated resolve() calls do not mutate the original base', () => {
+      const schema = z.object({
+        host: env(z.string(), 'APP_HOST').default('localhost'),
+      });
+      const base = { host: 'dev-host' };
+
+      const first = resolveConfig({
+        base,
+        env: { APP_HOST: 'env-host' },
+        schema,
+      });
+      expect(first.isOk()).toBe(true);
+      expect(first.unwrap().host).toBe('env-host');
+
+      const second = resolveConfig({ base, schema });
+      expect(second.isOk()).toBe(true);
+      expect(second.unwrap().host).toBe('dev-host');
+      expect(base.host).toBe('dev-host');
+    });
+  });
+
+  describe('full stack', () => {
+    test('all 5 sources compose correctly', () => {
+      const schema = z.object({
+        apiUrl: env(z.string(), 'API_URL').default('http://localhost'),
+        debug: env(z.boolean(), 'DEBUG').default(false),
+        local: z.string().default('default-local'),
+        name: z.string().default('app'),
+        port: z.number().default(3000),
+      });
+
+      const result = resolveConfig({
+        // base overrides name
+        base: { name: 'my-app', port: 8080 },
+        // env overrides debug and apiUrl
+        env: { API_URL: 'https://api.prod.com', DEBUG: 'true' },
+        // loadout overrides port
+        loadout: 'production',
+        loadouts: { production: { port: 443 } },
+        // local overrides local
+        localOverrides: { local: 'my-local-value' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      // Schema default
+      // (nothing left at just default — name was overridden by base)
+      // Base
+      expect(value.name).toBe('my-app');
+      // Loadout overrides base port
+      expect(value.port).toBe(443);
+      // Local overrides
+      expect(value.local).toBe('my-local-value');
+      // Env overrides
+      expect(value.apiUrl).toBe('https://api.prod.com');
+      expect(value.debug).toBe(true);
+    });
+  });
+});

--- a/packages/config/src/__tests__/workspace.test.ts
+++ b/packages/config/src/__tests__/workspace.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test, beforeEach } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
-import { mkdtemp, readdir, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
 import { ensureWorkspace } from '../workspace.js';
@@ -10,6 +10,10 @@ describe('ensureWorkspace', () => {
 
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), 'trails-ws-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, { force: true, recursive: true });
   });
 
   describe('directory creation', () => {
@@ -41,6 +45,7 @@ describe('ensureWorkspace', () => {
       );
       expect(content).toContain('config/');
       expect(content).toContain('dev/');
+      expect(content).toContain('generated/');
     });
 
     test('does not overwrite existing .gitignore', async () => {

--- a/packages/config/src/__tests__/workspace.test.ts
+++ b/packages/config/src/__tests__/workspace.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { join } from 'node:path';
+import { mkdtemp, readdir, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+import { ensureWorkspace } from '../workspace.js';
+
+describe('ensureWorkspace', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'trails-ws-'));
+  });
+
+  describe('directory creation', () => {
+    test('creates .trails/ directory', async () => {
+      await ensureWorkspace(root);
+      const entries = await readdir(join(root, '.trails'));
+      expect(entries).toContain('config');
+      expect(entries).toContain('dev');
+      expect(entries).toContain('generated');
+    });
+
+    test('creates all expected subdirectories', async () => {
+      await ensureWorkspace(root);
+      const config = await readdir(join(root, '.trails', 'config'));
+      expect(config).toBeDefined();
+      const dev = await readdir(join(root, '.trails', 'dev'));
+      expect(dev).toBeDefined();
+      const generated = await readdir(join(root, '.trails', 'generated'));
+      expect(generated).toBeDefined();
+    });
+  });
+
+  describe('.gitignore', () => {
+    test('writes .gitignore on first run', async () => {
+      await ensureWorkspace(root);
+      const content = await readFile(
+        join(root, '.trails', '.gitignore'),
+        'utf8'
+      );
+      expect(content).toContain('config/');
+      expect(content).toContain('dev/');
+    });
+
+    test('does not overwrite existing .gitignore', async () => {
+      await ensureWorkspace(root);
+      const customContent = '# custom\n*\n';
+      await Bun.write(join(root, '.trails', '.gitignore'), customContent);
+
+      await ensureWorkspace(root);
+      const content = await readFile(
+        join(root, '.trails', '.gitignore'),
+        'utf8'
+      );
+      expect(content).toBe(customContent);
+    });
+  });
+});

--- a/packages/config/src/app-config.ts
+++ b/packages/config/src/app-config.ts
@@ -89,7 +89,64 @@ const configFileName = (
 const fileExists = (filePath: string): Promise<boolean> =>
   Bun.file(filePath).exists();
 
-/** Read and parse a config file using Bun's native import. */
+/** Known config suffixes, ordered to avoid `.json` matching `.jsonc`. */
+const FORMAT_SUFFIXES: readonly [ConfigFormat, `.${string}`][] = [
+  ['jsonc', '.jsonc'],
+  ['json', '.json'],
+  ['toml', '.toml'],
+  ['yaml', '.yaml'],
+];
+
+/** Detect the declared config format from a file path. */
+const detectFormat = (filePath: string): ConfigFormat | undefined => {
+  for (const [format, suffix] of FORMAT_SUFFIXES) {
+    if (filePath.endsWith(suffix)) {
+      return format;
+    }
+  }
+  return undefined;
+};
+
+/** Parse config file text with Bun's native format parsers. */
+const parseConfigText = (
+  filePath: string,
+  text: string
+): Result<unknown, Error> => {
+  const format = detectFormat(filePath);
+
+  try {
+    switch (format) {
+      case 'json': {
+        return Result.ok(JSON.parse(text));
+      }
+      case 'jsonc': {
+        return Result.ok(Bun.JSONC.parse(text));
+      }
+      case 'toml': {
+        return Result.ok(Bun.TOML.parse(text));
+      }
+      case 'yaml': {
+        return Result.ok(Bun.YAML.parse(text));
+      }
+      default: {
+        return Result.err(
+          new ValidationError(`Unsupported config file format: ${filePath}`, {
+            context: { path: filePath },
+          })
+        );
+      }
+    }
+  } catch (error) {
+    return Result.err(
+      new ValidationError(`Failed to parse config file: ${filePath}`, {
+        cause: error instanceof Error ? error : new Error(String(error)),
+        context: { path: filePath },
+      })
+    );
+  }
+};
+
+/** Read and parse a config file, always reflecting the latest on-disk content. */
 const readConfigFile = async (
   filePath: string
 ): Promise<Result<unknown, Error>> => {
@@ -102,18 +159,8 @@ const readConfigFile = async (
     );
   }
 
-  try {
-    // Bun natively imports TOML, JSON, JSONC, and YAML — result has `.default`
-    const mod: Record<string, unknown> = await import(filePath);
-    return Result.ok(mod['default'] ?? mod);
-  } catch (error) {
-    return Result.err(
-      new ValidationError(`Failed to parse config file: ${filePath}`, {
-        cause: error instanceof Error ? error : new Error(String(error)),
-        context: { path: filePath },
-      })
-    );
-  }
+  const text = await Bun.file(filePath).text();
+  return parseConfigText(filePath, text);
 };
 
 /** Validate parsed data against a Zod schema. */

--- a/packages/config/src/app-config.ts
+++ b/packages/config/src/app-config.ts
@@ -1,0 +1,260 @@
+/**
+ * App config factory — declare a config contract once, discover and validate at runtime.
+ */
+
+import { dirname, join } from 'node:path';
+
+import { NotFoundError, Result, ValidationError } from '@ontrails/core';
+import type { z } from 'zod';
+
+import type { CheckResult } from './doctor.js';
+import { checkConfig } from './doctor.js';
+import type { FieldDescription } from './describe.js';
+import { describeConfig } from './describe.js';
+import type { ExplainConfigOptions, ProvenanceEntry } from './explain.js';
+import { explainConfig } from './explain.js';
+import type { ConfigRef } from './ref.js';
+import { configRef } from './ref.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Supported config file formats. */
+export type ConfigFormat = 'toml' | 'json' | 'jsonc' | 'yaml';
+
+/** Options for creating an app config. */
+export interface AppConfigOptions<T extends z.ZodType> {
+  readonly schema: T;
+  readonly formats?: readonly ConfigFormat[];
+  readonly dotfile?: boolean;
+}
+
+/** Options for resolving (discovering + parsing) a config file. */
+export interface ResolveOptions {
+  /** Working directory for discovery. Defaults to `process.cwd()`. */
+  readonly cwd?: string;
+  /** Explicit file path — skips discovery when provided. */
+  readonly path?: string;
+}
+
+/** Options for the `explain()` method on AppConfig, excluding schema. */
+export type AppConfigExplainOptions = Omit<
+  ExplainConfigOptions<z.ZodType>,
+  'schema'
+>;
+
+/** The resolved config contract returned by `appConfig()`. */
+export interface AppConfig<T extends z.ZodType> {
+  readonly name: string;
+  readonly schema: T;
+  readonly formats: readonly ConfigFormat[];
+  readonly dotfile: boolean;
+  resolve(options?: ResolveOptions): Promise<Result<z.infer<T>, Error>>;
+
+  /** Describe all fields in the schema without needing values. */
+  describe(): readonly FieldDescription[];
+
+  /** Check a config object against the schema and return diagnostics. */
+  check(
+    values: Record<string, unknown>,
+    options?: { readonly env?: Record<string, string | undefined> }
+  ): CheckResult;
+
+  /** Show which source won for each config field. */
+  explain(options: AppConfigExplainOptions): readonly ProvenanceEntry[];
+
+  /** Create a lazy reference to a config field for use as a trail input default. */
+  ref(fieldPath: string): ConfigRef;
+}
+
+// ---------------------------------------------------------------------------
+// Default values
+// ---------------------------------------------------------------------------
+
+const DEFAULT_FORMATS: readonly ConfigFormat[] = ['toml', 'json', 'yaml'];
+
+// ---------------------------------------------------------------------------
+// Internal helpers (defined before consumers — no-use-before-define)
+// ---------------------------------------------------------------------------
+
+/** Build the config filename for a given format. */
+const configFileName = (
+  name: string,
+  format: ConfigFormat,
+  dotfile: boolean
+): string => (dotfile ? `.${name}rc.${format}` : `${name}.config.${format}`);
+
+/** Check whether a file exists at the given path. */
+const fileExists = (filePath: string): Promise<boolean> =>
+  Bun.file(filePath).exists();
+
+/** Read and parse a config file using Bun's native import. */
+const readConfigFile = async (
+  filePath: string
+): Promise<Result<unknown, Error>> => {
+  const exists = await fileExists(filePath);
+  if (!exists) {
+    return Result.err(
+      new NotFoundError(`Config file not found: ${filePath}`, {
+        context: { path: filePath },
+      })
+    );
+  }
+
+  try {
+    // Bun natively imports TOML, JSON, JSONC, and YAML — result has `.default`
+    const mod: Record<string, unknown> = await import(filePath);
+    return Result.ok(mod['default'] ?? mod);
+  } catch (error) {
+    return Result.err(
+      new ValidationError(`Failed to parse config file: ${filePath}`, {
+        cause: error instanceof Error ? error : new Error(String(error)),
+        context: { path: filePath },
+      })
+    );
+  }
+};
+
+/** Validate parsed data against a Zod schema. */
+const validateConfig = <T extends z.ZodType>(
+  schema: T,
+  data: unknown,
+  filePath: string
+): Result<z.infer<T>, Error> => {
+  const parsed = schema.safeParse(data);
+  if (parsed.success) {
+    return Result.ok(parsed.data as z.infer<T>);
+  }
+  return Result.err(
+    new ValidationError(`Config validation failed: ${filePath}`, {
+      context: {
+        issues: parsed.error.issues,
+        path: filePath,
+      },
+    })
+  );
+};
+
+/** Check all format candidates in a single directory. */
+const findInDir = async (
+  dir: string,
+  name: string,
+  formats: readonly ConfigFormat[],
+  dotfile: boolean
+): Promise<string | undefined> => {
+  for (const format of formats) {
+    const candidate = join(dir, configFileName(name, format, dotfile));
+    if (await fileExists(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+};
+
+/** Walk up from `startDir` looking for any matching config filename. */
+const discoverConfigFile = async (
+  name: string,
+  formats: readonly ConfigFormat[],
+  dotfile: boolean,
+  startDir: string
+): Promise<string | undefined> => {
+  let dir = startDir;
+
+  for (let depth = 0; depth < 64; depth += 1) {
+    const found = await findInDir(dir, name, formats, dotfile);
+    if (found !== undefined) {
+      return found;
+    }
+    const parent = dirname(dir);
+    // Reached filesystem root
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+
+  return undefined;
+};
+
+/** Resolve a config file — either from an explicit path or via discovery. */
+const resolveConfig = async <T extends z.ZodType>(
+  name: string,
+  schema: T,
+  formats: readonly ConfigFormat[],
+  dotfile: boolean,
+  options?: ResolveOptions
+): Promise<Result<z.infer<T>, Error>> => {
+  const filePath =
+    options?.path ??
+    (await discoverConfigFile(
+      name,
+      formats,
+      dotfile,
+      options?.cwd ?? process.cwd()
+    ));
+
+  if (filePath === undefined) {
+    return Result.err(
+      new NotFoundError(`No config file found for "${name}"`, {
+        context: { dotfile, formats: [...formats], name },
+      })
+    );
+  }
+
+  const readResult = await readConfigFile(filePath);
+  if (readResult.isErr()) {
+    return readResult;
+  }
+
+  return validateConfig(schema, readResult.value, filePath);
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Declare a config contract for an app.
+ *
+ * The returned `AppConfig` exposes `resolve()` to discover, parse, and validate
+ * a config file matching the app name and format conventions.
+ *
+ * @example
+ * ```ts
+ * const config = appConfig('myapp', {
+ *   schema: z.object({
+ *     output: z.string().default('./output'),
+ *     verbose: z.boolean().default(false),
+ *   }),
+ * });
+ *
+ * const result = await config.resolve();
+ * if (result.isOk()) console.log(result.value.output);
+ * ```
+ */
+export const appConfig = <T extends z.ZodType>(
+  name: string,
+  options: AppConfigOptions<T>
+): AppConfig<T> => {
+  const formats = options.formats ?? DEFAULT_FORMATS;
+  const dotfile = options.dotfile ?? false;
+
+  const { schema } = options;
+
+  return {
+    check: (values, checkOpts) => checkConfig(schema, values, checkOpts),
+    describe: () =>
+      describeConfig(
+        schema as unknown as z.ZodObject<Record<string, z.ZodType>>
+      ),
+    dotfile,
+    explain: (explainOpts) => explainConfig({ ...explainOpts, schema }),
+    formats,
+    name,
+    ref: (fieldPath) => configRef(fieldPath),
+    resolve: (resolveOptions?: ResolveOptions) =>
+      resolveConfig(name, schema, formats, dotfile, resolveOptions),
+    schema,
+  };
+};

--- a/packages/config/src/collect.ts
+++ b/packages/config/src/collect.ts
@@ -1,0 +1,110 @@
+import { globalRegistry } from 'zod';
+import type { z } from 'zod';
+
+import type { ConfigFieldMeta } from './extensions.js';
+import { isZodObject } from './zod-utils.js';
+
+/** Config meta keys we look for in Zod registry entries. */
+const META_EXTRACTORS: readonly {
+  test: (raw: Record<string, unknown>) => boolean;
+  extract: (raw: Record<string, unknown>) => Partial<ConfigFieldMeta>;
+}[] = [
+  {
+    extract: (r) => ({ env: r['env'] as string }),
+    test: (r) => typeof r['env'] === 'string',
+  },
+  {
+    extract: () => ({ secret: true }),
+    test: (r) => r['secret'] === true,
+  },
+  {
+    extract: (r) => ({ deprecated: r['deprecationMessage'] as string }),
+    test: (r) => typeof r['deprecationMessage'] === 'string',
+  },
+];
+
+/**
+ * Pick only `ConfigFieldMeta` keys from a raw registry entry.
+ * Uses a lookup table to stay under the max-statements limit.
+ */
+const pickConfigMeta = (
+  raw: Record<string, unknown> | undefined
+): ConfigFieldMeta | undefined => {
+  if (!raw) {return undefined;}
+
+  const parts = META_EXTRACTORS.filter((e) => e.test(raw)).map((e) =>
+    e.extract(raw)
+  );
+  return parts.length > 0
+    ? (Object.assign({}, ...parts) as ConfigFieldMeta)
+    : undefined;
+};
+
+/**
+ * Extract `ConfigFieldMeta` from a schema, unwrapping through
+ * `.default()`, `.optional()`, `.nullable()` wrappers as needed.
+ */
+const extractConfigMeta = (schema: z.ZodType): ConfigFieldMeta | undefined => {
+  let current: z.ZodType | undefined = schema;
+
+  while (current) {
+    const meta = pickConfigMeta(globalRegistry.get(current));
+    if (meta) {return meta;}
+
+    const def = current.def as unknown as Record<string, unknown>;
+    current = def['innerType'] as z.ZodType | undefined;
+  }
+
+  return undefined;
+};
+
+/** Entry in the iterative work queue for schema walking. */
+interface WalkEntry {
+  readonly schema: z.ZodObject<Record<string, z.ZodType>>;
+  readonly prefix: string;
+}
+
+/** Process one level of an object schema, queuing nested objects. */
+const walkObjectShape = (
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  prefix: string,
+  result: Map<string, ConfigFieldMeta>,
+  queue: WalkEntry[]
+): void => {
+  const shape = schema.shape as Record<string, z.ZodType>;
+
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    if (isZodObject(fieldSchema)) {
+      queue.push({
+        prefix: path,
+        schema: fieldSchema as z.ZodObject<Record<string, z.ZodType>>,
+      });
+    } else {
+      const meta = extractConfigMeta(fieldSchema);
+      if (meta) {result.set(path, meta);}
+    }
+  }
+};
+
+/**
+ * Walk a Zod object schema and collect `ConfigFieldMeta` for each field.
+ *
+ * Handles unwrapping `.default()`, `.optional()`, `.nullable()` wrappers
+ * that don't carry inner metadata forward. Recurses into nested `ZodObject`
+ * fields using dot-separated paths.
+ */
+export const collectConfigMeta = (
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  prefix = ''
+): Map<string, ConfigFieldMeta> => {
+  const result = new Map<string, ConfigFieldMeta>();
+  const queue: WalkEntry[] = [{ prefix, schema }];
+
+  for (let entry = queue.pop(); entry; entry = queue.pop()) {
+    walkObjectShape(entry.schema, entry.prefix, result, queue);
+  }
+
+  return result;
+};

--- a/packages/config/src/collect.ts
+++ b/packages/config/src/collect.ts
@@ -2,7 +2,7 @@ import { globalRegistry } from 'zod';
 import type { z } from 'zod';
 
 import type { ConfigFieldMeta } from './extensions.js';
-import { isZodObject } from './zod-utils.js';
+import { isZodObject, unwrapToBase } from './zod-utils.js';
 
 /** Config meta keys we look for in Zod registry entries. */
 const META_EXTRACTORS: readonly {
@@ -83,7 +83,9 @@ const walkObjectShape = (
     if (isZodObject(fieldSchema)) {
       queue.push({
         prefix: path,
-        schema: fieldSchema as z.ZodObject<Record<string, z.ZodType>>,
+        schema: unwrapToBase(fieldSchema) as z.ZodObject<
+          Record<string, z.ZodType>
+        >,
       });
     } else {
       const meta = extractConfigMeta(fieldSchema);

--- a/packages/config/src/collect.ts
+++ b/packages/config/src/collect.ts
@@ -30,7 +30,9 @@ const META_EXTRACTORS: readonly {
 const pickConfigMeta = (
   raw: Record<string, unknown> | undefined
 ): ConfigFieldMeta | undefined => {
-  if (!raw) {return undefined;}
+  if (!raw) {
+    return undefined;
+  }
 
   const parts = META_EXTRACTORS.filter((e) => e.test(raw)).map((e) =>
     e.extract(raw)
@@ -49,7 +51,9 @@ const extractConfigMeta = (schema: z.ZodType): ConfigFieldMeta | undefined => {
 
   while (current) {
     const meta = pickConfigMeta(globalRegistry.get(current));
-    if (meta) {return meta;}
+    if (meta) {
+      return meta;
+    }
 
     const def = current.def as unknown as Record<string, unknown>;
     current = def['innerType'] as z.ZodType | undefined;
@@ -83,7 +87,9 @@ const walkObjectShape = (
       });
     } else {
       const meta = extractConfigMeta(fieldSchema);
-      if (meta) {result.set(path, meta);}
+      if (meta) {
+        result.set(path, meta);
+      }
     }
   }
 };

--- a/packages/config/src/compose.ts
+++ b/packages/config/src/compose.ts
@@ -1,0 +1,46 @@
+/**
+ * Config composition utilities for services.
+ *
+ * Collects config schemas from service declarations so they can be
+ * composed into a unified config structure via `defineConfig`.
+ */
+
+import type { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A service config schema entry extracted from a service declaration. */
+export interface ServiceConfigEntry {
+  readonly serviceId: string;
+  readonly schema: z.ZodType;
+}
+
+/** Minimal shape needed to extract config from a service-like object. */
+interface ServiceWithOptionalConfig {
+  readonly id: string;
+  readonly config?: z.ZodType | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect config schemas from services that declare them.
+ *
+ * Returns entries keyed by service ID for composition into `defineConfig`.
+ * Services without a `config` schema are excluded.
+ */
+export const collectServiceConfigs = (
+  services: readonly ServiceWithOptionalConfig[]
+): ServiceConfigEntry[] =>
+  services
+    .filter(
+      (
+        svc
+      ): svc is ServiceWithOptionalConfig & { readonly config: z.ZodType } =>
+        svc.config !== undefined
+    )
+    .map((svc) => ({ schema: svc.config, serviceId: svc.id }));

--- a/packages/config/src/config-layer.ts
+++ b/packages/config/src/config-layer.ts
@@ -1,0 +1,15 @@
+/**
+ * Config layer — attaches resolved config to the execution context.
+ *
+ * For v1, the layer is a pass-through: config resolution happens at
+ * bootstrap time and the service pipeline (TRL-91) injects the resolved
+ * config before any trail runs. The layer reserves a named slot so
+ * future versions can add per-trail config overrides or validation.
+ */
+import type { Layer } from '@ontrails/core';
+
+export const configLayer: Layer = {
+  description: 'Ensures resolved config is available in the execution context',
+  name: 'config',
+  wrap: (_trail, impl) => (input, ctx) => impl(input, ctx),
+};

--- a/packages/config/src/config-service.ts
+++ b/packages/config/src/config-service.ts
@@ -1,0 +1,32 @@
+/**
+ * Config service — manages resolved config lifecycle.
+ *
+ * The config is resolved during bootstrap (two-phase init per ADR-010)
+ * and registered via `registerConfigState`. This service reads from the
+ * global registry so trails can access it through `configService.from(ctx)`.
+ */
+import { InternalError, Result, service } from '@ontrails/core';
+import { z } from 'zod';
+
+import type { ConfigState } from './registry.js';
+import { getConfigState } from './registry.js';
+
+export const configService = service<ConfigState>('config', {
+  create: () => {
+    const state = getConfigState();
+    if (state === undefined) {
+      return Result.err(
+        new InternalError(
+          'Config state not registered — call registerConfigState at bootstrap'
+        )
+      );
+    }
+    return Result.ok(state);
+  },
+  description: 'Resolved application configuration',
+  metadata: { category: 'infrastructure' },
+  mock: (): ConfigState => ({
+    resolved: {},
+    schema: z.object({}),
+  }),
+});

--- a/packages/config/src/define-config.ts
+++ b/packages/config/src/define-config.ts
@@ -103,8 +103,9 @@ export const defineConfig = <T extends z.ZodType>(
     base: options.base,
     loadouts: options.loadouts,
     resolve: async (resolveOpts?: DefineConfigResolveOptions) => {
-      const envRecord =
-        resolveOpts?.env ?? (process.env as Record<string, string | undefined>);
+      const envRecord = {
+        ...(resolveOpts?.env ?? process.env),
+      } as Record<string, string | undefined>;
 
       if (
         options.envFromNodeEnv &&

--- a/packages/config/src/define-config.ts
+++ b/packages/config/src/define-config.ts
@@ -1,0 +1,133 @@
+/**
+ * Trails-specific config wrapper — `appConfig('trails', ...)` with
+ * framework conventions for loadout selection and local overrides.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { z } from 'zod';
+
+import { appConfig } from './app-config.js';
+import { resolveConfig } from './resolve.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for defining a Trails app config. */
+export interface DefineConfigOptions<T extends z.ZodType> {
+  readonly schema: T;
+  readonly base?: Partial<z.infer<T>>;
+  readonly loadouts?: Record<string, Partial<z.infer<T>>>;
+  /** When true, fall back to `NODE_ENV` when `TRAILS_ENV` is unset. */
+  readonly envFromNodeEnv?: boolean;
+}
+
+/** Options passed to `resolve()` on a defined config. */
+interface DefineConfigResolveOptions {
+  readonly loadout?: string;
+  readonly env?: Record<string, string | undefined>;
+  /** Working directory for local overrides discovery. Defaults to `process.cwd()`. */
+  readonly cwd?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Local overrides discovery
+// ---------------------------------------------------------------------------
+
+const LOCAL_OVERRIDE_CANDIDATES = ['local.ts', 'local.js'] as const;
+
+/**
+ * Discover and synchronously import a `.trails/config/local.{ts,js}` file.
+ *
+ * Skipped when `TRAILS_ENV=test` for hermetic test environments.
+ */
+const discoverLocalOverrides = async (
+  cwd: string,
+  envRecord: Record<string, string | undefined>
+): Promise<Record<string, unknown> | undefined> => {
+  if (envRecord['TRAILS_ENV'] === 'test') {
+    return undefined;
+  }
+
+  for (const filename of LOCAL_OVERRIDE_CANDIDATES) {
+    const candidate = join(cwd, '.trails', 'config', filename);
+    if (existsSync(candidate)) {
+      const mod: Record<string, unknown> = await import(candidate);
+      return (mod['default'] ?? mod) as Record<string, unknown>;
+    }
+  }
+
+  return undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Define Trails app config.
+ *
+ * This is `appConfig('trails', ...)` with the framework's own conventions:
+ * `TRAILS_ENV` selects the loadout. When `envFromNodeEnv` is true,
+ * `NODE_ENV` is used as a fallback when `TRAILS_ENV` is unset.
+ *
+ * @example
+ * ```ts
+ * const config = defineConfig({
+ *   schema: z.object({
+ *     port: z.number().default(3000),
+ *     debug: z.boolean().default(false),
+ *   }),
+ *   base: { port: 8080 },
+ *   loadouts: {
+ *     production: { debug: false },
+ *     test: { debug: true, port: 0 },
+ *   },
+ * });
+ *
+ * const result = config.resolve();
+ * ```
+ */
+export const defineConfig = <T extends z.ZodType>(
+  options: DefineConfigOptions<T>
+) => {
+  const config = appConfig('trails', {
+    formats: ['toml', 'json'],
+    schema: options.schema,
+  });
+
+  return {
+    ...config,
+    base: options.base,
+    loadouts: options.loadouts,
+    resolve: async (resolveOpts?: DefineConfigResolveOptions) => {
+      const envRecord =
+        resolveOpts?.env ?? (process.env as Record<string, string | undefined>);
+
+      if (
+        options.envFromNodeEnv &&
+        envRecord['TRAILS_ENV'] === undefined &&
+        envRecord['NODE_ENV'] !== undefined
+      ) {
+        envRecord['TRAILS_ENV'] = envRecord['NODE_ENV'];
+      }
+
+      const cwd = resolveOpts?.cwd ?? process.cwd();
+      const localOverrides = await discoverLocalOverrides(cwd, envRecord);
+
+      return resolveConfig({
+        base: options.base as Record<string, unknown> | undefined,
+        env: envRecord,
+        loadout: resolveOpts?.loadout ?? envRecord['TRAILS_ENV'],
+        loadouts: options.loadouts as
+          | Record<string, Record<string, unknown>>
+          | undefined,
+        localOverrides,
+        schema: options.schema,
+      });
+    },
+    schema: options.schema,
+  };
+};

--- a/packages/config/src/describe.ts
+++ b/packages/config/src/describe.ts
@@ -1,0 +1,252 @@
+/**
+ * Config introspection — describe all fields in a schema without values.
+ *
+ * Returns a structured catalog suitable for CLI rendering or agent inspection.
+ */
+
+import { globalRegistry } from 'zod';
+import type { z } from 'zod';
+
+import { collectConfigMeta } from './collect.js';
+import { isZodObject, zodDef } from './zod-utils.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Description of a single config field. */
+export interface FieldDescription {
+  readonly path: string;
+  readonly type: string;
+  readonly description?: string;
+  readonly default?: unknown;
+  readonly required: boolean;
+  readonly env?: string;
+  readonly secret?: boolean;
+  readonly deprecated?: string;
+  readonly constraints?: Record<string, unknown>;
+}
+
+/** Accumulated state while unwrapping Zod wrappers. */
+interface UnwrapState {
+  hasDefault: boolean;
+  defaultValue: unknown;
+  isOptional: boolean;
+}
+
+/** Unwrap result carrying both base schema and accumulated metadata. */
+interface UnwrapResult {
+  readonly base: z.ZodType;
+  readonly hasDefault: boolean;
+  readonly defaultValue: unknown;
+  readonly isOptional: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before consumers — satisfies no-use-before-define)
+// ---------------------------------------------------------------------------
+
+/** Read the description from the Zod global registry. */
+const getDescription = (schema: z.ZodType): string | undefined => {
+  const meta = globalRegistry.get(schema);
+  return meta?.description as string | undefined;
+};
+
+/** Handle a single unwrap step; returns updated inner type and state, or null to stop. */
+const unwrapStep = (
+  def: Record<string, unknown>,
+  state: UnwrapState
+): { inner: z.ZodType; state: UnwrapState } | null => {
+  const typeName = def['type'] as string;
+
+  if (typeName === 'default') {
+    return {
+      inner: def['innerType'] as z.ZodType,
+      state: { ...state, defaultValue: def['defaultValue'], hasDefault: true },
+    };
+  }
+
+  if (typeName === 'optional') {
+    return {
+      inner: def['innerType'] as z.ZodType,
+      state: { ...state, isOptional: true },
+    };
+  }
+
+  if (typeName === 'nullable') {
+    return { inner: def['innerType'] as z.ZodType, state };
+  }
+
+  return null;
+};
+
+/** Unwrap through default/optional/nullable wrappers to find the base type. */
+const unwrapSchema = (schema: z.ZodType): UnwrapResult => {
+  let current = schema;
+  let state: UnwrapState = {
+    defaultValue: undefined,
+    hasDefault: false,
+    isOptional: false,
+  };
+
+  for (let depth = 0; depth < 10; depth += 1) {
+    const result = unwrapStep(zodDef(current), state);
+    if (!result) {
+      break;
+    }
+    current = result.inner;
+    ({ state } = result);
+  }
+
+  return { base: current, ...state };
+};
+
+/** Resolve the user-facing type name from a base Zod schema. */
+const resolveTypeName = (schema: z.ZodType): string => {
+  const typeName = zodDef(schema)['type'] as string;
+  const typeMap: Record<string, string> = {
+    boolean: 'boolean',
+    enum: 'enum',
+    number: 'number',
+    string: 'string',
+  };
+  return typeMap[typeName] ?? typeName;
+};
+
+/** Extract enum values from an enum def. */
+const extractEnumConstraints = (
+  def: Record<string, unknown>
+): Record<string, unknown> | undefined => {
+  const entries = def['entries'] as Record<string, string> | undefined;
+  if (!entries) {
+    return undefined;
+  }
+  return { values: Object.values(entries) };
+};
+
+/** Extract min/max from a number schema's properties. */
+const extractNumberConstraints = (
+  schema: z.ZodType
+): Record<string, unknown> | undefined => {
+  const result: Record<string, unknown> = {};
+  const numSchema = schema as unknown as {
+    minValue?: number;
+    maxValue?: number;
+  };
+
+  if (numSchema.minValue !== undefined && numSchema.minValue !== null) {
+    result['min'] = numSchema.minValue;
+  }
+  if (numSchema.maxValue !== undefined && numSchema.maxValue !== null) {
+    result['max'] = numSchema.maxValue;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+};
+
+/** Extract constraints from a base schema (min, max, enum values). */
+const extractConstraints = (
+  schema: z.ZodType
+): Record<string, unknown> | undefined => {
+  const def = zodDef(schema);
+  const typeName = def['type'] as string;
+
+  if (typeName === 'enum') {
+    return extractEnumConstraints(def);
+  }
+  if (typeName === 'number') {
+    return extractNumberConstraints(schema);
+  }
+  return undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Schema walking
+// ---------------------------------------------------------------------------
+
+/** Entry for iterative schema walk. */
+interface WalkEntry {
+  readonly schema: z.ZodType;
+  readonly prefix: string;
+}
+
+/** Build a single FieldDescription from a leaf schema and its metadata. */
+const buildFieldDescription = (
+  path: string,
+  fieldSchema: z.ZodType,
+  configMeta: Map<
+    string,
+    { env?: string; secret?: boolean; deprecated?: string }
+  >
+): FieldDescription => {
+  const { base, defaultValue, hasDefault, isOptional } =
+    unwrapSchema(fieldSchema);
+  const meta = configMeta.get(path);
+  const description = getDescription(base) ?? getDescription(fieldSchema);
+  const constraints = extractConstraints(base);
+
+  return {
+    ...(constraints ? { constraints } : {}),
+    ...(hasDefault ? { default: defaultValue } : {}),
+    ...(meta?.deprecated ? { deprecated: meta.deprecated } : {}),
+    ...(description ? { description } : {}),
+    ...(meta?.env ? { env: meta.env } : {}),
+    path,
+    required: !hasDefault && !isOptional,
+    ...(meta?.secret ? { secret: meta.secret } : {}),
+    type: resolveTypeName(base),
+  };
+};
+
+/** Walk one level of an object shape, collecting leaves and queuing nested objects. */
+const walkShapeLevel = (
+  shape: Record<string, z.ZodType>,
+  prefix: string,
+  configMeta: Map<
+    string,
+    { env?: string; secret?: boolean; deprecated?: string }
+  >,
+  results: FieldDescription[],
+  queue: WalkEntry[]
+): void => {
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (isZodObject(fieldSchema)) {
+      queue.push({ prefix: path, schema: fieldSchema });
+    } else {
+      results.push(buildFieldDescription(path, fieldSchema, configMeta));
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Describe all fields in a schema without needing a config file.
+ *
+ * Returns a structured catalog suitable for CLI rendering or agent inspection.
+ */
+export const describeConfig = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): readonly FieldDescription[] => {
+  const configMeta = collectConfigMeta(schema);
+  const queue: WalkEntry[] = [];
+  const results: FieldDescription[] = [];
+
+  walkShapeLevel(
+    schema.shape as Record<string, z.ZodType>,
+    '',
+    configMeta,
+    results,
+    queue
+  );
+
+  for (let entry = queue.pop(); entry; entry = queue.pop()) {
+    const nested = zodDef(entry.schema)['shape'] as Record<string, z.ZodType>;
+    walkShapeLevel(nested, entry.prefix, configMeta, results, queue);
+  }
+
+  return results;
+};

--- a/packages/config/src/describe.ts
+++ b/packages/config/src/describe.ts
@@ -8,7 +8,7 @@ import { globalRegistry } from 'zod';
 import type { z } from 'zod';
 
 import { collectConfigMeta } from './collect.js';
-import { isZodObject, zodDef } from './zod-utils.js';
+import { isZodObject, unwrapToBase, zodDef } from './zod-utils.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -212,7 +212,7 @@ const walkShapeLevel = (
   for (const [key, fieldSchema] of Object.entries(shape)) {
     const path = prefix ? `${prefix}.${key}` : key;
     if (isZodObject(fieldSchema)) {
-      queue.push({ prefix: path, schema: fieldSchema });
+      queue.push({ prefix: path, schema: unwrapToBase(fieldSchema) });
     } else {
       results.push(buildFieldDescription(path, fieldSchema, configMeta));
     }

--- a/packages/config/src/doctor.ts
+++ b/packages/config/src/doctor.ts
@@ -7,7 +7,7 @@
 import type { z } from 'zod';
 
 import { collectConfigMeta } from './collect.js';
-import { getAtPath, isZodObject, zodDef } from './zod-utils.js';
+import { getAtPath, isZodObject, unwrapToBase, zodDef } from './zod-utils.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -165,7 +165,7 @@ const walkShape = (
   for (const [key, fieldSchema] of Object.entries(shape)) {
     const path = prefix ? `${prefix}.${key}` : key;
     if (isZodObject(fieldSchema)) {
-      queue.push({ path, schema: fieldSchema });
+      queue.push({ path, schema: unwrapToBase(fieldSchema) });
     } else {
       leaves.push({ path, schema: fieldSchema });
     }

--- a/packages/config/src/doctor.ts
+++ b/packages/config/src/doctor.ts
@@ -1,0 +1,219 @@
+/**
+ * Config doctor — structured diagnostics for a config object against a schema.
+ *
+ * Reports which fields are valid, missing, using defaults, deprecated, or invalid.
+ */
+
+import type { z } from 'zod';
+
+import { collectConfigMeta } from './collect.js';
+import { getAtPath, isZodObject, zodDef } from './zod-utils.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Diagnostic status for a single config field. */
+export interface ConfigDiagnostic {
+  readonly path: string;
+  readonly status: 'valid' | 'missing' | 'invalid' | 'deprecated' | 'default';
+  readonly message: string;
+  readonly value?: unknown;
+}
+
+/** Aggregated result from checking config against a schema. */
+export interface CheckResult {
+  readonly diagnostics: readonly ConfigDiagnostic[];
+  readonly valid: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before consumers)
+// ---------------------------------------------------------------------------
+
+/** Check if a schema wraps a ZodDefault. */
+const isDefaultWrapper = (schema: z.ZodType): boolean =>
+  zodDef(schema)['type'] === 'default';
+
+/** Check if a schema wraps a ZodOptional. */
+const isOptionalWrapper = (schema: z.ZodType): boolean =>
+  zodDef(schema)['type'] === 'optional';
+
+/** Get the default value from a ZodDefault wrapper. */
+const getDefaultValue = (schema: z.ZodType): unknown =>
+  zodDef(schema)['defaultValue'];
+
+/** Set a value at a dot-separated path, creating intermediate objects. */
+const setAtPath = (
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown
+): void => {
+  const parts = path.split('.');
+  let current: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const part = parts[i] as string;
+    const next = current[part];
+    const nested =
+      typeof next === 'object' && next !== null
+        ? (next as Record<string, unknown>)
+        : {};
+    current[part] = nested;
+    current = nested;
+  }
+  const lastPart = parts.at(-1) as string;
+  current[lastPart] = value;
+};
+
+/** Build values object with env overrides applied. */
+const applyEnvToValues = (
+  values: Record<string, unknown>,
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  envVars: Record<string, string | undefined>
+): Record<string, unknown> => {
+  const meta = collectConfigMeta(schema);
+  const result = structuredClone(values) as Record<string, unknown>;
+  for (const [path, fieldMeta] of meta) {
+    if (fieldMeta.env && envVars[fieldMeta.env] !== undefined) {
+      setAtPath(result, path, envVars[fieldMeta.env]);
+    }
+  }
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// Schema walking
+// ---------------------------------------------------------------------------
+
+/** Entry for the iterative schema walk queue. */
+interface WalkEntry {
+  readonly schema: z.ZodType;
+  readonly path: string;
+}
+
+/** Validate a single field value against its schema. */
+const validateFieldValue = (
+  path: string,
+  fieldSchema: z.ZodType,
+  value: unknown
+): ConfigDiagnostic => {
+  const result = fieldSchema.safeParse(value);
+  if (result.success) {
+    return { message: 'OK', path, status: 'valid', value };
+  }
+  const issue = result.error?.issues?.[0];
+  const msg = issue ? issue.message : 'Invalid value';
+  return { message: msg, path, status: 'invalid', value };
+};
+
+/** Classify a single field and produce a diagnostic. */
+const classifyField = (
+  path: string,
+  fieldSchema: z.ZodType,
+  values: Record<string, unknown>,
+  deprecatedMeta: Map<string, string>
+): ConfigDiagnostic => {
+  const value = getAtPath(values, path);
+  const deprecationMsg = deprecatedMeta.get(path);
+
+  if (deprecationMsg && value !== undefined) {
+    return { message: deprecationMsg, path, status: 'deprecated', value };
+  }
+
+  if (value === undefined && isDefaultWrapper(fieldSchema)) {
+    return {
+      message: 'Using default value',
+      path,
+      status: 'default',
+      value: getDefaultValue(fieldSchema),
+    };
+  }
+
+  if (value === undefined && !isOptionalWrapper(fieldSchema)) {
+    return {
+      message: `Required field "${path}" is missing`,
+      path,
+      status: 'missing',
+    };
+  }
+
+  return validateFieldValue(path, fieldSchema, value);
+};
+
+/** Collect deprecated metadata paths from config meta. */
+const collectDeprecatedPaths = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): Map<string, string> => {
+  const meta = collectConfigMeta(schema);
+  const result = new Map<string, string>();
+  for (const [path, fieldMeta] of meta) {
+    if (fieldMeta.deprecated) {
+      result.set(path, fieldMeta.deprecated);
+    }
+  }
+  return result;
+};
+
+/** Walk an object shape and enqueue leaf fields or nested objects. */
+const walkShape = (
+  schema: z.ZodType,
+  prefix: string,
+  queue: WalkEntry[],
+  leaves: WalkEntry[]
+): void => {
+  const shape = zodDef(schema)['shape'] as Record<string, z.ZodType>;
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (isZodObject(fieldSchema)) {
+      queue.push({ path, schema: fieldSchema });
+    } else {
+      leaves.push({ path, schema: fieldSchema });
+    }
+  }
+};
+
+/** Collect all leaf fields from a schema, walking nested objects iteratively. */
+const collectLeaves = (schema: z.ZodType): WalkEntry[] => {
+  const queue: WalkEntry[] = [];
+  const leaves: WalkEntry[] = [];
+  walkShape(schema, '', queue, leaves);
+
+  for (let entry = queue.pop(); entry; entry = queue.pop()) {
+    walkShape(entry.schema, entry.path, queue, leaves);
+  }
+
+  return leaves;
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check a config object against a schema and return structured diagnostics.
+ *
+ * Reports which fields are valid, missing, using defaults, deprecated, or invalid.
+ */
+export const checkConfig = <T extends z.ZodType>(
+  schema: T,
+  values: Record<string, unknown>,
+  options?: { readonly env?: Record<string, string | undefined> }
+): CheckResult => {
+  const objSchema = schema as unknown as z.ZodObject<Record<string, z.ZodType>>;
+  const effectiveValues = options?.env
+    ? applyEnvToValues(values, objSchema, options.env)
+    : values;
+
+  const deprecatedMeta = collectDeprecatedPaths(objSchema);
+  const leaves = collectLeaves(objSchema);
+
+  const diagnostics = leaves.map((leaf) =>
+    classifyField(leaf.path, leaf.schema, effectiveValues, deprecatedMeta)
+  );
+
+  const valid = diagnostics.every(
+    (d) => d.status !== 'missing' && d.status !== 'invalid'
+  );
+
+  return { diagnostics, valid };
+};

--- a/packages/config/src/explain.ts
+++ b/packages/config/src/explain.ts
@@ -8,7 +8,7 @@ import type { z } from 'zod';
 
 import { collectConfigMeta } from './collect.js';
 import { isLikelySecret } from './secret-heuristics.js';
-import { getAtPath, isZodObject, zodDef } from './zod-utils.js';
+import { getAtPath, isZodObject, unwrapToBase, zodDef } from './zod-utils.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -115,7 +115,7 @@ const collectLeafPaths = (schema: z.ZodType, prefix: string): string[] => {
     for (const [key, fieldSchema] of Object.entries(shape)) {
       const path = entry.prefix ? `${entry.prefix}.${key}` : key;
       if (isZodObject(fieldSchema)) {
-        queue.push({ prefix: path, schema: fieldSchema });
+        queue.push({ prefix: path, schema: unwrapToBase(fieldSchema) });
       } else {
         paths.push(path);
       }

--- a/packages/config/src/explain.ts
+++ b/packages/config/src/explain.ts
@@ -1,0 +1,176 @@
+/**
+ * Config provenance — show which source won for each config field.
+ *
+ * Used for debugging: answers "where did this value come from?"
+ */
+
+import type { z } from 'zod';
+
+import { collectConfigMeta } from './collect.js';
+import { isLikelySecret } from './secret-heuristics.js';
+import { getAtPath, isZodObject, zodDef } from './zod-utils.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Provenance entry describing the source of a resolved config value. */
+export interface ProvenanceEntry {
+  readonly path: string;
+  readonly value: unknown;
+  readonly source: 'default' | 'base' | 'loadout' | 'local' | 'env';
+  readonly redacted: boolean;
+}
+
+/** Options for explaining config provenance. */
+export interface ExplainConfigOptions<T extends z.ZodType> {
+  readonly schema: T;
+  readonly base?: Record<string, unknown>;
+  readonly loadout?: Record<string, unknown>;
+  readonly local?: Record<string, unknown>;
+  readonly env?: Record<string, string | undefined>;
+  readonly resolved: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before consumers)
+// ---------------------------------------------------------------------------
+
+/** Build a map of path → env var name from config metadata. */
+const buildEnvMap = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): Map<string, string> => {
+  const meta = collectConfigMeta(schema);
+  const result = new Map<string, string>();
+  for (const [path, fieldMeta] of meta) {
+    if (fieldMeta.env) {
+      result.set(path, fieldMeta.env);
+    }
+  }
+  return result;
+};
+
+/** Build a set of paths marked as secret from config metadata. */
+const buildSecretSet = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): Set<string> => {
+  const meta = collectConfigMeta(schema);
+  const result = new Set<string>();
+  for (const [path, fieldMeta] of meta) {
+    if (fieldMeta.secret) {
+      result.add(path);
+    }
+  }
+  return result;
+};
+
+/** Source layers in reverse precedence order for winner detection. */
+type SourceLayer = readonly [
+  name: ProvenanceEntry['source'],
+  values: Record<string, unknown> | undefined,
+];
+
+/** Determine which source provided the winning value for a given path. */
+const determineSource = (
+  path: string,
+  resolved: Record<string, unknown>,
+  layers: readonly SourceLayer[],
+  envMap: Map<string, string>,
+  envVars: Record<string, string | undefined> | undefined
+): ProvenanceEntry['source'] => {
+  if (envVars && envMap.has(path)) {
+    const envVar = envMap.get(path);
+    if (envVar && envVars[envVar] !== undefined) {
+      return 'env';
+    }
+  }
+
+  const resolvedValue = getAtPath(resolved, path);
+  for (const [name, values] of layers) {
+    if (values && getAtPath(values, path) === resolvedValue) {
+      return name;
+    }
+  }
+
+  return 'default';
+};
+
+// ---------------------------------------------------------------------------
+// Schema walking
+// ---------------------------------------------------------------------------
+
+/** Entry for iterative schema walk. */
+interface WalkEntry {
+  readonly schema: z.ZodType;
+  readonly prefix: string;
+}
+
+/** Collect all leaf field paths from an object schema. */
+const collectLeafPaths = (schema: z.ZodType, prefix: string): string[] => {
+  const paths: string[] = [];
+  const queue: WalkEntry[] = [{ prefix, schema }];
+
+  for (let entry = queue.pop(); entry; entry = queue.pop()) {
+    const shape = zodDef(entry.schema)['shape'] as Record<string, z.ZodType>;
+    for (const [key, fieldSchema] of Object.entries(shape)) {
+      const path = entry.prefix ? `${entry.prefix}.${key}` : key;
+      if (isZodObject(fieldSchema)) {
+        queue.push({ prefix: path, schema: fieldSchema });
+      } else {
+        paths.push(path);
+      }
+    }
+  }
+
+  return paths;
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Show which source won for each config field.
+ *
+ * Used for debugging — answers "where did this value come from?"
+ *
+ */
+export const explainConfig = <T extends z.ZodType>(
+  options: ExplainConfigOptions<T>
+): readonly ProvenanceEntry[] => {
+  const objSchema = options.schema as unknown as z.ZodObject<
+    Record<string, z.ZodType>
+  >;
+  const envMap = buildEnvMap(objSchema);
+  const secretSet = buildSecretSet(objSchema);
+
+  const layers: readonly SourceLayer[] = [
+    ['local', options.local],
+    ['loadout', options.loadout],
+    ['base', options.base],
+  ];
+
+  const paths = collectLeafPaths(objSchema, '');
+
+  return paths.map((path) => {
+    const source = determineSource(
+      path,
+      options.resolved,
+      layers,
+      envMap,
+      options.env
+    );
+    const envVarName = envMap.get(path);
+    const isSecret =
+      secretSet.has(path) ||
+      (envVarName !== undefined && isLikelySecret(envVarName));
+    const rawValue = getAtPath(options.resolved, path);
+
+    return {
+      path,
+      redacted: isSecret,
+      source,
+      value: isSecret ? '[REDACTED]' : rawValue,
+    };
+  });
+};

--- a/packages/config/src/extensions.ts
+++ b/packages/config/src/extensions.ts
@@ -1,0 +1,51 @@
+import type { z } from 'zod';
+
+/** Metadata shape stored on Zod schemas via `.meta()`. */
+export interface ConfigFieldMeta {
+  readonly env?: string;
+  readonly secret?: boolean;
+  readonly deprecated?: string;
+}
+
+/**
+ * Bind a schema field to an environment variable.
+ *
+ * Must be called BEFORE `.default()`, `.optional()`, or other transforms
+ * so that the metadata lives on the inner type where `collectConfigMeta`
+ * can find it by unwrapping wrappers.
+ */
+export const env = <T extends z.ZodType>(schema: T, varName: string): T =>
+  schema.meta({ ...schema.meta(), env: varName }) as T;
+
+/**
+ * Mark a schema field as sensitive. Redacted in survey, explain, and logs.
+ *
+ * Must be called BEFORE `.default()`, `.optional()`, or other transforms.
+ */
+export const secret = <T extends z.ZodType>(schema: T): T =>
+  schema.meta({ ...schema.meta(), secret: true }) as T;
+
+/**
+ * Mark a schema field as deprecated with migration guidance.
+ *
+ * Stores **two** meta keys: `deprecated: true` and `deprecationMessage: string`.
+ * This indirection exists because Zod 4's `GlobalMeta` types `deprecated` as
+ * `boolean | undefined` — there is no way to attach a migration message to the
+ * standard key. We set `deprecated: true` so Zod-native tooling (schema
+ * serializers, OpenAPI generators) recognises the field as deprecated, and store
+ * the human-readable message under `deprecationMessage` for our own
+ * `collectConfigMeta` / survey / explain surfaces.
+ *
+ * Must be called BEFORE `.default()`, `.optional()`, or other transforms
+ * so that the metadata lives on the inner type where `collectConfigMeta`
+ * can find it by unwrapping wrappers.
+ */
+export const deprecated = <T extends z.ZodType>(
+  schema: T,
+  message: string
+): T =>
+  schema.meta({
+    ...schema.meta(),
+    deprecated: true,
+    deprecationMessage: message,
+  }) as T;

--- a/packages/config/src/generate/env.ts
+++ b/packages/config/src/generate/env.ts
@@ -1,0 +1,104 @@
+/**
+ * `.env.example` file generation from Zod schema `env()` bindings.
+ *
+ * Lists each env var with its type, default, and whether it is a secret.
+ * Returns an empty string when no env bindings are present.
+ */
+import type { z } from 'zod';
+
+import { collectConfigMeta } from '../collect.js';
+import type { ConfigFieldMeta } from '../extensions.js';
+
+import { isLikelySecret } from '../secret-heuristics.js';
+
+import {
+  formatValue,
+  getDefault,
+  getDescription,
+  resolveFieldByPath,
+  unwrap,
+  zodTypeName,
+  zodTypeToJsonSchema,
+} from './helpers.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Map Zod type names to human-readable type labels. */
+const typeLabel = (schema: z.ZodType): string => {
+  const typeName = zodTypeName(unwrap(schema));
+  return zodTypeToJsonSchema[typeName] ?? typeName;
+};
+
+/** Build the type annotation comment for an env entry. */
+const envTypeAnnotation = (
+  fieldSchema: z.ZodType,
+  meta: ConfigFieldMeta
+): string => {
+  const parts = [`type: ${typeLabel(fieldSchema)}`];
+  const info = getDefault(fieldSchema);
+  if (info.has) {
+    parts.push(`default: ${formatValue(info.value)}`);
+  }
+  if (meta.secret) {
+    parts.push('secret');
+  }
+  return `# ${parts.join(', ')}`;
+};
+
+/** Format a single env var entry. */
+const envEntry = (
+  envVar: string,
+  fieldSchema: z.ZodType,
+  meta: ConfigFieldMeta
+): readonly string[] => {
+  const effectiveMeta =
+    !meta.secret && isLikelySecret(envVar) ? { ...meta, secret: true } : meta;
+
+  const lines: string[] = [];
+  const desc = getDescription(fieldSchema);
+  if (desc) {
+    lines.push(`# ${desc}`);
+  }
+  lines.push(envTypeAnnotation(fieldSchema, effectiveMeta));
+  lines.push(`${envVar}=`);
+  return lines;
+};
+
+/** Collect env entries from config metadata. */
+const collectEnvEntries = (
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  meta: Map<string, ConfigFieldMeta>
+): readonly string[] => {
+  const entries: string[] = [];
+  for (const [path, fieldMeta] of meta) {
+    if (!fieldMeta.env) {
+      continue;
+    }
+    const fieldSchema = resolveFieldByPath(schema, path);
+    if (!fieldSchema) {
+      continue;
+    }
+    entries.push(...envEntry(fieldMeta.env, fieldSchema, fieldMeta));
+    entries.push('');
+  }
+  return entries;
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a `.env.example` file from `env()` bindings in the schema.
+ *
+ * Lists each env var with its type, default, and whether it is a secret.
+ * Returns an empty string when no env bindings are present.
+ */
+export const generateEnvExample = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): string => {
+  const entries = collectEnvEntries(schema, collectConfigMeta(schema));
+  return entries.length === 0 ? '' : entries.join('\n');
+};

--- a/packages/config/src/generate/example.ts
+++ b/packages/config/src/generate/example.ts
@@ -1,0 +1,206 @@
+/**
+ * Config example file generation in multiple formats.
+ *
+ * Produces TOML, JSON, JSONC, and YAML example files from a Zod schema,
+ * with defaults shown and deprecated fields annotated.
+ */
+import type { z } from 'zod';
+
+import {
+  fieldComments,
+  fieldValue,
+  formatValue,
+  getObjectShape,
+  isObjectType,
+  pushComments,
+  unwrap,
+} from './helpers.js';
+
+// ---------------------------------------------------------------------------
+// TOML generation
+// ---------------------------------------------------------------------------
+
+/** Render a flat set of fields as TOML key = value lines. */
+const renderTomlFields = (
+  shape: Record<string, z.ZodType>,
+  lines: string[]
+): void => {
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    if (isObjectType(fieldSchema)) {
+      continue;
+    }
+    pushComments(lines, fieldComments(fieldSchema, '#'), '');
+    lines.push(`${key} = ${formatValue(fieldValue(fieldSchema))}`);
+  }
+};
+
+/** Render nested objects as TOML sections, recursing with dotted prefixes. */
+const renderTomlSections = (
+  shape: Record<string, z.ZodType>,
+  lines: string[],
+  prefix = ''
+): void => {
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    const nested = isObjectType(fieldSchema)
+      ? getObjectShape(fieldSchema)
+      : undefined;
+    if (!nested) {
+      continue;
+    }
+    const sectionKey = prefix ? `${prefix}.${key}` : key;
+    if (lines.length > 0) {
+      lines.push('');
+    }
+    lines.push(`[${sectionKey}]`);
+    renderTomlFields(nested, lines);
+    // oxlint-disable-next-line max-statements -- recursive TOML section rendering
+    renderTomlSections(nested, lines, sectionKey);
+  }
+};
+
+const formatToml = (schema: z.ZodObject<Record<string, z.ZodType>>): string => {
+  const shape = schema.shape as Record<string, z.ZodType>;
+  const lines: string[] = [];
+  renderTomlFields(shape, lines);
+  renderTomlSections(shape, lines);
+  return `${lines.join('\n')}\n`;
+};
+
+// ---------------------------------------------------------------------------
+// JSON / JSONC generation
+// ---------------------------------------------------------------------------
+
+/** Resolve a field to its nested object or its scalar value. */
+const resolveJsonField = (
+  fieldSchema: z.ZodType,
+  recurse: (
+    s: z.ZodObject<Record<string, z.ZodType>>
+  ) => Record<string, unknown>
+): unknown => {
+  if (!isObjectType(fieldSchema)) {
+    return fieldValue(fieldSchema);
+  }
+  const nested = getObjectShape(fieldSchema);
+  if (!nested) {
+    return fieldValue(fieldSchema);
+  }
+  const inner = unwrap(fieldSchema) as z.ZodObject<Record<string, z.ZodType>>;
+  return recurse(inner);
+};
+
+/** Build a plain object with default/placeholder values for JSON output. */
+const buildJsonObject = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): Record<string, unknown> => {
+  const shape = schema.shape as Record<string, z.ZodType>;
+  const obj: Record<string, unknown> = {};
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    obj[key] = resolveJsonField(fieldSchema, buildJsonObject);
+  }
+  return obj;
+};
+
+const formatJson = (schema: z.ZodObject<Record<string, z.ZodType>>): string =>
+  `${JSON.stringify(buildJsonObject(schema), null, 2)}\n`;
+
+/** Render a single JSONC entry (comments + key: value). */
+const renderJsoncEntry = (
+  key: string,
+  fieldSchema: z.ZodType,
+  isLast: boolean,
+  lines: string[]
+): void => {
+  pushComments(lines, fieldComments(fieldSchema, '//'), '  ');
+  const val = formatValue(fieldValue(fieldSchema));
+  const comma = isLast ? '' : ',';
+  lines.push(`  "${key}": ${val}${comma}`);
+};
+
+const formatJsonc = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): string => {
+  const keys = Object.keys(schema.shape);
+  const shape = schema.shape as Record<string, z.ZodType>;
+  const lines: string[] = ['{'];
+
+  for (let i = 0; i < keys.length; i += 1) {
+    const key = keys[i] as string;
+    renderJsoncEntry(
+      key,
+      shape[key] as z.ZodType,
+      i === keys.length - 1,
+      lines
+    );
+  }
+
+  lines.push('}');
+  return `${lines.join('\n')}\n`;
+};
+
+// ---------------------------------------------------------------------------
+// YAML generation
+// ---------------------------------------------------------------------------
+
+/** Render a single YAML scalar field. */
+const renderYamlScalar = (
+  key: string,
+  fieldSchema: z.ZodType,
+  indent: string,
+  lines: string[]
+): void => {
+  pushComments(lines, fieldComments(fieldSchema, '#'), indent);
+  lines.push(`${indent}${key}: ${formatValue(fieldValue(fieldSchema))}`);
+};
+
+/** Render YAML fields at a given indent level. */
+const renderYamlFields = (
+  shape: Record<string, z.ZodType>,
+  indent: string,
+  lines: string[]
+): void => {
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    if (isObjectType(fieldSchema)) {
+      const nested = getObjectShape(fieldSchema);
+      if (!nested) {
+        continue;
+      }
+      lines.push(`${indent}${key}:`);
+      renderYamlFields(nested, `${indent}  `, lines);
+    } else {
+      renderYamlScalar(key, fieldSchema, indent, lines);
+    }
+  }
+};
+
+const formatYaml = (schema: z.ZodObject<Record<string, z.ZodType>>): string => {
+  const shape = schema.shape as Record<string, z.ZodType>;
+  const lines: string[] = [];
+  renderYamlFields(shape, '', lines);
+  return `${lines.join('\n')}\n`;
+};
+
+// ---------------------------------------------------------------------------
+// Format dispatch
+// ---------------------------------------------------------------------------
+
+type ExampleFormat = 'json' | 'jsonc' | 'toml' | 'yaml';
+
+const formatters: Record<
+  ExampleFormat,
+  (schema: z.ZodObject<Record<string, z.ZodType>>) => string
+> = {
+  json: formatJson,
+  jsonc: formatJsonc,
+  toml: formatToml,
+  yaml: formatYaml,
+};
+
+/**
+ * Generate an example config file in the specified format.
+ *
+ * Includes descriptions as comments, defaults shown, deprecated fields annotated.
+ */
+export const generateExample = (
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  format: ExampleFormat
+): string => formatters[format](schema);

--- a/packages/config/src/generate/helpers.ts
+++ b/packages/config/src/generate/helpers.ts
@@ -1,0 +1,158 @@
+import { globalRegistry } from 'zod';
+import type { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Schema introspection helpers
+// ---------------------------------------------------------------------------
+
+/** Unwrap `.default()`, `.optional()`, `.nullable()` to reach the inner type. */
+export const unwrap = (schema: z.ZodType): z.ZodType => {
+  let current = schema;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (true) {
+    const def = current.def as unknown as Record<string, unknown>;
+    const inner = def['innerType'] as z.ZodType | undefined;
+    if (!inner) {
+      return current;
+    }
+    current = inner;
+  }
+};
+
+/** Read the Zod type discriminant from a schema's def. */
+export const zodTypeName = (schema: z.ZodType): string => {
+  const def = schema.def as unknown as Record<string, unknown>;
+  return (def['type'] as string) ?? 'unknown';
+};
+
+/** Walk the registry up through wrappers to find a metadata key. */
+export const walkRegistryKey = (
+  schema: z.ZodType,
+  key: string
+): unknown | undefined => {
+  let current: z.ZodType | undefined = schema;
+  while (current) {
+    const meta = globalRegistry.get(current) as
+      | Record<string, unknown>
+      | undefined;
+    if (meta?.[key] !== undefined) {
+      return meta[key];
+    }
+    const def = current.def as unknown as Record<string, unknown>;
+    current = def['innerType'] as z.ZodType | undefined;
+  }
+  return undefined;
+};
+
+/** Get the description from the global registry for a schema or its inner type. */
+export const getDescription = (schema: z.ZodType): string | undefined =>
+  walkRegistryKey(schema, 'description') as string | undefined;
+
+/** Get the deprecation message from the config meta for a field. */
+export const getDeprecation = (schema: z.ZodType): string | undefined =>
+  walkRegistryKey(schema, 'deprecationMessage') as string | undefined;
+
+/** Get the default value from a schema if it has one. */
+export const getDefault = (
+  schema: z.ZodType
+): { has: false } | { has: true; value: unknown } => {
+  const def = schema.def as unknown as Record<string, unknown>;
+  if (def['type'] === 'default') {
+    return { has: true, value: def['defaultValue'] };
+  }
+  return { has: false };
+};
+
+/** Check whether a schema (or its inner type) is a ZodObject. */
+export const isObjectType = (schema: z.ZodType): boolean => {
+  const inner = unwrap(schema);
+  const def = inner.def as unknown as Record<string, unknown>;
+  return def['type'] === 'object' && 'shape' in def;
+};
+
+/** Get the shape of a ZodObject, unwrapping wrappers first. */
+export const getObjectShape = (
+  schema: z.ZodType
+): Record<string, z.ZodType> | undefined => {
+  const inner = unwrap(schema);
+  const def = inner.def as unknown as Record<string, unknown>;
+  if (def['type'] !== 'object' || !('shape' in def)) {
+    return undefined;
+  }
+  return (inner as z.ZodObject<Record<string, z.ZodType>>).shape as Record<
+    string,
+    z.ZodType
+  >;
+};
+
+/** Resolve a dot-separated path to the field schema within an object. */
+export const resolveFieldByPath = (
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  path: string
+): z.ZodType | undefined => {
+  const parts = path.split('.');
+  let current: z.ZodType = schema;
+
+  for (const part of parts) {
+    const shape = getObjectShape(current);
+    if (!shape?.[part]) {
+      return undefined;
+    }
+    current = shape[part];
+  }
+
+  return current;
+};
+
+// ---------------------------------------------------------------------------
+// Value formatting helpers
+// ---------------------------------------------------------------------------
+
+/** Format a value as a quoted string or literal. */
+export const formatValue = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+  return String(value);
+};
+
+/** Get the display value for a field (default or empty placeholder). */
+export const fieldValue = (schema: z.ZodType): unknown => {
+  const info = getDefault(schema);
+  return info.has ? info.value : '';
+};
+
+/** Collect comment lines for a field (description + deprecation). */
+export const fieldComments = (
+  schema: z.ZodType,
+  prefix: string
+): readonly string[] => {
+  const lines: string[] = [];
+  const desc = getDescription(schema);
+  if (desc) {
+    lines.push(`${prefix} ${desc}`);
+  }
+  const dep = getDeprecation(schema);
+  if (dep) {
+    lines.push(`${prefix} DEPRECATED: ${dep}`);
+  }
+  return lines;
+};
+
+/** Append comment lines to an output array. */
+export const pushComments = (
+  lines: string[],
+  comments: readonly string[],
+  indent: string
+): void => {
+  for (const c of comments) {
+    lines.push(`${indent}${c}`);
+  }
+};
+
+/** Map a Zod type name to a JSON Schema type. */
+export const zodTypeToJsonSchema: Record<string, string> = {
+  boolean: 'boolean',
+  number: 'number',
+  string: 'string',
+};

--- a/packages/config/src/generate/index.ts
+++ b/packages/config/src/generate/index.ts
@@ -1,0 +1,3 @@
+export { generateEnvExample } from './env.js';
+export { generateExample } from './example.js';
+export { generateJsonSchema } from './json-schema.js';

--- a/packages/config/src/generate/json-schema.ts
+++ b/packages/config/src/generate/json-schema.ts
@@ -1,0 +1,137 @@
+/**
+ * JSON Schema generation from Zod object schemas.
+ *
+ * Produces JSON Schema Draft 2020-12 with descriptions, defaults,
+ * deprecated annotations, and constraints.
+ */
+import type { z } from 'zod';
+
+import {
+  getDefault,
+  getDeprecation,
+  getDescription,
+  getObjectShape,
+  isObjectType,
+  unwrap,
+  zodTypeName,
+  zodTypeToJsonSchema,
+} from './helpers.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the JSON Schema type or enum from a Zod schema. */
+const jsonSchemaType = (inner: z.ZodType): Record<string, unknown> => {
+  const typeName = zodTypeName(inner);
+  if (typeName === 'enum') {
+    const def = inner.def as unknown as Record<string, unknown>;
+    const entries = def['entries'] as Record<string, string> | undefined;
+    return entries ? { enum: Object.keys(entries) } : {};
+  }
+  const mapped = zodTypeToJsonSchema[typeName];
+  return mapped ? { type: mapped } : {};
+};
+
+/** Annotation extractors for JSON Schema properties. */
+const annotationExtractors: readonly ((
+  s: z.ZodType
+) => Record<string, unknown>)[] = [
+  (s) => {
+    const desc = getDescription(s);
+    return desc ? { description: desc } : {};
+  },
+  (s) => {
+    const info = getDefault(s);
+    return info.has ? { default: info.value } : {};
+  },
+  (s) => {
+    const dep = getDeprecation(s);
+    return dep ? { deprecated: true } : {};
+  },
+];
+
+/** Extract annotations (description, default, deprecated) for JSON Schema. */
+const jsonSchemaAnnotations = (
+  fieldSchema: z.ZodType
+): Record<string, unknown> =>
+  Object.assign({}, ...annotationExtractors.map((fn) => fn(fieldSchema)));
+
+/** Check if a field is required (no default and not optional). */
+const isRequired = (fieldSchema: z.ZodType): boolean => {
+  const def = fieldSchema.def as unknown as Record<string, unknown>;
+  return def['type'] !== 'default' && def['type'] !== 'optional';
+};
+
+/** Convert a single Zod field schema to a JSON Schema property. */
+const fieldToJsonSchema = (fieldSchema: z.ZodType): Record<string, unknown> => {
+  if (isObjectType(fieldSchema)) {
+    const nestedShape = getObjectShape(fieldSchema);
+    if (nestedShape) {
+      // oxlint-disable-next-line no-use-before-define -- mutual recursion with buildSchemaProperties
+      const { properties, required } = buildSchemaProperties(nestedShape);
+      return {
+        properties,
+        type: 'object',
+        ...(required.length > 0 ? { required } : {}),
+        ...jsonSchemaAnnotations(fieldSchema),
+      };
+    }
+  }
+  return {
+    ...jsonSchemaType(unwrap(fieldSchema)),
+    ...jsonSchemaAnnotations(fieldSchema),
+  };
+};
+
+/** Build properties and required arrays from a schema shape. */
+const buildSchemaProperties = (
+  shape: Record<string, z.ZodType>
+): {
+  properties: Record<string, Record<string, unknown>>;
+  required: readonly string[];
+} => {
+  const properties: Record<string, Record<string, unknown>> = {};
+  const required: string[] = [];
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    properties[key] = fieldToJsonSchema(fieldSchema);
+    if (isRequired(fieldSchema)) {
+      required.push(key);
+    }
+  }
+  return { properties, required };
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a JSON Schema from a Zod object schema.
+ *
+ * Includes descriptions, defaults, deprecated annotations, and constraints.
+ * Produces JSON Schema Draft 2020-12.
+ */
+export const generateJsonSchema = (
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  options?: { readonly description?: string; readonly title?: string }
+): Record<string, unknown> => {
+  const { properties, required } = buildSchemaProperties(
+    schema.shape as Record<string, z.ZodType>
+  );
+  const result: Record<string, unknown> = {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    properties,
+    type: 'object',
+  };
+  if (options?.title) {
+    result['title'] = options.title;
+  }
+  if (options?.description) {
+    result['description'] = options.description;
+  }
+  if (required.length > 0) {
+    result['required'] = required;
+  }
+  return result;
+};

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,4 @@
-// Placeholder — exports land in subsequent PRs.
-export type { ConfigPlaceholder as _ConfigPlaceholder } from './types.js';
+export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
+export { collectConfigMeta } from './collect.js';
 export { configCheck } from './trails/config-check.js';
 export { configDescribe } from './trails/config-describe.js';

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,6 +7,7 @@ export {
   type ResolveOptions,
 } from './app-config.js';
 export { collectConfigMeta } from './collect.js';
+export { collectServiceConfigs, type ServiceConfigEntry } from './compose.js';
 export { defineConfig, type DefineConfigOptions } from './define-config.js';
 export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
 export {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -9,7 +9,18 @@ export {
 export { collectConfigMeta } from './collect.js';
 export { collectServiceConfigs, type ServiceConfigEntry } from './compose.js';
 export { defineConfig, type DefineConfigOptions } from './define-config.js';
+export { describeConfig, type FieldDescription } from './describe.js';
+export {
+  checkConfig,
+  type CheckResult,
+  type ConfigDiagnostic,
+} from './doctor.js';
 export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
+export {
+  explainConfig,
+  type ExplainConfigOptions,
+  type ProvenanceEntry,
+} from './explain.js';
 export {
   generateEnvExample,
   generateExample,
@@ -22,6 +33,7 @@ export {
   registerConfigState,
 } from './registry.js';
 export { deepMerge } from './merge.js';
+export { configRef, isConfigRef, type ConfigRef } from './ref.js';
 export { resolveConfig, type ResolveConfigOptions } from './resolve.js';
 export { configCheck } from './trails/config-check.js';
 export { configDescribe } from './trails/config-describe.js';

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,11 @@
+export {
+  appConfig,
+  type AppConfig,
+  type AppConfigExplainOptions,
+  type AppConfigOptions,
+  type ConfigFormat,
+  type ResolveOptions,
+} from './app-config.js';
 export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
 export { collectConfigMeta } from './collect.js';
 export { configCheck } from './trails/config-check.js';

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -11,6 +11,11 @@ export { collectServiceConfigs, type ServiceConfigEntry } from './compose.js';
 export { defineConfig, type DefineConfigOptions } from './define-config.js';
 export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
 export {
+  generateEnvExample,
+  generateExample,
+  generateJsonSchema,
+} from './generate/index.js';
+export {
   clearConfigState,
   type ConfigState,
   getConfigState,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -6,7 +6,16 @@ export {
   type ConfigFormat,
   type ResolveOptions,
 } from './app-config.js';
-export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
 export { collectConfigMeta } from './collect.js';
+export { defineConfig, type DefineConfigOptions } from './define-config.js';
+export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
+export {
+  clearConfigState,
+  type ConfigState,
+  getConfigState,
+  registerConfigState,
+} from './registry.js';
+export { deepMerge } from './merge.js';
+export { resolveConfig, type ResolveConfigOptions } from './resolve.js';
 export { configCheck } from './trails/config-check.js';
 export { configDescribe } from './trails/config-describe.js';

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,4 @@
+// Placeholder — exports land in subsequent PRs.
+export type { ConfigPlaceholder as _ConfigPlaceholder } from './types.js';
+export { configCheck } from './trails/config-check.js';
+export { configDescribe } from './trails/config-describe.js';

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -26,6 +26,8 @@ export {
   generateExample,
   generateJsonSchema,
 } from './generate/index.js';
+export { configLayer } from './config-layer.js';
+export { configService } from './config-service.js';
 export {
   clearConfigState,
   type ConfigState,
@@ -37,3 +39,6 @@ export { configRef, isConfigRef, type ConfigRef } from './ref.js';
 export { resolveConfig, type ResolveConfigOptions } from './resolve.js';
 export { configCheck } from './trails/config-check.js';
 export { configDescribe } from './trails/config-describe.js';
+export { configExplain } from './trails/config-explain.js';
+export { configInit } from './trails/config-init.js';
+export { ensureWorkspace } from './workspace.js';

--- a/packages/config/src/merge.ts
+++ b/packages/config/src/merge.ts
@@ -1,0 +1,43 @@
+/**
+ * Simple recursive deep merge for config objects.
+ *
+ * - Objects merge recursively
+ * - Arrays replace (no concatenation)
+ * - Primitives replace
+ * - `undefined` values in source are skipped
+ */
+
+/** Check whether a value is a plain object (not array, null, or class instance). */
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.getPrototypeOf(value) === Object.prototype;
+
+/**
+ * Deep-merge `source` into `target`, returning a new object.
+ *
+ * Does not mutate either input. Undefined values in source are skipped,
+ * preserving the target's value at that key.
+ */
+export const deepMerge = (
+  target: Record<string, unknown>,
+  source: Record<string, unknown>
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = { ...target };
+
+  for (const [key, sourceValue] of Object.entries(source)) {
+    if (sourceValue === undefined) {
+      continue;
+    }
+
+    const targetValue = result[key];
+
+    result[key] =
+      isPlainObject(targetValue) && isPlainObject(sourceValue)
+        ? deepMerge(targetValue, sourceValue)
+        : sourceValue;
+  }
+
+  return result;
+};

--- a/packages/config/src/ref.ts
+++ b/packages/config/src/ref.ts
@@ -1,0 +1,33 @@
+/**
+ * Lazy config reference markers for trail input defaults.
+ *
+ * A `ConfigRef` is a marker object that can be embedded as a trail input
+ * default. The resolution stack detects it at invocation time and replaces
+ * it with the live config value at the given path.
+ */
+
+/** Marker object representing a lazy reference to a config field. */
+export interface ConfigRef {
+  readonly __configRef: true;
+  readonly path: string;
+}
+
+/**
+ * Create a lazy reference to a config field for use as a trail input default.
+ *
+ * The reference is resolved at invocation time, not at declaration time.
+ *
+ */
+export const configRef = (path: string): ConfigRef => ({
+  __configRef: true,
+  path,
+});
+
+/**
+ * Type guard: detect whether an unknown value is a `ConfigRef` marker.
+ */
+export const isConfigRef = (value?: unknown): value is ConfigRef =>
+  typeof value === 'object' &&
+  value !== null &&
+  '__configRef' in value &&
+  (value as Record<string, unknown>)['__configRef'] === true;

--- a/packages/config/src/registry.ts
+++ b/packages/config/src/registry.ts
@@ -1,0 +1,33 @@
+/**
+ * Module-level config state registry.
+ *
+ * Config is resolved once at bootstrap (two-phase init per ADR-010) and
+ * registered here so `configService` can surface it to trails. This is
+ * a process-level singleton — config resolution is inherently global.
+ */
+import type { z } from 'zod';
+
+/** Resolved config state carrying the schema and all layer values. */
+export interface ConfigState {
+  readonly schema: z.ZodObject<Record<string, z.ZodType>>;
+  readonly resolved: Record<string, unknown>;
+  readonly base?: Record<string, unknown>;
+  readonly loadout?: Record<string, unknown>;
+  readonly local?: Record<string, unknown>;
+  readonly env?: Record<string, string | undefined>;
+}
+
+let current: ConfigState | undefined;
+
+/** Register resolved config state at bootstrap. */
+export const registerConfigState = (state: ConfigState): void => {
+  current = state;
+};
+
+/** Read the registered config state. Returns `undefined` before registration. */
+export const getConfigState = (): ConfigState | undefined => current;
+
+/** Clear registered state. Primarily useful in tests. */
+export const clearConfigState = (): void => {
+  current = undefined;
+};

--- a/packages/config/src/resolve.ts
+++ b/packages/config/src/resolve.ts
@@ -1,0 +1,276 @@
+/**
+ * Config resolution engine — merges config from multiple sources through
+ * a deterministic stack: defaults → base → loadout → local → env.
+ */
+
+import type { z } from 'zod';
+
+import { Result } from '@ontrails/core';
+
+import { collectConfigMeta } from './collect.js';
+import { deepMerge } from './merge.js';
+import { zodDef } from './zod-utils.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for resolving config through the full stack. */
+export interface ResolveConfigOptions<T extends z.ZodType> {
+  readonly schema: T;
+  readonly base?: Record<string, unknown> | undefined;
+  readonly loadouts?: Record<string, Record<string, unknown>> | undefined;
+  readonly loadout?: string | undefined;
+  readonly localOverrides?: Record<string, unknown> | undefined;
+  readonly env?: Record<string, string | undefined> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Env coercion helpers (defined before consumers)
+// ---------------------------------------------------------------------------
+
+/** Boolean string values we accept from environment variables. */
+const BOOL_TRUE = new Set(['true', '1']);
+const BOOL_FALSE = new Set(['false', '0']);
+
+/** Primitive type names we can coerce env strings into. */
+const PRIMITIVE_TYPES = new Set(['number', 'boolean', 'string']);
+
+/** Try to advance one level through a Zod wrapper, returning the inner type or undefined. */
+const unwrapOne = (
+  schema: z.ZodType
+): { typeName: string | undefined; inner: z.ZodType | undefined } => {
+  const def = zodDef(schema);
+  return {
+    inner: def['innerType'] as z.ZodType | undefined,
+    typeName: def['type'] as string | undefined,
+  };
+};
+
+/** Unwrap ZodDefault / ZodOptional / ZodNullable to find the base type name. */
+const resolveBaseTypeName = (schema: z.ZodType): string => {
+  let current: z.ZodType = schema;
+
+  for (let depth = 0; depth < 10; depth += 1) {
+    const { typeName, inner } = unwrapOne(current);
+    if (typeName && PRIMITIVE_TYPES.has(typeName)) {
+      return typeName;
+    }
+    if (!inner) {
+      break;
+    }
+    current = inner;
+  }
+
+  return 'string';
+};
+
+/** Coerce a boolean env string. Returns the original string if unrecognized. */
+const coerceBooleanEnv = (raw: string): unknown => {
+  if (BOOL_TRUE.has(raw)) {
+    return true;
+  }
+  if (BOOL_FALSE.has(raw)) {
+    return false;
+  }
+  return raw;
+};
+
+/** Coerce env var lookup table keyed by base type name. */
+const ENV_COERCERS: Record<string, (raw: string) => unknown> = {
+  boolean: coerceBooleanEnv,
+  number: Number,
+};
+
+/** Coerce a string env value to the type expected by the schema field. */
+const coerceEnvValue = (raw: string, schema: z.ZodType): unknown => {
+  const coercer = ENV_COERCERS[resolveBaseTypeName(schema)];
+  return coercer ? coercer(raw) : raw;
+};
+
+// ---------------------------------------------------------------------------
+// Path utilities
+// ---------------------------------------------------------------------------
+
+/** Navigate one step of a nested object, creating an intermediate if needed. */
+const navigateOrCreate = (
+  current: Record<string, unknown>,
+  key: string
+): Record<string, unknown> => {
+  const next = current[key];
+  if (typeof next === 'object' && next !== null && !Array.isArray(next)) {
+    return next as Record<string, unknown>;
+  }
+  const nested: Record<string, unknown> = {};
+  current[key] = nested;
+  return nested;
+};
+
+/** Ensure a nested path exists in an object, creating intermediates as needed. */
+const ensurePath = (
+  obj: Record<string, unknown>,
+  parts: readonly string[]
+): Record<string, unknown> => {
+  let current = obj;
+  for (const part of parts) {
+    current = navigateOrCreate(current, part);
+  }
+  return current;
+};
+
+/** Set a value at a dot-separated path in a plain object. */
+const setAtPath = (
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown
+): void => {
+  const parts = path.split('.');
+  const parent = ensurePath(obj, parts.slice(0, -1));
+  parent[parts.at(-1) as string] = value;
+};
+
+/** Resolve one step of a Zod shape walk: find the field schema for a key. */
+const resolveShapeStep = (
+  current: z.ZodType,
+  key: string
+): z.ZodType | undefined => {
+  const shape = zodDef(current)['shape'] as
+    | Record<string, z.ZodType>
+    | undefined;
+  return shape?.[key];
+};
+
+/** Walk a Zod schema shape to find the field at a dot-separated path. */
+const getFieldSchema = (
+  schema: z.ZodType,
+  path: string
+): z.ZodType | undefined => {
+  let current: z.ZodType = schema;
+  for (const part of path.split('.')) {
+    const next = resolveShapeStep(current, part);
+    if (!next) {
+      return undefined;
+    }
+    current = next;
+  }
+  return current;
+};
+
+// ---------------------------------------------------------------------------
+// Env overlay
+// ---------------------------------------------------------------------------
+
+/** Coerce and set a single env override into the result object. */
+const applyOneEnvOverride = (
+  result: Record<string, unknown>,
+  schema: z.ZodType,
+  path: string,
+  envValue: string
+): void => {
+  const fieldSchema = getFieldSchema(schema, path);
+  const coerced = fieldSchema
+    ? coerceEnvValue(envValue, fieldSchema)
+    : envValue;
+  setAtPath(result, path, coerced);
+};
+
+/** Resolve a single env binding: look up the var, apply if present. */
+const resolveEnvBinding = (
+  result: Record<string, unknown>,
+  schema: z.ZodType,
+  path: string,
+  envVar: string,
+  envVars: Record<string, string | undefined>
+): void => {
+  const envValue = envVars[envVar];
+  if (envValue !== undefined) {
+    applyOneEnvOverride(result, schema, path, envValue);
+  }
+};
+
+/** Apply env var overrides based on schema metadata. */
+const applyEnvOverrides = (
+  merged: Record<string, unknown>,
+  schema: z.ZodType,
+  envVars: Record<string, string | undefined>
+): Record<string, unknown> => {
+  if (zodDef(schema)['type'] !== 'object') {
+    return merged;
+  }
+
+  const meta = collectConfigMeta(
+    schema as z.ZodObject<Record<string, z.ZodType>>
+  );
+  const result = deepMerge({}, merged);
+
+  for (const [path, fieldMeta] of meta) {
+    if (fieldMeta.env) {
+      resolveEnvBinding(result, schema, path, fieldMeta.env, envVars);
+    }
+  }
+
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// Merge pipeline
+// ---------------------------------------------------------------------------
+
+/** Apply the layered merge: base → loadout → local overrides. */
+const mergeLayers = (
+  base: Record<string, unknown> | undefined,
+  loadouts: Record<string, Record<string, unknown>> | undefined,
+  loadout: string | undefined,
+  localOverrides: Record<string, unknown> | undefined
+): Record<string, unknown> => {
+  let merged: Record<string, unknown> = {};
+  if (base) {
+    merged = deepMerge(merged, base);
+  }
+
+  const selected = loadout && loadouts ? loadouts[loadout] : undefined;
+  if (selected) {
+    merged = deepMerge(merged, selected);
+  }
+
+  if (localOverrides) {
+    merged = deepMerge(merged, localOverrides);
+  }
+  return merged;
+};
+
+/** Format Zod issues into a human-readable error message. */
+const formatValidationError = (
+  issues: readonly { path: PropertyKey[]; message: string }[]
+): string =>
+  `Config validation failed: ${issues.map((i) => `${String(i.path.join('.'))}: ${i.message}`).join(', ')}`;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve config through the full stack: defaults → base → loadout → local → env.
+ * Returns `Result.ok` with the validated config, or `Result.err` on validation failure.
+ */
+export const resolveConfig = <T extends z.ZodType>(
+  options: ResolveConfigOptions<T>
+): Result<z.infer<T>, Error> => {
+  let merged = mergeLayers(
+    options.base,
+    options.loadouts,
+    options.loadout,
+    options.localOverrides
+  );
+
+  if (options.env) {
+    merged = applyEnvOverrides(merged, options.schema, options.env);
+  }
+
+  const parsed = options.schema.safeParse(merged);
+  if (parsed.success) {
+    return Result.ok(parsed.data as z.infer<T>);
+  }
+
+  return Result.err(new Error(formatValidationError(parsed.error.issues)));
+};

--- a/packages/config/src/secret-heuristics.ts
+++ b/packages/config/src/secret-heuristics.ts
@@ -1,0 +1,13 @@
+/**
+ * Heuristic detection of secret env var names.
+ *
+ * Matches common suffixes like `_SECRET`, `_TOKEN`, `_KEY`, `_PASSWORD`,
+ * and `_CREDENTIALS` so that generated `.env.example` files and provenance
+ * output can redact likely-secret values even without explicit `secret()`.
+ */
+
+const SECRET_PATTERN = /_SECRET$|_TOKEN$|_KEY$|_PASSWORD$|_CREDENTIALS$/i;
+
+/** Return true when `envName` looks like it holds a secret value. */
+export const isLikelySecret = (envName: string): boolean =>
+  SECRET_PATTERN.test(envName);

--- a/packages/config/src/trails/config-check.ts
+++ b/packages/config/src/trails/config-check.ts
@@ -1,0 +1,59 @@
+/**
+ * Infrastructure trail that validates config values against a schema.
+ *
+ * Returns structured diagnostics indicating which fields are valid,
+ * missing, invalid, deprecated, or using defaults.
+ */
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { configService } from '../config-service.js';
+import { checkConfig } from '../doctor.js';
+
+const diagnosticSchema = z.object({
+  message: z.string(),
+  path: z.string(),
+  status: z.enum(['valid', 'missing', 'invalid', 'deprecated', 'default']),
+});
+
+const outputSchema = z.object({
+  diagnostics: z.array(diagnosticSchema),
+  valid: z.boolean(),
+});
+
+/** Merge input values on top of resolved config values. */
+const mergeValues = (
+  resolved: Record<string, unknown>,
+  overrides: Record<string, unknown>
+): Record<string, unknown> => {
+  const hasOverrides = Object.keys(overrides).length > 0;
+  return hasOverrides ? { ...resolved, ...overrides } : resolved;
+};
+
+export const configCheck = trail('config.check', {
+  examples: [
+    {
+      input: {},
+      name: 'Check current config',
+    },
+  ],
+  input: z.object({
+    values: z
+      .record(z.string(), z.unknown())
+      .describe('Config values to check (merged with resolved)')
+      .default({}),
+  }),
+  intent: 'read',
+  metadata: { category: 'infrastructure' },
+  output: outputSchema,
+  run: (input, ctx) => {
+    const state = configService.from(ctx);
+    const effective = mergeValues(state.resolved, input.values);
+    const checked = checkConfig(state.schema, effective);
+    return Result.ok({
+      diagnostics: [...checked.diagnostics],
+      valid: checked.valid,
+    });
+  },
+  services: [configService],
+});

--- a/packages/config/src/trails/config-check.ts
+++ b/packages/config/src/trails/config-check.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 import { configService } from '../config-service.js';
 import { checkConfig } from '../doctor.js';
+import { deepMerge } from '../merge.js';
 
 const diagnosticSchema = z.object({
   message: z.string(),
@@ -27,7 +28,7 @@ const mergeValues = (
   overrides: Record<string, unknown>
 ): Record<string, unknown> => {
   const hasOverrides = Object.keys(overrides).length > 0;
-  return hasOverrides ? { ...resolved, ...overrides } : resolved;
+  return hasOverrides ? deepMerge(resolved, overrides) : resolved;
 };
 
 export const configCheck = trail('config.check', {

--- a/packages/config/src/trails/config-describe.ts
+++ b/packages/config/src/trails/config-describe.ts
@@ -1,0 +1,44 @@
+/**
+ * Infrastructure trail that describes all config fields in a schema.
+ *
+ * Returns a structured catalog of field definitions suitable for
+ * CLI rendering or agent inspection.
+ */
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { configService } from '../config-service.js';
+import { describeConfig } from '../describe.js';
+
+const fieldSchema = z.object({
+  deprecated: z.string().optional(),
+  description: z.string().optional(),
+  env: z.string().optional(),
+  path: z.string(),
+  required: z.boolean(),
+  secret: z.boolean().optional(),
+  type: z.string(),
+});
+
+const outputSchema = z.object({
+  fields: z.array(fieldSchema),
+});
+
+export const configDescribe = trail('config.describe', {
+  examples: [
+    {
+      input: {},
+      name: 'Describe all config fields',
+    },
+  ],
+  input: z.object({}),
+  intent: 'read',
+  metadata: { category: 'infrastructure' },
+  output: outputSchema,
+  run: (_input, ctx) => {
+    const state = configService.from(ctx);
+    const fields = describeConfig(state.schema);
+    return Result.ok({ fields: [...fields] });
+  },
+  services: [configService],
+});

--- a/packages/config/src/trails/config-explain.ts
+++ b/packages/config/src/trails/config-explain.ts
@@ -28,7 +28,11 @@ const filterByPath = (
   entries: readonly { readonly path: string }[],
   prefix: string
 ): readonly { readonly path: string }[] =>
-  prefix ? entries.filter((e) => e.path.startsWith(prefix)) : entries;
+  prefix
+    ? entries.filter(
+        (entry) => entry.path === prefix || entry.path.startsWith(`${prefix}.`)
+      )
+    : entries;
 
 /** Build ExplainConfigOptions from ConfigState, omitting undefined layers. */
 const toExplainOptions = (

--- a/packages/config/src/trails/config-explain.ts
+++ b/packages/config/src/trails/config-explain.ts
@@ -1,0 +1,89 @@
+/**
+ * Infrastructure trail that exposes config provenance.
+ *
+ * Returns resolved config entries with source information so agents
+ * and operators can answer "where did this value come from?"
+ */
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { configService } from '../config-service.js';
+import type { ExplainConfigOptions } from '../explain.js';
+import { explainConfig } from '../explain.js';
+import type { ConfigState } from '../registry.js';
+
+const provenanceEntrySchema = z.object({
+  path: z.string(),
+  redacted: z.boolean(),
+  source: z.string(),
+  value: z.unknown(),
+});
+
+const outputSchema = z.object({
+  entries: z.array(provenanceEntrySchema),
+});
+
+/** Filter provenance entries by path prefix when specified. */
+const filterByPath = (
+  entries: readonly { readonly path: string }[],
+  prefix: string
+): readonly { readonly path: string }[] =>
+  prefix ? entries.filter((e) => e.path.startsWith(prefix)) : entries;
+
+/** Build ExplainConfigOptions from ConfigState, omitting undefined layers. */
+const toExplainOptions = (
+  state: ConfigState
+): ExplainConfigOptions<typeof state.schema> => {
+  const base: ExplainConfigOptions<typeof state.schema> = {
+    resolved: state.resolved,
+    schema: state.schema,
+  };
+  if (state.base) {
+    return { ...base, base: state.base };
+  }
+  return base;
+};
+
+/** Enrich explain options with env and layer overrides from state. */
+const enrichOptions = (
+  state: ConfigState,
+  options: ExplainConfigOptions<typeof state.schema>
+): ExplainConfigOptions<typeof state.schema> => {
+  let enriched = options;
+  if (state.env) {
+    enriched = { ...enriched, env: state.env };
+  }
+  if (state.loadout) {
+    enriched = { ...enriched, loadout: state.loadout };
+  }
+  if (state.local) {
+    enriched = { ...enriched, local: state.local };
+  }
+  return enriched;
+};
+
+export const configExplain = trail('config.explain', {
+  examples: [
+    {
+      input: {},
+      name: 'Explain all fields',
+    },
+  ],
+  input: z.object({
+    path: z
+      .string()
+      .describe('Config field path to explain (or empty for all)')
+      .default(''),
+  }),
+  intent: 'read',
+  metadata: { category: 'infrastructure' },
+  output: outputSchema,
+  run: (input, ctx) => {
+    const state = configService.from(ctx);
+    const options = enrichOptions(state, toExplainOptions(state));
+    const entries = explainConfig(options);
+    const filtered = filterByPath(entries, input.path);
+    return Result.ok({ entries: [...filtered] });
+  },
+  services: [configService],
+});

--- a/packages/config/src/trails/config-init.ts
+++ b/packages/config/src/trails/config-init.ts
@@ -1,0 +1,96 @@
+/**
+ * Infrastructure trail that generates an example config file.
+ *
+ * Produces TOML, JSON, JSONC, or YAML output from the registered
+ * config schema, with defaults shown and deprecated fields annotated.
+ *
+ * When `dir` is provided, also writes `.env.example` and `.schema.json`
+ * to the specified directory.
+ */
+import { join } from 'node:path';
+import { mkdir } from 'node:fs/promises';
+
+import { Result, trail } from '@ontrails/core';
+import type { z } from 'zod';
+import { z as zod } from 'zod';
+
+import { configService } from '../config-service.js';
+import {
+  generateEnvExample,
+  generateExample,
+  generateJsonSchema,
+} from '../generate/index.js';
+
+const formatEnum = zod.enum(['toml', 'json', 'jsonc', 'yaml']);
+
+const outputSchema = zod.object({
+  content: zod.string(),
+  format: zod.string(),
+  writtenFiles: zod.array(zod.string()).optional(),
+});
+
+/** Collect artifacts to write: [relativeName, content] pairs. */
+const collectArtifacts = (
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): [string, string][] => {
+  const artifacts: [string, string][] = [];
+  const envContent = generateEnvExample(schema);
+  if (envContent.length > 0) {
+    artifacts.push(['.env.example', envContent]);
+  }
+  artifacts.push([
+    '.schema.json',
+    JSON.stringify(generateJsonSchema(schema), null, 2),
+  ]);
+  return artifacts;
+};
+
+/** Write generated artifacts to the target directory. */
+const writeArtifacts = async (
+  dir: string,
+  schema: z.ZodObject<Record<string, z.ZodType>>
+): Promise<string[]> => {
+  await mkdir(dir, { recursive: true });
+  const artifacts = collectArtifacts(schema);
+  const written: string[] = [];
+  for (const [name, content] of artifacts) {
+    const fullPath = join(dir, name);
+    await Bun.write(fullPath, content);
+    written.push(fullPath);
+  }
+  return written;
+};
+
+export const configInit = trail('config.init', {
+  examples: [
+    {
+      input: {},
+      name: 'Generate TOML example',
+    },
+  ],
+  input: zod.object({
+    dir: zod
+      .string()
+      .describe('Directory to write generated artifacts to')
+      .optional(),
+    format: formatEnum
+      .describe('Output format for the example config file')
+      .default('toml'),
+  }),
+  intent: 'write',
+  metadata: { category: 'infrastructure' },
+  output: outputSchema,
+  run: async (input, ctx) => {
+    const state = configService.from(ctx);
+    const schema = state.schema as z.ZodObject<Record<string, z.ZodType>>;
+    const content = generateExample(schema, input.format);
+
+    if (input.dir) {
+      const writtenFiles = await writeArtifacts(input.dir, schema);
+      return Result.ok({ content, format: input.format, writtenFiles });
+    }
+
+    return Result.ok({ content, format: input.format });
+  },
+  services: [configService],
+});

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,4 +1,0 @@
-/** Internal placeholder — replaced by real types in TRL-88+. */
-export interface ConfigPlaceholder {
-  readonly __brand: 'config';
-}

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,0 +1,4 @@
+/** Internal placeholder — replaced by real types in TRL-88+. */
+export interface ConfigPlaceholder {
+  readonly __brand: 'config';
+}

--- a/packages/config/src/workspace.ts
+++ b/packages/config/src/workspace.ts
@@ -17,6 +17,9 @@ const GITIGNORE_CONTENT = [
   '# Development state',
   'dev/',
   '',
+  '# Generated artifacts',
+  'generated/',
+  '',
 ].join('\n');
 
 /**

--- a/packages/config/src/workspace.ts
+++ b/packages/config/src/workspace.ts
@@ -1,0 +1,48 @@
+/**
+ * Ensure the `.trails/` workspace directory exists with proper structure.
+ *
+ * Auto-creates on first framework operation. The workspace holds local
+ * config overrides, development state, and generated artifacts that
+ * should not be committed to source control.
+ */
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const WORKSPACE_DIRS = ['config', 'dev', 'generated'] as const;
+
+const GITIGNORE_CONTENT = [
+  '# Local config overrides',
+  'config/',
+  '',
+  '# Development state',
+  'dev/',
+  '',
+].join('\n');
+
+/**
+ * Write `.gitignore` inside the workspace directory if it does not already exist.
+ */
+const writeGitignoreIfMissing = async (trailsDir: string): Promise<void> => {
+  const gitignorePath = join(trailsDir, '.gitignore');
+  const file = Bun.file(gitignorePath);
+  if (!(await file.exists())) {
+    await Bun.write(gitignorePath, GITIGNORE_CONTENT);
+  }
+};
+
+/**
+ * Ensure the `.trails/` workspace directory exists with proper structure.
+ *
+ * Creates `config/`, `dev/`, and `generated/` subdirectories plus a
+ * `.gitignore` that excludes local-only files. Safe to call repeatedly —
+ * existing files are never overwritten.
+ */
+export const ensureWorkspace = async (root: string): Promise<void> => {
+  const trailsDir = join(root, '.trails');
+
+  await Promise.all(
+    WORKSPACE_DIRS.map((d) => mkdir(join(trailsDir, d), { recursive: true }))
+  );
+
+  await writeGitignoreIfMissing(trailsDir);
+};

--- a/packages/config/src/zod-utils.ts
+++ b/packages/config/src/zod-utils.ts
@@ -9,11 +9,31 @@ import type { z } from 'zod';
 export const zodDef = (schema: z.ZodType): Record<string, unknown> =>
   schema.def as unknown as Record<string, unknown>;
 
-/** Check if a schema is a ZodObject by inspecting its def. */
+/** Wrapper types that should be peeled before checking the base type. */
+const WRAPPER_TYPES = new Set(['optional', 'default', 'nullable']);
+
+/** Unwrap through optional/default/nullable wrappers to find the base schema. */
+export const unwrapToBase = (schema: z.ZodType): z.ZodType => {
+  let current = schema;
+  for (let depth = 0; depth < 10; depth += 1) {
+    const def = zodDef(current);
+    if (!WRAPPER_TYPES.has(def['type'] as string)) {
+      return current;
+    }
+    const inner = def['innerType'] as z.ZodType | undefined;
+    if (!inner) {
+      return current;
+    }
+    current = inner;
+  }
+  return current;
+};
+
+/** Check if a schema is (or wraps) a ZodObject by inspecting its def. */
 export const isZodObject = (
   schema: z.ZodType
 ): schema is z.ZodObject<Record<string, z.ZodType>> => {
-  const def = zodDef(schema);
+  const def = zodDef(unwrapToBase(schema));
   return def['type'] === 'object' && 'shape' in def;
 };
 

--- a/packages/config/src/zod-utils.ts
+++ b/packages/config/src/zod-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared Zod introspection helpers used by config resolution, doctor,
+ * describe, explain, and collect modules.
+ */
+
+import type { z } from 'zod';
+
+/** Extract the Zod def record from any ZodType. */
+export const zodDef = (schema: z.ZodType): Record<string, unknown> =>
+  schema.def as unknown as Record<string, unknown>;
+
+/** Check if a schema is a ZodObject by inspecting its def. */
+export const isZodObject = (
+  schema: z.ZodType
+): schema is z.ZodObject<Record<string, z.ZodType>> => {
+  const def = zodDef(schema);
+  return def['type'] === 'object' && 'shape' in def;
+};
+
+/** Read a value at a dot-separated path from a plain object. */
+export const getAtPath = (
+  obj: Record<string, unknown>,
+  path: string
+): unknown => {
+  let current: unknown = obj;
+  for (const part of path.split('.')) {
+    if (typeof current !== 'object' || current === null) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+};

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/packages/core/src/__tests__/service-config.test.ts
+++ b/packages/core/src/__tests__/service-config.test.ts
@@ -1,0 +1,224 @@
+/* oxlint-disable require-await -- trail implementations satisfy async interface without awaiting */
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { executeTrail } from '../execute.js';
+import { Result } from '../result.js';
+import { service } from '../service.js';
+import { trail } from '../trail.js';
+import type { ServiceContext } from '../service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const nextId = (name: string): string =>
+  `test.svc-config.${name}.${Bun.randomUUIDv7()}`;
+
+const createSingletonConfigTrail = (id: string) => {
+  const captures = { createCalls: 0 };
+  const svc = service(id, {
+    config: z.object({ key: z.string() }),
+    create: (ctx: ServiceContext<{ key: string }>) => {
+      captures.createCalls += 1;
+      return Result.ok({
+        createCall: captures.createCalls,
+        key: ctx.config.key,
+      });
+    },
+  });
+
+  return {
+    captures,
+    trail: trail('svc-config.singleton', {
+      input: z.object({}),
+      output: z.object({ createCall: z.number(), key: z.string() }),
+      run: (_input, ctx) =>
+        Result.ok({
+          createCall: svc.from(ctx).createCall,
+          key: svc.from(ctx).key,
+        }),
+      services: [svc],
+    }),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ServiceContext.config', () => {
+  test('service with config schema receives validated config in svc.config', async () => {
+    const id = nextId('typed-config');
+    let capturedConfig: unknown;
+
+    const db = service(id, {
+      config: z.object({ poolSize: z.number(), url: z.string().url() }),
+      create: (svc: ServiceContext<{ url: string; poolSize: number }>) => {
+        capturedConfig = svc.config;
+        return Result.ok({ connected: true });
+      },
+    });
+
+    const dbTrail = trail('svc-config.typed', {
+      input: z.object({}),
+      output: z.object({ connected: z.boolean() }),
+      run: (_input, ctx) => Result.ok({ connected: db.from(ctx).connected }),
+      services: [db],
+    });
+
+    const result = await executeTrail(
+      dbTrail,
+      {},
+      {
+        configValues: {
+          [id]: { poolSize: 5, url: 'https://example.com' },
+        },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(capturedConfig).toEqual({ poolSize: 5, url: 'https://example.com' });
+  });
+
+  test('service without config still works — svc.config is undefined', async () => {
+    const id = nextId('no-config');
+    let capturedConfig: unknown = 'sentinel';
+
+    const counter = service(id, {
+      create: (svc) => {
+        capturedConfig = svc.config;
+        return Result.ok(42);
+      },
+    });
+
+    const counterTrail = trail('svc-config.no-config', {
+      input: z.object({}),
+      run: (_input, ctx) => Result.ok({ value: counter.from(ctx) }),
+      services: [counter],
+    });
+
+    const result = await executeTrail(counterTrail, {});
+
+    expect(result.isOk()).toBe(true);
+    expect(capturedConfig).toBeUndefined();
+  });
+
+  test('config validation failure returns Result.err at service creation time', async () => {
+    const id = nextId('invalid-config');
+
+    const db = service(id, {
+      config: z.object({ url: z.string().url() }),
+      create: () => Result.ok({ connected: true }),
+    });
+
+    const dbTrail = trail('svc-config.invalid', {
+      input: z.object({}),
+      run: () => Result.ok(null),
+      services: [db],
+    });
+
+    const result = await executeTrail(
+      dbTrail,
+      {},
+      {
+        configValues: {
+          [id]: { url: 'not-a-url' },
+        },
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error.message).toContain(id);
+  });
+
+  test('missing configValues for a service with config schema returns Result.err', async () => {
+    const id = nextId('missing-config');
+
+    const db = service(id, {
+      config: z.object({ url: z.string().url() }),
+      create: () => Result.ok({ connected: true }),
+    });
+
+    const dbTrail = trail('svc-config.missing', {
+      input: z.object({}),
+      run: () => Result.ok(null),
+      services: [db],
+    });
+
+    const result = await executeTrail(dbTrail, {});
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error.message).toContain(id);
+  });
+
+  test('service override bypasses config validation', async () => {
+    const id = nextId('override-bypass');
+
+    const db = service(id, {
+      config: z.object({ url: z.string().url() }),
+      create: () => Result.ok({ connected: true }),
+    });
+
+    const dbTrail = trail('svc-config.override', {
+      input: z.object({}),
+      output: z.object({ value: z.number() }),
+      run: (_input, ctx) => Result.ok({ value: db.from(ctx) as number }),
+      services: [db],
+    });
+
+    // Provide the service via overrides without any configValues — should NOT fail
+    const result = await executeTrail(dbTrail, {}, { services: { [id]: 42 } });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ value: 42 });
+  });
+  test('config values passed through ExecuteTrailOptions.configValues', async () => {
+    const id = nextId('options-config');
+    const captures: unknown[] = [];
+
+    const svc = service(id, {
+      config: z.object({ key: z.string() }),
+      create: (ctx: ServiceContext<{ key: string }>) => {
+        captures.push(ctx.config);
+        return Result.ok({ key: ctx.config.key });
+      },
+    });
+
+    const svcTrail = trail('svc-config.options', {
+      input: z.object({}),
+      output: z.object({ key: z.string() }),
+      run: (_input, ctx) => Result.ok({ key: svc.from(ctx).key }),
+      services: [svc],
+    });
+
+    const result = await executeTrail(
+      svcTrail,
+      {},
+      {
+        configValues: { [id]: { key: 'hello' } },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ key: 'hello' });
+    expect(captures).toEqual([{ key: 'hello' }]);
+  });
+
+  test('config-aware singleton services reuse the cached instance', async () => {
+    const id = nextId('singleton-config');
+    const { captures, trail: singletonTrail } = createSingletonConfigTrail(id);
+    const options = {
+      configValues: { [id]: { key: 'hello' } },
+    };
+    const first = await executeTrail(singletonTrail, {}, options);
+    const second = await executeTrail(singletonTrail, {}, options);
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    expect(first.unwrap()).toEqual({ createCall: 1, key: 'hello' });
+    expect(second.unwrap()).toEqual({ createCall: 1, key: 'hello' });
+    expect(captures.createCalls).toBe(1);
+  });
+});

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -8,11 +8,7 @@
 
 import type { AnyTrail } from './trail.js';
 import type { Layer } from './layer.js';
-import type {
-  AnyService,
-  ServiceContext,
-  ServiceOverrideMap,
-} from './service.js';
+import type { ServiceOverrideMap } from './service.js';
 import type { TrailContext, TrailContextInit } from './types.js';
 
 import { composeLayers } from './layer.js';
@@ -20,6 +16,7 @@ import { createTrailContext } from './context.js';
 import { InternalError } from './errors.js';
 import { Result } from './result.js';
 import { createServiceLookup } from './service.js';
+import { resolveServices } from './service-config.js';
 import { validateInput } from './validation.js';
 
 type MutableTrailContext = {
@@ -44,6 +41,10 @@ export interface ExecuteTrailOptions {
     | undefined;
   /** Explicit service instance overrides keyed by service ID. */
   readonly services?: ServiceOverrideMap | undefined;
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  readonly configValues?:
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -87,213 +88,17 @@ const resolveContext = async (
   return resolved as TrailContext;
 };
 
-const singletonServices = new WeakMap<AnyService, Map<string, unknown>>();
-
-/** In-flight service creation promises, keyed by service × context. */
-const pendingCreations = new WeakMap<
-  AnyService,
-  Map<string, Promise<Result<unknown, Error>>>
->();
-
-const hasOwnServiceOverride = (
-  overrides: ServiceOverrideMap | undefined,
-  id: string
-): overrides is ServiceOverrideMap =>
-  overrides !== undefined && Object.hasOwn(overrides, id);
-
-const toServiceContext = (ctx: TrailContext): ServiceContext => ({
-  cwd: ctx.cwd,
-  env: ctx.env,
-  workspaceRoot: ctx.workspaceRoot,
-});
-
-const toServiceContextKey = (ctx: ServiceContext): string =>
-  JSON.stringify({
-    cwd: ctx.cwd,
-    env: Object.entries(ctx.env ?? {}).toSorted(([left], [right]) =>
-      left.localeCompare(right)
-    ),
-    workspaceRoot: ctx.workspaceRoot,
-  });
-
-const toInternalServiceError = (id: string, error: unknown): InternalError => {
-  const cause = error instanceof Error ? error : undefined;
-  const message = cause?.message ?? String(error);
-  return new InternalError(`Service "${id}" failed to resolve: ${message}`, {
-    ...(cause ? { cause } : {}),
-    context: { serviceId: id },
-  });
-};
-
-const getCachedSingletonService = (
-  declaredService: AnyService,
-  serviceContext: ServiceContext
-): { readonly found: boolean; readonly value: unknown } => {
-  const scopedCache = singletonServices.get(declaredService);
-  if (scopedCache === undefined) {
-    return { found: false, value: undefined };
-  }
-
-  const key = toServiceContextKey(serviceContext);
-  if (!scopedCache.has(key)) {
-    return { found: false, value: undefined };
-  }
-
-  return {
-    found: true,
-    value: scopedCache.get(key),
-  };
-};
-
-const getProvidedService = (
-  ctx: TrailContext,
-  overrides: ServiceOverrideMap | undefined,
-  declaredService: AnyService,
-  serviceContext: ServiceContext
-): Result<unknown, Error> | undefined => {
-  const { id } = declaredService;
-  if (hasOwnServiceOverride(overrides, id)) {
-    return Result.ok(overrides[id]);
-  }
-
-  if (Object.hasOwn(ctx.extensions ?? {}, id)) {
-    return Result.ok(ctx.extensions?.[id]);
-  }
-
-  const cached = getCachedSingletonService(declaredService, serviceContext);
-  if (cached.found) {
-    return Result.ok(cached.value);
-  }
-
-  return undefined;
-};
-
-const getSingletonServiceCache = (
-  declaredService: AnyService
-): Map<string, unknown> => {
-  const existing = singletonServices.get(declaredService);
-  if (existing !== undefined) {
-    return existing;
-  }
-
-  const created = new Map<string, unknown>();
-  singletonServices.set(declaredService, created);
-  return created;
-};
-
-const doCreateServiceInstance = async (
-  declaredService: AnyService,
-  serviceContext: ServiceContext
-): Promise<Result<unknown, Error>> => {
-  try {
-    const created = await declaredService.create(serviceContext);
-    if (created.isErr()) {
-      return Result.err(created.error);
-    }
-
-    const instance = created.unwrap();
-    getSingletonServiceCache(declaredService).set(
-      toServiceContextKey(serviceContext),
-      instance
-    );
-    return Result.ok(instance);
-  } catch (error: unknown) {
-    return Result.err(toInternalServiceError(declaredService.id, error));
-  }
-};
-
-const trackPendingCreation = (
-  declaredService: AnyService,
-  key: string,
-  promise: Promise<Result<unknown, Error>>
-): void => {
-  const pending = pendingCreations.get(declaredService);
-  if (pending) {
-    pending.set(key, promise);
-  } else {
-    pendingCreations.set(declaredService, new Map([[key, promise]]));
-  }
-};
-
-/**
- * Deduplicates concurrent creation of the same service singleton.
- * If a creation is already in flight for this service × context key,
- * returns the existing promise instead of spawning a second factory call.
- */
-const createServiceInstance = async (
-  declaredService: AnyService,
-  serviceContext: ServiceContext
-): Promise<Result<unknown, Error>> => {
-  const key = toServiceContextKey(serviceContext);
-  const inflight = pendingCreations.get(declaredService)?.get(key);
-  if (inflight) {
-    return inflight;
-  }
-
-  const promise = doCreateServiceInstance(declaredService, serviceContext);
-  trackPendingCreation(declaredService, key, promise);
-
-  try {
-    return await promise;
-  } finally {
-    pendingCreations.get(declaredService)?.delete(key);
-  }
-};
-
-const resolveServiceInstance = async (
-  declaredService: AnyService,
-  ctx: TrailContext,
-  serviceContext: ServiceContext,
-  overrides?: ServiceOverrideMap
-): Promise<Result<unknown, Error>> =>
-  getProvidedService(ctx, overrides, declaredService, serviceContext) ??
-  (await createServiceInstance(declaredService, serviceContext));
-
-const withResolvedServices = (
-  ctx: TrailContext,
-  resolvedServices: Record<string, unknown>
-): TrailContext => {
-  const extensions = { ...ctx.extensions, ...resolvedServices };
-  const resolvedCtx = { ...ctx, extensions } as MutableTrailContext;
-  resolvedCtx.service = createServiceLookup(() => resolvedCtx);
-  return resolvedCtx;
-};
-
-const resolveServices = async (
-  trail: AnyTrail,
-  ctx: TrailContext,
-  overrides?: ServiceOverrideMap
-): Promise<Result<TrailContext, Error>> => {
-  if (trail.services.length === 0) {
-    return Result.ok(ctx);
-  }
-
-  const resolvedServices: Record<string, unknown> = {};
-  const serviceContext = toServiceContext(ctx);
-
-  for (const declaredService of trail.services) {
-    const resolved = await resolveServiceInstance(
-      declaredService,
-      ctx,
-      serviceContext,
-      overrides
-    );
-    if (resolved.isErr()) {
-      return resolved;
-    }
-
-    resolvedServices[declaredService.id] = resolved.unwrap();
-  }
-
-  return Result.ok(withResolvedServices(ctx, resolvedServices));
-};
-
 const prepareContext = async (
   trail: AnyTrail,
   options?: ExecuteTrailOptions
 ): Promise<Result<TrailContext, Error>> => {
   const baseCtx = await resolveContext(options);
-  return await resolveServices(trail, baseCtx, options?.services);
+  return await resolveServices(
+    trail,
+    baseCtx,
+    options?.services,
+    options?.configValues
+  );
 };
 
 const runTrail = async (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export type {
   Logger,
   ServiceLookup,
 } from './types.js';
+export { SURFACE_KEY } from './types.js';
 
 // Context factory
 export { createTrailContext } from './context.js';

--- a/packages/core/src/service-config.ts
+++ b/packages/core/src/service-config.ts
@@ -1,0 +1,354 @@
+/**
+ * Service resolution pipeline.
+ *
+ * Extracted from execute.ts to keep both modules under the 400 LOC ceiling.
+ * Handles config validation, singleton caching, concurrent-creation dedup,
+ * and the full resolve-or-create flow for declared services.
+ */
+
+import type {
+  AnyService,
+  ServiceContext,
+  ServiceOverrideMap,
+} from './service.js';
+import type { AnyTrail } from './trail.js';
+import type { TrailContext } from './types.js';
+
+import { InternalError, ValidationError } from './errors.js';
+import { Result } from './result.js';
+import { createServiceLookup } from './service.js';
+
+type MutableTrailContext = {
+  -readonly [K in keyof TrailContext]: TrailContext[K];
+};
+
+type ConfigValues = Readonly<Record<string, Record<string, unknown>>>;
+
+// ---------------------------------------------------------------------------
+// Singleton caches
+// ---------------------------------------------------------------------------
+
+const singletonServices = new WeakMap<AnyService, Map<string, unknown>>();
+
+/** In-flight service creation promises, keyed by service x context. */
+const pendingCreations = new WeakMap<
+  AnyService,
+  Map<string, Promise<Result<unknown, Error>>>
+>();
+
+// ---------------------------------------------------------------------------
+// Context helpers
+// ---------------------------------------------------------------------------
+
+const toServiceContext = (
+  ctx: TrailContext,
+  config?: unknown
+): ServiceContext => ({
+  config,
+  cwd: ctx.cwd,
+  env: ctx.env,
+  workspaceRoot: ctx.workspaceRoot,
+});
+
+const toServiceContextKey = (ctx: ServiceContext): string =>
+  JSON.stringify({
+    config: ctx.config,
+    cwd: ctx.cwd,
+    env: Object.entries(ctx.env ?? {}).toSorted(([left], [right]) =>
+      left.localeCompare(right)
+    ),
+    workspaceRoot: ctx.workspaceRoot,
+  });
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+/** Validate and resolve a service's config from the provided configValues map. */
+const resolveServiceConfig = (
+  declaredService: AnyService,
+  configValues?: ConfigValues
+): Result<unknown, Error> => {
+  if (declaredService.config === undefined) {
+    return Result.ok();
+  }
+  const raw = configValues?.[declaredService.id];
+  if (raw === undefined) {
+    return Result.err(
+      new ValidationError(
+        `Service "${declaredService.id}" declares a config schema but no config was provided`
+      )
+    );
+  }
+  const parsed = declaredService.config.safeParse(raw);
+  if (!parsed.success) {
+    return Result.err(
+      new ValidationError(
+        `Service "${declaredService.id}" config validation failed: ${parsed.error.message}`
+      )
+    );
+  }
+  return Result.ok(parsed.data);
+};
+
+// ---------------------------------------------------------------------------
+// Override / cache lookups
+// ---------------------------------------------------------------------------
+
+const hasOwnServiceOverride = (
+  overrides: ServiceOverrideMap | undefined,
+  id: string
+): overrides is ServiceOverrideMap =>
+  overrides !== undefined && Object.hasOwn(overrides, id);
+
+const getCachedSingletonService = (
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): { readonly found: boolean; readonly value: unknown } => {
+  const scopedCache = singletonServices.get(declaredService);
+  if (scopedCache === undefined) {
+    return { found: false, value: undefined };
+  }
+
+  const key = toServiceContextKey(serviceContext);
+  if (!scopedCache.has(key)) {
+    return { found: false, value: undefined };
+  }
+
+  return {
+    found: true,
+    value: scopedCache.get(key),
+  };
+};
+
+const getProvidedService = (
+  ctx: TrailContext,
+  overrides: ServiceOverrideMap | undefined,
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): Result<unknown, Error> | undefined => {
+  const { id } = declaredService;
+  if (hasOwnServiceOverride(overrides, id)) {
+    return Result.ok(overrides[id]);
+  }
+
+  if (Object.hasOwn(ctx.extensions ?? {}, id)) {
+    return Result.ok(ctx.extensions?.[id]);
+  }
+
+  const cached = getCachedSingletonService(declaredService, serviceContext);
+  if (cached.found) {
+    return Result.ok(cached.value);
+  }
+
+  return undefined;
+};
+
+const getOverrideOrExtension = (
+  ctx: TrailContext,
+  overrides: ServiceOverrideMap | undefined,
+  declaredService: AnyService
+): Result<unknown, Error> | undefined =>
+  getProvidedService(ctx, overrides, declaredService, toServiceContext(ctx));
+
+type ConfigAwareResolution =
+  | Result<{ readonly kind: 'provided'; readonly value: unknown }, Error>
+  | Result<
+      { readonly kind: 'context'; readonly serviceContext: ServiceContext },
+      Error
+    >;
+
+const resolveConfigAwareProvidedService = (
+  ctx: TrailContext,
+  declaredService: AnyService,
+  configValues: ConfigValues | undefined
+): ConfigAwareResolution => {
+  const configResult = resolveServiceConfig(declaredService, configValues);
+  if (configResult.isErr()) {
+    return configResult;
+  }
+
+  const serviceContext = toServiceContext(ctx, configResult.value);
+  const provided = getProvidedService(
+    ctx,
+    undefined,
+    declaredService,
+    serviceContext
+  );
+
+  return provided
+    ? Result.ok({ kind: 'provided', value: provided.unwrap() })
+    : Result.ok({ kind: 'context', serviceContext });
+};
+
+// ---------------------------------------------------------------------------
+// Instance creation
+// ---------------------------------------------------------------------------
+
+const toInternalServiceError = (id: string, error: unknown): InternalError => {
+  const cause = error instanceof Error ? error : undefined;
+  const message = cause?.message ?? String(error);
+  return new InternalError(`Service "${id}" failed to resolve: ${message}`, {
+    ...(cause ? { cause } : {}),
+    context: { serviceId: id },
+  });
+};
+
+const getSingletonServiceCache = (
+  declaredService: AnyService
+): Map<string, unknown> => {
+  const existing = singletonServices.get(declaredService);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const created = new Map<string, unknown>();
+  singletonServices.set(declaredService, created);
+  return created;
+};
+
+const doCreateServiceInstance = async (
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): Promise<Result<unknown, Error>> => {
+  try {
+    const created = await declaredService.create(serviceContext);
+    if (created.isErr()) {
+      return Result.err(created.error);
+    }
+
+    const instance = created.unwrap();
+    getSingletonServiceCache(declaredService).set(
+      toServiceContextKey(serviceContext),
+      instance
+    );
+    return Result.ok(instance);
+  } catch (error: unknown) {
+    return Result.err(toInternalServiceError(declaredService.id, error));
+  }
+};
+
+const trackPendingCreation = (
+  declaredService: AnyService,
+  key: string,
+  promise: Promise<Result<unknown, Error>>
+): void => {
+  const pending = pendingCreations.get(declaredService);
+  if (pending) {
+    pending.set(key, promise);
+  } else {
+    pendingCreations.set(declaredService, new Map([[key, promise]]));
+  }
+};
+
+/**
+ * Deduplicates concurrent creation of the same service singleton.
+ * If a creation is already in flight for this service x context key,
+ * returns the existing promise instead of spawning a second factory call.
+ */
+const createServiceInstance = async (
+  declaredService: AnyService,
+  serviceContext: ServiceContext
+): Promise<Result<unknown, Error>> => {
+  const key = toServiceContextKey(serviceContext);
+  const inflight = pendingCreations.get(declaredService)?.get(key);
+  if (inflight) {
+    return inflight;
+  }
+
+  const promise = doCreateServiceInstance(declaredService, serviceContext);
+  trackPendingCreation(declaredService, key, promise);
+
+  try {
+    return await promise;
+  } finally {
+    pendingCreations.get(declaredService)?.delete(key);
+  }
+};
+
+/** Validate config and resolve a single declared service. */
+const resolveDeclaredService = async (
+  declaredService: AnyService,
+  ctx: TrailContext,
+  overrides: ServiceOverrideMap | undefined,
+  configValues: ConfigValues | undefined
+): Promise<Result<unknown, Error>> => {
+  // Check overrides/extensions first — skip config validation entirely when
+  // a service instance is already provided.
+  const overrideOrExtension = getOverrideOrExtension(
+    ctx,
+    overrides,
+    declaredService
+  );
+  if (overrideOrExtension !== undefined) {
+    return overrideOrExtension;
+  }
+
+  // Resolve config before consulting the singleton cache so config-aware
+  // services use the same canonical context for cache reads and writes.
+  const configAwareService = resolveConfigAwareProvidedService(
+    ctx,
+    declaredService,
+    configValues
+  );
+  if (configAwareService.isErr()) {
+    return configAwareService;
+  }
+
+  // No provided instance — create via factory.
+  const resolved = configAwareService.unwrap();
+  if (resolved.kind === 'provided') {
+    return Result.ok(resolved.value);
+  }
+
+  return await createServiceInstance(declaredService, resolved.serviceContext);
+};
+
+// ---------------------------------------------------------------------------
+// Full trail service resolution
+// ---------------------------------------------------------------------------
+
+const withResolvedServices = (
+  ctx: TrailContext,
+  resolvedServices: Record<string, unknown>
+): TrailContext => {
+  const extensions = { ...ctx.extensions, ...resolvedServices };
+  const resolvedCtx = { ...ctx, extensions } as MutableTrailContext;
+  resolvedCtx.service = createServiceLookup(() => resolvedCtx);
+  return resolvedCtx;
+};
+
+/**
+ * Resolve all declared services for a trail.
+ *
+ * Validates per-service config, checks overrides and caches, and creates
+ * new instances as needed. Returns an enriched context with all service
+ * instances injected into extensions.
+ */
+export const resolveServices = async (
+  trail: AnyTrail,
+  ctx: TrailContext,
+  overrides?: ServiceOverrideMap,
+  configValues?: ConfigValues
+): Promise<Result<TrailContext, Error>> => {
+  if (trail.services.length === 0) {
+    return Result.ok(ctx);
+  }
+
+  const resolvedServices: Record<string, unknown> = {};
+
+  for (const declaredService of trail.services) {
+    const resolved = await resolveDeclaredService(
+      declaredService,
+      ctx,
+      overrides,
+      configValues
+    );
+    if (resolved.isErr()) {
+      return resolved;
+    }
+    resolvedServices[declaredService.id] = resolved.unwrap();
+  }
+
+  return Result.ok(withResolvedServices(ctx, resolvedServices));
+};

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -7,23 +7,29 @@ import type { z } from 'zod';
  * Stable process-scoped fields available when constructing a service.
  *
  * Services are app-level singletons, so they intentionally do not receive the
- * full per-request TrailContext.
+ * full per-request TrailContext. When a service declares a `config` schema,
+ * the validated config is passed as `svc.config`.
  */
-export type ServiceContext = Pick<
+export type ServiceContext<C = unknown> = Pick<
   TrailContext,
   'cwd' | 'env' | 'workspaceRoot'
->;
+> & {
+  readonly config: C;
+};
 
 /**
  * Everything needed to describe a service before a factory is introduced.
+ *
+ * When `config` is a Zod schema, the `create` callback receives
+ * `ServiceContext<C>` with the validated config value.
  */
-export interface ServiceSpec<T> {
+export interface ServiceSpec<T, C = unknown> {
   /** Create the service instance from stable process-scoped context. */
   readonly create: (
-    svc: ServiceContext
+    svc: ServiceContext<C>
   ) => Result<T, Error> | Promise<Result<T, Error>>;
-  /** Reserved config schema for follow-up config composition work. */
-  readonly config?: z.ZodType | undefined;
+  /** Config schema — when present, config is validated and passed to `create`. */
+  readonly config?: z.ZodType<C> | undefined;
   /** Optional cleanup performed when the hosting surface shuts down. */
   readonly dispose?: ((service: T) => void | Promise<void>) | undefined;
   /** Optional operational readiness probe for introspection tooling. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -46,6 +46,9 @@ export interface Logger {
   child(context: Record<string, unknown>): Logger;
 }
 
+/** Context extension key for the invoking surface name. */
+export const SURFACE_KEY = '__trails_surface' as const;
+
 /** Runtime context threaded through every trail execution */
 export interface TrailContext {
   readonly requestId: string;

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -4,6 +4,7 @@ import {
   InternalError,
   NotFoundError,
   Result,
+  SURFACE_KEY,
   service,
   ValidationError,
   trail,
@@ -376,13 +377,14 @@ describe('buildHttpRoutes', () => {
 
   describe('custom createContext', () => {
     test('custom createContext is used when provided', async () => {
-      let contextUsed = false;
+      const contextState = { custom: false, surface: false };
 
       const ctxTrail = trail('ctx.custom', {
         input: z.object({}),
         intent: 'read',
         run: (_input, ctx) => {
-          contextUsed = ctx.extensions?.['custom'] === true;
+          contextState.custom = ctx.extensions?.['custom'] === true;
+          contextState.surface = ctx.extensions?.[SURFACE_KEY] === 'http';
           return Result.ok({ ok: true });
         },
       });
@@ -401,7 +403,8 @@ describe('buildHttpRoutes', () => {
 
       const result = await route?.execute({});
       expect(result?.isOk()).toBe(true);
-      expect(contextUsed).toBe(true);
+      expect(contextState.custom).toBe(true);
+      expect(contextState.surface).toBe(true);
     });
   });
 

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -6,7 +6,12 @@
  * implementation -- all without referencing any HTTP framework types.
  */
 
-import { Result, ValidationError, executeTrail } from '@ontrails/core';
+import {
+  Result,
+  SURFACE_KEY,
+  ValidationError,
+  executeTrail,
+} from '@ontrails/core';
 import type {
   Layer,
   ServiceOverrideMap,
@@ -86,6 +91,16 @@ const deriveInputSource = (method: HttpMethod): InputSource =>
 const shouldInclude = (trail: Trail<unknown, unknown>): boolean =>
   trail.metadata?.['internal'] !== true;
 
+/** Build per-request context overrides with the HTTP surface marker. */
+const withHttpSurface = (
+  requestId: string | undefined
+): Partial<TrailContextInit> => ({
+  ...(requestId === undefined ? {} : { requestId }),
+  extensions: {
+    [SURFACE_KEY]: 'http' as const,
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Execute factory
 // ---------------------------------------------------------------------------
@@ -105,7 +120,7 @@ const createExecute =
   (input, requestId, signal) =>
     executeTrail(t, input, {
       createContext: options.createContext,
-      ctx: requestId === undefined ? undefined : { requestId },
+      ctx: withHttpSurface(requestId),
       layers,
       services: options.services,
       signal,

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 
-import { Result, createBlobRef, service, trail, topo } from '@ontrails/core';
+import {
+  Result,
+  SURFACE_KEY,
+  createBlobRef,
+  service,
+  trail,
+  topo,
+} from '@ontrails/core';
 import type { Layer } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -297,11 +304,13 @@ describe('buildMcpTools', () => {
 
     test('custom createContext is used when provided', async () => {
       let contextUsed = false;
+      let surfaceUsed = false;
 
       const ctxTrail = trail('ctx.check', {
         input: z.object({}),
         run: (_input, ctx) => {
           contextUsed = ctx.extensions?.['custom'] === true;
+          surfaceUsed = ctx.extensions?.[SURFACE_KEY] === 'mcp';
           return Result.ok({ ok: true });
         },
       });
@@ -319,6 +328,7 @@ describe('buildMcpTools', () => {
 
       await tool.handler({}, noExtra);
       expect(contextUsed).toBe(true);
+      expect(surfaceUsed).toBe(true);
     });
 
     test('service overrides are forwarded to executeTrail', async () => {

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -8,6 +8,7 @@
 
 import {
   Result,
+  SURFACE_KEY,
   ValidationError,
   executeTrail,
   isBlobRef,
@@ -207,6 +208,16 @@ const mcpError = (message: string): McpToolResult => ({
   isError: true,
 });
 
+/** Add the MCP surface marker while preserving any existing context extras. */
+const withMcpSurface = (
+  progressCb: TrailContextInit['progress']
+): Partial<TrailContextInit> => ({
+  ...(progressCb === undefined ? {} : { progress: progressCb }),
+  extensions: {
+    [SURFACE_KEY]: 'mcp' as const,
+  },
+});
+
 const createHandler =
   (
     t: Trail<unknown, unknown>,
@@ -220,7 +231,7 @@ const createHandler =
     const progressCb = createMcpProgressCallback(extra);
     const result = await executeTrail(t, args, {
       createContext: options.createContext,
-      ctx: progressCb === undefined ? undefined : { progress: progressCb },
+      ctx: withMcpSurface(progressCb),
       layers,
       services: options.services,
       signal: extra.signal,

--- a/packages/testing/src/context.ts
+++ b/packages/testing/src/context.ts
@@ -56,6 +56,11 @@ export interface CreateFollowContextOptions {
 export interface TestExecutionOptions {
   readonly ctx?: Partial<TrailContext> | undefined;
   readonly services?: ServiceOverrideMap | undefined;
+  /**
+   * When true, disables automatic permit minting. Tests must provide
+   * explicit permits.
+   */
+  readonly strictPermits?: boolean | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR now carries the full config subsystem after folding the earlier config branches into the `TRL-94` capstone.

Included in this branch:

- scaffolds `@ontrails/config` as a first-class workspace package
- adds Zod-based config metadata extensions via `env()`, `secret()`, and `deprecated()`
- introduces the `appConfig()` primitive with config file discovery and schema validation
- implements the full config resolution stack plus `defineConfig()` for Trails apps
- wires `ServiceSpec.config` into config-aware service creation in core
- generates example config files, JSON Schema, and `.env.example` artifacts
- adds `checkConfig()`, `describeConfig()`, `explainConfig()`, and `configRef()` helpers
- completes the trifecta with `ConfigState`, `configService`, `configLayer`, config trails, and workspace bootstrapping

## Folded Work

- `TRL-87` — scaffold `@ontrails/config`
- `TRL-88` — Zod extensions for env/secret/deprecated metadata
- `TRL-89` — `appConfig()` primitive and config discovery
- `TRL-90` — resolution stack and `defineConfig()`
- `TRL-91` — `ServiceSpec.config` integration in core
- `TRL-92` — generated config artifacts
- `TRL-93` — doctor, introspection, provenance, and `configRef()`
- `TRL-94` — service/layer/trails/workspace capstone

## Test plan

- [ ] `bun test` passes in `packages/config/`
- [ ] `bun test` passes in `packages/core/`
- [ ] config trail tests verify real output through registered `ConfigState`
- [ ] workspace tests verify `.trails/{config,dev,generated}` creation and `.gitignore` idempotency

Closed: TRL-87, TRL-88, TRL-89, TRL-90, TRL-91, TRL-92, TRL-93, TRL-94

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
