### PR TITLE
feat(warden): add TopoAwareWardenRule for topo-level runtime inspection [TRL-268]

### DIFF
--- a/packages/warden/src/__tests__/topo-aware-rule.test.ts
+++ b/packages/warden/src/__tests__/topo-aware-rule.test.ts
@@ -1,0 +1,257 @@
+/**
+ * End-to-end dispatch test for `TopoAwareWardenRule`.
+ *
+ * Exercises the CLI → topo-aware rule dispatch path with a no-op mock rule
+ * injected via `extraTopoRules`. Proves the plumbing works without shipping
+ * any production topo-aware rule.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createTrailContext, topo, trail, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+import { runWarden } from '../cli.js';
+import type { TopoAwareWardenRule, WardenDiagnostic } from '../rules/types.js';
+import { topoAwareRuleInput } from '../trails/schema.js';
+import { wrapTopoRule } from '../trails/wrap-rule.js';
+
+const makeTempDir = (): string => {
+  const dir = join(
+    tmpdir(),
+    `warden-topo-aware-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+};
+
+const buildFixtureTopo = () => {
+  const echo = trail('fixture.echo', {
+    blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+    description: 'echo',
+    examples: [
+      {
+        expected: { value: 'a' },
+        input: { value: 'a' },
+        name: 'roundtrips',
+      },
+    ],
+    input: z.object({ value: z.string() }),
+    intent: 'read',
+    output: z.object({ value: z.string() }),
+  });
+  return topo('fixture', { echo });
+};
+
+const PLACEHOLDER_FINDING: WardenDiagnostic = {
+  filePath: '<topo>',
+  line: 1,
+  message: 'synthetic topo-level finding',
+  rule: 'placeholder-topo-aware',
+  severity: 'warn',
+};
+
+const buildPlaceholderRule = (seen: string[]): TopoAwareWardenRule => ({
+  checkTopo: (inspectedTopo) => {
+    seen.push(inspectedTopo.name);
+    return [PLACEHOLDER_FINDING];
+  },
+  description: 'placeholder rule returning one diagnostic',
+  name: 'placeholder-topo-aware',
+  severity: 'warn',
+});
+
+describe('TopoAwareWardenRule dispatch', () => {
+  test('CLI dispatches injected topo-aware rules and aggregates diagnostics into the report', async () => {
+    const dir = makeTempDir();
+    try {
+      const seen: string[] = [];
+      const report = await runWarden({
+        extraTopoRules: [buildPlaceholderRule(seen)],
+        lintOnly: true,
+        rootDir: dir,
+        topo: buildFixtureTopo(),
+      });
+      const emitted = report.diagnostics.filter(
+        (d) => d.rule === 'placeholder-topo-aware'
+      );
+
+      expect(seen).toEqual(['fixture']);
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual(PLACEHOLDER_FINDING);
+      expect(report.warnCount).toBeGreaterThanOrEqual(1);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI skips topo-aware rules when no topo is provided', async () => {
+    const dir = makeTempDir();
+    try {
+      let invoked = false;
+      const placeholder: TopoAwareWardenRule = {
+        checkTopo: () => {
+          invoked = true;
+          return [];
+        },
+        description: 'placeholder',
+        name: 'placeholder-unused',
+        severity: 'warn',
+      };
+
+      await runWarden({
+        extraTopoRules: [placeholder],
+        lintOnly: true,
+        rootDir: dir,
+      });
+
+      expect(invoked).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('wrapTopoRule flows diagnostics through the trail pipeline', async () => {
+    const diagnostic: WardenDiagnostic = {
+      filePath: '<topo>',
+      line: 1,
+      message: 'synthetic finding',
+      rule: 'synthetic-topo-rule',
+      severity: 'warn',
+    };
+    const placeholder: TopoAwareWardenRule = {
+      checkTopo: () => [diagnostic],
+      description: 'synthetic',
+      name: 'synthetic-topo-rule',
+      severity: 'warn',
+    };
+
+    const wrapped = wrapTopoRule({ examples: [], rule: placeholder });
+    const result = await wrapped.blaze(
+      { topo: buildFixtureTopo() },
+      createTrailContext()
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ diagnostics: [diagnostic] });
+    expect(wrapped.id).toBe('warden.rule.synthetic-topo-rule');
+  });
+
+  test('CLI awaits async topo-aware rules before aggregating diagnostics', async () => {
+    const dir = makeTempDir();
+    try {
+      const seen: string[] = [];
+      const asyncRule: TopoAwareWardenRule = {
+        checkTopo(inspectedTopo) {
+          seen.push(inspectedTopo.name);
+          return Promise.resolve([
+            {
+              ...PLACEHOLDER_FINDING,
+              rule: 'async-placeholder-topo-aware',
+            },
+          ]);
+        },
+        description: 'async placeholder',
+        name: 'async-placeholder-topo-aware',
+        severity: 'warn',
+      };
+
+      const report = await runWarden({
+        extraTopoRules: [asyncRule],
+        lintOnly: true,
+        rootDir: dir,
+        topo: buildFixtureTopo(),
+      });
+
+      expect(seen).toEqual(['fixture']);
+      expect(
+        report.diagnostics.filter(
+          (d) => d.rule === 'async-placeholder-topo-aware'
+        )
+      ).toEqual([
+        { ...PLACEHOLDER_FINDING, rule: 'async-placeholder-topo-aware' },
+      ]);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI converts thrown topo-aware rule errors into diagnostics', async () => {
+    const dir = makeTempDir();
+    try {
+      const report = await runWarden({
+        extraTopoRules: [
+          {
+            checkTopo: () => {
+              throw new Error('graph shape changed unexpectedly');
+            },
+            description: 'rule that throws',
+            name: 'throwing-topo-rule',
+            severity: 'error',
+          },
+        ],
+        lintOnly: true,
+        rootDir: dir,
+        topo: buildFixtureTopo(),
+      });
+
+      expect(
+        report.diagnostics.filter((d) => d.rule === 'throwing-topo-rule')
+      ).toEqual([
+        {
+          filePath: '<topo>',
+          line: 1,
+          message:
+            'Topo-aware rule "throwing-topo-rule" threw: graph shape changed unexpectedly',
+          rule: 'throwing-topo-rule',
+          severity: 'error',
+        },
+      ]);
+      expect(report.errorCount).toBeGreaterThanOrEqual(1);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('topoAwareRuleInput rejects partial topo-shaped objects', () => {
+    const result = topoAwareRuleInput.safeParse({
+      topo: {
+        resources: new Map(),
+        trails: new Map(),
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test('wrapTopoRule converts thrown errors into Result.err with InternalError', async () => {
+    const throwing: TopoAwareWardenRule = {
+      checkTopo: () => {
+        throw new Error('graph shape changed unexpectedly');
+      },
+      description: 'rule that throws',
+      name: 'throwing-topo-rule',
+      severity: 'error',
+    };
+
+    const wrapped = wrapTopoRule({ examples: [], rule: throwing });
+    const result = await wrapped.blaze(
+      { topo: buildFixtureTopo() },
+      createTrailContext()
+    );
+
+    expect(result.isErr()).toBe(true);
+    const err = result.match({
+      err: (e) => e,
+      ok: () => {
+        throw new Error('expected Result.err');
+      },
+    });
+    expect(err.name).toBe('InternalError');
+    expect(err.message).toContain('throwing-topo-rule');
+    expect(err.message).toContain('graph shape changed unexpectedly');
+  });
+});

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -26,10 +26,11 @@ import {
   parse,
 } from './rules/ast.js';
 import { collectFileCrudCoverage } from './rules/incomplete-crud.js';
-import { wardenRules } from './rules/index.js';
+import { wardenRules, wardenTopoRules } from './rules/index.js';
 import type {
   ProjectAwareWardenRule,
   ProjectContext,
+  TopoAwareWardenRule,
   WardenDiagnostic,
   WardenRule,
 } from './rules/types.js';
@@ -44,8 +45,25 @@ export interface WardenOptions {
   readonly lintOnly?: boolean | undefined;
   /** Only run drift detection, skip lint rules */
   readonly driftOnly?: boolean | undefined;
-  /** App topology for drift detection. When provided, enables real trailhead lock comparison. */
+  /**
+   * App topology for drift detection. When provided, enables real trailhead
+   * lock comparison and unlocks the topo-aware rule dispatch path.
+   *
+   * @remarks
+   * Topo-aware rules (both built-in `wardenTopoRules` and `extraTopoRules`)
+   * only fire when a `Topo` is supplied. Runs without a topo silently skip
+   * topo-aware dispatch — callers that depend on a topo-aware rule firing
+   * must pass `topo` explicitly.
+   */
   readonly topo?: Topo | undefined;
+  /**
+   * Extra topo-aware rules to run in addition to the built-in registry.
+   *
+   * Primarily a test hook — production callers should register rules via
+   * `wardenTopoRules` in `rules/index.ts`. These rules are only invoked
+   * when `topo` is also supplied (see `topo` remarks).
+   */
+  readonly extraTopoRules?: readonly TopoAwareWardenRule[] | undefined;
 }
 
 /**
@@ -564,21 +582,54 @@ const buildProjectContext = (
 const isProjectAwareRule = (rule: WardenRule): rule is ProjectAwareWardenRule =>
   'checkWithContext' in rule;
 
-/**
- * Lint all files against all warden rules.
- */
-const lintFiles = async (
-  rootDir: string,
-  appTopo?: Topo | undefined
-): Promise<WardenDiagnostic[]> => {
-  const allDiagnostics: WardenDiagnostic[] = [];
-  const sourceFiles = await loadSourceFiles(rootDir);
-  const context = buildProjectContext(sourceFiles, appTopo);
+const topoRuleFailureDiagnostic = (
+  rule: TopoAwareWardenRule,
+  error: unknown
+): WardenDiagnostic => {
+  const cause = error instanceof Error ? error : new Error(String(error));
+  return {
+    filePath: '<topo>',
+    line: 1,
+    message: `Topo-aware rule "${rule.name}" threw: ${cause.message}`,
+    rule: rule.name,
+    severity: 'error',
+  };
+};
 
+/**
+ * Run all registered topo-aware rules against the resolved topo.
+ *
+ * Topo-aware rules fire exactly once per run (not per file) because they
+ * inspect the compiled trail graph, not source text.
+ */
+const lintTopo = async (
+  appTopo: Topo,
+  extraTopoRules: readonly TopoAwareWardenRule[]
+): Promise<readonly WardenDiagnostic[]> => {
+  const diagnostics: WardenDiagnostic[] = [];
+  const rules: readonly TopoAwareWardenRule[] = [
+    ...wardenTopoRules.values(),
+    ...extraTopoRules,
+  ];
+  for (const rule of rules) {
+    try {
+      diagnostics.push(...(await rule.checkTopo(appTopo)));
+    } catch (error) {
+      diagnostics.push(topoRuleFailureDiagnostic(rule, error));
+    }
+  }
+  return diagnostics;
+};
+
+const lintSourceFiles = (
+  sourceFiles: readonly SourceFile[],
+  context: ProjectContext
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
   for (const sourceFile of sourceFiles) {
     for (const rule of wardenRules.values()) {
       if (isProjectAwareRule(rule)) {
-        allDiagnostics.push(
+        diagnostics.push(
           ...rule.checkWithContext(
             sourceFile.sourceCode,
             sourceFile.filePath,
@@ -587,11 +638,30 @@ const lintFiles = async (
         );
         continue;
       }
-
-      allDiagnostics.push(
+      diagnostics.push(
         ...rule.check(sourceFile.sourceCode, sourceFile.filePath)
       );
     }
+  }
+  return diagnostics;
+};
+
+/**
+ * Lint all files against all warden rules.
+ */
+const lintFiles = async (
+  rootDir: string,
+  appTopo?: Topo | undefined,
+  extraTopoRules: readonly TopoAwareWardenRule[] = []
+): Promise<WardenDiagnostic[]> => {
+  const sourceFiles = await loadSourceFiles(rootDir);
+  const context = buildProjectContext(sourceFiles, appTopo);
+  const allDiagnostics: WardenDiagnostic[] = [
+    ...lintSourceFiles(sourceFiles, context),
+  ];
+
+  if (appTopo) {
+    allDiagnostics.push(...(await lintTopo(appTopo, extraTopoRules)));
   }
 
   return allDiagnostics;
@@ -606,7 +676,7 @@ export const runWarden = async (
   const rootDir = resolve(options.rootDir ?? process.cwd());
   const allDiagnostics = options.driftOnly
     ? []
-    : await lintFiles(rootDir, options.topo);
+    : await lintFiles(rootDir, options.topo, options.extraTopoRules ?? []);
   const drift = options.lintOnly
     ? null
     : await checkDrift(rootDir, options.topo);

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -11,6 +11,7 @@
 export type {
   ProjectAwareWardenRule,
   ProjectContext,
+  TopoAwareWardenRule,
   WardenDiagnostic,
   WardenRule,
   WardenSeverity,
@@ -48,7 +49,7 @@ export { unreachableDetourShadowing } from './rules/unreachable-detour-shadowing
 export { validDescribeRefs } from './rules/valid-describe-refs.js';
 
 // Rule registry
-export { wardenRules } from './rules/index.js';
+export { wardenRules, wardenTopoRules } from './rules/index.js';
 
 // CLI runner
 export type { WardenOptions, WardenReport } from './cli.js';
@@ -116,8 +117,14 @@ export {
   resourceDeclarationsTrail,
   resourceIdGrammarTrail,
   resourceExistsTrail,
+  topoAwareRuleInput,
   unreachableDetourShadowingTrail,
   validDescribeRefsTrail,
   validDetourRefsTrail,
+  wrapTopoRule,
 } from './trails/index.js';
-export type { RuleInput, RuleOutput } from './trails/index.js';
+export type {
+  RuleInput,
+  RuleOutput,
+  TopoAwareRuleInput,
+} from './trails/index.js';

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -25,7 +25,7 @@ import { referenceExists } from './reference-exists.js';
 import { resourceDeclarations } from './resource-declarations.js';
 import { resourceExists } from './resource-exists.js';
 import { resourceIdGrammar } from './resource-id-grammar.js';
-import type { WardenRule } from './types.js';
+import type { TopoAwareWardenRule, WardenRule } from './types.js';
 import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 import { validDescribeRefs } from './valid-describe-refs.js';
 import { validDetourRefs } from './valid-detour-refs.js';
@@ -33,6 +33,7 @@ import { validDetourRefs } from './valid-detour-refs.js';
 export type {
   ProjectAwareWardenRule,
   ProjectContext,
+  TopoAwareWardenRule,
   WardenDiagnostic,
   WardenRule,
   WardenSeverity,
@@ -105,3 +106,19 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [noDirectImplInRoute.name, noDirectImplInRoute],
   [unreachableDetourShadowing.name, unreachableDetourShadowing],
 ]);
+
+/**
+ * Built-in topo-aware warden rules, keyed by rule name.
+ *
+ * These rules inspect the compiled runtime trail graph once per topo,
+ * rather than scanning source files. Kept in a separate registry because
+ * their dispatch shape differs from `WardenRule` / `ProjectAwareWardenRule`.
+ *
+ * @remarks
+ * Topo-aware rules only fire when the warden runtime is invoked with a
+ * resolved `Topo` (see `WardenOptions.topo`). Runs without a topo — e.g.
+ * pure source-directory lints — silently skip this registry. Rules
+ * registered here must tolerate non-execution when no topo is available.
+ */
+export const wardenTopoRules: ReadonlyMap<string, TopoAwareWardenRule> =
+  new Map<string, TopoAwareWardenRule>();

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -1,3 +1,5 @@
+import type { Topo } from '@ontrails/core';
+
 /**
  * Severity level for warden diagnostics.
  */
@@ -90,4 +92,28 @@ export interface ProjectAwareWardenRule extends WardenRule {
     filePath: string,
     context: ProjectContext
   ) => readonly WardenDiagnostic[];
+}
+
+/**
+ * A topo-aware warden rule inspects the compiled runtime trail graph —
+ * actual `Trail` objects with resolved types, accessor shapes, detour
+ * declarations, `pattern` field values, and other runtime-only data that
+ * is unavailable to AST-based rules.
+ *
+ * Unlike `WardenRule` and `ProjectAwareWardenRule`, which analyze source
+ * code on a per-file basis, a `TopoAwareWardenRule` runs once per topo
+ * and returns diagnostics spanning the whole graph. A rule file must
+ * implement exactly one of the three rule kinds.
+ */
+export interface TopoAwareWardenRule {
+  /** Unique rule identifier */
+  readonly name: string;
+  /** Default severity */
+  readonly severity: WardenSeverity;
+  /** Human-readable description of what the rule enforces */
+  readonly description: string;
+  /** Run the rule against the resolved topo and return any diagnostics */
+  readonly checkTopo: (
+    topo: Topo
+  ) => readonly WardenDiagnostic[] | Promise<readonly WardenDiagnostic[]>;
 }

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -27,5 +27,11 @@ export { unreachableDetourShadowingTrail } from './unreachable-detour-shadowing.
 export { validDescribeRefsTrail } from './valid-describe-refs.trail.js';
 export { validDetourRefsTrail } from './valid-detour-refs.trail.js';
 
-export { ruleInput, ruleOutput, diagnosticSchema } from './schema.js';
-export type { RuleInput, RuleOutput } from './schema.js';
+export {
+  diagnosticSchema,
+  ruleInput,
+  ruleOutput,
+  topoAwareRuleInput,
+} from './schema.js';
+export type { RuleInput, RuleOutput, TopoAwareRuleInput } from './schema.js';
+export { wrapTopoRule } from './wrap-rule.js';

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -5,6 +5,7 @@
  * (array of diagnostics) shape.
  */
 
+import type { Topo } from '@ontrails/core';
 import { z } from 'zod';
 
 /** A single diagnostic emitted by a warden rule trail. */
@@ -82,6 +83,29 @@ export const projectAwareRuleInput = ruleInput.extend({
     .describe('Normalized trail intents keyed by trail ID'),
 });
 
+/**
+ * Input for topo-aware warden rule trails.
+ *
+ * The `Topo` graph is not a serializable value, so the schema accepts it
+ * as an opaque `z.custom`. Topo-aware rules are invoked from the warden
+ * runtime with a live, resolved topo reference — they are not expected
+ * to be called across a network boundary.
+ */
+export const topoAwareRuleInput = z.object({
+  topo: z
+    .custom<Topo>(
+      (value) =>
+        typeof value === 'object' &&
+        value !== null &&
+        'trails' in value &&
+        'resources' in value &&
+        'contours' in value &&
+        'signals' in value,
+      { message: 'Expected a resolved Topo instance' }
+    )
+    .describe('Resolved topo graph under inspection'),
+});
+
 /** Output returned by every warden rule trail. */
 export const ruleOutput = z.object({
   diagnostics: z.array(diagnosticSchema).describe('Diagnostics found'),
@@ -89,4 +113,5 @@ export const ruleOutput = z.object({
 
 export type RuleInput = z.infer<typeof ruleInput>;
 export type ProjectAwareRuleInput = z.infer<typeof projectAwareRuleInput>;
+export type TopoAwareRuleInput = z.infer<typeof topoAwareRuleInput>;
 export type RuleOutput = z.infer<typeof ruleOutput>;

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -4,16 +4,27 @@
  * Keeps each rule trail file minimal — just the import + examples.
  */
 
-import { trail, Result } from '@ontrails/core';
+import { InternalError, trail, Result } from '@ontrails/core';
 import type { Trail } from '@ontrails/core';
 
 import type {
   ProjectAwareWardenRule,
   ProjectContext,
+  TopoAwareWardenRule,
   WardenRule,
 } from '../rules/types.js';
-import { projectAwareRuleInput, ruleInput, ruleOutput } from './schema.js';
-import type { ProjectAwareRuleInput, RuleInput, RuleOutput } from './schema.js';
+import {
+  projectAwareRuleInput,
+  ruleInput,
+  ruleOutput,
+  topoAwareRuleInput,
+} from './schema.js';
+import type {
+  ProjectAwareRuleInput,
+  RuleInput,
+  RuleOutput,
+  TopoAwareRuleInput,
+} from './schema.js';
 
 interface WrapRuleOptions {
   /** The existing warden rule to wrap. */
@@ -132,3 +143,45 @@ export function wrapRule(
     output: ruleOutput,
   });
 }
+
+interface WrapTopoRuleOptions {
+  /** The existing topo-aware warden rule to wrap. */
+  readonly rule: TopoAwareWardenRule;
+  /** Trail examples for testing and documentation. */
+  readonly examples: Trail<TopoAwareRuleInput, RuleOutput>['examples'];
+}
+
+/**
+ * Wrap an existing `TopoAwareWardenRule` as a trail.
+ *
+ * Mirrors `wrapRule` for the per-topo dispatch path. Topo-aware rules run
+ * once per topo against the compiled runtime graph rather than per file,
+ * so the trail accepts the live `Topo` as input.
+ */
+export const wrapTopoRule = (
+  options: WrapTopoRuleOptions
+): Trail<TopoAwareRuleInput, RuleOutput> => {
+  const { rule, examples } = options;
+  return trail(`warden.rule.${rule.name}`, {
+    blaze: async (input: TopoAwareRuleInput) => {
+      try {
+        const diagnostics = await rule.checkTopo(input.topo);
+        return Result.ok({ diagnostics: [...diagnostics] });
+      } catch (error) {
+        const cause = error instanceof Error ? error : new Error(String(error));
+        return Result.err(
+          new InternalError(
+            `Topo-aware rule "${rule.name}" threw while inspecting topo: ${cause.message}`,
+            { cause }
+          )
+        );
+      }
+    },
+    description: rule.description,
+    examples,
+    input: topoAwareRuleInput,
+    intent: 'read',
+    meta: { category: 'governance', severity: rule.severity },
+    output: ruleOutput,
+  });
+};


### PR DESCRIPTION
This adds a third warden rule kind for inspecting the resolved topo/runtime graph directly.

## What changed
- add `TopoAwareWardenRule` alongside the existing AST and project-aware rule kinds
- dispatch topo-aware rules separately from per-file rule execution
- support async topo diagnostics so rules can safely inspect async-backed runtime shapes
- add the built-in topo-aware registry plus `extraTopoRules` injection hooks for tests and callers
- add trail-wrapper plumbing and regression coverage for topo-aware rule execution and error handling

## Why
Some governance checks need the compiled topo rather than AST or cross-file source context. This branch lands that primitive cleanly so higher branches can implement real topo-aware rules without forcing them through the wrong abstraction.

## How to test
- `bun test packages/warden/src/__tests__/topo-aware-rule.test.ts --bail`
- `bun test packages/warden/src/__tests__/trails.test.ts --bail`
- `bun run build`

Closes TRL-268
