### PR TITLE
feat(permits): add auth layer with scope enforcement [TRL-100]

### DIFF
--- a/packages/permits/src/__tests__/auth-layer.test.ts
+++ b/packages/permits/src/__tests__/auth-layer.test.ts
@@ -1,0 +1,130 @@
+/* oxlint-disable require-await -- layer wrappers satisfy async interfaces without awaiting */
+import { describe, expect, test } from 'bun:test';
+
+import { Result, trail } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { authLayer } from '../auth-layer';
+import { PermitError } from '../errors';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeCtx = (permit?: {
+  id: string;
+  scopes: readonly string[];
+}): TrailContext => ({
+  permit,
+  requestId: 'test-auth',
+  signal: AbortSignal.timeout(5000),
+});
+
+const okImpl = async () => Result.ok({ done: true });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('authLayer', () => {
+  test('has correct name and description', () => {
+    expect(authLayer.name).toBe('auth');
+    expect(authLayer.description).toBeDefined();
+  });
+
+  describe('pass-through cases', () => {
+    test('passes through when trail has no permit field', async () => {
+      const t = trail('test.nopermit', {
+        input: z.object({}),
+        output: z.object({ done: z.boolean() }),
+        run: okImpl,
+      });
+
+      const wrapped = authLayer.wrap(t, okImpl);
+      const result = await wrapped({}, makeCtx());
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+
+    test('passes through when trail permit is public', async () => {
+      const t = trail('test.public', {
+        input: z.object({}),
+        output: z.object({ done: z.boolean() }),
+        permit: 'public',
+        run: okImpl,
+      });
+
+      const wrapped = authLayer.wrap(t, okImpl);
+      const result = await wrapped({}, makeCtx());
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+  });
+
+  describe('scope enforcement', () => {
+    const scopedTrail = trail('test.scoped', {
+      input: z.object({}),
+      output: z.object({ done: z.boolean() }),
+      permit: { scopes: ['user:read'] },
+      run: okImpl,
+    });
+
+    test('passes when ctx.permit has matching scopes', async () => {
+      const wrapped = authLayer.wrap(scopedTrail, okImpl);
+      const result = await wrapped(
+        {},
+        makeCtx({ id: 'usr-1', scopes: ['user:read'] })
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+
+    test('returns error when ctx has no permit', async () => {
+      const wrapped = authLayer.wrap(scopedTrail, okImpl);
+      const result = await wrapped({}, makeCtx());
+
+      expect(result.isErr()).toBe(true);
+      const err = (result as unknown as { error: PermitError }).error;
+      expect(err).toBeInstanceOf(PermitError);
+      expect(err.message).toContain('No permit');
+    });
+
+    test('returns error when permit is missing required scopes', async () => {
+      const multiScopeTrail = trail('test.multi', {
+        input: z.object({}),
+        output: z.object({ done: z.boolean() }),
+        permit: { scopes: ['user:read', 'user:write'] },
+        run: okImpl,
+      });
+
+      const wrapped = authLayer.wrap(multiScopeTrail, okImpl);
+      const result = await wrapped(
+        {},
+        makeCtx({ id: 'usr-1', scopes: ['user:read'] })
+      );
+
+      expect(result.isErr()).toBe(true);
+      const err = (result as unknown as { error: PermitError }).error;
+      expect(err).toBeInstanceOf(PermitError);
+      expect(err.message).toContain('user:write');
+    });
+
+    test('passes when permit has superset of required scopes', async () => {
+      const wrapped = authLayer.wrap(scopedTrail, okImpl);
+      const result = await wrapped(
+        {},
+        makeCtx({
+          id: 'usr-1',
+          scopes: ['user:read', 'user:write', 'admin'],
+        })
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+  });
+});

--- a/packages/permits/src/auth-layer.ts
+++ b/packages/permits/src/auth-layer.ts
@@ -1,0 +1,76 @@
+import { Result } from '@ontrails/core';
+import type { Layer } from '@ontrails/core';
+
+import { PermitError } from './errors.js';
+import { getPermit } from './permit.js';
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before callers — no use-before-define)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when the permit requirement means "no enforcement needed."
+ * Either the trail hasn't declared a permit posture or has explicitly
+ * opted out with `'public'`.
+ */
+const isPassThrough = (
+  requirement: unknown
+): requirement is undefined | 'public' =>
+  requirement === undefined || requirement === 'public';
+
+/** Returns scopes present in `required` but absent from `held`. */
+const findMissing = (
+  required: readonly string[],
+  held: readonly string[]
+): readonly string[] => required.filter((s) => !held.includes(s));
+
+// ---------------------------------------------------------------------------
+// Auth layer
+// ---------------------------------------------------------------------------
+
+/**
+ * A {@link Layer} that enforces permit scopes declared on trails.
+ *
+ * The layer reads the trail's `permit` field (a `PermitRequirement`):
+ *
+ * - If `permit` is `'public'` or `undefined` the layer passes through.
+ * - If `permit` has `scopes`, the layer checks that `ctx.permit` contains
+ *   all required scopes. A superset is fine; missing scopes produce a
+ *   `PermitError`.
+ *
+ * Because `ctx.follow()` re-enters `executeTrail` (which applies layers),
+ * this layer automatically re-checks on every invocation in a follow chain.
+ * No special follow-chain handling is needed — it is built into the
+ * architecture.
+ */
+export const authLayer: Layer = {
+  description: 'Enforces permit scopes declared on trails',
+  name: 'auth',
+  wrap: (_trail, impl) => {
+    const requirement = _trail.permit;
+
+    if (isPassThrough(requirement)) {
+      return impl;
+    }
+
+    return (input, ctx) => {
+      const permit = getPermit(ctx);
+
+      if (!permit) {
+        return Result.err(new PermitError('No permit provided'));
+      }
+
+      const missing = findMissing(requirement.scopes, permit.scopes);
+
+      if (missing.length > 0) {
+        return Result.err(
+          new PermitError(`Missing scopes: ${missing.join(', ')}`, {
+            context: { missing, required: requirement.scopes },
+          })
+        );
+      }
+
+      return impl(input, ctx);
+    };
+  },
+};

--- a/packages/permits/src/errors.ts
+++ b/packages/permits/src/errors.ts
@@ -1,0 +1,18 @@
+import { PermissionError } from '@ontrails/core';
+
+/**
+ * Error returned when permit scope enforcement fails.
+ *
+ * Extends `PermissionError` (category `'permission'`, HTTP 403) because
+ * it represents an *authorization* failure — the caller's identity is known
+ * but lacks the required scopes.
+ */
+export class PermitError extends PermissionError {
+  constructor(
+    message: string,
+    options?: { cause?: Error; context?: Record<string, unknown> }
+  ) {
+    super(message, options);
+    this.name = 'PermitError';
+  }
+}

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -4,5 +4,7 @@ export {
   type AuthError,
 } from './adapter.js';
 export { createJwtAdapter, type JwtAdapterOptions } from './adapters/jwt.js';
+export { authLayer } from './auth-layer.js';
+export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';


### PR DESCRIPTION
## Summary

- **authLayer**: Layer that enforces permit scopes declared on trails
- Passes through when `permit` is undefined or `'public'`
- Checks `ctx.permit.scopes` against required scopes
- Returns `PermitError` (extends `PermissionError`, HTTP 403) with missing scope details
- Re-checks on follow chains by design — layers apply on every `executeTrail` invocation

## Test plan

- [ ] 7 tests: no permit field, public, matching scopes, missing permit, insufficient scopes, superset passes, missing scope detail
- [ ] `bun test` passes in `packages/permits/`

Closes https://linear.app/outfitter/issue/TRL-100/auth-layer-scope-enforcement-and-follow-chain-re-checks

In-collaboration-with: [Claude Code](https://claude.com/claude-code)