### PR TITLE
fix(plugin): align marketplace.json version to 0.2.0 and fix vocabulary [TRL-188]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,16 +5,16 @@
     "url": "https://github.com/outfitter-dev"
   },
   "metadata": {
-    "description": "Build with the Trails framework — contract-first trails, surfaces, testing, and governance.",
-    "version": "0.1.0"
+    "description": "Build with the Trails framework — contract-first trails, trailheads, testing, and governance.",
+    "version": "0.2.0"
   },
   "repository": "https://github.com/outfitter-dev/trails",
   "plugins": [
     {
       "name": "trails",
       "source": "./plugin",
-      "version": "0.1.0",
-      "description": "Skills for building Trails applications — trail creation, surfaces, testing, debugging, migration, and governance."
+      "version": "0.2.0",
+      "description": "Skills for building Trails applications — trail creation, trailheads, testing, debugging, migration, and governance."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Aligns `.claude-plugin/marketplace.json` version from 0.1.0 to 0.2.0 to match `plugin/.claude-plugin/plugin.json`
- Fixes stale "surfaces" vocabulary to "trailheads" in marketplace descriptions

Closes https://linear.app/outfitter/issue/TRL-188

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
