### PR TITLE
feat: add vite runtime adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,13 @@
         "zod": "catalog:",
       },
     },
+    "connectors/vite": {
+      "name": "@ontrails/vite",
+      "version": "1.0.0-beta.14",
+      "devDependencies": {
+        "zod": "catalog:",
+      },
+    },
     "packages/cli": {
       "name": "@ontrails/cli",
       "version": "1.0.0-beta.14",
@@ -334,6 +341,8 @@
     "@ontrails/tracing": ["@ontrails/tracing@workspace:packages/tracing"],
 
     "@ontrails/trails": ["@ontrails/trails@workspace:apps/trails"],
+
+    "@ontrails/vite": ["@ontrails/vite@workspace:connectors/vite"],
 
     "@ontrails/warden": ["@ontrails/warden@workspace:packages/warden"],
 

--- a/connectors/vite/README.md
+++ b/connectors/vite/README.md
@@ -1,0 +1,24 @@
+# `@ontrails/vite`
+
+Bridge a fetch-based Trails HTTP surface into Vite's dev-server middleware stack.
+
+```ts
+import { createApp } from '@ontrails/hono';
+import { vite } from '@ontrails/vite';
+import { defineConfig } from 'vite';
+
+import { graph } from './src/app';
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'trails-surface',
+      configureServer(server) {
+        server.middlewares.use('/api', vite(createApp(graph)));
+      },
+    },
+  ],
+});
+```
+
+Mount the middleware under the path segment you want Vite to delegate to Trails.

--- a/connectors/vite/package.json
+++ b/connectors/vite/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@ontrails/vite",
+  "version": "1.0.0-beta.14",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "devDependencies": {
+    "zod": "catalog:"
+  }
+}

--- a/connectors/vite/src/__tests__/surface.test.ts
+++ b/connectors/vite/src/__tests__/surface.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { createApp } from '../../../../connectors/hono/src/index.ts';
+import { Result, trail, topo } from '../../../../packages/core/src/index.ts';
+import { z } from 'zod';
+
+import { vite } from '../index.js';
+import type { ViteMiddleware } from '../index.js';
+
+const echoTrail = trail('echo', {
+  blaze: (input) => Result.ok({ reply: input.message }),
+  input: z.object({ message: z.string() }),
+  intent: 'read',
+  output: z.object({ reply: z.string() }),
+});
+
+const submitTrail = trail('submit', {
+  blaze: (input) => Result.ok({ accepted: input.message }),
+  input: z.object({ message: z.string() }),
+  output: z.object({ accepted: z.string() }),
+});
+
+const graph = topo('vite-adapter', { echoTrail, submitTrail });
+
+const handleMiddleware = async (
+  middleware: ViteMiddleware,
+  req: IncomingMessage,
+  res: ServerResponse
+): Promise<void> => {
+  const completion = Promise.withResolvers<undefined>();
+
+  // oxlint-disable-next-line promise/prefer-await-to-callbacks -- Connect middleware completes through next(error?)
+  middleware(req, res, (error) => {
+    if (error !== undefined) {
+      completion.reject(error);
+      return;
+    }
+
+    completion.resolve();
+  });
+
+  try {
+    await completion.promise;
+  } catch (error) {
+    res.statusCode = 500;
+    res.end(error instanceof Error ? error.message : String(error));
+  }
+};
+
+const startServer = async (
+  middleware: ViteMiddleware
+): Promise<{ readonly close: () => Promise<void>; readonly url: string }> => {
+  const server = createServer(async (req, res) => {
+    try {
+      await handleMiddleware(middleware, req, res);
+    } catch (error: unknown) {
+      res.statusCode = 500;
+      res.end(error instanceof Error ? error.message : String(error));
+    }
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Expected an ephemeral TCP address for the test server');
+  }
+
+  return {
+    close: async () => {
+      server.close();
+      await once(server, 'close');
+    },
+    url: `http://127.0.0.1:${(address as AddressInfo).port}`,
+  };
+};
+
+describe('Vite runtime adapter', () => {
+  test('vite(createApp(graph)) serves read trails through query params', async () => {
+    const handle = await startServer(vite(createApp(graph)));
+
+    try {
+      const response = await fetch(new URL('/echo?message=hello', handle.url));
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ data: { reply: 'hello' } });
+    } finally {
+      await handle.close();
+    }
+  });
+
+  test('forwards JSON request bodies to write trails', async () => {
+    const handle = await startServer(vite(createApp(graph)));
+
+    try {
+      const response = await fetch(new URL('/submit', handle.url), {
+        body: JSON.stringify({ message: 'saved' }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        data: { accepted: 'saved' },
+      });
+    } finally {
+      await handle.close();
+    }
+  });
+});

--- a/connectors/vite/src/__tests__/surface.test.ts
+++ b/connectors/vite/src/__tests__/surface.test.ts
@@ -34,7 +34,7 @@ const handleMiddleware = async (
   const completion = Promise.withResolvers<undefined>();
 
   // oxlint-disable-next-line promise/prefer-await-to-callbacks -- Connect middleware completes through next(error?)
-  middleware(req, res, (error) => {
+  const middlewarePromise = middleware(req, res, (error) => {
     if (error !== undefined) {
       completion.reject(error);
       return;
@@ -44,7 +44,7 @@ const handleMiddleware = async (
   });
 
   try {
-    await completion.promise;
+    await Promise.race([middlewarePromise, completion.promise]);
   } catch (error) {
     res.statusCode = 500;
     res.end(error instanceof Error ? error.message : String(error));

--- a/connectors/vite/src/index.ts
+++ b/connectors/vite/src/index.ts
@@ -1,0 +1,145 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+import { finished } from 'node:stream/promises';
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
+
+export interface FetchSurface {
+  fetch(request: Request): Response | Promise<Response>;
+}
+
+export type ViteMiddlewareNext = (error?: unknown) => void;
+
+export type ViteMiddleware = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: ViteMiddlewareNext
+) => void | Promise<void>;
+
+type CookieReadableHeaders = Headers & {
+  readonly getAll?: (name: string) => string[];
+  readonly getSetCookie?: () => string[];
+};
+
+const BODYLESS_METHODS = new Set(['GET', 'HEAD']);
+
+const appendHeader = (
+  headers: Headers,
+  name: string,
+  value: string | readonly string[]
+): void => {
+  if (typeof value === 'string') {
+    headers.append(name, value);
+    return;
+  }
+
+  for (const item of value) {
+    headers.append(name, item);
+  }
+};
+
+const toRequestHeaders = (req: IncomingMessage): Headers => {
+  const headers = new Headers();
+
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    appendHeader(headers, name, value);
+  }
+
+  return headers;
+};
+
+const toRequestInit = (
+  req: IncomingMessage
+): RequestInit & { duplex?: 'half' } => {
+  const method = req.method ?? 'GET';
+  const headers = toRequestHeaders(req);
+
+  if (BODYLESS_METHODS.has(method)) {
+    return { headers, method };
+  }
+
+  return {
+    body: Readable.toWeb(req) as unknown as BodyInit,
+    duplex: 'half',
+    headers,
+    method,
+  };
+};
+
+const toRequest = (req: IncomingMessage): Request => {
+  const host = req.headers.host ?? 'localhost';
+  const url = new URL(req.url ?? '/', `http://${host}`);
+  return new Request(url, toRequestInit(req));
+};
+
+const readSetCookieHeaders = (headers: Headers): readonly string[] => {
+  const cookieHeaders = headers as CookieReadableHeaders;
+  if (typeof cookieHeaders.getSetCookie === 'function') {
+    return cookieHeaders.getSetCookie();
+  }
+  if (typeof cookieHeaders.getAll === 'function') {
+    return cookieHeaders.getAll('set-cookie');
+  }
+
+  const value = headers.get('set-cookie');
+  return value === null ? [] : [value];
+};
+
+const writeHeaders = (response: Response, res: ServerResponse): void => {
+  const setCookie = readSetCookieHeaders(response.headers);
+  if (setCookie.length > 0) {
+    res.setHeader('set-cookie', [...setCookie]);
+  }
+
+  for (const [name, value] of response.headers) {
+    if (name.toLowerCase() === 'set-cookie') {
+      continue;
+    }
+    res.setHeader(name, value);
+  }
+};
+
+const writeResponse = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+  response: Response
+): Promise<void> => {
+  res.statusCode = response.status;
+  if (response.statusText.length > 0) {
+    res.statusMessage = response.statusText;
+  }
+  writeHeaders(response, res);
+
+  if (req.method === 'HEAD' || response.body === null) {
+    res.end();
+    return;
+  }
+
+  const body = Readable.fromWeb(
+    response.body as unknown as NodeReadableStream<Uint8Array>
+  );
+  body.pipe(res);
+  await finished(res);
+};
+
+/**
+ * Convert a fetch-based HTTP surface into Vite/Connect middleware.
+ *
+ * Mount it under the path segment that should resolve through Trails:
+ *
+ * `server.middlewares.use('/api', vite(createApp(graph)))`
+ */
+export const vite =
+  (app: FetchSurface): ViteMiddleware =>
+  async (req, res, next) => {
+    try {
+      const response = await app.fetch(toRequest(req));
+      await writeResponse(req, res, response);
+    } catch (error: unknown) {
+      // oxlint-disable-next-line promise/prefer-await-to-callbacks -- Connect middleware reports errors through next(error)
+      next(error);
+    }
+  };

--- a/connectors/vite/src/index.ts
+++ b/connectors/vite/src/index.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
-import { finished } from 'node:stream/promises';
+import { pipeline } from 'node:stream/promises';
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 
 export interface FetchSurface {
@@ -121,8 +121,7 @@ const writeResponse = async (
   const body = Readable.fromWeb(
     response.body as unknown as NodeReadableStream<Uint8Array>
   );
-  body.pipe(res);
-  await finished(res);
+  await pipeline(body, res);
 };
 
 /**

--- a/connectors/vite/tsconfig.json
+++ b/connectors/vite/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
## Summary

Introduces the `@ontrails/vite` runtime adapter that turns any `FetchSurface` into Connect/Vite middleware, so consumers can mount `vite(createApp(graph))` under a Vite dev server without creating a parallel HTTP projection (per ADR-0035).

Also renames the `vite()` parameter from `surface` → `app` so the call site reads cleanly and the parameter name no longer shadows the `surface()` verb.

## Test plan

- [x] `bun run typecheck` — 31/31
- [x] `bun test connectors/vite` — 2/2 pass
- [x] `rg '\(surface: FetchSurface\)' connectors/vite/` → empty

## Closes

Progress on https://linear.app/outfitter/issue/TRL-327 (vite parameter rename)