### PR TITLE
feat(testing): add expectedMatch assertions and scenario() runner [TRL-217]

### DIFF
--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -85,7 +85,7 @@ export const loadApp = async (
   const resolvedModulePath = resolveAbsoluteModulePath(effectivePath, cwd);
   const mod =
     options.fresh === true
-      ? await importFreshModule(effectivePath, cwd)
+      ? await importFreshModule(resolvedModulePath, cwd)
       : ((await import(
           URL_SCHEME.test(resolvedModulePath) &&
             !resolvedModulePath.startsWith('/')

--- a/docs/adr/0025-composition-testing.md
+++ b/docs/adr/0025-composition-testing.md
@@ -1,7 +1,7 @@
 ---
 slug: composition-testing
 title: Composition Testing
-status: draft
+status: accepted
 created: 2026-04-09
 updated: 2026-04-09
 owners: ['[galligan](https://github.com/galligan)']

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,3 +31,4 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0022](0022-drizzle-store-connector.md) | Drizzle Binds Schema-Derived Stores to SQLite | Accepted |
 | [0023](0023-simplifying-the-trails-lexicon.md) | Simplifying the Trails Lexicon | Accepted |
 | [0024](0024-typed-trail-composition.md) | Typed Trail Composition | Accepted |
+| [0025](0025-composition-testing.md) | Composition Testing | Accepted |

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -36,8 +36,6 @@ Proposed decisions under discussion. Promoted to `docs/adr/` when accepted.
 - [Documentation structure](20260406-documentation-structure.md)
 - [Backend-Agnostic Store Schemas](20260409-backend-agnostic-store-schemas.md)
   - depends on [ADR-0009: First-Class Resources](../0009-first-class-resources.md), [ADR-0014: Core Database Primitive](../0014-core-database-primitive.md), [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md), [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md), [Connector Extraction and the with-* Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md)
-- [Composition Testing](20260409-composition-testing.md)
-  - depends on [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md), [ADR-0007: Governance as Trails with AST-Based Analysis](../0007-governance-as-trails.md), [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md)
 - [Connector Extraction and the with-* Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md)
   - depends on [ADR-0009: First-Class Resources](../0009-first-class-resources.md), [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md), [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md), [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md)
 - [Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -140,9 +140,29 @@ examples: [
 
 Asserts `result.isOk()` and `result.value` deep-equals `expected`.
 
+### Partial Match
+
+Example has `expectedMatch` — asserts the output contains the declared fields with matching values, ignoring extra keys. Ideal for composite trails where some output fields are generated or unpredictable:
+
+```typescript
+examples: [
+  {
+    name: 'Fork preserves content',
+    input: { id: 'g1' },
+    expectedMatch: {
+      content: '# Hello',
+      forkedFrom: 'g1',
+    },
+    // id, createdAt, etc. are NOT asserted — they're generated
+  },
+];
+```
+
+Asserts `result.isOk()` and that `result.value` is a superset of `expectedMatch`. Scalars match strictly, objects match recursively (extra keys ignored), arrays match as order-independent subsets.
+
 ### Schema-Only Match
 
-Example has no `expected` and no `error`:
+Example has no `expected`, no `expectedMatch`, and no `error`:
 
 ```typescript
 examples: [{ name: 'Returns something valid', input: { name: 'Alpha' } }];
@@ -236,6 +256,35 @@ import { testDetours } from '@ontrails/testing';
 testDetours(app);
 // Fails: Trail "entity.show" has detour target "entity.search" which does not exist in the topo
 ```
+
+## `scenario(name, app, steps)`
+
+Multi-step journey testing for flows that span multiple trail invocations. Scenarios live in test files alongside `testAll` — they test how trails compose, not what individual trails do.
+
+```typescript
+import { ref, scenario } from '@ontrails/testing';
+
+scenario('Fork flow', app, [
+  {
+    cross: createGist,
+    input: { description: 'Original', content: '# Hello' },
+    as: 'original',
+  },
+  {
+    cross: forkGist,
+    input: { id: ref('original.id') },
+    as: 'forked',
+    expectedMatch: {
+      content: '# Hello',
+      forkedFrom: ref('original.id'),
+    },
+  },
+]);
+```
+
+Each step executes through the normal pipeline (validation, layers, resources, tracing). `ref()` resolves cross-step references from prior step outputs. If a step fails, the scenario reports which step and why.
+
+`expectedMatch` on steps uses the same subset matching as trail examples. `expected` is also supported for exact matching.
 
 ## Test Context and Mocks
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -94,7 +94,7 @@ const greet = trail('greet', {
 
 ```bash
 myapp greet World          # positional
-myapp greet --name World   # flag form still works via structured input
+myapp greet --name World   # flag alias is kept for backward compatibility
 ```
 
 The heuristic is intentionally conservative: multiple required strings stay as

--- a/packages/core/src/cross-schema.ts
+++ b/packages/core/src/cross-schema.ts
@@ -1,0 +1,36 @@
+/**
+ * Cross-invocation schema merging for trails with `crossInput`.
+ *
+ * When a trail declares `crossInput`, callers via `ctx.cross()` pass both
+ * public input and composition-only fields. The merged schema validates the
+ * combined shape so `executeTrail` doesn't reject the extra fields.
+ */
+
+import { z } from 'zod';
+
+import type { AnyTrail } from './trail.js';
+
+/**
+ * Build the validation schema for a cross-invoked trail.
+ *
+ * When the target trail declares `crossInput`, returns the intersection of
+ * `trail.input` and `trail.crossInput`. Returns `undefined` when no
+ * `crossInput` is declared, signaling that normal input validation suffices.
+ */
+export const buildCrossValidationSchema = (
+  trailDef: AnyTrail
+): z.ZodType | undefined => {
+  if (!trailDef.crossInput) {
+    return undefined;
+  }
+  // Prefer .merge() for ZodObject pairs — produces a proper merged object
+  // schema that strips unknown keys and exposes .shape. Fall back to
+  // z.intersection for non-object schemas.
+  if (
+    trailDef.input instanceof z.ZodObject &&
+    trailDef.crossInput instanceof z.ZodObject
+  ) {
+    return trailDef.input.merge(trailDef.crossInput);
+  }
+  return z.intersection(trailDef.input, trailDef.crossInput);
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,6 +131,9 @@ export type { Layer } from './layer.js';
 export { deriveCliPath, deriveFields } from './derive.js';
 export type { Field, FieldOverride } from './derive.js';
 
+// Cross schema
+export { buildCrossValidationSchema } from './cross-schema.js';
+
 // Execute
 export { executeTrail } from './execute.js';
 export type { ExecuteTrailOptions } from './execute.js';

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -92,6 +92,7 @@ interface TopoExampleRow {
   readonly description: string | null;
   readonly error: string | null;
   readonly expected: string | null;
+  readonly expectedMatch: string | null;
   readonly id: string;
   readonly input: string;
   readonly name: string;
@@ -409,6 +410,10 @@ const normalizeExampleRows = (
       error: example.error ?? null,
       expected:
         example.expected === undefined ? null : stableJson(example.expected),
+      expectedMatch:
+        example.expectedMatch === undefined
+          ? null
+          : stableJson(example.expectedMatch),
       id: buildExampleId(saveId, trail.id, index),
       input: stableJson(example.input),
       name: example.name,

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -28,8 +28,10 @@ export interface TrailExample<I, O> {
   readonly description?: string | undefined;
   /** The input value — fields with schema defaults may be omitted */
   readonly input: Partial<I>;
-  /** Expected output for success-path examples */
+  /** Expected output for success-path examples (deep equality) */
   readonly expected?: O | undefined;
+  /** Partial output assertion — declared fields must match, others ignored */
+  readonly expectedMatch?: Partial<O> | undefined;
   /** Error class name for error-path examples */
   readonly error?: string | undefined;
 }

--- a/packages/testing/src/__tests__/partial-match.test.ts
+++ b/packages/testing/src/__tests__/partial-match.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result } from '@ontrails/core';
+
+import { assertPartialMatch } from '../assertions.js';
+
+describe('assertPartialMatch', () => {
+  describe('scalar values', () => {
+    test('passes with exact scalar match', () => {
+      const result = Result.ok('hello');
+      assertPartialMatch(result, 'hello');
+    });
+
+    test('passes with numeric match', () => {
+      const result = Result.ok(42);
+      assertPartialMatch(result, 42);
+    });
+
+    test('fails when scalar does not match', () => {
+      const result = Result.ok('hello');
+      expect(() => assertPartialMatch(result, 'world')).toThrow();
+    });
+  });
+
+  describe('object subset', () => {
+    test('passes with full match', () => {
+      const result = Result.ok({ id: '1', name: 'Alpha', type: 'concept' });
+      assertPartialMatch(result, { id: '1', name: 'Alpha', type: 'concept' });
+    });
+
+    test('passes with partial match (extra keys in actual ignored)', () => {
+      const result = Result.ok({
+        createdAt: '2026-01-01',
+        id: '1',
+        name: 'Alpha',
+        type: 'concept',
+      });
+      assertPartialMatch(result, { name: 'Alpha', type: 'concept' });
+    });
+
+    test('fails when expected key is missing from actual', () => {
+      const result = Result.ok({ id: '1', name: 'Alpha' });
+      expect(() =>
+        assertPartialMatch(result, { missing: true, name: 'Alpha' })
+      ).toThrow();
+    });
+
+    test('fails when expected value does not match', () => {
+      const result = Result.ok({ id: '1', name: 'Alpha' });
+      expect(() => assertPartialMatch(result, { name: 'Beta' })).toThrow();
+    });
+  });
+
+  describe('nested object subset', () => {
+    test('passes with nested partial match', () => {
+      const result = Result.ok({
+        id: '1',
+        meta: { stars: 0, tags: ['a', 'b'], views: 5 },
+      });
+      assertPartialMatch(result, { meta: { stars: 0 } });
+    });
+
+    test('fails when nested value does not match', () => {
+      const result = Result.ok({
+        id: '1',
+        meta: { stars: 0, views: 5 },
+      });
+      expect(() =>
+        assertPartialMatch(result, { meta: { stars: 3 } })
+      ).toThrow();
+    });
+  });
+
+  describe('array subset', () => {
+    test('passes when actual contains all expected elements (order-independent)', () => {
+      const result = Result.ok({
+        tags: ['a', 'b', 'c'],
+      });
+      assertPartialMatch(result, { tags: ['c', 'a'] });
+    });
+
+    test('fails when actual is missing expected array element', () => {
+      const result = Result.ok({
+        tags: ['a', 'b'],
+      });
+      expect(() => assertPartialMatch(result, { tags: ['a', 'z'] })).toThrow();
+    });
+  });
+
+  describe('error on non-ok result', () => {
+    test('fails when result is an error', () => {
+      const result = Result.err(new Error('boom'));
+      expect(() => assertPartialMatch(result, { id: '1' })).toThrow();
+    });
+  });
+});

--- a/packages/testing/src/__tests__/partial-match.test.ts
+++ b/packages/testing/src/__tests__/partial-match.test.ts
@@ -85,6 +85,36 @@ describe('assertPartialMatch', () => {
       });
       expect(() => assertPartialMatch(result, { tags: ['a', 'z'] })).toThrow();
     });
+
+    test('fails when expected has duplicate but actual has only one match', () => {
+      const result = Result.ok({
+        tags: ['a', 'b'],
+      });
+      expect(() => assertPartialMatch(result, { tags: ['a', 'a'] })).toThrow();
+    });
+
+    test('passes when expected has duplicate and actual has enough matches', () => {
+      const result = Result.ok({
+        tags: ['a', 'a', 'b'],
+      });
+      assertPartialMatch(result, { tags: ['a', 'a'] });
+    });
+
+    test('fails when expected objects have duplicates but actual has only one', () => {
+      const result = Result.ok({
+        items: [{ id: 1 }],
+      });
+      expect(() =>
+        assertPartialMatch(result, { items: [{ id: 1 }, { id: 1 }] })
+      ).toThrow();
+    });
+
+    test('passes when expected objects have duplicates and actual has enough', () => {
+      const result = Result.ok({
+        items: [{ id: 1 }, { id: 1 }, { id: 2 }],
+      });
+      assertPartialMatch(result, { items: [{ id: 1 }, { id: 1 }] });
+    });
   });
 
   describe('error on non-ok result', () => {

--- a/packages/testing/src/__tests__/scenario.test.ts
+++ b/packages/testing/src/__tests__/scenario.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { TrailContext } from '@ontrails/core';
-import { Result, trail, topo } from '@ontrails/core';
+import { resource, Result, trail, topo } from '@ontrails/core';
 import { z } from 'zod';
 
 import { ref, scenario } from '../scenario.js';
+import type { ScenarioStep } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Test trails
@@ -47,10 +48,30 @@ const createViaProxy = trail('item.create-via-proxy', {
   output: z.object({ id: z.string(), name: z.string() }),
 });
 
+/** A resource with a mock factory. */
+const db = resource<{ query: (sql: string) => string }>('db', {
+  create: () => Result.err(new Error('not wired in tests')),
+  mock: () => ({ query: (sql: string) => `mock:${sql}` }),
+});
+
+/** A trail that uses a resource via ctx.resource(). */
+const queryTrail = trail('item.query', {
+  blaze: (_input: { sql: string }, ctx: TrailContext) => {
+    const instance = db.from(ctx);
+    return Result.ok({ result: instance.query(_input.sql) });
+  },
+  description: 'Run a query via the db resource',
+  input: z.object({ sql: z.string() }),
+  output: z.object({ result: z.string() }),
+  resources: [db],
+});
+
 const app = topo('scenario-test-app', {
   createTrail,
   createViaProxy,
+  db,
   failTrail,
+  queryTrail,
   showTrail,
 } as Record<string, unknown>);
 
@@ -113,6 +134,16 @@ describe('scenario()', () => {
     },
   ]);
 
+  // Resource mock forwarding
+  // oxlint-disable-next-line jest/require-hook -- scenario() registers describe/test blocks, not setup code
+  scenario('step with resource receives mock from topo', app, [
+    {
+      cross: queryTrail,
+      expected: { result: 'mock:SELECT 1' },
+      input: { sql: 'SELECT 1' },
+    },
+  ]);
+
   // Step failure reporting
   describe('step failure reporting', () => {
     test('reports which step failed', async () => {
@@ -125,6 +156,23 @@ describe('scenario()', () => {
       const { executeTrail } = await import('@ontrails/core');
       const result = await executeTrail(failTrail, {}, { topo: app });
       expect(result.isErr()).toBe(true);
+    });
+  });
+
+  // Duplicate alias guard
+  describe('duplicate alias guard', () => {
+    test('throws on duplicate step alias', async () => {
+      // Import executeScenarioSteps to test the guard directly.
+      const { executeScenarioSteps } = await import('../scenario.js');
+
+      const steps: ScenarioStep[] = [
+        { as: 'dup', cross: createTrail, input: { name: 'A' } },
+        { as: 'dup', cross: createTrail, input: { name: 'B' } },
+      ];
+
+      await expect(executeScenarioSteps(app, steps)).rejects.toThrow(
+        'duplicate step alias "dup"'
+      );
     });
   });
 });

--- a/packages/testing/src/__tests__/scenario.test.ts
+++ b/packages/testing/src/__tests__/scenario.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
+import type { TrailContext } from '@ontrails/core';
 import { Result, trail, topo } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -31,8 +32,24 @@ const failTrail = trail('item.fail', {
   output: z.object({}),
 });
 
+/** A trail that uses ctx.cross() to delegate to item.create. */
+const createViaProxy = trail('item.create-via-proxy', {
+  blaze: (input: { name: string }, ctx: TrailContext) => {
+    const crossFn = ctx.cross;
+    if (!crossFn) {
+      return Promise.resolve(Result.err(new Error('ctx.cross is undefined')));
+    }
+    return crossFn(createTrail, input);
+  },
+  crosses: [createTrail],
+  description: 'Delegates to item.create via ctx.cross()',
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string(), name: z.string() }),
+});
+
 const app = topo('scenario-test-app', {
   createTrail,
+  createViaProxy,
   failTrail,
   showTrail,
 } as Record<string, unknown>);
@@ -83,6 +100,16 @@ describe('scenario()', () => {
       cross: createTrail,
       expectedMatch: { name: 'Partial' },
       input: { name: 'Partial' },
+    },
+  ]);
+
+  // oxlint-disable-next-line jest/require-hook -- scenario() registers describe/test blocks, not setup code
+  scenario('step that uses ctx.cross() receives a bound cross function', app, [
+    {
+      as: 'proxied',
+      cross: createViaProxy,
+      expectedMatch: { id: 'g1', name: 'CrossTest' },
+      input: { name: 'CrossTest' },
     },
   ]);
 

--- a/packages/testing/src/__tests__/scenario.test.ts
+++ b/packages/testing/src/__tests__/scenario.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result, trail, topo } from '@ontrails/core';
+import { z } from 'zod';
+
+import { ref, scenario } from '../scenario.js';
+
+// ---------------------------------------------------------------------------
+// Test trails
+// ---------------------------------------------------------------------------
+
+const createTrail = trail('item.create', {
+  blaze: (input: { name: string }) => Result.ok({ id: 'g1', name: input.name }),
+  description: 'Create an item',
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string(), name: z.string() }),
+});
+
+const showTrail = trail('item.show', {
+  blaze: (input: { id: string }) =>
+    Result.ok({ found: true, id: input.id, name: 'Test' }),
+  description: 'Show an item',
+  input: z.object({ id: z.string() }),
+  output: z.object({ found: z.boolean(), id: z.string(), name: z.string() }),
+});
+
+const failTrail = trail('item.fail', {
+  blaze: () => Result.err(new Error('intentional failure')),
+  description: 'Always fails',
+  input: z.object({}),
+  output: z.object({}),
+});
+
+const app = topo('scenario-test-app', {
+  createTrail,
+  failTrail,
+  showTrail,
+} as Record<string, unknown>);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ref()', () => {
+  test('creates a RefToken with the given path', () => {
+    const token = ref('create.id');
+    expect(token).toEqual({ __ref: true, path: 'create.id' });
+  });
+});
+
+describe('scenario()', () => {
+  // oxlint-disable-next-line jest/require-hook -- scenario() registers describe/test blocks, not setup code
+  scenario('basic two-step flow', app, [
+    {
+      as: 'created',
+      cross: createTrail,
+      input: { name: 'Hello' },
+    },
+    {
+      cross: showTrail,
+      expectedMatch: { found: true, id: 'g1' },
+      input: { id: ref('created.id') },
+    },
+  ]);
+
+  // oxlint-disable-next-line jest/require-hook -- scenario() registers describe/test blocks, not setup code
+  scenario('ref resolves dot-path from prior step', app, [
+    {
+      as: 'original',
+      cross: createTrail,
+      expected: { id: 'g1', name: 'Test' },
+      input: { name: 'Test' },
+    },
+    {
+      cross: showTrail,
+      input: { id: ref('original.id') },
+    },
+  ]);
+
+  // oxlint-disable-next-line jest/require-hook -- scenario() registers describe/test blocks, not setup code
+  scenario('expectedMatch on a step works', app, [
+    {
+      cross: createTrail,
+      expectedMatch: { name: 'Partial' },
+      input: { name: 'Partial' },
+    },
+  ]);
+
+  // Step failure reporting
+  describe('step failure reporting', () => {
+    test('reports which step failed', async () => {
+      // We can't use scenario() directly here because it registers
+      // describe/test blocks. Instead, test the error message shape
+      // by importing the internals or checking that the scenario
+      // properly reports failures.
+      // For now, verify that a failing trail in a scenario produces
+      // an informative error.
+      const { executeTrail } = await import('@ontrails/core');
+      const result = await executeTrail(failTrail, {}, { topo: app });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+});

--- a/packages/testing/src/assertions.ts
+++ b/packages/testing/src/assertions.ts
@@ -95,35 +95,53 @@ export const assertSchemaMatch = (
 const formatLoc = (path: readonly string[]): string =>
   path.length > 0 ? path.join('.') : 'root';
 
-/** Assert that every element in `expected` exists in `actual` (order-independent). */
+/** Find an unconsumed actual element that deep-matches the expected object. */
+const findObjectMatch = (
+  actual: unknown[],
+  elem: object,
+  consumed: ReadonlySet<number>,
+  path: readonly string[],
+  index: number
+): number =>
+  actual.findIndex((a, idx) => {
+    if (consumed.has(idx)) {
+      return false;
+    }
+    try {
+      // oxlint-disable-next-line no-use-before-define -- mutual recursion with assertSubset
+      assertSubset(a, elem, [...path, `[${String(index)}]`]);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+/**
+ * Assert that every element in `expected` exists in `actual` (order-independent).
+ *
+ * Tracks consumed indices so that duplicate expected elements each require a
+ * distinct actual element — `['a', 'a']` does not match `['a']`.
+ */
 const assertArraySubset = (
   actual: unknown[],
   expected: unknown[],
   path: readonly string[],
   loc: string
 ): void => {
+  const consumed = new Set<number>();
   for (let i = 0; i < expected.length; i += 1) {
     const elem = expected[i];
-    if (typeof elem === 'object' && elem !== null) {
-      const found = actual.some((a) => {
-        try {
-          // oxlint-disable-next-line no-use-before-define -- mutual recursion with assertSubset
-          assertSubset(a, elem, [...path, `[${String(i)}]`]);
-          return true;
-        } catch {
-          return false;
-        }
-      });
-      if (!found) {
-        throw new Error(
-          `at ${loc}[${String(i)}]: expected array to contain ${JSON.stringify(elem)}`
-        );
-      }
-    } else if (!actual.includes(elem)) {
+    const matchIndex =
+      typeof elem === 'object' && elem !== null
+        ? findObjectMatch(actual, elem, consumed, path, i)
+        : actual.findIndex((a, idx) => !consumed.has(idx) && a === elem);
+
+    if (matchIndex === -1) {
       throw new Error(
-        `at ${loc}: expected array to contain ${JSON.stringify(elem)}`
+        `at ${loc}[${String(i)}]: expected array to contain ${JSON.stringify(elem)}`
       );
     }
+    consumed.add(matchIndex);
   }
 };
 

--- a/packages/testing/src/assertions.ts
+++ b/packages/testing/src/assertions.ts
@@ -88,6 +88,133 @@ export const assertSchemaMatch = (
 };
 
 // ---------------------------------------------------------------------------
+// Partial Match
+// ---------------------------------------------------------------------------
+
+/** Format a path for error messages. */
+const formatLoc = (path: readonly string[]): string =>
+  path.length > 0 ? path.join('.') : 'root';
+
+/** Assert that every element in `expected` exists in `actual` (order-independent). */
+const assertArraySubset = (
+  actual: unknown[],
+  expected: unknown[],
+  path: readonly string[],
+  loc: string
+): void => {
+  for (let i = 0; i < expected.length; i += 1) {
+    const elem = expected[i];
+    if (typeof elem === 'object' && elem !== null) {
+      const found = actual.some((a) => {
+        try {
+          // oxlint-disable-next-line no-use-before-define -- mutual recursion with assertSubset
+          assertSubset(a, elem, [...path, `[${String(i)}]`]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      if (!found) {
+        throw new Error(
+          `at ${loc}[${String(i)}]: expected array to contain ${JSON.stringify(elem)}`
+        );
+      }
+    } else if (!actual.includes(elem)) {
+      throw new Error(
+        `at ${loc}: expected array to contain ${JSON.stringify(elem)}`
+      );
+    }
+  }
+};
+
+/** Assert that every key in `expected` exists in `actual` with a matching value. */
+const assertObjectSubset = (
+  actual: Record<string, unknown>,
+  expected: Record<string, unknown>,
+  path: readonly string[]
+): void => {
+  for (const key of Object.keys(expected)) {
+    if (!(key in actual)) {
+      throw new Error(
+        `at ${[...path, key].join('.')}: key not found in actual`
+      );
+    }
+    // oxlint-disable-next-line no-use-before-define -- mutual recursion with assertSubset
+    assertSubset(actual[key], expected[key], [...path, key]);
+  }
+};
+
+/**
+ * Recursively assert that `actual` is a superset of `expected`.
+ *
+ * - **Scalars:** strict equality.
+ * - **Objects:** every key in `expected` must exist in `actual` with a matching
+ *   value. Extra keys in `actual` are ignored.
+ * - **Arrays:** every element in `expected` must exist in `actual`
+ *   (order-independent subset check).
+ * - **Nested objects:** recursive subset matching.
+ */
+// oxlint-disable-next-line max-statements -- recursive dispatch across four type branches
+const assertSubset = (
+  actual: unknown,
+  expected: unknown,
+  path: readonly string[]
+): void => {
+  const loc = formatLoc(path);
+
+  if (expected === null || expected === undefined) {
+    if (actual !== expected) {
+      throw new Error(
+        `at ${loc}: expected ${String(expected)}, got ${String(actual)}`
+      );
+    }
+    return;
+  }
+
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual)) {
+      throw new TypeError(`at ${loc}: expected an array, got ${typeof actual}`);
+    }
+    assertArraySubset(actual, expected, path, loc);
+    return;
+  }
+
+  if (typeof expected === 'object') {
+    if (
+      typeof actual !== 'object' ||
+      actual === null ||
+      Array.isArray(actual)
+    ) {
+      throw new Error(`at ${loc}: expected an object, got ${typeof actual}`);
+    }
+    assertObjectSubset(
+      actual as Record<string, unknown>,
+      expected as Record<string, unknown>,
+      path
+    );
+    return;
+  }
+
+  if (actual !== expected) {
+    throw new Error(
+      `at ${loc}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+    );
+  }
+};
+
+/**
+ * Assert that the result is ok and its value is a superset of the expected
+ * partial output. Declared fields must match; extra fields are ignored.
+ */
+export const assertPartialMatch = (
+  result: Result<unknown, Error>,
+  expectedMatch: unknown
+): void => {
+  const value = expectOk(result);
+  assertSubset(value, expectedMatch, []);
+};
+
+// ---------------------------------------------------------------------------
 // Error Match
 // ---------------------------------------------------------------------------
 

--- a/packages/testing/src/context.ts
+++ b/packages/testing/src/context.ts
@@ -2,16 +2,18 @@
  * Test context factory for creating TrailContext instances suitable for testing.
  */
 
-import { z } from 'zod';
-
 import type {
-  AnyTrail,
   CrossFn,
   ResourceOverrideMap,
   Topo,
   TrailContext,
 } from '@ontrails/core';
-import { Result, createResourceLookup, passthroughTrace } from '@ontrails/core';
+import {
+  Result,
+  buildCrossValidationSchema,
+  createResourceLookup,
+  passthroughTrace,
+} from '@ontrails/core';
 
 import { createTestLogger } from './logger.js';
 import type { TestTrailContextOptions } from './types.js';
@@ -180,30 +182,8 @@ export const resolveMockResources = async (
   app: Topo
 ): Promise<ResourceOverrideMap> => await buildMockResources(app);
 
-/**
- * Build the validation schema for a cross-invoked trail.
- *
- * When the target trail declares `crossInput`, the cross caller passes both
- * public input and composition-only fields. The merged schema validates the
- * combined shape so `executeTrail` doesn't reject the extra fields.
- */
-export const buildCrossValidationSchema = (
-  trailDef: AnyTrail
-): z.ZodType | undefined => {
-  if (!trailDef.crossInput) {
-    return undefined;
-  }
-  // Prefer .merge() for ZodObject pairs — it produces a proper merged object
-  // schema that strips unknown keys and exposes .shape. Fall back to
-  // z.intersection for non-object schemas.
-  if (
-    trailDef.input instanceof z.ZodObject &&
-    trailDef.crossInput instanceof z.ZodObject
-  ) {
-    return trailDef.input.merge(trailDef.crossInput);
-  }
-  return z.intersection(trailDef.input, trailDef.crossInput);
-};
+// Re-export from core so existing consumers of this module continue to work.
+export { buildCrossValidationSchema };
 
 /**
  * Merge a Partial<TrailContext> into a test context.

--- a/packages/testing/src/crosses.ts
+++ b/packages/testing/src/crosses.ts
@@ -14,6 +14,7 @@ import type {
   TrailContext,
 } from '@ontrails/core';
 import {
+  buildCrossValidationSchema,
   executeTrail,
   InternalError,
   Result,
@@ -26,11 +27,7 @@ import {
   assertFullMatch,
   assertSchemaMatch,
 } from './assertions.js';
-import {
-  buildCrossValidationSchema,
-  mergeResourceOverrides,
-  mergeTestContext,
-} from './context.js';
+import { mergeResourceOverrides, mergeTestContext } from './context.js';
 import type { CrossScenario } from './types.js';
 
 // ---------------------------------------------------------------------------

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -42,6 +42,7 @@ import type { z } from 'zod';
 import {
   assertErrorMatch,
   assertFullMatch,
+  assertPartialMatch,
   assertSchemaMatch,
 } from './assertions.js';
 import {
@@ -92,16 +93,14 @@ const assertProgressiveMatch = (
   output: z.ZodType | undefined
 ): void => {
   if (example.expected !== undefined) {
-    assertFullMatch(result, example.expected);
-    return;
+    return assertFullMatch(result, example.expected);
   }
-
+  if (example.expectedMatch !== undefined) {
+    return assertPartialMatch(result, example.expectedMatch);
+  }
   if (example.error !== undefined) {
-    const errorClass = resolveErrorClass(example.error);
-    assertErrorMatch(result, errorClass);
-    return;
+    return assertErrorMatch(result, resolveErrorClass(example.error));
   }
-
   assertSchemaMatch(result, output);
 };
 

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -23,6 +23,7 @@ import {
   AmbiguousError,
   AssertionError,
   AuthError,
+  buildCrossValidationSchema,
   CancelledError,
   ConflictError,
   InternalError,
@@ -46,7 +47,6 @@ import {
   assertSchemaMatch,
 } from './assertions.js';
 import {
-  buildCrossValidationSchema,
   defaultMintPermit,
   mergeResourceOverrides,
   mergeTestContext,

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -17,7 +17,7 @@ export {
 } from './assertions.js';
 
 // Scenario testing
-export { ref, scenario } from './scenario.js';
+export { executeScenarioSteps, ref, scenario } from './scenario.js';
 
 // Mock factories
 export {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -10,10 +10,14 @@ export { testDetours } from './detours.js';
 export {
   assertErrorMatch,
   assertFullMatch,
+  assertPartialMatch,
   assertSchemaMatch,
   expectErr,
   expectOk,
 } from './assertions.js';
+
+// Scenario testing
+export { ref, scenario } from './scenario.js';
 
 // Mock factories
 export {
@@ -38,6 +42,8 @@ export type { TestCrossOptions } from './crosses.js';
 
 export type {
   CrossScenario,
+  RefToken,
+  ScenarioStep,
   TestScenario,
   TestLogger,
   TestTrailContextOptions,

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -1,0 +1,197 @@
+/**
+ * Multi-step scenario runner for composition testing.
+ *
+ * Scenarios express multi-trail flows as structured data — arrays of steps
+ * with cross-step references via `ref()`. Each step invokes a trail through
+ * the normal execution pipeline (validation, layers, blaze, Result).
+ */
+
+import { describe, test } from 'bun:test';
+
+import type { Result, Topo } from '@ontrails/core';
+import { executeTrail } from '@ontrails/core';
+
+import { assertPartialMatch, expectOk } from './assertions.js';
+import type { RefToken, ScenarioStep } from './types.js';
+
+// ---------------------------------------------------------------------------
+// ref() — cross-step reference marker
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a reference marker for cross-step data in scenario inputs.
+ *
+ * `ref('create.id')` resolves to the `id` field of the step aliased as
+ * `create`. Dot-paths are supported for nested access.
+ *
+ * @example
+ * ```typescript
+ * scenario('Fork flow', app, [
+ *   { cross: createGist, input: { name: 'Hello' }, as: 'original' },
+ *   { cross: forkGist, input: { id: ref('original.id') } },
+ * ]);
+ * ```
+ */
+export const ref = (path: string): RefToken => ({ __ref: true, path });
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** Type guard for RefToken. */
+const isRef = (value: unknown): value is RefToken =>
+  typeof value === 'object' &&
+  value !== null &&
+  '__ref' in value &&
+  (value as Record<string, unknown>)['__ref'] === true &&
+  'path' in value;
+
+/**
+ * Resolve a dot-path against the outputs map.
+ *
+ * `ref('create.id')` splits into step name `create` and field path `id`.
+ * The first segment is the step alias; remaining segments are property lookups.
+ */
+/**
+ * Walk remaining segments of a dot-path, drilling into the step output.
+ */
+const drillPath = (
+  path: string,
+  segments: readonly string[],
+  start: unknown
+): unknown => {
+  let current: unknown = start;
+  for (let i = 1; i < segments.length; i += 1) {
+    const segment = segments[i];
+    if (segment === undefined) {
+      break;
+    }
+    if (typeof current !== 'object' || current === null) {
+      throw new Error(
+        `ref('${path}'): cannot access '${segment}' on ${typeof current}`
+      );
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+};
+
+const resolvePath = (path: string, outputs: Map<string, unknown>): unknown => {
+  const segments = path.split('.');
+  const [stepName] = segments;
+  if (stepName === undefined) {
+    throw new Error(`ref(): empty path`);
+  }
+
+  const stepOutput = outputs.get(stepName);
+  if (stepOutput === undefined) {
+    throw new Error(
+      `ref('${path}'): no step output found for alias '${stepName}'`
+    );
+  }
+
+  return drillPath(path, segments, stepOutput);
+};
+
+/**
+ * Recursively walk a value, replacing RefToken instances with resolved values.
+ */
+export const resolveRefs = (
+  value: unknown,
+  outputs: Map<string, unknown>
+): unknown => {
+  if (isRef(value)) {
+    return resolvePath(value.path, outputs);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => resolveRefs(item, outputs));
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = resolveRefs(val, outputs);
+    }
+    return result;
+  }
+
+  return value;
+};
+
+// ---------------------------------------------------------------------------
+// scenario() — the public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Define a multi-step scenario test for composition flows.
+ *
+ * Each step invokes a trail through the normal execution pipeline.
+ * Steps can reference prior step outputs via `ref()`. If any step
+ * fails, the scenario stops and reports which step failed.
+ *
+ * @example
+ * ```typescript
+ * scenario('Create and show', app, [
+ *   { cross: createItem, input: { name: 'Test' }, as: 'created' },
+ *   { cross: showItem, input: { id: ref('created.id') },
+ *     expectedMatch: { found: true } },
+ * ]);
+ * ```
+ */
+/** Assert the result of a step against its expectations and record output. */
+const assertStepExpectations = async (
+  step: ScenarioStep,
+  result: Result<unknown, Error>,
+  outputs: Map<string, unknown>
+): Promise<void> => {
+  const value = expectOk(result);
+  if (step.expected !== undefined) {
+    const { expect } = await import('bun:test');
+    expect(value).toEqual(step.expected);
+  }
+  if (step.expectedMatch !== undefined) {
+    assertPartialMatch(result, resolveRefs(step.expectedMatch, outputs));
+  }
+  if (step.as !== undefined) {
+    outputs.set(step.as, value);
+  }
+};
+
+/**
+ * Execute a single scenario step: run the trail, assert expectations,
+ * and record outputs.
+ */
+const executeStep = async (
+  step: ScenarioStep,
+  index: number,
+  app: Topo,
+  outputs: Map<string, unknown>
+): Promise<void> => {
+  const resolvedInput = resolveRefs(step.input, outputs);
+  const result = await executeTrail(step.cross, resolvedInput, { topo: app });
+
+  if (result.isErr()) {
+    throw new Error(
+      `Step ${String(index + 1)} ("${step.as ?? step.cross.id}") failed: ${result.error.message}`
+    );
+  }
+
+  await assertStepExpectations(step, result, outputs);
+};
+
+export const scenario = (
+  name: string,
+  app: Topo,
+  steps: readonly ScenarioStep[]
+): void => {
+  describe(name, () => {
+    test('executes all steps', async () => {
+      const outputs = new Map<string, unknown>();
+
+      for (const [index, step] of steps.entries()) {
+        await executeStep(step, index, app, outputs);
+      }
+    });
+  });
+};

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -8,8 +8,10 @@
 
 import { describe, test } from 'bun:test';
 
-import type { Result, Topo } from '@ontrails/core';
-import { executeTrail } from '@ontrails/core';
+import type { AnyTrail, CrossFn, Result, Topo } from '@ontrails/core';
+import { executeTrail, InternalError, Result as R } from '@ontrails/core';
+
+import { buildCrossValidationSchema } from './context.js';
 
 import { assertPartialMatch, expectOk } from './assertions.js';
 import type { RefToken, ScenarioStep } from './types.js';
@@ -159,6 +161,32 @@ const assertStepExpectations = async (
 };
 
 /**
+ * Build a cross function that resolves trails from the topo and executes
+ * them through the standard pipeline. Mirrors the pattern in crosses.ts
+ * `executeFromMap` but without recording or injection.
+ */
+const createScenarioCross = (app: Topo): CrossFn => {
+  const cross: CrossFn = ((
+    idOrTrail: string | { readonly id: string },
+    input: unknown
+  ) => {
+    const id = typeof idOrTrail === 'string' ? idOrTrail : idOrTrail.id;
+    const trailDef: AnyTrail | undefined = app.get(id);
+    if (trailDef === undefined) {
+      return Promise.resolve(
+        R.err(new InternalError(`cross: trail "${id}" not found in topo`))
+      );
+    }
+    return executeTrail(trailDef, input, {
+      ctx: { cross },
+      topo: app,
+      validationSchema: buildCrossValidationSchema(trailDef),
+    });
+  }) as CrossFn;
+  return cross;
+};
+
+/**
  * Execute a single scenario step: run the trail, assert expectations,
  * and record outputs.
  */
@@ -168,8 +196,12 @@ const executeStep = async (
   app: Topo,
   outputs: Map<string, unknown>
 ): Promise<void> => {
+  const scenarioCross = createScenarioCross(app);
   const resolvedInput = resolveRefs(step.input, outputs);
-  const result = await executeTrail(step.cross, resolvedInput, { topo: app });
+  const result = await executeTrail(step.cross, resolvedInput, {
+    ctx: { cross: scenarioCross },
+    topo: app,
+  });
 
   if (result.isErr()) {
     throw new Error(

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -160,9 +160,8 @@ const assertStepExpectations = async (
   const value = expectOk(result);
   if (step.expected !== undefined) {
     const { expect } = await import('bun:test');
-    expect(value).toEqual(step.expected);
-  }
-  if (step.expectedMatch !== undefined) {
+    expect(value).toEqual(resolveRefs(step.expected, outputs));
+  } else if (step.expectedMatch !== undefined) {
     assertPartialMatch(result, resolveRefs(step.expectedMatch, outputs));
   }
   if (step.as !== undefined) {

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -9,9 +9,12 @@
 import { describe, test } from 'bun:test';
 
 import type { AnyTrail, CrossFn, Result, Topo } from '@ontrails/core';
-import { executeTrail, InternalError, Result as R } from '@ontrails/core';
-
-import { buildCrossValidationSchema } from './context.js';
+import {
+  buildCrossValidationSchema,
+  executeTrail,
+  InternalError,
+  Result as R,
+} from '@ontrails/core';
 
 import { assertPartialMatch, expectOk } from './assertions.js';
 import type { RefToken, ScenarioStep } from './types.js';

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -23,7 +23,7 @@ import {
 } from '@ontrails/core';
 
 import { assertPartialMatch, expectOk } from './assertions.js';
-import { resolveMockResources } from './context.js';
+import { createTestContext, resolveMockResources } from './context.js';
 import type { RefToken, ScenarioStep } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -190,8 +190,9 @@ const createScenarioCross = (
         R.err(new InternalError(`cross: trail "${id}" not found in topo`))
       );
     }
+    const baseCtx = createTestContext();
     return executeTrail(trailDef, input, {
-      ctx: { cross },
+      ctx: { ...baseCtx, cross },
       resources,
       topo: app,
       validationSchema: buildCrossValidationSchema(trailDef),
@@ -218,9 +219,10 @@ const executeStep = async (
   }
 
   const scenarioCross = createScenarioCross(app, resources);
+  const baseCtx = createTestContext();
   const resolvedInput = resolveRefs(step.input, outputs);
   const result = await executeTrail(step.cross, resolvedInput, {
-    ctx: { cross: scenarioCross },
+    ctx: { ...baseCtx, cross: scenarioCross },
     resources,
     topo: app,
   });

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -8,7 +8,13 @@
 
 import { describe, test } from 'bun:test';
 
-import type { AnyTrail, CrossFn, Result, Topo } from '@ontrails/core';
+import type {
+  AnyTrail,
+  CrossFn,
+  ResourceOverrideMap,
+  Result,
+  Topo,
+} from '@ontrails/core';
 import {
   buildCrossValidationSchema,
   executeTrail,
@@ -17,6 +23,7 @@ import {
 } from '@ontrails/core';
 
 import { assertPartialMatch, expectOk } from './assertions.js';
+import { resolveMockResources } from './context.js';
 import type { RefToken, ScenarioStep } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -168,7 +175,10 @@ const assertStepExpectations = async (
  * them through the standard pipeline. Mirrors the pattern in crosses.ts
  * `executeFromMap` but without recording or injection.
  */
-const createScenarioCross = (app: Topo): CrossFn => {
+const createScenarioCross = (
+  app: Topo,
+  resources?: ResourceOverrideMap
+): CrossFn => {
   const cross: CrossFn = ((
     idOrTrail: string | { readonly id: string },
     input: unknown
@@ -182,6 +192,7 @@ const createScenarioCross = (app: Topo): CrossFn => {
     }
     return executeTrail(trailDef, input, {
       ctx: { cross },
+      resources,
       topo: app,
       validationSchema: buildCrossValidationSchema(trailDef),
     });
@@ -197,12 +208,20 @@ const executeStep = async (
   step: ScenarioStep,
   index: number,
   app: Topo,
-  outputs: Map<string, unknown>
+  outputs: Map<string, unknown>,
+  resources?: ResourceOverrideMap
 ): Promise<void> => {
-  const scenarioCross = createScenarioCross(app);
+  if (step.as !== undefined && outputs.has(step.as)) {
+    throw new Error(
+      `scenario: duplicate step alias "${step.as}" — each alias must be unique`
+    );
+  }
+
+  const scenarioCross = createScenarioCross(app, resources);
   const resolvedInput = resolveRefs(step.input, outputs);
   const result = await executeTrail(step.cross, resolvedInput, {
     ctx: { cross: scenarioCross },
+    resources,
     topo: app,
   });
 
@@ -215,6 +234,24 @@ const executeStep = async (
   await assertStepExpectations(step, result, outputs);
 };
 
+/**
+ * Execute scenario steps sequentially, resolving mock resources once upfront.
+ *
+ * Exported for direct use in tests that need to assert on step execution
+ * without the describe/test wrapper that `scenario()` provides.
+ */
+export const executeScenarioSteps = async (
+  app: Topo,
+  steps: readonly ScenarioStep[]
+): Promise<void> => {
+  const outputs = new Map<string, unknown>();
+  const resources = await resolveMockResources(app);
+
+  for (const [index, step] of steps.entries()) {
+    await executeStep(step, index, app, outputs, resources);
+  }
+};
+
 export const scenario = (
   name: string,
   app: Topo,
@@ -222,11 +259,7 @@ export const scenario = (
 ): void => {
   describe(name, () => {
     test('executes all steps', async () => {
-      const outputs = new Map<string, unknown>();
-
-      for (const [index, step] of steps.entries()) {
-        await executeStep(step, index, app, outputs);
-      }
+      await executeScenarioSteps(app, steps);
     });
   });
 };

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -133,5 +133,5 @@ export interface ScenarioStep {
   readonly input: Record<string, unknown>;
   readonly as?: string | undefined;
   readonly expected?: unknown | undefined;
-  readonly expectedMatch?: Record<string, unknown> | undefined;
+  readonly expectedMatch?: unknown | undefined;
 }

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -2,7 +2,7 @@
  * Shared types for @ontrails/testing.
  */
 
-import type { Logger, Topo, TraceFn } from '@ontrails/core';
+import type { AnyTrail, Logger, Topo, TraceFn } from '@ontrails/core';
 import type { LogLevel, LogRecord } from '@ontrails/logging';
 
 // ---------------------------------------------------------------------------
@@ -115,4 +115,23 @@ export interface McpHarness {
 export interface McpHarnessResult {
   readonly content: unknown;
   readonly isError: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario (for composition testing)
+// ---------------------------------------------------------------------------
+
+/** Marker for cross-step references in scenario inputs. */
+export interface RefToken {
+  readonly __ref: true;
+  readonly path: string;
+}
+
+/** A single step in a scenario. */
+export interface ScenarioStep {
+  readonly cross: AnyTrail;
+  readonly input: Record<string, unknown>;
+  readonly as?: string | undefined;
+  readonly expected?: unknown | undefined;
+  readonly expectedMatch?: Record<string, unknown> | undefined;
 }

--- a/packages/warden/src/rules/cross-declarations.ts
+++ b/packages/warden/src/rules/cross-declarations.ts
@@ -129,6 +129,8 @@ const getCrossElements = (config: AstNode): readonly AstNode[] | null => {
 interface DeclaredCrosses {
   /** Statically resolved trail IDs from string literals / const identifiers. */
   readonly ids: ReadonlySet<string>;
+  /** IDs that were declared as string literals (not resolved from identifiers). */
+  readonly literalIds: ReadonlySet<string>;
   /**
    * True if any element could not be statically resolved (e.g. trail object
    * reference like `crosses: [showGist]`). When true, "undeclared" diagnostics
@@ -144,21 +146,38 @@ interface DeclaredCrosses {
  * time; they're normalized at runtime by `trail()`. When any entry is
  * unresolved, `hasUnresolved` is set so callers can soften diagnostics.
  */
+/** Classify a single element and accumulate into the id sets. */
+const classifyCrossElement = (
+  element: AstNode,
+  sourceCode: string,
+  ids: Set<string>,
+  literalIds: Set<string>
+): boolean => {
+  const resolved = resolveCrossElementId(element, sourceCode);
+  if (!resolved) {
+    // Element could not be statically resolved
+    return true;
+  }
+  ids.add(resolved);
+  if (isStringLiteral(element)) {
+    literalIds.add(resolved);
+  }
+  return false;
+};
+
 const resolveDeclaredCrossElements = (
   elements: readonly AstNode[],
   sourceCode: string
 ): DeclaredCrosses => {
   const ids = new Set<string>();
+  const literalIds = new Set<string>();
   let hasUnresolved = false;
   for (const element of elements) {
-    const resolved = resolveCrossElementId(element, sourceCode);
-    if (resolved) {
-      ids.add(resolved);
-    } else {
+    if (classifyCrossElement(element, sourceCode, ids, literalIds)) {
       hasUnresolved = true;
     }
   }
-  return { hasUnresolved, ids };
+  return { hasUnresolved, ids, literalIds };
 };
 
 /** Extract declared crosses from a `crosses: [...]` array. */
@@ -169,7 +188,7 @@ const extractDeclaredCrosses = (
   const elements = getCrossElements(config);
   return elements
     ? resolveDeclaredCrossElements(elements, sourceCode)
-    : { hasUnresolved: false, ids: new Set() };
+    : { hasUnresolved: false, ids: new Set(), literalIds: new Set() };
 };
 
 // ---------------------------------------------------------------------------
@@ -421,11 +440,13 @@ const checkTrailDefinition = (
   );
 
   // When ctx.cross() calls include typed trail object references we can't
-  // resolve (e.g. ctx.cross(showGist, input)), suppress "unused declaration"
-  // warnings — the unresolved call may target any declared entry.
-  if (!called.hasUnresolved) {
-    reportUnused(declared.ids, called.ids, ctx, diagnostics);
-  }
+  // resolve (e.g. ctx.cross(showGist, input)), limit "unused declaration"
+  // warnings to string-literal declarations only — unresolved calls may
+  // target any non-literal declared entry but cannot match a literal.
+  const unusedCandidates = called.hasUnresolved
+    ? declared.literalIds
+    : declared.ids;
+  reportUnused(unusedCandidates, called.ids, ctx, diagnostics);
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **`expectedMatch`**: new field on `TrailExample` for partial assertions — subset matching with proper duplicate handling in arrays
- **`assertPartialMatch()`**: recursive subset matcher (scalars strict, objects recursive, arrays order-independent with consumed-index tracking)
- **`scenario()`**: multi-step journey testing with `ref()` cross-step references and `createScenarioCross()` for proper `ctx.cross()` binding
- **ADR-0025** promoted from draft to accepted
- Updated `docs/testing.md` with new APIs

## Test plan
- [x] assertPartialMatch: scalar, object subset, nested, array subset
- [x] Array duplicates: `['a', 'a']` does NOT match `['a']`
- [x] scenario(): multi-step execution with ref() resolution
- [x] scenario(): trails using ctx.cross() work via createScenarioCross
- [x] expectedMatch wired into assertProgressiveMatch

Closes https://linear.app/outfitter/issue/TRL-217

In-collaboration-with: [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
