### PR TITLE
docs: update documentation for config, permits, and tracks [TRL-127]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -162,6 +162,14 @@
         "zod": "catalog:",
       },
     },
+    "packages/tracks": {
+      "name": "@ontrails/tracks",
+      "version": "1.0.0-beta.11",
+      "peerDependencies": {
+        "@ontrails/core": "workspace:^",
+        "zod": "catalog:",
+      },
+    },
     "packages/warden": {
       "name": "@ontrails/warden",
       "version": "1.0.0-beta.11",
@@ -268,6 +276,8 @@
     "@ontrails/schema": ["@ontrails/schema@workspace:packages/schema"],
 
     "@ontrails/testing": ["@ontrails/testing@workspace:packages/testing"],
+
+    "@ontrails/tracks": ["@ontrails/tracks@workspace:packages/tracks"],
 
     "@ontrails/trails": ["@ontrails/trails@workspace:apps/trails"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -135,6 +135,14 @@
         "zod": "catalog:",
       },
     },
+    "packages/permits": {
+      "name": "@ontrails/permits",
+      "version": "1.0.0-beta.11",
+      "peerDependencies": {
+        "@ontrails/core": "workspace:^",
+        "zod": "catalog:",
+      },
+    },
     "packages/schema": {
       "name": "@ontrails/schema",
       "version": "1.0.0-beta.11",
@@ -254,6 +262,8 @@
     "@ontrails/logging": ["@ontrails/logging@workspace:packages/logging"],
 
     "@ontrails/mcp": ["@ontrails/mcp@workspace:packages/mcp"],
+
+    "@ontrails/permits": ["@ontrails/permits@workspace:packages/permits"],
 
     "@ontrails/schema": ["@ontrails/schema@workspace:packages/schema"],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,16 +27,16 @@ Trails uses a hexagonal architecture. Core defines ports. Everything on the edge
                 +---------+-------------+
                           |
                 +---------v-------------+
+                |  Config (config)      |
+                |  Permits (permits)    |
+                |  Tracks (tracks)      |
                 |  Logging (logtape)    |
-                |  Storage (planned)    |
-                |  Telemetry (planned)  |
-                |  Search (planned)     |
                 +-----------------------+
                 RIGHT SIDE (outbound)
                 How the framework calls out
 ```
 
-The left side is where the world calls in -- CLI commands, MCP tool calls, HTTP requests. The right side is where the framework calls out -- logging, storage, telemetry. Core sits in the middle and defines the contracts for both sides.
+The left side is where the world calls in -- CLI commands, MCP tool calls, HTTP requests. The right side is where the framework calls out -- config, auth permits, telemetry tracks, and logging. Core sits in the middle and defines the contracts for both sides.
 
 ## Core Principles
 
@@ -106,9 +106,9 @@ These are derived from the implementation code itself. Useful for governance and
 
 Warden uses inference to verify that declarations match actual code. The surface map captures inferred information for CI governance.
 
-### Observed — learned from runtime (future)
+### Observed — learned from runtime
 
-The tracks (telemetry) system will capture what actually happens in production: error distributions, latency profiles, service usage patterns. Observations close the loop — declarations define intent, observations verify reality.
+The tracks (`@ontrails/tracks`) system captures what actually happens at runtime: execution duration, error distributions, trace context propagation. Observations close the loop -- declarations define intent, observations verify reality.
 
 ### Overridden — when derivation doesn't fit
 
@@ -148,6 +148,9 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 
 | Package | What it does | External dep |
 | --- | --- | --- |
+| `@ontrails/config` | Config resolution, loadouts, service config schemas, diagnostics | None beyond core |
+| `@ontrails/permits` | Auth layer, permit model, JWT adapter, scope enforcement | None beyond core |
+| `@ontrails/tracks` | Telemetry recording, trace context, memory/OTel sinks | None beyond core |
 | `@ontrails/logging` | Structured logging, sinks, formatters | None beyond core |
 | `@ontrails/logging/logtape` | LogTape sink adapter | `@logtape/logtape` (optional peer) |
 
@@ -174,6 +177,9 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 @ontrails/cli (core)
 @ontrails/mcp (core, @modelcontextprotocol/sdk)
 @ontrails/http (core, hono)
+@ontrails/config (core)
+@ontrails/permits (core)
+@ontrails/tracks (core)
 @ontrails/logging (core)
 @ontrails/testing (core, cli, mcp, logging)
 @ontrails/schema (core)

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -10,9 +10,11 @@
 
 **Services (`service()` and trail `services: [...]`).** Trails now declare infrastructure dependencies explicitly. `executeTrail()` resolves app-scoped singletons before layers and implementations run. Testing can auto-resolve `mock` factories, and survey / schema tooling exposes the full service graph.
 
-## Near-term (v1.1–v1.2)
+**Config resolution (`@ontrails/config`).** `defineConfig()` provides schema-validated config with loadouts (named environment profiles), env variable mapping, and `ServiceSpec.config` for service-level config schemas. Includes diagnostics (`checkConfig`), introspection (`describeConfig`, `explainConfig`), and generation (`generateEnvExample`).
 
-**Auth and permit model.** The `permit` field on TrailContext gets a full design: scopes, roles, per-surface resolution (bearer tokens for HTTP, session tokens for MCP, local keyring for CLI). Scope enforcement as a layer. Resource-level auth stays in the implementation — the framework provides identity, the app provides policy.
+**Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. `authLayer` extracts credentials from surface-specific sources, `AuthAdapter` resolves them to a `Permit` (identity, scopes, roles), and scope enforcement rejects unauthorized access. Includes JWT adapter, governance rules (`validatePermits`), and test helpers (`mintTestPermit`, `mintPermitForTrail`).
+
+**Tracks (`@ontrails/tracks`).** Telemetry recording with `createTracksLayer` capturing execution duration, errors, and trace context propagation for every trail invocation. Pluggable sinks: `createMemorySink` for testing, `createDevStore` for local development, `createOtelAdapter` for production OpenTelemetry export. Sampling configuration controls recording volume.
 
 ## Mid-term (v1.3+)
 
@@ -28,7 +30,7 @@
 
 **Progressive contract tightening.** A new trail starts loose — minimal schema, no examples. As it matures, the contract tightens: output schema added, examples written, error types specified. The framework tracks progression and suggests next steps.
 
-**Behavioral types from runtime observation.** The tracks (telemetry) system records what actually happens. Over time, runtime data validates or challenges authored declarations. A trail declared `intent: 'read'` that triggers database writes has a contract violation. The framework surfaces the discrepancy.
+**Behavioral types from runtime observation.** The tracks system already records execution data. Over time, runtime data validates or challenges authored declarations. A trail declared `intent: 'read'` that triggers database writes has a contract violation. The framework surfaces the discrepancy.
 
 **SDK generation via guide.** Typed TypeScript clients generated from the topo. Each trail becomes a method with typed input/output. Working over HTTP or WebSocket.
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -30,6 +30,24 @@ The type of the service instance is inferred from the `create` factory return. N
 
 The `create` factory receives `ServiceContext` -- a narrow subset of `TrailContext` -- because services are singletons resolved once per process. Request-scoped fields like `requestId` would be stale after the first resolution.
 
+## Service Config Schemas
+
+Services can declare a `config` field with a Zod schema. When present, the framework validates the service's config slice during resolution and passes the typed result to the `create` factory via `svc.config`:
+
+```typescript
+import { service, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+const db = service('db.main', {
+  config: z.object({ poolSize: z.number(), url: z.string().url() }),
+  create: (svc) => Result.ok(openPool(svc.config.url, svc.config.poolSize)),
+  dispose: (pool) => pool.end(),
+  mock: () => createInMemoryDb(),
+});
+```
+
+The config values come from the resolved app config, keyed by service ID. `@ontrails/config` provides `collectServiceConfigs()` to gather all service config schemas from a topo, and `defineConfig()` to wire loadout-based resolution into the bootstrap pipeline. Services without a `config` schema receive `unknown` and ignore `svc.config`.
+
 ## Declaring Services on a Trail
 
 Add services to the trail spec with the `services` array:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -323,6 +323,32 @@ const result = await harness.callTool('myapp_entity_show', { name: 'Alpha' });
 expect(result.isError).toBe(false);
 ```
 
+## Testing with Infrastructure Services
+
+The config, permits, and tracks packages each provide test-friendly primitives that work with `testAll(app)` and `testExamples(app)` without external dependencies.
+
+**Config test loadout.** Use `defineConfig()` with a `test` loadout that uses safe defaults (port 0, debug enabled, in-memory stores). When the `TRAILS_ENV` environment variable is set to `test`, the test loadout is selected automatically during resolution. Services with `config` schemas receive the test loadout values through `svc.config`.
+
+**Synthetic permit minting.** `mintTestPermit()` creates a `Permit` with exactly the scopes you specify -- no admin privileges, no wildcards. `mintPermitForTrail()` reads a trail's `permit` declaration and mints a permit with exactly the declared scopes, so tests exercise the real authorization path without a running auth provider:
+
+```typescript
+import { mintTestPermit, mintPermitForTrail } from '@ontrails/permits';
+
+const permit = mintTestPermit({ scopes: ['entity:read'] });
+const trailPermit = mintPermitForTrail(showTrail);
+```
+
+**Tracks memory sink.** `createMemorySink()` captures all track records in memory for assertion. Pair it with `createTracksLayer()` to verify that trails emit the expected telemetry without configuring a real exporter:
+
+```typescript
+import { createMemorySink, createTracksLayer } from '@ontrails/tracks';
+
+const sink = createMemorySink();
+const layer = createTracksLayer(sink);
+// ...run trails with the layer...
+expect(sink.records).toHaveLength(1);
+```
+
 ## Recommended Test Structure
 
 ```text

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -152,19 +152,63 @@ const list = trail('entity.list', {
 
 Access services through `db.from(ctx)` for typed access or `ctx.service()` for dynamic lookup. The `mock` factory enables `testAll(app)` to run without real infrastructure.
 
+### `permit`
+
+The resolved identity and scopes from a successful authentication. Attached to `TrailContext` by the auth layer. Trails declare their permit requirements with the `permit` field on the trail spec.
+
+```typescript
+import { getPermit } from '@ontrails/permits';
+
+const admin = trail('admin.dashboard', {
+  permit: { scopes: ['admin:read'] },
+  input: z.object({}),
+  run: async (_input, ctx) => {
+    const permit = getPermit(ctx);
+    return Result.ok({ user: permit?.id });
+  },
+});
+```
+
+### `loadout`
+
+A named config profile for a deployment environment. Loadouts are declared in `defineConfig()` and selected via `TRAILS_ENV` or explicit option.
+
+```typescript
+import { defineConfig } from '@ontrails/config';
+
+const config = defineConfig({
+  schema: z.object({
+    port: z.number().default(3000),
+    debug: z.boolean().default(false),
+  }),
+  loadouts: {
+    production: { debug: false },
+    test: { debug: true, port: 0 },
+  },
+});
+```
+
+### `tracks`
+
+Telemetry recording and trace context propagation. The tracks layer captures execution duration, errors, and trace context for every trail invocation.
+
+```typescript
+import { createTracksLayer, createMemorySink } from '@ontrails/tracks';
+
+const sink = createMemorySink();
+const layer = createTracksLayer(sink);
+```
+
 ## Reserved Terms (designed, not yet shipped)
 
 These are reserved for planned features. The naming is directional and may evolve.
 
 | Term | Concept |
 | --- | --- |
-| `tracks` | Observability, telemetry, audit logs, execution history |
 | `traverse` | Graph traversal, execution planning |
-| `permit` | Auth and principal model. Who is allowed on which trails |
 | `mount` | One-directional cross-app connection (consume another app's trails) |
 | `junction` | Bidirectional peer connection between two Trails apps (future) |
 | `pack` | Distributable capability bundle (trails + services + events + metadata) |
-| `loadout` | Deployment/environment config profile |
 | `depot` | Pack registry and marketplace |
 
 ## Standard Terms (not branded)
@@ -203,18 +247,19 @@ When introducing Trails to someone new, introduce terms in this order:
 4. `metadata` -- annotate trails with metadata
 5. `detours` -- define fallback paths when a trail fails
 
-**Advanced (introspection and observability):**
+**Advanced (introspection, infrastructure, and observability):**
 
 1. `topo` -- the internal trail collection
 2. `survey` -- full introspection of the trail system (use `--brief` for quick discovery)
 3. `guide` -- runtime guidance
-4. `tracks` -- observability and telemetry
+4. `permit` -- auth and scopes
+5. `loadout` -- deployment/environment config profiles
+6. `tracks` -- telemetry and trace context
 
 **Ecosystem (multi-app and governance):**
 
-1. `permit` -- auth and scopes
-2. `mount` -- consume another app's trails
-3. `warden` -- governance and contract enforcement
+1. `mount` -- consume another app's trails
+2. `warden` -- governance and contract enforcement
 
 ## Writing Style
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -32,6 +32,8 @@ export interface ActionResultContext {
 
 /** Options for buildCliCommands. */
 export interface BuildCliCommandsOptions {
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  configValues?: Readonly<Record<string, Record<string, unknown>>> | undefined;
   createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -165,6 +167,7 @@ const createExecute =
     await applyPrompting(fields, mergedInput, options);
 
     const result = await executeTrail(t, mergedInput, {
+      configValues: options?.configValues,
       createContext: options?.createContext,
       ctx: withCliSurface(ctxOverrides),
       layers: options?.layers,

--- a/packages/core/src/__tests__/trail-permit.test.ts
+++ b/packages/core/src/__tests__/trail-permit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { Result } from '../result';
+import { trail } from '../trail';
+import type { PermitRequirement } from '../types';
+
+describe('PermitRequirement type', () => {
+  test('accepts a scopes object', () => {
+    const req: PermitRequirement = { scopes: ['user:write', 'user:read'] };
+    expect(req).toEqual({ scopes: ['user:write', 'user:read'] });
+  });
+
+  test('accepts public literal', () => {
+    const req: PermitRequirement = 'public';
+    expect(req).toBe('public');
+  });
+});
+
+describe('trail() with permit field', () => {
+  test('accepts permit with scopes', () => {
+    const t = trail('user.delete', {
+      input: z.object({ id: z.string() }),
+      intent: 'destroy',
+      permit: { scopes: ['user:write'] },
+      run: (input) => Result.ok({ deleted: input.id }),
+    });
+    expect(t.permit).toEqual({ scopes: ['user:write'] });
+  });
+
+  test('accepts permit: public', () => {
+    const t = trail('health.check', {
+      input: z.object({}),
+      intent: 'read',
+      permit: 'public',
+      run: () => Result.ok({ status: 'ok' }),
+    });
+    expect(t.permit).toBe('public');
+  });
+
+  test('permit is undefined when omitted (backward compatible)', () => {
+    const t = trail('legacy.trail', {
+      input: z.object({}),
+      run: () => Result.ok(),
+    });
+    expect(t.permit).toBeUndefined();
+  });
+
+  test('preserves permit on the frozen Trail object', () => {
+    const t = trail('user.list', {
+      input: z.object({}),
+      intent: 'read',
+      permit: { scopes: ['user:read'] },
+      run: () => Result.ok([]),
+    });
+    expect(Object.isFrozen(t)).toBe(true);
+    expect(t.permit).toEqual({ scopes: ['user:read'] });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export type {
   TrailContext,
   TrailContextInit,
   FollowFn,
+  PermitRequirement,
   ProgressCallback,
   ProgressEvent,
   Logger,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export type {
   TrailContext,
   TrailContextInit,
   FollowFn,
+  BasePermit,
   PermitRequirement,
   ProgressCallback,
   ProgressEvent,

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -3,7 +3,11 @@ import type { z } from 'zod';
 import type { FieldOverride } from './derive.js';
 import type { Result } from './result.js';
 import type { AnyService } from './service.js';
-import type { Implementation, TrailContext } from './types.js';
+import type {
+  Implementation,
+  PermitRequirement,
+  TrailContext,
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Trail example
@@ -59,6 +63,8 @@ export interface TrailSpec<I, O> {
   readonly follow?: readonly string[] | undefined;
   /** Services this trail may access via service.from(ctx) */
   readonly services?: readonly AnyService[] | undefined;
+  /** Auth requirement: scopes object, 'public', or omitted (undeclared) */
+  readonly permit?: PermitRequirement | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,6 +64,17 @@ export interface TrailContext {
   readonly service?: ServiceLookup | undefined;
 }
 
+/**
+ * Permit requirement declared on a trail spec.
+ *
+ * A scopes object means the trail requires a permit with those scopes.
+ * `'public'` means the trail has explicitly opted out of auth.
+ * Omitting the field entirely means the trail hasn't declared an auth posture.
+ */
+export type PermitRequirement =
+  | { readonly scopes: readonly string[] }
+  | 'public';
+
 /** Input shape used to seed a runtime TrailContext before resolution. */
 export type TrailContextInit = Omit<TrailContext, 'service'> & {
   readonly service?: ServiceLookup | undefined;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,12 +49,18 @@ export interface Logger {
 /** Context extension key for the invoking surface name. */
 export const SURFACE_KEY = '__trails_surface' as const;
 
+/** Minimal permit shape available on TrailContext. Permits extends this. */
+export interface BasePermit {
+  readonly id: string;
+  readonly scopes: readonly string[];
+}
+
 /** Runtime context threaded through every trail execution */
 export interface TrailContext {
   readonly requestId: string;
   readonly signal: AbortSignal;
   readonly follow?: FollowFn | undefined;
-  readonly permit?: unknown | undefined;
+  readonly permit?: BasePermit;
   readonly workspaceRoot?: string | undefined;
   readonly logger?: Logger | undefined;
   readonly progress?: ProgressCallback | undefined;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -55,6 +55,9 @@ export interface BasePermit {
   readonly scopes: readonly string[];
 }
 
+/** Context extension key for the invoking surface name. */
+export const SURFACE_KEY = '__trails_surface' as const;
+
 /** Runtime context threaded through every trail execution */
 export interface TrailContext {
   readonly requestId: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -55,9 +55,6 @@ export interface BasePermit {
   readonly scopes: readonly string[];
 }
 
-/** Context extension key for the invoking surface name. */
-export const SURFACE_KEY = '__trails_surface' as const;
-
 /** Runtime context threaded through every trail execution */
 export interface TrailContext {
   readonly requestId: string;

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -26,6 +26,10 @@ import type {
 
 export interface BuildHttpRoutesOptions {
   readonly basePath?: string | undefined;
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  readonly configValues?:
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -119,6 +123,7 @@ const createExecute =
   ): HttpRouteDefinition['execute'] =>
   (input, requestId, signal) =>
     executeTrail(t, input, {
+      configValues: options.configValues,
       createContext: options.createContext,
       ctx: withHttpSurface(requestId),
       layers,

--- a/packages/http/src/hono/blaze.ts
+++ b/packages/http/src/hono/blaze.ts
@@ -31,6 +31,10 @@ import { buildHttpRoutes } from '../build.js';
 
 export interface BlazeHttpOptions {
   readonly basePath?: string | undefined;
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  readonly configValues?:
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -324,6 +328,7 @@ export const blaze = async (
 
   const routesResult = buildHttpRoutes(app, {
     basePath: options.basePath,
+    configValues: options.configValues,
     createContext: options.createContext,
     layers: options.layers,
     services: options.services,

--- a/packages/mcp/src/blaze.ts
+++ b/packages/mcp/src/blaze.ts
@@ -31,6 +31,10 @@ import { connectStdio } from './stdio.js';
 // ---------------------------------------------------------------------------
 
 export interface BlazeMcpOptions {
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  readonly configValues?:
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -147,6 +151,7 @@ export const blaze = async (
   }
 
   const toolsResult = buildMcpTools(app, {
+    configValues: options.configValues,
     createContext: options.createContext,
     excludeTrails: options.excludeTrails,
     includeTrails: options.includeTrails,

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -33,6 +33,10 @@ import { deriveToolName } from './tool-name.js';
 // ---------------------------------------------------------------------------
 
 export interface BuildMcpToolsOptions {
+  /** Config values for services that declare a `config` schema, keyed by service ID. */
+  readonly configValues?:
+    | Readonly<Record<string, Record<string, unknown>>>
+    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -230,6 +234,7 @@ const createHandler =
   async (args, extra): Promise<McpToolResult> => {
     const progressCb = createMcpProgressCallback(extra);
     const result = await executeTrail(t, args, {
+      configValues: options.configValues,
       createContext: options.createContext,
       ctx: withMcpSurface(progressCb),
       layers,

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@ontrails/permits",
+  "version": "1.0.0-beta.11",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./jwt": "./src/adapters/jwt.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@ontrails/core": "workspace:^",
+    "zod": "catalog:"
+  }
+}

--- a/packages/permits/src/__tests__/adapter.test.ts
+++ b/packages/permits/src/__tests__/adapter.test.ts
@@ -128,6 +128,22 @@ describe('createJwtAdapter', () => {
     expect(err.code).toBe('invalid_token');
   });
 
+  test('rejects tokens with a missing subject claim', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, scope: 'read' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Missing subject claim');
+  });
+
   test('extracts scopes from token claims', async () => {
     const adapter = createJwtAdapter({
       scopesClaim: 'permissions',
@@ -249,6 +265,25 @@ describe('createJwtAdapter', () => {
     const now = Math.floor(Date.now() / 1000);
     const token = await signJwt(
       { exp: now + 3600, scope: ['read', 'write'], sub: 'user-arr-scope' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.scopes).toEqual(['read', 'write']);
+  });
+
+  test('filters empty strings from array-format scope claims', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      {
+        exp: now + 3600,
+        scope: ['', 'read', '', 'write'],
+        sub: 'user-arr-scope-empty',
+      },
       TEST_SECRET
     );
     const result = await adapter.authenticate(

--- a/packages/permits/src/__tests__/adapter.test.ts
+++ b/packages/permits/src/__tests__/adapter.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result } from '@ontrails/core';
+
+import type { AuthAdapter, AuthError } from '../adapter.js';
+import type { PermitExtractionInput } from '../extraction.js';
+import type { Permit } from '../permit.js';
+import { createJwtAdapter } from '../adapters/jwt.js';
+
+// ---------------------------------------------------------------------------
+// Test helper: sign a JWT with HMAC-SHA256 using crypto.subtle
+// ---------------------------------------------------------------------------
+
+const base64url = (buf: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCodePoint(b);
+  }
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '');
+};
+
+const base64urlEncode = (str: string): string => {
+  const encoder = new TextEncoder();
+  return base64url(encoder.encode(str).buffer as ArrayBuffer);
+};
+
+const signJwt = async (
+  payload: Record<string, unknown>,
+  secret: string
+): Promise<string> => {
+  const header = base64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64urlEncode(JSON.stringify(payload));
+  const data = `${header}.${body}`;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(data));
+  return `${data}.${base64url(sig)}`;
+};
+
+const TEST_SECRET = 'test-secret-for-hmac-256';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/** Minimal extraction input for tests that don't need all fields. */
+const testInput = (
+  overrides?: Partial<PermitExtractionInput>
+): PermitExtractionInput => ({
+  requestId: 'test-req',
+  surface: 'http',
+  ...overrides,
+});
+
+describe('AuthAdapter interface', () => {
+  test('accepts a valid adapter implementation', async () => {
+    const adapter: AuthAdapter = {
+      // oxlint-disable-next-line require-await -- stub adapter for type test
+      authenticate: async (_input: PermitExtractionInput) => Result.ok(null),
+    };
+    const result = await adapter.authenticate(testInput());
+    expect(result.isOk()).toBe(true);
+  });
+});
+
+/* oxlint-disable max-statements -- test suite with multiple concern groups */
+describe('createJwtAdapter', () => {
+  test('returns an AuthAdapter', () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    expect(adapter).toBeDefined();
+    expect(adapter.authenticate).toBeInstanceOf(Function);
+  });
+
+  test('verifies a valid HS256 token and returns a Permit', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, scope: 'read write', sub: 'user-123' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit).not.toBeNull();
+    expect(permit.id).toBe('user-123');
+    expect(permit.scopes).toEqual(['read', 'write']);
+  });
+
+  test('rejects an expired token', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signJwt(
+      { exp: past, sub: 'user-expired' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('expired_token');
+  });
+
+  test('rejects an invalid signature', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-bad-sig' },
+      'wrong-secret'
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('extracts scopes from token claims', async () => {
+    const adapter = createJwtAdapter({
+      scopesClaim: 'permissions',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      {
+        exp: now + 3600,
+        permissions: 'admin:read admin:write',
+        sub: 'user-scopes',
+      },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.scopes).toEqual(['admin:read', 'admin:write']);
+  });
+
+  test('extracts roles from token claims', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, roles: ['admin', 'editor'], sub: 'user-roles' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.roles).toEqual(['admin', 'editor']);
+  });
+
+  test('returns null for missing credentials', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const result = await adapter.authenticate(testInput());
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBeNull();
+  });
+
+  test('checks issuer claim when configured', async () => {
+    const adapter = createJwtAdapter({
+      issuer: 'https://auth.example.com',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, iss: 'https://evil.example.com', sub: 'user-iss' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('checks audience claim when configured', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { aud: 'other-api', exp: now + 3600, sub: 'user-aud' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('accepts array-format audience containing configured value', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { aud: ['my-api', 'account'], exp: now + 3600, sub: 'user-arr-aud' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.id).toBe('user-arr-aud');
+  });
+
+  test('rejects array-format audience not containing configured value', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { aud: ['other-api', 'account'], exp: now + 3600, sub: 'user-no-aud' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('extracts scopes from array-format claim', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, scope: ['read', 'write'], sub: 'user-arr-scope' },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.scopes).toEqual(['read', 'write']);
+  });
+
+  test('returns error for malformed signature bytes', async () => {
+    const adapter = createJwtAdapter({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-bad' },
+      TEST_SECRET
+    );
+    const parts = token.split('.');
+    const malformed = `${parts[0]}.${parts[1]}.!!!invalid-base64!!!`;
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: malformed })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+  });
+
+  test('accepts token with matching issuer and audience', async () => {
+    const adapter = createJwtAdapter({
+      audience: 'my-api',
+      issuer: 'https://auth.example.com',
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      {
+        aud: 'my-api',
+        exp: now + 3600,
+        iss: 'https://auth.example.com',
+        scope: 'read',
+        sub: 'user-valid',
+      },
+      TEST_SECRET
+    );
+    const result = await adapter.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.id).toBe('user-valid');
+  });
+});

--- a/packages/permits/src/__tests__/auth-layer.test.ts
+++ b/packages/permits/src/__tests__/auth-layer.test.ts
@@ -1,0 +1,130 @@
+/* oxlint-disable require-await -- layer wrappers satisfy async interfaces without awaiting */
+import { describe, expect, test } from 'bun:test';
+
+import { Result, trail } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { authLayer } from '../auth-layer';
+import { PermitError } from '../errors';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeCtx = (permit?: {
+  id: string;
+  scopes: readonly string[];
+}): TrailContext => ({
+  permit,
+  requestId: 'test-auth',
+  signal: AbortSignal.timeout(5000),
+});
+
+const okImpl = async () => Result.ok({ done: true });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('authLayer', () => {
+  test('has correct name and description', () => {
+    expect(authLayer.name).toBe('auth');
+    expect(authLayer.description).toBeDefined();
+  });
+
+  describe('pass-through cases', () => {
+    test('passes through when trail has no permit field', async () => {
+      const t = trail('test.nopermit', {
+        input: z.object({}),
+        output: z.object({ done: z.boolean() }),
+        run: okImpl,
+      });
+
+      const wrapped = authLayer.wrap(t, okImpl);
+      const result = await wrapped({}, makeCtx());
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+
+    test('passes through when trail permit is public', async () => {
+      const t = trail('test.public', {
+        input: z.object({}),
+        output: z.object({ done: z.boolean() }),
+        permit: 'public',
+        run: okImpl,
+      });
+
+      const wrapped = authLayer.wrap(t, okImpl);
+      const result = await wrapped({}, makeCtx());
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+  });
+
+  describe('scope enforcement', () => {
+    const scopedTrail = trail('test.scoped', {
+      input: z.object({}),
+      output: z.object({ done: z.boolean() }),
+      permit: { scopes: ['user:read'] },
+      run: okImpl,
+    });
+
+    test('passes when ctx.permit has matching scopes', async () => {
+      const wrapped = authLayer.wrap(scopedTrail, okImpl);
+      const result = await wrapped(
+        {},
+        makeCtx({ id: 'usr-1', scopes: ['user:read'] })
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+
+    test('returns error when ctx has no permit', async () => {
+      const wrapped = authLayer.wrap(scopedTrail, okImpl);
+      const result = await wrapped({}, makeCtx());
+
+      expect(result.isErr()).toBe(true);
+      const err = (result as unknown as { error: PermitError }).error;
+      expect(err).toBeInstanceOf(PermitError);
+      expect(err.message).toContain('No permit');
+    });
+
+    test('returns error when permit is missing required scopes', async () => {
+      const multiScopeTrail = trail('test.multi', {
+        input: z.object({}),
+        output: z.object({ done: z.boolean() }),
+        permit: { scopes: ['user:read', 'user:write'] },
+        run: okImpl,
+      });
+
+      const wrapped = authLayer.wrap(multiScopeTrail, okImpl);
+      const result = await wrapped(
+        {},
+        makeCtx({ id: 'usr-1', scopes: ['user:read'] })
+      );
+
+      expect(result.isErr()).toBe(true);
+      const err = (result as unknown as { error: PermitError }).error;
+      expect(err).toBeInstanceOf(PermitError);
+      expect(err.message).toContain('user:write');
+    });
+
+    test('passes when permit has superset of required scopes', async () => {
+      const wrapped = authLayer.wrap(scopedTrail, okImpl);
+      const result = await wrapped(
+        {},
+        makeCtx({
+          id: 'usr-1',
+          scopes: ['user:read', 'user:write', 'admin'],
+        })
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
+    });
+  });
+});

--- a/packages/permits/src/__tests__/auth-service.test.ts
+++ b/packages/permits/src/__tests__/auth-service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { ServiceContext } from '@ontrails/core';
+
+import type { AuthAdapter } from '../adapter.js';
+import { authService } from '../auth-service.js';
+import type { PermitExtractionInput } from '../extraction.js';
+
+/** Minimal extraction input for tests. */
+const testInput = (
+  overrides?: Partial<PermitExtractionInput>
+): PermitExtractionInput => ({
+  requestId: 'test-svc-req',
+  surface: 'http',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const testSvcCtx: ServiceContext = {
+  config: undefined,
+  cwd: '/tmp',
+  env: {},
+  workspaceRoot: '/tmp',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('authService', () => {
+  test('has correct id and kind', () => {
+    expect(authService.id).toBe('auth');
+    expect(authService.kind).toBe('service');
+  });
+
+  test('has infrastructure metadata', () => {
+    expect(authService.metadata).toEqual({ category: 'infrastructure' });
+  });
+
+  test('mock returns an AuthAdapter', async () => {
+    const mock = authService.mock?.();
+    expect(mock).toBeDefined();
+
+    const adapter = mock as AuthAdapter;
+    const result = await adapter.authenticate(testInput());
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBeNull();
+  });
+
+  test('create returns Result.ok with an AuthAdapter', async () => {
+    const result = await authService.create(testSvcCtx);
+    expect(result.isOk()).toBe(true);
+
+    const adapter = result.unwrap() as AuthAdapter;
+    const authResult = await adapter.authenticate(testInput());
+    expect(authResult.isOk()).toBe(true);
+    expect(authResult.unwrap()).toBeNull();
+  });
+});

--- a/packages/permits/src/__tests__/auth-verify.test.ts
+++ b/packages/permits/src/__tests__/auth-verify.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test } from 'bun:test';
 
-import { Result, executeTrail } from '@ontrails/core';
+import {
+  Result,
+  SURFACE_KEY,
+  ValidationError,
+  executeTrail,
+} from '@ontrails/core';
 
 import type { AuthAdapter } from '../adapter.js';
 import { authService } from '../auth-service.js';
 import { createJwtAdapter } from '../adapters/jwt.js';
+import type { Permit } from '../permit.js';
 import { authVerify } from '../trails/auth-verify.js';
 
 // ---------------------------------------------------------------------------
@@ -55,12 +61,26 @@ const jwtAdapter = (): AuthAdapter => createJwtAdapter({ secret: TEST_SECRET });
 /** Execute auth.verify with a given adapter injected as the auth service. */
 const runVerify = async (
   token: string,
-  adapter: AuthAdapter
+  adapter: AuthAdapter,
+  options?: {
+    surface?: 'http' | 'mcp' | 'cli';
+  }
 ): Promise<
   Result<
     {
       error?: string;
-      permit?: { id: string; scopes: string[] };
+      errorCode?:
+        | 'expired_token'
+        | 'insufficient_scope'
+        | 'invalid_token'
+        | 'missing_credentials';
+      permit?: {
+        id: string;
+        metadata?: Record<string, unknown>;
+        roles?: string[];
+        scopes: string[];
+        tenantId?: string;
+      };
       valid: boolean;
     },
     Error
@@ -70,13 +90,23 @@ const runVerify = async (
     authVerify,
     { token },
     {
+      ctx:
+        options?.surface === undefined
+          ? undefined
+          : { extensions: { [SURFACE_KEY]: options.surface } },
       services: { [authService.id]: adapter },
     }
   );
   return result as Result<
     {
       error?: string;
-      permit?: { id: string; scopes: string[] };
+      permit?: {
+        id: string;
+        metadata?: Record<string, unknown>;
+        roles?: string[];
+        scopes: string[];
+        tenantId?: string;
+      };
       valid: boolean;
     },
     Error
@@ -122,6 +152,7 @@ describe('auth.verify trail', () => {
       const value = result.unwrap();
       expect(value.valid).toBe(false);
       expect(value.error).toBe('No credentials');
+      expect(value.errorCode).toBe('missing_credentials');
       expect(value.permit).toBeUndefined();
     });
   });
@@ -145,6 +176,52 @@ describe('auth.verify trail', () => {
       });
       expect(value.error).toBeUndefined();
     });
+
+    test('returns the full permit payload from the adapter', async () => {
+      const permit: Permit = {
+        id: 'user-42',
+        metadata: { plan: 'pro' },
+        roles: ['admin'],
+        scopes: ['read', 'write'],
+        tenantId: 'tenant-1',
+      };
+      const adapter: AuthAdapter = {
+        // oxlint-disable-next-line require-await -- satisfies async interface
+        authenticate: async () => Result.ok(permit),
+      };
+
+      const result = await runVerify('full-permit-token', adapter);
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().permit).toEqual({
+        id: 'user-42',
+        metadata: { plan: 'pro' },
+        roles: ['admin'],
+        scopes: ['read', 'write'],
+        tenantId: 'tenant-1',
+      });
+    });
+
+    test('forwards the invoking surface from trail context', async () => {
+      let seenSurface: string | undefined;
+      const adapter: AuthAdapter = {
+        // oxlint-disable-next-line require-await -- captures adapter input
+        authenticate: async (input) => {
+          seenSurface = input.surface;
+          return Result.ok({
+            id: 'user-42',
+            scopes: ['read'],
+          });
+        },
+      };
+
+      const result = await runVerify('surface-aware-token', adapter, {
+        surface: 'mcp',
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(seenSurface).toBe('mcp');
+    });
   });
 
   describe('with invalid token', () => {
@@ -161,6 +238,7 @@ describe('auth.verify trail', () => {
       const value = result.unwrap();
       expect(value.valid).toBe(false);
       expect(value.error).toBeDefined();
+      expect(value.errorCode).toBe('invalid_token');
       expect(value.permit).toBeUndefined();
     });
 
@@ -177,7 +255,23 @@ describe('auth.verify trail', () => {
       const value = result.unwrap();
       expect(value.valid).toBe(false);
       expect(value.error).toBeDefined();
+      expect(value.errorCode).toBe('expired_token');
       expect(value.permit).toBeUndefined();
+    });
+  });
+
+  describe('input validation', () => {
+    test('rejects empty bearer tokens at the boundary', async () => {
+      const result = await executeTrail(
+        authVerify,
+        { token: '' },
+        {
+          services: { [authService.id]: jwtAdapter() },
+        }
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(ValidationError);
     });
   });
 });

--- a/packages/permits/src/__tests__/auth-verify.test.ts
+++ b/packages/permits/src/__tests__/auth-verify.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result, executeTrail } from '@ontrails/core';
+
+import type { AuthAdapter } from '../adapter.js';
+import { authService } from '../auth-service.js';
+import { createJwtAdapter } from '../adapters/jwt.js';
+import { authVerify } from '../trails/auth-verify.js';
+
+// ---------------------------------------------------------------------------
+// Test helper: sign a JWT with HMAC-SHA256 using crypto.subtle
+// ---------------------------------------------------------------------------
+
+const base64url = (buf: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCodePoint(b);
+  }
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '');
+};
+
+const base64urlEncode = (str: string): string => {
+  const encoder = new TextEncoder();
+  return base64url(encoder.encode(str).buffer as ArrayBuffer);
+};
+
+const signJwt = async (
+  payload: Record<string, unknown>,
+  secret: string
+): Promise<string> => {
+  const header = base64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64urlEncode(JSON.stringify(payload));
+  const data = `${header}.${body}`;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(data));
+  return `${data}.${base64url(sig)}`;
+};
+
+const TEST_SECRET = 'test-secret-for-hmac-256';
+
+/** Create an AuthAdapter wired to a JWT secret. */
+const jwtAdapter = (): AuthAdapter => createJwtAdapter({ secret: TEST_SECRET });
+
+/** Execute auth.verify with a given adapter injected as the auth service. */
+const runVerify = async (
+  token: string,
+  adapter: AuthAdapter
+): Promise<
+  Result<
+    {
+      error?: string;
+      permit?: { id: string; scopes: string[] };
+      valid: boolean;
+    },
+    Error
+  >
+> => {
+  const result = await executeTrail(
+    authVerify,
+    { token },
+    {
+      services: { [authService.id]: adapter },
+    }
+  );
+  return result as Result<
+    {
+      error?: string;
+      permit?: { id: string; scopes: string[] };
+      valid: boolean;
+    },
+    Error
+  >;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('auth.verify trail', () => {
+  describe('contract', () => {
+    test('has correct id and intent', () => {
+      expect(authVerify.id).toBe('auth.verify');
+      expect(authVerify.intent).toBe('read');
+    });
+
+    test('has infrastructure metadata', () => {
+      expect(authVerify.metadata).toEqual({ category: 'infrastructure' });
+    });
+
+    test('has examples', () => {
+      expect(authVerify.examples).toBeDefined();
+      expect(authVerify.examples?.length).toBeGreaterThan(0);
+    });
+
+    test('declares authService dependency', () => {
+      expect(authVerify.services).toHaveLength(1);
+      expect(authVerify.services[0]?.id).toBe('auth');
+    });
+  });
+
+  describe('with mock adapter (no credentials)', () => {
+    test('returns valid: false with error message', async () => {
+      const noopAdapter: AuthAdapter = {
+        // oxlint-disable-next-line require-await -- satisfies async interface
+        authenticate: async () => Result.ok(null),
+      };
+
+      const result = await runVerify('some-token', noopAdapter);
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(false);
+      expect(value.error).toBe('No credentials');
+      expect(value.permit).toBeUndefined();
+    });
+  });
+
+  describe('with valid token and secret', () => {
+    test('returns valid: true with permit', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const token = await signJwt(
+        { exp: now + 3600, scope: 'read write', sub: 'user-42' },
+        TEST_SECRET
+      );
+
+      const result = await runVerify(token, jwtAdapter());
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(true);
+      expect(value.permit).toEqual({
+        id: 'user-42',
+        scopes: ['read', 'write'],
+      });
+      expect(value.error).toBeUndefined();
+    });
+  });
+
+  describe('with invalid token', () => {
+    test('returns valid: false with error for bad signature', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const token = await signJwt(
+        { exp: now + 3600, sub: 'user-bad' },
+        'wrong-secret'
+      );
+
+      const result = await runVerify(token, jwtAdapter());
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(false);
+      expect(value.error).toBeDefined();
+      expect(value.permit).toBeUndefined();
+    });
+
+    test('returns valid: false for expired token', async () => {
+      const past = Math.floor(Date.now() / 1000) - 3600;
+      const token = await signJwt(
+        { exp: past, sub: 'user-expired' },
+        TEST_SECRET
+      );
+
+      const result = await runVerify(token, jwtAdapter());
+
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.valid).toBe(false);
+      expect(value.error).toBeDefined();
+      expect(value.permit).toBeUndefined();
+    });
+  });
+});

--- a/packages/permits/src/__tests__/permit.test.ts
+++ b/packages/permits/src/__tests__/permit.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Permit, PermitExtractionInput } from '../index';
+import { getPermit } from '../index';
+
+describe('Permit type', () => {
+  test('accepts a valid permit with required fields only', () => {
+    const permit: Permit = {
+      id: 'usr_abc123',
+      scopes: ['user:read', 'user:write'],
+    };
+    expect(permit.id).toBe('usr_abc123');
+    expect(permit.scopes).toEqual(['user:read', 'user:write']);
+  });
+
+  test('accepts a permit with all optional fields', () => {
+    const permit: Permit = {
+      id: 'usr_full',
+      metadata: { plan: 'pro', provider: 'clerk' },
+      roles: ['admin', 'editor'],
+      scopes: ['entity:read'],
+      tenantId: 'tenant_xyz',
+    };
+    expect(permit.roles).toEqual(['admin', 'editor']);
+    expect(permit.tenantId).toBe('tenant_xyz');
+    expect(permit.metadata).toEqual({ plan: 'pro', provider: 'clerk' });
+  });
+
+  test('scopes and roles arrays are readonly', () => {
+    const permit: Permit = {
+      id: 'usr_ro',
+      roles: ['viewer'],
+      scopes: ['read'],
+    };
+    // Structural check: readonly arrays are assignable to readonly string[]
+    const { scopes } = permit;
+    const { roles } = permit;
+    expect(scopes).toEqual(['read']);
+    expect(roles).toEqual(['viewer']);
+  });
+});
+
+describe('getPermit()', () => {
+  test('returns Permit from a context with a permit', () => {
+    const permit: Permit = { id: 'usr_1', scopes: ['user:read'] };
+    const ctx = { permit, requestId: 'req-1' };
+    const result = getPermit(ctx);
+    expect(result).toEqual(permit);
+  });
+
+  test('returns undefined when context has no permit', () => {
+    const ctx = { requestId: 'req-2' };
+    const result = getPermit(ctx);
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when permit is explicitly undefined', () => {
+    const ctx = { permit: undefined, requestId: 'req-3' };
+    const result = getPermit(ctx);
+    expect(result).toBeUndefined();
+  });
+
+  test('preserves extended permit fields from the auth layer', () => {
+    const ctx = {
+      permit: {
+        id: 'usr_2',
+        metadata: { plan: 'pro' },
+        roles: ['admin'],
+        scopes: ['user:read'],
+        tenantId: 'tenant-1',
+      } satisfies Permit,
+      requestId: 'req-4',
+    };
+    const result = getPermit(ctx);
+    expect(result).toEqual(ctx.permit);
+  });
+});
+
+describe('PermitExtractionInput', () => {
+  test('accepts HTTP surface extraction', () => {
+    const input: PermitExtractionInput = {
+      bearerToken: 'eyJhbGciOiJSUzI1NiJ9.test',
+      headers: new Headers({
+        authorization: 'Bearer eyJhbGciOiJSUzI1NiJ9.test',
+      }),
+      requestId: 'req-http-1',
+      surface: 'http',
+    };
+    expect(input.surface).toBe('http');
+    expect(input.bearerToken).toBeDefined();
+  });
+
+  test('accepts MCP surface extraction', () => {
+    const input: PermitExtractionInput = {
+      requestId: 'req-mcp-1',
+      sessionId: 'mcp-session-abc',
+      surface: 'mcp',
+    };
+    expect(input.surface).toBe('mcp');
+    expect(input.sessionId).toBe('mcp-session-abc');
+  });
+
+  test('accepts CLI surface extraction', () => {
+    const input: PermitExtractionInput = {
+      bearerToken: 'cli-token-from-keyring',
+      requestId: 'req-cli-1',
+      surface: 'cli',
+    };
+    expect(input.surface).toBe('cli');
+  });
+
+  test('accepts minimal extraction with only required fields', () => {
+    const input: PermitExtractionInput = {
+      requestId: 'req-minimal',
+      surface: 'http',
+    };
+    expect(input.requestId).toBe('req-minimal');
+    expect(input.bearerToken).toBeUndefined();
+    expect(input.sessionId).toBeUndefined();
+    expect(input.headers).toBeUndefined();
+  });
+});

--- a/packages/permits/src/__tests__/rules.test.ts
+++ b/packages/permits/src/__tests__/rules.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from 'bun:test';
+import { trail, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  destroyWithoutPermit,
+  writeWithoutPermit,
+  scopeNamingConsistency,
+  orphanScopeDetection,
+  validatePermits,
+} from '../rules.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const emptyInput = z.object({});
+const noopRun = () => Result.ok({});
+
+// ---------------------------------------------------------------------------
+// destroyWithoutPermit
+// ---------------------------------------------------------------------------
+
+describe('destroyWithoutPermit', () => {
+  test('error when destroy trail has no permit', () => {
+    const t = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      run: noopRun,
+    });
+    const diagnostics = destroyWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      message: expect.stringContaining('destroy'),
+      rule: 'destroyWithoutPermit',
+      severity: 'error',
+      trailId: 'user.delete',
+    });
+  });
+
+  test('no diagnostic when destroy trail has a scoped permit', () => {
+    const t = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      permit: { scopes: ['user:delete'] },
+      run: noopRun,
+    });
+    const diagnostics = destroyWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('error when destroy trail has permit: public', () => {
+    const t = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      permit: 'public',
+      run: noopRun,
+    });
+    const diagnostics = destroyWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'destroyWithoutPermit',
+      severity: 'error',
+      trailId: 'user.delete',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeWithoutPermit
+// ---------------------------------------------------------------------------
+
+describe('writeWithoutPermit', () => {
+  test('warning when write trail has no permit', () => {
+    const t = trail('user.create', {
+      input: emptyInput,
+      run: noopRun,
+    });
+    const diagnostics = writeWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'writeWithoutPermit',
+      severity: 'warning',
+      trailId: 'user.create',
+    });
+  });
+
+  test('no warning when write trail has permit: public', () => {
+    const t = trail('user.create', {
+      input: emptyInput,
+      permit: 'public',
+      run: noopRun,
+    });
+    const diagnostics = writeWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('warning when trail has no intent (defaults to write)', () => {
+    const t = trail('user.update', {
+      input: emptyInput,
+      run: noopRun,
+    });
+    // Override intent to undefined to simulate a manually constructed trail
+    const noIntent = { ...t, intent: undefined } as unknown as ReturnType<
+      typeof trail
+    >;
+    const diagnostics = writeWithoutPermit([noIntent]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'writeWithoutPermit',
+      severity: 'warning',
+      trailId: 'user.update',
+    });
+  });
+
+  test('no diagnostic for read trail without permit', () => {
+    const t = trail('user.list', {
+      input: emptyInput,
+      intent: 'read',
+      run: noopRun,
+    });
+    const diagnostics = writeWithoutPermit([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scopeNamingConsistency
+// ---------------------------------------------------------------------------
+
+describe('scopeNamingConsistency', () => {
+  test('scope user:write passes naming check', () => {
+    const t = trail('user.update', {
+      input: emptyInput,
+      permit: { scopes: ['user:write'] },
+      run: noopRun,
+    });
+    const diagnostics = scopeNamingConsistency([t]);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('warning for scope without colon', () => {
+    const t = trail('admin.panel', {
+      input: emptyInput,
+      permit: { scopes: ['admin'] },
+      run: noopRun,
+    });
+    const diagnostics = scopeNamingConsistency([t]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      message: expect.stringContaining('admin'),
+      rule: 'scopeNamingConsistency',
+      severity: 'warning',
+      trailId: 'admin.panel',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orphanScopeDetection
+// ---------------------------------------------------------------------------
+
+describe('orphanScopeDetection', () => {
+  test('warning for orphan scope (typo)', () => {
+    const t1 = trail('user.read', {
+      input: emptyInput,
+      permit: { scopes: ['user:read'] },
+      run: noopRun,
+    });
+    const t2 = trail('user.write', {
+      input: emptyInput,
+      permit: { scopes: ['user:wirte'] },
+      run: noopRun,
+    });
+    const diagnostics = orphanScopeDetection([t1, t2]);
+    // Both scopes are unique (appear in only 1 trail each)
+    expect(diagnostics).toHaveLength(2);
+    const messages = diagnostics.map((d) => d.message);
+    expect(messages.some((m) => m.includes('user:wirte'))).toBe(true);
+  });
+
+  test('no warning for shared scopes', () => {
+    const t1 = trail('user.read', {
+      input: emptyInput,
+      permit: { scopes: ['user:read'] },
+      run: noopRun,
+    });
+    const t2 = trail('user.profile', {
+      input: emptyInput,
+      permit: { scopes: ['user:read'] },
+      run: noopRun,
+    });
+    const diagnostics = orphanScopeDetection([t1, t2]);
+    expect(diagnostics).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validatePermits
+// ---------------------------------------------------------------------------
+
+/* oxlint-disable max-statements -- integration test validates all rules fire */
+describe('validatePermits', () => {
+  test('runs all rules and aggregates diagnostics', () => {
+    const destroyNoPerm = trail('user.delete', {
+      input: emptyInput,
+      intent: 'destroy',
+      run: noopRun,
+    });
+    const writeNoPerm = trail('user.create', {
+      input: emptyInput,
+      run: noopRun,
+    });
+    const badScope = trail('admin.panel', {
+      input: emptyInput,
+      permit: { scopes: ['admin'] },
+      run: noopRun,
+    });
+    const orphanScope = trail('analytics.export', {
+      input: emptyInput,
+      permit: { scopes: ['analytics:exportt'] },
+      run: noopRun,
+    });
+
+    const diagnostics = validatePermits([
+      destroyNoPerm,
+      writeNoPerm,
+      badScope,
+      orphanScope,
+    ]);
+
+    const rules = diagnostics.map((d) => d.rule);
+    expect(rules).toContain('destroyWithoutPermit');
+    expect(rules).toContain('writeWithoutPermit');
+    expect(rules).toContain('scopeNamingConsistency');
+    expect(rules).toContain('orphanScopeDetection');
+    expect(diagnostics.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/permits/src/__tests__/testing.test.ts
+++ b/packages/permits/src/__tests__/testing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+
+import { mintPermitForTrail, mintTestPermit } from '../testing';
+
+describe('mintTestPermit()', () => {
+  test('returns a Permit with the given scopes', () => {
+    const permit = mintTestPermit({ scopes: ['user:read', 'user:write'] });
+    expect(permit.scopes).toEqual(['user:read', 'user:write']);
+  });
+
+  test('generates a unique id when not specified', () => {
+    const a = mintTestPermit();
+    const b = mintTestPermit();
+    expect(a.id).not.toBe(b.id);
+  });
+
+  test('uses the provided id when specified', () => {
+    const permit = mintTestPermit({ id: 'custom-id' });
+    expect(permit.id).toBe('custom-id');
+  });
+
+  test('returns empty scopes when no options provided', () => {
+    const permit = mintTestPermit();
+    expect(permit.scopes).toEqual([]);
+  });
+
+  test('includes roles when provided', () => {
+    const permit = mintTestPermit({ roles: ['admin', 'editor'] });
+    expect(permit.roles).toEqual(['admin', 'editor']);
+  });
+
+  test('includes tenantId when provided', () => {
+    const permit = mintTestPermit({ tenantId: 'tenant_abc' });
+    expect(permit.tenantId).toBe('tenant_abc');
+  });
+});
+
+describe('mintPermitForTrail()', () => {
+  test('extracts scopes from trail permit requirement', () => {
+    const trail = { permit: { scopes: ['entity:read', 'entity:write'] } };
+    const permit = mintPermitForTrail(trail);
+    expect(permit).toBeDefined();
+    expect(permit?.scopes).toEqual(['entity:read', 'entity:write']);
+  });
+
+  test('returns undefined for public trails', () => {
+    const trail = { permit: 'public' as const };
+    const permit = mintPermitForTrail(trail);
+    expect(permit).toBeUndefined();
+  });
+
+  test('returns undefined when no permit declared', () => {
+    const trail = {};
+    const permit = mintPermitForTrail(trail);
+    expect(permit).toBeUndefined();
+  });
+});

--- a/packages/permits/src/adapter.ts
+++ b/packages/permits/src/adapter.ts
@@ -1,0 +1,35 @@
+import type { Result } from '@ontrails/core';
+
+import type { PermitExtractionInput } from './extraction.js';
+import type { Permit } from './permit.js';
+
+/**
+ * @deprecated Use {@link PermitExtractionInput} instead. Kept as an alias
+ * for backward compatibility during migration.
+ */
+export type AuthCredentials = PermitExtractionInput;
+
+/** Errors from auth adapters. */
+export interface AuthError {
+  readonly code:
+    | 'expired_token'
+    | 'insufficient_scope'
+    | 'invalid_token'
+    | 'missing_credentials';
+  readonly message: string;
+}
+
+/**
+ * Auth adapter port. Given extraction input, produce a permit or an error.
+ *
+ * The adapter receives the full {@link PermitExtractionInput} — surface,
+ * headers, requestId, and credential fields — so it can make richer
+ * decisions (e.g., rate-limit by surface or correlate via requestId).
+ *
+ * Deliberately narrow — no session management, no token refresh.
+ */
+export interface AuthAdapter {
+  readonly authenticate: (
+    input: PermitExtractionInput
+  ) => Promise<Result<Permit | null, AuthError>>;
+}

--- a/packages/permits/src/adapters/jwt.ts
+++ b/packages/permits/src/adapters/jwt.ts
@@ -1,0 +1,225 @@
+import { Result } from '@ontrails/core';
+
+import type { AuthAdapter, AuthError } from '../adapter.js';
+import type { PermitExtractionInput } from '../extraction.js';
+import type { Permit } from '../permit.js';
+
+/** Configuration for the JWT auth adapter. */
+export interface JwtAdapterOptions {
+  /** HMAC secret for HS256 verification. */
+  readonly secret?: string;
+  /** JWKS endpoint for RS256/ES256 (not yet implemented). */
+  readonly jwksUrl?: string;
+  /** Expected issuer claim. */
+  readonly issuer?: string;
+  /** Expected audience claim. */
+  readonly audience?: string;
+  /** Claim containing scopes (default: 'scope'). */
+  readonly scopesClaim?: string;
+  /** Claim containing roles (default: 'roles'). */
+  readonly rolesClaim?: string;
+}
+
+/** JWT payload with standard claims. */
+interface JwtPayload {
+  readonly sub?: string;
+  readonly iss?: string;
+  readonly aud?: string | readonly string[];
+  readonly exp?: number;
+  readonly [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before callers)
+// ---------------------------------------------------------------------------
+
+const authErr = (
+  code: AuthError['code'],
+  message: string
+): Result<never, AuthError> => Result.err({ code, message });
+
+/** Base64url-decode a string to bytes. */
+const base64urlDecode = (input: string): Uint8Array => {
+  const padded = input
+    .replaceAll('-', '+')
+    .replaceAll('_', '/')
+    .padEnd(input.length + ((4 - (input.length % 4)) % 4), '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.codePointAt(i) ?? 0;
+  }
+  return bytes;
+};
+
+/** Decode a JWT payload without verifying the signature. */
+const decodePayload = (token: string): JwtPayload | undefined => {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return undefined;
+  }
+  try {
+    const json = new TextDecoder().decode(base64urlDecode(parts[1] ?? ''));
+    return JSON.parse(json) as JwtPayload;
+  } catch {
+    return undefined;
+  }
+};
+
+/** Import a secret as an HMAC CryptoKey. */
+const importHmacKey = (secret: string): Promise<CryptoKey> => {
+  const encoder = new TextEncoder();
+  return crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['verify']
+  );
+};
+
+/** Verify the HMAC-SHA256 signature of a JWT. */
+const verifyHmacSignature = (
+  token: string,
+  key: CryptoKey
+): Promise<boolean> => {
+  const lastDot = token.lastIndexOf('.');
+  if (lastDot === -1) {
+    return Promise.resolve(false);
+  }
+  const data = token.slice(0, lastDot);
+  const signature = base64urlDecode(token.slice(lastDot + 1));
+  const encoder = new TextEncoder();
+  return crypto.subtle.verify(
+    'HMAC',
+    key,
+    signature.buffer as ArrayBuffer,
+    encoder.encode(data)
+  );
+};
+
+/** Validate standard claims (exp, iss, aud). */
+const validateClaims = (
+  payload: JwtPayload,
+  options: JwtAdapterOptions
+): AuthError | undefined => {
+  if (
+    payload.exp !== undefined &&
+    payload.exp < Math.floor(Date.now() / 1000)
+  ) {
+    return { code: 'expired_token', message: 'Token has expired' };
+  }
+  if (options.issuer && payload.iss !== options.issuer) {
+    return { code: 'invalid_token', message: 'Issuer mismatch' };
+  }
+  if (options.audience) {
+    const { aud } = payload;
+    const matches = Array.isArray(aud)
+      ? aud.includes(options.audience)
+      : aud === options.audience;
+    if (!matches) {
+      return { code: 'invalid_token', message: 'Audience mismatch' };
+    }
+  }
+  return undefined;
+};
+
+/** Extract scopes from a payload claim (space-separated string or array). */
+const extractScopes = (
+  payload: JwtPayload,
+  claim: string
+): readonly string[] => {
+  const raw = payload[claim];
+  if (typeof raw === 'string') {
+    return raw.split(' ').filter(Boolean);
+  }
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === 'string');
+  }
+  return [];
+};
+
+/** Extract roles from a payload claim (string array). */
+const extractRoles = (
+  payload: JwtPayload,
+  claim: string
+): readonly string[] | undefined => {
+  const raw = payload[claim];
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  return raw.filter((r): r is string => typeof r === 'string');
+};
+
+/** Build a Permit from a validated JWT payload. */
+const buildPermit = (
+  payload: JwtPayload,
+  options: JwtAdapterOptions
+): Permit => {
+  const roles = extractRoles(payload, options.rolesClaim ?? 'roles');
+  return {
+    id: payload.sub ?? '',
+    scopes: extractScopes(payload, options.scopesClaim ?? 'scope'),
+    ...(roles ? { roles } : {}),
+  };
+};
+
+/** Verify the signature and return the decoded payload, or an error. */
+const decodeAndVerify = async (
+  token: string,
+  secret: string
+): Promise<Result<JwtPayload, AuthError>> => {
+  const payload = decodePayload(token);
+  if (!payload) {
+    return authErr('invalid_token', 'Malformed JWT');
+  }
+  try {
+    const key = await importHmacKey(secret);
+    const valid = await verifyHmacSignature(token, key);
+    return valid
+      ? Result.ok(payload)
+      : authErr('invalid_token', 'Invalid signature');
+  } catch {
+    return authErr('invalid_token', 'Malformed token signature');
+  }
+};
+
+/** Validate claims and build a permit from a verified payload. */
+const payloadToPermit = (
+  payload: JwtPayload,
+  options: JwtAdapterOptions
+): Result<Permit, AuthError> => {
+  const claimError = validateClaims(payload, options);
+  if (claimError) {
+    return Result.err(claimError);
+  }
+  return Result.ok(buildPermit(payload, options));
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a JWT auth adapter using Bun's native crypto.
+ *
+ * Verifies HS256-signed JWTs, extracts claims into a Permit, and checks
+ * issuer/audience when configured. Returns `Result.ok(null)` when no
+ * credentials are provided.
+ */
+export const createJwtAdapter = (options: JwtAdapterOptions): AuthAdapter => {
+  const authenticate = async (
+    input: PermitExtractionInput
+  ): Promise<Result<Permit | null, AuthError>> => {
+    if (!input.bearerToken) {
+      return Result.ok(null);
+    }
+    if (!options.secret) {
+      return authErr('invalid_token', 'No secret configured');
+    }
+    const decoded = await decodeAndVerify(input.bearerToken, options.secret);
+    return decoded.isErr() ? decoded : payloadToPermit(decoded.value, options);
+  };
+
+  return { authenticate };
+};

--- a/packages/permits/src/adapters/jwt.ts
+++ b/packages/permits/src/adapters/jwt.ts
@@ -134,7 +134,9 @@ const extractScopes = (
     return raw.split(' ').filter(Boolean);
   }
   if (Array.isArray(raw)) {
-    return raw.filter((s): s is string => typeof s === 'string');
+    return raw.filter(
+      (s): s is string => typeof s === 'string' && s.length > 0
+    );
   }
   return [];
 };
@@ -155,13 +157,16 @@ const extractRoles = (
 const buildPermit = (
   payload: JwtPayload,
   options: JwtAdapterOptions
-): Permit => {
+): Result<Permit, AuthError> => {
+  if (!payload.sub) {
+    return authErr('invalid_token', 'Missing subject claim (sub)');
+  }
   const roles = extractRoles(payload, options.rolesClaim ?? 'roles');
-  return {
-    id: payload.sub ?? '',
+  return Result.ok({
+    id: payload.sub,
     scopes: extractScopes(payload, options.scopesClaim ?? 'scope'),
     ...(roles ? { roles } : {}),
-  };
+  });
 };
 
 /** Verify the signature and return the decoded payload, or an error. */
@@ -193,7 +198,7 @@ const payloadToPermit = (
   if (claimError) {
     return Result.err(claimError);
   }
-  return Result.ok(buildPermit(payload, options));
+  return buildPermit(payload, options);
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/permits/src/auth-layer.ts
+++ b/packages/permits/src/auth-layer.ts
@@ -57,20 +57,24 @@ export const authLayer: Layer = {
       const permit = getPermit(ctx);
 
       if (!permit) {
-        return Result.err(new PermitError('No permit provided'));
+        return Promise.resolve(
+          Result.err(new PermitError('No permit provided'))
+        );
       }
 
       const missing = findMissing(requirement.scopes, permit.scopes);
 
       if (missing.length > 0) {
-        return Result.err(
-          new PermitError(`Missing scopes: ${missing.join(', ')}`, {
-            context: { missing, required: requirement.scopes },
-          })
+        return Promise.resolve(
+          Result.err(
+            new PermitError(`Missing scopes: ${missing.join(', ')}`, {
+              context: { missing, required: requirement.scopes },
+            })
+          )
         );
       }
 
-      return impl(input, ctx);
+      return Promise.resolve(impl(input, ctx));
     };
   },
 };

--- a/packages/permits/src/auth-layer.ts
+++ b/packages/permits/src/auth-layer.ts
@@ -1,0 +1,76 @@
+import { Result } from '@ontrails/core';
+import type { Layer } from '@ontrails/core';
+
+import { PermitError } from './errors.js';
+import { getPermit } from './permit.js';
+
+// ---------------------------------------------------------------------------
+// Helpers (defined before callers — no use-before-define)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when the permit requirement means "no enforcement needed."
+ * Either the trail hasn't declared a permit posture or has explicitly
+ * opted out with `'public'`.
+ */
+const isPassThrough = (
+  requirement: unknown
+): requirement is undefined | 'public' =>
+  requirement === undefined || requirement === 'public';
+
+/** Returns scopes present in `required` but absent from `held`. */
+const findMissing = (
+  required: readonly string[],
+  held: readonly string[]
+): readonly string[] => required.filter((s) => !held.includes(s));
+
+// ---------------------------------------------------------------------------
+// Auth layer
+// ---------------------------------------------------------------------------
+
+/**
+ * A {@link Layer} that enforces permit scopes declared on trails.
+ *
+ * The layer reads the trail's `permit` field (a `PermitRequirement`):
+ *
+ * - If `permit` is `'public'` or `undefined` the layer passes through.
+ * - If `permit` has `scopes`, the layer checks that `ctx.permit` contains
+ *   all required scopes. A superset is fine; missing scopes produce a
+ *   `PermitError`.
+ *
+ * Because `ctx.follow()` re-enters `executeTrail` (which applies layers),
+ * this layer automatically re-checks on every invocation in a follow chain.
+ * No special follow-chain handling is needed — it is built into the
+ * architecture.
+ */
+export const authLayer: Layer = {
+  description: 'Enforces permit scopes declared on trails',
+  name: 'auth',
+  wrap: (_trail, impl) => {
+    const requirement = _trail.permit;
+
+    if (isPassThrough(requirement)) {
+      return impl;
+    }
+
+    return (input, ctx) => {
+      const permit = getPermit(ctx);
+
+      if (!permit) {
+        return Result.err(new PermitError('No permit provided'));
+      }
+
+      const missing = findMissing(requirement.scopes, permit.scopes);
+
+      if (missing.length > 0) {
+        return Result.err(
+          new PermitError(`Missing scopes: ${missing.join(', ')}`, {
+            context: { missing, required: requirement.scopes },
+          })
+        );
+      }
+
+      return impl(input, ctx);
+    };
+  },
+};

--- a/packages/permits/src/auth-service.ts
+++ b/packages/permits/src/auth-service.ts
@@ -1,0 +1,25 @@
+import { Result, service } from '@ontrails/core';
+
+import type { AuthAdapter } from './adapter.js';
+
+/**
+ * Auth service — manages the auth adapter lifecycle.
+ *
+ * The v1 factory returns a no-op adapter that always succeeds (null permit).
+ * Real adapter configuration will come through `ServiceSpec.config` (TRL-91).
+ * The mock factory provides a synthetic adapter that always succeeds.
+ */
+export const authService = service<AuthAdapter>('auth', {
+  create: (_svc) =>
+    Result.ok({
+      // oxlint-disable-next-line require-await -- stub adapter satisfies async interface
+      authenticate: async () => Result.ok(null),
+    } satisfies AuthAdapter),
+  description: 'Authentication adapter',
+  metadata: { category: 'infrastructure' },
+  mock: () =>
+    ({
+      // oxlint-disable-next-line require-await -- mock adapter satisfies async interface
+      authenticate: async () => Result.ok(null),
+    }) satisfies AuthAdapter,
+});

--- a/packages/permits/src/errors.ts
+++ b/packages/permits/src/errors.ts
@@ -1,0 +1,18 @@
+import { PermissionError } from '@ontrails/core';
+
+/**
+ * Error returned when permit scope enforcement fails.
+ *
+ * Extends `PermissionError` (category `'permission'`, HTTP 403) because
+ * it represents an *authorization* failure — the caller's identity is known
+ * but lacks the required scopes.
+ */
+export class PermitError extends PermissionError {
+  constructor(
+    message: string,
+    options?: { cause?: Error; context?: Record<string, unknown> }
+  ) {
+    super(message, options);
+    this.name = 'PermitError';
+  }
+}

--- a/packages/permits/src/extraction.ts
+++ b/packages/permits/src/extraction.ts
@@ -1,0 +1,19 @@
+/**
+ * Normalized input for auth adapters.
+ *
+ * Each surface extracts raw credentials from its transport and normalizes
+ * them into this shape. No surface types (Request, McpSession, etc.) cross
+ * into core — only this interface.
+ */
+export interface PermitExtractionInput {
+  /** Which surface produced this extraction */
+  readonly surface: 'http' | 'mcp' | 'cli';
+  /** Bearer token from Authorization header or equivalent */
+  readonly bearerToken?: string;
+  /** Session identifier from transport handshake */
+  readonly sessionId?: string;
+  /** Raw headers (HTTP surface only, typically) */
+  readonly headers?: Headers;
+  /** Correlation ID for tracing */
+  readonly requestId: string;
+}

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -1,0 +1,4 @@
+/** Internal placeholder — replaced by real types in TRL-98+. */
+export interface PermitPlaceholder {
+  readonly __brand: 'permits';
+}

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -4,5 +4,7 @@ export {
   type AuthError,
 } from './adapter.js';
 export { createJwtAdapter, type JwtAdapterOptions } from './adapters/jwt.js';
+export { authLayer } from './auth-layer.js';
+export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -1,4 +1,2 @@
-/** Internal placeholder — replaced by real types in TRL-98+. */
-export interface PermitPlaceholder {
-  readonly __brand: 'permits';
-}
+export { type Permit, getPermit } from './permit.js';
+export { type PermitExtractionInput } from './extraction.js';

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -1,2 +1,8 @@
-export { type Permit, getPermit } from './permit.js';
+export {
+  type AuthAdapter,
+  type AuthCredentials,
+  type AuthError,
+} from './adapter.js';
+export { createJwtAdapter, type JwtAdapterOptions } from './adapters/jwt.js';
 export { type PermitExtractionInput } from './extraction.js';
+export { type Permit, getPermit } from './permit.js';

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -8,3 +8,4 @@ export { authLayer } from './auth-layer.js';
 export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';
+export { validatePermits, type PermitDiagnostic } from './rules.js';

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -5,6 +5,8 @@ export {
 } from './adapter.js';
 export { createJwtAdapter, type JwtAdapterOptions } from './adapters/jwt.js';
 export { authLayer } from './auth-layer.js';
+export { authService } from './auth-service.js';
+export { authVerify } from './trails/auth-verify.js';
 export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -9,3 +9,4 @@ export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';
 export { validatePermits, type PermitDiagnostic } from './rules.js';
+export { mintTestPermit, mintPermitForTrail } from './testing.js';

--- a/packages/permits/src/permit.ts
+++ b/packages/permits/src/permit.ts
@@ -1,0 +1,26 @@
+import type { BasePermit } from '@ontrails/core';
+
+/** The resolved identity and scopes from a successful authentication. */
+export interface Permit extends BasePermit {
+  readonly roles?: readonly string[];
+  readonly tenantId?: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Type-safe accessor for `ctx.permit` with a downcast to `Permit`.
+ *
+ * `TrailContext.permit` is typed as `BasePermit` (id + scopes). This accessor
+ * returns the full `Permit` when the auth layer has set one. Safe because
+ * the auth layer is the only writer and always sets a full `Permit`.
+ *
+ * @example
+ * ```typescript
+ * const permit = getPermit(ctx);
+ * if (permit) {
+ *   console.log(permit.roles, permit.tenantId);
+ * }
+ * ```
+ */
+export const getPermit = (ctx: { permit?: BasePermit }): Permit | undefined =>
+  ctx.permit === undefined ? undefined : (ctx.permit as Permit);

--- a/packages/permits/src/rules.ts
+++ b/packages/permits/src/rules.ts
@@ -1,0 +1,183 @@
+import type { Trail } from '@ontrails/core';
+
+// ---------------------------------------------------------------------------
+// Diagnostic type
+// ---------------------------------------------------------------------------
+
+/** A single governance finding from a permit rule. */
+export interface PermitDiagnostic {
+  readonly trailId: string;
+  readonly rule: string;
+  readonly severity: 'error' | 'warning';
+  readonly message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type AnyTrail = Trail<unknown, unknown>;
+type Rule = (trails: readonly AnyTrail[]) => readonly PermitDiagnostic[];
+
+/** Check whether a trail has any permit declaration (scopes object or 'public'). */
+const hasPermit = (t: AnyTrail): boolean => t.permit !== undefined;
+
+/** Extract scopes from a trail's permit declaration, or empty array. */
+const getScopes = (t: AnyTrail): readonly string[] => {
+  if (t.permit !== undefined && t.permit !== 'public') {
+    return t.permit.scopes;
+  }
+  return [];
+};
+
+// ---------------------------------------------------------------------------
+// Rule: destroyWithoutPermit
+// ---------------------------------------------------------------------------
+
+/**
+ * Destructive trails without a real permit declaration are a governance failure.
+ *
+ * Reports an error for every trail with `intent: 'destroy'` that has no
+ * `permit` field or explicitly opts out with `permit: 'public'`.
+ */
+export const destroyWithoutPermit: Rule = (trails) =>
+  trails
+    .filter(
+      (t) => t.intent === 'destroy' && (!hasPermit(t) || t.permit === 'public')
+    )
+    .map((t) => ({
+      message: `Trail "${t.id}" has intent 'destroy' but no permit declaration`,
+      rule: 'destroyWithoutPermit',
+      severity: 'error' as const,
+      trailId: t.id,
+    }));
+
+// ---------------------------------------------------------------------------
+// Rule: writeWithoutPermit
+// ---------------------------------------------------------------------------
+
+/**
+ * Write trails without a permit declaration get a warning.
+ *
+ * Trails with `intent: 'write'` (or no intent, which defaults to write) that
+ * lack a permit are flagged unless `permit: 'public'` is explicitly set.
+ */
+export const writeWithoutPermit: Rule = (trails) =>
+  trails
+    .filter(
+      (t) => (t.intent === 'write' || t.intent === undefined) && !hasPermit(t)
+    )
+    .map((t) => ({
+      message: `Trail "${t.id}" has write intent but no permit declaration`,
+      rule: 'writeWithoutPermit',
+      severity: 'warning' as const,
+      trailId: t.id,
+    }));
+
+// ---------------------------------------------------------------------------
+// Rule: scopeNamingConsistency
+// ---------------------------------------------------------------------------
+
+/** Returns true when a scope follows the `entity:action` convention. */
+const isValidScopeFormat = (scope: string): boolean => {
+  const parts = scope.split(':');
+  return (
+    parts.length === 2 &&
+    (parts[0]?.length ?? 0) > 0 &&
+    (parts[1]?.length ?? 0) > 0
+  );
+};
+
+/**
+ * Warns for scopes that don't follow the `entity:action` convention.
+ *
+ * A valid scope contains exactly one colon separating a non-empty entity
+ * and a non-empty action.
+ */
+export const scopeNamingConsistency: Rule = (trails) =>
+  trails.flatMap((t) =>
+    getScopes(t)
+      .filter((scope) => !isValidScopeFormat(scope))
+      .map((scope) => ({
+        message: `Scope "${scope}" on trail "${t.id}" does not follow entity:action convention`,
+        rule: 'scopeNamingConsistency',
+        severity: 'warning' as const,
+        trailId: t.id,
+      }))
+  );
+
+// ---------------------------------------------------------------------------
+// Rule: orphanScopeDetection
+// ---------------------------------------------------------------------------
+
+/** Build a map of scope -> set of trail IDs that declare it. */
+const buildScopeMap = (
+  trails: readonly AnyTrail[]
+): ReadonlyMap<string, ReadonlySet<string>> => {
+  const map = new Map<string, Set<string>>();
+  for (const t of trails) {
+    for (const scope of getScopes(t)) {
+      const existing = map.get(scope);
+      if (existing) {
+        existing.add(t.id);
+      } else {
+        map.set(scope, new Set([t.id]));
+      }
+    }
+  }
+  return map;
+};
+
+/** Filter trails that have a scoped (non-public) permit declaration. */
+const trailsWithScopedPermit = (
+  trails: readonly AnyTrail[]
+): readonly AnyTrail[] =>
+  trails.filter((t) => t.permit !== undefined && t.permit !== 'public');
+
+/** Convert orphan scope map entries into diagnostics. */
+const orphanDiagnostics = (
+  scopeMap: ReadonlyMap<string, ReadonlySet<string>>
+): readonly PermitDiagnostic[] =>
+  [...scopeMap.entries()]
+    .filter(([, ids]) => ids.size === 1)
+    .map(([scope, ids]) => ({
+      message: `Scope "${scope}" appears only on trail "${[...ids][0]}" — possible typo`,
+      rule: 'orphanScopeDetection',
+      severity: 'warning' as const,
+      trailId: [...ids][0] ?? '',
+    }));
+
+/**
+ * Warns for scopes that appear in only one trail's permit.
+ *
+ * Catches typos like `user:wirte` by surfacing scopes not shared with any
+ * other trail. Only runs when at least 2 trails have permit declarations.
+ */
+export const orphanScopeDetection: Rule = (trails) => {
+  const scoped = trailsWithScopedPermit(trails);
+  if (scoped.length < 2) {
+    return [];
+  }
+  return orphanDiagnostics(buildScopeMap(scoped));
+};
+
+// ---------------------------------------------------------------------------
+// Top-level validator
+// ---------------------------------------------------------------------------
+
+const allRules: readonly Rule[] = [
+  destroyWithoutPermit,
+  writeWithoutPermit,
+  scopeNamingConsistency,
+  orphanScopeDetection,
+];
+
+/**
+ * Run all permit governance rules against a set of trails.
+ *
+ * Returns a flat array of diagnostics from every rule. An empty array
+ * means the topo passes all permit governance checks.
+ */
+export const validatePermits = (
+  trails: readonly Trail<unknown, unknown>[]
+): readonly PermitDiagnostic[] => allRules.flatMap((rule) => rule(trails));

--- a/packages/permits/src/testing.ts
+++ b/packages/permits/src/testing.ts
@@ -1,0 +1,34 @@
+import type { PermitRequirement } from '@ontrails/core';
+
+import type { Permit } from './permit.js';
+
+/**
+ * Mint a synthetic test permit with exactly the declared scopes.
+ * No admin permit, no wildcard — tests get only what the trail declares.
+ */
+export const mintTestPermit = (options?: {
+  readonly id?: string;
+  readonly scopes?: readonly string[];
+  readonly roles?: readonly string[];
+  readonly tenantId?: string;
+}): Permit => ({
+  id:
+    options?.id ??
+    `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  scopes: [...(options?.scopes ?? [])],
+  ...(options?.roles === undefined ? {} : { roles: [...options.roles] }),
+  ...(options?.tenantId === undefined ? {} : { tenantId: options.tenantId }),
+});
+
+/**
+ * Create a test permit matching a trail's permit requirement.
+ * Extracts scopes from the requirement and mints a permit with exactly those scopes.
+ */
+export const mintPermitForTrail = (trail: {
+  readonly permit?: PermitRequirement | undefined;
+}): Permit | undefined => {
+  if (!trail.permit || trail.permit === 'public') {
+    return undefined;
+  }
+  return mintTestPermit({ scopes: trail.permit.scopes });
+};

--- a/packages/permits/src/trails/auth-verify.ts
+++ b/packages/permits/src/trails/auth-verify.ts
@@ -1,7 +1,42 @@
-import { Result, trail } from '@ontrails/core';
+import { Result, SURFACE_KEY, trail } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
 import { authService } from '../auth-service.js';
+import type { PermitExtractionInput } from '../extraction.js';
+import type { Permit } from '../permit.js';
+
+const permitSchema = z.object({
+  id: z.string(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  roles: z.array(z.string()).optional(),
+  scopes: z.array(z.string()),
+  tenantId: z.string().optional(),
+});
+const authErrorCodeSchema = z.enum([
+  'expired_token',
+  'insufficient_scope',
+  'invalid_token',
+  'missing_credentials',
+]);
+
+const toOutputPermit = (permit: Permit) => ({
+  ...(permit.metadata === undefined
+    ? {}
+    : { metadata: { ...permit.metadata } }),
+  ...(permit.roles === undefined ? {} : { roles: [...permit.roles] }),
+  ...(permit.tenantId === undefined ? {} : { tenantId: permit.tenantId }),
+  id: permit.id,
+  scopes: [...permit.scopes],
+});
+
+const isSurface = (value: unknown): value is PermitExtractionInput['surface'] =>
+  value === 'http' || value === 'mcp' || value === 'cli';
+
+const getSurface = (ctx: TrailContext): PermitExtractionInput['surface'] => {
+  const surface = ctx.extensions?.[SURFACE_KEY];
+  return isSurface(surface) ? surface : 'http';
+};
 
 /**
  * Infrastructure trail that verifies a bearer token and returns the resolved permit.
@@ -18,39 +53,43 @@ export const authVerify = trail('auth.verify', {
     },
   ],
   input: z.object({
-    token: z.string().describe('Bearer token to verify'),
+    token: z.string().min(1).describe('Bearer token to verify'),
   }),
   intent: 'read',
   metadata: { category: 'infrastructure' },
   output: z.object({
     error: z.string().optional(),
-    permit: z
-      .object({
-        id: z.string(),
-        scopes: z.array(z.string()),
-      })
-      .optional(),
+    errorCode: authErrorCodeSchema.optional(),
+    permit: permitSchema.optional(),
     valid: z.boolean(),
   }),
   run: async (input, ctx) => {
     const adapter = authService.from(ctx);
     const result = await adapter.authenticate({
       bearerToken: input.token,
-      requestId: ctx.requestId ?? 'unknown',
-      surface: 'http',
+      requestId: ctx.requestId,
+      surface: getSurface(ctx),
     });
 
     if (result.isErr()) {
-      return Result.ok({ error: result.error.message, valid: false });
+      return Result.ok({
+        error: result.error.message,
+        errorCode: result.error.code,
+        valid: false,
+      });
     }
 
     const permit = result.value;
     if (!permit) {
-      return Result.ok({ error: 'No credentials', valid: false });
+      return Result.ok({
+        error: 'No credentials',
+        errorCode: 'missing_credentials',
+        valid: false,
+      });
     }
 
     return Result.ok({
-      permit: { id: permit.id, scopes: [...permit.scopes] },
+      permit: toOutputPermit(permit),
       valid: true,
     });
   },

--- a/packages/permits/src/trails/auth-verify.ts
+++ b/packages/permits/src/trails/auth-verify.ts
@@ -1,0 +1,58 @@
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { authService } from '../auth-service.js';
+
+/**
+ * Infrastructure trail that verifies a bearer token and returns the resolved permit.
+ *
+ * Reads the auth adapter from `authService` — the adapter is configured at
+ * bootstrap (e.g. JWT with HMAC secret). The mock adapter always succeeds with
+ * a null permit, so `testAll(app)` works without configuration.
+ */
+export const authVerify = trail('auth.verify', {
+  examples: [
+    {
+      input: { token: 'test-token' },
+      name: 'Verify a token',
+    },
+  ],
+  input: z.object({
+    token: z.string().describe('Bearer token to verify'),
+  }),
+  intent: 'read',
+  metadata: { category: 'infrastructure' },
+  output: z.object({
+    error: z.string().optional(),
+    permit: z
+      .object({
+        id: z.string(),
+        scopes: z.array(z.string()),
+      })
+      .optional(),
+    valid: z.boolean(),
+  }),
+  run: async (input, ctx) => {
+    const adapter = authService.from(ctx);
+    const result = await adapter.authenticate({
+      bearerToken: input.token,
+      requestId: ctx.requestId ?? 'unknown',
+      surface: 'http',
+    });
+
+    if (result.isErr()) {
+      return Result.ok({ error: result.error.message, valid: false });
+    }
+
+    const permit = result.value;
+    if (!permit) {
+      return Result.ok({ error: 'No credentials', valid: false });
+    }
+
+    return Result.ok({
+      permit: { id: permit.id, scopes: [...permit.scopes] },
+      valid: true,
+    });
+  },
+  services: [authService],
+});

--- a/packages/permits/tsconfig.json
+++ b/packages/permits/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/packages/testing/src/__tests__/examples.test.ts
+++ b/packages/testing/src/__tests__/examples.test.ts
@@ -437,3 +437,97 @@ describe('testExamples nested follow chain (A → B → C)', () => {
     } as Record<string, unknown>)
   );
 });
+
+// ---------------------------------------------------------------------------
+// Auto-minting permit tests (B3)
+// ---------------------------------------------------------------------------
+
+const scopedTrail = trail('scoped.trail', {
+  description: 'Trail requiring admin scope',
+  examples: [
+    {
+      expected: { ok: true },
+      input: {},
+      name: 'Runs with auto-minted permit',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  permit: { scopes: ['admin'] },
+  run: (_input, ctx) => {
+    // Verify the permit was auto-minted with declared scopes
+    const permit = ctx.permit as
+      | { id: string; scopes: readonly string[] }
+      | undefined;
+    if (!permit || !permit.scopes.includes('admin')) {
+      return Result.err(new Error('Missing permit or scopes'));
+    }
+    return Result.ok({ ok: true });
+  },
+});
+
+const publicTrail = trail('public.trail', {
+  description: 'Public trail — no permit needed',
+  examples: [
+    {
+      expected: { ok: true },
+      input: {},
+      name: 'Runs without a permit',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  permit: 'public',
+  run: (_input, ctx) => {
+    // Public trail should NOT get a permit
+    if (ctx.permit !== undefined) {
+      return Result.err(new Error('Unexpected permit on public trail'));
+    }
+    return Result.ok({ ok: true });
+  },
+});
+
+describe('testExamples auto-minting permits', () => {
+  describe('scoped trail gets auto-minted permit', () => {
+    // eslint-disable-next-line jest/require-hook
+    testExamples(
+      topo('mint-scoped-app', {
+        scopedTrail,
+      } as Record<string, unknown>)
+    );
+  });
+
+  describe('public trail does NOT get a permit', () => {
+    // eslint-disable-next-line jest/require-hook
+    testExamples(
+      topo('mint-public-app', {
+        publicTrail,
+      } as Record<string, unknown>)
+    );
+  });
+
+  describe('strictPermits skips auto-minting', () => {
+    const strictScopedTrail = trail('strict.scoped', {
+      description: 'Trail that expects no permit under strictPermits',
+      examples: [
+        {
+          expected: { hasPermit: false },
+          input: {},
+          name: 'No auto-minted permit when strictPermits is true',
+        },
+      ],
+      input: z.object({}),
+      output: z.object({ hasPermit: z.boolean() }),
+      permit: { scopes: ['admin'] },
+      run: (_input, ctx) => Result.ok({ hasPermit: ctx.permit !== undefined }),
+    });
+
+    // eslint-disable-next-line jest/require-hook
+    testExamples(
+      topo('strict-app', {
+        strictScopedTrail,
+      } as Record<string, unknown>),
+      { strictPermits: true }
+    );
+  });
+});

--- a/packages/testing/src/context.ts
+++ b/packages/testing/src/context.ts
@@ -53,6 +53,20 @@ export interface CreateFollowContextOptions {
   readonly responses?: Record<string, Result<unknown, Error>> | undefined;
 }
 
+/** Minimal permit shape returned by the mint function. */
+export interface MintedPermit {
+  readonly id: string;
+  readonly scopes: readonly string[];
+}
+
+/** Trail shape consumed by the mint function — avoids importing permits. */
+export interface MintableTrail {
+  readonly permit?:
+    | { readonly scopes: readonly string[] }
+    | 'public'
+    | undefined;
+}
+
 export interface TestExecutionOptions {
   readonly ctx?: Partial<TrailContext> | undefined;
   readonly services?: ServiceOverrideMap | undefined;
@@ -61,6 +75,15 @@ export interface TestExecutionOptions {
    * explicit permits.
    */
   readonly strictPermits?: boolean | undefined;
+  /**
+   * Optional function to mint a test permit for a trail. When provided,
+   * called for each trail with a non-public `permit` requirement.
+   * Returning `undefined` skips minting for that trail.
+   *
+   * A default inline implementation is used when this is not provided,
+   * keeping the testing package free of a hard dependency on `@ontrails/permits`.
+   */
+  readonly mintPermit?: (trail: MintableTrail) => MintedPermit | undefined;
 }
 
 /**
@@ -95,11 +118,27 @@ export const createFollowContext = (
   };
 };
 
+/**
+ * Default permit minter — reads `trail.permit.scopes` and produces a
+ * minimal permit object. No dependency on `@ontrails/permits`.
+ */
+export const defaultMintPermit = (
+  trail: MintableTrail
+): MintedPermit | undefined => {
+  if (!trail.permit || trail.permit === 'public') {
+    return undefined;
+  }
+  return { id: 'test-permit', scopes: trail.permit.scopes };
+};
+
 const isTestExecutionOptions = (
   input: Partial<TrailContext> | TestExecutionOptions | undefined
 ): input is TestExecutionOptions =>
   input !== undefined &&
-  (Object.hasOwn(input, 'ctx') || Object.hasOwn(input, 'services'));
+  (Object.hasOwn(input, 'ctx') ||
+    Object.hasOwn(input, 'services') ||
+    Object.hasOwn(input, 'strictPermits') ||
+    Object.hasOwn(input, 'mintPermit'));
 
 export const normalizeTestExecutionOptions = (
   input?: Partial<TrailContext> | TestExecutionOptions

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -45,12 +45,13 @@ import {
   assertSchemaMatch,
 } from './assertions.js';
 import {
+  defaultMintPermit,
   mergeServiceOverrides,
   mergeTestContext,
   normalizeTestExecutionOptions,
   resolveMockServices,
 } from './context.js';
-import type { TestExecutionOptions } from './context.js';
+import type { MintableTrail, TestExecutionOptions } from './context.js';
 
 // ---------------------------------------------------------------------------
 // Error class name -> constructor map
@@ -128,6 +129,29 @@ const handleValidationError = (
 };
 
 /**
+ * Apply auto-minting: if the trail declares scoped permits and the context
+ * doesn't already have a permit, mint one and merge it into the context.
+ */
+const applyAutoMint = (
+  ctx: TrailContext,
+  trailDef: MintableTrail,
+  opts: TestExecutionOptions
+): TrailContext => {
+  if (opts.strictPermits) {
+    return ctx;
+  }
+  if (ctx.permit !== undefined) {
+    return ctx;
+  }
+  const mint = opts.mintPermit ?? defaultMintPermit;
+  const permit = mint(trailDef);
+  if (!permit) {
+    return ctx;
+  }
+  return { ...ctx, permit };
+};
+
+/**
  * Run a single example against a trail.
  * Handles validation, execution, and assertions.
  */
@@ -136,7 +160,8 @@ const runExample = async (
   example: TrailExample<unknown, unknown>,
   output: z.ZodType | undefined,
   testCtx: TrailContext,
-  services?: ServiceOverrideMap
+  services?: ServiceOverrideMap,
+  opts?: TestExecutionOptions
 ): Promise<void> => {
   const validated = validateInput(t.input, example.input);
 
@@ -144,8 +169,10 @@ const runExample = async (
     return;
   }
 
+  const ctx = opts ? applyAutoMint(testCtx, t, opts) : testCtx;
+
   const result = await executeTrail(t, example.input, {
-    ctx: testCtx,
+    ctx,
     services,
   });
   assertProgressiveMatch(result, example, output);
@@ -199,7 +226,8 @@ const runCompositionExample = async (
   baseCtx: TrailContext,
   called: Set<string>,
   topo: Topo,
-  services?: ServiceOverrideMap
+  services?: ServiceOverrideMap,
+  opts?: TestExecutionOptions
 ): Promise<void> => {
   const validated = validateInput(trailDef.input, example.input);
 
@@ -207,14 +235,15 @@ const runCompositionExample = async (
     return;
   }
 
+  const mintedCtx = opts ? applyAutoMint(baseCtx, trailDef, opts) : baseCtx;
   const follow = createCoverageFollow(
     called,
-    baseCtx.follow,
+    mintedCtx.follow,
     topo,
-    baseCtx,
+    mintedCtx,
     services
   );
-  const testCtx: TrailContext = { ...baseCtx, follow };
+  const testCtx: TrailContext = { ...mintedCtx, follow };
 
   const result = await executeTrail(trailDef, example.input, {
     ctx: testCtx,
@@ -273,7 +302,7 @@ export const testExamples = (
             resolved.services
           );
           const testCtx = mergeTestContext(resolved.ctx);
-          await runExample(t, example, output, testCtx, services);
+          await runExample(t, example, output, testCtx, services, resolved);
         }
       );
     });
@@ -306,7 +335,8 @@ export const testExamples = (
             baseCtx,
             called,
             app,
-            services
+            services,
+            resolved
           );
         }
       );

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -16,7 +16,11 @@ export {
 } from './assertions.js';
 
 // Mock factories
-export { createFollowContext, createTestContext } from './context.js';
+export {
+  createFollowContext,
+  createTestContext,
+  defaultMintPermit,
+} from './context.js';
 export { createTestLogger } from './logger.js';
 
 // Surface harnesses
@@ -25,7 +29,11 @@ export { createMcpHarness } from './harness-mcp.js';
 
 // Types
 export type { CreateFollowContextOptions } from './context.js';
-export type { TestExecutionOptions } from './context.js';
+export type {
+  MintableTrail,
+  MintedPermit,
+  TestExecutionOptions,
+} from './context.js';
 export type { TestFollowOptions } from './follows.js';
 
 export type {

--- a/packages/tracks/package.json
+++ b/packages/tracks/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@ontrails/tracks",
+  "version": "1.0.0-beta.11",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./otel": "./src/adapters/otel.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@ontrails/core": "workspace:^",
+    "zod": "catalog:"
+  }
+}

--- a/packages/tracks/src/__tests__/dev-store.test.ts
+++ b/packages/tracks/src/__tests__/dev-store.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { TrackRecord } from '../record.js';
+import type { DevStore } from '../stores/dev.js';
+import { createDevStore } from '../stores/dev.js';
+
+/** Build a minimal TrackRecord for testing. */
+const makeRecord = (overrides?: Partial<TrackRecord>): TrackRecord => ({
+  attrs: {},
+  endedAt: Date.now(),
+  id: `rec-${crypto.randomUUID()}`,
+  kind: 'trail',
+  name: 'test-trail',
+  rootId: 'root-1',
+  startedAt: Date.now() - 100,
+  status: 'ok',
+  traceId: 'trace-1',
+  trailId: 'test-trail',
+  ...overrides,
+});
+
+describe('createDevStore', () => {
+  let tmpDir: string;
+  let store: DevStore | undefined;
+
+  const makeTmpDir = (): string => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'dev-store-'));
+    return tmpDir;
+  };
+
+  afterEach(() => {
+    store?.close();
+    store = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { force: true, recursive: true });
+    }
+  });
+
+  describe('lifecycle', () => {
+    test('creates a database file at the specified path', () => {
+      const dir = makeTmpDir();
+      const dbPath = join(dir, 'tracks.db');
+
+      store = createDevStore({ path: dbPath });
+
+      expect(existsSync(dbPath)).toBe(true);
+    });
+
+    test('close() closes the database connection', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+      store.write(makeRecord());
+
+      store.close();
+
+      // Querying after close should throw
+      expect(() => store?.query()).toThrow();
+      /* Prevent double-close in afterEach */
+      store = undefined;
+    });
+  });
+
+  describe('write()', () => {
+    test('persists a TrackRecord', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+      const record = makeRecord();
+
+      store.write(record);
+      const results = store.query();
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.id).toBe(record.id);
+      expect(results[0]?.name).toBe('test-trail');
+    });
+
+    test('persists attrs as JSON', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+      const record = makeRecord({ attrs: { count: 42, key: 'value' } });
+
+      store.write(record);
+      const results = store.query();
+
+      expect(results[0]?.attrs).toEqual({ count: 42, key: 'value' });
+    });
+
+    test('persists permit fields', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+      const record = makeRecord({
+        permit: { id: 'permit-1', tenantId: 'tenant-1' },
+      });
+
+      store.write(record);
+      const results = store.query();
+
+      expect(results[0]?.permit).toEqual({
+        id: 'permit-1',
+        tenantId: 'tenant-1',
+      });
+    });
+
+    test('upserts duplicate record ids instead of throwing', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      store.write(makeRecord({ id: 'dup', name: 'first' }));
+      store.write(makeRecord({ id: 'dup', name: 'updated' }));
+
+      const results = store.query();
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('updated');
+    });
+  });
+
+  describe('query()', () => {
+    test('returns persisted records ordered by startedAt descending', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      const older = makeRecord({
+        id: 'rec-old',
+        name: 'first',
+        startedAt: 1000,
+      });
+      const newer = makeRecord({
+        id: 'rec-new',
+        name: 'second',
+        startedAt: 2000,
+      });
+
+      store.write(older);
+      store.write(newer);
+      const results = store.query();
+
+      expect(results).toHaveLength(2);
+      expect(results[0]?.id).toBe('rec-new');
+      expect(results[1]?.id).toBe('rec-old');
+    });
+
+    test('filters by trailId', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      store.write(makeRecord({ id: 'a', trailId: 'users.list' }));
+      store.write(makeRecord({ id: 'b', trailId: 'users.get' }));
+      store.write(makeRecord({ id: 'c', trailId: 'users.list' }));
+
+      const results = store.query({ trailId: 'users.list' });
+
+      expect(results).toHaveLength(2);
+      expect(results.every((r) => r.trailId === 'users.list')).toBe(true);
+    });
+
+    test('filters by traceId', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      store.write(makeRecord({ id: 'a', traceId: 'trace-abc' }));
+      store.write(makeRecord({ id: 'b', traceId: 'trace-xyz' }));
+
+      const results = store.query({ traceId: 'trace-abc' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.traceId).toBe('trace-abc');
+    });
+
+    test('filters by errorsOnly', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      store.write(makeRecord({ id: 'ok-1', status: 'ok' }));
+      store.write(
+        makeRecord({
+          errorCategory: 'NotFoundError',
+          id: 'err-1',
+          status: 'err',
+        })
+      );
+      store.write(makeRecord({ id: 'ok-2', status: 'ok' }));
+
+      const results = store.query({ errorsOnly: true });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.status).toBe('err');
+    });
+
+    test('limits results', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({ path: join(dir, 'tracks.db') });
+
+      for (let i = 0; i < 10; i += 1) {
+        store.write(makeRecord({ id: `rec-${String(i)}` }));
+      }
+
+      const results = store.query({ limit: 5 });
+
+      expect(results).toHaveLength(5);
+    });
+  });
+
+  describe('retention', () => {
+    test('enforces maxRecords by pruning oldest entries', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({
+        maxRecords: 5,
+        path: join(dir, 'tracks.db'),
+      });
+
+      for (let i = 0; i < 8; i += 1) {
+        store.write(
+          makeRecord({ id: `rec-${String(i)}`, startedAt: 1000 + i })
+        );
+      }
+
+      const results = store.query();
+
+      expect(results.length).toBeLessThanOrEqual(5);
+    });
+
+    test('prunes records older than maxAge', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({
+        maxAge: 1000,
+        path: join(dir, 'tracks.db'),
+      });
+
+      store.write(makeRecord({ id: 'old', startedAt: Date.now() - 5000 }));
+      store.write(makeRecord({ id: 'fresh', startedAt: Date.now() }));
+
+      const results = store.query();
+      expect(results).toHaveLength(1);
+      expect(results[0]?.id).toBe('fresh');
+    });
+  });
+
+  describe('count()', () => {
+    test('returns the number of retained records', () => {
+      const dir = makeTmpDir();
+      store = createDevStore({
+        maxRecords: 2,
+        path: join(dir, 'tracks.db'),
+      });
+
+      store.write(makeRecord({ id: 'a', startedAt: 1000 }));
+      store.write(makeRecord({ id: 'b', startedAt: 2000 }));
+      store.write(makeRecord({ id: 'c', startedAt: 3000 }));
+
+      expect(store.count()).toBe(2);
+      expect(store.query()).toHaveLength(2);
+    });
+  });
+});

--- a/packages/tracks/src/__tests__/otel-adapter.test.ts
+++ b/packages/tracks/src/__tests__/otel-adapter.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { TrackRecord } from '../record.js';
+import { createOtelAdapter } from '../adapters/otel.js';
+import type { OtelSpan } from '../adapters/otel.js';
+
+/** Build a minimal TrackRecord for testing with sensible defaults. */
+const makeRecord = (overrides: Partial<TrackRecord> = {}): TrackRecord => ({
+  attrs: {},
+  endedAt: 1000,
+  id: 'span-1',
+  kind: 'trail',
+  name: 'test.echo',
+  rootId: 'root-1',
+  startedAt: 0,
+  status: 'ok',
+  traceId: 'trace-1',
+  ...overrides,
+});
+
+describe('otelAdapter', () => {
+  describe('attribute mapping', () => {
+    test('maps trailId to attributes["trails.trail.id"]', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ trailId: 'greet' }));
+
+      expect(spans).toHaveLength(1);
+      expect(spans[0]?.attributes['trails.trail.id']).toBe('greet');
+    });
+
+    test('maps intent to attributes["trails.intent"]', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ intent: 'write' }));
+
+      expect(spans[0]?.attributes['trails.intent']).toBe('write');
+    });
+
+    test('maps surface to attributes["trails.surface"]', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ surface: 'mcp' }));
+
+      expect(spans[0]?.attributes['trails.surface']).toBe('mcp');
+    });
+
+    test('maps permit.id to attributes["trails.permit.id"]', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({ permit: { id: 'p-1', tenantId: 't-1' } })
+      );
+
+      expect(spans[0]?.attributes['trails.permit.id']).toBe('p-1');
+      expect(spans[0]?.attributes['trails.permit.tenant_id']).toBe('t-1');
+    });
+
+    test('omits undefined attributes', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({
+          intent: undefined,
+          surface: undefined,
+          trailId: undefined,
+        })
+      );
+
+      expect(spans).toHaveLength(1);
+      const keys = Object.keys(spans[0].attributes);
+      expect(keys).not.toContain('trails.trail.id');
+      expect(keys).not.toContain('trails.intent');
+      expect(keys).not.toContain('trails.surface');
+    });
+
+    test('forwards OTel-safe custom attributes', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({
+          attrs: {
+            'db.operation': 'select',
+            'http.status_code': 200,
+            sampled: true,
+            skipped: { nested: true },
+          },
+        })
+      );
+
+      expect(spans[0]?.attributes['db.operation']).toBe('select');
+      expect(spans[0]?.attributes['http.status_code']).toBe(200);
+      expect(spans[0]?.attributes.sampled).toBe(true);
+      expect(spans[0]?.attributes.skipped).toBeUndefined();
+    });
+  });
+
+  describe('status mapping', () => {
+    test('maps status "ok" to OTel "OK"', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ status: 'ok' }));
+
+      expect(spans[0]?.status).toBe('OK');
+    });
+
+    test('maps status "err" to OTel "ERROR"', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ status: 'err' }));
+
+      expect(spans[0]?.status).toBe('ERROR');
+    });
+
+    test('maps status "cancelled" to OTel "UNSET"', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ status: 'cancelled' }));
+
+      expect(spans[0]?.status).toBe('UNSET');
+    });
+  });
+
+  describe('kind mapping', () => {
+    test('root trail (no parentId) gets kind "SERVER"', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ parentId: undefined }));
+
+      expect(spans[0]?.kind).toBe('SERVER');
+    });
+
+    test('child trail (has parentId) gets kind "INTERNAL"', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(makeRecord({ parentId: 'parent-1' }));
+
+      expect(spans[0]?.kind).toBe('INTERNAL');
+    });
+  });
+
+  describe('exporter integration', () => {
+    test('calls exporter with translated spans', async () => {
+      let exportedSpans: readonly OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          exportedSpans = s;
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-42', traceId: 'trace-42' }));
+
+      expect(exportedSpans).toHaveLength(1);
+      expect(exportedSpans[0]?.spanId).toBe('span-42');
+      expect(exportedSpans[0]?.traceId).toBe('trace-42');
+    });
+  });
+
+  describe('flush', () => {
+    test('sends buffered spans that have not yet reached batchSize', async () => {
+      const exported: OtelSpan[][] = [];
+      const adapter = createOtelAdapter({
+        batchSize: 5,
+        exporter: (s) => {
+          exported.push([...s]);
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await adapter.write(makeRecord({ id: 'span-b' }));
+
+      // Not yet exported because batchSize is 5
+      expect(exported).toHaveLength(0);
+
+      await adapter.flush();
+
+      expect(exported).toHaveLength(1);
+      expect(exported[0]).toHaveLength(2);
+      expect(exported[0]?.[0]?.spanId).toBe('span-a');
+      expect(exported[0]?.[1]?.spanId).toBe('span-b');
+    });
+
+    test('auto-flushes when batchSize is reached', async () => {
+      const exported: OtelSpan[][] = [];
+      const adapter = createOtelAdapter({
+        batchSize: 3,
+        exporter: (s) => {
+          exported.push([...s]);
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await adapter.write(makeRecord({ id: 'span-b' }));
+
+      // Two writes — still buffered
+      expect(exported).toHaveLength(0);
+
+      await adapter.write(makeRecord({ id: 'span-c' }));
+
+      // Third write reaches batchSize=3, exporter must have been called
+      expect(exported).toHaveLength(1);
+      expect(exported[0]).toHaveLength(3);
+    });
+
+    test('rethrows exporter failures and restores the buffer', async () => {
+      let shouldFail = true;
+      const exported: OtelSpan[][] = [];
+      const adapter = createOtelAdapter({
+        batchSize: 2,
+        exporter: (s) => {
+          // eslint-disable-next-line jest/no-conditional-in-test -- testing retry behavior requires toggling exporter success
+          const fail = shouldFail;
+          shouldFail = false;
+          // eslint-disable-next-line jest/no-conditional-in-test
+          if (fail) {
+            throw new Error('exporter down');
+          }
+          exported.push([...s]);
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await expect(adapter.write(makeRecord({ id: 'span-b' }))).rejects.toThrow(
+        'exporter down'
+      );
+
+      // First flush failed — spans should still be buffered
+      expect(exported).toHaveLength(0);
+
+      // Manual flush retries and succeeds
+      await adapter.flush();
+      expect(exported).toHaveLength(1);
+      expect(exported[0]).toHaveLength(2);
+    });
+
+    test('is a no-op when buffer is empty', async () => {
+      let called = false;
+      const adapter = createOtelAdapter({
+        exporter: () => {
+          called = true;
+        },
+      });
+
+      await adapter.flush();
+
+      expect(called).toBe(false);
+    });
+  });
+});

--- a/packages/tracks/src/__tests__/record.test.ts
+++ b/packages/tracks/src/__tests__/record.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createTrackRecord } from '../record.js';
+
+describe('createTrackRecord', () => {
+  test('generates unique id and traceId', () => {
+    const a = createTrackRecord({ trailId: 'test.trail' });
+    const b = createTrackRecord({ trailId: 'test.trail' });
+
+    expect(a.id).toBeString();
+    expect(a.traceId).toBeString();
+    expect(a.id).not.toBe(b.id);
+    expect(a.traceId).not.toBe(b.traceId);
+  });
+
+  test('uses provided traceId when given', () => {
+    const record = createTrackRecord({
+      traceId: 'trace-abc',
+      trailId: 'test.trail',
+    });
+
+    expect(record.traceId).toBe('trace-abc');
+  });
+
+  test('uses provided rootId when given', () => {
+    const record = createTrackRecord({
+      rootId: 'root-abc',
+      trailId: 'test.trail',
+    });
+
+    expect(record.rootId).toBe('root-abc');
+  });
+
+  test('sets startedAt to current time', () => {
+    const before = Date.now();
+    const record = createTrackRecord({ trailId: 'test.trail' });
+    const after = Date.now();
+
+    expect(record.startedAt).toBeGreaterThanOrEqual(before);
+    expect(record.startedAt).toBeLessThanOrEqual(after);
+  });
+
+  test('sets status to ok initially', () => {
+    const record = createTrackRecord({ trailId: 'test.trail' });
+
+    expect(record.status).toBe('ok');
+  });
+
+  test('includes trailId, intent, and surface when provided', () => {
+    const record = createTrackRecord({
+      intent: 'write',
+      surface: 'mcp',
+      trailId: 'widget.create',
+    });
+
+    expect(record.trailId).toBe('widget.create');
+    expect(record.surface).toBe('mcp');
+    expect(record.intent).toBe('write');
+    expect(record.kind).toBe('trail');
+    expect(record.name).toBe('widget.create');
+  });
+});

--- a/packages/tracks/src/__tests__/sampling.test.ts
+++ b/packages/tracks/src/__tests__/sampling.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { DEFAULT_SAMPLING, shouldSample } from '../sampling.js';
+
+type Intent = 'read' | 'write' | 'destroy' | undefined;
+
+describe('DEFAULT_SAMPLING', () => {
+  test('read defaults to 0.05', () => {
+    expect(DEFAULT_SAMPLING.read).toBe(0.05);
+  });
+
+  test('write defaults to 1', () => {
+    expect(DEFAULT_SAMPLING.write).toBe(1);
+  });
+
+  test('destroy defaults to 1', () => {
+    expect(DEFAULT_SAMPLING.destroy).toBe(1);
+  });
+});
+
+describe('shouldSample', () => {
+  const originalRandom = Math.random;
+
+  afterEach(() => {
+    Math.random = originalRandom;
+  });
+
+  test('write intent defaults to 100% sampled', () => {
+    Math.random = () => 0.99;
+    expect(shouldSample('write')).toBe(true);
+  });
+
+  test('destroy intent defaults to 100% sampled', () => {
+    Math.random = () => 0.99;
+    expect(shouldSample('destroy')).toBe(true);
+  });
+
+  test('read intent with random 0.01 is sampled (under 5%)', () => {
+    Math.random = () => 0.01;
+    expect(shouldSample('read')).toBe(true);
+  });
+
+  test('read intent with random 0.10 is not sampled (over 5%)', () => {
+    Math.random = () => 0.1;
+    expect(shouldSample('read')).toBe(false);
+  });
+
+  test('custom sampling config overrides defaults', () => {
+    Math.random = () => 0.49;
+    expect(shouldSample('read', { read: 0.5 })).toBe(true);
+
+    Math.random = () => 0.51;
+    expect(shouldSample('read', { read: 0.5 })).toBe(false);
+  });
+
+  test('falls back to write rate for unspecified intent', () => {
+    Math.random = () => 0.99;
+    const noIntent: Intent = undefined;
+    expect(shouldSample(noIntent)).toBe(true);
+  });
+});

--- a/packages/tracks/src/__tests__/trace-context.test.ts
+++ b/packages/tracks/src/__tests__/trace-context.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  TRACE_CONTEXT_KEY,
+  childTraceContext,
+  getTraceContext,
+} from '../trace-context.js';
+import type { TraceContext } from '../trace-context.js';
+
+describe('getTraceContext', () => {
+  test('returns undefined when no extensions', () => {
+    const ctx = {};
+    expect(getTraceContext(ctx)).toBeUndefined();
+  });
+
+  test('returns undefined when key is absent from extensions', () => {
+    const ctx = { extensions: { other: 'value' } };
+    expect(getTraceContext(ctx)).toBeUndefined();
+  });
+
+  test('returns context when present in extensions', () => {
+    const trace: TraceContext = {
+      rootId: 'span-1',
+      sampled: true,
+      spanId: 'span-1',
+      traceId: 'trace-1',
+    };
+    const ctx = { extensions: { [TRACE_CONTEXT_KEY]: trace } };
+
+    expect(getTraceContext(ctx)).toEqual(trace);
+  });
+});
+
+describe('childTraceContext', () => {
+  test('inherits traceId from parent', () => {
+    const parent: TraceContext = {
+      rootId: 'root-span',
+      sampled: true,
+      spanId: 'parent-span',
+      traceId: 'trace-abc',
+    };
+    const child = childTraceContext(parent);
+
+    expect(child.traceId).toBe('trace-abc');
+  });
+
+  test('generates a new spanId', () => {
+    const parent: TraceContext = {
+      rootId: 'root-span',
+      sampled: true,
+      spanId: 'parent-span',
+      traceId: 'trace-abc',
+    };
+    const child = childTraceContext(parent);
+
+    expect(child.spanId).toBeString();
+    expect(child.spanId).not.toBe(parent.spanId);
+  });
+
+  test('inherits sampled flag', () => {
+    const sampledParent: TraceContext = {
+      rootId: 'span-1',
+      sampled: true,
+      spanId: 'span-1',
+      traceId: 'trace-1',
+    };
+    const unsampledParent: TraceContext = {
+      rootId: 'span-2',
+      sampled: false,
+      spanId: 'span-2',
+      traceId: 'trace-2',
+    };
+
+    expect(childTraceContext(sampledParent).sampled).toBe(true);
+    expect(childTraceContext(unsampledParent).sampled).toBe(false);
+  });
+
+  test('inherits rootId from parent (not spanId)', () => {
+    const parent: TraceContext = {
+      rootId: 'the-root',
+      sampled: true,
+      spanId: 'parent-span',
+      traceId: 'trace-abc',
+    };
+    const child = childTraceContext(parent);
+
+    expect(child.rootId).toBe('the-root');
+    expect(child.rootId).not.toBe(child.spanId);
+  });
+});

--- a/packages/tracks/src/__tests__/tracks-api.test.ts
+++ b/packages/tracks/src/__tests__/tracks-api.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createMemorySink } from '../memory-sink.js';
+import { TRACE_CONTEXT_KEY } from '../trace-context.js';
+import type { TraceContext } from '../trace-context.js';
+import { createTracksApi } from '../tracks-api.js';
+
+/** Build a stub ctx with trace context in extensions. */
+const makeCtx = (
+  overrides?: Partial<TraceContext>
+): { readonly extensions: Readonly<Record<string, unknown>> } => {
+  const trace: TraceContext = {
+    rootId: 'root-span-id',
+    sampled: true,
+    spanId: 'parent-span-id',
+    traceId: 'test-trace-id',
+    ...overrides,
+  };
+
+  return { extensions: { [TRACE_CONTEXT_KEY]: trace } };
+};
+
+describe('createTracksApi', () => {
+  describe('span()', () => {
+    test('creates a child record in the sink', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      await api.span('my-span', () => 'done');
+
+      expect(sink.records).toHaveLength(1);
+      const [record] = sink.records;
+      expect(record?.kind).toBe('span');
+      expect(record?.name).toBe('my-span');
+      expect(record?.traceId).toBe('test-trace-id');
+      expect(record?.parentId).toBe('parent-span-id');
+      expect(record?.rootId).toBe('root-span-id');
+    });
+
+    test('returns the callback result', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      const result = await api.span('op', () => 42);
+
+      expect(result).toBe(42);
+    });
+
+    test('returns the async callback result', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      const result = await api.span('async-op', () =>
+        Promise.resolve('async-value')
+      );
+
+      expect(result).toBe('async-value');
+    });
+
+    test('times the execution (endedAt >= startedAt)', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      await api.span('timed', () => 'ok');
+
+      const [record] = sink.records;
+      expect(record?.startedAt).toBeNumber();
+      expect(record?.endedAt).toBeNumber();
+      expect(Number(record?.endedAt)).toBeGreaterThanOrEqual(
+        Number(record?.startedAt)
+      );
+    });
+
+    test('marks record as err when callback throws', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      try {
+        await api.span('failing', () => {
+          throw new Error('boom');
+        });
+      } catch {
+        // expected
+      }
+
+      expect(sink.records).toHaveLength(1);
+      expect(sink.records[0]?.status).toBe('err');
+    });
+
+    test('re-throws the callback error after recording', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      await expect(
+        api.span('failing', () => {
+          throw new Error('boom');
+        })
+      ).rejects.toThrow('boom');
+
+      expect(sink.records).toHaveLength(1);
+    });
+
+    test('multiple spans create independent records', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      await api.span('first', () => 1);
+      await api.span('second', () => 2);
+
+      expect(sink.records).toHaveLength(2);
+      expect(sink.records[0]?.name).toBe('first');
+      expect(sink.records[1]?.name).toBe('second');
+      expect(sink.records[0]?.id).not.toBe(sink.records[1]?.id);
+    });
+
+    test('skips sink writes when trace sampling is disabled', async () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx({ sampled: false }), sink);
+
+      const result = await api.span('unsampled', () => 'done');
+
+      expect(result).toBe('done');
+      expect(sink.records).toHaveLength(0);
+    });
+  });
+
+  describe('annotate()', () => {
+    test('collects attributes without throwing', () => {
+      const sink = createMemorySink();
+      const { api } = createTracksApi(makeCtx(), sink);
+
+      expect(() => api.annotate({ count: 42, key: 'value' })).not.toThrow();
+    });
+
+    test('getAnnotations returns merged attrs from annotate calls', () => {
+      const sink = createMemorySink();
+      const { api, getAnnotations } = createTracksApi(makeCtx(), sink);
+
+      api.annotate({ first: 1 });
+      api.annotate({ second: 2 });
+
+      expect(getAnnotations()).toEqual({ first: 1, second: 2 });
+    });
+
+    test('getAnnotations returns empty object when no annotations', () => {
+      const sink = createMemorySink();
+      const { getAnnotations } = createTracksApi(makeCtx(), sink);
+
+      expect(getAnnotations()).toEqual({});
+    });
+
+    test('later annotations override earlier ones with same key', () => {
+      const sink = createMemorySink();
+      const { api, getAnnotations } = createTracksApi(makeCtx(), sink);
+
+      api.annotate({ key: 'old' });
+      api.annotate({ key: 'new' });
+
+      expect(getAnnotations()).toEqual({ key: 'new' });
+    });
+  });
+});

--- a/packages/tracks/src/__tests__/tracks-layer.test.ts
+++ b/packages/tracks/src/__tests__/tracks-layer.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import {
+  CancelledError,
+  Result,
+  SURFACE_KEY,
+  createTrailContext,
+  trail,
+} from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+
+import { createMemorySink } from '../memory-sink.js';
+import { createTracksLayer } from '../tracks-layer.js';
+
+const stubCtx: TrailContext = createTrailContext({
+  requestId: 'test-tracks',
+  signal: AbortSignal.timeout(5000),
+});
+
+const echoTrail = trail('echo', {
+  input: z.object({ value: z.string() }),
+  intent: 'read',
+  output: z.object({ value: z.string() }),
+  run: (input) => Result.ok({ value: input.value }),
+});
+
+const failTrail = trail('fail', {
+  input: z.object({}),
+  output: z.object({ value: z.string() }),
+  run: () => Result.err(new Error('boom')),
+});
+
+// oxlint-disable max-statements -- integration tests with setup + assertions
+describe('tracksLayer', () => {
+  test('records a successful trail execution', async () => {
+    const sink = createMemorySink();
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+    const result = await wrapped({ value: 'hello' }, stubCtx);
+
+    expect(result.isOk()).toBe(true);
+    expect(sink.records).toHaveLength(1);
+    expect(sink.records[0]?.status).toBe('ok');
+  });
+
+  test('records status err on failure', async () => {
+    const sink = createMemorySink();
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(failTrail, failTrail.run);
+
+    const result = await wrapped({}, stubCtx);
+
+    expect(result.isErr()).toBe(true);
+    expect(sink.records).toHaveLength(1);
+    expect(sink.records[0]?.status).toBe('err');
+  });
+
+  test('captures timing (endedAt > startedAt)', async () => {
+    const sink = createMemorySink();
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+    await wrapped({ value: 'hello' }, stubCtx);
+
+    expect(sink.records).toHaveLength(1);
+    const [record] = sink.records;
+    expect(record?.endedAt).toBeNumber();
+    expect(record?.startedAt).toBeNumber();
+    expect(Number(record?.endedAt)).toBeGreaterThanOrEqual(
+      Number(record?.startedAt)
+    );
+  });
+
+  test('records trailId and intent from the trail', async () => {
+    const sink = createMemorySink();
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+    await wrapped({ value: 'hello' }, stubCtx);
+
+    const [record] = sink.records;
+    expect(record?.trailId).toBe('echo');
+    expect(record?.intent).toBe('read');
+  });
+
+  test('writes to the provided sink', async () => {
+    const sink = createMemorySink();
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+    await wrapped({ value: 'a' }, stubCtx);
+    await wrapped({ value: 'b' }, stubCtx);
+
+    expect(sink.records).toHaveLength(2);
+    expect(sink.records[0]?.id).not.toBe(sink.records[1]?.id);
+  });
+
+  test('captures the invoking surface from ctx.extensions', async () => {
+    const sink = createMemorySink();
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+    const ctxWithSurface: TrailContext = {
+      ...stubCtx,
+      extensions: {
+        ...stubCtx.extensions,
+        [SURFACE_KEY]: 'http',
+      },
+    };
+
+    await wrapped({ value: 'hello' }, ctxWithSurface);
+
+    expect(sink.records[0]?.surface).toBe('http');
+  });
+
+  test('records thrown implementations as err results', async () => {
+    const sink = createMemorySink();
+    const throwingTrail = trail('throwing', {
+      input: z.object({}),
+      output: z.object({ value: z.string() }),
+      run: () => {
+        throw new Error('explode');
+      },
+    });
+
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(throwingTrail, throwingTrail.run);
+    const result = await wrapped({}, stubCtx);
+
+    expect(result.isErr()).toBe(true);
+    expect(sink.records).toHaveLength(1);
+    expect(sink.records[0]?.status).toBe('err');
+    expect(sink.records[0]?.errorCategory).toBe('internal');
+  });
+
+  test('maps cancelled errors to cancelled status and category', async () => {
+    const sink = createMemorySink();
+    const cancelledTrail = trail('cancelled', {
+      input: z.object({}),
+      output: z.object({ value: z.string() }),
+      run: () => Result.err(new CancelledError('stop')),
+    });
+
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(cancelledTrail, cancelledTrail.run);
+    const result = await wrapped({}, stubCtx);
+
+    expect(result.isErr()).toBe(true);
+    expect(sink.records).toHaveLength(1);
+    expect(sink.records[0]?.status).toBe('cancelled');
+    expect(sink.records[0]?.errorCategory).toBe('cancelled');
+  });
+});

--- a/packages/tracks/src/__tests__/tracks-layer.test.ts
+++ b/packages/tracks/src/__tests__/tracks-layer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 
 import { z } from 'zod';
 
@@ -12,6 +12,8 @@ import {
 import type { TrailContext } from '@ontrails/core';
 
 import { createMemorySink } from '../memory-sink.js';
+import { getTraceContext, TRACE_CONTEXT_KEY } from '../trace-context.js';
+import type { TraceContext } from '../trace-context.js';
 import { createTracksLayer } from '../tracks-layer.js';
 
 const stubCtx: TrailContext = createTrailContext({
@@ -98,22 +100,195 @@ describe('tracksLayer', () => {
     expect(sink.records[0]?.id).not.toBe(sink.records[1]?.id);
   });
 
-  test('captures the invoking surface from ctx.extensions', async () => {
-    const sink = createMemorySink();
-    const layer = createTracksLayer(sink);
+  describe('trace context propagation', () => {
+    test('creates root trace context for root invocations', async () => {
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink);
+      const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+      await wrapped({ value: 'hello' }, stubCtx);
+
+      const [record] = sink.records;
+      expect(record?.traceId).toBeString();
+      expect(record?.traceId.length).toBeGreaterThan(0);
+    });
+
+    test('injects trace context into ctx.extensions for child trails', async () => {
+      let capturedTrace: TraceContext | undefined;
+      const capturingTrail = trail('capture', {
+        input: z.object({}),
+        output: z.object({}),
+        run: (_input, ctx) => {
+          capturedTrace = getTraceContext(ctx as TrailContext);
+          return Result.ok({});
+        },
+      });
+
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink);
+      const wrapped = layer.wrap(capturingTrail, capturingTrail.run);
+
+      await wrapped({}, stubCtx);
+
+      expect(capturedTrace).toBeDefined();
+      expect(capturedTrace?.traceId).toBeString();
+      expect(capturedTrace?.spanId).toBeString();
+      expect(capturedTrace?.sampled).toBe(true);
+    });
+
+    test('child invocation inherits parent traceId and links to parent record id', async () => {
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink);
+
+      const childTrail = trail('child', {
+        input: z.object({}),
+        output: z.object({}),
+        run: () => Result.ok({}),
+      });
+
+      let capturedTrace: TraceContext | undefined;
+      const rootTrail = trail('root', {
+        input: z.object({}),
+        output: z.object({}),
+        run: (_input, ctx) => {
+          capturedTrace = getTraceContext(ctx as TrailContext);
+          return Result.ok({});
+        },
+      });
+
+      const wrappedRoot = layer.wrap(rootTrail, rootTrail.run);
+      await wrappedRoot({}, stubCtx);
+
+      const ctxWithTrace: TrailContext = {
+        ...stubCtx,
+        extensions: {
+          ...stubCtx.extensions,
+          [TRACE_CONTEXT_KEY]: capturedTrace,
+        },
+      };
+
+      const wrappedChild = layer.wrap(childTrail, childTrail.run);
+      await wrappedChild({}, ctxWithTrace);
+
+      const [rootRecord, childRecord] = sink.records;
+      expect(childRecord?.traceId).toBe(rootRecord?.traceId);
+      expect(childRecord?.parentId).toBe(rootRecord?.id);
+      expect(childRecord?.rootId).toBe(rootRecord?.id);
+    });
+  });
+
+  describe('permit capture', () => {
+    test('captures permit from ctx when present', async () => {
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink);
+      const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+      const ctxWithPermit: TrailContext = {
+        ...stubCtx,
+        permit: { id: 'permit-1', tenantId: 'tenant-abc' },
+      };
+
+      await wrapped({ value: 'hello' }, ctxWithPermit);
+
+      expect(sink.records[0]?.permit).toEqual({
+        id: 'permit-1',
+        tenantId: 'tenant-abc',
+      });
+    });
+  });
+
+  describe('surface capture', () => {
+    test('captures the invoking surface from ctx.extensions', async () => {
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink);
+      const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+      const ctxWithSurface: TrailContext = {
+        ...stubCtx,
+        extensions: {
+          ...stubCtx.extensions,
+          [SURFACE_KEY]: 'http',
+        },
+      };
+
+      await wrapped({ value: 'hello' }, ctxWithSurface);
+
+      expect(sink.records[0]?.surface).toBe('http');
+    });
+  });
+
+  test('keeps trail result delivery when onSinkError throws', async () => {
+    const layer = createTracksLayer(
+      {
+        write: async () => {
+          throw new Error('sink down');
+        },
+      },
+      {
+        onSinkError: () => {
+          throw new Error('observer down');
+        },
+      }
+    );
     const wrapped = layer.wrap(echoTrail, echoTrail.run);
 
-    const ctxWithSurface: TrailContext = {
-      ...stubCtx,
-      extensions: {
-        ...stubCtx.extensions,
-        [SURFACE_KEY]: 'http',
-      },
-    };
+    const result = await wrapped({ value: 'hello' }, stubCtx);
 
-    await wrapped({ value: 'hello' }, ctxWithSurface);
+    expect(result.isOk()).toBe(true);
+  });
 
-    expect(sink.records[0]?.surface).toBe('http');
+  describe('sampling', () => {
+    const originalRandom = Math.random;
+
+    afterEach(() => {
+      Math.random = originalRandom;
+    });
+
+    test('sampled-out read trails are NOT written to sink', async () => {
+      Math.random = () => 0.99;
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink, { sampling: { read: 0.05 } });
+      const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+      const result = await wrapped({ value: 'hello' }, stubCtx);
+
+      expect(result.isOk()).toBe(true);
+      expect(sink.records).toHaveLength(0);
+    });
+
+    test('error promotion writes sampled-out failing trails', async () => {
+      Math.random = () => 0.99;
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink, {
+        keepOnError: true,
+        sampling: { read: 0.05 },
+      });
+
+      const readFailTrail = trail('read-fail', {
+        input: z.object({}),
+        intent: 'read',
+        output: z.object({ value: z.string() }),
+        run: () => Result.err(new Error('boom')),
+      });
+
+      const wrapped = layer.wrap(readFailTrail, readFailTrail.run);
+      const result = await wrapped({}, stubCtx);
+
+      expect(result.isErr()).toBe(true);
+      expect(sink.records).toHaveLength(1);
+      expect(sink.records[0]?.status).toBe('err');
+    });
+
+    test('empty sampling config preserves record-everything default', async () => {
+      Math.random = () => 0.99;
+      const sink = createMemorySink();
+      const layer = createTracksLayer(sink, { sampling: {} });
+      const wrapped = layer.wrap(echoTrail, echoTrail.run);
+
+      await wrapped({ value: 'hello' }, stubCtx);
+
+      expect(sink.records).toHaveLength(1);
+    });
   });
 
   test('records thrown implementations as err results', async () => {

--- a/packages/tracks/src/__tests__/tracks-layer.test.ts
+++ b/packages/tracks/src/__tests__/tracks-layer.test.ts
@@ -14,6 +14,7 @@ import type { TrailContext } from '@ontrails/core';
 import { createMemorySink } from '../memory-sink.js';
 import { getTraceContext, TRACE_CONTEXT_KEY } from '../trace-context.js';
 import type { TraceContext } from '../trace-context.js';
+import { tracks } from '../index.js';
 import { createTracksLayer } from '../tracks-layer.js';
 
 const stubCtx: TrailContext = createTrailContext({
@@ -221,6 +222,7 @@ describe('tracksLayer', () => {
     const layer = createTracksLayer(
       {
         write: async () => {
+          await Promise.resolve();
           throw new Error('sink down');
         },
       },
@@ -327,5 +329,62 @@ describe('tracksLayer', () => {
     expect(sink.records).toHaveLength(1);
     expect(sink.records[0]?.status).toBe('cancelled');
     expect(sink.records[0]?.errorCategory).toBe('cancelled');
+  });
+
+  test('injects tracks.from(ctx).span so manual spans become child records', async () => {
+    const sink = createMemorySink();
+    const instrumentedTrail = trail('instrumented', {
+      input: z.object({}),
+      output: z.object({ value: z.string() }),
+      run: async (_input, ctx) => {
+        const value = await tracks
+          .from(ctx as TrailContext)
+          .span('inner-span', () => 'done');
+        return Result.ok({ value });
+      },
+    });
+
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(instrumentedTrail, instrumentedTrail.run);
+
+    const result = await wrapped({}, stubCtx);
+
+    expect(result.isOk()).toBe(true);
+    expect(sink.records).toHaveLength(2);
+
+    const trailRecord = sink.records.find((record) => record.kind === 'trail');
+    const spanRecord = sink.records.find((record) => record.kind === 'span');
+
+    expect(trailRecord?.trailId).toBe('instrumented');
+    expect(spanRecord?.name).toBe('inner-span');
+    expect(spanRecord?.parentId).toBe(trailRecord?.id);
+    expect(spanRecord?.rootId).toBe(trailRecord?.id);
+    expect(spanRecord?.traceId).toBe(trailRecord?.traceId);
+  });
+
+  test('merges tracks.from(ctx).annotate attrs into the trail record', async () => {
+    const sink = createMemorySink();
+    const annotatedTrail = trail('annotated', {
+      input: z.object({}),
+      output: z.object({ value: z.string() }),
+      run: (_input, ctx) => {
+        tracks.from(ctx as TrailContext).annotate({ count: 1, stage: 'start' });
+        tracks.from(ctx as TrailContext).annotate({ count: 2, detail: 'done' });
+        return Result.ok({ value: 'ok' });
+      },
+    });
+
+    const layer = createTracksLayer(sink);
+    const wrapped = layer.wrap(annotatedTrail, annotatedTrail.run);
+
+    const result = await wrapped({}, stubCtx);
+
+    expect(result.isOk()).toBe(true);
+    expect(sink.records).toHaveLength(1);
+    expect(sink.records[0]?.attrs).toEqual({
+      count: 2,
+      detail: 'done',
+      stage: 'start',
+    });
   });
 });

--- a/packages/tracks/src/__tests__/tracks-query.test.ts
+++ b/packages/tracks/src/__tests__/tracks-query.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createServiceLookup } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+
+import type { TrackRecord } from '../record.js';
+import type { TracksState } from '../registry.js';
+import { DEFAULT_SAMPLING } from '../sampling.js';
+import type { DevStore } from '../stores/dev.js';
+import { createDevStore } from '../stores/dev.js';
+import { tracksQuery } from '../trails/tracks-query.js';
+
+/** Build a TrailContext with tracksService resolved in extensions. */
+const buildCtx = (state: TracksState): TrailContext => {
+  const extensions = { tracks: state };
+  const ctx: TrailContext = {
+    cwd: '/tmp',
+    env: {},
+    extensions,
+    requestId: 'test',
+    service: undefined as unknown as TrailContext['service'],
+    signal: AbortSignal.timeout(5000),
+    workspaceRoot: '/tmp',
+  };
+  const withLookup = {
+    ...ctx,
+    service: createServiceLookup(() => withLookup),
+  };
+  return withLookup;
+};
+
+/** Build a minimal TrackRecord for testing. */
+const makeRecord = (overrides?: Partial<TrackRecord>): TrackRecord => ({
+  attrs: {},
+  endedAt: Date.now(),
+  id: `rec-${crypto.randomUUID()}`,
+  kind: 'trail',
+  name: 'test-trail',
+  rootId: 'root-1',
+  startedAt: Date.now() - 100,
+  status: 'ok',
+  traceId: 'trace-1',
+  trailId: 'test-trail',
+  ...overrides,
+});
+
+/** Default state without a store. */
+const noStoreState: TracksState = {
+  active: true,
+  sampling: DEFAULT_SAMPLING,
+  store: undefined,
+};
+
+/** Create a temp DevStore and return with cleanup. */
+const createTestStore = (): { cleanup: () => void; store: DevStore } => {
+  const dir = mkdtempSync(join(tmpdir(), 'tracks-query-'));
+  const store = createDevStore({ path: join(dir, 'tracks.db') });
+  const cleanup = () => {
+    store.close();
+    rmSync(dir, { force: true, recursive: true });
+  };
+  return { cleanup, store };
+};
+
+/** Build a TracksState with a real store. */
+const stateWithStore = (store: DevStore): TracksState => ({
+  active: true,
+  sampling: DEFAULT_SAMPLING,
+  store,
+});
+
+describe('tracks.query', () => {
+  describe('contract', () => {
+    test('has correct id', () => {
+      expect(tracksQuery.id).toBe('tracks.query');
+    });
+
+    test('has read intent', () => {
+      expect(tracksQuery.intent).toBe('read');
+    });
+
+    test('has infrastructure metadata', () => {
+      expect(tracksQuery.metadata).toEqual({ category: 'infrastructure' });
+    });
+
+    test('has examples', () => {
+      expect(tracksQuery.examples).toBeDefined();
+      expect(tracksQuery.examples?.length).toBeGreaterThanOrEqual(3);
+    });
+
+    test('declares tracksService in services', () => {
+      expect(tracksQuery.services).toBeDefined();
+      expect(tracksQuery.services?.length).toBe(1);
+    });
+  });
+
+  describe('run', () => {
+    let cleanup: (() => void) | undefined;
+
+    afterEach(() => {
+      cleanup?.();
+      cleanup = undefined;
+    });
+
+    test('returns empty records when state has no store', async () => {
+      const ctx = buildCtx(noStoreState);
+      const result = await tracksQuery.run({}, ctx);
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.count).toBe(0);
+      expect(value.records).toEqual([]);
+    });
+
+    test('returns records from store in state', async () => {
+      const testStore = createTestStore();
+      ({ cleanup } = testStore);
+      testStore.store.write(
+        makeRecord({
+          id: 'rec-abc',
+          intent: 'read',
+          name: 'user.list',
+          surface: 'cli',
+          traceId: 'trace-abc',
+          trailId: 'user.list',
+        })
+      );
+
+      const ctx = buildCtx(stateWithStore(testStore.store));
+      const result = await tracksQuery.run({}, ctx);
+      const value = result.unwrap();
+
+      expect(value.count).toBe(1);
+      expect(value.records[0]).toMatchObject({
+        id: 'rec-abc',
+        intent: 'read',
+        kind: 'trail',
+        name: 'user.list',
+        status: 'ok',
+        surface: 'cli',
+        traceId: 'trace-abc',
+        trailId: 'user.list',
+      });
+    });
+
+    test('filters by trailId', async () => {
+      const testStore = createTestStore();
+      ({ cleanup } = testStore);
+      testStore.store.write(makeRecord({ id: 'a', trailId: 'user.create' }));
+      testStore.store.write(makeRecord({ id: 'b', trailId: 'user.list' }));
+
+      const ctx = buildCtx(stateWithStore(testStore.store));
+      const result = await tracksQuery.run({ trailId: 'user.create' }, ctx);
+      const value = result.unwrap();
+
+      expect(value.count).toBe(1);
+      expect(value.records[0]?.trailId).toBe('user.create');
+    });
+
+    test('filters errorsOnly', async () => {
+      const testStore = createTestStore();
+      ({ cleanup } = testStore);
+      testStore.store.write(makeRecord({ id: 'ok-1', status: 'ok' }));
+      testStore.store.write(makeRecord({ id: 'err-1', status: 'err' }));
+
+      const ctx = buildCtx(stateWithStore(testStore.store));
+      const result = await tracksQuery.run({ errorsOnly: true }, ctx);
+      const value = result.unwrap();
+
+      expect(value.count).toBe(1);
+      expect(value.records[0]?.status).toBe('err');
+    });
+  });
+});

--- a/packages/tracks/src/__tests__/tracks-service.test.ts
+++ b/packages/tracks/src/__tests__/tracks-service.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+
+import { DEFAULT_SAMPLING } from '../sampling.js';
+import type { TracksState } from '../registry.js';
+import { tracksService } from '../tracks-service.js';
+
+describe('tracksService', () => {
+  test('has correct id', () => {
+    expect(tracksService.id).toBe('tracks');
+  });
+
+  test('has service kind', () => {
+    expect(tracksService.kind).toBe('service');
+  });
+
+  test('has infrastructure metadata', () => {
+    expect(tracksService.metadata).toEqual({ category: 'infrastructure' });
+  });
+
+  describe('mock', () => {
+    test('returns TracksState with default sampling', () => {
+      const value = tracksService.mock?.() as TracksState;
+      expect(value.active).toBe(true);
+      expect(value.sampling).toEqual(DEFAULT_SAMPLING);
+      expect(value.store).toBeUndefined();
+    });
+  });
+
+  describe('create', () => {
+    test('returns Result.ok with default TracksState when no state registered', () => {
+      const ctx = {
+        config: undefined,
+        cwd: '/tmp',
+        env: {},
+        workspaceRoot: '/tmp',
+      };
+      const result = tracksService.create(ctx);
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap() as TracksState;
+      expect(value.active).toBe(true);
+      expect(value.sampling).toEqual(DEFAULT_SAMPLING);
+      expect(value.store).toBeUndefined();
+    });
+  });
+});

--- a/packages/tracks/src/__tests__/tracks-status.test.ts
+++ b/packages/tracks/src/__tests__/tracks-status.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+import { createServiceLookup } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+
+import type { TracksState } from '../registry.js';
+import { DEFAULT_SAMPLING } from '../sampling.js';
+import { tracksStatus } from '../trails/tracks-status.js';
+
+/** Build a TrailContext with tracksService resolved in extensions. */
+const buildCtx = (state: TracksState): TrailContext => {
+  const extensions = { tracks: state };
+  const ctx: TrailContext = {
+    cwd: '/tmp',
+    env: {},
+    extensions,
+    requestId: 'test',
+    service: undefined as unknown as TrailContext['service'],
+    signal: AbortSignal.timeout(5000),
+    workspaceRoot: '/tmp',
+  };
+  const withLookup = {
+    ...ctx,
+    service: createServiceLookup(() => withLookup),
+  };
+  return withLookup;
+};
+
+/** Default test state. */
+const defaultState: TracksState = {
+  active: true,
+  sampling: DEFAULT_SAMPLING,
+  store: undefined,
+};
+
+describe('tracks.status', () => {
+  describe('contract', () => {
+    test('has correct id', () => {
+      expect(tracksStatus.id).toBe('tracks.status');
+    });
+
+    test('has read intent', () => {
+      expect(tracksStatus.intent).toBe('read');
+    });
+
+    test('has infrastructure metadata', () => {
+      expect(tracksStatus.metadata).toEqual({ category: 'infrastructure' });
+    });
+
+    test('has examples', () => {
+      expect(tracksStatus.examples).toBeDefined();
+      expect(tracksStatus.examples?.length).toBeGreaterThan(0);
+    });
+
+    test('declares tracksService in services', () => {
+      expect(tracksStatus.services).toBeDefined();
+      expect(tracksStatus.services?.length).toBe(1);
+    });
+  });
+
+  describe('run', () => {
+    test('returns active from state', async () => {
+      const ctx = buildCtx(defaultState);
+      const result = await tracksStatus.run({}, ctx);
+      expect(result.isOk()).toBe(true);
+      const value = result.unwrap();
+      expect(value.active).toBe(true);
+    });
+
+    test('returns inactive when state says so', async () => {
+      const ctx = buildCtx({ ...defaultState, active: false });
+      const result = await tracksStatus.run({}, ctx);
+      const value = result.unwrap();
+      expect(value.active).toBe(false);
+    });
+
+    test('returns recordCount of 0 for v1', async () => {
+      const ctx = buildCtx(defaultState);
+      const result = await tracksStatus.run({}, ctx);
+      const value = result.unwrap();
+      expect(value.recordCount).toBe(0);
+    });
+
+    test('returns sampling config from state', async () => {
+      const ctx = buildCtx(defaultState);
+      const result = await tracksStatus.run({}, ctx);
+      const value = result.unwrap();
+      expect(value.samplingConfig).toEqual({
+        destroy: DEFAULT_SAMPLING.destroy,
+        read: DEFAULT_SAMPLING.read,
+        write: DEFAULT_SAMPLING.write,
+      });
+    });
+
+    test('returns custom sampling when state overrides defaults', async () => {
+      const custom = { destroy: 0.5, read: 0.1, write: 0.9 };
+      const ctx = buildCtx({ ...defaultState, sampling: custom });
+      const result = await tracksStatus.run({}, ctx);
+      const value = result.unwrap();
+      expect(value.samplingConfig).toEqual(custom);
+    });
+  });
+});

--- a/packages/tracks/src/adapters/otel.ts
+++ b/packages/tracks/src/adapters/otel.ts
@@ -1,0 +1,128 @@
+import type { TrackRecord } from '../record.js';
+import type { TrackSink } from '../tracks-layer.js';
+
+/** OTel span representation produced by the adapter. */
+export interface OtelSpan {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly parentSpanId?: string | undefined;
+  readonly operationName: string;
+  readonly startTime: number;
+  readonly endTime?: number | undefined;
+  readonly status: 'OK' | 'ERROR' | 'UNSET';
+  readonly kind: 'INTERNAL' | 'SERVER';
+  readonly attributes: Readonly<Record<string, string | number | boolean>>;
+}
+
+/** Callback that receives translated OTel spans. */
+export type OtelExporter = (spans: readonly OtelSpan[]) => void | Promise<void>;
+
+/** Configuration for the OTel adapter. */
+export interface OtelAdapterOptions {
+  readonly exporter: OtelExporter;
+  readonly batchSize?: number;
+}
+
+/** Map from TrackRecord status to OTel status. */
+const STATUS_MAP: Record<TrackRecord['status'], OtelSpan['status']> = {
+  cancelled: 'UNSET',
+  err: 'ERROR',
+  ok: 'OK',
+};
+
+/** Derive OTel span kind from parentId presence. */
+const deriveKind = (parentId: string | undefined): OtelSpan['kind'] =>
+  parentId === undefined ? 'SERVER' : 'INTERNAL';
+
+/** Attribute mapping: record field → OTel attribute key + extractor. */
+const ATTR_MAP: readonly {
+  key: string;
+  get: (r: TrackRecord) => string | undefined;
+}[] = [
+  { get: (r) => r.trailId, key: 'trails.trail.id' },
+  { get: (r) => r.intent, key: 'trails.intent' },
+  { get: (r) => r.surface, key: 'trails.surface' },
+  { get: (r) => r.permit?.id, key: 'trails.permit.id' },
+  { get: (r) => r.permit?.tenantId, key: 'trails.permit.tenant_id' },
+];
+
+/** Build the trails-namespaced attributes from a TrackRecord. */
+const buildAttributes = (
+  record: TrackRecord
+): Record<string, string | number | boolean> => {
+  const attrs: Record<string, string | number | boolean> = {};
+  for (const { key, get } of ATTR_MAP) {
+    const val = get(record);
+    if (val !== undefined) {
+      attrs[key] = val;
+    }
+  }
+  for (const [key, val] of Object.entries(record.attrs)) {
+    if (
+      typeof val === 'string' ||
+      typeof val === 'number' ||
+      typeof val === 'boolean'
+    ) {
+      attrs[key] = val;
+    }
+  }
+  return attrs;
+};
+
+/** Translate a TrackRecord into an OTel span. */
+const toOtelSpan = (record: TrackRecord): OtelSpan => ({
+  attributes: buildAttributes(record),
+  endTime: record.endedAt,
+  kind: deriveKind(record.parentId),
+  operationName: record.name,
+  parentSpanId: record.parentId,
+  spanId: record.id,
+  startTime: record.startedAt,
+  status: STATUS_MAP[record.status],
+  traceId: record.traceId,
+});
+
+/** A TrackSink extended with an explicit flush for shutdown. */
+export interface OtelSink extends TrackSink {
+  /** Flush any remaining buffered spans to the exporter. */
+  readonly flush: () => Promise<void>;
+}
+
+/**
+ * Create a TrackSink that translates TrackRecords to OTel spans.
+ *
+ * The adapter maps Trails-native fields to OpenTelemetry span attributes
+ * under a `trails.*` namespace. Pass any OTel-compatible exporter callback
+ * to forward spans to your collector.
+ *
+ * Translates and exports spans on each write. Call `flush()` on shutdown
+ * to send any remaining buffered spans.
+ */
+export const createOtelAdapter = (options: OtelAdapterOptions): OtelSink => {
+  const batchSize = options.batchSize ?? 1;
+  const buffer: OtelSpan[] = [];
+
+  const flush = async (): Promise<void> => {
+    if (buffer.length === 0) {
+      return;
+    }
+    const batch = buffer.splice(0);
+    try {
+      await options.exporter(batch);
+    } catch (error) {
+      // Restore batch on exporter failure so data is not lost
+      buffer.unshift(...batch);
+      throw error;
+    }
+  };
+
+  return {
+    flush,
+    write: async (record: TrackRecord): Promise<void> => {
+      buffer.push(toOtelSpan(record));
+      if (buffer.length >= batchSize) {
+        await flush();
+      }
+    },
+  };
+};

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -23,3 +23,9 @@ export {
   type TracksApiWithState,
 } from './tracks-api.js';
 export { tracks } from './tracks-accessor.js';
+export {
+  createDevStore,
+  type DevStore,
+  type DevStoreOptions,
+  type DevStoreQueryOptions,
+} from './stores/dev.js';

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -16,3 +16,9 @@ export {
   DEFAULT_SAMPLING,
   type SamplingConfig,
 } from './sampling.js';
+export {
+  createTracksApi,
+  TRACKS_API_KEY,
+  type TracksApi,
+  type TracksApiWithState,
+} from './tracks-api.js';

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -1,5 +1,3 @@
-/** Internal placeholder — replaced by real types in TRL-106+. */
-export interface TracksPlaceholder {
-  readonly __brand: 'tracks';
-}
-export { tracks } from './tracks-accessor.js';
+export { type TrackRecord, createTrackRecord } from './record.js';
+export { createTracksLayer, type TrackSink } from './tracks-layer.js';
+export { createMemorySink } from './memory-sink.js';

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -23,9 +23,28 @@ export {
   type TracksApiWithState,
 } from './tracks-api.js';
 export { tracks } from './tracks-accessor.js';
+export { tracksService } from './tracks-service.js';
+export { tracksStatus } from './trails/tracks-status.js';
+export { tracksQuery } from './trails/tracks-query.js';
+export {
+  clearTrackStore,
+  clearTracksState,
+  getTrackStore,
+  getTracksState,
+  registerTrackStore,
+  registerTracksState,
+  type TracksState,
+} from './registry.js';
 export {
   createDevStore,
   type DevStore,
   type DevStoreOptions,
   type DevStoreQueryOptions,
 } from './stores/dev.js';
+export {
+  createOtelAdapter,
+  type OtelAdapterOptions,
+  type OtelExporter,
+  type OtelSink,
+  type OtelSpan,
+} from './adapters/otel.js';

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -1,3 +1,18 @@
 export { type TrackRecord, createTrackRecord } from './record.js';
-export { createTracksLayer, type TrackSink } from './tracks-layer.js';
+export {
+  createTracksLayer,
+  type TrackSink,
+  type TracksLayerOptions,
+} from './tracks-layer.js';
 export { createMemorySink } from './memory-sink.js';
+export {
+  type TraceContext,
+  getTraceContext,
+  childTraceContext,
+  TRACE_CONTEXT_KEY,
+} from './trace-context.js';
+export {
+  shouldSample,
+  DEFAULT_SAMPLING,
+  type SamplingConfig,
+} from './sampling.js';

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -22,3 +22,4 @@ export {
   type TracksApi,
   type TracksApiWithState,
 } from './tracks-api.js';
+export { tracks } from './tracks-accessor.js';

--- a/packages/tracks/src/index.ts
+++ b/packages/tracks/src/index.ts
@@ -1,0 +1,5 @@
+/** Internal placeholder — replaced by real types in TRL-106+. */
+export interface TracksPlaceholder {
+  readonly __brand: 'tracks';
+}
+export { tracks } from './tracks-accessor.js';

--- a/packages/tracks/src/memory-sink.ts
+++ b/packages/tracks/src/memory-sink.ts
@@ -1,0 +1,16 @@
+import type { TrackSink } from './tracks-layer.js';
+import type { TrackRecord } from './record.js';
+
+/** In-memory sink for testing — captures all written records. */
+export const createMemorySink = (): TrackSink & {
+  readonly records: TrackRecord[];
+} => {
+  const records: TrackRecord[] = [];
+
+  return {
+    records,
+    write: (record) => {
+      records.push(record);
+    },
+  };
+};

--- a/packages/tracks/src/record.ts
+++ b/packages/tracks/src/record.ts
@@ -1,0 +1,58 @@
+/** Evidence of a single trail execution or manual span. */
+export interface TrackRecord {
+  readonly id: string;
+  readonly traceId: string;
+  readonly rootId: string;
+  readonly parentId?: string | undefined;
+  readonly kind: 'trail' | 'span';
+  readonly name: string;
+  readonly trailId?: string | undefined;
+  readonly surface?: 'cli' | 'mcp' | 'http' | 'ws' | undefined;
+  readonly intent?: 'read' | 'write' | 'destroy' | undefined;
+  readonly startedAt: number;
+  readonly endedAt?: number | undefined;
+  readonly status: 'ok' | 'err' | 'cancelled';
+  readonly errorCategory?: string | undefined;
+  readonly permit?:
+    | { readonly id: string; readonly tenantId?: string }
+    | undefined;
+  readonly attrs: Readonly<Record<string, unknown>>;
+}
+
+/** Options for creating a trail-scoped TrackRecord. */
+interface CreateTrackRecordOptions {
+  readonly trailId: string;
+  readonly traceId?: string | undefined;
+  readonly parentId?: string | undefined;
+  readonly rootId?: string | undefined;
+  readonly surface?: TrackRecord['surface'];
+  readonly intent?: TrackRecord['intent'];
+  readonly permit?:
+    | { readonly id: string; readonly tenantId?: string }
+    | undefined;
+}
+
+/** Create a fresh TrackRecord for a trail execution. */
+export const createTrackRecord = (
+  options: CreateTrackRecordOptions
+): TrackRecord => {
+  const id = Bun.randomUUIDv7();
+  const traceId = options.traceId ?? Bun.randomUUIDv7();
+
+  return {
+    attrs: {},
+    endedAt: undefined,
+    id,
+    intent: options.intent,
+    kind: 'trail',
+    name: options.trailId,
+    parentId: options.parentId,
+    permit: options.permit,
+    rootId: options.rootId ?? id,
+    startedAt: Date.now(),
+    status: 'ok',
+    surface: options.surface,
+    traceId,
+    trailId: options.trailId,
+  };
+};

--- a/packages/tracks/src/registry.ts
+++ b/packages/tracks/src/registry.ts
@@ -1,0 +1,46 @@
+import { DEFAULT_SAMPLING } from './sampling.js';
+import type { SamplingConfig } from './sampling.js';
+import type { DevStore } from './stores/dev.js';
+
+/** Full telemetry subsystem state carried by tracksService. */
+export interface TracksState {
+  readonly active: boolean;
+  readonly sampling: SamplingConfig;
+  readonly store: DevStore | undefined;
+}
+
+let state: TracksState | undefined;
+
+/** Register telemetry state at bootstrap. */
+export const registerTracksState = (s: TracksState): void => {
+  state = s;
+};
+
+/** Read the registered telemetry state. Returns `undefined` before registration. */
+export const getTracksState = (): TracksState | undefined => state;
+
+/** Clear registered state. Primarily useful in tests. */
+export const clearTracksState = (): void => {
+  state = undefined;
+};
+
+// --- Backward-compatible convenience wrappers ---
+
+/** Register a DevStore instance for use by the tracks.query trail. */
+export const registerTrackStore = (s: DevStore): void => {
+  state = {
+    active: state?.active ?? true,
+    sampling: state?.sampling ?? DEFAULT_SAMPLING,
+    store: s,
+  };
+};
+
+/** Retrieve the currently registered DevStore, if any. */
+export const getTrackStore = (): DevStore | undefined => state?.store;
+
+/** Clear the registered store. Useful for testing teardown. */
+export const clearTrackStore = (): void => {
+  if (state) {
+    state = { ...state, store: undefined };
+  }
+};

--- a/packages/tracks/src/sampling.ts
+++ b/packages/tracks/src/sampling.ts
@@ -1,0 +1,30 @@
+/** Intent-based sampling rate configuration. */
+export interface SamplingConfig {
+  /** Sample rate for read operations (0.0 to 1.0). Default 0.05 (5%). */
+  readonly read: number;
+  /** Sample rate for write operations (0.0 to 1.0). Default 1.0 (100%). */
+  readonly write: number;
+  /** Sample rate for destroy operations (0.0 to 1.0). Default 1.0 (100%). */
+  readonly destroy: number;
+}
+
+/** Default sampling rates: 5% reads, 100% writes and destroys. */
+export const DEFAULT_SAMPLING: SamplingConfig = {
+  destroy: 1,
+  read: 0.05,
+  write: 1,
+};
+
+/**
+ * Decide whether to sample a trace based on intent.
+ *
+ * Undefined intent falls back to the write rate.
+ */
+export const shouldSample = (
+  intent: 'read' | 'write' | 'destroy' | undefined,
+  config?: Partial<SamplingConfig>
+): boolean => {
+  const merged = { ...DEFAULT_SAMPLING, ...config };
+  const rate = merged[intent ?? 'write'];
+  return Math.random() < rate;
+};

--- a/packages/tracks/src/stores/dev.ts
+++ b/packages/tracks/src/stores/dev.ts
@@ -1,0 +1,316 @@
+import { Database } from 'bun:sqlite';
+import type { SQLQueryBindings } from 'bun:sqlite';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import type { TrackRecord } from '../record.js';
+import type { TrackSink } from '../tracks-layer.js';
+
+/** Configuration for the SQLite dev store. */
+export interface DevStoreOptions {
+  /** Path to the SQLite database file. Defaults to `.trails/dev/tracks.db`. */
+  readonly path?: string;
+  /** Maximum number of records to retain. Defaults to 10000. */
+  readonly maxRecords?: number;
+  /** Maximum age of records in milliseconds. Defaults to 7 days. */
+  readonly maxAge?: number;
+}
+
+/** Query options for filtering stored track records. */
+export interface DevStoreQueryOptions {
+  readonly trailId?: string;
+  readonly traceId?: string;
+  readonly errorsOnly?: boolean;
+  readonly limit?: number;
+}
+
+/** SQLite-backed dev store for persisting and querying track records. */
+export interface DevStore extends TrackSink {
+  /** Query recent traces with optional filters. */
+  readonly query: (options?: DevStoreQueryOptions) => readonly TrackRecord[];
+  /** Return the total number of stored records. */
+  readonly count: () => number;
+  /** Close the database connection. */
+  readonly close: () => void;
+}
+
+/** SQL for creating the tracks table. */
+const CREATE_TABLE_SQL = `CREATE TABLE IF NOT EXISTS tracks (
+  id TEXT PRIMARY KEY,
+  trace_id TEXT NOT NULL,
+  root_id TEXT NOT NULL,
+  parent_id TEXT,
+  kind TEXT NOT NULL,
+  name TEXT NOT NULL,
+  trail_id TEXT,
+  surface TEXT,
+  intent TEXT,
+  started_at INTEGER NOT NULL,
+  ended_at INTEGER,
+  status TEXT NOT NULL,
+  error_category TEXT,
+  permit_id TEXT,
+  permit_tenant_id TEXT,
+  attrs TEXT
+)`;
+
+/** Index for common query patterns. */
+const CREATE_INDEXES_SQL = [
+  'CREATE INDEX IF NOT EXISTS idx_tracks_trail_id ON tracks(trail_id)',
+  'CREATE INDEX IF NOT EXISTS idx_tracks_trace_id ON tracks(trace_id)',
+  'CREATE INDEX IF NOT EXISTS idx_tracks_status ON tracks(status)',
+  'CREATE INDEX IF NOT EXISTS idx_tracks_started_at ON tracks(started_at)',
+];
+
+/** Shape of a row returned from the tracks table. */
+interface TrackRow {
+  readonly id: string;
+  readonly trace_id: string;
+  readonly root_id: string;
+  readonly parent_id: string | null;
+  readonly kind: string;
+  readonly name: string;
+  readonly trail_id: string | null;
+  readonly surface: string | null;
+  readonly intent: string | null;
+  readonly started_at: number;
+  readonly ended_at: number | null;
+  readonly status: string;
+  readonly error_category: string | null;
+  readonly permit_id: string | null;
+  readonly permit_tenant_id: string | null;
+  readonly attrs: string | null;
+}
+
+/** Reconstruct the permit object from decomposed columns. */
+const buildPermit = (
+  permitId: string | null,
+  tenantId: string | null
+): TrackRecord['permit'] => {
+  if (permitId === null) {
+    return undefined;
+  }
+  return tenantId === null ? { id: permitId } : { id: permitId, tenantId };
+};
+
+/** Parse attrs JSON back into a record. */
+const parseAttrs = (raw: string | null): Readonly<Record<string, unknown>> =>
+  raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+
+/** Reconstruct a TrackRecord from a database row. */
+const rowToRecord = (row: TrackRow): TrackRecord => ({
+  attrs: parseAttrs(row.attrs),
+  endedAt: row.ended_at ?? undefined,
+  errorCategory: row.error_category ?? undefined,
+  id: row.id,
+  intent: (row.intent ?? undefined) as TrackRecord['intent'],
+  kind: row.kind as TrackRecord['kind'],
+  name: row.name,
+  parentId: row.parent_id ?? undefined,
+  permit: buildPermit(row.permit_id, row.permit_tenant_id),
+  rootId: row.root_id,
+  startedAt: row.started_at,
+  status: row.status as TrackRecord['status'],
+  surface: (row.surface ?? undefined) as TrackRecord['surface'],
+  traceId: row.trace_id,
+  trailId: row.trail_id ?? undefined,
+});
+
+/** Initialize the database with pragmas, table, and indexes. */
+const initializeDb = (db: Database): void => {
+  db.run('PRAGMA journal_mode = WAL');
+  db.run('PRAGMA synchronous = NORMAL');
+  db.run(CREATE_TABLE_SQL);
+  for (const sql of CREATE_INDEXES_SQL) {
+    db.run(sql);
+  }
+};
+
+/** Ensure the parent directory for the database file exists. */
+const ensureDir = (path: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+};
+
+/** Prune records exceeding the retention limit. */
+const pruneByCount = (db: Database, maxRecords: number): void => {
+  const countResult = db
+    .query<{ count: number }, []>('SELECT COUNT(*) as count FROM tracks')
+    .get();
+  const count = countResult?.count ?? 0;
+
+  if (count <= maxRecords) {
+    return;
+  }
+
+  const excess = count - maxRecords;
+  db.run(
+    `DELETE FROM tracks WHERE id IN (
+      SELECT id FROM tracks ORDER BY started_at ASC LIMIT ?
+    )`,
+    [excess]
+  );
+};
+
+/** Prune records older than maxAge milliseconds. */
+const pruneByAge = (db: Database, maxAge: number): void => {
+  const threshold = Date.now() - maxAge;
+  db.run('DELETE FROM tracks WHERE started_at < ?', [threshold]);
+};
+
+/** Filter definition: column condition and optional bound value. */
+interface QueryFilter {
+  readonly condition: string;
+  readonly value?: SQLQueryBindings;
+}
+
+/** Derive active filters from query options. */
+const deriveFilters = (
+  options?: DevStoreQueryOptions
+): readonly QueryFilter[] => {
+  const filters: QueryFilter[] = [];
+
+  if (options?.trailId !== undefined) {
+    filters.push({ condition: 'trail_id = ?', value: options.trailId });
+  }
+  if (options?.traceId !== undefined) {
+    filters.push({ condition: 'trace_id = ?', value: options.traceId });
+  }
+  if (options?.errorsOnly === true) {
+    filters.push({ condition: "status = 'err'" });
+  }
+
+  return filters;
+};
+
+/** Build a parameterized SELECT query from query options. */
+const buildQuery = (
+  defaultLimit: number,
+  options?: DevStoreQueryOptions
+): { readonly sql: string; readonly params: SQLQueryBindings[] } => {
+  const filters = deriveFilters(options);
+  const where =
+    filters.length > 0
+      ? `WHERE ${filters.map((f) => f.condition).join(' AND ')}`
+      : '';
+  const params: SQLQueryBindings[] = [
+    ...filters.flatMap((f) => (f.value === undefined ? [] : [f.value])),
+    options?.limit ?? defaultLimit,
+  ];
+
+  return {
+    params,
+    sql: `SELECT * FROM tracks ${where} ORDER BY started_at DESC LIMIT ?`,
+  };
+};
+
+/** Serialize attrs to JSON, returning null for empty objects. */
+const serializeAttrs = (
+  attrs: Readonly<Record<string, unknown>>
+): string | null =>
+  Object.keys(attrs).length > 0 ? JSON.stringify(attrs) : null;
+
+/** Serialize a TrackRecord into positional INSERT parameters. */
+const recordToParams = (record: TrackRecord): SQLQueryBindings[] => [
+  record.id,
+  record.traceId,
+  record.rootId,
+  record.parentId ?? null,
+  record.kind,
+  record.name,
+  record.trailId ?? null,
+  record.surface ?? null,
+  record.intent ?? null,
+  record.startedAt,
+  record.endedAt ?? null,
+  record.status,
+  record.errorCategory ?? null,
+  record.permit?.id ?? null,
+  record.permit?.tenantId ?? null,
+  serializeAttrs(record.attrs),
+];
+
+/** SQL for inserting a track record. */
+const UPSERT_SQL = `INSERT INTO tracks (
+  id, trace_id, root_id, parent_id,
+  kind, name, trail_id, surface,
+  intent, started_at, ended_at, status,
+  error_category, permit_id, permit_tenant_id, attrs
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  trace_id = excluded.trace_id,
+  root_id = excluded.root_id,
+  parent_id = excluded.parent_id,
+  kind = excluded.kind,
+  name = excluded.name,
+  trail_id = excluded.trail_id,
+  surface = excluded.surface,
+  intent = excluded.intent,
+  started_at = excluded.started_at,
+  ended_at = excluded.ended_at,
+  status = excluded.status,
+  error_category = excluded.error_category,
+  permit_id = excluded.permit_id,
+  permit_tenant_id = excluded.permit_tenant_id,
+  attrs = excluded.attrs`;
+
+/** Open and initialize the database at the given path. */
+const openDb = (dbPath: string): Database => {
+  ensureDir(dbPath);
+  const db = new Database(dbPath, { create: true });
+  initializeDb(db);
+  return db;
+};
+
+/** Count stored track records. */
+const countRecords = (db: Database): number => {
+  const result = db
+    .query<{ count: number }, []>('SELECT COUNT(*) as count FROM tracks')
+    .get();
+  return result?.count ?? 0;
+};
+
+/** Create a transactional writer that keeps retention pruning atomic. */
+const createWriter = (
+  db: Database,
+  insertStmt: ReturnType<Database['prepare']>,
+  maxRecords: number,
+  maxAge: number | undefined
+): ((record: TrackRecord) => void) =>
+  db.transaction((record: TrackRecord) => {
+    insertStmt.run(...recordToParams(record));
+    pruneByCount(db, maxRecords);
+    if (maxAge !== undefined) {
+      pruneByAge(db, maxAge);
+    }
+  });
+
+/**
+ * Create a SQLite-backed dev store for persisting track records.
+ *
+ * Uses WAL mode and normal synchronous for good write performance.
+ * Automatically prunes records exceeding `maxRecords` on each write.
+ */
+export const createDevStore = (options?: DevStoreOptions): DevStore => {
+  const dbPath = options?.path ?? '.trails/dev/tracks.db';
+  const maxRecords = options?.maxRecords ?? 10_000;
+  const maxAge = options?.maxAge;
+  const db = openDb(dbPath);
+  const insertStmt = db.prepare(UPSERT_SQL);
+  const write = createWriter(db, insertStmt, maxRecords, maxAge);
+
+  const query = (
+    queryOptions?: DevStoreQueryOptions
+  ): readonly TrackRecord[] => {
+    const { sql, params } = buildQuery(maxRecords, queryOptions);
+    const rows = db.query<TrackRow, SQLQueryBindings[]>(sql).all(...params);
+    return rows.map(rowToRecord);
+  };
+
+  const count = (): number => countRecords(db);
+
+  const close = (): void => {
+    db.close();
+  };
+
+  return { close, count, query, write };
+};

--- a/packages/tracks/src/trace-context.ts
+++ b/packages/tracks/src/trace-context.ts
@@ -1,0 +1,24 @@
+/** Trace context carried through trail execution. */
+export interface TraceContext {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly rootId: string;
+  readonly sampled: boolean;
+}
+
+/** Key used to store trace context in ctx.extensions. */
+export const TRACE_CONTEXT_KEY = '__tracks_trace';
+
+/** Read trace context from trail context extensions. */
+export const getTraceContext = (ctx: {
+  readonly extensions?: Readonly<Record<string, unknown>> | undefined;
+}): TraceContext | undefined =>
+  ctx.extensions?.[TRACE_CONTEXT_KEY] as TraceContext | undefined;
+
+/** Create a child trace context inheriting from a parent. */
+export const childTraceContext = (parent: TraceContext): TraceContext => ({
+  rootId: parent.rootId,
+  sampled: parent.sampled,
+  spanId: Bun.randomUUIDv7(),
+  traceId: parent.traceId,
+});

--- a/packages/tracks/src/tracks-accessor.ts
+++ b/packages/tracks/src/tracks-accessor.ts
@@ -1,0 +1,26 @@
+import { TRACKS_API_KEY } from './tracks-api.js';
+import type { TracksApi } from './tracks-api.js';
+
+/** No-op TracksApi returned when the tracks layer is not active. */
+const noopApi: TracksApi = {
+  // oxlint-disable-next-line no-empty-function -- intentional no-op
+  annotate: () => {},
+  span: async <T>(_name: string, fn: () => T | Promise<T>): Promise<T> =>
+    // oxlint-disable-next-line require-await -- no-op passthrough must return Promise
+    fn(),
+};
+
+/**
+ * Typed accessor for the TracksApi on a trail context.
+ *
+ * Returns a no-op implementation when the tracks layer is not active,
+ * so callers never need null-checks.
+ */
+export const tracks = {
+  from: (ctx: {
+    readonly extensions?: Readonly<Record<string, unknown>> | undefined;
+  }): TracksApi => {
+    const api = ctx.extensions?.[TRACKS_API_KEY] as TracksApi | undefined;
+    return api ?? noopApi;
+  },
+};

--- a/packages/tracks/src/tracks-api.ts
+++ b/packages/tracks/src/tracks-api.ts
@@ -1,0 +1,132 @@
+import type { TrackRecord } from './record.js';
+import { getTraceContext } from './trace-context.js';
+
+/** Sink type re-declared to avoid circular import with tracks-layer. */
+interface TrackSinkLike {
+  readonly write: (record: TrackRecord) => void | Promise<void>;
+}
+
+/** Key used to store the TracksApi in ctx.extensions. */
+export const TRACKS_API_KEY = '__tracks_api';
+
+/** Manual instrumentation API for trail implementations. */
+export interface TracksApi {
+  /**
+   * Create a timed child span. Callback-only to guarantee spans close.
+   * No raw startSpan/endSpan to prevent forgotten closures.
+   */
+  readonly span: <T>(name: string, fn: () => T | Promise<T>) => Promise<T>;
+
+  /** Add key-value pairs to the current trail's record attrs. */
+  readonly annotate: (attrs: Record<string, unknown>) => void;
+}
+
+/** TracksApi bundled with internal state the layer needs after execution. */
+export interface TracksApiWithState {
+  readonly api: TracksApi;
+  /** Retrieve all accumulated annotations, merged into a single object. */
+  readonly getAnnotations: () => Record<string, unknown>;
+}
+
+/** Build a span record from trace context and span name. */
+const createSpanRecord = (
+  traceId: string,
+  parentId: string,
+  rootId: string,
+  name: string
+): TrackRecord => ({
+  attrs: {},
+  endedAt: undefined,
+  errorCategory: undefined,
+  id: Bun.randomUUIDv7(),
+  intent: undefined,
+  kind: 'span',
+  name,
+  parentId,
+  rootId,
+  startedAt: Date.now(),
+  status: 'ok',
+  surface: undefined,
+  traceId,
+  trailId: undefined,
+});
+
+/** Mark a record as completed with timing and status. */
+const completeSpanRecord = (
+  record: TrackRecord,
+  status: 'ok' | 'err',
+  error?: unknown
+): TrackRecord => ({
+  ...record,
+  endedAt: Date.now(),
+  errorCategory:
+    status === 'err' && error instanceof Error
+      ? error.constructor.name
+      : undefined,
+  status,
+});
+
+/** Merge an array of annotation objects into a single flat record. */
+const mergeAnnotations = (
+  annotations: readonly Record<string, unknown>[]
+): Record<string, unknown> =>
+  Object.assign({}, ...annotations) as Record<string, unknown>;
+
+/**
+ * Create a TracksApi bound to a specific execution context and sink.
+ *
+ * Reads trace context from `ctx.extensions` so manual spans become
+ * children of the trail's automatic record. Returns the API alongside
+ * a `getAnnotations` accessor the layer uses to merge attrs into the
+ * completed record.
+ */
+export const createTracksApi = (
+  ctx: { readonly extensions?: Readonly<Record<string, unknown>> | undefined },
+  sink: TrackSinkLike
+): TracksApiWithState => {
+  const annotations: Record<string, unknown>[] = [];
+
+  const trace = getTraceContext(ctx);
+  const traceId = trace?.traceId ?? Bun.randomUUIDv7();
+  const parentId = trace?.spanId ?? Bun.randomUUIDv7();
+  const rootId = trace?.rootId ?? parentId;
+
+  const span = async <T>(
+    name: string,
+    fn: () => T | Promise<T>
+  ): Promise<T> => {
+    if (trace?.sampled === false) {
+      return await fn();
+    }
+
+    const record = createSpanRecord(traceId, parentId, rootId, name);
+
+    try {
+      const result = await fn();
+      await Promise.resolve(sink.write(completeSpanRecord(record, 'ok'))).catch(
+        () => {
+          // sink failures must not affect span result delivery
+        }
+      );
+      return result;
+    } catch (error: unknown) {
+      try {
+        await Promise.resolve(
+          sink.write(completeSpanRecord(record, 'err', error))
+        );
+      } catch {
+        // best-effort write; don't let sink errors mask the original
+      }
+      throw error;
+    }
+  };
+
+  const annotate = (attrs: Record<string, unknown>): void => {
+    annotations.push(attrs);
+  };
+
+  const getAnnotations = (): Record<string, unknown> =>
+    mergeAnnotations(annotations);
+
+  return { api: { annotate, span }, getAnnotations };
+};

--- a/packages/tracks/src/tracks-layer.ts
+++ b/packages/tracks/src/tracks-layer.ts
@@ -18,6 +18,7 @@ import { createTrackRecord } from './record.js';
 import type { SamplingConfig } from './sampling.js';
 import { shouldSample } from './sampling.js';
 import type { TraceContext } from './trace-context.js';
+import { createTracksApi, TRACKS_API_KEY } from './tracks-api.js';
 import {
   TRACE_CONTEXT_KEY,
   childTraceContext,
@@ -86,6 +87,21 @@ const completeRecord = (
   ...deriveOutcome(result),
   endedAt: Date.now(),
 });
+
+/** Merge manual annotations into a completed trail record. */
+const mergeAnnotations = (
+  record: TrackRecord,
+  attrs: Readonly<Record<string, unknown>>
+): TrackRecord =>
+  Object.keys(attrs).length === 0
+    ? record
+    : {
+        ...record,
+        attrs: {
+          ...record.attrs,
+          ...attrs,
+        },
+      };
 
 /** Resolve whether this invocation should be sampled. */
 const resolveSampled = (
@@ -167,6 +183,7 @@ const notifySinkError = (
 const prepareExecution = <I, O>(
   trail: Trail<I, O>,
   ctx: TrailContext,
+  sink: TrackSink,
   options?: TracksLayerOptions
 ) => {
   const parentTrace = getTraceContext(ctx);
@@ -189,9 +206,18 @@ const prepareExecution = <I, O>(
     rootId: isRoot ? record.id : trace.rootId,
     spanId: record.id,
   };
+  const traceCtx = enrichExtensions(ctx, enrichedTrace);
+  const tracksApi = createTracksApi(traceCtx, sink);
 
   return {
-    ctx: enrichExtensions(ctx, enrichedTrace),
+    ctx: {
+      ...traceCtx,
+      extensions: {
+        ...traceCtx.extensions,
+        [TRACKS_API_KEY]: tracksApi.api,
+      },
+    },
+    getAnnotations: tracksApi.getAnnotations,
     record,
     sampled,
   };
@@ -214,7 +240,7 @@ export const createTracksLayer = (
   wrap:
     <I, O>(trail: Trail<I, O>, impl: Implementation<I, O>) =>
     async (input: I, ctx) => {
-      const execution = prepareExecution(trail, ctx, options);
+      const execution = prepareExecution(trail, ctx, sink, options);
       let result: Result<O, Error>;
 
       try {
@@ -223,7 +249,10 @@ export const createTracksLayer = (
         result = ResultCtor.err(normalizeThrownError(error));
       }
 
-      const completed = completeRecord(execution.record, result);
+      const completed = mergeAnnotations(
+        completeRecord(execution.record, result),
+        execution.getAnnotations()
+      );
 
       if (
         shouldWrite(completed, execution.sampled, options?.keepOnError ?? true)

--- a/packages/tracks/src/tracks-layer.ts
+++ b/packages/tracks/src/tracks-layer.ts
@@ -15,10 +15,28 @@ import {
 
 import type { TrackRecord } from './record.js';
 import { createTrackRecord } from './record.js';
+import type { SamplingConfig } from './sampling.js';
+import { shouldSample } from './sampling.js';
+import type { TraceContext } from './trace-context.js';
+import {
+  TRACE_CONTEXT_KEY,
+  childTraceContext,
+  getTraceContext,
+} from './trace-context.js';
 
 /** Sink that receives completed TrackRecords. */
 export interface TrackSink {
   readonly write: (record: TrackRecord) => void | Promise<void>;
+}
+
+/** Options for configuring the tracks layer. */
+export interface TracksLayerOptions {
+  /** Intent-based sampling overrides. */
+  readonly sampling?: Partial<SamplingConfig> | undefined;
+  /** Promote sampled-out traces to sampled on error. Default true. */
+  readonly keepOnError?: boolean | undefined;
+  /** Observe sink write failures without affecting trail delivery. */
+  readonly onSinkError?: ((error: unknown) => void) | undefined;
 }
 
 /** Outcome fields derived from a trail execution result. */
@@ -30,9 +48,9 @@ interface TrackOutcome {
 /** Derive status and errorCategory from a trail result. */
 const deriveOutcome = (result: Result<unknown, Error>): TrackOutcome =>
   result.match<TrackOutcome>({
-    err: (e) => ({
-      errorCategory: e instanceof TrailsError ? e.category : undefined,
-      status: e instanceof CancelledError ? 'cancelled' : 'err',
+    err: (error) => ({
+      errorCategory: error instanceof TrailsError ? error.category : undefined,
+      status: error instanceof CancelledError ? 'cancelled' : 'err',
     }),
     ok: () => ({ errorCategory: undefined, status: 'ok' }),
   });
@@ -47,6 +65,75 @@ const normalizeThrownError = (error: unknown): Error => {
   }
   return new InternalError(String(error));
 };
+
+/** Create a root trace context for a new trace. */
+const createRootTrace = (sampled: boolean): TraceContext => {
+  const spanId = Bun.randomUUIDv7();
+  return {
+    rootId: spanId,
+    sampled,
+    spanId,
+    traceId: Bun.randomUUIDv7(),
+  };
+};
+
+/** Build a completed record from a base record and execution result. */
+const completeRecord = (
+  record: TrackRecord,
+  result: Result<unknown, Error>
+): TrackRecord => ({
+  ...record,
+  ...deriveOutcome(result),
+  endedAt: Date.now(),
+});
+
+/** Resolve whether this invocation should be sampled. */
+const resolveSampled = (
+  parentTrace: TraceContext | undefined,
+  intent: 'read' | 'write' | 'destroy' | undefined,
+  sampling: Partial<SamplingConfig> | undefined
+): boolean => {
+  if (parentTrace) {
+    return parentTrace.sampled;
+  }
+  if (sampling && Object.keys(sampling).length > 0) {
+    return shouldSample(intent, sampling);
+  }
+  return true;
+};
+
+/** Enrich a context with trace context in extensions. */
+const enrichExtensions = (
+  ctx: TrailContext,
+  trace: TraceContext
+): TrailContext => ({
+  ...ctx,
+  extensions: {
+    ...ctx.extensions,
+    [TRACE_CONTEXT_KEY]: trace,
+  },
+});
+
+/** Decide whether a completed record should be written to the sink. */
+const shouldWrite = (
+  record: TrackRecord,
+  sampled: boolean,
+  keepOnError: boolean
+): boolean => {
+  if (sampled) {
+    return true;
+  }
+  return keepOnError && record.status === 'err';
+};
+
+/** Resolve the trace context for this invocation — child or root. */
+const resolveTrace = (
+  parentTrace: TraceContext | undefined,
+  sampled: boolean
+): TraceContext =>
+  parentTrace
+    ? { ...childTraceContext(parentTrace), sampled }
+    : createRootTrace(sampled);
 
 /** Extract permit fields from ctx for the track record. */
 const extractPermit = (
@@ -64,33 +151,88 @@ const extractPermit = (
     : { id: ctx.permit.id, tenantId };
 };
 
-export const createTracksLayer = (sink: TrackSink): Layer => ({
+/** Notify sink observers without letting secondary failures escape. */
+const notifySinkError = (
+  options: TracksLayerOptions | undefined,
+  error: unknown
+): void => {
+  try {
+    options?.onSinkError?.(error);
+  } catch {
+    // Observer failures must never affect trail result delivery.
+  }
+};
+
+/** Prepare the trace, record, and enriched context for a trail execution. */
+const prepareExecution = <I, O>(
+  trail: Trail<I, O>,
+  ctx: TrailContext,
+  options?: TracksLayerOptions
+) => {
+  const parentTrace = getTraceContext(ctx);
+  const sampled = resolveSampled(parentTrace, trail.intent, options?.sampling);
+  const trace = resolveTrace(parentTrace, sampled);
+  const isRoot = parentTrace === undefined;
+
+  const record = createTrackRecord({
+    intent: trail.intent,
+    parentId: parentTrace?.spanId,
+    permit: extractPermit(ctx),
+    rootId: isRoot ? undefined : trace.rootId,
+    surface: ctx.extensions?.[SURFACE_KEY] as TrackRecord['surface'],
+    traceId: trace.traceId,
+    trailId: trail.id,
+  });
+
+  const enrichedTrace: TraceContext = {
+    ...trace,
+    rootId: isRoot ? record.id : trace.rootId,
+    spanId: record.id,
+  };
+
+  return {
+    ctx: enrichExtensions(ctx, enrichedTrace),
+    record,
+    sampled,
+  };
+};
+
+/**
+ * Layer that automatically records every trail execution.
+ *
+ * Wraps each trail implementation to capture timing, status, and parentage,
+ * then writes the completed record to the provided sink. Injects trace
+ * context into `ctx.extensions` so child trails inherit the trace. Supports
+ * intent-based sampling and error promotion for sampled-out traces.
+ */
+export const createTracksLayer = (
+  sink: TrackSink,
+  options?: TracksLayerOptions
+): Layer => ({
   description: 'Automatic trail execution recording',
   name: 'tracks',
   wrap:
     <I, O>(trail: Trail<I, O>, impl: Implementation<I, O>) =>
     async (input: I, ctx) => {
-      const record = createTrackRecord({
-        intent: trail.intent,
-        permit: extractPermit(ctx),
-        surface: ctx.extensions?.[SURFACE_KEY] as TrackRecord['surface'],
-        trailId: trail.id,
-      });
+      const execution = prepareExecution(trail, ctx, options);
       let result: Result<O, Error>;
+
       try {
-        result = await impl(input, ctx);
+        result = await impl(input, execution.ctx);
       } catch (error: unknown) {
         result = ResultCtor.err(normalizeThrownError(error));
       }
-      const completed: TrackRecord = {
-        ...record,
-        ...deriveOutcome(result),
-        endedAt: Date.now(),
-      };
 
-      await Promise.resolve(sink.write(completed)).catch(() => {
-        // sink failures must not affect trail result delivery
-      });
+      const completed = completeRecord(execution.record, result);
+
+      if (
+        shouldWrite(completed, execution.sampled, options?.keepOnError ?? true)
+      ) {
+        await Promise.resolve(sink.write(completed)).catch((error) => {
+          notifySinkError(options, error);
+        });
+      }
+
       return result;
     },
 });

--- a/packages/tracks/src/tracks-layer.ts
+++ b/packages/tracks/src/tracks-layer.ts
@@ -1,0 +1,96 @@
+import type {
+  Implementation,
+  Layer,
+  Result,
+  Trail,
+  TrailContext,
+} from '@ontrails/core';
+import {
+  CancelledError,
+  InternalError,
+  Result as ResultCtor,
+  SURFACE_KEY,
+  TrailsError,
+} from '@ontrails/core';
+
+import type { TrackRecord } from './record.js';
+import { createTrackRecord } from './record.js';
+
+/** Sink that receives completed TrackRecords. */
+export interface TrackSink {
+  readonly write: (record: TrackRecord) => void | Promise<void>;
+}
+
+/** Outcome fields derived from a trail execution result. */
+interface TrackOutcome {
+  readonly status: TrackRecord['status'];
+  readonly errorCategory: string | undefined;
+}
+
+/** Derive status and errorCategory from a trail result. */
+const deriveOutcome = (result: Result<unknown, Error>): TrackOutcome =>
+  result.match<TrackOutcome>({
+    err: (e) => ({
+      errorCategory: e instanceof TrailsError ? e.category : undefined,
+      status: e instanceof CancelledError ? 'cancelled' : 'err',
+    }),
+    ok: () => ({ errorCategory: undefined, status: 'ok' }),
+  });
+
+/** Normalize thrown implementation errors into Trails-friendly failures. */
+const normalizeThrownError = (error: unknown): Error => {
+  if (error instanceof TrailsError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new InternalError(error.message, { cause: error });
+  }
+  return new InternalError(String(error));
+};
+
+/** Extract permit fields from ctx for the track record. */
+const extractPermit = (
+  ctx: TrailContext
+): { readonly id: string; readonly tenantId?: string } | undefined => {
+  if (ctx.permit === undefined) {
+    return undefined;
+  }
+  const tenantId =
+    'tenantId' in ctx.permit
+      ? (ctx.permit as { tenantId?: string }).tenantId
+      : undefined;
+  return tenantId === undefined
+    ? { id: ctx.permit.id }
+    : { id: ctx.permit.id, tenantId };
+};
+
+export const createTracksLayer = (sink: TrackSink): Layer => ({
+  description: 'Automatic trail execution recording',
+  name: 'tracks',
+  wrap:
+    <I, O>(trail: Trail<I, O>, impl: Implementation<I, O>) =>
+    async (input: I, ctx) => {
+      const record = createTrackRecord({
+        intent: trail.intent,
+        permit: extractPermit(ctx),
+        surface: ctx.extensions?.[SURFACE_KEY] as TrackRecord['surface'],
+        trailId: trail.id,
+      });
+      let result: Result<O, Error>;
+      try {
+        result = await impl(input, ctx);
+      } catch (error: unknown) {
+        result = ResultCtor.err(normalizeThrownError(error));
+      }
+      const completed: TrackRecord = {
+        ...record,
+        ...deriveOutcome(result),
+        endedAt: Date.now(),
+      };
+
+      await Promise.resolve(sink.write(completed)).catch(() => {
+        // sink failures must not affect trail result delivery
+      });
+      return result;
+    },
+});

--- a/packages/tracks/src/tracks-service.ts
+++ b/packages/tracks/src/tracks-service.ts
@@ -1,0 +1,28 @@
+import { Result, service } from '@ontrails/core';
+
+import type { TracksState } from './registry.js';
+import { getTracksState } from './registry.js';
+import { DEFAULT_SAMPLING } from './sampling.js';
+
+/** Default state when no explicit state has been registered. */
+const defaultState: TracksState = {
+  active: true,
+  sampling: DEFAULT_SAMPLING,
+  store: undefined,
+};
+
+/**
+ * Telemetry recording and query service.
+ *
+ * Wraps the track store, sampling config, and active flag as a single
+ * `TracksState` accessible to trails via `tracksService.from(ctx)`.
+ *
+ * Unlike config, tracks gracefully defaults when no state is registered —
+ * telemetry should never fail to start.
+ */
+export const tracksService = service<TracksState>('tracks', {
+  create: () => Result.ok(getTracksState() ?? defaultState),
+  description: 'Telemetry recording and query service',
+  metadata: { category: 'infrastructure' },
+  mock: (): TracksState => ({ ...defaultState }),
+});

--- a/packages/tracks/src/trails/tracks-query.ts
+++ b/packages/tracks/src/trails/tracks-query.ts
@@ -1,0 +1,99 @@
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import type { DevStoreQueryOptions } from '../stores/dev.js';
+import { tracksService } from '../tracks-service.js';
+
+/** Output schema for individual track records. */
+const trackRecordOutput = z.object({
+  endedAt: z.number().optional(),
+  id: z.string(),
+  intent: z.string().optional(),
+  kind: z.enum(['trail', 'span']),
+  name: z.string(),
+  parentId: z.string().optional(),
+  startedAt: z.number(),
+  status: z.enum(['ok', 'err', 'cancelled']),
+  surface: z.string().optional(),
+  traceId: z.string(),
+  trailId: z.string().optional(),
+});
+
+/** Output schema for the tracks.query trail. */
+const tracksQueryOutput = z.object({
+  count: z.number(),
+  records: z.array(trackRecordOutput),
+});
+
+/** Map a TrackRecord to the output shape, dropping internal fields. */
+const mapRecord = (r: {
+  readonly endedAt?: number | undefined;
+  readonly id: string;
+  readonly intent?: string | undefined;
+  readonly kind: 'trail' | 'span';
+  readonly name: string;
+  readonly parentId?: string | undefined;
+  readonly startedAt: number;
+  readonly status: 'ok' | 'err' | 'cancelled';
+  readonly surface?: string | undefined;
+  readonly traceId: string;
+  readonly trailId?: string | undefined;
+}) => ({
+  endedAt: r.endedAt,
+  id: r.id,
+  intent: r.intent,
+  kind: r.kind,
+  name: r.name,
+  parentId: r.parentId,
+  startedAt: r.startedAt,
+  status: r.status,
+  surface: r.surface,
+  traceId: r.traceId,
+  trailId: r.trailId,
+});
+
+/** Build DevStoreQueryOptions, omitting undefined fields for exactOptionalPropertyTypes. */
+const buildQueryOptions = (input: {
+  readonly errorsOnly: boolean;
+  readonly limit: number;
+  readonly traceId?: string | undefined;
+  readonly trailId?: string | undefined;
+}): DevStoreQueryOptions => ({
+  errorsOnly: input.errorsOnly,
+  limit: input.limit,
+  ...(input.trailId === undefined ? {} : { trailId: input.trailId }),
+  ...(input.traceId === undefined ? {} : { traceId: input.traceId }),
+});
+
+/**
+ * Query execution history from the tracks dev store.
+ *
+ * Reads the store from the `tracksService` state. Returns an empty
+ * result set when no store has been configured.
+ */
+export const tracksQuery = trail('tracks.query', {
+  examples: [
+    { input: {}, name: 'Recent traces' },
+    { input: { trailId: 'user.create' }, name: 'Filter by trail' },
+    { input: { errorsOnly: true }, name: 'Errors only' },
+  ],
+  input: z.object({
+    errorsOnly: z.boolean().describe('Show only failed traces').default(false),
+    limit: z.number().describe('Max results').default(20),
+    traceId: z.string().describe('Show full trace tree').optional(),
+    trailId: z.string().describe('Filter by trail ID').optional(),
+  }),
+  intent: 'read',
+  metadata: { category: 'infrastructure' },
+  output: tracksQueryOutput,
+  run: (input, ctx) => {
+    const state = tracksService.from(ctx);
+    if (!state.store) {
+      return Result.ok({ count: 0, records: [] });
+    }
+    const records = state.store.query(buildQueryOptions(input));
+    const mapped = records.map(mapRecord);
+    return Result.ok({ count: mapped.length, records: mapped });
+  },
+  services: [tracksService],
+});

--- a/packages/tracks/src/trails/tracks-status.ts
+++ b/packages/tracks/src/trails/tracks-status.ts
@@ -1,0 +1,44 @@
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { tracksService } from '../tracks-service.js';
+
+/** Output schema for the tracks.status trail. */
+const tracksStatusOutput = z.object({
+  active: z.boolean(),
+  recordCount: z.number(),
+  samplingConfig: z.object({
+    destroy: z.number(),
+    read: z.number(),
+    write: z.number(),
+  }),
+});
+
+/**
+ * Reports the current status of the tracks telemetry subsystem.
+ *
+ * Returns whether tracking is active, the current record count, and
+ * the sampling configuration for each intent. Reads all values from
+ * the `tracksService` state.
+ */
+export const tracksStatus = trail('tracks.status', {
+  examples: [
+    {
+      input: {},
+      name: 'Check tracks status',
+    },
+  ],
+  input: z.object({}),
+  intent: 'read',
+  metadata: { category: 'infrastructure' },
+  output: tracksStatusOutput,
+  run: (_input, ctx) => {
+    const state = tracksService.from(ctx);
+    return Result.ok({
+      active: state.active,
+      recordCount: state.store?.count() ?? 0,
+      samplingConfig: { ...state.sampling },
+    });
+  },
+  services: [tracksService],
+});

--- a/packages/tracks/tsconfig.json
+++ b/packages/tracks/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -9,9 +9,10 @@ Core defines ports. Everything on the edges is an adapter.
             How the world calls in          How the framework calls out
             +--------------------+          +--------------------+
             |  CLI (commander)   |          |  Services (core)   |
-            |  MCP (sdk)         |          |  Logging (logtape) |
-            |  HTTP (hono)       |          |  Storage (planned) |
-            |  WebSocket (plan.) |          |  Telemetry (planned)|
+            |  MCP (sdk)         |          |  Config (config)   |
+            |  HTTP (hono)       |          |  Permits (permits) |
+            |  WebSocket (plan.) |          |  Tracks (tracks)   |
+            |                    |          |  Logging (logtape) |
             +---------+----------+          +---------+----------+
                       |                               |
                       +-------> @ontrails/core <------+
@@ -94,6 +95,9 @@ Warden uses inference to verify declarations match actual code. The surface map 
 
 | Package | Purpose | External dep |
 |---------|---------|-------------|
+| `@ontrails/config` | Config resolution, loadouts, service config schemas, diagnostics | None beyond core |
+| `@ontrails/permits` | Auth layer, permit model, JWT adapter, scope enforcement | None beyond core |
+| `@ontrails/tracks` | Telemetry recording, trace context, memory/OTel sinks | None beyond core |
 | `@ontrails/logging` | Structured logging, sinks, formatters | None beyond core |
 | `@ontrails/logging/logtape` | LogTape sink adapter | `@logtape/logtape` (peer) |
 
@@ -112,6 +116,9 @@ Warden uses inference to verify declarations match actual code. The surface map 
   <- @ontrails/cli (core)
   <- @ontrails/mcp (core, @modelcontextprotocol/sdk)
   <- @ontrails/http (core, hono peer)
+  <- @ontrails/config (core)
+  <- @ontrails/permits (core)
+  <- @ontrails/tracks (core)
   <- @ontrails/logging (core)
   <- @ontrails/testing (core, cli, mcp, logging)
   <- @ontrails/schema (core)


### PR DESCRIPTION
## Summary

Documentation sweep reflecting the three new infrastructure packages:

- **architecture.md** — updated hexagonal diagram right side with Config, Permits, Tracks; dependency graph updated
- **vocabulary.md** — moved `permit`, `loadout`, `tracks` from Reserved to Locked with code examples
- **horizons.md** — Config, Permits, Tracks moved to Shipped section
- **services.md** — added `ServiceSpec.config` section with Zod schema example
- **testing.md** — added infrastructure testing section (loadouts, synthetic permits, memory sink)
- **plugin architecture reference** — mirrored hexagonal diagram updates

## Test plan

- [ ] `markdownlint` passes on all changed files
- [ ] No new branded terms outside `docs/vocabulary.md`

Closed: TRL-127

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
