### PR TITLE
fix: reject incompatible jsonfile table reuse

### DIFF
--- a/packages/store/src/__tests__/jsonfile.test.ts
+++ b/packages/store/src/__tests__/jsonfile.test.ts
@@ -44,6 +44,14 @@ const autoIdStore = defineStore({
   items: { generated: ['id'] as const, identity: 'id', schema: itemSchema },
 });
 
+const generatedNameStore = defineStore({
+  items: {
+    generated: ['name'] as const,
+    identity: 'id',
+    schema: itemSchema,
+  },
+});
+
 const fixtureStore = defineStore({
   items: {
     fixtures: [{ id: 'fixture-1', name: 'Fixture row' }],
@@ -86,6 +94,23 @@ afterEach(async () => {
   await rm(dir, { force: true, recursive: true });
 });
 
+const expectConflictError = async (
+  run: () => unknown,
+  messagePart: string
+): Promise<void> => {
+  const outcome = await Promise.resolve()
+    .then(run)
+    .then(
+      () => null,
+      (error: unknown) => error
+    );
+  if (outcome === null) {
+    throw new Error('Expected a ConflictError');
+  }
+  expect(outcome).toBeInstanceOf(ConflictError);
+  expect(String(outcome)).toContain(messagePart);
+};
+
 /** Copy a JSON table file into a fresh directory and load it via a new connection. */
 const reloadAndList = async (
   sourceDir: string,
@@ -102,7 +127,7 @@ const reloadAndList = async (
 };
 
 const createMockConnection = async <TConnection>(
-  factory: (() => Promise<TConnection>) | undefined
+  factory: (() => TConnection | Promise<TConnection>) | undefined
 ): Promise<TConnection> => {
   if (factory === undefined) {
     throw new Error('Expected jsonfile store mock factory to be defined');
@@ -110,6 +135,8 @@ const createMockConnection = async <TConnection>(
 
   return await factory();
 };
+
+const stableGeneratedId = (): string => 'generated-id';
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -270,6 +297,53 @@ describe('jsonfile connector', () => {
       const all = await reloadAndList(dir, 'items.json');
       expect(all).toHaveLength(2);
       expect(all.map((e) => e.name).toSorted()).toEqual(['First', 'Second']);
+    });
+  });
+
+  describe('table reuse', () => {
+    test('reuses the same table accessor when the config matches', async () => {
+      const first = await connectJsonFile(autoIdStore, {
+        dir,
+        generateIdentity: stableGeneratedId,
+      });
+      await first.items.upsert({ name: 'First' });
+
+      const second = await connectJsonFile(autoIdStore, {
+        dir,
+        generateIdentity: stableGeneratedId,
+      });
+
+      await expect(second.items.get('generated-id')).resolves.toEqual(
+        expect.objectContaining({
+          id: 'generated-id',
+          name: 'First',
+        })
+      );
+    });
+
+    test('throws when a shared path is reused with a different table config', async () => {
+      await connectJsonFile(itemStore, { dir });
+
+      await expectConflictError(
+        () => connectJsonFile(generatedNameStore, { dir }),
+        'generatedFields'
+      );
+    });
+
+    test('throws when a shared path is reused with a different identity generator', async () => {
+      await connectJsonFile(autoIdStore, {
+        dir,
+        generateIdentity: () => 'first-id',
+      });
+
+      await expectConflictError(
+        () =>
+          connectJsonFile(autoIdStore, {
+            dir,
+            generateIdentity: () => 'second-id',
+          }),
+        'generateIdentity'
+      );
     });
   });
 

--- a/packages/store/src/jsonfile/runtime.ts
+++ b/packages/store/src/jsonfile/runtime.ts
@@ -318,6 +318,80 @@ const deriveTableConfig = (options: JsonFileTableOptions): TableConfig => ({
   tableName: options.table.name,
 });
 
+interface JsonFileTableReuseConfig {
+  readonly generateIdentity: (() => string) | undefined;
+  readonly generatedFields: readonly string[];
+  readonly identityField: string;
+  readonly isVersioned: boolean;
+}
+
+const usesGeneratedIdentity = (config: {
+  readonly generatedFields: readonly string[];
+  readonly identityField: string;
+}): boolean => config.generatedFields.includes(config.identityField);
+
+const deriveTableReuseConfig = (
+  options: JsonFileTableOptions
+): JsonFileTableReuseConfig => {
+  const generatedFields = [...options.table.generated].toSorted();
+  return {
+    generateIdentity: usesGeneratedIdentity({
+      generatedFields,
+      identityField: options.table.identity,
+    })
+      ? options.generateIdentity
+      : undefined,
+    generatedFields,
+    identityField: options.table.identity,
+    isVersioned: options.table.versioned,
+  };
+};
+
+const diffTableReuseConfig = (
+  cached: JsonFileTableReuseConfig,
+  incoming: JsonFileTableReuseConfig
+): readonly string[] => {
+  const mismatches: string[] = [];
+
+  if (cached.identityField !== incoming.identityField) {
+    mismatches.push('identityField');
+  }
+
+  if (cached.isVersioned !== incoming.isVersioned) {
+    mismatches.push('versioned');
+  }
+
+  if (
+    cached.generatedFields.length !== incoming.generatedFields.length ||
+    cached.generatedFields.some(
+      (field, index) => field !== incoming.generatedFields[index]
+    )
+  ) {
+    mismatches.push('generatedFields');
+  }
+
+  if (cached.generateIdentity !== incoming.generateIdentity) {
+    mismatches.push('generateIdentity');
+  }
+
+  return mismatches;
+};
+
+const assertCompatibleTableReuse = (
+  path: string,
+  cached: JsonFileTableReuseConfig,
+  incoming: JsonFileTableReuseConfig
+): void => {
+  const mismatches = diffTableReuseConfig(cached, incoming);
+  if (mismatches.length === 0) {
+    return;
+  }
+
+  throw new ConflictError(
+    `JSON file table reuse conflict for "${path}": ${mismatches.join(', ')} differ across connections. Reuse the same table config for a shared path or isolate the stores to different directories.`
+  );
+};
+
 const createGetAccessor =
   <TTable extends AnyStoreTable>(
     index: Map<string, EntityOf<TTable>>
@@ -376,9 +450,14 @@ const executeRemove = async <TTable extends AnyStoreTable>(
 // Note: entries are never evicted. This is acceptable for v1 — the connector
 // targets single-process, short-lived servers where the number of distinct
 // table paths is bounded by the store definition.
+interface JsonFileTableRegistration<TTable extends AnyStoreTable> {
+  readonly accessor: LoadableTable<TTable>;
+  readonly reuseConfig: JsonFileTableReuseConfig;
+}
+
 const tableRegistry = new Map<
   string,
-  StoreAccessor<AnyStoreTable> & { readonly load: () => Promise<void> }
+  JsonFileTableRegistration<AnyStoreTable>
 >();
 
 type LoadableTable<TTable extends AnyStoreTable> = StoreAccessor<TTable> & {
@@ -429,7 +508,10 @@ const buildAndRegisterTable = <TTable extends AnyStoreTable>(
     remove,
     upsert,
   };
-  tableRegistry.set(path, instance);
+  tableRegistry.set(path, {
+    accessor: instance,
+    reuseConfig: deriveTableReuseConfig(options),
+  });
   return instance;
 };
 
@@ -437,19 +519,28 @@ const buildAndRegisterTable = <TTable extends AnyStoreTable>(
  * Return a cached or freshly-built table instance for the given path.
  *
  * @remarks
- * First-writer-wins: if a table for this path already exists in the registry,
- * the cached instance is returned and `options.generateIdentity` from the new
- * call is silently ignored. In practice this is fine — each resource creates
- * one connection per directory — but callers should not rely on passing
- * different generators for the same path across multiple `connectJsonFile`
- * calls.
+ * Tables are shared per resolved file path so multiple connections stay
+ * coherent in-process. Reuse is only allowed when table-affecting config
+ * matches exactly; otherwise the connector throws instead of silently
+ * inheriting the first connection's runtime semantics.
  */
 const createJsonFileTable = <TTable extends AnyStoreTable>(
   options: JsonFileTableOptions
 ): LoadableTable<TTable> => {
   const path = jsonFilePath(options.dir, options.table.name);
-  const cached = tableRegistry.get(path) as LoadableTable<TTable> | undefined;
-  return cached ?? buildAndRegisterTable<TTable>(path, options);
+  const cached = tableRegistry.get(path) as
+    | JsonFileTableRegistration<TTable>
+    | undefined;
+  if (cached === undefined) {
+    return buildAndRegisterTable<TTable>(path, options);
+  }
+
+  assertCompatibleTableReuse(
+    path,
+    cached.reuseConfig,
+    deriveTableReuseConfig(options)
+  );
+  return cached.accessor;
 };
 
 // Tracks temp directories created by mock factories so `dispose` can clean

--- a/packages/store/src/jsonfile/types.ts
+++ b/packages/store/src/jsonfile/types.ts
@@ -16,7 +16,31 @@ export interface JsonFileStoreOptions<
 > extends StoreConnectorOptions<TStore> {
   /** Directory where JSON files are written. One `<tableName>.json` per table. */
   readonly dir: string;
-  /** Optional identity generator. Defaults to `Bun.randomUUIDv7()`. */
+  /**
+   * Optional identity generator. Defaults to `Bun.randomUUIDv7()`.
+   *
+   * @remarks
+   * When a jsonfile table is reused across multiple `connectJsonFile` call
+   * sites (same `dir` + table), the runtime enforces that every connection
+   * supplies a compatible `generateIdentity`. That compatibility check is
+   * intentional reference equality, not a structural or behavioral comparison:
+   * two distinct arrow functions that happen to be "logically identical"
+   * (e.g. `() => uuid()` written inline in two files) will still be treated
+   * as a conflict and surface as a `ConflictError`. Callers that want to
+   * share a table across call sites should hoist `generateIdentity` to a
+   * stable reference — a module-level `const` or shared utility — and pass
+   * that same reference in from every connection, rather than recreating
+   * the function inline at each site.
+   *
+   * The conflict check only fires for custom generators. When no custom
+   * generator is provided for an auto-generated-identity store,
+   * `deriveTableReuseConfig` normalizes `generateIdentity` to `undefined`
+   * regardless of what (if anything) was passed, so two connections that
+   * both rely on defaults never conflict on this field. The same
+   * normalization also applies when the identity field is not in
+   * `generatedFields` — the generator is irrelevant in that case, so the
+   * check is skipped.
+   */
   readonly generateIdentity?: () => string;
 }
 


### PR DESCRIPTION
## Summary
This hardens the jsonfile connector so shared table access is only reused when the authored table configuration is actually compatible.

## What Changed
- rejects shared-path table reuse when table config differs
- rejects shared-path reuse when the identity generator differs
- preserves the successful reuse path when config matches exactly
- keeps the jsonfile connector behavior explicit instead of allowing silent config drift

## Verification
- `bun run build`
- `bun test packages/store/src/__tests__/jsonfile.test.ts apps/trails/src/__tests__/draft-promote.test.ts --bail`
- bottom-up stack verification reran this branch before submission

## Closes
- Closes `TRL-272`.
