### PR TITLE
feat: contain draft state outside established outputs

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,7 +6,13 @@
   },
   "rules": {
     "import/no-nodejs-modules": "off",
-    "import/no-relative-parent-imports": "off"
+    "import/no-relative-parent-imports": "off",
+    "jsdoc/check-tag-names": [
+      "error",
+      {
+        "definedTags": ["remarks"]
+      }
+    ]
   },
   "ignorePatterns": ["node_modules/**", "dist/**", ".turbo/**"]
 }

--- a/apps/trails/src/__tests__/draft-promote.test.ts
+++ b/apps/trails/src/__tests__/draft-promote.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import type { Result } from '@ontrails/core';
+import { ValidationError } from '@ontrails/core';
+
+import { draftPromoteTrail } from '../trails/draft-promote.js';
+
+const repoTempDir = (): string =>
+  join(
+    resolve(import.meta.dir, '../..'),
+    '.tmp-tests',
+    `draft-promote-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+
+const expectOk = <T>(result: Result<T, Error>): T => {
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const expectErr = <E extends Error>(result: Result<unknown, E>): E => {
+  if (result.isOk()) {
+    throw new Error('expected result to be an error');
+  }
+  return result.error;
+};
+
+const writeDraftPromoteFixture = (dir: string): void => {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    `import { topo } from '@ontrails/core';
+import { draftPrepare } from './_draft.prepare.js';
+import { exportTrail } from './export.js';
+
+export const app = topo('draft-test', { draftPrepare, exportTrail });
+`
+  );
+
+  writeFileSync(
+    join(dir, 'src', '_draft.prepare.ts'),
+    `import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const draftPrepare = trail('_draft.entity.prepare', {
+  blaze: async () => Result.ok({ ready: true }),
+  input: z.object({}),
+  output: z.object({ ready: z.boolean() }),
+});
+`
+  );
+
+  writeFileSync(
+    join(dir, 'src', 'export.ts'),
+    `import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const exportTrail = trail('entity.export', {
+  blaze: async () => Result.ok({ exported: true }),
+  crosses: ['_draft.entity.prepare'],
+  input: z.object({}),
+  output: z.object({ exported: z.boolean() }),
+});
+`
+  );
+};
+
+const expectDraftPromoteResults = (dir: string): void => {
+  expect(existsSync(join(dir, 'src', '_draft.prepare.ts'))).toBe(false);
+  expect(existsSync(join(dir, 'src', 'prepare.ts'))).toBe(true);
+  expect(readFileSync(join(dir, 'src', 'prepare.ts'), 'utf8')).toContain(
+    "trail('entity.prepare'"
+  );
+  expect(readFileSync(join(dir, 'src', 'export.ts'), 'utf8')).toContain(
+    "crosses: ['entity.prepare']"
+  );
+  expect(readFileSync(join(dir, 'src', 'app.ts'), 'utf8')).toContain(
+    "from './prepare.js'"
+  );
+};
+
+describe('draft.promote', () => {
+  test('promotes draft ids, renames files, and updates imports', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeDraftPromoteFixture(dir);
+
+      const result = expectOk(
+        await draftPromoteTrail.blaze(
+          {
+            fromId: '_draft.entity.prepare',
+            renameFiles: true,
+            rootDir: dir,
+            toId: 'entity.prepare',
+          },
+          { cwd: dir } as never
+        )
+      );
+
+      expect(result.promotedEstablished).toBe(true);
+      expect(result.remainingDraftIds).toEqual([]);
+      expect(result.updatedFiles).toEqual(
+        expect.arrayContaining(['src/app.ts', 'src/export.ts'])
+      );
+      expect(result.renamedFiles).toEqual([
+        {
+          from: 'src/_draft.prepare.ts',
+          to: 'src/prepare.ts',
+        },
+      ]);
+      expectDraftPromoteResults(dir);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('returns ValidationError when rootDir does not exist', async () => {
+    const error = expectErr(
+      await draftPromoteTrail.blaze(
+        {
+          fromId: '_draft.entity.prepare',
+          renameFiles: true,
+          rootDir: join(repoTempDir(), 'missing'),
+          toId: 'entity.prepare',
+        },
+        { cwd: process.cwd() } as never
+      )
+    );
+
+    expect(error).toBeInstanceOf(ValidationError);
+    expect(error.message).toContain('rootDir does not exist');
+  });
+});

--- a/apps/trails/src/__tests__/load-app.test.ts
+++ b/apps/trails/src/__tests__/load-app.test.ts
@@ -1,7 +1,36 @@
 import { describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
 import { loadApp } from '../trails/load-app.js';
+
+const writeLoadAppFixture = (cwd: string, name: string): void => {
+  writeFileSync(
+    resolve(cwd, 'src/app.ts'),
+    `export const app = {
+  name: '${name}',
+  trails: new Map(),
+  signals: new Map(),
+  provisions: new Map()
+};`
+  );
+};
+
+const assertLoadAppCaching = async (cwd: string): Promise<void> => {
+  writeLoadAppFixture(cwd, 'first');
+
+  const first = await loadApp('./src/app.ts', cwd);
+
+  writeLoadAppFixture(cwd, 'second');
+
+  const cached = await loadApp('./src/app.ts', cwd);
+  const fresh = await loadApp('./src/app.ts', cwd, { fresh: true });
+
+  expect(first.name).toBe('first');
+  expect(cached.name).toBe('first');
+  expect(fresh.name).toBe('second');
+};
 
 describe('loadApp', () => {
   test('resolves relative module paths from cwd', async () => {
@@ -11,5 +40,19 @@ describe('loadApp', () => {
 
     expect(app.name).toBe('trails');
     expect(app.get('survey')).toBeDefined();
+  });
+
+  test('can bypass module caching with fresh loading', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      await assertLoadAppCaching(cwd);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
   });
 });

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -5,6 +5,7 @@ import * as addTrail from './trails/add-trail.js';
 import * as addVerify from './trails/add-verify.js';
 import * as create from './trails/create.js';
 import * as createScaffold from './trails/create-scaffold.js';
+import * as draftPromote from './trails/draft-promote.js';
 import * as guide from './trails/guide.js';
 import * as survey from './trails/survey.js';
 import * as warden from './trails/warden.js';
@@ -13,6 +14,7 @@ export const app = topo(
   'trails',
   survey,
   guide,
+  draftPromote,
   warden,
   create,
   createScaffold,

--- a/apps/trails/src/trails/draft-promote.ts
+++ b/apps/trails/src/trails/draft-promote.ts
@@ -314,11 +314,35 @@ const collectPromotableFileRename = async (
   return buildPromotableFileRename(filePath, fileName);
 };
 
-const collectAndApplyFileRenames = async (
+/** Validate that no two renames target the same path and no target already exists. */
+const validateRenameTargets = (
+  renames: readonly FileRename[]
+): Result<void, Error> => {
+  const targets = new Set<string>();
+  for (const r of renames) {
+    if (targets.has(r.to)) {
+      return Result.err(
+        new ValidationError(
+          `Duplicate rename target "${r.to}" — multiple draft files would be renamed to the same path`
+        )
+      );
+    }
+    if (existsSync(r.to)) {
+      return Result.err(
+        new ValidationError(
+          `Rename target "${r.to}" already exists — cannot overwrite`
+        )
+      );
+    }
+    targets.add(r.to);
+  }
+  return Result.ok();
+};
+
+const collectFileRenames = async (
   filePaths: readonly string[]
 ): Promise<Result<FileRename[], Error>> => {
   const renames: FileRename[] = [];
-
   for (const filePath of filePaths) {
     const renameResult = await collectPromotableFileRename(filePath);
     if (renameResult.isErr()) {
@@ -327,6 +351,22 @@ const collectAndApplyFileRenames = async (
     if (renameResult.value !== null) {
       renames.push(renameResult.value);
     }
+  }
+  return Result.ok(renames);
+};
+
+const collectAndApplyFileRenames = async (
+  filePaths: readonly string[]
+): Promise<Result<FileRename[], Error>> => {
+  const collected = await collectFileRenames(filePaths);
+  if (collected.isErr()) {
+    return collected;
+  }
+
+  const renames = collected.value;
+  const valid = validateRenameTargets(renames);
+  if (valid.isErr()) {
+    return valid;
   }
 
   for (const r of renames) {

--- a/apps/trails/src/trails/draft-promote.ts
+++ b/apps/trails/src/trails/draft-promote.ts
@@ -1,0 +1,664 @@
+import { existsSync, renameSync, statSync } from 'node:fs';
+import { basename, dirname, join, relative } from 'node:path';
+
+import {
+  Result,
+  ValidationError,
+  analyzeDraftState,
+  isDraftId,
+  trail,
+} from '@ontrails/core';
+import {
+  DRAFT_FILE_PREFIX,
+  findStringLiterals,
+  isDraftMarkedFile,
+  parse,
+  stripDraftFileMarkers,
+} from '@ontrails/warden';
+import { z } from 'zod';
+
+import { loadApp } from './load-app.js';
+import { findTopoPath } from './project.js';
+
+interface PromotionEdit {
+  readonly end: number;
+  readonly replacement: string;
+  readonly start: number;
+}
+
+interface FileRename {
+  readonly from: string;
+  readonly to: string;
+}
+
+const isManagedSourceFile = (match: string): boolean =>
+  !match.endsWith('.d.ts') &&
+  !match.startsWith('node_modules/') &&
+  !match.startsWith('dist/') &&
+  !match.startsWith('.git/');
+
+const collectTsFiles = (rootDir: string): string[] => {
+  const files: string[] = [];
+  for (const match of new Bun.Glob('**/*.ts').scanSync({
+    cwd: rootDir,
+    dot: false,
+    onlyFiles: true,
+  })) {
+    if (isManagedSourceFile(match)) {
+      files.push(join(rootDir, match));
+    }
+  }
+  return files.toSorted();
+};
+
+const applyEdits = (
+  sourceCode: string,
+  edits: readonly PromotionEdit[]
+): string => {
+  let updated = sourceCode;
+  for (const edit of [...edits].toSorted((a, b) => b.start - a.start)) {
+    updated =
+      updated.slice(0, edit.start) + edit.replacement + updated.slice(edit.end);
+  }
+  return updated;
+};
+
+const literalQuote = (raw: string): '"' | "'" | '`' => {
+  const [first] = raw;
+  return first === '"' || first === '`' ? first : "'";
+};
+
+const replaceQuotedLiteral = (
+  sourceCode: string,
+  start: number,
+  end: number,
+  nextValue: string
+): string => {
+  const quote = literalQuote(sourceCode.slice(start, end));
+  return `${quote}${nextValue}${quote}`;
+};
+
+const replaceIdLiterals = (
+  sourceCode: string,
+  filePath: string,
+  fromId: string,
+  toId: string
+): { readonly changed: boolean; readonly nextSource: string } => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return { changed: false, nextSource: sourceCode };
+  }
+
+  const edits = findStringLiterals(ast, (value) => value === fromId).map(
+    (match) => ({
+      end: match.end,
+      replacement: replaceQuotedLiteral(
+        sourceCode,
+        match.start,
+        match.end,
+        toId
+      ),
+      start: match.start,
+    })
+  );
+
+  if (edits.length === 0) {
+    return { changed: false, nextSource: sourceCode };
+  }
+
+  return {
+    changed: true,
+    nextSource: applyEdits(sourceCode, edits),
+  };
+};
+
+const hasDraftIds = (sourceCode: string, filePath: string): boolean => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return sourceCode.includes(DRAFT_FILE_PREFIX);
+  }
+  return findStringLiterals(ast, (value) => isDraftId(value)).length > 0;
+};
+
+const toJsPath = (filePath: string): string => filePath.replace(/\.ts$/, '.js');
+
+const toRelativeModulePath = (fromFile: string, toFile: string): string => {
+  const rel = relative(dirname(fromFile), toJsPath(toFile)).replaceAll(
+    '\\',
+    '/'
+  );
+  return rel.startsWith('.') ? rel : `./${rel}`;
+};
+
+const replaceLiteralValue = (
+  sourceCode: string,
+  filePath: string,
+  currentValue: string,
+  nextValue: string
+): { readonly changed: boolean; readonly nextSource: string } => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return { changed: false, nextSource: sourceCode };
+  }
+
+  const edits = findStringLiterals(ast, (value) => value === currentValue).map(
+    (match) => ({
+      end: match.end,
+      replacement: replaceQuotedLiteral(
+        sourceCode,
+        match.start,
+        match.end,
+        nextValue
+      ),
+      start: match.start,
+    })
+  );
+
+  if (edits.length === 0) {
+    return { changed: false, nextSource: sourceCode };
+  }
+
+  return {
+    changed: true,
+    nextSource: applyEdits(sourceCode, edits),
+  };
+};
+
+const collectOutputId = (
+  app: Awaited<ReturnType<typeof loadApp>>,
+  id: string
+) => app.get(id) ?? app.signals.get(id) ?? app.getProvision(id);
+
+const toRelativeOutputPath = (rootDir: string, filePath: string): string =>
+  relative(rootDir, filePath).replaceAll('\\', '/');
+
+const toProjectModulePath = (sourceImport: string): string =>
+  sourceImport.startsWith('./')
+    ? `./src/${sourceImport.slice(2)}`
+    : sourceImport;
+
+interface PromotionRewriteState {
+  readonly renames: FileRename[];
+  readonly updatedSourceFiles: Set<string>;
+}
+
+interface PromotionLoadState {
+  readonly appModule: string | null;
+  readonly loadError: string | null;
+  readonly loadedApp: Awaited<ReturnType<typeof loadApp>> | undefined;
+}
+
+const validatePromotionInput = (input: {
+  readonly fromId: string;
+  readonly toId: string;
+}): Result<void, ValidationError> => {
+  if (!isDraftId(input.fromId)) {
+    return Result.err(
+      new ValidationError(
+        `fromId must use the reserved draft prefix: "${input.fromId}"`
+      )
+    );
+  }
+
+  if (isDraftId(input.toId)) {
+    return Result.err(
+      new ValidationError(
+        `toId must be established, not draft: "${input.toId}"`
+      )
+    );
+  }
+
+  return Result.ok();
+};
+
+const validatePromotionRoot = (
+  rootDir: string
+): Result<void, ValidationError> => {
+  if (!existsSync(rootDir)) {
+    return Result.err(
+      new ValidationError(`rootDir does not exist: "${rootDir}"`)
+    );
+  }
+
+  if (!statSync(rootDir).isDirectory()) {
+    return Result.err(
+      new ValidationError(`rootDir must be a directory: "${rootDir}"`)
+    );
+  }
+
+  return Result.ok();
+};
+
+const resolveValidatedPromotionRoot = (
+  input: {
+    readonly fromId: string;
+    readonly rootDir?: string | undefined;
+    readonly toId: string;
+  },
+  ctx: { readonly cwd?: string | undefined }
+): Result<string, ValidationError> => {
+  const validation = validatePromotionInput(input);
+  if (validation.isErr()) {
+    return validation;
+  }
+
+  const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
+  const rootValidation = validatePromotionRoot(rootDir);
+  if (rootValidation.isErr()) {
+    return rootValidation;
+  }
+
+  return Result.ok(rootDir);
+};
+
+const rewritePromotedSourceFiles = async (
+  filePaths: readonly string[],
+  fromId: string,
+  toId: string,
+  updatedSourceFiles: Set<string>
+): Promise<void> => {
+  for (const filePath of filePaths) {
+    const sourceCode = await Bun.file(filePath).text();
+    const replaced = replaceIdLiterals(sourceCode, filePath, fromId, toId);
+    if (!replaced.changed) {
+      continue;
+    }
+
+    await Bun.write(filePath, replaced.nextSource);
+    updatedSourceFiles.add(filePath);
+  }
+};
+
+const hasDraftIdsInFile = async (filePath: string): Promise<boolean> => {
+  const sourceCode = await Bun.file(filePath).text();
+  return hasDraftIds(sourceCode, filePath);
+};
+
+const buildPromotableFileRename = (
+  filePath: string,
+  fileName: string
+): Result<FileRename | null, Error> => {
+  const nextFileName = stripDraftFileMarkers(fileName);
+  if (nextFileName === fileName) {
+    return Result.ok(null);
+  }
+
+  const nextPath = join(dirname(filePath), nextFileName);
+  if (nextPath !== filePath && existsSync(nextPath)) {
+    return Result.err(
+      new ValidationError(
+        `Cannot promote draft file "${filePath}" because "${nextPath}" already exists.`
+      )
+    );
+  }
+
+  return Result.ok({ from: filePath, to: nextPath });
+};
+
+const collectPromotableFileRename = async (
+  filePath: string
+): Promise<Result<FileRename | null, Error>> => {
+  if (!isDraftMarkedFile(filePath)) {
+    return Result.ok(null);
+  }
+
+  const fileName = basename(filePath);
+  if (!fileName) {
+    return Result.ok(null);
+  }
+
+  if (await hasDraftIdsInFile(filePath)) {
+    return Result.ok(null);
+  }
+
+  return buildPromotableFileRename(filePath, fileName);
+};
+
+const collectAndApplyFileRenames = async (
+  filePaths: readonly string[]
+): Promise<Result<FileRename[], Error>> => {
+  const renames: FileRename[] = [];
+
+  for (const filePath of filePaths) {
+    const renameResult = await collectPromotableFileRename(filePath);
+    if (renameResult.isErr()) {
+      return renameResult;
+    }
+    if (renameResult.value !== null) {
+      renames.push(renameResult.value);
+    }
+  }
+
+  for (const r of renames) {
+    renameSync(r.from, r.to);
+  }
+  return Result.ok(renames);
+};
+
+const applyRenameEffects = (
+  updatedSourceFiles: Set<string>,
+  renames: readonly FileRename[]
+): void => {
+  for (const rename of renames) {
+    if (updatedSourceFiles.delete(rename.from)) {
+      updatedSourceFiles.add(rename.to);
+    }
+  }
+};
+
+const applyRelativeImportRename = (
+  sourceCode: string,
+  filePath: string,
+  rename: FileRename
+): { readonly changed: boolean; readonly sourceCode: string } => {
+  const currentValue = toRelativeModulePath(filePath, rename.from);
+  const nextValue = toRelativeModulePath(filePath, rename.to);
+  if (currentValue === nextValue) {
+    return { changed: false, sourceCode };
+  }
+
+  const replaced = replaceLiteralValue(
+    sourceCode,
+    filePath,
+    currentValue,
+    nextValue
+  );
+  if (!replaced.changed) {
+    return { changed: false, sourceCode };
+  }
+
+  return { changed: true, sourceCode: replaced.nextSource };
+};
+
+const rewriteRelativeImportsForFile = (
+  filePath: string,
+  renames: readonly FileRename[],
+  sourceCode: string
+): { readonly changed: boolean; readonly sourceCode: string } => {
+  let nextSourceCode = sourceCode;
+  let changed = false;
+
+  for (const rename of renames) {
+    const updated = applyRelativeImportRename(nextSourceCode, filePath, rename);
+    if (!updated.changed) {
+      continue;
+    }
+
+    nextSourceCode = updated.sourceCode;
+    changed = true;
+  }
+
+  return { changed, sourceCode: nextSourceCode };
+};
+
+const updateRelativeImportsForFile = async (
+  filePath: string,
+  renames: readonly FileRename[]
+): Promise<boolean> => {
+  const sourceCode = await Bun.file(filePath).text();
+  const updated = rewriteRelativeImportsForFile(filePath, renames, sourceCode);
+  if (updated.changed) {
+    await Bun.write(filePath, updated.sourceCode);
+    return true;
+  }
+
+  return false;
+};
+
+const updateRelativeImports = async (
+  filePaths: readonly string[],
+  renames: readonly FileRename[]
+): Promise<string[]> => {
+  const updatedFiles = new Set<string>();
+
+  for (const filePath of filePaths) {
+    const changed = await updateRelativeImportsForFile(filePath, renames);
+    if (changed) {
+      updatedFiles.add(filePath);
+    }
+  }
+
+  return [...updatedFiles].toSorted();
+};
+
+const rewritePromotionState = async (
+  rootDir: string,
+  input: {
+    readonly fromId: string;
+    readonly renameFiles: boolean;
+    readonly toId: string;
+  }
+): Promise<Result<PromotionRewriteState, Error>> => {
+  const initialFiles = collectTsFiles(rootDir);
+  const updatedSourceFiles = new Set<string>();
+
+  await rewritePromotedSourceFiles(
+    initialFiles,
+    input.fromId,
+    input.toId,
+    updatedSourceFiles
+  );
+
+  const renamesResult = input.renameFiles
+    ? await collectAndApplyFileRenames(initialFiles)
+    : Result.ok([] as FileRename[]);
+  if (renamesResult.isErr()) {
+    return Result.err(renamesResult.error);
+  }
+
+  applyRenameEffects(updatedSourceFiles, renamesResult.value);
+  for (const f of await updateRelativeImports(
+    collectTsFiles(rootDir),
+    renamesResult.value
+  )) {
+    updatedSourceFiles.add(f);
+  }
+  return Result.ok({ renames: renamesResult.value, updatedSourceFiles });
+};
+
+const resolvePromotionAppModule = async (
+  input: {
+    readonly appModule?: string | undefined;
+  },
+  rootDir: string
+): Promise<string | null> => {
+  const discoveredAppModule = await findTopoPath(rootDir);
+  return (
+    input.appModule ??
+    (discoveredAppModule === null
+      ? null
+      : toProjectModulePath(discoveredAppModule))
+  );
+};
+
+const loadVerifiedApp = async (
+  appModule: string | null,
+  rootDir: string
+): Promise<PromotionLoadState> => {
+  if (appModule === null) {
+    return { appModule, loadError: null, loadedApp: undefined };
+  }
+
+  let loadError: string | null = null;
+  const loadedApp = await loadApp(appModule, rootDir, { fresh: true }).catch(
+    (error: unknown): undefined => {
+      loadError = error instanceof Error ? error.message : String(error);
+      return undefined;
+    }
+  );
+
+  return { appModule, loadError, loadedApp };
+};
+
+const toRenamedFiles = (rootDir: string, renames: readonly FileRename[]) =>
+  renames.map((rename) => ({
+    from: toRelativeOutputPath(rootDir, rename.from),
+    to: toRelativeOutputPath(rootDir, rename.to),
+  }));
+
+const toUpdatedFiles = (rootDir: string, updatedSourceFiles: Set<string>) =>
+  [...updatedSourceFiles]
+    .toSorted()
+    .map((filePath) => toRelativeOutputPath(rootDir, filePath));
+
+const buildUnverifiedPromotionResult = (
+  rootDir: string,
+  loadError: string | null,
+  renames: readonly FileRename[],
+  updatedSourceFiles: Set<string>,
+  appModule: string | null
+) =>
+  Result.ok({
+    appModule,
+    message:
+      loadError === null
+        ? 'Promotion rewrote source files, but no topo entrypoint could be loaded for verification.'
+        : `Promotion rewrote source files, but verification failed: ${loadError}`,
+    promotedEstablished: false,
+    remainingDraftIds: [],
+    renamedFiles: toRenamedFiles(rootDir, renames),
+    updatedFiles: toUpdatedFiles(rootDir, updatedSourceFiles),
+  });
+
+const buildVerifiedPromotionResult = (
+  rootDir: string,
+  analysis: ReturnType<typeof analyzeDraftState>,
+  promotedEstablished: boolean,
+  renames: readonly FileRename[],
+  updatedSourceFiles: Set<string>,
+  appModule: string | null,
+  toId: string
+) => {
+  const blockingFinding = analysis.findings.find(
+    (finding) => finding.id === toId
+  );
+
+  return Result.ok({
+    appModule,
+    message:
+      blockingFinding?.message ??
+      (promotedEstablished
+        ? `Promoted "${toId}" is now established.`
+        : `Promoted "${toId}" could not be verified as established.`),
+    promotedEstablished,
+    remainingDraftIds: [...analysis.declaredDraftIds].toSorted(),
+    renamedFiles: toRenamedFiles(rootDir, renames),
+    updatedFiles: toUpdatedFiles(rootDir, updatedSourceFiles),
+  });
+};
+
+const buildVerifiedPromotionResultFromApp = (
+  rootDir: string,
+  loadedApp: Awaited<ReturnType<typeof loadApp>>,
+  renames: readonly FileRename[],
+  updatedSourceFiles: Set<string>,
+  appModule: string | null,
+  toId: string
+) => {
+  const analysis = analyzeDraftState(loadedApp);
+  const promotedNode = collectOutputId(loadedApp, toId);
+  const promotedEstablished =
+    promotedNode !== undefined && !analysis.contaminatedIds.has(toId);
+
+  return buildVerifiedPromotionResult(
+    rootDir,
+    analysis,
+    promotedEstablished,
+    renames,
+    updatedSourceFiles,
+    appModule,
+    toId
+  );
+};
+
+const promoteDraftState = async (
+  input: {
+    readonly appModule?: string | undefined;
+    readonly fromId: string;
+    readonly renameFiles: boolean;
+    readonly rootDir?: string | undefined;
+    readonly toId: string;
+  },
+  ctx: { readonly cwd?: string | undefined }
+) => {
+  const rootDirResult = resolveValidatedPromotionRoot(input, ctx);
+  if (rootDirResult.isErr()) {
+    return rootDirResult;
+  }
+
+  const rewriteResult = await rewritePromotionState(rootDirResult.value, input);
+  if (rewriteResult.isErr()) {
+    return Result.err(rewriteResult.error);
+  }
+
+  const { renames, updatedSourceFiles } = rewriteResult.value;
+  const appModule = await resolvePromotionAppModule(input, rootDirResult.value);
+  const { loadError, loadedApp } = await loadVerifiedApp(
+    appModule,
+    rootDirResult.value
+  );
+
+  return loadedApp
+    ? buildVerifiedPromotionResultFromApp(
+        rootDirResult.value,
+        loadedApp,
+        renames,
+        updatedSourceFiles,
+        appModule,
+        input.toId
+      )
+    : buildUnverifiedPromotionResult(
+        rootDirResult.value,
+        loadError,
+        renames,
+        updatedSourceFiles,
+        appModule
+      );
+};
+
+export const draftPromoteTrail = trail('draft.promote', {
+  blaze: promoteDraftState,
+  description:
+    'Promote a draft id to an established id, rewrite inbound references, and verify the result against a fresh topo load.',
+  examples: [
+    {
+      error: 'ValidationError',
+      input: {
+        fromId: '_draft.entity.prepare',
+        renameFiles: true,
+        rootDir: './__does_not_exist__/draft-promote-example',
+        toId: 'entity.prepare',
+      },
+      name: 'Rejects a missing project root before any rewrite begins',
+    },
+  ],
+  input: z.object({
+    appModule: z
+      .string()
+      .optional()
+      .describe('Optional app module to verify after promotion'),
+    fromId: z.string().describe('Draft id to promote'),
+    renameFiles: z
+      .boolean()
+      .default(true)
+      .describe('Rename draft-marked files that no longer contain draft ids'),
+    rootDir: z.string().optional().describe('Project root directory'),
+    toId: z
+      .string()
+      .describe('Established id to write in place of the draft id'),
+  }),
+  intent: 'write',
+  output: z.object({
+    appModule: z.string().nullable(),
+    message: z.string(),
+    promotedEstablished: z.boolean(),
+    remainingDraftIds: z.array(z.string()),
+    renamedFiles: z.array(
+      z.object({
+        from: z.string(),
+        to: z.string(),
+      })
+    ),
+    updatedFiles: z.array(z.string()),
+  }),
+});

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -1,31 +1,94 @@
-import { isAbsolute, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { existsSync, rmSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { Topo } from '@ontrails/core';
 
 const URL_SCHEME = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
-/** Resolve a module path from cwd so CLI defaults behave like shell paths. */
-const resolveModuleSpecifier = (modulePath: string, cwd: string): string => {
-  if (URL_SCHEME.test(modulePath)) {
-    return modulePath;
-  }
+const resolveUrlModulePath = (modulePath: string): string => {
+  const url = new URL(modulePath);
+  return url.protocol === 'file:' ? fileURLToPath(url) : modulePath;
+};
 
+const resolveFilesystemModulePath = (
+  modulePath: string,
+  cwd: string
+): string => {
   const absolutePath = isAbsolute(modulePath)
     ? modulePath
     : resolve(cwd, modulePath);
-  return pathToFileURL(absolutePath).href;
+  if (!absolutePath.endsWith('.js') || existsSync(absolutePath)) {
+    return absolutePath;
+  }
+
+  const tsPath = absolutePath.replace(/\.js$/, '.ts');
+  return existsSync(tsPath) ? tsPath : absolutePath;
+};
+
+/** Resolve a module path from cwd so CLI defaults behave like shell paths. */
+const resolveAbsoluteModulePath = (modulePath: string, cwd: string): string =>
+  URL_SCHEME.test(modulePath)
+    ? resolveUrlModulePath(modulePath)
+    : resolveFilesystemModulePath(modulePath, cwd);
+
+const freshModuleCopyPath = (absolutePath: string): string =>
+  join(
+    dirname(absolutePath),
+    `.__fresh-${Date.now()}-${Math.random().toString(36).slice(2)}-${basename(absolutePath)}`
+  );
+
+/**
+ * Import a module bypassing the ESM cache for the entry file.
+ *
+ * @remarks
+ * Cache-busting applies to the entry module only. Transitive imports resolved
+ * by the entry file are still served from Bun's module cache. This is
+ * acceptable for the draft promotion workflow (the only caller) because
+ * promotion changes which modules the entry file imports, not the modules
+ * themselves. If a deeper cache-bust is needed in the future, consider
+ * Bun's `Loader.registry` or a full process restart.
+ */
+const importFreshModule = async (
+  modulePath: string,
+  cwd: string
+): Promise<Record<string, unknown>> => {
+  const absolutePath = resolveAbsoluteModulePath(modulePath, cwd);
+  if (URL_SCHEME.test(absolutePath) && !absolutePath.startsWith('/')) {
+    const url = new URL(absolutePath);
+    url.searchParams.set('t', Date.now().toString());
+    return (await import(url.href)) as Record<string, unknown>;
+  }
+
+  const freshPath = freshModuleCopyPath(absolutePath);
+  await Bun.write(freshPath, await Bun.file(absolutePath).text());
+
+  try {
+    return (await import(pathToFileURL(freshPath).href)) as Record<
+      string,
+      unknown
+    >;
+  } finally {
+    rmSync(freshPath, { force: true });
+  }
 };
 
 /** Load a Topo export from a module path relative to cwd. */
 export const loadApp = async (
   modulePath: string,
-  cwd: string
+  cwd: string,
+  options: { fresh?: boolean | undefined } = {}
 ): Promise<Topo> => {
-  const mod = (await import(resolveModuleSpecifier(modulePath, cwd))) as Record<
-    string,
-    unknown
-  >;
+  const resolvedModulePath = resolveAbsoluteModulePath(modulePath, cwd);
+  const mod =
+    options.fresh === true
+      ? await importFreshModule(modulePath, cwd)
+      : ((await import(
+          URL_SCHEME.test(resolvedModulePath) &&
+            !resolvedModulePath.startsWith('/')
+            ? new URL(resolvedModulePath).href
+            : pathToFileURL(resolvedModulePath).href
+        )) as Record<string, unknown>);
   const app = (mod['default'] ?? mod['app']) as Topo | undefined;
   if (!app?.trails) {
     throw new Error(

--- a/apps/trails/src/trails/project.ts
+++ b/apps/trails/src/trails/project.ts
@@ -5,10 +5,24 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { isDraftMarkedFile } from '@ontrails/warden';
+
 /** Return all TypeScript entries in a project's src directory. */
-const scanSourceEntries = (srcDir: string): string[] => [
-  ...new Bun.Glob('*.ts').scanSync({ cwd: srcDir }),
-];
+const sourceEntryPriority = (entry: string): number => {
+  if (entry === 'app.ts') {
+    return 0;
+  }
+  return isDraftMarkedFile(entry) ? 2 : 1;
+};
+
+const scanSourceEntries = (srcDir: string): string[] =>
+  [...new Bun.Glob('*.ts').scanSync({ cwd: srcDir })].toSorted((a, b) => {
+    const priority = sourceEntryPriority(a) - sourceEntryPriority(b);
+    if (priority === 0) {
+      return a.localeCompare(b);
+    }
+    return priority;
+  });
 
 /** Resolve an entry to an app import if it contains topo(). */
 const toTopoImport = async (

--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -91,6 +91,7 @@ export const wardenTrail = trail('warden', {
     ),
     drift: z
       .object({
+        blockedReason: z.string().optional(),
         committedHash: z.string().nullable(),
         currentHash: z.string(),
         stale: z.boolean(),

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -456,3 +456,15 @@ describe('buildCliCommands provision overrides', () => {
     expect(result?.unwrap()).toEqual({ name: 'override' });
   });
 });
+
+describe('buildCliCommands established graph enforcement', () => {
+  test('throws when draft contamination remains', () => {
+    const draftTrail = trail('entity.export', {
+      blaze: () => Result.ok({ ok: true }),
+      crosses: ['_draft.entity.prepare'],
+      input: z.object({}),
+    });
+
+    expect(() => buildCliCommands(makeApp(draftTrail))).toThrowError(/draft/i);
+  });
+});

--- a/packages/cli/src/__tests__/trailhead.test.ts
+++ b/packages/cli/src/__tests__/trailhead.test.ts
@@ -68,7 +68,10 @@ describe('trailhead', () => {
     });
     const app = topo('test', { t });
     expect(() =>
-      buildCliCommands(app, { onResult: defaultOnResult })
+      buildCliCommands(app, {
+        onResult: defaultOnResult,
+        validate: false,
+      })
     ).not.toThrow();
     const opts: Parameters<typeof trailhead>[1] = {
       provisions: {},

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -17,6 +17,7 @@ import {
   deriveCliPath,
   deriveFields,
   executeTrail,
+  validateEstablishedTopo,
 } from '@ontrails/core';
 
 import type { AnyTrail, CliCommand, CliFlag } from './command.js';
@@ -58,6 +59,8 @@ export interface BuildCliCommandsOptions {
   presets?: CliFlag[][] | undefined;
   provisions?: ProvisionOverrideMap | undefined;
   resolveInput?: InputResolver | undefined;
+  /** Set to `false` to skip topo validation while building commands. */
+  validate?: boolean | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -77,6 +80,20 @@ const mergeFlags = (presets: CliFlag[], derived: CliFlag[]): CliFlag[] => {
     }
   }
   return merged;
+};
+
+const assertValidCliTopo = (
+  app: Topo,
+  options?: BuildCliCommandsOptions
+): void => {
+  if (options?.validate === false) {
+    return;
+  }
+
+  const validated = validateEstablishedTopo(app);
+  if (validated.isErr()) {
+    throw validated.error;
+  }
 };
 
 // ---------------------------------------------------------------------------
@@ -377,19 +394,21 @@ const toCliCommand = (
   };
 };
 
+const collectCommands = (
+  app: Topo,
+  options?: BuildCliCommandsOptions
+): CliCommand[] =>
+  app
+    .list()
+    .filter((trail) => trail.meta?.['internal'] !== true)
+    .map((trail) => toCliCommand(trail, options));
+
 export const buildCliCommands = (
   app: Topo,
   options?: BuildCliCommandsOptions
 ): CliCommand[] => {
-  const commands: CliCommand[] = [];
-
-  for (const trail of app.list()) {
-    if (trail.meta?.['internal'] === true) {
-      continue;
-    }
-    commands.push(toCliCommand(trail, options));
-  }
-
+  assertValidCliTopo(app, options);
+  const commands = collectCommands(app, options);
   validateCliCommands(commands);
   return commands;
 };

--- a/packages/cli/src/commander/trailhead.ts
+++ b/packages/cli/src/commander/trailhead.ts
@@ -8,7 +8,6 @@ import type {
   Topo,
   TrailContextInit,
 } from '@ontrails/core';
-import { validateTopo } from '@ontrails/core';
 
 import type { ActionResultContext } from '../build.js';
 import { buildCliCommands } from '../build.js';
@@ -39,23 +38,14 @@ export interface TrailheadCliOptions {
 }
 
 // ---------------------------------------------------------------------------
-// Validation
-// ---------------------------------------------------------------------------
-
-/** Throw a ValidationError if the topo has structural issues. */
-const assertValidTopo = (app: Topo): void => {
-  const validated = validateTopo(app);
-  if (validated.isErr()) {
-    throw validated.error;
-  }
-};
-
-// ---------------------------------------------------------------------------
 // trailhead
 // ---------------------------------------------------------------------------
 
 /**
  * Wire an App to Commander and parse argv in one call.
+ *
+ * Validation is handled by `buildCliCommands` — pass `validate: false`
+ * to skip it (e.g. during hot-reload or progressive startup).
  *
  * ```ts
  * import { topo } from "@ontrails/core";
@@ -70,10 +60,6 @@ export const trailhead = async (
   app: Topo,
   options: TrailheadCliOptions = {}
 ): Promise<void> => {
-  if (options.validate !== false) {
-    assertValidTopo(app);
-  }
-
   const commands = buildCliCommands(app, {
     createContext: options.createContext,
     gates: options.gates,
@@ -81,6 +67,7 @@ export const trailhead = async (
     presets: options.presets,
     provisions: options.provisions,
     resolveInput: options.resolveInput,
+    validate: options.validate,
   });
 
   const commanderOpts: ToCommanderOptions = {

--- a/packages/core/src/__tests__/validate-topo.test.ts
+++ b/packages/core/src/__tests__/validate-topo.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test';
 
 import { z } from 'zod';
 
+import { analyzeDraftState, isDraftId } from '../draft.js';
+import { validateEstablishedTopo } from '../validate-established-topo.js';
 import { provision } from '../provision.js';
 import { Result } from '../result.js';
 import { topo } from '../topo.js';
@@ -78,6 +80,17 @@ describe('validateTopo', () => {
   });
 
   describe('trail crossing', () => {
+    test('draft crossings are allowed in the authored graph', () => {
+      const app = topo('app', {
+        exportTrail: mockTrail('entity.export', {
+          crosses: ['_draft.entity.prepare'],
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isOk()).toBe(true);
+    });
+
     test('trail crossing a non-existent trail fails', () => {
       const app = topo('app', {
         onboard: mockTrail('entity.onboard', {
@@ -150,6 +163,18 @@ describe('validateTopo', () => {
   });
 
   describe('provision declarations', () => {
+    test('draft provision references are allowed in the authored graph', () => {
+      const db = mockProvision('_draft.db.main');
+      const app = topo('app', {
+        show: mockTrail('entity.show', {
+          provisions: [db],
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isOk()).toBe(true);
+    });
+
     test('trail declaring a registered provision passes', () => {
       const db = mockProvision('db.main');
       const app = topo('app', {
@@ -318,5 +343,143 @@ describe('validateTopo', () => {
 
     const issues = extractIssues(result);
     expect(issues).toHaveLength(4);
+  });
+
+  describe('signal origins', () => {
+    test('draft signal origins are allowed in the authored graph', () => {
+      const app = topo('app', {
+        updated: mockEvent('entity.updated', ['_draft.entity.prepare']),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isOk()).toBe(true);
+    });
+  });
+});
+
+describe('draft state analysis', () => {
+  test('detects declared draft ids', () => {
+    const app = topo('app', {
+      draftTrail: mockTrail('_draft.entity.prepare'),
+    });
+
+    const analysis = analyzeDraftState(app);
+
+    expect(analysis.declaredDraftIds.has('_draft.entity.prepare')).toBe(true);
+    expect(analysis.contaminatedIds.has('_draft.entity.prepare')).toBe(true);
+    expect(analysis.findings.map((finding) => finding.rule)).toContain(
+      'draft-id'
+    );
+  });
+
+  test('propagates contamination through dependencies', () => {
+    const app = topo('app', {
+      exportTrail: mockTrail('entity.export', {
+        crosses: ['entity.prepare'],
+      }),
+      prepareTrail: mockTrail('entity.prepare', {
+        crosses: ['_draft.entity.store'],
+      }),
+    });
+
+    const analysis = analyzeDraftState(app);
+    const exportFinding = analysis.findings.find(
+      (finding) => finding.id === 'entity.export'
+    );
+
+    expect(analysis.contaminatedIds.has('entity.prepare')).toBe(true);
+    expect(analysis.contaminatedIds.has('entity.export')).toBe(true);
+    expect(exportFinding).toBeDefined();
+    expect(exportFinding?.rule).toBe('draft-contamination');
+  });
+});
+
+describe('validateEstablishedTopo', () => {
+  test('passes for an established topo', () => {
+    const app = topo('app', {
+      show: mockTrail('entity.show'),
+    });
+
+    const result = validateEstablishedTopo(app);
+    expect(result.isOk()).toBe(true);
+  });
+
+  test('fails when draft declarations remain', () => {
+    const app = topo('app', {
+      draftTrail: mockTrail('_draft.entity.prepare'),
+    });
+
+    const result = validateEstablishedTopo(app);
+    expect(result.isErr()).toBe(true);
+
+    const issues = extractIssues(result);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.rule).toBe('draft-id');
+  });
+
+  test('fails when established trails depend on draft state', () => {
+    const app = topo('app', {
+      exportTrail: mockTrail('entity.export', {
+        crosses: ['_draft.entity.prepare'],
+      }),
+    });
+
+    const result = validateEstablishedTopo(app);
+    expect(result.isErr()).toBe(true);
+
+    const issues = extractIssues(result);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.rule).toBe('draft-contamination');
+    expect(issues[0]?.message).toContain('entity.export');
+  });
+
+  test('fails when authored structural validation still fails', () => {
+    const app = topo('app', {
+      exportTrail: mockTrail('entity.export', {
+        crosses: ['entity.missing'],
+      }),
+    });
+
+    const result = validateEstablishedTopo(app);
+    expect(result.isErr()).toBe(true);
+
+    const issues = extractIssues(result);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.rule).toBe('cross-exists');
+  });
+
+  test('allows provision declarations to be satisfied outside the topo', () => {
+    const app = topo('app', {
+      show: mockTrail('entity.show', {
+        provisions: [mockProvision('db.main')],
+      }),
+    });
+
+    const result = validateEstablishedTopo(app);
+    expect(result.isOk()).toBe(true);
+  });
+
+  test('allows authoring-only example issues outside projection checks', () => {
+    const app = topo('app', {
+      show: mockTrail('entity.show', {
+        examples: [
+          {
+            expected: { ok: true },
+            input: { name: 'test' },
+            name: 'Has expected',
+          },
+        ],
+      }),
+    });
+
+    const result = validateEstablishedTopo(app);
+    expect(result.isOk()).toBe(true);
+  });
+});
+
+describe('isDraftId', () => {
+  test('recognizes the reserved draft prefix', () => {
+    expect(isDraftId('_draft.entity.show')).toBe(true);
+    expect(isDraftId('entity.show')).toBe(false);
   });
 });

--- a/packages/core/src/draft.ts
+++ b/packages/core/src/draft.ts
@@ -1,0 +1,334 @@
+import { ValidationError } from './errors.js';
+import type { AnySignal } from './event.js';
+import type { AnyProvision } from './provision.js';
+import { Result } from './result.js';
+import type { Topo } from './topo.js';
+import type { AnyTrail } from './trail.js';
+
+export const DRAFT_ID_PREFIX = '_draft.';
+
+export type DraftDependencyKind =
+  | 'cross'
+  | 'detour'
+  | 'provision'
+  | 'replaced-by'
+  | 'signal-from';
+
+export interface DraftDependency {
+  readonly fromId: string;
+  readonly kind: DraftDependencyKind;
+  readonly toId: string;
+}
+
+export interface DraftFinding {
+  readonly id: string;
+  readonly kind: 'provision' | 'signal' | 'trail' | 'unknown';
+  readonly message: string;
+  readonly rule: 'draft-contamination' | 'draft-id';
+  readonly via?: DraftDependencyKind | undefined;
+  readonly dependsOn?: string | undefined;
+}
+
+export interface DraftStateAnalysis {
+  readonly contaminatedIds: ReadonlySet<string>;
+  readonly declaredDraftIds: ReadonlySet<string>;
+  readonly dependencies: readonly DraftDependency[];
+  readonly findings: readonly DraftFinding[];
+}
+
+interface DraftReason {
+  readonly dependsOn: string;
+  readonly via: DraftDependencyKind;
+}
+
+type TopoNode = AnyProvision | AnySignal | AnyTrail;
+
+const replacedByTarget = (value: TopoNode): string | undefined => {
+  const raw = value as unknown as { replacedBy?: unknown };
+  return typeof raw.replacedBy === 'string' ? raw.replacedBy : undefined;
+};
+
+export const isDraftId = (id: string): boolean =>
+  id.startsWith(DRAFT_ID_PREFIX);
+
+const dependenciesFromIds = (
+  fromId: string,
+  toIds: readonly string[],
+  kind: DraftDependencyKind
+): DraftDependency[] =>
+  toIds.map((toId) => ({
+    fromId,
+    kind,
+    toId,
+  }));
+
+const dependencyFromTarget = (
+  fromId: string,
+  toId: string | undefined,
+  kind: DraftDependencyKind
+): DraftDependency[] =>
+  toId === undefined
+    ? []
+    : [
+        {
+          fromId,
+          kind,
+          toId,
+        },
+      ];
+
+const dependenciesFromDetours = (
+  fromId: string,
+  detours: Record<string, string[]>
+): DraftDependency[] =>
+  Object.values(detours).flatMap((targets) =>
+    dependenciesFromIds(fromId, targets, 'detour')
+  );
+
+const trailDependencies = (trail: AnyTrail): DraftDependency[] => {
+  const { detours } = trail as unknown as {
+    detours?: Record<string, string[]>;
+  };
+
+  return [
+    ...dependenciesFromIds(trail.id, trail.crosses, 'cross'),
+    ...dependenciesFromIds(
+      trail.id,
+      trail.provisions.map(({ id }) => id),
+      'provision'
+    ),
+    ...(detours === undefined
+      ? []
+      : dependenciesFromDetours(trail.id, detours)),
+    ...dependencyFromTarget(trail.id, replacedByTarget(trail), 'replaced-by'),
+  ];
+};
+
+const signalDependencies = (signal: AnySignal): DraftDependency[] => [
+  ...dependenciesFromIds(signal.id, signal.from ?? [], 'signal-from'),
+  ...dependencyFromTarget(signal.id, replacedByTarget(signal), 'replaced-by'),
+];
+
+const provisionDependencies = (provision: AnyProvision): DraftDependency[] =>
+  dependencyFromTarget(
+    provision.id,
+    replacedByTarget(provision),
+    'replaced-by'
+  );
+
+const nodeKind = (
+  id: string,
+  trails: ReadonlyMap<string, AnyTrail>,
+  signals: ReadonlyMap<string, AnySignal>,
+  provisions: ReadonlyMap<string, AnyProvision>
+): DraftFinding['kind'] => {
+  if (trails.has(id)) {
+    return 'trail';
+  }
+  if (signals.has(id)) {
+    return 'signal';
+  }
+  if (provisions.has(id)) {
+    return 'provision';
+  }
+  return 'unknown';
+};
+
+const displayKind = (kind: DraftFinding['kind']): string =>
+  kind === 'unknown' ? 'Node' : kind[0]?.toUpperCase() + kind.slice(1);
+
+const draftIdsFromKeys = (keys: Iterable<string>): string[] =>
+  [...keys].filter(isDraftId);
+
+const collectDeclaredDraftIds = (topo: Topo): ReadonlySet<string> =>
+  new Set([
+    ...draftIdsFromKeys(topo.trails.keys()),
+    ...draftIdsFromKeys(topo.signals.keys()),
+    ...draftIdsFromKeys(topo.provisions.keys()),
+  ]);
+
+const findingForDraftId = (
+  id: string,
+  kind: DraftFinding['kind']
+): DraftFinding => ({
+  id,
+  kind,
+  message: `${displayKind(id ? kind : 'unknown')} "${id}" is draft and cannot appear in the established graph.`,
+  rule: 'draft-id',
+});
+
+const findingForContamination = (
+  id: string,
+  kind: DraftFinding['kind'],
+  reason: DraftReason
+): DraftFinding => {
+  const dependencyLabel = isDraftId(reason.dependsOn)
+    ? `draft "${reason.dependsOn}"`
+    : `draft-contaminated "${reason.dependsOn}"`;
+
+  return {
+    dependsOn: reason.dependsOn,
+    id,
+    kind,
+    message:
+      `Established ${kind} "${id}" depends on ${dependencyLabel} ` +
+      `via ${reason.via} and cannot appear in the established graph.`,
+    rule: 'draft-contamination',
+    via: reason.via,
+  };
+};
+
+const contaminationReason = (
+  dependency: DraftDependency,
+  contaminatedIds: ReadonlySet<string>
+): DraftReason | undefined => {
+  if (contaminatedIds.has(dependency.fromId)) {
+    return undefined;
+  }
+
+  if (!isDraftId(dependency.toId) && !contaminatedIds.has(dependency.toId)) {
+    return undefined;
+  }
+
+  return {
+    dependsOn: dependency.toId,
+    via: dependency.kind,
+  };
+};
+
+const markContaminatedDependency = (
+  dependency: DraftDependency,
+  contaminatedIds: Set<string>,
+  reasons: Map<string, DraftReason>
+): boolean => {
+  const reason = contaminationReason(dependency, contaminatedIds);
+
+  if (reason === undefined) {
+    return false;
+  }
+
+  contaminatedIds.add(dependency.fromId);
+  reasons.set(dependency.fromId, reason);
+  return true;
+};
+
+const propagateContaminatedIds = (
+  declaredDraftIds: ReadonlySet<string>,
+  dependencies: readonly DraftDependency[]
+): { contaminatedIds: Set<string>; reasons: Map<string, DraftReason> } => {
+  const contaminatedIds = new Set<string>(declaredDraftIds);
+  const reasons = new Map<string, DraftReason>();
+
+  const visit = (): void => {
+    if (
+      dependencies.some((dependency) =>
+        markContaminatedDependency(dependency, contaminatedIds, reasons)
+      )
+    ) {
+      visit();
+    }
+  };
+
+  visit();
+  return { contaminatedIds, reasons };
+};
+
+const contaminationFindingForId = (
+  id: string,
+  declaredDraftIds: ReadonlySet<string>,
+  reasons: ReadonlyMap<string, DraftReason>,
+  trails: ReadonlyMap<string, AnyTrail>,
+  signals: ReadonlyMap<string, AnySignal>,
+  provisions: ReadonlyMap<string, AnyProvision>
+): DraftFinding | undefined => {
+  if (declaredDraftIds.has(id)) {
+    return undefined;
+  }
+
+  const reason = reasons.get(id);
+  if (reason === undefined) {
+    return undefined;
+  }
+
+  return findingForContamination(
+    id,
+    nodeKind(id, trails, signals, provisions),
+    reason
+  );
+};
+
+const collectFindings = (
+  declaredDraftIds: ReadonlySet<string>,
+  contaminatedIds: ReadonlySet<string>,
+  reasons: ReadonlyMap<string, DraftReason>,
+  trails: ReadonlyMap<string, AnyTrail>,
+  signals: ReadonlyMap<string, AnySignal>,
+  provisions: ReadonlyMap<string, AnyProvision>
+): DraftFinding[] => [
+  ...[...declaredDraftIds]
+    .toSorted()
+    .map((id) =>
+      findingForDraftId(id, nodeKind(id, trails, signals, provisions))
+    ),
+  ...[...contaminatedIds].toSorted().flatMap((id) => {
+    const finding = contaminationFindingForId(
+      id,
+      declaredDraftIds,
+      reasons,
+      trails,
+      signals,
+      provisions
+    );
+
+    return finding === undefined ? [] : [finding];
+  }),
+];
+
+const collectDependencies = (topo: Topo): DraftDependency[] => [
+  ...[...topo.trails.values()].flatMap(trailDependencies),
+  ...[...topo.signals.values()].flatMap(signalDependencies),
+  ...[...topo.provisions.values()].flatMap(provisionDependencies),
+];
+
+export const analyzeDraftState = (topo: Topo): DraftStateAnalysis => {
+  const declaredDraftIds = collectDeclaredDraftIds(topo);
+  const dependencies = collectDependencies(topo);
+  const { contaminatedIds, reasons } = propagateContaminatedIds(
+    declaredDraftIds,
+    dependencies
+  );
+  const findings = collectFindings(
+    declaredDraftIds,
+    contaminatedIds,
+    reasons,
+    topo.trails,
+    topo.signals,
+    topo.provisions
+  );
+
+  return {
+    contaminatedIds,
+    declaredDraftIds,
+    dependencies,
+    findings,
+  };
+};
+
+export const validateEstablishedTopo = (
+  topo: Topo
+): Result<void, ValidationError> => {
+  const analysis = analyzeDraftState(topo);
+
+  if (analysis.findings.length === 0) {
+    return Result.ok();
+  }
+
+  return Result.err(
+    new ValidationError(
+      `Established topo validation failed with ${analysis.findings.length} draft issue(s)`,
+      {
+        context: { issues: analysis.findings },
+      }
+    )
+  );
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,9 +83,24 @@ export type { AnyEvent, Event, EventSpec } from './event.js';
 export { topo } from './topo.js';
 export type { Topo } from './topo.js';
 
+// Draft state
+export {
+  DRAFT_ID_PREFIX,
+  analyzeDraftState,
+  isDraftId,
+  validateEstablishedTopo as validateDraftFreeTopo,
+} from './draft.js';
+export type {
+  DraftDependency,
+  DraftDependencyKind,
+  DraftFinding,
+  DraftStateAnalysis,
+} from './draft.js';
+
 // Topo validation
 export { validateTopo } from './validate-topo.js';
 export type { TopoIssue } from './validate-topo.js';
+export { validateEstablishedTopo } from './validate-established-topo.js';
 
 // Gate
 export { composeGates } from './gate.js';

--- a/packages/core/src/validate-established-topo.ts
+++ b/packages/core/src/validate-established-topo.ts
@@ -1,0 +1,62 @@
+import { ValidationError } from './errors.js';
+import { Result } from './result.js';
+import type { Topo } from './topo.js';
+import { validateEstablishedTopo as validateDraftFreeTopo } from './draft.js';
+import type { TopoIssue } from './validate-topo.js';
+import { validateTopo } from './validate-topo.js';
+
+const PROJECTION_BLOCKING_RULES = new Set([
+  'cross-cycle',
+  'cross-exists',
+  'no-self-cross',
+  'signal-origin-exists',
+]);
+
+const keepProjectionBlockingIssues = (
+  result: ReturnType<typeof validateTopo>
+) => {
+  if (result.isOk()) {
+    return result;
+  }
+
+  const issues = (
+    result.error.context as { issues?: readonly TopoIssue[] } | undefined
+  )?.issues;
+  const remainingIssues = issues?.filter((issue) =>
+    PROJECTION_BLOCKING_RULES.has(issue.rule)
+  );
+
+  if (remainingIssues === undefined || remainingIssues.length === 0) {
+    return Result.ok();
+  }
+
+  return Result.err(
+    new ValidationError(
+      `Topo validation failed with ${remainingIssues.length} issue(s)`,
+      {
+        cause: result.error,
+        context: { issues: remainingIssues },
+      }
+    )
+  );
+};
+
+/**
+ * Validate that a topo is ready for established outputs.
+ *
+ * Established surfaces still require the authored graph to be structurally
+ * valid, and they must also reject any remaining draft state.
+ */
+export const validateEstablishedTopo = (topo: Topo) => {
+  const structural = keepProjectionBlockingIssues(validateTopo(topo));
+  if (structural.isErr()) {
+    return structural;
+  }
+
+  const established = validateDraftFreeTopo(topo);
+  if (established.isErr()) {
+    return established;
+  }
+
+  return Result.ok();
+};

--- a/packages/core/src/validate-topo.ts
+++ b/packages/core/src/validate-topo.ts
@@ -7,6 +7,7 @@
  */
 
 import { ValidationError } from './errors.js';
+import { isDraftId } from './draft.js';
 import type { AnySignal } from './event.js';
 import { Result } from './result.js';
 import type { Topo } from './topo.js';
@@ -100,7 +101,7 @@ const checkCrosses = (
           rule: 'no-self-cross',
           trailId: id,
         });
-      } else if (!topo.has(crossedId)) {
+      } else if (!topo.has(crossedId) && !isDraftId(crossedId)) {
         issues.push({
           message: `Crosses "${crossedId}" which is not in the topo`,
           rule: 'cross-exists',
@@ -121,7 +122,10 @@ const checkProvisions = (
 
   for (const [id, trail] of trails) {
     for (const declaredProvision of trail.provisions) {
-      if (!topo.hasProvision(declaredProvision.id)) {
+      if (
+        !topo.hasProvision(declaredProvision.id) &&
+        !isDraftId(declaredProvision.id)
+      ) {
         issues.push({
           message: `Provision "${declaredProvision.id}" is not in the topo`,
           rule: 'provision-exists',
@@ -187,7 +191,7 @@ const checkSignalOrigins = (
       continue;
     }
     for (const originId of evt.from) {
-      if (!topo.has(originId)) {
+      if (!topo.has(originId) && !isDraftId(originId)) {
         issues.push({
           message: `Signal origin "${originId}" is not in the topo`,
           rule: 'signal-origin-exists',

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -476,4 +476,19 @@ describe('buildHttpRoutes', () => {
       expect(result.error?.message).toContain('entity');
     });
   });
+
+  describe('established graph enforcement', () => {
+    test('returns err when draft contamination remains', () => {
+      const draftTrail = trail('entity.export', {
+        blaze: () => Result.ok({ ok: true }),
+        crosses: ['_draft.entity.prepare'],
+        input: z.object({}),
+      });
+
+      const result = buildHttpRoutes(topo('testapp', { draftTrail }));
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error?.message).toMatch(/draft/i);
+    });
+  });
 });

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -11,6 +11,7 @@ import {
   TRAILHEAD_KEY,
   ValidationError,
   executeTrail,
+  validateEstablishedTopo,
 } from '@ontrails/core';
 import type {
   Gate,
@@ -35,6 +36,8 @@ export interface BuildHttpRoutesOptions {
     | undefined;
   readonly gates?: readonly Gate[] | undefined;
   readonly provisions?: ProvisionOverrideMap | undefined;
+  /** Set to `false` to skip topo validation while building routes. */
+  readonly validate?: boolean | undefined;
 }
 
 export type HttpMethod = 'GET' | 'POST' | 'DELETE';
@@ -227,6 +230,13 @@ export const buildHttpRoutes = (
   app: Topo,
   options: BuildHttpRoutesOptions = {}
 ): Result<HttpRouteDefinition[], Error> => {
+  if (options.validate !== false) {
+    const validated = validateEstablishedTopo(app);
+    if (validated.isErr()) {
+      return Result.err(validated.error);
+    }
+  }
+
   const basePath = (options.basePath ?? '').replace(/\/+$/, '');
   const gates = options.gates ?? [];
   return accumulateRoutes(eligibleTrails(app), basePath, gates, options);

--- a/packages/http/src/hono/trailhead.ts
+++ b/packages/http/src/hono/trailhead.ts
@@ -10,7 +10,7 @@
  * ```
  */
 
-import { isTrailsError, statusCodeMap, validateTopo } from '@ontrails/core';
+import { isTrailsError, statusCodeMap } from '@ontrails/core';
 import type {
   Gate,
   ProvisionOverrideMap,
@@ -294,20 +294,6 @@ const registerErrorHandler = (hono: Hono): void => {
 // Validation
 // ---------------------------------------------------------------------------
 
-/**
- * Throw a ValidationError if the topo has structural issues.
- * Pass `skip: true` to bypass validation (e.g. when `validate: false` is set).
- */
-const assertValidTopo = (app: Topo, skip = false): void => {
-  if (skip) {
-    return;
-  }
-  const validated = validateTopo(app);
-  if (validated.isErr()) {
-    throw validated.error;
-  }
-};
-
 // ---------------------------------------------------------------------------
 // trailhead
 // ---------------------------------------------------------------------------
@@ -334,6 +320,7 @@ export const trailhead = async (
     createContext: options.createContext,
     gates: options.gates,
     provisions: options.provisions,
+    validate: options.validate,
   });
 
   if (routesResult.isErr()) {

--- a/packages/http/src/hono/trailhead.ts
+++ b/packages/http/src/hono/trailhead.ts
@@ -311,7 +311,6 @@ export const trailhead = async (
 ): Promise<Hono> => {
   const hono = new Hono();
 
-  assertValidTopo(app, options.validate === false);
   registerErrorHandler(hono);
 
   const routesResult = buildHttpRoutes(app, {

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -511,4 +511,19 @@ describe('buildMcpTools', () => {
       expect(errorResult?.isError).toBe(true);
     });
   });
+
+  describe('established graph enforcement', () => {
+    test('returns Err when draft contamination remains', () => {
+      const draftTrail = trail('entity.export', {
+        blaze: () => Result.ok({ ok: true }),
+        crosses: ['_draft.entity.prepare'],
+        input: z.object({}),
+      });
+
+      const result = buildMcpTools(topo('myapp', { draftTrail }));
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error?.message).toMatch(/draft/i);
+    });
+  });
 });

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -12,6 +12,7 @@ import {
   ValidationError,
   executeTrail,
   isBlobRef,
+  validateEstablishedTopo,
   zodToJsonSchema,
 } from '@ontrails/core';
 import type {
@@ -44,6 +45,8 @@ export interface BuildMcpToolsOptions {
   readonly includeTrails?: readonly string[] | undefined;
   readonly gates?: readonly Gate[] | undefined;
   readonly provisions?: ProvisionOverrideMap | undefined;
+  /** Set to `false` to skip topo validation while building tools. */
+  readonly validate?: boolean | undefined;
 }
 
 export interface McpToolDefinition {
@@ -348,11 +351,23 @@ const eligibleTrails = (
 ): Trail<unknown, unknown>[] =>
   app.list().filter((trail) => shouldInclude(trail, options));
 
-export const buildMcpTools = (
+const validateToolBuild = (
   app: Topo,
-  options: BuildMcpToolsOptions = {}
+  options: BuildMcpToolsOptions
+): Result<void, Error> => {
+  if (options.validate === false) {
+    return Result.ok();
+  }
+
+  const validated = validateEstablishedTopo(app);
+  return validated.isErr() ? Result.err(validated.error) : Result.ok();
+};
+
+const registerTools = (
+  app: Topo,
+  options: BuildMcpToolsOptions,
+  gates: readonly Gate[]
 ): Result<McpToolDefinition[], Error> => {
-  const gates = options.gates ?? [];
   const tools: McpToolDefinition[] = [];
   const nameToTrailId = new Map<string, string>();
 
@@ -371,4 +386,16 @@ export const buildMcpTools = (
   }
 
   return Result.ok(tools);
+};
+
+export const buildMcpTools = (
+  app: Topo,
+  options: BuildMcpToolsOptions = {}
+): Result<McpToolDefinition[], Error> => {
+  const validation = validateToolBuild(app, options);
+  if (validation.isErr()) {
+    return validation;
+  }
+
+  return registerTools(app, options, options.gates ?? []);
 };

--- a/packages/mcp/src/trailhead.ts
+++ b/packages/mcp/src/trailhead.ts
@@ -20,7 +20,7 @@ import type {
   Topo,
   TrailContextInit,
 } from '@ontrails/core';
-import { validateTopo } from '@ontrails/core';
+import { validateEstablishedTopo } from '@ontrails/core';
 
 import type { McpToolDefinition } from './build.js';
 import { buildMcpTools } from './build.js';
@@ -144,7 +144,7 @@ export const trailhead = async (
   options: TrailheadMcpOptions = {}
 ): Promise<void> => {
   if (options.validate !== false) {
-    const validated = validateTopo(app);
+    const validated = validateEstablishedTopo(app);
     if (validated.isErr()) {
       throw validated.error;
     }
@@ -157,6 +157,7 @@ export const trailhead = async (
     gates: options.gates,
     includeTrails: options.includeTrails,
     provisions: options.provisions,
+    validate: options.validate,
   });
 
   if (toolsResult.isErr()) {

--- a/packages/schema/src/__tests__/generate.test.ts
+++ b/packages/schema/src/__tests__/generate.test.ts
@@ -267,4 +267,18 @@ describe('generateTrailheadMap', () => {
       expect(new Date(map.generatedAt).toISOString()).toBe(map.generatedAt);
     });
   });
+
+  describe('established graph enforcement', () => {
+    test('rejects draft-contaminated topologies', () => {
+      const exportTrail = trail('entity.export', {
+        blaze: noop,
+        crosses: ['_draft.entity.prepare'],
+        input: z.object({}),
+      });
+
+      expect(() =>
+        generateTrailheadMap(topoFrom({ exportTrail }))
+      ).toThrowError(/draft/i);
+    });
+  });
 });

--- a/packages/schema/src/__tests__/openapi.test.ts
+++ b/packages/schema/src/__tests__/openapi.test.ts
@@ -32,11 +32,7 @@ const getJsonSchema = (
   return json['schema'] as Record<string, unknown>;
 };
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-describe('generateOpenApiSpec', () => {
+const registerPathAndMethodTests = () => {
   describe('path and method derivation', () => {
     test('dotted trail ID becomes a path', () => {
       const t = trail('entity.show', {
@@ -119,7 +115,9 @@ describe('generateOpenApiSpec', () => {
       expect(spec.paths['/api/v1//entity/show']).toBeUndefined();
     });
   });
+};
 
+const registerGetQueryParameterTests = () => {
   describe('GET query parameters', () => {
     const buildReadSpec = () => {
       const t = trail('entity.show', {
@@ -148,7 +146,9 @@ describe('generateOpenApiSpec', () => {
       expect(verboseParam?.['required']).toBe(false);
     });
   });
+};
 
+const registerRequestBodyTests = () => {
   describe('request body', () => {
     test('omits requestBody for empty input schema', () => {
       const t = trail('action.trigger', {
@@ -218,7 +218,9 @@ describe('generateOpenApiSpec', () => {
       expect(body['required']).toBe(true);
     });
   });
+};
 
+const registerResponseTests = () => {
   describe('responses', () => {
     test('trail with output schema → 200 response wrapped in { data }', () => {
       const t = trail('entity.show', {
@@ -322,7 +324,9 @@ describe('generateOpenApiSpec', () => {
       expect(responses['400']).toEqual({ description: 'ValidationError' });
     });
   });
+};
 
+const registerMetadataAndStructureTests = () => {
   describe('operationId', () => {
     test('dots replaced with underscores', () => {
       const t = trail('entity.show', {
@@ -494,4 +498,30 @@ describe('generateOpenApiSpec', () => {
       expect(op['summary']).toBeUndefined();
     });
   });
-});
+
+  describe('established graph enforcement', () => {
+    test('rejects draft-contaminated topologies', () => {
+      const exportTrail = trail('entity.export', {
+        blaze: noop,
+        crosses: ['_draft.entity.prepare'],
+        input: z.object({}),
+      });
+
+      expect(() => generateOpenApiSpec(topoFrom({ exportTrail }))).toThrowError(
+        /draft/i
+      );
+    });
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('generateOpenApiSpec', () => [
+  registerPathAndMethodTests(),
+  registerGetQueryParameterTests(),
+  registerRequestBodyTests(),
+  registerResponseTests(),
+  registerMetadataAndStructureTests(),
+]);

--- a/packages/schema/src/generate.ts
+++ b/packages/schema/src/generate.ts
@@ -2,7 +2,11 @@
  * Generate a deterministic trailhead map from a Topo.
  */
 
-import { deriveCliPath, zodToJsonSchema } from '@ontrails/core';
+import {
+  deriveCliPath,
+  validateDraftFreeTopo,
+  zodToJsonSchema,
+} from '@ontrails/core';
 import type { AnyProvision, Signal, Topo, Trail } from '@ontrails/core';
 
 import type { JsonSchema, TrailheadMap, TrailheadMapEntry } from './types.js';
@@ -189,6 +193,25 @@ const provisionToEntry = (provision: AnyProvision): TrailheadMapEntry => {
   return sortKeys(entry) as unknown as TrailheadMapEntry;
 };
 
+const assertEstablishedTopo = (topo: Topo): void => {
+  const validated = validateDraftFreeTopo(topo);
+  if (validated.isErr()) {
+    throw validated.error;
+  }
+};
+
+const collectEntries = (topo: Topo): TrailheadMapEntry[] => [
+  ...[...topo.trails.values()].map((trail) =>
+    trailToEntry(trail as Trail<unknown, unknown>)
+  ),
+  ...[...topo.signals.values()].map((signal) =>
+    signalToEntry(signal as Signal<unknown>)
+  ),
+  ...[...topo.provisions.values()].map((provision) =>
+    provisionToEntry(provision)
+  ),
+];
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -200,25 +223,10 @@ const provisionToEntry = (provision: AnyProvision): TrailheadMapEntry => {
  * are sorted lexicographically for stable serialization.
  */
 export const generateTrailheadMap = (topo: Topo): TrailheadMap => {
-  const entries: TrailheadMapEntry[] = [];
-
-  // Collect all trails
-  for (const t of topo.trails.values()) {
-    entries.push(trailToEntry(t as Trail<unknown, unknown>));
-  }
-
-  // Collect all signals
-  for (const e of topo.signals.values()) {
-    entries.push(signalToEntry(e as Signal<unknown>));
-  }
-
-  // Collect all provisions
-  for (const provision of topo.provisions.values()) {
-    entries.push(provisionToEntry(provision));
-  }
-
-  // Sort alphabetically by id
-  const sorted = entries.toSorted((a, b) => a.id.localeCompare(b.id));
+  assertEstablishedTopo(topo);
+  const sorted = collectEntries(topo).toSorted((a, b) =>
+    a.id.localeCompare(b.id)
+  );
 
   return {
     entries: sorted,

--- a/packages/schema/src/openapi.ts
+++ b/packages/schema/src/openapi.ts
@@ -5,7 +5,11 @@
  * parameters, and response schemas from the trail contract.
  */
 
-import { statusCodeMap, zodToJsonSchema } from '@ontrails/core';
+import {
+  statusCodeMap,
+  validateDraftFreeTopo,
+  zodToJsonSchema,
+} from '@ontrails/core';
 import type { Topo, Trail } from '@ontrails/core';
 
 import type { JsonSchema } from './types.js';
@@ -333,12 +337,19 @@ const buildInfo = (
 export const generateOpenApiSpec = (
   app: Topo,
   options?: OpenApiOptions
-): OpenApiSpec => ({
-  components: { schemas: {} },
-  info: buildInfo(app.name, options),
-  openapi: '3.1.0',
-  paths: collectPaths(app, (options?.basePath ?? '').replace(/\/+$/, '')),
-  ...(options?.servers && options.servers.length > 0
-    ? { servers: options.servers }
-    : {}),
-});
+): OpenApiSpec => {
+  const validated = validateDraftFreeTopo(app);
+  if (validated.isErr()) {
+    throw validated.error;
+  }
+
+  return {
+    components: { schemas: {} },
+    info: buildInfo(app.name, options),
+    openapi: '3.1.0',
+    paths: collectPaths(app, (options?.basePath ?? '').replace(/\/+$/, '')),
+    ...(options?.servers && options.servers.length > 0
+      ? { servers: options.servers }
+      : {}),
+  };
+};

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -299,7 +299,7 @@ describe('formatWardenReport', () => {
           'Established topo validation failed with 1 draft issue(s)',
         committedHash: null,
         currentHash: 'blocked',
-        stale: false,
+        stale: true,
       },
       errorCount: 0,
       passed: false,

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -5,6 +5,24 @@ import { join } from 'node:path';
 
 import { formatWardenReport, runWarden } from '../cli.js';
 
+const isDraftFileMarking = (rule: string): boolean =>
+  rule === 'draft-file-marking';
+
+const isDraftFileMarkingError = (diagnostic: {
+  rule: string;
+  severity?: string;
+}): boolean =>
+  isDraftFileMarking(diagnostic.rule) && diagnostic.severity === 'error';
+
+const isDraftFileMarkingWarn = (diagnostic: {
+  rule: string;
+  severity?: string;
+}): boolean =>
+  isDraftFileMarking(diagnostic.rule) && diagnostic.severity === 'warn';
+
+const isDraftVisibleDebt = (rule: string): boolean =>
+  rule === 'draft-visible-debt';
+
 const makeTempDir = (): string => {
   const dir = join(
     tmpdir(),
@@ -146,6 +164,83 @@ describe('runWarden', () => {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+
+  test('requires draft-bearing files to be visibly marked', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'draft-id.ts'),
+        `trail("_draft.entity.prepare", {
+  blaze: async () => Result.ok({ ok: true }),
+  input: z.object({})
+})`
+      );
+
+      const report = await runWarden({ rootDir: dir });
+
+      const hasDraftFileMarking = report.diagnostics.some((diagnostic) =>
+        isDraftFileMarking(diagnostic.rule)
+      );
+      const hasDraftVisibleDebt = report.diagnostics.some((diagnostic) =>
+        isDraftVisibleDebt(diagnostic.rule)
+      );
+
+      expect(hasDraftFileMarking).toBe(true);
+      expect(hasDraftVisibleDebt).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('allows correctly marked draft files while keeping the debt visible', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, '_draft.entity.ts'),
+        `trail("_draft.entity.prepare", {
+  blaze: async () => Result.ok({ ok: true }),
+  input: z.object({})
+})`
+      );
+
+      const report = await runWarden({ rootDir: dir });
+
+      const hasDraftFileMarkingError = report.diagnostics.some((diagnostic) =>
+        isDraftFileMarkingError(diagnostic)
+      );
+      const hasDraftVisibleDebt = report.diagnostics.some((diagnostic) =>
+        isDraftVisibleDebt(diagnostic.rule)
+      );
+
+      expect(hasDraftFileMarkingError).toBe(false);
+      expect(hasDraftVisibleDebt).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('warns when a draft-marked file no longer contains draft ids', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'entity.draft.ts'),
+        `trail("entity.prepare", {
+  blaze: async () => Result.ok({ ok: true }),
+  input: z.object({})
+})`
+      );
+
+      const report = await runWarden({ rootDir: dir });
+
+      const hasDraftFileMarkingWarn = report.diagnostics.some((diagnostic) =>
+        isDraftFileMarkingWarn(diagnostic)
+      );
+
+      expect(hasDraftFileMarkingWarn).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });
 
 describe('formatWardenReport', () => {
@@ -194,5 +289,23 @@ describe('formatWardenReport', () => {
     });
     expect(output).toContain('trailhead.lock is stale');
     expect(output).toContain('Result: FAIL');
+  });
+
+  test('formats a report with blocked established exports', () => {
+    const output = formatWardenReport({
+      diagnostics: [],
+      drift: {
+        blockedReason:
+          'Established topo validation failed with 1 draft issue(s)',
+        committedHash: null,
+        currentHash: 'blocked',
+        stale: false,
+      },
+      errorCount: 0,
+      passed: false,
+      warnCount: 0,
+    });
+    expect(output).toContain('Drift: blocked');
+    expect(output).toContain('established exports blocked');
   });
 });

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -71,4 +71,24 @@ describe('checkDrift', () => {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+
+  test('blocks drift calculation when draft state remains in the topo', async () => {
+    const dir = createTempDir();
+    try {
+      const draftTrail = trail('test.hello', {
+        blaze: () => Result.ok({ greeting: 'hi' }),
+        crosses: ['_draft.test.prepare'],
+        input: z.object({ name: z.string() }),
+        output: z.object({ greeting: z.string() }),
+      });
+
+      const result = await checkDrift(dir, topo('test-app', { draftTrail }));
+
+      expect(result.stale).toBe(false);
+      expect(result.blockedReason).toContain('draft');
+      expect(result.currentHash).toBe('blocked');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -84,7 +84,7 @@ describe('checkDrift', () => {
 
       const result = await checkDrift(dir, topo('test-app', { draftTrail }));
 
-      expect(result.stale).toBe(false);
+      expect(result.stale).toBe(true);
       expect(result.blockedReason).toContain('draft');
       expect(result.currentHash).toBe('blocked');
     } finally {

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -352,8 +352,7 @@ const formatResultLine = (report: WardenReport): string => {
   }
   if (report.drift?.blockedReason !== undefined) {
     parts.push('established exports blocked');
-  }
-  if (report.drift?.stale) {
+  } else if (report.drift?.stale) {
     parts.push('drift detected');
   }
   return `Result: FAIL (${parts.join(', ')})`;

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -293,7 +293,10 @@ export const runWarden = async (
     diagnostics: allDiagnostics,
     drift,
     errorCount,
-    passed: errorCount === 0 && !(drift?.stale ?? false),
+    passed:
+      errorCount === 0 &&
+      !(drift?.stale ?? false) &&
+      drift?.blockedReason === undefined,
     warnCount,
   };
 };
@@ -327,6 +330,9 @@ const formatDriftSection = (drift: DriftResult | null): string[] => {
   if (drift === null) {
     return [];
   }
+  if (drift.blockedReason !== undefined) {
+    return [`Drift: blocked (${drift.blockedReason})`, ''];
+  }
   const label = drift.stale
     ? 'Drift: trailhead.lock is stale (regenerate with `trails survey generate`)'
     : 'Drift: clean';
@@ -343,6 +349,9 @@ const formatResultLine = (report: WardenReport): string => {
   const parts: string[] = [];
   if (report.errorCount > 0) {
     parts.push(`${report.errorCount} errors`);
+  }
+  if (report.drift?.blockedReason !== undefined) {
+    parts.push('established exports blocked');
   }
   if (report.drift?.stale) {
     parts.push('drift detected');

--- a/packages/warden/src/draft.ts
+++ b/packages/warden/src/draft.ts
@@ -1,0 +1,22 @@
+import { basename } from 'node:path';
+
+export const DRAFT_FILE_PREFIX = '_draft.';
+export const DRAFT_FILE_SEGMENT = '.draft.';
+
+const DRAFT_TRAILING_SEGMENT = /\.draft(?=\.[^.]+$)/;
+
+export const isDraftMarkedFile = (filePath: string): boolean => {
+  const fileName = basename(filePath);
+  return (
+    fileName.startsWith(DRAFT_FILE_PREFIX) ||
+    fileName.includes(DRAFT_FILE_SEGMENT)
+  );
+};
+
+export const stripDraftFileMarkers = (fileName: string): string => {
+  if (fileName.startsWith(DRAFT_FILE_PREFIX)) {
+    return fileName.slice(DRAFT_FILE_PREFIX.length);
+  }
+
+  return fileName.replace(DRAFT_TRAILING_SEGMENT, '');
+};

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Topo } from '@ontrails/core';
+import { ValidationError } from '@ontrails/core';
 import {
   generateTrailheadMap,
   hashTrailheadMap,
@@ -17,6 +18,8 @@ import {
  * Result of a drift check comparing committed trailhead.lock against the current state.
  */
 export interface DriftResult {
+  /** Why drift could not be computed for the established graph, when blocked. */
+  readonly blockedReason?: string | undefined;
   /** Whether the committed lock is out of date */
   readonly stale: boolean;
   /** Hash from the committed trailhead.lock file, or null if not found */
@@ -38,13 +41,26 @@ export const checkDrift = async (
     return { committedHash: null, currentHash: 'unknown', stale: false };
   }
 
-  const trailheadMap = generateTrailheadMap(topo);
-  const currentHash = hashTrailheadMap(trailheadMap);
-  const committedHash = await readTrailheadLock({ dir: rootDir });
+  try {
+    const trailheadMap = generateTrailheadMap(topo);
+    const currentHash = hashTrailheadMap(trailheadMap);
+    const committedHash = await readTrailheadLock({ dir: rootDir });
 
-  return {
-    committedHash,
-    currentHash,
-    stale: committedHash !== null && committedHash !== currentHash,
-  };
+    return {
+      committedHash,
+      currentHash,
+      stale: committedHash !== null && committedHash !== currentHash,
+    };
+  } catch (error) {
+    if (!(error instanceof ValidationError)) {
+      throw error;
+    }
+
+    return {
+      blockedReason: error.message,
+      committedHash: null,
+      currentHash: 'blocked',
+      stale: true,
+    };
+  }
 };

--- a/packages/warden/src/formatters.ts
+++ b/packages/warden/src/formatters.ts
@@ -19,7 +19,8 @@ const ghLevel: Record<WardenSeverity, string> = {
  * Produce GitHub Actions workflow command annotations, one per diagnostic.
  *
  * Severity mapping: `error` to `::error`, `warn` to `::warning`.
- * Drift staleness is emitted as a single `::error` annotation when detected.
+ * Drift staleness or established-export blocking is emitted as a single
+ * `::error` annotation when detected.
  */
 export const formatGitHubAnnotations = (report: WardenReport): string => {
   const lines: string[] = [];
@@ -29,6 +30,10 @@ export const formatGitHubAnnotations = (report: WardenReport): string => {
     lines.push(
       `::${level} file=${d.filePath},line=${String(d.line)}::${d.rule}: ${d.message}`
     );
+  }
+
+  if (report.drift?.blockedReason !== undefined) {
+    lines.push(`::error::drift: ${report.drift.blockedReason}`);
   }
 
   if (report.drift?.stale) {
@@ -82,6 +87,14 @@ const severitySection = (
 
 /** Render a drift section if stale, otherwise empty array. */
 const driftSection = (drift: WardenReport['drift']): readonly string[] => {
+  if (drift?.blockedReason !== undefined) {
+    return [
+      '',
+      '### Drift',
+      `- established exports are blocked: ${drift.blockedReason}`,
+    ];
+  }
+
   if (!drift?.stale) {
     return [];
   }

--- a/packages/warden/src/formatters.ts
+++ b/packages/warden/src/formatters.ts
@@ -34,9 +34,7 @@ export const formatGitHubAnnotations = (report: WardenReport): string => {
 
   if (report.drift?.blockedReason !== undefined) {
     lines.push(`::error::drift: ${report.drift.blockedReason}`);
-  }
-
-  if (report.drift?.stale) {
+  } else if (report.drift?.stale) {
     lines.push(
       '::error::drift: trailhead.lock is stale (regenerate with `trails survey generate`)'
     );

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -19,6 +19,8 @@ export type {
 // Individual rules
 export { noThrowInImplementation } from './rules/no-throw-in-implementation.js';
 export { contextNoTrailheadTypes } from './rules/context-no-trailhead-types.js';
+export { draftFileMarking } from './rules/draft-file-marking.js';
+export { draftVisibleDebt } from './rules/draft-visible-debt.js';
 export { validDetourRefs } from './rules/valid-detour-refs.js';
 export { noDirectImplInRoute } from './rules/no-direct-impl-in-route.js';
 export { noDirectImplementationCall } from './rules/no-direct-implementation-call.js';
@@ -47,6 +49,25 @@ export {
 // Drift detection
 export type { DriftResult } from './drift.js';
 export { checkDrift } from './drift.js';
+
+// Draft helpers
+export {
+  DRAFT_FILE_PREFIX,
+  DRAFT_FILE_SEGMENT,
+  isDraftMarkedFile,
+  stripDraftFileMarkers,
+} from './draft.js';
+
+// AST helpers for repo-local tooling
+export {
+  findStringLiterals,
+  getStringValue,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  walk,
+} from './rules/ast.js';
+export type { AstNode, StringLiteralMatch } from './rules/ast.js';
 
 // Trail gate
 export { wardenTopo } from './trails/topo.js';

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -155,6 +155,44 @@ export const extractStringLiteral = (
 ): string | null =>
   node && isStringLiteral(node) ? getStringValue(node) : null;
 
+export interface StringLiteralMatch {
+  readonly end: number;
+  readonly node: AstNode;
+  readonly start: number;
+  readonly value: string;
+}
+
+export const findStringLiterals = (
+  ast: AstNode,
+  predicate?: (value: string, node: AstNode) => boolean
+): StringLiteralMatch[] => {
+  const matches: StringLiteralMatch[] = [];
+
+  walk(ast, (node) => {
+    if (!isStringLiteral(node)) {
+      return;
+    }
+
+    const value = getStringValue(node);
+    if (value === null) {
+      return;
+    }
+
+    if (predicate && !predicate(value, node)) {
+      return;
+    }
+
+    matches.push({
+      end: node.end,
+      node,
+      start: node.start,
+      value,
+    });
+  });
+
+  return matches;
+};
+
 /** Extract the first string argument from a CallExpression. */
 export const extractFirstStringArg = (node: AstNode): string | null => {
   if (node.type !== 'CallExpression') {

--- a/packages/warden/src/rules/draft-file-marking.ts
+++ b/packages/warden/src/rules/draft-file-marking.ts
@@ -1,0 +1,112 @@
+import { isDraftId } from '@ontrails/core';
+
+import { isDraftMarkedFile } from '../draft.js';
+import { findStringLiterals, offsetToLine, parse } from './ast.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const messageForMissingMarker = (draftId: string): string =>
+  `Draft id "${draftId}" appears in source, but the file is not draft-marked. ` +
+  'Rename it with an _draft. prefix or a .draft. trailing segment.';
+
+const makeDiagnostic = (
+  sourceCode: string,
+  filePath: string,
+  start: number,
+  message: string,
+  severity: WardenDiagnostic['severity']
+): WardenDiagnostic => ({
+  filePath,
+  line: offsetToLine(sourceCode, start),
+  message,
+  rule: 'draft-file-marking',
+  severity,
+});
+
+const draftMissingMarkerDiagnostic = (
+  sourceCode: string,
+  filePath: string,
+  ast: NonNullable<ReturnType<typeof parse>>
+): WardenDiagnostic | null => {
+  const draftMatches = findStringLiterals(ast, (value) => isDraftId(value));
+  if (!draftMatches.length || isDraftMarkedFile(filePath)) {
+    return null;
+  }
+
+  const [first] = draftMatches;
+  if (!first) {
+    return null;
+  }
+
+  return makeDiagnostic(
+    sourceCode,
+    filePath,
+    first.start,
+    messageForMissingMarker(first.value),
+    'error'
+  );
+};
+
+const draftMarkedWithoutIdsDiagnostic = (
+  filePath: string,
+  ast: NonNullable<ReturnType<typeof parse>>
+): WardenDiagnostic | null => {
+  if (findStringLiterals(ast, (value) => isDraftId(value)).length > 0) {
+    return null;
+  }
+
+  if (!isDraftMarkedFile(filePath)) {
+    return null;
+  }
+
+  return {
+    filePath,
+    line: 1,
+    message:
+      'File is draft-marked but no longer contains draft ids. Remove the draft filename marker or finish the promotion cleanup.',
+    rule: 'draft-file-marking',
+    severity: 'warn',
+  };
+};
+
+const collectDraftFileMarkingDiagnostics = (
+  sourceCode: string,
+  filePath: string,
+  ast: NonNullable<ReturnType<typeof parse>>
+): WardenDiagnostic[] => {
+  const missingMarkerDiagnostic = draftMissingMarkerDiagnostic(
+    sourceCode,
+    filePath,
+    ast
+  );
+  if (missingMarkerDiagnostic) {
+    return [missingMarkerDiagnostic];
+  }
+
+  const markedWithoutIdsDiagnostic = draftMarkedWithoutIdsDiagnostic(
+    filePath,
+    ast
+  );
+  if (markedWithoutIdsDiagnostic) {
+    return [markedWithoutIdsDiagnostic];
+  }
+
+  return [];
+};
+
+/**
+ * Ensures files containing draft ids are visibly marked as draft-bearing files.
+ */
+export const draftFileMarking: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    return collectDraftFileMarkingDiagnostics(sourceCode, filePath, ast);
+  },
+  description:
+    'Require draft-bearing files to use _draft.* or *.draft.* filename markers.',
+  name: 'draft-file-marking',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/draft-visible-debt.ts
+++ b/packages/warden/src/rules/draft-visible-debt.ts
@@ -1,0 +1,62 @@
+import { isDraftId } from '@ontrails/core';
+
+import { findStringLiterals, offsetToLine, parse } from './ast.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const createDiagnostic = (
+  sourceCode: string,
+  filePath: string,
+  match: { start: number; value: string }
+): WardenDiagnostic => ({
+  filePath,
+  line: offsetToLine(sourceCode, match.start),
+  message:
+    `Draft id "${match.value}" is still visible debt. ` +
+    'Established trailheads, lock export, and OpenAPI generation will reject it until it is promoted.',
+  rule: 'draft-visible-debt',
+  severity: 'warn',
+});
+
+const collectDraftVisibleDebtDiagnostics = (
+  sourceCode: string,
+  filePath: string,
+  ast: NonNullable<ReturnType<typeof parse>>
+): WardenDiagnostic[] => {
+  const seen = new Set<string>();
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const match of findStringLiterals(ast, (value) => isDraftId(value))) {
+    const key = `${match.value}:${String(match.start)}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    diagnostics.push(createDiagnostic(sourceCode, filePath, match));
+  }
+
+  return diagnostics;
+};
+
+/**
+ * Warns when draft ids are still present so the debt stays visible during
+ * review even when the file is correctly marked.
+ *
+ * Severity is intentionally `warn`, not `error`. The hard rejection gate for
+ * draft state leaking into established outputs is `validateEstablishedTopo` at
+ * runtime — it blocks topo export, trailhead projection, and lockfile writes.
+ * This rule surfaces the debt for human reviewers without duplicating that gate.
+ */
+export const draftVisibleDebt: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    return collectDraftVisibleDebtDiagnostics(sourceCode, filePath, ast);
+  },
+  description:
+    'Warn when draft ids remain in source so the debt stays visible during review.',
+  name: 'draft-visible-debt',
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -1,5 +1,7 @@
 import { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 import { crossDeclarations } from './cross-declarations.js';
+import { draftFileMarking } from './draft-file-marking.js';
+import { draftVisibleDebt } from './draft-visible-debt.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
 import { noDirectImplInRoute } from './no-direct-impl-in-route.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
@@ -24,6 +26,8 @@ export type {
 export { noThrowInImplementation } from './no-throw-in-implementation.js';
 export { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 export { crossDeclarations } from './cross-declarations.js';
+export { draftFileMarking } from './draft-file-marking.js';
+export { draftVisibleDebt } from './draft-visible-debt.js';
 export { validDetourRefs } from './valid-detour-refs.js';
 export { noDirectImplInRoute } from './no-direct-impl-in-route.js';
 export { noDirectImplementationCall } from './no-direct-implementation-call.js';
@@ -43,6 +47,8 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [noThrowInImplementation.name, noThrowInImplementation],
   [contextNoTrailheadTypes.name, contextNoTrailheadTypes],
   [crossDeclarations.name, crossDeclarations],
+  [draftFileMarking.name, draftFileMarking],
+  [draftVisibleDebt.name, draftVisibleDebt],
   [provisionDeclarations.name, provisionDeclarations],
   [provisionExists.name, provisionExists],
   [preferSchemaInference.name, preferSchemaInference],

--- a/packages/warden/src/rules/provision-exists.ts
+++ b/packages/warden/src/rules/provision-exists.ts
@@ -1,3 +1,5 @@
+import { isDraftId } from '@ontrails/core';
+
 import {
   collectNamedProvisionIds,
   collectProvisionDefinitionIds,
@@ -94,7 +96,7 @@ const reportMissingProvisions = (
     def.config,
     provisionIdsByName
   )) {
-    if (!knownProvisionIds.has(provisionId)) {
+    if (!knownProvisionIds.has(provisionId) && !isDraftId(provisionId)) {
       diagnostics.push(
         buildMissingProvisionDiagnostic(def.id, provisionId, filePath, line)
       );

--- a/packages/warden/src/rules/valid-detour-refs.ts
+++ b/packages/warden/src/rules/valid-detour-refs.ts
@@ -1,3 +1,5 @@
+import { isDraftId } from '@ontrails/core';
+
 import { collectTrailIds } from './specs.js';
 import type {
   ProjectAwareWardenRule,
@@ -44,7 +46,7 @@ const findMissingDetourTargets = (
   const missing: string[] = [];
   for (const m of text.matchAll(/target\s*:\s*["'`]([^"'`]+)["'`]/g)) {
     const [, id] = m;
-    if (id && !knownIds.has(id)) {
+    if (id && !knownIds.has(id) && !isDraftId(id)) {
       missing.push(id);
     }
   }
@@ -59,7 +61,7 @@ const findMissingPlainDetours = (
   const cleaned = text.replaceAll(/target\s*:\s*["'`][^"'`]+["'`]/g, '');
   for (const m of cleaned.matchAll(/["'`]([^"'`]+)["'`]/g)) {
     const [, id] = m;
-    if (id && id.includes('.') && !knownIds.has(id)) {
+    if (id && id.includes('.') && !knownIds.has(id) && !isDraftId(id)) {
       missing.push(id);
     }
   }


### PR DESCRIPTION
## Summary
- Establishes `_draft.` state conventions and contamination rules
- Prevents draft state from leaking into established trailheads, topo exports, and lockfiles
- Adds warden rules for draft file marking and a promotion workflow
- Removes redundant double-validation from CLI trailhead()

## What changed
Draft state now has formal containment rules. Files with `_draft.` prefix or `.draft.` trailing segment are recognized as containing draft-authored state. The warden enforces that draft state never leaks into established trailheads, topo exports, or committed lockfiles. A built-in promotion workflow moves draft state into the established graph cleanly. As a side-effect cleanup, redundant double-validation in the CLI trailhead was removed.

## How it was tested
- bun run build
- bun run test
- bun run typecheck
- bun run lint
- Package-specific tests where applicable

Closes: TRL-170, TRL-177, TRL-178, TRL-179
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
