### PR TITLE
feat(tracing)!: drop legacy tracker.db migration [TRL-213]

### DIFF
--- a/packages/tracing/src/__tests__/dev-store.test.ts
+++ b/packages/tracing/src/__tests__/dev-store.test.ts
@@ -74,7 +74,7 @@ interface LegacyStoreFixture {
   readonly tableName: string;
 }
 
-const writeLegacyTrackerDb = (
+const writeLegacyTracingDb = (
   rootDir: string,
   fixture: LegacyStoreFixture,
   records: readonly TraceRecord[]
@@ -386,7 +386,7 @@ describe('createDevStore', () => {
         }),
       ];
 
-      writeLegacyTrackerDb(
+      writeLegacyTracingDb(
         dir,
         { fileName: 'tracing.db', tableName: 'tracing' },
         legacyRecords
@@ -397,35 +397,6 @@ describe('createDevStore', () => {
       expect(existsSync(join(dir, '.trails', 'trails.db'))).toBe(true);
       expect(queryIds(store)).toEqual(['legacy-b', 'legacy-a']);
       expect(existsSync(join(dir, '.trails', 'dev', 'tracing.db'))).toBe(false);
-    });
-
-    test('migrates legacy .trails/dev/tracker.db records into shared trails.db', () => {
-      const dir = makeTmpDir();
-      const now = Date.now();
-      const legacyRecords = [
-        makeRecord({
-          id: 'legacy-tracker-a',
-          startedAt: now - 2000,
-          trailId: 'user.create',
-        }),
-        makeRecord({
-          id: 'legacy-tracker-b',
-          startedAt: now - 1000,
-          trailId: 'user.list',
-        }),
-      ];
-
-      writeLegacyTrackerDb(
-        dir,
-        { fileName: 'tracker.db', tableName: 'tracker' },
-        legacyRecords
-      );
-
-      store = createDevStore({ maxRecords: 10, rootDir: dir });
-
-      expect(existsSync(join(dir, '.trails', 'trails.db'))).toBe(true);
-      expect(queryIds(store)).toEqual(['legacy-tracker-b', 'legacy-tracker-a']);
-      expect(existsSync(join(dir, '.trails', 'dev', 'tracker.db'))).toBe(false);
     });
   });
 

--- a/packages/tracing/src/stores/dev.ts
+++ b/packages/tracing/src/stores/dev.ts
@@ -223,10 +223,7 @@ const resolveLegacyCandidates = (
   rootDir?: string
 ): readonly LegacyStoreCandidate[] => {
   const devDir = join(rootDir ?? process.cwd(), '.trails', 'dev');
-  return [
-    { path: join(devDir, 'tracing.db'), tableName: 'tracing' },
-    { path: join(devDir, 'tracker.db'), tableName: 'tracker' },
-  ];
+  return [{ path: join(devDir, 'tracing.db'), tableName: 'tracing' }];
 };
 
 const hasLegacyTable = (db: Database, tableName: string): boolean => {


### PR DESCRIPTION
## Summary

Drop the legacy \`tracker.db\` read path from the dev tracing store per ADR-0023. This was a one-time migration bridge for pre-rename beta builds and has no production users — cutover rather than keeping the maintenance cost.

- Removed the \`{ path: join(devDir, 'tracker.db'), tableName: 'tracker' }\` candidate from \`resolveLegacyCandidates\` in \`packages/tracing/src/stores/dev.ts\`. The \`tracing.db\` migration path is kept intact.
- Removed the \`migrates legacy .trails/dev/tracker.db records into shared trails.db\` test + its fixture IDs.
- Renamed the reusable \`writeLegacyTrackerDb\` test helper to \`writeLegacyTracingDb\` for accuracy (it still writes the \`tracing.db\` legacy fixture used by the remaining test).

Anyone still running a pre-rename beta build with a \`tracker.db\` in \`.trails/dev/\` should delete it or migrate before upgrading.

## Test plan

- [x] \`bun test\` in \`packages/tracing\` — 95 pass
- [x] \`rg -w 'tracker\\\\.db|writeLegacyTrackerDb|legacy-tracker' packages/tracing/\` — clean

Closes https://linear.app/outfitter/issue/TRL-213/tracing-drop-legacy-trackerdb-migration-path

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
