### PR TITLE
refactor(core): extend RetryExhaustedError from InternalError

### DIFF
--- a/docs/adr/0033-detour-execution-for-recovery.md
+++ b/docs/adr/0033-detour-execution-for-recovery.md
@@ -120,7 +120,7 @@ Non-`TrailsError` throws inside `recover` follow the same rule as the blaze: the
 When a detour's retry attempts exhaust, the framework returns a `RetryExhaustedError<TErr>` that preserves the original error via `cause`:
 
 ```typescript
-class RetryExhaustedError<TErr extends TrailsError> extends TrailsError {
+class RetryExhaustedError<TErr extends TrailsError> extends InternalError {
   readonly cause: TErr;
 
   constructor(wrapped: TErr, metadata: { attempts: number; detour: string }) {
@@ -137,6 +137,10 @@ class RetryExhaustedError<TErr extends TrailsError> extends TrailsError {
 ```
 
 The category inheritance is the important part. A `RetryExhaustedError<ConflictError>` reports `category: 'conflict'`, so surfaces map it to HTTP 409 and exit code 3 — the same way a bare `ConflictError` would. Callers see the semantic underlying problem, not a synthetic wrapper with its own mapping.
+
+`InternalError.category` therefore needs to be typed broadly enough for this
+subclass override, even though plain `InternalError` instances still report the
+runtime value `'internal'`.
 
 The instance-level `retryable: false` override is load-bearing for a different reason, covered next.
 

--- a/docs/adr/0033-detour-execution-for-recovery.md
+++ b/docs/adr/0033-detour-execution-for-recovery.md
@@ -130,8 +130,6 @@ class RetryExhaustedError<TErr extends TrailsError> extends InternalError {
     this.cause = wrapped;
     // Inherit the wrapped error's category for surface mapping
     this.category = wrapped.category;
-    // But override retryable to false at the instance level (see below)
-    this.retryable = false;
   }
 }
 ```
@@ -155,7 +153,7 @@ abstract class TrailsError extends Error {
 }
 ```
 
-For normal errors, `retryable` is undefined and any retry-aware machinery falls back to `this.category`'s retryable flag — **no behavior change for existing code**. For `RetryExhaustedError` instances, the constructor sets `retryable = false` regardless of the wrapped error's category.
+For normal errors, `retryable` is undefined and any retry-aware machinery falls back to `this.category`'s retryable flag — **no behavior change for existing code**. For `RetryExhaustedError` instances, `retryable` is `false` via inheritance from `InternalError`, regardless of the wrapped error's category.
 
 **Why this matters:** a future framework retry layer (see Out of Scope) honors `retryable: true` categories automatically. Without the instance-level override, `RetryExhaustedError<NetworkError>` would carry `category: 'network'`, which is retryable, and the retry layer would re-retry an already-exhausted recovery across `ctx.cross()` boundaries or stacked layers. Runaway amplification.
 

--- a/packages/core/src/__tests__/errors.test.ts
+++ b/packages/core/src/__tests__/errors.test.ts
@@ -392,6 +392,14 @@ describe('RetryExhaustedError', () => {
   });
 
   describe('identity', () => {
+    test('is instanceof InternalError', () => {
+      const err = new RetryExhaustedError(new ConflictError('x'), {
+        attempts: 1,
+        detour: 'ConflictError',
+      });
+      expect(err).toBeInstanceOf(InternalError);
+    });
+
     test('name is RetryExhaustedError', () => {
       const err = new RetryExhaustedError(new ConflictError('x'), {
         attempts: 1,

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -1321,6 +1321,7 @@ describe('executeTrail', () => {
       expect(result.isErr()).toBe(true);
       const { error } = result;
       expect(error).toBeInstanceOf(RetryExhaustedError);
+      expect(error).toBeInstanceOf(InternalError);
       const exhausted = error as RetryExhaustedError;
       expect(exhausted.category).toBe('conflict');
       expect(exhausted.retryable).toBe(false);

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -112,7 +112,7 @@ export class NetworkError extends TrailsError {
 }
 
 export class InternalError extends TrailsError {
-  readonly category = 'internal' as const;
+  readonly category: ErrorCategory = 'internal';
   readonly retryable = false as const;
 }
 
@@ -141,10 +141,10 @@ export class CancelledError extends TrailsError {
  */
 export class RetryExhaustedError<
   TErr extends TrailsError = TrailsError,
-> extends TrailsError {
-  declare readonly category: ErrorCategory;
+> extends InternalError {
+  readonly category: ErrorCategory;
   readonly retryable = false as const;
-  declare readonly cause: TErr;
+  readonly cause: TErr;
 
   /** Number of recovery attempts made before exhaustion. */
   readonly attempts: number;
@@ -163,8 +163,8 @@ export class RetryExhaustedError<
     this.cause = wrapped;
     this.attempts = metadata.attempts;
     this.detour = metadata.detour;
-    // Dynamic — inherited from wrapped error at construction time
-    (this as { category: ErrorCategory }).category = wrapped.category;
+    // Dynamic — inherited from wrapped error at construction time.
+    this.category = wrapped.category;
   }
 }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -143,7 +143,6 @@ export class RetryExhaustedError<
   TErr extends TrailsError = TrailsError,
 > extends InternalError {
   readonly category: ErrorCategory;
-  readonly retryable = false as const;
   readonly cause: TErr;
 
   /** Number of recovery attempts made before exhaustion. */


### PR DESCRIPTION
## Context

`RetryExhaustedError` belongs under `InternalError`, but the current hierarchy typed `InternalError.category` too narrowly to support that subclass cleanly.

## What Changed

- made `RetryExhaustedError` extend `InternalError` instead of `TrailsError` directly
- widened the `InternalError.category` type enough to preserve the wrapped error's runtime category without casts
- updated ADR-0033 and added regression coverage for the new hierarchy and detour behavior

## Verification

- `bun test packages/core/src/__tests__/errors.test.ts packages/core/src/__tests__/execute.test.ts`
- `bun run build`
- `bun run check`

Closes: TRL-298
