### PR TITLE
feat(cli)!: derive json env vars from topo name [TRL-211]

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -103,7 +103,7 @@ validateCliCommands(commands)      // validate command tree shape and collisions
 toCommander(commands, options?)    // escape hatch step 2
 deriveFlags(schema, overrides?)    // Zod → CLI flags
 output(value, mode)                // write to stdout in text/json/jsonl
-resolveOutputMode(flags)           // determine output format from flags/env
+resolveOutputMode(flags, topoName) // determine output format from flags/topo-derived env
 
 BuildCliCommandsOptions, ActionResultContext, OutputMode
 CliCommand, CliFlag, CliArg

--- a/docs/trailheads/cli.md
+++ b/docs/trailheads/cli.md
@@ -158,14 +158,16 @@ await output('Hello', 'text'); // Plain text
 
 ### Output Mode Resolution
 
-`resolveOutputMode(flags)` determines the format from flags and environment:
+`resolveOutputMode(flags, topoName)` determines the format from flags and topo-derived environment variables:
 
 1. `--json` flag (highest priority)
 2. `--jsonl` flag
 3. `--output <mode>` flag
-4. `TRAILS_JSON=1` env var
-5. `TRAILS_JSONL=1` env var
+4. `<TOPO>_JSON=1` env var (topo-derived — e.g., `STASH_JSON=1` for a topo named `stash`)
+5. `<TOPO>_JSONL=1` env var
 6. Default: `"text"`
+
+The `<TOPO>` prefix is derived from the topo name: uppercased, with non-alphanumerics replaced by `_`. Names starting with a digit get an `_` prefix so the result is a valid identifier (e.g., `1app` → `_1APP_JSON`). The topo name is threaded through the CLI trailhead automatically and appears on `ActionResultContext.topoName` for custom result handlers.
 
 ## Error Handling
 
@@ -200,7 +202,7 @@ trailhead(app, {
       console.error(`Failed: ${ctx.trail.id}`);
       throw ctx.result.error;
     }
-    const { mode } = resolveOutputMode(ctx.flags);
+    const { mode } = resolveOutputMode(ctx.flags, ctx.topoName);
     await output(ctx.result.value, mode);
   },
 });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -58,7 +58,7 @@ commands.
 | `toCommander(commands, options?)` | Connect `CliCommand[]` to a Commander program |
 | `deriveFlags(schema)` | Extract honest CLI flags from a Zod schema |
 | `output(data, mode)` | Format output as JSON, JSONL, or text |
-| `resolveOutputMode(options)` | Resolve output mode from flags and env vars |
+| `resolveOutputMode(flags, topoName)` | Resolve output mode from flags and topo-derived env vars (`<TOPO>_JSON`, `<TOPO>_JSONL`) |
 
 See the [API Reference](../../docs/api-reference.md) for the full list.
 

--- a/packages/cli/src/__tests__/on-result.test.ts
+++ b/packages/cli/src/__tests__/on-result.test.ts
@@ -32,6 +32,7 @@ describe('defaultOnResult', () => {
       flags: {},
       input: { name: 'test' },
       result: Result.ok('hello'),
+      topoName: 'test',
       trail: stubTrail(),
     };
     await defaultOnResult(ctx);
@@ -44,6 +45,7 @@ describe('defaultOnResult', () => {
       flags: { json: true },
       input: {},
       result: Result.ok({ id: 1 }),
+      topoName: 'test',
       trail: stubTrail(),
     };
     await defaultOnResult(ctx);
@@ -57,6 +59,7 @@ describe('defaultOnResult', () => {
       flags: {},
       input: {},
       result: Result.err(error),
+      topoName: 'test',
       trail: stubTrail(),
     };
     expect(defaultOnResult(ctx)).rejects.toThrow('something broke');

--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -63,53 +63,77 @@ describe('resolveOutputMode', () => {
 
   describe('flag precedence', () => {
     test('--json flag returns json', () => {
-      const result = resolveOutputMode({ json: true });
+      const result = resolveOutputMode({ json: true }, 'stash');
       expect(result.mode).toBe('json');
     });
 
     test('--jsonl flag returns jsonl', () => {
-      const result = resolveOutputMode({ jsonl: true });
+      const result = resolveOutputMode({ jsonl: true }, 'stash');
       expect(result.mode).toBe('jsonl');
     });
 
     test('--json takes priority over --jsonl', () => {
-      const result = resolveOutputMode({ json: true, jsonl: true });
+      const result = resolveOutputMode({ json: true, jsonl: true }, 'stash');
       expect(result.mode).toBe('json');
     });
 
     test('--output flag returns specified mode', () => {
-      const result = resolveOutputMode({ output: 'jsonl' });
+      const result = resolveOutputMode({ output: 'jsonl' }, 'stash');
       expect(result.mode).toBe('jsonl');
     });
 
     test('--json takes priority over --output', () => {
-      const result = resolveOutputMode({ json: true, output: 'text' });
+      const result = resolveOutputMode({ json: true, output: 'text' }, 'stash');
       expect(result.mode).toBe('json');
     });
   });
 
-  describe('environment fallback', () => {
-    test('TRAILS_JSON=1 env var returns json', () => {
-      process.env['TRAILS_JSON'] = '1';
-      const result = resolveOutputMode({});
+  describe('topo-derived environment fallback', () => {
+    test('<TOPO>_JSON=1 env var returns json', () => {
+      process.env['STASH_JSON'] = '1';
+      const result = resolveOutputMode({}, 'stash');
       expect(result.mode).toBe('json');
     });
 
-    test('TRAILS_JSONL=1 env var returns jsonl', () => {
-      process.env['TRAILS_JSONL'] = '1';
-      const result = resolveOutputMode({});
+    test('<TOPO>_JSONL=1 env var returns jsonl', () => {
+      process.env['STASH_JSONL'] = '1';
+      const result = resolveOutputMode({}, 'stash');
       expect(result.mode).toBe('jsonl');
     });
 
     test('flags take priority over env vars', () => {
-      process.env['TRAILS_JSON'] = '1';
-      const result = resolveOutputMode({ jsonl: true });
+      process.env['STASH_JSON'] = '1';
+      const result = resolveOutputMode({ jsonl: true }, 'stash');
       expect(result.mode).toBe('jsonl');
     });
 
     test('defaults to text when nothing specified', () => {
-      const result = resolveOutputMode({});
+      const result = resolveOutputMode({}, 'stash');
       expect(result.mode).toBe('text');
+    });
+
+    test('env var for a different topo does not leak', () => {
+      process.env['OTHER_JSON'] = '1';
+      const result = resolveOutputMode({}, 'stash');
+      expect(result.mode).toBe('text');
+    });
+
+    test('legacy TRAILS_JSON is no longer honored', () => {
+      process.env['TRAILS_JSON'] = '1';
+      const result = resolveOutputMode({}, 'stash');
+      expect(result.mode).toBe('text');
+    });
+
+    test('topo name with hyphens is normalized to underscores', () => {
+      process.env['MY_APP_JSON'] = '1';
+      const result = resolveOutputMode({}, 'my-app');
+      expect(result.mode).toBe('json');
+    });
+
+    test('topo name starting with a digit gets underscore prefix', () => {
+      process.env['_1APP_JSON'] = '1';
+      const result = resolveOutputMode({}, '1app');
+      expect(result.mode).toBe('json');
     });
   });
 });

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -44,6 +44,7 @@ export interface ActionResultContext {
   readonly flags: Record<string, unknown>;
   readonly input: unknown;
   readonly result: Result<unknown, Error>;
+  readonly topoName: string;
   readonly trail: AnyTrail;
 }
 
@@ -299,6 +300,7 @@ const createExecute =
         flags: parsedFlags,
         input: { ...parsedArgs, ...parsedFlags },
         result: merged,
+        topoName: app.name,
         trail: t,
       });
       return merged;
@@ -330,6 +332,7 @@ const createExecute =
       flags: parsedFlags,
       input: reportInput,
       result: finalResult,
+      topoName: app.name,
       trail: t,
     });
     return finalResult;

--- a/packages/cli/src/on-result.ts
+++ b/packages/cli/src/on-result.ts
@@ -22,6 +22,6 @@ export const defaultOnResult = async (
     throw ctx.result.error;
   }
 
-  const { mode } = resolveOutputMode(ctx.flags);
+  const { mode } = resolveOutputMode(ctx.flags, ctx.topoName);
   await output(ctx.result.value, mode);
 };

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -69,33 +69,52 @@ const resolveFlagMode = (
   return undefined;
 };
 
-/** Resolve mode from environment variables. */
-const resolveEnvMode = (): OutputMode | undefined => {
-  if (process.env['TRAILS_JSON'] === '1') {
+/**
+ * Convert a topo name into the env var prefix used for per-topo output mode.
+ *
+ * Derivation rules:
+ * - Uppercased
+ * - Non-alphanumerics replaced with `_`
+ * - Leading digits prefixed with `_` so the result is a valid identifier
+ */
+const topoNameToEnvPrefix = (topoName: string): string => {
+  const normalized = topoName.toUpperCase().replaceAll(/[^A-Z0-9]+/g, '_');
+  return /^\d/.test(normalized) ? `_${normalized}` : normalized;
+};
+
+/** Resolve mode from topo-derived environment variables. */
+const resolveEnvMode = (topoName: string): OutputMode | undefined => {
+  const prefix = topoNameToEnvPrefix(topoName);
+  if (process.env[`${prefix}_JSON`] === '1') {
     return 'json';
   }
-  if (process.env['TRAILS_JSONL'] === '1') {
+  if (process.env[`${prefix}_JSONL`] === '1') {
     return 'jsonl';
   }
   return undefined;
 };
 
 /**
- * Determine the output mode from parsed CLI flags and environment.
+ * Determine the output mode from parsed CLI flags and topo-derived env vars.
  *
  * Resolution order (highest priority wins):
  * 1. `flags.json === true` -> "json"
  * 2. `flags.jsonl === true` -> "jsonl"
  * 3. `flags.output` as string -> validate against OutputMode
- * 4. `TRAILS_JSON=1` env var -> "json"
- * 5. `TRAILS_JSONL=1` env var -> "jsonl"
+ * 4. `<TOPO>_JSON=1` env var -> "json"
+ * 5. `<TOPO>_JSONL=1` env var -> "jsonl"
  * 6. Default: "text"
+ *
+ * `<TOPO>` is derived from the topo name per ADR-0023: uppercased, with
+ * non-alphanumerics replaced by underscores. A topo named `stash` reads
+ * `STASH_JSON` / `STASH_JSONL`.
  */
 export const resolveOutputMode = (
-  flags: Record<string, unknown>
+  flags: Record<string, unknown>,
+  topoName: string
 ): {
   mode: OutputMode;
 } => {
-  const mode = resolveFlagMode(flags) ?? resolveEnvMode() ?? 'text';
+  const mode = resolveFlagMode(flags) ?? resolveEnvMode(topoName) ?? 'text';
   return { mode };
 };


### PR DESCRIPTION
## Summary

Cutover the CLI output mode env vars from the legacy \`TRAILS_JSON\` / \`TRAILS_JSONL\` globals to topo-derived names per ADR-0023.

A topo named \`stash\` now reads \`STASH_JSON\` / \`STASH_JSONL\`. Topo names with hyphens or other non-alphanumerics are normalized to underscores and leading digits are prefixed with \`_\` so the result is a valid identifier.

### Changes

- \`packages/cli/src/output.ts\` — new \`topoNameToEnvPrefix\` helper; \`resolveEnvMode\` takes a topo name; \`resolveOutputMode(flags, topoName)\` signature updated. Legacy \`TRAILS_JSON\` / \`TRAILS_JSONL\` are no longer honored.
- \`packages/cli/src/build.ts\` — \`ActionResultContext\` gains \`topoName: string\`; both \`reportResult\` call sites in the \`createExecute\` closure pass \`app.name\`.
- \`packages/cli/src/on-result.ts\` — \`defaultOnResult\` forwards \`ctx.topoName\` to \`resolveOutputMode\`.
- \`packages/cli/src/__tests__/output.test.ts\` — tests updated to pass a topo name; new cases cover legacy vars being ignored, hyphenated topo names normalizing to underscores, and env-var-for-a-different-topo not leaking.
- \`packages/cli/src/__tests__/on-result.test.ts\` — fixture contexts add \`topoName: 'test'\`.

**Breaking:** anyone running with \`TRAILS_JSON=1\` set needs to switch to \`<YOUR_TOPO>_JSON=1\`. Called out in the 1.0 release notes.

## Test plan

- [x] \`bun run typecheck\` — 25/25 pass
- [x] \`bun test\` in \`packages/cli\` — 104 pass
- [x] New tests cover: set env-var-for-this-topo, unset, precedence vs flags, leaked env vars from other topos, legacy TRAILS_JSON ignored, hyphen normalization

Closes https://linear.app/outfitter/issue/TRL-211/cli-derive-json-env-vars-from-topo-name-drop-trails-jsonjsonl

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
