### PR TITLE
feat(cli): add structured input channels

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -60,7 +60,7 @@ validateTopo(topo)                 // → Result<void, ValidationError>; called 
 TopoIssue
 
 // Schema derivation
-deriveFields(schema, overrides?)   // → Field[]
+deriveFields(schema, overrides?)   // → Field[] (faithfully representable fields only)
 deriveCliPath(trailId)             // dotted trail ID → ordered CLI path segments
 Field, FieldOverride
 

--- a/docs/trailheads/cli.md
+++ b/docs/trailheads/cli.md
@@ -1,6 +1,10 @@
 # CLI Trailhead
 
-The CLI trailhead connector turns every trail into a command. Flags are derived from Zod schemas. Output formatting, error handling, and exit codes are handled automatically.
+The CLI trailhead connector turns every trail into a command. Flags are
+derived from faithfully representable Zod schema fields, and structured JSON
+channels are available when the input shape is richer than flags can express
+honestly. Output formatting, error handling, and exit codes are handled
+automatically.
 
 ## Setup
 
@@ -40,7 +44,9 @@ commands exist beneath that path.
 
 ## Flag Derivation
 
-Flags are derived from the trail's Zod input schema. No manual flag configuration needed.
+Flags are derived from the trail's Zod input schema when the shape can be
+represented truthfully on the command line. No manual flag configuration
+needed.
 
 | Zod type | CLI flag | Example |
 | --- | --- | --- |
@@ -55,6 +61,9 @@ Flags are derived from the trail's Zod input schema. No manual flag configuratio
 **Name conversion:** `camelCase` field names become `--kebab-case` flags. `sortOrder` becomes `--sort-order`.
 
 **Descriptions:** `.describe("text")` on Zod fields becomes the flag help text.
+
+Nested objects and arrays of objects are intentionally omitted from automatic
+flag derivation. The CLI prefers fewer flags over dishonest flags.
 
 ```typescript
 const search = trail('search', {
@@ -75,6 +84,37 @@ Options:
   --limit [value]   Max results (default: 10)
   --format <value>  (choices: "json", "table", default: "json")
 ```
+
+## Structured Input
+
+Every non-empty object input schema also gets three structured input channels:
+
+- `--input-json <json>` to pass the full input object inline
+- `--input-file <path>` to load the full input object from a JSON file
+- `--stdin` to read the full input object as JSON from stdin
+
+These channels merge into one final input object before validation:
+
+1. Structured input payload
+2. Positional args
+3. Explicit CLI flags
+4. Interactive prompting for any remaining missing values
+
+Explicit args and flags always win on conflict. Validation still happens once,
+against the original trail schema, after the merge.
+
+```bash
+myapp gist create \
+  --input-json '{"files":[{"filename":"README.md","content":"Hello"}]}'
+```
+
+```bash
+cat payload.json | myapp gist create --stdin
+```
+
+When a schema includes fields that cannot be expressed truthfully as flags, the
+command help still shows the structured input options so the escape hatch stays
+discoverable.
 
 ## Flag Presets
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,8 @@
 # @ontrails/cli
 
-CLI trailhead connector. One `trailhead()` call turns a topo into a full CLI with flags, subcommands, help text, and error-mapped exit codes -- all derived from the trail contracts.
+CLI trailhead connector. One `trailhead()` call turns a topo into a full CLI
+with honest flags, structured input channels, subcommands, help text, and
+error-mapped exit codes -- all derived from the trail contracts.
 
 ## Usage
 
@@ -54,7 +56,7 @@ commands.
 | `buildCliCommands(app)` | Framework-agnostic command builder, returns `CliCommand[]` |
 | `validateCliCommands(commands)` | Validate `CliCommand[]` shapes before wiring a CLI adapter |
 | `toCommander(commands, options?)` | Connect `CliCommand[]` to a Commander program |
-| `deriveFlags(schema)` | Extract CLI flags from a Zod schema |
+| `deriveFlags(schema)` | Extract honest CLI flags from a Zod schema |
 | `output(data, mode)` | Format output as JSON, JSONL, or text |
 | `resolveOutputMode(options)` | Resolve output mode from flags and env vars |
 
@@ -62,7 +64,8 @@ See the [API Reference](../../docs/api-reference.md) for the full list.
 
 ## Flag derivation
 
-Flags come from the Zod schema automatically. No manual flag definitions.
+Flags come from the Zod schema automatically when the field shape can be
+represented truthfully on the command line. No manual flag definitions.
 
 | Zod type | CLI flag | Notes |
 | --- | --- | --- |
@@ -73,6 +76,26 @@ Flags come from the Zod schema automatically. No manual flag definitions.
 | `z.optional(...)` | `--name [value]` | Optional |
 
 `camelCase` fields become `--kebab-case` flags. `.describe()` becomes help text.
+
+Nested objects and arrays of objects are intentionally omitted from automatic
+flag derivation. The CLI prefers fewer flags over dishonest flags.
+
+## Structured input
+
+For every non-empty object input schema, the CLI also exposes:
+
+- `--input-json <json>`
+- `--input-file <path>`
+- `--stdin`
+
+These channels supply the full input object before positional args and explicit
+flags are merged on top. Explicit CLI inputs always win on conflict, and the
+final merged object is still validated once by the trail schema.
+
+```bash
+myapp gist create \
+  --input-json '{"files":[{"filename":"README.md","content":"Hello"}]}'
+```
 
 ## Subcommands
 

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -178,6 +178,40 @@ describe('buildCliCommands execution', () => {
       // onResult should receive the coerced number, not the raw string
       expect(captured?.input).toEqual({ count: 42 });
     });
+
+    test('receives merged args+flags as input on merge failure', async () => {
+      // Regression: the error path previously passed only parsedFlags, dropping parsedArgs.
+      let captured: ActionResultContext | undefined;
+      const t = trail('fail-merge', {
+        blaze: () => Result.ok('ok'),
+        // z.coerce.number on a non-numeric value will fail validation later,
+        // but we need merge itself to fail — pass invalid JSON via input-json to
+        // trigger a merge error before execution.
+        input: z.object({ name: z.string() }),
+      });
+      const app = makeApp(t);
+      const commands = buildCliCommands(app, {
+        onResult: (ctx) => {
+          captured = ctx;
+          return Promise.resolve();
+        },
+      });
+
+      // 'input-json' with invalid JSON causes safeMergeInput to throw and return Err.
+      // Pass an arg too so we can confirm it is not dropped.
+      await commands[0]?.execute(
+        { name: 'from-arg' },
+        { 'input-json': '{bad json}' }
+      );
+
+      expect(captured).toBeDefined();
+      expect(captured?.result.isErr()).toBe(true);
+      // input on the error path must be merged args + flags, not just flags.
+      expect(captured?.input).toMatchObject({
+        'input-json': '{bad json}',
+        name: 'from-arg',
+      });
+    });
   });
 
   test('validates input before calling implementation', async () => {

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -97,11 +97,25 @@ describe('buildCliCommands path derivation', () => {
     const app = makeApp(t);
     const { flags } = requireCommand(buildCliCommands(app));
 
-    expect(flags).toHaveLength(2);
     const queryFlag = flags.find((f) => f.name === 'query');
     const limitFlag = flags.find((f) => f.name === 'limit');
     expect(queryFlag?.required).toBe(true);
     expect(limitFlag?.required).toBe(false);
+  });
+
+  test('adds structured input flags for non-empty object schemas', () => {
+    const t = trail('search', {
+      blaze: () => Result.ok([]),
+      input: z.object({
+        query: z.string(),
+      }),
+    });
+    const app = makeApp(t);
+    const { flags } = requireCommand(buildCliCommands(app));
+
+    expect(flags.map((flag) => flag.name)).toEqual(
+      expect.arrayContaining(['input-file', 'input-json', 'stdin', 'query'])
+    );
   });
 
   test('adds --dry-run for destroy intent trails', () => {
@@ -272,6 +286,104 @@ describe('buildCliCommands execution', () => {
 
     await commands[0]?.execute({}, { 'sort-order': 'asc' });
     expect(receivedInput).toEqual({ sortOrder: 'asc' });
+  });
+
+  test('does not drop derived fields that collide with structured input flag names', async () => {
+    let receivedInput: unknown;
+    const t = trail('collision', {
+      blaze: (input) => {
+        receivedInput = input;
+        return Result.ok('ok');
+      },
+      input: z.object({ inputJson: z.string() }),
+    });
+    const app = makeApp(t);
+    const commands = buildCliCommands(app);
+
+    await commands[0]?.execute({}, { 'input-json': 'literal value' });
+
+    expect(receivedInput).toEqual({ inputJson: 'literal value' });
+  });
+
+  test('merges structured input before explicit flags and args', async () => {
+    let receivedInput: unknown;
+    const t = trail('search', {
+      blaze: (input) => {
+        receivedInput = input;
+        return Result.ok(input);
+      },
+      input: z.object({
+        limit: z.number(),
+        query: z.string(),
+      }),
+    });
+    const app = makeApp(t);
+    const commands = buildCliCommands(app);
+
+    await commands[0]?.execute(
+      { query: 'from arg' },
+      {
+        'input-json': '{"query":"from json","limit":10}',
+        limit: 20,
+      }
+    );
+
+    expect(receivedInput).toEqual({
+      limit: 20,
+      query: 'from arg',
+    });
+  });
+
+  test('resolveInput only fills missing values and never overwrites explicit input', async () => {
+    let receivedInput: unknown;
+    const t = trail('prompted', {
+      blaze: (input) => {
+        receivedInput = input;
+        return Result.ok(input);
+      },
+      input: z.object({
+        limit: z.number(),
+        query: z.string(),
+      }),
+    });
+    const app = makeApp(t);
+    const commands = buildCliCommands(app, {
+      resolveInput: async () =>
+        await Promise.resolve({
+          limit: 10,
+          query: 'from prompt',
+        }),
+    });
+
+    await commands[0]?.execute({}, { query: 'from flag' });
+
+    expect(receivedInput).toEqual({
+      limit: 10,
+      query: 'from flag',
+    });
+  });
+
+  test('validation errors for complex schemas point back to structured input', async () => {
+    const t = trail('gist.create', {
+      blaze: () => Result.ok('ok'),
+      input: z.object({
+        files: z.array(
+          z.object({
+            content: z.string(),
+            filename: z.string(),
+          })
+        ),
+      }),
+    });
+    const app = makeApp(t);
+    const commands = buildCliCommands(app);
+
+    const result = await commands[0]?.execute({}, {});
+
+    expect(result?.isErr()).toBe(true);
+    expect(result?.error.message).toContain(
+      'Use --input-json, --input-file, or --stdin for full structured input.'
+    );
   });
 
   test('returns InternalError when blaze function throws', async () => {

--- a/packages/cli/src/__tests__/flags.test.ts
+++ b/packages/cli/src/__tests__/flags.test.ts
@@ -78,6 +78,33 @@ describe('deriveFlags', () => {
       expect(flag.type).toBe('number[]');
       expect(flag.variadic).toBe(true);
     });
+
+    test('nested object fields are omitted when they are not faithfully representable', () => {
+      const flags = deriveFlags(
+        z.object({
+          filter: z.object({
+            query: z.string(),
+          }),
+        })
+      );
+
+      expect(flags).toEqual([]);
+    });
+
+    test('arrays of objects are omitted when they are not faithfully representable', () => {
+      const flags = deriveFlags(
+        z.object({
+          files: z.array(
+            z.object({
+              content: z.string(),
+              filename: z.string(),
+            })
+          ),
+        })
+      );
+
+      expect(flags).toEqual([]);
+    });
   });
 
   describe('modifiers and naming', () => {
@@ -105,6 +132,18 @@ describe('deriveFlags', () => {
 
       expect(flags).toHaveLength(1);
       expect(requireFlag(flags, 'query').description).toBe('Search query');
+    });
+
+    test('field overrides still flow through flag derivation', () => {
+      const flags = deriveFlags(
+        z.object({ query: z.string().describe('Search query') }),
+        {
+          query: { label: 'Find query' },
+        }
+      );
+
+      expect(flags).toHaveLength(1);
+      expect(requireFlag(flags, 'query').description).toBe('Find query');
     });
 
     test('camelCase field names convert to kebab-case flag names', () => {

--- a/packages/cli/src/__tests__/structured-input.test.ts
+++ b/packages/cli/src/__tests__/structured-input.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from 'bun:test';
+
+import { deriveFields } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  hasStructuredOnlyFields,
+  normalizeParsedFlags,
+  readStructuredInput,
+  structuredInputPreset,
+  supportsStructuredInput,
+} from '../structured-input.js';
+
+describe('structured input helpers', () => {
+  test('normalizeParsedFlags converts kebab-case names to camelCase', () => {
+    expect(
+      normalizeParsedFlags({
+        'input-file': '/tmp/input.json',
+        'sort-order': 'asc',
+      })
+    ).toEqual({
+      inputFile: '/tmp/input.json',
+      sortOrder: 'asc',
+    });
+  });
+
+  test('structuredInputPreset exposes JSON, file, and stdin channels', () => {
+    expect(structuredInputPreset().map((flag) => flag.name)).toEqual([
+      'input-json',
+      'input-file',
+      'stdin',
+    ]);
+  });
+
+  test('supportsStructuredInput returns true only for non-empty object schemas', () => {
+    expect(supportsStructuredInput(z.object({ query: z.string() }))).toBe(true);
+    expect(supportsStructuredInput(z.object({}))).toBe(false);
+    expect(supportsStructuredInput(z.string())).toBe(false);
+  });
+
+  test('hasStructuredOnlyFields detects omitted complex fields', () => {
+    const schema = z.object({
+      files: z.array(
+        z.object({
+          content: z.string(),
+          filename: z.string(),
+        })
+      ),
+      query: z.string(),
+    });
+
+    expect(hasStructuredOnlyFields(schema, deriveFields(schema).length)).toBe(
+      true
+    );
+    expect(
+      hasStructuredOnlyFields(
+        z.object({ query: z.string() }),
+        deriveFields(z.object({ query: z.string() })).length
+      )
+    ).toBe(false);
+  });
+});
+
+describe('readStructuredInput', () => {
+  test('returns an empty object when no structured source was provided', async () => {
+    await expect(readStructuredInput({ query: 'hello' })).resolves.toEqual({});
+  });
+
+  test('rejects multiple structured sources at once', async () => {
+    await expect(
+      readStructuredInput({
+        inputJson: '{"query":"hello"}',
+        stdin: true,
+      })
+    ).rejects.toThrow(
+      'Use only one structured input source at a time: --input-json, --input-file, or --stdin'
+    );
+  });
+
+  test('parses --input-json payloads into an input object', async () => {
+    await expect(
+      readStructuredInput({
+        inputJson: '{"query":"hello","limit":10}',
+      })
+    ).resolves.toEqual({
+      limit: 10,
+      query: 'hello',
+    });
+  });
+
+  test('rejects invalid JSON for --input-json', async () => {
+    await expect(
+      readStructuredInput({
+        inputJson: '{bad json}',
+      })
+    ).rejects.toThrow('Invalid JSON for --input-json');
+  });
+
+  test('rejects non-object JSON payloads', async () => {
+    await expect(
+      readStructuredInput({
+        inputJson: '["not","an","object"]',
+      })
+    ).rejects.toThrow(
+      '--input-json must provide a JSON object at the top level'
+    );
+  });
+
+  test('parses --input-file payloads via the injected file reader', async () => {
+    await expect(
+      readStructuredInput(
+        {
+          inputFile: '/tmp/input.json',
+        },
+        {
+          readFileText: (path) => {
+            expect(path).toBe('/tmp/input.json');
+            return Promise.resolve('{"query":"from file"}');
+          },
+        }
+      )
+    ).resolves.toEqual({ query: 'from file' });
+  });
+
+  test('parses --stdin payloads via the injected stdin reader', async () => {
+    await expect(
+      readStructuredInput(
+        {
+          stdin: true,
+        },
+        {
+          readStdinText: () => Promise.resolve('{"query":"from stdin"}'),
+        }
+      )
+    ).resolves.toEqual({ query: 'from stdin' });
+  });
+
+  test('rejects empty stdin payloads', async () => {
+    await expect(
+      readStructuredInput(
+        {
+          stdin: true,
+        },
+        {
+          readStdinText: () => Promise.resolve('   '),
+        }
+      )
+    ).rejects.toThrow(
+      '--stdin was provided but no JSON payload was read from stdin'
+    );
+  });
+});

--- a/packages/cli/src/__tests__/to-commander.test.ts
+++ b/packages/cli/src/__tests__/to-commander.test.ts
@@ -252,6 +252,31 @@ describe('toCommander option wiring', () => {
     expect(formatOpt?.argChoices).toEqual(['json', 'text']);
   });
 
+  test('complex schemas expose structured input options instead of lossy nested flags', () => {
+    const t = trail('gist.create', {
+      blaze: () => Result.ok('ok'),
+      input: z.object({
+        files: z.array(
+          z.object({
+            content: z.string(),
+            filename: z.string(),
+          })
+        ),
+      }),
+    });
+    const app = makeApp(t);
+    const commands = buildCliCommands(app);
+    const program = toCommander(commands);
+
+    const opts = requireNestedCommand(program, ['gist', 'create']).options;
+    const longs = opts.map((option) => option.long);
+
+    expect(longs).toEqual(
+      expect.arrayContaining(['--input-file', '--input-json', '--stdin'])
+    );
+    expect(longs).not.toContain('--files');
+  });
+
   describe('boolean flag negation', () => {
     test('boolean flags get --no-<name> negation options', () => {
       const t = trail('check', {

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -6,13 +6,14 @@ import type {
   Field,
   Gate,
   ProvisionOverrideMap,
-  Result,
   Topo,
   TrailContext,
   TrailContextInit,
 } from '@ontrails/core';
 import {
+  Result,
   TRAILHEAD_KEY,
+  ValidationError,
   deriveCliPath,
   deriveFields,
   executeTrail,
@@ -21,6 +22,15 @@ import {
 import type { AnyTrail, CliCommand, CliFlag } from './command.js';
 import { dryRunPreset, toFlags } from './flags.js';
 import type { InputResolver } from './prompt.js';
+import {
+  STRUCTURED_INPUT_HINT,
+  hasStructuredOnlyFields,
+  kebabToCamel,
+  normalizeParsedFlags,
+  readStructuredInput,
+  structuredInputPreset,
+  supportsStructuredInput,
+} from './structured-input.js';
 import { validateCliCommands } from './validate.js';
 
 // ---------------------------------------------------------------------------
@@ -54,10 +64,6 @@ export interface BuildCliCommandsOptions {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Convert kebab-case flag name back to camelCase for input merging. */
-const toCamel = (str: string): string =>
-  str.replaceAll(/-([a-z])/g, (_, ch: string) => ch.toUpperCase());
-
 /**
  * Merge preset flags with schema-derived flags.
  * Schema-derived flags take precedence on name collision.
@@ -84,17 +90,29 @@ const mergeFlags = (presets: CliFlag[], derived: CliFlag[]): CliFlag[] => {
  * dot-notation, and wires up the execute function with validation,
  * layer composition, and onResult handling.
  */
-const META_FLAGS = new Set(['json', 'jsonl', 'output']);
+const META_FLAG_CANDIDATES = new Set([
+  'inputFile',
+  'inputJson',
+  'json',
+  'jsonl',
+  'output',
+  'stdin',
+]);
 
 /** Merge parsed args and flags into a camelCase input record. */
 const mergeArgsAndFlags = (
+  metaFlagNames: ReadonlySet<string>,
+  structuredInput: Record<string, unknown>,
   parsedArgs: Record<string, unknown>,
   parsedFlags: Record<string, unknown>
 ): Record<string, unknown> => {
-  const mergedInput: Record<string, unknown> = { ...parsedArgs };
+  const mergedInput: Record<string, unknown> = {
+    ...structuredInput,
+    ...parsedArgs,
+  };
   for (const [key, value] of Object.entries(parsedFlags)) {
-    if (!META_FLAGS.has(key)) {
-      mergedInput[toCamel(key)] = value;
+    if (!metaFlagNames.has(key)) {
+      mergedInput[key] = value;
     }
   }
   return mergedInput;
@@ -111,7 +129,7 @@ const applyPrompting = async (
   }
   const resolved = await options.resolveInput(fields, mergedInput);
   for (const [key, value] of Object.entries(resolved)) {
-    if (value !== undefined) {
+    if (value !== undefined && mergedInput[key] === undefined) {
       mergedInput[key] = value;
     }
   }
@@ -138,12 +156,111 @@ const withCliTrailhead = (
   },
 });
 
+const selectStructuredInputFlags = (
+  normalizedFlags: Record<string, unknown>,
+  metaFlagNames: ReadonlySet<string>
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(normalizedFlags).filter(([key]) => metaFlagNames.has(key))
+  );
+
+const usesStructuredInput = (
+  structuredInputFlags: Record<string, unknown>
+): boolean =>
+  structuredInputFlags['inputJson'] !== undefined ||
+  structuredInputFlags['inputFile'] !== undefined ||
+  structuredInputFlags['stdin'] === true;
+
+const resolveMergedInput = async (
+  fields: readonly Field[],
+  metaFlagNames: ReadonlySet<string>,
+  parsedArgs: Record<string, unknown>,
+  parsedFlags: Record<string, unknown>,
+  options?: BuildCliCommandsOptions
+): Promise<{
+  readonly mergedInput: Record<string, unknown>;
+  readonly usedStructuredInput: boolean;
+}> => {
+  const normalizedFlags = normalizeParsedFlags(parsedFlags);
+  const structuredInputFlags = selectStructuredInputFlags(
+    normalizedFlags,
+    metaFlagNames
+  );
+  const structuredInput = await readStructuredInput(structuredInputFlags);
+  const mergedInput = mergeArgsAndFlags(
+    metaFlagNames,
+    structuredInput,
+    parsedArgs,
+    normalizedFlags
+  );
+  await applyPrompting(fields, mergedInput, options);
+  return {
+    mergedInput,
+    usedStructuredInput: usesStructuredInput(structuredInputFlags),
+  };
+};
+
+const maybeAddStructuredInputHint = (
+  result: Result<unknown, Error>,
+  shouldHintStructuredInput: boolean,
+  usedStructuredInput: boolean
+): Result<unknown, Error> => {
+  if (
+    !shouldHintStructuredInput ||
+    result.isOk() ||
+    !(result.error instanceof ValidationError) ||
+    usedStructuredInput ||
+    result.error.message.includes(STRUCTURED_INPUT_HINT)
+  ) {
+    return result;
+  }
+
+  return Result.err(
+    new ValidationError(`${result.error.message}. ${STRUCTURED_INPUT_HINT}`, {
+      cause: result.error,
+      ...(result.error.context === undefined
+        ? {}
+        : { context: result.error.context }),
+    })
+  );
+};
+
+const safeMergeInput = async (
+  fields: readonly Field[],
+  metaFlagNames: ReadonlySet<string>,
+  parsedArgs: Record<string, unknown>,
+  parsedFlags: Record<string, unknown>,
+  options?: BuildCliCommandsOptions
+): Promise<
+  Result<
+    { mergedInput: Record<string, unknown>; usedStructuredInput: boolean },
+    Error
+  >
+> => {
+  try {
+    return Result.ok(
+      await resolveMergedInput(
+        fields,
+        metaFlagNames,
+        parsedArgs,
+        parsedFlags,
+        options
+      )
+    );
+  } catch (error: unknown) {
+    return Result.err(
+      error instanceof Error ? error : new Error(String(error))
+    );
+  }
+};
+
 /** Create the execute function for a CLI command. */
 const createExecute =
   (
     t: AnyTrail,
     fields: readonly Field[],
-    _flags: CliFlag[],
+    metaFlagNames: ReadonlySet<string>,
+    shouldHintStructuredInput: boolean,
     options?: BuildCliCommandsOptions
   ) =>
   async (
@@ -151,8 +268,24 @@ const createExecute =
     parsedFlags: Record<string, unknown>,
     ctxOverrides?: Partial<TrailContext>
   ): Promise<Result<unknown, Error>> => {
-    const mergedInput = mergeArgsAndFlags(parsedArgs, parsedFlags);
-    await applyPrompting(fields, mergedInput, options);
+    const merged = await safeMergeInput(
+      fields,
+      metaFlagNames,
+      parsedArgs,
+      parsedFlags,
+      options
+    );
+    if (merged.isErr()) {
+      await reportResult(options, {
+        args: parsedArgs,
+        flags: parsedFlags,
+        input: { ...parsedArgs, ...parsedFlags },
+        result: merged,
+        trail: t,
+      });
+      return merged;
+    }
+    const { mergedInput, usedStructuredInput } = merged.value;
 
     const result = await executeTrail(t, mergedInput, {
       configValues: options?.configValues,
@@ -161,10 +294,15 @@ const createExecute =
       gates: options?.gates,
       provisions: options?.provisions,
     });
+    const finalResult = maybeAddStructuredInputHint(
+      result,
+      shouldHintStructuredInput,
+      usedStructuredInput
+    );
 
     // Pass validated (coerced/transformed) input to onResult on success,
     // raw merged input on validation failure.
-    const reportInput = result.isOk()
+    const reportInput = finalResult.isOk()
       ? (t.input.safeParse(mergedInput).data ?? mergedInput)
       : mergedInput;
 
@@ -172,19 +310,23 @@ const createExecute =
       args: parsedArgs,
       flags: parsedFlags,
       input: reportInput,
-      result,
+      result: finalResult,
       trail: t,
     });
-    return result;
+    return finalResult;
   };
 
 /** Derive and merge flags for a trail. */
 const buildFlags = (
+  t: AnyTrail,
   fields: readonly Field[],
   intent: 'read' | 'write' | 'destroy',
   options?: BuildCliCommandsOptions
 ): CliFlag[] => {
   let flags = toFlags(fields);
+  if (supportsStructuredInput(t.input)) {
+    flags = mergeFlags(structuredInputPreset(), flags);
+  }
   if (options?.presets) {
     flags = mergeFlags(options.presets.flat(), flags);
   }
@@ -200,12 +342,32 @@ const toCliCommand = (
   options?: BuildCliCommandsOptions
 ): CliCommand => {
   const fields = deriveFields(t.input, t.fields);
-  const flags = buildFlags(fields, t.intent, options);
+  const flags = buildFlags(t, fields, t.intent, options);
+  const derivedFlagNames = new Set(
+    toFlags(fields).map((flag) => kebabToCamel(flag.name))
+  );
+  const metaFlagNames = new Set(
+    flags
+      .map((flag) => kebabToCamel(flag.name))
+      .filter(
+        (name) => META_FLAG_CANDIDATES.has(name) && !derivedFlagNames.has(name)
+      )
+  );
+  const shouldHintStructuredInput = hasStructuredOnlyFields(
+    t.input,
+    fields.length
+  );
 
   return {
     args: [],
     description: t.description,
-    execute: createExecute(t, fields, flags, options),
+    execute: createExecute(
+      t,
+      fields,
+      metaFlagNames,
+      shouldHintStructuredInput,
+      options
+    ),
     flags,
     gates: options?.gates,
     idempotent: t.idempotent,

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -111,7 +111,7 @@ const mergeArgsAndFlags = (
     ...parsedArgs,
   };
   for (const [key, value] of Object.entries(parsedFlags)) {
-    if (!metaFlagNames.has(key)) {
+    if (!metaFlagNames.has(key) && value !== undefined) {
       mergedInput[key] = value;
     }
   }

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -2,7 +2,8 @@
  * Flag derivation from trailhead-agnostic fields and reusable flag presets.
  */
 
-import type { Field } from '@ontrails/core';
+import { deriveFields } from '@ontrails/core';
+import type { Field, FieldOverride } from '@ontrails/core';
 import type { z } from 'zod';
 
 import type { CliFlag } from './command.js';
@@ -14,13 +15,6 @@ import type { CliFlag } from './command.js';
 /** Convert camelCase to kebab-case. */
 const toKebab = (str: string): string =>
   str.replaceAll(/[A-Z]/g, (ch) => `-${ch.toLowerCase()}`);
-
-interface ZodInternals {
-  readonly _zod: {
-    readonly def: Readonly<Record<string, unknown>>;
-  };
-  readonly description?: string;
-}
 
 interface CliFlagShape {
   readonly choices?: string[] | undefined;
@@ -60,141 +54,11 @@ const toCliFlag = (field: Field): CliFlag => {
 export const toFlags = (fields: readonly Field[]): CliFlag[] =>
   fields.map(toCliFlag);
 
-interface UnwrapState {
-  defaultValue: unknown;
-  description: string | undefined;
-  required: boolean;
-}
-
-/** Get the inner type from an optional or default wrapper. */
-const getInnerType = (current: ZodInternals): ZodInternals =>
-  current._zod.def['innerType'] as ZodInternals;
-
-/** Propagate description from an inner type. */
-const propagateDescription = (
-  inner: ZodInternals,
-  state: UnwrapState
-): void => {
-  if (inner.description) {
-    state.description = inner.description;
-  }
-};
-
-/** Step one unwrap level for optional/default fields. */
-const unwrapStep = (
-  current: ZodInternals,
-  state: UnwrapState
-): ZodInternals | null => {
-  const defType = current._zod.def['type'] as string;
-  if (defType !== 'optional' && defType !== 'default') {
-    return null;
-  }
-  state.required = false;
-  if (defType === 'default') {
-    state.defaultValue = current._zod.def['defaultValue'];
-  }
-  const inner = getInnerType(current);
-  propagateDescription(inner, state);
-  return inner;
-};
-
-/** Unwrap optional/default wrappers, collecting metadata. */
-const unwrap = (
-  schema: ZodInternals
-): {
-  defaultValue: unknown;
-  description: string | undefined;
-  inner: ZodInternals;
-  required: boolean;
-} => {
-  const state: UnwrapState = {
-    defaultValue: undefined,
-    description: schema.description,
-    required: true,
-  };
-  let current = schema;
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const next = unwrapStep(current, state);
-    if (next === null) {
-      break;
-    }
-    current = next;
-  }
-
-  return { ...state, inner: current };
-};
-
-interface DerivedFlagShape {
-  readonly choices?: string[] | undefined;
-  readonly type: CliFlag['type'];
-  readonly variadic: boolean;
-}
-
-const flagShapeByDef: Record<
-  string,
-  (schema: ZodInternals) => DerivedFlagShape
-> = {
-  array: (schema) => {
-    const element = schema._zod.def['element'] as ZodInternals;
-    const elementType = element._zod.def['type'] as string;
-    if (elementType === 'number') {
-      return { type: 'number[]', variadic: true };
-    }
-    return { type: 'string[]', variadic: true };
-  },
-  boolean: () => ({ type: 'boolean', variadic: false }),
-  enum: (schema) => {
-    const entries = schema._zod.def['entries'] as Record<string, string>;
-    return {
-      choices: Object.values(entries),
-      type: 'string',
-      variadic: false,
-    };
-  },
-  number: () => ({ type: 'number', variadic: false }),
-  string: () => ({ type: 'string', variadic: false }),
-};
-
-/** Derive the CLI flag shape for an unwrapped Zod field. */
-const deriveFlagShape = (schema: ZodInternals): DerivedFlagShape => {
-  const defType = schema._zod.def['type'] as string;
-  const deriveShape = flagShapeByDef[defType];
-  return deriveShape
-    ? deriveShape(schema)
-    : { type: 'string', variadic: false };
-};
-
-/** Derive a single CLI flag from an object shape entry. */
-const deriveFlag = (key: string, value: ZodInternals): CliFlag => {
-  const { inner, required, defaultValue, description } = unwrap(value);
-  const { choices, type, variadic } = deriveFlagShape(inner);
-  return {
-    choices,
-    default: defaultValue,
-    description: description ?? inner.description,
-    name: toKebab(key),
-    required,
-    type,
-    variadic,
-  };
-};
-
 /** Derive CLI flags from a Zod input schema. */
-export const deriveFlags = (schema: z.ZodType): CliFlag[] => {
-  const zod = schema as unknown as ZodInternals;
-  if ((zod._zod.def['type'] as string) !== 'object') {
-    return [];
-  }
-  const shape = zod._zod.def['shape'] as
-    | Record<string, ZodInternals>
-    | undefined;
-  if (!shape) {
-    return [];
-  }
-  return Object.entries(shape).map(([key, value]) => deriveFlag(key, value));
-};
+export const deriveFlags = (
+  schema: z.ZodType,
+  overrides?: Readonly<Record<string, FieldOverride>> | undefined
+): CliFlag[] => toFlags(deriveFields(schema, overrides));
 
 // ---------------------------------------------------------------------------
 // Presets

--- a/packages/cli/src/structured-input.ts
+++ b/packages/cli/src/structured-input.ts
@@ -24,7 +24,7 @@ export const structuredInputPreset = (): CliFlag[] => [
     description:
       'JSON object to merge before explicit positional args and flags',
     name: 'input-json',
-    required: false,
+    required: true,
     type: 'string',
     variadic: false,
   },
@@ -32,7 +32,7 @@ export const structuredInputPreset = (): CliFlag[] => [
     description:
       'Path to a JSON file to merge before explicit positional args and flags',
     name: 'input-file',
-    required: false,
+    required: true,
     type: 'string',
     variadic: false,
   },

--- a/packages/cli/src/structured-input.ts
+++ b/packages/cli/src/structured-input.ts
@@ -1,0 +1,221 @@
+/**
+ * Structured input channels for CLI commands.
+ *
+ * These helpers keep JSON/file/stdin parsing and merge precedence out of the
+ * command builder so the behavior stays easy to test and reason about.
+ */
+
+import { ValidationError, isPlainObject } from '@ontrails/core';
+import type { z } from 'zod';
+
+import type { CliFlag } from './command.js';
+
+interface ZodInternals {
+  readonly _zod: {
+    readonly def: Readonly<Record<string, unknown>>;
+  };
+}
+
+export const STRUCTURED_INPUT_HINT =
+  'Use --input-json, --input-file, or --stdin for full structured input.';
+
+export const structuredInputPreset = (): CliFlag[] => [
+  {
+    description:
+      'JSON object to merge before explicit positional args and flags',
+    name: 'input-json',
+    required: false,
+    type: 'string',
+    variadic: false,
+  },
+  {
+    description:
+      'Path to a JSON file to merge before explicit positional args and flags',
+    name: 'input-file',
+    required: false,
+    type: 'string',
+    variadic: false,
+  },
+  {
+    description:
+      'Read a JSON object from stdin before explicit positional args and flags',
+    name: 'stdin',
+    required: false,
+    type: 'boolean',
+    variadic: false,
+  },
+];
+
+/** Convert a kebab-case string to camelCase. */
+export const kebabToCamel = (str: string): string =>
+  str.replaceAll(/-([a-z])/g, (_, ch: string) => ch.toUpperCase());
+
+export const normalizeParsedFlags = (
+  parsedFlags: Record<string, unknown>
+): Record<string, unknown> => {
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(parsedFlags)) {
+    normalized[kebabToCamel(key)] = value;
+  }
+  return normalized;
+};
+
+const getObjectShape = (
+  schema: z.ZodType
+): Record<string, ZodInternals> | undefined => {
+  const zod = schema as unknown as ZodInternals;
+  if ((zod._zod.def['type'] as string) !== 'object') {
+    return undefined;
+  }
+  return zod._zod.def['shape'] as Record<string, ZodInternals> | undefined;
+};
+
+export const supportsStructuredInput = (schema: z.ZodType): boolean => {
+  const shape = getObjectShape(schema);
+  return shape !== undefined && Object.keys(shape).length > 0;
+};
+
+export const hasStructuredOnlyFields = (
+  schema: z.ZodType,
+  derivedFieldCount: number
+): boolean => {
+  const shape = getObjectShape(schema);
+  return shape !== undefined && Object.keys(shape).length > derivedFieldCount;
+};
+
+interface StructuredInputReaders {
+  readonly readFileText?: ((path: string) => Promise<string>) | undefined;
+  readonly readStdinText?: (() => Promise<string>) | undefined;
+}
+
+type StructuredSource =
+  | { readonly kind: 'input-json'; readonly value: string }
+  | { readonly kind: 'input-file'; readonly value: string }
+  | { readonly kind: 'stdin' };
+
+const resolveStructuredSources = (
+  flags: Record<string, unknown>
+): StructuredSource[] => {
+  const sources: StructuredSource[] = [];
+
+  if (typeof flags['inputJson'] === 'string') {
+    sources.push({ kind: 'input-json', value: flags['inputJson'] });
+  }
+  if (typeof flags['inputFile'] === 'string') {
+    sources.push({ kind: 'input-file', value: flags['inputFile'] });
+  }
+  if (flags['stdin'] === true) {
+    sources.push({ kind: 'stdin' });
+  }
+
+  return sources;
+};
+
+const parseStructuredObject = (
+  raw: string,
+  sourceLabel: '--input-json' | '--input-file' | '--stdin'
+): Record<string, unknown> => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ValidationError(`Invalid JSON for ${sourceLabel}: ${message}`);
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new ValidationError(
+      `${sourceLabel} must provide a JSON object at the top level`
+    );
+  }
+
+  return parsed;
+};
+
+const readStdinText = async (): Promise<string> => {
+  if (process.stdin.isTTY ?? false) {
+    throw new ValidationError(
+      '--stdin was provided but no piped input is available on stdin'
+    );
+  }
+
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+  }
+
+  return Buffer.concat(chunks).toString('utf8');
+};
+
+const readStructuredFile = async (
+  path: string,
+  readers?: StructuredInputReaders
+): Promise<Record<string, unknown>> => {
+  const read =
+    readers?.readFileText ?? ((filePath: string) => Bun.file(filePath).text());
+  const contents = await read(path);
+  return parseStructuredObject(contents, '--input-file');
+};
+
+const readStructuredStdin = async (
+  readers?: StructuredInputReaders
+): Promise<Record<string, unknown>> => {
+  const read = readers?.readStdinText ?? readStdinText;
+  const contents = await read();
+  if (contents.trim().length === 0) {
+    throw new ValidationError(
+      '--stdin was provided but no JSON payload was read from stdin'
+    );
+  }
+  return parseStructuredObject(contents, '--stdin');
+};
+
+const readStructuredSource = async (
+  source: StructuredSource,
+  readers?: StructuredInputReaders
+): Promise<Record<string, unknown>> => {
+  switch (source.kind) {
+    case 'input-json': {
+      return parseStructuredObject(source.value, '--input-json');
+    }
+    case 'input-file': {
+      return await readStructuredFile(source.value, readers);
+    }
+    case 'stdin': {
+      return await readStructuredStdin(readers);
+    }
+    default: {
+      throw new ValidationError('Unsupported structured input source');
+    }
+  }
+};
+
+/**
+ * Read structured input from a JSON, file, or stdin source.
+ *
+ * Accepts both raw kebab-case and pre-normalized camelCase flag records —
+ * normalization is idempotent so callers need not pre-process.
+ */
+export const readStructuredInput = async (
+  parsedFlags: Record<string, unknown>,
+  readers?: StructuredInputReaders
+): Promise<Record<string, unknown>> => {
+  const flags = normalizeParsedFlags(parsedFlags);
+  const sources = resolveStructuredSources(flags);
+
+  if (sources.length === 0) {
+    return {};
+  }
+
+  if (sources.length > 1) {
+    throw new ValidationError(
+      'Use only one structured input source at a time: --input-json, --input-file, or --stdin'
+    );
+  }
+
+  const [source] = sources;
+  if (!source) {
+    return {};
+  }
+  return await readStructuredSource(source, readers);
+};

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -131,7 +131,8 @@ The developer returns `Result.err(new NotFoundError(...))`. The framework maps i
 
 ### Other exports
 
-- **Schema derivation** -- `deriveFields(schema)` extracts field metadata from Zod for prompts and forms
+- **Schema derivation** -- `deriveFields(schema)` extracts faithfully
+  representable field metadata from Zod for prompts and forms
 - **Validation** -- `validateInput`, `formatZodIssues`, `zodToJsonSchema`
 - **Resilience** -- `retry`, `withTimeout`, `shouldRetry`, `getBackoffDelay`
 - **Serialization** -- `serializeError`, `deserializeError`

--- a/packages/core/src/__tests__/derive.test.ts
+++ b/packages/core/src/__tests__/derive.test.ts
@@ -151,6 +151,31 @@ describe('derive', () => {
       expect(fields[0]?.type).toBe('string[]');
       expect(fields[0]?.default).toEqual(['a', 'b']);
     });
+
+    test('z.array(z.object(...)) is omitted when it cannot be represented faithfully', () => {
+      const schema = z.object({
+        files: z.array(
+          z.object({
+            content: z.string(),
+            filename: z.string(),
+          })
+        ),
+      });
+
+      expect(deriveFields(schema)).toEqual([]);
+    });
+  });
+
+  describe('unsupported shapes', () => {
+    test('nested objects are omitted when they cannot be represented faithfully', () => {
+      const schema = z.object({
+        filter: z.object({
+          query: z.string(),
+        }),
+      });
+
+      expect(deriveFields(schema)).toEqual([]);
+    });
   });
 
   describe('modifiers', () => {

--- a/packages/core/src/derive.ts
+++ b/packages/core/src/derive.ts
@@ -142,13 +142,20 @@ interface DerivedFieldType {
   type: Field['type'];
 }
 
-const fieldTypeByDef: Record<string, (s: ZodInternals) => DerivedFieldType> = {
+const fieldTypeByDef: Record<
+  string,
+  (s: ZodInternals) => DerivedFieldType | null
+> = {
   array: (s) => {
     const element = s._zod.def['element'] as unknown as ZodInternals;
-    const elementType = element._zod.def['type'] as string;
+    const { inner } = unwrap(element);
+    const elementType = inner._zod.def['type'] as string;
     if (elementType === 'enum') {
-      const entries = element._zod.def['entries'] as Record<string, string>;
+      const entries = inner._zod.def['entries'] as Record<string, string>;
       return { options: Object.values(entries), type: 'multiselect' };
+    }
+    if (elementType !== 'number' && elementType !== 'string') {
+      return null;
     }
     return {
       options: undefined,
@@ -165,10 +172,10 @@ const fieldTypeByDef: Record<string, (s: ZodInternals) => DerivedFieldType> = {
 };
 
 /** Derive field type and raw options from the unwrapped Zod def. */
-const deriveFieldType = (s: ZodInternals): DerivedFieldType => {
+const deriveFieldType = (s: ZodInternals): DerivedFieldType | null => {
   const defType = s._zod.def['type'] as string;
   const derive = fieldTypeByDef[defType];
-  return derive ? derive(s) : { options: undefined, type: 'string' };
+  return derive ? derive(s) : null;
 };
 
 /** Build options array, merging with overrides when present. */
@@ -216,9 +223,13 @@ const deriveField = (
   key: string,
   value: ZodInternals,
   overrides?: Record<string, FieldOverride>
-): Field => {
+): Field | null => {
   const { inner, required, defaultValue, description } = unwrap(value);
-  const { type, options: rawOptions } = deriveFieldType(inner);
+  const derived = deriveFieldType(inner);
+  if (!derived) {
+    return null;
+  }
+  const { type, options: rawOptions } = derived;
   const override = overrides?.[key];
   const label = override?.label ?? description ?? humanize(key);
   const options = buildOptions(rawOptions, override?.options);
@@ -247,5 +258,7 @@ export const deriveFields = (
   const fields = Object.entries(shape).map(([key, value]) =>
     deriveField(key, value, overrides)
   );
-  return fields.toSorted((a, b) => a.name.localeCompare(b.name));
+  return fields
+    .filter((field): field is Field => field !== null)
+    .toSorted((a, b) => a.name.localeCompare(b.name));
 };

--- a/packages/http/src/hono/trailhead.ts
+++ b/packages/http/src/hono/trailhead.ts
@@ -325,6 +325,7 @@ export const trailhead = async (
 ): Promise<Hono> => {
   const hono = new Hono();
 
+  assertValidTopo(app, options.validate === false);
   registerErrorHandler(hono);
 
   const routesResult = buildHttpRoutes(app, {

--- a/packages/http/src/hono/trailhead.ts
+++ b/packages/http/src/hono/trailhead.ts
@@ -314,14 +314,15 @@ const assertValidTopo = (app: Topo, skip = false): void => {
 
 /**
  * Build HTTP routes from a topo, create a Hono app, and optionally start serving.
+ *
+ * Validation is handled by `buildHttpRoutes` — pass `validate: false`
+ * to skip it (e.g. during hot-reload or progressive startup).
  */
 // oxlint-disable-next-line require-await -- async for consistency with other trailhead() entrypoints
 export const trailhead = async (
   app: Topo,
   options: TrailheadHttpOptions = {}
 ): Promise<Hono> => {
-  assertValidTopo(app, options.validate === false);
-
   const hono = new Hono();
 
   registerErrorHandler(hono);

--- a/packages/http/src/hono/trailhead.ts
+++ b/packages/http/src/hono/trailhead.ts
@@ -315,7 +315,7 @@ const assertValidTopo = (app: Topo, skip = false): void => {
 /**
  * Build HTTP routes from a topo, create a Hono app, and optionally start serving.
  *
- * Validation is handled by `buildHttpRoutes` — pass `validate: false`
+ * Topo validation runs before route construction — pass `validate: false`
  * to skip it (e.g. during hot-reload or progressive startup).
  */
 // oxlint-disable-next-line require-await -- async for consistency with other trailhead() entrypoints


### PR DESCRIPTION
## Summary
- Adds structured input channels: `--input-json`, `--input-file`, and `--stdin`
- Limits flag derivation to honestly representable schema shapes
- Defines merge precedence rules for mixed input modes

## What changed
CLI trails can now receive structured input through `--input-json`, `--input-file`, and stdin piping, in addition to derived flags. Flag derivation is restricted to schema shapes that map cleanly to CLI flags — complex nested objects and arrays are only accepted through the structured input channels. When multiple input modes are combined, a defined merge precedence determines the final input, keeping behavior predictable and inspectable.

## How it was tested
- bun run build
- bun run test
- bun run typecheck
- bun run lint
- Package-specific tests where applicable

Closes: TRL-169, TRL-174, TRL-175, TRL-176
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
