### PR TITLE
fix(core): add max-depth guard for signal fan-out chains [TRL-200]

### DIFF
--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -155,6 +155,46 @@ const createCycleScenario = (invocations: string[]) =>
     }),
   });
 
+const createDepthChainScenario = (chainLength: number) => {
+  const chainPayload = z.object({ n: z.number() });
+  const signals = Array.from({ length: chainLength }, (_, i) =>
+    signal(`chain.${i}`, { payload: chainPayload })
+  );
+  const [firstSignal] = signals;
+  const consumers = Object.fromEntries(
+    signals.slice(0, -1).map((sig, i) => [
+      `consumer${i}`,
+      trail(`chain.consumer.${i}`, {
+        blaze: async (_input, ctx) => {
+          const next = signals[i + 1];
+          await ctx.fire?.(next?.id ?? '', { n: i + 1 });
+          return Result.ok({ step: i });
+        },
+        fires: [signals[i + 1]?.id ?? ''],
+        input: chainPayload,
+        on: [sig.id],
+      }),
+    ])
+  );
+  const signalEntries = Object.fromEntries(
+    signals.map((s) => [s.id.replace('.', '_'), s])
+  );
+  return {
+    app: topo('fire-depth', {
+      ...consumers,
+      ...signalEntries,
+      producer: trail('chain.start', {
+        blaze: async (input: { n: number }, ctx) => {
+          await ctx.fire?.(firstSignal?.id ?? '', input);
+          return Result.ok({ started: true });
+        },
+        fires: [firstSignal?.id ?? ''],
+        input: chainPayload,
+      }),
+    }),
+  };
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -374,6 +414,25 @@ describe('fire', () => {
           signalId: 'loop.a',
         },
       ]);
+    });
+
+    test('stops at max depth for distinct-signal chains', async () => {
+      const warnings: { message: string; signalId?: unknown }[] = [];
+      const logger = createCycleLogger(warnings);
+      const { app } = createDepthChainScenario(20);
+
+      const result = await run(
+        app,
+        'chain.start',
+        { n: 0 },
+        { ctx: { logger } }
+      );
+
+      expect(result.isOk()).toBe(true);
+      const depthWarning = warnings.find((w) =>
+        w.message.includes('depth limit')
+      );
+      expect(depthWarning).toBeDefined();
     });
   });
 

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -42,6 +42,15 @@ type MutableConsumerContext = {
 
 const FIRE_STACK_KEY = '__trails_fire_stack';
 
+/**
+ * Maximum depth for signal fan-out chains.
+ *
+ * Cycle detection catches re-entrant fires of the same signal ID (A→B→A),
+ * but a chain of distinct signals (A→B→C→D→...) bypasses it. This limit
+ * prevents runaway fan-out in pathological topologies.
+ */
+const MAX_FIRE_DEPTH = 16;
+
 const getFireStack = (
   ctx: Pick<TrailContextInit, 'extensions'> | undefined
 ): readonly string[] => {
@@ -191,6 +200,28 @@ export const createFireFn = (
     return Result.ok();
   };
 
+  /** Return an early Result if the fire should be suppressed, or null to proceed. */
+  const guardFire = (
+    signalId: string,
+    stack: readonly string[]
+  ): Result<void, Error> | null => {
+    if (stack.length >= MAX_FIRE_DEPTH) {
+      producerCtx?.logger?.warn(
+        'Signal fan-out depth limit reached — skipping fire',
+        { depth: stack.length, signalId }
+      );
+      return Result.ok();
+    }
+    if (stack.includes(signalId)) {
+      producerCtx?.logger?.warn(
+        'Signal cycle detected — skipping re-entrant fire',
+        { signalId }
+      );
+      return Result.ok();
+    }
+    return null;
+  };
+
   const fireImpl: FireFn = async (
     signalOrId: unknown,
     payload: unknown
@@ -199,12 +230,9 @@ export const createFireFn = (
     if (resolved.isErr()) {
       return Result.err(resolved.error);
     }
-    if (getFireStack(producerCtx).includes(resolved.value)) {
-      producerCtx?.logger?.warn(
-        'Signal cycle detected — skipping re-entrant fire',
-        { signalId: resolved.value }
-      );
-      return Result.ok();
+    const suppressed = guardFire(resolved.value, getFireStack(producerCtx));
+    if (suppressed) {
+      return suppressed;
     }
     return await dispatchFire(resolved.value, payload);
   };


### PR DESCRIPTION
## Summary
- Add `MAX_FIRE_DEPTH = 16` limit for signal fan-out chains
- Cycle detection catches A→B→A, but distinct-signal chains (A→B→C→D→...) could recurse unbounded
- Depth check runs before cycle detection; logs warning and returns `Result.ok()` when limit hit
- Extracted `guardFire` helper to keep `fireImpl` under max-statements

## Test plan
- [x] Chain of 20 distinct signals triggers depth limit warning
- [x] Existing cycle detection still works
- [x] Normal fan-out unaffected

Closes https://linear.app/outfitter/issue/TRL-200

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
