### PR TITLE
feat(permits): complete trifecta with authService and auth.verify [TRL-103]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -135,6 +135,14 @@
         "zod": "catalog:",
       },
     },
+    "packages/permits": {
+      "name": "@ontrails/permits",
+      "version": "1.0.0-beta.11",
+      "peerDependencies": {
+        "@ontrails/core": "workspace:^",
+        "zod": "catalog:",
+      },
+    },
     "packages/schema": {
       "name": "@ontrails/schema",
       "version": "1.0.0-beta.11",
@@ -254,6 +262,8 @@
     "@ontrails/logging": ["@ontrails/logging@workspace:packages/logging"],
 
     "@ontrails/mcp": ["@ontrails/mcp@workspace:packages/mcp"],
+
+    "@ontrails/permits": ["@ontrails/permits@workspace:packages/permits"],
 
     "@ontrails/schema": ["@ontrails/schema@workspace:packages/schema"],
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -32,6 +32,8 @@ export interface ActionResultContext {
 
 /** Options for buildCliCommands. */
 export interface BuildCliCommandsOptions {
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  configValues?: Readonly<Record<string, Record<string, unknown>>> | undefined;
   createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -165,6 +167,7 @@ const createExecute =
     await applyPrompting(fields, mergedInput, options);
 
     const result = await executeTrail(t, mergedInput, {
+      configValues: options?.configValues,
       createContext: options?.createContext,
       ctx: withCliSurface(ctxOverrides),
       layers: options?.layers,

--- a/packages/core/src/__tests__/trail-permit.test.ts
+++ b/packages/core/src/__tests__/trail-permit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { Result } from '../result';
+import { trail } from '../trail';
+import type { PermitRequirement } from '../types';
+
+describe('PermitRequirement type', () => {
+  test('accepts a scopes object', () => {
+    const req: PermitRequirement = { scopes: ['user:write', 'user:read'] };
+    expect(req).toEqual({ scopes: ['user:write', 'user:read'] });
+  });
+
+  test('accepts public literal', () => {
+    const req: PermitRequirement = 'public';
+    expect(req).toBe('public');
+  });
+});
+
+describe('trail() with permit field', () => {
+  test('accepts permit with scopes', () => {
+    const t = trail('user.delete', {
+      input: z.object({ id: z.string() }),
+      intent: 'destroy',
+      permit: { scopes: ['user:write'] },
+      run: (input) => Result.ok({ deleted: input.id }),
+    });
+    expect(t.permit).toEqual({ scopes: ['user:write'] });
+  });
+
+  test('accepts permit: public', () => {
+    const t = trail('health.check', {
+      input: z.object({}),
+      intent: 'read',
+      permit: 'public',
+      run: () => Result.ok({ status: 'ok' }),
+    });
+    expect(t.permit).toBe('public');
+  });
+
+  test('permit is undefined when omitted (backward compatible)', () => {
+    const t = trail('legacy.trail', {
+      input: z.object({}),
+      run: () => Result.ok(),
+    });
+    expect(t.permit).toBeUndefined();
+  });
+
+  test('preserves permit on the frozen Trail object', () => {
+    const t = trail('user.list', {
+      input: z.object({}),
+      intent: 'read',
+      permit: { scopes: ['user:read'] },
+      run: () => Result.ok([]),
+    });
+    expect(Object.isFrozen(t)).toBe(true);
+    expect(t.permit).toEqual({ scopes: ['user:read'] });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export type {
   TrailContext,
   TrailContextInit,
   FollowFn,
+  PermitRequirement,
   ProgressCallback,
   ProgressEvent,
   Logger,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export type {
   TrailContext,
   TrailContextInit,
   FollowFn,
+  BasePermit,
   PermitRequirement,
   ProgressCallback,
   ProgressEvent,

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -3,7 +3,11 @@ import type { z } from 'zod';
 import type { FieldOverride } from './derive.js';
 import type { Result } from './result.js';
 import type { AnyService } from './service.js';
-import type { Implementation, TrailContext } from './types.js';
+import type {
+  Implementation,
+  PermitRequirement,
+  TrailContext,
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Trail example
@@ -59,6 +63,8 @@ export interface TrailSpec<I, O> {
   readonly follow?: readonly string[] | undefined;
   /** Services this trail may access via service.from(ctx) */
   readonly services?: readonly AnyService[] | undefined;
+  /** Auth requirement: scopes object, 'public', or omitted (undeclared) */
+  readonly permit?: PermitRequirement | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,6 +64,17 @@ export interface TrailContext {
   readonly service?: ServiceLookup | undefined;
 }
 
+/**
+ * Permit requirement declared on a trail spec.
+ *
+ * A scopes object means the trail requires a permit with those scopes.
+ * `'public'` means the trail has explicitly opted out of auth.
+ * Omitting the field entirely means the trail hasn't declared an auth posture.
+ */
+export type PermitRequirement =
+  | { readonly scopes: readonly string[] }
+  | 'public';
+
 /** Input shape used to seed a runtime TrailContext before resolution. */
 export type TrailContextInit = Omit<TrailContext, 'service'> & {
   readonly service?: ServiceLookup | undefined;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,12 +49,18 @@ export interface Logger {
 /** Context extension key for the invoking surface name. */
 export const SURFACE_KEY = '__trails_surface' as const;
 
+/** Minimal permit shape available on TrailContext. Permits extends this. */
+export interface BasePermit {
+  readonly id: string;
+  readonly scopes: readonly string[];
+}
+
 /** Runtime context threaded through every trail execution */
 export interface TrailContext {
   readonly requestId: string;
   readonly signal: AbortSignal;
   readonly follow?: FollowFn | undefined;
-  readonly permit?: unknown | undefined;
+  readonly permit?: BasePermit;
   readonly workspaceRoot?: string | undefined;
   readonly logger?: Logger | undefined;
   readonly progress?: ProgressCallback | undefined;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -55,6 +55,9 @@ export interface BasePermit {
   readonly scopes: readonly string[];
 }
 
+/** Context extension key for the invoking surface name. */
+export const SURFACE_KEY = '__trails_surface' as const;
+
 /** Runtime context threaded through every trail execution */
 export interface TrailContext {
   readonly requestId: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -55,9 +55,6 @@ export interface BasePermit {
   readonly scopes: readonly string[];
 }
 
-/** Context extension key for the invoking surface name. */
-export const SURFACE_KEY = '__trails_surface' as const;
-
 /** Runtime context threaded through every trail execution */
 export interface TrailContext {
   readonly requestId: string;

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -26,6 +26,10 @@ import type {
 
 export interface BuildHttpRoutesOptions {
   readonly basePath?: string | undefined;
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  readonly configValues?:
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -119,6 +123,7 @@ const createExecute =
   ): HttpRouteDefinition['execute'] =>
   (input, requestId, signal) =>
     executeTrail(t, input, {
+      configValues: options.configValues,
       createContext: options.createContext,
       ctx: withHttpSurface(requestId),
       layers,

--- a/packages/http/src/hono/blaze.ts
+++ b/packages/http/src/hono/blaze.ts
@@ -31,6 +31,10 @@ import { buildHttpRoutes } from '../build.js';
 
 export interface BlazeHttpOptions {
   readonly basePath?: string | undefined;
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  readonly configValues?:
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -324,6 +328,7 @@ export const blaze = async (
 
   const routesResult = buildHttpRoutes(app, {
     basePath: options.basePath,
+    configValues: options.configValues,
     createContext: options.createContext,
     layers: options.layers,
     services: options.services,

--- a/packages/mcp/src/blaze.ts
+++ b/packages/mcp/src/blaze.ts
@@ -31,6 +31,10 @@ import { connectStdio } from './stdio.js';
 // ---------------------------------------------------------------------------
 
 export interface BlazeMcpOptions {
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  readonly configValues?:
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -147,6 +151,7 @@ export const blaze = async (
   }
 
   const toolsResult = buildMcpTools(app, {
+    configValues: options.configValues,
     createContext: options.createContext,
     excludeTrails: options.excludeTrails,
     includeTrails: options.includeTrails,

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -33,6 +33,10 @@ import { deriveToolName } from './tool-name.js';
 // ---------------------------------------------------------------------------
 
 export interface BuildMcpToolsOptions {
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  readonly configValues?:
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -230,6 +234,7 @@ const createHandler =
   async (args, extra): Promise<McpToolResult> => {
     const progressCb = createMcpProgressCallback(extra);
     const result = await executeTrail(t, args, {
+      configValues: options.configValues,
       createContext: options.createContext,
       ctx: withMcpSurface(progressCb),
       layers,

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@ontrails/permits",
+  "version": "1.0.0-beta.11",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./jwt": "./src/adapters/jwt.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@ontrails/core": "workspace:^",
+    "zod": "catalog:"
+  }
+}

--- a/packages/permits/src/__tests__/adapter.test.ts
+++ b/packages/permits/src/__tests__/adapter.test.ts
@@ -128,6 +128,22 @@ describe('createJwtAdapter', () => {
     expect(err.code).toBe('invalid_token');
   });
 
+  test('rejects tokens with a missing subject claim', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, scope: 'read' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Missing subject claim');
+  });
+
   test('extracts scopes from token claims', async () => {
     const adapter = createJwtAdapter({
       scopesClaim: 'permissions',
@@ -249,6 +265,25 @@ describe('createJwtAdapter', () => {
     const now = Math.floor(Date.now() / 1000);
     const token = await signJwt(
       { exp: now + 3600, scope: ['read', 'write'], sub: 'user-arr-scope' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.scopes).toEqual(['read', 'write']);
+  });
+
+  test('filters empty strings from array-format scope claims', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      {
+        exp: now + 3600,
+        scope: ['', 'read', '', 'write'],
+        sub: 'user-arr-scope-empty',
+      },
       TEST_SECRET
     );
     const result = await adapter.authenticate(

--- a/packages/permits/src/__tests__/adapter.test.ts
+++ b/packages/permits/src/__tests__/adapter.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result } from '@ontrails/core';
+
+import type { AuthAdapter, AuthError } from '../adapter.js';
+import type { PermitExtractionInput } from '../extraction.js';
+import type { Permit } from '../permit.js';
+import { createJwtAdapter } from '../adapters/jwt.js';
+
+// ---------------------------------------------------------------------------
+// Test helper: sign a JWT with HMAC-SHA256 using crypto.subtle
+// ---------------------------------------------------------------------------
+
+const base64url = (buf: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCodePoint(b);
+  }
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '');
+};
+
+const base64urlEncode = (str: string): string => {
+  const encoder = new TextEncoder();
+  return base64url(encoder.encode(str).buffer as ArrayBuffer);
+};
+
+const signJwt = async (
+  payload: Record<string, unknown>,
+  secret: string
+): Promise<string> => {
+  const header = base64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64urlEncode(JSON.stringify(payload));
+  const data = `${header}.${body}`;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(data));
+  return `${data}.${base64url(sig)}`;
+};
+
+const TEST_SECRET = 'test-secret-for-hmac-256';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/** Minimal extraction input for tests that don't need all fields. */
+const testInput = (
+  overrides?: Partial<PermitExtractionInput>
+): PermitExtractionInput => ({
+  requestId: 'test-req',
+  surface: 'http',
+  ...overrides,
+});
+
+describe('AuthAdapter interface', () => {
+  test('accepts a valid adapter implementation', async () => {
+    const adapter: AuthAdapter = {
+      // oxlint-disable-next-line require-await -- stub adapter for type test
+      authenticate: async (_input: PermitExtractionInput) => Result.ok(null),
+    };
+    const result = await adapter.authenticate(testInput());
+    expect(result.isOk()).toBe(true);
+  });
+});
+
+/* oxlint-disable max-statements -- test suite with multiple concern groups */
+describe('createJwtAdapter', () => {
+  test('returns an AuthAdapter', () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    expect(adapter).toBeDefined();
+    expect(adapter.authenticate).toBeInstanceOf(Function);
+  });
+
+  test('verifies a valid HS256 token and returns a Permit', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, scope: 'read write', sub: 'user-123' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit).not.toBeNull();
+    expect(permit.id).toBe('user-123');
+    expect(permit.scopes).toEqual(['read', 'write']);
+  });
+
+  test('rejects an expired token', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signJwt(
+      { exp: past, sub: 'user-expired' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('expired_token');
+  });
+
+  test('rejects an invalid signature', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-bad-sig' },
+      'wrong-secret'
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('extracts scopes from token claims', async () => {
+    const adapter = createJwtAdapter({
+      scopesClaim: 'permissions',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      {
+        exp: now + 3600,
+        permissions: 'admin:read admin:write',
+        sub: 'user-scopes',
+      },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.scopes).toEqual(['admin:read', 'admin:write']);
+  });
+
+  test('extracts roles from token claims', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, roles: ['admin', 'editor'], sub: 'user-roles' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.roles).toEqual(['admin', 'editor']);
+  });
+
+  test('returns null for missing credentials', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const result = await adapter.authenticate(testInput());
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBeNull();
+  });
+
+  test('checks issuer claim when configured', async () => {
+    const adapter = createJwtAdapter({
+      issuer: 'https://auth.example.com',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, iss: 'https://evil.example.com', sub: 'user-iss' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('checks audience claim when configured', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { aud: 'other-api', exp: now + 3600, sub: 'user-aud' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('accepts array-format audience containing configured value', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { aud: ['my-api', 'account'], exp: now + 3600, sub: 'user-arr-aud' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.id).toBe('user-arr-aud');
+  });
+
+  test('rejects array-format audience not containing configured value', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { aud: ['other-api', 'account'], exp: now + 3600, sub: 'user-no-aud' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('extracts scopes from array-format claim', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, scope: ['read', 'write'], sub: 'user-arr-scope' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.scopes).toEqual(['read', 'write']);
+  });
+
+  test('returns error for malformed signature bytes', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-bad' },
+      TEST_SECRET
+    );
+    const parts = token.split('.');
+    const malformed = `${parts[0]}.${parts[1]}.!!!invalid-base64!!!`;
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: malformed })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('accepts token with matching issuer and audience', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      issuer: 'https://auth.example.com',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      {
+        aud: 'my-api',
+        exp: now + 3600,
+        iss: 'https://auth.example.com',
+        scope: 'read',
+        sub: 'user-valid',
+      },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.id).toBe('user-valid');
+  });
+});

--- a/packages/permits/src/__tests__/auth-layer.test.ts
+++ b/packages/permits/src/__tests__/auth-layer.test.ts
@@ -1,0 +1,130 @@
+/* oxlint-disable require-await -- layer wrappers satisfy async interfaces without awaiting */
+import { describe, expect, test } from 'bun:test';
+
+import { Result, trail } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { authLayer } from '../auth-layer';
+import { PermitError } from '../errors';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeCtx = (permit?: {
+  id: string;
+  scopes: readonly string[];
+}): TrailContext => ({
+  permit,
+  requestId: 'test-auth',
+  signal: AbortSignal.timeout(5000),
+});
+
+const okImpl = async () => Result.ok({ done: true });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('authLayer', () => {
+  test('has correct name and description', () => {
+    expect(authLayer.name).toBe('auth');
+    expect(authLayer.description).toBeDefined();
+  });
+
+  describe('pass-through cases', () => {
+    test('passes through when trail has no permit field', async () => {
+      const t = trail('test.nopermit', {
+        input: z.object({}),
+        output: z.object({ done: z.boolean() }),
+        run: okImpl,
+      });
+
+      const wrapped = authLayer.wrap(t, okImpl);
+      const result = await wrapped({}, makeCtx());
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+
+    test('passes through when trail permit is public', async () => {
+      const t = trail('test.public', {
+        input: z.object({}),
+        output: z.object({ done: z.boolean() }),
+        permit: 'public',
+        run: okImpl,
+      });
+
+      const wrapped = authLayer.wrap(t, okImpl);
+      const result = await wrapped({}, makeCtx());
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+  });
+
+  describe('scope enforcement', () => {
+    const scopedTrail = trail('test.scoped', {
+      input: z.object({}),
+      output: z.object({ done: z.boolean() }),
+      permit: { scopes: ['user:read'] },
+      run: okImpl,
+    });
+
+    test('passes when ctx.permit has matching scopes', async () => {
+      const wrapped = authLayer.wrap(scopedTrail, okImpl);
+      const result = await wrapped(
+        {},
+        makeCtx({ id: 'usr-1', scopes: ['user:read'] })
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+
+    test('returns error when ctx has no permit', async () => {
+      const wrapped = authLayer.wrap(scopedTrail, okImpl);
+      const result = await wrapped({}, makeCtx());
+
+      expect(result.isErr()).toBe(true);
+      const err = (result as unknown as { error: PermitError }).error;
+      expect(err).toBeInstanceOf(PermitError);
+      expect(err.message).toContain('No permit');
+    });
+
+    test('returns error when permit is missing required scopes', async () => {
+      const multiScopeTrail = trail('test.multi', {
+        input: z.object({}),
+        output: z.object({ done: z.boolean() }),
+        permit: { scopes: ['user:read', 'user:write'] },
+        run: okImpl,
+      });
+
+      const wrapped = authLayer.wrap(multiScopeTrail, okImpl);
+      const result = await wrapped(
+        {},
+        makeCtx({ id: 'usr-1', scopes: ['user:read'] })
+      );
+
+      expect(result.isErr()).toBe(true);
+      const err = (result as unknown as { error: PermitError }).error;
+      expect(err).toBeInstanceOf(PermitError);
+      expect(err.message).toContain('user:write');
+    });
+
+    test('passes when permit has superset of required scopes', async () => {
+      const wrapped = authLayer.wrap(scopedTrail, okImpl);
+      const result = await wrapped(
+        {},
+        makeCtx({
+          id: 'usr-1',
+          scopes: ['user:read', 'user:write', 'admin'],
+        })
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+  });
+});

--- a/packages/permits/src/__tests__/auth-service.test.ts
+++ b/packages/permits/src/__tests__/auth-service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { ServiceContext } from '@ontrails/core';
+
+import type { AuthAdapter } from '../adapter.js';
+import { authService } from '../auth-service.js';
+import type { PermitExtractionInput } from '../extraction.js';
+
+/** Minimal extraction input for tests. */
+const testInput = (
+  overrides?: Partial<PermitExtractionInput>
+): PermitExtractionInput => ({
+  requestId: 'test-svc-req',
+  surface: 'http',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const testSvcCtx: ServiceContext = {
+  config: undefined,
+  cwd: '/tmp',
+  env: {},
+  workspaceRoot: '/tmp',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('authService', () => {
+  test('has correct id and kind', () => {
+    expect(authService.id).toBe('auth');
+    expect(authService.kind).toBe('service');
+  });
+
+  test('has infrastructure metadata', () => {
+    expect(authService.metadata).toEqual({ category: 'infrastructure' });
+  });
+
+  test('mock returns an AuthAdapter', async () => {
+    const mock = authService.mock?.();
+    expect(mock).toBeDefined();
+
+    const adapter = mock as AuthAdapter;
+    const result = await adapter.authenticate(testInput());
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBeNull();
+  });
+
+  test('create returns Result.ok with an AuthAdapter', async () => {
+    const result = await authService.create(testSvcCtx);
+    expect(result.isOk()).toBe(true);
+
+    const adapter = result.unwrap() as AuthAdapter;
+    const authResult = await adapter.authenticate(testInput());
+    expect(authResult.isOk()).toBe(true);
+    expect(authResult.unwrap()).toBeNull();
+  });
+});

--- a/packages/permits/src/__tests__/auth-verify.test.ts
+++ b/packages/permits/src/__tests__/auth-verify.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test } from 'bun:test';
 
-import { Result, executeTrail } from '@ontrails/core';
+import {
+  Result,
+  SURFACE_KEY,
+  ValidationError,
+  executeTrail,
+} from '@ontrails/core';
 
 import type { AuthAdapter } from '../adapter.js';
 import { authService } from '../auth-service.js';
 import { createJwtAdapter } from '../adapters/jwt.js';
+import type { Permit } from '../permit.js';
 import { authVerify } from '../trails/auth-verify.js';
 
 // ---------------------------------------------------------------------------
@@ -55,12 +61,26 @@ const jwtAdapter = (): AuthAdapter => createJwtAdapter({ secret: TEST_SECRET });
 /** Execute auth.verify with a given adapter injected as the auth service. */
 const runVerify = async (
   token: string,
-  adapter: AuthAdapter
+  adapter: AuthAdapter,
+  options?: {
+    surface?: 'http' | 'mcp' | 'cli';
+  }
 ): Promise<
   Result<
     {
       error?: string;
-      permit?: { id: string; scopes: string[] };
+      errorCode?:
+        | 'expired_token'
+        | 'insufficient_scope'
+        | 'invalid_token'
+        | 'missing_credentials';
+      permit?: {
+        id: string;
+        metadata?: Record<string, unknown>;
+        roles?: string[];
+        scopes: string[];
+        tenantId?: string;
+      };
       valid: boolean;
     },
     Error
@@ -70,13 +90,23 @@ const runVerify = async (
     authVerify,
     { token },
     {
+      ctx:
+        options?.surface === undefined
+          ? undefined
+          : { extensions: { [SURFACE_KEY]: options.surface } },
       services: { [authService.id]: adapter },
     }
   );
   return result as Result<
     {
       error?: string;
-      permit?: { id: string; scopes: string[] };
+      permit?: {
+        id: string;
+        metadata?: Record<string, unknown>;
+        roles?: string[];
+        scopes: string[];
+        tenantId?: string;
+      };
       valid: boolean;
     },
     Error
@@ -122,6 +152,7 @@ describe('auth.verify trail', () => {
       const value = result.unwrap();
       expect(value.valid).toBe(false);
       expect(value.error).toBe('No credentials');
+      expect(value.errorCode).toBe('missing_credentials');
       expect(value.permit).toBeUndefined();
     });
   });
@@ -145,6 +176,52 @@ describe('auth.verify trail', () => {
       });
       expect(value.error).toBeUndefined();
     });
+
+    test('returns the full permit payload from the adapter', async () => {
+      const permit: Permit = {
+        id: 'user-42',
+        metadata: { plan: 'pro' },
+        roles: ['admin'],
+        scopes: ['read', 'write'],
+        tenantId: 'tenant-1',
+      };
+      const adapter: AuthAdapter = {
+        // oxlint-disable-next-line require-await -- satisfies async interface
+        authenticate: async () => Result.ok(permit),
+      };
+
+      const result = await runVerify('full-permit-token', adapter);
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().permit).toEqual({
+        id: 'user-42',
+        metadata: { plan: 'pro' },
+        roles: ['admin'],
+        scopes: ['read', 'write'],
+        tenantId: 'tenant-1',
+      });
+    });
+
+    test('forwards the invoking surface from trail context', async () => {
+      let seenSurface: string | undefined;
+      const adapter: AuthAdapter = {
+        // oxlint-disable-next-line require-await -- captures adapter input
+        authenticate: async (input) => {
+          seenSurface = input.surface;
+          return Result.ok({
+            id: 'user-42',
+            scopes: ['read'],
+          });
+        },
+      };
+
+      const result = await runVerify('surface-aware-token', adapter, {
+        surface: 'mcp',
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(seenSurface).toBe('mcp');
+    });
   });
 
   describe('with invalid token', () => {
@@ -161,6 +238,7 @@ describe('auth.verify trail', () => {
       const value = result.unwrap();
       expect(value.valid).toBe(false);
       expect(value.error).toBeDefined();
+      expect(value.errorCode).toBe('invalid_token');
       expect(value.permit).toBeUndefined();
     });
 
@@ -177,7 +255,23 @@ describe('auth.verify trail', () => {
       const value = result.unwrap();
       expect(value.valid).toBe(false);
       expect(value.error).toBeDefined();
+      expect(value.errorCode).toBe('expired_token');
       expect(value.permit).toBeUndefined();
+    });
+  });
+
+  describe('input validation', () => {
+    test('rejects empty bearer tokens at the boundary', async () => {
+      const result = await executeTrail(
+        authVerify,
+        { token: '' },
+        {
+          services: { [authService.id]: jwtAdapter() },
+        }
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(ValidationError);
     });
   });
 });

--- a/packages/permits/src/__tests__/auth-verify.test.ts
+++ b/packages/permits/src/__tests__/auth-verify.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result, executeTrail } from '@ontrails/core';
+
+import type { AuthAdapter } from '../adapter.js';
+import { authService } from '../auth-service.js';
+import { createJwtAdapter } from '../adapters/jwt.js';
+import { authVerify } from '../trails/auth-verify.js';
+
+// ---------------------------------------------------------------------------
+// Test helper: sign a JWT with HMAC-SHA256 using crypto.subtle
+// ---------------------------------------------------------------------------
+
+const base64url = (buf: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCodePoint(b);
+  }
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '');
+};
+
+const base64urlEncode = (str: string): string => {
+  const encoder = new TextEncoder();
+  return base64url(encoder.encode(str).buffer as ArrayBuffer);
+};
+
+const signJwt = async (
+  payload: Record<string, unknown>,
+  secret: string
+): Promise<string> => {
+  const header = base64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64urlEncode(JSON.stringify(payload));
+  const data = `${header}.${body}`;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(data));
+  return `${data}.${base64url(sig)}`;
+};
+
+const TEST_SECRET = 'test-secret-for-hmac-256';
+
+/** Create an AuthAdapter wired to a JWT secret. */
+const jwtAdapter = (): AuthAdapter => createJwtAdapter({ secret: TEST_SECRET });
+
+/** Execute auth.verify with a given adapter injected as the auth service. */
+const runVerify = async (
+  token: string,
+  adapter: AuthAdapter
+): Promise<
+  Result<
+    {
+      error?: string;
+      permit?: { id: string; scopes: string[] };
+      valid: boolean;
+    },
+    Error
+  >
+> => {
+  const result = await executeTrail(
+    authVerify,
+    { token },
+    {
+      services: { [authService.id]: adapter },
+    }
+  );
+  return result as Result<
+    {
+      error?: string;
+      permit?: { id: string; scopes: string[] };
+      valid: boolean;
+    },
+    Error
+  >;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('auth.verify trail', () => {
+  describe('contract', () => {
+    test('has correct id and intent', () => {
+      expect(authVerify.id).toBe('auth.verify');
+      expect(authVerify.intent).toBe('read');
+    });
+
+    test('has infrastructure metadata', () => {
+      expect(authVerify.metadata).toEqual({ category: 'infrastructure' });
+    });
+
+    test('has examples', () => {
+      expect(authVerify.examples).toBeDefined();
+      expect(authVerify.examples?.length).toBeGreaterThan(0);
+    });
+
+    test('declares authService dependency', () => {
+      expect(authVerify.services).toHaveLength(1);
+      expect(authVerify.services[0]?.id).toBe('auth');
+    });
+  });
+
+  describe('with mock adapter (no credentials)', () => {
+    test('returns valid: false with error message', async () => {
+      const noopAdapter: AuthAdapter = {
+        // oxlint-disable-next-line require-await -- satisfies async interface
+        authenticate: async () => Result.ok(null),
+      };
+
+      const result = await runVerify('some-token', noopAdapter);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(false);
+      expect(value.error).toBe('No credentials');
+      expect(value.permit).toBeUndefined();
+    });
+  });
+
+  describe('with valid token and secret', () => {
+    test('returns valid: true with permit', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const token = await signJwt(
+        { exp: now + 3600, scope: 'read write', sub: 'user-42' },
+        TEST_SECRET
+      );
+
+      const result = await runVerify(token, jwtAdapter());
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(true);
+      expect(value.permit).toEqual({
+        id: 'user-42',
+        scopes: ['read', 'write'],
+      });
+      expect(value.error).toBeUndefined();
+    });
+  });
+
+  describe('with invalid token', () => {
+    test('returns valid: false with error for bad signature', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const token = await signJwt(
+        { exp: now + 3600, sub: 'user-bad' },
+        'wrong-secret'
+      );
+
+      const result = await runVerify(token, jwtAdapter());
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(false);
+      expect(value.error).toBeDefined();
+      expect(value.permit).toBeUndefined();
+    });
+
+    test('returns valid: false for expired token', async () => {
+      const past = Math.floor(Date.now() / 1000) - 3600;
+      const token = await signJwt(
+        { exp: past, sub: 'user-expired' },
+        TEST_SECRET
+      );
+
+      const result = await runVerify(token, jwtAdapter());
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(false);
+      expect(value.error).toBeDefined();
+      expect(value.permit).toBeUndefined();
+    });
+  });
+});

--- a/packages/permits/src/__tests__/permit.test.ts
+++ b/packages/permits/src/__tests__/permit.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Permit, PermitExtractionInput } from '../index';
+import { getPermit } from '../index';
+
+describe('Permit type', () => {
+  test('accepts a valid permit with required fields only', () => {
+    const permit: Permit = {
+      id: 'usr_abc123',
+      scopes: ['user:read', 'user:write'],
+    };
+    expect(permit.id).toBe('usr_abc123');
+    expect(permit.scopes).toEqual(['user:read', 'user:write']);
+  });
+
+  test('accepts a permit with all optional fields', () => {
+    const permit: Permit = {
+      id: 'usr_full',
+      metadata: { plan: 'pro', provider: 'clerk' },
+      roles: ['admin', 'editor'],
+      scopes: ['entity:read'],
+      tenantId: 'tenant_xyz',
+    };
+    expect(permit.roles).toEqual(['admin', 'editor']);
+    expect(permit.tenantId).toBe('tenant_xyz');
+    expect(permit.metadata).toEqual({ plan: 'pro', provider: 'clerk' });
+  });
+
+  test('scopes and roles arrays are readonly', () => {
+    const permit: Permit = {
+      id: 'usr_ro',
+      roles: ['viewer'],
+      scopes: ['read'],
+    };
+    // Structural check: readonly arrays are assignable to readonly string[]
+    const { scopes } = permit;
+    const { roles } = permit;
+    expect(scopes).toEqual(['read']);
+    expect(roles).toEqual(['viewer']);
+  });
+});
+
+describe('getPermit()', () => {
+  test('returns Permit from a context with a permit', () => {
+    const permit: Permit = { id: 'usr_1', scopes: ['user:read'] };
+    const ctx = { permit, requestId: 'req-1' };
+    const result = getPermit(ctx);
+    expect(result).toEqual(permit);
+  });
+
+  test('returns undefined when context has no permit', () => {
+    const ctx = { requestId: 'req-2' };
+    const result = getPermit(ctx);
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when permit is explicitly undefined', () => {
+    const ctx = { permit: undefined, requestId: 'req-3' };
+    const result = getPermit(ctx);
+    expect(result).toBeUndefined();
+  });
+
+  test('preserves extended permit fields from the auth layer', () => {
+    const ctx = {
+      permit: {
+        id: 'usr_2',
+        metadata: { plan: 'pro' },
+        roles: ['admin'],
+        scopes: ['user:read'],
+        tenantId: 'tenant-1',
+      } satisfies Permit,
+      requestId: 'req-4',
+    };
+    const result = getPermit(ctx);
+    expect(result).toEqual(ctx.permit);
+  });
+});
+
+describe('PermitExtractionInput', () => {
+  test('accepts HTTP surface extraction', () => {
+    const input: PermitExtractionInput = {
+      bearerToken: 'eyJhbGciOiJSUzI1NiJ9.test',
+      headers: new Headers({
+        authorization: 'Bearer eyJhbGciOiJSUzI1NiJ9.test',
+      }),
+      requestId: 'req-http-1',
+      surface: 'http',
+    };
+    expect(input.surface).toBe('http');
+    expect(input.bearerToken).toBeDefined();
+  });
+
+  test('accepts MCP surface extraction', () => {
+    const input: PermitExtractionInput = {
+      requestId: 'req-mcp-1',
+      sessionId: 'mcp-session-abc',
+      surface: 'mcp',
+    };
+    expect(input.surface).toBe('mcp');
+    expect(input.sessionId).toBe('mcp-session-abc');
+  });
+
+  test('accepts CLI surface extraction', () => {
+    const input: PermitExtractionInput = {
+      bearerToken: 'cli-token-from-keyring',
+      requestId: 'req-cli-1',
+      surface: 'cli',
+    };
+    expect(input.surface).toBe('cli');
+  });
+
+  test('accepts minimal extraction with only required fields', () => {
+    const input: PermitExtractionInput = {
+      requestId: 'req-minimal',
+      surface: 'http',
+    };
+    expect(input.requestId).toBe('req-minimal');
+    expect(input.bearerToken).toBeUndefined();
+    expect(input.sessionId).toBeUndefined();
+    expect(input.headers).toBeUndefined();
+  });
+});

--- a/packages/permits/src/__tests__/rules.test.ts
+++ b/packages/permits/src/__tests__/rules.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from 'bun:test';
+import { trail, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  destroyWithoutPermit,
+  writeWithoutPermit,
+  scopeNamingConsistency,
+  orphanScopeDetection,
+  validatePermits,
+} from '../rules.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const emptyInput = z.object({});
+const noopRun = () => Result.ok({});
+
+// ---------------------------------------------------------------------------
+// destroyWithoutPermit
+// ---------------------------------------------------------------------------
+
+describe('destroyWithoutPermit', () => {
+  test('error when destroy trail has no permit', () => {
+    const t = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      run: noopRun,
+    });
+    const diagnostics = destroyWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      message: expect.stringContaining('destroy'),
+      rule: 'destroyWithoutPermit',
+      severity: 'error',
+      trailId: 'user.delete',
+    });
+  });
+
+  test('no diagnostic when destroy trail has a scoped permit', () => {
+    const t = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      permit: { scopes: ['user:delete'] },
+      run: noopRun,
+    });
+    const diagnostics = destroyWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('error when destroy trail has permit: public', () => {
+    const t = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      permit: 'public',
+      run: noopRun,
+    });
+    const diagnostics = destroyWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'destroyWithoutPermit',
+      severity: 'error',
+      trailId: 'user.delete',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeWithoutPermit
+// ---------------------------------------------------------------------------
+
+describe('writeWithoutPermit', () => {
+  test('warning when write trail has no permit', () => {
+    const t = trail('user.create', {
+      input: emptyInput,
+      run: noopRun,
+    });
+    const diagnostics = writeWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'writeWithoutPermit',
+      severity: 'warning',
+      trailId: 'user.create',
+    });
+  });
+
+  test('no warning when write trail has permit: public', () => {
+    const t = trail('user.create', {
+      input: emptyInput,
+      permit: 'public',
+      run: noopRun,
+    });
+    const diagnostics = writeWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('warning when trail has no intent (defaults to write)', () => {
+    const t = trail('user.update', {
+      input: emptyInput,
+      run: noopRun,
+    });
+    // Override intent to undefined to simulate a manually constructed trail
+    const noIntent = { ...t, intent: undefined } as unknown as ReturnType<
+      typeof trail
+    >;
+    const diagnostics = writeWithoutPermit([noIntent]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'writeWithoutPermit',
+      severity: 'warning',
+      trailId: 'user.update',
+    });
+  });
+
+  test('no diagnostic for read trail without permit', () => {
+    const t = trail('user.list', {
+      input: emptyInput,
+      intent: 'read',
+      run: noopRun,
+    });
+    const diagnostics = writeWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scopeNamingConsistency
+// ---------------------------------------------------------------------------
+
+describe('scopeNamingConsistency', () => {
+  test('scope user:write passes naming check', () => {
+    const t = trail('user.update', {
+      input: emptyInput,
+      permit: { scopes: ['user:write'] },
+      run: noopRun,
+    });
+    const diagnostics = scopeNamingConsistency([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('warning for scope without colon', () => {
+    const t = trail('admin.panel', {
+      input: emptyInput,
+      permit: { scopes: ['admin'] },
+      run: noopRun,
+    });
+    const diagnostics = scopeNamingConsistency([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      message: expect.stringContaining('admin'),
+      rule: 'scopeNamingConsistency',
+      severity: 'warning',
+      trailId: 'admin.panel',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orphanScopeDetection
+// ---------------------------------------------------------------------------
+
+describe('orphanScopeDetection', () => {
+  test('warning for orphan scope (typo)', () => {
+    const t1 = trail('user.read', {
+      input: emptyInput,
+      permit: { scopes: ['user:read'] },
+      run: noopRun,
+    });
+    const t2 = trail('user.write', {
+      input: emptyInput,
+      permit: { scopes: ['user:wirte'] },
+      run: noopRun,
+    });
+    const diagnostics = orphanScopeDetection([t1, t2]);
+    // Both scopes are unique (appear in only 1 trail each)
+    expect(diagnostics).toHaveLength(2);
+    const messages = diagnostics.map((d) => d.message);
+    expect(messages.some((m) => m.includes('user:wirte'))).toBe(true);
+  });
+
+  test('no warning for shared scopes', () => {
+    const t1 = trail('user.read', {
+      input: emptyInput,
+      permit: { scopes: ['user:read'] },
+      run: noopRun,
+    });
+    const t2 = trail('user.profile', {
+      input: emptyInput,
+      permit: { scopes: ['user:read'] },
+      run: noopRun,
+    });
+    const diagnostics = orphanScopeDetection([t1, t2]);
+    expect(diagnostics).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validatePermits
+// ---------------------------------------------------------------------------
+
+/* oxlint-disable max-statements -- integration test validates all rules fire */
+describe('validatePermits', () => {
+  test('runs all rules and aggregates diagnostics', () => {
+    const destroyNoPerm = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      run: noopRun,
+    });
+    const writeNoPerm = trail('user.create', {
+      input: emptyInput,
+      run: noopRun,
+    });
+    const badScope = trail('admin.panel', {
+      input: emptyInput,
+      permit: { scopes: ['admin'] },
+      run: noopRun,
+    });
+    const orphanScope = trail('analytics.export', {
+      input: emptyInput,
+      permit: { scopes: ['analytics:exportt'] },
+      run: noopRun,
+    });
+
+    const diagnostics = validatePermits([
+      destroyNoPerm,
+      writeNoPerm,
+      badScope,
+      orphanScope,
+    ]);
+
+    const rules = diagnostics.map((d) => d.rule);
+    expect(rules).toContain('destroyWithoutPermit');
+    expect(rules).toContain('writeWithoutPermit');
+    expect(rules).toContain('scopeNamingConsistency');
+    expect(rules).toContain('orphanScopeDetection');
+    expect(diagnostics.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/permits/src/__tests__/testing.test.ts
+++ b/packages/permits/src/__tests__/testing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+
+import { mintPermitForTrail, mintTestPermit } from '../testing';
+
+describe('mintTestPermit()', () => {
+  test('returns a Permit with the given scopes', () => {
+    const permit = mintTestPermit({ scopes: ['user:read', 'user:write'] });
+    expect(permit.scopes).toEqual(['user:read', 'user:write']);
+  });
+
+  test('generates a unique id when not specified', () => {
+    const a = mintTestPermit();
+    const b = mintTestPermit();
+    expect(a.id).not.toBe(b.id);
+  });
+
+  test('uses the provided id when specified', () => {
+    const permit = mintTestPermit({ id: 'custom-id' });
+    expect(permit.id).toBe('custom-id');
+  });
+
+  test('returns empty scopes when no options provided', () => {
+    const permit = mintTestPermit();
+    expect(permit.scopes).toEqual([]);
+  });
+
+  test('includes roles when provided', () => {
+    const permit = mintTestPermit({ roles: ['admin', 'editor'] });
+    expect(permit.roles).toEqual(['admin', 'editor']);
+  });
+
+  test('includes tenantId when provided', () => {
+    const permit = mintTestPermit({ tenantId: 'tenant_abc' });
+    expect(permit.tenantId).toBe('tenant_abc');
+  });
+});
+
+describe('mintPermitForTrail()', () => {
+  test('extracts scopes from trail permit requirement', () => {
+    const trail = { permit: { scopes: ['entity:read', 'entity:write'] } };
+    const permit = mintPermitForTrail(trail);
+    expect(permit).toBeDefined();
+    expect(permit?.scopes).toEqual(['entity:read', 'entity:write']);
+  });
+
+  test('returns undefined for public trails', () => {
+    const trail = { permit: 'public' as const };
+    const permit = mintPermitForTrail(trail);
+    expect(permit).toBeUndefined();
+  });
+
+  test('returns undefined when no permit declared', () => {
+    const trail = {};
+    const permit = mintPermitForTrail(trail);
+    expect(permit).toBeUndefined();
+  });
+});

--- a/packages/permits/src/adapter.ts
+++ b/packages/permits/src/adapter.ts
@@ -1,0 +1,35 @@
+import type { Result } from '@ontrails/core';
+
+import type { PermitExtractionInput } from './extraction.js';
+import type { Permit } from './permit.js';
+
+/**
+ * @deprecated Use {@link PermitExtractionInput} instead. Kept as an alias
+ * for backward compatibility during migration.
+ */
+export type AuthCredentials = PermitExtractionInput;
+
+/** Errors from auth adapters. */
+export interface AuthError {
+  readonly code:
+    | 'expired_token'
+    | 'insufficient_scope'
+    | 'invalid_token'
+    | 'missing_credentials';
+  readonly message: string;
+}
+
+/**
+ * Auth adapter port. Given extraction input, produce a permit or an error.
+ *
+ * The adapter receives the full {@link PermitExtractionInput} — surface,
+ * headers, requestId, and credential fields — so it can make richer
+ * decisions (e.g., rate-limit by surface or correlate via requestId).
+ *
+ * Deliberately narrow — no session management, no token refresh.
+ */
+export interface AuthAdapter {
+  readonly authenticate: (
+    input: PermitExtractionInput
+  ) => Promise<Result<Permit | null, AuthError>>;
+}

--- a/packages/permits/src/adapters/jwt.ts
+++ b/packages/permits/src/adapters/jwt.ts
@@ -1,0 +1,225 @@
+import { Result } from '@ontrails/core';
+
+import type { AuthAdapter, AuthError } from '../adapter.js';
+import type { PermitExtractionInput } from '../extraction.js';
+import type { Permit } from '../permit.js';
+
+/** Configuration for the JWT auth adapter. */
+export interface JwtAdapterOptions {
+  /** HMAC secret for HS256 verification. */
+  readonly secret?: string;
+  /** JWKS endpoint for RS256/ES256 (not yet implemented). */
+  readonly jwksUrl?: string;
+  /** Expected issuer claim. */
+  readonly issuer?: string;
+  /** Expected audience claim. */
+  readonly audience?: string;
+  /** Claim containing scopes (default: 'scope'). */
+  readonly scopesClaim?: string;
+  /** Claim containing roles (default: 'roles'). */
+  readonly rolesClaim?: string;
+}
+
+/** JWT payload with standard claims. */
+interface JwtPayload {
+  readonly sub?: string;
+  readonly iss?: string;
+  readonly aud?: string | readonly string[];
+  readonly exp?: number;
+  readonly [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before callers)
+// ---------------------------------------------------------------------------
+
+const authErr = (
+  code: AuthError['code'],
+  message: string
+): Result<never, AuthError> => Result.err({ code, message });
+
+/** Base64url-decode a string to bytes. */
+const base64urlDecode = (input: string): Uint8Array => {
+  const padded = input
+    .replaceAll('-', '+')
+    .replaceAll('_', '/')
+    .padEnd(input.length + ((4 - (input.length % 4)) % 4), '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.codePointAt(i) ?? 0;
+  }
+  return bytes;
+};
+
+/** Decode a JWT payload without verifying the signature. */
+const decodePayload = (token: string): JwtPayload | undefined => {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return undefined;
+  }
+  try {
+    const json = new TextDecoder().decode(base64urlDecode(parts[1] ?? ''));
+    return JSON.parse(json) as JwtPayload;
+  } catch {
+    return undefined;
+  }
+};
+
+/** Import a secret as an HMAC CryptoKey. */
+const importHmacKey = (secret: string): Promise<CryptoKey> => {
+  const encoder = new TextEncoder();
+  return crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['verify']
+  );
+};
+
+/** Verify the HMAC-SHA256 signature of a JWT. */
+const verifyHmacSignature = (
+  token: string,
+  key: CryptoKey
+): Promise<boolean> => {
+  const lastDot = token.lastIndexOf('.');
+  if (lastDot === -1) {
+    return Promise.resolve(false);
+  }
+  const data = token.slice(0, lastDot);
+  const signature = base64urlDecode(token.slice(lastDot + 1));
+  const encoder = new TextEncoder();
+  return crypto.subtle.verify(
+    'HMAC',
+    key,
+    signature.buffer as ArrayBuffer,
+    encoder.encode(data)
+  );
+};
+
+/** Validate standard claims (exp, iss, aud). */
+const validateClaims = (
+  payload: JwtPayload,
+  options: JwtAdapterOptions
+): AuthError | undefined => {
+  if (
+    payload.exp !== undefined &&
+    payload.exp < Math.floor(Date.now() / 1000)
+  ) {
+    return { code: 'expired_token', message: 'Token has expired' };
+  }
+  if (options.issuer && payload.iss !== options.issuer) {
+    return { code: 'invalid_token', message: 'Issuer mismatch' };
+  }
+  if (options.audience) {
+    const { aud } = payload;
+    const matches = Array.isArray(aud)
+      ? aud.includes(options.audience)
+      : aud === options.audience;
+    if (!matches) {
+      return { code: 'invalid_token', message: 'Audience mismatch' };
+    }
+  }
+  return undefined;
+};
+
+/** Extract scopes from a payload claim (space-separated string or array). */
+const extractScopes = (
+  payload: JwtPayload,
+  claim: string
+): readonly string[] => {
+  const raw = payload[claim];
+  if (typeof raw === 'string') {
+    return raw.split(' ').filter(Boolean);
+  }
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === 'string');
+  }
+  return [];
+};
+
+/** Extract roles from a payload claim (string array). */
+const extractRoles = (
+  payload: JwtPayload,
+  claim: string
+): readonly string[] | undefined => {
+  const raw = payload[claim];
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  return raw.filter((r): r is string => typeof r === 'string');
+};
+
+/** Build a Permit from a validated JWT payload. */
+const buildPermit = (
+  payload: JwtPayload,
+  options: JwtAdapterOptions
+): Permit => {
+  const roles = extractRoles(payload, options.rolesClaim ?? 'roles');
+  return {
+    id: payload.sub ?? '',
+    scopes: extractScopes(payload, options.scopesClaim ?? 'scope'),
+    ...(roles ? { roles } : {}),
+  };
+};
+
+/** Verify the signature and return the decoded payload, or an error. */
+const decodeAndVerify = async (
+  token: string,
+  secret: string
+): Promise<Result<JwtPayload, AuthError>> => {
+  const payload = decodePayload(token);
+  if (!payload) {
+    return authErr('invalid_token', 'Malformed JWT');
+  }
+  try {
+    const key = await importHmacKey(secret);
+    const valid = await verifyHmacSignature(token, key);
+    return valid
+      ? Result.ok(payload)
+      : authErr('invalid_token', 'Invalid signature');
+  } catch {
+    return authErr('invalid_token', 'Malformed token signature');
+  }
+};
+
+/** Validate claims and build a permit from a verified payload. */
+const payloadToPermit = (
+  payload: JwtPayload,
+  options: JwtAdapterOptions
+): Result<Permit, AuthError> => {
+  const claimError = validateClaims(payload, options);
+  if (claimError) {
+    return Result.err(claimError);
+  }
+  return Result.ok(buildPermit(payload, options));
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a JWT auth adapter using Bun's native crypto.
+ *
+ * Verifies HS256-signed JWTs, extracts claims into a Permit, and checks
+ * issuer/audience when configured. Returns `Result.ok(null)` when no
+ * credentials are provided.
+ */
+export const createJwtAdapter = (options: JwtAdapterOptions): AuthAdapter => {
+  const authenticate = async (
+    input: PermitExtractionInput
+  ): Promise<Result<Permit | null, AuthError>> => {
+    if (!input.bearerToken) {
+      return Result.ok(null);
+    }
+    if (!options.secret) {
+      return authErr('invalid_token', 'No secret configured');
+    }
+    const decoded = await decodeAndVerify(input.bearerToken, options.secret);
+    return decoded.isErr() ? decoded : payloadToPermit(decoded.value, options);
+  };
+
+  return { authenticate };
+};

--- a/packages/permits/src/adapters/jwt.ts
+++ b/packages/permits/src/adapters/jwt.ts
@@ -134,7 +134,9 @@ const extractScopes = (
     return raw.split(' ').filter(Boolean);
   }
   if (Array.isArray(raw)) {
-    return raw.filter((s): s is string => typeof s === 'string');
+    return raw.filter(
+      (s): s is string => typeof s === 'string' && s.length > 0
+    );
   }
   return [];
 };
@@ -155,13 +157,16 @@ const extractRoles = (
 const buildPermit = (
   payload: JwtPayload,
   options: JwtAdapterOptions
-): Permit => {
+): Result<Permit, AuthError> => {
+  if (!payload.sub) {
+    return authErr('invalid_token', 'Missing subject claim (sub)');
+  }
   const roles = extractRoles(payload, options.rolesClaim ?? 'roles');
-  return {
-    id: payload.sub ?? '',
+  return Result.ok({
+    id: payload.sub,
     scopes: extractScopes(payload, options.scopesClaim ?? 'scope'),
     ...(roles ? { roles } : {}),
-  };
+  });
 };
 
 /** Verify the signature and return the decoded payload, or an error. */
@@ -193,7 +198,7 @@ const payloadToPermit = (
   if (claimError) {
     return Result.err(claimError);
   }
-  return Result.ok(buildPermit(payload, options));
+  return buildPermit(payload, options);
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/permits/src/auth-layer.ts
+++ b/packages/permits/src/auth-layer.ts
@@ -57,20 +57,24 @@ export const authLayer: Layer = {
       const permit = getPermit(ctx);
 
       if (!permit) {
-        return Result.err(new PermitError('No permit provided'));
+        return Promise.resolve(
+          Result.err(new PermitError('No permit provided'))
+        );
       }
 
       const missing = findMissing(requirement.scopes, permit.scopes);
 
       if (missing.length > 0) {
-        return Result.err(
-          new PermitError(`Missing scopes: ${missing.join(', ')}`, {
-            context: { missing, required: requirement.scopes },
-          })
+        return Promise.resolve(
+          Result.err(
+            new PermitError(`Missing scopes: ${missing.join(', ')}`, {
+              context: { missing, required: requirement.scopes },
+            })
+          )
         );
       }
 
-      return impl(input, ctx);
+      return Promise.resolve(impl(input, ctx));
     };
   },
 };

--- a/packages/permits/src/auth-layer.ts
+++ b/packages/permits/src/auth-layer.ts
@@ -1,0 +1,76 @@
+import { Result } from '@ontrails/core';
+import type { Layer } from '@ontrails/core';
+
+import { PermitError } from './errors.js';
+import { getPermit } from './permit.js';
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before callers — no use-before-define)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when the permit requirement means "no enforcement needed."
+ * Either the trail hasn't declared a permit posture or has explicitly
+ * opted out with `'public'`.
+ */
+const isPassThrough = (
+  requirement: unknown
+): requirement is undefined | 'public' =>
+  requirement === undefined || requirement === 'public';
+
+/** Returns scopes present in `required` but absent from `held`. */
+const findMissing = (
+  required: readonly string[],
+  held: readonly string[]
+): readonly string[] => required.filter((s) => !held.includes(s));
+
+// ---------------------------------------------------------------------------
+// Auth layer
+// ---------------------------------------------------------------------------
+
+/**
+ * A {@link Layer} that enforces permit scopes declared on trails.
+ *
+ * The layer reads the trail's `permit` field (a `PermitRequirement`):
+ *
+ * - If `permit` is `'public'` or `undefined` the layer passes through.
+ * - If `permit` has `scopes`, the layer checks that `ctx.permit` contains
+ *   all required scopes. A superset is fine; missing scopes produce a
+ *   `PermitError`.
+ *
+ * Because `ctx.follow()` re-enters `executeTrail` (which applies layers),
+ * this layer automatically re-checks on every invocation in a follow chain.
+ * No special follow-chain handling is needed — it is built into the
+ * architecture.
+ */
+export const authLayer: Layer = {
+  description: 'Enforces permit scopes declared on trails',
+  name: 'auth',
+  wrap: (_trail, impl) => {
+    const requirement = _trail.permit;
+
+    if (isPassThrough(requirement)) {
+      return impl;
+    }
+
+    return (input, ctx) => {
+      const permit = getPermit(ctx);
+
+      if (!permit) {
+        return Result.err(new PermitError('No permit provided'));
+      }
+
+      const missing = findMissing(requirement.scopes, permit.scopes);
+
+      if (missing.length > 0) {
+        return Result.err(
+          new PermitError(`Missing scopes: ${missing.join(', ')}`, {
+            context: { missing, required: requirement.scopes },
+          })
+        );
+      }
+
+      return impl(input, ctx);
+    };
+  },
+};

--- a/packages/permits/src/auth-service.ts
+++ b/packages/permits/src/auth-service.ts
@@ -1,0 +1,25 @@
+import { Result, service } from '@ontrails/core';
+
+import type { AuthAdapter } from './adapter.js';
+
+/**
+ * Auth service — manages the auth adapter lifecycle.
+ *
+ * The v1 factory returns a no-op adapter that always succeeds (null permit).
+ * Real adapter configuration will come through `ServiceSpec.config` (TRL-91).
+ * The mock factory provides a synthetic adapter that always succeeds.
+ */
+export const authService = service<AuthAdapter>('auth', {
+  create: (_svc) =>
+    Result.ok({
+      // oxlint-disable-next-line require-await -- stub adapter satisfies async interface
+      authenticate: async () => Result.ok(null),
+    } satisfies AuthAdapter),
+  description: 'Authentication adapter',
+  metadata: { category: 'infrastructure' },
+  mock: () =>
+    ({
+      // oxlint-disable-next-line require-await -- mock adapter satisfies async interface
+      authenticate: async () => Result.ok(null),
+    }) satisfies AuthAdapter,
+});

--- a/packages/permits/src/errors.ts
+++ b/packages/permits/src/errors.ts
@@ -1,0 +1,18 @@
+import { PermissionError } from '@ontrails/core';
+
+/**
+ * Error returned when permit scope enforcement fails.
+ *
+ * Extends `PermissionError` (category `'permission'`, HTTP 403) because
+ * it represents an *authorization* failure — the caller's identity is known
+ * but lacks the required scopes.
+ */
+export class PermitError extends PermissionError {
+  constructor(
+    message: string,
+    options?: { cause?: Error; context?: Record<string, unknown> }
+  ) {
+    super(message, options);
+    this.name = 'PermitError';
+  }
+}

--- a/packages/permits/src/extraction.ts
+++ b/packages/permits/src/extraction.ts
@@ -1,0 +1,19 @@
+/**
+ * Normalized input for auth adapters.
+ *
+ * Each surface extracts raw credentials from its transport and normalizes
+ * them into this shape. No surface types (Request, McpSession, etc.) cross
+ * into core — only this interface.
+ */
+export interface PermitExtractionInput {
+  /** Which surface produced this extraction */
+  readonly surface: 'http' | 'mcp' | 'cli';
+  /** Bearer token from Authorization header or equivalent */
+  readonly bearerToken?: string;
+  /** Session identifier from transport handshake */
+  readonly sessionId?: string;
+  /** Raw headers (HTTP surface only, typically) */
+  readonly headers?: Headers;
+  /** Correlation ID for tracing */
+  readonly requestId: string;
+}

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -1,0 +1,4 @@
+/** Internal placeholder — replaced by real types in TRL-98+. */
+export interface PermitPlaceholder {
+  readonly __brand: 'permits';
+}

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -4,5 +4,7 @@ export {
   type AuthError,
 } from './adapter.js';
 export { createJwtAdapter, type JwtAdapterOptions } from './adapters/jwt.js';
+export { authLayer } from './auth-layer.js';
+export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -1,4 +1,2 @@
-/** Internal placeholder — replaced by real types in TRL-98+. */
-export interface PermitPlaceholder {
-  readonly __brand: 'permits';
-}
+export { type Permit, getPermit } from './permit.js';
+export { type PermitExtractionInput } from './extraction.js';

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -1,2 +1,8 @@
-export { type Permit, getPermit } from './permit.js';
+export {
+  type AuthAdapter,
+  type AuthCredentials,
+  type AuthError,
+} from './adapter.js';
+export { createJwtAdapter, type JwtAdapterOptions } from './adapters/jwt.js';
 export { type PermitExtractionInput } from './extraction.js';
+export { type Permit, getPermit } from './permit.js';

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -8,3 +8,4 @@ export { authLayer } from './auth-layer.js';
 export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';
+export { validatePermits, type PermitDiagnostic } from './rules.js';

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -5,6 +5,8 @@ export {
 } from './adapter.js';
 export { createJwtAdapter, type JwtAdapterOptions } from './adapters/jwt.js';
 export { authLayer } from './auth-layer.js';
+export { authService } from './auth-service.js';
+export { authVerify } from './trails/auth-verify.js';
 export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -9,3 +9,4 @@ export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';
 export { validatePermits, type PermitDiagnostic } from './rules.js';
+export { mintTestPermit, mintPermitForTrail } from './testing.js';

--- a/packages/permits/src/permit.ts
+++ b/packages/permits/src/permit.ts
@@ -1,0 +1,26 @@
+import type { BasePermit } from '@ontrails/core';
+
+/** The resolved identity and scopes from a successful authentication. */
+export interface Permit extends BasePermit {
+  readonly roles?: readonly string[];
+  readonly tenantId?: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Type-safe accessor for `ctx.permit` with a downcast to `Permit`.
+ *
+ * `TrailContext.permit` is typed as `BasePermit` (id + scopes). This accessor
+ * returns the full `Permit` when the auth layer has set one. Safe because
+ * the auth layer is the only writer and always sets a full `Permit`.
+ *
+ * @example
+ * ```typescript
+ * const permit = getPermit(ctx);
+ * if (permit) {
+ *   console.log(permit.roles, permit.tenantId);
+ * }
+ * ```
+ */
+export const getPermit = (ctx: { permit?: BasePermit }): Permit | undefined =>
+  ctx.permit === undefined ? undefined : (ctx.permit as Permit);

--- a/packages/permits/src/rules.ts
+++ b/packages/permits/src/rules.ts
@@ -1,0 +1,183 @@
+import type { Trail } from '@ontrails/core';
+
+// ---------------------------------------------------------------------------
+// Diagnostic type
+// ---------------------------------------------------------------------------
+
+/** A single governance finding from a permit rule. */
+export interface PermitDiagnostic {
+  readonly trailId: string;
+  readonly rule: string;
+  readonly severity: 'error' | 'warning';
+  readonly message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type AnyTrail = Trail<unknown, unknown>;
+type Rule = (trails: readonly AnyTrail[]) => readonly PermitDiagnostic[];
+
+/** Check whether a trail has any permit declaration (scopes object or 'public'). */
+const hasPermit = (t: AnyTrail): boolean => t.permit !== undefined;
+
+/** Extract scopes from a trail's permit declaration, or empty array. */
+const getScopes = (t: AnyTrail): readonly string[] => {
+  if (t.permit !== undefined && t.permit !== 'public') {
+    return t.permit.scopes;
+  }
+  return [];
+};
+
+// ---------------------------------------------------------------------------
+// Rule: destroyWithoutPermit
+// ---------------------------------------------------------------------------
+
+/**
+ * Destructive trails without a real permit declaration are a governance failure.
+ *
+ * Reports an error for every trail with `intent: 'destroy'` that has no
+ * `permit` field or explicitly opts out with `permit: 'public'`.
+ */
+export const destroyWithoutPermit: Rule = (trails) =>
+  trails
+    .filter(
+      (t) => t.intent === 'destroy' && (!hasPermit(t) || t.permit === 'public')
+    )
+    .map((t) => ({
+      message: `Trail "${t.id}" has intent 'destroy' but no permit declaration`,
+      rule: 'destroyWithoutPermit',
+      severity: 'error' as const,
+      trailId: t.id,
+    }));
+
+// ---------------------------------------------------------------------------
+// Rule: writeWithoutPermit
+// ---------------------------------------------------------------------------
+
+/**
+ * Write trails without a permit declaration get a warning.
+ *
+ * Trails with `intent: 'write'` (or no intent, which defaults to write) that
+ * lack a permit are flagged unless `permit: 'public'` is explicitly set.
+ */
+export const writeWithoutPermit: Rule = (trails) =>
+  trails
+    .filter(
+      (t) => (t.intent === 'write' || t.intent === undefined) && !hasPermit(t)
+    )
+    .map((t) => ({
+      message: `Trail "${t.id}" has write intent but no permit declaration`,
+      rule: 'writeWithoutPermit',
+      severity: 'warning' as const,
+      trailId: t.id,
+    }));
+
+// ---------------------------------------------------------------------------
+// Rule: scopeNamingConsistency
+// ---------------------------------------------------------------------------
+
+/** Returns true when a scope follows the `entity:action` convention. */
+const isValidScopeFormat = (scope: string): boolean => {
+  const parts = scope.split(':');
+  return (
+    parts.length === 2 &&
+    (parts[0]?.length ?? 0) > 0 &&
+    (parts[1]?.length ?? 0) > 0
+  );
+};
+
+/**
+ * Warns for scopes that don't follow the `entity:action` convention.
+ *
+ * A valid scope contains exactly one colon separating a non-empty entity
+ * and a non-empty action.
+ */
+export const scopeNamingConsistency: Rule = (trails) =>
+  trails.flatMap((t) =>
+    getScopes(t)
+      .filter((scope) => !isValidScopeFormat(scope))
+      .map((scope) => ({
+        message: `Scope "${scope}" on trail "${t.id}" does not follow entity:action convention`,
+        rule: 'scopeNamingConsistency',
+        severity: 'warning' as const,
+        trailId: t.id,
+      }))
+  );
+
+// ---------------------------------------------------------------------------
+// Rule: orphanScopeDetection
+// ---------------------------------------------------------------------------
+
+/** Build a map of scope -> set of trail IDs that declare it. */
+const buildScopeMap = (
+  trails: readonly AnyTrail[]
+): ReadonlyMap<string, ReadonlySet<string>> => {
+  const map = new Map<string, Set<string>>();
+  for (const t of trails) {
+    for (const scope of getScopes(t)) {
+      const existing = map.get(scope);
+      if (existing) {
+        existing.add(t.id);
+      } else {
+        map.set(scope, new Set([t.id]));
+      }
+    }
+  }
+  return map;
+};
+
+/** Filter trails that have a scoped (non-public) permit declaration. */
+const trailsWithScopedPermit = (
+  trails: readonly AnyTrail[]
+): readonly AnyTrail[] =>
+  trails.filter((t) => t.permit !== undefined && t.permit !== 'public');
+
+/** Convert orphan scope map entries into diagnostics. */
+const orphanDiagnostics = (
+  scopeMap: ReadonlyMap<string, ReadonlySet<string>>
+): readonly PermitDiagnostic[] =>
+  [...scopeMap.entries()]
+    .filter(([, ids]) => ids.size === 1)
+    .map(([scope, ids]) => ({
+      message: `Scope "${scope}" appears only on trail "${[...ids][0]}" — possible typo`,
+      rule: 'orphanScopeDetection',
+      severity: 'warning' as const,
+      trailId: [...ids][0] ?? '',
+    }));
+
+/**
+ * Warns for scopes that appear in only one trail's permit.
+ *
+ * Catches typos like `user:wirte` by surfacing scopes not shared with any
+ * other trail. Only runs when at least 2 trails have permit declarations.
+ */
+export const orphanScopeDetection: Rule = (trails) => {
+  const scoped = trailsWithScopedPermit(trails);
+  if (scoped.length < 2) {
+    return [];
+  }
+  return orphanDiagnostics(buildScopeMap(scoped));
+};
+
+// ---------------------------------------------------------------------------
+// Top-level validator
+// ---------------------------------------------------------------------------
+
+const allRules: readonly Rule[] = [
+  destroyWithoutPermit,
+  writeWithoutPermit,
+  scopeNamingConsistency,
+  orphanScopeDetection,
+];
+
+/**
+ * Run all permit governance rules against a set of trails.
+ *
+ * Returns a flat array of diagnostics from every rule. An empty array
+ * means the topo passes all permit governance checks.
+ */
+export const validatePermits = (
+  trails: readonly Trail<unknown, unknown>[]
+): readonly PermitDiagnostic[] => allRules.flatMap((rule) => rule(trails));

--- a/packages/permits/src/testing.ts
+++ b/packages/permits/src/testing.ts
@@ -1,0 +1,34 @@
+import type { PermitRequirement } from '@ontrails/core';
+
+import type { Permit } from './permit.js';
+
+/**
+ * Mint a synthetic test permit with exactly the declared scopes.
+ * No admin permit, no wildcard — tests get only what the trail declares.
+ */
+export const mintTestPermit = (options?: {
+  readonly id?: string;
+  readonly scopes?: readonly string[];
+  readonly roles?: readonly string[];
+  readonly tenantId?: string;
+}): Permit => ({
+  id:
+    options?.id ??
+    `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  scopes: [...(options?.scopes ?? [])],
+  ...(options?.roles === undefined ? {} : { roles: [...options.roles] }),
+  ...(options?.tenantId === undefined ? {} : { tenantId: options.tenantId }),
+});
+
+/**
+ * Create a test permit matching a trail's permit requirement.
+ * Extracts scopes from the requirement and mints a permit with exactly those scopes.
+ */
+export const mintPermitForTrail = (trail: {
+  readonly permit?: PermitRequirement | undefined;
+}): Permit | undefined => {
+  if (!trail.permit || trail.permit === 'public') {
+    return undefined;
+  }
+  return mintTestPermit({ scopes: trail.permit.scopes });
+};

--- a/packages/permits/src/trails/auth-verify.ts
+++ b/packages/permits/src/trails/auth-verify.ts
@@ -1,7 +1,42 @@
-import { Result, trail } from '@ontrails/core';
+import { Result, SURFACE_KEY, trail } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
 import { authService } from '../auth-service.js';
+import type { PermitExtractionInput } from '../extraction.js';
+import type { Permit } from '../permit.js';
+
+const permitSchema = z.object({
+  id: z.string(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  roles: z.array(z.string()).optional(),
+  scopes: z.array(z.string()),
+  tenantId: z.string().optional(),
+});
+const authErrorCodeSchema = z.enum([
+  'expired_token',
+  'insufficient_scope',
+  'invalid_token',
+  'missing_credentials',
+]);
+
+const toOutputPermit = (permit: Permit) => ({
+  ...(permit.metadata === undefined
+    ? {}
+    : { metadata: { ...permit.metadata } }),
+  ...(permit.roles === undefined ? {} : { roles: [...permit.roles] }),
+  ...(permit.tenantId === undefined ? {} : { tenantId: permit.tenantId }),
+  id: permit.id,
+  scopes: [...permit.scopes],
+});
+
+const isSurface = (value: unknown): value is PermitExtractionInput['surface'] =>
+  value === 'http' || value === 'mcp' || value === 'cli';
+
+const getSurface = (ctx: TrailContext): PermitExtractionInput['surface'] => {
+  const surface = ctx.extensions?.[SURFACE_KEY];
+  return isSurface(surface) ? surface : 'http';
+};
 
 /**
  * Infrastructure trail that verifies a bearer token and returns the resolved permit.
@@ -18,39 +53,43 @@ export const authVerify = trail('auth.verify', {
     },
   ],
   input: z.object({
-    token: z.string().describe('Bearer token to verify'),
+    token: z.string().min(1).describe('Bearer token to verify'),
   }),
   intent: 'read',
   metadata: { category: 'infrastructure' },
   output: z.object({
     error: z.string().optional(),
-    permit: z
-      .object({
-        id: z.string(),
-        scopes: z.array(z.string()),
-      })
-      .optional(),
+    errorCode: authErrorCodeSchema.optional(),
+    permit: permitSchema.optional(),
     valid: z.boolean(),
   }),
   run: async (input, ctx) => {
     const adapter = authService.from(ctx);
     const result = await adapter.authenticate({
       bearerToken: input.token,
-      requestId: ctx.requestId ?? 'unknown',
-      surface: 'http',
+      requestId: ctx.requestId,
+      surface: getSurface(ctx),
     });
 
     if (result.isErr()) {
-      return Result.ok({ error: result.error.message, valid: false });
+      return Result.ok({
+        error: result.error.message,
+        errorCode: result.error.code,
+        valid: false,
+      });
     }
 
     const permit = result.value;
     if (!permit) {
-      return Result.ok({ error: 'No credentials', valid: false });
+      return Result.ok({
+        error: 'No credentials',
+        errorCode: 'missing_credentials',
+        valid: false,
+      });
     }
 
     return Result.ok({
-      permit: { id: permit.id, scopes: [...permit.scopes] },
+      permit: toOutputPermit(permit),
       valid: true,
     });
   },

--- a/packages/permits/src/trails/auth-verify.ts
+++ b/packages/permits/src/trails/auth-verify.ts
@@ -1,0 +1,58 @@
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { authService } from '../auth-service.js';
+
+/**
+ * Infrastructure trail that verifies a bearer token and returns the resolved permit.
+ *
+ * Reads the auth adapter from `authService` — the adapter is configured at
+ * bootstrap (e.g. JWT with HMAC secret). The mock adapter always succeeds with
+ * a null permit, so `testAll(app)` works without configuration.
+ */
+export const authVerify = trail('auth.verify', {
+  examples: [
+    {
+      input: { token: 'test-token' },
+      name: 'Verify a token',
+    },
+  ],
+  input: z.object({
+    token: z.string().describe('Bearer token to verify'),
+  }),
+  intent: 'read',
+  metadata: { category: 'infrastructure' },
+  output: z.object({
+    error: z.string().optional(),
+    permit: z
+      .object({
+        id: z.string(),
+        scopes: z.array(z.string()),
+      })
+      .optional(),
+    valid: z.boolean(),
+  }),
+  run: async (input, ctx) => {
+    const adapter = authService.from(ctx);
+    const result = await adapter.authenticate({
+      bearerToken: input.token,
+      requestId: ctx.requestId ?? 'unknown',
+      surface: 'http',
+    });
+
+    if (result.isErr()) {
+      return Result.ok({ error: result.error.message, valid: false });
+    }
+
+    const permit = result.value;
+    if (!permit) {
+      return Result.ok({ error: 'No credentials', valid: false });
+    }
+
+    return Result.ok({
+      permit: { id: permit.id, scopes: [...permit.scopes] },
+      valid: true,
+    });
+  },
+  services: [authService],
+});

--- a/packages/permits/tsconfig.json
+++ b/packages/permits/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/packages/testing/src/__tests__/examples.test.ts
+++ b/packages/testing/src/__tests__/examples.test.ts
@@ -437,3 +437,97 @@ describe('testExamples nested follow chain (A → B → C)', () => {
     } as Record<string, unknown>)
   );
 });
+
+// ---------------------------------------------------------------------------
+// Auto-minting permit tests (B3)
+// ---------------------------------------------------------------------------
+
+const scopedTrail = trail('scoped.trail', {
+  description: 'Trail requiring admin scope',
+  examples: [
+    {
+      expected: { ok: true },
+      input: {},
+      name: 'Runs with auto-minted permit',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  permit: { scopes: ['admin'] },
+  run: (_input, ctx) => {
+    // Verify the permit was auto-minted with declared scopes
+    const permit = ctx.permit as
+      | { id: string; scopes: readonly string[] }
+      | undefined;
+    if (!permit || !permit.scopes.includes('admin')) {
+      return Result.err(new Error('Missing permit or scopes'));
+    }
+    return Result.ok({ ok: true });
+  },
+});
+
+const publicTrail = trail('public.trail', {
+  description: 'Public trail — no permit needed',
+  examples: [
+    {
+      expected: { ok: true },
+      input: {},
+      name: 'Runs without a permit',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  permit: 'public',
+  run: (_input, ctx) => {
+    // Public trail should NOT get a permit
+    if (ctx.permit !== undefined) {
+      return Result.err(new Error('Unexpected permit on public trail'));
+    }
+    return Result.ok({ ok: true });
+  },
+});
+
+describe('testExamples auto-minting permits', () => {
+  describe('scoped trail gets auto-minted permit', () => {
+    // eslint-disable-next-line jest/require-hook
+    testExamples(
+      topo('mint-scoped-app', {
+        scopedTrail,
+      } as Record<string, unknown>)
+    );
+  });
+
+  describe('public trail does NOT get a permit', () => {
+    // eslint-disable-next-line jest/require-hook
+    testExamples(
+      topo('mint-public-app', {
+        publicTrail,
+      } as Record<string, unknown>)
+    );
+  });
+
+  describe('strictPermits skips auto-minting', () => {
+    const strictScopedTrail = trail('strict.scoped', {
+      description: 'Trail that expects no permit under strictPermits',
+      examples: [
+        {
+          expected: { hasPermit: false },
+          input: {},
+          name: 'No auto-minted permit when strictPermits is true',
+        },
+      ],
+      input: z.object({}),
+      output: z.object({ hasPermit: z.boolean() }),
+      permit: { scopes: ['admin'] },
+      run: (_input, ctx) => Result.ok({ hasPermit: ctx.permit !== undefined }),
+    });
+
+    // eslint-disable-next-line jest/require-hook
+    testExamples(
+      topo('strict-app', {
+        strictScopedTrail,
+      } as Record<string, unknown>),
+      { strictPermits: true }
+    );
+  });
+});

--- a/packages/testing/src/context.ts
+++ b/packages/testing/src/context.ts
@@ -53,6 +53,20 @@ export interface CreateFollowContextOptions {
   readonly responses?: Record<string, Result<unknown, Error>> | undefined;
 }
 
+/** Minimal permit shape returned by the mint function. */
+export interface MintedPermit {
+  readonly id: string;
+  readonly scopes: readonly string[];
+}
+
+/** Trail shape consumed by the mint function — avoids importing permits. */
+export interface MintableTrail {
+  readonly permit?:
+    | { readonly scopes: readonly string[] }
+    | 'public'
+    | undefined;
+}
+
 export interface TestExecutionOptions {
   readonly ctx?: Partial<TrailContext> | undefined;
   readonly services?: ServiceOverrideMap | undefined;
@@ -61,6 +75,15 @@ export interface TestExecutionOptions {
    * explicit permits.
    */
   readonly strictPermits?: boolean | undefined;
+  /**
+   * Optional function to mint a test permit for a trail. When provided,
+   * called for each trail with a non-public `permit` requirement.
+   * Returning `undefined` skips minting for that trail.
+   *
+   * A default inline implementation is used when this is not provided,
+   * keeping the testing package free of a hard dependency on `@ontrails/permits`.
+   */
+  readonly mintPermit?: (trail: MintableTrail) => MintedPermit | undefined;
 }
 
 /**
@@ -95,11 +118,27 @@ export const createFollowContext = (
   };
 };
 
+/**
+ * Default permit minter — reads `trail.permit.scopes` and produces a
+ * minimal permit object. No dependency on `@ontrails/permits`.
+ */
+export const defaultMintPermit = (
+  trail: MintableTrail
+): MintedPermit | undefined => {
+  if (!trail.permit || trail.permit === 'public') {
+    return undefined;
+  }
+  return { id: 'test-permit', scopes: trail.permit.scopes };
+};
+
 const isTestExecutionOptions = (
   input: Partial<TrailContext> | TestExecutionOptions | undefined
 ): input is TestExecutionOptions =>
   input !== undefined &&
-  (Object.hasOwn(input, 'ctx') || Object.hasOwn(input, 'services'));
+  (Object.hasOwn(input, 'ctx') ||
+    Object.hasOwn(input, 'services') ||
+    Object.hasOwn(input, 'strictPermits') ||
+    Object.hasOwn(input, 'mintPermit'));
 
 export const normalizeTestExecutionOptions = (
   input?: Partial<TrailContext> | TestExecutionOptions

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -45,12 +45,13 @@ import {
   assertSchemaMatch,
 } from './assertions.js';
 import {
+  defaultMintPermit,
   mergeServiceOverrides,
   mergeTestContext,
   normalizeTestExecutionOptions,
   resolveMockServices,
 } from './context.js';
-import type { TestExecutionOptions } from './context.js';
+import type { MintableTrail, TestExecutionOptions } from './context.js';
 
 // ---------------------------------------------------------------------------
 // Error class name -> constructor map
@@ -128,6 +129,29 @@ const handleValidationError = (
 };
 
 /**
+ * Apply auto-minting: if the trail declares scoped permits and the context
+ * doesn't already have a permit, mint one and merge it into the context.
+ */
+const applyAutoMint = (
+  ctx: TrailContext,
+  trailDef: MintableTrail,
+  opts: TestExecutionOptions
+): TrailContext => {
+  if (opts.strictPermits) {
+    return ctx;
+  }
+  if (ctx.permit !== undefined) {
+    return ctx;
+  }
+  const mint = opts.mintPermit ?? defaultMintPermit;
+  const permit = mint(trailDef);
+  if (!permit) {
+    return ctx;
+  }
+  return { ...ctx, permit };
+};
+
+/**
  * Run a single example against a trail.
  * Handles validation, execution, and assertions.
  */
@@ -136,7 +160,8 @@ const runExample = async (
   example: TrailExample<unknown, unknown>,
   output: z.ZodType | undefined,
   testCtx: TrailContext,
-  services?: ServiceOverrideMap
+  services?: ServiceOverrideMap,
+  opts?: TestExecutionOptions
 ): Promise<void> => {
   const validated = validateInput(t.input, example.input);
 
@@ -144,8 +169,10 @@ const runExample = async (
     return;
   }
 
+  const ctx = opts ? applyAutoMint(testCtx, t, opts) : testCtx;
+
   const result = await executeTrail(t, example.input, {
-    ctx: testCtx,
+    ctx,
     services,
   });
   assertProgressiveMatch(result, example, output);
@@ -199,7 +226,8 @@ const runCompositionExample = async (
   baseCtx: TrailContext,
   called: Set<string>,
   topo: Topo,
-  services?: ServiceOverrideMap
+  services?: ServiceOverrideMap,
+  opts?: TestExecutionOptions
 ): Promise<void> => {
   const validated = validateInput(trailDef.input, example.input);
 
@@ -207,14 +235,15 @@ const runCompositionExample = async (
     return;
   }
 
+  const mintedCtx = opts ? applyAutoMint(baseCtx, trailDef, opts) : baseCtx;
   const follow = createCoverageFollow(
     called,
-    baseCtx.follow,
+    mintedCtx.follow,
     topo,
-    baseCtx,
+    mintedCtx,
     services
   );
-  const testCtx: TrailContext = { ...baseCtx, follow };
+  const testCtx: TrailContext = { ...mintedCtx, follow };
 
   const result = await executeTrail(trailDef, example.input, {
     ctx: testCtx,
@@ -273,7 +302,7 @@ export const testExamples = (
             resolved.services
           );
           const testCtx = mergeTestContext(resolved.ctx);
-          await runExample(t, example, output, testCtx, services);
+          await runExample(t, example, output, testCtx, services, resolved);
         }
       );
     });
@@ -306,7 +335,8 @@ export const testExamples = (
             baseCtx,
             called,
             app,
-            services
+            services,
+            resolved
           );
         }
       );

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -16,7 +16,11 @@ export {
 } from './assertions.js';
 
 // Mock factories
-export { createFollowContext, createTestContext } from './context.js';
+export {
+  createFollowContext,
+  createTestContext,
+  defaultMintPermit,
+} from './context.js';
 export { createTestLogger } from './logger.js';
 
 // Surface harnesses
@@ -25,7 +29,11 @@ export { createMcpHarness } from './harness-mcp.js';
 
 // Types
 export type { CreateFollowContextOptions } from './context.js';
-export type { TestExecutionOptions } from './context.js';
+export type {
+  MintableTrail,
+  MintedPermit,
+  TestExecutionOptions,
+} from './context.js';
 export type { TestFollowOptions } from './follows.js';
 
 export type {


### PR DESCRIPTION
## Summary

This PR now carries the full permits/auth subsystem after folding the earlier permits branches into the `TRL-103` capstone.

Included in this branch:

- scaffolds `@ontrails/permits` as a workspace package
- introduces the `Permit` model, `PermitRequirement`, and normalized extraction input types
- adds the `getPermit(ctx)` accessor and core trail contract support for permits
- implements the `AuthAdapter` interface plus the built-in JWT adapter
- adds the `authLayer` for scope enforcement across direct execution and follow chains
- adds governance rules for missing permits, scope naming, and orphan scope detection
- adds synthetic permit minting helpers for tests and examples
- completes the trifecta with `authService` and the `auth.verify` trail

## Folded Work

- `TRL-97` — scaffold `@ontrails/permits`
- `TRL-98` — `Permit` type, permit field, and extraction types
- `TRL-99` — `AuthAdapter` and JWT/JWKS adapter work
- `TRL-100` — auth layer and scope enforcement
- `TRL-101` — permit governance rules
- `TRL-102` — synthetic permit minting for testing
- `TRL-103` — `authService` and `auth.verify`

## Test plan

- [ ] `bun test` passes in `packages/permits/`
- [ ] core tests covering trail permit contract changes continue to pass
- [ ] `auth.verify` tests cover success, expiry, and invalid-signature cases
- [ ] governance-rule tests cover destroy/write/public and scope-diagnostic behavior

Closed: TRL-97, TRL-98, TRL-99, TRL-100, TRL-101, TRL-102, TRL-103

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
