### PR TITLE
feat(permits): add synthetic permit minting for testing [TRL-102]

### DIFF
--- a/packages/permits/src/__tests__/testing.test.ts
+++ b/packages/permits/src/__tests__/testing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+
+import { mintPermitForTrail, mintTestPermit } from '../testing';
+
+describe('mintTestPermit()', () => {
+  test('returns a Permit with the given scopes', () => {
+    const permit = mintTestPermit({ scopes: ['user:read', 'user:write'] });
+    expect(permit.scopes).toEqual(['user:read', 'user:write']);
+  });
+
+  test('generates a unique id when not specified', () => {
+    const a = mintTestPermit();
+    const b = mintTestPermit();
+    expect(a.id).not.toBe(b.id);
+  });
+
+  test('uses the provided id when specified', () => {
+    const permit = mintTestPermit({ id: 'custom-id' });
+    expect(permit.id).toBe('custom-id');
+  });
+
+  test('returns empty scopes when no options provided', () => {
+    const permit = mintTestPermit();
+    expect(permit.scopes).toEqual([]);
+  });
+
+  test('includes roles when provided', () => {
+    const permit = mintTestPermit({ roles: ['admin', 'editor'] });
+    expect(permit.roles).toEqual(['admin', 'editor']);
+  });
+
+  test('includes tenantId when provided', () => {
+    const permit = mintTestPermit({ tenantId: 'tenant_abc' });
+    expect(permit.tenantId).toBe('tenant_abc');
+  });
+});
+
+describe('mintPermitForTrail()', () => {
+  test('extracts scopes from trail permit requirement', () => {
+    const trail = { permit: { scopes: ['entity:read', 'entity:write'] } };
+    const permit = mintPermitForTrail(trail);
+    expect(permit).toBeDefined();
+    expect(permit?.scopes).toEqual(['entity:read', 'entity:write']);
+  });
+
+  test('returns undefined for public trails', () => {
+    const trail = { permit: 'public' as const };
+    const permit = mintPermitForTrail(trail);
+    expect(permit).toBeUndefined();
+  });
+
+  test('returns undefined when no permit declared', () => {
+    const trail = {};
+    const permit = mintPermitForTrail(trail);
+    expect(permit).toBeUndefined();
+  });
+});

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -9,3 +9,4 @@ export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';
 export { validatePermits, type PermitDiagnostic } from './rules.js';
+export { mintTestPermit, mintPermitForTrail } from './testing.js';

--- a/packages/permits/src/testing.ts
+++ b/packages/permits/src/testing.ts
@@ -1,0 +1,34 @@
+import type { PermitRequirement } from '@ontrails/core';
+
+import type { Permit } from './permit.js';
+
+/**
+ * Mint a synthetic test permit with exactly the declared scopes.
+ * No admin permit, no wildcard — tests get only what the trail declares.
+ */
+export const mintTestPermit = (options?: {
+  readonly id?: string;
+  readonly scopes?: readonly string[];
+  readonly roles?: readonly string[];
+  readonly tenantId?: string;
+}): Permit => ({
+  id:
+    options?.id ??
+    `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  scopes: [...(options?.scopes ?? [])],
+  ...(options?.roles === undefined ? {} : { roles: [...options.roles] }),
+  ...(options?.tenantId === undefined ? {} : { tenantId: options.tenantId }),
+});
+
+/**
+ * Create a test permit matching a trail's permit requirement.
+ * Extracts scopes from the requirement and mints a permit with exactly those scopes.
+ */
+export const mintPermitForTrail = (trail: {
+  readonly permit?: PermitRequirement | undefined;
+}): Permit | undefined => {
+  if (!trail.permit || trail.permit === 'public') {
+    return undefined;
+  }
+  return mintTestPermit({ scopes: trail.permit.scopes });
+};


### PR DESCRIPTION
## Summary

- **mintTestPermit()** — create permit with exact scopes, no wildcards. Unique ID generation.
- **mintPermitForTrail()** — extract scopes from trail's permit requirement, mint matching permit. Returns `undefined` for public trails.

## Test plan

- [ ] 9 tests covering custom scopes/id/roles/tenantId, trail extraction, public trails
- [ ] `bun test` passes in `packages/permits/`

Closes https://linear.app/outfitter/issue/TRL-102/permit-testing-synthetic-minting-and-strict-mode

In-collaboration-with: [Claude Code](https://claude.com/claude-code)