### PR TITLE
docs: align doctrine with surface vocabulary

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -231,7 +231,7 @@ assertErrorMatch(result, errorClass)
 // Factories
 createTestContext(options?), createTestLogger()
 createCrossContext(options?)       // minimal context for testing trail composition via ctx.cross()
-createCliHarness(topo, options?), createMcpHarness(topo, options?)
+createCliHarness(options: { app: Topo }), createMcpHarness(options: { app: Topo })
 
 TestExecutionOptions, TestCrossOptions
 TestScenario, CrossScenario, TestLogger, TestTrailContextOptions

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # Trails API Reference
 
-Canonical public trailhead-facing reference. For naming conventions and decision history, see [ADR-0001](./adr/0001-naming-conventions.md).
+Canonical public surface-facing reference. For naming conventions and decision history, see [ADR-0001](./adr/0001-naming-conventions.md).
 
 ---
 
@@ -43,7 +43,7 @@ ErrorCategory, isTrailsError(value?), isRetryable(error)
 // Implementation & context
 Implementation<I, O>              // (input, ctx) => Result | Promise<Result>
 TrailContext, createTrailContext(overrides?)
-CrossFn, ResourceLookup, ProgressCallback, ProgressEvent, Logger, Trailhead
+CrossFn, ResourceLookup, ProgressCallback, ProgressEvent, Logger
 
 // Execution pipeline
 executeTrail(trail, rawInput, options?) // validate → resolve context → resolve resources → compose layers → run
@@ -370,7 +370,7 @@ ConsoleSinkOptions, FileSinkOptions, PrettyFormatterOptions
 | Name | Intent |
 | --- | --- |
 | `trailblaze(topo, options?)` | Full hosted runtime |
-| `trailhead` | Static entry point / discovery |
+| `trailhead` | Conceptual boundary where a graph becomes reachable (reserved noun) |
 | `scout` | Agent-side runtime discovery |
 | `validateExample`, `validateCross` | Contract verification family |
 | `generateDocs`, `generateOpenApi`, `generateLlmsTxt` | Build-time doc generation |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,13 +41,13 @@ The left side is where the world calls in -- CLI commands, MCP tool calls, HTTP 
 
 ## Core Principles
 
-**The trail is the product, not the trailhead.** A trail is a typed function with a Zod schema, error taxonomy, examples, and metadata. CLI commands, MCP tools, and HTTP endpoints are projections of that trail onto trailheads.
+**The trail is the product, not the surface.** A trail is a typed function with a Zod schema, error taxonomy, examples, and metadata. CLI commands, MCP tools, and HTTP endpoints are projections of that trail onto surfaces.
 
-**Drift is structurally harder than alignment.** One schema, one `Result` type, one error taxonomy. You cannot have different parameter names across trailheads because there is only one schema.
+**Drift is structurally harder than alignment.** One schema, one `Result` type, one error taxonomy. You cannot have different parameter names across surfaces because there is only one schema.
 
-**Trailheads are peers.** No trailhead is privileged. CLI, MCP, HTTP, and WebSocket are all equal connectors reading from the same topo. Adding a trailhead is a `surface()` call, not an architecture change.
+**Surfaces are peers.** No surface is privileged. CLI, MCP, HTTP, and WebSocket are all equal connectors reading from the same topo. Adding a surface is a `surface()` call, not an architecture change.
 
-**Implementations are pure functions.** Input in, `Result` out. No `process.exit()`, no `console.log()`, no `req.headers`. The implementation does not know which trailhead invoked it. Authoring can be sync or async; runtime execution is normalized to one awaitable shape before layers and trailheads run.
+**Implementations are pure functions.** Input in, `Result` out. No `process.exit()`, no `console.log()`, no `req.headers`. The implementation does not know which surface invoked it. Authoring can be sync or async; runtime execution is normalized to one awaitable shape before layers and surfaces run.
 
 **The framework defines ports -- everything concrete is a connector.** CLI framework (Commander, yargs), logging backend (LogTape, pino), storage engine, telemetry exporter -- all pluggable. The framework never imports a concrete implementation.
 
@@ -93,7 +93,7 @@ These are boundaries the compiler enforces on the implementation at development 
 | `Result<T, Error>` | Implementation cannot throw — must return `Result.ok()` or `Result.err()` |
 | `TrailContext` interface | Implementation receives only the fields the framework provides |
 | `crosses: [...]` on trails | Declares the composition graph; trail objects give typed `ctx.cross()` — warden verifies calls match |
-| `crossInput: z.object({...})` | Composition-only input merged for `ctx.cross()`, invisible to public trailheads |
+| `crossInput: z.object({...})` | Composition-only input merged for `ctx.cross()`, invisible to public surfaces |
 | `resources: [...]` on trails | Declares infrastructure dependencies; warden verifies `resource.from(ctx)` / `ctx.resource()` usage match |
 
 ### Inferred — detected by static analysis, best-effort
@@ -104,9 +104,9 @@ These are derived from the implementation code itself. Useful for governance and
 | ---------------------------- | ------------------------------------------ |
 | Which trails a trail crosses | `ctx.cross()` calls in the implementation |
 | Error types returned | `Result.err(new XError(...))` patterns |
-| Trailhead map entries and lock metadata | All of the above, canonicalized |
+| Surface map entries and lock metadata | All of the above, canonicalized |
 
-Warden uses inference to verify that declarations match actual code. The trailhead map captures inferred information for CI governance.
+Warden uses inference to verify that declarations match actual code. The surface map captures inferred information for CI governance.
 
 ### Observed — learned from runtime
 
@@ -123,7 +123,7 @@ Any derived value can be overridden when the default is wrong for your case:
 | Flag name or description | Zod field name doesn't make a good flag |
 | `crosses` list | Lock the composition boundary tighter than the code implies |
 
-Overrides are escape hatches. They're visible in the trailhead map as explicit deviations from derivation. They should be rare — if you're overriding everything, the derivation rules are wrong.
+Overrides are escape hatches. They're visible in the surface map as explicit deviations from derivation. They should be rare — if you're overriding everything, the derivation rules are wrong.
 
 **The design heuristic:** when evaluating any new feature, ask "does this require the developer to author information the framework already has?" If yes, derive it. If it genuinely can't be derived, it earns a place on the trail spec. If it can be derived but might be wrong sometimes, derive it with an override.
 
@@ -135,9 +135,9 @@ Overrides are escape hatches. They're visible in the trailhead map as explicit d
 
 `@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, `trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, layers, and connector port interfaces.
 
-**The test:** if you are building a trailhead connector or ecosystem package, you should only need `@ontrails/core`.
+**The test:** if you are building a surface connector or ecosystem package, you should only need `@ontrails/core`.
 
-### Trailhead Connectors (left side)
+### Surface Connectors (left side)
 
 | Package | What it does | External dep |
 | --- | --- | --- |
@@ -146,6 +146,7 @@ Overrides are escape hatches. They're visible in the trailhead map as explicit d
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `surface()` | `@modelcontextprotocol/sdk` |
 | `@ontrails/http` | HTTP routes and error mapping | None beyond core |
 | `@ontrails/hono` | Hono connector, `surface()` | `hono` |
+| `@ontrails/vite` | Vite dev server integration, `surface()` | `vite` |
 
 ### Infrastructure Connectors (right side)
 
@@ -163,8 +164,8 @@ Overrides are escape hatches. They're visible in the trailhead map as explicit d
 
 | Package | What it does |
 | --- | --- |
-| `@ontrails/testing` | `testAll()`, `testExamples()`, `testTrail()`, contract testing, trailhead harnesses |
-| `@ontrails/schema` | Trailhead maps, semantic diffing, OpenAPI generation, lock helpers |
+| `@ontrails/testing` | `testAll()`, `testExamples()`, `testTrail()`, contract testing, surface harnesses |
+| `@ontrails/schema` | Surface maps, semantic diffing, OpenAPI generation, lock helpers |
 | `@ontrails/warden` | Lint rules, drift detection, CI gating |
 
 ### Apps
@@ -193,13 +194,14 @@ Overrides are escape hatches. They're visible in the trailhead map as explicit d
      ^
 @ontrails/cli/commander (cli, commander)
 @ontrails/hono (http, hono)
+@ontrails/vite (http, vite)
 @ontrails/logtape (logging)
 @ontrails/warden (core, schema)
      ^
 apps/trails (cli/commander, schema, tracing)
 ```
 
-Clean DAG. Core at the center. No cycles. Trailhead connectors depend only on core. Framework connectors depend on their parent package.
+Clean DAG. Core at the center. No cycles. Surface connectors depend only on core. Framework connectors depend on their parent package.
 
 ## Data Flow
 
@@ -249,7 +251,7 @@ The implementation is identical. Only the edges change.
 
 ### Headless Execution via `run()`
 
-`run()` is the headless path -- no trailhead connector needed:
+`run()` is the headless path -- no surface connector needed:
 
 ```text
 run(topo, 'entity.show', { name: 'Alpha' }, options?)
@@ -258,11 +260,11 @@ run(topo, 'entity.show', { name: 'Alpha' }, options?)
   -> Result returned, never throws
 ```
 
-This is useful for server-side composition, background workers, and test harnesses that need to invoke trails by ID without wiring a trailhead.
+This is useful for server-side composition, background workers, and test harnesses that need to invoke trails by ID without opening a surface.
 
 ### The Shared `executeTrail()` Pipeline
 
-All trailheads -- CLI, MCP, HTTP, and `run()` -- delegate to the same `executeTrail()` function in `@ontrails/core`:
+All surfaces -- CLI, MCP, HTTP, and `run()` -- delegate to the same `executeTrail()` function in `@ontrails/core`:
 
 ```text
 executeTrail(trail, rawInput, options?)
@@ -274,7 +276,7 @@ executeTrail(trail, rawInput, options?)
   -> Result returned
 ```
 
-This guarantees consistent validation, layer ordering, and error handling regardless of which trailhead initiated the call.
+This guarantees consistent validation, layer ordering, and error handling regardless of which surface initiated the call.
 
 ## Error Taxonomy
 
@@ -297,8 +299,8 @@ All extend `TrailsError` (direct class inheritance). Pattern matching uses `inst
 
 ## Runtime Strategy
 
-**Trails is Bun-native. Trailheads are universally consumable.**
+**Trails is Bun-native. Surfaces are universally consumable.**
 
 All packages use Bun APIs where they improve the developer experience: `Bun.file()` for I/O, `Bun.Glob` for discovery, `Bun.randomUUIDv7()` for IDs, `Bun.CryptoHasher` for hashing, `bun:sqlite` for storage.
 
-The trailheads Trails produces (CLI commands, MCP tools, HTTP endpoints) are protocol-based. Consumers interact via standard protocols -- they don't need Bun. A Node project can add Trails by installing Bun alongside Node. Bun runs Node code, so everything coexists.
+The surfaces Trails produces (CLI commands, MCP tools, HTTP endpoints) are protocol-based. Consumers interact via standard protocols -- they don't need Bun. A Node project can add Trails by installing Bun alongside Node. Bun runs Node code, so everything coexists.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `surface()` | `@modelcontextprotocol/sdk` |
 | `@ontrails/http` | HTTP routes and error mapping | None beyond core |
 | `@ontrails/hono` | Hono connector, `surface()` | `hono` |
-| `@ontrails/vite` | Vite dev server integration, `surface()` | `vite` |
+| `@ontrails/vite` | Vite middleware adapter, `vite()` | None (node:stream only) |
 
 ### Infrastructure Connectors (right side)
 
@@ -194,7 +194,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
      ^
 @ontrails/cli/commander (cli, commander)
 @ontrails/hono (http, hono)
-@ontrails/vite (http, vite)
+@ontrails/vite (node:stream only, no workspace deps)
 @ontrails/logtape (logging)
 @ontrails/warden (core, schema)
      ^

--- a/docs/draft-state.md
+++ b/docs/draft-state.md
@@ -1,6 +1,6 @@
 # Draft State
 
-Draft state is Trails' controlled sketching mode. Model future trails, signals, and resources before every dependency exists — without weakening the established graph that powers trailheads, lockfiles, and CI.
+Draft state is Trails' controlled sketching mode. Model future trails, signals, and resources before every dependency exists — without weakening the established graph that powers surfaces, lockfiles, and CI.
 
 ## Concept
 
@@ -9,7 +9,7 @@ Top-down authoring is how Trails reads best and how agents naturally work. But e
 The framework exposes two views:
 
 - **Authored graph** — may contain draft state, used for governance and sketching
-- **Established graph** — must not contain draft state, used for lockfiles, trailheads, and runtime export
+- **Established graph** — must not contain draft state, used for lockfiles, surfaces, and runtime export
 
 ## The `_draft.` marker
 
@@ -66,7 +66,7 @@ One draft dependency can turn surprising amounts of downstream work into draft s
 
 These outputs reject draft state at runtime via `validateEstablishedTopo()`:
 
-- **Trailhead projection** — no draft trails in CLI, MCP, or HTTP trailheads
+- **Surface projection** — no draft trails in CLI, MCP, or HTTP surfaces
 - **Lockfile export** — no draft nodes in `.trails/trails.lock`
 - **OpenAPI generation** — established schema export excludes draft trails
 - **Topo exports** — standard topo accessors exclude draft declarations

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -187,7 +187,7 @@ For finer control, use `testExamples(graph)` to run only example assertions with
 
 ```typescript
 import { testExamples } from '@ontrails/testing';
-import { app } from '../app';
+import { graph } from '../app';
 
 testExamples(graph);
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Install the core packages, define your first trail, open trailheads on CLI and MCP, and test it with one line.
+Install the core packages, define your first trail, open surfaces on CLI and MCP, and test it with one line.
 
 ## Installation
 
@@ -16,7 +16,7 @@ bun add @ontrails/core @ontrails/cli
 # Add Commander connector (for the /commander subpath)
 bun add commander
 
-# Add MCP trailhead (optional)
+# Add MCP surface (optional)
 bun add @ontrails/mcp
 
 # Add testing (dev dependency)
@@ -68,7 +68,7 @@ What you get from this single definition:
 - CLI derivation: `name` auto-promoted to a positional arg (sole required string), `--loud` as a flag
 - An MCP tool with JSON Schema input and annotations (`readOnlyHint: true`)
 - Two examples that serve as agent documentation AND test cases
-- Sync authoring for pure work, with the runtime normalized to one awaitable execution shape for layers and trailheads
+- Sync authoring for pure work, with the runtime normalized to one awaitable execution shape for layers and surfaces
 
 ## Collect Into a Topo
 
@@ -124,7 +124,7 @@ When a trail has exactly one required string field with no default, the CLI
 automatically promotes it to a positional argument. You can still pass it as a
 flag (`--name World`), but the positional form is shorter. To suppress
 auto-promotion, set `args: false` on the trail definition (see the
-[CLI trailhead guide](./trailheads/cli.md#positional-args)).
+[CLI surface guide](./surfaces/cli.md#positional-args)).
 
 ## Open an MCP Surface
 
@@ -137,13 +137,13 @@ import { graph } from './app';
 await surface(graph);
 ```
 
-Same trail. Same implementation. Different trailhead. The MCP server exposes a `myapp_greet` tool with:
+Same trail. Same implementation. Different surface. The MCP server exposes a `myapp_greet` tool with:
 
 - JSON Schema input derived from the Zod schema
 - `readOnlyHint: true` annotation from `intent: 'read'`
 - Examples available for agent planning
 
-Pure trails can return `Result` directly. Trails with `crosses` and I/O-heavy trails can stay `async`; Trails normalizes both forms before connectors run them.
+Pure trails can return `Result` directly. Trails with `crosses` and I/O-heavy trails can stay `async`; Trails normalizes both forms before surfaces run them.
 
 ## Test with `testAll`
 
@@ -295,5 +295,5 @@ If multiple candidates are found, the CLI exits with an error listing them; pass
 - [Architecture](./architecture.md) -- How the hexagonal model works
 - [Lexicon](./lexicon.md) -- All Trails terms defined
 - [Testing Guide](./testing.md) -- TDD approach, contract testing, harnesses
-- [CLI Trailhead Guide](./trailheads/cli.md) -- Flag derivation, output modes, layers
-- [MCP Trailhead Guide](./trailheads/mcp.md) -- Annotations, progress, tool naming
+- [CLI Surface Guide](./surfaces/cli.md) -- Flag derivation, output modes, layers
+- [MCP Surface Guide](./surfaces/mcp.md) -- Annotations, progress, tool naming

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -12,13 +12,13 @@
 
 **Config resolution (`@ontrails/config`).** `defineConfig()` provides schema-validated config with profiles (named environment profiles), env variable mapping, and `ResourceSpec.config` for resource-level config schemas. Includes diagnostics (`checkConfig`), introspection (`deriveConfigFields`, `deriveConfigProvenance`), and generation (`deriveConfigEnvExample`).
 
-**Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. `authLayer` extracts credentials from trailhead-specific sources, `AuthConnector` resolves them to a `Permit` (identity, scopes, roles), and scope enforcement rejects unauthorized access. Includes JWT connector, governance rules (`validatePermits`), and test helpers (`createTestPermit`, `createPermitForTrail`).
+**Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. `authLayer` extracts credentials from surface-specific sources, `AuthConnector` resolves them to a `Permit` (identity, scopes, roles), and scope enforcement rejects unauthorized access. Includes JWT connector, governance rules (`validatePermits`), and test helpers (`createTestPermit`, `createPermitForTrail`).
 
 **Tracing (intrinsic in `@ontrails/core`, sinks in `@ontrails/tracing`).** Every `executeTrail` invocation produces a `TraceRecord` automatically — no layer attachment required. `ctx.trace(label, fn)` records nested spans inside a trail blaze. Pluggable sinks register via `registerTraceSink()`: `createMemorySink` for testing, `createDevStore` for local development, `createOtelConnector` for production OpenTelemetry export. Sampling configuration controls recording volume.
 
 ## Mid-term (v1.3+)
 
-**Derived dependency graphs.** Instead of hand-maintaining `crosses` declarations, the framework infers them from `ctx.cross()` calls in the implementation via static analysis. The same idea could eventually extend beyond today's declared `resources: [...]` model to richer resource capability inference. The trailhead lock captures the graph. Changes show up in diffs.
+**Derived dependency graphs.** Instead of hand-maintaining `crosses` declarations, the framework infers them from `ctx.cross()` calls in the implementation via static analysis. The same idea could eventually extend beyond today's declared `resources: [...]` model to richer resource capability inference. The surface map captures the graph. Changes show up in diffs.
 
 **Implementation synthesis from examples.** For trails with comprehensive examples that fully specify behavior (pure transformations, mapping logic, validation rules), an agent could synthesize the implementation from the examples alone. The examples become the source of truth; the code becomes the derived artifact.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,30 +3,30 @@
 ## New to Trails?
 
 1. **[Why Trails](./why-trails.md)** — The problem, the approach, why contracts beat conventions
-2. **[Getting Started](./getting-started.md)** — Install, define your first trail, open a CLI trailhead, test it
-3. **[Lexicon](./lexicon.md)** — The terms you'll use every day: trail, blaze, topo, trailhead, cross, resource, signal, layer, tracing
+2. **[Getting Started](./getting-started.md)** — Install, define your first trail, open a CLI surface, test it
+3. **[Lexicon](./lexicon.md)** — The terms you'll use every day: trail, blaze, topo, surface, cross, resource, signal, layer, tracing
 
 ## Building something?
 
-- **[Architecture](./architecture.md)** — Hexagonal model, package layers, how data flows from trail to trailhead
+- **[Architecture](./architecture.md)** — Hexagonal model, package layers, how data flows from trail to surface
 - **[API Reference](./api-reference.md)** — Every public export across all packages
 - **[Resources Guide](./resources.md)** — Define resources, declare them on trails, test with mock factories
 - **[Store Guide](../packages/store/README.md)** — Declare schema-derived stores, bind them with Drizzle, use fixtures and read-only access
 - **[Config Guide](../packages/config/README.md)** — Schema-derived configuration, resolution stack, extensions, profiles
 - **[Permits Guide](../packages/permits/README.md)** — Scope-based authorization, auth connectors, permit governance
 - **[Tracing Guide](../packages/tracing/README.md)** — Execution recording, sinks, sampling, manual instrumentation
-- **[Testing Guide](./testing.md)** — TDD with examples, `testAll()`, contract testing, trailhead harnesses
+- **[Testing Guide](./testing.md)** — TDD with examples, `testAll()`, contract testing, surface harnesses
 
-## Adding a trailhead?
+## Adding a surface?
 
-- **[CLI Trailhead](./trailheads/cli.md)** — Flag derivation, output modes, exit codes, `--dry-run`
-- **[MCP Trailhead](./trailheads/mcp.md)** — Tool naming, annotations, progress bridge
-- **[HTTP Trailhead](./trailheads/http.md)** — Route derivation, verb mapping, error responses, Hono connector
+- **[CLI Surface](./surfaces/cli.md)** — Flag derivation, output modes, exit codes, `--dry-run`
+- **[MCP Surface](./surfaces/mcp.md)** — Tool naming, annotations, progress bridge
+- **[HTTP Surface](./surfaces/http.md)** — Route derivation, verb mapping, error responses, Hono connector
 
 ## Governing your codebase?
 
 - **[Warden](../packages/warden/README.md)** — AST-based convention rules, drift detection, CI integration
-- **[Schema](../packages/schema/README.md)** — Trailhead maps, topo export helpers, semantic diffing, lock files
+- **[Schema](../packages/schema/README.md)** — Surface maps, topo export helpers, semantic diffing, lock files
 
 ## Design decisions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,15 +34,15 @@
 - **[ADR-0001: Naming Conventions](./adr/0001-naming-conventions.md)** — How and why we chose every term
 - **[ADR-0002: Built-In Result Type](./adr/0002-built-in-result-type.md)** — Own the Result primitive, zero dependencies
 - **[ADR-0003: Unified Trail Primitive](./adr/0003-unified-trail-primitive.md)** — One `trail()`, composition as a property
-- **[ADR-0004: Intent as a First-Class Property](./adr/0004-intent-as-first-class-property.md)** — One field drives all trailhead behavior
+- **[ADR-0004: Intent as a First-Class Property](./adr/0004-intent-as-first-class-property.md)** — One field drives all surface behavior
 - **[ADR-0005: Framework-Agnostic HTTP Route Model](./adr/0005-framework-agnostic-http-route-model.md)** — `HttpRoute[]` with thin connector subpaths
 - **[ADR-0006: Shared Execution Pipeline](./adr/0006-shared-execution-pipeline.md)** — One `executeTrail`, Result-returning builders
 - **[ADR-0007: Governance as Trails](./adr/0007-governance-as-trails.md)** — Warden rules are trails, AST-based analysis
-- **[ADR-0008: Deterministic Trailhead Derivation](./adr/0008-deterministic-trailhead-derivation.md)** — Explicit lookup tables for every trailhead
+- **[ADR-0008: Deterministic Surface Derivation](./adr/0008-deterministic-trailhead-derivation.md)** — Explicit lookup tables for every surface
 - **[ADR-0009: First-Class Resources](./adr/0009-first-class-resources.md)** — Dependency declarations, lifecycle, testing, governance
 - **[ADR-0010: Trails-Native Infrastructure](./adr/0010-native-infrastructure.md)** — Workspace layout, `.trails/` directory, shared database
 - **[ADR-0011: Schema-Driven Config](./adr/0011-schema-driven-config.md)** — Typed configuration from schemas
-- **[ADR-0012: Connector-Agnostic Permits](./adr/0012-connector-agnostic-permits.md)** — Permission model independent of trailhead
+- **[ADR-0012: Connector-Agnostic Permits](./adr/0012-connector-agnostic-permits.md)** — Permission model independent of surface
 - **[ADR-0013: Tracing](./adr/0013-tracing.md)** — Runtime recording primitive
 - **[ADR-0014: Core Database Primitive](./adr/0014-core-database-primitive.md)** — Shared `trails.db`, subsystem schema versioning
 - **[ADR-0015: Topo Store](./adr/0015-topo-store.md)** — Queryable relational projection of the resolved graph
@@ -57,4 +57,4 @@
 
 ## Where to next?
 
-- **[Horizons](./horizons.md)** — HTTP trailhead, permits, mounts, tracing, and the road to v1 stable
+- **[Horizons](./horizons.md)** — HTTP surface, permits, mounts, tracing, and the road to v1 stable

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -20,7 +20,7 @@ This means:
 
 ## Branded — Top-Level Primitives
 
-Six terms a developer must internalize before reading a Trails app.
+Seven terms a developer must internalize before reading a Trails app.
 
 ### `trail`
 
@@ -49,6 +49,14 @@ await surfaceMcp(graph);
 
 Use `surface` for both the one-liner function and the concept. "This app has
 three surfaces" is the intended sentence.
+
+### `trailhead`
+
+The conceptual boundary where a surface meets the trail system. The
+trailhead is where external input enters the framework and where the
+surface's protocol-specific handling ends and the shared `executeTrail()`
+pipeline begins. "Surface" names the rendering; "trailhead" names the
+boundary point.
 
 ### `topo`
 

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -34,29 +34,35 @@ const show = trail('entity.show', {
 });
 ```
 
-### `trailhead`
+### `surface`
 
-The entry point where the outside world reaches the trail system. CLI, MCP, HTTP, and WebSocket are trailheads.
+The boundary-owned rendering where the outside world reaches the trail system.
+CLI, MCP, HTTP, and WebSocket are surfaces.
 
 ```typescript
-import { trailhead } from '@ontrails/cli/commander';
-trailhead(app);
+import { surface } from '@ontrails/cli/commander';
+await surface(graph);
 
-import { trailhead as mcpTrailhead } from '@ontrails/mcp';
-await mcpTrailhead(app);
+import { surface as surfaceMcp } from '@ontrails/mcp';
+await surfaceMcp(graph);
 ```
 
-Use `trailhead` for both the one-liner function and the concept. "This app has three trailheads" is the intended sentence.
+Use `surface` for both the one-liner function and the concept. "This app has
+three surfaces" is the intended sentence.
 
 ### `topo`
 
-Collect trail modules into an app. `topo()` scans exports and builds the internal trail map with `.trails`, `.signals`, and `.resources`.
+Collect trail modules into a graph. `topo()` scans exports and builds the
+internal trail map with `.trails`, `.signals`, and `.resources`.
 
 ```typescript
-const app = topo('myapp', entityModule, searchModule);
+const graph = topo('myapp', entityModule, searchModule);
 ```
 
-The topo is the center of gravity for discovery, validation, and runtime wiring. More than a registry — it is the queryable graph of everything: trails, relationships, signals, resources.
+The topo is the center of gravity for discovery, validation, and runtime
+wiring. More than a registry — it is the queryable graph of everything:
+trails, relationships, signals, resources. The primitive is `topo()`. The
+value it returns is a graph.
 
 ### `contour`
 
@@ -163,7 +169,8 @@ The noun is a crossing: a place where one trail intentionally steps onto another
 
 ### `crossInput`
 
-Composition-only input schema. Declares fields available through `ctx.cross()` but invisible to public trailheads (CLI, MCP, HTTP).
+Composition-only input schema. Declares fields available through `ctx.cross()`
+but invisible to public surfaces (CLI, MCP, HTTP).
 
 ```typescript
 const create = trail('gist.create', {
@@ -175,13 +182,15 @@ const create = trail('gist.create', {
     forkedFrom: z.string().optional(),
   }),
   blaze: async (input, ctx) => {
-    // input.forkedFrom is available here (undefined from trailheads)
+    // input.forkedFrom is available here (undefined from surfaces)
     return Result.ok({ id: '1' });
   },
 });
 ```
 
-`crossInput` fields are merged with `input` for the blaze. When invoked via a trailhead, `crossInput` fields are absent. When invoked via `ctx.cross()`, the caller can pass both. See [ADR-0024](adr/0024-typed-trail-composition.md).
+`crossInput` fields are merged with `input` for the blaze. When invoked via a
+surface, `crossInput` fields are absent. When invoked via `ctx.cross()`, the
+caller can pass both. See [ADR-0024](adr/0024-typed-trail-composition.md).
 
 ### `signal`
 
@@ -197,14 +206,17 @@ Trails signals go beyond events: cron triggers, webhook sources, file watchers, 
 
 ### `pin`
 
-A named snapshot of the topo state at a point in time. Pins are stored in `trails.db` and enable comparison between the current resolved graph and a previous known-good state.
+A named snapshot of the graph state at a point in time. Pins are stored in
+`trails.db` and enable comparison between the current resolved graph and a
+previous known-good state.
 
 ```bash
 trails topo pin --name v1.0
 trails topo verify
 ```
 
-Carries intent that "snapshot" doesn't — "this state is my reference point." Verb-friendly. A pin captures the topo; an export serializes it.
+Carries intent that "snapshot" doesn't — "this state is my reference point."
+Verb-friendly. A pin captures the graph; an export serializes it.
 
 ## Plain — Standard Language
 
@@ -212,10 +224,12 @@ Terms that name concepts existing cleanly across software. The standard word wor
 
 ### `layer`
 
-A cross-cutting wrapper around trail execution. Layers add behavior to the execution pipeline: dry-run, pagination, verbose, telemetry. Most layers don't block — they augment. Attaches at three levels: trail, trailhead, or topo.
+A cross-cutting wrapper around trail execution. Layers add behavior to the
+execution pipeline: dry-run, pagination, verbose, telemetry. Most layers don't
+block — they augment. Attaches at three levels: trail, surface, or graph.
 
 ```typescript
-const app = topo('myapp', entityModule, {
+const graph = topo('myapp', entityModule, {
   layers: [verboseLayer, paginationLayer],
 });
 ```
@@ -236,7 +250,7 @@ Trails declare their infrastructure needs with `resources: [...]` and access the
 
 ### `visibility`
 
-Whether a trail is exposed as a public verb on trailheads or kept as an internal
+Whether a trail is exposed as a public verb on surfaces or kept as an internal
 composition target.
 
 ```typescript
@@ -248,8 +262,8 @@ const normalizePayload = trail('github.normalize-payload', {
 });
 ```
 
-`'public'` is the default. `'internal'` keeps the trail off trailheads unless a
-specific trailhead includes that exact trail ID intentionally.
+`'public'` is the default. `'internal'` keeps the trail off surfaces unless a
+specific surface includes that exact trail ID intentionally.
 
 ### `profile`
 
@@ -284,10 +298,20 @@ const enableFeature = trail('feature.enable', {
 Direct programmatic execution through the full pipeline.
 
 ```typescript
-const result = await run(app, 'entity.show', { id: '123' });
+const result = await run(graph, 'entity.show', { id: '123' });
 ```
 
 `run()` is for "invoke this specific trail now." It is not the implementation field on a trail.
+
+### `graph`
+
+The assembled, queryable value returned by `topo()`. The graph is the runtime
+shape that surfaces render, survey inspects, and the lockfile serializes.
+
+```typescript
+const graph = topo('myapp', entityModule, searchModule);
+await surface(graph);
+```
 
 ### `store`
 
@@ -314,7 +338,12 @@ The store declaration stays kind-agnostic. The connector or binding chooses the 
 
 ### `projection`
 
-A mechanically derived output from authored information. The topo store is a relational projection of the resolved graph — the same data, restructured for queries. CLI flags are projections of input schemas. HTTP verbs are projections of intent. The framework derives projections; developers author the source.
+A mechanically derived output from authored information. The topo store is a
+relational projection of the resolved graph — the same data, restructured for
+queries. CLI flags are projections of input schemas. HTTP verbs are
+projections of intent. `deriveCliCommands(graph)` and
+`deriveHttpRoutes(graph)` are surface projections. The framework derives
+projections; developers author the source.
 
 ### Other plain terms
 
@@ -325,11 +354,13 @@ A mechanically derived output from authored information. The topo store is a rel
 | `meta` | Annotations for tooling and filtering |
 | `Result` | Ok/Err return type |
 | `error` | Error types |
+| `adapter` | A thinner runtime-specific layer that composes on top of an existing surface or connector |
 | `connector` | Integration-specific bridge to third-party systems (e.g., Hono, Commander, Drizzle) |
 | `logger` / `logging` | Structured logging — framework provides the interface; developers bring their own |
 | `health` | Health checks |
-| `build*` | Derived builder output before wiring |
-| `to*` / `connect*` | Runtime wiring helpers after build |
+| `derive*` | Mechanically project surface definitions from a graph |
+| `create*` | Materialize runtime objects without opening the boundary |
+| `to*` / `connect*` | Narrow translation or transport helpers where the boundary package needs them |
 
 ## Compound and Derived Terms
 
@@ -338,7 +369,7 @@ Built from the lexicon above.
 | Term | Composed of | Usage |
 | --- | --- | --- |
 | `pack` | Collection of trails as a distributable unit | Trail pack. Published capability bundle. |
-| `mount` | Cross-app composition | Mount a remote topo. Future. |
+| `mount` | Cross-app composition | Mount a remote graph. Future. |
 | `survey` | Full introspection of the trail system | `trails survey` to see everything. |
 | `guide` | Runtime guidance layer | `trails guide` for recommendations. |
 
@@ -352,7 +383,7 @@ These are directional. They should not be reused for unrelated concepts.
 | `pack` | Distributable capability bundle |
 | `depot` | Registry or distribution point for packs and shared assets |
 | `dispatch` | Reserved strong verb for a future concept, no longer the direct execution helper |
-| `_draft.` | Reserved ID prefix for draft state. Trails, signals, and other primitives with `_draft.` IDs are visible in source but excluded from the resolved graph, established trailheads, and topo exports. Draft state is visible debt — it must never leak into established outputs. See ADR-0021. |
+| `_draft.` | Reserved ID prefix for draft state. Trails, signals, and other primitives with `_draft.` IDs are visible in source but excluded from the resolved graph, established surfaces, and graph exports. Draft state is visible debt — it must never leak into established outputs. See ADR-0021. |
 
 ## Grammar
 
@@ -364,7 +395,7 @@ These rules carry over from ADR-0001 and govern how the lexicon composes:
 - **`create*` for runtime instances:** `createLogger()`, `createConsoleLogger()`
 - **`derive*` for derivations:** `deriveFields()`, `deriveFlags()`
 - **`validate*` for verification:** `validateInput()`, `validateTopo()`
-- **`derive*` then `to*` / `connect*` for surface wiring:** `deriveCliCommands()`, `toCommander()`
+- **`derive*` then `create*` then `surface()` for surface wiring:** `deriveCliCommands()`, `createProgram()`, `surface()`
 
 ## Term Hierarchy
 
@@ -374,8 +405,8 @@ When introducing Trails, use this order.
 
 1. `trail()` — define a unit of work
 2. `blaze:` — give the trail its implementation
-3. `topo()` — collect trails into an app
-4. `surface()` — open the app on CLI, MCP, HTTP, or WebSocket
+3. `topo()` — collect trails into a graph
+4. `surface()` — open the graph on CLI, MCP, HTTP, or WebSocket
 
 ### Intermediate
 
@@ -392,7 +423,7 @@ When introducing Trails, use this order.
 1. `layer` — wrap execution with cross-cutting behavior
 2. `tracing` / `ctx.trace()` — record what happened
 3. `permit` — auth and scopes
-4. `pin` — named topo snapshot for diffing and verification
+4. `pin` — named graph snapshot for diffing and verification
 5. `projection` — mechanically derived output from authored data
 6. `profile` — deployment and environment config sets
 7. `pattern` — declared operational shape on a trail
@@ -400,7 +431,8 @@ When introducing Trails, use this order.
 
 ## Writing Style
 
-- Lead with code: `trail()` → `blaze:` → `topo()` → `trailhead()`
-- Use the lexicon consistently: "cross" instead of "follow," "trailhead" instead of "surface"
+- Lead with code: `trail()` → `blaze:` → `topo()` → `surface()`
+- Use the lexicon consistently: "cross" instead of "follow," "surface"
+  instead of generic transport vocabulary
 - Keep the metaphor disciplined. The words should clarify behavior, not turn the docs into theme writing.
 - Prefer the lexicon's nouns even for internal architecture explanations. Leaving generic words in place only creates translation tax later.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -101,7 +101,7 @@ Resolution happens eagerly during `executeTrail`, after input validation and bef
 
 This means failures surface at the boundary -- a missing `DATABASE_URL` fails before the implementation runs, not on line 47. It also means layers can access resources via `db.from(ctx)` because resolution is already complete.
 
-Shutdown signaling differs by trailhead. CLI tools dispose after the command completes. Long-running servers (MCP, HTTP) dispose on `SIGTERM`/`SIGINT`. The trailhead's `surface()` owns the lifecycle.
+Shutdown signaling differs by surface. CLI tools dispose after the command completes. Long-running servers (MCP, HTTP) dispose on `SIGTERM`/`SIGINT`. The `surface()` call owns the lifecycle.
 
 ## Testing with Resources
 

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -1,6 +1,6 @@
-# CLI Trailhead
+# CLI Surface
 
-The CLI trailhead connector turns every trail into a command. Flags are
+The CLI surface connector turns every trail into a command. Flags are
 derived from faithfully representable Zod schema fields, and structured JSON
 channels are available when the input shape is richer than flags can express
 honestly. Output formatting, error handling, and exit codes are handled
@@ -203,7 +203,7 @@ await output('Hello', 'text'); // Plain text
 5. `<TOPO>_JSONL=1` env var
 6. Default: `"text"`
 
-The `<TOPO>` prefix is derived from the topo name: uppercased, with non-alphanumerics replaced by `_`. Names starting with a digit get an `_` prefix so the result is a valid identifier (e.g., `1app` → `_1APP_JSON`). The topo name is threaded through the CLI trailhead automatically and appears on `ActionResultContext.topoName` for custom result handlers.
+The `<TOPO>` prefix is derived from the topo name: uppercased, with non-alphanumerics replaced by `_`. Names starting with a digit get an `_` prefix so the result is a valid identifier (e.g., `1app` → `_1APP_JSON`). The topo name is threaded through the CLI surface automatically and appears on `ActionResultContext.topoName` for custom result handlers.
 
 ## Error Handling
 

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -1,6 +1,6 @@
-# HTTP Trailhead
+# HTTP Surface
 
-The HTTP trailhead connector turns every trail into an endpoint. Routes are derived from trail IDs, HTTP verbs from intent, input parsing from the method, and error responses from the error taxonomy. One `surface()` call starts a Hono server.
+The HTTP surface connector turns every trail into an endpoint. Routes are derived from trail IDs, HTTP verbs from intent, input parsing from the method, and error responses from the error taxonomy. One `surface()` call starts a Hono server.
 
 The package separates framework-agnostic route building (`@ontrails/http`) from the Hono connector (`@ontrails/hono`).
 
@@ -86,7 +86,7 @@ The `code` is the error class name. The `category` matches the error taxonomy.
 
 ## Status Code Mapping
 
-Status codes come directly from the error taxonomy -- the same mapping used across all trailheads:
+Status codes come directly from the error taxonomy -- the same mapping used across all surfaces:
 
 | Category     | HTTP Status | Classes                              |
 | ------------ | ----------- | ------------------------------------ |
@@ -119,7 +119,7 @@ await surface(graph, {
 
 Layers run in order, wrapping the implementation. They have access to the trail and its context, so they can inspect intent, metadata, and markers.
 
-## TrailheadHttpOptions
+## CreateAppOptions
 
 | Option          | Type                                   | Default       | Description                                          |
 | --------------- | -------------------------------------- | ------------- | ---------------------------------------------------- |

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -1,6 +1,6 @@
-# MCP Trailhead
+# MCP Surface
 
-The MCP trailhead connector turns every trail into an MCP tool. Annotations are auto-derived from trail intent and metadata. Progress callbacks bridge to MCP notifications. One `surface()` call starts a server.
+The MCP surface connector turns every trail into an MCP tool. Annotations are auto-derived from trail intent and metadata. Progress callbacks bridge to MCP notifications. One `surface()` call starts a server.
 
 ## Setup
 
@@ -110,7 +110,7 @@ If the result contains a `BlobRef` with an image MIME type, it becomes an image 
 
 ## Progress Bridging
 
-Trail implementations can report progress via `ctx.progress`. On the MCP trailhead, these are bridged to MCP `notifications/progress`:
+Trail implementations can report progress via `ctx.progress`. On the MCP surface, these are bridged to MCP `notifications/progress`:
 
 ```typescript
 const importTrail = trail('data.import', {
@@ -160,7 +160,7 @@ await surface(graph, {
 ```
 
 `surface(graph)` already derives the MCP server name and version from the
-topo identity. Pass `name` or `version` only when a specific trailhead instance
+topo identity. Pass `name` or `version` only when a specific surface instance
 needs to override them.
 
 ## AbortSignal Propagation

--- a/docs/tenets.md
+++ b/docs/tenets.md
@@ -1,6 +1,6 @@
 # Trails Design Tenets
 
-> Capabilities as contracts: define once, trailhead everywhere.
+> Capabilities as contracts: define once, surface everywhere.
 
 This is the stable doctrinal layer for the Trails framework. It governs. Where the repo may at times drift from this document, it's the repo that should be brought into alignment, not our tenets.
 
@@ -19,15 +19,15 @@ These are the foundational beliefs of the framework. Every feature, ADR, and API
 
 ### The trail is the product
 
-A trail definition is the source of truth. Trailheads (CLI, MCP, HTTP, WebSocket) are renderings of the trail contract, not separate implementations. One trail, many trailheads, zero divergence.
+A trail definition is the source of truth. Surfaces (CLI, MCP, HTTP, WebSocket) are renderings of the trail contract, not separate implementations. One trail, many surfaces, zero divergence.
 
 The trail is the unit of everything. Testing targets the trail. Governance targets the trail. Composition follows the trail. As the framework matures, versioning, permissions, and triggers will target the trail too. The trail is where capability lives.
 
 ### One schema, one Result, one error taxonomy
 
-Every trail has one input schema and one output schema. Every implementation returns one Result type. Every error belongs to a taxonomy that maps deterministically to every trailhead's error representation.
+Every trail has one input schema and one output schema. Every implementation returns one Result type. Every error belongs to a taxonomy that maps deterministically to every surface's error representation.
 
-Drift across trailheads is structurally harder than alignment. You cannot have different parameter names across trailheads because there is only one schema.
+Drift across surfaces is structurally harder than alignment. You cannot have different parameter names across surfaces because there is only one schema.
 
 ### Schema always exists
 
@@ -55,15 +55,15 @@ Trails should reduce ceremony wherever the framework can truthfully carry the bu
 
 Repeated ceremony is a framework smell. When the same setup keeps appearing around a core capability, the framework should consider absorbing that burden into derivation, defaults, layers, first-party capabilities, or a stronger primitive.
 
-The goal is not smaller trailhead area for its own sake. The goal is a smaller user burden. The real cost of ceremony is not just typing. It is drift, boilerplate, and future refactor load. Simplicity at the trailhead must still rest on inspectable ground truth underneath.
+The goal is not smaller surface area for its own sake. The goal is a smaller user burden. The real cost of ceremony is not just typing. It is drift, boilerplate, and future refactor load. Simplicity at the surface must still rest on inspectable ground truth underneath.
 
 ### Add with intent, not trend
 
 New built-in capability should be added only when it reinforces the broader Trails story. Additions must strengthen the existing principles, primitives, and patterns rather than fragment them.
 
-Good additions reduce ceremony, lower drift potential, impose an acceptable footprint cost, create a stronger operating contract, and compound value across trailheads, testing, governance, and agent ergonomics. Additions without deep consideration are just future tech debt.
+Good additions reduce ceremony, lower drift potential, impose an acceptable footprint cost, create a stronger operating contract, and compound value across surfaces, testing, governance, and agent ergonomics. Additions without deep consideration are just future tech debt.
 
-This does not preclude experimentation. Trails itself was formed through iteration, refinement, and repeated shaping over time. The key is that experimentation should feed the core story, not bypass it. Broadening the built-in trailhead is worth doing when it is a net win across the system. It is not worth doing to chase a trend or accumulate trailhead area.
+This does not preclude experimentation. Trails itself was formed through iteration, refinement, and repeated shaping over time. The key is that experimentation should feed the core story, not bypass it. Broadening the built-in surface is worth doing when it is a net win across the system. It is not worth doing to chase a trend or accumulate surface area.
 
 ### The information architecture
 
@@ -108,17 +108,17 @@ When derivation doesn't fit, override it. Overrides are visible in the resolved 
 
 Every tightening declaration is a place where the stated contract can drift from reality. The framework must make that drift structurally difficult (the compiler catches it), immediately visible (tests catch it), or governable (the warden catches it). If none of these catch it, the feature needs redesign.
 
-### Trailheads are peers
+### Surfaces are peers
 
-CLI, MCP, HTTP, and WebSocket are equal connectors over the same topology. No trailhead is privileged. The trail doesn't know which trailhead invoked it. The execution pipeline is identical regardless of entry point.
+CLI, MCP, HTTP, and WebSocket are equal surfaces over the same graph. No surface is privileged. The trail doesn't know which surface invoked it. The execution pipeline is identical regardless of entry point.
 
-New trailheads don't require new trail code. They derive from the contract. If a trail works on one trailhead, it works on all of them.
+New surfaces don't require new trail code. They derive from the contract. If a trail works on one surface, it works on all of them.
 
 ### Implementations are pure
 
-Input in, Result out. No process exits, no direct console output, no trailhead-specific request or response types in domain logic. The implementation does not know which trailhead invoked it.
+Input in, Result out. No process exits, no direct console output, no surface-specific request or response types in domain logic. The implementation does not know which surface invoked it.
 
-Purity is what makes trailhead-agnosticism possible. If an implementation touches stdout, it can't run on MCP. If it reads from a request object, it can't run on CLI. Side effects happen through structured, trailhead-agnostic channels.
+Purity is what makes surface-agnosticism possible. If an implementation touches stdout, it can't run on MCP. If it reads from a request object, it can't run on CLI. Side effects happen through structured, surface-agnostic channels.
 
 ### Validate at the boundary, trust internally
 
@@ -128,11 +128,11 @@ Validation is a framework guarantee enforced once at the boundary, not a develop
 
 ### The resolved graph is the story
 
-The lockfile is the serialized topology: the compiled, resolved, deduplicated story of a Trails application. Every trail, service, event, and trailhead is a node. Relationships are edges. An agent reading just the lockfile can understand the entire system without source code.
+The lockfile is the serialized topology: the compiled, resolved, deduplicated story of a Trails application. Every trail, service, event, and surface is a node. Relationships are edges. An agent reading just the lockfile can understand the entire system without source code.
 
 The lockfile is generated, checked in, and CI-diffable. Drift between code and lockfile is a governance finding.
 
-> The trailhead map provides the foundation today: trailhead map generation and semantic diffing. The full lockfile-as-resolved-graph, capturing the complete topology with all nodes and edges, is the target architecture. The principle holds now; the scope expands as the schema package matures.
+> The surface map provides the foundation today: surface map generation and semantic diffing. The full lockfile-as-resolved-graph, capturing the complete topology with all nodes and edges, is the target architecture. The principle holds now; the scope expands as the schema package matures.
 
 ## Primitives
 
@@ -158,11 +158,11 @@ When the same structural pattern keeps appearing with slightly different shapes,
 
 **Strengthen an existing primitive.** Can an existing primitive absorb this capability without losing coherence? This is always the best outcome. It compounds the value of everything that already uses that primitive.
 
-**Codify a pattern.** If no primitive fits, does the need map to a recurring structural pattern that can be documented and reused? Patterns are cheaper than primitives. They guide usage without expanding the API trailhead.
+**Codify a pattern.** If no primitive fits, does the need map to a recurring structural pattern that can be documented and reused? Patterns are cheaper than primitives. They guide usage without expanding the public surface.
 
 **Introduce a new primitive.** Only when no existing primitive can absorb the concept and no pattern can express it. The new primitive must compound with the existing set. It should make every other primitive smarter, not just add to a list.
 
-**Broaden built-in capability.** When a capability productively removes repeated ceremony across the system and compounds value across trailheads, testing, governance, and agent ergonomics, it is worth bringing in-house. This is not minimalism at all costs. It is deliberate growth with architectural discipline. The bar: a net win across the system, not just a convenience in one spot.
+**Broaden built-in capability.** When a capability productively removes repeated ceremony across the system and compounds value across surfaces, testing, governance, and agent ergonomics, it is worth bringing in-house. This is not minimalism at all costs. It is deliberate growth with architectural discipline. The bar: a net win across the system, not just a convenience in one spot.
 
 The history validates this hierarchy. `resource()` was introduced because typed infrastructure dependencies with lifecycle and testability could not be expressed through any existing primitive. `derivePermit()` was dropped because plain authored objects handled the same need without a new abstraction.
 
@@ -184,7 +184,7 @@ The framework should not impose ceremony before it becomes necessary. The warden
 
 ### Authored defaults, overridable in context
 
-A trail declares its defaults: intent, error behavior, crossing declarations, metadata. These are the author's stated design. The consuming context (the app, trailhead config, or a future composition layer) can override them.
+A trail declares its defaults: intent, error behavior, crossing declarations, metadata. These are the author's stated design. The consuming context (the app, surface config, or a future composition layer) can override them.
 
 The authored default documents intent. The override enables reuse. The resolved graph captures the final state. Governance can flag overrides that contradict intent.
 
@@ -214,13 +214,13 @@ Trails makes deliberate choices about where it is opinionated, where it defers t
 
 The framework uses its target runtime where doing so materially improves the development experience. The authoring side is opinionated.
 
-The outputs are not. A CLI works in any shell. An MCP server works with any MCP client. An HTTP trailhead serves standard HTTP. The trailheads Trails produces are universally consumable through standard protocols and formats. Standards live at the boundary.
+The outputs are not. A CLI works in any shell. An MCP server works with any MCP client. An HTTP surface serves standard HTTP. The surfaces Trails produces are universally consumable through standard protocols and formats. Standards live at the boundary.
 
 ### Opinionated authoring, standard outputs
 
 Trails is opinionated about how developers author contracts: schemas, Result types, the error taxonomy, the execution pipeline. These opinions exist because they make drift structurally harder than alignment and make one-write-many-reads possible.
 
-Trails is unopinionated about what consumes the result. Trailheads produce standard outputs. Agents, browsers, CLIs, and other services interact with Trails apps through protocols they already understand.
+Trails is unopinionated about what consumes the result. Surfaces produce standard outputs. Agents, browsers, CLIs, and other services interact with Trails apps through protocols they already understand.
 
 ### Performance is DX
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -257,7 +257,7 @@ testDetours(graph);
 // Fails: Trail "entity.show" has detour target "entity.search" which does not exist in the topo
 ```
 
-## `scenario(name, app, steps)`
+## `scenario(name, graph, steps)`
 
 Multi-step journey testing for flows that span multiple trail invocations. Scenarios live in test files alongside `testAll` — they test how trails compose, not what individual trails do.
 
@@ -352,7 +352,7 @@ Execute CLI commands in-process and capture stdout/stderr:
 ```typescript
 import { createCliHarness } from '@ontrails/testing';
 
-const harness = createCliHarness({ graph });
+const harness = createCliHarness({ app: graph });
 const result = await harness.run('entity show --name Alpha --output json');
 
 expect(result.exitCode).toBe(0);
@@ -366,7 +366,7 @@ Invoke MCP tools directly without transport:
 ```typescript
 import { createMcpHarness } from '@ontrails/testing';
 
-const harness = createMcpHarness({ graph });
+const harness = createMcpHarness({ app: graph });
 const result = await harness.callTool('myapp_entity_show', { name: 'Alpha' });
 
 expect(result.isError).toBe(false);

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,7 +4,7 @@ Trails takes a contract-driven approach to testing. Write examples for agent flu
 
 ## The Core Idea
 
-When you add `examples` to a trail, you are writing both agent documentation and a test suite. `testExamples(app)` runs every example as an assertion. No separate test files for the happy path.
+When you add `examples` to a trail, you are writing both agent documentation and a test suite. `testExamples(graph)` runs every example as an assertion. No separate test files for the happy path.
 
 ```typescript
 const search = trail('search', {
@@ -31,7 +31,7 @@ Those examples serve six consumers at once:
 
 | Consumer               | What it does                            |
 | ---------------------- | --------------------------------------- |
-| `testExamples(app)` | Runs every example as a test            |
+| `testExamples(graph)` | Runs every example as a test            |
 | Agents (via MCP)       | Learns input/result shapes by example   |
 | Agents (via survey)    | Sees what the trail does with real data |
 | Guide                  | Generates usage documentation           |
@@ -48,15 +48,15 @@ Red -> Green -> Refactor, with examples as the starting point:
 4. **Refactor** while tests stay green
 5. **Add edge-case tests** with `testTrail()` for scenarios that should not appear in agent-facing examples
 
-## `testAll(app)`
+## `testAll(graph)`
 
 One line runs the full governance suite -- structural validation, example execution, contract checks, and detour verification:
 
 ```typescript
 import { testAll } from '@ontrails/testing';
-import { app } from '../app';
+import { graph } from '../app';
 
-testAll(app);
+testAll(graph);
 ```
 
 When trails declare resources, the testing helpers respect them in two ways:
@@ -67,17 +67,17 @@ When trails declare resources, the testing helpers respect them in two ways:
 ```typescript
 import { resource, Result } from '@ontrails/core';
 import { testAll } from '@ontrails/testing';
-import { app } from '../app';
+import { graph } from '../app';
 
 const db = resource('db.main', {
   create: () => Result.ok(connectToDatabase()),
   mock: () => createInMemoryDb(),
 });
 
-// `db` must be part of `app`'s topo for auto-resolution to work.
-testAll(app); // auto-resolves db.main from db.mock()
+// `db` must be part of `graph`'s topo for auto-resolution to work.
+testAll(graph); // auto-resolves db.main from db.mock()
 
-testAll(app, () => ({
+testAll(graph, () => ({
   resources: { 'db.main': createInMemoryDb() },
 }));
 ```
@@ -93,15 +93,15 @@ Generates a `governance` describe block containing:
 
 For most apps, `testAll` is the only test call you need. Reach for the individual helpers below when you need finer control.
 
-## `testExamples(app)`
+## `testExamples(graph)`
 
 One line tests the entire app:
 
 ```typescript
 import { testExamples } from '@ontrails/testing';
-import { app } from '../app';
+import { graph } from '../app';
 
-testExamples(app);
+testExamples(graph);
 ```
 
 For each trail with examples, generates a `describe` block with individual `test` calls:
@@ -233,27 +233,27 @@ testTrail(onboardTrail, [
 ]);
 ```
 
-## `testContracts(app)`
+## `testContracts(graph)`
 
 Catches implementation-schema drift. Runs every example through the implementation, then validates the result against the trail's `output` schema. Reports detailed Zod errors on mismatch.
 
 ```typescript
 import { testContracts } from '@ontrails/testing';
 
-testContracts(app);
+testContracts(graph);
 // Fails if any implementation returns data that doesn't match its declared output schema
 ```
 
 TypeScript checks types at compile time, but the implementation could return `{ name: "foo" }` when the output schema says `{ title: string }`. `testContracts` catches this at runtime.
 
-## `testDetours(app)`
+## `testDetours(graph)`
 
 Structural validation. Verifies every detour target trail exists in the topo. No implementation execution needed.
 
 ```typescript
 import { testDetours } from '@ontrails/testing';
 
-testDetours(app);
+testDetours(graph);
 // Fails: Trail "entity.show" has detour target "entity.search" which does not exist in the topo
 ```
 
@@ -264,7 +264,7 @@ Multi-step journey testing for flows that span multiple trail invocations. Scena
 ```typescript
 import { ref, scenario } from '@ontrails/testing';
 
-scenario('Fork flow', app, [
+scenario('Fork flow', graph, [
   {
     cross: createGist,
     input: { description: 'Original', content: '# Hello' },
@@ -321,7 +321,7 @@ const cross = createCrossContext({
 });
 
 const ctx = { ...createTestContext(), cross };
-const result = await onboardTrail.trailhead({ name: 'Delta' }, ctx);
+const result = await onboardTrail.blaze({ name: 'Delta' }, ctx);
 
 expect(result.isOk()).toBe(true);
 ```
@@ -343,7 +343,7 @@ logger.entries; // all captured records
 logger.clear(); // reset
 ```
 
-## Trailhead Harnesses
+## Surface Harnesses
 
 ### CLI Harness
 
@@ -352,7 +352,7 @@ Execute CLI commands in-process and capture stdout/stderr:
 ```typescript
 import { createCliHarness } from '@ontrails/testing';
 
-const harness = createCliHarness({ app });
+const harness = createCliHarness({ graph });
 const result = await harness.run('entity show --name Alpha --output json');
 
 expect(result.exitCode).toBe(0);
@@ -366,7 +366,7 @@ Invoke MCP tools directly without transport:
 ```typescript
 import { createMcpHarness } from '@ontrails/testing';
 
-const harness = createMcpHarness({ app });
+const harness = createMcpHarness({ graph });
 const result = await harness.callTool('myapp_entity_show', { name: 'Alpha' });
 
 expect(result.isError).toBe(false);
@@ -374,7 +374,7 @@ expect(result.isError).toBe(false);
 
 ## Testing with Infrastructure Resources
 
-The config, permits, and tracing packages each provide test-friendly primitives that work with `testAll(app)` and `testExamples(app)` without external dependencies.
+The config, permits, and tracing packages each provide test-friendly primitives that work with `testAll(graph)` and `testExamples(graph)` without external dependencies.
 
 **Config test profile.** Use `defineConfig()` with a `test` profile that uses safe defaults (port 0, debug enabled, in-memory stores). When the `TRAILS_ENV` environment variable is set to `test`, the test profile is selected automatically during resolution. Services with `config` schemas receive the test profile values through `svc.config`.
 
@@ -410,7 +410,7 @@ src/
     entity.ts          # Trail definitions with examples
     search.ts
   __tests__/
-    governance.test.ts # testAll(app) -- full governance suite
+    governance.test.ts # testAll(graph) -- full governance suite
     entity.test.ts     # testTrail(show, [...]) -- edge cases
     cli.test.ts        # CLI harness integration tests
     mcp.test.ts        # MCP harness integration tests

--- a/docs/topo-store-reference.md
+++ b/docs/topo-store-reference.md
@@ -4,50 +4,40 @@ Schema definitions, query patterns, and programmatic API for the topo store. For
 
 ## SQLite Schema
 
-### `topo_saves`
+### `topo_snapshots`
 
-Every topo snapshot.
+Every topo snapshot. Pinned snapshots have a non-null `pinned_as` name.
 
 ```sql
-CREATE TABLE topo_saves (
+CREATE TABLE topo_snapshots (
   id TEXT PRIMARY KEY,
   git_sha TEXT,
-  git_dirty INTEGER NOT NULL,
-  trail_count INTEGER NOT NULL,
-  signal_count INTEGER NOT NULL,
-  resource_count INTEGER NOT NULL,
-  created_at TEXT NOT NULL
-);
-```
-
-### `topo_pins`
-
-Named references to important saves.
-
-```sql
-CREATE TABLE topo_pins (
-  name TEXT PRIMARY KEY,
-  save_id TEXT NOT NULL,
+  git_dirty INTEGER NOT NULL DEFAULT 0,
+  trail_count INTEGER NOT NULL DEFAULT 0,
+  signal_count INTEGER NOT NULL DEFAULT 0,
+  resource_count INTEGER NOT NULL DEFAULT 0,
+  pinned_as TEXT,
   created_at TEXT NOT NULL
 );
 ```
 
 ### `topo_trails`
 
-Trail definitions for each save.
+Trail definitions for each snapshot.
 
 ```sql
 CREATE TABLE topo_trails (
   id TEXT NOT NULL,
   intent TEXT,
-  idempotent INTEGER NOT NULL,
-  has_output INTEGER NOT NULL,
-  has_examples INTEGER NOT NULL,
-  example_count INTEGER NOT NULL,
+  idempotent INTEGER NOT NULL DEFAULT 0,
+  has_output INTEGER NOT NULL DEFAULT 0,
+  has_examples INTEGER NOT NULL DEFAULT 0,
+  example_count INTEGER NOT NULL DEFAULT 0,
   description TEXT,
   meta TEXT,
-  save_id TEXT NOT NULL,
-  PRIMARY KEY (id, save_id)
+  snapshot_id TEXT NOT NULL,
+  PRIMARY KEY (id, snapshot_id),
+  FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
 );
 ```
 
@@ -59,8 +49,9 @@ Trail composition graph.
 CREATE TABLE topo_crossings (
   source_id TEXT NOT NULL,
   target_id TEXT NOT NULL,
-  save_id TEXT NOT NULL,
-  PRIMARY KEY (source_id, target_id, save_id)
+  snapshot_id TEXT NOT NULL,
+  PRIMARY KEY (source_id, target_id, snapshot_id),
+  FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
 );
 ```
 
@@ -71,10 +62,11 @@ Resource definitions. Renamed from `topo_provisions` per ADR-0023.
 ```sql
 CREATE TABLE topo_resources (
   id TEXT NOT NULL,
-  has_mock INTEGER NOT NULL,
-  has_health INTEGER NOT NULL,
-  save_id TEXT NOT NULL,
-  PRIMARY KEY (id, save_id)
+  has_mock INTEGER NOT NULL DEFAULT 0,
+  has_health INTEGER NOT NULL DEFAULT 0,
+  snapshot_id TEXT NOT NULL,
+  PRIMARY KEY (id, snapshot_id),
+  FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
 );
 ```
 
@@ -86,8 +78,9 @@ Which resources each trail declares. Renamed from `topo_trail_provisions` per AD
 CREATE TABLE topo_trail_resources (
   trail_id TEXT NOT NULL,
   resource_id TEXT NOT NULL,
-  save_id TEXT NOT NULL,
-  PRIMARY KEY (trail_id, resource_id, save_id)
+  snapshot_id TEXT NOT NULL,
+  PRIMARY KEY (trail_id, resource_id, snapshot_id),
+  FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
 );
 ```
 
@@ -99,8 +92,9 @@ Signal definitions.
 CREATE TABLE topo_signals (
   id TEXT NOT NULL,
   description TEXT,
-  save_id TEXT NOT NULL,
-  PRIMARY KEY (id, save_id)
+  snapshot_id TEXT NOT NULL,
+  PRIMARY KEY (id, snapshot_id),
+  FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
 );
 ```
 
@@ -112,8 +106,9 @@ Which signals each trail can emit.
 CREATE TABLE topo_trail_signals (
   trail_id TEXT NOT NULL,
   signal_id TEXT NOT NULL,
-  save_id TEXT NOT NULL,
-  PRIMARY KEY (trail_id, signal_id, save_id)
+  snapshot_id TEXT NOT NULL,
+  PRIMARY KEY (trail_id, signal_id, snapshot_id),
+  FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
 );
 ```
 
@@ -131,35 +126,38 @@ CREATE TABLE topo_examples (
   input TEXT NOT NULL,
   expected TEXT,
   error TEXT,
-  save_id TEXT NOT NULL
+  snapshot_id TEXT NOT NULL,
+  FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
 );
 ```
 
-### `topo_trailheads`
+### `topo_surfaces`
 
-Which trailheads expose which trails.
+Which surfaces expose which trails.
 
 ```sql
-CREATE TABLE topo_trailheads (
+CREATE TABLE topo_surfaces (
   trail_id TEXT NOT NULL,
-  trailhead TEXT NOT NULL,
+  surface TEXT NOT NULL,
   derived_name TEXT NOT NULL,
   method TEXT,
-  save_id TEXT NOT NULL,
-  PRIMARY KEY (trail_id, trailhead, save_id)
+  snapshot_id TEXT NOT NULL,
+  PRIMARY KEY (trail_id, surface, snapshot_id),
+  FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
 );
 ```
 
 ### `topo_exports`
 
-Serialized trailhead maps and lockfiles.
+Serialized surface maps and lockfiles.
 
 ```sql
 CREATE TABLE topo_exports (
-  save_id TEXT PRIMARY KEY,
-  trailhead_map TEXT NOT NULL,
-  trailhead_hash TEXT NOT NULL,
-  serialized_lock TEXT NOT NULL
+  snapshot_id TEXT PRIMARY KEY,
+  surface_map TEXT NOT NULL,
+  surface_hash TEXT NOT NULL,
+  serialized_lock TEXT NOT NULL,
+  FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
 );
 ```
 
@@ -174,8 +172,9 @@ CREATE TABLE topo_schemas (
   schema_kind TEXT NOT NULL,
   zod_hash TEXT NOT NULL,
   json_schema TEXT NOT NULL,
-  save_id TEXT NOT NULL,
-  PRIMARY KEY (owner_id, owner_kind, schema_kind, save_id)
+  snapshot_id TEXT NOT NULL,
+  PRIMARY KEY (owner_id, owner_kind, schema_kind, snapshot_id),
+  FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
 );
 ```
 
@@ -185,7 +184,7 @@ CREATE TABLE topo_schemas (
 
 ```sql
 SELECT id, intent, description FROM topo_trails
-WHERE save_id = ? AND intent = ?
+WHERE snapshot_id = ? AND intent = ?
 ORDER BY id ASC
 ```
 
@@ -194,30 +193,30 @@ ORDER BY id ASC
 ```sql
 SELECT DISTINCT t.id, t.intent
 FROM topo_trails t
-JOIN topo_trail_resources tp ON t.id = tp.trail_id AND t.save_id = tp.save_id
-WHERE t.save_id = ? AND tp.resource_id = ?
+JOIN topo_trail_resources tp ON t.id = tp.trail_id AND t.snapshot_id = tp.snapshot_id
+WHERE t.snapshot_id = ? AND tp.resource_id = ?
 ```
 
 ### Find incoming callers
 
 ```sql
 SELECT source_id FROM topo_crossings
-WHERE save_id = ? AND target_id = ?
+WHERE snapshot_id = ? AND target_id = ?
 ```
 
 ### Trails without output schemas
 
 ```sql
 SELECT id, intent FROM topo_trails
-WHERE save_id = ? AND has_output = 0
+WHERE snapshot_id = ? AND has_output = 0
 ```
 
-### Compare two saves (trails added)
+### Compare two snapshots (trails added)
 
 ```sql
-SELECT id FROM topo_trails WHERE save_id = ?
+SELECT id FROM topo_trails WHERE snapshot_id = ?
 EXCEPT
-SELECT id FROM topo_trails WHERE save_id = ?
+SELECT id FROM topo_trails WHERE snapshot_id = ?
 ```
 
 ### Crossing closure (recursive)
@@ -228,7 +227,7 @@ WITH RECURSIVE closure(id) AS (
   UNION
   SELECT c.target_id FROM topo_crossings c
   JOIN closure cl ON c.source_id = cl.id
-  WHERE c.save_id = ?
+  WHERE c.snapshot_id = ?
 )
 SELECT id FROM closure
 ```
@@ -245,8 +244,8 @@ import { createTopoStore } from '@ontrails/core';
 const store = createTopoStore({ rootDir: '/path/to/workspace' });
 store.trails.list({ intent: 'write' });
 store.resources.get('db.main');
-store.pins.list();
-store.saves.latest();
+store.snapshots.list({ pinned: true });
+store.snapshots.latest();
 ```
 
 ### `createMockTopoStore(seed?)`
@@ -259,7 +258,6 @@ import { createMockTopoStore } from '@ontrails/core';
 const mock = createMockTopoStore({
   trails: [{ id: 'auth.login', intent: 'write', hasOutput: true, ... }],
   resources: [{ id: 'db.main', hasMock: true, ... }],
-  pins: [{ name: 'baseline', saveId: 'save-1', ... }],
 });
 ```
 
@@ -274,25 +272,25 @@ trail('warden.check', {
   resources: [topoStore],
   blaze: async (_input, ctx) => {
     const store = topoStore.from(ctx);
-    // store.trails, store.resources, store.pins, store.saves, store.query()
+    // store.trails, store.resources, store.snapshots, store.query()
   },
 });
 ```
 
 ### `TopoStoreRef`
 
-Reference type for querying by save or pin:
+Reference type for querying by snapshot or pin:
 
 ```typescript
 interface TopoStoreRef {
   readonly pin?: string;
-  readonly saveId?: string;
+  readonly snapshotId?: string;
 }
 ```
 
-- `{ pin: 'v1.0' }` — look up save by pin name
-- `{ saveId: 'uuid' }` — use exact save ID
-- `{}` — use the latest save
+- `{ pin: 'v1.0' }` — look up snapshot by pin name
+- `{ snapshotId: 'uuid' }` — use exact snapshot ID
+- `{}` — use the latest snapshot
 
 ## Record Types
 
@@ -310,7 +308,7 @@ interface TopoStoreRef {
   exampleCount: number;
   description: string | null;
   meta: Readonly<Record<string, unknown>> | null;
-  saveId: string;
+  snapshotId: string;
 }
 ```
 
@@ -329,7 +327,7 @@ Extends trail record with `crosses`, `detours`, `resources`, and `examples` arra
   description: string | null;
   hasMock: boolean;
   hasHealth: boolean;
-  saveId: string;
+  snapshotId: string;
   usedBy: readonly string[];
 }
 ```

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -16,12 +16,12 @@ Trails creates a `.trails/` directory in your workspace root on first use:
 ├── generated/             # Generated artifacts (gitignored)
 ├── trails.db              # SQLite database (topology store)
 ├── trails.lock            # Lockfile (text, git-tracked)
-└── _trailhead.json        # Full trailhead map (generated on export)
+└── _surface.json          # Full surface map (generated on export)
 ```
 
 - **`trails.db`** — SQLite database containing all topo saves, pins, and schema cache. Not git-tracked.
 - **`trails.lock`** — Committed lockfile. Text format, git-tracked. This is your contract's current state for CI.
-- **`_trailhead.json`** — Full trailhead map with all metadata, generated on export.
+- **`_surface.json`** — Full surface map with all metadata, generated on export.
 
 ## What trails.db contains
 
@@ -76,7 +76,7 @@ trails topo history --limit 20
 
 ### `trails topo export`
 
-Export the current topo to `.trails/trails.lock` and `.trails/_trailhead.json`.
+Export the current topo to `.trails/trails.lock` and `.trails/_surface.json`.
 
 ```bash
 trails topo export

--- a/docs/why-trails.md
+++ b/docs/why-trails.md
@@ -6,9 +6,9 @@
 
 When you define a trail, you author the things only you know: the input schema, the output schema, the implementation, and the examples that specify behavior. Everything else — CLI flags, MCP tool definitions, test assertions, error codes, command names — is derived from what you already wrote. If the derivation is wrong for your case, you override it.
 
-This is DRY applied not just to code, but to information. Frameworks have always been good at eliminating duplicate code. Trails extends that principle to duplicate authorship — across the entire trailhead area of a project, from the implementation to the CLI to the MCP tools to the tests to the agent documentation.
+This is DRY applied not just to code, but to information. Frameworks have always been good at eliminating duplicate code. Trails extends that principle to duplicate authorship — across the entire surface area of a project, from the implementation to the CLI to the MCP tools to the tests to the agent documentation.
 
-Trails is Bun-native — the framework uses Bun APIs throughout for I/O, hashing, discovery, and storage. But the trailheads it produces are universally consumable: CLI binaries, MCP servers, and HTTP endpoints work with any runtime on the consuming side.
+Trails is Bun-native — the framework uses Bun APIs throughout for I/O, hashing, discovery, and storage. But the surfaces it produces are universally consumable: CLI binaries, MCP servers, and HTTP endpoints work with any runtime on the consuming side.
 
 ---
 
@@ -20,7 +20,7 @@ An agent that builds `users` routes on Monday and `billing` routes on Thursday p
 
 The problem isn't speed. The problem is that every decision is freeform. Parameter names, error shapes, validation placement, response formatting — an agent using Express or Fastify makes all of these choices from scratch, every time, in every file.
 
-Trails eliminates the freeform decisions. An agent writing a trail can't use different parameter names across CLI and MCP — there's one Zod schema. It can't return unstructured errors — `Result<T, Error>` is the only return path. It can't forget input validation — Zod runs at the boundary for every trailhead, every time.
+Trails eliminates the freeform decisions. An agent writing a trail can't use different parameter names across CLI and MCP — there's one Zod schema. It can't return unstructured errors — `Result<T, Error>` is the only return path. It can't forget input validation — Zod runs at the boundary for every surface, every time.
 
 These aren't lint rules. They're structural constraints. The framework makes inconsistency require more effort than consistency. That's the principle we call: **drift is structurally harder than alignment.**
 
@@ -57,7 +57,7 @@ export const show = trail('entity.show', {
 });
 ```
 
-Collect trails into an app with `topo()`. Open it on any trailhead with `surface()`:
+Collect trails into an app with `topo()`. Open it on any surface with `surface()`:
 
 ```typescript
 const graph = topo('myapp', entityModule, searchModule);
@@ -71,9 +71,9 @@ import { surface as mcpSurface } from '@ontrails/mcp';
 await mcpSurface(graph);
 ```
 
-One definition. Every trailhead. The rest is derived.
+One definition. Every surface. The rest is derived.
 
-Pure trails can return `Result` directly. Trails with `crosses` and I/O-bound trails can stay `async`. Core normalizes both forms to one awaitable runtime shape before trailheads and layers execute them.
+Pure trails can return `Result` directly. Trails with `crosses` and I/O-bound trails can stay `async`. Core normalizes both forms to one awaitable runtime shape before surfaces and layers execute them.
 
 ---
 
@@ -81,7 +81,7 @@ Pure trails can return `Result` directly. Trails with `crosses` and I/O-bound tr
 
 Pure trail functions are great until they need a database. The typical escape hatch — constructing clients inline or importing singletons — couples implementations to concrete infrastructure and makes testing painful.
 
-Trails solves this with `resource()` declarations. A resource defines its factory, a `mock` factory for tests, and an optional `dispose` hook for cleanup. Trails declare their dependencies with `resources: [...]` and access them through `db.from(ctx)`. The framework manages the lifecycle, trailheads can inspect the dependency graph, and `testAll(graph)` resolves mocks automatically.
+Trails solves this with `resource()` declarations. A resource defines its factory, a `mock` factory for tests, and an optional `dispose` hook for cleanup. Trails declare their dependencies with `resources: [...]` and access them through `db.from(ctx)`. The framework manages the lifecycle, surfaces can inspect the dependency graph, and `testAll(graph)` resolves mocks automatically.
 
 The result: implementations stay pure (input in, `Result` out), infrastructure is declared rather than imported, and the entire app remains testable without configuration.
 
@@ -96,7 +96,7 @@ Every piece of information in a Trails app has a clear ownership model. Six cate
 - **Enforced:** Constrained by the type system — output schemas bound the return type, `Result<T, Error>` eliminates throw/catch, `TrailContext` scopes what the implementation can access. The compiler makes non-compliance an error.
 - **Inferred:** Detected by static analysis, best-effort — which trails a trail crosses (from `ctx.cross()` calls), error types returned (from `Result.err()` patterns). Warden verifies these. Useful for governance, not guaranteed.
 - **Observed:** Learned from runtime (future) — error distributions, latency profiles, resource usage patterns from the tracing system. Observations close the loop between declared intent and actual behavior.
-- **Overridden:** When derivation doesn't fit — any derived value can be explicitly set when the default is wrong. Overrides are escape hatches, visible in the trailhead map. If you're overriding everything, the derivation rules are wrong.
+- **Overridden:** When derivation doesn't fit — any derived value can be explicitly set when the default is wrong. Overrides are escape hatches, visible in the surface map. If you're overriding everything, the derivation rules are wrong.
 
 The design heuristic: if the developer has to author information the framework already has, that's a framework bug. Derive it. If it can't be derived, it earns a place on the trail spec. If it can be derived but might be wrong sometimes, derive it with an override.
 
@@ -111,7 +111,7 @@ Trails makes a different tradeoff. The trail declaration creates a bounded envir
 - **`output: schema`** constrains the return type. The implementation can't return data the contract doesn't describe.
 - **`Result<T, Error>`** eliminates throw/catch. Every code path returns a typed result.
 - **`examples`** specify concrete inputs plus expected results or error classes. `testExamples(graph)` runs them as assertions. One authoring act — three purposes: specification for builders, documentation for consumers, test coverage for CI.
-- **`intent` / `idempotent`** are behavioral assertions that trailheads honor. `intent: 'read'` means no confirmation prompts on CLI, `readOnlyHint` on MCP, GET on HTTP. These aren't suggestions — they're projections.
+- **`intent` / `idempotent`** are behavioral assertions that surfaces honor. `intent: 'read'` means no confirmation prompts on CLI, `readOnlyHint` on MCP, GET on HTTP. These aren't suggestions — they're projections.
 
 The implementation satisfies the specification. The framework enforces the boundaries. An agent building a trail writes the irreducible information — schema, examples, logic — and the framework handles the rest.
 
@@ -145,11 +145,11 @@ One write, three reads. If someone changes the business rule, they change the ex
 
 ## Where Trails Fits
 
-Great tools already exist for each trailhead. tRPC, Hono, and Fastify are excellent for HTTP. Commander and oclif are battle-tested for CLIs. FastMCP and the official SDK make MCP server development straightforward. NestJS spans multiple transports with a mature ecosystem.
+Great tools already exist for each surface. tRPC, Hono, and Fastify are excellent for HTTP. Commander and oclif are battle-tested for CLIs. FastMCP and the official SDK make MCP server development straightforward. NestJS spans multiple transports with a mature ecosystem.
 
-Trails doesn't try to replace any of them. It occupies a different layer: the **contract layer** that sits above individual trailhead implementations. A trail definition captures the schema, examples, error types, intent and metadata, and composition graph in one place. Trailhead connectors — CLI, MCP, HTTP, WebSocket — project that contract into whatever runtime format the trailhead needs.
+Trails doesn't try to replace any of them. It occupies a different layer: the **contract layer** that sits above individual surface implementations. A trail definition captures the schema, examples, error types, intent and metadata, and composition graph in one place. Surface connectors — CLI, MCP, HTTP, WebSocket — project that contract into whatever runtime format the surface needs.
 
-The value isn't in being better at any single trailhead. It's in making the contract the source of truth so that every trailhead stays consistent with it — not because anyone was careful, but because the framework derives each trailhead from the same definition.
+The value isn't in being better at any single surface. It's in making the contract the source of truth so that every surface stays consistent with it — not because anyone was careful, but because the framework derives each surface from the same definition.
 
 ---
 
@@ -176,7 +176,7 @@ The answers became the principles: author what's new, derive what's known, overr
 
 ## What's Next
 
-The v1 implementation delivers the foundation: Result types, error taxonomy, trail and signal definitions, CLI and MCP trailheads, contract-driven testing, schema governance, and the warden. These establish the contract layer and prove the core loop — define once, trailhead everywhere.
+The v1 implementation delivers the foundation: Result types, error taxonomy, trail and signal definitions, CLI and MCP surfaces, contract-driven testing, schema governance, and the warden. These establish the contract layer and prove the core loop — define once, surface everywhere.
 
 The architecture points toward capabilities that follow naturally — resource capability shaping, derived dependency graphs, cross-app contract negotiation, implementation synthesis from examples. Each follows from the same principle: if the information exists in the system, don't ask the developer to restate it.
 

--- a/docs/why-trails.md
+++ b/docs/why-trails.md
@@ -170,7 +170,7 @@ The questions that became Trails:
 - How do we make agents consistent in their work without relying on memory they don't have?
 - What if the contract wasn't documentation about the implementation, but the specification that bounds it?
 
-The answers became the principles: author what's new, derive what's known, override what's wrong. Make drift structurally harder than alignment. The trail is the product, not the trailhead.
+The answers became the principles: author what's new, derive what's known, override what's wrong. Make drift structurally harder than alignment. The trail is the product, not the surface.
 
 ---
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trails",
   "version": "0.2.0",
-  "description": "Build with the Trails framework — contract-first trails, trailheads, testing, and governance for agent-assisted development.",
+  "description": "Build with the Trails framework — contract-first trails, surfaces, testing, and governance for agent-assisted development.",
   "author": {
     "name": "Outfitter",
     "url": "https://github.com/outfitter-dev"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Trails Plugin for Claude Code
 
-Build with the [Trails](https://github.com/outfitter-dev/trails) framework — contract-first trails, trailheads, testing, and governance for agent-assisted development.
+Build with the [Trails](https://github.com/outfitter-dev/trails) framework — contract-first trails, surfaces, testing, and governance for agent-assisted development.
 
 ## Installation
 
@@ -13,7 +13,7 @@ claude plugin install trails@trails
 
 ### Skill
 
-**`trails`** — The complete guide to building with Trails. Covers trail creation, resources, trailheads, testing, debugging, migration, and governance in one skill with 11 reference files for deep dives.
+**`trails`** — The complete guide to building with Trails. Covers trail creation, resources, surfaces, testing, debugging, migration, and governance in one skill with 11 reference files for deep dives.
 
 ### Agent
 
@@ -23,8 +23,8 @@ claude plugin install trails@trails
 
 ### Rules
 
-- **lexicon** — Enforces Trails-branded terms (trail, trailhead, topo, blaze, cross, resource, signal, layer, tracing)
-- **patterns** — Core coding patterns (Result over throw, trailhead-agnostic implementations)
+- **lexicon** — Enforces Trails-branded terms (trail, surface, topo, blaze, cross, resource, signal, layer, tracing)
+- **patterns** — Core coding patterns (Result over throw, surface-agnostic implementations)
 
 ## License
 

--- a/plugin/agents/trail-engineer.md
+++ b/plugin/agents/trail-engineer.md
@@ -57,18 +57,18 @@ Write examples on the trail definition — they ARE the tests. Then:
 bun test
 ```
 
-If `testAll(app)` doesn't exist yet, create it:
+If `testAll(graph)` doesn't exist yet, create it:
 
 ```typescript
 import { testAll } from '@ontrails/testing';
-import { app } from '../app';
-testAll(app);
+import { graph } from '../app';
+testAll(graph);
 ```
 
-Resources with `mock` factories are resolved automatically by `testAll(app)` -- no manual wiring needed. Override specific resources when tests need controlled behavior:
+Resources with `mock` factories are resolved automatically by `testAll(graph)` -- no manual wiring needed. Override specific resources when tests need controlled behavior:
 
 ```typescript
-testAll(app, () => ({
+testAll(graph, () => ({
   resources: { 'db.main': createSpecialTestDb() },
 }));
 ```

--- a/plugin/agents/trail-engineer.md
+++ b/plugin/agents/trail-engineer.md
@@ -1,13 +1,13 @@
 ---
 name: trail-engineer
-description: Build features with the Trails framework — design contracts, implement trails, wire trailheads, test, and debug. Use when building a Trails app, implementing features with @ontrails/*, or when "build with trails", "implement trail", "add a feature" are mentioned.
+description: Build features with the Trails framework — design contracts, implement trails, open surfaces, test, and debug. Use when building a Trails app, implementing features with @ontrails/*, or when "build with trails", "implement trail", "add a feature" are mentioned.
 color: green
 skills:
   - trails
 memory: user
 ---
 
-You are a Trails engineer. You build features using the Trails framework — contract-first, then implement, then verify. The `trails` skill is loaded with your full reference material — lexicon, patterns, error taxonomy, testing, trailheads.
+You are a Trails engineer. You build features using the Trails framework — contract-first, then implement, then verify. The `trails` skill is loaded with your full reference material — lexicon, patterns, error taxonomy, testing, surfaces.
 
 ## Workflow
 
@@ -36,7 +36,7 @@ If the feature is complex, sketch the contract and get user alignment before imp
 ### 3. Implement
 
 - Return `Result`, never throw
-- Keep implementations trailhead-agnostic
+- Keep implementations surface-agnostic
 - Declare resources on the trail spec with `resources: [db]` and access via `db.from(ctx)` -- never construct dependencies inline
 - Use `ctx.cross()` for composition, never `.run()` directly
 - Use `ctx.logger` instead of `console.log`
@@ -115,6 +115,6 @@ When tests fail or behavior is unexpected:
 
 - Don't skip the contract. Design the trail before implementing it.
 - Don't throw in implementations. Return `Result.err()`.
-- Don't import trailhead types into trail logic. No `Request`, `Response`, `McpSession`.
+- Don't import surface types into trail logic. No `Request`, `Response`, `McpSession`.
 - Don't call `.blaze()` directly. Use `ctx.cross()`.
 - Don't skip warden. Run it before marking work complete.

--- a/plugin/rules/lexicon.md
+++ b/plugin/rules/lexicon.md
@@ -9,9 +9,9 @@ Use Trails-branded terms consistently. These are non-negotiable in code, docs, a
 | `trail` | handler, action, endpoint, route |
 | `cross` | workflow, pipeline, chain, route (for composition) |
 | `topo` | registry, collection, manifest |
-| `blaze` | serve, mount, start, wire up |
+| `blaze` | implementation function — input to Result |
 | `cross` | call, invoke |
-| `trailhead` | transport, interface |
+| `surface` | serve, mount, start, wire up |
 | `resource` | provider, dependency, service |
 | `signal` | event, notification, message |
 | `layer` | gate, middleware |
@@ -26,7 +26,7 @@ Use Trails-branded terms consistently. These are non-negotiable in code, docs, a
 ## When Writing
 
 - The framework is "Trails" (capitalized). The primitive is "trail" (lowercase).
-- Lead with code: `trail()` -> `crosses` -> `resource()` -> `trailhead()` before explaining.
+- Lead with code: `trail()` -> `crosses` -> `resource()` -> `surface()` before explaining.
 - Do not overextend the metaphor. "Define a trail" is good. "Blaze a path through the wilderness" is not.
 - Standard terms stay standard: `config`, `Result`, `Error`.
 - `resource` is a branded term: `resource()` defines a typed infrastructure dependency. Use `resources: [...]` on trail specs to declare dependencies. Do not use "resource" for generic helpers or utility classes.

--- a/plugin/rules/lexicon.md
+++ b/plugin/rules/lexicon.md
@@ -7,10 +7,9 @@ Use Trails-branded terms consistently. These are non-negotiable in code, docs, a
 | Use this | Not this |
 |----------|----------|
 | `trail` | handler, action, endpoint, route |
-| `cross` | workflow, pipeline, chain, route (for composition) |
+| `cross` | call, invoke, workflow, pipeline, chain, route (for composition) |
 | `topo` | registry, collection, manifest |
-| `blaze` | implementation function — input to Result |
-| `cross` | call, invoke |
+| `blaze` | handler, impl, run, execute |
 | `surface` | serve, mount, start, wire up |
 | `resource` | provider, dependency, service |
 | `signal` | event, notification, message |

--- a/plugin/rules/patterns.md
+++ b/plugin/rules/patterns.md
@@ -1,15 +1,15 @@
 # Trails Code Patterns
 
-## Run Functions
+## Blaze Functions
 
 - Return `Result`, never throw. Use `Result.ok(value)` and `Result.err(new XError(...))`.
-- Keep run functions surface-agnostic. No `process.exit()`, no `console.log()`, no `Request`/`Response`.
-- Run functions receive `(input, ctx)` — validated input and `TrailContext`.
+- Keep blaze functions surface-agnostic. No `process.exit()`, no `console.log()`, no `Request`/`Response`.
+- Blaze functions receive `(input, ctx)` — validated input and `TrailContext`.
 - Sync authoring is fine for pure work. The runtime normalizes to async.
 
 ## Composition
 
-- Trails with `crosses` compose through `ctx.cross()`, never by calling `.run()` directly.
+- Trails with `crosses` compose through `ctx.cross()`, never by calling `.blaze()` directly.
 - Declare `crosses` on trails that compose others. The warden verifies these match actual `ctx.cross()` calls.
 - Propagate errors: `if (result.isErr()) return result;`
 

--- a/plugin/rules/patterns.md
+++ b/plugin/rules/patterns.md
@@ -3,7 +3,7 @@
 ## Run Functions
 
 - Return `Result`, never throw. Use `Result.ok(value)` and `Result.err(new XError(...))`.
-- Keep run functions trailhead-agnostic. No `process.exit()`, no `console.log()`, no `Request`/`Response`.
+- Keep run functions surface-agnostic. No `process.exit()`, no `console.log()`, no `Request`/`Response`.
 - Run functions receive `(input, ctx)` — validated input and `TrailContext`.
 - Sync authoring is fine for pure work. The runtime normalizes to async.
 
@@ -50,7 +50,7 @@ const search = trail('search', {
 });
 ```
 
-Resource factories receive `ResourceContext` (env, cwd, workspaceRoot) — not the full `TrailContext`. Keep them trailhead-agnostic.
+Resource factories receive `ResourceContext` (env, cwd, workspaceRoot) — not the full `TrailContext`. Keep them surface-agnostic.
 
 ## Code Shape
 

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -156,7 +156,7 @@ const search = trail('search', {
 **Test** with zero config — resources with `mock` factories auto-resolve in `testAll(graph)`. Override explicitly when needed:
 
 ```typescript
-testAll(app, () => ({ resources: { 'db.main': createSpecialTestDb() } }));
+testAll(graph, () => ({ resources: { 'db.main': createSpecialTestDb() } }));
 ```
 
 **Governance:** The warden enforces `resource-declarations` (usage matches declarations) and `resource-exists` (resource IDs resolve in the topo).
@@ -234,7 +234,7 @@ Key rules: no throw in blaze functions, no surface imports, crosses declarations
 | MCP surface docs | Tool naming, annotations, progress |
 | [testing-patterns.md](references/testing-patterns.md) | testAll, testTrail, harnesses |
 | [error-taxonomy.md](references/error-taxonomy.md) | All 13 error classes with signatures |
-| [common-pitfalls.md](references/common-pitfalls.md) | 9 anti-patterns with fixes |
+| [common-pitfalls.md](references/common-pitfalls.md) | 12 anti-patterns with fixes |
 | [migration-checklist.md](references/migration-checklist.md) | Step-by-step conversion guide |
 | [trail.md](templates/trail.md) | Annotated trail skeleton |
 | [composition.md](templates/composition.md) | Annotated composite trail skeleton |

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: trails
-description: Build with the Trails framework — define trail contracts, wire CLI/MCP trailheads, test with examples, debug errors, migrate codebases, run governance. Use when creating trails, adding trailheads, testing, debugging Trails errors, migrating to Trails, running warden, or any work involving @ontrails/* packages.
+description: Build with the Trails framework — define trail contracts, open CLI/MCP surfaces, test with examples, debug errors, migrate codebases, run governance. Use when creating trails, adding surfaces, testing, debugging Trails errors, migrating to Trails, running warden, or any work involving @ontrails/* packages.
 ---
 
 # Trails
 
-Contract-first TypeScript framework. Define a trail once with typed input, Result output, examples, and metadata — then trailhead it on CLI, MCP, HTTP, or WebSocket without drift.
+Contract-first TypeScript framework. Define a trail once with typed input, Result output, examples, and metadata — then surface it on CLI, MCP, HTTP, or WebSocket without drift.
 
 ## Quick Start
 
@@ -22,11 +22,11 @@ const greet = trail('greet', {
 // 2. Collect into topo
 const graph = topo('myapp', greetModule);
 
-// 3. Open surfaces on trailheads
+// 3. Open surfaces
 await surface(graph);        // CLI — from @ontrails/cli/commander
 // await surface(graph);     // MCP — from @ontrails/mcp
 
-// 4. Headless execution (no trailhead needed)
+// 4. Headless execution (no surface needed)
 const result = await run(graph, 'greet', { name: 'Alice' });
 
 // 5. Test
@@ -42,8 +42,10 @@ Use these terms — they are non-negotiable in Trails codebases.
 | `trail` | Unit of work (atomic or composite) | handler, action |
 | `cross` | Composition declaration and runtime verb | workflow, route |
 | `topo` | Trail collection | registry |
-| `blaze` | Open trails on a trailhead | serve, mount |
-| `trailhead` | Transport connector (CLI, MCP, HTTP) | transport |
+| `blaze` | Implementation function — input to Result | handler, impl |
+| `surface` | The boundary-owned one-liner that opens a graph | serve, mount |
+| `graph` | Local name for a topo instance | app, registry |
+| `projection` | Deterministic derivation of graph onto a surface shape | mapping |
 | `metadata` | Trail annotations | tags |
 | `warden` | Governance enforcement | linter |
 
@@ -71,7 +73,7 @@ input: z.object({
 
 ### Output Schema
 
-Required for MCP and HTTP trailheads. Define what Result.ok returns.
+Required for MCP and HTTP surfaces. Define what Result.ok returns.
 
 ### Intent and Flags
 
@@ -91,9 +93,9 @@ Each example is both documentation AND a test case:
 
 See [contract-patterns.md](references/contract-patterns.md) for detailed patterns. Copy from [trail.md](templates/trail.md) or [composition.md](templates/composition.md).
 
-## Trailheads
+## Surfaces
 
-Adding a trailhead is a `surface()` call, not an architecture change. The framework derives everything from the trail contract.
+Adding a surface is a `surface()` call, not an architecture change. The framework derives everything from the trail contract.
 
 **CLI**: Flags from Zod, subcommands from dotted IDs, exit codes from error taxonomy.
 
@@ -116,7 +118,7 @@ import { surface } from '@ontrails/hono';
 await surface(graph, { port: 3000 });
 ```
 
-See the CLI trailhead docs, the MCP trailhead docs, and the HTTP trailhead docs for derivation details.
+See the CLI surface docs, the MCP surface docs, and the HTTP surface docs for derivation details.
 
 ## Resources
 
@@ -172,7 +174,7 @@ See [contract-patterns.md](references/contract-patterns.md) for declaration patt
 
 **TDD workflow**: Define trail with examples → run tests (red) → implement (green) → refactor.
 
-Edge cases go in `testTrail(trail, scenarios)`. Use `createCrossContext()` to mock `ctx.cross` for composite trail unit tests. Trailhead integration uses `createCliHarness()` / `createMcpHarness()`.
+Edge cases go in `testTrail(trail, scenarios)`. Use `createCrossContext()` to mock `ctx.cross` for composite trail unit tests. Surface integration uses `createCliHarness()` / `createMcpHarness()`.
 
 See [testing-patterns.md](references/testing-patterns.md) for the full testing API.
 
@@ -204,7 +206,7 @@ Converting existing code to Trails:
 1. Inventory handlers (routes, CLI commands, MCP tools)
 2. Extract Zod input/output schemas
 3. Convert implementations to return Result (replace throw/console.log/process.exit)
-4. Compose into topo, blaze on trailheads
+4. Compose into topo, open surfaces
 5. Add examples, run `testAll()`
 6. Run warden for governance
 
@@ -219,7 +221,7 @@ trails warden          # Convention checks
 trails warden --drift  # Contract drift vs lock file
 ```
 
-Key rules: no throw in blaze functions, no trailhead imports, crosses declarations match ctx.cross() calls, resource declarations match db.from(ctx) / ctx.resource() calls, output schemas present, .describe() on fields.
+Key rules: no throw in blaze functions, no surface imports, crosses declarations match ctx.cross() calls, resource declarations match db.from(ctx) / ctx.resource() calls, output schemas present, .describe() on fields.
 
 ## References
 
@@ -228,8 +230,8 @@ Key rules: no throw in blaze functions, no trailhead imports, crosses declaratio
 | [getting-started.md](references/getting-started.md) | Full install-to-test walkthrough |
 | [architecture.md](references/architecture.md) | Hexagonal model, package gates, data flow |
 | [contract-patterns.md](references/contract-patterns.md) | ID naming, schema design, example authoring |
-| CLI trailhead docs | Flag derivation, output modes, exit codes |
-| MCP trailhead docs | Tool naming, annotations, progress |
+| CLI surface docs | Flag derivation, output modes, exit codes |
+| MCP surface docs | Tool naming, annotations, progress |
 | [testing-patterns.md](references/testing-patterns.md) | testAll, testTrail, harnesses |
 | [error-taxonomy.md](references/error-taxonomy.md) | All 13 error classes with signatures |
 | [common-pitfalls.md](references/common-pitfalls.md) | 9 anti-patterns with fixes |

--- a/plugin/skills/trails/examples/cli-command.md
+++ b/plugin/skills/trails/examples/cli-command.md
@@ -74,7 +74,7 @@ import { surface } from '@ontrails/cli/commander';
 import * as deploy from './trails/deploy.js';
 
 const graph = topo('myapp', deploy);
-surface(graph);
+await surface(graph);
 // myapp deploy run --service api --env staging --dry-run
 // Flags, defaults, descriptions, and validation all derived from Zod.
 ```

--- a/plugin/skills/trails/examples/express-handler.md
+++ b/plugin/skills/trails/examples/express-handler.md
@@ -1,4 +1,4 @@
-Convert Express CRUD handlers to trails that work on any trailhead.
+Convert Express CRUD handlers to trails that work on any surface.
 
 ## Before
 

--- a/plugin/skills/trails/examples/express-handler.md
+++ b/plugin/skills/trails/examples/express-handler.md
@@ -100,9 +100,9 @@ import * as project from './trails/project.js';
 import * as resources from './resources/db.js';
 
 const graph = topo('myapp', project, resources);
-surface(graph); // "myapp project show --id ..."
+await surface(graph); // "myapp project show --id ..."
 
 // mcp.ts
 import { surface } from '@ontrails/mcp';
-surface(graph); // tool: myapp_project_show, myapp_project_destroy
+await surface(graph); // tool: myapp_project_show, myapp_project_destroy
 ```

--- a/plugin/skills/trails/examples/patterns.md
+++ b/plugin/skills/trails/examples/patterns.md
@@ -27,7 +27,7 @@ console.log(JSON.stringify(result, null, 2));
 ### After
 
 ```typescript
-// The implementation returns data. The trailhead decides how to render it.
+// The implementation returns data. The surface decides how to render it.
 const result = await computeReport(input);
 return Result.ok(result);
 // CLI prints JSON, MCP returns content[], HTTP sends application/json

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -69,7 +69,7 @@ Every piece of information has a clear ownership model.
 
 | Inferred | From |
 |----------|------|
-| Which trails a trail crosses | `ctx.cross()` calls in run |
+| Which trails a trail crosses | `ctx.cross()` calls in the blaze function |
 | Error types returned | `Result.err(new XError(...))` patterns |
 | Surface map entries and hash | All of the above, canonicalized |
 
@@ -90,6 +90,7 @@ Warden uses inference to verify declarations match actual code. The surface map 
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `surface()` | `@modelcontextprotocol/sdk` |
 | `@ontrails/http` | HTTP route definitions (framework-agnostic) | None beyond core |
 | `@ontrails/hono` | Hono connector, `surface()` | `hono` |
+| `@ontrails/vite` | Vite dev server adapter | `vite` |
 
 ### Infrastructure Connectors (right side)
 
@@ -115,14 +116,18 @@ Warden uses inference to verify declarations match actual code. The surface map 
 @ontrails/core (zod)
   <- @ontrails/cli (core)
   <- @ontrails/mcp (core, @modelcontextprotocol/sdk)
-  <- @ontrails/http (core, hono peer)
+  <- @ontrails/http (core)
   <- @ontrails/config (core)
   <- @ontrails/permits (core)
   <- @ontrails/tracing (core)
   <- @ontrails/logging (core)
+  <- @ontrails/store (core)
+  <- @ontrails/drizzle (store, drizzle-orm)
   <- @ontrails/testing (core, cli, mcp, logging)
   <- @ontrails/schema (core)
      <- @ontrails/cli/commander (cli, commander)
+     <- @ontrails/hono (http, hono)
+     <- @ontrails/vite (node:stream only)
      <- @ontrails/logtape (logging)
      <- @ontrails/warden (core, schema)
 ```

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -23,10 +23,10 @@ Core defines ports. Everything on the edges is a connector.
 
 **Core principles:**
 
-- The trail is the product, not the trailhead. Trailheads are projections.
+- The trail is the product, not the surface. Surfaces are projections.
 - Drift is structurally harder than alignment — one schema, one Result type, one error taxonomy.
-- Trailheads are peers. CLI, MCP, and HTTP are shipped connectors. Adding a trailhead is a `surface()` call.
-- Implementations are pure functions. Input in, Result out. No trailhead awareness.
+- Surfaces are peers. CLI, MCP, and HTTP are shipped connectors. Adding a surface is a `surface()` call.
+- Implementations are pure functions. Input in, Result out. No surface awareness.
 - The contract is machine-readable at runtime via topo, survey, and guide.
 
 ## Information Architecture
@@ -71,9 +71,9 @@ Every piece of information has a clear ownership model.
 |----------|------|
 | Which trails a trail crosses | `ctx.cross()` calls in run |
 | Error types returned | `Result.err(new XError(...))` patterns |
-| Trailhead map entries and hash | All of the above, canonicalized |
+| Surface map entries and hash | All of the above, canonicalized |
 
-Warden uses inference to verify declarations match actual code. The trailhead map captures inferred information for CI governance.
+Warden uses inference to verify declarations match actual code. The surface map captures inferred information for CI governance.
 
 ## Package Layout
 
@@ -81,7 +81,7 @@ Warden uses inference to verify declarations match actual code. The trailhead ma
 
 `@ontrails/core` — only external dependency is `zod`. Contains Result, error taxonomy, `trail()`/`signal()`, `topo()`, validation, layers, connector port interfaces, `executeTrail()` (the shared pipeline), and `run()` (headless execution by trail ID).
 
-### Trailhead Connectors (left side)
+### Surface Connectors (left side)
 
 | Package | Purpose | External dep |
 |---------|---------|-------------|
@@ -106,7 +106,7 @@ Warden uses inference to verify declarations match actual code. The trailhead ma
 | Package | Purpose |
 |---------|---------|
 | `@ontrails/testing` | `testAll()`, `testExamples()`, `testTrail()`, contract testing |
-| `@ontrails/schema` | Trailhead maps, semantic diffing, lock files |
+| `@ontrails/schema` | Surface maps, semantic diffing, lock files |
 | `@ontrails/warden` | Lint rules, drift detection, CI gating |
 
 ### Dependency graph
@@ -131,7 +131,7 @@ Warden uses inference to verify declarations match actual code. The trailhead ma
 
 ### Shared Execution Pipeline
 
-All trailheads delegate to `executeTrail(trail, rawInput, options)` from `@ontrails/core`. It is the single implementation of the validate-context-layers-run pipeline:
+All surfaces delegate to `executeTrail(trail, rawInput, options)` from `@ontrails/core`. It is the single implementation of the validate-context-layers-run pipeline:
 
 ```text
 executeTrail(trail, rawInput, options)
@@ -143,7 +143,7 @@ executeTrail(trail, rawInput, options)
   -> Result returned (never throws)
 ```
 
-Trailheads only differ in how they parse inbound requests and map Results to their response format.
+Surfaces only differ in how they parse inbound requests and map Results to their response format.
 
 ### CLI Request Path
 
@@ -174,9 +174,9 @@ HTTP request (GET /entity/show?name=Alpha)
   -> Result mapped to JSON response with status code from error taxonomy
 ```
 
-### Headless Execution (no trailhead)
+### Headless Execution (no surface)
 
-`run(topo, id, input, options)` from `@ontrails/core` is the "no-trailhead" path. It resolves a trail by ID from the topo, then delegates to `executeTrail`. Returns `Result.err(NotFoundError)` if the ID is not registered.
+`run(topo, id, input, options)` from `@ontrails/core` is the "no-surface" path. It resolves a trail by ID from the topo, then delegates to `executeTrail`. Returns `Result.err(NotFoundError)` if the ID is not registered.
 
 ```text
 run(myTopo, 'entity.show', { name: 'Alpha' })
@@ -204,4 +204,4 @@ The implementation is identical across all paths. Only the edges change.
 | `auth` | 9 | 401 | No | `AuthError` |
 | `cancelled` | 130 | 499 | No | `CancelledError` |
 
-Use the most specific `TrailsError` subclass available. The error category determines exit code, HTTP status, JSON-RPC code, and retryability across all trailheads automatically.
+Use the most specific `TrailsError` subclass available. The error category determines exit code, HTTP status, JSON-RPC code, and retryability across all surfaces automatically.

--- a/plugin/skills/trails/references/cli-surface.md
+++ b/plugin/skills/trails/references/cli-surface.md
@@ -95,7 +95,7 @@ surface(graph, {
 });
 ```
 
-## Blaze Options
+## Surface Options
 
 ```typescript
 surface(graph, {

--- a/plugin/skills/trails/references/cli-surface.md
+++ b/plugin/skills/trails/references/cli-surface.md
@@ -1,4 +1,4 @@
-# CLI Trailhead Reference
+# CLI Surface Reference
 
 ## Flag Derivation
 
@@ -23,7 +23,7 @@ Zod fields on a trail's `input` schema become CLI flags automatically.
 
 ## Output Modes
 
-CLI trailheads support `--output text|json|jsonl` for structured output.
+CLI surfaces support `--output text|json|jsonl` for structured output.
 
 ```typescript
 surface(graph, {
@@ -31,9 +31,9 @@ surface(graph, {
 });
 ```
 
-The trailhead handles formatting based on mode:
+The surface handles formatting based on mode:
 
-- `text` — Human-readable (default). The trailhead calls `.toString()` or formats objects.
+- `text` — Human-readable (default). The surface calls `.toString()` or formats objects.
 - `json` — Pretty-printed JSON of the Result value.
 - `jsonl` — One JSON object per line. Useful for piping to `jq`.
 
@@ -71,7 +71,7 @@ Groups are created automatically from the dot-separated prefix.
 
 ## Destructive Trails
 
-When a trail has `intent: 'destroy'`, the CLI trailhead automatically adds a `--dry-run` flag. The `ctx.dryRun` boolean is available inside the implementation. You can also add this explicitly:
+When a trail has `intent: 'destroy'`, the CLI surface automatically adds a `--dry-run` flag. The `ctx.dryRun` boolean is available inside the implementation. You can also add this explicitly:
 
 ```typescript
 surface(graph, {
@@ -111,7 +111,7 @@ surface(graph, {
 
 ## Execution Pipeline
 
-The CLI trailhead delegates to `executeTrail()` from `@ontrails/core` — the same pipeline used by MCP, HTTP, and `run()`. Input is validated by Zod before the implementation runs. Layers are applied in order. The Result is mapped to an exit code and stdout/stderr by the trailhead; implementations never call `process.exit()` directly.
+The CLI surface delegates to `executeTrail()` from `@ontrails/core` — the same pipeline used by MCP, HTTP, and `run()`. Input is validated by Zod before the implementation runs. Layers are applied in order. The Result is mapped to an exit code and stdout/stderr by the surface; implementations never call `process.exit()` directly.
 
 ## Escape Hatch
 

--- a/plugin/skills/trails/references/common-pitfalls.md
+++ b/plugin/skills/trails/references/common-pitfalls.md
@@ -27,9 +27,9 @@ blaze: async (input) => {
 
 **Fix:** Keep implementations pure: `(input, ctx) => Result`. Access surface-specific features through `ctx` only.
 
-## 3. Calling .run() directly
+## 3. Calling .blaze() directly
 
-**Symptom:** Tests or composite trails call `myTrail.run(input)` and skip validation, layers, and tracing.
+**Symptom:** Tests or composite trails call `myTrail.blaze(input)` and skip validation, layers, and tracing.
 
 **Why it's wrong:** Direct calls bypass the framework pipeline. Input isn't validated, layers don't run, and traces aren't recorded.
 
@@ -109,7 +109,7 @@ blaze: async (input, ctx) => {
 
 ## 9. Constructing dependencies inline instead of declaring resources
 
-**Symptom:** Every trail creates its own database connection. Tests require `vi.mock()`. `testAll(app)` fails for any trail with external dependencies.
+**Symptom:** Every trail creates its own database connection. Tests require `vi.mock()`. `testAll(graph)` fails for any trail with external dependencies.
 
 **Why it's wrong:** Inline construction hides dependencies from the framework. The warden can't verify them, survey can't report them, and the testing harness can't swap them.
 
@@ -134,7 +134,7 @@ const search = trail('search', {
 
 ## 10. Forgetting mock factories on resource definitions
 
-**Symptom:** `testAll(app)` fails with a resource resolution error because `DATABASE_URL` is not set in the test environment.
+**Symptom:** `testAll(graph)` fails with a resource resolution error because `DATABASE_URL` is not set in the test environment.
 
 **Why it's wrong:** Without a `mock` factory, the testing harness falls back to the real `create` factory, which needs production-like configuration.
 
@@ -143,7 +143,7 @@ const search = trail('search', {
 ```typescript
 const db = resource('db.main', {
   create: (svc) => Result.ok(openDatabase(svc.env?.DATABASE_URL)),
-  mock: () => createInMemoryDb(), // enables zero-config testAll(app)
+  mock: () => createInMemoryDb(), // enables zero-config testAll(graph)
 });
 ```
 
@@ -168,4 +168,4 @@ const api = resource('api.client', {
 
 **Why it's wrong:** Even synchronous implementations are awaited at runtime. The framework wraps all implementations uniformly.
 
-**Fix:** Always `await` trail results in tests. Use `testTrail(myTrail, input)` instead of calling `.run()` directly.
+**Fix:** Always `await` trail results in tests. Use `testTrail(myTrail, input)` instead of calling `.blaze()` directly.

--- a/plugin/skills/trails/references/common-pitfalls.md
+++ b/plugin/skills/trails/references/common-pitfalls.md
@@ -2,9 +2,9 @@
 
 ## 1. Throwing in implementations
 
-**Symptom:** Unhandled exception crashes the trailhead connector. Stack trace instead of structured error.
+**Symptom:** Unhandled exception crashes the surface connector. Stack trace instead of structured error.
 
-**Why it's wrong:** Trail implementations must return `Result`, never throw. Trailheads expect `Result.ok` or `Result.err` — a thrown exception bypasses error mapping, exit codes, and serialization.
+**Why it's wrong:** Trail implementations must return `Result`, never throw. Surfaces expect `Result.ok` or `Result.err` — a thrown exception bypasses error mapping, exit codes, and serialization.
 
 **Fix:** Wrap risky code with try/catch and return `Result.err`:
 
@@ -19,13 +19,13 @@ blaze: async (input) => {
 }
 ```
 
-## 2. Importing trailhead types
+## 2. Importing surface types
 
 **Symptom:** Implementation depends on `Request`, `Response`, `McpSession`, or `process`.
 
-**Why it's wrong:** Implementations must be trailhead-agnostic. Importing trailhead types couples logic to a specific transport and breaks portability.
+**Why it's wrong:** Implementations must be surface-agnostic. Importing surface types couples logic to a specific transport and breaks portability.
 
-**Fix:** Keep implementations pure: `(input, ctx) => Result`. Access trailhead-specific features through `ctx` only.
+**Fix:** Keep implementations pure: `(input, ctx) => Result`. Access surface-specific features through `ctx` only.
 
 ## 3. Calling .run() directly
 
@@ -37,9 +37,9 @@ blaze: async (input) => {
 
 ## 4. Missing output schema
 
-**Symptom:** MCP trailhead rejects the trail. HTTP trailhead returns untyped JSON.
+**Symptom:** MCP surface rejects the trail. HTTP surface returns untyped JSON.
 
-**Why it's wrong:** MCP and HTTP trailheads require output schemas to generate tool descriptions and validate responses.
+**Why it's wrong:** MCP and HTTP surfaces require output schemas to generate tool descriptions and validate responses.
 
 **Fix:** Always define `output` in the trail definition:
 
@@ -88,7 +88,7 @@ trail('onboard', {
 
 **Symptom:** Debug output interleaved with CLI formatted output. JSON output corrupted.
 
-**Why it's wrong:** `console.log` writes to stdout, which CLI trailheads own for structured output. It breaks JSON mode, table formatting, and piped output.
+**Why it's wrong:** `console.log` writes to stdout, which CLI surfaces own for structured output. It breaks JSON mode, table formatting, and piped output.
 
 **Fix:** Use `ctx.logger` for debug output:
 
@@ -147,13 +147,13 @@ const db = resource('db.main', {
 });
 ```
 
-## 11. Importing trailhead types into resource factories
+## 11. Importing surface types into resource factories
 
-**Symptom:** A resource factory imports `Request`, `McpSession`, or reads `process.argv`. It works on one trailhead but breaks on others.
+**Symptom:** A resource factory imports `Request`, `McpSession`, or reads `process.argv`. It works on one surface but breaks on others.
 
-**Why it's wrong:** Resource factories receive `ResourceContext` — a narrow subset with `env`, `cwd`, and `workspaceRoot` only. Resources are singletons resolved once per process, not per request. Trailhead-specific state would be stale after the first resolution.
+**Why it's wrong:** Resource factories receive `ResourceContext` — a narrow subset with `env`, `cwd`, and `workspaceRoot` only. Resources are singletons resolved once per process, not per request. Surface-specific state would be stale after the first resolution.
 
-**Fix:** Keep resource factories trailhead-agnostic. Use `svc.env` for configuration:
+**Fix:** Keep resource factories surface-agnostic. Use `svc.env` for configuration:
 
 ```typescript
 const api = resource('api.client', {

--- a/plugin/skills/trails/references/contract-patterns.md
+++ b/plugin/skills/trails/references/contract-patterns.md
@@ -101,7 +101,7 @@ examples: [
 | `intent` | `'destroy'` | Deletes, irreversible mutations. CLI adds `--dry-run`. |
 | `idempotent` | `true` | Safe to retry. Upserts, PUT-style operations. |
 
-Omitting `intent` means "has side effects but not destructive" — typical for create/update. Trailhead effects: CLI adds `--dry-run` for `intent: 'destroy'`; MCP skips confirmation for `intent: 'read'`; HTTP maps `'read'` to GET, others to POST.
+Omitting `intent` means "has side effects but not destructive" — typical for create/update. Surface effects: CLI adds `--dry-run` for `intent: 'destroy'`; MCP skips confirmation for `intent: 'read'`; HTTP maps `'read'` to GET, others to POST.
 
 ## Detours
 
@@ -114,7 +114,7 @@ detours: {
 },
 ```
 
-Keys are error type names (strings, not classes). Values are arrays of trail IDs. Trailheads can auto-suggest or auto-cross detours.
+Keys are error type names (strings, not classes). Values are arrays of trail IDs. Surfaces can auto-suggest or auto-cross detours.
 
 ## Field Overrides
 

--- a/plugin/skills/trails/references/getting-started.md
+++ b/plugin/skills/trails/references/getting-started.md
@@ -11,7 +11,7 @@ bunx @ontrails/trails create
 # Or install manually
 bun add @ontrails/core @ontrails/cli
 bun add commander                    # Commander connector
-bun add @ontrails/mcp                # MCP trailhead (optional)
+bun add @ontrails/mcp                # MCP surface (optional)
 bun add -d @ontrails/testing         # Testing (dev)
 ```
 
@@ -101,7 +101,7 @@ import { graph } from './app';
 await surface(graph);
 ```
 
-Same trail, same implementation, different trailhead. The MCP server exposes `myapp_greet` with JSON Schema input, `readOnlyHint: true`, and examples for agent planning.
+Same trail, same implementation, different surface. The MCP server exposes `myapp_greet` with JSON Schema input, `readOnlyHint: true`, and examples for agent planning.
 
 ## Test with testAll
 

--- a/plugin/skills/trails/references/getting-started.md
+++ b/plugin/skills/trails/references/getting-started.md
@@ -75,7 +75,7 @@ Create `src/cli.ts`:
 import { surface } from '@ontrails/cli/commander';
 import { graph } from './app';
 
-surface(graph);
+await surface(graph);
 ```
 
 Run it:
@@ -109,7 +109,7 @@ Create `src/__tests__/app.test.ts`:
 
 ```typescript
 import { testAll } from '@ontrails/testing';
-import { app } from '../app';
+import { graph } from '../app';
 
 testAll(graph);
 ```

--- a/plugin/skills/trails/references/mcp-surface.md
+++ b/plugin/skills/trails/references/mcp-surface.md
@@ -1,4 +1,4 @@
-# MCP Trailhead Reference
+# MCP Surface Reference
 
 ## Tool Naming
 
@@ -44,7 +44,7 @@ These annotations help MCP clients (like Claude) make informed decisions about t
 
 ## Progress Bridging
 
-`ctx.progress(current, total)` inside a trail implementation maps to MCP progress notifications. The trailhead handles the protocol — implementations just report progress:
+`ctx.progress(current, total)` inside a trail implementation maps to MCP progress notifications. The surface handles the protocol — implementations just report progress:
 
 ```typescript
 blaze: async (input, ctx) => {
@@ -60,7 +60,7 @@ blaze: async (input, ctx) => {
 
 Trail `examples` are included in MCP tool metadata. Agents use these to understand expected input/output shapes and plan tool usage without trial and error.
 
-## Trailhead Options
+## Surface Options
 
 ```typescript
 import { surface } from '@ontrails/mcp';

--- a/plugin/skills/trails/references/migration-checklist.md
+++ b/plugin/skills/trails/references/migration-checklist.md
@@ -47,7 +47,7 @@ For each handler:
 ## Phase 4: Composition
 
 - [ ] Create topo: `topo('appname', ...modules)`
-- [ ] Open CLI surface: `surface(graph)` from `@ontrails/cli/commander`
+- [ ] Open CLI surface: `await surface(graph)` from `@ontrails/cli/commander`
 - [ ] Open MCP surface: `await surface(graph)` from `@ontrails/mcp`
 - [ ] Remove old routing/command setup code
 

--- a/plugin/skills/trails/references/migration-checklist.md
+++ b/plugin/skills/trails/references/migration-checklist.md
@@ -37,18 +37,18 @@ For each handler:
   - `throw new Error('unauthorized')` → `Result.err(new AuthError(...))`
   - `throw new Error('forbidden')` → `Result.err(new PermissionError(...))`
   - `throw new Error('invalid')` → `Result.err(new ValidationError(...))`
-- [ ] Replace trailhead-specific returns with `Result.ok(value)`
+- [ ] Replace surface-specific returns with `Result.ok(value)`
   - `res.json(data)` → `Result.ok(data)`
   - `console.log(output)` → `Result.ok(output)`
   - `process.exit(1)` → `Result.err(new InternalError(...))`
-- [ ] Remove trailhead imports from implementation files
+- [ ] Remove surface imports from implementation files
 - [ ] Convert handler-to-handler calls to `ctx.cross()` in composite trails
 
 ## Phase 4: Composition
 
 - [ ] Create topo: `topo('appname', ...modules)`
-- [ ] Wire CLI trailhead: `surface(graph)` from `@ontrails/cli/commander`
-- [ ] Wire MCP trailhead: `await surface(graph)` from `@ontrails/mcp`
+- [ ] Open CLI surface: `surface(graph)` from `@ontrails/cli/commander`
+- [ ] Open MCP surface: `await surface(graph)` from `@ontrails/mcp`
 - [ ] Remove old routing/command setup code
 
 ## Phase 5: Testing
@@ -56,18 +56,18 @@ For each handler:
 - [ ] Add examples to every trail (happy path + key error cases)
 - [ ] Create `governance.test.ts` with `testAll(graph)`
 - [ ] Add edge-case tests with `testTrail()` for complex trails
-- [ ] Add trailhead integration tests with CLI/MCP harnesses
+- [ ] Add surface integration tests with CLI/MCP harnesses
 - [ ] All tests pass
 
 ## Phase 6: Governance
 
 - [ ] `trails warden` reports clean
-- [ ] Generate trailhead lock: `trails schema lock`
+- [ ] Generate surface lock: `trails schema lock`
 - [ ] Add lock check to CI
 
 ## Common Gotchas
 
 - **Async handlers**: Trails normalizes sync and async — both work. But `ctx.cross()` is always async.
 - **Layers**: Convert to Layers, not trails. Layers wrap trail execution.
-- **Error handling layers**: Remove it. Trails maps errors to exit codes/HTTP status automatically.
+- **Error handling layers**: Remove them. Trails maps errors to exit codes/HTTP status automatically.
 - **Response formatting**: Remove it. Use `outputModePreset()` for CLI, MCP handles it automatically.

--- a/plugin/skills/trails/references/testing-patterns.md
+++ b/plugin/skills/trails/references/testing-patterns.md
@@ -94,14 +94,14 @@ testTrail(onboardTrail, [
 
 Composition-specific fields: `expectCrossed` (ordered trail IDs), `expectCrossedCount` (counts per ID), `injectFromExample` (inject error from a crossed trail's error example by name). Pass `options.trails` map to enable injection lookups.
 
-## `testContracts(app)` / `testDetours(app)`
+## `testContracts(graph)` / `testDetours(graph)`
 
 `testContracts` verifies every trail's implementation output matches its declared output schema -- catches drift. `testDetours` checks that every detour target references a trail that exists in the topo. Both are included in `testAll` automatically; use standalone when debugging a specific failure.
 
 ```typescript
 import { testContracts, testDetours } from '@ontrails/testing';
-testContracts(app);  // schema drift detection
-testDetours(app);    // structural detour validation
+testContracts(graph);  // schema drift detection
+testDetours(graph);    // structural detour validation
 ```
 
 ## Service Mocking
@@ -110,13 +110,13 @@ Services with a `mock` factory auto-resolve during `testAll`, `testExamples`, an
 
 ```typescript
 // Zero-config: mock factories on resource definitions are used automatically
-testAll(app);
+testAll(graph);
 ```
 
 Override explicitly when you need specific behavior:
 
 ```typescript
-testAll(app, () => ({
+testAll(graph, () => ({
   resources: { 'db.main': createSpecialTestDb() },
 }));
 ```
@@ -179,9 +179,9 @@ For integration-style tests that verify the full pipeline (validation, layers, i
 
 ```typescript
 import { run } from '@ontrails/core';
-import { app } from '../src/app.js';
+import { graph } from '../src/app.js';
 
-const result = await run(app, 'entity.show', { name: 'Alpha' });
+const result = await run(graph, 'entity.show', { name: 'Alpha' });
 expect(result.isOk()).toBe(true);
 ```
 
@@ -209,7 +209,7 @@ logger.clear(); // reset captured entries
 ```typescript
 import { createCliHarness } from '@ontrails/testing';
 
-const cli = createCliHarness({ app });
+const cli = createCliHarness({ app: graph });
 const result = await cli.run('entity show --name Alpha --output json');
 expect(result.exitCode).toBe(0);
 expect(result.json).toEqual({ name: 'Alpha', type: 'concept' });
@@ -222,7 +222,7 @@ expect(result.json).toEqual({ name: 'Alpha', type: 'concept' });
 ```typescript
 import { createMcpHarness } from '@ontrails/testing';
 
-const mcp = createMcpHarness({ app });
+const mcp = createMcpHarness({ app: graph });
 const result = await mcp.callTool('myapp_entity_show', { name: 'Alpha' });
 expect(result.isError).toBe(false);
 ```
@@ -233,7 +233,7 @@ expect(result.isError).toBe(false);
 
 ```text
 src/__tests__/
-  governance.test.ts    # testAll(app) -- the one-liner
+  governance.test.ts    # testAll(graph) -- the one-liner
   entity.test.ts        # testTrail edge cases per domain
   onboard.test.ts       # testTrail composition scenarios
   cli.test.ts           # CLI harness integration

--- a/plugin/skills/trails/references/testing-patterns.md
+++ b/plugin/skills/trails/references/testing-patterns.md
@@ -175,7 +175,7 @@ Calls to IDs not registered in `responses` return `Result.err` with a descriptiv
 
 ## `run()` -- Headless Testing Against a Topo
 
-For integration-style tests that verify the full pipeline (validation, layers, implementation) without mounting a trailhead, use `run()` from `@ontrails/core`:
+For integration-style tests that verify the full pipeline (validation, layers, implementation) without opening a surface, use `run()` from `@ontrails/core`:
 
 ```typescript
 import { run } from '@ontrails/core';
@@ -202,7 +202,7 @@ logger.find(r => r.level === 'error'); // filtered entries
 logger.clear(); // reset captured entries
 ```
 
-## Trailhead Harnesses
+## Surface Harnesses
 
 ### CLI Harness
 
@@ -242,4 +242,4 @@ src/__tests__/
 
 - `governance.test.ts` is the minimum. One file, one line, full coverage of examples and contracts.
 - Add `*.test.ts` files per domain when edge cases accumulate beyond what examples cover.
-- Trailhead harness tests are optional but valuable for verifying flag parsing, output formatting, and tool naming.
+- Surface harness tests are optional but valuable for verifying flag parsing, output formatting, and tool naming.

--- a/plugin/skills/trails/templates/trail.md
+++ b/plugin/skills/trails/templates/trail.md
@@ -76,7 +76,7 @@ export const myTrail = trail('namespace.verb', {
     },
   ],
 
-  // --- Run ---
+  // --- Blaze ---
   // Receives validated input and TrailContext.
   // Return Result — never throw.
   // Keep surface-agnostic: no process.exit(), no console.log().

--- a/plugin/skills/trails/templates/trail.md
+++ b/plugin/skills/trails/templates/trail.md
@@ -12,7 +12,7 @@ import { z } from 'zod';
 
 const outputSchema = z.object({
   // Define the shape of successful results.
-  // This schema is required for MCP and HTTP trailheads.
+  // This schema is required for MCP and HTTP surfaces.
   id: z.string(),
   name: z.string(),
 });
@@ -43,7 +43,7 @@ export const myTrail = trail('namespace.verb', {
   // --- Intent and flags ---
   // intent: 'read',       // No side effects — safe for agents to call freely
   // intent: 'destroy',    // Irreversible — CLI auto-adds --dry-run flag
-  // idempotent: true,     // Safe to retry — trailheads may auto-retry on failure
+  // idempotent: true,     // Safe to retry — surfaces may auto-retry on failure
   // Omit intent for standard create/update operations.
 
   // --- Detours (optional) ---
@@ -79,7 +79,7 @@ export const myTrail = trail('namespace.verb', {
   // --- Run ---
   // Receives validated input and TrailContext.
   // Return Result — never throw.
-  // Keep trailhead-agnostic: no process.exit(), no console.log().
+  // Keep surface-agnostic: no process.exit(), no console.log().
   // --- Resources (optional) ---
   // Declare external dependencies so the framework manages lifecycle and testing.
   // resources: [db],


### PR DESCRIPTION
## Summary

Sweep all pedagogical docs, plugin skill content, and reference docs to match the ADR-0035 surface API vocabulary. This is the final vocabulary alignment branch for the pre-v1.0 clean cutover.

- **TRL-316:** Rewrite `docs/topo-store-reference.md` for `topo_snapshots` schema
- **TRL-310:** Fix `docs/testing.md` broken `.trailhead()` call → `.blaze()`; rename `app` → `graph` throughout
- **TRL-311:** Rewrite `docs/architecture.md` Core Principles ("Surfaces are peers"), Package Table (add `@ontrails/vite`), dependency graph
- **TRL-312:** Sweep `docs/why-trails.md` pedagogy (trailhead → surface)
- **TRL-319:** Fix `docs/api-reference.md` stale types + glossary; rename `docs/trailheads/` → `docs/surfaces/`
- **TRL-323:** Sweep `docs/getting-started.md` vocabulary + link refs
- **TRL-309:** Rewrite plugin SKILL.md lexicon table (fix `blaze` definition, add `surface`/`graph`/`projection`/`derive*`/`create*` rows)
- **TRL-322:** Batch sweep across 20+ plugin references, templates, examples, agents, rules, and meta files

Also fixes additional vocabulary drift found during sweep in `docs/index.md`, `docs/topo-store.md`, `docs/draft-state.md`, `docs/resources.md`, and `docs/surfaces/{cli,http,mcp}.md`.

## Test plan

- [x] `bun run typecheck` — 31/31
- [x] `bun run test` — 58 pass, 0 fail
- [x] `rg '\.trailhead\(|trailhead\(app\)' docs/ plugin/` → empty (except historical ADR/release notes)
- [x] `rg 'buildCliCommands|buildMcpTools|buildHttpRoutes' docs/ plugin/ --glob '!**/CHANGELOG.md'` → empty

## Closes

https://linear.app/outfitter/issue/TRL-309
https://linear.app/outfitter/issue/TRL-310
https://linear.app/outfitter/issue/TRL-311
https://linear.app/outfitter/issue/TRL-312
https://linear.app/outfitter/issue/TRL-316
https://linear.app/outfitter/issue/TRL-319
https://linear.app/outfitter/issue/TRL-322
https://linear.app/outfitter/issue/TRL-323