### PR TITLE
feat: add the drizzle store connector

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@changesets/cli": "^2.29.8",
         "@types/bun": "^1.3.11",
         "@types/node": "^25.5.0",
+        "drizzle-orm": "^0.45.2",
         "lefthook": "^2.1.1",
         "markdownlint-cli2": "^0.22.0",
         "oxfmt": "0.35.0",
@@ -513,6 +514,8 @@
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@changesets/cli": "^2.29.8",
     "@types/bun": "^1.3.11",
     "@types/node": "^25.5.0",
+    "drizzle-orm": "^0.45.2",
     "lefthook": "^2.1.1",
     "markdownlint-cli2": "^0.22.0",
     "oxfmt": "0.35.0",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./drizzle": "./src/drizzle/index.ts",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -17,6 +18,12 @@
     "@ontrails/core": "workspace:^"
   },
   "peerDependencies": {
+    "drizzle-orm": "^0.45.2",
     "zod": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "drizzle-orm": {
+      "optional": true
+    }
   }
 }

--- a/packages/store/src/drizzle/__tests__/drizzle.test.ts
+++ b/packages/store/src/drizzle/__tests__/drizzle.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  AlreadyExistsError,
+  ValidationError,
+  createTrailContext,
+} from '@ontrails/core';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+import { getSchema, readonlyStore, store } from '../index.js';
+
+const userSchema = z.object({
+  email: z.string().email(),
+  id: z.string(),
+});
+
+const gistSchema = z.object({
+  createdAt: z.string(),
+  description: z.string().nullable().default(null),
+  id: z.string(),
+  isPublic: z.boolean().default(true),
+  ownerId: z.string(),
+  tags: z.array(z.string()).default([]),
+  updatedAt: z.string(),
+});
+
+const accountSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+const userTable = {
+  generated: ['id'],
+  primaryKey: 'id',
+  schema: userSchema,
+} as const;
+
+const gistTable = {
+  generated: ['id', 'createdAt', 'updatedAt'],
+  indexes: ['ownerId'],
+  primaryKey: 'id',
+  references: { ownerId: 'users' },
+  schema: gistSchema,
+} as const;
+
+const createProvisionInput = (rootDir: string) => ({
+  config: undefined,
+  cwd: rootDir,
+  env: {},
+  workspaceRoot: rootDir,
+});
+
+const expectOk = async <T>(value: PromiseLike<T> | T): Promise<T> =>
+  await value;
+
+const unwrapCreated = async <T>(
+  value:
+    | PromiseLike<{
+        unwrap(): T;
+      }>
+    | {
+        unwrap(): T;
+      }
+): Promise<T> => {
+  const result = await value;
+  return result.unwrap();
+};
+
+const createWritableDemoStore = (rootDir: string) =>
+  store(
+    {
+      gists: gistTable,
+      users: userTable,
+    },
+    {
+      description: 'Writable demo store',
+      id: 'demo.store',
+      url: join(rootDir, 'demo.sqlite'),
+    }
+  );
+
+const setupWritableDemoStore = async (rootDir: string) => {
+  const db = createWritableDemoStore(rootDir);
+  return {
+    created: await unwrapCreated(db.create(createProvisionInput(rootDir))),
+    db,
+  };
+};
+
+type WritableDemoStoreRuntime = Awaited<
+  ReturnType<typeof setupWritableDemoStore>
+>['created'];
+
+const expectWritableProvisionDefinition = (
+  db: ReturnType<typeof createWritableDemoStore>
+): void => {
+  expect(db.kind).toBe('provision');
+  expect(db.id).toBe('demo.store');
+  expect(db.access).toBe('readwrite');
+  expect(db.mock).toBeDefined();
+  expect(getSchema(db).gists).toBe(db.tables.gists);
+};
+
+const expectInsertedGist = (
+  gist: z.output<typeof gistSchema>,
+  ownerId: string
+): void => {
+  expect(gist).toEqual(
+    expect.objectContaining({
+      createdAt: expect.any(String),
+      description: null,
+      id: expect.any(String),
+      isPublic: true,
+      ownerId,
+      tags: [],
+      updatedAt: expect.any(String),
+    })
+  );
+};
+
+const seedWritableRecords = async (
+  created: WritableDemoStoreRuntime
+): Promise<{
+  readonly gist: z.output<typeof gistSchema>;
+  readonly user: z.output<typeof userSchema>;
+}> => {
+  const user = await expectOk(
+    created.users.insert({ email: 'alice@example.com' })
+  );
+  expect(user.id).toEqual(expect.any(String));
+
+  const gist = await expectOk(
+    created.gists.insert({
+      ownerId: user.id,
+    })
+  );
+  expectInsertedGist(gist, user.id);
+  return { gist, user };
+};
+
+const expectStoredGist = async (
+  created: WritableDemoStoreRuntime,
+  gist: z.output<typeof gistSchema>,
+  ownerId: string
+): Promise<void> => {
+  expect(await created.gists.get(gist.id)).toEqual(gist);
+  expect(await created.gists.list({ ownerId })).toEqual([gist]);
+};
+
+const expectUpdatedGist = async (
+  created: WritableDemoStoreRuntime,
+  gist: z.output<typeof gistSchema>
+): Promise<void> => {
+  const updated = await expectOk(
+    created.gists.update(gist.id, {
+      description: 'Updated',
+    })
+  );
+
+  expect(updated).toEqual(
+    expect.objectContaining({
+      description: 'Updated',
+      id: gist.id,
+    })
+  );
+  expect(updated?.updatedAt).toEqual(expect.any(String));
+  expect(updated?.updatedAt).not.toBe(gist.updatedAt);
+};
+
+const expectQueryEscapeHatch = async (
+  created: WritableDemoStoreRuntime
+): Promise<void> => {
+  const rows = await created.query(({ drizzle, tables }) =>
+    drizzle.select().from(tables.gists).all()
+  );
+  expect(rows).toHaveLength(1);
+};
+
+const expectDeletedGist = async (
+  created: WritableDemoStoreRuntime,
+  gistId: string
+): Promise<void> => {
+  const deleted = await created.gists.remove(gistId);
+  expect(deleted).toEqual({ deleted: true });
+  expect(await created.gists.get(gistId)).toBeNull();
+};
+
+const expectWritableLifecycle = async (
+  created: WritableDemoStoreRuntime
+): Promise<void> => {
+  const { gist, user } = await seedWritableRecords(created);
+  await expectStoredGist(created, gist, user.id);
+  await expectUpdatedGist(created, gist);
+  await expectQueryEscapeHatch(created);
+  await expectDeletedGist(created, gist.id);
+};
+
+const expectProvisionResolution = (
+  db: ReturnType<typeof createWritableDemoStore>,
+  created: WritableDemoStoreRuntime
+): void => {
+  const ctx = createTrailContext({
+    abortSignal: new AbortController().signal,
+    extensions: {
+      [db.id]: created,
+    },
+    requestId: 'store-drizzle',
+  });
+  expect(db.from(ctx).users).toBeDefined();
+};
+
+const createFixtureBackedStore = () =>
+  store(
+    {
+      gists: {
+        ...gistTable,
+        fixtures: [
+          {
+            id: 'gist-seed',
+            ownerId: 'user-seed',
+          },
+        ],
+      },
+      users: {
+        ...userTable,
+        fixtures: [
+          {
+            email: 'seed@example.com',
+            id: 'user-seed',
+          },
+        ],
+      },
+    },
+    {
+      id: 'demo.store.mock',
+      url: ':memory:',
+    }
+  );
+
+const createWritableSeedStore = (url: string) =>
+  store(
+    {
+      users: userTable,
+    },
+    {
+      id: 'demo.store.seed',
+      url,
+    }
+  );
+
+const seedReadonlyFixture = async (
+  url: string,
+  rootDir: string
+): Promise<z.output<typeof userSchema>> => {
+  const writable = createWritableSeedStore(url);
+  const seeded = await unwrapCreated(
+    writable.create(createProvisionInput(rootDir))
+  );
+  const inserted = await seeded.users.insert({ email: 'seed@example.com' });
+  await writable.dispose?.(seeded);
+  return inserted;
+};
+
+const createReadonlyUserStore = (url: string) =>
+  readonlyStore(
+    {
+      users: userTable,
+    },
+    {
+      id: 'demo.store.readonly',
+      url,
+    }
+  );
+
+const setupReadonlyUserStore = async (url: string, rootDir: string) => {
+  const db = createReadonlyUserStore(url);
+  return {
+    created: await unwrapCreated(db.create(createProvisionInput(rootDir))),
+    db,
+  };
+};
+
+type ReadonlyUserStoreRuntime = Awaited<
+  ReturnType<typeof setupReadonlyUserStore>
+>['created'];
+
+const expectReadonlyReads = async (
+  created: ReadonlyUserStoreRuntime,
+  inserted: z.output<typeof userSchema>
+): Promise<void> => {
+  expect(await created.users.get(inserted.id)).toEqual(inserted);
+  expect(await created.users.list()).toEqual([inserted]);
+};
+
+const expectReadonlyWriteFailure = async (
+  created: ReadonlyUserStoreRuntime
+): Promise<void> => {
+  await expect(
+    created.query(({ drizzle, tables }) =>
+      drizzle
+        .insert(tables.users)
+        .values({ email: 'blocked@example.com', id: 'blocked' })
+        .run()
+    )
+  ).rejects.toThrow();
+};
+
+const createErrorStore = (rootDir: string) =>
+  store(
+    {
+      accounts: {
+        primaryKey: 'id',
+        schema: accountSchema,
+      },
+      gists: {
+        ...gistTable,
+        references: { ownerId: 'accounts' },
+      },
+    },
+    {
+      id: 'demo.store.errors',
+      url: join(rootDir, 'errors.sqlite'),
+    }
+  );
+
+describe('@ontrails/store/drizzle', () => {
+  let tmpRoot: string | undefined;
+
+  afterEach(() => {
+    if (tmpRoot !== undefined) {
+      rmSync(tmpRoot, { force: true, recursive: true });
+      tmpRoot = undefined;
+    }
+  });
+
+  const makeRoot = (): string => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'store-drizzle-'));
+    return tmpRoot;
+  };
+
+  test('binds a writable provision with CRUD accessors and one escape hatch', async () => {
+    const rootDir = makeRoot();
+    const { created, db } = await setupWritableDemoStore(rootDir);
+    expectWritableProvisionDefinition(db);
+    await expectWritableLifecycle(created);
+    expectProvisionResolution(db, created);
+    await db.dispose?.(created);
+  });
+
+  test('creates a writable mock provision seeded from fixtures', async () => {
+    const db = createFixtureBackedStore();
+
+    const mock = await db.mock?.();
+    expect(mock).toBeDefined();
+    expect(await mock?.users.get('user-seed')).toEqual(
+      expect.objectContaining({
+        email: 'seed@example.com',
+        id: 'user-seed',
+      })
+    );
+    expect(await mock?.gists.get('gist-seed')).toEqual(
+      expect.objectContaining({
+        createdAt: expect.any(String),
+        description: null,
+        id: 'gist-seed',
+        isPublic: true,
+        ownerId: 'user-seed',
+        updatedAt: expect.any(String),
+      })
+    );
+  });
+
+  test('opens a read-only store without a mock and enforces writes at the database layer', async () => {
+    const rootDir = makeRoot();
+    const url = join(rootDir, 'readonly.sqlite');
+    const inserted = await seedReadonlyFixture(url, rootDir);
+    const { created, db: readOnly } = await setupReadonlyUserStore(
+      url,
+      rootDir
+    );
+    expect(readOnly.access).toBe('readonly');
+    expect(readOnly.mock).toBeUndefined();
+    await expectReadonlyReads(created, inserted);
+    await expectReadonlyWriteFailure(created);
+    await readOnly.dispose?.(created);
+  });
+
+  test('maps primary-key and foreign-key failures into Trails errors', async () => {
+    const rootDir = makeRoot();
+    const db = createErrorStore(rootDir);
+    const created = await unwrapCreated(
+      db.create(createProvisionInput(rootDir))
+    );
+
+    await created.accounts.insert({
+      id: 'acct-1',
+      name: 'Alpha',
+    });
+
+    await expect(
+      created.accounts.insert({
+        id: 'acct-1',
+        name: 'Duplicate',
+      })
+    ).rejects.toBeInstanceOf(AlreadyExistsError);
+
+    await expect(
+      created.gists.insert({
+        ownerId: 'missing-account',
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+
+    await db.dispose?.(created);
+  });
+
+  test('maps z.number().int() to INTEGER (Zod internals regression guard)', () => {
+    const intStore = store(
+      {
+        counters: {
+          generated: ['id'],
+          primaryKey: 'id',
+          schema: z.object({
+            id: z.number().int(),
+            value: z.number(),
+          }),
+        },
+      },
+      { url: join(makeRoot(), 'int.sqlite') }
+    );
+
+    const schema = getSchema(intStore);
+    const col = schema.counters;
+    expect(col).toBeDefined();
+
+    const idColumn = col.id as unknown as { columnType: string };
+    expect(idColumn.columnType).toBe('SQLiteInteger');
+  });
+
+  test('update returns null for a non-existent ID', async () => {
+    const db = createFixtureBackedStore();
+    const mock = await db.mock?.();
+    expect(mock).toBeDefined();
+
+    const result = await mock?.gists.update('ghost-id', {
+      description: 'nope',
+    });
+    expect(result).toBeNull();
+  });
+
+  test('update rejects empty fields even when updatedAt is generated', async () => {
+    const db = createFixtureBackedStore();
+    const mock = await db.mock?.();
+    expect(mock).toBeDefined();
+
+    await expect(mock?.gists.update('gist-seed', {})).rejects.toBeInstanceOf(
+      ValidationError
+    );
+  });
+});

--- a/packages/store/src/drizzle/__tests__/drizzle.test.ts
+++ b/packages/store/src/drizzle/__tests__/drizzle.test.ts
@@ -187,6 +187,13 @@ const expectDeletedGist = async (
   expect(await created.gists.get(gistId)).toBeNull();
 };
 
+const expectMissingGistDelete = async (
+  created: WritableDemoStoreRuntime
+): Promise<void> => {
+  const deleted = await created.gists.remove('non-existent-id');
+  expect(deleted).toEqual({ deleted: false });
+};
+
 const expectWritableLifecycle = async (
   created: WritableDemoStoreRuntime
 ): Promise<void> => {
@@ -195,6 +202,7 @@ const expectWritableLifecycle = async (
   await expectUpdatedGist(created, gist);
   await expectQueryEscapeHatch(created);
   await expectDeletedGist(created, gist.id);
+  await expectMissingGistDelete(created);
 };
 
 const expectProvisionResolution = (

--- a/packages/store/src/drizzle/index.ts
+++ b/packages/store/src/drizzle/index.ts
@@ -1,0 +1,17 @@
+export {
+  connectDrizzle,
+  connectReadOnlyDrizzle,
+  getSchema,
+  readonlyStore,
+  store,
+} from './runtime.js';
+export type {
+  ConnectDrizzleOptions,
+  DrizzleMockSeed,
+  DrizzleQueryContext,
+  DrizzleStoreConnection,
+  DrizzleStoreProvision,
+  DrizzleStoreSchema,
+  ReadOnlyDrizzleOptions,
+  ReadOnlyDrizzleStoreConnection,
+} from './types.js';

--- a/packages/store/src/drizzle/runtime.ts
+++ b/packages/store/src/drizzle/runtime.ts
@@ -82,7 +82,11 @@ const closeConnection = (connection: object): void => {
 };
 
 const mapDatabaseError = (tableName: string, error: unknown): Error => {
-  if (error instanceof ValidationError || error instanceof AlreadyExistsError) {
+  if (
+    error instanceof ValidationError ||
+    error instanceof AlreadyExistsError ||
+    error instanceof InternalError
+  ) {
     return error;
   }
 
@@ -371,6 +375,18 @@ const primaryKeyColumn = (
   field: string
 ): AnySQLiteColumn => table[field as keyof typeof table] as AnySQLiteColumn;
 
+const buildFilterConditions = (
+  drizzleTable: AnySQLiteTable,
+  filters: Record<string, unknown> | undefined
+): ReturnType<typeof eq>[] =>
+  filters === undefined
+    ? []
+    : Object.entries(filters)
+        .filter(([, value]) => value !== undefined)
+        .map(([field, value]) =>
+          eq(primaryKeyColumn(drizzleTable, field), value as never)
+        );
+
 const createReadOnlyAccessor = <
   TStore extends AnyStoreDefinition,
   TName extends keyof TStore['tables'] & string,
@@ -403,30 +419,20 @@ const createReadOnlyAccessor = <
   },
   list(filters, options) {
     try {
-      let query = db.select().from(drizzleTable).$dynamic();
-      const conditions =
-        filters === undefined
-          ? []
-          : Object.entries(filters)
-              .filter(([, value]) => value !== undefined)
-              .map(([field, value]) =>
-                eq(primaryKeyColumn(drizzleTable, field), value as never)
-              );
-
-      if (conditions.length > 0) {
-        query = query.where(and(...conditions));
-      }
-
-      if (options?.limit !== undefined) {
-        query = query.limit(options.limit);
-      }
-
-      if (options?.offset !== undefined) {
-        query = query.offset(options.offset);
-      }
+      const conditions = buildFilterConditions(
+        drizzleTable,
+        filters as Record<string, unknown> | undefined
+      );
+      const base = db.select().from(drizzleTable).$dynamic();
+      const filtered =
+        conditions.length > 0 ? base.where(and(...conditions)) : base;
+      const rows = filtered
+        .limit(options?.limit ?? -1)
+        .offset(options?.offset ?? 0)
+        .all();
 
       return Promise.resolve(
-        query.all().map((row) => cloneValue(parseEntity(definitionTable, row)))
+        rows.map((row) => cloneValue(parseEntity(definitionTable, row)))
       );
     } catch (error) {
       return Promise.reject(mapDatabaseError(definitionTable.name, error));

--- a/packages/store/src/drizzle/runtime.ts
+++ b/packages/store/src/drizzle/runtime.ts
@@ -152,45 +152,65 @@ const baseFieldKind = <TTable extends AnyStoreTable>(
     table.schema.shape[field as keyof typeof table.schema.shape] as z.ZodType
   ).kind;
 
+const TIMESTAMP_FIELD_NAMES = new Set([
+  'createdAt',
+  'updatedAt',
+  'created_at',
+  'updated_at',
+]);
+
+const ID_FIELD_SUFFIX_RE = /[Ii]d$/;
+
 /**
  * Synthesize a value for a generated field during insert.
  *
  * The connector recognizes these conventions for generated fields:
  *
  * - **Primary key** (`integer` type): auto-increment, left to SQLite.
- * - **`createdAt` / `updatedAt`**: materialized as `new Date()` (date type)
- *   or ISO 8601 string (text type). Fields must be named exactly
- *   `createdAt` or `updatedAt` — other timestamp names like `modifiedAt`
- *   or `created_at` are not recognized and will produce a `ValidationError`.
- * - **Text fields**: filled with `Bun.randomUUIDv7()`.
+ * - **Timestamp fields** (`createdAt`, `updatedAt`, `created_at`,
+ *   `updated_at`): materialized as `new Date()` (date type) or ISO 8601
+ *   string (text type).
+ * - **ID-like text fields** (name ends with `Id` or `id`): filled with
+ *   `Bun.randomUUIDv7()`.
+ *
+ * Any other generated `text` field that does not match a recognized convention
+ * throws a `ValidationError` — the developer must either supply a value or
+ * give the field a Zod default.
  *
  * All other generated field types fall through to `undefined`, letting the
  * schema's Zod default (if any) apply during validation.
  */
+const generatedTimestamp = (kind: string): unknown =>
+  kind === 'date' ? new Date() : new Date().toISOString();
+
+const generatedTextValue = (tableName: string, fieldName: string): unknown => {
+  if (ID_FIELD_SUFFIX_RE.test(fieldName)) {
+    return Bun.randomUUIDv7();
+  }
+  throw new ValidationError(
+    `Store table "${tableName}" has a generated text field "${fieldName}" that does not match a recognized convention (timestamp or ID field). Supply a value or add a Zod default.`
+  );
+};
+
 const generatedValueForInsert = <TTable extends AnyStoreTable>(
   table: TTable,
   field: StoreFieldKey<TTable['schema']>
 ): unknown => {
+  const fieldName = field as string;
   const kind = baseFieldKind(table, field);
 
   if (field === table.primaryKey && kind === 'integer') {
     return undefined;
   }
-
-  if (field === 'createdAt' || field === 'updatedAt') {
-    if (kind === 'date') {
-      return new Date();
-    }
-
-    return new Date().toISOString();
+  if (TIMESTAMP_FIELD_NAMES.has(fieldName)) {
+    return generatedTimestamp(kind);
   }
-
   if (kind === 'text') {
-    return Bun.randomUUIDv7();
+    return generatedTextValue(table.name, fieldName);
   }
-
-  // Unrecognized generated field — return undefined so Zod defaults apply.
-  return undefined;
+  throw new ValidationError(
+    `Store table "${table.name}" has a generated field "${fieldName}" of unrecognized type "${kind}". Only "integer" (primary key), "text", and timestamp fields are supported as generated fields. Supply a value or add a Zod default.`
+  );
 };
 
 const materializeGeneratedFields = <TTable extends AnyStoreTable>(
@@ -528,35 +548,66 @@ const createWritableAccessor = <
   },
 });
 
-const seedFixtures = <TStore extends AnyStoreDefinition>(
+/** Collect non-empty fixture arrays keyed by table name. */
+const collectFixtures = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  seed?: DrizzleMockSeed<TStore>
+): Map<string, readonly FixtureInputOf<AnyStoreTable>[]> => {
+  const result = new Map<string, readonly FixtureInputOf<AnyStoreTable>[]>();
+  for (const tableName of definition.tableNames) {
+    const table = definition.tables[tableName];
+    if (table === undefined) {
+      continue;
+    }
+    const fixtures =
+      (seed?.[tableName] as
+        | readonly FixtureInputOf<typeof table>[]
+        | undefined) ?? table.fixtures;
+    if (fixtures.length > 0) {
+      result.set(tableName, fixtures);
+    }
+  }
+  return result;
+};
+
+/** Insert fixture rows in topological order. */
+const insertFixtureRows = <TStore extends AnyStoreDefinition>(
   definition: TStore,
   tables: DrizzleStoreSchema<TStore>,
   db: ReturnType<typeof drizzle<DrizzleStoreSchema<TStore>>>,
-  seed?: DrizzleMockSeed<TStore>
+  fixturesByTable: Map<string, readonly FixtureInputOf<AnyStoreTable>[]>
 ): void => {
   for (const tableName of topologicalTableOrder(definition)) {
-    const definitionTable = definition.tables[tableName];
+    const defTable = definition.tables[tableName];
     const drizzleTable = tables[tableName];
-    if (definitionTable === undefined || drizzleTable === undefined) {
+    const fixtures = fixturesByTable.get(tableName);
+    if (!defTable || !drizzleTable || !fixtures) {
       continue;
     }
-
-    const fixtures =
-      (seed?.[tableName] as
-        | readonly FixtureInputOf<typeof definitionTable>[]
-        | undefined) ?? definitionTable.fixtures;
-
     for (const fixture of fixtures) {
       db.insert(drizzleTable)
         .values(
           applyGeneratedInsertFields(
-            definitionTable,
+            defTable,
             fixture as Record<string, unknown>
           ) as never
         )
         .run();
     }
   }
+};
+
+const seedFixtures = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  tables: DrizzleStoreSchema<TStore>,
+  db: ReturnType<typeof drizzle<DrizzleStoreSchema<TStore>>>,
+  seed?: DrizzleMockSeed<TStore>
+): void => {
+  const fixturesByTable = collectFixtures(definition, seed);
+  if (fixturesByTable.size === 0) {
+    return;
+  }
+  insertFixtureRows(definition, tables, db, fixturesByTable);
 };
 
 const createReadOnlyConnection = <TStore extends AnyStoreDefinition>(
@@ -669,7 +720,7 @@ const connectionHealth = (
  * factory creates an in-memory SQLite database seeded with fixtures — callers
  * who obtain a mock connection are responsible for calling `closeConnection()`
  * when done, or letting the connection be garbage-collected (the underlying
- * `Database` client is tracked via `WeakRef`).
+ * `Database` client is tracked via `WeakMap`).
  *
  * Note: the `search` field on `StoreTableInput` is not yet interpreted by
  * this connector — it is reserved for future full-text search support.
@@ -687,18 +738,26 @@ export const connectDrizzle = <const TStore extends AnyStoreDefinition>(
   return buildProvisionShape(
     provision(options.id ?? defaultProvisionId, {
       create: () => {
-        const client = openSqliteDatabase(options.url, false);
         try {
-          ensureSqliteSchema(client, definition);
+          const client = openSqliteDatabase(options.url, false);
+          try {
+            ensureSqliteSchema(client, definition);
+          } catch (error) {
+            client.close();
+            throw error;
+          }
+          const db = drizzle({ client, schema: tables });
+          return Result.ok(
+            createWritableConnection(definition, tables, db, client)
+          );
         } catch (error) {
-          client.close();
-          throw error;
+          return Result.err(
+            new InternalError(
+              `Drizzle store failed to open database at "${options.url}": ${asError(error).message}`,
+              { cause: asError(error) }
+            )
+          );
         }
-        const db = drizzle({ client, schema: tables });
-
-        return Result.ok(
-          createWritableConnection(definition, tables, db, client)
-        );
       },
       description:
         options.description ??
@@ -739,12 +798,20 @@ export const connectReadOnlyDrizzle = <const TStore extends AnyStoreDefinition>(
   return buildProvisionShape(
     provision(options.id ?? defaultProvisionId, {
       create: () => {
-        const client = openSqliteDatabase(options.url, true);
-        const db = drizzle({ client, schema: tables });
-
-        return Result.ok(
-          createReadOnlyConnection(definition, tables, db, client)
-        );
+        try {
+          const client = openSqliteDatabase(options.url, true);
+          const db = drizzle({ client, schema: tables });
+          return Result.ok(
+            createReadOnlyConnection(definition, tables, db, client)
+          );
+        } catch (error) {
+          return Result.err(
+            new InternalError(
+              `Drizzle read-only store failed to open database at "${options.url}": ${asError(error).message}`,
+              { cause: asError(error) }
+            )
+          );
+        }
       },
       description:
         options.description ??

--- a/packages/store/src/drizzle/runtime.ts
+++ b/packages/store/src/drizzle/runtime.ts
@@ -1,0 +1,780 @@
+import { Database } from 'bun:sqlite';
+import {
+  AlreadyExistsError,
+  InternalError,
+  Result,
+  ValidationError,
+  provision,
+} from '@ontrails/core';
+import { and, eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import type { AnySQLiteColumn, AnySQLiteTable } from 'drizzle-orm/sqlite-core';
+import type { z } from 'zod';
+
+import { store as defineStore } from '../store.js';
+import type {
+  AnyStoreDefinition,
+  AnyStoreTable,
+  EntityOf,
+  FixtureInputOf,
+  InsertOf,
+  ReadOnlyStoreConnection,
+  StoreAccessMode,
+  StoreConnection,
+  StoreFieldKey,
+  StoreTablesInput,
+  UpdateOf,
+} from '../types.js';
+import {
+  createSqliteSchemaStatements,
+  describeField,
+  deriveDrizzleTables,
+} from './schema.js';
+import type {
+  ConnectDrizzleOptions,
+  DrizzleMockSeed,
+  DrizzleStoreConnection,
+  DrizzleStoreProvision,
+  DrizzleStoreSchema,
+  ReadOnlyDrizzleOptions,
+  ReadOnlyDrizzleStoreConnection,
+} from './types.js';
+
+const defaultProvisionId = 'store';
+const connectionClients = new WeakMap<object, Database>();
+
+const cloneValue = <T>(value: T): T => structuredClone(value);
+
+const openSqliteDatabase = (url: string, readOnly: boolean): Database => {
+  const client = new Database(
+    url,
+    readOnly ? { readonly: true } : { create: true }
+  );
+  client.run('PRAGMA foreign_keys = ON');
+
+  if (!readOnly) {
+    client.run('PRAGMA journal_mode = WAL');
+    client.run('PRAGMA synchronous = NORMAL');
+  }
+
+  return client;
+};
+
+const asError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const storeTableNames = <TStore extends AnyStoreDefinition>(
+  definition: TStore
+): readonly Extract<keyof TStore['tables'], string>[] =>
+  definition.tableNames as readonly Extract<keyof TStore['tables'], string>[];
+
+const registerConnection = <TConnection extends object>(
+  connection: TConnection,
+  client: Database
+): TConnection => {
+  connectionClients.set(connection, client);
+  return connection;
+};
+
+const closeConnection = (connection: object): void => {
+  connectionClients.get(connection)?.close();
+  connectionClients.delete(connection);
+};
+
+const mapDatabaseError = (tableName: string, error: unknown): Error => {
+  if (error instanceof ValidationError || error instanceof AlreadyExistsError) {
+    return error;
+  }
+
+  // ZodError from .parse() should surface as ValidationError, not InternalError.
+  const resolved = asError(error);
+  if (resolved.name === 'ZodError') {
+    return new ValidationError(
+      `Store table "${tableName}" input failed schema validation: ${resolved.message}`,
+      { cause: resolved }
+    );
+  }
+  if (resolved.message.includes('UNIQUE constraint failed')) {
+    return new AlreadyExistsError(
+      `Drizzle store insert for table "${tableName}" violated a uniqueness constraint`,
+      { cause: resolved }
+    );
+  }
+
+  if (resolved.message.includes('FOREIGN KEY constraint failed')) {
+    return new ValidationError(
+      `Drizzle store insert for table "${tableName}" violated a foreign key constraint`,
+      { cause: resolved }
+    );
+  }
+
+  return new InternalError(
+    `Drizzle store encountered an unexpected error for table "${tableName}": ${resolved.message}`,
+    { cause: resolved }
+  );
+};
+
+const formatIssues = (
+  issues: readonly { readonly message: string }[]
+): string => issues.map((issue) => issue.message).join('; ');
+
+const parseEntity = <TTable extends AnyStoreTable>(
+  table: TTable,
+  value: unknown
+): EntityOf<TTable> => {
+  const parsed = table.schema.safeParse(value);
+  if (!parsed.success) {
+    throw new InternalError(
+      `Drizzle store for table "${table.name}" returned an entity that does not match the schema: ${formatIssues(parsed.error.issues)}`
+    );
+  }
+
+  return parsed.data as EntityOf<TTable>;
+};
+
+const normalizeWriteInput = (
+  input: Record<string, unknown>
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(input).filter(([, value]) => value !== undefined)
+  );
+
+const baseFieldKind = <TTable extends AnyStoreTable>(
+  table: TTable,
+  field: StoreFieldKey<TTable['schema']>
+): string =>
+  describeField(
+    field as string,
+    table.schema.shape[field as keyof typeof table.schema.shape] as z.ZodType
+  ).kind;
+
+/**
+ * Synthesize a value for a generated field during insert.
+ *
+ * The connector recognizes these conventions for generated fields:
+ *
+ * - **Primary key** (`integer` type): auto-increment, left to SQLite.
+ * - **`createdAt` / `updatedAt`**: materialized as `new Date()` (date type)
+ *   or ISO 8601 string (text type). Fields must be named exactly
+ *   `createdAt` or `updatedAt` — other timestamp names like `modifiedAt`
+ *   or `created_at` are not recognized and will produce a `ValidationError`.
+ * - **Text fields**: filled with `Bun.randomUUIDv7()`.
+ *
+ * All other generated field types fall through to `undefined`, letting the
+ * schema's Zod default (if any) apply during validation.
+ */
+const generatedValueForInsert = <TTable extends AnyStoreTable>(
+  table: TTable,
+  field: StoreFieldKey<TTable['schema']>
+): unknown => {
+  const kind = baseFieldKind(table, field);
+
+  if (field === table.primaryKey && kind === 'integer') {
+    return undefined;
+  }
+
+  if (field === 'createdAt' || field === 'updatedAt') {
+    if (kind === 'date') {
+      return new Date();
+    }
+
+    return new Date().toISOString();
+  }
+
+  if (kind === 'text') {
+    return Bun.randomUUIDv7();
+  }
+
+  // Unrecognized generated field — return undefined so Zod defaults apply.
+  return undefined;
+};
+
+const materializeGeneratedFields = <TTable extends AnyStoreTable>(
+  table: TTable,
+  input: Record<string, unknown>
+): Record<string, unknown> => {
+  const next = { ...input };
+
+  for (const field of table.generated) {
+    if (next[field] !== undefined) {
+      continue;
+    }
+
+    const generated = generatedValueForInsert(
+      table,
+      field as StoreFieldKey<TTable['schema']>
+    );
+    if (generated !== undefined) {
+      next[field] = generated;
+    }
+  }
+
+  return next;
+};
+
+const validateFixturePayload = <TTable extends AnyStoreTable>(
+  table: TTable,
+  input: Record<string, unknown>
+): Record<string, unknown> => {
+  const parsed = table.fixtureSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new ValidationError(
+      `Store table "${table.name}" insert payload is invalid after generated-field materialization: ${formatIssues(parsed.error.issues)}`
+    );
+  }
+
+  return normalizeWriteInput(parsed.data as Record<string, unknown>);
+};
+
+const applyGeneratedInsertFields = <TTable extends AnyStoreTable>(
+  table: TTable,
+  input: Record<string, unknown>
+): Record<string, unknown> =>
+  validateFixturePayload(table, materializeGeneratedFields(table, input));
+
+const applyGeneratedUpdateFields = <TTable extends AnyStoreTable>(
+  table: TTable,
+  input: Record<string, unknown>
+): Record<string, unknown> => {
+  const updatedAtKey = (['updatedAt', 'updated_at'] as const).find((key) =>
+    table.generated.includes(key as StoreFieldKey<TTable['schema']>)
+  );
+
+  if (!updatedAtKey) {
+    return normalizeWriteInput(input);
+  }
+
+  const kind = baseFieldKind(
+    table,
+    updatedAtKey as StoreFieldKey<TTable['schema']>
+  );
+
+  return normalizeWriteInput({
+    ...input,
+    [updatedAtKey]:
+      input[updatedAtKey] ??
+      (kind === 'date' ? new Date() : new Date().toISOString()),
+  });
+};
+
+interface VisitFrame {
+  readonly expanded: boolean;
+  readonly tableName: string;
+}
+
+const ensureNotCyclic = (
+  visiting: ReadonlySet<string>,
+  tableName: string
+): void => {
+  if (!visiting.has(tableName)) {
+    return;
+  }
+
+  throw new ValidationError(
+    `Store definition contains a reference cycle involving "${tableName}", which the SQLite connector cannot seed automatically`
+  );
+};
+
+const pushVisitDependencies = (
+  stack: VisitFrame[],
+  definition: AnyStoreDefinition,
+  visited: ReadonlySet<string>,
+  tableName: string
+): void => {
+  const table = definition.tables[tableName];
+  if (table === undefined) {
+    return;
+  }
+
+  for (const target of Object.values(table.references).toReversed()) {
+    if (target !== undefined && !visited.has(target)) {
+      stack.push({ expanded: false, tableName: target });
+    }
+  }
+};
+
+const finishVisitFrame = (
+  frame: VisitFrame,
+  visiting: Set<string>,
+  visited: Set<string>,
+  ordered: string[]
+): void => {
+  visiting.delete(frame.tableName);
+  visited.add(frame.tableName);
+  ordered.push(frame.tableName);
+};
+
+const startVisitFrame = (
+  stack: VisitFrame[],
+  definition: AnyStoreDefinition,
+  visiting: Set<string>,
+  visited: Set<string>,
+  tableName: string
+): void => {
+  ensureNotCyclic(visiting, tableName);
+  visiting.add(tableName);
+  stack.push({ expanded: true, tableName });
+  pushVisitDependencies(stack, definition, visited, tableName);
+};
+
+const visitTableForSeeding = (
+  definition: AnyStoreDefinition,
+  visiting: Set<string>,
+  visited: Set<string>,
+  ordered: string[],
+  tableName: string
+): void => {
+  const stack: VisitFrame[] = [{ expanded: false, tableName }];
+
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (frame === undefined) {
+      continue;
+    }
+
+    if (frame.expanded) {
+      finishVisitFrame(frame, visiting, visited, ordered);
+      continue;
+    }
+
+    if (!visited.has(frame.tableName)) {
+      startVisitFrame(stack, definition, visiting, visited, frame.tableName);
+    }
+  }
+};
+
+const topologicalTableOrder = (
+  definition: AnyStoreDefinition
+): readonly string[] => {
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+  const ordered: string[] = [];
+
+  for (const tableName of definition.tableNames) {
+    visitTableForSeeding(definition, visiting, visited, ordered, tableName);
+  }
+
+  return Object.freeze(ordered);
+};
+
+const ensureSqliteSchema = (
+  client: Database,
+  definition: AnyStoreDefinition
+): void => {
+  for (const statement of createSqliteSchemaStatements(definition)) {
+    client.run(statement);
+  }
+};
+
+const primaryKeyColumn = (
+  table: AnySQLiteTable,
+  field: string
+): AnySQLiteColumn => table[field as keyof typeof table] as AnySQLiteColumn;
+
+const createReadOnlyAccessor = <
+  TStore extends AnyStoreDefinition,
+  TName extends keyof TStore['tables'] & string,
+>(
+  definitionTable: TStore['tables'][TName],
+  drizzleTable: DrizzleStoreSchema<TStore>[TName],
+  db: ReturnType<typeof drizzle<DrizzleStoreSchema<TStore>>>
+): ReadOnlyStoreConnection<TStore>[TName] => ({
+  get(id) {
+    try {
+      const row = db
+        .select()
+        .from(drizzleTable)
+        .where(
+          eq(
+            primaryKeyColumn(drizzleTable, definitionTable.primaryKey),
+            id as never
+          )
+        )
+        .get();
+
+      return Promise.resolve(
+        row === null || row === undefined
+          ? null
+          : cloneValue(parseEntity(definitionTable, row))
+      );
+    } catch (error) {
+      return Promise.reject(mapDatabaseError(definitionTable.name, error));
+    }
+  },
+  list(filters, options) {
+    try {
+      let query = db.select().from(drizzleTable).$dynamic();
+      const conditions =
+        filters === undefined
+          ? []
+          : Object.entries(filters)
+              .filter(([, value]) => value !== undefined)
+              .map(([field, value]) =>
+                eq(primaryKeyColumn(drizzleTable, field), value as never)
+              );
+
+      if (conditions.length > 0) {
+        query = query.where(and(...conditions));
+      }
+
+      if (options?.limit !== undefined) {
+        query = query.limit(options.limit);
+      }
+
+      if (options?.offset !== undefined) {
+        query = query.offset(options.offset);
+      }
+
+      return Promise.resolve(
+        query.all().map((row) => cloneValue(parseEntity(definitionTable, row)))
+      );
+    } catch (error) {
+      return Promise.reject(mapDatabaseError(definitionTable.name, error));
+    }
+  },
+});
+
+const createWritableAccessor = <
+  TStore extends AnyStoreDefinition,
+  TName extends keyof TStore['tables'] & string,
+>(
+  definitionTable: TStore['tables'][TName],
+  drizzleTable: DrizzleStoreSchema<TStore>[TName],
+  db: ReturnType<typeof drizzle<DrizzleStoreSchema<TStore>>>
+): StoreConnection<TStore>[TName] => ({
+  ...createReadOnlyAccessor(definitionTable, drizzleTable, db),
+  insert(input) {
+    try {
+      const parsed = definitionTable.insertSchema.parse(input) as InsertOf<
+        TStore['tables'][TName]
+      >;
+      const row = db
+        .insert(drizzleTable)
+        .values(
+          applyGeneratedInsertFields(
+            definitionTable,
+            parsed as Record<string, unknown>
+          ) as never
+        )
+        .returning()
+        .get();
+
+      return Promise.resolve(cloneValue(parseEntity(definitionTable, row)));
+    } catch (error) {
+      return Promise.reject(mapDatabaseError(definitionTable.name, error));
+    }
+  },
+  remove(id) {
+    try {
+      const deleted = db
+        .delete(drizzleTable)
+        .where(
+          eq(
+            primaryKeyColumn(drizzleTable, definitionTable.primaryKey),
+            id as never
+          )
+        )
+        .returning({
+          deletedId: primaryKeyColumn(drizzleTable, definitionTable.primaryKey),
+        })
+        .get();
+
+      return Promise.resolve({ deleted: deleted !== undefined });
+    } catch (error) {
+      return Promise.reject(mapDatabaseError(definitionTable.name, error));
+    }
+  },
+  update(id, input) {
+    try {
+      const parsed = definitionTable.updateSchema.parse(input) as UpdateOf<
+        TStore['tables'][TName]
+      >;
+      const userFields = normalizeWriteInput(parsed as Record<string, unknown>);
+      if (Object.keys(userFields).length === 0) {
+        return Promise.reject(
+          new ValidationError(
+            `Store table "${definitionTable.name}" update requires at least one field to set.`
+          )
+        );
+      }
+      const fields = applyGeneratedUpdateFields(
+        definitionTable,
+        parsed as Record<string, unknown>
+      );
+      const row = db
+        .update(drizzleTable)
+        .set(fields as never)
+        .where(
+          eq(
+            primaryKeyColumn(drizzleTable, definitionTable.primaryKey),
+            id as never
+          )
+        )
+        .returning()
+        .get();
+
+      return Promise.resolve(
+        row === undefined ? null : cloneValue(parseEntity(definitionTable, row))
+      );
+    } catch (error) {
+      return Promise.reject(mapDatabaseError(definitionTable.name, error));
+    }
+  },
+});
+
+const seedFixtures = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  tables: DrizzleStoreSchema<TStore>,
+  db: ReturnType<typeof drizzle<DrizzleStoreSchema<TStore>>>,
+  seed?: DrizzleMockSeed<TStore>
+): void => {
+  for (const tableName of topologicalTableOrder(definition)) {
+    const definitionTable = definition.tables[tableName];
+    const drizzleTable = tables[tableName];
+    if (definitionTable === undefined || drizzleTable === undefined) {
+      continue;
+    }
+
+    const fixtures =
+      (seed?.[tableName] as
+        | readonly FixtureInputOf<typeof definitionTable>[]
+        | undefined) ?? definitionTable.fixtures;
+
+    for (const fixture of fixtures) {
+      db.insert(drizzleTable)
+        .values(
+          applyGeneratedInsertFields(
+            definitionTable,
+            fixture as Record<string, unknown>
+          ) as never
+        )
+        .run();
+    }
+  }
+};
+
+const createReadOnlyConnection = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  tables: DrizzleStoreSchema<TStore>,
+  db: ReturnType<typeof drizzle<DrizzleStoreSchema<TStore>>>,
+  client: Database
+): ReadOnlyDrizzleStoreConnection<TStore> => {
+  const connection = {
+    async query(run) {
+      return await run({ drizzle: db, tables });
+    },
+  } as ReadOnlyDrizzleStoreConnection<TStore>;
+
+  for (const tableName of storeTableNames(definition)) {
+    const definitionTable = definition.tables[tableName];
+    const drizzleTable = tables[tableName];
+    if (definitionTable === undefined || drizzleTable === undefined) {
+      continue;
+    }
+
+    Object.defineProperty(connection, tableName, {
+      enumerable: true,
+      value: createReadOnlyAccessor(
+        definitionTable as TStore['tables'][typeof tableName],
+        drizzleTable,
+        db
+      ),
+    });
+  }
+
+  return Object.freeze(
+    registerConnection(connection, client)
+  ) as ReadOnlyDrizzleStoreConnection<TStore>;
+};
+
+const createWritableConnection = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  tables: DrizzleStoreSchema<TStore>,
+  db: ReturnType<typeof drizzle<DrizzleStoreSchema<TStore>>>,
+  client: Database
+): DrizzleStoreConnection<TStore> => {
+  const connection = {
+    async query(run) {
+      return await run({ drizzle: db, tables });
+    },
+  } as DrizzleStoreConnection<TStore>;
+
+  for (const tableName of storeTableNames(definition)) {
+    const definitionTable = definition.tables[tableName];
+    const drizzleTable = tables[tableName];
+    if (definitionTable === undefined || drizzleTable === undefined) {
+      continue;
+    }
+
+    Object.defineProperty(connection, tableName, {
+      enumerable: true,
+      value: createWritableAccessor(
+        definitionTable as TStore['tables'][typeof tableName],
+        drizzleTable,
+        db
+      ),
+    });
+  }
+
+  return Object.freeze(
+    registerConnection(connection, client)
+  ) as DrizzleStoreConnection<TStore>;
+};
+
+const buildProvisionShape = <
+  TStore extends AnyStoreDefinition,
+  TConnection,
+  TAccess extends StoreAccessMode,
+>(
+  value: ReturnType<typeof provision<TConnection>>,
+  store: TStore,
+  tables: DrizzleStoreSchema<TStore>,
+  access: TAccess
+): DrizzleStoreProvision<TStore, TConnection, TAccess> =>
+  Object.freeze({
+    ...value,
+    access,
+    store,
+    tables,
+  });
+
+const connectionHealth = (
+  connection: object
+): Result<{ readonly ok: true }, Error> => {
+  const client = connectionClients.get(connection);
+  if (client === undefined) {
+    return Result.err(
+      new InternalError('Drizzle store connection is missing its SQLite client')
+    );
+  }
+
+  try {
+    client.query('SELECT 1').get();
+    return Result.ok({ ok: true });
+  } catch (error) {
+    return Result.err(asError(error));
+  }
+};
+
+/**
+ * Bind a store definition to a Drizzle-backed SQLite provision.
+ *
+ * The returned provision manages its own connection lifecycle. The `mock()`
+ * factory creates an in-memory SQLite database seeded with fixtures — callers
+ * who obtain a mock connection are responsible for calling `closeConnection()`
+ * when done, or letting the connection be garbage-collected (the underlying
+ * `Database` client is tracked via `WeakRef`).
+ *
+ * Note: the `search` field on `StoreTableInput` is not yet interpreted by
+ * this connector — it is reserved for future full-text search support.
+ */
+export const connectDrizzle = <const TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  options: ConnectDrizzleOptions<TStore>
+): DrizzleStoreProvision<
+  TStore,
+  DrizzleStoreConnection<TStore>,
+  'readwrite'
+> => {
+  const tables = deriveDrizzleTables(definition);
+
+  return buildProvisionShape(
+    provision(options.id ?? defaultProvisionId, {
+      create: () => {
+        const client = openSqliteDatabase(options.url, false);
+        try {
+          ensureSqliteSchema(client, definition);
+        } catch (error) {
+          client.close();
+          throw error;
+        }
+        const db = drizzle({ client, schema: tables });
+
+        return Result.ok(
+          createWritableConnection(definition, tables, db, client)
+        );
+      },
+      description:
+        options.description ??
+        'Drizzle-backed writable store bound from an @ontrails/store definition.',
+      dispose: (connection) => {
+        closeConnection(connection);
+      },
+      health: connectionHealth,
+      mock: () => {
+        const client = openSqliteDatabase(':memory:', false);
+        try {
+          ensureSqliteSchema(client, definition);
+          const db = drizzle({ client, schema: tables });
+          seedFixtures(definition, tables, db, options.mockSeed);
+          return createWritableConnection(definition, tables, db, client);
+        } catch (error) {
+          client.close();
+          throw error;
+        }
+      },
+    }),
+    definition,
+    tables,
+    'readwrite'
+  );
+};
+
+export const connectReadOnlyDrizzle = <const TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  options: ReadOnlyDrizzleOptions
+): DrizzleStoreProvision<
+  TStore,
+  ReadOnlyDrizzleStoreConnection<TStore>,
+  'readonly'
+> => {
+  const tables = deriveDrizzleTables(definition);
+
+  return buildProvisionShape(
+    provision(options.id ?? defaultProvisionId, {
+      create: () => {
+        const client = openSqliteDatabase(options.url, true);
+        const db = drizzle({ client, schema: tables });
+
+        return Result.ok(
+          createReadOnlyConnection(definition, tables, db, client)
+        );
+      },
+      description:
+        options.description ??
+        'Drizzle-backed read-only store bound from an @ontrails/store definition.',
+      dispose: (connection) => {
+        closeConnection(connection);
+      },
+      health: connectionHealth,
+    }),
+    definition,
+    tables,
+    'readonly'
+  );
+};
+
+export const store = <const TTables extends StoreTablesInput>(
+  tables: TTables,
+  options: ConnectDrizzleOptions<ReturnType<typeof defineStore<TTables>>>
+): DrizzleStoreProvision<
+  ReturnType<typeof defineStore<TTables>>,
+  DrizzleStoreConnection<ReturnType<typeof defineStore<TTables>>>,
+  'readwrite'
+> => connectDrizzle(defineStore(tables), options);
+
+export const readonlyStore = <const TTables extends StoreTablesInput>(
+  tables: TTables,
+  options: ReadOnlyDrizzleOptions
+): DrizzleStoreProvision<
+  ReturnType<typeof defineStore<TTables>>,
+  ReadOnlyDrizzleStoreConnection<ReturnType<typeof defineStore<TTables>>>,
+  'readonly'
+> => connectReadOnlyDrizzle(defineStore(tables), options);
+
+export const getSchema = <TStore extends AnyStoreDefinition>(
+  binding: Pick<
+    DrizzleStoreProvision<TStore, unknown, StoreAccessMode>,
+    'tables'
+  >
+): DrizzleStoreSchema<TStore> => binding.tables;

--- a/packages/store/src/drizzle/schema.ts
+++ b/packages/store/src/drizzle/schema.ts
@@ -449,6 +449,7 @@ const appendPrimaryKeySql = (
     return;
   }
 
+  parts.push('NOT NULL');
   parts.push('PRIMARY KEY');
   const isAutoIncrement =
     table.generated.includes(field) &&

--- a/packages/store/src/drizzle/schema.ts
+++ b/packages/store/src/drizzle/schema.ts
@@ -1,0 +1,576 @@
+import { ValidationError } from '@ontrails/core';
+import {
+  customType,
+  index,
+  integer,
+  real,
+  sqliteTable,
+  text,
+} from 'drizzle-orm/sqlite-core';
+import type {
+  AnySQLiteColumn,
+  AnySQLiteTable,
+  SQLiteColumnBuilderBase,
+} from 'drizzle-orm/sqlite-core';
+import type { z } from 'zod';
+
+import type { AnyStoreDefinition, AnyStoreTable } from '../types.js';
+import type { DrizzleStoreSchema } from './types.js';
+
+const dateText = customType<{ data: Date; driverData: string }>({
+  dataType() {
+    return 'text';
+  },
+  fromDriver(value) {
+    return new Date(value);
+  },
+  toDriver(value) {
+    return value.toISOString();
+  },
+});
+
+interface InnerTypeDef {
+  readonly innerType: z.ZodType;
+}
+
+interface DefaultTypeDef extends InnerTypeDef {
+  readonly defaultValue?: unknown;
+}
+
+interface UnwrappedSchema {
+  readonly defaultValue?: unknown;
+  readonly nullable: boolean;
+  readonly optional: boolean;
+  readonly schema: z.ZodType;
+}
+
+interface SqliteFieldSpec {
+  readonly defaultValue?: unknown;
+  readonly enumValues?: readonly [string, ...string[]];
+  readonly kind: 'boolean' | 'date' | 'integer' | 'json' | 'real' | 'text';
+  readonly nullable: boolean;
+  readonly optional: boolean;
+}
+
+interface SqliteColumnBuilder {
+  default(value: unknown): SqliteColumnBuilder;
+  notNull(): SqliteColumnBuilder;
+  primaryKey(config?: {
+    readonly autoIncrement?: boolean;
+  }): SqliteColumnBuilder;
+  references(
+    ref: () => AnySQLiteColumn,
+    actions?: {
+      readonly onDelete?:
+        | 'cascade'
+        | 'restrict'
+        | 'set null'
+        | 'set default'
+        | 'no action';
+      readonly onUpdate?:
+        | 'cascade'
+        | 'restrict'
+        | 'set null'
+        | 'set default'
+        | 'no action';
+    }
+  ): SqliteColumnBuilder;
+}
+
+const defaultUnwrapState: Omit<UnwrappedSchema, 'schema'> = {
+  nullable: false,
+  optional: false,
+};
+
+/**
+ * The unwrap helpers below access Zod internal `._def` shapes (`def.type`,
+ * `def.checks`, `def.innerType`, `def.defaultValue`). These are not part of
+ * Zod's public API and may change across minor versions. The store package
+ * pins Zod through the workspace catalog — test `z.number().int()` mapping
+ * to `INTEGER` (see drizzle.test.ts) to catch regressions on Zod upgrades.
+ */
+const unwrapInnerType = (schema: z.ZodType): z.ZodType => {
+  const { innerType } = schema.def as unknown as InnerTypeDef;
+  return innerType;
+};
+
+const unwrapDefaultLayer = (
+  schema: z.ZodType
+): {
+  readonly defaultValue?: unknown;
+  readonly schema: z.ZodType;
+} => {
+  const { defaultValue } = schema.def as unknown as DefaultTypeDef;
+  return {
+    defaultValue,
+    schema: unwrapInnerType(schema),
+  };
+};
+
+const unwrapSchema = (
+  schema: z.ZodType,
+  state: Omit<UnwrappedSchema, 'schema'> = defaultUnwrapState
+): UnwrappedSchema => {
+  switch (schema.def.type) {
+    case 'default': {
+      const { defaultValue, schema: innerSchema } = unwrapDefaultLayer(schema);
+      return unwrapSchema(innerSchema, { ...state, defaultValue });
+    }
+    case 'nullable': {
+      return unwrapSchema(unwrapInnerType(schema), {
+        ...state,
+        nullable: true,
+      });
+    }
+    case 'optional': {
+      return unwrapSchema(unwrapInnerType(schema), {
+        ...state,
+        optional: true,
+      });
+    }
+    default: {
+      return {
+        ...state,
+        schema,
+      };
+    }
+  }
+};
+
+const isIntegerNumber = (schema: z.ZodType): boolean =>
+  schema.def.type === 'number' &&
+  ((schema.def.checks as readonly unknown[] | undefined) ?? []).some(
+    (check) => {
+      const { def } = check as { readonly def?: Record<string, unknown> };
+      return def?.['check'] === 'number_format';
+    }
+  );
+
+const toEnumValues = (
+  entries: Record<string, string>
+): readonly [string, ...string[]] => {
+  const values = Object.values(entries);
+  if (values.length === 0) {
+    throw new ValidationError('Enum-backed store fields must declare values');
+  }
+
+  return values as unknown as readonly [string, ...string[]];
+};
+
+const fieldSpecBase = (
+  unwrapped: UnwrappedSchema
+): Omit<SqliteFieldSpec, 'kind'> => ({
+  ...(unwrapped.defaultValue === undefined
+    ? {}
+    : { defaultValue: unwrapped.defaultValue }),
+  nullable: unwrapped.nullable,
+  optional: unwrapped.optional,
+});
+
+const enumEntriesOf = (schema: z.ZodType): Record<string, string> => {
+  const { entries } = schema.def as unknown as {
+    readonly entries: Record<string, string>;
+  };
+  return entries;
+};
+
+const inferFieldKind = (
+  field: string,
+  schema: z.ZodType
+): SqliteFieldSpec['kind'] => {
+  switch (schema.def.type) {
+    case 'array':
+    case 'object': {
+      return 'json';
+    }
+    case 'boolean': {
+      return 'boolean';
+    }
+    case 'date': {
+      return 'date';
+    }
+    case 'enum': {
+      return 'text';
+    }
+    case 'number': {
+      return isIntegerNumber(schema) ? 'integer' : 'real';
+    }
+    case 'string': {
+      return 'text';
+    }
+    default: {
+      throw new ValidationError(
+        `Store field "${field}" uses unsupported schema type "${schema.def.type}" for the Drizzle SQLite connector`
+      );
+    }
+  }
+};
+
+export const describeField = (
+  field: string,
+  schema: z.ZodType
+): SqliteFieldSpec => {
+  const unwrapped = unwrapSchema(schema);
+  const base = fieldSpecBase(unwrapped);
+  const kind = inferFieldKind(field, unwrapped.schema);
+
+  return {
+    ...base,
+    ...(unwrapped.schema.def.type === 'enum'
+      ? { enumValues: toEnumValues(enumEntriesOf(unwrapped.schema)) }
+      : {}),
+    kind,
+  };
+};
+
+const quoteIdentifier = (value: string): string =>
+  `"${value.replaceAll('"', '""')}"`;
+
+const quoteStringLiteral = (value: string): string =>
+  `'${value.replaceAll("'", "''")}'`;
+
+const serializeJsonDefault = (value: object | readonly unknown[]): string =>
+  quoteStringLiteral(JSON.stringify(value));
+
+const serializePrimitiveDefault = (
+  value: string | number | boolean
+): string | undefined => {
+  switch (typeof value) {
+    case 'boolean': {
+      return value ? '1' : '0';
+    }
+    case 'number': {
+      return Number.isFinite(value) ? `${value}` : undefined;
+    }
+    case 'string': {
+      return quoteStringLiteral(value);
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
+
+const toSqlDefault = (value: unknown): string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return quoteStringLiteral(value.toISOString());
+  }
+
+  return typeof value === 'object'
+    ? serializeJsonDefault(value as object)
+    : serializePrimitiveDefault(value as string | number | boolean);
+};
+
+const toSqlType = (kind: SqliteFieldSpec['kind']): string => {
+  switch (kind) {
+    case 'boolean':
+    case 'integer': {
+      return 'INTEGER';
+    }
+    case 'real': {
+      return 'REAL';
+    }
+    case 'date':
+    case 'json':
+    case 'text': {
+      return 'TEXT';
+    }
+    default: {
+      return 'TEXT';
+    }
+  }
+};
+
+const createBaseColumnBuilder = (
+  field: string,
+  spec: SqliteFieldSpec
+): SqliteColumnBuilder => {
+  switch (spec.kind) {
+    case 'boolean': {
+      return integer(field, {
+        mode: 'boolean',
+      }) as unknown as SqliteColumnBuilder;
+    }
+    case 'date': {
+      return dateText(field) as unknown as SqliteColumnBuilder;
+    }
+    case 'integer': {
+      return integer(field) as unknown as SqliteColumnBuilder;
+    }
+    case 'json': {
+      return text(field, { mode: 'json' }) as unknown as SqliteColumnBuilder;
+    }
+    case 'real': {
+      return real(field) as unknown as SqliteColumnBuilder;
+    }
+    case 'text': {
+      return spec.enumValues === undefined
+        ? (text(field) as unknown as SqliteColumnBuilder)
+        : (text(field, {
+            enum: spec.enumValues,
+          }) as unknown as SqliteColumnBuilder);
+    }
+    default: {
+      throw new ValidationError(
+        `Store field "${field}" resolved to an unsupported Drizzle column builder`
+      );
+    }
+  }
+};
+
+const applyPrimaryKey = (
+  builder: SqliteColumnBuilder,
+  spec: SqliteFieldSpec,
+  isPrimaryKey: boolean,
+  isGenerated: boolean
+): SqliteColumnBuilder => {
+  if (!isPrimaryKey) {
+    return builder;
+  }
+
+  const shouldAutoIncrement =
+    isGenerated && spec.kind === 'integer' && spec.defaultValue === undefined;
+
+  return shouldAutoIncrement
+    ? builder.primaryKey({ autoIncrement: true })
+    : builder.primaryKey();
+};
+
+const applyCommonBuilderState = (
+  builder: SqliteColumnBuilder,
+  spec: SqliteFieldSpec,
+  notNull: boolean
+): SqliteColumnBuilder => {
+  let next = builder;
+
+  if (notNull) {
+    next = next.notNull();
+  }
+
+  if (toSqlDefault(spec.defaultValue) !== undefined) {
+    next = next.default(spec.defaultValue);
+  }
+
+  return next;
+};
+
+const resolveReferencedTable = (
+  definition: AnyStoreDefinition,
+  sourceTable: AnyStoreTable,
+  targetTableName: string
+): AnyStoreTable => {
+  const target = definition.tables[targetTableName];
+  if (target !== undefined) {
+    return target;
+  }
+
+  throw new ValidationError(
+    `Store table "${sourceTable.name}" references unknown table "${targetTableName}"`
+  );
+};
+
+const resolveReferencedColumn = (
+  tables: Record<string, AnySQLiteTable>,
+  targetTableName: string,
+  targetPrimaryKey: string
+): AnySQLiteColumn => {
+  const targetTable = tables[targetTableName];
+  if (targetTable === undefined) {
+    throw new ValidationError(
+      `Store table reference to "${targetTableName}" could not be resolved during Drizzle schema derivation`
+    );
+  }
+
+  return targetTable[
+    targetPrimaryKey as keyof typeof targetTable
+  ] as AnySQLiteColumn;
+};
+
+const applyReference = (
+  builder: SqliteColumnBuilder,
+  field: string,
+  table: AnyStoreTable,
+  definition: AnyStoreDefinition,
+  tables: Record<string, AnySQLiteTable>
+): SqliteColumnBuilder => {
+  const targetTableName = table.references[field];
+  if (targetTableName === undefined) {
+    return builder;
+  }
+
+  const target = resolveReferencedTable(definition, table, targetTableName);
+  return builder.references(
+    () => resolveReferencedColumn(tables, targetTableName, target.primaryKey),
+    { onDelete: 'restrict', onUpdate: 'cascade' }
+  );
+};
+
+const deriveColumnBuilder = (
+  field: string,
+  table: AnyStoreTable,
+  definition: AnyStoreDefinition,
+  tables: Record<string, AnySQLiteTable>
+): SqliteColumnBuilder => {
+  const schema = table.schema.shape[field] as z.ZodType;
+  const spec = describeField(field, schema);
+  const isPrimaryKey = field === table.primaryKey;
+  const isGenerated = table.generated.includes(field);
+  const baseBuilder = createBaseColumnBuilder(field, spec);
+  const keyedBuilder = applyPrimaryKey(
+    baseBuilder,
+    spec,
+    isPrimaryKey,
+    isGenerated
+  );
+  const finalizedBuilder = applyCommonBuilderState(
+    keyedBuilder,
+    spec,
+    !isPrimaryKey && !spec.optional && !spec.nullable
+  );
+
+  return applyReference(finalizedBuilder, field, table, definition, tables);
+};
+
+const appendPrimaryKeySql = (
+  parts: string[],
+  field: string,
+  table: AnyStoreTable,
+  spec: SqliteFieldSpec
+): void => {
+  const isPrimaryKey = field === table.primaryKey;
+  if (!isPrimaryKey) {
+    if (!spec.optional && !spec.nullable) {
+      parts.push('NOT NULL');
+    }
+    return;
+  }
+
+  parts.push('PRIMARY KEY');
+  const isAutoIncrement =
+    table.generated.includes(field) &&
+    spec.kind === 'integer' &&
+    spec.defaultValue === undefined;
+
+  if (isAutoIncrement) {
+    parts.push('AUTOINCREMENT');
+  }
+};
+
+const appendDefaultSql = (parts: string[], spec: SqliteFieldSpec): void => {
+  const sqlDefault = toSqlDefault(spec.defaultValue);
+  if (sqlDefault !== undefined) {
+    parts.push(`DEFAULT ${sqlDefault}`);
+  }
+};
+
+const appendReferenceSql = (
+  parts: string[],
+  field: string,
+  table: AnyStoreTable,
+  definition: AnyStoreDefinition
+): void => {
+  const targetTableName = table.references[field];
+  if (targetTableName === undefined) {
+    return;
+  }
+
+  const target = resolveReferencedTable(definition, table, targetTableName);
+  parts.push(
+    `REFERENCES ${quoteIdentifier(targetTableName)} (${quoteIdentifier(target.primaryKey)}) ON DELETE RESTRICT ON UPDATE CASCADE`
+  );
+};
+
+const createColumnSqlParts = (
+  field: string,
+  schema: z.ZodType,
+  table: AnyStoreTable,
+  definition: AnyStoreDefinition
+): string[] => {
+  const spec = describeField(field, schema);
+  const parts = [quoteIdentifier(field), toSqlType(spec.kind)];
+  appendPrimaryKeySql(parts, field, table, spec);
+  appendDefaultSql(parts, spec);
+  appendReferenceSql(parts, field, table, definition);
+  return parts;
+};
+
+const createColumnSql = (
+  field: string,
+  schema: z.ZodType,
+  table: AnyStoreTable,
+  definition: AnyStoreDefinition
+): string =>
+  `  ${createColumnSqlParts(field, schema, table, definition).join(' ')}`;
+
+const createTableSql = (
+  table: AnyStoreTable,
+  definition: AnyStoreDefinition
+): string => {
+  const columns = Object.entries(table.schema.shape).map(([field, schema]) =>
+    createColumnSql(field, schema as z.ZodType, table, definition)
+  );
+
+  return [
+    `CREATE TABLE IF NOT EXISTS ${quoteIdentifier(table.name)} (`,
+    columns.join(',\n'),
+    ')',
+  ].join('\n');
+};
+
+const createIndexSql = (table: AnyStoreTable, field: string): string =>
+  `CREATE INDEX IF NOT EXISTS ${quoteIdentifier(`${table.name}_${field}_idx`)} ON ${quoteIdentifier(table.name)} (${quoteIdentifier(field)})`;
+
+const definedTables = (
+  definition: AnyStoreDefinition
+): readonly AnyStoreTable[] =>
+  definition.tableNames.flatMap((name) => {
+    const table = definition.tables[name];
+    return table === undefined ? [] : [table];
+  });
+
+const createIndexStatements = (
+  definition: AnyStoreDefinition
+): readonly string[] =>
+  definedTables(definition).flatMap((table) =>
+    table.indexes.map((field) => createIndexSql(table, field))
+  );
+
+export const deriveDrizzleTables = <TStore extends AnyStoreDefinition>(
+  definition: TStore
+): DrizzleStoreSchema<TStore> => {
+  const tables: Record<string, AnySQLiteTable> = {};
+
+  for (const table of definedTables(definition)) {
+    tables[table.name] = sqliteTable(
+      table.name,
+      Object.fromEntries(
+        Object.keys(table.schema.shape).map((field) => [
+          field,
+          deriveColumnBuilder(field, table, definition, tables),
+        ])
+      ) as unknown as Record<string, SQLiteColumnBuilderBase>,
+      (self) =>
+        table.indexes.map((field) =>
+          index(`${table.name}_${field}_idx`).on(
+            self[field as keyof typeof self] as AnySQLiteColumn
+          )
+        )
+    );
+  }
+
+  return Object.freeze(tables) as DrizzleStoreSchema<TStore>;
+};
+
+export const createSqliteSchemaStatements = (
+  definition: AnyStoreDefinition
+): readonly string[] =>
+  Object.freeze([
+    ...definedTables(definition).map((table) =>
+      createTableSql(table, definition)
+    ),
+    ...createIndexStatements(definition),
+  ]);

--- a/packages/store/src/drizzle/types.ts
+++ b/packages/store/src/drizzle/types.ts
@@ -1,0 +1,70 @@
+import type { Provision } from '@ontrails/core';
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import type { AnySQLiteTable } from 'drizzle-orm/sqlite-core';
+
+import type {
+  AnyStoreDefinition,
+  FixtureInputOf,
+  ReadOnlyStoreConnection,
+  StoreAccessMode,
+  StoreConnection,
+} from '../types.js';
+
+export type DrizzleStoreSchema<TStore extends AnyStoreDefinition> = {
+  readonly [TName in keyof TStore['tables']]: AnySQLiteTable<{
+    name: Extract<TName, string>;
+  }>;
+};
+
+export interface DrizzleQueryContext<TStore extends AnyStoreDefinition> {
+  readonly drizzle: BunSQLiteDatabase<DrizzleStoreSchema<TStore>>;
+  readonly tables: DrizzleStoreSchema<TStore>;
+}
+
+export type DrizzleMockSeed<TStore extends AnyStoreDefinition> = Partial<{
+  readonly [TName in keyof TStore['tables']]: readonly FixtureInputOf<
+    TStore['tables'][TName]
+  >[];
+}>;
+
+export interface ConnectDrizzleOptions<TStore extends AnyStoreDefinition> {
+  readonly description?: string;
+  readonly id?: string;
+  readonly mockSeed?: DrizzleMockSeed<TStore>;
+  readonly url: string;
+}
+
+export interface ReadOnlyDrizzleOptions {
+  readonly description?: string;
+  readonly id?: string;
+  readonly url: string;
+}
+
+export type ReadOnlyDrizzleStoreConnection<TStore extends AnyStoreDefinition> =
+  ReadOnlyStoreConnection<TStore> & {
+    query<TResult>(
+      run: (ctx: DrizzleQueryContext<TStore>) => TResult | Promise<TResult>
+    ): Promise<Awaited<TResult>>;
+  };
+
+export type DrizzleStoreConnection<TStore extends AnyStoreDefinition> =
+  StoreConnection<TStore> & ReadOnlyDrizzleStoreConnection<TStore>;
+
+export interface DrizzleStoreProvisionShape<
+  TStore extends AnyStoreDefinition,
+  TConnection,
+  TAccess extends StoreAccessMode,
+> {
+  readonly access: TAccess;
+  readonly store: TStore;
+  readonly tables: DrizzleStoreSchema<TStore>;
+  from(ctx: Parameters<Provision<TConnection>['from']>[0]): TConnection;
+  readonly kind: 'provision';
+}
+
+export type DrizzleStoreProvision<
+  TStore extends AnyStoreDefinition,
+  TConnection,
+  TAccess extends StoreAccessMode,
+> = Provision<TConnection> &
+  DrizzleStoreProvisionShape<TStore, TConnection, TAccess>;

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -181,14 +181,39 @@ export interface StoreDefinition<
 }
 
 /**
- * Any normalized store table.
+ * Structural view of any normalized store table.
+ *
+ * This stays broad on purpose so connector packages can accept concrete store
+ * definitions returned by `store(...)` without erasing their table-specific
+ * types back to one canonical generic instantiation.
  */
-export type AnyStoreTable = StoreTable<StoreTableInput, string>;
+export interface AnyStoreTable {
+  readonly fixtureSchema: StoreObjectSchema;
+  readonly fixtures: readonly Record<string, unknown>[];
+  readonly generated: readonly string[];
+  readonly indexes: readonly string[];
+  readonly insertSchema: StoreObjectSchema;
+  readonly name: string;
+  readonly primaryKey: string;
+  readonly references: Readonly<Partial<Record<string, string>>>;
+  readonly schema: StoreObjectSchema;
+  readonly search?: StoreSearchDefinition | undefined;
+  readonly updateSchema: StoreObjectSchema;
+}
 
 /**
- * Any normalized store definition.
+ * Structural view of any normalized store definition.
  */
-export type AnyStoreDefinition = StoreDefinition<StoreTablesInput>;
+export interface AnyStoreDefinition {
+  readonly kind: 'store';
+  readonly tableNames: readonly string[];
+  readonly tables: Readonly<Record<string, AnyStoreTable>>;
+}
+
+type GeneratedFieldKeysOf<TTable extends AnyStoreTable> = readonly Extract<
+  TTable['generated'][number],
+  StoreFieldKey<TTable['schema']>
+>[];
 
 /**
  * Full entity type represented by one store table.
@@ -200,7 +225,7 @@ export type EntityOf<TTable extends AnyStoreTable> = z.output<TTable['schema']>;
  */
 export type FixtureInputOf<TTable extends AnyStoreTable> = StoreFixtureInput<
   TTable['schema'],
-  TTable['generated']
+  GeneratedFieldKeysOf<TTable>
 >;
 
 /**
@@ -208,7 +233,7 @@ export type FixtureInputOf<TTable extends AnyStoreTable> = StoreFixtureInput<
  */
 export type FixtureOf<TTable extends AnyStoreTable> = StoreFixtureRow<
   TTable['schema'],
-  TTable['generated']
+  GeneratedFieldKeysOf<TTable>
 >;
 
 /**
@@ -219,8 +244,10 @@ export type PrimaryKeyOf<TTable extends AnyStoreTable> = TTable['primaryKey'];
 /**
  * Server-managed fields for one store table.
  */
-export type GeneratedKeysOf<TTable extends AnyStoreTable> =
-  TTable['generated'][number] & string;
+export type GeneratedKeysOf<TTable extends AnyStoreTable> = Extract<
+  TTable['generated'][number],
+  StoreFieldKey<TTable['schema']>
+>;
 
 /**
  * Insert shape: entity minus generated fields, with defaulted fields optional.


### PR DESCRIPTION
## Summary
- Adds `@ontrails/store/drizzle` SQLite connector
- Derives Drizzle tables from store definitions automatically
- CRUD accessors with error taxonomy mapping (AlreadyExistsError, ValidationError)
- Real in-memory SQLite mocks and read-only enforcement at DB + type level
- Single `query()` escape hatch for custom queries
- Documents generated field conventions (createdAt/updatedAt/UUID) and ZodError mapping

## What changed
The Drizzle connector bridges `@ontrails/store` declarations to a real SQLite backend. Drizzle table schemas are derived automatically from store Zod definitions — no hand-written table definitions needed. CRUD accessors map database errors to the Trails error taxonomy (AlreadyExistsError for unique constraint violations, ValidationError for schema mismatches). Mock provisions use real in-memory SQLite databases seeded with fixtures. Read-only enforcement is applied at both the database connection level and the TypeScript type level. A `query()` escape hatch allows direct Drizzle queries when the accessor API is insufficient.

## How it was tested
- bun run build
- bun run test
- bun run typecheck
- bun run lint
- Package-specific tests where applicable

Closes: TRL-135, TRL-159, TRL-160, TRL-161
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
