### PR TITLE
refactor: platform-package verb tightening and mint→create cascade [TRL-276, TRL-275p, TRL-277p]

### DIFF
--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -3,7 +3,7 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { Topo } from '@ontrails/core';
-import { resolveAppModule } from '@ontrails/cli';
+import { findAppModule } from '@ontrails/cli';
 
 const URL_SCHEME = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
@@ -81,7 +81,7 @@ export const loadApp = async (
   options: { fresh?: boolean | undefined } = {}
 ): Promise<Topo> => {
   const effectivePath =
-    modulePath === undefined ? resolveAppModule(cwd) : modulePath;
+    modulePath === undefined ? findAppModule(cwd) : modulePath;
   const resolvedModulePath = resolveAbsoluteModulePath(effectivePath, cwd);
   const mod =
     options.fresh === true

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -114,7 +114,7 @@ validateCliCommands(commands)      // validate command tree shape and collisions
 toCommander(commands, options?)    // escape hatch step 2
 deriveFlags(schema, overrides?)    // Zod → CLI flags
 output(value, mode)                // write to stdout in text/json/jsonl
-resolveOutputMode(flags, topoName) // determine output format from flags/topo-derived env
+deriveOutputMode(flags, topoName)  // determine output format from flags/topo-derived env
 
 BuildCliCommandsOptions, ActionResultContext, OutputMode
 CliCommand, CliFlag, CliArg

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -309,8 +309,8 @@ createJwtConnector(options)          // built-in HS256 JWT connector (from @ontr
 authVerify                           // verify a bearer token and return a permit
 
 // Testing
-mintTestPermit(overrides?)           // create a permit for tests
-mintPermitForTrail(trail)            // mint a permit matching a trail's requirements
+createTestPermit(overrides?)         // create a permit for tests
+createPermitForTrail(trail)          // create a permit matching a trail's requirements
 
 // Governance
 validatePermits(trails)              // check trails against permit governance rules

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -12,7 +12,7 @@
 
 **Config resolution (`@ontrails/config`).** `defineConfig()` provides schema-validated config with profiles (named environment profiles), env variable mapping, and `ResourceSpec.config` for resource-level config schemas. Includes diagnostics (`checkConfig`), introspection (`deriveConfigFields`, `deriveConfigProvenance`), and generation (`deriveConfigEnvExample`).
 
-**Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. `authLayer` extracts credentials from trailhead-specific sources, `AuthConnector` resolves them to a `Permit` (identity, scopes, roles), and scope enforcement rejects unauthorized access. Includes JWT connector, governance rules (`validatePermits`), and test helpers (`mintTestPermit`, `mintPermitForTrail`).
+**Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. `authLayer` extracts credentials from trailhead-specific sources, `AuthConnector` resolves them to a `Permit` (identity, scopes, roles), and scope enforcement rejects unauthorized access. Includes JWT connector, governance rules (`validatePermits`), and test helpers (`createTestPermit`, `createPermitForTrail`).
 
 **Tracing (intrinsic in `@ontrails/core`, sinks in `@ontrails/tracing`).** Every `executeTrail` invocation produces a `TraceRecord` automatically — no layer attachment required. `ctx.trace(label, fn)` records nested spans inside a trail blaze. Pluggable sinks register via `registerTraceSink()`: `createMemorySink` for testing, `createDevStore` for local development, `createOtelConnector` for production OpenTelemetry export. Sampling configuration controls recording volume.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -378,13 +378,13 @@ The config, permits, and tracing packages each provide test-friendly primitives 
 
 **Config test profile.** Use `defineConfig()` with a `test` profile that uses safe defaults (port 0, debug enabled, in-memory stores). When the `TRAILS_ENV` environment variable is set to `test`, the test profile is selected automatically during resolution. Services with `config` schemas receive the test profile values through `svc.config`.
 
-**Synthetic permit minting.** `mintTestPermit()` creates a `Permit` with exactly the scopes you specify -- no admin privileges, no wildcards. `mintPermitForTrail()` reads a trail's `permit` declaration and mints a permit with exactly the declared scopes, so tests exercise the real authorization path without a running auth provider:
+**Synthetic permit creation.** `createTestPermit()` creates a `Permit` with exactly the scopes you specify -- no admin privileges, no wildcards. `createPermitForTrail()` reads a trail's `permit` declaration and creates a permit with exactly the declared scopes, so tests exercise the real authorization path without a running auth provider:
 
 ```typescript
-import { mintTestPermit, mintPermitForTrail } from '@ontrails/permits';
+import { createTestPermit, createPermitForTrail } from '@ontrails/permits';
 
-const permit = mintTestPermit({ scopes: ['entity:read'] });
-const trailPermit = mintPermitForTrail(showTrail);
+const permit = createTestPermit({ scopes: ['entity:read'] });
+const trailPermit = createPermitForTrail(showTrail);
 ```
 
 **Tracing memory sink.** Tracing is intrinsic to `executeTrail` — every trail execution produces a `TraceRecord` automatically. Register `createMemorySink()` to capture records in memory for assertion:

--- a/docs/trailheads/cli.md
+++ b/docs/trailheads/cli.md
@@ -185,7 +185,7 @@ Adds `--dry-run` flag. Automatically added for trails with `intent: 'destroy'`.
 The `output()` function writes values to stdout in the specified format:
 
 ```typescript
-import { output, resolveOutputMode } from '@ontrails/cli';
+import { output, deriveOutputMode } from '@ontrails/cli';
 
 await output({ name: 'Alpha' }, 'json'); // Pretty JSON to stdout
 await output(items, 'jsonl'); // One JSON line per item
@@ -194,7 +194,7 @@ await output('Hello', 'text'); // Plain text
 
 ### Output Mode Resolution
 
-`resolveOutputMode(flags, topoName)` determines the format from flags and topo-derived environment variables:
+`deriveOutputMode(flags, topoName)` determines the format from flags and topo-derived environment variables:
 
 1. `--json` flag (highest priority)
 2. `--jsonl` flag
@@ -230,7 +230,7 @@ Override the default result handler for custom formatting, logging, or metrics:
 
 ```typescript
 import { trailhead } from '@ontrails/cli/commander';
-import { output, resolveOutputMode } from '@ontrails/cli';
+import { output, deriveOutputMode } from '@ontrails/cli';
 
 trailhead(app, {
   onResult: async (ctx) => {
@@ -238,7 +238,7 @@ trailhead(app, {
       console.error(`Failed: ${ctx.trail.id}`);
       throw ctx.result.error;
     }
-    const { mode } = resolveOutputMode(ctx.flags, ctx.topoName);
+    const { mode } = deriveOutputMode(ctx.flags, ctx.topoName);
     await output(ctx.result.value, mode);
   },
 });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -58,7 +58,7 @@ commands.
 | `toCommander(commands, options?)` | Connect `CliCommand[]` to a Commander program |
 | `deriveFlags(schema)` | Extract honest CLI flags from a Zod schema |
 | `output(data, mode)` | Format output as JSON, JSONL, or text |
-| `resolveOutputMode(flags, topoName)` | Resolve output mode from flags and topo-derived env vars (`<TOPO>_JSON`, `<TOPO>_JSONL`) |
+| `deriveOutputMode(flags, topoName)` | Derive output mode from flags and topo-derived env vars (`<TOPO>_JSON`, `<TOPO>_JSONL`) |
 
 See the [API Reference](../../docs/api-reference.md) for the full list.
 
@@ -134,7 +134,7 @@ myapp topo
 myapp topo --module ./apps/api/src/app.ts
 ```
 
-Use `discoverAppModules(cwd)` and `resolveAppModule(cwd, explicit?)` directly
+Use `findAppModuleCandidates(cwd)` and `findAppModule(cwd, explicit?)` directly
 for programmatic access.
 
 ## Structured input

--- a/packages/cli/src/__tests__/discover.test.ts
+++ b/packages/cli/src/__tests__/discover.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
 import { AmbiguousError, NotFoundError } from '@ontrails/core';
 
-import { discoverAppModules, resolveAppModule } from '../discover.js';
+import { findAppModuleCandidates, findAppModule } from '../discover.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -27,10 +27,10 @@ const touchFile = (dir: string, relativePath: string): void => {
 };
 
 // ---------------------------------------------------------------------------
-// discoverAppModules
+// findAppModuleCandidates
 // ---------------------------------------------------------------------------
 
-describe('discoverAppModules', () => {
+describe('findAppModuleCandidates', () => {
   let tempDir: string;
 
   beforeEach(() => {
@@ -44,7 +44,7 @@ describe('discoverAppModules', () => {
   test('finds src/app.ts in single-app layout', () => {
     touchFile(tempDir, 'src/app.ts');
 
-    const result = discoverAppModules(tempDir);
+    const result = findAppModuleCandidates(tempDir);
 
     expect(result).toEqual(['src/app.ts']);
   });
@@ -52,13 +52,13 @@ describe('discoverAppModules', () => {
   test('finds apps/*/src/app.ts in monorepo layout', () => {
     touchFile(tempDir, 'apps/myapp/src/app.ts');
 
-    const result = discoverAppModules(tempDir);
+    const result = findAppModuleCandidates(tempDir);
 
     expect(result).toEqual(['apps/myapp/src/app.ts']);
   });
 
   test('returns empty array when nothing found', () => {
-    const result = discoverAppModules(tempDir);
+    const result = findAppModuleCandidates(tempDir);
 
     expect(result).toEqual([]);
   });
@@ -68,7 +68,7 @@ describe('discoverAppModules', () => {
     touchFile(tempDir, 'apps/alpha/src/app.ts');
     touchFile(tempDir, 'apps/beta/src/app.ts');
 
-    const result = discoverAppModules(tempDir);
+    const result = findAppModuleCandidates(tempDir);
 
     expect(result).toHaveLength(3);
     expect(result).toContain('src/app.ts');
@@ -80,17 +80,17 @@ describe('discoverAppModules', () => {
     touchFile(tempDir, 'src/app.ts');
     touchFile(tempDir, 'apps/myapp/src/app.ts');
 
-    const result = discoverAppModules(tempDir);
+    const result = findAppModuleCandidates(tempDir);
 
     expect(result[0]).toBe('src/app.ts');
   });
 });
 
 // ---------------------------------------------------------------------------
-// resolveAppModule
+// findAppModule
 // ---------------------------------------------------------------------------
 
-describe('resolveAppModule', () => {
+describe('findAppModule', () => {
   let tempDir: string;
 
   beforeEach(() => {
@@ -102,7 +102,7 @@ describe('resolveAppModule', () => {
   });
 
   test('returns explicit module path when provided', () => {
-    const result = resolveAppModule(tempDir, './custom/entry.ts');
+    const result = findAppModule(tempDir, './custom/entry.ts');
 
     expect(result).toBe('./custom/entry.ts');
   });
@@ -110,7 +110,7 @@ describe('resolveAppModule', () => {
   test('returns single discovered module', () => {
     touchFile(tempDir, 'src/app.ts');
 
-    const result = resolveAppModule(tempDir);
+    const result = findAppModule(tempDir);
 
     expect(result).toBe('src/app.ts');
   });
@@ -119,7 +119,7 @@ describe('resolveAppModule', () => {
     touchFile(tempDir, 'src/app.ts');
     touchFile(tempDir, 'apps/alpha/src/app.ts');
 
-    expect(() => resolveAppModule(tempDir)).toThrow(AmbiguousError);
+    expect(() => findAppModule(tempDir)).toThrow(AmbiguousError);
   });
 
   test('ambiguous error message lists candidates and suggests --module', () => {
@@ -127,7 +127,7 @@ describe('resolveAppModule', () => {
     touchFile(tempDir, 'apps/alpha/src/app.ts');
 
     try {
-      resolveAppModule(tempDir);
+      findAppModule(tempDir);
       expect.unreachable('should have thrown');
     } catch (error) {
       expect(error).toBeInstanceOf(AmbiguousError);
@@ -139,12 +139,12 @@ describe('resolveAppModule', () => {
   });
 
   test('throws NotFoundError when no candidates found', () => {
-    expect(() => resolveAppModule(tempDir)).toThrow(NotFoundError);
+    expect(() => findAppModule(tempDir)).toThrow(NotFoundError);
   });
 
   test('not-found error message is helpful', () => {
     try {
-      resolveAppModule(tempDir);
+      findAppModule(tempDir);
       expect.unreachable('should have thrown');
     } catch (error) {
       expect(error).toBeInstanceOf(NotFoundError);

--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
-import { output, resolveOutputMode } from '../output.js';
+import { output, deriveOutputMode } from '../output.js';
 
 describe('output', () => {
   let written: string[];
@@ -50,7 +50,7 @@ describe('output', () => {
   });
 });
 
-describe('resolveOutputMode', () => {
+describe('deriveOutputMode', () => {
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
@@ -63,27 +63,27 @@ describe('resolveOutputMode', () => {
 
   describe('flag precedence', () => {
     test('--json flag returns json', () => {
-      const result = resolveOutputMode({ json: true }, 'stash');
+      const result = deriveOutputMode({ json: true }, 'stash');
       expect(result.mode).toBe('json');
     });
 
     test('--jsonl flag returns jsonl', () => {
-      const result = resolveOutputMode({ jsonl: true }, 'stash');
+      const result = deriveOutputMode({ jsonl: true }, 'stash');
       expect(result.mode).toBe('jsonl');
     });
 
     test('--json takes priority over --jsonl', () => {
-      const result = resolveOutputMode({ json: true, jsonl: true }, 'stash');
+      const result = deriveOutputMode({ json: true, jsonl: true }, 'stash');
       expect(result.mode).toBe('json');
     });
 
     test('--output flag returns specified mode', () => {
-      const result = resolveOutputMode({ output: 'jsonl' }, 'stash');
+      const result = deriveOutputMode({ output: 'jsonl' }, 'stash');
       expect(result.mode).toBe('jsonl');
     });
 
     test('--json takes priority over --output', () => {
-      const result = resolveOutputMode({ json: true, output: 'text' }, 'stash');
+      const result = deriveOutputMode({ json: true, output: 'text' }, 'stash');
       expect(result.mode).toBe('json');
     });
   });
@@ -91,48 +91,48 @@ describe('resolveOutputMode', () => {
   describe('topo-derived environment fallback', () => {
     test('<TOPO>_JSON=1 env var returns json', () => {
       process.env['STASH_JSON'] = '1';
-      const result = resolveOutputMode({}, 'stash');
+      const result = deriveOutputMode({}, 'stash');
       expect(result.mode).toBe('json');
     });
 
     test('<TOPO>_JSONL=1 env var returns jsonl', () => {
       process.env['STASH_JSONL'] = '1';
-      const result = resolveOutputMode({}, 'stash');
+      const result = deriveOutputMode({}, 'stash');
       expect(result.mode).toBe('jsonl');
     });
 
     test('flags take priority over env vars', () => {
       process.env['STASH_JSON'] = '1';
-      const result = resolveOutputMode({ jsonl: true }, 'stash');
+      const result = deriveOutputMode({ jsonl: true }, 'stash');
       expect(result.mode).toBe('jsonl');
     });
 
     test('defaults to text when nothing specified', () => {
-      const result = resolveOutputMode({}, 'stash');
+      const result = deriveOutputMode({}, 'stash');
       expect(result.mode).toBe('text');
     });
 
     test('env var for a different topo does not leak', () => {
       process.env['OTHER_JSON'] = '1';
-      const result = resolveOutputMode({}, 'stash');
+      const result = deriveOutputMode({}, 'stash');
       expect(result.mode).toBe('text');
     });
 
     test('legacy TRAILS_JSON is no longer honored', () => {
       process.env['TRAILS_JSON'] = '1';
-      const result = resolveOutputMode({}, 'stash');
+      const result = deriveOutputMode({}, 'stash');
       expect(result.mode).toBe('text');
     });
 
     test('topo name with hyphens is normalized to underscores', () => {
       process.env['MY_APP_JSON'] = '1';
-      const result = resolveOutputMode({}, 'my-app');
+      const result = deriveOutputMode({}, 'my-app');
       expect(result.mode).toBe('json');
     });
 
     test('topo name starting with a digit gets underscore prefix', () => {
       process.env['_1APP_JSON'] = '1';
-      const result = resolveOutputMode({}, '1app');
+      const result = deriveOutputMode({}, '1app');
       expect(result.mode).toBe('json');
     });
   });

--- a/packages/cli/src/discover.ts
+++ b/packages/cli/src/discover.ts
@@ -13,7 +13,7 @@ import { AmbiguousError, NotFoundError } from '@ontrails/core';
  * Returns relative candidate paths in priority order: single-app layout
  * first, then monorepo entries in filesystem scan order.
  */
-export const discoverAppModules = (cwd: string): string[] => {
+export const findAppModuleCandidates = (cwd: string): string[] => {
   const candidates: string[] = [];
 
   if (existsSync(join(cwd, 'src/app.ts'))) {
@@ -28,13 +28,13 @@ export const discoverAppModules = (cwd: string): string[] => {
   return candidates;
 };
 
-/** Resolve the app module path, using discovery when no explicit path is provided. */
-export const resolveAppModule = (cwd: string, explicit?: string): string => {
+/** Find the app module path, using discovery when no explicit path is provided. */
+export const findAppModule = (cwd: string, explicit?: string): string => {
   if (explicit !== undefined) {
     return explicit;
   }
 
-  const candidates = discoverAppModules(cwd);
+  const candidates = findAppModuleCandidates(cwd);
 
   const [first] = candidates;
   if (candidates.length === 1 && first !== undefined) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,7 @@ export {
 } from './flags.js';
 
 // Output
-export { output, resolveOutputMode } from './output.js';
+export { output, deriveOutputMode } from './output.js';
 export type { OutputMode } from './output.js';
 
 // onResult
@@ -26,7 +26,7 @@ export { passthroughResolver, isInteractive } from './prompt.js';
 export type { Field, InputResolver, ResolveInputOptions } from './prompt.js';
 
 // Discovery
-export { discoverAppModules, resolveAppModule } from './discover.js';
+export { findAppModuleCandidates, findAppModule } from './discover.js';
 
 // Layers
 export { autoIterateLayer, dateShortcutsLayer } from './layers.js';

--- a/packages/cli/src/on-result.ts
+++ b/packages/cli/src/on-result.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ActionResultContext } from './build.js';
-import { output, resolveOutputMode } from './output.js';
+import { output, deriveOutputMode } from './output.js';
 
 // ---------------------------------------------------------------------------
 // defaultOnResult
@@ -22,6 +22,6 @@ export const defaultOnResult = async (
     throw ctx.result.error;
   }
 
-  const { mode } = resolveOutputMode(ctx.flags, ctx.topoName);
+  const { mode } = deriveOutputMode(ctx.flags, ctx.topoName);
   await output(ctx.result.value, mode);
 };

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -45,7 +45,7 @@ export const output = (value: unknown, mode: OutputMode): void => {
 };
 
 // ---------------------------------------------------------------------------
-// resolveOutputMode()
+// deriveOutputMode()
 // ---------------------------------------------------------------------------
 
 const VALID_MODES = new Set<OutputMode>(['text', 'json', 'jsonl']);
@@ -109,7 +109,7 @@ const resolveEnvMode = (topoName: string): OutputMode | undefined => {
  * non-alphanumerics replaced by underscores. A topo named `stash` reads
  * `STASH_JSON` / `STASH_JSONL`.
  */
-export const resolveOutputMode = (
+export const deriveOutputMode = (
   flags: Record<string, unknown>,
   topoName: string
 ): {

--- a/packages/permits/README.md
+++ b/packages/permits/README.md
@@ -135,19 +135,19 @@ import { authVerify } from '@ontrails/permits';
 
 ## Testing with mock permits
 
-Use `mintTestPermit()` and `mintPermitForTrail()` in tests:
+Use `createTestPermit()` and `createPermitForTrail()` in tests:
 
 ```typescript
-import { mintTestPermit, mintPermitForTrail } from '@ontrails/permits';
+import { createTestPermit, createPermitForTrail } from '@ontrails/permits';
 
-const permit = mintTestPermit({
+const permit = createTestPermit({
   id: 'user-123',
   scopes: ['gist:read', 'gist:write'],
   roles: ['editor'],
 });
 
-// Mint a permit matching a trail's requirements
-const trailPermit = mintPermitForTrail(myTrail);
+// Create a permit matching a trail's requirements
+const trailPermit = createPermitForTrail(myTrail);
 // { id: 'test-...', scopes: ['gist:write'] }
 ```
 

--- a/packages/permits/src/__tests__/testing.test.ts
+++ b/packages/permits/src/__tests__/testing.test.ts
@@ -1,57 +1,57 @@
 import { describe, expect, test } from 'bun:test';
 
-import { mintPermitForTrail, mintTestPermit } from '../testing';
+import { createPermitForTrail, createTestPermit } from '../testing';
 
-describe('mintTestPermit()', () => {
+describe('createTestPermit()', () => {
   test('returns a Permit with the given scopes', () => {
-    const permit = mintTestPermit({ scopes: ['user:read', 'user:write'] });
+    const permit = createTestPermit({ scopes: ['user:read', 'user:write'] });
     expect(permit.scopes).toEqual(['user:read', 'user:write']);
   });
 
   test('generates a unique id when not specified', () => {
-    const a = mintTestPermit();
-    const b = mintTestPermit();
+    const a = createTestPermit();
+    const b = createTestPermit();
     expect(a.id).not.toBe(b.id);
   });
 
   test('uses the provided id when specified', () => {
-    const permit = mintTestPermit({ id: 'custom-id' });
+    const permit = createTestPermit({ id: 'custom-id' });
     expect(permit.id).toBe('custom-id');
   });
 
   test('returns empty scopes when no options provided', () => {
-    const permit = mintTestPermit();
+    const permit = createTestPermit();
     expect(permit.scopes).toEqual([]);
   });
 
   test('includes roles when provided', () => {
-    const permit = mintTestPermit({ roles: ['admin', 'editor'] });
+    const permit = createTestPermit({ roles: ['admin', 'editor'] });
     expect(permit.roles).toEqual(['admin', 'editor']);
   });
 
   test('includes tenantId when provided', () => {
-    const permit = mintTestPermit({ tenantId: 'tenant_abc' });
+    const permit = createTestPermit({ tenantId: 'tenant_abc' });
     expect(permit.tenantId).toBe('tenant_abc');
   });
 });
 
-describe('mintPermitForTrail()', () => {
+describe('createPermitForTrail()', () => {
   test('extracts scopes from trail permit requirement', () => {
     const trail = { permit: { scopes: ['entity:read', 'entity:write'] } };
-    const permit = mintPermitForTrail(trail);
+    const permit = createPermitForTrail(trail);
     expect(permit).toBeDefined();
     expect(permit?.scopes).toEqual(['entity:read', 'entity:write']);
   });
 
   test('returns undefined for public trails', () => {
     const trail = { permit: 'public' as const };
-    const permit = mintPermitForTrail(trail);
+    const permit = createPermitForTrail(trail);
     expect(permit).toBeUndefined();
   });
 
   test('returns undefined when no permit declared', () => {
     const trail = {};
-    const permit = mintPermitForTrail(trail);
+    const permit = createPermitForTrail(trail);
     expect(permit).toBeUndefined();
   });
 });

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -14,4 +14,4 @@ export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';
 export { validatePermits, type PermitDiagnostic } from './rules.js';
-export { mintTestPermit, mintPermitForTrail } from './testing.js';
+export { createTestPermit, createPermitForTrail } from './testing.js';

--- a/packages/permits/src/testing.ts
+++ b/packages/permits/src/testing.ts
@@ -3,10 +3,10 @@ import type { PermitRequirement } from '@ontrails/core';
 import type { Permit } from './permit.js';
 
 /**
- * Mint a synthetic test permit with exactly the declared scopes.
+ * Create a synthetic test permit with exactly the declared scopes.
  * No admin permit, no wildcard — tests get only what the trail declares.
  */
-export const mintTestPermit = (options?: {
+export const createTestPermit = (options?: {
   readonly id?: string;
   readonly scopes?: readonly string[];
   readonly roles?: readonly string[];
@@ -22,13 +22,13 @@ export const mintTestPermit = (options?: {
 
 /**
  * Create a test permit matching a trail's permit requirement.
- * Extracts scopes from the requirement and mints a permit with exactly those scopes.
+ * Extracts scopes from the requirement and creates a permit with exactly those scopes.
  */
-export const mintPermitForTrail = (trail: {
+export const createPermitForTrail = (trail: {
   readonly permit?: PermitRequirement | undefined;
 }): Permit | undefined => {
   if (!trail.permit || trail.permit === 'public') {
     return undefined;
   }
-  return mintTestPermit({ scopes: trail.permit.scopes });
+  return createTestPermit({ scopes: trail.permit.scopes });
 };

--- a/packages/testing/src/__tests__/effective-examples.test.ts
+++ b/packages/testing/src/__tests__/effective-examples.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import { contour, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { resolveTrailExamples } from '../effective-examples.js';
+import { deriveTrailExamples } from '../effective-examples.js';
 
 const requireContourExample = (
   contourDef: { examples?: readonly Record<string, unknown>[] },
@@ -65,7 +65,7 @@ const gistContour = contour(
   }
 );
 
-describe('resolveTrailExamples', () => {
+describe('deriveTrailExamples', () => {
   test('prefers authored trail examples over contour-derived fixtures', () => {
     const authoredExample = {
       expected: { email: 'manual@example.com', name: 'Manual' },
@@ -81,7 +81,7 @@ describe('resolveTrailExamples', () => {
       output: z.object({ email: z.string().email(), name: z.string() }),
     });
 
-    expect(resolveTrailExamples(trailDef)).toEqual([authoredExample]);
+    expect(deriveTrailExamples(trailDef)).toEqual([authoredExample]);
   });
 
   test('derives single-contour fixtures and preserves full contour output', () => {
@@ -94,7 +94,7 @@ describe('resolveTrailExamples', () => {
       output: userContour,
     });
 
-    const examples = resolveTrailExamples(trailDef);
+    const examples = deriveTrailExamples(trailDef);
     expect(examples).toHaveLength(2);
     const firstRecord = firstUserExample as Record<string, unknown>;
     expect(examples[0]).toEqual(
@@ -118,7 +118,7 @@ describe('resolveTrailExamples', () => {
       output: z.object({ slug: z.string() }),
     });
 
-    expect(resolveTrailExamples(trailDef)).toEqual([]);
+    expect(deriveTrailExamples(trailDef)).toEqual([]);
   });
 
   test('matches cross-contour references and exposes contour-prefixed aliases', () => {
@@ -135,7 +135,7 @@ describe('resolveTrailExamples', () => {
       }),
     });
 
-    const examples = resolveTrailExamples(trailDef);
+    const examples = deriveTrailExamples(trailDef);
     expect(examples).toHaveLength(2);
     // No contour fixture parses as the output schema on its own (the
     // output expects `gistId` and `userId`, but the fixtures expose
@@ -169,7 +169,7 @@ describe('resolveTrailExamples', () => {
       output: z.object({ email: z.string().email(), name: z.string() }),
     });
 
-    const examples = resolveTrailExamples(trailDef);
+    const examples = deriveTrailExamples(trailDef);
     expect(examples).toHaveLength(2);
     expect(examples[0]?.input).toEqual({
       email: (firstUserExample as { email: string }).email,
@@ -194,7 +194,7 @@ describe('resolveTrailExamples', () => {
         .strict(),
     });
 
-    const examples = resolveTrailExamples(trailDef);
+    const examples = deriveTrailExamples(trailDef);
     expect(examples.length).toBeGreaterThan(0);
     for (const example of examples) {
       expect(example.expected).toBeUndefined();

--- a/packages/testing/src/context.ts
+++ b/packages/testing/src/context.ts
@@ -60,14 +60,14 @@ export interface CreateCrossContextOptions {
   readonly responses?: Record<string, Result<unknown, Error>> | undefined;
 }
 
-/** Minimal permit shape returned by the mint function. */
-export interface MintedPermit {
+/** Minimal permit shape returned by the create function. */
+export interface MinimalPermit {
   readonly id: string;
   readonly scopes: readonly string[];
 }
 
-/** Trail shape consumed by the mint function — avoids importing permits. */
-export interface MintableTrail {
+/** Trail shape consumed by the create function — avoids importing permits. */
+export interface PermittedTrail {
   readonly permit?:
     | { readonly scopes: readonly string[] }
     | 'public'
@@ -78,19 +78,19 @@ export interface TestExecutionOptions {
   readonly ctx?: Partial<TrailContext> | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
   /**
-   * When true, disables automatic permit minting. Tests must provide
+   * When true, disables automatic permit creation. Tests must provide
    * explicit permits.
    */
   readonly strictPermits?: boolean | undefined;
   /**
-   * Optional function to mint a test permit for a trail. When provided,
+   * Optional function to create a test permit for a trail. When provided,
    * called for each trail with a non-public `permit` requirement.
-   * Returning `undefined` skips minting for that trail.
+   * Returning `undefined` skips creation for that trail.
    *
    * A default inline implementation is used when this is not provided,
    * keeping the testing package free of a hard dependency on `@ontrails/permits`.
    */
-  readonly mintPermit?: (trail: MintableTrail) => MintedPermit | undefined;
+  readonly createPermit?: (trail: PermittedTrail) => MinimalPermit | undefined;
 }
 
 /**
@@ -145,12 +145,12 @@ export const createCrossContext = (
 };
 
 /**
- * Default permit minter — reads `trail.permit.scopes` and produces a
+ * Default permit creator — reads `trail.permit.scopes` and produces a
  * minimal permit object. No dependency on `@ontrails/permits`.
  */
-export const defaultMintPermit = (
-  trail: MintableTrail
-): MintedPermit | undefined => {
+export const defaultCreatePermit = (
+  trail: PermittedTrail
+): MinimalPermit | undefined => {
   if (!trail.permit || trail.permit === 'public') {
     return undefined;
   }
@@ -164,7 +164,7 @@ const isTestExecutionOptions = (
   (Object.hasOwn(input, 'ctx') ||
     Object.hasOwn(input, 'resources') ||
     Object.hasOwn(input, 'strictPermits') ||
-    Object.hasOwn(input, 'mintPermit'));
+    Object.hasOwn(input, 'createPermit'));
 
 export const normalizeTestExecutionOptions = (
   input?: Partial<TrailContext> | TestExecutionOptions

--- a/packages/testing/src/contracts.ts
+++ b/packages/testing/src/contracts.ts
@@ -20,7 +20,7 @@ import {
   createMockResources,
 } from './context.js';
 import type { TestExecutionOptions } from './context.js';
-import { resolveTrailExamples } from './effective-examples.js';
+import { deriveTrailExamples } from './effective-examples.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -75,7 +75,7 @@ export const testContracts = (
   const allEntries = (app.list() as Trail<unknown, unknown, unknown>[]).map(
     (trailDef) => ({
       ...trailDef,
-      examples: resolveTrailExamples(trailDef),
+      examples: deriveTrailExamples(trailDef),
     })
   );
 

--- a/packages/testing/src/effective-examples.ts
+++ b/packages/testing/src/effective-examples.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 type ExampleRecord = Readonly<Record<string, unknown>>;
 
 /**
- * Tracks examples that `resolveTrailExamples` synthesizes from contour
+ * Tracks examples that `deriveTrailExamples` synthesizes from contour
  * fixtures. Authored examples are passed through untouched and never
  * appear here, so consumers can distinguish the two by identity.
  *
@@ -17,7 +17,7 @@ const derivedExamples = new WeakSet<TrailExample<unknown, unknown>>();
 
 /**
  * Returns `true` if the given example was synthesized from contour fixtures
- * by `resolveTrailExamples`, `false` if it was authored on the trail.
+ * by `deriveTrailExamples`, `false` if it was authored on the trail.
  */
 export const isDerivedExample = (
   example: TrailExample<unknown, unknown>
@@ -304,7 +304,7 @@ const formatFixtureName = (
  * `WeakSet` so consumers can detect them without widening the public
  * `TrailExample` shape.
  */
-export const resolveTrailExamples = (
+export const deriveTrailExamples = (
   trail: Trail<unknown, unknown, unknown>
 ): readonly TrailExample<unknown, unknown>[] => {
   if (trail.examples !== undefined && trail.examples.length > 0) {

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -47,17 +47,14 @@ import {
   assertSchemaMatch,
 } from './assertions.js';
 import {
-  defaultMintPermit,
+  defaultCreatePermit,
   mergeResourceOverrides,
   mergeTestContext,
   normalizeTestExecutionOptions,
   createMockResources,
 } from './context.js';
-import type { MintableTrail, TestExecutionOptions } from './context.js';
-import {
-  isDerivedExample,
-  resolveTrailExamples,
-} from './effective-examples.js';
+import type { PermittedTrail, TestExecutionOptions } from './context.js';
+import { isDerivedExample, deriveTrailExamples } from './effective-examples.js';
 
 // ---------------------------------------------------------------------------
 // Error class name -> constructor map
@@ -133,12 +130,12 @@ const handleValidationError = (
 };
 
 /**
- * Apply auto-minting: if the trail declares scoped permits and the context
- * doesn't already have a permit, mint one and merge it into the context.
+ * Apply auto-permit: if the trail declares scoped permits and the context
+ * doesn't already have a permit, create one and merge it into the context.
  */
-const applyAutoMint = (
+const applyAutoPermit = (
   ctx: TrailContext,
-  trailDef: MintableTrail,
+  trailDef: PermittedTrail,
   opts: TestExecutionOptions
 ): TrailContext => {
   if (opts.strictPermits) {
@@ -147,8 +144,8 @@ const applyAutoMint = (
   if (ctx.permit !== undefined) {
     return ctx;
   }
-  const mint = opts.mintPermit ?? defaultMintPermit;
-  const permit = mint(trailDef);
+  const create = opts.createPermit ?? defaultCreatePermit;
+  const permit = create(trailDef);
   if (!permit) {
     return ctx;
   }
@@ -173,7 +170,7 @@ const runExample = async (
     return;
   }
 
-  const ctx = opts ? applyAutoMint(testCtx, t, opts) : testCtx;
+  const ctx = opts ? applyAutoPermit(testCtx, t, opts) : testCtx;
 
   const result = await executeTrail(t, example.input, {
     ctx,
@@ -270,15 +267,17 @@ const runCompositionExample = async (
     return;
   }
 
-  const mintedCtx = opts ? applyAutoMint(baseCtx, trailDef, opts) : baseCtx;
+  const permittedCtx = opts
+    ? applyAutoPermit(baseCtx, trailDef, opts)
+    : baseCtx;
   const cross = createCoverageCross(
     called,
-    mintedCtx.cross,
+    permittedCtx.cross,
     topo,
-    mintedCtx,
+    permittedCtx,
     resources
   );
-  const testCtx: TrailContext = { ...mintedCtx, cross };
+  const testCtx: TrailContext = { ...permittedCtx, cross };
 
   // Top-level trail validates against trail.input (not merged crossInput).
   // Merged validation only applies to cross targets in executeFromMap/createCoverageCross.
@@ -316,7 +315,7 @@ export const testExamples = (
   const withExamples = (app.list() as Trail<unknown, unknown, unknown>[])
     .map((trailDef) => ({
       ...trailDef,
-      examples: resolveTrailExamples(trailDef),
+      examples: deriveTrailExamples(trailDef),
     }))
     .filter((trailDef) => trailDef.examples.length > 0);
   const simpleTrails = withExamples.filter((t) => t.crosses.length === 0);

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -25,7 +25,7 @@ export { executeScenarioSteps, ref, scenario } from './scenario.js';
 export {
   createCrossContext,
   createTestContext,
-  defaultMintPermit,
+  defaultCreatePermit,
 } from './context.js';
 export { createTestLogger } from './logger.js';
 
@@ -36,8 +36,8 @@ export { createMcpHarness } from './harness-mcp.js';
 // Types
 export type { CreateCrossContextOptions } from './context.js';
 export type {
-  MintableTrail,
-  MintedPermit,
+  PermittedTrail,
+  MinimalPermit,
   TestExecutionOptions,
 } from './context.js';
 export type { TestCrossOptions } from './crosses.js';

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -117,7 +117,7 @@ const resolvePath = (path: string, outputs: Map<string, unknown>): unknown => {
 /**
  * Recursively walk a value, replacing RefToken instances with resolved values.
  */
-export const resolveRefs = (
+export const deriveRefs = (
   value: unknown,
   outputs: Map<string, unknown>
 ): unknown => {
@@ -126,13 +126,13 @@ export const resolveRefs = (
   }
 
   if (Array.isArray(value)) {
-    return value.map((item) => resolveRefs(item, outputs));
+    return value.map((item) => deriveRefs(item, outputs));
   }
 
   if (typeof value === 'object' && value !== null) {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
-      result[key] = resolveRefs(val, outputs);
+      result[key] = deriveRefs(val, outputs);
     }
     return result;
   }
@@ -169,9 +169,9 @@ const assertStepExpectations = async (
   const value = expectOk(result);
   if (step.expected !== undefined) {
     const { expect } = await import('bun:test');
-    expect(value).toEqual(resolveRefs(step.expected, outputs));
+    expect(value).toEqual(deriveRefs(step.expected, outputs));
   } else if (step.expectedMatch !== undefined) {
-    assertPartialMatch(result, resolveRefs(step.expectedMatch, outputs));
+    assertPartialMatch(result, deriveRefs(step.expectedMatch, outputs));
   }
   if (step.as !== undefined) {
     outputs.set(step.as, value);
@@ -323,7 +323,7 @@ const executeStep = async (
 
   const scenarioCross = createScenarioCross(app, resources);
   const baseCtx = createTestContext();
-  const resolvedInput = resolveRefs(step.input, outputs);
+  const resolvedInput = deriveRefs(step.input, outputs);
   const result = await executeTrail(step.cross, resolvedInput, {
     ctx: { ...baseCtx, cross: scenarioCross },
     resources,

--- a/packages/warden/src/__tests__/ast.test.ts
+++ b/packages/warden/src/__tests__/ast.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 
-import { resolveContourIdentifierName } from '../rules/ast.js';
+import { deriveContourIdentifierName } from '../rules/ast.js';
 
-describe('resolveContourIdentifierName', () => {
+describe('deriveContourIdentifierName', () => {
   test('supports the common *Contour binding suffix when resolving known contours', () => {
     expect(
-      resolveContourIdentifierName(
+      deriveContourIdentifierName(
         'userContour',
         new Map<string, string>(),
         new Set(['user'])
@@ -15,7 +15,7 @@ describe('resolveContourIdentifierName', () => {
 
   test('prefers exact contour ids over the *Contour fallback', () => {
     expect(
-      resolveContourIdentifierName(
+      deriveContourIdentifierName(
         'userContour',
         new Map<string, string>(),
         new Set(['user', 'userContour'])

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -167,7 +167,7 @@ export const getStringValue = (node: AstNode): string | null => {
  * warden rules that need to resolve identifier references to signal / trail
  * IDs at lint time.
  */
-export const resolveConstString = (
+export const deriveConstString = (
   name: string,
   sourceCode: string
 ): string | null => {
@@ -699,7 +699,7 @@ const resolveKnownContourName = (
  * reason about" (e.g. a bare undeclared variable), as opposed to
  * "a contour reference whose target is missing".
  */
-export const resolveContourIdentifierName = (
+export const deriveContourIdentifierName = (
   bindingName: string,
   namedContourIds: ReadonlyMap<string, string>,
   knownContourIds?: ReadonlySet<string>,
@@ -755,7 +755,7 @@ const getContourReferenceTargetFromObject = (
   if (object.type === 'Identifier') {
     const bindingName = identifierName(object);
     return bindingName
-      ? resolveContourIdentifierName(
+      ? deriveContourIdentifierName(
           bindingName,
           namedContourIds,
           knownContourIds,
@@ -1008,7 +1008,7 @@ export const getCrossElements = (config: AstNode): readonly AstNode[] => {
  * Handles string literals, identifier references (via `namedTrailIds` map or
  * `const NAME = '...'` resolution), and inline `trail(...)` call expressions.
  */
-export const resolveCrossElementId = (
+export const deriveCrossElementId = (
   element: AstNode,
   sourceCode: string,
   namedTrailIds: ReadonlyMap<string, string>
@@ -1020,7 +1020,7 @@ export const resolveCrossElementId = (
   if (element.type === 'Identifier') {
     const name = identifierName(element);
     return name
-      ? (namedTrailIds.get(name) ?? resolveConstString(name, sourceCode))
+      ? (namedTrailIds.get(name) ?? deriveConstString(name, sourceCode))
       : null;
   }
 
@@ -1039,7 +1039,7 @@ export const extractDefinitionCrossTargetIds = (
 ): readonly string[] => [
   ...new Set(
     getCrossElements(config).flatMap((element) => {
-      const id = resolveCrossElementId(element, sourceCode, namedTrailIds);
+      const id = deriveCrossElementId(element, sourceCode, namedTrailIds);
       return id ? [id] : [];
     })
   ),
@@ -1255,7 +1255,7 @@ export const collectNamedStoreTableIds = (
  *   - direct member access: `db.tables.notes`
  *   - identifier reference: `const notesTable = db.tables.notes; crud(notesTable, …)`
  */
-export const resolveStoreTableId = (
+export const deriveStoreTableId = (
   node: AstNode | undefined,
   namedStoreTableIds: ReadonlyMap<string, string>
 ): string | null => {
@@ -1376,7 +1376,7 @@ export const collectCrudTableIds = (ast: AstNode): ReadonlySet<string> => {
 
     const [tableArg] = ((node as unknown as { arguments?: readonly AstNode[] })
       .arguments ?? []) as readonly AstNode[];
-    const tableId = resolveStoreTableId(tableArg, namedStoreTableIds);
+    const tableId = deriveStoreTableId(tableArg, namedStoreTableIds);
     if (tableId) {
       ids.add(tableId);
     }
@@ -1404,7 +1404,7 @@ export const collectReconcileTableIds = (ast: AstNode): ReadonlySet<string> => {
     }
 
     const tableProp = findConfigProperty(configArg, 'table');
-    const tableId = resolveStoreTableId(
+    const tableId = deriveStoreTableId(
       tableProp?.value as AstNode | undefined,
       namedStoreTableIds
     );
@@ -1433,7 +1433,7 @@ const extractStoreSignalIdFromMember = (
     return null;
   }
 
-  const tableId = resolveStoreTableId(signalsMember.object, namedStoreTableIds);
+  const tableId = deriveStoreTableId(signalsMember.object, namedStoreTableIds);
   return tableId ? `${tableId}.${operation}` : null;
 };
 
@@ -1490,7 +1490,7 @@ const resolveNamedOnSignalId = (
 
   const name = identifierName(element);
   return name
-    ? (namedStoreSignalIds.get(name) ?? resolveConstString(name, sourceCode))
+    ? (namedStoreSignalIds.get(name) ?? deriveConstString(name, sourceCode))
     : null;
 };
 

--- a/packages/warden/src/rules/contour-exists.ts
+++ b/packages/warden/src/rules/contour-exists.ts
@@ -8,7 +8,7 @@ import {
   identifierName,
   offsetToLine,
   parse,
-  resolveContourIdentifierName,
+  deriveContourIdentifierName,
 } from './ast.js';
 import type { AstNode, TrailDefinition } from './ast.js';
 import { isTestFile } from './scan.js';
@@ -49,7 +49,7 @@ const resolveDeclaredContourName = (
   if (element.type === 'Identifier') {
     const name = identifierName(element);
     return name
-      ? resolveContourIdentifierName(
+      ? deriveContourIdentifierName(
           name,
           contourIdsByName,
           knownContourIds,

--- a/packages/warden/src/rules/cross-declarations.ts
+++ b/packages/warden/src/rules/cross-declarations.ts
@@ -61,10 +61,7 @@ const getStringValue = (node: AstNode): string | null => {
  * Returns the string value if a simple `const <name> = '...'` or `"..."` is
  * found in the source. Returns null for anything more complex.
  */
-const resolveConstString = (
-  name: string,
-  sourceCode: string
-): string | null => {
+const deriveConstString = (name: string, sourceCode: string): string | null => {
   const pattern = new RegExp(
     `const\\s+${name}\\s*=\\s*(?:'([^']*)'|"([^"]*)")`
   );
@@ -84,11 +81,11 @@ const resolveIdentifierElement = (
   if (!name) {
     return null;
   }
-  return resolveConstString(name, sourceCode);
+  return deriveConstString(name, sourceCode);
 };
 
 /** Resolve an array element to a static trail ID when possible. */
-const resolveCrossElementId = (
+const deriveCrossElementId = (
   element: AstNode,
   sourceCode: string
 ): string | null => {
@@ -149,7 +146,7 @@ const classifyCrossElement = (
   sourceCode: string,
   ids: Set<string>
 ): boolean => {
-  const resolved = resolveCrossElementId(element, sourceCode);
+  const resolved = deriveCrossElementId(element, sourceCode);
   if (!resolved) {
     // Element could not be statically resolved
     return true;
@@ -250,7 +247,7 @@ const resolveBatchCrossTupleTarget = (
 
   const tupleElements = element['elements'] as readonly AstNode[] | undefined;
   const [target] = tupleElements ?? [];
-  return target ? resolveCrossElementId(target, sourceCode) : null;
+  return target ? deriveCrossElementId(target, sourceCode) : null;
 };
 
 const collectBatchCrossId = (

--- a/packages/warden/src/rules/fires-declarations.ts
+++ b/packages/warden/src/rules/fires-declarations.ts
@@ -18,7 +18,7 @@ import {
   identifierName,
   offsetToLine,
   parse,
-  resolveConstString,
+  deriveConstString,
   walkScope,
 } from './ast.js';
 import type { AstNode } from './ast.js';
@@ -38,7 +38,7 @@ const resolveIdentifierElement = (
   if (!name) {
     return null;
   }
-  return resolveConstString(name, sourceCode);
+  return deriveConstString(name, sourceCode);
 };
 
 /**

--- a/packages/warden/src/rules/incomplete-crud.ts
+++ b/packages/warden/src/rules/incomplete-crud.ts
@@ -8,7 +8,7 @@ import {
   isStringLiteral,
   offsetToLine,
   parse,
-  resolveStoreTableId,
+  deriveStoreTableId,
   walk,
 } from './ast.js';
 import type { AstNode } from './ast.js';
@@ -192,7 +192,7 @@ const extractCrudTuplePattern = (
 
   const [tableArg] = ((init as unknown as { arguments?: readonly AstNode[] })
     .arguments ?? []) as readonly AstNode[];
-  const entityId = resolveStoreTableId(tableArg, namedStoreTableIds);
+  const entityId = deriveStoreTableId(tableArg, namedStoreTableIds);
   const { elements } = id as unknown as { elements?: readonly AstNode[] };
   return entityId && elements ? { elements, entityId } : null;
 };

--- a/packages/warden/src/rules/on-references-exist.ts
+++ b/packages/warden/src/rules/on-references-exist.ts
@@ -18,7 +18,7 @@ import {
   isStringLiteral,
   offsetToLine,
   parse,
-  resolveConstString,
+  deriveConstString,
 } from './ast.js';
 import type { AstNode } from './ast.js';
 import { isTestFile } from './scan.js';
@@ -65,7 +65,7 @@ const extractOnElementId = (
 ): string | null => {
   if (element.type === 'Identifier') {
     const name = identifierName(element);
-    return name ? resolveConstString(name, sourceCode) : null;
+    return name ? deriveConstString(name, sourceCode) : null;
   }
 
   if (isStringLiteral(element)) {

--- a/packages/warden/src/rules/resource-declarations.ts
+++ b/packages/warden/src/rules/resource-declarations.ts
@@ -123,7 +123,7 @@ const extractDeclaredResources = (
   });
 
 // ---------------------------------------------------------------------------
-// Called service extraction
+// Called resource extraction
 // ---------------------------------------------------------------------------
 
 /** Extract the raw second parameter node from a blaze function. */


### PR DESCRIPTION
## Summary

Verb tightening across the platform packages — cli, warden, testing, permits. Renames the `mint*` permit family to `create*` per the closed grammar, corrects filesystem-discovery helpers from `derive*` (purity violation) to `find*`, and tightens assorted `resolve*` projections to `derive*`. Also carries the small `service → resource` comment fix and wraps up the service-vocabulary cleanup.

## What changed

### cli

- `resolveOutputMode` → `deriveOutputMode` (pure flag/env check)
- `discoverAppModules` → `findAppModuleCandidates` (I/O: `existsSync` + `Bun.Glob().scanSync()` — `find*`, not `derive*`)
- `resolveAppModule` → `findAppModule` (delegates to above; I/O-dependent)

Excluded from this PR's ownership: `packages/cli/src/build.ts`, `packages/cli/src/commander/trailhead.ts`, `packages/cli/src/commander/to-commander.ts` — those are PR 8 (Surface API) territory.

### warden

All pure AST helpers:

- `resolveConstString` → `deriveConstString`
- `resolveContourIdentifierName` → `deriveContourIdentifierName`
- `resolveCrossElementId` → `deriveCrossElementId`
- `resolveStoreTableId` → `deriveStoreTableId`

Private helpers in `cross-declarations.ts` that duplicate the exported shape were renamed to match for readability.

Also: `// Called service extraction` → `// Called resource extraction` in `resource-declarations.ts:126` (the last service-vocabulary residue from the earlier rename — closes out the TRL-278 scope).

### testing

- `resolveRefs` → `deriveRefs`
- `resolveTrailExamples` → `deriveTrailExamples`
- `MintedPermit` interface → `MinimalPermit` (signals subset relationship to `@ontrails/permits#Permit`; Decision #35 domain-noun principle)
- `MintableTrail` interface → `PermittedTrail` (shape-descriptive; reads naturally at call sites)
- `defaultMintPermit` → `defaultCreatePermit`
- `mintPermit` option on `TestExecutionOptions` → `createPermit`
- `applyAutoMint` → `applyAutoPermit` (local `mintedCtx` → `permittedCtx` at two adjacent sites for readability)

### permits

- `mintTestPermit` → `createTestPermit`
- `mintPermitForTrail` → `createPermitForTrail`

### Consumer updates (imports only)

- `apps/trails/src/trails/load-app.ts` (`resolveAppModule` → `findAppModule`)

No other consumers needed updates.

## Why

- **Decision #22.** `mint*` isn't in the closed grammar — it collapses into `create*` because it produces a runtime instance.
- **Decision #22 corollary (honing-session §1).** `discoverAppModules` and `resolveAppModule` hit the filesystem — they fail the `derive*` purity test. The `find*` conventional verb (already in the catalogue under "search/enumerate") is the honest label.
- **Decision #35 (domain-noun principle).** Supporting nouns describe the shape of the output, not the construction method. `MinimalPermit` and `PermittedTrail` read naturally; `MintedPermit` and `MintableTrail` leak the factory verb into the type name.
- **Decision #30.** Resource vocabulary completeness — the comment fix picks up the last vestigial `service` reference in warden.

## File ownership

Entirety of `packages/cli/` (except the three PR 8 files), `packages/warden/`, `packages/testing/`, `packages/permits/`, plus `apps/trails/src/trails/load-app.ts` for the lone consumer import swap. No file in this diff is touched by any other PR in the stack.

## Test plan

- [x] `bun run typecheck` — 30/30 green
- [x] `bun run test` — 30/30 green (permits 7/7, testing suite green)
- [x] `bunx ultracite check` — 0/0
- [x] CI green across all checks

## Relates to

Relates to TRL-275. This PR contributes the cli/warden/testing/permits slice; TRL-275 closes when PR #163 (the final packages slice) merges.

Closes TRL-276, TRL-278.