### PR TITLE
ci: enable turbo remote cache

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export TURBO_API=https://turbo-cache.outfitter.dev
+export TURBO_REMOTE_CACHE_SIGNATURE_KEY=297902a324b26bd2941596bc6e77b0530fa9b9d98f0dd16f450ba3f28bae5113

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_API: ${{ secrets.TURBO_API }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+
 jobs:
   build:
     name: Build
@@ -21,12 +27,6 @@ jobs:
       - name: Build
         run: bun run build
 
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-
-
   lint:
     name: Lint & Format
     needs: build
@@ -35,12 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-
 
       - name: Lint
         run: bun run lint
@@ -57,12 +51,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
 
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-
-
       - name: Build
         run: bun run build
 
@@ -77,12 +65,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-
 
       - name: Build
         run: bun run build
@@ -103,12 +85,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-
 
       - name: Build
         run: bun run build

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "remoteCache": {
+    "signature": true
+  },
   "globalDependencies": [".bun-version", ".oxlintrc.json"],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

- Enables turbo remote cache via `turbo-cache.outfitter.dev` (same org cache server as `stack`)
- Replaces per-job `actions/cache@v4` blocks with top-level env vars from org-wide GitHub secrets (`TURBO_TOKEN`, `TURBO_API`, `TURBO_TEAM`, `TURBO_REMOTE_CACHE_SIGNATURE_KEY`)
- Adds `.envrc` for local dev cache hits
- Adds `remoteCache.signature: true` to `turbo.json`

## Why

The old approach cached `.turbo/` via `actions/cache` keyed on `bun.lock` hash + commit SHA. This meant:
- No cache sharing across branches (different SHAs)
- No cache sharing between local dev and CI
- No cache sharing with other repos in the org

Turbo remote cache keys on **input content hashes**, so stacked branches get correct cache hits — if source files match, cache hits; if they diverge, cache misses. Strictly better for our Graphite workflow.

## Test plan

- [ ] CI passes with remote cache enabled
- [ ] Verify cache hits in turbo output logs (look for `cache hit, replaying logs`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
