### PR TITLE
fix(ci): rename aggregate job to CI Gate for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
         run: bun apps/ci/bin/ci.ts --format github --fail-on error
         continue-on-error: true
 
-  ci-summary:
-    name: CI
+  ci-gate:
+    name: CI Gate
     if: always()
     needs: [build, lint, typecheck, test, governance]
     runs-on: ubuntu-latest
@@ -135,6 +135,6 @@ jobs:
           echo "| Test | \`${{ needs.test.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Governance | \`${{ needs.governance.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Check for failures
+      - name: Require all jobs to pass
         if: contains(needs.*.result, 'failure') && !cancelled()
         run: exit 1


### PR DESCRIPTION
## Summary

- Rename the aggregate CI job from "CI" to "CI Gate" so it's visually distinct from individual job names (Build, Lint, Typecheck, Test, Governance)
- Keep the `exit 1` gate so it works as a single required status check in branch protection
- When setting up branch protection on `main`, require **"CI Gate"** as the required check

## Test plan

- [ ] "CI Gate" appears as a distinct check name in GitHub Actions
- [ ] When a job fails, "CI Gate" also fails (the gate works)
- [ ] Individual job names remain clear and don't duplicate the gate name

In-collaboration-with: [Claude Code](https://claude.com/claude-code)