### PR TITLE
feat(core)!: rename provision schema to resource [TRL-212]

### DIFF
--- a/docs/adr/0014-core-database-primitive.md
+++ b/docs/adr/0014-core-database-primitive.md
@@ -101,7 +101,7 @@ CREATE TABLE topo_saves (
   git_dirty INTEGER,          -- 1 if working tree had uncommitted changes
   trail_count INTEGER,        -- summary stats for quick display
   signal_count INTEGER,
-  provision_count INTEGER,
+  resource_count INTEGER,
   created_at TEXT NOT NULL     -- ISO 8601
 );
 

--- a/docs/adr/0015-topo-store.md
+++ b/docs/adr/0015-topo-store.md
@@ -47,7 +47,7 @@ CREATE TABLE topo_saves (
   git_dirty INTEGER DEFAULT 0,
   trail_count INTEGER DEFAULT 0,
   signal_count INTEGER DEFAULT 0,
-  provision_count INTEGER DEFAULT 0,
+  resource_count INTEGER DEFAULT 0,
   created_at TEXT NOT NULL
 );
 
@@ -82,17 +82,17 @@ CREATE TABLE topo_crossings (
   FOREIGN KEY (save_id) REFERENCES topo_saves(id)
 );
 
--- Resources declared per trail
-CREATE TABLE topo_trail_provisions (
+-- Resources declared per trail [^adr23]
+CREATE TABLE topo_trail_resources (
   trail_id TEXT NOT NULL,
-  provision_id TEXT NOT NULL,
+  resource_id TEXT NOT NULL,
   save_id TEXT NOT NULL,
-  PRIMARY KEY (trail_id, provision_id, save_id),
+  PRIMARY KEY (trail_id, resource_id, save_id),
   FOREIGN KEY (save_id) REFERENCES topo_saves(id)
 );
 
--- Resource definitions
-CREATE TABLE topo_provisions (
+-- Resource definitions [^adr23]
+CREATE TABLE topo_resources (
   id TEXT NOT NULL,
   has_mock INTEGER DEFAULT 0,
   has_health INTEGER DEFAULT 0,

--- a/docs/topo-store-reference.md
+++ b/docs/topo-store-reference.md
@@ -15,7 +15,7 @@ CREATE TABLE topo_saves (
   git_dirty INTEGER NOT NULL,
   trail_count INTEGER NOT NULL,
   signal_count INTEGER NOT NULL,
-  provision_count INTEGER NOT NULL,
+  resource_count INTEGER NOT NULL,
   created_at TEXT NOT NULL
 );
 ```
@@ -64,12 +64,12 @@ CREATE TABLE topo_crossings (
 );
 ```
 
-### `topo_provisions`
+### `topo_resources`
 
-Resource definitions.
+Resource definitions. Renamed from `topo_provisions` per ADR-0023.
 
 ```sql
-CREATE TABLE topo_provisions (
+CREATE TABLE topo_resources (
   id TEXT NOT NULL,
   has_mock INTEGER NOT NULL,
   has_health INTEGER NOT NULL,
@@ -78,16 +78,16 @@ CREATE TABLE topo_provisions (
 );
 ```
 
-### `topo_trail_provisions`
+### `topo_trail_resources`
 
-Which resources each trail declares.
+Which resources each trail declares. Renamed from `topo_trail_provisions` per ADR-0023.
 
 ```sql
-CREATE TABLE topo_trail_provisions (
+CREATE TABLE topo_trail_resources (
   trail_id TEXT NOT NULL,
-  provision_id TEXT NOT NULL,
+  resource_id TEXT NOT NULL,
   save_id TEXT NOT NULL,
-  PRIMARY KEY (trail_id, provision_id, save_id)
+  PRIMARY KEY (trail_id, resource_id, save_id)
 );
 ```
 
@@ -194,8 +194,8 @@ ORDER BY id ASC
 ```sql
 SELECT DISTINCT t.id, t.intent
 FROM topo_trails t
-JOIN topo_trail_provisions tp ON t.id = tp.trail_id AND t.save_id = tp.save_id
-WHERE t.save_id = ? AND tp.provision_id = ?
+JOIN topo_trail_resources tp ON t.id = tp.trail_id AND t.save_id = tp.save_id
+WHERE t.save_id = ? AND tp.resource_id = ?
 ```
 
 ### Find incoming callers

--- a/packages/core/src/__tests__/topo-store-read.test.ts
+++ b/packages/core/src/__tests__/topo-store-read.test.ts
@@ -17,10 +17,7 @@ import {
 } from '../index.js';
 import { pinTopoSave } from '../internal/topo-saves.js';
 import type { TopoSaveRecord } from '../internal/topo-saves.js';
-import {
-  getStoredTopoExport,
-  persistEstablishedTopoSave,
-} from '../internal/topo-store.js';
+import { persistEstablishedTopoSave } from '../internal/topo-store.js';
 import { openWriteTrailsDb } from '../internal/trails-db.js';
 
 const noop = () => Result.ok({ ok: true });
@@ -40,37 +37,6 @@ const requireValue = <T>(value: T | undefined, message: string): T => {
     throw new Error(message);
   }
   return value;
-};
-
-const rewriteStoredResourceKind = (
-  rootDir: string,
-  saveId: string,
-  resourceId: string
-): void => {
-  const db = openWriteTrailsDb({ rootDir });
-
-  try {
-    const stored = requireValue(
-      getStoredTopoExport(db, saveId),
-      `Expected stored topo export for save "${saveId}"`
-    );
-    const map = JSON.parse(stored.trailheadMapJson) as {
-      entries: { id: string; kind: string }[];
-    };
-    const entry = map.entries.find((candidate) => candidate.id === resourceId);
-    if (!entry) {
-      throw new Error(
-        `Expected stored trailhead entry for resource "${resourceId}"`
-      );
-    }
-
-    entry.kind = 'provision';
-    db.query<{ changes: number }, [string, string]>(
-      'UPDATE topo_exports SET trailhead_map = ? WHERE save_id = ?'
-    ).run(JSON.stringify(map), saveId);
-  } finally {
-    db.close();
-  }
 };
 
 const exampleApp = () => {
@@ -186,22 +152,6 @@ describe('read-only topo store', () => {
         safety: 'read',
       }),
     ]);
-
-    expect(store.resources.list({ save: { saveId: save.id } })).toEqual([
-      expect.objectContaining({
-        description: 'Primary database',
-        health: 'available',
-        id: 'db.main',
-        usedBy: ['entity.add', 'entity.list'],
-      }),
-    ]);
-  });
-
-  test('reads legacy stored provision entries through the resources accessor', () => {
-    const { rootDir, save } = seedStore();
-    rewriteStoredResourceKind(rootDir, save.id, 'db.main');
-
-    const store = createTopoStore({ rootDir });
 
     expect(store.resources.list({ save: { saveId: save.id } })).toEqual([
       expect.objectContaining({

--- a/packages/core/src/__tests__/topo-store.test.ts
+++ b/packages/core/src/__tests__/topo-store.test.ts
@@ -5,7 +5,9 @@ import { join } from 'node:path';
 
 import { z } from 'zod';
 
+import { NotFoundError } from '../errors.js';
 import { Result, resource, signal, topo, trail } from '../index.js';
+import { __topoStoreMigrationStats, createTopoStore } from '../topo-store.js';
 import {
   ensureTopoHistorySchema,
   pinTopoSave,
@@ -221,8 +223,8 @@ const expectProjectionCounts = (
 ): void => {
   expect(countRows(db, 'topo_trails', saveId)).toBe(2);
   expect(countRows(db, 'topo_crossings', saveId)).toBe(1);
-  expect(countRows(db, 'topo_trail_provisions', saveId)).toBe(3);
-  expect(countRows(db, 'topo_provisions', saveId)).toBe(2);
+  expect(countRows(db, 'topo_trail_resources', saveId)).toBe(3);
+  expect(countRows(db, 'topo_resources', saveId)).toBe(2);
   expect(countRows(db, 'topo_signals', saveId)).toBe(1);
   expect(countRows(db, 'topo_trail_signals', saveId)).toBe(1);
   expect(countRows(db, 'topo_trailheads', saveId)).toBe(2);
@@ -347,6 +349,160 @@ const buildSignalPruneApp = () => {
   });
 };
 
+const seedLegacyProvisionSchema = (
+  db: ReturnType<typeof openWriteTrailsDb>,
+  legacyVersion = 4
+): void => {
+  db.run(
+    `INSERT INTO meta_schema_versions (subsystem, version, updated_at)
+     VALUES ('topo', ?, ?)`,
+    [legacyVersion, '2026-04-03T10:00:00.000Z']
+  );
+  db.run(`CREATE TABLE topo_saves (
+    id TEXT PRIMARY KEY,
+    git_sha TEXT,
+    git_dirty INTEGER NOT NULL DEFAULT 0,
+    trail_count INTEGER NOT NULL DEFAULT 0,
+    signal_count INTEGER NOT NULL DEFAULT 0,
+    provision_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+  )`);
+  db.run(`CREATE TABLE topo_provisions (
+    id TEXT NOT NULL,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (id, save_id)
+  )`);
+  db.run(`CREATE TABLE topo_trail_provisions (
+    trail_id TEXT NOT NULL,
+    provision_id TEXT NOT NULL,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (trail_id, provision_id, save_id)
+  )`);
+};
+
+const seedLegacyProvisionStoreWithRow = (rootDir: string): void => {
+  const db = openWriteTrailsDb({ rootDir });
+  try {
+    seedLegacyProvisionSchema(db, 4);
+    db.run(
+      `INSERT INTO topo_saves (
+        id, git_sha, git_dirty, trail_count, signal_count, provision_count, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ['legacy-save', 'sha', 0, 0, 0, 0, '2026-04-03T11:00:00.000Z']
+    );
+  } finally {
+    db.close();
+  }
+};
+
+const captureReadError = (run: () => unknown): unknown => {
+  try {
+    run();
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+};
+
+const withWriteDb = (
+  rootDir: string,
+  run: (db: ReturnType<typeof openWriteTrailsDb>) => void
+): void => {
+  const db = openWriteTrailsDb({ rootDir });
+  try {
+    run(db);
+  } finally {
+    db.close();
+  }
+};
+
+const seedOrphanLegacyProvisionTables = (
+  db: ReturnType<typeof openWriteTrailsDb>
+): void => {
+  // Seed a v2 store with the new-style `resource_count` column but orphan
+  // legacy `topo_provisions` / `topo_trail_provisions` tables hanging around.
+  db.run(
+    `INSERT INTO meta_schema_versions (subsystem, version, updated_at)
+     VALUES ('topo', 2, ?)`,
+    ['2026-04-03T10:00:00.000Z']
+  );
+  db.run(`CREATE TABLE topo_saves (
+    id TEXT PRIMARY KEY,
+    git_sha TEXT,
+    git_dirty INTEGER NOT NULL DEFAULT 0,
+    trail_count INTEGER NOT NULL DEFAULT 0,
+    signal_count INTEGER NOT NULL DEFAULT 0,
+    resource_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+  )`);
+  db.run(`CREATE TABLE topo_provisions (
+    id TEXT NOT NULL,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (id, save_id)
+  )`);
+  db.run(`CREATE TABLE topo_trail_provisions (
+    trail_id TEXT NOT NULL,
+    provision_id TEXT NOT NULL,
+    save_id TEXT NOT NULL,
+    PRIMARY KEY (trail_id, provision_id, save_id)
+  )`);
+};
+
+const assertLegacyProvisionSchemaDropped = (
+  db: ReturnType<typeof openWriteTrailsDb>
+): void => {
+  expect(tableExists(db, 'topo_provisions')).toBe(false);
+  expect(tableExists(db, 'topo_trail_provisions')).toBe(false);
+  expect(tableExists(db, 'topo_resources')).toBe(true);
+  expect(tableExists(db, 'topo_trail_resources')).toBe(true);
+  const columns = db
+    .query<{ name: string }, []>('PRAGMA table_info(topo_saves)')
+    .all();
+  const columnNames = columns.map((column) => column.name);
+  expect(columnNames).toContain('resource_count');
+  expect(columnNames).not.toContain('provision_count');
+};
+
+const seedCurrentSchemaStore = (rootDir: string): void => {
+  const db = openWriteTrailsDb({ rootDir });
+  try {
+    ensureTopoHistorySchema(db);
+  } finally {
+    db.close();
+  }
+};
+
+const assertNoWriteEscalationOnReads = (rootDir: string): void => {
+  const baselineEscalations = __topoStoreMigrationStats.writeEscalations;
+  const baselinePeeks = __topoStoreMigrationStats.peekCalls;
+
+  // First read: peek must happen, no write-mode escalation.
+  const caught = captureReadError(() =>
+    createTopoStore({ rootDir }).saves.latest()
+  );
+  expect(caught).toBeInstanceOf(NotFoundError);
+  expect(__topoStoreMigrationStats.peekCalls).toBe(baselinePeeks + 1);
+  expect(__topoStoreMigrationStats.writeEscalations).toBe(baselineEscalations);
+
+  // Second read is served entirely from the memoized identity.
+  captureReadError(() => createTopoStore({ rootDir }).saves.latest());
+  expect(__topoStoreMigrationStats.peekCalls).toBe(baselinePeeks + 1);
+  expect(__topoStoreMigrationStats.writeEscalations).toBe(baselineEscalations);
+};
+
+const replaceStoreWithLegacyProvisionStore = async (
+  rootDir: string
+): Promise<void> => {
+  // Ensure mtime/size differs so the cached identity is invalidated even on
+  // filesystems with coarse mtime granularity.
+  const dbPath = join(rootDir, '.trails', 'trails.db');
+  rmSync(dbPath, { force: true });
+  rmSync(`${dbPath}-shm`, { force: true });
+  rmSync(`${dbPath}-wal`, { force: true });
+  await Bun.sleep(10);
+  seedLegacyProvisionStoreWithRow(rootDir);
+};
+
 const seedHistoryOnlyTopoSchema = (
   db: ReturnType<typeof openWriteTrailsDb>
 ): void => {
@@ -361,7 +517,7 @@ const seedHistoryOnlyTopoSchema = (
     git_dirty INTEGER NOT NULL DEFAULT 0,
     trail_count INTEGER NOT NULL DEFAULT 0,
     signal_count INTEGER NOT NULL DEFAULT 0,
-    provision_count INTEGER NOT NULL DEFAULT 0,
+    resource_count INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL
   )`);
   db.run(`CREATE TABLE IF NOT EXISTS topo_pins (
@@ -371,7 +527,7 @@ const seedHistoryOnlyTopoSchema = (
   )`);
   db.run(
     `INSERT INTO topo_saves (
-      id, git_sha, git_dirty, trail_count, signal_count, provision_count, created_at
+      id, git_sha, git_dirty, trail_count, signal_count, resource_count, created_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
     ['seed-save', 'seed123', 0, 1, 0, 0, '2026-04-03T11:00:00.000Z']
   );
@@ -569,6 +725,102 @@ describe('topo store projection', () => {
     });
   });
 
+  describe('ADR-0023 legacy provision schema drop', () => {
+    test('drops legacy provision schema per ADR-0023 on first open', () => {
+      withProjectionDb((db) => {
+        seedLegacyProvisionSchema(db);
+        ensureTopoHistorySchema(db);
+        assertLegacyProvisionSchemaDropped(db);
+      });
+    });
+
+    // Regression: if dropLegacyProvisionSchema wipes every topo table because
+    // of a legacy provision_count column, the version-delta migration must
+    // not skip the base tables. A v2 or v3 store with provision_count would
+    // otherwise end up with no topo_saves / topo_resources / topo_trail_resources.
+    test('createTopoStore migrates a legacy v4 provision_count store on first read', () => {
+      const rootDir = makeRoot();
+      seedLegacyProvisionStoreWithRow(rootDir);
+
+      // Pre-fix: this throws SQLiteError "no such column: resource_count"
+      // because the read-only path SELECTs resource_count before any
+      // migration runs. Post-fix: the migration runs first, drops the
+      // legacy provision schema (per ADR-0023), and the empty post-migration
+      // store surfaces a NotFoundError instead of a SQLite error.
+      const caught = captureReadError(() =>
+        createTopoStore({ rootDir }).saves.latest()
+      );
+      expect(caught).toBeInstanceOf(NotFoundError);
+
+      withWriteDb(rootDir, (db) => {
+        assertLegacyProvisionSchemaDropped(db);
+      });
+    });
+
+    test('createTopoStore skips write-mode escalation when schema is current', () => {
+      const rootDir = makeRoot();
+      seedCurrentSchemaStore(rootDir);
+      assertNoWriteEscalationOnReads(rootDir);
+    });
+
+    test('createTopoStore re-migrates after trails.db is replaced at the same path', async () => {
+      const rootDir = makeRoot();
+
+      // Round 1: seed a current-schema store and read through createTopoStore
+      // to prime the migration cache.
+      seedCurrentSchemaStore(rootDir);
+      captureReadError(() => createTopoStore({ rootDir }).saves.latest());
+      const baselineEscalations = __topoStoreMigrationStats.writeEscalations;
+
+      await replaceStoreWithLegacyProvisionStore(rootDir);
+
+      // Round 2: a fresh createTopoStore call must detect the file swap,
+      // re-run the migration, and not surface a SQLiteError.
+      const caught = captureReadError(() =>
+        createTopoStore({ rootDir }).saves.latest()
+      );
+      expect(caught).toBeInstanceOf(NotFoundError);
+      expect(__topoStoreMigrationStats.writeEscalations).toBe(
+        baselineEscalations + 1
+      );
+      withWriteDb(rootDir, (db) => {
+        assertLegacyProvisionSchemaDropped(db);
+      });
+    });
+
+    test.each([2, 3] as const)(
+      'rebuilds all tables when legacy schema drop happens from v%i',
+      (legacyVersion) => {
+        withProjectionDb((db) => {
+          seedLegacyProvisionSchema(db, legacyVersion);
+          ensureTopoHistorySchema(db);
+          assertLegacyProvisionSchemaDropped(db);
+          expect(tableExists(db, 'topo_trails')).toBe(true);
+          expect(tableExists(db, 'topo_crossings')).toBe(true);
+          expect(tableExists(db, 'topo_pins')).toBe(true);
+        });
+      }
+    );
+
+    // Regression: if the store already has `resource_count` on `topo_saves`
+    // (e.g. from a partial manual migration) but orphan `topo_provisions` /
+    // `topo_trail_provisions` tables remain, dropLegacyProvisionSchema must
+    // still trigger a full rebuild. Previously this path fell through to the
+    // version-delta migration, which for v2/v3 only created incremental
+    // tables and left the store permanently missing topo_resources /
+    // topo_trail_resources.
+    test('rebuilds all tables when orphan legacy tables exist without legacy column', () => {
+      withProjectionDb((db) => {
+        seedOrphanLegacyProvisionTables(db);
+        ensureTopoHistorySchema(db);
+        assertLegacyProvisionSchemaDropped(db);
+        expect(tableExists(db, 'topo_trails')).toBe(true);
+        expect(tableExists(db, 'topo_crossings')).toBe(true);
+        expect(tableExists(db, 'topo_pins')).toBe(true);
+      });
+    });
+  });
+
   test('upgrades a history-only topo schema to the projected topo schema', () => {
     withProjectionDb((db) => {
       seedHistoryOnlyTopoSchema(db);
@@ -579,7 +831,7 @@ describe('topo store projection', () => {
             "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
           )
           .get()?.version
-      ).toBe(4);
+      ).toBe(5);
       for (const table of [
         'topo_trails',
         'topo_crossings',

--- a/packages/core/src/internal/topo-saves.ts
+++ b/packages/core/src/internal/topo-saves.ts
@@ -10,7 +10,7 @@ const TOPO_TABLE_STATEMENTS = [
     git_dirty INTEGER NOT NULL DEFAULT 0,
     trail_count INTEGER NOT NULL DEFAULT 0,
     signal_count INTEGER NOT NULL DEFAULT 0,
-    provision_count INTEGER NOT NULL DEFAULT 0,
+    resource_count INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL
   )`,
   `CREATE TABLE IF NOT EXISTS topo_pins (
@@ -39,14 +39,14 @@ const TOPO_TABLE_STATEMENTS = [
     PRIMARY KEY (source_id, target_id, save_id),
     FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
   )`,
-  `CREATE TABLE IF NOT EXISTS topo_trail_provisions (
+  `CREATE TABLE IF NOT EXISTS topo_trail_resources (
     trail_id TEXT NOT NULL,
-    provision_id TEXT NOT NULL,
+    resource_id TEXT NOT NULL,
     save_id TEXT NOT NULL,
-    PRIMARY KEY (trail_id, provision_id, save_id),
+    PRIMARY KEY (trail_id, resource_id, save_id),
     FOREIGN KEY (save_id) REFERENCES topo_saves(id) ON DELETE CASCADE
   )`,
-  `CREATE TABLE IF NOT EXISTS topo_provisions (
+  `CREATE TABLE IF NOT EXISTS topo_resources (
     id TEXT NOT NULL,
     has_mock INTEGER NOT NULL DEFAULT 0,
     has_health INTEGER NOT NULL DEFAULT 0,
@@ -126,8 +126,8 @@ const TOPO_INDEX_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_topo_pins_save_id ON topo_pins(save_id)',
   'CREATE INDEX IF NOT EXISTS idx_topo_trails_save_id ON topo_trails(save_id)',
   'CREATE INDEX IF NOT EXISTS idx_topo_crossings_save_id ON topo_crossings(save_id)',
-  'CREATE INDEX IF NOT EXISTS idx_topo_trail_provisions_save_id ON topo_trail_provisions(save_id)',
-  'CREATE INDEX IF NOT EXISTS idx_topo_provisions_save_id ON topo_provisions(save_id)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_trail_resources_save_id ON topo_trail_resources(save_id)',
+  'CREATE INDEX IF NOT EXISTS idx_topo_resources_save_id ON topo_resources(save_id)',
   'CREATE INDEX IF NOT EXISTS idx_topo_signals_save_id ON topo_signals(save_id)',
   'CREATE INDEX IF NOT EXISTS idx_topo_trail_signals_save_id ON topo_trail_signals(save_id)',
   'CREATE INDEX IF NOT EXISTS idx_topo_trailheads_save_id ON topo_trailheads(save_id)',
@@ -144,7 +144,7 @@ interface TopoSaveRow {
   readonly git_dirty: number;
   readonly git_sha: string | null;
   readonly id: string;
-  readonly provision_count: number;
+  readonly resource_count: number;
   readonly signal_count: number;
   readonly trail_count: number;
 }
@@ -191,7 +191,7 @@ const rowToSave = (row: TopoSaveRow): TopoSaveRecord => ({
   createdAt: row.created_at,
   gitDirty: row.git_dirty === 1,
   id: row.id,
-  resourceCount: row.provision_count,
+  resourceCount: row.resource_count,
   signalCount: row.signal_count,
   trailCount: row.trail_count,
   ...(row.git_sha === null ? {} : { gitSha: row.git_sha }),
@@ -218,26 +218,164 @@ const runStatements = (db: Database, statements: readonly string[]): void => {
   }
 };
 
+const LEGACY_PROVISION_TABLES = [
+  'topo_provisions',
+  'topo_trail_provisions',
+] as const;
+
+const ALL_TOPO_TABLES = [
+  'topo_exports',
+  'topo_schemas',
+  'topo_examples',
+  'topo_trailheads',
+  'topo_trail_signals',
+  'topo_signals',
+  'topo_trail_on',
+  'topo_trail_fires',
+  'topo_resources',
+  'topo_trail_resources',
+  'topo_crossings',
+  'topo_trails',
+  'topo_pins',
+  'topo_saves',
+] as const;
+
+const notifyLegacyDrop = (savesCleared: boolean): void => {
+  // biome-ignore lint/suspicious/noConsole: one-shot migration notice
+  console.info(
+    savesCleared
+      ? 'topo store schema updated per ADR-0023; previous topo saves cleared'
+      : 'topo store schema updated per ADR-0023; legacy provision tables removed'
+  );
+};
+
+const topoSavesHasLegacyProvisionColumn = (db: Database): boolean => {
+  if (!tableExists(db, 'topo_saves')) {
+    return false;
+  }
+  const columns = db
+    .query<{ name: string }, []>('PRAGMA table_info(topo_saves)')
+    .all();
+  return columns.some((column) => column.name === 'provision_count');
+};
+
+const dropAllTopoTables = (db: Database): void => {
+  for (const table of ALL_TOPO_TABLES) {
+    db.run(`DROP TABLE IF EXISTS ${table}`);
+  }
+};
+
+const dropLegacyProvisionTables = (db: Database): boolean => {
+  let dropped = false;
+  for (const table of LEGACY_PROVISION_TABLES) {
+    if (tableExists(db, table)) {
+      db.run(`DROP TABLE IF EXISTS ${table}`);
+      dropped = true;
+    }
+  }
+  return dropped;
+};
+
+/**
+ * Drop legacy provision schema per ADR-0023.
+ *
+ * Returns `true` when anything legacy was dropped — either the orphan
+ * `topo_provisions` / `topo_trail_provisions` tables, or the full topo
+ * table set (because `topo_saves` still carried the legacy `provision_count`
+ * column). In either case the caller MUST recreate every table from scratch,
+ * regardless of the recorded subsystem version. The version-delta migration
+ * branches only add incremental tables and cannot be trusted to rebuild
+ * missing base tables.
+ *
+ * Pure-rename stores (v4 with `resource_count` already in place) return
+ * `false` and skip the rebuild path.
+ */
+const dropLegacyProvisionSchema = (db: Database): boolean => {
+  const droppedLegacyTables = dropLegacyProvisionTables(db);
+  const hasLegacyColumn = topoSavesHasLegacyProvisionColumn(db);
+  if (hasLegacyColumn) {
+    dropAllTopoTables(db);
+  }
+  const anyDropHappened = droppedLegacyTables || hasLegacyColumn;
+  if (anyDropHappened) {
+    notifyLegacyDrop(hasLegacyColumn);
+  }
+  return anyDropHappened;
+};
+
+const createAllTopoTables = (db: Database): void => {
+  runStatements(db, TOPO_TABLE_STATEMENTS);
+  runStatements(db, TOPO_INDEX_STATEMENTS);
+};
+
+const createSchemaCacheAndExportTables = (db: Database): void => {
+  // v2→v3: add schema cache and export tables
+  runStatements(db, TOPO_TABLE_STATEMENTS.slice(10, 12));
+  runStatements(db, TOPO_INDEX_STATEMENTS.slice(10, 12));
+};
+
+const createSignalEdgeTables = (db: Database): void => {
+  // v3→v4: add persisted signal edges (fires/on)
+  runStatements(db, TOPO_TABLE_STATEMENTS.slice(12));
+  runStatements(db, TOPO_INDEX_STATEMENTS.slice(12));
+};
+
+const runVersionDeltaMigration = (
+  db: Database,
+  currentVersion: number
+): void => {
+  if (currentVersion < 2) {
+    createAllTopoTables(db);
+    return;
+  }
+  if (currentVersion === 2) {
+    createSchemaCacheAndExportTables(db);
+  }
+  if (currentVersion < 4) {
+    createSignalEdgeTables(db);
+    return;
+  }
+  // currentVersion >= 4: (re)create all tables with the new resource*
+  // names. IF NOT EXISTS guards keep this safe when the store was already
+  // consistent.
+  createAllTopoTables(db);
+};
+
+const runTopoMigration = (db: Database, currentVersion: number): void => {
+  // v4→v5 (ADR-0023): drop any legacy `provision*` tables and rebuild
+  // `topo_saves` when it still carries the legacy `provision_count`
+  // column. Runs before the create-if-not-exists statements below so
+  // the new schema lands cleanly. Rows are not migrated.
+  const legacyDropHappened = dropLegacyProvisionSchema(db);
+
+  // When any legacy artifact was dropped — orphan provision tables OR the
+  // full topo table set — the version-delta branches can't be trusted to
+  // recreate the base tables (v2/v3 deltas only add incremental tables and
+  // would leave the store permanently missing `topo_resources`,
+  // `topo_trail_resources`, etc.). Rebuild everything from scratch and skip
+  // the old deltas.
+  if (legacyDropHappened) {
+    createAllTopoTables(db);
+    return;
+  }
+
+  runVersionDeltaMigration(db, currentVersion);
+};
+
+/**
+ * Current topo subsystem schema version. Exported so read-only callers can
+ * peek at `meta_schema_versions` and skip the write-mode migration escalation
+ * when the store is already current.
+ */
+export const TOPO_SCHEMA_VERSION = 5;
+
 export const ensureTopoHistorySchema = (db: Database): void => {
   ensureSubsystemSchema(db, {
     migrate: (currentVersion) => {
-      if (currentVersion < 2) {
-        runStatements(db, TOPO_TABLE_STATEMENTS);
-        runStatements(db, TOPO_INDEX_STATEMENTS);
-      }
-      if (currentVersion === 2) {
-        // v2→v3: add schema cache and export tables
-        runStatements(db, TOPO_TABLE_STATEMENTS.slice(10, 12));
-        runStatements(db, TOPO_INDEX_STATEMENTS.slice(10, 12));
-      }
-      if (currentVersion < 4 && currentVersion >= 2) {
-        // v3→v4: add persisted signal edges (fires/on)
-        runStatements(db, TOPO_TABLE_STATEMENTS.slice(12));
-        runStatements(db, TOPO_INDEX_STATEMENTS.slice(12));
-      }
+      runTopoMigration(db, currentVersion);
     },
     subsystem: TOPO_SUBSYSTEM,
-    version: 4,
+    version: TOPO_SCHEMA_VERSION,
   });
 };
 
@@ -257,7 +395,7 @@ export const insertTopoSaveRecord = (
 
   db.run(
     `INSERT INTO topo_saves (
-      id, git_sha, git_dirty, trail_count, signal_count, provision_count, created_at
+      id, git_sha, git_dirty, trail_count, signal_count, resource_count, created_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
     [
       record.id,
@@ -310,7 +448,7 @@ export const listTopoSaves = (db: Database): readonly TopoSaveRecord[] => {
   }
   const rows = db
     .query<TopoSaveRow, []>(
-      `SELECT id, git_sha, git_dirty, trail_count, signal_count, provision_count, created_at
+      `SELECT id, git_sha, git_dirty, trail_count, signal_count, resource_count, created_at
        FROM topo_saves
        ORDER BY created_at DESC, id DESC`
     )
@@ -365,7 +503,7 @@ export const getTopoSave = (
   }
   const row = db
     .query<TopoSaveRow, [string]>(
-      `SELECT id, git_sha, git_dirty, trail_count, signal_count, provision_count, created_at
+      `SELECT id, git_sha, git_dirty, trail_count, signal_count, resource_count, created_at
        FROM topo_saves
        WHERE id = ?`
     )

--- a/packages/core/src/internal/topo-store-read.ts
+++ b/packages/core/src/internal/topo-store-read.ts
@@ -79,7 +79,7 @@ interface TopoCrossingRow {
 }
 
 interface TopoTrailResourceRow {
-  readonly provision_id: string;
+  readonly resource_id: string;
 }
 
 interface TopoExampleRow {
@@ -103,7 +103,7 @@ interface StoredTrailheadMapEntry {
   readonly detours?: Readonly<Record<string, readonly string[]>>;
   readonly healthcheck?: boolean;
   readonly id: string;
-  readonly kind: 'provision' | 'resource' | 'signal' | 'trail';
+  readonly kind: 'resource' | 'signal' | 'trail';
 }
 
 interface StoredTrailheadMap {
@@ -178,15 +178,7 @@ const readStoredEntry = (
   }
 
   const map = JSON.parse(stored.trailheadMapJson) as StoredTrailheadMap;
-  return map.entries.find((entry) => {
-    if (entry.id !== id) {
-      return false;
-    }
-    if (kind === 'resource') {
-      return entry.kind === 'resource' || entry.kind === 'provision';
-    }
-    return entry.kind === kind;
-  });
+  return map.entries.find((entry) => entry.id === id && entry.kind === kind);
 };
 
 const mapTrailRow = (row: TopoTrailRow): TopoStoreTrailRecord => {
@@ -229,13 +221,13 @@ const readTrailResourceIds = (
 ): readonly string[] =>
   db
     .query<TopoTrailResourceRow, [string, string]>(
-      `SELECT provision_id
-       FROM topo_trail_provisions
+      `SELECT resource_id
+       FROM topo_trail_resources
        WHERE save_id = ? AND trail_id = ?
-       ORDER BY provision_id ASC`
+       ORDER BY resource_id ASC`
     )
     .all(saveId, trailId)
-    .map((row) => row.provision_id);
+    .map((row) => row.resource_id);
 
 const readTrailExamples = (
   db: Database,
@@ -264,19 +256,19 @@ const readResourceUsage = (
   saveId: string
 ): ReadonlyMap<string, readonly string[]> => {
   const rows = db
-    .query<{ provision_id: string; trail_id: string }, [string]>(
-      `SELECT provision_id, trail_id
-       FROM topo_trail_provisions
+    .query<{ resource_id: string; trail_id: string }, [string]>(
+      `SELECT resource_id, trail_id
+       FROM topo_trail_resources
        WHERE save_id = ?
-       ORDER BY provision_id ASC, trail_id ASC`
+       ORDER BY resource_id ASC, trail_id ASC`
     )
     .all(saveId);
 
   const usage = new Map<string, string[]>();
   for (const row of rows) {
-    const trails = usage.get(row.provision_id) ?? [];
+    const trails = usage.get(row.resource_id) ?? [];
     trails.push(row.trail_id);
-    usage.set(row.provision_id, trails);
+    usage.set(row.resource_id, trails);
   }
 
   return new Map(
@@ -420,7 +412,7 @@ export const listTopoStoreResources = (
   const rows = db
     .query<TopoResourceRow, [string]>(
       `SELECT id, has_mock, has_health, save_id
-       FROM topo_provisions
+       FROM topo_resources
        WHERE save_id = ?
        ORDER BY id ASC`
     )
@@ -435,11 +427,7 @@ export const listTopoStoreResources = (
     mapResourceRow(
       row,
       usage.get(row.id) ?? [],
-      entries.find(
-        (entry) =>
-          entry.id === row.id &&
-          (entry.kind === 'resource' || entry.kind === 'provision')
-      )
+      entries.find((entry) => entry.id === row.id && entry.kind === 'resource')
     )
   );
 };
@@ -457,7 +445,7 @@ export const getTopoStoreResource = (
   const row = db
     .query<TopoResourceRow, [string, string]>(
       `SELECT id, has_mock, has_health, save_id
-       FROM topo_provisions
+       FROM topo_resources
        WHERE save_id = ? AND id = ?
        LIMIT 1`
     )

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -977,14 +977,14 @@ const insertProjectedRows = (
   insertRows(
     db,
     projection.trailResources,
-    `INSERT INTO topo_trail_provisions (trail_id, provision_id, save_id)
+    `INSERT INTO topo_trail_resources (trail_id, resource_id, save_id)
      VALUES (?, ?, ?)`,
     (row) => [row.trailId, row.resourceId, row.saveId]
   );
   insertRows(
     db,
     projection.resources,
-    `INSERT INTO topo_provisions (id, has_mock, has_health, save_id)
+    `INSERT INTO topo_resources (id, has_mock, has_health, save_id)
      VALUES (?, ?, ?, ?)`,
     (row) => [row.id, row.hasMock, row.hasHealth, row.saveId]
   );

--- a/packages/core/src/topo-store.ts
+++ b/packages/core/src/topo-store.ts
@@ -1,11 +1,15 @@
 import type { SQLQueryBindings } from 'bun:sqlite';
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 
 import { NotFoundError } from './errors.js';
 import { resource } from './resource.js';
 import { Result } from './result.js';
 import type { TopoPinRecord, TopoSaveRecord } from './internal/topo-saves.js';
-import { getTopoPin } from './internal/topo-saves.js';
+import {
+  TOPO_SCHEMA_VERSION,
+  ensureTopoHistorySchema,
+  getTopoPin,
+} from './internal/topo-saves.js';
 import type {
   TopoStoreExportRecord,
   TopoStoreResourceRecord,
@@ -24,8 +28,136 @@ import {
   queryTopoStore,
   resolveTopoStoreSave,
 } from './internal/topo-store-read.js';
-import { openReadTrailsDb, resolveTrailsDbPath } from './internal/trails-db.js';
+import {
+  openReadTrailsDb,
+  openWriteTrailsDb,
+  resolveTrailsDbPath,
+} from './internal/trails-db.js';
 import type { TrailsDbLocationOptions } from './internal/trails-db.js';
+
+interface MigratedDbIdentity {
+  readonly mtimeMs: number;
+  readonly size: number;
+}
+
+const migratedTopoDbPaths = new Map<string, MigratedDbIdentity>();
+
+/**
+ * Test-only instrumentation counters. Incremented by the read-path migration
+ * check to let tests assert that a current-schema store does not escalate to
+ * a write-mode open, and that cache invalidation re-runs the check when the
+ * underlying file is replaced.
+ *
+ * @internal
+ */
+export const __topoStoreMigrationStats = {
+  peekCalls: 0,
+  writeEscalations: 0,
+};
+
+const peekTopoSchemaVersion = (
+  options: TrailsDbLocationOptions | undefined
+): number | undefined => {
+  let db: ReturnType<typeof openReadTrailsDb> | undefined;
+  try {
+    db = openReadTrailsDb(options);
+    const row = db
+      .query<{ version: number }, [string]>(
+        'SELECT version FROM meta_schema_versions WHERE subsystem = ?'
+      )
+      .get('topo');
+    return row?.version ?? 0;
+  } catch {
+    // Table missing or unexpected shape: caller will escalate to a write-mode
+    // open and run the migration, which rebuilds the schema.
+    return undefined;
+  } finally {
+    db?.close();
+  }
+};
+
+const statIdentity = (dbPath: string): MigratedDbIdentity | undefined => {
+  try {
+    const info = statSync(dbPath);
+    return { mtimeMs: info.mtimeMs, size: info.size };
+  } catch {
+    return undefined;
+  }
+};
+
+const identitiesEqual = (
+  a: MigratedDbIdentity,
+  b: MigratedDbIdentity
+): boolean => a.mtimeMs === b.mtimeMs && a.size === b.size;
+
+const runTopoMigrationEscalation = (
+  options: TrailsDbLocationOptions | undefined,
+  dbPath: string,
+  fallbackIdentity: MigratedDbIdentity
+): void => {
+  __topoStoreMigrationStats.writeEscalations += 1;
+  const db = openWriteTrailsDb(options);
+  try {
+    ensureTopoHistorySchema(db);
+  } finally {
+    db.close();
+  }
+  // Re-stat after the migration so the cached identity matches the file we
+  // just touched, avoiding a spurious second escalation on the next read.
+  const postIdentity = statIdentity(dbPath) ?? fallbackIdentity;
+  migratedTopoDbPaths.set(dbPath, postIdentity);
+};
+
+const resolveIdentityIfFresh = (
+  dbPath: string
+): MigratedDbIdentity | undefined => {
+  if (!existsSync(dbPath)) {
+    return undefined;
+  }
+  const identity = statIdentity(dbPath);
+  if (identity === undefined) {
+    return undefined;
+  }
+  const cached = migratedTopoDbPaths.get(dbPath);
+  if (cached !== undefined && identitiesEqual(cached, identity)) {
+    return undefined;
+  }
+  return identity;
+};
+
+/**
+ * Ensure the topo history schema is at the current version before any
+ * read-only access. Peeks the version through a read-only handle first and
+ * only escalates to a write-mode open + migration when the store is stale.
+ *
+ * Memoized per resolved DB path keyed on file identity (mtime + size) so a
+ * long-running process that deletes and recreates `trails.db` re-runs the
+ * migration check against the fresh file.
+ *
+ * If the DB file does not yet exist, this is a no-op — the downstream read
+ * path will surface its own NotFoundError.
+ */
+const ensureTopoMigratedIfExists = (
+  options?: TrailsDbLocationOptions
+): void => {
+  const dbPath = resolveTrailsDbPath(options);
+  const identity = resolveIdentityIfFresh(dbPath);
+  if (identity === undefined) {
+    return;
+  }
+
+  __topoStoreMigrationStats.peekCalls += 1;
+  const version = peekTopoSchemaVersion(options);
+  if (version !== undefined && version >= TOPO_SCHEMA_VERSION) {
+    // Already current — record identity and skip the write-mode open entirely,
+    // preserving the read-only contract for callers whose filesystem mounts
+    // `trails.db` read-only.
+    migratedTopoDbPaths.set(dbPath, identity);
+    return;
+  }
+
+  runTopoMigrationEscalation(options, dbPath, identity);
+};
 
 export type {
   TopoStoreExportRecord,
@@ -94,6 +226,7 @@ const requireReadDb = (
   if (!existsSync(dbPath)) {
     throw new NotFoundError(missingStoreMessage);
   }
+  ensureTopoMigratedIfExists(options);
   return openReadTrailsDb(options);
 };
 


### PR DESCRIPTION
## Summary

Cutover rename of the on-disk SQLite topo store schema from \`provision*\` to \`resource*\` per ADR-0023. Stacked on top of TRL-210 which handled the TS identifier rename.

**Breaking:** the topo store schema bumps v4 → v5. Existing \`.trails/trails.db\` files carrying the legacy schema are detected on open and dropped-and-recreated. No data migration — previous topo saves are cleared with a one-shot info log: \`topo store schema updated per ADR-0023; previous topo saves cleared\`.

### Changes

- **DDL rename** in \`packages/core/src/internal/topo-saves.ts\` — \`topo_provisions\` → \`topo_resources\`, \`topo_trail_provisions\` → \`topo_trail_resources\`, \`provision_count\` → \`resource_count\`, \`provision_id\` → \`resource_id\`, indices renamed, subsystem version bumped v4→v5.
- **INSERT queries** in \`topo-store.ts\` updated to the new table names.
- **Stored-data helpers** in \`topo-store-read.ts\` — \`listTopoStoreProvisions\` → \`listTopoStoreResources\`, \`getTopoStoreProvision\` → \`getTopoStoreResource\`, \`readProvisionUsage\` → \`readResourceUsage\`, \`mapProvisionRow\` → \`mapResourceRow\`. Dropped the \`kind: 'provision'\` fallback path (no reachable state after drop-and-recreate).
- **Drop-and-recreate** — \`dropLegacyProvisionSchema()\` detects legacy tables or the \`provision_count\` column, drops the affected tables (or the full topo table set when the column is present), and lets the create-if-not-exists pass rebuild. Runs at the start of every \`ensureTopoHistorySchema\` call but is a cheap pair of \`sqlite_master\` / \`PRAGMA table_info\` probes when nothing legacy is present.
- **Tests** — fixtures updated; new test seeds a v4 store with legacy tables/column, runs \`ensureTopoHistorySchema\`, asserts old tables gone and new tables present with \`resource_count\`.
- **Docs** — ADR-0014, ADR-0015, and \`docs/topo-store-reference.md\` updated; footnoted as renamed per ADR-0023.

## Test plan

- [x] \`bun run typecheck\` — 25/25 pass
- [x] \`bun test\` in \`packages/core\` — 648 pass (includes new migration test)
- [x] \`bun test\` in \`apps/trails\` — 58 pass
- [x] Stash dogfood app (\`.try/stash/\`) re-runs cleanly after \`rm .trails/trails.db\`

Closes https://linear.app/outfitter/issue/TRL-212/core-rename-provision-schema-to-resource-topo-store

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
