### PR TITLE
feat(warden): promote incompleteCrud to ProjectAwareWardenRule [TRL-271]

### DIFF
--- a/packages/warden/src/__tests__/incomplete-crud.test.ts
+++ b/packages/warden/src/__tests__/incomplete-crud.test.ts
@@ -1,8 +1,97 @@
 import { describe, expect, test } from 'bun:test';
 
 import { incompleteCrud } from '../rules/incomplete-crud.js';
+import type { ProjectContext } from '../rules/types.js';
 
 const TEST_FILE = 'entity.ts';
+
+const buildContext = (
+  coverage: Record<string, readonly string[]>
+): ProjectContext => ({
+  crudCoverageByEntity: new Map(
+    Object.entries(coverage).map(([entityId, operations]) => [
+      entityId,
+      new Set(operations) as ReadonlySet<string>,
+    ])
+  ),
+  knownTrailIds: new Set<string>(),
+});
+
+const splitFileSource = (operation: string): string => `
+import { Result, contour, resource } from '@ontrails/core';
+import { deriveTrail } from '@ontrails/core/trails';
+import { z } from 'zod';
+
+const note = contour('note', {
+  body: z.string(),
+  id: z.string(),
+  title: z.string(),
+}, { identity: 'id' });
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+export const ${operation}Note = deriveTrail(note, '${operation}', {
+  blaze: async () => Result.ok({}),
+  resource: notesResource,
+});
+`;
+
+const importedSplitFileSource = (operation: string): string => `
+import { Result, resource } from '@ontrails/core';
+import { deriveTrail } from '@ontrails/core/trails';
+import { note } from './shared/contours.js';
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+export const ${operation}Note = deriveTrail(note, '${operation}', {
+  blaze: async () => Result.ok({}),
+  resource: notesResource,
+});
+`;
+
+const suffixedBindingSplitFileSource = (operation: string): string => `
+import { Result, contour, resource } from '@ontrails/core';
+import { deriveTrail } from '@ontrails/core/trails';
+import { z } from 'zod';
+
+const noteContour = contour('note', {
+  body: z.string(),
+  id: z.string(),
+  title: z.string(),
+}, { identity: 'id' });
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+export const ${operation}Note = deriveTrail(noteContour, '${operation}', {
+  blaze: async () => Result.ok({}),
+  resource: notesResource,
+});
+`;
+
+const importedSuffixedBindingSplitFileSource = (operation: string): string => `
+import { Result, resource } from '@ontrails/core';
+import { deriveTrail } from '@ontrails/core/trails';
+import { noteContour } from './shared/contours.js';
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+export const ${operation}Note = deriveTrail(noteContour, '${operation}', {
+  blaze: async () => Result.ok({}),
+  resource: notesResource,
+});
+`;
 
 describe('incomplete-crud', () => {
   test('warns when deriveTrail only covers part of the CRUD set', () => {
@@ -209,5 +298,181 @@ const [createArchive, readArchive] = crud(archive.tables.notes, archiveResource)
     expect(diagnostics[0]?.message).toContain('archive:notes');
     expect(diagnostics[0]?.message).toContain('create');
     expect(diagnostics[0]?.message).toContain('read');
+  });
+
+  describe('project-aware (cross-file) coverage', () => {
+    const CREATE_FILE = 'notes/create.ts';
+    const READ_FILE = 'notes/read.ts';
+
+    test('stays quiet when sibling files cover the remaining CRUD operations', () => {
+      const context = buildContext({
+        note: ['create', 'read', 'update', 'delete', 'list'],
+      });
+
+      expect(
+        incompleteCrud.checkWithContext(
+          splitFileSource('create'),
+          CREATE_FILE,
+          context
+        )
+      ).toEqual([]);
+      expect(
+        incompleteCrud.checkWithContext(
+          splitFileSource('read'),
+          READ_FILE,
+          context
+        )
+      ).toEqual([]);
+    });
+
+    test('merges local and imported contour coverage for the same entity', () => {
+      const context = buildContext({
+        'imported:note': ['read', 'update', 'delete', 'list'],
+        note: ['create'],
+      });
+
+      expect(
+        incompleteCrud.checkWithContext(
+          splitFileSource('create'),
+          CREATE_FILE,
+          context
+        )
+      ).toEqual([]);
+      expect(
+        incompleteCrud.checkWithContext(
+          importedSplitFileSource('read'),
+          READ_FILE,
+          context
+        )
+      ).toEqual([]);
+    });
+
+    test('merges imported coverage when the contour binding ends with Contour', () => {
+      const context = buildContext({
+        'imported:noteContour': ['read', 'update', 'delete', 'list'],
+        note: ['create'],
+      });
+
+      expect(
+        incompleteCrud.checkWithContext(
+          suffixedBindingSplitFileSource('create'),
+          CREATE_FILE,
+          context
+        )
+      ).toEqual([]);
+      expect(
+        incompleteCrud.checkWithContext(
+          importedSuffixedBindingSplitFileSource('read'),
+          READ_FILE,
+          context
+        )
+      ).toEqual([]);
+    });
+
+    test('does not collapse authored contour IDs that end with Contour', () => {
+      const source = `
+import { Result, contour, resource } from '@ontrails/core';
+import { deriveTrail } from '@ontrails/core/trails';
+import { z } from 'zod';
+
+const noteContour = contour('noteContour', {
+  body: z.string(),
+  id: z.string(),
+  title: z.string(),
+}, { identity: 'id' });
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+export const readNote = deriveTrail(noteContour, 'read', {
+  blaze: async () => Result.ok({}),
+  resource: notesResource,
+});
+`;
+      const context = buildContext({
+        note: ['create', 'update', 'delete', 'list'],
+        noteContour: ['read'],
+      });
+
+      const diagnostics = incompleteCrud.checkWithContext(
+        source,
+        READ_FILE,
+        context
+      );
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('noteContour');
+      expect(diagnostics[0]?.message).not.toContain('"note"');
+    });
+
+    test('still warns when aggregated coverage is incomplete', () => {
+      const context = buildContext({
+        note: ['create', 'read'],
+      });
+
+      const diagnostics = incompleteCrud.checkWithContext(
+        splitFileSource('create'),
+        CREATE_FILE,
+        context
+      );
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.filePath).toBe(CREATE_FILE);
+      expect(diagnostics[0]?.message).toContain('note');
+      expect(diagnostics[0]?.message).toContain('create');
+      expect(diagnostics[0]?.message).toContain('read');
+      expect(diagnostics[0]?.message).toContain('update');
+    });
+
+    test('colocated full-coverage still passes via checkWithContext', () => {
+      const code = `
+import { Result, contour, resource } from '@ontrails/core';
+import { deriveTrail } from '@ontrails/core/trails';
+import { z } from 'zod';
+
+const note = contour('note', {
+  body: z.string(),
+  id: z.string(),
+  title: z.string(),
+}, { identity: 'id' });
+
+const notesResource = resource('db.notes', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+export const createNote = deriveTrail(note, 'create', { blaze: async () => Result.ok({}), resource: notesResource });
+export const readNote = deriveTrail(note, 'read', { blaze: async () => Result.ok({}), resource: notesResource });
+export const updateNote = deriveTrail(note, 'update', { blaze: async () => Result.ok({}), resource: notesResource });
+export const deleteNote = deriveTrail(note, 'delete', { blaze: async () => Result.ok({}), resource: notesResource });
+export const listNote = deriveTrail(note, 'list', { blaze: async () => Result.ok({}), resource: notesResource });
+`;
+
+      expect(
+        incompleteCrud.checkWithContext(
+          code,
+          TEST_FILE,
+          buildContext({
+            note: ['create', 'read', 'update', 'delete', 'list'],
+          })
+        )
+      ).toEqual([]);
+    });
+
+    test('project context with no matching entity falls back to file-scoped behavior', () => {
+      const diagnostics = incompleteCrud.checkWithContext(
+        splitFileSource('create'),
+        CREATE_FILE,
+        buildContext({})
+      );
+
+      // The local file has only `create`, so without cross-file context
+      // the rule behaves exactly like the file-scoped check.
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.filePath).toBe(CREATE_FILE);
+      expect(diagnostics[0]?.message).toContain('note');
+    });
   });
 });

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -25,6 +25,7 @@ import {
   findTrailDefinitions,
   parse,
 } from './rules/ast.js';
+import { collectFileCrudCoverage } from './rules/incomplete-crud.js';
 import { wardenRules } from './rules/index.js';
 import type {
   ProjectAwareWardenRule,
@@ -103,6 +104,7 @@ interface MutableProjectContext {
   contourReferencesByName: Map<string, Set<string>>;
   crudTableIds: Set<string>;
   crossTargetTrailIds: Set<string>;
+  crudCoverageByEntity: Map<string, Set<string>>;
   detourTargetTrailIds: Set<string>;
   knownContourIds: Set<string>;
   knownResourceIds: Set<string>;
@@ -116,6 +118,7 @@ interface MutableProjectContext {
 const createMutableProjectContext = (): MutableProjectContext => ({
   contourReferencesByName: new Map<string, Set<string>>(),
   crossTargetTrailIds: new Set<string>(),
+  crudCoverageByEntity: new Map<string, Set<string>>(),
   crudTableIds: new Set<string>(),
   detourTargetTrailIds: new Set<string>(),
   knownContourIds: new Set<string>(),
@@ -155,6 +158,18 @@ const toProjectContext = (context: MutableProjectContext): ProjectContext => ({
     : {}),
   ...(context.crudTableIds.size > 0
     ? { crudTableIds: context.crudTableIds }
+    : {}),
+  ...(context.crudCoverageByEntity.size > 0
+    ? {
+        crudCoverageByEntity: new Map(
+          [...context.crudCoverageByEntity.entries()].map(
+            ([entityId, operations]) => [
+              entityId,
+              new Set(operations) as ReadonlySet<string>,
+            ]
+          )
+        ),
+      }
     : {}),
   crossTargetTrailIds: context.crossTargetTrailIds,
   detourTargetTrailIds: context.detourTargetTrailIds,
@@ -296,6 +311,27 @@ const collectOnTargetSignalIds = (
   }
 };
 
+const collectCrudCoverageByEntity = (
+  sourceCode: string,
+  filePath: string,
+  coverageByEntity: Map<string, Set<string>>
+): void => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return;
+  }
+  for (const [entityId, operations] of collectFileCrudCoverage(
+    ast,
+    sourceCode
+  )) {
+    const bucket = coverageByEntity.get(entityId) ?? new Set<string>();
+    for (const operation of operations) {
+      bucket.add(operation);
+    }
+    coverageByEntity.set(entityId, bucket);
+  }
+};
+
 const collectReconcileTableIds = (
   sourceCode: string,
   filePath: string,
@@ -401,7 +437,7 @@ const collectTopoTrailContext = (
   collectTopoContourReferences(appTopo, context);
 };
 
-const collectFileProjectContext = (
+const collectFileKnownIds = (
   sourceFile: SourceFile,
   context: MutableProjectContext
 ): void => {
@@ -425,6 +461,12 @@ const collectFileProjectContext = (
     sourceFile.filePath,
     context.knownSignalIds
   );
+};
+
+const collectFileTrailRelationships = (
+  sourceFile: SourceFile,
+  context: MutableProjectContext
+): void => {
   collectCrossedTrailIds(
     sourceFile.sourceCode,
     sourceFile.filePath,
@@ -439,21 +481,6 @@ const collectFileProjectContext = (
     sourceFile.sourceCode,
     sourceFile.filePath,
     context.trailIntentsById
-  );
-  collectCrudTableIds(
-    sourceFile.sourceCode,
-    sourceFile.filePath,
-    context.crudTableIds
-  );
-  collectOnTargetSignalIds(
-    sourceFile.sourceCode,
-    sourceFile.filePath,
-    context.onTargetSignalIds
-  );
-  collectReconcileTableIds(
-    sourceFile.sourceCode,
-    sourceFile.filePath,
-    context.reconcileTableIds
   );
 };
 
@@ -476,6 +503,20 @@ const collectFileSupplementalProjectContext = (
     sourceFile.filePath,
     context.reconcileTableIds
   );
+  collectCrudCoverageByEntity(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    context.crudCoverageByEntity
+  );
+};
+
+const collectFileProjectContext = (
+  sourceFile: SourceFile,
+  context: MutableProjectContext
+): void => {
+  collectFileKnownIds(sourceFile, context);
+  collectFileTrailRelationships(sourceFile, context);
+  collectFileSupplementalProjectContext(sourceFile, context);
 };
 
 const collectFileContourReferences = (

--- a/packages/warden/src/rules/incomplete-crud.ts
+++ b/packages/warden/src/rules/incomplete-crud.ts
@@ -13,13 +13,18 @@ import {
 } from './ast.js';
 import type { AstNode } from './ast.js';
 import { isTestFile } from './scan.js';
-import type { WardenDiagnostic, WardenRule } from './types.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
 
 const CRUD_OPERATIONS = ['create', 'read', 'update', 'delete', 'list'] as const;
 const CRUD_OPERATION_SET = new Set<string>(CRUD_OPERATIONS);
 
 /** Sentinel entity id prefix for contours imported from another module. */
 const IMPORTED_CONTOUR_PREFIX = 'imported:';
+const CONTOUR_BINDING_SUFFIX = 'Contour';
 
 interface CrudCoverage {
   readonly entityId: string;
@@ -57,6 +62,52 @@ const resolveContourIdentifier = (
   }
 
   return null;
+};
+
+const stripImportedContourPrefix = (entityId: string): string =>
+  entityId.startsWith(IMPORTED_CONTOUR_PREFIX)
+    ? entityId.slice(IMPORTED_CONTOUR_PREFIX.length)
+    : entityId;
+
+const stripContourBindingSuffix = (entityId: string): string =>
+  entityId.endsWith(CONTOUR_BINDING_SUFFIX)
+    ? entityId.slice(0, -CONTOUR_BINDING_SUFFIX.length)
+    : entityId;
+
+const normalizeProjectEntityId = (
+  entityId: string,
+  projectEntityIds: ReadonlySet<string>
+): string => {
+  const localId = stripImportedContourPrefix(entityId);
+  if (!entityId.startsWith(IMPORTED_CONTOUR_PREFIX)) {
+    return localId;
+  }
+
+  const strippedId = stripContourBindingSuffix(localId);
+  if (
+    strippedId !== localId &&
+    (projectEntityIds.has(strippedId) ||
+      projectEntityIds.has(`${IMPORTED_CONTOUR_PREFIX}${strippedId}`))
+  ) {
+    return strippedId;
+  }
+  return localId;
+};
+
+const normalizeProjectCoverage = (
+  projectCoverage: ReadonlyMap<string, ReadonlySet<string>>,
+  projectEntityIds: ReadonlySet<string>
+): ReadonlyMap<string, ReadonlySet<string>> => {
+  const normalized = new Map<string, Set<string>>();
+  for (const [entityId, operations] of projectCoverage) {
+    const normalizedId = normalizeProjectEntityId(entityId, projectEntityIds);
+    const bucket = normalized.get(normalizedId) ?? new Set<string>();
+    for (const operation of operations) {
+      bucket.add(operation);
+    }
+    normalized.set(normalizedId, bucket);
+  }
+  return normalized;
 };
 
 /**
@@ -242,14 +293,113 @@ const collectCrudTupleCoverage = (
   return coverageByEntityId;
 };
 
-const collectIncompleteCoverage = (
-  coverageByEntityId: ReadonlyMap<string, CrudCoverage>
-): readonly CrudCoverage[] =>
-  [...coverageByEntityId.values()].filter(
-    (coverage) =>
-      coverage.operations.size > 0 &&
-      coverage.operations.size < CRUD_OPERATIONS.length
+const collectFileCoverage = (
+  ast: AstNode,
+  sourceCode: string
+): {
+  readonly derived: ReadonlyMap<string, CrudCoverage>;
+  readonly tuple: ReadonlyMap<string, CrudCoverage>;
+} => ({
+  derived: collectDerivedCrudCoverage(ast, sourceCode),
+  tuple: collectCrudTupleCoverage(ast, sourceCode),
+});
+
+/**
+ * Public AST helper: collect per-entity CRUD operation coverage for a single
+ * file. Used by the CLI to aggregate coverage across the project before the
+ * rule runs, so one-file-per-operation layouts are evaluated correctly.
+ */
+export const collectFileCrudCoverage = (
+  ast: AstNode,
+  sourceCode: string
+): ReadonlyMap<string, ReadonlySet<string>> => {
+  const { derived, tuple } = collectFileCoverage(ast, sourceCode);
+  const merged = new Map<string, Set<string>>();
+  const merge = (source: ReadonlyMap<string, CrudCoverage>): void => {
+    for (const [entityId, coverage] of source) {
+      const bucket = merged.get(entityId) ?? new Set<string>();
+      for (const operation of coverage.operations) {
+        bucket.add(operation);
+      }
+      merged.set(entityId, bucket);
+    }
+  };
+  merge(derived);
+  merge(tuple);
+  return merged;
+};
+
+const seedCombinedCoverage = (
+  fileCoverage: ReadonlyMap<string, CrudCoverage>
+): Map<string, Set<string>> => {
+  const combined = new Map<string, Set<string>>();
+  for (const [entityId, coverage] of fileCoverage) {
+    combined.set(entityId, new Set(coverage.operations));
+  }
+  return combined;
+};
+
+const applyProjectOperations = (
+  combined: Map<string, Set<string>>,
+  fileCoverage: ReadonlyMap<string, CrudCoverage>,
+  projectCoverage: ReadonlyMap<string, ReadonlySet<string>>
+): void => {
+  const projectEntityIds = new Set(projectCoverage.keys());
+  const normalizedProjectCoverage = normalizeProjectCoverage(
+    projectCoverage,
+    projectEntityIds
   );
+  for (const entityId of fileCoverage.keys()) {
+    const bucket = combined.get(entityId) ?? new Set<string>();
+    const operations = normalizedProjectCoverage.get(
+      normalizeProjectEntityId(entityId, projectEntityIds)
+    );
+    if (operations) {
+      for (const operation of operations) {
+        bucket.add(operation);
+      }
+    }
+    combined.set(entityId, bucket);
+  }
+};
+
+const mergeProjectOperations = (
+  fileCoverage: ReadonlyMap<string, CrudCoverage>,
+  projectCoverage?: ReadonlyMap<string, ReadonlySet<string>>
+): Map<string, Set<string>> => {
+  const combined = seedCombinedCoverage(fileCoverage);
+  if (projectCoverage) {
+    applyProjectOperations(combined, fileCoverage, projectCoverage);
+  }
+  return combined;
+};
+
+const collectIncompleteEntities = (
+  fileCoverage: ReadonlyMap<string, CrudCoverage>,
+  projectCoverage?: ReadonlyMap<string, ReadonlySet<string>>
+): readonly CrudCoverage[] => {
+  const combinedOperations = mergeProjectOperations(
+    fileCoverage,
+    projectCoverage
+  );
+
+  return [...fileCoverage.values()].flatMap((coverage) => {
+    const combined = combinedOperations.get(coverage.entityId);
+    if (!combined || combined.size === 0) {
+      return [];
+    }
+    if (combined.size >= CRUD_OPERATIONS.length) {
+      return [];
+    }
+    return [
+      {
+        entityId: coverage.entityId,
+        line: coverage.line,
+        operations: combined,
+      },
+    ];
+  });
+};
 
 const formatEntityLabel = (entityId: string): string =>
   entityId.startsWith(IMPORTED_CONTOUR_PREFIX)
@@ -276,24 +426,52 @@ const buildIncompleteCrudDiagnostic = (
   };
 };
 
-export const incompleteCrud: WardenRule = {
+const evaluateFile = (
+  sourceCode: string,
+  filePath: string,
+  projectCoverage?: ReadonlyMap<string, ReadonlySet<string>>
+): readonly WardenDiagnostic[] => {
+  if (isTestFile(filePath)) {
+    return [];
+  }
+
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  const { derived, tuple } = collectFileCoverage(ast, sourceCode);
+
+  return [
+    ...collectIncompleteEntities(derived, projectCoverage),
+    ...collectIncompleteEntities(tuple, projectCoverage),
+  ].map((coverage) => buildIncompleteCrudDiagnostic(coverage, filePath));
+};
+
+/**
+ * Warn when factory-style CRUD authoring covers only part of the standard
+ * create/read/update/delete/list set.
+ *
+ * Project-aware: when a `ProjectContext` is available, operations observed in
+ * sibling files (e.g. one-file-per-operation layouts such as `create.ts`,
+ * `read.ts`, `update.ts`, `delete.ts`, `list.ts`) are merged with the local
+ * file's coverage before completeness is evaluated, so split layouts do not
+ * produce false positives. The fallback `check` entry point stays file-scoped
+ * for direct invocations that lack project context.
+ */
+export const incompleteCrud: ProjectAwareWardenRule = {
   check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
-    if (isTestFile(filePath)) {
-      return [];
-    }
-
-    const ast = parse(filePath, sourceCode);
-    if (!ast) {
-      return [];
-    }
-
-    return [
-      ...collectIncompleteCoverage(collectDerivedCrudCoverage(ast, sourceCode)),
-      ...collectIncompleteCoverage(collectCrudTupleCoverage(ast, sourceCode)),
-    ].map((coverage) => buildIncompleteCrudDiagnostic(coverage, filePath));
+    return evaluateFile(sourceCode, filePath);
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    return evaluateFile(sourceCode, filePath, context.crudCoverageByEntity);
   },
   description:
-    'Warn when factory-style CRUD authoring covers only part of the standard create/read/update/delete/list set. This rule is file-scoped: all operations for an entity must be colocated in the same file for the rule to correctly assess completeness. One-file-per-operation layouts (e.g. deriveTrail in separate create.ts, read.ts, etc.) may produce false positives.',
+    'Warn when factory-style CRUD authoring covers only part of the standard create/read/update/delete/list set. Coverage is aggregated across the project so one-file-per-operation layouts are evaluated on the full CRUD set.',
   name: 'incomplete-crud',
   severity: 'warn',
 };

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -65,6 +65,19 @@ export interface ProjectContext {
   readonly reconcileTableIds?: ReadonlySet<string>;
   /** Normalized trail intents by trail ID across the project. */
   readonly trailIntentsById?: ReadonlyMap<string, 'destroy' | 'read' | 'write'>;
+  /**
+   * CRUD operation coverage per entity aggregated across the project.
+   *
+   * Keys are stable entity IDs (authored contour names, `imported:<local>`
+   * sentinels for contours imported from another module, or store-table IDs
+   * produced by `deriveStoreTableId`). Values are the set of CRUD operations
+   * (`create`, `read`, `update`, `delete`, `list`) observed for that entity.
+   *
+   * Enables cross-file completeness evaluation so one-file-per-operation
+   * layouts (e.g. separate `create.ts`, `read.ts`) do not trip file-scoped
+   * coverage warnings.
+   */
+  readonly crudCoverageByEntity?: ReadonlyMap<string, ReadonlySet<string>>;
 }
 
 /**

--- a/packages/warden/src/trails/run.ts
+++ b/packages/warden/src/trails/run.ts
@@ -33,6 +33,7 @@ interface ProjectRuleOptions {
   >;
   readonly crossTargetTrailIds?: readonly string[];
   readonly crudTableIds?: readonly string[];
+  readonly crudCoverageByEntity?: Readonly<Record<string, readonly string[]>>;
   readonly detourTargetTrailIds?: readonly string[];
   readonly knownContourIds?: readonly string[];
   readonly knownResourceIds?: readonly string[];
@@ -47,6 +48,7 @@ const PROJECT_OPTION_KEYS = [
   'contourReferencesByName',
   'crossTargetTrailIds',
   'crudTableIds',
+  'crudCoverageByEntity',
   'detourTargetTrailIds',
   'knownContourIds',
   'knownResourceIds',

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -38,6 +38,12 @@ export const projectAwareRuleInput = ruleInput.extend({
     .array(z.string())
     .optional()
     .describe('Trail IDs referenced by crosses arrays across the project'),
+  crudCoverageByEntity: z
+    .record(z.string(), z.array(z.string()))
+    .optional()
+    .describe(
+      'CRUD operation coverage per entity aggregated across the project'
+    ),
   crudTableIds: z
     .array(z.string())
     .optional()

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -38,6 +38,18 @@ const buildProjectContext = (input: ProjectAwareRuleInput): ProjectContext => ({
       }
     : {}),
   ...(input.crudTableIds ? { crudTableIds: new Set(input.crudTableIds) } : {}),
+  ...(input.crudCoverageByEntity
+    ? {
+        crudCoverageByEntity: new Map(
+          Object.entries(input.crudCoverageByEntity).map(
+            ([entityId, operations]) => [
+              entityId,
+              new Set(operations) as ReadonlySet<string>,
+            ]
+          )
+        ),
+      }
+    : {}),
   ...(input.knownContourIds
     ? { knownContourIds: new Set(input.knownContourIds) }
     : {}),


### PR DESCRIPTION
This promotes `incompleteCrud` from a file-scoped rule to a project-aware rule so split CRUD layouts stop false-positiving.

## What changed
- aggregate derived CRUD coverage across the project in `buildProjectContext`
- evaluate rule completeness against the union of local and project-level operations
- preserve the old file-scoped behavior when no project context is available
- merge local and imported contour coverage keys during project aggregation
- normalize common `*Contour` alias imports so mixed `note` / `imported:noteContour` layouts collapse to the same entity

## Why
One-file-per-operation layouts were being flagged as incomplete because each file only saw its own local operation. The new project-aware path fixes that without regressing colocated CRUD definitions, and the follow-up review fixes tighten the aggregation logic for imported contour variants.

## How to test
- `bun test packages/warden/src/__tests__/incomplete-crud.test.ts --bail`
- `bun test packages/warden/src/__tests__/trails.test.ts --bail`
- `bun run build`

Closes TRL-271
