### PR TITLE
feat(tracks): scaffold @ontrails/tracks package [TRL-105]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -162,6 +162,14 @@
         "zod": "catalog:",
       },
     },
+    "packages/tracks": {
+      "name": "@ontrails/tracks",
+      "version": "1.0.0-beta.11",
+      "peerDependencies": {
+        "@ontrails/core": "workspace:^",
+        "zod": "catalog:",
+      },
+    },
     "packages/warden": {
       "name": "@ontrails/warden",
       "version": "1.0.0-beta.11",
@@ -268,6 +276,8 @@
     "@ontrails/schema": ["@ontrails/schema@workspace:packages/schema"],
 
     "@ontrails/testing": ["@ontrails/testing@workspace:packages/testing"],
+
+    "@ontrails/tracks": ["@ontrails/tracks@workspace:packages/tracks"],
 
     "@ontrails/trails": ["@ontrails/trails@workspace:apps/trails"],
 

--- a/packages/tracks/package.json
+++ b/packages/tracks/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@ontrails/tracks",
+  "version": "1.0.0-beta.11",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./otel": "./src/adapters/otel.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@ontrails/core": "workspace:^",
+    "zod": "catalog:"
+  }
+}

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -1,0 +1,5 @@
+/** Internal placeholder — replaced by real types in TRL-106+. */
+export interface TracksPlaceholder {
+  readonly __brand: 'tracks';
+}
+export { tracks } from './tracks-accessor.js';

--- a/packages/tracks/tsconfig.json
+++ b/packages/tracks/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
## Summary

- Create `packages/tracks/` with `package.json`, `tsconfig.json`, and barrel export
- Same structure as `@ontrails/permits` — peer deps on `@ontrails/core` and `zod`

## Test plan

- [ ] `bun run typecheck` passes in `packages/tracks/`
- [ ] Package visible in workspace

Closes https://linear.app/outfitter/issue/TRL-105/scaffold-ontrailstracks-package

In-collaboration-with: [Claude Code](https://claude.com/claude-code)