### PR TITLE
feat(core): fires:/on: signal activation runtime [TRL-197]

### DIFF
--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -1,0 +1,183 @@
+/* oxlint-disable require-await -- trail implementations satisfy async interface without awaiting */
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { NotFoundError, ValidationError } from '../errors';
+import { Result } from '../result';
+import { run } from '../run';
+import { signal } from '../signal';
+import { topo } from '../topo';
+import { trail } from '../trail';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const orderPlaced = signal('order.placed', {
+  payload: z.object({ orderId: z.string(), total: z.number() }),
+});
+
+// Mutable capture box for assertions. Each test resets it.
+interface Capture {
+  invocations: { trailId: string; payload: unknown }[];
+}
+const createCapture = (): Capture => ({ invocations: [] });
+
+const makeConsumer = (
+  id: string,
+  capture: Capture,
+  behavior: 'ok' | 'err' = 'ok'
+) =>
+  trail(id, {
+    blaze: (input) => {
+      capture.invocations.push({ payload: input, trailId: id });
+      if (behavior === 'err') {
+        return Result.err(new Error(`${id} failed`));
+      }
+      return Result.ok({ received: input });
+    },
+    input: z.object({ orderId: z.string(), total: z.number() }),
+    on: ['order.placed'],
+  });
+
+const makeProducer = (fireResultKey: { result?: Result<void, Error> }) =>
+  trail('order.create', {
+    blaze: async (input, ctx) => {
+      const fired = await ctx.fire?.('order.placed', {
+        orderId: input.orderId,
+        total: input.total,
+      });
+      fireResultKey.result = fired;
+      return Result.ok({ ok: true });
+    },
+    fires: ['order.placed'],
+    input: z.object({ orderId: z.string(), total: z.number() }),
+  });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fire', () => {
+  describe('fan-out', () => {
+    test('invokes every consumer with validated payload', async () => {
+      const capture = createCapture();
+      const fireBox: { result?: Result<void, Error> } = {};
+      const app = topo('fire-test', {
+        consumerA: makeConsumer('notify.email', capture),
+        consumerB: makeConsumer('notify.slack', capture),
+        orderPlaced,
+        producer: makeProducer(fireBox),
+      });
+      const result = await run(app, 'order.create', {
+        orderId: 'o-1',
+        total: 42,
+      });
+      expect(result.isOk()).toBe(true);
+      expect(fireBox.result?.isOk()).toBe(true);
+      expect(capture.invocations).toHaveLength(2);
+      expect(capture.invocations.map((i) => i.trailId).toSorted()).toEqual([
+        'notify.email',
+        'notify.slack',
+      ]);
+      expect(capture.invocations[0]?.payload).toEqual({
+        orderId: 'o-1',
+        total: 42,
+      });
+      expect(capture.invocations[1]?.payload).toEqual({
+        orderId: 'o-1',
+        total: 42,
+      });
+    });
+
+    test('no-consumer fan-out returns Result.ok', async () => {
+      const fireBox: { result?: Result<void, Error> } = {};
+      const producer = makeProducer(fireBox);
+      const app = topo('fire-empty', { orderPlaced, producer });
+
+      const result = await run(app, 'order.create', {
+        orderId: 'o-2',
+        total: 0,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(fireBox.result?.isOk()).toBe(true);
+    });
+  });
+
+  describe('validation', () => {
+    test('unknown signal id returns Result.err(NotFoundError)', async () => {
+      const badProducer = trail('bad.producer', {
+        blaze: async (_input, ctx) => {
+          const fired = await ctx.fire?.('ghost.signal', {});
+          return fired as Result<unknown, Error>;
+        },
+        input: z.object({}),
+      });
+
+      const app = topo('fire-unknown', { badProducer });
+      const result = await run(app, 'bad.producer', {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(NotFoundError);
+    });
+
+    test('bad payload returns Result.err(ValidationError) and skips consumers', async () => {
+      const capture = createCapture();
+      const consumer = makeConsumer('notify.email', capture);
+
+      const badProducer = trail('bad.payload', {
+        blaze: async (_input, ctx) => {
+          const fired = await ctx.fire?.('order.placed', { orderId: 123 });
+          return fired as Result<unknown, Error>;
+        },
+        input: z.object({}),
+      });
+
+      const app = topo('fire-bad-payload', {
+        badProducer,
+        consumer,
+        orderPlaced,
+      });
+      const result = await run(app, 'bad.payload', {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(capture.invocations).toHaveLength(0);
+    });
+  });
+
+  describe('error isolation', () => {
+    test('consumer error does not fail the producer', async () => {
+      const capture = createCapture();
+      const failingConsumer = makeConsumer('notify.broken', capture, 'err');
+      const fireBox: { result?: Result<void, Error> } = {};
+      const producer = makeProducer(fireBox);
+
+      const app = topo('fire-err', { failingConsumer, orderPlaced, producer });
+      const result = await run(app, 'order.create', {
+        orderId: 'o-3',
+        total: 1,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(fireBox.result?.isOk()).toBe(true);
+      expect(capture.invocations).toHaveLength(1);
+    });
+  });
+
+  describe('context binding', () => {
+    test('ctx.fire is undefined when executeTrail is called without a topo', async () => {
+      const { executeTrail } = await import('../execute');
+      const standalone = trail('standalone', {
+        blaze: async (_input, ctx) =>
+          Result.ok({ hasFire: ctx.fire !== undefined }),
+        input: z.object({}),
+      });
+
+      const result = await executeTrail(standalone, {});
+      expect(result.isOk()).toBe(true);
+      expect((result.unwrap() as { hasFire: boolean }).hasFire).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -1,0 +1,75 @@
+/**
+ * Signal emission and auto-activation.
+ *
+ * `createFireFn(topo)` returns a `FireFn` bound to a topo. Calling
+ * `fire(signalId, payload)` looks up the signal, validates the payload
+ * against its schema, finds every trail with the signal in its `on:` array,
+ * and invokes each consumer via `executeTrail`.
+ *
+ * Error semantics match the fire-and-forget framing: producers get
+ * `Result.ok(undefined)` unless the signal id is unknown or the payload
+ * fails schema validation. Consumer errors are logged via the context's
+ * logger (when available) but do NOT propagate back to the producer.
+ * Consumers that need transactional coupling should use `crosses:`.
+ */
+
+import { NotFoundError, ValidationError } from './errors.js';
+import { executeTrail } from './execute.js';
+import { Result } from './result.js';
+import type { AnyTrail } from './trail.js';
+import type { Topo } from './topo.js';
+import type { FireFn, Logger, TrailContextInit } from './types.js';
+
+const fanOutToConsumers = async (
+  consumers: readonly AnyTrail[],
+  payload: unknown,
+  signalId: string,
+  fire: FireFn,
+  logger: Logger | undefined
+): Promise<void> => {
+  const consumerCtx: Partial<TrailContextInit> = { fire };
+  for (const consumer of consumers) {
+    const consumerResult = await executeTrail(consumer, payload, {
+      ctx: consumerCtx,
+    });
+    if (consumerResult.isErr()) {
+      logger?.warn('Signal consumer failed', {
+        consumerId: consumer.id,
+        error: consumerResult.error.message,
+        signalId,
+      });
+    }
+  }
+};
+
+/** Build a `FireFn` closure bound to a topo. */
+export const createFireFn = (topo: Topo, logger?: Logger): FireFn => {
+  const fire: FireFn = async (signalId, payload) => {
+    const signal = topo.signals.get(signalId);
+    if (signal === undefined) {
+      return Result.err(
+        new NotFoundError(
+          `Signal "${signalId}" not found in topo "${topo.name}"`
+        )
+      );
+    }
+
+    const parsed = signal.payload.safeParse(payload);
+    if (!parsed.success) {
+      return Result.err(
+        new ValidationError(
+          `Invalid payload for signal "${signalId}": ${parsed.error.message}`
+        )
+      );
+    }
+
+    const consumers = topo
+      .list()
+      .filter((trail) => trail.on.includes(signalId));
+    await fanOutToConsumers(consumers, parsed.data, signalId, fire, logger);
+
+    return Result.ok();
+  };
+
+  return fire;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export type {
   TrailContext,
   TrailContextInit,
   CrossFn,
+  FireFn,
   BasePermit,
   PermitRequirement,
   ProgressCallback,

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -9,7 +9,9 @@ import type { Topo } from './topo.js';
 import { executeTrail } from './execute.js';
 import type { ExecuteTrailOptions } from './execute.js';
 import { NotFoundError } from './errors.js';
+import { createFireFn } from './fire.js';
 import { Result } from './result.js';
+import type { TrailContextInit } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -50,5 +52,7 @@ export const run = (
       )
     );
   }
-  return executeTrail(trail, input, options);
+  const fire = createFireFn(topo, options?.ctx?.logger);
+  const ctxWithFire: Partial<TrailContextInit> = { ...options?.ctx, fire };
+  return executeTrail(trail, input, { ...options, ctx: ctxWithFire });
 };

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -63,6 +63,10 @@ export interface TrailSpec<I, O> {
   readonly crosses?: readonly string[] | undefined;
   /** Resources this trail may access via resource.from(ctx) */
   readonly resources?: readonly AnyProvision[] | undefined;
+  /** IDs of signals this trail emits via ctx.fire() */
+  readonly fires?: readonly string[] | undefined;
+  /** IDs of signals that activate this trail (framework auto-subscribes) */
+  readonly on?: readonly string[] | undefined;
   /** Auth requirement: scopes object, 'public', or omitted (undeclared) */
   readonly permit?: PermitRequirement | undefined;
 }
@@ -77,7 +81,7 @@ export type Intent = 'read' | 'write' | 'destroy';
 /** A fully-defined trail — the unit of work in the Trails system */
 export interface Trail<I, O> extends Omit<
   TrailSpec<I, O>,
-  'blaze' | 'crosses' | 'intent' | 'resources'
+  'blaze' | 'crosses' | 'fires' | 'intent' | 'on' | 'resources'
 > {
   readonly kind: 'trail';
   readonly id: string;
@@ -86,6 +90,10 @@ export interface Trail<I, O> extends Omit<
   readonly crosses: readonly string[];
   /** Resources this trail may access via resource.from(ctx) (always present, default []) */
   readonly resources: readonly AnyProvision[];
+  /** IDs of signals this trail emits via ctx.fire() (always present, default []) */
+  readonly fires: readonly string[];
+  /** IDs of signals that activate this trail (always present, default []) */
+  readonly on: readonly string[];
   /** What this trail does to the world (always present, default 'write') */
   readonly intent: Intent;
 }
@@ -136,7 +144,9 @@ export function trail<I, O>(
   const {
     blaze,
     crosses: rawCrosses,
+    fires: rawFires,
     intent: rawIntent,
+    on: rawOn,
     resources: rawProvisions,
     ...spec
   } = resolved.spec;
@@ -146,9 +156,11 @@ export function trail<I, O>(
     ...spec,
     blaze: async (input: I, ctx: TrailContext) => await blaze(input, ctx),
     crosses: Object.freeze([...(rawCrosses ?? [])]),
+    fires: Object.freeze([...(rawFires ?? [])]),
     id: resolved.id,
     intent: rawIntent ?? 'write',
     kind: 'trail' as const,
+    on: Object.freeze([...(rawOn ?? [])]),
     resources,
   });
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,6 +17,19 @@ export type CrossFn = <O>(
   input: unknown
 ) => Promise<Result<O, Error>>;
 
+/**
+ * Emit a signal by id — used for signal-driven activation.
+ *
+ * Fan-out to consumer trails (those with the signal in their `on:` array) is
+ * the framework's responsibility. Producers get `Result.ok(undefined)` unless
+ * the signal id is unknown or the payload fails schema validation. Consumer
+ * errors are logged but do not propagate back to the producer.
+ */
+export type FireFn = (
+  signalId: string,
+  payload: unknown
+) => Promise<Result<void, Error>>;
+
 /** Resolve a resource instance from the current trail context. */
 export type ProvisionLookup = <T = unknown>(
   provisionOrId: { readonly id: string } | string
@@ -70,6 +83,12 @@ export interface TrailContext {
   readonly requestId: string;
   readonly abortSignal: AbortSignal;
   readonly cross?: CrossFn | undefined;
+  /**
+   * Emit a signal by id. Fans out to every trail with the signal in its
+   * `on:` declaration. Bound by the runner that holds the topo (typically
+   * `run()`); undefined when a context is constructed without topo access.
+   */
+  readonly fire?: FireFn | undefined;
   readonly permit?: BasePermit;
   readonly workspaceRoot?: string | undefined;
   readonly logger?: Logger | undefined;


### PR DESCRIPTION
Implements the producer-side fires: and consumer-side on: fields on
the trail spec plus ctx.fire() runtime emission with auto-activation,
mirroring the crosses: pattern exactly. No new primitives — uses the
existing signal and topo machinery.

Phase 1 (types + runtime): this commit. Warden parity rules and
dogfooding app integration ship as follow-up phases.

Types:
- TrailSpec gains optional fires?: readonly string[] and
  on?: readonly string[] fields (signal IDs, matching crosses shape)
- Trail normalizes both to readonly string[] defaulting to []
- TrailContext gains optional fire?: FireFn, bound by callers that
  hold the topo (mirrors ctx.cross which is unbound in core)
- New FireFn type: (signalId, payload) => Promise<Result<void, Error>>

Runtime:
- New packages/core/src/fire.ts: createFireFn(topo, logger?) builds a
  self-referential FireFn closure
- run.ts binds fire on the context before delegating to executeTrail
  so ctx.fire is available inside any trail invoked via run()
- Signal lookup via topo.signals.get(id); consumer lookup via
  topo.list().filter(t => t.on.includes(id))
- Payload validated against the signal's zod schema at the fire
  boundary; invalid payloads short-circuit with Result.err
- Consumers invoked sequentially via executeTrail; errors logged via
  ctx.logger but do not propagate — producers stay decoupled

Error semantics (tenet-aligned with "reduce ceremony, not clarity"):
- Unknown signal id -> Result.err(NotFoundError)
- Invalid payload -> Result.err(ValidationError)
- No consumers -> Result.ok(undefined)
- Consumer failure -> logged, producer still gets Result.ok

Tests (packages/core/src/__tests__/fire.test.ts, 6 tests):
- Fan-out happy path with two consumers
- No-consumer no-op
- Unknown signal rejection
- Bad payload rejection skips consumers
- Consumer error does not fail the producer
- executeTrail without a topo leaves ctx.fire undefined

Deferred:
- Warden rules: fires-declarations (parity with ctx.fire calls) and
  on-references-exist (signal resolution). Mirror the existing
  cross-declarations rule structure.
- Dogfooding app integration with a producer/consumer flow
- Persisted topo edges (topo_trail_fires / topo_trail_on tables)
  for queryability — Phase 2 when warden needs them
- Generic payload typing overload for ctx.fire<T>(signal, payload)
  — progressive disclosure once the base API proves out
- Parallel consumer fan-out + error isolation refinement

bun run typecheck, bun run test, bun run check all pass.