### PR TITLE
feat(store): extract StoreConnectorOptions + StoreMockSeed shared bases [TRL-284, TRL-275p, TRL-277p]

### DIFF
--- a/apps/trails-demo/src/store.ts
+++ b/apps/trails-demo/src/store.ts
@@ -7,7 +7,7 @@
  */
 
 import { store as defineStore } from '@ontrails/store';
-import { store as bindDrizzleStore } from '@ontrails/drizzle';
+import { connectDrizzle } from '@ontrails/drizzle';
 import { z } from 'zod';
 
 export const entitySchema = z.object({
@@ -61,7 +61,7 @@ const normalizeSeed = (seed: EntitySeed): MutableEntitySeed => ({
 });
 
 const createBoundEntityStore = (seed?: readonly EntitySeed[]) =>
-  bindDrizzleStore(entityTables, {
+  connectDrizzle(entityStoreDefinition, {
     id: 'demo.entity-store',
     ...(seed === undefined
       ? {}

--- a/connectors/drizzle/src/__tests__/drizzle.test.ts
+++ b/connectors/drizzle/src/__tests__/drizzle.test.ts
@@ -14,13 +14,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 
-import {
-  connectDrizzle,
-  connectReadOnlyDrizzle,
-  getSchema,
-  readonlyStore,
-  store,
-} from '../index.js';
+import { connectDrizzle, connectReadOnlyDrizzle } from '../index.js';
 
 const userSchema = z.object({
   email: z.string().email(),
@@ -92,26 +86,27 @@ const unwrapCreated = async <T>(
 };
 
 const createWritableDemoStore = (rootDir: string) =>
-  store(
-    {
+  connectDrizzle(
+    defineStore({
       gists: gistTable,
       users: userTable,
-    },
+    }),
     {
       description: 'Writable demo store',
       id: 'demo.store',
+      meta: { domain: 'demo' },
       url: join(rootDir, 'demo.sqlite'),
     }
   );
 
 const createVersionedUserStore = (rootDir: string) =>
-  store(
-    {
+  connectDrizzle(
+    defineStore({
       users: {
         ...userTable,
         versioned: true,
       },
-    },
+    }),
     {
       description: 'Versioned demo store',
       id: 'demo.store.versioned',
@@ -183,6 +178,7 @@ const expectWritableResourceDefinition = (
   expect(db.id).toBe('demo.store');
   expect(db.access).toBe('readwrite');
   expect(db.mock).toBeDefined();
+  expect(db.meta).toEqual({ domain: 'demo' });
   expect(db.signals.map((candidate) => candidate.id)).toEqual([
     'gists.created',
     'gists.updated',
@@ -191,7 +187,8 @@ const expectWritableResourceDefinition = (
     'users.updated',
     'users.removed',
   ]);
-  expect(getSchema(db).gists).toBe(db.tables.gists);
+  expect(db.tables.gists).toBeDefined();
+  expect(db.tables.users).toBeDefined();
 };
 
 const expectInsertedGist = (
@@ -360,8 +357,8 @@ const expectRecordedSignals = (
 };
 
 const createFixtureBackedStore = () =>
-  store(
-    {
+  connectDrizzle(
+    defineStore({
       gists: {
         ...gistTable,
         fixtures: [
@@ -380,7 +377,7 @@ const createFixtureBackedStore = () =>
           },
         ],
       },
-    },
+    }),
     {
       id: 'demo.store.mock',
       url: ':memory:',
@@ -388,10 +385,10 @@ const createFixtureBackedStore = () =>
   );
 
 const createWritableSeedStore = (url: string) =>
-  store(
-    {
+  connectDrizzle(
+    defineStore({
       users: userTable,
-    },
+    }),
     {
       id: 'demo.store.seed',
       url,
@@ -412,12 +409,13 @@ const seedReadonlyFixture = async (
 };
 
 const createReadonlyUserStore = (url: string) =>
-  readonlyStore(
-    {
+  connectReadOnlyDrizzle(
+    defineStore({
       users: userTable,
-    },
+    }),
     {
       id: 'demo.store.readonly',
+      meta: { domain: 'readonly-demo' },
       url,
     }
   );
@@ -494,8 +492,8 @@ const expectVersionedCreate = async (
 };
 
 const createErrorStore = (rootDir: string) =>
-  store(
-    {
+  connectDrizzle(
+    defineStore({
       accounts: {
         primaryKey: 'id',
         schema: accountSchema,
@@ -504,7 +502,7 @@ const createErrorStore = (rootDir: string) =>
         ...gistTable,
         references: { ownerId: 'accounts' },
       },
-    },
+    }),
     {
       id: 'demo.store.errors',
       url: join(rootDir, 'errors.sqlite'),
@@ -705,8 +703,8 @@ describe('@ontrails/drizzle resource access', () => {
 
   test('round-trips a user-declared "version" field on non-versioned tables', async () => {
     const rootDir = tmp.makeRoot();
-    const db = store(
-      {
+    const db = connectDrizzle(
+      defineStore({
         documents: {
           generated: ['id'],
           primaryKey: 'id',
@@ -716,7 +714,7 @@ describe('@ontrails/drizzle resource access', () => {
             version: z.string(),
           }),
         },
-      },
+      }),
       {
         description: 'Non-versioned store with a user-owned "version" column',
         id: 'demo.store.user-version',
@@ -823,10 +821,10 @@ describe('@ontrails/drizzle read-only resource access', () => {
   });
 
   test('creates a mock resource seeded from mockSeed', async () => {
-    const db = readonlyStore(
-      {
+    const db = connectReadOnlyDrizzle(
+      defineStore({
         users: userTable,
-      },
+      }),
       {
         id: 'demo.store.readonly.mock',
         mockSeed: {
@@ -871,6 +869,11 @@ describe('@ontrails/drizzle read-only resource access', () => {
     await expectReadonlyWriteFailure(mock as ReadonlyUserStoreRuntime);
     await db.dispose?.(mock as ReadonlyUserStoreRuntime);
   });
+
+  test('preserves connector metadata on the resource definition', () => {
+    const db = createReadonlyUserStore(':memory:');
+    expect(db.meta).toEqual({ domain: 'readonly-demo' });
+  });
 });
 
 describe('@ontrails/drizzle edge cases', () => {
@@ -909,8 +912,8 @@ describe('@ontrails/drizzle edge cases', () => {
   });
 
   test('maps z.number().int() to INTEGER (Zod internals regression guard)', () => {
-    const intStore = store(
-      {
+    const intStore = connectDrizzle(
+      defineStore({
         counters: {
           generated: ['id'],
           primaryKey: 'id',
@@ -919,12 +922,11 @@ describe('@ontrails/drizzle edge cases', () => {
             value: z.number(),
           }),
         },
-      },
+      }),
       { url: join(tmp.makeRoot(), 'int.sqlite') }
     );
 
-    const schema = getSchema(intStore);
-    const col = schema.counters;
+    const col = intStore.tables.counters;
     expect(col).toBeDefined();
 
     const idColumn = col.id as unknown as { columnType: string };

--- a/connectors/drizzle/src/index.ts
+++ b/connectors/drizzle/src/index.ts
@@ -1,17 +1,9 @@
-export {
-  connectDrizzle,
-  connectReadOnlyDrizzle,
-  getSchema,
-  readonlyStore,
-  store,
-} from './runtime.js';
+export { connectDrizzle, connectReadOnlyDrizzle } from './runtime.js';
 export type {
-  ConnectDrizzleOptions,
-  DrizzleMockSeed,
   DrizzleQueryContext,
   DrizzleStoreConnection,
+  DrizzleStoreOptions,
   DrizzleStoreResource,
   DrizzleStoreSchema,
-  ReadOnlyDrizzleOptions,
   ReadOnlyDrizzleStoreConnection,
 } from './types.js';

--- a/connectors/drizzle/src/runtime.ts
+++ b/connectors/drizzle/src/runtime.ts
@@ -10,7 +10,7 @@ import {
   ValidationError,
   resource,
 } from '@ontrails/core';
-import { store as defineStore, versionFieldName } from '@ontrails/store';
+import { versionFieldName } from '@ontrails/store';
 import type {
   AnyStoreDefinition,
   AnyStoreTable,
@@ -21,9 +21,9 @@ import type {
   StoreAccessMode,
   StoreFieldKey,
   StoreIdentifierOf,
+  StoreMockSeed,
   StoreTableAccessor,
   StoreTableConnection,
-  StoreTablesInput,
   UpsertOf,
   UpdateOf,
 } from '@ontrails/store';
@@ -34,17 +34,15 @@ import type { z } from 'zod';
 import type { TrailContext } from '@ontrails/core';
 
 import {
-  createSqliteSchemaStatements,
-  describeField,
   deriveDrizzleTables,
+  deriveFieldSpec,
+  deriveSqliteSchemaStatements,
 } from './schema.js';
 import type {
-  ConnectDrizzleOptions,
-  DrizzleMockSeed,
   DrizzleStoreConnection,
+  DrizzleStoreOptions,
   DrizzleStoreResource,
   DrizzleStoreSchema,
-  ReadOnlyDrizzleOptions,
   ReadOnlyDrizzleStoreConnection,
 } from './types.js';
 
@@ -169,7 +167,7 @@ const baseFieldKind = <TTable extends AnyStoreTable>(
   table: TTable,
   field: StoreFieldKey<TTable['schema']>
 ): string =>
-  describeField(
+  deriveFieldSpec(
     field as string,
     table.schema.shape[field as keyof typeof table.schema.shape] as z.ZodType
   ).kind;
@@ -565,7 +563,7 @@ const ensureSqliteSchema = (
   client: Database,
   definition: AnyStoreDefinition
 ): void => {
-  for (const statement of createSqliteSchemaStatements(definition)) {
+  for (const statement of deriveSqliteSchemaStatements(definition)) {
     client.run(statement);
   }
 };
@@ -857,7 +855,7 @@ const createWritableAccessor = <
 /** Collect non-empty fixture arrays keyed by table name. */
 const collectFixtures = <TStore extends AnyStoreDefinition>(
   definition: TStore,
-  seed?: DrizzleMockSeed<TStore>
+  seed?: StoreMockSeed<TStore>
 ): Map<string, readonly FixtureInputOf<AnyStoreTable>[]> => {
   const result = new Map<string, readonly FixtureInputOf<AnyStoreTable>[]>();
   for (const tableName of definition.tableNames) {
@@ -907,7 +905,7 @@ const seedFixtures = <TStore extends AnyStoreDefinition>(
   definition: TStore,
   tables: DrizzleStoreSchema<TStore>,
   db: ReturnType<typeof drizzle<DrizzleStoreSchema<TStore>>>,
-  seed?: DrizzleMockSeed<TStore>
+  seed?: StoreMockSeed<TStore>
 ): void => {
   const fixturesByTable = collectFixtures(definition, seed);
   if (fixturesByTable.size === 0) {
@@ -989,7 +987,7 @@ const seedReadonlyMockDatabase = <TStore extends AnyStoreDefinition>(
   definition: TStore,
   tables: DrizzleStoreSchema<TStore>,
   url: string,
-  seed?: DrizzleMockSeed<TStore>
+  seed?: StoreMockSeed<TStore>
 ): void => {
   const writableClient = openSqliteDatabase(url, false);
   try {
@@ -1020,7 +1018,7 @@ const openReadonlyMockConnection = <TStore extends AnyStoreDefinition>(
 const createReadonlyMockConnection = <TStore extends AnyStoreDefinition>(
   definition: TStore,
   tables: DrizzleStoreSchema<TStore>,
-  seed?: DrizzleMockSeed<TStore>
+  seed?: StoreMockSeed<TStore>
 ): ReadOnlyDrizzleStoreConnection<TStore> => {
   const tempDir = createReadonlyMockTempDir();
   const url = join(tempDir, 'mock.sqlite');
@@ -1243,7 +1241,7 @@ const connectionHealth = (
  */
 export const connectDrizzle = <const TStore extends AnyStoreDefinition>(
   definition: TStore,
-  options: ConnectDrizzleOptions<TStore>
+  options: DrizzleStoreOptions<TStore>
 ): DrizzleStoreResource<
   TStore,
   DrizzleStoreConnection<TStore>,
@@ -1282,6 +1280,7 @@ export const connectDrizzle = <const TStore extends AnyStoreDefinition>(
         closeConnection(connection);
       },
       health: connectionHealth,
+      meta: options.meta,
       mock: () => {
         const client = openSqliteDatabase(':memory:', false);
         try {
@@ -1303,7 +1302,7 @@ export const connectDrizzle = <const TStore extends AnyStoreDefinition>(
 
 export const connectReadOnlyDrizzle = <const TStore extends AnyStoreDefinition>(
   definition: TStore,
-  options: ReadOnlyDrizzleOptions<TStore>
+  options: DrizzleStoreOptions<TStore>
 ): DrizzleStoreResource<
   TStore,
   ReadOnlyDrizzleStoreConnection<TStore>,
@@ -1336,6 +1335,7 @@ export const connectReadOnlyDrizzle = <const TStore extends AnyStoreDefinition>(
         closeConnection(connection);
       },
       health: connectionHealth,
+      meta: options.meta,
       mock: () =>
         createReadonlyMockConnection(definition, tables, options.mockSeed),
     }),
@@ -1344,28 +1344,3 @@ export const connectReadOnlyDrizzle = <const TStore extends AnyStoreDefinition>(
     'readonly'
   );
 };
-
-export const store = <const TTables extends StoreTablesInput>(
-  tables: TTables,
-  options: ConnectDrizzleOptions<ReturnType<typeof defineStore<TTables>>>
-): DrizzleStoreResource<
-  ReturnType<typeof defineStore<TTables>>,
-  DrizzleStoreConnection<ReturnType<typeof defineStore<TTables>>>,
-  'readwrite'
-> => connectDrizzle(defineStore(tables), options);
-
-export const readonlyStore = <const TTables extends StoreTablesInput>(
-  tables: TTables,
-  options: ReadOnlyDrizzleOptions<ReturnType<typeof defineStore<TTables>>>
-): DrizzleStoreResource<
-  ReturnType<typeof defineStore<TTables>>,
-  ReadOnlyDrizzleStoreConnection<ReturnType<typeof defineStore<TTables>>>,
-  'readonly'
-> => connectReadOnlyDrizzle(defineStore(tables), options);
-
-export const getSchema = <TStore extends AnyStoreDefinition>(
-  binding: Pick<
-    DrizzleStoreResource<TStore, unknown, StoreAccessMode>,
-    'tables'
-  >
-): DrizzleStoreSchema<TStore> => binding.tables;

--- a/connectors/drizzle/src/schema.ts
+++ b/connectors/drizzle/src/schema.ts
@@ -206,7 +206,7 @@ const inferFieldKind = (
   }
 };
 
-export const describeField = (
+export const deriveFieldSpec = (
   field: string,
   schema: z.ZodType
 ): SqliteFieldSpec => {
@@ -416,7 +416,7 @@ const deriveColumnBuilder = (
   tables: Record<string, AnySQLiteTable>
 ): SqliteColumnBuilder => {
   const schema = table.schema.shape[field] as z.ZodType;
-  const spec = describeField(field, schema);
+  const spec = deriveFieldSpec(field, schema);
   const isPrimaryKey = field === table.primaryKey;
   const isGenerated = table.generated.includes(field);
   const baseBuilder = createBaseColumnBuilder(field, spec);
@@ -491,7 +491,7 @@ const createColumnSqlParts = (
   table: AnyStoreTable,
   definition: AnyStoreDefinition
 ): string[] => {
-  const spec = describeField(field, schema);
+  const spec = deriveFieldSpec(field, schema);
   const parts = [quoteIdentifier(field), toSqlType(spec.kind)];
   appendPrimaryKeySql(parts, field, table, spec);
   appendDefaultSql(parts, spec);
@@ -577,7 +577,7 @@ export const deriveDrizzleTables = <TStore extends AnyStoreDefinition>(
   return Object.freeze(tables) as DrizzleStoreSchema<TStore>;
 };
 
-export const createSqliteSchemaStatements = (
+export const deriveSqliteSchemaStatements = (
   definition: AnyStoreDefinition
 ): readonly string[] => {
   assertTabularStoreKind(definition);

--- a/connectors/drizzle/src/types.ts
+++ b/connectors/drizzle/src/types.ts
@@ -1,9 +1,9 @@
 import type { Resource } from '@ontrails/core';
 import type {
   AnyStoreDefinition,
-  FixtureInputOf,
   ReadOnlyStoreConnection,
   StoreAccessMode,
+  StoreConnectorOptions,
   StoreTableConnection,
 } from '@ontrails/store';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
@@ -20,25 +20,17 @@ export interface DrizzleQueryContext<TStore extends AnyStoreDefinition> {
   readonly tables: DrizzleStoreSchema<TStore>;
 }
 
-export type DrizzleMockSeed<TStore extends AnyStoreDefinition> = Partial<{
-  readonly [TName in keyof TStore['tables']]: readonly FixtureInputOf<
-    TStore['tables'][TName]
-  >[];
-}>;
-
-export interface ConnectDrizzleOptions<TStore extends AnyStoreDefinition> {
-  readonly description?: string;
-  readonly id?: string;
-  readonly mockSeed?: DrizzleMockSeed<TStore>;
-  readonly url: string;
-}
-
-export interface ReadOnlyDrizzleOptions<
-  TStore extends AnyStoreDefinition = AnyStoreDefinition,
-> {
-  readonly description?: string;
-  readonly id?: string;
-  readonly mockSeed?: DrizzleMockSeed<TStore>;
+/**
+ * Options accepted by the Drizzle store connector.
+ *
+ * Extends {@link StoreConnectorOptions} with drizzle-specific fields. The
+ * read-only vs writable distinction is enforced by the factory that consumes
+ * these options, not by the options type itself.
+ */
+export interface DrizzleStoreOptions<
+  TDef extends AnyStoreDefinition = AnyStoreDefinition,
+> extends StoreConnectorOptions<TDef> {
+  /** Path to the SQLite database file. Use `":memory:"` for ephemeral runs. */
   readonly url: string;
 }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -173,11 +173,11 @@ OpenApiOptions, OpenApiSpec, OpenApiServer
 
 ```typescript
 store(tables)                      // connector-agnostic store definition
-entitySchemaOf(table)              // normalized full entity schema
-insertSchemaOf(table)              // entity schema minus generated fields
-updateSchemaOf(table)              // partial update schema
-fixtureSchemaOf(table)             // fixture schema with generated fields optional
-// every normalized table derives:
+// every normalized table exposes derived schemas and signals directly:
+// table.schema          — normalized full entity schema
+// table.insertSchema    — entity schema minus generated fields
+// table.updateSchema    — partial update schema keyed by identity
+// table.fixtureSchema   — fixture schema with generated fields optional
 // table.signals.created | table.signals.updated | table.signals.removed
 
 StoreDefinition, StoreTable, StoreTableSignals, StoreTablesInput, StoreTableInput

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -204,13 +204,11 @@ StoreAccessorContractOptions<T>, StoreAccessorContractSubject<T>
 ```typescript
 connectDrizzle(definition, options?)         // bind a root store definition to a writable Drizzle resource
 connectReadOnlyDrizzle(definition, options?) // bind a root store definition to a read-only Drizzle resource
-store(tables, options?)                      // convenience: define + connect writable store
-readonlyStore(tables, options?)              // convenience: define + connect read-only store
-getSchema(binding)                           // expose raw derived Drizzle tables
+binding.tables                               // expose raw derived Drizzle tables on the bound resource
 
-ConnectDrizzleOptions, ReadOnlyDrizzleOptions
+DrizzleStoreOptions
 DrizzleStoreResource, DrizzleStoreConnection, ReadOnlyDrizzleStoreConnection
-DrizzleQueryContext, DrizzleStoreSchema, DrizzleMockSeed
+DrizzleQueryContext, DrizzleStoreSchema
 ```
 
 ## `@ontrails/testing`

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -162,26 +162,15 @@ That means `testAll(app)` can auto-resolve connector-bound store resources witho
 
 ## Read-only bindings
 
-Use the Drizzle connector's read-only helpers when a trail should inspect persisted state without exposing writes:
+Use the Drizzle connector's read-only binding when a trail should inspect persisted state without exposing writes:
 
 ```typescript
-import { connectReadOnlyDrizzle, readonlyStore } from '@ontrails/drizzle';
+import { connectReadOnlyDrizzle } from '@ontrails/drizzle';
 
 const analytics = connectReadOnlyDrizzle(definition, {
   id: 'analytics.db',
   url: './data/analytics.sqlite',
 });
-
-const auditLog = readonlyStore(
-  {
-    entries: {
-      schema: auditEntrySchema,
-      identity: 'id',
-      generated: ['id', 'createdAt'],
-    },
-  },
-  { id: 'audit.db', url: './data/audit.sqlite' }
-);
 ```
 
 Read-only bindings expose `get()`, `list()`, and `query()`, but not `upsert()`, `remove()`, `insert()`, or `update()`.
@@ -212,46 +201,52 @@ const rows = await conn.query(({ drizzle, tables }) =>
 
 This keeps the default happy path derived and typed, while still giving you full access to the underlying connector when the CRUD accessors are not enough.
 
-## Connector conveniences
+## Connector binding
 
-`@ontrails/drizzle` also exports one-line conveniences when you want declaration and binding together:
+`@ontrails/drizzle` keeps the durable `store(...)` declaration in
+`@ontrails/store` and binds it to a concrete runtime:
 
 ```typescript
-import { store, readonlyStore } from '@ontrails/drizzle';
+import { connectDrizzle, connectReadOnlyDrizzle } from '@ontrails/drizzle';
+import { store } from '@ontrails/store';
 
-export const writable = store(
-  {
-    gists: {
-      schema: gistSchema,
-      identity: 'id',
-      generated: ['id', 'createdAt', 'updatedAt'],
-    },
+const definition = store({
+  gists: {
+    schema: gistSchema,
+    identity: 'id',
+    generated: ['id', 'createdAt', 'updatedAt'],
   },
-  { url: ':memory:' }
-);
+});
 
-export const readonly = readonlyStore(
-  {
-    gists: {
-      schema: gistSchema,
-      identity: 'id',
-      generated: ['id', 'createdAt', 'updatedAt'],
-    },
-  },
-  { url: './data/gists.sqlite' }
-);
+export const writable = connectDrizzle(definition, { url: ':memory:' });
+
+export const readonly = connectReadOnlyDrizzle(definition, {
+  url: './data/gists.sqlite',
+});
 ```
 
-These are conveniences, not the architectural source of truth. The root package still owns the durable authored `store(...)` model.
+The root package still owns the authored persistence model; connector packages
+project that model into runnable resources.
 
 ## Schema export for external tooling
 
-If you need the raw derived Drizzle tables for tooling such as `drizzle-kit`, use `getSchema()`:
+If you need the raw derived Drizzle tables for tooling such as `drizzle-kit`,
+read them from the bound resource's `tables` field:
 
 ```typescript
-import { getSchema } from '@ontrails/drizzle';
+import { connectDrizzle } from '@ontrails/drizzle';
+import { store } from '@ontrails/store';
 
-const schema = getSchema(db);
+const definition = store({
+  gists: {
+    schema: gistSchema,
+    identity: 'id',
+    generated: ['id', 'createdAt', 'updatedAt'],
+  },
+});
+
+const db = connectDrizzle(definition, { url: ':memory:' });
+const schema = db.tables;
 ```
 
 ## Installation

--- a/packages/store/src/__tests__/jsonfile.test.ts
+++ b/packages/store/src/__tests__/jsonfile.test.ts
@@ -347,5 +347,14 @@ describe('jsonfile connector', () => {
 
       await store.dispose?.(mock);
     });
+
+    test('preserves connector metadata on the resource definition', () => {
+      const store = jsonFile(fixtureStore, {
+        dir,
+        meta: { domain: 'fixtures' },
+      });
+
+      expect(store.meta).toEqual({ domain: 'fixtures' });
+    });
   });
 });

--- a/packages/store/src/__tests__/jsonfile.test.ts
+++ b/packages/store/src/__tests__/jsonfile.test.ts
@@ -356,5 +356,22 @@ describe('jsonfile connector', () => {
 
       expect(store.meta).toEqual({ domain: 'fixtures' });
     });
+
+    test('propagates caller-provided description to the resource', () => {
+      const store = jsonFile(fixtureStore, {
+        description: 'Custom jsonfile store description',
+        dir,
+      });
+
+      expect(store.description).toBe('Custom jsonfile store description');
+    });
+
+    test('uses a default description when caller omits one', () => {
+      const store = jsonFile(fixtureStore, { dir });
+
+      expect(store.description).toBe(
+        'JSON-file-backed store bound from an @ontrails/store definition.'
+      );
+    });
   });
 });

--- a/packages/store/src/__tests__/store.test.ts
+++ b/packages/store/src/__tests__/store.test.ts
@@ -3,19 +3,14 @@ import { ValidationError } from '@ontrails/core';
 import { z } from 'zod';
 
 import type {
+  AnyStoreTable,
   EntityOf,
   FixtureInputOf,
   FixtureOf,
   InsertOf,
   UpdateOf,
 } from '../index.js';
-import {
-  entitySchemaOf,
-  fixtureSchemaOf,
-  insertSchemaOf,
-  store,
-  updateSchemaOf,
-} from '../index.js';
+import { store } from '../index.js';
 
 const userSchema = z.object({
   email: z.string().email(),
@@ -90,10 +85,10 @@ const expectNormalizedGistTable = (
 const expectDerivedSchemas = (
   table: ReturnType<typeof createStoreDefinition>['tables']['gists']
 ) => {
-  expect(entitySchemaOf(table)).toBe(table.schema);
-  expect(fixtureSchemaOf(table)).toBe(table.fixtureSchema);
-  expect(insertSchemaOf(table)).toBe(table.insertSchema);
-  expect(updateSchemaOf(table)).toBe(table.updateSchema);
+  expect(table.schema).toBeDefined();
+  expect(table.fixtureSchema).toBeDefined();
+  expect(table.insertSchema).toBeDefined();
+  expect(table.updateSchema).toBeDefined();
 
   expect(
     table.insertSchema.parse({
@@ -138,9 +133,7 @@ type VersionedGistTable = ReturnType<
   typeof createVersionedStoreDefinition
 >['tables']['gists'];
 
-const createGistEntity = <
-  TTable extends Parameters<typeof entitySchemaOf>[0],
->() =>
+const createGistEntity = <TTable extends AnyStoreTable>() =>
   ({
     createdAt: '2026-04-03T12:00:00.000Z',
     description: null,

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,11 +1,4 @@
-export {
-  entitySchemaOf,
-  fixtureSchemaOf,
-  insertSchemaOf,
-  store,
-  updateSchemaOf,
-  versionFieldName,
-} from './store.js';
+export { store, versionFieldName } from './store.js';
 export type {
   AnyStoreDefinition,
   AnyStoreTable,
@@ -21,13 +14,13 @@ export type {
   IndexFieldsOfInput,
   IndexedFieldsOfInput,
   InsertOf,
-  PrimaryKeyOf,
   ReadOnlyStoreConnection,
   StoreAccessor,
   ReadOnlyStoreTableAccessor,
   ReferencesOfInput,
   StoreAccessMode,
   StoreConnection,
+  StoreConnectorOptions,
   StoreDefinition,
   StoreFieldKey,
   StoreFixtureInput,
@@ -35,6 +28,7 @@ export type {
   StoreIdentifierOf,
   StoreKind,
   StoreListOptions,
+  StoreMockSeed,
   StoreObjectSchema,
   StoreOptions,
   StoreSearchDefinition,

--- a/packages/store/src/jsonfile/index.ts
+++ b/packages/store/src/jsonfile/index.ts
@@ -1,7 +1,6 @@
 export { connectJsonFile, jsonFile, jsonFile as store } from './runtime.js';
 export type {
   JsonFileConnection,
-  JsonFileMockSeed,
   JsonFileStoreOptions,
   JsonFileStoreResource,
 } from './types.js';

--- a/packages/store/src/jsonfile/runtime.ts
+++ b/packages/store/src/jsonfile/runtime.ts
@@ -572,6 +572,9 @@ export const jsonFile = <TStore extends AnyStoreDefinition>(
         );
       }
     },
+    description:
+      options.description ??
+      'JSON-file-backed store bound from an @ontrails/store definition.',
     dispose: async (connection) => {
       const tmpDir = mockTmpDirs.get(connection as object);
       if (tmpDir !== undefined) {

--- a/packages/store/src/jsonfile/runtime.ts
+++ b/packages/store/src/jsonfile/runtime.ts
@@ -583,6 +583,7 @@ export const jsonFile = <TStore extends AnyStoreDefinition>(
         }
       }
     },
+    meta: options.meta,
     mock: async () => {
       const { mkdtemp } = await import('node:fs/promises');
       const { join } = await import('node:path');

--- a/packages/store/src/jsonfile/types.ts
+++ b/packages/store/src/jsonfile/types.ts
@@ -2,33 +2,22 @@ import type { Resource } from '@ontrails/core';
 import type {
   AnyStoreDefinition,
   AnyStoreTable,
-  FixtureInputOf,
   StoreAccessor,
+  StoreConnectorOptions,
 } from '../types.js';
 
 /** Connection shape: one StoreAccessor per table name. */
 export type JsonFileConnection<TStore extends Record<string, AnyStoreTable>> =
   Readonly<{ [K in keyof TStore]: StoreAccessor<TStore[K]> }>;
 
-/** Optional fixture overrides used when building a mock jsonfile store. */
-export type JsonFileMockSeed<TStore extends AnyStoreDefinition> = Partial<{
-  readonly [TName in keyof TStore['tables']]: readonly FixtureInputOf<
-    TStore['tables'][TName]
-  >[];
-}>;
-
 /** Options for creating a jsonfile store. */
 export interface JsonFileStoreOptions<
   TStore extends AnyStoreDefinition = AnyStoreDefinition,
-> {
+> extends StoreConnectorOptions<TStore> {
   /** Directory where JSON files are written. One `<tableName>.json` per table. */
   readonly dir: string;
-  /** Resource ID override. Defaults to `"store"`. */
-  readonly id?: string;
   /** Optional identity generator. Defaults to `Bun.randomUUIDv7()`. */
   readonly generateIdentity?: () => string;
-  /** Optional per-table fixture overrides used by the mock resource factory. */
-  readonly mockSeed?: JsonFileMockSeed<TStore>;
 }
 
 /** Resource type for a jsonfile store. */

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -546,31 +546,3 @@ export const store = <const TTables extends StoreTablesInput>(
     type: 'store' as const,
   });
 };
-
-/**
- * Read the full entity schema from a normalized store table.
- */
-export const entitySchemaOf = <TTable extends StoreTable>(
-  table: TTable
-): TTable['schema'] => table.schema;
-
-/**
- * Read the fixture schema from a normalized store table.
- */
-export const fixtureSchemaOf = <TTable extends StoreTable>(
-  table: TTable
-): TTable['fixtureSchema'] => table.fixtureSchema;
-
-/**
- * Read the insert schema from a normalized store table.
- */
-export const insertSchemaOf = <TTable extends StoreTable>(
-  table: TTable
-): TTable['insertSchema'] => table.insertSchema;
-
-/**
- * Read the update schema from a normalized store table.
- */
-export const updateSchemaOf = <TTable extends StoreTable>(
-  table: TTable
-): TTable['updateSchema'] => table.updateSchema;

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -276,7 +276,7 @@ export interface StoreTable<
   readonly primaryKey: IdentityFieldOfInput<TInput>;
   readonly references: ReferencesOfInput<TInput>;
   readonly schema: SchemaOfInput<TInput>;
-  readonly search?: TInput['search'];
+  readonly search?: StoreSearchDefinition | undefined;
   readonly signals: StoreTableSignals<z.output<SchemaOfInput<TInput>>>;
   readonly updateSchema: StoreObjectSchema;
   readonly versioned: VersionedFieldsOfInput<TInput>;
@@ -371,11 +371,6 @@ export type FixtureOf<TTable extends AnyStoreTable> = StoreFixtureRow<
 export type IdentityOf<TTable extends AnyStoreTable> = TTable['identity'];
 
 /**
- * Primary-key field name for one store table.
- */
-export type PrimaryKeyOf<TTable extends AnyStoreTable> = IdentityOf<TTable>;
-
-/**
  * Server-managed fields for one store table.
  */
 export type GeneratedKeysOf<TTable extends AnyStoreTable> = Extract<
@@ -398,7 +393,7 @@ export type InsertOf<TTable extends AnyStoreTable> = Omit<
  * Update shape: partial insert minus the primary key (immutable identifier).
  */
 export type UpdateOf<TTable extends AnyStoreTable> = Partial<
-  Omit<InsertOf<TTable>, PrimaryKeyOf<TTable>>
+  Omit<InsertOf<TTable>, IdentityOf<TTable>>
 >;
 
 /**
@@ -569,3 +564,34 @@ export type StoreTableConnection<TStore extends AnyStoreDefinition> = {
     TStore['tables'][TName]
   >;
 };
+
+/**
+ * Optional fixture overrides used when building a mock store connection.
+ *
+ * The shape is a partial map keyed by table name; each entry is a list of
+ * fixture inputs validated against the table's fixture schema. Connectors
+ * share this type so every store backend seeds mocks the same way.
+ */
+export type StoreMockSeed<TDef extends AnyStoreDefinition> = Partial<{
+  readonly [TName in keyof TDef['tables']]: readonly FixtureInputOf<
+    TDef['tables'][TName]
+  >[];
+}>;
+
+/**
+ * Shared connector options every store backend accepts.
+ *
+ * Concrete connectors extend this shape with their backend-specific fields
+ * (e.g. `url`, `dir`). Aligning the authored surface here lets the framework
+ * reason about connector options uniformly — one shape, many projections.
+ */
+export interface StoreConnectorOptions<TDef extends AnyStoreDefinition> {
+  /** Optional resource id override. Defaults to `"store"`. */
+  readonly id?: string;
+  /** Human-readable description surfaced on the resource definition. */
+  readonly description?: string;
+  /** Free-form metadata for downstream tooling and governance. */
+  readonly meta?: Record<string, unknown>;
+  /** Optional per-table fixture overrides used by the mock resource factory. */
+  readonly mockSeed?: StoreMockSeed<TDef>;
+}


### PR DESCRIPTION
## Summary

Apply the connector composition principle in the store ecosystem: extract `StoreConnectorOptions` and `StoreMockSeed` as shared bases on `@ontrails/store`, collapse the duplicate Drizzle option types, refactor JsonFile options to extend the shared base, and delete the shortcut/accessor exports that shadow primitive authoring or add no value. Also the final `packages/connectors` slice of the projection-verb sweep.

## What changed

### New shared bases in `@ontrails/store` (`packages/store/src/types.ts`)

```typescript
interface StoreConnectorOptions<TDef extends AnyStoreDefinition> {
  readonly id?: string;
  readonly description?: string;
  readonly meta?: Record<string, unknown>;
  readonly mockSeed?: StoreMockSeed<TDef>;
}

type StoreMockSeed<TDef extends AnyStoreDefinition> = Partial<{
  readonly [TName in keyof TDef['tables']]: readonly FixtureInputOf<TDef['tables'][TName]>[];
}>;
```

Both re-exported from `@ontrails/store`.

### Drizzle options collapse

```typescript
// Was: ConnectDrizzleOptions + ReadOnlyDrizzleOptions (byte-identical)
// Now:
interface DrizzleStoreOptions<TDef extends AnyStoreDefinition = AnyStoreDefinition>
  extends StoreConnectorOptions<TDef> {
  readonly url: string;
}
```

Read-only vs writable is enforced by the factory (`connectReadOnlyDrizzle` vs `connectDrizzle`), not by a separate options type.

### JsonFile options refactor

`JsonFileStoreOptions<TDef>` now extends `StoreConnectorOptions`, inheriting `id`, `description`, `meta`, `mockSeed`. Preserves JsonFile-specific `dir` and `generateIdentity?`. This also fixes the `description` drift flagged in the alignment doc — JsonFile was missing the field.

### Symbol renames

- `createSqliteSchemaStatements` → `deriveSqliteSchemaStatements` (Decision #1 — SQL DDL strings are projections, not lifecycle instances)
- `describeField` → `deriveFieldSpec` (Decision #3)
- `DrizzleMockSeed` / `JsonFileMockSeed` → `StoreMockSeed` (byte-identical; lifted to shared base)

### Deletions

- **Decision #34** (zero external callers): `entitySchemaOf` / `fixtureSchemaOf` / `insertSchemaOf` / `updateSchemaOf` from `@ontrails/store`. Tests updated to read `table.schema`, `table.fixtureSchema`, etc. directly.
- **Decision #36** (connector composition — don't shadow primitive authoring): `store` and `readonlyStore` shortcuts in `connectors/drizzle/src/runtime.ts`. Callers now write `connectDrizzle(defineStore(tables), options)` or `connectReadOnlyDrizzle(...)` explicitly — one authoring primitive, one factory.
- `getSchema` (drizzle one-line wrapper over `.tables`)
- **Decision #24**: `PrimaryKeyOf<T>` — inlined `IdentityOf<T>` at the single call site in `UpdateOf<T>` and deleted the alias.

### Latent bug caught in scope

Tightened `StoreTable.search` from `TInput['search']` (which resolved to `unknown` for `as const` tables without a declared `search` field) to `StoreSearchDefinition | undefined`. The `store`/`readonlyStore` shortcut layer was masking this; removing them surfaced it. Now `StoreDefinition<TTables>` correctly satisfies `AnyStoreDefinition` without casting.

### Consumer updates

- `connectors/drizzle/src/__tests__/drizzle.test.ts` — 9 shortcut call sites swapped to explicit factory calls; 2 `getSchema(x).tables` reads rewritten to direct `x.tables.<name>` access
- `apps/trails-demo/src/store.ts` — import swap from `store as bindDrizzleStore` to `connectDrizzle`; reuses the existing `entityStoreDefinition` built via `defineStore`

## Why

- **Decision #36 (connector composition principle).** Connectors compose over primitive-authored declarations; they don't shadow or re-invent the primitive authoring surface. The `store`/`readonlyStore` shortcuts in `@ontrails/drizzle` shadowed `@ontrails/store#store` and inlined the `defineStore` authoring step, preventing swap-ability across connectors.
- **Decision #6.** Duplicate types with identical shapes collapse — `ConnectDrizzleOptions` and `ReadOnlyDrizzleOptions` were structurally identical.
- **Decision #34.** The `*Of` accessors were one-line property lookups with zero external callers. Deleting them keeps the public API tight and pushes callers toward direct property access.
- **Decisions #1 and #3.** `createSqliteSchemaStatements` and `describeField` both produce data (SQL strings, field specs) from authored schemas — they're projections, not lifecycle instances. `derive*` is the correct grammar slot.

### Decision #17 status

The `DerivationError` demotion from PR #160 plus the other deletions above complete TRL-277's in-scope work. The remaining `RetryExhaustedError` → subclass of `InternalError` change is split to **TRL-298** — it requires an ADR-level category-widening decision on `InternalError.category`, not a mechanical rename.

### Docs deferred

`docs/api-reference.md`, `packages/store/README.md`, `connectors/drizzle/README.md`, and `docs/adr/0022-drizzle-store-connector.md` still reference deleted symbols (`entitySchemaOf`, `getSchema`, `store`/`readonlyStore`, `ConnectDrizzleOptions`, `DrizzleMockSeed`). Out of PR 4's scope — flagged for PR 10 / docs sweep.

## File ownership

Entirety of `packages/store/**` and `connectors/drizzle/**`, plus the import-cascade consumer at `apps/trails-demo/src/store.ts`. No file in this diff is touched by any other PR in the stack.

## Test plan

- [x] `bun run typecheck` — 30/30 green
- [x] `bun run test` — 30/30 green (store, drizzle, jsonfile, testing, warden suites all pass)
- [x] `bunx ultracite check` — 0/0
- [x] CI green across all checks

Pre-existing LSP-only diagnostics in `packages/store/src/__tests__/jsonfile.test.ts` remain unchanged — test files are excluded from the package's tsc build; `bun test` runs green at runtime.

Closes TRL-275, TRL-277, TRL-284.