### PR TITLE
refactor: tighten projection verbs to derive* in schema/config/logging/tracing [TRL-275]

### DIFF
--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -15,9 +15,9 @@ import { describe, expect, test } from 'bun:test';
 
 import { Result, trail, topo, validateTopo } from '@ontrails/core';
 import {
-  diffTrailheadMaps,
-  generateTrailheadMap,
-  hashTrailheadMap,
+  deriveSurfaceMapDiff,
+  deriveSurfaceMap,
+  deriveSurfaceMapHash,
 } from '@ontrails/schema';
 import { z } from 'zod';
 
@@ -36,7 +36,7 @@ import * as search from '../src/trails/search.js';
 // ---------------------------------------------------------------------------
 
 describe('trailhead map generation', () => {
-  const trailheadMap = generateTrailheadMap(app);
+  const trailheadMap = deriveSurfaceMap(app);
 
   test('contains all expected trail, event, and resource IDs', () => {
     const ids = trailheadMap.entries.map((e) => e.id);
@@ -138,24 +138,24 @@ describe('trailhead map generation', () => {
 
 describe('trailhead map hashing is deterministic', () => {
   test('identical topos produce identical hashes', () => {
-    const map1 = generateTrailheadMap(app);
-    const map2 = generateTrailheadMap(app);
+    const map1 = deriveSurfaceMap(app);
+    const map2 = deriveSurfaceMap(app);
 
-    const hash1 = hashTrailheadMap(map1);
-    const hash2 = hashTrailheadMap(map2);
+    const hash1 = deriveSurfaceMapHash(map1);
+    const hash2 = deriveSurfaceMapHash(map2);
 
     expect(hash1).toBe(hash2);
   });
 
   test('hash is a valid 64-character hex string', () => {
-    const trailheadMap = generateTrailheadMap(app);
-    const hash = hashTrailheadMap(trailheadMap);
+    const trailheadMap = deriveSurfaceMap(app);
+    const hash = deriveSurfaceMapHash(trailheadMap);
 
     expect(hash).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test('generatedAt timestamp does not affect hash', () => {
-    const map1 = generateTrailheadMap(app);
+    const map1 = deriveSurfaceMap(app);
 
     // Manually create a copy with a different generatedAt
     const map2 = {
@@ -163,7 +163,7 @@ describe('trailhead map hashing is deterministic', () => {
       generatedAt: '2099-12-31T23:59:59.999Z',
     };
 
-    expect(hashTrailheadMap(map1)).toBe(hashTrailheadMap(map2));
+    expect(deriveSurfaceMapHash(map1)).toBe(deriveSurfaceMapHash(map2));
   });
 });
 
@@ -204,10 +204,10 @@ const makeModifiedShow = (inputSchema: z.ZodType) =>
 
 /** Diff the baseline app against a modified app. */
 const diffAgainst = (...modules: Record<string, unknown>[]) => {
-  const before = generateTrailheadMap(app);
+  const before = deriveSurfaceMap(app);
   const modifiedApp = topo('demo-modified', ...modules);
-  const after = generateTrailheadMap(modifiedApp);
-  return diffTrailheadMaps(before, after);
+  const after = deriveSurfaceMap(modifiedApp);
+  return deriveSurfaceMapDiff(before, after);
 };
 
 describe('breaking change detection', () => {
@@ -320,9 +320,9 @@ describe('non-breaking change detection', () => {
   });
 
   test('no changes produces empty diff', () => {
-    const map1 = generateTrailheadMap(app);
-    const map2 = generateTrailheadMap(app);
-    const diff = diffTrailheadMaps(map1, map2);
+    const map1 = deriveSurfaceMap(app);
+    const map2 = deriveSurfaceMap(app);
+    const diff = deriveSurfaceMapDiff(map1, map2);
 
     expect(diff.hasBreaking).toBe(false);
     expect(diff.entries).toHaveLength(0);

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -10,9 +10,9 @@ import { join, resolve } from 'node:path';
 
 import { ConflictError, Result, resource, topo, trail } from '@ontrails/core';
 import {
-  generateTrailheadMap,
-  hashTrailheadMap,
-  diffTrailheadMaps,
+  deriveSurfaceMap,
+  deriveSurfaceMapHash,
+  deriveSurfaceMapDiff,
 } from '@ontrails/schema';
 import type { TrailheadMap } from '@ontrails/schema';
 import { z } from 'zod';
@@ -129,8 +129,8 @@ const repoTempDir = (): string =>
 // ---------------------------------------------------------------------------
 
 describe('trails survey', () => {
-  test('generateTrailheadMap includes all trails', () => {
-    const trailheadMap = generateTrailheadMap(app);
+  test('deriveSurfaceMap includes all trails', () => {
+    const trailheadMap = deriveSurfaceMap(app);
     expect(trailheadMap.entries.length).toBe(3);
     const ids = trailheadMap.entries.map((e) => e.id);
     expect(ids).toContain('hello');
@@ -139,7 +139,7 @@ describe('trails survey', () => {
   });
 
   test('trailhead map entries have expected fields', () => {
-    const trailheadMap = generateTrailheadMap(app);
+    const trailheadMap = deriveSurfaceMap(app);
     const hello = trailheadMap.entries.find((e) => e.id === 'hello');
     expect(hello).toBeDefined();
     expect(hello?.cli?.path).toEqual(['hello']);
@@ -150,26 +150,26 @@ describe('trails survey', () => {
   });
 
   test('JSON output is valid JSON', () => {
-    const trailheadMap = generateTrailheadMap(app);
+    const trailheadMap = deriveSurfaceMap(app);
     const json = JSON.stringify(trailheadMap, null, 2);
     const parsed = JSON.parse(json) as TrailheadMap;
     expect(parsed.version).toBe('1.0');
     expect(parsed.entries.length).toBe(3);
   });
 
-  test('hashTrailheadMap produces stable hash', () => {
-    const trailheadMap = generateTrailheadMap(app);
-    const hash1 = hashTrailheadMap(trailheadMap);
-    const hash2 = hashTrailheadMap(trailheadMap);
+  test('deriveSurfaceMapHash produces stable hash', () => {
+    const trailheadMap = deriveSurfaceMap(app);
+    const hash1 = deriveSurfaceMapHash(trailheadMap);
+    const hash2 = deriveSurfaceMapHash(trailheadMap);
     expect(hash1).toBe(hash2);
     // SHA-256 hex
     expect(hash1.length).toBe(64);
   });
 
-  test('diffTrailheadMaps detects added trails', () => {
-    const prev = generateTrailheadMap(topo('test', { hello: helloTrail }));
-    const curr = generateTrailheadMap(app);
-    const diff = diffTrailheadMaps(prev, curr);
+  test('deriveSurfaceMapDiff detects added trails', () => {
+    const prev = deriveSurfaceMap(topo('test', { hello: helloTrail }));
+    const curr = deriveSurfaceMap(app);
+    const diff = deriveSurfaceMapDiff(prev, curr);
 
     expect(diff.info.length).toBeGreaterThan(0);
     const addedBye = diff.info.find((e) => e.id === 'bye');
@@ -177,10 +177,10 @@ describe('trails survey', () => {
     expect(addedBye?.change).toBe('added');
   });
 
-  test('diffTrailheadMaps detects removed trails', () => {
-    const prev = generateTrailheadMap(app);
-    const curr = generateTrailheadMap(topo('test', { hello: helloTrail }));
-    const diff = diffTrailheadMaps(prev, curr);
+  test('deriveSurfaceMapDiff detects removed trails', () => {
+    const prev = deriveSurfaceMap(app);
+    const curr = deriveSurfaceMap(topo('test', { hello: helloTrail }));
+    const diff = deriveSurfaceMapDiff(prev, curr);
 
     expect(diff.hasBreaking).toBe(true);
     const removedBye = diff.breaking.find((e) => e.id === 'bye');
@@ -188,9 +188,9 @@ describe('trails survey', () => {
     expect(removedBye?.change).toBe('removed');
   });
 
-  test('diffTrailheadMaps returns empty for identical maps', () => {
-    const trailheadMap = generateTrailheadMap(app);
-    const diff = diffTrailheadMaps(trailheadMap, trailheadMap);
+  test('deriveSurfaceMapDiff returns empty for identical maps', () => {
+    const trailheadMap = deriveSurfaceMap(app);
+    const diff = deriveSurfaceMapDiff(trailheadMap, trailheadMap);
     expect(diff.entries.length).toBe(0);
     expect(diff.hasBreaking).toBe(false);
   });

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -9,9 +9,9 @@ import type { Topo } from '@ontrails/core';
 import { NotFoundError, Result, trail } from '@ontrails/core';
 import type { DiffResult } from '@ontrails/schema';
 import {
-  diffTrailheadMaps,
-  generateOpenApiSpec,
-  generateTrailheadMap,
+  deriveSurfaceMapDiff,
+  deriveOpenApiSpec,
+  deriveSurfaceMap,
   readTrailheadMap,
 } from '@ontrails/schema';
 import { z } from 'zod';
@@ -51,7 +51,7 @@ const buildSurveyDiff = async (
   app: Topo,
   breakingOnly: boolean
 ): Promise<Result<object, Error>> => {
-  const currentMap = generateTrailheadMap(app);
+  const currentMap = deriveSurfaceMap(app);
   const previousMap = await readTrailheadMap();
   if (!previousMap) {
     return Result.err(
@@ -61,7 +61,7 @@ const buildSurveyDiff = async (
     );
   }
 
-  const diff = diffTrailheadMaps(previousMap, currentMap);
+  const diff = deriveSurfaceMapDiff(previousMap, currentMap);
   return Result.ok(
     breakingOnly
       ? formatDiff({
@@ -143,7 +143,7 @@ const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
   generate: (app, _input, rootDir) => buildSurveyGenerate(app, rootDir),
   list: (app, _input, rootDir) =>
     Result.ok(buildCurrentTopoList(app, { rootDir })),
-  openapi: (app) => Result.ok(generateOpenApiSpec(app)),
+  openapi: (app) => Result.ok(deriveOpenApiSpec(app)),
 };
 
 /** Dispatch to the appropriate survey sub-command based on input flags. */

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -158,8 +158,8 @@ TrailheadHttpOptions
 ## `@ontrails/schema`
 
 ```typescript
-generateOpenApiSpec(topo, options?) // OpenAPI 3.1 spec from topo
-generateTrailheadMap(topo), hashTrailheadMap(map), diffTrailheadMaps(before, after)
+deriveOpenApiSpec(topo, options?) // OpenAPI 3.1 spec from topo
+deriveSurfaceMap(topo), deriveSurfaceMapHash(map), deriveSurfaceMapDiff(before, after)
 writeTrailheadMap(map, options?), readTrailheadMap(options?)
 writeTrailheadLock(lock, options?), readTrailheadLockData(options?), readTrailheadLock(options?)
 
@@ -265,11 +265,20 @@ deprecated(schema, message)          // mark a field as deprecated with migratio
 
 // Resource & layer
 configResource                       // resource for resolved config state
-configGate                           // layer for per-trail config context
+configLayer                          // layer for per-trail config context
 
 // State management
 registerConfigState(state)           // register resolved config at bootstrap
+getConfigState()                     // read registered config state
 clearConfigState()                   // clear global config state (for tests)
+
+// Derivation helpers
+deriveConfig(options?)               // resolve config values against schema + sources
+deriveConfigFields(schema)           // field descriptions from the schema
+deriveConfigProvenance(result)       // provenance by resolved field
+deriveConfigEnvExample(schema)       // .env.example content from the schema
+deriveConfigExample(schema, format?) // commented example config for TOML / YAML / JSON
+deriveConfigJsonSchema(schema)       // JSON Schema Draft 2020-12 from the config schema
 
 // Trail definitions
 configCheck                          // validate config values against schema

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -6,11 +6,11 @@
 
 **HTTP trailhead (`@ontrails/http`).** The third trailhead connector. `intent: 'read'` maps to GET, mutations to POST, `'destroy'` to DELETE. Route paths derived from trail IDs. Error taxonomy maps to HTTP status codes. One `trailhead()` call, same pattern as CLI and MCP. Built on Hono.
 
-**OpenAPI generation (`@ontrails/schema`).** `generateOpenApiSpec()` produces a complete OpenAPI 3.1 spec from the topo. The topo already carries everything OpenAPI needs.
+**OpenAPI generation (`@ontrails/schema`).** `deriveOpenApiSpec()` produces a complete OpenAPI 3.1 spec from the topo. The topo already carries everything OpenAPI needs.
 
 **Resources (`resource()` and trail `resources: [...]`).** Trails now declare infrastructure dependencies explicitly. `executeTrail()` resolves app-scoped singletons before layers and implementations run. Testing can auto-resolve `mock` factories, and survey / schema tooling exposes the full resource graph.
 
-**Config resolution (`@ontrails/config`).** `defineConfig()` provides schema-validated config with profiles (named environment profiles), env variable mapping, and `ResourceSpec.config` for resource-level config schemas. Includes diagnostics (`checkConfig`), introspection (`describeConfig`, `explainConfig`), and generation (`generateEnvExample`).
+**Config resolution (`@ontrails/config`).** `defineConfig()` provides schema-validated config with profiles (named environment profiles), env variable mapping, and `ResourceSpec.config` for resource-level config schemas. Includes diagnostics (`checkConfig`), introspection (`deriveConfigFields`, `deriveConfigProvenance`), and generation (`deriveConfigEnvExample`).
 
 **Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. `authLayer` extracts credentials from trailhead-specific sources, `AuthConnector` resolves them to a `Permit` (identity, scopes, roles), and scope enforcement rejects unauthorized access. Includes JWT connector, governance rules (`validatePermits`), and test helpers (`mintTestPermit`, `mintPermitForTrail`).
 

--- a/packages/config/src/__tests__/app-config.test.ts
+++ b/packages/config/src/__tests__/app-config.test.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 import type { AppConfig } from '../app-config.js';
 import { appConfig } from '../app-config.js';
-import { describeConfig } from '../describe.js';
+import { deriveConfigFields } from '../derive-fields.js';
 import { checkConfig } from '../doctor.js';
 import { configRef } from '../ref.js';
 
@@ -289,10 +289,10 @@ describe('appConfig()', () => {
   });
 
   describe('method delegations', () => {
-    test('describe() returns same result as describeConfig(schema)', () => {
+    test('describe() returns same result as deriveConfigFields(schema)', () => {
       const config = appConfig('myapp', { schema: testSchema });
       const methodResult = config.describe();
-      const standaloneResult = describeConfig(testSchema);
+      const standaloneResult = deriveConfigFields(testSchema);
 
       expect(methodResult).toEqual(standaloneResult);
     });
@@ -315,7 +315,7 @@ describe('appConfig()', () => {
       expect(methodResult).toEqual(standaloneResult);
     });
 
-    test('explain() delegates to explainConfig with bound schema', () => {
+    test('explain() delegates to deriveConfigProvenance with bound schema', () => {
       const config = appConfig('myapp', { schema: testSchema });
       const resolved = { output: './dist', verbose: true };
 

--- a/packages/config/src/__tests__/derive-fields.test.ts
+++ b/packages/config/src/__tests__/derive-fields.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from 'bun:test';
 import { z } from 'zod';
 
 import { deprecated, env, secret } from '../extensions.js';
-import { describeConfig } from '../describe.js';
+import { deriveConfigFields } from '../derive-fields.js';
 
-describe('describeConfig', () => {
+describe('deriveConfigFields', () => {
   describe('basic field descriptions', () => {
     test('returns path, type, and required for each field', () => {
       const schema = z.object({
@@ -13,7 +13,7 @@ describe('describeConfig', () => {
         port: z.number(),
       });
 
-      const fields = describeConfig(schema);
+      const fields = deriveConfigFields(schema);
 
       expect(fields).toHaveLength(3);
       const host = fields.find((f) => f.path === 'host');
@@ -32,7 +32,7 @@ describe('describeConfig', () => {
         host: z.string().describe('The server hostname'),
       });
 
-      const fields = describeConfig(schema);
+      const fields = deriveConfigFields(schema);
       const host = fields.find((f) => f.path === 'host');
       expect(host?.description).toBe('The server hostname');
     });
@@ -47,7 +47,7 @@ describe('describeConfig', () => {
         ),
       });
 
-      const fields = describeConfig(schema);
+      const fields = deriveConfigFields(schema);
 
       const apiKey = fields.find((f) => f.path === 'apiKey');
       expect(apiKey?.env).toBe('API_KEY');
@@ -65,7 +65,7 @@ describe('describeConfig', () => {
         port: z.number().default(3000),
       });
 
-      const fields = describeConfig(schema);
+      const fields = deriveConfigFields(schema);
 
       const port = fields.find((f) => f.path === 'port');
       expect(port?.default).toBe(3000);
@@ -85,7 +85,7 @@ describe('describeConfig', () => {
         }),
       });
 
-      const fields = describeConfig(schema);
+      const fields = deriveConfigFields(schema);
 
       const dbHost = fields.find((f) => f.path === 'db.host');
       expect(dbHost?.type).toBe('string');
@@ -106,7 +106,7 @@ describe('describeConfig', () => {
           .optional(),
       });
 
-      const fields = describeConfig(schema);
+      const fields = deriveConfigFields(schema);
 
       expect(fields).toEqual([
         expect.objectContaining({ path: 'db.host', required: true }),
@@ -121,7 +121,7 @@ describe('describeConfig', () => {
         env: z.enum(['development', 'production', 'test']),
       });
 
-      const fields = describeConfig(schema);
+      const fields = deriveConfigFields(schema);
       const envField = fields.find((f) => f.path === 'env');
       expect(envField?.type).toBe('enum');
       expect(envField?.constraints?.values).toEqual([
@@ -136,7 +136,7 @@ describe('describeConfig', () => {
         port: z.number().min(1).max(65_535),
       });
 
-      const fields = describeConfig(schema);
+      const fields = deriveConfigFields(schema);
       const port = fields.find((f) => f.path === 'port');
       expect(port?.constraints?.min).toBe(1);
       expect(port?.constraints?.max).toBe(65_535);
@@ -150,7 +150,7 @@ describe('describeConfig', () => {
         nickname: z.string().optional(),
       });
 
-      const fields = describeConfig(schema);
+      const fields = deriveConfigFields(schema);
       const nickname = fields.find((f) => f.path === 'nickname');
       expect(nickname?.required).toBe(false);
     });

--- a/packages/config/src/__tests__/derive-provenance.test.ts
+++ b/packages/config/src/__tests__/derive-provenance.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { z } from 'zod';
 
 import { env, secret } from '../extensions.js';
-import { explainConfig } from '../explain.js';
+import { deriveConfigProvenance } from '../derive-provenance.js';
 
 const schema = z.object({
   debug: z.boolean().default(false),
@@ -10,10 +10,10 @@ const schema = z.object({
   port: z.number().default(3000),
 });
 
-describe('explainConfig', () => {
+describe('deriveConfigProvenance', () => {
   describe('default source', () => {
     test('reports "default" when no other source provides value', () => {
-      const entries = explainConfig({
+      const entries = deriveConfigProvenance({
         resolved: { debug: false, host: 'localhost', port: 3000 },
         schema,
       });
@@ -26,7 +26,7 @@ describe('explainConfig', () => {
 
   describe('base overrides default', () => {
     test('reports "base" when base provides value', () => {
-      const entries = explainConfig({
+      const entries = deriveConfigProvenance({
         base: { host: 'base.example.com' },
         resolved: { debug: false, host: 'base.example.com', port: 3000 },
         schema,
@@ -40,7 +40,7 @@ describe('explainConfig', () => {
 
   describe('profile overrides base', () => {
     test('reports "profile" when profile provides winning value', () => {
-      const entries = explainConfig({
+      const entries = deriveConfigProvenance({
         base: { host: 'base.example.com' },
         profile: { host: 'profile.example.com' },
         resolved: { debug: false, host: 'profile.example.com', port: 3000 },
@@ -55,7 +55,7 @@ describe('explainConfig', () => {
 
   describe('local overrides profile', () => {
     test('reports "local" when local provides winning value', () => {
-      const entries = explainConfig({
+      const entries = deriveConfigProvenance({
         base: { host: 'base.example.com' },
         local: { host: 'local.example.com' },
         profile: { host: 'profile.example.com' },
@@ -75,7 +75,7 @@ describe('explainConfig', () => {
         port: z.number().default(3000),
       });
 
-      const entries = explainConfig({
+      const entries = deriveConfigProvenance({
         base: { host: 'base.example.com' },
         env: { APP_HOST: 'env.example.com' },
         resolved: { host: 'env.example.com', port: 3000 },
@@ -96,7 +96,7 @@ describe('explainConfig', () => {
           .optional(),
       });
 
-      const entries = explainConfig({
+      const entries = deriveConfigProvenance({
         env: { DB_HOST: 'env.example.com' },
         resolved: { db: { host: 'env.example.com' } },
         schema: envSchema,
@@ -115,7 +115,7 @@ describe('explainConfig', () => {
         host: z.string().default('localhost'),
       });
 
-      const entries = explainConfig({
+      const entries = deriveConfigProvenance({
         env: { API_KEY: 'super-secret-key' },
         resolved: { apiKey: 'super-secret-key', host: 'localhost' },
         schema: secretSchema,
@@ -127,7 +127,7 @@ describe('explainConfig', () => {
     });
 
     test('does not redact non-secret fields', () => {
-      const entries = explainConfig({
+      const entries = deriveConfigProvenance({
         resolved: { debug: false, host: 'localhost', port: 3000 },
         schema,
       });

--- a/packages/config/src/__tests__/derive.test.ts
+++ b/packages/config/src/__tests__/derive.test.ts
@@ -3,10 +3,10 @@ import { z } from 'zod';
 
 import { deprecated, env, secret } from '../extensions.js';
 import {
-  generateEnvExample,
-  generateExample,
-  generateJsonSchema,
-} from '../generate/index.js';
+  deriveConfigEnvExample,
+  deriveConfigExample,
+  deriveConfigJsonSchema,
+} from '../derive/index.js';
 
 /** Shared test schema used across generator tests. */
 const testSchema = z.object({
@@ -39,10 +39,10 @@ const nestedSchema = z.object({
   }),
 });
 
-describe('generateExample()', () => {
+describe('deriveConfigExample()', () => {
   describe('TOML format', () => {
     test('produces valid TOML with comments for descriptions', () => {
-      const result = generateExample(testSchema, 'toml');
+      const result = deriveConfigExample(testSchema, 'toml');
 
       expect(result).toContain('# The server hostname');
       expect(result).toContain('host = "localhost"');
@@ -53,13 +53,13 @@ describe('generateExample()', () => {
     });
 
     test('annotates deprecated fields in TOML', () => {
-      const result = generateExample(annotatedSchema, 'toml');
+      const result = deriveConfigExample(annotatedSchema, 'toml');
 
       expect(result).toContain('# DEPRECATED: Use newEndpoint instead');
     });
 
     test('handles nested objects as TOML sections', () => {
-      const result = generateExample(nestedSchema, 'toml');
+      const result = deriveConfigExample(nestedSchema, 'toml');
 
       expect(result).toContain('[db]');
       expect(result).toContain('[server]');
@@ -70,7 +70,7 @@ describe('generateExample()', () => {
 
   describe('JSON format', () => {
     test('produces valid JSON without comments', () => {
-      const result = generateExample(testSchema, 'json');
+      const result = deriveConfigExample(testSchema, 'json');
       const parsed = JSON.parse(result);
 
       expect(parsed).toEqual({
@@ -81,7 +81,7 @@ describe('generateExample()', () => {
     });
 
     test('handles nested objects', () => {
-      const result = generateExample(nestedSchema, 'json');
+      const result = deriveConfigExample(nestedSchema, 'json');
       const parsed = JSON.parse(result);
 
       expect(parsed).toHaveProperty('db');
@@ -92,7 +92,7 @@ describe('generateExample()', () => {
 
   describe('JSONC format', () => {
     test('produces JSON with // comments for descriptions', () => {
-      const result = generateExample(testSchema, 'jsonc');
+      const result = deriveConfigExample(testSchema, 'jsonc');
 
       expect(result).toContain('// The server hostname');
       expect(result).toContain('"host"');
@@ -100,13 +100,13 @@ describe('generateExample()', () => {
     });
 
     test('annotates deprecated fields in JSONC', () => {
-      const result = generateExample(annotatedSchema, 'jsonc');
+      const result = deriveConfigExample(annotatedSchema, 'jsonc');
 
       expect(result).toContain('// DEPRECATED: Use newEndpoint instead');
     });
 
     test('handles nested objects', () => {
-      const result = generateExample(nestedSchema, 'jsonc');
+      const result = deriveConfigExample(nestedSchema, 'jsonc');
 
       expect(result).toContain('"db"');
       expect(result).toContain('"host"');
@@ -117,7 +117,7 @@ describe('generateExample()', () => {
 
   describe('YAML format', () => {
     test('produces valid YAML with comments for descriptions', () => {
-      const result = generateExample(testSchema, 'yaml');
+      const result = deriveConfigExample(testSchema, 'yaml');
 
       expect(result).toContain('# The server hostname');
       expect(result).toContain('host: "localhost"');
@@ -128,13 +128,13 @@ describe('generateExample()', () => {
     });
 
     test('annotates deprecated fields in YAML', () => {
-      const result = generateExample(annotatedSchema, 'yaml');
+      const result = deriveConfigExample(annotatedSchema, 'yaml');
 
       expect(result).toContain('# DEPRECATED: Use newEndpoint instead');
     });
 
     test('handles nested objects', () => {
-      const result = generateExample(nestedSchema, 'yaml');
+      const result = deriveConfigExample(nestedSchema, 'yaml');
 
       expect(result).toContain('db:');
       expect(result).toContain('  host: "localhost"');
@@ -143,9 +143,9 @@ describe('generateExample()', () => {
   });
 });
 
-describe('generateJsonSchema()', () => {
+describe('deriveConfigJsonSchema()', () => {
   test('produces valid JSON Schema with $schema, type, and properties', () => {
-    const result = generateJsonSchema(testSchema);
+    const result = deriveConfigJsonSchema(testSchema);
 
     expect(result.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
     expect(result.type).toBe('object');
@@ -153,7 +153,7 @@ describe('generateJsonSchema()', () => {
   });
 
   test('includes title and description from options', () => {
-    const result = generateJsonSchema(testSchema, {
+    const result = deriveConfigJsonSchema(testSchema, {
       description: 'Server configuration',
       title: 'ServerConfig',
     });
@@ -163,7 +163,7 @@ describe('generateJsonSchema()', () => {
   });
 
   test('includes descriptions from .describe()', () => {
-    const result = generateJsonSchema(testSchema);
+    const result = deriveConfigJsonSchema(testSchema);
     const props = result.properties as Record<string, Record<string, unknown>>;
 
     expect(props['host']?.description).toBe('The server hostname');
@@ -171,7 +171,7 @@ describe('generateJsonSchema()', () => {
   });
 
   test('includes defaults', () => {
-    const result = generateJsonSchema(testSchema);
+    const result = deriveConfigJsonSchema(testSchema);
     const props = result.properties as Record<string, Record<string, unknown>>;
 
     expect(props['host']?.default).toBe('localhost');
@@ -187,7 +187,7 @@ describe('generateJsonSchema()', () => {
       name: z.string().describe('A name'),
     });
 
-    const result = generateJsonSchema(enumSchema);
+    const result = deriveConfigJsonSchema(enumSchema);
     const props = result.properties as Record<string, Record<string, unknown>>;
 
     expect(props['name']?.type).toBe('string');
@@ -197,21 +197,21 @@ describe('generateJsonSchema()', () => {
   });
 
   test('marks deprecated fields', () => {
-    const result = generateJsonSchema(annotatedSchema);
+    const result = deriveConfigJsonSchema(annotatedSchema);
     const props = result.properties as Record<string, Record<string, unknown>>;
 
     expect(props['oldEndpoint']?.deprecated).toBe(true);
   });
 
   test('lists required fields (those without defaults or optional)', () => {
-    const result = generateJsonSchema(annotatedSchema);
+    const result = deriveConfigJsonSchema(annotatedSchema);
 
     expect(result.required).toContain('apiKey');
     expect(result.required).toContain('oldEndpoint');
   });
 
   test('recurses into nested object fields', () => {
-    const result = generateJsonSchema(nestedSchema);
+    const result = deriveConfigJsonSchema(nestedSchema);
     const props = result.properties as Record<string, Record<string, unknown>>;
 
     expect(props['db']?.type).toBe('object');
@@ -232,9 +232,9 @@ describe('generateJsonSchema()', () => {
   });
 });
 
-describe('generateEnvExample()', () => {
+describe('deriveConfigEnvExample()', () => {
   test('lists env vars with type info', () => {
-    const result = generateEnvExample(testSchema);
+    const result = deriveConfigEnvExample(testSchema);
 
     expect(result).toContain('HOST=');
     expect(result).toContain('PORT=');
@@ -243,14 +243,14 @@ describe('generateEnvExample()', () => {
   });
 
   test('annotates secrets', () => {
-    const result = generateEnvExample(annotatedSchema);
+    const result = deriveConfigEnvExample(annotatedSchema);
 
     expect(result).toContain('API_KEY=');
     expect(result).toContain('secret');
   });
 
   test('shows defaults as comments', () => {
-    const result = generateEnvExample(testSchema);
+    const result = deriveConfigEnvExample(testSchema);
 
     expect(result).toContain('default: "localhost"');
     expect(result).toContain('default: 3000');
@@ -262,7 +262,7 @@ describe('generateEnvExample()', () => {
       verbose: z.boolean().default(false),
     });
 
-    const result = generateEnvExample(noEnvSchema);
+    const result = deriveConfigEnvExample(noEnvSchema);
 
     expect(result).toBe('');
   });

--- a/packages/config/src/__tests__/resolve.test.ts
+++ b/packages/config/src/__tests__/resolve.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { z } from 'zod';
 
 import { env } from '../extensions.js';
-import { resolveConfig } from '../resolve.js';
+import { deriveConfig } from '../resolve.js';
 
 const baseSchema = z.object({
   debug: z.boolean().default(false),
@@ -10,10 +10,10 @@ const baseSchema = z.object({
   port: z.number().default(3000),
 });
 
-describe('resolveConfig', () => {
+describe('deriveConfig', () => {
   describe('schema defaults', () => {
     test('applies schema defaults when no other source provides values', () => {
-      const result = resolveConfig({ schema: baseSchema });
+      const result = deriveConfig({ schema: baseSchema });
 
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toEqual({
@@ -26,7 +26,7 @@ describe('resolveConfig', () => {
 
   describe('base config', () => {
     test('overrides schema defaults', () => {
-      const result = resolveConfig({
+      const result = deriveConfig({
         base: { host: 'example.com', port: 8080 },
         schema: baseSchema,
       });
@@ -42,7 +42,7 @@ describe('resolveConfig', () => {
 
   describe('profiles', () => {
     test('overrides base config for matching profile', () => {
-      const result = resolveConfig({
+      const result = deriveConfig({
         base: { host: 'example.com', port: 8080 },
         profile: 'production',
         profiles: {
@@ -59,7 +59,7 @@ describe('resolveConfig', () => {
     });
 
     test('silently ignores unrecognized profile (base only)', () => {
-      const result = resolveConfig({
+      const result = deriveConfig({
         base: { host: 'example.com' },
         profile: 'staging',
         profiles: {
@@ -84,7 +84,7 @@ describe('resolveConfig', () => {
           .default({}),
       });
 
-      const result = resolveConfig({
+      const result = deriveConfig({
         base: { db: { host: 'db.example.com', port: 5432 } },
         localOverrides: { db: { port: 9999 } },
         profile: 'production',
@@ -108,7 +108,7 @@ describe('resolveConfig', () => {
         port: env(z.number(), 'APP_PORT').default(3000),
       });
 
-      const result = resolveConfig({
+      const result = deriveConfig({
         base: { host: 'example.com', port: 8080 },
         env: { APP_HOST: 'env-host.example.com', APP_PORT: '9090' },
         schema,
@@ -125,7 +125,7 @@ describe('resolveConfig', () => {
         port: env(z.number(), 'PORT').default(3000),
       });
 
-      const result = resolveConfig({
+      const result = deriveConfig({
         env: { PORT: '8080' },
         schema,
       });
@@ -139,7 +139,7 @@ describe('resolveConfig', () => {
         port: env(z.number(), 'PORT').default(3000),
       });
 
-      const result = resolveConfig({
+      const result = deriveConfig({
         env: { PORT: 'abc' },
         schema,
       });
@@ -153,7 +153,7 @@ describe('resolveConfig', () => {
         verbose: env(z.boolean(), 'VERBOSE').default(false),
       });
 
-      const trueValues = resolveConfig({
+      const trueValues = deriveConfig({
         env: { DEBUG: 'true', VERBOSE: '1' },
         schema,
       });
@@ -161,7 +161,7 @@ describe('resolveConfig', () => {
       expect(trueValues.unwrap().debug).toBe(true);
       expect(trueValues.unwrap().verbose).toBe(true);
 
-      const falseValues = resolveConfig({
+      const falseValues = deriveConfig({
         env: { DEBUG: 'false', VERBOSE: '0' },
         schema,
       });
@@ -177,7 +177,7 @@ describe('resolveConfig', () => {
         required: z.string(),
       });
 
-      const result = resolveConfig({ schema });
+      const result = deriveConfig({ schema });
 
       expect(result.isErr()).toBe(true);
     });
@@ -190,7 +190,7 @@ describe('resolveConfig', () => {
       });
       const base = { host: 'dev-host' };
 
-      const first = resolveConfig({
+      const first = deriveConfig({
         base,
         env: { APP_HOST: 'env-host' },
         schema,
@@ -198,7 +198,7 @@ describe('resolveConfig', () => {
       expect(first.isOk()).toBe(true);
       expect(first.unwrap().host).toBe('env-host');
 
-      const second = resolveConfig({ base, schema });
+      const second = deriveConfig({ base, schema });
       expect(second.isOk()).toBe(true);
       expect(second.unwrap().host).toBe('dev-host');
       expect(base.host).toBe('dev-host');
@@ -215,7 +215,7 @@ describe('resolveConfig', () => {
         port: z.number().default(3000),
       });
 
-      const result = resolveConfig({
+      const result = deriveConfig({
         // base overrides name
         base: { name: 'my-app', port: 8080 },
         // env overrides debug and apiUrl

--- a/packages/config/src/app-config.ts
+++ b/packages/config/src/app-config.ts
@@ -9,10 +9,13 @@ import type { z } from 'zod';
 
 import type { CheckResult } from './doctor.js';
 import { checkConfig } from './doctor.js';
-import type { FieldDescription } from './describe.js';
-import { describeConfig } from './describe.js';
-import type { ExplainConfigOptions, ProvenanceEntry } from './explain.js';
-import { explainConfig } from './explain.js';
+import type { FieldDescription } from './derive-fields.js';
+import { deriveConfigFields } from './derive-fields.js';
+import type {
+  DeriveConfigProvenanceOptions,
+  ProvenanceEntry,
+} from './derive-provenance.js';
+import { deriveConfigProvenance } from './derive-provenance.js';
 import type { ConfigRef } from './ref.js';
 import { configRef } from './ref.js';
 
@@ -39,8 +42,8 @@ export interface ResolveOptions {
 }
 
 /** Options for the `explain()` method on AppConfig, excluding schema. */
-export type AppConfigExplainOptions = Omit<
-  ExplainConfigOptions<z.ZodType>,
+export type AppConfigDeriveProvenanceOptions = Omit<
+  DeriveConfigProvenanceOptions<z.ZodType>,
   'schema'
 >;
 
@@ -62,7 +65,9 @@ export interface AppConfig<T extends z.ZodType> {
   ): CheckResult;
 
   /** Show which source won for each config field. */
-  explain(options: AppConfigExplainOptions): readonly ProvenanceEntry[];
+  explain(
+    options: AppConfigDeriveProvenanceOptions
+  ): readonly ProvenanceEntry[];
 
   /** Create a lazy reference to a config field for use as a trail input default. */
   ref(fieldPath: string): ConfigRef;
@@ -225,7 +230,7 @@ const discoverConfigFile = async (
 };
 
 /** Resolve a config file — either from an explicit path or via discovery. */
-const resolveConfig = async <T extends z.ZodType>(
+const resolveAppConfigFile = async <T extends z.ZodType>(
   name: string,
   schema: T,
   formats: readonly ConfigFormat[],
@@ -292,16 +297,17 @@ export const appConfig = <T extends z.ZodType>(
   return {
     check: (values, checkOpts) => checkConfig(schema, values, checkOpts),
     describe: () =>
-      describeConfig(
+      deriveConfigFields(
         schema as unknown as z.ZodObject<Record<string, z.ZodType>>
       ),
     dotfile,
-    explain: (explainOpts) => explainConfig({ ...explainOpts, schema }),
+    explain: (explainOpts) =>
+      deriveConfigProvenance({ ...explainOpts, schema }),
     formats,
     name,
     ref: (fieldPath) => configRef(fieldPath),
     resolve: (resolveOptions?: ResolveOptions) =>
-      resolveConfig(name, schema, formats, dotfile, resolveOptions),
+      resolveAppConfigFile(name, schema, formats, dotfile, resolveOptions),
     schema,
   };
 };

--- a/packages/config/src/define-config.ts
+++ b/packages/config/src/define-config.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import type { z } from 'zod';
 
 import { appConfig } from './app-config.js';
-import { resolveConfig } from './resolve.js';
+import { deriveConfig } from './resolve.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -118,7 +118,7 @@ export const defineConfig = <T extends z.ZodType>(
       const cwd = resolveOpts?.cwd ?? process.cwd();
       const localOverrides = await discoverLocalOverrides(cwd, envRecord);
 
-      return resolveConfig({
+      return deriveConfig({
         base: options.base as Record<string, unknown> | undefined,
         env: envRecord,
         localOverrides,

--- a/packages/config/src/derive-fields.ts
+++ b/packages/config/src/derive-fields.ts
@@ -228,7 +228,7 @@ const walkShapeLevel = (
  *
  * Returns a structured catalog suitable for CLI rendering or agent inspection.
  */
-export const describeConfig = (
+export const deriveConfigFields = (
   schema: z.ZodObject<Record<string, z.ZodType>>
 ): readonly FieldDescription[] => {
   const configMeta = collectConfigMeta(schema);

--- a/packages/config/src/derive-provenance.ts
+++ b/packages/config/src/derive-provenance.ts
@@ -23,7 +23,7 @@ export interface ProvenanceEntry {
 }
 
 /** Options for explaining config provenance. */
-export interface ExplainConfigOptions<T extends z.ZodType> {
+export interface DeriveConfigProvenanceOptions<T extends z.ZodType> {
   readonly schema: T;
   readonly base?: Record<string, unknown>;
   readonly profile?: Record<string, unknown>;
@@ -135,8 +135,8 @@ const collectLeafPaths = (schema: z.ZodType, prefix: string): string[] => {
  * Used for debugging — answers "where did this value come from?"
  *
  */
-export const explainConfig = <T extends z.ZodType>(
-  options: ExplainConfigOptions<T>
+export const deriveConfigProvenance = <T extends z.ZodType>(
+  options: DeriveConfigProvenanceOptions<T>
 ): readonly ProvenanceEntry[] => {
   const objSchema = options.schema as unknown as z.ZodObject<
     Record<string, z.ZodType>

--- a/packages/config/src/derive/env.ts
+++ b/packages/config/src/derive/env.ts
@@ -15,7 +15,7 @@ import {
   formatValue,
   getDefault,
   getDescription,
-  resolveFieldByPath,
+  deriveFieldByPath,
   unwrap,
   zodTypeName,
   zodTypeToJsonSchema,
@@ -76,7 +76,7 @@ const collectEnvEntries = (
     if (!fieldMeta.env) {
       continue;
     }
-    const fieldSchema = resolveFieldByPath(schema, path);
+    const fieldSchema = deriveFieldByPath(schema, path);
     if (!fieldSchema) {
       continue;
     }
@@ -96,7 +96,7 @@ const collectEnvEntries = (
  * Lists each env var with its type, default, and whether it is a secret.
  * Returns an empty string when no env bindings are present.
  */
-export const generateEnvExample = (
+export const deriveConfigEnvExample = (
   schema: z.ZodObject<Record<string, z.ZodType>>
 ): string => {
   const entries = collectEnvEntries(schema, collectConfigMeta(schema));

--- a/packages/config/src/derive/example.ts
+++ b/packages/config/src/derive/example.ts
@@ -216,7 +216,7 @@ const formatters: Record<
  *
  * Includes descriptions as comments, defaults shown, deprecated fields annotated.
  */
-export const generateExample = (
+export const deriveConfigExample = (
   schema: z.ZodObject<Record<string, z.ZodType>>,
   format: ExampleFormat
 ): string => formatters[format](schema);

--- a/packages/config/src/derive/helpers.ts
+++ b/packages/config/src/derive/helpers.ts
@@ -86,7 +86,7 @@ export const getObjectShape = (
 };
 
 /** Resolve a dot-separated path to the field schema within an object. */
-export const resolveFieldByPath = (
+export const deriveFieldByPath = (
   schema: z.ZodObject<Record<string, z.ZodType>>,
   path: string
 ): z.ZodType | undefined => {

--- a/packages/config/src/derive/index.ts
+++ b/packages/config/src/derive/index.ts
@@ -1,0 +1,3 @@
+export { deriveConfigEnvExample } from './env.js';
+export { deriveConfigExample } from './example.js';
+export { deriveConfigJsonSchema } from './json-schema.js';

--- a/packages/config/src/derive/json-schema.ts
+++ b/packages/config/src/derive/json-schema.ts
@@ -112,7 +112,7 @@ const buildSchemaProperties = (
  * Includes descriptions, defaults, deprecated annotations, and constraints.
  * Produces JSON Schema Draft 2020-12.
  */
-export const generateJsonSchema = (
+export const deriveConfigJsonSchema = (
   schema: z.ZodObject<Record<string, z.ZodType>>,
   options?: { readonly description?: string; readonly title?: string }
 ): Record<string, unknown> => {

--- a/packages/config/src/generate/index.ts
+++ b/packages/config/src/generate/index.ts
@@ -1,3 +1,0 @@
-export { generateEnvExample } from './env.js';
-export { generateExample } from './example.js';
-export { generateJsonSchema } from './json-schema.js';

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,7 +1,7 @@
 export {
   appConfig,
   type AppConfig,
-  type AppConfigExplainOptions,
+  type AppConfigDeriveProvenanceOptions,
   type AppConfigOptions,
   type ConfigFormat,
   type ResolveOptions,
@@ -14,7 +14,7 @@ export {
   type ServiceConfigEntry,
 } from './compose.js';
 export { defineConfig, type DefineConfigOptions } from './define-config.js';
-export { describeConfig, type FieldDescription } from './describe.js';
+export { deriveConfigFields, type FieldDescription } from './derive-fields.js';
 export {
   checkConfig,
   type CheckResult,
@@ -22,15 +22,15 @@ export {
 } from './doctor.js';
 export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
 export {
-  explainConfig,
-  type ExplainConfigOptions,
+  deriveConfigProvenance,
+  type DeriveConfigProvenanceOptions,
   type ProvenanceEntry,
-} from './explain.js';
+} from './derive-provenance.js';
 export {
-  generateEnvExample,
-  generateExample,
-  generateJsonSchema,
-} from './generate/index.js';
+  deriveConfigEnvExample,
+  deriveConfigExample,
+  deriveConfigJsonSchema,
+} from './derive/index.js';
 export { configLayer } from './config-layer.js';
 export { configResource } from './config-resource.js';
 export {
@@ -41,7 +41,7 @@ export {
 } from './registry.js';
 export { deepMerge } from './merge.js';
 export { configRef, isConfigRef, type ConfigRef } from './ref.js';
-export { resolveConfig, type ResolveConfigOptions } from './resolve.js';
+export { deriveConfig, type DeriveConfigOptions } from './resolve.js';
 export { configCheck } from './trails/config-check.js';
 export { configDescribe } from './trails/config-describe.js';
 export { configExplain } from './trails/config-explain.js';

--- a/packages/config/src/resolve.ts
+++ b/packages/config/src/resolve.ts
@@ -16,7 +16,7 @@ import { zodDef } from './zod-utils.js';
 // ---------------------------------------------------------------------------
 
 /** Options for resolving config through the full stack. */
-export interface ResolveConfigOptions<T extends z.ZodType> {
+export interface DeriveConfigOptions<T extends z.ZodType> {
   readonly schema: T;
   readonly base?: Record<string, unknown> | undefined;
   readonly profiles?: Record<string, Record<string, unknown>> | undefined;
@@ -256,8 +256,8 @@ const formatValidationError = (
  * Resolve config through the full stack: defaults → base → profile → local → env.
  * Returns `Result.ok` with the validated config, or `Result.err` on validation failure.
  */
-export const resolveConfig = <T extends z.ZodType>(
-  options: ResolveConfigOptions<T>
+export const deriveConfig = <T extends z.ZodType>(
+  options: DeriveConfigOptions<T>
 ): Result<z.infer<T>, Error> => {
   let merged = mergeLayers(
     options.base,

--- a/packages/config/src/resolve.ts
+++ b/packages/config/src/resolve.ts
@@ -253,7 +253,7 @@ const formatValidationError = (
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve config through the full stack: defaults → base → profile → local → env.
+ * Derive config through the full stack: defaults → base → profile → local → env.
  * Returns `Result.ok` with the validated config, or `Result.err` on validation failure.
  */
 export const deriveConfig = <T extends z.ZodType>(

--- a/packages/config/src/trails/config-describe.ts
+++ b/packages/config/src/trails/config-describe.ts
@@ -8,7 +8,7 @@ import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { configResource } from '../config-resource.js';
-import { describeConfig } from '../describe.js';
+import { deriveConfigFields } from '../derive-fields.js';
 
 const fieldSchema = z.object({
   deprecated: z.string().optional(),
@@ -27,7 +27,7 @@ const outputSchema = z.object({
 export const configDescribe = trail('config.describe', {
   blaze: (_input, ctx) => {
     const state = configResource.from(ctx);
-    const fields = describeConfig(state.schema);
+    const fields = deriveConfigFields(state.schema);
     return Result.ok({ fields: [...fields] });
   },
   examples: [

--- a/packages/config/src/trails/config-explain.ts
+++ b/packages/config/src/trails/config-explain.ts
@@ -8,8 +8,8 @@ import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { configResource } from '../config-resource.js';
-import type { ExplainConfigOptions } from '../explain.js';
-import { explainConfig } from '../explain.js';
+import type { DeriveConfigProvenanceOptions } from '../derive-provenance.js';
+import { deriveConfigProvenance } from '../derive-provenance.js';
 import type { ConfigState } from '../registry.js';
 
 const provenanceEntrySchema = z.object({
@@ -34,11 +34,11 @@ const filterByPath = (
       )
     : entries;
 
-/** Build ExplainConfigOptions from ConfigState, omitting undefined source overrides. */
+/** Build DeriveConfigProvenanceOptions from ConfigState, omitting undefined source overrides. */
 const toExplainOptions = (
   state: ConfigState
-): ExplainConfigOptions<typeof state.schema> => {
-  const base: ExplainConfigOptions<typeof state.schema> = {
+): DeriveConfigProvenanceOptions<typeof state.schema> => {
+  const base: DeriveConfigProvenanceOptions<typeof state.schema> = {
     resolved: state.resolved,
     schema: state.schema,
   };
@@ -51,8 +51,8 @@ const toExplainOptions = (
 /** Enrich explain options with env and source overrides from state. */
 const enrichOptions = (
   state: ConfigState,
-  options: ExplainConfigOptions<typeof state.schema>
-): ExplainConfigOptions<typeof state.schema> => {
+  options: DeriveConfigProvenanceOptions<typeof state.schema>
+): DeriveConfigProvenanceOptions<typeof state.schema> => {
   let enriched = options;
   if (state.env) {
     enriched = { ...enriched, env: state.env };
@@ -70,7 +70,7 @@ export const configExplain = trail('config.explain', {
   blaze: (input, ctx) => {
     const state = configResource.from(ctx);
     const options = enrichOptions(state, toExplainOptions(state));
-    const entries = explainConfig(options);
+    const entries = deriveConfigProvenance(options);
     const filtered = filterByPath(entries, input.path);
     return Result.ok({ entries: [...filtered] });
   },

--- a/packages/config/src/trails/config-init.ts
+++ b/packages/config/src/trails/config-init.ts
@@ -16,10 +16,10 @@ import { z as zod } from 'zod';
 
 import { configResource } from '../config-resource.js';
 import {
-  generateEnvExample,
-  generateExample,
-  generateJsonSchema,
-} from '../generate/index.js';
+  deriveConfigEnvExample,
+  deriveConfigExample,
+  deriveConfigJsonSchema,
+} from '../derive/index.js';
 
 const formatEnum = zod.enum(['toml', 'json', 'jsonc', 'yaml']);
 
@@ -34,13 +34,13 @@ const collectArtifacts = (
   schema: z.ZodObject<Record<string, z.ZodType>>
 ): [string, string][] => {
   const artifacts: [string, string][] = [];
-  const envContent = generateEnvExample(schema);
+  const envContent = deriveConfigEnvExample(schema);
   if (envContent.length > 0) {
     artifacts.push(['.env.example', envContent]);
   }
   artifacts.push([
     '.schema.json',
-    JSON.stringify(generateJsonSchema(schema), null, 2),
+    JSON.stringify(deriveConfigJsonSchema(schema), null, 2),
   ]);
   return artifacts;
 };
@@ -65,7 +65,7 @@ export const configInit = trail('config.init', {
   blaze: async (input, ctx) => {
     const state = configResource.from(ctx);
     const schema = state.schema as z.ZodObject<Record<string, z.ZodType>>;
-    const content = generateExample(schema, input.format);
+    const content = deriveConfigExample(schema, input.format);
 
     if (input.dir) {
       const writtenFiles = await writeArtifacts(input.dir, schema);

--- a/packages/core/src/internal/trails-db.ts
+++ b/packages/core/src/internal/trails-db.ts
@@ -40,11 +40,11 @@ interface SchemaVersionRow {
   readonly version: number;
 }
 
-const resolveRootDir = (rootDir?: string): string =>
+const deriveRootDir = (rootDir?: string): string =>
   resolve(rootDir ?? process.cwd());
 
 export const deriveTrailsDir = (options?: TrailsDbLocationOptions): string =>
-  join(resolveRootDir(options?.rootDir), TRAILS_DIR);
+  join(deriveRootDir(options?.rootDir), TRAILS_DIR);
 
 export const deriveTrailsDbPath = (options?: TrailsDbLocationOptions): string =>
   options?.path
@@ -138,7 +138,7 @@ const writeSubsystemVersion = (
 export const openWriteTrailsDb = (
   options?: TrailsDbLocationOptions
 ): Database => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   const dbPath = deriveTrailsDbPath(
     options?.path ? { path: options.path, rootDir } : { rootDir }
   );

--- a/packages/logging/src/__tests__/env.test.ts
+++ b/packages/logging/src/__tests__/env.test.ts
@@ -1,21 +1,21 @@
 import { describe, test, expect } from 'bun:test';
 
-import { resolveLogLevel } from '../env.js';
+import { deriveLogLevel } from '../env.js';
 
 // ---------------------------------------------------------------------------
-// resolveLogLevel
+// deriveLogLevel
 // ---------------------------------------------------------------------------
 
-describe('resolveLogLevel', () => {
+describe('deriveLogLevel', () => {
   test('reads from TRAILS_LOG_LEVEL', () => {
-    expect(resolveLogLevel({ TRAILS_LOG_LEVEL: 'debug' })).toBe('debug');
-    expect(resolveLogLevel({ TRAILS_LOG_LEVEL: 'error' })).toBe('error');
-    expect(resolveLogLevel({ TRAILS_LOG_LEVEL: 'trace' })).toBe('trace');
+    expect(deriveLogLevel({ TRAILS_LOG_LEVEL: 'debug' })).toBe('debug');
+    expect(deriveLogLevel({ TRAILS_LOG_LEVEL: 'error' })).toBe('error');
+    expect(deriveLogLevel({ TRAILS_LOG_LEVEL: 'trace' })).toBe('trace');
   });
 
   test('TRAILS_LOG_LEVEL takes precedence over TRAILS_ENV', () => {
     expect(
-      resolveLogLevel({
+      deriveLogLevel({
         TRAILS_ENV: 'development',
         TRAILS_LOG_LEVEL: 'error',
       })
@@ -23,29 +23,29 @@ describe('resolveLogLevel', () => {
   });
 
   test('falls back to TRAILS_ENV profile defaults', () => {
-    expect(resolveLogLevel({ TRAILS_ENV: 'development' })).toBe('debug');
+    expect(deriveLogLevel({ TRAILS_ENV: 'development' })).toBe('debug');
   });
 
   test('TRAILS_ENV=test returns undefined', () => {
-    expect(resolveLogLevel({ TRAILS_ENV: 'test' })).toBeUndefined();
+    expect(deriveLogLevel({ TRAILS_ENV: 'test' })).toBeUndefined();
   });
 
   test('TRAILS_ENV=production returns undefined', () => {
-    expect(resolveLogLevel({ TRAILS_ENV: 'production' })).toBeUndefined();
+    expect(deriveLogLevel({ TRAILS_ENV: 'production' })).toBeUndefined();
   });
 
   test('returns undefined when no env is set', () => {
-    expect(resolveLogLevel({})).toBeUndefined();
+    expect(deriveLogLevel({})).toBeUndefined();
   });
 
   test('invalid TRAILS_LOG_LEVEL values are ignored', () => {
-    expect(resolveLogLevel({ TRAILS_LOG_LEVEL: 'banana' })).toBeUndefined();
-    expect(resolveLogLevel({ TRAILS_LOG_LEVEL: '' })).toBeUndefined();
+    expect(deriveLogLevel({ TRAILS_LOG_LEVEL: 'banana' })).toBeUndefined();
+    expect(deriveLogLevel({ TRAILS_LOG_LEVEL: '' })).toBeUndefined();
   });
 
   test('invalid TRAILS_LOG_LEVEL falls through to TRAILS_ENV', () => {
     expect(
-      resolveLogLevel({
+      deriveLogLevel({
         TRAILS_ENV: 'development',
         TRAILS_LOG_LEVEL: 'banana',
       })

--- a/packages/logging/src/__tests__/levels.test.ts
+++ b/packages/logging/src/__tests__/levels.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 
-import { shouldLog, resolveCategory, LEVEL_PRIORITY } from '../levels.js';
+import { shouldLog, deriveCategory, LEVEL_PRIORITY } from '../levels.js';
 
 // ---------------------------------------------------------------------------
 // LEVEL_PRIORITY
@@ -46,37 +46,37 @@ describe('shouldLog', () => {
 });
 
 // ---------------------------------------------------------------------------
-// resolveCategory
+// deriveCategory
 // ---------------------------------------------------------------------------
 
-describe('resolveCategory', () => {
+describe('deriveCategory', () => {
   test('returns exact match for a full category name', () => {
     const levels = { 'app.db.queries': 'debug' as const };
-    expect(resolveCategory('app.db.queries', levels, 'info')).toBe('debug');
+    expect(deriveCategory('app.db.queries', levels, 'info')).toBe('debug');
   });
 
   test('walks up hierarchy: app.db.queries -> app.db -> app', () => {
     const levels = { app: 'warn' as const, 'app.db': 'debug' as const };
     // "app.db.queries" not found, falls to "app.db"
-    expect(resolveCategory('app.db.queries', levels, 'info')).toBe('debug');
+    expect(deriveCategory('app.db.queries', levels, 'info')).toBe('debug');
   });
 
   test('walks all the way to parent prefix', () => {
     const levels = { app: 'error' as const };
-    expect(resolveCategory('app.db.queries', levels, 'info')).toBe('error');
+    expect(deriveCategory('app.db.queries', levels, 'info')).toBe('error');
   });
 
   test('returns fallback when no prefix matches', () => {
     const levels = { other: 'debug' as const };
-    expect(resolveCategory('app.db.queries', levels, 'info')).toBe('info');
+    expect(deriveCategory('app.db.queries', levels, 'info')).toBe('info');
   });
 
   test('returns fallback when levels is undefined', () => {
-    expect(resolveCategory('app.db', undefined, 'warn')).toBe('warn');
+    expect(deriveCategory('app.db', undefined, 'warn')).toBe('warn');
   });
 
   test('returns fallback when category has no dots and no match', () => {
     const levels = { other: 'debug' as const };
-    expect(resolveCategory('app', levels, 'info')).toBe('info');
+    expect(deriveCategory('app', levels, 'info')).toBe('info');
   });
 });

--- a/packages/logging/src/env.ts
+++ b/packages/logging/src/env.ts
@@ -11,7 +11,7 @@ const isValidLogLevel = (value: string): value is LogLevel =>
   VALID_LEVELS.has(value);
 
 // ---------------------------------------------------------------------------
-// resolveLogLevel
+// deriveLogLevel
 // ---------------------------------------------------------------------------
 
 /**
@@ -24,7 +24,7 @@ const isValidLogLevel = (value: string): value is LogLevel =>
  *    - `production` -> `undefined` (caller falls through to `"info"`)
  * 3. `undefined` -- no env-based level configured.
  */
-export const resolveLogLevel = (
+export const deriveLogLevel = (
   env?: Record<string, string | undefined>
 ): LogLevel | undefined => {
   const source = env ?? process.env;

--- a/packages/logging/src/env.ts
+++ b/packages/logging/src/env.ts
@@ -15,7 +15,7 @@ const isValidLogLevel = (value: string): value is LogLevel =>
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve log level from environment variables.
+ * Derive log level from environment variables.
  *
  * 1. `TRAILS_LOG_LEVEL` -- explicit override (if valid).
  * 2. `TRAILS_ENV` profile defaults:

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -9,10 +9,10 @@ export { createConsoleSink, createFileSink } from './sinks.js';
 export { createJsonFormatter, createPrettyFormatter } from './formatters.js';
 
 // Level resolution
-export { resolveLogLevel } from './env.js';
+export { deriveLogLevel } from './env.js';
 
 // Levels
-export { LEVEL_PRIORITY, shouldLog, resolveCategory } from './levels.js';
+export { LEVEL_PRIORITY, shouldLog, deriveCategory } from './levels.js';
 
 // Types
 export type {

--- a/packages/logging/src/levels.ts
+++ b/packages/logging/src/levels.ts
@@ -28,7 +28,7 @@ export const shouldLog = (
 ): boolean => LEVEL_PRIORITY[messageLevel] >= LEVEL_PRIORITY[configuredLevel];
 
 // ---------------------------------------------------------------------------
-// resolveCategory
+// deriveCategory
 // ---------------------------------------------------------------------------
 
 /**
@@ -57,7 +57,7 @@ const findLevel = (
   return undefined;
 };
 
-export const resolveCategory = (
+export const deriveCategory = (
   name: string,
   levels: Record<string, LogLevel> | undefined,
   fallback: LogLevel

--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -6,8 +6,8 @@ import {
 
 import type { Logger } from '@ontrails/core';
 
-import { resolveLogLevel } from './env.js';
-import { resolveCategory, shouldLog } from './levels.js';
+import { deriveLogLevel } from './env.js';
+import { deriveCategory, shouldLog } from './levels.js';
 import { createConsoleSink } from './sinks.js';
 import type {
   LogLevel,
@@ -110,9 +110,9 @@ const buildInstance = (
  * This is the **only** API for creating loggers in `@ontrails/logging`.
  */
 export const createLogger = (config: LoggerConfig): Logger => {
-  const envLevel = resolveLogLevel();
+  const envLevel = deriveLogLevel();
   const baseLevel: LogLevel = config.level ?? envLevel ?? 'info';
-  const effectiveLevel = resolveCategory(config.name, config.levels, baseLevel);
+  const effectiveLevel = deriveCategory(config.name, config.levels, baseLevel);
 
   const redactor = createRedactor({
     patterns: [...DEFAULT_PATTERNS, ...(config.redaction?.patterns ?? [])],

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -18,29 +18,32 @@ The package does not own topo history, pins, or `trails.db`. Those higher-level 
 
 ```typescript
 import {
-  diffTrailheadMaps,
-  generateTrailheadMap,
-  hashTrailheadMap,
+  deriveOpenApiSpec,
+  deriveSurfaceMap,
+  deriveSurfaceMapDiff,
+  deriveSurfaceMapHash,
   writeTrailheadLock,
   writeTrailheadMap,
 } from '@ontrails/schema';
 
-const map = generateTrailheadMap(app);
-const hash = hashTrailheadMap(map);
+const map = deriveSurfaceMap(app);
+const hash = deriveSurfaceMapHash(map);
 
 await writeTrailheadMap(map);
 await writeTrailheadLock({ hash });
 
 // Later, after changes:
-const nextMap = generateTrailheadMap(app);
-const diff = diffTrailheadMaps(map, nextMap);
+const nextMap = deriveSurfaceMap(app);
+const diff = deriveSurfaceMapDiff(map, nextMap);
 
 if (diff.hasBreaking) {
   console.error('Breaking changes:', diff.breaking);
 }
+
+const openApi = deriveOpenApiSpec(app);
 ```
 
-`generateTrailheadMap()` rejects draft-contaminated topos. Only established state can be serialized into the committed artifacts.
+`deriveSurfaceMap()` rejects draft-contaminated topos. Only established state can be serialized into the committed artifacts.
 
 ## File outputs
 
@@ -55,15 +58,15 @@ The typical exported artifact pair is:
 
 | Export | What it does |
 | --- | --- |
-| `generateTrailheadMap(topo)` | Deterministic trailhead map of every established trail, signal, and resource |
-| `hashTrailheadMap(map)` | Stable SHA-256 hash of the map |
-| `diffTrailheadMaps(prev, curr)` | Semantic diff with `breaking`, `warning`, and `info` classifications |
+| `deriveSurfaceMap(topo)` | Deterministic trailhead map of every established trail, signal, and resource |
+| `deriveSurfaceMapHash(map)` | Stable SHA-256 hash of the map |
+| `deriveSurfaceMapDiff(prev, curr)` | Semantic diff with `breaking`, `warning`, and `info` classifications |
 | `writeTrailheadMap(map, options?)` | Write `.trails/_trailhead.json` |
 | `readTrailheadMap(options?)` | Read `.trails/_trailhead.json` |
 | `writeTrailheadLock(lock, options?)` | Write `.trails/trails.lock` as either structured JSON or legacy hash text |
 | `readTrailheadLockData(options?)` | Read the full normalized lock payload from `.trails/trails.lock` |
 | `readTrailheadLock(options?)` | Read just the committed lock hash |
-| `generateOpenApiSpec(topo, options?)` | Generate an OpenAPI 3.1 document from the topo |
+| `deriveOpenApiSpec(topo, options?)` | Generate an OpenAPI 3.1 document from the topo |
 
 ## Breaking change detection
 
@@ -91,9 +94,9 @@ Because CLI paths are now full hierarchical command paths, command-tree changes 
 ## Drift detection with warden
 
 ```typescript
-import { generateTrailheadMap, hashTrailheadMap, readTrailheadLock } from '@ontrails/schema';
+import { deriveSurfaceMap, deriveSurfaceMapHash, readTrailheadLock } from '@ontrails/schema';
 
-const current = hashTrailheadMap(generateTrailheadMap(app));
+const current = deriveSurfaceMapHash(deriveSurfaceMap(app));
 const committed = await readTrailheadLock();
 
 if (committed !== current) {

--- a/packages/schema/src/__tests__/derive.test.ts
+++ b/packages/schema/src/__tests__/derive.test.ts
@@ -12,7 +12,7 @@ import {
 import type { Topo } from '@ontrails/core';
 import { z } from 'zod';
 
-import { generateTrailheadMap } from '../generate.js';
+import { deriveSurfaceMap } from '../derive.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -45,7 +45,7 @@ const gistContour = contour(
   { identity: 'id' }
 );
 
-const getFirstEntry = (map: ReturnType<typeof generateTrailheadMap>) => {
+const getFirstEntry = (map: ReturnType<typeof deriveSurfaceMap>) => {
   const [entry] = map.entries;
   expect(entry).toBeDefined();
   if (!entry) {
@@ -70,7 +70,7 @@ const expectSchemaProperties = (
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('generateTrailheadMap', () => {
+describe('deriveSurfaceMap', () => {
   describe('entries', () => {
     test('produces entries for all trails in the topo', () => {
       const a = trail('a.create', {
@@ -82,7 +82,7 @@ describe('generateTrailheadMap', () => {
         input: z.object({}),
       });
       const tp = topoFrom({ a, b });
-      const map = generateTrailheadMap(tp);
+      const map = deriveSurfaceMap(tp);
 
       expect(map.entries).toHaveLength(2);
       expect(map.entries.map((e) => e.id)).toEqual(['a.create', 'b.list']);
@@ -102,7 +102,7 @@ describe('generateTrailheadMap', () => {
         input: z.object({}),
       });
       const tp = topoFrom({ a2, m2, z2 });
-      const map = generateTrailheadMap(tp);
+      const map = deriveSurfaceMap(tp);
 
       expect(map.entries.map((e) => e.id)).toEqual([
         'a.trail',
@@ -118,7 +118,7 @@ describe('generateTrailheadMap', () => {
         output: z.object({ id: z.string(), name: z.string() }),
         resources: [dbResource],
       });
-      const map = generateTrailheadMap(topoFrom({ t }));
+      const map = deriveSurfaceMap(topoFrom({ t }));
       const entry = getFirstEntry(map);
 
       expect(entry.input).toBeDefined();
@@ -141,7 +141,7 @@ describe('generateTrailheadMap', () => {
         contours: [gistContour, userContour],
         input: z.object({}),
       });
-      const entry = generateTrailheadMap(topoFrom({ t })).entries.find(
+      const entry = deriveSurfaceMap(topoFrom({ t })).entries.find(
         (candidate) => candidate.id === 'gist.create'
       );
 
@@ -154,7 +154,7 @@ describe('generateTrailheadMap', () => {
         input: z.object({ msg: z.string() }),
       });
       const tp = topoFrom({ t });
-      const map = generateTrailheadMap(tp);
+      const map = deriveSurfaceMap(tp);
 
       expect(map.entries[0]?.output).toBeUndefined();
     });
@@ -170,7 +170,7 @@ describe('generateTrailheadMap', () => {
         input: z.object({ id: z.string(), name: z.string() }),
       });
       const tp = topoFrom({ base, r });
-      const map = generateTrailheadMap(tp);
+      const map = deriveSurfaceMap(tp);
       const crossesEntry = map.entries.find((e) => e.id === 'user.update');
       expect(crossesEntry).toBeDefined();
 
@@ -184,7 +184,7 @@ describe('generateTrailheadMap', () => {
         description: 'A user was created',
         payload: z.object({ userId: z.string() }),
       });
-      const entry = getFirstEntry(generateTrailheadMap(topoFrom({ e })));
+      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ e })));
 
       expect(entry.kind).toBe('signal');
       expect(entry.id).toBe('user.created');
@@ -193,7 +193,7 @@ describe('generateTrailheadMap', () => {
     });
 
     test('resource entries are included with description and healthcheck metadata', () => {
-      const map = generateTrailheadMap(topoFrom({ dbResource }));
+      const map = deriveSurfaceMap(topoFrom({ dbResource }));
       const entry = getFirstEntry(map);
 
       expect(entry.kind).toBe('resource');
@@ -204,7 +204,7 @@ describe('generateTrailheadMap', () => {
     });
 
     test('contour entries are included with schema and references', () => {
-      const entry = generateTrailheadMap(
+      const entry = deriveSurfaceMap(
         topoFrom({ gistContour, userContour })
       ).entries.find((candidate) => candidate.id === 'gist');
 
@@ -234,7 +234,7 @@ describe('generateTrailheadMap', () => {
         input: z.object({}),
         intent: 'read',
       });
-      const entry = getFirstEntry(generateTrailheadMap(topoFrom({ t })));
+      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ t })));
 
       expect(entry.intent).toBe('read');
       expect(entry.idempotent).toBe(true);
@@ -252,7 +252,7 @@ describe('generateTrailheadMap', () => {
         output: z.object({ y: z.number() }),
       });
       const tp = topoFrom({ t });
-      const map = generateTrailheadMap(tp);
+      const map = deriveSurfaceMap(tp);
 
       expect(map.entries[0]?.exampleCount).toBe(3);
     });
@@ -270,7 +270,7 @@ describe('generateTrailheadMap', () => {
         ],
         input: z.object({}),
       });
-      const entry = getFirstEntry(generateTrailheadMap(topoFrom({ t })));
+      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ t })));
 
       expect(entry.detours).toEqual([{ maxAttempts: 2, on: 'ConflictError' }]);
     });
@@ -282,7 +282,7 @@ describe('generateTrailheadMap', () => {
         input: z.object({}),
       });
       const tp = topoFrom({ t });
-      const map = generateTrailheadMap(tp);
+      const map = deriveSurfaceMap(tp);
 
       expect(map.entries[0]?.description).toBe('A described trail');
     });
@@ -299,8 +299,8 @@ describe('generateTrailheadMap', () => {
       });
       const tp = topoFrom({ t });
 
-      const map1 = generateTrailheadMap(tp);
-      const map2 = generateTrailheadMap(tp);
+      const map1 = deriveSurfaceMap(tp);
+      const map2 = deriveSurfaceMap(tp);
 
       expect(map1.entries).toEqual(map2.entries);
       expect(map1.version).toBe(map2.version);
@@ -312,7 +312,7 @@ describe('generateTrailheadMap', () => {
         input: z.object({}),
       });
       const tp = topoFrom({ t });
-      const map = generateTrailheadMap(tp);
+      const map = deriveSurfaceMap(tp);
 
       expect(map.version).toBe('1.0');
     });
@@ -323,7 +323,7 @@ describe('generateTrailheadMap', () => {
         input: z.object({}),
       });
       const tp = topoFrom({ t });
-      const map = generateTrailheadMap(tp);
+      const map = deriveSurfaceMap(tp);
 
       expect(new Date(map.generatedAt).toISOString()).toBe(map.generatedAt);
     });
@@ -337,9 +337,9 @@ describe('generateTrailheadMap', () => {
         input: z.object({}),
       });
 
-      expect(() =>
-        generateTrailheadMap(topoFrom({ exportTrail }))
-      ).toThrowError(/draft/i);
+      expect(() => deriveSurfaceMap(topoFrom({ exportTrail }))).toThrowError(
+        /draft/i
+      );
     });
   });
 });

--- a/packages/schema/src/__tests__/diff.test.ts
+++ b/packages/schema/src/__tests__/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 
-import { diffTrailheadMaps } from '../diff.js';
+import { deriveSurfaceMapDiff } from '../diff.js';
 import type { TrailheadMap, TrailheadMapEntry } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -26,11 +26,11 @@ const trailheadMap = (entries: TrailheadMapEntry[]): TrailheadMap => ({
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('diffTrailheadMaps', () => {
+describe('deriveSurfaceMapDiff', () => {
   describe('top-level changes', () => {
     test('empty diff for identical maps', () => {
       const e = entry({ id: 'user.create' });
-      const result = diffTrailheadMaps(trailheadMap([e]), trailheadMap([e]));
+      const result = deriveSurfaceMapDiff(trailheadMap([e]), trailheadMap([e]));
 
       expect(result.entries).toHaveLength(0);
       expect(result.hasBreaking).toBe(false);
@@ -39,7 +39,7 @@ describe('diffTrailheadMaps', () => {
     test('added trail detected as info', () => {
       const prev = trailheadMap([]);
       const curr = trailheadMap([entry({ id: 'user.create' })]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries).toHaveLength(1);
       expect(result.entries[0]?.change).toBe('added');
@@ -50,7 +50,7 @@ describe('diffTrailheadMaps', () => {
     test('added resource detected as info', () => {
       const prev = trailheadMap([]);
       const curr = trailheadMap([entry({ id: 'db.main', kind: 'resource' })]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries[0]?.details).toContain('Resource "db.main" added');
       expect(result.info).toHaveLength(1);
@@ -59,7 +59,7 @@ describe('diffTrailheadMaps', () => {
     test('added contour detected as info', () => {
       const prev = trailheadMap([]);
       const curr = trailheadMap([entry({ id: 'user', kind: 'contour' })]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries[0]?.details).toContain('Contour "user" added');
       expect(result.info).toHaveLength(1);
@@ -68,7 +68,7 @@ describe('diffTrailheadMaps', () => {
     test('removed trail detected as breaking', () => {
       const prev = trailheadMap([entry({ id: 'user.delete' })]);
       const curr = trailheadMap([]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries).toHaveLength(1);
       expect(result.entries[0]?.change).toBe('removed');
@@ -79,7 +79,7 @@ describe('diffTrailheadMaps', () => {
     test('removed resource detected as breaking', () => {
       const prev = trailheadMap([entry({ id: 'db.main', kind: 'resource' })]);
       const curr = trailheadMap([]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries[0]?.details).toContain(
         'Resource "db.main" removed'
@@ -90,7 +90,7 @@ describe('diffTrailheadMaps', () => {
     test('DiffResult.hasBreaking is true when any breaking entries exist', () => {
       const prev = trailheadMap([entry({ id: 'user.delete' })]);
       const curr = trailheadMap([]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(result.breaking.length).toBeGreaterThan(0);
@@ -122,7 +122,7 @@ describe('diffTrailheadMaps', () => {
           },
         }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(result.breaking).toHaveLength(1);
@@ -159,7 +159,7 @@ describe('diffTrailheadMaps', () => {
           },
         }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.info).toHaveLength(1);
       const [infoEntry] = result.info;
@@ -195,7 +195,7 @@ describe('diffTrailheadMaps', () => {
           },
         }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(
@@ -224,7 +224,7 @@ describe('diffTrailheadMaps', () => {
           },
         }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(
@@ -243,7 +243,7 @@ describe('diffTrailheadMaps', () => {
       const curr = trailheadMap([
         entry({ id: 'user.list', trailheads: ['mcp'] }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(
@@ -260,7 +260,7 @@ describe('diffTrailheadMaps', () => {
       const curr = trailheadMap([
         entry({ cli: { path: ['topo', 'save'] }, id: 'topo.pin' }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(
@@ -275,7 +275,7 @@ describe('diffTrailheadMaps', () => {
       const curr = trailheadMap([
         entry({ id: 'data.wipe', intent: 'destroy' }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(1);
       expect(
@@ -290,7 +290,7 @@ describe('diffTrailheadMaps', () => {
       const curr = trailheadMap([
         entry({ description: 'Fetch a user by ID', id: 'user.get' }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.info).toHaveLength(1);
       expect(
@@ -307,7 +307,7 @@ describe('diffTrailheadMaps', () => {
           replacedBy: 'entity.show',
         }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(1);
       expect(
@@ -332,7 +332,7 @@ describe('diffTrailheadMaps', () => {
           kind: 'trail',
         }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(1);
       const crossesDetail = result.warnings[0]?.details.find((d) =>
@@ -356,7 +356,7 @@ describe('diffTrailheadMaps', () => {
           resources: ['db.main', 'cache.main'],
         }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(1);
       const resourceDetail = result.warnings[0]?.details.find((detail) =>
@@ -393,7 +393,7 @@ describe('diffTrailheadMaps', () => {
         }),
         entry({ id: 'b.trail' }),
       ]);
-      const result = diffTrailheadMaps(prev, curr);
+      const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries.length).toBeGreaterThanOrEqual(2);
 

--- a/packages/schema/src/__tests__/hash.test.ts
+++ b/packages/schema/src/__tests__/hash.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 
-import { hashTrailheadMap } from '../hash.js';
+import { deriveSurfaceMapHash } from '../hash.js';
 import type { TrailheadMap } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -35,16 +35,16 @@ const makeTrailheadMap = (overrides?: Partial<TrailheadMap>): TrailheadMap => ({
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('hashTrailheadMap', () => {
+describe('deriveSurfaceMapHash', () => {
   test('produces a valid SHA-256 hex string (64 characters)', () => {
-    const hash = hashTrailheadMap(makeTrailheadMap());
+    const hash = deriveSurfaceMapHash(makeTrailheadMap());
     expect(hash).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test('same trailhead map produces the same hash (deterministic)', () => {
     const map = makeTrailheadMap();
-    const hash1 = hashTrailheadMap(map);
-    const hash2 = hashTrailheadMap(map);
+    const hash1 = deriveSurfaceMapHash(map);
+    const hash2 = deriveSurfaceMapHash(map);
     expect(hash1).toBe(hash2);
   });
 
@@ -62,19 +62,19 @@ describe('hashTrailheadMap', () => {
       ],
     });
 
-    expect(hashTrailheadMap(map1)).not.toBe(hashTrailheadMap(map2));
+    expect(deriveSurfaceMapHash(map1)).not.toBe(deriveSurfaceMapHash(map2));
   });
 
   test('generatedAt does not affect the hash', () => {
     const map1 = makeTrailheadMap({ generatedAt: '2025-01-01T00:00:00.000Z' });
     const map2 = makeTrailheadMap({ generatedAt: '2099-12-31T23:59:59.999Z' });
 
-    expect(hashTrailheadMap(map1)).toBe(hashTrailheadMap(map2));
+    expect(deriveSurfaceMapHash(map1)).toBe(deriveSurfaceMapHash(map2));
   });
 
   test('hash is stable across invocations', () => {
     const map = makeTrailheadMap();
-    const hashes = Array.from({ length: 10 }, () => hashTrailheadMap(map));
+    const hashes = Array.from({ length: 10 }, () => deriveSurfaceMapHash(map));
     const unique = new Set(hashes);
     expect(unique.size).toBe(1);
   });
@@ -110,6 +110,6 @@ describe('hashTrailheadMap', () => {
       ],
     });
 
-    expect(hashTrailheadMap(map1)).toBe(hashTrailheadMap(map2));
+    expect(deriveSurfaceMapHash(map1)).toBe(deriveSurfaceMapHash(map2));
   });
 });

--- a/packages/schema/src/__tests__/openapi.test.ts
+++ b/packages/schema/src/__tests__/openapi.test.ts
@@ -4,7 +4,7 @@ import { Result, signal, topo, trail } from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 import { z } from 'zod';
 
-import { generateOpenApiSpec } from '../openapi.js';
+import { deriveOpenApiSpec } from '../openapi.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -17,7 +17,7 @@ const noop = () => Result.ok(null as unknown);
 
 /** Extract an operation from a spec by path and method. */
 const getOperation = (
-  spec: ReturnType<typeof generateOpenApiSpec>,
+  spec: ReturnType<typeof deriveOpenApiSpec>,
   path: string,
   method: string
 ): Record<string, unknown> =>
@@ -40,7 +40,7 @@ const registerPathAndMethodTests = () => {
         input: z.object({ id: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
 
       expect(spec.paths['/entity/show']).toBeDefined();
     });
@@ -51,7 +51,7 @@ const registerPathAndMethodTests = () => {
         input: z.object({ q: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
 
       expect(spec.paths['/search']).toBeDefined();
     });
@@ -62,7 +62,7 @@ const registerPathAndMethodTests = () => {
         input: z.object({ id: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
 
       expect(spec.paths['/entity/show']?.['get']).toBeDefined();
     });
@@ -73,7 +73,7 @@ const registerPathAndMethodTests = () => {
         input: z.object({ id: z.string() }),
         intent: 'destroy',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
 
       expect(spec.paths['/entity/remove']?.['delete']).toBeDefined();
     });
@@ -83,7 +83,7 @@ const registerPathAndMethodTests = () => {
         blaze: noop,
         input: z.object({ name: z.string() }),
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
 
       expect(spec.paths['/entity/create']?.['post']).toBeDefined();
     });
@@ -94,7 +94,7 @@ const registerPathAndMethodTests = () => {
         input: z.object({ id: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }), {
+      const spec = deriveOpenApiSpec(topoFrom({ t }), {
         basePath: '/api/v1',
       });
 
@@ -107,7 +107,7 @@ const registerPathAndMethodTests = () => {
         input: z.object({ id: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }), {
+      const spec = deriveOpenApiSpec(topoFrom({ t }), {
         basePath: '/api/v1/',
       });
 
@@ -125,7 +125,7 @@ const registerGetQueryParameterTests = () => {
         input: z.object({ id: z.string(), verbose: z.boolean().optional() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/show']?.['get'] as Record<string, unknown>;
       return op['parameters'] as Record<string, unknown>[];
     };
@@ -155,7 +155,7 @@ const registerRequestBodyTests = () => {
         blaze: noop,
         input: z.object({}),
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/action/trigger']?.['post'] as Record<
         string,
         unknown
@@ -169,7 +169,7 @@ const registerRequestBodyTests = () => {
         blaze: noop,
         input: z.object({ name: z.string() }),
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/create']?.['post'] as Record<
         string,
         unknown
@@ -190,7 +190,7 @@ const registerRequestBodyTests = () => {
           tag: z.string().optional(),
         }),
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/update']?.['post'] as Record<
         string,
         unknown
@@ -208,7 +208,7 @@ const registerRequestBodyTests = () => {
           tag: z.string().optional(),
         }),
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/create']?.['post'] as Record<
         string,
         unknown
@@ -229,7 +229,7 @@ const registerResponseTests = () => {
         intent: 'read',
         output: z.object({ id: z.string(), name: z.string() }),
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const success = (
         getOperation(spec, '/entity/show', 'get')['responses'] as Record<
           string,
@@ -252,7 +252,7 @@ const registerResponseTests = () => {
         blaze: noop,
         input: z.object({ msg: z.string() }),
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/fire/forget']?.['post'] as Record<
         string,
         unknown
@@ -279,7 +279,7 @@ const registerResponseTests = () => {
         intent: 'read',
         output: z.object({ id: z.string() }),
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/show']?.['get'] as Record<string, unknown>;
       const responses = op['responses'] as Record<string, unknown>;
 
@@ -293,7 +293,7 @@ const registerResponseTests = () => {
         intent: 'read',
         output: z.object({ id: z.string() }),
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/show']?.['get'] as Record<string, unknown>;
       const fourHundred = (op['responses'] as Record<string, unknown>)[
         '400'
@@ -316,7 +316,7 @@ const registerResponseTests = () => {
         intent: 'read',
         output: z.object({ id: z.string() }),
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/show']?.['get'] as Record<string, unknown>;
       const responses = op['responses'] as Record<string, unknown>;
 
@@ -334,7 +334,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({ id: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/show']?.['get'] as Record<string, unknown>;
 
       expect(op['operationId']).toBe('entity_show');
@@ -346,7 +346,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({ q: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/search']?.['get'] as Record<string, unknown>;
 
       expect(op['operationId']).toBe('search');
@@ -360,7 +360,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({ id: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/show']?.['get'] as Record<string, unknown>;
 
       expect(op['tags']).toEqual(['entity']);
@@ -372,7 +372,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({ q: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/search']?.['get'] as Record<string, unknown>;
 
       expect(op['tags']).toEqual(['search']);
@@ -395,7 +395,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({ id: z.string() }),
         intent: 'destroy',
       });
-      const spec = generateOpenApiSpec(topoFrom({ a, b, c }));
+      const spec = deriveOpenApiSpec(topoFrom({ a, b, c }));
 
       expect(Object.keys(spec.paths)).toHaveLength(3);
       expect(spec.paths['/entity/create']?.['post']).toBeDefined();
@@ -416,7 +416,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({}),
         visibility: 'internal',
       });
-      const spec = generateOpenApiSpec(topoFrom({ internal, pub }));
+      const spec = deriveOpenApiSpec(topoFrom({ internal, pub }));
 
       expect(Object.keys(spec.paths)).toHaveLength(1);
       expect(spec.paths['/entity/show']).toBeDefined();
@@ -439,7 +439,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({ id: z.string() }),
         on: [changed],
       });
-      const spec = generateOpenApiSpec(topoFrom({ changed, consumer, pub }));
+      const spec = deriveOpenApiSpec(topoFrom({ changed, consumer, pub }));
 
       expect(Object.keys(spec.paths)).toHaveLength(1);
       expect(spec.paths['/entity/show']).toBeDefined();
@@ -458,7 +458,7 @@ const registerMetadataAndStructureTests = () => {
         intent: 'destroy',
       });
 
-      const spec = generateOpenApiSpec(topoFrom({ destroyTrail, readTrail }), {
+      const spec = deriveOpenApiSpec(topoFrom({ destroyTrail, readTrail }), {
         intent: ['read'],
       });
 
@@ -478,7 +478,7 @@ const registerMetadataAndStructureTests = () => {
         intent: 'destroy',
       });
 
-      const spec = generateOpenApiSpec(topoFrom({ destroyTrail, readTrail }), {
+      const spec = deriveOpenApiSpec(topoFrom({ destroyTrail, readTrail }), {
         include: ['entity.*'],
         intent: ['destroy'],
       });
@@ -490,20 +490,20 @@ const registerMetadataAndStructureTests = () => {
 
   describe('spec structure', () => {
     test('openapi version is 3.1.0', () => {
-      const spec = generateOpenApiSpec(topoFrom({}));
+      const spec = deriveOpenApiSpec(topoFrom({}));
 
       expect(spec.openapi).toBe('3.1.0');
     });
 
     test('info defaults from topo name', () => {
-      const spec = generateOpenApiSpec(topoFrom({}));
+      const spec = deriveOpenApiSpec(topoFrom({}));
 
       expect(spec.info.title).toBe('test-app');
       expect(spec.info.version).toBe('1.0.0');
     });
 
     test('info uses options when provided', () => {
-      const spec = generateOpenApiSpec(topoFrom({}), {
+      const spec = deriveOpenApiSpec(topoFrom({}), {
         description: 'Test API',
         title: 'My API',
         version: '2.0.0',
@@ -515,7 +515,7 @@ const registerMetadataAndStructureTests = () => {
     });
 
     test('servers included when provided', () => {
-      const spec = generateOpenApiSpec(topoFrom({}), {
+      const spec = deriveOpenApiSpec(topoFrom({}), {
         servers: [{ description: 'Local', url: 'http://localhost:3000' }],
       });
 
@@ -524,13 +524,13 @@ const registerMetadataAndStructureTests = () => {
     });
 
     test('servers omitted when not provided', () => {
-      const spec = generateOpenApiSpec(topoFrom({}));
+      const spec = deriveOpenApiSpec(topoFrom({}));
 
       expect(spec.servers).toBeUndefined();
     });
 
     test('components.schemas is present (empty)', () => {
-      const spec = generateOpenApiSpec(topoFrom({}));
+      const spec = deriveOpenApiSpec(topoFrom({}));
 
       expect(spec.components.schemas).toEqual({});
     });
@@ -544,7 +544,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({ id: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/show']?.['get'] as Record<string, unknown>;
 
       expect(op['summary']).toBe('Show an entity by ID');
@@ -556,7 +556,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({ id: z.string() }),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ t }));
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
       const op = spec.paths['/entity/show']?.['get'] as Record<string, unknown>;
 
       expect(op['summary']).toBeUndefined();
@@ -571,7 +571,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({}),
       });
 
-      expect(() => generateOpenApiSpec(topoFrom({ exportTrail }))).toThrowError(
+      expect(() => deriveOpenApiSpec(topoFrom({ exportTrail }))).toThrowError(
         /draft/i
       );
     });
@@ -589,7 +589,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({}),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ privateShow, publicShow }), {
+      const spec = deriveOpenApiSpec(topoFrom({ privateShow, publicShow }), {
         include: ['public.*'],
       });
 
@@ -607,7 +607,7 @@ const registerMetadataAndStructureTests = () => {
         input: z.object({}),
         intent: 'read',
       });
-      const spec = generateOpenApiSpec(topoFrom({ publicHide, publicShow }), {
+      const spec = deriveOpenApiSpec(topoFrom({ publicHide, publicShow }), {
         exclude: ['public.hide'],
       });
 
@@ -620,7 +620,7 @@ const registerMetadataAndStructureTests = () => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('generateOpenApiSpec', () => [
+describe('deriveOpenApiSpec', () => [
   registerPathAndMethodTests(),
   registerGetQueryParameterTests(),
   registerRequestBodyTests(),

--- a/packages/schema/src/derive.ts
+++ b/packages/schema/src/derive.ts
@@ -1,5 +1,5 @@
 /**
- * Generate a deterministic trailhead map from a Topo.
+ * Derive a deterministic trailhead map from a Topo.
  */
 
 import {
@@ -257,7 +257,7 @@ const collectEntries = (topo: Topo): TrailheadMapEntry[] => [
 // ---------------------------------------------------------------------------
 
 /**
- * Generate a deterministic trailhead map from a Topo.
+ * Derive a deterministic trailhead map from a Topo.
  *
  * Entries are sorted alphabetically by id. Object keys within each entry
  * are sorted lexicographically for stable serialization.

--- a/packages/schema/src/derive.ts
+++ b/packages/schema/src/derive.ts
@@ -262,7 +262,7 @@ const collectEntries = (topo: Topo): TrailheadMapEntry[] => [
  * Entries are sorted alphabetically by id. Object keys within each entry
  * are sorted lexicographically for stable serialization.
  */
-export const generateTrailheadMap = (topo: Topo): TrailheadMap => {
+export const deriveSurfaceMap = (topo: Topo): TrailheadMap => {
   assertEstablishedTopo(topo);
   const sorted = collectEntries(topo).toSorted((a, b) =>
     a.id.localeCompare(b.id)

--- a/packages/schema/src/diff.ts
+++ b/packages/schema/src/diff.ts
@@ -578,7 +578,7 @@ const collectDiffEntries = (
   ...findModified(prevById, currById),
 ];
 
-export const diffTrailheadMaps = (
+export const deriveSurfaceMapDiff = (
   prev: TrailheadMap,
   curr: TrailheadMap
 ): DiffResult => {

--- a/packages/schema/src/hash.ts
+++ b/packages/schema/src/hash.ts
@@ -38,7 +38,7 @@ const canonicalize = (value: unknown): unknown => {
  * The `generatedAt` field is excluded so that identical topos always
  * produce the same hash regardless of when they were generated.
  */
-export const hashTrailheadMap = (trailheadMap: TrailheadMap): string => {
+export const deriveSurfaceMapHash = (trailheadMap: TrailheadMap): string => {
   // Strip generatedAt before hashing
   const { generatedAt: _unused, ...rest } = trailheadMap;
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,10 +1,10 @@
 // Generation
-export { generateTrailheadMap } from './generate.js';
-export { hashTrailheadMap } from './hash.js';
-export { diffTrailheadMaps } from './diff.js';
+export { deriveSurfaceMap } from './derive.js';
+export { deriveSurfaceMapHash } from './hash.js';
+export { deriveSurfaceMapDiff } from './diff.js';
 
 // OpenAPI
-export { generateOpenApiSpec } from './openapi.js';
+export { deriveOpenApiSpec } from './openapi.js';
 export type { OpenApiOptions, OpenApiSpec, OpenApiServer } from './openapi.js';
 
 // File I/O

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,4 +1,4 @@
-// Generation
+// Derivation
 export { deriveSurfaceMap } from './derive.js';
 export { deriveSurfaceMapHash } from './hash.js';
 export { deriveSurfaceMapDiff } from './diff.js';

--- a/packages/schema/src/openapi.ts
+++ b/packages/schema/src/openapi.ts
@@ -328,7 +328,7 @@ const buildInfo = (
  * paths, operations, parameters, and response schemas derived from
  * the trail contract.
  */
-export const generateOpenApiSpec = (
+export const deriveOpenApiSpec = (
   app: Topo,
   options?: OpenApiOptions
 ): OpenApiSpec => {

--- a/packages/schema/src/openapi.ts
+++ b/packages/schema/src/openapi.ts
@@ -1,5 +1,5 @@
 /**
- * Generate an OpenAPI 3.1 specification from a Topo.
+ * Derive an OpenAPI 3.1 specification from a Topo.
  *
  * Converts each trail into an HTTP operation, deriving paths, methods,
  * parameters, and response schemas from the trail contract.
@@ -322,7 +322,7 @@ const buildInfo = (
 // ---------------------------------------------------------------------------
 
 /**
- * Generate an OpenAPI 3.1 specification from a Topo.
+ * Derive an OpenAPI 3.1 specification from a Topo.
  *
  * Iterates all trails, skipping signals and internal trails, and produces
  * paths, operations, parameters, and response schemas derived from

--- a/packages/tracing/src/__tests__/trace-context.test.ts
+++ b/packages/tracing/src/__tests__/trace-context.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   TRACE_CONTEXT_KEY,
-  childTraceContext,
+  createChildTraceContext,
   getTraceContext,
 } from '../trace-context.js';
 import type { TraceContext } from '../trace-context.js';
@@ -31,7 +31,7 @@ describe('getTraceContext', () => {
   });
 });
 
-describe('childTraceContext', () => {
+describe('createChildTraceContext', () => {
   test('inherits traceId from parent', () => {
     const parent: TraceContext = {
       rootId: 'root-span',
@@ -39,7 +39,7 @@ describe('childTraceContext', () => {
       spanId: 'parent-span',
       traceId: 'trace-abc',
     };
-    const child = childTraceContext(parent);
+    const child = createChildTraceContext(parent);
 
     expect(child.traceId).toBe('trace-abc');
   });
@@ -51,7 +51,7 @@ describe('childTraceContext', () => {
       spanId: 'parent-span',
       traceId: 'trace-abc',
     };
-    const child = childTraceContext(parent);
+    const child = createChildTraceContext(parent);
 
     expect(child.spanId).toBeString();
     expect(child.spanId).not.toBe(parent.spanId);
@@ -71,8 +71,8 @@ describe('childTraceContext', () => {
       traceId: 'trace-2',
     };
 
-    expect(childTraceContext(sampledParent).sampled).toBe(true);
-    expect(childTraceContext(unsampledParent).sampled).toBe(false);
+    expect(createChildTraceContext(sampledParent).sampled).toBe(true);
+    expect(createChildTraceContext(unsampledParent).sampled).toBe(false);
   });
 
   test('inherits rootId from parent (not spanId)', () => {
@@ -82,7 +82,7 @@ describe('childTraceContext', () => {
       spanId: 'parent-span',
       traceId: 'trace-abc',
     };
-    const child = childTraceContext(parent);
+    const child = createChildTraceContext(parent);
 
     expect(child.rootId).toBe('the-root');
     expect(child.rootId).not.toBe(child.spanId);

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -17,7 +17,7 @@ export {
 
 // Tracing-package-owned utilities
 export { createMemorySink } from './memory-sink.js';
-export { childTraceContext } from './trace-context.js';
+export { createChildTraceContext } from './trace-context.js';
 export {
   shouldSample,
   DEFAULT_SAMPLING,

--- a/packages/tracing/src/trace-context.ts
+++ b/packages/tracing/src/trace-context.ts
@@ -1,7 +1,7 @@
 /**
  * Trace context primitives live in `@ontrails/core` as of Phase 1 of the
  * tracing collapse. This module re-exports them so existing imports from
- * `@ontrails/tracing` keep working. `childTraceContext` remains available as
+ * `@ontrails/tracing` keep working. `createChildTraceContext` remains available as
  * a small utility for tests and custom adapters that need to derive a child
  * trace context outside of `executeTrail`.
  */
@@ -11,7 +11,9 @@ export { getTraceContext, type TraceContext } from '@ontrails/core';
 export { TRACE_CONTEXT_KEY } from '@ontrails/core/internal/tracing';
 
 /** Create a child trace context inheriting from a parent. */
-export const childTraceContext = (parent: TraceContext): TraceContext => ({
+export const createChildTraceContext = (
+  parent: TraceContext
+): TraceContext => ({
   rootId: parent.rootId,
   sampled: parent.sampled,
   spanId: Bun.randomUUIDv7(),

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -10,8 +10,8 @@ import {
   deriveTrailsDir,
 } from '@ontrails/core/internal/trails-db';
 import {
-  hashTrailheadMap,
-  generateTrailheadMap,
+  deriveSurfaceMapHash,
+  deriveSurfaceMap,
   writeTrailheadLock,
 } from '@ontrails/schema';
 import { z } from 'zod';
@@ -91,7 +91,7 @@ describe('checkDrift', () => {
     const dir = createTempDir();
     try {
       const tp = makeTopo();
-      const hash = hashTrailheadMap(generateTrailheadMap(tp));
+      const hash = deriveSurfaceMapHash(deriveSurfaceMap(tp));
       await writeTrailheadLock(
         { hash, version: 1 },
         { dir: committedLockDir(dir) }

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -17,8 +17,8 @@ import {
 } from '@ontrails/core';
 import { deriveTrailsDir } from '@ontrails/core/internal/trails-db';
 import {
-  generateTrailheadMap,
-  hashTrailheadMap,
+  deriveSurfaceMap,
+  deriveSurfaceMapHash,
   readTrailheadLockData,
 } from '@ontrails/schema';
 
@@ -67,7 +67,7 @@ export const checkDrift = async (
       storedHash ??
       (topo === undefined
         ? 'unknown'
-        : hashTrailheadMap(generateTrailheadMap(topo)));
+        : deriveSurfaceMapHash(deriveSurfaceMap(topo)));
 
     return {
       committedHash: committedLock?.hash ?? null,


### PR DESCRIPTION
## Summary

Verb tightening across the projection packages: schema, config, logging, and tracing. This renames `generate*` / `resolve*` functions to `derive*` where they're pure projections, promotes `childTraceContext` to `createChildTraceContext` because it mints a fresh span id, and includes one small package-internal follow-through in `packages/core/src/internal/trails-db.ts` to keep the vocabulary consistent.

## What changed

### File and directory renames

- `packages/config/src/generate/` -> `packages/config/src/derive/`
- `packages/config/src/describe.ts` -> `derive-fields.ts`
- `packages/config/src/explain.ts` -> `derive-provenance.ts`
- `packages/schema/src/generate.ts` -> `derive.ts`
- Matching `__tests__/*.test.ts` renamed to follow

### Symbol renames — config

| From | To |
|---|---|
| `describeConfig` | `deriveConfigFields` |
| `explainConfig` | `deriveConfigProvenance` |
| `resolveConfig` | `deriveConfig` |
| `resolveFieldByPath` | `deriveFieldByPath` |
| `generateEnvExample` | `deriveConfigEnvExample` |
| `generateExample` | `deriveConfigExample` |
| `generateJsonSchema` | `deriveConfigJsonSchema` |
| `ResolveConfigOptions` | `DeriveConfigOptions` |
| `ExplainConfigOptions` | `DeriveConfigProvenanceOptions` |
| `AppConfigExplainOptions` | `AppConfigDeriveProvenanceOptions` |

A private `resolveConfig` helper inside `app-config.ts` was renamed to `resolveAppConfigFile` to avoid colliding with the exported `deriveConfig` name.

### Symbol renames — logging

- `resolveLogLevel` -> `deriveLogLevel`
- `resolveCategory` -> `deriveCategory`

### Symbol renames — tracing

- `childTraceContext` -> `createChildTraceContext`

### Symbol renames — schema (functions only)

- `generateTrailheadMap` -> `deriveSurfaceMap`
- `generateOpenApiSpec` -> `deriveOpenApiSpec`
- `hashTrailheadMap` -> `deriveSurfaceMapHash`
- `diffTrailheadMaps` -> `deriveSurfaceMapDiff`

Type names (`TrailheadMap`, `TrailheadMapEntry`, `TrailheadContourReference`, `TrailheadLock`) stay as-is in this PR; the type cascade remains intentionally split from this branch's ownership.

### Adjacent package-side cleanup

- `packages/core/src/internal/trails-db.ts`: `resolveRootDir` -> `deriveRootDir`

That helper is local-only, but it is still a pure projection and showed up as the last package-side residue during the stack sweep.

### Consumer and docs updates

- Import-only follow-through in `packages/warden`, `apps/trails`, and `apps/trails-demo`
- Active docs updated in `docs/api-reference.md`, `docs/horizons.md`, and `packages/schema/README.md`

## Why

- `derive*` is the closed-grammar verb for pure projections: schemas, configs, hashes, diffs, paths, and derived report inputs all project from authored state.
- `generate*` and `resolve*` were loosely overlapping synonyms; collapsing them into `derive*` makes the vocabulary match the intended semantics.
- `childTraceContext` is the exception because it creates a new value with a fresh span id; that is `create*` behavior, not `derive*` behavior.
- The tiny `trails-db` rename keeps the package-side sweep complete before the remaining `apps/trails` follow-through continues in `TRL-299`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] CI green on the previously submitted version; CI reruns on the refreshed stack after this submit

## Relates to

Relates to TRL-275. The deferred `apps/trails` naming slice now lives in TRL-299.
