### PR TITLE
feat(warden): add factory completeness rules

### DIFF
--- a/packages/core/src/trails/derive-trail.ts
+++ b/packages/core/src/trails/derive-trail.ts
@@ -355,6 +355,17 @@ const formatExampleName = (
   return `${titleCase(operation)} ${contour.name} ${suffix}`;
 };
 
+/**
+ * Derive a single trail example from a contour fixture.
+ *
+ * @remarks
+ * For `list` operations, each derived example wraps a single fixture in an
+ * array (`expected: [example]`) and uses the fixture's identity as input
+ * filters. This means the expected output is always a one-element array,
+ * which may not match the real accessor behavior when multiple fixtures
+ * share the same filter. A custom `blaze` with hand-authored examples is
+ * required for multi-result list assertions.
+ */
 const deriveExample = (
   contour: AnyContour,
   operation: DeriveTrailOperation,

--- a/packages/store/src/trails/reconcile.ts
+++ b/packages/store/src/trails/reconcile.ts
@@ -16,6 +16,7 @@ import type {
   StoreAccessor,
   UpsertOf,
 } from '../types.js';
+import { versionFieldName } from '../store.js';
 import { createTableContour, mapStoreTrailError } from './utils.js';
 
 type ReconcileConnection<TTable extends AnyStoreTable> = Readonly<
@@ -45,8 +46,6 @@ export interface ReconcileOptions<
   readonly strategy?: ReconcileStrategy<TTable>;
   readonly table: TTable;
 }
-
-const versionFieldName = 'version';
 
 const resolveAccessor = <
   TTable extends AnyStoreTable,

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -270,6 +270,84 @@ export const gist = contour('gist', {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+
+  test('uses project context for store factory completeness across files', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'store.ts'),
+        `import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+export const definition = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+    versioned: true,
+  },
+});
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const noteTrails = crud(definition.tables.notes, notesResource);`
+      );
+      writeFileSync(
+        join(dir, 'reconcile.ts'),
+        `import { Result, resource } from '@ontrails/core';
+import { reconcile } from '@ontrails/store/trails';
+import { definition } from './store';
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const reconcileNotes = reconcile({
+  resource: notesResource,
+  table: definition.tables.notes,
+});`
+      );
+      writeFileSync(
+        join(dir, 'listener.ts'),
+        `import { Result, trail } from '@ontrails/core';
+import { definition } from './store';
+import { z } from 'zod';
+
+trail('notes.notify', {
+  on: [
+    definition.tables.notes.signals.created,
+    definition.tables.notes.signals.updated,
+    definition.tables.notes.signals.removed,
+  ],
+  blaze: async () => Result.ok({ ok: true }),
+  output: z.object({ ok: z.boolean() }),
+});`
+      );
+
+      const report = await runWarden({ rootDir: dir });
+
+      expect(
+        report.diagnostics.filter(
+          (diagnostic) => diagnostic.rule === 'missing-reconcile'
+        )
+      ).toHaveLength(0);
+      expect(
+        report.diagnostics.filter(
+          (diagnostic) => diagnostic.rule === 'orphaned-signal'
+        )
+      ).toHaveLength(0);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });
 
 describe('runWarden draft markers', () => {

--- a/packages/warden/src/__tests__/incomplete-crud.test.ts
+++ b/packages/warden/src/__tests__/incomplete-crud.test.ts
@@ -107,4 +107,107 @@ const [createNote, readNote, updateNote, deleteNote, listNote] = crud(
 
     expect(incompleteCrud.check(code, TEST_FILE)).toEqual([]);
   });
+
+  test('tracks deriveTrail coverage for imported contours as pending-resolution', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { deriveTrail } from '@ontrails/core/trails';
+import { note } from './shared/contours.js';
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+export const createNote = deriveTrail(note, 'create', {
+  blaze: async () => Result.ok({}),
+  resource: notesResource,
+});
+
+export const readNote = deriveTrail(note, 'read', {
+  blaze: async () => Result.ok({}),
+  resource: notesResource,
+});
+`;
+
+    const diagnostics = incompleteCrud.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('incomplete-crud');
+    // Imported contours surface as pending-resolution so coverage is still tracked.
+    expect(diagnostics[0]?.message).toContain('note');
+    expect(diagnostics[0]?.message).toContain('pending-resolution');
+    expect(diagnostics[0]?.message).toContain('create');
+    expect(diagnostics[0]?.message).toContain('read');
+  });
+
+  test('does not warn when imported contour covers the full CRUD set', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { deriveTrail } from '@ontrails/core/trails';
+import { note } from './shared/contours.js';
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+export const createNote = deriveTrail(note, 'create', { blaze: async () => Result.ok({}), resource: notesResource });
+export const readNote = deriveTrail(note, 'read', { blaze: async () => Result.ok({}), resource: notesResource });
+export const updateNote = deriveTrail(note, 'update', { blaze: async () => Result.ok({}), resource: notesResource });
+export const deleteNote = deriveTrail(note, 'delete', { blaze: async () => Result.ok({}), resource: notesResource });
+export const listNote = deriveTrail(note, 'list', { blaze: async () => Result.ok({}), resource: notesResource });
+`;
+
+    expect(incompleteCrud.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('tracks two stores with colliding table names independently', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+const primary = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({ id: z.string(), title: z.string() }),
+  },
+});
+
+const archive = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({ id: z.string(), title: z.string() }),
+  },
+});
+
+const primaryResource = resource('db.primary', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+const archiveResource = resource('db.archive', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+// primary is fully covered
+const [createPrimary, readPrimary, updatePrimary, deletePrimary, listPrimary] =
+  crud(primary.tables.notes, primaryResource);
+
+// archive is partially covered — the warning should target only archive
+const [createArchive, readArchive] = crud(archive.tables.notes, archiveResource);
+`;
+
+    const diagnostics = incompleteCrud.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('incomplete-crud');
+    // Stores are keyed by their local binding, so the colliding bare name
+    // `notes` does not cause archive coverage to leak into primary.
+    expect(diagnostics[0]?.message).toContain('archive:notes');
+    expect(diagnostics[0]?.message).toContain('create');
+    expect(diagnostics[0]?.message).toContain('read');
+  });
 });

--- a/packages/warden/src/__tests__/incomplete-crud.test.ts
+++ b/packages/warden/src/__tests__/incomplete-crud.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'bun:test';
+
+import { incompleteCrud } from '../rules/incomplete-crud.js';
+
+const TEST_FILE = 'entity.ts';
+
+describe('incomplete-crud', () => {
+  test('warns when deriveTrail only covers part of the CRUD set', () => {
+    const code = `
+import { Result, contour, resource } from '@ontrails/core';
+import { deriveTrail } from '@ontrails/core/trails';
+import { z } from 'zod';
+
+const note = contour('note', {
+  body: z.string(),
+  id: z.string(),
+  title: z.string(),
+}, { identity: 'id' });
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+export const createNote = deriveTrail(note, 'create', {
+  blaze: async () => Result.ok({}),
+  resource: notesResource,
+});
+
+export const readNote = deriveTrail(note, 'read', {
+  blaze: async () => Result.ok({}),
+  resource: notesResource,
+});
+`;
+
+    const diagnostics = incompleteCrud.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('incomplete-crud');
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toContain('note');
+    expect(diagnostics[0]?.message).toContain('create');
+    expect(diagnostics[0]?.message).toContain('read');
+  });
+
+  test('warns when crud() tuple destructuring captures only part of the standard trails', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+const db = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  },
+});
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const [createNote, readNote] = crud(db.tables.notes, notesResource);
+`;
+
+    const diagnostics = incompleteCrud.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('incomplete-crud');
+    expect(diagnostics[0]?.message).toContain('notes');
+    expect(diagnostics[0]?.message).toContain('create');
+    expect(diagnostics[0]?.message).toContain('read');
+  });
+
+  test('stays quiet when the full CRUD tuple is captured', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+const db = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  },
+});
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const [createNote, readNote, updateNote, deleteNote, listNote] = crud(
+  db.tables.notes,
+  notesResource
+);
+`;
+
+    expect(incompleteCrud.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/missing-reconcile.test.ts
+++ b/packages/warden/src/__tests__/missing-reconcile.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+
+import { missingReconcile } from '../rules/missing-reconcile.js';
+
+const TEST_FILE = 'store.ts';
+
+describe('missing-reconcile', () => {
+  test('warns when a versioned store table is used with crud() but no reconcile() trail exists', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+const definition = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+    versioned: true,
+  },
+});
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const noteTrails = crud(definition.tables.notes, notesResource);
+`;
+
+    const diagnostics = missingReconcile.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('missing-reconcile');
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toContain('notes');
+    expect(diagnostics[0]?.message).toContain('reconcile');
+  });
+
+  test('stays quiet when reconcile() is present for the versioned table', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud, reconcile } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+const definition = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+    versioned: true,
+  },
+});
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const noteTrails = crud(definition.tables.notes, notesResource);
+const reconcileNote = reconcile({
+  resource: notesResource,
+  table: definition.tables.notes,
+});
+`;
+
+    expect(missingReconcile.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('stays quiet for non-versioned tables even when crud() is present', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+const definition = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  },
+});
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const noteTrails = crud(definition.tables.notes, notesResource);
+`;
+
+    expect(missingReconcile.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/missing-reconcile.test.ts
+++ b/packages/warden/src/__tests__/missing-reconcile.test.ts
@@ -73,6 +73,57 @@ const reconcileNote = reconcile({
     expect(missingReconcile.check(code, TEST_FILE)).toEqual([]);
   });
 
+  test('tracks two stores with colliding table names independently', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud, reconcile } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+const primary = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({ id: z.string(), title: z.string() }),
+    versioned: true,
+  },
+});
+
+const archive = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({ id: z.string(), title: z.string() }),
+    versioned: true,
+  },
+});
+
+const primaryResource = resource('db.primary', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+const archiveResource = resource('db.archive', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+// primary gets both crud and reconcile — should be quiet
+const primaryCrud = crud(primary.tables.notes, primaryResource);
+const primaryReconcile = reconcile({
+  resource: primaryResource,
+  table: primary.tables.notes,
+});
+
+// archive only gets crud — should warn ONCE for archive (not primary)
+const archiveCrud = crud(archive.tables.notes, archiveResource);
+`;
+
+    const diagnostics = missingReconcile.check(code, TEST_FILE);
+
+    // Only archive should warn; primary's reconcile is correctly paired.
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('missing-reconcile');
+    expect(diagnostics[0]?.message).toContain('notes');
+  });
+
   test('stays quiet for non-versioned tables even when crud() is present', () => {
     const code = `
 import { Result, resource } from '@ontrails/core';

--- a/packages/warden/src/__tests__/orphaned-signal.test.ts
+++ b/packages/warden/src/__tests__/orphaned-signal.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+
+import { orphanedSignal } from '../rules/orphaned-signal.js';
+
+const TEST_FILE = 'store.ts';
+
+describe('orphaned-signal', () => {
+  test('warns when a crud-backed store table has no reactive consumers for its change signals', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+const definition = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  },
+});
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const noteTrails = crud(definition.tables.notes, notesResource);
+`;
+
+    const diagnostics = orphanedSignal.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('orphaned-signal');
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toContain('notes');
+    expect(diagnostics[0]?.message).toContain('notes.created');
+    expect(diagnostics[0]?.message).toContain('notes.updated');
+    expect(diagnostics[0]?.message).toContain('notes.removed');
+  });
+
+  test('stays quiet when all derived change signals are consumed elsewhere in the project', () => {
+    const code = `
+import { store } from '@ontrails/store';
+import { z } from 'zod';
+
+const definition = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  },
+});
+`;
+
+    const diagnostics = orphanedSignal.checkWithContext(code, TEST_FILE, {
+      crudTableIds: new Set(['notes']),
+      knownTrailIds: new Set(['notes.notify']),
+      onTargetSignalIds: new Set([
+        'notes.created',
+        'notes.updated',
+        'notes.removed',
+      ]),
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('stays quiet when the table is not used with crud()', () => {
+    const code = `
+import { store } from '@ontrails/store';
+import { z } from 'zod';
+
+const definition = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  },
+});
+`;
+
+    expect(orphanedSignal.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/orphaned-signal.test.ts
+++ b/packages/warden/src/__tests__/orphaned-signal.test.ts
@@ -58,16 +58,62 @@ const definition = store({
 `;
 
     const diagnostics = orphanedSignal.checkWithContext(code, TEST_FILE, {
-      crudTableIds: new Set(['notes']),
+      // Keys are composite (`${storeBinding}:${tableName}`) so two stores
+      // that share a table name don't collide across files.
+      crudTableIds: new Set(['definition:notes']),
       knownTrailIds: new Set(['notes.notify']),
       onTargetSignalIds: new Set([
-        'notes.created',
-        'notes.updated',
-        'notes.removed',
+        'definition:notes.created',
+        'definition:notes.updated',
+        'definition:notes.removed',
       ]),
     });
 
     expect(diagnostics).toEqual([]);
+  });
+
+  test('tracks two stores with colliding table names independently', () => {
+    const code = `
+import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+const primary = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({ id: z.string(), title: z.string() }),
+  },
+});
+
+const archive = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({ id: z.string(), title: z.string() }),
+  },
+});
+
+const primaryResource = resource('db.primary', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+const archiveResource = resource('db.archive', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const primaryTrails = crud(primary.tables.notes, primaryResource);
+const archiveTrails = crud(archive.tables.notes, archiveResource);
+`;
+
+    const diagnostics = orphanedSignal.check(code, TEST_FILE);
+
+    // Both stores warn, but independently — not one combined message.
+    expect(diagnostics).toHaveLength(2);
+    for (const diagnostic of diagnostics) {
+      expect(diagnostic.rule).toBe('orphaned-signal');
+      expect(diagnostic.message).toContain('notes');
+    }
   });
 
   test('stays quiet when the table is not used with crud()', () => {

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 23 rule trails', () => {
-    expect(wardenTopo.count).toBe(23);
+  test('contains all 26 rule trails', () => {
+    expect(wardenTopo.count).toBe(26);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -15,7 +15,10 @@ import { checkDrift } from './drift.js';
 import {
   collectContourDefinitionIds,
   collectContourReferenceTargetsByName,
+  collectCrudTableIds as collectCrudTableIdsFromAst,
   collectCrossTargetTrailIds,
+  collectOnTargetSignalIds as collectOnTargetSignalIdsFromAst,
+  collectReconcileTableIds as collectReconcileTableIdsFromAst,
   collectResourceDefinitionIds,
   collectSignalDefinitionIds,
   collectTrailIntentsById,
@@ -98,23 +101,29 @@ interface SourceFile {
 
 interface MutableProjectContext {
   contourReferencesByName: Map<string, Set<string>>;
+  crudTableIds: Set<string>;
   crossTargetTrailIds: Set<string>;
   detourTargetTrailIds: Set<string>;
   knownContourIds: Set<string>;
   knownResourceIds: Set<string>;
   knownSignalIds: Set<string>;
   knownTrailIds: Set<string>;
+  onTargetSignalIds: Set<string>;
+  reconcileTableIds: Set<string>;
   trailIntentsById: Map<string, 'destroy' | 'read' | 'write'>;
 }
 
 const createMutableProjectContext = (): MutableProjectContext => ({
   contourReferencesByName: new Map<string, Set<string>>(),
   crossTargetTrailIds: new Set<string>(),
+  crudTableIds: new Set<string>(),
   detourTargetTrailIds: new Set<string>(),
   knownContourIds: new Set<string>(),
   knownResourceIds: new Set<string>(),
   knownSignalIds: new Set<string>(),
   knownTrailIds: new Set<string>(),
+  onTargetSignalIds: new Set<string>(),
+  reconcileTableIds: new Set<string>(),
   trailIntentsById: new Map<string, 'destroy' | 'read' | 'write'>(),
 });
 
@@ -144,12 +153,21 @@ const toProjectContext = (context: MutableProjectContext): ProjectContext => ({
         ),
       }
     : {}),
+  ...(context.crudTableIds.size > 0
+    ? { crudTableIds: context.crudTableIds }
+    : {}),
   crossTargetTrailIds: context.crossTargetTrailIds,
   detourTargetTrailIds: context.detourTargetTrailIds,
   knownContourIds: context.knownContourIds,
   knownResourceIds: context.knownResourceIds,
   knownSignalIds: context.knownSignalIds,
   knownTrailIds: context.knownTrailIds,
+  ...(context.onTargetSignalIds.size > 0
+    ? { onTargetSignalIds: context.onTargetSignalIds }
+    : {}),
+  ...(context.reconcileTableIds.size > 0
+    ? { reconcileTableIds: context.reconcileTableIds }
+    : {}),
   trailIntentsById: context.trailIntentsById,
 });
 
@@ -250,6 +268,48 @@ const collectTrailIntents = (
   }
 };
 
+const collectCrudTableIds = (
+  sourceCode: string,
+  filePath: string,
+  crudTableIds: Set<string>
+): void => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return;
+  }
+  for (const id of collectCrudTableIdsFromAst(ast)) {
+    crudTableIds.add(id);
+  }
+};
+
+const collectOnTargetSignalIds = (
+  sourceCode: string,
+  filePath: string,
+  onTargetSignalIds: Set<string>
+): void => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return;
+  }
+  for (const id of collectOnTargetSignalIdsFromAst(ast, sourceCode)) {
+    onTargetSignalIds.add(id);
+  }
+};
+
+const collectReconcileTableIds = (
+  sourceCode: string,
+  filePath: string,
+  reconcileTableIds: Set<string>
+): void => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return;
+  }
+  for (const id of collectReconcileTableIdsFromAst(ast)) {
+    reconcileTableIds.add(id);
+  }
+};
+
 const loadSourceFiles = async (
   rootDir: string
 ): Promise<readonly SourceFile[]> => {
@@ -341,12 +401,6 @@ const collectTopoTrailContext = (
   collectTopoContourReferences(appTopo, context);
 };
 
-const buildProjectContextFromTopo = (appTopo: Topo): ProjectContext => {
-  const context = createMutableProjectContext();
-  collectTopoTrailContext(appTopo, context);
-  return toProjectContext(context);
-};
-
 const collectFileProjectContext = (
   sourceFile: SourceFile,
   context: MutableProjectContext
@@ -386,6 +440,21 @@ const collectFileProjectContext = (
     sourceFile.filePath,
     context.trailIntentsById
   );
+  collectCrudTableIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.crudTableIds
+  );
+  collectOnTargetSignalIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.onTargetSignalIds
+  );
+  collectReconcileTableIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.reconcileTableIds
+  );
 };
 
 const collectFileContourReferences = (
@@ -406,8 +475,9 @@ const collectFileContourReferences = (
   }
 };
 
-const buildProjectContextFromFiles = (
-  sourceFiles: readonly SourceFile[]
+const buildProjectContext = (
+  sourceFiles: readonly SourceFile[],
+  appTopo?: Topo | undefined
 ): ProjectContext => {
   const context = createMutableProjectContext();
 
@@ -417,6 +487,10 @@ const buildProjectContextFromFiles = (
 
   for (const sourceFile of sourceFiles) {
     collectFileContourReferences(sourceFile, context);
+  }
+
+  if (appTopo) {
+    collectTopoTrailContext(appTopo, context);
   }
 
   return toProjectContext(context);
@@ -434,9 +508,7 @@ const lintFiles = async (
 ): Promise<WardenDiagnostic[]> => {
   const allDiagnostics: WardenDiagnostic[] = [];
   const sourceFiles = await loadSourceFiles(rootDir);
-  const context = appTopo
-    ? buildProjectContextFromTopo(appTopo)
-    : buildProjectContextFromFiles(sourceFiles);
+  const context = buildProjectContext(sourceFiles, appTopo);
 
   for (const sourceFile of sourceFiles) {
     for (const rule of wardenRules.values()) {

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -457,6 +457,27 @@ const collectFileProjectContext = (
   );
 };
 
+const collectFileSupplementalProjectContext = (
+  sourceFile: SourceFile,
+  context: MutableProjectContext
+): void => {
+  collectCrudTableIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.crudTableIds
+  );
+  collectOnTargetSignalIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.onTargetSignalIds
+  );
+  collectReconcileTableIds(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.reconcileTableIds
+  );
+};
+
 const collectFileContourReferences = (
   sourceFile: SourceFile,
   context: MutableProjectContext
@@ -481,16 +502,19 @@ const buildProjectContext = (
 ): ProjectContext => {
   const context = createMutableProjectContext();
 
-  for (const sourceFile of sourceFiles) {
-    collectFileProjectContext(sourceFile, context);
+  if (appTopo) {
+    collectTopoTrailContext(appTopo, context);
+    for (const sourceFile of sourceFiles) {
+      collectFileSupplementalProjectContext(sourceFile, context);
+    }
+  } else {
+    for (const sourceFile of sourceFiles) {
+      collectFileProjectContext(sourceFile, context);
+    }
   }
 
   for (const sourceFile of sourceFiles) {
     collectFileContourReferences(sourceFile, context);
-  }
-
-  if (appTopo) {
-    collectTopoTrailContext(appTopo, context);
   }
 
   return toProjectContext(context);

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -27,8 +27,10 @@ export { draftVisibleDebt } from './rules/draft-visible-debt.js';
 export { errorMappingCompleteness } from './rules/error-mapping-completeness.js';
 export { exampleValid } from './rules/example-valid.js';
 export { firesDeclarations } from './rules/fires-declarations.js';
+export { incompleteCrud } from './rules/incomplete-crud.js';
 export { intentPropagation } from './rules/intent-propagation.js';
 export { missingVisibility } from './rules/missing-visibility.js';
+export { missingReconcile } from './rules/missing-reconcile.js';
 export { onReferencesExist } from './rules/on-references-exist.js';
 export { validDetourRefs } from './rules/valid-detour-refs.js';
 export { noDirectImplInRoute } from './rules/no-direct-impl-in-route.js';
@@ -36,6 +38,7 @@ export { noDirectImplementationCall } from './rules/no-direct-implementation-cal
 export { noSyncResultAssumption } from './rules/no-sync-result-assumption.js';
 export { implementationReturnsResult } from './rules/implementation-returns-result.js';
 export { noThrowInDetourTarget } from './rules/no-throw-in-detour-target.js';
+export { orphanedSignal } from './rules/orphaned-signal.js';
 export { preferSchemaInference } from './rules/prefer-schema-inference.js';
 export { referenceExists } from './rules/reference-exists.js';
 export { resourceDeclarations } from './rules/resource-declarations.js';
@@ -93,14 +96,17 @@ export {
   exampleValidTrail,
   firesDeclarationsTrail,
   implementationReturnsResultTrail,
+  incompleteCrudTrail,
   intentPropagationTrail,
   missingVisibilityTrail,
+  missingReconcileTrail,
   noDirectImplInRouteTrail,
   noDirectImplementationCallTrail,
   noSyncResultAssumptionTrail,
   noThrowInDetourTargetTrail,
   noThrowInImplementationTrail,
   onReferencesExistTrail,
+  orphanedSignalTrail,
   preferSchemaInferenceTrail,
   referenceExistsTrail,
   ruleInput,

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -1090,6 +1090,364 @@ export const collectTrailIntentsById = (
 };
 
 // ---------------------------------------------------------------------------
+// Store / factory pattern extraction
+// ---------------------------------------------------------------------------
+
+export interface StoreTableDefinition {
+  /** Table name declared inside store({ ... }). */
+  readonly name: string;
+  /** Start offset of the table property declaration. */
+  readonly start: number;
+  /** Whether the authored table opts into version tracking. */
+  readonly versioned: boolean;
+}
+
+const isBooleanLiteral = (node: AstNode | undefined): boolean =>
+  Boolean(
+    node &&
+    ((node.type === 'BooleanLiteral' &&
+      (node as unknown as { value?: unknown }).value === true) ||
+      (node.type === 'Literal' &&
+        (node as unknown as { value?: unknown }).value === true))
+  );
+
+const isNamedCall = (node: AstNode | undefined, name: string): boolean =>
+  !!node &&
+  node.type === 'CallExpression' &&
+  identifierName((node as unknown as { callee?: AstNode }).callee) === name;
+
+const getMemberExpression = (
+  node: AstNode | undefined
+): { readonly object?: AstNode; readonly property?: AstNode } | null => {
+  if (
+    !node ||
+    (node.type !== 'MemberExpression' && node.type !== 'StaticMemberExpression')
+  ) {
+    return null;
+  }
+
+  return node as unknown as {
+    readonly object?: AstNode;
+    readonly property?: AstNode;
+  };
+};
+
+const extractStoreTableNameFromMember = (
+  node: AstNode | undefined
+): string | null => {
+  const member = getMemberExpression(node);
+  const tableName = member ? getPropertyName(member.property) : null;
+  const tablesMember = member ? getMemberExpression(member.object) : null;
+  if (!tableName || !tablesMember) {
+    return null;
+  }
+
+  return getPropertyName(tablesMember.property) === 'tables' ? tableName : null;
+};
+
+export const collectNamedStoreTableIds = (
+  ast: AstNode
+): ReadonlyMap<string, string> => {
+  const ids = new Map<string, string>();
+
+  walk(ast, (node) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+
+    const { id, init } = node as unknown as {
+      readonly id?: AstNode;
+      readonly init?: AstNode;
+    };
+    const name = extractBindingName(id);
+    const tableId = extractStoreTableNameFromMember(init);
+    if (name && tableId) {
+      ids.set(name, tableId);
+    }
+  });
+
+  return ids;
+};
+
+const resolveStoreTableId = (
+  node: AstNode | undefined,
+  namedStoreTableIds: ReadonlyMap<string, string>
+): string | null => {
+  if (!node) {
+    return null;
+  }
+
+  if (node.type === 'Identifier') {
+    const name = identifierName(node);
+    return name ? (namedStoreTableIds.get(name) ?? null) : null;
+  }
+
+  return extractStoreTableNameFromMember(node);
+};
+
+const extractStoreTableDefinitions = (
+  node: AstNode
+): readonly StoreTableDefinition[] => {
+  if (!isNamedCall(node, 'store')) {
+    return [];
+  }
+
+  const [tablesArg] = ((node as unknown as { arguments?: readonly AstNode[] })
+    .arguments ?? []) as readonly AstNode[];
+  if (!tablesArg || tablesArg.type !== 'ObjectExpression') {
+    return [];
+  }
+
+  const properties = tablesArg['properties'] as readonly AstNode[] | undefined;
+  if (!properties) {
+    return [];
+  }
+
+  return properties.flatMap((property) => {
+    if (property.type !== 'Property') {
+      return [];
+    }
+
+    const name = getPropertyName(property.key);
+    const value = property.value as AstNode | undefined;
+    if (!name || value?.type !== 'ObjectExpression') {
+      return [];
+    }
+
+    const versionedProp = findConfigProperty(value, 'versioned');
+    return [
+      {
+        name,
+        start: property.start,
+        versioned: isBooleanLiteral(
+          versionedProp?.value as AstNode | undefined
+        ),
+      },
+    ];
+  });
+};
+
+export const findStoreTableDefinitions = (
+  ast: AstNode
+): readonly StoreTableDefinition[] => {
+  const definitions: StoreTableDefinition[] = [];
+
+  walk(ast, (node) => {
+    definitions.push(...extractStoreTableDefinitions(node));
+  });
+
+  return definitions;
+};
+
+export const collectVersionedStoreTableIds = (
+  ast: AstNode
+): ReadonlySet<string> =>
+  new Set(
+    findStoreTableDefinitions(ast).flatMap((definition) =>
+      definition.versioned ? [definition.name] : []
+    )
+  );
+
+export const collectCrudTableIds = (ast: AstNode): ReadonlySet<string> => {
+  const ids = new Set<string>();
+  const namedStoreTableIds = collectNamedStoreTableIds(ast);
+
+  walk(ast, (node) => {
+    if (!isNamedCall(node, 'crud')) {
+      return;
+    }
+
+    const [tableArg] = ((node as unknown as { arguments?: readonly AstNode[] })
+      .arguments ?? []) as readonly AstNode[];
+    const tableId = resolveStoreTableId(tableArg, namedStoreTableIds);
+    if (tableId) {
+      ids.add(tableId);
+    }
+  });
+
+  return ids;
+};
+
+export const collectReconcileTableIds = (ast: AstNode): ReadonlySet<string> => {
+  const ids = new Set<string>();
+  const namedStoreTableIds = collectNamedStoreTableIds(ast);
+
+  walk(ast, (node) => {
+    if (!isNamedCall(node, 'reconcile')) {
+      return;
+    }
+
+    const [configArg] = ((
+      node as unknown as {
+        arguments?: readonly AstNode[];
+      }
+    ).arguments ?? []) as readonly AstNode[];
+    if (!configArg || configArg.type !== 'ObjectExpression') {
+      return;
+    }
+
+    const tableProp = findConfigProperty(configArg, 'table');
+    const tableId = resolveStoreTableId(
+      tableProp?.value as AstNode | undefined,
+      namedStoreTableIds
+    );
+    if (tableId) {
+      ids.add(tableId);
+    }
+  });
+
+  return ids;
+};
+
+const STORE_SIGNAL_OPERATIONS = new Set(['created', 'removed', 'updated']);
+
+const extractStoreSignalIdFromMember = (
+  node: AstNode | undefined,
+  namedStoreTableIds: ReadonlyMap<string, string>
+): string | null => {
+  const member = getMemberExpression(node);
+  const operation = member ? getPropertyName(member.property) : null;
+  if (!operation || !STORE_SIGNAL_OPERATIONS.has(operation)) {
+    return null;
+  }
+
+  const signalsMember = member ? getMemberExpression(member.object) : null;
+  if (!signalsMember || getPropertyName(signalsMember.property) !== 'signals') {
+    return null;
+  }
+
+  const tableId = resolveStoreTableId(signalsMember.object, namedStoreTableIds);
+  return tableId ? `${tableId}.${operation}` : null;
+};
+
+const collectNamedStoreSignalIds = (
+  ast: AstNode,
+  namedStoreTableIds: ReadonlyMap<string, string>
+): ReadonlyMap<string, string> => {
+  const ids = new Map<string, string>();
+
+  walk(ast, (node) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+
+    const { id, init } = node as unknown as {
+      readonly id?: AstNode;
+      readonly init?: AstNode;
+    };
+    const name = extractBindingName(id);
+    const signalId = extractStoreSignalIdFromMember(init, namedStoreTableIds);
+    if (name && signalId) {
+      ids.set(name, signalId);
+    }
+  });
+
+  return ids;
+};
+
+const getOnElements = (config: AstNode): readonly AstNode[] => {
+  const onProp = findConfigProperty(config, 'on');
+  if (!onProp) {
+    return [];
+  }
+
+  const arrayNode = onProp.value;
+  if (!arrayNode || (arrayNode as AstNode).type !== 'ArrayExpression') {
+    return [];
+  }
+
+  const elements = (arrayNode as AstNode)['elements'] as
+    | readonly AstNode[]
+    | undefined;
+  return elements ?? [];
+};
+
+const resolveNamedOnSignalId = (
+  element: AstNode,
+  sourceCode: string,
+  namedStoreSignalIds: ReadonlyMap<string, string>
+): string | null => {
+  if (element.type !== 'Identifier') {
+    return null;
+  }
+
+  const name = identifierName(element);
+  return name
+    ? (namedStoreSignalIds.get(name) ?? resolveConstString(name, sourceCode))
+    : null;
+};
+
+const resolveInlineOnSignalId = (element: AstNode): string | null => {
+  const definition = extractTrailDefinition(element);
+  return definition?.kind === 'signal' || definition?.kind === 'event'
+    ? definition.id
+    : null;
+};
+
+const resolveOnElementSignalId = (
+  element: AstNode,
+  sourceCode: string,
+  namedStoreSignalIds: ReadonlyMap<string, string>,
+  namedStoreTableIds: ReadonlyMap<string, string>
+): string | null => {
+  if (isStringLiteral(element)) {
+    return getStringValue(element);
+  }
+
+  return (
+    extractStoreSignalIdFromMember(element, namedStoreTableIds) ??
+    resolveNamedOnSignalId(element, sourceCode, namedStoreSignalIds) ??
+    resolveInlineOnSignalId(element)
+  );
+};
+
+const addOnTargetSignalIds = (
+  config: AstNode,
+  ids: Set<string>,
+  sourceCode: string,
+  namedStoreSignalIds: ReadonlyMap<string, string>,
+  namedStoreTableIds: ReadonlyMap<string, string>
+): void => {
+  for (const element of getOnElements(config)) {
+    const signalId = resolveOnElementSignalId(
+      element,
+      sourceCode,
+      namedStoreSignalIds,
+      namedStoreTableIds
+    );
+    if (signalId) {
+      ids.add(signalId);
+    }
+  }
+};
+
+export const collectOnTargetSignalIds = (
+  ast: AstNode,
+  sourceCode: string
+): ReadonlySet<string> => {
+  const ids = new Set<string>();
+  const namedStoreTableIds = collectNamedStoreTableIds(ast);
+  const namedStoreSignalIds = collectNamedStoreSignalIds(
+    ast,
+    namedStoreTableIds
+  );
+
+  for (const definition of findTrailDefinitions(ast)) {
+    if (definition.kind === 'trail') {
+      addOnTargetSignalIds(
+        definition.config,
+        ids,
+        sourceCode,
+        namedStoreSignalIds,
+        namedStoreTableIds
+      );
+    }
+  }
+
+  return ids;
+};
+
+// ---------------------------------------------------------------------------
 // Misc helpers
 // ---------------------------------------------------------------------------
 

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -638,7 +638,13 @@ export interface ContourReferenceSite {
   readonly target: string;
 }
 
-const getPropertyName = (node: unknown): string | null => {
+/**
+ * Read a property key or member access identifier.
+ *
+ * Returns the identifier name for `Identifier` keys, or the underlying
+ * string literal value for computed access via `['name']` / `"name"`.
+ */
+export const getPropertyName = (node: unknown): string | null => {
   if (typeof node !== 'object' || node === null) {
     return null;
   }
@@ -1096,11 +1102,43 @@ export const collectTrailIntentsById = (
 export interface StoreTableDefinition {
   /** Table name declared inside store({ ... }). */
   readonly name: string;
+  /**
+   * Local binding name of the enclosing `store(...)` declaration, if the
+   * `store(...)` call is bound to a `const`/`let`/`var` (e.g. `db` in
+   * `const db = store({ ... })`). Null for anonymous stores.
+   */
+  readonly storeBinding: string | null;
+  /**
+   * Stable composite key for this table in the form `${storeBinding}:${name}`,
+   * falling back to the bare `name` when the store is anonymous. Use this for
+   * cross-rule / cross-file keying so two stores with the same table name
+   * never collide.
+   */
+  readonly key: string;
   /** Start offset of the table property declaration. */
   readonly start: number;
   /** Whether the authored table opts into version tracking. */
   readonly versioned: boolean;
 }
+
+/**
+ * Build a composite key for a store table: `${storeBinding}:${tableName}`,
+ * falling back to the bare `tableName` when the enclosing store has no local
+ * binding. Centralized so rule keying stays stable.
+ *
+ * @remarks
+ * The key is intentionally file-local (no module path prefix). Cross-file
+ * aggregation in `ProjectContext` merges keys from all files, so two files
+ * with `const db = store({ notes: ... })` both produce `db:notes` — this is
+ * the desired behavior because the warden checks for *pattern completeness*
+ * across the project and matching keys signals that the same logical table
+ * is covered. If two genuinely different tables share a binding and name,
+ * that is a code-level naming collision the developer should resolve.
+ */
+export const makeStoreTableKey = (
+  storeBinding: string | null,
+  tableName: string
+): string => (storeBinding ? `${storeBinding}:${tableName}` : tableName);
 
 const isBooleanLiteral = (node: AstNode | undefined): boolean =>
   Boolean(
@@ -1111,12 +1149,22 @@ const isBooleanLiteral = (node: AstNode | undefined): boolean =>
         (node as unknown as { value?: unknown }).value === true))
   );
 
-const isNamedCall = (node: AstNode | undefined, name: string): boolean =>
+/**
+ * Check if a node is a `CallExpression` to the identifier `name`.
+ *
+ * e.g. `isNamedCall(node, 'store')` matches `store({...})` but not
+ * `someObj.store()` or `storeAlt()`.
+ */
+export const isNamedCall = (node: AstNode | undefined, name: string): boolean =>
   !!node &&
   node.type === 'CallExpression' &&
   identifierName((node as unknown as { callee?: AstNode }).callee) === name;
 
-const getMemberExpression = (
+/**
+ * Narrow a member-expression node (`a.b` or `a['b']`) to its `object` /
+ * `property` pair, returning `null` for anything else.
+ */
+export const getMemberExpression = (
   node: AstNode | undefined
 ): { readonly object?: AstNode; readonly property?: AstNode } | null => {
   if (
@@ -1132,9 +1180,20 @@ const getMemberExpression = (
   };
 };
 
-const extractStoreTableNameFromMember = (
+/**
+ * Resolve a `<store>.tables.<name>` member expression to its store binding
+ * and table name.
+ *
+ * Returns `null` for anything that isn't a two-level member access ending in
+ * `.tables.<name>`. The store binding is the identifier of the object owning
+ * `.tables` — typically the local binding from `const db = store(...)`.
+ */
+export const extractStoreTableFromMember = (
   node: AstNode | undefined
-): string | null => {
+): {
+  readonly storeBinding: string | null;
+  readonly tableName: string;
+} | null => {
   const member = getMemberExpression(node);
   const tableName = member ? getPropertyName(member.property) : null;
   const tablesMember = member ? getMemberExpression(member.object) : null;
@@ -1142,9 +1201,28 @@ const extractStoreTableNameFromMember = (
     return null;
   }
 
-  return getPropertyName(tablesMember.property) === 'tables' ? tableName : null;
+  if (getPropertyName(tablesMember.property) !== 'tables') {
+    return null;
+  }
+
+  const storeBinding = identifierName(tablesMember.object) ?? null;
+  return { storeBinding, tableName };
 };
 
+/**
+ * Back-compat shim for rule code that only needs the table name. Prefer
+ * `extractStoreTableFromMember` so the caller can build a composite key.
+ */
+export const extractStoreTableIdFromMember = (
+  node: AstNode | undefined
+): string | null => extractStoreTableFromMember(node)?.tableName ?? null;
+
+/**
+ * Collect `const foo = <store>.tables.<name>` bindings from a parsed file,
+ * keyed by the local binding name. Values are the composite table key
+ * (`${storeBinding}:${tableName}`) so callers can dedupe across stores that
+ * share a table name.
+ */
 export const collectNamedStoreTableIds = (
   ast: AstNode
 ): ReadonlyMap<string, string> => {
@@ -1160,16 +1238,24 @@ export const collectNamedStoreTableIds = (
       readonly init?: AstNode;
     };
     const name = extractBindingName(id);
-    const tableId = extractStoreTableNameFromMember(init);
-    if (name && tableId) {
-      ids.set(name, tableId);
+    const table = extractStoreTableFromMember(init);
+    if (name && table) {
+      ids.set(name, makeStoreTableKey(table.storeBinding, table.tableName));
     }
   });
 
   return ids;
 };
 
-const resolveStoreTableId = (
+/**
+ * Resolve an argument node to a composite store-table key
+ * (`${storeBinding}:${tableName}` or bare `tableName` when anonymous).
+ *
+ * Handles the two authoring patterns:
+ *   - direct member access: `db.tables.notes`
+ *   - identifier reference: `const notesTable = db.tables.notes; crud(notesTable, …)`
+ */
+export const resolveStoreTableId = (
   node: AstNode | undefined,
   namedStoreTableIds: ReadonlyMap<string, string>
 ): string | null => {
@@ -1182,11 +1268,15 @@ const resolveStoreTableId = (
     return name ? (namedStoreTableIds.get(name) ?? null) : null;
   }
 
-  return extractStoreTableNameFromMember(node);
+  const member = extractStoreTableFromMember(node);
+  return member
+    ? makeStoreTableKey(member.storeBinding, member.tableName)
+    : null;
 };
 
 const extractStoreTableDefinitions = (
-  node: AstNode
+  node: AstNode,
+  storeBinding: string | null
 ): readonly StoreTableDefinition[] => {
   if (!isNamedCall(node, 'store')) {
     return [];
@@ -1217,8 +1307,10 @@ const extractStoreTableDefinitions = (
     const versionedProp = findConfigProperty(value, 'versioned');
     return [
       {
+        key: makeStoreTableKey(storeBinding, name),
         name,
         start: property.start,
+        storeBinding,
         versioned: isBooleanLiteral(
           versionedProp?.value as AstNode | undefined
         ),
@@ -1231,9 +1323,34 @@ export const findStoreTableDefinitions = (
   ast: AstNode
 ): readonly StoreTableDefinition[] => {
   const definitions: StoreTableDefinition[] = [];
+  const seenStoreCalls = new WeakSet<AstNode>();
 
+  // First pass: bound stores (walk VariableDeclarators so we know the binding).
   walk(ast, (node) => {
-    definitions.push(...extractStoreTableDefinitions(node));
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+
+    const { id, init } = node as unknown as {
+      readonly id?: AstNode;
+      readonly init?: AstNode;
+    };
+    if (!init || !isNamedCall(init, 'store')) {
+      return;
+    }
+
+    seenStoreCalls.add(init);
+    const storeBinding = extractBindingName(id);
+    definitions.push(...extractStoreTableDefinitions(init, storeBinding));
+  });
+
+  // Second pass: anonymous `store({...})` calls not bound to a variable
+  // (e.g. an inline default export). Use the bare table name as the key.
+  walk(ast, (node) => {
+    if (!isNamedCall(node, 'store') || seenStoreCalls.has(node)) {
+      return;
+    }
+    definitions.push(...extractStoreTableDefinitions(node, null));
   });
 
   return definitions;
@@ -1244,7 +1361,7 @@ export const collectVersionedStoreTableIds = (
 ): ReadonlySet<string> =>
   new Set(
     findStoreTableDefinitions(ast).flatMap((definition) =>
-      definition.versioned ? [definition.name] : []
+      definition.versioned ? [definition.key] : []
     )
   );
 

--- a/packages/warden/src/rules/incomplete-crud.ts
+++ b/packages/warden/src/rules/incomplete-crud.ts
@@ -1,0 +1,308 @@
+import {
+  collectNamedContourIds,
+  collectNamedStoreTableIds,
+  getStringValue,
+  identifierName,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  walk,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const CRUD_OPERATIONS = ['create', 'read', 'update', 'delete', 'list'] as const;
+const CRUD_OPERATION_SET = new Set<string>(CRUD_OPERATIONS);
+
+interface CrudCoverage {
+  readonly entityId: string;
+  readonly line: number;
+  readonly operations: Set<string>;
+}
+
+const isNamedCall = (node: AstNode | undefined, name: string): boolean =>
+  !!node &&
+  node.type === 'CallExpression' &&
+  identifierName((node as unknown as { callee?: AstNode }).callee) === name;
+
+const getMemberExpression = (
+  node: AstNode | undefined
+): { readonly object?: AstNode; readonly property?: AstNode } | null => {
+  if (
+    !node ||
+    (node.type !== 'MemberExpression' && node.type !== 'StaticMemberExpression')
+  ) {
+    return null;
+  }
+
+  return node as unknown as {
+    readonly object?: AstNode;
+    readonly property?: AstNode;
+  };
+};
+
+const getPropertyName = (node: AstNode | undefined): string | null => {
+  if (node?.type === 'Identifier') {
+    return identifierName(node);
+  }
+
+  if (node && isStringLiteral(node)) {
+    return getStringValue(node);
+  }
+
+  return null;
+};
+
+const extractInlineContourId = (node: AstNode | undefined): string | null => {
+  if (!isNamedCall(node, 'contour')) {
+    return null;
+  }
+
+  const [nameArg] = ((node as unknown as { arguments?: readonly AstNode[] })
+    .arguments ?? []) as readonly AstNode[];
+  return nameArg && isStringLiteral(nameArg) ? getStringValue(nameArg) : null;
+};
+
+const resolveContourId = (
+  node: AstNode | undefined,
+  namedContourIds: ReadonlyMap<string, string>
+): string | null => {
+  if (!node) {
+    return null;
+  }
+
+  if (node.type === 'Identifier') {
+    const name = identifierName(node);
+    return name ? (namedContourIds.get(name) ?? null) : null;
+  }
+
+  return extractInlineContourId(node);
+};
+
+const extractStoreTableIdFromMember = (
+  node: AstNode | undefined
+): string | null => {
+  const member = getMemberExpression(node);
+  const tableId = member ? getPropertyName(member.property) : null;
+  const tablesMember = member ? getMemberExpression(member.object) : null;
+  if (!tableId || !tablesMember) {
+    return null;
+  }
+
+  return getPropertyName(tablesMember.property) === 'tables' ? tableId : null;
+};
+
+const resolveStoreTableId = (
+  node: AstNode | undefined,
+  namedStoreTableIds: ReadonlyMap<string, string>
+): string | null => {
+  if (!node) {
+    return null;
+  }
+
+  if (node.type === 'Identifier') {
+    const name = identifierName(node);
+    return name ? (namedStoreTableIds.get(name) ?? null) : null;
+  }
+
+  return extractStoreTableIdFromMember(node);
+};
+
+const ensureCoverage = (
+  coverageByEntityId: Map<string, CrudCoverage>,
+  entityId: string,
+  line: number
+): CrudCoverage => {
+  const existing = coverageByEntityId.get(entityId);
+  if (existing) {
+    return existing;
+  }
+
+  const coverage: CrudCoverage = {
+    entityId,
+    line,
+    operations: new Set<string>(),
+  };
+  coverageByEntityId.set(entityId, coverage);
+  return coverage;
+};
+
+const extractCrudOperation = (node: AstNode | undefined): string | null => {
+  if (!node || !isStringLiteral(node)) {
+    return null;
+  }
+
+  const operation = getStringValue(node);
+  return operation && CRUD_OPERATION_SET.has(operation) ? operation : null;
+};
+
+const extractDerivedCrudEntry = (
+  node: AstNode,
+  namedContourIds: ReadonlyMap<string, string>
+): { readonly entityId: string; readonly operation: string } | null => {
+  if (!isNamedCall(node, 'deriveTrail')) {
+    return null;
+  }
+
+  const [contourArg, operationArg] = ((
+    node as unknown as {
+      arguments?: readonly AstNode[];
+    }
+  ).arguments ?? []) as readonly AstNode[];
+  const operation = extractCrudOperation(operationArg);
+  const entityId = resolveContourId(contourArg, namedContourIds);
+  return operation && entityId ? { entityId, operation } : null;
+};
+
+const collectDerivedCrudCoverage = (
+  ast: AstNode,
+  sourceCode: string
+): ReadonlyMap<string, CrudCoverage> => {
+  const coverageByEntityId = new Map<string, CrudCoverage>();
+  const namedContourIds = collectNamedContourIds(ast);
+
+  walk(ast, (node) => {
+    const entry = extractDerivedCrudEntry(node, namedContourIds);
+    if (!entry) {
+      return;
+    }
+
+    ensureCoverage(
+      coverageByEntityId,
+      entry.entityId,
+      offsetToLine(sourceCode, node.start)
+    ).operations.add(entry.operation);
+  });
+
+  return coverageByEntityId;
+};
+
+const collectTupleOperations = (
+  elements: readonly AstNode[]
+): readonly string[] =>
+  CRUD_OPERATIONS.flatMap((operation, index) =>
+    elements[index] ? [operation] : []
+  );
+
+const extractCrudTuplePattern = (
+  node: AstNode,
+  namedStoreTableIds: ReadonlyMap<string, string>
+): {
+  readonly elements: readonly AstNode[];
+  readonly entityId: string;
+} | null => {
+  if (node.type !== 'VariableDeclarator') {
+    return null;
+  }
+
+  const { id, init } = node as unknown as {
+    readonly id?: AstNode;
+    readonly init?: AstNode;
+  };
+  if (!id || id.type !== 'ArrayPattern' || !isNamedCall(init, 'crud')) {
+    return null;
+  }
+
+  const [tableArg] = ((init as unknown as { arguments?: readonly AstNode[] })
+    .arguments ?? []) as readonly AstNode[];
+  const entityId = resolveStoreTableId(tableArg, namedStoreTableIds);
+  const { elements } = id as unknown as { elements?: readonly AstNode[] };
+  return entityId && elements ? { elements, entityId } : null;
+};
+
+const extractCrudTupleEntry = (
+  node: AstNode,
+  namedStoreTableIds: ReadonlyMap<string, string>
+): {
+  readonly entityId: string;
+  readonly operations: readonly string[];
+} | null => {
+  const pattern = extractCrudTuplePattern(node, namedStoreTableIds);
+  if (!pattern) {
+    return null;
+  }
+
+  return {
+    entityId: pattern.entityId,
+    operations: collectTupleOperations(pattern.elements),
+  };
+};
+
+const collectCrudTupleCoverage = (
+  ast: AstNode,
+  sourceCode: string
+): ReadonlyMap<string, CrudCoverage> => {
+  const coverageByEntityId = new Map<string, CrudCoverage>();
+  const namedStoreTableIds = collectNamedStoreTableIds(ast);
+
+  walk(ast, (node) => {
+    const entry = extractCrudTupleEntry(node, namedStoreTableIds);
+    if (!entry) {
+      return;
+    }
+
+    const coverage = ensureCoverage(
+      coverageByEntityId,
+      entry.entityId,
+      offsetToLine(sourceCode, node.start)
+    );
+
+    for (const operation of entry.operations) {
+      coverage.operations.add(operation);
+    }
+  });
+
+  return coverageByEntityId;
+};
+
+const collectIncompleteCoverage = (
+  coverageByEntityId: ReadonlyMap<string, CrudCoverage>
+): readonly CrudCoverage[] =>
+  [...coverageByEntityId.values()].filter(
+    (coverage) =>
+      coverage.operations.size > 0 &&
+      coverage.operations.size < CRUD_OPERATIONS.length
+  );
+
+const buildIncompleteCrudDiagnostic = (
+  coverage: CrudCoverage,
+  filePath: string
+): WardenDiagnostic => {
+  const present = CRUD_OPERATIONS.filter((operation) =>
+    coverage.operations.has(operation)
+  );
+  const missing = CRUD_OPERATIONS.filter(
+    (operation) => !coverage.operations.has(operation)
+  );
+
+  return {
+    filePath,
+    line: coverage.line,
+    message: `Factory coverage for "${coverage.entityId}" is incomplete: found ${present.join(', ')} but missing ${missing.join(', ')}. Prefer the full CRUD set or document the intentional omission.`,
+    rule: 'incomplete-crud',
+    severity: 'warn',
+  };
+};
+
+export const incompleteCrud: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isTestFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    return [
+      ...collectIncompleteCoverage(collectDerivedCrudCoverage(ast, sourceCode)),
+      ...collectIncompleteCoverage(collectCrudTupleCoverage(ast, sourceCode)),
+    ].map((coverage) => buildIncompleteCrudDiagnostic(coverage, filePath));
+  },
+  description:
+    'Warn when factory-style CRUD authoring covers only part of the standard create/read/update/delete/list set. This rule is file-scoped: all operations for an entity must be colocated in the same file for the rule to correctly assess completeness. One-file-per-operation layouts (e.g. deriveTrail in separate create.ts, read.ts, etc.) may produce false positives.',
+  name: 'incomplete-crud',
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/incomplete-crud.ts
+++ b/packages/warden/src/rules/incomplete-crud.ts
@@ -1,11 +1,14 @@
 import {
+  collectImportAliasMap,
   collectNamedContourIds,
   collectNamedStoreTableIds,
   getStringValue,
   identifierName,
+  isNamedCall,
   isStringLiteral,
   offsetToLine,
   parse,
+  resolveStoreTableId,
   walk,
 } from './ast.js';
 import type { AstNode } from './ast.js';
@@ -15,44 +18,14 @@ import type { WardenDiagnostic, WardenRule } from './types.js';
 const CRUD_OPERATIONS = ['create', 'read', 'update', 'delete', 'list'] as const;
 const CRUD_OPERATION_SET = new Set<string>(CRUD_OPERATIONS);
 
+/** Sentinel entity id prefix for contours imported from another module. */
+const IMPORTED_CONTOUR_PREFIX = 'imported:';
+
 interface CrudCoverage {
   readonly entityId: string;
   readonly line: number;
   readonly operations: Set<string>;
 }
-
-const isNamedCall = (node: AstNode | undefined, name: string): boolean =>
-  !!node &&
-  node.type === 'CallExpression' &&
-  identifierName((node as unknown as { callee?: AstNode }).callee) === name;
-
-const getMemberExpression = (
-  node: AstNode | undefined
-): { readonly object?: AstNode; readonly property?: AstNode } | null => {
-  if (
-    !node ||
-    (node.type !== 'MemberExpression' && node.type !== 'StaticMemberExpression')
-  ) {
-    return null;
-  }
-
-  return node as unknown as {
-    readonly object?: AstNode;
-    readonly property?: AstNode;
-  };
-};
-
-const getPropertyName = (node: AstNode | undefined): string | null => {
-  if (node?.type === 'Identifier') {
-    return identifierName(node);
-  }
-
-  if (node && isStringLiteral(node)) {
-    return getStringValue(node);
-  }
-
-  return null;
-};
 
 const extractInlineContourId = (node: AstNode | undefined): string | null => {
   if (!isNamedCall(node, 'contour')) {
@@ -64,9 +37,43 @@ const extractInlineContourId = (node: AstNode | undefined): string | null => {
   return nameArg && isStringLiteral(nameArg) ? getStringValue(nameArg) : null;
 };
 
+/**
+ * Resolve an identifier reference (bound contour or imported alias) to a
+ * stable entity id. Imported identifiers return a `pending-resolution`
+ * sentinel so coverage is still tracked instead of silently dropped.
+ */
+const resolveContourIdentifier = (
+  name: string,
+  namedContourIds: ReadonlyMap<string, string>,
+  importAliases: ReadonlyMap<string, string>
+): string | null => {
+  const local = namedContourIds.get(name);
+  if (local) {
+    return local;
+  }
+
+  if (importAliases.has(name)) {
+    return `${IMPORTED_CONTOUR_PREFIX}${importAliases.get(name) ?? name}`;
+  }
+
+  return null;
+};
+
+/**
+ * Resolve a `deriveTrail` contour argument to a stable entity id.
+ *
+ * Resolution order:
+ *   1. Inline `contour('name', …)` call — use the authored name.
+ *   2. Local identifier bound to `contour('name', …)` via `namedContourIds`.
+ *   3. Identifier imported from another module — mark as a pending
+ *      `imported:<local>` coverage observation so the rule still tracks the
+ *      entity across the file instead of silently dropping it. The prefix is
+ *      stripped from diagnostic output for readability.
+ */
 const resolveContourId = (
   node: AstNode | undefined,
-  namedContourIds: ReadonlyMap<string, string>
+  namedContourIds: ReadonlyMap<string, string>,
+  importAliases: ReadonlyMap<string, string>
 ): string | null => {
   if (!node) {
     return null;
@@ -74,39 +81,12 @@ const resolveContourId = (
 
   if (node.type === 'Identifier') {
     const name = identifierName(node);
-    return name ? (namedContourIds.get(name) ?? null) : null;
+    return name
+      ? resolveContourIdentifier(name, namedContourIds, importAliases)
+      : null;
   }
 
   return extractInlineContourId(node);
-};
-
-const extractStoreTableIdFromMember = (
-  node: AstNode | undefined
-): string | null => {
-  const member = getMemberExpression(node);
-  const tableId = member ? getPropertyName(member.property) : null;
-  const tablesMember = member ? getMemberExpression(member.object) : null;
-  if (!tableId || !tablesMember) {
-    return null;
-  }
-
-  return getPropertyName(tablesMember.property) === 'tables' ? tableId : null;
-};
-
-const resolveStoreTableId = (
-  node: AstNode | undefined,
-  namedStoreTableIds: ReadonlyMap<string, string>
-): string | null => {
-  if (!node) {
-    return null;
-  }
-
-  if (node.type === 'Identifier') {
-    const name = identifierName(node);
-    return name ? (namedStoreTableIds.get(name) ?? null) : null;
-  }
-
-  return extractStoreTableIdFromMember(node);
 };
 
 const ensureCoverage = (
@@ -139,7 +119,8 @@ const extractCrudOperation = (node: AstNode | undefined): string | null => {
 
 const extractDerivedCrudEntry = (
   node: AstNode,
-  namedContourIds: ReadonlyMap<string, string>
+  namedContourIds: ReadonlyMap<string, string>,
+  importAliases: ReadonlyMap<string, string>
 ): { readonly entityId: string; readonly operation: string } | null => {
   if (!isNamedCall(node, 'deriveTrail')) {
     return null;
@@ -151,7 +132,7 @@ const extractDerivedCrudEntry = (
     }
   ).arguments ?? []) as readonly AstNode[];
   const operation = extractCrudOperation(operationArg);
-  const entityId = resolveContourId(contourArg, namedContourIds);
+  const entityId = resolveContourId(contourArg, namedContourIds, importAliases);
   return operation && entityId ? { entityId, operation } : null;
 };
 
@@ -161,9 +142,10 @@ const collectDerivedCrudCoverage = (
 ): ReadonlyMap<string, CrudCoverage> => {
   const coverageByEntityId = new Map<string, CrudCoverage>();
   const namedContourIds = collectNamedContourIds(ast);
+  const importAliases = collectImportAliasMap(ast);
 
   walk(ast, (node) => {
-    const entry = extractDerivedCrudEntry(node, namedContourIds);
+    const entry = extractDerivedCrudEntry(node, namedContourIds, importAliases);
     if (!entry) {
       return;
     }
@@ -181,6 +163,10 @@ const collectDerivedCrudCoverage = (
 const collectTupleOperations = (
   elements: readonly AstNode[]
 ): readonly string[] =>
+  // Array-pattern elisions are represented as null by OXC today; the truthy
+  // check below intentionally treats those the same as out-of-bounds slots.
+  // If OXC ever switches to a non-null placeholder node, update this to an
+  // explicit null check so elisions still count as absent.
   CRUD_OPERATIONS.flatMap((operation, index) =>
     elements[index] ? [operation] : []
   );
@@ -265,6 +251,11 @@ const collectIncompleteCoverage = (
       coverage.operations.size < CRUD_OPERATIONS.length
   );
 
+const formatEntityLabel = (entityId: string): string =>
+  entityId.startsWith(IMPORTED_CONTOUR_PREFIX)
+    ? `${entityId.slice(IMPORTED_CONTOUR_PREFIX.length)} (imported, pending-resolution)`
+    : entityId;
+
 const buildIncompleteCrudDiagnostic = (
   coverage: CrudCoverage,
   filePath: string
@@ -279,7 +270,7 @@ const buildIncompleteCrudDiagnostic = (
   return {
     filePath,
     line: coverage.line,
-    message: `Factory coverage for "${coverage.entityId}" is incomplete: found ${present.join(', ')} but missing ${missing.join(', ')}. Prefer the full CRUD set or document the intentional omission.`,
+    message: `Factory coverage for "${formatEntityLabel(coverage.entityId)}" is incomplete: found ${present.join(', ')} but missing ${missing.join(', ')}. Prefer the full CRUD set or document the intentional omission.`,
     rule: 'incomplete-crud',
     severity: 'warn',
   };

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -9,14 +9,17 @@ import { errorMappingCompleteness } from './error-mapping-completeness.js';
 import { exampleValid } from './example-valid.js';
 import { firesDeclarations } from './fires-declarations.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
+import { incompleteCrud } from './incomplete-crud.js';
 import { intentPropagation } from './intent-propagation.js';
 import { missingVisibility } from './missing-visibility.js';
+import { missingReconcile } from './missing-reconcile.js';
 import { noDirectImplInRoute } from './no-direct-impl-in-route.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
 import { onReferencesExist } from './on-references-exist.js';
+import { orphanedSignal } from './orphaned-signal.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
 import { referenceExists } from './reference-exists.js';
 import { resourceDeclarations } from './resource-declarations.js';
@@ -44,8 +47,10 @@ export { draftVisibleDebt } from './draft-visible-debt.js';
 export { errorMappingCompleteness } from './error-mapping-completeness.js';
 export { exampleValid } from './example-valid.js';
 export { firesDeclarations } from './fires-declarations.js';
+export { incompleteCrud } from './incomplete-crud.js';
 export { intentPropagation } from './intent-propagation.js';
 export { missingVisibility } from './missing-visibility.js';
+export { missingReconcile } from './missing-reconcile.js';
 export { onReferencesExist } from './on-references-exist.js';
 export { validDetourRefs } from './valid-detour-refs.js';
 export { noDirectImplInRoute } from './no-direct-impl-in-route.js';
@@ -53,6 +58,7 @@ export { noDirectImplementationCall } from './no-direct-implementation-call.js';
 export { noSyncResultAssumption } from './no-sync-result-assumption.js';
 export { implementationReturnsResult } from './implementation-returns-result.js';
 export { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
+export { orphanedSignal } from './orphaned-signal.js';
 export { preferSchemaInference } from './prefer-schema-inference.js';
 export { referenceExists } from './reference-exists.js';
 export { resourceDeclarations } from './resource-declarations.js';
@@ -75,9 +81,12 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [errorMappingCompleteness.name, errorMappingCompleteness],
   [exampleValid.name, exampleValid],
   [firesDeclarations.name, firesDeclarations],
+  [incompleteCrud.name, incompleteCrud],
   [intentPropagation.name, intentPropagation],
   [missingVisibility.name, missingVisibility],
+  [missingReconcile.name, missingReconcile],
   [onReferencesExist.name, onReferencesExist],
+  [orphanedSignal.name, orphanedSignal],
   [resourceDeclarations.name, resourceDeclarations],
   [referenceExists.name, referenceExists],
   [resourceExists.name, resourceExists],

--- a/packages/warden/src/rules/missing-reconcile.ts
+++ b/packages/warden/src/rules/missing-reconcile.ts
@@ -1,0 +1,98 @@
+import {
+  collectCrudTableIds,
+  collectReconcileTableIds,
+  findStoreTableDefinitions,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+const buildMissingReconcileDiagnostic = (
+  tableId: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Versioned store table "${tableId}" is used with CRUD factories but has no reconcile trail. Add reconcile(...) to complete the versioned store pattern.`,
+  rule: 'missing-reconcile',
+  severity: 'warn',
+});
+
+const checkMissingReconcile = (
+  ast: AstNode | null,
+  sourceCode: string,
+  filePath: string,
+  crudTableIds: ReadonlySet<string>,
+  reconcileTableIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath) || !ast) {
+    return [];
+  }
+
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const definition of findStoreTableDefinitions(ast)) {
+    if (
+      !definition.versioned ||
+      !crudTableIds.has(definition.name) ||
+      reconcileTableIds.has(definition.name)
+    ) {
+      continue;
+    }
+
+    diagnostics.push(
+      buildMissingReconcileDiagnostic(
+        definition.name,
+        filePath,
+        offsetToLine(sourceCode, definition.start)
+      )
+    );
+  }
+
+  return diagnostics;
+};
+
+export const missingReconcile: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    return checkMissingReconcile(
+      ast,
+      sourceCode,
+      filePath,
+      ast ? collectCrudTableIds(ast) : new Set<string>(),
+      ast ? collectReconcileTableIds(ast) : new Set<string>()
+    );
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    const localCrudTableIds = ast
+      ? collectCrudTableIds(ast)
+      : new Set<string>();
+    const localReconcileTableIds = ast
+      ? collectReconcileTableIds(ast)
+      : new Set<string>();
+
+    return checkMissingReconcile(
+      ast,
+      sourceCode,
+      filePath,
+      context.crudTableIds ?? localCrudTableIds,
+      context.reconcileTableIds ?? localReconcileTableIds
+    );
+  },
+  description:
+    'Warn when a versioned store table participates in CRUD factory generation without a matching reconcile trail.',
+  name: 'missing-reconcile',
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/missing-reconcile.ts
+++ b/packages/warden/src/rules/missing-reconcile.ts
@@ -41,8 +41,8 @@ const checkMissingReconcile = (
   for (const definition of findStoreTableDefinitions(ast)) {
     if (
       !definition.versioned ||
-      !crudTableIds.has(definition.name) ||
-      reconcileTableIds.has(definition.name)
+      !crudTableIds.has(definition.key) ||
+      reconcileTableIds.has(definition.key)
     ) {
       continue;
     }

--- a/packages/warden/src/rules/orphaned-signal.ts
+++ b/packages/warden/src/rules/orphaned-signal.ts
@@ -1,0 +1,129 @@
+import {
+  collectCrudTableIds,
+  collectOnTargetSignalIds,
+  findStoreTableDefinitions,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+const CHANGE_SIGNAL_OPERATIONS = ['created', 'updated', 'removed'] as const;
+
+const buildOrphanedSignalDiagnostic = (
+  tableId: string,
+  missingSignalIds: readonly string[],
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Store table "${tableId}" derives change signals with no trail listeners: ${missingSignalIds.join(', ')}. Add trail on: consumers or remove the unused reactive pattern.`,
+  rule: 'orphaned-signal',
+  severity: 'warn',
+});
+
+const getMissingSignalIds = (
+  tableId: string,
+  onTargetSignalIds: ReadonlySet<string>
+): readonly string[] =>
+  CHANGE_SIGNAL_OPERATIONS.map((operation) => `${tableId}.${operation}`).filter(
+    (signalId) => !onTargetSignalIds.has(signalId)
+  );
+
+const buildDefinitionDiagnostic = (
+  definition: ReturnType<typeof findStoreTableDefinitions>[number],
+  sourceCode: string,
+  filePath: string,
+  crudTableIds: ReadonlySet<string>,
+  onTargetSignalIds: ReadonlySet<string>
+): WardenDiagnostic | null => {
+  if (!crudTableIds.has(definition.name)) {
+    return null;
+  }
+
+  const missingSignalIds = getMissingSignalIds(
+    definition.name,
+    onTargetSignalIds
+  );
+  return missingSignalIds.length === 0
+    ? null
+    : buildOrphanedSignalDiagnostic(
+        definition.name,
+        missingSignalIds,
+        filePath,
+        offsetToLine(sourceCode, definition.start)
+      );
+};
+
+const checkOrphanedSignals = (
+  ast: AstNode | null,
+  sourceCode: string,
+  filePath: string,
+  crudTableIds: ReadonlySet<string>,
+  onTargetSignalIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath) || !ast) {
+    return [];
+  }
+
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const definition of findStoreTableDefinitions(ast)) {
+    const diagnostic = buildDefinitionDiagnostic(
+      definition,
+      sourceCode,
+      filePath,
+      crudTableIds,
+      onTargetSignalIds
+    );
+    if (diagnostic) {
+      diagnostics.push(diagnostic);
+    }
+  }
+
+  return diagnostics;
+};
+
+export const orphanedSignal: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    return checkOrphanedSignals(
+      ast,
+      sourceCode,
+      filePath,
+      ast ? collectCrudTableIds(ast) : new Set<string>(),
+      ast ? collectOnTargetSignalIds(ast, sourceCode) : new Set<string>()
+    );
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    const localCrudTableIds = ast
+      ? collectCrudTableIds(ast)
+      : new Set<string>();
+    const localOnTargetSignalIds = ast
+      ? collectOnTargetSignalIds(ast, sourceCode)
+      : new Set<string>();
+
+    return checkOrphanedSignals(
+      ast,
+      sourceCode,
+      filePath,
+      context.crudTableIds ?? localCrudTableIds,
+      context.onTargetSignalIds ?? localOnTargetSignalIds
+    );
+  },
+  description:
+    'Warn when CRUD-backed store change signals are never consumed by trail on: declarations.',
+  name: 'orphaned-signal',
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/orphaned-signal.ts
+++ b/packages/warden/src/rules/orphaned-signal.ts
@@ -33,7 +33,11 @@ const getMissingSignalIds = (
   onTargetSignalIds: ReadonlySet<string>
 ): readonly string[] =>
   CHANGE_SIGNAL_OPERATIONS.map((operation) => `${tableId}.${operation}`).filter(
-    (signalId) => !onTargetSignalIds.has(signalId)
+    (signalId) =>
+      !onTargetSignalIds.has(signalId) &&
+      // Bare-name fallback: string-literal `on:` consumers store the signal
+      // without the composite `${storeBinding}:` prefix.
+      !onTargetSignalIds.has(signalId.replace(/^[^:]+:/, ''))
   );
 
 /**

--- a/packages/warden/src/rules/orphaned-signal.ts
+++ b/packages/warden/src/rules/orphaned-signal.ts
@@ -36,6 +36,21 @@ const getMissingSignalIds = (
     (signalId) => !onTargetSignalIds.has(signalId)
   );
 
+/**
+ * Strip the `${storeBinding}:` prefix from a composite signal id for display.
+ * Keeps diagnostic messages readable while keeping keys composite internally.
+ */
+const stripStoreBinding = (
+  signalId: string,
+  storeBinding: string | null
+): string => {
+  if (!storeBinding) {
+    return signalId;
+  }
+  const prefix = `${storeBinding}:`;
+  return signalId.startsWith(prefix) ? signalId.slice(prefix.length) : signalId;
+};
+
 const buildDefinitionDiagnostic = (
   definition: ReturnType<typeof findStoreTableDefinitions>[number],
   sourceCode: string,
@@ -43,19 +58,21 @@ const buildDefinitionDiagnostic = (
   crudTableIds: ReadonlySet<string>,
   onTargetSignalIds: ReadonlySet<string>
 ): WardenDiagnostic | null => {
-  if (!crudTableIds.has(definition.name)) {
+  if (!crudTableIds.has(definition.key)) {
     return null;
   }
 
   const missingSignalIds = getMissingSignalIds(
-    definition.name,
+    definition.key,
     onTargetSignalIds
   );
   return missingSignalIds.length === 0
     ? null
     : buildOrphanedSignalDiagnostic(
         definition.name,
-        missingSignalIds,
+        missingSignalIds.map((id) =>
+          stripStoreBinding(id, definition.storeBinding)
+        ),
         filePath,
         offsetToLine(sourceCode, definition.start)
       );

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -45,6 +45,8 @@ export interface WardenRule {
 export interface ProjectContext {
   /** All known contour names in the project. */
   readonly knownContourIds?: ReadonlySet<string>;
+  /** Store table IDs used with the CRUD factory across the project. */
+  readonly crudTableIds?: ReadonlySet<string>;
   /** All known trail IDs in the project */
   readonly knownTrailIds: ReadonlySet<string>;
   /** Declared contour references keyed by source contour name. */
@@ -57,6 +59,10 @@ export interface ProjectContext {
   readonly detourTargetTrailIds?: ReadonlySet<string>;
   /** All trail IDs referenced by declared crosses arrays across the project. */
   readonly crossTargetTrailIds?: ReadonlySet<string>;
+  /** Signal IDs referenced by trail `on` arrays across the project. */
+  readonly onTargetSignalIds?: ReadonlySet<string>;
+  /** Store table IDs used with reconcile trails across the project. */
+  readonly reconcileTableIds?: ReadonlySet<string>;
   /** Normalized trail intents by trail ID across the project. */
   readonly trailIntentsById?: ReadonlyMap<string, 'destroy' | 'read' | 'write'>;
 }

--- a/packages/warden/src/trails/incomplete-crud.trail.ts
+++ b/packages/warden/src/trails/incomplete-crud.trail.ts
@@ -1,0 +1,39 @@
+import { incompleteCrud } from '../rules/incomplete-crud.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const incompleteCrudTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        sourceCode: `import { Result, resource } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+const db = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  },
+});
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const [createNote, readNote, updateNote, deleteNote, listNote] = crud(
+  db.tables.notes,
+  notesResource
+);`,
+      },
+      name: 'Full CRUD coverage stays quiet',
+    },
+  ],
+  rule: incompleteCrud,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -7,14 +7,17 @@ export { errorMappingCompletenessTrail } from './error-mapping-completeness.trai
 export { exampleValidTrail } from './example-valid.trail.js';
 export { firesDeclarationsTrail } from './fires-declarations.trail.js';
 export { implementationReturnsResultTrail } from './implementation-returns-result.trail.js';
+export { incompleteCrudTrail } from './incomplete-crud.trail.js';
 export { intentPropagationTrail } from './intent-propagation.trail.js';
 export { missingVisibilityTrail } from './missing-visibility.trail.js';
+export { missingReconcileTrail } from './missing-reconcile.trail.js';
 export { onReferencesExistTrail } from './on-references-exist.trail.js';
 export { noDirectImplInRouteTrail } from './no-direct-impl-in-route.trail.js';
 export { noDirectImplementationCallTrail } from './no-direct-implementation-call.trail.js';
 export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.js';
 export { noThrowInDetourTargetTrail } from './no-throw-in-detour-target.trail.js';
 export { noThrowInImplementationTrail } from './no-throw-in-implementation.trail.js';
+export { orphanedSignalTrail } from './orphaned-signal.trail.js';
 export { preferSchemaInferenceTrail } from './prefer-schema-inference.trail.js';
 export { referenceExistsTrail } from './reference-exists.trail.js';
 export { resourceDeclarationsTrail } from './resource-declarations.trail.js';

--- a/packages/warden/src/trails/missing-reconcile.trail.ts
+++ b/packages/warden/src/trails/missing-reconcile.trail.ts
@@ -6,10 +6,12 @@ export const missingReconcileTrail = wrapRule({
     {
       expected: { diagnostics: [] },
       input: {
-        crudTableIds: ['notes'],
+        // Composite keys: `${storeBinding}:${tableName}` so two stores with
+        // the same table name don't collide.
+        crudTableIds: ['definition:notes'],
         filePath: 'clean.ts',
         knownTrailIds: ['notes.reconcile'],
-        reconcileTableIds: ['notes'],
+        reconcileTableIds: ['definition:notes'],
         sourceCode: `import { store } from '@ontrails/store';
 import { z } from 'zod';
 

--- a/packages/warden/src/trails/missing-reconcile.trail.ts
+++ b/packages/warden/src/trails/missing-reconcile.trail.ts
@@ -1,0 +1,31 @@
+import { missingReconcile } from '../rules/missing-reconcile.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const missingReconcileTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        crudTableIds: ['notes'],
+        filePath: 'clean.ts',
+        knownTrailIds: ['notes.reconcile'],
+        reconcileTableIds: ['notes'],
+        sourceCode: `import { store } from '@ontrails/store';
+import { z } from 'zod';
+
+const definition = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+    versioned: true,
+  },
+});`,
+      },
+      name: 'Versioned CRUD tables stay clean when reconcile exists',
+    },
+  ],
+  rule: missingReconcile,
+});

--- a/packages/warden/src/trails/orphaned-signal.trail.ts
+++ b/packages/warden/src/trails/orphaned-signal.trail.ts
@@ -1,0 +1,30 @@
+import { orphanedSignal } from '../rules/orphaned-signal.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const orphanedSignalTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        crudTableIds: ['notes'],
+        filePath: 'clean.ts',
+        knownTrailIds: ['notes.notify'],
+        onTargetSignalIds: ['notes.created', 'notes.updated', 'notes.removed'],
+        sourceCode: `import { store } from '@ontrails/store';
+import { z } from 'zod';
+
+const definition = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  },
+});`,
+      },
+      name: 'Derived store signals stay quiet when trail listeners exist',
+    },
+  ],
+  rule: orphanedSignal,
+});

--- a/packages/warden/src/trails/orphaned-signal.trail.ts
+++ b/packages/warden/src/trails/orphaned-signal.trail.ts
@@ -6,10 +6,16 @@ export const orphanedSignalTrail = wrapRule({
     {
       expected: { diagnostics: [] },
       input: {
-        crudTableIds: ['notes'],
+        // Composite keys: `${storeBinding}:${tableName}` so two stores with
+        // the same table name don't collide.
+        crudTableIds: ['definition:notes'],
         filePath: 'clean.ts',
         knownTrailIds: ['notes.notify'],
-        onTargetSignalIds: ['notes.created', 'notes.updated', 'notes.removed'],
+        onTargetSignalIds: [
+          'definition:notes.created',
+          'definition:notes.updated',
+          'definition:notes.removed',
+        ],
         sourceCode: `import { store } from '@ontrails/store';
 import { z } from 'zod';
 

--- a/packages/warden/src/trails/run.ts
+++ b/packages/warden/src/trails/run.ts
@@ -25,124 +25,78 @@ const appendDiagnostics = (
   }
 };
 
-const hasProjectOptions = (
-  options:
-    | {
-        readonly contourReferencesByName?: Readonly<
-          Record<string, readonly string[]>
-        >;
-        readonly crossTargetTrailIds?: readonly string[];
-        readonly detourTargetTrailIds?: readonly string[];
-        readonly knownContourIds?: readonly string[];
-        readonly knownResourceIds?: readonly string[];
-        readonly knownSignalIds?: readonly string[];
-        readonly knownTrailIds?: readonly string[];
-        readonly trailIntentsById?: Readonly<
-          Record<string, 'destroy' | 'read' | 'write'>
-        >;
-      }
-    | undefined
-): boolean =>
+type TrailIntentMap = Readonly<Record<string, 'destroy' | 'read' | 'write'>>;
+
+interface ProjectRuleOptions {
+  readonly contourReferencesByName?: Readonly<
+    Record<string, readonly string[]>
+  >;
+  readonly crossTargetTrailIds?: readonly string[];
+  readonly crudTableIds?: readonly string[];
+  readonly detourTargetTrailIds?: readonly string[];
+  readonly knownContourIds?: readonly string[];
+  readonly knownResourceIds?: readonly string[];
+  readonly knownSignalIds?: readonly string[];
+  readonly knownTrailIds?: readonly string[];
+  readonly onTargetSignalIds?: readonly string[];
+  readonly reconcileTableIds?: readonly string[];
+  readonly trailIntentsById?: TrailIntentMap;
+}
+
+const PROJECT_OPTION_KEYS = [
+  'contourReferencesByName',
+  'crossTargetTrailIds',
+  'crudTableIds',
+  'detourTargetTrailIds',
+  'knownContourIds',
+  'knownResourceIds',
+  'knownSignalIds',
+  'knownTrailIds',
+  'onTargetSignalIds',
+  'reconcileTableIds',
+  'trailIntentsById',
+] as const satisfies readonly (keyof ProjectRuleOptions)[];
+
+const hasProjectOptions = (options?: ProjectRuleOptions): boolean =>
   Boolean(
-    options?.contourReferencesByName ||
-    options?.crossTargetTrailIds ||
-    options?.detourTargetTrailIds ||
-    options?.knownContourIds ||
-    options?.knownResourceIds ||
-    options?.knownSignalIds ||
-    options?.knownTrailIds ||
-    options?.trailIntentsById
+    options && PROJECT_OPTION_KEYS.some((key) => options[key] !== undefined)
   );
+
+const collectProjectOptions = (
+  options?: ProjectRuleOptions
+): ProjectRuleOptions => {
+  if (!options) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    PROJECT_OPTION_KEYS.flatMap((key) => {
+      const value = options[key];
+      return value === undefined ? [] : [[key, value] as const];
+    })
+  ) as ProjectRuleOptions;
+};
 
 const buildRuleInput = (
   filePath: string,
   sourceCode: string,
-  options:
-    | {
-        readonly contourReferencesByName?: Readonly<
-          Record<string, readonly string[]>
-        >;
-        readonly crossTargetTrailIds?: readonly string[];
-        readonly detourTargetTrailIds?: readonly string[];
-        readonly knownContourIds?: readonly string[];
-        readonly knownResourceIds?: readonly string[];
-        readonly knownSignalIds?: readonly string[];
-        readonly knownTrailIds?: readonly string[];
-        readonly trailIntentsById?: Readonly<
-          Record<string, 'destroy' | 'read' | 'write'>
-        >;
-      }
-    | undefined
-):
-  | {
-      readonly filePath: string;
-      readonly sourceCode: string;
-    }
-  | {
-      readonly contourReferencesByName?: Readonly<
-        Record<string, readonly string[]>
-      >;
-      readonly crossTargetTrailIds?: readonly string[];
-      readonly detourTargetTrailIds?: readonly string[];
-      readonly filePath: string;
-      readonly knownContourIds?: readonly string[];
-      readonly knownResourceIds?: readonly string[];
-      readonly knownSignalIds?: readonly string[];
-      readonly knownTrailIds?: readonly string[];
-      readonly sourceCode: string;
-      readonly trailIntentsById?: Readonly<
-        Record<string, 'destroy' | 'read' | 'write'>
-      >;
-    } => {
+  options?: ProjectRuleOptions
+): {
+  readonly filePath: string;
+  readonly sourceCode: string;
+} & ProjectRuleOptions => {
   const base = { filePath, sourceCode };
   if (!hasProjectOptions(options)) {
     return base;
   }
 
-  return {
-    ...base,
-    ...(options?.contourReferencesByName
-      ? { contourReferencesByName: options.contourReferencesByName }
-      : {}),
-    ...(options?.crossTargetTrailIds
-      ? { crossTargetTrailIds: options.crossTargetTrailIds }
-      : {}),
-    ...(options?.detourTargetTrailIds
-      ? { detourTargetTrailIds: options.detourTargetTrailIds }
-      : {}),
-    ...(options?.knownContourIds
-      ? { knownContourIds: options.knownContourIds }
-      : {}),
-    ...(options?.knownResourceIds
-      ? { knownResourceIds: options.knownResourceIds }
-      : {}),
-    ...(options?.knownSignalIds
-      ? { knownSignalIds: options.knownSignalIds }
-      : {}),
-    ...(options?.knownTrailIds ? { knownTrailIds: options.knownTrailIds } : {}),
-    ...(options?.trailIntentsById
-      ? { trailIntentsById: options.trailIntentsById }
-      : {}),
-  };
+  return { ...base, ...collectProjectOptions(options) };
 };
 
 export const runWardenTrails = async (
   filePath: string,
   sourceCode: string,
-  options?: {
-    readonly contourReferencesByName?: Readonly<
-      Record<string, readonly string[]>
-    >;
-    readonly crossTargetTrailIds?: readonly string[];
-    readonly detourTargetTrailIds?: readonly string[];
-    readonly knownContourIds?: readonly string[];
-    readonly knownResourceIds?: readonly string[];
-    readonly knownSignalIds?: readonly string[];
-    readonly knownTrailIds?: readonly string[];
-    readonly trailIntentsById?: Readonly<
-      Record<string, 'destroy' | 'read' | 'write'>
-    >;
-  }
+  options?: ProjectRuleOptions
 ): Promise<readonly WardenDiagnostic[]> => {
   const allDiagnostics: WardenDiagnostic[] = [];
   const input = buildRuleInput(filePath, sourceCode, options);

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -38,6 +38,10 @@ export const projectAwareRuleInput = ruleInput.extend({
     .array(z.string())
     .optional()
     .describe('Trail IDs referenced by crosses arrays across the project'),
+  crudTableIds: z
+    .array(z.string())
+    .optional()
+    .describe('Store table IDs used with CRUD factories across the project'),
   detourTargetTrailIds: z
     .array(z.string())
     .optional()
@@ -58,6 +62,14 @@ export const projectAwareRuleInput = ruleInput.extend({
     .array(z.string())
     .optional()
     .describe('Trail IDs known across the project'),
+  onTargetSignalIds: z
+    .array(z.string())
+    .optional()
+    .describe('Signal IDs referenced by trail on arrays across the project'),
+  reconcileTableIds: z
+    .array(z.string())
+    .optional()
+    .describe('Store table IDs used with reconcile trails across the project'),
   trailIntentsById: z
     .record(z.string(), z.enum(['read', 'write', 'destroy']))
     .optional()

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -37,6 +37,7 @@ const buildProjectContext = (input: ProjectAwareRuleInput): ProjectContext => ({
         ),
       }
     : {}),
+  ...(input.crudTableIds ? { crudTableIds: new Set(input.crudTableIds) } : {}),
   ...(input.knownContourIds
     ? { knownContourIds: new Set(input.knownContourIds) }
     : {}),
@@ -54,6 +55,12 @@ const buildProjectContext = (input: ProjectAwareRuleInput): ProjectContext => ({
     : {}),
   ...(input.knownSignalIds
     ? { knownSignalIds: new Set(input.knownSignalIds) }
+    : {}),
+  ...(input.onTargetSignalIds
+    ? { onTargetSignalIds: new Set(input.onTargetSignalIds) }
+    : {}),
+  ...(input.reconcileTableIds
+    ? { reconcileTableIds: new Set(input.reconcileTableIds) }
     : {}),
   ...(input.trailIntentsById
     ? { trailIntentsById: new Map(Object.entries(input.trailIntentsById)) }


### PR DESCRIPTION
## Summary

- add `incomplete-crud`, `missing-reconcile`, and `orphaned-signal` rules to `@ontrails/warden`
- extend warden project context so factory completeness checks can reason across files
- add focused rule coverage plus a CLI integration test for cross-file detection

## Testing

- bun test packages/warden/src/__tests__/incomplete-crud.test.ts
- bun test packages/warden/src/__tests__/missing-reconcile.test.ts
- bun test packages/warden/src/__tests__/orphaned-signal.test.ts
- bun test packages/warden/src/__tests__/trails.test.ts
- bun test packages/warden/src/__tests__/cli.test.ts
- bun run --cwd packages/warden test
- bun run --cwd packages/warden typecheck
- bun run --cwd packages/warden lint

## Closes

Closes TRL-251
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
