### PR TITLE
feat: migrate trailheads and add mapper completeness rule

### DIFF
--- a/packages/cli/src/__tests__/to-commander.test.ts
+++ b/packages/cli/src/__tests__/to-commander.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 
-import { Result, trail, topo } from '@ontrails/core';
+import { NotFoundError, Result, trail, topo } from '@ontrails/core';
 import { z } from 'zod';
 
 import { buildCliCommands } from '../build.js';
@@ -91,6 +91,50 @@ const buildExecutableParentProgram = (calls: string[]) => {
   const program = toCommander(commands, { name: 'test' });
   program.exitOverride();
   return program;
+};
+
+const makeCliExit = () =>
+  mock((code?: number) => {
+    throw new Error(`EXIT ${String(code)}`);
+  }) as unknown as typeof process.exit;
+
+const buildFailingProgram = () => {
+  const failTrail = trail('fail', {
+    blaze: () => Result.ok('ok'),
+    input: z.object({}),
+  });
+
+  return toCommander([
+    {
+      args: [],
+      execute: () => {
+        throw new NotFoundError('missing');
+      },
+      flags: [],
+      intent: 'read' as const,
+      path: ['fail'] as const,
+      trail: failTrail,
+    },
+  ]);
+};
+
+const withMockedProcess = async (
+  run: () => Promise<void> | void
+): Promise<void> => {
+  const originalExit = process.exit;
+  const originalWrite = process.stderr.write;
+
+  process.exit = makeCliExit();
+  process.stderr.write = mock(
+    () => true
+  ) as unknown as typeof process.stderr.write;
+
+  try {
+    await run();
+  } finally {
+    process.exit = originalExit;
+    process.stderr.write = originalWrite;
+  }
 };
 
 // ---------------------------------------------------------------------------
@@ -434,19 +478,13 @@ describe('toCommander option wiring', () => {
     expect(program.description()).toBe('A test app');
   });
 
-  test('error handling maps categories to exit codes', () => {
-    // This test verifies the error handling structure exists.
-    // Full integration would need process.exit mocking.
-    const t = trail('fail', {
-      blaze: () => Result.ok('ok'),
-      input: z.object({}),
+  test('error handling maps categories to exit codes', async () => {
+    await withMockedProcess(async () => {
+      const program = buildFailingProgram();
+      await expect(
+        program.parseAsync(['node', 'test', 'fail'], { from: 'node' })
+      ).rejects.toThrow('EXIT 2');
+      expect(process.stderr.write).toHaveBeenCalledWith('Error: missing\n');
     });
-    const app = makeApp(t);
-    const commands = buildCliCommands(app);
-    const program = toCommander(commands);
-
-    // Verify the program was created (error handling is wired in action)
-    expect(program).toBeDefined();
-    expect(program.commands).toHaveLength(1);
   });
 });

--- a/packages/cli/src/commander/to-commander.ts
+++ b/packages/cli/src/commander/to-commander.ts
@@ -2,7 +2,7 @@
  * Adapt framework-agnostic CliCommand[] to a Commander program.
  */
 
-import { exitCodeMap, isTrailsError } from '@ontrails/core';
+import { isTrailsError, mapTransportError } from '@ontrails/core';
 import { Command, InvalidArgumentError, Option } from 'commander';
 
 import type { CliCommand, CliFlag } from '../command.js';
@@ -113,7 +113,7 @@ const handleError = (error: unknown): void => {
   if (error instanceof Error) {
     process.stderr.write(`Error: ${error.message}\n`);
     if (isTrailsError(error)) {
-      process.exit(exitCodeMap[error.category]);
+      process.exit(mapTransportError('cli', error));
     }
   } else {
     process.stderr.write(`Error: ${String(error)}\n`);

--- a/packages/http/src/hono/trailhead.ts
+++ b/packages/http/src/hono/trailhead.ts
@@ -10,7 +10,7 @@
  * ```
  */
 
-import { isTrailsError, statusCodeMap } from '@ontrails/core';
+import { isTrailsError, mapTransportError } from '@ontrails/core';
 import type {
   Layer,
   ResourceOverrideMap,
@@ -173,7 +173,7 @@ const mapErrorResponse = (
           message: error.message,
         },
       },
-      status: statusCodeMap[error.category] as ContentfulStatusCode,
+      status: mapTransportError('http', error) as ContentfulStatusCode,
     };
   }
   return {

--- a/packages/warden/src/__tests__/error-mapping-completeness.test.ts
+++ b/packages/warden/src/__tests__/error-mapping-completeness.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+
+import { errorMappingCompleteness } from '../rules/error-mapping-completeness.js';
+
+const TEST_FILE = 'transport-error-map.ts';
+
+describe('error-mapping-completeness', () => {
+  test('passes complete mapper registrations', () => {
+    const code = `
+import { createTransportErrorMapper } from '@ontrails/core';
+
+const cliMapper = createTransportErrorMapper({
+  auth: 9,
+  cancelled: 130,
+  conflict: 3,
+  internal: 8,
+  network: 7,
+  not_found: 2,
+  permission: 4,
+  rate_limit: 6,
+  timeout: 5,
+  validation: 1,
+});
+`;
+
+    const diagnostics = errorMappingCompleteness.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('catches incomplete mapper registrations resolved through object properties', () => {
+    const code = `
+import { createTransportErrorMapper } from '@ontrails/core';
+
+const transportErrorMap = {
+  cli: {
+    conflict: 3,
+    internal: 8,
+    not_found: 2,
+    validation: 1,
+  },
+};
+
+const cliMapper = createTransportErrorMapper(transportErrorMap.cli);
+`;
+
+    const diagnostics = errorMappingCompleteness.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('error-mapping-completeness');
+    expect(diagnostics[0]?.severity).toBe('error');
+    expect(diagnostics[0]?.message).toContain('auth');
+    expect(diagnostics[0]?.message).toContain('cancelled');
+    expect(diagnostics[0]?.line).toBeGreaterThan(0);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 15 rule trails', () => {
-    expect(wardenTopo.count).toBe(15);
+  test('contains all 16 rule trails', () => {
+    expect(wardenTopo.count).toBe(16);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -21,6 +21,7 @@ export { noThrowInImplementation } from './rules/no-throw-in-implementation.js';
 export { contextNoTrailheadTypes } from './rules/context-no-trailhead-types.js';
 export { draftFileMarking } from './rules/draft-file-marking.js';
 export { draftVisibleDebt } from './rules/draft-visible-debt.js';
+export { errorMappingCompleteness } from './rules/error-mapping-completeness.js';
 export { firesDeclarations } from './rules/fires-declarations.js';
 export { onReferencesExist } from './rules/on-references-exist.js';
 export { validDetourRefs } from './rules/valid-detour-refs.js';
@@ -78,6 +79,7 @@ export {
   contextNoTrailheadTypesTrail,
   crossDeclarationsTrail,
   diagnosticSchema,
+  errorMappingCompletenessTrail,
   firesDeclarationsTrail,
   implementationReturnsResultTrail,
   noDirectImplInRouteTrail,

--- a/packages/warden/src/rules/error-mapping-completeness.ts
+++ b/packages/warden/src/rules/error-mapping-completeness.ts
@@ -1,0 +1,273 @@
+/**
+ * Validates that registered transport error mappers cover every error category.
+ *
+ * Scans `createTransportErrorMapper(...)` calls and resolves simple object
+ * literals, identifier bindings, and object-property references in the same
+ * file so incomplete mapper registrations are caught before they ship.
+ */
+
+import { errorCategories } from '@ontrails/core';
+
+import {
+  getStringValue,
+  identifierName,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  walk,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const MEMBER_EXPRESSION_TYPES = new Set([
+  'MemberExpression',
+  'StaticMemberExpression',
+]);
+
+const getPropertyName = (node: AstNode | undefined): string | null => {
+  if (!node) {
+    return null;
+  }
+
+  return (
+    identifierName(node) ??
+    (isStringLiteral(node) ? getStringValue(node) : null)
+  );
+};
+
+const collectObjectBindings = (ast: AstNode): ReadonlyMap<string, AstNode> => {
+  const bindings = new Map<string, AstNode>();
+
+  walk(ast, (node) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+
+    const { id, init } = node as { id?: AstNode; init?: AstNode };
+    const bindingName = identifierName(id);
+
+    if (bindingName && init?.type === 'ObjectExpression') {
+      bindings.set(bindingName, init);
+    }
+  });
+
+  return bindings;
+};
+
+const getObjectProperties = (objectNode: AstNode): readonly AstNode[] =>
+  objectNode.type === 'ObjectExpression'
+    ? ((objectNode['properties'] as readonly AstNode[] | undefined) ?? [])
+    : [];
+
+const findObjectPropertyValue = (
+  objectNode: AstNode,
+  propertyName: string
+): AstNode | null => {
+  for (const property of getObjectProperties(objectNode)) {
+    if (property.type !== 'Property') {
+      continue;
+    }
+
+    const key = getPropertyName((property as unknown as { key?: AstNode }).key);
+    if (key === propertyName) {
+      return (property as unknown as { value?: AstNode }).value ?? null;
+    }
+  }
+
+  return null;
+};
+
+const resolveIdentifierObject = (
+  node: AstNode,
+  bindings: ReadonlyMap<string, AstNode>
+): AstNode | null =>
+  bindings.get((node as { name?: string }).name ?? '') ?? null;
+
+const resolveMemberObject = (
+  node: AstNode,
+  bindings: ReadonlyMap<string, AstNode>,
+  depth: number,
+  resolve: (
+    node: AstNode | undefined,
+    bindings: ReadonlyMap<string, AstNode>,
+    depth?: number
+  ) => AstNode | null
+): AstNode | null => {
+  const { object, property } = node as { object?: AstNode; property?: AstNode };
+  const propertyName = getPropertyName(property);
+  if (!propertyName) {
+    return null;
+  }
+
+  const objectNode = resolve(object, bindings, depth + 1);
+  return objectNode
+    ? resolve(
+        findObjectPropertyValue(objectNode, propertyName) ?? undefined,
+        bindings,
+        depth + 1
+      )
+    : null;
+};
+
+const resolveObjectExpression = function resolveObjectExpression(
+  node: AstNode | undefined,
+  bindings: ReadonlyMap<string, AstNode>,
+  depth = 0
+): AstNode | null {
+  if (!node || depth > 4) {
+    return null;
+  }
+
+  if (node.type === 'ObjectExpression') {
+    return node;
+  }
+
+  if (node.type === 'Identifier') {
+    return resolveIdentifierObject(node, bindings);
+  }
+
+  return MEMBER_EXPRESSION_TYPES.has(node.type)
+    ? resolveMemberObject(node, bindings, depth, resolveObjectExpression)
+    : null;
+};
+
+const addMappedCategory = (
+  categories: Set<string>,
+  property: AstNode
+): boolean => {
+  if (property.type === 'SpreadElement') {
+    return false;
+  }
+
+  if (property.type !== 'Property') {
+    return true;
+  }
+
+  const key = getPropertyName((property as unknown as { key?: AstNode }).key);
+  if (key) {
+    categories.add(key);
+  }
+
+  return true;
+};
+
+const collectMappedCategories = (
+  mapperObject: AstNode
+): ReadonlySet<string> | null => {
+  if (mapperObject.type !== 'ObjectExpression') {
+    return null;
+  }
+
+  const categories = new Set<string>();
+  for (const property of getObjectProperties(mapperObject)) {
+    if (!addMappedCategory(categories, property)) {
+      return null;
+    }
+  }
+
+  return categories;
+};
+
+const createDiagnostic = (
+  filePath: string,
+  line: number,
+  missingCategories: readonly string[]
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Transport error mapper is missing mappings for: ${missingCategories.join(', ')}. Registered createTransportErrorMapper() calls must cover every ErrorCategory.`,
+  rule: 'error-mapping-completeness',
+  severity: 'error',
+});
+
+const getCallArgs = (node: AstNode): readonly AstNode[] =>
+  (node as { arguments?: readonly AstNode[] }).arguments ?? [];
+
+const getCallCallee = (node: AstNode): AstNode | undefined =>
+  (node as { callee?: AstNode }).callee;
+
+const isMapperFactoryCall = (node: AstNode): boolean =>
+  node.type === 'CallExpression' &&
+  identifierName(getCallCallee(node)) === 'createTransportErrorMapper';
+
+const findMissingCategories = (
+  mappedCategories: ReadonlySet<string>
+): readonly string[] =>
+  errorCategories.filter((category) => !mappedCategories.has(category));
+
+const resolveMappedCategories = (
+  node: AstNode,
+  bindings: ReadonlyMap<string, AstNode>
+): ReadonlySet<string> | null => {
+  const [firstArg] = getCallArgs(node);
+  const mapperObject = resolveObjectExpression(firstArg, bindings);
+  return mapperObject ? collectMappedCategories(mapperObject) : null;
+};
+
+const inspectMapperCall = (
+  node: AstNode,
+  bindings: ReadonlyMap<string, AstNode>,
+  filePath: string,
+  sourceCode: string
+): WardenDiagnostic | null => {
+  if (!isMapperFactoryCall(node)) {
+    return null;
+  }
+
+  const mappedCategories = resolveMappedCategories(node, bindings);
+  if (!mappedCategories) {
+    return null;
+  }
+
+  const missingCategories = findMissingCategories(mappedCategories);
+  if (missingCategories.length === 0) {
+    return null;
+  }
+
+  return createDiagnostic(
+    filePath,
+    offsetToLine(sourceCode, node.start),
+    missingCategories
+  );
+};
+
+/**
+ * Flags `createTransportErrorMapper()` registrations that omit error categories.
+ */
+export const errorMappingCompleteness: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (
+      isTestFile(filePath) ||
+      !sourceCode.includes('createTransportErrorMapper')
+    ) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const bindings = collectObjectBindings(ast);
+    const diagnostics: WardenDiagnostic[] = [];
+
+    walk(ast, (node) => {
+      const diagnostic = inspectMapperCall(
+        node,
+        bindings,
+        filePath,
+        sourceCode
+      );
+      if (diagnostic) {
+        diagnostics.push(diagnostic);
+      }
+    });
+
+    return diagnostics;
+  },
+  description:
+    'Require registered transport error mappers to cover every ErrorCategory.',
+  name: 'error-mapping-completeness',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -2,6 +2,7 @@ import { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 import { crossDeclarations } from './cross-declarations.js';
 import { draftFileMarking } from './draft-file-marking.js';
 import { draftVisibleDebt } from './draft-visible-debt.js';
+import { errorMappingCompleteness } from './error-mapping-completeness.js';
 import { firesDeclarations } from './fires-declarations.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
 import { noDirectImplInRoute } from './no-direct-impl-in-route.js';
@@ -30,6 +31,7 @@ export { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 export { crossDeclarations } from './cross-declarations.js';
 export { draftFileMarking } from './draft-file-marking.js';
 export { draftVisibleDebt } from './draft-visible-debt.js';
+export { errorMappingCompleteness } from './error-mapping-completeness.js';
 export { firesDeclarations } from './fires-declarations.js';
 export { onReferencesExist } from './on-references-exist.js';
 export { validDetourRefs } from './valid-detour-refs.js';
@@ -53,6 +55,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [crossDeclarations.name, crossDeclarations],
   [draftFileMarking.name, draftFileMarking],
   [draftVisibleDebt.name, draftVisibleDebt],
+  [errorMappingCompleteness.name, errorMappingCompleteness],
   [firesDeclarations.name, firesDeclarations],
   [onReferencesExist.name, onReferencesExist],
   [resourceDeclarations.name, resourceDeclarations],

--- a/packages/warden/src/trails/error-mapping-completeness.trail.ts
+++ b/packages/warden/src/trails/error-mapping-completeness.trail.ts
@@ -1,0 +1,29 @@
+import { errorMappingCompleteness } from '../rules/error-mapping-completeness.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const errorMappingCompletenessTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'transport-error-map.ts',
+        sourceCode: `import { createTransportErrorMapper } from "@ontrails/core";
+
+const cliMapper = createTransportErrorMapper({
+  auth: 9,
+  cancelled: 130,
+  conflict: 3,
+  internal: 8,
+  network: 7,
+  not_found: 2,
+  permission: 4,
+  rate_limit: 6,
+  timeout: 5,
+  validation: 1,
+});`,
+      },
+      name: 'Complete transport error mapper',
+    },
+  ],
+  rule: errorMappingCompleteness,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -1,5 +1,6 @@
 export { contextNoTrailheadTypesTrail } from './context-no-trailhead-types.trail.js';
 export { crossDeclarationsTrail } from './cross-declarations.trail.js';
+export { errorMappingCompletenessTrail } from './error-mapping-completeness.trail.js';
 export { firesDeclarationsTrail } from './fires-declarations.trail.js';
 export { implementationReturnsResultTrail } from './implementation-returns-result.trail.js';
 export { onReferencesExistTrail } from './on-references-exist.trail.js';


### PR DESCRIPTION
## Summary
- route the CLI and HTTP trailheads through `mapTransportError(...)` instead of indexing transport maps directly
- add the `error-mapping-completeness` warden rule, wrapped trail export, and focused tests so incomplete `createTransportErrorMapper(...)` registrations get flagged
- keep MCP on its existing `isError: true` tool-result behavior in this slice; changing that to thrown `McpError` responses would alter runtime semantics, so that scope note is documented on `TRL-221`

## Testing
- `bun test packages/cli/src/__tests__/to-commander.test.ts packages/http/src/hono/__tests__/trailhead.test.ts packages/warden/src/__tests__/error-mapping-completeness.test.ts packages/warden/src/__tests__/trails.test.ts`
- `bun run lint`
- `bun run typecheck`

## Closes
- TRL-221
- TRL-222

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
