### PR TITLE
feat(trails-demo): exercise fires:/on: end-to-end [TRL-197]

### DIFF
--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -245,3 +245,48 @@ trails survey --module ./src/app.ts
 ```
 
 Use `trails topo *` for the day-to-day operational flow: inspect the current topo, pin meaningful points, and export or verify the committed lock artifacts. `survey` remains the broader introspection surface for list, detail, diff, and OpenAPI output.
+
+## Signals
+
+The demo exercises the lexicon's reactive activation primitive end-to-end. A producer trail declares the signal it emits, calls `ctx.fire()` from its blaze, and any trail that lists the signal in `on:` runs automatically.
+
+```typescript
+// src/signals/entity-signals.ts
+export const updated = signal('entity.updated', {
+  from: ['entity.add', 'entity.delete'],
+  payload: z.object({
+    action: z.enum(['created', 'updated', 'deleted']),
+    entityId: z.string(),
+    entityName: z.string(),
+    timestamp: z.string(),
+  }),
+});
+
+// src/trails/entity.ts -- producer
+export const add = trail('entity.add', {
+  fires: ['entity.updated'],
+  blaze: async (input, ctx) => {
+    const entity = await store.entities.insert(input);
+    await ctx.fire?.('entity.updated', {
+      action: 'created',
+      entityId: entity.id,
+      entityName: entity.name,
+      timestamp: entity.createdAt,
+    });
+    return Result.ok(entity);
+  },
+  // ...
+});
+
+// src/trails/notify.ts -- consumer
+export const notifyEntityUpdated = trail('entity.notify-updated', {
+  on: ['entity.updated'],
+  blaze: (input, ctx) => {
+    // runs automatically whenever entity.updated fires
+    return Result.ok({ notified: true });
+  },
+  // ...
+});
+```
+
+The warden enforces that every `ctx.fire(id, ...)` call appears in the trail's `fires: [...]` declaration (and vice-versa), and that every `on:` reference resolves to a signal definition the topo actually knows about. See `__tests__/signals.test.ts` for the end-to-end proof.

--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -26,6 +26,7 @@ import * as entitySignals from '../src/signals/entity-signals.js';
 import * as demoProvisions from '../src/resources/entity-store.js';
 import * as entity from '../src/trails/entity.js';
 import * as kv from '../src/trails/kv.js';
+import * as notify from '../src/trails/notify.js';
 import * as onboard from '../src/trails/onboard.js';
 import * as search from '../src/trails/search.js';
 
@@ -50,8 +51,8 @@ describe('trailhead map generation', () => {
     expect(ids).toContain('demo.entity-store');
   });
 
-  test('has exactly 9 entries (7 trails + 1 event + 1 resource)', () => {
-    expect(trailheadMap.entries).toHaveLength(9);
+  test('has exactly 10 entries (8 trails + 1 event + 1 resource)', () => {
+    expect(trailheadMap.entries).toHaveLength(10);
   });
 
   test('entries are sorted alphabetically by id', () => {
@@ -215,6 +216,7 @@ describe('breaking change detection', () => {
       onboard,
       entitySignals,
       kv,
+      notify,
       demoProvisions
     );
 
@@ -236,6 +238,7 @@ describe('breaking change detection', () => {
       onboard,
       entitySignals,
       kv,
+      notify,
       demoProvisions
     );
 
@@ -270,6 +273,7 @@ describe('non-breaking change detection', () => {
       onboard,
       entitySignals,
       kv,
+      notify,
       demoProvisions,
       { update }
     );
@@ -293,6 +297,7 @@ describe('non-breaking change detection', () => {
       onboard,
       entitySignals,
       kv,
+      notify,
       demoProvisions
     );
     expect(diff.hasBreaking).toBe(false);
@@ -338,7 +343,7 @@ describe('topo validation', () => {
       const trailDef = t as { examples?: readonly unknown[] };
       exampleCount += trailDef.examples?.length ?? 0;
     }
-    // 5 trails x 2 examples each + 1 onboard trail x 1 example + 1 kv trail x 1 example = 12
-    expect(exampleCount).toBe(12);
+    // 5 trails x 2 examples each + 1 onboard trail x 1 example + 1 kv trail x 1 example + 1 notify trail x 1 example = 13
+    expect(exampleCount).toBe(13);
   });
 });

--- a/apps/trails-demo/__tests__/signals.test.ts
+++ b/apps/trails-demo/__tests__/signals.test.ts
@@ -1,0 +1,123 @@
+/**
+ * End-to-end integration tests for the producer -> consumer signal flow.
+ *
+ * Proves that `fires:` / `on:` fan-out works against a real topo:
+ * - entity.add declares `fires: ['entity.updated']` and calls ctx.fire
+ * - entity.updated is a signal defined in src/signals/entity-signals.ts
+ * - entity.notify-updated declares `on: ['entity.updated']` as a consumer
+ *
+ * Also exercises the warden rules that guard the declarations.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+import { firesDeclarations, onReferencesExist } from '@ontrails/warden';
+
+import { app } from '../src/app.js';
+import { entityStoreProvision } from '../src/resources/entity-store.js';
+import { createStore } from '../src/store.js';
+import { clearNotifications, getNotifications } from '../src/trails/notify.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+const entitySourcePath = resolve(moduleDir, '../src/trails/entity.ts');
+const notifySourcePath = resolve(moduleDir, '../src/trails/notify.ts');
+
+// ---------------------------------------------------------------------------
+// End-to-end fan-out
+// ---------------------------------------------------------------------------
+
+describe('entity.updated signal flow', () => {
+  beforeEach(() => {
+    clearNotifications();
+  });
+
+  test('entity.add fires entity.updated and notify consumer runs', async () => {
+    const store = createStore([]);
+
+    const result = await run(
+      app,
+      'entity.add',
+      { name: 'Epsilon', tags: ['reactive'], type: 'concept' },
+      { ctx: { extensions: { [entityStoreProvision.id]: store } } }
+    );
+
+    expect(result.isOk()).toBe(true);
+
+    const notifications = getNotifications();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.action).toBe('created');
+    expect(notifications[0]?.entityName).toBe('Epsilon');
+    expect(notifications[0]?.entityId).toBeString();
+    expect(notifications[0]?.timestamp).toBeString();
+  });
+
+  test('entity.delete also fires entity.updated', async () => {
+    const store = createStore([{ name: 'Disposable', tags: [], type: 'tool' }]);
+
+    const result = await run(
+      app,
+      'entity.delete',
+      { name: 'Disposable' },
+      { ctx: { extensions: { [entityStoreProvision.id]: store } } }
+    );
+
+    expect(result.isOk()).toBe(true);
+    const notifications = getNotifications();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.action).toBe('deleted');
+    expect(notifications[0]?.entityName).toBe('Disposable');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Topo registration sanity
+// ---------------------------------------------------------------------------
+
+describe('signal wiring in the demo topo', () => {
+  test('entity.updated is registered as a signal', () => {
+    expect(app.signals.has('entity.updated')).toBe(true);
+  });
+
+  test('entity.notify-updated is registered with on: [entity.updated]', () => {
+    const consumer = app.get('entity.notify-updated');
+    expect(consumer).toBeDefined();
+    expect(consumer?.on).toContain('entity.updated');
+  });
+
+  test('entity.add declares fires: [entity.updated]', () => {
+    const producer = app.get('entity.add');
+    expect(producer).toBeDefined();
+    expect(producer?.fires).toContain('entity.updated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warden rule coverage
+// ---------------------------------------------------------------------------
+
+describe('warden rules over the signal producer/consumer', () => {
+  test('fires-declarations passes for entity.ts', () => {
+    const source = readFileSync(entitySourcePath, 'utf8');
+    const diagnostics = firesDeclarations.check(source, entitySourcePath);
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('on-references-exist passes for notify.ts with known signals', () => {
+    const source = readFileSync(notifySourcePath, 'utf8');
+    const diagnostics = onReferencesExist.checkWithContext(
+      source,
+      notifySourcePath,
+      { knownSignalIds: new Set(['entity.updated']) }
+    );
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/apps/trails-demo/package.json
+++ b/apps/trails-demo/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@ontrails/schema": "workspace:^",
-    "@ontrails/testing": "workspace:^"
+    "@ontrails/testing": "workspace:^",
+    "@ontrails/warden": "workspace:^"
   }
 }

--- a/apps/trails-demo/src/app.ts
+++ b/apps/trails-demo/src/app.ts
@@ -8,6 +8,7 @@ import * as entitySignals from './signals/entity-signals.js';
 import * as demoProvisions from './resources/entity-store.js';
 import * as entity from './trails/entity.js';
 import * as kv from './trails/kv.js';
+import * as notify from './trails/notify.js';
 import * as onboard from './trails/onboard.js';
 import * as search from './trails/search.js';
 
@@ -18,5 +19,6 @@ export const app = topo(
   search,
   onboard,
   entitySignals,
-  kv
+  kv,
+  notify
 );

--- a/apps/trails-demo/src/trails/entity.ts
+++ b/apps/trails-demo/src/trails/entity.ts
@@ -91,6 +91,12 @@ export const add = trail('entity.add', {
         tags: input.tags ?? [],
         type: input.type,
       });
+      await ctx.fire?.('entity.updated', {
+        action: 'created',
+        entityId: entity.id,
+        entityName: entity.name,
+        timestamp: entity.createdAt,
+      });
       return Result.ok(toEntity(entity));
     } catch (error) {
       if (error instanceof AlreadyExistsError) {
@@ -116,6 +122,7 @@ export const add = trail('entity.add', {
       name: 'Duplicate entity returns conflict',
     },
   ],
+  fires: ['entity.updated'],
   input: z.object({
     name: z.string().describe('Entity name'),
     tags: z
@@ -141,6 +148,12 @@ export const remove = trail('entity.delete', {
     if (!deleted.deleted) {
       return Result.err(new NotFoundError(`Entity "${input.name}" not found`));
     }
+    await ctx.fire?.('entity.updated', {
+      action: 'deleted',
+      entityId: input.name,
+      entityName: input.name,
+      timestamp: new Date().toISOString(),
+    });
     return Result.ok({ deleted: true, name: input.name });
   },
   description: 'Delete an entity by name',
@@ -157,6 +170,7 @@ export const remove = trail('entity.delete', {
       name: 'Delete non-existent entity returns not found',
     },
   ],
+  fires: ['entity.updated'],
   input: z.object({
     name: z.string().describe('Entity name to delete'),
   }),

--- a/apps/trails-demo/src/trails/notify.ts
+++ b/apps/trails-demo/src/trails/notify.ts
@@ -1,0 +1,90 @@
+/**
+ * Notification trails -- reactive consumers of domain signals.
+ *
+ * Demonstrates: `on:` activation wiring trails to signals emitted by
+ * other trails. The runtime fans out to every consumer that lists the
+ * signal in its `on:` array when a producer calls `ctx.fire()`.
+ */
+
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Notification log -- in-memory side-effect sink
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutable in-memory log of notifications emitted by `entity.notify-updated`.
+ *
+ * Exists so the demo and its integration tests can observe the end-to-end
+ * signal fan-out pipeline without a real notification transport. A real
+ * app would replace this with an email/slack/webhook provision.
+ */
+export interface Notification {
+  readonly action: 'created' | 'updated' | 'deleted';
+  readonly entityId: string;
+  readonly entityName: string;
+  readonly timestamp: string;
+}
+
+const notificationLog: Notification[] = [];
+
+/** Read the current notification log (defensive copy). */
+export const getNotifications = (): readonly Notification[] => [
+  ...notificationLog,
+];
+
+/** Clear the notification log. Useful between tests. */
+export const clearNotifications = (): void => {
+  notificationLog.length = 0;
+};
+
+// ---------------------------------------------------------------------------
+// entity.notify-updated
+// ---------------------------------------------------------------------------
+
+/**
+ * Consumer trail that reacts to entity.updated signals.
+ *
+ * Receives the validated signal payload as its input and logs a
+ * notification. Serves as the proof-of-life for the signal fan-out
+ * pipeline in the demo app.
+ */
+export const notifyEntityUpdated = trail('entity.notify-updated', {
+  blaze: (input, ctx) => {
+    notificationLog.push({
+      action: input.action,
+      entityId: input.entityId,
+      entityName: input.entityName,
+      timestamp: input.timestamp,
+    });
+    ctx.logger?.info('entity.updated notification', {
+      action: input.action,
+      entityId: input.entityId,
+      entityName: input.entityName,
+    });
+    return Result.ok({ notified: true });
+  },
+  description: 'Log a notification whenever an entity.updated signal is fired.',
+  examples: [
+    {
+      description: 'Notify on a created entity',
+      input: {
+        action: 'created',
+        entityId: 'ent_1',
+        entityName: 'Epsilon',
+        timestamp: '2026-04-07T00:00:00.000Z',
+      },
+      name: 'Notify created',
+    },
+  ],
+  input: z.object({
+    action: z.enum(['created', 'updated', 'deleted']),
+    entityId: z.string(),
+    entityName: z.string(),
+    timestamp: z.string(),
+  }),
+  intent: 'write',
+  on: ['entity.updated'],
+  output: z.object({ notified: z.boolean() }),
+});

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
       "devDependencies": {
         "@ontrails/schema": "workspace:^",
         "@ontrails/testing": "workspace:^",
+        "@ontrails/warden": "workspace:^",
       },
     },
     "packages/cli": {


### PR DESCRIPTION
Phase 3 of TRL-197. Wires the entity.updated signal that was already
declared on entity-signals.ts but never actually fired. entity.add and
entity.delete now declare fires: ['entity.updated'] and call ctx.fire
from their blazes. A new notify.ts consumer trail with on:
['entity.updated'] subscribes via the topo and records side effects in
an exported notificationLog so tests and real callers can observe
delivery.

Files added:
- apps/trails-demo/src/trails/notify.ts — consumer trail
- apps/trails-demo/__tests__/signals.test.ts — 9 end-to-end tests

Files modified:
- apps/trails-demo/src/trails/entity.ts — entity.add and entity.delete
  now fire entity.updated
- apps/trails-demo/src/app.ts — registers notify module
- apps/trails-demo/__tests__/governance.test.ts — entry/example counts
  bumped to reflect new trail
- apps/trails-demo/package.json — adds @ontrails/warden devDependency
  for in-test rule coverage
- apps/trails-demo/README.md — new Signals section

Test coverage:
- Producer fan-out via real run() calls + getNotifications() side
  effect assertions
- Topo registration of signal and consumer
- fires-declarations rule passes against entity.ts source
- on-references-exist rule passes against notify.ts with known signals

bun run typecheck, test, and check all pass.

Surfaced for follow-up: fanOutToConsumers in packages/core/src/fire.ts
intentionally only forwards { fire } to consumer contexts, dropping
the producer's logger, extensions, and provisions. This is an
ergonomics gap worth a dedicated issue — consumer trails currently
can't use provisions or share logger streams.