### PR TITLE
feat(tracks): add OTel adapter for span export [TRL-110]

### DIFF
--- a/packages/tracks/src/__tests__/otel-adapter.test.ts
+++ b/packages/tracks/src/__tests__/otel-adapter.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { TrackRecord } from '../record.js';
+import { createOtelAdapter } from '../adapters/otel.js';
+import type { OtelSpan } from '../adapters/otel.js';
+
+/** Build a minimal TrackRecord for testing with sensible defaults. */
+const makeRecord = (overrides: Partial<TrackRecord> = {}): TrackRecord => ({
+  attrs: {},
+  endedAt: 1000,
+  id: 'span-1',
+  kind: 'trail',
+  name: 'test.echo',
+  rootId: 'root-1',
+  startedAt: 0,
+  status: 'ok',
+  traceId: 'trace-1',
+  ...overrides,
+});
+
+describe('otelAdapter', () => {
+  describe('attribute mapping', () => {
+    test('maps trailId to attributes["trails.trail.id"]', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ trailId: 'greet' }));
+
+      expect(spans).toHaveLength(1);
+      expect(spans[0]?.attributes['trails.trail.id']).toBe('greet');
+    });
+
+    test('maps intent to attributes["trails.intent"]', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ intent: 'write' }));
+
+      expect(spans[0]?.attributes['trails.intent']).toBe('write');
+    });
+
+    test('maps surface to attributes["trails.surface"]', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ surface: 'mcp' }));
+
+      expect(spans[0]?.attributes['trails.surface']).toBe('mcp');
+    });
+
+    test('maps permit.id to attributes["trails.permit.id"]', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({ permit: { id: 'p-1', tenantId: 't-1' } })
+      );
+
+      expect(spans[0]?.attributes['trails.permit.id']).toBe('p-1');
+      expect(spans[0]?.attributes['trails.permit.tenant_id']).toBe('t-1');
+    });
+
+    test('omits undefined attributes', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({
+          intent: undefined,
+          surface: undefined,
+          trailId: undefined,
+        })
+      );
+
+      expect(spans).toHaveLength(1);
+      const keys = Object.keys(spans[0].attributes);
+      expect(keys).not.toContain('trails.trail.id');
+      expect(keys).not.toContain('trails.intent');
+      expect(keys).not.toContain('trails.surface');
+    });
+
+    test('forwards OTel-safe custom attributes', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({
+          attrs: {
+            'db.operation': 'select',
+            'http.status_code': 200,
+            sampled: true,
+            skipped: { nested: true },
+          },
+        })
+      );
+
+      expect(spans[0]?.attributes['db.operation']).toBe('select');
+      expect(spans[0]?.attributes['http.status_code']).toBe(200);
+      expect(spans[0]?.attributes.sampled).toBe(true);
+      expect(spans[0]?.attributes.skipped).toBeUndefined();
+    });
+  });
+
+  describe('status mapping', () => {
+    test('maps status "ok" to OTel "OK"', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ status: 'ok' }));
+
+      expect(spans[0]?.status).toBe('OK');
+    });
+
+    test('maps status "err" to OTel "ERROR"', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ status: 'err' }));
+
+      expect(spans[0]?.status).toBe('ERROR');
+    });
+
+    test('maps status "cancelled" to OTel "UNSET"', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ status: 'cancelled' }));
+
+      expect(spans[0]?.status).toBe('UNSET');
+    });
+  });
+
+  describe('kind mapping', () => {
+    test('root trail (no parentId) gets kind "SERVER"', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ parentId: undefined }));
+
+      expect(spans[0]?.kind).toBe('SERVER');
+    });
+
+    test('child trail (has parentId) gets kind "INTERNAL"', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ parentId: 'parent-1' }));
+
+      expect(spans[0]?.kind).toBe('INTERNAL');
+    });
+  });
+
+  describe('exporter integration', () => {
+    test('calls exporter with translated spans', async () => {
+      let exportedSpans: readonly OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          exportedSpans = s;
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-42', traceId: 'trace-42' }));
+
+      expect(exportedSpans).toHaveLength(1);
+      expect(exportedSpans[0]?.spanId).toBe('span-42');
+      expect(exportedSpans[0]?.traceId).toBe('trace-42');
+    });
+  });
+
+  describe('flush', () => {
+    test('sends buffered spans that have not yet reached batchSize', async () => {
+      const exported: OtelSpan[][] = [];
+      const adapter = createOtelAdapter({
+        batchSize: 5,
+        exporter: (s) => {
+          exported.push([...s]);
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await adapter.write(makeRecord({ id: 'span-b' }));
+
+      // Not yet exported because batchSize is 5
+      expect(exported).toHaveLength(0);
+
+      await adapter.flush();
+
+      expect(exported).toHaveLength(1);
+      expect(exported[0]).toHaveLength(2);
+      expect(exported[0]?.[0]?.spanId).toBe('span-a');
+      expect(exported[0]?.[1]?.spanId).toBe('span-b');
+    });
+
+    test('auto-flushes when batchSize is reached', async () => {
+      const exported: OtelSpan[][] = [];
+      const adapter = createOtelAdapter({
+        batchSize: 3,
+        exporter: (s) => {
+          exported.push([...s]);
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await adapter.write(makeRecord({ id: 'span-b' }));
+
+      // Two writes — still buffered
+      expect(exported).toHaveLength(0);
+
+      await adapter.write(makeRecord({ id: 'span-c' }));
+
+      // Third write reaches batchSize=3, exporter must have been called
+      expect(exported).toHaveLength(1);
+      expect(exported[0]).toHaveLength(3);
+    });
+
+    test('rethrows exporter failures and restores the buffer', async () => {
+      let shouldFail = true;
+      const exported: OtelSpan[][] = [];
+      const adapter = createOtelAdapter({
+        batchSize: 2,
+        exporter: (s) => {
+          // eslint-disable-next-line jest/no-conditional-in-test -- testing retry behavior requires toggling exporter success
+          const fail = shouldFail;
+          shouldFail = false;
+          // eslint-disable-next-line jest/no-conditional-in-test
+          if (fail) {
+            throw new Error('exporter down');
+          }
+          exported.push([...s]);
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await expect(adapter.write(makeRecord({ id: 'span-b' }))).rejects.toThrow(
+        'exporter down'
+      );
+
+      // First flush failed — spans should still be buffered
+      expect(exported).toHaveLength(0);
+
+      // Manual flush retries and succeeds
+      await adapter.flush();
+      expect(exported).toHaveLength(1);
+      expect(exported[0]).toHaveLength(2);
+    });
+
+    test('is a no-op when buffer is empty', async () => {
+      let called = false;
+      const adapter = createOtelAdapter({
+        exporter: () => {
+          called = true;
+        },
+      });
+
+      await adapter.flush();
+
+      expect(called).toBe(false);
+    });
+  });
+});

--- a/packages/tracks/src/adapters/otel.ts
+++ b/packages/tracks/src/adapters/otel.ts
@@ -1,0 +1,128 @@
+import type { TrackRecord } from '../record.js';
+import type { TrackSink } from '../tracks-layer.js';
+
+/** OTel span representation produced by the adapter. */
+export interface OtelSpan {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly parentSpanId?: string | undefined;
+  readonly operationName: string;
+  readonly startTime: number;
+  readonly endTime?: number | undefined;
+  readonly status: 'OK' | 'ERROR' | 'UNSET';
+  readonly kind: 'INTERNAL' | 'SERVER';
+  readonly attributes: Readonly<Record<string, string | number | boolean>>;
+}
+
+/** Callback that receives translated OTel spans. */
+export type OtelExporter = (spans: readonly OtelSpan[]) => void | Promise<void>;
+
+/** Configuration for the OTel adapter. */
+export interface OtelAdapterOptions {
+  readonly exporter: OtelExporter;
+  readonly batchSize?: number;
+}
+
+/** Map from TrackRecord status to OTel status. */
+const STATUS_MAP: Record<TrackRecord['status'], OtelSpan['status']> = {
+  cancelled: 'UNSET',
+  err: 'ERROR',
+  ok: 'OK',
+};
+
+/** Derive OTel span kind from parentId presence. */
+const deriveKind = (parentId: string | undefined): OtelSpan['kind'] =>
+  parentId === undefined ? 'SERVER' : 'INTERNAL';
+
+/** Attribute mapping: record field → OTel attribute key + extractor. */
+const ATTR_MAP: readonly {
+  key: string;
+  get: (r: TrackRecord) => string | undefined;
+}[] = [
+  { get: (r) => r.trailId, key: 'trails.trail.id' },
+  { get: (r) => r.intent, key: 'trails.intent' },
+  { get: (r) => r.surface, key: 'trails.surface' },
+  { get: (r) => r.permit?.id, key: 'trails.permit.id' },
+  { get: (r) => r.permit?.tenantId, key: 'trails.permit.tenant_id' },
+];
+
+/** Build the trails-namespaced attributes from a TrackRecord. */
+const buildAttributes = (
+  record: TrackRecord
+): Record<string, string | number | boolean> => {
+  const attrs: Record<string, string | number | boolean> = {};
+  for (const { key, get } of ATTR_MAP) {
+    const val = get(record);
+    if (val !== undefined) {
+      attrs[key] = val;
+    }
+  }
+  for (const [key, val] of Object.entries(record.attrs)) {
+    if (
+      typeof val === 'string' ||
+      typeof val === 'number' ||
+      typeof val === 'boolean'
+    ) {
+      attrs[key] = val;
+    }
+  }
+  return attrs;
+};
+
+/** Translate a TrackRecord into an OTel span. */
+const toOtelSpan = (record: TrackRecord): OtelSpan => ({
+  attributes: buildAttributes(record),
+  endTime: record.endedAt,
+  kind: deriveKind(record.parentId),
+  operationName: record.name,
+  parentSpanId: record.parentId,
+  spanId: record.id,
+  startTime: record.startedAt,
+  status: STATUS_MAP[record.status],
+  traceId: record.traceId,
+});
+
+/** A TrackSink extended with an explicit flush for shutdown. */
+export interface OtelSink extends TrackSink {
+  /** Flush any remaining buffered spans to the exporter. */
+  readonly flush: () => Promise<void>;
+}
+
+/**
+ * Create a TrackSink that translates TrackRecords to OTel spans.
+ *
+ * The adapter maps Trails-native fields to OpenTelemetry span attributes
+ * under a `trails.*` namespace. Pass any OTel-compatible exporter callback
+ * to forward spans to your collector.
+ *
+ * Translates and exports spans on each write. Call `flush()` on shutdown
+ * to send any remaining buffered spans.
+ */
+export const createOtelAdapter = (options: OtelAdapterOptions): OtelSink => {
+  const batchSize = options.batchSize ?? 1;
+  const buffer: OtelSpan[] = [];
+
+  const flush = async (): Promise<void> => {
+    if (buffer.length === 0) {
+      return;
+    }
+    const batch = buffer.splice(0);
+    try {
+      await options.exporter(batch);
+    } catch (error) {
+      // Restore batch on exporter failure so data is not lost
+      buffer.unshift(...batch);
+      throw error;
+    }
+  };
+
+  return {
+    flush,
+    write: async (record: TrackRecord): Promise<void> => {
+      buffer.push(toOtelSpan(record));
+      if (buffer.length >= batchSize) {
+        await flush();
+      }
+    },
+  };
+};


### PR DESCRIPTION
## Summary

- **OtelSink** extending TrackSink with `flush()` for graceful shutdown
- Translates TrackRecords to OTel spans under `trails.*` namespace:
  - `trails.trail.id`, `trails.intent`, `trails.surface`, `trails.permit.id`, `trails.permit.tenant_id`
  - Root trails → `SERVER` kind, children → `INTERNAL`
  - Status: ok → OK, err → ERROR, cancelled → UNSET
- Undefined fields omitted from attributes (no string leaks)
- Batching support via `batchSize` option (default 1)

## Test plan

- [ ] 12 tests covering attribute mapping, status, kind, exporter calls, undefined omission, flush behavior
- [ ] `bun test` passes in `packages/tracks/`

Closes https://linear.app/outfitter/issue/TRL-110/otel-adapter-ontrailstracksotel-subpath-export

In-collaboration-with: [Claude Code](https://claude.com/claude-code)