### PR TITLE
feat: ctx.cross concurrency limits, tracing, and scenario coverage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./internal/cross-batch": "./src/internal/cross-batch.ts",
     "./internal/topo-saves": "./src/internal/topo-saves.ts",
     "./internal/topo-store": "./src/internal/topo-store.ts",
     "./internal/trails-db": "./src/internal/trails-db.ts",

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -798,6 +798,84 @@ describe('executeTrail', () => {
           resultOrder: labels,
         });
       });
+
+      describe.each([
+        { label: '0', value: 0 },
+        { label: '-1', value: -1 },
+        { label: '1.5', value: 1.5 },
+        { label: 'NaN', value: Number.NaN },
+      ])(
+        'rejects batch ctx.cross() calls with invalid concurrency $label',
+        ({ value }) => {
+          test('produces a ValidationError for every branch without running any', async () => {
+            const branchRuns: string[] = [];
+            const child = trail('entity.batch.invalid-concurrency.child', {
+              blaze: async () => {
+                branchRuns.push('ran');
+                return Result.ok({ id: 'child' });
+              },
+              input: z.object({}),
+              output: z.object({ id: z.string() }),
+              visibility: 'internal',
+            });
+            const entry = trail('entity.batch.invalid-concurrency.entry', {
+              blaze: async (_input, ctx) => {
+                const crossed = await requireCross(ctx)(
+                  [
+                    [child, {}],
+                    [child, {}],
+                  ] as const,
+                  { concurrency: value }
+                );
+                return Result.ok({
+                  statuses: crossed.map((result) =>
+                    result.match({
+                      err: (error) => ({
+                        isValidation: error instanceof ValidationError,
+                        message: error.message,
+                      }),
+                      ok: () => ({ isValidation: false, message: 'ok' }),
+                    })
+                  ),
+                });
+              },
+              crosses: [child],
+              input: z.object({}),
+              output: z.object({
+                statuses: z.array(
+                  z.object({
+                    isValidation: z.boolean(),
+                    message: z.string(),
+                  })
+                ),
+              }),
+            });
+            const app = topo(
+              `cross-batch-invalid-concurrency-${String(value)}-topo`,
+              { child, entry }
+            );
+
+            const result = await executeTrail(entry, {}, { topo: app });
+
+            expect(result.isOk()).toBe(true);
+            expect(result.unwrap()).toEqual({
+              statuses: [
+                {
+                  isValidation: true,
+                  message:
+                    'ctx.cross() batch concurrency must be a positive integer',
+                },
+                {
+                  isValidation: true,
+                  message:
+                    'ctx.cross() batch concurrency must be a positive integer',
+                },
+              ],
+            });
+            expect(branchRuns).toEqual([]);
+          });
+        }
+      );
     });
   });
 

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -352,318 +352,452 @@ const createSiblingFailureScopeScenario = () => {
   };
 };
 
+const createConcurrencyWorkerScenario = () => {
+  const captures = {
+    active: 0,
+    completionOrder: [] as string[],
+    maxActive: 0,
+  };
+  const worker = trail('entity.concurrent.worker', {
+    blaze: async (input: { delayMs: number; label: string }) => {
+      captures.active += 1;
+      captures.maxActive = Math.max(captures.maxActive, captures.active);
+      await Bun.sleep(input.delayMs);
+      captures.completionOrder.push(input.label);
+      captures.active -= 1;
+      return Result.ok({ label: input.label });
+    },
+    input: z.object({
+      delayMs: z.number(),
+      label: z.string(),
+    }),
+    output: z.object({ label: z.string() }),
+    visibility: 'internal',
+  });
+
+  return { captures, worker };
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe('executeTrail', () => {
   describe('happy path', () => {
-    test('validates input and executes trail', async () => {
-      const result = await executeTrail(echoTrail, { value: 'hello' });
+    describe('execution and resources', () => {
+      test('validates input and executes trail', async () => {
+        const result = await executeTrail(echoTrail, { value: 'hello' });
 
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({ value: 'hello' });
-    });
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toEqual({ value: 'hello' });
+      });
 
-    test('eagerly resolves declared resources before layers and implementation run', async () => {
-      const id = nextResourceId('eager');
-      const captures = {
-        createCalls: 0,
-        gateResolved: undefined as number | undefined,
-        runResolved: undefined as number | undefined,
-      };
-      const counter = createResolvedValueResource(
-        id,
-        () => {
+      test('eagerly resolves declared resources before layers and implementation run', async () => {
+        const id = nextResourceId('eager');
+        const captures = {
+          createCalls: 0,
+          gateResolved: undefined as number | undefined,
+          runResolved: undefined as number | undefined,
+        };
+        const counter = createResolvedValueResource(
+          id,
+          () => {
+            captures.createCalls += 1;
+          },
+          41
+        );
+        const layeredTrail = createEagerResourceTrail(id, counter, (value) => {
+          captures.runResolved = value;
+        });
+        const layer = createResourceProbeGate(counter, (value) => {
+          captures.gateResolved = value;
+        });
+
+        const result = await executeTrail(
+          layeredTrail,
+          {},
+          { layers: [layer] }
+        );
+
+        expect(result.unwrap()).toEqual({ total: 42 });
+        expect(captures.createCalls).toBe(1);
+        expect(captures.gateResolved).toBe(41);
+        expect(captures.runResolved).toBe(41);
+      });
+
+      test('awaits async resource factories before running the trail', async () => {
+        const db = resource(nextResourceId('async-factory'), {
+          create: async () => {
+            await Bun.sleep(0);
+            return Result.ok({ source: 'async-factory' });
+          },
+        });
+        const resourceTrail = trail('resource.async-factory', {
+          blaze: (_input, ctx) =>
+            Result.ok({ source: db.from(ctx).source as string }),
+          input: z.object({}),
+          output: z.object({ source: z.string() }),
+          resources: [db],
+        });
+
+        const result = await executeTrail(resourceTrail, {});
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toEqual({ source: 'async-factory' });
+      });
+
+      test('reuses cached singleton resources across executions', async () => {
+        const id = nextResourceId('singleton');
+        const captures = { createCalls: 0 };
+        const singleton = createSingletonResource(id, () => {
           captures.createCalls += 1;
-        },
-        41
-      );
-      const layeredTrail = createEagerResourceTrail(id, counter, (value) => {
-        captures.runResolved = value;
-      });
-      const layer = createResourceProbeGate(counter, (value) => {
-        captures.gateResolved = value;
-      });
+          return captures.createCalls;
+        });
+        const singletonTrail = createSingletonTrail(singleton);
 
-      const result = await executeTrail(layeredTrail, {}, { layers: [layer] });
+        const outputs = [
+          await unwrapExecution(singletonTrail),
+          await unwrapExecution(singletonTrail),
+        ];
 
-      expect(result.unwrap()).toEqual({ total: 42 });
-      expect(captures.createCalls).toBe(1);
-      expect(captures.gateResolved).toBe(41);
-      expect(captures.runResolved).toBe(41);
-    });
-
-    test('awaits async resource factories before running the trail', async () => {
-      const db = resource(nextResourceId('async-factory'), {
-        create: async () => {
-          await Bun.sleep(0);
-          return Result.ok({ source: 'async-factory' });
-        },
-      });
-      const resourceTrail = trail('resource.async-factory', {
-        blaze: (_input, ctx) =>
-          Result.ok({ source: db.from(ctx).source as string }),
-        input: z.object({}),
-        output: z.object({ source: z.string() }),
-        resources: [db],
+        expect(outputs).toEqual([{ createdAtCall: 1 }, { createdAtCall: 1 }]);
+        expect(captures.createCalls).toBe(1);
       });
 
-      const result = await executeTrail(resourceTrail, {});
+      test('scopes cached singleton resources to compatible resource contexts', async () => {
+        const id = nextResourceId('singleton-context');
+        const envAwareResource = resource(id, {
+          create: (ctx) => Result.ok({ value: String(ctx.env?.VAL) }),
+        });
+        const envAwareTrail = trail('resource.singleton-context', {
+          blaze: (_input, ctx) =>
+            Result.ok({ value: envAwareResource.from(ctx).value }),
+          input: z.object({}),
+          output: z.object({ value: z.string() }),
+          resources: [envAwareResource],
+        });
 
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({ source: 'async-factory' });
-    });
+        const first = await executeTrail(
+          envAwareTrail,
+          {},
+          {
+            createContext: () =>
+              createTrailContext({
+                env: { VAL: 'first' },
+              }),
+          }
+        );
+        const second = await executeTrail(
+          envAwareTrail,
+          {},
+          {
+            createContext: () =>
+              createTrailContext({
+                env: { VAL: 'second' },
+              }),
+          }
+        );
 
-    test('reuses cached singleton resources across executions', async () => {
-      const id = nextResourceId('singleton');
-      const captures = { createCalls: 0 };
-      const singleton = createSingletonResource(id, () => {
-        captures.createCalls += 1;
-        return captures.createCalls;
-      });
-      const singletonTrail = createSingletonTrail(singleton);
-
-      const outputs = [
-        await unwrapExecution(singletonTrail),
-        await unwrapExecution(singletonTrail),
-      ];
-
-      expect(outputs).toEqual([{ createdAtCall: 1 }, { createdAtCall: 1 }]);
-      expect(captures.createCalls).toBe(1);
-    });
-
-    test('scopes cached singleton resources to compatible resource contexts', async () => {
-      const id = nextResourceId('singleton-context');
-      const envAwareResource = resource(id, {
-        create: (ctx) => Result.ok({ value: String(ctx.env?.VAL) }),
-      });
-      const envAwareTrail = trail('resource.singleton-context', {
-        blaze: (_input, ctx) =>
-          Result.ok({ value: envAwareResource.from(ctx).value }),
-        input: z.object({}),
-        output: z.object({ value: z.string() }),
-        resources: [envAwareResource],
-      });
-
-      const first = await executeTrail(
-        envAwareTrail,
-        {},
-        {
-          createContext: () =>
-            createTrailContext({
-              env: { VAL: 'first' },
-            }),
-        }
-      );
-      const second = await executeTrail(
-        envAwareTrail,
-        {},
-        {
-          createContext: () =>
-            createTrailContext({
-              env: { VAL: 'second' },
-            }),
-        }
-      );
-
-      expect(first.unwrap()).toEqual({ value: 'first' });
-      expect(second.unwrap()).toEqual({ value: 'second' });
-    });
-
-    test('binds ctx.cross when topo access is available', async () => {
-      const helper = trail('entity.secret.rotate', {
-        blaze: (input: { id: string }) => Result.ok({ rotated: input.id }),
-        input: z.object({ id: z.string() }),
-        output: z.object({ rotated: z.string() }),
-        visibility: 'internal',
-      });
-      const entry = trail('entity.rotate', {
-        blaze: async (input: { id: string }, ctx) => {
-          const crossed = await requireCross(ctx)(
-            'entity.secret.rotate',
-            input
-          );
-          return crossed.match({
-            err: (error) => Result.err(error),
-            ok: (value) => Result.ok(value),
-          });
-        },
-        crosses: ['entity.secret.rotate'],
-        input: z.object({ id: z.string() }),
-        output: z.object({ rotated: z.string() }),
-      });
-      const app = topo('cross-topo', { entry, helper });
-
-      const result = await executeTrail(entry, { id: 'abc123' }, { topo: app });
-
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({ rotated: 'abc123' });
-    });
-
-    test('validates merged crossInput fields when invoking through ctx.cross', async () => {
-      const helper = trail('entity.prepare', {
-        blaze: (input: { forkedFrom: string; id: string }) =>
-          Result.ok({ summary: `${input.id}:${input.forkedFrom}` }),
-        crossInput: z.object({ forkedFrom: z.string() }),
-        input: z.object({ id: z.string() }),
-        output: z.object({ summary: z.string() }),
-        visibility: 'internal',
-      });
-      const entry = trail('entity.run', {
-        blaze: async (input: { id: string }, ctx) => {
-          const crossed = await requireCross(ctx)(helper, {
-            forkedFrom: 'entity.run',
-            id: input.id,
-          });
-          return crossed.match({
-            err: (error) => Result.err(error),
-            ok: (value) => Result.ok(value),
-          });
-        },
-        crosses: [helper],
-        input: z.object({ id: z.string() }),
-        output: z.object({ summary: z.string() }),
-      });
-      const app = topo('cross-input-topo', { entry, helper });
-
-      const result = await executeTrail(entry, { id: 'abc123' }, { topo: app });
-
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({ summary: 'abc123:entity.run' });
-    });
-
-    test('executes batch ctx.cross() calls concurrently and preserves tuple order', async () => {
-      const completionOrder: string[] = [];
-      const slow = trail('entity.slow', {
-        blaze: async () => {
-          await Bun.sleep(10);
-          completionOrder.push('slow');
-          return Result.ok({ id: 'slow' });
-        },
-        input: z.object({}),
-        output: z.object({ id: z.string() }),
-        visibility: 'internal',
-      });
-      const fast = trail('entity.fast', {
-        blaze: async () => {
-          await Bun.sleep(0);
-          completionOrder.push('fast');
-          return Result.ok({ id: 'fast' });
-        },
-        input: z.object({}),
-        output: z.object({ id: z.string() }),
-        visibility: 'internal',
-      });
-      const entry = trail('entity.batch', {
-        blaze: async (_input, ctx) => {
-          const crossed = await requireCross(ctx)([
-            ['entity.slow', {}],
-            ['entity.fast', {}],
-          ]);
-          return Result.ok({
-            completionOrder,
-            resultOrder: crossed.map((result) =>
-              result.match({
-                err: () => 'err',
-                ok: (value) => (value as { id: string }).id,
-              })
-            ),
-          });
-        },
-        crosses: ['entity.fast', 'entity.slow'],
-        input: z.object({}),
-        output: z.object({
-          completionOrder: z.array(z.string()),
-          resultOrder: z.array(z.string()),
-        }),
-      });
-      const app = topo('cross-batch-topo', { entry, fast, slow });
-
-      const result = await executeTrail(entry, {}, { topo: app });
-
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({
-        completionOrder: ['fast', 'slow'],
-        resultOrder: ['slow', 'fast'],
+        expect(first.unwrap()).toEqual({ value: 'first' });
+        expect(second.unwrap()).toEqual({ value: 'second' });
       });
     });
 
-    test('returns every batch cross result without short-circuiting on errors', async () => {
-      const completions: string[] = [];
-      const failing = trail('entity.fail', {
-        blaze: async () => {
-          await Bun.sleep(0);
-          completions.push('fail');
-          return Result.err(new ValidationError('nope'));
-        },
-        input: z.object({}),
-        output: z.object({ ok: z.boolean() }),
-        visibility: 'internal',
-      });
-      const succeeding = trail('entity.ok', {
-        blaze: async () => {
-          await Bun.sleep(5);
-          completions.push('ok');
-          return Result.ok({ ok: true });
-        },
-        input: z.object({}),
-        output: z.object({ ok: z.boolean() }),
-        visibility: 'internal',
-      });
-      const entry = trail('entity.batch.errors', {
-        blaze: async (_input, ctx) => {
-          const crossed = await requireCross(ctx)([
-            [failing, {}],
-            [succeeding, {}],
-          ] as const);
-          return Result.ok({
-            completions,
-            statuses: crossed.map((result) =>
-              result.match({
-                err: () => 'err',
-                ok: () => 'ok',
-              })
-            ),
-          });
-        },
-        crosses: [failing, succeeding],
-        input: z.object({}),
-        output: z.object({
-          completions: z.array(z.string()),
-          statuses: z.array(z.string()),
-        }),
-      });
-      const app = topo('cross-batch-errors-topo', {
-        entry,
-        failing,
-        succeeding,
+    describe('crossing execution', () => {
+      test('binds ctx.cross when topo access is available', async () => {
+        const helper = trail('entity.secret.rotate', {
+          blaze: (input: { id: string }) => Result.ok({ rotated: input.id }),
+          input: z.object({ id: z.string() }),
+          output: z.object({ rotated: z.string() }),
+          visibility: 'internal',
+        });
+        const entry = trail('entity.rotate', {
+          blaze: async (input: { id: string }, ctx) => {
+            const crossed = await requireCross(ctx)(
+              'entity.secret.rotate',
+              input
+            );
+            return crossed.match({
+              err: (error) => Result.err(error),
+              ok: (value) => Result.ok(value),
+            });
+          },
+          crosses: ['entity.secret.rotate'],
+          input: z.object({ id: z.string() }),
+          output: z.object({ rotated: z.string() }),
+        });
+        const app = topo('cross-topo', { entry, helper });
+
+        const result = await executeTrail(
+          entry,
+          { id: 'abc123' },
+          { topo: app }
+        );
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toEqual({ rotated: 'abc123' });
       });
 
-      const result = await executeTrail(entry, {}, { topo: app });
+      test('validates merged crossInput fields when invoking through ctx.cross', async () => {
+        const helper = trail('entity.prepare', {
+          blaze: (input: { forkedFrom: string; id: string }) =>
+            Result.ok({ summary: `${input.id}:${input.forkedFrom}` }),
+          crossInput: z.object({ forkedFrom: z.string() }),
+          input: z.object({ id: z.string() }),
+          output: z.object({ summary: z.string() }),
+          visibility: 'internal',
+        });
+        const entry = trail('entity.run', {
+          blaze: async (input: { id: string }, ctx) => {
+            const crossed = await requireCross(ctx)(helper, {
+              forkedFrom: 'entity.run',
+              id: input.id,
+            });
+            return crossed.match({
+              err: (error) => Result.err(error),
+              ok: (value) => Result.ok(value),
+            });
+          },
+          crosses: [helper],
+          input: z.object({ id: z.string() }),
+          output: z.object({ summary: z.string() }),
+        });
+        const app = topo('cross-input-topo', { entry, helper });
 
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({
-        completions: ['fail', 'ok'],
-        statuses: ['err', 'ok'],
+        const result = await executeTrail(
+          entry,
+          { id: 'abc123' },
+          { topo: app }
+        );
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toEqual({ summary: 'abc123:entity.run' });
       });
-    });
 
-    test('returns an empty array for empty batch ctx.cross() calls', async () => {
-      const entry = trail('entity.batch.empty', {
-        blaze: async (_input, ctx) => {
-          const crossed = await requireCross(ctx)([]);
-          return Result.ok({ count: crossed.length });
-        },
-        input: z.object({}),
-        output: z.object({ count: z.number() }),
+      test('executes batch ctx.cross() calls concurrently and preserves tuple order', async () => {
+        const completionOrder: string[] = [];
+        const slow = trail('entity.slow', {
+          blaze: async () => {
+            await Bun.sleep(10);
+            completionOrder.push('slow');
+            return Result.ok({ id: 'slow' });
+          },
+          input: z.object({}),
+          output: z.object({ id: z.string() }),
+          visibility: 'internal',
+        });
+        const fast = trail('entity.fast', {
+          blaze: async () => {
+            await Bun.sleep(0);
+            completionOrder.push('fast');
+            return Result.ok({ id: 'fast' });
+          },
+          input: z.object({}),
+          output: z.object({ id: z.string() }),
+          visibility: 'internal',
+        });
+        const entry = trail('entity.batch', {
+          blaze: async (_input, ctx) => {
+            const crossed = await requireCross(ctx)([
+              ['entity.slow', {}],
+              ['entity.fast', {}],
+            ]);
+            return Result.ok({
+              completionOrder,
+              resultOrder: crossed.map((result) =>
+                result.match({
+                  err: () => 'err',
+                  ok: (value) => value.id,
+                })
+              ),
+            });
+          },
+          crosses: ['entity.fast', 'entity.slow'],
+          input: z.object({}),
+          output: z.object({
+            completionOrder: z.array(z.string()),
+            resultOrder: z.array(z.string()),
+          }),
+        });
+        const app = topo('cross-batch-topo', { entry, fast, slow });
+
+        const result = await executeTrail(entry, {}, { topo: app });
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toEqual({
+          completionOrder: ['fast', 'slow'],
+          resultOrder: ['slow', 'fast'],
+        });
       });
-      const app = topo('cross-batch-empty-topo', { entry });
 
-      const result = await executeTrail(entry, {}, { topo: app });
+      test('returns every batch cross result without short-circuiting on errors', async () => {
+        const completions: string[] = [];
+        const failing = trail('entity.fail', {
+          blaze: async () => {
+            await Bun.sleep(0);
+            completions.push('fail');
+            return Result.err(new ValidationError('nope'));
+          },
+          input: z.object({}),
+          output: z.object({ ok: z.boolean() }),
+          visibility: 'internal',
+        });
+        const succeeding = trail('entity.ok', {
+          blaze: async () => {
+            await Bun.sleep(5);
+            completions.push('ok');
+            return Result.ok({ ok: true });
+          },
+          input: z.object({}),
+          output: z.object({ ok: z.boolean() }),
+          visibility: 'internal',
+        });
+        const entry = trail('entity.batch.errors', {
+          blaze: async (_input, ctx) => {
+            const crossed = await requireCross(ctx)([
+              [failing, {}],
+              [succeeding, {}],
+            ] as const);
+            return Result.ok({
+              completions,
+              statuses: crossed.map((result) =>
+                result.match({
+                  err: () => 'err',
+                  ok: () => 'ok',
+                })
+              ),
+            });
+          },
+          crosses: [failing, succeeding],
+          input: z.object({}),
+          output: z.object({
+            completions: z.array(z.string()),
+            statuses: z.array(z.string()),
+          }),
+        });
+        const app = topo('cross-batch-errors-topo', {
+          entry,
+          failing,
+          succeeding,
+        });
 
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({ count: 0 });
+        const result = await executeTrail(entry, {}, { topo: app });
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toEqual({
+          completions: ['fail', 'ok'],
+          statuses: ['err', 'ok'],
+        });
+      });
+
+      test('returns an empty array for empty batch ctx.cross() calls', async () => {
+        const entry = trail('entity.batch.empty', {
+          blaze: async (_input, ctx) => {
+            const crossed = await requireCross(ctx)([]);
+            return Result.ok({ count: crossed.length });
+          },
+          input: z.object({}),
+          output: z.object({ count: z.number() }),
+        });
+        const app = topo('cross-batch-empty-topo', { entry });
+
+        const result = await executeTrail(entry, {}, { topo: app });
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toEqual({ count: 0 });
+      });
+
+      test('limits batch ctx.cross() execution to sequential flow when concurrency is 1', async () => {
+        const { captures, worker } = createConcurrencyWorkerScenario();
+        const entry = trail('entity.batch.sequential-limit', {
+          blaze: async (_input, ctx) => {
+            const crossed = await requireCross(ctx)(
+              [
+                [worker, { delayMs: 5, label: 'first' }],
+                [worker, { delayMs: 0, label: 'second' }],
+                [worker, { delayMs: 0, label: 'third' }],
+              ] as const,
+              { concurrency: 1 }
+            );
+            return Result.ok({
+              completionOrder: captures.completionOrder,
+              maxActive: captures.maxActive,
+              resultOrder: crossed.map((result) =>
+                result.match({
+                  err: () => 'err',
+                  ok: (value) => value.label,
+                })
+              ),
+            });
+          },
+          crosses: [worker],
+          input: z.object({}),
+          output: z.object({
+            completionOrder: z.array(z.string()),
+            maxActive: z.number(),
+            resultOrder: z.array(z.string()),
+          }),
+        });
+        const app = topo('cross-batch-sequential-limit-topo', {
+          entry,
+          worker,
+        });
+
+        const result = await executeTrail(entry, {}, { topo: app });
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toEqual({
+          completionOrder: ['first', 'second', 'third'],
+          maxActive: 1,
+          resultOrder: ['first', 'second', 'third'],
+        });
+      });
+
+      test('caps concurrent batch ctx.cross() execution and preserves input order', async () => {
+        const { captures, worker } = createConcurrencyWorkerScenario();
+        const labels = Array.from(
+          { length: 10 },
+          (_, index) => `task-${index}`
+        );
+        const entry = trail('entity.batch.concurrent-limit', {
+          blaze: async (_input, ctx) => {
+            const crossed = await requireCross(ctx)(
+              labels.map((label) => [worker, { delayMs: 5, label }] as const),
+              { concurrency: 3 }
+            );
+            return Result.ok({
+              completionCount: captures.completionOrder.length,
+              maxActive: captures.maxActive,
+              resultOrder: crossed.map((result) =>
+                result.match({
+                  err: () => 'err',
+                  ok: (value) => value.label,
+                })
+              ),
+            });
+          },
+          crosses: [worker],
+          input: z.object({}),
+          output: z.object({
+            completionCount: z.number(),
+            maxActive: z.number(),
+            resultOrder: z.array(z.string()),
+          }),
+        });
+        const app = topo('cross-batch-concurrent-limit-topo', {
+          entry,
+          worker,
+        });
+
+        const result = await executeTrail(entry, {}, { topo: app });
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toEqual({
+          completionCount: 10,
+          maxActive: 3,
+          resultOrder: labels,
+        });
+      });
     });
   });
 

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -607,7 +607,7 @@ describe('executeTrail', () => {
               resultOrder: crossed.map((result) =>
                 result.match({
                   err: () => 'err',
-                  ok: (value) => value.id,
+                  ok: (value) => (value as { id: string }).id,
                 })
               ),
             });

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -16,6 +16,7 @@ import type { Topo } from './topo.js';
 
 import { createFireFn } from './fire.js';
 import type {
+  CrossBatchOptions,
   CrossFn,
   Implementation,
   TraceFn,
@@ -30,6 +31,7 @@ import {
   InternalError,
   NotFoundError,
   TrailsError,
+  ValidationError,
 } from './errors.js';
 import {
   TRACE_CONTEXT_KEY,
@@ -441,6 +443,142 @@ const executeCrossTarget = async (
   );
 };
 
+type CrossBatchCall = readonly [AnyTrail | string, unknown];
+
+const normalizeCrossBatchConcurrency = (
+  options: CrossBatchOptions | undefined
+): Result<number | undefined, Error> => {
+  const concurrency = options?.concurrency;
+  if (concurrency === undefined) {
+    return Result.ok();
+  }
+
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    return Result.err(
+      new ValidationError(
+        'ctx.cross() batch concurrency must be a positive integer'
+      )
+    );
+  }
+
+  return Result.ok(concurrency);
+};
+
+const createCrossBatchValidationResults = (
+  calls: readonly CrossBatchCall[],
+  error: Error
+): Result<unknown, Error>[] => calls.map(() => Result.err(error));
+
+const executeConcurrentCrossBatchCall = async (
+  call: CrossBatchCall,
+  branchIndex: number,
+  ctx: TrailContext,
+  topo: Topo | undefined,
+  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>
+): Promise<Result<unknown, Error>> => {
+  const [trailOrId, batchInput] = call;
+  const target = resolveCrossTarget(trailOrId, topo);
+  if (target.isErr()) {
+    return target;
+  }
+
+  return await executeResolvedCrossTarget(
+    target.value,
+    batchInput,
+    buildConcurrentBranchContext(ctx, target.value, topo, branchIndex),
+    topo,
+    forwarded
+  );
+};
+
+const executeUnlimitedCrossBatch = async (
+  calls: readonly CrossBatchCall[],
+  ctx: TrailContext,
+  topo: Topo | undefined,
+  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>
+): Promise<Result<unknown, Error>[]> =>
+  await Promise.all(
+    calls.map((call, branchIndex) =>
+      executeConcurrentCrossBatchCall(call, branchIndex, ctx, topo, forwarded)
+    )
+  );
+
+const createCrossBatchResults = (
+  calls: readonly CrossBatchCall[]
+): Result<unknown, Error>[] =>
+  Array.from<Result<unknown, Error>>({ length: calls.length });
+
+const claimNextCrossBatchIndex = (
+  nextIndex: { value: number },
+  calls: readonly CrossBatchCall[]
+): number | undefined => {
+  if (nextIndex.value >= calls.length) {
+    return undefined;
+  }
+
+  const branchIndex = nextIndex.value;
+  nextIndex.value += 1;
+  return branchIndex;
+};
+
+const executeLimitedCrossBatch = async (
+  calls: readonly CrossBatchCall[],
+  ctx: TrailContext,
+  topo: Topo | undefined,
+  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>,
+  limit: number
+): Promise<Result<unknown, Error>[]> => {
+  const results = createCrossBatchResults(calls);
+  const nextIndex = { value: 0 };
+
+  const runWorker = async () => {
+    while (true) {
+      const branchIndex = claimNextCrossBatchIndex(nextIndex, calls);
+      if (branchIndex === undefined) {
+        return;
+      }
+
+      const call = calls[branchIndex];
+      if (call === undefined) {
+        return;
+      }
+
+      results[branchIndex] = await executeConcurrentCrossBatchCall(
+        call,
+        branchIndex,
+        ctx,
+        topo,
+        forwarded
+      );
+    }
+  };
+
+  await Promise.all(Array.from({ length: limit }, runWorker));
+  return results;
+};
+
+const executeCrossBatch = async (
+  calls: readonly CrossBatchCall[],
+  ctx: TrailContext,
+  topo: Topo | undefined,
+  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>,
+  batchOptions?: CrossBatchOptions
+): Promise<Result<unknown, Error>[]> => {
+  if (calls.length === 0) {
+    return [];
+  }
+
+  const concurrency = normalizeCrossBatchConcurrency(batchOptions);
+  if (concurrency.isErr()) {
+    return createCrossBatchValidationResults(calls, concurrency.error);
+  }
+
+  const limit = concurrency.value ?? calls.length;
+  return limit >= calls.length
+    ? await executeUnlimitedCrossBatch(calls, ctx, topo, forwarded)
+    : await executeLimitedCrossBatch(calls, ctx, topo, forwarded, limit);
+};
+
 const bindCrossToCtx = (
   ctx: TrailContext,
   topo: Topo | undefined,
@@ -460,30 +598,21 @@ const bindCrossToCtx = (
       | AnyTrail
       | string
       | readonly (readonly [AnyTrail | string, unknown])[],
-    input?: unknown
+    inputOrOptions?: CrossBatchOptions | unknown
   ) => {
     if (Array.isArray(trailOrCalls)) {
-      return await Promise.all(
-        trailOrCalls.map(async ([trailOrId, batchInput], branchIndex) => {
-          const target = resolveCrossTarget(trailOrId, topo);
-          if (target.isErr()) {
-            return target;
-          }
-
-          return await executeResolvedCrossTarget(
-            target.value,
-            batchInput,
-            buildConcurrentBranchContext(ctx, target.value, topo, branchIndex),
-            topo,
-            forwarded
-          );
-        })
+      return await executeCrossBatch(
+        trailOrCalls,
+        ctx,
+        topo,
+        forwarded,
+        inputOrOptions as CrossBatchOptions | undefined
       );
     }
 
     return await executeCrossTarget(
       trailOrCalls as AnyTrail | string,
-      input,
+      inputOrOptions,
       ctx,
       topo,
       forwarded

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -31,8 +31,12 @@ import {
   InternalError,
   NotFoundError,
   TrailsError,
-  ValidationError,
 } from './errors.js';
+import {
+  claimNextCrossBatchIndex,
+  createCrossBatchValidationResults,
+  normalizeCrossBatchConcurrency,
+} from './internal/cross-batch.js';
 import {
   TRACE_CONTEXT_KEY,
   completeRecord,
@@ -445,30 +449,6 @@ const executeCrossTarget = async (
 
 type CrossBatchCall = readonly [AnyTrail | string, unknown];
 
-const normalizeCrossBatchConcurrency = (
-  options: CrossBatchOptions | undefined
-): Result<number | undefined, Error> => {
-  const concurrency = options?.concurrency;
-  if (concurrency === undefined) {
-    return Result.ok();
-  }
-
-  if (!Number.isInteger(concurrency) || concurrency < 1) {
-    return Result.err(
-      new ValidationError(
-        'ctx.cross() batch concurrency must be a positive integer'
-      )
-    );
-  }
-
-  return Result.ok(concurrency);
-};
-
-const createCrossBatchValidationResults = (
-  calls: readonly CrossBatchCall[],
-  error: Error
-): Result<unknown, Error>[] => calls.map(() => Result.err(error));
-
 const executeConcurrentCrossBatchCall = async (
   call: CrossBatchCall,
   branchIndex: number,
@@ -508,19 +488,6 @@ const createCrossBatchResults = (
 ): Result<unknown, Error>[] =>
   Array.from<Result<unknown, Error>>({ length: calls.length });
 
-const claimNextCrossBatchIndex = (
-  nextIndex: { value: number },
-  calls: readonly CrossBatchCall[]
-): number | undefined => {
-  if (nextIndex.value >= calls.length) {
-    return undefined;
-  }
-
-  const branchIndex = nextIndex.value;
-  nextIndex.value += 1;
-  return branchIndex;
-};
-
 const executeLimitedCrossBatch = async (
   calls: readonly CrossBatchCall[],
   ctx: TrailContext,
@@ -540,7 +507,16 @@ const executeLimitedCrossBatch = async (
 
       const call = calls[branchIndex];
       if (call === undefined) {
-        return;
+        // Defensive: `claimNextCrossBatchIndex` only returns indices within
+        // bounds, so this slot should always be populated. If it ever isn't,
+        // surface a clear InternalError in place of the missing slot and keep
+        // the worker loop running so sibling branches still get processed.
+        results[branchIndex] = Result.err(
+          new InternalError(
+            `unreachable: concurrent cross batch call missing at index ${branchIndex}`
+          )
+        );
+        continue;
       }
 
       results[branchIndex] = await executeConcurrentCrossBatchCall(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,7 @@ export type {
   Implementation,
   TrailContext,
   TrailContextInit,
+  CrossBatchOptions,
   CrossFn,
   FireFn,
   BasePermit,

--- a/packages/core/src/internal/cross-batch.ts
+++ b/packages/core/src/internal/cross-batch.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared helpers for `ctx.cross([...])` batch execution.
+ *
+ * These helpers normalize batch options, produce validation results, and
+ * implement the unlimited/limited worker-pool execution strategies used by
+ * both the real executor (`packages/core/src/execute.ts`) and the scenario
+ * runner in `@ontrails/testing`. Extracting them here keeps the validation
+ * rule, error message, and worker-pool semantics authored in one place so
+ * the two call sites cannot drift.
+ *
+ * @internal
+ */
+
+import { ValidationError } from '../errors.js';
+import { Result } from '../result.js';
+import type { CrossBatchOptions } from '../types.js';
+
+/**
+ * Validate the `concurrency` option on a batch `ctx.cross()` call.
+ *
+ * Returns `Ok(undefined)` when no limit is requested, `Ok(n)` when a
+ * positive integer is supplied, and `Err(ValidationError)` for any other
+ * value. The error message is load-bearing: callers and tests depend on
+ * the exact string.
+ *
+ * @internal
+ */
+export const normalizeCrossBatchConcurrency = (
+  options: CrossBatchOptions | undefined
+): Result<number | undefined, Error> => {
+  const concurrency = options?.concurrency;
+  if (concurrency === undefined) {
+    return Result.ok();
+  }
+
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    return Result.err(
+      new ValidationError(
+        'ctx.cross() batch concurrency must be a positive integer'
+      )
+    );
+  }
+
+  return Result.ok(concurrency);
+};
+
+/**
+ * Produce one validation-error result per call, preserving the original
+ * call order. Used when `normalizeCrossBatchConcurrency` fails so the caller
+ * can surface a uniform batch shape to the trail implementation.
+ *
+ * @internal
+ */
+export const createCrossBatchValidationResults = <TCall>(
+  calls: readonly TCall[],
+  error: Error
+): Result<unknown, Error>[] => calls.map(() => Result.err(error));
+
+/**
+ * Claim the next branch index from a shared counter. Safe to call from
+ * multiple worker coroutines because JavaScript is single-threaded between
+ * awaits — the read/increment pair runs without interleaving.
+ *
+ * @internal
+ */
+export const claimNextCrossBatchIndex = <TCall>(
+  nextIndex: { value: number },
+  calls: readonly TCall[]
+): number | undefined => {
+  if (nextIndex.value >= calls.length) {
+    return undefined;
+  }
+
+  const branchIndex = nextIndex.value;
+  nextIndex.value += 1;
+  return branchIndex;
+};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -24,6 +24,16 @@ type CrossBatchResults<TCalls extends readonly CrossBatchCall[]> = {
     : never;
 };
 
+/** Runtime options for batch `ctx.cross([...])` calls. */
+export interface CrossBatchOptions {
+  /**
+   * Maximum number of branches to execute concurrently.
+   *
+   * Omit for unbounded concurrency. `1` is equivalent to sequential execution.
+   */
+  readonly concurrency?: number | undefined;
+}
+
 /**
  * Trail implementation — sync or async.
  *
@@ -46,11 +56,14 @@ export type Implementation<I, O> = (
  *   — returns `Result<O, Error>` where `O` defaults to `unknown`.
  * - **By batch**: `ctx.cross([[showGist, { id }], ['audit.log', payload]])`
  *   — executes every crossing concurrently and resolves once all results are
- *   available. Result ordering always matches the input tuple ordering.
+ *   available. Result ordering always matches the input tuple ordering. Pass
+ *   `{ concurrency: N }` as the second argument to limit how many branches
+ *   run at once.
  */
 export interface CrossFn {
   <const TCalls extends readonly CrossBatchCall[]>(
-    calls: TCalls
+    calls: TCalls,
+    options?: CrossBatchOptions
   ): Promise<CrossBatchResults<TCalls>>;
   <T extends AnyTrail>(
     trail: T,

--- a/packages/testing/src/__tests__/scenario.test.ts
+++ b/packages/testing/src/__tests__/scenario.test.ts
@@ -343,9 +343,12 @@ describe('executeScenarioSteps concurrent crossing support', () => {
         return Result.ok({
           startedBeforeRelease,
           startedOverall: [...startedIds],
-          successIds: results
-            .filter((result) => result.isOk())
-            .map((result) => result.value.id),
+          successIds: results.flatMap((result) =>
+            result.match({
+              err: () => [] as string[],
+              ok: (value) => [value.id],
+            })
+          ),
         });
       },
       crosses: [slowTrail, fastTrail, queuedTrail],

--- a/packages/testing/src/__tests__/scenario.test.ts
+++ b/packages/testing/src/__tests__/scenario.test.ts
@@ -4,7 +4,8 @@ import type { TrailContext } from '@ontrails/core';
 import { resource, Result, trail, topo } from '@ontrails/core';
 import { z } from 'zod';
 
-import { ref, scenario } from '../scenario.js';
+import { errResultMatch, okResultMatch } from '../assertions.js';
+import { executeScenarioSteps, ref, scenario } from '../scenario.js';
 import type { ScenarioStep } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -74,6 +75,28 @@ const app = topo('scenario-test-app', {
   queryTrail,
   showTrail,
 } as Record<string, unknown>);
+
+const readySignal = 'ready';
+type ReadySignal = typeof readySignal;
+
+const concurrentBatchOutput = z.object({ results: z.array(z.unknown()) });
+
+const createReadyController = () => Promise.withResolvers<ReadySignal>();
+
+const requireCrossFn = (
+  ctx: TrailContext
+): NonNullable<TrailContext['cross']> => {
+  expect(ctx.cross).toBeDefined();
+  return ctx.cross as NonNullable<TrailContext['cross']>;
+};
+
+const waitForReadyPair = async (
+  first: Promise<ReadySignal>,
+  second: Promise<ReadySignal>
+): Promise<void> => {
+  await first;
+  await second;
+};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -162,9 +185,6 @@ describe('scenario()', () => {
   // Duplicate alias guard
   describe('duplicate alias guard', () => {
     test('throws on duplicate step alias', async () => {
-      // Import executeScenarioSteps to test the guard directly.
-      const { executeScenarioSteps } = await import('../scenario.js');
-
       const steps: ScenarioStep[] = [
         { as: 'dup', cross: createTrail, input: { name: 'A' } },
         { as: 'dup', cross: createTrail, input: { name: 'B' } },
@@ -174,5 +194,185 @@ describe('scenario()', () => {
         'duplicate step alias "dup"'
       );
     });
+  });
+});
+
+describe('executeScenarioSteps concurrent crossing support', () => {
+  test('matches concurrent fan-out arrays with ok result helpers', async () => {
+    const alphaTrail = trail('scenario.batch.alpha', {
+      blaze: () => Result.ok({ label: 'alpha' }),
+      input: z.object({}),
+      output: z.object({ label: z.string() }),
+      visibility: 'internal',
+    });
+    const betaTrail = trail('scenario.batch.beta', {
+      blaze: () => Result.ok({ label: 'beta' }),
+      input: z.object({}),
+      output: z.object({ label: z.string() }),
+      visibility: 'internal',
+    });
+    const fanoutTrail = trail('scenario.batch.fanout', {
+      blaze: async (_input, ctx) => {
+        const results = await requireCrossFn(ctx)([
+          [alphaTrail, {}],
+          [betaTrail, {}],
+        ] as const);
+        return Result.ok({ results });
+      },
+      crosses: [alphaTrail, betaTrail],
+      input: z.object({}),
+      output: concurrentBatchOutput,
+    });
+    const fanoutApp = topo('scenario-concurrent-fanout-app', {
+      alphaTrail,
+      betaTrail,
+      fanoutTrail,
+    } as Record<string, unknown>);
+
+    await executeScenarioSteps(fanoutApp, [
+      {
+        cross: fanoutTrail,
+        expectedMatch: {
+          results: [
+            okResultMatch({ label: 'alpha' }),
+            okResultMatch({ label: 'beta' }),
+          ],
+        },
+        input: {},
+      },
+    ]);
+  });
+
+  test('matches mixed ok/err batch results for partial failure scenarios', async () => {
+    const successTrail = trail('scenario.batch.partial.success', {
+      blaze: () => Result.ok({ label: 'success' }),
+      input: z.object({}),
+      output: z.object({ label: z.string() }),
+      visibility: 'internal',
+    });
+    const failureTrail = trail('scenario.batch.partial.failure', {
+      blaze: () => Result.err(new Error('branch failure')),
+      input: z.object({}),
+      output: z.object({}),
+      visibility: 'internal',
+    });
+    const partialTrail = trail('scenario.batch.partial.root', {
+      blaze: async (_input, ctx) => {
+        const results = await requireCrossFn(ctx)([
+          [successTrail, {}],
+          [failureTrail, {}],
+        ] as const);
+        return Result.ok({ results });
+      },
+      crosses: [successTrail, failureTrail],
+      input: z.object({}),
+      output: concurrentBatchOutput,
+    });
+    const partialApp = topo('scenario-partial-failure-app', {
+      failureTrail,
+      partialTrail,
+      successTrail,
+    } as Record<string, unknown>);
+
+    await executeScenarioSteps(partialApp, [
+      {
+        cross: partialTrail,
+        expectedMatch: {
+          results: [
+            okResultMatch({ label: 'success' }),
+            errResultMatch({ message: 'branch failure' }),
+          ],
+        },
+        input: {},
+      },
+    ]);
+  });
+
+  test('respects concurrency limits for scenario ctx.cross batch flows', async () => {
+    const slowStarted = createReadyController();
+    const fastStarted = createReadyController();
+    const releaseFirstBatch = createReadyController();
+    const startedIds: string[] = [];
+    const slowTrail = trail('scenario.batch.limited.slow', {
+      blaze: async () => {
+        startedIds.push('slow');
+        slowStarted.resolve(readySignal);
+        await releaseFirstBatch.promise;
+        await Bun.sleep(20);
+        return Result.ok({ id: 'slow' });
+      },
+      input: z.object({}),
+      output: z.object({ id: z.string() }),
+      visibility: 'internal',
+    });
+    const fastTrail = trail('scenario.batch.limited.fast', {
+      blaze: async () => {
+        startedIds.push('fast');
+        fastStarted.resolve(readySignal);
+        await releaseFirstBatch.promise;
+        await Bun.sleep(1);
+        return Result.ok({ id: 'fast' });
+      },
+      input: z.object({}),
+      output: z.object({ id: z.string() }),
+      visibility: 'internal',
+    });
+    const queuedTrail = trail('scenario.batch.limited.queued', {
+      blaze: () => {
+        startedIds.push('queued');
+        return Result.ok({ id: 'queued' });
+      },
+      input: z.object({}),
+      output: z.object({ id: z.string() }),
+      visibility: 'internal',
+    });
+    const limitedTrail = trail('scenario.batch.limited.root', {
+      blaze: async (_input, ctx) => {
+        const run = requireCrossFn(ctx)(
+          [
+            [slowTrail, {}],
+            [fastTrail, {}],
+            [queuedTrail, {}],
+          ] as const,
+          { concurrency: 2 }
+        );
+        await waitForReadyPair(slowStarted.promise, fastStarted.promise);
+        const startedBeforeRelease = [...startedIds];
+        releaseFirstBatch.resolve(readySignal);
+        const results = await run;
+        return Result.ok({
+          startedBeforeRelease,
+          startedOverall: [...startedIds],
+          successIds: results
+            .filter((result) => result.isOk())
+            .map((result) => result.value.id),
+        });
+      },
+      crosses: [slowTrail, fastTrail, queuedTrail],
+      input: z.object({}),
+      output: z.object({
+        startedBeforeRelease: z.array(z.string()),
+        startedOverall: z.array(z.string()),
+        successIds: z.array(z.string()),
+      }),
+    });
+    const limitedApp = topo('scenario-concurrency-limited-app', {
+      fastTrail,
+      limitedTrail,
+      queuedTrail,
+      slowTrail,
+    } as Record<string, unknown>);
+
+    await executeScenarioSteps(limitedApp, [
+      {
+        cross: limitedTrail,
+        expected: {
+          startedBeforeRelease: ['slow', 'fast'],
+          startedOverall: ['slow', 'fast', 'queued'],
+          successIds: ['slow', 'fast', 'queued'],
+        },
+        input: {},
+      },
+    ]);
   });
 });

--- a/packages/testing/src/assertions.ts
+++ b/packages/testing/src/assertions.ts
@@ -50,6 +50,40 @@ export const expectErr = <T, E>(result: Result<T, E>): E => {
 };
 
 // ---------------------------------------------------------------------------
+// Result Match Tokens
+// ---------------------------------------------------------------------------
+
+export interface OkResultMatch {
+  readonly __resultMatch: 'ok';
+  readonly value?: unknown | undefined;
+}
+
+export interface ErrResultMatch {
+  readonly __resultMatch: 'err';
+  readonly error?: unknown | undefined;
+}
+
+type ResultMatchToken = OkResultMatch | ErrResultMatch;
+
+/**
+ * Create a partial-match token for `Result.ok(...)` values nested inside
+ * arrays or objects, such as the `Result[]` returned by batch `ctx.cross()`.
+ */
+export const okResultMatch = (value?: unknown): OkResultMatch => ({
+  __resultMatch: 'ok',
+  value,
+});
+
+/**
+ * Create a partial-match token for `Result.err(...)` values nested inside
+ * arrays or objects, such as mixed-success batch `ctx.cross()`.
+ */
+export const errResultMatch = (error?: unknown): ErrResultMatch => ({
+  __resultMatch: 'err',
+  error,
+});
+
+// ---------------------------------------------------------------------------
 // Full Match
 // ---------------------------------------------------------------------------
 
@@ -94,6 +128,28 @@ export const assertSchemaMatch = (
 /** Format a path for error messages. */
 const formatLoc = (path: readonly string[]): string =>
   path.length > 0 ? path.join('.') : 'root';
+
+interface ResultLike {
+  readonly error?: unknown;
+  isErr(): boolean;
+  isOk(): boolean;
+  readonly value?: unknown;
+}
+
+const isResultMatchToken = (value: unknown): value is ResultMatchToken =>
+  typeof value === 'object' &&
+  value !== null &&
+  '__resultMatch' in value &&
+  ((value as Record<string, unknown>)['__resultMatch'] === 'ok' ||
+    (value as Record<string, unknown>)['__resultMatch'] === 'err');
+
+const isResultLike = (value: unknown): value is ResultLike =>
+  typeof value === 'object' &&
+  value !== null &&
+  'isOk' in value &&
+  typeof (value as Record<string, unknown>)['isOk'] === 'function' &&
+  'isErr' in value &&
+  typeof (value as Record<string, unknown>)['isErr'] === 'function';
 
 /** Find an unconsumed actual element that deep-matches the expected object. */
 const findObjectMatch = (
@@ -189,6 +245,12 @@ const assertSubset = (
     return;
   }
 
+  if (isResultMatchToken(expected)) {
+    // oxlint-disable-next-line no-use-before-define -- result token matching delegates back into assertSubset
+    assertResultTokenMatch(actual, expected, path);
+    return;
+  }
+
   if (Array.isArray(expected)) {
     if (!Array.isArray(actual)) {
       throw new TypeError(`at ${loc}: expected an array, got ${typeof actual}`);
@@ -218,6 +280,52 @@ const assertSubset = (
       `at ${loc}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
     );
   }
+};
+
+const assertOkResultTokenMatch = (
+  actual: ResultLike,
+  expected: OkResultMatch,
+  loc: string,
+  path: readonly string[]
+): void => {
+  if (!actual.isOk()) {
+    throw new Error(`at ${loc}: expected Result.ok(...), got Result.err(...)`);
+  }
+  if (expected.value !== undefined) {
+    assertSubset(actual.value, expected.value, [...path, 'value']);
+  }
+};
+
+const assertErrResultTokenMatch = (
+  actual: ResultLike,
+  expected: ErrResultMatch,
+  loc: string,
+  path: readonly string[]
+): void => {
+  if (!actual.isErr()) {
+    throw new Error(`at ${loc}: expected Result.err(...), got Result.ok(...)`);
+  }
+  if (expected.error !== undefined) {
+    assertSubset(actual.error, expected.error, [...path, 'error']);
+  }
+};
+
+const assertResultTokenMatch = (
+  actual: unknown,
+  expected: ResultMatchToken,
+  path: readonly string[]
+): void => {
+  const loc = formatLoc(path);
+  if (!isResultLike(actual)) {
+    throw new TypeError(`at ${loc}: expected a Result-like value`);
+  }
+
+  if (expected.__resultMatch === 'ok') {
+    assertOkResultTokenMatch(actual, expected, loc, path);
+    return;
+  }
+
+  assertErrResultTokenMatch(actual, expected, loc, path);
 };
 
 /**

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -12,8 +12,10 @@ export {
   assertFullMatch,
   assertPartialMatch,
   assertSchemaMatch,
+  errResultMatch,
   expectErr,
   expectOk,
+  okResultMatch,
 } from './assertions.js';
 
 // Scenario testing

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -21,8 +21,12 @@ import {
   executeTrail,
   InternalError,
   Result as R,
-  ValidationError,
 } from '@ontrails/core';
+import {
+  claimNextCrossBatchIndex,
+  createCrossBatchValidationResults,
+  normalizeCrossBatchConcurrency,
+} from '@ontrails/core/internal/cross-batch';
 
 import { assertPartialMatch, expectOk } from './assertions.js';
 import { createTestContext, resolveMockResources } from './context.js';
@@ -174,43 +178,6 @@ const assertStepExpectations = async (
   }
 };
 
-const normalizeCrossBatchConcurrency = (
-  options: CrossBatchOptions | undefined
-): Result<number | undefined, Error> => {
-  const concurrency = options?.concurrency;
-  if (concurrency === undefined) {
-    return R.ok();
-  }
-
-  if (!Number.isInteger(concurrency) || concurrency < 1) {
-    return R.err(
-      new ValidationError(
-        'ctx.cross() batch concurrency must be a positive integer'
-      )
-    );
-  }
-
-  return R.ok(concurrency);
-};
-
-const createCrossBatchValidationResults = (
-  calls: readonly ScenarioCrossCall[],
-  error: Error
-): Result<unknown, Error>[] => calls.map(() => R.err(error));
-
-const claimNextCrossBatchIndex = (
-  nextIndex: { value: number },
-  calls: readonly ScenarioCrossCall[]
-): number | undefined => {
-  if (nextIndex.value >= calls.length) {
-    return undefined;
-  }
-
-  const branchIndex = nextIndex.value;
-  nextIndex.value += 1;
-  return branchIndex;
-};
-
 const executeUnlimitedCrossBatch = async (
   calls: readonly ScenarioCrossCall[],
   runCall: (
@@ -242,7 +209,16 @@ const executeLimitedCrossBatch = async (
 
       const call = calls[branchIndex];
       if (call === undefined) {
-        return;
+        // Defensive: `claimNextCrossBatchIndex` only returns indices within
+        // bounds, so this slot should always be populated. If it ever isn't,
+        // surface a clear InternalError in place of the missing slot and keep
+        // the worker loop running so sibling branches still get processed.
+        results[branchIndex] = R.err(
+          new InternalError(
+            `unreachable: concurrent cross batch call missing at index ${branchIndex}`
+          )
+        );
+        continue;
       }
 
       results[branchIndex] = await runCall(call, branchIndex);

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -10,6 +10,7 @@ import { describe, test } from 'bun:test';
 
 import type {
   AnyTrail,
+  CrossBatchOptions,
   CrossFn,
   ResourceOverrideMap,
   Result,
@@ -20,11 +21,15 @@ import {
   executeTrail,
   InternalError,
   Result as R,
+  ValidationError,
 } from '@ontrails/core';
 
 import { assertPartialMatch, expectOk } from './assertions.js';
 import { createTestContext, resolveMockResources } from './context.js';
 import type { RefToken, ScenarioStep } from './types.js';
+
+type ScenarioCrossTarget = string | { readonly id: string };
+type ScenarioCrossCall = readonly [ScenarioCrossTarget, unknown];
 
 // ---------------------------------------------------------------------------
 // ref() — cross-step reference marker
@@ -169,6 +174,85 @@ const assertStepExpectations = async (
   }
 };
 
+const normalizeCrossBatchConcurrency = (
+  options: CrossBatchOptions | undefined
+): Result<number | undefined, Error> => {
+  const concurrency = options?.concurrency;
+  if (concurrency === undefined) {
+    return R.ok();
+  }
+
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    return R.err(
+      new ValidationError(
+        'ctx.cross() batch concurrency must be a positive integer'
+      )
+    );
+  }
+
+  return R.ok(concurrency);
+};
+
+const createCrossBatchValidationResults = (
+  calls: readonly ScenarioCrossCall[],
+  error: Error
+): Result<unknown, Error>[] => calls.map(() => R.err(error));
+
+const claimNextCrossBatchIndex = (
+  nextIndex: { value: number },
+  calls: readonly ScenarioCrossCall[]
+): number | undefined => {
+  if (nextIndex.value >= calls.length) {
+    return undefined;
+  }
+
+  const branchIndex = nextIndex.value;
+  nextIndex.value += 1;
+  return branchIndex;
+};
+
+const executeUnlimitedCrossBatch = async (
+  calls: readonly ScenarioCrossCall[],
+  runCall: (
+    call: ScenarioCrossCall,
+    branchIndex: number
+  ) => Promise<Result<unknown, Error>>
+): Promise<Result<unknown, Error>[]> =>
+  await Promise.all(
+    calls.map((call, branchIndex) => runCall(call, branchIndex))
+  );
+
+const executeLimitedCrossBatch = async (
+  calls: readonly ScenarioCrossCall[],
+  runCall: (
+    call: ScenarioCrossCall,
+    branchIndex: number
+  ) => Promise<Result<unknown, Error>>,
+  limit: number
+): Promise<Result<unknown, Error>[]> => {
+  const results = Array.from<Result<unknown, Error>>({ length: calls.length });
+  const nextIndex = { value: 0 };
+
+  const runWorker = async () => {
+    while (true) {
+      const branchIndex = claimNextCrossBatchIndex(nextIndex, calls);
+      if (branchIndex === undefined) {
+        return;
+      }
+
+      const call = calls[branchIndex];
+      if (call === undefined) {
+        return;
+      }
+
+      results[branchIndex] = await runCall(call, branchIndex);
+    }
+  };
+
+  await Promise.all(Array.from({ length: limit }, runWorker));
+  return results;
+};
+
 /**
  * Build a cross function that resolves trails from the topo and executes
  * them through the standard pipeline. Mirrors the pattern in crosses.ts
@@ -179,7 +263,7 @@ const createScenarioCross = (
   resources?: ResourceOverrideMap
 ): CrossFn => {
   const invokeCross = async (
-    idOrTrail: string | { readonly id: string },
+    idOrTrail: ScenarioCrossTarget,
     input: unknown,
     self: CrossFn
   ) => {
@@ -197,24 +281,46 @@ const createScenarioCross = (
     });
   };
 
+  const executeCrossBatch = async (
+    calls: readonly ScenarioCrossCall[],
+    self: CrossFn,
+    options?: CrossBatchOptions
+  ): Promise<Result<unknown, Error>[]> => {
+    if (calls.length === 0) {
+      return [];
+    }
+
+    const concurrency = normalizeCrossBatchConcurrency(options);
+    if (concurrency.isErr()) {
+      return createCrossBatchValidationResults(calls, concurrency.error);
+    }
+
+    const runCall = async (
+      [target, batchInput]: ScenarioCrossCall,
+      _branchIndex: number
+    ) => await invokeCross(target, batchInput, self);
+
+    const limit = concurrency.value ?? calls.length;
+    return limit >= calls.length
+      ? await executeUnlimitedCrossBatch(calls, runCall)
+      : await executeLimitedCrossBatch(calls, runCall, limit);
+  };
+
   const cross = async function cross(
-    idOrTrail:
-      | string
-      | { readonly id: string }
-      | readonly (readonly [string | { readonly id: string }, unknown])[],
-    input?: unknown
+    idOrTrail: ScenarioCrossTarget | readonly ScenarioCrossCall[],
+    inputOrOptions?: unknown
   ) {
     if (Array.isArray(idOrTrail)) {
-      return await Promise.all(
-        idOrTrail.map(([target, batchInput]) =>
-          invokeCross(target, batchInput, cross as CrossFn)
-        )
+      return await executeCrossBatch(
+        idOrTrail,
+        cross as CrossFn,
+        inputOrOptions as CrossBatchOptions | undefined
       );
     }
 
     return await invokeCross(
-      idOrTrail as string | { readonly id: string },
-      input,
+      idOrTrail as ScenarioCrossTarget,
+      inputOrOptions,
       cross as CrossFn
     );
   } as CrossFn;

--- a/packages/tracing/src/__tests__/intrinsic-tracing.test.ts
+++ b/packages/tracing/src/__tests__/intrinsic-tracing.test.ts
@@ -8,8 +8,16 @@ import {
   executeTrail,
   registerTraceSink,
   trail,
+  topo,
 } from '@ontrails/core';
-import type { Layer, TraceContext, TraceRecord } from '@ontrails/core';
+import type {
+  AnyTrail,
+  CrossBatchOptions,
+  Layer,
+  TraceContext,
+  TraceRecord,
+  TrailContext,
+} from '@ontrails/core';
 import { z } from 'zod';
 
 import { createMemorySink } from '../memory-sink.js';
@@ -22,6 +30,11 @@ import { createMemorySink } from '../memory-sink.js';
  */
 
 const emptyIO = z.object({});
+const completedOutput = z.object({ completed: z.boolean() });
+const SIGNAL = 'signal';
+
+type Signal = typeof SIGNAL;
+type SignalController = ReturnType<typeof Promise.withResolvers<Signal>>;
 
 const okTrail = trail('intrinsic.ok', {
   blaze: () => Result.ok({ value: 1 }),
@@ -116,6 +129,236 @@ const firstSpanRecord = (records: readonly TraceRecord[]): TraceRecord => {
   const found = records.find((r) => r.kind === 'span');
   expect(found).toBeDefined();
   return found as TraceRecord;
+};
+
+const trailRecord = (
+  records: readonly TraceRecord[],
+  trailId: string
+): TraceRecord => {
+  const found = records.find((record) => record.trailId === trailId);
+  expect(found).toBeDefined();
+  return found as TraceRecord;
+};
+
+const requireCross = (
+  ctx: TrailContext
+): NonNullable<TrailContext['cross']> => {
+  expect(ctx.cross).toBeDefined();
+  return ctx.cross as NonNullable<TrailContext['cross']>;
+};
+
+const recordsOverlap = (left: TraceRecord, right: TraceRecord): boolean => {
+  expect(left.endedAt).toBeDefined();
+  expect(right.endedAt).toBeDefined();
+  return (
+    left.startedAt <= (right.endedAt as number) &&
+    right.startedAt <= (left.endedAt as number)
+  );
+};
+
+const createSignalController = (): SignalController =>
+  Promise.withResolvers<Signal>();
+
+const waitForSignalPair = async (
+  left: Promise<unknown>,
+  right: Promise<unknown>
+): Promise<void> => {
+  await left;
+  await right;
+};
+
+const createReleasedSignal = (): Promise<Signal> => {
+  const signal = createSignalController();
+  signal.resolve(SIGNAL);
+  return signal.promise;
+};
+
+const createBatchCrossParent = (
+  id: string,
+  children: readonly [AnyTrail, ...AnyTrail[]],
+  options?: CrossBatchOptions
+) =>
+  trail(id, {
+    blaze: async (_input, ctx) => {
+      const calls = children.map((child) => [child, {}] as const);
+      await requireCross(ctx)(calls, options);
+      return Result.ok({ completed: true });
+    },
+    crosses: [...children],
+    input: emptyIO,
+    output: completedOutput,
+  });
+
+const createGatedCrossChild = (
+  id: string,
+  started: SignalController,
+  gate: Promise<unknown>
+) =>
+  trail(id, {
+    blaze: async () => {
+      started.resolve(SIGNAL);
+      await gate;
+      return Result.ok({ ok: true });
+    },
+    input: emptyIO,
+    output: z.object({ ok: z.boolean() }),
+    visibility: 'internal',
+  });
+
+const createTimedCrossChild = (
+  id: string,
+  startedIds: string[],
+  started: SignalController,
+  gate: Promise<unknown>,
+  delayMs: number
+) =>
+  trail(id, {
+    blaze: async () => {
+      startedIds.push(id);
+      started.resolve(SIGNAL);
+      await gate;
+      await Bun.sleep(delayMs);
+      return Result.ok({ id });
+    },
+    input: emptyIO,
+    output: z.object({ id: z.string() }),
+    visibility: 'internal',
+  });
+
+const createConcurrentCrossBatchScenario = () => {
+  const leftStarted = createSignalController();
+  const rightStarted = createSignalController();
+  const release = createSignalController();
+  const left = createGatedCrossChild(
+    'trace.cross.concurrent.left',
+    leftStarted,
+    waitForSignalPair(rightStarted.promise, release.promise)
+  );
+  const right = createGatedCrossChild(
+    'trace.cross.concurrent.right',
+    rightStarted,
+    waitForSignalPair(leftStarted.promise, release.promise)
+  );
+  const parent = createBatchCrossParent('trace.cross.concurrent.parent', [
+    left,
+    right,
+  ]);
+  const app = topo('trace-cross-concurrent-topo', { left, parent, right });
+
+  return {
+    app,
+    left,
+    parent,
+    release,
+    right,
+    started: waitForSignalPair(leftStarted.promise, rightStarted.promise),
+  };
+};
+
+const createLimitedCrossBatchChildren = (
+  startedIds: string[],
+  releaseFirstBatch: Promise<unknown>
+) => {
+  const slowStarted = createSignalController();
+  const fastStarted = createSignalController();
+  const queuedStarted = createSignalController();
+  const slow = createTimedCrossChild(
+    'trace.cross.limited.slow',
+    startedIds,
+    slowStarted,
+    releaseFirstBatch,
+    20
+  );
+  const fast = createTimedCrossChild(
+    'trace.cross.limited.fast',
+    startedIds,
+    fastStarted,
+    releaseFirstBatch,
+    1
+  );
+  const queued = createTimedCrossChild(
+    'trace.cross.limited.queued',
+    startedIds,
+    queuedStarted,
+    createReleasedSignal(),
+    1
+  );
+
+  return {
+    fast,
+    fastStarted,
+    queued,
+    queuedStarted,
+    slow,
+    slowStarted,
+  };
+};
+
+const createLimitedCrossBatchScenario = () => {
+  const releaseFirstBatch = createSignalController();
+  const startedIds: string[] = [];
+  const { fast, fastStarted, queued, queuedStarted, slow, slowStarted } =
+    createLimitedCrossBatchChildren(startedIds, releaseFirstBatch.promise);
+  const parent = createBatchCrossParent(
+    'trace.cross.limited.parent',
+    [slow, fast, queued],
+    { concurrency: 2 }
+  );
+  const app = topo('trace-cross-limited-topo', {
+    fast,
+    parent,
+    queued,
+    slow,
+  });
+
+  return {
+    app,
+    fast,
+    firstBatchStarted: waitForSignalPair(
+      slowStarted.promise,
+      fastStarted.promise
+    ),
+    parent,
+    queued,
+    queuedStarted: queuedStarted.promise,
+    releaseFirstBatch,
+    slow,
+    startedIds,
+  };
+};
+
+const expectSiblingCrossTrailOverlap = (
+  records: readonly TraceRecord[],
+  parentTrailId: string,
+  leftTrailId: string,
+  rightTrailId: string
+) => {
+  const parentRecord = trailRecord(records, parentTrailId);
+  const leftRecord = trailRecord(records, leftTrailId);
+  const rightRecord = trailRecord(records, rightTrailId);
+  expect(leftRecord.parentId).toBe(parentRecord.id);
+  expect(rightRecord.parentId).toBe(parentRecord.id);
+  expect(recordsOverlap(leftRecord, rightRecord)).toBe(true);
+};
+
+const expectLimitedCrossTrailWaveShape = (
+  records: readonly TraceRecord[],
+  parentTrailId: string,
+  slowTrailId: string,
+  fastTrailId: string,
+  queuedTrailId: string
+) => {
+  const parentRecord = trailRecord(records, parentTrailId);
+  const slowRecord = trailRecord(records, slowTrailId);
+  const fastRecord = trailRecord(records, fastTrailId);
+  const queuedRecord = trailRecord(records, queuedTrailId);
+  expect(slowRecord.parentId).toBe(parentRecord.id);
+  expect(fastRecord.parentId).toBe(parentRecord.id);
+  expect(queuedRecord.parentId).toBe(parentRecord.id);
+  expect(queuedRecord.startedAt).toBeGreaterThanOrEqual(
+    fastRecord.endedAt as number
+  );
+  expect(recordsOverlap(slowRecord, queuedRecord)).toBe(true);
 };
 
 describe('intrinsic tracing via executeTrail + ctx.trace', () => {
@@ -266,6 +509,70 @@ describe('intrinsic tracing via executeTrail + ctx.trace', () => {
       expect(child?.traceId).toBe('parent-trace');
       expect(child?.rootId).toBe('parent-root');
       expect(child?.parentId).toBe('parent-span');
+    });
+  });
+
+  describe('cross-trail tracing', () => {
+    test('single ctx.cross() produces a child trail record under the parent trail', async () => {
+      const crossed = trail('trace.cross.single.child', {
+        blaze: () => Result.ok({ ok: true }),
+        input: emptyIO,
+        output: z.object({ ok: z.boolean() }),
+        visibility: 'internal',
+      });
+      const parent = trail('trace.cross.single.parent', {
+        blaze: async (_input, ctx) => {
+          const result = await requireCross(ctx)(crossed, {});
+          return result.match({
+            err: (error) => Result.err(error),
+            ok: (value) => Result.ok(value),
+          });
+        },
+        crosses: [crossed],
+        input: emptyIO,
+        output: z.object({ ok: z.boolean() }),
+      });
+      const app = topo('trace-cross-single-topo', { crossed, parent });
+
+      await executeTrail(parent, {}, { topo: app });
+
+      const parentRecord = trailRecord(sink.records, parent.id);
+      const childRecord = trailRecord(sink.records, crossed.id);
+      expect(childRecord.parentId).toBe(parentRecord.id);
+      expect(childRecord.rootId).toBe(parentRecord.id);
+      expect(childRecord.traceId).toBe(parentRecord.traceId);
+    });
+
+    test('batch ctx.cross([...]) produces sibling child trail records with overlapping timings', async () => {
+      const scenario = createConcurrentCrossBatchScenario();
+      const run = executeTrail(scenario.parent, {}, { topo: scenario.app });
+      await scenario.started;
+      scenario.release.resolve(SIGNAL);
+      await run;
+      expectSiblingCrossTrailOverlap(
+        sink.records,
+        scenario.parent.id,
+        scenario.left.id,
+        scenario.right.id
+      );
+    });
+
+    test('concurrency-limited batch crossings emit a second wave only after a slot frees up', async () => {
+      const scenario = createLimitedCrossBatchScenario();
+      const run = executeTrail(scenario.parent, {}, { topo: scenario.app });
+      await scenario.firstBatchStarted;
+      expect(scenario.startedIds).toEqual([scenario.slow.id, scenario.fast.id]);
+      scenario.releaseFirstBatch.resolve(SIGNAL);
+      await scenario.queuedStarted;
+      await run;
+
+      expectLimitedCrossTrailWaveShape(
+        sink.records,
+        scenario.parent.id,
+        scenario.slow.id,
+        scenario.fast.id,
+        scenario.queued.id
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Second half of the concurrent crossings feature. Adds runtime controls, observability, and test-harness support for batch `ctx.cross(...)` calls. Three branches folded together.

### Concurrency limit option
- Add a `concurrency` option to batch `ctx.cross(...)` so callers can cap parallel invocations without rewriting their fan-out logic
- Default preserves the previous unbounded behavior
- Extends `execute.ts` with the limited scheduler and updates `types.ts` / `index.ts` exports
- Coverage added for ordered resolution under limit and for mixed success/failure batches

### Tracing spans for concurrent crossings
- Each concurrent branch emits its own tracing span rooted under the parent trail span
- `@ontrails/tracing` intrinsic tracing tests assert span topology, branch index, and batch-size attributes

### Scenario support for concurrent flows
- Extend `@ontrails/testing` scenarios to express concurrent crossings (declarative fan-out with per-branch expectations) via new `assertions.ts` helpers
- Scenario coverage for batch success, partial failure, and interaction with the concurrency limit

## Testing

- `bun test packages/core/src/__tests__/execute.test.ts`
- `bun test packages/tracing/src/__tests__/intrinsic-tracing.test.ts`
- `bun test packages/testing/src/__tests__/scenario.test.ts`
- `bun run typecheck`

## Closes

- Closes TRL-230
- Closes TRL-231
- Closes TRL-232
