### PR TITLE
feat(store): sync, reconcile, and ingest composition factories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Use the project language consistently:
 - Every trail exposed on MCP or HTTP trailheads must define an `output` schema.
 - Use `metadata` for annotations and ownership data.
 - Use `detours` for recovery strategies instead of inline retry logic.
+  - **Narrow factory carve-out.** Detours execute at runtime. Factory-built trails such as the store's `reconcile` factory (`packages/store/src/trails/reconcile.ts`) may still keep a tightly-scoped inline recovery bridge when the current detour model cannot yet express the required store-specific behavior. Prefer detours first; treat inline recovery as a local exception, not the default pattern.
 - Prefer the most specific `TrailsError` subclass available.
 - Keep error taxonomy behavior aligned across trailheads so CLI, HTTP, and JSON-RPC mappings stay coherent.
 - Trails that use external dependencies declare them with `resources: [...]`.

--- a/packages/core/src/__tests__/ingest.test.ts
+++ b/packages/core/src/__tests__/ingest.test.ts
@@ -1,0 +1,190 @@
+/* oxlint-disable require-await -- layer wrappers satisfy async interfaces without awaiting */
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { ValidationError } from '../errors.js';
+import type { Layer } from '../layer.js';
+import { Result } from '../result.js';
+import { run } from '../run.js';
+import { signal } from '../signal.js';
+import { topo } from '../topo.js';
+import { trail } from '../trail.js';
+import { ingest } from '../trails/index.js';
+
+const withExamples = <TSchema extends z.ZodType>(
+  schema: TSchema,
+  examples: readonly z.input<TSchema>[]
+): TSchema & { readonly examples: readonly z.input<TSchema>[] } =>
+  Object.assign(schema, { examples });
+
+const paymentCompleted = signal('payment.completed', {
+  payload: z.object({
+    amount: z.number(),
+    paymentId: z.string(),
+  }),
+});
+
+const rawPaymentEvent = z.object({
+  amount: z.number(),
+  paymentId: z.string(),
+});
+
+const stripeEvent = z.object({
+  data: z.object({
+    object: z.object({
+      amount: z.number(),
+      id: z.string(),
+    }),
+  }),
+});
+
+const createConsumer = (
+  id: string,
+  capture: { payloads: unknown[] },
+  source = paymentCompleted
+) =>
+  trail(id, {
+    blaze: (input) => {
+      capture.payloads.push(input);
+      return Result.ok({ ok: true });
+    },
+    input: source.payload,
+    on: [source],
+  });
+
+describe('ingest()', () => {
+  test('derives id, intent, fires, output schema, and examples from schema examples', () => {
+    const schema = withExamples(rawPaymentEvent, [
+      { amount: 42, paymentId: 'pay_1' },
+      { amount: 7, paymentId: 'pay_2' },
+    ]);
+
+    const paymentIngest = ingest({
+      schema,
+      signal: paymentCompleted,
+    });
+
+    expect(paymentIngest.id).toBe('payment.completed.ingest');
+    expect(paymentIngest.intent).toBe('write');
+    expect(paymentIngest.fires).toEqual(['payment.completed']);
+    expect(paymentIngest.output?.safeParse().success).toBe(true);
+    expect(paymentIngest.examples).toEqual([
+      {
+        input: { amount: 42, paymentId: 'pay_1' },
+        name: 'Ingest payment.completed 1',
+      },
+      {
+        input: { amount: 7, paymentId: 'pay_2' },
+        name: 'Ingest payment.completed 2',
+      },
+    ]);
+  });
+
+  test('validates input before attempting to emit the signal', async () => {
+    const capture = { payloads: [] as unknown[] };
+    const paymentIngest = ingest({
+      schema: rawPaymentEvent,
+      signal: paymentCompleted,
+    });
+
+    const app = topo('ingest-validation', {
+      consumer: createConsumer('payments.capture', capture),
+      paymentCompleted,
+      paymentIngest,
+    });
+
+    const result = await run(app, paymentIngest.id, {
+      amount: '42',
+      paymentId: 'pay_1',
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(capture.payloads).toEqual([]);
+  });
+
+  test('applies the verification layer when provided', async () => {
+    const wrapped: string[] = [];
+    const verify: Layer = {
+      name: 'verify',
+      wrap: (trailDef, implementation) => async (input, ctx) => {
+        wrapped.push(trailDef.id);
+        return await implementation(input, ctx);
+      },
+    };
+    const capture = { payloads: [] as unknown[] };
+    const paymentIngest = ingest({
+      schema: rawPaymentEvent,
+      signal: paymentCompleted,
+      verify,
+    });
+
+    const app = topo('ingest-verify', {
+      consumer: createConsumer('payments.capture', capture),
+      paymentCompleted,
+      paymentIngest,
+    });
+
+    const result = await run(app, paymentIngest.id, {
+      amount: 42,
+      paymentId: 'pay_1',
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(wrapped).toEqual(['payment.completed.ingest']);
+    expect(capture.payloads).toEqual([{ amount: 42, paymentId: 'pay_1' }]);
+  });
+
+  test('emits the declared signal after successful ingestion', async () => {
+    const capture = { payloads: [] as unknown[] };
+    const paymentIngest = ingest({
+      schema: rawPaymentEvent,
+      signal: paymentCompleted,
+    });
+
+    const app = topo('ingest-fire', {
+      consumer: createConsumer('payments.capture', capture),
+      paymentCompleted,
+      paymentIngest,
+    });
+
+    const result = await run(app, paymentIngest.id, {
+      amount: 42,
+      paymentId: 'pay_1',
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(capture.payloads).toEqual([{ amount: 42, paymentId: 'pay_1' }]);
+  });
+
+  test('applies the transform before emitting the signal payload', async () => {
+    const capture = { payloads: [] as unknown[] };
+    const paymentIngest = ingest({
+      schema: stripeEvent,
+      signal: paymentCompleted,
+      transform: (payload) => ({
+        amount: payload.data.object.amount,
+        paymentId: payload.data.object.id,
+      }),
+    });
+
+    const app = topo('ingest-transform', {
+      consumer: createConsumer('payments.capture', capture),
+      paymentCompleted,
+      paymentIngest,
+    });
+
+    const result = await run(app, paymentIngest.id, {
+      data: {
+        object: {
+          amount: 99,
+          id: 'pay_99',
+        },
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(capture.payloads).toEqual([{ amount: 99, paymentId: 'pay_99' }]);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -204,6 +204,17 @@ export type { TraceFn } from './types.js';
 export { run } from './run.js';
 export type { RunOptions } from './run.js';
 
+// Trail factories
+export { deriveTrail, ingest } from './trails/index.js';
+export type {
+  DeriveTrailInput,
+  DeriveTrailOperation,
+  DeriveTrailOutput,
+  DeriveTrailSpec,
+  IngestOptions,
+  IngestTransform,
+} from './trails/index.js';
+
 // Validation
 export {
   validateInput,

--- a/packages/core/src/trails/index.ts
+++ b/packages/core/src/trails/index.ts
@@ -5,3 +5,5 @@ export type {
   DeriveTrailOutput,
   DeriveTrailSpec,
 } from './derive-trail.js';
+export { ingest } from './ingest.js';
+export type { IngestOptions, IngestTransform } from './ingest.js';

--- a/packages/core/src/trails/ingest.ts
+++ b/packages/core/src/trails/ingest.ts
@@ -1,0 +1,145 @@
+import { z } from 'zod';
+
+import { InternalError } from '../errors.js';
+import { composeLayers } from '../layer.js';
+import type { Layer } from '../layer.js';
+import { Result } from '../result.js';
+import type { Signal } from '../signal.js';
+import { trail } from '../trail.js';
+import type { Trail, TrailExample, TrailSpec } from '../trail.js';
+import type { TrailContext } from '../types.js';
+
+type SchemaValue<TSchema extends z.ZodType> = z.output<TSchema>;
+type SignalRef<TSignal> = string | Signal<TSignal>;
+
+type ExampleBearingSchema<TSchema extends z.ZodType> = TSchema & {
+  readonly examples?: readonly Partial<SchemaValue<TSchema>>[] | undefined;
+};
+
+interface IngestBaseOptions<TSchema extends z.ZodType, TSignal> extends Omit<
+  TrailSpec<SchemaValue<TSchema>, void>,
+  'blaze' | 'examples' | 'fires' | 'input' | 'intent' | 'output'
+> {
+  /** Override the derived trail id. Defaults to `${signal}.ingest`. */
+  readonly id?: string | undefined;
+  /** Validated external payload shape. */
+  readonly schema: TSchema;
+  /** Signal to emit after verification and optional transformation. */
+  readonly signal: SignalRef<TSignal>;
+  /** Optional per-trail verification layer, e.g. HMAC signature checks. */
+  readonly verify?: Layer | undefined;
+}
+
+export type IngestTransform<TInput, TSignal> = (
+  payload: TInput,
+  ctx: TrailContext
+) => TSignal | Promise<TSignal>;
+
+export interface IngestOptions<
+  TSchema extends z.ZodType,
+  TSignal,
+> extends IngestBaseOptions<TSchema, TSignal> {
+  readonly transform?:
+    | IngestTransform<SchemaValue<TSchema>, TSignal>
+    | undefined;
+}
+
+const resolveSignalId = <TSignal>(signalRef: SignalRef<TSignal>): string =>
+  typeof signalRef === 'string' ? signalRef : signalRef.id;
+
+const deriveExampleName = (signalId: string, index: number): string =>
+  `Ingest ${signalId} ${index + 1}`;
+
+const deriveExamples = <TSchema extends z.ZodType>(
+  schema: ExampleBearingSchema<TSchema>,
+  signalId: string
+): readonly TrailExample<SchemaValue<TSchema>, void>[] | undefined => {
+  const { examples } = schema;
+  if (examples === undefined || examples.length === 0) {
+    return undefined;
+  }
+
+  return Object.freeze(
+    examples.map((example, index) => ({
+      input: example,
+      name: deriveExampleName(signalId, index),
+    }))
+  );
+};
+
+const createIngestBlaze =
+  <TSchema extends z.ZodType, TSignal>(
+    signalRef: SignalRef<TSignal>,
+    signalId: string,
+    trailId: string,
+    transform: IngestTransform<SchemaValue<TSchema>, TSignal> | undefined
+  ) =>
+  async (
+    input: SchemaValue<TSchema>,
+    ctx: TrailContext
+  ): Promise<Result<void, Error>> => {
+    if (ctx.fire === undefined) {
+      return Result.err(
+        new InternalError(
+          `ingest("${trailId}") requires topo-backed execution to emit "${signalId}"`
+        )
+      );
+    }
+
+    try {
+      const payload =
+        transform === undefined
+          ? (input as TSignal)
+          : await transform(input, ctx);
+      const fired =
+        typeof signalRef === 'string'
+          ? await ctx.fire(signalRef, payload as unknown)
+          : await ctx.fire(signalRef as Signal<unknown>, payload as unknown);
+
+      return fired.isErr() ? Result.err(fired.error) : Result.ok();
+    } catch (error) {
+      const message = `ingest("${trailId}"): ${error instanceof Error ? error.message : String(error)}`;
+      return Result.err(
+        error instanceof Error
+          ? new InternalError(message, { cause: error })
+          : new InternalError(message)
+      );
+    }
+  };
+
+export const ingest = <
+  TSchema extends z.ZodType,
+  TSignal = SchemaValue<TSchema>,
+>(
+  options: IngestOptions<TSchema, TSignal>
+): Trail<SchemaValue<TSchema>, void> => {
+  const signalId = resolveSignalId(options.signal);
+  const id = options.id ?? `${signalId}.ingest`;
+  const { id: _id, schema, signal, transform, verify, ...trailSpec } = options;
+  const baseBlaze = createIngestBlaze<TSchema, TSignal>(
+    signal,
+    signalId,
+    id,
+    transform
+  );
+  const baseTrail = trail(id, {
+    ...trailSpec,
+    blaze: baseBlaze,
+    examples: deriveExamples(schema as ExampleBearingSchema<TSchema>, signalId),
+    fires: [signal],
+    input: schema as z.ZodType<SchemaValue<TSchema>>,
+    intent: 'write',
+    output: z.void(),
+  }) as Trail<SchemaValue<TSchema>, void>;
+
+  if (verify === undefined) {
+    return baseTrail;
+  }
+
+  // Verification is a per-factory concern, so compose it locally instead of
+  // mutating runner-wide layer configuration.
+  return Object.freeze({
+    ...baseTrail,
+    blaze: composeLayers([verify], baseTrail, baseTrail.blaze),
+  }) as Trail<SchemaValue<TSchema>, void>;
+};

--- a/packages/store/src/__tests__/sync-reconcile.test.ts
+++ b/packages/store/src/__tests__/sync-reconcile.test.ts
@@ -1,0 +1,513 @@
+import { describe, expect, mock, test } from 'bun:test';
+import {
+  ConflictError,
+  Result,
+  ValidationError,
+  createTrailContext,
+  resource,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+import type {
+  EntityOf,
+  ReadOnlyStoreTableAccessor,
+  StoreAccessor,
+  UpsertOf,
+} from '../index.js';
+import { store } from '../index.js';
+import { reconcile, sync } from '../trails/index.js';
+
+const noteSchema = z.object({
+  body: z.string(),
+  createdAt: z.string(),
+  id: z.string(),
+  title: z.string(),
+});
+
+const externalNoteSchema = z.object({
+  bodyText: z.string(),
+  createdAt: z.string(),
+  heading: z.string(),
+  id: z.string(),
+});
+
+const versionedNoteDefinition = store({
+  notes: {
+    fixtures: [
+      {
+        body: 'Seed body',
+        createdAt: '2026-04-10T12:00:00.000Z',
+        id: 'note-1',
+        title: 'Seed title',
+        version: 1,
+      },
+    ],
+    generated: ['createdAt'],
+    identity: 'id',
+    schema: noteSchema,
+    versioned: true,
+  },
+});
+
+const plainNoteDefinition = store({
+  notes: {
+    generated: ['createdAt'],
+    identity: 'id',
+    schema: noteSchema,
+  },
+});
+
+const sourceDefinition = store({
+  externalNotes: {
+    fixtures: [
+      {
+        bodyText: 'Copied body',
+        createdAt: '2026-04-10T12:00:00.000Z',
+        heading: 'Copied title',
+        id: 'external-1',
+      },
+    ],
+    identity: 'id',
+    schema: externalNoteSchema,
+  },
+});
+
+const targetDefinition = store({
+  notes: {
+    fixtures: [
+      {
+        body: 'Copied body',
+        createdAt: '2026-04-10T12:00:00.000Z',
+        id: 'external-1',
+        title: 'Copied title',
+      },
+    ],
+    generated: ['createdAt'],
+    identity: 'id',
+    schema: noteSchema,
+  },
+});
+
+type SourceTable = typeof sourceDefinition.tables.externalNotes;
+type TargetTable = typeof targetDefinition.tables.notes;
+type VersionedNotesTable = typeof versionedNoteDefinition.tables.notes;
+type PlainNotesTable = typeof plainNoteDefinition.tables.notes;
+
+type SourceConnection = Readonly<
+  Record<'externalNotes', ReadOnlyStoreTableAccessor<SourceTable>>
+>;
+
+type TargetConnection = Readonly<Record<'notes', StoreAccessor<TargetTable>>>;
+type VersionedConnection = Readonly<
+  Record<'notes', StoreAccessor<VersionedNotesTable>>
+>;
+type PlainConnection = Readonly<
+  Record<'notes', StoreAccessor<PlainNotesTable>>
+>;
+
+const requireFixture = <T>(value: T | undefined): T => {
+  if (value === undefined) {
+    throw new Error('Expected fixture to be present');
+  }
+
+  return value;
+};
+
+const sourceFixture = requireFixture(
+  sourceDefinition.tables.externalNotes.fixtures[0]
+);
+const targetFixture = requireFixture(targetDefinition.tables.notes.fixtures[0]);
+const versionedFixture = requireFixture(
+  versionedNoteDefinition.tables.notes.fixtures[0]
+);
+
+const clone = <T>(value: T): T => structuredClone(value);
+
+const expectOk = <T>(result: Result<T, Error>): T => {
+  if (result.isErr()) {
+    throw result.error;
+  }
+
+  return result.value;
+};
+
+const createSourceAccessor = (): ReadOnlyStoreTableAccessor<SourceTable> => ({
+  get(id) {
+    return Promise.resolve(
+      id === sourceFixture.id ? clone(sourceFixture) : null
+    );
+  },
+  list(filters) {
+    const matches =
+      filters === undefined ||
+      Object.entries(filters).every(
+        ([field, value]) =>
+          sourceFixture[field as keyof typeof sourceFixture] === value
+      );
+
+    return Promise.resolve(matches ? [clone(sourceFixture)] : []);
+  },
+});
+
+const createTargetAccessor = (
+  records = new Map<string, EntityOf<TargetTable>>()
+): StoreAccessor<TargetTable> => ({
+  get(id) {
+    return Promise.resolve(clone(records.get(id) ?? null));
+  },
+  list(filters) {
+    return Promise.resolve(
+      [...records.values()]
+        .filter((entity) =>
+          filters === undefined
+            ? true
+            : Object.entries(filters).every(
+                ([field, value]) =>
+                  entity[field as keyof EntityOf<TargetTable>] === value
+              )
+        )
+        .map((entity) => clone(entity))
+    );
+  },
+  remove(id) {
+    return Promise.resolve({ deleted: records.delete(id) });
+  },
+  upsert(input) {
+    const next = {
+      body: input.body ?? targetFixture.body,
+      createdAt: input.createdAt ?? targetFixture.createdAt,
+      id: input.id ?? targetFixture.id,
+      title: input.title ?? targetFixture.title,
+    } satisfies EntityOf<TargetTable>;
+
+    records.set(next.id, next);
+    return Promise.resolve(clone(next));
+  },
+});
+
+const createConflictAccessor = (
+  calls: UpsertOf<VersionedNotesTable>[] = []
+): StoreAccessor<VersionedNotesTable> => {
+  let current = clone({
+    ...versionedFixture,
+    body: 'Current body',
+    title: 'Current title',
+    version: 2,
+  });
+
+  return {
+    get(id) {
+      return Promise.resolve(id === current.id ? clone(current) : null);
+    },
+    list(filters) {
+      const matches =
+        filters === undefined ||
+        Object.entries(filters).every(
+          ([field, value]) => current[field as keyof typeof current] === value
+        );
+
+      return Promise.resolve(matches ? [clone(current)] : []);
+    },
+    remove(id) {
+      const deleted = id === current.id;
+      if (deleted) {
+        current = { ...current, id: '__deleted__' };
+      }
+
+      return Promise.resolve({ deleted });
+    },
+    upsert(input) {
+      calls.push(clone(input));
+
+      if (input.id === current.id && input.version !== current.version) {
+        throw new ConflictError(
+          `Version conflict for "${current.id}": expected ${String(input.version)}, found ${String(current.version)}`
+        );
+      }
+
+      current = {
+        ...current,
+        ...input,
+        version: current.version + 1,
+      };
+
+      return clone(current);
+    },
+  };
+};
+
+const sourceResource = resource<SourceConnection>('db.source', {
+  create: () =>
+    Result.ok({
+      externalNotes: createSourceAccessor(),
+    }),
+  mock: () => ({
+    externalNotes: createSourceAccessor(),
+  }),
+});
+
+const targetRecords = new Map<string, EntityOf<TargetTable>>();
+
+const targetResource = resource<TargetConnection>('db.target', {
+  create: () =>
+    Result.ok({
+      notes: createTargetAccessor(targetRecords),
+    }),
+  mock: () => ({
+    notes: createTargetAccessor(new Map<string, EntityOf<TargetTable>>()),
+  }),
+});
+
+const plainResource = resource<PlainConnection>('db.notes.plain', {
+  create: () =>
+    Result.ok({
+      notes:
+        createTargetAccessor() as unknown as StoreAccessor<PlainNotesTable>,
+    }),
+  mock: () => ({
+    notes: createTargetAccessor() as unknown as StoreAccessor<PlainNotesTable>,
+  }),
+});
+
+const createSyncContext = (records: Map<string, EntityOf<TargetTable>>) =>
+  createTrailContext({
+    extensions: {
+      'db.source': {
+        externalNotes: createSourceAccessor(),
+      },
+      'db.target': {
+        notes: createTargetAccessor(records),
+      },
+    },
+  });
+
+const expectSyncShape = (
+  syncNote: ReturnType<
+    typeof sync<SourceTable, TargetTable, SourceConnection, TargetConnection>
+  >
+) => {
+  expect(syncNote.id).toBe('notes.sync');
+  expect(syncNote.resources).toEqual([sourceResource, targetResource]);
+  expect(syncNote.contours.map((candidate) => candidate.name)).toEqual([
+    'externalNotes',
+    'notes',
+  ]);
+  expect(syncNote.input.safeParse({ id: sourceFixture.id }).success).toBe(true);
+  expect(syncNote.output?.safeParse(targetFixture).success).toBe(true);
+  expect(syncNote.examples).toEqual([
+    {
+      expected: targetFixture,
+      input: { id: sourceFixture.id },
+      name: 'Sync notes external-1',
+    },
+  ]);
+};
+
+describe('sync()', () => {
+  test('reads from the source resource and writes to the target resource', async () => {
+    targetRecords.clear();
+    const syncNote = sync({
+      from: {
+        resource: sourceResource,
+        table: sourceDefinition.tables.externalNotes,
+      },
+      to: {
+        resource: targetResource,
+        table: targetDefinition.tables.notes,
+      },
+      transform: (entity) => ({
+        body: entity.bodyText,
+        createdAt: entity.createdAt,
+        id: entity.id,
+        title: entity.heading,
+      }),
+    });
+
+    const result = await syncNote.blaze(
+      { id: sourceFixture.id },
+      createSyncContext(targetRecords)
+    );
+
+    expectSyncShape(syncNote);
+    expect(expectOk(result)).toEqual(targetFixture);
+    expect(targetRecords.get(targetFixture.id)).toEqual(targetFixture);
+  });
+
+  test('applies the transform before writing to the target accessor', async () => {
+    const transform = mock((entity: EntityOf<SourceTable>) => ({
+      body: `${entity.bodyText} (normalized)`,
+      createdAt: entity.createdAt,
+      id: entity.id,
+      title: entity.heading.toUpperCase(),
+    }));
+    const syncNote = sync({
+      from: {
+        resource: sourceResource,
+        table: sourceDefinition.tables.externalNotes,
+      },
+      to: {
+        resource: targetResource,
+        table: targetDefinition.tables.notes,
+      },
+      transform,
+    });
+    const records = new Map<string, EntityOf<TargetTable>>();
+
+    const result = await syncNote.blaze(
+      { id: sourceFixture.id },
+      createSyncContext(records)
+    );
+
+    expect(transform).toHaveBeenCalledTimes(1);
+    expect(expectOk(result)).toEqual({
+      body: 'Copied body (normalized)',
+      createdAt: sourceFixture.createdAt,
+      id: sourceFixture.id,
+      title: 'COPIED TITLE',
+    });
+  });
+});
+
+describe('reconcile()', () => {
+  test('retries version conflicts with the last-write-wins strategy', async () => {
+    const calls: UpsertOf<VersionedNotesTable>[] = [];
+    const reconcileNote = reconcile({
+      resource: resource<VersionedConnection>('db.notes.versioned', {
+        create: () =>
+          Result.ok({
+            notes: createConflictAccessor(calls),
+          }),
+        mock: () => ({
+          notes: createConflictAccessor([]),
+        }),
+      }),
+      strategy: 'last-write-wins',
+      table: versionedNoteDefinition.tables.notes,
+    });
+
+    const result = await reconcileNote.blaze(
+      {
+        body: 'Incoming body',
+        createdAt: versionedFixture.createdAt,
+        id: versionedFixture.id,
+        title: 'Incoming title',
+        version: 1,
+      },
+      createTrailContext({
+        extensions: {
+          'db.notes.versioned': {
+            notes: createConflictAccessor(calls),
+          },
+        },
+      })
+    );
+
+    expect(reconcileNote.id).toBe('notes.reconcile');
+    expect(
+      reconcileNote.input.safeParse({
+        body: 'Incoming body',
+        id: versionedFixture.id,
+        title: 'Incoming title',
+        version: 1,
+      }).success
+    ).toBe(true);
+    expect(reconcileNote.output?.safeParse(expectOk(result)).success).toBe(
+      true
+    );
+    expect(calls).toEqual([
+      {
+        body: 'Incoming body',
+        createdAt: versionedFixture.createdAt,
+        id: versionedFixture.id,
+        title: 'Incoming title',
+        version: 1,
+      },
+      {
+        body: 'Incoming body',
+        createdAt: versionedFixture.createdAt,
+        id: versionedFixture.id,
+        title: 'Incoming title',
+        version: 2,
+      },
+    ]);
+    expect(expectOk(result)).toEqual({
+      body: 'Incoming body',
+      createdAt: versionedFixture.createdAt,
+      id: versionedFixture.id,
+      title: 'Incoming title',
+      version: 3,
+    });
+  });
+
+  test('delegates conflict resolution to a custom strategy', async () => {
+    const calls: UpsertOf<VersionedNotesTable>[] = [];
+    const strategy = mock(
+      ({
+        current,
+        incoming,
+      }: {
+        current: EntityOf<VersionedNotesTable>;
+        incoming: UpsertOf<VersionedNotesTable>;
+      }) => ({
+        ...current,
+        body: `${current.body} + ${incoming.body as string}`,
+        title: `${current.title} / resolved`,
+      })
+    );
+    const reconcileNote = reconcile({
+      resource: resource<VersionedConnection>('db.notes.strategy', {
+        create: () =>
+          Result.ok({
+            notes: createConflictAccessor(calls),
+          }),
+        mock: () => ({
+          notes: createConflictAccessor([]),
+        }),
+      }),
+      strategy,
+      table: versionedNoteDefinition.tables.notes,
+    });
+
+    const result = await reconcileNote.blaze(
+      {
+        body: 'Incoming body',
+        createdAt: versionedFixture.createdAt,
+        id: versionedFixture.id,
+        title: 'Incoming title',
+        version: 1,
+      },
+      createTrailContext({
+        extensions: {
+          'db.notes.strategy': {
+            notes: createConflictAccessor(calls),
+          },
+        },
+      })
+    );
+
+    expect(strategy).toHaveBeenCalledTimes(1);
+    expect(calls[1]).toEqual({
+      body: 'Current body + Incoming body',
+      createdAt: versionedFixture.createdAt,
+      id: versionedFixture.id,
+      title: 'Current title / resolved',
+      version: 2,
+    });
+    expect(expectOk(result)).toEqual({
+      body: 'Current body + Incoming body',
+      createdAt: versionedFixture.createdAt,
+      id: versionedFixture.id,
+      title: 'Current title / resolved',
+      version: 3,
+    });
+  });
+
+  test('rejects non-versioned tables at factory creation time', () => {
+    expect(() =>
+      reconcile({
+        resource: plainResource,
+        table: plainNoteDefinition.tables.notes,
+      })
+    ).toThrow(ValidationError);
+  });
+});

--- a/packages/store/src/__tests__/sync-reconcile.test.ts
+++ b/packages/store/src/__tests__/sync-reconcile.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import {
   ConflictError,
   Result,
@@ -15,7 +15,14 @@ import type {
   UpsertOf,
 } from '../index.js';
 import { store } from '../index.js';
-import { reconcile, sync } from '../trails/index.js';
+import {
+  ReconcileRetryExhaustedError,
+  reconcile,
+  sync,
+} from '../trails/index.js';
+
+const cloneOrNull = <T>(value: T | undefined): T | null =>
+  value === undefined ? null : structuredClone(value);
 
 const noteSchema = z.object({
   body: z.string(),
@@ -246,12 +253,10 @@ const sourceResource = resource<SourceConnection>('db.source', {
   }),
 });
 
-const targetRecords = new Map<string, EntityOf<TargetTable>>();
-
 const targetResource = resource<TargetConnection>('db.target', {
   create: () =>
     Result.ok({
-      notes: createTargetAccessor(targetRecords),
+      notes: createTargetAccessor(new Map<string, EntityOf<TargetTable>>()),
     }),
   mock: () => ({
     notes: createTargetAccessor(new Map<string, EntityOf<TargetTable>>()),
@@ -304,8 +309,13 @@ const expectSyncShape = (
 };
 
 describe('sync()', () => {
+  let targetRecords: Map<string, EntityOf<TargetTable>>;
+
+  beforeEach(() => {
+    targetRecords = new Map<string, EntityOf<TargetTable>>();
+  });
+
   test('reads from the source resource and writes to the target resource', async () => {
-    targetRecords.clear();
     const syncNote = sync({
       from: {
         resource: sourceResource,
@@ -509,5 +519,114 @@ describe('reconcile()', () => {
         table: plainNoteDefinition.tables.notes,
       })
     ).toThrow(ValidationError);
+  });
+
+  test('requires `version` in the derived input schema for versioned tables', () => {
+    const reconcileNote = reconcile({
+      resource: resource<VersionedConnection>('db.notes.versioned.required', {
+        create: () =>
+          Result.ok({
+            notes: createConflictAccessor([]),
+          }),
+        mock: () => ({
+          notes: createConflictAccessor([]),
+        }),
+      }),
+      strategy: 'last-write-wins',
+      table: versionedNoteDefinition.tables.notes,
+    });
+
+    const withoutVersion = reconcileNote.input.safeParse({
+      body: 'Incoming body',
+      id: versionedFixture.id,
+      title: 'Incoming title',
+    });
+    expect(withoutVersion.success).toBe(false);
+
+    const withVersion = reconcileNote.input.safeParse({
+      body: 'Incoming body',
+      id: versionedFixture.id,
+      title: 'Incoming title',
+      version: 1,
+    });
+    expect(withVersion.success).toBe(true);
+  });
+
+  test('surfaces ReconcileRetryExhaustedError when the retry also conflicts', async () => {
+    // Accessor that always throws ConflictError on upsert, mirroring a
+    // concurrent writer that races the retry path. The retry in
+    // recoverConflict produces a second ConflictError, which the blaze
+    // wraps in ReconcileRetryExhaustedError so callers can distinguish
+    // "retry reconcile at a higher level" from "reconcile lost the race".
+    const stubbornCurrent = {
+      body: 'Current body',
+      createdAt: versionedFixture.createdAt,
+      id: versionedFixture.id,
+      title: 'Current title',
+      version: 99,
+    } satisfies EntityOf<VersionedNotesTable>;
+
+    const stubbornById = new Map<string, typeof stubbornCurrent>([
+      [stubbornCurrent.id, stubbornCurrent],
+    ]);
+    const stubbornAccessor: StoreAccessor<VersionedNotesTable> = {
+      get: async (id) => {
+        await Promise.resolve();
+        return cloneOrNull(stubbornById.get(id));
+      },
+      list: async () => {
+        await Promise.resolve();
+        return [structuredClone(stubbornCurrent)];
+      },
+      remove: async () => {
+        await Promise.resolve();
+        return { deleted: false };
+      },
+      upsert: () => {
+        throw new ConflictError(`Version conflict for "${stubbornCurrent.id}"`);
+      },
+    };
+
+    const reconcileNote = reconcile({
+      resource: resource<VersionedConnection>('db.notes.stubborn', {
+        create: () =>
+          Result.ok({
+            notes: stubbornAccessor,
+          }),
+        mock: () => ({
+          notes: stubbornAccessor,
+        }),
+      }),
+      strategy: 'last-write-wins',
+      table: versionedNoteDefinition.tables.notes,
+    });
+
+    const result = await reconcileNote.blaze(
+      {
+        body: 'Incoming body',
+        createdAt: versionedFixture.createdAt,
+        id: versionedFixture.id,
+        title: 'Incoming title',
+        version: 1,
+      },
+      createTrailContext({
+        extensions: {
+          'db.notes.stubborn': {
+            notes: stubbornAccessor,
+          },
+        },
+      })
+    );
+
+    const err = result.match({
+      err: (e) => e,
+      ok: () => {
+        throw new Error('expected reconcile to fail after retry');
+      },
+    });
+    expect(err).toBeInstanceOf(ReconcileRetryExhaustedError);
+    // Subclass of ConflictError so callers that catch the base class
+    // still catch it.
+    expect(err).toBeInstanceOf(ConflictError);
   });
 });

--- a/packages/store/src/__tests__/sync-reconcile.test.ts
+++ b/packages/store/src/__tests__/sync-reconcile.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import {
   ConflictError,
   Result,
+  RetryExhaustedError,
   ValidationError,
   createTrailContext,
+  executeTrail,
   resource,
 } from '@ontrails/core';
 import { z } from 'zod';
@@ -15,11 +17,7 @@ import type {
   UpsertOf,
 } from '../index.js';
 import { store } from '../index.js';
-import {
-  ReconcileRetryExhaustedError,
-  reconcile,
-  sync,
-} from '../trails/index.js';
+import { reconcile, sync } from '../trails/index.js';
 
 const cloneOrNull = <T>(value: T | undefined): T | null =>
   value === undefined ? null : structuredClone(value);
@@ -395,7 +393,8 @@ describe('reconcile()', () => {
       table: versionedNoteDefinition.tables.notes,
     });
 
-    const result = await reconcileNote.blaze(
+    const result = await executeTrail(
+      reconcileNote,
       {
         body: 'Incoming body',
         createdAt: versionedFixture.createdAt,
@@ -403,13 +402,15 @@ describe('reconcile()', () => {
         title: 'Incoming title',
         version: 1,
       },
-      createTrailContext({
-        extensions: {
-          'db.notes.versioned': {
-            notes: createConflictAccessor(calls),
+      {
+        ctx: {
+          extensions: {
+            'db.notes.versioned': {
+              notes: createConflictAccessor(calls),
+            },
           },
         },
-      })
+      }
     );
 
     expect(reconcileNote.id).toBe('notes.reconcile');
@@ -478,7 +479,8 @@ describe('reconcile()', () => {
       table: versionedNoteDefinition.tables.notes,
     });
 
-    const result = await reconcileNote.blaze(
+    const result = await executeTrail(
+      reconcileNote,
       {
         body: 'Incoming body',
         createdAt: versionedFixture.createdAt,
@@ -486,13 +488,15 @@ describe('reconcile()', () => {
         title: 'Incoming title',
         version: 1,
       },
-      createTrailContext({
-        extensions: {
-          'db.notes.strategy': {
-            notes: createConflictAccessor(calls),
+      {
+        ctx: {
+          extensions: {
+            'db.notes.strategy': {
+              notes: createConflictAccessor(calls),
+            },
           },
         },
-      })
+      }
     );
 
     expect(strategy).toHaveBeenCalledTimes(1);
@@ -552,12 +556,11 @@ describe('reconcile()', () => {
     expect(withVersion.success).toBe(true);
   });
 
-  test('surfaces ReconcileRetryExhaustedError when the retry also conflicts', async () => {
+  test('surfaces RetryExhaustedError when the retry also conflicts', async () => {
     // Accessor that always throws ConflictError on upsert, mirroring a
-    // concurrent writer that races the retry path. The retry in
-    // recoverConflict produces a second ConflictError, which the blaze
-    // wraps in ReconcileRetryExhaustedError so callers can distinguish
-    // "retry reconcile at a higher level" from "reconcile lost the race".
+    // concurrent writer that races the retry path. The detour loop
+    // exhausts after one recovery attempt and wraps in
+    // RetryExhaustedError<ConflictError>.
     const stubbornCurrent = {
       body: 'Current body',
       createdAt: versionedFixture.createdAt,
@@ -587,8 +590,9 @@ describe('reconcile()', () => {
       },
     };
 
-    const reconcileNote = reconcile({
-      resource: resource<VersionedConnection>('db.notes.stubborn', {
+    const stubbornResource = resource<VersionedConnection>(
+      'db.notes.stubborn',
+      {
         create: () =>
           Result.ok({
             notes: stubbornAccessor,
@@ -596,12 +600,17 @@ describe('reconcile()', () => {
         mock: () => ({
           notes: stubbornAccessor,
         }),
-      }),
+      }
+    );
+
+    const reconcileNote = reconcile({
+      resource: stubbornResource,
       strategy: 'last-write-wins',
       table: versionedNoteDefinition.tables.notes,
     });
 
-    const result = await reconcileNote.blaze(
+    const result = await executeTrail(
+      reconcileNote,
       {
         body: 'Incoming body',
         createdAt: versionedFixture.createdAt,
@@ -609,13 +618,15 @@ describe('reconcile()', () => {
         title: 'Incoming title',
         version: 1,
       },
-      createTrailContext({
-        extensions: {
-          'db.notes.stubborn': {
-            notes: stubbornAccessor,
+      {
+        ctx: {
+          extensions: {
+            'db.notes.stubborn': {
+              notes: stubbornAccessor,
+            },
           },
         },
-      })
+      }
     );
 
     const err = result.match({
@@ -624,9 +635,10 @@ describe('reconcile()', () => {
         throw new Error('expected reconcile to fail after retry');
       },
     });
-    expect(err).toBeInstanceOf(ReconcileRetryExhaustedError);
-    // Subclass of ConflictError so callers that catch the base class
-    // still catch it.
-    expect(err).toBeInstanceOf(ConflictError);
+    expect(err).toBeInstanceOf(RetryExhaustedError);
+    // Inherits the conflict category for trailhead mapping.
+    expect((err as RetryExhaustedError).category).toBe('conflict');
+    // The cause is the original ConflictError.
+    expect(err.cause).toBeInstanceOf(ConflictError);
   });
 });

--- a/packages/store/src/trails/crud.ts
+++ b/packages/store/src/trails/crud.ts
@@ -1,10 +1,4 @@
-import type {
-  AnyContour,
-  Implementation,
-  Resource,
-  Trail,
-} from '@ontrails/core';
-import { contour } from '@ontrails/core';
+import type { Implementation, Resource, Trail } from '@ontrails/core';
 import { deriveTrail } from '@ontrails/core/trails';
 import type { z } from 'zod';
 
@@ -17,6 +11,7 @@ import type {
   StoreIdentifierOf,
   UpdateOf,
 } from '../types.js';
+import { createTableContour } from './utils.js';
 
 type IdentityInputOf<TTable extends AnyStoreTable> = Readonly<
   Record<Extract<TTable['identity'], string>, StoreIdentifierOf<TTable>>
@@ -85,52 +80,6 @@ export interface CrudBlazeOverrides<TTable extends AnyStoreTable> {
 export interface CrudOptions<TTable extends AnyStoreTable> {
   readonly blaze?: CrudBlazeOverrides<TTable>;
 }
-
-const contourCache = new WeakMap<AnyStoreTable, AnyContour>();
-
-/**
- * Build the contour shape view of a store table.
- *
- * Generated non-identity fields are wrapped in `.optional()` so fixtures can
- * omit values the connector populates (e.g. `createdAt`, `version`). The
- * identity field stays required because read/update/delete all derive their
- * input from it. This mirrors `fixtureSchema` at runtime without needing a
- * separate schema instance.
- */
-const buildContourShape = (table: AnyStoreTable): Record<string, z.ZodType> => {
-  const shape = table.schema.shape as unknown as Record<string, z.ZodType>;
-  const generatedNonIdentity = new Set(
-    table.generated.filter((field) => field !== table.identity)
-  );
-
-  if (generatedNonIdentity.size === 0) {
-    return shape;
-  }
-
-  const next: Record<string, z.ZodType> = {};
-  for (const [field, fieldSchema] of Object.entries(shape)) {
-    next[field] = generatedNonIdentity.has(field)
-      ? fieldSchema.optional()
-      : fieldSchema;
-  }
-  return next;
-};
-
-const createTableContour = (table: AnyStoreTable): AnyContour => {
-  const cached = contourCache.get(table);
-  if (cached) {
-    return cached;
-  }
-
-  // oxlint-disable-next-line @typescript-eslint/consistent-type-assertions -- `contour()` infers a fresh typed Contour from the untyped shape produced by `buildContourShape`, and we re-widen to `AnyContour` at this one cache boundary. The runtime construction is provably correct and TypeScript cannot bridge zod shape inference in one hop.
-  const derived = contour(table.name, buildContourShape(table), {
-    examples: table.fixtures as readonly Record<string, unknown>[],
-    identity: table.identity,
-  }) as AnyContour;
-
-  contourCache.set(table, derived);
-  return derived;
-};
 
 const normalizeExampleForOutput = <TInput, TOutput>(
   example: TrailExampleOf<TInput, TOutput>,

--- a/packages/store/src/trails/index.ts
+++ b/packages/store/src/trails/index.ts
@@ -1,2 +1,10 @@
 export { crud } from './crud.js';
 export type { CrudBlazeOverrides, CrudOptions, CrudTrails } from './crud.js';
+export { reconcile } from './reconcile.js';
+export type {
+  ReconcileConflict,
+  ReconcileOptions,
+  ReconcileStrategy,
+} from './reconcile.js';
+export { sync } from './sync.js';
+export type { SyncEndpoint, SyncOptions, SyncTransform } from './sync.js';

--- a/packages/store/src/trails/index.ts
+++ b/packages/store/src/trails/index.ts
@@ -1,6 +1,6 @@
 export { crud } from './crud.js';
 export type { CrudBlazeOverrides, CrudOptions, CrudTrails } from './crud.js';
-export { reconcile } from './reconcile.js';
+export { ReconcileRetryExhaustedError, reconcile } from './reconcile.js';
 export type {
   ReconcileConflict,
   ReconcileOptions,

--- a/packages/store/src/trails/index.ts
+++ b/packages/store/src/trails/index.ts
@@ -1,6 +1,6 @@
 export { crud } from './crud.js';
 export type { CrudBlazeOverrides, CrudOptions, CrudTrails } from './crud.js';
-export { ReconcileRetryExhaustedError, reconcile } from './reconcile.js';
+export { reconcile } from './reconcile.js';
 export type {
   ReconcileConflict,
   ReconcileOptions,

--- a/packages/store/src/trails/reconcile.ts
+++ b/packages/store/src/trails/reconcile.ts
@@ -1,21 +1,12 @@
-import {
-  ConflictError,
-  InternalError,
-  Result,
-  ValidationError,
-  contour,
-  isTrailsError,
-  trail,
-} from '@ontrails/core';
+import { ConflictError, Result, ValidationError, trail } from '@ontrails/core';
 import type {
-  AnyContour,
   AnySignal,
   Resource,
   Trail,
   TrailContext,
   TrailExample,
 } from '@ontrails/core';
-import type { z } from 'zod';
+import { z } from 'zod';
 
 import type {
   AnyStoreTable,
@@ -23,6 +14,7 @@ import type {
   StoreAccessor,
   UpsertOf,
 } from '../types.js';
+import { createTableContour, mapStoreTrailError } from './utils.js';
 
 type ReconcileConnection<TTable extends AnyStoreTable> = Readonly<
   Record<TTable['name'], StoreAccessor<TTable>>
@@ -52,35 +44,16 @@ export interface ReconcileOptions<
   readonly table: TTable;
 }
 
-const contourCache = new WeakMap<AnyStoreTable, AnyContour>();
+/**
+ * Surfaced when `reconcile` exhausts its single retry after a second
+ * `ConflictError` from the underlying store. Extends `ConflictError` so
+ * callers that catch `ConflictError` still catch it, while still allowing
+ * "I should retry reconcile at a higher level" to be distinguished from
+ * "reconcile tried and lost the race".
+ */
+export class ReconcileRetryExhaustedError extends ConflictError {}
+
 const versionFieldName = 'version';
-
-const createTableContour = <TTable extends AnyStoreTable>(
-  table: TTable
-): AnyContour => {
-  const cached = contourCache.get(table);
-  if (cached) {
-    return cached;
-  }
-
-  const clonedShape = Object.fromEntries(
-    Object.entries(table.schema.shape).map(([field, schema]) => [
-      field,
-      schema.clone(),
-    ])
-  );
-  const derived = contour(
-    table.name,
-    clonedShape as Record<string, z.ZodType>,
-    {
-      examples: table.fixtures as readonly Record<string, unknown>[],
-      identity: table.identity,
-    }
-  ) as AnyContour;
-
-  contourCache.set(table, derived);
-  return derived;
-};
 
 const resolveAccessor = <
   TTable extends AnyStoreTable,
@@ -92,20 +65,6 @@ const resolveAccessor = <
 ): StoreAccessor<TTable> => {
   const connection = resource.from(ctx);
   return connection[table.name as keyof TConnection] as StoreAccessor<TTable>;
-};
-
-const asError = (error: unknown): Error =>
-  error instanceof Error ? error : new Error(String(error));
-
-const mapReconcileError = (trailId: string, error: unknown): Error => {
-  if (isTrailsError(error)) {
-    return error;
-  }
-
-  const resolved = asError(error);
-  return new InternalError(`${trailId} failed: ${resolved.message}`, {
-    cause: resolved,
-  });
 };
 
 const omitUndefined = <T extends Record<string, unknown>>(value: T): T =>
@@ -190,6 +149,16 @@ const resolveStrategy = async <TTable extends AnyStoreTable>(
     ? lastWriteWins(conflict)
     : await strategy(conflict, ctx);
 
+/**
+ * Single-retry conflict recovery.
+ *
+ * `recoverConflict` retries `upsert` exactly once after resolving the
+ * conflict through the configured strategy. A concurrent writer between
+ * retries produces a second `ConflictError`, which is wrapped in a
+ * `ReconcileRetryExhaustedError` by the blaze so callers can distinguish
+ * "I should retry reconcile at a higher level" from "reconcile tried and
+ * lost the race".
+ */
 const recoverConflict = async <TTable extends AnyStoreTable>(
   table: TTable,
   input: UpsertOf<TTable>,
@@ -208,6 +177,49 @@ const recoverConflict = async <TTable extends AnyStoreTable>(
   return Result.ok(await accessor.upsert(normalized));
 };
 
+const wrapRetryExhaustion = (
+  trailId: string,
+  error: unknown
+): ReconcileRetryExhaustedError | Error => {
+  if (!(error instanceof ConflictError)) {
+    return mapStoreTrailError(trailId, error);
+  }
+
+  if (error instanceof ReconcileRetryExhaustedError) {
+    return error;
+  }
+
+  return new ReconcileRetryExhaustedError(
+    `${trailId} retry exhausted after second conflict: ${error.message}`,
+    { cause: error }
+  );
+};
+
+/**
+ * Build the input schema for a reconcile trail.
+ *
+ * `fixtureSchema` makes generated fields (including `version` on versioned
+ * tables) optional because connectors populate them. Reconcile, however,
+ * relies on optimistic concurrency: the caller must pass the expected
+ * `version` so `assertExpectedVersionMatch` can detect stale payloads. We
+ * therefore extend `fixtureSchema` with a required `version` field so
+ * callers cannot sidestep optimistic concurrency at the input boundary.
+ */
+const buildReconcileInputSchema = <TTable extends AnyStoreTable>(
+  table: TTable
+): z.ZodType<UpsertOf<TTable>> =>
+  table.fixtureSchema.extend({
+    [versionFieldName]: z.number().int(),
+  }) as unknown as z.ZodType<UpsertOf<TTable>>;
+
+/**
+ * Conflict recovery uses inline try/catch rather than `detours` because
+ * detours are declarative-only today — there is no execution machinery to
+ * wire recovery strategies to versioned upserts yet. Factory-provided trails
+ * like `reconcile` need working recovery at runtime, so the inline path is
+ * the pragmatic bridge until a detour execution primitive lands. See the
+ * "Factory-provided trails" carve-out in the repo-root `AGENTS.md`.
+ */
 const createReconcileBlaze =
   <
     TTable extends AnyStoreTable,
@@ -218,33 +230,57 @@ const createReconcileBlaze =
     strategy: ReconcileStrategy<TTable>
   ) =>
   async (input: UpsertOf<TTable>, ctx: TrailContext) => {
-    const accessor = resolveAccessor(options.table, options.resource, ctx);
-
     try {
-      return Result.ok(await accessor.upsert(input));
-    } catch (error) {
-      if (!(error instanceof ConflictError)) {
-        return Result.err(mapReconcileError(id, error));
-      }
+      const accessor = resolveAccessor(options.table, options.resource, ctx);
 
       try {
-        return await recoverConflict(
-          options.table,
-          input,
-          accessor,
-          error,
-          strategy,
-          ctx
-        );
-      } catch (conflictError) {
-        return Result.err(mapReconcileError(id, conflictError));
+        return Result.ok(await accessor.upsert(input));
+      } catch (error) {
+        if (!(error instanceof ConflictError)) {
+          return Result.err(mapStoreTrailError(id, error));
+        }
+
+        try {
+          return await recoverConflict(
+            options.table,
+            input,
+            accessor,
+            error,
+            strategy,
+            ctx
+          );
+        } catch (conflictError) {
+          return Result.err(wrapRetryExhaustion(id, conflictError));
+        }
       }
+    } catch (error) {
+      return Result.err(mapStoreTrailError(id, error));
     }
   };
 
 /**
  * Produce one trail that retries a versioned upsert with a conflict strategy
  * when the incoming entity is stale.
+ *
+ * Reconcile is bounded to a single retry. If a concurrent writer races the
+ * retry and produces a second `ConflictError`, the blaze surfaces a
+ * `ReconcileRetryExhaustedError` (a `ConflictError` subclass) so callers can
+ * distinguish "retry reconcile at a higher level" from "reconcile tried and
+ * lost the race".
+ *
+ * Conflict recovery is inline rather than delegated to a `detour` because
+ * detours are declarative-only today — there is no execution machinery for
+ * them yet. Factory-provided trails need working recovery at runtime, so
+ * the inline path is the pragmatic bridge until a detour execution primitive
+ * lands. See the "Factory-provided trails" carve-out in the repo-root
+ * `AGENTS.md`.
+ *
+ * @remarks
+ * For versioned tables, the derived input schema requires an explicit
+ * `version` field so callers cannot sidestep optimistic concurrency at the
+ * input boundary. `fixtureSchema` alone makes `version` optional because
+ * connectors populate it for writes; reconcile must reject that relaxed
+ * shape.
  */
 export const reconcile = <
   TTable extends AnyStoreTable,
@@ -269,9 +305,7 @@ export const reconcile = <
       options.description ??
       `Reconcile version conflicts for "${options.table.name}" entities.`,
     examples: deriveExamples(options.table),
-    input: options.table.fixtureSchema as unknown as z.ZodType<
-      UpsertOf<TTable>
-    >,
+    input: buildReconcileInputSchema(options.table),
     intent: 'write',
     on: options.on,
     output: options.table.schema as unknown as z.ZodType<EntityOf<TTable>>,

--- a/packages/store/src/trails/reconcile.ts
+++ b/packages/store/src/trails/reconcile.ts
@@ -1,0 +1,280 @@
+import {
+  ConflictError,
+  InternalError,
+  Result,
+  ValidationError,
+  contour,
+  isTrailsError,
+  trail,
+} from '@ontrails/core';
+import type {
+  AnyContour,
+  AnySignal,
+  Resource,
+  Trail,
+  TrailContext,
+  TrailExample,
+} from '@ontrails/core';
+import type { z } from 'zod';
+
+import type {
+  AnyStoreTable,
+  EntityOf,
+  StoreAccessor,
+  UpsertOf,
+} from '../types.js';
+
+type ReconcileConnection<TTable extends AnyStoreTable> = Readonly<
+  Record<TTable['name'], StoreAccessor<TTable>>
+>;
+
+export interface ReconcileConflict<TTable extends AnyStoreTable> {
+  readonly current: EntityOf<TTable>;
+  readonly incoming: UpsertOf<TTable>;
+}
+
+export type ReconcileStrategy<TTable extends AnyStoreTable> =
+  | 'last-write-wins'
+  | ((
+      conflict: ReconcileConflict<TTable>,
+      ctx: TrailContext
+    ) => Promise<UpsertOf<TTable>> | UpsertOf<TTable>);
+
+export interface ReconcileOptions<
+  TTable extends AnyStoreTable,
+  TConnection extends ReconcileConnection<TTable>,
+> {
+  readonly description?: string;
+  readonly id?: string;
+  readonly on?: readonly (AnySignal | string)[];
+  readonly resource: Resource<TConnection>;
+  readonly strategy?: ReconcileStrategy<TTable>;
+  readonly table: TTable;
+}
+
+const contourCache = new WeakMap<AnyStoreTable, AnyContour>();
+const versionFieldName = 'version';
+
+const createTableContour = <TTable extends AnyStoreTable>(
+  table: TTable
+): AnyContour => {
+  const cached = contourCache.get(table);
+  if (cached) {
+    return cached;
+  }
+
+  const clonedShape = Object.fromEntries(
+    Object.entries(table.schema.shape).map(([field, schema]) => [
+      field,
+      schema.clone(),
+    ])
+  );
+  const derived = contour(
+    table.name,
+    clonedShape as Record<string, z.ZodType>,
+    {
+      examples: table.fixtures as readonly Record<string, unknown>[],
+      identity: table.identity,
+    }
+  ) as AnyContour;
+
+  contourCache.set(table, derived);
+  return derived;
+};
+
+const resolveAccessor = <
+  TTable extends AnyStoreTable,
+  TConnection extends ReconcileConnection<TTable>,
+>(
+  table: TTable,
+  resource: Resource<TConnection>,
+  ctx: TrailContext
+): StoreAccessor<TTable> => {
+  const connection = resource.from(ctx);
+  return connection[table.name as keyof TConnection] as StoreAccessor<TTable>;
+};
+
+const asError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const mapReconcileError = (trailId: string, error: unknown): Error => {
+  if (isTrailsError(error)) {
+    return error;
+  }
+
+  const resolved = asError(error);
+  return new InternalError(`${trailId} failed: ${resolved.message}`, {
+    cause: resolved,
+  });
+};
+
+const omitUndefined = <T extends Record<string, unknown>>(value: T): T =>
+  Object.fromEntries(
+    Object.entries(value).filter(([, candidate]) => candidate !== undefined)
+  ) as T;
+
+const currentVersion = <TTable extends AnyStoreTable>(
+  current: EntityOf<TTable>
+): number => current[versionFieldName as keyof EntityOf<TTable>] as number;
+
+const lastWriteWins = <TTable extends AnyStoreTable>(
+  conflict: ReconcileConflict<TTable>
+): UpsertOf<TTable> =>
+  ({
+    ...conflict.current,
+    ...omitUndefined(conflict.incoming as Record<string, unknown>),
+    [versionFieldName]: currentVersion(conflict.current),
+  }) as UpsertOf<TTable>;
+
+const normalizeResolvedInput = <TTable extends AnyStoreTable>(
+  table: TTable,
+  current: EntityOf<TTable>,
+  resolved: UpsertOf<TTable>
+): UpsertOf<TTable> =>
+  ({
+    ...current,
+    ...omitUndefined(resolved as Record<string, unknown>),
+    [table.identity]: current[
+      table.identity as keyof EntityOf<TTable>
+    ] as EntityOf<TTable>[keyof EntityOf<TTable>],
+    [versionFieldName]: currentVersion(current),
+  }) as UpsertOf<TTable>;
+
+const deriveExamples = <TTable extends AnyStoreTable>(
+  table: TTable
+): readonly TrailExample<UpsertOf<TTable>, EntityOf<TTable>>[] | undefined => {
+  const examples = table.fixtures.flatMap((fixture) => {
+    const parsed = table.schema.safeParse(fixture);
+    if (!parsed.success) {
+      return [];
+    }
+
+    return [
+      {
+        expected: parsed.data as EntityOf<TTable>,
+        input: fixture as UpsertOf<TTable>,
+        name: `Reconcile ${table.name} ${String(
+          fixture[table.identity as keyof typeof fixture]
+        )}`,
+      },
+    ];
+  });
+
+  return examples.length === 0 ? undefined : Object.freeze(examples);
+};
+
+const buildConflict = async <TTable extends AnyStoreTable>(
+  table: TTable,
+  input: UpsertOf<TTable>,
+  accessor: StoreAccessor<TTable>,
+  error: ConflictError
+): Promise<ConflictError | ReconcileConflict<TTable>> => {
+  const identifier = input[table.identity as keyof typeof input] as
+    | EntityOf<TTable>[keyof EntityOf<TTable>]
+    | undefined;
+
+  if (identifier === undefined) {
+    return error;
+  }
+
+  const current = await accessor.get(identifier as never);
+  return current === null ? error : { current, incoming: input };
+};
+
+const resolveStrategy = async <TTable extends AnyStoreTable>(
+  strategy: ReconcileStrategy<TTable>,
+  conflict: ReconcileConflict<TTable>,
+  ctx: TrailContext
+): Promise<UpsertOf<TTable>> =>
+  strategy === 'last-write-wins'
+    ? lastWriteWins(conflict)
+    : await strategy(conflict, ctx);
+
+const recoverConflict = async <TTable extends AnyStoreTable>(
+  table: TTable,
+  input: UpsertOf<TTable>,
+  accessor: StoreAccessor<TTable>,
+  error: ConflictError,
+  strategy: ReconcileStrategy<TTable>,
+  ctx: TrailContext
+) => {
+  const conflict = await buildConflict(table, input, accessor, error);
+  if (conflict instanceof ConflictError) {
+    return Result.err(conflict);
+  }
+
+  const resolved = await resolveStrategy(strategy, conflict, ctx);
+  const normalized = normalizeResolvedInput(table, conflict.current, resolved);
+  return Result.ok(await accessor.upsert(normalized));
+};
+
+const createReconcileBlaze =
+  <
+    TTable extends AnyStoreTable,
+    TConnection extends ReconcileConnection<TTable>,
+  >(
+    options: ReconcileOptions<TTable, TConnection>,
+    id: string,
+    strategy: ReconcileStrategy<TTable>
+  ) =>
+  async (input: UpsertOf<TTable>, ctx: TrailContext) => {
+    const accessor = resolveAccessor(options.table, options.resource, ctx);
+
+    try {
+      return Result.ok(await accessor.upsert(input));
+    } catch (error) {
+      if (!(error instanceof ConflictError)) {
+        return Result.err(mapReconcileError(id, error));
+      }
+
+      try {
+        return await recoverConflict(
+          options.table,
+          input,
+          accessor,
+          error,
+          strategy,
+          ctx
+        );
+      } catch (conflictError) {
+        return Result.err(mapReconcileError(id, conflictError));
+      }
+    }
+  };
+
+/**
+ * Produce one trail that retries a versioned upsert with a conflict strategy
+ * when the incoming entity is stale.
+ */
+export const reconcile = <
+  TTable extends AnyStoreTable,
+  TConnection extends ReconcileConnection<TTable>,
+>(
+  options: ReconcileOptions<TTable, TConnection>
+): Trail<UpsertOf<TTable>, EntityOf<TTable>> => {
+  if (!options.table.versioned) {
+    throw new ValidationError(
+      `reconcile("${options.table.name}") requires a versioned store table.`
+    );
+  }
+
+  const id = options.id ?? `${options.table.name}.reconcile`;
+  const entityContour = createTableContour(options.table);
+  const strategy = options.strategy ?? 'last-write-wins';
+
+  return trail<UpsertOf<TTable>, EntityOf<TTable>>(id, {
+    blaze: createReconcileBlaze(options, id, strategy),
+    contours: [entityContour],
+    description:
+      options.description ??
+      `Reconcile version conflicts for "${options.table.name}" entities.`,
+    examples: deriveExamples(options.table),
+    input: options.table.fixtureSchema as unknown as z.ZodType<
+      UpsertOf<TTable>
+    >,
+    intent: 'write',
+    on: options.on,
+    output: options.table.schema as unknown as z.ZodType<EntityOf<TTable>>,
+    resources: [options.resource],
+  });
+};

--- a/packages/store/src/trails/reconcile.ts
+++ b/packages/store/src/trails/reconcile.ts
@@ -1,10 +1,12 @@
 import { ConflictError, Result, ValidationError, trail } from '@ontrails/core';
 import type {
   AnySignal,
+  Detour,
   Resource,
   Trail,
   TrailContext,
   TrailExample,
+  TrailsError,
 } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -43,15 +45,6 @@ export interface ReconcileOptions<
   readonly strategy?: ReconcileStrategy<TTable>;
   readonly table: TTable;
 }
-
-/**
- * Surfaced when `reconcile` exhausts its single retry after a second
- * `ConflictError` from the underlying store. Extends `ConflictError` so
- * callers that catch `ConflictError` still catch it, while still allowing
- * "I should retry reconcile at a higher level" to be distinguished from
- * "reconcile tried and lost the race".
- */
-export class ReconcileRetryExhaustedError extends ConflictError {}
 
 const versionFieldName = 'version';
 
@@ -149,16 +142,7 @@ const resolveStrategy = async <TTable extends AnyStoreTable>(
     ? lastWriteWins(conflict)
     : await strategy(conflict, ctx);
 
-/**
- * Single-retry conflict recovery.
- *
- * `recoverConflict` retries `upsert` exactly once after resolving the
- * conflict through the configured strategy. A concurrent writer between
- * retries produces a second `ConflictError`, which is wrapped in a
- * `ReconcileRetryExhaustedError` by the blaze so callers can distinguish
- * "I should retry reconcile at a higher level" from "reconcile tried and
- * lost the race".
- */
+/** Resolve a version conflict through the configured strategy and retry the upsert. */
 const recoverConflict = async <TTable extends AnyStoreTable>(
   table: TTable,
   input: UpsertOf<TTable>,
@@ -175,24 +159,6 @@ const recoverConflict = async <TTable extends AnyStoreTable>(
   const resolved = await resolveStrategy(strategy, conflict, ctx);
   const normalized = normalizeResolvedInput(table, conflict.current, resolved);
   return Result.ok(await accessor.upsert(normalized));
-};
-
-const wrapRetryExhaustion = (
-  trailId: string,
-  error: unknown
-): ReconcileRetryExhaustedError | Error => {
-  if (!(error instanceof ConflictError)) {
-    return mapStoreTrailError(trailId, error);
-  }
-
-  if (error instanceof ReconcileRetryExhaustedError) {
-    return error;
-  }
-
-  return new ReconcileRetryExhaustedError(
-    `${trailId} retry exhausted after second conflict: ${error.message}`,
-    { cause: error }
-  );
 };
 
 /**
@@ -212,68 +178,68 @@ const buildReconcileInputSchema = <TTable extends AnyStoreTable>(
     [versionFieldName]: z.number().int(),
   }) as unknown as z.ZodType<UpsertOf<TTable>>;
 
-/**
- * Conflict recovery uses inline try/catch rather than `detours` because
- * detours are declarative-only today — there is no execution machinery to
- * wire recovery strategies to versioned upserts yet. Factory-provided trails
- * like `reconcile` need working recovery at runtime, so the inline path is
- * the pragmatic bridge until a detour execution primitive lands. See the
- * "Factory-provided trails" carve-out in the repo-root `AGENTS.md`.
- */
+/** The blaze performs only the initial upsert; conflict recovery is handled by the detour. */
 const createReconcileBlaze =
   <
     TTable extends AnyStoreTable,
     TConnection extends ReconcileConnection<TTable>,
   >(
     options: ReconcileOptions<TTable, TConnection>,
-    id: string,
-    strategy: ReconcileStrategy<TTable>
+    id: string
   ) =>
   async (input: UpsertOf<TTable>, ctx: TrailContext) => {
     try {
       const accessor = resolveAccessor(options.table, options.resource, ctx);
-
-      try {
-        return Result.ok(await accessor.upsert(input));
-      } catch (error) {
-        if (!(error instanceof ConflictError)) {
-          return Result.err(mapStoreTrailError(id, error));
-        }
-
-        try {
-          return await recoverConflict(
-            options.table,
-            input,
-            accessor,
-            error,
-            strategy,
-            ctx
-          );
-        } catch (conflictError) {
-          return Result.err(wrapRetryExhaustion(id, conflictError));
-        }
-      }
+      return Result.ok(await accessor.upsert(input));
     } catch (error) {
+      if (error instanceof ConflictError) {
+        return Result.err(error);
+      }
       return Result.err(mapStoreTrailError(id, error));
     }
   };
+
+/** Build the detour that handles ConflictError recovery via the configured strategy. */
+const createReconcileDetour = <
+  TTable extends AnyStoreTable,
+  TConnection extends ReconcileConnection<TTable>,
+>(
+  options: ReconcileOptions<TTable, TConnection>,
+  id: string,
+  strategy: ReconcileStrategy<TTable>
+): Detour<UpsertOf<TTable>, EntityOf<TTable>, TrailsError> => ({
+  maxAttempts: 1,
+  on: ConflictError,
+  recover: async (attempt, ctx) => {
+    const conflictError = attempt.error as ConflictError;
+    try {
+      const accessor = resolveAccessor(options.table, options.resource, ctx);
+      return await recoverConflict(
+        options.table,
+        attempt.input,
+        accessor,
+        conflictError,
+        strategy,
+        ctx
+      );
+    } catch (error) {
+      if (error instanceof ConflictError) {
+        return Result.err(error);
+      }
+      return Result.err(mapStoreTrailError(id, error) as TrailsError);
+    }
+  },
+});
 
 /**
  * Produce one trail that retries a versioned upsert with a conflict strategy
  * when the incoming entity is stale.
  *
- * Reconcile is bounded to a single retry. If a concurrent writer races the
- * retry and produces a second `ConflictError`, the blaze surfaces a
- * `ReconcileRetryExhaustedError` (a `ConflictError` subclass) so callers can
- * distinguish "retry reconcile at a higher level" from "reconcile tried and
- * lost the race".
- *
- * Conflict recovery is inline rather than delegated to a `detour` because
- * detours are declarative-only today — there is no execution machinery for
- * them yet. Factory-provided trails need working recovery at runtime, so
- * the inline path is the pragmatic bridge until a detour execution primitive
- * lands. See the "Factory-provided trails" carve-out in the repo-root
- * `AGENTS.md`.
+ * Reconcile is bounded to a single retry via a declarative `detour`. If a
+ * concurrent writer races the retry and produces a second `ConflictError`,
+ * the detour loop wraps it in `RetryExhaustedError<ConflictError>` so
+ * callers can distinguish "retry reconcile at a higher level" from
+ * "reconcile tried and lost the race".
  *
  * @remarks
  * For versioned tables, the derived input schema requires an explicit
@@ -299,11 +265,12 @@ export const reconcile = <
   const strategy = options.strategy ?? 'last-write-wins';
 
   return trail<UpsertOf<TTable>, EntityOf<TTable>>(id, {
-    blaze: createReconcileBlaze(options, id, strategy),
+    blaze: createReconcileBlaze(options, id),
     contours: [entityContour],
     description:
       options.description ??
       `Reconcile version conflicts for "${options.table.name}" entities.`,
+    detours: [createReconcileDetour(options, id, strategy)],
     examples: deriveExamples(options.table),
     input: buildReconcileInputSchema(options.table),
     intent: 'write',

--- a/packages/store/src/trails/sync.ts
+++ b/packages/store/src/trails/sync.ts
@@ -1,0 +1,280 @@
+import {
+  contour,
+  InternalError,
+  isTrailsError,
+  NotFoundError,
+  Result,
+  trail,
+} from '@ontrails/core';
+import type {
+  AnyContour,
+  AnySignal,
+  Resource,
+  Trail,
+  TrailContext,
+  TrailExample,
+} from '@ontrails/core';
+import type { z } from 'zod';
+
+import type {
+  AnyStoreTable,
+  EntityOf,
+  ReadOnlyStoreTableAccessor,
+  StoreAccessor,
+  StoreIdentifierOf,
+  UpsertOf,
+} from '../types.js';
+
+type IdentityInputOf<TTable extends AnyStoreTable> = Readonly<
+  Record<Extract<TTable['identity'], string>, StoreIdentifierOf<TTable>>
+>;
+
+type SourceConnection<TTable extends AnyStoreTable> = Readonly<
+  Record<TTable['name'], ReadOnlyStoreTableAccessor<TTable>>
+>;
+
+type TargetConnection<TTable extends AnyStoreTable> = Readonly<
+  Record<TTable['name'], StoreAccessor<TTable>>
+>;
+
+export interface SyncEndpoint<
+  TTable extends AnyStoreTable,
+  TConnection extends SourceConnection<TTable> | TargetConnection<TTable>,
+> {
+  readonly resource: Resource<TConnection>;
+  readonly table: TTable;
+}
+
+export type SyncTransform<
+  TSourceTable extends AnyStoreTable,
+  TTargetTable extends AnyStoreTable,
+> = (
+  entity: EntityOf<TSourceTable>,
+  ctx: TrailContext
+) => Promise<UpsertOf<TTargetTable>> | UpsertOf<TTargetTable>;
+
+export interface SyncOptions<
+  TSourceTable extends AnyStoreTable,
+  TTargetTable extends AnyStoreTable,
+  TSourceConnection extends SourceConnection<TSourceTable>,
+  TTargetConnection extends TargetConnection<TTargetTable>,
+> {
+  readonly description?: string;
+  readonly from: SyncEndpoint<TSourceTable, TSourceConnection>;
+  readonly id?: string;
+  readonly on?: readonly (AnySignal | string)[];
+  readonly to: SyncEndpoint<TTargetTable, TTargetConnection>;
+  readonly transform?: SyncTransform<TSourceTable, TTargetTable>;
+}
+
+const contourCache = new WeakMap<AnyStoreTable, AnyContour>();
+
+const createTableContour = <TTable extends AnyStoreTable>(
+  table: TTable
+): AnyContour => {
+  const cached = contourCache.get(table);
+  if (cached) {
+    return cached;
+  }
+
+  const clonedShape = Object.fromEntries(
+    Object.entries(table.schema.shape).map(([field, schema]) => [
+      field,
+      schema.clone(),
+    ])
+  );
+  const derived = contour(
+    table.name,
+    clonedShape as Record<string, z.ZodType>,
+    {
+      examples: table.fixtures as readonly Record<string, unknown>[],
+      identity: table.identity,
+    }
+  ) as AnyContour;
+
+  contourCache.set(table, derived);
+  return derived;
+};
+
+const resolveSourceAccessor = <
+  TTable extends AnyStoreTable,
+  TConnection extends SourceConnection<TTable>,
+>(
+  endpoint: SyncEndpoint<TTable, TConnection>,
+  ctx: TrailContext
+): ReadOnlyStoreTableAccessor<TTable> => {
+  const connection = endpoint.resource.from(ctx);
+  return connection[
+    endpoint.table.name as keyof TConnection
+  ] as ReadOnlyStoreTableAccessor<TTable>;
+};
+
+const resolveTargetAccessor = <
+  TTable extends AnyStoreTable,
+  TConnection extends TargetConnection<TTable>,
+>(
+  endpoint: SyncEndpoint<TTable, TConnection>,
+  ctx: TrailContext
+): StoreAccessor<TTable> => {
+  const connection = endpoint.resource.from(ctx);
+  return connection[
+    endpoint.table.name as keyof TConnection
+  ] as StoreAccessor<TTable>;
+};
+
+const asError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const mapSyncError = (trailId: string, error: unknown): Error => {
+  if (isTrailsError(error)) {
+    return error;
+  }
+
+  const resolved = asError(error);
+  return new InternalError(`${trailId} failed: ${resolved.message}`, {
+    cause: resolved,
+  });
+};
+
+const sourceMissingError = <TTable extends AnyStoreTable>(
+  table: TTable,
+  id: StoreIdentifierOf<TTable>
+): NotFoundError =>
+  new NotFoundError(
+    `Store table "${table.name}" could not find source entity "${String(id)}"`
+  );
+
+const identityInputSchema = <TTable extends AnyStoreTable>(
+  table: TTable
+): z.ZodType<IdentityInputOf<TTable>> =>
+  table.schema.pick({
+    [table.identity]: true,
+  } as never) as unknown as z.ZodType<IdentityInputOf<TTable>>;
+
+const deriveExamples = <
+  TSourceTable extends AnyStoreTable,
+  TTargetTable extends AnyStoreTable,
+>(
+  sourceTable: TSourceTable,
+  targetTable: TTargetTable,
+  transform: SyncTransform<TSourceTable, TTargetTable> | undefined
+):
+  | readonly TrailExample<
+      IdentityInputOf<TSourceTable>,
+      EntityOf<TTargetTable>
+    >[]
+  | undefined => {
+  const targetById = new Map<
+    StoreIdentifierOf<TTargetTable>,
+    EntityOf<TTargetTable>
+  >();
+  for (const fixture of targetTable.fixtures) {
+    const id = fixture[targetTable.identity as keyof typeof fixture] as
+      | StoreIdentifierOf<TTargetTable>
+      | undefined;
+    if (id !== undefined) {
+      targetById.set(id, fixture as EntityOf<TTargetTable>);
+    }
+  }
+
+  const examples = sourceTable.fixtures.flatMap((fixture) => {
+    const id = fixture[sourceTable.identity as keyof typeof fixture] as
+      | StoreIdentifierOf<TSourceTable>
+      | undefined;
+    if (id === undefined) {
+      return [];
+    }
+
+    const targetFixture =
+      targetById.get(id as unknown as StoreIdentifierOf<TTargetTable>) ??
+      (transform === undefined && targetTable.schema.safeParse(fixture).success
+        ? (fixture as EntityOf<TTargetTable>)
+        : undefined);
+
+    if (targetFixture === undefined) {
+      return [];
+    }
+
+    return [
+      {
+        expected: targetFixture,
+        input: { [sourceTable.identity]: id } as IdentityInputOf<TSourceTable>,
+        name: `Sync ${targetTable.name} ${String(id)}`,
+      },
+    ];
+  });
+
+  return examples.length === 0 ? undefined : Object.freeze(examples);
+};
+
+/**
+ * Produce one trail that reads one source entity and writes the transformed
+ * result into a target store resource.
+ */
+export const sync = <
+  TSourceTable extends AnyStoreTable,
+  TTargetTable extends AnyStoreTable,
+  TSourceConnection extends SourceConnection<TSourceTable>,
+  TTargetConnection extends TargetConnection<TTargetTable>,
+>(
+  options: SyncOptions<
+    TSourceTable,
+    TTargetTable,
+    TSourceConnection,
+    TTargetConnection
+  >
+): Trail<IdentityInputOf<TSourceTable>, EntityOf<TTargetTable>> => {
+  const id = options.id ?? `${options.to.table.name}.sync`;
+  const sourceContour = createTableContour(options.from.table);
+  const targetContour = createTableContour(options.to.table);
+
+  return trail<IdentityInputOf<TSourceTable>, EntityOf<TTargetTable>>(id, {
+    blaze: async (input, ctx) => {
+      try {
+        const identifier = input[
+          options.from.table.identity as keyof typeof input
+        ] as StoreIdentifierOf<TSourceTable>;
+        const sourceEntity = await resolveSourceAccessor(options.from, ctx).get(
+          identifier
+        );
+
+        if (sourceEntity === null) {
+          return Result.err(sourceMissingError(options.from.table, identifier));
+        }
+
+        const next =
+          options.transform === undefined
+            ? (sourceEntity as unknown as UpsertOf<TTargetTable>)
+            : await options.transform(sourceEntity, ctx);
+
+        const synced = await resolveTargetAccessor(options.to, ctx).upsert(
+          next
+        );
+        return Result.ok(synced);
+      } catch (error) {
+        return Result.err(mapSyncError(id, error));
+      }
+    },
+    contours: [sourceContour, targetContour],
+    description:
+      options.description ??
+      `Sync one "${options.from.table.name}" entity into "${options.to.table.name}".`,
+    examples: deriveExamples(
+      options.from.table,
+      options.to.table,
+      options.transform
+    ) as
+      | readonly TrailExample<
+          IdentityInputOf<TSourceTable>,
+          EntityOf<TTargetTable>
+        >[]
+      | undefined,
+    input: identityInputSchema(options.from.table),
+    intent: 'write',
+    on: options.on,
+    output: options.to.table.schema as unknown as z.ZodType<
+      EntityOf<TTargetTable>
+    >,
+    resources: [options.from.resource, options.to.resource],
+  });
+};

--- a/packages/store/src/trails/sync.ts
+++ b/packages/store/src/trails/sync.ts
@@ -1,13 +1,5 @@
-import {
-  contour,
-  InternalError,
-  isTrailsError,
-  NotFoundError,
-  Result,
-  trail,
-} from '@ontrails/core';
+import { InternalError, NotFoundError, Result, trail } from '@ontrails/core';
 import type {
-  AnyContour,
   AnySignal,
   Resource,
   Trail,
@@ -24,6 +16,7 @@ import type {
   StoreIdentifierOf,
   UpsertOf,
 } from '../types.js';
+import { createTableContour, mapStoreTrailError } from './utils.js';
 
 type IdentityInputOf<TTable extends AnyStoreTable> = Readonly<
   Record<Extract<TTable['identity'], string>, StoreIdentifierOf<TTable>>
@@ -67,35 +60,6 @@ export interface SyncOptions<
   readonly transform?: SyncTransform<TSourceTable, TTargetTable>;
 }
 
-const contourCache = new WeakMap<AnyStoreTable, AnyContour>();
-
-const createTableContour = <TTable extends AnyStoreTable>(
-  table: TTable
-): AnyContour => {
-  const cached = contourCache.get(table);
-  if (cached) {
-    return cached;
-  }
-
-  const clonedShape = Object.fromEntries(
-    Object.entries(table.schema.shape).map(([field, schema]) => [
-      field,
-      schema.clone(),
-    ])
-  );
-  const derived = contour(
-    table.name,
-    clonedShape as Record<string, z.ZodType>,
-    {
-      examples: table.fixtures as readonly Record<string, unknown>[],
-      identity: table.identity,
-    }
-  ) as AnyContour;
-
-  contourCache.set(table, derived);
-  return derived;
-};
-
 const resolveSourceAccessor = <
   TTable extends AnyStoreTable,
   TConnection extends SourceConnection<TTable>,
@@ -120,20 +84,6 @@ const resolveTargetAccessor = <
   return connection[
     endpoint.table.name as keyof TConnection
   ] as StoreAccessor<TTable>;
-};
-
-const asError = (error: unknown): Error =>
-  error instanceof Error ? error : new Error(String(error));
-
-const mapSyncError = (trailId: string, error: unknown): Error => {
-  if (isTrailsError(error)) {
-    return error;
-  }
-
-  const resolved = asError(error);
-  return new InternalError(`${trailId} failed: ${resolved.message}`, {
-    cause: resolved,
-  });
 };
 
 const sourceMissingError = <TTable extends AnyStoreTable>(
@@ -229,6 +179,7 @@ export const sync = <
   const targetContour = createTableContour(options.to.table);
 
   return trail<IdentityInputOf<TSourceTable>, EntityOf<TTargetTable>>(id, {
+    // oxlint-disable-next-line max-statements -- sync blaze reads more clearly as one try/catch with schema validation, transform, and accessor call inline
     blaze: async (input, ctx) => {
       try {
         const identifier = input[
@@ -242,17 +193,36 @@ export const sync = <
           return Result.err(sourceMissingError(options.from.table, identifier));
         }
 
+        // No-transform path: the source entity is upserted directly into
+        // the target table. The generic signature does not require the two
+        // tables to be structurally compatible, so validate `next` against
+        // the target table's fixture schema at runtime. This catches
+        // accidentally omitted transforms before the underlying store sees
+        // a mismatched payload.
         const next =
           options.transform === undefined
-            ? (sourceEntity as unknown as UpsertOf<TTargetTable>)
+            ? options.to.table.fixtureSchema.safeParse(sourceEntity)
+            : undefined;
+
+        if (next !== undefined && !next.success) {
+          return Result.err(
+            new InternalError(
+              `${id} produced an invalid target entity: ${next.error.message}`
+            )
+          );
+        }
+
+        const payload =
+          options.transform === undefined
+            ? (next?.data as unknown as UpsertOf<TTargetTable>)
             : await options.transform(sourceEntity, ctx);
 
         const synced = await resolveTargetAccessor(options.to, ctx).upsert(
-          next
+          payload
         );
         return Result.ok(synced);
       } catch (error) {
-        return Result.err(mapSyncError(id, error));
+        return Result.err(mapStoreTrailError(id, error));
       }
     },
     contours: [sourceContour, targetContour],

--- a/packages/store/src/trails/utils.ts
+++ b/packages/store/src/trails/utils.ts
@@ -1,0 +1,83 @@
+import { InternalError, contour, isTrailsError } from '@ontrails/core';
+import type { AnyContour } from '@ontrails/core';
+import type { z } from 'zod';
+
+import type { AnyStoreTable } from '../types.js';
+
+/**
+ * Build the shape used when deriving a contour view of a store table.
+ *
+ * Contour validates every example against the shape passed in, so the shape
+ * must match how fixtures are actually shaped. Store fixtures may omit
+ * framework-generated fields (`createdAt`, `version`, ...) because the
+ * connector populates them, so we mirror `fixtureSchema`'s treatment of
+ * generated fields: generated, non-identity fields are made optional; the
+ * identity field stays required because read/delete/update all derive their
+ * input from it. Previously reconcile.ts and sync.ts passed
+ * `table.schema.shape` directly and crashed when a fixture omitted
+ * `createdAt` or another generated field.
+ */
+export const buildContourShape = (
+  table: AnyStoreTable
+): Record<string, z.ZodType> => {
+  const shape = table.schema.shape as unknown as Record<string, z.ZodType>;
+  const generatedNonIdentity = new Set(
+    table.generated.filter((field) => field !== table.identity)
+  );
+
+  if (generatedNonIdentity.size === 0) {
+    return shape;
+  }
+
+  const next: Record<string, z.ZodType> = {};
+  for (const [field, fieldSchema] of Object.entries(shape)) {
+    next[field] = generatedNonIdentity.has(field)
+      ? fieldSchema.optional()
+      : fieldSchema;
+  }
+  return next;
+};
+
+/**
+ * Derive a contour view of a store table.
+ *
+ * Both `sync` and `reconcile` use this helper so they pick up the
+ * fixture-shape treatment (generated fields optional).
+ *
+ * @remarks
+ * Intentionally not cached. `contour()` brands the identity schema via
+ * `Object.defineProperty(..., { writable: false })`, and re-invoking on a
+ * schema that's already been branded throws TypeError. Factory call sites
+ * already build the contour once per trail instance, so rebuilding on a
+ * warm call is cheap and side-effect-free.
+ */
+export const createTableContour = <TTable extends AnyStoreTable>(
+  table: TTable
+): AnyContour =>
+  contour(table.name, buildContourShape(table), {
+    examples: table.fixtures as readonly Record<string, unknown>[],
+    identity: table.identity,
+  }) as AnyContour;
+
+/**
+ * Coerce an unknown thrown value into an Error instance, preserving the
+ * original when possible.
+ */
+export const asError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+/**
+ * Map a caught error into a `TrailsError` suitable for surfacing from a store
+ * trail factory. Pass-through for errors already in the taxonomy; otherwise
+ * wrap in an `InternalError` keyed by the trail id.
+ */
+export const mapStoreTrailError = (trailId: string, error: unknown): Error => {
+  if (isTrailsError(error)) {
+    return error;
+  }
+
+  const resolved = asError(error);
+  return new InternalError(`${trailId} failed: ${resolved.message}`, {
+    cause: resolved,
+  });
+};


### PR DESCRIPTION
## Summary

Composition-style trail factories that build on the CRUD factory from #150. Two branches folded: sync/reconcile (store) and ingest (core).

### Sync and reconcile factories
- Add `syncFactory(...)` in `@ontrails/store` that derives a sync trail for one-way replication between a source and a store
- Add `reconcileFactory(...)` that derives a reconcile trail for bidirectional convergence with conflict-resolution hooks
- Both factories compose through `deriveTrail` and the generalized store accessor, so they work across connectors
- Full coverage in `sync-reconcile.test.ts` including happy-path, conflict, and partial-progress scenarios

### Ingest composition factory
- Add `ingestFactory(...)` in `@ontrails/core` that derives an ingest trail composing crosses to transform, validate, and persist incoming payloads
- Uses `ctx.cross` batch support for fan-out transformations and the derive-trail helper for the contract surface
- Coverage in `ingest.test.ts` for success, partial failure, and validation-error paths

## Testing

- `bun test packages/store/src/__tests__/sync-reconcile.test.ts`
- `bun test packages/core/src/__tests__/ingest.test.ts`
- `bun run --cwd packages/store test`
- `bun run --cwd packages/core test`
- `bun run typecheck`

## Closes

- Closes TRL-249
- Closes TRL-250
