### PR TITLE
refactor(apps/trails): finish topo helper naming sweep [TRL-299]

### DIFF
--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -18,9 +18,9 @@ import type { TrailheadMap } from '@ontrails/schema';
 import { z } from 'zod';
 
 import {
-  generateBriefReport,
-  generateSurveyList,
-  generateTrailDetail,
+  deriveBriefReport,
+  deriveSurveyList,
+  deriveTrailDetail,
   surveyTrail,
 } from '../trails/survey.js';
 import type {
@@ -202,20 +202,20 @@ describe('trails survey', () => {
 
 describe('trails survey --brief', () => {
   test('produces a valid capability report', () => {
-    const report = generateBriefReport(app);
+    const report = deriveBriefReport(app);
     expect(report.name).toBe('test-app');
     expect(report.contractVersion).toBe('2026-03');
   });
 
   test('report includes correct trail count', () => {
-    const report = generateBriefReport(app);
+    const report = deriveBriefReport(app);
     expect(report.trails).toBe(2);
     expect(report.signals).toBe(0);
     expect(report.resources).toBe(1);
   });
 
   test('detects features in use', () => {
-    const report = generateBriefReport(app);
+    const report = deriveBriefReport(app);
     expect(report.features.outputSchemas).toBe(true);
     expect(report.features.examples).toBe(true);
     expect(report.features.detours).toBe(true);
@@ -224,7 +224,7 @@ describe('trails survey --brief', () => {
   });
 
   test('JSON output is valid', () => {
-    const report = generateBriefReport(app);
+    const report = deriveBriefReport(app);
     const json = JSON.stringify(report, null, 2);
     const parsed = JSON.parse(json) as BriefReport;
     expect(parsed.name).toBe('test-app');
@@ -234,7 +234,7 @@ describe('trails survey --brief', () => {
 
   test('empty app reports zero features', () => {
     const emptyApp = topo('empty', {});
-    const report = generateBriefReport(emptyApp);
+    const report = deriveBriefReport(emptyApp);
     expect(report.trails).toBe(0);
     expect(report.features.outputSchemas).toBe(false);
     expect(report.features.examples).toBe(false);
@@ -245,7 +245,7 @@ describe('trails survey --brief', () => {
 
 describe('trails survey detail', () => {
   test('trail detail includes declared resources, crossings, and intent', () => {
-    const detail = generateTrailDetail(helloTrail);
+    const detail = deriveTrailDetail(helloTrail);
     const parsed = structuredClone(detail) as TrailDetailReport;
 
     expect(parsed.crosses).toEqual([]);
@@ -256,7 +256,7 @@ describe('trails survey detail', () => {
 
 describe('trails survey resources section', () => {
   test('list output includes resource lifetime and health status', () => {
-    const report = generateSurveyList(app);
+    const report = deriveSurveyList(app);
     const parsed = structuredClone(report) as SurveyListReport;
     const db = parsed.resources.find((entry) => entry.id === 'db.main');
 

--- a/apps/trails/src/trails/dev-clean.ts
+++ b/apps/trails/src/trails/dev-clean.ts
@@ -2,7 +2,7 @@ import { Result, ValidationError, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { cleanDevState, DEFAULT_TOPO_SAVE_RETENTION } from './dev-support.js';
-import { isolatedExampleInput } from './topo-support.js';
+import { createIsolatedExampleInput } from './topo-support.js';
 
 export const devCleanTrail = trail('dev.clean', {
   blaze: (input, ctx) => {
@@ -30,7 +30,7 @@ export const devCleanTrail = trail('dev.clean', {
     {
       input: {
         dryRun: true,
-        rootDir: isolatedExampleInput('dev-clean').rootDir,
+        rootDir: createIsolatedExampleInput('dev-clean').rootDir,
       },
       name: 'Preview local cleanup',
     },

--- a/apps/trails/src/trails/dev-reset.ts
+++ b/apps/trails/src/trails/dev-reset.ts
@@ -2,7 +2,7 @@ import { Result, ValidationError, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { resetDevState } from './dev-support.js';
-import { isolatedExampleInput } from './topo-support.js';
+import { createIsolatedExampleInput } from './topo-support.js';
 
 export const devResetTrail = trail('dev.reset', {
   blaze: (input, ctx) => {
@@ -22,7 +22,7 @@ export const devResetTrail = trail('dev.reset', {
     {
       input: {
         dryRun: true,
-        rootDir: isolatedExampleInput('dev-reset').rootDir,
+        rootDir: createIsolatedExampleInput('dev-reset').rootDir,
       },
       name: 'Preview local reset',
     },

--- a/apps/trails/src/trails/dev-stats.ts
+++ b/apps/trails/src/trails/dev-stats.ts
@@ -2,7 +2,7 @@ import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { buildDevStats, DEFAULT_TOPO_SAVE_RETENTION } from './dev-support.js';
-import { isolatedExampleInput } from './topo-support.js';
+import { createIsolatedExampleInput } from './topo-support.js';
 
 export const devStatsTrail = trail('dev.stats', {
   blaze: (input, ctx) => {
@@ -19,7 +19,7 @@ export const devStatsTrail = trail('dev.stats', {
   description: 'Show local Trails workspace state and retention',
   examples: [
     {
-      input: { rootDir: isolatedExampleInput('dev-stats').rootDir },
+      input: { rootDir: createIsolatedExampleInput('dev-stats').rootDir },
       name: 'Show local dev state',
     },
   ],

--- a/apps/trails/src/trails/dev-support.ts
+++ b/apps/trails/src/trails/dev-support.ts
@@ -174,7 +174,7 @@ const liveDevStats = (
   },
 });
 
-const resolveDevStatsContext = (options?: DevRetentionOptions) => {
+const deriveDevStatsContext = (options?: DevRetentionOptions) => {
   const rootDir = deriveRootDir(options?.rootDir);
   const dbPath = deriveTrailsDbPath({ rootDir });
   const trailsDir = deriveTrailsDir({ rootDir });
@@ -188,7 +188,7 @@ const resolveDevStatsContext = (options?: DevRetentionOptions) => {
   };
 };
 
-const resolveDevCleanupContext = (
+const deriveDevCleanupContext = (
   options?: DevRetentionOptions & { readonly dryRun?: boolean }
 ): DevCleanupContext => {
   const rootDir = deriveRootDir(options?.rootDir);
@@ -268,7 +268,7 @@ export const buildDevStats = (
   options?: DevRetentionOptions
 ): DevStatsReport => {
   const { dbExists, dbPath, lockPath, retention, rootDir } =
-    resolveDevStatsContext(options);
+    deriveDevStatsContext(options);
 
   if (!dbExists) {
     return emptyDevStats(dbPath, lockPath, retention);
@@ -286,7 +286,7 @@ export const buildDevStats = (
 export const cleanDevState = (
   options?: DevRetentionOptions & { readonly dryRun?: boolean }
 ): DevCleanReport => {
-  const context = resolveDevCleanupContext(options);
+  const context = deriveDevCleanupContext(options);
   if (!existsSync(context.dbPath)) {
     return emptyDevClean(context.retention, context.dryRun);
   }

--- a/apps/trails/src/trails/dev-support.ts
+++ b/apps/trails/src/trails/dev-support.ts
@@ -25,7 +25,7 @@ import { resolveLockPath } from './topo-support.js';
 
 export const DEFAULT_TOPO_SAVE_RETENTION = 50;
 
-const resolveRootDir = (cwd?: string): string => cwd ?? process.cwd();
+const deriveRootDir = (cwd?: string): string => cwd ?? process.cwd();
 
 const removeIfPresent = (filePath: string): boolean => {
   if (!existsSync(filePath)) {
@@ -175,7 +175,7 @@ const liveDevStats = (
 });
 
 const resolveDevStatsContext = (options?: DevRetentionOptions) => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   const dbPath = deriveTrailsDbPath({ rootDir });
   const trailsDir = deriveTrailsDir({ rootDir });
   const lockPath = resolveLockPath(trailsDir);
@@ -191,7 +191,7 @@ const resolveDevStatsContext = (options?: DevRetentionOptions) => {
 const resolveDevCleanupContext = (
   options?: DevRetentionOptions & { readonly dryRun?: boolean }
 ): DevCleanupContext => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   return {
     dbPath: deriveTrailsDbPath({ rootDir }),
     dryRun: options?.dryRun ?? false,
@@ -306,7 +306,7 @@ export const resetDevState = (options?: {
   readonly dryRun?: boolean;
   readonly rootDir?: string;
 }): DevResetReport => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   const files = presentResetFiles(rootDir);
 
   if (options?.dryRun === true) {

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -25,10 +25,10 @@ import {
 import { exportCurrentTopo } from './topo-store-support.js';
 
 export {
-  formatResourceDetail,
-  generateBriefReport,
-  generateSurveyList,
-  generateTrailDetail,
+  deriveBriefReport,
+  deriveResourceDetail,
+  deriveSurveyList,
+  deriveTrailDetail,
 } from './topo-reports.js';
 export type {
   BriefReport,

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -124,7 +124,7 @@ const modeChecks: readonly [(input: SurveyInput) => boolean, SurveyMode][] = [
 ];
 
 /** Determine which survey mode was requested, falling back to 'list'. */
-const resolveSurveyMode = (input: SurveyInput): SurveyMode =>
+const deriveSurveyMode = (input: SurveyInput): SurveyMode =>
   modeChecks.find(([predicate]) => predicate(input))?.[1] ?? 'list';
 
 type SurveyHandler = (
@@ -152,7 +152,7 @@ const dispatchSurvey = (
   input: SurveyInput,
   rootDir: string
 ): Result<object, Error> | Promise<Result<object, Error>> => {
-  const mode = resolveSurveyMode(input);
+  const mode = deriveSurveyMode(input);
   const handler = surveyHandlers[mode];
   return handler(app, input, rootDir);
 };

--- a/apps/trails/src/trails/topo-export.ts
+++ b/apps/trails/src/trails/topo-export.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { loadApp } from './load-app.js';
 import { exportCurrentTopo } from './topo-store-support.js';
-import { isolatedExampleInput, topoSaveOutput } from './topo-support.js';
+import { createIsolatedExampleInput, topoSaveOutput } from './topo-support.js';
 
 export const topoExportTrail = trail('topo.export', {
   blaze: async (input, ctx) => {
@@ -14,7 +14,7 @@ export const topoExportTrail = trail('topo.export', {
   description: 'Export the current topo to .trails artifacts',
   examples: [
     {
-      input: isolatedExampleInput('topo-export'),
+      input: createIsolatedExampleInput('topo-export'),
       name: 'Write the current topo export',
     },
   ],

--- a/apps/trails/src/trails/topo-history.ts
+++ b/apps/trails/src/trails/topo-history.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import {
   DEFAULT_TOPO_HISTORY_LIMIT,
-  isolatedExampleInput,
+  createIsolatedExampleInput,
   listTopoHistory,
   topoPinOutput,
   topoSaveOutput,
@@ -17,7 +17,7 @@ export const topoHistoryTrail = trail('topo.history', {
   description: 'List saved topo metadata, including pins and recent autosaves',
   examples: [
     {
-      input: isolatedExampleInput('topo-history'),
+      input: createIsolatedExampleInput('topo-history'),
       name: 'Show topo history',
     },
   ],

--- a/apps/trails/src/trails/topo-pin.ts
+++ b/apps/trails/src/trails/topo-pin.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { loadApp } from './load-app.js';
 import {
-  isolatedExampleInput,
+  createIsolatedExampleInput,
   pinCurrentTopo,
   topoPinOutput,
   topoSaveOutput,
@@ -19,7 +19,7 @@ export const topoPinTrail = trail('topo.pin', {
   examples: [
     {
       input: {
-        ...isolatedExampleInput('topo-pin'),
+        ...createIsolatedExampleInput('topo-pin'),
         name: 'before-auth-refactor',
       },
       name: 'Pin the current topo',

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -30,8 +30,8 @@ import type { TopoSummaryReport, TopoVerifyReport } from './topo-support.js';
 import { REPORT_CONTRACT_VERSION, REPORT_VERSION } from './topo-constants.js';
 import {
   createCurrentTopoSave,
+  deriveRootDir,
   LOCK_PATH,
-  resolveRootDir,
 } from './topo-support.js';
 
 // ---------------------------------------------------------------------------
@@ -219,7 +219,7 @@ export const buildTopoSummary = (
   app: Topo,
   options?: { readonly rootDir?: string }
 ): TopoSummaryReport => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   const trailsDir = deriveTrailsDir({ rootDir });
   return withCurrentTopoStore(app, rootDir, (store, ref, save) => ({
     app: buildBriefReportFromStore(app, store, ref, save),
@@ -234,7 +234,7 @@ export const buildCurrentTopoBrief = (
   app: Topo,
   options?: { readonly rootDir?: string }
 ): BriefReport => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   return withCurrentTopoStore(app, rootDir, (store, ref, save) =>
     buildBriefReportFromStore(app, store, ref, save)
   );
@@ -244,7 +244,7 @@ export const buildCurrentTopoList = (
   app: Topo,
   options?: { readonly rootDir?: string }
 ): SurveyListReport => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   return withCurrentTopoStore(app, rootDir, (store, ref) =>
     buildSurveyListFromStore(store, ref)
   );
@@ -259,7 +259,7 @@ export const buildCurrentGuideEntries = (
   readonly id: string;
   readonly kind: string;
 }[] => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   return withCurrentTopoStore(app, rootDir, (store, ref) =>
     store.trails.list({ save: ref }).map((trail) => ({
       description: trail.description ?? '(no description)',
@@ -275,7 +275,7 @@ export const buildCurrentTopoDetail = (
   id: string,
   options?: { readonly rootDir?: string }
 ): CurrentResourceDetail | CurrentTrailDetail | undefined => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   return withCurrentTopoStore(app, rootDir, (store, ref) => {
     const trail = store.trails.get(id, { save: ref });
     if (trail !== undefined) {
@@ -293,7 +293,7 @@ export const verifyCurrentTopo = async (
   app: Topo,
   options?: { readonly rootDir?: string }
 ): Promise<Result<TopoVerifyReport, Error>> => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   const committedLock = await readTrailheadLockData({
     dir: deriveTrailsDir({ rootDir }),
   });

--- a/apps/trails/src/trails/topo-reports.ts
+++ b/apps/trails/src/trails/topo-reports.ts
@@ -81,7 +81,7 @@ const detectFeatures = (
   };
 };
 
-export const generateBriefReport = (app: Topo): BriefReport => {
+export const deriveBriefReport = (app: Topo): BriefReport => {
   const { hasDetours, hasExamples, hasOutputSchemas, hasResources } =
     detectFeatures(app);
 
@@ -140,7 +140,7 @@ const resourceHealthStatus = (resource: {
 }): 'available' | 'none' =>
   resource.health === undefined ? 'none' : 'available';
 
-export const formatResourceDetail = (app: Topo, resourceId: string): object => {
+export const deriveResourceDetail = (app: Topo, resourceId: string): object => {
   const item = app.getResource(resourceId);
   const usedBy = buildResourceUsage(app).get(resourceId) ?? [];
 
@@ -169,7 +169,7 @@ const formatResourceList = (app: Topo): SurveyListReport['resources'] => {
     .toSorted((a, b) => a.id.localeCompare(b.id));
 };
 
-export const generateSurveyList = (app: Topo): SurveyListReport => {
+export const deriveSurveyList = (app: Topo): SurveyListReport => {
   const items = app.list();
   const entries = items.map((item) => {
     const safety = safetyLabel(
@@ -199,7 +199,7 @@ export const generateSurveyList = (app: Topo): SurveyListReport => {
   };
 };
 
-export const generateTrailDetail = (
+export const deriveTrailDetail = (
   item: Trail<unknown, unknown>
 ): TrailDetailReport => {
   const safety = safetyLabel(

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -21,7 +21,11 @@ import type { TrailheadLock, TrailheadMap } from '@ontrails/schema';
 import { writeTrailheadLock, writeTrailheadMap } from '@ontrails/schema';
 
 import type { TopoExportReport } from './topo-support.js';
-import { currentGitState, resolveRootDir, topoCounts } from './topo-support.js';
+import {
+  deriveRootDir,
+  deriveTopoCounts,
+  readGitState,
+} from './topo-support.js';
 
 const persistAndReadStoredExport = (
   app: Topo,
@@ -29,8 +33,8 @@ const persistAndReadStoredExport = (
   rootDir: string
 ): Result<{ save: TopoSaveRecord; storedExport: StoredTopoExport }, Error> => {
   const saveResult = persistEstablishedTopoSave(db, app, {
-    ...currentGitState(rootDir),
-    ...topoCounts(app),
+    ...readGitState(rootDir),
+    ...deriveTopoCounts(app),
   });
   if (saveResult.isErr()) {
     return saveResult;
@@ -75,7 +79,7 @@ export const exportCurrentTopo = async (
   app: Topo,
   options?: { readonly rootDir?: string }
 ): Promise<Result<TopoExportReport, Error>> => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   const db = openWriteTrailsDb({ rootDir });
 
   try {

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -90,7 +90,7 @@ export interface TopoVerifyReport {
   readonly stale: false;
 }
 
-export const resolveRootDir = (cwd?: string): string => cwd ?? process.cwd();
+export const deriveRootDir = (cwd?: string): string => cwd ?? process.cwd();
 
 const safeGit = (cwd: string, args: readonly string[]): string | undefined => {
   const proc = Bun.spawnSync({
@@ -105,7 +105,7 @@ const safeGit = (cwd: string, args: readonly string[]): string | undefined => {
   return text.length === 0 ? undefined : text;
 };
 
-export const currentGitState = (
+export const readGitState = (
   rootDir: string
 ): { readonly gitDirty: boolean; readonly gitSha?: string } => {
   const gitSha = safeGit(rootDir, ['rev-parse', 'HEAD']);
@@ -116,7 +116,7 @@ export const currentGitState = (
   };
 };
 
-export const topoCounts = (
+export const deriveTopoCounts = (
   app: Topo
 ): Pick<TopoSaveRecord, 'resourceCount' | 'signalCount' | 'trailCount'> => ({
   resourceCount: app.resources.size,
@@ -163,7 +163,7 @@ const removeTopoPinWithDb = (
     ? { dryRun: true, pin, removed: false }
     : { dryRun: false, pin, removed: unpinTopoSave(db, input.name) };
 
-export const isolatedExampleInput = (
+export const createIsolatedExampleInput = (
   name: string
 ): { readonly module: string; readonly rootDir: string } => {
   const rootDir = join(tmpdir(), 'ontrails-trails-examples', name);
@@ -179,13 +179,13 @@ export const createCurrentTopoSave = (
   app: Topo,
   options?: { readonly rootDir?: string }
 ): TopoSaveRecord => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   const db = openWriteTrailsDb({ rootDir });
 
   try {
     const result = persistEstablishedTopoSave(db, app, {
-      ...currentGitState(rootDir),
-      ...topoCounts(app),
+      ...readGitState(rootDir),
+      ...deriveTopoCounts(app),
     });
     if (result.isErr()) {
       throw result.error;
@@ -200,7 +200,7 @@ export const listTopoHistory = (options?: {
   readonly limit?: number;
   readonly rootDir?: string;
 }): TopoHistoryReport => {
-  const rootDir = resolveRootDir(options?.rootDir);
+  const rootDir = deriveRootDir(options?.rootDir);
   const limit = options?.limit ?? DEFAULT_TOPO_HISTORY_LIMIT;
   const dbPath = deriveTrailsDbPath({ rootDir });
   if (!existsSync(dbPath)) {
@@ -224,13 +224,13 @@ export const pinCurrentTopo = (
   app: Topo,
   input: { readonly name: string; readonly rootDir?: string }
 ): { readonly pin: TopoPinRecord; readonly save: TopoSaveRecord } => {
-  const rootDir = resolveRootDir(input.rootDir);
+  const rootDir = deriveRootDir(input.rootDir);
   const db = openWriteTrailsDb({ rootDir });
 
   try {
     const result = persistEstablishedTopoSave(db, app, {
-      ...currentGitState(rootDir),
-      ...topoCounts(app),
+      ...readGitState(rootDir),
+      ...deriveTopoCounts(app),
     });
     if (result.isErr()) {
       throw result.error;
@@ -254,7 +254,7 @@ export const removeTopoPin = (input: {
   readonly pin?: TopoPinRecord;
   readonly removed: boolean;
 } => {
-  const rootDir = resolveRootDir(input.rootDir);
+  const rootDir = deriveRootDir(input.rootDir);
   if (!existsSync(deriveTrailsDbPath({ rootDir }))) {
     return { dryRun: input.dryRun, removed: false };
   }

--- a/apps/trails/src/trails/topo-unpin.ts
+++ b/apps/trails/src/trails/topo-unpin.ts
@@ -2,7 +2,7 @@ import { Result, ValidationError, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import {
-  isolatedExampleInput,
+  createIsolatedExampleInput,
   removeTopoPin,
   topoPinOutput,
 } from './topo-support.js';
@@ -26,7 +26,7 @@ export const topoUnpinTrail = trail('topo.unpin', {
   examples: [
     {
       input: {
-        ...isolatedExampleInput('topo-unpin'),
+        ...createIsolatedExampleInput('topo-unpin'),
         dryRun: true,
         name: 'before-auth-refactor',
       },


### PR DESCRIPTION
## Summary

Finish the deferred `apps/trails` slice of the helper naming sweep. This PR brings the active topo/survey/dev helpers in `apps/trails` into line with the closed verb grammar: pure projections become `derive*`, filesystem reads become `read*`, and value construction becomes `create*`.

## What changed

### Report helpers

- `apps/trails/src/trails/topo-reports.ts`

| From | To |
|---|---|
| `generateBriefReport` | `deriveBriefReport` |
| `generateSurveyList` | `deriveSurveyList` |
| `generateTrailDetail` | `deriveTrailDetail` |
| `formatResourceDetail` | `deriveResourceDetail` |

### Topo support helpers

- `apps/trails/src/trails/topo-support.ts`

| From | To |
|---|---|
| `currentGitState` | `readGitState` |
| `topoCounts` | `deriveTopoCounts` |
| `isolatedExampleInput` | `createIsolatedExampleInput` |
| `resolveRootDir` | `deriveRootDir` |

### Final internal follow-through

- `apps/trails/src/trails/dev-support.ts`
- `apps/trails/src/trails/survey.ts`

| From | To |
|---|---|
| `resolveDevStatsContext` | `deriveDevStatsContext` |
| `resolveDevCleanupContext` | `deriveDevCleanupContext` |
| `resolveSurveyMode` | `deriveSurveyMode` |

### Caller and test updates

Call sites were updated across `topo-history`, `topo-pin`, `topo-unpin`, `topo-export`, `topo-read-support`, `topo-store-support`, the dev trails, and `apps/trails/src/__tests__/survey.test.ts`.

## Why

- This was the last active `apps/trails` residue from the broader vocabulary sweep.
- The helpers in this layer are a mix of pure projections, git/filesystem reads, and value construction; the new names make those semantics obvious at the call site.
- Keeping this slice isolated in its own PR preserves the earlier package-focused review surface on `TRL-275` while still finishing the user-facing helper layer.

## Test plan

- [x] `bun run build`
- [x] `bun run test`

## Relates to

Closes TRL-299. This is the deferred `apps/trails` follow-through that was split out of TRL-275 so the package-level sweep and the app-level rename surface could review independently.
