### PR TITLE
feat(permits): scaffold @ontrails/permits package [TRL-97]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -135,6 +135,14 @@
         "zod": "catalog:",
       },
     },
+    "packages/permits": {
+      "name": "@ontrails/permits",
+      "version": "1.0.0-beta.11",
+      "peerDependencies": {
+        "@ontrails/core": "workspace:^",
+        "zod": "catalog:",
+      },
+    },
     "packages/schema": {
       "name": "@ontrails/schema",
       "version": "1.0.0-beta.11",
@@ -254,6 +262,8 @@
     "@ontrails/logging": ["@ontrails/logging@workspace:packages/logging"],
 
     "@ontrails/mcp": ["@ontrails/mcp@workspace:packages/mcp"],
+
+    "@ontrails/permits": ["@ontrails/permits@workspace:packages/permits"],
 
     "@ontrails/schema": ["@ontrails/schema@workspace:packages/schema"],
 

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@ontrails/permits",
+  "version": "1.0.0-beta.11",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./jwt": "./src/adapters/jwt.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@ontrails/core": "workspace:^",
+    "zod": "catalog:"
+  }
+}

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -1,0 +1,4 @@
+/** Internal placeholder — replaced by real types in TRL-98+. */
+export interface PermitPlaceholder {
+  readonly __brand: 'permits';
+}

--- a/packages/permits/tsconfig.json
+++ b/packages/permits/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
## Summary

- Create `packages/permits/` with `package.json`, `tsconfig.json`, and barrel export
- Same structure as `@ontrails/config` — peer deps on `@ontrails/core` and `zod`

## Test plan

- [ ] `bun run typecheck` passes in `packages/permits/`
- [ ] Package visible in workspace

Closes https://linear.app/outfitter/issue/TRL-97/scaffold-ontrailspermits-package

In-collaboration-with: [Claude Code](https://claude.com/claude-code)