### PR TITLE
docs: add READMEs for config, permits, and tracker packages [TRL-182]

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,212 @@
+# @ontrails/config
+
+Schema-derived configuration for Trails.
+
+The root package owns the connector-agnostic config declaration and resolution engine. Schemas define the contract; the provision and gate bind resolved values to the execution context.
+
+## The core pattern
+
+### 1. Define the config schema
+
+```typescript
+import { defineConfig, env, secret } from '@ontrails/config';
+import { z } from 'zod';
+
+export const config = defineConfig({
+  schema: z.object({
+    port: z.number().default(3000),
+    host: z.string().default('localhost'),
+    database: z.object({
+      url: env(secret(z.string()), 'DATABASE_URL'),
+    }),
+    debug: z.boolean().default(false),
+  }),
+  base: {
+    host: 'example.com',
+  },
+  loadouts: {
+    production: {
+      debug: false,
+      host: 'prod.example.com',
+      port: 443,
+    },
+    test: {
+      debug: true,
+      port: 0,
+    },
+  },
+});
+```
+
+### 2. Resolve the config at bootstrap
+
+```typescript
+import { registerConfigState } from '@ontrails/config';
+
+const result = await config.resolve({
+  cwd: process.cwd(),
+  loadout: process.env.TRAILS_ENV,
+});
+
+if (!result.isOk()) {
+  throw result.error;
+}
+
+registerConfigState({
+  resolved: result.unwrap(),
+  schema: config.schema,
+  base: config.base,
+  loadout: process.env.TRAILS_ENV,
+  env: process.env,
+});
+```
+
+### 3. Access resolved config in trails
+
+```typescript
+import { configProvision } from '@ontrails/config';
+
+export const getStatus = trail('status.get', {
+  provisions: [configProvision],
+  blaze: (_input, ctx) => {
+    const state = configProvision.from(ctx);
+    return Result.ok({
+      port: state.resolved.port,
+      debug: state.resolved.debug,
+    });
+  },
+});
+```
+
+## Resolution stack
+
+Config resolves through a deterministic priority order:
+
+```text
+defaults (schema) → base → loadout → local → env
+```
+
+Each layer overrides the previous. Environment variables always win.
+
+## Extensions
+
+### `env()`
+
+Bind a schema field to an environment variable:
+
+```typescript
+import { env } from '@ontrails/config';
+
+const schema = z.object({
+  database: env(z.string(), 'DATABASE_URL'),
+  port: env(z.number(), 'PORT').default(3000),
+});
+```
+
+Environment variables are coerced to the schema type. Apply `env()` before `.default()` so metadata lives on the inner type.
+
+### `secret()`
+
+Mark a schema field as sensitive:
+
+```typescript
+import { secret } from '@ontrails/config';
+
+const schema = z.object({
+  apiKey: secret(z.string()),
+  password: secret(env(z.string(), 'DB_PASSWORD')),
+});
+```
+
+Secret fields are redacted in explain output, diagnostics, and logs.
+
+### `deprecated()`
+
+Mark a field as deprecated with migration guidance:
+
+```typescript
+import { deprecated } from '@ontrails/config';
+
+const schema = z.object({
+  oldField: deprecated(z.string(), 'Use newField instead'),
+  newField: z.string(),
+});
+```
+
+## The provision
+
+The config provision manages resolved config lifecycle:
+
+```typescript
+import { configProvision } from '@ontrails/config';
+
+export const myTrail = trail('my.trail', {
+  provisions: [configProvision],
+  blaze: (_input, ctx) => {
+    const state = configProvision.from(ctx);
+    return Result.ok(state.resolved);
+  },
+});
+```
+
+## The gate
+
+The config gate reserves a slot in the execution context for per-trail config validation:
+
+```typescript
+import { configGate } from '@ontrails/config';
+
+export const app = topo('my-app', configModule);
+// Register configGate with your trailhead
+```
+
+## Trail definitions
+
+### `config.check`
+
+Validate config values against the schema. Returns diagnostics with field-level status (valid, missing, invalid, deprecated, default).
+
+### `config.describe`
+
+Describe all fields in the schema — paths, types, defaults, env bindings, secret markers, deprecation messages.
+
+### `config.explain`
+
+Show which source won for each config field — defaults, base, loadout, local, or env.
+
+### `config.init`
+
+Generate example config files in TOML, JSON, JSONC, or YAML. Optionally writes `.env.example` and `.schema.json`.
+
+## Testing
+
+Trails that depend on `configProvision` auto-resolve with a mock when registered in the topo:
+
+```typescript
+import { testAll } from '@ontrails/testing';
+
+const results = testAll(app);
+// configProvision.mock() is called automatically
+```
+
+For explicit test setup:
+
+```typescript
+import { registerConfigState, clearConfigState } from '@ontrails/config';
+
+afterEach(() => clearConfigState());
+
+test('config trail', async () => {
+  registerConfigState({
+    resolved: { port: 3000 },
+    schema: z.object({ port: z.number() }),
+  });
+  // ...
+});
+```
+
+## Installation
+
+```bash
+bun add @ontrails/config @ontrails/core zod
+```

--- a/packages/permits/README.md
+++ b/packages/permits/README.md
@@ -1,0 +1,175 @@
+# @ontrails/permits
+
+Scope-based authorization for Trails.
+
+The permits package owns the connector-agnostic `authProvision` and `authGate`. Connector packages bind those declarations to concrete auth logic, just like a trailhead connector binds a topo to CLI, MCP, or HTTP.
+
+## The core pattern
+
+### 1. Declare permit requirements on trails
+
+```typescript
+export const create = trail('gist.create', {
+  permit: { scopes: ['gist:write'] },
+  blaze: async (input, ctx) => {
+    // authGate enforces scopes before blaze runs
+    return Result.ok(newGist);
+  },
+});
+
+export const search = trail('gist.search', {
+  permit: 'public',
+  blaze: async (input, ctx) => {
+    // No authentication required
+    return Result.ok(results);
+  },
+});
+```
+
+### 2. Register the auth gate
+
+```typescript
+import { authGate } from '@ontrails/permits';
+
+export const app = topo('my-app', gistModule);
+// Register authGate with your trailhead
+```
+
+The gate reads each trail's `permit` field:
+
+- `'public'` or `undefined` — gate passes through
+- `{ scopes: [...] }` — gate checks that `ctx.permit` contains all required scopes
+
+### 3. Bind a connector at bootstrap
+
+```typescript
+import { createJwtConnector } from '@ontrails/permits/jwt';
+
+const connector = createJwtConnector({
+  secret: process.env.JWT_SECRET,
+  issuer: 'https://auth.example.com',
+  audience: 'api.example.com',
+});
+```
+
+## Auth connectors
+
+An auth connector authenticates requests and produces permits.
+
+### Built-in: JWT connector
+
+Verifies HS256-signed JWTs and extracts claims into permits:
+
+```typescript
+import { createJwtConnector } from '@ontrails/permits/jwt';
+
+const connector = createJwtConnector({
+  secret: 'your-hmac-secret',
+  issuer: 'https://auth.example.com',
+  audience: 'api.example.com',
+  scopesClaim: 'scope',
+  rolesClaim: 'roles',
+});
+```
+
+### Custom connectors
+
+Implement the `AuthConnector` interface:
+
+```typescript
+import type { AuthConnector, PermitExtractionInput, Permit } from '@ontrails/permits';
+
+const myConnector: AuthConnector = {
+  authenticate: async (input: PermitExtractionInput) => {
+    if (!input.bearerToken) return Result.ok(null);
+    const permit: Permit = {
+      id: 'user-42',
+      scopes: ['user:read', 'user:write'],
+      roles: ['admin'],
+    };
+    return Result.ok(permit);
+  },
+};
+```
+
+## Permits and scopes
+
+A `Permit` is the resolved identity and scopes from successful authentication:
+
+```typescript
+interface Permit {
+  readonly id: string;
+  readonly scopes: readonly string[];
+  readonly roles?: readonly string[];
+  readonly tenantId?: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+```
+
+Access the permit in your blaze:
+
+```typescript
+import { getPermit } from '@ontrails/permits';
+
+const myTrail = trail('do.something', {
+  blaze: async (_input, ctx) => {
+    const permit = getPermit(ctx);
+    if (!permit) return Result.err(new Error('Not authenticated'));
+    return Result.ok({ userId: permit.id });
+  },
+});
+```
+
+Scopes follow the `entity:action` convention: `user:read`, `gist:write`, etc.
+
+## The auth.verify trail
+
+An infrastructure trail that verifies bearer tokens and returns permits:
+
+```typescript
+import { authVerify } from '@ontrails/permits';
+
+// Returns { valid: true, permit: { id, scopes, roles } }
+// or { valid: false, error: 'Token has expired', errorCode: 'expired_token' }
+```
+
+## Testing with mock permits
+
+Use `mintTestPermit()` and `mintPermitForTrail()` in tests:
+
+```typescript
+import { mintTestPermit, mintPermitForTrail } from '@ontrails/permits';
+
+const permit = mintTestPermit({
+  id: 'user-123',
+  scopes: ['gist:read', 'gist:write'],
+  roles: ['editor'],
+});
+
+// Mint a permit matching a trail's requirements
+const trailPermit = mintPermitForTrail(myTrail);
+// { id: 'test-...', scopes: ['gist:write'] }
+```
+
+## Permit governance
+
+Use `validatePermits()` to check trails against governance rules:
+
+```typescript
+import { validatePermits } from '@ontrails/permits';
+
+const diagnostics = validatePermits(app.list());
+```
+
+Built-in rules:
+
+- `destroyWithoutPermit` — error if a destroy trail has no permit
+- `writeWithoutPermit` — warning if a write trail has no permit
+- `scopeNamingConsistency` — warning if a scope doesn't follow `entity:action`
+- `orphanScopeDetection` — warning if a scope appears in only one trail
+
+## Installation
+
+```bash
+bun add @ontrails/permits @ontrails/core zod
+```

--- a/packages/tracker/README.md
+++ b/packages/tracker/README.md
@@ -1,0 +1,183 @@
+# @ontrails/tracker
+
+Automatic trail execution recording — just add a gate.
+
+Tracker wraps every trail invocation to capture timing, status, and parentage, then writes records to a sink. Supports intent-based sampling, manual instrumentation through spans and annotations, and multiple backends (memory, SQLite dev store, OpenTelemetry).
+
+## The core pattern
+
+### 1. Create a sink
+
+```typescript
+import { createMemorySink } from '@ontrails/tracker';
+
+const sink = createMemorySink();
+```
+
+Sinks receive completed Track records. Use a memory sink for testing, a dev store for local development, or an OTel connector to forward to your collector.
+
+### 2. Create a gate and register it
+
+```typescript
+import { createTrackerGate } from '@ontrails/tracker';
+
+const gate = createTrackerGate(sink);
+```
+
+The gate intercepts every trail and wraps its execution. No trails need to change — tracking is automatic.
+
+## The tracker provision
+
+Access tracker state from any trail:
+
+```typescript
+import { trackerProvision } from '@ontrails/tracker';
+
+export const checkStatus = trail('status.check', {
+  provisions: [trackerProvision],
+  blaze: (_input, ctx) => {
+    const state = trackerProvision.from(ctx);
+    return Result.ok({
+      active: state.active,
+      recordCount: state.store?.count() ?? 0,
+    });
+  },
+});
+```
+
+## Trail definitions
+
+### `tracker.status`
+
+Reports the current tracking state — active status, record count, sampling config.
+
+### `tracker.query`
+
+Query execution history from the dev store:
+
+The trail accepts these inputs:
+
+- `trailId` — filter by trail ID
+- `errorsOnly` — show only failed executions
+- `traceId` — retrieve a full trace tree
+- `limit` — cap the number of results
+
+Use `run()` or `ctx.cross('tracker.query', { trailId: 'user.create' })` to invoke it programmatically.
+
+## Sinks
+
+### Memory sink
+
+For testing and demos:
+
+```typescript
+const sink = createMemorySink();
+const gate = createTrackerGate(sink);
+
+// ... run trails ...
+
+expect(sink.records).toHaveLength(3);
+expect(sink.records[0]?.status).toBe('ok');
+```
+
+### Dev store
+
+SQLite-backed persistence for local development:
+
+```typescript
+import { createDevStore } from '@ontrails/tracker';
+
+const store = createDevStore({
+  path: './debug.db',
+  maxRecords: 50000,
+  maxAge: 1000 * 60 * 60 * 24 * 30,
+});
+
+const gate = createTrackerGate(store);
+```
+
+The dev store uses WAL mode and prunes automatically.
+
+### OpenTelemetry connector
+
+Export traces to any OTel-compatible collector:
+
+```typescript
+import { createOtelConnector } from '@ontrails/tracker';
+
+const sink = createOtelConnector({
+  exporter: async (spans) => {
+    await myOtelCollector.send(spans);
+  },
+  batchSize: 50,
+});
+```
+
+The connector translates Track records to OTel spans with Trails-namespaced attributes (`trails.trail.id`, `trails.intent`, `trails.trailhead`, `trails.permit.id`).
+
+## Sampling
+
+By default, tracker samples traces based on intent:
+
+- `read` operations: sampled (low rate)
+- `write` operations: 100%
+- `destroy` operations: 100%
+
+Override sampling per gate:
+
+```typescript
+const gate = createTrackerGate(sink, {
+  sampling: { read: 0.1, write: 1.0, destroy: 1.0 },
+  keepOnError: true, // Promote sampled-out traces if they fail
+});
+```
+
+## Manual instrumentation
+
+### Spans
+
+Create child spans within a trail to break timing into segments:
+
+```typescript
+import { tracker } from '@ontrails/tracker';
+
+export const processUser = trail('user.process', {
+  blaze: async (input, ctx) => {
+    const api = tracker.from(ctx);
+    const user = await api.span('load-user', async () => {
+      return await db.users.get(input.userId);
+    });
+    return Result.ok(user);
+  },
+});
+```
+
+### Annotations
+
+Add context to a trail's record:
+
+```typescript
+const api = tracker.from(ctx);
+api.annotate({ userId: input.userId, dataSize: bytes });
+```
+
+## Testing
+
+```typescript
+import { createMemorySink, createTrackerGate } from '@ontrails/tracker';
+import { testAll } from '@ontrails/testing';
+
+const sink = createMemorySink();
+const results = testAll(app, {
+  gates: [createTrackerGate(sink)],
+});
+
+expect(sink.records).toHaveLength(5);
+expect(sink.records.filter((r) => r.status === 'err')).toHaveLength(0);
+```
+
+## Installation
+
+```bash
+bun add @ontrails/tracker
+```


### PR DESCRIPTION
## Summary
- Adds README.md for `@ontrails/config` — schema-driven config, resolution stack, extensions, provision, gate, trail definitions
- Adds README.md for `@ontrails/permits` — auth provision, auth gate, connectors, permit governance, testing helpers
- Adds README.md for `@ontrails/tracker` — tracker gate, sinks, sampling, manual instrumentation, trail definitions

All three follow the style and depth of `packages/store/README.md`.

Closes https://linear.app/outfitter/issue/TRL-182

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
