### PR TITLE
feat: flag unreachable detour shadowing

### DIFF
--- a/docs/adr/0033-detour-execution-for-recovery.md
+++ b/docs/adr/0033-detour-execution-for-recovery.md
@@ -105,7 +105,7 @@ When multiple detours could match an error, the framework runs the first one dec
 
 1. **Predictability.** Authors know exactly which detour will run by reading the spec top-to-bottom.
 2. **No runtime reflection.** Most-specific-first requires walking `instanceof` chains to compare distances. The framework does not otherwise inspect the class hierarchy at runtime and should not start here.
-3. **The warden catches the drift case.** When detour A's `on:` type is a supertype of detour B's `on:` type and A is declared before B, B is unreachable. This is a lint-time diagnostic, not a runtime behavior. Authors who get the order wrong get an error at build time, not a silent mismatch at runtime. A warden rule for detecting unreachable detours is planned as a follow-up.
+3. **The warden catches the drift case.** When detour A's `on:` type is a supertype of detour B's `on:` type and A is declared before B, B is unreachable. This is a lint-time diagnostic, not a runtime behavior. Authors who get the order wrong get an error at build time, not a silent mismatch at runtime. Warden now ships `unreachable-detour-shadowing` to flag that ordering mistake.
 
 If `recover` returns an error whose class does not match the same detour's `on:` type (e.g., a `ConflictError` detour whose `recover` returns `NetworkError`), the framework returns that error to the caller directly. The detour loop terminates; no further matching happens.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -244,7 +244,7 @@ McpHarness, McpHarnessOptions, McpHarnessResult
 
 ```typescript
 runWarden(options?), formatWardenReport(report), checkDrift(rootDir, topo?)
-wardenRules                        // ReadonlyMap<string, WardenRule> — 15 AST-based rules
+wardenRules                        // ReadonlyMap<string, WardenRule> — built-in AST-based rules
 wardenTopo                         // pre-built Topo of all warden trails
 runWardenTrails(filePath, sourceCode, options?) // run warden rules against a single file
 formatGitHubAnnotations(report), formatJson(report), formatSummary(report)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export {
   InternalError,
   AuthError,
   CancelledError,
+  DerivationError,
   errorCategories,
   exitCodeMap,
   statusCodeMap,

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -1,6 +1,6 @@
 # @ontrails/warden
 
-AST-based code convention rules for Trails. 15 lint rules that catch contract violations at development time, plus lock drift detection and CI formatters.
+AST-based code convention rules for Trails. Built-in lint rules catch contract violations at development time, alongside lock drift detection and CI formatters.
 
 Structural checks (cross target existence, declared resource existence, recursive crossing, example schema validation) live in `validateTopo()` from `@ontrails/core`. Warden handles the code-level rules that need AST analysis.
 
@@ -34,6 +34,7 @@ console.log(formatWardenReport(report));
 | `no-sync-result-assumption` | error | Missing `await` on `.blaze()` results |
 | `valid-detour-refs` | error | Detour targets that do not exist in the topo |
 | `no-throw-in-detour-target` | error | `throw` inside detour target trails |
+| `unreachable-detour-shadowing` | error | Later detours made unreachable by earlier same-or-broader `on:` error types |
 | `no-direct-implementation-call` | warn | Direct `.blaze()` calls bypassing `ctx.cross()` |
 | `no-direct-impl-in-route` | warn | Direct `.blaze()` calls inside trail bodies with `crosses` |
 | `prefer-schema-inference` | warn | Redundant field overrides already derivable from the schema |

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -162,9 +162,38 @@ describe('runWarden project context', () => {
         (diagnostic) => diagnostic.rule === 'no-throw-in-detour-target'
       );
 
-      // Detour target collection is dormant — detours now use error class
-      // constructors, not string trail IDs. See TRL-273 for the replacement rule.
+      // Target collection stays dormant because modern detours match error
+      // classes, not trail IDs. Shadowed detours are linted separately.
       expect(detourThrowRules).toHaveLength(0);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('reports detours shadowed by earlier broader on: types', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'shadowed.ts'),
+        `import { ConflictError, Result, TrailsError, trail } from '@ontrails/core';
+
+trail("entity.save", {
+  detours: [
+    { on: TrailsError, recover: async () => Result.ok({ winner: "broad" }) },
+    { on: ConflictError, recover: async () => Result.ok({ winner: "specific" }) },
+  ],
+  blaze: () => Result.err(new ConflictError("boom")),
+});`
+      );
+
+      const report = await runWarden({ rootDir: dir });
+      const shadowRules = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'unreachable-detour-shadowing'
+      );
+
+      expect(shadowRules).toHaveLength(1);
+      expect(shadowRules[0]?.message).toContain('TrailsError');
+      expect(shadowRules[0]?.message).toContain('ConflictError');
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 27 rule trails', () => {
-    expect(wardenTopo.count).toBe(27);
+  test('contains all 28 rule trails', () => {
+    expect(wardenTopo.count).toBe(28);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/__tests__/unreachable-detour-shadowing.test.ts
+++ b/packages/warden/src/__tests__/unreachable-detour-shadowing.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test';
+
+import { unreachableDetourShadowing } from '../rules/unreachable-detour-shadowing.js';
+
+const TEST_FILE = 'detour.ts';
+
+describe('unreachable-detour-shadowing', () => {
+  test('passes when the more specific detour is declared first', () => {
+    const code = `
+trail('entity.save', {
+  detours: [
+    { on: ConflictError, recover: async () => Result.ok({ winner: 'specific' }) },
+    { on: TrailsError, recover: async () => Result.ok({ winner: 'broad' }) },
+  ],
+});
+`;
+
+    expect(unreachableDetourShadowing.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('flags a later detour shadowed by an earlier broader core error type', () => {
+    const code = `
+trail('entity.save', {
+  detours: [
+    { on: TrailsError, recover: async () => Result.ok({ winner: 'broad' }) },
+    { on: ConflictError, recover: async () => Result.ok({ winner: 'specific' }) },
+  ],
+});
+`;
+
+    const diagnostics = unreachableDetourShadowing.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('unreachable-detour-shadowing');
+    expect(diagnostics[0]?.severity).toBe('error');
+    expect(diagnostics[0]?.message).toContain('TrailsError');
+    expect(diagnostics[0]?.message).toContain('ConflictError');
+  });
+
+  test('flags a later local subclass shadowed by its parent detour', () => {
+    const code = `
+class StoreConflictError extends ConflictError {}
+
+trail('entity.save', {
+  detours: [
+    { on: ConflictError, recover: async () => Result.ok({ winner: 'parent' }) },
+    { on: StoreConflictError, recover: async () => Result.ok({ winner: 'child' }) },
+  ],
+});
+`;
+
+    const diagnostics = unreachableDetourShadowing.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('ConflictError');
+    expect(diagnostics[0]?.message).toContain('StoreConflictError');
+  });
+
+  test('flags a later detour shadowed by an earlier DerivationError detour', () => {
+    const code = `
+trail('entity.derive', {
+  detours: [
+    { on: DerivationError, recover: async () => Result.ok({ winner: 'broad' }) },
+    { on: DerivationError, recover: async () => Result.ok({ winner: 'dup' }) },
+  ],
+});
+`;
+
+    const diagnostics = unreachableDetourShadowing.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('DerivationError');
+  });
+
+  test('flags a later detour shadowed by a ClassExpression-bound local subclass', () => {
+    const code = `
+const StoreConflictError = class extends ConflictError {};
+
+trail('entity.save', {
+  detours: [
+    { on: ConflictError, recover: async () => Result.ok({ winner: 'parent' }) },
+    { on: StoreConflictError, recover: async () => Result.ok({ winner: 'child' }) },
+  ],
+});
+`;
+
+    const diagnostics = unreachableDetourShadowing.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('ConflictError');
+    expect(diagnostics[0]?.message).toContain('StoreConflictError');
+  });
+
+  test('tolerates sparse holes in the detours array', () => {
+    const code = `
+trail('entity.save', {
+  detours: [
+    ,
+    { on: TrailsError, recover: async () => Result.ok({ winner: 'broad' }) },
+    ,
+    { on: ConflictError, recover: async () => Result.ok({ winner: 'specific' }) },
+  ],
+});
+`;
+
+    let diagnostics: readonly { message: string }[] = [];
+    expect(() => {
+      diagnostics = unreachableDetourShadowing.check(code, TEST_FILE);
+    }).not.toThrow();
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('TrailsError');
+    expect(diagnostics[0]?.message).toContain('ConflictError');
+  });
+
+  test('does not flag unrelated sibling error types', () => {
+    const code = `
+trail('entity.save', {
+  detours: [
+    { on: ConflictError, recover: async () => Result.ok({ winner: 'conflict' }) },
+    { on: ValidationError, recover: async () => Result.ok({ winner: 'validation' }) },
+  ],
+});
+`;
+
+    expect(unreachableDetourShadowing.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -44,6 +44,7 @@ export { referenceExists } from './rules/reference-exists.js';
 export { resourceDeclarations } from './rules/resource-declarations.js';
 export { resourceIdGrammar } from './rules/resource-id-grammar.js';
 export { resourceExists } from './rules/resource-exists.js';
+export { unreachableDetourShadowing } from './rules/unreachable-detour-shadowing.js';
 export { validDescribeRefs } from './rules/valid-describe-refs.js';
 
 // Rule registry
@@ -115,6 +116,7 @@ export {
   resourceDeclarationsTrail,
   resourceIdGrammarTrail,
   resourceExistsTrail,
+  unreachableDetourShadowingTrail,
   validDescribeRefsTrail,
   validDetourRefsTrail,
 } from './trails/index.js';

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -26,6 +26,7 @@ import { resourceDeclarations } from './resource-declarations.js';
 import { resourceExists } from './resource-exists.js';
 import { resourceIdGrammar } from './resource-id-grammar.js';
 import type { WardenRule } from './types.js';
+import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 import { validDescribeRefs } from './valid-describe-refs.js';
 import { validDetourRefs } from './valid-detour-refs.js';
 
@@ -65,6 +66,7 @@ export { referenceExists } from './reference-exists.js';
 export { resourceDeclarations } from './resource-declarations.js';
 export { resourceExists } from './resource-exists.js';
 export { resourceIdGrammar } from './resource-id-grammar.js';
+export { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 export { validDescribeRefs } from './valid-describe-refs.js';
 
 /** All built-in warden rules, keyed by rule name. */
@@ -101,4 +103,5 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [implementationReturnsResult.name, implementationReturnsResult],
   [noThrowInDetourTarget.name, noThrowInDetourTarget],
   [noDirectImplInRoute.name, noDirectImplInRoute],
+  [unreachableDetourShadowing.name, unreachableDetourShadowing],
 ]);

--- a/packages/warden/src/rules/unreachable-detour-shadowing.ts
+++ b/packages/warden/src/rules/unreachable-detour-shadowing.ts
@@ -1,0 +1,375 @@
+import {
+  AlreadyExistsError,
+  AmbiguousError,
+  AssertionError,
+  AuthError,
+  CancelledError,
+  ConflictError,
+  DerivationError,
+  InternalError,
+  NetworkError,
+  NotFoundError,
+  PermissionError,
+  RateLimitError,
+  RetryExhaustedError,
+  TimeoutError,
+  TrailsError,
+  ValidationError,
+} from '@ontrails/core';
+
+import {
+  extractStringLiteral,
+  findConfigProperty,
+  findTrailDefinitions,
+  identifierName,
+  offsetToLine,
+  parse,
+  walk,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+interface ErrorTypeShape {
+  readonly name: string;
+  readonly prototype: TrailsError;
+}
+
+interface DetourOnType {
+  readonly line: number;
+  readonly onType: string;
+}
+
+const knownErrorConstructors = new Map<string, ErrorTypeShape>([
+  [TrailsError.name, TrailsError],
+  [ValidationError.name, ValidationError],
+  [AmbiguousError.name, AmbiguousError],
+  [AssertionError.name, AssertionError],
+  [NotFoundError.name, NotFoundError],
+  [AlreadyExistsError.name, AlreadyExistsError],
+  [ConflictError.name, ConflictError],
+  [PermissionError.name, PermissionError],
+  [TimeoutError.name, TimeoutError],
+  [RateLimitError.name, RateLimitError],
+  [NetworkError.name, NetworkError],
+  [InternalError.name, InternalError],
+  [DerivationError.name, DerivationError],
+  [AuthError.name, AuthError],
+  [CancelledError.name, CancelledError],
+  [RetryExhaustedError.name, RetryExhaustedError],
+]);
+
+const knownErrorParents = new Map<string, string | null>(
+  [...knownErrorConstructors.entries()].map(([name, ctor]) => {
+    const parent = Object.getPrototypeOf(ctor.prototype)?.constructor;
+    const parentName =
+      typeof parent?.name === 'string' &&
+      knownErrorConstructors.has(parent.name)
+        ? parent.name
+        : null;
+    return [name, parentName];
+  })
+);
+
+const resolveKnownErrorName = (
+  name: string,
+  aliases: ReadonlyMap<string, string>
+): string => aliases.get(name) ?? name;
+
+const coreImportSource = (node: AstNode): string | null =>
+  extractStringLiteral((node as unknown as { source?: AstNode }).source);
+
+const collectImportSpecifierAliases = (
+  specifiers: readonly AstNode[] | undefined,
+  aliases: Map<string, string>
+): void => {
+  for (const specifier of specifiers ?? []) {
+    if (specifier.type !== 'ImportSpecifier') {
+      continue;
+    }
+
+    const localName = identifierName(
+      (specifier as unknown as { local?: AstNode }).local
+    );
+    const importedName =
+      identifierName(
+        (specifier as unknown as { imported?: AstNode }).imported
+      ) ?? localName;
+
+    if (localName && importedName && knownErrorConstructors.has(importedName)) {
+      aliases.set(localName, importedName);
+    }
+  }
+};
+
+const collectKnownErrorAliases = (
+  ast: AstNode
+): ReadonlyMap<string, string> => {
+  const aliases = new Map<string, string>();
+
+  walk(ast, (node) => {
+    if (node.type !== 'ImportDeclaration') {
+      return;
+    }
+
+    if (coreImportSource(node) !== '@ontrails/core') {
+      return;
+    }
+
+    const { specifiers } = node as unknown as {
+      specifiers?: readonly AstNode[];
+    };
+    collectImportSpecifierAliases(specifiers, aliases);
+  });
+
+  return aliases;
+};
+
+const recordLocalErrorParent = (
+  parents: Map<string, string>,
+  aliases: ReadonlyMap<string, string>,
+  className: string | null,
+  parentName: string | null
+): void => {
+  if (!className || !parentName) {
+    return;
+  }
+
+  parents.set(className, resolveKnownErrorName(parentName, aliases));
+};
+
+const collectClassExpressionParent = (
+  node: AstNode,
+  parents: Map<string, string>,
+  aliases: ReadonlyMap<string, string>
+): void => {
+  if (node.type !== 'VariableDeclarator') {
+    return;
+  }
+
+  const { init } = node as unknown as { init?: AstNode };
+  if (!init || init.type !== 'ClassExpression') {
+    return;
+  }
+
+  const className = identifierName((node as unknown as { id?: AstNode }).id);
+  const parentName = identifierName(
+    (init as unknown as { superClass?: AstNode }).superClass
+  );
+  recordLocalErrorParent(parents, aliases, className, parentName);
+};
+
+const collectLocalErrorParents = (
+  ast: AstNode,
+  aliases: ReadonlyMap<string, string>
+): ReadonlyMap<string, string> => {
+  const parents = new Map<string, string>();
+
+  walk(ast, (node) => {
+    if (node.type === 'ClassDeclaration') {
+      const className = identifierName(
+        (node as unknown as { id?: AstNode }).id
+      );
+      const parentName = identifierName(
+        (node as unknown as { superClass?: AstNode }).superClass
+      );
+      recordLocalErrorParent(parents, aliases, className, parentName);
+      return;
+    }
+
+    collectClassExpressionParent(node, parents, aliases);
+  });
+
+  return parents;
+};
+
+/**
+ * Return the raw AST elements of a trail's `detours` array.
+ *
+ * @remarks
+ * Spread elements (`...baseDetours`) in the `detours` array are intentionally
+ * skipped here and by {@link extractDetourOnTypes}. This makes the ordering
+ * analysis best-effort for arrays that contain spreads: only literal inline
+ * detour object entries are ordering-checked, so spreads can cause both false
+ * negatives and false positives depending on where they sit relative to the
+ * literal entries.
+ */
+const getDetourElements = (config: AstNode): readonly (AstNode | null)[] => {
+  const detoursProp = findConfigProperty(config, 'detours');
+  if (!detoursProp) {
+    return [];
+  }
+
+  const detoursValue = detoursProp.value as AstNode | undefined;
+  if (!detoursValue || detoursValue.type !== 'ArrayExpression') {
+    return [];
+  }
+
+  const elements = (detoursValue as AstNode)['elements'] as
+    | readonly (AstNode | null)[]
+    | undefined;
+  return elements ?? [];
+};
+
+const extractDetourOnTypes = (
+  config: AstNode,
+  sourceCode: string,
+  aliases: ReadonlyMap<string, string>
+): readonly DetourOnType[] =>
+  getDetourElements(config).flatMap((element) => {
+    if (!element || element.type !== 'ObjectExpression') {
+      return [];
+    }
+
+    const onProp = findConfigProperty(element, 'on');
+    const onNode = onProp?.value as AstNode | undefined;
+    const onTypeName = identifierName(onNode);
+    if (!onNode || !onTypeName) {
+      return [];
+    }
+
+    return [
+      {
+        line: offsetToLine(sourceCode, onNode.start),
+        onType: resolveKnownErrorName(onTypeName, aliases),
+      },
+    ];
+  });
+
+const nextParentType = (
+  errorType: string,
+  localParents: ReadonlyMap<string, string>
+): string | null =>
+  localParents.get(errorType) ?? knownErrorParents.get(errorType) ?? null;
+
+const isSameOrSubtype = (
+  candidate: string,
+  ancestor: string,
+  localParents: ReadonlyMap<string, string>
+): boolean => {
+  let current: string | null = candidate;
+  const seen = new Set<string>();
+
+  while (current && !seen.has(current)) {
+    if (current === ancestor) {
+      return true;
+    }
+
+    seen.add(current);
+    current = nextParentType(current, localParents);
+  }
+
+  return false;
+};
+
+const buildDiagnostic = (
+  trailId: string,
+  shadowedType: string,
+  shadowingType: string,
+  filePath: string,
+  line: number
+): WardenDiagnostic => ({
+  filePath,
+  line,
+  message: `Trail "${trailId}" declares detour on "${shadowedType}" after earlier detour on "${shadowingType}". Because "${shadowingType}" matches "${shadowedType}" first, the later detour is unreachable.`,
+  rule: 'unreachable-detour-shadowing',
+  severity: 'error',
+});
+
+const findShadowingDetour = (
+  detours: readonly DetourOnType[],
+  index: number,
+  localParents: ReadonlyMap<string, string>
+): DetourOnType | null => {
+  const detour = detours[index];
+  if (!detour) {
+    return null;
+  }
+
+  for (let previousIndex = 0; previousIndex < index; previousIndex += 1) {
+    const previous = detours[previousIndex];
+    if (
+      previous &&
+      isSameOrSubtype(detour.onType, previous.onType, localParents)
+    ) {
+      return previous;
+    }
+  }
+
+  return null;
+};
+
+const buildTrailDiagnostics = (
+  trailId: string,
+  detours: readonly DetourOnType[],
+  filePath: string,
+  localParents: ReadonlyMap<string, string>
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (let index = 1; index < detours.length; index += 1) {
+    const detour = detours[index];
+    const shadowing = findShadowingDetour(detours, index, localParents);
+    if (!detour || !shadowing) {
+      continue;
+    }
+
+    diagnostics.push(
+      buildDiagnostic(
+        trailId,
+        detour.onType,
+        shadowing.onType,
+        filePath,
+        detour.line
+      )
+    );
+  }
+
+  return diagnostics;
+};
+
+const buildDiagnostics = (
+  ast: AstNode,
+  sourceCode: string,
+  filePath: string
+): readonly WardenDiagnostic[] => {
+  const aliases = collectKnownErrorAliases(ast);
+  const localParents = collectLocalErrorParents(ast, aliases);
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const definition of findTrailDefinitions(ast)) {
+    if (definition.kind !== 'trail') {
+      continue;
+    }
+
+    diagnostics.push(
+      ...buildTrailDiagnostics(
+        definition.id,
+        extractDetourOnTypes(definition.config, sourceCode, aliases),
+        filePath,
+        localParents
+      )
+    );
+  }
+
+  return diagnostics;
+};
+
+export const unreachableDetourShadowing: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isTestFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    return buildDiagnostics(ast, sourceCode, filePath);
+  },
+  description:
+    'Detect later detours whose on: error type is already matched by an earlier same or broader detour.',
+  name: 'unreachable-detour-shadowing',
+  severity: 'error',
+};

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -23,6 +23,7 @@ export { referenceExistsTrail } from './reference-exists.trail.js';
 export { resourceDeclarationsTrail } from './resource-declarations.trail.js';
 export { resourceIdGrammarTrail } from './resource-id-grammar.trail.js';
 export { resourceExistsTrail } from './resource-exists.trail.js';
+export { unreachableDetourShadowingTrail } from './unreachable-detour-shadowing.trail.js';
 export { validDescribeRefsTrail } from './valid-describe-refs.trail.js';
 export { validDetourRefsTrail } from './valid-detour-refs.trail.js';
 

--- a/packages/warden/src/trails/unreachable-detour-shadowing.trail.ts
+++ b/packages/warden/src/trails/unreachable-detour-shadowing.trail.ts
@@ -1,0 +1,45 @@
+import { unreachableDetourShadowing } from '../rules/unreachable-detour-shadowing.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const unreachableDetourShadowingTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        sourceCode: `trail("entity.save", {
+  detours: [
+    { on: ConflictError, recover: async () => Result.ok({ winner: "specific" }) },
+    { on: TrailsError, recover: async () => Result.ok({ winner: "broad" }) },
+  ],
+});`,
+      },
+      name: 'Specific detours can precede broader ones',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'shadowed.ts',
+            line: 4,
+            message:
+              'Trail "entity.save" declares detour on "ConflictError" after earlier detour on "TrailsError". Because "TrailsError" matches "ConflictError" first, the later detour is unreachable.',
+            rule: 'unreachable-detour-shadowing',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        filePath: 'shadowed.ts',
+        sourceCode: `trail("entity.save", {
+  detours: [
+    { on: TrailsError, recover: async () => Result.ok({ winner: "broad" }) },
+    { on: ConflictError, recover: async () => Result.ok({ winner: "specific" }) },
+  ],
+});`,
+      },
+      name: 'Broader detours declared first shadow later specific ones',
+    },
+  ],
+  rule: unreachableDetourShadowing,
+});


### PR DESCRIPTION
## Summary
This adds governance coverage for detours that can never match because an earlier broader `on:` type already shadows them.

## What Changed
- adds the unreachable detour shadowing warden rule
- wires the rule through the trail and CLI surfaces
- adds focused regression coverage for broad-before-specific shadowing and non-shadowed sibling cases
- leaves the surrounding detour collector comments aligned with the now-shipped rule

## Verification
- `bun run build`
- `bun test packages/warden/src/__tests__/unreachable-detour-shadowing.test.ts packages/warden/src/__tests__/cli.test.ts packages/warden/src/__tests__/trails.test.ts apps/trails/src/__tests__/draft-promote.test.ts --bail`
- bottom-up stack verification reran this branch before submission

## Closes
- Closes `TRL-273`.
