### PR TITLE
feat(cli): auto-discover Trails app entry points [TRL-193]

### DIFF
--- a/apps/trails/src/trails/guide.ts
+++ b/apps/trails/src/trails/guide.ts
@@ -62,10 +62,7 @@ export const guideTrail = trail('guide', {
     },
   ],
   input: z.object({
-    module: z
-      .string()
-      .default('./src/app.ts')
-      .describe('Path to the app module'),
+    module: z.string().optional().describe('Path to the app module'),
     trailId: z.string().optional().describe('Trail ID for detailed guidance'),
   }),
   intent: 'read',

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -3,6 +3,7 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { Topo } from '@ontrails/core';
+import { resolveAppModule } from '@ontrails/cli';
 
 const URL_SCHEME = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
@@ -73,13 +74,18 @@ const importFreshModule = async (
   }
 };
 
+const DEFAULT_MODULE_PATHS = new Set(['./src/app.ts', 'src/app.ts']);
+
 /** Load a Topo export from a module path relative to cwd. */
 export const loadApp = async (
   modulePath: string,
   cwd: string,
   options: { fresh?: boolean | undefined } = {}
 ): Promise<Topo> => {
-  const resolvedModulePath = resolveAbsoluteModulePath(modulePath, cwd);
+  const effectivePath = DEFAULT_MODULE_PATHS.has(modulePath)
+    ? resolveAppModule(cwd)
+    : modulePath;
+  const resolvedModulePath = resolveAbsoluteModulePath(effectivePath, cwd);
   const mod =
     options.fresh === true
       ? await importFreshModule(modulePath, cwd)
@@ -92,7 +98,7 @@ export const loadApp = async (
   const app = (mod['default'] ?? mod['app']) as Topo | undefined;
   if (!app?.trails) {
     throw new Error(
-      `Could not find a Topo export in "${modulePath}". ` +
+      `Could not find a Topo export in "${effectivePath}". ` +
         "Expected a default or named 'app' export created with topo()."
     );
   }

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -88,7 +88,7 @@ export const loadApp = async (
   const resolvedModulePath = resolveAbsoluteModulePath(effectivePath, cwd);
   const mod =
     options.fresh === true
-      ? await importFreshModule(modulePath, cwd)
+      ? await importFreshModule(effectivePath, cwd)
       : ((await import(
           URL_SCHEME.test(resolvedModulePath) &&
             !resolvedModulePath.startsWith('/')

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -74,17 +74,14 @@ const importFreshModule = async (
   }
 };
 
-const DEFAULT_MODULE_PATHS = new Set(['./src/app.ts', 'src/app.ts']);
-
 /** Load a Topo export from a module path relative to cwd. */
 export const loadApp = async (
-  modulePath: string,
+  modulePath: string | undefined,
   cwd: string,
   options: { fresh?: boolean | undefined } = {}
 ): Promise<Topo> => {
-  const effectivePath = DEFAULT_MODULE_PATHS.has(modulePath)
-    ? resolveAppModule(cwd)
-    : modulePath;
+  const effectivePath =
+    modulePath === undefined ? resolveAppModule(cwd) : modulePath;
   const resolvedModulePath = resolveAbsoluteModulePath(effectivePath, cwd);
   const mod =
     options.fresh === true

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -196,10 +196,7 @@ export const surveyTrail = trail('survey', {
       .boolean()
       .default(false)
       .describe('Generate trailhead map and lock file'),
-    module: z
-      .string()
-      .default('./src/app.ts')
-      .describe('Path to the app module'),
+    module: z.string().optional().describe('Path to the app module'),
     openapi: z.boolean().default(false).describe('Output OpenAPI 3.1 spec'),
     trailId: z.string().optional().describe('Trail ID for detail view'),
   }),

--- a/apps/trails/src/trails/topo-export.ts
+++ b/apps/trails/src/trails/topo-export.ts
@@ -3,11 +3,7 @@ import { z } from 'zod';
 
 import { loadApp } from './load-app.js';
 import { exportCurrentTopo } from './topo-store-support.js';
-import {
-  DEFAULT_APP_MODULE,
-  isolatedExampleInput,
-  topoSaveOutput,
-} from './topo-support.js';
+import { isolatedExampleInput, topoSaveOutput } from './topo-support.js';
 
 export const topoExportTrail = trail('topo.export', {
   blaze: async (input, ctx) => {
@@ -23,10 +19,7 @@ export const topoExportTrail = trail('topo.export', {
     },
   ],
   input: z.object({
-    module: z
-      .string()
-      .default(DEFAULT_APP_MODULE)
-      .describe('Path to the app module'),
+    module: z.string().optional().describe('Path to the app module'),
     rootDir: z.string().optional().describe('Workspace root directory'),
   }),
   intent: 'write',

--- a/apps/trails/src/trails/topo-pin.ts
+++ b/apps/trails/src/trails/topo-pin.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 
 import { loadApp } from './load-app.js';
 import {
-  DEFAULT_APP_MODULE,
   isolatedExampleInput,
   pinCurrentTopo,
   topoPinOutput,
@@ -27,10 +26,7 @@ export const topoPinTrail = trail('topo.pin', {
     },
   ],
   input: z.object({
-    module: z
-      .string()
-      .default(DEFAULT_APP_MODULE)
-      .describe('Path to the app module'),
+    module: z.string().optional().describe('Path to the app module'),
     name: z.string().describe('Pin name'),
     rootDir: z.string().optional().describe('Workspace root directory'),
   }),

--- a/apps/trails/src/trails/topo-show.ts
+++ b/apps/trails/src/trails/topo-show.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 
 import { loadApp } from './load-app.js';
 import { buildCurrentTopoDetail } from './topo-read-support.js';
-import { DEFAULT_APP_MODULE } from './topo-support.js';
 
 const trailDetailOutput = z.object({
   crosses: z.array(z.string()),
@@ -47,10 +46,7 @@ export const topoShowTrail = trail('topo.show', {
   ],
   input: z.object({
     id: z.string().describe('Trail or resource ID to inspect'),
-    module: z
-      .string()
-      .default(DEFAULT_APP_MODULE)
-      .describe('Path to the app module'),
+    module: z.string().optional().describe('Path to the app module'),
     rootDir: z.string().optional().describe('Workspace root directory'),
   }),
   intent: 'read',

--- a/apps/trails/src/trails/topo-verify.ts
+++ b/apps/trails/src/trails/topo-verify.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 
 import { loadApp } from './load-app.js';
 import { verifyCurrentTopo } from './topo-read-support.js';
-import { DEFAULT_APP_MODULE } from './topo-support.js';
 
 export const topoVerifyTrail = trail('topo.verify', {
   blaze: async (input, ctx) => {
@@ -13,10 +12,7 @@ export const topoVerifyTrail = trail('topo.verify', {
   },
   description: 'Verify that the committed lockfile matches the current topo',
   input: z.object({
-    module: z
-      .string()
-      .default(DEFAULT_APP_MODULE)
-      .describe('Path to the app module'),
+    module: z.string().optional().describe('Path to the app module'),
     rootDir: z.string().optional().describe('Workspace root directory'),
   }),
   intent: 'read',

--- a/apps/trails/src/trails/topo.ts
+++ b/apps/trails/src/trails/topo.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 
 import { loadApp } from './load-app.js';
 import { buildTopoSummary } from './topo-read-support.js';
-import { DEFAULT_APP_MODULE } from './topo-support.js';
 
 const summaryOutput = z.object({
   app: z.object({
@@ -62,10 +61,7 @@ export const topoTrail = trail('topo', {
     },
   ],
   input: z.object({
-    module: z
-      .string()
-      .default(DEFAULT_APP_MODULE)
-      .describe('Path to the app module'),
+    module: z.string().optional().describe('Path to the app module'),
     rootDir: z.string().optional().describe('Workspace root directory'),
   }),
   intent: 'read',

--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -24,7 +24,7 @@ export const wardenTrail = trail('warden', {
   blaze: async (input, ctx) => {
     const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
     // oxlint-disable-next-line prefer-await-to-then -- catch converts rejection to undefined cleanly
-    const topo = await loadApp(undefined, rootDir).catch(
+    const topo = await loadApp(input.module, rootDir).catch(
       (): undefined => undefined
     );
 
@@ -76,6 +76,10 @@ export const wardenTrail = trail('warden', {
       .default('text')
       .describe('Output format: text, json, github, or summary'),
     lintOnly: z.boolean().default(false).describe('Only run lint rules'),
+    module: z
+      .string()
+      .optional()
+      .describe('App module path (auto-discovered if omitted)'),
     rootDir: z.string().optional().describe('Root directory to scan'),
   }),
   intent: 'read',

--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -24,7 +24,7 @@ export const wardenTrail = trail('warden', {
   blaze: async (input, ctx) => {
     const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
     // oxlint-disable-next-line prefer-await-to-then -- catch converts rejection to undefined cleanly
-    const topo = await loadApp('./src/app.ts', rootDir).catch(
+    const topo = await loadApp(undefined, rootDir).catch(
       (): undefined => undefined
     );
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -270,6 +270,15 @@ export const listUsers = trail('user.list', {
 
 The `resources: [db]` declaration tells the topo which infrastructure this trail depends on. Access the resource instance through `db.from(ctx)` for typed access. When you run `testAll(app)`, the framework automatically resolves `mock` factories — no configuration needed for example-based tests.
 
+## Trails CLI Auto-Discovery
+
+The `trails` CLI commands (`topo`, `survey`, `guide`, etc.) automatically discover your app entry point when run from the workspace root. No `--module` flag needed if your app follows one of these layouts:
+
+- **Single-app:** `src/app.ts`
+- **Monorepo:** `apps/*/src/app.ts`
+
+If multiple candidates are found, the CLI lists them and asks you to select one with `--module`.
+
 ## What's Next
 
 - [Architecture](./architecture.md) -- How the hexagonal model works

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -115,6 +115,28 @@ auto-promotion entirely, or `undefined` (omit) for the heuristic.
 myapp file copy ./readme.md --dest /tmp/readme.md
 ```
 
+## App auto-discovery
+
+When running from the workspace root without an explicit `--module` flag, the CLI
+automatically discovers your app entry point:
+
+1. `src/app.ts` (single-app layout)
+2. `apps/*/src/app.ts` (monorepo convention)
+
+If exactly one candidate is found, it is used automatically. If multiple
+candidates are found, the CLI lists them and asks you to choose with `--module`.
+
+```bash
+# Auto-discovers src/app.ts — no --module needed
+myapp topo
+
+# Explicit when multiple apps exist
+myapp topo --module ./apps/api/src/app.ts
+```
+
+Use `discoverAppModules(cwd)` and `resolveAppModule(cwd, explicit?)` directly
+for programmatic access.
+
 ## Structured input
 
 For every non-empty object input schema, the CLI also exposes:

--- a/packages/cli/src/__tests__/discover.test.ts
+++ b/packages/cli/src/__tests__/discover.test.ts
@@ -1,0 +1,155 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { AmbiguousError, NotFoundError } from '@ontrails/core';
+
+import { discoverAppModules, resolveAppModule } from '../discover.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeTempDir = (): string => {
+  const dir = join(
+    tmpdir(),
+    `trails-discover-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+};
+
+const touchFile = (dir: string, relativePath: string): void => {
+  const fullPath = join(dir, relativePath);
+  mkdirSync(join(fullPath, '..'), { recursive: true });
+  writeFileSync(fullPath, '// stub');
+};
+
+// ---------------------------------------------------------------------------
+// discoverAppModules
+// ---------------------------------------------------------------------------
+
+describe('discoverAppModules', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  test('finds src/app.ts in single-app layout', () => {
+    touchFile(tempDir, 'src/app.ts');
+
+    const result = discoverAppModules(tempDir);
+
+    expect(result).toEqual([join(tempDir, 'src/app.ts')]);
+  });
+
+  test('finds apps/*/src/app.ts in monorepo layout', () => {
+    touchFile(tempDir, 'apps/myapp/src/app.ts');
+
+    const result = discoverAppModules(tempDir);
+
+    expect(result).toEqual([join(tempDir, 'apps/myapp/src/app.ts')]);
+  });
+
+  test('returns empty array when nothing found', () => {
+    const result = discoverAppModules(tempDir);
+
+    expect(result).toEqual([]);
+  });
+
+  test('finds both single-app and monorepo candidates', () => {
+    touchFile(tempDir, 'src/app.ts');
+    touchFile(tempDir, 'apps/alpha/src/app.ts');
+    touchFile(tempDir, 'apps/beta/src/app.ts');
+
+    const result = discoverAppModules(tempDir);
+
+    expect(result).toHaveLength(3);
+    expect(result).toContain(join(tempDir, 'src/app.ts'));
+    expect(result).toContain(join(tempDir, 'apps/alpha/src/app.ts'));
+    expect(result).toContain(join(tempDir, 'apps/beta/src/app.ts'));
+  });
+
+  test('returns single-app candidate first', () => {
+    touchFile(tempDir, 'src/app.ts');
+    touchFile(tempDir, 'apps/myapp/src/app.ts');
+
+    const result = discoverAppModules(tempDir);
+
+    expect(result[0]).toBe(join(tempDir, 'src/app.ts'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAppModule
+// ---------------------------------------------------------------------------
+
+describe('resolveAppModule', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  test('returns explicit module path when provided', () => {
+    const result = resolveAppModule(tempDir, './custom/entry.ts');
+
+    expect(result).toBe('./custom/entry.ts');
+  });
+
+  test('returns single discovered module', () => {
+    touchFile(tempDir, 'src/app.ts');
+
+    const result = resolveAppModule(tempDir);
+
+    expect(result).toBe(join(tempDir, 'src/app.ts'));
+  });
+
+  test('throws AmbiguousError for multiple candidates', () => {
+    touchFile(tempDir, 'src/app.ts');
+    touchFile(tempDir, 'apps/alpha/src/app.ts');
+
+    expect(() => resolveAppModule(tempDir)).toThrow(AmbiguousError);
+  });
+
+  test('ambiguous error message lists candidates and suggests --module', () => {
+    touchFile(tempDir, 'src/app.ts');
+    touchFile(tempDir, 'apps/alpha/src/app.ts');
+
+    try {
+      resolveAppModule(tempDir);
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AmbiguousError);
+      const { message } = error as AmbiguousError;
+      expect(message).toContain('--module');
+      expect(message).toContain('src/app.ts');
+      expect(message).toContain('apps/alpha/src/app.ts');
+    }
+  });
+
+  test('throws NotFoundError when no candidates found', () => {
+    expect(() => resolveAppModule(tempDir)).toThrow(NotFoundError);
+  });
+
+  test('not-found error message is helpful', () => {
+    try {
+      resolveAppModule(tempDir);
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(NotFoundError);
+      const { message } = error as NotFoundError;
+      expect(message).toContain('src/app.ts');
+    }
+  });
+});

--- a/packages/cli/src/__tests__/discover.test.ts
+++ b/packages/cli/src/__tests__/discover.test.ts
@@ -46,7 +46,7 @@ describe('discoverAppModules', () => {
 
     const result = discoverAppModules(tempDir);
 
-    expect(result).toEqual([join(tempDir, 'src/app.ts')]);
+    expect(result).toEqual(['src/app.ts']);
   });
 
   test('finds apps/*/src/app.ts in monorepo layout', () => {
@@ -54,7 +54,7 @@ describe('discoverAppModules', () => {
 
     const result = discoverAppModules(tempDir);
 
-    expect(result).toEqual([join(tempDir, 'apps/myapp/src/app.ts')]);
+    expect(result).toEqual(['apps/myapp/src/app.ts']);
   });
 
   test('returns empty array when nothing found', () => {
@@ -71,9 +71,9 @@ describe('discoverAppModules', () => {
     const result = discoverAppModules(tempDir);
 
     expect(result).toHaveLength(3);
-    expect(result).toContain(join(tempDir, 'src/app.ts'));
-    expect(result).toContain(join(tempDir, 'apps/alpha/src/app.ts'));
-    expect(result).toContain(join(tempDir, 'apps/beta/src/app.ts'));
+    expect(result).toContain('src/app.ts');
+    expect(result).toContain('apps/alpha/src/app.ts');
+    expect(result).toContain('apps/beta/src/app.ts');
   });
 
   test('returns single-app candidate first', () => {
@@ -82,7 +82,7 @@ describe('discoverAppModules', () => {
 
     const result = discoverAppModules(tempDir);
 
-    expect(result[0]).toBe(join(tempDir, 'src/app.ts'));
+    expect(result[0]).toBe('src/app.ts');
   });
 });
 
@@ -112,7 +112,7 @@ describe('resolveAppModule', () => {
 
     const result = resolveAppModule(tempDir);
 
-    expect(result).toBe(join(tempDir, 'src/app.ts'));
+    expect(result).toBe('src/app.ts');
   });
 
   test('throws AmbiguousError for multiple candidates', () => {

--- a/packages/cli/src/discover.ts
+++ b/packages/cli/src/discover.ts
@@ -1,0 +1,60 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { AmbiguousError, NotFoundError } from '@ontrails/core';
+
+/**
+ * Scan for Trails app entry points using fast heuristics (no AST parsing).
+ *
+ * Checks candidates in priority order:
+ * 1. `src/app.ts` relative to cwd (single-app layout)
+ * 2. `apps/* /src/app.ts` via glob (monorepo convention)
+ *
+ * Returns candidate module paths sorted by specificity (most specific first).
+ */
+export const discoverAppModules = (cwd: string): string[] => {
+  const candidates: string[] = [];
+
+  const singleApp = join(cwd, 'src/app.ts');
+  if (existsSync(singleApp)) {
+    candidates.push(singleApp);
+  }
+
+  const glob = new Bun.Glob('apps/*/src/app.ts');
+  for (const match of glob.scanSync({ cwd, onlyFiles: true })) {
+    candidates.push(join(cwd, match));
+  }
+
+  return candidates;
+};
+
+/**
+ * Resolve the app module path, using discovery when no explicit path is provided.
+ *
+ * When `explicit` is provided, returns it as-is without discovery.
+ * Otherwise discovers candidates and returns the single match, or throws
+ * `NotFoundError` (none found) or `AmbiguousError` (multiple found).
+ */
+export const resolveAppModule = (cwd: string, explicit?: string): string => {
+  if (explicit !== undefined) {
+    return explicit;
+  }
+
+  const candidates = discoverAppModules(cwd);
+
+  const [first] = candidates;
+  if (candidates.length === 1 && first !== undefined) {
+    return first;
+  }
+
+  if (candidates.length > 1) {
+    const listing = candidates.map((c) => `  - ${c}`).join('\n');
+    throw new AmbiguousError(
+      `Found multiple Trails app entry points:\n${listing}\n\nUse --module to select one explicitly.`
+    );
+  }
+
+  throw new NotFoundError(
+    'No Trails app entry point found. Expected src/app.ts or apps/*/src/app.ts. Use --module to specify the path.'
+  );
+};

--- a/packages/cli/src/discover.ts
+++ b/packages/cli/src/discover.ts
@@ -10,31 +10,25 @@ import { AmbiguousError, NotFoundError } from '@ontrails/core';
  * 1. `src/app.ts` relative to cwd (single-app layout)
  * 2. `apps/* /src/app.ts` via glob (monorepo convention)
  *
- * Returns candidate module paths sorted by specificity (most specific first).
+ * Returns relative candidate paths in priority order: single-app layout
+ * first, then monorepo entries in filesystem scan order.
  */
 export const discoverAppModules = (cwd: string): string[] => {
   const candidates: string[] = [];
 
-  const singleApp = join(cwd, 'src/app.ts');
-  if (existsSync(singleApp)) {
-    candidates.push(singleApp);
+  if (existsSync(join(cwd, 'src/app.ts'))) {
+    candidates.push('src/app.ts');
   }
 
   const glob = new Bun.Glob('apps/*/src/app.ts');
   for (const match of glob.scanSync({ cwd, onlyFiles: true })) {
-    candidates.push(join(cwd, match));
+    candidates.push(match);
   }
 
   return candidates;
 };
 
-/**
- * Resolve the app module path, using discovery when no explicit path is provided.
- *
- * When `explicit` is provided, returns it as-is without discovery.
- * Otherwise discovers candidates and returns the single match, or throws
- * `NotFoundError` (none found) or `AmbiguousError` (multiple found).
- */
+/** Resolve the app module path, using discovery when no explicit path is provided. */
 export const resolveAppModule = (cwd: string, explicit?: string): string => {
   if (explicit !== undefined) {
     return explicit;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,5 +25,8 @@ export { defaultOnResult } from './on-result.js';
 export { passthroughResolver, isInteractive } from './prompt.js';
 export type { Field, InputResolver, ResolveInputOptions } from './prompt.js';
 
+// Discovery
+export { discoverAppModules, resolveAppModule } from './discover.js';
+
 // Layers
 export { autoIterateLayer, dateShortcutsLayer } from './layers.js';


### PR DESCRIPTION
## Summary
- New `discoverAppModules(cwd)` and `resolveAppModule(cwd, explicit?)` in `@ontrails/cli`
- Scans `src/app.ts` and `apps/*/src/app.ts` using fast file-existence checks
- Wired into `loadApp()` — auto-discovery runs when `--module` matches the default
- Fixed: fresh mode now uses the discovered path, not the original default
- Multiple candidates → error with list; no candidates → helpful NotFoundError

## Test plan
- [x] Discovers `src/app.ts` in single-app layout
- [x] Discovers `apps/*/src/app.ts` in monorepo layout
- [x] `resolveAppModule` throws for ambiguous/missing
- [x] Explicit `--module` bypasses discovery
- [x] Fresh mode uses discovered path

Closes https://linear.app/outfitter/issue/TRL-193

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
