### PR TITLE
feat(core): stamp first-party trail patterns

### DIFF
--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -54,6 +54,7 @@ interface CurrentTrailDetail {
   readonly id: string;
   readonly intent: 'destroy' | 'read' | 'write';
   readonly kind: string;
+  readonly pattern: string | null;
   readonly resources: string[];
   readonly safety: string;
 }
@@ -145,17 +146,20 @@ const buildSurveyListFromStore = (
 };
 
 const buildTrailDetailFromStore = (
-  detail: ReturnType<ReturnType<typeof createTopoStore>['trails']['get']>
+  detail: NonNullable<
+    ReturnType<ReturnType<typeof createTopoStore>['trails']['get']>
+  >
 ): CurrentTrailDetail => ({
-  crosses: [...(detail?.crosses ?? [])],
-  description: detail?.description ?? null,
-  detours: detail?.detours ?? null,
-  examples: [...(detail?.examples ?? [])],
-  id: detail?.id ?? '',
-  intent: detail?.intent ?? 'write',
-  kind: detail?.kind ?? 'trail',
-  resources: [...(detail?.resources ?? [])],
-  safety: detail?.safety ?? '-',
+  crosses: [...detail.crosses],
+  description: detail.description,
+  detours: detail.detours,
+  examples: [...detail.examples],
+  id: detail.id,
+  intent: detail.intent,
+  kind: detail.kind,
+  pattern: detail.pattern,
+  resources: [...detail.resources],
+  safety: detail.safety,
 });
 
 const buildResourceDetailFromStore = (

--- a/apps/trails/src/trails/topo-reports.ts
+++ b/apps/trails/src/trails/topo-reports.ts
@@ -47,6 +47,7 @@ export interface TrailDetailReport {
   readonly id: string;
   readonly intent: 'read' | 'write' | 'destroy';
   readonly kind: string;
+  readonly pattern: string | null;
   readonly safety: string;
   readonly resources: readonly string[];
 }
@@ -220,6 +221,7 @@ export const deriveTrailDetail = (
     id: item.id,
     intent: item.intent,
     kind: item.kind,
+    pattern: item.pattern ?? null,
     resources: item.resources.map((resource) => resource.id).toSorted(),
     safety,
   };

--- a/docs/adr/0032-derivetrail-and-trail-factories.md
+++ b/docs/adr/0032-derivetrail-and-trail-factories.md
@@ -31,7 +31,7 @@ Trails has a clear convention: core primitives are bare nouns (`trail()`, `store
 
 ### `deriveTrail()` is the base helper
 
-`deriveTrail()` takes a store schema, an operation name, and a resource. It derives everything internally — trail ID, input/output schemas, examples from fixtures, pattern metadata, resource wiring, and blaze for standard operations. One call, one trail.
+`deriveTrail()` takes a store schema, an operation name, and a resource. It derives everything internally except family-level pattern stamping — trail ID, input/output schemas, examples from fixtures, resource wiring, and blaze for standard operations. One call, one trail.
 
 ```typescript
 import { deriveTrail } from '@ontrails/core/trails';
@@ -39,7 +39,7 @@ import { deriveTrail } from '@ontrails/core/trails';
 const createNote = deriveTrail(noteSchema, 'create', db);
 ```
 
-The output is a regular trail — `kind: 'trail'`, with `pattern` metadata set automatically, blaze, input/output schemas, and resource declarations. Inspectable, testable, governable. The output is always trails.
+The output is a regular trail — `kind: 'trail'`, with blaze, input/output schemas, and resource declarations. Inspectable, testable, governable. The output is always trails.
 
 "Derive" is accurate: contour or schema in, trail out, deterministically. `deriveTrail()` sits one level above `trail()` — useful, powerful, but downstream of the primitive.
 
@@ -76,7 +76,7 @@ export const sync = ({ from, to, on, transform }) =>
   });
 ```
 
-When you provide a `blaze`, `deriveTrail()` uses yours. When you don't (standard CRUD operations), it derives one. Same function, progressive complexity.
+When you provide a `blaze`, `deriveTrail()` uses yours. When you don't (standard CRUD operations), it derives one. Same function, progressive complexity. First-party factories like `crud()`, `sync()`, `reconcile()`, and `ingest()` stamp their own family-level `pattern` values on the trails they return; `deriveTrail()` itself stays neutral unless the caller declares a pattern explicitly.
 
 The `ingest` factory handles the inverse: external data arriving in a non-trail shape that needs to enter the system as a signal. A Stripe webhook, a GitHub event, a partner API callback — the pattern is always the same: verify the source, validate the payload, transform to the domain shape, emit a signal.
 

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -292,7 +292,7 @@ Industry-standard terminology, aligned with OpenTelemetry. Production observabil
 
 ### `pattern`
 
-A declared operational shape on a trail. Recognized structural forms — `toggle`, `crud`, `transition` — that the framework can use for derivation, governance, and agent guidance.
+A declared operational shape on a trail. Recognized structural forms — `crud`, `sync`, `reconcile`, `ingest`, `toggle`, `transition` — that the framework can use for derivation, governance, and agent guidance. First-party factories stamp the patterns they own; lower-level helpers like `deriveTrail()` stay neutral unless the caller declares one explicitly.
 
 ```typescript
 const enableFeature = trail('feature.enable', {

--- a/packages/core/src/__tests__/derive-trail.test.ts
+++ b/packages/core/src/__tests__/derive-trail.test.ts
@@ -232,6 +232,23 @@ describe('deriveTrail()', () => {
     expect(updated.input.parse({ id: 'note-1' })).toEqual({ id: 'note-1' });
     expect(listed.input.parse({})).toEqual({});
   });
+
+  test('does not auto-stamp a pattern when none is declared', () => {
+    const created = deriveNoteTrail('create');
+
+    expect(created.pattern).toBeUndefined();
+  });
+
+  test('preserves a caller-declared pattern', () => {
+    const created = deriveTrail(note, 'create', {
+      blaze: createBlaze,
+      generated: ['id', 'createdAt'],
+      pattern: 'crud',
+      resource: noteResource,
+    });
+
+    expect(created.pattern).toBe('crud');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/__tests__/ingest.test.ts
+++ b/packages/core/src/__tests__/ingest.test.ts
@@ -67,6 +67,7 @@ describe('ingest()', () => {
 
     expect(paymentIngest.id).toBe('payment.completed.ingest');
     expect(paymentIngest.intent).toBe('write');
+    expect(paymentIngest.pattern).toBe('ingest');
     expect(paymentIngest.fires).toEqual(['payment.completed']);
     expect(paymentIngest.output?.safeParse().success).toBe(true);
     expect(paymentIngest.examples).toEqual([

--- a/packages/core/src/__tests__/topo-store.test.ts
+++ b/packages/core/src/__tests__/topo-store.test.ts
@@ -731,7 +731,7 @@ describe('topo store projection', () => {
               "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
             )
             .get()?.version
-        ).toBe(7);
+        ).toBe(8);
         expect(countRows(db, 'topo_snapshots')).toBe(0);
       });
     });
@@ -789,7 +789,7 @@ describe('topo store projection', () => {
             "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
           )
           .get()?.version
-      ).toBe(7);
+      ).toBe(8);
       for (const table of [
         'topo_snapshots',
         'topo_trails',

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -104,6 +104,16 @@ describe('trail()', () => {
       expect(withMeta.meta).toEqual({ domain: 'billing', tier: 1 });
     });
 
+    test('pattern is stored when declared', () => {
+      const withPattern = trail('feature.enable', {
+        blaze: () => Result.ok({ enabled: true }),
+        input: z.object({ id: z.string() }),
+        pattern: 'toggle',
+      });
+
+      expect(withPattern.pattern).toBe('toggle');
+    });
+
     test('detours are stored', () => {
       const withDetours = trail('orchestrator', {
         blaze: () => Result.ok(),

--- a/packages/core/src/internal/topo-snapshots.ts
+++ b/packages/core/src/internal/topo-snapshots.ts
@@ -22,6 +22,7 @@ const TOPO_TABLE_STATEMENTS = [
     has_examples INTEGER NOT NULL DEFAULT 0,
     example_count INTEGER NOT NULL DEFAULT 0,
     description TEXT,
+    pattern TEXT,
     meta TEXT,
     snapshot_id TEXT NOT NULL,
     PRIMARY KEY (id, snapshot_id),
@@ -206,18 +207,23 @@ const createAllTopoTables = (db: Database): void => {
 /**
  * Current topo subsystem schema version.
  *
- * Version 7 defines the snapshot-first topo tables (`topo_snapshots`,
+ * Version 8 adds `pattern TEXT` column to `topo_trails`.
+ *
+ * Version 7 defined the snapshot-first topo tables (`topo_snapshots`,
  * `topo_surfaces`, and `snapshot_id` foreign keys) as the only supported
  * schema. Older pre-release tables are ignored in place; we create the current
  * tables and advance the subsystem version without translating or deleting
  * legacy rows.
  */
-export const TOPO_SCHEMA_VERSION = 7;
+export const TOPO_SCHEMA_VERSION = 8;
 
 export const ensureTopoSnapshotSchema = (db: Database): void => {
   ensureSubsystemSchema(db, {
-    migrate: () => {
+    migrate: (currentVersion) => {
       createAllTopoTables(db);
+      if (currentVersion === 7) {
+        db.run('ALTER TABLE topo_trails ADD COLUMN pattern TEXT');
+      }
     },
     subsystem: TOPO_SUBSYSTEM,
     version: TOPO_SCHEMA_VERSION,

--- a/packages/core/src/internal/topo-store-read.ts
+++ b/packages/core/src/internal/topo-store-read.ts
@@ -28,6 +28,7 @@ export interface TopoStoreTrailRecord {
   readonly intent: 'destroy' | 'read' | 'write';
   readonly kind: 'trail';
   readonly meta: Readonly<Record<string, unknown>> | null;
+  readonly pattern: string | null;
   readonly safety: '-' | 'destroy' | 'read' | 'write';
   readonly snapshotId: string;
 }
@@ -75,6 +76,7 @@ interface TopoTrailRow {
   readonly idempotent: number;
   readonly intent: string | null;
   readonly meta: string | null;
+  readonly pattern: string | null;
   readonly snapshot_id: string;
 }
 
@@ -200,6 +202,7 @@ const mapTrailRow = (row: TopoTrailRow): TopoStoreTrailRecord => {
     intent,
     kind: 'trail',
     meta: parseMeta(row.meta),
+    pattern: row.pattern,
     safety: safetyForIntent(intent),
     snapshotId: row.snapshot_id,
   };
@@ -324,7 +327,7 @@ export const listTopoStoreTrails = (
     return [];
   }
 
-  const baseQuery = `SELECT id, intent, idempotent, has_output, has_examples, example_count, description, meta, snapshot_id
+  const baseQuery = `SELECT id, intent, idempotent, has_output, has_examples, example_count, description, pattern, meta, snapshot_id
              FROM topo_trails`;
 
   let rows: TopoTrailRow[];
@@ -363,7 +366,7 @@ export const getTopoStoreTrail = (
 
   const row = db
     .query<TopoTrailRow, [string, string]>(
-      `SELECT id, intent, idempotent, has_output, has_examples, example_count, description, meta, snapshot_id
+      `SELECT id, intent, idempotent, has_output, has_examples, example_count, description, pattern, meta, snapshot_id
        FROM topo_trails
        WHERE snapshot_id = ? AND id = ?
        LIMIT 1`

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -42,6 +42,7 @@ interface TopoTrailRow {
   readonly idempotent: number;
   readonly intent: string;
   readonly meta: string | null;
+  readonly pattern: string | null;
   readonly snapshotId: string;
 }
 
@@ -296,6 +297,7 @@ const normalizeTrailRows = (
     idempotent: trail.idempotent === true ? 1 : 0,
     intent: trail.intent,
     meta: trail.meta === undefined ? null : stableJson(trail.meta),
+    pattern: trail.pattern ?? null,
     snapshotId,
   }));
 
@@ -746,6 +748,10 @@ const buildTrailEntryBase = (
     entry['description'] = trail.description;
   }
 
+  if (trail.pattern !== undefined) {
+    entry['pattern'] = trail.pattern;
+  }
+
   return {
     entry,
     raw,
@@ -998,8 +1004,8 @@ const insertProjectedRows = (
     db,
     projection.trails,
     `INSERT INTO topo_trails (
-      id, intent, idempotent, has_output, has_examples, example_count, description, meta, snapshot_id
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      id, intent, idempotent, has_output, has_examples, example_count, description, pattern, meta, snapshot_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     (row) => [
       row.id,
       row.intent,
@@ -1008,6 +1014,7 @@ const insertProjectedRows = (
       row.hasExamples,
       row.exampleCount,
       row.description,
+      row.pattern,
       row.meta,
       row.snapshotId,
     ]

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -67,6 +67,8 @@ export interface TrailSpec<I, O, CI = never> {
   readonly blaze: Implementation<BlazeInput<I, CI>, O>;
   /** Human-readable description */
   readonly description?: string | undefined;
+  /** Declared operational shape for governance, derivation, and agent guidance. */
+  readonly pattern?: string | undefined;
   /** Named examples for docs and testing */
   readonly examples?: readonly TrailExample<I, O>[] | undefined;
   /** What this trail does to the world: read, write (default), or destroy */

--- a/packages/core/src/trails/ingest.ts
+++ b/packages/core/src/trails/ingest.ts
@@ -18,7 +18,7 @@ type ExampleBearingSchema<TSchema extends z.ZodType> = TSchema & {
 
 interface IngestBaseOptions<TSchema extends z.ZodType, TSignal> extends Omit<
   TrailSpec<SchemaValue<TSchema>, void>,
-  'blaze' | 'examples' | 'fires' | 'input' | 'intent' | 'output'
+  'blaze' | 'examples' | 'fires' | 'input' | 'intent' | 'output' | 'pattern'
 > {
   /** Override the derived trail id. Defaults to `${signal}.ingest`. */
   readonly id?: string | undefined;
@@ -130,6 +130,7 @@ export const ingest = <
     input: schema as z.ZodType<SchemaValue<TSchema>>,
     intent: 'write',
     output: z.void(),
+    pattern: 'ingest',
   }) as Trail<SchemaValue<TSchema>, void>;
 
   if (verify === undefined) {

--- a/packages/schema/src/derive.ts
+++ b/packages/schema/src/derive.ts
@@ -125,6 +125,9 @@ const addMetadata = (
   if (t.description !== undefined) {
     entry['description'] = t.description;
   }
+  if (t.pattern !== undefined) {
+    entry['pattern'] = t.pattern;
+  }
   addSafetyMarkers(entry, t);
   addExtendedMetadata(entry, t, raw);
 };

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -32,6 +32,7 @@ export interface SurfaceMapEntry {
   readonly output?: JsonSchema | undefined;
   readonly intent?: 'read' | 'write' | 'destroy' | undefined;
   readonly idempotent?: boolean | undefined;
+  readonly pattern?: string | undefined;
   readonly deprecated?: boolean | undefined;
   readonly replacedBy?: string | undefined;
   readonly crosses?: readonly string[] | undefined;

--- a/packages/store/src/__tests__/crud.test.ts
+++ b/packages/store/src/__tests__/crud.test.ts
@@ -139,6 +139,14 @@ const expectCrudIds = () => {
   expect(listNote.id).toBe('notes.list');
 };
 
+const expectCrudPatterns = () => {
+  expect(createNote.pattern).toBe('crud');
+  expect(readNote.pattern).toBe('crud');
+  expect(updateNote.pattern).toBe('crud');
+  expect(deleteNote.pattern).toBe('crud');
+  expect(listNote.pattern).toBe('crud');
+};
+
 const expectCrudInputSchemas = () => {
   const createParsed = createNote.input.safeParse({
     id: 'note-1',
@@ -182,6 +190,7 @@ const expectOk = <T>(result: Result<T, Error>): T => {
 describe('crud()', () => {
   test('produces the five standard CRUD trails with derived schemas', () => {
     expectCrudIds();
+    expectCrudPatterns();
     expectCrudInputSchemas();
     expectCrudOutputSchemas();
     expect(createNote.resources).toEqual([notesResource]);

--- a/packages/store/src/__tests__/sync-reconcile.test.ts
+++ b/packages/store/src/__tests__/sync-reconcile.test.ts
@@ -290,6 +290,7 @@ const expectSyncShape = (
   >
 ) => {
   expect(syncNote.id).toBe('notes.sync');
+  expect(syncNote.pattern).toBe('sync');
   expect(syncNote.resources).toEqual([sourceResource, targetResource]);
   expect(syncNote.contours.map((candidate) => candidate.name)).toEqual([
     'externalNotes',
@@ -414,6 +415,7 @@ describe('reconcile()', () => {
     );
 
     expect(reconcileNote.id).toBe('notes.reconcile');
+    expect(reconcileNote.pattern).toBe('reconcile');
     expect(
       reconcileNote.input.safeParse({
         body: 'Incoming body',

--- a/packages/store/src/trails/crud.ts
+++ b/packages/store/src/trails/crud.ts
@@ -124,6 +124,7 @@ const finalizeTrail = <TInput, TOutput>(
   options: {
     readonly blaze?: Implementation<TInput, TOutput> | undefined;
     readonly output?: z.ZodType<TOutput> | undefined;
+    readonly pattern?: string | undefined;
   } = {}
 ): Trail<TInput, TOutput> =>
   Object.freeze({
@@ -135,6 +136,7 @@ const finalizeTrail = <TInput, TOutput>(
           examples: normalizeExamplesForOutput(base, options.output),
           output: options.output,
         }),
+    ...(options.pattern === undefined ? {} : { pattern: options.pattern }),
   }) as Trail<TInput, TOutput>;
 
 const deriveCrudBaseTrails = <
@@ -183,21 +185,28 @@ const buildCrudTrails = <TTable extends AnyStoreTable>(
     finalizeTrail(baseTrails.createBase, {
       ...(overrides.create === undefined ? {} : { blaze: overrides.create }),
       output: entityOutput,
+      pattern: 'crud',
     }),
     finalizeTrail(baseTrails.readBase, {
       ...(overrides.read === undefined ? {} : { blaze: overrides.read }),
       output: entityOutput,
+      pattern: 'crud',
     }),
     finalizeTrail(baseTrails.updateBase, {
       ...(overrides.update === undefined ? {} : { blaze: overrides.update }),
       output: entityOutput,
+      pattern: 'crud',
     }),
     overrides.delete === undefined
-      ? finalizeTrail(baseTrails.deleteBase)
-      : finalizeTrail(baseTrails.deleteBase, { blaze: overrides.delete }),
+      ? finalizeTrail(baseTrails.deleteBase, { pattern: 'crud' })
+      : finalizeTrail(baseTrails.deleteBase, {
+          blaze: overrides.delete,
+          pattern: 'crud',
+        }),
     finalizeTrail(baseTrails.listBase, {
       ...(overrides.list === undefined ? {} : { blaze: overrides.list }),
       output: listOutput,
+      pattern: 'crud',
     }),
   ]) as CrudTrails<TTable>;
 

--- a/packages/store/src/trails/reconcile.ts
+++ b/packages/store/src/trails/reconcile.ts
@@ -275,6 +275,7 @@ export const reconcile = <
     intent: 'write',
     on: options.on,
     output: options.table.schema as unknown as z.ZodType<EntityOf<TTable>>,
+    pattern: 'reconcile',
     resources: [options.resource],
   });
 };

--- a/packages/store/src/trails/sync.ts
+++ b/packages/store/src/trails/sync.ts
@@ -245,6 +245,7 @@ export const sync = <
     output: options.to.table.schema as unknown as z.ZodType<
       EntityOf<TTargetTable>
     >,
+    pattern: 'sync',
     resources: [options.from.resource, options.to.resource],
   });
 };


### PR DESCRIPTION
## Context

First-party factories were expected to surface `pattern` metadata, but `deriveTrail()` should not own family-level stamping itself.

## What Changed

- added optional `pattern` to `TrailSpec`
- stamped `pattern` on the first-party `crud()`, `sync()`, `reconcile()`, and `ingest()` factories
- kept `deriveTrail()` neutral unless the caller explicitly declares a pattern
- updated ADR-0032 and the lexicon, and added targeted tests for stamping and non-auto-stamping behavior

## Verification

- `bun test packages/core/src/__tests__/trail.test.ts packages/core/src/__tests__/derive-trail.test.ts packages/core/src/__tests__/ingest.test.ts packages/store/src/__tests__/crud.test.ts packages/store/src/__tests__/sync-reconcile.test.ts`
- `bun run build`
- `bun run check`

Closes: TRL-301
