### PR TITLE
feat: add the @ontrails/store declaration package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -152,6 +152,16 @@
         "zod": "catalog:",
       },
     },
+    "packages/store": {
+      "name": "@ontrails/store",
+      "version": "1.0.0-beta.13",
+      "dependencies": {
+        "@ontrails/core": "workspace:^",
+      },
+      "peerDependencies": {
+        "zod": "catalog:",
+      },
+    },
     "packages/testing": {
       "name": "@ontrails/testing",
       "version": "1.0.0-beta.13",
@@ -275,6 +285,8 @@
     "@ontrails/permits": ["@ontrails/permits@workspace:packages/permits"],
 
     "@ontrails/schema": ["@ontrails/schema@workspace:packages/schema"],
+
+    "@ontrails/store": ["@ontrails/store@workspace:packages/store"],
 
     "@ontrails/testing": ["@ontrails/testing@workspace:packages/testing"],
 

--- a/packages/store/CHANGELOG.md
+++ b/packages/store/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @ontrails/store

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@ontrails/store",
+  "version": "1.0.0-beta.13",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "dependencies": {
+    "@ontrails/core": "workspace:^"
+  },
+  "peerDependencies": {
+    "zod": "catalog:"
+  }
+}

--- a/packages/store/src/__tests__/store.test.ts
+++ b/packages/store/src/__tests__/store.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from 'bun:test';
+import { ValidationError } from '@ontrails/core';
+import { z } from 'zod';
+
+import type { EntityOf, InsertOf, UpdateOf } from '../index.js';
+import {
+  entitySchemaOf,
+  insertSchemaOf,
+  store,
+  updateSchemaOf,
+} from '../index.js';
+
+const userSchema = z.object({
+  email: z.string().email(),
+  id: z.string(),
+});
+
+const gistSchema = z.object({
+  createdAt: z.string(),
+  description: z.string().nullable().default(null),
+  id: z.string(),
+  isPublic: z.boolean().default(true),
+  ownerId: z.string(),
+  tags: z.array(z.string()).default([]),
+  updatedAt: z.string(),
+});
+
+const createStoreDefinition = () =>
+  store({
+    gists: {
+      generated: ['id', 'createdAt', 'updatedAt'],
+      indexes: ['ownerId'],
+      primaryKey: 'id',
+      references: { ownerId: 'users' },
+      schema: gistSchema,
+      search: { fts: true },
+    },
+    users: {
+      generated: ['id'],
+      primaryKey: 'id',
+      schema: userSchema,
+    },
+  });
+
+const expectNormalizedGistTable = (
+  table: ReturnType<typeof createStoreDefinition>['tables']['gists']
+) => {
+  expect(table.name).toBe('gists');
+  expect(table.primaryKey).toBe('id');
+  expect(table.generated).toEqual(['id', 'createdAt', 'updatedAt']);
+  expect(table.indexes).toEqual(['ownerId']);
+  expect(table.references).toEqual({ ownerId: 'users' });
+  expect(table.search).toEqual({ fts: true });
+};
+
+const expectDerivedSchemas = (
+  table: ReturnType<typeof createStoreDefinition>['tables']['gists']
+) => {
+  expect(entitySchemaOf(table)).toBe(table.schema);
+  expect(insertSchemaOf(table)).toBe(table.insertSchema);
+  expect(updateSchemaOf(table)).toBe(table.updateSchema);
+
+  expect(
+    table.insertSchema.parse({
+      ownerId: 'user-1',
+    })
+  ).toEqual({
+    description: null,
+    isPublic: true,
+    ownerId: 'user-1',
+    tags: [],
+  });
+
+  expect(
+    table.updateSchema.parse({
+      description: 'Updated',
+    })
+  ).toEqual({
+    description: 'Updated',
+  });
+};
+
+const createTypeTestStore = () =>
+  store({
+    gists: {
+      generated: ['id', 'createdAt', 'updatedAt'],
+      primaryKey: 'id',
+      schema: gistSchema,
+    },
+  });
+
+const createGistEntity = <
+  TTable extends Parameters<typeof entitySchemaOf>[0],
+>() =>
+  ({
+    createdAt: '2026-04-03T12:00:00.000Z',
+    description: null,
+    id: 'gist-1',
+    isPublic: true,
+    ownerId: 'user-1',
+    tags: ['core'],
+    updatedAt: '2026-04-03T12:00:00.000Z',
+  }) as EntityOf<TTable>;
+
+describe('@ontrails/store', () => {
+  test('normalizes tables and derives insert/update schemas', () => {
+    const db = createStoreDefinition();
+
+    expect(db.kind).toBe('store');
+    expect(db.tableNames).toEqual(['gists', 'users']);
+
+    const table = db.tables.gists;
+    expectNormalizedGistTable(table);
+    expect(db.get('users')).toBe(db.tables.users);
+    expectDerivedSchemas(table);
+  });
+
+  test('rejects non-object schemas and unknown metadata fields', () => {
+    expect(() =>
+      store({
+        broken: {
+          primaryKey: 'id' as never,
+          schema: z.string() as never,
+        },
+      })
+    ).toThrow(
+      new ValidationError('Store table "broken" must use a Zod object schema')
+    );
+
+    expect(() =>
+      store({
+        gists: {
+          primaryKey: 'slug' as never,
+          schema: gistSchema,
+        },
+      })
+    ).toThrow(
+      new ValidationError(
+        'Store table "gists" declares primaryKey "slug" that is not present on the schema'
+      )
+    );
+
+    expect(() =>
+      store({
+        gists: {
+          generated: ['missing'] as const as never,
+          primaryKey: 'id',
+          schema: gistSchema,
+        },
+      })
+    ).toThrow(
+      new ValidationError(
+        'Store table "gists" declares generated field "missing" that is not present on the schema'
+      )
+    );
+
+    expect(() =>
+      store({
+        gists: {
+          indexes: ['missing'] as const as never,
+          primaryKey: 'id',
+          schema: gistSchema,
+        },
+      })
+    ).toThrow(
+      new ValidationError(
+        'Store table "gists" declares index field "missing" that is not present on the schema'
+      )
+    );
+  });
+
+  test('rejects bad references', () => {
+    expect(() =>
+      store({
+        gists: {
+          primaryKey: 'id',
+          references: { missing: 'users' } as never,
+          schema: gistSchema,
+        },
+        users: {
+          primaryKey: 'id',
+          schema: userSchema,
+        },
+      })
+    ).toThrow(
+      new ValidationError(
+        'Store table "gists" declares reference field "missing" that is not present on the schema'
+      )
+    );
+
+    expect(() =>
+      store({
+        gists: {
+          primaryKey: 'id',
+          references: { ownerId: 'accounts' },
+          schema: gistSchema,
+        },
+        users: {
+          primaryKey: 'id',
+          schema: userSchema,
+        },
+      })
+    ).toThrow(
+      new ValidationError(
+        'Store table "gists" references unknown table "accounts"'
+      )
+    );
+  });
+
+  test('type-level helpers expose connector-facing contracts', () => {
+    const db = createTypeTestStore();
+
+    type GistTable = typeof db.tables.gists;
+
+    const entity = createGistEntity<GistTable>();
+
+    const insert: InsertOf<GistTable> = {
+      description: null,
+      isPublic: true,
+      ownerId: 'user-1',
+      tags: ['core'],
+    };
+
+    const update: UpdateOf<GistTable> = {
+      description: 'Updated',
+    };
+
+    expect(insert.ownerId).toBe('user-1');
+    expect(update.description).toBe('Updated');
+    expect(entity.id).toBe('gist-1');
+    expect(db.tables.gists.name).toBe('gists');
+  });
+});

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,0 +1,28 @@
+export {
+  entitySchemaOf,
+  insertSchemaOf,
+  store,
+  updateSchemaOf,
+} from './store.js';
+export type {
+  AnyStoreDefinition,
+  AnyStoreTable,
+  EntityOf,
+  FiltersOf,
+  GeneratedFieldsOfInput,
+  GeneratedKeysOf,
+  IndexFieldsOfInput,
+  InsertOf,
+  PrimaryKeyOf,
+  ReferencesOfInput,
+  StoreDefinition,
+  StoreFieldKey,
+  StoreIdentifierOf,
+  StoreListOptions,
+  StoreObjectSchema,
+  StoreSearchDefinition,
+  StoreTable,
+  StoreTableInput,
+  StoreTablesInput,
+  UpdateOf,
+} from './types.js';

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,0 +1,285 @@
+import { ValidationError } from '@ontrails/core';
+import type { z } from 'zod';
+
+import type {
+  StoreDefinition,
+  StoreObjectSchema,
+  StoreTable,
+  StoreTableInput,
+  StoreTablesInput,
+} from './types.js';
+
+const isStoreObjectSchema = (schema: z.ZodType): schema is StoreObjectSchema =>
+  schema.def.type === 'object' && 'shape' in schema.def;
+
+const uniqueStrings = <T extends string>(
+  values: readonly T[] | undefined
+): readonly T[] =>
+  Object.freeze([...(values === undefined ? [] : new Set(values))]);
+
+const hasField = (schema: StoreObjectSchema, field: string): boolean =>
+  field in schema.shape;
+
+const validateFieldList = (
+  tableName: string,
+  schema: StoreObjectSchema,
+  fields: readonly string[],
+  label: string
+): void => {
+  for (const field of fields) {
+    if (hasField(schema, field)) {
+      continue;
+    }
+
+    throw new ValidationError(
+      `Store table "${tableName}" declares ${label} field "${field}" that is not present on the schema`
+    );
+  }
+};
+
+const validateReferences = (
+  tableName: string,
+  schema: StoreObjectSchema,
+  references: Readonly<Partial<Record<string, string>>>,
+  tableNames: readonly string[]
+): void => {
+  for (const [field, target] of Object.entries(references)) {
+    if (!hasField(schema, field)) {
+      throw new ValidationError(
+        `Store table "${tableName}" declares reference field "${field}" that is not present on the schema`
+      );
+    }
+
+    if (target !== undefined && tableNames.includes(target)) {
+      continue;
+    }
+
+    throw new ValidationError(
+      `Store table "${tableName}" references unknown table "${target}"`
+    );
+  }
+};
+
+const buildFieldMask = (fields: readonly string[]): Record<string, true> =>
+  Object.fromEntries(fields.map((field) => [field, true] as const)) as Record<
+    string,
+    true
+  >;
+
+const omitFields = <TSchema extends StoreObjectSchema>(
+  schema: TSchema,
+  fields: readonly string[]
+): StoreObjectSchema => {
+  if (fields.length === 0) {
+    return schema;
+  }
+
+  return schema.omit(buildFieldMask(fields)) as StoreObjectSchema;
+};
+
+const deriveInsertSchema = <TSchema extends StoreObjectSchema>(
+  schema: TSchema,
+  generated: readonly string[]
+): StoreObjectSchema => omitFields(schema, generated);
+
+/**
+ * Strip `default` wrappers from a Zod type so that partial update schemas
+ * do not silently re-materialize defaults. Walks through all wrapper layers
+ * (default, optional, nullable), strips defaults, and re-applies non-default
+ * wrappers to preserve the nullable constraint.
+ */
+const stripDefaultWrappers = (schema: z.ZodType): z.ZodType => {
+  const wrappers: ('optional' | 'nullable')[] = [];
+  let current = schema;
+
+  while (
+    current.def.type === 'default' ||
+    current.def.type === 'optional' ||
+    current.def.type === 'nullable'
+  ) {
+    const type = current.def.type as 'default' | 'optional' | 'nullable';
+    if (type !== 'default') {
+      wrappers.push(type);
+    }
+    current = (current.def as unknown as Record<string, unknown>)[
+      'innerType'
+    ] as z.ZodType;
+  }
+
+  // Re-apply nullable wrappers (optional is dropped — .partial() re-adds it)
+  return wrappers.reduceRight(
+    (acc, w) => (w === 'nullable' ? acc.nullable() : acc),
+    current
+  );
+};
+
+const stripDefaultsFromShape = (
+  schema: StoreObjectSchema
+): Record<string, z.ZodType> => {
+  const stripped: Record<string, z.ZodType> = {};
+
+  for (const [field, value] of Object.entries(schema.shape)) {
+    stripped[field] = stripDefaultWrappers(value);
+  }
+
+  return stripped;
+};
+
+const deriveUpdateSchema = (
+  schema: StoreObjectSchema,
+  primaryKey: string
+): StoreObjectSchema => {
+  const partial = schema
+    .extend(stripDefaultsFromShape(schema))
+    .partial() as StoreObjectSchema;
+  // Only omit the primaryKey if it's still present (it may already be in `generated`)
+  return hasField(partial, primaryKey)
+    ? omitFields(partial, [primaryKey])
+    : partial;
+};
+
+const normalizeReferences = (
+  references: Readonly<Partial<Record<string, string>>> | undefined
+): Readonly<Record<string, string>> => {
+  const normalized: Record<string, string> = {};
+
+  for (const [field, target] of Object.entries(references ?? {})) {
+    if (target !== undefined) {
+      normalized[field] = target;
+    }
+  }
+
+  return Object.freeze(normalized);
+};
+
+const validatePrimaryKey = (
+  tableName: string,
+  schema: StoreObjectSchema,
+  primaryKey: string
+): void => {
+  if (hasField(schema, primaryKey)) {
+    return;
+  }
+
+  throw new ValidationError(
+    `Store table "${tableName}" declares primaryKey "${primaryKey}" that is not present on the schema`
+  );
+};
+
+const validateTableInput = (
+  tableName: string,
+  schema: StoreObjectSchema,
+  primaryKey: string,
+  generated: readonly string[],
+  indexes: readonly string[],
+  references: Readonly<Partial<Record<string, string>>>,
+  tableNames: readonly string[]
+): void => {
+  validatePrimaryKey(tableName, schema, primaryKey);
+  validateFieldList(tableName, schema, generated, 'generated');
+  validateFieldList(tableName, schema, indexes, 'index');
+  validateReferences(tableName, schema, references, tableNames);
+};
+
+type MutableTables<TTables extends StoreTablesInput> = {
+  -readonly [TName in keyof TTables]: StoreDefinition<TTables>['tables'][TName];
+};
+
+const normalizeTable = <
+  TName extends string,
+  TInput extends StoreTableInput<StoreObjectSchema>,
+>(
+  name: TName,
+  input: TInput,
+  tableNames: readonly string[]
+): StoreTable<TInput, TName> => {
+  if (!isStoreObjectSchema(input.schema)) {
+    throw new ValidationError(
+      `Store table "${name}" must use a Zod object schema`
+    );
+  }
+
+  const generated = uniqueStrings(input.generated);
+  const indexes = uniqueStrings(input.indexes);
+  const references = normalizeReferences(input.references);
+  validateTableInput(
+    name,
+    input.schema,
+    input.primaryKey,
+    generated,
+    indexes,
+    references,
+    tableNames
+  );
+
+  const insertSchema = deriveInsertSchema(input.schema, generated);
+
+  return Object.freeze({
+    generated,
+    indexes,
+    insertSchema,
+    name,
+    primaryKey: input.primaryKey,
+    references,
+    schema: input.schema,
+    ...(input.search === undefined ? {} : { search: input.search }),
+    updateSchema: deriveUpdateSchema(insertSchema, input.primaryKey),
+  }) as StoreTable<TInput, TName>;
+};
+
+/**
+ * Declare a connector-agnostic store definition from entity schemas and
+ * persistence metadata.
+ *
+ * The returned value is a normalized, read-only contract that connectors can
+ * bind to a concrete runtime later.
+ */
+export const store = <const TTables extends StoreTablesInput>(
+  tables: TTables
+): StoreDefinition<TTables> => {
+  const tableNames = Object.freeze(
+    Object.keys(tables).toSorted()
+  ) as readonly Extract<keyof TTables, string>[];
+
+  const normalized = {} as MutableTables<TTables>;
+  for (const name of tableNames) {
+    const input = tables[name];
+
+    if (input === undefined) {
+      continue;
+    }
+
+    normalized[name] = normalizeTable(name, input, tableNames);
+  }
+
+  const get = <TName extends Extract<keyof TTables, string>>(name: TName) =>
+    normalized[name];
+
+  return Object.freeze({
+    get,
+    kind: 'store' as const,
+    tableNames,
+    tables: Object.freeze(normalized),
+  });
+};
+
+/**
+ * Read the full entity schema from a normalized store table.
+ */
+export const entitySchemaOf = <TTable extends StoreTable>(
+  table: TTable
+): TTable['schema'] => table.schema;
+
+/**
+ * Read the insert schema from a normalized store table.
+ */
+export const insertSchemaOf = <TTable extends StoreTable>(
+  table: TTable
+): TTable['insertSchema'] => table.insertSchema;
+
+/**
+ * Read the update schema from a normalized store table.
+ */
+export const updateSchemaOf = <TTable extends StoreTable>(
+  table: TTable
+): TTable['updateSchema'] => table.updateSchema;

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -107,10 +107,7 @@ const stripDefaultWrappers = (schema: z.ZodType): z.ZodType => {
   }
 
   // Re-apply nullable wrappers (optional is dropped — .partial() re-adds it)
-  return wrappers.reduceRight(
-    (acc, w) => (w === 'nullable' ? acc.nullable() : acc),
-    current
-  );
+  return wrappers.includes('nullable') ? current.nullable() : current;
 };
 
 const stripDefaultsFromShape = (

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -18,7 +18,7 @@ const uniqueStrings = <T extends string>(
   Object.freeze([...(values === undefined ? [] : new Set(values))]);
 
 const hasField = (schema: StoreObjectSchema, field: string): boolean =>
-  field in schema.shape;
+  Object.hasOwn(schema.shape, field);
 
 const validateFieldList = (
   tableName: string,

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -1,0 +1,169 @@
+import type { z } from 'zod';
+
+/**
+ * Object schema accepted by the store definition layer.
+ */
+export type StoreObjectSchema = z.ZodObject<Record<string, z.ZodType>>;
+
+/**
+ * String field names available on a store-backed entity schema.
+ */
+export type StoreFieldKey<TSchema extends StoreObjectSchema> = Extract<
+  keyof z.output<TSchema>,
+  string
+>;
+
+/**
+ * Connector-owned search metadata.
+ *
+ * The core package keeps this opaque on purpose. Search behavior is declared
+ * here and interpreted by a concrete connector later.
+ */
+export type StoreSearchDefinition = Readonly<Record<string, unknown>>;
+
+/**
+ * Authored metadata for one store table.
+ */
+export interface StoreTableInput<
+  TSchema extends StoreObjectSchema = StoreObjectSchema,
+> {
+  readonly generated?: readonly StoreFieldKey<TSchema>[];
+  readonly indexes?: readonly StoreFieldKey<TSchema>[];
+  readonly primaryKey: StoreFieldKey<TSchema>;
+  readonly references?: Readonly<
+    Partial<Record<StoreFieldKey<TSchema>, string>>
+  >;
+  readonly schema: TSchema;
+  readonly search?: StoreSearchDefinition;
+}
+
+/**
+ * Record of authored tables passed to `store(...)`.
+ */
+export type StoreTablesInput = Record<
+  string,
+  StoreTableInput<StoreObjectSchema>
+>;
+
+/**
+ * Preserve generated fields when present, otherwise normalize to an empty tuple.
+ */
+export type GeneratedFieldsOfInput<TInput extends StoreTableInput> =
+  TInput['generated'] extends readonly StoreFieldKey<TInput['schema']>[]
+    ? TInput['generated']
+    : readonly [];
+
+/**
+ * Preserve index fields when present, otherwise normalize to an empty tuple.
+ */
+export type IndexFieldsOfInput<TInput extends StoreTableInput> =
+  TInput['indexes'] extends readonly StoreFieldKey<TInput['schema']>[]
+    ? TInput['indexes']
+    : readonly [];
+
+/**
+ * Preserve references when present, otherwise normalize to an empty object.
+ */
+export type ReferencesOfInput<TInput extends StoreTableInput> =
+  TInput['references'] extends Readonly<
+    Partial<Record<StoreFieldKey<TInput['schema']>, string>>
+  >
+    ? TInput['references']
+    : Readonly<Record<never, never>>;
+
+/**
+ * Generated store table contract derived from authored metadata.
+ */
+export interface StoreTable<
+  TInput extends StoreTableInput = StoreTableInput,
+  TName extends string = string,
+> {
+  readonly generated: GeneratedFieldsOfInput<TInput>;
+  readonly indexes: IndexFieldsOfInput<TInput>;
+  readonly insertSchema: StoreObjectSchema;
+  readonly name: TName;
+  readonly primaryKey: TInput['primaryKey'];
+  readonly references: ReferencesOfInput<TInput>;
+  readonly schema: TInput['schema'];
+  readonly search?: TInput['search'];
+  readonly updateSchema: StoreObjectSchema;
+}
+
+/**
+ * Full store definition returned by `store(...)`.
+ */
+export interface StoreDefinition<
+  TTables extends StoreTablesInput = StoreTablesInput,
+> {
+  readonly get: <TName extends Extract<keyof TTables, string>>(
+    name: TName
+  ) => StoreTable<TTables[TName], TName>;
+  readonly kind: 'store';
+  readonly tableNames: readonly Extract<keyof TTables, string>[];
+  readonly tables: {
+    readonly [TName in keyof TTables]: StoreTable<
+      TTables[TName],
+      Extract<TName, string>
+    >;
+  };
+}
+
+/**
+ * Any normalized store table.
+ */
+export type AnyStoreTable = StoreTable<StoreTableInput, string>;
+
+/**
+ * Any normalized store definition.
+ */
+export type AnyStoreDefinition = StoreDefinition<StoreTablesInput>;
+
+/**
+ * Full entity type represented by one store table.
+ */
+export type EntityOf<TTable extends AnyStoreTable> = z.output<TTable['schema']>;
+
+/**
+ * Primary-key field name for one store table.
+ */
+export type PrimaryKeyOf<TTable extends AnyStoreTable> = TTable['primaryKey'];
+
+/**
+ * Server-managed fields for one store table.
+ */
+export type GeneratedKeysOf<TTable extends AnyStoreTable> =
+  TTable['generated'][number] & string;
+
+/**
+ * Insert shape derived from the entity schema minus generated fields.
+ */
+export type InsertOf<TTable extends AnyStoreTable> = Omit<
+  z.input<TTable['schema']>,
+  GeneratedKeysOf<TTable>
+>;
+
+/**
+ * Update shape derived from the insert shape.
+ */
+export type UpdateOf<TTable extends AnyStoreTable> = Partial<
+  Omit<InsertOf<TTable>, PrimaryKeyOf<TTable>>
+>;
+
+/**
+ * Typed filter shape for list operations.
+ */
+export type FiltersOf<TTable extends AnyStoreTable> = Partial<EntityOf<TTable>>;
+
+/**
+ * Common pagination controls for store list operations.
+ */
+export interface StoreListOptions {
+  readonly limit?: number;
+  readonly offset?: number;
+}
+
+/**
+ * Shared identifier type for read/write accessors.
+ */
+export type StoreIdentifierOf<TTable extends AnyStoreTable> =
+  EntityOf<TTable>[Extract<PrimaryKeyOf<TTable>, keyof EntityOf<TTable>>];

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -22,6 +22,7 @@ fi
 # Packages in dependency order (core first, dependents after)
 PACKAGES=(
   packages/core
+  packages/store
   packages/logging
   packages/schema
   packages/config


### PR DESCRIPTION
## Summary
- Scaffolds `@ontrails/store` as a declaration-only package
- Derives insert and update schemas from normalized Zod definitions
- Strips defaults for honest update semantics
- Adds workspace and release wiring

## What changed
The new `@ontrails/store` package provides a declaration-only API for defining data stores with Zod schemas. Insert schemas include defaults and required fields; update schemas strip defaults so partial updates behave honestly — no silent default injection. The package is wired into the monorepo workspace and release pipeline but intentionally contains no runtime implementation, deferring that to connector packages.

## How it was tested
- bun run build
- bun run test
- bun run typecheck
- bun run lint
- Package-specific tests where applicable

Closes: TRL-133, TRL-153, TRL-154, TRL-155
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
