### PR TITLE
docs(adr): mark ADR-0013 partially superseded [TRL-214]

### DIFF
--- a/.changeset/lexicon-rename-cleanup.md
+++ b/.changeset/lexicon-rename-cleanup.md
@@ -1,0 +1,13 @@
+---
+'@ontrails/core': minor
+'@ontrails/cli': minor
+'@ontrails/tracing': minor
+'@ontrails/warden': minor
+---
+
+Lexicon rename cleanup (ADR-0023). Breaking for `@ontrails/core`, `@ontrails/cli`, and `@ontrails/tracing` at the boundary; internal-only churn for `@ontrails/warden`.
+
+- **core**: the topo store schema renames `topo_provisions` / `topo_trail_provisions` → `topo_resources` / `topo_trail_resources` and `provision_count` → `resource_count`. Schema version bumped v4→v5. Stores still carrying the legacy schema are detected on open, dropped, and recreated from the new DDL — previous topo saves are cleared. Stored-data helpers `listTopoStoreProvisions` / `getTopoStoreProvision` / `readProvisionUsage` / `mapProvisionRow` renamed to their `resource` counterparts. TS row types `TopoTrailProvisionRow` / `TopoProvisionRow` renamed to `TopoTrailResourceRow` / `TopoResourceRow`.
+- **cli**: CLI output mode env vars are now derived from the topo name per ADR-0023. Legacy globals `TRAILS_JSON` / `TRAILS_JSONL` are no longer honored — a topo named `stash` reads `STASH_JSON` / `STASH_JSONL`. `ActionResultContext` gains a `topoName: string` field; `resolveOutputMode(flags, topoName)` takes a topo name argument.
+- **tracing**: legacy `.trails/dev/tracker.db` migration path removed. Any user still running a pre-rename beta build with a `tracker.db` should delete it or migrate before upgrading.
+- **warden**: internal-only rename of `provisionDeclarations` / `provisionExists` rules and their trails to `resourceDeclarations` / `resourceExists`. No behavior change.

--- a/.claude/skills/trails-adrs/scripts/lib/decision-map.ts
+++ b/.claude/skills/trails-adrs/scripts/lib/decision-map.ts
@@ -39,7 +39,7 @@ export interface DecisionMapEntry {
   path: string;
   owners: string[];
   depends_on: string[];
-  superseded_by: number | null;
+  superseded_by: string[] | null;
   inbound: InboundRef[];
 }
 
@@ -153,7 +153,7 @@ const buildNumberedEntries = (allFiles: AdrFile[]): DecisionMapEntry[] =>
       path: `docs/adr/${adr.filename}`,
       slug,
       status: String(adr.frontmatter.status ?? 'unknown'),
-      superseded_by: (adr.frontmatter.superseded_by as number) ?? null,
+      superseded_by: (adr.frontmatter.superseded_by as string[]) ?? null,
       title: adr.title.replace(/^ADR-\d+:\s*/, ''),
       updated: String(adr.frontmatter.updated ?? ''),
     };

--- a/docs/adr/0013-tracing.md
+++ b/docs/adr/0013-tracing.md
@@ -2,7 +2,8 @@
 id: 13
 slug: tracing
 title: Tracing — Runtime Recording Primitive
-status: accepted
+status: partially-superseded
+superseded_by: ['23']
 created: 2026-03-30
 updated: 2026-04-08
 owners: ['[galligan](https://github.com/galligan)']

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,7 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0010](0010-native-infrastructure.md) | Trails-Native Infrastructure Pattern | Accepted |
 | [0011](0011-schema-driven-config.md) | Schema-Driven Config | Accepted |
 | [0012](0012-connector-agnostic-permits.md) | Connector-Agnostic Permits | Accepted |
-| [0013](0013-tracing.md) | Tracing — Runtime Recording Primitive | Accepted |
+| [0013](0013-tracing.md) | Tracing — Runtime Recording Primitive | Partially superseded by [0023](0023-simplifying-the-trails-lexicon.md) |
 | [0014](0014-core-database-primitive.md) | Core Database Primitive | Accepted |
 | [0015](0015-topo-store.md) | Topo Store | Accepted |
 | [0016](0016-schema-derived-persistence.md) | Schema-Derived Persistence | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -921,10 +921,10 @@
       "owners": ["[galligan](https://github.com/galligan)"],
       "path": "docs/adr/0013-tracing.md",
       "slug": "tracing",
-      "status": "accepted",
-      "superseded_by": null,
+      "status": "partially-superseded",
+      "superseded_by": ["23"],
       "title": "Tracing — Runtime Recording Primitive",
-      "updated": "2026-04-02"
+      "updated": "2026-04-08"
     },
     {
       "created": "2026-04-02",


### PR DESCRIPTION
## Summary

Doc correctness pass on ADR-0013 per ADR-0023's supersession note, plus the lockfile changeset for the whole stack.

ADR-0023 said ADR-0013 is "partially superseded" — the \`tracingLayer\` → intrinsic-in-\`executeTrail\` collapse replaces the layer side, but the resource/accessor side of ADR-0013's design still stands. ADR-0013's frontmatter, the ADR index, and \`decision-map.json\` all said \`accepted\` and didn't reflect that.

### Changes

- \`docs/adr/0013-tracing.md\` — frontmatter \`status: partially-superseded\`, \`superseded_by: [23]\`. The existing "Status update (2026-04-08)" note at the top already describes the scope of the supersession in detail.
- \`docs/adr/README.md\` — index row updated to \`Partially superseded by 0023\`.
- \`docs/adr/decision-map.json\` — ADR-0013 record updated to match.
- \`.changeset/lexicon-rename-cleanup.md\` — lockfile changeset for the full stack covering \`@ontrails/core\`, \`@ontrails/cli\`, \`@ontrails/tracing\`, \`@ontrails/warden\`. Documents the breaking changes from TRL-210 through TRL-214.

## Test plan

- [x] ADR-0013 frontmatter status updated
- [x] ADR index row updated
- [x] \`decision-map.json\` record updated
- [x] Changeset covers all four affected packages
- [x] \`bun run check\` green

Closes https://linear.app/outfitter/issue/TRL-214/adr-0013-mark-partially-superseded-by-adr-0023

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
