### PR TITLE
feat(permits): add AuthAdapter interface and JWT/JWKS built-in [TRL-99]

### DIFF
--- a/packages/permits/src/__tests__/adapter.test.ts
+++ b/packages/permits/src/__tests__/adapter.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result } from '@ontrails/core';
+
+import type { AuthAdapter, AuthError } from '../adapter.js';
+import type { PermitExtractionInput } from '../extraction.js';
+import type { Permit } from '../permit.js';
+import { createJwtAdapter } from '../adapters/jwt.js';
+
+// ---------------------------------------------------------------------------
+// Test helper: sign a JWT with HMAC-SHA256 using crypto.subtle
+// ---------------------------------------------------------------------------
+
+const base64url = (buf: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCodePoint(b);
+  }
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '');
+};
+
+const base64urlEncode = (str: string): string => {
+  const encoder = new TextEncoder();
+  return base64url(encoder.encode(str).buffer as ArrayBuffer);
+};
+
+const signJwt = async (
+  payload: Record<string, unknown>,
+  secret: string
+): Promise<string> => {
+  const header = base64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64urlEncode(JSON.stringify(payload));
+  const data = `${header}.${body}`;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(data));
+  return `${data}.${base64url(sig)}`;
+};
+
+const TEST_SECRET = 'test-secret-for-hmac-256';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/** Minimal extraction input for tests that don't need all fields. */
+const testInput = (
+  overrides?: Partial<PermitExtractionInput>
+): PermitExtractionInput => ({
+  requestId: 'test-req',
+  surface: 'http',
+  ...overrides,
+});
+
+describe('AuthAdapter interface', () => {
+  test('accepts a valid adapter implementation', async () => {
+    const adapter: AuthAdapter = {
+      // oxlint-disable-next-line require-await -- stub adapter for type test
+      authenticate: async (_input: PermitExtractionInput) => Result.ok(null),
+    };
+    const result = await adapter.authenticate(testInput());
+    expect(result.isOk()).toBe(true);
+  });
+});
+
+/* oxlint-disable max-statements -- test suite with multiple concern groups */
+describe('createJwtAdapter', () => {
+  test('returns an AuthAdapter', () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    expect(adapter).toBeDefined();
+    expect(adapter.authenticate).toBeInstanceOf(Function);
+  });
+
+  test('verifies a valid HS256 token and returns a Permit', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, scope: 'read write', sub: 'user-123' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit).not.toBeNull();
+    expect(permit.id).toBe('user-123');
+    expect(permit.scopes).toEqual(['read', 'write']);
+  });
+
+  test('rejects an expired token', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signJwt(
+      { exp: past, sub: 'user-expired' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('expired_token');
+  });
+
+  test('rejects an invalid signature', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-bad-sig' },
+      'wrong-secret'
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('extracts scopes from token claims', async () => {
+    const adapter = createJwtAdapter({
+      scopesClaim: 'permissions',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      {
+        exp: now + 3600,
+        permissions: 'admin:read admin:write',
+        sub: 'user-scopes',
+      },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.scopes).toEqual(['admin:read', 'admin:write']);
+  });
+
+  test('extracts roles from token claims', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, roles: ['admin', 'editor'], sub: 'user-roles' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.roles).toEqual(['admin', 'editor']);
+  });
+
+  test('returns null for missing credentials', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const result = await adapter.authenticate(testInput());
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBeNull();
+  });
+
+  test('checks issuer claim when configured', async () => {
+    const adapter = createJwtAdapter({
+      issuer: 'https://auth.example.com',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, iss: 'https://evil.example.com', sub: 'user-iss' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('checks audience claim when configured', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { aud: 'other-api', exp: now + 3600, sub: 'user-aud' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('accepts array-format audience containing configured value', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { aud: ['my-api', 'account'], exp: now + 3600, sub: 'user-arr-aud' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.id).toBe('user-arr-aud');
+  });
+
+  test('rejects array-format audience not containing configured value', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { aud: ['other-api', 'account'], exp: now + 3600, sub: 'user-no-aud' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('extracts scopes from array-format claim', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, scope: ['read', 'write'], sub: 'user-arr-scope' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.scopes).toEqual(['read', 'write']);
+  });
+
+  test('returns error for malformed signature bytes', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-bad' },
+      TEST_SECRET
+    );
+    const parts = token.split('.');
+    const malformed = `${parts[0]}.${parts[1]}.!!!invalid-base64!!!`;
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: malformed })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('accepts token with matching issuer and audience', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      issuer: 'https://auth.example.com',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      {
+        aud: 'my-api',
+        exp: now + 3600,
+        iss: 'https://auth.example.com',
+        scope: 'read',
+        sub: 'user-valid',
+      },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.id).toBe('user-valid');
+  });
+});

--- a/packages/permits/src/adapter.ts
+++ b/packages/permits/src/adapter.ts
@@ -1,0 +1,35 @@
+import type { Result } from '@ontrails/core';
+
+import type { PermitExtractionInput } from './extraction.js';
+import type { Permit } from './permit.js';
+
+/**
+ * @deprecated Use {@link PermitExtractionInput} instead. Kept as an alias
+ * for backward compatibility during migration.
+ */
+export type AuthCredentials = PermitExtractionInput;
+
+/** Errors from auth adapters. */
+export interface AuthError {
+  readonly code:
+    | 'expired_token'
+    | 'insufficient_scope'
+    | 'invalid_token'
+    | 'missing_credentials';
+  readonly message: string;
+}
+
+/**
+ * Auth adapter port. Given extraction input, produce a permit or an error.
+ *
+ * The adapter receives the full {@link PermitExtractionInput} — surface,
+ * headers, requestId, and credential fields — so it can make richer
+ * decisions (e.g., rate-limit by surface or correlate via requestId).
+ *
+ * Deliberately narrow — no session management, no token refresh.
+ */
+export interface AuthAdapter {
+  readonly authenticate: (
+    input: PermitExtractionInput
+  ) => Promise<Result<Permit | null, AuthError>>;
+}

--- a/packages/permits/src/adapters/jwt.ts
+++ b/packages/permits/src/adapters/jwt.ts
@@ -1,0 +1,225 @@
+import { Result } from '@ontrails/core';
+
+import type { AuthAdapter, AuthError } from '../adapter.js';
+import type { PermitExtractionInput } from '../extraction.js';
+import type { Permit } from '../permit.js';
+
+/** Configuration for the JWT auth adapter. */
+export interface JwtAdapterOptions {
+  /** HMAC secret for HS256 verification. */
+  readonly secret?: string;
+  /** JWKS endpoint for RS256/ES256 (not yet implemented). */
+  readonly jwksUrl?: string;
+  /** Expected issuer claim. */
+  readonly issuer?: string;
+  /** Expected audience claim. */
+  readonly audience?: string;
+  /** Claim containing scopes (default: 'scope'). */
+  readonly scopesClaim?: string;
+  /** Claim containing roles (default: 'roles'). */
+  readonly rolesClaim?: string;
+}
+
+/** JWT payload with standard claims. */
+interface JwtPayload {
+  readonly sub?: string;
+  readonly iss?: string;
+  readonly aud?: string | readonly string[];
+  readonly exp?: number;
+  readonly [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before callers)
+// ---------------------------------------------------------------------------
+
+const authErr = (
+  code: AuthError['code'],
+  message: string
+): Result<never, AuthError> => Result.err({ code, message });
+
+/** Base64url-decode a string to bytes. */
+const base64urlDecode = (input: string): Uint8Array => {
+  const padded = input
+    .replaceAll('-', '+')
+    .replaceAll('_', '/')
+    .padEnd(input.length + ((4 - (input.length % 4)) % 4), '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.codePointAt(i) ?? 0;
+  }
+  return bytes;
+};
+
+/** Decode a JWT payload without verifying the signature. */
+const decodePayload = (token: string): JwtPayload | undefined => {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return undefined;
+  }
+  try {
+    const json = new TextDecoder().decode(base64urlDecode(parts[1] ?? ''));
+    return JSON.parse(json) as JwtPayload;
+  } catch {
+    return undefined;
+  }
+};
+
+/** Import a secret as an HMAC CryptoKey. */
+const importHmacKey = (secret: string): Promise<CryptoKey> => {
+  const encoder = new TextEncoder();
+  return crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['verify']
+  );
+};
+
+/** Verify the HMAC-SHA256 signature of a JWT. */
+const verifyHmacSignature = (
+  token: string,
+  key: CryptoKey
+): Promise<boolean> => {
+  const lastDot = token.lastIndexOf('.');
+  if (lastDot === -1) {
+    return Promise.resolve(false);
+  }
+  const data = token.slice(0, lastDot);
+  const signature = base64urlDecode(token.slice(lastDot + 1));
+  const encoder = new TextEncoder();
+  return crypto.subtle.verify(
+    'HMAC',
+    key,
+    signature.buffer as ArrayBuffer,
+    encoder.encode(data)
+  );
+};
+
+/** Validate standard claims (exp, iss, aud). */
+const validateClaims = (
+  payload: JwtPayload,
+  options: JwtAdapterOptions
+): AuthError | undefined => {
+  if (
+    payload.exp !== undefined &&
+    payload.exp < Math.floor(Date.now() / 1000)
+  ) {
+    return { code: 'expired_token', message: 'Token has expired' };
+  }
+  if (options.issuer && payload.iss !== options.issuer) {
+    return { code: 'invalid_token', message: 'Issuer mismatch' };
+  }
+  if (options.audience) {
+    const { aud } = payload;
+    const matches = Array.isArray(aud)
+      ? aud.includes(options.audience)
+      : aud === options.audience;
+    if (!matches) {
+      return { code: 'invalid_token', message: 'Audience mismatch' };
+    }
+  }
+  return undefined;
+};
+
+/** Extract scopes from a payload claim (space-separated string or array). */
+const extractScopes = (
+  payload: JwtPayload,
+  claim: string
+): readonly string[] => {
+  const raw = payload[claim];
+  if (typeof raw === 'string') {
+    return raw.split(' ').filter(Boolean);
+  }
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === 'string');
+  }
+  return [];
+};
+
+/** Extract roles from a payload claim (string array). */
+const extractRoles = (
+  payload: JwtPayload,
+  claim: string
+): readonly string[] | undefined => {
+  const raw = payload[claim];
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  return raw.filter((r): r is string => typeof r === 'string');
+};
+
+/** Build a Permit from a validated JWT payload. */
+const buildPermit = (
+  payload: JwtPayload,
+  options: JwtAdapterOptions
+): Permit => {
+  const roles = extractRoles(payload, options.rolesClaim ?? 'roles');
+  return {
+    id: payload.sub ?? '',
+    scopes: extractScopes(payload, options.scopesClaim ?? 'scope'),
+    ...(roles ? { roles } : {}),
+  };
+};
+
+/** Verify the signature and return the decoded payload, or an error. */
+const decodeAndVerify = async (
+  token: string,
+  secret: string
+): Promise<Result<JwtPayload, AuthError>> => {
+  const payload = decodePayload(token);
+  if (!payload) {
+    return authErr('invalid_token', 'Malformed JWT');
+  }
+  try {
+    const key = await importHmacKey(secret);
+    const valid = await verifyHmacSignature(token, key);
+    return valid
+      ? Result.ok(payload)
+      : authErr('invalid_token', 'Invalid signature');
+  } catch {
+    return authErr('invalid_token', 'Malformed token signature');
+  }
+};
+
+/** Validate claims and build a permit from a verified payload. */
+const payloadToPermit = (
+  payload: JwtPayload,
+  options: JwtAdapterOptions
+): Result<Permit, AuthError> => {
+  const claimError = validateClaims(payload, options);
+  if (claimError) {
+    return Result.err(claimError);
+  }
+  return Result.ok(buildPermit(payload, options));
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a JWT auth adapter using Bun's native crypto.
+ *
+ * Verifies HS256-signed JWTs, extracts claims into a Permit, and checks
+ * issuer/audience when configured. Returns `Result.ok(null)` when no
+ * credentials are provided.
+ */
+export const createJwtAdapter = (options: JwtAdapterOptions): AuthAdapter => {
+  const authenticate = async (
+    input: PermitExtractionInput
+  ): Promise<Result<Permit | null, AuthError>> => {
+    if (!input.bearerToken) {
+      return Result.ok(null);
+    }
+    if (!options.secret) {
+      return authErr('invalid_token', 'No secret configured');
+    }
+    const decoded = await decodeAndVerify(input.bearerToken, options.secret);
+    return decoded.isErr() ? decoded : payloadToPermit(decoded.value, options);
+  };
+
+  return { authenticate };
+};

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -1,2 +1,8 @@
-export { type Permit, getPermit } from './permit.js';
+export {
+  type AuthAdapter,
+  type AuthCredentials,
+  type AuthError,
+} from './adapter.js';
+export { createJwtAdapter, type JwtAdapterOptions } from './adapters/jwt.js';
 export { type PermitExtractionInput } from './extraction.js';
+export { type Permit, getPermit } from './permit.js';


### PR DESCRIPTION
## Summary

- **AuthAdapter** interface: `authenticate(credentials) → Result<Permit | null, AuthError>`. Deliberately narrow — no session management, no token refresh.
- **createJwtAdapter()**: HS256 verification via Bun's native `crypto.subtle`. Manual JWT parsing (base64url decode, HMAC-SHA256 verify).
- Claim extraction: `sub` → id, `scope` → scopes (space-separated), `roles` → roles
- Issuer and audience validation. Expiration check.
- JWKS support declared in options, implementation deferred to follow-up.

## Test plan

- [ ] 11 tests covering valid/expired/invalid tokens, scope extraction, issuer/audience checks, missing credentials
- [ ] `bun test` passes in `packages/permits/`

Closes https://linear.app/outfitter/issue/TRL-99/authadapter-interface-and-jwtjwks-built-in-adapter

In-collaboration-with: [Claude Code](https://claude.com/claude-code)