### PR TITLE
feat(tracks): add follow chain propagation and intent-based sampling [TRL-107]

### DIFF
--- a/packages/tracks/src/__tests__/sampling.test.ts
+++ b/packages/tracks/src/__tests__/sampling.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { DEFAULT_SAMPLING, shouldSample } from '../sampling.js';
+
+type Intent = 'read' | 'write' | 'destroy' | undefined;
+
+describe('DEFAULT_SAMPLING', () => {
+  test('read defaults to 0.05', () => {
+    expect(DEFAULT_SAMPLING.read).toBe(0.05);
+  });
+
+  test('write defaults to 1', () => {
+    expect(DEFAULT_SAMPLING.write).toBe(1);
+  });
+
+  test('destroy defaults to 1', () => {
+    expect(DEFAULT_SAMPLING.destroy).toBe(1);
+  });
+});
+
+describe('shouldSample', () => {
+  const originalRandom = Math.random;
+
+  afterEach(() => {
+    Math.random = originalRandom;
+  });
+
+  test('write intent defaults to 100% sampled', () => {
+    Math.random = () => 0.99;
+    expect(shouldSample('write')).toBe(true);
+  });
+
+  test('destroy intent defaults to 100% sampled', () => {
+    Math.random = () => 0.99;
+    expect(shouldSample('destroy')).toBe(true);
+  });
+
+  test('read intent with random 0.01 is sampled (under 5%)', () => {
+    Math.random = () => 0.01;
+    expect(shouldSample('read')).toBe(true);
+  });
+
+  test('read intent with random 0.10 is not sampled (over 5%)', () => {
+    Math.random = () => 0.1;
+    expect(shouldSample('read')).toBe(false);
+  });
+
+  test('custom sampling config overrides defaults', () => {
+    Math.random = () => 0.49;
+    expect(shouldSample('read', { read: 0.5 })).toBe(true);
+
+    Math.random = () => 0.51;
+    expect(shouldSample('read', { read: 0.5 })).toBe(false);
+  });
+
+  test('falls back to write rate for unspecified intent', () => {
+    Math.random = () => 0.99;
+    const noIntent: Intent = undefined;
+    expect(shouldSample(noIntent)).toBe(true);
+  });
+});

--- a/packages/tracks/src/__tests__/trace-context.test.ts
+++ b/packages/tracks/src/__tests__/trace-context.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  TRACE_CONTEXT_KEY,
+  childTraceContext,
+  getTraceContext,
+} from '../trace-context.js';
+import type { TraceContext } from '../trace-context.js';
+
+describe('getTraceContext', () => {
+  test('returns undefined when no extensions', () => {
+    const ctx = {};
+    expect(getTraceContext(ctx)).toBeUndefined();
+  });
+
+  test('returns undefined when key is absent from extensions', () => {
+    const ctx = { extensions: { other: 'value' } };
+    expect(getTraceContext(ctx)).toBeUndefined();
+  });
+
+  test('returns context when present in extensions', () => {
+    const trace: TraceContext = {
+      rootId: 'span-1',
+      sampled: true,
+      spanId: 'span-1',
+      traceId: 'trace-1',
+    };
+    const ctx = { extensions: { [TRACE_CONTEXT_KEY]: trace } };
+
+    expect(getTraceContext(ctx)).toEqual(trace);
+  });
+});
+
+describe('childTraceContext', () => {
+  test('inherits traceId from parent', () => {
+    const parent: TraceContext = {
+      rootId: 'root-span',
+      sampled: true,
+      spanId: 'parent-span',
+      traceId: 'trace-abc',
+    };
+    const child = childTraceContext(parent);
+
+    expect(child.traceId).toBe('trace-abc');
+  });
+
+  test('generates a new spanId', () => {
+    const parent: TraceContext = {
+      rootId: 'root-span',
+      sampled: true,
+      spanId: 'parent-span',
+      traceId: 'trace-abc',
+    };
+    const child = childTraceContext(parent);
+
+    expect(child.spanId).toBeString();
+    expect(child.spanId).not.toBe(parent.spanId);
+  });
+
+  test('inherits sampled flag', () => {
+    const sampledParent: TraceContext = {
+      rootId: 'span-1',
+      sampled: true,
+      spanId: 'span-1',
+      traceId: 'trace-1',
+    };
+    const unsampledParent: TraceContext = {
+      rootId: 'span-2',
+      sampled: false,
+      spanId: 'span-2',
+      traceId: 'trace-2',
+    };
+
+    expect(childTraceContext(sampledParent).sampled).toBe(true);
+    expect(childTraceContext(unsampledParent).sampled).toBe(false);
+  });
+
+  test('inherits rootId from parent (not spanId)', () => {
+    const parent: TraceContext = {
+      rootId: 'the-root',
+      sampled: true,
+      spanId: 'parent-span',
+      traceId: 'trace-abc',
+    };
+    const child = childTraceContext(parent);
+
+    expect(child.rootId).toBe('the-root');
+    expect(child.rootId).not.toBe(child.spanId);
+  });
+});

--- a/packages/tracks/src/__tests__/tracks-layer.test.ts
+++ b/packages/tracks/src/__tests__/tracks-layer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 
 import { z } from 'zod';
 
@@ -12,6 +12,8 @@ import {
 import type { TrailContext } from '@ontrails/core';
 
 import { createMemorySink } from '../memory-sink.js';
+import { getTraceContext, TRACE_CONTEXT_KEY } from '../trace-context.js';
+import type { TraceContext } from '../trace-context.js';
 import { createTracksLayer } from '../tracks-layer.js';
 
 const stubCtx: TrailContext = createTrailContext({
@@ -98,22 +100,195 @@ describe('tracksLayer', () => {
     expect(sink.records[0]?.id).not.toBe(sink.records[1]?.id);
   });
 
-  test('captures the invoking surface from ctx.extensions', async () => {
-    const sink = createMemorySink();
-    const layer = createTracksLayer(sink);
+  describe('trace context propagation', () => {
+    test('creates root trace context for root invocations', async () => {
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink);
+      const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+      await wrapped({ value: 'hello' }, stubCtx);
+
+      const [record] = sink.records;
+      expect(record?.traceId).toBeString();
+      expect(record?.traceId.length).toBeGreaterThan(0);
+    });
+
+    test('injects trace context into ctx.extensions for child trails', async () => {
+      let capturedTrace: TraceContext | undefined;
+      const capturingTrail = trail('capture', {
+        input: z.object({}),
+        output: z.object({}),
+        run: (_input, ctx) => {
+          capturedTrace = getTraceContext(ctx as TrailContext);
+          return Result.ok({});
+        },
+      });
+
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink);
+      const wrapped = layer.wrap(capturingTrail, capturingTrail.run);
+
+      await wrapped({}, stubCtx);
+
+      expect(capturedTrace).toBeDefined();
+      expect(capturedTrace?.traceId).toBeString();
+      expect(capturedTrace?.spanId).toBeString();
+      expect(capturedTrace?.sampled).toBe(true);
+    });
+
+    test('child invocation inherits parent traceId and links to parent record id', async () => {
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink);
+
+      const childTrail = trail('child', {
+        input: z.object({}),
+        output: z.object({}),
+        run: () => Result.ok({}),
+      });
+
+      let capturedTrace: TraceContext | undefined;
+      const rootTrail = trail('root', {
+        input: z.object({}),
+        output: z.object({}),
+        run: (_input, ctx) => {
+          capturedTrace = getTraceContext(ctx as TrailContext);
+          return Result.ok({});
+        },
+      });
+
+      const wrappedRoot = layer.wrap(rootTrail, rootTrail.run);
+      await wrappedRoot({}, stubCtx);
+
+      const ctxWithTrace: TrailContext = {
+        ...stubCtx,
+        extensions: {
+          ...stubCtx.extensions,
+          [TRACE_CONTEXT_KEY]: capturedTrace,
+        },
+      };
+
+      const wrappedChild = layer.wrap(childTrail, childTrail.run);
+      await wrappedChild({}, ctxWithTrace);
+
+      const [rootRecord, childRecord] = sink.records;
+      expect(childRecord?.traceId).toBe(rootRecord?.traceId);
+      expect(childRecord?.parentId).toBe(rootRecord?.id);
+      expect(childRecord?.rootId).toBe(rootRecord?.id);
+    });
+  });
+
+  describe('permit capture', () => {
+    test('captures permit from ctx when present', async () => {
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink);
+      const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+      const ctxWithPermit: TrailContext = {
+        ...stubCtx,
+        permit: { id: 'permit-1', tenantId: 'tenant-abc' },
+      };
+
+      await wrapped({ value: 'hello' }, ctxWithPermit);
+
+      expect(sink.records[0]?.permit).toEqual({
+        id: 'permit-1',
+        tenantId: 'tenant-abc',
+      });
+    });
+  });
+
+  describe('surface capture', () => {
+    test('captures the invoking surface from ctx.extensions', async () => {
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink);
+      const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+      const ctxWithSurface: TrailContext = {
+        ...stubCtx,
+        extensions: {
+          ...stubCtx.extensions,
+          [SURFACE_KEY]: 'http',
+        },
+      };
+
+      await wrapped({ value: 'hello' }, ctxWithSurface);
+
+      expect(sink.records[0]?.surface).toBe('http');
+    });
+  });
+
+  test('keeps trail result delivery when onSinkError throws', async () => {
+    const layer = createTracksLayer(
+      {
+        write: async () => {
+          throw new Error('sink down');
+        },
+      },
+      {
+        onSinkError: () => {
+          throw new Error('observer down');
+        },
+      }
+    );
     const wrapped = layer.wrap(echoTrail, echoTrail.run);
 
-    const ctxWithSurface: TrailContext = {
-      ...stubCtx,
-      extensions: {
-        ...stubCtx.extensions,
-        [SURFACE_KEY]: 'http',
-      },
-    };
+    const result = await wrapped({ value: 'hello' }, stubCtx);
 
-    await wrapped({ value: 'hello' }, ctxWithSurface);
+    expect(result.isOk()).toBe(true);
+  });
 
-    expect(sink.records[0]?.surface).toBe('http');
+  describe('sampling', () => {
+    const originalRandom = Math.random;
+
+    afterEach(() => {
+      Math.random = originalRandom;
+    });
+
+    test('sampled-out read trails are NOT written to sink', async () => {
+      Math.random = () => 0.99;
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink, { sampling: { read: 0.05 } });
+      const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+      const result = await wrapped({ value: 'hello' }, stubCtx);
+
+      expect(result.isOk()).toBe(true);
+      expect(sink.records).toHaveLength(0);
+    });
+
+    test('error promotion writes sampled-out failing trails', async () => {
+      Math.random = () => 0.99;
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink, {
+        keepOnError: true,
+        sampling: { read: 0.05 },
+      });
+
+      const readFailTrail = trail('read-fail', {
+        input: z.object({}),
+        intent: 'read',
+        output: z.object({ value: z.string() }),
+        run: () => Result.err(new Error('boom')),
+      });
+
+      const wrapped = layer.wrap(readFailTrail, readFailTrail.run);
+      const result = await wrapped({}, stubCtx);
+
+      expect(result.isErr()).toBe(true);
+      expect(sink.records).toHaveLength(1);
+      expect(sink.records[0]?.status).toBe('err');
+    });
+
+    test('empty sampling config preserves record-everything default', async () => {
+      Math.random = () => 0.99;
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink, { sampling: {} });
+      const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+      await wrapped({ value: 'hello' }, stubCtx);
+
+      expect(sink.records).toHaveLength(1);
+    });
   });
 
   test('records thrown implementations as err results', async () => {

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -1,3 +1,18 @@
 export { type TrackRecord, createTrackRecord } from './record.js';
-export { createTracksLayer, type TrackSink } from './tracks-layer.js';
+export {
+  createTracksLayer,
+  type TrackSink,
+  type TracksLayerOptions,
+} from './tracks-layer.js';
 export { createMemorySink } from './memory-sink.js';
+export {
+  type TraceContext,
+  getTraceContext,
+  childTraceContext,
+  TRACE_CONTEXT_KEY,
+} from './trace-context.js';
+export {
+  shouldSample,
+  DEFAULT_SAMPLING,
+  type SamplingConfig,
+} from './sampling.js';

--- a/packages/tracks/src/sampling.ts
+++ b/packages/tracks/src/sampling.ts
@@ -1,0 +1,30 @@
+/** Intent-based sampling rate configuration. */
+export interface SamplingConfig {
+  /** Sample rate for read operations (0.0 to 1.0). Default 0.05 (5%). */
+  readonly read: number;
+  /** Sample rate for write operations (0.0 to 1.0). Default 1.0 (100%). */
+  readonly write: number;
+  /** Sample rate for destroy operations (0.0 to 1.0). Default 1.0 (100%). */
+  readonly destroy: number;
+}
+
+/** Default sampling rates: 5% reads, 100% writes and destroys. */
+export const DEFAULT_SAMPLING: SamplingConfig = {
+  destroy: 1,
+  read: 0.05,
+  write: 1,
+};
+
+/**
+ * Decide whether to sample a trace based on intent.
+ *
+ * Undefined intent falls back to the write rate.
+ */
+export const shouldSample = (
+  intent: 'read' | 'write' | 'destroy' | undefined,
+  config?: Partial<SamplingConfig>
+): boolean => {
+  const merged = { ...DEFAULT_SAMPLING, ...config };
+  const rate = merged[intent ?? 'write'];
+  return Math.random() < rate;
+};

--- a/packages/tracks/src/trace-context.ts
+++ b/packages/tracks/src/trace-context.ts
@@ -1,0 +1,24 @@
+/** Trace context carried through trail execution. */
+export interface TraceContext {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly rootId: string;
+  readonly sampled: boolean;
+}
+
+/** Key used to store trace context in ctx.extensions. */
+export const TRACE_CONTEXT_KEY = '__tracks_trace';
+
+/** Read trace context from trail context extensions. */
+export const getTraceContext = (ctx: {
+  readonly extensions?: Readonly<Record<string, unknown>> | undefined;
+}): TraceContext | undefined =>
+  ctx.extensions?.[TRACE_CONTEXT_KEY] as TraceContext | undefined;
+
+/** Create a child trace context inheriting from a parent. */
+export const childTraceContext = (parent: TraceContext): TraceContext => ({
+  rootId: parent.rootId,
+  sampled: parent.sampled,
+  spanId: Bun.randomUUIDv7(),
+  traceId: parent.traceId,
+});

--- a/packages/tracks/src/tracks-layer.ts
+++ b/packages/tracks/src/tracks-layer.ts
@@ -15,10 +15,28 @@ import {
 
 import type { TrackRecord } from './record.js';
 import { createTrackRecord } from './record.js';
+import type { SamplingConfig } from './sampling.js';
+import { shouldSample } from './sampling.js';
+import type { TraceContext } from './trace-context.js';
+import {
+  TRACE_CONTEXT_KEY,
+  childTraceContext,
+  getTraceContext,
+} from './trace-context.js';
 
 /** Sink that receives completed TrackRecords. */
 export interface TrackSink {
   readonly write: (record: TrackRecord) => void | Promise<void>;
+}
+
+/** Options for configuring the tracks layer. */
+export interface TracksLayerOptions {
+  /** Intent-based sampling overrides. */
+  readonly sampling?: Partial<SamplingConfig> | undefined;
+  /** Promote sampled-out traces to sampled on error. Default true. */
+  readonly keepOnError?: boolean | undefined;
+  /** Observe sink write failures without affecting trail delivery. */
+  readonly onSinkError?: ((error: unknown) => void) | undefined;
 }
 
 /** Outcome fields derived from a trail execution result. */
@@ -30,9 +48,9 @@ interface TrackOutcome {
 /** Derive status and errorCategory from a trail result. */
 const deriveOutcome = (result: Result<unknown, Error>): TrackOutcome =>
   result.match<TrackOutcome>({
-    err: (e) => ({
-      errorCategory: e instanceof TrailsError ? e.category : undefined,
-      status: e instanceof CancelledError ? 'cancelled' : 'err',
+    err: (error) => ({
+      errorCategory: error instanceof TrailsError ? error.category : undefined,
+      status: error instanceof CancelledError ? 'cancelled' : 'err',
     }),
     ok: () => ({ errorCategory: undefined, status: 'ok' }),
   });
@@ -47,6 +65,75 @@ const normalizeThrownError = (error: unknown): Error => {
   }
   return new InternalError(String(error));
 };
+
+/** Create a root trace context for a new trace. */
+const createRootTrace = (sampled: boolean): TraceContext => {
+  const spanId = Bun.randomUUIDv7();
+  return {
+    rootId: spanId,
+    sampled,
+    spanId,
+    traceId: Bun.randomUUIDv7(),
+  };
+};
+
+/** Build a completed record from a base record and execution result. */
+const completeRecord = (
+  record: TrackRecord,
+  result: Result<unknown, Error>
+): TrackRecord => ({
+  ...record,
+  ...deriveOutcome(result),
+  endedAt: Date.now(),
+});
+
+/** Resolve whether this invocation should be sampled. */
+const resolveSampled = (
+  parentTrace: TraceContext | undefined,
+  intent: 'read' | 'write' | 'destroy' | undefined,
+  sampling: Partial<SamplingConfig> | undefined
+): boolean => {
+  if (parentTrace) {
+    return parentTrace.sampled;
+  }
+  if (sampling && Object.keys(sampling).length > 0) {
+    return shouldSample(intent, sampling);
+  }
+  return true;
+};
+
+/** Enrich a context with trace context in extensions. */
+const enrichExtensions = (
+  ctx: TrailContext,
+  trace: TraceContext
+): TrailContext => ({
+  ...ctx,
+  extensions: {
+    ...ctx.extensions,
+    [TRACE_CONTEXT_KEY]: trace,
+  },
+});
+
+/** Decide whether a completed record should be written to the sink. */
+const shouldWrite = (
+  record: TrackRecord,
+  sampled: boolean,
+  keepOnError: boolean
+): boolean => {
+  if (sampled) {
+    return true;
+  }
+  return keepOnError && record.status === 'err';
+};
+
+/** Resolve the trace context for this invocation — child or root. */
+const resolveTrace = (
+  parentTrace: TraceContext | undefined,
+  sampled: boolean
+): TraceContext =>
+  parentTrace
+    ? { ...childTraceContext(parentTrace), sampled }
+    : createRootTrace(sampled);
 
 /** Extract permit fields from ctx for the track record. */
 const extractPermit = (
@@ -64,33 +151,88 @@ const extractPermit = (
     : { id: ctx.permit.id, tenantId };
 };
 
-export const createTracksLayer = (sink: TrackSink): Layer => ({
+/** Notify sink observers without letting secondary failures escape. */
+const notifySinkError = (
+  options: TracksLayerOptions | undefined,
+  error: unknown
+): void => {
+  try {
+    options?.onSinkError?.(error);
+  } catch {
+    // Observer failures must never affect trail result delivery.
+  }
+};
+
+/** Prepare the trace, record, and enriched context for a trail execution. */
+const prepareExecution = <I, O>(
+  trail: Trail<I, O>,
+  ctx: TrailContext,
+  options?: TracksLayerOptions
+) => {
+  const parentTrace = getTraceContext(ctx);
+  const sampled = resolveSampled(parentTrace, trail.intent, options?.sampling);
+  const trace = resolveTrace(parentTrace, sampled);
+  const isRoot = parentTrace === undefined;
+
+  const record = createTrackRecord({
+    intent: trail.intent,
+    parentId: parentTrace?.spanId,
+    permit: extractPermit(ctx),
+    rootId: isRoot ? undefined : trace.rootId,
+    surface: ctx.extensions?.[SURFACE_KEY] as TrackRecord['surface'],
+    traceId: trace.traceId,
+    trailId: trail.id,
+  });
+
+  const enrichedTrace: TraceContext = {
+    ...trace,
+    rootId: isRoot ? record.id : trace.rootId,
+    spanId: record.id,
+  };
+
+  return {
+    ctx: enrichExtensions(ctx, enrichedTrace),
+    record,
+    sampled,
+  };
+};
+
+/**
+ * Layer that automatically records every trail execution.
+ *
+ * Wraps each trail implementation to capture timing, status, and parentage,
+ * then writes the completed record to the provided sink. Injects trace
+ * context into `ctx.extensions` so child trails inherit the trace. Supports
+ * intent-based sampling and error promotion for sampled-out traces.
+ */
+export const createTracksLayer = (
+  sink: TrackSink,
+  options?: TracksLayerOptions
+): Layer => ({
   description: 'Automatic trail execution recording',
   name: 'tracks',
   wrap:
     <I, O>(trail: Trail<I, O>, impl: Implementation<I, O>) =>
     async (input: I, ctx) => {
-      const record = createTrackRecord({
-        intent: trail.intent,
-        permit: extractPermit(ctx),
-        surface: ctx.extensions?.[SURFACE_KEY] as TrackRecord['surface'],
-        trailId: trail.id,
-      });
+      const execution = prepareExecution(trail, ctx, options);
       let result: Result<O, Error>;
+
       try {
-        result = await impl(input, ctx);
+        result = await impl(input, execution.ctx);
       } catch (error: unknown) {
         result = ResultCtor.err(normalizeThrownError(error));
       }
-      const completed: TrackRecord = {
-        ...record,
-        ...deriveOutcome(result),
-        endedAt: Date.now(),
-      };
 
-      await Promise.resolve(sink.write(completed)).catch(() => {
-        // sink failures must not affect trail result delivery
-      });
+      const completed = completeRecord(execution.record, result);
+
+      if (
+        shouldWrite(completed, execution.sampled, options?.keepOnError ?? true)
+      ) {
+        await Promise.resolve(sink.write(completed)).catch((error) => {
+          notifySinkError(options, error);
+        });
+      }
+
       return result;
     },
 });


### PR DESCRIPTION
## Summary

- **TraceContext** with traceId, spanId, sampled flag — stored in `ctx.extensions[TRACE_CONTEXT_KEY]`
- **getTraceContext/childTraceContext** for parent-child inheritance through follow chains
- **Intent-based sampling**: read 5%, write 100%, destroy 100%. Decision at root, inherited by children.
- **Error promotion**: sampled-out traces promoted to sampled if any record errors (`keepOnError: true` default)
- Backward compatible: no sampling config = record everything

## Test plan

- [ ] 5 trace-context tests + 9 sampling tests + 3 layer integration tests
- [ ] `bun test` passes in `packages/tracks/`

Closes https://linear.app/outfitter/issue/TRL-107/follow-chain-propagation-and-intent-based-sampling

In-collaboration-with: [Claude Code](https://claude.com/claude-code)