### PR TITLE
refactor: rename `app` export to `graph` across packages and docs

### DIFF
--- a/.changeset/graph-rename-harness.md
+++ b/.changeset/graph-rename-harness.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/testing': minor
+---
+
+Rename `app` field to `graph` in `CliHarnessOptions` and `McpHarnessOptions`

--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -142,10 +142,10 @@ export const onboard = trail('entity.onboard', {
 
 ```typescript
 import { testAll } from '@ontrails/testing';
-import { app } from '../src/app.js';
+import { graph } from '../src/app.js';
 import { createMockEntityStore, entityStoreResource } from '../src/resources/entity-store.js';
 
-testAll(app, () => ({
+testAll(graph, () => ({
   resources: {
     [entityStoreResource.id]: createMockEntityStore(),
   },

--- a/apps/trails-demo/__tests__/examples.test.ts
+++ b/apps/trails-demo/__tests__/examples.test.ts
@@ -5,7 +5,7 @@
 
 import { testAll } from '@ontrails/testing';
 
-import { app } from '../src/app.js';
+import { graph } from '../src/app.js';
 
 // oxlint-disable-next-line require-hook -- testAll registers tests at module level by design
-testAll(app);
+testAll(graph);

--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -21,7 +21,7 @@ import {
 } from '@ontrails/schema';
 import { z } from 'zod';
 
-import { app } from '../src/app.js';
+import { graph } from '../src/app.js';
 import * as entitySignals from '../src/signals/entity-signals.js';
 import * as demoResources from '../src/resources/entity-store.js';
 import * as notificationStoreResource from '../src/resources/notification-store.js';
@@ -32,11 +32,11 @@ import * as onboard from '../src/trails/onboard.js';
 import * as search from '../src/trails/search.js';
 
 // ---------------------------------------------------------------------------
-// 1. Trailhead map generation
+// 1. Surface map generation
 // ---------------------------------------------------------------------------
 
-describe('trailhead map generation', () => {
-  const surfaceMap = deriveSurfaceMap(app);
+describe('surface map generation', () => {
+  const surfaceMap = deriveSurfaceMap(graph);
 
   test('contains all expected trail, event, and resource IDs', () => {
     const ids = surfaceMap.entries.map((e) => e.id);
@@ -136,10 +136,10 @@ describe('trailhead map generation', () => {
 // 2. Deterministic hashing
 // ---------------------------------------------------------------------------
 
-describe('trailhead map hashing is deterministic', () => {
+describe('surface map hashing is deterministic', () => {
   test('identical topos produce identical hashes', () => {
-    const map1 = deriveSurfaceMap(app);
-    const map2 = deriveSurfaceMap(app);
+    const map1 = deriveSurfaceMap(graph);
+    const map2 = deriveSurfaceMap(graph);
 
     const hash1 = deriveSurfaceMapHash(map1);
     const hash2 = deriveSurfaceMapHash(map2);
@@ -148,14 +148,14 @@ describe('trailhead map hashing is deterministic', () => {
   });
 
   test('hash is a valid 64-character hex string', () => {
-    const surfaceMap = deriveSurfaceMap(app);
+    const surfaceMap = deriveSurfaceMap(graph);
     const hash = deriveSurfaceMapHash(surfaceMap);
 
     expect(hash).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test('generatedAt timestamp does not affect hash', () => {
-    const map1 = deriveSurfaceMap(app);
+    const map1 = deriveSurfaceMap(graph);
 
     // Manually create a copy with a different generatedAt
     const map2 = {
@@ -204,7 +204,7 @@ const makeModifiedShow = (inputSchema: z.ZodType) =>
 
 /** Diff the baseline app against a modified app. */
 const diffAgainst = (...modules: Record<string, unknown>[]) => {
-  const before = deriveSurfaceMap(app);
+  const before = deriveSurfaceMap(graph);
   const modifiedApp = topo('demo-modified', ...modules);
   const after = deriveSurfaceMap(modifiedApp);
   return deriveSurfaceMapDiff(before, after);
@@ -320,8 +320,8 @@ describe('non-breaking change detection', () => {
   });
 
   test('no changes produces empty diff', () => {
-    const map1 = deriveSurfaceMap(app);
-    const map2 = deriveSurfaceMap(app);
+    const map1 = deriveSurfaceMap(graph);
+    const map2 = deriveSurfaceMap(graph);
     const diff = deriveSurfaceMapDiff(map1, map2);
 
     expect(diff.hasBreaking).toBe(false);
@@ -335,12 +335,12 @@ describe('non-breaking change detection', () => {
 
 describe('topo validation', () => {
   test('validateTopo passes for the demo app', () => {
-    const result = validateTopo(app);
+    const result = validateTopo(graph);
     expect(result.isOk()).toBe(true);
   });
 
   test('all trails in the topo have at least one example', () => {
-    for (const [_id, t] of app.trails) {
+    for (const [_id, t] of graph.trails) {
       const trailDef = t as { examples?: readonly unknown[] };
       expect(trailDef.examples?.length ?? 0).toBeGreaterThan(0);
     }
@@ -348,7 +348,7 @@ describe('topo validation', () => {
 
   test('topo contains the expected number of trails with examples', () => {
     let exampleCount = 0;
-    for (const [_id, t] of app.trails) {
+    for (const [_id, t] of graph.trails) {
       const trailDef = t as { examples?: readonly unknown[] };
       exampleCount += trailDef.examples?.length ?? 0;
     }

--- a/apps/trails-demo/__tests__/signals.test.ts
+++ b/apps/trails-demo/__tests__/signals.test.ts
@@ -20,7 +20,7 @@ import { describe, expect, test } from 'bun:test';
 import { run } from '@ontrails/core';
 import { firesDeclarations, onReferencesExist } from '@ontrails/warden';
 
-import { app } from '../src/app.js';
+import { graph } from '../src/app.js';
 import { entityStoreResource } from '../src/resources/entity-store.js';
 import {
   createNotificationStore,
@@ -53,7 +53,7 @@ describe('entity.updated signal flow', () => {
     const entityStore = createStore([]);
     const notificationStore = createNotificationStore();
     const result = await run(
-      app,
+      graph,
       'entity.add',
       { name: 'Epsilon', tags: ['reactive'], type: 'concept' },
       {
@@ -75,7 +75,7 @@ describe('entity.updated signal flow', () => {
     ]);
     const notificationStore = createNotificationStore();
     const result = await run(
-      app,
+      graph,
       'entity.delete',
       { name: 'Disposable' },
       {
@@ -99,17 +99,17 @@ describe('entity.updated signal flow', () => {
 
 describe('signal wiring in the demo topo', () => {
   test('entity.updated is registered as a signal', () => {
-    expect(app.signals.has('entity.updated')).toBe(true);
+    expect(graph.signals.has('entity.updated')).toBe(true);
   });
 
   test('entity.notify-updated is registered with on: [entity.updated]', () => {
-    const consumer = app.get('entity.notify-updated');
+    const consumer = graph.get('entity.notify-updated');
     expect(consumer).toBeDefined();
     expect(consumer?.on).toContain('entity.updated');
   });
 
   test('entity.add declares fires: [entity.updated]', () => {
-    const producer = app.get('entity.add');
+    const producer = graph.get('entity.add');
     expect(producer).toBeDefined();
     expect(producer?.fires).toContain('entity.updated');
   });

--- a/apps/trails-demo/bin/demo.ts
+++ b/apps/trails-demo/bin/demo.ts
@@ -11,7 +11,7 @@
 
 import { surface } from '@ontrails/cli/commander';
 
-import { app } from '../src/app.js';
+import { graph } from '../src/app.js';
 
 // oxlint-disable-next-line require-hook -- CLI entry point, not a test file
-await surface(app);
+await surface(graph);

--- a/apps/trails-demo/src/app.ts
+++ b/apps/trails-demo/src/app.ts
@@ -13,7 +13,7 @@ import * as notify from './trails/notify.js';
 import * as onboard from './trails/onboard.js';
 import * as search from './trails/search.js';
 
-export const app = topo(
+export const graph = topo(
   {
     description: 'Trails demo application',
     name: 'demo',

--- a/apps/trails-demo/src/http.ts
+++ b/apps/trails-demo/src/http.ts
@@ -7,8 +7,8 @@
 
 import { surface } from '@ontrails/hono';
 
-import { app } from './app.js';
+import { graph } from './app.js';
 
-await surface(app, {
+await surface(graph, {
   port: 3000,
 });

--- a/apps/trails-demo/src/mcp.ts
+++ b/apps/trails-demo/src/mcp.ts
@@ -7,6 +7,6 @@
 
 import { surface } from '@ontrails/mcp';
 
-import { app } from './app.js';
+import { graph } from './app.js';
 
-await surface(app);
+await surface(graph);

--- a/apps/trails/src/__tests__/load-app.test.ts
+++ b/apps/trails/src/__tests__/load-app.test.ts
@@ -32,7 +32,34 @@ const assertLoadAppCaching = async (cwd: string): Promise<void> => {
   expect(fresh.name).toBe('second');
 };
 
+const writeGraphFixture = (cwd: string, name: string): void => {
+  writeFileSync(
+    resolve(cwd, 'src/app.ts'),
+    `export const graph = {
+  name: '${name}',
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};`
+  );
+};
+
 describe('loadApp', () => {
+  test('resolves named graph export', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-graph-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      writeGraphFixture(cwd, 'graph-test');
+      const loaded = await loadApp('./src/app.ts', cwd);
+      expect(loaded.name).toBe('graph-test');
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
   test('resolves relative module paths from cwd', async () => {
     // import.meta.dir is src/__tests__/, go up two to get apps/trails/
     const cwd = resolve(import.meta.dir, '../..');

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -92,11 +92,13 @@ export const loadApp = async (
             ? new URL(resolvedModulePath).href
             : pathToFileURL(resolvedModulePath).href
         )) as Record<string, unknown>);
-  const app = (mod['default'] ?? mod['app']) as Topo | undefined;
+  const app = (mod['default'] ?? mod['graph'] ?? mod['app']) as
+    | Topo
+    | undefined;
   if (!app?.trails) {
     throw new Error(
       `Could not find a Topo export in "${effectivePath}". ` +
-        "Expected a default or named 'app' export created with topo()."
+        "Expected a default, 'graph', or 'app' named export created with topo()."
     );
   }
   return app;

--- a/connectors/hono/src/surface.ts
+++ b/connectors/hono/src/surface.ts
@@ -308,12 +308,15 @@ const registerErrorHandler = (hono: Hono): void => {
 /**
  * Build HTTP routes from a topo and register them on a Hono app.
  */
-export const createApp = (app: Topo, options: CreateAppOptions = {}): Hono => {
+export const createApp = (
+  graph: Topo,
+  options: CreateAppOptions = {}
+): Hono => {
   const hono = new Hono();
 
   registerErrorHandler(hono);
 
-  const routesResult = deriveHttpRoutes(app, {
+  const routesResult = deriveHttpRoutes(graph, {
     basePath: options.basePath,
     configValues: options.configValues,
     createContext: options.createContext,
@@ -362,10 +365,10 @@ const startServer = (
  * unserved Hono app that you can wire into your own server.
  */
 export const surface = async (
-  app: Topo,
+  graph: Topo,
   options: CreateAppOptions = {}
 ): Promise<SurfaceHttpResult> => {
   // oxlint-disable-next-line require-await -- async ensures createApp() throws become rejected promises, not uncaught exceptions
-  const hono = createApp(app, options);
+  const hono = createApp(graph, options);
   return startServer(hono, options);
 };

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -108,9 +108,9 @@ DeriveTrailSpec<TContour, TOp, TGenerated>
 ## `@ontrails/cli`
 
 ```typescript
-surface(topo, options?)                // one-liner: parse argv, execute, return exit code
-createProgram(topo, options?)          // create a Commander program without parsing argv
-deriveCliCommands(topo, options?)      // projection: Result-returning command definitions
+surface(graph, options?)               // one-liner: parse argv, execute, return exit code
+createProgram(graph, options?)         // create a Commander program without parsing argv
+deriveCliCommands(graph, options?)     // projection: Result-returning command definitions
 validateCliCommands(commands)          // validate command tree shape and collisions
 toCommander(commands, options?)        // translate commands to Commander.js program
 deriveFlags(schema, overrides?)        // Zod → CLI flags
@@ -128,9 +128,9 @@ autoIterateLayer, dateShortcutsLayer
 ## `@ontrails/mcp`
 
 ```typescript
-surface(topo, options?)                // one-liner: create server, connect stdio, return close handle
-createServer(topo, options?)           // create an MCP server without connecting
-deriveMcpTools(topo, options?)         // projection: Result-returning tool definitions
+surface(graph, options?)               // one-liner: create server, connect stdio, return close handle
+createServer(graph, options?)          // create an MCP server without connecting
+deriveMcpTools(graph, options?)        // projection: Result-returning tool definitions
 connectStdio(server)                   // connect a created server to stdio transport
 deriveToolName(appName, trailId)       // tool name derivation
 deriveAnnotations(trail)               // MCP annotations from intent and metadata
@@ -144,7 +144,7 @@ McpToolResult, McpContent, McpExtra, McpAnnotations
 ## `@ontrails/http`
 
 ```typescript
-deriveHttpRoutes(topo, options?)       // projection: route definitions without server; returns Result<HttpRouteDefinition[], Error>
+deriveHttpRoutes(graph, options?)      // projection: route definitions without server; returns Result<HttpRouteDefinition[], Error>
 
 DeriveHttpRoutesOptions, HttpMethod, HttpRouteDefinition, InputSource
 ```
@@ -152,8 +152,8 @@ DeriveHttpRoutesOptions, HttpMethod, HttpRouteDefinition, InputSource
 ## `@ontrails/hono`
 
 ```typescript
-surface(topo, options?)                // one-liner: create and serve Hono app; returns close handle + url
-createApp(topo, options?)              // create a Hono app without serving
+surface(graph, options?)               // one-liner: create and serve Hono app; returns close handle + url
+createApp(graph, options?)             // create a Hono app without serving
 
 CreateAppOptions, SurfaceHttpResult
 ```
@@ -161,8 +161,8 @@ CreateAppOptions, SurfaceHttpResult
 ## `@ontrails/schema`
 
 ```typescript
-deriveOpenApiSpec(topo, options?) // OpenAPI 3.1 spec from topo
-deriveSurfaceMap(topo), deriveSurfaceMapHash(map), deriveSurfaceMapDiff(before, after)
+deriveOpenApiSpec(graph, options?) // OpenAPI 3.1 spec from topo
+deriveSurfaceMap(graph), deriveSurfaceMapHash(map), deriveSurfaceMapDiff(before, after)
 writeSurfaceMap(map, options?), readSurfaceMap(options?)
 writeSurfaceLock(lock, options?), readSurfaceLockData(options?), readSurfaceLock(options?)
 
@@ -231,7 +231,7 @@ assertErrorMatch(result, errorClass)
 // Factories
 createTestContext(options?), createTestLogger()
 createCrossContext(options?)       // minimal context for testing trail composition via ctx.cross()
-createCliHarness(options: { app: Topo }), createMcpHarness(options: { app: Topo })
+createCliHarness(options: { graph: Topo }), createMcpHarness(options: { graph: Topo })
 
 TestExecutionOptions, TestCrossOptions
 TestScenario, CrossScenario, TestLogger, TestTrailContextOptions

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -352,7 +352,7 @@ Execute CLI commands in-process and capture stdout/stderr:
 ```typescript
 import { createCliHarness } from '@ontrails/testing';
 
-const harness = createCliHarness({ app: graph });
+const harness = createCliHarness({ graph });
 const result = await harness.run('entity show --name Alpha --output json');
 
 expect(result.exitCode).toBe(0);
@@ -366,7 +366,7 @@ Invoke MCP tools directly without transport:
 ```typescript
 import { createMcpHarness } from '@ontrails/testing';
 
-const harness = createMcpHarness({ app: graph });
+const harness = createMcpHarness({ graph });
 const result = await harness.callTool('myapp_entity_show', { name: 'Alpha' });
 
 expect(result.isError).toBe(false);

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -1,5 +1,5 @@
 /**
- * Build framework-agnostic CliCommand[] from an App's topology.
+ * Build framework-agnostic CliCommand[] from a graph topology.
  */
 
 import type {
@@ -89,14 +89,14 @@ const mergeFlags = (presets: CliFlag[], derived: CliFlag[]): CliFlag[] => {
 };
 
 const validateCliCommandBuild = (
-  app: Topo,
+  graph: Topo,
   options?: DeriveCliCommandsOptions
 ): Result<void, Error> => {
   if (options?.validate === false) {
     return Result.ok();
   }
 
-  const validated = validateEstablishedTopo(app);
+  const validated = validateEstablishedTopo(graph);
   if (validated.isErr()) {
     return Result.err(validated.error);
   }
@@ -109,7 +109,7 @@ const validateCliCommandBuild = (
 // ---------------------------------------------------------------------------
 
 /**
- * Build an array of framework-agnostic CLI commands from an App.
+ * Build an array of framework-agnostic CLI commands from a graph.
  *
  * Iterates the topo, derives flags from input schemas, groups by
  * dot-notation, and wires up the execute function with validation,
@@ -285,7 +285,7 @@ const safeMergeInput = async (
 /** Create the execute function for a CLI command. */
 const createExecute =
   (
-    app: Topo,
+    graph: Topo,
     t: AnyTrail,
     fields: readonly Field[],
     metaFlagNames: ReadonlySet<string>,
@@ -310,7 +310,7 @@ const createExecute =
         flags: parsedFlags,
         input: { ...parsedArgs, ...parsedFlags },
         result: merged,
-        topoName: app.name,
+        topoName: graph.name,
         trail: t,
       });
       return merged;
@@ -323,7 +323,7 @@ const createExecute =
       ctx: withCliTrailhead(ctxOverrides),
       layers: options?.layers,
       resources: options?.resources,
-      topo: app,
+      topo: graph,
     });
     const finalResult = maybeAddStructuredInputHint(
       result,
@@ -342,7 +342,7 @@ const createExecute =
       flags: parsedFlags,
       input: reportInput,
       result: finalResult,
-      topoName: app.name,
+      topoName: graph.name,
       trail: t,
     });
     return finalResult;
@@ -426,7 +426,7 @@ const derivePositionalArgs = (
 
 /** Convert a trail or route into a CLI command when it is publicly exposed. */
 const toCliCommand = (
-  app: Topo,
+  graph: Topo,
   t: AnyTrail,
   options?: DeriveCliCommandsOptions
 ): CliCommand => {
@@ -453,7 +453,7 @@ const toCliCommand = (
     args,
     description: t.description,
     execute: createExecute(
-      app,
+      graph,
       t,
       fields,
       metaFlagNames,
@@ -470,25 +470,25 @@ const toCliCommand = (
 };
 
 const collectCommands = (
-  app: Topo,
+  graph: Topo,
   options?: DeriveCliCommandsOptions
 ): CliCommand[] =>
-  filterSurfaceTrails(app.list(), {
+  filterSurfaceTrails(graph.list(), {
     exclude: options?.exclude,
     include: options?.include,
     intent: options?.intent,
-  }).map((trail) => toCliCommand(app, trail, options));
+  }).map((trail) => toCliCommand(graph, trail, options));
 
 export const deriveCliCommands = (
-  app: Topo,
+  graph: Topo,
   options?: DeriveCliCommandsOptions
 ): Result<CliCommand[], Error> => {
-  const validation = validateCliCommandBuild(app, options);
+  const validation = validateCliCommandBuild(graph, options);
   if (validation.isErr()) {
     return validation;
   }
 
-  const commands = collectCommands(app, options);
+  const commands = collectCommands(graph, options);
   try {
     validateCliCommands(commands);
     return Result.ok(commands);

--- a/packages/cli/src/commander/surface.ts
+++ b/packages/cli/src/commander/surface.ts
@@ -48,17 +48,17 @@ export interface SurfaceCliResult {
 // ---------------------------------------------------------------------------
 
 const deriveCommanderOptions = (
-  app: Topo,
+  graph: Topo,
   options: CreateProgramOptions
 ): ToCommanderOptions => {
   const commanderOpts: ToCommanderOptions = {
-    name: options.name ?? app.name,
+    name: options.name ?? graph.name,
   };
-  if (options.version !== undefined || app.version !== undefined) {
-    commanderOpts.version = options.version ?? app.version;
+  if (options.version !== undefined || graph.version !== undefined) {
+    commanderOpts.version = options.version ?? graph.version;
   }
-  if (options.description !== undefined || app.description !== undefined) {
-    commanderOpts.description = options.description ?? app.description;
+  if (options.description !== undefined || graph.description !== undefined) {
+    commanderOpts.description = options.description ?? graph.description;
   }
   return commanderOpts;
 };
@@ -67,10 +67,10 @@ const deriveCommanderOptions = (
  * Create a Commander program from a topo without parsing argv.
  */
 export const createProgram = (
-  app: Topo,
+  graph: Topo,
   options: CreateProgramOptions = {}
 ) => {
-  const commandsResult = deriveCliCommands(app, {
+  const commandsResult = deriveCliCommands(graph, {
     createContext: options.createContext,
     exclude: options.exclude,
     include: options.include,
@@ -88,7 +88,7 @@ export const createProgram = (
 
   return toCommander(
     commandsResult.value,
-    deriveCommanderOptions(app, options)
+    deriveCommanderOptions(graph, options)
   );
 };
 
@@ -100,14 +100,14 @@ export const createProgram = (
  * Parse argv for a topo through Commander.
  *
  * Returns the process exit code without calling `process.exit()`, so callers
- * can run cleanup before terminating. The CLI `trailhead()` entry point
+ * can run cleanup before terminating. The CLI `surface()` entry point
  * delegates here and lets the process exit naturally.
  */
 export const surface = async (
-  app: Topo,
+  graph: Topo,
   options: CreateProgramOptions = {}
 ): Promise<SurfaceCliResult> => {
-  const program = createProgram(app, options);
+  const program = createProgram(graph, options);
   await program.parseAsync();
   const { exitCode } = process;
   return { exitCode: typeof exitCode === 'number' ? exitCode : 0 };

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -156,7 +156,7 @@ The config layer reserves a slot in the execution context for per-trail config v
 ```typescript
 import { configLayer } from '@ontrails/config';
 
-export const app = topo('my-app', configModule);
+export const graph = topo('my-app', configModule);
 // Register configLayer with your trailhead
 ```
 
@@ -185,7 +185,7 @@ Trails that depend on `configResource` auto-resolve with a mock when registered 
 ```typescript
 import { testAll } from '@ontrails/testing';
 
-const results = testAll(app);
+const results = testAll(graph);
 // configResource.mock() is called automatically
 ```
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,7 +18,7 @@ const greet = trail('greet', {
   blaze: (input) => Result.ok({ message: `Hello, ${input.name}!` }),
 });
 
-const app = topo('myapp', { greet });
+const graph = topo('myapp', { greet });
 ```
 
 Trails compose other trails through `crosses` and `ctx.cross()`:
@@ -60,7 +60,7 @@ const onboard = trail('entity.onboard', {
 const result = await executeTrail(greet, { name: 'Alice' });
 
 // run — no-trailhead execution by trail ID
-const result = await run(app, 'greet', { name: 'Alice' });
+const result = await run(graph, 'greet', { name: 'Alice' });
 if (result.isOk()) console.log(result.value);
 ```
 

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -121,7 +121,7 @@ const withHttpTrailhead = (
  */
 const createExecute =
   (
-    app: Topo,
+    graph: Topo,
     t: Trail<unknown, unknown, unknown>,
     layers: readonly Layer[],
     options: DeriveHttpRoutesOptions
@@ -134,7 +134,7 @@ const createExecute =
       ctx: withHttpTrailhead(requestId),
       layers,
       resources: options.resources,
-      topo: app,
+      topo: graph,
     });
 
 // ---------------------------------------------------------------------------
@@ -143,10 +143,10 @@ const createExecute =
 
 /** Filter topo items to eligible trails. */
 const eligibleTrails = (
-  app: Topo,
+  graph: Topo,
   options: DeriveHttpRoutesOptions
 ): Trail<unknown, unknown, unknown>[] =>
-  filterSurfaceTrails(app.list(), {
+  filterSurfaceTrails(graph.list(), {
     exclude: options.exclude,
     include: options.include,
     intent: options.intent,
@@ -154,7 +154,7 @@ const eligibleTrails = (
 
 /** Build a single route definition from a trail. */
 const buildRoute = (
-  app: Topo,
+  graph: Topo,
   trail: Trail<unknown, unknown, unknown>,
   basePath: string,
   layers: readonly Layer[],
@@ -163,7 +163,7 @@ const buildRoute = (
   const method = deriveMethod(trail);
   const path = derivePath(basePath, trail.id);
   return {
-    execute: createExecute(app, trail, layers, options),
+    execute: createExecute(graph, trail, layers, options),
     inputSource: deriveInputSource(method),
     method,
     path,
@@ -202,7 +202,7 @@ const registerRoute = (
 
 /** Accumulate route definitions, returning early on the first collision. */
 const accumulateRoutes = (
-  app: Topo,
+  graph: Topo,
   trails: Trail<unknown, unknown, unknown>[],
   basePath: string,
   layers: readonly Layer[],
@@ -212,7 +212,7 @@ const accumulateRoutes = (
   const seenRoutes = new Map<string, string>();
 
   for (const trail of trails) {
-    const route = buildRoute(app, trail, basePath, layers, options);
+    const route = buildRoute(graph, trail, basePath, layers, options);
     const registered = registerRoute(route, seenRoutes, routes);
     if (registered.isErr()) {
       return registered;
@@ -239,11 +239,11 @@ const accumulateRoutes = (
  * (method, path) pair. Returns `Result.ok(routes)` on success.
  */
 export const deriveHttpRoutes = (
-  app: Topo,
+  graph: Topo,
   options: DeriveHttpRoutesOptions = {}
 ): Result<HttpRouteDefinition[], Error> => {
   if (options.validate !== false) {
-    const validated = validateEstablishedTopo(app);
+    const validated = validateEstablishedTopo(graph);
     if (validated.isErr()) {
       return Result.err(validated.error);
     }
@@ -252,8 +252,8 @@ export const deriveHttpRoutes = (
   const basePath = (options.basePath ?? '').replace(/\/+$/, '');
   const layers = options.layers ?? [];
   return accumulateRoutes(
-    app,
-    eligibleTrails(app, options),
+    graph,
+    eligibleTrails(graph, options),
     basePath,
     layers,
     options

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -263,7 +263,7 @@ const createHandler =
  * Build MCP tool definitions from a graph's topology.
  *
  * Each trail in the topo becomes an McpToolDefinition with:
- * - A derived tool name (graph-prefixed, underscore-delimited)
+ * - A derived tool name (topo-name-prefixed, underscore-delimited)
  * - JSON Schema input from zodToJsonSchema
  * - MCP annotations from trail meta
  * - A handler that validates, composes layers, executes, and maps results

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -1,5 +1,5 @@
 /**
- * Build MCP tool definitions from a Trails App.
+ * Build MCP tool definitions from a Trails graph.
  *
  * Iterates the topo, generates McpToolDefinition[] with handlers that
  * validate input, compose layers, execute the implementation, and map
@@ -230,7 +230,7 @@ const withMcpTrailhead = (
 
 const createHandler =
   (
-    app: Topo,
+    graph: Topo,
     t: Trail<unknown, unknown, unknown>,
     layers: readonly Layer[],
     options: DeriveMcpToolsOptions
@@ -247,7 +247,7 @@ const createHandler =
       ctx: withMcpTrailhead(progressCb),
       layers,
       resources: options.resources,
-      topo: app,
+      topo: graph,
     });
     if (result.isOk()) {
       return { content: await serializeOutput(result.value) };
@@ -260,10 +260,10 @@ const createHandler =
 // ---------------------------------------------------------------------------
 
 /**
- * Build MCP tool definitions from an App's topology.
+ * Build MCP tool definitions from a graph's topology.
  *
  * Each trail in the topo becomes an McpToolDefinition with:
- * - A derived tool name (app-prefixed, underscore-delimited)
+ * - A derived tool name (graph-prefixed, underscore-delimited)
  * - JSON Schema input from zodToJsonSchema
  * - MCP annotations from trail meta
  * - A handler that validates, composes layers, executes, and maps results
@@ -289,7 +289,7 @@ const buildDescription = (
 
 /** Build a single MCP tool definition from a trail. */
 const buildToolDefinition = (
-  app: Topo,
+  graph: Topo,
   trail: Trail<unknown, unknown, unknown>,
   layers: readonly Layer[],
   options: DeriveMcpToolsOptions
@@ -300,23 +300,23 @@ const buildToolDefinition = (
   return {
     annotations,
     description: buildDescription(trail),
-    handler: createHandler(app, trail, layers, options),
+    handler: createHandler(graph, trail, layers, options),
     inputSchema: zodToJsonSchema(trail.input),
-    name: deriveToolName(app.name, trail.id),
+    name: deriveToolName(graph.name, trail.id),
     trailId: trail.id,
   };
 };
 
 /** Register a trail as an MCP tool, checking for name collisions. */
 const registerTool = (
-  app: Topo,
+  graph: Topo,
   trailItem: Trail<unknown, unknown, unknown>,
   layers: readonly Layer[],
   options: DeriveMcpToolsOptions,
   nameToTrailId: Map<string, string>,
   tools: McpToolDefinition[]
 ): Result<void, Error> => {
-  const toolName = deriveToolName(app.name, trailItem.id);
+  const toolName = deriveToolName(graph.name, trailItem.id);
   const existingId = nameToTrailId.get(toolName);
   if (existingId !== undefined) {
     return Result.err(
@@ -326,44 +326,44 @@ const registerTool = (
     );
   }
   nameToTrailId.set(toolName, trailItem.id);
-  tools.push(buildToolDefinition(app, trailItem, layers, options));
+  tools.push(buildToolDefinition(graph, trailItem, layers, options));
   return Result.ok();
 };
 
 /** Filter topo items to eligible trails. */
 const eligibleTrails = (
-  app: Topo,
+  graph: Topo,
   options: DeriveMcpToolsOptions
 ): Trail<unknown, unknown, unknown>[] =>
-  filterSurfaceTrails(app.list(), {
+  filterSurfaceTrails(graph.list(), {
     exclude: options.exclude,
     include: options.include,
     intent: options.intent,
   });
 
 const validateToolBuild = (
-  app: Topo,
+  graph: Topo,
   options: DeriveMcpToolsOptions
 ): Result<void, Error> => {
   if (options.validate === false) {
     return Result.ok();
   }
 
-  const validated = validateEstablishedTopo(app);
+  const validated = validateEstablishedTopo(graph);
   return validated.isErr() ? Result.err(validated.error) : Result.ok();
 };
 
 const registerTools = (
-  app: Topo,
+  graph: Topo,
   options: DeriveMcpToolsOptions,
   layers: readonly Layer[]
 ): Result<McpToolDefinition[], Error> => {
   const tools: McpToolDefinition[] = [];
   const nameToTrailId = new Map<string, string>();
 
-  for (const trailItem of eligibleTrails(app, options)) {
+  for (const trailItem of eligibleTrails(graph, options)) {
     const registered = registerTool(
-      app,
+      graph,
       trailItem,
       layers,
       options,
@@ -379,13 +379,13 @@ const registerTools = (
 };
 
 export const deriveMcpTools = (
-  app: Topo,
+  graph: Topo,
   options: DeriveMcpToolsOptions = {}
 ): Result<McpToolDefinition[], Error> => {
-  const validation = validateToolBuild(app, options);
+  const validation = validateToolBuild(graph, options);
   if (validation.isErr()) {
     return validation;
   }
 
-  return registerTools(app, options, options.layers ?? []);
+  return registerTools(graph, options, options.layers ?? []);
 };

--- a/packages/mcp/src/surface.ts
+++ b/packages/mcp/src/surface.ts
@@ -147,10 +147,10 @@ const createMcpServer = (
  * Build MCP tools from a topo and create an MCP server.
  */
 export const createServer = (
-  app: Topo,
+  graph: Topo,
   options: CreateServerOptions = {}
 ): Server => {
-  const toolsResult = deriveMcpTools(app, {
+  const toolsResult = deriveMcpTools(graph, {
     configValues: options.configValues,
     createContext: options.createContext,
     exclude: options.exclude,
@@ -166,9 +166,9 @@ export const createServer = (
   }
 
   return createMcpServer(toolsResult.value, {
-    description: options.description ?? app.description,
-    name: options.name ?? app.name,
-    version: options.version ?? app.version ?? '0.1.0',
+    description: options.description ?? graph.description,
+    name: options.name ?? graph.name,
+    version: options.version ?? graph.version ?? '0.1.0',
   });
 };
 
@@ -183,10 +183,10 @@ export const createServer = (
  * `createServer(graph)` with `connectStdio` or your own connector.
  */
 export const surface = async (
-  app: Topo,
+  graph: Topo,
   options: CreateServerOptions = {}
 ): Promise<SurfaceMcpResult> => {
-  const server = createServer(app, options);
+  const server = createServer(graph, options);
   await connectStdio(server);
 
   return {

--- a/packages/permits/README.md
+++ b/packages/permits/README.md
@@ -31,7 +31,7 @@ export const search = trail('gist.search', {
 ```typescript
 import { authLayer } from '@ontrails/permits';
 
-export const app = topo('my-app', gistModule);
+export const graph = topo('my-app', gistModule);
 // Register authLayer with your trailhead
 ```
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -26,21 +26,21 @@ import {
   writeSurfaceMap,
 } from '@ontrails/schema';
 
-const map = deriveSurfaceMap(app);
+const map = deriveSurfaceMap(graph);
 const hash = deriveSurfaceMapHash(map);
 
 await writeSurfaceMap(map);
 await writeSurfaceLock({ hash });
 
 // Later, after changes:
-const nextMap = deriveSurfaceMap(app);
+const nextMap = deriveSurfaceMap(graph);
 const diff = deriveSurfaceMapDiff(map, nextMap);
 
 if (diff.hasBreaking) {
   console.error('Breaking changes:', diff.breaking);
 }
 
-const openApi = deriveOpenApiSpec(app);
+const openApi = deriveOpenApiSpec(graph);
 ```
 
 `deriveSurfaceMap()` rejects draft-contaminated topos. Only established state can be serialized into the committed artifacts.
@@ -96,7 +96,7 @@ Because CLI paths are now full hierarchical command paths, command-tree changes 
 ```typescript
 import { deriveSurfaceMap, deriveSurfaceMapHash, readSurfaceLock } from '@ontrails/schema';
 
-const current = deriveSurfaceMapHash(deriveSurfaceMap(app));
+const current = deriveSurfaceMapHash(deriveSurfaceMap(graph));
 const committed = await readSurfaceLock();
 
 if (committed !== current) {

--- a/packages/schema/src/openapi.ts
+++ b/packages/schema/src/openapi.ts
@@ -25,7 +25,7 @@ export interface OpenApiServer {
 }
 
 export interface OpenApiOptions {
-  /** Default: `app.name` */
+  /** Default: `graph.name` */
   readonly title?: string | undefined;
   /** Default: `'1.0.0'` */
   readonly version?: string | undefined;
@@ -285,15 +285,15 @@ const buildOperation = (
 // Path collection
 // ---------------------------------------------------------------------------
 
-/** Collect all paths from public trails in the topo. */
+/** Collect all paths from public trails in the graph. */
 const collectPaths = (
-  app: Topo,
+  graph: Topo,
   basePath: string,
   options?: OpenApiOptions
 ): Record<string, Record<string, unknown>> => {
   const paths: Record<string, Record<string, unknown>> = {};
 
-  for (const t of filterSurfaceTrails(app.list(), {
+  for (const t of filterSurfaceTrails(graph.list(), {
     exclude: options?.exclude,
     include: options?.include,
     intent: options?.intent,
@@ -307,12 +307,12 @@ const collectPaths = (
   return paths;
 };
 
-/** Build the info object from options and app name. */
+/** Build the info object from options and graph name. */
 const buildInfo = (
-  appName: string,
+  graphName: string,
   options?: OpenApiOptions
 ): OpenApiSpec['info'] => ({
-  title: options?.title ?? appName,
+  title: options?.title ?? graphName,
   version: options?.version ?? '1.0.0',
   ...(options?.description ? { description: options.description } : {}),
 });
@@ -329,20 +329,20 @@ const buildInfo = (
  * the trail contract.
  */
 export const deriveOpenApiSpec = (
-  app: Topo,
+  graph: Topo,
   options?: OpenApiOptions
 ): OpenApiSpec => {
-  const validated = validateDraftFreeTopo(app);
+  const validated = validateDraftFreeTopo(graph);
   if (validated.isErr()) {
     throw validated.error;
   }
 
   return {
     components: { schemas: {} },
-    info: buildInfo(app.name, options),
+    info: buildInfo(graph.name, options),
     openapi: '3.1.0',
     paths: collectPaths(
-      app,
+      graph,
       (options?.basePath ?? '').replace(/\/+$/, ''),
       options
     ),

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,14 +1,14 @@
 # @ontrails/testing
 
-Contract-driven testing for Trails. Add examples to your trails, then `testAll(app)` runs them as assertions, validates output schemas, checks composition graphs, and verifies structural integrity. One line of test code, full governance.
+Contract-driven testing for Trails. Add examples to your trails, then `testAll(graph)` runs them as assertions, validates output schemas, checks composition graphs, and verifies structural integrity. One line of test code, full governance.
 
 ## Usage
 
 ```typescript
 import { testAll } from '@ontrails/testing';
-import { app } from '../app';
+import { graph } from '../app';
 
-testAll(app);
+testAll(graph);
 ```
 
 That single call covers example execution, contract validation, detour checks, and topo validation. For most apps, this is all you need.
@@ -18,9 +18,9 @@ If you want finer control:
 ```typescript
 import { testExamples, testContracts, testDetours } from '@ontrails/testing';
 
-testExamples(app);   // Run every trail's examples as tests
-testContracts(app);  // Validate outputs against declared schemas
-testDetours(app);    // Verify detour targets exist
+testExamples(graph);   // Run every trail's examples as tests
+testContracts(graph);  // Validate outputs against declared schemas
+testDetours(graph);    // Verify detour targets exist
 ```
 
 ## API
@@ -92,12 +92,12 @@ Calls to unregistered trail IDs return `Result.err` with a descriptive message, 
 import { createCliHarness, createMcpHarness } from '@ontrails/testing';
 
 // CLI
-const cli = createCliHarness({ app });
+const cli = createCliHarness({ graph });
 const result = await cli.run('entity show --name Alpha --output json');
 expect(result.exitCode).toBe(0);
 
 // MCP
-const mcp = createMcpHarness({ app });
+const mcp = createMcpHarness({ graph });
 const tool = await mcp.callTool('myapp_entity_show', { name: 'Alpha' });
 expect(tool.isError).toBe(false);
 ```

--- a/packages/testing/src/__tests__/harness-cli.test.ts
+++ b/packages/testing/src/__tests__/harness-cli.test.ts
@@ -12,7 +12,7 @@ describe('createCliHarness', () => {
       input: z.object({ name: z.string() }),
     });
     const harness = createCliHarness({
-      app: topo('test-app', { greet }),
+      graph: topo('test-app', { greet }),
     });
 
     const result = await harness.run('greet --name Trails');
@@ -27,7 +27,7 @@ describe('createCliHarness', () => {
       input: z.object({ name: z.string() }),
     });
     const harness = createCliHarness({
-      app: topo('test-app', { pin }),
+      graph: topo('test-app', { pin }),
     });
 
     const result = await harness.run('topo pin --name before-auth');
@@ -53,7 +53,7 @@ describe('createCliHarness', () => {
       input: z.object({}),
     });
     const harness = createCliHarness({
-      app: topo('test-app', { topoPin, topoShow }),
+      graph: topo('test-app', { topoPin, topoShow }),
     });
 
     const child = await harness.run('topo pin');

--- a/packages/testing/src/all.ts
+++ b/packages/testing/src/all.ts
@@ -31,9 +31,9 @@ import { testExamples } from './examples.js';
  * @example
  * ```ts
  * import { testAll } from '@ontrails/testing';
- * import { app } from '../src/app.js';
+ * import { graph } from '../src/app.js';
  *
- * testAll(app);
+ * testAll(graph);
  * ```
  */
 export const testAll = (

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -300,7 +300,7 @@ const runCompositionExample = async (
  *
  * One line in your test file:
  * ```ts
- * testExamples(app);
+ * testExamples(graph);
  * ```
  */
 export const testExamples = (

--- a/packages/testing/src/harness-cli.ts
+++ b/packages/testing/src/harness-cli.ts
@@ -1,7 +1,7 @@
 /**
  * CLI integration test harness.
  *
- * Builds CLI commands from an App, executes them in-process,
+ * Builds CLI commands from a graph, executes them in-process,
  * and captures stdout/stderr.
  */
 
@@ -268,17 +268,17 @@ const runCommand = async (
 /**
  * Create a CLI harness for integration testing.
  *
- * Builds commands from the app's topo and provides a `run()` method
+ * Builds commands from the graph's topo and provides a `run()` method
  * that parses command strings and executes them in-process.
  *
  * ```ts
- * const harness = createCliHarness({ app });
+ * const harness = createCliHarness({ graph });
  * const result = await harness.run("entity show --name Alpha --output json");
  * expect(result.exitCode).toBe(0);
  * ```
  */
 export const createCliHarness = (options: CliHarnessOptions): CliHarness => {
-  const commandsResult = deriveCliCommands(options.app);
+  const commandsResult = deriveCliCommands(options.graph);
   if (commandsResult.isErr()) {
     throw commandsResult.error;
   }

--- a/packages/testing/src/harness-mcp.ts
+++ b/packages/testing/src/harness-mcp.ts
@@ -1,7 +1,7 @@
 /**
  * MCP integration test harness.
  *
- * Builds MCP tools from an App, invokes them directly (no transport),
+ * Builds MCP tools from a graph, invokes them directly (no transport),
  * and returns the MCP tool response.
  */
 
@@ -21,17 +21,17 @@ import type {
 /**
  * Create an MCP harness for integration testing.
  *
- * Builds MCP tools from the app's topo and provides a `callTool()` method
+ * Builds MCP tools from the graph's topo and provides a `callTool()` method
  * that invokes tools directly without any transport boundary.
  *
  * ```ts
- * const harness = createMcpHarness({ app });
+ * const harness = createMcpHarness({ graph });
  * const result = await harness.callTool("myapp_entity_show", { name: "Alpha" });
  * expect(result.isError).toBe(false);
  * ```
  */
 export const createMcpHarness = (options: McpHarnessOptions): McpHarness => {
-  const toolsResult = deriveMcpTools(options.app);
+  const toolsResult = deriveMcpTools(options.graph);
   if (toolsResult.isErr()) {
     throw toolsResult.error;
   }

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -75,7 +75,7 @@ export interface TestTrailContextOptions {
 
 /** Options for creating a CLI harness. */
 export interface CliHarnessOptions {
-  readonly app: Topo;
+  readonly graph: Topo;
 }
 
 /** A test harness for CLI commands. */
@@ -99,7 +99,7 @@ export interface CliHarnessResult {
 
 /** Options for creating an MCP harness. */
 export interface McpHarnessOptions {
-  readonly app: Topo;
+  readonly graph: Topo;
 }
 
 /** A test harness for MCP tools. */

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -22,7 +22,7 @@ Sinks receive completed `TraceRecord` records. The default sink is a no-op — t
 Tracing happens automatically. No layer attachment, no per-trail wiring.
 
 ```typescript
-await run(app, 'user.create', { name: 'alice' });
+await run(graph, 'user.create', { name: 'alice' });
 
 // sink.records now contains a root TraceRecord for the execution
 ```

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -20,7 +20,7 @@ Or programmatically:
 ```typescript
 import { runWarden, formatWardenReport } from '@ontrails/warden';
 
-const report = await runWarden({ topo: app });
+const report = await runWarden({ topo: graph });
 console.log(formatWardenReport(report));
 ```
 
@@ -51,7 +51,7 @@ Warden integrates with `@ontrails/schema` to detect when the topo has changed wi
 ```typescript
 import { checkDrift } from '@ontrails/warden';
 
-const drift = await checkDrift(process.cwd(), app);
+const drift = await checkDrift(process.cwd(), graph);
 if (drift.stale) {
   console.log('lock file is stale -- regenerate with `trails topo export`');
 }

--- a/plugin/skills/trails/references/testing-patterns.md
+++ b/plugin/skills/trails/references/testing-patterns.md
@@ -209,7 +209,7 @@ logger.clear(); // reset captured entries
 ```typescript
 import { createCliHarness } from '@ontrails/testing';
 
-const cli = createCliHarness({ app: graph });
+const cli = createCliHarness({ graph });
 const result = await cli.run('entity show --name Alpha --output json');
 expect(result.exitCode).toBe(0);
 expect(result.json).toEqual({ name: 'Alpha', type: 'concept' });
@@ -222,7 +222,7 @@ expect(result.json).toEqual({ name: 'Alpha', type: 'concept' });
 ```typescript
 import { createMcpHarness } from '@ontrails/testing';
 
-const mcp = createMcpHarness({ app: graph });
+const mcp = createMcpHarness({ graph });
 const result = await mcp.callTool('myapp_entity_show', { name: 'Alpha' });
 expect(result.isError).toBe(false);
 ```


### PR DESCRIPTION
Renames the exported `app` constant to `graph` throughout the codebase, and updates all call sites, type definitions, option interfaces, and documentation to use `graph` as the parameter and property name when referring to a `Topo` instance. The `CliHarnessOptions.app` and `McpHarnessOptions.app` fields are renamed to `graph`, and test descriptions referencing "trailhead map" are updated to "surface map" for consistency with the existing naming convention.