### PR TITLE
fix(skill): correct superseded_by format in ADR management instructions [TRL-215]

### DIFF
--- a/.claude/skills/trails-adrs/assets/adr-management.md
+++ b/.claude/skills/trails-adrs/assets/adr-management.md
@@ -30,7 +30,7 @@ Manual instructions for ADR lifecycle operations when the `../scripts/adr.ts` sc
 ## Superseding an ADR
 
 1. Create a new ADR (the successor) following the normal process
-2. In the old ADR's frontmatter, set `status: superseded` and add `superseded_by: NNNN`
+2. In the old ADR's frontmatter, set `status: superseded` and add `superseded_by: ['NNNN']`
 3. Update the old ADR's index entry status to `Superseded`
 4. In the new ADR's References, link to the predecessor
 


### PR DESCRIPTION
## Summary
- Fix `superseded_by: NNNN` (scalar) to `superseded_by: ['NNNN']` (string array) in ADR skill instructions
- Prevents silent data corruption when YAML parser produces a scalar number instead of a string array

Closes https://linear.app/outfitter/issue/TRL-215

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
