### PR TITLE
feat: add trail visibility and trailhead filtering

### DIFF
--- a/docs/adr/0024-typed-trail-composition.md
+++ b/docs/adr/0024-typed-trail-composition.md
@@ -212,4 +212,4 @@ The existing `cross-declarations` rule gains awareness of `crossInput`: if a `ct
 
 [^1]: [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — `crosses` and `ctx.cross()` as the composition mechanism
 [^2]: [ADR-0000: Core Premise — The information architecture](../0000-core-premise.md)
-[^3]: See [Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft)
+[^3]: See [Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft)

--- a/docs/adr/0024-typed-trail-composition.md
+++ b/docs/adr/0024-typed-trail-composition.md
@@ -212,4 +212,4 @@ The existing `cross-declarations` rule gains awareness of `crossInput`: if a `ct
 
 [^1]: [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — `crosses` and `ctx.cross()` as the composition mechanism
 [^2]: [ADR-0000: Core Premise — The information architecture](../0000-core-premise.md)
-[^3]: See [Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft)
+[^3]: See [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md)

--- a/docs/adr/0027-visibility-and-filtering.md
+++ b/docs/adr/0027-visibility-and-filtering.md
@@ -1,14 +1,15 @@
 ---
+id: 27
 slug: visibility-and-filtering
 title: Trail Visibility and Trailhead Filtering
-status: draft
+status: accepted
 created: 2026-03-31
-updated: 2026-04-09
+updated: 2026-04-10
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [packs-namespace-boundaries]
 ---
 
-# ADR: Trail Visibility and Trailhead Filtering
+# ADR-0027: Trail Visibility and Trailhead Filtering
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,3 +33,4 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0024](0024-typed-trail-composition.md) | Typed Trail Composition | Accepted |
 | [0025](0025-composition-testing.md) | Composition Testing | Accepted |
 | [0026](0026-error-taxonomy-as-transport-independent-behavior-contract.md) | Error Taxonomy as Transport-Independent Behavior Contract | Accepted |
+| [0027](0027-visibility-and-filtering.md) | Trail Visibility and Trailhead Filtering | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -85,6 +85,11 @@
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
         },
         {
+          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"derive by default, override deliberately\"; the information architecture categories",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
           "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"derive by default\"; tracing observes composition shape rather than requiring it to be declared",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
@@ -118,11 +123,6 @@
           "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) — \"derive by default\"; framework lifecycle events are derived from execution observation",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
-        },
-        {
-          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"derive by default, override deliberately\"; the information architecture categories",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"trailheads are peers\"; WebSocket is the fourth trailhead, following the same patterns as CLI, MCP, and HTTP",
@@ -327,6 +327,11 @@
           "fromPath": "docs/adr/0025-composition-testing.md"
         },
         {
+          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- the trail spec that gains the `visibility` field",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- \"composition is a property, not a type\"; parallel vs sequential is a runtime choice, not a contract distinction. The crossi",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
@@ -355,11 +360,6 @@
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — `fires` is a new property on the trail spec",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
-        },
-        {
-          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- the trail spec that gains the `visibility` field",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) — the merge test applied to contour vs. trail (conclusion: they're different enough to stay separate)",
@@ -411,6 +411,11 @@
           "fromPath": "docs/adr/0013-tracing.md"
         },
         {
+          "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- intent drives HTTP verbs, MCP annotations, and now trailhead filtering",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
           "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- rigged trails declare intent; HTTP method mapping and MCP annotations work identically",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
@@ -419,11 +424,6 @@
           "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) — intent compounds with activation; lifecycle signals filter by intent",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
-        },
-        {
-          "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- intent drives HTTP verbs, MCP annotations, and now trailhead filtering",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- intent compounds with layers for surface derivation and governance",
@@ -667,6 +667,11 @@
           "fromPath": "docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md"
         },
         {
+          "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- the derivation rules that visibility and intent filtering extend",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
           "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- rigged trails get trailhead derivation for free",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
@@ -675,11 +680,6 @@
           "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- survey output provides the contract snapshots",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
-        },
-        {
-          "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- the derivation rules that visibility and intent filtering extend",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- trail IDs map to WebSocket method names, event IDs map to subscription channels",
@@ -927,6 +927,11 @@
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
         },
         {
+          "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- the observability system; visibility filtering events are observable through tracing",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
@@ -960,11 +965,6 @@
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) — tracing records emission and delivery metadata",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
-        },
-        {
-          "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- the observability system; visibility filtering events are observable through tracing",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- observability and replay buffer backing store",
@@ -1163,6 +1163,11 @@
           "fromPath": "docs/adr/0021-draft-state-stays-out-of-the-resolved-graph.md"
         },
         {
+          "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures resolved visibility state after all overrides are applied",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
@@ -1171,11 +1176,6 @@
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- rig state captured in the lockfile graph; rig lock state occupies a section in `trails.lock`",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
-        },
-        {
-          "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures resolved visibility state after all overrides are applied",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- captures WebSocket trailhead configuration in the resolved topo graph",
@@ -1421,6 +1421,11 @@
           "fromPath": "docs/adr/0025-composition-testing.md"
         },
         {
+          "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- `crossInput` relates to internal visibility; a trail with required `crossInput` fields should declare `visibility: 'interna",
+          "from": "0027",
+          "fromPath": "docs/adr/0027-visibility-and-filtering.md"
+        },
+        {
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
@@ -1434,11 +1439,6 @@
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) — typed `ctx.cross()` complements signal-based decoupling; signals are for loose coupling, crosses are for typed direct compos",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
-        },
-        {
-          "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- `crossInput` relates to internal visibility; a trail with required `crossInput` fields should declare `visibility: 'interna",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-visibility-and-filtering.md"
         },
         {
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- `crossInput` follows the same \"compose schemas, project the union\" pattern as layer input schemas",
@@ -1489,17 +1489,17 @@
       "depends_on": ["2", "6"],
       "inbound": [
         {
-          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
+          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, discard) ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
         },
         {
-          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
+          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, discard) ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
         },
         {
-          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) -- WebSocket close code mapping deferred there; the error ",
+          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) -- WebSocket close code mapping deferred there; the error ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
         }
@@ -1511,7 +1511,46 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Error Taxonomy as Transport-Independent Behavior Contract",
-      "updated": "2026-04-13"
+      "updated": "2026-04-10"
+    },
+    {
+      "created": "2026-03-31",
+      "depends_on": ["packs-namespace-boundaries"],
+      "inbound": [
+        {
+          "context": "[^3]: See [Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft)",
+          "from": "0024",
+          "fromPath": "docs/adr/0024-typed-trail-composition.md"
+        },
+        {
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+        },
+        {
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
+        },
+        {
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
+        },
+        {
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
+        }
+      ],
+      "number": "0027",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0027-visibility-and-filtering.md",
+      "slug": "visibility-and-filtering",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Trail Visibility and Trailhead Filtering",
+      "updated": "2026-04-10"
     }
   ],
   "version": 1

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -1489,17 +1489,17 @@
       "depends_on": ["2", "6"],
       "inbound": [
         {
-          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, discard) ",
+          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
         },
         {
-          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, discard) ",
+          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
         },
         {
-          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) -- WebSocket close code mapping deferred there; the error ",
+          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) -- WebSocket close code mapping deferred there; the error ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
         }
@@ -1518,27 +1518,27 @@
       "depends_on": ["packs-namespace-boundaries"],
       "inbound": [
         {
-          "context": "[^3]: See [Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft)",
+          "context": "[^3]: See [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md)",
           "from": "0024",
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
         },
         {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode",
+          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
         },
         {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
+          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
         },
         {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`",
+          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- rigged SDK wrapper packs use `visibility: 'internal'`",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
         },
         {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
+          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
         }

--- a/docs/adr/drafts/20260331-concurrent-crossing.md
+++ b/docs/adr/drafts/20260331-concurrent-crossing.md
@@ -315,7 +315,7 @@ Rejected because implicit concurrency is a correctness hazard. Two crossings may
 - [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged
 - [ADR-0013: Tracing](../0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime
 - [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns
-- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode
+- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode
 - [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred here
 - [ADR: Composition Testing](../0025-composition-testing.md) -- `scenario()` and `expectedMatch` for testing concurrent composition flows
 - ADR: Packs as Namespace Boundaries (draft) -- concurrent crossings across pack boundaries work identically to sequential crossings; pack boundary governance is unchanged

--- a/docs/adr/drafts/20260331-concurrent-crossing.md
+++ b/docs/adr/drafts/20260331-concurrent-crossing.md
@@ -315,7 +315,7 @@ Rejected because implicit concurrency is a correctness hazard. Two crossings may
 - [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged
 - [ADR-0013: Tracing](../0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime
 - [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns
-- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode
+- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode
 - [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred here
 - [ADR: Composition Testing](../0025-composition-testing.md) -- `scenario()` and `expectedMatch` for testing concurrent composition flows
 - ADR: Packs as Namespace Boundaries (draft) -- concurrent crossings across pack boundaries work identically to sequential crossings; pack boundary governance is unchanged

--- a/docs/adr/drafts/20260331-direct-invocation.md
+++ b/docs/adr/drafts/20260331-direct-invocation.md
@@ -583,7 +583,7 @@ Trail IDs are completed from the topo. Example names are completed from the trai
 - [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- `trails run` executes through the pipeline, the same as every trailhead
 - ADR: Typed Signal Emission (draft) -- events emitted during `trails run` flow through normal routing, triggers fire
 - [ADR: Concurrent Trail Crossing](20260331-concurrent-crossing.md) (draft) -- `--trace` renders concurrent crossings as parallel branches in the execution tree
-- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)
+- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)
 - [ADR: Unified Observability](20260409-unified-observability.md) (draft) -- `--trace` flag, `ctx.trace()`, and the tracing vocabulary used throughout this draft. Note: this draft uses `--tracing` as the flag name; the canonical flag is `--trace` per the observability ADR.
 - ADR: Packs as Namespace Boundaries (draft) -- `trails run` can invoke any trail in any pack, regardless of visibility
 - [ADR-0013: Tracing](../0013-tracing.md) -- the tracing primitive; live tracing during `trails run`, historical tracing via `trails trace`

--- a/docs/adr/drafts/20260331-direct-invocation.md
+++ b/docs/adr/drafts/20260331-direct-invocation.md
@@ -583,7 +583,7 @@ Trail IDs are completed from the topo. Example names are completed from the trai
 - [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- `trails run` executes through the pipeline, the same as every trailhead
 - ADR: Typed Signal Emission (draft) -- events emitted during `trails run` flow through normal routing, triggers fire
 - [ADR: Concurrent Trail Crossing](20260331-concurrent-crossing.md) (draft) -- `--trace` renders concurrent crossings as parallel branches in the execution tree
-- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)
+- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)
 - [ADR: Unified Observability](20260409-unified-observability.md) (draft) -- `--trace` flag, `ctx.trace()`, and the tracing vocabulary used throughout this draft. Note: this draft uses `--tracing` as the flag name; the canonical flag is `--trace` per the observability ADR.
 - ADR: Packs as Namespace Boundaries (draft) -- `trails run` can invoke any trail in any pack, regardless of visibility
 - [ADR-0013: Tracing](../0013-tracing.md) -- the tracing primitive; live tracing during `trails run`, historical tracing via `trails trace`

--- a/docs/adr/drafts/20260331-external-trailheads-as-trails.md
+++ b/docs/adr/drafts/20260331-external-trailheads-as-trails.md
@@ -785,7 +785,7 @@ Rig lock state rolls up into the `rigs` section of `trails.lock`:
 - [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- rigged trails declare intent; HTTP method mapping and MCP annotations work identically
 - [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- rigged trails execute through the same pipeline
 - [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- rigged trails get trailhead derivation for free
-- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`
+- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- rigged SDK wrapper packs use `visibility: 'internal'`
 - [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) -- `deriveTrail()` and `ingest()` factory that produces trails from external input shapes
 - [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) -- the packaging model for connector-contributed capabilities that rig packs may use
 - ADR: Packs as Namespace Boundaries (draft) -- rigged trails compose into packs with the same layering pattern

--- a/docs/adr/drafts/20260331-external-trailheads-as-trails.md
+++ b/docs/adr/drafts/20260331-external-trailheads-as-trails.md
@@ -785,7 +785,7 @@ Rig lock state rolls up into the `rigs` section of `trails.lock`:
 - [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- rigged trails declare intent; HTTP method mapping and MCP annotations work identically
 - [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- rigged trails execute through the same pipeline
 - [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- rigged trails get trailhead derivation for free
-- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`
+- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`
 - [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) -- `deriveTrail()` and `ingest()` factory that produces trails from external input shapes
 - [ADR: Connector Extraction and the `with-*` Packaging Model](20260409-connector-extraction-and-the-with-packaging-model.md) (draft) -- the packaging model for connector-contributed capabilities that rig packs may use
 - ADR: Packs as Namespace Boundaries (draft) -- rigged trails compose into packs with the same layering pattern

--- a/docs/adr/drafts/20260331-websocket-trailhead.md
+++ b/docs/adr/drafts/20260331-websocket-trailhead.md
@@ -342,7 +342,7 @@ The package depends on `@ontrails/core` and benefits from the Events Runtime for
 - [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) -- WebSocket close code mapping deferred there; the error taxonomy extends to WebSocket as a transport
 - [ADR: Unified Observability](20260409-unified-observability.md) (draft) -- tracing system that provides WebSocket connection observability
 - ADR: Typed Signal Emission (draft) -- `ctx.signal()` provides the events that WebSocket subscriptions deliver
-- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- visibility and intent filtering apply to WebSocket trail discovery and invocation
+- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- visibility and intent filtering apply to WebSocket trail discovery and invocation
 - ADR: Reactive Trail Activation (draft) -- triggers and WebSocket subscriptions are both consumers of the event routing pipeline
 - [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) -- `ingest()` factory for webhook-to-trail flows that can feed events to WebSocket subscribers
 - [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- captures WebSocket trailhead configuration in the resolved topo graph

--- a/docs/adr/drafts/20260331-websocket-trailhead.md
+++ b/docs/adr/drafts/20260331-websocket-trailhead.md
@@ -342,7 +342,7 @@ The package depends on `@ontrails/core` and benefits from the Events Runtime for
 - [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) -- WebSocket close code mapping deferred there; the error taxonomy extends to WebSocket as a transport
 - [ADR: Unified Observability](20260409-unified-observability.md) (draft) -- tracing system that provides WebSocket connection observability
 - ADR: Typed Signal Emission (draft) -- `ctx.signal()` provides the events that WebSocket subscriptions deliver
-- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- visibility and intent filtering apply to WebSocket trail discovery and invocation
+- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- visibility and intent filtering apply to WebSocket trail discovery and invocation
 - ADR: Reactive Trail Activation (draft) -- triggers and WebSocket subscriptions are both consumers of the event routing pipeline
 - [ADR: `deriveTrail()` and Trail Factories](20260409-derivetrail-and-trail-factories.md) (draft) -- `ingest()` factory for webhook-to-trail flows that can feed events to WebSocket subscribers
 - [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- captures WebSocket trailhead configuration in the resolved topo graph

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -20,8 +20,6 @@ Proposed decisions under discussion. Promoted to `docs/adr/` when accepted.
   - depends on [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md), [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md), [ADR-0013: Tracing — Runtime Recording Primitive](../0013-tracing.md), [Typed Signal Emission](20260331-typed-signal-emission.md)
 - [Typed Signal Emission](20260331-typed-signal-emission.md)
   - depends on [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md), [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md), [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md), [ADR-0007: Governance as Trails with AST-Based Analysis](../0007-governance-as-trails.md), [ADR-0013: Tracing — Runtime Recording Primitive](../0013-tracing.md)
-- [Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md)
-  - depends on [Packs as Namespace Boundaries](20260331-packs-namespace-boundaries.md)
 - [WebSocket Trailhead](20260331-websocket-trailhead.md)
   - depends on [Typed Signal Emission](20260331-typed-signal-emission.md)
 

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -111,45 +111,6 @@
     },
     {
       "created": "2026-03-31",
-      "depends_on": ["packs-namespace-boundaries"],
-      "inbound": [
-        {
-          "context": "[^3]: See [Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft)",
-          "from": "0024",
-          "fromPath": "docs/adr/0024-typed-trail-composition.md"
-        },
-        {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
-        },
-        {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
-        },
-        {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
-        },
-        {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](20260331-visibility-and-filtering.md) (draft) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
-        }
-      ],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260331-visibility-and-filtering.md",
-      "slug": "visibility-and-filtering",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Trail Visibility and Trailhead Filtering",
-      "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-03-31",
       "depends_on": ["typed-signal-emission"],
       "inbound": [],
       "number": null,

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -218,6 +218,23 @@ const db = resource('db.main', {
 });
 ```
 
+### `visibility`
+
+Whether a trail is exposed as a public verb on trailheads or kept as an internal
+composition target.
+
+```typescript
+const normalizePayload = trail('github.normalize-payload', {
+  visibility: 'internal',
+  input: PayloadSchema,
+  output: NormalizedSchema,
+  blaze: async (input) => Result.ok(input),
+});
+```
+
+`'public'` is the default. `'internal'` keeps the trail off trailheads unless a
+specific trailhead includes that exact trail ID intentionally.
+
 Trails declare their infrastructure needs with `resources: [...]` and access them through `db.from(ctx)` or `ctx.resource()`.
 
 ### `profile`

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -218,6 +218,8 @@ const db = resource('db.main', {
 });
 ```
 
+Trails declare their infrastructure needs with `resources: [...]` and access them through `db.from(ctx)` or `ctx.resource()`.
+
 ### `visibility`
 
 Whether a trail is exposed as a public verb on trailheads or kept as an internal
@@ -234,8 +236,6 @@ const normalizePayload = trail('github.normalize-payload', {
 
 `'public'` is the default. `'internal'` keeps the trail off trailheads unless a
 specific trailhead includes that exact trail ID intentionally.
-
-Trails declare their infrastructure needs with `resources: [...]` and access them through `db.from(ctx)` or `ctx.resource()`.
 
 ### `profile`
 

--- a/docs/trailheads/mcp.md
+++ b/docs/trailheads/mcp.md
@@ -134,16 +134,18 @@ Not every trail should be exposed as an MCP tool. Use include/exclude filters:
 
 ```typescript
 await trailhead(app, {
-  includeTrails: ['entity.show', 'entity.add', 'search'],
+  include: ['entity.**', 'search'],
 });
 
 // Or exclude specific trails
 await trailhead(app, {
-  excludeTrails: ['internal.debug', 'admin.reset'],
+  exclude: ['internal.debug', 'admin.reset'],
 });
 ```
 
-`includeTrails` takes precedence over `excludeTrails`.
+`*` matches one dotted namespace segment and `**` matches any depth. Excludes
+apply before include narrowing, and trails marked `visibility: 'internal'` stay
+hidden unless you include their exact trail ID.
 
 ## Server Configuration
 
@@ -191,7 +193,7 @@ For advanced use cases, build the tool definitions directly:
 import { buildMcpTools } from '@ontrails/mcp';
 
 const result = buildMcpTools(app, {
-  includeTrails: ['entity.show', 'search'],
+  include: ['entity.**', 'search'],
 });
 
 if (result.isErr()) {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -173,6 +173,17 @@ beneath that path.
 
 Declared resources on each trail are resolved into the context before the implementation runs.
 
+## Filtering
+
+```typescript
+trailhead(app, { include: ['entity.**'] });
+trailhead(app, { exclude: ['dev.**'] });
+```
+
+`*` matches one dotted segment and `**` matches any depth. Trails declared
+with `visibility: 'internal'` stay hidden unless you include their exact trail
+ID intentionally.
+
 ## Layers
 
 - **`autoIterateLayer`** -- adds `--all` for paginated trails, collects all pages

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -513,6 +513,61 @@ describe('buildCliCommands resource overrides', () => {
 });
 
 describe('buildCliCommands filtering', () => {
+  test('internal trails are excluded by default', () => {
+    const publicTrail = trail('entity.show', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+    });
+    const internalTrail = trail('entity.secret.rotate', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      visibility: 'internal',
+    });
+    const commands = buildCliCommands(makeApp(publicTrail, internalTrail));
+
+    expect(commands.map((command) => command.trail.id)).toEqual([
+      'entity.show',
+    ]);
+  });
+
+  test('exact include can expose an internal trail', () => {
+    const publicTrail = trail('entity.show', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+    });
+    const internalTrail = trail('entity.secret.rotate', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      visibility: 'internal',
+    });
+    const commands = buildCliCommands(makeApp(publicTrail, internalTrail), {
+      include: ['entity.secret.rotate'],
+    });
+
+    expect(commands.map((command) => command.trail.id)).toEqual([
+      'entity.secret.rotate',
+    ]);
+  });
+
+  test('exclude patterns apply before include narrowing', () => {
+    const show = trail('entity.show', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+    });
+    const remove = trail('entity.remove', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+    });
+    const commands = buildCliCommands(makeApp(show, remove), {
+      exclude: ['entity.remove'],
+      include: ['entity.*'],
+    });
+
+    expect(commands.map((command) => command.trail.id)).toEqual([
+      'entity.show',
+    ]);
+  });
+
   test('consumer trails (on: [...]) are excluded', () => {
     const producer = trail('order.create', {
       blaze: () => Result.ok({ ok: true }),

--- a/packages/cli/src/__tests__/trailhead.test.ts
+++ b/packages/cli/src/__tests__/trailhead.test.ts
@@ -74,9 +74,13 @@ describe('trailhead', () => {
       })
     ).not.toThrow();
     const opts: Parameters<typeof trailhead>[1] = {
+      exclude: ['entity.secret'],
+      include: ['entity.show'],
       resources: {},
       validate: false,
     };
+    expect(opts.exclude).toEqual(['entity.secret']);
+    expect(opts.include).toEqual(['entity.show']);
     expect(opts.validate).toBe(false);
     expect(opts.resources).toEqual({});
   });

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -17,6 +17,7 @@ import {
   deriveCliPath,
   deriveFields,
   executeTrail,
+  filterTrailheadTrails,
   validateEstablishedTopo,
 } from '@ontrails/core';
 
@@ -55,6 +56,8 @@ export interface BuildCliCommandsOptions {
   createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
+  exclude?: readonly string[] | undefined;
+  include?: readonly string[] | undefined;
   layers?: Layer[] | undefined;
   onResult?: ((ctx: ActionResultContext) => Promise<void>) | undefined;
   presets?: CliFlag[][] | undefined;
@@ -466,12 +469,10 @@ const collectCommands = (
   app: Topo,
   options?: BuildCliCommandsOptions
 ): CliCommand[] =>
-  app
-    .list()
-    .filter(
-      (trail) => trail.meta?.['internal'] !== true && trail.on.length === 0
-    )
-    .map((trail) => toCliCommand(app, trail, options));
+  filterTrailheadTrails(app.list(), {
+    exclude: options?.exclude,
+    include: options?.include,
+  }).map((trail) => toCliCommand(app, trail, options));
 
 export const buildCliCommands = (
   app: Topo,

--- a/packages/cli/src/commander/trailhead.ts
+++ b/packages/cli/src/commander/trailhead.ts
@@ -26,6 +26,8 @@ export interface TrailheadCliOptions {
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
   description?: string | undefined;
+  exclude?: readonly string[] | undefined;
+  include?: readonly string[] | undefined;
   layers?: Layer[] | undefined;
   name?: string | undefined;
   onResult?: ((ctx: ActionResultContext) => Promise<void>) | undefined;
@@ -62,6 +64,8 @@ export const trailhead = async (
 ): Promise<void> => {
   const commands = buildCliCommands(app, {
     createContext: options.createContext,
+    exclude: options.exclude,
+    include: options.include,
     layers: options.layers,
     onResult: options.onResult ?? defaultOnResult,
     presets: options.presets,

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -246,6 +246,23 @@ describe('trail()', () => {
       });
       expect(t.idempotent).toBe(true);
     });
+
+    test('visibility defaults to public', () => {
+      const minimal = trail('visible', {
+        blaze: () => Result.ok(),
+        input: z.object({}),
+      });
+      expect(minimal.visibility).toBe('public');
+    });
+
+    test('visibility is preserved when set', () => {
+      const t = trail('internal.helper', {
+        blaze: () => Result.ok(),
+        input: z.object({}),
+        visibility: 'internal',
+      });
+      expect(t.visibility).toBe('internal');
+    });
   });
 
   describe('single-object overload', () => {

--- a/packages/core/src/__tests__/trailhead-filter.test.ts
+++ b/packages/core/src/__tests__/trailhead-filter.test.ts
@@ -30,6 +30,22 @@ const internalTrail = trail('entity.secret.rotate', {
   visibility: 'internal',
 });
 
+const legacyInternalTrail = trail('entity.legacy.rotate', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  meta: { internal: true },
+});
+
+const bareEntityTrail = trail('entity', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+});
+
+const otherTrail = trail('other', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+});
+
 const consumerTrail = trail('notify.email', {
   blaze: () => Result.ok({ ok: true }),
   input: z.object({}),
@@ -49,6 +65,15 @@ describe('matchesTrailPattern', () => {
   test('** matches any remaining dotted depth', () => {
     expect(matchesTrailPattern('entity.admin.show', 'entity.**')).toBe(true);
     expect(matchesTrailPattern('entity.show', 'entity.**')).toBe(true);
+  });
+
+  test('** terminal segment matches entity and all descendants', () => {
+    // Zero-remaining-segments case: bare parent matches entity.**.
+    expect(matchesTrailPattern('entity', 'entity.**')).toBe(true);
+    // One-remaining-segment case for completeness.
+    expect(matchesTrailPattern('entity.read', 'entity.**')).toBe(true);
+    // Sibling namespace must not match entity.**.
+    expect(matchesTrailPattern('other', 'entity.**')).toBe(false);
   });
 });
 
@@ -103,5 +128,31 @@ describe('filterTrailheadTrails', () => {
         include: ['notify.email'],
       })
     ).toEqual([]);
+  });
+
+  test('legacy meta.internal is treated as internal visibility', () => {
+    // Default filter: legacy internal trails must not leak out.
+    expect(filterTrailheadTrails([legacyInternalTrail])).toEqual([]);
+
+    // Wildcard include must also refuse to expose the legacy internal trail.
+    expect(
+      filterTrailheadTrails([legacyInternalTrail], { include: ['entity.**'] })
+    ).toEqual([]);
+
+    // Explicit exact-id include is the documented escape hatch.
+    expect(
+      filterTrailheadTrails([legacyInternalTrail], {
+        include: ['entity.legacy.rotate'],
+      })
+    ).toEqual([legacyInternalTrail]);
+  });
+
+  test('entity.** include matches bare entity and descendants', () => {
+    // Regression guard for the ** terminal-segment zero-depth case.
+    expect(
+      filterTrailheadTrails([bareEntityTrail, publicTrail, otherTrail], {
+        include: ['entity.**'],
+      })
+    ).toEqual([bareEntityTrail, publicTrail]);
   });
 });

--- a/packages/core/src/__tests__/trailhead-filter.test.ts
+++ b/packages/core/src/__tests__/trailhead-filter.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { Result } from '../result.js';
+import {
+  filterTrailheadTrails,
+  matchesTrailPattern,
+} from '../trailhead-filter.js';
+import { signal } from '../signal.js';
+import { trail } from '../trail.js';
+
+const orderPlaced = signal('order.placed', {
+  payload: z.object({ orderId: z.string() }),
+});
+
+const publicTrail = trail('entity.show', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+});
+
+const nestedTrail = trail('entity.admin.audit', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+});
+
+const internalTrail = trail('entity.secret.rotate', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  visibility: 'internal',
+});
+
+const consumerTrail = trail('notify.email', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  on: [orderPlaced],
+});
+
+describe('matchesTrailPattern', () => {
+  test('exact trail IDs match directly', () => {
+    expect(matchesTrailPattern('entity.show', 'entity.show')).toBe(true);
+  });
+
+  test('* matches a single dotted segment', () => {
+    expect(matchesTrailPattern('entity.show', 'entity.*')).toBe(true);
+    expect(matchesTrailPattern('entity.admin.show', 'entity.*')).toBe(false);
+  });
+
+  test('** matches any remaining dotted depth', () => {
+    expect(matchesTrailPattern('entity.admin.show', 'entity.**')).toBe(true);
+    expect(matchesTrailPattern('entity.show', 'entity.**')).toBe(true);
+  });
+});
+
+describe('filterTrailheadTrails', () => {
+  test('includes public trails by default', () => {
+    expect(filterTrailheadTrails([publicTrail])).toEqual([publicTrail]);
+  });
+
+  test('excludes internal trails by default', () => {
+    expect(filterTrailheadTrails([internalTrail])).toEqual([]);
+  });
+
+  test('does not expose internal trails for wildcard includes', () => {
+    expect(
+      filterTrailheadTrails([internalTrail], { include: ['entity.**'] })
+    ).toEqual([]);
+  });
+
+  test('allows exact include to expose an internal trail', () => {
+    expect(
+      filterTrailheadTrails([internalTrail], {
+        include: ['entity.secret.rotate'],
+      })
+    ).toEqual([internalTrail]);
+  });
+
+  test('exclude patterns remove matches before include narrowing', () => {
+    expect(
+      filterTrailheadTrails([publicTrail], {
+        exclude: ['entity.*'],
+        include: ['entity.show'],
+      })
+    ).toEqual([]);
+  });
+
+  test('include patterns narrow the visible trail set', () => {
+    expect(
+      filterTrailheadTrails([publicTrail, nestedTrail], {
+        include: ['entity.**'],
+      })
+    ).toEqual([publicTrail, nestedTrail]);
+    expect(
+      filterTrailheadTrails([publicTrail, nestedTrail], {
+        include: ['entity.*'],
+      })
+    ).toEqual([publicTrail]);
+  });
+
+  test('consumer trails are never exposed on trailheads', () => {
+    expect(
+      filterTrailheadTrails([consumerTrail], {
+        include: ['notify.email'],
+      })
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,7 +83,14 @@ export type {
   Trail,
   TrailSpec,
   TrailExample,
+  TrailVisibility,
 } from './trail.js';
+export {
+  filterTrailheadTrails,
+  matchesTrailPattern,
+  shouldIncludeTrailForTrailhead,
+} from './trailhead-filter.js';
+export type { TrailheadFilterOptions } from './trailhead-filter.js';
 
 // Type utilities
 export type {

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -70,6 +70,8 @@ export interface TrailSpec<I, O, CI = never> {
   readonly intent?: 'read' | 'write' | 'destroy' | undefined;
   /** Trail is idempotent (safe to retry) */
   readonly idempotent?: boolean | undefined;
+  /** Whether trailheads expose this trail by default. */
+  readonly visibility?: TrailVisibility | undefined;
   /** Arbitrary meta for tooling and filtering */
   readonly meta?: Readonly<Record<string, unknown>> | undefined;
   /** Named sets of downstream trail IDs that may be invoked */
@@ -120,6 +122,9 @@ export interface TrailSpec<I, O, CI = never> {
 /** Intent describes what a trail does to the world */
 export type Intent = 'read' | 'write' | 'destroy';
 
+/** Whether trailheads expose a trail by default. */
+export type TrailVisibility = 'public' | 'internal';
+
 /** A fully-defined trail — the unit of work in the Trails system */
 export interface Trail<I, O, CI = never> extends Omit<
   TrailSpec<I, O, CI>,
@@ -147,6 +152,8 @@ export interface Trail<I, O, CI = never> extends Omit<
   readonly on: readonly string[];
   /** What this trail does to the world (always present, default 'write') */
   readonly intent: Intent;
+  /** Whether trailheads expose this trail by default (always present, default 'public'). */
+  readonly visibility: TrailVisibility;
   /** Primary input fields and their order (always present, default undefined) */
   readonly args?: readonly string[] | false | undefined;
 }
@@ -213,6 +220,7 @@ export function trail<I, O, CI = never>(
     intent: rawIntent,
     on: rawOn,
     resources: rawResources,
+    visibility: rawVisibility,
     ...spec
   } = resolved.spec;
   const resources = Object.freeze([...(rawResources ?? [])]);
@@ -233,6 +241,7 @@ export function trail<I, O, CI = never>(
     kind: 'trail' as const,
     on,
     resources,
+    visibility: rawVisibility ?? 'public',
   });
 }
 

--- a/packages/core/src/trailhead-filter.ts
+++ b/packages/core/src/trailhead-filter.ts
@@ -1,0 +1,148 @@
+import type { Trail } from './trail.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface TrailheadFilterOptions {
+  /** Glob patterns that keep only matching trail IDs when provided. */
+  readonly include?: readonly string[] | undefined;
+  /** Glob patterns that remove matching trail IDs. */
+  readonly exclude?: readonly string[] | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Glob matching
+// ---------------------------------------------------------------------------
+
+const trailIdSegments = (trailId: string): readonly string[] =>
+  trailId.split('.');
+
+const patternSegments = (pattern: string): readonly string[] =>
+  pattern.split('.');
+
+type SegmentMatcher = (
+  trail: readonly string[],
+  pattern: readonly string[],
+  trailIndex: number,
+  patternIndex: number
+) => boolean;
+
+const matchesDoubleStar = (
+  trail: readonly string[],
+  pattern: readonly string[],
+  trailIndex: number,
+  patternIndex: number,
+  matchSegments: SegmentMatcher
+): boolean =>
+  patternIndex === pattern.length - 1 ||
+  Array.from(
+    { length: trail.length - trailIndex + 1 },
+    (_, offset) => trailIndex + offset
+  ).some((index) => matchSegments(trail, pattern, index, patternIndex + 1));
+
+const matchesSingleSegment = (
+  trail: readonly string[],
+  pattern: readonly string[],
+  trailIndex: number,
+  patternIndex: number,
+  current: string,
+  matchSegments: SegmentMatcher
+): boolean =>
+  trailIndex < trail.length &&
+  (current === '*' || current === trail[trailIndex]) &&
+  matchSegments(trail, pattern, trailIndex + 1, patternIndex + 1);
+
+const matchesFrom = function matchesFrom(
+  trail: readonly string[],
+  pattern: readonly string[],
+  trailIndex: number,
+  patternIndex: number
+): boolean {
+  if (patternIndex >= pattern.length) {
+    return trailIndex >= trail.length;
+  }
+
+  const current = pattern[patternIndex];
+  if (current === undefined) {
+    return false;
+  }
+
+  return current === '**'
+    ? matchesDoubleStar(trail, pattern, trailIndex, patternIndex, matchesFrom)
+    : matchesSingleSegment(
+        trail,
+        pattern,
+        trailIndex,
+        patternIndex,
+        current,
+        matchesFrom
+      );
+};
+
+export const matchesTrailPattern = (
+  trailId: string,
+  pattern: string
+): boolean => {
+  if (pattern === trailId) {
+    return true;
+  }
+  return matchesFrom(trailIdSegments(trailId), patternSegments(pattern), 0, 0);
+};
+
+// ---------------------------------------------------------------------------
+// Trailhead filtering
+// ---------------------------------------------------------------------------
+
+const matchesAnyPattern = (
+  trailId: string,
+  patterns: readonly string[] | undefined
+): boolean =>
+  patterns !== undefined &&
+  patterns.some((pattern) => matchesTrailPattern(trailId, pattern));
+
+const isExplicitInternalInclude = (
+  trailId: string,
+  include: readonly string[] | undefined
+): boolean => include !== undefined && include.includes(trailId);
+
+const isVisibleToTrailheads = (
+  trail: Trail<unknown, unknown, unknown>,
+  include: readonly string[] | undefined
+): boolean =>
+  trail.visibility !== 'internal' ||
+  isExplicitInternalInclude(trail.id, include);
+
+const passesIncludeFilter = (
+  trailId: string,
+  include: readonly string[] | undefined
+): boolean =>
+  include === undefined ||
+  include.length === 0 ||
+  matchesAnyPattern(trailId, include);
+
+export const shouldIncludeTrailForTrailhead = (
+  trail: Trail<unknown, unknown, unknown>,
+  options: TrailheadFilterOptions = {}
+): boolean => {
+  if (trail.on.length > 0) {
+    return false;
+  }
+
+  const { exclude, include } = options;
+  if (!isVisibleToTrailheads(trail, include)) {
+    return false;
+  }
+
+  if (matchesAnyPattern(trail.id, exclude)) {
+    return false;
+  }
+
+  return passesIncludeFilter(trail.id, include);
+};
+
+export const filterTrailheadTrails = (
+  trails: readonly Trail<unknown, unknown, unknown>[],
+  options: TrailheadFilterOptions = {}
+): Trail<unknown, unknown, unknown>[] =>
+  trails.filter((trail) => shouldIncludeTrailForTrailhead(trail, options));

--- a/packages/core/src/trailhead-filter.ts
+++ b/packages/core/src/trailhead-filter.ts
@@ -106,11 +106,35 @@ const isExplicitInternalInclude = (
   include: readonly string[] | undefined
 ): boolean => include !== undefined && include.includes(trailId);
 
+/**
+ * Resolve the effective visibility for a trail.
+ *
+ * Returns `'internal'` when either the explicit `visibility` field is
+ * `'internal'` or the legacy `meta.internal === true` convention is set.
+ * Honoring the legacy flag keeps trails authored before the visibility
+ * field was introduced (e.g. `meta: { internal: true }`) off trailheads.
+ *
+ * The runtime always fills in `visibility: 'public'` when the spec did not
+ * declare it, so we cannot distinguish explicit `'public'` from the default.
+ * This means a trail that sets both `meta.internal = true` and
+ * `visibility: 'public'` will still be treated as internal — that
+ * combination has never been a documented override and, if the author
+ * really means "public", they should remove the legacy flag.
+ */
+const effectiveVisibility = (
+  trail: Trail<unknown, unknown, unknown>
+): 'public' | 'internal' => {
+  if (trail.visibility === 'internal') {
+    return 'internal';
+  }
+  return trail.meta?.['internal'] === true ? 'internal' : 'public';
+};
+
 const isVisibleToTrailheads = (
   trail: Trail<unknown, unknown, unknown>,
   include: readonly string[] | undefined
 ): boolean =>
-  trail.visibility !== 'internal' ||
+  effectiveVisibility(trail) !== 'internal' ||
   isExplicitInternalInclude(trail.id, include);
 
 const passesIncludeFilter = (

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -64,6 +64,19 @@ Trail IDs map to paths: `entity.show` becomes `/entity/show`. Dots become slashe
 
 Declared resources on each trail are resolved into the context before the implementation runs.
 
+## Filtering
+
+```typescript
+const result = buildHttpRoutes(app, {
+  include: ['entity.**'],
+  exclude: ['dev.**'],
+});
+```
+
+`*` matches one dotted segment and `**` matches any depth. Trails declared
+with `visibility: 'internal'` stay hidden unless you include their exact trail
+ID intentionally.
+
 ## AbortSignal propagation
 
 The `execute` function on each `HttpRouteDefinition` accepts an optional `abortSignal`. The Hono connector extracts `signal` from `c.req.raw` and forwards it as `abortSignal`, so client disconnects propagate into trail execution.

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -55,11 +55,11 @@ const internalTrail = trail('crash', {
   input: z.object({}),
 });
 
-const internalMetaTrail = trail('secret', {
+const internalVisibilityTrail = trail('secret', {
   blaze: () => Result.ok({ ok: true }),
   description: 'Internal trail that should be skipped',
   input: z.object({}),
-  meta: { internal: true },
+  visibility: 'internal',
 });
 
 const dbResource = resource('db.main', {
@@ -179,13 +179,44 @@ describe('buildHttpRoutes', () => {
 
   describe('filtering', () => {
     test('internal trails are skipped', () => {
-      const app = topo('testapp', { echoTrail, internalMetaTrail });
+      const app = topo('testapp', { echoTrail, internalVisibilityTrail });
       const result = buildHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
       const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.trailId).toBe('echo');
+    });
+
+    test('exact include can expose an internal trail', () => {
+      const app = topo('testapp', { echoTrail, internalVisibilityTrail });
+      const result = buildHttpRoutes(app, { include: ['secret'] });
+
+      expect(result.isOk()).toBe(true);
+      const routes = result.value;
+      expect(routes).toHaveLength(1);
+      expect(routes[0]?.trailId).toBe('secret');
+    });
+
+    test('wildcard include does not expose internal trails', () => {
+      const app = topo('testapp', { echoTrail, internalVisibilityTrail });
+      const result = buildHttpRoutes(app, { include: ['**'] });
+
+      expect(result.isOk()).toBe(true);
+      const routes = result.value;
+      expect(routes).toHaveLength(1);
+      expect(routes[0]?.trailId).toBe('echo');
+    });
+
+    test('exclude patterns win before include narrowing', () => {
+      const app = topo('testapp', { deleteTrail, echoTrail });
+      const result = buildHttpRoutes(app, {
+        exclude: ['item.**'],
+        include: ['echo', 'item.delete'],
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.value.map((route) => route.trailId)).toEqual(['echo']);
     });
 
     test('consumer trails (on: [...]) are skipped', () => {

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -11,6 +11,7 @@ import {
   TRAILHEAD_KEY,
   ValidationError,
   executeTrail,
+  filterTrailheadTrails,
   validateEstablishedTopo,
 } from '@ontrails/core';
 import type {
@@ -34,6 +35,8 @@ export interface BuildHttpRoutesOptions {
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
+  readonly exclude?: readonly string[] | undefined;
+  readonly include?: readonly string[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
   /** Set to `false` to skip topo validation while building routes. */
@@ -94,10 +97,6 @@ const derivePath = (basePath: string, trailId: string): string => {
 const deriveInputSource = (method: HttpMethod): InputSource =>
   method === 'GET' ? 'query' : 'body';
 
-/** Check if a trail should be included (skip internal and consumer trails). */
-const shouldInclude = (trail: Trail<unknown, unknown, unknown>): boolean =>
-  trail.meta?.['internal'] !== true && trail.on.length === 0;
-
 /** Build per-request context overrides with the HTTP trailhead marker. */
 const withHttpTrailhead = (
   requestId: string | undefined
@@ -141,8 +140,14 @@ const createExecute =
 // ---------------------------------------------------------------------------
 
 /** Filter topo items to eligible trails. */
-const eligibleTrails = (app: Topo): Trail<unknown, unknown, unknown>[] =>
-  app.list().filter((trail) => shouldInclude(trail));
+const eligibleTrails = (
+  app: Topo,
+  options: BuildHttpRoutesOptions
+): Trail<unknown, unknown, unknown>[] =>
+  filterTrailheadTrails(app.list(), {
+    exclude: options.exclude,
+    include: options.include,
+  });
 
 /** Build a single route definition from a trail. */
 const buildRoute = (
@@ -243,5 +248,11 @@ export const buildHttpRoutes = (
 
   const basePath = (options.basePath ?? '').replace(/\/+$/, '');
   const layers = options.layers ?? [];
-  return accumulateRoutes(app, eligibleTrails(app), basePath, layers, options);
+  return accumulateRoutes(
+    app,
+    eligibleTrails(app, options),
+    basePath,
+    layers,
+    options
+  );
 };

--- a/packages/http/src/hono/__tests__/trailhead.test.ts
+++ b/packages/http/src/hono/__tests__/trailhead.test.ts
@@ -46,6 +46,12 @@ const notFoundTrail = trail('item.get', {
   intent: 'read',
 });
 
+const hiddenTrail = trail('internal.secret', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  visibility: 'internal',
+});
+
 const internalTrail = trail('crash', {
   blaze: () => Result.err(new InternalError('Something broke')),
   description: 'Always fails with internal error',
@@ -177,6 +183,18 @@ describe('trailhead (Hono connector)', () => {
 
       const json = await res.json();
       expect(json.error.category).toBe('validation');
+    });
+
+    test('exact include can expose an internal route', async () => {
+      const app = topo('testapp', { echoTrail, hiddenTrail });
+      const hono = await trailhead(app, {
+        include: ['internal.secret'],
+        serve: false,
+      });
+
+      const res = await request(hono, 'POST', '/internal/secret', {});
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ data: { ok: true } });
     });
 
     test('POST with empty input schema succeeds without a body', async () => {

--- a/packages/http/src/hono/trailhead.ts
+++ b/packages/http/src/hono/trailhead.ts
@@ -38,7 +38,9 @@ export interface TrailheadHttpOptions {
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
+  readonly exclude?: readonly string[] | undefined;
   readonly hostname?: string | undefined;
+  readonly include?: readonly string[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly name?: string | undefined;
   readonly port?: number | undefined;
@@ -317,6 +319,8 @@ export const trailhead = async (
     basePath: options.basePath,
     configValues: options.configValues,
     createContext: options.createContext,
+    exclude: options.exclude,
+    include: options.include,
     layers: options.layers,
     resources: options.resources,
     validate: options.validate,

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -90,9 +90,12 @@ const importTrail = trail('data.import', {
 ## Filtering
 
 ```typescript
-await trailhead(app, { includeTrails: ['entity.show', 'search'] });
-await trailhead(app, { excludeTrails: ['internal.debug'] });
+await trailhead(app, { include: ['entity.**', 'search'] });
+await trailhead(app, { exclude: ['internal.debug'] });
 ```
+
+`*` matches one dotted segment and `**` matches any depth. Trails declared with
+`visibility: 'internal'` stay hidden unless you include their exact trail ID.
 
 ## Installation
 

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -351,6 +351,18 @@ describe('buildMcpTools', () => {
 
       expect(tools.map((tool) => tool.trailId)).toEqual(['echo']);
     });
+
+    test('legacy includeTrails wins over excludeTrails for overlapping ids', () => {
+      const app = topo('myapp', { deleteTrail, echoTrail, failTrail });
+      const tools = buildTools(app, {
+        excludeTrails: ['fail'],
+        includeTrails: ['echo', 'fail'],
+      });
+
+      // Historical MCP semantics: include wins when both list the same id.
+      const ids = tools.map((tool) => tool.trailId).toSorted();
+      expect(ids).toEqual(['echo', 'fail']);
+    });
   });
 
   describe('composition', () => {

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -53,6 +53,12 @@ const exampleTrail = trail('with.examples', {
   input: z.object({ name: z.string() }),
 });
 
+const internalTrail = trail('internal.secret', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  visibility: 'internal',
+});
+
 const dbResource = resource('db.main', {
   create: () =>
     Result.ok({
@@ -287,7 +293,7 @@ describe('buildMcpTools', () => {
     test('include filter limits which trails become tools', () => {
       const app = topo('myapp', { deleteTrail, echoTrail, failTrail });
       const tools = buildTools(app, {
-        includeTrails: ['echo'],
+        include: ['echo'],
       });
 
       expect(tools).toHaveLength(1);
@@ -297,7 +303,7 @@ describe('buildMcpTools', () => {
     test('exclude filter removes specific trails', () => {
       const app = topo('myapp', { deleteTrail, echoTrail, failTrail });
       const tools = buildTools(app, {
-        excludeTrails: ['fail'],
+        exclude: ['fail'],
       });
 
       expect(tools).toHaveLength(2);
@@ -305,17 +311,45 @@ describe('buildMcpTools', () => {
       expect(names).not.toContain('myapp_fail');
     });
 
-    test('include takes precedence over exclude', () => {
+    test('exclude patterns apply before include narrowing', () => {
+      const app = topo('myapp', { deleteTrail, echoTrail, failTrail });
+      const tools = buildTools(app, {
+        exclude: ['fail'],
+        include: ['echo', 'fail'],
+      });
+
+      expect(tools).toHaveLength(1);
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('myapp_echo');
+      expect(names).not.toContain('myapp_fail');
+    });
+
+    test('exact include can expose an internal trail', () => {
+      const app = topo('myapp', { echoTrail, internalTrail });
+      const tools = buildTools(app, {
+        include: ['internal.secret'],
+      });
+
+      expect(tools.map((tool) => tool.trailId)).toEqual(['internal.secret']);
+    });
+
+    test('wildcard include does not expose internal trails', () => {
+      const app = topo('myapp', { echoTrail, internalTrail });
+      const tools = buildTools(app, {
+        include: ['**'],
+      });
+
+      expect(tools.map((tool) => tool.trailId)).toEqual(['echo']);
+    });
+
+    test('legacy includeTrails and excludeTrails options still work', () => {
       const app = topo('myapp', { deleteTrail, echoTrail, failTrail });
       const tools = buildTools(app, {
         excludeTrails: ['fail'],
-        includeTrails: ['echo', 'fail'],
+        includeTrails: ['echo'],
       });
 
-      expect(tools).toHaveLength(2);
-      const names = tools.map((t) => t.name);
-      expect(names).toContain('myapp_echo');
-      expect(names).toContain('myapp_fail');
+      expect(tools.map((tool) => tool.trailId)).toEqual(['echo']);
     });
   });
 

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -11,6 +11,7 @@ import {
   TRAILHEAD_KEY,
   ValidationError,
   executeTrail,
+  filterTrailheadTrails,
   isBlobRef,
   validateEstablishedTopo,
   zodToJsonSchema,
@@ -41,7 +42,9 @@ export interface BuildMcpToolsOptions {
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
+  readonly exclude?: readonly string[] | undefined;
   readonly excludeTrails?: readonly string[] | undefined;
+  readonly include?: readonly string[] | undefined;
   readonly includeTrails?: readonly string[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
@@ -265,24 +268,12 @@ const createHandler =
  * - MCP annotations from trail meta
  * - A handler that validates, composes layers, executes, and maps results
  */
-/** Check if a trail should be included based on meta and filters. */
-const shouldInclude = (
-  trail: Trail<unknown, unknown, unknown>,
-  options: BuildMcpToolsOptions
-): boolean => {
-  if (trail.meta?.['internal'] === true || trail.on.length > 0) {
-    return false;
-  }
-  if (options.includeTrails !== undefined && options.includeTrails.length > 0) {
-    return options.includeTrails.includes(trail.id);
-  }
-  if (
-    options.excludeTrails !== undefined &&
-    options.excludeTrails.includes(trail.id)
-  ) {
-    return false;
-  }
-  return true;
+const dedupePatterns = (
+  patterns: readonly string[] | undefined,
+  legacyPatterns: readonly string[] | undefined
+): string[] | undefined => {
+  const merged = [...(patterns ?? []), ...(legacyPatterns ?? [])];
+  return merged.length > 0 ? [...new Set(merged)] : undefined;
 };
 
 /** Build a description with optional example input appended. */
@@ -351,7 +342,10 @@ const eligibleTrails = (
   app: Topo,
   options: BuildMcpToolsOptions
 ): Trail<unknown, unknown, unknown>[] =>
-  app.list().filter((trail) => shouldInclude(trail, options));
+  filterTrailheadTrails(app.list(), {
+    exclude: dedupePatterns(options.exclude, options.excludeTrails),
+    include: dedupePatterns(options.include, options.includeTrails),
+  });
 
 const validateToolBuild = (
   app: Topo,

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -276,6 +276,33 @@ const dedupePatterns = (
   return merged.length > 0 ? [...new Set(merged)] : undefined;
 };
 
+/**
+ * Compute the legacy "include wins over exclude" allowlist.
+ *
+ * Preserves historical MCP semantics: trails named in `includeTrails` are
+ * kept even when they also match `excludeTrails`. Only trails that appear
+ * in `excludeTrails` without also appearing in `includeTrails` are removed.
+ *
+ * Returns the set of trail IDs that should bypass exclude-filter processing,
+ * or `undefined` when no legacy options were supplied.
+ */
+const computeLegacyIncludeOverrides = (
+  includeTrails: readonly string[] | undefined,
+  excludeTrails: readonly string[] | undefined
+): ReadonlySet<string> | undefined => {
+  if (includeTrails === undefined || excludeTrails === undefined) {
+    return undefined;
+  }
+  const excludes = new Set(excludeTrails);
+  const overrides = new Set<string>();
+  for (const id of includeTrails) {
+    if (excludes.has(id)) {
+      overrides.add(id);
+    }
+  }
+  return overrides.size > 0 ? overrides : undefined;
+};
+
 /** Build a description with optional example input appended. */
 const buildDescription = (
   trail: Trail<unknown, unknown, unknown>
@@ -337,15 +364,50 @@ const registerTool = (
   return Result.ok();
 };
 
+/**
+ * Restore legacy "include wins over exclude" semantics: for any trail id
+ * that appears in both legacy include and exclude, re-include it even
+ * though the unified filter would have dropped it on the exclude pass.
+ * We reuse filterTrailheadTrails (without the legacy exclude) so that
+ * visibility rules, `on: [...]` consumer trails, and new-style exclude
+ * globs still apply.
+ */
+const mergeLegacyIncludeOverrides = (
+  app: Topo,
+  filtered: Trail<unknown, unknown, unknown>[],
+  legacyOverrides: ReadonlySet<string>,
+  options: BuildMcpToolsOptions
+): Trail<unknown, unknown, unknown>[] => {
+  const overrideCandidates = filterTrailheadTrails(app.list(), {
+    exclude: options.exclude,
+    include: options.includeTrails,
+  }).filter((t) => legacyOverrides.has(t.id));
+  if (overrideCandidates.length === 0) {
+    return filtered;
+  }
+  const filteredIds = new Set(filtered.map((t) => t.id));
+  const additions = overrideCandidates.filter((t) => !filteredIds.has(t.id));
+  return [...filtered, ...additions];
+};
+
 /** Filter topo items to eligible trails. */
 const eligibleTrails = (
   app: Topo,
   options: BuildMcpToolsOptions
-): Trail<unknown, unknown, unknown>[] =>
-  filterTrailheadTrails(app.list(), {
+): Trail<unknown, unknown, unknown>[] => {
+  const legacyOverrides = computeLegacyIncludeOverrides(
+    options.includeTrails,
+    options.excludeTrails
+  );
+  const filtered = filterTrailheadTrails(app.list(), {
     exclude: dedupePatterns(options.exclude, options.excludeTrails),
     include: dedupePatterns(options.include, options.includeTrails),
   });
+  if (legacyOverrides === undefined) {
+    return filtered;
+  }
+  return mergeLegacyIncludeOverrides(app, filtered, legacyOverrides, options);
+};
 
 const validateToolBuild = (
   app: Topo,

--- a/packages/mcp/src/trailhead.ts
+++ b/packages/mcp/src/trailhead.ts
@@ -38,7 +38,9 @@ export interface TrailheadMcpOptions {
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
+  readonly exclude?: readonly string[] | undefined;
   readonly excludeTrails?: readonly string[] | undefined;
+  readonly include?: readonly string[] | undefined;
   readonly includeTrails?: readonly string[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
@@ -153,7 +155,9 @@ export const trailhead = async (
   const toolsResult = buildMcpTools(app, {
     configValues: options.configValues,
     createContext: options.createContext,
+    exclude: options.exclude,
     excludeTrails: options.excludeTrails,
+    include: options.include,
     includeTrails: options.includeTrails,
     layers: options.layers,
     resources: options.resources,

--- a/packages/schema/src/__tests__/openapi.test.ts
+++ b/packages/schema/src/__tests__/openapi.test.ts
@@ -535,6 +535,44 @@ const registerMetadataAndStructureTests = () => {
       );
     });
   });
+
+  describe('include / exclude filters', () => {
+    test('include narrows the generated spec to matching trails', () => {
+      const publicShow = trail('public.show', {
+        blaze: noop,
+        input: z.object({}),
+        intent: 'read',
+      });
+      const privateShow = trail('private.show', {
+        blaze: noop,
+        input: z.object({}),
+        intent: 'read',
+      });
+      const spec = generateOpenApiSpec(topoFrom({ privateShow, publicShow }), {
+        include: ['public.*'],
+      });
+
+      expect(Object.keys(spec.paths)).toEqual(['/public/show']);
+    });
+
+    test('exclude removes matching trails from the generated spec', () => {
+      const publicShow = trail('public.show', {
+        blaze: noop,
+        input: z.object({}),
+        intent: 'read',
+      });
+      const publicHide = trail('public.hide', {
+        blaze: noop,
+        input: z.object({}),
+        intent: 'read',
+      });
+      const spec = generateOpenApiSpec(topoFrom({ publicHide, publicShow }), {
+        exclude: ['public.hide'],
+      });
+
+      expect(Object.keys(spec.paths).toSorted()).toEqual(['/public/show']);
+    });
+  });
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/schema/src/__tests__/openapi.test.ts
+++ b/packages/schema/src/__tests__/openapi.test.ts
@@ -405,7 +405,7 @@ const registerMetadataAndStructureTests = () => {
   });
 
   describe('internal trails', () => {
-    test('trails with meta.internal are skipped', () => {
+    test('trails with visibility internal are skipped', () => {
       const pub = trail('entity.show', {
         blaze: noop,
         input: z.object({ id: z.string() }),
@@ -414,7 +414,7 @@ const registerMetadataAndStructureTests = () => {
       const internal = trail('internal.helper', {
         blaze: noop,
         input: z.object({}),
-        meta: { internal: true },
+        visibility: 'internal',
       });
       const spec = generateOpenApiSpec(topoFrom({ internal, pub }));
 

--- a/packages/schema/src/openapi.ts
+++ b/packages/schema/src/openapi.ts
@@ -33,6 +33,16 @@ export interface OpenApiOptions {
   readonly servers?: readonly OpenApiServer[] | undefined;
   /** Prefix for all paths. Default: `''` */
   readonly basePath?: string | undefined;
+  /**
+   * Glob patterns that keep only matching trail IDs in the generated spec.
+   * Mirrors the `include` option on other trailhead builders.
+   */
+  readonly include?: readonly string[] | undefined;
+  /**
+   * Glob patterns that remove matching trail IDs from the generated spec.
+   * Mirrors the `exclude` option on other trailhead builders.
+   */
+  readonly exclude?: readonly string[] | undefined;
 }
 
 /** Minimal OpenAPI 3.1 spec shape — intentionally plain objects, no heavy library. */
@@ -285,11 +295,15 @@ const buildOperation = (
 /** Collect all paths from public trails in the topo. */
 const collectPaths = (
   app: Topo,
-  basePath: string
+  basePath: string,
+  options?: OpenApiOptions
 ): Record<string, Record<string, unknown>> => {
   const paths: Record<string, Record<string, unknown>> = {};
 
-  for (const t of filterTrailheadTrails(app.list())) {
+  for (const t of filterTrailheadTrails(app.list(), {
+    exclude: options?.exclude,
+    include: options?.include,
+  })) {
     const method = intentToMethod[t.intent] ?? 'post';
     paths[trailIdToPath(t.id, basePath)] = {
       [method]: buildOperation(t, method),
@@ -333,7 +347,11 @@ export const generateOpenApiSpec = (
     components: { schemas: {} },
     info: buildInfo(app.name, options),
     openapi: '3.1.0',
-    paths: collectPaths(app, (options?.basePath ?? '').replace(/\/+$/, '')),
+    paths: collectPaths(
+      app,
+      (options?.basePath ?? '').replace(/\/+$/, ''),
+      options
+    ),
     ...(options?.servers && options.servers.length > 0
       ? { servers: options.servers }
       : {}),

--- a/packages/schema/src/openapi.ts
+++ b/packages/schema/src/openapi.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  filterTrailheadTrails,
   statusCodeMap,
   validateDraftFreeTopo,
   zodToJsonSchema,
@@ -281,21 +282,6 @@ const buildOperation = (
 // Path collection
 // ---------------------------------------------------------------------------
 
-/** Check whether a trail should be included in the spec (skip signals, internal, and consumer trails). */
-const isPublicTrail = (t: Trail<unknown, unknown, unknown>): boolean => {
-  if (t.kind !== 'trail') {
-    return false;
-  }
-  // Consumer trails (activated by signals via `on`) are not HTTP-addressable
-  if (t.on.length > 0) {
-    return false;
-  }
-  const { meta } = t as unknown as {
-    meta?: Record<string, unknown>;
-  };
-  return meta?.['internal'] !== true;
-};
-
 /** Collect all paths from public trails in the topo. */
 const collectPaths = (
   app: Topo,
@@ -303,11 +289,7 @@ const collectPaths = (
 ): Record<string, Record<string, unknown>> => {
   const paths: Record<string, Record<string, unknown>> = {};
 
-  for (const item of app.list()) {
-    const t = item as Trail<unknown, unknown, unknown>;
-    if (!isPublicTrail(t)) {
-      continue;
-    }
+  for (const t of filterTrailheadTrails(app.list())) {
     const method = intentToMethod[t.intent] ?? 'post';
     paths[trailIdToPath(t.id, basePath)] = {
       [method]: buildOperation(t, method),


### PR DESCRIPTION
## Context

This stack layer lands the core contract and ADR work for the Visibility & Filtering milestone.

## What Changed

- promoted the visibility ADR to accepted as `ADR-0027` and refreshed ADR indexes / decision maps
- added `visibility: 'public' | 'internal'` to trail specs with a default of `public`
- introduced shared trailhead filtering in `@ontrails/core` for `include` / `exclude` glob matching with exact-ID internal exposure rules
- wired CLI, HTTP, MCP, and OpenAPI generation through the shared filtering helper
- documented the new visibility vocabulary and trailhead filtering behavior
- kept MCP's legacy `includeTrails` / `excludeTrails` aliases working while making `include` / `exclude` the canonical API

## Verification

- `bun scripts/adr.ts check`
- `bun run lint`
- `bun run typecheck`
- `bun test packages/core/src/__tests__/trail.test.ts packages/core/src/__tests__/trailhead-filter.test.ts packages/cli/src/__tests__/build.test.ts packages/cli/src/__tests__/trailhead.test.ts packages/http/src/__tests__/build.test.ts packages/http/src/hono/__tests__/trailhead.test.ts packages/mcp/src/__tests__/build.test.ts packages/schema/src/__tests__/openapi.test.ts`

## Closes

Closes TRL-253
Closes TRL-223
Closes TRL-224

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
