### PR TITLE
fix: parallelize signal consumer fan-out

### DIFF
--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -80,6 +80,25 @@ const makeProducer = (fireResultKey: { result?: Result<void, Error> }) =>
     input: z.object({ orderId: z.string(), total: z.number() }),
   });
 
+const READY = 'ready';
+
+type Ready = typeof READY;
+type ReadyGate = ReturnType<typeof Promise.withResolvers<Ready>>;
+
+const createReadyGate = (): ReadyGate => Promise.withResolvers<Ready>();
+
+const waitForReadyPair = async (
+  left: Promise<Ready>,
+  right: Promise<Ready>
+): Promise<'started'> => {
+  await left;
+  await right;
+  return 'started';
+};
+
+const observedConsumerIds = (capture: Capture): string[] =>
+  capture.invocations.map((entry) => entry.trailId).toSorted();
+
 const cyclePayload = z.object({ id: z.string() });
 
 const loopA = signal('loop.a', { payload: cyclePayload });
@@ -111,6 +130,83 @@ const createCycleLogger = (
   },
 });
 
+const createWarningLogger = (
+  warnings: {
+    consumerId?: unknown;
+    message: string;
+    signalId?: unknown;
+  }[]
+): Logger => ({
+  child() {
+    return this;
+  },
+  debug() {
+    // noop
+  },
+  error() {
+    // noop
+  },
+  fatal() {
+    // noop
+  },
+  info() {
+    // noop
+  },
+  trace() {
+    // noop
+  },
+  warn(message, data) {
+    warnings.push({
+      consumerId: data?.consumerId,
+      message,
+      signalId: data?.signalId,
+    });
+  },
+});
+
+interface WarningEvent {
+  consumerId?: unknown;
+  message: string;
+  signalId?: unknown;
+}
+
+const createBlockingConsumer = (
+  id: string,
+  started: ReadyGate,
+  release: Promise<Ready>
+) =>
+  trail(id, {
+    blaze: async () => {
+      started.resolve(READY);
+      await release;
+      return Result.ok({ ok: true });
+    },
+    input: z.object({ orderId: z.string(), total: z.number() }),
+    on: ['order.placed'],
+    output: z.object({ ok: z.boolean() }),
+  });
+
+const createIsolatedConsumer = (
+  id: string,
+  value: string,
+  started: ReadyGate,
+  release: Promise<Ready>,
+  seen: Map<string, string>
+) =>
+  trail(id, {
+    blaze: async (_input, ctx) => {
+      const extensions = ctx.extensions as Record<string, unknown>;
+      extensions.currentConsumer = value;
+      started.resolve(READY);
+      await release;
+      seen.set(id, extensions.currentConsumer as string);
+      return Result.ok({ consumer: extensions.currentConsumer });
+    },
+    input: z.object({ orderId: z.string(), total: z.number() }),
+    on: ['order.placed'],
+    output: z.object({ consumer: z.unknown() }),
+  });
+
 const createCycleConsumer = (
   id: string,
   signalId: 'loop.a' | 'loop.b',
@@ -127,6 +223,105 @@ const createCycleConsumer = (
     input: cyclePayload,
     on: [signalId],
   });
+
+const createErrorIsolationScenario = () => {
+  const capture = createCapture();
+  const warnings: WarningEvent[] = [];
+  const fireBox: { result?: Result<void, Error> } = {};
+  const app = topo('fire-err', {
+    failingConsumer: makeConsumer('notify.broken', capture, 'err'),
+    healthyConsumer: makeConsumer('notify.email', capture),
+    orderPlaced,
+    producer: makeProducer(fireBox),
+  });
+
+  return {
+    app,
+    capture,
+    fireBox,
+    warnings,
+  };
+};
+
+const expectConsumerFailureWarning = (warnings: WarningEvent[]): void => {
+  expect(warnings).toEqual([
+    {
+      consumerId: 'notify.broken',
+      message: 'Signal consumer failed',
+      signalId: 'order.placed',
+    },
+  ]);
+};
+
+const createParallelStartScenario = () => {
+  const leftStarted = createReadyGate();
+  const rightStarted = createReadyGate();
+  const release = createReadyGate();
+  const app = topo('fire-parallel-start', {
+    consumerA: createBlockingConsumer(
+      'notify.email',
+      leftStarted,
+      release.promise
+    ),
+    consumerB: createBlockingConsumer(
+      'notify.slack',
+      rightStarted,
+      release.promise
+    ),
+    orderPlaced,
+    producer: makeProducer({}),
+  });
+
+  return {
+    app,
+    leftStarted,
+    release,
+    rightStarted,
+  };
+};
+
+const waitForConsumersToStart = async (
+  left: ReadyGate,
+  right: ReadyGate
+): Promise<'started'> =>
+  // Sequential fan-out would deadlock here: consumerA resolves `left` then
+  // blocks on `release`, which only resolves after both consumers have
+  // started. The test runner's own timeout catches the regression without
+  // needing a wall-clock timer that flakes under CI load.
+  await waitForReadyPair(left.promise, right.promise);
+
+const createContextIsolationScenario = () => {
+  const leftStarted = createReadyGate();
+  const rightStarted = createReadyGate();
+  const release = createReadyGate();
+  const seen = new Map<string, string>();
+  const app = topo('fire-context-isolation', {
+    consumerA: createIsolatedConsumer(
+      'notify.email',
+      'email',
+      leftStarted,
+      release.promise,
+      seen
+    ),
+    consumerB: createIsolatedConsumer(
+      'notify.slack',
+      'slack',
+      rightStarted,
+      release.promise,
+      seen
+    ),
+    orderPlaced,
+    producer: makeProducer({}),
+  });
+
+  return {
+    app,
+    leftStarted,
+    release,
+    rightStarted,
+    seen,
+  };
+};
 
 const createCycleScenario = (invocations: string[]) =>
   topo('fire-cycle', {
@@ -289,21 +484,66 @@ describe('fire', () => {
   });
 
   describe('error isolation', () => {
-    test('consumer error does not fail the producer', async () => {
-      const capture = createCapture();
-      const failingConsumer = makeConsumer('notify.broken', capture, 'err');
-      const fireBox: { result?: Result<void, Error> } = {};
-      const producer = makeProducer(fireBox);
-
-      const app = topo('fire-err', { failingConsumer, orderPlaced, producer });
-      const result = await run(app, 'order.create', {
-        orderId: 'o-3',
-        total: 1,
-      });
+    test('consumer error does not fail successful siblings or the producer', async () => {
+      const scenario = createErrorIsolationScenario();
+      const result = await run(
+        scenario.app,
+        'order.create',
+        {
+          orderId: 'o-3',
+          total: 1,
+        },
+        {
+          ctx: { logger: createWarningLogger(scenario.warnings) },
+        }
+      );
 
       expect(result.isOk()).toBe(true);
-      expect(fireBox.result?.isOk()).toBe(true);
-      expect(capture.invocations).toHaveLength(1);
+      expect(scenario.fireBox.result?.isOk()).toBe(true);
+      expect(observedConsumerIds(scenario.capture)).toEqual([
+        'notify.broken',
+        'notify.email',
+      ]);
+      expectConsumerFailureWarning(scenario.warnings);
+    });
+
+    test('starts sibling consumers before the first one settles', async () => {
+      const scenario = createParallelStartScenario();
+      const runPromise = run(scenario.app, 'order.create', {
+        orderId: 'o-parallel',
+        total: 1,
+      });
+      const started = await waitForConsumersToStart(
+        scenario.leftStarted,
+        scenario.rightStarted
+      );
+
+      scenario.release.resolve(READY);
+      const result = await runPromise;
+
+      expect(result.isOk()).toBe(true);
+      expect(started).toBe('started');
+    });
+
+    test('gives each consumer its own derived top-level context', async () => {
+      const scenario = createContextIsolationScenario();
+      const runPromise = run(
+        scenario.app,
+        'order.create',
+        { orderId: 'o-isolated', total: 1 },
+        { ctx: { extensions: { source: 'producer' } } }
+      );
+
+      await waitForReadyPair(
+        scenario.leftStarted.promise,
+        scenario.rightStarted.promise
+      );
+      scenario.release.resolve(READY);
+      const result = await runPromise;
+
+      expect(result.isOk()).toBe(true);
+      expect(scenario.seen.get('notify.email')).toBe('email');
+      expect(scenario.seen.get('notify.slack')).toBe('slack');
     });
   });
 

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -13,8 +13,10 @@
  * Consumer contexts inherit the producer's full ctx (logger, extensions,
  * resources, abortSignal, requestId, env, workspaceRoot, permit) with
  * `fire` rebound to the same closure so consumers can fan out further.
- * The consumer logger is derived from the producer logger as a child
- * tagged with `signalId` when `logger.child` exists.
+ * Each consumer gets its own derived context so sibling fan-out branches do
+ * not share mutable top-level state. The consumer logger is derived from the
+ * producer logger as a child tagged with `signalId` and `consumerId` when
+ * `logger.child` exists.
  *
  * Error semantics match the fire-and-forget framing: producers get
  * `Result.ok(undefined)` unless the signal id is unknown or the payload
@@ -62,31 +64,93 @@ const getFireStack = (
  * Fan out a validated signal payload to its consumer trails.
  *
  * @remarks
- * Consumers are awaited sequentially on purpose. Sequential execution gives
- * deterministic ordering for tracing and tests and makes error attribution
- * straightforward (each warn log pairs cleanly with the consumer that
- * produced it). Parallelizing via `Promise.allSettled` is a deliberate
- * future option — not an oversight — and would be worth revisiting once
- * tracing and error-aggregation semantics are designed to handle
- * interleaved consumer execution.
+ * Consumers fan out in parallel by design. Signal delivery is fire-and-forget
+ * notification, not ordered orchestration; if one consumer depends on another,
+ * the dependency belongs in `crosses:` instead of sibling signal sequencing.
+ *
+ * `Promise.allSettled` preserves failure isolation and waits for every branch
+ * to settle. Each consumer gets its own derived context so sibling branches do
+ * not share mutable top-level state while they overlap.
  */
+type ConsumerFireBinder = (
+  consumerCtx: MutableConsumerContext
+) => MutableConsumerContext;
+
+const deriveConsumerLogger = (
+  producerCtx: TrailContextInit | undefined,
+  signalId: string,
+  consumerId: string
+): Logger | undefined =>
+  producerCtx?.logger?.child?.({ consumerId, signalId }) ?? producerCtx?.logger;
+
+const deriveConsumerEnv = (
+  producerCtx: TrailContextInit | undefined
+): TrailContextInit['env'] =>
+  producerCtx?.env ? { ...producerCtx.env } : undefined;
+
+const deriveConsumerExtensions = (
+  producerCtx: TrailContextInit | undefined,
+  signalId: string
+): TrailContextInit['extensions'] => ({
+  ...producerCtx?.extensions,
+  [FIRE_STACK_KEY]: [...getFireStack(producerCtx), signalId],
+});
+
+const deriveConsumerCtx = (
+  producerCtx: TrailContextInit | undefined,
+  signalId: string,
+  consumerId: string
+): MutableConsumerContext =>
+  producerCtx
+    ? {
+        ...producerCtx,
+        env: deriveConsumerEnv(producerCtx),
+        extensions: deriveConsumerExtensions(producerCtx, signalId),
+        logger: deriveConsumerLogger(producerCtx, signalId, consumerId),
+      }
+    : {};
+
 const fanOutToConsumers = async (
   consumers: readonly AnyTrail[],
   payload: unknown,
   signalId: string,
-  consumerCtx: Partial<TrailContextInit>,
+  producerCtx: TrailContextInit | undefined,
+  bindFire: ConsumerFireBinder,
   executor: ConsumerExecutor,
   logger: Logger | undefined
 ): Promise<void> => {
-  for (const consumer of consumers) {
-    const consumerResult = await executor(consumer, payload, consumerCtx);
-    if (consumerResult.isErr()) {
-      logger?.warn('Signal consumer failed', {
-        consumerId: consumer.id,
-        error: consumerResult.error.message,
-        signalId,
-      });
+  const settled = await Promise.allSettled(
+    consumers.map(async (consumer) => {
+      const consumerCtx = bindFire(
+        deriveConsumerCtx(producerCtx, signalId, consumer.id)
+      );
+      const consumerResult = await executor(consumer, payload, consumerCtx);
+      if (consumerResult.isErr()) {
+        (consumerCtx.logger ?? logger)?.warn('Signal consumer failed', {
+          consumerId: consumer.id,
+          error: consumerResult.error.message,
+          signalId,
+        });
+      }
+      return consumer.id;
+    })
+  );
+  for (const [index, entry] of settled.entries()) {
+    if (entry.status !== 'rejected') {
+      continue;
     }
+    // `executeTrail` normalizes throws into `Result.err`, so reaching this
+    // branch means the executor (or the warn call above) rejected
+    // unexpectedly. Log at debug to preserve provenance without propagating
+    // the failure to the producer (fire-and-forget semantics).
+    logger?.debug('Signal consumer rejected unexpectedly', {
+      consumerId: consumers[index]?.id,
+      error:
+        entry.reason instanceof Error
+          ? entry.reason.message
+          : String(entry.reason),
+      signalId,
+    });
   }
 };
 
@@ -116,24 +180,6 @@ const resolveFireDispatch = (
     consumers: topo.list().filter((trail) => trail.on.includes(signalId)),
     payload: parsed.data,
   });
-};
-
-const buildConsumerCtx = (
-  producerCtx: TrailContextInit | undefined,
-  signalId: string
-): MutableConsumerContext => {
-  const childLogger: Logger | undefined =
-    producerCtx?.logger?.child?.({ signalId }) ?? producerCtx?.logger;
-  return producerCtx
-    ? {
-        ...producerCtx,
-        extensions: {
-          ...producerCtx.extensions,
-          [FIRE_STACK_KEY]: [...getFireStack(producerCtx), signalId],
-        },
-        logger: childLogger,
-      }
-    : {};
 };
 
 const resolveSignalId = (signalOrId: unknown): Result<string, Error> => {
@@ -169,6 +215,17 @@ export const createFireFn = (
   producerCtx: TrailContextInit | undefined,
   executor: ConsumerExecutor
 ): FireFn => {
+  const bindConsumerFire: ConsumerFireBinder = (consumerCtx) => ({
+    ...consumerCtx,
+    // Pre-bind fire on the consumer ctx as a safety net for direct
+    // executeTrail calls that skip the topo-aware path. In the normal
+    // fan-out flow below, bindFireToCtx in execute.ts rebinds fire to
+    // the fully-traced ctx before the blaze runs, so this assignment
+    // is superseded — but keeping it makes consumerCtx self-sufficient
+    // for any caller that inspects it pre-execution.
+    fire: createFireFn(topo, consumerCtx as TrailContextInit, executor),
+  });
+
   const dispatchFire = async (
     signalId: string,
     payload: unknown
@@ -177,23 +234,12 @@ export const createFireFn = (
     if (dispatch.isErr()) {
       return Result.err(dispatch.error);
     }
-    const consumerCtx = buildConsumerCtx(producerCtx, signalId);
-    // Pre-bind fire on the consumer ctx as a safety net for direct
-    // executeTrail calls that skip the topo-aware path. In the normal
-    // fan-out flow below, bindFireToCtx in execute.ts rebinds fire to
-    // the fully-traced ctx before the blaze runs, so this assignment
-    // is superseded — but keeping it makes consumerCtx self-sufficient
-    // for any caller that inspects it pre-execution.
-    consumerCtx.fire = createFireFn(
-      topo,
-      consumerCtx as TrailContextInit,
-      executor
-    );
     await fanOutToConsumers(
       dispatch.value.consumers,
       dispatch.value.payload,
       signalId,
-      consumerCtx,
+      producerCtx,
+      bindConsumerFire,
       executor,
       producerCtx?.logger
     );

--- a/packages/tracing/src/__tests__/intrinsic-tracing.test.ts
+++ b/packages/tracing/src/__tests__/intrinsic-tracing.test.ts
@@ -8,6 +8,8 @@ import {
   executeTrail,
   getTraceSink,
   registerTraceSink,
+  run,
+  signal,
   trail,
   topo,
 } from '@ontrails/core';
@@ -170,9 +172,9 @@ const waitForSignalPair = async (
 };
 
 const createReleasedSignal = (): Promise<Signal> => {
-  const signal = createSignalController();
-  signal.resolve(SIGNAL);
-  return signal.promise;
+  const controller = createSignalController();
+  controller.resolve(SIGNAL);
+  return controller.promise;
 };
 
 const createBatchCrossParent = (
@@ -329,6 +331,58 @@ const createLimitedCrossBatchScenario = () => {
   };
 };
 
+const createParallelSignalFanoutScenario = () => {
+  const emitted = signal('trace.signal.parallel', {
+    payload: z.object({ id: z.string() }),
+  });
+  const leftStarted = createSignalController();
+  const rightStarted = createSignalController();
+  const release = createSignalController();
+  const createSignalConsumer = (id: string, started: SignalController) =>
+    trail(id, {
+      blaze: async (_input, ctx) => {
+        await ctx.trace('work', async () => {
+          started.resolve(SIGNAL);
+          await release.promise;
+        });
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      on: [emitted.id],
+      output: z.object({ ok: z.boolean() }),
+      visibility: 'internal',
+    });
+  const left = createSignalConsumer('trace.signal.left', leftStarted);
+  const right = createSignalConsumer('trace.signal.right', rightStarted);
+  const producer = trail('trace.signal.producer', {
+    blaze: async (input, ctx) => {
+      const fired = await ctx.fire?.(emitted.id, input);
+      return (fired as Result<void, Error>).match({
+        err: (error) => Result.err(error),
+        ok: () => Result.ok({ ok: true }),
+      });
+    },
+    fires: [emitted.id],
+    input: z.object({ id: z.string() }),
+    output: z.object({ ok: z.boolean() }),
+  });
+  const app = topo('trace-signal-parallel-topo', {
+    emitted,
+    left,
+    producer,
+    right,
+  });
+
+  return {
+    app,
+    left,
+    producer,
+    release,
+    right,
+    started: waitForSignalPair(leftStarted.promise, rightStarted.promise),
+  };
+};
+
 const expectSiblingCrossTrailOverlap = (
   records: readonly TraceRecord[],
   parentTrailId: string,
@@ -361,6 +415,20 @@ const expectLimitedCrossTrailWaveShape = (
     fastRecord.endedAt as number
   );
   expect(recordsOverlap(slowRecord, queuedRecord)).toBe(true);
+};
+
+const expectParallelSignalFanoutTraceShape = (
+  records: readonly TraceRecord[],
+  producerTrailId: string,
+  leftTrailId: string,
+  rightTrailId: string
+) => {
+  const producerRecord = trailRecord(records, producerTrailId);
+  const leftRecord = trailRecord(records, leftTrailId);
+  const rightRecord = trailRecord(records, rightTrailId);
+  expect(leftRecord.parentId).toBe(producerRecord.id);
+  expect(rightRecord.parentId).toBe(producerRecord.id);
+  expect(recordsOverlap(leftRecord, rightRecord)).toBe(true);
 };
 
 describe('intrinsic tracing via executeTrail + ctx.trace', () => {
@@ -547,10 +615,14 @@ describe('intrinsic tracing via executeTrail + ctx.trace', () => {
 
     test('batch ctx.cross([...]) produces sibling child trail records with overlapping timings', async () => {
       const scenario = createConcurrentCrossBatchScenario();
-      const run = executeTrail(scenario.parent, {}, { topo: scenario.app });
+      const execution = executeTrail(
+        scenario.parent,
+        {},
+        { topo: scenario.app }
+      );
       await scenario.started;
       scenario.release.resolve(SIGNAL);
-      await run;
+      await execution;
       expectSiblingCrossTrailOverlap(
         sink.records,
         scenario.parent.id,
@@ -561,12 +633,16 @@ describe('intrinsic tracing via executeTrail + ctx.trace', () => {
 
     test('concurrency-limited batch crossings emit a second wave only after a slot frees up', async () => {
       const scenario = createLimitedCrossBatchScenario();
-      const run = executeTrail(scenario.parent, {}, { topo: scenario.app });
+      const execution = executeTrail(
+        scenario.parent,
+        {},
+        { topo: scenario.app }
+      );
       await scenario.firstBatchStarted;
       expect(scenario.startedIds).toEqual([scenario.slow.id, scenario.fast.id]);
       scenario.releaseFirstBatch.resolve(SIGNAL);
       await scenario.queuedStarted;
-      await run;
+      await execution;
 
       expectLimitedCrossTrailWaveShape(
         sink.records,
@@ -574,6 +650,26 @@ describe('intrinsic tracing via executeTrail + ctx.trace', () => {
         scenario.slow.id,
         scenario.fast.id,
         scenario.queued.id
+      );
+    });
+  });
+
+  describe('signal fan-out tracing', () => {
+    test('parallel signal consumers trace as overlapping sibling trails under the producer', async () => {
+      const scenario = createParallelSignalFanoutScenario();
+      const runPromise = run(scenario.app, scenario.producer.id, {
+        id: 'trace-signal-1',
+      });
+      await scenario.started;
+      scenario.release.resolve(SIGNAL);
+
+      const result = await runPromise;
+      expect(result.isOk()).toBe(true);
+      expectParallelSignalFanoutTraceShape(
+        sink.records,
+        scenario.producer.id,
+        scenario.left.id,
+        scenario.right.id
       );
     });
   });


### PR DESCRIPTION
## Summary
This moves signal consumer fan-out from sequential execution to parallel execution while keeping producer success semantics stable.

## What Changed
- fans out signal consumers in parallel instead of one-by-one
- keeps consumer failures isolated so one failing listener does not poison successful siblings or the producer
- preserves context inheritance and tracing expectations under concurrent execution
- adds regression coverage for overlapping execution and inherited producer context

## Verification
- `bun run build`
- `bun test packages/core/src/__tests__/fire.test.ts packages/tracing/src/__tests__/intrinsic-tracing.test.ts apps/trails/src/__tests__/draft-promote.test.ts --bail`
- bottom-up stack verification reran this branch before submission

## Closes
- Closes `TRL-203`.
