### PR TITLE
feat(warden): flag standard-op trails missing required accessor methods [TRL-269]

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -245,8 +245,10 @@ McpHarness, McpHarnessOptions, McpHarnessResult
 ```typescript
 runWarden(options?), formatWardenReport(report), checkDrift(rootDir, topo?)
 wardenRules                        // ReadonlyMap<string, WardenRule> — built-in AST-based rules
+wardenTopoRules                    // ReadonlyMap<string, TopoAwareWardenRule> — built-in topo-aware rules
 wardenTopo                         // pre-built Topo of all warden trails
-runWardenTrails(filePath, sourceCode, options?) // run warden rules against a single file
+runWardenTrails(filePath, sourceCode, options?) // run file-scoped warden rules against a single file
+runTopoAwareWardenTrails(topo)     // run built-in topo-aware warden rule trails once per topo
 formatGitHubAnnotations(report), formatJson(report), formatSummary(report)
 
 WardenOptions, WardenReport, WardenDiagnostic, WardenSeverity, DriftResult

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -81,7 +81,11 @@ import { formatGitHubAnnotations, formatJson, formatSummary } from '@ontrails/wa
 Every built-in warden rule is also available as a composable trail. This makes rules queryable, testable, and invocable through any Trails trailhead.
 
 ```typescript
-import { wardenTopo, runWardenTrails } from '@ontrails/warden';
+import {
+  runTopoAwareWardenTrails,
+  runWardenTrails,
+  wardenTopo,
+} from '@ontrails/warden';
 
 // Inspect the warden rule trails
 console.log(wardenTopo.ids()); // ['warden.rule.no-throw-in-implementation', ...]
@@ -91,6 +95,9 @@ const diagnostics = await runWardenTrails(filePath, sourceCode, {
   knownTrailIds: myApp.ids(),
   knownResourceIds: myApp.resourceIds(),
 });
+
+// Run built-in topo-aware rule trails once against the resolved graph
+const topoDiagnostics = await runTopoAwareWardenTrails(myApp);
 ```
 
 To wrap a custom rule as a trail, use `wrapRule` (imported from `@ontrails/warden/trails/wrap-rule`). This is the same factory used internally to build all built-in rule trails.
@@ -104,7 +111,8 @@ To wrap a custom rule as a trail, use `wrapRule` (imported from `@ontrails/warde
 | `checkDrift(rootDir, topo?)` | Check if the lock file matches the current topo |
 | `wardenRules` | Registry of all built-in rules |
 | `wardenTopo` | `Topo` of all built-in rule trails (one per rule) |
-| `runWardenTrails(filePath, sourceCode, options?)` | Dispatch all rule trails for a file, collect diagnostics |
+| `runWardenTrails(filePath, sourceCode, options?)` | Dispatch file-scoped rule trails for a file, collect diagnostics |
+| `runTopoAwareWardenTrails(topo)` | Dispatch built-in topo-aware rule trails once for a resolved topo |
 | `formatGitHubAnnotations(report)` | GitHub Actions annotation format |
 | `formatJson(report)` | Machine-readable JSON |
 | `formatSummary(report)` | Compact summary line |

--- a/packages/warden/src/__tests__/incomplete-accessor-for-standard-op.test.ts
+++ b/packages/warden/src/__tests__/incomplete-accessor-for-standard-op.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for `incomplete-accessor-for-standard-op`.
+ *
+ * Builds in-memory topos with synthetic CRUD-pattern trails and resources
+ * whose mock factories return accessors with controlled method shapes.
+ * Asserts the rule emits diagnostics matching the severity matrix from
+ * TRL-269 without depending on `@ontrails/store`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+import { runWarden } from '../cli.js';
+import { runTopoAwareWardenTrails, runWardenTrails } from '../trails/run.js';
+
+import { resource, Result, topo, trail } from '@ontrails/core';
+import type {
+  AnyResource,
+  AnyTrail,
+  Resource,
+  TrailSpec,
+} from '@ontrails/core';
+
+import { incompleteAccessorForStandardOp } from '../rules/incomplete-accessor-for-standard-op.js';
+
+type Accessor = Readonly<Record<string, (...args: unknown[]) => unknown>>;
+type Connection = Readonly<Record<string, Accessor>>;
+
+const buildResource = (
+  id: string,
+  contourName: string,
+  accessor: Accessor
+): Resource<Connection> => {
+  const connection: Connection = { [contourName]: accessor };
+  return resource<Connection>(id, {
+    create: () => Result.ok(connection),
+    mock: () => connection,
+  });
+};
+
+const crudInputSchema = z.object({});
+const crudOutputSchema = z.object({ ok: z.boolean() });
+type CrudInput = z.infer<typeof crudInputSchema>;
+type CrudOutput = z.infer<typeof crudOutputSchema>;
+
+const baseCrudSpec = (
+  resourceValue: Resource<Connection>
+): TrailSpec<CrudInput, CrudOutput> => ({
+  blaze: () => Result.ok({ ok: true }),
+  description: 'synthetic crud trail',
+  input: crudInputSchema,
+  output: crudOutputSchema,
+  resources: [resourceValue],
+});
+
+const buildCrudTrail = (
+  trailId: string,
+  resourceValue: Resource<Connection>
+): AnyTrail =>
+  trail<CrudInput, CrudOutput>(trailId, {
+    ...baseCrudSpec(resourceValue),
+    pattern: 'crud',
+  });
+
+const buildTrailWithoutPattern = (
+  trailId: string,
+  resourceValue: Resource<Connection>
+): AnyTrail =>
+  trail<CrudInput, CrudOutput>(trailId, baseCrudSpec(resourceValue));
+
+const collectUniqueResources = (
+  trails: readonly AnyTrail[]
+): readonly AnyResource[] => {
+  const resources: AnyResource[] = [];
+  for (const t of trails) {
+    for (const r of t.resources ?? []) {
+      if (!resources.includes(r)) {
+        resources.push(r);
+      }
+    }
+  }
+  return resources;
+};
+
+const buildModuleExports = (
+  trails: readonly AnyTrail[],
+  resources: readonly AnyResource[]
+): Record<string, unknown> => {
+  const moduleExports: Record<string, unknown> = {};
+  for (const [i, t] of trails.entries()) {
+    moduleExports[`trail_${i}`] = t;
+  }
+  for (const [i, r] of resources.entries()) {
+    moduleExports[`resource_${i}`] = r;
+  }
+  return moduleExports;
+};
+
+const runRule = async (trails: readonly AnyTrail[]) => {
+  const resources = collectUniqueResources(trails);
+  const moduleExports = buildModuleExports(trails, resources);
+  const t = topo('test-topo', moduleExports);
+  return await incompleteAccessorForStandardOp.checkTopo(t);
+};
+
+const noop = (): undefined => undefined;
+const resolveAsync = async <T>(value: T): Promise<T> =>
+  await Promise.resolve(value);
+
+const makeTempDir = (): string => {
+  const dir = join(
+    tmpdir(),
+    `warden-trl269-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+};
+
+const buildMisconfiguredTopo = () => {
+  const r = buildResource('store.note', 'note', { upsert: noop });
+  const t = buildCrudTrail('note.create', r);
+  return topo('registry-test-topo', { resource_0: r, trail_0: t });
+};
+
+describe('incomplete-accessor-for-standard-op', () => {
+  describe('preferred-method presence', () => {
+    test('create op with `insert` — no diagnostic', async () => {
+      const r = buildResource('store.note', 'note', { insert: noop });
+      const t = buildCrudTrail('note.create', r);
+      expect(await runRule([t])).toEqual([]);
+    });
+  });
+
+  describe('fallback semantics', () => {
+    test('create op with only `upsert` — warn (fallback available)', async () => {
+      const r = buildResource('store.note', 'note', { upsert: noop });
+      const t = buildCrudTrail('note.create', r);
+      const diagnostics = await runRule([t]);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+      expect(diagnostics[0]?.rule).toBe('incomplete-accessor-for-standard-op');
+      expect(diagnostics[0]?.message).toContain('note.create');
+      expect(diagnostics[0]?.message).toContain('upsert');
+      expect(diagnostics[0]?.message).toContain('insert');
+    });
+
+    test('read op missing `get` — error (no fallback)', async () => {
+      const r = buildResource('store.note', 'note', { list: noop });
+      const t = buildCrudTrail('note.read', r);
+      const diagnostics = await runRule([t]);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain('get');
+    });
+
+    test('create op missing both `insert` and `upsert` — error', async () => {
+      const r = buildResource('store.note', 'note', { list: noop });
+      const t = buildCrudTrail('note.create', r);
+      const diagnostics = await runRule([t]);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain('insert');
+      expect(diagnostics[0]?.message).toContain('upsert');
+    });
+
+    test('list op missing `list` — error', async () => {
+      const r = buildResource('store.note', 'note', { get: noop });
+      const t = buildCrudTrail('note.list', r);
+      const diagnostics = await runRule([t]);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain('list');
+    });
+  });
+
+  describe('silent cases', () => {
+    test('trail without pattern=crud is silent', async () => {
+      const r = buildResource('store.note', 'note', {});
+      const t = buildTrailWithoutPattern('note.create', r);
+      expect(await runRule([t])).toEqual([]);
+    });
+
+    test('pattern=crud but non-standard op name is silent', async () => {
+      const r = buildResource('store.note', 'note', {});
+      const t = buildCrudTrail('note.archive', r);
+      expect(await runRule([t])).toEqual([]);
+    });
+  });
+
+  describe('other operations', () => {
+    test('update op with only `upsert` — warn', async () => {
+      const r = buildResource('store.note', 'note', { upsert: noop });
+      const t = buildCrudTrail('note.update', r);
+      const diagnostics = await runRule([t]);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+    });
+
+    test('update op missing both `update` and `upsert` — error', async () => {
+      const r = buildResource('store.note', 'note', { get: noop });
+      const t = buildCrudTrail('note.update', r);
+      const diagnostics = await runRule([t]);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain('update');
+      expect(diagnostics[0]?.message).toContain('upsert');
+    });
+
+    test('delete op missing `remove` — error', async () => {
+      const r = buildResource('store.note', 'note', { get: noop });
+      const t = buildCrudTrail('note.delete', r);
+      const diagnostics = await runRule([t]);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain('remove');
+    });
+  });
+
+  describe('introspection safety', () => {
+    test('class-based accessors with prototype methods are inspected', async () => {
+      class NoteAccessor {
+        insert(): undefined {
+          Object.getPrototypeOf(this);
+          return undefined;
+        }
+      }
+
+      const connection = { note: new NoteAccessor() };
+      const r = resource<typeof connection>('store.note', {
+        create: () => Result.ok(connection),
+        mock: () => connection,
+      });
+      const t = buildCrudTrail('note.create', r);
+
+      expect(await runRule([t])).toEqual([]);
+    });
+
+    test('resource without mock is skipped (no false positives)', async () => {
+      const emptyConnection: Connection = { note: {} };
+      const r = resource<Connection>('store.note', {
+        create: () => Result.ok(emptyConnection),
+      });
+      const t = buildCrudTrail('note.create', r);
+      expect(await runRule([t])).toEqual([]);
+    });
+
+    test('resource whose mock throws is skipped', async () => {
+      const emptyConnection: Connection = { note: {} };
+      const r = resource<Connection>('store.note', {
+        create: () => Result.ok(emptyConnection),
+        mock: () => {
+          throw new Error('boom');
+        },
+      });
+      const t = buildCrudTrail('note.create', r);
+      expect(await runRule([t])).toEqual([]);
+    });
+
+    test('resource whose mock resolves asynchronously is still inspected', async () => {
+      const connection: Connection = { note: { upsert: noop } };
+      const r = resource<Connection>('store.note', {
+        create: () => Result.ok(connection),
+        mock: () => resolveAsync(connection),
+      });
+      const t = buildCrudTrail('note.create', r);
+      const diagnostics = await runRule([t]);
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+      expect(diagnostics[0]?.message).toContain('falls back to "upsert"');
+    });
+
+    test('resource mock connections are disposed after inspection', async () => {
+      const connection: Connection = { note: { upsert: noop } };
+      let disposed = 0;
+      const r = resource<Connection>('store.note', {
+        create: () => Result.ok(connection),
+        dispose: () => {
+          disposed += 1;
+        },
+        mock: () => connection,
+      });
+      const t = buildCrudTrail('note.create', r);
+
+      const diagnostics = await runRule([t]);
+
+      expect(diagnostics).toHaveLength(1);
+      expect(disposed).toBe(1);
+    });
+  });
+
+  describe('registry wiring', () => {
+    test('runWarden dispatches the rule from wardenTopoRules without extras', async () => {
+      const dir = makeTempDir();
+      try {
+        const report = await runWarden({
+          lintOnly: true,
+          rootDir: dir,
+          topo: buildMisconfiguredTopo(),
+        });
+        const emitted = report.diagnostics.filter(
+          (d) => d.rule === 'incomplete-accessor-for-standard-op'
+        );
+        expect(emitted).toHaveLength(1);
+        expect(emitted[0]?.severity).toBe('warn');
+        expect(emitted[0]?.message).toContain('note.create');
+      } finally {
+        rmSync(dir, { force: true, recursive: true });
+      }
+    });
+
+    test('runTopoAwareWardenTrails dispatches the exported topo-aware trail once per topo', async () => {
+      const diagnostics = await runTopoAwareWardenTrails(
+        buildMisconfiguredTopo()
+      );
+      const emitted = diagnostics.filter(
+        (d) => d.rule === 'incomplete-accessor-for-standard-op'
+      );
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]?.severity).toBe('warn');
+      expect(emitted[0]?.message).toContain('note.create');
+    });
+
+    test('runWardenTrails remains file-scoped and skips topo-aware diagnostics', async () => {
+      const diagnostics = await runWardenTrails('noop.ts', 'export {}');
+      const emitted = diagnostics.filter(
+        (d) => d.rule === 'incomplete-accessor-for-standard-op'
+      );
+
+      expect(emitted).toEqual([]);
+    });
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 28 rule trails', () => {
-    expect(wardenTopo.count).toBe(28);
+  test('contains all 29 rule trails', () => {
+    expect(wardenTopo.count).toBe(29);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -87,7 +87,7 @@ export type { AstNode, StringLiteralMatch } from './rules/ast.js';
 
 // Trail layer
 export { wardenTopo } from './trails/topo.js';
-export { runWardenTrails } from './trails/run.js';
+export { runTopoAwareWardenTrails, runWardenTrails } from './trails/run.js';
 export {
   circularRefsTrail,
   contourExistsTrail,
@@ -99,6 +99,7 @@ export {
   exampleValidTrail,
   firesDeclarationsTrail,
   implementationReturnsResultTrail,
+  incompleteAccessorForStandardOpTrail,
   incompleteCrudTrail,
   intentPropagationTrail,
   missingVisibilityTrail,

--- a/packages/warden/src/rules/incomplete-accessor-for-standard-op.ts
+++ b/packages/warden/src/rules/incomplete-accessor-for-standard-op.ts
@@ -1,0 +1,315 @@
+/**
+ * `incomplete-accessor-for-standard-op` — flag standard-op CRUD trails whose
+ * backing resource accessor is missing the method the trail will call at
+ * runtime.
+ *
+ * The warden cannot invoke blazes directly, but most resources declare a
+ * `mock` factory that returns a structurally real accessor for testing. We
+ * exploit that: invoke the mock with no arguments, look up the accessor by
+ * contour name (which equals every CRUD-emitted trail ID's leading
+ * segments), and inspect the method keys.
+ *
+ * The rule is intentionally forgiving — if the mock factory is missing,
+ * throws, or the connection shape does not match what we expect, we skip
+ * the trail rather than produce a false positive. The runtime fallback in
+ * `derive-trail.ts` still surfaces genuine misuse at execution time.
+ */
+
+import type { AnyResource, AnyTrail, Topo } from '@ontrails/core';
+
+import type { TopoAwareWardenRule, WardenDiagnostic } from './types.js';
+
+type StandardOp = 'create' | 'read' | 'update' | 'delete' | 'list';
+
+type AccessorExpectation =
+  | {
+      readonly preferred: string;
+      readonly fallback: string;
+      readonly severityWhenPreferredMissingWithFallback: 'warn';
+      readonly severityWhenNoFallback: 'error';
+    }
+  | {
+      readonly preferred: string;
+      readonly fallback?: undefined;
+      readonly severityWhenNoFallback: 'error';
+    };
+
+const STANDARD_OPS: ReadonlySet<StandardOp> = new Set([
+  'create',
+  'read',
+  'update',
+  'delete',
+  'list',
+]);
+
+const EXPECTATIONS: Readonly<Record<StandardOp, AccessorExpectation>> = {
+  create: {
+    fallback: 'upsert',
+    preferred: 'insert',
+    severityWhenNoFallback: 'error',
+    severityWhenPreferredMissingWithFallback: 'warn',
+  },
+  delete: {
+    preferred: 'remove',
+    severityWhenNoFallback: 'error',
+  },
+  list: {
+    preferred: 'list',
+    severityWhenNoFallback: 'error',
+  },
+  read: {
+    preferred: 'get',
+    severityWhenNoFallback: 'error',
+  },
+  update: {
+    fallback: 'upsert',
+    preferred: 'update',
+    severityWhenNoFallback: 'error',
+    severityWhenPreferredMissingWithFallback: 'warn',
+  },
+};
+
+const RULE_NAME = 'incomplete-accessor-for-standard-op';
+
+const deriveOperation = (trailId: string): StandardOp | undefined => {
+  const lastDot = trailId.lastIndexOf('.');
+  if (lastDot === -1) {
+    return undefined;
+  }
+  const tail = trailId.slice(lastDot + 1);
+  return STANDARD_OPS.has(tail as StandardOp)
+    ? (tail as StandardOp)
+    : undefined;
+};
+
+const deriveContourName = (trailId: string): string | undefined => {
+  const lastDot = trailId.lastIndexOf('.');
+  if (lastDot <= 0) {
+    return undefined;
+  }
+  return trailId.slice(0, lastDot);
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  return typeof (value as { then?: unknown }).then !== 'function';
+};
+
+const collectMethodNames = (
+  accessor: Record<string, unknown>
+): ReadonlySet<string> => {
+  const methods = new Set<string>();
+  let current: object | null = accessor;
+  while (current !== null && current !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(current)) {
+      const descriptor = Object.getOwnPropertyDescriptor(current, key);
+      if (
+        descriptor !== undefined &&
+        'value' in descriptor &&
+        typeof descriptor.value === 'function'
+      ) {
+        methods.add(key);
+      }
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  return methods;
+};
+
+const invokeMockSafely = async (
+  resource: AnyResource
+): Promise<unknown | undefined> => {
+  const { mock } = resource;
+  if (typeof mock !== 'function') {
+    return undefined;
+  }
+  try {
+    return await mock();
+  } catch {
+    return undefined;
+  }
+};
+
+const disposeMockConnection = async (
+  resource: AnyResource,
+  connection: unknown
+): Promise<void> => {
+  const { dispose } = resource;
+  if (typeof dispose !== 'function') {
+    return;
+  }
+  try {
+    await dispose(connection);
+  } catch {
+    // Cleanup failures should not turn best-effort inspection into a false positive.
+  }
+};
+
+const resolveAccessor = (
+  connection: unknown,
+  contourName: string
+): Record<string, unknown> | undefined => {
+  if (!isPlainObject(connection)) {
+    return undefined;
+  }
+  const accessor = connection[contourName];
+  return isPlainObject(accessor) ? accessor : undefined;
+};
+
+/**
+ * Attempt to resolve the accessor shape from the resource's mock factory.
+ *
+ * Returns `undefined` when the accessor cannot be inspected (no mock, mock
+ * throws, connection doesn't have the expected key, etc.). The rule treats
+ * `undefined` as "skip this trail" rather than as a violation — we should
+ * never false-positive on a shape we cannot see.
+ */
+const inspectAccessorMethods = async (
+  resource: AnyResource,
+  contourName: string
+): Promise<ReadonlySet<string> | undefined> => {
+  const connection = await invokeMockSafely(resource);
+  if (connection === undefined) {
+    return undefined;
+  }
+  try {
+    const accessor = resolveAccessor(connection, contourName);
+    if (accessor === undefined) {
+      return undefined;
+    }
+    return collectMethodNames(accessor);
+  } finally {
+    await disposeMockConnection(resource, connection);
+  }
+};
+
+const formatDiagnostic = (
+  trailId: string,
+  operation: StandardOp,
+  message: string,
+  severity: 'warn' | 'error'
+): WardenDiagnostic => ({
+  filePath: '<topo>',
+  line: 1,
+  message: `Trail "${trailId}" (crud.${operation}): ${message}`,
+  rule: RULE_NAME,
+  severity,
+});
+
+interface StandardOpContext {
+  readonly trailId: string;
+  readonly operation: StandardOp;
+  readonly contourName: string;
+  readonly resource: AnyResource;
+}
+
+// CRUD trails synthesized by the store factory always declare one resource.
+// For multi- or zero-resource trails, we cannot unambiguously pick one to
+// inspect; skip rather than guess.
+const extractSoleResource = (trail: AnyTrail): AnyResource | undefined => {
+  const resources = trail.resources ?? [];
+  if (resources.length !== 1) {
+    return undefined;
+  }
+  const [resource] = resources;
+  return resource;
+};
+
+const extractStandardOpContext = (
+  trail: AnyTrail
+): StandardOpContext | undefined => {
+  if (trail.pattern !== 'crud') {
+    return undefined;
+  }
+  const operation = deriveOperation(trail.id);
+  const contourName = deriveContourName(trail.id);
+  const resource = extractSoleResource(trail);
+  if (
+    operation === undefined ||
+    contourName === undefined ||
+    resource === undefined
+  ) {
+    return undefined;
+  }
+  return { contourName, operation, resource, trailId: trail.id };
+};
+
+const diagnoseMissingMethod = (
+  ctx: StandardOpContext,
+  methods: ReadonlySet<string>,
+  expectation: AccessorExpectation
+): WardenDiagnostic | undefined => {
+  if (methods.has(expectation.preferred)) {
+    return undefined;
+  }
+  const { fallback } = expectation;
+  const base = `resource "${ctx.resource.id}" accessor "${ctx.contourName}"`;
+  if (fallback === undefined) {
+    return formatDiagnostic(
+      ctx.trailId,
+      ctx.operation,
+      `${base} is missing required method "${expectation.preferred}"`,
+      expectation.severityWhenNoFallback
+    );
+  }
+  if (methods.has(fallback)) {
+    return formatDiagnostic(
+      ctx.trailId,
+      ctx.operation,
+      `${base} is missing preferred method "${expectation.preferred}"; falls back to "${fallback}"`,
+      expectation.severityWhenPreferredMissingWithFallback
+    );
+  }
+  return formatDiagnostic(
+    ctx.trailId,
+    ctx.operation,
+    `${base} is missing both "${expectation.preferred}" and fallback "${fallback}"`,
+    expectation.severityWhenNoFallback
+  );
+};
+
+const evaluateTrail = async (
+  trail: AnyTrail
+): Promise<readonly WardenDiagnostic[]> => {
+  const ctx = extractStandardOpContext(trail);
+  if (ctx === undefined) {
+    return [];
+  }
+  const methods = await inspectAccessorMethods(ctx.resource, ctx.contourName);
+  if (methods === undefined) {
+    return [];
+  }
+  const diagnostic = diagnoseMissingMethod(
+    ctx,
+    methods,
+    EXPECTATIONS[ctx.operation]
+  );
+  return diagnostic === undefined ? [] : [diagnostic];
+};
+
+/**
+ * Topo-aware rule that flags CRUD trails whose backing accessor is missing
+ * the method invoked by the synthesized blaze.
+ *
+ * @remarks
+ * Introspects each resource's `mock()` factory to determine the accessor
+ * shape. Trails whose resource has no mock, whose mock throws, or whose
+ * mock returns a shape the rule cannot interpret are silently skipped. The
+ * runtime fallback in `derive-trail.ts` remains the enforcement of last
+ * resort.
+ */
+export const incompleteAccessorForStandardOp: TopoAwareWardenRule = {
+  async checkTopo(topo: Topo): Promise<readonly WardenDiagnostic[]> {
+    const diagnostics: WardenDiagnostic[] = [];
+    for (const trail of topo.trails.values()) {
+      diagnostics.push(...(await evaluateTrail(trail)));
+    }
+    return diagnostics;
+  },
+  description:
+    'Flag CRUD-pattern trails whose resource accessor lacks the method the synthesized blaze will call at runtime.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -9,6 +9,7 @@ import { errorMappingCompleteness } from './error-mapping-completeness.js';
 import { exampleValid } from './example-valid.js';
 import { firesDeclarations } from './fires-declarations.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
+import { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 import { incompleteCrud } from './incomplete-crud.js';
 import { intentPropagation } from './intent-propagation.js';
 import { missingVisibility } from './missing-visibility.js';
@@ -50,6 +51,7 @@ export { draftVisibleDebt } from './draft-visible-debt.js';
 export { errorMappingCompleteness } from './error-mapping-completeness.js';
 export { exampleValid } from './example-valid.js';
 export { firesDeclarations } from './fires-declarations.js';
+export { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 export { incompleteCrud } from './incomplete-crud.js';
 export { intentPropagation } from './intent-propagation.js';
 export { missingVisibility } from './missing-visibility.js';
@@ -121,4 +123,6 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
  * registered here must tolerate non-execution when no topo is available.
  */
 export const wardenTopoRules: ReadonlyMap<string, TopoAwareWardenRule> =
-  new Map<string, TopoAwareWardenRule>();
+  new Map<string, TopoAwareWardenRule>([
+    [incompleteAccessorForStandardOp.name, incompleteAccessorForStandardOp],
+  ]);

--- a/packages/warden/src/trails/incomplete-accessor-for-standard-op.trail.ts
+++ b/packages/warden/src/trails/incomplete-accessor-for-standard-op.trail.ts
@@ -1,0 +1,76 @@
+import { resource, Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { incompleteAccessorForStandardOp } from '../rules/incomplete-accessor-for-standard-op.js';
+import { wrapTopoRule } from './wrap-rule.js';
+
+type Accessor = Readonly<Record<string, (...args: unknown[]) => unknown>>;
+type Connection = Readonly<Record<string, Accessor>>;
+
+const noop = (): undefined => undefined;
+
+const buildResource = (id: string, contourName: string, accessor: Accessor) =>
+  resource<Connection>(id, {
+    create: () => Result.ok({ [contourName]: accessor }),
+    mock: () => ({ [contourName]: accessor }),
+  });
+
+const buildCrudTrail = (
+  trailId: string,
+  resourceValue: ReturnType<typeof buildResource>
+) =>
+  trail(trailId, {
+    blaze: () => Result.ok({ ok: true }),
+    input: z.object({}),
+    output: z.object({ ok: z.boolean() }),
+    pattern: 'crud',
+    resources: [resourceValue],
+  });
+
+const cleanResource = buildResource('store.note.clean', 'note', {
+  insert: noop,
+});
+const warningResource = buildResource('store.note.warn', 'note', {
+  upsert: noop,
+});
+
+const cleanTopo = topo('trl-269-clean', {
+  noteCreate: buildCrudTrail('note.create', cleanResource),
+  noteResource: cleanResource,
+});
+
+const warningTopo = topo('trl-269-warning', {
+  noteCreate: buildCrudTrail('note.create', warningResource),
+  noteResource: warningResource,
+});
+
+export const incompleteAccessorForStandardOpTrail = wrapTopoRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        topo: cleanTopo,
+      },
+      name: 'Preferred accessors keep CRUD trails quiet',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: '<topo>',
+            line: 1,
+            message:
+              'Trail "note.create" (crud.create): resource "store.note.warn" accessor "note" is missing preferred method "insert"; falls back to "upsert"',
+            rule: 'incomplete-accessor-for-standard-op',
+            severity: 'warn',
+          },
+        ],
+      },
+      input: {
+        topo: warningTopo,
+      },
+      name: 'Fallback-only create accessors emit a warning',
+    },
+  ],
+  rule: incompleteAccessorForStandardOp,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -7,6 +7,7 @@ export { errorMappingCompletenessTrail } from './error-mapping-completeness.trai
 export { exampleValidTrail } from './example-valid.trail.js';
 export { firesDeclarationsTrail } from './fires-declarations.trail.js';
 export { implementationReturnsResultTrail } from './implementation-returns-result.trail.js';
+export { incompleteAccessorForStandardOpTrail } from './incomplete-accessor-for-standard-op.trail.js';
 export { incompleteCrudTrail } from './incomplete-crud.trail.js';
 export { intentPropagationTrail } from './intent-propagation.trail.js';
 export { missingVisibilityTrail } from './missing-visibility.trail.js';

--- a/packages/warden/src/trails/run.ts
+++ b/packages/warden/src/trails/run.ts
@@ -1,17 +1,21 @@
 /**
- * Run all warden rule trails against a single source file.
+ * Run file-scoped warden rule trails against a single source file.
  *
- * Returns a flat array of diagnostics from every rule.
+ * Returns a flat array of diagnostics from every source-aware rule. Built-in
+ * topo-aware rules are dispatched separately via `runTopoAwareWardenTrails()`
+ * so callers that loop files do not duplicate graph-level findings.
  */
 
+import type { Topo } from '@ontrails/core';
 import { run } from '@ontrails/core';
 
+import { wardenTopoRules } from '../rules/index.js';
 import type { WardenDiagnostic } from '../rules/types.js';
 import type { RuleOutput } from './schema.js';
 import { wardenTopo } from './topo.js';
 
 /**
- * Run all warden rule trails for a given file and collect diagnostics.
+ * Run all file-scoped warden rule trails for a given file and collect diagnostics.
  *
  * Each rule trail runs independently. Errors from individual trails are
  * silently skipped so that one broken rule does not block the rest.
@@ -95,6 +99,10 @@ const buildRuleInput = (
   return { ...base, ...collectProjectOptions(options) };
 };
 
+const topoAwareTrailIds = new Set(
+  [...wardenTopoRules.keys()].map((ruleName) => `warden.rule.${ruleName}`)
+);
+
 export const runWardenTrails = async (
   filePath: string,
   sourceCode: string,
@@ -104,7 +112,34 @@ export const runWardenTrails = async (
   const input = buildRuleInput(filePath, sourceCode, options);
 
   for (const id of wardenTopo.ids()) {
+    if (topoAwareTrailIds.has(id)) {
+      continue;
+    }
     const result = await run(wardenTopo, id, input);
+    if (result.isOk()) {
+      appendDiagnostics(
+        allDiagnostics,
+        (result.value as RuleOutput).diagnostics
+      );
+    }
+  }
+
+  return allDiagnostics;
+};
+
+/**
+ * Run the built-in topo-aware warden rule trails once against a resolved topo.
+ *
+ * Unlike `runWardenTrails()`, which is file-scoped, topo-aware rules inspect
+ * the compiled graph and should only be dispatched once per topo.
+ */
+export const runTopoAwareWardenTrails = async (
+  topo: Topo
+): Promise<readonly WardenDiagnostic[]> => {
+  const allDiagnostics: WardenDiagnostic[] = [];
+
+  for (const id of topoAwareTrailIds) {
+    const result = await run(wardenTopo, id, { topo });
     if (result.isOk()) {
       appendDiagnostics(
         allDiagnostics,


### PR DESCRIPTION
This adds the first built-in topo-aware governance rule: flag standard CRUD trails whose backing resource mock is missing the expected accessor methods.

## What changed
- add `incompleteAccessorForStandardOp` as a topo-aware warden rule over CRUD-pattern trails
- inspect resource accessors using the resolved topo instead of AST guesses
- await async resource mocks during inspection so async-backed resources participate in the rule
- expose the built-in topo-aware trail and add a dedicated topo-aware trail runner so topo diagnostics execute once per graph, not once per file
- expand regression coverage across the severity matrix, async/mock safety paths, and topo-aware trail execution

## Why
The framework already enforces accessor presence at runtime, but governance had no static/topo-level check for standard CRUD trails. This rule closes that gap while keeping async and topo-aware execution semantics correct.

## How to test
- `bun test packages/warden/src/__tests__/incomplete-accessor-for-standard-op.test.ts --bail`
- `bun test packages/warden/src/__tests__/topo-aware-rule.test.ts --bail`
- `bun test packages/warden/src/__tests__/trails.test.ts --bail`
- `bun run build`

Closes TRL-269
