### PR TITLE
feat(permits): add warden governance rules for permits [TRL-101]

### DIFF
--- a/packages/permits/src/__tests__/rules.test.ts
+++ b/packages/permits/src/__tests__/rules.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from 'bun:test';
+import { trail, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  destroyWithoutPermit,
+  writeWithoutPermit,
+  scopeNamingConsistency,
+  orphanScopeDetection,
+  validatePermits,
+} from '../rules.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const emptyInput = z.object({});
+const noopRun = () => Result.ok({});
+
+// ---------------------------------------------------------------------------
+// destroyWithoutPermit
+// ---------------------------------------------------------------------------
+
+describe('destroyWithoutPermit', () => {
+  test('error when destroy trail has no permit', () => {
+    const t = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      run: noopRun,
+    });
+    const diagnostics = destroyWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      message: expect.stringContaining('destroy'),
+      rule: 'destroyWithoutPermit',
+      severity: 'error',
+      trailId: 'user.delete',
+    });
+  });
+
+  test('no diagnostic when destroy trail has a scoped permit', () => {
+    const t = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      permit: { scopes: ['user:delete'] },
+      run: noopRun,
+    });
+    const diagnostics = destroyWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('error when destroy trail has permit: public', () => {
+    const t = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      permit: 'public',
+      run: noopRun,
+    });
+    const diagnostics = destroyWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'destroyWithoutPermit',
+      severity: 'error',
+      trailId: 'user.delete',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeWithoutPermit
+// ---------------------------------------------------------------------------
+
+describe('writeWithoutPermit', () => {
+  test('warning when write trail has no permit', () => {
+    const t = trail('user.create', {
+      input: emptyInput,
+      run: noopRun,
+    });
+    const diagnostics = writeWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'writeWithoutPermit',
+      severity: 'warning',
+      trailId: 'user.create',
+    });
+  });
+
+  test('no warning when write trail has permit: public', () => {
+    const t = trail('user.create', {
+      input: emptyInput,
+      permit: 'public',
+      run: noopRun,
+    });
+    const diagnostics = writeWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('warning when trail has no intent (defaults to write)', () => {
+    const t = trail('user.update', {
+      input: emptyInput,
+      run: noopRun,
+    });
+    // Override intent to undefined to simulate a manually constructed trail
+    const noIntent = { ...t, intent: undefined } as unknown as ReturnType<
+      typeof trail
+    >;
+    const diagnostics = writeWithoutPermit([noIntent]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'writeWithoutPermit',
+      severity: 'warning',
+      trailId: 'user.update',
+    });
+  });
+
+  test('no diagnostic for read trail without permit', () => {
+    const t = trail('user.list', {
+      input: emptyInput,
+      intent: 'read',
+      run: noopRun,
+    });
+    const diagnostics = writeWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scopeNamingConsistency
+// ---------------------------------------------------------------------------
+
+describe('scopeNamingConsistency', () => {
+  test('scope user:write passes naming check', () => {
+    const t = trail('user.update', {
+      input: emptyInput,
+      permit: { scopes: ['user:write'] },
+      run: noopRun,
+    });
+    const diagnostics = scopeNamingConsistency([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('warning for scope without colon', () => {
+    const t = trail('admin.panel', {
+      input: emptyInput,
+      permit: { scopes: ['admin'] },
+      run: noopRun,
+    });
+    const diagnostics = scopeNamingConsistency([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      message: expect.stringContaining('admin'),
+      rule: 'scopeNamingConsistency',
+      severity: 'warning',
+      trailId: 'admin.panel',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orphanScopeDetection
+// ---------------------------------------------------------------------------
+
+describe('orphanScopeDetection', () => {
+  test('warning for orphan scope (typo)', () => {
+    const t1 = trail('user.read', {
+      input: emptyInput,
+      permit: { scopes: ['user:read'] },
+      run: noopRun,
+    });
+    const t2 = trail('user.write', {
+      input: emptyInput,
+      permit: { scopes: ['user:wirte'] },
+      run: noopRun,
+    });
+    const diagnostics = orphanScopeDetection([t1, t2]);
+    // Both scopes are unique (appear in only 1 trail each)
+    expect(diagnostics).toHaveLength(2);
+    const messages = diagnostics.map((d) => d.message);
+    expect(messages.some((m) => m.includes('user:wirte'))).toBe(true);
+  });
+
+  test('no warning for shared scopes', () => {
+    const t1 = trail('user.read', {
+      input: emptyInput,
+      permit: { scopes: ['user:read'] },
+      run: noopRun,
+    });
+    const t2 = trail('user.profile', {
+      input: emptyInput,
+      permit: { scopes: ['user:read'] },
+      run: noopRun,
+    });
+    const diagnostics = orphanScopeDetection([t1, t2]);
+    expect(diagnostics).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validatePermits
+// ---------------------------------------------------------------------------
+
+/* oxlint-disable max-statements -- integration test validates all rules fire */
+describe('validatePermits', () => {
+  test('runs all rules and aggregates diagnostics', () => {
+    const destroyNoPerm = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      run: noopRun,
+    });
+    const writeNoPerm = trail('user.create', {
+      input: emptyInput,
+      run: noopRun,
+    });
+    const badScope = trail('admin.panel', {
+      input: emptyInput,
+      permit: { scopes: ['admin'] },
+      run: noopRun,
+    });
+    const orphanScope = trail('analytics.export', {
+      input: emptyInput,
+      permit: { scopes: ['analytics:exportt'] },
+      run: noopRun,
+    });
+
+    const diagnostics = validatePermits([
+      destroyNoPerm,
+      writeNoPerm,
+      badScope,
+      orphanScope,
+    ]);
+
+    const rules = diagnostics.map((d) => d.rule);
+    expect(rules).toContain('destroyWithoutPermit');
+    expect(rules).toContain('writeWithoutPermit');
+    expect(rules).toContain('scopeNamingConsistency');
+    expect(rules).toContain('orphanScopeDetection');
+    expect(diagnostics.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -8,3 +8,4 @@ export { authLayer } from './auth-layer.js';
 export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';
+export { validatePermits, type PermitDiagnostic } from './rules.js';

--- a/packages/permits/src/rules.ts
+++ b/packages/permits/src/rules.ts
@@ -1,0 +1,183 @@
+import type { Trail } from '@ontrails/core';
+
+// ---------------------------------------------------------------------------
+// Diagnostic type
+// ---------------------------------------------------------------------------
+
+/** A single governance finding from a permit rule. */
+export interface PermitDiagnostic {
+  readonly trailId: string;
+  readonly rule: string;
+  readonly severity: 'error' | 'warning';
+  readonly message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type AnyTrail = Trail<unknown, unknown>;
+type Rule = (trails: readonly AnyTrail[]) => readonly PermitDiagnostic[];
+
+/** Check whether a trail has any permit declaration (scopes object or 'public'). */
+const hasPermit = (t: AnyTrail): boolean => t.permit !== undefined;
+
+/** Extract scopes from a trail's permit declaration, or empty array. */
+const getScopes = (t: AnyTrail): readonly string[] => {
+  if (t.permit !== undefined && t.permit !== 'public') {
+    return t.permit.scopes;
+  }
+  return [];
+};
+
+// ---------------------------------------------------------------------------
+// Rule: destroyWithoutPermit
+// ---------------------------------------------------------------------------
+
+/**
+ * Destructive trails without a real permit declaration are a governance failure.
+ *
+ * Reports an error for every trail with `intent: 'destroy'` that has no
+ * `permit` field or explicitly opts out with `permit: 'public'`.
+ */
+export const destroyWithoutPermit: Rule = (trails) =>
+  trails
+    .filter(
+      (t) => t.intent === 'destroy' && (!hasPermit(t) || t.permit === 'public')
+    )
+    .map((t) => ({
+      message: `Trail "${t.id}" has intent 'destroy' but no permit declaration`,
+      rule: 'destroyWithoutPermit',
+      severity: 'error' as const,
+      trailId: t.id,
+    }));
+
+// ---------------------------------------------------------------------------
+// Rule: writeWithoutPermit
+// ---------------------------------------------------------------------------
+
+/**
+ * Write trails without a permit declaration get a warning.
+ *
+ * Trails with `intent: 'write'` (or no intent, which defaults to write) that
+ * lack a permit are flagged unless `permit: 'public'` is explicitly set.
+ */
+export const writeWithoutPermit: Rule = (trails) =>
+  trails
+    .filter(
+      (t) => (t.intent === 'write' || t.intent === undefined) && !hasPermit(t)
+    )
+    .map((t) => ({
+      message: `Trail "${t.id}" has write intent but no permit declaration`,
+      rule: 'writeWithoutPermit',
+      severity: 'warning' as const,
+      trailId: t.id,
+    }));
+
+// ---------------------------------------------------------------------------
+// Rule: scopeNamingConsistency
+// ---------------------------------------------------------------------------
+
+/** Returns true when a scope follows the `entity:action` convention. */
+const isValidScopeFormat = (scope: string): boolean => {
+  const parts = scope.split(':');
+  return (
+    parts.length === 2 &&
+    (parts[0]?.length ?? 0) > 0 &&
+    (parts[1]?.length ?? 0) > 0
+  );
+};
+
+/**
+ * Warns for scopes that don't follow the `entity:action` convention.
+ *
+ * A valid scope contains exactly one colon separating a non-empty entity
+ * and a non-empty action.
+ */
+export const scopeNamingConsistency: Rule = (trails) =>
+  trails.flatMap((t) =>
+    getScopes(t)
+      .filter((scope) => !isValidScopeFormat(scope))
+      .map((scope) => ({
+        message: `Scope "${scope}" on trail "${t.id}" does not follow entity:action convention`,
+        rule: 'scopeNamingConsistency',
+        severity: 'warning' as const,
+        trailId: t.id,
+      }))
+  );
+
+// ---------------------------------------------------------------------------
+// Rule: orphanScopeDetection
+// ---------------------------------------------------------------------------
+
+/** Build a map of scope -> set of trail IDs that declare it. */
+const buildScopeMap = (
+  trails: readonly AnyTrail[]
+): ReadonlyMap<string, ReadonlySet<string>> => {
+  const map = new Map<string, Set<string>>();
+  for (const t of trails) {
+    for (const scope of getScopes(t)) {
+      const existing = map.get(scope);
+      if (existing) {
+        existing.add(t.id);
+      } else {
+        map.set(scope, new Set([t.id]));
+      }
+    }
+  }
+  return map;
+};
+
+/** Filter trails that have a scoped (non-public) permit declaration. */
+const trailsWithScopedPermit = (
+  trails: readonly AnyTrail[]
+): readonly AnyTrail[] =>
+  trails.filter((t) => t.permit !== undefined && t.permit !== 'public');
+
+/** Convert orphan scope map entries into diagnostics. */
+const orphanDiagnostics = (
+  scopeMap: ReadonlyMap<string, ReadonlySet<string>>
+): readonly PermitDiagnostic[] =>
+  [...scopeMap.entries()]
+    .filter(([, ids]) => ids.size === 1)
+    .map(([scope, ids]) => ({
+      message: `Scope "${scope}" appears only on trail "${[...ids][0]}" — possible typo`,
+      rule: 'orphanScopeDetection',
+      severity: 'warning' as const,
+      trailId: [...ids][0] ?? '',
+    }));
+
+/**
+ * Warns for scopes that appear in only one trail's permit.
+ *
+ * Catches typos like `user:wirte` by surfacing scopes not shared with any
+ * other trail. Only runs when at least 2 trails have permit declarations.
+ */
+export const orphanScopeDetection: Rule = (trails) => {
+  const scoped = trailsWithScopedPermit(trails);
+  if (scoped.length < 2) {
+    return [];
+  }
+  return orphanDiagnostics(buildScopeMap(scoped));
+};
+
+// ---------------------------------------------------------------------------
+// Top-level validator
+// ---------------------------------------------------------------------------
+
+const allRules: readonly Rule[] = [
+  destroyWithoutPermit,
+  writeWithoutPermit,
+  scopeNamingConsistency,
+  orphanScopeDetection,
+];
+
+/**
+ * Run all permit governance rules against a set of trails.
+ *
+ * Returns a flat array of diagnostics from every rule. An empty array
+ * means the topo passes all permit governance checks.
+ */
+export const validatePermits = (
+  trails: readonly Trail<unknown, unknown>[]
+): readonly PermitDiagnostic[] => allRules.flatMap((rule) => rule(trails));


### PR DESCRIPTION
## Summary

- **destroyWithoutPermit** — error on `intent: 'destroy'` without permit
- **writeWithoutPermit** — warning on `intent: 'write'` or `undefined` (defaults to write) without permit; silenced by `permit: 'public'`
- **scopeNamingConsistency** — warns on scopes not in `entity:action` format
- **orphanScopeDetection** — catches typos via single-use scope detection
- **validatePermits()** — runs all rules, returns aggregated diagnostics

## Test plan

- [ ] 11 tests including trail with undefined intent triggering write warning
- [ ] `bun test` passes in `packages/permits/`

Closes https://linear.app/outfitter/issue/TRL-101/warden-governance-rules-for-permits

In-collaboration-with: [Claude Code](https://claude.com/claude-code)