### PR TITLE
docs(lexicon): rename consumer-side fires: to on: in ADRs [TRL-195]

### DIFF
--- a/docs/adr/0018-signal-driven-governance.md
+++ b/docs/adr/0018-signal-driven-governance.md
@@ -76,7 +76,7 @@ The lockfile generator becomes a trail that fires on topo saves and pins:
 
 ```typescript
 trail('framework.lock.export', {
-  fires: [topoSaved],
+  on: [topoSaved],
   resources: [topoStore],
   intent: 'write',
   blaze: async (input, ctx) => {
@@ -99,7 +99,7 @@ trail('framework.lock.export', {
 
 The lockfile is a projection of a signal. Same execution model as any other trail. Testable. Governable. Has examples.
 
-**Dev vs CI behavior.** In CI, this trail fires on every `topo.saved` signal. In dev, it fires only on `topo.pinned` — explicit developer landmarks, not every file-save refresh. The CI topo includes the lockfile trail with `fires: [topoSaved]`. The dev topo includes it with `fires: [topoPinned]`. This is configuration, not conditional logic.
+**Dev vs CI behavior.** In CI, this trail fires on every `topo.saved` signal. In dev, it fires only on `topo.pinned` — explicit developer landmarks, not every file-save refresh. The CI topo includes the lockfile trail with `on: [topoSaved]`. The dev topo includes it with `on: [topoPinned]`. This is configuration, not conditional logic.
 
 ### Warden rules as trails
 

--- a/docs/adr/drafts/20260331-external-trailheads-as-trails.md
+++ b/docs/adr/drafts/20260331-external-trailheads-as-trails.md
@@ -704,7 +704,7 @@ Rigged trails can signal and declare fires like any other trail:
 const gitStatus = rig('git.status', {
   source: { type: 'cli', command: 'git status', binary: 'git' },
   intent: 'read',
-  fires: [{ schedule: '*/5 * * * *' }],
+  on: [{ schedule: '*/5 * * * *' }],
   signals: [uncommittedChangesDetected],
   input: z.object({}),
   output: GitStatusSchema,

--- a/docs/adr/drafts/20260331-packs-namespace-boundaries.md
+++ b/docs/adr/drafts/20260331-packs-namespace-boundaries.md
@@ -198,10 +198,10 @@ A pack's trails may declare `on` triggers as authored defaults. When a consuming
 const app = topo('firewatch',
   githubCore,
   githubPullRequests.resource({
-    fires: {
-      'github.pr.list': { fires: ['cron:every-5m'] },       // replace authored fire sources
-      'github.pr.show': { fires: [] },                       // suppress all fire sources
-      'github.pr.submit-review': { fires: { add: ['event:review.requested'] } }, // add to existing
+    on: {
+      'github.pr.list': { on: ['cron:every-5m'] },       // replace authored fire sources
+      'github.pr.show': { on: [] },                       // suppress all fire sources
+      'github.pr.submit-review': { on: { add: ['event:review.requested'] } }, // add to existing
     },
   }),
 );

--- a/docs/adr/drafts/20260331-reactive-trail-activation.md
+++ b/docs/adr/drafts/20260331-reactive-trail-activation.md
@@ -48,7 +48,7 @@ A trail can declare what activates it with the `fires` field:
 
 ```typescript
 const confirmBooking = trail('booking.confirm', {
-  fires: [{
+  on: [{
     webhook: 'stripe',
     event: 'payment_intent.succeeded',
     verify: stripeSignatureVerifier,
@@ -75,23 +75,23 @@ This matters for packs. A pack declares `fires` for its trails. The consuming ap
 ```typescript
 // The pack trail declares its default trigger
 const notifyBooking = trail('notify.booking-confirmed', {
-  fires: [{ signal: 'booking.confirmed' }],
+  on: [{ signal: 'booking.confirmed' }],
   // ...
 });
 
 // The consuming app overrides activation
 app.override('notify.booking-confirmed', {
-  fires: [{ signal: 'reservation.finalized' }],
+  on: [{ signal: 'reservation.finalized' }],
 });
 
 // Or suppresses it entirely
 app.override('notify.booking-confirmed', {
-  fires: [], // disable default fire sources
+  on: [], // disable default fire sources
 });
 
 // Or adds additional fire sources
 app.override('notify.booking-confirmed', {
-  fires: [
+  on: [
     { signal: 'booking.confirmed' },     // keep default
     { signal: 'reservation.finalized' }, // add another
   ],
@@ -110,7 +110,7 @@ Time-based activation. Cron expressions for recurring schedules.
 
 ```typescript
 const archiveOld = trail('data.archive-old', {
-  fires: [{
+  on: [{
     schedule: '0 2 * * *',
     input: { olderThanDays: 90 },
   }],
@@ -130,7 +130,7 @@ Activation when a signal is emitted. This covers authored signals (via `ctx.sign
 
 ```typescript
 const notifyBooking = trail('notify.booking-confirmed', {
-  fires: [{ signal: 'booking.confirmed' }],
+  on: [{ signal: 'booking.confirmed' }],
   intent: 'write',
   input: BookingConfirmedSchema,
   blaze: async (input, ctx) => { /* ... */ },
@@ -141,7 +141,7 @@ const notifyBooking = trail('notify.booking-confirmed', {
 
 ```typescript
 const billingConflictResolve = trail('billing.conflict-resolve', {
-  fires: [{
+  on: [{
     signal: 'trail.failed.conflict',
     where: (signal) => signal.trailId.startsWith('billing.'),
   }],
@@ -159,7 +159,7 @@ Activation when an external system sends a webhook payload.
 
 ```typescript
 const githubEventReceived = trail('github.event.received', {
-  fires: [{
+  on: [{
     webhook: 'github',
     path: '/webhooks/github',
     verify: githubSignatureVerifier,
@@ -178,7 +178,7 @@ Fire sources can include a predicate that filters activations:
 
 ```typescript
 const highValueApproval = trail('approval.high-value', {
-  fires: [{
+  on: [{
     signal: 'order.completed',
     where: (payload) => payload.total > 10000,
   }],
@@ -194,9 +194,9 @@ const highValueApproval = trail('approval.high-value', {
 where: {
   predicate: (payload) => payload.total > 10000,
   examples: [
-    { payload: { total: 15000 }, fires: true },
-    { payload: { total: 5000 }, fires: false },
-    { payload: { total: 10000 }, fires: false },
+    { payload: { total: 15000 }, on: true },
+    { payload: { total: 5000 }, on: false },
+    { payload: { total: 10000 }, on: false },
   ],
 },
 ```
@@ -207,7 +207,7 @@ where: {
 
 ```typescript
 const healthCheck = trail('health.check-all', {
-  fires: [
+  on: [
     { schedule: '*/5 * * * *' },
     { signal: 'trail.failed.network' },
   ],
@@ -306,7 +306,7 @@ Tracing queries can filter by fire source type: "show me all scheduled execution
 ### Tradeoffs
 
 - **New field on the trail spec.** `fires` adds a concept to learn. The justification: activation is genuinely new information that the framework can't derive.
-- **Fire resolution adds startup cost.** Topo construction resolves fires: register schedules, bind signal listeners, register webhook endpoints.
+- **Fire resolution adds startup cost.** Topo construction resolves on: register schedules, bind signal listeners, register webhook endpoints.
 - **Complex reactive chains.** Deep chains are inspectable via survey and the lockfile, and the warden detects cycles, but emergent behavior of long chains requires attention.
 - **Scheduled fires need runtime infrastructure.** `Bun.cron` for production, mock scheduler for testing.
 

--- a/docs/adr/drafts/20260331-typed-signal-emission.md
+++ b/docs/adr/drafts/20260331-typed-signal-emission.md
@@ -190,7 +190,7 @@ When `ctx.signal()` fires or the framework emits a lifecycle event:
 
 1. **Validate.** The payload validates against the event's schema. Invalid payloads produce an `InternalError` logged to tracing (the emission is dropped, not the trail).
 2. **Record.** Tracing records the emission: event ID, payload, source trail, execution ID, timestamp.
-3. **Route internally.** The signal bus notifies fire listeners. Trails with matching `fires: [{ signal: '...' }]` activate via `run()`.
+3. **Route internally.** The signal bus notifies fire listeners. Trails with matching `on: [{ signal: '...' }]` activate via `run()`.
 4. **Route externally.** Subscription listeners (WebSocket clients, SSE streams, future outbound webhooks) receive the event through their trailhead's delivery mechanism.
 5. **Record delivery.** Tracing records delivery outcomes: how many triggers fired, how many subscriptions received the event, how many failed.
 

--- a/docs/adr/drafts/20260331-webhooks-and-connectors.md
+++ b/docs/adr/drafts/20260331-webhooks-and-connectors.md
@@ -260,7 +260,7 @@ When `idempotent: true`, the trailhead checks `deliveryId` against the tracing s
 
 ### Interaction with triggers
 
-The activation ADR introduces `fires: [{ webhook: 'stripe', ... }]` on the trail spec. The fires declaration captures the activation intent. The webhook trailhead config in `trailhead()` handles the HTTP concerns. These are complementary:
+The activation ADR introduces `on: [{ webhook: 'stripe', ... }]` on the trail spec. The fires declaration captures the activation intent. The webhook trailhead config in `trailhead()` handles the HTTP concerns. These are complementary:
 
 - **The fires declaration** says "this trail is activated by Stripe webhooks." It's part of the trail's contract. Survey reports it. The warden governs it.
 - **The webhook config** says "Stripe webhooks arrive at `/webhooks/stripe`, verified with this function, adapted with this transformer." It's trailhead configuration.
@@ -337,7 +337,7 @@ testWebhook(app, '/webhooks/stripe', {
 
 - **Connector authoring is manual.** The developer writes the transform function. For common providers (Stripe, GitHub), built-in connectors or connector packs can amortize this. But each new provider integration needs a new connector.
 - **Two schemas per webhook.** The provider's payload schema (`from`) and the trail's input schema (`to`). Both must be maintained. If the provider changes their payload format, the connector needs updating. This is inherent to the problem: you're bridging two contracts.
-- **Webhook config in `trailhead()` is trailhead-side.** The endpoint path, verification function, and connector are configured on trailhead options, not on the trail spec. This is correct (the trail shouldn't know about HTTP paths) but means the webhook wiring is split between the trail (`fires: [{ webhook: '...' }]`) and the trailhead (`trailhead({ webhooks: ... })`). The warden validates consistency between the two.
+- **Webhook config in `trailhead()` is trailhead-side.** The endpoint path, verification function, and connector are configured on trailhead options, not on the trail spec. This is correct (the trail shouldn't know about HTTP paths) but means the webhook wiring is split between the trail (`on: [{ webhook: '...' }]`) and the trailhead (`trailhead({ webhooks: ... })`). The warden validates consistency between the two.
 - **Async run adds complexity.** The `async: true` option introduces background execution, which means the webhook response doesn't reflect the trail's result. Tracing records the result, but the webhook sender only sees 202. This is standard for long-running webhook handlers but adds operational complexity.
 
 ### What this does NOT decide


### PR DESCRIPTION
Frees up the field name fires: for the producer-side semantic that
ADR-0023 introduces. The consumer-side activation field (currently
called fires: in design ADRs) becomes on:.

Zero code changes — fires: was never implemented as a runtime
primitive, only designed in draft and accepted ADRs. Updates the
design docs so future readers and the eventual implementation PR
have a clean slate for producer-side fires:.

Files updated:
- docs/adr/0018-signal-driven-governance.md
- docs/adr/drafts/20260331-reactive-trail-activation.md
- docs/adr/drafts/20260331-typed-signal-emission.md
- docs/adr/drafts/20260331-webhooks-and-connectors.md
- docs/adr/drafts/20260331-external-trailheads-as-trails.md
- docs/adr/drafts/20260331-packs-namespace-boundaries.md