### PR TITLE
feat: cache schemas and export topo state from the store

### DIFF
--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -1,4 +1,12 @@
 import { describe, expect, test } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
 
 import { Result, provision, topo, trail } from '@ontrails/core';
 import {
@@ -13,6 +21,7 @@ import {
   generateBriefReport,
   generateSurveyList,
   generateTrailDetail,
+  surveyTrail,
 } from '../trails/survey.js';
 import type {
   BriefReport,
@@ -67,6 +76,49 @@ const app = topo('test-app', {
   dbProvision,
   hello: helloTrail,
 });
+
+const expectOk = <T>(result: Result<T, Error>): T => {
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const writeSurveyAppFixture = (dir: string): void => {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    `import { Result, provision, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const hello = trail('hello', {
+  blaze: async (input) => Result.ok({ message: \`Hello, \${input.name ?? 'world'}!\` }),
+  input: z.object({ name: z.string().optional() }),
+  intent: 'read',
+  output: z.object({ message: z.string() }),
+  provisions: [
+    provision('db.main', {
+      create: () => Result.ok({ source: 'factory' }),
+    }),
+  ],
+});
+
+const [dbMain] = hello.provisions;
+if (!dbMain) {
+  throw new Error('expected hello to declare db.main');
+}
+
+export const app = topo('survey-fixture', { dbMain, hello });
+`
+  );
+};
+
+const repoTempDir = (): string =>
+  join(
+    resolve(import.meta.dir, '../..'),
+    '.tmp-tests',
+    `trails-survey-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -213,5 +265,37 @@ describe('trails survey provisions section', () => {
       lifetime: 'singleton',
       usedBy: ['hello'],
     });
+  });
+});
+
+describe('trails survey generate', () => {
+  test('delegates to topo export and writes a structured lock', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+
+      const generated = expectOk(
+        await surveyTrail.blaze({ generate: true, module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      ) as {
+        readonly hash: string;
+        readonly lockPath: string;
+        readonly mapPath: string;
+      };
+
+      expect(generated.hash).toHaveLength(64);
+      expect(existsSync(join(dir, '.trails', '_trailhead.json'))).toBe(true);
+      expect(existsSync(join(dir, '.trails', 'trails.lock'))).toBe(true);
+      expect(
+        JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
+      ).toMatchObject({
+        hash: generated.hash,
+        version: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
   });
 });

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -115,6 +115,12 @@ describe('topo and dev trails', () => {
       expect(exportResult.hash).toHaveLength(64);
       expect(existsSync(join(dir, '.trails', '_trailhead.json'))).toBe(true);
       expect(existsSync(join(dir, '.trails', 'trails.lock'))).toBe(true);
+      expect(
+        JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
+      ).toMatchObject({
+        hash: exportResult.hash,
+        version: 1,
+      });
 
       const verifyResult = expectOk(
         await topoVerifyTrail.blaze(moduleInput, { cwd: dir } as never)
@@ -151,6 +157,13 @@ describe('topo and dev trails', () => {
       const secondExport = expectOk(
         await topoExportTrail.blaze(moduleInput, { cwd: dir } as never)
       );
+      expect(firstExport.hash).toBe(secondExport.hash);
+      expect(
+        JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
+      ).toMatchObject({
+        hash: secondExport.hash,
+        version: 1,
+      });
 
       const projectionDb = openReadTrailsDb({ rootDir: dir });
       try {
@@ -169,10 +182,16 @@ describe('topo and dev trails', () => {
             'SELECT COUNT(DISTINCT save_id) as count FROM topo_trails'
           )
           .get();
+        const cachedSchemas = projectionDb
+          .query<{ count: number }, []>(
+            'SELECT COUNT(*) as count FROM topo_schemas'
+          )
+          .get();
 
         expect(pinnedRows?.count).toBe(2);
         expect(exportedRows?.count).toBe(2);
         expect(projectedSaves?.count).toBe(3);
+        expect(cachedSchemas?.count).toBeGreaterThanOrEqual(9);
       } finally {
         projectionDb.close();
       }

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -12,10 +12,7 @@ import {
   diffTrailheadMaps,
   generateOpenApiSpec,
   generateTrailheadMap,
-  hashTrailheadMap,
   readTrailheadMap,
-  writeTrailheadLock,
-  writeTrailheadMap,
 } from '@ontrails/schema';
 import { z } from 'zod';
 
@@ -26,6 +23,7 @@ import {
   generateSurveyList,
   generateTrailDetail,
 } from './topo-reports.js';
+import { exportCurrentTopo } from './topo-support.js';
 
 export {
   formatProvisionDetail,
@@ -94,13 +92,18 @@ const buildSurveyDetail = (
 };
 
 const buildSurveyGenerate = async (
-  app: Topo
+  app: Topo,
+  rootDir: string
 ): Promise<Result<object, Error>> => {
-  const trailheadMap = generateTrailheadMap(app);
-  const mapPath = await writeTrailheadMap(trailheadMap);
-  const hash = hashTrailheadMap(trailheadMap);
-  const lockPath = await writeTrailheadLock(hash);
-  return Result.ok({ hash, lockPath, mapPath });
+  const exported = await exportCurrentTopo(app, { rootDir });
+  if (exported.isErr()) {
+    return exported;
+  }
+  return Result.ok({
+    hash: exported.value.hash,
+    lockPath: exported.value.lockPath,
+    mapPath: exported.value.mapPath,
+  });
 };
 
 interface SurveyInput {
@@ -129,7 +132,8 @@ const resolveSurveyMode = (input: SurveyInput): SurveyMode =>
 
 type SurveyHandler = (
   app: Topo,
-  input: SurveyInput
+  input: SurveyInput,
+  rootDir: string
 ) => Result<object, Error> | Promise<Result<object, Error>>;
 
 /** Handlers keyed by survey mode. */
@@ -137,7 +141,7 @@ const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
   brief: (app) => Result.ok(generateBriefReport(app)),
   detail: (app, input) => buildSurveyDetail(app, input.trailId ?? ''),
   diff: (app, input) => buildSurveyDiff(app, input.breakingOnly),
-  generate: (app) => buildSurveyGenerate(app),
+  generate: (app, _input, rootDir) => buildSurveyGenerate(app, rootDir),
   list: (app) => Result.ok(generateSurveyList(app)),
   openapi: (app) => Result.ok(generateOpenApiSpec(app)),
 };
@@ -145,11 +149,12 @@ const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
 /** Dispatch to the appropriate survey sub-command based on input flags. */
 const dispatchSurvey = (
   app: Topo,
-  input: SurveyInput
+  input: SurveyInput,
+  rootDir: string
 ): Result<object, Error> | Promise<Result<object, Error>> => {
   const mode = resolveSurveyMode(input);
   const handler = surveyHandlers[mode];
-  return handler(app, input);
+  return handler(app, input, rootDir);
 };
 
 // ---------------------------------------------------------------------------
@@ -158,8 +163,9 @@ const dispatchSurvey = (
 
 export const surveyTrail = trail('survey', {
   blaze: async (input, ctx) => {
-    const app = await loadApp(input.module, ctx.cwd ?? '.');
-    return dispatchSurvey(app, input);
+    const rootDir = ctx.cwd ?? '.';
+    const app = await loadApp(input.module, rootDir);
+    return dispatchSurvey(app, input, rootDir);
   },
   description: 'Full topo introspection',
   examples: [

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -23,7 +23,7 @@ import {
   generateSurveyList,
   generateTrailDetail,
 } from './topo-reports.js';
-import { exportCurrentTopo } from './topo-support.js';
+import { exportCurrentTopo } from './topo-store-support.js';
 
 export {
   formatProvisionDetail,

--- a/apps/trails/src/trails/topo-export.ts
+++ b/apps/trails/src/trails/topo-export.ts
@@ -2,9 +2,9 @@ import { trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { loadApp } from './load-app.js';
+import { exportCurrentTopo } from './topo-store-support.js';
 import {
   DEFAULT_APP_MODULE,
-  exportCurrentTopo,
   isolatedExampleInput,
   topoSaveOutput,
 } from './topo-support.js';

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -1,0 +1,96 @@
+/**
+ * Stored-export pipeline for topo persistence.
+ *
+ * Extracted from topo-support.ts so this branch (trl-131) owns its own file,
+ * keeping absorb routing clean across the stack.
+ */
+
+import type { Topo } from '@ontrails/core';
+import { InternalError, Result } from '@ontrails/core';
+import type { TopoSaveRecord } from '@ontrails/core/internal/topo-saves';
+import type { StoredTopoExport } from '@ontrails/core/internal/topo-store';
+import {
+  getStoredTopoExport,
+  persistEstablishedTopoSave,
+} from '@ontrails/core/internal/topo-store';
+import {
+  openWriteTrailsDb,
+  resolveTrailsDir,
+} from '@ontrails/core/internal/trails-db';
+import type { TrailheadLock, TrailheadMap } from '@ontrails/schema';
+import { writeTrailheadLock, writeTrailheadMap } from '@ontrails/schema';
+
+import type { TopoExportReport } from './topo-support.js';
+import { currentGitState, resolveRootDir, topoCounts } from './topo-support.js';
+
+const persistAndReadStoredExport = (
+  app: Topo,
+  db: ReturnType<typeof openWriteTrailsDb>,
+  rootDir: string
+): Result<{ save: TopoSaveRecord; storedExport: StoredTopoExport }, Error> => {
+  const saveResult = persistEstablishedTopoSave(db, app, {
+    ...currentGitState(rootDir),
+    ...topoCounts(app),
+  });
+  if (saveResult.isErr()) {
+    return saveResult;
+  }
+
+  const save = saveResult.value;
+  const storedExport = getStoredTopoExport(db, save.id);
+
+  if (storedExport === undefined) {
+    return Result.err(
+      new InternalError(`Missing stored topo export for save "${save.id}"`)
+    );
+  }
+
+  return Result.ok({
+    save,
+    storedExport,
+  });
+};
+
+const writeStoredExportArtifacts = async (
+  storedExport: StoredTopoExport,
+  trailsDir: string
+): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'mapPath'>> => {
+  const mapPath = await writeTrailheadMap(
+    JSON.parse(storedExport.trailheadMapJson) as TrailheadMap,
+    { dir: trailsDir }
+  );
+  const lockPath = await writeTrailheadLock(
+    JSON.parse(storedExport.lockContent) as TrailheadLock,
+    { dir: trailsDir }
+  );
+
+  return {
+    hash: storedExport.trailheadHash,
+    lockPath,
+    mapPath,
+  };
+};
+
+export const exportCurrentTopo = async (
+  app: Topo,
+  options?: { readonly rootDir?: string }
+): Promise<Result<TopoExportReport, Error>> => {
+  const rootDir = resolveRootDir(options?.rootDir);
+  const db = openWriteTrailsDb({ rootDir });
+
+  try {
+    const persisted = persistAndReadStoredExport(app, db, rootDir);
+    if (persisted.isErr()) {
+      return persisted;
+    }
+
+    const { save, storedExport } = persisted.value;
+    const artifacts = await writeStoredExportArtifacts(
+      storedExport,
+      resolveTrailsDir({ rootDir })
+    );
+    return Result.ok({ ...artifacts, save });
+  } finally {
+    db.close();
+  }
+};

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { Topo } from '@ontrails/core';
-import { ConflictError, NotFoundError, Result } from '@ontrails/core';
+import {
+  ConflictError,
+  NotFoundError,
+  Result,
+  createTopoStore,
+} from '@ontrails/core';
 import type {
   TopoPinRecord,
   TopoSaveRecord,
@@ -298,14 +303,29 @@ export const removeTopoPin = (input: {
   }
 };
 
+/**
+ * Resolve the current topo hash, preferring the stored export hash to avoid
+ * divergence between the schema and store hash pipelines.
+ */
+const resolveCurrentHash = (app: Topo, rootDir: string): string => {
+  try {
+    const stored = createTopoStore({ rootDir }).exports.get()?.trailheadHash;
+    if (stored !== undefined) {
+      return stored;
+    }
+  } catch {
+    // DB may not exist yet — fall back to schema pipeline hash.
+  }
+  return hashTrailheadMap(generateTrailheadMap(app));
+};
+
 export const verifyCurrentTopo = async (
   app: Topo,
   options?: { readonly rootDir?: string }
 ): Promise<Result<TopoVerifyReport, Error>> => {
   const rootDir = resolveRootDir(options?.rootDir);
   const trailsDir = resolveTrailsDir({ rootDir });
-  const trailheadMap = generateTrailheadMap(app);
-  const currentHash = hashTrailheadMap(trailheadMap);
+  const currentHash = resolveCurrentHash(app, rootDir);
   const committedHash = await readTrailheadLock({ dir: trailsDir });
 
   if (committedHash === null) {

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -4,12 +4,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { Topo } from '@ontrails/core';
-import {
-  ConflictError,
-  NotFoundError,
-  Result,
-  createTopoStore,
-} from '@ontrails/core';
+import { ConflictError, NotFoundError, Result } from '@ontrails/core';
 import type {
   TopoPinRecord,
   TopoSaveRecord,
@@ -303,29 +298,13 @@ export const removeTopoPin = (input: {
   }
 };
 
-/**
- * Resolve the current topo hash, preferring the stored export hash to avoid
- * divergence between the schema and store hash pipelines.
- */
-const resolveCurrentHash = (app: Topo, rootDir: string): string => {
-  try {
-    const stored = createTopoStore({ rootDir }).exports.get()?.trailheadHash;
-    if (stored !== undefined) {
-      return stored;
-    }
-  } catch {
-    // DB may not exist yet — fall back to schema pipeline hash.
-  }
-  return hashTrailheadMap(generateTrailheadMap(app));
-};
-
 export const verifyCurrentTopo = async (
   app: Topo,
   options?: { readonly rootDir?: string }
 ): Promise<Result<TopoVerifyReport, Error>> => {
   const rootDir = resolveRootDir(options?.rootDir);
   const trailsDir = resolveTrailsDir({ rootDir });
-  const currentHash = resolveCurrentHash(app, rootDir);
+  const currentHash = hashTrailheadMap(generateTrailheadMap(app));
   const committedHash = await readTrailheadLock({ dir: trailsDir });
 
   if (committedHash === null) {

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { Topo } from '@ontrails/core';
-import { ConflictError, NotFoundError, Result } from '@ontrails/core';
+import {
+  ConflictError,
+  InternalError,
+  NotFoundError,
+  Result,
+} from '@ontrails/core';
 import type {
   TopoPinRecord,
   TopoSaveRecord,
@@ -16,13 +21,18 @@ import {
   pinTopoSave,
   unpinTopoSave,
 } from '@ontrails/core/internal/topo-saves';
-import { persistEstablishedTopoSave } from '@ontrails/core/internal/topo-store';
+import type { StoredTopoExport } from '@ontrails/core/internal/topo-store';
+import {
+  getStoredTopoExport,
+  persistEstablishedTopoSave,
+} from '@ontrails/core/internal/topo-store';
 import {
   openReadTrailsDb,
   openWriteTrailsDb,
   resolveTrailsDbPath,
   resolveTrailsDir,
 } from '@ontrails/core/internal/trails-db';
+import type { TrailheadLock, TrailheadMap } from '@ontrails/schema';
 import {
   generateTrailheadMap,
   hashTrailheadMap,
@@ -300,24 +310,79 @@ export const removeTopoPin = (input: {
   }
 };
 
+const persistAndReadStoredExport = (
+  app: Topo,
+  db: ReturnType<typeof openWriteTrailsDb>,
+  rootDir: string
+): Result<{ save: TopoSaveRecord; storedExport: StoredTopoExport }, Error> => {
+  let save: TopoSaveRecord;
+  try {
+    save = persistEstablishedTopoSave(db, app, {
+      ...currentGitState(rootDir),
+      ...topoCounts(app),
+    });
+  } catch (error) {
+    return Result.err(
+      error instanceof Error ? error : new Error(String(error))
+    );
+  }
+
+  const storedExport = getStoredTopoExport(db, save.id);
+
+  if (storedExport === undefined) {
+    return Result.err(
+      new InternalError(`Missing stored topo export for save "${save.id}"`)
+    );
+  }
+
+  return Result.ok({
+    save,
+    storedExport,
+  });
+};
+
+const writeStoredExportArtifacts = async (
+  storedExport: StoredTopoExport,
+  trailsDir: string
+): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'mapPath'>> => {
+  const mapPath = await writeTrailheadMap(
+    JSON.parse(storedExport.trailheadMapJson) as TrailheadMap,
+    { dir: trailsDir }
+  );
+  const lockPath = await writeTrailheadLock(
+    JSON.parse(storedExport.lockContent) as TrailheadLock,
+    { dir: trailsDir }
+  );
+
+  return {
+    hash: storedExport.trailheadHash,
+    lockPath,
+    mapPath,
+  };
+};
+
 export const exportCurrentTopo = async (
   app: Topo,
   options?: { readonly rootDir?: string }
 ): Promise<Result<TopoExportReport, Error>> => {
   const rootDir = resolveRootDir(options?.rootDir);
-  const trailsDir = resolveTrailsDir({ rootDir });
-  const save = createCurrentTopoSave(app, { rootDir });
-  const trailheadMap = generateTrailheadMap(app);
-  const mapPath = await writeTrailheadMap(trailheadMap, { dir: trailsDir });
-  const hash = hashTrailheadMap(trailheadMap);
-  const lockPath = await writeTrailheadLock(hash, { dir: trailsDir });
+  const db = openWriteTrailsDb({ rootDir });
 
-  return Result.ok({
-    hash,
-    lockPath,
-    mapPath,
-    save,
-  });
+  try {
+    const persisted = persistAndReadStoredExport(app, db, rootDir);
+    if (persisted.isErr()) {
+      return persisted;
+    }
+
+    const { save, storedExport } = persisted.value;
+    const artifacts = await writeStoredExportArtifacts(
+      storedExport,
+      resolveTrailsDir({ rootDir })
+    );
+    return Result.ok({ ...artifacts, save });
+  } finally {
+    db.close();
+  }
 };
 
 export const verifyCurrentTopo = async (

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -4,12 +4,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { Topo } from '@ontrails/core';
-import {
-  ConflictError,
-  InternalError,
-  NotFoundError,
-  Result,
-} from '@ontrails/core';
+import { ConflictError, NotFoundError, Result } from '@ontrails/core';
 import type {
   TopoPinRecord,
   TopoSaveRecord,
@@ -21,24 +16,17 @@ import {
   pinTopoSave,
   unpinTopoSave,
 } from '@ontrails/core/internal/topo-saves';
-import type { StoredTopoExport } from '@ontrails/core/internal/topo-store';
-import {
-  getStoredTopoExport,
-  persistEstablishedTopoSave,
-} from '@ontrails/core/internal/topo-store';
+import { persistEstablishedTopoSave } from '@ontrails/core/internal/topo-store';
 import {
   openReadTrailsDb,
   openWriteTrailsDb,
   resolveTrailsDbPath,
   resolveTrailsDir,
 } from '@ontrails/core/internal/trails-db';
-import type { TrailheadLock, TrailheadMap } from '@ontrails/schema';
 import {
   generateTrailheadMap,
   hashTrailheadMap,
   readTrailheadLock,
-  writeTrailheadLock,
-  writeTrailheadMap,
 } from '@ontrails/schema';
 import { z } from 'zod';
 
@@ -110,7 +98,7 @@ export interface TopoVerifyReport {
   readonly stale: false;
 }
 
-const resolveRootDir = (cwd?: string): string => cwd ?? process.cwd();
+export const resolveRootDir = (cwd?: string): string => cwd ?? process.cwd();
 
 const safeGit = (cwd: string, args: readonly string[]): string | undefined => {
   const proc = Bun.spawnSync({
@@ -125,7 +113,7 @@ const safeGit = (cwd: string, args: readonly string[]): string | undefined => {
   return text.length === 0 ? undefined : text;
 };
 
-const currentGitState = (
+export const currentGitState = (
   rootDir: string
 ): { readonly gitDirty: boolean; readonly gitSha?: string } => {
   const gitSha = safeGit(rootDir, ['rev-parse', 'HEAD']);
@@ -136,7 +124,7 @@ const currentGitState = (
   };
 };
 
-const topoCounts = (
+export const topoCounts = (
   app: Topo
 ): Pick<TopoSaveRecord, 'provisionCount' | 'signalCount' | 'trailCount'> => ({
   provisionCount: app.provisions.size,
@@ -305,81 +293,6 @@ export const removeTopoPin = (input: {
       return { dryRun: input.dryRun, removed: false };
     }
     return removeTopoPinWithDb(input, pin, db);
-  } finally {
-    db.close();
-  }
-};
-
-const persistAndReadStoredExport = (
-  app: Topo,
-  db: ReturnType<typeof openWriteTrailsDb>,
-  rootDir: string
-): Result<{ save: TopoSaveRecord; storedExport: StoredTopoExport }, Error> => {
-  let save: TopoSaveRecord;
-  try {
-    save = persistEstablishedTopoSave(db, app, {
-      ...currentGitState(rootDir),
-      ...topoCounts(app),
-    });
-  } catch (error) {
-    return Result.err(
-      error instanceof Error ? error : new Error(String(error))
-    );
-  }
-
-  const storedExport = getStoredTopoExport(db, save.id);
-
-  if (storedExport === undefined) {
-    return Result.err(
-      new InternalError(`Missing stored topo export for save "${save.id}"`)
-    );
-  }
-
-  return Result.ok({
-    save,
-    storedExport,
-  });
-};
-
-const writeStoredExportArtifacts = async (
-  storedExport: StoredTopoExport,
-  trailsDir: string
-): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'mapPath'>> => {
-  const mapPath = await writeTrailheadMap(
-    JSON.parse(storedExport.trailheadMapJson) as TrailheadMap,
-    { dir: trailsDir }
-  );
-  const lockPath = await writeTrailheadLock(
-    JSON.parse(storedExport.lockContent) as TrailheadLock,
-    { dir: trailsDir }
-  );
-
-  return {
-    hash: storedExport.trailheadHash,
-    lockPath,
-    mapPath,
-  };
-};
-
-export const exportCurrentTopo = async (
-  app: Topo,
-  options?: { readonly rootDir?: string }
-): Promise<Result<TopoExportReport, Error>> => {
-  const rootDir = resolveRootDir(options?.rootDir);
-  const db = openWriteTrailsDb({ rootDir });
-
-  try {
-    const persisted = persistAndReadStoredExport(app, db, rootDir);
-    if (persisted.isErr()) {
-      return persisted;
-    }
-
-    const { save, storedExport } = persisted.value;
-    const artifacts = await writeStoredExportArtifacts(
-      storedExport,
-      resolveTrailsDir({ rootDir })
-    );
-    return Result.ok({ ...artifacts, save });
   } finally {
     db.close();
   }

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -53,7 +53,7 @@ describe('buildCliCommands path derivation', () => {
       blaze: (input: { name: string }) => Result.ok(`Hello, ${input.name}`),
       input: z.object({ name: z.string() }),
     });
-    const app = makeApp(t);
+    const app = topo('test-app', { 'db.main': dbProvision, [t.id]: t });
     const commands = buildCliCommands(app);
     expect(commands).toHaveLength(1);
     expect(commands[0]?.path).toEqual(['greet']);
@@ -94,7 +94,10 @@ describe('buildCliCommands path derivation', () => {
         query: z.string(),
       }),
     });
-    const app = makeApp(t);
+    const app = topo('test-app', {
+      'db.main': dbProvision,
+      [t.id]: t,
+    });
     const { flags } = requireCommand(buildCliCommands(app));
 
     const queryFlag = flags.find((f) => f.name === 'query');
@@ -446,7 +449,10 @@ describe('buildCliCommands provision overrides', () => {
       output: z.object({ name: z.string() }),
       provisions: [dbProvision],
     });
-    const app = makeApp(t);
+    const app = topo('test-app', {
+      'db.main': dbProvision,
+      [t.id]: t,
+    });
     const commands = buildCliCommands(app, {
       provisions: { 'db.main': { name: 'override' } },
     });

--- a/packages/core/src/__tests__/topo-store.test.ts
+++ b/packages/core/src/__tests__/topo-store.test.ts
@@ -11,7 +11,10 @@ import {
   pinTopoSave,
   pruneUnpinnedTopoSaves,
 } from '../internal/topo-saves.js';
-import { persistEstablishedTopoSave } from '../internal/topo-store.js';
+import {
+  getStoredTopoExport,
+  persistEstablishedTopoSave,
+} from '../internal/topo-store.js';
 import { openWriteTrailsDb } from '../internal/trails-db.js';
 
 const noop = () => Result.ok({ ok: true });
@@ -199,6 +202,17 @@ const readProjectedTrailIds = (
     .all(saveId)
     .map((row) => row.id);
 
+const requireStoredExport = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  saveId: string
+) => {
+  const stored = getStoredTopoExport(db, saveId);
+  if (stored === undefined) {
+    throw new Error(`Expected stored topo export for save "${saveId}"`);
+  }
+  return stored;
+};
+
 const expectProjectionCounts = (
   db: ReturnType<typeof openWriteTrailsDb>,
   saveId: string
@@ -211,6 +225,8 @@ const expectProjectionCounts = (
   expect(countRows(db, 'topo_trail_signals', saveId)).toBe(1);
   expect(countRows(db, 'topo_trailheads', saveId)).toBe(2);
   expect(countRows(db, 'topo_examples', saveId)).toBe(2);
+  expect(countRows(db, 'topo_schemas', saveId)).toBe(5);
+  expect(countRows(db, 'topo_exports')).toBeGreaterThanOrEqual(1);
 };
 
 const expectProjectedFixtureRows = (
@@ -356,6 +372,25 @@ describe('topo store projection', () => {
       );
       expectProjectionCounts(db, save.id);
       expectProjectedFixtureRows(db, save.id);
+
+      const stored = requireStoredExport(db, save.id);
+      expect(JSON.parse(stored.trailheadMapJson)).toMatchObject({
+        entries: expect.any(Array),
+        generatedAt: '2026-04-03T12:00:00.000Z',
+        version: '1.0',
+      });
+      expect(JSON.parse(stored.lockContent)).toMatchObject({
+        apps: {
+          'projection-app': {
+            provisions: expect.any(Object),
+            signals: expect.any(Object),
+            trails: expect.any(Object),
+          },
+        },
+        generatedAt: '2026-04-03T12:00:00.000Z',
+        hash: stored.trailheadHash,
+        version: 1,
+      });
     });
   });
 
@@ -380,6 +415,9 @@ describe('topo store projection', () => {
         'entity.add',
         'entity.list',
       ]);
+      expect(requireStoredExport(db, firstSave.id).trailheadHash).not.toBe(
+        requireStoredExport(db, secondSave.id).trailheadHash
+      );
     });
   });
 
@@ -404,6 +442,7 @@ describe('topo store projection', () => {
       expect(countRows(db, 'topo_trails', disposable.id)).toBe(0);
       expect(countRows(db, 'topo_crossings', disposable.id)).toBe(0);
       expect(countRows(db, 'topo_examples', disposable.id)).toBe(0);
+      expect(countRows(db, 'topo_schemas', disposable.id)).toBe(0);
     });
   });
 
@@ -417,10 +456,12 @@ describe('topo store projection', () => {
             "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
           )
           .get()?.version
-      ).toBe(2);
+      ).toBe(3);
       expect(tableExists(db, 'topo_trails')).toBe(true);
       expect(tableExists(db, 'topo_crossings')).toBe(true);
       expect(tableExists(db, 'topo_examples')).toBe(true);
+      expect(tableExists(db, 'topo_exports')).toBe(true);
+      expect(tableExists(db, 'topo_schemas')).toBe(true);
       expect(countRows(db, 'topo_saves')).toBe(1);
       expect(countRows(db, 'topo_pins')).toBe(1);
     });

--- a/packages/core/src/__tests__/validate-topo.test.ts
+++ b/packages/core/src/__tests__/validate-topo.test.ts
@@ -448,7 +448,7 @@ describe('validateEstablishedTopo', () => {
     expect(issues[0]?.rule).toBe('cross-exists');
   });
 
-  test('allows provision declarations to be satisfied outside the topo', () => {
+  test('fails when provision declarations are not established in the topo', () => {
     const app = topo('app', {
       show: mockTrail('entity.show', {
         provisions: [mockProvision('db.main')],
@@ -456,7 +456,11 @@ describe('validateEstablishedTopo', () => {
     });
 
     const result = validateEstablishedTopo(app);
-    expect(result.isOk()).toBe(true);
+    expect(result.isErr()).toBe(true);
+
+    const issues = extractIssues(result);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.rule).toBe('provision-exists');
   });
 
   test('allows authoring-only example issues outside projection checks', () => {

--- a/packages/core/src/internal/topo-saves.ts
+++ b/packages/core/src/internal/topo-saves.ts
@@ -89,6 +89,23 @@ const TOPO_TABLE_STATEMENTS = [
     save_id TEXT NOT NULL,
     FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
   )`,
+  `CREATE TABLE IF NOT EXISTS topo_schemas (
+    owner_id TEXT NOT NULL,
+    owner_kind TEXT NOT NULL,
+    schema_kind TEXT NOT NULL,
+    zod_hash TEXT NOT NULL,
+    json_schema TEXT NOT NULL,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (owner_id, owner_kind, schema_kind, save_id),
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_exports (
+    save_id TEXT PRIMARY KEY,
+    trailhead_map TEXT NOT NULL,
+    trailhead_hash TEXT NOT NULL,
+    serialized_lock TEXT NOT NULL,
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
 ] as const;
 const TOPO_INDEX_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_topo_saves_created_at ON topo_saves(created_at DESC)',
@@ -101,6 +118,9 @@ const TOPO_INDEX_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_topo_trail_signals_save_id ON topo_trail_signals(save_id)',
   'CREATE INDEX IF NOT EXISTS idx_topo_trailheads_save_id ON topo_trailheads(save_id)',
   'CREATE UNIQUE INDEX IF NOT EXISTS idx_topo_examples_save_trail_ordinal ON topo_examples(save_id, trail_id, ordinal)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_schemas_save_id ON topo_schemas(save_id)',
+  `CREATE INDEX IF NOT EXISTS idx_topo_schemas_lookup
+   ON topo_schemas(owner_id, owner_kind, schema_kind, zod_hash)`,
 ] as const;
 
 interface TopoSaveRow {
@@ -196,7 +216,7 @@ export const ensureTopoHistorySchema = (db: Database): void => {
       }
     },
     subsystem: TOPO_SUBSYSTEM,
-    version: 2,
+    version: 3,
   });
 };
 

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -192,6 +192,29 @@ const canonicalize = (value: unknown): unknown => {
   return canonicalLeaf(value);
 };
 
+/**
+ * Canonicalize a value for schema definition hashing.
+ *
+ * Matches the canonicalization logic used in `@ontrails/schema` so that
+ * schema hashes are consistent regardless of which code path computes them.
+ * Unlike the general `canonicalize`, this does not convert `Date`, `RegExp`,
+ * or `undefined` to sentinel strings — Zod `_zod.def` objects are plain
+ * JSON-serializable structures and both paths must agree on the same encoding.
+ */
+const schemaCanonical = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(schemaCanonical);
+  }
+  if (value !== null && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).toSorted()) {
+      sorted[key] = schemaCanonical((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+};
+
 const stableJson = (value: unknown): string =>
   JSON.stringify(canonicalize(value));
 
@@ -208,10 +231,15 @@ const parseJsonRecord = (value: string): JsonRecord =>
 
 const schemaDefinitionHash = (schema: unknown): string => {
   const def =
-    typeof schema === 'object' && schema !== null && '_def' in schema
-      ? (schema as { readonly _def: unknown })._def
+    typeof schema === 'object' &&
+    schema !== null &&
+    '_zod' in schema &&
+    typeof (schema as { readonly _zod: unknown })._zod === 'object' &&
+    (schema as { readonly _zod: Record<string, unknown> })._zod !== null &&
+    'def' in (schema as { readonly _zod: Record<string, unknown> })._zod
+      ? (schema as { readonly _zod: { readonly def: unknown } })._zod.def
       : schema;
-  return hashValue(def);
+  return hashText(JSON.stringify(schemaCanonical(def)));
 };
 
 const sortedJsonSchema = (

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -7,8 +7,23 @@ import type { AnySignal } from '../signal.js';
 import type { Topo } from '../topo.js';
 import type { AnyTrail } from '../trail.js';
 import { validateEstablishedTopo } from '../validate-established-topo.js';
+import { zodToJsonSchema } from '../validation.js';
 import type { CreateTopoSaveInput, TopoSaveRecord } from './topo-saves.js';
 import { ensureTopoHistorySchema, insertTopoSaveRecord } from './topo-saves.js';
+
+type TrailheadMapEntryRecord = Readonly<Record<string, unknown>> & {
+  readonly id: string;
+  readonly kind: 'provision' | 'signal' | 'trail';
+};
+
+type TrailheadMapRecord = Readonly<{
+  readonly entries: readonly TrailheadMapEntryRecord[];
+  readonly generatedAt: string;
+  readonly version: '1.0';
+}>;
+
+type JsonRecord = Readonly<Record<string, unknown>>;
+type ZodSchemaInput = Parameters<typeof zodToJsonSchema>[0];
 
 interface TopoTrailRow {
   readonly description: string | null;
@@ -73,6 +88,51 @@ interface TopoExampleRow {
   readonly trailId: string;
 }
 
+interface TopoSchemaRow {
+  readonly jsonSchema: string;
+  readonly ownerId: string;
+  readonly ownerKind: 'signal' | 'trail';
+  readonly saveId: string;
+  readonly schemaKind: 'input' | 'output' | 'payload';
+  readonly zodHash: string;
+}
+
+interface StoredTopoExportRow {
+  readonly saveId: string;
+  readonly serializedLock: string;
+  readonly trailheadHash: string;
+  readonly trailheadMap: string;
+}
+
+interface StoredTopoExportDbRow {
+  readonly serialized_lock: string;
+  readonly trailhead_hash: string;
+  readonly trailhead_map: string;
+}
+
+export interface StoredTopoExport {
+  readonly lockContent: string;
+  readonly trailheadHash: string;
+  readonly trailheadMapJson: string;
+}
+
+interface MaterializedSchemas {
+  readonly rows: readonly TopoSchemaRow[];
+  readonly signalPayloads: ReadonlyMap<string, JsonRecord>;
+  readonly trailSchemas: ReadonlyMap<
+    string,
+    Readonly<{
+      readonly input: JsonRecord;
+      readonly output?: JsonRecord;
+    }>
+  >;
+}
+
+interface MaterializedTopoArtifacts {
+  readonly exportRow: StoredTopoExportRow;
+  readonly schemaRows: readonly TopoSchemaRow[];
+}
+
 interface NormalizedTopoProjection {
   readonly crossings: readonly TopoCrossingRow[];
   readonly examples: readonly TopoExampleRow[];
@@ -84,22 +144,93 @@ interface NormalizedTopoProjection {
   readonly trails: readonly TopoTrailRow[];
 }
 
+const canonicalLeaf = (value: unknown): unknown => {
+  switch (typeof value) {
+    case 'bigint': {
+      return value.toString();
+    }
+    case 'function': {
+      return `[Function:${value.name || 'anonymous'}]`;
+    }
+    case 'symbol': {
+      return `[Symbol:${value.description ?? ''}]`;
+    }
+    case 'undefined': {
+      return '[Undefined]';
+    }
+    default: {
+      return value;
+    }
+  }
+};
+
+const canonicalObject = (
+  value: Record<string, unknown>,
+  visit: (value: unknown) => unknown
+): Record<string, unknown> => {
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).toSorted()) {
+    const next = value[key];
+    sorted[key] = next === undefined ? '[Undefined]' : visit(next);
+  }
+  return sorted;
+};
+
 const canonicalize = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map(canonicalize);
   }
-  if (value !== null && typeof value === 'object') {
-    const sorted: Record<string, unknown> = {};
-    for (const key of Object.keys(value).toSorted()) {
-      sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
-    }
-    return sorted;
+  if (value instanceof Date) {
+    return value.toISOString();
   }
-  return value;
+  if (value instanceof RegExp) {
+    return value.toString();
+  }
+  if (value !== null && typeof value === 'object') {
+    return canonicalObject(value as Record<string, unknown>, canonicalize);
+  }
+  return canonicalLeaf(value);
 };
 
 const stableJson = (value: unknown): string =>
   JSON.stringify(canonicalize(value));
+
+const hashText = (text: string): string => {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(text);
+  return hasher.digest('hex');
+};
+
+const hashValue = (value: unknown): string => hashText(stableJson(value));
+
+const parseJsonRecord = (value: string): JsonRecord =>
+  JSON.parse(value) as JsonRecord;
+
+const schemaDefinitionHash = (schema: unknown): string => {
+  const def =
+    typeof schema === 'object' && schema !== null && '_def' in schema
+      ? (schema as { readonly _def: unknown })._def
+      : schema;
+  return hashValue(def);
+};
+
+const sortedJsonSchema = (
+  schema: ZodSchemaInput
+): { readonly json: string; readonly value: JsonRecord } => {
+  const json = stableJson(zodToJsonSchema(schema));
+  return {
+    json,
+    value: parseJsonRecord(json),
+  };
+};
+
+const sortKeys = <T extends Record<string, unknown>>(value: T): T => {
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).toSorted()) {
+    sorted[key] = value[key];
+  }
+  return sorted as T;
+};
 
 const normalizeTrailRows = (
   trails: readonly AnyTrail[],
@@ -255,6 +386,487 @@ const normalizeTopoProjection = (
  * deterministic for a given `_def` hash — the `schemaDefinitionHash` pipeline
  * guarantees that structurally identical schemas produce the same hash.
  */
+const readCachedJsonSchema = (
+  db: Database,
+  ownerId: string,
+  ownerKind: TopoSchemaRow['ownerKind'],
+  schemaKind: TopoSchemaRow['schemaKind'],
+  zodHash: string
+): string | undefined => {
+  const row = db
+    .query<
+      {
+        readonly json_schema: string;
+      },
+      [string, string, string, string]
+    >(
+      `SELECT json_schema
+       FROM topo_schemas
+       WHERE owner_id = ?
+         AND owner_kind = ?
+         AND schema_kind = ?
+         AND zod_hash = ?
+       LIMIT 1`
+    )
+    .get(ownerId, ownerKind, schemaKind, zodHash);
+
+  return row?.json_schema;
+};
+
+const resolveSchemaRow = (
+  db: Database,
+  ownerId: string,
+  ownerKind: TopoSchemaRow['ownerKind'],
+  saveId: string,
+  schemaKind: TopoSchemaRow['schemaKind'],
+  schema: ZodSchemaInput
+): {
+  readonly row: TopoSchemaRow;
+  readonly value: JsonRecord;
+} => {
+  const zodHash = schemaDefinitionHash(schema);
+  const cachedJson = readCachedJsonSchema(
+    db,
+    ownerId,
+    ownerKind,
+    schemaKind,
+    zodHash
+  );
+
+  if (cachedJson !== undefined) {
+    return {
+      row: {
+        jsonSchema: cachedJson,
+        ownerId,
+        ownerKind,
+        saveId,
+        schemaKind,
+        zodHash,
+      },
+      value: parseJsonRecord(cachedJson),
+    };
+  }
+
+  const generated = sortedJsonSchema(schema);
+  return {
+    row: {
+      jsonSchema: generated.json,
+      ownerId,
+      ownerKind,
+      saveId,
+      schemaKind,
+      zodHash,
+    },
+    value: generated.value,
+  };
+};
+
+const materializeTrailSchema = (
+  db: Database,
+  saveId: string,
+  trail: AnyTrail
+): {
+  readonly rows: readonly TopoSchemaRow[];
+  readonly value: Readonly<{
+    readonly input: JsonRecord;
+    readonly output?: JsonRecord;
+  }>;
+} => {
+  const inputSchema = resolveSchemaRow(
+    db,
+    trail.id,
+    'trail',
+    saveId,
+    'input',
+    trail.input as ZodSchemaInput
+  );
+
+  if (trail.output === undefined) {
+    return {
+      rows: [inputSchema.row],
+      value: {
+        input: inputSchema.value,
+      },
+    };
+  }
+
+  const outputSchema = resolveSchemaRow(
+    db,
+    trail.id,
+    'trail',
+    saveId,
+    'output',
+    trail.output as ZodSchemaInput
+  );
+
+  return {
+    rows: [inputSchema.row, outputSchema.row],
+    value: {
+      input: inputSchema.value,
+      output: outputSchema.value,
+    },
+  };
+};
+
+const materializeTrailSchemas = (
+  db: Database,
+  saveId: string,
+  trails: readonly AnyTrail[]
+): Pick<MaterializedSchemas, 'rows' | 'trailSchemas'> => {
+  const rows: TopoSchemaRow[] = [];
+  const trailSchemas = new Map<
+    string,
+    Readonly<{
+      readonly input: JsonRecord;
+      readonly output?: JsonRecord;
+    }>
+  >();
+
+  for (const trail of trails) {
+    const materialized = materializeTrailSchema(db, saveId, trail);
+    rows.push(...materialized.rows);
+    trailSchemas.set(trail.id, materialized.value);
+  }
+
+  return {
+    rows,
+    trailSchemas,
+  };
+};
+
+const materializeSignalSchemas = (
+  db: Database,
+  saveId: string,
+  signals: readonly AnySignal[]
+): Pick<MaterializedSchemas, 'rows' | 'signalPayloads'> => {
+  const rows: TopoSchemaRow[] = [];
+  const signalPayloads = new Map<string, JsonRecord>();
+
+  for (const signal of signals) {
+    const payloadSchema = resolveSchemaRow(
+      db,
+      signal.id,
+      'signal',
+      saveId,
+      'payload',
+      signal.payload as ZodSchemaInput
+    );
+    rows.push(payloadSchema.row);
+    signalPayloads.set(signal.id, payloadSchema.value);
+  }
+
+  return {
+    rows,
+    signalPayloads,
+  };
+};
+
+const materializeSchemas = (
+  db: Database,
+  saveId: string,
+  signals: readonly AnySignal[],
+  trails: readonly AnyTrail[]
+): MaterializedSchemas => {
+  const trailMaterial = materializeTrailSchemas(db, saveId, trails);
+  const signalMaterial = materializeSignalSchemas(db, saveId, signals);
+
+  return {
+    rows: [...trailMaterial.rows, ...signalMaterial.rows],
+    signalPayloads: signalMaterial.signalPayloads,
+    trailSchemas: trailMaterial.trailSchemas,
+  };
+};
+
+const extractTrailheads = (raw: Record<string, unknown>): string[] =>
+  Array.isArray(raw['trailheads'])
+    ? (raw['trailheads'] as string[]).toSorted()
+    : [];
+
+const addSafetyMarkers = (
+  entry: Record<string, unknown>,
+  trail: AnyTrail
+): void => {
+  if (trail.intent !== 'write') {
+    entry['intent'] = trail.intent;
+  }
+
+  if (trail.idempotent === true) {
+    entry['idempotent'] = true;
+  }
+};
+
+const addExtendedMetadata = (
+  entry: Record<string, unknown>,
+  raw: Record<string, unknown>,
+  trail: AnyTrail
+): void => {
+  if (raw['deprecated'] === true) {
+    entry['deprecated'] = true;
+  }
+
+  if (typeof raw['replacedBy'] === 'string') {
+    entry['replacedBy'] = raw['replacedBy'];
+  }
+
+  if (trail.detours !== undefined) {
+    const detours: Record<string, readonly string[]> = {};
+    for (const key of Object.keys(trail.detours).toSorted()) {
+      detours[key] = (trail.detours[key] ?? []).toSorted();
+    }
+    entry['detours'] = detours;
+  }
+};
+
+const addTrailRelations = (
+  entry: Record<string, unknown>,
+  trail: AnyTrail
+): void => {
+  if (trail.crosses.length > 0) {
+    entry['crosses'] = trail.crosses.toSorted();
+  }
+
+  if (trail.provisions.length > 0) {
+    entry['provisions'] = trail.provisions
+      .map((provision) => provision.id)
+      .toSorted();
+  }
+};
+
+const buildTrailEntryBase = (
+  trail: AnyTrail,
+  trailSchema: Readonly<{
+    readonly input: JsonRecord;
+    readonly output?: JsonRecord;
+  }>
+): {
+  readonly entry: Record<string, unknown>;
+  readonly raw: Record<string, unknown>;
+} => {
+  const raw = trail as unknown as Record<string, unknown>;
+  const entry: Record<string, unknown> = {
+    cli: { path: deriveCliPath(trail.id) },
+    exampleCount: trail.examples?.length ?? 0,
+    id: trail.id,
+    input: trailSchema.input,
+    kind: trail.kind,
+    trailheads: extractTrailheads(raw),
+  };
+
+  if (trailSchema.output !== undefined) {
+    entry['output'] = trailSchema.output;
+  }
+
+  if (trail.description !== undefined) {
+    entry['description'] = trail.description;
+  }
+
+  return {
+    entry,
+    raw,
+  };
+};
+
+const trailToEntryRecord = (
+  trail: AnyTrail,
+  trailSchema: Readonly<{
+    readonly input: JsonRecord;
+    readonly output?: JsonRecord;
+  }>
+): TrailheadMapEntryRecord => {
+  const { entry, raw } = buildTrailEntryBase(trail, trailSchema);
+  addSafetyMarkers(entry, trail);
+  addExtendedMetadata(entry, raw, trail);
+  addTrailRelations(entry, trail);
+  return sortKeys(entry) as TrailheadMapEntryRecord;
+};
+
+const signalToEntryRecord = (
+  signal: AnySignal,
+  payloadSchema: JsonRecord
+): TrailheadMapEntryRecord => {
+  const raw = signal as unknown as Record<string, unknown>;
+  const entry: Record<string, unknown> = {
+    exampleCount: 0,
+    id: signal.id,
+    input: payloadSchema,
+    kind: 'signal',
+    trailheads: extractTrailheads(raw),
+  };
+
+  if (signal.description !== undefined) {
+    entry['description'] = signal.description;
+  }
+
+  if (raw['deprecated'] === true) {
+    entry['deprecated'] = true;
+  }
+
+  if (typeof raw['replacedBy'] === 'string') {
+    entry['replacedBy'] = raw['replacedBy'];
+  }
+
+  return sortKeys(entry) as TrailheadMapEntryRecord;
+};
+
+const provisionToEntryRecord = (
+  provision: AnyProvision
+): TrailheadMapEntryRecord => {
+  const entry: Record<string, unknown> = {
+    exampleCount: 0,
+    id: provision.id,
+    kind: 'provision',
+    trailheads: [],
+  };
+
+  if (provision.description !== undefined) {
+    entry['description'] = provision.description;
+  }
+
+  if (provision.health !== undefined) {
+    entry['healthcheck'] = true;
+  }
+
+  return sortKeys(entry) as TrailheadMapEntryRecord;
+};
+
+const requireTrailSchema = (
+  trailSchemas: MaterializedSchemas['trailSchemas'],
+  trailId: string
+): Readonly<{
+  readonly input: JsonRecord;
+  readonly output?: JsonRecord;
+}> => {
+  const schema = trailSchemas.get(trailId);
+  if (schema === undefined) {
+    throw new Error(`Missing cached trail schema for "${trailId}"`);
+  }
+  return schema;
+};
+
+const requireSignalPayload = (
+  signalPayloads: MaterializedSchemas['signalPayloads'],
+  signalId: string
+): JsonRecord => {
+  const payload = signalPayloads.get(signalId);
+  if (payload === undefined) {
+    throw new Error(`Missing cached signal schema for "${signalId}"`);
+  }
+  return payload;
+};
+
+const buildTrailheadMap = (
+  generatedAt: string,
+  provisions: readonly AnyProvision[],
+  signalPayloads: ReadonlyMap<string, JsonRecord>,
+  signals: readonly AnySignal[],
+  trailSchemas: ReadonlyMap<
+    string,
+    Readonly<{
+      readonly input: JsonRecord;
+      readonly output?: JsonRecord;
+    }>
+  >,
+  trails: readonly AnyTrail[]
+): TrailheadMapRecord => {
+  const entries = [
+    ...trails.map((trail) =>
+      trailToEntryRecord(trail, requireTrailSchema(trailSchemas, trail.id))
+    ),
+    ...signals.map((signal) =>
+      signalToEntryRecord(
+        signal,
+        requireSignalPayload(signalPayloads, signal.id)
+      )
+    ),
+    ...provisions.map((provision) => provisionToEntryRecord(provision)),
+  ].toSorted((a, b) => a.id.localeCompare(b.id));
+
+  return {
+    entries,
+    generatedAt,
+    version: '1.0',
+  };
+};
+
+const hashTrailheadMapRecord = (trailheadMap: TrailheadMapRecord): string => {
+  const { generatedAt: _unused, ...rest } = trailheadMap;
+  return hashValue(rest);
+};
+
+const entryPayload = (
+  entry: TrailheadMapEntryRecord
+): Readonly<Record<string, unknown>> => {
+  const { id: _unusedId, kind: _unusedKind, ...rest } = entry;
+  return sortKeys(rest);
+};
+
+const entriesForKind = (
+  entries: readonly TrailheadMapEntryRecord[],
+  kind: TrailheadMapEntryRecord['kind']
+): Readonly<Record<string, Readonly<Record<string, unknown>>>> =>
+  Object.fromEntries(
+    entries
+      .filter((entry) => entry.kind === kind)
+      .map((entry) => [entry.id, entryPayload(entry)])
+  );
+
+const buildSerializedLock = (
+  hash: string,
+  topo: Topo,
+  trailheadMap: TrailheadMapRecord
+): Readonly<Record<string, unknown>> =>
+  sortKeys({
+    apps: sortKeys({
+      [topo.name]: sortKeys({
+        provisions: entriesForKind(trailheadMap.entries, 'provision'),
+        signals: entriesForKind(trailheadMap.entries, 'signal'),
+        trails: entriesForKind(trailheadMap.entries, 'trail'),
+      }),
+    }),
+    generatedAt: trailheadMap.generatedAt,
+    hash,
+    version: 1,
+  });
+
+const buildStoredTopoExport = (
+  db: Database,
+  save: TopoSaveRecord,
+  topo: Topo
+): MaterializedTopoArtifacts => {
+  const trails = topo.list().toSorted((a, b) => a.id.localeCompare(b.id));
+  const provisions = topo
+    .listProvisions()
+    .toSorted((a, b) => a.id.localeCompare(b.id));
+  const signals = topo
+    .listSignals()
+    .toSorted((a, b) => a.id.localeCompare(b.id));
+  const schemas = materializeSchemas(db, save.id, signals, trails);
+  const trailheadMap = buildTrailheadMap(
+    save.createdAt,
+    provisions,
+    schemas.signalPayloads,
+    signals,
+    schemas.trailSchemas,
+    trails
+  );
+  const trailheadHash = hashTrailheadMapRecord(trailheadMap);
+  const serializedLock = `${JSON.stringify(
+    buildSerializedLock(trailheadHash, topo, trailheadMap),
+    null,
+    2
+  )}\n`;
+
+  return {
+    exportRow: {
+      saveId: save.id,
+      serializedLock,
+      trailheadHash,
+      trailheadMap: `${JSON.stringify(trailheadMap, null, 2)}\n`,
+    },
+    schemaRows: schemas.rows,
+  };
+};
+
 const insertRows = <TRow>(
   db: Database,
   rows: readonly TRow[],
@@ -354,6 +966,67 @@ const insertProjectedRows = (
   );
 };
 
+const insertSchemaRows = (
+  db: Database,
+  rows: readonly TopoSchemaRow[]
+): void => {
+  insertRows(
+    db,
+    rows,
+    `INSERT INTO topo_schemas (
+      owner_id, owner_kind, schema_kind, zod_hash, json_schema, save_id
+    ) VALUES (?, ?, ?, ?, ?, ?)`,
+    (row) => [
+      row.ownerId,
+      row.ownerKind,
+      row.schemaKind,
+      row.zodHash,
+      row.jsonSchema,
+      row.saveId,
+    ]
+  );
+};
+
+const insertStoredExport = (
+  db: Database,
+  exportRow: StoredTopoExportRow
+): void => {
+  db.run(
+    `INSERT INTO topo_exports (
+      save_id, trailhead_map, trailhead_hash, serialized_lock
+    ) VALUES (?, ?, ?, ?)`,
+    [
+      exportRow.saveId,
+      exportRow.trailheadMap,
+      exportRow.trailheadHash,
+      exportRow.serializedLock,
+    ]
+  );
+};
+
+export const getStoredTopoExport = (
+  db: Database,
+  saveId: string
+): StoredTopoExport | undefined => {
+  const row = db
+    .query<StoredTopoExportDbRow, [string]>(
+      `SELECT trailhead_map, trailhead_hash, serialized_lock
+       FROM topo_exports
+       WHERE save_id = ?`
+    )
+    .get(saveId);
+
+  if (row === undefined || row === null) {
+    return undefined;
+  }
+
+  return {
+    lockContent: row.serialized_lock,
+    trailheadHash: row.trailhead_hash,
+    trailheadMapJson: row.trailhead_map,
+  };
+};
+
 export const persistEstablishedTopoSave = (
   db: Database,
   topo: Topo,
@@ -375,7 +1048,10 @@ export const persistEstablishedTopoSave = (
 
   const save = db.transaction(() => {
     const record = insertTopoSaveRecord(db, saveInput);
+    const artifacts = buildStoredTopoExport(db, record, topo);
     insertProjectedRows(db, normalizeTopoProjection(topo, record.id));
+    insertSchemaRows(db, artifacts.schemaRows);
+    insertStoredExport(db, artifacts.exportRow);
     return record;
   })();
 

--- a/packages/core/src/validate-established-topo.ts
+++ b/packages/core/src/validate-established-topo.ts
@@ -9,6 +9,7 @@ const PROJECTION_BLOCKING_RULES = new Set([
   'cross-cycle',
   'cross-exists',
   'no-self-cross',
+  'provision-exists',
   'signal-origin-exists',
 ]);
 

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -333,7 +333,7 @@ describe('buildHttpRoutes', () => {
         provisions: [dbProvision],
       });
 
-      const app = topo('testapp', { provisionTrail });
+      const app = topo('testapp', { dbProvision, provisionTrail });
       const buildResult = buildHttpRoutes(app, {
         provisions: { 'db.main': { source: 'override' } },
       });

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -341,7 +341,7 @@ describe('buildMcpTools', () => {
       });
 
       const tool = requireOnlyTool(
-        buildTools(topo('myapp', { provisionTrail }), {
+        buildTools(topo('myapp', { dbProvision, provisionTrail }), {
           provisions: { 'db.main': { source: 'override' } },
         })
       );

--- a/packages/schema/src/__tests__/io.test.ts
+++ b/packages/schema/src/__tests__/io.test.ts
@@ -7,6 +7,7 @@ import {
   writeTrailheadMap,
   readTrailheadMap,
   writeTrailheadLock,
+  readTrailheadLockData,
   readTrailheadLock,
 } from '../io.js';
 import type { TrailheadMap } from '../types.js';
@@ -29,6 +30,17 @@ const makeTrailheadMap = (): TrailheadMap => ({
   generatedAt: '2025-01-01T00:00:00.000Z',
   version: '1.0',
 });
+
+const makeStructuredLock = (hash: string) => ({
+  generatedAt: '2026-04-03T00:00:00.000Z',
+  hash,
+  version: 1,
+});
+
+const readParsedLock = async (
+  filePath: string
+): Promise<Record<string, unknown>> =>
+  JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
 
 // ---------------------------------------------------------------------------
 // Setup / Teardown
@@ -94,12 +106,24 @@ describe('writeTrailheadLock / readTrailheadLock', () => {
     expect(content).toBe(`${hash}\n`);
   });
 
-  test('reads the hash back', async () => {
+  test('writes and reads structured JSON locks', async () => {
     const hash = 'deadbeef'.repeat(8);
-    await writeTrailheadLock(hash, { dir: tempDir });
-    const result = await readTrailheadLock({ dir: tempDir });
+    const filePath = await writeTrailheadLock(makeStructuredLock(hash), {
+      dir: tempDir,
+    });
 
-    expect(result).toBe(hash);
+    expect(filePath).toBe(join(tempDir, 'trails.lock'));
+
+    const parsed = await readParsedLock(filePath);
+    expect(parsed.hash).toBe(hash);
+    expect(parsed.version).toBe(1);
+
+    const result = await readTrailheadLockData({ dir: tempDir });
+
+    expect(result).toEqual(makeStructuredLock(hash));
+
+    const legacyResult = await readTrailheadLock({ dir: tempDir });
+    expect(legacyResult).toBe(hash);
   });
 
   test('falls back to the legacy trailhead.lock name during migration', async () => {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -12,6 +12,7 @@ export {
   writeTrailheadMap,
   readTrailheadMap,
   writeTrailheadLock,
+  readTrailheadLockData,
   readTrailheadLock,
 } from './io.js';
 
@@ -19,6 +20,7 @@ export {
 export type {
   TrailheadMap,
   TrailheadMapEntry,
+  TrailheadLock,
   DiffEntry,
   DiffResult,
   JsonSchema,

--- a/packages/schema/src/io.ts
+++ b/packages/schema/src/io.ts
@@ -5,7 +5,12 @@
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import type { ReadOptions, TrailheadMap, WriteOptions } from './types.js';
+import type {
+  ReadOptions,
+  TrailheadLock,
+  TrailheadMap,
+  WriteOptions,
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -47,6 +52,31 @@ const readFirstExistingText = async (
   return null;
 };
 
+const isTrailheadLock = (value: unknown): value is TrailheadLock => {
+  const lock = value as Record<string, unknown>;
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof lock['hash'] === 'string'
+  );
+};
+
+const parseTrailheadLock = (content: string): TrailheadLock => {
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (isTrailheadLock(parsed)) {
+      return parsed;
+    }
+    if (typeof parsed === 'string') {
+      return { hash: parsed.trim() };
+    }
+  } catch {
+    // Fall through to the legacy hash-line format.
+  }
+
+  return { hash: content.trim() };
+};
+
 // ---------------------------------------------------------------------------
 // Trailhead Map
 // ---------------------------------------------------------------------------
@@ -84,32 +114,53 @@ export const readTrailheadMap = async (
 // ---------------------------------------------------------------------------
 
 /**
- * Write a hash to `<dir>/trails.lock` as a single line.
+ * Write a committed lock to `<dir>/trails.lock`.
  *
- * Creates the directory if it doesn't exist. Returns the file path.
+ * String input preserves the legacy single-line hash format. Structured input
+ * is serialized as JSON. Creates the directory if it doesn't exist.
  */
 export const writeTrailheadLock = async (
-  hash: string,
+  lock: string | TrailheadLock,
   options?: WriteOptions
 ): Promise<string> => {
   const dir = resolveDir(options);
   await ensureDir(dir);
   const filePath = join(dir, TRAILHEAD_LOCK_FILE);
-  await Bun.write(filePath, `${hash}\n`);
+
+  if (typeof lock === 'string') {
+    await Bun.write(filePath, `${lock}\n`);
+    return filePath;
+  }
+
+  await Bun.write(filePath, `${JSON.stringify(lock, null, 2)}\n`);
   return filePath;
 };
 
 /**
- * Read the hash from `<dir>/trails.lock`, falling back to the legacy
- * `<dir>/trailhead.lock` during migration.
+ * Read the committed lock from `<dir>/trails.lock`, falling back to the
+ * legacy `<dir>/trailhead.lock` during migration.
+ *
+ * Structured JSON locks are normalized to expose their committed hash while
+ * preserving additional metadata.
  */
-export const readTrailheadLock = async (
+export const readTrailheadLockData = async (
   options?: ReadOptions
-): Promise<string | null> => {
+): Promise<TrailheadLock | null> => {
   const dir = resolveDir(options);
   const content = await readFirstExistingText([
     join(dir, TRAILHEAD_LOCK_FILE),
     join(dir, LEGACY_TRAILHEAD_LOCK_FILE),
   ]);
-  return content ? content.trim() : null;
+  return content ? parseTrailheadLock(content) : null;
+};
+
+/**
+ * Read the committed lock hash from `<dir>/trails.lock`, falling back to the
+ * legacy `<dir>/trailhead.lock` during migration.
+ */
+export const readTrailheadLock = async (
+  options?: ReadOptions
+): Promise<string | null> => {
+  const lock = await readTrailheadLockData(options);
+  return lock?.hash ?? null;
 };

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -43,6 +43,21 @@ export interface TrailheadMap {
 }
 
 // ---------------------------------------------------------------------------
+// Trailhead Lock
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalized lock data read from `trails.lock`.
+ *
+ * The file may be stored as structured JSON or legacy single-line text.
+ * The normalized shape always exposes the committed hash and preserves any
+ * extra structured metadata.
+ */
+export type TrailheadLock = Readonly<Record<string, unknown>> & {
+  readonly hash: string;
+};
+
+// ---------------------------------------------------------------------------
 // Diff
 // ---------------------------------------------------------------------------
 

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { trail, topo, Result } from '@ontrails/core';
-import { hashTrailheadMap, generateTrailheadMap } from '@ontrails/schema';
+import {
+  hashTrailheadMap,
+  generateTrailheadMap,
+  writeTrailheadLock,
+} from '@ontrails/schema';
 import { z } from 'zod';
 
 import { checkDrift } from '../drift.js';
@@ -54,7 +58,10 @@ describe('checkDrift', () => {
     try {
       const tp = makeTopo();
       const hash = hashTrailheadMap(generateTrailheadMap(tp));
-      writeFileSync(join(committedLockDir(dir), 'trailhead.lock'), `${hash}\n`);
+      await writeTrailheadLock(
+        { hash, version: 1 },
+        { dir: committedLockDir(dir) }
+      );
 
       const result = await checkDrift(dir, tp);
       expect(result.stale).toBe(false);

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -3,7 +3,8 @@
  *
  * Compares the committed `trails.lock` hash against a freshly generated
  * trailhead map hash to detect when the trail topology has changed without
- * updating the lock file.
+ * updating the lock file. The committed lock may be structured JSON or the
+ * legacy single-line hash format.
  */
 
 import type { Topo } from '@ontrails/core';
@@ -12,7 +13,7 @@ import { resolveTrailsDir } from '@ontrails/core/internal/trails-db';
 import {
   generateTrailheadMap,
   hashTrailheadMap,
-  readTrailheadLock,
+  readTrailheadLockData,
 } from '@ontrails/schema';
 
 /**
@@ -45,14 +46,17 @@ export const checkDrift = async (
   try {
     const trailheadMap = generateTrailheadMap(topo);
     const currentHash = hashTrailheadMap(trailheadMap);
-    const committedHash = await readTrailheadLock({
+    const committedLock = await readTrailheadLockData({
       dir: resolveTrailsDir({ rootDir }),
     });
 
     return {
-      committedHash,
+      committedHash: committedLock?.hash ?? null,
       currentHash,
-      stale: committedHash !== null && committedHash !== currentHash,
+      stale:
+        committedLock !== null &&
+        currentHash !== 'unknown' &&
+        committedLock.hash !== currentHash,
     };
   } catch (error) {
     if (!(error instanceof ValidationError)) {


### PR DESCRIPTION
## Summary
- Caches derived JSON schemas via zod-hash in `topo_schemas`
- Moves trailhead map and lock export onto stored topo state
- Introduces structured lock format with legacy compatibility reader
- Tightens established-topo validation for provision declarations

## What changed
JSON schemas derived from Zod definitions are now cached in a `topo_schemas` table, keyed by a stable hash of the Zod schema. Trailhead map generation and lock export now read from stored topo state rather than recomputing from source. The lock format gains structured metadata while a legacy reader maintains backward compatibility. Validation for established topo entries is tightened to require proper provision declarations.

## How it was tested
- bun run build
- bun run test
- bun run typecheck
- bun run lint
- Package-specific tests where applicable

Closes: TRL-131, TRL-147, TRL-148, TRL-149
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
