### PR TITLE
test(core): add default frozen-array tests for fires/on [TRL-208]

### DIFF
--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -298,5 +298,16 @@ describe('trail()', () => {
         'audit.logged',
       ]);
     });
+
+    test('defaults to empty frozen arrays when omitted', () => {
+      const minimal = trail('bare', {
+        blaze: () => Result.ok(),
+        input: z.object({}),
+      });
+      expect(minimal.fires).toEqual([]);
+      expect(Object.isFrozen(minimal.fires)).toBe(true);
+      expect(minimal.on).toEqual([]);
+      expect(Object.isFrozen(minimal.on)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add test asserting `trail.fires` and `trail.on` default to empty frozen arrays when omitted
- Mirrors existing `crosses` and `resources` default tests

Closes https://linear.app/outfitter/issue/TRL-208

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
