### PR TITLE
ci: enable turbo remote cache

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,8 @@
+# Turbo remote cache — enables local dev cache sharing with CI and other machines.
+# Copy this to .envrc and fill in the values from 1Password or your team secret store.
+# direnv will auto-load .envrc when you cd into this directory.
+
+export TURBO_TOKEN=<your-turbo-token>
+export TURBO_TEAM=<your-turbo-team>
+export TURBO_API=https://turbo-cache.outfitter.dev
+export TURBO_REMOTE_CACHE_SIGNATURE_KEY=<set-from-1password-or-team-secret>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Turbo remote cache — speeds up CI by sharing build artifacts across runs.
+# Forks: these secrets won't be available, and turbo will fall back to local
+# caching automatically. CI still works, just without cross-run cache hits.
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_API: https://turbo-cache.outfitter.dev
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+
 jobs:
   build:
     name: Build
@@ -21,12 +30,6 @@ jobs:
       - name: Build
         run: bun run build
 
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-
-
   lint:
     name: Lint & Format
     needs: build
@@ -35,12 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-
 
       - name: Lint
         run: bun run lint
@@ -57,12 +54,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
 
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-
-
       - name: Build
         run: bun run build
 
@@ -77,12 +68,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-
 
       - name: Build
         run: bun run build
@@ -103,12 +88,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}-
 
       - name: Build
         run: bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 .agents/notes/
 .claude/agent-memory/
 .npmrc
+.envrc

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "remoteCache": {
+    "signature": true
+  },
   "globalDependencies": [".bun-version", ".oxlintrc.json"],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

- Enables turbo remote cache via `turbo-cache.outfitter.dev` (same org cache server as `stack`)
- Replaces per-job `actions/cache@v4` blocks with top-level env vars from org-wide GitHub secrets
- Adds `.envrc.example` template for local dev cache hits (`.envrc` is gitignored)
- Adds `remoteCache.signature: true` to `turbo.json`

## Changes from previous attempt (#86)

- **No secrets in committed files** — `.envrc` is gitignored, `.envrc.example` uses placeholders
- **`TURBO_API` hardcoded in workflow** — it's a URL, not sensitive, single source of truth
- Fresh branch with clean history (no leaked key in git log)

## Action required

The `TURBO_REMOTE_CACHE_SIGNATURE_KEY` that was exposed in #86 **must be rotated** in:
1. GitHub org secrets
2. `turbo-cache.outfitter.dev` server config

## Test plan

- [ ] CI passes with remote cache enabled
- [ ] Verify cache hits in turbo output logs (look for `cache hit, replaying logs`)
- [ ] Confirm `.envrc` is not tracked (`git ls-files .envrc` returns nothing)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
