### PR TITLE
fix(core): consumer trails inherit producer ctx [TRL-198]

### DIFF
--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -24,6 +24,7 @@ import { z } from 'zod';
 import { app } from '../src/app.js';
 import * as entitySignals from '../src/signals/entity-signals.js';
 import * as demoProvisions from '../src/resources/entity-store.js';
+import * as notificationStoreResource from '../src/resources/notification-store.js';
 import * as entity from '../src/trails/entity.js';
 import * as kv from '../src/trails/kv.js';
 import * as notify from '../src/trails/notify.js';
@@ -51,8 +52,14 @@ describe('trailhead map generation', () => {
     expect(ids).toContain('demo.entity-store');
   });
 
-  test('has exactly 10 entries (8 trails + 1 event + 1 resource)', () => {
-    expect(trailheadMap.entries).toHaveLength(10);
+  test('has exactly 11 entries (8 trails + 1 event + 2 resources)', () => {
+    expect(trailheadMap.entries).toHaveLength(11);
+    expect(trailheadMap.entries.map((e) => e.id)).toContain(
+      'entity.notify-updated'
+    );
+    expect(trailheadMap.entries.map((e) => e.id)).toContain(
+      'demo.notification-store'
+    );
   });
 
   test('entries are sorted alphabetically by id', () => {
@@ -217,6 +224,7 @@ describe('breaking change detection', () => {
       entitySignals,
       kv,
       notify,
+      notificationStoreResource,
       demoProvisions
     );
 
@@ -239,6 +247,7 @@ describe('breaking change detection', () => {
       entitySignals,
       kv,
       notify,
+      notificationStoreResource,
       demoProvisions
     );
 
@@ -274,6 +283,7 @@ describe('non-breaking change detection', () => {
       entitySignals,
       kv,
       notify,
+      notificationStoreResource,
       demoProvisions,
       { update }
     );
@@ -298,6 +308,7 @@ describe('non-breaking change detection', () => {
       entitySignals,
       kv,
       notify,
+      notificationStoreResource,
       demoProvisions
     );
     expect(diff.hasBreaking).toBe(false);

--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -53,13 +53,11 @@ describe('trailhead map generation', () => {
   });
 
   test('has exactly 11 entries (8 trails + 1 event + 2 resources)', () => {
+    const ids = trailheadMap.entries.map((e) => e.id);
+
     expect(trailheadMap.entries).toHaveLength(11);
-    expect(trailheadMap.entries.map((e) => e.id)).toContain(
-      'entity.notify-updated'
-    );
-    expect(trailheadMap.entries.map((e) => e.id)).toContain(
-      'demo.notification-store'
-    );
+    expect(ids).toContain('entity.notify-updated');
+    expect(ids).toContain('demo.notification-store');
   });
 
   test('entries are sorted alphabetically by id', () => {

--- a/apps/trails-demo/__tests__/signals.test.ts
+++ b/apps/trails-demo/__tests__/signals.test.ts
@@ -5,6 +5,8 @@
  * - entity.add declares `fires: ['entity.updated']` and calls ctx.fire
  * - entity.updated is a signal defined in src/signals/entity-signals.ts
  * - entity.notify-updated declares `on: ['entity.updated']` as a consumer
+ *   and reads its notification sink from a real resource registered on
+ *   the producer's context — proving consumer ctx inheritance (TRL-198)
  *
  * Also exercises the warden rules that guard the declarations.
  */
@@ -13,15 +15,18 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
-import { beforeEach, describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 
 import { run } from '@ontrails/core';
 import { firesDeclarations, onReferencesExist } from '@ontrails/warden';
 
 import { app } from '../src/app.js';
 import { entityStoreProvision } from '../src/resources/entity-store.js';
+import {
+  createNotificationStore,
+  notificationStoreProvision,
+} from '../src/resources/notification-store.js';
 import { createStore } from '../src/store.js';
-import { clearNotifications, getNotifications } from '../src/trails/notify.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -31,28 +36,32 @@ const moduleDir = dirname(fileURLToPath(import.meta.url));
 const entitySourcePath = resolve(moduleDir, '../src/trails/entity.ts');
 const notifySourcePath = resolve(moduleDir, '../src/trails/notify.ts');
 
+const buildCtxExtensions = (
+  entityStore: ReturnType<typeof createStore>,
+  notificationStore: ReturnType<typeof createNotificationStore>
+) => ({
+  [entityStoreProvision.id]: entityStore,
+  [notificationStoreProvision.id]: notificationStore,
+});
+
 // ---------------------------------------------------------------------------
 // End-to-end fan-out
 // ---------------------------------------------------------------------------
 
 describe('entity.updated signal flow', () => {
-  beforeEach(() => {
-    clearNotifications();
-  });
-
   test('entity.add fires entity.updated and notify consumer runs', async () => {
-    const store = createStore([]);
-
+    const entityStore = createStore([]);
+    const notificationStore = createNotificationStore();
     const result = await run(
       app,
       'entity.add',
       { name: 'Epsilon', tags: ['reactive'], type: 'concept' },
-      { ctx: { extensions: { [entityStoreProvision.id]: store } } }
+      {
+        ctx: { extensions: buildCtxExtensions(entityStore, notificationStore) },
+      }
     );
-
     expect(result.isOk()).toBe(true);
-
-    const notifications = getNotifications();
+    const notifications = notificationStore.list();
     expect(notifications).toHaveLength(1);
     expect(notifications[0]?.action).toBe('created');
     expect(notifications[0]?.entityName).toBe('Epsilon');
@@ -61,17 +70,20 @@ describe('entity.updated signal flow', () => {
   });
 
   test('entity.delete also fires entity.updated', async () => {
-    const store = createStore([{ name: 'Disposable', tags: [], type: 'tool' }]);
-
+    const entityStore = createStore([
+      { name: 'Disposable', tags: [], type: 'tool' },
+    ]);
+    const notificationStore = createNotificationStore();
     const result = await run(
       app,
       'entity.delete',
       { name: 'Disposable' },
-      { ctx: { extensions: { [entityStoreProvision.id]: store } } }
+      {
+        ctx: { extensions: buildCtxExtensions(entityStore, notificationStore) },
+      }
     );
-
     expect(result.isOk()).toBe(true);
-    const notifications = getNotifications();
+    const notifications = notificationStore.list();
     expect(notifications).toHaveLength(1);
     expect(notifications[0]?.action).toBe('deleted');
     expect(notifications[0]?.entityName).toBe('Disposable');

--- a/apps/trails-demo/src/app.ts
+++ b/apps/trails-demo/src/app.ts
@@ -5,7 +5,8 @@
 import { topo } from '@ontrails/core';
 
 import * as entitySignals from './signals/entity-signals.js';
-import * as demoProvisions from './resources/entity-store.js';
+import * as entityStore from './resources/entity-store.js';
+import * as notificationStore from './resources/notification-store.js';
 import * as entity from './trails/entity.js';
 import * as kv from './trails/kv.js';
 import * as notify from './trails/notify.js';
@@ -14,7 +15,8 @@ import * as search from './trails/search.js';
 
 export const app = topo(
   'demo',
-  demoProvisions,
+  entityStore,
+  notificationStore,
   entity,
   search,
   onboard,

--- a/apps/trails-demo/src/resources/notification-store.ts
+++ b/apps/trails-demo/src/resources/notification-store.ts
@@ -1,0 +1,44 @@
+/**
+ * Resource-backed notification store for the trails-demo app.
+ *
+ * Demonstrates that consumer trails activated via `on:` can access
+ * resources registered on the producer's context. The notification
+ * store is the side-effect sink for the entity.notify-updated trail.
+ */
+
+import { Result, resource } from '@ontrails/core';
+
+export interface Notification {
+  readonly action: 'created' | 'updated' | 'deleted';
+  readonly entityId: string;
+  readonly entityName: string;
+  readonly timestamp: string;
+}
+
+export interface NotificationStore {
+  push(notification: Notification): void;
+  list(): readonly Notification[];
+  clear(): void;
+}
+
+export const createNotificationStore = (): NotificationStore => {
+  const log: Notification[] = [];
+  return {
+    clear() {
+      log.length = 0;
+    },
+    list() {
+      return [...log];
+    },
+    push(notification: Notification) {
+      log.push(notification);
+    },
+  };
+};
+
+export const notificationStoreProvision = resource('demo.notification-store', {
+  create: () => Result.ok(createNotificationStore()),
+  description:
+    'In-memory notification store consumed by the entity.notify-updated trail.',
+  mock: () => createNotificationStore(),
+});

--- a/apps/trails-demo/src/trails/notify.ts
+++ b/apps/trails-demo/src/trails/notify.ts
@@ -4,40 +4,16 @@
  * Demonstrates: `on:` activation wiring trails to signals emitted by
  * other trails. The runtime fans out to every consumer that lists the
  * signal in its `on:` array when a producer calls `ctx.fire()`.
+ *
+ * Consumer trails inherit the producer's full context, including
+ * resources, so the notification side-effect lives in a real
+ * `notificationStoreProvision` resource rather than a module-level array.
  */
 
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-// ---------------------------------------------------------------------------
-// Notification log -- in-memory side-effect sink
-// ---------------------------------------------------------------------------
-
-/**
- * Mutable in-memory log of notifications emitted by `entity.notify-updated`.
- *
- * Exists so the demo and its integration tests can observe the end-to-end
- * signal fan-out pipeline without a real notification transport. A real
- * app would replace this with an email/slack/webhook provision.
- */
-export interface Notification {
-  readonly action: 'created' | 'updated' | 'deleted';
-  readonly entityId: string;
-  readonly entityName: string;
-  readonly timestamp: string;
-}
-
-const notificationLog: Notification[] = [];
-
-/** Read the current notification log (defensive copy). */
-export const getNotifications = (): readonly Notification[] => [
-  ...notificationLog,
-];
-
-/** Clear the notification log. Useful between tests. */
-export const clearNotifications = (): void => {
-  notificationLog.length = 0;
-};
+import { notificationStoreProvision } from '../resources/notification-store.js';
 
 // ---------------------------------------------------------------------------
 // entity.notify-updated
@@ -46,13 +22,15 @@ export const clearNotifications = (): void => {
 /**
  * Consumer trail that reacts to entity.updated signals.
  *
- * Receives the validated signal payload as its input and logs a
- * notification. Serves as the proof-of-life for the signal fan-out
- * pipeline in the demo app.
+ * Receives the validated signal payload as its input and writes a
+ * notification to the resource-backed notification store. Serves as
+ * the proof-of-life for the signal fan-out pipeline in the demo app
+ * AND for resource access from a consumer context.
  */
 export const notifyEntityUpdated = trail('entity.notify-updated', {
   blaze: (input, ctx) => {
-    notificationLog.push({
+    const store = notificationStoreProvision.from(ctx);
+    store.push({
       action: input.action,
       entityId: input.entityId,
       entityName: input.entityName,
@@ -87,4 +65,5 @@ export const notifyEntityUpdated = trail('entity.notify-updated', {
   intent: 'write',
   on: ['entity.updated'],
   output: z.object({ notified: z.boolean() }),
+  resources: [notificationStoreProvision],
 });

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -5,6 +5,7 @@ import {
   TRAILHEAD_KEY,
   createTrailContext,
   resource,
+  signal,
   trail,
   topo,
 } from '@ontrails/core';
@@ -34,6 +35,10 @@ const dbProvision = resource('db.main', {
     }),
 });
 
+const orderPlaced = signal('order.placed', {
+  payload: z.object({ orderId: z.string() }),
+});
+
 const requireCommand = (commands: ReturnType<typeof buildCliCommands>) => {
   const [command] = commands;
   expect(command).toBeDefined();
@@ -41,6 +46,13 @@ const requireCommand = (commands: ReturnType<typeof buildCliCommands>) => {
     throw new Error('Expected command');
   }
   return command;
+};
+
+const requireFire = (fire: TrailContext['fire']) => {
+  if (!fire) {
+    throw new Error('Expected ctx.fire to be bound');
+  }
+  return fire;
 };
 
 // ---------------------------------------------------------------------------
@@ -441,6 +453,40 @@ describe('buildCliCommands execution', () => {
 });
 
 describe('buildCliCommands resource overrides', () => {
+  test('passes topo to executeTrail so CLI-invoked producers can fan out', async () => {
+    const captured: string[] = [];
+    const consumer = trail('notify.email', {
+      blaze: (input: { orderId: string }) => {
+        captured.push(input.orderId);
+        return Result.ok({ delivered: true });
+      },
+      input: z.object({ orderId: z.string() }),
+      on: ['order.placed'],
+    });
+    const producer = trail('order.create', {
+      blaze: async (input: { orderId: string }, ctx) => {
+        const fired = await requireFire(ctx.fire)('order.placed', {
+          orderId: input.orderId,
+        });
+        return fired.match({
+          err: (error) => Result.err(error),
+          ok: () => Result.ok({ ok: true }),
+        });
+      },
+      fires: ['order.placed'],
+      input: z.object({ orderId: z.string() }),
+    });
+    const app = topo('signal-cli', { consumer, orderPlaced, producer });
+
+    const result = await requireCommand(buildCliCommands(app)).execute(
+      {},
+      { orderId: 'o-cli' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(captured).toEqual(['o-cli']);
+  });
+
   test('forwards resource overrides into executeTrail', async () => {
     const t = trail('resource-test', {
       blaze: (_input, ctx) =>

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -274,6 +274,7 @@ const safeMergeInput = async (
 /** Create the execute function for a CLI command. */
 const createExecute =
   (
+    app: Topo,
     t: AnyTrail,
     fields: readonly Field[],
     metaFlagNames: ReadonlySet<string>,
@@ -310,6 +311,7 @@ const createExecute =
       ctx: withCliTrailhead(ctxOverrides),
       layers: options?.layers,
       resources: options?.resources,
+      topo: app,
     });
     const finalResult = maybeAddStructuredInputHint(
       result,
@@ -355,6 +357,7 @@ const buildFlags = (
 
 /** Convert a trail or route into a CLI command when it is publicly exposed. */
 const toCliCommand = (
+  app: Topo,
   t: AnyTrail,
   options?: BuildCliCommandsOptions
 ): CliCommand => {
@@ -379,6 +382,7 @@ const toCliCommand = (
     args: [],
     description: t.description,
     execute: createExecute(
+      app,
       t,
       fields,
       metaFlagNames,
@@ -401,7 +405,7 @@ const collectCommands = (
   app
     .list()
     .filter((trail) => trail.meta?.['internal'] !== true)
-    .map((trail) => toCliCommand(trail, options));
+    .map((trail) => toCliCommand(app, trail, options));
 
 export const buildCliCommands = (
   app: Topo,

--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -8,7 +8,7 @@ import { run } from '../run';
 import { signal } from '../signal';
 import { topo } from '../topo';
 import { trail } from '../trail';
-import type { Logger, TrailContext } from '../types';
+import type { Logger } from '../types';
 
 const noopLogger: Logger = {
   child() {

--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -8,6 +8,31 @@ import { run } from '../run';
 import { signal } from '../signal';
 import { topo } from '../topo';
 import { trail } from '../trail';
+import type { Logger, TrailContext } from '../types';
+
+const noopLogger: Logger = {
+  child() {
+    return noopLogger;
+  },
+  debug() {
+    // noop
+  },
+  error() {
+    // noop
+  },
+  fatal() {
+    // noop
+  },
+  info() {
+    // noop
+  },
+  trace() {
+    // noop
+  },
+  warn() {
+    // noop
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -178,6 +203,190 @@ describe('fire', () => {
       const result = await executeTrail(standalone, {});
       expect(result.isOk()).toBe(true);
       expect((result.unwrap() as { hasFire: boolean }).hasFire).toBe(false);
+    });
+  });
+
+  describe('option forwarding', () => {
+    test('consumer inherits producer layers applied via options.layers', async () => {
+      const layerCalls: string[] = [];
+      const tagging: Layer = {
+        name: 'tag',
+        wrap: (_trail, implementation) => (input, ctx) => {
+          layerCalls.push('wrap');
+          return implementation(input, ctx);
+        },
+      };
+
+      const consumer = trail('layered.consumer', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({ orderId: z.string(), total: z.number() }),
+        on: ['order.placed'],
+      });
+      const fireBox: { result?: Result<void, Error> } = {};
+      const producer = makeProducer(fireBox);
+      const app = topo('fire-layer-forward', {
+        consumer,
+        orderPlaced,
+        producer,
+      });
+
+      const result = await run(
+        app,
+        'order.create',
+        { orderId: 'o-layer', total: 1 },
+        { layers: [tagging] }
+      );
+
+      expect(result.isOk()).toBe(true);
+      // Layer runs once for producer and once for consumer when forwarded.
+      expect(layerCalls.length).toBe(2);
+    });
+  });
+
+  describe('cycle detection', () => {
+    test('skips re-entrant signal cycles and logs a warning', async () => {
+      const warnings: { message: string; signalId?: unknown }[] = [];
+      const invocations: string[] = [];
+      const cycleLogger = createCycleLogger(warnings);
+      const app = createCycleScenario(invocations);
+
+      const result = await run(
+        app,
+        'loop.producer',
+        { id: 'loop-1' },
+        { ctx: { logger: cycleLogger } }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(invocations).toEqual(['a', 'b']);
+      expect(warnings).toEqual([
+        {
+          message: 'Signal cycle detected — skipping re-entrant fire',
+          signalId: 'loop.a',
+        },
+      ]);
+    });
+  });
+
+  describe('producer context inheritance', () => {
+    test('consumer inherits producer logger and requestId', async () => {
+      const captured: { requestId: string; loggerExists: boolean }[] = [];
+      const consumer = trail('inherit.consumer', {
+        blaze: (_input, ctx) => {
+          captured.push({
+            loggerExists: ctx.logger !== undefined,
+            requestId: ctx.requestId,
+          });
+          return Result.ok({ ok: true });
+        },
+        input: z.object({ orderId: z.string(), total: z.number() }),
+        on: ['order.placed'],
+      });
+      const fireBox: { result?: Result<void, Error> } = {};
+      const app = topo('fire-inherit', {
+        consumer,
+        orderPlaced,
+        producer: makeProducer(fireBox),
+      });
+      const result = await run(
+        app,
+        'order.create',
+        { orderId: 'o-inherit', total: 1 },
+        { ctx: { logger: noopLogger, requestId: 'producer-request-id' } }
+      );
+      expect(result.isOk()).toBe(true);
+      expect(captured).toHaveLength(1);
+      expect(captured[0]?.loggerExists).toBe(true);
+      expect(captured[0]?.requestId).toBe('producer-request-id');
+    });
+
+    test('consumer inherits layer-mutated producer requestId', async () => {
+      const captured: string[] = [];
+      const consumer = trail('inherit.layered.consumer', {
+        blaze: (_input, ctx) => {
+          captured.push(ctx.requestId);
+          return Result.ok({ ok: true });
+        },
+        input: z.object({ orderId: z.string(), total: z.number() }),
+        on: ['order.placed'],
+      });
+      const requestIdLayer: Layer = {
+        name: 'request-id-layer',
+        wrap: (_trail, implementation) => (input, ctx) =>
+          implementation(input, {
+            ...ctx,
+            requestId: 'layer-request-id',
+          }),
+      };
+      const fireBox: { result?: Result<void, Error> } = {};
+      const app = topo('fire-inherit-layered', {
+        consumer,
+        orderPlaced,
+        producer: makeProducer(fireBox),
+      });
+
+      const result = await run(
+        app,
+        'order.create',
+        { orderId: 'o-layered-inherit', total: 1 },
+        {
+          ctx: { requestId: 'producer-request-id' },
+          layers: [requestIdLayer],
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(captured).toEqual(['layer-request-id']);
+    });
+
+    test('extracted fire inherits layer-mutated producer requestId', async () => {
+      const captured: string[] = [];
+      const consumer = trail('inherit.extracted.consumer', {
+        blaze: (_input, ctx) => {
+          captured.push(ctx.requestId);
+          return Result.ok({ ok: true });
+        },
+        input: z.object({ orderId: z.string(), total: z.number() }),
+        on: ['order.placed'],
+      });
+      const producer = trail('inherit.extracted.producer', {
+        blaze: async (input, ctx) => {
+          const { fire } = ctx;
+          const fired = await fire?.('order.placed', {
+            orderId: input.orderId,
+            total: input.total,
+          });
+          return fired as Result<unknown, Error>;
+        },
+        fires: ['order.placed'],
+        input: z.object({ orderId: z.string(), total: z.number() }),
+      });
+      const requestIdLayer: Layer = {
+        name: 'request-id-layer',
+        wrap: (_trail, implementation) => (input, ctx) =>
+          implementation(input, {
+            ...ctx,
+            requestId: 'layer-request-id',
+          }),
+      };
+      const app = topo('fire-inherit-extracted', {
+        consumer,
+        orderPlaced,
+        producer,
+      });
+
+      const result = await run(
+        app,
+        'inherit.extracted.producer',
+        { orderId: 'o-layered-inherit', total: 1 },
+        {
+          ctx: { requestId: 'producer-request-id' },
+          layers: [requestIdLayer],
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(captured).toEqual(['layer-request-id']);
     });
   });
 });

--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -34,6 +34,85 @@ const noopLogger: Logger = {
   },
 };
 
+const createCycleLogger = (
+  warnings: { message: string; signalId?: unknown }[]
+): Logger => {
+  const logger: Logger = {
+    child() {
+      return logger;
+    },
+    debug() {
+      // noop
+    },
+    error() {
+      // noop
+    },
+    fatal() {
+      // noop
+    },
+    info() {
+      // noop
+    },
+    trace() {
+      // noop
+    },
+    warn(message, meta) {
+      const entry: { message: string; signalId?: unknown } = {
+        message: String(message),
+      };
+      if (
+        meta !== undefined &&
+        meta !== null &&
+        typeof meta === 'object' &&
+        'signalId' in meta
+      ) {
+        entry.signalId = (meta as { signalId: unknown }).signalId;
+      }
+      warnings.push(entry);
+    },
+  };
+  return logger;
+};
+
+const loopA = signal('loop.a', { payload: z.object({ id: z.string() }) });
+const loopB = signal('loop.b', { payload: z.object({ id: z.string() }) });
+
+const createCycleScenario = (invocations: string[]) => {
+  const producer = trail('loop.producer', {
+    blaze: async (_input, ctx) => {
+      await ctx.fire(loopA, { id: 'loop-1' });
+      return Result.ok();
+    },
+    input: z.object({ id: z.string() }),
+  });
+  const consumerA = trail('loop.consumer.a', {
+    blaze: async (_input, ctx) => {
+      invocations.push('a');
+      await ctx.fire(loopB, { id: 'loop-1' });
+      return Result.ok();
+    },
+    input: z.object({ id: z.string() }),
+    on: [loopA],
+  });
+  const consumerB = trail('loop.consumer.b', {
+    blaze: async (_input, ctx) => {
+      invocations.push('b');
+      // Re-fire loop.a to trigger cycle detection.
+      await ctx.fire(loopA, { id: 'loop-1' });
+      return Result.ok();
+    },
+    input: z.object({ id: z.string() }),
+    on: [loopB],
+  });
+  return topo('fire-cycle', {
+    consumerA,
+    consumerB,
+    loopA,
+    loopB,
+    producer,
+  });
+};
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -21,7 +21,6 @@ import type {
 } from './types.js';
 
 import { createTrailContext } from './context.js';
-import { composeLayers } from './layer.js';
 import { CancelledError, InternalError, TrailsError } from './errors.js';
 import {
   TRACE_CONTEXT_KEY,

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -10,6 +10,9 @@ import type { AnyTrail } from './trail.js';
 import type { Layer } from './layer.js';
 import type { ResourceOverrideMap } from './resource.js';
 import type { TraceContext, TraceRecord } from './internal/tracing.js';
+import type { Topo } from './topo.js';
+
+import { createFireFn } from './fire.js';
 import type {
   Implementation,
   TraceFn,
@@ -60,6 +63,8 @@ export interface ExecuteTrailOptions {
   readonly configValues?:
     | Readonly<Record<string, Record<string, unknown>>>
     | undefined;
+  /** Topo used for signal-driven activation; required for `ctx.fire()` to work. */
+  readonly topo?: Topo | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -296,30 +301,91 @@ const runImplWithRootRecord = async (
   }
 };
 
+const bindFireToCtx = (
+  ctx: TrailContext,
+  topo: Topo | undefined,
+  options: ExecuteTrailOptions | undefined
+): TrailContext => {
+  if (topo === undefined) {
+    return ctx;
+  }
+  // Forward the producer's execution options to consumers so resources,
+  // layers, configValues, and abortSignal propagate through signal fan-out.
+  // `createContext` is intentionally stripped — consumers inherit the
+  // already-resolved ctx via `consumerCtx`, and re-running the factory would
+  // clobber that.
+  const { createContext: _omit, ...forwarded } = options ?? {};
+  const fire = createFireFn(topo, ctx, (consumer, input, consumerCtx) =>
+    // eslint-disable-next-line no-use-before-define -- executor closure runs only after executeTrail is defined
+    executeTrail(consumer, input, {
+      ...forwarded,
+      ctx: consumerCtx,
+      topo,
+    })
+  );
+  return { ...ctx, fire };
+};
+
+const bindFireAtLayerBoundary = <I, O>(
+  implementation: Implementation<I, O>,
+  topo: Topo | undefined,
+  options: ExecuteTrailOptions | undefined
+): Implementation<I, O> => {
+  if (topo === undefined) {
+    return implementation;
+  }
+
+  return (input, ctx) =>
+    implementation(input, bindFireToCtx(ctx, topo, options));
+};
 const prepareRunImpl = (
   trail: AnyTrail,
-  layers: readonly Layer[]
+  ctx: TrailContext,
+  layers: readonly Layer[],
+  topo: Topo | undefined,
+  options: ExecuteTrailOptions | undefined
 ): {
+  readonly ctxWithFire: TrailContext;
   readonly impl: Implementation<unknown, unknown>;
-} => ({
-  impl: composeLayers([...layers], trail, trail.blaze) as Implementation<
-    unknown,
-    unknown
-  >,
-});
+} => {
+  const ctxWithFire = bindFireToCtx(ctx, topo, options);
+  let impl = bindFireAtLayerBoundary(
+    trail.blaze as Implementation<unknown, unknown>,
+    topo,
+    options
+  );
+
+  for (let i = layers.length - 1; i >= 0; i -= 1) {
+    const layer = layers[i];
+    if (layer) {
+      impl = bindFireAtLayerBoundary(
+        layer.wrap(trail, impl as never) as Implementation<unknown, unknown>,
+        topo,
+        options
+      );
+    }
+  }
+
+  return {
+    ctxWithFire,
+    impl,
+  };
+};
 
 const runTrail = async (
   trail: AnyTrail,
   input: unknown,
   ctx: TrailContext,
-  layers: readonly Layer[]
+  layers: readonly Layer[],
+  topo: Topo | undefined,
+  options: ExecuteTrailOptions | undefined
 ): Promise<Result<unknown, Error>> => {
   const sink = getTraceSink();
   const { record, tracedCtx } = buildTracedContext(trail, ctx, sink);
   let prepared: ReturnType<typeof prepareRunImpl>;
 
   try {
-    prepared = prepareRunImpl(trail, layers);
+    prepared = prepareRunImpl(trail, tracedCtx, layers, topo, options);
   } catch (error: unknown) {
     const status: TraceRecord['status'] =
       error instanceof CancelledError ? 'cancelled' : 'err';
@@ -333,7 +399,7 @@ const runTrail = async (
   return await runImplWithRootRecord(
     prepared.impl,
     input,
-    tracedCtx,
+    prepared.ctxWithFire,
     record,
     sink
   );
@@ -369,7 +435,9 @@ export const executeTrail = async (
       trail,
       validated.value,
       resolvedCtx.value,
-      options?.layers ?? []
+      options?.layers ?? [],
+      options?.topo,
+      options
     );
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -157,6 +157,12 @@ export const createFireFn = (
       return Result.err(dispatch.error);
     }
     const consumerCtx = buildConsumerCtx(producerCtx, signalId);
+    // Pre-bind fire on the consumer ctx as a safety net for direct
+    // executeTrail calls that skip the topo-aware path. In the normal
+    // fan-out flow below, bindFireToCtx in execute.ts rebinds fire to
+    // the fully-traced ctx before the blaze runs, so this assignment
+    // is superseded — but keeping it makes consumerCtx self-sufficient
+    // for any caller that inspects it pre-execution.
     consumerCtx.fire = createFireFn(
       topo,
       consumerCtx as TrailContextInit,

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -49,6 +49,18 @@ const getFireStack = (
   return Array.isArray(value) ? (value as readonly string[]) : [];
 };
 
+/**
+ * Fan out a validated signal payload to its consumer trails.
+ *
+ * @remarks
+ * Consumers are awaited sequentially on purpose. Sequential execution gives
+ * deterministic ordering for tracing and tests and makes error attribution
+ * straightforward (each warn log pairs cleanly with the consumer that
+ * produced it). Parallelizing via `Promise.allSettled` is a deliberate
+ * future option — not an oversight — and would be worth revisiting once
+ * tracing and error-aggregation semantics are designed to handle
+ * interleaved consumer execution.
+ */
 const fanOutToConsumers = async (
   consumers: readonly AnyTrail[],
   payload: unknown,
@@ -115,15 +127,6 @@ const buildConsumerCtx = (
     : {};
 };
 
-/**
- * Build a `FireFn` closure bound to a topo.
- *
- * When `producerCtx` is provided, consumer trails activated via `on:`
- * inherit the producer's logger, extensions, resources, abortSignal,
- * requestId, env, workspaceRoot, and permit. `ctx.fire` on the consumer
- * is rebound to the same closure so consumers can emit downstream
- * signals naturally.
- */
 const resolveSignalId = (signalOrId: unknown): Result<string, Error> => {
   if (typeof signalOrId === 'string') {
     return Result.ok(signalOrId);
@@ -143,6 +146,15 @@ const resolveSignalId = (signalOrId: unknown): Result<string, Error> => {
   );
 };
 
+/**
+ * Build a `FireFn` closure bound to a topo.
+ *
+ * When `producerCtx` is provided, consumer trails activated via `on:`
+ * inherit the producer's logger, extensions, resources, abortSignal,
+ * requestId, env, workspaceRoot, and permit. `ctx.fire` on the consumer
+ * is rebound to the same closure so consumers can emit downstream
+ * signals naturally.
+ */
 export const createFireFn = (
   topo: Topo,
   producerCtx: TrailContextInit | undefined,

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -1,37 +1,64 @@
 /**
  * Signal emission and auto-activation.
  *
- * `createFireFn(topo)` returns a `FireFn` bound to a topo. Calling
- * `fire(signalId, payload)` looks up the signal, validates the payload
- * against its schema, finds every trail with the signal in its `on:` array,
- * and invokes each consumer via `executeTrail`.
+ * `createFireFn(topo, producerCtx?, executor)` returns a `FireFn` bound to
+ * a topo. Calling `fire(signalId, payload)` looks up the signal, validates
+ * the payload against its schema, finds every trail with the signal in its
+ * `on:` array, and invokes each consumer via the supplied executor.
+ *
+ * The `executor` parameter is an indirection that lets `execute.ts` pass in
+ * `executeTrail` without `fire.ts` importing it directly — keeping the two
+ * modules dependency-cycle-free.
+ *
+ * Consumer contexts inherit the producer's full ctx (logger, extensions,
+ * resources, abortSignal, requestId, env, workspaceRoot, permit) with
+ * `fire` rebound to the same closure so consumers can fan out further.
+ * The consumer logger is derived from the producer logger as a child
+ * tagged with `signalId` when `logger.child` exists.
  *
  * Error semantics match the fire-and-forget framing: producers get
  * `Result.ok(undefined)` unless the signal id is unknown or the payload
- * fails schema validation. Consumer errors are logged via the context's
- * logger (when available) but do NOT propagate back to the producer.
- * Consumers that need transactional coupling should use `crosses:`.
+ * fails schema validation. Consumer errors are logged via the producer's
+ * logger but do NOT propagate back to the producer. Consumers that need
+ * transactional coupling should use `crosses:`.
  */
 
 import { NotFoundError, ValidationError } from './errors.js';
-import { executeTrail } from './execute.js';
 import { Result } from './result.js';
-import type { AnyTrail } from './trail.js';
 import type { Topo } from './topo.js';
+import type { AnyTrail } from './trail.js';
 import type { FireFn, Logger, TrailContextInit } from './types.js';
+
+/** Signature execute.ts passes in to avoid a fire ↔ execute import cycle. */
+export type ConsumerExecutor = (
+  consumer: AnyTrail,
+  input: unknown,
+  ctx: Partial<TrailContextInit>
+) => Promise<Result<unknown, Error>>;
+
+type MutableConsumerContext = {
+  -readonly [K in keyof Partial<TrailContextInit>]: Partial<TrailContextInit>[K];
+};
+
+const FIRE_STACK_KEY = '__trails_fire_stack';
+
+const getFireStack = (
+  ctx: Pick<TrailContextInit, 'extensions'> | undefined
+): readonly string[] => {
+  const value = ctx?.extensions?.[FIRE_STACK_KEY];
+  return Array.isArray(value) ? (value as readonly string[]) : [];
+};
 
 const fanOutToConsumers = async (
   consumers: readonly AnyTrail[],
   payload: unknown,
   signalId: string,
-  fire: FireFn,
+  consumerCtx: Partial<TrailContextInit>,
+  executor: ConsumerExecutor,
   logger: Logger | undefined
 ): Promise<void> => {
-  const consumerCtx: Partial<TrailContextInit> = { fire };
   for (const consumer of consumers) {
-    const consumerResult = await executeTrail(consumer, payload, {
-      ctx: consumerCtx,
-    });
+    const consumerResult = await executor(consumer, payload, consumerCtx);
     if (consumerResult.isErr()) {
       logger?.warn('Signal consumer failed', {
         consumerId: consumer.id,
@@ -42,33 +69,126 @@ const fanOutToConsumers = async (
   }
 };
 
-/** Build a `FireFn` closure bound to a topo. */
-export const createFireFn = (topo: Topo, logger?: Logger): FireFn => {
-  const fire: FireFn = async (signalId, payload) => {
-    const signal = topo.signals.get(signalId);
-    if (signal === undefined) {
-      return Result.err(
-        new NotFoundError(
-          `Signal "${signalId}" not found in topo "${topo.name}"`
-        )
-      );
-    }
+const resolveFireDispatch = (
+  topo: Topo,
+  signalId: string,
+  payload: unknown
+): Result<
+  { readonly consumers: readonly AnyTrail[]; readonly payload: unknown },
+  Error
+> => {
+  const signal = topo.signals.get(signalId);
+  if (signal === undefined) {
+    return Result.err(
+      new NotFoundError(`Signal "${signalId}" not found in topo "${topo.name}"`)
+    );
+  }
+  const parsed = signal.payload.safeParse(payload);
+  if (!parsed.success) {
+    return Result.err(
+      new ValidationError(
+        `Invalid payload for signal "${signalId}": ${parsed.error.message}`
+      )
+    );
+  }
+  return Result.ok({
+    consumers: topo.list().filter((trail) => trail.on.includes(signalId)),
+    payload: parsed.data,
+  });
+};
 
-    const parsed = signal.payload.safeParse(payload);
-    if (!parsed.success) {
-      return Result.err(
-        new ValidationError(
-          `Invalid payload for signal "${signalId}": ${parsed.error.message}`
-        )
-      );
-    }
+const buildConsumerCtx = (
+  producerCtx: TrailContextInit | undefined,
+  signalId: string
+): MutableConsumerContext => {
+  const childLogger: Logger | undefined =
+    producerCtx?.logger?.child?.({ signalId }) ?? producerCtx?.logger;
+  return producerCtx
+    ? {
+        ...producerCtx,
+        extensions: {
+          ...producerCtx.extensions,
+          [FIRE_STACK_KEY]: [...getFireStack(producerCtx), signalId],
+        },
+        logger: childLogger,
+      }
+    : {};
+};
 
-    const consumers = topo
-      .list()
-      .filter((trail) => trail.on.includes(signalId));
-    await fanOutToConsumers(consumers, parsed.data, signalId, fire, logger);
+/**
+ * Build a `FireFn` closure bound to a topo.
+ *
+ * When `producerCtx` is provided, consumer trails activated via `on:`
+ * inherit the producer's logger, extensions, resources, abortSignal,
+ * requestId, env, workspaceRoot, and permit. `ctx.fire` on the consumer
+ * is rebound to the same closure so consumers can emit downstream
+ * signals naturally.
+ */
+const resolveSignalId = (signalOrId: unknown): Result<string, Error> => {
+  if (typeof signalOrId === 'string') {
+    return Result.ok(signalOrId);
+  }
+  if (
+    typeof signalOrId === 'object' &&
+    signalOrId !== null &&
+    'id' in signalOrId &&
+    typeof (signalOrId as { id: unknown }).id === 'string'
+  ) {
+    return Result.ok((signalOrId as { id: string }).id);
+  }
+  return Result.err(
+    new ValidationError(
+      'ctx.fire() requires a signal id string or a Signal value'
+    )
+  );
+};
+
+export const createFireFn = (
+  topo: Topo,
+  producerCtx: TrailContextInit | undefined,
+  executor: ConsumerExecutor
+): FireFn => {
+  const dispatchFire = async (
+    signalId: string,
+    payload: unknown
+  ): Promise<Result<void, Error>> => {
+    const dispatch = resolveFireDispatch(topo, signalId, payload);
+    if (dispatch.isErr()) {
+      return Result.err(dispatch.error);
+    }
+    const consumerCtx = buildConsumerCtx(producerCtx, signalId);
+    consumerCtx.fire = createFireFn(
+      topo,
+      consumerCtx as TrailContextInit,
+      executor
+    );
+    await fanOutToConsumers(
+      dispatch.value.consumers,
+      dispatch.value.payload,
+      signalId,
+      consumerCtx,
+      executor,
+      producerCtx?.logger
+    );
     return Result.ok();
   };
 
-  return fire;
+  const fireImpl: FireFn = async (
+    signalOrId: unknown,
+    payload: unknown
+  ): Promise<Result<void, Error>> => {
+    const resolved = resolveSignalId(signalOrId);
+    if (resolved.isErr()) {
+      return Result.err(resolved.error);
+    }
+    if (getFireStack(producerCtx).includes(resolved.value)) {
+      producerCtx?.logger?.warn(
+        'Signal cycle detected — skipping re-entrant fire',
+        { signalId: resolved.value }
+      );
+      return Result.ok();
+    }
+    return await dispatchFire(resolved.value, payload);
+  };
+  return fireImpl;
 };

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -9,9 +9,7 @@ import type { Topo } from './topo.js';
 import { executeTrail } from './execute.js';
 import type { ExecuteTrailOptions } from './execute.js';
 import { NotFoundError } from './errors.js';
-import { createFireFn } from './fire.js';
 import { Result } from './result.js';
-import type { TrailContextInit } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -28,9 +26,10 @@ export type RunOptions = ExecuteTrailOptions;
  * Execute a trail by ID from a topo without mounting a trailhead.
  *
  * Resolves the trail from the topo, then runs it through the standard
- * `executeTrail` pipeline. Returns `Result.err(NotFoundError)` if the
- * trail ID is not registered. Never throws — unexpected exceptions are
- * returned as `Result.err(InternalError)`.
+ * `executeTrail` pipeline with `topo` threaded so `ctx.fire()` is bound
+ * to the producer's context inside `executeTrail`. Returns
+ * `Result.err(NotFoundError)` if the trail ID is not registered. Never
+ * throws — unexpected exceptions are returned as `Result.err(InternalError)`.
  *
  * @example
  * ```typescript
@@ -52,7 +51,5 @@ export const run = (
       )
     );
   }
-  const fire = createFireFn(topo, options?.ctx?.logger);
-  const ctxWithFire: Partial<TrailContextInit> = { ...options?.ctx, fire };
-  return executeTrail(trail, input, { ...options, ctx: ctxWithFire });
+  return executeTrail(trail, input, { ...options, topo });
 };

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -6,11 +6,12 @@ import {
   Result,
   TRAILHEAD_KEY,
   resource,
+  signal,
   ValidationError,
   trail,
   topo,
 } from '@ontrails/core';
-import type { Layer } from '@ontrails/core';
+import type { Layer, TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
 import { buildHttpRoutes } from '../build.js';
@@ -67,6 +68,17 @@ const dbProvision = resource('db.main', {
       source: 'factory',
     }),
 });
+
+const orderPlaced = signal('order.placed', {
+  payload: z.object({ orderId: z.string() }),
+});
+
+const requireFire = (fire: TrailContext['fire']) => {
+  if (!fire) {
+    throw new Error('Expected ctx.fire to be bound');
+  }
+  return fire;
+};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -277,6 +289,41 @@ describe('buildHttpRoutes', () => {
       expect(result?.isErr()).toBe(true);
       expect(result?.error).toBeInstanceOf(InternalError);
       expect(result?.error?.message).toBe('context creation failed');
+    });
+
+    test('passes topo to executeTrail so HTTP-invoked producers can fan out', async () => {
+      const captured: string[] = [];
+      const consumer = trail('notify.email', {
+        blaze: (input: { orderId: string }) => {
+          captured.push(input.orderId);
+          return Result.ok({ delivered: true });
+        },
+        input: z.object({ orderId: z.string() }),
+        on: ['order.placed'],
+      });
+      const producer = trail('order.create', {
+        blaze: async (input: { orderId: string }, ctx) => {
+          const fired = await requireFire(ctx.fire)('order.placed', {
+            orderId: input.orderId,
+          });
+          return fired.match({
+            err: (error) => Result.err(error),
+            ok: () => Result.ok({ ok: true }),
+          });
+        },
+        fires: ['order.placed'],
+        input: z.object({ orderId: z.string() }),
+      });
+      const app = topo('signal-http', { consumer, orderPlaced, producer });
+      const buildResult = buildHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      const [route] = buildResult.value;
+
+      const result = await route?.execute({ orderId: 'o-http' });
+
+      expect(result?.isOk()).toBe(true);
+      expect(captured).toEqual(['o-http']);
     });
 
     test('passes requestId to context', async () => {

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -120,6 +120,7 @@ const withHttpTrailhead = (
  */
 const createExecute =
   (
+    app: Topo,
     t: Trail<unknown, unknown>,
     layers: readonly Layer[],
     options: BuildHttpRoutesOptions
@@ -132,6 +133,7 @@ const createExecute =
       ctx: withHttpTrailhead(requestId),
       layers,
       resources: options.resources,
+      topo: app,
     });
 
 // ---------------------------------------------------------------------------
@@ -144,6 +146,7 @@ const eligibleTrails = (app: Topo): Trail<unknown, unknown>[] =>
 
 /** Build a single route definition from a trail. */
 const buildRoute = (
+  app: Topo,
   trail: Trail<unknown, unknown>,
   basePath: string,
   layers: readonly Layer[],
@@ -152,7 +155,7 @@ const buildRoute = (
   const method = deriveMethod(trail);
   const path = derivePath(basePath, trail.id);
   return {
-    execute: createExecute(trail, layers, options),
+    execute: createExecute(app, trail, layers, options),
     inputSource: deriveInputSource(method),
     method,
     path,
@@ -191,6 +194,7 @@ const registerRoute = (
 
 /** Accumulate route definitions, returning early on the first collision. */
 const accumulateRoutes = (
+  app: Topo,
   trails: Trail<unknown, unknown>[],
   basePath: string,
   layers: readonly Layer[],
@@ -200,7 +204,7 @@ const accumulateRoutes = (
   const seenRoutes = new Map<string, string>();
 
   for (const trail of trails) {
-    const route = buildRoute(trail, basePath, layers, options);
+    const route = buildRoute(app, trail, basePath, layers, options);
     const registered = registerRoute(route, seenRoutes, routes);
     if (registered.isErr()) {
       return registered;
@@ -239,5 +243,5 @@ export const buildHttpRoutes = (
 
   const basePath = (options.basePath ?? '').replace(/\/+$/, '');
   const layers = options.layers ?? [];
-  return accumulateRoutes(eligibleTrails(app), basePath, layers, options);
+  return accumulateRoutes(app, eligibleTrails(app), basePath, layers, options);
 };

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -5,10 +5,11 @@ import {
   TRAILHEAD_KEY,
   createBlobRef,
   resource,
+  signal,
   trail,
   topo,
 } from '@ontrails/core';
-import type { Layer } from '@ontrails/core';
+import type { Layer, TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
 import { buildMcpTools } from '../build.js';
@@ -58,6 +59,17 @@ const dbProvision = resource('db.main', {
       source: 'factory',
     }),
 });
+
+const orderPlaced = signal('order.placed', {
+  payload: z.object({ orderId: z.string() }),
+});
+
+const requireFire = (fire: TrailContext['fire']) => {
+  if (!fire) {
+    throw new Error('Expected ctx.fire to be bound');
+  }
+  return fire;
+};
 
 const noExtra: McpExtra = {};
 
@@ -190,6 +202,40 @@ describe('buildMcpTools', () => {
       expect(parseJsonContent(result?.content[0])).toEqual({
         reply: 'hello',
       });
+    });
+
+    test('passes topo to executeTrail so MCP-invoked producers can fan out', async () => {
+      const captured: string[] = [];
+      const consumer = trail('notify.email', {
+        blaze: (input: { orderId: string }) => {
+          captured.push(input.orderId);
+          return Result.ok({ delivered: true });
+        },
+        input: z.object({ orderId: z.string() }),
+        on: ['order.placed'],
+      });
+      const producer = trail('order.create', {
+        blaze: async (input: { orderId: string }, ctx) => {
+          const fired = await requireFire(ctx.fire)('order.placed', {
+            orderId: input.orderId,
+          });
+          return fired.match({
+            err: (error) => Result.err(error),
+            ok: () => Result.ok({ ok: true }),
+          });
+        },
+        fires: ['order.placed'],
+        input: z.object({ orderId: z.string() }),
+      });
+      const tool = requireTool(
+        buildTools(topo('signal-mcp', { consumer, orderPlaced, producer })),
+        'signal_mcp_order_create'
+      );
+
+      const result = await tool.handler({ orderId: 'o-mcp' }, noExtra);
+
+      expect(result.isError).toBeUndefined();
+      expect(captured).toEqual(['o-mcp']);
     });
 
     test('handler maps errors to isError content', async () => {

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -227,6 +227,7 @@ const withMcpTrailhead = (
 
 const createHandler =
   (
+    app: Topo,
     t: Trail<unknown, unknown>,
     layers: readonly Layer[],
     options: BuildMcpToolsOptions
@@ -243,6 +244,7 @@ const createHandler =
       ctx: withMcpTrailhead(progressCb),
       layers,
       resources: options.resources,
+      topo: app,
     });
     if (result.isOk()) {
       return { content: await serializeOutput(result.value) };
@@ -314,7 +316,7 @@ const buildToolDefinition = (
   return {
     annotations,
     description: buildDescription(trail),
-    handler: createHandler(trail, layers, options),
+    handler: createHandler(app, trail, layers, options),
     inputSchema: zodToJsonSchema(trail.input),
     name: deriveToolName(app.name, trail.id),
     trailId: trail.id,


### PR DESCRIPTION
## TRL-198: Consumer trails activated via on: should inherit producer context

Fixes the producer→consumer context propagation gap surfaced during TRL-197 dogfooding. Previously `fanOutToConsumers` in `packages/core/src/fire.ts` built a fresh consumer ctx with only `{ fire }`, dropping the producer's logger, extensions, resources, abortSignal, requestId, env, workspaceRoot, and permit.

Practical consequences this PR removes:
- Consumer trails couldn't use `ctx.resource()` — contradicts the resources-for-infrastructure tenet
- Logger streams broke across the signal boundary
- requestId provenance was lost
- Trace context didn't propagate into consumer spans

### The fix

`createFireFn` now takes `(topo, producerCtx?, executor)`. The consumer context is built by spreading the producer ctx and rebinding `fire` to the same closure. The logger is derived as a child tagged with `signalId` when `logger.child` exists, so consumer log lines auto-correlate with the signal.

Architectural note: `createFireFn` previously imported `executeTrail` directly, which created a circular import once the closure had to be reconstructed inside `execute.ts`. The fix uses a `ConsumerExecutor` callback parameter so `fire.ts` and `execute.ts` are dependency-cycle-free. The fire binding now happens late, inside `runTrail` after `buildTracedContext`, where the producer's full ctx is available.

### Files

- `packages/core/src/fire.ts` — new `ConsumerExecutor` type, `buildConsumerCtx` helper, refactored `createFireFn` signature
- `packages/core/src/execute.ts` — new `topo` field on `ExecuteTrailOptions`, `bindFireToCtx` helper, `runTrail` threads `topo` and rebinds `ctx.fire` after the traced context is built
- `packages/core/src/run.ts` — stops pre-binding fire, just threads `topo` through options
- `packages/core/src/__tests__/fire.test.ts` — new inheritance test (consumer reads producer logger + requestId)
- `apps/trails-demo/src/resources/notification-store.ts` — new `notificationStoreProvision` resource with `NotificationStore` interface
- `apps/trails-demo/src/trails/notify.ts` — switches from module-level `notificationLog` array to a real `resources: [notificationStoreProvision]` declaration, reads via `.from(ctx)`
- `apps/trails-demo/__tests__/signals.test.ts` — injects the resource and reads notifications back from it
- `apps/trails-demo/__tests__/governance.test.ts` — entry count 10 → 11, threads new resource through `diffAgainst()`

### Tenet alignment

- **Resources for infrastructure**: consumer trails can now declare and use resources, restoring the primitive's intended scope
- **One graph, many views**: trace context propagates so observability can correlate producer→consumer chains
- **Reduce ceremony, not clarity**: producers and consumers share infrastructure naturally via shared ctx, no extra wiring

### Acceptance

- [x] `fanOutToConsumers` builds the consumer context by spreading the producer context
- [x] Consumer trails can use `ctx.resource()` and access registered resources
- [x] Logger inheritance verified end-to-end via test
- [x] Existing dogfood test updated to use a real resource instead of the module-level array workaround
- [x] `bun run typecheck && bun run test && bun run check` all green

### Open questions for later

- AbortSignal cancellation propagation: currently inherited but not actively cancelled mid-fan-out
- requestId derivation: currently inherits the producer's id verbatim — a derived child id (`${parentId}.signal.${idx}`) would be better for trace tooling
- Trace span parenting across the fire boundary: child spans in the consumer don't yet parent under the producer's root trace
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
