### PR TITLE
docs: add topo store user guide and schema reference [TRL-190]

### DIFF
--- a/docs/topo-store-reference.md
+++ b/docs/topo-store-reference.md
@@ -1,0 +1,335 @@
+# Topo Store Reference
+
+Schema definitions, query patterns, and programmatic API for the topo store. For the user-facing operations guide, see [Topo Store](./topo-store.md).
+
+## SQLite Schema
+
+### `topo_saves`
+
+Every topo snapshot.
+
+```sql
+CREATE TABLE topo_saves (
+  id TEXT PRIMARY KEY,
+  git_sha TEXT,
+  git_dirty INTEGER NOT NULL,
+  trail_count INTEGER NOT NULL,
+  signal_count INTEGER NOT NULL,
+  provision_count INTEGER NOT NULL,
+  created_at TEXT NOT NULL
+);
+```
+
+### `topo_pins`
+
+Named references to important saves.
+
+```sql
+CREATE TABLE topo_pins (
+  name TEXT PRIMARY KEY,
+  save_id TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+```
+
+### `topo_trails`
+
+Trail definitions for each save.
+
+```sql
+CREATE TABLE topo_trails (
+  id TEXT NOT NULL,
+  intent TEXT,
+  idempotent INTEGER NOT NULL,
+  has_output INTEGER NOT NULL,
+  has_examples INTEGER NOT NULL,
+  example_count INTEGER NOT NULL,
+  description TEXT,
+  meta TEXT,
+  save_id TEXT NOT NULL,
+  PRIMARY KEY (id, save_id)
+);
+```
+
+### `topo_crossings`
+
+Trail composition graph.
+
+```sql
+CREATE TABLE topo_crossings (
+  source_id TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  save_id TEXT NOT NULL,
+  PRIMARY KEY (source_id, target_id, save_id)
+);
+```
+
+### `topo_provisions`
+
+Provision definitions.
+
+```sql
+CREATE TABLE topo_provisions (
+  id TEXT NOT NULL,
+  has_mock INTEGER NOT NULL,
+  has_health INTEGER NOT NULL,
+  save_id TEXT NOT NULL,
+  PRIMARY KEY (id, save_id)
+);
+```
+
+### `topo_trail_provisions`
+
+Which provisions each trail declares.
+
+```sql
+CREATE TABLE topo_trail_provisions (
+  trail_id TEXT NOT NULL,
+  provision_id TEXT NOT NULL,
+  save_id TEXT NOT NULL,
+  PRIMARY KEY (trail_id, provision_id, save_id)
+);
+```
+
+### `topo_signals`
+
+Signal definitions.
+
+```sql
+CREATE TABLE topo_signals (
+  id TEXT NOT NULL,
+  description TEXT,
+  save_id TEXT NOT NULL,
+  PRIMARY KEY (id, save_id)
+);
+```
+
+### `topo_trail_signals`
+
+Which signals each trail can emit.
+
+```sql
+CREATE TABLE topo_trail_signals (
+  trail_id TEXT NOT NULL,
+  signal_id TEXT NOT NULL,
+  save_id TEXT NOT NULL,
+  PRIMARY KEY (trail_id, signal_id, save_id)
+);
+```
+
+### `topo_examples`
+
+Trail examples with input, expected output, and error cases.
+
+```sql
+CREATE TABLE topo_examples (
+  id TEXT PRIMARY KEY,
+  trail_id TEXT NOT NULL,
+  ordinal INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  input TEXT NOT NULL,
+  expected TEXT,
+  error TEXT,
+  save_id TEXT NOT NULL
+);
+```
+
+### `topo_trailheads`
+
+Which trailheads expose which trails.
+
+```sql
+CREATE TABLE topo_trailheads (
+  trail_id TEXT NOT NULL,
+  trailhead TEXT NOT NULL,
+  derived_name TEXT NOT NULL,
+  method TEXT,
+  save_id TEXT NOT NULL,
+  PRIMARY KEY (trail_id, trailhead, save_id)
+);
+```
+
+### `topo_exports`
+
+Serialized trailhead maps and lockfiles.
+
+```sql
+CREATE TABLE topo_exports (
+  save_id TEXT PRIMARY KEY,
+  trailhead_map TEXT NOT NULL,
+  trailhead_hash TEXT NOT NULL,
+  serialized_lock TEXT NOT NULL
+);
+```
+
+### `topo_schemas`
+
+Cached JSON schemas (avoids recomputing `zodToJsonSchema()`).
+
+```sql
+CREATE TABLE topo_schemas (
+  owner_id TEXT NOT NULL,
+  owner_kind TEXT NOT NULL,
+  schema_kind TEXT NOT NULL,
+  zod_hash TEXT NOT NULL,
+  json_schema TEXT NOT NULL,
+  save_id TEXT NOT NULL,
+  PRIMARY KEY (owner_id, owner_kind, schema_kind, save_id)
+);
+```
+
+## Query Patterns
+
+### Find all trails by intent
+
+```sql
+SELECT id, intent, description FROM topo_trails
+WHERE save_id = ? AND intent = ?
+ORDER BY id ASC
+```
+
+### Find trails using a specific provision
+
+```sql
+SELECT DISTINCT t.id, t.intent
+FROM topo_trails t
+JOIN topo_trail_provisions tp ON t.id = tp.trail_id AND t.save_id = tp.save_id
+WHERE t.save_id = ? AND tp.provision_id = ?
+```
+
+### Find incoming callers
+
+```sql
+SELECT source_id FROM topo_crossings
+WHERE save_id = ? AND target_id = ?
+```
+
+### Trails without output schemas
+
+```sql
+SELECT id, intent FROM topo_trails
+WHERE save_id = ? AND has_output = 0
+```
+
+### Compare two saves (trails added)
+
+```sql
+SELECT id FROM topo_trails WHERE save_id = ?
+EXCEPT
+SELECT id FROM topo_trails WHERE save_id = ?
+```
+
+### Crossing closure (recursive)
+
+```sql
+WITH RECURSIVE closure(id) AS (
+  VALUES(?)
+  UNION
+  SELECT c.target_id FROM topo_crossings c
+  JOIN closure cl ON c.source_id = cl.id
+  WHERE c.save_id = ?
+)
+SELECT id FROM closure
+```
+
+## Programmatic API
+
+### `createTopoStore(options?)`
+
+Create a read-only interface.
+
+```typescript
+import { createTopoStore } from '@ontrails/core';
+
+const store = createTopoStore({ rootDir: '/path/to/workspace' });
+store.trails.list({ intent: 'write' });
+store.provisions.get('db.main');
+store.pins.list();
+store.saves.latest();
+```
+
+### `createMockTopoStore(seed?)`
+
+Create a mock for testing.
+
+```typescript
+import { createMockTopoStore } from '@ontrails/core';
+
+const mock = createMockTopoStore({
+  trails: [{ id: 'auth.login', intent: 'write', hasOutput: true, ... }],
+  provisions: [{ id: 'db.main', hasMock: true, ... }],
+  pins: [{ name: 'baseline', saveId: 'save-1', ... }],
+});
+```
+
+### `topoStore` provision
+
+Read-only provision for accessing the topo store in trails.
+
+```typescript
+import { topoStore } from '@ontrails/core';
+
+trail('warden.check', {
+  provisions: [topoStore],
+  blaze: async (_input, ctx) => {
+    const store = topoStore.from(ctx);
+    // store.trails, store.provisions, store.pins, store.saves, store.query()
+  },
+});
+```
+
+### `TopoStoreRef`
+
+Reference type for querying by save or pin:
+
+```typescript
+interface TopoStoreRef {
+  readonly pin?: string;
+  readonly saveId?: string;
+}
+```
+
+- `{ pin: 'v1.0' }` — look up save by pin name
+- `{ saveId: 'uuid' }` — use exact save ID
+- `{}` — use the latest save
+
+## Record Types
+
+### `TopoStoreTrailRecord`
+
+```typescript
+{
+  id: string;
+  kind: 'trail';
+  intent: 'read' | 'write' | 'destroy';
+  safety: '-' | 'read' | 'write' | 'destroy';
+  idempotent: boolean;
+  hasOutput: boolean;
+  hasExamples: boolean;
+  exampleCount: number;
+  description: string | null;
+  meta: Readonly<Record<string, unknown>> | null;
+  saveId: string;
+}
+```
+
+### `TopoStoreTrailDetailRecord`
+
+Extends trail record with `crosses`, `detours`, `provisions`, and `examples` arrays.
+
+### `TopoStoreProvisionRecord`
+
+```typescript
+{
+  id: string;
+  kind: 'provision';
+  lifetime: 'singleton';
+  health: 'available' | 'none';
+  description: string | null;
+  hasMock: boolean;
+  hasHealth: boolean;
+  saveId: string;
+  usedBy: readonly string[];
+}
+```

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -1,0 +1,131 @@
+# Topo Store
+
+The topo store is Trails' queryable database of your application's topology — every trail, signal, provision, and their relationships. It lives in `.trails/trails.db` and is created automatically when you run topo commands.
+
+For the full SQLite schema and programmatic query API, see the [Topo Store Reference](./topo-store-reference.md).
+
+## The `.trails/` directory
+
+Trails creates a `.trails/` directory in your workspace root on first use:
+
+```text
+.trails/
+├── .gitignore             # Auto-generated gitignore for this directory
+├── config/                # Local config overrides (gitignored)
+├── dev/                   # Development state (gitignored)
+├── generated/             # Generated artifacts (gitignored)
+├── trails.db              # SQLite database (topology store)
+├── trails.lock            # Lockfile (text, git-tracked)
+└── _trailhead.json        # Full trailhead map (generated on export)
+```
+
+- **`trails.db`** — SQLite database containing all topo saves, pins, and schema cache. Not git-tracked.
+- **`trails.lock`** — Committed lockfile. Text format, git-tracked. This is your contract's current state for CI.
+- **`_trailhead.json`** — Full trailhead map with all metadata, generated on export.
+
+## What trails.db contains
+
+### Saves
+
+Every topo write creates a **save** — a snapshot of your topology at that moment. Each save records a unique ID, git SHA, dirty state, trail/signal/provision counts, and timestamp. Older unpinned saves are pruned automatically.
+
+### Pins
+
+A **pin** is a durable, human-friendly name you assign to a save you care about. Pins persist until you explicitly unpin them. They are your landmarks in topo history.
+
+### Metadata
+
+For each save, the database stores trail IDs, intents, descriptions, examples, crossings, signals, provisions, and their relationships. The schema cache avoids recomputing `zodToJsonSchema()` when schemas haven't changed.
+
+## Commands
+
+### `trails topo pin`
+
+Create a named pin for the current topo state.
+
+```bash
+trails topo pin --name before-auth-refactor
+trails topo pin --name v1.2.0-baseline
+```
+
+Use before major refactors, deployments, or release boundaries.
+
+### `trails topo unpin`
+
+Remove a pin. Requires `--yes` to confirm (dry-run by default). The underlying save becomes eligible for pruning.
+
+```bash
+trails topo unpin --name experimental-feature --yes
+```
+
+### `trails topo show`
+
+Display detailed information about a trail or provision — schema, examples, crossings, provisions.
+
+```bash
+trails topo show auth.login
+```
+
+### `trails topo history`
+
+List saved topo states (pinned and recent autosaves).
+
+```bash
+trails topo history --limit 20
+```
+
+### `trails topo export`
+
+Export the current topo to `.trails/trails.lock` and `.trails/_trailhead.json`.
+
+```bash
+trails topo export
+```
+
+### `trails topo verify`
+
+Check that `.trails/trails.lock` matches your current topo. Fails if the lockfile has drifted.
+
+```bash
+# In CI
+trails topo verify || exit 1
+```
+
+## Workflows
+
+### Pre-deployment
+
+1. Make topology changes
+2. Export: `trails topo export`
+3. Commit `.trails/trails.lock`
+4. In CI, verify: `trails topo verify`
+
+### Pin before refactoring
+
+```bash
+trails topo pin --name pre-refactor
+# ... make changes ...
+trails topo export
+# Compare lockfile diff against the pinned baseline
+```
+
+### Querying from trails
+
+Use the `topoStore` provision for programmatic access:
+
+```typescript
+import { topoStore } from '@ontrails/core';
+
+trail('warden.check-outputs', {
+  provisions: [topoStore],
+  intent: 'read',
+  blaze: async (_input, ctx) => {
+    const store = topoStore.from(ctx);
+    const writeTrails = store.trails.list({ intent: 'write' });
+    const missing = writeTrails.filter(t => !t.hasOutput);
+    return Result.ok({ pass: missing.length === 0, missing });
+  },
+});
+```
+
+The provision is read-only by design — available in dev and CI, not production.


### PR DESCRIPTION
## Summary
- Adds `docs/topo-store.md` — user-facing operations guide covering .trails/ directory, all topo commands, practical workflows
- Adds `docs/topo-store-reference.md` — SQLite schema definitions, query patterns, programmatic API, record types

Closes https://linear.app/outfitter/issue/TRL-190

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
