### PR TITLE
feat(cli): derive hierarchical command trees

### DIFF
--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -86,6 +86,7 @@ describe('trails survey', () => {
     const trailheadMap = generateTrailheadMap(app);
     const hello = trailheadMap.entries.find((e) => e.id === 'hello');
     expect(hello).toBeDefined();
+    expect(hello?.cli?.path).toEqual(['hello']);
     expect(hello?.kind).toBe('trail');
     expect(hello?.intent).toBe('read');
     expect(hello?.exampleCount).toBe(1);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -61,6 +61,7 @@ TopoIssue
 
 // Schema derivation
 deriveFields(schema, overrides?)   // → Field[]
+deriveCliPath(trailId)             // dotted trail ID → ordered CLI path segments
 Field, FieldOverride
 
 // Resilience
@@ -92,6 +93,7 @@ findWorkspaceRoot, isInsideWorkspace, getRelativePath
 ```typescript
 trailhead(topo, options?)              // one-liner (from @ontrails/cli/commander)
 buildCliCommands(topo, options?)   // escape hatch step 1
+validateCliCommands(commands)      // validate command tree shape and collisions
 toCommander(commands, options?)    // escape hatch step 2
 deriveFlags(schema, overrides?)    // Zod → CLI flags
 output(value, mode)                // write to stdout in text/json/jsonl

--- a/docs/trailheads/cli.md
+++ b/docs/trailheads/cli.md
@@ -20,7 +20,7 @@ That is the entire CLI setup. Every trail in the app becomes a command.
 
 ## How Trail IDs Map to Commands
 
-Trail IDs with dots create subcommand groups:
+Trail IDs derive to full ordered command paths:
 
 | Trail ID      | CLI command         |
 | ------------- | ------------------- |
@@ -28,8 +28,15 @@ Trail IDs with dots create subcommand groups:
 | `entity.show` | `myapp entity show` |
 | `entity.add`  | `myapp entity add`  |
 | `math.add`    | `myapp math add`    |
+| `topo.pin`    | `myapp topo pin`    |
 
-Trails sharing the same first segment are grouped under a parent command.
+Each dot becomes another command-path segment. A path node may be both
+executable and a parent, so `myapp topo` and `myapp topo pin` can coexist
+naturally.
+
+The CLI model is validated before adapter wiring. Duplicate command paths are
+rejected, and executable parents cannot also declare positional args if child
+commands exist beneath that path.
 
 ## Flag Derivation
 
@@ -198,4 +205,6 @@ import { trailhead } from '@ontrails/cli/commander';
 trailhead(app);
 ```
 
-To use a different CLI framework (yargs, oclif, etc.), consume `CliCommand[]` directly and write your own connector. The model carries everything needed: command names, flags, args, groups, and an `execute()` function.
+To use a different CLI framework (yargs, oclif, etc.), consume `CliCommand[]`
+directly and write your own connector. The model carries everything needed: a
+full ordered command path, flags, args, and an `execute()` function.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,6 +42,9 @@ program.parse();
 ```
 
 `buildCliCommands` returns a framework-agnostic `CliCommand[]`. Use `toCommander` for Commander, or write your own connector.
+Invalid command models are rejected before adapter wiring, including duplicate
+CLI paths and executable parents that also declare positional args beneath child
+commands.
 
 ## API
 
@@ -49,6 +52,7 @@ program.parse();
 | --- | --- |
 | `trailhead(app, options?)` | One-liner: build commands, wire Commander, parse argv |
 | `buildCliCommands(app)` | Framework-agnostic command builder, returns `CliCommand[]` |
+| `validateCliCommands(commands)` | Validate `CliCommand[]` shapes before wiring a CLI adapter |
 | `toCommander(commands, options?)` | Connect `CliCommand[]` to a Commander program |
 | `deriveFlags(schema)` | Extract CLI flags from a Zod schema |
 | `output(data, mode)` | Format output as JSON, JSONL, or text |
@@ -72,7 +76,18 @@ Flags come from the Zod schema automatically. No manual flag definitions.
 
 ## Subcommands
 
-Dotted trail IDs create subcommand groups: `entity.show` becomes `myapp entity show`.
+Dotted trail IDs derive to full ordered command paths:
+
+- `entity.show` -> `myapp entity show`
+- `topo.pin` -> `myapp topo pin`
+- `topo.pin.remove` -> `myapp topo pin remove`
+
+Command-path nodes may be both executable and parents, so `myapp topo` and
+`myapp topo pin` can coexist naturally.
+
+`CliCommand[]` validation rejects ambiguous parent/child shapes, so an
+executable parent cannot also declare positional args if child commands exist
+beneath that path.
 
 ## Service resolution
 

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -47,7 +47,7 @@ const requireCommand = (commands: ReturnType<typeof buildCliCommands>) => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('buildCliCommands', () => {
+describe('buildCliCommands path derivation', () => {
   test('builds commands from a simple app with one trail', () => {
     const t = trail('greet', {
       blaze: (input: { name: string }) => Result.ok(`Hello, ${input.name}`),
@@ -56,11 +56,10 @@ describe('buildCliCommands', () => {
     const app = makeApp(t);
     const commands = buildCliCommands(app);
     expect(commands).toHaveLength(1);
-    expect(commands[0]?.name).toBe('greet');
-    expect(commands[0]?.group).toBeUndefined();
+    expect(commands[0]?.path).toEqual(['greet']);
   });
 
-  test('builds grouped subcommands from dotted trail IDs', () => {
+  test('builds full ordered paths from dotted trail IDs', () => {
     const show = trail('entity.show', {
       blaze: (input: { id: string }) => Result.ok({ id: input.id }),
       input: z.object({ id: z.string() }),
@@ -72,10 +71,19 @@ describe('buildCliCommands', () => {
     const app = makeApp(show, add);
     const commands = buildCliCommands(app);
     expect(commands).toHaveLength(2);
-    expect(commands[0]?.group).toBe('entity');
-    expect(commands[0]?.name).toBe('show');
-    expect(commands[1]?.group).toBe('entity');
-    expect(commands[1]?.name).toBe('add');
+    expect(commands[0]?.path).toEqual(['entity', 'show']);
+    expect(commands[1]?.path).toEqual(['entity', 'add']);
+  });
+
+  test('preserves deeper CLI hierarchies from multi-dot trail IDs', () => {
+    const remove = trail('topo.pin.remove', {
+      blaze: () => Result.ok({ removed: true }),
+      input: z.object({ name: z.string() }),
+    });
+    const app = makeApp(remove);
+    const commands = buildCliCommands(app);
+
+    expect(commands[0]?.path).toEqual(['topo', 'pin', 'remove']);
   });
 
   test('derives flags from input schema', () => {
@@ -108,7 +116,9 @@ describe('buildCliCommands', () => {
     expect(dryRunFlag).toBeDefined();
     expect(dryRunFlag?.type).toBe('boolean');
   });
+});
 
+describe('buildCliCommands execution', () => {
   describe('onResult callback', () => {
     test('receives correct context', async () => {
       let captured: ActionResultContext | undefined;

--- a/packages/cli/src/__tests__/to-commander.test.ts
+++ b/packages/cli/src/__tests__/to-commander.test.ts
@@ -55,11 +55,49 @@ const requireCommand = (
   return command;
 };
 
+const requireNestedCommand = (
+  program: ReturnType<typeof toCommander>,
+  path: readonly string[]
+) => {
+  let current = program;
+  for (const segment of path) {
+    const next = current.commands.find((entry) => entry.name() === segment);
+    expect(next).toBeDefined();
+    if (!next) {
+      throw new Error(`Expected command path: ${path.join(' ')}`);
+    }
+    current = next;
+  }
+  return current;
+};
+
+const buildExecutableParentProgram = (calls: string[]) => {
+  const topoShow = trail('topo', {
+    blaze: () => {
+      calls.push('topo');
+      return Result.ok('topo');
+    },
+    input: z.object({}),
+  });
+  const topoPin = trail('topo.pin', {
+    blaze: () => {
+      calls.push('topo.pin');
+      return Result.ok('topo.pin');
+    },
+    input: z.object({}),
+  });
+  const app = makeApp(topoShow, topoPin);
+  const commands = buildCliCommands(app, { onResult: noopResult });
+  const program = toCommander(commands, { name: 'test' });
+  program.exitOverride();
+  return program;
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('toCommander', () => {
+describe('toCommander command trees', () => {
   test('creates a Commander program with correct commands', () => {
     const t = trail('greet', {
       blaze: (input: { name: string }) => Result.ok(`Hello, ${input.name}`),
@@ -88,15 +126,108 @@ describe('toCommander', () => {
     const commands = buildCliCommands(app);
     const program = toCommander(commands);
 
-    // Should have an "entity" parent command
-    const entityCmd = program.commands.find((c) => c.name() === 'entity');
-    expect(entityCmd).toBeDefined();
-    // With "show" and "add" subcommands
+    const entityCmd = requireNestedCommand(program, ['entity']);
     const subNames = entityCmd?.commands.map((c) => c.name());
     expect(subNames).toContain('show');
     expect(subNames).toContain('add');
   });
 
+  test('supports arbitrary-depth nested command trees', () => {
+    const remove = trail('topo.pin.remove', {
+      blaze: () => Result.ok({ removed: true }),
+      input: z.object({ name: z.string() }),
+    });
+    const app = makeApp(remove);
+    const commands = buildCliCommands(app);
+    const program = toCommander(commands);
+
+    const topoCmd = requireNestedCommand(program, ['topo']);
+    const pinCmd = requireNestedCommand(program, ['topo', 'pin']);
+    const removeCmd = requireNestedCommand(program, ['topo', 'pin', 'remove']);
+
+    expect(topoCmd.commands.map((entry) => entry.name())).toContain('pin');
+    expect(pinCmd.commands.map((entry) => entry.name())).toContain('remove');
+    expect(removeCmd.name()).toBe('remove');
+  });
+
+  test('supports executable parents alongside child commands', async () => {
+    const calls: string[] = [];
+    const program = buildExecutableParentProgram(calls);
+
+    const topoCmd = requireNestedCommand(program, ['topo']);
+    expect(topoCmd.commands.map((entry) => entry.name())).toContain('pin');
+
+    await program.parseAsync(['node', 'test', 'topo']);
+    await program.parseAsync(['node', 'test', 'topo', 'pin']);
+
+    expect(calls).toEqual(['topo', 'topo.pin']);
+  });
+});
+
+describe('toCommander validation', () => {
+  test('throws when two commands share the same CLI path', () => {
+    const duplicatePath = ['topo', 'pin'] as const;
+    const commands = [
+      {
+        args: [],
+        execute: async () => await Result.ok('first'),
+        flags: [],
+        intent: 'read' as const,
+        path: duplicatePath,
+        trail: trail('first', {
+          blaze: () => Result.ok('first'),
+          input: z.object({}),
+        }),
+      },
+      {
+        args: [],
+        execute: async () => await Result.ok('second'),
+        flags: [],
+        intent: 'read' as const,
+        path: duplicatePath,
+        trail: trail('second', {
+          blaze: () => Result.ok('second'),
+          input: z.object({}),
+        }),
+      },
+    ];
+
+    expect(() => toCommander(commands)).toThrow('Duplicate CLI path: topo pin');
+  });
+
+  test('rejects executable parents with positional args when child commands exist', () => {
+    const commands = [
+      {
+        args: [{ name: 'ref', required: true, variadic: false }],
+        execute: async () => await Result.ok('topo'),
+        flags: [],
+        intent: 'read' as const,
+        path: ['topo'] as const,
+        trail: trail('topo', {
+          blaze: () => Result.ok('topo'),
+          input: z.object({}),
+        }),
+      },
+      {
+        args: [],
+        execute: async () => await Result.ok('topo.pin'),
+        flags: [],
+        intent: 'read' as const,
+        path: ['topo', 'pin'] as const,
+        trail: trail('topo.pin', {
+          blaze: () => Result.ok('topo.pin'),
+          input: z.object({}),
+        }),
+      },
+    ];
+
+    expect(() => toCommander(commands)).toThrow(
+      'Executable parent commands cannot declare positional args when child commands exist: topo'
+    );
+  });
+});
+
+describe('toCommander option wiring', () => {
   test('flag types map correctly to Commander options', () => {
     const t = trail('search', {
       blaze: () => Result.ok([]),

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -11,11 +11,17 @@ import type {
   TrailContext,
   TrailContextInit,
 } from '@ontrails/core';
-import { TRAILHEAD_KEY, deriveFields, executeTrail } from '@ontrails/core';
+import {
+  TRAILHEAD_KEY,
+  deriveCliPath,
+  deriveFields,
+  executeTrail,
+} from '@ontrails/core';
 
 import type { AnyTrail, CliCommand, CliFlag } from './command.js';
 import { dryRunPreset, toFlags } from './flags.js';
 import type { InputResolver } from './prompt.js';
+import { validateCliCommands } from './validate.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -51,24 +57,6 @@ export interface BuildCliCommandsOptions {
 /** Convert kebab-case flag name back to camelCase for input merging. */
 const toCamel = (str: string): string =>
   str.replaceAll(/-([a-z])/g, (_, ch: string) => ch.toUpperCase());
-
-/**
- * Parse a trail ID into group + command name.
- * "entity.show" -> { group: "entity", name: "show" }
- * "search" -> { group: undefined, name: "search" }
- */
-const parseTrailId = (
-  id: string
-): { group: string | undefined; name: string } => {
-  const dotIndex = id.indexOf('.');
-  if (dotIndex === -1) {
-    return { group: undefined, name: id };
-  }
-  return {
-    group: id.slice(0, dotIndex),
-    name: id.slice(dotIndex + 1),
-  };
-};
 
 /**
  * Merge preset flags with schema-derived flags.
@@ -211,7 +199,6 @@ const toCliCommand = (
   t: AnyTrail,
   options?: BuildCliCommandsOptions
 ): CliCommand => {
-  const { group, name } = parseTrailId(t.id);
   const fields = deriveFields(t.input, t.fields);
   const flags = buildFlags(fields, t.intent, options);
 
@@ -221,10 +208,9 @@ const toCliCommand = (
     execute: createExecute(t, fields, flags, options),
     flags,
     gates: options?.gates,
-    group,
     idempotent: t.idempotent,
     intent: t.intent,
-    name,
+    path: deriveCliPath(t.id),
     trail: t,
   };
 };
@@ -242,5 +228,6 @@ export const buildCliCommands = (
     commands.push(toCliCommand(trail, options));
   }
 
+  validateCliCommands(commands);
   return commands;
 };

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -54,9 +54,8 @@ export interface CliArg {
 
 /** A framework-agnostic representation of a CLI command. */
 export interface CliCommand {
-  readonly name: string;
+  readonly path: readonly string[];
   readonly description?: string | undefined;
-  readonly group?: string | undefined;
   readonly flags: CliFlag[];
   readonly args: CliArg[];
   readonly trail: AnyTrail;

--- a/packages/cli/src/commander/to-commander.ts
+++ b/packages/cli/src/commander/to-commander.ts
@@ -6,6 +6,7 @@ import { exitCodeMap, isTrailsError } from '@ontrails/core';
 import { Command, InvalidArgumentError, Option } from 'commander';
 
 import type { CliCommand, CliFlag } from '../command.js';
+import { validateCliCommands } from '../validate.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -121,9 +122,9 @@ const handleError = (error: unknown): void => {
 };
 
 /** Wire a CliCommand's action to a Commander subcommand. */
-const wireAction = (sub: Command, cmd: CliCommand): void => {
-  sub.action(async (...actionArgs: unknown[]) => {
-    const opts = sub.opts() as Record<string, unknown>;
+const wireAction = (target: Command, cmd: CliCommand): void => {
+  target.action(async (...actionArgs: unknown[]) => {
+    const opts = target.opts() as Record<string, unknown>;
     const parsedArgs = collectPositionalArgs(cmd, actionArgs);
     try {
       await cmd.execute(parsedArgs, opts);
@@ -131,26 +132,6 @@ const wireAction = (sub: Command, cmd: CliCommand): void => {
       handleError(error);
     }
   });
-};
-
-/** Attach a subcommand to its group or to the top-level program. */
-const attachToGroup = (
-  sub: Command,
-  cmd: CliCommand,
-  program: Command,
-  groups: Map<string, Command>
-): void => {
-  if (cmd.group) {
-    let groupCmd = groups.get(cmd.group);
-    if (!groupCmd) {
-      groupCmd = new Command(cmd.group);
-      groups.set(cmd.group, groupCmd);
-      program.addCommand(groupCmd);
-    }
-    groupCmd.addCommand(sub);
-  } else {
-    program.addCommand(sub);
-  }
 };
 
 /** Apply options to a Commander program. */
@@ -173,36 +154,98 @@ const applyOptions = (program: Command, options?: ToCommanderOptions): void => {
 /**
  * Convert CliCommand[] into a configured Commander program.
  *
- * Groups commands by their `group` field into parent/subcommand structure.
+ * Builds a nested command tree from each command's full ordered path.
  * Wires each command's `.action()` to call `execute()` and handle errors.
  */
-/** Build a Commander subcommand from a CliCommand. */
-const buildSubcommand = (cmd: CliCommand): Command => {
-  const sub = new Command(cmd.name);
+const pathKey = (path: readonly string[]): string => path.join('\0');
+
+interface CommandNodeState {
+  readonly command: Command;
+  executable: boolean;
+}
+
+const getPathSegment = (path: readonly string[], index: number): string => {
+  const segment = path[index];
+  if (segment === undefined) {
+    throw new Error('CLI command path contains an undefined segment');
+  }
+  return segment;
+};
+
+const getOrCreateCommandNode = (
+  key: string,
+  segment: string,
+  parent: Command,
+  nodes: Map<string, CommandNodeState>
+): CommandNodeState => {
+  const existing = nodes.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const command = new Command(segment);
+  const state = { command, executable: false };
+  nodes.set(key, state);
+  parent.addCommand(command);
+  return state;
+};
+
+const ensureCommandNode = (
+  path: readonly string[],
+  program: Command,
+  nodes: Map<string, CommandNodeState>
+): CommandNodeState => {
+  let parent = program;
+  let state: CommandNodeState | undefined;
+
+  for (let index = 0; index < path.length; index += 1) {
+    const segment = getPathSegment(path, index);
+    const key = pathKey(path.slice(0, index + 1));
+    state = getOrCreateCommandNode(key, segment, parent, nodes);
+    parent = state.command;
+  }
+
+  if (!state) {
+    throw new Error('CLI command path cannot be empty');
+  }
+
+  return state;
+};
+
+const applyCliCommand = (state: CommandNodeState, cmd: CliCommand): void => {
+  if (state.executable) {
+    throw new Error(`Duplicate CLI path: ${cmd.path.join(' ')}`);
+  }
+
   if (cmd.description) {
-    sub.description(cmd.description);
+    state.command.description(cmd.description);
   }
   for (const flag of cmd.flags) {
     for (const opt of buildOptions(flag)) {
-      sub.addOption(opt);
+      state.command.addOption(opt);
     }
   }
-  addArgs(sub, cmd);
-  wireAction(sub, cmd);
-  return sub;
+  addArgs(state.command, cmd);
+  wireAction(state.command, cmd);
+  state.executable = true;
 };
 
 export const toCommander = (
   commands: CliCommand[],
   options?: ToCommanderOptions
 ): Command => {
+  validateCliCommands(commands);
   const program = new Command();
   applyOptions(program, options);
-  const groups = new Map<string, Command>();
+  const nodes = new Map<string, CommandNodeState>();
 
-  for (const cmd of commands) {
-    const sub = buildSubcommand(cmd);
-    attachToGroup(sub, cmd, program, groups);
+  for (const cmd of commands.toSorted((a, b) =>
+    a.path.length === b.path.length
+      ? a.path.join('.').localeCompare(b.path.join('.'))
+      : a.path.length - b.path.length
+  )) {
+    const state = ensureCommandNode(cmd.path, program, nodes);
+    applyCliCommand(state, cmd);
   }
 
   return program;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ export type { AnyTrail, CliCommand, CliFlag, CliArg } from './command.js';
 // Build
 export { buildCliCommands } from './build.js';
 export type { BuildCliCommandsOptions, ActionResultContext } from './build.js';
+export { validateCliCommands } from './validate.js';
 
 // Flags
 export {

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -1,0 +1,64 @@
+import { ValidationError } from '@ontrails/core';
+
+import type { CliCommand } from './command.js';
+
+const renderPath = (path: readonly string[]): string => path.join(' ');
+
+const isPrefixPath = (
+  prefix: readonly string[],
+  path: readonly string[]
+): boolean =>
+  prefix.length < path.length &&
+  prefix.every((segment, index) => path[index] === segment);
+
+const validateCommandPath = (command: CliCommand): void => {
+  if (command.path.length === 0) {
+    throw new ValidationError('CLI command path cannot be empty');
+  }
+
+  for (const segment of command.path) {
+    if (segment.trim().length === 0) {
+      throw new ValidationError(
+        'CLI command path cannot contain empty segments'
+      );
+    }
+  }
+};
+
+const validateUniquePaths = (commands: readonly CliCommand[]): void => {
+  const seen = new Set<string>();
+
+  for (const command of commands) {
+    const key = renderPath(command.path);
+    if (seen.has(key)) {
+      throw new ValidationError(`Duplicate CLI path: ${key}`);
+    }
+    seen.add(key);
+  }
+};
+
+const validateExecutableParents = (commands: readonly CliCommand[]): void => {
+  for (const command of commands) {
+    if (command.args.length === 0) {
+      continue;
+    }
+
+    const hasChildCommand = commands.some((candidate) =>
+      isPrefixPath(command.path, candidate.path)
+    );
+    if (hasChildCommand) {
+      throw new ValidationError(
+        `Executable parent commands cannot declare positional args when child commands exist: ${renderPath(command.path)}`
+      );
+    }
+  }
+};
+
+export const validateCliCommands = (commands: readonly CliCommand[]): void => {
+  for (const command of commands) {
+    validateCommandPath(command);
+  }
+
+  validateUniquePaths(commands);
+  validateExecutableParents(commands);
+};

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -4,6 +4,8 @@ import type { CliCommand } from './command.js';
 
 const renderPath = (path: readonly string[]): string => path.join(' ');
 
+const keyPath = (path: readonly string[]): string => path.join('\0');
+
 const isPrefixPath = (
   prefix: readonly string[],
   path: readonly string[]
@@ -29,9 +31,11 @@ const validateUniquePaths = (commands: readonly CliCommand[]): void => {
   const seen = new Set<string>();
 
   for (const command of commands) {
-    const key = renderPath(command.path);
+    const key = keyPath(command.path);
     if (seen.has(key)) {
-      throw new ValidationError(`Duplicate CLI path: ${key}`);
+      throw new ValidationError(
+        `Duplicate CLI path: ${renderPath(command.path)}`
+      );
     }
     seen.add(key);
   }

--- a/packages/core/src/__tests__/derive.test.ts
+++ b/packages/core/src/__tests__/derive.test.ts
@@ -21,6 +21,24 @@ describe('derive', () => {
         'remove',
       ]);
     });
+
+    test('trail IDs with consecutive dots throw a ValidationError', () => {
+      expect(() => deriveCliPath('topo..pin')).toThrow(
+        'Trail ID "topo..pin" contains an empty segment'
+      );
+    });
+
+    test('trail IDs with a leading dot throw a ValidationError', () => {
+      expect(() => deriveCliPath('.pin')).toThrow(
+        'Trail ID ".pin" contains an empty segment'
+      );
+    });
+
+    test('trail IDs with a trailing dot throw a ValidationError', () => {
+      expect(() => deriveCliPath('pin.')).toThrow(
+        'Trail ID "pin." contains an empty segment'
+      );
+    });
   });
 
   describe('primitive types', () => {

--- a/packages/core/src/__tests__/derive.test.ts
+++ b/packages/core/src/__tests__/derive.test.ts
@@ -2,13 +2,27 @@ import { describe, test, expect } from 'bun:test';
 
 import { z } from 'zod';
 
-import { deriveFields } from '../derive.js';
+import { deriveCliPath, deriveFields } from '../derive.js';
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe('derive', () => {
+  describe('cli paths', () => {
+    test('top-level trail IDs derive to a one-segment CLI path', () => {
+      expect(deriveCliPath('search')).toEqual(['search']);
+    });
+
+    test('multi-dot trail IDs derive to the full ordered CLI path', () => {
+      expect(deriveCliPath('topo.pin.remove')).toEqual([
+        'topo',
+        'pin',
+        'remove',
+      ]);
+    });
+  });
+
   describe('primitive types', () => {
     test('z.string() derives string field', () => {
       const schema = z.object({ name: z.string() });

--- a/packages/core/src/derive.ts
+++ b/packages/core/src/derive.ts
@@ -189,6 +189,10 @@ const buildOptions = (
   });
 };
 
+/** Derive the canonical ordered CLI path from a trail ID. */
+export const deriveCliPath = (trailId: string): string[] =>
+  trailId.split('.').filter((segment) => segment.length > 0);
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------

--- a/packages/core/src/derive.ts
+++ b/packages/core/src/derive.ts
@@ -7,6 +7,8 @@
 
 import type { z } from 'zod';
 
+import { ValidationError } from './errors.js';
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -189,9 +191,21 @@ const buildOptions = (
   });
 };
 
-/** Derive the canonical ordered CLI path from a trail ID. */
-export const deriveCliPath = (trailId: string): string[] =>
-  trailId.split('.').filter((segment) => segment.length > 0);
+/**
+ * Derive the canonical ordered CLI path from a trail ID.
+ *
+ * @throws {ValidationError} if the trail ID contains empty segments (e.g. consecutive dots).
+ */
+export const deriveCliPath = (trailId: string): string[] => {
+  const segments = trailId.split('.');
+  const emptyIndex = segments.findIndex((s) => s.length === 0);
+  if (emptyIndex !== -1) {
+    throw new ValidationError(
+      `Trail ID "${trailId}" contains an empty segment at position ${emptyIndex}`
+    );
+  }
+  return segments;
+};
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,7 +92,7 @@ export { composeGates } from './gate.js';
 export type { Gate } from './gate.js';
 
 // Derive
-export { deriveFields } from './derive.js';
+export { deriveCliPath, deriveFields } from './derive.js';
 export type { Field, FieldOverride } from './derive.js';
 
 // Execute

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -19,7 +19,7 @@ if (diff.hasBreaking) {
 }
 ```
 
-The trailhead map captures every trail's input/output schemas (as JSON Schema), intent and metadata, crossing graph, declared provisions, example counts, and the registered provision inventory. The hash goes into the committed lock file -- a single line that CI can check for drift.
+The trailhead map captures every trail's input/output schemas (as JSON Schema), intent and metadata, CLI path projection, crossing graph, declared provisions, example counts, and the registered provision inventory. The hash goes into the committed lock file -- a single line that CI can check for drift.
 
 ## API
 
@@ -45,6 +45,7 @@ The diff classifies every change by severity:
 | Required input field added | breaking |
 | Input/output field removed | breaking |
 | Output field type changed | breaking |
+| CLI path changed | breaking |
 | Safety property changed | warning |
 | Trail deprecated | warning |
 | Crosses changed | warning |

--- a/packages/schema/src/__tests__/diff.test.ts
+++ b/packages/schema/src/__tests__/diff.test.ts
@@ -244,6 +244,23 @@ describe('diffTrailheadMaps', () => {
       ).toBe(true);
     });
 
+    test('CLI path change is classified as breaking', () => {
+      const prev = trailheadMap([
+        entry({ cli: { path: ['topo', 'pin'] }, id: 'topo.pin' }),
+      ]);
+      const curr = trailheadMap([
+        entry({ cli: { path: ['topo', 'save'] }, id: 'topo.pin' }),
+      ]);
+      const result = diffTrailheadMaps(prev, curr);
+
+      expect(result.hasBreaking).toBe(true);
+      expect(
+        result.breaking[0]?.details.some((detail) =>
+          detail.includes('CLI path changed: topo pin -> topo save')
+        )
+      ).toBe(true);
+    });
+
     test('safety marker changed classified as warning', () => {
       const prev = trailheadMap([entry({ id: 'data.wipe', intent: 'read' })]);
       const curr = trailheadMap([

--- a/packages/schema/src/__tests__/generate.test.ts
+++ b/packages/schema/src/__tests__/generate.test.ts
@@ -98,6 +98,7 @@ describe('generateTrailheadMap', () => {
 
       expect(entry.input).toBeDefined();
       expect(entry.output).toBeDefined();
+      expect(entry.cli?.path).toEqual(['entity', 'create']);
       expectSchemaProperties(entry.input, {
         age: { type: 'number' },
         name: { type: 'string' },
@@ -136,6 +137,7 @@ describe('generateTrailheadMap', () => {
       expect(crossesEntry).toBeDefined();
 
       expect(crossesEntry?.kind).toBe('trail');
+      expect(crossesEntry?.cli?.path).toEqual(['user', 'update']);
       expect(crossesEntry?.crosses).toEqual(['user.get']);
     });
 

--- a/packages/schema/src/diff.ts
+++ b/packages/schema/src/diff.ts
@@ -265,6 +265,32 @@ const diffMetadata = (
   }
 };
 
+const diffCliPath = (
+  acc: DetailAccumulator,
+  prev: TrailheadMapEntry,
+  curr: TrailheadMapEntry
+): void => {
+  const prevPath = prev.cli?.path.join(' ');
+  const currPath = curr.cli?.path.join(' ');
+
+  if (prevPath === currPath) {
+    return;
+  }
+
+  // First-time CLI path recording (upgrade from a lockfile without paths)
+  // is informational, not a breaking change.
+  if (prevPath === undefined && currPath !== undefined) {
+    addDetail(acc, 'info', `CLI path recorded: ${currPath}`);
+    return;
+  }
+
+  addDetail(
+    acc,
+    'breaking',
+    `CLI path changed: ${prevPath ?? '(none)'} -> ${currPath ?? '(none)'}`
+  );
+};
+
 /** Build a crossing-changed description from added/removed arrays. */
 const buildCrossesMessage = (added: string[], removed: string[]): string => {
   const parts: string[] = [];
@@ -326,18 +352,27 @@ const diffProvisions = (
   }
 };
 
+const diffEntryDetails = (
+  acc: DetailAccumulator,
+  prev: TrailheadMapEntry,
+  curr: TrailheadMapEntry
+): void => {
+  diffSchemaFields(acc, 'input', prev.input, curr.input);
+  diffSchemaFields(acc, 'output', prev.output, curr.output);
+  diffTrailheads(acc, prev, curr);
+  diffCliPath(acc, prev, curr);
+  diffMetadata(acc, prev, curr);
+  diffCrosses(acc, prev, curr);
+  diffProvisions(acc, prev, curr);
+};
+
 const diffEntry = (
   prev: TrailheadMapEntry,
   curr: TrailheadMapEntry
 ): DiffEntry | undefined => {
   const acc: DetailAccumulator = { details: [], severity: 'info' };
 
-  diffSchemaFields(acc, 'input', prev.input, curr.input);
-  diffSchemaFields(acc, 'output', prev.output, curr.output);
-  diffTrailheads(acc, prev, curr);
-  diffMetadata(acc, prev, curr);
-  diffCrosses(acc, prev, curr);
-  diffProvisions(acc, prev, curr);
+  diffEntryDetails(acc, prev, curr);
 
   if (acc.details.length === 0) {
     return undefined;

--- a/packages/schema/src/generate.ts
+++ b/packages/schema/src/generate.ts
@@ -2,7 +2,7 @@
  * Generate a deterministic trailhead map from a Topo.
  */
 
-import { zodToJsonSchema } from '@ontrails/core';
+import { deriveCliPath, zodToJsonSchema } from '@ontrails/core';
 import type { AnyProvision, Signal, Topo, Trail } from '@ontrails/core';
 
 import type { JsonSchema, TrailheadMap, TrailheadMapEntry } from './types.js';
@@ -116,6 +116,7 @@ const trailToEntry = (t: Trail<unknown, unknown>): TrailheadMapEntry => {
   const raw = t as unknown as Record<string, unknown>;
   const trailheads = extractTrailheads(raw);
   const entry: Record<string, unknown> = {
+    cli: { path: deriveCliPath(t.id) },
     exampleCount: Array.isArray(t.examples) ? t.examples.length : 0,
     id: t.id,
     kind: t.kind,

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -17,6 +17,11 @@ export interface TrailheadMapEntry {
   readonly id: string;
   readonly kind: 'trail' | 'signal' | 'provision';
   readonly trailheads: readonly string[];
+  readonly cli?:
+    | {
+        readonly path: readonly string[];
+      }
+    | undefined;
   readonly input?: JsonSchema | undefined;
   readonly output?: JsonSchema | undefined;
   readonly intent?: 'read' | 'write' | 'destroy' | undefined;

--- a/packages/testing/src/__tests__/harness-cli.test.ts
+++ b/packages/testing/src/__tests__/harness-cli.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { createCliHarness } from '../harness-cli.js';
+
+describe('createCliHarness', () => {
+  test('runs top-level commands', async () => {
+    const greet = trail('greet', {
+      blaze: (input: { name: string }) => Result.ok(`Hello, ${input.name}!`),
+      input: z.object({ name: z.string() }),
+    });
+    const harness = createCliHarness({
+      app: topo('test-app', { greet }),
+    });
+
+    const result = await harness.run('greet --name Trails');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Hello, Trails!');
+  });
+
+  test('runs nested commands using the full ordered path', async () => {
+    const pin = trail('topo.pin', {
+      blaze: (input: { name: string }) => Result.ok(`Pinned ${input.name}`),
+      input: z.object({ name: z.string() }),
+    });
+    const harness = createCliHarness({
+      app: topo('test-app', { pin }),
+    });
+
+    const result = await harness.run('topo pin --name before-auth');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Pinned before-auth');
+  });
+
+  test('prefers the deepest matching executable path', async () => {
+    const calls: string[] = [];
+    const topoShow = trail('topo', {
+      blaze: () => {
+        calls.push('topo');
+        return Result.ok('topo');
+      },
+      input: z.object({}),
+    });
+    const topoPin = trail('topo.pin', {
+      blaze: () => {
+        calls.push('topo.pin');
+        return Result.ok('topo.pin');
+      },
+      input: z.object({}),
+    });
+    const harness = createCliHarness({
+      app: topo('test-app', { topoPin, topoShow }),
+    });
+
+    const child = await harness.run('topo pin');
+    const parent = await harness.run('topo');
+
+    expect(child.exitCode).toBe(0);
+    expect(parent.exitCode).toBe(0);
+    expect(calls).toEqual(['topo.pin', 'topo']);
+  });
+});

--- a/packages/testing/src/harness-cli.ts
+++ b/packages/testing/src/harness-cli.ts
@@ -30,55 +30,31 @@ const parseCommandString = (input: string): string[] =>
 // Command resolution
 // ---------------------------------------------------------------------------
 
-/** Try to match group + name from tokens. */
-const tryGroupMatch = (
-  commands: CliCommand[],
-  firstToken: string,
-  secondToken: string | undefined,
-  tokens: string[]
-): { command: CliCommand; flagTokens: string[] } | undefined => {
-  if (secondToken === undefined || secondToken.startsWith('-')) {
-    return undefined;
-  }
-  const match = commands.find(
-    (c) => c.group === firstToken && c.name === secondToken
-  );
-  if (match === undefined) {
-    return undefined;
-  }
-  return { command: match, flagTokens: tokens.slice(2) };
-};
+const matchesPath = (
+  path: readonly string[],
+  tokens: readonly string[]
+): boolean =>
+  path.length <= tokens.length &&
+  path.every((segment, index) => tokens[index] === segment);
 
-/** Try to match a direct name from the first token. */
-const tryDirectMatch = (
-  commands: CliCommand[],
-  firstToken: string,
-  tokens: string[]
-): { command: CliCommand; flagTokens: string[] } | undefined => {
-  const match = commands.find(
-    (c) => c.name === firstToken && c.group === undefined
-  );
-  if (match === undefined) {
-    return undefined;
-  }
-  return { command: match, flagTokens: tokens.slice(1) };
-};
-
-/** Resolve a command from tokens, handling group.name patterns. */
+/** Resolve a command from tokens using the longest matching command path. */
 const resolveCommand = (
   commands: CliCommand[],
   tokens: string[]
 ): { command: CliCommand; flagTokens: string[] } | undefined => {
-  const [firstToken, secondToken] = tokens;
-
-  if (firstToken === undefined) {
+  if (tokens.length === 0) {
     return undefined;
   }
 
-  return (
-    tryGroupMatch(commands, firstToken, secondToken, tokens) ??
-    tryDirectMatch(commands, firstToken, tokens)
-  );
+  const [match] = commands
+    .filter((command) => matchesPath(command.path, tokens))
+    .toSorted((a, b) => b.path.length - a.path.length);
+
+  if (match === undefined) {
+    return undefined;
+  }
+
+  return { command: match, flagTokens: tokens.slice(match.path.length) };
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Derives full CLI command paths from dotted trail IDs, supporting arbitrary-depth nested command trees
- Supports executable parent commands alongside nested subcommands
- Updates trailhead maps to record full CLI paths for each trail

## What changed
Trail IDs with dot-separated segments (e.g. `admin.users.list`) now project into hierarchical CLI command trees (`admin users list`). The CLI trailhead derives the full command path from the trail ID, supporting arbitrary nesting depth and executable parents. Trailhead map output now includes the resolved CLI path for each trail, making the command structure inspectable from the contract.

## How it was tested
- bun run build
- bun run test
- bun run typecheck
- bun run lint
- Package-specific tests where applicable

Closes: TRL-168, TRL-171, TRL-172, TRL-173
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
