### PR TITLE
fix: add missing packages to publish script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -24,7 +24,11 @@ PACKAGES=(
   packages/core
   packages/logging
   packages/schema
+  packages/config
+  packages/permits
+  packages/crumbs
   packages/cli
+  packages/http
   packages/mcp
   packages/testing
   packages/warden


### PR DESCRIPTION
Add config, permits, crumbs, and http to the PACKAGES array so they are included in future publish runs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
