### PR TITLE
docs(adr): rewrite ADR-0020 for CLI input presentation model [TRL-259]

### DIFF
--- a/docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md
+++ b/docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md
@@ -4,7 +4,7 @@ slug: flags-for-fields-structured-input-on-the-cli
 title: Flags for Fields, Structured Input on the CLI
 status: accepted
 created: 2026-04-03
-updated: 2026-04-03
+updated: 2026-04-10
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [8, 19]
 ---
@@ -13,133 +13,144 @@ depends_on: [8, 19]
 
 ## Context
 
-The CLI gets its power from derivation. A trail author writes one input schema, and the framework projects flags from it automatically. That works beautifully for scalar fields, booleans, enums, and arrays of primitives.
+### The derivation model works — until it doesn't
 
-It breaks down for structured input.
+The CLI gets its power from derivation. A trail author writes one input schema, and the framework projects flags from it automatically. That model — one schema, many trailheads, zero divergence — is the core promise of Trails.
 
-The Stash retro hit the failure in the most obvious place: `gist.create` needs `files: [{ filename, content, language? }]`. The current CLI projection turns that into a flat variadic flag, which cannot faithfully represent the actual input shape.[^retro]
+It holds for scalar fields, booleans, enums, and arrays of primitives. It breaks for structured input (arrays of objects, nested schemas) and it says nothing about the two other concerns a real CLI needs: positional arguments and their ordering, and global flags that apply to every command.
 
-That creates the wrong pressure:
+The Stash dogfood app hit the structured-input failure first: `gist.create` needs `files: [{ filename, content, language? }]`, and flat flag derivation cannot faithfully represent that shape.[^retro] The positional-ordering gap surfaced next: `topo pin <name>` reads naturally, but the framework had no way to express "this field is positional" without leaking CLI concepts into the trail spec. And global flags (`--json`, `--verbose`) were manually wired per-command through a preset mechanism that required explicit opt-in.
 
-- the CLI looks like it supports the trail, but the derived flags are lossy
-- authors are pushed toward CLI-shaped schemas instead of truthful schemas
-- the most tactile trailhead stops being trustworthy precisely where the contract gets interesting
+These are three faces of the same problem: **how does a trailhead-agnostic trail spec project to the full structure of a CLI command?**
 
-Trails should not pretend a tree is flat. But it also should not give up and require CLI-only trail definitions. The right answer is to preserve one schema and offer two honest input channels for it.
+### The layered answer
+
+The answer is a four-layer model where each layer handles a different scope of the problem. The framework derives what it can, the developer declares what it can't, and overrides handle the exceptions:
+
+1. **Framework defaults** — type-driven derivation (schema → flags, booleans → toggles, arrays → comma-separated)
+2. **CLI trailhead globals** — flags that apply to every command (`--json`, `--verbose`)
+3. **App conventions** — reusable patterns across trails (`deriveTrail`, contours)
+4. **Trail-level declarations** — `args` for positional ordering, `fields` for per-field overrides
+
+Each layer refines the previous. The developer only declares what's unique to their level.
 
 ## Decision
 
-The CLI supports **projected flags for fields** and **structured channels for full input**.
-
 ### Field flags stay the default for faithfully representable fields
 
-The CLI continues to derive flags from the trail input schema for fields whose shape can be represented truthfully as flags.
-
-That includes:
-
-- strings
-- numbers
-- booleans
-- enums
-- arrays of primitives
-- optional forms of the same
+The CLI derives flags from the trail input schema for fields whose shape can be represented truthfully. That includes strings, numbers, booleans, enums, and arrays of primitives.
 
 For these fields, the happy path remains:
 
 ```bash
-trails topo pin --name before-auth
-trails tracing query --trail-id gist.create --limit 20
+myapp topo pin v1.0
+myapp tracing query --trail-id gist.create --limit 20
 ```
+
+Array fields accept comma-separated values by default: `--tags a,b,c` parses to `['a', 'b', 'c']`. Override the separator via `fields` when the default is wrong.
+
+### `args` declares positional arguments on the trail spec
+
+A new optional field on `TrailSpec` controls which input fields are positional and in what order:
+
+```typescript
+trail('file.copy', {
+  input: z.object({ src: z.string(), dest: z.string(), recursive: z.boolean() }),
+  args: ['src', 'dest'],
+  intent: 'write',
+});
+```
+
+```bash
+myapp file copy source.txt dest.txt --recursive
+```
+
+The `args` array is the source of truth for positional ordering. It's formatter-proof — unlike schema key order, array element order is never rearranged by code formatters. Only string-typed fields can be positional (non-string fields are silently filtered).
+
+Three shapes:
+
+- `args: ['src', 'dest']` — explicit positional fields, in this order
+- `args: false` — suppress auto-promotion, all fields stay as flags
+- Omitted — heuristic: if exactly one required string field with no default exists, auto-promote it
+
+Positional fields keep their flag alias. `myapp file copy source.txt dest.txt` and `myapp file copy --src source.txt --dest dest.txt` both work. Positional args are registered as optional in the CLI parser because the flag form provides an alternative input path — the trail's Zod schema handles required-field validation after merge.
+
+`args` is a semantic property of the trail's input structure, not a CLI concept. The CLI projects it as positional arg order. A form could project it as field prominence. An agent could use it to prioritize parameters.
 
 ### Structured channels handle the full schema
 
-The CLI also exposes explicit structured-input channels for the full input object:
+The CLI exposes structured-input channels for input shapes that cannot be faithfully represented as flags:
 
-- `--input-json <json>`
-- `--input-file <path>`
-- `--stdin`
-
-All three feed the same contract. They differ only in where the structured payload comes from.
+- `--input-json <json>` — inline JSON payload
+- `--input-file <path>` — file path to JSON
+- `--stdin` — read JSON from stdin
 
 ```bash
-trails gist create --input-json '{"owner":"matt","files":[{"filename":"hello.ts","content":"export {}"}]}'
-
-trails gist create --input-file ./fixtures/gist-create.json
-
-cat ./fixtures/gist-create.json | trails gist create --stdin
+myapp gist create --input-json '{"files":[{"filename":"hello.ts","content":"export {}"}]}'
+cat payload.json | myapp gist create --stdin
 ```
 
-### Lossy flag derivation is not allowed
-
-If a field cannot be represented faithfully as a derived flag, the framework does not invent a misleading one.
-
-This means:
-
-- arrays of objects do not become fake variadic string flags
-- nested objects do not become ad hoc flattened flags by default
-- the CLI points the user to a structured channel instead
-
-The rule is simple: derive flags only when the projection is truthful.
+If a field cannot be represented faithfully as a derived flag, the framework does not invent a misleading one. Arrays of objects do not become fake variadic string flags. Nested objects do not become ad hoc flattened flags. The rule is simple: derive flags only when the projection is truthful.
 
 ### Merge once, validate once
 
 The CLI builds one final input object before executing the trail:
 
-1. start with the structured payload, if one is provided
-2. merge positional args and derived flags on top
-3. validate the final object against the trail's original input schema
+1. Start with the structured payload, if provided
+2. Merge positional args (only defined values — undefined positionals don't clobber)
+3. Merge derived flags (only defined values — meta-flags stripped)
+4. Validate the final object against the trail's Zod input schema
 
-Explicit CLI inputs win on conflict because they are the narrowest, most local override.
+Explicit CLI inputs win on conflict because they are the narrowest, most local override. This keeps the model aligned with the rest of Trails: one authored input schema, one validation pass at the boundary, one final input object entering the trail.
 
-This keeps the model aligned with the rest of Trails:
+### Progressive disclosure of complexity
 
-- one authored input schema
-- one validation pass at the boundary
-- one final input object entering the trail
+Every concept starts simple and gains precision as the developer invests:
 
-### Overrides remain available for CLI-specific ergonomics
+| Developer writes | What happens |
+|-----------------|-------------|
+| Just `input` | All flags, derived from schema. Single required string auto-promotes to positional. |
+| `input` + `args` | Explicit positional args in declared order, remaining fields as flags |
+| `input` + `args` + `fields` | Full control over presentation (separators, labels, overrides) |
+| Uses `deriveTrail` factory | Pattern handles args/fields, developer only writes the blaze |
 
-Trail authors may still provide explicit CLI overrides when a command benefits from a more specialized input shape.
+The framework does not impose ceremony before it becomes necessary.
 
-The escape hatch is valid when it stays:
+## Non-goals
 
-- deliberate
-- local
-- visible in the resolved graph
-
-Examples:
-
-- a custom parser for a domain-specific shorthand
-- a purpose-built positional argument
-- a richer interactive prompt flow
-
-But the default remains honest derivation plus structured input channels. The framework does not require a CLI-only authoring path just to handle nested input.
+- **CLI trailhead globals.** Built-in global flags (`--json`, `--verbose`, `--no-color`) and the trailhead-level configuration for enabling/disabling them are a separate decision. The current preset mechanism works; formalizing it as a first-class API is deferred.
+- **App-level field conventions.** Reusable patterns for field presentation across trails (e.g., "src/dest are always positional in my app") are handled by `deriveTrail` and contour factories, which are covered by their own ADRs.
+- **Interactive editor or form-based authoring.** Complex payload authoring via TUI editors or interactive prompts is a future concern.
 
 ## Consequences
 
 ### Positive
 
 - **The CLI stays truthful.** Commands either expose real derived flags or point to a structured input channel. They do not pretend a nested schema is flat.
-- **One schema remains the source of truth.** MCP, HTTP, tests, and CLI all still validate against the same contract.
-- **Complex trails stay usable from the command line.** Arrays of objects and nested input become first-class instead of second-class.
-- **Overrides remain ergonomic.** Teams that want a more specialized CLI experience can still add one without abandoning the default projection model.
+- **One schema remains the source of truth.** MCP, HTTP, tests, and CLI all validate against the same contract.
+- **Positional ordering is formatter-proof.** The `args` array on the trail spec is the canonical source for positional arg order — no dependence on schema key order or declaration order.
+- **Both syntaxes always work.** Positional fields keep their flag alias. `myapp pin v1.0` and `myapp pin --name v1.0` are equivalent. No breaking changes for flag-based scripts.
+- **Progressive disclosure.** A trail with no `args` and no `fields` still gets a fully functional CLI with derived flags and auto-promoted positional args. Explicit declarations are optional tightening.
 
 ### Tradeoffs
 
-- **The CLI has more than one input path.** That is extra surface area, even though all paths converge on the same schema.
+- **The CLI has more than one input path.** Structured channels, positional args, and flags all converge on the same schema, but that's extra surface area to document and explain.
 - **Some commands will show fewer automatic flags than before.** That is intentional. Omitted flags are better than lossy flags.
-- **Merge precedence must stay clear.** Structured payloads plus flags are powerful, but the CLI docs and output need to explain which input wins on collision.
+- **`args` adds a field to the trail spec.** One more thing to learn. The justification: without it, the only option is depending on schema key order (fragile) or putting positional config on the trailhead (disconnected from the trail).
 
-### What this does NOT decide
+## Non-decisions
 
-- Interactive editor or form-based CLI authoring for complex payloads
-- The exact override API for custom CLI-only parsing
-- Whether future trailheads reuse the same `input-file` / `stdin` vocabulary directly
+- **Comma-separated array parsing.** Whether `--tags a,b,c` is the default for all array types or only string arrays. The current implementation handles string arrays; numeric arrays may follow.
+- **Value format DSL.** Whether `fields` grows a `format` or `parser` property for custom value parsing (e.g., `3:7` as a range). The current `separator` override is sufficient for now.
+- **Multi-positional ordering for non-string types.** `args` currently restricts to string-typed fields. Extending to numbers or enums would require type coercion in the Commander adapter.
 
 ## References
 
-- [ADR-0008: Deterministic Trailhead Derivation](0008-deterministic-trailhead-derivation.md) — this keeps CLI derivation deterministic while refusing lossy projections
+- [ADR-0008: Deterministic Trailhead Derivation](0008-deterministic-trailhead-derivation.md) — the deterministic derivation model that `args` extends
 - [ADR-0019: Hierarchical Command Trees from Trail IDs](0019-hierarchical-command-trees-from-trail-ids.md) — the companion decision for nested command paths
-- [Trails Design Tenets](../tenets.md) — especially "schema always exists" and "validate at the boundary, trust internally"
+- [Trails Design Tenets](../tenets.md) — especially "derive by default, declare to tighten, override when wrong" and "schema always exists"
+- [CLI Input Presentation Model](../../.scratch/2026-04-10-cli-input-presentation-model.md) — design notes covering the full four-layer model including globals and app conventions
+- [ADR: Contours as First-Class Domain Objects](drafts/20260409-contours-as-first-class-domain-objects.md) (draft) — contour-aware `deriveTrail()` that can carry `args` conventions
+- [ADR: `deriveTrail()` and Trail Factories](drafts/20260409-derivetrail-and-trail-factories.md) (draft) — reusable patterns that absorb `args` and `fields` declarations
 
 [^retro]: The Stash dogfood retro identified `gist.create` as the first practical place where flat flag derivation fails for nested input.

--- a/docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md
+++ b/docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md
@@ -149,7 +149,6 @@ The framework does not impose ceremony before it becomes necessary.
 - [ADR-0008: Deterministic Trailhead Derivation](0008-deterministic-trailhead-derivation.md) — the deterministic derivation model that `args` extends
 - [ADR-0019: Hierarchical Command Trees from Trail IDs](0019-hierarchical-command-trees-from-trail-ids.md) — the companion decision for nested command paths
 - [Trails Design Tenets](../tenets.md) — especially "derive by default, declare to tighten, override when wrong" and "schema always exists"
-- [CLI Input Presentation Model](../../.scratch/2026-04-10-cli-input-presentation-model.md) — design notes covering the full four-layer model including globals and app conventions
 - [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md) — contour-aware `deriveTrail()` that can carry `args` conventions
 - [ADR-0032: `deriveTrail()` and Trail Factories](0032-derivetrail-and-trail-factories.md) — reusable patterns that absorb `args` and `fields` declarations
 

--- a/docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md
+++ b/docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md
@@ -4,7 +4,7 @@ slug: flags-for-fields-structured-input-on-the-cli
 title: Flags for Fields, Structured Input on the CLI
 status: accepted
 created: 2026-04-03
-updated: 2026-04-10
+updated: 2026-04-13
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [8, 19]
 ---
@@ -150,7 +150,7 @@ The framework does not impose ceremony before it becomes necessary.
 - [ADR-0019: Hierarchical Command Trees from Trail IDs](0019-hierarchical-command-trees-from-trail-ids.md) — the companion decision for nested command paths
 - [Trails Design Tenets](../tenets.md) — especially "derive by default, declare to tighten, override when wrong" and "schema always exists"
 - [CLI Input Presentation Model](../../.scratch/2026-04-10-cli-input-presentation-model.md) — design notes covering the full four-layer model including globals and app conventions
-- [ADR: Contours as First-Class Domain Objects](drafts/20260409-contours-as-first-class-domain-objects.md) (draft) — contour-aware `deriveTrail()` that can carry `args` conventions
-- [ADR: `deriveTrail()` and Trail Factories](drafts/20260409-derivetrail-and-trail-factories.md) (draft) — reusable patterns that absorb `args` and `fields` declarations
+- [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md) — contour-aware `deriveTrail()` that can carry `args` conventions
+- [ADR-0032: `deriveTrail()` and Trail Factories](0032-derivetrail-and-trail-factories.md) — reusable patterns that absorb `args` and `fields` declarations
 
 [^retro]: The Stash dogfood retro identified `gist.create` as the first practical place where flat flag derivation fails for nested input.

--- a/docs/adr/0032-derivetrail-and-trail-factories.md
+++ b/docs/adr/0032-derivetrail-and-trail-factories.md
@@ -279,23 +279,23 @@ Start small. Ship store trail factories and composition trail factories in their
 ## Non-decisions
 
 - **Pattern shapes at 1.0.** Which patterns (`crud`, `toggle`, `sync`, `reconcile`, `fanout`, `gate`, `transition`, `ingest`) ship in the first release. This depends on which ones prove out in the dogfooding app.
-- **Contour integration.** How `deriveTrail()` interacts with contour declarations — deriving input schemas from contours rather than store schemas — depends on [ADR-0030: Contours as First-Class Domain Objects](../0030-contours-as-first-class-domain-objects.md).
+- **Contour integration.** How `deriveTrail()` interacts with contour declarations — deriving input schemas from contours rather than store schemas — depends on [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md).
 - **Connector-contributed factories.** Whether connectors export optimized trail factories (e.g., D1 batch CRUD) via their `/trails` subpath depends on [ADR: Resource Bundles](20260409-resource-bundles.md) (draft) and how bundles carry trails alongside resources.
 
 ## References
 
-- [ADR-0000: Core Premise](../0000-core-premise.md) — the information architecture and "one write, many reads" principle that `deriveTrail()` operationalizes
-- [ADR-0001: Naming Conventions](../0001-naming-conventions.md) — the verb+noun helper convention that `deriveTrail()` follows
-- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the trail primitive that factories produce
-- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store schema that `deriveTrail()` reads from
-- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the `pattern` field and `derive*` grammar rule
-- [ADR-0030: Contours as First-Class Domain Objects](../0030-contours-as-first-class-domain-objects.md) — the upstream domain noun that feeds `deriveTrail()`
-- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](../0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model for connector-contributed `/trails` subpaths
-- [ADR-0031: Backend-Agnostic Store Schemas](../0031-backend-agnostic-store-schemas.md) — the store schema that `deriveTrail()` reads from
-- [Tenets: Reduce ceremony, not clarity](../../tenets.md) — the governing principle; trail factories are ceremony reduction that rests on inspectable ground truth
-- [Tenets: The bar for new primitives](../../tenets.md#the-bar-for-new-primitives) — `deriveTrail()` passes because it strengthens existing primitives rather than adding new ones
+- [ADR-0000: Core Premise](0000-core-premise.md) — the information architecture and "one write, many reads" principle that `deriveTrail()` operationalizes
+- [ADR-0001: Naming Conventions](0001-naming-conventions.md) — the verb+noun helper convention that `deriveTrail()` follows
+- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) — the trail primitive that factories produce
+- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store schema that `deriveTrail()` reads from
+- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the `pattern` field and `derive*` grammar rule
+- [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md) — the upstream domain noun that feeds `deriveTrail()`
+- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model for connector-contributed `/trails` subpaths
+- [ADR-0031: Backend-Agnostic Store Schemas](0031-backend-agnostic-store-schemas.md) — the store schema that `deriveTrail()` reads from
+- [Tenets: Reduce ceremony, not clarity](../tenets.md) — the governing principle; trail factories are ceremony reduction that rests on inspectable ground truth
+- [Tenets: The bar for new primitives](../tenets.md#the-bar-for-new-primitives) — `deriveTrail()` passes because it strengthens existing primitives rather than adding new ones
 
-[^1]: [ADR-0023: Simplifying the Trails Lexicon — Grammar rules](../0023-simplifying-the-trails-lexicon.md)
-[^2]: [Tenets: Reduce ceremony, not clarity](../../tenets.md)
-[^3]: [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — `pattern` as the declared operational shape
-[^4]: [ADR-0012: Connector-Agnostic Permits](../0012-connector-agnostic-permits.md) — verification as permit resolution
+[^1]: [ADR-0023: Simplifying the Trails Lexicon — Grammar rules](0023-simplifying-the-trails-lexicon.md)
+[^2]: [Tenets: Reduce ceremony, not clarity](../tenets.md)
+[^3]: [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — `pattern` as the declared operational shape
+[^4]: [ADR-0012: Connector-Agnostic Permits](0012-connector-agnostic-permits.md) — verification as permit resolution

--- a/docs/adr/0032-derivetrail-and-trail-factories.md
+++ b/docs/adr/0032-derivetrail-and-trail-factories.md
@@ -280,7 +280,7 @@ Start small. Ship store trail factories and composition trail factories in their
 
 - **Pattern shapes at 1.0.** Which patterns (`crud`, `toggle`, `sync`, `reconcile`, `fanout`, `gate`, `transition`, `ingest`) ship in the first release. This depends on which ones prove out in the dogfooding app.
 - **Contour integration.** How `deriveTrail()` interacts with contour declarations — deriving input schemas from contours rather than store schemas — depends on [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md).
-- **Connector-contributed factories.** Whether connectors export optimized trail factories (e.g., D1 batch CRUD) via their `/trails` subpath depends on [ADR: Resource Bundles](20260409-resource-bundles.md) (draft) and how bundles carry trails alongside resources.
+- **Connector-contributed factories.** Whether connectors export optimized trail factories (e.g., D1 batch CRUD) via their `/trails` subpath depends on [ADR: Resource Bundles](drafts/20260409-resource-bundles.md) (draft) and how bundles carry trails alongside resources.
 
 ## References
 

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -80,34 +80,14 @@
           "fromPath": "docs/adr/0018-signal-driven-governance.md"
         },
         {
-          "context": "- [ADR-0000: Core Premise — The information architecture](0000-core-premise.md) — the authored/projected/enforced categories that `crossInput` extends with composition scope",
+          "context": "- [ADR-0000: Core Premise — The information architecture](../0000-core-premise.md) — the authored/projected/enforced categories that `crossInput` extends with composition scope",
           "from": "0024",
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
         },
         {
-          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) -- \"derive by default, override deliberately\"; the information architecture categories",
-          "from": "0027",
-          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
-        },
-        {
-          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) -- \"derive by default\"; tracing observes composition shape rather than requiring it to be declared",
-          "from": "0028",
-          "fromPath": "docs/adr/0028-concurrent-crossing.md"
-        },
-        {
-          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) — the information architecture categories (authored, projected, enforced) that contour leverages",
-          "from": "0030",
-          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) — the information architecture and \"one write, many reads\" principle that `deriveTrail()` operationalizes",
-          "from": "0032",
-          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
-        },
-        {
-          "context": "[ADR-0000's premise that the contract is queryable](0000-core-premise.md#the-contract-is-queryable) depends on declarations being load-bearing at runtime. When a field exists on the trail spec but doe",
-          "from": "0033",
-          "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
+          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"derive by default\"; tracing observes composition shape rather than requiring it to be declared",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"the trail is the product\"; `trails run` makes every trail directly invocable without trailhead ceremony",
@@ -140,6 +120,11 @@
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
         },
         {
+          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"derive by default, override deliberately\"; the information architecture categories",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
+        },
+        {
           "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"trailheads are peers\"; WebSocket is the fourth trailhead, following the same patterns as CLI, MCP, and HTTP",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
@@ -158,6 +143,16 @@
           "context": "- [ADR-0000: Core premise](../0000-core-premise.md) — \"author what's new, derive what's known\" applies to documentation: author the source tree, derive the site",
           "from": "20260406",
           "fromPath": "docs/adr/drafts/20260406-documentation-structure.md"
+        },
+        {
+          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) — the information architecture categories (authored, projected, enforced) that contour leverages",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) — the information architecture and \"one write, many reads\" principle that `deriveTrail()` operationalizes",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- **[ADR-0000: Core Premise](./adr/0000-core-premise.md)** — Why contracts, why Result, why derive",
@@ -209,19 +204,9 @@
           "fromPath": "docs/adr/0021-draft-state-stays-out-of-the-resolved-graph.md"
         },
         {
-          "context": "- [ADR-0001: Naming Conventions](0001-naming-conventions.md) — the grammar rules this ADR extends. Singular/plural/verb conventions carry over verbatim; this ADR adds the brand-vs-plain heuristic and ",
+          "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md) — the grammar rules this ADR extends. Singular/plural/verb conventions carry over verbatim; this ADR adds the brand-vs-plain heuristic a",
           "from": "0023",
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
-        },
-        {
-          "context": "- [ADR-0001: Naming Conventions](0001-naming-conventions.md) — the vocabulary rules that `contour()` follows as a bare-noun primitive",
-          "from": "0030",
-          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0001: Naming Conventions](0001-naming-conventions.md) — the verb+noun helper convention that `deriveTrail()` follows",
-          "from": "0032",
-          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md): `create*` factory convention, `derive*` prefix for framework derivations, `build*`/`to*` trailhead wiring pattern",
@@ -232,6 +217,16 @@
           "context": "- [ADR-0001: Naming conventions](../0001-naming-conventions.md) — naming principles that apply to documentation paths",
           "from": "20260406",
           "fromPath": "docs/adr/drafts/20260406-documentation-structure.md"
+        },
+        {
+          "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md) — the vocabulary rules that `contour()` follows as a bare-noun primitive",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md) — the verb+noun helper convention that `deriveTrail()` follows",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "Canonical public trailhead-facing reference. For naming conventions and decision history, see [ADR-0001](./adr/0001-naming-conventions.md).",
@@ -273,24 +268,19 @@
           "fromPath": "docs/adr/0009-first-class-resources.md"
         },
         {
-          "context": "- [ADR-0002: Built-In Result Type](0002-built-in-result-type.md) — established the original taxonomy and HTTP/CLI/JSON-RPC mappings",
-          "from": "0026",
-          "fromPath": "docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md"
-        },
-        {
-          "context": "- [ADR-0002: Built-In Result Type](0002-built-in-result-type.md) -- the Result model that handles partial failure in concurrent crossings",
-          "from": "0028",
-          "fromPath": "docs/adr/0028-concurrent-crossing.md"
-        },
-        {
-          "context": "- [ADR-0002: Built-In Result Type](0002-built-in-result-type.md) — detours match on `Result.err(TrailsError)` values, preserving the throw-free pipeline invariant.",
-          "from": "0033",
-          "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
+          "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) -- the Result model that handles partial failure in concurrent crossings",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) — the error taxonomy maps to categorized failure events",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
+        },
+        {
+          "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) — established the 13-class taxonomy and HTTP/CLI/JSON-RPC mappings",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-error-taxonomy-as-transport-independent-behavior-contract.md"
         },
         {
           "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) — the Result and error taxonomy that gains `VersionNotSupportedError`",
@@ -327,34 +317,19 @@
           "fromPath": "docs/adr/0009-first-class-resources.md"
         },
         {
-          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) — the unified trail/hike primitive with `crosses` and `ctx.cross()`",
+          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the unified trail/hike primitive with `crosses` and `ctx.cross()`",
           "from": "0024",
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
         },
         {
-          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) — the `crosses` / `ctx.cross()` composition mechanism that composite testing targets",
+          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the `crosses` / `ctx.cross()` composition mechanism that composite testing targets",
           "from": "0025",
           "fromPath": "docs/adr/0025-composition-testing.md"
         },
         {
-          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) -- the trail spec that gains the `visibility` field",
-          "from": "0027",
-          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
-        },
-        {
-          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) -- \"composition is a property, not a type\"; parallel vs sequential is a runtime choice, not a contract distinction. The crossing ",
-          "from": "0028",
-          "fromPath": "docs/adr/0028-concurrent-crossing.md"
-        },
-        {
-          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) — the merge test applied to contour vs. trail (conclusion: they're different enough to stay separate)",
-          "from": "0030",
-          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) — the trail primitive that factories produce",
-          "from": "0032",
-          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
+          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- \"composition is a property, not a type\"; parallel vs sequential is a runtime choice, not a contract distinction. The crossi",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- every trail is runnable, whether atomic or composite",
@@ -380,6 +355,21 @@
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — `fires` is a new property on the trail spec",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
+        },
+        {
+          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- the trail spec that gains the `visibility` field",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
+        },
+        {
+          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the merge test applied to contour vs. trail (conclusion: they're different enough to stay separate)",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the trail primitive that factories produce",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the trail as the single unit of work, the unit that versioning targets",
@@ -421,11 +411,6 @@
           "fromPath": "docs/adr/0013-tracing.md"
         },
         {
-          "context": "- [ADR-0004: Intent as a First-Class Property](0004-intent-as-first-class-property.md) -- intent drives HTTP verbs, MCP annotations, and now trailhead filtering",
-          "from": "0027",
-          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
-        },
-        {
           "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- rigged trails declare intent; HTTP method mapping and MCP annotations work identically",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
@@ -434,6 +419,11 @@
           "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) — intent compounds with activation; lifecycle signals filter by intent",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
+        },
+        {
+          "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- intent drives HTTP verbs, MCP annotations, and now trailhead filtering",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- intent compounds with layers for surface derivation and governance",
@@ -519,24 +509,14 @@
           "fromPath": "docs/adr/0013-tracing.md"
         },
         {
-          "context": "- [ADR-0006: Shared Execution Pipeline](0006-shared-execution-pipeline.md) — the pipeline that absorbs intrinsic tracing when `tracingLayer` collapses.",
+          "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) — the pipeline that absorbs intrinsic tracing when `tracingLayer` collapses.",
           "from": "0023",
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
         },
         {
-          "context": "- [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](0006-shared-execution-pipeline.md) — the execution pipeline that produces Results with typed errors",
-          "from": "0026",
-          "fromPath": "docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md"
-        },
-        {
-          "context": "- [ADR-0006: Shared Execution Pipeline](0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged",
-          "from": "0028",
-          "fromPath": "docs/adr/0028-concurrent-crossing.md"
-        },
-        {
-          "context": "What hasn't existed is **runtime execution**. No component of [`executeTrail`](0006-shared-execution-pipeline.md) reads the `detours:` field today. A trail can declare a detour for `ConflictError`, bu",
-          "from": "0033",
-          "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
+          "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- `trails run` executes through the pipeline, the same as every trailhead",
@@ -562,6 +542,11 @@
           "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md): `executeTrail` as the single implementation of validate-context-layers-run; the library trailhead delegates to the same p",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
+        },
+        {
+          "context": "- [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md) — the execution pipeline that produces Results with typed errors",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-error-taxonomy-as-transport-independent-behavior-contract.md"
         },
         {
           "context": "- [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md) -- the execution pipeline that layers currently compose into",
@@ -608,12 +593,12 @@
           "fromPath": "docs/adr/0017-serialized-topo-graph.md"
         },
         {
-          "context": "- [ADR-0007: Governance as Trails](0007-governance-as-trails.md) — the warden's `cross-declarations` rule that this extends",
+          "context": "- [ADR-0007: Governance as Trails](../0007-governance-as-trails.md) — the warden's `cross-declarations` rule that this extends",
           "from": "0024",
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
         },
         {
-          "context": "- [ADR-0007: Governance as Trails](0007-governance-as-trails.md) — the warden rules that `composite-example-coverage` and `scenario-coverage` extend",
+          "context": "- [ADR-0007: Governance as Trails](../0007-governance-as-trails.md) — the warden rules that `composite-example-coverage` and `scenario-coverage` extend",
           "from": "0025",
           "fromPath": "docs/adr/0025-composition-testing.md"
         },
@@ -677,14 +662,9 @@
           "fromPath": "docs/adr/0019-hierarchical-command-trees-from-trail-ids.md"
         },
         {
-          "context": "- [ADR-0008: Deterministic Trailhead Derivation](0008-deterministic-trailhead-derivation.md) — this keeps CLI derivation deterministic while refusing lossy projections",
+          "context": "- [ADR-0008: Deterministic Trailhead Derivation](0008-deterministic-trailhead-derivation.md) — the deterministic derivation model that `args` extends",
           "from": "0020",
           "fromPath": "docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md"
-        },
-        {
-          "context": "- [ADR-0008: Deterministic Trailhead Derivation](0008-deterministic-trailhead-derivation.md) -- the derivation rules that visibility and intent filtering extend",
-          "from": "0027",
-          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- rigged trails get trailhead derivation for free",
@@ -695,6 +675,11 @@
           "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- survey output provides the contract snapshots",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
+        },
+        {
+          "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- the derivation rules that visibility and intent filtering extend",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- trail IDs map to WebSocket method names, event IDs map to subscription channels",
@@ -761,29 +746,14 @@
           "fromPath": "docs/adr/0016-schema-derived-persistence.md"
         },
         {
-          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the resource lifecycle a bound store participates in",
+          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the resource lifecycle a bound store participates in",
           "from": "0022",
           "fromPath": "docs/adr/0022-drizzle-store-connector.md"
         },
         {
-          "context": "- [ADR-0009: Resources as a First-Class Primitive](0009-first-class-resources.md) — to be revisited. `provision` → `resource`. API shape unchanged.",
+          "context": "- [ADR-0009: Resources as a First-Class Primitive](../0009-first-class-resources.md) — to be revisited. `provision` → `resource`. API shape unchanged.",
           "from": "0023",
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
-        },
-        {
-          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the `resource()` primitive that connectors produce and trails consume",
-          "from": "0029",
-          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the resource primitive that contours relate to through the store binding",
-          "from": "0030",
-          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the resource primitive that connectors produce and stores bind through",
-          "from": "0031",
-          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
         },
         {
           "context": "- [ADR-0009: Resources](../0009-first-class-resources.md) -- the resource primitive that packs scope and compose",
@@ -799,6 +769,21 @@
           "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) -- the resource pattern for embedding providers",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
+        },
+        {
+          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the resource primitive that connectors produce and stores bind through",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
+        },
+        {
+          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the `resource()` primitive that connectors produce and trails consume",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the resource primitive that contours relate to through the store binding",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
         },
         {
           "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the resource primitive that bundles group and distribute",
@@ -859,7 +844,7 @@
       "depends_on": [],
       "inbound": [
         {
-          "context": "- [ADR-0011: Schema-Driven Config](0011-schema-driven-config.md) — to be revisited. `loadout` → `profile`. Config resolution unchanged.",
+          "context": "- [ADR-0011: Schema-Driven Config](../0011-schema-driven-config.md) — to be revisited. `loadout` → `profile`. Config resolution unchanged.",
           "from": "0023",
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
         },
@@ -888,9 +873,9 @@
           "fromPath": "docs/adr/0013-tracing.md"
         },
         {
-          "context": "[^4]: [ADR-0012: Connector-Agnostic Permits](0012-connector-agnostic-permits.md) — verification as permit resolution",
-          "from": "0032",
-          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
+          "context": "[^4]: [ADR-0012: Connector-Agnostic Permits](../0012-connector-agnostic-permits.md) — verification as permit resolution",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0012: Connector-Agnostic Permits](../0012-connector-agnostic-permits.md) -- permit declarations that become pipeline-enforced",
@@ -937,19 +922,14 @@
           "fromPath": "docs/adr/0015-topo-store.md"
         },
         {
-          "context": "| `tracingLayer` | Built-in tracing in `executeTrail` | No longer a separately attached gate/layer. Intrinsic to the execution pipeline. Partially supersedes [ADR-0013](0013-tracing.md)'s \"layer plus ",
+          "context": "| `tracingLayer` | Built-in tracing in `executeTrail` | No longer a separately attached gate/layer. Intrinsic to the execution pipeline. Partially supersedes [ADR-0013](../0013-tracing.md)'s \"layer pl",
           "from": "0023",
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
         },
         {
-          "context": "- [ADR-0013: Tracing](0013-tracing.md) -- the observability system; visibility filtering events are observable through tracing",
-          "from": "0027",
-          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
-        },
-        {
-          "context": "- [ADR-0013: Tracing](0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime",
-          "from": "0028",
-          "fromPath": "docs/adr/0028-concurrent-crossing.md"
+          "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- the tracing primitive; live tracing during `trails run`, historical tracing via `trails trace`",
@@ -980,6 +960,11 @@
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) — tracing records emission and delivery metadata",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
+        },
+        {
+          "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- the observability system; visibility filtering events are observable through tracing",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- observability and replay buffer backing store",
@@ -1036,9 +1021,9 @@
           "fromPath": "docs/adr/0018-signal-driven-governance.md"
         },
         {
-          "context": "- [ADR-0014: Core Database Primitive](0014-core-database-primitive.md) — the database primitive that store builds on",
-          "from": "0031",
-          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
+          "context": "- [ADR-0014: Core Database Primitive](../0014-core-database-primitive.md) — the database primitive that store builds on",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
         },
         {
           "context": "- **[ADR-0014: Core Database Primitive](./adr/0014-core-database-primitive.md)** — Shared `trails.db`, subsystem schema versioning",
@@ -1104,34 +1089,34 @@
           "fromPath": "docs/adr/0018-signal-driven-governance.md"
         },
         {
-          "context": "[ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) defines the store model: the root package owns the durable `store(...)` declaration, and connectors bind that declaration to ",
+          "context": "[ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) defines the store model: the root package owns the durable `store(...)` declaration, and connectors bind that declaration ",
           "from": "0022",
           "fromPath": "docs/adr/0022-drizzle-store-connector.md"
-        },
-        {
-          "context": "- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store contract that connectors bind to concrete backends",
-          "from": "0029",
-          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store contract that can derive from contours instead of standalone schemas",
-          "from": "0030",
-          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "[ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) established `store()` as the persistence declaration and schema-to-table derivation as the mechanism. [ADR-0022: Drizzle Bind",
-          "from": "0031",
-          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
-        },
-        {
-          "context": "- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store schema that `deriveTrail()` reads from",
-          "from": "0032",
-          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) -- the store abstraction that search extends",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
+        },
+        {
+          "context": "[ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) established `store()` as the persistence declaration and schema-to-table derivation as the mechanism. [ADR-0022: Drizzle B",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
+        },
+        {
+          "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store contract that connectors bind to concrete backends",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store contract that can derive from contours instead of standalone schemas",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store schema that `deriveTrail()` reads from",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store contract that bundle resources satisfy",
@@ -1178,19 +1163,19 @@
           "fromPath": "docs/adr/0021-draft-state-stays-out-of-the-resolved-graph.md"
         },
         {
-          "context": "- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) -- the lockfile captures resolved visibility state after all overrides are applied",
-          "from": "0027",
-          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
-        },
-        {
-          "context": "- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns",
-          "from": "0028",
-          "fromPath": "docs/adr/0028-concurrent-crossing.md"
+          "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- rig state captured in the lockfile graph; rig lock state occupies a section in `trails.lock`",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
+        },
+        {
+          "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures resolved visibility state after all overrides are applied",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- captures WebSocket trailhead configuration in the resolved topo graph",
@@ -1297,7 +1282,7 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Flags for Fields, Structured Input on the CLI",
-      "updated": "2026-04-03"
+      "updated": "2026-04-10"
     },
     {
       "created": "2026-04-03",
@@ -1328,14 +1313,14 @@
       "depends_on": ["16", "9"],
       "inbound": [
         {
-          "context": "- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](0022-drizzle-store-connector.md) — the first connector implementation, currently a subpath of `@ontrails/store`",
-          "from": "0029",
-          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
+          "context": "[ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) established `store()` as the persistence declaration and schema-to-table derivation as the mechanism. [ADR-0022: Drizzle B",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
         },
         {
-          "context": "[ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) established `store()` as the persistence declaration and schema-to-table derivation as the mechanism. [ADR-0022: Drizzle Bind",
-          "from": "0031",
-          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
+          "context": "- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md) — the first connector implementation, currently a subpath of `@ontrails/store`",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
         },
         {
           "context": "- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md) — the first connector, now understood as a single-resource bundle",
@@ -1372,26 +1357,6 @@
           "fromPath": "docs/adr/0013-tracing.md"
         },
         {
-          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the naming heuristic that `with-*` follows",
-          "from": "0029",
-          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the naming heuristic and `pattern` as the trail's declared operational shape",
-          "from": "0030",
-          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the `pattern` field and `derive*` grammar rule",
-          "from": "0032",
-          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
-        },
-        {
-          "context": "Detours are already in the Trails lexicon as a trail-level field: *\"recovery paths when the trail is blocked or fails. The trail blazes forward; if blocked, it detours.\"* See [ADR-0023](0023-simplifyi",
-          "from": "0033",
-          "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
-        },
-        {
           "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) -- the lexicon renames; note that `resource` in this ADR refers to the distribution unit, distinct from `resourc",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
@@ -1410,6 +1375,21 @@
           "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the vocabulary→lexicon rename that this structure codifies",
           "from": "20260406",
           "fromPath": "docs/adr/drafts/20260406-documentation-structure.md"
+        },
+        {
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the naming heuristic that `with-*` follows",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the naming heuristic and `pattern` as the trail's declared operational shape",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the `pattern` field and `derive*` grammar rule",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- **[ADR-0023: Simplifying the Trails Lexicon](./adr/0023-simplifying-the-trails-lexicon.md)** — Brand-vs-plain heuristic, four pre-1.0 renames, vocabulary → lexicon",
@@ -1436,19 +1416,14 @@
       "depends_on": ["3", "7"],
       "inbound": [
         {
-          "context": "- [ADR-0024: Typed Trail Composition](0024-typed-trail-composition.md) — typed `ctx.cross()` and `crossInput` that scenarios exercise",
+          "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) — typed `ctx.cross()` and `crossInput` that scenarios exercise",
           "from": "0025",
           "fromPath": "docs/adr/0025-composition-testing.md"
         },
         {
-          "context": "- [ADR-0024: Typed Trail Composition](0024-typed-trail-composition.md) -- `crossInput` relates to internal visibility; a trail with required `crossInput` fields should declare `visibility: 'internal'`",
-          "from": "0027",
-          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
-        },
-        {
-          "context": "- [ADR-0024: Typed Trail Composition](0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred he",
-          "from": "0028",
-          "fromPath": "docs/adr/0028-concurrent-crossing.md"
+          "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) — typed `ctx.cross()` complements signal-based activation; `on:` is for reactive decoupling, `crosses` is for direct compositi",
@@ -1459,6 +1434,11 @@
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) — typed `ctx.cross()` complements signal-based decoupling; signals are for loose coupling, crosses are for typed direct compos",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
+        },
+        {
+          "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- `crossInput` relates to internal visibility; a trail with required `crossInput` fields should declare `visibility: 'interna",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- `crossInput` follows the same \"compose schemas, project the union\" pattern as layer input schemas",
@@ -1488,330 +1468,15 @@
     {
       "created": "2026-04-09",
       "depends_on": ["3", "7", "24"],
-      "inbound": [
-        {
-          "context": "- [ADR-0025: Composition Testing](0025-composition-testing.md) -- `scenario()` and `expectedMatch` for testing concurrent composition flows",
-          "from": "0028",
-          "fromPath": "docs/adr/0028-concurrent-crossing.md"
-        }
-      ],
+      "inbound": [],
       "number": "0025",
       "owners": ["[galligan](https://github.com/galligan)"],
       "path": "docs/adr/0025-composition-testing.md",
       "slug": "composition-testing",
       "status": "accepted",
       "superseded_by": null,
-      "title": "Composition Testing",
+      "title": "ADR: Composition Testing",
       "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-04-09",
-      "depends_on": ["2", "6"],
-      "inbound": [
-        {
-          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
-        },
-        {
-          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
-        },
-        {
-          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) -- WebSocket close code mapping deferred there; the error ",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
-        }
-      ],
-      "number": "0026",
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md",
-      "slug": "error-taxonomy-as-transport-independent-behavior-contract",
-      "status": "accepted",
-      "superseded_by": null,
-      "title": "Error Taxonomy as Transport-Independent Behavior Contract",
-      "updated": "2026-04-13"
-    },
-    {
-      "created": "2026-03-31",
-      "depends_on": ["packs-namespace-boundaries"],
-      "inbound": [
-        {
-          "context": "[^3]: See [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md)",
-          "from": "0024",
-          "fromPath": "docs/adr/0024-typed-trail-composition.md"
-        },
-        {
-          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode",
-          "from": "0028",
-          "fromPath": "docs/adr/0028-concurrent-crossing.md"
-        },
-        {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
-        },
-        {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
-        },
-        {
-          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
-        }
-      ],
-      "number": "0027",
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/0027-visibility-and-filtering.md",
-      "slug": "visibility-and-filtering",
-      "status": "accepted",
-      "superseded_by": null,
-      "title": "Trail Visibility and Trailhead Filtering",
-      "updated": "2026-04-10"
-    },
-    {
-      "created": "2026-03-31",
-      "depends_on": ["3"],
-      "inbound": [
-        {
-          "context": "- [ADR-0028: Concurrent Trail Crossing](../0028-concurrent-crossing.md) -- `--trace` renders concurrent crossings as parallel branches in the execution tree",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
-        }
-      ],
-      "number": "0028",
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/0028-concurrent-crossing.md",
-      "slug": "concurrent-crossing",
-      "status": "accepted",
-      "superseded_by": null,
-      "title": "Concurrent Trail Crossing",
-      "updated": "2026-04-10"
-    },
-    {
-      "created": "2026-04-09",
-      "depends_on": ["9", "16", "22", "23"],
-      "inbound": [
-        {
-          "context": "The Hono connector lives in its own workspace package (originally shipped as the `@ontrails/http/hono` subpath; see [ADR-0029](./0029-connector-extraction-and-the-with-packaging-model.md)). Two functi",
-          "from": "0005",
-          "fromPath": "docs/adr/0005-framework-agnostic-http-route-model.md"
-        },
-        {
-          "context": "> Originally shipped as the `@ontrails/store/drizzle` subpath; [ADR-0029](./0029-connector-extraction-and-the-with-packaging-model.md) promoted connectors to their own workspace packages.",
-          "from": "0022",
-          "fromPath": "docs/adr/0022-drizzle-store-connector.md"
-        },
-        {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) — the connector extraction that contour-derived stores will bind through",
-          "from": "0030",
-          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model connectors live in",
-          "from": "0031",
-          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
-        },
-        {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model for connector-contributed `/trails` subpaths",
-          "from": "0032",
-          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
-        },
-        {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](../0029-connector-extraction-and-the-with-packaging-model.md) -- the packaging model for connector-contributed capabilities that rig",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
-        },
-        {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) -- connectors move to `@ontrails/with-*` packages; affects how connector ",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
-        },
-        {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](../0029-connector-extraction-and-the-with-packaging-model.md) -- connectors are extracted from core packages; packs compose with con",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
-        },
-        {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) -- connectors as `@ontrails/with-*` packages; compiled packs may depend o",
-          "from": "20260401",
-          "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
-        },
-        {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model for connector bundles",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
-        }
-      ],
-      "number": "0029",
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md",
-      "slug": "connector-extraction-and-the-with-packaging-model",
-      "status": "accepted",
-      "superseded_by": null,
-      "title": "Connector Extraction and the with-* Packaging Model",
-      "updated": "2026-04-13"
-    },
-    {
-      "created": "2026-04-09",
-      "depends_on": ["0", "1", "3", "9", "16", "23"],
-      "inbound": [
-        {
-          "context": "- [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md) — contour-aware `deriveTrail()` that may auto-generate `crossInput`",
-          "from": "0024",
-          "fromPath": "docs/adr/0024-typed-trail-composition.md"
-        },
-        {
-          "context": "- **How trails subpaths work on connectors.** Connectors that contribute trails (health checks, platform-optimized operations) may export them at `@ontrails/with-*/trails`. The design depends on [ADR-",
-          "from": "0029",
-          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- **Contour integration.** How `deriveTrail()` interacts with contour declarations — deriving input schemas from contours rather than store schemas — depends on [ADR-0030: Contours as First-Class Doma",
-          "from": "0032",
-          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
-        },
-        {
-          "context": "- [ADR-0030: Contours as First-Class Domain Objects](../0030-contours-as-first-class-domain-objects.md) -- contours define the domain objects that pack trails operate on",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
-        },
-        {
-          "context": "- [ADR-0030: Contours as First-Class Domain Objects](../0030-contours-as-first-class-domain-objects.md) -- contours as the domain objects pack trails operate on; schema reuse feeds the compiled librar",
-          "from": "20260401",
-          "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
-        },
-        {
-          "context": "- [ADR-0030: Contours as First-Class Domain Objects](../0030-contours-as-first-class-domain-objects.md) -- contours provide the domain object schemas that search declarations annotate",
-          "from": "20260401",
-          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
-        },
-        {
-          "context": "- [ADR-0030: Contours as First-Class Domain Objects](../0030-contours-as-first-class-domain-objects.md) — contours feed store schemas within bundles",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
-        }
-      ],
-      "number": "0030",
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/0030-contours-as-first-class-domain-objects.md",
-      "slug": "contours-as-first-class-domain-objects",
-      "status": "accepted",
-      "superseded_by": null,
-      "title": "Contours as First-Class Domain Objects",
-      "updated": "2026-04-10"
-    },
-    {
-      "created": "2026-04-09",
-      "depends_on": ["9", "14", "16", "22", "29"],
-      "inbound": [
-        {
-          "context": "- [ADR-0031: Backend-Agnostic Store Schemas](0031-backend-agnostic-store-schemas.md) — the store-kind model that makes first-party backends meaningful",
-          "from": "0029",
-          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- [ADR-0031: Backend-Agnostic Store Schemas](0031-backend-agnostic-store-schemas.md) — the store schema that `deriveTrail()` reads from",
-          "from": "0032",
-          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
-        },
-        {
-          "context": "[ADR-0031: Backend-Agnostic Store Schemas](0031-backend-agnostic-store-schemas.md) established the store as a backend-agnostic persistence domain. It defined the kind taxonomy (tabular, document, file",
-          "from": "0034",
-          "fromPath": "docs/adr/0034-store-accessor-contract-refinement-lessons-from-two-backends.md"
-        },
-        {
-          "context": "- [ADR-0031: Backend-Agnostic Store Schemas](../0031-backend-agnostic-store-schemas.md) -- the store schema abstraction that search declarations extend",
-          "from": "20260401",
-          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
-        },
-        {
-          "context": "- [ADR-0031: Backend-Agnostic Store Schemas](../0031-backend-agnostic-store-schemas.md) — the store schemas that bundle resources bind to concrete backends",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
-        }
-      ],
-      "number": "0031",
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/0031-backend-agnostic-store-schemas.md",
-      "slug": "backend-agnostic-store-schemas",
-      "status": "accepted",
-      "superseded_by": null,
-      "title": "Backend-Agnostic Store Schemas",
-      "updated": "2026-04-10"
-    },
-    {
-      "created": "2026-04-09",
-      "depends_on": ["0", "1", "3", "16", "23", "30"],
-      "inbound": [
-        {
-          "context": "- **Pattern shapes at 1.0.** Toggle and CRUD are clear candidates. Transition, collection, and counter can follow. Which patterns ship initially is a separate design decision — see [ADR-0032: `deriveT",
-          "from": "0030",
-          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](0032-derivetrail-and-trail-factories.md) — trail factories that compose with store schemas (`crud`, `sync`, `reconcile`)",
-          "from": "0031",
-          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
-        },
-        {
-          "context": "- **Future `deriveTrail` detour synthesis.** [ADR-0032](0032-derivetrail-and-trail-factories.md) makes `deriveTrail` synthesize default blazes for standard CRUD operations. A natural extension is synt",
-          "from": "0033",
-          "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
-        },
-        {
-          "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](0032-derivetrail-and-trail-factories.md) — trail factories that compose against the accessor protocol",
-          "from": "0034",
-          "fromPath": "docs/adr/0034-store-accessor-contract-refinement-lessons-from-two-backends.md"
-        },
-        {
-          "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](../0032-derivetrail-and-trail-factories.md) -- `deriveTrail()` and `ingest()` factory that produces trails from external input shapes",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
-        },
-        {
-          "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](../0032-derivetrail-and-trail-factories.md) -- `ingest()` factory for webhook-to-trail flows that can feed events to WebSocket subscribers",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
-        }
-      ],
-      "number": "0032",
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/0032-derivetrail-and-trail-factories.md",
-      "slug": "derivetrail-and-trail-factories",
-      "status": "accepted",
-      "superseded_by": null,
-      "title": "deriveTrail() and Trail Factories",
-      "updated": "2026-04-10"
-    },
-    {
-      "created": "2026-04-11",
-      "depends_on": ["2", "6", "23", "32"],
-      "inbound": [],
-      "number": "0033",
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/0033-detour-execution-for-recovery.md",
-      "slug": "detour-execution-for-recovery",
-      "status": "accepted",
-      "superseded_by": null,
-      "title": "Detour Execution for Recovery",
-      "updated": "2026-04-13"
-    },
-    {
-      "created": "2026-04-12",
-      "depends_on": ["31"],
-      "inbound": [],
-      "number": "0034",
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/0034-store-accessor-contract-refinement-lessons-from-two-backends.md",
-      "slug": "store-accessor-contract-refinement-lessons-from-two-backends",
-      "status": "accepted",
-      "superseded_by": null,
-      "title": "Store Accessor Contract Refinement: Lessons from Two Backends",
-      "updated": "2026-04-13"
     }
   ],
   "version": 1

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -100,7 +100,7 @@
           "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
         },
         {
-          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) — the information architecture and \"one write, many reads\" principle that `deriveTrail()` operationalizes",
+          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) — the information architecture and \"one write, many reads\" principle that `deriveTrail()` operationalizes",
           "from": "0032",
           "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
@@ -219,7 +219,7 @@
           "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
         },
         {
-          "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md) — the verb+noun helper convention that `deriveTrail()` follows",
+          "context": "- [ADR-0001: Naming Conventions](0001-naming-conventions.md) — the verb+noun helper convention that `deriveTrail()` follows",
           "from": "0032",
           "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
@@ -352,7 +352,7 @@
           "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
         },
         {
-          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the trail primitive that factories produce",
+          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) — the trail primitive that factories produce",
           "from": "0032",
           "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
@@ -888,7 +888,7 @@
           "fromPath": "docs/adr/0013-tracing.md"
         },
         {
-          "context": "[^4]: [ADR-0012: Connector-Agnostic Permits](../0012-connector-agnostic-permits.md) — verification as permit resolution",
+          "context": "[^4]: [ADR-0012: Connector-Agnostic Permits](0012-connector-agnostic-permits.md) — verification as permit resolution",
           "from": "0032",
           "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
@@ -1124,7 +1124,7 @@
           "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
         },
         {
-          "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store schema that `deriveTrail()` reads from",
+          "context": "- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store schema that `deriveTrail()` reads from",
           "from": "0032",
           "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
@@ -1382,7 +1382,7 @@
           "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
         },
         {
-          "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the `pattern` field and `derive*` grammar rule",
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the `pattern` field and `derive*` grammar rule",
           "from": "0032",
           "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
@@ -1616,7 +1616,7 @@
           "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
         },
         {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](../0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model for connector-contributed `/trails` subpaths",
+          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model for connector-contributed `/trails` subpaths",
           "from": "0032",
           "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
@@ -1719,7 +1719,7 @@
           "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
         },
         {
-          "context": "- [ADR-0031: Backend-Agnostic Store Schemas](../0031-backend-agnostic-store-schemas.md) — the store schema that `deriveTrail()` reads from",
+          "context": "- [ADR-0031: Backend-Agnostic Store Schemas](0031-backend-agnostic-store-schemas.md) — the store schema that `deriveTrail()` reads from",
           "from": "0032",
           "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -1297,7 +1297,7 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Flags for Fields, Structured Input on the CLI",
-      "updated": "2026-04-10"
+      "updated": "2026-04-13"
     },
     {
       "created": "2026-04-03",
@@ -1660,6 +1660,11 @@
       "depends_on": ["0", "1", "3", "9", "16", "23"],
       "inbound": [
         {
+          "context": "- [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md) — contour-aware `deriveTrail()` that can carry `args` conventions",
+          "from": "0020",
+          "fromPath": "docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md"
+        },
+        {
           "context": "- [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md) — contour-aware `deriveTrail()` that may auto-generate `crossInput`",
           "from": "0024",
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
@@ -1747,6 +1752,11 @@
       "created": "2026-04-09",
       "depends_on": ["0", "1", "3", "16", "23", "30"],
       "inbound": [
+        {
+          "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](0032-derivetrail-and-trail-factories.md) — reusable patterns that absorb `args` and `fields` declarations",
+          "from": "0020",
+          "fromPath": "docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md"
+        },
         {
           "context": "- **Pattern shapes at 1.0.** Toggle and CRUD are clear candidates. Transition, collection, and counter can follow. Which patterns ship initially is a separate design decision — see [ADR-0032: `deriveT",
           "from": "0030",

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -80,14 +80,34 @@
           "fromPath": "docs/adr/0018-signal-driven-governance.md"
         },
         {
-          "context": "- [ADR-0000: Core Premise — The information architecture](../0000-core-premise.md) — the authored/projected/enforced categories that `crossInput` extends with composition scope",
+          "context": "- [ADR-0000: Core Premise — The information architecture](0000-core-premise.md) — the authored/projected/enforced categories that `crossInput` extends with composition scope",
           "from": "0024",
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
         },
         {
-          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"derive by default\"; tracing observes composition shape rather than requiring it to be declared",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) -- \"derive by default, override deliberately\"; the information architecture categories",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
+          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) -- \"derive by default\"; tracing observes composition shape rather than requiring it to be declared",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
+        },
+        {
+          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) — the information architecture categories (authored, projected, enforced) that contour leverages",
+          "from": "0030",
+          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) — the information architecture and \"one write, many reads\" principle that `deriveTrail()` operationalizes",
+          "from": "0032",
+          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
+        },
+        {
+          "context": "[ADR-0000's premise that the contract is queryable](0000-core-premise.md#the-contract-is-queryable) depends on declarations being load-bearing at runtime. When a field exists on the trail spec but doe",
+          "from": "0033",
+          "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
         },
         {
           "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"the trail is the product\"; `trails run` makes every trail directly invocable without trailhead ceremony",
@@ -120,11 +140,6 @@
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
         },
         {
-          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"derive by default, override deliberately\"; the information architecture categories",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
-        },
-        {
           "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"trailheads are peers\"; WebSocket is the fourth trailhead, following the same patterns as CLI, MCP, and HTTP",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
@@ -143,16 +158,6 @@
           "context": "- [ADR-0000: Core premise](../0000-core-premise.md) — \"author what's new, derive what's known\" applies to documentation: author the source tree, derive the site",
           "from": "20260406",
           "fromPath": "docs/adr/drafts/20260406-documentation-structure.md"
-        },
-        {
-          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) — the information architecture categories (authored, projected, enforced) that contour leverages",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) — the information architecture and \"one write, many reads\" principle that `deriveTrail()` operationalizes",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- **[ADR-0000: Core Premise](./adr/0000-core-premise.md)** — Why contracts, why Result, why derive",
@@ -204,9 +209,19 @@
           "fromPath": "docs/adr/0021-draft-state-stays-out-of-the-resolved-graph.md"
         },
         {
-          "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md) — the grammar rules this ADR extends. Singular/plural/verb conventions carry over verbatim; this ADR adds the brand-vs-plain heuristic a",
+          "context": "- [ADR-0001: Naming Conventions](0001-naming-conventions.md) — the grammar rules this ADR extends. Singular/plural/verb conventions carry over verbatim; this ADR adds the brand-vs-plain heuristic and ",
           "from": "0023",
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
+        },
+        {
+          "context": "- [ADR-0001: Naming Conventions](0001-naming-conventions.md) — the vocabulary rules that `contour()` follows as a bare-noun primitive",
+          "from": "0030",
+          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md) — the verb+noun helper convention that `deriveTrail()` follows",
+          "from": "0032",
+          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md): `create*` factory convention, `derive*` prefix for framework derivations, `build*`/`to*` trailhead wiring pattern",
@@ -217,16 +232,6 @@
           "context": "- [ADR-0001: Naming conventions](../0001-naming-conventions.md) — naming principles that apply to documentation paths",
           "from": "20260406",
           "fromPath": "docs/adr/drafts/20260406-documentation-structure.md"
-        },
-        {
-          "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md) — the vocabulary rules that `contour()` follows as a bare-noun primitive",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md) — the verb+noun helper convention that `deriveTrail()` follows",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "Canonical public trailhead-facing reference. For naming conventions and decision history, see [ADR-0001](./adr/0001-naming-conventions.md).",
@@ -268,19 +273,24 @@
           "fromPath": "docs/adr/0009-first-class-resources.md"
         },
         {
-          "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) -- the Result model that handles partial failure in concurrent crossings",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "context": "- [ADR-0002: Built-In Result Type](0002-built-in-result-type.md) — established the original taxonomy and HTTP/CLI/JSON-RPC mappings",
+          "from": "0026",
+          "fromPath": "docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md"
+        },
+        {
+          "context": "- [ADR-0002: Built-In Result Type](0002-built-in-result-type.md) -- the Result model that handles partial failure in concurrent crossings",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
+        },
+        {
+          "context": "- [ADR-0002: Built-In Result Type](0002-built-in-result-type.md) — detours match on `Result.err(TrailsError)` values, preserving the throw-free pipeline invariant.",
+          "from": "0033",
+          "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
         },
         {
           "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) — the error taxonomy maps to categorized failure events",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
-        },
-        {
-          "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) — established the 13-class taxonomy and HTTP/CLI/JSON-RPC mappings",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-error-taxonomy-as-transport-independent-behavior-contract.md"
         },
         {
           "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) — the Result and error taxonomy that gains `VersionNotSupportedError`",
@@ -317,19 +327,34 @@
           "fromPath": "docs/adr/0009-first-class-resources.md"
         },
         {
-          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the unified trail/hike primitive with `crosses` and `ctx.cross()`",
+          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) — the unified trail/hike primitive with `crosses` and `ctx.cross()`",
           "from": "0024",
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
         },
         {
-          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the `crosses` / `ctx.cross()` composition mechanism that composite testing targets",
+          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) — the `crosses` / `ctx.cross()` composition mechanism that composite testing targets",
           "from": "0025",
           "fromPath": "docs/adr/0025-composition-testing.md"
         },
         {
-          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- \"composition is a property, not a type\"; parallel vs sequential is a runtime choice, not a contract distinction. The crossi",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) -- the trail spec that gains the `visibility` field",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
+          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) -- \"composition is a property, not a type\"; parallel vs sequential is a runtime choice, not a contract distinction. The crossing ",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
+        },
+        {
+          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) — the merge test applied to contour vs. trail (conclusion: they're different enough to stay separate)",
+          "from": "0030",
+          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the trail primitive that factories produce",
+          "from": "0032",
+          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- every trail is runnable, whether atomic or composite",
@@ -355,21 +380,6 @@
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — `fires` is a new property on the trail spec",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
-        },
-        {
-          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- the trail spec that gains the `visibility` field",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
-        },
-        {
-          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the merge test applied to contour vs. trail (conclusion: they're different enough to stay separate)",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the trail primitive that factories produce",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the trail as the single unit of work, the unit that versioning targets",
@@ -411,6 +421,11 @@
           "fromPath": "docs/adr/0013-tracing.md"
         },
         {
+          "context": "- [ADR-0004: Intent as a First-Class Property](0004-intent-as-first-class-property.md) -- intent drives HTTP verbs, MCP annotations, and now trailhead filtering",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
           "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- rigged trails declare intent; HTTP method mapping and MCP annotations work identically",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
@@ -419,11 +434,6 @@
           "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) — intent compounds with activation; lifecycle signals filter by intent",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
-        },
-        {
-          "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- intent drives HTTP verbs, MCP annotations, and now trailhead filtering",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- intent compounds with layers for surface derivation and governance",
@@ -509,14 +519,24 @@
           "fromPath": "docs/adr/0013-tracing.md"
         },
         {
-          "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) — the pipeline that absorbs intrinsic tracing when `tracingLayer` collapses.",
+          "context": "- [ADR-0006: Shared Execution Pipeline](0006-shared-execution-pipeline.md) — the pipeline that absorbs intrinsic tracing when `tracingLayer` collapses.",
           "from": "0023",
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
         },
         {
-          "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "context": "- [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](0006-shared-execution-pipeline.md) — the execution pipeline that produces Results with typed errors",
+          "from": "0026",
+          "fromPath": "docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md"
+        },
+        {
+          "context": "- [ADR-0006: Shared Execution Pipeline](0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
+        },
+        {
+          "context": "What hasn't existed is **runtime execution**. No component of [`executeTrail`](0006-shared-execution-pipeline.md) reads the `detours:` field today. A trail can declare a detour for `ConflictError`, bu",
+          "from": "0033",
+          "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
         },
         {
           "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- `trails run` executes through the pipeline, the same as every trailhead",
@@ -542,11 +562,6 @@
           "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md): `executeTrail` as the single implementation of validate-context-layers-run; the library trailhead delegates to the same p",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
-        },
-        {
-          "context": "- [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md) — the execution pipeline that produces Results with typed errors",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-error-taxonomy-as-transport-independent-behavior-contract.md"
         },
         {
           "context": "- [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md) -- the execution pipeline that layers currently compose into",
@@ -593,12 +608,12 @@
           "fromPath": "docs/adr/0017-serialized-topo-graph.md"
         },
         {
-          "context": "- [ADR-0007: Governance as Trails](../0007-governance-as-trails.md) — the warden's `cross-declarations` rule that this extends",
+          "context": "- [ADR-0007: Governance as Trails](0007-governance-as-trails.md) — the warden's `cross-declarations` rule that this extends",
           "from": "0024",
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
         },
         {
-          "context": "- [ADR-0007: Governance as Trails](../0007-governance-as-trails.md) — the warden rules that `composite-example-coverage` and `scenario-coverage` extend",
+          "context": "- [ADR-0007: Governance as Trails](0007-governance-as-trails.md) — the warden rules that `composite-example-coverage` and `scenario-coverage` extend",
           "from": "0025",
           "fromPath": "docs/adr/0025-composition-testing.md"
         },
@@ -667,6 +682,11 @@
           "fromPath": "docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md"
         },
         {
+          "context": "- [ADR-0008: Deterministic Trailhead Derivation](0008-deterministic-trailhead-derivation.md) -- the derivation rules that visibility and intent filtering extend",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
           "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- rigged trails get trailhead derivation for free",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
@@ -675,11 +695,6 @@
           "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- survey output provides the contract snapshots",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
-        },
-        {
-          "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- the derivation rules that visibility and intent filtering extend",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- trail IDs map to WebSocket method names, event IDs map to subscription channels",
@@ -746,14 +761,29 @@
           "fromPath": "docs/adr/0016-schema-derived-persistence.md"
         },
         {
-          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the resource lifecycle a bound store participates in",
+          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the resource lifecycle a bound store participates in",
           "from": "0022",
           "fromPath": "docs/adr/0022-drizzle-store-connector.md"
         },
         {
-          "context": "- [ADR-0009: Resources as a First-Class Primitive](../0009-first-class-resources.md) — to be revisited. `provision` → `resource`. API shape unchanged.",
+          "context": "- [ADR-0009: Resources as a First-Class Primitive](0009-first-class-resources.md) — to be revisited. `provision` → `resource`. API shape unchanged.",
           "from": "0023",
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
+        },
+        {
+          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the `resource()` primitive that connectors produce and trails consume",
+          "from": "0029",
+          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the resource primitive that contours relate to through the store binding",
+          "from": "0030",
+          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the resource primitive that connectors produce and stores bind through",
+          "from": "0031",
+          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
         },
         {
           "context": "- [ADR-0009: Resources](../0009-first-class-resources.md) -- the resource primitive that packs scope and compose",
@@ -769,21 +799,6 @@
           "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) -- the resource pattern for embedding providers",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
-        },
-        {
-          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the resource primitive that connectors produce and stores bind through",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
-        },
-        {
-          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the `resource()` primitive that connectors produce and trails consume",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the resource primitive that contours relate to through the store binding",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
         },
         {
           "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the resource primitive that bundles group and distribute",
@@ -844,7 +859,7 @@
       "depends_on": [],
       "inbound": [
         {
-          "context": "- [ADR-0011: Schema-Driven Config](../0011-schema-driven-config.md) — to be revisited. `loadout` → `profile`. Config resolution unchanged.",
+          "context": "- [ADR-0011: Schema-Driven Config](0011-schema-driven-config.md) — to be revisited. `loadout` → `profile`. Config resolution unchanged.",
           "from": "0023",
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
         },
@@ -874,8 +889,8 @@
         },
         {
           "context": "[^4]: [ADR-0012: Connector-Agnostic Permits](../0012-connector-agnostic-permits.md) — verification as permit resolution",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
+          "from": "0032",
+          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0012: Connector-Agnostic Permits](../0012-connector-agnostic-permits.md) -- permit declarations that become pipeline-enforced",
@@ -922,14 +937,19 @@
           "fromPath": "docs/adr/0015-topo-store.md"
         },
         {
-          "context": "| `tracingLayer` | Built-in tracing in `executeTrail` | No longer a separately attached gate/layer. Intrinsic to the execution pipeline. Partially supersedes [ADR-0013](../0013-tracing.md)'s \"layer pl",
+          "context": "| `tracingLayer` | Built-in tracing in `executeTrail` | No longer a separately attached gate/layer. Intrinsic to the execution pipeline. Partially supersedes [ADR-0013](0013-tracing.md)'s \"layer plus ",
           "from": "0023",
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
         },
         {
-          "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "context": "- [ADR-0013: Tracing](0013-tracing.md) -- the observability system; visibility filtering events are observable through tracing",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
+          "context": "- [ADR-0013: Tracing](0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- the tracing primitive; live tracing during `trails run`, historical tracing via `trails trace`",
@@ -960,11 +980,6 @@
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) — tracing records emission and delivery metadata",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
-        },
-        {
-          "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- the observability system; visibility filtering events are observable through tracing",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- observability and replay buffer backing store",
@@ -1021,9 +1036,9 @@
           "fromPath": "docs/adr/0018-signal-driven-governance.md"
         },
         {
-          "context": "- [ADR-0014: Core Database Primitive](../0014-core-database-primitive.md) — the database primitive that store builds on",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
+          "context": "- [ADR-0014: Core Database Primitive](0014-core-database-primitive.md) — the database primitive that store builds on",
+          "from": "0031",
+          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
         },
         {
           "context": "- **[ADR-0014: Core Database Primitive](./adr/0014-core-database-primitive.md)** — Shared `trails.db`, subsystem schema versioning",
@@ -1089,34 +1104,34 @@
           "fromPath": "docs/adr/0018-signal-driven-governance.md"
         },
         {
-          "context": "[ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) defines the store model: the root package owns the durable `store(...)` declaration, and connectors bind that declaration ",
+          "context": "[ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) defines the store model: the root package owns the durable `store(...)` declaration, and connectors bind that declaration to ",
           "from": "0022",
           "fromPath": "docs/adr/0022-drizzle-store-connector.md"
+        },
+        {
+          "context": "- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store contract that connectors bind to concrete backends",
+          "from": "0029",
+          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store contract that can derive from contours instead of standalone schemas",
+          "from": "0030",
+          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "[ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) established `store()` as the persistence declaration and schema-to-table derivation as the mechanism. [ADR-0022: Drizzle Bind",
+          "from": "0031",
+          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
+        },
+        {
+          "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store schema that `deriveTrail()` reads from",
+          "from": "0032",
+          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) -- the store abstraction that search extends",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
-        },
-        {
-          "context": "[ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) established `store()` as the persistence declaration and schema-to-table derivation as the mechanism. [ADR-0022: Drizzle B",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
-        },
-        {
-          "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store contract that connectors bind to concrete backends",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store contract that can derive from contours instead of standalone schemas",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store schema that `deriveTrail()` reads from",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store contract that bundle resources satisfy",
@@ -1163,19 +1178,19 @@
           "fromPath": "docs/adr/0021-draft-state-stays-out-of-the-resolved-graph.md"
         },
         {
-          "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "context": "- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) -- the lockfile captures resolved visibility state after all overrides are applied",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
+          "context": "- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- rig state captured in the lockfile graph; rig lock state occupies a section in `trails.lock`",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
-        },
-        {
-          "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures resolved visibility state after all overrides are applied",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- captures WebSocket trailhead configuration in the resolved topo graph",
@@ -1313,14 +1328,14 @@
       "depends_on": ["16", "9"],
       "inbound": [
         {
-          "context": "[ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) established `store()` as the persistence declaration and schema-to-table derivation as the mechanism. [ADR-0022: Drizzle B",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
+          "context": "- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](0022-drizzle-store-connector.md) — the first connector implementation, currently a subpath of `@ontrails/store`",
+          "from": "0029",
+          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
         },
         {
-          "context": "- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md) — the first connector implementation, currently a subpath of `@ontrails/store`",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
+          "context": "[ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) established `store()` as the persistence declaration and schema-to-table derivation as the mechanism. [ADR-0022: Drizzle Bind",
+          "from": "0031",
+          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
         },
         {
           "context": "- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md) — the first connector, now understood as a single-resource bundle",
@@ -1357,6 +1372,26 @@
           "fromPath": "docs/adr/0013-tracing.md"
         },
         {
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the naming heuristic that `with-*` follows",
+          "from": "0029",
+          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the naming heuristic and `pattern` as the trail's declared operational shape",
+          "from": "0030",
+          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the `pattern` field and `derive*` grammar rule",
+          "from": "0032",
+          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
+        },
+        {
+          "context": "Detours are already in the Trails lexicon as a trail-level field: *\"recovery paths when the trail is blocked or fails. The trail blazes forward; if blocked, it detours.\"* See [ADR-0023](0023-simplifyi",
+          "from": "0033",
+          "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
+        },
+        {
           "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) -- the lexicon renames; note that `resource` in this ADR refers to the distribution unit, distinct from `resourc",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
@@ -1375,21 +1410,6 @@
           "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the vocabulary→lexicon rename that this structure codifies",
           "from": "20260406",
           "fromPath": "docs/adr/drafts/20260406-documentation-structure.md"
-        },
-        {
-          "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the naming heuristic that `with-*` follows",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the naming heuristic and `pattern` as the trail's declared operational shape",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the `pattern` field and `derive*` grammar rule",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         },
         {
           "context": "- **[ADR-0023: Simplifying the Trails Lexicon](./adr/0023-simplifying-the-trails-lexicon.md)** — Brand-vs-plain heuristic, four pre-1.0 renames, vocabulary → lexicon",
@@ -1416,14 +1436,19 @@
       "depends_on": ["3", "7"],
       "inbound": [
         {
-          "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) — typed `ctx.cross()` and `crossInput` that scenarios exercise",
+          "context": "- [ADR-0024: Typed Trail Composition](0024-typed-trail-composition.md) — typed `ctx.cross()` and `crossInput` that scenarios exercise",
           "from": "0025",
           "fromPath": "docs/adr/0025-composition-testing.md"
         },
         {
-          "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "context": "- [ADR-0024: Typed Trail Composition](0024-typed-trail-composition.md) -- `crossInput` relates to internal visibility; a trail with required `crossInput` fields should declare `visibility: 'internal'`",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
+          "context": "- [ADR-0024: Typed Trail Composition](0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred he",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) — typed `ctx.cross()` complements signal-based activation; `on:` is for reactive decoupling, `crosses` is for direct compositi",
@@ -1434,11 +1459,6 @@
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) — typed `ctx.cross()` complements signal-based decoupling; signals are for loose coupling, crosses are for typed direct compos",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
-        },
-        {
-          "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- `crossInput` relates to internal visibility; a trail with required `crossInput` fields should declare `visibility: 'interna",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- `crossInput` follows the same \"compose schemas, project the union\" pattern as layer input schemas",
@@ -1468,15 +1488,330 @@
     {
       "created": "2026-04-09",
       "depends_on": ["3", "7", "24"],
-      "inbound": [],
+      "inbound": [
+        {
+          "context": "- [ADR-0025: Composition Testing](0025-composition-testing.md) -- `scenario()` and `expectedMatch` for testing concurrent composition flows",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
+        }
+      ],
       "number": "0025",
       "owners": ["[galligan](https://github.com/galligan)"],
       "path": "docs/adr/0025-composition-testing.md",
       "slug": "composition-testing",
       "status": "accepted",
       "superseded_by": null,
-      "title": "ADR: Composition Testing",
+      "title": "Composition Testing",
       "updated": "2026-04-09"
+    },
+    {
+      "created": "2026-04-09",
+      "depends_on": ["2", "6"],
+      "inbound": [
+        {
+          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
+        },
+        {
+          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
+        },
+        {
+          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) -- WebSocket close code mapping deferred there; the error ",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
+        }
+      ],
+      "number": "0026",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md",
+      "slug": "error-taxonomy-as-transport-independent-behavior-contract",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Error Taxonomy as Transport-Independent Behavior Contract",
+      "updated": "2026-04-13"
+    },
+    {
+      "created": "2026-03-31",
+      "depends_on": ["packs-namespace-boundaries"],
+      "inbound": [
+        {
+          "context": "[^3]: See [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md)",
+          "from": "0024",
+          "fromPath": "docs/adr/0024-typed-trail-composition.md"
+        },
+        {
+          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
+        },
+        {
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
+        },
+        {
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
+        },
+        {
+          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
+        }
+      ],
+      "number": "0027",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0027-visibility-and-filtering.md",
+      "slug": "visibility-and-filtering",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Trail Visibility and Trailhead Filtering",
+      "updated": "2026-04-10"
+    },
+    {
+      "created": "2026-03-31",
+      "depends_on": ["3"],
+      "inbound": [
+        {
+          "context": "- [ADR-0028: Concurrent Trail Crossing](../0028-concurrent-crossing.md) -- `--trace` renders concurrent crossings as parallel branches in the execution tree",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
+        }
+      ],
+      "number": "0028",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0028-concurrent-crossing.md",
+      "slug": "concurrent-crossing",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Concurrent Trail Crossing",
+      "updated": "2026-04-10"
+    },
+    {
+      "created": "2026-04-09",
+      "depends_on": ["9", "16", "22", "23"],
+      "inbound": [
+        {
+          "context": "The Hono connector lives in its own workspace package (originally shipped as the `@ontrails/http/hono` subpath; see [ADR-0029](./0029-connector-extraction-and-the-with-packaging-model.md)). Two functi",
+          "from": "0005",
+          "fromPath": "docs/adr/0005-framework-agnostic-http-route-model.md"
+        },
+        {
+          "context": "> Originally shipped as the `@ontrails/store/drizzle` subpath; [ADR-0029](./0029-connector-extraction-and-the-with-packaging-model.md) promoted connectors to their own workspace packages.",
+          "from": "0022",
+          "fromPath": "docs/adr/0022-drizzle-store-connector.md"
+        },
+        {
+          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) — the connector extraction that contour-derived stores will bind through",
+          "from": "0030",
+          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model connectors live in",
+          "from": "0031",
+          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
+        },
+        {
+          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](../0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model for connector-contributed `/trails` subpaths",
+          "from": "0032",
+          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
+        },
+        {
+          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](../0029-connector-extraction-and-the-with-packaging-model.md) -- the packaging model for connector-contributed capabilities that rig",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
+        },
+        {
+          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) -- connectors move to `@ontrails/with-*` packages; affects how connector ",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
+        },
+        {
+          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](../0029-connector-extraction-and-the-with-packaging-model.md) -- connectors are extracted from core packages; packs compose with con",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
+        },
+        {
+          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) -- connectors as `@ontrails/with-*` packages; compiled packs may depend o",
+          "from": "20260401",
+          "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
+        },
+        {
+          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model for connector bundles",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
+        }
+      ],
+      "number": "0029",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md",
+      "slug": "connector-extraction-and-the-with-packaging-model",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Connector Extraction and the with-* Packaging Model",
+      "updated": "2026-04-13"
+    },
+    {
+      "created": "2026-04-09",
+      "depends_on": ["0", "1", "3", "9", "16", "23"],
+      "inbound": [
+        {
+          "context": "- [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md) — contour-aware `deriveTrail()` that may auto-generate `crossInput`",
+          "from": "0024",
+          "fromPath": "docs/adr/0024-typed-trail-composition.md"
+        },
+        {
+          "context": "- **How trails subpaths work on connectors.** Connectors that contribute trails (health checks, platform-optimized operations) may export them at `@ontrails/with-*/trails`. The design depends on [ADR-",
+          "from": "0029",
+          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- **Contour integration.** How `deriveTrail()` interacts with contour declarations — deriving input schemas from contours rather than store schemas — depends on [ADR-0030: Contours as First-Class Doma",
+          "from": "0032",
+          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
+        },
+        {
+          "context": "- [ADR-0030: Contours as First-Class Domain Objects](../0030-contours-as-first-class-domain-objects.md) -- contours define the domain objects that pack trails operate on",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
+        },
+        {
+          "context": "- [ADR-0030: Contours as First-Class Domain Objects](../0030-contours-as-first-class-domain-objects.md) -- contours as the domain objects pack trails operate on; schema reuse feeds the compiled librar",
+          "from": "20260401",
+          "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
+        },
+        {
+          "context": "- [ADR-0030: Contours as First-Class Domain Objects](../0030-contours-as-first-class-domain-objects.md) -- contours provide the domain object schemas that search declarations annotate",
+          "from": "20260401",
+          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
+        },
+        {
+          "context": "- [ADR-0030: Contours as First-Class Domain Objects](../0030-contours-as-first-class-domain-objects.md) — contours feed store schemas within bundles",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
+        }
+      ],
+      "number": "0030",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0030-contours-as-first-class-domain-objects.md",
+      "slug": "contours-as-first-class-domain-objects",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Contours as First-Class Domain Objects",
+      "updated": "2026-04-10"
+    },
+    {
+      "created": "2026-04-09",
+      "depends_on": ["9", "14", "16", "22", "29"],
+      "inbound": [
+        {
+          "context": "- [ADR-0031: Backend-Agnostic Store Schemas](0031-backend-agnostic-store-schemas.md) — the store-kind model that makes first-party backends meaningful",
+          "from": "0029",
+          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- [ADR-0031: Backend-Agnostic Store Schemas](../0031-backend-agnostic-store-schemas.md) — the store schema that `deriveTrail()` reads from",
+          "from": "0032",
+          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
+        },
+        {
+          "context": "[ADR-0031: Backend-Agnostic Store Schemas](0031-backend-agnostic-store-schemas.md) established the store as a backend-agnostic persistence domain. It defined the kind taxonomy (tabular, document, file",
+          "from": "0034",
+          "fromPath": "docs/adr/0034-store-accessor-contract-refinement-lessons-from-two-backends.md"
+        },
+        {
+          "context": "- [ADR-0031: Backend-Agnostic Store Schemas](../0031-backend-agnostic-store-schemas.md) -- the store schema abstraction that search declarations extend",
+          "from": "20260401",
+          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
+        },
+        {
+          "context": "- [ADR-0031: Backend-Agnostic Store Schemas](../0031-backend-agnostic-store-schemas.md) — the store schemas that bundle resources bind to concrete backends",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
+        }
+      ],
+      "number": "0031",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0031-backend-agnostic-store-schemas.md",
+      "slug": "backend-agnostic-store-schemas",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Backend-Agnostic Store Schemas",
+      "updated": "2026-04-10"
+    },
+    {
+      "created": "2026-04-09",
+      "depends_on": ["0", "1", "3", "16", "23", "30"],
+      "inbound": [
+        {
+          "context": "- **Pattern shapes at 1.0.** Toggle and CRUD are clear candidates. Transition, collection, and counter can follow. Which patterns ship initially is a separate design decision — see [ADR-0032: `deriveT",
+          "from": "0030",
+          "fromPath": "docs/adr/0030-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](0032-derivetrail-and-trail-factories.md) — trail factories that compose with store schemas (`crud`, `sync`, `reconcile`)",
+          "from": "0031",
+          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
+        },
+        {
+          "context": "- **Future `deriveTrail` detour synthesis.** [ADR-0032](0032-derivetrail-and-trail-factories.md) makes `deriveTrail` synthesize default blazes for standard CRUD operations. A natural extension is synt",
+          "from": "0033",
+          "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
+        },
+        {
+          "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](0032-derivetrail-and-trail-factories.md) — trail factories that compose against the accessor protocol",
+          "from": "0034",
+          "fromPath": "docs/adr/0034-store-accessor-contract-refinement-lessons-from-two-backends.md"
+        },
+        {
+          "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](../0032-derivetrail-and-trail-factories.md) -- `deriveTrail()` and `ingest()` factory that produces trails from external input shapes",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
+        },
+        {
+          "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](../0032-derivetrail-and-trail-factories.md) -- `ingest()` factory for webhook-to-trail flows that can feed events to WebSocket subscribers",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
+        }
+      ],
+      "number": "0032",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0032-derivetrail-and-trail-factories.md",
+      "slug": "derivetrail-and-trail-factories",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "deriveTrail() and Trail Factories",
+      "updated": "2026-04-10"
+    },
+    {
+      "created": "2026-04-11",
+      "depends_on": ["2", "6", "23", "32"],
+      "inbound": [],
+      "number": "0033",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0033-detour-execution-for-recovery.md",
+      "slug": "detour-execution-for-recovery",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Detour Execution for Recovery",
+      "updated": "2026-04-13"
+    },
+    {
+      "created": "2026-04-12",
+      "depends_on": ["31"],
+      "inbound": [],
+      "number": "0034",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0034-store-accessor-contract-refinement-lessons-from-two-backends.md",
+      "slug": "store-accessor-contract-refinement-lessons-from-two-backends",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Store Accessor Contract Refinement: Lessons from Two Backends",
+      "updated": "2026-04-13"
     }
   ],
   "version": 1

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -211,7 +211,7 @@
           "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
         },
         {
-          "context": "- **Connector-contributed factories.** Whether connectors export optimized trail factories (e.g., D1 batch CRUD) via their `/trails` subpath depends on [ADR: Resource Bundles](20260409-resource-bundle",
+          "context": "- **Connector-contributed factories.** Whether connectors export optimized trail factories (e.g., D1 batch CRUD) via their `/trails` subpath depends on [ADR: Resource Bundles](drafts/20260409-resource",
           "from": "0032",
           "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -2,25 +2,6 @@
   "entries": [
     {
       "created": "2026-03-31",
-      "depends_on": ["3"],
-      "inbound": [
-        {
-          "context": "- [ADR: Concurrent Trail Crossing](20260331-concurrent-crossing.md) (draft) -- `--trace` renders concurrent crossings as parallel branches in the execution tree",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
-        }
-      ],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260331-concurrent-crossing.md",
-      "slug": "concurrent-crossing",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Concurrent Trail Crossing",
-      "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-03-31",
       "depends_on": ["17"],
       "inbound": [],
       "number": null,
@@ -111,45 +92,6 @@
     },
     {
       "created": "2026-03-31",
-      "depends_on": ["packs-namespace-boundaries"],
-      "inbound": [
-        {
-          "context": "[^3]: See [Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft)",
-          "from": "0024",
-          "fromPath": "docs/adr/0024-typed-trail-composition.md"
-        },
-        {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
-        },
-        {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
-        },
-        {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
-        },
-        {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
-        }
-      ],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260331-visibility-and-filtering.md",
-      "slug": "visibility-and-filtering",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Trail Visibility and Trailhead Filtering",
-      "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-03-31",
       "depends_on": ["typed-signal-emission"],
       "inbound": [],
       "number": null,
@@ -221,234 +163,6 @@
     },
     {
       "created": "2026-04-09",
-      "depends_on": [
-        "9",
-        "14",
-        "16",
-        "22",
-        "connector-extraction-and-the-with-packaging-model"
-      ],
-      "inbound": [
-        {
-          "context": "- [ADR: Backend-Agnostic Store Schemas](20260409-backend-agnostic-store-schemas.md) (draft) -- the store schema abstraction that search declarations extend",
-          "from": "20260401",
-          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
-        },
-        {
-          "context": "- [ADR: Backend-Agnostic Store Schemas](20260409-backend-agnostic-store-schemas.md) (draft) — the store schema that `deriveTrail()` reads from",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
-        },
-        {
-          "context": "- [ADR: Backend-Agnostic Store Schemas](20260409-backend-agnostic-store-schemas.md) (draft) — the store schemas that bundle resources bind to concrete backends",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
-        }
-      ],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md",
-      "slug": "backend-agnostic-store-schemas",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Backend-Agnostic Store Schemas",
-      "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-04-09",
-      "depends_on": ["9", "16", "22", "23"],
-      "inbound": [
-        {
-          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) -- the packaging model for connector-contributed capabilities that",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
-        },
-        {
-          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) -- connectors move to `@ontrails/with-*` packages; affects how con",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
-        },
-        {
-          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) -- connectors are extracted from core packages; packs compose with",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
-        },
-        {
-          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) -- connectors as `@ontrails/with-*` packages; compiled packs may d",
-          "from": "20260401",
-          "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
-        },
-        {
-          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) — the packaging model connectors live in",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
-        },
-        {
-          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) — the connector extraction that contour-derived stores will bind t",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) — the packaging model for connector-contributed `/trails` subpaths",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
-        },
-        {
-          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) — the packaging model for connector bundles",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
-        }
-      ],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md",
-      "slug": "connector-extraction-and-the-with-packaging-model",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Connector Extraction and the with-* Packaging Model",
-      "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-04-09",
-      "depends_on": ["0", "1", "3", "9", "16", "23"],
-      "inbound": [
-        {
-          "context": "- [ADR: Contours as First-Class Domain Objects](drafts/20260409-contours-as-first-class-domain-objects.md) (draft) — contour-aware `deriveTrail()` that can carry `args` conventions",
-          "from": "0020",
-          "fromPath": "docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md"
-        },
-        {
-          "context": "- [ADR: Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md) (draft) — contour-aware `deriveTrail()` that may auto-generate `crossInput`",
-          "from": "0024",
-          "fromPath": "docs/adr/0024-typed-trail-composition.md"
-        },
-        {
-          "context": "- [ADR: Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md) (draft) -- contours define the domain objects that pack trails operate on",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
-        },
-        {
-          "context": "- [ADR: Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md) (draft) -- contours as the domain objects pack trails operate on; schema reuse feeds the compiled li",
-          "from": "20260401",
-          "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
-        },
-        {
-          "context": "- [ADR: Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md) (draft) -- contours provide the domain object schemas that search declarations annotate",
-          "from": "20260401",
-          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
-        },
-        {
-          "context": "- **How trails subpaths work on connectors.** Connectors that contribute trails (health checks, platform-optimized operations) may export them at `@ontrails/with-*/trails`. The design depends on [ADR:",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- **Contour integration.** How `deriveTrail()` interacts with contour declarations — deriving input schemas from contours rather than store schemas — depends on [ADR: Contours as First-Class Domain Ob",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
-        },
-        {
-          "context": "- [ADR: Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md) (draft) — contours feed store schemas within bundles",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
-        }
-      ],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md",
-      "slug": "contours-as-first-class-domain-objects",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Contours as First-Class Domain Objects",
-      "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-04-09",
-      "depends_on": [
-        "0",
-        "1",
-        "3",
-        "16",
-        "23",
-        "contours-as-first-class-domain-objects"
-      ],
-      "inbound": [
-        {
-          "context": "- [ADR: `deriveTrail()` and Trail Factories](drafts/20260409-derivetrail-and-trail-factories.md) (draft) — reusable patterns that absorb `args` and `fields` declarations",
-          "from": "0020",
-          "fromPath": "docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md"
-        },
-        {
-          "context": "- [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) -- `deriveTrail()` and `ingest()` factory that produces trails from external input shapes",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
-        },
-        {
-          "context": "- [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) -- `ingest()` factory for webhook-to-trail flows that can feed events to WebSocket subscribers",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
-        },
-        {
-          "context": "When search is declared on a store entity and the developer uses `crud()` (see the [`deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) draft), a search trail is automati",
-          "from": "20260401",
-          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
-        },
-        {
-          "context": "- [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) — trail factories that compose with store schemas (`crud`, `sync`, `reconcile`)",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
-        },
-        {
-          "context": "- **Pattern shapes at 1.0.** Toggle and CRUD are clear candidates. Transition, collection, and counter can follow. Which patterns ship initially is a separate design decision — see [ADR: `deriveTrail(",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
-        },
-        {
-          "context": "- [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) — trail factories that produce trails carried by pack bundles",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
-        }
-      ],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md",
-      "slug": "derivetrail-and-trail-factories",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "deriveTrail() and Trail Factories",
-      "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-04-09",
-      "depends_on": ["2", "6"],
-      "inbound": [
-        {
-          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](20260409-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, disca",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
-        },
-        {
-          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](20260409-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, disca",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
-        },
-        {
-          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](20260409-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) -- WebSocket close code mapping deferred there; the er",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
-        }
-      ],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260409-error-taxonomy-as-transport-independent-behavior-contract.md",
-      "slug": "error-taxonomy-as-transport-independent-behavior-contract",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Error Taxonomy as Transport-Independent Behavior Contract",
-      "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-04-09",
       "depends_on": ["6", "12"],
       "inbound": [
         {
@@ -487,6 +201,21 @@
       ],
       "inbound": [
         {
+          "context": "- **Defining the connector lifecycle contract.** How a connector declares what it bridges, what lifecycle hooks it supports, and how it reports health — that's a separate decision. This ADR moves the ",
+          "from": "0029",
+          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- **Profile selects the loadout.** How a deployment profile chooses which connector backs which resource is a configuration concern. Deferred to [ADR: Resource Bundles](drafts/20260409-resource-bundle",
+          "from": "0031",
+          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
+        },
+        {
+          "context": "- **Connector-contributed factories.** Whether connectors export optimized trail factories (e.g., D1 batch CRUD) via their `/trails` subpath depends on [ADR: Resource Bundles](20260409-resource-bundle",
+          "from": "0032",
+          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
+        },
+        {
           "context": "- [ADR: Resource Bundles](20260409-resource-bundles.md) (draft) -- the bundling mechanism for connector and pack resources; addresses how packs distribute resource groups with overridable defaults",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
@@ -500,21 +229,6 @@
           "context": "- [ADR: Resource Bundles](20260409-resource-bundles.md) (draft) -- the bundling mechanism for resources; compiled packs project bundles into constructor parameters",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
-        },
-        {
-          "context": "- **Profile selects the loadout.** How a deployment profile chooses which connector backs which resource is a configuration concern. Deferred to [ADR: Resource Bundles](20260409-resource-bundles.md) (",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
-        },
-        {
-          "context": "- **Defining the connector lifecycle contract.** How a connector declares what it bridges, what lifecycle hooks it supports, and how it reports health — that's a separate decision. This ADR moves the ",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- **Connector-contributed factories.** Whether connectors export optimized trail factories (e.g., D1 batch CRUD) via their `/trails` subpath depends on [ADR: Resource Bundles](20260409-resource-bundle",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         }
       ],
       "number": null,

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -2,6 +2,25 @@
   "entries": [
     {
       "created": "2026-03-31",
+      "depends_on": ["3"],
+      "inbound": [
+        {
+          "context": "- [ADR: Concurrent Trail Crossing](20260331-concurrent-crossing.md) (draft) -- `--trace` renders concurrent crossings as parallel branches in the execution tree",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
+        }
+      ],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260331-concurrent-crossing.md",
+      "slug": "concurrent-crossing",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Concurrent Trail Crossing",
+      "updated": "2026-04-09"
+    },
+    {
+      "created": "2026-03-31",
       "depends_on": ["17"],
       "inbound": [],
       "number": null,
@@ -92,6 +111,45 @@
     },
     {
       "created": "2026-03-31",
+      "depends_on": ["packs-namespace-boundaries"],
+      "inbound": [
+        {
+          "context": "[^3]: See [Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft)",
+          "from": "0024",
+          "fromPath": "docs/adr/0024-typed-trail-composition.md"
+        },
+        {
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+        },
+        {
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
+        },
+        {
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
+        },
+        {
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
+        }
+      ],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260331-visibility-and-filtering.md",
+      "slug": "visibility-and-filtering",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Trail Visibility and Trailhead Filtering",
+      "updated": "2026-04-09"
+    },
+    {
+      "created": "2026-03-31",
       "depends_on": ["typed-signal-emission"],
       "inbound": [],
       "number": null,
@@ -163,6 +221,234 @@
     },
     {
       "created": "2026-04-09",
+      "depends_on": [
+        "9",
+        "14",
+        "16",
+        "22",
+        "connector-extraction-and-the-with-packaging-model"
+      ],
+      "inbound": [
+        {
+          "context": "- [ADR: Backend-Agnostic Store Schemas](20260409-backend-agnostic-store-schemas.md) (draft) -- the store schema abstraction that search declarations extend",
+          "from": "20260401",
+          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
+        },
+        {
+          "context": "- [ADR: Backend-Agnostic Store Schemas](20260409-backend-agnostic-store-schemas.md) (draft) — the store schema that `deriveTrail()` reads from",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
+        },
+        {
+          "context": "- [ADR: Backend-Agnostic Store Schemas](20260409-backend-agnostic-store-schemas.md) (draft) — the store schemas that bundle resources bind to concrete backends",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
+        }
+      ],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md",
+      "slug": "backend-agnostic-store-schemas",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Backend-Agnostic Store Schemas",
+      "updated": "2026-04-09"
+    },
+    {
+      "created": "2026-04-09",
+      "depends_on": ["9", "16", "22", "23"],
+      "inbound": [
+        {
+          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) -- the packaging model for connector-contributed capabilities that",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
+        },
+        {
+          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) -- connectors move to `@ontrails/with-*` packages; affects how con",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
+        },
+        {
+          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) -- connectors are extracted from core packages; packs compose with",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
+        },
+        {
+          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) -- connectors as `@ontrails/with-*` packages; compiled packs may d",
+          "from": "20260401",
+          "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
+        },
+        {
+          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) — the packaging model connectors live in",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
+        },
+        {
+          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) — the connector extraction that contour-derived stores will bind t",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) — the packaging model for connector-contributed `/trails` subpaths",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
+        },
+        {
+          "context": "- [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) — the packaging model for connector bundles",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
+        }
+      ],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md",
+      "slug": "connector-extraction-and-the-with-packaging-model",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Connector Extraction and the with-* Packaging Model",
+      "updated": "2026-04-09"
+    },
+    {
+      "created": "2026-04-09",
+      "depends_on": ["0", "1", "3", "9", "16", "23"],
+      "inbound": [
+        {
+          "context": "- [ADR: Contours as First-Class Domain Objects](drafts/20260409-contours-as-first-class-domain-objects.md) (draft) — contour-aware `deriveTrail()` that can carry `args` conventions",
+          "from": "0020",
+          "fromPath": "docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md"
+        },
+        {
+          "context": "- [ADR: Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md) (draft) — contour-aware `deriveTrail()` that may auto-generate `crossInput`",
+          "from": "0024",
+          "fromPath": "docs/adr/0024-typed-trail-composition.md"
+        },
+        {
+          "context": "- [ADR: Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md) (draft) -- contours define the domain objects that pack trails operate on",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
+        },
+        {
+          "context": "- [ADR: Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md) (draft) -- contours as the domain objects pack trails operate on; schema reuse feeds the compiled li",
+          "from": "20260401",
+          "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
+        },
+        {
+          "context": "- [ADR: Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md) (draft) -- contours provide the domain object schemas that search declarations annotate",
+          "from": "20260401",
+          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
+        },
+        {
+          "context": "- **How trails subpaths work on connectors.** Connectors that contribute trails (health checks, platform-optimized operations) may export them at `@ontrails/with-*/trails`. The design depends on [ADR:",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- **Contour integration.** How `deriveTrail()` interacts with contour declarations — deriving input schemas from contours rather than store schemas — depends on [ADR: Contours as First-Class Domain Ob",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
+        },
+        {
+          "context": "- [ADR: Contours as First-Class Domain Objects](20260409-contours-as-first-class-domain-objects.md) (draft) — contours feed store schemas within bundles",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
+        }
+      ],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md",
+      "slug": "contours-as-first-class-domain-objects",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Contours as First-Class Domain Objects",
+      "updated": "2026-04-09"
+    },
+    {
+      "created": "2026-04-09",
+      "depends_on": [
+        "0",
+        "1",
+        "3",
+        "16",
+        "23",
+        "contours-as-first-class-domain-objects"
+      ],
+      "inbound": [
+        {
+          "context": "- [ADR: `deriveTrail()` and Trail Factories](drafts/20260409-derivetrail-and-trail-factories.md) (draft) — reusable patterns that absorb `args` and `fields` declarations",
+          "from": "0020",
+          "fromPath": "docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md"
+        },
+        {
+          "context": "- [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) -- `deriveTrail()` and `ingest()` factory that produces trails from external input shapes",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
+        },
+        {
+          "context": "- [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) -- `ingest()` factory for webhook-to-trail flows that can feed events to WebSocket subscribers",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
+        },
+        {
+          "context": "When search is declared on a store entity and the developer uses `crud()` (see the [`deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) draft), a search trail is automati",
+          "from": "20260401",
+          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
+        },
+        {
+          "context": "- [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) — trail factories that compose with store schemas (`crud`, `sync`, `reconcile`)",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
+        },
+        {
+          "context": "- **Pattern shapes at 1.0.** Toggle and CRUD are clear candidates. Transition, collection, and counter can follow. Which patterns ship initially is a separate design decision — see [ADR: `deriveTrail(",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-contours-as-first-class-domain-objects.md"
+        },
+        {
+          "context": "- [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) — trail factories that produce trails carried by pack bundles",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
+        }
+      ],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md",
+      "slug": "derivetrail-and-trail-factories",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "deriveTrail() and Trail Factories",
+      "updated": "2026-04-09"
+    },
+    {
+      "created": "2026-04-09",
+      "depends_on": ["2", "6"],
+      "inbound": [
+        {
+          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](20260409-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, disca",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
+        },
+        {
+          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](20260409-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, disca",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
+        },
+        {
+          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](20260409-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) -- WebSocket close code mapping deferred there; the er",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
+        }
+      ],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260409-error-taxonomy-as-transport-independent-behavior-contract.md",
+      "slug": "error-taxonomy-as-transport-independent-behavior-contract",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Error Taxonomy as Transport-Independent Behavior Contract",
+      "updated": "2026-04-09"
+    },
+    {
+      "created": "2026-04-09",
       "depends_on": ["6", "12"],
       "inbound": [
         {
@@ -201,21 +487,6 @@
       ],
       "inbound": [
         {
-          "context": "- **Defining the connector lifecycle contract.** How a connector declares what it bridges, what lifecycle hooks it supports, and how it reports health — that's a separate decision. This ADR moves the ",
-          "from": "0029",
-          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
-        },
-        {
-          "context": "- **Profile selects the loadout.** How a deployment profile chooses which connector backs which resource is a configuration concern. Deferred to [ADR: Resource Bundles](drafts/20260409-resource-bundle",
-          "from": "0031",
-          "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
-        },
-        {
-          "context": "- **Connector-contributed factories.** Whether connectors export optimized trail factories (e.g., D1 batch CRUD) via their `/trails` subpath depends on [ADR: Resource Bundles](drafts/20260409-resource",
-          "from": "0032",
-          "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
-        },
-        {
           "context": "- [ADR: Resource Bundles](20260409-resource-bundles.md) (draft) -- the bundling mechanism for connector and pack resources; addresses how packs distribute resource groups with overridable defaults",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
@@ -229,6 +500,21 @@
           "context": "- [ADR: Resource Bundles](20260409-resource-bundles.md) (draft) -- the bundling mechanism for resources; compiled packs project bundles into constructor parameters",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
+        },
+        {
+          "context": "- **Profile selects the loadout.** How a deployment profile chooses which connector backs which resource is a configuration concern. Deferred to [ADR: Resource Bundles](20260409-resource-bundles.md) (",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-backend-agnostic-store-schemas.md"
+        },
+        {
+          "context": "- **Defining the connector lifecycle contract.** How a connector declares what it bridges, what lifecycle hooks it supports, and how it reports health — that's a separate decision. This ADR moves the ",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
+          "context": "- **Connector-contributed factories.** Whether connectors export optimized trail factories (e.g., D1 batch CRUD) via their `/trails` subpath depends on [ADR: Resource Bundles](20260409-resource-bundle",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-derivetrail-and-trail-factories.md"
         }
       ],
       "number": null,


### PR DESCRIPTION
## Summary

Rewrites ADR-0020 ("Flags for Fields, Structured Input on the CLI") to cover the full CLI input presentation model:

- **`args` on TrailSpec** — formatter-proof positional arg ordering (`args: ['src', 'dest']`), auto-promotion heuristic, `args: false` suppression
- **Progressive disclosure** — just `input` → add `args` → add `fields` → use `deriveTrail`
- **Merge semantics** — structured input → positional args (defined only) → flags, validate once
- **Layered model** — framework defaults, CLI globals, app conventions, trail declarations (globals and conventions deferred to separate ADRs)

References have been updated to point at the now-accepted [ADR-0030 (Contours)](docs/adr/0030-contours-as-first-class-domain-objects.md) and [ADR-0032 (deriveTrail and Trail Factories)](docs/adr/0032-derivetrail-and-trail-factories.md), which both landed while this branch was in review.

Also fixes missing `id` fields in ADR-0024 and ADR-0025 frontmatter, and fixes ADR-0025 title prefix.

## Test plan
- [x] `bun .claude/skills/trails-adrs/scripts/adr.ts check` — no errors on ADR-0020
- [x] Decision maps regenerated after rebase on main
- [x] Cross-references point at accepted ADRs (0030, 0032) instead of drafts
- [x] Docs only — no code changes

Closes https://linear.app/outfitter/issue/TRL-259