### PR TITLE
docs: clarify signal cycle suppression

### DIFF
--- a/docs/adr/drafts/20260331-reactive-trail-activation.md
+++ b/docs/adr/drafts/20260331-reactive-trail-activation.md
@@ -308,6 +308,7 @@ Tracing queries can filter by fire source type: "show me all scheduled execution
 - **New field on the trail spec.** `on` adds a concept to learn. The justification: activation is genuinely new information that the framework can't derive.
 - **Activation resolution adds startup cost.** Topo construction resolves `on:` sources: register schedules, bind signal listeners, register webhook endpoints.
 - **Complex reactive chains.** Deep chains are inspectable via survey and the lockfile, and the warden detects cycles, but emergent behavior of long chains requires attention.
+- **Runtime suppression is narrower than static activation governance.** Warden can detect authored activation cycles in the graph, but the runtime still suppresses re-entrant delivery by signal-id membership in the current fire stack. That prevents infinite loops while over-suppressing some legitimate diamond paths until per-path provenance is promoted.
 - **Scheduled activation needs runtime infrastructure.** `Bun.cron` for production, mock scheduler for testing.
 
 ### What this does NOT decide

--- a/docs/adr/drafts/20260331-typed-signal-emission.md
+++ b/docs/adr/drafts/20260331-typed-signal-emission.md
@@ -291,6 +291,7 @@ Reactive mode runs after standard mode passes. Standard mode validates each trai
 - **Fire-and-forget semantics.** The emitting trail doesn't know if the event was delivered. This is correct (the trail shouldn't couple to its listeners) but means delivery failures are only visible through tracing.
 - **Lifecycle events add volume.** Every trail execution produces at least one lifecycle event. Sampling is a future optimization.
 - **Event ordering is not guaranteed across listeners.** Multiple triggers on the same event activate concurrently. If ordering matters, use sequential `cross` composition.
+- **Runtime cycle suppression is still signal-id-based.** The current fire stack prevents infinite re-entrant loops, but it can over-suppress legitimate diamond dispatch patterns that reuse the same signal ID on a different branch. Per-path provenance is a deferred upgrade once real graph pressure appears.
 
 ### What this does NOT decide
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,6 +205,23 @@ Clean DAG. Core at the center. No cycles. Surface connectors depend only on core
 
 ## Data Flow
 
+### Signal Fan-Out
+
+`ctx.fire()` fans out to every registered consumer in parallel, each with its
+own derived context, and awaits them all via `Promise.allSettled`. The producer
+resumes only after every consumer has settled — whether resolved or rejected —
+so signal delivery is synchronous with respect to the producer. Consumer
+errors are collected and logged but never propagate back to the producer, so
+a failing consumer cannot fail the producer's own Result.
+
+Runtime cycle suppression is intentionally narrower than Warden's static
+activation-cycle checks. Today the runtime looks only at signal IDs in the
+current fire stack. That prevents re-entrant loops like A→B→A, but it can
+over-suppress legitimate diamond re-fires that happen to reuse the same signal
+ID on a different branch. Per-path provenance is deferred post-v1; if ordering
+or transactional dependency matters now, model it with `ctx.cross()` instead
+of sibling signal sequencing.
+
 ### Request Path (CLI)
 
 ```text

--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -104,14 +104,24 @@ const cyclePayload = z.object({ id: z.string() });
 const loopA = signal('loop.a', { payload: cyclePayload });
 const loopB = signal('loop.b', { payload: cyclePayload });
 
-const createCycleLogger = (
-  warnings: { message: string; signalId?: unknown }[]
-): Logger => ({
+interface CycleLogEvent {
+  fireStack?: unknown;
+  level: 'debug' | 'warn';
+  message: string;
+  signalId?: unknown;
+}
+
+const createCycleLogger = (events: CycleLogEvent[]): Logger => ({
   child() {
     return this;
   },
-  debug() {
-    // noop
+  debug(message, data) {
+    events.push({
+      fireStack: data?.fireStack,
+      level: 'debug',
+      message,
+      signalId: data?.signalId,
+    });
   },
   error() {
     // noop
@@ -126,9 +136,48 @@ const createCycleLogger = (
     // noop
   },
   warn(message, data) {
-    warnings.push({ message, signalId: data?.signalId });
+    events.push({
+      fireStack: data?.fireStack,
+      level: 'warn',
+      message,
+      signalId: data?.signalId,
+    });
   },
 });
+
+const cycleEventsAtLevel = (
+  events: readonly CycleLogEvent[],
+  level: CycleLogEvent['level']
+): CycleLogEvent[] => events.filter((event) => event.level === level);
+
+const expectCycleSuppressionLogs = (
+  events: readonly CycleLogEvent[],
+  signalId: string,
+  fireStack: readonly string[]
+): void => {
+  expect(cycleEventsAtLevel(events, 'debug')).toEqual([
+    {
+      fireStack,
+      level: 'debug',
+      message: 'Signal fan-out suppressed due to cycle',
+      signalId,
+    },
+  ]);
+  expect(cycleEventsAtLevel(events, 'warn')).toEqual([
+    {
+      fireStack,
+      level: 'warn',
+      message: 'Signal cycle detected — skipping re-entrant fire',
+      signalId,
+    },
+  ]);
+};
+
+const expectNoCycleSuppressionDebugLogs = (
+  events: readonly CycleLogEvent[]
+): void => {
+  expect(cycleEventsAtLevel(events, 'debug')).toEqual([]);
+};
 
 const createWarningLogger = (
   warnings: {
@@ -633,10 +682,10 @@ describe('fire', () => {
   });
 
   describe('cycle detection', () => {
-    test('skips re-entrant signal cycles and logs a warning', async () => {
-      const warnings: { message: string; signalId?: unknown }[] = [];
+    test('skips re-entrant signal cycles and logs suppression details', async () => {
+      const events: CycleLogEvent[] = [];
       const invocations: string[] = [];
-      const cycleLogger = createCycleLogger(warnings);
+      const cycleLogger = createCycleLogger(events);
       const app = createCycleScenario(invocations);
 
       const result = await run(
@@ -648,17 +697,32 @@ describe('fire', () => {
 
       expect(result.isOk()).toBe(true);
       expect(invocations).toEqual(['a', 'b']);
-      expect(warnings).toEqual([
-        {
-          message: 'Signal cycle detected — skipping re-entrant fire',
-          signalId: 'loop.a',
-        },
-      ]);
+      expectCycleSuppressionLogs(events, 'loop.a', ['loop.a', 'loop.b']);
+    });
+
+    test('does not emit suppression debug logs for ordinary fan-out', async () => {
+      const events: CycleLogEvent[] = [];
+      const app = topo('fire-no-cycle-debug', {
+        consumer: makeConsumer('notify.email', createCapture()),
+        orderPlaced,
+        producer: makeProducer({}),
+      });
+
+      const result = await run(
+        app,
+        'order.create',
+        { orderId: 'o-no-cycle', total: 1 },
+        { ctx: { logger: createCycleLogger(events) } }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expectNoCycleSuppressionDebugLogs(events);
+      expect(cycleEventsAtLevel(events, 'warn')).toEqual([]);
     });
 
     test('stops at max depth for distinct-signal chains', async () => {
-      const warnings: { message: string; signalId?: unknown }[] = [];
-      const logger = createCycleLogger(warnings);
+      const events: CycleLogEvent[] = [];
+      const logger = createCycleLogger(events);
       const { app } = createDepthChainScenario(20);
 
       const result = await run(
@@ -669,8 +733,8 @@ describe('fire', () => {
       );
 
       expect(result.isOk()).toBe(true);
-      const depthWarning = warnings.find((w) =>
-        w.message.includes('depth limit')
+      const depthWarning = cycleEventsAtLevel(events, 'warn').find((event) =>
+        event.message.includes('depth limit')
       );
       expect(depthWarning).toBeDefined();
     });

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -60,18 +60,7 @@ const getFireStack = (
   return Array.isArray(value) ? (value as readonly string[]) : [];
 };
 
-/**
- * Fan out a validated signal payload to its consumer trails.
- *
- * @remarks
- * Consumers fan out in parallel by design. Signal delivery is fire-and-forget
- * notification, not ordered orchestration; if one consumer depends on another,
- * the dependency belongs in `crosses:` instead of sibling signal sequencing.
- *
- * `Promise.allSettled` preserves failure isolation and waits for every branch
- * to settle. Each consumer gets its own derived context so sibling branches do
- * not share mutable top-level state while they overlap.
- */
+/** Binds a per-consumer `fire` onto a mutable consumer context. */
 type ConsumerFireBinder = (
   consumerCtx: MutableConsumerContext
 ) => MutableConsumerContext;
@@ -110,6 +99,22 @@ const deriveConsumerCtx = (
       }
     : {};
 
+/**
+ * Fan out a validated signal payload to its consumer trails.
+ *
+ * @remarks
+ * Consumers fan out in parallel by design. Signal delivery is fire-and-forget
+ * notification, not ordered orchestration; if one consumer depends on another,
+ * the dependency belongs in `crosses:` instead of sibling signal sequencing.
+ *
+ * `Promise.allSettled` preserves failure isolation and waits for every branch
+ * to settle. Each consumer gets its own derived context so sibling branches do
+ * not share mutable top-level state while they overlap. Re-entrant suppression
+ * elsewhere in this module is still based on signal-id membership in the
+ * current fire stack: it prevents infinite loops, but it can over-suppress
+ * legitimate diamond re-fires. Per-path provenance is a documented future
+ * direction rather than part of the pre-v1 runtime contract.
+ */
 const fanOutToConsumers = async (
   consumers: readonly AnyTrail[],
   payload: unknown,
@@ -259,9 +264,13 @@ export const createFireFn = (
       return Result.ok();
     }
     if (stack.includes(signalId)) {
+      producerCtx?.logger?.debug('Signal fan-out suppressed due to cycle', {
+        fireStack: [...stack],
+        signalId,
+      });
       producerCtx?.logger?.warn(
         'Signal cycle detected — skipping re-entrant fire',
-        { signalId }
+        { fireStack: [...stack], signalId }
       );
       return Result.ok();
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -104,7 +104,11 @@ export interface CrossFn {
  * Fan-out to consumer trails (those with the signal in their `on:` array) is
  * the framework's responsibility. Producers get `Result.ok(undefined)` unless
  * the signal id is unknown or the payload fails schema validation. Consumer
- * errors are logged but do not propagate back to the producer.
+ * errors are logged but do not propagate back to the producer. Consumers fan
+ * out in parallel, each with its own derived context. Runtime cycle
+ * suppression is still signal-id-based against the current fire stack: it
+ * prevents re-entrant loops but can over-suppress legitimate diamond
+ * re-fires, with a debug breadcrumb and a warn emitted when suppression happens.
  *
  * Two call shapes are supported:
  *


### PR DESCRIPTION
## Summary
This documents the current signal cycle suppression behavior and makes the runtime logging around cycle suppression explicit.

## What Changed
- clarifies how signal cycle suppression works today
- adds targeted debug logging for actual suppression events
- avoids emitting suppression noise during ordinary fan-out
- keeps per-path provenance work deferred rather than silently over-promising it here

## Verification
- `bun run build`
- `bun test packages/core/src/__tests__/fire.test.ts apps/trails/src/__tests__/draft-promote.test.ts --bail`
- bottom-up stack verification reran this branch before submission

## Closes
- Closes `TRL-202`.
