### PR TITLE
refactor: drop with-* prefix and reorganize connectors [TRL-280]

### DIFF
--- a/apps/trails-demo/package.json
+++ b/apps/trails-demo/package.json
@@ -17,12 +17,12 @@
   "dependencies": {
     "@ontrails/cli": "workspace:^",
     "@ontrails/core": "workspace:^",
+    "@ontrails/drizzle": "workspace:^",
+    "@ontrails/hono": "workspace:^",
     "@ontrails/http": "workspace:^",
     "@ontrails/logging": "workspace:^",
     "@ontrails/mcp": "workspace:^",
     "@ontrails/store": "workspace:^",
-    "@ontrails/with-drizzle": "workspace:^",
-    "@ontrails/with-hono": "workspace:^",
     "commander": "catalog:",
     "zod": "catalog:"
   },

--- a/apps/trails-demo/src/http.ts
+++ b/apps/trails-demo/src/http.ts
@@ -5,7 +5,7 @@
  *   bun run src/http.ts
  */
 
-import { trailhead } from '@ontrails/with-hono';
+import { trailhead } from '@ontrails/hono';
 
 import { app } from './app.js';
 

--- a/apps/trails-demo/src/store.ts
+++ b/apps/trails-demo/src/store.ts
@@ -3,11 +3,11 @@
  *
  * The demo still uses an in-memory SQLite database for easy local runs, but
  * the storage contract itself is now authored once and projected through
- * `@ontrails/with-drizzle`.
+ * `@ontrails/drizzle`.
  */
 
 import { store as defineStore } from '@ontrails/store';
-import { store as bindDrizzleStore } from '@ontrails/with-drizzle';
+import { store as bindDrizzleStore } from '@ontrails/drizzle';
 import { z } from 'zod';
 
 export const entitySchema = z.object({

--- a/bun.lock
+++ b/bun.lock
@@ -64,12 +64,12 @@
       "dependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
+        "@ontrails/drizzle": "workspace:^",
+        "@ontrails/hono": "workspace:^",
         "@ontrails/http": "workspace:^",
         "@ontrails/logging": "workspace:^",
         "@ontrails/mcp": "workspace:^",
         "@ontrails/store": "workspace:^",
-        "@ontrails/with-drizzle": "workspace:^",
-        "@ontrails/with-hono": "workspace:^",
         "commander": "catalog:",
         "zod": "catalog:",
       },
@@ -80,7 +80,7 @@
       },
     },
     "connectors/drizzle": {
-      "name": "@ontrails/with-drizzle",
+      "name": "@ontrails/drizzle",
       "version": "1.0.0-beta.14",
       "dependencies": {
         "@ontrails/core": "workspace:^",
@@ -92,7 +92,7 @@
       },
     },
     "connectors/hono": {
-      "name": "@ontrails/with-hono",
+      "name": "@ontrails/hono",
       "version": "1.0.0-beta.14",
       "dependencies": {
         "@ontrails/core": "workspace:^",
@@ -149,6 +149,13 @@
         "@ontrails/core": "workspace:^",
       },
     },
+    "packages/logtape": {
+      "name": "@ontrails/logtape",
+      "version": "1.0.0-beta.14",
+      "peerDependencies": {
+        "@ontrails/logging": "workspace:^",
+      },
+    },
     "packages/mcp": {
       "name": "@ontrails/mcp",
       "version": "1.0.0-beta.14",
@@ -190,8 +197,8 @@
       "name": "@ontrails/testing",
       "version": "1.0.0-beta.14",
       "devDependencies": {
+        "@ontrails/drizzle": "workspace:^",
         "@ontrails/store": "workspace:^",
-        "@ontrails/with-drizzle": "workspace:^",
       },
       "peerDependencies": {
         "@ontrails/cli": "workspace:^",
@@ -304,9 +311,15 @@
 
     "@ontrails/core": ["@ontrails/core@workspace:packages/core"],
 
+    "@ontrails/drizzle": ["@ontrails/drizzle@workspace:connectors/drizzle"],
+
+    "@ontrails/hono": ["@ontrails/hono@workspace:connectors/hono"],
+
     "@ontrails/http": ["@ontrails/http@workspace:packages/http"],
 
     "@ontrails/logging": ["@ontrails/logging@workspace:packages/logging"],
+
+    "@ontrails/logtape": ["@ontrails/logtape@workspace:packages/logtape"],
 
     "@ontrails/mcp": ["@ontrails/mcp@workspace:packages/mcp"],
 
@@ -323,10 +336,6 @@
     "@ontrails/trails": ["@ontrails/trails@workspace:apps/trails"],
 
     "@ontrails/warden": ["@ontrails/warden@workspace:packages/warden"],
-
-    "@ontrails/with-drizzle": ["@ontrails/with-drizzle@workspace:connectors/drizzle"],
-
-    "@ontrails/with-hono": ["@ontrails/with-hono@workspace:connectors/hono"],
 
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.121.0", "", { "os": "android", "cpu": "arm" }, "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A=="],
 

--- a/connectors/drizzle/README.md
+++ b/connectors/drizzle/README.md
@@ -1,4 +1,4 @@
-# @ontrails/with-drizzle
+# @ontrails/drizzle
 
 Drizzle connector for Trails stores. Use this package to bind a connector-agnostic `store(...)` definition from `@ontrails/store` to a concrete Drizzle runtime.
 
@@ -6,7 +6,7 @@ Drizzle connector for Trails stores. Use this package to bind a connector-agnost
 
 ```typescript
 import { store } from '@ontrails/store';
-import { connectDrizzle } from '@ontrails/with-drizzle';
+import { connectDrizzle } from '@ontrails/drizzle';
 
 const definition = store({
   gists: {
@@ -25,7 +25,7 @@ export const db = connectDrizzle(definition, {
 ## Installation
 
 ```bash
-bun add @ontrails/store @ontrails/with-drizzle zod
+bun add @ontrails/store @ontrails/drizzle zod
 ```
 
 ## Migration
@@ -33,4 +33,4 @@ bun add @ontrails/store @ontrails/with-drizzle zod
 This package replaces the old `@ontrails/store/drizzle` subpath.
 
 - Before: `import { connectDrizzle } from '@ontrails/store/drizzle'`
-- After: `import { connectDrizzle } from '@ontrails/with-drizzle'`
+- After: `import { connectDrizzle } from '@ontrails/drizzle'`

--- a/connectors/drizzle/package.json
+++ b/connectors/drizzle/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ontrails/with-drizzle",
+  "name": "@ontrails/drizzle",
   "version": "1.0.0-beta.14",
   "type": "module",
   "exports": {

--- a/connectors/drizzle/src/__tests__/drizzle.test.ts
+++ b/connectors/drizzle/src/__tests__/drizzle.test.ts
@@ -632,7 +632,7 @@ describe('versioned user accessor contract', () => {
   });
 });
 
-describe('@ontrails/with-drizzle resource access', () => {
+describe('@ontrails/drizzle resource access', () => {
   const tmp = createTmpRootManager('store-drizzle-');
 
   afterEach(() => {
@@ -799,7 +799,7 @@ describe('@ontrails/with-drizzle resource access', () => {
   });
 });
 
-describe('@ontrails/with-drizzle read-only resource access', () => {
+describe('@ontrails/drizzle read-only resource access', () => {
   const tmp = createTmpRootManager('store-drizzle-readonly-');
 
   afterEach(() => {
@@ -873,7 +873,7 @@ describe('@ontrails/with-drizzle read-only resource access', () => {
   });
 });
 
-describe('@ontrails/with-drizzle edge cases', () => {
+describe('@ontrails/drizzle edge cases', () => {
   const tmp = createTmpRootManager('store-drizzle-');
 
   afterEach(() => {

--- a/connectors/drizzle/src/schema.ts
+++ b/connectors/drizzle/src/schema.ts
@@ -531,7 +531,7 @@ const assertTabularStoreKind = (definition: AnyStoreDefinition): void => {
   }
 
   throw new ValidationError(
-    `@ontrails/with-drizzle only supports store definitions with kind "tabular". Received "${definition.kind}".`
+    `@ontrails/drizzle only supports store definitions with kind "tabular". Received "${definition.kind}".`
   );
 };
 

--- a/connectors/hono/README.md
+++ b/connectors/hono/README.md
@@ -1,11 +1,11 @@
-# @ontrails/with-hono
+# @ontrails/hono
 
 Hono trailhead connector for Trails. Use this package when you want to serve a topo over HTTP with Hono while keeping `@ontrails/http` focused on framework-agnostic route building.
 
 ## Usage
 
 ```typescript
-import { trailhead } from '@ontrails/with-hono';
+import { trailhead } from '@ontrails/hono';
 import { app } from './app';
 
 await trailhead(app, { port: 3000 });
@@ -16,7 +16,7 @@ For custom HTTP integrations or route inspection, keep using `buildHttpRoutes()`
 ## Installation
 
 ```bash
-bun add @ontrails/http @ontrails/with-hono
+bun add @ontrails/http @ontrails/hono
 ```
 
 ## Migration
@@ -24,4 +24,4 @@ bun add @ontrails/http @ontrails/with-hono
 This package replaces the old `@ontrails/http/hono` subpath.
 
 - Before: `import { trailhead } from '@ontrails/http/hono'`
-- After: `import { trailhead } from '@ontrails/with-hono'`
+- After: `import { trailhead } from '@ontrails/hono'`

--- a/connectors/hono/package.json
+++ b/connectors/hono/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ontrails/with-hono",
+  "name": "@ontrails/hono",
   "version": "1.0.0-beta.14",
   "type": "module",
   "exports": {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -147,7 +147,7 @@ buildHttpRoutes(topo, options?)    // escape hatch: route definitions without se
 BuildHttpRoutesOptions, HttpMethod, HttpRouteDefinition, InputSource
 ```
 
-## `@ontrails/with-hono`
+## `@ontrails/hono`
 
 ```typescript
 trailhead(topo, options?)              // one-liner Hono HTTP server
@@ -199,7 +199,7 @@ createStoreAccessorContractCases(options) // shared writable accessor contract c
 StoreAccessorContractOptions<T>, StoreAccessorContractSubject<T>
 ```
 
-## `@ontrails/with-drizzle`
+## `@ontrails/drizzle`
 
 ```typescript
 connectDrizzle(definition, options?)         // bind a root store definition to a writable Drizzle resource

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,7 +157,7 @@ Overrides are escape hatches. They're visible in the trailhead map as explicit d
 | `@ontrails/drizzle` | Drizzle SQLite connector, typed store bindings, read-only bindings | `drizzle-orm` |
 | `@ontrails/tracing` | Telemetry recording, trace context, `trails.db` dev-state sinks | None beyond core |
 | `@ontrails/logging` | Structured logging, sinks, formatters | None beyond core |
-| `@ontrails/logtape` | LogTape sink connector | `@logtape/logtape` (optional peer) |
+| `@ontrails/logtape` | LogTape sink connector | None (accepts any LogTape-shaped logger via a structural interface) |
 
 ### Ecosystem
 
@@ -193,7 +193,7 @@ Overrides are escape hatches. They're visible in the trailhead map as explicit d
      ^
 @ontrails/cli/commander (cli, commander)
 @ontrails/hono (http, hono)
-@ontrails/logtape (logging, @logtape/logtape)
+@ontrails/logtape (logging)
 @ontrails/warden (core, schema)
      ^
 apps/trails (cli/commander, schema, tracing)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,7 @@ Overrides are escape hatches. They're visible in the trailhead map as explicit d
 | `@ontrails/cli/commander` | Commander connector, `trailhead()` | `commander` (optional peer) |
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `trailhead()` | `@modelcontextprotocol/sdk` |
 | `@ontrails/http` | HTTP routes and error mapping | None beyond core |
-| `@ontrails/with-hono` | Hono connector, `trailhead()` | `hono` |
+| `@ontrails/hono` | Hono connector, `trailhead()` | `hono` |
 
 ### Infrastructure Connectors (right side)
 
@@ -154,10 +154,10 @@ Overrides are escape hatches. They're visible in the trailhead map as explicit d
 | `@ontrails/config` | Config resolution, profiles, resource config schemas, diagnostics | None beyond core |
 | `@ontrails/permits` | Auth layer, permit model, JWT connector, scope enforcement | None beyond core |
 | `@ontrails/store` | Connector-agnostic schema-derived store definitions | None beyond core |
-| `@ontrails/with-drizzle` | Drizzle SQLite connector, typed store bindings, read-only bindings | `drizzle-orm` |
+| `@ontrails/drizzle` | Drizzle SQLite connector, typed store bindings, read-only bindings | `drizzle-orm` |
 | `@ontrails/tracing` | Telemetry recording, trace context, `trails.db` dev-state sinks | None beyond core |
 | `@ontrails/logging` | Structured logging, sinks, formatters | None beyond core |
-| `@ontrails/logging/logtape` | LogTape sink connector | `@logtape/logtape` (optional peer) |
+| `@ontrails/logtape` | LogTape sink connector | `@logtape/logtape` (optional peer) |
 
 ### Ecosystem
 
@@ -185,15 +185,15 @@ Overrides are escape hatches. They're visible in the trailhead map as explicit d
 @ontrails/config (core)
 @ontrails/permits (core)
 @ontrails/store (core)
-@ontrails/with-drizzle (store, drizzle-orm)
+@ontrails/drizzle (store, drizzle-orm)
 @ontrails/tracing (core)
 @ontrails/logging (core)
 @ontrails/testing (core, cli, mcp, logging)
 @ontrails/schema (core)
      ^
 @ontrails/cli/commander (cli, commander)
-@ontrails/with-hono (http, hono)
-@ontrails/logging/logtape (logging, @logtape/logtape)
+@ontrails/hono (http, hono)
+@ontrails/logtape (logging, @logtape/logtape)
 @ontrails/warden (core, schema)
      ^
 apps/trails (cli/commander, schema, tracing)

--- a/docs/trailheads/http.md
+++ b/docs/trailheads/http.md
@@ -2,16 +2,16 @@
 
 The HTTP trailhead connector turns every trail into an endpoint. Routes are derived from trail IDs, HTTP verbs from intent, input parsing from the method, and error responses from the error taxonomy. One `trailhead()` call starts a Hono server.
 
-The package separates framework-agnostic route building (`@ontrails/http`) from the Hono connector (`@ontrails/with-hono`), following the same connector extraction pattern as the rest of the `with-*` ecosystem.
+The package separates framework-agnostic route building (`@ontrails/http`) from the Hono connector (`@ontrails/hono`).
 
 ## Setup
 
 ```bash
-bun add @ontrails/http @ontrails/with-hono
+bun add @ontrails/http @ontrails/hono
 ```
 
 ```typescript
-import { trailhead } from '@ontrails/with-hono';
+import { trailhead } from '@ontrails/hono';
 import { app } from './app';
 
 await trailhead(app, { port: 3000 });
@@ -108,7 +108,7 @@ Unrecognized errors (non-`TrailsError` exceptions) return 500 with `category: 'i
 Layers compose the same way as on CLI and MCP -- they wrap trail implementations:
 
 ```typescript
-import { trailhead } from '@ontrails/with-hono';
+import { trailhead } from '@ontrails/hono';
 import { authLayer, loggingLayer } from './layers';
 
 await trailhead(app, {
@@ -193,7 +193,7 @@ const longTask = trail('report.generate', {
 
 ```typescript
 import { createTrailContext } from '@ontrails/core';
-import { trailhead } from '@ontrails/with-hono';
+import { trailhead } from '@ontrails/hono';
 import { app } from './app';
 import { createStore } from './store';
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -1,12 +1,12 @@
 # @ontrails/http
 
-Framework-agnostic HTTP route derivation for Trails. Pair this package with `@ontrails/with-hono` when you want the Hono trailhead connector.
+Framework-agnostic HTTP route derivation for Trails. Pair this package with `@ontrails/hono` when you want the Hono trailhead connector.
 
 ## Usage
 
 ```typescript
 import { trail, topo, Result } from '@ontrails/core';
-import { trailhead } from '@ontrails/with-hono';
+import { trailhead } from '@ontrails/hono';
 import { z } from 'zod';
 
 const greet = trail('greet', {
@@ -57,7 +57,7 @@ Trail IDs map to paths: `entity.show` becomes `/entity/show`. Dots become slashe
 
 ## Collision detection
 
-`buildHttpRoutes` detects when two trails would produce the same `(method, path)` pair and returns `Result.err(ValidationError)` describing both trail IDs. The `trailhead()` helper from `@ontrails/with-hono` throws on collision.
+`buildHttpRoutes` detects when two trails would produce the same `(method, path)` pair and returns `Result.err(ValidationError)` describing both trail IDs. The `trailhead()` helper from `@ontrails/hono` throws on collision.
 
 ## Resource resolution
 
@@ -96,12 +96,12 @@ Each route definition produced by `buildHttpRoutes` includes:
 ## Installation
 
 ```bash
-bun add @ontrails/http @ontrails/with-hono
+bun add @ontrails/http @ontrails/hono
 ```
 
 ## Migration
 
-Hono integration now lives in `@ontrails/with-hono`.
+Hono integration now lives in `@ontrails/hono`.
 
-- Replace `import { trailhead } from '@ontrails/http/hono'` with `import { trailhead } from '@ontrails/with-hono'`
+- Replace `import { trailhead } from '@ontrails/http/hono'` with `import { trailhead } from '@ontrails/hono'`
 - Keep `buildHttpRoutes()` and the route model imports on `@ontrails/http`

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -74,10 +74,10 @@ logger.info('Auth', { user: 'admin', password: 'hunter2' });
 
 ## LogTape connector
 
-Bridge to an existing LogTape setup via the `/logtape` subpath:
+Bridge to an existing LogTape setup via the dedicated `@ontrails/logtape` package:
 
 ```typescript
-import { logtapeSink } from '@ontrails/logging/logtape';
+import { logtapeSink } from '@ontrails/logtape';
 import { getLogger } from '@logtape/logtape';
 
 const logger = createLogger({
@@ -86,7 +86,7 @@ const logger = createLogger({
 });
 ```
 
-`@logtape/logtape` is an optional peer dependency.
+`@logtape/logtape` is an optional peer dependency of `@ontrails/logtape`.
 
 ## Installation
 

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -86,7 +86,7 @@ const logger = createLogger({
 });
 ```
 
-`@logtape/logtape` is an optional peer dependency of `@ontrails/logtape`.
+`@ontrails/logtape` does not depend on `@logtape/logtape`. It uses a structural `LogtapeLoggerLike` interface to accept any object shaped like a LogTape logger, so consumers only install `@logtape/logtape` if their own code uses it directly.
 
 ## Installation
 

--- a/packages/logtape/README.md
+++ b/packages/logtape/README.md
@@ -1,0 +1,3 @@
+# @ontrails/logtape
+
+The logtape sink for `@ontrails/logging`. See `@ontrails/logging` for the logger API; this package only provides the optional logtape forwarding sink.

--- a/packages/logtape/package.json
+++ b/packages/logtape/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ontrails/logging",
+  "name": "@ontrails/logtape",
   "version": "1.0.0-beta.14",
   "type": "module",
   "exports": {
@@ -14,6 +14,11 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "peerDependencies": {
-    "@ontrails/core": "workspace:^"
+    "@ontrails/logging": "workspace:^"
+  },
+  "peerDependenciesMeta": {
+    "@logtape/logtape": {
+      "optional": true
+    }
   }
 }

--- a/packages/logtape/package.json
+++ b/packages/logtape/package.json
@@ -15,10 +15,5 @@
   },
   "peerDependencies": {
     "@ontrails/logging": "workspace:^"
-  },
-  "peerDependenciesMeta": {
-    "@logtape/logtape": {
-      "optional": true
-    }
   }
 }

--- a/packages/logtape/src/__tests__/logtape.test.ts
+++ b/packages/logtape/src/__tests__/logtape.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+
+import { logtapeSink } from '../index.js';
+import type { LogtapeLoggerLike } from '../index.js';
+
+const createRecordingLogger = () => {
+  const calls: {
+    level: string;
+    message: string;
+    props?: Record<string, unknown>;
+  }[] = [];
+
+  const logger: LogtapeLoggerLike = {
+    debug(message, props) {
+      calls.push({ level: 'debug', message, props });
+    },
+    error(message, props) {
+      calls.push({ level: 'error', message, props });
+    },
+    fatal(message, props) {
+      calls.push({ level: 'fatal', message, props });
+    },
+    info(message, props) {
+      calls.push({ level: 'info', message, props });
+    },
+    trace(message, props) {
+      calls.push({ level: 'trace', message, props });
+    },
+    warn(message, props) {
+      calls.push({ level: 'warn', message, props });
+    },
+  };
+
+  return { calls, logger };
+};
+
+describe('logtapeSink', () => {
+  test('forwards records to the underlying logtape logger by level', () => {
+    const { calls, logger } = createRecordingLogger();
+    const sink = logtapeSink({ logger });
+
+    sink.write({
+      category: 'app.http',
+      level: 'info',
+      message: 'request received',
+      metadata: { path: '/greet' },
+      timestamp: new Date(),
+    });
+
+    expect(calls).toEqual([
+      {
+        level: 'info',
+        message: 'request received',
+        props: { category: 'app.http', path: '/greet' },
+      },
+    ]);
+  });
+
+  test('ignores records whose level does not map to a logtape method', () => {
+    const { calls, logger } = createRecordingLogger();
+    const sink = logtapeSink({ logger });
+
+    sink.write({
+      category: 'app',
+      // @ts-expect-error -- exercising unexpected level handling
+      level: 'unknown',
+      message: 'should not forward',
+      metadata: {},
+      timestamp: new Date(),
+    });
+
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/logtape/src/index.ts
+++ b/packages/logtape/src/index.ts
@@ -1,4 +1,4 @@
-import type { LogRecord, LogSink } from '../types.js';
+import type { LogRecord, LogSink } from '@ontrails/logging';
 
 // ---------------------------------------------------------------------------
 // Minimal logtape logger interface (avoids importing @logtape/logtape)

--- a/packages/logtape/tsconfig.json
+++ b/packages/logtape/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -2,7 +2,7 @@
 
 Schema-derived persistence for Trails.
 
-The root package owns the connector-agnostic `store(...)` declaration. External connector packages such as `@ontrails/with-drizzle` bind that declaration to a concrete runtime, and first-party built-ins such as `@ontrails/store/jsonfile` live as opt-in subpaths on the same package.
+The root package owns the connector-agnostic `store(...)` declaration. External connector packages such as `@ontrails/drizzle` bind that declaration to a concrete runtime, and first-party built-ins such as `@ontrails/store/jsonfile` live as opt-in subpaths on the same package.
 
 ## The two layers
 
@@ -47,7 +47,7 @@ No database connection is opened here. The returned value is the durable authore
 
 ```typescript
 import { store } from '@ontrails/store';
-import { connectDrizzle } from '@ontrails/with-drizzle';
+import { connectDrizzle } from '@ontrails/drizzle';
 
 const definition = store({
   gists: {
@@ -137,7 +137,7 @@ const removed = definition.tables.gists.signals.removed;
 
 Writable bindings fire those signals automatically when you access the resource through `db.from(ctx)` inside a trail context.
 
-Tabular connectors such as `@ontrails/with-drizzle` also expose `insert()` and `update()` as convenience methods when the backend natively distinguishes create and patch operations.
+Tabular connectors such as `@ontrails/drizzle` also expose `insert()` and `update()` as convenience methods when the backend natively distinguishes create and patch operations.
 
 ## Fixtures and mocks
 
@@ -165,7 +165,7 @@ That means `testAll(app)` can auto-resolve connector-bound store resources witho
 Use the Drizzle connector's read-only helpers when a trail should inspect persisted state without exposing writes:
 
 ```typescript
-import { connectReadOnlyDrizzle, readonlyStore } from '@ontrails/with-drizzle';
+import { connectReadOnlyDrizzle, readonlyStore } from '@ontrails/drizzle';
 
 const analytics = connectReadOnlyDrizzle(definition, {
   id: 'analytics.db',
@@ -214,10 +214,10 @@ This keeps the default happy path derived and typed, while still giving you full
 
 ## Connector conveniences
 
-`@ontrails/with-drizzle` also exports one-line conveniences when you want declaration and binding together:
+`@ontrails/drizzle` also exports one-line conveniences when you want declaration and binding together:
 
 ```typescript
-import { store, readonlyStore } from '@ontrails/with-drizzle';
+import { store, readonlyStore } from '@ontrails/drizzle';
 
 export const writable = store(
   {
@@ -249,7 +249,7 @@ These are conveniences, not the architectural source of truth. The root package 
 If you need the raw derived Drizzle tables for tooling such as `drizzle-kit`, use `getSchema()`:
 
 ```typescript
-import { getSchema } from '@ontrails/with-drizzle';
+import { getSchema } from '@ontrails/drizzle';
 
 const schema = getSchema(db);
 ```
@@ -263,12 +263,12 @@ bun add @ontrails/store zod
 Add Drizzle only when you want the external SQLite/ORM connector:
 
 ```bash
-bun add @ontrails/with-drizzle
+bun add @ontrails/drizzle
 ```
 
 ## Migration
 
-The Drizzle binding now lives in `@ontrails/with-drizzle`.
+The Drizzle binding now lives in `@ontrails/drizzle`.
 
-- Replace `import { ... } from '@ontrails/store/drizzle'` with `import { ... } from '@ontrails/with-drizzle'`
+- Replace `import { ... } from '@ontrails/store/drizzle'` with `import { ... } from '@ontrails/drizzle'`
 - Keep connector-agnostic store declarations on `@ontrails/store`

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -14,8 +14,8 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "devDependencies": {
-    "@ontrails/store": "workspace:^",
-    "@ontrails/with-drizzle": "workspace:^"
+    "@ontrails/drizzle": "workspace:^",
+    "@ontrails/store": "workspace:^"
   },
   "peerDependencies": {
     "@ontrails/cli": "workspace:^",

--- a/packages/testing/src/__tests__/all.test.ts
+++ b/packages/testing/src/__tests__/all.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, mock } from 'bun:test';
 
 import { contour, Result, trail, topo } from '@ontrails/core';
-import { connectDrizzle } from '@ontrails/with-drizzle';
+import { connectDrizzle } from '@ontrails/drizzle';
 import { z } from 'zod';
 
 import { testAll } from '../all.js';

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -112,7 +112,7 @@ await trailhead(app);
 **HTTP**: Routes from trail IDs (dots become path segments), verbs from intent, error responses from taxonomy.
 
 ```typescript
-import { trailhead } from '@ontrails/with-hono';
+import { trailhead } from '@ontrails/hono';
 await trailhead(app, { port: 3000 });
 ```
 

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -99,7 +99,7 @@ Warden uses inference to verify declarations match actual code. The trailhead ma
 | `@ontrails/permits` | Auth layer, permit model, JWT connector, scope enforcement | None beyond core |
 | `@ontrails/tracing` | Telemetry recording, trace context, memory/OTel sinks | None beyond core |
 | `@ontrails/logging` | Structured logging, sinks, formatters | None beyond core |
-| `@ontrails/logtape` | LogTape sink connector | `@logtape/logtape` (peer) |
+| `@ontrails/logtape` | LogTape sink connector | None (accepts any LogTape-shaped logger via a structural interface) |
 
 ### Ecosystem
 
@@ -123,7 +123,7 @@ Warden uses inference to verify declarations match actual code. The trailhead ma
   <- @ontrails/testing (core, cli, mcp, logging)
   <- @ontrails/schema (core)
      <- @ontrails/cli/commander (cli, commander)
-     <- @ontrails/logtape (logging, @logtape/logtape)
+     <- @ontrails/logtape (logging)
      <- @ontrails/warden (core, schema)
 ```
 

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -89,7 +89,7 @@ Warden uses inference to verify declarations match actual code. The trailhead ma
 | `@ontrails/cli/commander` | Commander connector, `trailhead()` | `commander` (peer) |
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `trailhead()` | `@modelcontextprotocol/sdk` |
 | `@ontrails/http` | HTTP route definitions (framework-agnostic) | None beyond core |
-| `@ontrails/with-hono` | Hono connector, `trailhead()` | `hono` |
+| `@ontrails/hono` | Hono connector, `trailhead()` | `hono` |
 
 ### Infrastructure Connectors (right side)
 
@@ -99,7 +99,7 @@ Warden uses inference to verify declarations match actual code. The trailhead ma
 | `@ontrails/permits` | Auth layer, permit model, JWT connector, scope enforcement | None beyond core |
 | `@ontrails/tracing` | Telemetry recording, trace context, memory/OTel sinks | None beyond core |
 | `@ontrails/logging` | Structured logging, sinks, formatters | None beyond core |
-| `@ontrails/logging/logtape` | LogTape sink connector | `@logtape/logtape` (peer) |
+| `@ontrails/logtape` | LogTape sink connector | `@logtape/logtape` (peer) |
 
 ### Ecosystem
 
@@ -123,7 +123,7 @@ Warden uses inference to verify declarations match actual code. The trailhead ma
   <- @ontrails/testing (core, cli, mcp, logging)
   <- @ontrails/schema (core)
      <- @ontrails/cli/commander (cli, commander)
-     <- @ontrails/logging/logtape (logging, @logtape/logtape)
+     <- @ontrails/logtape (logging, @logtape/logtape)
      <- @ontrails/warden (core, schema)
 ```
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -24,6 +24,7 @@ PACKAGES=(
   packages/core
   packages/store
   packages/logging
+  packages/logtape
   packages/schema
   packages/config
   packages/permits

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "noUnusedParameters": true,
     "skipLibCheck": true,
     "paths": {
-      "@ontrails/with-*": ["node_modules/@ontrails/with-*"]
+      "@ontrails/*": ["node_modules/@ontrails/*"]
     },
     "outDir": "dist",
     "rootDir": "src"


### PR DESCRIPTION
## Summary

Stack base. Renames the `@ontrails/with-*` connector packages to bare names and extracts `@ontrails/logtape` as a standalone package. Deletes orphan directories left over from earlier cutovers. Every other PR in the stack depends on this one's import paths.

## What changed

- `@ontrails/with-drizzle` → `@ontrails/drizzle` (package name and all 34 consumer imports)
- `@ontrails/with-hono` → `@ontrails/hono`
- Extract `@ontrails/logging/logtape` subpath → new `@ontrails/logtape` package with its own `package.json`, `tsconfig.json`, and a minimal smoke test
- Remove `./logtape` subpath + the optional `@logtape/logtape` peer dep from `@ontrails/logging`
- Delete `connectors/with-jsonfile/` (empty; build artifacts only)
- Delete `packages/tracker/` (empty; orphan from the tracker → tracing rename)
- Refresh `bun.lock`

## Why

- **Decision #7 (Pillar 2: packaging follows dependencies).** A package that brings a third-party runtime dep ships as a standalone package in `connectors/` or `packages/`, not as a subpath. `@logtape/logtape` is third-party, so `logtape` graduates out of `@ontrails/logging`.
- **Decision #7** also retires the `with-*` prefix — boundary ownership and naming live in the package name, not a decorative prefix. ADR-0029 was already amended in place during the walkthrough; this PR ships the mechanical rename.
- **Decision #37 (no migration scaffolding).** No deprecated aliases, no `existsSync`-based old-name probes. Pre-1.0 means the codebase represents the 1.0 target state.

Cloudflare restructure and `bun-sqlite` → `sqlite` subpath rename are no-ops in the current tree (no `@ontrails/cloudflare` package exists today; `@ontrails/store` exposes `./jsonfile` and `./trails` but not `./bun-sqlite`). Re-evaluate when PR 9 introduces the Cloudflare runtime adapters.

## File ownership

Only `package.json`, `tsconfig.json`, and imports-only touches in source files where import paths change. Source-code logic unchanged. No file in this diff is modified by any later PR in the stack.

## Test plan

- [x] `bun run typecheck` — 30/30 green
- [x] `bun run test` — 30/30 green
- [x] `bunx ultracite check` — 0 warnings, 0 errors across 527 files
- [x] CI green across Build / Lint & Format / Typecheck / Test / Governance / CI Gate
- [x] Zero `@ontrails/with-*` references in code (remaining references are in `docs/`, `plugin/skills/**`, CHANGELOGs, and `.changeset/**` — out of PR 7 ownership)

Closes TRL-280.