### PR TITLE
docs(warden): add softening-asymmetry comment on reportUnused [TRL-207]

### DIFF
--- a/packages/warden/src/rules/fires-declarations.ts
+++ b/packages/warden/src/rules/fires-declarations.ts
@@ -508,7 +508,16 @@ const reportUndeclared = (
   }
 };
 
-/** Emit warning for each declared ID not present in called set. */
+/**
+ * Emit warning for each declared ID not present in called set.
+ *
+ * Note: unlike `reportUndeclared`, this function does NOT soften its
+ * diagnostics when `hasUnresolved` is true. The asymmetry is intentional —
+ * softening only applies to the undeclared direction because unresolved
+ * Signal-value entries might cover an unknown set of called IDs. In the
+ * unused direction, a declared string-literal that is never called is
+ * genuinely unused regardless of whether other entries are unresolved.
+ */
 const reportUnused = (
   declared: ReadonlySet<string>,
   called: ReadonlySet<string>,


### PR DESCRIPTION
## Summary
- Add clarifying comment on `reportUnused` explaining why softening only applies to the undeclared direction
- Mirrors the existing comment on `reportUndeclared` for discoverability

Closes https://linear.app/outfitter/issue/TRL-207

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
