### PR TITLE
fix: add NOOP_SINK tracing fast path

### DIFF
--- a/docs/adr/0013-tracing.md
+++ b/docs/adr/0013-tracing.md
@@ -5,7 +5,7 @@ title: Tracing — Runtime Recording Primitive
 status: partially-superseded
 superseded_by: ['23']
 created: 2026-03-30
-updated: 2026-04-08
+updated: 2026-04-19
 owners: ['[galligan](https://github.com/galligan)']
 ---
 
@@ -43,10 +43,10 @@ The core recording model remains Trails-shaped. A `TraceRecord` knows about trai
 
 Tracing now integrates in two ways:
 
-- **Intrinsic recording in `executeTrail`** writes a root `TraceRecord` for every trail execution automatically
+- **Intrinsic recording in `executeTrail`** writes a root `TraceRecord` automatically whenever a real sink is installed
 - **`ctx.trace(label, fn)`** gives trail implementations scoped manual spans for important internal work
 
-The automatic path is the default. The manual path exists for trails that need extra detail around internal work inside the shared root trace.
+The automatic path is the default when tracing is enabled. When the installed sink is `NOOP_SINK`, `executeTrail` short-circuits the tracing allocation path and `ctx.trace(label, fn)` stays in passthrough mode. The manual path exists for trails that need extra detail around internal work inside the shared root trace.
 
 ```typescript
 const result = await ctx.trace('db-query', async () => {
@@ -113,6 +113,25 @@ No raw `start` / `end` pair in v1. Structural safety beats flexibility here.
 ### Dev store and export connectors
 
 The development store remains local SQLite. Production export remains an optional connector. The important language change is that these are **connectors**, not stores. Tracing owns the Trails-native model; connectors translate it into storage or observability systems.
+
+## Overhead Envelope
+
+`TRL-201` benchmarked the disabled-tracing baseline against a traced no-op sink on 2026-04-19 using `bun run bench:tracing` on Bun `1.3.12`.
+
+| Scenario | `NOOP_SINK` median | Wrapped no-op median | Overhead |
+| --- | ---: | ---: | ---: |
+| Pure no-op trail | 21.48 ms (`1.07 us/call`) | 28.50 ms (`1.42 us/call`) | `31.09%` |
+| Typical trail | 26.07 ms (`1.30 us/call`) | 33.25 ms (`1.66 us/call`) | `30.77%` |
+| Mocked I/O trail | 319.15 ms (`1276.60 us/call`) | 318.99 ms (`1275.98 us/call`) | `-0.15%` |
+
+The decision rule for `TRL-201` was locked before measurement: ship the fast path if tight-loop worst-case overhead exceeded `~5%` on a trivial trail. The measured worst-case overhead was roughly `31%`, so the fast path ships.
+
+That outcome gives the runtime two clear modes:
+
+- With a real sink installed, `executeTrail` records the root trace and `ctx.trace()` records child spans.
+- With `NOOP_SINK` installed, `executeTrail` skips root trace allocation and `ctx.trace()` stays in passthrough mode.
+
+The benchmark note lives at `.scratch/2026-04-19-trl-201-tracing-overhead-benchmark.md`.
 
 ## Consequences
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -321,13 +321,14 @@ PermitDiagnostic
 
 ## `@ontrails/tracing`
 
-Tracing is intrinsic in `executeTrail` — every trail execution produces a `TraceRecord` automatically. `ctx.trace(label, fn)` records nested spans. No layer attachment required.
+Tracing is intrinsic in `executeTrail`. With a real sink installed, a trail execution emits a root `TraceRecord` and `ctx.trace(label, fn)` emits child spans. With `NOOP_SINK`, `executeTrail` short-circuits the tracing allocation path and `ctx.trace(label, fn)` stays a passthrough.
 
 ```typescript
 // Sink registration (from @ontrails/core or re-exported from @ontrails/tracing)
 registerTraceSink(sink)              // install a sink for trace records
 getTraceSink()                       // get the currently registered sink
 clearTraceSink()                     // revert to the default no-op sink
+NOOP_SINK                            // stable disabled-tracing sentinel
 
 // Sinks
 createMemorySink()                   // in-memory sink for testing

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -14,7 +14,7 @@
 
 **Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. `authLayer` extracts credentials from surface-specific sources, `AuthConnector` resolves them to a `Permit` (identity, scopes, roles), and scope enforcement rejects unauthorized access. Includes JWT connector, governance rules (`validatePermits`), and test helpers (`createTestPermit`, `createPermitForTrail`).
 
-**Tracing (intrinsic in `@ontrails/core`, sinks in `@ontrails/tracing`).** Every `executeTrail` invocation produces a `TraceRecord` automatically — no layer attachment required. `ctx.trace(label, fn)` records nested spans inside a trail blaze. Pluggable sinks register via `registerTraceSink()`: `createMemorySink` for testing, `createDevStore` for local development, `createOtelConnector` for production OpenTelemetry export. Sampling configuration controls recording volume.
+**Tracing (intrinsic in `@ontrails/core`, sinks in `@ontrails/tracing`).** With a real sink installed, `executeTrail` produces a `TraceRecord` automatically and `ctx.trace(label, fn)` records nested spans inside a trail blaze. With `NOOP_SINK`, the tracing path short-circuits without layer attachment or per-trail wiring. Pluggable sinks register via `registerTraceSink()`: `createMemorySink` for testing, `createDevStore` for local development, `createOtelConnector` for production OpenTelemetry export. Sampling configuration controls recording volume.
 
 ## Mid-term (v1.3+)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -387,7 +387,7 @@ const permit = createTestPermit({ scopes: ['entity:read'] });
 const trailPermit = createPermitForTrail(showTrail);
 ```
 
-**Tracing memory sink.** Tracing is intrinsic to `executeTrail` — every trail execution produces a `TraceRecord` automatically. Register `createMemorySink()` to capture records in memory for assertion:
+**Tracing memory sink.** Tracing is intrinsic to `executeTrail`, but records are only emitted when a real sink is installed. Register `createMemorySink()` to capture records in memory for assertion, then use `clearTraceSink()` to restore the `NOOP_SINK` baseline:
 
 ```typescript
 import { createMemorySink, registerTraceSink, clearTraceSink } from '@ontrails/tracing';

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "vocab:audit": "bun scripts/vocab-cutover-audit.ts",
     "vocab:audit:json": "bun scripts/vocab-cutover-audit.ts --json",
     "vocab:rewrite": "bun scripts/vocab-cutover-rewrite.ts",
+    "bench:tracing": "bun packages/tracing/scripts/benchmark-intrinsic-tracing.ts",
     "format:check": "./node_modules/.bin/ultracite check .",
     "format:fix": "./node_modules/.bin/ultracite fix .",
     "format:file": "./node_modules/.bin/ultracite fix",

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -14,6 +14,7 @@ import {
   ValidationError,
 } from '../errors';
 import { executeTrail } from '../execute';
+import { TRACE_CONTEXT_KEY, clearTraceSink } from '../internal/tracing';
 import { createTrailContext } from '../context';
 import type { Layer } from '../layer';
 import { Result } from '../result';
@@ -1113,10 +1114,30 @@ describe('executeTrail', () => {
           ctx: { extensions: { userId: '123' } },
         }
       );
-      // Intrinsic tracing injects TRACE_CONTEXT_KEY into extensions; the
-      // user-authored keys must still be present and untouched.
+      // User-authored extension keys must stay intact regardless of whether
+      // tracing later adds its own internal bookkeeping.
       expect(captured?.extensions?.store).toBe('db');
       expect(captured?.extensions?.userId).toBe('123');
+    });
+
+    test('keeps ctx.trace in passthrough mode when NOOP_SINK is installed', async () => {
+      clearTraceSink();
+
+      let sawTraceContext = true;
+      const probe = trail('ctx.trace.noop-sink', {
+        blaze: async (_input, ctx) => {
+          const value = await ctx.trace('inner', () => Promise.resolve(42));
+          sawTraceContext = ctx.extensions?.[TRACE_CONTEXT_KEY] !== undefined;
+          return Result.ok({ value });
+        },
+        input: z.object({}),
+        output: z.object({ value: z.number() }),
+      });
+
+      const result = await executeTrail(probe, {});
+
+      expect(result).toEqual(Result.ok({ value: 42 }));
+      expect(sawTraceContext).toBe(false);
     });
 
     test('rebinds ctx.resource after merging extension overrides from createContext', async () => {

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -25,7 +25,7 @@ import type {
   TrailContextInit,
 } from './types.js';
 
-import { createTrailContext } from './context.js';
+import { createTrailContext, passthroughTrace } from './context.js';
 import { buildCrossValidationSchema } from './cross-schema.js';
 import {
   CancelledError,
@@ -45,6 +45,7 @@ import {
   createSpanRecord,
   createTraceRecord,
   getTraceSink,
+  isTracingDisabled,
   writeToSink,
 } from './internal/tracing.js';
 import { Result } from './result.js';
@@ -300,6 +301,18 @@ const buildTracedContext = (
   };
 
   return { record, tracedCtx };
+};
+
+const buildUntracedContext = (ctx: TrailContext): TrailContext => {
+  const { [TRACE_CONTEXT_KEY]: _traceContext, ...extensions } =
+    ctx.extensions ?? {};
+  const hasExtensions = Object.keys(extensions).length > 0;
+
+  return {
+    ...ctx,
+    extensions: hasExtensions ? extensions : undefined,
+    trace: passthroughTrace,
+  };
 };
 
 /** Run the composed implementation and write the root record on any outcome. */
@@ -857,7 +870,7 @@ const prepareRunImpl = (
   };
 };
 
-const runTrail = async (
+const runImplWithoutTracing = async (
   trail: AnyTrail,
   input: unknown,
   ctx: TrailContext,
@@ -865,7 +878,25 @@ const runTrail = async (
   topo: Topo | undefined,
   options: ExecuteTrailOptions | undefined
 ): Promise<Result<unknown, Error>> => {
-  const sink = getTraceSink();
+  const prepared = prepareRunImpl(
+    trail,
+    buildUntracedContext(ctx),
+    layers,
+    topo,
+    options
+  );
+  return await prepared.impl(input, prepared.ctxWithIntrinsics);
+};
+
+const runTrailWithTracing = async (
+  trail: AnyTrail,
+  input: unknown,
+  ctx: TrailContext,
+  layers: readonly Layer[],
+  topo: Topo | undefined,
+  options: ExecuteTrailOptions | undefined,
+  sink: ReturnType<typeof getTraceSink>
+): Promise<Result<unknown, Error>> => {
   const { record, tracedCtx } = buildTracedContext(trail, ctx, sink);
   let prepared: ReturnType<typeof prepareRunImpl>;
 
@@ -888,6 +919,20 @@ const runTrail = async (
     record,
     sink
   );
+};
+
+const runTrail = async (
+  trail: AnyTrail,
+  input: unknown,
+  ctx: TrailContext,
+  layers: readonly Layer[],
+  topo: Topo | undefined,
+  options: ExecuteTrailOptions | undefined
+): Promise<Result<unknown, Error>> => {
+  const sink = getTraceSink();
+  return isTracingDisabled(sink)
+    ? await runImplWithoutTracing(trail, input, ctx, layers, topo, options)
+    : await runTrailWithTracing(trail, input, ctx, layers, topo, options, sink);
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -191,6 +191,7 @@ export {
   clearTraceSink,
   getTraceContext,
   getTraceSink,
+  NOOP_SINK,
   registerTraceSink,
 } from './internal/tracing.js';
 export type {

--- a/packages/core/src/internal/tracing.ts
+++ b/packages/core/src/internal/tracing.ts
@@ -67,13 +67,13 @@ export const getTraceContext = (ctx: {
 // ---------------------------------------------------------------------------
 
 /** No-op sink installed by default so core never crashes without configuration. */
-const noopSink: TraceSink = {
+export const NOOP_SINK: TraceSink = {
   // oxlint-disable-next-line no-empty-function -- intentional no-op
   write: () => {},
 };
 
 // oxlint-disable-next-line eslint-plugin-jest/require-hook -- module-level sink registry, not test setup
-let currentSink: TraceSink = noopSink;
+let currentSink: TraceSink = NOOP_SINK;
 
 /**
  * Register a trace sink globally.
@@ -84,15 +84,19 @@ let currentSink: TraceSink = noopSink;
  * the default no-op sink.
  */
 export const registerTraceSink = (sink: TraceSink | undefined): void => {
-  currentSink = sink ?? noopSink;
+  currentSink = sink ?? NOOP_SINK;
 };
 
 /** Retrieve the currently registered sink (never undefined). */
 export const getTraceSink = (): TraceSink => currentSink;
 
+/** True when tracing is effectively disabled and executeTrail should skip allocation. */
+export const isTracingDisabled = (sink: TraceSink = currentSink): boolean =>
+  sink === NOOP_SINK;
+
 /** Reset the sink registry back to the default no-op sink. */
 export const clearTraceSink = (): void => {
-  currentSink = noopSink;
+  currentSink = NOOP_SINK;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -2,7 +2,7 @@
 
 Sinks and query trails for the intrinsic tracing that ships in `@ontrails/core`.
 
-Tracing is built into `executeTrail` — every trail execution produces a `TraceRecord` automatically. This package provides the pluggable sinks, manual span API via `ctx.trace()`, and query trails that let you inspect recorded history. See [ADR-0023](../../docs/adr/0023-simplifying-the-trails-lexicon.md) for the design rationale.
+Tracing is built into `executeTrail`. When a real sink is installed, each trail execution writes a root `TraceRecord` automatically and `ctx.trace()` writes child spans. When `NOOP_SINK` is installed, the tracing path short-circuits and `ctx.trace()` remains a passthrough. This package provides the pluggable sinks, the `NOOP_SINK` sentinel, the manual span API via `ctx.trace()`, and query trails that let you inspect recorded history. See [ADR-0023](../../docs/adr/0023-simplifying-the-trails-lexicon.md) for the design rationale.
 
 ## The core pattern
 
@@ -15,11 +15,11 @@ const sink = createMemorySink();
 registerTraceSink(sink);
 ```
 
-Sinks receive completed `TraceRecord` records. The default sink is a no-op — tracing always works without configuration, but records are dropped until you register a real sink. Use a memory sink for testing, a dev store for local development, or an OTel connector to forward to your collector.
+Sinks receive completed `TraceRecord` records. The default sink is `NOOP_SINK` — tracing APIs still work without configuration, but root/span record allocation is skipped until you register a real sink. Use a memory sink for testing, a dev store for local development, or an OTel connector to forward to your collector. Use `registerTraceSink(NOOP_SINK)` or `clearTraceSink()` to switch back to the silent baseline.
 
 ### 2. Run trails
 
-Tracing happens automatically. No layer attachment, no per-trail wiring.
+Tracing happens automatically when a real sink is installed. No layer attachment, no per-trail wiring.
 
 ```typescript
 await run(graph, 'user.create', { name: 'alice' });
@@ -45,7 +45,7 @@ export const processUser = trail('user.process', {
 });
 ```
 
-Each `ctx.trace()` call creates a child span under the trail's root trace record. Spans time their callback, record errors, and flush to the registered sink.
+Each `ctx.trace()` call creates a child span under the trail's root trace record when tracing is enabled. Under `NOOP_SINK`, the same API runs as a passthrough.
 
 ## The tracing resource
 
@@ -102,6 +102,8 @@ try {
   clearTraceSink();
 }
 ```
+
+`clearTraceSink()` restores `NOOP_SINK`.
 
 ### Dev store
 
@@ -171,6 +173,8 @@ try {
   clearTraceSink();
 }
 ```
+
+Use `clearTraceSink()` or `registerTraceSink(NOOP_SINK)` to switch back to the silent baseline between tests.
 
 ## Installation
 

--- a/packages/tracing/scripts/benchmark-intrinsic-tracing.ts
+++ b/packages/tracing/scripts/benchmark-intrinsic-tracing.ts
@@ -1,0 +1,201 @@
+/* oxlint-disable eslint-plugin-import/consistent-type-specifier-style -- single import keeps the benchmark script lint-clean */
+/* oxlint-disable eslint-plugin-jest/require-hook -- standalone benchmark script, not a test file */
+
+import {
+  NOOP_SINK,
+  Result,
+  executeTrail,
+  registerTraceSink,
+  trail,
+  type AnyTrail,
+  type TraceSink,
+} from '../../core/src/index.ts';
+import { z } from 'zod';
+
+interface Scenario {
+  readonly input: unknown;
+  readonly iterations: number;
+  readonly name: string;
+  readonly samples: number;
+  readonly trail: AnyTrail;
+}
+
+interface Sample {
+  readonly baselineMs: number;
+  readonly overheadPct: number;
+  readonly tracedMs: number;
+}
+
+const wrappedNoopSink: TraceSink = {
+  write: () => 0,
+};
+
+const emptyIO = z.object({});
+const typicalInput = z.object({
+  count: z.number().int().nonnegative(),
+  id: z.string().uuid(),
+  label: z.string().min(3),
+  tags: z.array(z.string()).max(4),
+});
+const ioInput = z.object({
+  jobId: z.string(),
+});
+
+const trivialTrail = trail('bench.tracing.trivial', {
+  blaze: () => Result.ok({ ok: true }),
+  input: emptyIO,
+  output: z.object({ ok: z.boolean() }),
+});
+
+const typicalTrail = trail('bench.tracing.typical', {
+  blaze: (input) =>
+    Result.ok({
+      checksum: `${input.id}:${input.label}:${input.tags.length}`,
+      count: input.count + 1,
+      ok: true,
+    }),
+  input: typicalInput,
+  output: z.object({
+    checksum: z.string(),
+    count: z.number(),
+    ok: z.boolean(),
+  }),
+});
+
+const ioTrail = trail('bench.tracing.io', {
+  blaze: async (input) => {
+    await Bun.sleep(1);
+    return Result.ok({ jobId: input.jobId, ok: true });
+  },
+  input: ioInput,
+  output: z.object({
+    jobId: z.string(),
+    ok: z.boolean(),
+  }),
+});
+
+const scenarios: readonly Scenario[] = [
+  {
+    input: {},
+    iterations: 20_000,
+    name: 'pure no-op trail',
+    samples: 6,
+    trail: trivialTrail,
+  },
+  {
+    input: {
+      count: 2,
+      id: '0f2b6d6a-3b22-4e6b-a4e8-9f5f3c2d5f9a',
+      label: 'alpha',
+      tags: ['bench', 'trace'],
+    },
+    iterations: 20_000,
+    name: 'typical trail',
+    samples: 6,
+    trail: typicalTrail,
+  },
+  {
+    input: { jobId: 'job-1' },
+    iterations: 250,
+    name: 'mocked I/O trail',
+    samples: 5,
+    trail: ioTrail,
+  },
+];
+
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].toSorted((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted[middle] ?? 0;
+};
+
+const measureScenario = async (
+  scenario: Scenario,
+  sink: TraceSink
+): Promise<number> => {
+  registerTraceSink(sink);
+
+  for (let i = 0; i < 250; i += 1) {
+    await executeTrail(scenario.trail, scenario.input);
+  }
+
+  const startedAt = performance.now();
+  for (let i = 0; i < scenario.iterations; i += 1) {
+    await executeTrail(scenario.trail, scenario.input);
+  }
+  return performance.now() - startedAt;
+};
+
+const collectSamples = async (
+  scenario: Scenario
+): Promise<readonly Sample[]> => {
+  const samples: Sample[] = [];
+
+  for (let i = 0; i < scenario.samples; i += 1) {
+    const baselineMs = await measureScenario(scenario, NOOP_SINK);
+    const tracedMs = await measureScenario(scenario, wrappedNoopSink);
+    const overheadPct = ((tracedMs - baselineMs) / baselineMs) * 100;
+    samples.push({ baselineMs, overheadPct, tracedMs });
+  }
+
+  return samples;
+};
+
+const formatMs = (value: number): string => value.toFixed(2);
+const formatPct = (value: number): string => `${value.toFixed(2)}%`;
+
+const summarizeScenario = (
+  scenario: Scenario,
+  samples: readonly Sample[]
+): {
+  readonly baselineMs: number;
+  readonly baselineUs: number;
+  readonly overheadPct: number;
+  readonly tracedMs: number;
+  readonly tracedUs: number;
+} => {
+  const baselineMs = median(samples.map((sample) => sample.baselineMs));
+  const tracedMs = median(samples.map((sample) => sample.tracedMs));
+  const overheadPct = median(samples.map((sample) => sample.overheadPct));
+  const baselineUs = (baselineMs * 1000) / scenario.iterations;
+  const tracedUs = (tracedMs * 1000) / scenario.iterations;
+
+  return {
+    baselineMs,
+    baselineUs,
+    overheadPct,
+    tracedMs,
+    tracedUs,
+  };
+};
+
+const printScenario = (
+  scenario: Scenario,
+  samples: readonly Sample[]
+): void => {
+  const summary = summarizeScenario(scenario, samples);
+
+  console.log(`## ${scenario.name}`);
+  console.log(`iterations: ${scenario.iterations}`);
+  console.log(`samples: ${scenario.samples}`);
+  console.log(
+    `NOOP_SINK median: ${formatMs(summary.baselineMs)} ms (${summary.baselineUs.toFixed(2)} us/call)`
+  );
+  console.log(
+    `wrapped no-op sink median: ${formatMs(summary.tracedMs)} ms (${summary.tracedUs.toFixed(2)} us/call)`
+  );
+  console.log(
+    `overhead vs NOOP_SINK baseline: ${formatPct(summary.overheadPct)}`
+  );
+  console.log('');
+};
+
+console.log('# Intrinsic tracing benchmark');
+console.log(`bun: ${Bun.version}`);
+console.log(`timestamp: ${new Date().toISOString()}`);
+console.log('');
+
+for (const scenario of scenarios) {
+  const samples = await collectSamples(scenario);
+  printScenario(scenario, samples);
+}

--- a/packages/tracing/src/__tests__/intrinsic-tracing.test.ts
+++ b/packages/tracing/src/__tests__/intrinsic-tracing.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   InternalError,
+  NOOP_SINK,
   NotFoundError,
   Result,
   clearTraceSink,
   executeTrail,
+  getTraceSink,
   registerTraceSink,
   trail,
   topo,
@@ -581,6 +583,24 @@ describe('intrinsic tracing via executeTrail + ctx.trace', () => {
       clearTraceSink();
       const result = await executeTrail(noSinkTrail, {});
       expect(result.isOk()).toBe(true);
+    });
+
+    test('clearTraceSink restores the NOOP_SINK sentinel', () => {
+      registerTraceSink({ write: () => 0 });
+      clearTraceSink();
+      expect(getTraceSink()).toBe(NOOP_SINK);
+    });
+
+    test('NOOP_SINK fast path preserves trail results', async () => {
+      const tracedNoopSink = { write: () => 0 };
+
+      registerTraceSink(NOOP_SINK);
+      const fastPath = await executeTrail(spanOkTrail, {});
+
+      registerTraceSink(tracedNoopSink);
+      const traced = await executeTrail(spanOkTrail, {});
+
+      expect(fastPath).toEqual(traced);
     });
 
     test('registerTraceSink routes subsequent executions to the new sink', async () => {

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -8,6 +8,7 @@ export {
   clearTraceSink,
   getTraceContext,
   getTraceSink,
+  NOOP_SINK,
   registerTraceSink,
 } from '@ontrails/core';
 export {


### PR DESCRIPTION
## Summary
This adds a real no-op fast path for intrinsic tracing so Trails does not pay unnecessary record-building cost when tracing is effectively disabled.

## What Changed
- short-circuits intrinsic tracing work when the installed sink is the no-op sink
- preserves existing trace behavior when a real sink is registered
- adds focused regression coverage around execute-time tracing behavior
- includes the benchmark and decision documentation needed to close out the issue cleanly

## Verification
- `bun run build`
- `bun test packages/core/src/__tests__/execute.test.ts packages/tracing/src/__tests__/intrinsic-tracing.test.ts apps/trails/src/__tests__/draft-promote.test.ts --bail`
- bottom-up stack verification reran this branch before submission

## Closes
- Closes `TRL-201`.
