### PR TITLE
refactor: rename schema artifacts to surface maps

### DIFF
--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -14,7 +14,7 @@ import {
   deriveSurfaceMapHash,
   deriveSurfaceMapDiff,
 } from '@ontrails/schema';
-import type { TrailheadMap } from '@ontrails/schema';
+import type { SurfaceMap } from '@ontrails/schema';
 import { z } from 'zod';
 
 import {
@@ -130,17 +130,17 @@ const repoTempDir = (): string =>
 
 describe('trails survey', () => {
   test('deriveSurfaceMap includes all trails', () => {
-    const trailheadMap = deriveSurfaceMap(app);
-    expect(trailheadMap.entries.length).toBe(3);
-    const ids = trailheadMap.entries.map((e) => e.id);
+    const surfaceMap = deriveSurfaceMap(app);
+    expect(surfaceMap.entries.length).toBe(3);
+    const ids = surfaceMap.entries.map((e) => e.id);
     expect(ids).toContain('hello');
     expect(ids).toContain('bye');
     expect(ids).toContain('db.main');
   });
 
-  test('trailhead map entries have expected fields', () => {
-    const trailheadMap = deriveSurfaceMap(app);
-    const hello = trailheadMap.entries.find((e) => e.id === 'hello');
+  test('surface map entries have expected fields', () => {
+    const surfaceMap = deriveSurfaceMap(app);
+    const hello = surfaceMap.entries.find((e) => e.id === 'hello');
     expect(hello).toBeDefined();
     expect(hello?.cli?.path).toEqual(['hello']);
     expect(hello?.kind).toBe('trail');
@@ -150,17 +150,17 @@ describe('trails survey', () => {
   });
 
   test('JSON output is valid JSON', () => {
-    const trailheadMap = deriveSurfaceMap(app);
-    const json = JSON.stringify(trailheadMap, null, 2);
-    const parsed = JSON.parse(json) as TrailheadMap;
+    const surfaceMap = deriveSurfaceMap(app);
+    const json = JSON.stringify(surfaceMap, null, 2);
+    const parsed = JSON.parse(json) as SurfaceMap;
     expect(parsed.version).toBe('1.0');
     expect(parsed.entries.length).toBe(3);
   });
 
   test('deriveSurfaceMapHash produces stable hash', () => {
-    const trailheadMap = deriveSurfaceMap(app);
-    const hash1 = deriveSurfaceMapHash(trailheadMap);
-    const hash2 = deriveSurfaceMapHash(trailheadMap);
+    const surfaceMap = deriveSurfaceMap(app);
+    const hash1 = deriveSurfaceMapHash(surfaceMap);
+    const hash2 = deriveSurfaceMapHash(surfaceMap);
     expect(hash1).toBe(hash2);
     // SHA-256 hex
     expect(hash1.length).toBe(64);

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -189,8 +189,8 @@ describe('trails survey', () => {
   });
 
   test('deriveSurfaceMapDiff returns empty for identical maps', () => {
-    const trailheadMap = deriveSurfaceMap(app);
-    const diff = deriveSurfaceMapDiff(trailheadMap, trailheadMap);
+    const surfaceMap = deriveSurfaceMap(app);
+    const diff = deriveSurfaceMapDiff(surfaceMap, surfaceMap);
     expect(diff.entries.length).toBe(0);
     expect(diff.hasBreaking).toBe(false);
   });

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -124,23 +124,17 @@ describe('topo and dev trails', () => {
         version: 1,
       });
 
-      writeFileSync(
-        join(dir, '.trails', 'trailhead.lock'),
-        readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8')
-      );
-      rmSync(join(dir, '.trails', 'trails.lock'));
-
-      const legacySummary = expectOk(
+      const summaryAfterExport = expectOk(
         await topoTrail.blaze(moduleInput, { cwd: dir } as never)
       );
-      expect(legacySummary.lockExists).toBe(true);
+      expect(summaryAfterExport.lockExists).toBe(true);
 
       const verifyResult = expectOk(
         await topoVerifyTrail.blaze(moduleInput, { cwd: dir } as never)
       );
       expect(verifyResult.stale).toBe(false);
 
-      writeFileSync(join(dir, '.trails', 'trailhead.lock'), 'stale\n');
+      writeFileSync(join(dir, '.trails', 'trails.lock'), 'stale\n');
       const verifyError = expectErr(
         await topoVerifyTrail.blaze(moduleInput, { cwd: dir } as never)
       );

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -1,7 +1,7 @@
 /**
  * `survey` trail -- Full topo introspection.
  *
- * Lists trails, shows detail for individual trails, generates trailhead maps,
+ * Lists trails, shows detail for individual trails, generates surface maps,
  * and diffs against previous versions.
  */
 
@@ -12,7 +12,7 @@ import {
   deriveSurfaceMapDiff,
   deriveOpenApiSpec,
   deriveSurfaceMap,
-  readTrailheadMap,
+  readSurfaceMap,
 } from '@ontrails/schema';
 import { z } from 'zod';
 
@@ -52,11 +52,11 @@ const buildSurveyDiff = async (
   breakingOnly: boolean
 ): Promise<Result<object, Error>> => {
   const currentMap = deriveSurfaceMap(app);
-  const previousMap = await readTrailheadMap();
+  const previousMap = await readSurfaceMap();
   if (!previousMap) {
     return Result.err(
       new NotFoundError(
-        'No previous trailhead map found. Run `trails topo export` first.'
+        'No previous surface map found. Run `trails topo export` first.'
       )
     );
   }
@@ -195,7 +195,7 @@ export const surveyTrail = trail('survey', {
     generate: z
       .boolean()
       .default(false)
-      .describe('Generate trailhead map and lock file'),
+      .describe('Generate surface map and lock file'),
     module: z.string().optional().describe('Path to the app module'),
     openapi: z.boolean().default(false).describe('Output OpenAPI 3.1 spec'),
     trailId: z.string().optional().describe('Trail ID for detail view'),

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -23,7 +23,7 @@ import {
   deriveTrailsDbPath,
   deriveTrailsDir,
 } from '@ontrails/core/internal/trails-db';
-import { readTrailheadLockData } from '@ontrails/schema';
+import { readSurfaceLockData } from '@ontrails/schema';
 
 import type { BriefReport, SurveyListReport } from './topo-reports.js';
 import type { TopoSummaryReport, TopoVerifyReport } from './topo-support.js';
@@ -38,7 +38,7 @@ import {
 // Internal types
 // ---------------------------------------------------------------------------
 
-interface StoredTrailheadMapEntry {
+interface StoredSurfaceMapEntry {
   readonly detours?: readonly {
     readonly on: string;
     readonly maxAttempts: number;
@@ -79,12 +79,12 @@ const hasCommittedLock = (trailsDir: string): boolean =>
   existsSync(join(trailsDir, 'trails.lock')) ||
   existsSync(join(trailsDir, 'trailhead.lock'));
 
-const readTrailheadEntries = (
+const readSurfaceEntries = (
   trailheadMapJson: string
-): readonly StoredTrailheadMapEntry[] =>
+): readonly StoredSurfaceMapEntry[] =>
   (
     JSON.parse(trailheadMapJson) as {
-      readonly entries: readonly StoredTrailheadMapEntry[];
+      readonly entries: readonly StoredSurfaceMapEntry[];
     }
   ).entries;
 
@@ -99,7 +99,7 @@ const buildBriefReportFromStore = (
   const trailEntries =
     exportRecord === undefined
       ? []
-      : readTrailheadEntries(exportRecord.trailheadMapJson).filter(
+      : readSurfaceEntries(exportRecord.trailheadMapJson).filter(
           (entry) => entry.kind === 'trail'
         );
 
@@ -294,7 +294,7 @@ export const verifyCurrentTopo = async (
   options?: { readonly rootDir?: string }
 ): Promise<Result<TopoVerifyReport, Error>> => {
   const rootDir = deriveRootDir(options?.rootDir);
-  const committedLock = await readTrailheadLockData({
+  const committedLock = await readSurfaceLockData({
     dir: deriveTrailsDir({ rootDir }),
   });
 

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -76,8 +76,7 @@ interface CurrentResourceDetail {
 const topoStoreRef = (saveId: string) => ({ saveId }) as const;
 
 const hasCommittedLock = (trailsDir: string): boolean =>
-  existsSync(join(trailsDir, 'trails.lock')) ||
-  existsSync(join(trailsDir, 'trailhead.lock'));
+  existsSync(join(trailsDir, 'trails.lock'));
 
 const readSurfaceEntries = (
   trailheadMapJson: string

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -17,8 +17,8 @@ import {
   openWriteTrailsDb,
   deriveTrailsDir,
 } from '@ontrails/core/internal/trails-db';
-import type { TrailheadLock, TrailheadMap } from '@ontrails/schema';
-import { writeTrailheadLock, writeTrailheadMap } from '@ontrails/schema';
+import type { SurfaceLock, SurfaceMap } from '@ontrails/schema';
+import { writeSurfaceLock, writeSurfaceMap } from '@ontrails/schema';
 
 import type { TopoExportReport } from './topo-support.js';
 import {
@@ -59,12 +59,12 @@ const writeStoredExportArtifacts = async (
   storedExport: StoredTopoExport,
   trailsDir: string
 ): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'mapPath'>> => {
-  const mapPath = await writeTrailheadMap(
-    JSON.parse(storedExport.trailheadMapJson) as TrailheadMap,
+  const mapPath = await writeSurfaceMap(
+    JSON.parse(storedExport.trailheadMapJson) as SurfaceMap,
     { dir: trailsDir }
   );
-  const lockPath = await writeTrailheadLock(
-    JSON.parse(storedExport.lockContent) as TrailheadLock,
+  const lockPath = await writeSurfaceLock(
+    JSON.parse(storedExport.lockContent) as SurfaceLock,
     { dir: trailsDir }
   );
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -163,10 +163,10 @@ CreateAppOptions, SurfaceHttpResult
 ```typescript
 deriveOpenApiSpec(topo, options?) // OpenAPI 3.1 spec from topo
 deriveSurfaceMap(topo), deriveSurfaceMapHash(map), deriveSurfaceMapDiff(before, after)
-writeTrailheadMap(map, options?), readTrailheadMap(options?)
-writeTrailheadLock(lock, options?), readTrailheadLockData(options?), readTrailheadLock(options?)
+writeSurfaceMap(map, options?), readSurfaceMap(options?)
+writeSurfaceLock(lock, options?), readSurfaceLockData(options?), readSurfaceLock(options?)
 
-TrailheadMap, TrailheadMapEntry, DiffResult, DiffEntry, JsonSchema
+SurfaceMap, SurfaceMapEntry, SurfaceMapContourReference, SurfaceLock, DiffResult, DiffEntry, JsonSchema
 WriteOptions, ReadOptions
 
 OpenApiOptions, OpenApiSpec, OpenApiServer

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1,14 +1,14 @@
 # @ontrails/schema
 
-Deterministic trailhead maps, lockfile helpers, and semantic diffing for Trails.
+Deterministic surface maps, lockfile helpers, and semantic diffing for Trails.
 
 Most applications reach this package through `trails topo export` and `trails topo verify`. Those CLI trails layer workspace and topo-store behavior on top of the low-level building blocks in `@ontrails/schema`.
 
 ## What it owns
 
-- deterministic trailhead-map generation from an established topo
+- deterministic surface-map generation from an established topo
 - stable hashing for CI drift detection
-- semantic diffing between two trailhead maps
+- semantic diffing between two surface maps
 - file I/O helpers for `.trails/_trailhead.json` and `.trails/trails.lock`
 - OpenAPI generation from the same topo contract
 
@@ -22,15 +22,15 @@ import {
   deriveSurfaceMap,
   deriveSurfaceMapDiff,
   deriveSurfaceMapHash,
-  writeTrailheadLock,
-  writeTrailheadMap,
+  writeSurfaceLock,
+  writeSurfaceMap,
 } from '@ontrails/schema';
 
 const map = deriveSurfaceMap(app);
 const hash = deriveSurfaceMapHash(map);
 
-await writeTrailheadMap(map);
-await writeTrailheadLock({ hash });
+await writeSurfaceMap(map);
+await writeSurfaceLock({ hash });
 
 // Later, after changes:
 const nextMap = deriveSurfaceMap(app);
@@ -58,14 +58,14 @@ The typical exported artifact pair is:
 
 | Export | What it does |
 | --- | --- |
-| `deriveSurfaceMap(topo)` | Deterministic trailhead map of every established trail, signal, and resource |
+| `deriveSurfaceMap(topo)` | Deterministic surface map of every established trail, signal, and resource |
 | `deriveSurfaceMapHash(map)` | Stable SHA-256 hash of the map |
 | `deriveSurfaceMapDiff(prev, curr)` | Semantic diff with `breaking`, `warning`, and `info` classifications |
-| `writeTrailheadMap(map, options?)` | Write `.trails/_trailhead.json` |
-| `readTrailheadMap(options?)` | Read `.trails/_trailhead.json` |
-| `writeTrailheadLock(lock, options?)` | Write `.trails/trails.lock` as either structured JSON or legacy hash text |
-| `readTrailheadLockData(options?)` | Read the full normalized lock payload from `.trails/trails.lock` |
-| `readTrailheadLock(options?)` | Read just the committed lock hash |
+| `writeSurfaceMap(map, options?)` | Write `.trails/_trailhead.json` |
+| `readSurfaceMap(options?)` | Read `.trails/_trailhead.json` |
+| `writeSurfaceLock(lock, options?)` | Write `.trails/trails.lock` as either structured JSON or legacy hash text |
+| `readSurfaceLockData(options?)` | Read the full normalized lock payload from `.trails/trails.lock` |
+| `readSurfaceLock(options?)` | Read just the committed lock hash |
 | `deriveOpenApiSpec(topo, options?)` | Generate an OpenAPI 3.1 document from the topo |
 
 ## Breaking change detection
@@ -94,10 +94,10 @@ Because CLI paths are now full hierarchical command paths, command-tree changes 
 ## Drift detection with warden
 
 ```typescript
-import { deriveSurfaceMap, deriveSurfaceMapHash, readTrailheadLock } from '@ontrails/schema';
+import { deriveSurfaceMap, deriveSurfaceMapHash, readSurfaceLock } from '@ontrails/schema';
 
 const current = deriveSurfaceMapHash(deriveSurfaceMap(app));
-const committed = await readTrailheadLock();
+const committed = await readSurfaceLock();
 
 if (committed !== current) {
   // lock file is stale -- topo has changed

--- a/packages/schema/src/__tests__/derive.test.ts
+++ b/packages/schema/src/__tests__/derive.test.ts
@@ -49,7 +49,7 @@ const getFirstEntry = (map: ReturnType<typeof deriveSurfaceMap>) => {
   const [entry] = map.entries;
   expect(entry).toBeDefined();
   if (!entry) {
-    throw new Error('Expected trailhead map entry');
+    throw new Error('Expected surface map entry');
   }
   return entry;
 };

--- a/packages/schema/src/__tests__/diff.test.ts
+++ b/packages/schema/src/__tests__/diff.test.ts
@@ -1,22 +1,22 @@
 import { describe, test, expect } from 'bun:test';
 
 import { deriveSurfaceMapDiff } from '../diff.js';
-import type { TrailheadMap, TrailheadMapEntry } from '../types.js';
+import type { SurfaceMap, SurfaceMapEntry } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 const entry = (
-  overrides: Partial<TrailheadMapEntry> & { id: string }
-): TrailheadMapEntry => ({
+  overrides: Partial<SurfaceMapEntry> & { id: string }
+): SurfaceMapEntry => ({
   exampleCount: 0,
   kind: 'trail',
   trailheads: [],
   ...overrides,
 });
 
-const trailheadMap = (entries: TrailheadMapEntry[]): TrailheadMap => ({
+const surfaceMap = (entries: SurfaceMapEntry[]): SurfaceMap => ({
   entries,
   generatedAt: new Date().toISOString(),
   version: '1.0',
@@ -30,15 +30,15 @@ describe('deriveSurfaceMapDiff', () => {
   describe('top-level changes', () => {
     test('empty diff for identical maps', () => {
       const e = entry({ id: 'user.create' });
-      const result = deriveSurfaceMapDiff(trailheadMap([e]), trailheadMap([e]));
+      const result = deriveSurfaceMapDiff(surfaceMap([e]), surfaceMap([e]));
 
       expect(result.entries).toHaveLength(0);
       expect(result.hasBreaking).toBe(false);
     });
 
     test('added trail detected as info', () => {
-      const prev = trailheadMap([]);
-      const curr = trailheadMap([entry({ id: 'user.create' })]);
+      const prev = surfaceMap([]);
+      const curr = surfaceMap([entry({ id: 'user.create' })]);
       const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries).toHaveLength(1);
@@ -48,8 +48,8 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('added resource detected as info', () => {
-      const prev = trailheadMap([]);
-      const curr = trailheadMap([entry({ id: 'db.main', kind: 'resource' })]);
+      const prev = surfaceMap([]);
+      const curr = surfaceMap([entry({ id: 'db.main', kind: 'resource' })]);
       const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries[0]?.details).toContain('Resource "db.main" added');
@@ -57,8 +57,8 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('added contour detected as info', () => {
-      const prev = trailheadMap([]);
-      const curr = trailheadMap([entry({ id: 'user', kind: 'contour' })]);
+      const prev = surfaceMap([]);
+      const curr = surfaceMap([entry({ id: 'user', kind: 'contour' })]);
       const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries[0]?.details).toContain('Contour "user" added');
@@ -66,8 +66,8 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('removed trail detected as breaking', () => {
-      const prev = trailheadMap([entry({ id: 'user.delete' })]);
-      const curr = trailheadMap([]);
+      const prev = surfaceMap([entry({ id: 'user.delete' })]);
+      const curr = surfaceMap([]);
       const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries).toHaveLength(1);
@@ -77,8 +77,8 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('removed resource detected as breaking', () => {
-      const prev = trailheadMap([entry({ id: 'db.main', kind: 'resource' })]);
-      const curr = trailheadMap([]);
+      const prev = surfaceMap([entry({ id: 'db.main', kind: 'resource' })]);
+      const curr = surfaceMap([]);
       const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.entries[0]?.details).toContain(
@@ -88,8 +88,8 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('DiffResult.hasBreaking is true when any breaking entries exist', () => {
-      const prev = trailheadMap([entry({ id: 'user.delete' })]);
-      const curr = trailheadMap([]);
+      const prev = surfaceMap([entry({ id: 'user.delete' })]);
+      const curr = surfaceMap([]);
       const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
@@ -99,7 +99,7 @@ describe('deriveSurfaceMapDiff', () => {
 
   describe('schema changes', () => {
     test('required input field added classified as breaking', () => {
-      const prev = trailheadMap([
+      const prev = surfaceMap([
         entry({
           id: 'user.create',
           input: {
@@ -109,7 +109,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const curr = trailheadMap([
+      const curr = surfaceMap([
         entry({
           id: 'user.create',
           input: {
@@ -136,7 +136,7 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('optional input field added classified as info', () => {
-      const prev = trailheadMap([
+      const prev = surfaceMap([
         entry({
           id: 'user.create',
           input: {
@@ -146,7 +146,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const curr = trailheadMap([
+      const curr = surfaceMap([
         entry({
           id: 'user.create',
           input: {
@@ -172,7 +172,7 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('output field removed classified as breaking', () => {
-      const prev = trailheadMap([
+      const prev = surfaceMap([
         entry({
           id: 'user.get',
           output: {
@@ -184,7 +184,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const curr = trailheadMap([
+      const curr = surfaceMap([
         entry({
           id: 'user.get',
           output: {
@@ -206,7 +206,7 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('output field type changed classified as breaking', () => {
-      const prev = trailheadMap([
+      const prev = surfaceMap([
         entry({
           id: 'user.get',
           output: {
@@ -215,7 +215,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const curr = trailheadMap([
+      const curr = surfaceMap([
         entry({
           id: 'user.get',
           output: {
@@ -237,10 +237,10 @@ describe('deriveSurfaceMapDiff', () => {
 
   describe('meta and trailheads', () => {
     test('trailhead removed classified as breaking', () => {
-      const prev = trailheadMap([
+      const prev = surfaceMap([
         entry({ id: 'user.list', trailheads: ['cli', 'mcp'] }),
       ]);
-      const curr = trailheadMap([
+      const curr = surfaceMap([
         entry({ id: 'user.list', trailheads: ['mcp'] }),
       ]);
       const result = deriveSurfaceMapDiff(prev, curr);
@@ -254,10 +254,10 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('CLI path change is classified as breaking', () => {
-      const prev = trailheadMap([
+      const prev = surfaceMap([
         entry({ cli: { path: ['topo', 'pin'] }, id: 'topo.pin' }),
       ]);
-      const curr = trailheadMap([
+      const curr = surfaceMap([
         entry({ cli: { path: ['topo', 'save'] }, id: 'topo.pin' }),
       ]);
       const result = deriveSurfaceMapDiff(prev, curr);
@@ -271,10 +271,8 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('safety marker changed classified as warning', () => {
-      const prev = trailheadMap([entry({ id: 'data.wipe', intent: 'read' })]);
-      const curr = trailheadMap([
-        entry({ id: 'data.wipe', intent: 'destroy' }),
-      ]);
+      const prev = surfaceMap([entry({ id: 'data.wipe', intent: 'read' })]);
+      const curr = surfaceMap([entry({ id: 'data.wipe', intent: 'destroy' })]);
       const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(1);
@@ -284,10 +282,10 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('description change classified as info', () => {
-      const prev = trailheadMap([
+      const prev = surfaceMap([
         entry({ description: 'Get a user', id: 'user.get' }),
       ]);
-      const curr = trailheadMap([
+      const curr = surfaceMap([
         entry({ description: 'Fetch a user by ID', id: 'user.get' }),
       ]);
       const result = deriveSurfaceMapDiff(prev, curr);
@@ -299,8 +297,8 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('deprecation added classified as warning', () => {
-      const prev = trailheadMap([entry({ id: 'entity.list' })]);
-      const curr = trailheadMap([
+      const prev = surfaceMap([entry({ id: 'entity.list' })]);
+      const curr = surfaceMap([
         entry({
           deprecated: true,
           id: 'entity.list',
@@ -318,14 +316,14 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('crosses changed produces warning', () => {
-      const prev = trailheadMap([
+      const prev = surfaceMap([
         entry({
           crosses: ['user.get', 'user.lookup'],
           id: 'user.update',
           kind: 'trail',
         }),
       ]);
-      const curr = trailheadMap([
+      const curr = surfaceMap([
         entry({
           crosses: ['user.get', 'user.search'],
           id: 'user.update',
@@ -344,13 +342,13 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('declared resources changed produces warning', () => {
-      const prev = trailheadMap([
+      const prev = surfaceMap([
         entry({
           id: 'user.update',
           resources: ['db.main', 'search.index'],
         }),
       ]);
-      const curr = trailheadMap([
+      const curr = surfaceMap([
         entry({
           id: 'user.update',
           resources: ['db.main', 'cache.main'],
@@ -370,7 +368,7 @@ describe('deriveSurfaceMapDiff', () => {
 
   describe('severity partitioning', () => {
     test('DiffResult partitions correctly into breaking, warnings, info', () => {
-      const prev = trailheadMap([
+      const prev = surfaceMap([
         entry({
           description: 'old',
           id: 'a.trail',
@@ -381,7 +379,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const curr = trailheadMap([
+      const curr = surfaceMap([
         entry({
           description: 'new',
           id: 'a.trail',

--- a/packages/schema/src/__tests__/hash.test.ts
+++ b/packages/schema/src/__tests__/hash.test.ts
@@ -1,13 +1,13 @@
 import { describe, test, expect } from 'bun:test';
 
 import { deriveSurfaceMapHash } from '../hash.js';
-import type { TrailheadMap } from '../types.js';
+import type { SurfaceMap } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const makeTrailheadMap = (overrides?: Partial<TrailheadMap>): TrailheadMap => ({
+const makeSurfaceMap = (overrides?: Partial<SurfaceMap>): SurfaceMap => ({
   entries: [
     {
       exampleCount: 2,
@@ -37,20 +37,20 @@ const makeTrailheadMap = (overrides?: Partial<TrailheadMap>): TrailheadMap => ({
 
 describe('deriveSurfaceMapHash', () => {
   test('produces a valid SHA-256 hex string (64 characters)', () => {
-    const hash = deriveSurfaceMapHash(makeTrailheadMap());
+    const hash = deriveSurfaceMapHash(makeSurfaceMap());
     expect(hash).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  test('same trailhead map produces the same hash (deterministic)', () => {
-    const map = makeTrailheadMap();
+  test('same surface map produces the same hash (deterministic)', () => {
+    const map = makeSurfaceMap();
     const hash1 = deriveSurfaceMapHash(map);
     const hash2 = deriveSurfaceMapHash(map);
     expect(hash1).toBe(hash2);
   });
 
-  test('different trailhead maps produce different hashes', () => {
-    const map1 = makeTrailheadMap();
-    const map2 = makeTrailheadMap({
+  test('different surface maps produce different hashes', () => {
+    const map1 = makeSurfaceMap();
+    const map2 = makeSurfaceMap({
       entries: [
         {
           exampleCount: 0,
@@ -66,14 +66,14 @@ describe('deriveSurfaceMapHash', () => {
   });
 
   test('generatedAt does not affect the hash', () => {
-    const map1 = makeTrailheadMap({ generatedAt: '2025-01-01T00:00:00.000Z' });
-    const map2 = makeTrailheadMap({ generatedAt: '2099-12-31T23:59:59.999Z' });
+    const map1 = makeSurfaceMap({ generatedAt: '2025-01-01T00:00:00.000Z' });
+    const map2 = makeSurfaceMap({ generatedAt: '2099-12-31T23:59:59.999Z' });
 
     expect(deriveSurfaceMapHash(map1)).toBe(deriveSurfaceMapHash(map2));
   });
 
   test('hash is stable across invocations', () => {
-    const map = makeTrailheadMap();
+    const map = makeSurfaceMap();
     const hashes = Array.from({ length: 10 }, () => deriveSurfaceMapHash(map));
     const unique = new Set(hashes);
     expect(unique.size).toBe(1);
@@ -81,7 +81,7 @@ describe('deriveSurfaceMapHash', () => {
 
   test('key order in entry does not affect hash', () => {
     // Build two maps with same data but different insertion order
-    const map1 = makeTrailheadMap({
+    const map1 = makeSurfaceMap({
       entries: [
         {
           exampleCount: 0,
@@ -95,7 +95,7 @@ describe('deriveSurfaceMapHash', () => {
         },
       ],
     });
-    const map2 = makeTrailheadMap({
+    const map2 = makeSurfaceMap({
       entries: [
         {
           exampleCount: 0,

--- a/packages/schema/src/__tests__/io.test.ts
+++ b/packages/schema/src/__tests__/io.test.ts
@@ -1,22 +1,22 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
-  writeTrailheadMap,
-  readTrailheadMap,
-  writeTrailheadLock,
-  readTrailheadLockData,
-  readTrailheadLock,
+  writeSurfaceMap,
+  readSurfaceMap,
+  writeSurfaceLock,
+  readSurfaceLockData,
+  readSurfaceLock,
 } from '../io.js';
-import type { TrailheadMap } from '../types.js';
+import type { SurfaceMap } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const makeTrailheadMap = (): TrailheadMap => ({
+const makeSurfaceMap = (): SurfaceMap => ({
   entries: [
     {
       description: 'Create a user',
@@ -57,13 +57,13 @@ afterEach(async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Trailhead map tests
+// Surface map tests
 // ---------------------------------------------------------------------------
 
-describe('writeTrailheadMap / readTrailheadMap', () => {
+describe('writeSurfaceMap / readSurfaceMap', () => {
   test('writes valid JSON to _trailhead.json', async () => {
-    const map = makeTrailheadMap();
-    const filePath = await writeTrailheadMap(map, { dir: tempDir });
+    const map = makeSurfaceMap();
+    const filePath = await writeSurfaceMap(map, { dir: tempDir });
 
     expect(filePath).toBe(join(tempDir, '_trailhead.json'));
 
@@ -74,15 +74,15 @@ describe('writeTrailheadMap / readTrailheadMap', () => {
   });
 
   test('reads it back and produces identical data', async () => {
-    const map = makeTrailheadMap();
-    await writeTrailheadMap(map, { dir: tempDir });
-    const result = await readTrailheadMap({ dir: tempDir });
+    const map = makeSurfaceMap();
+    await writeSurfaceMap(map, { dir: tempDir });
+    const result = await readSurfaceMap({ dir: tempDir });
 
     expect(result).toEqual(map);
   });
 
   test('returns null for missing file', async () => {
-    const result = await readTrailheadMap({
+    const result = await readSurfaceMap({
       dir: join(tempDir, 'nonexistent'),
     });
     expect(result).toBeNull();
@@ -93,10 +93,10 @@ describe('writeTrailheadMap / readTrailheadMap', () => {
 // Surface Lock tests
 // ---------------------------------------------------------------------------
 
-describe('writeTrailheadLock / readTrailheadLock', () => {
+describe('writeSurfaceLock / readSurfaceLock', () => {
   test('writes a single line with the hash', async () => {
     const hash = 'abc123def456'.repeat(4);
-    const filePath = await writeTrailheadLock(hash, { dir: tempDir });
+    const filePath = await writeSurfaceLock(hash, { dir: tempDir });
 
     expect(filePath).toBe(join(tempDir, 'trails.lock'));
 
@@ -108,7 +108,7 @@ describe('writeTrailheadLock / readTrailheadLock', () => {
 
   test('writes and reads structured JSON locks', async () => {
     const hash = 'deadbeef'.repeat(8);
-    const filePath = await writeTrailheadLock(makeStructuredLock(hash), {
+    const filePath = await writeSurfaceLock(makeStructuredLock(hash), {
       dir: tempDir,
     });
 
@@ -118,24 +118,16 @@ describe('writeTrailheadLock / readTrailheadLock', () => {
     expect(parsed.hash).toBe(hash);
     expect(parsed.version).toBe(1);
 
-    const result = await readTrailheadLockData({ dir: tempDir });
+    const result = await readSurfaceLockData({ dir: tempDir });
 
     expect(result).toEqual(makeStructuredLock(hash));
 
-    const legacyResult = await readTrailheadLock({ dir: tempDir });
+    const legacyResult = await readSurfaceLock({ dir: tempDir });
     expect(legacyResult).toBe(hash);
   });
 
-  test('falls back to the legacy trailhead.lock name during migration', async () => {
-    const hash = 'legacydeadbeef'.repeat(4);
-    await writeFile(join(tempDir, 'trailhead.lock'), `${hash}\n`);
-
-    const result = await readTrailheadLock({ dir: tempDir });
-    expect(result).toBe(hash);
-  });
-
   test('returns null for missing file', async () => {
-    const result = await readTrailheadLock({
+    const result = await readSurfaceLock({
       dir: join(tempDir, 'nonexistent'),
     });
     expect(result).toBeNull();
@@ -150,24 +142,24 @@ describe('default directory', () => {
   test('defaults to .trails/', async () => {
     // We can't easily test the actual default without polluting the repo,
     // so we verify the custom directory option works and trust the default
-    const map = makeTrailheadMap();
+    const map = makeSurfaceMap();
     const customDir = join(tempDir, 'custom-trails');
-    const filePath = await writeTrailheadMap(map, { dir: customDir });
+    const filePath = await writeSurfaceMap(map, { dir: customDir });
 
     expect(filePath).toBe(join(customDir, '_trailhead.json'));
 
-    const result = await readTrailheadMap({ dir: customDir });
+    const result = await readSurfaceMap({ dir: customDir });
     expect(result).toEqual(map);
   });
 
   test('custom directory option works for lock files', async () => {
     const customDir = join(tempDir, 'custom-lock-dir');
     const hash = 'a1b2c3d4e5f6'.repeat(5);
-    const filePath = await writeTrailheadLock(hash, { dir: customDir });
+    const filePath = await writeSurfaceLock(hash, { dir: customDir });
 
     expect(filePath).toBe(join(customDir, 'trails.lock'));
 
-    const result = await readTrailheadLock({ dir: customDir });
+    const result = await readSurfaceLock({ dir: customDir });
     expect(result).toBe(hash);
   });
 });

--- a/packages/schema/src/derive.ts
+++ b/packages/schema/src/derive.ts
@@ -1,5 +1,5 @@
 /**
- * Derive a deterministic trailhead map from a Topo.
+ * Derive a deterministic surface map from a Topo.
  */
 
 import {
@@ -16,7 +16,7 @@ import type {
   Trail,
 } from '@ontrails/core';
 
-import type { JsonSchema, TrailheadMap, TrailheadMapEntry } from './types.js';
+import type { JsonSchema, SurfaceMap, SurfaceMapEntry } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -144,9 +144,7 @@ const addTrailRelations = (
   }
 };
 
-const trailToEntry = (
-  t: Trail<unknown, unknown, unknown>
-): TrailheadMapEntry => {
+const trailToEntry = (t: Trail<unknown, unknown, unknown>): SurfaceMapEntry => {
   const raw = t as unknown as Record<string, unknown>;
   const trailheads = extractTrailheads(raw);
   const entry: Record<string, unknown> = {
@@ -161,7 +159,7 @@ const trailToEntry = (
   addMetadata(entry, t, raw);
   addTrailRelations(entry, t);
 
-  return sortKeys(entry) as unknown as TrailheadMapEntry;
+  return sortKeys(entry) as unknown as SurfaceMapEntry;
 };
 
 /** Add optional event-specific fields. */
@@ -184,7 +182,7 @@ const addEventFields = (
   }
 };
 
-const signalToEntry = (e: Signal<unknown>): TrailheadMapEntry => {
+const signalToEntry = (e: Signal<unknown>): SurfaceMapEntry => {
   const raw = e as unknown as Record<string, unknown>;
   const trailheads = extractTrailheads(raw);
   const entry: Record<string, unknown> = {
@@ -194,10 +192,10 @@ const signalToEntry = (e: Signal<unknown>): TrailheadMapEntry => {
     trailheads,
   };
   addEventFields(entry, e, raw);
-  return sortKeys(entry) as unknown as TrailheadMapEntry;
+  return sortKeys(entry) as unknown as SurfaceMapEntry;
 };
 
-const resourceToEntry = (resource: AnyResource): TrailheadMapEntry => {
+const resourceToEntry = (resource: AnyResource): SurfaceMapEntry => {
   const entry: Record<string, unknown> = {
     exampleCount: 0,
     id: resource.id,
@@ -212,10 +210,10 @@ const resourceToEntry = (resource: AnyResource): TrailheadMapEntry => {
     entry['healthcheck'] = true;
   }
 
-  return sortKeys(entry) as unknown as TrailheadMapEntry;
+  return sortKeys(entry) as unknown as SurfaceMapEntry;
 };
 
-const contourToEntry = (contour: AnyContour): TrailheadMapEntry => {
+const contourToEntry = (contour: AnyContour): SurfaceMapEntry => {
   const entry: Record<string, unknown> = {
     exampleCount: contour.examples?.length ?? 0,
     id: contour.name,
@@ -231,7 +229,7 @@ const contourToEntry = (contour: AnyContour): TrailheadMapEntry => {
     entry['references'] = references;
   }
 
-  return sortKeys(entry) as unknown as TrailheadMapEntry;
+  return sortKeys(entry) as unknown as SurfaceMapEntry;
 };
 
 const assertEstablishedTopo = (topo: Topo): void => {
@@ -241,7 +239,7 @@ const assertEstablishedTopo = (topo: Topo): void => {
   }
 };
 
-const collectEntries = (topo: Topo): TrailheadMapEntry[] => [
+const collectEntries = (topo: Topo): SurfaceMapEntry[] => [
   ...[...topo.contours.values()].map((contour) => contourToEntry(contour)),
   ...[...topo.trails.values()].map((trail) =>
     trailToEntry(trail as Trail<unknown, unknown, unknown>)
@@ -257,12 +255,12 @@ const collectEntries = (topo: Topo): TrailheadMapEntry[] => [
 // ---------------------------------------------------------------------------
 
 /**
- * Derive a deterministic trailhead map from a Topo.
+ * Derive a deterministic surface map from a Topo.
  *
  * Entries are sorted alphabetically by id. Object keys within each entry
  * are sorted lexicographically for stable serialization.
  */
-export const deriveSurfaceMap = (topo: Topo): TrailheadMap => {
+export const deriveSurfaceMap = (topo: Topo): SurfaceMap => {
   assertEstablishedTopo(topo);
   const sorted = collectEntries(topo).toSorted((a, b) =>
     a.id.localeCompare(b.id)

--- a/packages/schema/src/diff.ts
+++ b/packages/schema/src/diff.ts
@@ -1,13 +1,13 @@
 /**
- * Semantic diffing of trailhead maps.
+ * Semantic diffing of surface maps.
  */
 
 import type {
   DiffEntry,
   DiffResult,
   JsonSchema,
-  TrailheadMap,
-  TrailheadMapEntry,
+  SurfaceMap,
+  SurfaceMapEntry,
 } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -44,7 +44,7 @@ const addDetail = (
 const capitalize = (s: string): string =>
   `${s.charAt(0).toUpperCase()}${s.slice(1)}`;
 
-const labelForKind = (kind: TrailheadMapEntry['kind']): string => {
+const labelForKind = (kind: SurfaceMapEntry['kind']): string => {
   if (kind === 'contour') {
     return 'Contour';
   }
@@ -233,8 +233,8 @@ const diffSchemaFields = (
 /** Diff trailhead additions and removals. */
 const diffTrailheads = (
   acc: DetailAccumulator,
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): void => {
   const prevTrailheads = new Set(prev.trailheads);
   const currTrailheads = new Set(curr.trailheads);
@@ -253,8 +253,8 @@ const diffTrailheads = (
 /** Diff safety markers, description, and deprecation. */
 const diffMetadata = (
   acc: DetailAccumulator,
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): void => {
   if (prev.intent !== curr.intent) {
     addDetail(
@@ -285,8 +285,8 @@ const diffMetadata = (
 
 const diffCliPath = (
   acc: DetailAccumulator,
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): void => {
   const prevPath = prev.cli?.path.join(' ');
   const currPath = curr.cli?.path.join(' ');
@@ -346,8 +346,8 @@ const buildContoursMessage = (added: string[], removed: string[]): string => {
 /** Diff crosses arrays. */
 const diffCrosses = (
   acc: DetailAccumulator,
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): void => {
   const prevCrosses = new Set(prev.crosses);
   const currCrosses = new Set(curr.crosses);
@@ -365,8 +365,8 @@ const diffCrosses = (
 /** Diff declared resource arrays on trail entries. */
 const diffResources = (
   acc: DetailAccumulator,
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): void => {
   const prevResources = new Set(prev.resources);
   const currResources = new Set(curr.resources);
@@ -384,8 +384,8 @@ const diffResources = (
 /** Diff declared contour arrays on trail entries. */
 const diffContours = (
   acc: DetailAccumulator,
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): void => {
   const prevContours = new Set(prev.contours);
   const currContours = new Set(curr.contours);
@@ -402,8 +402,8 @@ const diffContours = (
 
 const diffContourSchema = (
   acc: DetailAccumulator,
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): void => {
   diffSchemaFields(acc, 'contour', prev.schema, curr.schema);
 
@@ -424,8 +424,8 @@ const referenceLabel = (reference: {
 
 const diffContourReferences = (
   acc: DetailAccumulator,
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): void => {
   const prevReferences = new Set(
     (prev.references ?? []).map((reference) => referenceLabel(reference))
@@ -459,8 +459,8 @@ const diffContourReferences = (
 
 const diffTrailEntryDetails = (
   acc: DetailAccumulator,
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): void => {
   diffSchemaFields(acc, 'input', prev.input, curr.input);
   diffSchemaFields(acc, 'output', prev.output, curr.output);
@@ -472,8 +472,8 @@ const diffTrailEntryDetails = (
 
 const diffEntryDetails = (
   acc: DetailAccumulator,
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): void => {
   diffTrailheads(acc, prev, curr);
   diffMetadata(acc, prev, curr);
@@ -488,8 +488,8 @@ const diffEntryDetails = (
 };
 
 const diffEntry = (
-  prev: TrailheadMapEntry,
-  curr: TrailheadMapEntry
+  prev: SurfaceMapEntry,
+  curr: SurfaceMapEntry
 ): DiffEntry | undefined => {
   const acc: DetailAccumulator = { details: [], severity: 'info' };
 
@@ -513,7 +513,7 @@ const diffEntry = (
 // ---------------------------------------------------------------------------
 
 /**
- * Compute a semantic diff between two trailhead maps.
+ * Compute a semantic diff between two surface maps.
  *
  * Classifies each change with a severity:
  * - `info`: new trail, optional field added, output field added, description change
@@ -522,8 +522,8 @@ const diffEntry = (
  */
 /** Find entries added in curr that don't exist in prev. */
 const findAdded = (
-  prevById: Map<string, TrailheadMapEntry>,
-  currById: Map<string, TrailheadMapEntry>
+  prevById: Map<string, SurfaceMapEntry>,
+  currById: Map<string, SurfaceMapEntry>
 ): DiffEntry[] =>
   [...currById.entries()]
     .filter(([id]) => !prevById.has(id))
@@ -537,8 +537,8 @@ const findAdded = (
 
 /** Find entries removed from prev that don't exist in curr. */
 const findRemoved = (
-  prevById: Map<string, TrailheadMapEntry>,
-  currById: Map<string, TrailheadMapEntry>
+  prevById: Map<string, SurfaceMapEntry>,
+  currById: Map<string, SurfaceMapEntry>
 ): DiffEntry[] =>
   [...prevById.entries()]
     .filter(([id]) => !currById.has(id))
@@ -552,8 +552,8 @@ const findRemoved = (
 
 /** Find entries modified between prev and curr. */
 const findModified = (
-  prevById: Map<string, TrailheadMapEntry>,
-  currById: Map<string, TrailheadMapEntry>
+  prevById: Map<string, SurfaceMapEntry>,
+  currById: Map<string, SurfaceMapEntry>
 ): DiffEntry[] => {
   const results: DiffEntry[] = [];
   for (const [id, currEntry] of currById) {
@@ -570,8 +570,8 @@ const findModified = (
 
 /** Collect all diff entries (added, removed, modified) between two maps. */
 const collectDiffEntries = (
-  prevById: Map<string, TrailheadMapEntry>,
-  currById: Map<string, TrailheadMapEntry>
+  prevById: Map<string, SurfaceMapEntry>,
+  currById: Map<string, SurfaceMapEntry>
 ): DiffEntry[] => [
   ...findAdded(prevById, currById),
   ...findRemoved(prevById, currById),
@@ -579,8 +579,8 @@ const collectDiffEntries = (
 ];
 
 export const deriveSurfaceMapDiff = (
-  prev: TrailheadMap,
-  curr: TrailheadMap
+  prev: SurfaceMap,
+  curr: SurfaceMap
 ): DiffResult => {
   const prevById = new Map(prev.entries.map((e) => [e.id, e]));
   const currById = new Map(curr.entries.map((e) => [e.id, e]));

--- a/packages/schema/src/hash.ts
+++ b/packages/schema/src/hash.ts
@@ -1,10 +1,10 @@
 /**
- * SHA-256 hashing for trailhead maps.
+ * SHA-256 hashing for surface maps.
  *
  * Uses Bun.CryptoHasher for native hashing.
  */
 
-import type { TrailheadMap } from './types.js';
+import type { SurfaceMap } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,14 +33,14 @@ const canonicalize = (value: unknown): unknown => {
 // ---------------------------------------------------------------------------
 
 /**
- * Compute a SHA-256 hash of a trailhead map.
+ * Compute a SHA-256 hash of a surface map.
  *
  * The `generatedAt` field is excluded so that identical topos always
  * produce the same hash regardless of when they were generated.
  */
-export const deriveSurfaceMapHash = (trailheadMap: TrailheadMap): string => {
+export const deriveSurfaceMapHash = (surfaceMap: SurfaceMap): string => {
   // Strip generatedAt before hashing
-  const { generatedAt: _unused, ...rest } = trailheadMap;
+  const { generatedAt: _unused, ...rest } = surfaceMap;
 
   const canonical = canonicalize(rest);
   const json = JSON.stringify(canonical);

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -9,22 +9,22 @@ export type { OpenApiOptions, OpenApiSpec, OpenApiServer } from './openapi.js';
 
 // File I/O
 export {
-  writeTrailheadMap,
-  readTrailheadMap,
-  writeTrailheadLock,
-  readTrailheadLockData,
-  readTrailheadLock,
+  writeSurfaceMap,
+  readSurfaceMap,
+  writeSurfaceLock,
+  readSurfaceLockData,
+  readSurfaceLock,
 } from './io.js';
 
 // Types
 export type {
-  TrailheadMap,
-  TrailheadMapEntry,
-  TrailheadLock,
+  SurfaceMap,
+  SurfaceMapEntry,
+  SurfaceLock,
   DiffEntry,
   DiffResult,
   JsonSchema,
-  TrailheadContourReference,
+  SurfaceMapContourReference,
   WriteOptions,
   ReadOptions,
 } from './types.js';

--- a/packages/schema/src/io.ts
+++ b/packages/schema/src/io.ts
@@ -36,19 +36,15 @@ const ensureDir = async (dir: string): Promise<void> => {
   await mkdir(dir, { recursive: true });
 };
 
-const readFirstExistingText = async (
-  filePaths: readonly string[]
-): Promise<string | null> => {
-  for (const filePath of filePaths) {
-    try {
-      return await Bun.file(filePath).text();
-    } catch (error: unknown) {
-      if (!isNotFound(error)) {
-        throw error;
-      }
+const readTextIfExists = async (filePath: string): Promise<string | null> => {
+  try {
+    return await Bun.file(filePath).text();
+  } catch (error: unknown) {
+    if (!isNotFound(error)) {
+      throw error;
     }
+    return null;
   }
-  return null;
 };
 
 const isSurfaceLock = (value: unknown): value is SurfaceLock => {
@@ -104,7 +100,7 @@ export const readSurfaceMap = async (
   options?: ReadOptions
 ): Promise<SurfaceMap | null> => {
   const dir = resolveDir(options);
-  const content = await readFirstExistingText([join(dir, SURFACE_MAP_FILE)]);
+  const content = await readTextIfExists(join(dir, SURFACE_MAP_FILE));
   return content ? (JSON.parse(content) as SurfaceMap) : null;
 };
 
@@ -145,7 +141,7 @@ export const readSurfaceLockData = async (
   options?: ReadOptions
 ): Promise<SurfaceLock | null> => {
   const dir = resolveDir(options);
-  const content = await readFirstExistingText([join(dir, SURFACE_LOCK_FILE)]);
+  const content = await readTextIfExists(join(dir, SURFACE_LOCK_FILE));
   return content ? parseSurfaceLock(content) : null;
 };
 

--- a/packages/schema/src/io.ts
+++ b/packages/schema/src/io.ts
@@ -1,5 +1,5 @@
 /**
- * File I/O for trailhead maps and lock files.
+ * File I/O for surface maps and lock files.
  */
 
 import { mkdir } from 'node:fs/promises';
@@ -7,8 +7,8 @@ import { join } from 'node:path';
 
 import type {
   ReadOptions,
-  TrailheadLock,
-  TrailheadMap,
+  SurfaceLock,
+  SurfaceMap,
   WriteOptions,
 } from './types.js';
 
@@ -17,9 +17,8 @@ import type {
 // ---------------------------------------------------------------------------
 
 const DEFAULT_DIR = '.trails';
-const TRAILHEAD_MAP_FILE = '_trailhead.json';
-const TRAILHEAD_LOCK_FILE = 'trails.lock';
-const LEGACY_TRAILHEAD_LOCK_FILE = 'trailhead.lock';
+const SURFACE_MAP_FILE = '_trailhead.json';
+const SURFACE_LOCK_FILE = 'trails.lock';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -52,7 +51,7 @@ const readFirstExistingText = async (
   return null;
 };
 
-const isTrailheadLock = (value: unknown): value is TrailheadLock => {
+const isSurfaceLock = (value: unknown): value is SurfaceLock => {
   const lock = value as Record<string, unknown>;
   return (
     typeof value === 'object' &&
@@ -61,10 +60,10 @@ const isTrailheadLock = (value: unknown): value is TrailheadLock => {
   );
 };
 
-const parseTrailheadLock = (content: string): TrailheadLock => {
+const parseSurfaceLock = (content: string): SurfaceLock => {
   try {
     const parsed: unknown = JSON.parse(content);
-    if (isTrailheadLock(parsed)) {
+    if (isSurfaceLock(parsed)) {
       return parsed;
     }
     if (typeof parsed === 'string') {
@@ -78,39 +77,39 @@ const parseTrailheadLock = (content: string): TrailheadLock => {
 };
 
 // ---------------------------------------------------------------------------
-// Trailhead Map
+// Surface Map
 // ---------------------------------------------------------------------------
 
 /**
- * Write a trailhead map to `<dir>/_trailhead.json`.
+ * Write a surface map to `<dir>/_trailhead.json`.
  *
  * Creates the directory if it doesn't exist. Returns the file path.
  */
-export const writeTrailheadMap = async (
-  trailheadMap: TrailheadMap,
+export const writeSurfaceMap = async (
+  surfaceMap: SurfaceMap,
   options?: WriteOptions
 ): Promise<string> => {
   const dir = resolveDir(options);
   await ensureDir(dir);
-  const filePath = join(dir, TRAILHEAD_MAP_FILE);
-  const json = `${JSON.stringify(trailheadMap, null, 2)}\n`;
+  const filePath = join(dir, SURFACE_MAP_FILE);
+  const json = `${JSON.stringify(surfaceMap, null, 2)}\n`;
   await Bun.write(filePath, json);
   return filePath;
 };
 
 /**
- * Read a trailhead map from `<dir>/_trailhead.json`.
+ * Read a surface map from `<dir>/_trailhead.json`.
  */
-export const readTrailheadMap = async (
+export const readSurfaceMap = async (
   options?: ReadOptions
-): Promise<TrailheadMap | null> => {
+): Promise<SurfaceMap | null> => {
   const dir = resolveDir(options);
-  const content = await readFirstExistingText([join(dir, TRAILHEAD_MAP_FILE)]);
-  return content ? (JSON.parse(content) as TrailheadMap) : null;
+  const content = await readFirstExistingText([join(dir, SURFACE_MAP_FILE)]);
+  return content ? (JSON.parse(content) as SurfaceMap) : null;
 };
 
 // ---------------------------------------------------------------------------
-// Trailhead Lock
+// Surface Lock
 // ---------------------------------------------------------------------------
 
 /**
@@ -119,13 +118,13 @@ export const readTrailheadMap = async (
  * String input preserves the legacy single-line hash format. Structured input
  * is serialized as JSON. Creates the directory if it doesn't exist.
  */
-export const writeTrailheadLock = async (
-  lock: string | TrailheadLock,
+export const writeSurfaceLock = async (
+  lock: string | SurfaceLock,
   options?: WriteOptions
 ): Promise<string> => {
   const dir = resolveDir(options);
   await ensureDir(dir);
-  const filePath = join(dir, TRAILHEAD_LOCK_FILE);
+  const filePath = join(dir, SURFACE_LOCK_FILE);
 
   if (typeof lock === 'string') {
     await Bun.write(filePath, `${lock}\n`);
@@ -137,30 +136,25 @@ export const writeTrailheadLock = async (
 };
 
 /**
- * Read the committed lock from `<dir>/trails.lock`, falling back to the
- * legacy `<dir>/trailhead.lock` during migration.
+ * Read the committed lock from `<dir>/trails.lock`.
  *
  * Structured JSON locks are normalized to expose their committed hash while
  * preserving additional metadata.
  */
-export const readTrailheadLockData = async (
+export const readSurfaceLockData = async (
   options?: ReadOptions
-): Promise<TrailheadLock | null> => {
+): Promise<SurfaceLock | null> => {
   const dir = resolveDir(options);
-  const content = await readFirstExistingText([
-    join(dir, TRAILHEAD_LOCK_FILE),
-    join(dir, LEGACY_TRAILHEAD_LOCK_FILE),
-  ]);
-  return content ? parseTrailheadLock(content) : null;
+  const content = await readFirstExistingText([join(dir, SURFACE_LOCK_FILE)]);
+  return content ? parseSurfaceLock(content) : null;
 };
 
 /**
- * Read the committed lock hash from `<dir>/trails.lock`, falling back to the
- * legacy `<dir>/trailhead.lock` during migration.
+ * Read the committed lock hash from `<dir>/trails.lock`.
  */
-export const readTrailheadLock = async (
+export const readSurfaceLock = async (
   options?: ReadOptions
 ): Promise<string | null> => {
-  const lock = await readTrailheadLockData(options);
+  const lock = await readSurfaceLockData(options);
   return lock?.hash ?? null;
 };

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Types for trailhead maps, diffing, and lock files.
+ * Types for surface maps, diffing, and lock files.
  */
 
 // ---------------------------------------------------------------------------
@@ -9,17 +9,17 @@
 /** A JSON Schema object produced by zodToJsonSchema. */
 export type JsonSchema = Readonly<Record<string, unknown>>;
 
-export interface TrailheadContourReference {
+export interface SurfaceMapContourReference {
   readonly contour: string;
   readonly field: string;
   readonly identity: string;
 }
 
 // ---------------------------------------------------------------------------
-// Trailhead Map
+// Surface Map
 // ---------------------------------------------------------------------------
 
-export interface TrailheadMapEntry {
+export interface SurfaceMapEntry {
   readonly id: string;
   readonly kind: 'contour' | 'trail' | 'signal' | 'resource';
   readonly trailheads: readonly string[];
@@ -38,7 +38,7 @@ export interface TrailheadMapEntry {
   readonly contours?: readonly string[] | undefined;
   readonly schema?: JsonSchema | undefined;
   readonly identity?: string | undefined;
-  readonly references?: readonly TrailheadContourReference[] | undefined;
+  readonly references?: readonly SurfaceMapContourReference[] | undefined;
   readonly resources?: readonly string[] | undefined;
   readonly detours?:
     | readonly { readonly on: string; readonly maxAttempts: number }[]
@@ -48,14 +48,14 @@ export interface TrailheadMapEntry {
   readonly description?: string | undefined;
 }
 
-export interface TrailheadMap {
+export interface SurfaceMap {
   readonly version: string;
   readonly generatedAt: string;
-  readonly entries: readonly TrailheadMapEntry[];
+  readonly entries: readonly SurfaceMapEntry[];
 }
 
 // ---------------------------------------------------------------------------
-// Trailhead Lock
+// Surface Lock
 // ---------------------------------------------------------------------------
 
 /**
@@ -65,7 +65,7 @@ export interface TrailheadMap {
  * The normalized shape always exposes the committed hash and preserves any
  * extra structured metadata.
  */
-export type TrailheadLock = Readonly<Record<string, unknown>> & {
+export type SurfaceLock = Readonly<Record<string, unknown>> & {
   readonly hash: string;
 };
 

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -12,7 +12,7 @@ import {
 import {
   deriveSurfaceMapHash,
   deriveSurfaceMap,
-  writeTrailheadLock,
+  writeSurfaceLock,
 } from '@ontrails/schema';
 import { z } from 'zod';
 
@@ -92,7 +92,7 @@ describe('checkDrift', () => {
     try {
       const tp = makeTopo();
       const hash = deriveSurfaceMapHash(deriveSurfaceMap(tp));
-      await writeTrailheadLock(
+      await writeSurfaceLock(
         { hash, version: 1 },
         { dir: committedLockDir(dir) }
       );
@@ -110,7 +110,7 @@ describe('checkDrift', () => {
     const dir = createTempDir();
     try {
       writeFileSync(
-        join(committedLockDir(dir), 'trailhead.lock'),
+        join(committedLockDir(dir), 'trails.lock'),
         'outdated-hash\n'
       );
 

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -2,7 +2,7 @@
  * Topo lock drift detection.
  *
  * Compares the committed `trails.lock` hash against a freshly generated
- * trailhead map hash to detect when the trail topology has changed without
+ * surface map hash to detect when the trail topology has changed without
  * updating the lock file. The committed lock may be structured JSON or the
  * legacy single-line hash format.
  */
@@ -19,7 +19,7 @@ import { deriveTrailsDir } from '@ontrails/core/internal/trails-db';
 import {
   deriveSurfaceMap,
   deriveSurfaceMapHash,
-  readTrailheadLockData,
+  readSurfaceLockData,
 } from '@ontrails/schema';
 
 /**
@@ -49,7 +49,7 @@ export const checkDrift = async (
     const trailsDir = deriveTrailsDir({ rootDir });
     const committedLock =
       existsSync(rootDir) && statSync(rootDir).isDirectory()
-        ? await readTrailheadLockData({ dir: trailsDir })
+        ? await readSurfaceLockData({ dir: trailsDir })
         : null;
     // Prefer the stored hash (computed by the export pipeline) to avoid
     // divergence between the schema and store hash pipelines.


### PR DESCRIPTION
## Summary

Complete the `TrailheadMap` → `SurfaceMap` vocabulary cutover in `@ontrails/schema` by deleting all backwards-compat aliases — not just renaming the canonical names. Also remove the legacy `trailhead.lock` fallback to uphold the clean-cutover directive (no backwards compatibility pre-v1.0).

- Delete type aliases: `TrailheadContourReference`, `TrailheadMapEntry`, `TrailheadMap`, `TrailheadLock`
- Delete function aliases: `writeTrailheadMap`, `readTrailheadMap`, `writeTrailheadLock`, `readTrailheadLockData`, `readTrailheadLock`
- Remove old names from schema public re-exports
- Remove legacy-names paragraph from `packages/schema/README.md`
- Update `docs/api-reference.md` schema table to reflect deletions
- Delete `LEGACY_TRAILHEAD_LOCK_FILE` constant + fallback path in `readSurfaceLockData`; clean related TSDoc and test

## Test plan

- [x] `bun run typecheck` — 30/30
- [x] `bun run test` — schema 90/90
- [x] `rg '\bTrailheadMap\b|\bTrailheadLock\b|\bwriteTrailheadMap\b' packages/schema/ connectors/ apps/` → empty

## Closes

https://linear.app/outfitter/issue/TRL-305