### PR TITLE
feat(trails): adopt positional args and auto-discovery [TRL-218]

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,8 +122,9 @@ Options:
 
 When a trail has exactly one required string field with no default, the CLI
 automatically promotes it to a positional argument. You can still pass it as a
-flag (`--name World`), but the positional form is shorter. If you need to
-override this heuristic, use `fields` in the CLI trailhead config.
+flag (`--name World`), but the positional form is shorter. To suppress
+auto-promotion, set `args: false` on the trail definition (see the
+[CLI trailhead guide](./trailheads/cli.md#positional-args)).
 
 ## Open an MCP Trailhead
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ $ bun src/cli.ts greet --name World --loud
 { "message": "HELLO, WORLD!" }
 
 $ bun src/cli.ts greet --help
-Usage: myapp greet [options] <name>
+Usage: myapp greet [options] [name]
 
 Greet someone by name
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -287,7 +287,7 @@ The `trails` CLI commands (`topo`, `survey`, `guide`, etc.) automatically discov
 - **Single-app:** `src/app.ts`
 - **Monorepo:** `apps/*/src/app.ts`
 
-If multiple candidates are found, the CLI lists them and asks you to select one with `--module`.
+If multiple candidates are found, the CLI exits with an error listing them; pass `--module` to specify which one to use.
 
 ## What's Next
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ $ bun src/cli.ts greet --name World --loud
 { "message": "HELLO, WORLD!" }
 
 $ bun src/cli.ts greet --help
-Usage: myapp greet [options] [name]
+Usage: myapp greet [options] <name>
 
 Greet someone by name
 
@@ -115,8 +115,8 @@ Arguments:
   name            Who to greet
 
 Options:
+  --name <value>  Who to greet
   --loud          Shout the greeting (default: false)
-  -o, --output <mode>  Output format (choices: "text", "json", "jsonl", default: "text")
   -h, --help      display help for command
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ export const greet = trail('greet', {
 What you get from this single definition:
 
 - A typed implementation that receives validated input and returns `Result`
-- CLI flags derived from the Zod schema: `--name <value>`, `--loud`
+- CLI derivation: `name` auto-promoted to a positional arg (sole required string), `--loud` as a flag
 - An MCP tool with JSON Schema input and annotations (`readOnlyHint: true`)
 - Two examples that serve as agent documentation AND test cases
 - Sync authoring for pure work, with the runtime normalized to one awaitable execution shape for layers and trailheads
@@ -97,23 +97,33 @@ trailhead(app);
 Run it:
 
 ```bash
-$ bun src/cli.ts greet --name World
+# Positional arg — `name` is the sole required string field,
+# so the CLI auto-promotes it to a positional argument.
+$ bun src/cli.ts greet World
 { "message": "Hello, World!" }
 
+# Flags still work as an alternative.
 $ bun src/cli.ts greet --name World --loud
 { "message": "HELLO, WORLD!" }
 
 $ bun src/cli.ts greet --help
-Usage: myapp greet [options]
+Usage: myapp greet [options] [name]
 
 Greet someone by name
 
+Arguments:
+  name            Who to greet
+
 Options:
-  --name <value>  Who to greet
   --loud          Shout the greeting (default: false)
   -o, --output <mode>  Output format (choices: "text", "json", "jsonl", default: "text")
   -h, --help      display help for command
 ```
+
+When a trail has exactly one required string field with no default, the CLI
+automatically promotes it to a positional argument. You can still pass it as a
+flag (`--name World`), but the positional form is shorter. If you need to
+override this heuristic, use `fields` in the CLI trailhead config.
 
 ## Open an MCP Trailhead
 

--- a/docs/trailheads/cli.md
+++ b/docs/trailheads/cli.md
@@ -79,8 +79,10 @@ const search = trail('search', {
 Produces:
 
 ```text
+Arguments:
+  query             Search query
+
 Options:
-  --query <value>   Search query
   --limit [value]   Max results (default: 10)
   --format <value>  (choices: "json", "table", default: "json")
 ```

--- a/docs/trailheads/cli.md
+++ b/docs/trailheads/cli.md
@@ -83,8 +83,9 @@ Arguments:
   query             Search query
 
 Options:
+  --query <value>   Search query
   --limit [value]   Max results (default: 10)
-  --format <value>  (choices: "json", "table", default: "json")
+  --format [value]  (choices: "json", "table", default: "json")
 ```
 
 ## Positional Args


### PR DESCRIPTION
## Summary
- Verified `topo pin` and `topo unpin` auto-promote their `name` field to positional
- Verified auto-discovery works for topo commands from workspace root
- Updated `docs/getting-started.md` and `docs/trailheads/cli.md` with positional syntax examples
- Scaffold templates naturally benefit from the heuristic

## Test plan
- [x] `topo pin v1.0` works (positional)
- [x] `topo unpin v1.0` works (positional)
- [x] Auto-discovery resolves `--module` automatically
- [x] Docs reflect new behavior

Closes https://linear.app/outfitter/issue/TRL-218

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
