### PR TITLE
feat(tracks): add tracks service with span() and annotate() [TRL-108]

### DIFF
--- a/packages/tracks/src/__tests__/tracks-api.test.ts
+++ b/packages/tracks/src/__tests__/tracks-api.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createMemorySink } from '../memory-sink.js';
+import { TRACE_CONTEXT_KEY } from '../trace-context.js';
+import type { TraceContext } from '../trace-context.js';
+import { createTracksApi } from '../tracks-api.js';
+
+/** Build a stub ctx with trace context in extensions. */
+const makeCtx = (
+  overrides?: Partial<TraceContext>
+): { readonly extensions: Readonly<Record<string, unknown>> } => {
+  const trace: TraceContext = {
+    rootId: 'root-span-id',
+    sampled: true,
+    spanId: 'parent-span-id',
+    traceId: 'test-trace-id',
+    ...overrides,
+  };
+
+  return { extensions: { [TRACE_CONTEXT_KEY]: trace } };
+};
+
+describe('createTracksApi', () => {
+  describe('span()', () => {
+    test('creates a child record in the sink', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      await api.span('my-span', () => 'done');
+
+      expect(sink.records).toHaveLength(1);
+      const [record] = sink.records;
+      expect(record?.kind).toBe('span');
+      expect(record?.name).toBe('my-span');
+      expect(record?.traceId).toBe('test-trace-id');
+      expect(record?.parentId).toBe('parent-span-id');
+      expect(record?.rootId).toBe('root-span-id');
+    });
+
+    test('returns the callback result', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      const result = await api.span('op', () => 42);
+
+      expect(result).toBe(42);
+    });
+
+    test('returns the async callback result', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      const result = await api.span('async-op', () =>
+        Promise.resolve('async-value')
+      );
+
+      expect(result).toBe('async-value');
+    });
+
+    test('times the execution (endedAt >= startedAt)', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      await api.span('timed', () => 'ok');
+
+      const [record] = sink.records;
+      expect(record?.startedAt).toBeNumber();
+      expect(record?.endedAt).toBeNumber();
+      expect(Number(record?.endedAt)).toBeGreaterThanOrEqual(
+        Number(record?.startedAt)
+      );
+    });
+
+    test('marks record as err when callback throws', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      try {
+        await api.span('failing', () => {
+          throw new Error('boom');
+        });
+      } catch {
+        // expected
+      }
+
+      expect(sink.records).toHaveLength(1);
+      expect(sink.records[0]?.status).toBe('err');
+    });
+
+    test('re-throws the callback error after recording', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      await expect(
+        api.span('failing', () => {
+          throw new Error('boom');
+        })
+      ).rejects.toThrow('boom');
+
+      expect(sink.records).toHaveLength(1);
+    });
+
+    test('multiple spans create independent records', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      await api.span('first', () => 1);
+      await api.span('second', () => 2);
+
+      expect(sink.records).toHaveLength(2);
+      expect(sink.records[0]?.name).toBe('first');
+      expect(sink.records[1]?.name).toBe('second');
+      expect(sink.records[0]?.id).not.toBe(sink.records[1]?.id);
+    });
+
+    test('skips sink writes when trace sampling is disabled', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx({ sampled: false }), sink);
+
+      const result = await api.span('unsampled', () => 'done');
+
+      expect(result).toBe('done');
+      expect(sink.records).toHaveLength(0);
+    });
+  });
+
+  describe('annotate()', () => {
+    test('collects attributes without throwing', () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      expect(() => api.annotate({ count: 42, key: 'value' })).not.toThrow();
+    });
+
+    test('getAnnotations returns merged attrs from annotate calls', () => {
+      const sink = createMemorySink();
+      const { api, getAnnotations } = createTracksApi(makeCtx(), sink);
+
+      api.annotate({ first: 1 });
+      api.annotate({ second: 2 });
+
+      expect(getAnnotations()).toEqual({ first: 1, second: 2 });
+    });
+
+    test('getAnnotations returns empty object when no annotations', () => {
+      const sink = createMemorySink();
+      const { getAnnotations } = createTracksApi(makeCtx(), sink);
+
+      expect(getAnnotations()).toEqual({});
+    });
+
+    test('later annotations override earlier ones with same key', () => {
+      const sink = createMemorySink();
+      const { api, getAnnotations } = createTracksApi(makeCtx(), sink);
+
+      api.annotate({ key: 'old' });
+      api.annotate({ key: 'new' });
+
+      expect(getAnnotations()).toEqual({ key: 'new' });
+    });
+  });
+});

--- a/packages/tracks/src/__tests__/tracks-layer.test.ts
+++ b/packages/tracks/src/__tests__/tracks-layer.test.ts
@@ -14,6 +14,7 @@ import type { TrailContext } from '@ontrails/core';
 import { createMemorySink } from '../memory-sink.js';
 import { getTraceContext, TRACE_CONTEXT_KEY } from '../trace-context.js';
 import type { TraceContext } from '../trace-context.js';
+import { tracks } from '../index.js';
 import { createTracksLayer } from '../tracks-layer.js';
 
 const stubCtx: TrailContext = createTrailContext({
@@ -221,6 +222,7 @@ describe('tracksLayer', () => {
     const layer = createTracksLayer(
       {
         write: async () => {
+          await Promise.resolve();
           throw new Error('sink down');
         },
       },
@@ -327,5 +329,62 @@ describe('tracksLayer', () => {
     expect(sink.records).toHaveLength(1);
     expect(sink.records[0]?.status).toBe('cancelled');
     expect(sink.records[0]?.errorCategory).toBe('cancelled');
+  });
+
+  test('injects tracks.from(ctx).span so manual spans become child records', async () => {
+    const sink = createMemorySink();
+    const instrumentedTrail = trail('instrumented', {
+      input: z.object({}),
+      output: z.object({ value: z.string() }),
+      run: async (_input, ctx) => {
+        const value = await tracks
+          .from(ctx as TrailContext)
+          .span('inner-span', () => 'done');
+        return Result.ok({ value });
+      },
+    });
+
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(instrumentedTrail, instrumentedTrail.run);
+
+    const result = await wrapped({}, stubCtx);
+
+    expect(result.isOk()).toBe(true);
+    expect(sink.records).toHaveLength(2);
+
+    const trailRecord = sink.records.find((record) => record.kind === 'trail');
+    const spanRecord = sink.records.find((record) => record.kind === 'span');
+
+    expect(trailRecord?.trailId).toBe('instrumented');
+    expect(spanRecord?.name).toBe('inner-span');
+    expect(spanRecord?.parentId).toBe(trailRecord?.id);
+    expect(spanRecord?.rootId).toBe(trailRecord?.id);
+    expect(spanRecord?.traceId).toBe(trailRecord?.traceId);
+  });
+
+  test('merges tracks.from(ctx).annotate attrs into the trail record', async () => {
+    const sink = createMemorySink();
+    const annotatedTrail = trail('annotated', {
+      input: z.object({}),
+      output: z.object({ value: z.string() }),
+      run: (_input, ctx) => {
+        tracks.from(ctx as TrailContext).annotate({ count: 1, stage: 'start' });
+        tracks.from(ctx as TrailContext).annotate({ count: 2, detail: 'done' });
+        return Result.ok({ value: 'ok' });
+      },
+    });
+
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(annotatedTrail, annotatedTrail.run);
+
+    const result = await wrapped({}, stubCtx);
+
+    expect(result.isOk()).toBe(true);
+    expect(sink.records).toHaveLength(1);
+    expect(sink.records[0]?.attrs).toEqual({
+      count: 2,
+      detail: 'done',
+      stage: 'start',
+    });
   });
 });

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -16,3 +16,9 @@ export {
   DEFAULT_SAMPLING,
   type SamplingConfig,
 } from './sampling.js';
+export {
+  createTracksApi,
+  TRACKS_API_KEY,
+  type TracksApi,
+  type TracksApiWithState,
+} from './tracks-api.js';

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -22,3 +22,4 @@ export {
   type TracksApi,
   type TracksApiWithState,
 } from './tracks-api.js';
+export { tracks } from './tracks-accessor.js';

--- a/packages/tracks/src/tracks-accessor.ts
+++ b/packages/tracks/src/tracks-accessor.ts
@@ -1,0 +1,26 @@
+import { TRACKS_API_KEY } from './tracks-api.js';
+import type { TracksApi } from './tracks-api.js';
+
+/** No-op TracksApi returned when the tracks layer is not active. */
+const noopApi: TracksApi = {
+  // oxlint-disable-next-line no-empty-function -- intentional no-op
+  annotate: () => {},
+  span: async <T>(_name: string, fn: () => T | Promise<T>): Promise<T> =>
+    // oxlint-disable-next-line require-await -- no-op passthrough must return Promise
+    fn(),
+};
+
+/**
+ * Typed accessor for the TracksApi on a trail context.
+ *
+ * Returns a no-op implementation when the tracks layer is not active,
+ * so callers never need null-checks.
+ */
+export const tracks = {
+  from: (ctx: {
+    readonly extensions?: Readonly<Record<string, unknown>> | undefined;
+  }): TracksApi => {
+    const api = ctx.extensions?.[TRACKS_API_KEY] as TracksApi | undefined;
+    return api ?? noopApi;
+  },
+};

--- a/packages/tracks/src/tracks-api.ts
+++ b/packages/tracks/src/tracks-api.ts
@@ -1,0 +1,132 @@
+import type { TrackRecord } from './record.js';
+import { getTraceContext } from './trace-context.js';
+
+/** Sink type re-declared to avoid circular import with tracks-layer. */
+interface TrackSinkLike {
+  readonly write: (record: TrackRecord) => void | Promise<void>;
+}
+
+/** Key used to store the TracksApi in ctx.extensions. */
+export const TRACKS_API_KEY = '__tracks_api';
+
+/** Manual instrumentation API for trail implementations. */
+export interface TracksApi {
+  /**
+   * Create a timed child span. Callback-only to guarantee spans close.
+   * No raw startSpan/endSpan to prevent forgotten closures.
+   */
+  readonly span: <T>(name: string, fn: () => T | Promise<T>) => Promise<T>;
+
+  /** Add key-value pairs to the current trail's record attrs. */
+  readonly annotate: (attrs: Record<string, unknown>) => void;
+}
+
+/** TracksApi bundled with internal state the layer needs after execution. */
+export interface TracksApiWithState {
+  readonly api: TracksApi;
+  /** Retrieve all accumulated annotations, merged into a single object. */
+  readonly getAnnotations: () => Record<string, unknown>;
+}
+
+/** Build a span record from trace context and span name. */
+const createSpanRecord = (
+  traceId: string,
+  parentId: string,
+  rootId: string,
+  name: string
+): TrackRecord => ({
+  attrs: {},
+  endedAt: undefined,
+  errorCategory: undefined,
+  id: Bun.randomUUIDv7(),
+  intent: undefined,
+  kind: 'span',
+  name,
+  parentId,
+  rootId,
+  startedAt: Date.now(),
+  status: 'ok',
+  surface: undefined,
+  traceId,
+  trailId: undefined,
+});
+
+/** Mark a record as completed with timing and status. */
+const completeSpanRecord = (
+  record: TrackRecord,
+  status: 'ok' | 'err',
+  error?: unknown
+): TrackRecord => ({
+  ...record,
+  endedAt: Date.now(),
+  errorCategory:
+    status === 'err' && error instanceof Error
+      ? error.constructor.name
+      : undefined,
+  status,
+});
+
+/** Merge an array of annotation objects into a single flat record. */
+const mergeAnnotations = (
+  annotations: readonly Record<string, unknown>[]
+): Record<string, unknown> =>
+  Object.assign({}, ...annotations) as Record<string, unknown>;
+
+/**
+ * Create a TracksApi bound to a specific execution context and sink.
+ *
+ * Reads trace context from `ctx.extensions` so manual spans become
+ * children of the trail's automatic record. Returns the API alongside
+ * a `getAnnotations` accessor the layer uses to merge attrs into the
+ * completed record.
+ */
+export const createTracksApi = (
+  ctx: { readonly extensions?: Readonly<Record<string, unknown>> | undefined },
+  sink: TrackSinkLike
+): TracksApiWithState => {
+  const annotations: Record<string, unknown>[] = [];
+
+  const trace = getTraceContext(ctx);
+  const traceId = trace?.traceId ?? Bun.randomUUIDv7();
+  const parentId = trace?.spanId ?? Bun.randomUUIDv7();
+  const rootId = trace?.rootId ?? parentId;
+
+  const span = async <T>(
+    name: string,
+    fn: () => T | Promise<T>
+  ): Promise<T> => {
+    if (trace?.sampled === false) {
+      return await fn();
+    }
+
+    const record = createSpanRecord(traceId, parentId, rootId, name);
+
+    try {
+      const result = await fn();
+      await Promise.resolve(sink.write(completeSpanRecord(record, 'ok'))).catch(
+        () => {
+          // sink failures must not affect span result delivery
+        }
+      );
+      return result;
+    } catch (error: unknown) {
+      try {
+        await Promise.resolve(
+          sink.write(completeSpanRecord(record, 'err', error))
+        );
+      } catch {
+        // best-effort write; don't let sink errors mask the original
+      }
+      throw error;
+    }
+  };
+
+  const annotate = (attrs: Record<string, unknown>): void => {
+    annotations.push(attrs);
+  };
+
+  const getAnnotations = (): Record<string, unknown> =>
+    mergeAnnotations(annotations);
+
+  return { api: { annotate, span }, getAnnotations };
+};

--- a/packages/tracks/src/tracks-layer.ts
+++ b/packages/tracks/src/tracks-layer.ts
@@ -18,6 +18,7 @@ import { createTrackRecord } from './record.js';
 import type { SamplingConfig } from './sampling.js';
 import { shouldSample } from './sampling.js';
 import type { TraceContext } from './trace-context.js';
+import { createTracksApi, TRACKS_API_KEY } from './tracks-api.js';
 import {
   TRACE_CONTEXT_KEY,
   childTraceContext,
@@ -86,6 +87,21 @@ const completeRecord = (
   ...deriveOutcome(result),
   endedAt: Date.now(),
 });
+
+/** Merge manual annotations into a completed trail record. */
+const mergeAnnotations = (
+  record: TrackRecord,
+  attrs: Readonly<Record<string, unknown>>
+): TrackRecord =>
+  Object.keys(attrs).length === 0
+    ? record
+    : {
+        ...record,
+        attrs: {
+          ...record.attrs,
+          ...attrs,
+        },
+      };
 
 /** Resolve whether this invocation should be sampled. */
 const resolveSampled = (
@@ -167,6 +183,7 @@ const notifySinkError = (
 const prepareExecution = <I, O>(
   trail: Trail<I, O>,
   ctx: TrailContext,
+  sink: TrackSink,
   options?: TracksLayerOptions
 ) => {
   const parentTrace = getTraceContext(ctx);
@@ -189,9 +206,18 @@ const prepareExecution = <I, O>(
     rootId: isRoot ? record.id : trace.rootId,
     spanId: record.id,
   };
+  const traceCtx = enrichExtensions(ctx, enrichedTrace);
+  const tracksApi = createTracksApi(traceCtx, sink);
 
   return {
-    ctx: enrichExtensions(ctx, enrichedTrace),
+    ctx: {
+      ...traceCtx,
+      extensions: {
+        ...traceCtx.extensions,
+        [TRACKS_API_KEY]: tracksApi.api,
+      },
+    },
+    getAnnotations: tracksApi.getAnnotations,
     record,
     sampled,
   };
@@ -214,7 +240,7 @@ export const createTracksLayer = (
   wrap:
     <I, O>(trail: Trail<I, O>, impl: Implementation<I, O>) =>
     async (input: I, ctx) => {
-      const execution = prepareExecution(trail, ctx, options);
+      const execution = prepareExecution(trail, ctx, sink, options);
       let result: Result<O, Error>;
 
       try {
@@ -223,7 +249,10 @@ export const createTracksLayer = (
         result = ResultCtor.err(normalizeThrownError(error));
       }
 
-      const completed = completeRecord(execution.record, result);
+      const completed = mergeAnnotations(
+        completeRecord(execution.record, result),
+        execution.getAnnotations()
+      );
 
       if (
         shouldWrite(completed, execution.sampled, options?.keepOnError ?? true)


### PR DESCRIPTION
## Summary

- **span(name, fn)** — callback-only child spans. Guarantees closure (no forgotten `endSpan()`). Creates TrackRecord with `kind: 'span'`, times execution, writes to sink. Re-throws on error after recording.
- **annotate(attrs)** — collects key-value annotations merged into the parent trail's record by tracksLayer
- **createTracksApi(ctx, sink)** — factory bound to execution context

## Test plan

- [ ] 8 tests: child record creation, timing, error marking, re-throw, multi-span independence, annotate safety
- [ ] `bun test` passes in `packages/tracks/`

Closes https://linear.app/outfitter/issue/TRL-108/tracks-service-span-callback-api-and-annotate

In-collaboration-with: [Claude Code](https://claude.com/claude-code)