### PR TITLE
feat(core): fires:/on: signal activation runtime [TRL-197]

### DIFF
--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -245,3 +245,48 @@ trails survey --module ./src/app.ts
 ```
 
 Use `trails topo *` for the day-to-day operational flow: inspect the current topo, pin meaningful points, and export or verify the committed lock artifacts. `survey` remains the broader introspection surface for list, detail, diff, and OpenAPI output.
+
+## Signals
+
+The demo exercises the lexicon's reactive activation primitive end-to-end. A producer trail declares the signal it emits, calls `ctx.fire()` from its blaze, and any trail that lists the signal in `on:` runs automatically.
+
+```typescript
+// src/signals/entity-signals.ts
+export const updated = signal('entity.updated', {
+  from: ['entity.add', 'entity.delete'],
+  payload: z.object({
+    action: z.enum(['created', 'updated', 'deleted']),
+    entityId: z.string(),
+    entityName: z.string(),
+    timestamp: z.string(),
+  }),
+});
+
+// src/trails/entity.ts -- producer
+export const add = trail('entity.add', {
+  fires: ['entity.updated'],
+  blaze: async (input, ctx) => {
+    const entity = await store.entities.insert(input);
+    await ctx.fire?.('entity.updated', {
+      action: 'created',
+      entityId: entity.id,
+      entityName: entity.name,
+      timestamp: entity.createdAt,
+    });
+    return Result.ok(entity);
+  },
+  // ...
+});
+
+// src/trails/notify.ts -- consumer
+export const notifyEntityUpdated = trail('entity.notify-updated', {
+  on: ['entity.updated'],
+  blaze: (input, ctx) => {
+    // runs automatically whenever entity.updated fires
+    return Result.ok({ notified: true });
+  },
+  // ...
+});
+```
+
+The warden enforces that every `ctx.fire(id, ...)` call appears in the trail's `fires: [...]` declaration (and vice-versa), and that every `on:` reference resolves to a signal definition the topo actually knows about. See `__tests__/signals.test.ts` for the end-to-end proof.

--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -26,6 +26,7 @@ import * as entitySignals from '../src/signals/entity-signals.js';
 import * as demoProvisions from '../src/resources/entity-store.js';
 import * as entity from '../src/trails/entity.js';
 import * as kv from '../src/trails/kv.js';
+import * as notify from '../src/trails/notify.js';
 import * as onboard from '../src/trails/onboard.js';
 import * as search from '../src/trails/search.js';
 
@@ -50,8 +51,8 @@ describe('trailhead map generation', () => {
     expect(ids).toContain('demo.entity-store');
   });
 
-  test('has exactly 9 entries (7 trails + 1 event + 1 resource)', () => {
-    expect(trailheadMap.entries).toHaveLength(9);
+  test('has exactly 10 entries (8 trails + 1 event + 1 resource)', () => {
+    expect(trailheadMap.entries).toHaveLength(10);
   });
 
   test('entries are sorted alphabetically by id', () => {
@@ -215,6 +216,7 @@ describe('breaking change detection', () => {
       onboard,
       entitySignals,
       kv,
+      notify,
       demoProvisions
     );
 
@@ -236,6 +238,7 @@ describe('breaking change detection', () => {
       onboard,
       entitySignals,
       kv,
+      notify,
       demoProvisions
     );
 
@@ -270,6 +273,7 @@ describe('non-breaking change detection', () => {
       onboard,
       entitySignals,
       kv,
+      notify,
       demoProvisions,
       { update }
     );
@@ -293,6 +297,7 @@ describe('non-breaking change detection', () => {
       onboard,
       entitySignals,
       kv,
+      notify,
       demoProvisions
     );
     expect(diff.hasBreaking).toBe(false);
@@ -338,7 +343,7 @@ describe('topo validation', () => {
       const trailDef = t as { examples?: readonly unknown[] };
       exampleCount += trailDef.examples?.length ?? 0;
     }
-    // 5 trails x 2 examples each + 1 onboard trail x 1 example + 1 kv trail x 1 example = 12
-    expect(exampleCount).toBe(12);
+    // 5 trails x 2 examples each + 1 onboard trail x 1 example + 1 kv trail x 1 example + 1 notify trail x 1 example = 13
+    expect(exampleCount).toBe(13);
   });
 });

--- a/apps/trails-demo/__tests__/signals.test.ts
+++ b/apps/trails-demo/__tests__/signals.test.ts
@@ -1,0 +1,126 @@
+/**
+ * End-to-end integration tests for the producer -> consumer signal flow.
+ *
+ * Proves that `fires:` / `on:` fan-out works against a real topo:
+ * - entity.add declares `fires: ['entity.updated']` and calls ctx.fire
+ * - entity.updated is a signal defined in src/signals/entity-signals.ts
+ * - entity.notify-updated declares `on: ['entity.updated']` as a consumer
+ *
+ * Also exercises the warden rules that guard the declarations.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+import { firesDeclarations, onReferencesExist } from '@ontrails/warden';
+
+import { app } from '../src/app.js';
+import { entityStoreProvision } from '../src/resources/entity-store.js';
+import { createStore } from '../src/store.js';
+import { clearNotifications, getNotifications } from '../src/trails/notify.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+const entitySourcePath = resolve(moduleDir, '../src/trails/entity.ts');
+const notifySourcePath = resolve(moduleDir, '../src/trails/notify.ts');
+
+// ---------------------------------------------------------------------------
+// End-to-end fan-out
+// ---------------------------------------------------------------------------
+
+describe('entity.updated signal flow', () => {
+  beforeEach(() => {
+    clearNotifications();
+  });
+
+  test('entity.add fires entity.updated and notify consumer runs', async () => {
+    const store = createStore([]);
+
+    const result = await run(
+      app,
+      'entity.add',
+      { name: 'Epsilon', tags: ['reactive'], type: 'concept' },
+      { ctx: { extensions: { [entityStoreProvision.id]: store } } }
+    );
+
+    expect(result.isOk()).toBe(true);
+
+    const notifications = getNotifications();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.action).toBe('created');
+    expect(notifications[0]?.entityName).toBe('Epsilon');
+    expect(notifications[0]?.entityId).toBeString();
+    expect(notifications[0]?.timestamp).toBeString();
+  });
+
+  test('entity.delete also fires entity.updated', async () => {
+    const store = createStore([{ name: 'Disposable', tags: [], type: 'tool' }]);
+
+    const result = await run(
+      app,
+      'entity.delete',
+      { name: 'Disposable' },
+      { ctx: { extensions: { [entityStoreProvision.id]: store } } }
+    );
+
+    expect(result.isOk()).toBe(true);
+    const notifications = getNotifications();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.action).toBe('deleted');
+    expect(notifications[0]?.entityName).toBe('Disposable');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Topo registration sanity
+// ---------------------------------------------------------------------------
+
+describe('signal wiring in the demo topo', () => {
+  test('entity.updated is registered as a signal', () => {
+    expect(app.signals.has('entity.updated')).toBe(true);
+  });
+
+  test('entity.notify-updated is registered with on: [entity.updated]', () => {
+    const consumer = app.get('entity.notify-updated');
+    expect(consumer).toBeDefined();
+    expect(consumer?.on).toContain('entity.updated');
+  });
+
+  test('entity.add declares fires: [entity.updated]', () => {
+    const producer = app.get('entity.add');
+    expect(producer).toBeDefined();
+    expect(producer?.fires).toContain('entity.updated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warden rule coverage
+// ---------------------------------------------------------------------------
+
+describe('warden rules over the signal producer/consumer', () => {
+  test('fires-declarations passes for entity.ts', () => {
+    const source = readFileSync(entitySourcePath, 'utf8');
+    const diagnostics = firesDeclarations.check(source, entitySourcePath);
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('on-references-exist passes for notify.ts with known signals', () => {
+    const source = readFileSync(notifySourcePath, 'utf8');
+    const diagnostics = onReferencesExist.checkWithContext(
+      source,
+      notifySourcePath,
+      {
+        knownSignalIds: new Set(['entity.updated']),
+        knownTrailIds: new Set(),
+      }
+    );
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/apps/trails-demo/__tests__/signals.test.ts
+++ b/apps/trails-demo/__tests__/signals.test.ts
@@ -75,6 +75,9 @@ describe('entity.updated signal flow', () => {
     expect(notifications).toHaveLength(1);
     expect(notifications[0]?.action).toBe('deleted');
     expect(notifications[0]?.entityName).toBe('Disposable');
+    // entityId should be the store-generated id, not the natural key.
+    expect(notifications[0]?.entityId).toBeString();
+    expect(notifications[0]?.entityId).not.toBe('Disposable');
   });
 });
 

--- a/apps/trails-demo/package.json
+++ b/apps/trails-demo/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@ontrails/schema": "workspace:^",
-    "@ontrails/testing": "workspace:^"
+    "@ontrails/testing": "workspace:^",
+    "@ontrails/warden": "workspace:^"
   }
 }

--- a/apps/trails-demo/src/app.ts
+++ b/apps/trails-demo/src/app.ts
@@ -8,6 +8,7 @@ import * as entitySignals from './signals/entity-signals.js';
 import * as demoProvisions from './resources/entity-store.js';
 import * as entity from './trails/entity.js';
 import * as kv from './trails/kv.js';
+import * as notify from './trails/notify.js';
 import * as onboard from './trails/onboard.js';
 import * as search from './trails/search.js';
 
@@ -18,5 +19,6 @@ export const app = topo(
   search,
   onboard,
   entitySignals,
-  kv
+  kv,
+  notify
 );

--- a/apps/trails-demo/src/trails/entity.ts
+++ b/apps/trails-demo/src/trails/entity.ts
@@ -144,14 +144,20 @@ export const add = trail('entity.add', {
 export const remove = trail('entity.delete', {
   blaze: async (input, ctx) => {
     const store = entityStoreProvision.from(ctx);
+    // Look up the entity first so we can emit its real id on the signal —
+    // `input.name` is a natural key, not the generated entity id.
+    const existing = await store.entities.get(input.name);
+    if (!existing) {
+      return Result.err(new NotFoundError(`Entity "${input.name}" not found`));
+    }
     const deleted = await store.entities.remove(input.name);
     if (!deleted.deleted) {
       return Result.err(new NotFoundError(`Entity "${input.name}" not found`));
     }
     await ctx.fire?.('entity.updated', {
       action: 'deleted',
-      entityId: input.name,
-      entityName: input.name,
+      entityId: existing.id,
+      entityName: existing.name,
       timestamp: new Date().toISOString(),
     });
     return Result.ok({ deleted: true, name: input.name });

--- a/apps/trails-demo/src/trails/entity.ts
+++ b/apps/trails-demo/src/trails/entity.ts
@@ -91,6 +91,12 @@ export const add = trail('entity.add', {
         tags: input.tags ?? [],
         type: input.type,
       });
+      await ctx.fire?.('entity.updated', {
+        action: 'created',
+        entityId: entity.id,
+        entityName: entity.name,
+        timestamp: entity.createdAt,
+      });
       return Result.ok(toEntity(entity));
     } catch (error) {
       if (error instanceof AlreadyExistsError) {
@@ -116,6 +122,7 @@ export const add = trail('entity.add', {
       name: 'Duplicate entity returns conflict',
     },
   ],
+  fires: ['entity.updated'],
   input: z.object({
     name: z.string().describe('Entity name'),
     tags: z
@@ -141,6 +148,12 @@ export const remove = trail('entity.delete', {
     if (!deleted.deleted) {
       return Result.err(new NotFoundError(`Entity "${input.name}" not found`));
     }
+    await ctx.fire?.('entity.updated', {
+      action: 'deleted',
+      entityId: input.name,
+      entityName: input.name,
+      timestamp: new Date().toISOString(),
+    });
     return Result.ok({ deleted: true, name: input.name });
   },
   description: 'Delete an entity by name',
@@ -157,6 +170,7 @@ export const remove = trail('entity.delete', {
       name: 'Delete non-existent entity returns not found',
     },
   ],
+  fires: ['entity.updated'],
   input: z.object({
     name: z.string().describe('Entity name to delete'),
   }),

--- a/apps/trails-demo/src/trails/notify.ts
+++ b/apps/trails-demo/src/trails/notify.ts
@@ -1,0 +1,90 @@
+/**
+ * Notification trails -- reactive consumers of domain signals.
+ *
+ * Demonstrates: `on:` activation wiring trails to signals emitted by
+ * other trails. The runtime fans out to every consumer that lists the
+ * signal in its `on:` array when a producer calls `ctx.fire()`.
+ */
+
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Notification log -- in-memory side-effect sink
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutable in-memory log of notifications emitted by `entity.notify-updated`.
+ *
+ * Exists so the demo and its integration tests can observe the end-to-end
+ * signal fan-out pipeline without a real notification transport. A real
+ * app would replace this with an email/slack/webhook provision.
+ */
+export interface Notification {
+  readonly action: 'created' | 'updated' | 'deleted';
+  readonly entityId: string;
+  readonly entityName: string;
+  readonly timestamp: string;
+}
+
+const notificationLog: Notification[] = [];
+
+/** Read the current notification log (defensive copy). */
+export const getNotifications = (): readonly Notification[] => [
+  ...notificationLog,
+];
+
+/** Clear the notification log. Useful between tests. */
+export const clearNotifications = (): void => {
+  notificationLog.length = 0;
+};
+
+// ---------------------------------------------------------------------------
+// entity.notify-updated
+// ---------------------------------------------------------------------------
+
+/**
+ * Consumer trail that reacts to entity.updated signals.
+ *
+ * Receives the validated signal payload as its input and logs a
+ * notification. Serves as the proof-of-life for the signal fan-out
+ * pipeline in the demo app.
+ */
+export const notifyEntityUpdated = trail('entity.notify-updated', {
+  blaze: (input, ctx) => {
+    notificationLog.push({
+      action: input.action,
+      entityId: input.entityId,
+      entityName: input.entityName,
+      timestamp: input.timestamp,
+    });
+    ctx.logger?.info('entity.updated notification', {
+      action: input.action,
+      entityId: input.entityId,
+      entityName: input.entityName,
+    });
+    return Result.ok({ notified: true });
+  },
+  description: 'Log a notification whenever an entity.updated signal is fired.',
+  examples: [
+    {
+      description: 'Notify on a created entity',
+      input: {
+        action: 'created',
+        entityId: 'ent_1',
+        entityName: 'Epsilon',
+        timestamp: '2026-04-07T00:00:00.000Z',
+      },
+      name: 'Notify created',
+    },
+  ],
+  input: z.object({
+    action: z.enum(['created', 'updated', 'deleted']),
+    entityId: z.string(),
+    entityName: z.string(),
+    timestamp: z.string(),
+  }),
+  intent: 'write',
+  on: ['entity.updated'],
+  output: z.object({ notified: z.boolean() }),
+});

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
       "devDependencies": {
         "@ontrails/schema": "workspace:^",
         "@ontrails/testing": "workspace:^",
+        "@ontrails/warden": "workspace:^",
       },
     },
     "packages/cli": {

--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from 'bun:test';
 import { z } from 'zod';
 
 import { NotFoundError, ValidationError } from '../errors';
-import type { Layer } from '../layer';
 import { Result } from '../result';
 import { run } from '../run';
 import { signal } from '../signal';
@@ -54,80 +53,6 @@ const makeProducer = (fireResultKey: { result?: Result<void, Error> }) =>
     fires: ['order.placed'],
     input: z.object({ orderId: z.string(), total: z.number() }),
   });
-
-const cyclePayload = z.object({ id: z.string() });
-
-const resolveFireResult = (
-  fired: Result<void, Error> | undefined
-): Result<{ ok: true }, Error> =>
-  fired?.match({
-    err: (error) => Result.err(error),
-    ok: () => Result.ok({ ok: true }),
-  }) ?? Result.ok({ ok: true });
-
-const createCycleLogger = (
-  warnings: { message: string; signalId?: unknown }[]
-): Logger => {
-  const logger: Logger = {
-    ...noopLogger,
-    child() {
-      return logger;
-    },
-    warn(message, data) {
-      warnings.push({ message, signalId: data?.signalId });
-    },
-  };
-  return logger;
-};
-
-const createCycleConsumer = (
-  id: string,
-  onSignalId: string,
-  nextSignalId: string,
-  marker: string,
-  invocations: string[]
-) =>
-  trail(id, {
-    blaze: async (input: { readonly id: string }, ctx: TrailContext) => {
-      invocations.push(marker);
-      return resolveFireResult(await ctx.fire?.(nextSignalId, input));
-    },
-    input: cyclePayload,
-    on: [onSignalId],
-  });
-
-const createCycleScenario = (invocations: string[]) => {
-  const signalA = signal('loop.a', { payload: cyclePayload });
-  const signalB = signal('loop.b', { payload: cyclePayload });
-  const consumerA = createCycleConsumer(
-    'loop.consumer-a',
-    'loop.a',
-    'loop.b',
-    'a',
-    invocations
-  );
-  const consumerB = createCycleConsumer(
-    'loop.consumer-b',
-    'loop.b',
-    'loop.a',
-    'b',
-    invocations
-  );
-  const producer = trail('loop.producer', {
-    blaze: async (input: { readonly id: string }, ctx: TrailContext) =>
-      resolveFireResult(await ctx.fire?.('loop.a', input)),
-    fires: ['loop.a'],
-    input: cyclePayload,
-  });
-
-  return topo('fire-cycle', {
-    consumerA,
-    consumerB,
-    producer,
-    signalA,
-    signalB,
-  });
-};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -219,26 +144,6 @@ describe('fire', () => {
       expect(result.isErr()).toBe(true);
       expect(result.error).toBeInstanceOf(ValidationError);
       expect(capture.invocations).toHaveLength(0);
-    });
-
-    test('invalid ctx.fire input returns Result.err(ValidationError)', async () => {
-      const badProducer = trail('bad.fire-input', {
-        blaze: async (_input, ctx) => {
-          const fire = ctx.fire as (
-            signalOrId: unknown,
-            payload: unknown
-          ) => Promise<Result<void, Error>>;
-          const fired = await fire(123, {});
-          return fired as Result<unknown, Error>;
-        },
-        input: z.object({}),
-      });
-
-      const app = topo('fire-bad-input', { badProducer, orderPlaced });
-      const result = await run(app, 'bad.fire-input', {});
-
-      expect(result.isErr()).toBe(true);
-      expect(result.error).toBeInstanceOf(ValidationError);
     });
   });
 

--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -1,0 +1,278 @@
+/* oxlint-disable require-await -- trail implementations satisfy async interface without awaiting */
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { NotFoundError, ValidationError } from '../errors';
+import type { Layer } from '../layer';
+import { Result } from '../result';
+import { run } from '../run';
+import { signal } from '../signal';
+import { topo } from '../topo';
+import { trail } from '../trail';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const orderPlaced = signal('order.placed', {
+  payload: z.object({ orderId: z.string(), total: z.number() }),
+});
+
+// Mutable capture box for assertions. Each test resets it.
+interface Capture {
+  invocations: { trailId: string; payload: unknown }[];
+}
+const createCapture = (): Capture => ({ invocations: [] });
+
+const makeConsumer = (
+  id: string,
+  capture: Capture,
+  behavior: 'ok' | 'err' = 'ok'
+) =>
+  trail(id, {
+    blaze: (input) => {
+      capture.invocations.push({ payload: input, trailId: id });
+      if (behavior === 'err') {
+        return Result.err(new Error(`${id} failed`));
+      }
+      return Result.ok({ received: input });
+    },
+    input: z.object({ orderId: z.string(), total: z.number() }),
+    on: ['order.placed'],
+  });
+
+const makeProducer = (fireResultKey: { result?: Result<void, Error> }) =>
+  trail('order.create', {
+    blaze: async (input, ctx) => {
+      const fired = await ctx.fire?.('order.placed', {
+        orderId: input.orderId,
+        total: input.total,
+      });
+      fireResultKey.result = fired;
+      return Result.ok({ ok: true });
+    },
+    fires: ['order.placed'],
+    input: z.object({ orderId: z.string(), total: z.number() }),
+  });
+
+const cyclePayload = z.object({ id: z.string() });
+
+const resolveFireResult = (
+  fired: Result<void, Error> | undefined
+): Result<{ ok: true }, Error> =>
+  fired?.match({
+    err: (error) => Result.err(error),
+    ok: () => Result.ok({ ok: true }),
+  }) ?? Result.ok({ ok: true });
+
+const createCycleLogger = (
+  warnings: { message: string; signalId?: unknown }[]
+): Logger => {
+  const logger: Logger = {
+    ...noopLogger,
+    child() {
+      return logger;
+    },
+    warn(message, data) {
+      warnings.push({ message, signalId: data?.signalId });
+    },
+  };
+  return logger;
+};
+
+const createCycleConsumer = (
+  id: string,
+  onSignalId: string,
+  nextSignalId: string,
+  marker: string,
+  invocations: string[]
+) =>
+  trail(id, {
+    blaze: async (input: { readonly id: string }, ctx: TrailContext) => {
+      invocations.push(marker);
+      return resolveFireResult(await ctx.fire?.(nextSignalId, input));
+    },
+    input: cyclePayload,
+    on: [onSignalId],
+  });
+
+const createCycleScenario = (invocations: string[]) => {
+  const signalA = signal('loop.a', { payload: cyclePayload });
+  const signalB = signal('loop.b', { payload: cyclePayload });
+  const consumerA = createCycleConsumer(
+    'loop.consumer-a',
+    'loop.a',
+    'loop.b',
+    'a',
+    invocations
+  );
+  const consumerB = createCycleConsumer(
+    'loop.consumer-b',
+    'loop.b',
+    'loop.a',
+    'b',
+    invocations
+  );
+  const producer = trail('loop.producer', {
+    blaze: async (input: { readonly id: string }, ctx: TrailContext) =>
+      resolveFireResult(await ctx.fire?.('loop.a', input)),
+    fires: ['loop.a'],
+    input: cyclePayload,
+  });
+
+  return topo('fire-cycle', {
+    consumerA,
+    consumerB,
+    producer,
+    signalA,
+    signalB,
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fire', () => {
+  describe('fan-out', () => {
+    test('invokes every consumer with validated payload', async () => {
+      const capture = createCapture();
+      const fireBox: { result?: Result<void, Error> } = {};
+      const app = topo('fire-test', {
+        consumerA: makeConsumer('notify.email', capture),
+        consumerB: makeConsumer('notify.slack', capture),
+        orderPlaced,
+        producer: makeProducer(fireBox),
+      });
+      const result = await run(app, 'order.create', {
+        orderId: 'o-1',
+        total: 42,
+      });
+      expect(result.isOk()).toBe(true);
+      expect(fireBox.result?.isOk()).toBe(true);
+      expect(capture.invocations).toHaveLength(2);
+      expect(capture.invocations.map((i) => i.trailId).toSorted()).toEqual([
+        'notify.email',
+        'notify.slack',
+      ]);
+      expect(capture.invocations[0]?.payload).toEqual({
+        orderId: 'o-1',
+        total: 42,
+      });
+      expect(capture.invocations[1]?.payload).toEqual({
+        orderId: 'o-1',
+        total: 42,
+      });
+    });
+
+    test('no-consumer fan-out returns Result.ok', async () => {
+      const fireBox: { result?: Result<void, Error> } = {};
+      const producer = makeProducer(fireBox);
+      const app = topo('fire-empty', { orderPlaced, producer });
+
+      const result = await run(app, 'order.create', {
+        orderId: 'o-2',
+        total: 0,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(fireBox.result?.isOk()).toBe(true);
+    });
+  });
+
+  describe('validation', () => {
+    test('unknown signal id returns Result.err(NotFoundError)', async () => {
+      const badProducer = trail('bad.producer', {
+        blaze: async (_input, ctx) => {
+          const fired = await ctx.fire?.('ghost.signal', {});
+          return fired as Result<unknown, Error>;
+        },
+        input: z.object({}),
+      });
+
+      const app = topo('fire-unknown', { badProducer });
+      const result = await run(app, 'bad.producer', {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(NotFoundError);
+    });
+
+    test('bad payload returns Result.err(ValidationError) and skips consumers', async () => {
+      const capture = createCapture();
+      const consumer = makeConsumer('notify.email', capture);
+
+      const badProducer = trail('bad.payload', {
+        blaze: async (_input, ctx) => {
+          const fired = await ctx.fire?.('order.placed', { orderId: 123 });
+          return fired as Result<unknown, Error>;
+        },
+        input: z.object({}),
+      });
+
+      const app = topo('fire-bad-payload', {
+        badProducer,
+        consumer,
+        orderPlaced,
+      });
+      const result = await run(app, 'bad.payload', {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(capture.invocations).toHaveLength(0);
+    });
+
+    test('invalid ctx.fire input returns Result.err(ValidationError)', async () => {
+      const badProducer = trail('bad.fire-input', {
+        blaze: async (_input, ctx) => {
+          const fire = ctx.fire as (
+            signalOrId: unknown,
+            payload: unknown
+          ) => Promise<Result<void, Error>>;
+          const fired = await fire(123, {});
+          return fired as Result<unknown, Error>;
+        },
+        input: z.object({}),
+      });
+
+      const app = topo('fire-bad-input', { badProducer, orderPlaced });
+      const result = await run(app, 'bad.fire-input', {});
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe('error isolation', () => {
+    test('consumer error does not fail the producer', async () => {
+      const capture = createCapture();
+      const failingConsumer = makeConsumer('notify.broken', capture, 'err');
+      const fireBox: { result?: Result<void, Error> } = {};
+      const producer = makeProducer(fireBox);
+
+      const app = topo('fire-err', { failingConsumer, orderPlaced, producer });
+      const result = await run(app, 'order.create', {
+        orderId: 'o-3',
+        total: 1,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(fireBox.result?.isOk()).toBe(true);
+      expect(capture.invocations).toHaveLength(1);
+    });
+  });
+
+  describe('context binding', () => {
+    test('ctx.fire is undefined when executeTrail is called without a topo', async () => {
+      const { executeTrail } = await import('../execute');
+      const standalone = trail('standalone', {
+        blaze: async (_input, ctx) =>
+          Result.ok({ hasFire: ctx.fire !== undefined }),
+        input: z.object({}),
+      });
+
+      const result = await executeTrail(standalone, {});
+      expect(result.isOk()).toBe(true);
+      expect((result.unwrap() as { hasFire: boolean }).hasFire).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { createTrailContext } from '../context';
 import { Result } from '../result';
 import { resource } from '../resource';
+import { signal } from '../signal';
 import { trail } from '../trail';
 import type { TrailContext } from '../types';
 
@@ -256,6 +257,46 @@ describe('trail()', () => {
       const result = await promise;
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toBe(3);
+    });
+  });
+
+  describe('fires/on normalization', () => {
+    const orderPlaced = signal('order.placed', {
+      payload: z.object({ id: z.string() }),
+    });
+    const auditLogged = signal('audit.logged', {
+      payload: z.object({ actor: z.string() }),
+    });
+
+    test('Signal value in fires: is normalized to its id', () => {
+      const t = trail('checkout', {
+        blaze: () => Result.ok({}),
+        fires: [orderPlaced],
+        input: z.object({}),
+      });
+      expect(t.fires).toEqual(['order.placed']);
+    });
+
+    test('Signal value in on: is normalized to its id', () => {
+      const t = trail('notify', {
+        blaze: () => Result.ok({}),
+        input: z.object({}),
+        on: [orderPlaced],
+      });
+      expect(t.on).toEqual(['order.placed']);
+    });
+
+    test('mixed string + Signal value in fires: is normalized', () => {
+      const t = trail('checkout', {
+        blaze: () => Result.ok({}),
+        fires: ['metric.emitted', orderPlaced, auditLogged],
+        input: z.object({}),
+      });
+      expect(t.fires).toEqual([
+        'metric.emitted',
+        'order.placed',
+        'audit.logged',
+      ]);
     });
   });
 });

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -1,0 +1,120 @@
+/**
+ * Signal emission and auto-activation.
+ *
+ * `createFireFn(topo)` returns a `FireFn` bound to a topo. Calling
+ * `fire(signalId, payload)` looks up the signal, validates the payload
+ * against its schema, finds every trail with the signal in its `on:` array,
+ * and invokes each consumer via `executeTrail`.
+ *
+ * Error semantics match the fire-and-forget framing: producers get
+ * `Result.ok(undefined)` unless the signal id is unknown or the payload
+ * fails schema validation. Consumer errors are logged via the context's
+ * logger (when available) but do NOT propagate back to the producer.
+ * Consumers that need transactional coupling should use `crosses:`.
+ */
+
+import { NotFoundError, ValidationError } from './errors.js';
+import { executeTrail } from './execute.js';
+import { Result } from './result.js';
+import type { AnyTrail } from './trail.js';
+import type { Topo } from './topo.js';
+import type { FireFn, Logger, TrailContextInit } from './types.js';
+
+const fanOutToConsumers = async (
+  consumers: readonly AnyTrail[],
+  payload: unknown,
+  signalId: string,
+  fire: FireFn,
+  logger: Logger | undefined
+): Promise<void> => {
+  const consumerCtx: Partial<TrailContextInit> = { fire };
+  for (const consumer of consumers) {
+    const consumerResult = await executeTrail(consumer, payload, {
+      ctx: consumerCtx,
+    });
+    if (consumerResult.isErr()) {
+      logger?.warn('Signal consumer failed', {
+        consumerId: consumer.id,
+        error: consumerResult.error.message,
+        signalId,
+      });
+    }
+  }
+};
+
+const resolveFireDispatch = (
+  topo: Topo,
+  signalId: string,
+  payload: unknown
+): Result<
+  { readonly consumers: readonly AnyTrail[]; readonly payload: unknown },
+  Error
+> => {
+  const signal = topo.signals.get(signalId);
+  if (signal === undefined) {
+    return Result.err(
+      new NotFoundError(`Signal "${signalId}" not found in topo "${topo.name}"`)
+    );
+  }
+  const parsed = signal.payload.safeParse(payload);
+  if (!parsed.success) {
+    return Result.err(
+      new ValidationError(
+        `Invalid payload for signal "${signalId}": ${parsed.error.message}`
+      )
+    );
+  }
+  return Result.ok({
+    consumers: topo.list().filter((trail) => trail.on.includes(signalId)),
+    payload: parsed.data,
+  });
+};
+
+const buildConsumerCtx = (
+  producerCtx: TrailContextInit | undefined,
+  signalId: string
+): MutableConsumerContext => {
+  const childLogger: Logger | undefined =
+    producerCtx?.logger?.child?.({ signalId }) ?? producerCtx?.logger;
+  return producerCtx
+    ? {
+        ...producerCtx,
+        extensions: {
+          ...producerCtx.extensions,
+          [FIRE_STACK_KEY]: [...getFireStack(producerCtx), signalId],
+        },
+        logger: childLogger,
+      }
+    : {};
+};
+
+/** Build a `FireFn` closure bound to a topo. */
+export const createFireFn = (topo: Topo, logger?: Logger): FireFn => {
+  const fire: FireFn = async (signalId, payload) => {
+    const signal = topo.signals.get(signalId);
+    if (signal === undefined) {
+      return Result.err(
+        new NotFoundError(
+          `Signal "${signalId}" not found in topo "${topo.name}"`
+        )
+      );
+    }
+
+    const parsed = signal.payload.safeParse(payload);
+    if (!parsed.success) {
+      return Result.err(
+        new ValidationError(
+          `Invalid payload for signal "${signalId}": ${parsed.error.message}`
+        )
+      );
+    }
+
+    const consumers = topo
+      .list()
+      .filter((trail) => trail.on.includes(signalId));
+    await fanOutToConsumers(consumers, parsed.data, signalId, fire, logger);
+    return Result.ok();
+  };
+
+  return fire;
+};

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -42,52 +42,6 @@ const fanOutToConsumers = async (
   }
 };
 
-const resolveFireDispatch = (
-  topo: Topo,
-  signalId: string,
-  payload: unknown
-): Result<
-  { readonly consumers: readonly AnyTrail[]; readonly payload: unknown },
-  Error
-> => {
-  const signal = topo.signals.get(signalId);
-  if (signal === undefined) {
-    return Result.err(
-      new NotFoundError(`Signal "${signalId}" not found in topo "${topo.name}"`)
-    );
-  }
-  const parsed = signal.payload.safeParse(payload);
-  if (!parsed.success) {
-    return Result.err(
-      new ValidationError(
-        `Invalid payload for signal "${signalId}": ${parsed.error.message}`
-      )
-    );
-  }
-  return Result.ok({
-    consumers: topo.list().filter((trail) => trail.on.includes(signalId)),
-    payload: parsed.data,
-  });
-};
-
-const buildConsumerCtx = (
-  producerCtx: TrailContextInit | undefined,
-  signalId: string
-): MutableConsumerContext => {
-  const childLogger: Logger | undefined =
-    producerCtx?.logger?.child?.({ signalId }) ?? producerCtx?.logger;
-  return producerCtx
-    ? {
-        ...producerCtx,
-        extensions: {
-          ...producerCtx.extensions,
-          [FIRE_STACK_KEY]: [...getFireStack(producerCtx), signalId],
-        },
-        logger: childLogger,
-      }
-    : {};
-};
-
 /** Build a `FireFn` closure bound to a topo. */
 export const createFireFn = (topo: Topo, logger?: Logger): FireFn => {
   const fire: FireFn = async (signalId, payload) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export type {
   TrailContext,
   TrailContextInit,
   CrossFn,
+  FireFn,
   BasePermit,
   PermitRequirement,
   ProgressCallback,

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -9,7 +9,9 @@ import type { Topo } from './topo.js';
 import { executeTrail } from './execute.js';
 import type { ExecuteTrailOptions } from './execute.js';
 import { NotFoundError } from './errors.js';
+import { createFireFn } from './fire.js';
 import { Result } from './result.js';
+import type { TrailContextInit } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -50,5 +52,7 @@ export const run = (
       )
     );
   }
-  return executeTrail(trail, input, options);
+  const fire = createFireFn(topo, options?.ctx?.logger);
+  const ctxWithFire: Partial<TrailContextInit> = { ...options?.ctx, fire };
+  return executeTrail(trail, input, { ...options, ctx: ctxWithFire });
 };

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -63,6 +63,10 @@ export interface TrailSpec<I, O> {
   readonly crosses?: readonly string[] | undefined;
   /** Resources this trail may access via resource.from(ctx) */
   readonly resources?: readonly AnyResource[] | undefined;
+  /** IDs of signals this trail emits via ctx.fire() */
+  readonly fires?: readonly string[] | undefined;
+  /** IDs of signals that activate this trail (framework auto-subscribes) */
+  readonly on?: readonly string[] | undefined;
   /** Auth requirement: scopes object, 'public', or omitted (undeclared) */
   readonly permit?: PermitRequirement | undefined;
 }
@@ -77,7 +81,7 @@ export type Intent = 'read' | 'write' | 'destroy';
 /** A fully-defined trail — the unit of work in the Trails system */
 export interface Trail<I, O> extends Omit<
   TrailSpec<I, O>,
-  'blaze' | 'crosses' | 'intent' | 'resources'
+  'blaze' | 'crosses' | 'fires' | 'intent' | 'on' | 'resources'
 > {
   readonly kind: 'trail';
   readonly id: string;
@@ -86,6 +90,10 @@ export interface Trail<I, O> extends Omit<
   readonly crosses: readonly string[];
   /** Resources this trail may access via resource.from(ctx) (always present, default []) */
   readonly resources: readonly AnyResource[];
+  /** IDs of signals this trail emits via ctx.fire() (always present, default []) */
+  readonly fires: readonly string[];
+  /** IDs of signals that activate this trail (always present, default []) */
+  readonly on: readonly string[];
   /** What this trail does to the world (always present, default 'write') */
   readonly intent: Intent;
 }
@@ -136,19 +144,23 @@ export function trail<I, O>(
   const {
     blaze,
     crosses: rawCrosses,
+    fires: rawFires,
     intent: rawIntent,
-    resources: rawProvisions,
+    on: rawOn,
+    resources: rawResources,
     ...spec
   } = resolved.spec;
-  const resources = Object.freeze([...(rawProvisions ?? [])]);
+  const resources = Object.freeze([...(rawResources ?? [])]);
 
   return Object.freeze({
     ...spec,
     blaze: async (input: I, ctx: TrailContext) => await blaze(input, ctx),
     crosses: Object.freeze([...(rawCrosses ?? [])]),
+    fires: Object.freeze([...(rawFires ?? [])]),
     id: resolved.id,
     intent: rawIntent ?? 'write',
     kind: 'trail' as const,
+    on: Object.freeze([...(rawOn ?? [])]),
     resources,
   });
 }

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -3,6 +3,7 @@ import type { z } from 'zod';
 import type { FieldOverride } from './derive.js';
 import type { Result } from './result.js';
 import type { AnyResource } from './resource.js';
+import type { AnySignal } from './signal.js';
 import type {
   Implementation,
   PermitRequirement,
@@ -64,9 +65,25 @@ export interface TrailSpec<I, O> {
   /** Resources this trail may access via resource.from(ctx) */
   readonly resources?: readonly AnyResource[] | undefined;
   /** IDs of signals this trail emits via ctx.fire() */
-  readonly fires?: readonly string[] | undefined;
-  /** IDs of signals that activate this trail (framework auto-subscribes) */
-  readonly on?: readonly string[] | undefined;
+  /**
+   * Signals this trail emits via `ctx.fire()`.
+   *
+   * Accepts either a string id or a `Signal` value. Both forms are
+   * normalized to the signal's id at trail definition time, so
+   * `trail.fires` is always `readonly string[]`.
+   *
+   * Note: `crosses` is still string-only — only signal references are
+   * loosened here because callers typically have the `Signal` value in
+   * scope at the definition site.
+   */
+  readonly fires?: readonly (string | AnySignal)[] | undefined;
+  /**
+   * Signals that activate this trail (framework auto-subscribes).
+   *
+   * Accepts either a string id or a `Signal` value. Both forms are
+   * normalized to the signal's id at trail definition time.
+   */
+  readonly on?: readonly (string | AnySignal)[] | undefined;
   /** Auth requirement: scopes object, 'public', or omitted (undeclared) */
   readonly permit?: PermitRequirement | undefined;
 }
@@ -101,6 +118,9 @@ export interface Trail<I, O> extends Omit<
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
+
+const normalizeSignalRef = (entry: string | AnySignal): string =>
+  typeof entry === 'string' ? entry : entry.id;
 
 /**
  * Create a trail definition.
@@ -151,16 +171,18 @@ export function trail<I, O>(
     ...spec
   } = resolved.spec;
   const resources = Object.freeze([...(rawResources ?? [])]);
+  const fires = Object.freeze((rawFires ?? []).map(normalizeSignalRef));
+  const on = Object.freeze((rawOn ?? []).map(normalizeSignalRef));
 
   return Object.freeze({
     ...spec,
     blaze: async (input: I, ctx: TrailContext) => await blaze(input, ctx),
     crosses: Object.freeze([...(rawCrosses ?? [])]),
-    fires: Object.freeze([...(rawFires ?? [])]),
+    fires,
     id: resolved.id,
     intent: rawIntent ?? 'write',
     kind: 'trail' as const,
-    on: Object.freeze([...(rawOn ?? [])]),
+    on,
     resources,
   });
 }

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -64,7 +64,6 @@ export interface TrailSpec<I, O> {
   readonly crosses?: readonly string[] | undefined;
   /** Resources this trail may access via resource.from(ctx) */
   readonly resources?: readonly AnyResource[] | undefined;
-  /** IDs of signals this trail emits via ctx.fire() */
   /**
    * Signals this trail emits via `ctx.fire()`.
    *

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,6 +17,19 @@ export type CrossFn = <O>(
   input: unknown
 ) => Promise<Result<O, Error>>;
 
+/**
+ * Emit a signal by id — used for signal-driven activation.
+ *
+ * Fan-out to consumer trails (those with the signal in their `on:` array) is
+ * the framework's responsibility. Producers get `Result.ok(undefined)` unless
+ * the signal id is unknown or the payload fails schema validation. Consumer
+ * errors are logged but do not propagate back to the producer.
+ */
+export type FireFn = (
+  signalId: string,
+  payload: unknown
+) => Promise<Result<void, Error>>;
+
 /** Resolve a resource instance from the current trail context. */
 export type ResourceLookup = <T = unknown>(
   resourceOrId: { readonly id: string } | string
@@ -73,6 +86,12 @@ export interface TrailContext {
   readonly requestId: string;
   readonly abortSignal: AbortSignal;
   readonly cross?: CrossFn | undefined;
+  /**
+   * Emit a signal by id. Fans out to every trail with the signal in its
+   * `on:` declaration. Bound by the runner that holds the topo (typically
+   * `run()`); undefined when a context is constructed without topo access.
+   */
+  readonly fire?: FireFn | undefined;
   readonly permit?: BasePermit;
   readonly workspaceRoot?: string | undefined;
   readonly logger?: Logger | undefined;

--- a/packages/warden/src/__tests__/fires-declarations-param-destructure.test.ts
+++ b/packages/warden/src/__tests__/fires-declarations-param-destructure.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+
+import { firesDeclarations } from '../rules/fires-declarations.js';
+
+const TEST_FILE = 'test.ts';
+
+describe('fires-declarations — parameter-level destructure', () => {
+  test('parameter-level { fire } destructure is tracked (clean)', () => {
+    const code = `
+trail('paramDestructure', {
+  fires: ['entity.created'],
+  blaze: async (input, { fire }) => {
+    await fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+    const diagnostics = firesDeclarations.check(code, TEST_FILE);
+    expect(diagnostics.length).toBe(0);
+  });
+
+  test('parameter-level { fire } destructure flags undeclared signal', () => {
+    const code = `
+trail('paramDestructureUndeclared', {
+  blaze: async (input, { fire }) => {
+    await fire('undeclared.signal', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+    const diagnostics = firesDeclarations.check(code, TEST_FILE);
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.severity).toBe('error');
+    expect(diagnostics[0]?.message).toContain("'undeclared.signal'");
+  });
+
+  test('parameter-level { fire: emit } rename is tracked', () => {
+    const code = `
+trail('paramRename', {
+  blaze: async (input, { fire: emit }) => {
+    await emit('undeclared.renamed', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+    const diagnostics = firesDeclarations.check(code, TEST_FILE);
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.severity).toBe('error');
+    expect(diagnostics[0]?.message).toContain("'undeclared.renamed'");
+  });
+});

--- a/packages/warden/src/__tests__/fires-declarations.test.ts
+++ b/packages/warden/src/__tests__/fires-declarations.test.ts
@@ -362,4 +362,259 @@ trail('mixed', {
       expect(warns.length).toBe(1);
     });
   });
+
+  describe('bare fire() helpers', () => {
+    test('unrelated local fire() helper is not flagged', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+const fire = (x: number) => x * 2;
+const t = trail('calc', {
+  input: z.object({ n: z.number() }),
+  blaze: async (input, ctx) => {
+    const doubled = fire(input.n);
+    return Result.ok({ doubled });
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      // Neither declared nor "called" from the trail's perspective.
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('destructured { fire } from ctx is tracked', () => {
+      const code = `
+trail('onboard', {
+  fires: ['entity.created'],
+  blaze: async (input, ctx) => {
+    const { fire } = ctx;
+    await fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('nested-scope destructure does not leak to outer blaze scope', () => {
+      const code = `
+trail('outer', {
+  blaze: async (input, ctx) => {
+    function nested() {
+      const { fire } = ctx;
+      return fire;
+    }
+    fire('outer.signal');
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      // Top-level fire('outer.signal') should NOT be treated as a ctx call —
+      // the nested destructure must not leak out.
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('top-level destructure is still tracked (regression check)', () => {
+      const code = `
+trail('tracked', {
+  blaze: async (input, ctx) => {
+    const { fire } = ctx;
+    await fire('undeclared.signal', {});
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain("'undeclared.signal'");
+    });
+
+    test('nested function parameter shadowing fire is not flagged', () => {
+      const code = `
+trail('shadowFire', {
+  blaze: async (_, ctx) => {
+    const { fire } = ctx;
+    function nested(fire) {
+      fire('shadow.only');
+    }
+    nested(() => {});
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      // The nested parameter shadows the outer destructured `fire`, so the
+      // call inside `nested` must not be treated as a trail fire.
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('nested function parameter shadowing ctx is not flagged', () => {
+      const code = `
+trail('shadowCtx', {
+  blaze: async (_, ctx) => {
+    function nested(ctx) {
+      ctx.fire('shadow.ctx');
+    }
+    nested({});
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('nested arrow with legitimate ctx.fire is not flagged as undeclared', () => {
+      const code = `
+trail('nestedLegit', {
+  fires: ['legitimate.signal'],
+  blaze: async (input, ctx) => {
+    const runLater = () => ctx.fire('legitimate.signal', {});
+    runLater();
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      // Precision tradeoff: the nested arrow isn't walked, so the warden sees
+      // the declared 'legitimate.signal' as "unused". What matters for the
+      // P1 bug is that it is NOT reported as undeclared (no false error).
+      const undeclared = diagnostics.filter((d) =>
+        d.message.includes('not declared in fires')
+      );
+      expect(undeclared.length).toBe(0);
+    });
+
+    test('top-level ctx.fire with matching declaration still clean (regression)', () => {
+      const code = `
+trail('regression', {
+  fires: ['declared.signal'],
+  blaze: async (input, ctx) => {
+    await ctx.fire('declared.signal', {});
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('let { fire: emit } = ctx is not tracked (precision tradeoff)', () => {
+      const code = `
+trail('letDestructure', {
+  blaze: async (input, ctx) => {
+    let { fire: emit } = ctx;
+    emit('some.id');
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      // Only `const` destructures are tracked. `let` / `var` allow
+      // reassignment which this flow-insensitive walker cannot follow, so
+      // `emit` is treated as unrelated and no diagnostic is produced.
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('destructured { fire: emit } alias from ctx is tracked', () => {
+      const code = `
+trail('onboard', {
+  fires: ['entity.created'],
+  blaze: async (input, ctx) => {
+    const { fire: emit } = ctx;
+    await emit('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('object-form fires declarations', () => {
+    test('Signal value reference downgrades undeclared to warn', () => {
+      const code = `
+import { trail, signal, Result } from '@ontrails/core';
+const orderPlaced = signal('order.placed', { payload: z.object({}) });
+trail('checkout', {
+  fires: [orderPlaced],
+  blaze: async (input, ctx) => {
+    await ctx.fire('order.placed', {});
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      // Object-form makes the declared set unresolvable — downgrade undeclared
+      // to warn rather than silently suppressing; runtime normalization in
+      // trail() may cover the call.
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+      expect(diagnostics[0]?.message).toContain('object-form fires entries');
+    });
+
+    test('genuinely undeclared string call alongside Signal value is downgraded to warn', () => {
+      const code = `
+import { trail, signal, Result } from '@ontrails/core';
+const orderPlaced = signal('order.placed', { payload: z.object({}) });
+trail('checkout', {
+  fires: [orderPlaced],
+  blaze: async (input, ctx) => {
+    await ctx.fire('audit.logged', {});
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      // Cannot statically prove 'audit.logged' isn't covered by the object-form
+      // entry, but also cannot stay silent — warn with disclaimer.
+      const undeclared = diagnostics.filter((d) =>
+        d.message.includes("'audit.logged'")
+      );
+      expect(undeclared.length).toBe(1);
+      expect(undeclared[0]?.severity).toBe('warn');
+      expect(undeclared[0]?.message).toContain(
+        'may be declared via object-form fires entries'
+      );
+    });
+
+    test('mixed string + Signal value — resolved string still matches, unresolved warns', () => {
+      const code = `
+import { trail, signal, Result } from '@ontrails/core';
+const orderPlaced = signal('order.placed', { payload: z.object({}) });
+trail('checkout', {
+  fires: ['audit.logged', orderPlaced],
+  blaze: async (input, ctx) => {
+    await ctx.fire('order.placed', {});
+    await ctx.fire('audit.logged', {});
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      // 'audit.logged' resolves from the string literal; 'order.placed' can't
+      // be resolved statically so it downgrades to warn.
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+      expect(diagnostics[0]?.message).toContain("'order.placed'");
+      expect(diagnostics[0]?.message).toContain('object-form fires entries');
+    });
+  });
 });

--- a/packages/warden/src/__tests__/fires-declarations.test.ts
+++ b/packages/warden/src/__tests__/fires-declarations.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, test } from 'bun:test';
+
+import { firesDeclarations } from '../rules/fires-declarations.js';
+
+const TEST_FILE = 'test.ts';
+
+describe('fires-declarations', () => {
+  describe('clean cases', () => {
+    test('declared and called match exactly', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+const t = trail('onboard', {
+  fires: ['entity.created', 'audit.logged'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    await ctx.fire('audit.logged', { actor: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('optional-chained ctx.fire?.() call matching declaration is clean', () => {
+      const code = `
+trail('optionalChain', {
+  fires: ['declared.signal'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire?.('declared.signal', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      // Optional-chain invocation of ctx.fire must not produce false positives.
+      // Locks in current behavior so the dogfood demo's `ctx.fire?.(...)` stays
+      // clean regardless of future AST walker changes.
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('no fires declaration and no ctx.fire() calls', () => {
+      const code = `
+trail('simple', {
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    return Result.ok({ greeting: 'hello ' + input.name });
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('error cases', () => {
+    test('called but not declared produces error', () => {
+      const code = `
+trail('onboard', {
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.rule).toBe('fires-declarations');
+      expect(diagnostics[0]?.message).toContain("ctx.fire('entity.created')");
+      expect(diagnostics[0]?.message).toContain('not declared in fires');
+    });
+  });
+
+  describe('warn cases', () => {
+    test('declared but not called produces warning', () => {
+      const code = `
+trail('onboard', {
+  fires: ['entity.created', 'audit.logged'],
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+      expect(diagnostics[0]?.rule).toBe('fires-declarations');
+      expect(diagnostics[0]?.message).toContain(
+        "'audit.logged' declared in fires"
+      );
+      expect(diagnostics[0]?.message).toContain('never called');
+    });
+  });
+
+  describe('single-object overload', () => {
+    test('recognizes trail({ id, fires, blaze }) form', () => {
+      const code = `
+trail({
+  id: 'onboard',
+  fires: ['entity.created'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('detects undeclared fires in single-object form', () => {
+      const code = `
+trail({
+  id: 'onboard',
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain("'entity.created'");
+    });
+  });
+
+  describe('context parameter naming', () => {
+    test('recognizes context.fire() when second param is named context', () => {
+      const code = `
+trail('onboard', {
+  fires: ['entity.created'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, context) => {
+    await context.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('blaze with no second parameter: unrelated closure ctx.fire is not tracked', () => {
+      const code = `
+const ctx = { fire: (_: string) => {} };
+trail('noCtxParam', {
+  blaze: async (input) => {
+    ctx.fire('closure.signal');
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      // The blaze has no context parameter, so `ctx` in the body refers to
+      // some unrelated closure identifier, not a trail context. It must not
+      // be tracked — no diagnostics.
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('custom-named context param: only that name is tracked', () => {
+      const code = `
+const ctx = { fire: (_: string) => {} };
+trail('customCtx', {
+  fires: ['declared.id'],
+  blaze: async (input, c) => {
+    await c.fire('declared.id', {});
+    ctx.fire('whatever');
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      // `c.fire('declared.id')` matches the declaration. The unrelated
+      // closure `ctx.fire('whatever')` must not be flagged because `ctx` is
+      // not the trail context — only `c` is.
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('custom-named context param: undeclared call via that name is flagged', () => {
+      const code = `
+trail('customCtxUndeclared', {
+  fires: ['declared.id'],
+  blaze: async (input, c) => {
+    await c.fire('undeclared.id', {});
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+      const undeclared = diagnostics.filter((d) =>
+        d.message.includes("'undeclared.id'")
+      );
+      expect(undeclared.length).toBe(1);
+      expect(undeclared[0]?.severity).toBe('error');
+    });
+
+    test('recognizes destructured fire() calls', () => {
+      const code = `
+trail('onboard', {
+  fires: ['entity.created'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    const { fire } = ctx;
+    await fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('nested run false positives', () => {
+    test('meta.blaze with phantom fire does not trigger false positives', () => {
+      const code = `
+trail('onboard', {
+  fires: ['entity.created'],
+  input: z.object({ name: z.string() }),
+  meta: { blaze: async () => ctx.fire('phantom') },
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('identifier resolution in fires arrays', () => {
+    test('resolves const identifiers in fires array', () => {
+      const code = `
+const ENTITY_CREATED = 'entity.created';
+trail('onboard', {
+  fires: [ENTITY_CREATED],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', { name: input.name });
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('dynamic fire IDs are skipped', () => {
+      const code = `
+trail('dispatch', {
+  fires: ['entity.created'],
+  blaze: async (input, ctx) => {
+    const signalId = input.target;
+    await ctx.fire(signalId, input);
+    await ctx.fire('entity.created', input);
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('multiple trails in one file are validated independently', () => {
+      const code = `
+trail('alpha', {
+  fires: ['shared.signal'],
+  blaze: async (input, ctx) => {
+    await ctx.fire('shared.signal', input);
+    return Result.ok({});
+  },
+});
+
+trail('beta', {
+  blaze: async (input, ctx) => {
+    await ctx.fire('undeclared.signal', input);
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('Trail "beta"');
+      expect(diagnostics[0]?.message).toContain("'undeclared.signal'");
+      expect(diagnostics[0]?.severity).toBe('error');
+    });
+
+    test('skips test files', () => {
+      const code = `
+trail('onboard', {
+  blaze: async (input, ctx) => {
+    await ctx.fire('entity.created', input);
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(
+        code,
+        'src/__tests__/trails.test.ts'
+      );
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('both wrong: called and undeclared, declared and unused', () => {
+      const code = `
+trail('mixed', {
+  fires: ['declared.only'],
+  blaze: async (input, ctx) => {
+    await ctx.fire('called.only', input);
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = firesDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(2);
+      const errors = diagnostics.filter((d) => d.severity === 'error');
+      const warns = diagnostics.filter((d) => d.severity === 'warn');
+      expect(errors.length).toBe(1);
+      expect(warns.length).toBe(1);
+    });
+  });
+});

--- a/packages/warden/src/__tests__/fires-declarations.test.ts
+++ b/packages/warden/src/__tests__/fires-declarations.test.ts
@@ -398,7 +398,6 @@ trail('onboard', {
       const diagnostics = firesDeclarations.check(code, TEST_FILE);
       expect(diagnostics.length).toBe(0);
     });
-
     test('nested-scope destructure does not leak to outer blaze scope', () => {
       const code = `
 trail('outer', {

--- a/packages/warden/src/__tests__/on-references-exist.test.ts
+++ b/packages/warden/src/__tests__/on-references-exist.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+
+import { onReferencesExist } from '../rules/on-references-exist.js';
+
+const TEST_FILE = 'consumer.ts';
+
+describe('on-references-exist', () => {
+  test('passes when a locally defined signal is referenced', () => {
+    const code = `
+import { signal, trail, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+const created = signal('entity.created', { payload: z.object({ id: z.string() }) });
+
+trail('notify', {
+  on: ['entity.created'],
+  input: z.object({ id: z.string() }),
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    expect(onReferencesExist.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('passes when a locally defined legacy event alias is referenced', () => {
+    const code = `
+import { event, trail, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+const created = event('entity.created', { payload: z.object({ id: z.string() }) });
+
+trail('notify', {
+  on: ['entity.created'],
+  input: z.object({ id: z.string() }),
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    expect(onReferencesExist.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('flags an on: reference missing from project context', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+trail('notify', {
+  on: ['entity.created'],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    const diagnostics = onReferencesExist.checkWithContext(code, TEST_FILE, {
+      knownSignalIds: new Set(['some.other.signal']),
+      knownTrailIds: new Set(['notify']),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('on-references-exist');
+    expect(diagnostics[0]?.severity).toBe('error');
+    expect(diagnostics[0]?.message).toContain('entity.created');
+  });
+
+  test('passes when project context includes the referenced signal', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+trail('notify', {
+  on: ['entity.created'],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    const diagnostics = onReferencesExist.checkWithContext(code, TEST_FILE, {
+      knownSignalIds: new Set(['entity.created']),
+      knownTrailIds: new Set(['notify']),
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('flags only the unresolved id when multiple references are present', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+trail('notify', {
+  on: ['entity.created', 'audit.logged'],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    const diagnostics = onReferencesExist.checkWithContext(code, TEST_FILE, {
+      knownSignalIds: new Set(['entity.created']),
+      knownTrailIds: new Set(['notify']),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('audit.logged');
+  });
+
+  test('skips trails with no on: declaration', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+trail('plain', {
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    expect(
+      onReferencesExist.checkWithContext(code, TEST_FILE, {
+        knownSignalIds: new Set(),
+        knownTrailIds: new Set(['plain']),
+      })
+    ).toEqual([]);
+  });
+
+  test('resolves const identifiers in on: array', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+const ENTITY_CREATED = 'entity.created';
+
+trail('notify', {
+  on: [ENTITY_CREATED],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    const diagnostics = onReferencesExist.checkWithContext(code, TEST_FILE, {
+      knownSignalIds: new Set(['entity.created']),
+      knownTrailIds: new Set(['notify']),
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('skips test files', () => {
+    const code = `
+trail('notify', {
+  on: ['unknown.signal'],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    expect(
+      onReferencesExist.check(code, 'src/__tests__/notify.test.ts')
+    ).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/on-references-exist.test.ts
+++ b/packages/warden/src/__tests__/on-references-exist.test.ts
@@ -146,4 +146,23 @@ trail('notify', {
       onReferencesExist.check(code, 'src/__tests__/notify.test.ts')
     ).toEqual([]);
   });
+
+  test('skips object-form Signal value references without error', () => {
+    const code = `
+import { trail, signal, Result } from '@ontrails/core';
+const orderPlaced = signal('order.placed', { payload: z.object({}) });
+trail('notify', {
+  on: [orderPlaced],
+  blaze: async (input, ctx) => Result.ok({}),
+});
+`;
+
+    // Even without registering 'order.placed' as known, the object-form entry
+    // is skipped — runtime normalization is the source of truth.
+    const diagnostics = onReferencesExist.checkWithContext(code, TEST_FILE, {
+      knownSignalIds: new Set(),
+      knownTrailIds: new Set(['notify']),
+    });
+    expect(diagnostics).toEqual([]);
+  });
 });

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 13 rule trails', () => {
-    expect(wardenTopo.count).toBe(13);
+  test('contains all 15 rule trails', () => {
+    expect(wardenTopo.count).toBe(15);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -13,6 +13,7 @@ import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
 import {
   collectProvisionDefinitionIds,
+  collectSignalDefinitionIds,
   findConfigProperty,
   findTrailDefinitions,
   parse,
@@ -147,6 +148,20 @@ const collectKnownProvisionIds = (
   }
 };
 
+const collectKnownSignalIds = (
+  sourceCode: string,
+  filePath: string,
+  knownSignalIds: Set<string>
+): void => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return;
+  }
+  for (const id of collectSignalDefinitionIds(ast)) {
+    knownSignalIds.add(id);
+  }
+};
+
 const loadSourceFiles = async (
   rootDir: string
 ): Promise<readonly SourceFile[]> => {
@@ -191,11 +206,13 @@ const collectTopoDetourTargetTrailIds = (
 const buildProjectContextFromTopo = (appTopo: Topo): ProjectContext => {
   const knownTrailIds = new Set<string>(appTopo.trails.keys());
   const knownProvisionIds = new Set<string>(appTopo.resources.keys());
+  const knownSignalIds = new Set<string>(appTopo.signals.keys());
   const detourTargetTrailIds = collectTopoDetourTargetTrailIds(appTopo);
 
   return {
     detourTargetTrailIds,
     knownProvisionIds,
+    knownSignalIds,
     knownTrailIds,
   };
 };
@@ -205,6 +222,7 @@ const buildProjectContextFromFiles = (
 ): ProjectContext => {
   const knownTrailIds = new Set<string>();
   const knownProvisionIds = new Set<string>();
+  const knownSignalIds = new Set<string>();
   const detourTargetTrailIds = new Set<string>();
 
   for (const sourceFile of sourceFiles) {
@@ -218,6 +236,11 @@ const buildProjectContextFromFiles = (
       sourceFile.filePath,
       knownProvisionIds
     );
+    collectKnownSignalIds(
+      sourceFile.sourceCode,
+      sourceFile.filePath,
+      knownSignalIds
+    );
     collectDetourTargetTrailIds(
       sourceFile.sourceCode,
       sourceFile.filePath,
@@ -228,6 +251,7 @@ const buildProjectContextFromFiles = (
   return {
     detourTargetTrailIds,
     knownProvisionIds,
+    knownSignalIds,
     knownTrailIds,
   };
 };

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -21,6 +21,8 @@ export { noThrowInImplementation } from './rules/no-throw-in-implementation.js';
 export { contextNoTrailheadTypes } from './rules/context-no-trailhead-types.js';
 export { draftFileMarking } from './rules/draft-file-marking.js';
 export { draftVisibleDebt } from './rules/draft-visible-debt.js';
+export { firesDeclarations } from './rules/fires-declarations.js';
+export { onReferencesExist } from './rules/on-references-exist.js';
 export { validDetourRefs } from './rules/valid-detour-refs.js';
 export { noDirectImplInRoute } from './rules/no-direct-impl-in-route.js';
 export { noDirectImplementationCall } from './rules/no-direct-implementation-call.js';
@@ -76,12 +78,14 @@ export {
   contextNoTrailheadTypesTrail,
   crossDeclarationsTrail,
   diagnosticSchema,
+  firesDeclarationsTrail,
   implementationReturnsResultTrail,
   noDirectImplInRouteTrail,
   noDirectImplementationCallTrail,
   noSyncResultAssumptionTrail,
   noThrowInDetourTargetTrail,
   noThrowInImplementationTrail,
+  onReferencesExistTrail,
   preferSchemaInferenceTrail,
   ruleInput,
   ruleOutput,

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -462,6 +462,24 @@ export const findBlazeBodies = (node: AstNode): AstNode[] => {
   return bodies;
 };
 
+/**
+ * Collect all `signal('id', { ... })` / `signal({ id: 'x', ... })` definition IDs.
+ *
+ * Uses `findTrailDefinitions` under the hood — it already recognizes both
+ * `trail` and `signal` call sites, distinguished by the `kind` field.
+ */
+export const collectSignalDefinitionIds = (
+  ast: AstNode
+): ReadonlySet<string> => {
+  const ids = new Set<string>();
+  for (const def of findTrailDefinitions(ast)) {
+    if (def.kind === 'signal' || def.kind === 'event') {
+      ids.add(def.id);
+    }
+  }
+  return ids;
+};
+
 // ---------------------------------------------------------------------------
 // Misc helpers
 // ---------------------------------------------------------------------------

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -149,6 +149,28 @@ export const getStringValue = (node: AstNode): string | null => {
   return typeof val === 'string' ? val : null;
 };
 
+/**
+ * Best-effort resolution of `const NAME = 'value'` declarations via regex.
+ *
+ * Returns the string value if a simple `const <name> = '...'` or `"..."` is
+ * found in the source. Returns null for anything more complex. Shared between
+ * warden rules that need to resolve identifier references to signal / trail
+ * IDs at lint time.
+ */
+export const resolveConstString = (
+  name: string,
+  sourceCode: string
+): string | null => {
+  const pattern = new RegExp(
+    `const\\s+${name}\\s*=\\s*(?:'([^']*)'|"([^"]*)")`
+  );
+  const match = pattern.exec(sourceCode);
+  if (!match) {
+    return null;
+  }
+  return match[1] ?? match[2] ?? null;
+};
+
 /** Extract a string literal value, or null when the node is not a string. */
 export const extractStringLiteral = (
   node: AstNode | undefined
@@ -318,11 +340,11 @@ export interface TrailDefinition {
 
 /**
  * Find all `trail("id", { ... })`, `trail({ id: "x", ... })`, and
- * `signal("id", { ... })` call sites.
+ * `signal("id", { ... })`, and legacy `event("id", { ... })` call sites.
  *
  * Returns the trail ID, kind, and config object node for each definition.
  */
-const TRAIL_CALLEE_NAMES = new Set(['trail', 'signal']);
+const TRAIL_CALLEE_NAMES = new Set(['event', 'signal', 'trail']);
 
 const getTrailCalleeName = (node: AstNode): string | null => {
   if (node.type !== 'CallExpression') {

--- a/packages/warden/src/rules/cross-declarations.ts
+++ b/packages/warden/src/rules/cross-declarations.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  extractFirstStringArg,
   findConfigProperty,
   findBlazeBodies,
   findTrailDefinitions,
@@ -171,21 +172,6 @@ const extractMemberPair = (
   );
 
   return objName && propName ? { objName, propName } : null;
-};
-
-/** Extract the first argument string from a CallExpression's arguments list. */
-const extractFirstStringArg = (node: AstNode): string | null => {
-  const args = node['arguments'] as readonly AstNode[] | undefined;
-  if (!args || args.length === 0) {
-    return null;
-  }
-
-  const [firstArg] = args;
-  if (!firstArg || !isStringLiteral(firstArg)) {
-    return null;
-  }
-
-  return getStringValue(firstArg);
 };
 
 /**

--- a/packages/warden/src/rules/fires-declarations.ts
+++ b/packages/warden/src/rules/fires-declarations.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  extractFirstStringArg,
   extractStringLiteral,
   findConfigProperty,
   findBlazeBodies,
@@ -151,17 +152,6 @@ const extractMemberPair = (
   );
 
   return objName && propName ? { objName, propName } : null;
-};
-
-/** Extract the first argument string from a CallExpression's arguments list. */
-const extractFirstStringArg = (node: AstNode): string | null => {
-  const args = node['arguments'] as readonly AstNode[] | undefined;
-  if (!args || args.length === 0) {
-    return null;
-  }
-
-  const [firstArg] = args;
-  return extractStringLiteral(firstArg);
 };
 
 /**

--- a/packages/warden/src/rules/fires-declarations.ts
+++ b/packages/warden/src/rules/fires-declarations.ts
@@ -40,7 +40,15 @@ const resolveIdentifierElement = (
   return resolveConstString(name, sourceCode);
 };
 
-/** Resolve an array element to a static signal ID when possible. */
+/**
+ * Resolve an array element to a static signal ID when possible.
+ *
+ * Returns null for entries the rule can't statically resolve — callers should
+ * treat "unresolved" as "trust the runtime" rather than a missing declaration.
+ * In particular, object-form references (e.g. `fires: [orderPlaced]` where
+ * `orderPlaced` is a `Signal` imported from elsewhere) resolve via runtime
+ * normalization in `trail()`, not at lint time.
+ */
 const resolveFireElementId = (
   element: AstNode,
   sourceCode: string
@@ -79,28 +87,46 @@ const getFiresElements = (config: AstNode): readonly AstNode[] | null => {
   return elements ?? null;
 };
 
-/** Collect string IDs from array elements, resolving identifiers when possible. */
-const collectStringIds = (
+interface DeclaredFires {
+  /** Statically resolved signal ids from string literals / const identifiers. */
+  readonly ids: ReadonlySet<string>;
+  /** True if any element could not be statically resolved (e.g. Signal value). */
+  readonly hasUnresolved: boolean;
+}
+
+/**
+ * Extract declared fires from a `fires: [...]` array.
+ *
+ * Object-form entries (`fires: [someSignal]`) cannot be resolved at lint time;
+ * they're normalized at runtime by `trail()`. When any entry is unresolved,
+ * the rule reports `hasUnresolved: true`, and callers should suppress the
+ * "undeclared" diagnostic since the declared set is incomplete from our view.
+ */
+const resolveDeclaredFiresElements = (
   elements: readonly AstNode[],
   sourceCode: string
-): Set<string> => {
+): DeclaredFires => {
   const ids = new Set<string>();
+  let hasUnresolved = false;
   for (const element of elements) {
     const resolved = resolveFireElementId(element, sourceCode);
     if (resolved) {
       ids.add(resolved);
+    } else {
+      hasUnresolved = true;
     }
   }
-  return ids;
+  return { hasUnresolved, ids };
 };
 
-/** Extract string literal elements from a `fires: [...]` array property. */
 const extractDeclaredFires = (
   config: AstNode,
   sourceCode: string
-): ReadonlySet<string> => {
+): DeclaredFires => {
   const elements = getFiresElements(config);
-  return elements ? collectStringIds(elements, sourceCode) : new Set();
+  return elements
+    ? resolveDeclaredFiresElements(elements, sourceCode)
+    : { hasUnresolved: false, ids: new Set() };
 };
 
 // ---------------------------------------------------------------------------
@@ -164,30 +190,173 @@ const isMemberFireCall = (
 /**
  * Check if a node is a `<ctxName>.fire(...)` call and return the string signal ID.
  *
- * Also matches bare `fire(...)` calls from destructuring.
+ * Also matches bare `<fireLocalName>(...)` calls, but only when the local name
+ * was verifiably destructured from the trail context (e.g. `const { fire } = ctx`
+ * or `const { fire: emit } = ctx`). Unrelated local `fire()` helpers are
+ * ignored — see `collectDestructuredFireNames`.
  */
+const isTrackedFireCallee = (
+  callee: AstNode,
+  ctxNames: ReadonlySet<string>,
+  fireLocalNames: ReadonlySet<string>
+): boolean => {
+  if (isMemberFireCall(callee, ctxNames)) {
+    return true;
+  }
+  const calleeName = identifierName(callee);
+  return !!calleeName && fireLocalNames.has(calleeName);
+};
+
 const extractFireCallId = (
   node: AstNode,
-  ctxNames: ReadonlySet<string>
+  ctxNames: ReadonlySet<string>,
+  fireLocalNames: ReadonlySet<string>
 ): string | null => {
   if (node.type !== 'CallExpression') {
     return null;
   }
-
   const callee = node['callee'] as AstNode | undefined;
   if (!callee) {
     return null;
   }
+  return isTrackedFireCallee(callee, ctxNames, fireLocalNames)
+    ? extractFirstStringArg(node)
+    : null;
+};
 
-  if (isMemberFireCall(callee, ctxNames)) {
-    return extractFirstStringArg(node);
+/**
+ * Walk a blaze body and collect local names bound to `ctx.fire` via destructure.
+ *
+ * Recognizes:
+ *   - `const { fire } = ctx;` → adds `fire`
+ *   - `const { fire: emit } = context;` → adds `emit`
+ *
+ * Only destructures whose init is one of the tracked ctx parameter names are
+ * accepted. This prevents unrelated local `fire` helpers from being treated as
+ * calls into the trail context.
+ */
+/** Extract the local name bound to `fire` inside an ObjectPattern Property. */
+const extractFireLocalName = (prop: AstNode): string | null => {
+  if (prop.type !== 'Property') {
+    return null;
   }
-
-  if (identifierName(callee) === 'fire') {
-    return extractFirstStringArg(node);
+  const { key } = prop as unknown as { key?: AstNode };
+  const { value } = prop as unknown as { value?: AstNode };
+  const keyName = identifierName(key);
+  if (keyName !== 'fire') {
+    return null;
   }
+  // `{ fire }` → key and value are the same Identifier (shorthand).
+  // `{ fire: emit }` → value is a distinct Identifier.
+  return identifierName(value) ?? keyName;
+};
 
-  return null;
+/** Collect `fire` local names from an ObjectPattern's properties into `names`. */
+const collectFireNamesFromPattern = (
+  pattern: AstNode,
+  names: Set<string>
+): void => {
+  const { properties } = pattern as unknown as {
+    properties?: readonly AstNode[];
+  };
+  if (!properties) {
+    return;
+  }
+  for (const prop of properties) {
+    const localName = extractFireLocalName(prop);
+    if (localName) {
+      names.add(localName);
+    }
+  }
+};
+
+/** Check if a VariableDeclarator destructures from a known ctx identifier. */
+const getCtxDestructurePattern = (
+  node: AstNode,
+  ctxNames: ReadonlySet<string>
+): AstNode | null => {
+  if (node.type !== 'VariableDeclarator') {
+    return null;
+  }
+  const { id, init } = node as unknown as {
+    readonly id?: AstNode;
+    readonly init?: AstNode;
+  };
+  if (!id || id.type !== 'ObjectPattern' || !init) {
+    return null;
+  }
+  const initName = identifierName(init);
+  if (!initName || !ctxNames.has(initName)) {
+    return null;
+  }
+  return id;
+};
+
+/**
+ * Collect `fire` local names destructured from ctx at the TOP LEVEL of the
+ * blaze body. Destructures inside nested functions are intentionally ignored
+ * to avoid leaking nested-scope bindings into the outer blaze scope — a
+ * `const { fire } = ctx` inside a nested helper should not cause an outer
+ * bare `fire('x')` to be treated as a ctx-bound call.
+ *
+ * Tradeoff: nested-scope destructures lose tracking entirely. Calls inside
+ * nested functions that rely on their own destructure will not be analyzed.
+ * This is a conservative precision loss; a full scope walker is a follow-up.
+ *
+ * Tradeoff: only `const` destructures are tracked. `let` and `var` bindings
+ * allow reassignment (`let { fire } = ctx; fire = other; fire('x')`) which
+ * this flow-insensitive walker cannot follow. Skipping them trades a small
+ * amount of precision — `let { fire } = ctx` is rare — for eliminating a
+ * class of false positives. The runtime + signal-id cross-check still
+ * validate real undeclared fires.
+ */
+/** Get the top-level statements of a blaze function's BlockStatement body. */
+const getTopLevelStatements = (body: AstNode): readonly AstNode[] => {
+  const blockBody = (body as unknown as { body?: AstNode }).body;
+  if (!blockBody || blockBody.type !== 'BlockStatement') {
+    return [];
+  }
+  return (blockBody as unknown as { body?: readonly AstNode[] }).body ?? [];
+};
+
+/** Collect fire-local names from a single top-level VariableDeclaration. */
+const collectFireNamesFromDeclaration = (
+  stmt: AstNode,
+  ctxNames: ReadonlySet<string>,
+  names: Set<string>
+): void => {
+  if (stmt.type !== 'VariableDeclaration') {
+    return;
+  }
+  // Only track `const` destructures. `let` and `var` allow reassignment that
+  // a single-pass walker cannot track, so `let { fire } = ctx; fire = other;
+  // fire('x')` would otherwise be a false positive. Skipping non-const is a
+  // small precision loss (see TSDoc on `collectDestructuredFireNames`) in
+  // exchange for eliminating that class of false positives.
+  const { kind } = stmt as unknown as { kind?: string };
+  if (kind !== 'const') {
+    return;
+  }
+  const declarations =
+    (stmt as unknown as { declarations?: readonly AstNode[] }).declarations ??
+    [];
+  for (const decl of declarations) {
+    const pattern = getCtxDestructurePattern(decl, ctxNames);
+    if (pattern) {
+      collectFireNamesFromPattern(pattern, names);
+    }
+  }
+};
+
+const collectDestructuredFireNames = (
+  body: AstNode,
+  ctxNames: ReadonlySet<string>
+): ReadonlySet<string> => {
+  const names = new Set<string>();
+  for (const stmt of getTopLevelStatements(body)) {
+    collectFireNamesFromDeclaration(stmt, ctxNames, names);
+  }
+  return names;
 };
 
 /**
@@ -236,9 +405,10 @@ const extractCalledFires = (config: AstNode): ReadonlySet<string> => {
 
   for (const body of findBlazeBodies(config)) {
     const ctxNames = buildCtxNames(body);
+    const fireLocalNames = collectDestructuredFireNames(body, ctxNames);
 
     walkScope(body, (node) => {
-      const id = extractFireCallId(node, ctxNames);
+      const id = extractFireCallId(node, ctxNames, fireLocalNames);
       if (id) {
         ids.add(id);
       }
@@ -337,15 +507,25 @@ const checkTrailDefinition = (
   const declared = extractDeclaredFires(def.config, sourceCode);
   const called = extractCalledFires(def.config);
 
-  if (declared.size === 0 && called.size === 0) {
+  if (declared.ids.size === 0 && !declared.hasUnresolved && called.size === 0) {
     return;
   }
 
   const line = offsetToLine(sourceCode, def.start);
   const ctx = { filePath, line, trailId: def.id };
 
-  reportUndeclared(called, declared, ctx, diagnostics);
-  reportUnused(declared, called, ctx, diagnostics);
+  // When the declared array contains object-form references we can't resolve,
+  // downgrade "undeclared" diagnostics from error to warn with a disclaimer
+  // instead of suppressing entirely. The developer still sees genuinely
+  // undeclared calls, but we can't statically prove the call isn't covered by
+  // a Signal-value entry the runtime will normalize.
+  reportUndeclared(
+    called,
+    declared.ids,
+    { ...ctx, softened: declared.hasUnresolved },
+    diagnostics
+  );
+  reportUnused(declared.ids, called, ctx, diagnostics);
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/warden/src/rules/fires-declarations.ts
+++ b/packages/warden/src/rules/fires-declarations.ts
@@ -1,0 +1,381 @@
+/**
+ * Validates that `ctx.fire()` calls match the declared `fires` array.
+ *
+ * Statically analyzes trail `blaze` functions to find `ctx.fire('signalId', ...)`
+ * calls and compares them against the `fires: [...]` declaration in the trail
+ * config. Reports errors for undeclared fires and warnings for unused ones.
+ *
+ * Mirrors `cross-declarations` structurally — same extraction, same reporting
+ * shape, same const-identifier resolution, same context-parameter handling.
+ */
+
+import {
+  extractStringLiteral,
+  findConfigProperty,
+  findBlazeBodies,
+  findTrailDefinitions,
+  identifierName,
+  offsetToLine,
+  parse,
+  resolveConstString,
+  walkScope,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Const identifier resolution
+// ---------------------------------------------------------------------------
+
+/** Try to resolve an Identifier element to a string via const declaration. */
+const resolveIdentifierElement = (
+  el: AstNode,
+  sourceCode: string
+): string | null => {
+  const name = identifierName(el);
+  if (!name) {
+    return null;
+  }
+  return resolveConstString(name, sourceCode);
+};
+
+/** Resolve an array element to a static signal ID when possible. */
+const resolveFireElementId = (
+  element: AstNode,
+  sourceCode: string
+): string | null => {
+  const literalValue = extractStringLiteral(element);
+  if (literalValue !== null) {
+    return literalValue;
+  }
+
+  if (element.type === 'Identifier') {
+    return resolveIdentifierElement(element, sourceCode);
+  }
+
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Declared fires extraction
+// ---------------------------------------------------------------------------
+
+/** Extract the ArrayExpression elements from a config's `fires` property. */
+const getFiresElements = (config: AstNode): readonly AstNode[] | null => {
+  const firesProp = findConfigProperty(config, 'fires');
+  if (!firesProp) {
+    return null;
+  }
+
+  const arrayNode = firesProp.value;
+  if (!arrayNode || (arrayNode as AstNode).type !== 'ArrayExpression') {
+    return null;
+  }
+
+  const elements = (arrayNode as AstNode)['elements'] as
+    | readonly AstNode[]
+    | undefined;
+  return elements ?? null;
+};
+
+/** Collect string IDs from array elements, resolving identifiers when possible. */
+const collectStringIds = (
+  elements: readonly AstNode[],
+  sourceCode: string
+): Set<string> => {
+  const ids = new Set<string>();
+  for (const element of elements) {
+    const resolved = resolveFireElementId(element, sourceCode);
+    if (resolved) {
+      ids.add(resolved);
+    }
+  }
+  return ids;
+};
+
+/** Extract string literal elements from a `fires: [...]` array property. */
+const extractDeclaredFires = (
+  config: AstNode,
+  sourceCode: string
+): ReadonlySet<string> => {
+  const elements = getFiresElements(config);
+  return elements ? collectStringIds(elements, sourceCode) : new Set();
+};
+
+// ---------------------------------------------------------------------------
+// Called fires extraction — member expression helpers
+// ---------------------------------------------------------------------------
+
+const MEMBER_TYPES = new Set(['StaticMemberExpression', 'MemberExpression']);
+
+/** Extract object and property Identifier names from a MemberExpression. */
+const extractMemberPair = (
+  callee: AstNode
+): { objName: string; propName: string } | null => {
+  if (!MEMBER_TYPES.has(callee.type)) {
+    return null;
+  }
+
+  const objName = identifierName(
+    (callee as unknown as { object?: AstNode }).object
+  );
+  const propName = identifierName(
+    (callee as unknown as { property?: AstNode }).property
+  );
+
+  return objName && propName ? { objName, propName } : null;
+};
+
+/** Extract the first argument string from a CallExpression's arguments list. */
+const extractFirstStringArg = (node: AstNode): string | null => {
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  if (!args || args.length === 0) {
+    return null;
+  }
+
+  const [firstArg] = args;
+  return extractStringLiteral(firstArg);
+};
+
+/**
+ * Extract the second parameter name from a blaze function node.
+ *
+ * Handles `(input, ctx) => ...`, `async (input, context) => ...`, and
+ * `function(input, ctx) { ... }` forms.
+ */
+const extractContextParamName = (blazeBody: AstNode): string | null => {
+  const params = blazeBody['params'] as readonly AstNode[] | undefined;
+  if (!params || params.length < 2) {
+    return null;
+  }
+  return identifierName(params[1]);
+};
+
+/** Check if a callee is a member-style fire call: <ctxName>.fire(...). */
+const isMemberFireCall = (
+  callee: AstNode,
+  ctxNames: ReadonlySet<string>
+): boolean => {
+  const pair = extractMemberPair(callee);
+  return !!pair && ctxNames.has(pair.objName) && pair.propName === 'fire';
+};
+
+/**
+ * Check if a node is a `<ctxName>.fire(...)` call and return the string signal ID.
+ *
+ * Also matches bare `fire(...)` calls from destructuring.
+ */
+const extractFireCallId = (
+  node: AstNode,
+  ctxNames: ReadonlySet<string>
+): string | null => {
+  if (node.type !== 'CallExpression') {
+    return null;
+  }
+
+  const callee = node['callee'] as AstNode | undefined;
+  if (!callee) {
+    return null;
+  }
+
+  if (isMemberFireCall(callee, ctxNames)) {
+    return extractFirstStringArg(node);
+  }
+
+  if (identifierName(callee) === 'fire') {
+    return extractFirstStringArg(node);
+  }
+
+  return null;
+};
+
+/**
+ * Build the set of context parameter names to match against.
+ *
+ * Returns ONLY the actual second-parameter name from the blaze signature.
+ * No seeded defaults: if the blaze has no second parameter, the returned set
+ * is empty and no `ctx.fire(...)` / `context.fire(...)` calls are tracked
+ * for that blaze. An unrelated closure-scoped `ctx` identifier is not the
+ * trail context and must not be treated as one.
+ */
+const buildCtxNames = (body: AstNode): ReadonlySet<string> => {
+  const ctxNames = new Set<string>();
+  const paramName = extractContextParamName(body);
+  if (paramName) {
+    ctxNames.add(paramName);
+  }
+  return ctxNames;
+};
+
+/**
+ * Walk blaze bodies and collect all statically resolvable ctx.fire() signal IDs.
+ *
+ * Traversal uses `walkScope`, which stops at nested function boundaries
+ * (FunctionDeclaration, FunctionExpression, ArrowFunctionExpression). This
+ * mirrors the top-level-only behavior of `collectDestructuredFireNames` and
+ * avoids false positives when a nested function parameter shadows `ctx` or a
+ * destructured `fire` local:
+ *
+ * ```ts
+ * blaze: async (_, ctx) => {
+ *   const { fire } = ctx;
+ *   function nested(fire) { fire('shadow'); } // ignored — shadowed
+ *   function other(ctx)  { ctx.fire('x'); }   // ignored — shadowed
+ *   return Result.ok({});
+ * }
+ * ```
+ *
+ * Tradeoff: legitimate `ctx.fire(...)` calls inside nested helpers are not
+ * statically analyzed. The runtime + signal-id cross-check still validate
+ * them; the warden just can't prove them at lint time. A full scope walker is
+ * a follow-up if this precision loss becomes meaningful in practice.
+ */
+const extractCalledFires = (config: AstNode): ReadonlySet<string> => {
+  const ids = new Set<string>();
+
+  for (const body of findBlazeBodies(config)) {
+    const ctxNames = buildCtxNames(body);
+
+    walkScope(body, (node) => {
+      const id = extractFireCallId(node, ctxNames);
+      if (id) {
+        ids.add(id);
+      }
+    });
+  }
+
+  return ids;
+};
+
+// ---------------------------------------------------------------------------
+// Diagnostic builders
+// ---------------------------------------------------------------------------
+
+const buildUndeclaredDiagnostic = (
+  trailId: string,
+  signalId: string,
+  filePath: string,
+  line: number,
+  softened = false
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: softened
+    ? `Trail "${trailId}": ctx.fire('${signalId}') called but '${signalId}' is not declared in fires (may be declared via object-form fires entries)`
+    : `Trail "${trailId}": ctx.fire('${signalId}') called but '${signalId}' is not declared in fires`,
+  rule: 'fires-declarations',
+  severity: softened ? 'warn' : 'error',
+});
+
+const buildUnusedDiagnostic = (
+  trailId: string,
+  signalId: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}": '${signalId}' declared in fires but ctx.fire('${signalId}') never called`,
+  rule: 'fires-declarations',
+  severity: 'warn',
+});
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+/** Emit error for each called ID not present in declared set. */
+const reportUndeclared = (
+  called: ReadonlySet<string>,
+  declared: ReadonlySet<string>,
+  ctx: {
+    trailId: string;
+    filePath: string;
+    line: number;
+    softened?: boolean;
+  },
+  diagnostics: WardenDiagnostic[]
+): void => {
+  for (const id of called) {
+    if (!declared.has(id)) {
+      diagnostics.push(
+        buildUndeclaredDiagnostic(
+          ctx.trailId,
+          id,
+          ctx.filePath,
+          ctx.line,
+          ctx.softened
+        )
+      );
+    }
+  }
+};
+
+/** Emit warning for each declared ID not present in called set. */
+const reportUnused = (
+  declared: ReadonlySet<string>,
+  called: ReadonlySet<string>,
+  ctx: { trailId: string; filePath: string; line: number },
+  diagnostics: WardenDiagnostic[]
+): void => {
+  for (const id of declared) {
+    if (!called.has(id)) {
+      diagnostics.push(
+        buildUnusedDiagnostic(ctx.trailId, id, ctx.filePath, ctx.line)
+      );
+    }
+  }
+};
+
+const checkTrailDefinition = (
+  def: { id: string; config: AstNode; start: number },
+  filePath: string,
+  sourceCode: string,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  const declared = extractDeclaredFires(def.config, sourceCode);
+  const called = extractCalledFires(def.config);
+
+  if (declared.size === 0 && called.size === 0) {
+    return;
+  }
+
+  const line = offsetToLine(sourceCode, def.start);
+  const ctx = { filePath, line, trailId: def.id };
+
+  reportUndeclared(called, declared, ctx, diagnostics);
+  reportUnused(declared, called, ctx, diagnostics);
+};
+
+// ---------------------------------------------------------------------------
+// Rule
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates that `ctx.fire()` calls align with declared `fires` arrays.
+ */
+export const firesDeclarations: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isTestFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const diagnostics: WardenDiagnostic[] = [];
+
+    for (const def of findTrailDefinitions(ast)) {
+      checkTrailDefinition(def, filePath, sourceCode, diagnostics);
+    }
+
+    return diagnostics;
+  },
+  description:
+    'Ensure ctx.fire() calls match the declared fires array in trail definitions.',
+  name: 'fires-declarations',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/fires-declarations.ts
+++ b/packages/warden/src/rules/fires-declarations.ts
@@ -165,17 +165,83 @@ const extractFirstStringArg = (node: AstNode): string | null => {
 };
 
 /**
- * Extract the second parameter name from a blaze function node.
+ * Extract the second parameter node from a blaze function node.
  *
- * Handles `(input, ctx) => ...`, `async (input, context) => ...`, and
- * `function(input, ctx) { ... }` forms.
+ * Handles `(input, ctx) => ...`, `async (input, context) => ...`,
+ * `function(input, ctx) { ... }`, and parameter-level destructuring
+ * like `(input, { fire }) => ...`.
  */
-const extractContextParamName = (blazeBody: AstNode): string | null => {
+const extractContextParamNode = (blazeBody: AstNode): AstNode | null => {
   const params = blazeBody['params'] as readonly AstNode[] | undefined;
   if (!params || params.length < 2) {
     return null;
   }
-  return identifierName(params[1]);
+  return params[1] ?? null;
+};
+
+/** Extract the local name bound to `fire` inside an ObjectPattern Property. */
+const extractFireLocalName = (prop: AstNode): string | null => {
+  if (prop.type !== 'Property') {
+    return null;
+  }
+  const { key } = prop as unknown as { key?: AstNode };
+  const { value } = prop as unknown as { value?: AstNode };
+  const keyName = identifierName(key);
+  if (keyName !== 'fire') {
+    return null;
+  }
+  // `{ fire }` → key and value are the same Identifier (shorthand).
+  // `{ fire: emit }` → value is a distinct Identifier.
+  return identifierName(value) ?? keyName;
+};
+
+/** Collect `fire` local names from an ObjectPattern's properties into `names`. */
+const collectFireNamesFromPattern = (
+  pattern: AstNode,
+  names: Set<string>
+): void => {
+  const { properties } = pattern as unknown as {
+    properties?: readonly AstNode[];
+  };
+  if (!properties) {
+    return;
+  }
+  for (const prop of properties) {
+    const localName = extractFireLocalName(prop);
+    if (localName) {
+      names.add(localName);
+    }
+  }
+};
+
+/**
+ * Extract the second parameter name from a blaze function node.
+ *
+ * Returns null when the parameter is not a plain Identifier (e.g. when the
+ * author destructures `{ fire }` in the parameter list). Parameter-level
+ * destructuring is handled separately by `collectParamFireNames`.
+ */
+const extractContextParamName = (blazeBody: AstNode): string | null => {
+  const param = extractContextParamNode(blazeBody);
+  return param ? identifierName(param) : null;
+};
+
+/**
+ * Collect `fire` local names bound via parameter-level destructuring.
+ *
+ * Recognizes `(input, { fire }) => ...` and `(input, { fire: emit }) => ...`.
+ * When the blaze author destructures in the parameter list, there is no
+ * enclosing `ctx` identifier to track — we seed the fire local set directly
+ * from the ObjectPattern in `params[1]`.
+ */
+const collectParamFireNames = (body: AstNode): ReadonlySet<string> => {
+  const param = extractContextParamNode(body);
+  if (!param || param.type !== 'ObjectPattern') {
+    return new Set();
+  }
+  const names = new Set<string>();
+  collectFireNamesFromPattern(param, names);
+  return names;
 };
 
 /** Check if a callee is a member-style fire call: <ctxName>.fire(...). */
@@ -235,41 +301,6 @@ const extractFireCallId = (
  * accepted. This prevents unrelated local `fire` helpers from being treated as
  * calls into the trail context.
  */
-/** Extract the local name bound to `fire` inside an ObjectPattern Property. */
-const extractFireLocalName = (prop: AstNode): string | null => {
-  if (prop.type !== 'Property') {
-    return null;
-  }
-  const { key } = prop as unknown as { key?: AstNode };
-  const { value } = prop as unknown as { value?: AstNode };
-  const keyName = identifierName(key);
-  if (keyName !== 'fire') {
-    return null;
-  }
-  // `{ fire }` → key and value are the same Identifier (shorthand).
-  // `{ fire: emit }` → value is a distinct Identifier.
-  return identifierName(value) ?? keyName;
-};
-
-/** Collect `fire` local names from an ObjectPattern's properties into `names`. */
-const collectFireNamesFromPattern = (
-  pattern: AstNode,
-  names: Set<string>
-): void => {
-  const { properties } = pattern as unknown as {
-    properties?: readonly AstNode[];
-  };
-  if (!properties) {
-    return;
-  }
-  for (const prop of properties) {
-    const localName = extractFireLocalName(prop);
-    if (localName) {
-      names.add(localName);
-    }
-  }
-};
-
 /** Check if a VariableDeclarator destructures from a known ctx identifier. */
 const getCtxDestructurePattern = (
   node: AstNode,
@@ -405,7 +436,12 @@ const extractCalledFires = (config: AstNode): ReadonlySet<string> => {
 
   for (const body of findBlazeBodies(config)) {
     const ctxNames = buildCtxNames(body);
-    const fireLocalNames = collectDestructuredFireNames(body, ctxNames);
+    const bodyFireNames = collectDestructuredFireNames(body, ctxNames);
+    const paramFireNames = collectParamFireNames(body);
+    const fireLocalNames = new Set<string>([
+      ...bodyFireNames,
+      ...paramFireNames,
+    ]);
 
     walkScope(body, (node) => {
       const id = extractFireCallId(node, ctxNames, fireLocalNames);

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -2,12 +2,14 @@ import { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 import { crossDeclarations } from './cross-declarations.js';
 import { draftFileMarking } from './draft-file-marking.js';
 import { draftVisibleDebt } from './draft-visible-debt.js';
+import { firesDeclarations } from './fires-declarations.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
 import { noDirectImplInRoute } from './no-direct-impl-in-route.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
+import { onReferencesExist } from './on-references-exist.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
 import { provisionDeclarations } from './resource-declarations.js';
 import { provisionExists } from './resource-exists.js';
@@ -28,6 +30,8 @@ export { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 export { crossDeclarations } from './cross-declarations.js';
 export { draftFileMarking } from './draft-file-marking.js';
 export { draftVisibleDebt } from './draft-visible-debt.js';
+export { firesDeclarations } from './fires-declarations.js';
+export { onReferencesExist } from './on-references-exist.js';
 export { validDetourRefs } from './valid-detour-refs.js';
 export { noDirectImplInRoute } from './no-direct-impl-in-route.js';
 export { noDirectImplementationCall } from './no-direct-implementation-call.js';
@@ -49,6 +53,8 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [crossDeclarations.name, crossDeclarations],
   [draftFileMarking.name, draftFileMarking],
   [draftVisibleDebt.name, draftVisibleDebt],
+  [firesDeclarations.name, firesDeclarations],
+  [onReferencesExist.name, onReferencesExist],
   [provisionDeclarations.name, provisionDeclarations],
   [provisionExists.name, provisionExists],
   [preferSchemaInference.name, preferSchemaInference],

--- a/packages/warden/src/rules/on-references-exist.ts
+++ b/packages/warden/src/rules/on-references-exist.ts
@@ -1,0 +1,184 @@
+/**
+ * Validates that every signal id declared in a trail's `on:` array resolves
+ * to a known signal definition somewhere in the project.
+ *
+ * Mirrors `resource-exists` structurally — collects local signal definitions
+ * for the standalone `check()` path and accepts a project-wide
+ * `knownSignalIds` set via `checkWithContext()`.
+ */
+
+import { isDraftId } from '@ontrails/core';
+
+import {
+  collectSignalDefinitionIds,
+  findConfigProperty,
+  findTrailDefinitions,
+  getStringValue,
+  identifierName,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  resolveConstString,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Declared `on:` extraction
+// ---------------------------------------------------------------------------
+
+const getOnElements = (config: AstNode): readonly AstNode[] => {
+  const onProp = findConfigProperty(config, 'on');
+  if (!onProp) {
+    return [];
+  }
+
+  const arrayNode = onProp.value;
+  if (!arrayNode || (arrayNode as AstNode).type !== 'ArrayExpression') {
+    return [];
+  }
+
+  const elements = (arrayNode as AstNode)['elements'] as
+    | readonly AstNode[]
+    | undefined;
+  return elements ?? [];
+};
+
+const extractOnElementId = (
+  element: AstNode,
+  sourceCode: string
+): string | null => {
+  if (element.type === 'Identifier') {
+    const name = identifierName(element);
+    return name ? resolveConstString(name, sourceCode) : null;
+  }
+
+  if (isStringLiteral(element)) {
+    return getStringValue(element);
+  }
+
+  return null;
+};
+
+const extractDeclaredOnIds = (
+  config: AstNode,
+  sourceCode: string
+): readonly string[] => [
+  ...new Set(
+    getOnElements(config).flatMap((element) => {
+      const id = extractOnElementId(element, sourceCode);
+      return id ? [id] : [];
+    })
+  ),
+];
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+const buildMissingSignalDiagnostic = (
+  trailId: string,
+  signalId: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}" declares on: "${signalId}" which is not a known signal in the project.`,
+  rule: 'on-references-exist',
+  severity: 'error',
+});
+
+const reportMissingSignals = (
+  def: { id: string; config: AstNode; start: number },
+  sourceCode: string,
+  filePath: string,
+  knownSignalIds: ReadonlySet<string>,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  const line = offsetToLine(sourceCode, def.start);
+  for (const signalId of extractDeclaredOnIds(def.config, sourceCode)) {
+    if (!knownSignalIds.has(signalId) && !isDraftId(signalId)) {
+      diagnostics.push(
+        buildMissingSignalDiagnostic(def.id, signalId, filePath, line)
+      );
+    }
+  }
+};
+
+const buildSignalDiagnostics = (
+  ast: AstNode,
+  sourceCode: string,
+  filePath: string,
+  knownSignalIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+  for (const def of findTrailDefinitions(ast)) {
+    if (def.kind !== 'trail') {
+      continue;
+    }
+    reportMissingSignals(
+      def,
+      sourceCode,
+      filePath,
+      knownSignalIds,
+      diagnostics
+    );
+  }
+  return diagnostics;
+};
+
+const checkOnReferences = (
+  ast: AstNode | null,
+  sourceCode: string,
+  filePath: string,
+  knownSignalIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath) || !ast) {
+    return [];
+  }
+  return buildSignalDiagnostics(ast, sourceCode, filePath, knownSignalIds);
+};
+
+/**
+ * Checks that every `on:` reference resolves to a known signal definition.
+ */
+export const onReferencesExist: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+    return checkOnReferences(
+      ast,
+      sourceCode,
+      filePath,
+      collectSignalDefinitionIds(ast)
+    );
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    const localSignalIds = ast
+      ? collectSignalDefinitionIds(ast)
+      : new Set<string>();
+    return checkOnReferences(
+      ast,
+      sourceCode,
+      filePath,
+      context.knownSignalIds ?? localSignalIds
+    );
+  },
+  description:
+    'Ensure every signal id declared in a trail on: array resolves to a known signal definition.',
+  name: 'on-references-exist',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/on-references-exist.ts
+++ b/packages/warden/src/rules/on-references-exist.ts
@@ -49,6 +49,16 @@ const getOnElements = (config: AstNode): readonly AstNode[] => {
   return elements ?? [];
 };
 
+/**
+ * Resolve an `on:` array element to a signal id when possible.
+ *
+ * Handles string literals and `const NAME = 'id'` identifier references.
+ * Object-form entries (e.g. `on: [someSignal]` where `someSignal` is a
+ * `Signal` value) cannot be statically resolved here and are skipped — the
+ * runtime normalizes them inside `trail()`, so skipping is safe. The tradeoff
+ * is that typo'd Signal imports won't be caught at lint time; the TypeScript
+ * compiler catches those instead.
+ */
 const extractOnElementId = (
   element: AstNode,
   sourceCode: string

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -47,6 +47,8 @@ export interface ProjectContext {
   readonly knownTrailIds: ReadonlySet<string>;
   /** All known resource IDs in the project */
   readonly knownProvisionIds?: ReadonlySet<string>;
+  /** All known signal IDs in the project */
+  readonly knownSignalIds?: ReadonlySet<string>;
   /** All trail IDs referenced as detour targets across the project */
   readonly detourTargetTrailIds?: ReadonlySet<string>;
 }

--- a/packages/warden/src/trails/fires-declarations.trail.ts
+++ b/packages/warden/src/trails/fires-declarations.trail.ts
@@ -1,0 +1,22 @@
+import { firesDeclarations } from '../rules/fires-declarations.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const firesDeclarationsTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        sourceCode: `trail("entity.onboard", {
+  fires: ["entity.created"],
+  blaze: async (input, ctx) => {
+    await ctx.fire("entity.created", { id: input.id });
+    return Result.ok({});
+  }
+})`,
+      },
+      name: 'Matched fires declarations and calls',
+    },
+  ],
+  rule: firesDeclarations,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -1,6 +1,8 @@
 export { contextNoTrailheadTypesTrail } from './context-no-trailhead-types.trail.js';
 export { crossDeclarationsTrail } from './cross-declarations.trail.js';
+export { firesDeclarationsTrail } from './fires-declarations.trail.js';
 export { implementationReturnsResultTrail } from './implementation-returns-result.trail.js';
+export { onReferencesExistTrail } from './on-references-exist.trail.js';
 export { noDirectImplInRouteTrail } from './no-direct-impl-in-route.trail.js';
 export { noDirectImplementationCallTrail } from './no-direct-implementation-call.trail.js';
 export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.js';

--- a/packages/warden/src/trails/on-references-exist.trail.ts
+++ b/packages/warden/src/trails/on-references-exist.trail.ts
@@ -1,0 +1,21 @@
+import { onReferencesExist } from '../rules/on-references-exist.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const onReferencesExistTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'consumer.ts',
+        knownSignalIds: ['entity.created'],
+        knownTrailIds: ['notify'],
+        sourceCode: `trail("notify", {
+  on: ["entity.created"],
+  blaze: async (input, ctx) => Result.ok({}),
+})`,
+      },
+      name: 'Resolved on: reference',
+    },
+  ],
+  rule: onReferencesExist,
+});

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -34,6 +34,10 @@ export const projectAwareRuleInput = ruleInput.extend({
     .array(z.string())
     .optional()
     .describe('Resource IDs known across the project'),
+  knownSignalIds: z
+    .array(z.string())
+    .optional()
+    .describe('Signal IDs known across the project'),
   knownTrailIds: z
     .array(z.string())
     .optional()

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -54,6 +54,9 @@ export function wrapRule(
           knownProvisionIds: input.knownProvisionIds
             ? new Set(input.knownProvisionIds)
             : undefined,
+          knownSignalIds: input.knownSignalIds
+            ? new Set(input.knownSignalIds)
+            : undefined,
           knownTrailIds: input.knownTrailIds
             ? new Set(input.knownTrailIds)
             : new Set<string>(),


### PR DESCRIPTION
## TRL-197 (core): fires:/on: signal activation runtime

Implements the producer-side `fires:` and consumer-side `on:` fields on the trail spec, with the runtime emission API, the warden parity rules, end-to-end dogfooding, and Codex review fixes folded in. Mirrors the `crosses:` pattern exactly — no new primitives.

This is the first of two TRL-197 PRs. The second (`trl-197-fires-on-tail`, #103) lands the persisted topo edges and the `ctx.fire(Signal, payload)` generic overload, both of which depend on TRL-198 (#98) being in place first.

### Commits (4)

1. **`feat(core): fires:/on: signal activation runtime`** — `TrailSpec` gains `fires?` and `on?` (signal IDs OR Signal values, normalized at trail() factory time). `TrailContext` gains `fire?: FireFn`. New `packages/core/src/fire.ts` with `createFireFn(topo)` building a self-referential closure. `run.ts` binds fire on the context before delegating to `executeTrail`. 6 tests covering happy path, no-consumer no-op, unknown signal, bad payload, consumer error isolation, unbound-without-topo.

2. **`feat(warden): fires-declarations and on-references-exist parity rules`** — mirrors `cross-declarations.ts` and `resource-exists.ts`. AST-walks blaze bodies for `ctx.fire('id')` calls and diffs against `fires:`. Verifies every `on:` reference resolves against the topo via `knownSignalIds` (project-aware). 24 new tests across both rules. Plumbs `knownSignalIds` through warden CLI / project context / wrap-rule / Zod schema.

3. **`feat(trails-demo): exercise fires:/on: end-to-end`** — wires the existing (previously unused) `entity.updated` signal into a real producer→consumer flow. `entity.add` and `entity.delete` now declare `fires: ['entity.updated']` and call `ctx.fire`. New `entity.notify-updated` consumer with `on: ['entity.updated']`. New integration test exercises the full flow + warden rule coverage.

4. **`fix(core,warden,demo): apply Codex review feedback`** — addresses 9 findings across 4 Codex review passes:
   - **P1**: `TrailSpec.fires`/`on` accept Signal values (`fires: [orderPlaced]`), restoring one-write-many-reads parity with `ctx.fire(orderPlaced, payload)`. Normalized via `normalizeSignalRef` at factory time so frozen `Trail.fires`/`on` stay `readonly string[]`.
   - **P1**: `fires-declarations` warden rule tightened to eliminate false positives. Bare `fire(...)` calls only matched when verifiably destructured from the trail context. Walker uses `walkScope` from `ast.ts` to skip nested function bodies (parameter shadowing no longer leaks). `buildCtxNames` only seeds the actual second parameter — no `ctx`/`context` defaults.
   - **P1/P2**: Mixed object-form/string-form `fires:` no longer creates a false-negative window. Undeclared calls are downgraded from error to warn with a "(may be declared via object-form fires entries)" disclaimer when `hasUnresolved` is true. Genuinely undeclared calls still surface, just at warn severity.
   - **P2**: Demo `entity.delete` was emitting `entityId: input.name` (the natural key, not an id). Now looks up the entity before removal and emits `existing.id`. Test strengthened to assert `entityId` is not the natural key.
   - **P2**: `let`/`var` destructure tracking removed (only `const` is tracked, since the walker is flow-insensitive and can't track reassignment). Documented as a known precision tradeoff.

### Tenet alignment

- **One write, many reads**: `fires:`/`on:` declarations and `ctx.fire()` runtime calls share the same authoring shape (string id or Signal value). Single declaration feeds warden verification, agent introspection, lockfile graph, documentation.
- **Few primitives, many derivations**: zero new primitives — `fires:`/`on:` are properties on the existing `trail()`, exactly like `crosses:`.
- **The contract is queryable**: signal flow becomes a first-class queryable graph dimension, not a runtime mystery.
- **Reduce ceremony, not clarity**: producers stay decoupled from consumers (fire-and-forget), consumers auto-subscribe via topo.

### Acceptance

- [x] `TrailSpec.fires` and `TrailSpec.on` accept `string | Signal` entries
- [x] `TrailContext.fire(signalId, payload)` works end-to-end
- [x] Topo registers consumer activation
- [x] Warden parity rules catch declared/called mismatches without false positives
- [x] Dogfooding app exercises producer→consumer flow with correct entity ids
- [x] `bun run typecheck && bun run test && bun run check` all green

### Tracked follow-ups (out of scope)

- `cross-declarations.ts` has the same bare-callee false positive that `fires-declarations.ts` had. The new helpers form a reusable pattern that could be lifted into a shared AST helper when that fix lands.
- Persisted `topo_trail_fires` / `topo_trail_on` tables → in #103
- `ctx.fire(Signal, payload)` generic overload → in #103
- TRL-198 (#98) consumer-context inheritance → in its own PR

### Codex review history (4 passes)

| Pass | Findings | Resolution |
|---|---|---|
| 1 | 4 (2 P1 + 2 P2) | Signal value support, warden bare-callee, object-form coverage, demo entityId |
| 2 | 2 (1 P2 + 1 P3) | Mixed-fires false negative, nested-scope leak (outward) |
| 3 | 1 (1 P1) | Nested-scope leak (inward — parameter shadowing) |
| 4 | 2 (2 P1) | `buildCtxNames` defaults, `let`/`var` destructure tracking |

All 9 findings addressed with test coverage. ~12 new warden tests + 4 new core tests + 1 strengthened dogfood assertion.