### PR TITLE
feat(core): persist fires/on edges in topo store [TRL-197]

### DIFF
--- a/packages/core/src/__tests__/topo-store.test.ts
+++ b/packages/core/src/__tests__/topo-store.test.ts
@@ -13,6 +13,8 @@ import {
 } from '../internal/topo-saves.js';
 import {
   getStoredTopoExport,
+  normalizeFiresRows,
+  normalizeOnRows,
   persistEstablishedTopoSave,
 } from '../internal/topo-store.js';
 import { openWriteTrailsDb } from '../internal/trails-db.js';
@@ -446,6 +448,78 @@ describe('topo store projection', () => {
     });
   });
 
+  test('persists fires and on edges for signal-declaring trails', () => {
+    withProjectionDb((db) => {
+      const created = signal('entity.created', {
+        from: ['entity.create'],
+        payload: z.object({ id: z.string() }),
+      });
+      const updated = signal('entity.updated', {
+        from: ['entity.create'],
+        payload: z.object({ id: z.string() }),
+      });
+
+      const createTrail = trail('entity.create', {
+        blaze: () => Result.ok({ id: 'x' }),
+        fires: ['entity.created', 'entity.updated'],
+        input: z.object({}),
+        output: z.object({ id: z.string() }),
+      });
+      const indexTrail = trail('entity.index', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        on: ['entity.created'],
+        output: z.object({ ok: z.boolean() }),
+      });
+      const auditTrail = trail('entity.audit', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        on: ['entity.created', 'entity.updated'],
+        output: z.object({ ok: z.boolean() }),
+      });
+
+      const save = unwrap(
+        persistEstablishedTopoSave(
+          db,
+          topo('signal-edges-app', {
+            auditTrail,
+            createTrail,
+            created,
+            indexTrail,
+            updated,
+          })
+        )
+      );
+
+      const fires = db
+        .query<{ signal_id: string; trail_id: string }, [string]>(
+          `SELECT trail_id, signal_id
+           FROM topo_trail_fires
+           WHERE save_id = ?
+           ORDER BY trail_id ASC, signal_id ASC`
+        )
+        .all(save.id);
+      expect(fires).toEqual([
+        { signal_id: 'entity.created', trail_id: 'entity.create' },
+        { signal_id: 'entity.updated', trail_id: 'entity.create' },
+      ]);
+
+      const on = db
+        .query<{ signal_id: string; trail_id: string }, [string]>(
+          `SELECT trail_id, signal_id
+           FROM topo_trail_on
+           WHERE save_id = ?
+           ORDER BY trail_id ASC, signal_id ASC`
+        )
+        .all(save.id);
+      expect(on).toEqual([
+        { signal_id: 'entity.created', trail_id: 'entity.audit' },
+        { signal_id: 'entity.updated', trail_id: 'entity.audit' },
+        { signal_id: 'entity.created', trail_id: 'entity.index' },
+      ]);
+    });
+  });
+
   test('upgrades a history-only topo schema to the projected topo schema', () => {
     withProjectionDb((db) => {
       seedHistoryOnlyTopoSchema(db);
@@ -456,14 +530,75 @@ describe('topo store projection', () => {
             "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
           )
           .get()?.version
-      ).toBe(3);
-      expect(tableExists(db, 'topo_trails')).toBe(true);
-      expect(tableExists(db, 'topo_crossings')).toBe(true);
-      expect(tableExists(db, 'topo_examples')).toBe(true);
-      expect(tableExists(db, 'topo_exports')).toBe(true);
-      expect(tableExists(db, 'topo_schemas')).toBe(true);
+      ).toBe(4);
+      for (const table of [
+        'topo_trails',
+        'topo_crossings',
+        'topo_examples',
+        'topo_exports',
+        'topo_schemas',
+        'topo_trail_fires',
+        'topo_trail_on',
+      ]) {
+        expect(tableExists(db, table)).toBe(true);
+      }
       expect(countRows(db, 'topo_saves')).toBe(1);
       expect(countRows(db, 'topo_pins')).toBe(1);
     });
+  });
+});
+
+describe('signal edge normalizers', () => {
+  const makeTrail = (
+    id: string,
+    opts: {
+      readonly fires?: readonly string[];
+      readonly on?: readonly string[];
+    }
+  ) =>
+    trail(id, {
+      blaze: () => Result.ok({ ok: true }),
+      ...(opts.fires ? { fires: opts.fires } : {}),
+      input: z.object({}),
+      ...(opts.on ? { on: opts.on } : {}),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+  test('normalizeFiresRows produces one row per (trail, signal) pair', () => {
+    const trails = [
+      makeTrail('t.one', { fires: ['s.a', 's.b'] }),
+      makeTrail('t.two', { fires: ['s.a'] }),
+    ];
+    expect(normalizeFiresRows(trails, 'save-1')).toEqual([
+      { saveId: 'save-1', signalId: 's.a', trailId: 't.one' },
+      { saveId: 'save-1', signalId: 's.b', trailId: 't.one' },
+      { saveId: 'save-1', signalId: 's.a', trailId: 't.two' },
+    ]);
+  });
+
+  test('normalizeOnRows produces one row per (trail, signal) pair', () => {
+    const trails = [
+      makeTrail('t.one', { on: ['s.a', 's.b'] }),
+      makeTrail('t.two', { on: ['s.b'] }),
+    ];
+    expect(normalizeOnRows(trails, 'save-1')).toEqual([
+      { saveId: 'save-1', signalId: 's.a', trailId: 't.one' },
+      { saveId: 'save-1', signalId: 's.b', trailId: 't.one' },
+      { saveId: 'save-1', signalId: 's.b', trailId: 't.two' },
+    ]);
+  });
+
+  test('trails without fires/on produce no rows', () => {
+    const trails = [makeTrail('t.plain', {})];
+    expect(normalizeFiresRows(trails, 'save-1')).toEqual([]);
+    expect(normalizeOnRows(trails, 'save-1')).toEqual([]);
+  });
+
+  test('deduplicates and sorts signal ids', () => {
+    const trails = [makeTrail('t.one', { fires: ['s.b', 's.a', 's.b'] })];
+    expect(normalizeFiresRows(trails, 'save-1')).toEqual([
+      { saveId: 'save-1', signalId: 's.a', trailId: 't.one' },
+      { saveId: 'save-1', signalId: 's.b', trailId: 't.one' },
+    ]);
   });
 });

--- a/packages/core/src/internal/topo-saves.ts
+++ b/packages/core/src/internal/topo-saves.ts
@@ -106,6 +106,20 @@ const TOPO_TABLE_STATEMENTS = [
     serialized_lock TEXT NOT NULL,
     FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
   )`,
+  `CREATE TABLE IF NOT EXISTS topo_trail_fires (
+    trail_id TEXT NOT NULL,
+    signal_id TEXT NOT NULL,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (trail_id, signal_id, save_id),
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
+  `CREATE TABLE IF NOT EXISTS topo_trail_on (
+    trail_id TEXT NOT NULL,
+    signal_id TEXT NOT NULL,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (trail_id, signal_id, save_id),
+    FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
+  )`,
 ] as const;
 const TOPO_INDEX_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_topo_saves_created_at ON topo_saves(created_at DESC)',
@@ -121,6 +135,8 @@ const TOPO_INDEX_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_topo_schemas_save_id ON topo_schemas(save_id)',
   `CREATE INDEX IF NOT EXISTS idx_topo_schemas_lookup
    ON topo_schemas(owner_id, owner_kind, schema_kind, zod_hash)`,
+  'CREATE INDEX IF NOT EXISTS idx_topo_trail_fires_save_id ON topo_trail_fires(save_id)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_trail_on_save_id ON topo_trail_on(save_id)',
 ] as const;
 
 interface TopoSaveRow {
@@ -211,12 +227,17 @@ export const ensureTopoHistorySchema = (db: Database): void => {
       }
       if (currentVersion === 2) {
         // v2→v3: add schema cache and export tables
-        runStatements(db, TOPO_TABLE_STATEMENTS.slice(10));
-        runStatements(db, TOPO_INDEX_STATEMENTS.slice(10));
+        runStatements(db, TOPO_TABLE_STATEMENTS.slice(10, 12));
+        runStatements(db, TOPO_INDEX_STATEMENTS.slice(10, 12));
+      }
+      if (currentVersion < 4 && currentVersion >= 2) {
+        // v3→v4: add persisted signal edges (fires/on)
+        runStatements(db, TOPO_TABLE_STATEMENTS.slice(12));
+        runStatements(db, TOPO_INDEX_STATEMENTS.slice(12));
       }
     },
     subsystem: TOPO_SUBSYSTEM,
-    version: 3,
+    version: 4,
   });
 };
 

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -43,6 +43,18 @@ interface TopoCrossingRow {
   readonly targetId: string;
 }
 
+interface TopoFiresRow {
+  readonly saveId: string;
+  readonly signalId: string;
+  readonly trailId: string;
+}
+
+interface TopoOnRow {
+  readonly saveId: string;
+  readonly signalId: string;
+  readonly trailId: string;
+}
+
 interface TopoTrailProvisionRow {
   readonly provisionId: string;
   readonly saveId: string;
@@ -136,6 +148,8 @@ interface MaterializedTopoArtifacts {
 interface NormalizedTopoProjection {
   readonly crossings: readonly TopoCrossingRow[];
   readonly examples: readonly TopoExampleRow[];
+  readonly fires: readonly TopoFiresRow[];
+  readonly on: readonly TopoOnRow[];
   readonly resources: readonly TopoProvisionRow[];
   readonly signals: readonly TopoSignalRow[];
   readonly trailheads: readonly TopoTrailheadRow[];
@@ -288,6 +302,30 @@ const normalizeCrossingRows = (
     }))
   );
 
+export const normalizeFiresRows = (
+  trails: readonly AnyTrail[],
+  saveId: string
+): readonly TopoFiresRow[] =>
+  trails.flatMap((trail) =>
+    [...new Set(trail.fires)].toSorted().map((signalId) => ({
+      saveId,
+      signalId,
+      trailId: trail.id,
+    }))
+  );
+
+export const normalizeOnRows = (
+  trails: readonly AnyTrail[],
+  saveId: string
+): readonly TopoOnRow[] =>
+  trails.flatMap((trail) =>
+    [...new Set(trail.on)].toSorted().map((signalId) => ({
+      saveId,
+      signalId,
+      trailId: trail.id,
+    }))
+  );
+
 const normalizeTrailProvisionRows = (
   trails: readonly AnyTrail[],
   saveId: string
@@ -395,6 +433,8 @@ const normalizeTopoProjection = (
   return {
     crossings: normalizeCrossingRows(trails, saveId),
     examples: normalizeExampleRows(trails, saveId),
+    fires: normalizeFiresRows(trails, saveId),
+    on: normalizeOnRows(trails, saveId),
     resources: normalizeProvisionRows(resources, saveId),
     signals: normalizeSignalRows(signals, saveId),
     trailProvisions: normalizeTrailProvisionRows(trails, saveId),
@@ -958,6 +998,20 @@ const insertProjectedRows = (
     db,
     projection.trailSignals,
     `INSERT INTO topo_trail_signals (trail_id, signal_id, save_id)
+     VALUES (?, ?, ?)`,
+    (row) => [row.trailId, row.signalId, row.saveId]
+  );
+  insertRows(
+    db,
+    projection.fires,
+    `INSERT INTO topo_trail_fires (trail_id, signal_id, save_id)
+     VALUES (?, ?, ?)`,
+    (row) => [row.trailId, row.signalId, row.saveId]
+  );
+  insertRows(
+    db,
+    projection.on,
+    `INSERT INTO topo_trail_on (trail_id, signal_id, save_id)
      VALUES (?, ?, ?)`,
     (row) => [row.trailId, row.signalId, row.saveId]
   );


### PR DESCRIPTION
Adds topo_trail_fires and topo_trail_on tables to the topo subsystem
so signal-graph governance is queryable from the lockfile alone.
Parallels the existing topo_crossings edge persistence.

New tables (in topo-saves.ts):
- topo_trail_fires (trail_id, signal_id, save_id) with PK
  (trail_id, signal_id, save_id) and FK to topo_saves ON DELETE
  CASCADE, plus idx_topo_trail_fires_save_id
- topo_trail_on (same shape, idx_topo_trail_on_save_id)

Migration: topo subsystem version 3 → 4. The v3→v4 step creates both
new tables. Bounded the existing v2→v3 slice so upgrades from v2
don't accidentally pull in v4 tables. Fresh installs (<v2) still
get everything from the full statement list in one pass.

Normalizers (in topo-store.ts):
- normalizeFiresRows(trails, saveId) → readonly TopoFiresRow[]
- normalizeOnRows(trails, saveId) → readonly TopoOnRow[]
Both dedupe and sort signal ids. Added TopoFiresRow and TopoOnRow
interfaces. Wired into NormalizedTopoProjection and
normalizeTopoProjection.

Wiring: insertProjectedRows now issues insertRows for projection.fires
and projection.on inside the existing db.transaction wrapper in
persistEstablishedTopoSave.

Tests:
- Integration test: producer with fires: [a, b] and consumers with
  on: [...] persist correctly; asserts expected (trail, signal) pairs
- Migration upgrade test: version 4 and existence of both new tables
  (refactored into a loop to stay under max-statements)
- Signal edge normalizer unit tests: one row per pair, empty
  arrays, multi-signal expansion, dedup + sort

Surface: the existing v2→v3 migration used slice(10) (unbounded),
which would have leaked future v4 tables into the v3 upgrade path.
Tightened to slice(10, 12) as a side effect.

bun run typecheck, test, and check all pass.