### PR TITLE
feat(tracks): add bun:sqlite dev store for local traces [TRL-109]

### DIFF
--- a/packages/tracks/src/__tests__/dev-store.test.ts
+++ b/packages/tracks/src/__tests__/dev-store.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { TrackRecord } from '../record.js';
+import type { DevStore } from '../stores/dev.js';
+import { createDevStore } from '../stores/dev.js';
+
+/** Build a minimal TrackRecord for testing. */
+const makeRecord = (overrides?: Partial<TrackRecord>): TrackRecord => ({
+  attrs: {},
+  endedAt: Date.now(),
+  id: `rec-${crypto.randomUUID()}`,
+  kind: 'trail',
+  name: 'test-trail',
+  rootId: 'root-1',
+  startedAt: Date.now() - 100,
+  status: 'ok',
+  traceId: 'trace-1',
+  trailId: 'test-trail',
+  ...overrides,
+});
+
+describe('createDevStore', () => {
+  let tmpDir: string;
+  let store: DevStore | undefined;
+
+  const makeTmpDir = (): string => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'dev-store-'));
+    return tmpDir;
+  };
+
+  afterEach(() => {
+    store?.close();
+    store = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { force: true, recursive: true });
+    }
+  });
+
+  describe('lifecycle', () => {
+    test('creates a database file at the specified path', () => {
+      const dir = makeTmpDir();
+      const dbPath = join(dir, 'tracks.db');
+
+      store = createDevStore({ path: dbPath });
+
+      expect(existsSync(dbPath)).toBe(true);
+    });
+
+    test('close() closes the database connection', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+      store.write(makeRecord());
+
+      store.close();
+
+      // Querying after close should throw
+      expect(() => store?.query()).toThrow();
+      /* Prevent double-close in afterEach */
+      store = undefined;
+    });
+  });
+
+  describe('write()', () => {
+    test('persists a TrackRecord', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+      const record = makeRecord();
+
+      store.write(record);
+      const results = store.query();
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.id).toBe(record.id);
+      expect(results[0]?.name).toBe('test-trail');
+    });
+
+    test('persists attrs as JSON', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+      const record = makeRecord({ attrs: { count: 42, key: 'value' } });
+
+      store.write(record);
+      const results = store.query();
+
+      expect(results[0]?.attrs).toEqual({ count: 42, key: 'value' });
+    });
+
+    test('persists permit fields', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+      const record = makeRecord({
+        permit: { id: 'permit-1', tenantId: 'tenant-1' },
+      });
+
+      store.write(record);
+      const results = store.query();
+
+      expect(results[0]?.permit).toEqual({
+        id: 'permit-1',
+        tenantId: 'tenant-1',
+      });
+    });
+
+    test('upserts duplicate record ids instead of throwing', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      store.write(makeRecord({ id: 'dup', name: 'first' }));
+      store.write(makeRecord({ id: 'dup', name: 'updated' }));
+
+      const results = store.query();
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('updated');
+    });
+  });
+
+  describe('query()', () => {
+    test('returns persisted records ordered by startedAt descending', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      const older = makeRecord({
+        id: 'rec-old',
+        name: 'first',
+        startedAt: 1000,
+      });
+      const newer = makeRecord({
+        id: 'rec-new',
+        name: 'second',
+        startedAt: 2000,
+      });
+
+      store.write(older);
+      store.write(newer);
+      const results = store.query();
+
+      expect(results).toHaveLength(2);
+      expect(results[0]?.id).toBe('rec-new');
+      expect(results[1]?.id).toBe('rec-old');
+    });
+
+    test('filters by trailId', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      store.write(makeRecord({ id: 'a', trailId: 'users.list' }));
+      store.write(makeRecord({ id: 'b', trailId: 'users.get' }));
+      store.write(makeRecord({ id: 'c', trailId: 'users.list' }));
+
+      const results = store.query({ trailId: 'users.list' });
+
+      expect(results).toHaveLength(2);
+      expect(results.every((r) => r.trailId === 'users.list')).toBe(true);
+    });
+
+    test('filters by traceId', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      store.write(makeRecord({ id: 'a', traceId: 'trace-abc' }));
+      store.write(makeRecord({ id: 'b', traceId: 'trace-xyz' }));
+
+      const results = store.query({ traceId: 'trace-abc' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.traceId).toBe('trace-abc');
+    });
+
+    test('filters by errorsOnly', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      store.write(makeRecord({ id: 'ok-1', status: 'ok' }));
+      store.write(
+        makeRecord({
+          errorCategory: 'NotFoundError',
+          id: 'err-1',
+          status: 'err',
+        })
+      );
+      store.write(makeRecord({ id: 'ok-2', status: 'ok' }));
+
+      const results = store.query({ errorsOnly: true });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.status).toBe('err');
+    });
+
+    test('limits results', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      for (let i = 0; i < 10; i += 1) {
+        store.write(makeRecord({ id: `rec-${String(i)}` }));
+      }
+
+      const results = store.query({ limit: 5 });
+
+      expect(results).toHaveLength(5);
+    });
+  });
+
+  describe('retention', () => {
+    test('enforces maxRecords by pruning oldest entries', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({
+        maxRecords: 5,
+        path: join(dir, 'tracks.db'),
+      });
+
+      for (let i = 0; i < 8; i += 1) {
+        store.write(
+          makeRecord({ id: `rec-${String(i)}`, startedAt: 1000 + i })
+        );
+      }
+
+      const results = store.query();
+
+      expect(results.length).toBeLessThanOrEqual(5);
+    });
+
+    test('prunes records older than maxAge', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({
+        maxAge: 1000,
+        path: join(dir, 'tracks.db'),
+      });
+
+      store.write(makeRecord({ id: 'old', startedAt: Date.now() - 5000 }));
+      store.write(makeRecord({ id: 'fresh', startedAt: Date.now() }));
+
+      const results = store.query();
+      expect(results).toHaveLength(1);
+      expect(results[0]?.id).toBe('fresh');
+    });
+  });
+
+  describe('count()', () => {
+    test('returns the number of retained records', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({
+        maxRecords: 2,
+        path: join(dir, 'tracks.db'),
+      });
+
+      store.write(makeRecord({ id: 'a', startedAt: 1000 }));
+      store.write(makeRecord({ id: 'b', startedAt: 2000 }));
+      store.write(makeRecord({ id: 'c', startedAt: 3000 }));
+
+      expect(store.count()).toBe(2);
+      expect(store.query()).toHaveLength(2);
+    });
+  });
+});

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -23,3 +23,9 @@ export {
   type TracksApiWithState,
 } from './tracks-api.js';
 export { tracks } from './tracks-accessor.js';
+export {
+  createDevStore,
+  type DevStore,
+  type DevStoreOptions,
+  type DevStoreQueryOptions,
+} from './stores/dev.js';

--- a/packages/tracks/src/stores/dev.ts
+++ b/packages/tracks/src/stores/dev.ts
@@ -1,0 +1,316 @@
+import { Database } from 'bun:sqlite';
+import type { SQLQueryBindings } from 'bun:sqlite';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import type { TrackRecord } from '../record.js';
+import type { TrackSink } from '../tracks-layer.js';
+
+/** Configuration for the SQLite dev store. */
+export interface DevStoreOptions {
+  /** Path to the SQLite database file. Defaults to `.trails/dev/tracks.db`. */
+  readonly path?: string;
+  /** Maximum number of records to retain. Defaults to 10000. */
+  readonly maxRecords?: number;
+  /** Maximum age of records in milliseconds. Defaults to 7 days. */
+  readonly maxAge?: number;
+}
+
+/** Query options for filtering stored track records. */
+export interface DevStoreQueryOptions {
+  readonly trailId?: string;
+  readonly traceId?: string;
+  readonly errorsOnly?: boolean;
+  readonly limit?: number;
+}
+
+/** SQLite-backed dev store for persisting and querying track records. */
+export interface DevStore extends TrackSink {
+  /** Query recent traces with optional filters. */
+  readonly query: (options?: DevStoreQueryOptions) => readonly TrackRecord[];
+  /** Return the total number of stored records. */
+  readonly count: () => number;
+  /** Close the database connection. */
+  readonly close: () => void;
+}
+
+/** SQL for creating the tracks table. */
+const CREATE_TABLE_SQL = `CREATE TABLE IF NOT EXISTS tracks (
+  id TEXT PRIMARY KEY,
+  trace_id TEXT NOT NULL,
+  root_id TEXT NOT NULL,
+  parent_id TEXT,
+  kind TEXT NOT NULL,
+  name TEXT NOT NULL,
+  trail_id TEXT,
+  surface TEXT,
+  intent TEXT,
+  started_at INTEGER NOT NULL,
+  ended_at INTEGER,
+  status TEXT NOT NULL,
+  error_category TEXT,
+  permit_id TEXT,
+  permit_tenant_id TEXT,
+  attrs TEXT
+)`;
+
+/** Index for common query patterns. */
+const CREATE_INDEXES_SQL = [
+  'CREATE INDEX IF NOT EXISTS idx_tracks_trail_id ON tracks(trail_id)',
+  'CREATE INDEX IF NOT EXISTS idx_tracks_trace_id ON tracks(trace_id)',
+  'CREATE INDEX IF NOT EXISTS idx_tracks_status ON tracks(status)',
+  'CREATE INDEX IF NOT EXISTS idx_tracks_started_at ON tracks(started_at)',
+];
+
+/** Shape of a row returned from the tracks table. */
+interface TrackRow {
+  readonly id: string;
+  readonly trace_id: string;
+  readonly root_id: string;
+  readonly parent_id: string | null;
+  readonly kind: string;
+  readonly name: string;
+  readonly trail_id: string | null;
+  readonly surface: string | null;
+  readonly intent: string | null;
+  readonly started_at: number;
+  readonly ended_at: number | null;
+  readonly status: string;
+  readonly error_category: string | null;
+  readonly permit_id: string | null;
+  readonly permit_tenant_id: string | null;
+  readonly attrs: string | null;
+}
+
+/** Reconstruct the permit object from decomposed columns. */
+const buildPermit = (
+  permitId: string | null,
+  tenantId: string | null
+): TrackRecord['permit'] => {
+  if (permitId === null) {
+    return undefined;
+  }
+  return tenantId === null ? { id: permitId } : { id: permitId, tenantId };
+};
+
+/** Parse attrs JSON back into a record. */
+const parseAttrs = (raw: string | null): Readonly<Record<string, unknown>> =>
+  raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+
+/** Reconstruct a TrackRecord from a database row. */
+const rowToRecord = (row: TrackRow): TrackRecord => ({
+  attrs: parseAttrs(row.attrs),
+  endedAt: row.ended_at ?? undefined,
+  errorCategory: row.error_category ?? undefined,
+  id: row.id,
+  intent: (row.intent ?? undefined) as TrackRecord['intent'],
+  kind: row.kind as TrackRecord['kind'],
+  name: row.name,
+  parentId: row.parent_id ?? undefined,
+  permit: buildPermit(row.permit_id, row.permit_tenant_id),
+  rootId: row.root_id,
+  startedAt: row.started_at,
+  status: row.status as TrackRecord['status'],
+  surface: (row.surface ?? undefined) as TrackRecord['surface'],
+  traceId: row.trace_id,
+  trailId: row.trail_id ?? undefined,
+});
+
+/** Initialize the database with pragmas, table, and indexes. */
+const initializeDb = (db: Database): void => {
+  db.run('PRAGMA journal_mode = WAL');
+  db.run('PRAGMA synchronous = NORMAL');
+  db.run(CREATE_TABLE_SQL);
+  for (const sql of CREATE_INDEXES_SQL) {
+    db.run(sql);
+  }
+};
+
+/** Ensure the parent directory for the database file exists. */
+const ensureDir = (path: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+};
+
+/** Prune records exceeding the retention limit. */
+const pruneByCount = (db: Database, maxRecords: number): void => {
+  const countResult = db
+    .query<{ count: number }, []>('SELECT COUNT(*) as count FROM tracks')
+    .get();
+  const count = countResult?.count ?? 0;
+
+  if (count <= maxRecords) {
+    return;
+  }
+
+  const excess = count - maxRecords;
+  db.run(
+    `DELETE FROM tracks WHERE id IN (
+      SELECT id FROM tracks ORDER BY started_at ASC LIMIT ?
+    )`,
+    [excess]
+  );
+};
+
+/** Prune records older than maxAge milliseconds. */
+const pruneByAge = (db: Database, maxAge: number): void => {
+  const threshold = Date.now() - maxAge;
+  db.run('DELETE FROM tracks WHERE started_at < ?', [threshold]);
+};
+
+/** Filter definition: column condition and optional bound value. */
+interface QueryFilter {
+  readonly condition: string;
+  readonly value?: SQLQueryBindings;
+}
+
+/** Derive active filters from query options. */
+const deriveFilters = (
+  options?: DevStoreQueryOptions
+): readonly QueryFilter[] => {
+  const filters: QueryFilter[] = [];
+
+  if (options?.trailId !== undefined) {
+    filters.push({ condition: 'trail_id = ?', value: options.trailId });
+  }
+  if (options?.traceId !== undefined) {
+    filters.push({ condition: 'trace_id = ?', value: options.traceId });
+  }
+  if (options?.errorsOnly === true) {
+    filters.push({ condition: "status = 'err'" });
+  }
+
+  return filters;
+};
+
+/** Build a parameterized SELECT query from query options. */
+const buildQuery = (
+  defaultLimit: number,
+  options?: DevStoreQueryOptions
+): { readonly sql: string; readonly params: SQLQueryBindings[] } => {
+  const filters = deriveFilters(options);
+  const where =
+    filters.length > 0
+      ? `WHERE ${filters.map((f) => f.condition).join(' AND ')}`
+      : '';
+  const params: SQLQueryBindings[] = [
+    ...filters.flatMap((f) => (f.value === undefined ? [] : [f.value])),
+    options?.limit ?? defaultLimit,
+  ];
+
+  return {
+    params,
+    sql: `SELECT * FROM tracks ${where} ORDER BY started_at DESC LIMIT ?`,
+  };
+};
+
+/** Serialize attrs to JSON, returning null for empty objects. */
+const serializeAttrs = (
+  attrs: Readonly<Record<string, unknown>>
+): string | null =>
+  Object.keys(attrs).length > 0 ? JSON.stringify(attrs) : null;
+
+/** Serialize a TrackRecord into positional INSERT parameters. */
+const recordToParams = (record: TrackRecord): SQLQueryBindings[] => [
+  record.id,
+  record.traceId,
+  record.rootId,
+  record.parentId ?? null,
+  record.kind,
+  record.name,
+  record.trailId ?? null,
+  record.surface ?? null,
+  record.intent ?? null,
+  record.startedAt,
+  record.endedAt ?? null,
+  record.status,
+  record.errorCategory ?? null,
+  record.permit?.id ?? null,
+  record.permit?.tenantId ?? null,
+  serializeAttrs(record.attrs),
+];
+
+/** SQL for inserting a track record. */
+const UPSERT_SQL = `INSERT INTO tracks (
+  id, trace_id, root_id, parent_id,
+  kind, name, trail_id, surface,
+  intent, started_at, ended_at, status,
+  error_category, permit_id, permit_tenant_id, attrs
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  trace_id = excluded.trace_id,
+  root_id = excluded.root_id,
+  parent_id = excluded.parent_id,
+  kind = excluded.kind,
+  name = excluded.name,
+  trail_id = excluded.trail_id,
+  surface = excluded.surface,
+  intent = excluded.intent,
+  started_at = excluded.started_at,
+  ended_at = excluded.ended_at,
+  status = excluded.status,
+  error_category = excluded.error_category,
+  permit_id = excluded.permit_id,
+  permit_tenant_id = excluded.permit_tenant_id,
+  attrs = excluded.attrs`;
+
+/** Open and initialize the database at the given path. */
+const openDb = (dbPath: string): Database => {
+  ensureDir(dbPath);
+  const db = new Database(dbPath, { create: true });
+  initializeDb(db);
+  return db;
+};
+
+/** Count stored track records. */
+const countRecords = (db: Database): number => {
+  const result = db
+    .query<{ count: number }, []>('SELECT COUNT(*) as count FROM tracks')
+    .get();
+  return result?.count ?? 0;
+};
+
+/** Create a transactional writer that keeps retention pruning atomic. */
+const createWriter = (
+  db: Database,
+  insertStmt: ReturnType<Database['prepare']>,
+  maxRecords: number,
+  maxAge: number | undefined
+): ((record: TrackRecord) => void) =>
+  db.transaction((record: TrackRecord) => {
+    insertStmt.run(...recordToParams(record));
+    pruneByCount(db, maxRecords);
+    if (maxAge !== undefined) {
+      pruneByAge(db, maxAge);
+    }
+  });
+
+/**
+ * Create a SQLite-backed dev store for persisting track records.
+ *
+ * Uses WAL mode and normal synchronous for good write performance.
+ * Automatically prunes records exceeding `maxRecords` on each write.
+ */
+export const createDevStore = (options?: DevStoreOptions): DevStore => {
+  const dbPath = options?.path ?? '.trails/dev/tracks.db';
+  const maxRecords = options?.maxRecords ?? 10_000;
+  const maxAge = options?.maxAge;
+  const db = openDb(dbPath);
+  const insertStmt = db.prepare(UPSERT_SQL);
+  const write = createWriter(db, insertStmt, maxRecords, maxAge);
+
+  const query = (
+    queryOptions?: DevStoreQueryOptions
+  ): readonly TrackRecord[] => {
+    const { sql, params } = buildQuery(maxRecords, queryOptions);
+    const rows = db.query<TrackRow, SQLQueryBindings[]>(sql).all(...params);
+    return rows.map(rowToRecord);
+  };
+
+  const count = (): number => countRecords(db);
+
+  const close = (): void => {
+    db.close();
+  };
+
+  return { close, count, query, write };
+};


### PR DESCRIPTION
## Summary

- SQLite-backed TrackSink at `.trails/dev/tracks.db` using `bun:sqlite`
- WAL mode for concurrent reads, indexes on trail_id/trace_id/status/started_at
- `query()` with filters: trailId, traceId, errorsOnly, limit
- `count()` method for efficient record counting
- Automatic retention pruning: `maxRecords` (count-based) + `maxAge` (time-based)
- Attrs serialized as JSON, permit decomposed to columns

## Test plan

- [ ] 11 tests covering lifecycle, write, query filters, retention
- [ ] Uses temp directories for test isolation
- [ ] `bun test` passes in `packages/tracks/`

Closes https://linear.app/outfitter/issue/TRL-109/dev-store-bunsqlite-and-trails-tracks-cli-command

In-collaboration-with: [Claude Code](https://claude.com/claude-code)