### PR TITLE
chore(ci): ignore graphite-base pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize]
+    branches-ignore:
+      - '**/graphite-base/**'
   push:
     branches: [main]
 


### PR DESCRIPTION
## Context
We enabled Graphite merge queue for Trails and want CI to avoid unnecessary runs against Graphite's temporary `graphite-base/*` branches during stack restacks.

## What Changed
- limit `pull_request` CI triggers to `opened`, `reopened`, and `synchronize`
- ignore `graphite-base/*` pull request base branches in the main CI workflow

## How To Test
- confirm the workflow still runs normally for regular PR updates
- confirm Graphite restacks do not trigger extra CI runs against temporary `graphite-base/*` branches

## Risks
- low: this only changes GitHub Actions trigger conditions for the existing CI workflow