### PR TITLE
feat(cli): derive positional arguments from trail input schemas [TRL-192]

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["Skill(stack-and-ship)", "Skill(stack-and-ship:*)"]
+  }
+}

--- a/docs/trailheads/cli.md
+++ b/docs/trailheads/cli.md
@@ -85,6 +85,39 @@ Options:
   --format <value>  (choices: "json", "table", default: "json")
 ```
 
+## Positional Args
+
+By default, if a trail has exactly one required string field with no default, the CLI auto-promotes it to a positional arg:
+
+```bash
+myapp topo pin v1.0          # instead of: myapp topo pin --name v1.0
+```
+
+For multiple positional args, declare `args` on the trail spec:
+
+```typescript
+trail('file.copy', {
+  input: z.object({ src: z.string(), dest: z.string(), recursive: z.boolean() }),
+  args: ['src', 'dest'],
+  intent: 'write',
+});
+```
+
+```bash
+myapp file copy source.txt dest.txt --recursive
+```
+
+The `args` array controls which fields are positional and their order. Fields not in `args` become flags. Positional fields also keep their flag alias (`--src` still works).
+
+To suppress auto-promotion entirely:
+
+```typescript
+trail('config.set', {
+  input: z.object({ key: z.string(), value: z.string() }),
+  args: false,  // both stay as --key and --value flags
+});
+```
+
 ## Structured Input
 
 Every non-empty object input schema also gets three structured input channels:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -80,6 +80,38 @@ represented truthfully on the command line. No manual flag definitions.
 Nested objects and arrays of objects are intentionally omitted from automatic
 flag derivation. The CLI prefers fewer flags over dishonest flags.
 
+## Positional arguments
+
+When a trail's input schema has exactly one required `string` field with no
+default, the CLI auto-promotes it to a positional argument instead of a flag:
+
+```typescript
+const greet = trail('greet', {
+  input: z.object({ name: z.string().describe('Who to greet') }),
+  blaze: (input) => Result.ok(`Hello, ${input.name}!`),
+});
+```
+
+```bash
+myapp greet World          # positional
+myapp greet --name World   # flag form still works via structured input
+```
+
+The heuristic is intentionally conservative: multiple required strings stay as
+flags. To override, mark a field explicitly via `fields`:
+
+```typescript
+const copy = trail('file.copy', {
+  input: z.object({ src: z.string(), dest: z.string() }),
+  fields: { src: { positional: true } },
+  blaze: (input) => Result.ok({ src: input.src, dest: input.dest }),
+});
+```
+
+```bash
+myapp file copy ./readme.md --dest /tmp/readme.md
+```
+
 ## Structured input
 
 For every non-empty object input schema, the CLI also exposes:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -98,15 +98,18 @@ myapp greet --name World   # flag form still works via structured input
 ```
 
 The heuristic is intentionally conservative: multiple required strings stay as
-flags. To override, mark a field explicitly via `fields`:
+flags. To override, declare `args` on the trail:
 
 ```typescript
 const copy = trail('file.copy', {
   input: z.object({ src: z.string(), dest: z.string() }),
-  fields: { src: { positional: true } },
+  args: ['src'],
   blaze: (input) => Result.ok({ src: input.src, dest: input.dest }),
 });
 ```
+
+`args` accepts `string[]` for explicit positional order, `false` to suppress
+auto-promotion entirely, or `undefined` (omit) for the heuristic.
 
 ```bash
 myapp file copy ./readme.md --dest /tmp/readme.md

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -114,7 +114,7 @@ describe('buildCliCommands path derivation', () => {
 
     // Single required string → auto-promoted to positional arg + kept as flag alias
     expect(args).toHaveLength(1);
-    expect(args[0]).toMatchObject({ name: 'query', required: true });
+    expect(args[0]).toMatchObject({ name: 'query', required: false });
     expect(flags.find((f) => f.name === 'query')).toBeDefined();
     const limitFlag = flags.find((f) => f.name === 'limit');
     expect(limitFlag?.required).toBe(false);
@@ -545,7 +545,7 @@ describe('positional arg derivation', () => {
     expect(cmd.args).toHaveLength(1);
     expect(cmd.args[0]).toMatchObject({
       name: 'path',
-      required: true,
+      required: false,
       variadic: false,
     });
     // The positional field is kept as a --path flag alias
@@ -579,7 +579,7 @@ describe('positional arg derivation', () => {
     const cmd = requireCommand(buildCliCommands(app));
 
     expect(cmd.args).toHaveLength(1);
-    expect(cmd.args[0]).toMatchObject({ name: 'query', required: true });
+    expect(cmd.args[0]).toMatchObject({ name: 'query', required: false });
     // query kept as flag alias, limit also present
     expect(cmd.flags.find((f) => f.name === 'query')).toBeDefined();
     expect(cmd.flags.find((f) => f.name === 'limit')).toBeDefined();
@@ -596,7 +596,7 @@ describe('positional arg derivation', () => {
     const cmd = requireCommand(buildCliCommands(app));
 
     expect(cmd.args).toHaveLength(1);
-    expect(cmd.args[0]).toMatchObject({ name: 'src', required: true });
+    expect(cmd.args[0]).toMatchObject({ name: 'src', required: false });
     // src kept as flag alias, dest also present
     expect(cmd.flags.find((f) => f.name === 'src')).toBeDefined();
     expect(cmd.flags.find((f) => f.name === 'dest')).toBeDefined();
@@ -641,7 +641,7 @@ describe('positional arg derivation', () => {
     const cmd = requireCommand(buildCliCommands(app));
 
     expect(cmd.args).toHaveLength(1);
-    expect(cmd.args[0]).toMatchObject({ name: 'path', required: true });
+    expect(cmd.args[0]).toMatchObject({ name: 'path', required: false });
   });
 
   test('no positional args when no required string fields exist', () => {

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -112,10 +112,10 @@ describe('buildCliCommands path derivation', () => {
     });
     const { flags, args } = requireCommand(buildCliCommands(app));
 
-    // Single required string → auto-promoted to positional arg
+    // Single required string → auto-promoted to positional arg + kept as flag alias
     expect(args).toHaveLength(1);
     expect(args[0]).toMatchObject({ name: 'query', required: true });
-    expect(flags.find((f) => f.name === 'query')).toBeUndefined();
+    expect(flags.find((f) => f.name === 'query')).toBeDefined();
     const limitFlag = flags.find((f) => f.name === 'limit');
     expect(limitFlag?.required).toBe(false);
   });
@@ -130,13 +130,10 @@ describe('buildCliCommands path derivation', () => {
     const app = makeApp(t);
     const { flags, args } = requireCommand(buildCliCommands(app));
 
-    // query is auto-promoted to positional, so only structured input flags remain
+    // query is auto-promoted to positional AND kept as --query flag alias
     expect(args).toHaveLength(1);
     expect(args[0]).toMatchObject({ name: 'query' });
-    expect(flags.map((flag) => flag.name)).toEqual(
-      expect.arrayContaining(['input-file', 'input-json', 'stdin'])
-    );
-    expect(flags.find((f) => f.name === 'query')).toBeUndefined();
+    expect(flags.find((f) => f.name === 'query')).toBeDefined();
   });
 
   test('adds --dry-run for destroy intent trails', () => {

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -110,11 +110,13 @@ describe('buildCliCommands path derivation', () => {
       'db.main': dbResource,
       [t.id]: t,
     });
-    const { flags } = requireCommand(buildCliCommands(app));
+    const { flags, args } = requireCommand(buildCliCommands(app));
 
-    const queryFlag = flags.find((f) => f.name === 'query');
+    // Single required string → auto-promoted to positional arg
+    expect(args).toHaveLength(1);
+    expect(args[0]).toMatchObject({ name: 'query', required: true });
+    expect(flags.find((f) => f.name === 'query')).toBeUndefined();
     const limitFlag = flags.find((f) => f.name === 'limit');
-    expect(queryFlag?.required).toBe(true);
     expect(limitFlag?.required).toBe(false);
   });
 
@@ -126,11 +128,15 @@ describe('buildCliCommands path derivation', () => {
       }),
     });
     const app = makeApp(t);
-    const { flags } = requireCommand(buildCliCommands(app));
+    const { flags, args } = requireCommand(buildCliCommands(app));
 
+    // query is auto-promoted to positional, so only structured input flags remain
+    expect(args).toHaveLength(1);
+    expect(args[0]).toMatchObject({ name: 'query' });
     expect(flags.map((flag) => flag.name)).toEqual(
-      expect.arrayContaining(['input-file', 'input-json', 'stdin', 'query'])
+      expect.arrayContaining(['input-file', 'input-json', 'stdin'])
     );
+    expect(flags.find((f) => f.name === 'query')).toBeUndefined();
   });
 
   test('adds --dry-run for destroy intent trails', () => {
@@ -527,6 +533,99 @@ describe('buildCliCommands filtering', () => {
 
     expect(commands).toHaveLength(1);
     expect(commands[0]?.trail.id).toBe('order.create');
+  });
+});
+
+describe('positional arg derivation', () => {
+  test('auto-promotes single required string field to positional arg', () => {
+    const t = trail('file.read', {
+      blaze: (input: { path: string }) => Result.ok(input.path),
+      input: z.object({ path: z.string() }),
+    });
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCliCommands(app));
+
+    expect(cmd.args).toHaveLength(1);
+    expect(cmd.args[0]).toMatchObject({
+      name: 'path',
+      required: true,
+      variadic: false,
+    });
+    // The positional field is kept as a --path flag alias
+    expect(cmd.flags.find((f) => f.name === 'path')).toBeDefined();
+  });
+
+  test('does not auto-promote when multiple required string fields exist', () => {
+    const t = trail('file.copy', {
+      blaze: (input: { dest: string; src: string }) =>
+        Result.ok({ dest: input.dest, src: input.src }),
+      input: z.object({ dest: z.string(), src: z.string() }),
+    });
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCliCommands(app));
+
+    expect(cmd.args).toHaveLength(0);
+    // Both should remain as flags
+    expect(cmd.flags.find((f) => f.name === 'dest')).toBeDefined();
+    expect(cmd.flags.find((f) => f.name === 'src')).toBeDefined();
+  });
+
+  test('auto-promotes single required string alongside other optional fields', () => {
+    const t = trail('search', {
+      blaze: () => Result.ok([]),
+      input: z.object({
+        limit: z.number().optional(),
+        query: z.string(),
+      }),
+    });
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCliCommands(app));
+
+    expect(cmd.args).toHaveLength(1);
+    expect(cmd.args[0]).toMatchObject({ name: 'query', required: true });
+    // query kept as flag alias, limit also present
+    expect(cmd.flags.find((f) => f.name === 'query')).toBeDefined();
+    expect(cmd.flags.find((f) => f.name === 'limit')).toBeDefined();
+  });
+
+  test('explicit positional override promotes field even with multiple strings', () => {
+    const t = trail('file.copy', {
+      blaze: (input: { dest: string; src: string }) =>
+        Result.ok({ dest: input.dest, src: input.src }),
+      fields: { src: { positional: true } },
+      input: z.object({ dest: z.string(), src: z.string() }),
+    });
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCliCommands(app));
+
+    expect(cmd.args).toHaveLength(1);
+    expect(cmd.args[0]).toMatchObject({ name: 'src', required: true });
+    // src kept as flag alias, dest also present
+    expect(cmd.flags.find((f) => f.name === 'src')).toBeDefined();
+    expect(cmd.flags.find((f) => f.name === 'dest')).toBeDefined();
+  });
+
+  test('no positional args when no required string fields exist', () => {
+    const t = trail('config.set', {
+      blaze: (input: { count: number; verbose: boolean }) =>
+        Result.ok({ count: input.count, verbose: input.verbose }),
+      input: z.object({ count: z.number(), verbose: z.boolean() }),
+    });
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCliCommands(app));
+
+    expect(cmd.args).toHaveLength(0);
+  });
+
+  test('does not auto-promote a required string field that has a default', () => {
+    const t = trail('greet', {
+      blaze: (input: { name: string }) => Result.ok(`Hello, ${input.name}`),
+      input: z.object({ name: z.string().default('World') }),
+    });
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCliCommands(app));
+
+    expect(cmd.args).toHaveLength(0);
   });
 });
 

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -602,6 +602,22 @@ describe('positional arg derivation', () => {
     expect(cmd.flags.find((f) => f.name === 'dest')).toBeDefined();
   });
 
+  test('multiple explicit positionals preserve schema declaration order', () => {
+    const t = trail('file.copy', {
+      blaze: (input: { dest: string; src: string }) =>
+        Result.ok({ dest: input.dest, src: input.src }),
+      fields: { dest: { positional: true }, src: { positional: true } },
+      // Positionals follow schema declaration order (alphabetical after formatting)
+      input: z.object({ dest: z.string(), src: z.string() }),
+    });
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCliCommands(app));
+
+    expect(cmd.args).toHaveLength(2);
+    expect(cmd.args[0]?.name).toBe('dest');
+    expect(cmd.args[1]?.name).toBe('src');
+  });
+
   test('no positional args when no required string fields exist', () => {
     const t = trail('config.set', {
       blaze: (input: { count: number; verbose: boolean }) =>

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -585,11 +585,11 @@ describe('positional arg derivation', () => {
     expect(cmd.flags.find((f) => f.name === 'limit')).toBeDefined();
   });
 
-  test('explicit positional override promotes field even with multiple strings', () => {
+  test('explicit args promotes field even with multiple strings', () => {
     const t = trail('file.copy', {
+      args: ['src'],
       blaze: (input: { dest: string; src: string }) =>
         Result.ok({ dest: input.dest, src: input.src }),
-      fields: { src: { positional: true } },
       input: z.object({ dest: z.string(), src: z.string() }),
     });
     const app = makeApp(t);
@@ -602,20 +602,46 @@ describe('positional arg derivation', () => {
     expect(cmd.flags.find((f) => f.name === 'dest')).toBeDefined();
   });
 
-  test('multiple explicit positionals preserve schema declaration order', () => {
+  test('multiple explicit args preserve declared order', () => {
     const t = trail('file.copy', {
+      args: ['src', 'dest'],
       blaze: (input: { dest: string; src: string }) =>
         Result.ok({ dest: input.dest, src: input.src }),
-      fields: { dest: { positional: true }, src: { positional: true } },
-      // Positionals follow schema declaration order (alphabetical after formatting)
       input: z.object({ dest: z.string(), src: z.string() }),
     });
     const app = makeApp(t);
     const cmd = requireCommand(buildCliCommands(app));
 
     expect(cmd.args).toHaveLength(2);
-    expect(cmd.args[0]?.name).toBe('dest');
-    expect(cmd.args[1]?.name).toBe('src');
+    expect(cmd.args[0]?.name).toBe('src');
+    expect(cmd.args[1]?.name).toBe('dest');
+  });
+
+  test('args: false suppresses auto-promotion', () => {
+    const t = trail('file.read', {
+      args: false,
+      blaze: (input: { path: string }) => Result.ok(input.path),
+      input: z.object({ path: z.string() }),
+    });
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCliCommands(app));
+
+    // Single required string would normally be auto-promoted, but args: false suppresses it
+    expect(cmd.args).toHaveLength(0);
+    expect(cmd.flags.find((f) => f.name === 'path')).toBeDefined();
+  });
+
+  test('args with non-existent field name is silently ignored', () => {
+    const t = trail('file.read', {
+      args: ['path', 'nonexistent'],
+      blaze: (input: { path: string }) => Result.ok(input.path),
+      input: z.object({ path: z.string() }),
+    });
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCliCommands(app));
+
+    expect(cmd.args).toHaveLength(1);
+    expect(cmd.args[0]).toMatchObject({ name: 'path', required: true });
   });
 
   test('no positional args when no required string fields exist', () => {

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -4,6 +4,7 @@
 
 import type {
   Field,
+  FieldOverride,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -20,7 +21,7 @@ import {
   validateEstablishedTopo,
 } from '@ontrails/core';
 
-import type { AnyTrail, CliCommand, CliFlag } from './command.js';
+import type { AnyTrail, CliArg, CliCommand, CliFlag } from './command.js';
 import { dryRunPreset, toFlags } from './flags.js';
 import type { InputResolver } from './prompt.js';
 import {
@@ -358,6 +359,63 @@ const buildFlags = (
   return flags;
 };
 
+/** Collect field names explicitly marked as positional in overrides. */
+const collectExplicitPositionals = (
+  overrides?: Readonly<Record<string, FieldOverride>>
+): ReadonlySet<string> => {
+  if (!overrides) {
+    return new Set();
+  }
+  return new Set(
+    Object.entries(overrides)
+      .filter(([, o]) => o.positional === true)
+      .map(([name]) => name)
+  );
+};
+
+/** Auto-promote heuristic: exactly one required string field with no default. */
+const inferPositionalName = (fields: readonly Field[]): ReadonlySet<string> => {
+  const candidates = fields.filter(
+    (f) => f.type === 'string' && f.required && f.default === undefined
+  );
+  const [sole] = candidates;
+  return candidates.length === 1 && sole ? new Set([sole.name]) : new Set();
+};
+
+/** Convert a field to a positional CliArg. */
+const fieldToArg = (field: Field): CliArg => ({
+  description: field.label,
+  name: field.name,
+  required: field.required,
+  variadic: false,
+});
+
+/**
+ * Derive positional args from fields and overrides.
+ *
+ * Explicit: any field with `positional: true` in overrides becomes positional.
+ * Heuristic: if no explicit overrides and exactly one required string field
+ * with no default exists, auto-promote it to positional.
+ */
+const derivePositionalArgs = (
+  fields: readonly Field[],
+  fieldOverrides?: Readonly<Record<string, FieldOverride>>
+): { readonly args: CliArg[]; readonly remainingFields: readonly Field[] } => {
+  const explicit = collectExplicitPositionals(fieldOverrides);
+  const positionalNames =
+    explicit.size > 0 ? explicit : inferPositionalName(fields);
+
+  if (positionalNames.size === 0) {
+    return { args: [], remainingFields: fields };
+  }
+
+  const args = fields
+    .filter((f) => positionalNames.has(f.name))
+    .map(fieldToArg);
+  const remainingFields = fields.filter((f) => !positionalNames.has(f.name));
+  return { args, remainingFields };
+};
+
 /** Convert a trail or route into a CLI command when it is publicly exposed. */
 const toCliCommand = (
   app: Topo,
@@ -365,10 +423,13 @@ const toCliCommand = (
   options?: BuildCliCommandsOptions
 ): CliCommand => {
   const fields = deriveFields(t.input, t.fields);
-  const flags = buildFlags(t, fields, t.intent, options);
-  const derivedFlagNames = new Set(
-    toFlags(fields).map((flag) => kebabToCamel(flag.name))
-  );
+  const { args, remainingFields } = derivePositionalArgs(fields, t.fields);
+  const flags = buildFlags(t, remainingFields, t.intent, options);
+  const positionalArgNames = new Set(args.map((a) => a.name));
+  const derivedFlagNames = new Set([
+    ...toFlags(remainingFields).map((flag) => kebabToCamel(flag.name)),
+    ...positionalArgNames,
+  ]);
   const metaFlagNames = new Set(
     flags
       .map((flag) => kebabToCamel(flag.name))
@@ -382,7 +443,7 @@ const toCliCommand = (
   );
 
   return {
-    args: [],
+    args,
     description: t.description,
     execute: createExecute(
       app,

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -380,12 +380,22 @@ const collectExplicitPositionals = (
 };
 
 /** Auto-promote heuristic: exactly one required string field with no default. */
-const inferPositionalName = (fields: readonly Field[]): ReadonlySet<string> => {
+const inferPositionalName = (
+  fields: readonly Field[],
+  fieldOverrides?: Readonly<Record<string, FieldOverride>>
+): ReadonlySet<string> => {
   const candidates = fields.filter(
     (f) => f.type === 'string' && f.required && f.default === undefined
   );
   const [sole] = candidates;
-  return candidates.length === 1 && sole ? new Set([sole.name]) : new Set();
+  if (candidates.length !== 1 || !sole) {
+    return new Set();
+  }
+  // Allow suppressing auto-promotion with positional: false
+  if (fieldOverrides?.[sole.name]?.positional === false) {
+    return new Set();
+  }
+  return new Set([sole.name]);
 };
 
 /** Convert a field to a positional CliArg. */
@@ -409,7 +419,7 @@ const derivePositionalArgs = (
 ): { readonly args: CliArg[]; readonly remainingFields: readonly Field[] } => {
   const explicit = collectExplicitPositionals(fields, fieldOverrides);
   const positionalNames =
-    explicit.size > 0 ? explicit : inferPositionalName(fields);
+    explicit.size > 0 ? explicit : inferPositionalName(fields, fieldOverrides);
 
   if (positionalNames.size === 0) {
     return { args: [], remainingFields: fields };

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -359,16 +359,22 @@ const buildFlags = (
   return flags;
 };
 
-/** Collect field names explicitly marked as positional in overrides. */
+/** Collect field names explicitly marked as positional (string fields only). */
 const collectExplicitPositionals = (
+  fields: readonly Field[],
   overrides?: Readonly<Record<string, FieldOverride>>
 ): ReadonlySet<string> => {
   if (!overrides) {
     return new Set();
   }
+  const stringFieldNames = new Set(
+    fields.filter((f) => f.type === 'string').map((f) => f.name)
+  );
   return new Set(
     Object.entries(overrides)
-      .filter(([, o]) => o.positional === true)
+      .filter(
+        ([name, o]) => o.positional === true && stringFieldNames.has(name)
+      )
       .map(([name]) => name)
   );
 };
@@ -401,7 +407,7 @@ const derivePositionalArgs = (
   fields: readonly Field[],
   fieldOverrides?: Readonly<Record<string, FieldOverride>>
 ): { readonly args: CliArg[]; readonly remainingFields: readonly Field[] } => {
-  const explicit = collectExplicitPositionals(fieldOverrides);
+  const explicit = collectExplicitPositionals(fields, fieldOverrides);
   const positionalNames =
     explicit.size > 0 ? explicit : inferPositionalName(fields);
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -381,8 +381,11 @@ const derivePositionalArgs = (
   trail: AnyTrail,
   fields: readonly Field[]
 ): { readonly args: CliArg[] } => {
-  // Explicit suppression
-  if (trail.args === false) {
+  // Explicit suppression (false or empty array)
+  if (
+    trail.args === false ||
+    (Array.isArray(trail.args) && trail.args.length === 0)
+  ) {
     return { args: [] };
   }
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -359,10 +359,11 @@ const buildFlags = (
 };
 
 /** Convert a field to a positional CliArg. */
+/** Convert a field to a positional CliArg. Always optional because the flag alias is an alternative. */
 const fieldToArg = (field: Field): CliArg => ({
   description: field.label,
   name: field.name,
-  required: field.required,
+  required: false,
   variadic: false,
 });
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -412,24 +412,39 @@ const fieldToArg = (field: Field): CliArg => ({
  * Explicit: any field with `positional: true` in overrides becomes positional.
  * Heuristic: if no explicit overrides and exactly one required string field
  * with no default exists, auto-promote it to positional.
+ *
+ * Positional args preserve schema declaration order (not alphabetical) because
+ * position is semantically meaningful in CLI usage.
  */
 const derivePositionalArgs = (
   fields: readonly Field[],
+  schemaKeyOrder: readonly string[],
   fieldOverrides?: Readonly<Record<string, FieldOverride>>
-): { readonly args: CliArg[]; readonly remainingFields: readonly Field[] } => {
+): { readonly args: CliArg[] } => {
   const explicit = collectExplicitPositionals(fields, fieldOverrides);
   const positionalNames =
     explicit.size > 0 ? explicit : inferPositionalName(fields, fieldOverrides);
 
   if (positionalNames.size === 0) {
-    return { args: [], remainingFields: fields };
+    return { args: [] };
   }
 
-  const args = fields
-    .filter((f) => positionalNames.has(f.name))
-    .map(fieldToArg);
-  const remainingFields = fields.filter((f) => !positionalNames.has(f.name));
-  return { args, remainingFields };
+  // Sort positional args by schema declaration order, not alphabetical
+  const orderMap = new Map(schemaKeyOrder.map((name, i) => [name, i]));
+  const positionalFields = fields.filter((f) => positionalNames.has(f.name));
+  positionalFields.sort(
+    (a, b) => (orderMap.get(a.name) ?? 0) - (orderMap.get(b.name) ?? 0)
+  );
+  return { args: positionalFields.map(fieldToArg) };
+};
+
+/** Extract schema key order from a Zod object schema (preserves declaration order). */
+const extractSchemaKeyOrder = (schema: unknown): readonly string[] => {
+  const s = schema as unknown as {
+    _zod?: { def?: { shape?: Record<string, unknown> } };
+  };
+  const shape = s._zod?.def?.shape;
+  return shape ? Object.keys(shape) : [];
 };
 
 /** Convert a trail or route into a CLI command when it is publicly exposed. */
@@ -439,7 +454,11 @@ const toCliCommand = (
   options?: BuildCliCommandsOptions
 ): CliCommand => {
   const fields = deriveFields(t.input, t.fields);
-  const { args } = derivePositionalArgs(fields, t.fields);
+  const { args } = derivePositionalArgs(
+    fields,
+    extractSchemaKeyOrder(t.input),
+    t.fields
+  );
   // All fields generate flags — positional fields keep their --flag alias
   const flags = buildFlags(t, fields, t.intent, options);
   const derivedFlagNames = new Set(

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -4,7 +4,6 @@
 
 import type {
   Field,
-  FieldOverride,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -359,45 +358,6 @@ const buildFlags = (
   return flags;
 };
 
-/** Collect field names explicitly marked as positional (string fields only). */
-const collectExplicitPositionals = (
-  fields: readonly Field[],
-  overrides?: Readonly<Record<string, FieldOverride>>
-): ReadonlySet<string> => {
-  if (!overrides) {
-    return new Set();
-  }
-  const stringFieldNames = new Set(
-    fields.filter((f) => f.type === 'string').map((f) => f.name)
-  );
-  return new Set(
-    Object.entries(overrides)
-      .filter(
-        ([name, o]) => o.positional === true && stringFieldNames.has(name)
-      )
-      .map(([name]) => name)
-  );
-};
-
-/** Auto-promote heuristic: exactly one required string field with no default. */
-const inferPositionalName = (
-  fields: readonly Field[],
-  fieldOverrides?: Readonly<Record<string, FieldOverride>>
-): ReadonlySet<string> => {
-  const candidates = fields.filter(
-    (f) => f.type === 'string' && f.required && f.default === undefined
-  );
-  const [sole] = candidates;
-  if (candidates.length !== 1 || !sole) {
-    return new Set();
-  }
-  // Allow suppressing auto-promotion with positional: false
-  if (fieldOverrides?.[sole.name]?.positional === false) {
-    return new Set();
-  }
-  return new Set([sole.name]);
-};
-
 /** Convert a field to a positional CliArg. */
 const fieldToArg = (field: Field): CliArg => ({
   description: field.label,
@@ -407,44 +367,47 @@ const fieldToArg = (field: Field): CliArg => ({
 });
 
 /**
- * Derive positional args from fields and overrides.
+ * Derive positional args from a trail's `args` declaration and fields.
  *
- * Explicit: any field with `positional: true` in overrides becomes positional.
- * Heuristic: if no explicit overrides and exactly one required string field
- * with no default exists, auto-promote it to positional.
+ * - `args: false` — explicit suppression, no positional args.
+ * - `args: string[]` — use the declared order; only string fields are kept.
+ * - `args: undefined` — heuristic: if exactly one required string field with
+ *   no default exists, auto-promote it to positional.
  *
- * Positional args preserve schema declaration order (not alphabetical) because
+ * Positional args preserve `trail.args` order (not alphabetical) because
  * position is semantically meaningful in CLI usage.
  */
 const derivePositionalArgs = (
-  fields: readonly Field[],
-  schemaKeyOrder: readonly string[],
-  fieldOverrides?: Readonly<Record<string, FieldOverride>>
+  trail: AnyTrail,
+  fields: readonly Field[]
 ): { readonly args: CliArg[] } => {
-  const explicit = collectExplicitPositionals(fields, fieldOverrides);
-  const positionalNames =
-    explicit.size > 0 ? explicit : inferPositionalName(fields, fieldOverrides);
-
-  if (positionalNames.size === 0) {
+  // Explicit suppression
+  if (trail.args === false) {
     return { args: [] };
   }
 
-  // Sort positional args by schema declaration order, not alphabetical
-  const orderMap = new Map(schemaKeyOrder.map((name, i) => [name, i]));
-  const positionalFields = fields.filter((f) => positionalNames.has(f.name));
-  positionalFields.sort(
-    (a, b) => (orderMap.get(a.name) ?? 0) - (orderMap.get(b.name) ?? 0)
-  );
-  return { args: positionalFields.map(fieldToArg) };
-};
+  // Explicit args declaration — use the order from the array
+  if (trail.args !== undefined && trail.args.length > 0) {
+    const stringFieldNames = new Set(
+      fields.filter((f) => f.type === 'string').map((f) => f.name)
+    );
+    const validArgs = trail.args
+      .filter((name) => stringFieldNames.has(name))
+      .map((name) => fields.find((f) => f.name === name))
+      .filter((f): f is Field => f !== undefined)
+      .map(fieldToArg);
+    return { args: validArgs };
+  }
 
-/** Extract schema key order from a Zod object schema (preserves declaration order). */
-const extractSchemaKeyOrder = (schema: unknown): readonly string[] => {
-  const s = schema as unknown as {
-    _zod?: { def?: { shape?: Record<string, unknown> } };
-  };
-  const shape = s._zod?.def?.shape;
-  return shape ? Object.keys(shape) : [];
+  // Heuristic: single required string with no default
+  const candidates = fields.filter(
+    (f) => f.type === 'string' && f.required && f.default === undefined
+  );
+  if (candidates.length === 1 && candidates[0]) {
+    return { args: [fieldToArg(candidates[0])] };
+  }
+
+  return { args: [] };
 };
 
 /** Convert a trail or route into a CLI command when it is publicly exposed. */
@@ -454,11 +417,7 @@ const toCliCommand = (
   options?: BuildCliCommandsOptions
 ): CliCommand => {
   const fields = deriveFields(t.input, t.fields);
-  const { args } = derivePositionalArgs(
-    fields,
-    extractSchemaKeyOrder(t.input),
-    t.fields
-  );
+  const { args } = derivePositionalArgs(t, fields);
   // All fields generate flags — positional fields keep their --flag alias
   const flags = buildFlags(t, fields, t.intent, options);
   const derivedFlagNames = new Set(

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -124,10 +124,13 @@ const mergeArgsAndFlags = (
   parsedArgs: Record<string, unknown>,
   parsedFlags: Record<string, unknown>
 ): Record<string, unknown> => {
-  const mergedInput: Record<string, unknown> = {
-    ...structuredInput,
-    ...parsedArgs,
-  };
+  const mergedInput: Record<string, unknown> = { ...structuredInput };
+  // Only merge defined positional args — undefined means the user omitted it
+  for (const [key, value] of Object.entries(parsedArgs)) {
+    if (value !== undefined) {
+      mergedInput[key] = value;
+    }
+  }
   for (const [key, value] of Object.entries(parsedFlags)) {
     if (!metaFlagNames.has(key) && value !== undefined) {
       mergedInput[key] = value;

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -423,13 +423,12 @@ const toCliCommand = (
   options?: BuildCliCommandsOptions
 ): CliCommand => {
   const fields = deriveFields(t.input, t.fields);
-  const { args, remainingFields } = derivePositionalArgs(fields, t.fields);
-  const flags = buildFlags(t, remainingFields, t.intent, options);
-  const positionalArgNames = new Set(args.map((a) => a.name));
-  const derivedFlagNames = new Set([
-    ...toFlags(remainingFields).map((flag) => kebabToCamel(flag.name)),
-    ...positionalArgNames,
-  ]);
+  const { args } = derivePositionalArgs(fields, t.fields);
+  // All fields generate flags — positional fields keep their --flag alias
+  const flags = buildFlags(t, fields, t.intent, options);
+  const derivedFlagNames = new Set(
+    toFlags(fields).map((flag) => kebabToCamel(flag.name))
+  );
   const metaFlagNames = new Set(
     flags
       .map((flag) => kebabToCamel(flag.name))

--- a/packages/core/src/derive.ts
+++ b/packages/core/src/derive.ts
@@ -48,8 +48,6 @@ export interface FieldOverride {
         hint?: string | undefined;
       }[]
     | undefined;
-  /** Mark this field as a CLI positional argument instead of a flag. */
-  readonly positional?: boolean | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/derive.ts
+++ b/packages/core/src/derive.ts
@@ -48,6 +48,8 @@ export interface FieldOverride {
         hint?: string | undefined;
       }[]
     | undefined;
+  /** Mark this field as a CLI positional argument instead of a flag. */
+  readonly positional?: boolean | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -85,6 +85,8 @@ export interface TrailSpec<I, O> {
   readonly on?: readonly (string | AnySignal)[] | undefined;
   /** Auth requirement: scopes object, 'public', or omitted (undeclared) */
   readonly permit?: PermitRequirement | undefined;
+  /** Primary input fields and their order. CLI projects as positional args. */
+  readonly args?: readonly string[] | false | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -97,7 +99,7 @@ export type Intent = 'read' | 'write' | 'destroy';
 /** A fully-defined trail — the unit of work in the Trails system */
 export interface Trail<I, O> extends Omit<
   TrailSpec<I, O>,
-  'blaze' | 'crosses' | 'fires' | 'intent' | 'on' | 'resources'
+  'args' | 'blaze' | 'crosses' | 'fires' | 'intent' | 'on' | 'resources'
 > {
   readonly kind: 'trail';
   readonly id: string;
@@ -112,6 +114,8 @@ export interface Trail<I, O> extends Omit<
   readonly on: readonly string[];
   /** What this trail does to the world (always present, default 'write') */
   readonly intent: Intent;
+  /** Primary input fields and their order (always present, default undefined) */
+  readonly args?: readonly string[] | false | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -161,6 +165,7 @@ export function trail<I, O>(
   }
 
   const {
+    args: rawArgs,
     blaze,
     crosses: rawCrosses,
     fires: rawFires,
@@ -172,9 +177,11 @@ export function trail<I, O>(
   const resources = Object.freeze([...(rawResources ?? [])]);
   const fires = Object.freeze((rawFires ?? []).map(normalizeSignalRef));
   const on = Object.freeze((rawOn ?? []).map(normalizeSignalRef));
+  const args = Array.isArray(rawArgs) ? Object.freeze([...rawArgs]) : rawArgs;
 
   return Object.freeze({
     ...spec,
+    args,
     blaze: async (input: I, ctx: TrailContext) => await blaze(input, ctx),
     crosses: Object.freeze([...(rawCrosses ?? [])]),
     fires,


### PR DESCRIPTION
## Summary
- Auto-derive positional CLI arguments from trail input schemas
- Conservative heuristic: exactly one required string field with no default becomes positional
- Add `positional?: boolean` to `FieldOverride` for explicit opt-in
- Positional fields keep their `--flag` form as a compatibility alias — both syntaxes work

## Test plan
- [x] Single required string → positional arg + flag alias retained
- [x] Multiple required strings → no auto-promotion
- [x] Explicit `fields: { name: { positional: true } }` override works
- [x] Trail with no required strings → no positional args
- [x] Validation rejects executable parents with positional args + child commands

Closes https://linear.app/outfitter/issue/TRL-192

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
