### PR TITLE
feat(core): ctx.fire generic signal-value overload [TRL-197]

### DIFF
--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -206,6 +206,39 @@ describe('fire', () => {
     });
   });
 
+  describe('signal-value overload', () => {
+    test('ctx.fire(signal, payload) accepts a signal value and fans out', async () => {
+      const capture = createCapture();
+      const consumerA = makeConsumer('notify.email', capture);
+      const valueProducer = trail('order.create-by-value', {
+        blaze: async (input, ctx) => {
+          const fired = await ctx.fire?.(orderPlaced, {
+            orderId: input.orderId,
+            total: input.total,
+          });
+          return fired as Result<unknown, Error>;
+        },
+        fires: ['order.placed'],
+        input: z.object({ orderId: z.string(), total: z.number() }),
+      });
+      const app = topo('fire-signal-value', {
+        consumerA,
+        orderPlaced,
+        valueProducer,
+      });
+      const result = await run(app, 'order.create-by-value', {
+        orderId: 'o-value',
+        total: 99,
+      });
+      expect(result.isOk()).toBe(true);
+      expect(capture.invocations).toHaveLength(1);
+      expect(capture.invocations[0]?.payload).toEqual({
+        orderId: 'o-value',
+        total: 99,
+      });
+    });
+  });
+
   describe('producer context inheritance', () => {
     test('consumer inherits producer logger and requestId', async () => {
       const captured: { requestId: string; loggerExists: boolean }[] = [];

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -87,45 +87,77 @@ const fanOutToConsumers = async (
  * is rebound to the same closure so consumers can emit downstream
  * signals naturally.
  */
+const resolveSignalId = (signalOrId: unknown): string => {
+  if (typeof signalOrId === 'string') {
+    return signalOrId;
+  }
+  if (
+    typeof signalOrId === 'object' &&
+    signalOrId !== null &&
+    'id' in signalOrId &&
+    typeof (signalOrId as { id: unknown }).id === 'string'
+  ) {
+    return (signalOrId as { id: string }).id;
+  }
+  throw new TypeError(
+    'ctx.fire() requires a signal id string or a Signal value'
+  );
+};
+
+const dispatchFire = async (
+  topo: Topo,
+  producerCtx: TrailContext | undefined,
+  executor: ConsumerExecutor,
+  self: FireFn,
+  signalId: string,
+  payload: unknown
+): Promise<Result<void, Error>> => {
+  const signal = topo.signals.get(signalId);
+  if (signal === undefined) {
+    return Result.err(
+      new NotFoundError(`Signal "${signalId}" not found in topo "${topo.name}"`)
+    );
+  }
+  const parsed = signal.payload.safeParse(payload);
+  if (!parsed.success) {
+    return Result.err(
+      new ValidationError(
+        `Invalid payload for signal "${signalId}": ${parsed.error.message}`
+      )
+    );
+  }
+  const consumers = topo.list().filter((trail) => trail.on.includes(signalId));
+  const consumerCtx = buildConsumerCtx(producerCtx, self, signalId);
+  await fanOutToConsumers(
+    consumers,
+    parsed.data,
+    signalId,
+    consumerCtx,
+    executor,
+    producerCtx?.logger
+  );
+  return Result.ok();
+};
+
 export const createFireFn = (
   topo: Topo,
   producerCtx: TrailContext | undefined,
   executor: ConsumerExecutor
 ): FireFn => {
-  const fire: FireFn = async (signalId, payload) => {
-    const signal = topo.signals.get(signalId);
-    if (signal === undefined) {
-      return Result.err(
-        new NotFoundError(
-          `Signal "${signalId}" not found in topo "${topo.name}"`
-        )
-      );
-    }
-
-    const parsed = signal.payload.safeParse(payload);
-    if (!parsed.success) {
-      return Result.err(
-        new ValidationError(
-          `Invalid payload for signal "${signalId}": ${parsed.error.message}`
-        )
-      );
-    }
-
-    const consumers = topo
-      .list()
-      .filter((trail) => trail.on.includes(signalId));
-    const consumerCtx = buildConsumerCtx(producerCtx, fire, signalId);
-    await fanOutToConsumers(
-      consumers,
-      parsed.data,
-      signalId,
-      consumerCtx,
+  // Holder bag so the closure body can reference the final FireFn without
+  // triggering eslint(no-use-before-define). The bag is populated on the
+  // line after the closure is built; by the time the closure runs, the
+  // bag's `fn` field holds the same FireFn that was returned.
+  const holder: { fn: FireFn | undefined } = { fn: undefined };
+  const fireImpl = (signalOrId: unknown, payload: unknown) =>
+    dispatchFire(
+      topo,
+      producerCtx,
       executor,
-      producerCtx?.logger
+      holder.fn as FireFn,
+      resolveSignalId(signalOrId),
+      payload
     );
-
-    return Result.ok();
-  };
-
-  return fire;
+  holder.fn = fireImpl as FireFn;
+  return holder.fn;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -18,17 +18,32 @@ export type CrossFn = <O>(
 ) => Promise<Result<O, Error>>;
 
 /**
- * Emit a signal by id — used for signal-driven activation.
+ * Emit a signal — used for signal-driven activation.
  *
  * Fan-out to consumer trails (those with the signal in their `on:` array) is
  * the framework's responsibility. Producers get `Result.ok(undefined)` unless
  * the signal id is unknown or the payload fails schema validation. Consumer
  * errors are logged but do not propagate back to the producer.
+ *
+ * Two call shapes are supported:
+ *
+ * - **By id** (base shape): `ctx.fire('order.placed', { ... })`. Matches
+ *   the shape of `ctx.cross`; payload is typed as `unknown` and validated
+ *   against the signal's schema at the fire boundary.
+ * - **By signal value** (progressive disclosure): `ctx.fire(orderPlaced, payload)`
+ *   where `orderPlaced` is a `Signal<T>`. The compiler enforces that
+ *   `payload` matches the signal's declared schema type at the call site,
+ *   on top of the runtime validation.
  */
-export type FireFn = (
-  signalId: string,
-  payload: unknown
-) => Promise<Result<void, Error>>;
+export interface FireFn {
+  <T>(
+    signal: { readonly id: string; readonly kind: 'signal' } & {
+      readonly payload: { _output?: T };
+    },
+    payload: T
+  ): Promise<Result<void, Error>>;
+  (signalId: string, payload: unknown): Promise<Result<void, Error>>;
+}
 
 /** Resolve a resource instance from the current trail context. */
 export type ProvisionLookup = <T = unknown>(


### PR DESCRIPTION
Progressive disclosure: callers can now pass either a signal id
string or a Signal<T> value to ctx.fire, with compile-time payload
typing when a Signal value is used.

## Before

  await ctx.fire('order.placed', { orderId, total });
  // payload typed as unknown; validation at runtime only

## After

  await ctx.fire(orderPlaced, { orderId, total });
  // payload checked against Signal<T> at compile time;
  // runtime validation still runs at the fire boundary

## Changes

- FireFn is now an overloaded interface with two call shapes:
  - Generic: <T>(signal: Signal-like<T>, payload: T) -> Promise<Result>
  - Base: (signalId: string, payload: unknown) -> Promise<Result>
- fire.ts adds resolveSignalId() that accepts either a string or an
  object with { id: string }, extracted to a small helper
- dispatchFire() extracted to stay under the max-statements lint cap
- Forward-reference the returned FireFn via a holder bag so closures
  capturing `self` for consumer-ctx propagation don't trip
  eslint(no-use-before-define)

## Test coverage

- New test: producer using ctx.fire(orderPlaced, payload) fans out
  to consumer with correct payload (signal-value overload path)
- 7 existing fire.test.ts tests still pass (base id-string path)

bun run typecheck, test, and check all pass. That closes out the
TRL-197 acceptance list.