### PR TITLE
feat: dogfood derived persistence in trails-demo

### DIFF
--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -1,6 +1,6 @@
 # trails-demo
 
-A complete working application built with the Trails framework. It demonstrates every core concept: trails, composition via `crosses`, a first-class provision dependency, a signal, examples, metadata, detours, idempotent upsert, and trailhead entrypoints on CLI, MCP, and HTTP.
+A complete working application built with the Trails framework. It demonstrates every core concept: trails, composition via `crosses`, a first-class provision dependency, a schema-derived store, a signal, examples, metadata, detours, idempotent upsert, and trailhead entrypoints on CLI, MCP, and HTTP.
 
 ## What this app does
 
@@ -18,7 +18,7 @@ Entity management -- a small CRUD + search system with enough depth to exercise 
 
 Plus one signal: `entity.updated` (fired by `entity.add` and `entity.delete`).
 
-Plus one provision: `demo.entity-store` (the in-memory entity store used by the entity and search trails).
+Plus one provision: `demo.entity-store` (a Drizzle-backed in-memory entity store derived from a root `store(...)` definition).
 
 ## Running the CLI
 
@@ -159,7 +159,7 @@ testAll(app, () => ({
 3. **`testContracts`** -- output schema verification for every success example.
 4. **`testDetours`** -- detour targets reference real trails in the topo.
 
-Pass a factory function (not a plain object) when your explicit provision overrides contain mutable state like an in-memory store, so each test gets a fresh copy.
+Pass a factory function (not a plain object) when your explicit provision overrides contain mutable state like an in-memory SQLite store, so each test gets a fresh copy.
 
 ### Progressive assertion
 

--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -120,7 +120,7 @@ describe('trailhead map generation', () => {
     if (provisionEntry) {
       expect(provisionEntry.kind).toBe('provision');
       expect(provisionEntry.description).toBe(
-        'In-memory entity store used by the demo trails app.'
+        'Drizzle-backed in-memory entity store used by the demo trails app.'
       );
     }
   });

--- a/apps/trails-demo/package.json
+++ b/apps/trails-demo/package.json
@@ -20,6 +20,7 @@
     "@ontrails/http": "workspace:^",
     "@ontrails/logging": "workspace:^",
     "@ontrails/mcp": "workspace:^",
+    "@ontrails/store": "workspace:^",
     "commander": "catalog:",
     "hono": "^4.7.0",
     "zod": "catalog:"

--- a/apps/trails-demo/src/provisions/entity-store.ts
+++ b/apps/trails-demo/src/provisions/entity-store.ts
@@ -23,6 +23,7 @@ export const createMockEntityStore = () => createStore(mockSeed);
 
 export const entityStoreProvision = provision('demo.entity-store', {
   create: () => Result.ok(createStore(runtimeSeed)),
-  description: 'In-memory entity store used by the demo trails app.',
+  description:
+    'Drizzle-backed in-memory entity store used by the demo trails app.',
   mock: () => createMockEntityStore(),
 });

--- a/apps/trails-demo/src/store.ts
+++ b/apps/trails-demo/src/store.ts
@@ -1,121 +1,88 @@
 /**
- * In-memory entity store for the trails-demo app.
+ * Schema-derived entity store for the trails-demo app.
  *
- * No external dependencies -- the focus is on demonstrating Trails patterns,
- * not infrastructure.
+ * The demo still uses an in-memory SQLite database for easy local runs, but
+ * the storage contract itself is now authored once and projected through
+ * `@ontrails/store/drizzle`.
  */
 
-// ---------------------------------------------------------------------------
-// Entity type
-// ---------------------------------------------------------------------------
+import { store as defineStore } from '@ontrails/store';
+import { store as bindDrizzleStore } from '@ontrails/store/drizzle';
+import { z } from 'zod';
 
-export interface Entity {
-  readonly id: string;
-  readonly name: string;
-  readonly type: string;
-  readonly tags: readonly string[];
-  readonly createdAt: string;
-  readonly updatedAt: string;
-}
+export const entitySchema = z.object({
+  createdAt: z.string(),
+  id: z.string(),
+  name: z.string(),
+  tags: z.array(z.string()),
+  type: z.string(),
+  updatedAt: z.string(),
+});
 
-// ---------------------------------------------------------------------------
-// Store interface
-// ---------------------------------------------------------------------------
+const mockFixtures = [
+  { name: 'Alpha', tags: ['core'], type: 'concept' },
+  { name: 'Deletable', tags: ['temp'], type: 'tool' },
+] as const;
 
-export interface EntityStore {
-  get(name: string): Entity | undefined;
-  add(entity: Omit<Entity, 'id' | 'createdAt' | 'updatedAt'>): Entity;
-  delete(name: string): boolean;
-  list(options?: { type?: string; limit?: number; offset?: number }): Entity[];
-  search(query: string): Entity[];
-}
+const entityTables = {
+  entities: {
+    fixtures: mockFixtures,
+    generated: ['id', 'createdAt', 'updatedAt'],
+    indexes: ['type'],
+    primaryKey: 'name',
+    schema: entitySchema,
+  },
+} as const;
 
-// ---------------------------------------------------------------------------
-// Seed input (partial entity without generated fields)
-// ---------------------------------------------------------------------------
+export const entityStoreDefinition = defineStore(entityTables);
 
+export type Entity = z.output<typeof entitySchema>;
 export interface EntitySeed {
+  readonly createdAt?: string;
+  readonly id?: string;
   readonly name: string;
+  readonly tags: readonly string[];
   readonly type: string;
-  readonly tags?: readonly string[];
+  readonly updatedAt?: string;
 }
 
-// ---------------------------------------------------------------------------
-// Factory
-// ---------------------------------------------------------------------------
+interface MutableEntitySeed {
+  readonly createdAt?: string;
+  readonly id?: string;
+  readonly name: string;
+  readonly tags: string[];
+  readonly type: string;
+  readonly updatedAt?: string;
+}
+
+const normalizeSeed = (seed: EntitySeed): MutableEntitySeed => ({
+  ...seed,
+  tags: [...seed.tags],
+});
+
+const createBoundEntityStore = (seed?: readonly EntitySeed[]) =>
+  bindDrizzleStore(entityTables, {
+    id: 'demo.entity-store',
+    ...(seed === undefined
+      ? {}
+      : { mockSeed: { entities: seed.map(normalizeSeed) } }),
+    url: ':memory:',
+  });
+
+export type EntityStore = Awaited<
+  ReturnType<NonNullable<ReturnType<typeof createBoundEntityStore>['mock']>>
+>;
 
 export const createStore = (seed?: readonly EntitySeed[]): EntityStore => {
-  let counter = 0;
-
-  const nextId = (): string => {
-    counter += 1;
-    return `e${String(counter)}`;
-  };
-
-  const byName = new Map<string, Entity>();
-
-  // Seed initial data
-  if (seed !== undefined) {
-    for (const s of seed) {
-      const entity: Entity = {
-        createdAt: '2026-01-01T00:00:00Z',
-        id: nextId(),
-        name: s.name,
-        tags: s.tags ?? [],
-        type: s.type,
-        updatedAt: '2026-01-01T00:00:00Z',
-      };
-      byName.set(entity.name, entity);
-    }
+  const { mock } = createBoundEntityStore(seed);
+  if (mock === undefined) {
+    throw new Error('Demo entity store requires a mock factory');
   }
 
-  return {
-    add(input: Omit<Entity, 'id' | 'createdAt' | 'updatedAt'>): Entity {
-      const now = new Date().toISOString();
-      const entity: Entity = {
-        createdAt: now,
-        id: nextId(),
-        name: input.name,
-        tags: input.tags,
-        type: input.type,
-        updatedAt: now,
-      };
-      byName.set(entity.name, entity);
-      return entity;
-    },
+  const created = mock();
+  if (created instanceof Promise) {
+    throw new TypeError('Demo entity store mock must resolve synchronously');
+  }
 
-    delete(name: string): boolean {
-      return byName.delete(name);
-    },
-
-    get(name: string): Entity | undefined {
-      return byName.get(name);
-    },
-
-    list(options?: {
-      type?: string;
-      limit?: number;
-      offset?: number;
-    }): Entity[] {
-      let entities = [...byName.values()];
-
-      if (options?.type !== undefined) {
-        entities = entities.filter((e) => e.type === options.type);
-      }
-
-      const offset = options?.offset ?? 0;
-      const limit = options?.limit ?? 20;
-      return entities.slice(offset, offset + limit);
-    },
-
-    search(query: string): Entity[] {
-      const q = query.toLowerCase();
-      return [...byName.values()].filter(
-        (e) =>
-          e.name.toLowerCase().includes(q) ||
-          e.type.toLowerCase().includes(q) ||
-          e.tags.some((t) => t.toLowerCase().includes(q))
-      );
-    },
-  };
+  return created;
 };

--- a/apps/trails-demo/src/trails/entity.ts
+++ b/apps/trails-demo/src/trails/entity.ts
@@ -185,7 +185,7 @@ export const list = trail('entity.list', {
     ]);
     return Result.ok({
       entities: entities.map(toSummary),
-      total: entities.length,
+      total: allMatching.length,
     });
   },
   description: 'List entities with optional type filter',

--- a/apps/trails-demo/src/trails/entity.ts
+++ b/apps/trails-demo/src/trails/entity.ts
@@ -14,19 +14,12 @@ import {
 import { z } from 'zod';
 
 import { entityStoreProvision } from '../provisions/entity-store.js';
+import type { Entity } from '../store.js';
+import { entitySchema } from '../store.js';
 
 // ---------------------------------------------------------------------------
 // Shared schemas
 // ---------------------------------------------------------------------------
-
-const entitySchema = z.object({
-  createdAt: z.string(),
-  id: z.string(),
-  name: z.string(),
-  tags: z.array(z.string()),
-  type: z.string(),
-  updatedAt: z.string(),
-});
 
 const entitySummarySchema = z.object({
   id: z.string(),
@@ -35,21 +28,30 @@ const entitySummarySchema = z.object({
   type: z.string(),
 });
 
+const toEntity = (entity: Entity) => ({
+  createdAt: entity.createdAt,
+  id: entity.id,
+  name: entity.name,
+  tags: [...entity.tags],
+  type: entity.type,
+  updatedAt: entity.updatedAt,
+});
+
+const toSummary = (entity: Entity) => ({
+  id: entity.id,
+  name: entity.name,
+  tags: [...entity.tags],
+  type: entity.type,
+});
+
 export const show = trail('entity.show', {
-  blaze: (input, ctx) => {
+  blaze: async (input, ctx) => {
     const store = entityStoreProvision.from(ctx);
-    const entity = store.get(input.name);
+    const entity = await store.entities.get(input.name);
     if (!entity) {
       return Result.err(new NotFoundError(`Entity "${input.name}" not found`));
     }
-    return Result.ok({
-      createdAt: entity.createdAt,
-      id: entity.id,
-      name: entity.name,
-      tags: [...entity.tags],
-      type: entity.type,
-      updatedAt: entity.updatedAt,
-    });
+    return Result.ok(toEntity(entity));
   },
   description: 'Show an entity by name',
   detours: {
@@ -81,27 +83,24 @@ export const show = trail('entity.show', {
 // ---------------------------------------------------------------------------
 
 export const add = trail('entity.add', {
-  blaze: (input, ctx) => {
+  blaze: async (input, ctx) => {
     const store = entityStoreProvision.from(ctx);
-    const existing = store.get(input.name);
-    if (existing) {
+    try {
+      const entity = await store.entities.insert({
+        name: input.name,
+        tags: input.tags ?? [],
+        type: input.type,
+      });
+      return Result.ok(toEntity(entity));
+    } catch (error) {
+      if (error instanceof AlreadyExistsError) {
+        return Result.err(error);
+      }
+
       return Result.err(
-        new AlreadyExistsError(`Entity "${input.name}" already exists`)
+        error instanceof Error ? error : new Error(String(error))
       );
     }
-    const entity = store.add({
-      name: input.name,
-      tags: input.tags ?? [],
-      type: input.type,
-    });
-    return Result.ok({
-      createdAt: entity.createdAt,
-      id: entity.id,
-      name: entity.name,
-      tags: [...entity.tags],
-      type: entity.type,
-      updatedAt: entity.updatedAt,
-    });
   },
   description: 'Create a new entity',
   examples: [
@@ -126,6 +125,7 @@ export const add = trail('entity.add', {
       .describe('Tags for categorization'),
     type: z.string().describe('Entity type (concept, tool, pattern)'),
   }),
+  intent: 'write',
   output: entitySchema,
   provisions: [entityStoreProvision],
 });
@@ -135,10 +135,10 @@ export const add = trail('entity.add', {
 // ---------------------------------------------------------------------------
 
 export const remove = trail('entity.delete', {
-  blaze: (input, ctx) => {
+  blaze: async (input, ctx) => {
     const store = entityStoreProvision.from(ctx);
-    const deleted = store.delete(input.name);
-    if (!deleted) {
+    const deleted = await store.entities.remove(input.name);
+    if (!deleted.deleted) {
       return Result.err(new NotFoundError(`Entity "${input.name}" not found`));
     }
     return Result.ok({ deleted: true, name: input.name });
@@ -173,23 +173,18 @@ export const remove = trail('entity.delete', {
 // ---------------------------------------------------------------------------
 
 export const list = trail('entity.list', {
-  blaze: (input, ctx) => {
+  blaze: async (input, ctx) => {
     const store = entityStoreProvision.from(ctx);
-    const listOptions: { limit?: number; offset?: number; type?: string } = {
-      limit: input.limit,
-      offset: input.offset,
-    };
-    if (input.type !== undefined) {
-      listOptions.type = input.type;
-    }
-    const entities = store.list(listOptions);
+    const filters = input.type === undefined ? undefined : { type: input.type };
+    const [entities, allMatching] = await Promise.all([
+      store.entities.list(filters, {
+        limit: input.limit,
+        offset: input.offset,
+      }),
+      store.entities.list(filters),
+    ]);
     return Result.ok({
-      entities: entities.map((e) => ({
-        id: e.id,
-        name: e.name,
-        tags: [...e.tags],
-        type: e.type,
-      })),
+      entities: entities.map(toSummary),
       total: entities.length,
     });
   },

--- a/apps/trails-demo/src/trails/onboard.ts
+++ b/apps/trails-demo/src/trails/onboard.ts
@@ -69,6 +69,7 @@ export const onboard = trail('entity.onboard', {
     tags: z.array(z.string()).optional().default([]),
     type: z.string().describe('Entity type'),
   }),
+  intent: 'write',
   output: z.object({
     entity: z.object({
       id: z.string(),

--- a/apps/trails-demo/src/trails/search.ts
+++ b/apps/trails-demo/src/trails/search.ts
@@ -14,9 +14,16 @@ import { entityStoreProvision } from '../provisions/entity-store.js';
 // ---------------------------------------------------------------------------
 
 export const search = trail('search', {
-  blaze: (input, ctx) => {
+  blaze: async (input, ctx) => {
     const store = entityStoreProvision.from(ctx);
-    const results = store.search(input.query);
+    const query = input.query.toLowerCase();
+    const entities = await store.entities.list();
+    const results = entities.filter(
+      (entity) =>
+        entity.name.toLowerCase().includes(query) ||
+        entity.type.toLowerCase().includes(query) ||
+        entity.tags.some((tag) => tag.toLowerCase().includes(query))
+    );
     const limited = results.slice(0, input.limit);
     return Result.ok({
       query: input.query,

--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,7 @@
         "@ontrails/http": "workspace:^",
         "@ontrails/logging": "workspace:^",
         "@ontrails/mcp": "workspace:^",
+        "@ontrails/store": "workspace:^",
         "commander": "catalog:",
         "hono": "^4.7.0",
         "zod": "catalog:",
@@ -160,8 +161,12 @@
         "@ontrails/core": "workspace:^",
       },
       "peerDependencies": {
+        "drizzle-orm": "^0.45.2",
         "zod": "catalog:",
       },
+      "optionalPeers": [
+        "drizzle-orm",
+      ],
     },
     "packages/testing": {
       "name": "@ontrails/testing",

--- a/bun.lock
+++ b/bun.lock
@@ -171,6 +171,9 @@
     "packages/testing": {
       "name": "@ontrails/testing",
       "version": "1.0.0-beta.13",
+      "devDependencies": {
+        "@ontrails/store": "workspace:^",
+      },
       "peerDependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -13,6 +13,9 @@
     "lint": "oxlint ./src",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
+  "devDependencies": {
+    "@ontrails/store": "workspace:^"
+  },
   "peerDependencies": {
     "@ontrails/cli": "workspace:^",
     "@ontrails/core": "workspace:^",

--- a/packages/testing/src/__tests__/all.test.ts
+++ b/packages/testing/src/__tests__/all.test.ts
@@ -1,44 +1,111 @@
 import { describe } from 'bun:test';
 
-import { Result, provision, trail, topo } from '@ontrails/core';
+import { Result, trail, topo } from '@ontrails/core';
 import { z } from 'zod';
 
 import { testAll } from '../all.js';
+import { store as defineStore } from '@ontrails/store';
+import { connectDrizzle } from '@ontrails/store/drizzle';
 
-const mockDbProvision = provision('db.mock.all', {
-  create: () => Result.ok({ source: 'factory' }),
-  mock: () => ({ source: 'mock' }),
+const dbDefinition = defineStore({
+  entities: {
+    fixtures: [
+      {
+        id: 'seed-1',
+        name: 'Alpha',
+        source: 'mock',
+      },
+    ],
+    generated: ['id'],
+    primaryKey: 'id',
+    schema: z.object({
+      id: z.string(),
+      name: z.string(),
+      source: z.string(),
+    }),
+  },
 });
 
+const createDbProvision = (
+  seed?: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly source: string;
+  }[]
+) =>
+  connectDrizzle(dbDefinition, {
+    id: 'db.mock.all',
+    ...(seed === undefined ? {} : { mockSeed: { entities: seed } }),
+    url: ':memory:',
+  });
+
+const createOverrideStore = () => {
+  const { mock } = createDbProvision([
+    {
+      id: 'seed-1',
+      name: 'Override',
+      source: 'override',
+    },
+  ]);
+
+  if (mock === undefined) {
+    throw new Error('Expected drizzle test store to expose a mock factory');
+  }
+
+  const created = mock();
+  if (created instanceof Promise) {
+    throw new TypeError(
+      'Expected drizzle test store mock to resolve synchronously'
+    );
+  }
+
+  return created;
+};
+
+const mockDbProvision = createDbProvision();
+
 const mockedTrail = trail('provision.mocked.all', {
-  blaze: (_input, ctx) =>
-    Result.ok({ source: mockDbProvision.from(ctx).source }),
-  description: 'Trail that uses a mocked provision through testAll',
+  blaze: async (_input, ctx) => {
+    const entity = await mockDbProvision.from(ctx).entities.get('seed-1');
+    if (entity === null) {
+      return Result.err(new Error('expected seeded entity to exist'));
+    }
+
+    return Result.ok({ name: entity.name, source: entity.source });
+  },
+  description:
+    'Trail that uses a mocked connector-bound provision through testAll',
   examples: [
     {
-      expected: { source: 'mock' },
+      expected: { name: 'Alpha', source: 'mock' },
       input: {},
       name: 'Uses auto-resolved provision mock',
     },
   ],
   input: z.object({}),
-  output: z.object({ source: z.string() }),
+  output: z.object({ name: z.string(), source: z.string() }),
   provisions: [mockDbProvision],
 });
 
 const overrideTrail = trail('provision.override.all', {
-  blaze: (_input, ctx) =>
-    Result.ok({ source: mockDbProvision.from(ctx).source }),
+  blaze: async (_input, ctx) => {
+    const entity = await mockDbProvision.from(ctx).entities.get('seed-1');
+    if (entity === null) {
+      return Result.err(new Error('expected overridden entity to exist'));
+    }
+
+    return Result.ok({ name: entity.name, source: entity.source });
+  },
   description: 'Trail that prefers explicit overrides over mock factories',
   examples: [
     {
-      expected: { source: 'override' },
+      expected: { name: 'Override', source: 'override' },
       input: {},
       name: 'Explicit provision override wins',
     },
   ],
   input: z.object({}),
-  output: z.object({ source: z.string() }),
+  output: z.object({ name: z.string(), source: z.string() }),
   provisions: [mockDbProvision],
 });
 
@@ -59,8 +126,10 @@ describe('testAll explicit provision overrides', () => {
       mockDbProvision,
       overrideTrail,
     } as Record<string, unknown>),
-    {
-      provisions: { 'db.mock.all': { source: 'override' } },
-    }
+    () => ({
+      provisions: {
+        'db.mock.all': createOverrideStore(),
+      },
+    })
   );
 });


### PR DESCRIPTION
## Summary
- Replaces trails-demo hand-written Map store with `@ontrails/store/drizzle`
- Proves `testAll` works with connector-bound provisions
- Adds explicit intent declarations to demo trails
- Fixes AlreadyExistsError double-wrapping bug

## What changed
The trails-demo app is updated to dogfood the new store packages. The hand-written in-memory Map store is replaced with a `@ontrails/store/drizzle`-backed provision, validating the full declaration-to-connector pipeline in a real app. All demo trails now include explicit intent declarations. The `testAll` harness is confirmed to work with connector-bound provisions using mock factories. A bug where AlreadyExistsError was double-wrapped during error handling is fixed.

## How it was tested
- bun run build
- bun run test
- bun run typecheck
- bun run lint
- Package-specific tests where applicable

Closes: TRL-136, TRL-162, TRL-163, TRL-164
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
