### PR TITLE
docs: fix residual surface API reference drift

### DIFF
--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -56,7 +56,8 @@ The conceptual boundary where a surface meets the trail system. The
 trailhead is where external input enters the framework and where the
 surface's protocol-specific handling ends and the shared `executeTrail()`
 pipeline begins. "Surface" names the rendering; "trailhead" names the
-boundary point.
+boundary point. Use `surface` for the user-facing API and docs; reserve
+`trailhead` for this boundary concept only.
 
 ### `topo`
 

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -134,6 +134,7 @@ options bag. The most useful fields are:
 | `include` | `readonly string[]` | *none* | Narrow the surface to matching trail IDs |
 | `intent` | `readonly Intent[]` | *none* | Filter exposed trails by intent |
 | `layers` | `readonly Layer[]` | `[]` | Layers to compose around implementations |
+| `name` | `string` | *none* | Accepted but currently unused — reserved for future use |
 | `port` | `number` | `3000` | Listen port used by `surface()` |
 | `resources` | `ResourceOverrideMap` | *none* | Explicit resource instances for this surface |
 | `validate` | `boolean` | `true` | Set to `false` to skip topo validation at startup |

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -121,15 +121,22 @@ Layers run in order, wrapping the implementation. They have access to the trail 
 
 ## CreateAppOptions
 
-| Option          | Type                                   | Default       | Description                                          |
-| --------------- | -------------------------------------- | ------------- | ---------------------------------------------------- |
-| `basePath`      | `string`                               | `''`          | Prefix for all route paths                           |
-| `createContext`  | `() => TrailContext \| Promise<TrailContext>` | default context | Factory for per-request TrailContext           |
-| `hostname`      | `string`                               | `'0.0.0.0'`  | Bind address                                         |
-| `layers`         | `readonly Layer[]`                      | `[]`          | Layers to compose around implementations              |
-| `name`          | `string`                               | *none*        | Server name for logging                              |
-| `port`          | `number`                               | `3000`        | Listen port                                          |
-| `serve`         | `boolean`                              | `true`        | Set `false` to return the Hono app without starting  |
+`surface(graph, options)` and `createApp(graph, options)` share the same
+options bag. The most useful fields are:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `basePath` | `string` | `''` | Prefix for all derived route paths |
+| `configValues` | `Record<string, Record<string, unknown>>` | *none* | Resource config values keyed by resource ID |
+| `createContext` | `() => TrailContextInit \| Promise<TrailContextInit>` | default context | Factory for per-request TrailContext init data |
+| `exclude` | `readonly string[]` | *none* | Exclude matching trail IDs from the surface |
+| `hostname` | `string` | `'0.0.0.0'` | Bind address used by `surface()` |
+| `include` | `readonly string[]` | *none* | Narrow the surface to matching trail IDs |
+| `intent` | `readonly Intent[]` | *none* | Filter exposed trails by intent |
+| `layers` | `readonly Layer[]` | `[]` | Layers to compose around implementations |
+| `port` | `number` | `3000` | Listen port used by `surface()` |
+| `resources` | `ResourceOverrideMap` | *none* | Explicit resource instances for this surface |
+| `validate` | `boolean` | `true` | Set to `false` to skip topo validation at startup |
 
 ## Request ID Bridging
 

--- a/plugin/skills/trails/references/mcp-surface.md
+++ b/plugin/skills/trails/references/mcp-surface.md
@@ -60,17 +60,22 @@ blaze: async (input, ctx) => {
 
 Trail `examples` are included in MCP tool metadata. Agents use these to understand expected input/output shapes and plan tool usage without trial and error.
 
-## Surface Options
+## CreateServerOptions
 
 ```typescript
 import { surface } from '@ontrails/mcp';
 
 await surface(graph, {
-  name: 'myapp',           // Tool name prefix (defaults to topo name)
-  version: '1.0.0',        // Server version
-  capabilities: {},        // MCP server capabilities object
+  name: 'myapp',                  // Tool name prefix (defaults to topo name)
+  version: '1.0.0',               // Server version
+  description: 'Internal tools',  // Forwarded as MCP server instructions
+  include: ['entity.**'],         // Optional trail filters
 });
 ```
+
+`surface(graph, options)` and `createServer(graph, options)` accept the same
+options bag: `name`, `version`, `description`, `include`, `exclude`, `intent`,
+`layers`, `createContext`, `configValues`, `resources`, and `validate`.
 
 ## Escape Hatch
 


### PR DESCRIPTION
## Context

Residual surface API docs still used retired type names and outdated option tables after the cutover landed on `main`.

## What Changed

- corrected the HTTP surface reference to match the current `surface()` / `createApp()` options bag
- updated the MCP surface reference to the current `CreateServerOptions` shape
- clarified the `surface` versus `trailhead` lexicon boundary and fixed the stale CLI `surface()` doc comment

## Verification

- `bun run build`
- `bun run check`

Closes: TRL-332
