### PR TITLE
test(vite): use workspace imports in surface tests [TRL-330]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -107,6 +107,8 @@
       "name": "@ontrails/vite",
       "version": "1.0.0-beta.14",
       "devDependencies": {
+        "@ontrails/core": "workspace:^",
+        "@ontrails/hono": "workspace:^",
         "zod": "catalog:",
       },
     },

--- a/connectors/vite/package.json
+++ b/connectors/vite/package.json
@@ -14,6 +14,8 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "devDependencies": {
+    "@ontrails/core": "workspace:^",
+    "@ontrails/hono": "workspace:^",
     "zod": "catalog:"
   }
 }

--- a/connectors/vite/src/__tests__/surface.test.ts
+++ b/connectors/vite/src/__tests__/surface.test.ts
@@ -4,8 +4,8 @@ import { createServer } from 'node:http';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
-import { createApp } from '../../../../connectors/hono/src/index.ts';
-import { Result, trail, topo } from '../../../../packages/core/src/index.ts';
+import { Result, trail, topo } from '@ontrails/core';
+import { createApp } from '@ontrails/hono';
 import { z } from 'zod';
 
 import { vite } from '../index.js';


### PR DESCRIPTION
## Summary
- replace deep relative test imports in the Vite adapter test with workspace package imports
- declare the workspace package devDependencies Bun needs to resolve those imports in the package test environment
- keep the runtime adapter API unchanged (`vite(httpApp)`)

## Testing
- bun test connectors/vite/src/__tests__/surface.test.ts
- bun run typecheck --filter @ontrails/vite

Closes TRL-330