### PR TITLE
fix(warden): handle ObjectPattern ctx destructure in resource-declarations [TRL-205]

### DIFF
--- a/packages/warden/src/__tests__/resource-declarations.test.ts
+++ b/packages/warden/src/__tests__/resource-declarations.test.ts
@@ -96,6 +96,48 @@ trail('entity.show', {
       expect(diagnostics.length).toBe(0);
     });
 
+    test('recognizes parameter-level destructured resource() calls', () => {
+      const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (_input, { resource }) => {
+    return Result.ok(resource('db.main'));
+  },
+});
+`;
+
+      const diagnostics = resourceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('recognizes parameter-level renamed resource() calls', () => {
+      const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (_input, { resource: r }) => {
+    return Result.ok(r('db.main'));
+  },
+});
+`;
+
+      const diagnostics = resourceDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
     test('recognizes ctx.resource(db) lookups by declared resource object', () => {
       const code = `
 import { Result, resource, trail } from '@ontrails/core';

--- a/packages/warden/src/rules/resource-declarations.ts
+++ b/packages/warden/src/rules/resource-declarations.ts
@@ -126,13 +126,66 @@ const extractDeclaredResources = (
 // Called service extraction
 // ---------------------------------------------------------------------------
 
-/** Extract the second parameter name from a blaze function node. */
-const extractContextParamName = (blazeBody: AstNode): string | null => {
+/** Extract the raw second parameter node from a blaze function. */
+const extractContextParamNode = (blazeBody: AstNode): AstNode | null => {
   const params = blazeBody['params'] as readonly AstNode[] | undefined;
   if (!params || params.length < 2) {
     return null;
   }
-  return identifierName(params[1]);
+  return params[1] ?? null;
+};
+
+/**
+ * Extract the second parameter name from a blaze function node.
+ *
+ * Returns null when the parameter is not a plain Identifier (e.g. when the
+ * author destructures `{ resource }` in the parameter list). Parameter-level
+ * destructuring is handled separately by `collectParamResourceAliases`.
+ */
+const extractContextParamName = (blazeBody: AstNode): string | null => {
+  const param = extractContextParamNode(blazeBody);
+  return param ? identifierName(param) : null;
+};
+
+/** Extract the alias name from a Property node whose key is `resource`. */
+const extractResourceAlias = (property: AstNode): string | null => {
+  if (property.type !== 'Property') {
+    return null;
+  }
+  const keyName = identifierName(
+    (property as unknown as { key?: AstNode }).key
+  );
+  if (keyName !== 'resource') {
+    return null;
+  }
+  return (
+    identifierName((property as unknown as { value?: AstNode }).value) ??
+    keyName
+  );
+};
+
+/**
+ * Collect `resource` aliases bound via parameter-level destructuring.
+ *
+ * Recognizes `(input, { resource }) => ...` and `(input, { resource: r }) => ...`.
+ * When the blaze author destructures in the parameter list, there is no
+ * enclosing `ctx` identifier to track — we seed the resource alias set directly
+ * from the ObjectPattern in `params[1]`.
+ */
+const collectParamResourceAliases = (body: AstNode): ReadonlySet<string> => {
+  const param = extractContextParamNode(body);
+  if (!param || param.type !== 'ObjectPattern') {
+    return new Set();
+  }
+  const aliases = new Set<string>();
+  const properties = param['properties'] as readonly AstNode[] | undefined;
+  for (const property of properties ?? []) {
+    const alias = extractResourceAlias(property);
+    if (alias) {
+      aliases.add(alias);
+    }
+  }
+  return aliases;
 };
 
 /** Build the set of context parameter names to match against. */
@@ -308,7 +361,9 @@ const extractCalledResources = (config: AstNode): CalledResources => {
 
   for (const body of findBlazeBodies(config)) {
     const ctxNames = buildCtxNames(body);
-    const resourceAliases = collectResourceAliases(body, ctxNames);
+    const paramAliases = collectParamResourceAliases(body);
+    const bodyAliases = collectResourceAliases(body, ctxNames);
+    const resourceAliases = new Set([...paramAliases, ...bodyAliases]);
 
     walkScope(body, (node) => {
       const fromName = extractFromCallName(node, ctxNames);


### PR DESCRIPTION
## Summary
- Teach the resource-declarations warden rule to handle parameter-level ctx destructuring (`(input, { resource }) =>`)
- Extract `collectParamResourceAliases` to detect `resource` bindings from ObjectPattern params
- Previously, `(input, { resource: r }) => r('db.main')` was invisible to the rule

## Test plan
- [x] Parameter-level destructured `resource()` calls recognized
- [x] Renamed form `{ resource: r }` recognized
- [x] All 16 resource-declarations tests pass

Closes https://linear.app/outfitter/issue/TRL-205

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
