### PR TITLE
feat: add contour completeness warden rules

### DIFF
--- a/packages/warden/src/__tests__/ast.test.ts
+++ b/packages/warden/src/__tests__/ast.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveContourIdentifierName } from '../rules/ast.js';
+
+describe('resolveContourIdentifierName', () => {
+  test('supports the common *Contour binding suffix when resolving known contours', () => {
+    expect(
+      resolveContourIdentifierName(
+        'userContour',
+        new Map<string, string>(),
+        new Set(['user'])
+      )
+    ).toBe('user');
+  });
+
+  test('prefers exact contour ids over the *Contour fallback', () => {
+    expect(
+      resolveContourIdentifierName(
+        'userContour',
+        new Map<string, string>(),
+        new Set(['user', 'userContour'])
+      )
+    ).toBe('userContour');
+  });
+});

--- a/packages/warden/src/__tests__/circular-refs.test.ts
+++ b/packages/warden/src/__tests__/circular-refs.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+
+import { circularRefs } from '../rules/circular-refs.js';
+
+const TEST_FILE = 'contours.ts';
+
+describe('circular-refs', () => {
+  test('passes when contour references are acyclic', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  id: z.string().uuid(),
+}, { identity: 'id' });
+
+const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: 'id' });
+`;
+
+    expect(circularRefs.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('warns on direct local contour cycles', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  gistId: gist.id(),
+  id: z.string().uuid(),
+}, { identity: 'id' });
+
+const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: 'id' });
+`;
+
+    const diagnostics = circularRefs.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics[0]?.rule).toBe('circular-refs');
+    expect(diagnostics[0]?.message).toContain('user -> gist -> user');
+  });
+
+  test('warns on transitive cycles discovered through project context', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+import { gist } from './gist';
+
+const user = contour('user', {
+  gistId: gist.id(),
+  id: z.string().uuid(),
+}, { identity: 'id' });
+`;
+
+    const diagnostics = circularRefs.checkWithContext(code, TEST_FILE, {
+      contourReferencesByName: new Map([
+        ['account', ['user']],
+        ['gist', ['account']],
+      ]),
+      knownContourIds: new Set(['account', 'gist', 'user']),
+      knownTrailIds: new Set<string>(),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain(
+      'user -> gist -> account -> user'
+    );
+  });
+});

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { topo } from '@ontrails/core';
+
 import { formatWardenReport, runWarden } from '../cli.js';
 
 const isDraftFileMarking = (rule: string): boolean =>
@@ -197,6 +199,35 @@ export const gist = contour('gist', {
       );
 
       expect(referenceErrors).toHaveLength(0);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('preserves empty topo resource sets instead of falling back to file-local ids', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'entity.ts'),
+        `import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (_input, ctx) => Result.ok(db.from(ctx)),
+});`
+      );
+
+      const report = await runWarden({ rootDir: dir, topo: topo('empty-app') });
+      const resourceErrors = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'resource-exists'
+      );
+
+      expect(resourceErrors).toHaveLength(1);
+      expect(resourceErrors[0]?.message).toContain('db.main');
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -32,7 +32,7 @@ const makeTempDir = (): string => {
   return dir;
 };
 
-describe('runWarden', () => {
+describe('runWarden basics', () => {
   test('produces a report with diagnostics for bad code', async () => {
     const dir = makeTempDir();
     try {
@@ -99,7 +99,9 @@ describe('runWarden', () => {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+});
 
+describe('runWarden project context', () => {
   test('uses project context for detour references across files', async () => {
     const dir = makeTempDir();
     try {
@@ -165,6 +167,80 @@ describe('runWarden', () => {
     }
   });
 
+  test('uses project context for contour references across files', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'user.ts'),
+        `import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+export const user = contour('user', {
+  id: z.string().uuid(),
+}, { identity: 'id' });`
+      );
+      writeFileSync(
+        join(dir, 'gist.ts'),
+        `import { contour } from '@ontrails/core';
+import { z } from 'zod';
+import { user } from './user';
+
+export const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: 'id' });`
+      );
+
+      const report = await runWarden({ rootDir: dir });
+      const referenceErrors = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'reference-exists'
+      );
+
+      expect(referenceErrors).toHaveLength(0);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('warns on contour cycles declared across files', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'user.ts'),
+        `import { contour } from '@ontrails/core';
+import { z } from 'zod';
+import { gist } from './gist';
+
+export const user = contour('user', {
+  gistId: gist.id(),
+  id: z.string().uuid(),
+}, { identity: 'id' });`
+      );
+      writeFileSync(
+        join(dir, 'gist.ts'),
+        `import { contour } from '@ontrails/core';
+import { z } from 'zod';
+import { user } from './user';
+
+export const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: 'id' });`
+      );
+
+      const report = await runWarden({ rootDir: dir });
+      const circularWarnings = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'circular-refs'
+      );
+
+      expect(circularWarnings.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('runWarden draft markers', () => {
   test('requires draft-bearing files to be visibly marked', async () => {
     const dir = makeTempDir();
     try {

--- a/packages/warden/src/__tests__/contour-exists.test.ts
+++ b/packages/warden/src/__tests__/contour-exists.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+
+import { contourExists } from '../rules/contour-exists.js';
+
+const TEST_FILE = 'entity.ts';
+
+describe('contour-exists', () => {
+  test('passes when a locally declared contour exists', () => {
+    const code = `
+import { Result, contour, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  id: z.string().uuid(),
+}, { identity: 'id' });
+
+trail('user.create', {
+  contours: [user],
+  blaze: async () => Result.ok({ ok: true }),
+});
+`;
+
+    expect(contourExists.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('flags a missing contour declaration', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail('user.create', {
+  contours: [user],
+  blaze: async () => Result.ok({ ok: true }),
+});
+`;
+
+    const diagnostics = contourExists.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('contour-exists');
+    expect(diagnostics[0]?.message).toContain('user');
+  });
+
+  test('passes when project context includes an imported contour', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+import { user } from './contours';
+
+trail('user.create', {
+  contours: [user],
+  blaze: async () => Result.ok({ ok: true }),
+});
+`;
+
+    expect(
+      contourExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set(['user']),
+        knownTrailIds: new Set(['user.create']),
+      })
+    ).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/contour-exists.test.ts
+++ b/packages/warden/src/__tests__/contour-exists.test.ts
@@ -26,6 +26,7 @@ trail('user.create', {
   test('flags a missing contour declaration', () => {
     const code = `
 import { Result, trail } from '@ontrails/core';
+import { user } from './contours';
 
 trail('user.create', {
   contours: [user],
@@ -33,11 +34,33 @@ trail('user.create', {
 });
 `;
 
-    const diagnostics = contourExists.check(code, TEST_FILE);
+    const diagnostics = contourExists.checkWithContext(code, TEST_FILE, {
+      knownContourIds: new Set<string>(),
+      knownTrailIds: new Set(['user.create']),
+    });
 
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.rule).toBe('contour-exists');
     expect(diagnostics[0]?.message).toContain('user');
+  });
+
+  test('resolves aliased imports to the original contour name', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+import { user as userModel } from './contours';
+
+trail('user.create', {
+  contours: [userModel],
+  blaze: async () => Result.ok({ ok: true }),
+});
+`;
+
+    expect(
+      contourExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set(['user']),
+        knownTrailIds: new Set(['user.create']),
+      })
+    ).toEqual([]);
   });
 
   test('passes when project context includes an imported contour', () => {

--- a/packages/warden/src/__tests__/example-valid.test.ts
+++ b/packages/warden/src/__tests__/example-valid.test.ts
@@ -70,4 +70,32 @@ const user = contour('user', {
 
     expect(exampleValid.check(code, TEST_FILE)).toEqual([]);
   });
+
+  test('keeps dependent contour validation alive when base contours omit options', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const base = contour('base', {
+  id: z.string().uuid(),
+});
+
+const child = contour('child', {
+  id: z.string().uuid(),
+  baseId: base.id(),
+}, {
+  examples: [{
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    baseId: 'not-a-uuid',
+  }],
+  identity: 'id',
+});
+`;
+
+    const diagnostics = exampleValid.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('example-valid');
+    expect(diagnostics[0]?.message).toContain('child');
+  });
 });

--- a/packages/warden/src/__tests__/example-valid.test.ts
+++ b/packages/warden/src/__tests__/example-valid.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+
+import { exampleValid } from '../rules/example-valid.js';
+
+const TEST_FILE = 'contours.ts';
+
+describe('example-valid', () => {
+  test('passes when contour examples match the schema', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  id: z.string().uuid(),
+  name: z.string(),
+}, {
+  examples: [{
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    name: 'Ada',
+  }],
+  identity: 'id',
+});
+`;
+
+    expect(exampleValid.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('flags invalid contour examples', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  id: z.string().uuid(),
+  name: z.string(),
+}, {
+  examples: [{
+    id: 'not-a-uuid',
+    name: 42,
+  }],
+  identity: 'id',
+});
+`;
+
+    const diagnostics = exampleValid.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('example-valid');
+    expect(diagnostics[0]?.message).toContain('example 0 is invalid');
+  });
+
+  test('skips unsupported example expressions instead of guessing', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const buildExample = () => ({
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  name: 'Ada',
+});
+
+const user = contour('user', {
+  id: z.string().uuid(),
+  name: z.string(),
+}, {
+  examples: [buildExample()],
+  identity: 'id',
+});
+`;
+
+    expect(exampleValid.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/reference-exists.test.ts
+++ b/packages/warden/src/__tests__/reference-exists.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+
+import { referenceExists } from '../rules/reference-exists.js';
+
+const TEST_FILE = 'contours.ts';
+
+describe('reference-exists', () => {
+  test('passes when a local contour reference exists', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  id: z.string().uuid(),
+}, { identity: 'id' });
+
+const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: 'id' });
+`;
+
+    expect(referenceExists.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('flags a missing contour reference target', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: 'id' });
+`;
+
+    const diagnostics = referenceExists.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('reference-exists');
+    expect(diagnostics[0]?.message).toContain('user');
+  });
+
+  test('passes when project context includes an imported contour', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+import { user } from './user';
+
+const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: 'id' });
+`;
+
+    expect(
+      referenceExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set(['gist', 'user']),
+        knownTrailIds: new Set<string>(),
+      })
+    ).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/reference-exists.test.ts
+++ b/packages/warden/src/__tests__/reference-exists.test.ts
@@ -27,6 +27,7 @@ const gist = contour('gist', {
     const code = `
 import { contour } from '@ontrails/core';
 import { z } from 'zod';
+import { user } from './user';
 
 const gist = contour('gist', {
   id: z.string().uuid(),
@@ -34,11 +35,34 @@ const gist = contour('gist', {
 }, { identity: 'id' });
 `;
 
-    const diagnostics = referenceExists.check(code, TEST_FILE);
+    const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
+      knownContourIds: new Set(['gist']),
+      knownTrailIds: new Set<string>(),
+    });
 
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.rule).toBe('reference-exists');
     expect(diagnostics[0]?.message).toContain('user');
+  });
+
+  test('resolves aliased imports to the original contour id', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+import { user as userModel } from './user';
+
+const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: userModel.id(),
+}, { identity: 'id' });
+`;
+
+    const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
+      knownContourIds: new Set(['gist', 'user']),
+      knownTrailIds: new Set<string>(),
+    });
+
+    expect(diagnostics).toEqual([]);
   });
 
   test('passes when project context includes an imported contour', () => {

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 19 rule trails', () => {
-    expect(wardenTopo.count).toBe(19);
+  test('contains all 23 rule trails', () => {
+    expect(wardenTopo.count).toBe(23);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -8,10 +8,13 @@
 import { resolve } from 'node:path';
 
 import type { Topo } from '@ontrails/core';
+import { getContourReferences } from '@ontrails/core';
 
 import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
 import {
+  collectContourDefinitionIds,
+  collectContourReferenceTargetsByName,
   collectCrossTargetTrailIds,
   collectResourceDefinitionIds,
   collectSignalDefinitionIds,
@@ -96,8 +99,10 @@ interface SourceFile {
 }
 
 interface MutableProjectContext {
+  contourReferencesByName: Map<string, Set<string>>;
   crossTargetTrailIds: Set<string>;
   detourTargetTrailIds: Set<string>;
+  knownContourIds: Set<string>;
   knownResourceIds: Set<string>;
   knownSignalIds: Set<string>;
   knownTrailIds: Set<string>;
@@ -105,13 +110,70 @@ interface MutableProjectContext {
 }
 
 const createMutableProjectContext = (): MutableProjectContext => ({
+  contourReferencesByName: new Map<string, Set<string>>(),
   crossTargetTrailIds: new Set<string>(),
   detourTargetTrailIds: new Set<string>(),
+  knownContourIds: new Set<string>(),
   knownResourceIds: new Set<string>(),
   knownSignalIds: new Set<string>(),
   knownTrailIds: new Set<string>(),
   trailIntentsById: new Map<string, 'destroy' | 'read' | 'write'>(),
 });
+
+const addContourReferenceTargets = (
+  context: MutableProjectContext,
+  contourName: string,
+  targets: readonly string[]
+): void => {
+  const existing = context.contourReferencesByName.get(contourName);
+  if (existing) {
+    for (const target of targets) {
+      existing.add(target);
+    }
+    return;
+  }
+
+  context.contourReferencesByName.set(contourName, new Set(targets));
+};
+
+const toProjectContext = (context: MutableProjectContext): ProjectContext => ({
+  ...(context.contourReferencesByName.size > 0
+    ? {
+        contourReferencesByName: new Map(
+          [...context.contourReferencesByName.entries()].map(
+            ([name, targets]) => [name, [...targets]]
+          )
+        ),
+      }
+    : {}),
+  ...(context.knownContourIds.size > 0
+    ? { knownContourIds: context.knownContourIds }
+    : {}),
+  ...(context.knownResourceIds.size > 0
+    ? { knownResourceIds: context.knownResourceIds }
+    : {}),
+  ...(context.knownSignalIds.size > 0
+    ? { knownSignalIds: context.knownSignalIds }
+    : {}),
+  crossTargetTrailIds: context.crossTargetTrailIds,
+  detourTargetTrailIds: context.detourTargetTrailIds,
+  knownTrailIds: context.knownTrailIds,
+  trailIntentsById: context.trailIntentsById,
+});
+
+const collectKnownContourIds = (
+  sourceCode: string,
+  filePath: string,
+  knownContourIds: Set<string>
+): void => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return;
+  }
+  for (const id of collectContourDefinitionIds(ast)) {
+    knownContourIds.add(id);
+  }
+};
 
 const collectKnownTrailIds = (
   sourceCode: string,
@@ -255,6 +317,10 @@ const collectTopoKnownIds = (
   appTopo: Topo,
   context: MutableProjectContext
 ): void => {
+  for (const name of appTopo.contours.keys()) {
+    context.knownContourIds.add(name);
+  }
+
   for (const id of appTopo.trails.keys()) {
     context.knownTrailIds.add(id);
   }
@@ -289,6 +355,19 @@ const collectTopoCrossesAndIntents = (
   }
 };
 
+const collectTopoContourReferences = (
+  appTopo: Topo,
+  context: MutableProjectContext
+): void => {
+  for (const contour of appTopo.listContours()) {
+    addContourReferenceTargets(
+      context,
+      contour.name,
+      getContourReferences(contour).map((reference) => reference.contour)
+    );
+  }
+};
+
 const collectTopoTrailContext = (
   appTopo: Topo,
   context: MutableProjectContext
@@ -296,18 +375,24 @@ const collectTopoTrailContext = (
   collectTopoKnownIds(appTopo, context);
   collectTopoDetourIds(appTopo, context);
   collectTopoCrossesAndIntents(appTopo, context);
+  collectTopoContourReferences(appTopo, context);
 };
 
 const buildProjectContextFromTopo = (appTopo: Topo): ProjectContext => {
   const context = createMutableProjectContext();
   collectTopoTrailContext(appTopo, context);
-  return context;
+  return toProjectContext(context);
 };
 
 const collectFileProjectContext = (
   sourceFile: SourceFile,
   context: MutableProjectContext
 ): void => {
+  collectKnownContourIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.knownContourIds
+  );
   collectKnownTrailIds(
     sourceFile.sourceCode,
     sourceFile.filePath,
@@ -340,6 +425,24 @@ const collectFileProjectContext = (
   );
 };
 
+const collectFileContourReferences = (
+  sourceFile: SourceFile,
+  context: MutableProjectContext
+): void => {
+  const ast = parse(sourceFile.filePath, sourceFile.sourceCode);
+  if (!ast) {
+    return;
+  }
+
+  const referencesByName = collectContourReferenceTargetsByName(
+    ast,
+    context.knownContourIds
+  );
+  for (const [contourName, targets] of referencesByName) {
+    addContourReferenceTargets(context, contourName, targets);
+  }
+};
+
 const buildProjectContextFromFiles = (
   sourceFiles: readonly SourceFile[]
 ): ProjectContext => {
@@ -349,7 +452,11 @@ const buildProjectContextFromFiles = (
     collectFileProjectContext(sourceFile, context);
   }
 
-  return context;
+  for (const sourceFile of sourceFiles) {
+    collectFileContourReferences(sourceFile, context);
+  }
+
+  return toProjectContext(context);
 };
 
 const isProjectAwareRule = (rule: WardenRule): rule is ProjectAwareWardenRule =>

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -146,17 +146,11 @@ const toProjectContext = (context: MutableProjectContext): ProjectContext => ({
         ),
       }
     : {}),
-  ...(context.knownContourIds.size > 0
-    ? { knownContourIds: context.knownContourIds }
-    : {}),
-  ...(context.knownResourceIds.size > 0
-    ? { knownResourceIds: context.knownResourceIds }
-    : {}),
-  ...(context.knownSignalIds.size > 0
-    ? { knownSignalIds: context.knownSignalIds }
-    : {}),
   crossTargetTrailIds: context.crossTargetTrailIds,
   detourTargetTrailIds: context.detourTargetTrailIds,
+  knownContourIds: context.knownContourIds,
+  knownResourceIds: context.knownResourceIds,
+  knownSignalIds: context.knownSignalIds,
   knownTrailIds: context.knownTrailIds,
   trailIntentsById: context.trailIntentsById,
 });

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -18,11 +18,14 @@ export type {
 
 // Individual rules
 export { noThrowInImplementation } from './rules/no-throw-in-implementation.js';
+export { circularRefs } from './rules/circular-refs.js';
+export { contourExists } from './rules/contour-exists.js';
 export { contextNoTrailheadTypes } from './rules/context-no-trailhead-types.js';
 export { deadInternalTrail } from './rules/dead-internal-trail.js';
 export { draftFileMarking } from './rules/draft-file-marking.js';
 export { draftVisibleDebt } from './rules/draft-visible-debt.js';
 export { errorMappingCompleteness } from './rules/error-mapping-completeness.js';
+export { exampleValid } from './rules/example-valid.js';
 export { firesDeclarations } from './rules/fires-declarations.js';
 export { intentPropagation } from './rules/intent-propagation.js';
 export { missingVisibility } from './rules/missing-visibility.js';
@@ -34,6 +37,7 @@ export { noSyncResultAssumption } from './rules/no-sync-result-assumption.js';
 export { implementationReturnsResult } from './rules/implementation-returns-result.js';
 export { noThrowInDetourTarget } from './rules/no-throw-in-detour-target.js';
 export { preferSchemaInference } from './rules/prefer-schema-inference.js';
+export { referenceExists } from './rules/reference-exists.js';
 export { resourceDeclarations } from './rules/resource-declarations.js';
 export { resourceExists } from './rules/resource-exists.js';
 export { validDescribeRefs } from './rules/valid-describe-refs.js';
@@ -79,11 +83,14 @@ export type { AstNode, StringLiteralMatch } from './rules/ast.js';
 export { wardenTopo } from './trails/topo.js';
 export { runWardenTrails } from './trails/run.js';
 export {
+  circularRefsTrail,
+  contourExistsTrail,
   contextNoTrailheadTypesTrail,
   crossDeclarationsTrail,
   deadInternalTrailTrail,
   diagnosticSchema,
   errorMappingCompletenessTrail,
+  exampleValidTrail,
   firesDeclarationsTrail,
   implementationReturnsResultTrail,
   intentPropagationTrail,
@@ -95,6 +102,7 @@ export {
   noThrowInImplementationTrail,
   onReferencesExistTrail,
   preferSchemaInferenceTrail,
+  referenceExistsTrail,
   ruleInput,
   ruleOutput,
   resourceDeclarationsTrail,

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -579,6 +579,54 @@ export const collectNamedContourIds = (
   return ids;
 };
 
+const extractImportSpecifierAlias = (
+  specifier: AstNode
+): { readonly localName: string; readonly importedName: string } | null => {
+  if (specifier.type !== 'ImportSpecifier') {
+    return null;
+  }
+
+  const { imported } = specifier as unknown as { imported?: AstNode };
+  const { local } = specifier as unknown as { local?: AstNode };
+  const localName = identifierName(local);
+  if (!localName) {
+    return null;
+  }
+
+  const importedName = imported
+    ? (identifierName(imported) ?? extractStringLiteral(imported))
+    : null;
+  return { importedName: importedName ?? localName, localName };
+};
+
+/**
+ * Collect `import { foo as bar } from '...'` specifier mappings keyed by
+ * local binding name. The value is the original exported name. Bindings
+ * without an alias map to themselves.
+ */
+export const collectImportAliasMap = (
+  ast: AstNode
+): ReadonlyMap<string, string> => {
+  const aliases = new Map<string, string>();
+
+  walk(ast, (node) => {
+    if (node.type !== 'ImportDeclaration') {
+      return;
+    }
+
+    const specifiers =
+      (node['specifiers'] as readonly AstNode[] | undefined) ?? [];
+    for (const specifier of specifiers) {
+      const alias = extractImportSpecifierAlias(specifier);
+      if (alias) {
+        aliases.set(alias.localName, alias.importedName);
+      }
+    }
+  });
+
+  return aliases;
+};
+
 export interface ContourReferenceSite {
   /** Field on the source contour that declares the reference. */
   readonly field: string;
@@ -603,29 +651,77 @@ const getPropertyName = (node: unknown): string | null => {
   return isAstNode(node) ? extractStringLiteral(node) : null;
 };
 
-const resolveContourIdentifierName = (
+const stripContourSuffix = (name: string): string => {
+  const suffix = 'Contour';
+  return name.endsWith(suffix) ? name.slice(0, -suffix.length) : name;
+};
+
+const resolveKnownContourName = (
+  name: string,
+  knownContourIds?: ReadonlySet<string>
+): string | null => {
+  if (knownContourIds?.has(name)) {
+    return name;
+  }
+
+  // Support the common `const userContour = contour('user', ...)` naming
+  // pattern when callers refer to the binding name instead of the contour ID.
+  // Exact matches always win; suffix stripping is a fallback only.
+  const stripped = stripContourSuffix(name);
+  if (stripped !== name && knownContourIds?.has(stripped)) {
+    return stripped;
+  }
+
+  return null;
+};
+
+/**
+ * Resolve a local binding name to a contour ID, honoring import aliases.
+ *
+ * Strategies, in order:
+ * 1. Local `const foo = contour('name', ...)` binding → the contour name.
+ * 2. `knownContourIds` membership on the binding name itself (or the
+ *    conventional `Contour` suffix strip).
+ * 3. `import { foo as bar }` → use the original exported name `foo`
+ *    (and apply strategy 2 / suffix-stripping against it so aliased imports
+ *    resolve correctly). If the imported name still isn't recognized, the
+ *    imported name is returned so the caller can report it missing.
+ *
+ * Returns `null` only when the name belongs to no known resolution path —
+ * no local binding, no known contour ID, no import, and no suffix match.
+ * Returning `null` means "this identifier is not a contour reference we can
+ * reason about" (e.g. a bare undeclared variable), as opposed to
+ * "a contour reference whose target is missing".
+ */
+export const resolveContourIdentifierName = (
   bindingName: string,
   namedContourIds: ReadonlyMap<string, string>,
-  knownContourIds?: ReadonlySet<string>
+  knownContourIds?: ReadonlySet<string>,
+  importAliases?: ReadonlyMap<string, string>
 ): string | null => {
   const localName = namedContourIds.get(bindingName);
   if (localName) {
     return localName;
   }
 
-  if (knownContourIds?.has(bindingName)) {
-    return bindingName;
+  const known = resolveKnownContourName(bindingName, knownContourIds);
+  if (known) {
+    return known;
   }
 
-  const suffix = 'Contour';
-  if (
-    bindingName.endsWith(suffix) &&
-    knownContourIds?.has(bindingName.slice(0, -suffix.length))
-  ) {
-    return bindingName.slice(0, -suffix.length);
+  // If the binding came from an import, use the original exported name as
+  // the resolution target. This lets `import { foo as bar }` resolve to
+  // the exported `foo` rather than the local alias `bar`. If the imported
+  // name still isn't recognized, return it so callers can report it as
+  // missing under its original name.
+  const importedName = importAliases?.get(bindingName);
+  if (importedName) {
+    return (
+      resolveKnownContourName(importedName, knownContourIds) ?? importedName
+    );
   }
 
-  return bindingName;
+  return null;
 };
 
 const getContourReferenceMember = (
@@ -647,7 +743,8 @@ const getContourReferenceMember = (
 const getContourReferenceTargetFromObject = (
   object: AstNode,
   namedContourIds: ReadonlyMap<string, string>,
-  knownContourIds?: ReadonlySet<string>
+  knownContourIds?: ReadonlySet<string>,
+  importAliases?: ReadonlyMap<string, string>
 ): string | null => {
   if (object.type === 'Identifier') {
     const bindingName = identifierName(object);
@@ -655,7 +752,8 @@ const getContourReferenceTargetFromObject = (
       ? resolveContourIdentifierName(
           bindingName,
           namedContourIds,
-          knownContourIds
+          knownContourIds,
+          importAliases
         )
       : null;
   }
@@ -680,14 +778,16 @@ const getContourIdCallObject = (node: AstNode | undefined): AstNode | null => {
 const extractContourReferenceTarget = (
   node: AstNode | undefined,
   namedContourIds: ReadonlyMap<string, string>,
-  knownContourIds?: ReadonlySet<string>
+  knownContourIds?: ReadonlySet<string>,
+  importAliases?: ReadonlyMap<string, string>
 ): string | null => {
   const object = getContourIdCallObject(node);
   return object
     ? getContourReferenceTargetFromObject(
         object,
         namedContourIds,
-        knownContourIds
+        knownContourIds,
+        importAliases
       )
     : null;
 };
@@ -701,7 +801,8 @@ const buildContourReferenceSite = (
   definition: ContourDefinition,
   property: AstNode,
   namedContourIds: ReadonlyMap<string, string>,
-  knownContourIds?: ReadonlySet<string>
+  knownContourIds?: ReadonlySet<string>,
+  importAliases?: ReadonlyMap<string, string>
 ): ContourReferenceSite | null => {
   if (property.type !== 'Property') {
     return null;
@@ -711,7 +812,8 @@ const buildContourReferenceSite = (
   const target = extractContourReferenceTarget(
     property.value as AstNode | undefined,
     namedContourIds,
-    knownContourIds
+    knownContourIds,
+    importAliases
   );
   if (!field || !target) {
     return null;
@@ -728,14 +830,16 @@ const buildContourReferenceSite = (
 const findContourReferenceSitesForDefinition = (
   definition: ContourDefinition,
   namedContourIds: ReadonlyMap<string, string>,
-  knownContourIds?: ReadonlySet<string>
+  knownContourIds?: ReadonlySet<string>,
+  importAliases?: ReadonlyMap<string, string>
 ): readonly ContourReferenceSite[] =>
   getContourShapeProperties(definition).flatMap((property) => {
     const reference = buildContourReferenceSite(
       definition,
       property,
       namedContourIds,
-      knownContourIds
+      knownContourIds,
+      importAliases
     );
     return reference ? [reference] : [];
   });
@@ -746,11 +850,13 @@ export const collectContourReferenceSites = (
   knownContourIds?: ReadonlySet<string>
 ): readonly ContourReferenceSite[] => {
   const namedContourIds = collectNamedContourIds(ast);
+  const importAliases = collectImportAliasMap(ast);
   return findContourDefinitions(ast).flatMap((definition) =>
     findContourReferenceSitesForDefinition(
       definition,
       namedContourIds,
-      knownContourIds
+      knownContourIds,
+      importAliases
     )
   );
 };

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -451,6 +451,333 @@ export const findTrailDefinitions = (ast: AstNode): TrailDefinition[] => {
 };
 
 // ---------------------------------------------------------------------------
+// Contour definition extraction
+// ---------------------------------------------------------------------------
+
+export interface ContourDefinition {
+  /** Local binding name when the contour is assigned to a variable. */
+  readonly bindingName?: string;
+  /** Contour name string, e.g. "user". */
+  readonly name: string;
+  /** Original call expression for the contour declaration. */
+  readonly call: AstNode;
+  /** Options object argument passed to contour(), when present. */
+  readonly options: AstNode | null;
+  /** Shape object argument passed to contour(). */
+  readonly shape: AstNode;
+  /** Start offset of the call expression. */
+  readonly start: number;
+}
+
+const getContourCalleeName = (node: AstNode): string | null => {
+  if (node.type !== 'CallExpression') {
+    return null;
+  }
+  const callee = node['callee'] as AstNode | undefined;
+  if (!callee || callee.type !== 'Identifier') {
+    return null;
+  }
+  const { name } = callee as unknown as { name?: string };
+  return name === 'contour' ? name : null;
+};
+
+const extractContourDefinition = (
+  node: AstNode
+): Omit<ContourDefinition, 'bindingName'> | null => {
+  if (!getContourCalleeName(node)) {
+    return null;
+  }
+
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  const [nameArg, shapeArg, optionsArg] = args ?? [];
+  const name = extractStringLiteral(nameArg);
+  if (!name || shapeArg?.type !== 'ObjectExpression') {
+    return null;
+  }
+
+  return {
+    call: node,
+    name,
+    options: optionsArg?.type === 'ObjectExpression' ? optionsArg : null,
+    shape: shapeArg,
+    start: node.start,
+  };
+};
+
+export const findContourDefinitions = (ast: AstNode): ContourDefinition[] => {
+  const definitions: ContourDefinition[] = [];
+  const seenStarts = new Set<number>();
+
+  const addContourDefinition = (definition: ContourDefinition): void => {
+    if (seenStarts.has(definition.start)) {
+      return;
+    }
+
+    definitions.push(definition);
+    seenStarts.add(definition.start);
+  };
+
+  const addNamedContourDefinition = (
+    id: AstNode | undefined,
+    init: AstNode | undefined
+  ): void => {
+    if (!init) {
+      return;
+    }
+
+    const definition = extractContourDefinition(init);
+    if (!definition) {
+      return;
+    }
+
+    const bindingName = extractBindingName(id);
+    if (bindingName) {
+      addContourDefinition({ ...definition, bindingName });
+      return;
+    }
+
+    addContourDefinition(definition);
+  };
+
+  walk(ast, (node) => {
+    if (node.type === 'VariableDeclarator') {
+      const { id, init } = node as unknown as {
+        readonly id?: AstNode;
+        readonly init?: AstNode;
+      };
+      addNamedContourDefinition(id, init);
+      return;
+    }
+
+    const definition = extractContourDefinition(node);
+    if (definition) {
+      addContourDefinition(definition);
+    }
+  });
+
+  return definitions.toSorted((left, right) => left.start - right.start);
+};
+
+/** Collect all inline `contour('name', ...)` definition names from a parsed file. */
+export const collectContourDefinitionIds = (
+  ast: AstNode
+): ReadonlySet<string> =>
+  new Set(findContourDefinitions(ast).map((def) => def.name));
+
+/** Collect `const foo = contour('name', ...)` bindings from a parsed file. */
+export const collectNamedContourIds = (
+  ast: AstNode
+): ReadonlyMap<string, string> => {
+  const ids = new Map<string, string>();
+
+  for (const def of findContourDefinitions(ast)) {
+    if (def.bindingName) {
+      ids.set(def.bindingName, def.name);
+    }
+  }
+
+  return ids;
+};
+
+export interface ContourReferenceSite {
+  /** Field on the source contour that declares the reference. */
+  readonly field: string;
+  /** Source contour name. */
+  readonly source: string;
+  /** Start offset of the field declaration. */
+  readonly start: number;
+  /** Target contour name. */
+  readonly target: string;
+}
+
+const getPropertyName = (node: unknown): string | null => {
+  if (typeof node !== 'object' || node === null) {
+    return null;
+  }
+
+  const { name } = node as { readonly name?: unknown };
+  if (typeof name === 'string') {
+    return name;
+  }
+
+  return isAstNode(node) ? extractStringLiteral(node) : null;
+};
+
+const resolveContourIdentifierName = (
+  bindingName: string,
+  namedContourIds: ReadonlyMap<string, string>,
+  knownContourIds?: ReadonlySet<string>
+): string | null => {
+  const localName = namedContourIds.get(bindingName);
+  if (localName) {
+    return localName;
+  }
+
+  if (knownContourIds?.has(bindingName)) {
+    return bindingName;
+  }
+
+  const suffix = 'Contour';
+  if (
+    bindingName.endsWith(suffix) &&
+    knownContourIds?.has(bindingName.slice(0, -suffix.length))
+  ) {
+    return bindingName.slice(0, -suffix.length);
+  }
+
+  return bindingName;
+};
+
+const getContourReferenceMember = (
+  node: AstNode
+): { readonly object?: AstNode; readonly property?: AstNode } | null => {
+  if (
+    node.type !== 'MemberExpression' &&
+    node.type !== 'StaticMemberExpression'
+  ) {
+    return null;
+  }
+
+  return node as unknown as {
+    readonly object?: AstNode;
+    readonly property?: AstNode;
+  };
+};
+
+const getContourReferenceTargetFromObject = (
+  object: AstNode,
+  namedContourIds: ReadonlyMap<string, string>,
+  knownContourIds?: ReadonlySet<string>
+): string | null => {
+  if (object.type === 'Identifier') {
+    const bindingName = identifierName(object);
+    return bindingName
+      ? resolveContourIdentifierName(
+          bindingName,
+          namedContourIds,
+          knownContourIds
+        )
+      : null;
+  }
+
+  return extractContourDefinition(object)?.name ?? null;
+};
+
+const getContourIdCallObject = (node: AstNode | undefined): AstNode | null => {
+  if (!node || node.type !== 'CallExpression') {
+    return null;
+  }
+
+  const callee = node['callee'] as AstNode | undefined;
+  const member = callee ? getContourReferenceMember(callee) : null;
+  if (!member || identifierName(member.property) !== 'id') {
+    return null;
+  }
+
+  return member.object ?? null;
+};
+
+const extractContourReferenceTarget = (
+  node: AstNode | undefined,
+  namedContourIds: ReadonlyMap<string, string>,
+  knownContourIds?: ReadonlySet<string>
+): string | null => {
+  const object = getContourIdCallObject(node);
+  return object
+    ? getContourReferenceTargetFromObject(
+        object,
+        namedContourIds,
+        knownContourIds
+      )
+    : null;
+};
+
+const getContourShapeProperties = (
+  definition: ContourDefinition
+): readonly AstNode[] =>
+  (definition.shape['properties'] as readonly AstNode[] | undefined) ?? [];
+
+const buildContourReferenceSite = (
+  definition: ContourDefinition,
+  property: AstNode,
+  namedContourIds: ReadonlyMap<string, string>,
+  knownContourIds?: ReadonlySet<string>
+): ContourReferenceSite | null => {
+  if (property.type !== 'Property') {
+    return null;
+  }
+
+  const field = getPropertyName(property.key);
+  const target = extractContourReferenceTarget(
+    property.value as AstNode | undefined,
+    namedContourIds,
+    knownContourIds
+  );
+  if (!field || !target) {
+    return null;
+  }
+
+  return {
+    field,
+    source: definition.name,
+    start: property.start,
+    target,
+  };
+};
+
+const findContourReferenceSitesForDefinition = (
+  definition: ContourDefinition,
+  namedContourIds: ReadonlyMap<string, string>,
+  knownContourIds?: ReadonlySet<string>
+): readonly ContourReferenceSite[] =>
+  getContourShapeProperties(definition).flatMap((property) => {
+    const reference = buildContourReferenceSite(
+      definition,
+      property,
+      namedContourIds,
+      knownContourIds
+    );
+    return reference ? [reference] : [];
+  });
+
+/** Collect all contour field references declared via `.id()` in a parsed file. */
+export const collectContourReferenceSites = (
+  ast: AstNode,
+  knownContourIds?: ReadonlySet<string>
+): readonly ContourReferenceSite[] => {
+  const namedContourIds = collectNamedContourIds(ast);
+  return findContourDefinitions(ast).flatMap((definition) =>
+    findContourReferenceSitesForDefinition(
+      definition,
+      namedContourIds,
+      knownContourIds
+    )
+  );
+};
+
+/** Collect contour reference targets keyed by source contour name. */
+export const collectContourReferenceTargetsByName = (
+  ast: AstNode,
+  knownContourIds?: ReadonlySet<string>
+): ReadonlyMap<string, readonly string[]> => {
+  const targetsByName = new Map<string, Set<string>>();
+
+  for (const reference of collectContourReferenceSites(ast, knownContourIds)) {
+    const existing = targetsByName.get(reference.source);
+    if (existing) {
+      existing.add(reference.target);
+      continue;
+    }
+
+    targetsByName.set(reference.source, new Set([reference.target]));
+  }
+
+  return new Map(
+    [...targetsByName.entries()].map(([name, targets]) => [name, [...targets]])
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Blaze body extraction
 // ---------------------------------------------------------------------------
 

--- a/packages/warden/src/rules/circular-refs.ts
+++ b/packages/warden/src/rules/circular-refs.ts
@@ -1,0 +1,156 @@
+import {
+  collectContourReferenceTargetsByName,
+  findContourDefinitions,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+const mergeReferenceGraphs = (
+  localGraph: ReadonlyMap<string, readonly string[]>,
+  contextGraph?: ReadonlyMap<string, readonly string[]>
+): ReadonlyMap<string, readonly string[]> => {
+  const merged = new Map<string, Set<string>>();
+
+  const addTargets = (source: string, targets: readonly string[]): void => {
+    const existing = merged.get(source);
+    if (existing) {
+      for (const target of targets) {
+        existing.add(target);
+      }
+      return;
+    }
+
+    merged.set(source, new Set(targets));
+  };
+
+  for (const [source, targets] of contextGraph ?? []) {
+    addTargets(source, targets);
+  }
+
+  for (const [source, targets] of localGraph) {
+    addTargets(source, targets);
+  }
+
+  return new Map(
+    [...merged.entries()].map(([source, targets]) => [source, [...targets]])
+  );
+};
+
+const findCyclePath = (
+  start: string,
+  graph: ReadonlyMap<string, readonly string[]>,
+  current = start,
+  path: readonly string[] = [start],
+  active: ReadonlySet<string> = new Set([start])
+): readonly string[] | null => {
+  for (const target of graph.get(current) ?? []) {
+    if (target === start) {
+      return [...path, target];
+    }
+
+    if (active.has(target)) {
+      continue;
+    }
+
+    const cycle = findCyclePath(
+      start,
+      graph,
+      target,
+      [...path, target],
+      new Set([...active, target])
+    );
+    if (cycle) {
+      return cycle;
+    }
+  }
+
+  return null;
+};
+
+const buildCircularReferenceDiagnostic = (
+  contourName: string,
+  cyclePath: readonly string[],
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Contour "${contourName}" participates in circular contour references: ${cyclePath.join(' -> ')}.`,
+  rule: 'circular-refs',
+  severity: 'warn',
+});
+
+const checkCircularReferences = (
+  sourceCode: string,
+  filePath: string,
+  graph: ReadonlyMap<string, readonly string[]>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath)) {
+    return [];
+  }
+
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  return findContourDefinitions(ast).flatMap((definition) => {
+    const cyclePath = findCyclePath(definition.name, graph);
+    if (!cyclePath) {
+      return [];
+    }
+
+    return [
+      buildCircularReferenceDiagnostic(
+        definition.name,
+        cyclePath,
+        filePath,
+        offsetToLine(sourceCode, definition.start)
+      ),
+    ];
+  });
+};
+
+/**
+ * Warns when contour references form a direct or transitive cycle.
+ */
+export const circularRefs: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const graph = collectContourReferenceTargetsByName(ast);
+    return checkCircularReferences(sourceCode, filePath, graph);
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const localGraph = collectContourReferenceTargetsByName(
+      ast,
+      context.knownContourIds
+    );
+    return checkCircularReferences(
+      sourceCode,
+      filePath,
+      mergeReferenceGraphs(localGraph, context.contourReferencesByName)
+    );
+  },
+  description: 'Warn when contour references form direct or transitive cycles.',
+  name: 'circular-refs',
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/circular-refs.ts
+++ b/packages/warden/src/rules/circular-refs.ts
@@ -4,6 +4,7 @@ import {
   offsetToLine,
   parse,
 } from './ast.js';
+import type { AstNode } from './ast.js';
 import { isTestFile } from './scan.js';
 import type {
   ProjectAwareWardenRule,
@@ -87,16 +88,12 @@ const buildCircularReferenceDiagnostic = (
 });
 
 const checkCircularReferences = (
+  ast: AstNode,
   sourceCode: string,
   filePath: string,
   graph: ReadonlyMap<string, readonly string[]>
 ): readonly WardenDiagnostic[] => {
   if (isTestFile(filePath)) {
-    return [];
-  }
-
-  const ast = parse(filePath, sourceCode);
-  if (!ast) {
     return [];
   }
 
@@ -128,7 +125,7 @@ export const circularRefs: ProjectAwareWardenRule = {
     }
 
     const graph = collectContourReferenceTargetsByName(ast);
-    return checkCircularReferences(sourceCode, filePath, graph);
+    return checkCircularReferences(ast, sourceCode, filePath, graph);
   },
   checkWithContext(
     sourceCode: string,
@@ -145,6 +142,7 @@ export const circularRefs: ProjectAwareWardenRule = {
       context.knownContourIds
     );
     return checkCircularReferences(
+      ast,
       sourceCode,
       filePath,
       mergeReferenceGraphs(localGraph, context.contourReferencesByName)

--- a/packages/warden/src/rules/contour-exists.ts
+++ b/packages/warden/src/rules/contour-exists.ts
@@ -1,5 +1,6 @@
 import {
   collectContourDefinitionIds,
+  collectImportAliasMap,
   collectNamedContourIds,
   extractFirstStringArg,
   findConfigProperty,
@@ -7,8 +8,9 @@ import {
   identifierName,
   offsetToLine,
   parse,
+  resolveContourIdentifierName,
 } from './ast.js';
-import type { AstNode } from './ast.js';
+import type { AstNode, TrailDefinition } from './ast.js';
 import { isTestFile } from './scan.js';
 import type {
   ProjectAwareWardenRule,
@@ -20,31 +22,6 @@ const isContourCall = (node: AstNode): boolean =>
   node.type === 'CallExpression' &&
   identifierName((node as unknown as { callee?: AstNode }).callee) ===
     'contour';
-
-const resolveContourIdentifierName = (
-  name: string,
-  contourIdsByName: ReadonlyMap<string, string>,
-  knownContourIds?: ReadonlySet<string>
-): string | null => {
-  const localName = contourIdsByName.get(name);
-  if (localName) {
-    return localName;
-  }
-
-  if (knownContourIds?.has(name)) {
-    return name;
-  }
-
-  const suffix = 'Contour';
-  if (
-    name.endsWith(suffix) &&
-    knownContourIds?.has(name.slice(0, -suffix.length))
-  ) {
-    return name.slice(0, -suffix.length);
-  }
-
-  return name;
-};
 
 const getContourElements = (config: AstNode): readonly AstNode[] => {
   const contoursProp = findConfigProperty(config, 'contours');
@@ -66,12 +43,18 @@ const getContourElements = (config: AstNode): readonly AstNode[] => {
 const resolveDeclaredContourName = (
   element: AstNode,
   contourIdsByName: ReadonlyMap<string, string>,
-  knownContourIds?: ReadonlySet<string>
+  knownContourIds?: ReadonlySet<string>,
+  importAliases?: ReadonlyMap<string, string>
 ): string | null => {
   if (element.type === 'Identifier') {
     const name = identifierName(element);
     return name
-      ? resolveContourIdentifierName(name, contourIdsByName, knownContourIds)
+      ? resolveContourIdentifierName(
+          name,
+          contourIdsByName,
+          knownContourIds,
+          importAliases
+        )
       : null;
   }
 
@@ -81,14 +64,16 @@ const resolveDeclaredContourName = (
 const extractDeclaredContourNames = (
   config: AstNode,
   contourIdsByName: ReadonlyMap<string, string>,
-  knownContourIds?: ReadonlySet<string>
+  knownContourIds?: ReadonlySet<string>,
+  importAliases?: ReadonlyMap<string, string>
 ): readonly string[] => [
   ...new Set(
     getContourElements(config).flatMap((element) => {
       const contourName = resolveDeclaredContourName(
         element,
         contourIdsByName,
-        knownContourIds
+        knownContourIds,
+        importAliases
       );
       return contourName ? [contourName] : [];
     })
@@ -108,53 +93,66 @@ const buildMissingContourDiagnostic = (
   severity: 'error',
 });
 
+const buildDiagnosticsForDefinition = (
+  definition: TrailDefinition,
+  sourceCode: string,
+  filePath: string,
+  knownContourIds: ReadonlySet<string>,
+  contourIdsByName: ReadonlyMap<string, string>,
+  importAliases: ReadonlyMap<string, string>
+): readonly WardenDiagnostic[] => {
+  if (definition.kind !== 'trail') {
+    return [];
+  }
+
+  const line = offsetToLine(sourceCode, definition.start);
+  return extractDeclaredContourNames(
+    definition.config,
+    contourIdsByName,
+    knownContourIds,
+    importAliases
+  ).flatMap((contourName) =>
+    knownContourIds.has(contourName)
+      ? []
+      : [
+          buildMissingContourDiagnostic(
+            definition.id,
+            contourName,
+            filePath,
+            line
+          ),
+        ]
+  );
+};
+
 const buildContourDiagnostics = (
   ast: AstNode,
   sourceCode: string,
   filePath: string,
   knownContourIds: ReadonlySet<string>
 ): readonly WardenDiagnostic[] => {
-  const diagnostics: WardenDiagnostic[] = [];
   const contourIdsByName = collectNamedContourIds(ast);
+  const importAliases = collectImportAliasMap(ast);
 
-  for (const definition of findTrailDefinitions(ast)) {
-    if (definition.kind !== 'trail') {
-      continue;
-    }
-
-    const line = offsetToLine(sourceCode, definition.start);
-    for (const contourName of extractDeclaredContourNames(
-      definition.config,
+  return findTrailDefinitions(ast).flatMap((definition) =>
+    buildDiagnosticsForDefinition(
+      definition,
+      sourceCode,
+      filePath,
+      knownContourIds,
       contourIdsByName,
-      knownContourIds
-    )) {
-      if (!knownContourIds.has(contourName)) {
-        diagnostics.push(
-          buildMissingContourDiagnostic(
-            definition.id,
-            contourName,
-            filePath,
-            line
-          )
-        );
-      }
-    }
-  }
-
-  return diagnostics;
+      importAliases
+    )
+  );
 };
 
 const checkContourDeclarations = (
+  ast: AstNode,
   sourceCode: string,
   filePath: string,
   knownContourIds: ReadonlySet<string>
 ): readonly WardenDiagnostic[] => {
   if (isTestFile(filePath)) {
-    return [];
-  }
-
-  const ast = parse(filePath, sourceCode);
-  if (!ast) {
     return [];
   }
 
@@ -173,6 +171,7 @@ export const contourExists: ProjectAwareWardenRule = {
     }
 
     return checkContourDeclarations(
+      ast,
       sourceCode,
       filePath,
       collectContourDefinitionIds(ast)
@@ -184,10 +183,13 @@ export const contourExists: ProjectAwareWardenRule = {
     context: ProjectContext
   ): readonly WardenDiagnostic[] {
     const ast = parse(filePath, sourceCode);
-    const localContourIds = ast
-      ? collectContourDefinitionIds(ast)
-      : new Set<string>();
+    if (!ast) {
+      return [];
+    }
+
+    const localContourIds = collectContourDefinitionIds(ast);
     return checkContourDeclarations(
+      ast,
       sourceCode,
       filePath,
       context.knownContourIds ?? localContourIds

--- a/packages/warden/src/rules/contour-exists.ts
+++ b/packages/warden/src/rules/contour-exists.ts
@@ -1,0 +1,200 @@
+import {
+  collectContourDefinitionIds,
+  collectNamedContourIds,
+  extractFirstStringArg,
+  findConfigProperty,
+  findTrailDefinitions,
+  identifierName,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+const isContourCall = (node: AstNode): boolean =>
+  node.type === 'CallExpression' &&
+  identifierName((node as unknown as { callee?: AstNode }).callee) ===
+    'contour';
+
+const resolveContourIdentifierName = (
+  name: string,
+  contourIdsByName: ReadonlyMap<string, string>,
+  knownContourIds?: ReadonlySet<string>
+): string | null => {
+  const localName = contourIdsByName.get(name);
+  if (localName) {
+    return localName;
+  }
+
+  if (knownContourIds?.has(name)) {
+    return name;
+  }
+
+  const suffix = 'Contour';
+  if (
+    name.endsWith(suffix) &&
+    knownContourIds?.has(name.slice(0, -suffix.length))
+  ) {
+    return name.slice(0, -suffix.length);
+  }
+
+  return name;
+};
+
+const getContourElements = (config: AstNode): readonly AstNode[] => {
+  const contoursProp = findConfigProperty(config, 'contours');
+  if (!contoursProp) {
+    return [];
+  }
+
+  const arrayNode = contoursProp.value;
+  if (!arrayNode || (arrayNode as AstNode).type !== 'ArrayExpression') {
+    return [];
+  }
+
+  const elements = (arrayNode as AstNode)['elements'] as
+    | readonly AstNode[]
+    | undefined;
+  return elements ?? [];
+};
+
+const resolveDeclaredContourName = (
+  element: AstNode,
+  contourIdsByName: ReadonlyMap<string, string>,
+  knownContourIds?: ReadonlySet<string>
+): string | null => {
+  if (element.type === 'Identifier') {
+    const name = identifierName(element);
+    return name
+      ? resolveContourIdentifierName(name, contourIdsByName, knownContourIds)
+      : null;
+  }
+
+  return isContourCall(element) ? extractFirstStringArg(element) : null;
+};
+
+const extractDeclaredContourNames = (
+  config: AstNode,
+  contourIdsByName: ReadonlyMap<string, string>,
+  knownContourIds?: ReadonlySet<string>
+): readonly string[] => [
+  ...new Set(
+    getContourElements(config).flatMap((element) => {
+      const contourName = resolveDeclaredContourName(
+        element,
+        contourIdsByName,
+        knownContourIds
+      );
+      return contourName ? [contourName] : [];
+    })
+  ),
+];
+
+const buildMissingContourDiagnostic = (
+  trailId: string,
+  contourName: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}" declares contour "${contourName}" which is not defined in the project.`,
+  rule: 'contour-exists',
+  severity: 'error',
+});
+
+const buildContourDiagnostics = (
+  ast: AstNode,
+  sourceCode: string,
+  filePath: string,
+  knownContourIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+  const contourIdsByName = collectNamedContourIds(ast);
+
+  for (const definition of findTrailDefinitions(ast)) {
+    if (definition.kind !== 'trail') {
+      continue;
+    }
+
+    const line = offsetToLine(sourceCode, definition.start);
+    for (const contourName of extractDeclaredContourNames(
+      definition.config,
+      contourIdsByName,
+      knownContourIds
+    )) {
+      if (!knownContourIds.has(contourName)) {
+        diagnostics.push(
+          buildMissingContourDiagnostic(
+            definition.id,
+            contourName,
+            filePath,
+            line
+          )
+        );
+      }
+    }
+  }
+
+  return diagnostics;
+};
+
+const checkContourDeclarations = (
+  sourceCode: string,
+  filePath: string,
+  knownContourIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath)) {
+    return [];
+  }
+
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  return buildContourDiagnostics(ast, sourceCode, filePath, knownContourIds);
+};
+
+/**
+ * Checks that every contour declared in a trail `contours` array resolves to a
+ * known contour definition.
+ */
+export const contourExists: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    return checkContourDeclarations(
+      sourceCode,
+      filePath,
+      collectContourDefinitionIds(ast)
+    );
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    const localContourIds = ast
+      ? collectContourDefinitionIds(ast)
+      : new Set<string>();
+    return checkContourDeclarations(
+      sourceCode,
+      filePath,
+      context.knownContourIds ?? localContourIds
+    );
+  },
+  description:
+    'Ensure every contour declared on a trail resolves to a known contour definition.',
+  name: 'contour-exists',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/example-valid.ts
+++ b/packages/warden/src/rules/example-valid.ts
@@ -59,10 +59,22 @@ type ContourNodeEvaluator = (
   env: ContourEvaluationEnvironment
 ) => unknown;
 
-// oxlint-disable-next-line require-hook -- evaluator placeholder is module-scope wiring, not test setup
-let evaluateNode: ContourNodeEvaluator = (): never => {
+// The evaluator table is declared before `evaluateNode` so the recursive
+// dispatch can read it at call time without any forward references. Entries
+// are registered below once each per-type evaluator is defined.
+const contourNodeEvaluators = new Map<string, ContourNodeEvaluator>();
+
+const evaluateNode: ContourNodeEvaluator = (
+  node: AstNode,
+  env: ContourEvaluationEnvironment
+): unknown => {
+  const evaluator = contourNodeEvaluators.get(node.type);
+  if (evaluator) {
+    return evaluator(node, env);
+  }
+
   throw new UnsupportedContourEvaluationError(
-    'Contour evaluator not initialized.'
+    `Unsupported AST node "${node.type}" in contour evaluation.`
   );
 };
 
@@ -149,22 +161,52 @@ const evaluateCallArguments = (
     evaluateNode(arg, env)
   );
 
+const resolveContourFallbackOptions = (
+  shape: unknown
+): Parameters<typeof contour>[2] | null =>
+  typeof shape === 'object' &&
+  shape !== null &&
+  Object.hasOwn(shape, 'id') &&
+  (shape as z.ZodRawShape)['id'] !== undefined
+    ? ({ identity: 'id' } as Parameters<typeof contour>[2])
+    : null;
+
+const resolveContourOptions = (
+  shape: unknown,
+  options: unknown
+): Parameters<typeof contour>[2] => {
+  if (options === undefined) {
+    const fallbackOptions = resolveContourFallbackOptions(shape);
+    if (fallbackOptions !== null) {
+      return fallbackOptions;
+    }
+
+    throw new UnsupportedContourEvaluationError(
+      'Contour evaluator requires literal options, or an `id` field when options are omitted.'
+    );
+  }
+
+  if (typeof options !== 'object' || options === null) {
+    throw new UnsupportedContourEvaluationError(
+      'Contour evaluator requires literal options when provided.'
+    );
+  }
+
+  return options as Parameters<typeof contour>[2];
+};
+
 const evaluateContourCall = (args: readonly unknown[]): unknown => {
   const [name, shape, options] = args;
-  if (
-    typeof name !== 'string' ||
-    typeof options !== 'object' ||
-    options === null
-  ) {
+  if (typeof name !== 'string') {
     throw new UnsupportedContourEvaluationError(
-      'Contour evaluator requires literal name and options.'
+      'Contour evaluator requires a literal name.'
     );
   }
 
   return contour(
     name,
     shape as z.ZodRawShape,
-    options as Parameters<typeof contour>[2]
+    resolveContourOptions(shape, options)
   );
 };
 
@@ -226,7 +268,10 @@ const evaluateCallExpression: ContourNodeEvaluator = (
   return evaluateMemberCall(callee, args, env);
 };
 
-const contourNodeEvaluators = new Map<string, ContourNodeEvaluator>([
+const EVALUATOR_REGISTRATIONS: readonly (readonly [
+  string,
+  ContourNodeEvaluator,
+])[] = [
   ['ArrayExpression', evaluateArrayExpression],
   ['BooleanLiteral', evaluateLiteralExpression],
   ['Literal', evaluateLiteralExpression],
@@ -239,18 +284,11 @@ const contourNodeEvaluators = new Map<string, ContourNodeEvaluator>([
   ['ParenthesizedExpression', evaluateWrappedExpression],
   ['TSAsExpression', evaluateWrappedExpression],
   ['TSSatisfiesExpression', evaluateWrappedExpression],
-]);
+];
 
-evaluateNode = (node: AstNode, env: ContourEvaluationEnvironment): unknown => {
-  const evaluator = contourNodeEvaluators.get(node.type);
-  if (evaluator) {
-    return evaluator(node, env);
-  }
-
-  throw new UnsupportedContourEvaluationError(
-    `Unsupported AST node "${node.type}" in contour evaluation.`
-  );
-};
+for (const [type, evaluator] of EVALUATOR_REGISTRATIONS) {
+  contourNodeEvaluators.set(type, evaluator);
+}
 
 const hasExamples = (definition: ContourDefinition): boolean =>
   definition.options !== null &&

--- a/packages/warden/src/rules/example-valid.ts
+++ b/packages/warden/src/rules/example-valid.ts
@@ -1,0 +1,363 @@
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  extractStringLiteral,
+  findConfigProperty,
+  findContourDefinitions,
+  getStringValue,
+  identifierName,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import type { AstNode, ContourDefinition } from './ast.js';
+import { isTestFile } from './scan.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+class UnsupportedContourEvaluationError extends Error {}
+
+type ContourEvaluationEnvironment = ReadonlyMap<string, unknown>;
+
+const buildInvalidExampleDiagnostic = (
+  contourName: string,
+  message: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Contour "${contourName}" has invalid examples: ${message}`,
+  rule: 'example-valid',
+  severity: 'error',
+});
+
+const getPropertyName = (node: unknown): string | null => {
+  if (typeof node !== 'object' || node === null) {
+    return null;
+  }
+
+  const { name } = node as { readonly name?: unknown };
+  if (typeof name === 'string') {
+    return name;
+  }
+
+  return extractStringLiteral(node as AstNode);
+};
+
+const requireNode = (node: AstNode | undefined): AstNode => {
+  if (!node) {
+    throw new UnsupportedContourEvaluationError(
+      'Missing node in contour evaluation.'
+    );
+  }
+
+  return node;
+};
+
+type ContourNodeEvaluator = (
+  node: AstNode,
+  env: ContourEvaluationEnvironment
+) => unknown;
+
+// oxlint-disable-next-line require-hook -- evaluator placeholder is module-scope wiring, not test setup
+let evaluateNode: ContourNodeEvaluator = (): never => {
+  throw new UnsupportedContourEvaluationError(
+    'Contour evaluator not initialized.'
+  );
+};
+
+const evaluateArrayExpression: ContourNodeEvaluator = (
+  node: AstNode,
+  env: ContourEvaluationEnvironment
+): readonly unknown[] => {
+  const elements = node['elements'] as readonly AstNode[] | undefined;
+  return (elements ?? []).map((element) => evaluateNode(element, env));
+};
+
+const evaluateLiteralExpression: ContourNodeEvaluator = (
+  node: AstNode
+): unknown => getStringValue(node) ?? node.value;
+
+const evaluateIdentifierExpression: ContourNodeEvaluator = (
+  node: AstNode,
+  env: ContourEvaluationEnvironment
+): unknown => {
+  const name = identifierName(node);
+  if (name === 'undefined') {
+    return undefined;
+  }
+
+  if (name === 'z') {
+    return z;
+  }
+
+  if (!name || !env.has(name)) {
+    throw new UnsupportedContourEvaluationError(
+      `Unknown identifier "${name ?? '<unknown>'}" in contour evaluation.`
+    );
+  }
+
+  return env.get(name);
+};
+
+const evaluateWrappedExpression: ContourNodeEvaluator = (
+  node: AstNode,
+  env: ContourEvaluationEnvironment
+): unknown =>
+  evaluateNode(
+    requireNode((node as unknown as { expression?: AstNode }).expression),
+    env
+  );
+
+const evaluateNullExpression: ContourNodeEvaluator = (): null => null;
+
+const evaluateObjectExpression: ContourNodeEvaluator = (
+  node: AstNode,
+  env: ContourEvaluationEnvironment
+): Record<string, unknown> => {
+  const properties = node['properties'] as readonly AstNode[] | undefined;
+  const value: Record<string, unknown> = {};
+
+  for (const property of properties ?? []) {
+    if (property.type !== 'Property') {
+      throw new UnsupportedContourEvaluationError(
+        `Unsupported object property type "${property.type}".`
+      );
+    }
+
+    const propertyName = getPropertyName(property.key);
+    if (!propertyName) {
+      throw new UnsupportedContourEvaluationError(
+        'Unsupported object property key in contour evaluation.'
+      );
+    }
+
+    value[propertyName] = evaluateNode(
+      requireNode(property.value as AstNode | undefined),
+      env
+    );
+  }
+
+  return value;
+};
+
+const evaluateCallArguments = (
+  node: AstNode,
+  env: ContourEvaluationEnvironment
+): readonly unknown[] =>
+  ((node['arguments'] as readonly AstNode[] | undefined) ?? []).map((arg) =>
+    evaluateNode(arg, env)
+  );
+
+const evaluateContourCall = (args: readonly unknown[]): unknown => {
+  const [name, shape, options] = args;
+  if (
+    typeof name !== 'string' ||
+    typeof options !== 'object' ||
+    options === null
+  ) {
+    throw new UnsupportedContourEvaluationError(
+      'Contour evaluator requires literal name and options.'
+    );
+  }
+
+  return contour(
+    name,
+    shape as z.ZodRawShape,
+    options as Parameters<typeof contour>[2]
+  );
+};
+
+const evaluateMemberCall = (
+  callee: AstNode,
+  args: readonly unknown[],
+  env: ContourEvaluationEnvironment
+): unknown => {
+  const receiver = evaluateNode(
+    requireNode((callee as unknown as { object?: AstNode }).object),
+    env
+  );
+  const propertyName = getPropertyName(
+    (callee as unknown as { property?: AstNode }).property
+  );
+  if (!propertyName) {
+    throw new UnsupportedContourEvaluationError(
+      'Unsupported member property in contour evaluation.'
+    );
+  }
+
+  const method = (receiver as Record<string, unknown>)[propertyName];
+  if (typeof method !== 'function') {
+    throw new UnsupportedContourEvaluationError(
+      `Contour evaluator could not call "${propertyName}".`
+    );
+  }
+
+  return Reflect.apply(method, receiver, args);
+};
+
+const evaluateCallExpression: ContourNodeEvaluator = (
+  node: AstNode,
+  env: ContourEvaluationEnvironment
+): unknown => {
+  const args = evaluateCallArguments(node, env);
+  const callee = requireNode(node['callee'] as AstNode | undefined);
+
+  if (callee.type === 'Identifier') {
+    const calleeName = identifierName(callee);
+    if (calleeName !== 'contour') {
+      throw new UnsupportedContourEvaluationError(
+        `Unsupported contour evaluator call "${calleeName ?? '<unknown>'}".`
+      );
+    }
+
+    return evaluateContourCall(args);
+  }
+
+  if (
+    callee.type !== 'MemberExpression' &&
+    callee.type !== 'StaticMemberExpression'
+  ) {
+    throw new UnsupportedContourEvaluationError(
+      `Unsupported callee type "${callee.type}".`
+    );
+  }
+
+  return evaluateMemberCall(callee, args, env);
+};
+
+const contourNodeEvaluators = new Map<string, ContourNodeEvaluator>([
+  ['ArrayExpression', evaluateArrayExpression],
+  ['BooleanLiteral', evaluateLiteralExpression],
+  ['Literal', evaluateLiteralExpression],
+  ['NumericLiteral', evaluateLiteralExpression],
+  ['StringLiteral', evaluateLiteralExpression],
+  ['CallExpression', evaluateCallExpression],
+  ['Identifier', evaluateIdentifierExpression],
+  ['NullLiteral', evaluateNullExpression],
+  ['ObjectExpression', evaluateObjectExpression],
+  ['ParenthesizedExpression', evaluateWrappedExpression],
+  ['TSAsExpression', evaluateWrappedExpression],
+  ['TSSatisfiesExpression', evaluateWrappedExpression],
+]);
+
+evaluateNode = (node: AstNode, env: ContourEvaluationEnvironment): unknown => {
+  const evaluator = contourNodeEvaluators.get(node.type);
+  if (evaluator) {
+    return evaluator(node, env);
+  }
+
+  throw new UnsupportedContourEvaluationError(
+    `Unsupported AST node "${node.type}" in contour evaluation.`
+  );
+};
+
+const hasExamples = (definition: ContourDefinition): boolean =>
+  definition.options !== null &&
+  findConfigProperty(definition.options, 'examples') !== null;
+
+const evaluateContourDefinition = (
+  definition: ContourDefinition,
+  env: ContourEvaluationEnvironment
+): unknown => evaluateNode(definition.call, env);
+
+const buildContourExampleErrorDiagnostic = (
+  definition: ContourDefinition,
+  error: unknown,
+  sourceCode: string,
+  filePath: string
+): WardenDiagnostic | null => {
+  if (
+    error instanceof UnsupportedContourEvaluationError ||
+    !hasExamples(definition) ||
+    !(error instanceof Error)
+  ) {
+    return null;
+  }
+
+  return buildInvalidExampleDiagnostic(
+    definition.name,
+    error.message,
+    filePath,
+    offsetToLine(sourceCode, definition.start)
+  );
+};
+
+const evaluateContourExamples = (
+  definition: ContourDefinition,
+  env: Map<string, unknown>,
+  sourceCode: string,
+  filePath: string
+): WardenDiagnostic | null => {
+  try {
+    const value = evaluateContourDefinition(definition, env);
+    if (definition.bindingName) {
+      env.set(definition.bindingName, value);
+    }
+
+    return null;
+  } catch (error) {
+    return buildContourExampleErrorDiagnostic(
+      definition,
+      error,
+      sourceCode,
+      filePath
+    );
+  }
+};
+
+const collectContourExampleDiagnostics = (
+  definitions: readonly ContourDefinition[],
+  sourceCode: string,
+  filePath: string
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+  const env = new Map<string, unknown>();
+
+  for (const definition of definitions) {
+    const diagnostic = evaluateContourExamples(
+      definition,
+      env,
+      sourceCode,
+      filePath
+    );
+    if (diagnostic) {
+      diagnostics.push(diagnostic);
+    }
+  }
+
+  return diagnostics;
+};
+
+const checkContourExamples = (
+  sourceCode: string,
+  filePath: string
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath)) {
+    return [];
+  }
+
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  return collectContourExampleDiagnostics(
+    findContourDefinitions(ast),
+    sourceCode,
+    filePath
+  );
+};
+
+/**
+ * Checks that contour examples validate against their schema.
+ */
+export const exampleValid: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    return checkContourExamples(sourceCode, filePath);
+  },
+  description:
+    'Ensure every contour example validates against the declared contour schema.',
+  name: 'example-valid',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -1,9 +1,12 @@
+import { circularRefs } from './circular-refs.js';
+import { contourExists } from './contour-exists.js';
 import { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 import { crossDeclarations } from './cross-declarations.js';
 import { deadInternalTrail } from './dead-internal-trail.js';
 import { draftFileMarking } from './draft-file-marking.js';
 import { draftVisibleDebt } from './draft-visible-debt.js';
 import { errorMappingCompleteness } from './error-mapping-completeness.js';
+import { exampleValid } from './example-valid.js';
 import { firesDeclarations } from './fires-declarations.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
 import { intentPropagation } from './intent-propagation.js';
@@ -15,6 +18,7 @@ import { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
 import { onReferencesExist } from './on-references-exist.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
+import { referenceExists } from './reference-exists.js';
 import { resourceDeclarations } from './resource-declarations.js';
 import { resourceExists } from './resource-exists.js';
 import type { WardenRule } from './types.js';
@@ -30,12 +34,15 @@ export type {
 } from './types.js';
 
 export { noThrowInImplementation } from './no-throw-in-implementation.js';
+export { circularRefs } from './circular-refs.js';
+export { contourExists } from './contour-exists.js';
 export { contextNoTrailheadTypes } from './context-no-trailhead-types.js';
 export { crossDeclarations } from './cross-declarations.js';
 export { deadInternalTrail } from './dead-internal-trail.js';
 export { draftFileMarking } from './draft-file-marking.js';
 export { draftVisibleDebt } from './draft-visible-debt.js';
 export { errorMappingCompleteness } from './error-mapping-completeness.js';
+export { exampleValid } from './example-valid.js';
 export { firesDeclarations } from './fires-declarations.js';
 export { intentPropagation } from './intent-propagation.js';
 export { missingVisibility } from './missing-visibility.js';
@@ -47,6 +54,7 @@ export { noSyncResultAssumption } from './no-sync-result-assumption.js';
 export { implementationReturnsResult } from './implementation-returns-result.js';
 export { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 export { preferSchemaInference } from './prefer-schema-inference.js';
+export { referenceExists } from './reference-exists.js';
 export { resourceDeclarations } from './resource-declarations.js';
 export { resourceExists } from './resource-exists.js';
 export { validDescribeRefs } from './valid-describe-refs.js';
@@ -57,17 +65,21 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   WardenRule
 >([
   [noThrowInImplementation.name, noThrowInImplementation],
+  [circularRefs.name, circularRefs],
+  [contourExists.name, contourExists],
   [contextNoTrailheadTypes.name, contextNoTrailheadTypes],
   [crossDeclarations.name, crossDeclarations],
   [deadInternalTrail.name, deadInternalTrail],
   [draftFileMarking.name, draftFileMarking],
   [draftVisibleDebt.name, draftVisibleDebt],
   [errorMappingCompleteness.name, errorMappingCompleteness],
+  [exampleValid.name, exampleValid],
   [firesDeclarations.name, firesDeclarations],
   [intentPropagation.name, intentPropagation],
   [missingVisibility.name, missingVisibility],
   [onReferencesExist.name, onReferencesExist],
   [resourceDeclarations.name, resourceDeclarations],
+  [referenceExists.name, referenceExists],
   [resourceExists.name, resourceExists],
   [preferSchemaInference.name, preferSchemaInference],
   [validDescribeRefs.name, validDescribeRefs],

--- a/packages/warden/src/rules/reference-exists.ts
+++ b/packages/warden/src/rules/reference-exists.ts
@@ -4,6 +4,7 @@ import {
   offsetToLine,
   parse,
 } from './ast.js';
+import type { AstNode } from './ast.js';
 import { isTestFile } from './scan.js';
 import type {
   ProjectAwareWardenRule,
@@ -26,16 +27,12 @@ const buildMissingReferenceDiagnostic = (
 });
 
 const checkContourReferences = (
+  ast: AstNode,
   sourceCode: string,
   filePath: string,
   knownContourIds: ReadonlySet<string>
 ): readonly WardenDiagnostic[] => {
   if (isTestFile(filePath)) {
-    return [];
-  }
-
-  const ast = parse(filePath, sourceCode);
-  if (!ast) {
     return [];
   }
 
@@ -69,6 +66,7 @@ export const referenceExists: ProjectAwareWardenRule = {
     }
 
     return checkContourReferences(
+      ast,
       sourceCode,
       filePath,
       collectContourDefinitionIds(ast)
@@ -80,10 +78,13 @@ export const referenceExists: ProjectAwareWardenRule = {
     context: ProjectContext
   ): readonly WardenDiagnostic[] {
     const ast = parse(filePath, sourceCode);
-    const localContourIds = ast
-      ? collectContourDefinitionIds(ast)
-      : new Set<string>();
+    if (!ast) {
+      return [];
+    }
+
+    const localContourIds = collectContourDefinitionIds(ast);
     return checkContourReferences(
+      ast,
       sourceCode,
       filePath,
       context.knownContourIds ?? localContourIds

--- a/packages/warden/src/rules/reference-exists.ts
+++ b/packages/warden/src/rules/reference-exists.ts
@@ -1,0 +1,96 @@
+import {
+  collectContourDefinitionIds,
+  collectContourReferenceSites,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+const buildMissingReferenceDiagnostic = (
+  sourceContour: string,
+  field: string,
+  targetContour: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Contour "${sourceContour}" field "${field}" references contour "${targetContour}" which is not defined in the project.`,
+  rule: 'reference-exists',
+  severity: 'error',
+});
+
+const checkContourReferences = (
+  sourceCode: string,
+  filePath: string,
+  knownContourIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath)) {
+    return [];
+  }
+
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  return collectContourReferenceSites(ast, knownContourIds).flatMap(
+    (reference) => {
+      if (knownContourIds.has(reference.target)) {
+        return [];
+      }
+
+      return [
+        buildMissingReferenceDiagnostic(
+          reference.source,
+          reference.field,
+          reference.target,
+          filePath,
+          offsetToLine(sourceCode, reference.start)
+        ),
+      ];
+    }
+  );
+};
+
+/**
+ * Checks that every contour `.id()` reference resolves to a known contour.
+ */
+export const referenceExists: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    return checkContourReferences(
+      sourceCode,
+      filePath,
+      collectContourDefinitionIds(ast)
+    );
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    const localContourIds = ast
+      ? collectContourDefinitionIds(ast)
+      : new Set<string>();
+    return checkContourReferences(
+      sourceCode,
+      filePath,
+      context.knownContourIds ?? localContourIds
+    );
+  },
+  description:
+    'Ensure every contour field declared via .id() resolves to a known contour.',
+  name: 'reference-exists',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -43,8 +43,12 @@ export interface WardenRule {
  * Options for cross-file rules that need knowledge of all trail IDs in a project.
  */
 export interface ProjectContext {
+  /** All known contour names in the project. */
+  readonly knownContourIds?: ReadonlySet<string>;
   /** All known trail IDs in the project */
   readonly knownTrailIds: ReadonlySet<string>;
+  /** Declared contour references keyed by source contour name. */
+  readonly contourReferencesByName?: ReadonlyMap<string, readonly string[]>;
   /** All known resource IDs in the project */
   readonly knownResourceIds?: ReadonlySet<string>;
   /** All known signal IDs in the project */

--- a/packages/warden/src/trails/circular-refs.trail.ts
+++ b/packages/warden/src/trails/circular-refs.trail.ts
@@ -1,0 +1,29 @@
+import { circularRefs } from '../rules/circular-refs.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const circularRefsTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        contourReferencesByName: {
+          gist: ['user'],
+          user: [],
+        },
+        filePath: 'contours.ts',
+        knownContourIds: ['gist', 'user'],
+        knownTrailIds: [],
+        sourceCode: `const user = contour("user", {
+  id: z.string().uuid(),
+}, { identity: "id" });
+
+const gist = contour("gist", {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: "id" });`,
+      },
+      name: 'Acyclic contour references stay clean',
+    },
+  ],
+  rule: circularRefs,
+});

--- a/packages/warden/src/trails/contour-exists.trail.ts
+++ b/packages/warden/src/trails/contour-exists.trail.ts
@@ -1,0 +1,21 @@
+import { contourExists } from '../rules/contour-exists.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const contourExistsTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'entity.ts',
+        knownContourIds: ['user'],
+        knownTrailIds: ['user.create'],
+        sourceCode: `trail("user.create", {
+  contours: [user],
+  blaze: async (input, ctx) => Result.ok({ ok: true }),
+})`,
+      },
+      name: 'Declared contours resolve to known project contours',
+    },
+  ],
+  rule: contourExists,
+});

--- a/packages/warden/src/trails/example-valid.trail.ts
+++ b/packages/warden/src/trails/example-valid.trail.ts
@@ -1,0 +1,25 @@
+import { exampleValid } from '../rules/example-valid.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const exampleValidTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'contours.ts',
+        sourceCode: `const user = contour("user", {
+  id: z.string().uuid(),
+  name: z.string(),
+}, {
+  examples: [{
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "Ada",
+  }],
+  identity: "id",
+});`,
+      },
+      name: 'Contour examples validate against their schema',
+    },
+  ],
+  rule: exampleValid,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -1,7 +1,10 @@
+export { circularRefsTrail } from './circular-refs.trail.js';
+export { contourExistsTrail } from './contour-exists.trail.js';
 export { contextNoTrailheadTypesTrail } from './context-no-trailhead-types.trail.js';
 export { crossDeclarationsTrail } from './cross-declarations.trail.js';
 export { deadInternalTrailTrail } from './dead-internal-trail.trail.js';
 export { errorMappingCompletenessTrail } from './error-mapping-completeness.trail.js';
+export { exampleValidTrail } from './example-valid.trail.js';
 export { firesDeclarationsTrail } from './fires-declarations.trail.js';
 export { implementationReturnsResultTrail } from './implementation-returns-result.trail.js';
 export { intentPropagationTrail } from './intent-propagation.trail.js';
@@ -13,6 +16,7 @@ export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.j
 export { noThrowInDetourTargetTrail } from './no-throw-in-detour-target.trail.js';
 export { noThrowInImplementationTrail } from './no-throw-in-implementation.trail.js';
 export { preferSchemaInferenceTrail } from './prefer-schema-inference.trail.js';
+export { referenceExistsTrail } from './reference-exists.trail.js';
 export { resourceDeclarationsTrail } from './resource-declarations.trail.js';
 export { resourceExistsTrail } from './resource-exists.trail.js';
 export { validDescribeRefsTrail } from './valid-describe-refs.trail.js';

--- a/packages/warden/src/trails/reference-exists.trail.ts
+++ b/packages/warden/src/trails/reference-exists.trail.ts
@@ -1,0 +1,25 @@
+import { referenceExists } from '../rules/reference-exists.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const referenceExistsTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'contours.ts',
+        knownContourIds: ['gist', 'user'],
+        knownTrailIds: [],
+        sourceCode: `const user = contour("user", {
+  id: z.string().uuid(),
+}, { identity: "id" });
+
+const gist = contour("gist", {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: "id" });`,
+      },
+      name: 'Contour references resolve to known project contours',
+    },
+  ],
+  rule: referenceExists,
+});

--- a/packages/warden/src/trails/run.ts
+++ b/packages/warden/src/trails/run.ts
@@ -28,8 +28,12 @@ const appendDiagnostics = (
 const hasProjectOptions = (
   options:
     | {
+        readonly contourReferencesByName?: Readonly<
+          Record<string, readonly string[]>
+        >;
         readonly crossTargetTrailIds?: readonly string[];
         readonly detourTargetTrailIds?: readonly string[];
+        readonly knownContourIds?: readonly string[];
         readonly knownResourceIds?: readonly string[];
         readonly knownSignalIds?: readonly string[];
         readonly knownTrailIds?: readonly string[];
@@ -40,8 +44,10 @@ const hasProjectOptions = (
     | undefined
 ): boolean =>
   Boolean(
+    options?.contourReferencesByName ||
     options?.crossTargetTrailIds ||
     options?.detourTargetTrailIds ||
+    options?.knownContourIds ||
     options?.knownResourceIds ||
     options?.knownSignalIds ||
     options?.knownTrailIds ||
@@ -53,8 +59,12 @@ const buildRuleInput = (
   sourceCode: string,
   options:
     | {
+        readonly contourReferencesByName?: Readonly<
+          Record<string, readonly string[]>
+        >;
         readonly crossTargetTrailIds?: readonly string[];
         readonly detourTargetTrailIds?: readonly string[];
+        readonly knownContourIds?: readonly string[];
         readonly knownResourceIds?: readonly string[];
         readonly knownSignalIds?: readonly string[];
         readonly knownTrailIds?: readonly string[];
@@ -69,9 +79,13 @@ const buildRuleInput = (
       readonly sourceCode: string;
     }
   | {
+      readonly contourReferencesByName?: Readonly<
+        Record<string, readonly string[]>
+      >;
       readonly crossTargetTrailIds?: readonly string[];
       readonly detourTargetTrailIds?: readonly string[];
       readonly filePath: string;
+      readonly knownContourIds?: readonly string[];
       readonly knownResourceIds?: readonly string[];
       readonly knownSignalIds?: readonly string[];
       readonly knownTrailIds?: readonly string[];
@@ -87,11 +101,17 @@ const buildRuleInput = (
 
   return {
     ...base,
+    ...(options?.contourReferencesByName
+      ? { contourReferencesByName: options.contourReferencesByName }
+      : {}),
     ...(options?.crossTargetTrailIds
       ? { crossTargetTrailIds: options.crossTargetTrailIds }
       : {}),
     ...(options?.detourTargetTrailIds
       ? { detourTargetTrailIds: options.detourTargetTrailIds }
+      : {}),
+    ...(options?.knownContourIds
+      ? { knownContourIds: options.knownContourIds }
       : {}),
     ...(options?.knownResourceIds
       ? { knownResourceIds: options.knownResourceIds }
@@ -110,8 +130,12 @@ export const runWardenTrails = async (
   filePath: string,
   sourceCode: string,
   options?: {
+    readonly contourReferencesByName?: Readonly<
+      Record<string, readonly string[]>
+    >;
     readonly crossTargetTrailIds?: readonly string[];
     readonly detourTargetTrailIds?: readonly string[];
+    readonly knownContourIds?: readonly string[];
     readonly knownResourceIds?: readonly string[];
     readonly knownSignalIds?: readonly string[];
     readonly knownTrailIds?: readonly string[];

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -30,6 +30,10 @@ export const ruleInput = z.object({
  * files.
  */
 export const projectAwareRuleInput = ruleInput.extend({
+  contourReferencesByName: z
+    .record(z.string(), z.array(z.string()))
+    .optional()
+    .describe('Declared contour references keyed by source contour name'),
   crossTargetTrailIds: z
     .array(z.string())
     .optional()
@@ -38,6 +42,10 @@ export const projectAwareRuleInput = ruleInput.extend({
     .array(z.string())
     .optional()
     .describe('Trail IDs referenced as detour targets across the project'),
+  knownContourIds: z
+    .array(z.string())
+    .optional()
+    .describe('Contour names known across the project'),
   knownResourceIds: z
     .array(z.string())
     .optional()

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -30,6 +30,16 @@ interface WrapProjectAwareRuleOptions {
 }
 
 const buildProjectContext = (input: ProjectAwareRuleInput): ProjectContext => ({
+  ...(input.contourReferencesByName
+    ? {
+        contourReferencesByName: new Map(
+          Object.entries(input.contourReferencesByName)
+        ),
+      }
+    : {}),
+  ...(input.knownContourIds
+    ? { knownContourIds: new Set(input.knownContourIds) }
+    : {}),
   knownTrailIds: input.knownTrailIds
     ? new Set(input.knownTrailIds)
     : new Set<string>(),


### PR DESCRIPTION
## Summary

Adds warden rules that catch common mistakes in contour-backed trails, along with the AST plumbing the rules need to reason across files.

- Add `contour-exists` rule so trails referencing a contour without a matching definition are flagged
- Add `reference-exists` rule for dangling trail / resource / contour references
- Add `circular-refs` rule to detect circular contour references
- Add `example-valid` rule so contour / trail example payloads are validated against the declared schema at lint time
- New shared `rules/ast.ts` module so the contour rules can analyze project structure across files
- Extends `warden/cli` integration so cross-file detection works from the CLI

## Testing

- `bun test packages/warden/src/__tests__/contour-exists.test.ts`
- `bun test packages/warden/src/__tests__/reference-exists.test.ts`
- `bun test packages/warden/src/__tests__/circular-refs.test.ts`
- `bun test packages/warden/src/__tests__/example-valid.test.ts`
- `bun test packages/warden/src/__tests__/trails.test.ts packages/warden/src/__tests__/cli.test.ts`
- `bun run --cwd packages/warden test`
- `bun run --cwd packages/warden typecheck`

## Closes

- Closes TRL-240
