### PR TITLE
feat: harden intent-aware trailhead filtering

### DIFF
--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -568,6 +568,49 @@ describe('buildCliCommands filtering', () => {
     ]);
   });
 
+  test('intent filters narrow the command set', () => {
+    const show = trail('entity.show', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      intent: 'read',
+    });
+    const remove = trail('entity.remove', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      intent: 'destroy',
+    });
+
+    const commands = buildCliCommands(makeApp(show, remove), {
+      intent: ['read'],
+    });
+
+    expect(commands.map((command) => command.trail.id)).toEqual([
+      'entity.show',
+    ]);
+  });
+
+  test('intent filters compose with include patterns using AND logic', () => {
+    const show = trail('entity.show', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      intent: 'read',
+    });
+    const remove = trail('entity.remove', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      intent: 'destroy',
+    });
+
+    const commands = buildCliCommands(makeApp(show, remove), {
+      include: ['entity.*'],
+      intent: ['destroy'],
+    });
+
+    expect(commands.map((command) => command.trail.id)).toEqual([
+      'entity.remove',
+    ]);
+  });
+
   test('consumer trails (on: [...]) are excluded', () => {
     const producer = trail('order.create', {
       blaze: () => Result.ok({ ok: true }),
@@ -585,6 +628,39 @@ describe('buildCliCommands filtering', () => {
 
     expect(commands).toHaveLength(1);
     expect(commands[0]?.trail.id).toBe('order.create');
+  });
+
+  test('internal trails remain crossable even when they stay hidden', async () => {
+    const helper = trail('entity.secret.rotate', {
+      blaze: (input: { id: string }) => Result.ok({ rotated: input.id }),
+      input: z.object({ id: z.string() }),
+      intent: 'read',
+      output: z.object({ rotated: z.string() }),
+      visibility: 'internal',
+    });
+    const entry = trail('entity.rotate', {
+      blaze: async (input: { id: string }, ctx) => {
+        const result = await ctx.cross('entity.secret.rotate', input);
+        return result.match({
+          err: (error) => Result.err(error),
+          ok: (value) => Result.ok(value),
+        });
+      },
+      crosses: ['entity.secret.rotate'],
+      input: z.object({ id: z.string() }),
+      intent: 'read',
+      output: z.object({ rotated: z.string() }),
+    });
+
+    const commands = buildCliCommands(makeApp(entry, helper));
+
+    expect(commands.map((command) => command.trail.id)).toEqual([
+      'entity.rotate',
+    ]);
+
+    const result = await commands[0]?.execute({}, { id: 'abc123' });
+    expect(result?.isOk()).toBe(true);
+    expect(result?.unwrap()).toEqual({ rotated: 'abc123' });
   });
 });
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -4,6 +4,7 @@
 
 import type {
   Field,
+  Intent,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -58,6 +59,7 @@ export interface BuildCliCommandsOptions {
     | undefined;
   exclude?: readonly string[] | undefined;
   include?: readonly string[] | undefined;
+  intent?: readonly Intent[] | undefined;
   layers?: Layer[] | undefined;
   onResult?: ((ctx: ActionResultContext) => Promise<void>) | undefined;
   presets?: CliFlag[][] | undefined;
@@ -472,6 +474,7 @@ const collectCommands = (
   filterTrailheadTrails(app.list(), {
     exclude: options?.exclude,
     include: options?.include,
+    intent: options?.intent,
   }).map((trail) => toCliCommand(app, trail, options));
 
 export const buildCliCommands = (

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -9,6 +9,7 @@ import { createTrailContext } from '../context';
 import type { Layer } from '../layer';
 import { Result } from '../result';
 import { resource } from '../resource';
+import { topo } from '../topo';
 import { trail } from '../trail';
 import type { TrailContext, TrailContextInit } from '../types';
 
@@ -102,6 +103,13 @@ const unwrapExecution = async (
 ) => {
   const result = await executeTrail(target, {});
   return result.unwrap();
+};
+
+const requireCross = (
+  ctx: TrailContext
+): NonNullable<TrailContext['cross']> => {
+  expect(ctx.cross).toBeDefined();
+  return ctx.cross as NonNullable<TrailContext['cross']>;
 };
 
 // ---------------------------------------------------------------------------
@@ -221,6 +229,68 @@ describe('executeTrail', () => {
 
       expect(first.unwrap()).toEqual({ value: 'first' });
       expect(second.unwrap()).toEqual({ value: 'second' });
+    });
+
+    test('binds ctx.cross when topo access is available', async () => {
+      const helper = trail('entity.secret.rotate', {
+        blaze: (input: { id: string }) => Result.ok({ rotated: input.id }),
+        input: z.object({ id: z.string() }),
+        output: z.object({ rotated: z.string() }),
+        visibility: 'internal',
+      });
+      const entry = trail('entity.rotate', {
+        blaze: async (input: { id: string }, ctx) => {
+          const crossed = await requireCross(ctx)(
+            'entity.secret.rotate',
+            input
+          );
+          return crossed.match({
+            err: (error) => Result.err(error),
+            ok: (value) => Result.ok(value),
+          });
+        },
+        crosses: ['entity.secret.rotate'],
+        input: z.object({ id: z.string() }),
+        output: z.object({ rotated: z.string() }),
+      });
+      const app = topo('cross-topo', { entry, helper });
+
+      const result = await executeTrail(entry, { id: 'abc123' }, { topo: app });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ rotated: 'abc123' });
+    });
+
+    test('validates merged crossInput fields when invoking through ctx.cross', async () => {
+      const helper = trail('entity.prepare', {
+        blaze: (input: { forkedFrom: string; id: string }) =>
+          Result.ok({ summary: `${input.id}:${input.forkedFrom}` }),
+        crossInput: z.object({ forkedFrom: z.string() }),
+        input: z.object({ id: z.string() }),
+        output: z.object({ summary: z.string() }),
+        visibility: 'internal',
+      });
+      const entry = trail('entity.run', {
+        blaze: async (input: { id: string }, ctx) => {
+          const crossed = await requireCross(ctx)(helper, {
+            forkedFrom: 'entity.run',
+            id: input.id,
+          });
+          return crossed.match({
+            err: (error) => Result.err(error),
+            ok: (value) => Result.ok(value),
+          });
+        },
+        crosses: [helper],
+        input: z.object({ id: z.string() }),
+        output: z.object({ summary: z.string() }),
+      });
+      const app = topo('cross-input-topo', { entry, helper });
+
+      const result = await executeTrail(entry, { id: 'abc123' }, { topo: app });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ summary: 'abc123:entity.run' });
     });
   });
 

--- a/packages/core/src/__tests__/trailhead-filter.test.ts
+++ b/packages/core/src/__tests__/trailhead-filter.test.ts
@@ -80,112 +80,120 @@ describe('matchesTrailPattern', () => {
 });
 
 describe('filterTrailheadTrails', () => {
-  test('includes public trails by default', () => {
-    expect(filterTrailheadTrails([publicTrail])).toEqual([publicTrail]);
+  describe('visibility defaults', () => {
+    test('includes public trails by default', () => {
+      expect(filterTrailheadTrails([publicTrail])).toEqual([publicTrail]);
+    });
+
+    test('excludes internal trails by default', () => {
+      expect(filterTrailheadTrails([internalTrail])).toEqual([]);
+    });
+
+    test('does not expose internal trails for wildcard includes', () => {
+      expect(
+        filterTrailheadTrails([internalTrail], { include: ['entity.**'] })
+      ).toEqual([]);
+    });
+
+    test('allows exact include to expose an internal trail', () => {
+      expect(
+        filterTrailheadTrails([internalTrail], {
+          include: ['entity.secret.rotate'],
+        })
+      ).toEqual([internalTrail]);
+    });
+
+    test('legacy meta.internal is treated as internal visibility', () => {
+      // Default filter: legacy internal trails must not leak out.
+      expect(filterTrailheadTrails([legacyInternalTrail])).toEqual([]);
+
+      // Wildcard include must also refuse to expose the legacy internal trail.
+      expect(
+        filterTrailheadTrails([legacyInternalTrail], { include: ['entity.**'] })
+      ).toEqual([]);
+
+      // Explicit exact-id include is the documented escape hatch.
+      expect(
+        filterTrailheadTrails([legacyInternalTrail], {
+          include: ['entity.legacy.rotate'],
+        })
+      ).toEqual([legacyInternalTrail]);
+    });
   });
 
-  test('excludes internal trails by default', () => {
-    expect(filterTrailheadTrails([internalTrail])).toEqual([]);
+  describe('include and exclude patterns', () => {
+    test('exclude patterns remove matches before include narrowing', () => {
+      expect(
+        filterTrailheadTrails([publicTrail], {
+          exclude: ['entity.*'],
+          include: ['entity.show'],
+        })
+      ).toEqual([]);
+    });
+
+    test('include patterns narrow the visible trail set', () => {
+      expect(
+        filterTrailheadTrails([publicTrail, nestedTrail], {
+          include: ['entity.**'],
+        })
+      ).toEqual([publicTrail, nestedTrail]);
+      expect(
+        filterTrailheadTrails([publicTrail, nestedTrail], {
+          include: ['entity.*'],
+        })
+      ).toEqual([publicTrail]);
+    });
+
+    test('entity.** include matches bare entity and descendants', () => {
+      // Regression guard for the ** terminal-segment zero-depth case.
+      expect(
+        filterTrailheadTrails([bareEntityTrail, publicTrail, otherTrail], {
+          include: ['entity.**'],
+        })
+      ).toEqual([bareEntityTrail, publicTrail]);
+    });
   });
 
-  test('does not expose internal trails for wildcard includes', () => {
-    expect(
-      filterTrailheadTrails([internalTrail], { include: ['entity.**'] })
-    ).toEqual([]);
+  describe('intent filtering', () => {
+    test('intent filtering narrows visible trails by behavior class', () => {
+      expect(
+        filterTrailheadTrails([publicTrail, nestedTrail], {
+          intent: ['read'],
+        })
+      ).toEqual([publicTrail]);
+
+      expect(
+        filterTrailheadTrails([publicTrail, nestedTrail], {
+          intent: ['destroy'],
+        })
+      ).toEqual([nestedTrail]);
+    });
+
+    test('intent filtering composes with glob include patterns using AND logic', () => {
+      expect(
+        filterTrailheadTrails([publicTrail, nestedTrail], {
+          include: ['entity.**'],
+          intent: ['read'],
+        })
+      ).toEqual([publicTrail]);
+    });
+
+    test('empty intent filters behave like no filter', () => {
+      expect(
+        filterTrailheadTrails([publicTrail, nestedTrail], {
+          intent: [],
+        })
+      ).toEqual([publicTrail, nestedTrail]);
+    });
   });
 
-  test('allows exact include to expose an internal trail', () => {
-    expect(
-      filterTrailheadTrails([internalTrail], {
-        include: ['entity.secret.rotate'],
-      })
-    ).toEqual([internalTrail]);
-  });
-
-  test('exclude patterns remove matches before include narrowing', () => {
-    expect(
-      filterTrailheadTrails([publicTrail], {
-        exclude: ['entity.*'],
-        include: ['entity.show'],
-      })
-    ).toEqual([]);
-  });
-
-  test('include patterns narrow the visible trail set', () => {
-    expect(
-      filterTrailheadTrails([publicTrail, nestedTrail], {
-        include: ['entity.**'],
-      })
-    ).toEqual([publicTrail, nestedTrail]);
-    expect(
-      filterTrailheadTrails([publicTrail, nestedTrail], {
-        include: ['entity.*'],
-      })
-    ).toEqual([publicTrail]);
-  });
-
-  test('intent filtering narrows visible trails by behavior class', () => {
-    expect(
-      filterTrailheadTrails([publicTrail, nestedTrail], {
-        intent: ['read'],
-      })
-    ).toEqual([publicTrail]);
-
-    expect(
-      filterTrailheadTrails([publicTrail, nestedTrail], {
-        intent: ['destroy'],
-      })
-    ).toEqual([nestedTrail]);
-  });
-
-  test('intent filtering composes with glob include patterns using AND logic', () => {
-    expect(
-      filterTrailheadTrails([publicTrail, nestedTrail], {
-        include: ['entity.**'],
-        intent: ['read'],
-      })
-    ).toEqual([publicTrail]);
-  });
-
-  test('empty intent filters behave like no filter', () => {
-    expect(
-      filterTrailheadTrails([publicTrail, nestedTrail], {
-        intent: [],
-      })
-    ).toEqual([publicTrail, nestedTrail]);
-  });
-
-  test('consumer trails are never exposed on trailheads', () => {
-    expect(
-      filterTrailheadTrails([consumerTrail], {
-        include: ['notify.email'],
-      })
-    ).toEqual([]);
-  });
-
-  test('legacy meta.internal is treated as internal visibility', () => {
-    // Default filter: legacy internal trails must not leak out.
-    expect(filterTrailheadTrails([legacyInternalTrail])).toEqual([]);
-
-    // Wildcard include must also refuse to expose the legacy internal trail.
-    expect(
-      filterTrailheadTrails([legacyInternalTrail], { include: ['entity.**'] })
-    ).toEqual([]);
-
-    // Explicit exact-id include is the documented escape hatch.
-    expect(
-      filterTrailheadTrails([legacyInternalTrail], {
-        include: ['entity.legacy.rotate'],
-      })
-    ).toEqual([legacyInternalTrail]);
-  });
-
-  test('entity.** include matches bare entity and descendants', () => {
-    // Regression guard for the ** terminal-segment zero-depth case.
-    expect(
-      filterTrailheadTrails([bareEntityTrail, publicTrail, otherTrail], {
-        include: ['entity.**'],
-      })
-    ).toEqual([bareEntityTrail, publicTrail]);
+  describe('consumer trails', () => {
+    test('consumer trails are never exposed on trailheads', () => {
+      expect(
+        filterTrailheadTrails([consumerTrail], {
+          include: ['notify.email'],
+        })
+      ).toEqual([]);
+    });
   });
 });

--- a/packages/core/src/__tests__/trailhead-filter.test.ts
+++ b/packages/core/src/__tests__/trailhead-filter.test.ts
@@ -17,11 +17,13 @@ const orderPlaced = signal('order.placed', {
 const publicTrail = trail('entity.show', {
   blaze: () => Result.ok({ ok: true }),
   input: z.object({}),
+  intent: 'read',
 });
 
 const nestedTrail = trail('entity.admin.audit', {
   blaze: () => Result.ok({ ok: true }),
   input: z.object({}),
+  intent: 'destroy',
 });
 
 const internalTrail = trail('entity.secret.rotate', {
@@ -120,6 +122,37 @@ describe('filterTrailheadTrails', () => {
         include: ['entity.*'],
       })
     ).toEqual([publicTrail]);
+  });
+
+  test('intent filtering narrows visible trails by behavior class', () => {
+    expect(
+      filterTrailheadTrails([publicTrail, nestedTrail], {
+        intent: ['read'],
+      })
+    ).toEqual([publicTrail]);
+
+    expect(
+      filterTrailheadTrails([publicTrail, nestedTrail], {
+        intent: ['destroy'],
+      })
+    ).toEqual([nestedTrail]);
+  });
+
+  test('intent filtering composes with glob include patterns using AND logic', () => {
+    expect(
+      filterTrailheadTrails([publicTrail, nestedTrail], {
+        include: ['entity.**'],
+        intent: ['read'],
+      })
+    ).toEqual([publicTrail]);
+  });
+
+  test('empty intent filters behave like no filter', () => {
+    expect(
+      filterTrailheadTrails([publicTrail, nestedTrail], {
+        intent: [],
+      })
+    ).toEqual([publicTrail, nestedTrail]);
   });
 
   test('consumer trails are never exposed on trailheads', () => {

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -16,6 +16,7 @@ import type { Topo } from './topo.js';
 
 import { createFireFn } from './fire.js';
 import type {
+  CrossFn,
   Implementation,
   TraceFn,
   TrailContext,
@@ -23,7 +24,13 @@ import type {
 } from './types.js';
 
 import { createTrailContext } from './context.js';
-import { CancelledError, InternalError, TrailsError } from './errors.js';
+import { buildCrossValidationSchema } from './cross-schema.js';
+import {
+  CancelledError,
+  InternalError,
+  NotFoundError,
+  TrailsError,
+} from './errors.js';
 import {
   TRACE_CONTEXT_KEY,
   completeRecord,
@@ -315,6 +322,70 @@ const runImplWithRootRecord = async (
   }
 };
 
+const resolveCrossTarget = (
+  trailOrId: AnyTrail | string,
+  topo: Topo | undefined
+): Result<AnyTrail, Error> => {
+  if (typeof trailOrId !== 'string') {
+    return Result.ok(trailOrId);
+  }
+
+  if (topo === undefined) {
+    return Result.err(
+      new NotFoundError(
+        `Trail "${trailOrId}" cannot be crossed without topo access`
+      )
+    );
+  }
+
+  const target = topo.get(trailOrId);
+  return target
+    ? Result.ok(target)
+    : Result.err(
+        new NotFoundError(
+          `Trail "${trailOrId}" not found in topo "${topo.name}"`
+        )
+      );
+};
+
+const bindCrossToCtx = (
+  ctx: TrailContext,
+  topo: Topo | undefined,
+  options: ExecuteTrailOptions | undefined
+): TrailContext => {
+  if (ctx.cross !== undefined) {
+    return ctx;
+  }
+
+  const {
+    createContext: _omit,
+    validationSchema: _omitSchema,
+    ...forwarded
+  } = options ?? {};
+  const cross: CrossFn = async (
+    trailOrId: AnyTrail | string,
+    input: unknown
+  ) => {
+    const target = resolveCrossTarget(trailOrId, topo);
+    if (target.isErr()) {
+      return target;
+    }
+
+    return await // eslint-disable-next-line no-use-before-define -- executor closure runs only after executeTrail is defined
+    executeTrail(target.value, input, {
+      ...forwarded,
+      ctx,
+      topo,
+      validationSchema: buildCrossValidationSchema(target.value),
+    });
+  };
+
+  return {
+    ...ctx,
+    cross,
+  };
+};
+
 const bindFireToCtx = (
   ctx: TrailContext,
   topo: Topo | undefined,
@@ -346,6 +417,15 @@ const bindFireToCtx = (
   return { ...ctx, fire };
 };
 
+const bindCrossAtLayerBoundary =
+  <I, O>(
+    implementation: Implementation<I, O>,
+    topo: Topo | undefined,
+    options: ExecuteTrailOptions | undefined
+  ): Implementation<I, O> =>
+  (input, ctx) =>
+    implementation(input, bindCrossToCtx(ctx, topo, options));
+
 const bindFireAtLayerBoundary = <I, O>(
   implementation: Implementation<I, O>,
   topo: Topo | undefined,
@@ -365,12 +445,20 @@ const prepareRunImpl = (
   topo: Topo | undefined,
   options: ExecuteTrailOptions | undefined
 ): {
-  readonly ctxWithFire: TrailContext;
+  readonly ctxWithIntrinsics: TrailContext;
   readonly impl: Implementation<unknown, unknown>;
 } => {
-  const ctxWithFire = bindFireToCtx(ctx, topo, options);
+  const ctxWithIntrinsics = bindFireToCtx(
+    bindCrossToCtx(ctx, topo, options),
+    topo,
+    options
+  );
   let impl = bindFireAtLayerBoundary(
-    trail.blaze as Implementation<unknown, unknown>,
+    bindCrossAtLayerBoundary(
+      trail.blaze as Implementation<unknown, unknown>,
+      topo,
+      options
+    ),
     topo,
     options
   );
@@ -379,7 +467,11 @@ const prepareRunImpl = (
     const layer = layers[i];
     if (layer) {
       impl = bindFireAtLayerBoundary(
-        layer.wrap(trail, impl as never) as Implementation<unknown, unknown>,
+        bindCrossAtLayerBoundary(
+          layer.wrap(trail, impl as never) as Implementation<unknown, unknown>,
+          topo,
+          options
+        ),
         topo,
         options
       );
@@ -387,7 +479,7 @@ const prepareRunImpl = (
   }
 
   return {
-    ctxWithFire,
+    ctxWithIntrinsics,
     impl,
   };
 };
@@ -419,7 +511,7 @@ const runTrail = async (
   return await runImplWithRootRecord(
     prepared.impl,
     input,
-    prepared.ctxWithFire,
+    prepared.ctxWithIntrinsics,
     record,
     sink
   );

--- a/packages/core/src/trailhead-filter.ts
+++ b/packages/core/src/trailhead-filter.ts
@@ -1,4 +1,4 @@
-import type { Trail } from './trail.js';
+import type { Intent, Trail } from './trail.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -9,6 +9,8 @@ export interface TrailheadFilterOptions {
   readonly include?: readonly string[] | undefined;
   /** Glob patterns that remove matching trail IDs. */
   readonly exclude?: readonly string[] | undefined;
+  /** Allowed intents for exposed trailheads. Empty arrays act as no filter. */
+  readonly intent?: readonly Intent[] | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -145,6 +147,12 @@ const passesIncludeFilter = (
   include.length === 0 ||
   matchesAnyPattern(trailId, include);
 
+const passesIntentFilter = (
+  trail: Trail<unknown, unknown, unknown>,
+  intent: readonly Intent[] | undefined
+): boolean =>
+  intent === undefined || intent.length === 0 || intent.includes(trail.intent);
+
 export const shouldIncludeTrailForTrailhead = (
   trail: Trail<unknown, unknown, unknown>,
   options: TrailheadFilterOptions = {}
@@ -153,7 +161,7 @@ export const shouldIncludeTrailForTrailhead = (
     return false;
   }
 
-  const { exclude, include } = options;
+  const { exclude, include, intent } = options;
   if (!isVisibleToTrailheads(trail, include)) {
     return false;
   }
@@ -162,7 +170,9 @@ export const shouldIncludeTrailForTrailhead = (
     return false;
   }
 
-  return passesIncludeFilter(trail.id, include);
+  return (
+    passesIncludeFilter(trail.id, include) && passesIntentFilter(trail, intent)
+  );
 };
 
 export const filterTrailheadTrails = (

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -219,6 +219,27 @@ describe('buildHttpRoutes', () => {
       expect(result.value.map((route) => route.trailId)).toEqual(['echo']);
     });
 
+    test('intent filters narrow the route table', () => {
+      const app = topo('testapp', { deleteTrail, echoTrail });
+      const result = buildHttpRoutes(app, { intent: ['read'] });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.value.map((route) => route.trailId)).toEqual(['echo']);
+    });
+
+    test('intent filters compose with include patterns using AND logic', () => {
+      const app = topo('testapp', { deleteTrail, echoTrail });
+      const result = buildHttpRoutes(app, {
+        include: ['item.*', 'echo'],
+        intent: ['destroy'],
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.value.map((route) => route.trailId)).toEqual([
+        'item.delete',
+      ]);
+    });
+
     test('consumer trails (on: [...]) are skipped', () => {
       const consumerTrail = trail('notify.email', {
         blaze: (input: { orderId: string }) =>

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -15,6 +15,7 @@ import {
   validateEstablishedTopo,
 } from '@ontrails/core';
 import type {
+  Intent,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -37,6 +38,7 @@ export interface BuildHttpRoutesOptions {
     | undefined;
   readonly exclude?: readonly string[] | undefined;
   readonly include?: readonly string[] | undefined;
+  readonly intent?: readonly Intent[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
   /** Set to `false` to skip topo validation while building routes. */
@@ -147,6 +149,7 @@ const eligibleTrails = (
   filterTrailheadTrails(app.list(), {
     exclude: options.exclude,
     include: options.include,
+    intent: options.intent,
   });
 
 /** Build a single route definition from a trail. */

--- a/packages/http/src/hono/__tests__/trailhead.test.ts
+++ b/packages/http/src/hono/__tests__/trailhead.test.ts
@@ -197,6 +197,22 @@ describe('trailhead (Hono connector)', () => {
       expect(await res.json()).toEqual({ data: { ok: true } });
     });
 
+    test('intent filters only register matching routes', async () => {
+      const app = topo('testapp', { createTrail, echoTrail });
+      const hono = await trailhead(app, {
+        intent: ['read'],
+        serve: false,
+      });
+
+      const readRes = await request(hono, 'GET', '/echo?message=hello');
+      expect(readRes.status).toBe(200);
+
+      const writeRes = await request(hono, 'POST', '/item/create', {
+        name: 'Widget',
+      });
+      expect(writeRes.status).toBe(404);
+    });
+
     test('POST with empty input schema succeeds without a body', async () => {
       const emptyWriteTrail = trail('empty.write', {
         blaze: () => Result.ok({ ok: true }),

--- a/packages/http/src/hono/trailhead.ts
+++ b/packages/http/src/hono/trailhead.ts
@@ -12,6 +12,7 @@
 
 import { isTrailsError, mapTransportError } from '@ontrails/core';
 import type {
+  Intent,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -41,6 +42,7 @@ export interface TrailheadHttpOptions {
   readonly exclude?: readonly string[] | undefined;
   readonly hostname?: string | undefined;
   readonly include?: readonly string[] | undefined;
+  readonly intent?: readonly Intent[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly name?: string | undefined;
   readonly port?: number | undefined;
@@ -321,6 +323,7 @@ export const trailhead = async (
     createContext: options.createContext,
     exclude: options.exclude,
     include: options.include,
+    intent: options.intent,
     layers: options.layers,
     resources: options.resources,
     validate: options.validate,

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -352,16 +352,23 @@ describe('buildMcpTools', () => {
       expect(tools.map((tool) => tool.trailId)).toEqual(['echo']);
     });
 
-    test('legacy includeTrails wins over excludeTrails for overlapping ids', () => {
+    test('intent filters narrow the tool list', () => {
       const app = topo('myapp', { deleteTrail, echoTrail, failTrail });
       const tools = buildTools(app, {
-        excludeTrails: ['fail'],
-        includeTrails: ['echo', 'fail'],
+        intent: ['read'],
       });
 
-      // Historical MCP semantics: include wins when both list the same id.
-      const ids = tools.map((tool) => tool.trailId).toSorted();
-      expect(ids).toEqual(['echo', 'fail']);
+      expect(tools.map((tool) => tool.trailId)).toEqual(['echo']);
+    });
+
+    test('intent filters compose with include patterns using AND logic', () => {
+      const app = topo('myapp', { deleteTrail, echoTrail });
+      const tools = buildTools(app, {
+        include: ['item.*', 'echo'],
+        intent: ['destroy'],
+      });
+
+      expect(tools.map((tool) => tool.trailId)).toEqual(['item.delete']);
     });
   });
 

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -18,6 +18,7 @@ import {
 } from '@ontrails/core';
 import type {
   BlobRef,
+  Intent,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -46,6 +47,7 @@ export interface BuildMcpToolsOptions {
   readonly excludeTrails?: readonly string[] | undefined;
   readonly include?: readonly string[] | undefined;
   readonly includeTrails?: readonly string[] | undefined;
+  readonly intent?: readonly Intent[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
   /** Set to `false` to skip topo validation while building tools. */
@@ -402,6 +404,7 @@ const eligibleTrails = (
   const filtered = filterTrailheadTrails(app.list(), {
     exclude: dedupePatterns(options.exclude, options.excludeTrails),
     include: dedupePatterns(options.include, options.includeTrails),
+    intent: options.intent,
   });
   if (legacyOverrides === undefined) {
     return filtered;

--- a/packages/mcp/src/trailhead.ts
+++ b/packages/mcp/src/trailhead.ts
@@ -15,6 +15,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type {
+  Intent,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -42,6 +43,7 @@ export interface TrailheadMcpOptions {
   readonly excludeTrails?: readonly string[] | undefined;
   readonly include?: readonly string[] | undefined;
   readonly includeTrails?: readonly string[] | undefined;
+  readonly intent?: readonly Intent[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
   readonly serverInfo?:
@@ -159,6 +161,7 @@ export const trailhead = async (
     excludeTrails: options.excludeTrails,
     include: options.include,
     includeTrails: options.includeTrails,
+    intent: options.intent,
     layers: options.layers,
     resources: options.resources,
     validate: options.validate,

--- a/packages/schema/src/__tests__/openapi.test.ts
+++ b/packages/schema/src/__tests__/openapi.test.ts
@@ -445,6 +445,47 @@ const registerMetadataAndStructureTests = () => {
       expect(spec.paths['/entity/show']).toBeDefined();
       expect(spec.paths['/entity/onChanged']).toBeUndefined();
     });
+
+    test('intent filters narrow the generated paths', () => {
+      const readTrail = trail('entity.show', {
+        blaze: noop,
+        input: z.object({ id: z.string() }),
+        intent: 'read',
+      });
+      const destroyTrail = trail('entity.remove', {
+        blaze: noop,
+        input: z.object({ id: z.string() }),
+        intent: 'destroy',
+      });
+
+      const spec = generateOpenApiSpec(topoFrom({ destroyTrail, readTrail }), {
+        intent: ['read'],
+      });
+
+      expect(spec.paths['/entity/show']).toBeDefined();
+      expect(spec.paths['/entity/remove']).toBeUndefined();
+    });
+
+    test('intent filters compose with include patterns using AND logic', () => {
+      const readTrail = trail('entity.show', {
+        blaze: noop,
+        input: z.object({ id: z.string() }),
+        intent: 'read',
+      });
+      const destroyTrail = trail('entity.remove', {
+        blaze: noop,
+        input: z.object({ id: z.string() }),
+        intent: 'destroy',
+      });
+
+      const spec = generateOpenApiSpec(topoFrom({ destroyTrail, readTrail }), {
+        include: ['entity.*'],
+        intent: ['destroy'],
+      });
+
+      expect(spec.paths['/entity/show']).toBeUndefined();
+      expect(spec.paths['/entity/remove']).toBeDefined();
+    });
   });
 
   describe('spec structure', () => {

--- a/packages/schema/src/openapi.ts
+++ b/packages/schema/src/openapi.ts
@@ -11,7 +11,7 @@ import {
   validateDraftFreeTopo,
   zodToJsonSchema,
 } from '@ontrails/core';
-import type { Topo, Trail } from '@ontrails/core';
+import type { Intent, Topo, Trail } from '@ontrails/core';
 
 import type { JsonSchema } from './types.js';
 
@@ -33,16 +33,9 @@ export interface OpenApiOptions {
   readonly servers?: readonly OpenApiServer[] | undefined;
   /** Prefix for all paths. Default: `''` */
   readonly basePath?: string | undefined;
-  /**
-   * Glob patterns that keep only matching trail IDs in the generated spec.
-   * Mirrors the `include` option on other trailhead builders.
-   */
-  readonly include?: readonly string[] | undefined;
-  /**
-   * Glob patterns that remove matching trail IDs from the generated spec.
-   * Mirrors the `exclude` option on other trailhead builders.
-   */
   readonly exclude?: readonly string[] | undefined;
+  readonly include?: readonly string[] | undefined;
+  readonly intent?: readonly Intent[] | undefined;
 }
 
 /** Minimal OpenAPI 3.1 spec shape — intentionally plain objects, no heavy library. */
@@ -303,6 +296,7 @@ const collectPaths = (
   for (const t of filterTrailheadTrails(app.list(), {
     exclude: options?.exclude,
     include: options?.include,
+    intent: options?.intent,
   })) {
     const method = intentToMethod[t.intent] ?? 'post';
     paths[trailIdToPath(t.id, basePath)] = {

--- a/packages/warden/src/__tests__/dead-internal-trail.test.ts
+++ b/packages/warden/src/__tests__/dead-internal-trail.test.ts
@@ -64,4 +64,18 @@ trail('entity.audit', {
 
     expect(deadInternalTrail.check(code, TEST_FILE)).toEqual([]);
   });
+
+  test('stays quiet when on: is a module-level identifier reference', () => {
+    const code = `
+const activationSignals = ['entity.created', 'entity.updated'];
+
+trail('entity.audit', {
+  visibility: 'internal',
+  on: activationSignals,
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    expect(deadInternalTrail.check(code, TEST_FILE)).toEqual([]);
+  });
 });

--- a/packages/warden/src/__tests__/dead-internal-trail.test.ts
+++ b/packages/warden/src/__tests__/dead-internal-trail.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+
+import { deadInternalTrail } from '../rules/dead-internal-trail.js';
+
+const TEST_FILE = 'entity.ts';
+
+describe('dead-internal-trail', () => {
+  test('warns when an internal trail is never crossed and has no on: activation', () => {
+    const code = `
+trail('entity.sync', {
+  visibility: 'internal',
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = deadInternalTrail.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('dead-internal-trail');
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toContain('entity.sync');
+  });
+
+  test('stays quiet when another trail crosses the internal trail in the same file', () => {
+    const code = `
+trail('entity.public', {
+  crosses: ['entity.sync'],
+  blaze: async (_input, ctx) => ctx.cross('entity.sync', {}),
+});
+
+trail('entity.sync', {
+  visibility: 'internal',
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    expect(deadInternalTrail.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('stays quiet when project context marks the trail as crossed elsewhere', () => {
+    const code = `
+trail('entity.sync', {
+  visibility: 'internal',
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = deadInternalTrail.checkWithContext(code, TEST_FILE, {
+      crossTargetTrailIds: new Set(['entity.sync']),
+      knownTrailIds: new Set(['entity.public', 'entity.sync']),
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('stays quiet when the internal trail has on: activation', () => {
+    const code = `
+trail('entity.audit', {
+  visibility: 'internal',
+  on: ['entity.created'],
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    expect(deadInternalTrail.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/intent-propagation.test.ts
+++ b/packages/warden/src/__tests__/intent-propagation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+
+import { intentPropagation } from '../rules/intent-propagation.js';
+
+const TEST_FILE = 'entity.ts';
+
+describe('intent-propagation', () => {
+  test('warns when a read trail crosses a write trail', () => {
+    const code = `
+trail('entity.read', {
+  intent: 'read',
+  crosses: ['entity.refresh'],
+  blaze: async (_input, ctx) => ctx.cross('entity.refresh', {}),
+});
+
+trail('entity.refresh', {
+  intent: 'write',
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = intentPropagation.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('intent-propagation');
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toContain('entity.refresh');
+    expect(diagnostics[0]?.message).toContain("intent: 'write'");
+  });
+
+  test('warns when project context resolves a crossed trail to destroy intent', () => {
+    const code = `
+trail('entity.read', {
+  intent: 'read',
+  crosses: ['entity.delete'],
+  blaze: async (_input, ctx) => ctx.cross('entity.delete', {}),
+});
+`;
+
+    const diagnostics = intentPropagation.checkWithContext(code, TEST_FILE, {
+      knownTrailIds: new Set(['entity.delete', 'entity.read']),
+      trailIntentsById: new Map([
+        ['entity.delete', 'destroy'],
+        ['entity.read', 'read'],
+      ]),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain("intent: 'destroy'");
+  });
+
+  test('stays quiet when a read trail crosses another read trail', () => {
+    const code = `
+trail('entity.read', {
+  intent: 'read',
+  crosses: ['entity.lookup'],
+  blaze: async (_input, ctx) => ctx.cross('entity.lookup', {}),
+});
+
+trail('entity.lookup', {
+  intent: 'read',
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    expect(intentPropagation.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('stays quiet when the entry trail is not read-only', () => {
+    const code = `
+trail('entity.update', {
+  intent: 'write',
+  crosses: ['entity.delete'],
+  blaze: async (_input, ctx) => ctx.cross('entity.delete', {}),
+});
+
+trail('entity.delete', {
+  intent: 'destroy',
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    expect(intentPropagation.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/missing-visibility.test.ts
+++ b/packages/warden/src/__tests__/missing-visibility.test.ts
@@ -25,6 +25,43 @@ trail('entity.resolve', {
     expect(diagnostics[0]?.message).toContain("visibility: 'internal'");
   });
 
+  describe('hasLegacyMetaInternal detection', () => {
+    test('treats trail with meta: { internal: true } as internal', () => {
+      const code = `
+trail('entity.resolve', {
+  meta: { internal: true },
+  crossInput: z.object({ forkedFrom: z.string() }),
+  blaze: async () => Result.ok({}),
+});
+`;
+
+      expect(
+        missingVisibility.checkWithContext(code, TEST_FILE, {
+          crossTargetTrailIds: new Set(['entity.resolve']),
+          knownTrailIds: new Set(['entity.resolve']),
+        })
+      ).toEqual([]);
+    });
+
+    test('does not false-positive on string values containing "internal: true"', () => {
+      const code = `
+trail('entity.resolve', {
+  meta: { description: "this has internal: true in it" },
+  crossInput: z.object({ forkedFrom: z.string() }),
+  blaze: async () => Result.ok({}),
+});
+`;
+
+      const diagnostics = missingVisibility.checkWithContext(code, TEST_FILE, {
+        crossTargetTrailIds: new Set(['entity.resolve']),
+        knownTrailIds: new Set(['entity.resolve']),
+      });
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.rule).toBe('missing-visibility');
+    });
+  });
+
   test('stays quiet when the crossed trail is already internal', () => {
     const code = `
 trail('entity.resolve', {

--- a/packages/warden/src/__tests__/missing-visibility.test.ts
+++ b/packages/warden/src/__tests__/missing-visibility.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+
+import { missingVisibility } from '../rules/missing-visibility.js';
+
+const TEST_FILE = 'entity.ts';
+
+describe('missing-visibility', () => {
+  test('warns when a crossed trail has required crossInput but remains public', () => {
+    const code = `
+trail('entity.resolve', {
+  crossInput: z.object({ forkedFrom: z.string() }),
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = missingVisibility.checkWithContext(code, TEST_FILE, {
+      crossTargetTrailIds: new Set(['entity.resolve']),
+      knownTrailIds: new Set(['entity.resolve']),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('missing-visibility');
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toContain('entity.resolve');
+    expect(diagnostics[0]?.message).toContain("visibility: 'internal'");
+  });
+
+  test('stays quiet when the crossed trail is already internal', () => {
+    const code = `
+trail('entity.resolve', {
+  visibility: 'internal',
+  crossInput: z.object({ forkedFrom: z.string() }),
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    expect(
+      missingVisibility.checkWithContext(code, TEST_FILE, {
+        crossTargetTrailIds: new Set(['entity.resolve']),
+        knownTrailIds: new Set(['entity.resolve']),
+      })
+    ).toEqual([]);
+  });
+
+  test('stays quiet when crossInput fields are optional', () => {
+    const code = `
+trail('entity.resolve', {
+  crossInput: z.object({ forkedFrom: z.string().optional() }),
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    expect(
+      missingVisibility.checkWithContext(code, TEST_FILE, {
+        crossTargetTrailIds: new Set(['entity.resolve']),
+        knownTrailIds: new Set(['entity.resolve']),
+      })
+    ).toEqual([]);
+  });
+
+  test('stays quiet when the trail is not crossed', () => {
+    const code = `
+trail('entity.resolve', {
+  crossInput: z.object({ forkedFrom: z.string() }),
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    expect(missingVisibility.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 16 rule trails', () => {
-    expect(wardenTopo.count).toBe(16);
+  test('contains all 19 rule trails', () => {
+    expect(wardenTopo.count).toBe(19);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/__tests__/wrap-rule.test.ts
+++ b/packages/warden/src/__tests__/wrap-rule.test.ts
@@ -6,7 +6,7 @@ import { wrapRule } from '../trails/wrap-rule.js';
 import type { ProjectAwareWardenRule } from '../rules/types.js';
 
 describe('wrapRule', () => {
-  test('preserves undefined knownResourceIds and defaults knownTrailIds to empty set', async () => {
+  test('omits absent resource ids and defaults knownTrailIds to empty set', async () => {
     let capturedContext:
       | {
           readonly knownResourceIds?: ReadonlySet<string>;
@@ -34,8 +34,8 @@ describe('wrapRule', () => {
     expect(result.isOk()).toBe(true);
     expect(result.unwrap()).toEqual({ diagnostics: [] });
     expect(capturedContext).toEqual({
-      knownResourceIds: undefined,
       knownTrailIds: new Set<string>(),
     });
+    expect(capturedContext?.knownResourceIds).toBeUndefined();
   });
 });

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -12,8 +12,10 @@ import type { Topo } from '@ontrails/core';
 import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
 import {
+  collectCrossTargetTrailIds,
   collectResourceDefinitionIds,
   collectSignalDefinitionIds,
+  collectTrailIntentsById,
   findConfigProperty,
   findTrailDefinitions,
   parse,
@@ -93,6 +95,24 @@ interface SourceFile {
   readonly sourceCode: string;
 }
 
+interface MutableProjectContext {
+  crossTargetTrailIds: Set<string>;
+  detourTargetTrailIds: Set<string>;
+  knownResourceIds: Set<string>;
+  knownSignalIds: Set<string>;
+  knownTrailIds: Set<string>;
+  trailIntentsById: Map<string, 'destroy' | 'read' | 'write'>;
+}
+
+const createMutableProjectContext = (): MutableProjectContext => ({
+  crossTargetTrailIds: new Set<string>(),
+  detourTargetTrailIds: new Set<string>(),
+  knownResourceIds: new Set<string>(),
+  knownSignalIds: new Set<string>(),
+  knownTrailIds: new Set<string>(),
+  trailIntentsById: new Map<string, 'destroy' | 'read' | 'write'>(),
+});
+
 const collectKnownTrailIds = (
   sourceCode: string,
   filePath: string,
@@ -134,6 +154,20 @@ const collectDetourTargetTrailIds = (
   }
 };
 
+const collectCrossedTrailIds = (
+  sourceCode: string,
+  filePath: string,
+  crossTargetTrailIds: Set<string>
+): void => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return;
+  }
+  for (const id of collectCrossTargetTrailIds(ast, sourceCode)) {
+    crossTargetTrailIds.add(id);
+  }
+};
+
 const collectKnownResourceIds = (
   sourceCode: string,
   filePath: string,
@@ -159,6 +193,20 @@ const collectKnownSignalIds = (
   }
   for (const id of collectSignalDefinitionIds(ast)) {
     knownSignalIds.add(id);
+  }
+};
+
+const collectTrailIntents = (
+  sourceCode: string,
+  filePath: string,
+  trailIntentsById: Map<string, 'destroy' | 'read' | 'write'>
+): void => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return;
+  }
+  for (const [id, intent] of collectTrailIntentsById(ast)) {
+    trailIntentsById.set(id, intent);
   }
 };
 
@@ -203,57 +251,105 @@ const collectTopoDetourTargetTrailIds = (
   return detourTargetTrailIds;
 };
 
-const buildProjectContextFromTopo = (appTopo: Topo): ProjectContext => {
-  const knownTrailIds = new Set<string>(appTopo.trails.keys());
-  const knownResourceIds = new Set<string>(appTopo.resources.keys());
-  const knownSignalIds = new Set<string>(appTopo.signals.keys());
-  const detourTargetTrailIds = collectTopoDetourTargetTrailIds(appTopo);
+const collectTopoKnownIds = (
+  appTopo: Topo,
+  context: MutableProjectContext
+): void => {
+  for (const id of appTopo.trails.keys()) {
+    context.knownTrailIds.add(id);
+  }
 
-  return {
-    detourTargetTrailIds,
-    knownResourceIds,
-    knownSignalIds,
-    knownTrailIds,
-  };
+  for (const id of appTopo.resources.keys()) {
+    context.knownResourceIds.add(id);
+  }
+
+  for (const id of appTopo.signals.keys()) {
+    context.knownSignalIds.add(id);
+  }
+};
+
+const collectTopoDetourIds = (
+  appTopo: Topo,
+  context: MutableProjectContext
+): void => {
+  for (const id of collectTopoDetourTargetTrailIds(appTopo)) {
+    context.detourTargetTrailIds.add(id);
+  }
+};
+
+const collectTopoCrossesAndIntents = (
+  appTopo: Topo,
+  context: MutableProjectContext
+): void => {
+  for (const trail of appTopo.trails.values()) {
+    context.trailIntentsById.set(trail.id, trail.intent);
+    for (const crossedTrailId of trail.crosses) {
+      context.crossTargetTrailIds.add(crossedTrailId);
+    }
+  }
+};
+
+const collectTopoTrailContext = (
+  appTopo: Topo,
+  context: MutableProjectContext
+): void => {
+  collectTopoKnownIds(appTopo, context);
+  collectTopoDetourIds(appTopo, context);
+  collectTopoCrossesAndIntents(appTopo, context);
+};
+
+const buildProjectContextFromTopo = (appTopo: Topo): ProjectContext => {
+  const context = createMutableProjectContext();
+  collectTopoTrailContext(appTopo, context);
+  return context;
+};
+
+const collectFileProjectContext = (
+  sourceFile: SourceFile,
+  context: MutableProjectContext
+): void => {
+  collectKnownTrailIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.knownTrailIds
+  );
+  collectKnownResourceIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.knownResourceIds
+  );
+  collectKnownSignalIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.knownSignalIds
+  );
+  collectCrossedTrailIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.crossTargetTrailIds
+  );
+  collectDetourTargetTrailIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.detourTargetTrailIds
+  );
+  collectTrailIntents(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.trailIntentsById
+  );
 };
 
 const buildProjectContextFromFiles = (
   sourceFiles: readonly SourceFile[]
 ): ProjectContext => {
-  const knownTrailIds = new Set<string>();
-  const knownResourceIds = new Set<string>();
-  const knownSignalIds = new Set<string>();
-  const detourTargetTrailIds = new Set<string>();
+  const context = createMutableProjectContext();
 
   for (const sourceFile of sourceFiles) {
-    collectKnownTrailIds(
-      sourceFile.sourceCode,
-      sourceFile.filePath,
-      knownTrailIds
-    );
-    collectKnownResourceIds(
-      sourceFile.sourceCode,
-      sourceFile.filePath,
-      knownResourceIds
-    );
-    collectKnownSignalIds(
-      sourceFile.sourceCode,
-      sourceFile.filePath,
-      knownSignalIds
-    );
-    collectDetourTargetTrailIds(
-      sourceFile.sourceCode,
-      sourceFile.filePath,
-      detourTargetTrailIds
-    );
+    collectFileProjectContext(sourceFile, context);
   }
 
-  return {
-    detourTargetTrailIds,
-    knownResourceIds,
-    knownSignalIds,
-    knownTrailIds,
-  };
+  return context;
 };
 
 const isProjectAwareRule = (rule: WardenRule): rule is ProjectAwareWardenRule =>

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -19,10 +19,13 @@ export type {
 // Individual rules
 export { noThrowInImplementation } from './rules/no-throw-in-implementation.js';
 export { contextNoTrailheadTypes } from './rules/context-no-trailhead-types.js';
+export { deadInternalTrail } from './rules/dead-internal-trail.js';
 export { draftFileMarking } from './rules/draft-file-marking.js';
 export { draftVisibleDebt } from './rules/draft-visible-debt.js';
 export { errorMappingCompleteness } from './rules/error-mapping-completeness.js';
 export { firesDeclarations } from './rules/fires-declarations.js';
+export { intentPropagation } from './rules/intent-propagation.js';
+export { missingVisibility } from './rules/missing-visibility.js';
 export { onReferencesExist } from './rules/on-references-exist.js';
 export { validDetourRefs } from './rules/valid-detour-refs.js';
 export { noDirectImplInRoute } from './rules/no-direct-impl-in-route.js';
@@ -78,10 +81,13 @@ export { runWardenTrails } from './trails/run.js';
 export {
   contextNoTrailheadTypesTrail,
   crossDeclarationsTrail,
+  deadInternalTrailTrail,
   diagnosticSchema,
   errorMappingCompletenessTrail,
   firesDeclarationsTrail,
   implementationReturnsResultTrail,
+  intentPropagationTrail,
+  missingVisibilityTrail,
   noDirectImplInRouteTrail,
   noDirectImplementationCallTrail,
   noSyncResultAssumptionTrail,

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -545,7 +545,8 @@ export const collectNamedTrailIds = (
   return ids;
 };
 
-const getCrossElements = (config: AstNode): readonly AstNode[] => {
+/** Extract the raw `crosses: [...]` array elements from a trail config. */
+export const getCrossElements = (config: AstNode): readonly AstNode[] => {
   const crossesProp = findConfigProperty(config, 'crosses');
   if (!crossesProp) {
     return [];
@@ -562,7 +563,13 @@ const getCrossElements = (config: AstNode): readonly AstNode[] => {
   return elements ?? [];
 };
 
-const resolveCrossElementId = (
+/**
+ * Resolve a single `crosses: [...]` element to its target trail ID.
+ *
+ * Handles string literals, identifier references (via `namedTrailIds` map or
+ * `const NAME = '...'` resolution), and inline `trail(...)` call expressions.
+ */
+export const resolveCrossElementId = (
   element: AstNode,
   sourceCode: string,
   namedTrailIds: ReadonlyMap<string, string>
@@ -582,6 +589,23 @@ const resolveCrossElementId = (
   return inlineDef?.kind === 'trail' ? inlineDef.id : null;
 };
 
+/**
+ * Collect all trail IDs referenced by a single trail definition's
+ * `crosses: [...]` array, deduplicated.
+ */
+export const extractDefinitionCrossTargetIds = (
+  config: AstNode,
+  sourceCode: string,
+  namedTrailIds: ReadonlyMap<string, string>
+): readonly string[] => [
+  ...new Set(
+    getCrossElements(config).flatMap((element) => {
+      const id = resolveCrossElementId(element, sourceCode, namedTrailIds);
+      return id ? [id] : [];
+    })
+  ),
+];
+
 /** Collect all trail IDs referenced by declared `crosses: [...]` arrays. */
 export const collectCrossTargetTrailIds = (
   ast: AstNode,
@@ -595,11 +619,12 @@ export const collectCrossTargetTrailIds = (
       continue;
     }
 
-    for (const element of getCrossElements(def.config)) {
-      const id = resolveCrossElementId(element, sourceCode, namedTrailIds);
-      if (id) {
-        ids.add(id);
-      }
+    for (const id of extractDefinitionCrossTargetIds(
+      def.config,
+      sourceCode,
+      namedTrailIds
+    )) {
+      ids.add(id);
     }
   }
 

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -16,10 +16,18 @@ export interface AstNode {
   readonly start: number;
   readonly end: number;
   readonly key?: { readonly name?: string };
-  readonly value?: AstNode;
+  readonly value?: unknown;
   readonly body?: AstNode | readonly AstNode[];
   readonly [key: string]: unknown;
 }
+
+interface StringLiteralNode extends AstNode {
+  readonly type: 'Literal' | 'StringLiteral';
+  readonly value?: unknown;
+}
+
+const isAstNode = (value: unknown): value is AstNode =>
+  Boolean(value && typeof value === 'object' && (value as AstNode).type);
 
 // ---------------------------------------------------------------------------
 // Parser
@@ -130,7 +138,9 @@ export const identifierName = (node: AstNode | undefined): string | null => {
 };
 
 /** Check if a node is a string literal. */
-export const isStringLiteral = (node: AstNode | undefined): node is AstNode => {
+export const isStringLiteral = (
+  node: AstNode | undefined
+): node is StringLiteralNode => {
   if (!node) {
     return false;
   }
@@ -456,7 +466,11 @@ const extractBlazeFromConfig = (config: AstNode): AstNode[] => {
     return bodies;
   }
   for (const prop of properties) {
-    if (prop.type === 'Property' && prop.key?.name === 'blaze' && prop.value) {
+    if (
+      prop.type === 'Property' &&
+      prop.key?.name === 'blaze' &&
+      isAstNode(prop.value)
+    ) {
       bodies.push(prop.value);
     }
   }
@@ -500,6 +514,121 @@ export const collectSignalDefinitionIds = (
     }
   }
   return ids;
+};
+
+/** Collect `const foo = trail('id', ...)` bindings from a parsed file. */
+export const collectNamedTrailIds = (
+  ast: AstNode
+): ReadonlyMap<string, string> => {
+  const ids = new Map<string, string>();
+
+  walk(ast, (node) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+
+    const { id, init } = node as unknown as {
+      readonly id?: AstNode;
+      readonly init?: AstNode;
+    };
+    if (!init) {
+      return;
+    }
+
+    const def = extractTrailDefinition(init);
+    const name = extractBindingName(id);
+    if (def?.kind === 'trail' && name) {
+      ids.set(name, def.id);
+    }
+  });
+
+  return ids;
+};
+
+const getCrossElements = (config: AstNode): readonly AstNode[] => {
+  const crossesProp = findConfigProperty(config, 'crosses');
+  if (!crossesProp) {
+    return [];
+  }
+
+  const arrayNode = crossesProp.value;
+  if (!arrayNode || (arrayNode as AstNode).type !== 'ArrayExpression') {
+    return [];
+  }
+
+  const elements = (arrayNode as AstNode)['elements'] as
+    | readonly AstNode[]
+    | undefined;
+  return elements ?? [];
+};
+
+const resolveCrossElementId = (
+  element: AstNode,
+  sourceCode: string,
+  namedTrailIds: ReadonlyMap<string, string>
+): string | null => {
+  if (isStringLiteral(element)) {
+    return getStringValue(element);
+  }
+
+  if (element.type === 'Identifier') {
+    const name = identifierName(element);
+    return name
+      ? (namedTrailIds.get(name) ?? resolveConstString(name, sourceCode))
+      : null;
+  }
+
+  const inlineDef = extractTrailDefinition(element);
+  return inlineDef?.kind === 'trail' ? inlineDef.id : null;
+};
+
+/** Collect all trail IDs referenced by declared `crosses: [...]` arrays. */
+export const collectCrossTargetTrailIds = (
+  ast: AstNode,
+  sourceCode: string
+): ReadonlySet<string> => {
+  const ids = new Set<string>();
+  const namedTrailIds = collectNamedTrailIds(ast);
+
+  for (const def of findTrailDefinitions(ast)) {
+    if (def.kind !== 'trail') {
+      continue;
+    }
+
+    for (const element of getCrossElements(def.config)) {
+      const id = resolveCrossElementId(element, sourceCode, namedTrailIds);
+      if (id) {
+        ids.add(id);
+      }
+    }
+  }
+
+  return ids;
+};
+
+const extractTrailIntent = (config: AstNode): 'destroy' | 'read' | 'write' => {
+  const intentProp = findConfigProperty(config, 'intent');
+  if (!intentProp || !isStringLiteral(intentProp.value as AstNode)) {
+    return 'write';
+  }
+
+  const value = getStringValue(intentProp.value as AstNode);
+  return value === 'destroy' || value === 'read' ? value : 'write';
+};
+
+/** Collect the normalized intent for every trail definition in a parsed file. */
+export const collectTrailIntentsById = (
+  ast: AstNode
+): ReadonlyMap<string, 'destroy' | 'read' | 'write'> => {
+  const intents = new Map<string, 'destroy' | 'read' | 'write'>();
+
+  for (const def of findTrailDefinitions(ast)) {
+    if (def.kind === 'trail') {
+      intents.set(def.id, extractTrailIntent(def.config));
+    }
+  }
+
+  return intents;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/warden/src/rules/dead-internal-trail.ts
+++ b/packages/warden/src/rules/dead-internal-trail.ts
@@ -1,0 +1,136 @@
+import {
+  collectCrossTargetTrailIds,
+  findConfigProperty,
+  findTrailDefinitions,
+  getStringValue,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+const hasOnActivation = (config: AstNode): boolean => {
+  const onProp = findConfigProperty(config, 'on');
+  if (!onProp) {
+    return false;
+  }
+
+  const onValue = onProp.value as AstNode | undefined;
+  if (!onValue || onValue.type !== 'ArrayExpression') {
+    return false;
+  }
+
+  const elements = onValue['elements'] as readonly AstNode[] | undefined;
+  return (elements?.length ?? 0) > 0;
+};
+
+const hasExplicitInternalVisibility = (config: AstNode): boolean => {
+  const visibilityProp = findConfigProperty(config, 'visibility');
+  const visibilityValue = visibilityProp?.value as AstNode | undefined;
+  return (
+    !!visibilityValue &&
+    isStringLiteral(visibilityValue) &&
+    getStringValue(visibilityValue) === 'internal'
+  );
+};
+
+/** Check legacy `meta: { internal: true }` convention (mirrors runtime effectiveVisibility). */
+const hasLegacyMetaInternal = (config: AstNode): boolean => {
+  const metaProp = findConfigProperty(config, 'meta');
+  const metaValue = metaProp?.value as AstNode | undefined;
+  if (!metaValue || metaValue.type !== 'ObjectExpression') {
+    return false;
+  }
+  const internalProp = findConfigProperty(metaValue, 'internal');
+  const internalValue = internalProp?.value as AstNode | undefined;
+  return (
+    internalValue?.type === 'BooleanLiteral' &&
+    (internalValue as unknown as { value: boolean }).value === true
+  );
+};
+
+const isInternalTrail = (config: AstNode): boolean =>
+  hasExplicitInternalVisibility(config) || hasLegacyMetaInternal(config);
+
+const buildDeadInternalTrailDiagnostic = (
+  trailId: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}" is marked visibility: 'internal' but nothing crosses it and it has no on: activation. Internal trails should stay reachable through ctx.cross() or reactive activation.`,
+  rule: 'dead-internal-trail',
+  severity: 'warn',
+});
+
+const checkDeadInternalTrails = (
+  ast: AstNode | null,
+  sourceCode: string,
+  filePath: string,
+  crossedTrailIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath) || !ast) {
+    return [];
+  }
+
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const def of findTrailDefinitions(ast)) {
+    if (def.kind !== 'trail' || !isInternalTrail(def.config)) {
+      continue;
+    }
+
+    if (hasOnActivation(def.config) || crossedTrailIds.has(def.id)) {
+      continue;
+    }
+
+    diagnostics.push(
+      buildDeadInternalTrailDiagnostic(
+        def.id,
+        filePath,
+        offsetToLine(sourceCode, def.start)
+      )
+    );
+  }
+
+  return diagnostics;
+};
+
+export const deadInternalTrail: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    return checkDeadInternalTrails(
+      ast,
+      sourceCode,
+      filePath,
+      ast ? collectCrossTargetTrailIds(ast, sourceCode) : new Set<string>()
+    );
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    const localCrossTargetTrailIds = ast
+      ? collectCrossTargetTrailIds(ast, sourceCode)
+      : new Set<string>();
+    return checkDeadInternalTrails(
+      ast,
+      sourceCode,
+      filePath,
+      context.crossTargetTrailIds ?? localCrossTargetTrailIds
+    );
+  },
+  description:
+    'Warn when an internal trail has no crossings anywhere in the project and no on: activation.',
+  name: 'dead-internal-trail',
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/dead-internal-trail.ts
+++ b/packages/warden/src/rules/dead-internal-trail.ts
@@ -15,19 +15,24 @@ import type {
   WardenDiagnostic,
 } from './types.js';
 
-const hasOnActivation = (config: AstNode): boolean => {
-  const onProp = findConfigProperty(config, 'on');
-  if (!onProp) {
+const isNonEmptyActivationValue = (onValue: AstNode): boolean => {
+  // Identifier reference (e.g. `on: signalsArray`) — conservatively treat as
+  // having activation to avoid false positives. We can't cheaply resolve what
+  // the identifier binds to, so assume it's a non-empty activation.
+  if (onValue.type === 'Identifier') {
+    return true;
+  }
+  if (onValue.type !== 'ArrayExpression') {
     return false;
   }
-
-  const onValue = onProp.value as AstNode | undefined;
-  if (!onValue || onValue.type !== 'ArrayExpression') {
-    return false;
-  }
-
   const elements = onValue['elements'] as readonly AstNode[] | undefined;
   return (elements?.length ?? 0) > 0;
+};
+
+const hasOnActivation = (config: AstNode): boolean => {
+  const onProp = findConfigProperty(config, 'on');
+  const onValue = onProp?.value as AstNode | undefined;
+  return onValue ? isNonEmptyActivationValue(onValue) : false;
 };
 
 const hasExplicitInternalVisibility = (config: AstNode): boolean => {

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -1,10 +1,13 @@
 import { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 import { crossDeclarations } from './cross-declarations.js';
+import { deadInternalTrail } from './dead-internal-trail.js';
 import { draftFileMarking } from './draft-file-marking.js';
 import { draftVisibleDebt } from './draft-visible-debt.js';
 import { errorMappingCompleteness } from './error-mapping-completeness.js';
 import { firesDeclarations } from './fires-declarations.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
+import { intentPropagation } from './intent-propagation.js';
+import { missingVisibility } from './missing-visibility.js';
 import { noDirectImplInRoute } from './no-direct-impl-in-route.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
@@ -29,10 +32,13 @@ export type {
 export { noThrowInImplementation } from './no-throw-in-implementation.js';
 export { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 export { crossDeclarations } from './cross-declarations.js';
+export { deadInternalTrail } from './dead-internal-trail.js';
 export { draftFileMarking } from './draft-file-marking.js';
 export { draftVisibleDebt } from './draft-visible-debt.js';
 export { errorMappingCompleteness } from './error-mapping-completeness.js';
 export { firesDeclarations } from './fires-declarations.js';
+export { intentPropagation } from './intent-propagation.js';
+export { missingVisibility } from './missing-visibility.js';
 export { onReferencesExist } from './on-references-exist.js';
 export { validDetourRefs } from './valid-detour-refs.js';
 export { noDirectImplInRoute } from './no-direct-impl-in-route.js';
@@ -53,10 +59,13 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [noThrowInImplementation.name, noThrowInImplementation],
   [contextNoTrailheadTypes.name, contextNoTrailheadTypes],
   [crossDeclarations.name, crossDeclarations],
+  [deadInternalTrail.name, deadInternalTrail],
   [draftFileMarking.name, draftFileMarking],
   [draftVisibleDebt.name, draftVisibleDebt],
   [errorMappingCompleteness.name, errorMappingCompleteness],
   [firesDeclarations.name, firesDeclarations],
+  [intentPropagation.name, intentPropagation],
+  [missingVisibility.name, missingVisibility],
   [onReferencesExist.name, onReferencesExist],
   [resourceDeclarations.name, resourceDeclarations],
   [resourceExists.name, resourceExists],

--- a/packages/warden/src/rules/intent-propagation.ts
+++ b/packages/warden/src/rules/intent-propagation.ts
@@ -1,0 +1,244 @@
+import {
+  collectNamedTrailIds,
+  collectTrailIntentsById,
+  findConfigProperty,
+  findTrailDefinitions,
+  getStringValue,
+  identifierName,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  resolveConstString,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+type TrailIntent = 'destroy' | 'read' | 'write';
+
+const getCrossElements = (config: AstNode): readonly AstNode[] => {
+  const crossesProp = findConfigProperty(config, 'crosses');
+  if (!crossesProp) {
+    return [];
+  }
+
+  const crossesValue = crossesProp.value as AstNode | undefined;
+  if (!crossesValue || crossesValue.type !== 'ArrayExpression') {
+    return [];
+  }
+
+  const elements = crossesValue['elements'] as readonly AstNode[] | undefined;
+  return elements ?? [];
+};
+
+const getTrailCallConfigNode = (
+  firstArg: AstNode,
+  secondArg: AstNode | undefined
+): AstNode | null => {
+  if (firstArg.type === 'ObjectExpression') {
+    return firstArg;
+  }
+
+  if (secondArg?.type === 'ObjectExpression') {
+    return secondArg;
+  }
+
+  return null;
+};
+
+const extractTrailIdFromConfigNode = (
+  configNode: AstNode | null
+): string | null => {
+  if (!configNode) {
+    return null;
+  }
+
+  const idProp = findConfigProperty(configNode, 'id');
+  const idValue = idProp?.value as AstNode | undefined;
+  return idValue && isStringLiteral(idValue) ? getStringValue(idValue) : null;
+};
+
+const isInlineTrailFactoryCall = (node: AstNode): boolean =>
+  identifierName((node as unknown as { callee?: AstNode }).callee) === 'trail';
+
+const getTrailCallArgs = (
+  node: AstNode
+): readonly [AstNode | undefined, AstNode | undefined] => {
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  const [firstArg, secondArg] = args ?? [];
+  return [firstArg, secondArg];
+};
+
+const extractInlineTrailId = (node: AstNode): string | null => {
+  if (node.type !== 'CallExpression' || !isInlineTrailFactoryCall(node)) {
+    return null;
+  }
+
+  const [firstArg, secondArg] = getTrailCallArgs(node);
+  if (!firstArg) {
+    return null;
+  }
+
+  return isStringLiteral(firstArg)
+    ? getStringValue(firstArg)
+    : extractTrailIdFromConfigNode(getTrailCallConfigNode(firstArg, secondArg));
+};
+
+const resolveCrossedTrailId = (
+  element: AstNode,
+  sourceCode: string,
+  namedTrailIds: ReadonlyMap<string, string>
+): string | null => {
+  if (isStringLiteral(element)) {
+    return getStringValue(element);
+  }
+
+  if (element.type === 'Identifier') {
+    const name = identifierName(element);
+    return name
+      ? (namedTrailIds.get(name) ?? resolveConstString(name, sourceCode))
+      : null;
+  }
+
+  return extractInlineTrailId(element);
+};
+
+const extractCrossTargetIds = (
+  config: AstNode,
+  sourceCode: string,
+  namedTrailIds: ReadonlyMap<string, string>
+): readonly string[] => [
+  ...new Set(
+    getCrossElements(config).flatMap((element) => {
+      const id = resolveCrossedTrailId(element, sourceCode, namedTrailIds);
+      return id ? [id] : [];
+    })
+  ),
+];
+
+const extractTrailIntent = (config: AstNode): TrailIntent => {
+  const intentProp = findConfigProperty(config, 'intent');
+  const intentValue = intentProp?.value as AstNode | undefined;
+  if (!intentValue || !isStringLiteral(intentValue)) {
+    return 'write';
+  }
+
+  const value = getStringValue(intentValue);
+  return value === 'destroy' || value === 'read' ? value : 'write';
+};
+
+const buildIntentPropagationDiagnostic = (
+  trailId: string,
+  targetTrailId: string,
+  targetIntent: Exclude<TrailIntent, 'read'>,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}" declares intent: 'read' but crosses "${targetTrailId}" with intent: '${targetIntent}'. Read trails must not compose write or destroy side effects.`,
+  rule: 'intent-propagation',
+  severity: 'warn',
+});
+
+const buildDiagnosticsForCrossTargets = (
+  trailId: string,
+  targetTrailIds: readonly string[],
+  filePath: string,
+  line: number,
+  trailIntentsById: ReadonlyMap<string, TrailIntent>
+): readonly WardenDiagnostic[] =>
+  targetTrailIds.flatMap((targetTrailId) => {
+    const targetIntent = trailIntentsById.get(targetTrailId);
+    if (!targetIntent || targetIntent === 'read') {
+      return [];
+    }
+
+    return [
+      buildIntentPropagationDiagnostic(
+        trailId,
+        targetTrailId,
+        targetIntent,
+        filePath,
+        line
+      ),
+    ];
+  });
+
+const buildDiagnosticsForTrail = (
+  def: ReturnType<typeof findTrailDefinitions>[number],
+  sourceCode: string,
+  filePath: string,
+  namedTrailIds: ReadonlyMap<string, string>,
+  trailIntentsById: ReadonlyMap<string, TrailIntent>
+): readonly WardenDiagnostic[] => {
+  if (def.kind !== 'trail' || extractTrailIntent(def.config) !== 'read') {
+    return [];
+  }
+
+  return buildDiagnosticsForCrossTargets(
+    def.id,
+    extractCrossTargetIds(def.config, sourceCode, namedTrailIds),
+    filePath,
+    offsetToLine(sourceCode, def.start),
+    trailIntentsById
+  );
+};
+
+const checkIntentPropagation = (
+  ast: AstNode | null,
+  sourceCode: string,
+  filePath: string,
+  trailIntentsById: ReadonlyMap<string, TrailIntent>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath) || !ast) {
+    return [];
+  }
+
+  const namedTrailIds = collectNamedTrailIds(ast);
+  return findTrailDefinitions(ast).flatMap((def) =>
+    buildDiagnosticsForTrail(
+      def,
+      sourceCode,
+      filePath,
+      namedTrailIds,
+      trailIntentsById
+    )
+  );
+};
+
+export const intentPropagation: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    return checkIntentPropagation(
+      ast,
+      sourceCode,
+      filePath,
+      ast ? collectTrailIntentsById(ast) : new Map<string, TrailIntent>()
+    );
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    const localTrailIntentsById = ast
+      ? collectTrailIntentsById(ast)
+      : new Map<string, TrailIntent>();
+    return checkIntentPropagation(
+      ast,
+      sourceCode,
+      filePath,
+      context.trailIntentsById ?? localTrailIntentsById
+    );
+  },
+  description:
+    "Warn when a trail declaring intent: 'read' crosses a trail whose normalized intent is write or destroy.",
+  name: 'intent-propagation',
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/intent-propagation.ts
+++ b/packages/warden/src/rules/intent-propagation.ts
@@ -1,14 +1,14 @@
+import type { Intent } from '@ontrails/core';
 import {
   collectNamedTrailIds,
   collectTrailIntentsById,
+  extractDefinitionCrossTargetIds,
   findConfigProperty,
   findTrailDefinitions,
   getStringValue,
-  identifierName,
   isStringLiteral,
   offsetToLine,
   parse,
-  resolveConstString,
 } from './ast.js';
 import type { AstNode } from './ast.js';
 import { isTestFile } from './scan.js';
@@ -18,109 +18,7 @@ import type {
   WardenDiagnostic,
 } from './types.js';
 
-type TrailIntent = 'destroy' | 'read' | 'write';
-
-const getCrossElements = (config: AstNode): readonly AstNode[] => {
-  const crossesProp = findConfigProperty(config, 'crosses');
-  if (!crossesProp) {
-    return [];
-  }
-
-  const crossesValue = crossesProp.value as AstNode | undefined;
-  if (!crossesValue || crossesValue.type !== 'ArrayExpression') {
-    return [];
-  }
-
-  const elements = crossesValue['elements'] as readonly AstNode[] | undefined;
-  return elements ?? [];
-};
-
-const getTrailCallConfigNode = (
-  firstArg: AstNode,
-  secondArg: AstNode | undefined
-): AstNode | null => {
-  if (firstArg.type === 'ObjectExpression') {
-    return firstArg;
-  }
-
-  if (secondArg?.type === 'ObjectExpression') {
-    return secondArg;
-  }
-
-  return null;
-};
-
-const extractTrailIdFromConfigNode = (
-  configNode: AstNode | null
-): string | null => {
-  if (!configNode) {
-    return null;
-  }
-
-  const idProp = findConfigProperty(configNode, 'id');
-  const idValue = idProp?.value as AstNode | undefined;
-  return idValue && isStringLiteral(idValue) ? getStringValue(idValue) : null;
-};
-
-const isInlineTrailFactoryCall = (node: AstNode): boolean =>
-  identifierName((node as unknown as { callee?: AstNode }).callee) === 'trail';
-
-const getTrailCallArgs = (
-  node: AstNode
-): readonly [AstNode | undefined, AstNode | undefined] => {
-  const args = node['arguments'] as readonly AstNode[] | undefined;
-  const [firstArg, secondArg] = args ?? [];
-  return [firstArg, secondArg];
-};
-
-const extractInlineTrailId = (node: AstNode): string | null => {
-  if (node.type !== 'CallExpression' || !isInlineTrailFactoryCall(node)) {
-    return null;
-  }
-
-  const [firstArg, secondArg] = getTrailCallArgs(node);
-  if (!firstArg) {
-    return null;
-  }
-
-  return isStringLiteral(firstArg)
-    ? getStringValue(firstArg)
-    : extractTrailIdFromConfigNode(getTrailCallConfigNode(firstArg, secondArg));
-};
-
-const resolveCrossedTrailId = (
-  element: AstNode,
-  sourceCode: string,
-  namedTrailIds: ReadonlyMap<string, string>
-): string | null => {
-  if (isStringLiteral(element)) {
-    return getStringValue(element);
-  }
-
-  if (element.type === 'Identifier') {
-    const name = identifierName(element);
-    return name
-      ? (namedTrailIds.get(name) ?? resolveConstString(name, sourceCode))
-      : null;
-  }
-
-  return extractInlineTrailId(element);
-};
-
-const extractCrossTargetIds = (
-  config: AstNode,
-  sourceCode: string,
-  namedTrailIds: ReadonlyMap<string, string>
-): readonly string[] => [
-  ...new Set(
-    getCrossElements(config).flatMap((element) => {
-      const id = resolveCrossedTrailId(element, sourceCode, namedTrailIds);
-      return id ? [id] : [];
-    })
-  ),
-];
-
-const extractTrailIntent = (config: AstNode): TrailIntent => {
+const extractTrailIntent = (config: AstNode): Intent => {
   const intentProp = findConfigProperty(config, 'intent');
   const intentValue = intentProp?.value as AstNode | undefined;
   if (!intentValue || !isStringLiteral(intentValue)) {
@@ -134,7 +32,7 @@ const extractTrailIntent = (config: AstNode): TrailIntent => {
 const buildIntentPropagationDiagnostic = (
   trailId: string,
   targetTrailId: string,
-  targetIntent: Exclude<TrailIntent, 'read'>,
+  targetIntent: Exclude<Intent, 'read'>,
   filePath: string,
   line: number
 ): WardenDiagnostic => ({
@@ -150,7 +48,7 @@ const buildDiagnosticsForCrossTargets = (
   targetTrailIds: readonly string[],
   filePath: string,
   line: number,
-  trailIntentsById: ReadonlyMap<string, TrailIntent>
+  trailIntentsById: ReadonlyMap<string, Intent>
 ): readonly WardenDiagnostic[] =>
   targetTrailIds.flatMap((targetTrailId) => {
     const targetIntent = trailIntentsById.get(targetTrailId);
@@ -174,7 +72,7 @@ const buildDiagnosticsForTrail = (
   sourceCode: string,
   filePath: string,
   namedTrailIds: ReadonlyMap<string, string>,
-  trailIntentsById: ReadonlyMap<string, TrailIntent>
+  trailIntentsById: ReadonlyMap<string, Intent>
 ): readonly WardenDiagnostic[] => {
   if (def.kind !== 'trail' || extractTrailIntent(def.config) !== 'read') {
     return [];
@@ -182,7 +80,7 @@ const buildDiagnosticsForTrail = (
 
   return buildDiagnosticsForCrossTargets(
     def.id,
-    extractCrossTargetIds(def.config, sourceCode, namedTrailIds),
+    extractDefinitionCrossTargetIds(def.config, sourceCode, namedTrailIds),
     filePath,
     offsetToLine(sourceCode, def.start),
     trailIntentsById
@@ -193,7 +91,7 @@ const checkIntentPropagation = (
   ast: AstNode | null,
   sourceCode: string,
   filePath: string,
-  trailIntentsById: ReadonlyMap<string, TrailIntent>
+  trailIntentsById: ReadonlyMap<string, Intent>
 ): readonly WardenDiagnostic[] => {
   if (isTestFile(filePath) || !ast) {
     return [];
@@ -218,7 +116,7 @@ export const intentPropagation: ProjectAwareWardenRule = {
       ast,
       sourceCode,
       filePath,
-      ast ? collectTrailIntentsById(ast) : new Map<string, TrailIntent>()
+      ast ? collectTrailIntentsById(ast) : new Map<string, Intent>()
     );
   },
   checkWithContext(
@@ -229,7 +127,7 @@ export const intentPropagation: ProjectAwareWardenRule = {
     const ast = parse(filePath, sourceCode);
     const localTrailIntentsById = ast
       ? collectTrailIntentsById(ast)
-      : new Map<string, TrailIntent>();
+      : new Map<string, Intent>();
     return checkIntentPropagation(
       ast,
       sourceCode,

--- a/packages/warden/src/rules/missing-visibility.ts
+++ b/packages/warden/src/rules/missing-visibility.ts
@@ -1,0 +1,110 @@
+import { collectCrossTargetTrailIds, parse } from './ast.js';
+import { isTestFile } from './scan.js';
+import {
+  findTrailLikeSpecs,
+  parseStringLiteral,
+  parseZodObjectShape,
+} from './specs.js';
+import type { TrailLikeSpec } from './specs.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+/** Check legacy `meta: { internal: true }` convention (mirrors runtime effectiveVisibility). */
+const hasLegacyMetaInternal = (spec: TrailLikeSpec): boolean => {
+  const meta = spec.properties.get('meta')?.value ?? '';
+  return /internal\s*:\s*true/.test(meta);
+};
+
+const trailVisibility = (spec: TrailLikeSpec): 'internal' | 'public' => {
+  if (
+    parseStringLiteral(spec.properties.get('visibility')?.value ?? '') ===
+    'internal'
+  ) {
+    return 'internal';
+  }
+  return hasLegacyMetaInternal(spec) ? 'internal' : 'public';
+};
+
+const hasRequiredCrossInput = (spec: TrailLikeSpec): boolean => {
+  const crossInput = spec.properties.get('crossInput');
+  if (!crossInput) {
+    return false;
+  }
+
+  const fields = parseZodObjectShape(crossInput.value);
+  return [...fields.values()].some((field) => field.required);
+};
+
+const buildMissingVisibilityDiagnostic = (
+  trailId: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}" is crossed elsewhere and declares required crossInput fields, but it is still public. Consider visibility: 'internal' so trailheads do not expose a trail that only works through ctx.cross().`,
+  rule: 'missing-visibility',
+  severity: 'warn',
+});
+
+const checkMissingVisibility = (
+  sourceCode: string,
+  filePath: string,
+  crossedTrailIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath)) {
+    return [];
+  }
+
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const spec of findTrailLikeSpecs(sourceCode)) {
+    if (
+      spec.kind !== 'trail' ||
+      trailVisibility(spec) === 'internal' ||
+      !crossedTrailIds.has(spec.id) ||
+      !hasRequiredCrossInput(spec)
+    ) {
+      continue;
+    }
+
+    diagnostics.push(
+      buildMissingVisibilityDiagnostic(spec.id, filePath, spec.line)
+    );
+  }
+
+  return diagnostics;
+};
+
+export const missingVisibility: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    return checkMissingVisibility(
+      sourceCode,
+      filePath,
+      ast ? collectCrossTargetTrailIds(ast, sourceCode) : new Set<string>()
+    );
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    const localCrossTargetTrailIds = ast
+      ? collectCrossTargetTrailIds(ast, sourceCode)
+      : new Set<string>();
+    return checkMissingVisibility(
+      sourceCode,
+      filePath,
+      context.crossTargetTrailIds ?? localCrossTargetTrailIds
+    );
+  },
+  description:
+    'Coach when a crossed trail still looks composition-only because it declares required crossInput but remains public.',
+  name: 'missing-visibility',
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/missing-visibility.ts
+++ b/packages/warden/src/rules/missing-visibility.ts
@@ -15,7 +15,7 @@ import type {
 /** Check legacy `meta: { internal: true }` convention (mirrors runtime effectiveVisibility). */
 const hasLegacyMetaInternal = (spec: TrailLikeSpec): boolean => {
   const meta = spec.properties.get('meta')?.value ?? '';
-  return /internal\s*:\s*true/.test(meta);
+  return /(?:^|[{,])\s*internal\s*:\s*true/.test(meta);
 };
 
 const trailVisibility = (spec: TrailLikeSpec): 'internal' | 'public' => {

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -51,6 +51,10 @@ export interface ProjectContext {
   readonly knownSignalIds?: ReadonlySet<string>;
   /** All trail IDs referenced as detour targets across the project */
   readonly detourTargetTrailIds?: ReadonlySet<string>;
+  /** All trail IDs referenced by declared crosses arrays across the project. */
+  readonly crossTargetTrailIds?: ReadonlySet<string>;
+  /** Normalized trail intents by trail ID across the project. */
+  readonly trailIntentsById?: ReadonlyMap<string, 'destroy' | 'read' | 'write'>;
 }
 
 /**

--- a/packages/warden/src/trails/dead-internal-trail.trail.ts
+++ b/packages/warden/src/trails/dead-internal-trail.trail.ts
@@ -1,0 +1,26 @@
+import { deadInternalTrail } from '../rules/dead-internal-trail.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const deadInternalTrailTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        crossTargetTrailIds: ['entity.sync'],
+        filePath: 'clean.ts',
+        knownTrailIds: ['entity.public', 'entity.sync'],
+        sourceCode: `trail('entity.public', {
+  crosses: ['entity.sync'],
+  blaze: async (_input, ctx) => ctx.cross('entity.sync', {}),
+});
+
+trail('entity.sync', {
+  visibility: 'internal',
+  blaze: async () => Result.ok({}),
+});`,
+      },
+      name: 'Internal trails stay clean when another trail crosses them',
+    },
+  ],
+  rule: deadInternalTrail,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -1,8 +1,11 @@
 export { contextNoTrailheadTypesTrail } from './context-no-trailhead-types.trail.js';
 export { crossDeclarationsTrail } from './cross-declarations.trail.js';
+export { deadInternalTrailTrail } from './dead-internal-trail.trail.js';
 export { errorMappingCompletenessTrail } from './error-mapping-completeness.trail.js';
 export { firesDeclarationsTrail } from './fires-declarations.trail.js';
 export { implementationReturnsResultTrail } from './implementation-returns-result.trail.js';
+export { intentPropagationTrail } from './intent-propagation.trail.js';
+export { missingVisibilityTrail } from './missing-visibility.trail.js';
 export { onReferencesExistTrail } from './on-references-exist.trail.js';
 export { noDirectImplInRouteTrail } from './no-direct-impl-in-route.trail.js';
 export { noDirectImplementationCallTrail } from './no-direct-implementation-call.trail.js';

--- a/packages/warden/src/trails/intent-propagation.trail.ts
+++ b/packages/warden/src/trails/intent-propagation.trail.ts
@@ -1,0 +1,30 @@
+import { intentPropagation } from '../rules/intent-propagation.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const intentPropagationTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        knownTrailIds: ['entity.read', 'entity.lookup'],
+        sourceCode: `trail('entity.read', {
+  intent: 'read',
+  crosses: ['entity.lookup'],
+  blaze: async (_input, ctx) => ctx.cross('entity.lookup', {}),
+});
+
+trail('entity.lookup', {
+  intent: 'read',
+  blaze: async () => Result.ok({}),
+});`,
+        trailIntentsById: {
+          'entity.lookup': 'read',
+          'entity.read': 'read',
+        },
+      },
+      name: 'Read trails may cross other read trails',
+    },
+  ],
+  rule: intentPropagation,
+});

--- a/packages/warden/src/trails/missing-visibility.trail.ts
+++ b/packages/warden/src/trails/missing-visibility.trail.ts
@@ -1,0 +1,22 @@
+import { missingVisibility } from '../rules/missing-visibility.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const missingVisibilityTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        crossTargetTrailIds: ['entity.resolve'],
+        filePath: 'clean.ts',
+        knownTrailIds: ['entity.resolve'],
+        sourceCode: `trail('entity.resolve', {
+  visibility: 'internal',
+  crossInput: z.object({ forkedFrom: z.string() }),
+  blaze: async () => Result.ok({}),
+});`,
+      },
+      name: 'Composition-only trails stay quiet when already internal',
+    },
+  ],
+  rule: missingVisibility,
+});

--- a/packages/warden/src/trails/run.ts
+++ b/packages/warden/src/trails/run.ts
@@ -16,36 +16,120 @@ import { wardenTopo } from './topo.js';
  * Each rule trail runs independently. Errors from individual trails are
  * silently skipped so that one broken rule does not block the rest.
  */
+const appendDiagnostics = (
+  target: WardenDiagnostic[],
+  diagnostics: readonly WardenDiagnostic[]
+): void => {
+  for (const diagnostic of diagnostics) {
+    target.push(diagnostic);
+  }
+};
+
+const hasProjectOptions = (
+  options:
+    | {
+        readonly crossTargetTrailIds?: readonly string[];
+        readonly detourTargetTrailIds?: readonly string[];
+        readonly knownResourceIds?: readonly string[];
+        readonly knownSignalIds?: readonly string[];
+        readonly knownTrailIds?: readonly string[];
+        readonly trailIntentsById?: Readonly<
+          Record<string, 'destroy' | 'read' | 'write'>
+        >;
+      }
+    | undefined
+): boolean =>
+  Boolean(
+    options?.crossTargetTrailIds ||
+    options?.detourTargetTrailIds ||
+    options?.knownResourceIds ||
+    options?.knownSignalIds ||
+    options?.knownTrailIds ||
+    options?.trailIntentsById
+  );
+
+const buildRuleInput = (
+  filePath: string,
+  sourceCode: string,
+  options:
+    | {
+        readonly crossTargetTrailIds?: readonly string[];
+        readonly detourTargetTrailIds?: readonly string[];
+        readonly knownResourceIds?: readonly string[];
+        readonly knownSignalIds?: readonly string[];
+        readonly knownTrailIds?: readonly string[];
+        readonly trailIntentsById?: Readonly<
+          Record<string, 'destroy' | 'read' | 'write'>
+        >;
+      }
+    | undefined
+):
+  | {
+      readonly filePath: string;
+      readonly sourceCode: string;
+    }
+  | {
+      readonly crossTargetTrailIds?: readonly string[];
+      readonly detourTargetTrailIds?: readonly string[];
+      readonly filePath: string;
+      readonly knownResourceIds?: readonly string[];
+      readonly knownSignalIds?: readonly string[];
+      readonly knownTrailIds?: readonly string[];
+      readonly sourceCode: string;
+      readonly trailIntentsById?: Readonly<
+        Record<string, 'destroy' | 'read' | 'write'>
+      >;
+    } => {
+  const base = { filePath, sourceCode };
+  if (!hasProjectOptions(options)) {
+    return base;
+  }
+
+  return {
+    ...base,
+    ...(options?.crossTargetTrailIds
+      ? { crossTargetTrailIds: options.crossTargetTrailIds }
+      : {}),
+    ...(options?.detourTargetTrailIds
+      ? { detourTargetTrailIds: options.detourTargetTrailIds }
+      : {}),
+    ...(options?.knownResourceIds
+      ? { knownResourceIds: options.knownResourceIds }
+      : {}),
+    ...(options?.knownSignalIds
+      ? { knownSignalIds: options.knownSignalIds }
+      : {}),
+    ...(options?.knownTrailIds ? { knownTrailIds: options.knownTrailIds } : {}),
+    ...(options?.trailIntentsById
+      ? { trailIntentsById: options.trailIntentsById }
+      : {}),
+  };
+};
+
 export const runWardenTrails = async (
   filePath: string,
   sourceCode: string,
   options?: {
+    readonly crossTargetTrailIds?: readonly string[];
+    readonly detourTargetTrailIds?: readonly string[];
     readonly knownResourceIds?: readonly string[];
+    readonly knownSignalIds?: readonly string[];
     readonly knownTrailIds?: readonly string[];
+    readonly trailIntentsById?: Readonly<
+      Record<string, 'destroy' | 'read' | 'write'>
+    >;
   }
 ): Promise<readonly WardenDiagnostic[]> => {
   const allDiagnostics: WardenDiagnostic[] = [];
+  const input = buildRuleInput(filePath, sourceCode, options);
 
   for (const id of wardenTopo.ids()) {
-    const input =
-      options?.knownTrailIds || options?.knownResourceIds
-        ? {
-            filePath,
-            ...(options?.knownResourceIds
-              ? { knownResourceIds: options.knownResourceIds }
-              : {}),
-            ...(options?.knownTrailIds
-              ? { knownTrailIds: options.knownTrailIds }
-              : {}),
-            sourceCode,
-          }
-        : { filePath, sourceCode };
     const result = await run(wardenTopo, id, input);
     if (result.isOk()) {
-      const { diagnostics } = result.value as RuleOutput;
-      for (const d of diagnostics) {
-        allDiagnostics.push(d);
-      }
+      appendDiagnostics(
+        allDiagnostics,
+        (result.value as RuleOutput).diagnostics
+      );
     }
   }
 

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -30,6 +30,14 @@ export const ruleInput = z.object({
  * files.
  */
 export const projectAwareRuleInput = ruleInput.extend({
+  crossTargetTrailIds: z
+    .array(z.string())
+    .optional()
+    .describe('Trail IDs referenced by crosses arrays across the project'),
+  detourTargetTrailIds: z
+    .array(z.string())
+    .optional()
+    .describe('Trail IDs referenced as detour targets across the project'),
   knownResourceIds: z
     .array(z.string())
     .optional()
@@ -42,6 +50,10 @@ export const projectAwareRuleInput = ruleInput.extend({
     .array(z.string())
     .optional()
     .describe('Trail IDs known across the project'),
+  trailIntentsById: z
+    .record(z.string(), z.enum(['read', 'write', 'destroy']))
+    .optional()
+    .describe('Normalized trail intents keyed by trail ID'),
 });
 
 /** Output returned by every warden rule trail. */

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -29,6 +29,27 @@ interface WrapProjectAwareRuleOptions {
   readonly examples: Trail<ProjectAwareRuleInput, RuleOutput>['examples'];
 }
 
+const buildProjectContext = (input: ProjectAwareRuleInput): ProjectContext => ({
+  knownTrailIds: input.knownTrailIds
+    ? new Set(input.knownTrailIds)
+    : new Set<string>(),
+  ...(input.crossTargetTrailIds
+    ? { crossTargetTrailIds: new Set(input.crossTargetTrailIds) }
+    : {}),
+  ...(input.detourTargetTrailIds
+    ? { detourTargetTrailIds: new Set(input.detourTargetTrailIds) }
+    : {}),
+  ...(input.knownResourceIds
+    ? { knownResourceIds: new Set(input.knownResourceIds) }
+    : {}),
+  ...(input.knownSignalIds
+    ? { knownSignalIds: new Set(input.knownSignalIds) }
+    : {}),
+  ...(input.trailIntentsById
+    ? { trailIntentsById: new Map(Object.entries(input.trailIntentsById)) }
+    : {}),
+});
+
 /**
  * Wrap an existing `WardenRule` as a trail with typed input/output.
  *
@@ -50,21 +71,10 @@ export function wrapRule(
     const projectAwareRule = rule as ProjectAwareWardenRule;
     return trail(`warden.rule.${rule.name}`, {
       blaze: (input: ProjectAwareRuleInput) => {
-        const context = {
-          knownResourceIds: input.knownResourceIds
-            ? new Set(input.knownResourceIds)
-            : undefined,
-          knownSignalIds: input.knownSignalIds
-            ? new Set(input.knownSignalIds)
-            : undefined,
-          knownTrailIds: input.knownTrailIds
-            ? new Set(input.knownTrailIds)
-            : new Set<string>(),
-        } as ProjectContext;
         const diagnostics = projectAwareRule.checkWithContext(
           input.sourceCode,
           input.filePath,
-          context
+          buildProjectContext(input)
         );
         return Result.ok({ diagnostics: [...diagnostics] });
       },


### PR DESCRIPTION
## Summary

Hardens the intent-aware trailhead filtering system landed in #125 so trails opt in or out of trailheads through declarative intent rather than per-trailhead config.

- Extend `execute.ts` to propagate trail intent into the shared `trailhead-filter` and thread it through CLI, HTTP, and MCP build pipelines
- Add `dead-internal-trail`, `intent-propagation`, and `missing-visibility` warden rules so drift between declared intent and trailhead wiring is caught at lint time
- Update OpenAPI generation to respect the resolved visibility map
- Expand `trailhead-filter` and `execute` test coverage for mixed-intent stacks across multiple trailheads

## Testing

- `bun test packages/core/src/__tests__/execute.test.ts packages/core/src/__tests__/trailhead-filter.test.ts`
- `bun test packages/cli/src/__tests__/build.test.ts`
- `bun test packages/http/src/__tests__/build.test.ts packages/http/src/hono/__tests__/trailhead.test.ts`
- `bun test packages/mcp/src/__tests__/build.test.ts`
- `bun test packages/schema/src/__tests__/openapi.test.ts`
- `bun test packages/warden/src/__tests__/dead-internal-trail.test.ts packages/warden/src/__tests__/intent-propagation.test.ts packages/warden/src/__tests__/missing-visibility.test.ts`
- `bun run typecheck`
- `bun run lint`

## Closes

- Closes TRL-225
