### PR TITLE
feat: ctx.cross batch overload and isolated branch scoping

### DIFF
--- a/docs/adr/0028-concurrent-crossing.md
+++ b/docs/adr/0028-concurrent-crossing.md
@@ -292,7 +292,7 @@ Rejected because implicit concurrency is a correctness hazard. Two crossings may
 - **The declaration stays simple.** The `crosses` array is still a flat list of trail IDs. No structural annotations, no groups, no ordering constraints. The declaration is the vocabulary. The code is the grammar.
 - **Partial failure uses existing patterns.** The Result model handles optionality. The developer checks results and decides what's required vs optional. No new framework concept for optional crossings.
 - **Tracing observes composition shape.** Concurrent crossings produce sibling spans with overlapping timestamps. Sequential crossings produce sequential spans. The observation is ground truth, not declaration.
-- **Warden rules are unchanged.** The existing `crossing-declarations` rule validates that every ID in a `ctx.cross()` call appears in the crossing declaration. The rule works identically for single and array forms.
+- **Warden rules are unchanged.** The existing `cross-declarations` rule validates that every ID in a `ctx.cross()` call appears in the crossing declaration. The rule works identically for single and array forms.
 - **Concurrency control is opt-in.** The `{ concurrency: N }` option handles backpressure for large fan-outs without affecting the common case. The option is specified here; the initial implementation lands the unbounded array overload first and adds the `{ concurrency: N }` option in a follow-up slice (PR #130).
 
 ### Tradeoffs

--- a/docs/adr/0028-concurrent-crossing.md
+++ b/docs/adr/0028-concurrent-crossing.md
@@ -1,14 +1,15 @@
 ---
+id: 28
 slug: concurrent-crossing
 title: Concurrent Trail Crossing
-status: draft
+status: accepted
 created: 2026-03-31
-updated: 2026-04-09
+updated: 2026-04-10
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [3]
 ---
 
-# ADR: Concurrent Trail Crossing
+# ADR-0028: Concurrent Trail Crossing
 
 ## Context
 
@@ -315,7 +316,7 @@ Rejected because implicit concurrency is a correctness hazard. Two crossings may
 - [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged
 - [ADR-0013: Tracing](../0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime
 - [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns
-- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode
+- [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode
 - [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred here
-- [ADR: Composition Testing](../0025-composition-testing.md) -- `scenario()` and `expectedMatch` for testing concurrent composition flows
+- [ADR-0025: Composition Testing](0025-composition-testing.md) -- `scenario()` and `expectedMatch` for testing concurrent composition flows
 - ADR: Packs as Namespace Boundaries (draft) -- concurrent crossings across pack boundaries work identically to sequential crossings; pack boundary governance is unchanged

--- a/docs/adr/0028-concurrent-crossing.md
+++ b/docs/adr/0028-concurrent-crossing.md
@@ -293,7 +293,7 @@ Rejected because implicit concurrency is a correctness hazard. Two crossings may
 - **Partial failure uses existing patterns.** The Result model handles optionality. The developer checks results and decides what's required vs optional. No new framework concept for optional crossings.
 - **Tracing observes composition shape.** Concurrent crossings produce sibling spans with overlapping timestamps. Sequential crossings produce sequential spans. The observation is ground truth, not declaration.
 - **Warden rules are unchanged.** The existing `crossing-declarations` rule validates that every ID in a `ctx.cross()` call appears in the crossing declaration. The rule works identically for single and array forms.
-- **Concurrency control is opt-in.** The `{ concurrency: N }` option handles backpressure for large fan-outs without affecting the common case.
+- **Concurrency control is opt-in.** The `{ concurrency: N }` option handles backpressure for large fan-outs without affecting the common case. The option is specified here; the initial implementation lands the unbounded array overload first and adds the `{ concurrency: N }` option in a follow-up slice (PR #130).
 
 ### Tradeoffs
 
@@ -310,13 +310,13 @@ Rejected because implicit concurrency is a correctness hazard. Two crossings may
 
 ## References
 
-- [ADR-0000: Core Premise](../0000-core-premise.md) -- "derive by default"; tracing observes composition shape rather than requiring it to be declared
-- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) -- the Result model that handles partial failure in concurrent crossings
-- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- "composition is a property, not a type"; parallel vs sequential is a runtime choice, not a contract distinction. The crossing declaration stays flat, same as when `hike()` was unified into `trail()`.
-- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged
-- [ADR-0013: Tracing](../0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime
-- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns
-- [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode
-- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred here
+- [ADR-0000: Core Premise](0000-core-premise.md) -- "derive by default"; tracing observes composition shape rather than requiring it to be declared
+- [ADR-0002: Built-In Result Type](0002-built-in-result-type.md) -- the Result model that handles partial failure in concurrent crossings
+- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) -- "composition is a property, not a type"; parallel vs sequential is a runtime choice, not a contract distinction. The crossing declaration stays flat, same as when `hike()` was unified into `trail()`.
+- [ADR-0006: Shared Execution Pipeline](0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged
+- [ADR-0013: Tracing](0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime
+- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns
+- [ADR-0024: Typed Trail Composition](0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred here
 - [ADR-0025: Composition Testing](0025-composition-testing.md) -- `scenario()` and `expectedMatch` for testing concurrent composition flows
+- [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode
 - ADR: Packs as Namespace Boundaries (draft) -- concurrent crossings across pack boundaries work identically to sequential crossings; pack boundary governance is unchanged

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0025](0025-composition-testing.md) | Composition Testing | Accepted |
 | [0026](0026-error-taxonomy-as-transport-independent-behavior-contract.md) | Error Taxonomy as Transport-Independent Behavior Contract | Accepted |
 | [0027](0027-visibility-and-filtering.md) | Trail Visibility and Trailhead Filtering | Accepted |
+| [0028](0028-concurrent-crossing.md) | Concurrent Trail Crossing | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -91,8 +91,8 @@
         },
         {
           "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"derive by default\"; tracing observes composition shape rather than requiring it to be declared",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"the trail is the product\"; `trails run` makes every trail directly invocable without trailhead ceremony",
@@ -274,8 +274,8 @@
         },
         {
           "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) -- the Result model that handles partial failure in concurrent crossings",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) — the error taxonomy maps to categorized failure events",
@@ -333,8 +333,8 @@
         },
         {
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- \"composition is a property, not a type\"; parallel vs sequential is a runtime choice, not a contract distinction. The crossi",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- every trail is runnable, whether atomic or composite",
@@ -520,8 +520,8 @@
         },
         {
           "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- `trails run` executes through the pipeline, the same as every trailhead",
@@ -933,8 +933,8 @@
         },
         {
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- the tracing primitive; live tracing during `trails run`, historical tracing via `trails trace`",
@@ -1169,8 +1169,8 @@
         },
         {
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- rig state captured in the lockfile graph; rig lock state occupies a section in `trails.lock`",
@@ -1427,8 +1427,8 @@
         },
         {
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
           "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) — typed `ctx.cross()` complements signal-based activation; `on:` is for reactive decoupling, `crosses` is for direct compositi",
@@ -1470,9 +1470,9 @@
       "depends_on": ["3", "7", "24"],
       "inbound": [
         {
-          "context": "- [ADR: Composition Testing](../0025-composition-testing.md) -- `scenario()` and `expectedMatch` for testing concurrent composition flows",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "context": "- [ADR-0025: Composition Testing](0025-composition-testing.md) -- `scenario()` and `expectedMatch` for testing concurrent composition flows",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         }
       ],
       "number": "0025",
@@ -1489,17 +1489,17 @@
       "depends_on": ["2", "6"],
       "inbound": [
         {
-          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
+          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, discard) ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
         },
         {
-          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
+          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, discard) ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
         },
         {
-          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) -- WebSocket close code mapping deferred there; the error ",
+          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) -- WebSocket close code mapping deferred there; the error ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
         }
@@ -1518,27 +1518,27 @@
       "depends_on": ["packs-namespace-boundaries"],
       "inbound": [
         {
-          "context": "[^3]: See [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md)",
+          "context": "[^3]: See [Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft)",
           "from": "0024",
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
         },
         {
-          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-concurrent-crossing.md"
+          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) -- concurrent crossings respect visibility; internal trails are crossable regardless of concurrency mode",
+          "from": "0028",
+          "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
         {
-          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
         },
         {
-          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- rigged SDK wrapper packs use `visibility: 'internal'`",
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
         },
         {
-          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
+          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
         }
@@ -1550,6 +1550,25 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Trail Visibility and Trailhead Filtering",
+      "updated": "2026-04-10"
+    },
+    {
+      "created": "2026-03-31",
+      "depends_on": ["3"],
+      "inbound": [
+        {
+          "context": "- [ADR: Concurrent Trail Crossing](0028-concurrent-crossing.md) (draft) -- `--trace` renders concurrent crossings as parallel branches in the execution tree",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
+        }
+      ],
+      "number": "0028",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0028-concurrent-crossing.md",
+      "slug": "concurrent-crossing",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Concurrent Trail Crossing",
       "updated": "2026-04-10"
     }
   ],

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -90,7 +90,7 @@
           "fromPath": "docs/adr/0027-visibility-and-filtering.md"
         },
         {
-          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) -- \"derive by default\"; tracing observes composition shape rather than requiring it to be declared",
+          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) -- \"derive by default\"; tracing observes composition shape rather than requiring it to be declared",
           "from": "0028",
           "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
@@ -273,7 +273,7 @@
           "fromPath": "docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md"
         },
         {
-          "context": "- [ADR-0002: Built-In Result Type](../0002-built-in-result-type.md) -- the Result model that handles partial failure in concurrent crossings",
+          "context": "- [ADR-0002: Built-In Result Type](0002-built-in-result-type.md) -- the Result model that handles partial failure in concurrent crossings",
           "from": "0028",
           "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
@@ -332,7 +332,7 @@
           "fromPath": "docs/adr/0027-visibility-and-filtering.md"
         },
         {
-          "context": "- [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- \"composition is a property, not a type\"; parallel vs sequential is a runtime choice, not a contract distinction. The crossi",
+          "context": "- [ADR-0003: Unified Trail Primitive](0003-unified-trail-primitive.md) -- \"composition is a property, not a type\"; parallel vs sequential is a runtime choice, not a contract distinction. The crossing ",
           "from": "0028",
           "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
@@ -519,7 +519,7 @@
           "fromPath": "docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md"
         },
         {
-          "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged",
+          "context": "- [ADR-0006: Shared Execution Pipeline](0006-shared-execution-pipeline.md) -- the execution pipeline runs for each concurrent branch; the pipeline is unchanged",
           "from": "0028",
           "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
@@ -932,7 +932,7 @@
           "fromPath": "docs/adr/0027-visibility-and-filtering.md"
         },
         {
-          "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime",
+          "context": "- [ADR-0013: Tracing](0013-tracing.md) -- tracing observes concurrent vs sequential spans to derive composition shape at runtime",
           "from": "0028",
           "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
@@ -1168,7 +1168,7 @@
           "fromPath": "docs/adr/0027-visibility-and-filtering.md"
         },
         {
-          "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns",
+          "context": "- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) -- the lockfile captures composition shapes including parallel crossing patterns",
           "from": "0028",
           "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
@@ -1426,7 +1426,7 @@
           "fromPath": "docs/adr/0027-visibility-and-filtering.md"
         },
         {
-          "context": "- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred",
+          "context": "- [ADR-0024: Typed Trail Composition](0024-typed-trail-composition.md) -- typed `ctx.cross()` that the array overload extends; parallel crossing with typed results is a non-decision there, deferred he",
           "from": "0028",
           "fromPath": "docs/adr/0028-concurrent-crossing.md"
         },
@@ -1489,17 +1489,17 @@
       "depends_on": ["2", "6"],
       "inbound": [
         {
-          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, discard) ",
+          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-reactive-trail-activation.md"
         },
         {
-          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) — signal delivery semantics (retry, dead-letter, discard) ",
+          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) — signal delivery semantics (retry, dead-letter, discard) ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-typed-signal-emission.md"
         },
         {
-          "context": "- [ADR: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md) (draft) -- WebSocket close code mapping deferred there; the error ",
+          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) -- WebSocket close code mapping deferred there; the error ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
         }
@@ -1511,14 +1511,14 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Error Taxonomy as Transport-Independent Behavior Contract",
-      "updated": "2026-04-10"
+      "updated": "2026-04-13"
     },
     {
       "created": "2026-03-31",
       "depends_on": ["packs-namespace-boundaries"],
       "inbound": [
         {
-          "context": "[^3]: See [Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft)",
+          "context": "[^3]: See [ADR-0027: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md)",
           "from": "0024",
           "fromPath": "docs/adr/0024-typed-trail-composition.md"
         },
@@ -1533,12 +1533,12 @@
           "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
         },
         {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`",
+          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- rigged SDK wrapper packs use `visibility: 'internal'`",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
         },
         {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
+          "context": "- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- visibility and intent filtering apply to WebSocket trail discovery and invocation",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
         }
@@ -1557,7 +1557,7 @@
       "depends_on": ["3"],
       "inbound": [
         {
-          "context": "- [ADR: Concurrent Trail Crossing](0028-concurrent-crossing.md) (draft) -- `--trace` renders concurrent crossings as parallel branches in the execution tree",
+          "context": "- [ADR-0028: Concurrent Trail Crossing](../0028-concurrent-crossing.md) -- `--trace` renders concurrent crossings as parallel branches in the execution tree",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
         }

--- a/docs/adr/drafts/20260331-direct-invocation.md
+++ b/docs/adr/drafts/20260331-direct-invocation.md
@@ -582,8 +582,8 @@ Trail IDs are completed from the topo. Example names are completed from the trai
 - [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- every trail is runnable, whether atomic or composite
 - [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- `trails run` executes through the pipeline, the same as every trailhead
 - ADR: Typed Signal Emission (draft) -- events emitted during `trails run` flow through normal routing, triggers fire
-- [ADR: Concurrent Trail Crossing](20260331-concurrent-crossing.md) (draft) -- `--trace` renders concurrent crossings as parallel branches in the execution tree
-- [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)
+- [ADR: Concurrent Trail Crossing](0028-concurrent-crossing.md) (draft) -- `--trace` renders concurrent crossings as parallel branches in the execution tree
+- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)
 - [ADR: Unified Observability](20260409-unified-observability.md) (draft) -- `--trace` flag, `ctx.trace()`, and the tracing vocabulary used throughout this draft. Note: this draft uses `--tracing` as the flag name; the canonical flag is `--trace` per the observability ADR.
 - ADR: Packs as Namespace Boundaries (draft) -- `trails run` can invoke any trail in any pack, regardless of visibility
 - [ADR-0013: Tracing](../0013-tracing.md) -- the tracing primitive; live tracing during `trails run`, historical tracing via `trails trace`

--- a/docs/adr/drafts/20260331-direct-invocation.md
+++ b/docs/adr/drafts/20260331-direct-invocation.md
@@ -582,7 +582,7 @@ Trail IDs are completed from the topo. Example names are completed from the trai
 - [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md) -- every trail is runnable, whether atomic or composite
 - [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- `trails run` executes through the pipeline, the same as every trailhead
 - ADR: Typed Signal Emission (draft) -- events emitted during `trails run` flow through normal routing, triggers fire
-- [ADR: Concurrent Trail Crossing](0028-concurrent-crossing.md) (draft) -- `--trace` renders concurrent crossings as parallel branches in the execution tree
+- [ADR-0028: Concurrent Trail Crossing](../0028-concurrent-crossing.md) -- `--trace` renders concurrent crossings as parallel branches in the execution tree
 - [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)
 - [ADR: Unified Observability](20260409-unified-observability.md) (draft) -- `--trace` flag, `ctx.trace()`, and the tracing vocabulary used throughout this draft. Note: this draft uses `--tracing` as the flag name; the canonical flag is `--trace` per the observability ADR.
 - ADR: Packs as Namespace Boundaries (draft) -- `trails run` can invoke any trail in any pack, regardless of visibility

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -6,8 +6,6 @@ Proposed decisions under discussion. Promoted to `docs/adr/` when accepted.
 
 ## 2026-03
 
-- [Concurrent Trail Crossing](20260331-concurrent-crossing.md)
-  - depends on [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md)
 - [Direct Trail Invocation (`trails run`)](20260331-direct-invocation.md)
   - depends on [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md)
 - [External Trailheads as Trails](20260331-external-trailheads-as-trails.md)

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -2,25 +2,6 @@
   "entries": [
     {
       "created": "2026-03-31",
-      "depends_on": ["3"],
-      "inbound": [
-        {
-          "context": "- [ADR: Concurrent Trail Crossing](20260331-concurrent-crossing.md) (draft) -- `--trace` renders concurrent crossings as parallel branches in the execution tree",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
-        }
-      ],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260331-concurrent-crossing.md",
-      "slug": "concurrent-crossing",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Concurrent Trail Crossing",
-      "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-03-31",
       "depends_on": ["17"],
       "inbound": [],
       "number": null,

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -3,7 +3,7 @@ import { describe, test, expect } from 'bun:test';
 
 import { z } from 'zod';
 
-import { InternalError, ValidationError } from '../errors';
+import { CancelledError, InternalError, ValidationError } from '../errors';
 import { executeTrail } from '../execute';
 import { createTrailContext } from '../context';
 import type { Layer } from '../layer';
@@ -110,6 +110,246 @@ const requireCross = (
 ): NonNullable<TrailContext['cross']> => {
   expect(ctx.cross).toBeDefined();
   return ctx.cross as NonNullable<TrailContext['cross']>;
+};
+
+const waitForAbort = async (signal: AbortSignal): Promise<void> => {
+  if (signal.aborted) {
+    return;
+  }
+
+  const { promise, resolve } = Promise.withResolvers<undefined>();
+  signal.addEventListener('abort', () => resolve(), { once: true });
+  await promise;
+};
+
+const createConcurrentBranchResourceScopeScenario = () => {
+  const id = nextResourceId('branch-scope');
+  const captures = { createCalls: 0 };
+  const scopedResource = resource(id, {
+    create: () => {
+      captures.createCalls += 1;
+      return Result.ok({ source: `branch-scope-${captures.createCalls}` });
+    },
+  });
+  const createReader = (trailId: string) =>
+    trail(trailId, {
+      blaze: (_input, ctx) =>
+        Result.ok({ source: scopedResource.from(ctx).source }),
+      input: z.object({}),
+      output: z.object({ source: z.string() }),
+      resources: [scopedResource],
+      visibility: 'internal',
+    });
+  const left = createReader('entity.branch.left');
+  const right = createReader('entity.branch.right');
+  const entry = trail('entity.branch.resource-scope', {
+    blaze: async (_input, ctx) => {
+      const crossed = await requireCross(ctx)([
+        [left, {}],
+        [right, {}],
+      ] as const);
+      return Result.ok({
+        sources: crossed.map((result) =>
+          result.match({
+            err: () => 'err',
+            ok: (value) => value.source,
+          })
+        ),
+      });
+    },
+    crosses: [left, right],
+    input: z.object({}),
+    output: z.object({ sources: z.array(z.string()) }),
+  });
+
+  return {
+    app: topo('cross-branch-resource-scope-topo', {
+      entry,
+      left,
+      right,
+      scopedResource,
+    }),
+    captures,
+    entry,
+    id,
+  };
+};
+
+const createAbortSignalScenario = (seenSignals: AbortSignal[]) => {
+  const createCancellable = (id: string) =>
+    trail(id, {
+      blaze: async (_input, ctx) => {
+        seenSignals.push(ctx.abortSignal);
+        await waitForAbort(ctx.abortSignal);
+        return Result.err(
+          new CancelledError(`${id} cancelled by shared abort signal`)
+        );
+      },
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      visibility: 'internal',
+    });
+  const left = createCancellable('entity.cancel.left');
+  const right = createCancellable('entity.cancel.right');
+  const entry = trail('entity.branch.abort-signal', {
+    blaze: async (_input, ctx) => {
+      const crossed = await requireCross(ctx)([
+        [left, {}],
+        [right, {}],
+      ] as const);
+      return Result.ok({
+        statuses: crossed.map((result) =>
+          result.match({
+            err: (error) =>
+              error instanceof CancelledError ? error.category : 'err',
+            ok: () => 'ok',
+          })
+        ),
+      });
+    },
+    crosses: [left, right],
+    input: z.object({}),
+    output: z.object({ statuses: z.array(z.string()) }),
+  });
+
+  return {
+    app: topo('cross-branch-abort-signal-topo', {
+      entry,
+      left,
+      right,
+    }),
+    entry,
+  };
+};
+
+interface PermitCapture {
+  readonly permitId: string;
+  readonly sameReference: boolean;
+}
+
+const createPermitScenario = (
+  permit: { readonly id: string; readonly scopes: readonly string[] },
+  captures: PermitCapture[]
+) => {
+  const createChild = (id: string) =>
+    trail(id, {
+      blaze: (_input, ctx) => {
+        const branchPermit = ctx.permit as typeof permit;
+        const permitCapture = {
+          permitId: branchPermit.id,
+          sameReference: branchPermit === permit,
+        };
+        captures.push(permitCapture);
+        return Result.ok(permitCapture);
+      },
+      input: z.object({}),
+      output: z.object({
+        permitId: z.string(),
+        sameReference: z.boolean(),
+      }),
+      visibility: 'internal',
+    });
+  const left = createChild('entity.permit.left');
+  const right = createChild('entity.permit.right');
+  const entry = trail('entity.branch.permit', {
+    blaze: async (_input, ctx) => {
+      const crossed = await requireCross(ctx)([
+        [left, {}],
+        [right, {}],
+      ] as const);
+      return Result.ok({
+        permits: crossed.map((result) =>
+          result.match({
+            err: () => ({ permitId: 'err', sameReference: false }),
+            ok: (value) => value,
+          })
+        ),
+      });
+    },
+    crosses: [left, right],
+    input: z.object({}),
+    output: z.object({
+      permits: z.array(
+        z.object({
+          permitId: z.string(),
+          sameReference: z.boolean(),
+        })
+      ),
+    }),
+  });
+
+  return {
+    app: topo('cross-branch-permit-topo', {
+      entry,
+      left,
+      right,
+    }),
+    entry,
+  };
+};
+
+const createSiblingFailureScopeScenario = () => {
+  const failingId = nextResourceId('branch-fail');
+  const succeedingId = nextResourceId('branch-success');
+  const failingResource = resource(failingId, {
+    create: () =>
+      Result.err(new ValidationError('failing branch scope exploded')),
+  });
+  const succeedingResource = resource(succeedingId, {
+    create: () => Result.ok({ source: 'sibling-branch-scope' }),
+  });
+  const failing = trail('entity.scope.fail', {
+    blaze: () => Result.ok({ ok: true }),
+    input: z.object({}),
+    output: z.object({ ok: z.boolean() }),
+    resources: [failingResource],
+    visibility: 'internal',
+  });
+  const succeeding = trail('entity.scope.ok', {
+    blaze: (_input, ctx) =>
+      Result.ok({ source: succeedingResource.from(ctx).source }),
+    input: z.object({}),
+    output: z.object({ source: z.string() }),
+    resources: [succeedingResource],
+    visibility: 'internal',
+  });
+  const entry = trail('entity.branch.failure-scope', {
+    blaze: async (_input, ctx) => {
+      const [failed, succeeded] = await requireCross(ctx)([
+        [failing, {}],
+        [succeeding, {}],
+      ] as const);
+      return Result.ok({
+        failed: failed.match({
+          err: (error) => error.message,
+          ok: () => 'ok',
+        }),
+        succeeded: succeeded.match({
+          err: () => 'err',
+          ok: (value) => value.source,
+        }),
+      });
+    },
+    crosses: [failing, succeeding],
+    input: z.object({}),
+    output: z.object({
+      failed: z.string(),
+      succeeded: z.string(),
+    }),
+  });
+
+  return {
+    app: topo('cross-branch-failure-scope-topo', {
+      entry,
+      failing,
+      failingResource,
+      succeeding,
+      succeedingResource,
+    }),
+    entry,
+    failingId,
+    succeedingId,
+  };
 };
 
 // ---------------------------------------------------------------------------
@@ -424,6 +664,94 @@ describe('executeTrail', () => {
 
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toEqual({ count: 0 });
+    });
+  });
+
+  describe('concurrent crossings', () => {
+    test('resolves concurrent branch resources from branch scope instead of inheriting parent resources', async () => {
+      const { app, captures, entry, id } =
+        createConcurrentBranchResourceScopeScenario();
+
+      const result = await executeTrail(
+        entry,
+        {},
+        {
+          ctx: { extensions: { [id]: { source: 'parent-scope' } } },
+          topo: app,
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({
+        sources: ['branch-scope-1', 'branch-scope-1'],
+      });
+      expect(captures.createCalls).toBe(1);
+    });
+
+    test('propagates the same AbortSignal to every concurrent branch', async () => {
+      const seenSignals: AbortSignal[] = [];
+      const { app, entry } = createAbortSignalScenario(seenSignals);
+      const abortSignal = AbortSignal.timeout(5);
+
+      const result = await executeTrail(entry, {}, { abortSignal, topo: app });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({
+        statuses: ['cancelled', 'cancelled'],
+      });
+      expect(seenSignals).toEqual([abortSignal, abortSignal]);
+    });
+
+    test('propagates the parent permit to every concurrent branch', async () => {
+      const permit = Object.freeze({
+        id: 'permit-orders',
+        scopes: ['orders:read'] as const,
+      });
+      const captures: PermitCapture[] = [];
+      const { app, entry } = createPermitScenario(permit, captures);
+
+      const result = await executeTrail(
+        entry,
+        {},
+        { ctx: { permit }, topo: app }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({
+        permits: [
+          { permitId: 'permit-orders', sameReference: true },
+          { permitId: 'permit-orders', sameReference: true },
+        ],
+      });
+      expect(captures).toEqual([
+        { permitId: 'permit-orders', sameReference: true },
+        { permitId: 'permit-orders', sameReference: true },
+      ]);
+    });
+
+    test("keeps one branch's failure from poisoning sibling branch scopes", async () => {
+      const { app, entry, failingId, succeedingId } =
+        createSiblingFailureScopeScenario();
+
+      const result = await executeTrail(
+        entry,
+        {},
+        {
+          ctx: {
+            extensions: {
+              [failingId]: { source: 'parent-failing-scope' },
+              [succeedingId]: { source: 'parent-success-scope' },
+            },
+          },
+          topo: app,
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({
+        failed: 'failing branch scope exploded',
+        succeeded: 'sibling-branch-scope',
+      });
     });
   });
 

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -566,7 +566,7 @@ describe('executeTrail', () => {
             resultOrder: crossed.map((result) =>
               result.match({
                 err: () => 'err',
-                ok: (value) => value.id,
+                ok: (value) => (value as { id: string }).id,
               })
             ),
           });

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -292,6 +292,139 @@ describe('executeTrail', () => {
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toEqual({ summary: 'abc123:entity.run' });
     });
+
+    test('executes batch ctx.cross() calls concurrently and preserves tuple order', async () => {
+      const completionOrder: string[] = [];
+      const slow = trail('entity.slow', {
+        blaze: async () => {
+          await Bun.sleep(10);
+          completionOrder.push('slow');
+          return Result.ok({ id: 'slow' });
+        },
+        input: z.object({}),
+        output: z.object({ id: z.string() }),
+        visibility: 'internal',
+      });
+      const fast = trail('entity.fast', {
+        blaze: async () => {
+          await Bun.sleep(0);
+          completionOrder.push('fast');
+          return Result.ok({ id: 'fast' });
+        },
+        input: z.object({}),
+        output: z.object({ id: z.string() }),
+        visibility: 'internal',
+      });
+      const entry = trail('entity.batch', {
+        blaze: async (_input, ctx) => {
+          const crossed = await requireCross(ctx)([
+            ['entity.slow', {}],
+            ['entity.fast', {}],
+          ]);
+          return Result.ok({
+            completionOrder,
+            resultOrder: crossed.map((result) =>
+              result.match({
+                err: () => 'err',
+                ok: (value) => value.id,
+              })
+            ),
+          });
+        },
+        crosses: ['entity.fast', 'entity.slow'],
+        input: z.object({}),
+        output: z.object({
+          completionOrder: z.array(z.string()),
+          resultOrder: z.array(z.string()),
+        }),
+      });
+      const app = topo('cross-batch-topo', { entry, fast, slow });
+
+      const result = await executeTrail(entry, {}, { topo: app });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({
+        completionOrder: ['fast', 'slow'],
+        resultOrder: ['slow', 'fast'],
+      });
+    });
+
+    test('returns every batch cross result without short-circuiting on errors', async () => {
+      const completions: string[] = [];
+      const failing = trail('entity.fail', {
+        blaze: async () => {
+          await Bun.sleep(0);
+          completions.push('fail');
+          return Result.err(new ValidationError('nope'));
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+        visibility: 'internal',
+      });
+      const succeeding = trail('entity.ok', {
+        blaze: async () => {
+          await Bun.sleep(5);
+          completions.push('ok');
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+        visibility: 'internal',
+      });
+      const entry = trail('entity.batch.errors', {
+        blaze: async (_input, ctx) => {
+          const crossed = await requireCross(ctx)([
+            [failing, {}],
+            [succeeding, {}],
+          ] as const);
+          return Result.ok({
+            completions,
+            statuses: crossed.map((result) =>
+              result.match({
+                err: () => 'err',
+                ok: () => 'ok',
+              })
+            ),
+          });
+        },
+        crosses: [failing, succeeding],
+        input: z.object({}),
+        output: z.object({
+          completions: z.array(z.string()),
+          statuses: z.array(z.string()),
+        }),
+      });
+      const app = topo('cross-batch-errors-topo', {
+        entry,
+        failing,
+        succeeding,
+      });
+
+      const result = await executeTrail(entry, {}, { topo: app });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({
+        completions: ['fail', 'ok'],
+        statuses: ['err', 'ok'],
+      });
+    });
+
+    test('returns an empty array for empty batch ctx.cross() calls', async () => {
+      const entry = trail('entity.batch.empty', {
+        blaze: async (_input, ctx) => {
+          const crossed = await requireCross(ctx)([]);
+          return Result.ok({ count: crossed.length });
+        },
+        input: z.object({}),
+        output: z.object({ count: z.number() }),
+      });
+      const app = topo('cross-batch-empty-topo', { entry });
+
+      const result = await executeTrail(entry, {}, { topo: app });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ count: 0 });
+    });
   });
 
   describe('validation', () => {

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -348,6 +348,27 @@ const resolveCrossTarget = (
       );
 };
 
+const executeCrossTarget = async (
+  trailOrId: AnyTrail | string,
+  input: unknown,
+  ctx: TrailContext,
+  topo: Topo | undefined,
+  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>
+): Promise<Result<unknown, Error>> => {
+  const target = resolveCrossTarget(trailOrId, topo);
+  if (target.isErr()) {
+    return target;
+  }
+
+  return await // eslint-disable-next-line no-use-before-define -- executor closure runs only after executeTrail is defined
+  executeTrail(target.value, input, {
+    ...forwarded,
+    ctx,
+    topo,
+    validationSchema: buildCrossValidationSchema(target.value),
+  });
+};
+
 const bindCrossToCtx = (
   ctx: TrailContext,
   topo: Topo | undefined,
@@ -362,23 +383,29 @@ const bindCrossToCtx = (
     validationSchema: _omitSchema,
     ...forwarded
   } = options ?? {};
-  const cross: CrossFn = async (
-    trailOrId: AnyTrail | string,
-    input: unknown
+  const cross = (async (
+    trailOrCalls:
+      | AnyTrail
+      | string
+      | readonly (readonly [AnyTrail | string, unknown])[],
+    input?: unknown
   ) => {
-    const target = resolveCrossTarget(trailOrId, topo);
-    if (target.isErr()) {
-      return target;
+    if (Array.isArray(trailOrCalls)) {
+      return await Promise.all(
+        trailOrCalls.map(([trailOrId, batchInput]) =>
+          executeCrossTarget(trailOrId, batchInput, ctx, topo, forwarded)
+        )
+      );
     }
 
-    return await // eslint-disable-next-line no-use-before-define -- executor closure runs only after executeTrail is defined
-    executeTrail(target.value, input, {
-      ...forwarded,
+    return await executeCrossTarget(
+      trailOrCalls as AnyTrail | string,
+      input,
       ctx,
       topo,
-      validationSchema: buildCrossValidationSchema(target.value),
-    });
-  };
+      forwarded
+    );
+  }) as CrossFn;
 
   return {
     ...ctx,

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -348,6 +348,78 @@ const resolveCrossTarget = (
       );
 };
 
+const collectConcurrentBranchResourceIds = (
+  target: AnyTrail,
+  topo: Topo | undefined
+): Set<string> =>
+  new Set(
+    topo?.resourceIds() ?? target.resources.map((resource) => resource.id)
+  );
+
+const stripInheritedResourceExtensions = (
+  ctx: TrailContext,
+  target: AnyTrail,
+  topo: Topo | undefined
+): Record<string, unknown> => {
+  const resourceIds = collectConcurrentBranchResourceIds(target, topo);
+  const entries = Object.entries(ctx.extensions ?? {}).filter(
+    ([key]) => !resourceIds.has(key)
+  );
+  return Object.fromEntries(entries);
+};
+
+const deriveConcurrentBranchLogger = (
+  ctx: TrailContext,
+  target: AnyTrail,
+  branchIndex: number
+) =>
+  ctx.logger?.child?.({
+    branchIndex,
+    crossedTrailId: target.id,
+  }) ?? ctx.logger;
+
+/**
+ * Build a child context for one concurrent crossing branch.
+ *
+ * Concurrent crossings should not inherit already-resolved resource instances
+ * from the parent execution scope. Stripping resource IDs from extensions
+ * forces each branch to resolve its own scope while still carrying forward
+ * request-scoped values like tracing, trailhead identity, permits, and the
+ * shared AbortSignal.
+ *
+ * `cross`, `fire`, and `resource` are cleared so the child execution can
+ * rebind them to the branch-local context instead of reusing closures that
+ * capture the parent scope.
+ */
+const buildConcurrentBranchContext = (
+  ctx: TrailContext,
+  target: AnyTrail,
+  topo: Topo | undefined,
+  branchIndex: number
+): TrailContext => ({
+  ...ctx,
+  cross: undefined,
+  extensions: stripInheritedResourceExtensions(ctx, target, topo),
+  fire: undefined,
+  logger: deriveConcurrentBranchLogger(ctx, target, branchIndex),
+  resource: undefined,
+});
+
+const executeResolvedCrossTarget = async (
+  target: AnyTrail,
+  input: unknown,
+  ctx: TrailContext,
+  topo: Topo | undefined,
+  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>
+): Promise<Result<unknown, Error>> =>
+  await // eslint-disable-next-line no-use-before-define -- executor closure runs only after executeTrail is defined
+  executeTrail(target, input, {
+    ...forwarded,
+    ctx,
+    topo,
+    validationSchema: buildCrossValidationSchema(target),
+  });
+
 const executeCrossTarget = async (
   trailOrId: AnyTrail | string,
   input: unknown,
@@ -360,13 +432,13 @@ const executeCrossTarget = async (
     return target;
   }
 
-  return await // eslint-disable-next-line no-use-before-define -- executor closure runs only after executeTrail is defined
-  executeTrail(target.value, input, {
-    ...forwarded,
+  return await executeResolvedCrossTarget(
+    target.value,
+    input,
     ctx,
     topo,
-    validationSchema: buildCrossValidationSchema(target.value),
-  });
+    forwarded
+  );
 };
 
 const bindCrossToCtx = (
@@ -392,9 +464,20 @@ const bindCrossToCtx = (
   ) => {
     if (Array.isArray(trailOrCalls)) {
       return await Promise.all(
-        trailOrCalls.map(([trailOrId, batchInput]) =>
-          executeCrossTarget(trailOrId, batchInput, ctx, topo, forwarded)
-        )
+        trailOrCalls.map(async ([trailOrId, batchInput], branchIndex) => {
+          const target = resolveCrossTarget(trailOrId, topo);
+          if (target.isErr()) {
+            return target;
+          }
+
+          return await executeResolvedCrossTarget(
+            target.value,
+            batchInput,
+            buildConcurrentBranchContext(ctx, target.value, topo, branchIndex),
+            topo,
+            forwarded
+          );
+        })
       );
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,27 @@ import type { Signal } from './signal.js';
 import type { AnyTrail } from './trail.js';
 import type { CrossInput, TrailOutput } from './type-utils.js';
 
+type CrossBatchCall<TTarget extends AnyTrail | string = AnyTrail | string> =
+  TTarget extends AnyTrail
+    ? readonly [trail: TTarget, input: CrossInput<TTarget>]
+    : readonly [id: string, input: unknown];
+
+type CrossBatchResult<TTarget extends AnyTrail | string> =
+  TTarget extends AnyTrail
+    ? Result<TrailOutput<TTarget>, Error>
+    : Result<unknown, Error>;
+
+type CrossBatchResults<TCalls extends readonly CrossBatchCall[]> = {
+  readonly [K in keyof TCalls]: TCalls[K] extends readonly [
+    infer TTarget,
+    unknown,
+  ]
+    ? TTarget extends AnyTrail | string
+      ? CrossBatchResult<TTarget>
+      : never
+    : never;
+};
+
 /**
  * Trail implementation — sync or async.
  *
@@ -23,8 +44,14 @@ export type Implementation<I, O> = (
  *   infers `I` and `O` from the trail's schemas, so the result is fully typed.
  * - **By string id** (untyped escape hatch): `ctx.cross('gist.show', { id })`
  *   — returns `Result<O, Error>` where `O` defaults to `unknown`.
+ * - **By batch**: `ctx.cross([[showGist, { id }], ['audit.log', payload]])`
+ *   — executes every crossing concurrently and resolves once all results are
+ *   available. Result ordering always matches the input tuple ordering.
  */
 export interface CrossFn {
+  <const TCalls extends readonly CrossBatchCall[]>(
+    calls: TCalls
+  ): Promise<CrossBatchResults<TCalls>>;
   <T extends AnyTrail>(
     trail: T,
     input: CrossInput<T>

--- a/packages/testing/src/context.ts
+++ b/packages/testing/src/context.ts
@@ -111,10 +111,8 @@ export const createCrossContext = (
   options?: CreateCrossContextOptions
 ): CrossFn => {
   const responses = options?.responses ?? {};
-  // Accepts either a trail object (typed cross) or a string id (untyped).
-  return <O>(
-    idOrTrail: string | { readonly id: string },
-    _input: unknown
+  const respondToCross = <O>(
+    idOrTrail: string | { readonly id: string }
   ): Promise<Result<O, Error>> => {
     const id = typeof idOrTrail === 'string' ? idOrTrail : idOrTrail.id;
     const response = responses[id];
@@ -128,6 +126,22 @@ export const createCrossContext = (
     }
     return Promise.resolve(response as Result<O, Error>);
   };
+  const cross = (async (
+    idOrTrail:
+      | string
+      | { readonly id: string }
+      | readonly (readonly [string | { readonly id: string }, unknown])[],
+    _input?: unknown
+  ) => {
+    if (Array.isArray(idOrTrail)) {
+      return await Promise.all(
+        idOrTrail.map(([target]) => respondToCross(target))
+      );
+    }
+
+    return await respondToCross(idOrTrail as string | { readonly id: string });
+  }) as CrossFn;
+  return cross;
 };
 
 /**

--- a/packages/testing/src/crosses.ts
+++ b/packages/testing/src/crosses.ts
@@ -203,30 +203,55 @@ const createRecordingCross = (
 ): CrossFn => {
   // The generic O on CrossFn is erased at runtime; the cast is safe
   // because callers narrow via isOk/isErr before accessing the value.
-  // Accepts either a trail object (typed cross) or a string id (untyped).
-  const cross = (
+  const invokeCross = async (
     idOrTrail: string | { readonly id: string },
-    input: unknown
+    input: unknown,
+    self: CrossFn
   ) => {
     const id = resolveCrossId(idOrTrail);
     trace.push({ id, input });
 
     const injected = tryInjectError(id, scenario, trailsMap);
     if (injected !== undefined) {
-      return Promise.resolve(injected);
+      return injected;
     }
 
-    return delegateCross(
+    return await delegateCross(
       id,
       input,
       baseCross,
       trailsMap,
       ctx,
       resources,
-      cross as CrossFn
+      self
     );
   };
-  return cross as CrossFn;
+
+  // Accepts either a trail object (typed cross), a string id (untyped),
+  // or a batch of `[target, input]` tuples.
+  const cross = async function cross(
+    idOrTrail:
+      | string
+      | { readonly id: string }
+      | readonly (readonly [string | { readonly id: string }, unknown])[],
+    input?: unknown
+  ) {
+    if (Array.isArray(idOrTrail)) {
+      return await Promise.all(
+        idOrTrail.map(([target, batchInput]) =>
+          invokeCross(target, batchInput, cross as CrossFn)
+        )
+      );
+    }
+
+    return await invokeCross(
+      idOrTrail as string | { readonly id: string },
+      input,
+      cross as CrossFn
+    );
+  } as CrossFn;
+
+  return cross;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -196,30 +196,55 @@ const createCoverageCross = (
   ctx: TrailContext,
   resources?: ResourceOverrideMap
 ): CrossFn => {
-  // Accepts either a trail object (typed cross) or a string id (untyped).
-  const cross = (
+  const invokeCross = async (
     idOrTrail: string | { readonly id: string },
-    input: unknown
+    input: unknown,
+    self: CrossFn
   ) => {
     const id = typeof idOrTrail === 'string' ? idOrTrail : idOrTrail.id;
     called.add(id);
 
     if (baseCross !== undefined) {
-      return baseCross(id, input);
+      return await baseCross(id, input);
     }
 
     const trailDef = topo.get(id);
     if (trailDef !== undefined) {
-      return executeTrail(trailDef, input, {
-        ctx: { ...ctx, cross },
+      return await executeTrail(trailDef, input, {
+        ctx: { ...ctx, cross: self },
         resources,
         validationSchema: buildCrossValidationSchema(trailDef),
       });
     }
 
-    return Promise.resolve(Result.ok());
+    return Result.ok();
   };
-  return cross as CrossFn;
+
+  // Accepts either a trail object (typed cross), a string id (untyped),
+  // or a batch of `[target, input]` tuples.
+  const cross = async function cross(
+    idOrTrail:
+      | string
+      | { readonly id: string }
+      | readonly (readonly [string | { readonly id: string }, unknown])[],
+    input?: unknown
+  ) {
+    if (Array.isArray(idOrTrail)) {
+      return await Promise.all(
+        idOrTrail.map(([target, batchInput]) =>
+          invokeCross(target, batchInput, cross as CrossFn)
+        )
+      );
+    }
+
+    return await invokeCross(
+      idOrTrail as string | { readonly id: string },
+      input,
+      cross as CrossFn
+    );
+  } as CrossFn;
+
+  return cross;
 };
 
 /**

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -178,25 +178,47 @@ const createScenarioCross = (
   app: Topo,
   resources?: ResourceOverrideMap
 ): CrossFn => {
-  const cross: CrossFn = ((
+  const invokeCross = async (
     idOrTrail: string | { readonly id: string },
-    input: unknown
+    input: unknown,
+    self: CrossFn
   ) => {
     const id = typeof idOrTrail === 'string' ? idOrTrail : idOrTrail.id;
     const trailDef: AnyTrail | undefined = app.get(id);
     if (trailDef === undefined) {
-      return Promise.resolve(
-        R.err(new InternalError(`cross: trail "${id}" not found in topo`))
-      );
+      return R.err(new InternalError(`cross: trail "${id}" not found in topo`));
     }
     const baseCtx = createTestContext();
-    return executeTrail(trailDef, input, {
-      ctx: { ...baseCtx, cross },
+    return await executeTrail(trailDef, input, {
+      ctx: { ...baseCtx, cross: self },
       resources,
       topo: app,
       validationSchema: buildCrossValidationSchema(trailDef),
     });
-  }) as CrossFn;
+  };
+
+  const cross = async function cross(
+    idOrTrail:
+      | string
+      | { readonly id: string }
+      | readonly (readonly [string | { readonly id: string }, unknown])[],
+    input?: unknown
+  ) {
+    if (Array.isArray(idOrTrail)) {
+      return await Promise.all(
+        idOrTrail.map(([target, batchInput]) =>
+          invokeCross(target, batchInput, cross as CrossFn)
+        )
+      );
+    }
+
+    return await invokeCross(
+      idOrTrail as string | { readonly id: string },
+      input,
+      cross as CrossFn
+    );
+  } as CrossFn;
+
   return cross;
 };
 

--- a/packages/warden/src/__tests__/cross-declarations.test.ts
+++ b/packages/warden/src/__tests__/cross-declarations.test.ts
@@ -25,6 +25,26 @@ const t = trail('onboard', {
       expect(diagnostics.length).toBe(0);
     });
 
+    test('resolves batch ctx.cross() calls with string literals', () => {
+      const code = `
+trail('onboard', {
+  crosses: ['entity.add', 'search'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.cross([
+      ['entity.add', { name: input.name }],
+      ['search', { query: input.name }],
+    ]);
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = crossDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(0);
+    });
+
     test('no crosses declaration and no ctx.cross() calls', () => {
       const code = `
 trail('simple', {
@@ -60,6 +80,28 @@ trail('onboard', {
       expect(diagnostics[0]?.rule).toBe('cross-declarations');
       expect(diagnostics[0]?.message).toContain("ctx.cross('entity.add')");
       expect(diagnostics[0]?.message).toContain('not declared in crosses');
+    });
+
+    test('undeclared batch crossings still report an error', () => {
+      const code = `
+trail('onboard', {
+  crosses: ['entity.add'],
+  input: z.object({ name: z.string() }),
+  blaze: async (input, ctx) => {
+    await ctx.cross([
+      ['entity.add', { name: input.name }],
+      ['search', { query: input.name }],
+    ]);
+    return Result.ok({});
+  },
+});
+`;
+
+      const diagnostics = crossDeclarations.check(code, TEST_FILE);
+
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain("ctx.cross('search')");
     });
   });
 

--- a/packages/warden/src/rules/cross-declarations.ts
+++ b/packages/warden/src/rules/cross-declarations.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  extractFirstStringArg,
   findConfigProperty,
   findBlazeBodies,
   findTrailDefinitions,
@@ -231,38 +230,135 @@ const isMemberCrossCall = (
   return !!pair && ctxNames.has(pair.objName) && pair.propName === 'cross';
 };
 
-/** Sentinel indicating a cross call was found but the first arg is not a string literal. */
-const UNRESOLVED_CROSS = Symbol('unresolved-cross');
+interface ExtractedCrossCall {
+  readonly ids: readonly string[];
+  readonly hasUnresolved: boolean;
+}
 
-/**
- * Check if a node is a `<ctxName>.cross(...)` call and return the string trail ID.
- *
- * Also matches bare `cross(...)` calls from destructuring. When the first
- * argument is a non-string expression (e.g. a trail object identifier like
- * `ctx.cross(showGist, input)`), returns `UNRESOLVED_CROSS` so callers can
- * track that a cross call exists but its target cannot be statically resolved.
- */
-const extractCrossCallId = (
+const unresolvedCross = (): ExtractedCrossCall => ({
+  hasUnresolved: true,
+  ids: [],
+});
+
+const resolveBatchCrossTupleTarget = (
+  element: AstNode,
+  sourceCode: string
+): string | null => {
+  if (element.type !== 'ArrayExpression') {
+    return null;
+  }
+
+  const tupleElements = element['elements'] as readonly AstNode[] | undefined;
+  const [target] = tupleElements ?? [];
+  return target ? resolveCrossElementId(target, sourceCode) : null;
+};
+
+const collectBatchCrossId = (
+  element: AstNode,
+  sourceCode: string,
+  ids: string[]
+): boolean => {
+  const resolved = resolveBatchCrossTupleTarget(element, sourceCode);
+  if (!resolved) {
+    return true;
+  }
+  ids.push(resolved);
+  return false;
+};
+
+/** Extract statically-resolved trail IDs from `ctx.cross([[trail, input], ...])`. */
+const extractBatchCrossIds = (
+  firstArg: AstNode | undefined,
+  sourceCode: string
+): ExtractedCrossCall | null => {
+  if (firstArg?.type !== 'ArrayExpression') {
+    return null;
+  }
+
+  const elements = firstArg['elements'] as readonly AstNode[] | undefined;
+  const ids: string[] = [];
+  let hasUnresolved = false;
+
+  for (const element of elements ?? []) {
+    if (collectBatchCrossId(element, sourceCode, ids)) {
+      hasUnresolved = true;
+    }
+  }
+
+  return { hasUnresolved, ids };
+};
+
+const extractDirectCrossIds = (
+  firstArg: AstNode | undefined
+): ExtractedCrossCall | null => {
+  if (!firstArg || !isStringLiteral(firstArg)) {
+    return null;
+  }
+
+  const value = getStringValue(firstArg);
+  return value ? { hasUnresolved: false, ids: [value] } : unresolvedCross();
+};
+
+const isCrossCallExpression = (
+  callee: AstNode,
+  ctxNames: ReadonlySet<string>
+): boolean =>
+  isMemberCrossCall(callee, ctxNames) || identifierName(callee) === 'cross';
+
+const extractCrossFirstArg = (node: AstNode): AstNode | undefined => {
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  return args?.[0];
+};
+
+const resolveCrossCallNode = (
   node: AstNode,
   ctxNames: ReadonlySet<string>
-): string | typeof UNRESOLVED_CROSS | null => {
+): AstNode | null => {
   if (node.type !== 'CallExpression') {
     return null;
   }
 
   const callee = node['callee'] as AstNode | undefined;
-  if (!callee) {
+  if (!callee || !isCrossCallExpression(callee, ctxNames)) {
     return null;
   }
 
-  const isCrossCall =
-    isMemberCrossCall(callee, ctxNames) || identifierName(callee) === 'cross';
+  return node;
+};
 
-  if (!isCrossCall) {
+const resolveCrossCallTargets = (
+  firstArg: AstNode | undefined,
+  sourceCode: string
+): ExtractedCrossCall => {
+  const direct = extractDirectCrossIds(firstArg);
+  if (direct) {
+    return direct;
+  }
+
+  const batch = extractBatchCrossIds(firstArg, sourceCode);
+  return batch ?? unresolvedCross();
+};
+
+/**
+ * Check if a node is a `<ctxName>.cross(...)` call and return any statically
+ * resolvable target IDs.
+ *
+ * Also matches bare `cross(...)` calls from destructuring. When the first
+ * argument is a non-string expression (e.g. a trail object identifier like
+ * `ctx.cross(showGist, input)`), marks the call as unresolved so callers can
+ * track that a cross call exists but its target cannot be statically resolved.
+ */
+const extractCrossCall = (
+  node: AstNode,
+  ctxNames: ReadonlySet<string>,
+  sourceCode: string
+): ExtractedCrossCall | null => {
+  const crossCall = resolveCrossCallNode(node, ctxNames);
+  if (!crossCall) {
     return null;
   }
 
-  return extractFirstStringArg(node) ?? UNRESOLVED_CROSS;
+  return resolveCrossCallTargets(extractCrossFirstArg(crossCall), sourceCode);
 };
 
 /** Build the set of context parameter names to match against. */
@@ -289,16 +385,23 @@ interface CalledCrosses {
 /** Collect cross call results from a single blaze body. */
 const collectCrossCallsFromBody = (
   body: AstNode,
-  ids: Set<string>
+  ids: Set<string>,
+  sourceCode: string
 ): boolean => {
   const ctxNames = buildCtxNames(body);
   let foundUnresolved = false;
 
   walk(body, (node) => {
-    const id = extractCrossCallId(node, ctxNames);
-    if (id === UNRESOLVED_CROSS) {
+    const extracted = extractCrossCall(node, ctxNames, sourceCode);
+    if (!extracted) {
+      return;
+    }
+
+    if (extracted.hasUnresolved) {
       foundUnresolved = true;
-    } else if (id) {
+    }
+
+    for (const id of extracted.ids) {
       ids.add(id);
     }
   });
@@ -307,12 +410,15 @@ const collectCrossCallsFromBody = (
 };
 
 /** Walk blaze bodies and collect all statically resolvable ctx.cross() trail IDs. */
-const extractCalledCrosses = (config: AstNode): CalledCrosses => {
+const extractCalledCrosses = (
+  config: AstNode,
+  sourceCode: string
+): CalledCrosses => {
   const ids = new Set<string>();
   let hasUnresolved = false;
 
   for (const body of findBlazeBodies(config)) {
-    if (collectCrossCallsFromBody(body, ids)) {
+    if (collectCrossCallsFromBody(body, ids, sourceCode)) {
       hasUnresolved = true;
     }
   }
@@ -407,7 +513,7 @@ const checkTrailDefinition = (
   diagnostics: WardenDiagnostic[]
 ): void => {
   const declared = extractDeclaredCrosses(def.config, sourceCode);
-  const called = extractCalledCrosses(def.config);
+  const called = extractCalledCrosses(def.config, sourceCode);
 
   if (
     declared.ids.size === 0 &&


### PR DESCRIPTION
## Summary

First half of the concurrent crossings feature. Promotes ADR-0028 and lands the core `ctx.cross(...)` changes so reviewers see the contract change, the batch API, and scope isolation in one pass. Three branches folded together.

### ADR promotion
- Promote ADR-0028: Concurrent Trail Crossing to accepted status

### Batch `ctx.cross(...)` overload
- Accept an array of crossing declarations and resolve them concurrently, returning `Result[]` with order preserved
- Type the batch return as a tuple so callers keep per-entry `Result` narrowing
- Teach `@ontrails/testing` context/crosses/examples/scenario helpers to model batch crossings
- Extend the `cross-declarations` warden rule so `crosses` declarations match the new batch usage

### Isolated concurrent branch scopes
- Each concurrent branch now runs with its own `TrailContext` child scope so resource/state side effects don't cross-pollute
- Layers see a consistent per-branch scope for logging, tracing, and permit evaluation

## Testing

- `bun test packages/core/src/__tests__/execute.test.ts`
- `bun test packages/warden/src/__tests__/cross-declarations.test.ts`
- `bun run --cwd packages/core test`
- `bun run --cwd packages/testing test`
- `bun run typecheck`

## Closes

- Closes TRL-254
- Closes TRL-228
- Closes TRL-229
