### PR TITLE
feat: store version tracking, change signals, and Drizzle tabular

### DIFF
--- a/connectors/drizzle/src/__tests__/drizzle.test.ts
+++ b/connectors/drizzle/src/__tests__/drizzle.test.ts
@@ -671,7 +671,6 @@ describe('@ontrails/with-drizzle resource access', () => {
     );
   });
 
-
   test('manages versioned writes and rejects stale optimistic-concurrency updates', async () => {
     const rootDir = tmp.makeRoot();
     const { created, db } = await setupVersionedUserStore(rootDir);
@@ -817,6 +816,7 @@ describe('@ontrails/with-drizzle read-only resource access', () => {
     );
     expect(readOnly.access).toBe('readonly');
     expect(readOnly.mock).toBeDefined();
+    expect(readOnly.signals).toBeUndefined();
     await expectReadonlyReads(created, inserted);
     await expectReadonlyWriteFailure(created);
     await readOnly.dispose?.(created);
@@ -841,6 +841,7 @@ describe('@ontrails/with-drizzle read-only resource access', () => {
       }
     );
     expect(db.access).toBe('readonly');
+    expect(db.signals).toBeUndefined();
 
     const mockFactory = db.mock;
     expect(mockFactory).toBeDefined();

--- a/connectors/drizzle/src/__tests__/drizzle.test.ts
+++ b/connectors/drizzle/src/__tests__/drizzle.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import {
   AlreadyExistsError,
+  ConflictError,
   ValidationError,
   createTrailContext,
 } from '@ontrails/core';
@@ -59,6 +60,13 @@ const writableDemoDefinition = defineStore({
   users: userTable,
 });
 
+const versionedUserDefinition = defineStore({
+  users: {
+    ...userTable,
+    versioned: true,
+  },
+});
+
 const expectOk = async <T>(value: PromiseLike<T> | T): Promise<T> =>
   await value;
 
@@ -88,11 +96,51 @@ const createWritableDemoStore = (rootDir: string) =>
     }
   );
 
+const createVersionedUserStore = (rootDir: string) =>
+  store(
+    {
+      users: {
+        ...userTable,
+        versioned: true,
+      },
+    },
+    {
+      description: 'Versioned demo store',
+      id: 'demo.store.versioned',
+      url: join(rootDir, 'versioned.sqlite'),
+    }
+  );
+
 const setupWritableDemoStore = async (rootDir: string) => {
   const db = createWritableDemoStore(rootDir);
   return {
     created: await unwrapCreated(db.create(createResourceInput(rootDir))),
     db,
+  };
+};
+
+const setupVersionedUserStore = async (rootDir: string) => {
+  const db = createVersionedUserStore(rootDir);
+  return {
+    created: await unwrapCreated(db.create(createResourceInput(rootDir))),
+    db,
+  };
+};
+
+const createTmpRootManager = (prefix: string) => {
+  let tmpRoot: string | undefined;
+
+  return {
+    cleanup() {
+      if (tmpRoot !== undefined) {
+        rmSync(tmpRoot, { force: true, recursive: true });
+        tmpRoot = undefined;
+      }
+    },
+    makeRoot(): string {
+      tmpRoot = mkdtempSync(join(tmpdir(), prefix));
+      return tmpRoot;
+    },
   };
 };
 
@@ -141,13 +189,6 @@ const seedWritableRecords = async (
   const gist = await expectOk(created.gists.upsert({ ownerId: user.id }));
   expectInsertedGist(gist, user.id);
   return { gist, user };
-};
-
-const expectDefined = <T>(value: T | undefined, label: string): T => {
-  if (value === undefined) {
-    throw new Error(`${label} should be defined`);
-  }
-  return value;
 };
 
 const expectStoredGist = async (
@@ -305,6 +346,9 @@ const setupReadonlyUserStore = async (url: string, rootDir: string) => {
 type ReadonlyUserStoreRuntime = Awaited<
   ReturnType<typeof setupReadonlyUserStore>
 >['created'];
+type VersionedUserStoreRuntime = Awaited<
+  ReturnType<typeof setupVersionedUserStore>
+>['created'];
 
 const expectReadonlyReads = async (
   created: ReadonlyUserStoreRuntime,
@@ -325,6 +369,41 @@ const expectReadonlyWriteFailure = async (
         .run()
     )
   ).rejects.toThrow();
+};
+
+const expectVersionedCreate = async (
+  created: VersionedUserStoreRuntime
+): Promise<{
+  readonly first: Awaited<ReturnType<typeof created.users.upsert>>;
+  readonly second: Awaited<ReturnType<typeof created.users.upsert>>;
+}> => {
+  const first = await expectOk(
+    created.users.upsert({ email: 'versioned@example.com' })
+  );
+  expect(first).toEqual(
+    expect.objectContaining({
+      email: 'versioned@example.com',
+      id: expect.any(String),
+      version: 1,
+    })
+  );
+  expect(await created.users.get(first.id)).toEqual(first);
+
+  const second = await expectOk(
+    created.users.upsert({
+      email: 'versioned+updated@example.com',
+      id: first.id,
+      version: first.version,
+    })
+  );
+  expect(second).toEqual({
+    email: 'versioned+updated@example.com',
+    id: first.id,
+    version: 2,
+  });
+  expect(await created.users.get(first.id)).toEqual(second);
+
+  return { first, second };
 };
 
 const createErrorStore = (rootDir: string) =>
@@ -404,7 +483,7 @@ describe('writable user accessor contract', () => {
   });
 });
 
-describe('@ontrails/with-drizzle', () => {
+describe('versioned user accessor contract', () => {
   let tmpRoot: string | undefined;
 
   afterEach(() => {
@@ -415,12 +494,66 @@ describe('@ontrails/with-drizzle', () => {
   });
 
   const makeRoot = (): string => {
-    tmpRoot = mkdtempSync(join(tmpdir(), 'store-drizzle-'));
+    tmpRoot = mkdtempSync(join(tmpdir(), 'store-drizzle-versioned-'));
     return tmpRoot;
   };
 
+  const contractCases = createStoreAccessorContractCases({
+    createInput: () => ({ email: 'contract@example.com' }),
+    async createSubject() {
+      const rootDir = makeRoot();
+      const { created, db } = await setupVersionedUserStore(rootDir);
+
+      return {
+        accessor: created.users,
+        dispose: async () => {
+          await db.dispose?.(created);
+        },
+      };
+    },
+    expectCreated(entity, input) {
+      expect(entity).toEqual(
+        expect.objectContaining({
+          email: input.email,
+          id: expect.any(String),
+          version: 1,
+        })
+      );
+    },
+    expectUpdated(entity, previous, input) {
+      expect(entity).toEqual({
+        email: input.email,
+        id: previous.id,
+        version: previous.version + 1,
+      });
+    },
+    missingId: 'missing-user-id',
+    table: versionedUserDefinition.tables.users,
+    updateInput(existing) {
+      return {
+        email: 'contract+updated@example.com',
+        id: existing.id,
+        version: existing.version,
+      };
+    },
+  });
+
+  test.each(
+    contractCases.map((contractCase) => [contractCase.name, contractCase.run])
+  )('%s', async (_name, run) => {
+    await run();
+  });
+});
+
+describe('@ontrails/with-drizzle resource access', () => {
+  const tmp = createTmpRootManager('store-drizzle-');
+
+  afterEach(() => {
+    tmp.cleanup();
+  });
+
   test('binds a writable resource with CRUD accessors and one escape hatch', async () => {
-    const rootDir = makeRoot();
+    const rootDir = tmp.makeRoot();
     const { created, db } = await setupWritableDemoStore(rootDir);
     expectWritableResourceDefinition(db);
     await expectWritableLifecycle(created);
@@ -451,67 +584,216 @@ describe('@ontrails/with-drizzle', () => {
     );
   });
 
-  describe('read-only stores', () => {
-    test('enforces writes at the database layer', async () => {
-      const rootDir = makeRoot();
-      const url = join(rootDir, 'readonly.sqlite');
-      const inserted = await seedReadonlyFixture(url, rootDir);
-      const { created, db: readOnly } = await setupReadonlyUserStore(
-        url,
-        rootDir
-      );
-      expect(readOnly.access).toBe('readonly');
-      expect(readOnly.mock).toBeDefined();
-      await expectReadonlyReads(created, inserted);
-      await expectReadonlyWriteFailure(created);
-      await readOnly.dispose?.(created);
-    });
 
-    test('creates a mock resource seeded from mockSeed', async () => {
-      const db = readonlyStore(
-        {
-          users: userTable,
+  test('manages versioned writes and rejects stale optimistic-concurrency updates', async () => {
+    const rootDir = tmp.makeRoot();
+    const { created, db } = await setupVersionedUserStore(rootDir);
+    const { first, second } = await expectVersionedCreate(created);
+
+    await expect(
+      created.users.upsert({
+        email: 'stale@example.com',
+        id: first.id,
+        version: first.version,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    expect(await created.users.list()).toEqual([second]);
+    await db.dispose?.(created);
+  });
+
+  test('keeps non-versioned writes free of framework-managed version fields', async () => {
+    const rootDir = tmp.makeRoot();
+    const { created, db } = await setupWritableDemoStore(rootDir);
+    const user = await expectOk(
+      created.users.upsert({ email: 'plain@example.com' })
+    );
+
+    expect(user).toEqual({
+      email: 'plain@example.com',
+      id: expect.any(String),
+    });
+    expect(user).not.toHaveProperty('version');
+    await db.dispose?.(created);
+  });
+
+  test('round-trips a user-declared "version" field on non-versioned tables', async () => {
+    const rootDir = tmp.makeRoot();
+    const db = store(
+      {
+        documents: {
+          generated: ['id'],
+          primaryKey: 'id',
+          schema: z.object({
+            body: z.string(),
+            id: z.string(),
+            version: z.string(),
+          }),
         },
-        {
-          id: 'demo.store.readonly.mock',
-          mockSeed: {
-            users: [
-              {
-                email: 'mock@example.com',
-                id: 'user-mock',
-              },
-            ],
-          },
-          url: ':memory:',
-        }
-      );
-      expect(db.access).toBe('readonly');
-      const mockFactory = expectDefined(db.mock, 'readonlyStore.mock');
-      const mock = await mockFactory();
-      expect(await mock.users.get('user-mock')).toEqual(
-        expect.objectContaining({
-          email: 'mock@example.com',
-          id: 'user-mock',
-        })
-      );
-      expect(await mock.users.list()).toHaveLength(1);
-      await db.dispose?.(mock);
+      },
+      {
+        description: 'Non-versioned store with a user-owned "version" column',
+        id: 'demo.store.user-version',
+        url: join(rootDir, 'user-version.sqlite'),
+      }
+    );
+    const created = await unwrapCreated(
+      db.create(createResourceInput(rootDir))
+    );
+
+    const inserted = await created.documents.insert({
+      body: 'original',
+      version: 'draft-1',
+    });
+    expect(inserted).toEqual(
+      expect.objectContaining({
+        body: 'original',
+        id: expect.any(String),
+        version: 'draft-1',
+      })
+    );
+
+    const upserted = await created.documents.upsert({
+      body: 'final',
+      id: inserted.id,
+      version: 'draft-2',
+    });
+    expect(upserted).toEqual({
+      body: 'final',
+      id: inserted.id,
+      version: 'draft-2',
     });
 
-    test('creates a read-only mock that rejects writes through query', async () => {
-      const db = createReadonlyUserStore(
-        join(makeRoot(), 'readonly-mock.sqlite')
-      );
-      const mockFactory = expectDefined(db.mock, 'readonlyStore.mock');
-      const mock = await mockFactory();
+    const reread = await created.documents.get(inserted.id);
+    expect(reread).toEqual(upserted);
+    await db.dispose?.(created);
+  });
 
-      await expectReadonlyWriteFailure(mock);
-      await db.dispose?.(mock);
-    });
+  test('atomically rejects stale upserts on versioned tables', async () => {
+    const rootDir = tmp.makeRoot();
+    const { created, db } = await setupVersionedUserStore(rootDir);
+
+    const first = await expectOk(
+      created.users.upsert({ email: 'race@example.com' })
+    );
+
+    // Simulate a concurrent writer that advances the version between two
+    // attempts sharing the same stale expected version.
+    const winner = await expectOk(
+      created.users.upsert({
+        email: 'winner@example.com',
+        id: first.id,
+        version: first.version,
+      })
+    );
+    expect(winner.version).toBe(first.version + 1);
+
+    // The second attempt still holds the stale version and must be rejected
+    // by the atomic WHERE clause rather than silently overwriting.
+    await expect(
+      created.users.upsert({
+        email: 'loser@example.com',
+        id: first.id,
+        version: first.version,
+      })
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    expect(await created.users.get(first.id)).toEqual(winner);
+    await db.dispose?.(created);
+  });
+
+  test('fires derived change signals from context-bound writable accessors', async () => {
+    const rootDir = tmp.makeRoot();
+    const { bound, created, db, recorder } =
+      await createSignalBoundStore(rootDir);
+    const { createdGist, updatedGist } = await exerciseSignalWrites(bound);
+
+    expectRecordedSignals(recorder, createdGist, updatedGist);
+    await db.dispose?.(created);
+  });
+});
+
+describe('@ontrails/with-drizzle read-only resource access', () => {
+  const tmp = createTmpRootManager('store-drizzle-readonly-');
+
+  afterEach(() => {
+    tmp.cleanup();
+  });
+
+  test('opens a read-only store and enforces writes at the database layer', async () => {
+    const rootDir = tmp.makeRoot();
+    const url = join(rootDir, 'readonly.sqlite');
+    const inserted = await seedReadonlyFixture(url, rootDir);
+    const { created, db: readOnly } = await setupReadonlyUserStore(
+      url,
+      rootDir
+    );
+    expect(readOnly.access).toBe('readonly');
+    expect(readOnly.mock).toBeDefined();
+    await expectReadonlyReads(created, inserted);
+    await expectReadonlyWriteFailure(created);
+    await readOnly.dispose?.(created);
+  });
+
+  test('creates a mock resource seeded from mockSeed', async () => {
+    const db = readonlyStore(
+      {
+        users: userTable,
+      },
+      {
+        id: 'demo.store.readonly.mock',
+        mockSeed: {
+          users: [
+            {
+              email: 'mock@example.com',
+              id: 'user-mock',
+            },
+          ],
+        },
+        url: ':memory:',
+      }
+    );
+    expect(db.access).toBe('readonly');
+
+    const mockFactory = db.mock;
+    expect(mockFactory).toBeDefined();
+
+    const mock = await mockFactory?.();
+    expect(mock).toBeDefined();
+    expect(await mock?.users.get('user-mock')).toEqual(
+      expect.objectContaining({
+        email: 'mock@example.com',
+        id: 'user-mock',
+      })
+    );
+    expect(await mock?.users.list()).toHaveLength(1);
+    await db.dispose?.(mock as ReadonlyUserStoreRuntime);
+  });
+
+  test('creates a read-only mock that rejects writes through query', async () => {
+    const db = createReadonlyUserStore(
+      join(tmp.makeRoot(), 'readonly-mock.sqlite')
+    );
+    const mockFactory = db.mock;
+    expect(mockFactory).toBeDefined();
+
+    const mock = await mockFactory?.();
+    expect(mock).toBeDefined();
+
+    await expectReadonlyWriteFailure(mock as ReadonlyUserStoreRuntime);
+    await db.dispose?.(mock as ReadonlyUserStoreRuntime);
+  });
+});
+
+describe('@ontrails/with-drizzle edge cases', () => {
+  const tmp = createTmpRootManager('store-drizzle-');
+
+  afterEach(() => {
+    tmp.cleanup();
   });
 
   test('maps primary-key and foreign-key failures into Trails errors', async () => {
-    const rootDir = makeRoot();
+    const rootDir = tmp.makeRoot();
     const db = createErrorStore(rootDir);
     const created = await unwrapCreated(
       db.create(createResourceInput(rootDir))
@@ -550,7 +832,7 @@ describe('@ontrails/with-drizzle', () => {
           }),
         },
       },
-      { url: join(makeRoot(), 'int.sqlite') }
+      { url: join(tmp.makeRoot(), 'int.sqlite') }
     );
 
     const schema = getSchema(intStore);

--- a/connectors/drizzle/src/__tests__/drizzle.test.ts
+++ b/connectors/drizzle/src/__tests__/drizzle.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import {
   AlreadyExistsError,
   ConflictError,
+  Result,
   ValidationError,
   createTrailContext,
 } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
 import { store as defineStore } from '@ontrails/store';
 import { createStoreAccessorContractCases } from '@ontrails/store/testing';
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -144,6 +146,26 @@ const createTmpRootManager = (prefix: string) => {
   };
 };
 
+const createFireRecorder = () => {
+  const events: { payload: unknown; signalId: string }[] = [];
+  const record = (
+    signal: string | { readonly id: string },
+    payload: unknown
+  ) => {
+    events.push({
+      payload,
+      signalId: typeof signal === 'string' ? signal : signal.id,
+    });
+
+    return Result.ok();
+  };
+
+  return {
+    events,
+    fire: record as unknown as NonNullable<TrailContext['fire']>,
+  };
+};
+
 type WritableDemoStoreRuntime = Awaited<
   ReturnType<typeof setupWritableDemoStore>
 >['created'];
@@ -155,6 +177,14 @@ const expectWritableResourceDefinition = (
   expect(db.id).toBe('demo.store');
   expect(db.access).toBe('readwrite');
   expect(db.mock).toBeDefined();
+  expect(db.signals.map((candidate) => candidate.id)).toEqual([
+    'gists.created',
+    'gists.updated',
+    'gists.removed',
+    'users.created',
+    'users.updated',
+    'users.removed',
+  ]);
   expect(getSchema(db).gists).toBe(db.tables.gists);
 };
 
@@ -219,7 +249,9 @@ const expectUpdatedGist = async (
     })
   );
   expect(updated?.updatedAt).toEqual(expect.any(String));
-  expect(updated?.updatedAt).not.toBe(gist.updatedAt);
+  expect(Date.parse(updated.updatedAt)).toBeGreaterThanOrEqual(
+    Date.parse(gist.updatedAt)
+  );
 };
 
 const expectQueryEscapeHatch = async (
@@ -270,6 +302,55 @@ const expectResourceResolution = (
     requestId: 'store-drizzle',
   });
   expect(db.from(ctx).users).toBeDefined();
+};
+
+const createSignalBoundStore = async (rootDir: string) => {
+  const { created, db } = await setupWritableDemoStore(rootDir);
+  const recorder = createFireRecorder();
+  const ctx = createTrailContext({
+    abortSignal: new AbortController().signal,
+    extensions: {
+      [db.id]: created,
+    },
+    fire: recorder.fire,
+    requestId: 'store-drizzle-signals',
+  });
+
+  return {
+    bound: db.from(ctx),
+    created,
+    db,
+    recorder,
+  };
+};
+
+const exerciseSignalWrites = async (bound: WritableDemoStoreRuntime) => {
+  const user = await bound.users.upsert({ email: 'signals@example.com' });
+  const createdGist = await bound.gists.upsert({ ownerId: user.id });
+  const updatedGist = await bound.gists.upsert({
+    description: 'Updated',
+    id: createdGist.id,
+    ownerId: user.id,
+  });
+
+  expect(await bound.gists.remove(createdGist.id)).toEqual({ deleted: true });
+  return { createdGist, updatedGist };
+};
+
+const expectRecordedSignals = (
+  recorder: ReturnType<typeof createFireRecorder>,
+  createdGist: z.output<typeof gistSchema>,
+  updatedGist: z.output<typeof gistSchema>
+): void => {
+  expect(recorder.events.map((event) => event.signalId)).toEqual([
+    'users.created',
+    'gists.created',
+    'gists.updated',
+    'gists.removed',
+  ]);
+  expect(recorder.events[1]?.payload).toEqual(createdGist);
+  expect(recorder.events[2]?.payload).toEqual(updatedGist);
+  expect(recorder.events[3]?.payload).toEqual(updatedGist);
 };
 
 const createFixtureBackedStore = () =>

--- a/connectors/drizzle/src/__tests__/drizzle.test.ts
+++ b/connectors/drizzle/src/__tests__/drizzle.test.ts
@@ -14,7 +14,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 
-import { getSchema, readonlyStore, store } from '../index.js';
+import {
+  connectDrizzle,
+  connectReadOnlyDrizzle,
+  getSchema,
+  readonlyStore,
+  store,
+} from '../index.js';
 
 const userSchema = z.object({
   email: z.string().email(),
@@ -922,6 +928,47 @@ describe('@ontrails/with-drizzle edge cases', () => {
 
     const idColumn = col.id as unknown as { columnType: string };
     expect(idColumn.columnType).toBe('SQLiteInteger');
+  });
+
+  test('rejects non-tabular store definitions with a clear error', () => {
+    const documentStore = defineStore(
+      {
+        documents: {
+          generated: ['id'],
+          primaryKey: 'id',
+          schema: z.object({
+            body: z.string(),
+            id: z.string(),
+          }),
+        },
+      },
+      { kind: 'document' }
+    );
+    const rootDir = tmp.makeRoot();
+
+    const expectKindMismatch = (run: () => unknown) => {
+      try {
+        run();
+        throw new Error(
+          'expected connector binding to reject a non-tabular store'
+        );
+      } catch (error) {
+        expect(error).toBeInstanceOf(ValidationError);
+        expect((error as Error).message).toContain('kind "tabular"');
+        expect((error as Error).message).toContain('"document"');
+      }
+    };
+
+    expectKindMismatch(() =>
+      connectDrizzle(documentStore, {
+        url: join(rootDir, 'document.sqlite'),
+      })
+    );
+    expectKindMismatch(() =>
+      connectReadOnlyDrizzle(documentStore, {
+        url: join(rootDir, 'document-readonly.sqlite'),
+      })
+    );
   });
 
   test('update returns null for a non-existent ID', async () => {

--- a/connectors/drizzle/src/runtime.ts
+++ b/connectors/drizzle/src/runtime.ts
@@ -1101,14 +1101,18 @@ const bindWritableAccessorSignals = <TTable extends AnyStoreTable>(
       return removed;
     },
     async update(id: StoreIdentifierOf<TTable>, input: UpdateOf<TTable>) {
+      if (table.versioned) {
+        // Versioned tables auto-increment the version column on every write,
+        // so changedEntity always detects a diff. Skip the redundant pre-read
+        // and fire unconditionally on successful update.
+        const updated = await accessor.update(id, input);
+        if (updated !== null) {
+          await fireDerivedSignal(fire, table.signals.updated.id, updated);
+        }
+        return updated;
+      }
       const existing = await accessor.get(id);
       const updated = await accessor.update(id, input);
-      // On versioned tables the version column auto-increments on every
-      // write, so `changedEntity` will always detect a diff even when the
-      // caller-supplied fields are identical. This means `updated` fires on
-      // every successful update for versioned tables — expected behavior,
-      // not a bug. Consumers should treat the signal as "a write occurred"
-      // rather than "user-visible data changed."
       if (changedEntity(existing, updated)) {
         await fireDerivedSignal(fire, table.signals.updated.id, updated);
       }

--- a/connectors/drizzle/src/runtime.ts
+++ b/connectors/drizzle/src/runtime.ts
@@ -1120,6 +1120,10 @@ const bindWritableAccessorSignals = <TTable extends AnyStoreTable>(
     },
     async upsert(input: UpsertOf<TTable>) {
       const existingId = inputIdentity(table, input);
+      // NOTE: pre-read is not transactional with the write below. Under
+      // concurrent deletes, `existing` may be non-null while `accessor.upsert`
+      // actually inserts. `created` vs `updated` signal discrimination is
+      // best-effort — matches the same caveat documented on `remove`.
       const existing =
         existingId === undefined ? null : await accessor.get(existingId);
       const written = await accessor.upsert(input);

--- a/connectors/drizzle/src/runtime.ts
+++ b/connectors/drizzle/src/runtime.ts
@@ -10,7 +10,7 @@ import {
   ValidationError,
   resource,
 } from '@ontrails/core';
-import { store as defineStore } from '@ontrails/store';
+import { store as defineStore, versionFieldName } from '@ontrails/store';
 import type {
   AnyStoreDefinition,
   AnyStoreTable,
@@ -27,7 +27,7 @@ import type {
   UpsertOf,
   UpdateOf,
 } from '@ontrails/store';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import type { AnySQLiteColumn, AnySQLiteTable } from 'drizzle-orm/sqlite-core';
 import type { z } from 'zod';
@@ -180,9 +180,19 @@ const TIMESTAMP_FIELD_NAMES = new Set([
   'created_at',
   'updated_at',
 ]);
-const versionFieldName = 'version';
 
 const ID_FIELD_SUFFIX_RE = /[Ii]d$/;
+
+/**
+ * Returns true when the given field on `table` is the framework-managed
+ * version column. Used by insert and upsert paths to gate behavior that
+ * only applies to versioned tables, preventing silent data loss when a
+ * non-versioned table happens to have a user field named `version`.
+ */
+const isVersionManagedField = <TTable extends AnyStoreTable>(
+  table: TTable,
+  fieldName: string
+): boolean => table.versioned && fieldName === versionFieldName;
 
 /**
  * Synthesize a value for a generated field during insert.
@@ -221,7 +231,7 @@ const generatedVersionValue = (tableName: string, kind: string): number => {
   }
 
   throw new ValidationError(
-    `Store table "${tableName}" manages "${versionFieldName}" as an integer field.`
+    `Store table "${tableName}" has a versioned "${versionFieldName}" field of type "${kind}", but the framework requires it to be an integer. Ensure the schema uses z.number().int() for the version field.`
   );
 };
 
@@ -253,7 +263,7 @@ const generatedValueForInsert = <TTable extends AnyStoreTable>(
   const fieldName = field as string;
   const kind = baseFieldKind(table, field);
 
-  if (fieldName === versionFieldName) {
+  if (isVersionManagedField(table, fieldName)) {
     return generatedVersionValue(table.name, kind);
   }
 
@@ -393,20 +403,6 @@ const assertExpectedVersionMatch = <TTable extends AnyStoreTable>(
   if (currentVersion !== expectedVersion) {
     throw versionConflictError(table.name, id, expectedVersion, currentVersion);
   }
-};
-
-const applyVersionedUpdateFields = <TTable extends AnyStoreTable>(
-  table: TTable,
-  existing: EntityOf<TTable>,
-  userFields: Record<string, unknown>
-): Record<string, unknown> => {
-  const fields = applyGeneratedUpdateFields(table, userFields);
-  return table.versioned
-    ? {
-        ...fields,
-        [versionFieldName]: versionFromEntity(table, existing) + 1,
-      }
-    : fields;
 };
 
 const resolveUpsertWithoutPatch = <
@@ -685,43 +681,57 @@ const createWritableAccessor = <
     return cloneValue(parseEntity(definitionTable, row)) as EntityOf<Table>;
   };
 
+  const versionColumn = definitionTable.versioned
+    ? primaryKeyColumn(drizzleTable, versionFieldName)
+    : undefined;
+
+  // oxlint-disable-next-line max-statements -- atomic UPDATE ... WHERE with version guard and conflict diagnosis reads more clearly as one function
   const updateEntity = (
     id: Identifier,
     input: Record<string, unknown>,
     expectedVersion?: number
   ): EntityOf<Table> | null => {
-    const userFields = requireUpdateFields(definitionTable.name, input);
-    const existing = readEntity(id);
-    if (existing === null) {
-      return null;
-    }
-
-    assertExpectedVersionMatch(
+    const base = applyGeneratedUpdateFields(
       definitionTable,
-      id as string | number,
-      existing,
-      expectedVersion
+      requireUpdateFields(definitionTable.name, input)
     );
-    const fields = applyVersionedUpdateFields(
-      definitionTable,
-      existing,
-      userFields
-    );
+    // Atomic increment via SQL expression — avoids the read-then-write race
+    // on optimistic-concurrency updates.
+    const fields =
+      definitionTable.versioned && versionColumn !== undefined
+        ? { ...base, [versionFieldName]: sql`${versionColumn} + 1` }
+        : base;
+    const idColumn = primaryKeyColumn(drizzleTable, definitionTable.primaryKey);
+    const idCondition = eq(idColumn, id as never);
+    const condition =
+      definitionTable.versioned &&
+      versionColumn !== undefined &&
+      expectedVersion !== undefined
+        ? and(idCondition, eq(versionColumn, expectedVersion as never))
+        : idCondition;
     const row = db
       .update(drizzleTable)
       .set(fields as never)
-      .where(
-        eq(
-          primaryKeyColumn(drizzleTable, definitionTable.primaryKey),
-          id as never
-        )
-      )
+      .where(condition)
       .returning()
-      .get();
-
-    return row === undefined
-      ? null
-      : (cloneValue(parseEntity(definitionTable, row)) as EntityOf<Table>);
+      .get() as Record<string, unknown> | undefined;
+    if (row !== undefined) {
+      return cloneValue(parseEntity(definitionTable, row)) as EntityOf<Table>;
+    }
+    if (
+      !definitionTable.versioned ||
+      versionColumn === undefined ||
+      expectedVersion === undefined
+    ) {
+      return null;
+    }
+    const existing = readEntity(id);
+    throw versionConflictError(
+      definitionTable.name,
+      id as string | number,
+      expectedVersion,
+      existing === null ? null : versionFromEntity(definitionTable, existing)
+    );
   };
 
   const patchFromUpsert = (
@@ -731,7 +741,7 @@ const createWritableAccessor = <
       Object.entries(input).filter(
         ([field, value]) =>
           field !== definitionTable.identity &&
-          field !== versionFieldName &&
+          !isVersionManagedField(definitionTable, field) &&
           value !== undefined
       )
     );
@@ -1188,7 +1198,7 @@ const buildResourceShape = <
     from(ctx: TrailContext) {
       return bindResourceConnection(access, store, value.from(ctx), ctx.fire);
     },
-    signals: store.signals,
+    ...(access === 'readwrite' ? { signals: store.signals } : {}),
     store,
     tables,
   });

--- a/connectors/drizzle/src/runtime.ts
+++ b/connectors/drizzle/src/runtime.ts
@@ -21,6 +21,7 @@ import type {
   StoreAccessMode,
   StoreFieldKey,
   StoreIdentifierOf,
+  StoreTableAccessor,
   StoreTableConnection,
   StoreTablesInput,
   UpsertOf,
@@ -30,6 +31,7 @@ import { and, eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import type { AnySQLiteColumn, AnySQLiteTable } from 'drizzle-orm/sqlite-core';
 import type { z } from 'zod';
+import type { TrailContext } from '@ontrails/core';
 
 import {
   createSqliteSchemaStatements,
@@ -1022,6 +1024,154 @@ const createReadonlyMockConnection = <TStore extends AnyStoreDefinition>(
   }
 };
 
+type BoundFireFn = NonNullable<TrailContext['fire']>;
+
+/**
+ * Best-effort signal emission after a successful DB write.
+ *
+ * Signal errors are caught and logged rather than re-thrown so that a
+ * listener failure does not mask a successful database mutation. The
+ * caller already holds the write result; surfacing a signal error here
+ * would discard it and confuse error handling upstream.
+ */
+const fireDerivedSignal = async <TTable extends AnyStoreTable>(
+  fire: BoundFireFn,
+  signalId: string,
+  entity: EntityOf<TTable>
+): Promise<void> => {
+  try {
+    const fired = await fire(signalId, entity);
+    if (fired.isErr()) {
+      console.warn(
+        `[drizzle] signal "${signalId}" emission failed:`,
+        fired.error
+      );
+    }
+  } catch (error) {
+    console.warn(`[drizzle] signal "${signalId}" emission threw:`, error);
+  }
+};
+
+const inputIdentity = <TTable extends AnyStoreTable>(
+  table: TTable,
+  input: UpsertOf<TTable>
+): StoreIdentifierOf<TTable> | undefined =>
+  input[table.identity as keyof UpsertOf<TTable> & string] as
+    | StoreIdentifierOf<TTable>
+    | undefined;
+
+const changedEntity = <TTable extends AnyStoreTable>(
+  previous: EntityOf<TTable> | null,
+  next: EntityOf<TTable> | null
+): next is EntityOf<TTable> =>
+  previous !== null && next !== null && !Bun.deepEquals(previous, next);
+
+const bindWritableAccessorSignals = <TTable extends AnyStoreTable>(
+  table: TTable,
+  accessor: StoreTableAccessor<TTable>,
+  fire: BoundFireFn
+): StoreTableAccessor<TTable> =>
+  Object.freeze({
+    ...accessor,
+    async insert(input: InsertOf<TTable>) {
+      const created = await accessor.insert(input);
+      await fireDerivedSignal(fire, table.signals.created.id, created);
+      return created;
+    },
+    async remove(id: StoreIdentifierOf<TTable>) {
+      // Snapshot taken before delete. May be stale under concurrent writes
+      // since StoreAccessor.remove returns `{ deleted: boolean }` without a
+      // post-delete returning clause. Acceptable for signal consumers that
+      // tolerate eventual consistency; revisit if strict ordering is needed.
+      const existing = await accessor.get(id);
+      const removed = await accessor.remove(id);
+      if (removed.deleted && existing !== null) {
+        await fireDerivedSignal(fire, table.signals.removed.id, existing);
+      }
+      return removed;
+    },
+    async update(id: StoreIdentifierOf<TTable>, input: UpdateOf<TTable>) {
+      const existing = await accessor.get(id);
+      const updated = await accessor.update(id, input);
+      // On versioned tables the version column auto-increments on every
+      // write, so `changedEntity` will always detect a diff even when the
+      // caller-supplied fields are identical. This means `updated` fires on
+      // every successful update for versioned tables — expected behavior,
+      // not a bug. Consumers should treat the signal as "a write occurred"
+      // rather than "user-visible data changed."
+      if (changedEntity(existing, updated)) {
+        await fireDerivedSignal(fire, table.signals.updated.id, updated);
+      }
+      return updated;
+    },
+    async upsert(input: UpsertOf<TTable>) {
+      const existingId = inputIdentity(table, input);
+      const existing =
+        existingId === undefined ? null : await accessor.get(existingId);
+      const written = await accessor.upsert(input);
+
+      if (existing === null) {
+        await fireDerivedSignal(fire, table.signals.created.id, written);
+        return written;
+      }
+
+      if (changedEntity(existing, written)) {
+        await fireDerivedSignal(fire, table.signals.updated.id, written);
+      }
+      return written;
+    },
+  });
+
+const bindWritableConnectionSignals = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  connection: DrizzleStoreConnection<TStore>,
+  fire: BoundFireFn
+): DrizzleStoreConnection<TStore> => {
+  const bound = {
+    query: connection.query,
+  } as DrizzleStoreConnection<TStore>;
+
+  for (const tableName of storeTableNames(definition)) {
+    const table = definition.tables[tableName];
+    const accessor = connection[tableName];
+    if (table === undefined || accessor === undefined) {
+      continue;
+    }
+
+    Object.defineProperty(bound, tableName, {
+      enumerable: true,
+      value: bindWritableAccessorSignals(
+        table,
+        accessor as StoreTableAccessor<typeof table>,
+        fire
+      ),
+    });
+  }
+
+  return Object.freeze(bound);
+};
+
+const bindResourceConnection = <
+  TStore extends AnyStoreDefinition,
+  TConnection,
+  TAccess extends StoreAccessMode,
+>(
+  access: TAccess,
+  definition: TStore,
+  connection: TConnection,
+  fire: TrailContext['fire']
+): TConnection => {
+  if (access !== 'readwrite' || fire === undefined) {
+    return connection;
+  }
+
+  return bindWritableConnectionSignals(
+    definition,
+    connection as DrizzleStoreConnection<TStore>,
+    fire
+  ) as TConnection;
+};
+
 const buildResourceShape = <
   TStore extends AnyStoreDefinition,
   TConnection,
@@ -1035,6 +1185,10 @@ const buildResourceShape = <
   Object.freeze({
     ...value,
     access,
+    from(ctx: TrailContext) {
+      return bindResourceConnection(access, store, value.from(ctx), ctx.fire);
+    },
+    signals: store.signals,
     store,
     tables,
   });

--- a/connectors/drizzle/src/runtime.ts
+++ b/connectors/drizzle/src/runtime.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   AlreadyExistsError,
+  ConflictError,
   InternalError,
   Result,
   ValidationError,
@@ -103,6 +104,7 @@ const mapDatabaseError = (tableName: string, error: unknown): Error => {
   if (
     error instanceof ValidationError ||
     error instanceof AlreadyExistsError ||
+    error instanceof ConflictError ||
     error instanceof InternalError
   ) {
     return error;
@@ -176,6 +178,7 @@ const TIMESTAMP_FIELD_NAMES = new Set([
   'created_at',
   'updated_at',
 ]);
+const versionFieldName = 'version';
 
 const ID_FIELD_SUFFIX_RE = /[Ii]d$/;
 
@@ -210,13 +213,22 @@ const generatedTextValue = (tableName: string, fieldName: string): unknown => {
   );
 };
 
-const generatedValueForInsert = <TTable extends AnyStoreTable>(
-  table: TTable,
-  field: StoreFieldKey<TTable['schema']>
-): unknown => {
-  const fieldName = field as string;
-  const kind = baseFieldKind(table, field);
+const generatedVersionValue = (tableName: string, kind: string): number => {
+  if (kind === 'integer') {
+    return 1;
+  }
 
+  throw new ValidationError(
+    `Store table "${tableName}" manages "${versionFieldName}" as an integer field.`
+  );
+};
+
+const generatedFallbackValue = <TTable extends AnyStoreTable>(
+  table: TTable,
+  field: StoreFieldKey<TTable['schema']>,
+  fieldName: string,
+  kind: string
+): unknown => {
   if (field === table.primaryKey && kind === 'integer') {
     return undefined;
   }
@@ -226,9 +238,24 @@ const generatedValueForInsert = <TTable extends AnyStoreTable>(
   if (kind === 'text') {
     return generatedTextValue(table.name, fieldName);
   }
+
   throw new ValidationError(
     `Store table "${table.name}" has a generated field "${fieldName}" of unrecognized type "${kind}". Only "integer" (primary key), "text", and timestamp fields are supported as generated fields. Supply a value or add a Zod default.`
   );
+};
+
+const generatedValueForInsert = <TTable extends AnyStoreTable>(
+  table: TTable,
+  field: StoreFieldKey<TTable['schema']>
+): unknown => {
+  const fieldName = field as string;
+  const kind = baseFieldKind(table, field);
+
+  if (fieldName === versionFieldName) {
+    return generatedVersionValue(table.name, kind);
+  }
+
+  return generatedFallbackValue(table, field, fieldName, kind);
 };
 
 const materializeGeneratedFields = <TTable extends AnyStoreTable>(
@@ -297,6 +324,143 @@ const applyGeneratedUpdateFields = <TTable extends AnyStoreTable>(
       input[updatedAtKey] ??
       (kind === 'date' ? new Date() : new Date().toISOString()),
   });
+};
+
+const versionFromEntity = <TTable extends AnyStoreTable>(
+  table: TTable,
+  entity: EntityOf<TTable>
+): number => {
+  const version = (entity as Record<string, unknown>)[versionFieldName];
+  if (typeof version === 'number' && Number.isInteger(version) && version > 0) {
+    return version;
+  }
+
+  throw new InternalError(
+    `Drizzle store for table "${table.name}" returned a versioned entity without a valid integer "${versionFieldName}" field.`
+  );
+};
+
+const versionConflictError = (
+  tableName: string,
+  id: string | number,
+  expectedVersion: number,
+  actualVersion: number | null
+): ConflictError =>
+  new ConflictError(
+    actualVersion === null
+      ? `Store table "${tableName}" expected version ${expectedVersion} for "${String(id)}" but found no existing row.`
+      : `Store table "${tableName}" expected version ${expectedVersion} for "${String(id)}" but found ${actualVersion}.`
+  );
+
+const expectedVersionFromInput = (
+  input: Record<string, unknown>
+): number | undefined => {
+  const candidate = input[versionFieldName];
+  return typeof candidate === 'number' &&
+    Number.isInteger(candidate) &&
+    candidate > 0
+    ? candidate
+    : undefined;
+};
+
+const requireUpdateFields = (
+  tableName: string,
+  input: Record<string, unknown>
+): Record<string, unknown> => {
+  const userFields = normalizeWriteInput(input);
+  if (Object.keys(userFields).length > 0) {
+    return userFields;
+  }
+
+  throw new ValidationError(
+    `Store table "${tableName}" update requires at least one field to set.`
+  );
+};
+
+const assertExpectedVersionMatch = <TTable extends AnyStoreTable>(
+  table: TTable,
+  id: string | number,
+  existing: EntityOf<TTable>,
+  expectedVersion?: number
+): void => {
+  if (!table.versioned || expectedVersion === undefined) {
+    return;
+  }
+
+  const currentVersion = versionFromEntity(table, existing);
+  if (currentVersion !== expectedVersion) {
+    throw versionConflictError(table.name, id, expectedVersion, currentVersion);
+  }
+};
+
+const applyVersionedUpdateFields = <TTable extends AnyStoreTable>(
+  table: TTable,
+  existing: EntityOf<TTable>,
+  userFields: Record<string, unknown>
+): Record<string, unknown> => {
+  const fields = applyGeneratedUpdateFields(table, userFields);
+  return table.versioned
+    ? {
+        ...fields,
+        [versionFieldName]: versionFromEntity(table, existing) + 1,
+      }
+    : fields;
+};
+
+const resolveUpsertWithoutPatch = <
+  TTable extends AnyStoreTable,
+  TIdentifier extends StoreIdentifierOf<TTable>,
+>(
+  table: TTable,
+  identifier: TIdentifier,
+  input: Record<string, unknown>,
+  expectedVersion: number | undefined,
+  readEntity: (id: TIdentifier) => EntityOf<TTable> | null,
+  insertEntity: (input: Record<string, unknown>) => EntityOf<TTable>
+): EntityOf<TTable> => {
+  const existing = readEntity(identifier);
+  if (existing === null) {
+    if (expectedVersion !== undefined) {
+      throw versionConflictError(
+        table.name,
+        identifier as string | number,
+        expectedVersion,
+        null
+      );
+    }
+
+    return insertEntity(input);
+  }
+
+  assertExpectedVersionMatch(
+    table,
+    identifier as string | number,
+    existing,
+    expectedVersion
+  );
+  return existing;
+};
+
+const resolveUpsertAfterMissingUpdate = <
+  TTable extends AnyStoreTable,
+  TIdentifier extends StoreIdentifierOf<TTable>,
+>(
+  table: TTable,
+  identifier: TIdentifier,
+  input: Record<string, unknown>,
+  expectedVersion: number | undefined,
+  insertEntity: (input: Record<string, unknown>) => EntityOf<TTable>
+): EntityOf<TTable> => {
+  if (expectedVersion !== undefined) {
+    throw versionConflictError(
+      table.name,
+      identifier as string | number,
+      expectedVersion,
+      null
+    );
+  }
+
+  return insertEntity(input);
 };
 
 interface VisitFrame {
@@ -521,16 +685,26 @@ const createWritableAccessor = <
 
   const updateEntity = (
     id: Identifier,
-    input: Record<string, unknown>
+    input: Record<string, unknown>,
+    expectedVersion?: number
   ): EntityOf<Table> | null => {
-    const userFields = normalizeWriteInput(input);
-    if (Object.keys(userFields).length === 0) {
-      throw new ValidationError(
-        `Store table "${definitionTable.name}" update requires at least one field to set.`
-      );
+    const userFields = requireUpdateFields(definitionTable.name, input);
+    const existing = readEntity(id);
+    if (existing === null) {
+      return null;
     }
 
-    const fields = applyGeneratedUpdateFields(definitionTable, userFields);
+    assertExpectedVersionMatch(
+      definitionTable,
+      id as string | number,
+      existing,
+      expectedVersion
+    );
+    const fields = applyVersionedUpdateFields(
+      definitionTable,
+      existing,
+      userFields
+    );
     const row = db
       .update(drizzleTable)
       .set(fields as never)
@@ -554,7 +728,9 @@ const createWritableAccessor = <
     Object.fromEntries(
       Object.entries(input).filter(
         ([field, value]) =>
-          field !== definitionTable.identity && value !== undefined
+          field !== definitionTable.identity &&
+          field !== versionFieldName &&
+          value !== undefined
       )
     );
 
@@ -562,17 +738,42 @@ const createWritableAccessor = <
     const identifier = input[definitionTable.identity] as
       | Identifier
       | undefined;
+    const expectedVersion = definitionTable.versioned
+      ? expectedVersionFromInput(input)
+      : undefined;
 
     if (identifier === undefined) {
+      if (expectedVersion !== undefined) {
+        throw new ValidationError(
+          `Store table "${definitionTable.name}" cannot accept an expected version without an identity during upsert.`
+        );
+      }
+
       return insertEntity(input);
     }
 
     const patch = patchFromUpsert(input);
     if (Object.keys(patch).length === 0) {
-      return readEntity(identifier) ?? insertEntity(input);
+      return resolveUpsertWithoutPatch(
+        definitionTable,
+        identifier,
+        input,
+        expectedVersion,
+        readEntity,
+        insertEntity
+      );
     }
 
-    return updateEntity(identifier, patch) ?? insertEntity(input);
+    return (
+      updateEntity(identifier, patch, expectedVersion) ??
+      resolveUpsertAfterMissingUpdate(
+        definitionTable,
+        identifier,
+        input,
+        expectedVersion,
+        insertEntity
+      )
+    );
   };
 
   return {

--- a/connectors/drizzle/src/schema.ts
+++ b/connectors/drizzle/src/schema.ts
@@ -525,6 +525,16 @@ const createTableSql = (
 const createIndexSql = (table: AnyStoreTable, field: string): string =>
   `CREATE INDEX IF NOT EXISTS ${quoteIdentifier(`${table.name}_${field}_idx`)} ON ${quoteIdentifier(table.name)} (${quoteIdentifier(field)})`;
 
+const assertTabularStoreKind = (definition: AnyStoreDefinition): void => {
+  if (definition.kind === 'tabular') {
+    return;
+  }
+
+  throw new ValidationError(
+    `@ontrails/with-drizzle only supports store definitions with kind "tabular". Received "${definition.kind}".`
+  );
+};
+
 const definedTables = (
   definition: AnyStoreDefinition
 ): readonly AnyStoreTable[] =>
@@ -543,6 +553,7 @@ const createIndexStatements = (
 export const deriveDrizzleTables = <TStore extends AnyStoreDefinition>(
   definition: TStore
 ): DrizzleStoreSchema<TStore> => {
+  assertTabularStoreKind(definition);
   const tables: Record<string, AnySQLiteTable> = {};
 
   for (const table of definedTables(definition)) {
@@ -568,10 +579,12 @@ export const deriveDrizzleTables = <TStore extends AnyStoreDefinition>(
 
 export const createSqliteSchemaStatements = (
   definition: AnyStoreDefinition
-): readonly string[] =>
-  Object.freeze([
+): readonly string[] => {
+  assertTabularStoreKind(definition);
+  return Object.freeze([
     ...definedTables(definition).map((table) =>
       createTableSql(table, definition)
     ),
     ...createIndexStatements(definition),
   ]);
+};

--- a/connectors/drizzle/src/types.ts
+++ b/connectors/drizzle/src/types.ts
@@ -58,8 +58,8 @@ export interface DrizzleStoreResourceShape<
   TAccess extends StoreAccessMode,
 > {
   readonly access: TAccess;
+  readonly signals?: TStore['signals'] | undefined;
   readonly store: TStore;
-  readonly signals: TStore['signals'];
   readonly tables: DrizzleStoreSchema<TStore>;
   from(ctx: Parameters<Resource<TConnection>['from']>[0]): TConnection;
   readonly kind: 'resource';

--- a/connectors/drizzle/src/types.ts
+++ b/connectors/drizzle/src/types.ts
@@ -59,6 +59,7 @@ export interface DrizzleStoreResourceShape<
 > {
   readonly access: TAccess;
   readonly store: TStore;
+  readonly signals: TStore['signals'];
   readonly tables: DrizzleStoreSchema<TStore>;
   from(ctx: Parameters<Resource<TConnection>['from']>[0]): TConnection;
   readonly kind: 'resource';

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -172,6 +172,9 @@ EntityOf<T>, InsertOf<T>, UpdateOf<T>, UpsertOf<T>, FixtureInputOf<T>, FixtureOf
 FiltersOf<T>, StoreListOptions
 StoreConnection<T>, StoreTableConnection<T>, ReadOnlyStoreConnection<T>
 StoreAccessor<T>, StoreTableAccessor<T>, ReadOnlyStoreTableAccessor<T>
+
+// `versioned: true` on a store table adds a framework-managed integer `version`
+// field to returned entities and allows `upsert()` optimistic concurrency.
 ```
 
 ## `@ontrails/store/testing`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -166,8 +166,10 @@ entitySchemaOf(table)              // normalized full entity schema
 insertSchemaOf(table)              // entity schema minus generated fields
 updateSchemaOf(table)              // partial update schema
 fixtureSchemaOf(table)             // fixture schema with generated fields optional
+// every normalized table derives:
+// table.signals.created | table.signals.updated | table.signals.removed
 
-StoreDefinition, StoreTable, StoreTablesInput, StoreTableInput
+StoreDefinition, StoreTable, StoreTableSignals, StoreTablesInput, StoreTableInput
 EntityOf<T>, InsertOf<T>, UpdateOf<T>, UpsertOf<T>, FixtureInputOf<T>, FixtureOf<T>
 FiltersOf<T>, StoreListOptions
 StoreConnection<T>, StoreTableConnection<T>, ReadOnlyStoreConnection<T>
@@ -175,6 +177,7 @@ StoreAccessor<T>, StoreTableAccessor<T>, ReadOnlyStoreTableAccessor<T>
 
 // `versioned: true` on a store table adds a framework-managed integer `version`
 // field to returned entities and allows `upsert()` optimistic concurrency.
+// writable store resources fire the derived signals when accessed through `db.from(ctx)`.
 ```
 
 ## `@ontrails/store/testing`

--- a/packages/core/src/__tests__/topo.test.ts
+++ b/packages/core/src/__tests__/topo.test.ts
@@ -45,10 +45,14 @@ const mockEvent = (id: string) => ({
   payload: z.object({ payload: z.string() }),
 });
 
-const mockResource = (id: string) =>
+const mockResource = (
+  id: string,
+  signals?: readonly ReturnType<typeof mockEvent>[]
+) =>
   resource(id, {
     create: () => Result.ok({ id }),
     description: `${id} resource`,
+    signals,
   });
 
 // ---------------------------------------------------------------------------
@@ -124,6 +128,16 @@ describe('topo', () => {
 
       expect(t.resources.size).toBe(1);
       expect(t.resources.get('db.main')).toBe(mod.db);
+    });
+
+    test('registers signals declared on resources into the topo graph', () => {
+      const usersCreated = mockEvent('users.created');
+      const t = topo('app', {
+        db: mockResource('db.main', [usersCreated]),
+      });
+
+      expect(t.signals.size).toBe(1);
+      expect(t.listSignals()).toContain(usersCreated);
     });
 
     test('collects contours exported directly from modules', () => {

--- a/packages/core/src/resource.ts
+++ b/packages/core/src/resource.ts
@@ -1,5 +1,6 @@
 import { NotFoundError } from './errors.js';
 import type { Result } from './result.js';
+import type { AnySignal } from './signal.js';
 import type { ResourceLookup, TrailContext } from './types.js';
 import type { z } from 'zod';
 
@@ -44,6 +45,8 @@ export interface ResourceSpec<T, C = unknown> {
   readonly description?: string | undefined;
   /** Arbitrary meta for tooling and filtering. */
   readonly meta?: Readonly<Record<string, unknown>> | undefined;
+  /** Signals projected or owned by this resource. */
+  readonly signals?: readonly AnySignal[] | undefined;
 }
 
 /** A typed resource definition. */

--- a/packages/core/src/topo.ts
+++ b/packages/core/src/topo.ts
@@ -170,6 +170,15 @@ const registerSignal = (
   );
 };
 
+const registerResourceSignals = (
+  resource: AnyResource,
+  signals: Map<string, AnySignal>
+): void => {
+  for (const derived of resource.signals ?? []) {
+    registerSignal(derived, signals);
+  }
+};
+
 const registerTrail = (
   trail: AnyTrail,
   trails: Map<string, AnyTrail>
@@ -243,6 +252,10 @@ const registerModuleValue = (
 ): void => {
   if (isResource(value) || isRegistrable(value)) {
     register(value, contours, trails, signals, resources);
+  }
+
+  if (isResource(value)) {
+    registerResourceSignals(value, signals);
   }
 
   if (

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -17,6 +17,7 @@ export const db = store({
     identity: 'id',
     generated: ['id', 'createdAt', 'updatedAt'],
     indexed: ['owner', 'createdAt'],
+    versioned: true,
   },
   files: {
     schema: fileSchema,
@@ -35,6 +36,7 @@ This declaration is pure metadata:
 - fixture schema
 - identity field
 - generated-field metadata
+- optional framework-managed version tracking
 - indexed markers
 - references
 
@@ -101,6 +103,7 @@ Types are derived from the Zod schema:
 - `upsert()` uses the fixture/entity shape with generated fields optional
 - `get()` returns `Entity | null`
 - `list()` accepts typed partial filters and pagination options
+- `versioned: true` adds a framework-managed `version` field to returned entities and lets `upsert()` accept an expected `version` for optimistic concurrency
 
 Tabular connectors such as `@ontrails/with-drizzle` also expose `insert()` and `update()` as convenience methods when the backend natively distinguishes create and patch operations.
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -34,6 +34,7 @@ This declaration is pure metadata:
 - insert schema
 - update schema
 - fixture schema
+- derived change signals (`table.signals.created|updated|removed`)
 - identity field
 - generated-field metadata
 - optional framework-managed version tracking
@@ -104,6 +105,16 @@ Types are derived from the Zod schema:
 - `get()` returns `Entity | null`
 - `list()` accepts typed partial filters and pagination options
 - `versioned: true` adds a framework-managed `version` field to returned entities and lets `upsert()` accept an expected `version` for optimistic concurrency
+
+Each normalized table also derives typed change signals from the same schema:
+
+```typescript
+const created = definition.tables.gists.signals.created;
+const updated = definition.tables.gists.signals.updated;
+const removed = definition.tables.gists.signals.removed;
+```
+
+Writable bindings fire those signals automatically when you access the resource through `db.from(ctx)` inside a trail context.
 
 Tabular connectors such as `@ontrails/with-drizzle` also expose `insert()` and `update()` as convenience methods when the backend natively distinguishes create and patch operations.
 

--- a/packages/store/src/__tests__/store.test.ts
+++ b/packages/store/src/__tests__/store.test.ts
@@ -49,6 +49,30 @@ const createStoreDefinition = () =>
     },
   });
 
+const expectGistSignals = (
+  table: ReturnType<typeof createStoreDefinition>['tables']['gists']
+) => {
+  expect(table.signals.created.id).toBe('gists.created');
+  expect(table.signals.updated.id).toBe('gists.updated');
+  expect(table.signals.removed.id).toBe('gists.removed');
+  expect(
+    table.signals.created.payload.parse({
+      createdAt: '2026-04-03T12:00:00.000Z',
+      id: 'gist-1',
+      ownerId: 'user-1',
+      updatedAt: '2026-04-03T12:00:00.000Z',
+    })
+  ).toEqual({
+    createdAt: '2026-04-03T12:00:00.000Z',
+    description: null,
+    id: 'gist-1',
+    isPublic: true,
+    ownerId: 'user-1',
+    tags: [],
+    updatedAt: '2026-04-03T12:00:00.000Z',
+  });
+};
+
 const expectNormalizedGistTable = (
   table: ReturnType<typeof createStoreDefinition>['tables']['gists']
 ) => {
@@ -60,6 +84,7 @@ const expectNormalizedGistTable = (
   expect(table.indexes).toEqual(['ownerId']);
   expect(table.references).toEqual({ ownerId: 'users' });
   expect(table.search).toEqual({ fts: true });
+  expectGistSignals(table);
 };
 
 const expectDerivedSchemas = (
@@ -184,6 +209,14 @@ describe('@ontrails/store', () => {
     const db = createStoreDefinition();
 
     expect(db.kind).toBe('tabular');
+    expect(db.signals.map((candidate) => candidate.id)).toEqual([
+      'gists.created',
+      'gists.updated',
+      'gists.removed',
+      'users.created',
+      'users.updated',
+      'users.removed',
+    ]);
     expect(db.tableNames).toEqual(['gists', 'users']);
     expect(db.type).toBe('store');
 
@@ -266,6 +299,24 @@ describe('@ontrails/store', () => {
     expect(db.tables.gists.schema.parse(samples.entity)).toEqual(
       samples.entity
     );
+    expect(
+      db.tables.gists.signals.updated.payload.parse({
+        createdAt: '2026-04-03T12:00:00.000Z',
+        id: 'gist-1',
+        ownerId: 'user-1',
+        updatedAt: '2026-04-03T12:00:00.000Z',
+        version: 2,
+      })
+    ).toEqual({
+      createdAt: '2026-04-03T12:00:00.000Z',
+      description: null,
+      id: 'gist-1',
+      isPublic: true,
+      ownerId: 'user-1',
+      tags: [],
+      updatedAt: '2026-04-03T12:00:00.000Z',
+      version: 2,
+    });
     expectVersionedFixtureDefaults(db);
   });
 

--- a/packages/store/src/__tests__/store.test.ts
+++ b/packages/store/src/__tests__/store.test.ts
@@ -99,6 +99,20 @@ const createTypeTestStore = () =>
     },
   });
 
+const createVersionedStoreDefinition = () =>
+  store({
+    gists: {
+      generated: ['id', 'createdAt', 'updatedAt'],
+      identity: 'id',
+      schema: gistSchema,
+      versioned: true,
+    },
+  });
+
+type VersionedGistTable = ReturnType<
+  typeof createVersionedStoreDefinition
+>['tables']['gists'];
+
 const createGistEntity = <
   TTable extends Parameters<typeof entitySchemaOf>[0],
 >() =>
@@ -118,6 +132,51 @@ const requireFixture = <T>(fixture: T | undefined): T => {
   }
 
   return fixture;
+};
+
+const createVersionedGistTypeSamples = (): {
+  readonly entity: EntityOf<VersionedGistTable>;
+  readonly fixtureInput: FixtureInputOf<VersionedGistTable>;
+  readonly insertInput: InsertOf<VersionedGistTable>;
+} => ({
+  entity: {
+    createdAt: '2026-04-03T12:00:00.000Z',
+    description: null,
+    id: 'gist-1',
+    isPublic: true,
+    ownerId: 'user-1',
+    tags: ['core'],
+    updatedAt: '2026-04-03T12:00:00.000Z',
+    version: 1,
+  },
+  fixtureInput: {
+    ownerId: 'user-2',
+    version: 2,
+  },
+  insertInput: {
+    ownerId: 'user-3',
+  },
+});
+
+const expectVersionedGistTypeSamples = ({
+  entity,
+  fixtureInput,
+  insertInput,
+}: ReturnType<typeof createVersionedGistTypeSamples>): void => {
+  expect(entity.version).toBe(1);
+  expect(fixtureInput.version).toBe(2);
+  expect(insertInput.ownerId).toBe('user-3');
+};
+
+const expectVersionedFixtureDefaults = (
+  db: ReturnType<typeof createVersionedStoreDefinition>
+): void => {
+  expect(db.tables.gists.fixtureSchema.parse({ ownerId: 'user-4' })).toEqual({
+    description: null,
+    isPublic: true,
+    ownerId: 'user-4',
+    tags: [],
+  });
 };
 
 describe('@ontrails/store', () => {
@@ -192,6 +251,24 @@ describe('@ontrails/store', () => {
     });
   });
 
+  test('normalizes versioned tables with a framework-managed version field', () => {
+    const db = createVersionedStoreDefinition();
+    const samples = createVersionedGistTypeSamples();
+
+    expect(db.tables.gists.versioned).toBe(true);
+    expect(db.tables.gists.generated).toEqual([
+      'id',
+      'createdAt',
+      'updatedAt',
+      'version',
+    ]);
+    expectVersionedGistTypeSamples(samples);
+    expect(db.tables.gists.schema.parse(samples.entity)).toEqual(
+      samples.entity
+    );
+    expectVersionedFixtureDefaults(db);
+  });
+
   test('rejects duplicate fixture primary keys when they are explicitly provided', () => {
     expect(() =>
       store({
@@ -254,6 +331,20 @@ describe('@ontrails/store', () => {
     ).toThrow(
       new ValidationError(
         'Store table "gists" declares generated field "missing" that is not present on the schema'
+      )
+    );
+
+    expect(() =>
+      store({
+        gists: {
+          identity: 'id',
+          schema: gistSchema.extend({ version: z.number().int() }),
+          versioned: true,
+        },
+      })
+    ).toThrow(
+      new ValidationError(
+        'Store table "gists" cannot declare a "version" field when versioned storage is enabled because the framework manages that field.'
       )
     );
 

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -4,6 +4,7 @@ export {
   insertSchemaOf,
   store,
   updateSchemaOf,
+  versionFieldName,
 } from './store.js';
 export type {
   AnyStoreDefinition,

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -38,6 +38,7 @@ export type {
   StoreOptions,
   StoreSearchDefinition,
   StoreTable,
+  StoreTableSignals,
   StoreTableAccessor,
   StoreTableConnection,
   StoreTableInput,

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,4 +1,5 @@
-import { ValidationError } from '@ontrails/core';
+import { signal, ValidationError } from '@ontrails/core';
+import type { AnySignal } from '@ontrails/core';
 import { z } from 'zod';
 
 import type {
@@ -7,6 +8,7 @@ import type {
   StoreOptions,
   StoreObjectSchema,
   StoreTable,
+  StoreTableSignals,
   StoreTableInput,
   StoreTablesInput,
 } from './types.js';
@@ -111,6 +113,25 @@ const deriveFixtureSchema = <TSchema extends StoreObjectSchema>(
   schema: TSchema,
   generated: readonly string[]
 ): StoreObjectSchema => partialFields(schema, generated);
+
+const createTableSignals = (
+  tableName: string,
+  schema: StoreObjectSchema
+): StoreTableSignals<unknown> =>
+  Object.freeze({
+    created: signal(`${tableName}.created`, {
+      description: `Fired after a "${tableName}" entity is created.`,
+      payload: schema,
+    }),
+    removed: signal(`${tableName}.removed`, {
+      description: `Fired after a "${tableName}" entity is removed.`,
+      payload: schema,
+    }),
+    updated: signal(`${tableName}.updated`, {
+      description: `Fired after a "${tableName}" entity is updated.`,
+      payload: schema,
+    }),
+  });
 
 /**
  * Strip `default` wrappers from a Zod type so that partial update schemas
@@ -374,6 +395,7 @@ const freezeNormalizedTable = <
     readonly insertSchema: StoreObjectSchema;
     readonly references: Readonly<Partial<Record<string, string>>>;
     readonly schema: StoreObjectSchema;
+    readonly signals: StoreTable<TInput, TName>['signals'];
     readonly versioned: boolean;
   }
 ): StoreTable<TInput, TName> =>
@@ -390,23 +412,33 @@ const freezeNormalizedTable = <
     references: resolved.references,
     schema: resolved.schema,
     ...(input.search === undefined ? {} : { search: input.search }),
+    signals: resolved.signals,
     updateSchema: deriveUpdateSchema(resolved.insertSchema, resolved.identity),
     versioned: resolved.versioned,
   }) as StoreTable<TInput, TName>;
 
-const normalizeTable = <
-  TName extends string,
+interface NormalizedTableState {
+  readonly generated: readonly string[];
+  readonly identity: string;
+  readonly indexed: readonly string[];
+  readonly references: Readonly<Partial<Record<string, string>>>;
+  readonly schema: StoreObjectSchema;
+  readonly versioned: boolean;
+}
+
+const resolveNormalizedTableState = <
   TInput extends StoreTableInput<StoreObjectSchema>,
 >(
-  name: TName,
+  name: string,
   input: TInput,
   tableNames: readonly string[]
-): StoreTable<TInput, TName> => {
+): NormalizedTableState => {
   const { schema, versioned } = resolveTableSchema(name, input);
   const identity = resolveIdentity(name, input);
   const generated = resolveGeneratedFields(input, versioned);
   const indexed = resolveIndexed(input);
   const references = normalizeReferences(input.references);
+
   validateTableInput(
     name,
     schema,
@@ -417,27 +449,107 @@ const normalizeTable = <
     tableNames
   );
 
-  const insertSchema = deriveInsertSchema(schema, generated);
-  const fixtureSchema = deriveFixtureSchema(schema, generated);
-  const fixtures = normalizeFixtures(
-    name,
-    identity,
-    fixtureSchema,
-    input.fixtures
-  );
-
-  return freezeNormalizedTable(name, input, {
-    fixtureSchema,
-    fixtures,
+  return {
     generated,
     identity,
     indexed,
-    insertSchema,
     references,
     schema,
     versioned,
+  };
+};
+
+const resolveNormalizedTableArtifacts = <
+  TName extends string,
+  TInput extends StoreTableInput<StoreObjectSchema>,
+>(
+  name: TName,
+  input: TInput,
+  resolved: NormalizedTableState
+): {
+  readonly fixtureSchema: StoreObjectSchema;
+  readonly fixtures: StoreTable<TInput>['fixtures'];
+  readonly generated: readonly string[];
+  readonly identity: string;
+  readonly indexed: readonly string[];
+  readonly insertSchema: StoreObjectSchema;
+  readonly references: Readonly<Partial<Record<string, string>>>;
+  readonly schema: StoreObjectSchema;
+  readonly signals: StoreTable<TInput, TName>['signals'];
+} => {
+  const insertSchema = deriveInsertSchema(resolved.schema, resolved.generated);
+  const fixtureSchema = deriveFixtureSchema(
+    resolved.schema,
+    resolved.generated
+  );
+  const fixtures = normalizeFixtures(
+    name,
+    resolved.identity,
+    fixtureSchema,
+    input.fixtures
+  );
+  const signals = createTableSignals(name, resolved.schema) as StoreTable<
+    TInput,
+    TName
+  >['signals'];
+
+  return {
+    fixtureSchema,
+    fixtures,
+    generated: resolved.generated,
+    identity: resolved.identity,
+    indexed: resolved.indexed,
+    insertSchema,
+    references: resolved.references,
+    schema: resolved.schema,
+    signals,
+  };
+};
+
+const normalizeTable = <
+  TName extends string,
+  TInput extends StoreTableInput<StoreObjectSchema>,
+>(
+  name: TName,
+  input: TInput,
+  tableNames: readonly string[]
+): StoreTable<TInput, TName> => {
+  const resolved = resolveNormalizedTableState(name, input, tableNames);
+
+  return freezeNormalizedTable(name, input, {
+    ...resolveNormalizedTableArtifacts(name, input, resolved),
+    versioned: resolved.versioned,
   });
 };
+
+const normalizeTables = <const TTables extends StoreTablesInput>(
+  tables: TTables,
+  tableNames: readonly Extract<keyof TTables, string>[]
+): MutableTables<TTables> => {
+  const normalized = {} as MutableTables<TTables>;
+
+  for (const name of tableNames) {
+    const input = tables[name];
+    if (input !== undefined) {
+      normalized[name] = normalizeTable(name, input, tableNames);
+    }
+  }
+
+  return normalized;
+};
+
+const collectStoreSignals = <const TTables extends StoreTablesInput>(
+  normalized: MutableTables<TTables>,
+  tableNames: readonly Extract<keyof TTables, string>[]
+): readonly AnySignal[] =>
+  Object.freeze(
+    tableNames.flatMap((name) => {
+      const table = normalized[name];
+      return table === undefined
+        ? []
+        : [table.signals.created, table.signals.updated, table.signals.removed];
+    })
+  );
 
 /**
  * Declare a connector-agnostic store definition from entity schemas and
@@ -454,24 +566,15 @@ export const store = <const TTables extends StoreTablesInput>(
   const tableNames = Object.freeze(
     Object.keys(tables).toSorted()
   ) as readonly Extract<keyof TTables, string>[];
-
-  const normalized = {} as MutableTables<TTables>;
-  for (const name of tableNames) {
-    const input = tables[name];
-
-    if (input === undefined) {
-      continue;
-    }
-
-    normalized[name] = normalizeTable(name, input, tableNames);
-  }
-
+  const normalized = normalizeTables(tables, tableNames);
   const get = <TName extends Extract<keyof TTables, string>>(name: TName) =>
     normalized[name];
+  const signals = collectStoreSignals(normalized, tableNames);
 
   return Object.freeze({
     get,
     kind,
+    signals,
     tableNames,
     tables: Object.freeze(normalized),
     type: 'store' as const,

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from '@ontrails/core';
-import type { z } from 'zod';
+import { z } from 'zod';
 
 import type {
   StoreDefinition,
@@ -14,6 +14,9 @@ import type {
 const isStoreObjectSchema = (schema: z.ZodType): schema is StoreObjectSchema =>
   schema.def.type === 'object' && 'shape' in schema.def;
 
+const versionFieldName = 'version';
+const versionFieldSchema = z.number().int().positive();
+
 const uniqueStrings = <T extends string>(
   values: readonly T[] | undefined
 ): readonly T[] =>
@@ -25,6 +28,11 @@ const uniqueMergedStrings = <T extends string>(
 
 const hasField = (schema: StoreObjectSchema, field: string): boolean =>
   Object.hasOwn(schema.shape, field);
+
+const versionedSchema = (schema: StoreObjectSchema): StoreObjectSchema =>
+  schema.extend({
+    [versionFieldName]: versionFieldSchema,
+  }) as StoreObjectSchema;
 
 const validateFieldList = (
   tableName: string,
@@ -211,6 +219,20 @@ const validatePrimaryKey = (
   );
 };
 
+const validateVersioning = (
+  tableName: string,
+  schema: StoreObjectSchema,
+  versioned: boolean
+): void => {
+  if (!versioned || !hasField(schema, versionFieldName)) {
+    return;
+  }
+
+  throw new ValidationError(
+    `Store table "${tableName}" cannot declare a "${versionFieldName}" field when versioned storage is enabled because the framework manages that field.`
+  );
+};
+
 const resolveStoreObjectSchema = (
   tableName: string,
   schema: StoreTableInput['schema']
@@ -245,6 +267,9 @@ const resolveIdentity = (tableName: string, input: StoreTableInput): string => {
 
 const resolveIndexed = (input: StoreTableInput): readonly string[] =>
   uniqueMergedStrings(input.indexed, input.indexes);
+
+const resolveVersioned = (input: StoreTableInput): boolean =>
+  input.versioned === true;
 
 const validateTableInput = (
   tableName: string,
@@ -307,6 +332,68 @@ const normalizeFixtures = <TInput extends StoreTableInput>(
   return Object.freeze(normalized) as StoreTable<TInput>['fixtures'];
 };
 
+const resolveTableSchema = <TInput extends StoreTableInput<StoreObjectSchema>>(
+  tableName: string,
+  input: TInput
+): {
+  readonly schema: StoreObjectSchema;
+  readonly versioned: boolean;
+} => {
+  const authoredSchema = resolveStoreObjectSchema(tableName, input.schema);
+  const versioned = resolveVersioned(input);
+  validateVersioning(tableName, authoredSchema, versioned);
+
+  return {
+    schema: versioned ? versionedSchema(authoredSchema) : authoredSchema,
+    versioned,
+  };
+};
+
+const resolveGeneratedFields = <
+  TInput extends StoreTableInput<StoreObjectSchema>,
+>(
+  input: TInput,
+  versioned: boolean
+): readonly string[] =>
+  versioned
+    ? uniqueMergedStrings(input.generated, [versionFieldName])
+    : uniqueStrings(input.generated);
+
+const freezeNormalizedTable = <
+  TName extends string,
+  TInput extends StoreTableInput<StoreObjectSchema>,
+>(
+  name: TName,
+  input: TInput,
+  resolved: {
+    readonly fixtureSchema: StoreObjectSchema;
+    readonly fixtures: StoreTable<TInput>['fixtures'];
+    readonly generated: readonly string[];
+    readonly identity: string;
+    readonly indexed: readonly string[];
+    readonly insertSchema: StoreObjectSchema;
+    readonly references: Readonly<Partial<Record<string, string>>>;
+    readonly schema: StoreObjectSchema;
+    readonly versioned: boolean;
+  }
+): StoreTable<TInput, TName> =>
+  Object.freeze({
+    fixtureSchema: resolved.fixtureSchema,
+    fixtures: resolved.fixtures,
+    generated: resolved.generated,
+    identity: resolved.identity,
+    indexed: resolved.indexed,
+    indexes: resolved.indexed,
+    insertSchema: resolved.insertSchema,
+    name,
+    primaryKey: resolved.identity,
+    references: resolved.references,
+    schema: resolved.schema,
+    ...(input.search === undefined ? {} : { search: input.search }),
+    updateSchema: deriveUpdateSchema(resolved.insertSchema, resolved.identity),
+    versioned: resolved.versioned,
+  }) as StoreTable<TInput, TName>;
+
 const normalizeTable = <
   TName extends string,
   TInput extends StoreTableInput<StoreObjectSchema>,
@@ -315,9 +402,9 @@ const normalizeTable = <
   input: TInput,
   tableNames: readonly string[]
 ): StoreTable<TInput, TName> => {
-  const schema = resolveStoreObjectSchema(name, input.schema);
+  const { schema, versioned } = resolveTableSchema(name, input);
   const identity = resolveIdentity(name, input);
-  const generated = uniqueStrings(input.generated);
+  const generated = resolveGeneratedFields(input, versioned);
   const indexed = resolveIndexed(input);
   const references = normalizeReferences(input.references);
   validateTableInput(
@@ -339,21 +426,17 @@ const normalizeTable = <
     input.fixtures
   );
 
-  return Object.freeze({
+  return freezeNormalizedTable(name, input, {
     fixtureSchema,
     fixtures,
     generated,
     identity,
     indexed,
-    indexes: indexed,
     insertSchema,
-    name,
-    primaryKey: identity,
     references,
     schema,
-    ...(input.search === undefined ? {} : { search: input.search }),
-    updateSchema: deriveUpdateSchema(insertSchema, identity),
-  }) as StoreTable<TInput, TName>;
+    versioned,
+  });
 };
 
 /**

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -16,7 +16,12 @@ import type {
 const isStoreObjectSchema = (schema: z.ZodType): schema is StoreObjectSchema =>
   schema.def.type === 'object' && 'shape' in schema.def;
 
-const versionFieldName = 'version';
+/**
+ * Name of the framework-managed version column used by versioned tables for
+ * optimistic concurrency control. Exported so connectors can gate their own
+ * version-handling logic without duplicating the literal.
+ */
+export const versionFieldName = 'version';
 const versionFieldSchema = z.number().int().positive();
 
 const uniqueStrings = <T extends string>(

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -1,3 +1,4 @@
+import type { Signal } from '@ontrails/core';
 import type { z } from 'zod';
 
 /**
@@ -90,6 +91,15 @@ export type StoreFixtureRow<
  * here and interpreted by a concrete connector later.
  */
 export type StoreSearchDefinition = Readonly<Record<string, unknown>>;
+
+/**
+ * Change signals projected from one store entity definition.
+ */
+export interface StoreTableSignals<TPayload> {
+  readonly created: Signal<TPayload>;
+  readonly updated: Signal<TPayload>;
+  readonly removed: Signal<TPayload>;
+}
 
 /**
  * Shared fields for all store table input variants.
@@ -266,6 +276,7 @@ export interface StoreTable<
   readonly references: ReferencesOfInput<TInput>;
   readonly schema: SchemaOfInput<TInput>;
   readonly search?: TInput['search'];
+  readonly signals: StoreTableSignals<z.output<SchemaOfInput<TInput>>>;
   readonly updateSchema: StoreObjectSchema;
   readonly versioned: VersionedFieldsOfInput<TInput>;
 }
@@ -280,6 +291,7 @@ export interface StoreDefinition<
     name: TName
   ) => StoreTable<TTables[TName], TName>;
   readonly kind: StoreKind;
+  readonly signals: readonly Signal<unknown>[];
   readonly tableNames: readonly Extract<keyof TTables, string>[];
   readonly tables: {
     readonly [TName in keyof TTables]: StoreTable<
@@ -310,6 +322,7 @@ export interface AnyStoreTable {
   readonly references: Readonly<Partial<Record<string, string>>>;
   readonly schema: StoreObjectSchema;
   readonly search?: StoreSearchDefinition | undefined;
+  readonly signals: StoreTableSignals<unknown>;
   readonly updateSchema: StoreObjectSchema;
   readonly versioned: boolean;
 }
@@ -319,6 +332,7 @@ export interface AnyStoreTable {
  */
 export interface AnyStoreDefinition {
   readonly kind: StoreKind;
+  readonly signals: readonly Signal<unknown>[];
   readonly tableNames: readonly string[];
   readonly tables: Readonly<Record<string, AnyStoreTable>>;
   readonly type: 'store';

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -493,6 +493,15 @@ export interface StoreTableAccessor<
   /**
    * Patch an entity by identity with partial fields. Returns the updated
    * entity, or `null` when no row with that ID exists.
+   *
+   * @remarks
+   * On versioned tables, `update` does **not** participate in optimistic
+   * concurrency control. The `UpdateOf<TTable>` shape is derived by omitting
+   * generated fields — including the framework-managed `version` column — so
+   * any `version` value is dropped before reaching the connector and the
+   * connector always auto-increments without comparing. Callers that need
+   * lost-update protection must use {@link StoreAccessor.upsert | `upsert`}
+   * instead and pass the expected `version` in the payload.
    */
   update(
     id: StoreIdentifierOf<TTable>,

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -25,9 +25,18 @@ export type StoreFieldKey<TSchema extends StoreObjectSchema> = Extract<
   string
 >;
 
+type VersionedSchema<
+  TSchema extends StoreObjectSchema,
+  TVersioned extends boolean | undefined,
+> = TVersioned extends true
+  ? TSchema extends z.ZodObject<infer TShape>
+    ? z.ZodObject<TShape & { version: z.ZodNumber }>
+    : never
+  : TSchema;
+
 type GeneratedFieldNames<
   TSchema extends StoreObjectSchema,
-  TGenerated extends readonly StoreFieldKey<TSchema>[] | undefined,
+  TGenerated extends readonly string[] | undefined,
 > = TGenerated extends readonly StoreFieldKey<TSchema>[]
   ? TGenerated[number]
   : never;
@@ -41,8 +50,8 @@ type GeneratedFieldNames<
  */
 export type StoreFixtureInput<
   TSchema extends StoreObjectSchema,
-  TGenerated extends readonly StoreFieldKey<TSchema>[] | undefined =
-    | readonly StoreFieldKey<TSchema>[]
+  TGenerated extends readonly string[] | undefined =
+    | readonly string[]
     | undefined,
 > = Omit<
   z.input<TSchema>,
@@ -60,8 +69,8 @@ export type StoreFixtureInput<
  */
 export type StoreFixtureRow<
   TSchema extends StoreObjectSchema,
-  TGenerated extends readonly StoreFieldKey<TSchema>[] | undefined =
-    | readonly StoreFieldKey<TSchema>[]
+  TGenerated extends readonly string[] | undefined =
+    | readonly string[]
     | undefined,
 > = Omit<
   z.output<TSchema>,
@@ -92,7 +101,10 @@ interface StoreTableInputBase<
     | undefined,
   TVersioned extends boolean | undefined = boolean | undefined,
 > {
-  readonly fixtures?: readonly StoreFixtureInput<TSchema, TGenerated>[];
+  readonly fixtures?: readonly StoreFixtureInput<
+    VersionedSchema<TSchema, TVersioned>,
+    GeneratedFieldsOfShape<TSchema, TGenerated, TVersioned>
+  >[];
   readonly generated?: TGenerated;
   readonly indexed?: readonly StoreFieldKey<TSchema>[];
   readonly indexes?: readonly StoreFieldKey<TSchema>[];
@@ -134,17 +146,48 @@ export type StoreTablesInput = Record<
   string,
   StoreTableInput<
     StoreObjectSchema,
-    readonly StoreFieldKey<StoreObjectSchema>[] | undefined
+    readonly StoreFieldKey<StoreObjectSchema>[] | undefined,
+    boolean | undefined
   >
+>;
+
+type DeclaredGeneratedFieldsOfInput<TInput extends StoreTableInput> =
+  TInput['generated'] extends readonly StoreFieldKey<TInput['schema']>[]
+    ? TInput['generated']
+    : readonly [];
+
+type GeneratedFieldsOfShape<
+  TSchema extends StoreObjectSchema,
+  TGenerated extends readonly StoreFieldKey<TSchema>[] | undefined,
+  TVersioned extends boolean | undefined,
+> = TVersioned extends true
+  ? readonly [
+      ...(TGenerated extends readonly StoreFieldKey<TSchema>[]
+        ? TGenerated
+        : readonly []),
+      'version',
+    ]
+  : TGenerated extends readonly StoreFieldKey<TSchema>[]
+    ? TGenerated
+    : readonly [];
+
+type VersionedFieldsOfInput<TInput extends StoreTableInput> =
+  TInput['versioned'] extends true ? true : false;
+
+type SchemaOfInput<TInput extends StoreTableInput> = VersionedSchema<
+  TInput['schema'],
+  VersionedFieldsOfInput<TInput>
 >;
 
 /**
  * Preserve generated fields when present, otherwise normalize to an empty tuple.
  */
 export type GeneratedFieldsOfInput<TInput extends StoreTableInput> =
-  TInput['generated'] extends readonly StoreFieldKey<TInput['schema']>[]
-    ? TInput['generated']
-    : readonly [];
+  GeneratedFieldsOfShape<
+    TInput['schema'],
+    DeclaredGeneratedFieldsOfInput<TInput>,
+    VersionedFieldsOfInput<TInput>
+  >;
 
 /**
  * Preserve the authored identity field.
@@ -195,11 +238,11 @@ export type ReferencesOfInput<TInput extends StoreTableInput> =
  */
 export type FixturesOfInput<TInput extends StoreTableInput> =
   TInput['fixtures'] extends readonly StoreFixtureInput<
-    TInput['schema'],
+    SchemaOfInput<TInput>,
     GeneratedFieldsOfInput<TInput>
   >[]
     ? readonly StoreFixtureRow<
-        TInput['schema'],
+        SchemaOfInput<TInput>,
         GeneratedFieldsOfInput<TInput>
       >[]
     : readonly [];
@@ -221,9 +264,10 @@ export interface StoreTable<
   readonly name: TName;
   readonly primaryKey: IdentityFieldOfInput<TInput>;
   readonly references: ReferencesOfInput<TInput>;
-  readonly schema: TInput['schema'];
+  readonly schema: SchemaOfInput<TInput>;
   readonly search?: TInput['search'];
   readonly updateSchema: StoreObjectSchema;
+  readonly versioned: VersionedFieldsOfInput<TInput>;
 }
 
 /**
@@ -267,6 +311,7 @@ export interface AnyStoreTable {
   readonly schema: StoreObjectSchema;
   readonly search?: StoreSearchDefinition | undefined;
   readonly updateSchema: StoreObjectSchema;
+  readonly versioned: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Layers version tracking, derived change signals, and Drizzle tabular compatibility onto the generalized store from #144. Three branches folded.

### Opt-in version tracking for store entities
- Add a `version` field to the store taxonomy with CRUD paths that maintain it transparently
- Update the drizzle connector runtime to persist and read back version metadata
- Document the opt-in surface in `docs/api-reference.md` and `packages/store/README.md`

### Derived change signals from store writes
- Store writes now derive change signals through `@ontrails/core` topo integration so downstream trails can react to entity lifecycle events without manual plumbing
- Extend `core/topo.ts` and `core/resource.ts` so signal derivation is wired to store-backed resources
- Update the drizzle connector runtime to emit signals on write
- Store taxonomy documentation updated with the signal surface

### Drizzle tabular store compatibility
- Assert Drizzle tabular schema compatibility with the generalized store taxonomy
- Tighten `connectors/drizzle/src/schema.ts` so tabular mismatches fail fast

## Testing

- `bun test packages/store/src/__tests__/store.test.ts`
- `bun test packages/core/src/__tests__/topo.test.ts`
- `bun run --cwd connectors/drizzle test`
- `bun run --cwd packages/store test`
- `bun run typecheck`

## Closes

- Closes TRL-245
- Closes TRL-244
- Closes TRL-246
