### PR TITLE
chore: version packages to 1.0.0-beta.12

### DIFF
--- a/.changeset/beta12-config-permits-crumbs.md
+++ b/.changeset/beta12-config-permits-crumbs.md
@@ -1,0 +1,19 @@
+---
+"@ontrails/config": minor
+"@ontrails/permits": minor
+"@ontrails/crumbs": minor
+"@ontrails/core": patch
+"@ontrails/cli": patch
+"@ontrails/testing": patch
+"@ontrails/mcp": patch
+"@ontrails/http": patch
+---
+
+Complete trifecta for config, permits, and crumbs (formerly tracks)
+
+- **config**: Add `configService`, `config.layer`, `config.trail`, and `config.workspace` trails with full `defineConfig`, `resolve`, `describe`, `explain`, `doctor`, and code generation support
+- **permits**: Add `authService` and `auth.verify` trail for runtime authorization checks
+- **crumbs**: Rename tracks to crumbs; add `crumbsService` and `crumbs.status` trail for structured event tracking
+- **cli**: Fix build flag handling and improve bootstrap scaffolding
+- **testing**: Expand test context helpers and example-based testing utilities
+- **core/mcp/http**: Internal alignment for service and composition updates

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -11,11 +11,16 @@
     "@ontrails/schema": "0.1.0",
     "@ontrails/testing": "0.1.0",
     "@ontrails/warden": "0.1.0",
-    "@ontrails/http": "1.0.0-beta.6"
+    "@ontrails/http": "1.0.0-beta.6",
+    "stash": "0.1.0",
+    "@ontrails/config": "1.0.0-beta.11",
+    "@ontrails/crumbs": "1.0.0-beta.11",
+    "@ontrails/permits": "1.0.0-beta.11"
   },
   "changesets": [
     "api-simplification-beta4",
     "beta10-cleanup-and-hardening",
+    "beta12-config-permits-crumbs",
     "beta9-consolidated",
     "bug-fixes-beta3",
     "codex-review-fixes",

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 .turbo/
 .scratch/
+.try/
 *.tsbuildinfo
 .DS_Store
 .trail/

--- a/apps/trails/CHANGELOG.md
+++ b/apps/trails/CHANGELOG.md
@@ -1,5 +1,16 @@
 # trails
 
+## 1.0.0-beta.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12
+  - @ontrails/cli@1.0.0-beta.12
+  - @ontrails/logging@1.0.0-beta.12
+  - @ontrails/schema@1.0.0-beta.12
+  - @ontrails/warden@1.0.0-beta.12
+
 ## 1.0.0-beta.11
 
 ### Patch Changes

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/trails",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "bin": {
     "trails": "./bin/trails.ts"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "apps/trails": {
       "name": "@ontrails/trails",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "bin": {
         "trails": "./bin/trails.ts",
       },
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "@ontrails/cli",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -90,7 +90,7 @@
     },
     "packages/config": {
       "name": "@ontrails/config",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -98,14 +98,14 @@
     },
     "packages/core": {
       "name": "@ontrails/core",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "peerDependencies": {
         "zod": "catalog:",
       },
     },
     "packages/crumbs": {
       "name": "@ontrails/crumbs",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -113,7 +113,7 @@
     },
     "packages/http": {
       "name": "@ontrails/http",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -127,14 +127,14 @@
     },
     "packages/logging": {
       "name": "@ontrails/logging",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
       },
     },
     "packages/mcp": {
       "name": "@ontrails/mcp",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -145,7 +145,7 @@
     },
     "packages/permits": {
       "name": "@ontrails/permits",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -153,7 +153,7 @@
     },
     "packages/schema": {
       "name": "@ontrails/schema",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -161,7 +161,7 @@
     },
     "packages/testing": {
       "name": "@ontrails/testing",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "peerDependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
@@ -172,7 +172,7 @@
     },
     "packages/warden": {
       "name": "@ontrails/warden",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "devDependencies": {
         "@ontrails/testing": "workspace:^",
         "@oxc-project/types": "^0.122.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   },
   "workspaces": [
     "packages/*",
-    "apps/*"
+    "apps/*",
+    ".try/*"
   ],
   "scripts": {
     "build": "turbo run build",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @ontrails/cli
 
+## 1.0.0-beta.12
+
+### Patch Changes
+
+- Complete trifecta for config, permits, and crumbs (formerly tracks)
+
+  - **config**: Add `configService`, `config.layer`, `config.trail`, and `config.workspace` trails with full `defineConfig`, `resolve`, `describe`, `explain`, `doctor`, and code generation support
+  - **permits**: Add `authService` and `auth.verify` trail for runtime authorization checks
+  - **crumbs**: Rename tracks to crumbs; add `crumbsService` and `crumbs.status` trail for structured event tracking
+  - **cli**: Fix build flag handling and improve bootstrap scaffolding
+  - **testing**: Expand test context helpers and example-based testing utilities
+  - **core/mcp/http**: Internal alignment for service and composition updates
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12
+
 ## 1.0.0-beta.11
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/cli",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,0 +1,19 @@
+# @ontrails/config
+
+## 1.0.0-beta.12
+
+### Minor Changes
+
+- Complete trifecta for config, permits, and crumbs (formerly tracks)
+
+  - **config**: Add `configService`, `config.layer`, `config.trail`, and `config.workspace` trails with full `defineConfig`, `resolve`, `describe`, `explain`, `doctor`, and code generation support
+  - **permits**: Add `authService` and `auth.verify` trail for runtime authorization checks
+  - **crumbs**: Rename tracks to crumbs; add `crumbsService` and `crumbs.status` trail for structured event tracking
+  - **cli**: Fix build flag handling and improve bootstrap scaffolding
+  - **testing**: Expand test context helpers and example-based testing utilities
+  - **core/mcp/http**: Internal alignment for service and composition updates
+
+### Patch Changes
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/config",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @ontrails/core
 
+## 1.0.0-beta.12
+
+### Patch Changes
+
+- Complete trifecta for config, permits, and crumbs (formerly tracks)
+
+  - **config**: Add `configService`, `config.layer`, `config.trail`, and `config.workspace` trails with full `defineConfig`, `resolve`, `describe`, `explain`, `doctor`, and code generation support
+  - **permits**: Add `authService` and `auth.verify` trail for runtime authorization checks
+  - **crumbs**: Rename tracks to crumbs; add `crumbsService` and `crumbs.status` trail for structured event tracking
+  - **cli**: Fix build flag handling and improve bootstrap scaffolding
+  - **testing**: Expand test context helpers and example-based testing utilities
+  - **core/mcp/http**: Internal alignment for service and composition updates
+
 ## 1.0.0-beta.11
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/core",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/crumbs/CHANGELOG.md
+++ b/packages/crumbs/CHANGELOG.md
@@ -1,0 +1,19 @@
+# @ontrails/crumbs
+
+## 1.0.0-beta.12
+
+### Minor Changes
+
+- Complete trifecta for config, permits, and crumbs (formerly tracks)
+
+  - **config**: Add `configService`, `config.layer`, `config.trail`, and `config.workspace` trails with full `defineConfig`, `resolve`, `describe`, `explain`, `doctor`, and code generation support
+  - **permits**: Add `authService` and `auth.verify` trail for runtime authorization checks
+  - **crumbs**: Rename tracks to crumbs; add `crumbsService` and `crumbs.status` trail for structured event tracking
+  - **cli**: Fix build flag handling and improve bootstrap scaffolding
+  - **testing**: Expand test context helpers and example-based testing utilities
+  - **core/mcp/http**: Internal alignment for service and composition updates
+
+### Patch Changes
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12

--- a/packages/crumbs/package.json
+++ b/packages/crumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/crumbs",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @ontrails/http
 
+## 1.0.0-beta.12
+
+### Patch Changes
+
+- Complete trifecta for config, permits, and crumbs (formerly tracks)
+
+  - **config**: Add `configService`, `config.layer`, `config.trail`, and `config.workspace` trails with full `defineConfig`, `resolve`, `describe`, `explain`, `doctor`, and code generation support
+  - **permits**: Add `authService` and `auth.verify` trail for runtime authorization checks
+  - **crumbs**: Rename tracks to crumbs; add `crumbsService` and `crumbs.status` trail for structured event tracking
+  - **cli**: Fix build flag handling and improve bootstrap scaffolding
+  - **testing**: Expand test context helpers and example-based testing utilities
+  - **core/mcp/http**: Internal alignment for service and composition updates
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12
+
 ## 1.0.0-beta.11
 
 ### Patch Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/http",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/logging/CHANGELOG.md
+++ b/packages/logging/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/logging
 
+## 1.0.0-beta.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12
+
 ## 1.0.0-beta.11
 
 ### Patch Changes

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/logging",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @ontrails/mcp
 
+## 1.0.0-beta.12
+
+### Patch Changes
+
+- Complete trifecta for config, permits, and crumbs (formerly tracks)
+
+  - **config**: Add `configService`, `config.layer`, `config.trail`, and `config.workspace` trails with full `defineConfig`, `resolve`, `describe`, `explain`, `doctor`, and code generation support
+  - **permits**: Add `authService` and `auth.verify` trail for runtime authorization checks
+  - **crumbs**: Rename tracks to crumbs; add `crumbsService` and `crumbs.status` trail for structured event tracking
+  - **cli**: Fix build flag handling and improve bootstrap scaffolding
+  - **testing**: Expand test context helpers and example-based testing utilities
+  - **core/mcp/http**: Internal alignment for service and composition updates
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12
+
 ## 1.0.0-beta.11
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/mcp",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/permits/CHANGELOG.md
+++ b/packages/permits/CHANGELOG.md
@@ -1,0 +1,19 @@
+# @ontrails/permits
+
+## 1.0.0-beta.12
+
+### Minor Changes
+
+- Complete trifecta for config, permits, and crumbs (formerly tracks)
+
+  - **config**: Add `configService`, `config.layer`, `config.trail`, and `config.workspace` trails with full `defineConfig`, `resolve`, `describe`, `explain`, `doctor`, and code generation support
+  - **permits**: Add `authService` and `auth.verify` trail for runtime authorization checks
+  - **crumbs**: Rename tracks to crumbs; add `crumbsService` and `crumbs.status` trail for structured event tracking
+  - **cli**: Fix build flag handling and improve bootstrap scaffolding
+  - **testing**: Expand test context helpers and example-based testing utilities
+  - **core/mcp/http**: Internal alignment for service and composition updates
+
+### Patch Changes
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/permits",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/schema
 
+## 1.0.0-beta.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12
+
 ## 1.0.0-beta.11
 
 ### Patch Changes

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/schema",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @ontrails/testing
 
+## 1.0.0-beta.12
+
+### Patch Changes
+
+- Complete trifecta for config, permits, and crumbs (formerly tracks)
+
+  - **config**: Add `configService`, `config.layer`, `config.trail`, and `config.workspace` trails with full `defineConfig`, `resolve`, `describe`, `explain`, `doctor`, and code generation support
+  - **permits**: Add `authService` and `auth.verify` trail for runtime authorization checks
+  - **crumbs**: Rename tracks to crumbs; add `crumbsService` and `crumbs.status` trail for structured event tracking
+  - **cli**: Fix build flag handling and improve bootstrap scaffolding
+  - **testing**: Expand test context helpers and example-based testing utilities
+  - **core/mcp/http**: Internal alignment for service and composition updates
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12
+  - @ontrails/cli@1.0.0-beta.12
+  - @ontrails/mcp@1.0.0-beta.12
+  - @ontrails/logging@1.0.0-beta.12
+
 ## 1.0.0-beta.11
 
 ### Minor Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/testing",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/warden/CHANGELOG.md
+++ b/packages/warden/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/warden
 
+## 1.0.0-beta.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @ontrails/core@1.0.0-beta.12
+  - @ontrails/schema@1.0.0-beta.12
+
 ## 1.0.0-beta.11
 
 ### Minor Changes

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/warden",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",


### PR DESCRIPTION
## Summary

- Version all `@ontrails/*` packages to `1.0.0-beta.12`
- Add changeset covering config, permits, and crumbs trifectas shipped since beta.11
- Fix `.try/stash` workspace reference to use `.try/*` glob so CI doesn't fail when the directory is absent

## What's in beta.12

- **config**: `configService`, `config.layer`, `config.trail`, `config.workspace` trails with `defineConfig`, `resolve`, `describe`, `explain`, `doctor`, and code generation
- **permits**: `authService` and `auth.verify` trail for runtime authorization
- **crumbs**: Rename tracks → crumbs; `crumbsService` and `crumbs.status` trail for structured event tracking
- **cli**: Build flag fixes and bootstrap scaffolding improvements
- **testing**: Expanded test context helpers and example-based testing utilities
- **core/mcp/http**: Internal alignment for service and composition updates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
