### PR TITLE
fix: reload local dependency graph for fresh app loads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 dist/
 .turbo/
 .scratch/
+.tmp-tests/
+.trails-tmp/
 .try/
 *.tsbuildinfo
 .DS_Store

--- a/apps/trails/src/__tests__/load-app.test.ts
+++ b/apps/trails/src/__tests__/load-app.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, test } from 'bun:test';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { afterAll, describe, expect, test } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
@@ -32,6 +40,66 @@ const assertLoadAppCaching = async (cwd: string): Promise<void> => {
   expect(fresh.name).toBe('second');
 };
 
+const writeDependentLoadAppFixture = (cwd: string, name: string): void => {
+  writeFileSync(resolve(cwd, 'src/name.ts'), `export const name = '${name}';`);
+  writeFileSync(
+    resolve(cwd, 'src/app.ts'),
+    `import { name } from './name.ts';
+
+export const app = {
+  name,
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};`
+  );
+};
+
+const writeJsSpecifierLoadAppFixture = (cwd: string, name: string): void => {
+  writeFileSync(resolve(cwd, 'src/name.ts'), `export const name = '${name}';`);
+  writeFileSync(
+    resolve(cwd, 'src/app.ts'),
+    `import { name } from './name.js';
+
+export const app = {
+  name,
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};`
+  );
+};
+
+const assertLoadAppDependencyCaching = async (cwd: string): Promise<void> => {
+  writeDependentLoadAppFixture(cwd, 'first');
+
+  const first = await loadApp('./src/app.ts', cwd);
+
+  writeDependentLoadAppFixture(cwd, 'second');
+
+  const cached = await loadApp('./src/app.ts', cwd);
+  const fresh = await loadApp('./src/app.ts', cwd, { fresh: true });
+
+  expect(first.name).toBe('first');
+  expect(cached.name).toBe('first');
+  expect(fresh.name).toBe('second');
+};
+
+const assertLoadAppJsSpecifierCaching = async (cwd: string): Promise<void> => {
+  writeJsSpecifierLoadAppFixture(cwd, 'first');
+
+  const first = await loadApp('./src/app.ts', cwd);
+
+  writeJsSpecifierLoadAppFixture(cwd, 'second');
+
+  const cached = await loadApp('./src/app.ts', cwd);
+  const fresh = await loadApp('./src/app.ts', cwd, { fresh: true });
+
+  expect(first.name).toBe('first');
+  expect(cached.name).toBe('first');
+  expect(fresh.name).toBe('second');
+};
+
 const writeGraphFixture = (cwd: string, name: string): void => {
   writeFileSync(
     resolve(cwd, 'src/app.ts'),
@@ -44,7 +112,89 @@ const writeGraphFixture = (cwd: string, name: string): void => {
   );
 };
 
+const writeWorkspaceDependencyFixture = (cwd: string): void => {
+  writeFileSync(
+    resolve(cwd, 'src/app.ts'),
+    `import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const sample = trail('sample', {
+  blaze: async () => Result.ok({ ok: true }),
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+});
+
+export const app = topo('fixture', { sample });
+`
+  );
+};
+
+// Bytes that are intentionally not valid UTF-8. Decoding then re-encoding
+// would replace them with U+FFFD and corrupt the file.
+const BINARY_SIBLING_BYTES = new Uint8Array([
+  0, 1, 2, 255, 254, 253, 192, 193, 245, 255, 128, 129,
+]);
+
+const BINARY_SIBLING_APP_SOURCE = `import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bytes = readFileSync(resolve(here, 'blob.bin'));
+
+export const app = {
+  name: Array.from(bytes).join(','),
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};`;
+
+const assertLoadAppPreservesBinarySiblings = async (
+  cwd: string
+): Promise<void> => {
+  mkdirSync(resolve(cwd, 'src'), { recursive: true });
+  writeFileSync(resolve(cwd, 'src/blob.bin'), BINARY_SIBLING_BYTES);
+  writeFileSync(resolve(cwd, 'src/app.ts'), BINARY_SIBLING_APP_SOURCE);
+
+  const fresh = await loadApp('./src/app.ts', cwd, { fresh: true });
+  const originalBytes = readFileSync(resolve(cwd, 'src/blob.bin'));
+  const expected = [...originalBytes].join(',');
+  expect(fresh.name).toBe(expected);
+};
+
+/**
+ * Seed a stale mirror dir under `.trails-tmp/` with an mtime well past the
+ * 10-minute freshness threshold, simulating a directory abandoned by a
+ * signal-killed process.
+ */
+const seedStaleMirrorDir = (cwd: string): string => {
+  mkdirSync(resolve(cwd, 'src'), { recursive: true });
+  writeLoadAppFixture(cwd, 'stale-cleanup');
+  const mirrorParent = resolve(cwd, '.trails-tmp');
+  const staleDir = resolve(mirrorParent, 'load-app-fresh-stale-fixture');
+  mkdirSync(staleDir, { recursive: true });
+  writeFileSync(resolve(staleDir, 'marker'), 'stale');
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+  utimesSync(staleDir, oneHourAgo, oneHourAgo);
+  return staleDir;
+};
+
+const assertStaleDirCleaned = (cwd: string, staleDir: string): void => {
+  expect(existsSync(staleDir)).toBe(false);
+  const mirrorParent = resolve(cwd, '.trails-tmp');
+  const remaining = readdirSync(mirrorParent).filter((entry) =>
+    entry.startsWith('load-app-fresh-')
+  );
+  expect(remaining.length).toBeGreaterThan(0);
+};
+
+const workspaceTmpRoot = resolve(import.meta.dir, '../..', '.tmp-tests');
+
 describe('loadApp', () => {
+  afterAll(() => {
+    rmSync(workspaceTmpRoot, { force: true, recursive: true });
+  });
+
   test('resolves named graph export', async () => {
     const cwd = resolve(
       tmpdir(),
@@ -78,6 +228,127 @@ describe('loadApp', () => {
     try {
       mkdirSync(resolve(cwd, 'src'), { recursive: true });
       await assertLoadAppCaching(cwd);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('fresh loading reloads transitive local imports', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-deps-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      await assertLoadAppDependencyCaching(cwd);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('fresh loading resolves .js specifiers to local .ts sources', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-js-specifier-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      await assertLoadAppJsSpecifierCaching(cwd);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('fresh loading mirrors siblings reached via computed dynamic imports', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-dynamic-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src/parts'), { recursive: true });
+      writeFileSync(
+        resolve(cwd, 'src/parts/alpha.ts'),
+        `export const label = 'alpha';`
+      );
+      writeFileSync(
+        resolve(cwd, 'src/parts/beta.ts'),
+        `export const label = 'beta';`
+      );
+      writeFileSync(
+        resolve(cwd, 'src/app.ts'),
+        `const which = 'beta';
+const mod = await import(\`./parts/\${which}.ts\`);
+
+export const app = {
+  name: mod.label,
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};`
+      );
+
+      const fresh = await loadApp('./src/app.ts', cwd, { fresh: true });
+      expect(fresh.name).toBe('beta');
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('fresh loading preserves binary sibling bytes in the mirror', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-binary-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      await assertLoadAppPreservesBinarySiblings(cwd);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('fresh loading opportunistically cleans up stale mirror roots', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-stale-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      const staleDir = seedStaleMirrorDir(cwd);
+      await loadApp('./src/app.ts', cwd, { fresh: true });
+      assertStaleDirCleaned(cwd, staleDir);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('fresh loading preserves workspace package resolution for mirrored apps', async () => {
+    const cwd = resolve(
+      workspaceTmpRoot,
+      `trails-load-app-workspace-deps-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      writeWorkspaceDependencyFixture(cwd);
+
+      const app = await loadApp('./src/app.ts', cwd, { fresh: true });
+
+      expect(app.name).toBe('fixture');
+      expect(app.get('sample')).toBeDefined();
     } finally {
       rmSync(cwd, { force: true, recursive: true });
     }

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -1,11 +1,83 @@
-import { existsSync, rmSync } from 'node:fs';
-import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  parse as parsePath,
+  relative,
+  resolve,
+} from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { Topo } from '@ontrails/core';
 import { findAppModule } from '@ontrails/cli';
 
 const URL_SCHEME = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+
+type TranspilerLoader = 'ts' | 'tsx' | 'js' | 'jsx';
+
+/** Extension → Bun.Transpiler loader, so JSX-bearing files parse correctly. */
+const LOADER_BY_EXTENSION: Record<string, TranspilerLoader> = {
+  '.cjs': 'js',
+  '.cts': 'ts',
+  '.js': 'js',
+  '.jsx': 'jsx',
+  '.mjs': 'js',
+  '.mts': 'ts',
+  '.ts': 'ts',
+  '.tsx': 'tsx',
+};
+
+const SCANNABLE_EXTENSIONS = new Set(Object.keys(LOADER_BY_EXTENSION));
+
+const TRANSPILER_CACHE = new Map<TranspilerLoader, Bun.Transpiler>();
+
+const getImportScanner = (loader: TranspilerLoader): Bun.Transpiler => {
+  const cached = TRANSPILER_CACHE.get(loader);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const scanner = new Bun.Transpiler({ loader });
+  TRANSPILER_CACHE.set(loader, scanner);
+  return scanner;
+};
+
+/**
+ * Mirror roots kept alive for the lifetime of the process.
+ *
+ * @remarks
+ * A fresh-loaded module may expose functions whose deferred relative imports
+ * are resolved only when those functions run (for example inside a trail's
+ * `blaze`). If we deleted the mirror tree immediately after the initial
+ * `import()` resolved, those later resolutions would hit an ENOENT. We keep
+ * the mirrors on disk and clean them up once, on process exit.
+ */
+const ACTIVE_MIRROR_ROOTS = new Set<string>();
+
+const cleanupAllMirrorRoots = (): void => {
+  for (const root of ACTIVE_MIRROR_ROOTS) {
+    rmSync(root, { force: true, recursive: true });
+  }
+  ACTIVE_MIRROR_ROOTS.clear();
+};
+
+const mirrorCleanup = (() => {
+  let registered = false;
+  return {
+    ensureRegistered(): void {
+      if (registered) {
+        return;
+      }
+      registered = true;
+      process.once('exit', cleanupAllMirrorRoots);
+    },
+  };
+})();
+
+const ensureMirrorCleanupHook = (): void => {
+  mirrorCleanup.ensureRegistered();
+};
 
 const resolveUrlModulePath = (modulePath: string): string => {
   const url = new URL(modulePath);
@@ -33,45 +105,345 @@ const resolveAbsoluteModulePath = (modulePath: string, cwd: string): string =>
     ? resolveUrlModulePath(modulePath)
     : resolveFilesystemModulePath(modulePath, cwd);
 
-const freshModuleCopyPath = (absolutePath: string): string =>
-  join(
-    dirname(absolutePath),
-    `.__fresh-${Date.now()}-${Math.random().toString(36).slice(2)}-${basename(absolutePath)}`
-  );
+const MIRROR_PARENT_DIRNAME = '.trails-tmp';
+
+const MIRROR_ENTRY_PREFIX = 'load-app-fresh-';
 
 /**
- * Import a module bypassing the ESM cache for the entry file.
+ * Convert an absolute path to a drive-safe relative form before appending it
+ * to the mirror root. `path.parse(...).root` returns `'/'` on POSIX and
+ * `'C:\\'` (or similar) on Windows, so `relative` strips the platform root
+ * in both cases.
+ */
+const freshMirrorPath = (absolutePath: string, mirrorRoot: string): string =>
+  join(mirrorRoot, relative(parsePath(absolutePath).root, absolutePath));
+
+const isLocalFilesystemImport = (importPath: string): boolean =>
+  importPath.startsWith('.') ||
+  importPath.startsWith('/') ||
+  importPath.startsWith('file:');
+
+const isScannableModule = (modulePath: string): boolean =>
+  SCANNABLE_EXTENSIONS.has(extname(modulePath));
+
+const resolveImportedModulePath = (
+  importerPath: string,
+  importPath: string
+): string => {
+  const resolved = import.meta.resolve(
+    importPath,
+    pathToFileURL(importerPath).href
+  );
+  return resolveFilesystemModulePath(
+    fileURLToPath(resolved),
+    dirname(importerPath)
+  );
+};
+
+const collectImportedModulePaths = (
+  modulePath: string,
+  source: string
+): readonly string[] => {
+  const extension = extname(modulePath);
+  const loader = LOADER_BY_EXTENSION[extension];
+  if (loader === undefined) {
+    return [];
+  }
+
+  return getImportScanner(loader)
+    .scanImports(source)
+    .map((entry) => entry.path)
+    .filter(isLocalFilesystemImport)
+    .map((importPath) => resolveImportedModulePath(modulePath, importPath));
+};
+
+/**
+ * Copy a single file into the mirror by raw bytes.
  *
  * @remarks
- * Cache-busting applies to the entry module only. Transitive imports resolved
- * by the entry file are still served from Bun's module cache. This is
- * acceptable for the draft promotion workflow (the only caller) because
- * promotion changes which modules the entry file imports, not the modules
- * themselves. If a deeper cache-bust is needed in the future, consider
- * Bun's `Loader.registry` or a full process restart.
+ * Reading via `.bytes()` rather than `.text()` preserves binary payloads
+ * (`.wasm`, `.node`, compiled assets) that may sit alongside source files in
+ * the app's graph. Text decoding would corrupt them on the way through the
+ * mirror.
  */
+const copyFileToMirror = async (
+  sourcePath: string,
+  mirrorRoot: string,
+  copied: Set<string>
+): Promise<void> => {
+  if (copied.has(sourcePath)) {
+    return;
+  }
+  copied.add(sourcePath);
+
+  const mirrorPath = freshMirrorPath(sourcePath, mirrorRoot);
+  mkdirSync(dirname(mirrorPath), { recursive: true });
+  const bytes = await Bun.file(sourcePath).bytes();
+  await Bun.write(mirrorPath, bytes);
+};
+
+/**
+ * Directory basenames that are never worth mirroring.
+ *
+ * @remarks
+ * These directories are excluded because they can be large and are never
+ * sources of resolvable imports — they hold VCS metadata, package installs,
+ * prior mirror artifacts, or build/tooling output that module resolution
+ * should not touch.
+ */
+const MIRROR_SKIP_DIRECTORIES = new Set([
+  '.cache',
+  '.git',
+  '.next',
+  '.nuxt',
+  '.output',
+  '.svelte-kit',
+  '.trails-tmp',
+  '.turbo',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+]);
+
+/**
+ * Recursively copy every regular file inside `directoryPath` into the
+ * mirror, skipping well-known heavy directories.
+ *
+ * @remarks
+ * `Bun.Transpiler#scanImports` only surfaces statically analyzable import
+ * specifiers. Computed dynamic imports such as `import(\`./${name}.ts\`)`
+ * never appear, so their targets would otherwise be missing from the
+ * mirror. Shadowing each directory touched by the static walk with its
+ * full subtree keeps those sibling modules resolvable under the mirror
+ * root at runtime without pulling in package installs or nested mirror
+ * artifacts.
+ */
+const readDirectoryEntries = (directoryPath: string): readonly string[] => {
+  try {
+    return readdirSync(directoryPath);
+  } catch {
+    return [];
+  }
+};
+
+const safeStat = (
+  entryPath: string
+): ReturnType<typeof statSync> | undefined => {
+  try {
+    return statSync(entryPath);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Age threshold (ms) above which a mirror entry in `.trails-tmp/` is
+ * considered stale and safe to remove opportunistically.
+ *
+ * @remarks
+ * Fresh loads complete in seconds. Anything older than 10 minutes is almost
+ * certainly left over from a crashed or signal-killed process. We intentionally
+ * avoid registering SIGTERM/SIGINT handlers here because that would risk
+ * clobbering host-app signal handlers (and still wouldn't rescue SIGKILL).
+ * Opportunistic cleanup is self-healing across crashes from any cause.
+ */
+const STALE_MIRROR_THRESHOLD_MS = 10 * 60 * 1000;
+
+const isStaleMirrorEntry = (entryPath: string, now: number): boolean => {
+  if (ACTIVE_MIRROR_ROOTS.has(entryPath)) {
+    return false;
+  }
+  const entryStat = safeStat(entryPath);
+  if (entryStat === undefined) {
+    return false;
+  }
+  const mtimeMs = Number(entryStat.mtimeMs);
+  return now - mtimeMs >= STALE_MIRROR_THRESHOLD_MS;
+};
+
+const removeStaleMirrorEntry = (entryPath: string): void => {
+  try {
+    rmSync(entryPath, { force: true, recursive: true });
+  } catch {
+    /*
+     * Another concurrent load may own it. Safe to ignore — the next sweep
+     * will retry.
+     */
+  }
+};
+
+/**
+ * Best-effort removal of stale mirror directories left by previous (crashed or
+ * signal-killed) processes. Called before creating a new mirror root.
+ */
+const cleanupStaleMirrorRoots = (mirrorParent: string): void => {
+  const entries = readDirectoryEntries(mirrorParent);
+  if (entries.length === 0) {
+    return;
+  }
+  const now = Date.now();
+  for (const entry of entries) {
+    if (!entry.startsWith(MIRROR_ENTRY_PREFIX)) {
+      continue;
+    }
+    const entryPath = join(mirrorParent, entry);
+    if (isStaleMirrorEntry(entryPath, now)) {
+      removeStaleMirrorEntry(entryPath);
+    }
+  }
+};
+
+const freshMirrorRootPath = (cwd: string): string => {
+  const mirrorParent = join(cwd, MIRROR_PARENT_DIRNAME);
+  cleanupStaleMirrorRoots(mirrorParent);
+  return join(
+    mirrorParent,
+    `${MIRROR_ENTRY_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+};
+
+interface MirrorWalkContext {
+  readonly mirrorRoot: string;
+  readonly copied: Set<string>;
+  readonly visitedDirectories: Set<string>;
+}
+
+type DirectoryEntryKind = 'directory' | 'file' | 'skip';
+
+const classifyDirectoryEntry = (
+  entry: string,
+  entryPath: string
+): DirectoryEntryKind => {
+  const entryStat = safeStat(entryPath);
+  if (entryStat === undefined) {
+    return 'skip';
+  }
+  if (entryStat.isDirectory()) {
+    return MIRROR_SKIP_DIRECTORIES.has(entry) ? 'skip' : 'directory';
+  }
+  return entryStat.isFile() ? 'file' : 'skip';
+};
+
+const copyDirectoryTreeToMirror = async (
+  directoryPath: string,
+  context: MirrorWalkContext
+): Promise<void> => {
+  if (context.visitedDirectories.has(directoryPath)) {
+    return;
+  }
+  context.visitedDirectories.add(directoryPath);
+
+  for (const entry of readDirectoryEntries(directoryPath)) {
+    const entryPath = join(directoryPath, entry);
+    const kind = classifyDirectoryEntry(entry, entryPath);
+    if (kind === 'directory') {
+      await copyDirectoryTreeToMirror(entryPath, context);
+    } else if (kind === 'file') {
+      await copyFileToMirror(entryPath, context.mirrorRoot, context.copied);
+    }
+  }
+};
+
+const mirrorImportedModule = async (
+  modulePath: string,
+  context: MirrorWalkContext
+): Promise<void> => {
+  const moduleDirectory = dirname(modulePath);
+  if (context.visitedDirectories.has(moduleDirectory)) {
+    await copyFileToMirror(modulePath, context.mirrorRoot, context.copied);
+    return;
+  }
+  await copyDirectoryTreeToMirror(moduleDirectory, context);
+};
+
+const scanAndVisitLocalImports = async (
+  modulePath: string,
+  visit: (path: string) => Promise<void>
+): Promise<void> => {
+  if (!isScannableModule(modulePath)) {
+    return;
+  }
+  const source = await Bun.file(modulePath).text();
+  for (const importedPath of collectImportedModulePaths(modulePath, source)) {
+    await visit(importedPath);
+  }
+};
+
+const mirrorFreshImportGraph = async (
+  entryPath: string,
+  mirrorRoot: string
+): Promise<string> => {
+  const scanned = new Set<string>();
+  const context: MirrorWalkContext = {
+    copied: new Set<string>(),
+    mirrorRoot,
+    visitedDirectories: new Set<string>(),
+  };
+
+  const visit = async (modulePath: string): Promise<void> => {
+    if (scanned.has(modulePath)) {
+      return;
+    }
+    scanned.add(modulePath);
+    await scanAndVisitLocalImports(modulePath, visit);
+    await mirrorImportedModule(modulePath, context);
+  };
+
+  await visit(entryPath);
+  return freshMirrorPath(entryPath, mirrorRoot);
+};
+
+/**
+ * Import a module bypassing the ESM cache for the local filesystem import graph.
+ *
+ * @remarks
+ * External packages and built-in modules still resolve normally. Only local
+ * filesystem imports are mirrored into the fresh temp root. The mirror tree
+ * is retained for the lifetime of the process so that deferred relative
+ * `import()`/`require()` calls originating from the loaded module (e.g.
+ * inside a trail's `blaze`) can still resolve. If the graph walk itself
+ * fails, the partially-written mirror is removed immediately so failed
+ * loads do not leak disk space.
+ */
+const importWithCacheBust = async (
+  absolutePath: string
+): Promise<Record<string, unknown>> => {
+  const url = new URL(absolutePath);
+  url.searchParams.set('t', Date.now().toString());
+  return (await import(url.href)) as Record<string, unknown>;
+};
+
+const prepareMirror = async (
+  absolutePath: string,
+  cwd: string
+): Promise<{ mirrorRoot: string; freshPath: string }> => {
+  const mirrorRoot = freshMirrorRootPath(cwd);
+  try {
+    const freshPath = await mirrorFreshImportGraph(absolutePath, mirrorRoot);
+    return { freshPath, mirrorRoot };
+  } catch (error) {
+    rmSync(mirrorRoot, { force: true, recursive: true });
+    throw error;
+  }
+};
+
 const importFreshModule = async (
   modulePath: string,
   cwd: string
 ): Promise<Record<string, unknown>> => {
   const absolutePath = resolveAbsoluteModulePath(modulePath, cwd);
   if (URL_SCHEME.test(absolutePath) && !absolutePath.startsWith('/')) {
-    const url = new URL(absolutePath);
-    url.searchParams.set('t', Date.now().toString());
-    return (await import(url.href)) as Record<string, unknown>;
+    return await importWithCacheBust(absolutePath);
   }
 
-  const freshPath = freshModuleCopyPath(absolutePath);
-  await Bun.write(freshPath, await Bun.file(absolutePath).text());
-
-  try {
-    return (await import(pathToFileURL(freshPath).href)) as Record<
-      string,
-      unknown
-    >;
-  } finally {
-    rmSync(freshPath, { force: true });
-  }
+  const { mirrorRoot, freshPath } = await prepareMirror(absolutePath, cwd);
+  ACTIVE_MIRROR_ROOTS.add(mirrorRoot);
+  ensureMirrorCleanupHook();
+  return (await import(pathToFileURL(freshPath).href)) as Record<
+    string,
+    unknown
+  >;
 };
 
 /** Load a Topo export from a module path relative to cwd. */


### PR DESCRIPTION
## Summary
This fixes `loadApp(..., { fresh: true })` so it really reloads local app graphs without breaking package resolution for mirrored fixtures and repo-local temp projects.

## What Changed
- kept fresh loading cache-busting by mirroring the local filesystem import graph
- moved the fresh mirror under the project root instead of a system temp dir so bare package imports still resolve through the repo's `node_modules`
- taught local import graph walking to resolve `.js` specifiers back to sibling `.ts` sources when mirroring authored TypeScript modules
- added focused regression coverage for `.js` specifiers and repo-local workspace package resolution

## Verification
- `bun run build`
- `bun test apps/trails/src/__tests__/load-app.test.ts apps/trails/src/__tests__/draft-promote.test.ts --bail`
- bottom-up stack verification also reran this branch before submission

## Closes
- Closes `TRL-180`.
