### PR TITLE
feat: project topo saves into relational tables

### DIFF
--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -11,6 +11,7 @@ import {
 import { join, resolve } from 'node:path';
 
 import type { Result } from '@ontrails/core';
+import { openReadTrailsDb } from '@ontrails/core/internal/trails-db';
 import { createDevStore } from '@ontrails/tracker';
 
 import { devCleanTrail } from '../trails/dev-clean.js';
@@ -142,9 +143,39 @@ describe('topo and dev trails', () => {
         } as never)
       );
       expect(firstPin.pin.name).toBe('before-auth');
+      expect(firstPin.pin.saveId).toBe(firstPin.save.id);
 
-      await topoExportTrail.blaze(moduleInput, { cwd: dir } as never);
-      await topoExportTrail.blaze(moduleInput, { cwd: dir } as never);
+      const firstExport = expectOk(
+        await topoExportTrail.blaze(moduleInput, { cwd: dir } as never)
+      );
+      const secondExport = expectOk(
+        await topoExportTrail.blaze(moduleInput, { cwd: dir } as never)
+      );
+
+      const projectionDb = openReadTrailsDb({ rootDir: dir });
+      try {
+        const pinnedRows = projectionDb
+          .query<{ count: number }, [string]>(
+            'SELECT COUNT(*) as count FROM topo_trails WHERE save_id = ?'
+          )
+          .get(firstPin.save.id);
+        const exportedRows = projectionDb
+          .query<{ count: number }, [string]>(
+            'SELECT COUNT(*) as count FROM topo_trails WHERE save_id = ?'
+          )
+          .get(firstExport.save.id);
+        const projectedSaves = projectionDb
+          .query<{ count: number }, []>(
+            'SELECT COUNT(DISTINCT save_id) as count FROM topo_trails'
+          )
+          .get();
+
+        expect(pinnedRows?.count).toBe(2);
+        expect(exportedRows?.count).toBe(2);
+        expect(projectedSaves?.count).toBe(3);
+      } finally {
+        projectionDb.close();
+      }
 
       const store = createDevStore({ rootDir: dir });
       try {
@@ -183,6 +214,10 @@ describe('topo and dev trails', () => {
       );
       expect(history.pinCount).toBe(1);
       expect(history.saveCount).toBeGreaterThanOrEqual(3);
+      expect(history.pins[0]?.saveId).toBe(firstPin.save.id);
+      expect(
+        history.saves.some((save) => save.id === secondExport.save.id)
+      ).toBe(true);
 
       const stats = expectOk(
         await devStatsTrail.blaze({}, { cwd: dir } as never)

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -10,13 +10,13 @@ import type {
   TopoSaveRecord,
 } from '@ontrails/core/internal/topo-saves';
 import {
-  createTopoSave,
   getTopoPin,
   listTopoPins,
   listTopoSaves,
   pinTopoSave,
   unpinTopoSave,
 } from '@ontrails/core/internal/topo-saves';
+import { persistEstablishedTopoSave } from '@ontrails/core/internal/topo-store';
 import {
   openReadTrailsDb,
   openWriteTrailsDb,
@@ -210,7 +210,7 @@ export const createCurrentTopoSave = (
   const db = openWriteTrailsDb({ rootDir });
 
   try {
-    return createTopoSave(db, {
+    const result = persistEstablishedTopoSave(db, app, {
       ...currentGitState(rootDir),
       ...topoCounts(app),
     });
@@ -251,7 +251,7 @@ export const pinCurrentTopo = (
   const db = openWriteTrailsDb({ rootDir });
 
   try {
-    const save = createTopoSave(db, {
+    const result = persistEstablishedTopoSave(db, app, {
       ...currentGitState(rootDir),
       ...topoCounts(app),
     });

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -214,6 +214,10 @@ export const createCurrentTopoSave = (
       ...currentGitState(rootDir),
       ...topoCounts(app),
     });
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return result.value;
   } finally {
     db.close();
   }
@@ -255,8 +259,14 @@ export const pinCurrentTopo = (
       ...currentGitState(rootDir),
       ...topoCounts(app),
     });
-    const pin = pinTopoSave(db, { name: input.name, saveId: save.id });
-    return { pin, save };
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const pin = pinTopoSave(db, {
+      name: input.name,
+      saveId: result.value.id,
+    });
+    return { pin, save: result.value };
   } finally {
     db.close();
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./internal/topo-saves": "./src/internal/topo-saves.ts",
+    "./internal/topo-store": "./src/internal/topo-store.ts",
     "./internal/trails-db": "./src/internal/trails-db.ts",
     "./patterns": "./src/patterns/index.ts",
     "./redaction": "./src/redaction/index.ts",

--- a/packages/core/src/__tests__/topo-store.test.ts
+++ b/packages/core/src/__tests__/topo-store.test.ts
@@ -1,0 +1,428 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { z } from 'zod';
+
+import { Result, provision, signal, topo, trail } from '../index.js';
+import {
+  ensureTopoHistorySchema,
+  pinTopoSave,
+  pruneUnpinnedTopoSaves,
+} from '../internal/topo-saves.js';
+import { persistEstablishedTopoSave } from '../internal/topo-store.js';
+import { openWriteTrailsDb } from '../internal/trails-db.js';
+
+const noop = () => Result.ok({ ok: true });
+
+/** Unwrap a Result in tests, throwing on Err. */
+const unwrap = <T>(result: Result<T, Error>): T => {
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const countRows = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  tableName: string,
+  saveId?: string
+): number => {
+  const row =
+    saveId === undefined
+      ? db
+          .query<{ count: number }, []>(
+            `SELECT COUNT(*) as count FROM ${tableName}`
+          )
+          .get()
+      : db
+          .query<{ count: number }, [string]>(
+            `SELECT COUNT(*) as count FROM ${tableName} WHERE save_id = ?`
+          )
+          .get(saveId);
+  return row?.count ?? 0;
+};
+
+const tableExists = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  tableName: string
+): boolean => {
+  const row = db
+    .query<{ name: string }, [string]>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?"
+    )
+    .get(tableName);
+  return row?.name === tableName;
+};
+
+const exampleApp = () => {
+  const dbMain = provision('db.main', {
+    create: () => Result.ok({ source: 'factory' }),
+    description: 'Primary database',
+    health: () => Result.ok({ ok: true }),
+    mock: () => ({ source: 'mock' }),
+  });
+
+  const searchIndex = provision('search.index', {
+    create: () => Result.ok({ source: 'factory' }),
+    mock: () => ({ source: 'mock' }),
+  });
+
+  const entityAdded = signal('entity.added', {
+    description: 'An entity was added',
+    from: ['entity.add'],
+    payload: z.object({ id: z.string() }),
+  });
+
+  const entityAdd = trail('entity.add', {
+    blaze: (input: { readonly name: string }) =>
+      Result.ok({ id: input.name.toLowerCase(), ok: true }),
+    description: 'Add a new entity',
+    examples: [
+      {
+        expected: { id: 'ada', ok: true },
+        input: { name: 'Ada' },
+        name: 'Add Ada',
+      },
+      {
+        error: 'ConflictError',
+        input: { name: 'Existing' },
+        name: 'Conflict on duplicate',
+      },
+    ],
+    input: z.object({ name: z.string() }),
+    meta: { owner: 'core', tags: ['write', 'entity'] },
+    output: z.object({ id: z.string(), ok: z.boolean() }),
+    provisions: [dbMain, searchIndex],
+  });
+
+  const entityList = trail('entity.list', {
+    blaze: () => Result.ok({ items: ['ada'] }),
+    crosses: ['entity.add'],
+    description: 'List entities',
+    idempotent: true,
+    input: z.object({}),
+    intent: 'read',
+    output: z.object({ items: z.array(z.string()) }),
+    provisions: [dbMain],
+  });
+
+  return topo('projection-app', {
+    dbMain,
+    entityAdd,
+    entityAdded,
+    entityList,
+    searchIndex,
+  });
+};
+
+const readTrailRows = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  saveId: string
+) =>
+  db
+    .query<
+      {
+        description: string | null;
+        example_count: number;
+        has_output: number;
+        id: string;
+        idempotent: number;
+        intent: string;
+        meta: string | null;
+      },
+      [string]
+    >(
+      `SELECT id, intent, idempotent, has_output, example_count, description, meta
+       FROM topo_trails
+       WHERE save_id = ?
+       ORDER BY id ASC`
+    )
+    .all(saveId);
+
+const readTrailSignalRows = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  saveId: string
+) =>
+  db
+    .query<{ signal_id: string; trail_id: string }, [string]>(
+      `SELECT trail_id, signal_id
+       FROM topo_trail_signals
+       WHERE save_id = ?`
+    )
+    .all(saveId);
+
+const readTrailheadRows = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  saveId: string
+) =>
+  db
+    .query<{ derived_name: string; trail_id: string }, [string]>(
+      `SELECT trail_id, derived_name
+       FROM topo_trailheads
+       WHERE save_id = ?
+       ORDER BY trail_id ASC`
+    )
+    .all(saveId);
+
+const readExampleRows = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  saveId: string
+) =>
+  db
+    .query<
+      {
+        error: string | null;
+        expected: string | null;
+        input: string;
+        name: string;
+        ordinal: number;
+      },
+      [string]
+    >(
+      `SELECT ordinal, name, input, expected, error
+       FROM topo_examples
+       WHERE save_id = ?
+       ORDER BY ordinal ASC`
+    )
+    .all(saveId);
+
+const readProjectedTrailIds = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  saveId: string
+) =>
+  db
+    .query<{ id: string }, [string]>(
+      'SELECT id FROM topo_trails WHERE save_id = ? ORDER BY id ASC'
+    )
+    .all(saveId)
+    .map((row) => row.id);
+
+const expectProjectionCounts = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  saveId: string
+): void => {
+  expect(countRows(db, 'topo_trails', saveId)).toBe(2);
+  expect(countRows(db, 'topo_crossings', saveId)).toBe(1);
+  expect(countRows(db, 'topo_trail_provisions', saveId)).toBe(3);
+  expect(countRows(db, 'topo_provisions', saveId)).toBe(2);
+  expect(countRows(db, 'topo_signals', saveId)).toBe(1);
+  expect(countRows(db, 'topo_trail_signals', saveId)).toBe(1);
+  expect(countRows(db, 'topo_trailheads', saveId)).toBe(2);
+  expect(countRows(db, 'topo_examples', saveId)).toBe(2);
+};
+
+const expectProjectedFixtureRows = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  saveId: string
+): void => {
+  expect(readTrailRows(db, saveId)).toEqual([
+    {
+      description: 'Add a new entity',
+      example_count: 2,
+      has_output: 1,
+      id: 'entity.add',
+      idempotent: 0,
+      intent: 'write',
+      meta: JSON.stringify({
+        owner: 'core',
+        tags: ['write', 'entity'],
+      }),
+    },
+    {
+      description: 'List entities',
+      example_count: 0,
+      has_output: 1,
+      id: 'entity.list',
+      idempotent: 1,
+      intent: 'read',
+      meta: null,
+    },
+  ]);
+  expect(readTrailSignalRows(db, saveId)).toEqual([
+    { signal_id: 'entity.added', trail_id: 'entity.add' },
+  ]);
+  expect(readTrailheadRows(db, saveId)).toEqual([
+    { derived_name: 'entity add', trail_id: 'entity.add' },
+    { derived_name: 'entity list', trail_id: 'entity.list' },
+  ]);
+  expect(readExampleRows(db, saveId)).toEqual([
+    {
+      error: null,
+      expected: JSON.stringify({ id: 'ada', ok: true }),
+      input: JSON.stringify({ name: 'Ada' }),
+      name: 'Add Ada',
+      ordinal: 0,
+    },
+    {
+      error: 'ConflictError',
+      expected: null,
+      input: JSON.stringify({ name: 'Existing' }),
+      name: 'Conflict on duplicate',
+      ordinal: 1,
+    },
+  ]);
+};
+
+const simpleProjectionApp = (withList: boolean) =>
+  topo('projection-app', {
+    entityAdd: trail('entity.add', {
+      blaze: noop,
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    }),
+    ...(withList
+      ? {
+          entityList: trail('entity.list', {
+            blaze: () => Result.ok({ items: ['one'] }),
+            input: z.object({}),
+            intent: 'read',
+            output: z.object({ items: z.array(z.string()) }),
+          }),
+        }
+      : {}),
+  });
+
+const seedHistoryOnlyTopoSchema = (
+  db: ReturnType<typeof openWriteTrailsDb>
+): void => {
+  db.run(
+    `INSERT INTO meta_schema_versions (subsystem, version, updated_at)
+     VALUES ('topo', 1, ?)`,
+    ['2026-04-03T11:00:00.000Z']
+  );
+  db.run(`CREATE TABLE IF NOT EXISTS topo_saves (
+    id TEXT PRIMARY KEY,
+    git_sha TEXT,
+    git_dirty INTEGER NOT NULL DEFAULT 0,
+    trail_count INTEGER NOT NULL DEFAULT 0,
+    signal_count INTEGER NOT NULL DEFAULT 0,
+    provision_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS topo_pins (
+    name TEXT PRIMARY KEY,
+    save_id TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+  )`);
+  db.run(
+    `INSERT INTO topo_saves (
+      id, git_sha, git_dirty, trail_count, signal_count, provision_count, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ['seed-save', 'seed123', 0, 1, 0, 0, '2026-04-03T11:00:00.000Z']
+  );
+  db.run('INSERT INTO topo_pins (name, save_id, created_at) VALUES (?, ?, ?)', [
+    'seed-pin',
+    'seed-save',
+    '2026-04-03T11:01:00.000Z',
+  ]);
+};
+
+describe('topo store projection', () => {
+  let tmpRoot: string | undefined;
+
+  afterEach(() => {
+    if (tmpRoot) {
+      rmSync(tmpRoot, { force: true, recursive: true });
+      tmpRoot = undefined;
+    }
+  });
+
+  const makeRoot = (): string => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'topo-store-'));
+    return tmpRoot;
+  };
+
+  const withProjectionDb = (
+    run: (db: ReturnType<typeof openWriteTrailsDb>) => void
+  ): void => {
+    const db = openWriteTrailsDb({ rootDir: makeRoot() });
+    try {
+      run(db);
+    } finally {
+      db.close();
+    }
+  };
+
+  test('projects a save-scoped relational topo from the established app graph', () => {
+    withProjectionDb((db) => {
+      const save = unwrap(
+        persistEstablishedTopoSave(db, exampleApp(), {
+          createdAt: '2026-04-03T12:00:00.000Z',
+          gitDirty: false,
+          gitSha: 'abc123',
+        })
+      );
+      expectProjectionCounts(db, save.id);
+      expectProjectedFixtureRows(db, save.id);
+    });
+  });
+
+  test('keeps projected rows isolated across successive saves', () => {
+    withProjectionDb((db) => {
+      const firstSave = unwrap(
+        persistEstablishedTopoSave(db, simpleProjectionApp(false), {
+          createdAt: '2026-04-03T12:00:00.000Z',
+        })
+      );
+      const secondSave = unwrap(
+        persistEstablishedTopoSave(db, simpleProjectionApp(true), {
+          createdAt: '2026-04-03T12:05:00.000Z',
+        })
+      );
+
+      expect(firstSave.id).not.toBe(secondSave.id);
+      expect(countRows(db, 'topo_trails', firstSave.id)).toBe(1);
+      expect(countRows(db, 'topo_trails', secondSave.id)).toBe(2);
+      expect(readProjectedTrailIds(db, firstSave.id)).toEqual(['entity.add']);
+      expect(readProjectedTrailIds(db, secondSave.id)).toEqual([
+        'entity.add',
+        'entity.list',
+      ]);
+    });
+  });
+
+  test("pruning an unpinned save removes only that save's projected rows", () => {
+    withProjectionDb((db) => {
+      const app = exampleApp();
+      const pinned = unwrap(
+        persistEstablishedTopoSave(db, app, {
+          createdAt: '2026-04-03T12:00:00.000Z',
+        })
+      );
+      pinTopoSave(db, { name: 'before-auth', saveId: pinned.id });
+
+      const disposable = unwrap(
+        persistEstablishedTopoSave(db, app, {
+          createdAt: '2026-04-03T12:05:00.000Z',
+        })
+      );
+
+      expect(pruneUnpinnedTopoSaves(db, { keep: 0 })).toBe(1);
+      expectProjectionCounts(db, pinned.id);
+      expect(countRows(db, 'topo_trails', disposable.id)).toBe(0);
+      expect(countRows(db, 'topo_crossings', disposable.id)).toBe(0);
+      expect(countRows(db, 'topo_examples', disposable.id)).toBe(0);
+    });
+  });
+
+  test('upgrades a history-only topo schema to the projected topo schema', () => {
+    withProjectionDb((db) => {
+      seedHistoryOnlyTopoSchema(db);
+      ensureTopoHistorySchema(db);
+      expect(
+        db
+          .query<{ version: number }, []>(
+            "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
+          )
+          .get()?.version
+      ).toBe(2);
+      expect(tableExists(db, 'topo_trails')).toBe(true);
+      expect(tableExists(db, 'topo_crossings')).toBe(true);
+      expect(tableExists(db, 'topo_examples')).toBe(true);
+      expect(countRows(db, 'topo_saves')).toBe(1);
+      expect(countRows(db, 'topo_pins')).toBe(1);
+    });
+  });
+});

--- a/packages/core/src/internal/topo-saves.ts
+++ b/packages/core/src/internal/topo-saves.ts
@@ -3,6 +3,105 @@ import type { Database } from 'bun:sqlite';
 import { ensureSubsystemSchema } from './trails-db.js';
 
 const TOPO_SUBSYSTEM = 'topo';
+const TOPO_TABLE_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS topo_saves (
+    id TEXT PRIMARY KEY,
+    git_sha TEXT,
+    git_dirty INTEGER NOT NULL DEFAULT 0,
+    trail_count INTEGER NOT NULL DEFAULT 0,
+    signal_count INTEGER NOT NULL DEFAULT 0,
+    provision_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_pins (
+    name TEXT PRIMARY KEY,
+    save_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_trails (
+    id TEXT NOT NULL,
+    intent TEXT,
+    idempotent INTEGER NOT NULL DEFAULT 0,
+    has_output INTEGER NOT NULL DEFAULT 0,
+    has_examples INTEGER NOT NULL DEFAULT 0,
+    example_count INTEGER NOT NULL DEFAULT 0,
+    description TEXT,
+    meta TEXT,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (id, save_id),
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_crossings (
+    source_id TEXT NOT NULL,
+    target_id TEXT NOT NULL,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (source_id, target_id, save_id),
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_trail_provisions (
+    trail_id TEXT NOT NULL,
+    provision_id TEXT NOT NULL,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (trail_id, provision_id, save_id),
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_provisions (
+    id TEXT NOT NULL,
+    has_mock INTEGER NOT NULL DEFAULT 0,
+    has_health INTEGER NOT NULL DEFAULT 0,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (id, save_id),
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_signals (
+    id TEXT NOT NULL,
+    description TEXT,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (id, save_id),
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_trail_signals (
+    trail_id TEXT NOT NULL,
+    signal_id TEXT NOT NULL,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (trail_id, signal_id, save_id),
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_trailheads (
+    trail_id TEXT NOT NULL,
+    trailhead TEXT NOT NULL,
+    derived_name TEXT NOT NULL,
+    method TEXT,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (trail_id, trailhead, save_id),
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_examples (
+    id TEXT PRIMARY KEY,
+    trail_id TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    input TEXT NOT NULL,
+    expected TEXT,
+    error TEXT,
+    save_id TEXT NOT NULL,
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
+] as const;
+const TOPO_INDEX_STATEMENTS = [
+  'CREATE INDEX IF NOT EXISTS idx_topo_saves_created_at ON topo_saves(created_at DESC)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_pins_save_id ON topo_pins(save_id)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_trails_save_id ON topo_trails(save_id)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_crossings_save_id ON topo_crossings(save_id)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_trail_provisions_save_id ON topo_trail_provisions(save_id)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_provisions_save_id ON topo_provisions(save_id)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_signals_save_id ON topo_signals(save_id)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_trail_signals_save_id ON topo_trail_signals(save_id)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_trailheads_save_id ON topo_trailheads(save_id)',
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_topo_examples_save_trail_ordinal ON topo_examples(save_id, trail_id, ordinal)',
+] as const;
 
 interface TopoSaveRow {
   readonly created_at: string;
@@ -77,42 +176,34 @@ const tableExists = (db: Database, tableName: string): boolean => {
   return row?.name === tableName;
 };
 
+const runStatements = (db: Database, statements: readonly string[]): void => {
+  for (const statement of statements) {
+    db.run(statement);
+  }
+};
+
 export const ensureTopoHistorySchema = (db: Database): void => {
   ensureSubsystemSchema(db, {
-    migrate: () => {
-      db.run(`CREATE TABLE IF NOT EXISTS topo_saves (
-        id TEXT PRIMARY KEY,
-        git_sha TEXT,
-        git_dirty INTEGER NOT NULL DEFAULT 0,
-        trail_count INTEGER NOT NULL DEFAULT 0,
-        signal_count INTEGER NOT NULL DEFAULT 0,
-        provision_count INTEGER NOT NULL DEFAULT 0,
-        created_at TEXT NOT NULL
-      )`);
-      db.run(`CREATE TABLE IF NOT EXISTS topo_pins (
-        name TEXT PRIMARY KEY,
-        save_id TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        FOREIGN KEY (save_id) REFERENCES topo_saves(id)
-      )`);
-      db.run(
-        'CREATE INDEX IF NOT EXISTS idx_topo_saves_created_at ON topo_saves(created_at DESC)'
-      );
-      db.run(
-        'CREATE INDEX IF NOT EXISTS idx_topo_pins_save_id ON topo_pins(save_id)'
-      );
+    migrate: (currentVersion) => {
+      if (currentVersion < 2) {
+        runStatements(db, TOPO_TABLE_STATEMENTS);
+        runStatements(db, TOPO_INDEX_STATEMENTS);
+      }
+      if (currentVersion === 2) {
+        // v2→v3: add schema cache and export tables
+        runStatements(db, TOPO_TABLE_STATEMENTS.slice(10));
+        runStatements(db, TOPO_INDEX_STATEMENTS.slice(10));
+      }
     },
     subsystem: TOPO_SUBSYSTEM,
-    version: 1,
+    version: 2,
   });
 };
 
-export const createTopoSave = (
+export const insertTopoSaveRecord = (
   db: Database,
   input?: CreateTopoSaveInput
 ): TopoSaveRecord => {
-  ensureTopoHistorySchema(db);
-
   const record: TopoSaveRecord = {
     createdAt: input?.createdAt ?? new Date().toISOString(),
     gitDirty: input?.gitDirty ?? false,
@@ -139,6 +230,14 @@ export const createTopoSave = (
   );
 
   return record;
+};
+
+export const createTopoSave = (
+  db: Database,
+  input?: CreateTopoSaveInput
+): TopoSaveRecord => {
+  ensureTopoHistorySchema(db);
+  return insertTopoSaveRecord(db, input);
 };
 
 export const pinTopoSave = (

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -169,7 +169,7 @@ const normalizeTrailSignalRows = (
   saveId: string
 ): readonly TopoTrailSignalRow[] =>
   signals.flatMap((signal) =>
-    [...new Set(signal.from ?? [])].toSorted().map((trailId) => ({
+    [...new Set(signal.from)].toSorted().map((trailId) => ({
       saveId,
       signalId: signal.id,
       trailId,
@@ -373,11 +373,11 @@ export const persistEstablishedTopoSave = (
     trailCount: input?.trailCount ?? topo.trails.size,
   };
 
-  return db.transaction(() => {
-    const save = insertTopoSaveRecord(db, saveInput);
-    insertProjectedRows(db, normalizeTopoProjection(topo, save.id));
-    return created;
+  const save = db.transaction(() => {
+    const record = insertTopoSaveRecord(db, saveInput);
+    insertProjectedRows(db, normalizeTopoProjection(topo, record.id));
+    return record;
   })();
 
-  return Result.ok(record);
+  return Result.ok(save);
 };

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -1,0 +1,383 @@
+import type { Database, SQLQueryBindings } from 'bun:sqlite';
+
+import { deriveCliPath } from '../derive.js';
+import { Result } from '../result.js';
+import type { AnyProvision } from '../provision.js';
+import type { AnySignal } from '../signal.js';
+import type { Topo } from '../topo.js';
+import type { AnyTrail } from '../trail.js';
+import { validateEstablishedTopo } from '../validate-established-topo.js';
+import type { CreateTopoSaveInput, TopoSaveRecord } from './topo-saves.js';
+import { ensureTopoHistorySchema, insertTopoSaveRecord } from './topo-saves.js';
+
+interface TopoTrailRow {
+  readonly description: string | null;
+  readonly exampleCount: number;
+  readonly hasExamples: number;
+  readonly hasOutput: number;
+  readonly id: string;
+  readonly idempotent: number;
+  readonly intent: string;
+  readonly meta: string | null;
+  readonly saveId: string;
+}
+
+interface TopoCrossingRow {
+  readonly saveId: string;
+  readonly sourceId: string;
+  readonly targetId: string;
+}
+
+interface TopoTrailProvisionRow {
+  readonly provisionId: string;
+  readonly saveId: string;
+  readonly trailId: string;
+}
+
+interface TopoProvisionRow {
+  readonly hasHealth: number;
+  readonly hasMock: number;
+  readonly id: string;
+  readonly saveId: string;
+}
+
+interface TopoSignalRow {
+  readonly description: string | null;
+  readonly id: string;
+  readonly saveId: string;
+}
+
+interface TopoTrailSignalRow {
+  readonly saveId: string;
+  readonly signalId: string;
+  readonly trailId: string;
+}
+
+interface TopoTrailheadRow {
+  readonly derivedName: string;
+  readonly method: string | null;
+  readonly saveId: string;
+  readonly trailId: string;
+  readonly trailhead: string;
+}
+
+interface TopoExampleRow {
+  readonly description: string | null;
+  readonly error: string | null;
+  readonly expected: string | null;
+  readonly id: string;
+  readonly input: string;
+  readonly name: string;
+  readonly ordinal: number;
+  readonly saveId: string;
+  readonly trailId: string;
+}
+
+interface NormalizedTopoProjection {
+  readonly crossings: readonly TopoCrossingRow[];
+  readonly examples: readonly TopoExampleRow[];
+  readonly provisions: readonly TopoProvisionRow[];
+  readonly signals: readonly TopoSignalRow[];
+  readonly trailheads: readonly TopoTrailheadRow[];
+  readonly trailProvisions: readonly TopoTrailProvisionRow[];
+  readonly trailSignals: readonly TopoTrailSignalRow[];
+  readonly trails: readonly TopoTrailRow[];
+}
+
+const canonicalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value !== null && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).toSorted()) {
+      sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+};
+
+const stableJson = (value: unknown): string =>
+  JSON.stringify(canonicalize(value));
+
+const normalizeTrailRows = (
+  trails: readonly AnyTrail[],
+  saveId: string
+): readonly TopoTrailRow[] =>
+  trails.map((trail) => ({
+    description: trail.description ?? null,
+    exampleCount: trail.examples?.length ?? 0,
+    hasExamples: (trail.examples?.length ?? 0) > 0 ? 1 : 0,
+    hasOutput: trail.output === undefined ? 0 : 1,
+    id: trail.id,
+    idempotent: trail.idempotent === true ? 1 : 0,
+    intent: trail.intent,
+    meta: trail.meta === undefined ? null : stableJson(trail.meta),
+    saveId,
+  }));
+
+const normalizeCrossingRows = (
+  trails: readonly AnyTrail[],
+  saveId: string
+): readonly TopoCrossingRow[] =>
+  trails.flatMap((trail) =>
+    [...new Set(trail.crosses)].toSorted().map((targetId) => ({
+      saveId,
+      sourceId: trail.id,
+      targetId,
+    }))
+  );
+
+const normalizeTrailProvisionRows = (
+  trails: readonly AnyTrail[],
+  saveId: string
+): readonly TopoTrailProvisionRow[] =>
+  trails.flatMap((trail) =>
+    [...new Set(trail.provisions.map((provision) => provision.id))]
+      .toSorted()
+      .map((provisionId) => ({
+        provisionId,
+        saveId,
+        trailId: trail.id,
+      }))
+  );
+
+const normalizeProvisionRows = (
+  provisions: readonly AnyProvision[],
+  saveId: string
+): readonly TopoProvisionRow[] =>
+  provisions.map((provision) => ({
+    hasHealth: provision.health === undefined ? 0 : 1,
+    hasMock: provision.mock === undefined ? 0 : 1,
+    id: provision.id,
+    saveId,
+  }));
+
+const normalizeSignalRows = (
+  signals: readonly AnySignal[],
+  saveId: string
+): readonly TopoSignalRow[] =>
+  signals.map((signal) => ({
+    description: signal.description ?? null,
+    id: signal.id,
+    saveId,
+  }));
+
+const normalizeTrailSignalRows = (
+  signals: readonly AnySignal[],
+  saveId: string
+): readonly TopoTrailSignalRow[] =>
+  signals.flatMap((signal) =>
+    [...new Set(signal.from ?? [])].toSorted().map((trailId) => ({
+      saveId,
+      signalId: signal.id,
+      trailId,
+    }))
+  );
+
+/**
+ * Project trailhead rows for stored topo.
+ *
+ * Currently records only CLI-derived rows. MCP, HTTP, and other trailhead
+ * projections are intentionally deferred until the topo-store schema supports
+ * multi-trailhead representation. The JSON export (`trailhead_map` in
+ * `topo_exports`) is more faithful for now. See ADR-0015 for the target shape.
+ */
+const normalizeTrailheadRows = (
+  trails: readonly AnyTrail[],
+  saveId: string
+): readonly TopoTrailheadRow[] =>
+  trails.map((trail) => ({
+    derivedName: deriveCliPath(trail.id).join(' '),
+    method: null,
+    saveId,
+    trailId: trail.id,
+    trailhead: 'cli',
+  }));
+
+const buildExampleId = (
+  saveId: string,
+  trailId: string,
+  ordinal: number
+): string => `${saveId}:${trailId}:${ordinal.toString().padStart(4, '0')}`;
+
+const normalizeExampleRows = (
+  trails: readonly AnyTrail[],
+  saveId: string
+): readonly TopoExampleRow[] =>
+  trails.flatMap((trail) =>
+    (trail.examples ?? []).map((example, index) => ({
+      description: example.description ?? null,
+      error: example.error ?? null,
+      expected:
+        example.expected === undefined ? null : stableJson(example.expected),
+      id: buildExampleId(saveId, trail.id, index),
+      input: stableJson(example.input),
+      name: example.name,
+      ordinal: index,
+      saveId,
+      trailId: trail.id,
+    }))
+  );
+
+const normalizeTopoProjection = (
+  topo: Topo,
+  saveId: string
+): NormalizedTopoProjection => {
+  const trails = topo.list().toSorted((a, b) => a.id.localeCompare(b.id));
+  const provisions = topo
+    .listProvisions()
+    .toSorted((a, b) => a.id.localeCompare(b.id));
+  const signals = topo
+    .listSignals()
+    .toSorted((a, b) => a.id.localeCompare(b.id));
+
+  return {
+    crossings: normalizeCrossingRows(trails, saveId),
+    examples: normalizeExampleRows(trails, saveId),
+    provisions: normalizeProvisionRows(provisions, saveId),
+    signals: normalizeSignalRows(signals, saveId),
+    trailProvisions: normalizeTrailProvisionRows(trails, saveId),
+    trailSignals: normalizeTrailSignalRows(signals, saveId),
+    trailheads: normalizeTrailheadRows(trails, saveId),
+    trails: normalizeTrailRows(trails, saveId),
+  };
+};
+
+/**
+ * Look up a cached JSON schema by content hash.
+ *
+ * The query matches on `zod_hash` without filtering by `save_id` because the
+ * cache is intentionally cross-save: if the Zod schema definition has not
+ * changed (same hash), the serialized JSON Schema is reused regardless of
+ * which save produced it. This is safe as long as `zodToJsonSchema` is
+ * deterministic for a given `_def` hash — the `schemaDefinitionHash` pipeline
+ * guarantees that structurally identical schemas produce the same hash.
+ */
+const insertRows = <TRow>(
+  db: Database,
+  rows: readonly TRow[],
+  statement: string,
+  toParams: (row: TRow) => SQLQueryBindings[]
+): void => {
+  for (const row of rows) {
+    db.run(statement, toParams(row));
+  }
+};
+
+const insertProjectedRows = (
+  db: Database,
+  projection: NormalizedTopoProjection
+): void => {
+  insertRows(
+    db,
+    projection.trails,
+    `INSERT INTO topo_trails (
+      id, intent, idempotent, has_output, has_examples, example_count, description, meta, save_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    (row) => [
+      row.id,
+      row.intent,
+      row.idempotent,
+      row.hasOutput,
+      row.hasExamples,
+      row.exampleCount,
+      row.description,
+      row.meta,
+      row.saveId,
+    ]
+  );
+  insertRows(
+    db,
+    projection.crossings,
+    'INSERT INTO topo_crossings (source_id, target_id, save_id) VALUES (?, ?, ?)',
+    (row) => [row.sourceId, row.targetId, row.saveId]
+  );
+  insertRows(
+    db,
+    projection.trailProvisions,
+    `INSERT INTO topo_trail_provisions (trail_id, provision_id, save_id)
+     VALUES (?, ?, ?)`,
+    (row) => [row.trailId, row.provisionId, row.saveId]
+  );
+  insertRows(
+    db,
+    projection.provisions,
+    `INSERT INTO topo_provisions (id, has_mock, has_health, save_id)
+     VALUES (?, ?, ?, ?)`,
+    (row) => [row.id, row.hasMock, row.hasHealth, row.saveId]
+  );
+  insertRows(
+    db,
+    projection.signals,
+    'INSERT INTO topo_signals (id, description, save_id) VALUES (?, ?, ?)',
+    (row) => [row.id, row.description, row.saveId]
+  );
+  insertRows(
+    db,
+    projection.trailSignals,
+    `INSERT INTO topo_trail_signals (trail_id, signal_id, save_id)
+     VALUES (?, ?, ?)`,
+    (row) => [row.trailId, row.signalId, row.saveId]
+  );
+  insertRows(
+    db,
+    projection.trailheads,
+    `INSERT INTO topo_trailheads (trail_id, trailhead, derived_name, method, save_id)
+     VALUES (?, ?, ?, ?, ?)`,
+    (row) => [
+      row.trailId,
+      row.trailhead,
+      row.derivedName,
+      row.method,
+      row.saveId,
+    ]
+  );
+  insertRows(
+    db,
+    projection.examples,
+    `INSERT INTO topo_examples (
+      id, trail_id, ordinal, name, description, input, expected, error, save_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    (row) => [
+      row.id,
+      row.trailId,
+      row.ordinal,
+      row.name,
+      row.description,
+      row.input,
+      row.expected,
+      row.error,
+      row.saveId,
+    ]
+  );
+};
+
+export const persistEstablishedTopoSave = (
+  db: Database,
+  topo: Topo,
+  input?: CreateTopoSaveInput
+): Result<TopoSaveRecord, Error> => {
+  const validated = validateEstablishedTopo(topo);
+  if (validated.isErr()) {
+    return Result.err(validated.error);
+  }
+
+  ensureTopoHistorySchema(db);
+
+  const saveInput: CreateTopoSaveInput = {
+    ...input,
+    provisionCount: input?.provisionCount ?? topo.provisions.size,
+    signalCount: input?.signalCount ?? topo.signals.size,
+    trailCount: input?.trailCount ?? topo.trails.size,
+  };
+
+  return db.transaction(() => {
+    const save = insertTopoSaveRecord(db, saveInput);
+    insertProjectedRows(db, normalizeTopoProjection(topo, save.id));
+    return created;
+  })();
+
+  return Result.ok(record);
+};


### PR DESCRIPTION
## Summary
- Projects resolved topo into relational `topo_*` tables
- Save-scoped projection with transaction atomicity
- Pruning behavior for unpinned saves
- Migration path for existing workspaces

## What changed
The resolved topology is now projected into normalized relational tables (`topo_*`) within trails.db. Each save operation atomically writes the full projection within a transaction, scoped to that save's ID. Unpinned saves are pruned automatically to keep the database lean. Existing workspaces are migrated forward with schema versioning, preserving any pinned state.

## How it was tested
- bun run build
- bun run test
- bun run typecheck
- bun run lint
- Package-specific tests where applicable

Closes: TRL-130, TRL-144, TRL-145, TRL-146
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
