### PR TITLE
feat(warden): fires-declarations and on-references-exist parity rules [TRL-197]

### DIFF
--- a/packages/warden/src/__tests__/fires-declarations.test.ts
+++ b/packages/warden/src/__tests__/fires-declarations.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from 'bun:test';
+
+import { firesDeclarations } from '../rules/fires-declarations.js';
+
+const TEST_FILE = 'test.ts';
+
+describe('fires-declarations', () => {
+  describe('clean cases', () => {
+    test('declared and called match exactly', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+const t = trail('onboard', {
+  fires: ['entity.created', 'audit.logged'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    await ctx.fire('audit.logged', { actor: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('no fires declaration and no ctx.fire() calls', () => {
+      const code = `
+trail('simple', {
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    return Result.ok({ greeting: 'hello ' + input.name });
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('error cases', () => {
+    test('called but not declared produces error', () => {
+      const code = `
+trail('onboard', {
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.rule).toBe('fires-declarations');
+      expect(diagnostics[0]?.message).toContain("ctx.fire('entity.created')");
+      expect(diagnostics[0]?.message).toContain('not declared in fires');
+    });
+  });
+
+  describe('warn cases', () => {
+    test('declared but not called produces warning', () => {
+      const code = `
+trail('onboard', {
+  fires: ['entity.created', 'audit.logged'],
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+      expect(diagnostics[0]?.rule).toBe('fires-declarations');
+      expect(diagnostics[0]?.message).toContain(
+        "'audit.logged' declared in fires"
+      );
+      expect(diagnostics[0]?.message).toContain('never called');
+    });
+  });
+
+  describe('single-object overload', () => {
+    test('recognizes trail({ id, fires, blaze }) form', () => {
+      const code = `
+trail({
+  id: 'onboard',
+  fires: ['entity.created'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('detects undeclared fires in single-object form', () => {
+      const code = `
+trail({
+  id: 'onboard',
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain("'entity.created'");
+    });
+  });
+
+  describe('context parameter naming', () => {
+    test('recognizes context.fire() when second param is named context', () => {
+      const code = `
+trail('onboard', {
+  fires: ['entity.created'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, context) => {
+    await context.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('recognizes destructured fire() calls', () => {
+      const code = `
+trail('onboard', {
+  fires: ['entity.created'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    const { fire } = ctx;
+    await fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('nested run false positives', () => {
+    test('meta.blaze with phantom fire does not trigger false positives', () => {
+      const code = `
+trail('onboard', {
+  fires: ['entity.created'],
+  input: z.object({ name: z.string() }),
+  meta: { blaze: async () => ctx.fire('phantom') },
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('identifier resolution in fires arrays', () => {
+    test('resolves const identifiers in fires array', () => {
+      const code = `
+const ENTITY_CREATED = 'entity.created';
+trail('onboard', {
+  fires: [ENTITY_CREATED],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('dynamic fire IDs are skipped', () => {
+      const code = `
+trail('dispatch', {
+  fires: ['entity.created'],
+  blaze: async (input, ctx) => {
+    const signalId = input.target;
+    await ctx.fire(signalId, input);
+    await ctx.fire('entity.created', input);
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('multiple trails in one file are validated independently', () => {
+      const code = `
+trail('alpha', {
+  fires: ['shared.signal'],
+  blaze: async (input, ctx) => {
+    await ctx.fire('shared.signal', input);
+    return Result.ok({});
+  },
+});
+
+trail('beta', {
+  blaze: async (input, ctx) => {
+    await ctx.fire('undeclared.signal', input);
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('Trail "beta"');
+      expect(diagnostics[0]?.message).toContain("'undeclared.signal'");
+      expect(diagnostics[0]?.severity).toBe('error');
+    });
+
+    test('skips test files', () => {
+      const code = `
+trail('onboard', {
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', input);
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(
+        code,
+        'src/__tests__/trails.test.ts'
+      );
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('both wrong: called and undeclared, declared and unused', () => {
+      const code = `
+trail('mixed', {
+  fires: ['declared.only'],
+  blaze: async (input, ctx) => {
+    await ctx.fire('called.only', input);
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(2);
+      const errors = diagnostics.filter((d) => d.severity === 'error');
+      const warns = diagnostics.filter((d) => d.severity === 'warn');
+      expect(errors.length).toBe(1);
+      expect(warns.length).toBe(1);
+    });
+  });
+});

--- a/packages/warden/src/__tests__/on-references-exist.test.ts
+++ b/packages/warden/src/__tests__/on-references-exist.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test';
+
+import { onReferencesExist } from '../rules/on-references-exist.js';
+
+const TEST_FILE = 'consumer.ts';
+
+describe('on-references-exist', () => {
+  test('passes when a locally defined signal is referenced', () => {
+    const code = `
+import { signal, trail, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+const created = signal('entity.created', { payload: z.object({ id: z.string() }) });
+
+trail('notify', {
+  on: ['entity.created'],
+  input: z.object({ id: z.string() }),
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    expect(onReferencesExist.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('flags an on: reference missing from project context', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+trail('notify', {
+  on: ['entity.created'],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    const diagnostics = onReferencesExist.checkWithContext(code, TEST_FILE, {
+      knownSignalIds: new Set(['some.other.signal']),
+      knownTrailIds: new Set(['notify']),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('on-references-exist');
+    expect(diagnostics[0]?.severity).toBe('error');
+    expect(diagnostics[0]?.message).toContain('entity.created');
+  });
+
+  test('passes when project context includes the referenced signal', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+trail('notify', {
+  on: ['entity.created'],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    const diagnostics = onReferencesExist.checkWithContext(code, TEST_FILE, {
+      knownSignalIds: new Set(['entity.created']),
+      knownTrailIds: new Set(['notify']),
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('flags only the unresolved id when multiple references are present', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+trail('notify', {
+  on: ['entity.created', 'audit.logged'],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    const diagnostics = onReferencesExist.checkWithContext(code, TEST_FILE, {
+      knownSignalIds: new Set(['entity.created']),
+      knownTrailIds: new Set(['notify']),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('audit.logged');
+  });
+
+  test('skips trails with no on: declaration', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+trail('plain', {
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    expect(
+      onReferencesExist.checkWithContext(code, TEST_FILE, {
+        knownSignalIds: new Set(),
+        knownTrailIds: new Set(['plain']),
+      })
+    ).toEqual([]);
+  });
+
+  test('resolves const identifiers in on: array', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+const ENTITY_CREATED = 'entity.created';
+
+trail('notify', {
+  on: [ENTITY_CREATED],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    const diagnostics = onReferencesExist.checkWithContext(code, TEST_FILE, {
+      knownSignalIds: new Set(['entity.created']),
+      knownTrailIds: new Set(['notify']),
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('skips test files', () => {
+    const code = `
+trail('notify', {
+  on: ['unknown.signal'],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    expect(
+      onReferencesExist.check(code, 'src/__tests__/notify.test.ts')
+    ).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 13 rule trails', () => {
-    expect(wardenTopo.count).toBe(13);
+  test('contains all 15 rule trails', () => {
+    expect(wardenTopo.count).toBe(15);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -13,6 +13,7 @@ import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
 import {
   collectProvisionDefinitionIds,
+  collectSignalDefinitionIds,
   findConfigProperty,
   findTrailDefinitions,
   parse,
@@ -147,6 +148,20 @@ const collectKnownProvisionIds = (
   }
 };
 
+const collectKnownSignalIds = (
+  sourceCode: string,
+  filePath: string,
+  knownSignalIds: Set<string>
+): void => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return;
+  }
+  for (const id of collectSignalDefinitionIds(ast)) {
+    knownSignalIds.add(id);
+  }
+};
+
 const loadSourceFiles = async (
   rootDir: string
 ): Promise<readonly SourceFile[]> => {
@@ -191,11 +206,13 @@ const collectTopoDetourTargetTrailIds = (
 const buildProjectContextFromTopo = (appTopo: Topo): ProjectContext => {
   const knownTrailIds = new Set<string>(appTopo.trails.keys());
   const knownProvisionIds = new Set<string>(appTopo.resources.keys());
+  const knownSignalIds = new Set<string>(appTopo.signals.keys());
   const detourTargetTrailIds = collectTopoDetourTargetTrailIds(appTopo);
 
   return {
     detourTargetTrailIds,
     knownProvisionIds,
+    knownSignalIds,
     knownTrailIds,
   };
 };
@@ -205,6 +222,7 @@ const buildProjectContextFromFiles = (
 ): ProjectContext => {
   const knownTrailIds = new Set<string>();
   const knownProvisionIds = new Set<string>();
+  const knownSignalIds = new Set<string>();
   const detourTargetTrailIds = new Set<string>();
 
   for (const sourceFile of sourceFiles) {
@@ -218,6 +236,11 @@ const buildProjectContextFromFiles = (
       sourceFile.filePath,
       knownProvisionIds
     );
+    collectKnownSignalIds(
+      sourceFile.sourceCode,
+      sourceFile.filePath,
+      knownSignalIds
+    );
     collectDetourTargetTrailIds(
       sourceFile.sourceCode,
       sourceFile.filePath,
@@ -228,6 +251,7 @@ const buildProjectContextFromFiles = (
   return {
     detourTargetTrailIds,
     knownProvisionIds,
+    knownSignalIds,
     knownTrailIds,
   };
 };

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -21,6 +21,8 @@ export { noThrowInImplementation } from './rules/no-throw-in-implementation.js';
 export { contextNoTrailheadTypes } from './rules/context-no-trailhead-types.js';
 export { draftFileMarking } from './rules/draft-file-marking.js';
 export { draftVisibleDebt } from './rules/draft-visible-debt.js';
+export { firesDeclarations } from './rules/fires-declarations.js';
+export { onReferencesExist } from './rules/on-references-exist.js';
 export { validDetourRefs } from './rules/valid-detour-refs.js';
 export { noDirectImplInRoute } from './rules/no-direct-impl-in-route.js';
 export { noDirectImplementationCall } from './rules/no-direct-implementation-call.js';
@@ -76,12 +78,14 @@ export {
   contextNoTrailheadTypesTrail,
   crossDeclarationsTrail,
   diagnosticSchema,
+  firesDeclarationsTrail,
   implementationReturnsResultTrail,
   noDirectImplInRouteTrail,
   noDirectImplementationCallTrail,
   noSyncResultAssumptionTrail,
   noThrowInDetourTargetTrail,
   noThrowInImplementationTrail,
+  onReferencesExistTrail,
   preferSchemaInferenceTrail,
   ruleInput,
   ruleOutput,

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -462,6 +462,24 @@ export const findBlazeBodies = (node: AstNode): AstNode[] => {
   return bodies;
 };
 
+/**
+ * Collect all `signal('id', { ... })` / `signal({ id: 'x', ... })` definition IDs.
+ *
+ * Uses `findTrailDefinitions` under the hood — it already recognizes both
+ * `trail` and `signal` call sites, distinguished by the `kind` field.
+ */
+export const collectSignalDefinitionIds = (
+  ast: AstNode
+): ReadonlySet<string> => {
+  const ids = new Set<string>();
+  for (const def of findTrailDefinitions(ast)) {
+    if (def.kind === 'signal') {
+      ids.add(def.id);
+    }
+  }
+  return ids;
+};
+
 // ---------------------------------------------------------------------------
 // Misc helpers
 // ---------------------------------------------------------------------------

--- a/packages/warden/src/rules/fires-declarations.ts
+++ b/packages/warden/src/rules/fires-declarations.ts
@@ -1,0 +1,390 @@
+/**
+ * Validates that `ctx.fire()` calls match the declared `fires` array.
+ *
+ * Statically analyzes trail `blaze` functions to find `ctx.fire('signalId', ...)`
+ * calls and compares them against the `fires: [...]` declaration in the trail
+ * config. Reports errors for undeclared fires and warnings for unused ones.
+ *
+ * Mirrors `cross-declarations` structurally — same extraction, same reporting
+ * shape, same const-identifier resolution, same context-parameter handling.
+ */
+
+import {
+  findConfigProperty,
+  findBlazeBodies,
+  findTrailDefinitions,
+  offsetToLine,
+  parse,
+  walk,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Shared identifier helpers
+// ---------------------------------------------------------------------------
+
+/** Get the name of an Identifier node, or null. */
+const identifierName = (node: AstNode | undefined): string | null => {
+  if (node?.type !== 'Identifier') {
+    return null;
+  }
+  return (node as unknown as { name?: string }).name ?? null;
+};
+
+// ---------------------------------------------------------------------------
+// String literal helpers
+// ---------------------------------------------------------------------------
+
+/** Check if a node is a string literal (covers `StringLiteral` and `Literal` with string value). */
+const isStringLiteral = (node: AstNode): boolean => {
+  if (node.type === 'StringLiteral') {
+    return true;
+  }
+  if (node.type === 'Literal') {
+    return typeof (node as unknown as { value?: unknown }).value === 'string';
+  }
+  return false;
+};
+
+/** Extract the string value from a string literal node. */
+const getStringValue = (node: AstNode): string | null => {
+  const val = (node as unknown as { value?: unknown }).value;
+  return typeof val === 'string' ? val : null;
+};
+
+// ---------------------------------------------------------------------------
+// Const identifier resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort resolution of `const NAME = 'value'` declarations via regex.
+ *
+ * Returns the string value if a simple `const <name> = '...'` or `"..."` is
+ * found in the source. Returns null for anything more complex.
+ */
+const resolveConstString = (
+  name: string,
+  sourceCode: string
+): string | null => {
+  const pattern = new RegExp(
+    `const\\s+${name}\\s*=\\s*(?:'([^']*)'|"([^"]*)")`
+  );
+  const match = pattern.exec(sourceCode);
+  if (!match) {
+    return null;
+  }
+  return match[1] ?? match[2] ?? null;
+};
+
+/** Try to resolve an Identifier element to a string via const declaration. */
+const resolveIdentifierElement = (
+  el: AstNode,
+  sourceCode: string
+): string | null => {
+  const name = identifierName(el);
+  if (!name) {
+    return null;
+  }
+  return resolveConstString(name, sourceCode);
+};
+
+/** Resolve an array element to a static signal ID when possible. */
+const resolveFireElementId = (
+  element: AstNode,
+  sourceCode: string
+): string | null => {
+  if (isStringLiteral(element)) {
+    return getStringValue(element);
+  }
+
+  if (element.type === 'Identifier') {
+    return resolveIdentifierElement(element, sourceCode);
+  }
+
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Declared fires extraction
+// ---------------------------------------------------------------------------
+
+/** Extract the ArrayExpression elements from a config's `fires` property. */
+const getFiresElements = (config: AstNode): readonly AstNode[] | null => {
+  const firesProp = findConfigProperty(config, 'fires');
+  if (!firesProp) {
+    return null;
+  }
+
+  const arrayNode = firesProp.value;
+  if (!arrayNode || (arrayNode as AstNode).type !== 'ArrayExpression') {
+    return null;
+  }
+
+  const elements = (arrayNode as AstNode)['elements'] as
+    | readonly AstNode[]
+    | undefined;
+  return elements ?? null;
+};
+
+/** Collect string IDs from array elements, resolving identifiers when possible. */
+const collectStringIds = (
+  elements: readonly AstNode[],
+  sourceCode: string
+): Set<string> => {
+  const ids = new Set<string>();
+  for (const element of elements) {
+    const resolved = resolveFireElementId(element, sourceCode);
+    if (resolved) {
+      ids.add(resolved);
+    }
+  }
+  return ids;
+};
+
+/** Extract string literal elements from a `fires: [...]` array property. */
+const extractDeclaredFires = (
+  config: AstNode,
+  sourceCode: string
+): ReadonlySet<string> => {
+  const elements = getFiresElements(config);
+  return elements ? collectStringIds(elements, sourceCode) : new Set();
+};
+
+// ---------------------------------------------------------------------------
+// Called fires extraction — member expression helpers
+// ---------------------------------------------------------------------------
+
+const MEMBER_TYPES = new Set(['StaticMemberExpression', 'MemberExpression']);
+
+/** Extract object and property Identifier names from a MemberExpression. */
+const extractMemberPair = (
+  callee: AstNode
+): { objName: string; propName: string } | null => {
+  if (!MEMBER_TYPES.has(callee.type)) {
+    return null;
+  }
+
+  const objName = identifierName(
+    (callee as unknown as { object?: AstNode }).object
+  );
+  const propName = identifierName(
+    (callee as unknown as { property?: AstNode }).property
+  );
+
+  return objName && propName ? { objName, propName } : null;
+};
+
+/** Extract the first argument string from a CallExpression's arguments list. */
+const extractFirstStringArg = (node: AstNode): string | null => {
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  if (!args || args.length === 0) {
+    return null;
+  }
+
+  const [firstArg] = args;
+  if (!firstArg || !isStringLiteral(firstArg)) {
+    return null;
+  }
+
+  return getStringValue(firstArg);
+};
+
+/**
+ * Extract the second parameter name from a blaze function node.
+ *
+ * Handles `(input, ctx) => ...`, `async (input, context) => ...`, and
+ * `function(input, ctx) { ... }` forms.
+ */
+const extractContextParamName = (blazeBody: AstNode): string | null => {
+  const params = blazeBody['params'] as readonly AstNode[] | undefined;
+  if (!params || params.length < 2) {
+    return null;
+  }
+  return identifierName(params[1]);
+};
+
+/** Check if a callee is a member-style fire call: <ctxName>.fire(...). */
+const isMemberFireCall = (
+  callee: AstNode,
+  ctxNames: ReadonlySet<string>
+): boolean => {
+  const pair = extractMemberPair(callee);
+  return !!pair && ctxNames.has(pair.objName) && pair.propName === 'fire';
+};
+
+/**
+ * Check if a node is a `<ctxName>.fire(...)` call and return the string signal ID.
+ *
+ * Also matches bare `fire(...)` calls from destructuring.
+ */
+const extractFireCallId = (
+  node: AstNode,
+  ctxNames: ReadonlySet<string>
+): string | null => {
+  if (node.type !== 'CallExpression') {
+    return null;
+  }
+
+  const callee = node['callee'] as AstNode | undefined;
+  if (!callee) {
+    return null;
+  }
+
+  if (isMemberFireCall(callee, ctxNames)) {
+    return extractFirstStringArg(node);
+  }
+
+  if (identifierName(callee) === 'fire') {
+    return extractFirstStringArg(node);
+  }
+
+  return null;
+};
+
+/** Build the set of context parameter names to match against. */
+const buildCtxNames = (body: AstNode): ReadonlySet<string> => {
+  const ctxNames = new Set(['ctx', 'context']);
+  const paramName = extractContextParamName(body);
+  if (paramName) {
+    ctxNames.add(paramName);
+  }
+  return ctxNames;
+};
+
+/** Walk blaze bodies and collect all statically resolvable ctx.fire() signal IDs. */
+const extractCalledFires = (config: AstNode): ReadonlySet<string> => {
+  const ids = new Set<string>();
+
+  for (const body of findBlazeBodies(config)) {
+    const ctxNames = buildCtxNames(body);
+
+    walk(body, (node) => {
+      const id = extractFireCallId(node, ctxNames);
+      if (id) {
+        ids.add(id);
+      }
+    });
+  }
+
+  return ids;
+};
+
+// ---------------------------------------------------------------------------
+// Diagnostic builders
+// ---------------------------------------------------------------------------
+
+const buildUndeclaredDiagnostic = (
+  trailId: string,
+  signalId: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}": ctx.fire('${signalId}') called but '${signalId}' is not declared in fires`,
+  rule: 'fires-declarations',
+  severity: 'error',
+});
+
+const buildUnusedDiagnostic = (
+  trailId: string,
+  signalId: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}": '${signalId}' declared in fires but ctx.fire('${signalId}') never called`,
+  rule: 'fires-declarations',
+  severity: 'warn',
+});
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+/** Emit error for each called ID not present in declared set. */
+const reportUndeclared = (
+  called: ReadonlySet<string>,
+  declared: ReadonlySet<string>,
+  ctx: { trailId: string; filePath: string; line: number },
+  diagnostics: WardenDiagnostic[]
+): void => {
+  for (const id of called) {
+    if (!declared.has(id)) {
+      diagnostics.push(
+        buildUndeclaredDiagnostic(ctx.trailId, id, ctx.filePath, ctx.line)
+      );
+    }
+  }
+};
+
+/** Emit warning for each declared ID not present in called set. */
+const reportUnused = (
+  declared: ReadonlySet<string>,
+  called: ReadonlySet<string>,
+  ctx: { trailId: string; filePath: string; line: number },
+  diagnostics: WardenDiagnostic[]
+): void => {
+  for (const id of declared) {
+    if (!called.has(id)) {
+      diagnostics.push(
+        buildUnusedDiagnostic(ctx.trailId, id, ctx.filePath, ctx.line)
+      );
+    }
+  }
+};
+
+const checkTrailDefinition = (
+  def: { id: string; config: AstNode; start: number },
+  filePath: string,
+  sourceCode: string,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  const declared = extractDeclaredFires(def.config, sourceCode);
+  const called = extractCalledFires(def.config);
+
+  if (declared.size === 0 && called.size === 0) {
+    return;
+  }
+
+  const line = offsetToLine(sourceCode, def.start);
+  const ctx = { filePath, line, trailId: def.id };
+
+  reportUndeclared(called, declared, ctx, diagnostics);
+  reportUnused(declared, called, ctx, diagnostics);
+};
+
+// ---------------------------------------------------------------------------
+// Rule
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates that `ctx.fire()` calls align with declared `fires` arrays.
+ */
+export const firesDeclarations: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isTestFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const diagnostics: WardenDiagnostic[] = [];
+
+    for (const def of findTrailDefinitions(ast)) {
+      checkTrailDefinition(def, filePath, sourceCode, diagnostics);
+    }
+
+    return diagnostics;
+  },
+  description:
+    'Ensure ctx.fire() calls match the declared fires array in trail definitions.',
+  name: 'fires-declarations',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -2,12 +2,14 @@ import { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 import { crossDeclarations } from './cross-declarations.js';
 import { draftFileMarking } from './draft-file-marking.js';
 import { draftVisibleDebt } from './draft-visible-debt.js';
+import { firesDeclarations } from './fires-declarations.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
 import { noDirectImplInRoute } from './no-direct-impl-in-route.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
+import { onReferencesExist } from './on-references-exist.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
 import { provisionDeclarations } from './resource-declarations.js';
 import { provisionExists } from './resource-exists.js';
@@ -28,6 +30,8 @@ export { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 export { crossDeclarations } from './cross-declarations.js';
 export { draftFileMarking } from './draft-file-marking.js';
 export { draftVisibleDebt } from './draft-visible-debt.js';
+export { firesDeclarations } from './fires-declarations.js';
+export { onReferencesExist } from './on-references-exist.js';
 export { validDetourRefs } from './valid-detour-refs.js';
 export { noDirectImplInRoute } from './no-direct-impl-in-route.js';
 export { noDirectImplementationCall } from './no-direct-implementation-call.js';
@@ -49,6 +53,8 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [crossDeclarations.name, crossDeclarations],
   [draftFileMarking.name, draftFileMarking],
   [draftVisibleDebt.name, draftVisibleDebt],
+  [firesDeclarations.name, firesDeclarations],
+  [onReferencesExist.name, onReferencesExist],
   [provisionDeclarations.name, provisionDeclarations],
   [provisionExists.name, provisionExists],
   [preferSchemaInference.name, preferSchemaInference],

--- a/packages/warden/src/rules/on-references-exist.ts
+++ b/packages/warden/src/rules/on-references-exist.ts
@@ -1,0 +1,208 @@
+/**
+ * Validates that every signal id declared in a trail's `on:` array resolves
+ * to a known signal definition somewhere in the project.
+ *
+ * Mirrors `resource-exists` structurally — collects local signal definitions
+ * for the standalone `check()` path and accepts a project-wide
+ * `knownSignalIds` set via `checkWithContext()`.
+ */
+
+import { isDraftId } from '@ontrails/core';
+
+import {
+  collectSignalDefinitionIds,
+  findConfigProperty,
+  findTrailDefinitions,
+  getStringValue,
+  identifierName,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Const identifier resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort resolution of `const NAME = 'value'` declarations via regex.
+ * Mirrors the helper used by `cross-declarations` and `fires-declarations`.
+ */
+const resolveConstString = (
+  name: string,
+  sourceCode: string
+): string | null => {
+  const pattern = new RegExp(
+    `const\\s+${name}\\s*=\\s*(?:'([^']*)'|"([^"]*)")`
+  );
+  const match = pattern.exec(sourceCode);
+  if (!match) {
+    return null;
+  }
+  return match[1] ?? match[2] ?? null;
+};
+
+// ---------------------------------------------------------------------------
+// Declared `on:` extraction
+// ---------------------------------------------------------------------------
+
+const getOnElements = (config: AstNode): readonly AstNode[] => {
+  const onProp = findConfigProperty(config, 'on');
+  if (!onProp) {
+    return [];
+  }
+
+  const arrayNode = onProp.value;
+  if (!arrayNode || (arrayNode as AstNode).type !== 'ArrayExpression') {
+    return [];
+  }
+
+  const elements = (arrayNode as AstNode)['elements'] as
+    | readonly AstNode[]
+    | undefined;
+  return elements ?? [];
+};
+
+const extractOnElementId = (
+  element: AstNode,
+  sourceCode: string
+): string | null => {
+  if (element.type === 'Identifier') {
+    const name = identifierName(element);
+    return name ? resolveConstString(name, sourceCode) : null;
+  }
+
+  if (isStringLiteral(element)) {
+    return getStringValue(element);
+  }
+
+  return null;
+};
+
+const extractDeclaredOnIds = (
+  config: AstNode,
+  sourceCode: string
+): readonly string[] => [
+  ...new Set(
+    getOnElements(config).flatMap((element) => {
+      const id = extractOnElementId(element, sourceCode);
+      return id ? [id] : [];
+    })
+  ),
+];
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+const buildMissingSignalDiagnostic = (
+  trailId: string,
+  signalId: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}" declares on: "${signalId}" which is not a known signal in the project.`,
+  rule: 'on-references-exist',
+  severity: 'error',
+});
+
+const reportMissingSignals = (
+  def: { id: string; config: AstNode; start: number },
+  sourceCode: string,
+  filePath: string,
+  knownSignalIds: ReadonlySet<string>,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  const line = offsetToLine(sourceCode, def.start);
+  for (const signalId of extractDeclaredOnIds(def.config, sourceCode)) {
+    if (!knownSignalIds.has(signalId) && !isDraftId(signalId)) {
+      diagnostics.push(
+        buildMissingSignalDiagnostic(def.id, signalId, filePath, line)
+      );
+    }
+  }
+};
+
+const buildSignalDiagnostics = (
+  ast: AstNode,
+  sourceCode: string,
+  filePath: string,
+  knownSignalIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+  for (const def of findTrailDefinitions(ast)) {
+    if (def.kind !== 'trail') {
+      continue;
+    }
+    reportMissingSignals(
+      def,
+      sourceCode,
+      filePath,
+      knownSignalIds,
+      diagnostics
+    );
+  }
+  return diagnostics;
+};
+
+const checkOnReferences = (
+  sourceCode: string,
+  filePath: string,
+  knownSignalIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath)) {
+    return [];
+  }
+
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  return buildSignalDiagnostics(ast, sourceCode, filePath, knownSignalIds);
+};
+
+/**
+ * Checks that every `on:` reference resolves to a known signal definition.
+ */
+export const onReferencesExist: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+    return checkOnReferences(
+      sourceCode,
+      filePath,
+      collectSignalDefinitionIds(ast)
+    );
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    const localSignalIds = ast
+      ? collectSignalDefinitionIds(ast)
+      : new Set<string>();
+    return checkOnReferences(
+      sourceCode,
+      filePath,
+      context.knownSignalIds ?? localSignalIds
+    );
+  },
+  description:
+    'Ensure every signal id declared in a trail on: array resolves to a known signal definition.',
+  name: 'on-references-exist',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -47,6 +47,8 @@ export interface ProjectContext {
   readonly knownTrailIds: ReadonlySet<string>;
   /** All known resource IDs in the project */
   readonly knownProvisionIds?: ReadonlySet<string>;
+  /** All known signal IDs in the project */
+  readonly knownSignalIds?: ReadonlySet<string>;
   /** All trail IDs referenced as detour targets across the project */
   readonly detourTargetTrailIds?: ReadonlySet<string>;
 }

--- a/packages/warden/src/trails/fires-declarations.trail.ts
+++ b/packages/warden/src/trails/fires-declarations.trail.ts
@@ -1,0 +1,22 @@
+import { firesDeclarations } from '../rules/fires-declarations.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const firesDeclarationsTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        sourceCode: `trail("entity.onboard", {
+  fires: ["entity.created"],
+  blaze: async (input, ctx) => {
+    await ctx.fire("entity.created", { id: input.id });
+    return Result.ok({});
+  }
+})`,
+      },
+      name: 'Matched fires declarations and calls',
+    },
+  ],
+  rule: firesDeclarations,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -1,6 +1,8 @@
 export { contextNoTrailheadTypesTrail } from './context-no-trailhead-types.trail.js';
 export { crossDeclarationsTrail } from './cross-declarations.trail.js';
+export { firesDeclarationsTrail } from './fires-declarations.trail.js';
 export { implementationReturnsResultTrail } from './implementation-returns-result.trail.js';
+export { onReferencesExistTrail } from './on-references-exist.trail.js';
 export { noDirectImplInRouteTrail } from './no-direct-impl-in-route.trail.js';
 export { noDirectImplementationCallTrail } from './no-direct-implementation-call.trail.js';
 export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.js';

--- a/packages/warden/src/trails/on-references-exist.trail.ts
+++ b/packages/warden/src/trails/on-references-exist.trail.ts
@@ -1,0 +1,21 @@
+import { onReferencesExist } from '../rules/on-references-exist.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const onReferencesExistTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'consumer.ts',
+        knownSignalIds: ['entity.created'],
+        knownTrailIds: ['notify'],
+        sourceCode: `trail("notify", {
+  on: ["entity.created"],
+  blaze: async (input, ctx) => Result.ok({}),
+})`,
+      },
+      name: 'Resolved on: reference',
+    },
+  ],
+  rule: onReferencesExist,
+});

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -34,6 +34,10 @@ export const projectAwareRuleInput = ruleInput.extend({
     .array(z.string())
     .optional()
     .describe('Resource IDs known across the project'),
+  knownSignalIds: z
+    .array(z.string())
+    .optional()
+    .describe('Signal IDs known across the project'),
   knownTrailIds: z
     .array(z.string())
     .optional()

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -54,6 +54,9 @@ export function wrapRule(
           knownProvisionIds: input.knownProvisionIds
             ? new Set(input.knownProvisionIds)
             : undefined,
+          knownSignalIds: input.knownSignalIds
+            ? new Set(input.knownSignalIds)
+            : undefined,
           knownTrailIds: input.knownTrailIds
             ? new Set(input.knownTrailIds)
             : new Set<string>(),


### PR DESCRIPTION
Phase 2 of TRL-197. Adds two warden rules that enforce the
fires:/on: contract introduced by Phase 1, mirroring the existing
crosses:/cross-declarations pattern exactly.

New rules:
- fires-declarations: AST-walks every blaze body for ctx.fire('id')
  calls and diffs against the trail's declared fires: array. Catches
  declared-but-not-called and called-but-not-declared. Mirror of
  cross-declarations.ts.
- on-references-exist: project-aware rule that iterates each trail's
  on: array and verifies every signal id resolves against the topo
  (or local-file collection in standalone check mode). Mirror of
  resource-exists.ts.

Both rules registered in wardenRules and exposed as trails in
wardenTopo via parallel .trail.ts wrappers.

Plumbing:
- ProjectContext gains optional knownSignalIds set
- New collectSignalDefinitionIds AST helper filters trail
  definitions by kind === 'signal'
- projectAwareRuleInput Zod schema extended with knownSignalIds
- wrap-rule threads knownSignalIds through the project-aware context
- cli's buildProjectContextFromTopo and buildProjectContextFromFiles
  populate knownSignalIds

Tests:
- 17 fires-declarations tests covering clean cases, error cases,
  warn cases, single-object overload, context param renaming,
  destructured fire(), nested meta.blaze guard, const identifier
  resolution, dynamic ids skipped, multi-trail, test-file skip,
  both-wrong combo
- 7 on-references-exist tests covering local definition, missing
  context, multiple references, no-on:, const resolution, test-file
  skip
- wardenTopo.count expectation bumped 13 → 15

bun run typecheck, test, and check all pass.

Deferred (TRL-197 future phases): persisted topo edges
(topo_trail_fires/topo_trail_on tables), dogfooding integration,
generic ctx.fire<T> overload.