### PR TITLE
refactor(warden): trim public surface to trail and registry [TRL-340]

### DIFF
--- a/apps/trails-demo/__tests__/signals.test.ts
+++ b/apps/trails-demo/__tests__/signals.test.ts
@@ -18,7 +18,12 @@ import { dirname, resolve } from 'node:path';
 import { describe, expect, test } from 'bun:test';
 
 import { run } from '@ontrails/core';
-import { firesDeclarations, onReferencesExist } from '@ontrails/warden';
+import type { RuleOutput } from '@ontrails/warden';
+import {
+  firesDeclarationsTrail,
+  onReferencesExistTrail,
+  wardenTopo,
+} from '@ontrails/warden';
 
 import { graph } from '../src/app.js';
 import { entityStoreResource } from '../src/resources/entity-store.js';
@@ -120,22 +125,25 @@ describe('signal wiring in the demo topo', () => {
 // ---------------------------------------------------------------------------
 
 describe('warden rules over the signal producer/consumer', () => {
-  test('fires-declarations passes for entity.ts', () => {
+  test('fires-declarations passes for entity.ts', async () => {
     const source = readFileSync(entitySourcePath, 'utf8');
-    const diagnostics = firesDeclarations.check(source, entitySourcePath);
-    expect(diagnostics).toEqual([]);
+    const result = await run(wardenTopo, firesDeclarationsTrail.id, {
+      filePath: entitySourcePath,
+      sourceCode: source,
+    });
+    const output = result.unwrap() as RuleOutput;
+    expect(output.diagnostics).toEqual([]);
   });
 
-  test('on-references-exist passes for notify.ts with known signals', () => {
+  test('on-references-exist passes for notify.ts with known signals', async () => {
     const source = readFileSync(notifySourcePath, 'utf8');
-    const diagnostics = onReferencesExist.checkWithContext(
-      source,
-      notifySourcePath,
-      {
-        knownSignalIds: new Set(['entity.updated']),
-        knownTrailIds: new Set(),
-      }
-    );
-    expect(diagnostics).toEqual([]);
+    const result = await run(wardenTopo, onReferencesExistTrail.id, {
+      filePath: notifySourcePath,
+      knownSignalIds: ['entity.updated'],
+      knownTrailIds: [],
+      sourceCode: source,
+    });
+    const output = result.unwrap() as RuleOutput;
+    expect(output.diagnostics).toEqual([]);
   });
 });

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 29 rule trails', () => {
-    expect(wardenTopo.count).toBe(29);
+  test('contains all 31 rule trails', () => {
+    expect(wardenTopo.count).toBe(31);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -17,37 +17,6 @@ export type {
   WardenSeverity,
 } from './rules/index.js';
 
-// Individual rules
-export { noThrowInImplementation } from './rules/no-throw-in-implementation.js';
-export { circularRefs } from './rules/circular-refs.js';
-export { contourExists } from './rules/contour-exists.js';
-export { contextNoSurfaceTypes } from './rules/context-no-surface-types.js';
-export { deadInternalTrail } from './rules/dead-internal-trail.js';
-export { draftFileMarking } from './rules/draft-file-marking.js';
-export { draftVisibleDebt } from './rules/draft-visible-debt.js';
-export { errorMappingCompleteness } from './rules/error-mapping-completeness.js';
-export { exampleValid } from './rules/example-valid.js';
-export { firesDeclarations } from './rules/fires-declarations.js';
-export { incompleteCrud } from './rules/incomplete-crud.js';
-export { intentPropagation } from './rules/intent-propagation.js';
-export { missingVisibility } from './rules/missing-visibility.js';
-export { missingReconcile } from './rules/missing-reconcile.js';
-export { onReferencesExist } from './rules/on-references-exist.js';
-export { validDetourRefs } from './rules/valid-detour-refs.js';
-export { noDirectImplInRoute } from './rules/no-direct-impl-in-route.js';
-export { noDirectImplementationCall } from './rules/no-direct-implementation-call.js';
-export { noSyncResultAssumption } from './rules/no-sync-result-assumption.js';
-export { implementationReturnsResult } from './rules/implementation-returns-result.js';
-export { noThrowInDetourTarget } from './rules/no-throw-in-detour-target.js';
-export { orphanedSignal } from './rules/orphaned-signal.js';
-export { preferSchemaInference } from './rules/prefer-schema-inference.js';
-export { referenceExists } from './rules/reference-exists.js';
-export { resourceDeclarations } from './rules/resource-declarations.js';
-export { resourceIdGrammar } from './rules/resource-id-grammar.js';
-export { resourceExists } from './rules/resource-exists.js';
-export { unreachableDetourShadowing } from './rules/unreachable-detour-shadowing.js';
-export { validDescribeRefs } from './rules/valid-describe-refs.js';
-
 // Rule registry
 export { wardenRules, wardenTopoRules } from './rules/index.js';
 
@@ -95,6 +64,8 @@ export {
   crossDeclarationsTrail,
   deadInternalTrailTrail,
   diagnosticSchema,
+  draftFileMarkingTrail,
+  draftVisibleDebtTrail,
   errorMappingCompletenessTrail,
   exampleValidTrail,
   firesDeclarationsTrail,

--- a/packages/warden/src/trails/draft-file-marking.trail.ts
+++ b/packages/warden/src/trails/draft-file-marking.trail.ts
@@ -1,0 +1,16 @@
+import { draftFileMarking } from '../rules/draft-file-marking.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const draftFileMarkingTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        sourceCode: `export const id = "notes.list";`,
+      },
+      name: 'File without draft ids passes',
+    },
+  ],
+  rule: draftFileMarking,
+});

--- a/packages/warden/src/trails/draft-visible-debt.trail.ts
+++ b/packages/warden/src/trails/draft-visible-debt.trail.ts
@@ -1,0 +1,16 @@
+import { draftVisibleDebt } from '../rules/draft-visible-debt.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const draftVisibleDebtTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        sourceCode: `export const id = "notes.list";`,
+      },
+      name: 'File without draft ids emits no visible-debt diagnostics',
+    },
+  ],
+  rule: draftVisibleDebt,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -3,6 +3,8 @@ export { contourExistsTrail } from './contour-exists.trail.js';
 export { contextNoSurfaceTypesTrail } from './context-no-surface-types.trail.js';
 export { crossDeclarationsTrail } from './cross-declarations.trail.js';
 export { deadInternalTrailTrail } from './dead-internal-trail.trail.js';
+export { draftFileMarkingTrail } from './draft-file-marking.trail.js';
+export { draftVisibleDebtTrail } from './draft-visible-debt.trail.js';
 export { errorMappingCompletenessTrail } from './error-mapping-completeness.trail.js';
 export { exampleValidTrail } from './example-valid.trail.js';
 export { firesDeclarationsTrail } from './fires-declarations.trail.js';


### PR DESCRIPTION
This trims the `@ontrails/warden` public surface from three paths to two — implementing ADR-0036. Raw rule object re-exports leave the package boundary; consumers drive rules through the trail wrapper or the registry, which is now the only canonical shape.

## What changed
- remove 30 raw-rule re-exports from `packages/warden/src/index.ts` (the manual barrel that was the source of the three-path drift)
- migrate `apps/trails-demo/__tests__/signals.test.ts` from `firesDeclarations.check(...)` / `onReferencesExist.checkWithContext(...)` to `run(wardenTopo, trailId, input)`, matching warden's own internal invocation pattern
- public surface retains: types, `wardenRules` / `wardenTopoRules` registries, `runWarden`, `checkDrift`, formatters, draft helpers, AST helpers, and every `*Trail` wrapper

## Why
ADR-0036 (see #196) rules the trail wrapper as the canonical public shape for warden rules. This is the code change that enforces the decision. Only one file in the monorepo (`apps/trails-demo/__tests__/signals.test.ts`) was using the raw-rule path — migrated in this PR.

## How to test
- `bun run typecheck` — full monorepo green, confirms no consumer references a removed identifier
- `bun run test` — 31/31 tasks pass; `apps/trails-demo/__tests__/signals.test.ts` passes with the migrated invocations
- `bunx ultracite check apps/trails-demo/__tests__/signals.test.ts packages/warden/src/index.ts` — clean
- `import { noThrowInImplementation } from '@ontrails/warden'` (or any removed identifier) now fails type check

Closes TRL-340