### PR TITLE
feat(topo): derive trailhead identity from topo metadata [TRL-281]

### DIFF
--- a/apps/trails-demo/src/app.ts
+++ b/apps/trails-demo/src/app.ts
@@ -14,7 +14,11 @@ import * as onboard from './trails/onboard.js';
 import * as search from './trails/search.js';
 
 export const app = topo(
-  'demo',
+  {
+    description: 'Trails demo application',
+    name: 'demo',
+    version: '0.1.0',
+  },
   entityStore,
   notificationStore,
   entity,

--- a/apps/trails-demo/src/mcp.ts
+++ b/apps/trails-demo/src/mcp.ts
@@ -9,6 +9,4 @@ import { trailhead } from '@ontrails/mcp';
 
 import { app } from './app.js';
 
-await trailhead(app, {
-  serverInfo: { name: 'demo', version: '0.1.0' },
-});
+await trailhead(app);

--- a/docs/draft-state.md
+++ b/docs/draft-state.md
@@ -82,7 +82,7 @@ These outputs reject draft state at runtime via `validateEstablishedTopo()`:
 3. Rewrites every string literal matching `fromId` → `toId`
 4. Renames draft-marked files if they no longer contain draft IDs
 5. Updates relative imports that reference renamed files
-6. Loads the topo fresh and runs `analyzeDraftState()` to verify
+6. Loads the topo fresh and runs `deriveDraftReport()` to verify
 
 ### Example
 
@@ -146,7 +146,7 @@ Warns when draft IDs remain in source. Intentionally a warning — the hard reje
 
 When multiple draft IDs form a dependency chain, promote the deepest first:
 
-1. Run `analyzeDraftState(topo)` to see the full contamination graph
+1. Run `deriveDraftReport(topo)` to see the full contamination graph
 2. Start with draft IDs that have no draft dependencies
 3. Promote each, verify, then move up the chain
 
@@ -162,6 +162,6 @@ If a draft trail is no longer needed:
 ## Reference
 
 - `isDraftId(id)` — returns true if the ID starts with `_draft.`
-- `analyzeDraftState(topo)` — returns declared draft IDs, contaminated IDs, dependency graph, and findings
+- `deriveDraftReport(topo)` — returns declared draft IDs, contaminated IDs, dependency graph, and findings
 - `validateEstablishedTopo(topo)` — hard layer that rejects draft contamination
 - [ADR-0021](adr/0021-draft-state-stays-out-of-the-resolved-graph.md) — the decision and rationale

--- a/docs/trailheads/mcp.md
+++ b/docs/trailheads/mcp.md
@@ -151,15 +151,17 @@ hidden unless you include their exact trail ID.
 
 ```typescript
 await trailhead(app, {
-  serverInfo: {
-    name: 'myapp',
-    version: '1.0.0',
-  },
+  name: 'myapp',
+  version: '1.0.0',
   transport: 'stdio', // Only stdio for now; SSE/streamable HTTP planned
   layers: [myAuthGate, myRateLimitGate],
   createContext: () => createTrailContext({ logger: myLogger }),
 });
 ```
+
+`trailhead(app)` already derives the MCP server name and version from the
+topo identity. Pass `name` or `version` only when a specific trailhead instance
+needs to override them.
 
 ## AbortSignal Propagation
 

--- a/packages/cli/src/commander/trailhead.ts
+++ b/packages/cli/src/commander/trailhead.ts
@@ -77,11 +77,11 @@ export const trailhead = async (
   const commanderOpts: ToCommanderOptions = {
     name: options.name ?? app.name,
   };
-  if (options.version !== undefined) {
-    commanderOpts.version = options.version;
+  if (options.version !== undefined || app.version !== undefined) {
+    commanderOpts.version = options.version ?? app.version;
   }
-  if (options.description !== undefined) {
-    commanderOpts.description = options.description;
+  if (options.description !== undefined || app.description !== undefined) {
+    commanderOpts.description = options.description ?? app.description;
   }
 
   const program = toCommander(commands, commanderOpts);

--- a/packages/core/src/__tests__/topo.test.ts
+++ b/packages/core/src/__tests__/topo.test.ts
@@ -60,6 +60,20 @@ const mockResource = (
 // ---------------------------------------------------------------------------
 
 describe('topo', () => {
+  describe('identity', () => {
+    test('preserves object identity metadata', () => {
+      const t = topo({
+        description: 'Demo topo',
+        name: 'my-app',
+        version: '1.2.3',
+      });
+
+      expect(t.name).toBe('my-app');
+      expect(t.version).toBe('1.2.3');
+      expect(t.description).toBe('Demo topo');
+    });
+  });
+
   describe('collection', () => {
     test('returns Topo with name', () => {
       const t = topo('my-app');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -129,7 +129,7 @@ export type {
 
 // Topo
 export { topo } from './topo.js';
-export type { Topo } from './topo.js';
+export type { Topo, TopoIdentity } from './topo.js';
 export {
   createMockTopoStore,
   createTopoStore,

--- a/packages/core/src/topo.ts
+++ b/packages/core/src/topo.ts
@@ -13,8 +13,16 @@ import type { AnyTrail } from './trail.js';
 // Public types
 // ---------------------------------------------------------------------------
 
+export interface TopoIdentity {
+  readonly name: string;
+  readonly version?: string;
+  readonly description?: string;
+}
+
 export interface Topo {
   readonly name: string;
+  readonly version?: string;
+  readonly description?: string;
   readonly contours: ReadonlyMap<string, AnyContour>;
   readonly trails: ReadonlyMap<string, AnyTrail>;
   readonly signals: ReadonlyMap<string, AnySignal>;
@@ -56,7 +64,7 @@ const isRegistrable = (value: unknown): value is Registrable => {
 // ---------------------------------------------------------------------------
 
 const createTopo = (
-  name: string,
+  identity: TopoIdentity,
   contours: ReadonlyMap<string, AnyContour>,
   trails: ReadonlyMap<string, AnyTrail>,
   signals: ReadonlyMap<string, AnySignal>,
@@ -104,7 +112,11 @@ const createTopo = (
     return [...signals.values()];
   },
 
-  name,
+  name: identity.name,
+  ...(identity.version !== undefined && { version: identity.version }),
+  ...(identity.description !== undefined && {
+    description: identity.description,
+  }),
   resourceCount: resources.size,
   resourceIds(): string[] {
     return [...resources.keys()];
@@ -290,9 +302,14 @@ const registerModuleValues = (
 };
 
 export const topo = (
-  name: string,
+  nameOrIdentity: string | TopoIdentity,
   ...modules: Record<string, unknown>[]
 ): Topo => {
+  const identity: TopoIdentity =
+    typeof nameOrIdentity === 'string'
+      ? { name: nameOrIdentity }
+      : nameOrIdentity;
+
   const contours = new Map<string, AnyContour>();
   const trails = new Map<string, AnyTrail>();
   const signals = new Map<string, AnySignal>();
@@ -302,5 +319,5 @@ export const topo = (
     registerModuleValues(mod, contours, trails, signals, resources);
   }
 
-  return createTopo(name, contours, trails, signals, resources);
+  return createTopo(identity, contours, trails, signals, resources);
 };

--- a/packages/mcp/src/__tests__/trailhead.test.ts
+++ b/packages/mcp/src/__tests__/trailhead.test.ts
@@ -83,7 +83,7 @@ describe('trailhead', () => {
     expect(['resolved', 'timeout']).toContain(result);
   });
 
-  test('TrailheadMcpOptions accepts resource overrides', () => {
+  test('TrailheadMcpOptions accepts flattened identity and resource fields', () => {
     const opts: Parameters<typeof trailhead>[1] = {
       description: 'Test MCP server',
       name: 'testapp',

--- a/packages/mcp/src/__tests__/trailhead.test.ts
+++ b/packages/mcp/src/__tests__/trailhead.test.ts
@@ -85,10 +85,17 @@ describe('trailhead', () => {
 
   test('TrailheadMcpOptions accepts resource overrides', () => {
     const opts: Parameters<typeof trailhead>[1] = {
+      description: 'Test MCP server',
+      name: 'testapp',
       resources: {},
       validate: false,
+      version: '1.2.3',
     };
+    expect(opts.description).toBe('Test MCP server');
+    expect(opts.name).toBe('testapp');
     expect(opts.resources).toEqual({});
+    expect(opts.validate).toBe(false);
+    expect(opts.version).toBe('1.2.3');
   });
 
   test('createMcpServer registers tools that can be listed', () => {

--- a/packages/mcp/src/trailhead.ts
+++ b/packages/mcp/src/trailhead.ts
@@ -60,14 +60,27 @@ export interface TrailheadMcpOptions {
 
 /**
  * Create an MCP Server instance and register all tools.
+ *
+ * When provided, `info.description` is forwarded to the MCP SDK as the
+ * server's `instructions` field — the SDK's documented channel for
+ * "optional instructions describing how to use the server and its features."
  */
 export const createMcpServer = (
   tools: McpToolDefinition[],
-  info: { readonly name: string; readonly version: string }
+  info: {
+    readonly name: string;
+    readonly version: string;
+    readonly description?: string | undefined;
+  }
 ): Server => {
   const server = new Server(
     { name: info.name, version: info.version },
-    { capabilities: { tools: {} } }
+    {
+      capabilities: { tools: {} },
+      ...(info.description === undefined
+        ? {}
+        : { instructions: info.description }),
+    }
   );
 
   // Build a lookup map for tool dispatch
@@ -169,6 +182,7 @@ export const trailhead = async (
   }
 
   const server = createMcpServer(toolsResult.value, {
+    description: options.description ?? app.description,
     name: options.name ?? app.name,
     version: options.version ?? app.version ?? '0.1.0',
   });

--- a/packages/mcp/src/trailhead.ts
+++ b/packages/mcp/src/trailhead.ts
@@ -39,22 +39,19 @@ export interface TrailheadMcpOptions {
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
+  readonly description?: string | undefined;
   readonly exclude?: readonly string[] | undefined;
   readonly excludeTrails?: readonly string[] | undefined;
   readonly include?: readonly string[] | undefined;
   readonly includeTrails?: readonly string[] | undefined;
   readonly intent?: readonly Intent[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
+  readonly name?: string | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
-  readonly serverInfo?:
-    | {
-        readonly name?: string | undefined;
-        readonly version?: string | undefined;
-      }
-    | undefined;
   readonly transport?: 'stdio' | undefined;
   /** Set to `false` to skip topo validation at startup. Defaults to `true`. */
   readonly validate?: boolean | undefined;
+  readonly version?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -172,8 +169,8 @@ export const trailhead = async (
   }
 
   const server = createMcpServer(toolsResult.value, {
-    name: options.serverInfo?.name ?? app.name,
-    version: options.serverInfo?.version ?? '0.1.0',
+    name: options.name ?? app.name,
+    version: options.version ?? app.version ?? '0.1.0',
   });
 
   await connectStdio(server);

--- a/packages/warden/src/__tests__/valid-describe-refs.test.ts
+++ b/packages/warden/src/__tests__/valid-describe-refs.test.ts
@@ -57,4 +57,24 @@ trail("entity.show", {
 
     expect(diagnostics).toHaveLength(0);
   });
+
+  test('does not treat legacy event declarations as valid trail refs', () => {
+    const code = `
+event("entity.updated", {
+  payload: z.object({ id: z.string() }),
+})
+
+trail("entity.show", {
+  input: z.object({
+    query: z.string().describe("Search query. @see entity.updated"),
+  }),
+  blaze: (input) => Result.ok(input),
+})`;
+
+    const diagnostics = validDescribeRefs.check(code, 'src/entity.ts');
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('valid-describe-refs');
+    expect(diagnostics[0]?.message).toContain('entity.updated');
+  });
 });

--- a/packages/warden/src/rules/specs.ts
+++ b/packages/warden/src/rules/specs.ts
@@ -31,7 +31,7 @@ export interface SchemaFieldInfo {
   readonly required: boolean;
 }
 
-const TRAIL_LIKE_PATTERN = /\b(trail|event)\s*\(/g;
+const TRAIL_LIKE_PATTERN = /\b(trail|signal)\s*\(/g;
 
 const PROPERTY_PATTERN =
   /^(?:readonly\s+)?(?:(["'`])([^"'`]+)\1|([A-Za-z_$][\w$]*))\s*:\s*([\s\S]+)$/;

--- a/packages/warden/src/rules/specs.ts
+++ b/packages/warden/src/rules/specs.ts
@@ -31,7 +31,11 @@ export interface SchemaFieldInfo {
   readonly required: boolean;
 }
 
-const TRAIL_LIKE_PATTERN = /\b(trail|signal)\s*\(/g;
+// Match `trail(...)` / `signal(...)` declaration sites, not method calls.
+// The negative lookbehind excludes `foo.signal(...)`, `foo?.signal(...)`, and
+// similar member-expression call sites (including optional chaining with
+// whitespace) where `signal` / `trail` is a property name, not a factory.
+const TRAIL_LIKE_PATTERN = /(?<![.?])\b(trail|signal)\s*\(/g;
 
 const PROPERTY_PATTERN =
   /^(?:readonly\s+)?(?:(["'`])([^"'`]+)\1|([A-Za-z_$][\w$]*))\s*:\s*([\s\S]+)$/;


### PR DESCRIPTION
## Summary

Topo identity becomes the source of app name, version, and description across core, CLI, and MCP. `topo()` now accepts an identity object, CLI and MCP default from that authored topo identity, and MCP's trailhead options flatten to top-level `name` / `version` / `description` instead of the nested `serverInfo` wrapper.

## What changed

### Core topo identity

- `packages/core/src/topo.ts`
- `packages/core/src/__tests__/topo.test.ts`

`topo()` now accepts `string | TopoIdentity` as its first argument. `Topo` gains optional `version?` and `description?` fields, and the new tests cover both the string shorthand and the structured identity form.

### Trailhead defaults derive from topo

- `packages/cli/src/commander/trailhead.ts`
- `packages/mcp/src/trailhead.ts`
- `packages/mcp/src/__tests__/trailhead.test.ts`

CLI and MCP now read `name`, `version`, and `description` from the topo by default. On the MCP side, `TrailheadMcpOptions` is flattened so callers pass those fields directly instead of nesting them under `serverInfo`.

### Demo and docs follow-through

- `apps/trails-demo/src/app.ts`
- `apps/trails-demo/src/mcp.ts`
- `docs/trailheads/mcp.md`

The demo app now declares topo identity at the source, and the MCP docs/examples show the flattened option shape.

### Active cutover cleanup found during the final stack sweep

- `packages/warden/src/rules/specs.ts`
- `packages/warden/src/__tests__/valid-describe-refs.test.ts`
- `docs/draft-state.md`
- `packages/core/README.md`

While validating the stack, I found a few active-code/docs stragglers from the same vocabulary cutover:

- Warden was still accepting legacy `event(...)` declarations as valid describe refs.
- `docs/draft-state.md` still taught `analyzeDraftState()`.
- `packages/core/README.md` still referenced `getBackoffDelay`.

Those are cleaned up here so the top branch reflects the actual post-cutover surface.

## Why

- Topo is the authored source of identity; surfaces should derive from it rather than making each trailhead re-declare the same metadata.
- Flattening MCP identity options matches the clean-cutover direction for the rest of the stack and removes a one-off nesting shape from the public surface.
- Folding the final active stragglers into the top branch keeps the stack internally consistent before review.

## Test plan

- [x] `bun run build`
- [x] `bun run test`
- [x] CI was green on the previously submitted version; CI reruns on the refreshed stack after this submit

## Closes

Closes TRL-281.
