### PR TITLE
refactor: ignore legacy topo tables instead of dropping them during migration

### DIFF
--- a/packages/core/src/__tests__/topo-store.test.ts
+++ b/packages/core/src/__tests__/topo-store.test.ts
@@ -454,8 +454,8 @@ const seedHistoryOnlyTopoSchema = (
 
 /**
  * Seed a pre-v7 projection store that still uses the `topo_trailheads`
- * table and the `save_id` foreign-key column. The fresh migration should drop
- * these before recreating the snapshot-first schema.
+ * table and the `save_id` foreign-key column. The fresh migration should
+ * ignore this legacy state and create the snapshot-first schema alongside it.
  */
 const seedLegacyProjectionStore = (
   db: ReturnType<typeof openWriteTrailsDb>
@@ -706,7 +706,7 @@ describe('topo store projection', () => {
       assertNoWriteEscalationOnReads(rootDir);
     });
 
-    test('createTopoStore resets a legacy history-only store during cutover', () => {
+    test('createTopoStore ignores a legacy history-only store during cutover', () => {
       const rootDir = makeRoot();
       withWriteDb(rootDir, (db) => {
         seedHistoryOnlyTopoSchema(db);
@@ -722,8 +722,8 @@ describe('topo store projection', () => {
         expect(tableExists(db, 'topo_trails')).toBe(true);
         expect(tableExists(db, 'topo_resources')).toBe(true);
         expect(tableExists(db, 'topo_surfaces')).toBe(true);
-        expect(tableExists(db, 'topo_saves')).toBe(false);
-        expect(tableExists(db, 'topo_pins')).toBe(false);
+        expect(tableExists(db, 'topo_saves')).toBe(true);
+        expect(tableExists(db, 'topo_pins')).toBe(true);
         expect(tableExists(db, 'topo_trailheads')).toBe(false);
         expect(
           db
@@ -736,7 +736,7 @@ describe('topo store projection', () => {
       });
     });
 
-    test('createTopoSnapshot succeeds after resetting a legacy projection store', () => {
+    test('createTopoSnapshot succeeds alongside a legacy projection store', () => {
       withProjectionDb((db) => {
         seedLegacyProjectionStore(db);
 
@@ -746,7 +746,7 @@ describe('topo store projection', () => {
           })
         );
 
-        expect(tableExists(db, 'topo_saves')).toBe(false);
+        expect(tableExists(db, 'topo_trailheads')).toBe(true);
         expect(countRows(db, 'topo_snapshots')).toBe(1);
         expectProjectionCounts(db, snapshot.id);
       });
@@ -779,7 +779,7 @@ describe('topo store projection', () => {
     });
   });
 
-  test('history-only topo stores are reset instead of translated into snapshots', () => {
+  test('history-only topo stores are ignored instead of translated into snapshots', () => {
     withProjectionDb((db) => {
       seedHistoryOnlyTopoSchema(db);
       ensureTopoSnapshotSchema(db);
@@ -804,10 +804,10 @@ describe('topo store projection', () => {
         expect(tableExists(db, table)).toBe(true);
       }
       expect(countRows(db, 'topo_snapshots')).toBe(0);
-      // Legacy history and trailhead tables are dropped during the migration,
-      // never translated into the new snapshot-first schema.
-      expect(tableExists(db, 'topo_saves')).toBe(false);
-      expect(tableExists(db, 'topo_pins')).toBe(false);
+      // Legacy history tables are left untouched during the migration and are
+      // simply ignored by the snapshot-first readers.
+      expect(tableExists(db, 'topo_saves')).toBe(true);
+      expect(tableExists(db, 'topo_pins')).toBe(true);
       expect(tableExists(db, 'topo_trailheads')).toBe(false);
     });
   });

--- a/packages/core/src/internal/topo-snapshots.ts
+++ b/packages/core/src/internal/topo-snapshots.ts
@@ -134,25 +134,6 @@ const TOPO_INDEX_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_topo_trail_fires_snapshot_id ON topo_trail_fires(snapshot_id)',
   'CREATE INDEX IF NOT EXISTS idx_topo_trail_on_snapshot_id ON topo_trail_on(snapshot_id)',
 ] as const;
-const ALL_TOPO_TABLES = [
-  'topo_exports',
-  'topo_schemas',
-  'topo_examples',
-  'topo_surfaces',
-  'topo_trailheads',
-  'topo_trail_signals',
-  'topo_signals',
-  'topo_trail_on',
-  'topo_trail_fires',
-  'topo_resources',
-  'topo_trail_resources',
-  'topo_crossings',
-  'topo_trails',
-  'topo_pins',
-  'topo_saves',
-  'topo_snapshots',
-] as const;
-
 interface TopoSnapshotRow {
   readonly created_at: string;
   readonly git_dirty: number;
@@ -222,30 +203,20 @@ const createAllTopoTables = (db: Database): void => {
   runStatements(db, TOPO_INDEX_STATEMENTS);
 };
 
-const dropAllTopoTables = (db: Database): void => {
-  for (const table of ALL_TOPO_TABLES) {
-    db.run(`DROP TABLE IF EXISTS ${table}`);
-  }
-};
-
 /**
  * Current topo subsystem schema version.
  *
- * Version 7 renames `topo_trailheads` to `topo_surfaces`, the stored export
- * columns to `surface_map`/`surface_hash`, and the child foreign key column
- * `save_id` to `snapshot_id` to match the snapshot-first vocabulary. Older
- * pre-release topo stores are cut over by dropping the previous history and
- * snapshot tables and recreating the schema in place rather than translating
- * old rows.
+ * Version 7 defines the snapshot-first topo tables (`topo_snapshots`,
+ * `topo_surfaces`, and `snapshot_id` foreign keys) as the only supported
+ * schema. Older pre-release tables are ignored in place; we create the current
+ * tables and advance the subsystem version without translating or deleting
+ * legacy rows.
  */
 export const TOPO_SCHEMA_VERSION = 7;
 
 export const ensureTopoSnapshotSchema = (db: Database): void => {
   ensureSubsystemSchema(db, {
-    migrate: (currentVersion) => {
-      if (currentVersion > 0 && currentVersion < TOPO_SCHEMA_VERSION) {
-        dropAllTopoTables(db);
-      }
+    migrate: () => {
       createAllTopoTables(db);
     },
     subsystem: TOPO_SUBSYSTEM,


### PR DESCRIPTION
## Replace legacy topo schema drop-and-recreate with an ignore-in-place strategy

Previously, when migrating a pre-v7 topo store, the migration would drop all existing topo tables before recreating the schema. This meant legacy rows (from `topo_saves`, `topo_pins`, etc.) were destroyed during cutover.

This changes the migration strategy so that legacy tables are left untouched. Instead of dropping and recreating, `ensureTopoSnapshotSchema` now unconditionally runs `createAllTopoTables` (using `IF NOT EXISTS` guards) and advances the subsystem version without translating or deleting any legacy rows. The snapshot-first readers simply ignore any pre-v7 tables that may still be present.

As a result:
- `dropAllTopoTables` and the `ALL_TOPO_TABLES` list are removed entirely.
- The `migrate` callback no longer receives or acts on `currentVersion`.
- `topo_saves` and `topo_pins` are expected to still exist after migration when seeded from a legacy store, and tests are updated to assert this.
- `topo_trailheads` remains absent (it was never part of the snapshot-first schema and is not created by `createAllTopoTables`).