### PR TITLE
feat(warden): enforce registry-to-trail export symmetry [TRL-341]

### DIFF
--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 31 rule trails', () => {
-    expect(wardenTopo.count).toBe(31);
+  test('contains all 32 rule trails', () => {
+    expect(wardenTopo.count).toBe(32);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/__tests__/warden-export-symmetry.test.ts
+++ b/packages/warden/src/__tests__/warden-export-symmetry.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test';
+
+import { wardenRules, wardenTopoRules } from '../rules/index.js';
+import { registeredRuleNames } from '../rules/registry-names.js';
+import { wardenExportSymmetry } from '../rules/warden-export-symmetry.js';
+
+const SELF_RULE_NAME = 'warden-export-symmetry';
+
+const TARGET_FILE = 'packages/warden/src/index.ts';
+const UNRELATED_FILE = 'packages/warden/src/cli.ts';
+
+const kebabToCamel = (value: string): string =>
+  value.replaceAll(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+
+const allRuleNames = [...wardenRules.keys(), ...wardenTopoRules.keys()];
+
+const expectedTrailExports = allRuleNames
+  .map((name) => `${kebabToCamel(name)}Trail`)
+  .toSorted();
+
+const [sampleTrailExport = 'missingTrailExportSentinel'] = expectedTrailExports;
+const [sampleRuleName = 'missing-rule-sentinel'] = allRuleNames;
+const sampleRawRuleCamel = kebabToCamel(sampleRuleName);
+
+const buildIndexSource = (extraExports = '', skip: readonly string[] = []) => {
+  const skipSet = new Set(skip);
+  const rendered = expectedTrailExports
+    .filter((name) => !skipSet.has(name))
+    .map((name) => `  ${name},`)
+    .join('\n');
+  return `export {
+${rendered}
+} from './trails/index.js';
+${extraExports}
+`;
+};
+
+describe('warden-export-symmetry', () => {
+  test('only targets packages/warden/src/index.ts', () => {
+    const source = buildIndexSource();
+    const diagnostics = wardenExportSymmetry.check(source, UNRELATED_FILE);
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('baseline: current warden barrel emits zero diagnostics', async () => {
+    const realPath = Bun.fileURLToPath(new URL('../index.ts', import.meta.url));
+    const source = await Bun.file(realPath).text();
+    const diagnostics = wardenExportSymmetry.check(source, realPath);
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('fires when a registry entry has no matching trail export', () => {
+    const source = buildIndexSource('', [sampleTrailExport]);
+    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+    const missing = diagnostics.filter((d) =>
+      d.message.includes(`missing trail export "${sampleTrailExport}"`)
+    );
+    expect(missing.length).toBe(1);
+    expect(missing[0]?.severity).toBe('error');
+  });
+
+  test('fires when a *Trail export has no matching registry entry', () => {
+    const source = buildIndexSource(
+      `export { fictitiousGhostTrail } from './trails/index.js';\n`
+    );
+    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+    const orphans = diagnostics.filter((d) =>
+      d.message.includes('fictitiousGhostTrail')
+    );
+    expect(orphans.length).toBe(1);
+    expect(orphans[0]?.severity).toBe('error');
+  });
+
+  test('fires when a raw rule object is re-exported on the barrel', () => {
+    const source = buildIndexSource(
+      `export { ${sampleRawRuleCamel} } from './rules/index.js';\n`
+    );
+    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+    const rawLeaks = diagnostics.filter((d) =>
+      d.message.includes(`raw rule export "${sampleRawRuleCamel}"`)
+    );
+    expect(rawLeaks.length).toBe(1);
+    expect(rawLeaks[0]?.severity).toBe('error');
+  });
+
+  test('registry-names snapshot matches the live registry', () => {
+    const live = new Set([...wardenRules.keys(), ...wardenTopoRules.keys()]);
+    const snapshot = new Set([...registeredRuleNames, SELF_RULE_NAME]);
+    // Symmetric diff: both directions must be empty. Any missing / extra name
+    // means `registry-names.ts` drifted from `rules/index.ts`.
+    const missingFromSnapshot = [...live].filter((n) => !snapshot.has(n));
+    const extraInSnapshot = [...snapshot].filter((n) => !live.has(n));
+    expect(missingFromSnapshot).toEqual([]);
+    expect(extraInSnapshot).toEqual([]);
+  });
+
+  test('fires on namespace re-exports (export * from ...)', () => {
+    const source = `${buildIndexSource()}export * from './trails/index.js';\n`;
+    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+    const nsReexports = diagnostics.filter((d) =>
+      d.message.includes('namespace re-export')
+    );
+    expect(nsReexports.length).toBe(1);
+    expect(nsReexports[0]?.severity).toBe('error');
+  });
+});

--- a/packages/warden/src/__tests__/warden-export-symmetry.test.ts
+++ b/packages/warden/src/__tests__/warden-export-symmetry.test.ts
@@ -1,6 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import { describe, expect, test } from 'bun:test';
 
 import { wardenRules, wardenTopoRules } from '../rules/index.js';
@@ -55,16 +53,11 @@ describe('warden-export-symmetry', () => {
     test('ignores a foreign packages/warden/src/index.ts in another repo', () => {
       // Simulate a consumer repo that happens to have the same folder
       // structure. A path suffix match would incorrectly engage the rule here
-      // and flood the consumer with bogus diagnostics.
-      const foreignRepo = mkdtempSync(join(tmpdir(), 'warden-foreign-'));
-      const foreignBarrelDir = join(foreignRepo, 'packages/warden/src');
-      mkdirSync(foreignBarrelDir, { recursive: true });
-      const foreignBarrel = join(foreignBarrelDir, 'index.ts');
-      // Contents that WOULD trip every check if the rule ran: missing trails,
-      // raw rule leak, namespace re-export, default export.
-      writeFileSync(
-        foreignBarrel,
-        `export { ${sampleRawRuleCamel} } from './rules/index.js';\nexport * from './trails/index.js';\nexport default {};\n`
+      // and flood the consumer with bogus diagnostics. The rule reads source
+      // from its argument, not from disk, so no fs setup is needed — only the
+      // path-anchoring check runs against `foreignBarrel`.
+      const foreignBarrel = resolve(
+        '/tmp/warden-foreign-sim/packages/warden/src/index.ts'
       );
       const diagnostics = wardenExportSymmetry.check(
         `export { ${sampleRawRuleCamel} } from './rules/index.js';\nexport * from './trails/index.js';\nexport default {};\n`,
@@ -126,6 +119,33 @@ describe('warden-export-symmetry', () => {
       expect(orphans.length).toBe(1);
       expect(orphans[0]?.severity).toBe('error');
     });
+
+    test('fires on orphan *Trail declared via destructured object pattern', () => {
+      // Regression: `sitesForDeclaration` previously only handled Identifier
+      // declarator ids. A destructured `export const { ... } = ...` silently
+      // bypassed the orphan-trail check.
+      const source = buildIndexSource(
+        `export const { fictitiousGhostTrail } = {} as { fictitiousGhostTrail: unknown };\n`
+      );
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const orphans = diagnostics.filter((d) =>
+        d.message.includes('fictitiousGhostTrail')
+      );
+      expect(orphans.length).toBe(1);
+      expect(orphans[0]?.severity).toBe('error');
+    });
+
+    test('fires on orphan *Trail declared via destructured array pattern', () => {
+      const source = buildIndexSource(
+        `export const [fictitiousGhostTrail] = [] as unknown as [unknown];\n`
+      );
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const orphans = diagnostics.filter((d) =>
+        d.message.includes('fictitiousGhostTrail')
+      );
+      expect(orphans.length).toBe(1);
+      expect(orphans[0]?.severity).toBe('error');
+    });
   });
 
   describe('raw-rule leaks', () => {
@@ -144,6 +164,21 @@ describe('warden-export-symmetry', () => {
     test('fires on aliased raw-rule re-exports using the local binding name', () => {
       const source = buildIndexSource(
         `export { ${sampleRawRuleCamel} as disguisedRule } from './rules/index.js';\n`
+      );
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const rawLeaks = diagnostics.filter((d) =>
+        d.message.includes(`raw rule export "${sampleRawRuleCamel}"`)
+      );
+      expect(rawLeaks.length).toBe(1);
+      expect(rawLeaks[0]?.severity).toBe('error');
+    });
+
+    test('fires on raw-rule leak via destructured object pattern', () => {
+      // Regression: destructuring was a silent bypass for raw-rule leaks —
+      // `export const { wardenExportSymmetry } = rulesModule` exposed the raw
+      // rule object without tripping the check.
+      const source = buildIndexSource(
+        `export const { ${sampleRawRuleCamel} } = {} as Record<string, unknown>;\n`
       );
       const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
       const rawLeaks = diagnostics.filter((d) =>

--- a/packages/warden/src/__tests__/warden-export-symmetry.test.ts
+++ b/packages/warden/src/__tests__/warden-export-symmetry.test.ts
@@ -103,4 +103,38 @@ describe('warden-export-symmetry', () => {
     expect(nsReexports.length).toBe(1);
     expect(nsReexports[0]?.severity).toBe('error');
   });
+
+  test('fires on aliased raw-rule re-exports using the local binding name', () => {
+    const source = buildIndexSource(
+      `export { ${sampleRawRuleCamel} as disguisedRule } from './rules/index.js';\n`
+    );
+    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+    const rawLeaks = diagnostics.filter((d) =>
+      d.message.includes(`raw rule export "${sampleRawRuleCamel}"`)
+    );
+    expect(rawLeaks.length).toBe(1);
+    expect(rawLeaks[0]?.severity).toBe('error');
+  });
+
+  test('fires on orphan *Trail declared via `export const`', () => {
+    const source = buildIndexSource(
+      `export const fictitiousGhostTrail = {} as unknown;\n`
+    );
+    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+    const orphans = diagnostics.filter((d) =>
+      d.message.includes('fictitiousGhostTrail')
+    );
+    expect(orphans.length).toBe(1);
+    expect(orphans[0]?.severity).toBe('error');
+  });
+
+  test('rejects `export default` on the warden barrel', () => {
+    const source = `${buildIndexSource()}export default {};\n`;
+    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+    const defaults = diagnostics.filter((d) =>
+      d.message.includes('default export')
+    );
+    expect(defaults.length).toBe(1);
+    expect(defaults[0]?.severity).toBe('error');
+  });
 });

--- a/packages/warden/src/__tests__/warden-export-symmetry.test.ts
+++ b/packages/warden/src/__tests__/warden-export-symmetry.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { describe, expect, test } from 'bun:test';
 
 import { wardenRules, wardenTopoRules } from '../rules/index.js';
@@ -6,8 +9,14 @@ import { wardenExportSymmetry } from '../rules/warden-export-symmetry.js';
 
 const SELF_RULE_NAME = 'warden-export-symmetry';
 
-const TARGET_FILE = 'packages/warden/src/index.ts';
-const UNRELATED_FILE = 'packages/warden/src/cli.ts';
+// The rule anchors to this package's own on-disk `src/index.ts`. Tests must
+// use the same resolved path so the rule actually engages.
+const TARGET_FILE = resolve(
+  Bun.fileURLToPath(new URL('../index.ts', import.meta.url))
+);
+const UNRELATED_FILE = resolve(
+  Bun.fileURLToPath(new URL('../cli.ts', import.meta.url))
+);
 
 const kebabToCamel = (value: string): string =>
   value.replaceAll(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
@@ -37,9 +46,30 @@ ${extraExports}
 
 describe('warden-export-symmetry', () => {
   describe('scope', () => {
-    test('only targets packages/warden/src/index.ts', () => {
+    test("only targets this package's own src/index.ts", () => {
       const source = buildIndexSource();
       const diagnostics = wardenExportSymmetry.check(source, UNRELATED_FILE);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('ignores a foreign packages/warden/src/index.ts in another repo', () => {
+      // Simulate a consumer repo that happens to have the same folder
+      // structure. A path suffix match would incorrectly engage the rule here
+      // and flood the consumer with bogus diagnostics.
+      const foreignRepo = mkdtempSync(join(tmpdir(), 'warden-foreign-'));
+      const foreignBarrelDir = join(foreignRepo, 'packages/warden/src');
+      mkdirSync(foreignBarrelDir, { recursive: true });
+      const foreignBarrel = join(foreignBarrelDir, 'index.ts');
+      // Contents that WOULD trip every check if the rule ran: missing trails,
+      // raw rule leak, namespace re-export, default export.
+      writeFileSync(
+        foreignBarrel,
+        `export { ${sampleRawRuleCamel} } from './rules/index.js';\nexport * from './trails/index.js';\nexport default {};\n`
+      );
+      const diagnostics = wardenExportSymmetry.check(
+        `export { ${sampleRawRuleCamel} } from './rules/index.js';\nexport * from './trails/index.js';\nexport default {};\n`,
+        foreignBarrel
+      );
       expect(diagnostics).toEqual([]);
     });
 
@@ -133,6 +163,24 @@ describe('warden-export-symmetry', () => {
       );
       expect(nsReexports.length).toBe(1);
       expect(nsReexports[0]?.severity).toBe('error');
+      // Regression guard: plain `export *` must not mention an ` as ` alias.
+      expect(nsReexports[0]?.message).not.toContain(' as ');
+      expect(nsReexports[0]?.message).toContain(
+        "export * from './trails/index.js'"
+      );
+    });
+
+    test('fires on aliased namespace re-exports and preserves the alias', () => {
+      const source = `${buildIndexSource()}export * as trailsNs from './trails/index.js';\n`;
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const nsReexports = diagnostics.filter((d) =>
+        d.message.includes('namespace re-export')
+      );
+      expect(nsReexports.length).toBe(1);
+      expect(nsReexports[0]?.severity).toBe('error');
+      expect(nsReexports[0]?.message).toContain(
+        "export * as trailsNs from './trails/index.js'"
+      );
     });
 
     test('rejects `export default` on the warden barrel', () => {

--- a/packages/warden/src/__tests__/warden-export-symmetry.test.ts
+++ b/packages/warden/src/__tests__/warden-export-symmetry.test.ts
@@ -36,105 +36,133 @@ ${extraExports}
 };
 
 describe('warden-export-symmetry', () => {
-  test('only targets packages/warden/src/index.ts', () => {
-    const source = buildIndexSource();
-    const diagnostics = wardenExportSymmetry.check(source, UNRELATED_FILE);
-    expect(diagnostics).toEqual([]);
+  describe('scope', () => {
+    test('only targets packages/warden/src/index.ts', () => {
+      const source = buildIndexSource();
+      const diagnostics = wardenExportSymmetry.check(source, UNRELATED_FILE);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('baseline: current warden barrel emits zero diagnostics', async () => {
+      const realPath = Bun.fileURLToPath(
+        new URL('../index.ts', import.meta.url)
+      );
+      const source = await Bun.file(realPath).text();
+      const diagnostics = wardenExportSymmetry.check(source, realPath);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('registry-names snapshot matches the live registry', () => {
+      const live = new Set([...wardenRules.keys(), ...wardenTopoRules.keys()]);
+      const snapshot = new Set([...registeredRuleNames, SELF_RULE_NAME]);
+      const missingFromSnapshot = [...live].filter((n) => !snapshot.has(n));
+      const extraInSnapshot = [...snapshot].filter((n) => !live.has(n));
+      expect(missingFromSnapshot).toEqual([]);
+      expect(extraInSnapshot).toEqual([]);
+    });
   });
 
-  test('baseline: current warden barrel emits zero diagnostics', async () => {
-    const realPath = Bun.fileURLToPath(new URL('../index.ts', import.meta.url));
-    const source = await Bun.file(realPath).text();
-    const diagnostics = wardenExportSymmetry.check(source, realPath);
-    expect(diagnostics).toEqual([]);
+  describe('symmetry diagnostics', () => {
+    test('fires when a registry entry has no matching trail export', () => {
+      const source = buildIndexSource('', [sampleTrailExport]);
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const missing = diagnostics.filter((d) =>
+        d.message.includes(`missing trail export "${sampleTrailExport}"`)
+      );
+      expect(missing.length).toBe(1);
+      expect(missing[0]?.severity).toBe('error');
+    });
+
+    test('fires when a *Trail export has no matching registry entry', () => {
+      const source = buildIndexSource(
+        `export { fictitiousGhostTrail } from './trails/index.js';\n`
+      );
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const orphans = diagnostics.filter((d) =>
+        d.message.includes('fictitiousGhostTrail')
+      );
+      expect(orphans.length).toBe(1);
+      expect(orphans[0]?.severity).toBe('error');
+    });
+
+    test('fires on orphan *Trail declared via `export const`', () => {
+      const source = buildIndexSource(
+        `export const fictitiousGhostTrail = {} as unknown;\n`
+      );
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const orphans = diagnostics.filter((d) =>
+        d.message.includes('fictitiousGhostTrail')
+      );
+      expect(orphans.length).toBe(1);
+      expect(orphans[0]?.severity).toBe('error');
+    });
   });
 
-  test('fires when a registry entry has no matching trail export', () => {
-    const source = buildIndexSource('', [sampleTrailExport]);
-    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
-    const missing = diagnostics.filter((d) =>
-      d.message.includes(`missing trail export "${sampleTrailExport}"`)
-    );
-    expect(missing.length).toBe(1);
-    expect(missing[0]?.severity).toBe('error');
+  describe('raw-rule leaks', () => {
+    test('fires when a raw rule object is re-exported on the barrel', () => {
+      const source = buildIndexSource(
+        `export { ${sampleRawRuleCamel} } from './rules/index.js';\n`
+      );
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const rawLeaks = diagnostics.filter((d) =>
+        d.message.includes(`raw rule export "${sampleRawRuleCamel}"`)
+      );
+      expect(rawLeaks.length).toBe(1);
+      expect(rawLeaks[0]?.severity).toBe('error');
+    });
+
+    test('fires on aliased raw-rule re-exports using the local binding name', () => {
+      const source = buildIndexSource(
+        `export { ${sampleRawRuleCamel} as disguisedRule } from './rules/index.js';\n`
+      );
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const rawLeaks = diagnostics.filter((d) =>
+        d.message.includes(`raw rule export "${sampleRawRuleCamel}"`)
+      );
+      expect(rawLeaks.length).toBe(1);
+      expect(rawLeaks[0]?.severity).toBe('error');
+    });
   });
 
-  test('fires when a *Trail export has no matching registry entry', () => {
-    const source = buildIndexSource(
-      `export { fictitiousGhostTrail } from './trails/index.js';\n`
-    );
-    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
-    const orphans = diagnostics.filter((d) =>
-      d.message.includes('fictitiousGhostTrail')
-    );
-    expect(orphans.length).toBe(1);
-    expect(orphans[0]?.severity).toBe('error');
+  describe('forbidden barrel shapes', () => {
+    test('fires on namespace re-exports (export * from ...)', () => {
+      const source = `${buildIndexSource()}export * from './trails/index.js';\n`;
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const nsReexports = diagnostics.filter((d) =>
+        d.message.includes('namespace re-export')
+      );
+      expect(nsReexports.length).toBe(1);
+      expect(nsReexports[0]?.severity).toBe('error');
+    });
+
+    test('rejects `export default` on the warden barrel', () => {
+      const source = `${buildIndexSource()}export default {};\n`;
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const defaults = diagnostics.filter((d) =>
+        d.message.includes('default export')
+      );
+      expect(defaults.length).toBe(1);
+      expect(defaults[0]?.severity).toBe('error');
+    });
   });
 
-  test('fires when a raw rule object is re-exported on the barrel', () => {
-    const source = buildIndexSource(
-      `export { ${sampleRawRuleCamel} } from './rules/index.js';\n`
-    );
-    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
-    const rawLeaks = diagnostics.filter((d) =>
-      d.message.includes(`raw rule export "${sampleRawRuleCamel}"`)
-    );
-    expect(rawLeaks.length).toBe(1);
-    expect(rawLeaks[0]?.severity).toBe('error');
-  });
+  describe('type-only namespace re-exports', () => {
+    test('allows `export type * from ...`', () => {
+      const source = `${buildIndexSource()}export type * from './rules/types.js';\n`;
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const nsReexports = diagnostics.filter((d) =>
+        d.message.includes('namespace re-export')
+      );
+      expect(nsReexports).toEqual([]);
+    });
 
-  test('registry-names snapshot matches the live registry', () => {
-    const live = new Set([...wardenRules.keys(), ...wardenTopoRules.keys()]);
-    const snapshot = new Set([...registeredRuleNames, SELF_RULE_NAME]);
-    // Symmetric diff: both directions must be empty. Any missing / extra name
-    // means `registry-names.ts` drifted from `rules/index.ts`.
-    const missingFromSnapshot = [...live].filter((n) => !snapshot.has(n));
-    const extraInSnapshot = [...snapshot].filter((n) => !live.has(n));
-    expect(missingFromSnapshot).toEqual([]);
-    expect(extraInSnapshot).toEqual([]);
-  });
-
-  test('fires on namespace re-exports (export * from ...)', () => {
-    const source = `${buildIndexSource()}export * from './trails/index.js';\n`;
-    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
-    const nsReexports = diagnostics.filter((d) =>
-      d.message.includes('namespace re-export')
-    );
-    expect(nsReexports.length).toBe(1);
-    expect(nsReexports[0]?.severity).toBe('error');
-  });
-
-  test('fires on aliased raw-rule re-exports using the local binding name', () => {
-    const source = buildIndexSource(
-      `export { ${sampleRawRuleCamel} as disguisedRule } from './rules/index.js';\n`
-    );
-    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
-    const rawLeaks = diagnostics.filter((d) =>
-      d.message.includes(`raw rule export "${sampleRawRuleCamel}"`)
-    );
-    expect(rawLeaks.length).toBe(1);
-    expect(rawLeaks[0]?.severity).toBe('error');
-  });
-
-  test('fires on orphan *Trail declared via `export const`', () => {
-    const source = buildIndexSource(
-      `export const fictitiousGhostTrail = {} as unknown;\n`
-    );
-    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
-    const orphans = diagnostics.filter((d) =>
-      d.message.includes('fictitiousGhostTrail')
-    );
-    expect(orphans.length).toBe(1);
-    expect(orphans[0]?.severity).toBe('error');
-  });
-
-  test('rejects `export default` on the warden barrel', () => {
-    const source = `${buildIndexSource()}export default {};\n`;
-    const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
-    const defaults = diagnostics.filter((d) =>
-      d.message.includes('default export')
-    );
-    expect(defaults.length).toBe(1);
-    expect(defaults[0]?.severity).toBe('error');
+    test('allows `export type * as ns from ...`', () => {
+      const source = `${buildIndexSource()}export type * as types from './rules/types.js';\n`;
+      const diagnostics = wardenExportSymmetry.check(source, TARGET_FILE);
+      const nsReexports = diagnostics.filter((d) =>
+        d.message.includes('namespace re-export')
+      );
+      expect(nsReexports).toEqual([]);
+    });
   });
 });

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -93,6 +93,7 @@ export {
   unreachableDetourShadowingTrail,
   validDescribeRefsTrail,
   validDetourRefsTrail,
+  wardenExportSymmetryTrail,
   wrapTopoRule,
 } from './trails/index.js';
 export type {

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -30,6 +30,7 @@ import type { TopoAwareWardenRule, WardenRule } from './types.js';
 import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 import { validDescribeRefs } from './valid-describe-refs.js';
 import { validDetourRefs } from './valid-detour-refs.js';
+import { wardenExportSymmetry } from './warden-export-symmetry.js';
 
 export type {
   ProjectAwareWardenRule,
@@ -107,6 +108,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [noThrowInDetourTarget.name, noThrowInDetourTarget],
   [noDirectImplInRoute.name, noDirectImplInRoute],
   [unreachableDetourShadowing.name, unreachableDetourShadowing],
+  [wardenExportSymmetry.name, wardenExportSymmetry],
 ]);
 
 /**

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -1,0 +1,79 @@
+/**
+ * Registry name snapshot used by `warden-export-symmetry`.
+ *
+ * Imports each rule module directly to avoid a dependency cycle with
+ * `./index.ts`, which itself imports `warden-export-symmetry`. Keep this
+ * list in lockstep with `wardenRules` / `wardenTopoRules` in `./index.ts` —
+ * the `warden-export-symmetry` rule will fail the build if they drift.
+ */
+import { circularRefs } from './circular-refs.js';
+import { contourExists } from './contour-exists.js';
+import { contextNoSurfaceTypes } from './context-no-surface-types.js';
+import { crossDeclarations } from './cross-declarations.js';
+import { deadInternalTrail } from './dead-internal-trail.js';
+import { draftFileMarking } from './draft-file-marking.js';
+import { draftVisibleDebt } from './draft-visible-debt.js';
+import { errorMappingCompleteness } from './error-mapping-completeness.js';
+import { exampleValid } from './example-valid.js';
+import { firesDeclarations } from './fires-declarations.js';
+import { implementationReturnsResult } from './implementation-returns-result.js';
+import { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
+import { incompleteCrud } from './incomplete-crud.js';
+import { intentPropagation } from './intent-propagation.js';
+import { missingReconcile } from './missing-reconcile.js';
+import { missingVisibility } from './missing-visibility.js';
+import { noDirectImplInRoute } from './no-direct-impl-in-route.js';
+import { noDirectImplementationCall } from './no-direct-implementation-call.js';
+import { noSyncResultAssumption } from './no-sync-result-assumption.js';
+import { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
+import { noThrowInImplementation } from './no-throw-in-implementation.js';
+import { onReferencesExist } from './on-references-exist.js';
+import { orphanedSignal } from './orphaned-signal.js';
+import { preferSchemaInference } from './prefer-schema-inference.js';
+import { referenceExists } from './reference-exists.js';
+import { resourceDeclarations } from './resource-declarations.js';
+import { resourceExists } from './resource-exists.js';
+import { resourceIdGrammar } from './resource-id-grammar.js';
+import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
+import { validDescribeRefs } from './valid-describe-refs.js';
+import { validDetourRefs } from './valid-detour-refs.js';
+
+/**
+ * All non-`warden-export-symmetry` rule identifiers registered in
+ * `wardenRules` / `wardenTopoRules`. Excludes the symmetry rule itself to
+ * avoid a self-referential check; the symmetry rule adds its own name back in
+ * when comparing against the public barrel.
+ */
+export const registeredRuleNames: readonly string[] = [
+  circularRefs.name,
+  contextNoSurfaceTypes.name,
+  contourExists.name,
+  crossDeclarations.name,
+  deadInternalTrail.name,
+  draftFileMarking.name,
+  draftVisibleDebt.name,
+  errorMappingCompleteness.name,
+  exampleValid.name,
+  firesDeclarations.name,
+  implementationReturnsResult.name,
+  incompleteAccessorForStandardOp.name,
+  incompleteCrud.name,
+  intentPropagation.name,
+  missingReconcile.name,
+  missingVisibility.name,
+  noDirectImplInRoute.name,
+  noDirectImplementationCall.name,
+  noSyncResultAssumption.name,
+  noThrowInDetourTarget.name,
+  noThrowInImplementation.name,
+  onReferencesExist.name,
+  orphanedSignal.name,
+  preferSchemaInference.name,
+  referenceExists.name,
+  resourceDeclarations.name,
+  resourceExists.name,
+  resourceIdGrammar.name,
+  unreachableDetourShadowing.name,
+  validDescribeRefs.name,
+  validDetourRefs.name,
+];

--- a/packages/warden/src/rules/warden-export-symmetry.ts
+++ b/packages/warden/src/rules/warden-export-symmetry.ts
@@ -32,20 +32,47 @@ const kebabToCamel = (value: string): string =>
   value.replaceAll(/-([a-z0-9])/g, (_, char: string) => char.toUpperCase());
 
 interface ExportSite {
+  /** Public export name — what consumers see on the barrel. */
   readonly name: string;
+  /**
+   * Local source binding name. For alias re-exports
+   * (`export { foo as bar }`) this is `foo`. Equals `name` for non-aliased
+   * exports and for declaration-form exports (`export const foo = ...`).
+   * Used by `rawRuleLeakDiagnostics` so aliasing a raw rule does not sanitize it.
+   */
+  readonly localName: string;
   readonly start: number;
 }
 
-const extractSpecifierName = (specifier: AstNode): string | null => {
-  const { exported } = specifier as unknown as { exported?: AstNode };
-  if (exported?.type === 'Identifier') {
-    return (exported as unknown as { name?: string }).name ?? null;
+const readIdentifierOrStringName = (
+  node: AstNode | undefined
+): string | null => {
+  if (!node) {
+    return null;
   }
-  if (exported?.type === 'Literal' || exported?.type === 'StringLiteral') {
-    const { value } = exported as unknown as { value?: unknown };
+  if (node.type === 'Identifier') {
+    return (node as unknown as { name?: string }).name ?? null;
+  }
+  if (node.type === 'Literal' || node.type === 'StringLiteral') {
+    const { value } = node as unknown as { value?: unknown };
     return typeof value === 'string' ? value : null;
   }
   return null;
+};
+
+const extractSpecifierNames = (
+  specifier: AstNode
+): { readonly name: string; readonly localName: string } | null => {
+  const { exported, local } = specifier as unknown as {
+    exported?: AstNode;
+    local?: AstNode;
+  };
+  const name = readIdentifierOrStringName(exported);
+  if (!name) {
+    return null;
+  }
+  const localName = readIdentifierOrStringName(local) ?? name;
+  return { localName, name };
 };
 
 const isTypeExportSpecifier = (specifier: AstNode): boolean =>
@@ -58,8 +85,46 @@ const specifierSite = (specifier: AstNode): ExportSite | null => {
   ) {
     return null;
   }
-  const name = extractSpecifierName(specifier);
-  return name ? { name, start: specifier.start } : null;
+  const names = extractSpecifierNames(specifier);
+  return names ? { ...names, start: specifier.start } : null;
+};
+
+const TYPE_ONLY_DECL_TYPES = new Set([
+  'TSTypeAliasDeclaration',
+  'TSInterfaceDeclaration',
+]);
+
+const namedSiteFromDeclId = (
+  declId: AstNode | undefined,
+  start: number
+): ExportSite | null => {
+  const name = readIdentifierOrStringName(declId);
+  return name ? { localName: name, name, start } : null;
+};
+
+const sitesForDeclaration = (declaration: AstNode): readonly ExportSite[] => {
+  if (TYPE_ONLY_DECL_TYPES.has(declaration.type)) {
+    return [];
+  }
+  if (
+    declaration.type === 'FunctionDeclaration' ||
+    declaration.type === 'ClassDeclaration'
+  ) {
+    const { id } = declaration as unknown as { id?: AstNode };
+    const site = namedSiteFromDeclId(id, declaration.start);
+    return site ? [site] : [];
+  }
+  if (declaration.type === 'VariableDeclaration') {
+    const declarations =
+      (declaration as unknown as { declarations?: readonly AstNode[] })
+        .declarations ?? [];
+    return declarations.flatMap((declarator) => {
+      const { id } = declarator as unknown as { id?: AstNode };
+      const site = namedSiteFromDeclId(id, declarator.start);
+      return site ? [site] : [];
+    });
+  }
+  return [];
 };
 
 const sitesForExportNode = (node: AstNode): readonly ExportSite[] => {
@@ -68,6 +133,10 @@ const sitesForExportNode = (node: AstNode): readonly ExportSite[] => {
   }
   if ((node as unknown as { exportKind?: string }).exportKind === 'type') {
     return [];
+  }
+  const { declaration } = node as unknown as { declaration?: AstNode };
+  if (declaration) {
+    return sitesForDeclaration(declaration);
   }
   const specifiers =
     (node['specifiers'] as readonly AstNode[] | undefined) ?? [];
@@ -96,7 +165,7 @@ const collectNamespaceReexports = (ast: AstNode): readonly ExportSite[] => {
     };
     const target =
       typeof source?.value === 'string' ? source.value : '<unknown>';
-    sites.push({ name: target, start: node.start });
+    sites.push({ localName: target, name: target, start: node.start });
   });
   return sites;
 };
@@ -165,23 +234,105 @@ const orphanTrailDiagnostics = (
       severity: 'error' as const,
     }));
 
+const pickRawRuleMatch = (
+  site: ExportSite,
+  rawNames: ReadonlySet<string>
+): string | null => {
+  if (rawNames.has(site.localName)) {
+    return site.localName;
+  }
+  if (rawNames.has(site.name)) {
+    return site.name;
+  }
+  return null;
+};
+
 const rawRuleLeakDiagnostics = (
   sourceCode: string,
   filePath: string,
   exports: readonly ExportSite[],
   rawNames: ReadonlySet<string>
 ): readonly WardenDiagnostic[] =>
-  exports
-    .filter((site) => rawNames.has(site.name))
-    .map((site) => ({
+  exports.flatMap((site) => {
+    // Check BOTH the public name and the local source binding — aliasing a
+    // raw rule (`export { wardenExportSymmetry as disguised }`) must not
+    // sanitize the leak. Prefer the raw-matching name in the diagnostic so
+    // the incident points at the actual rule identifier.
+    const matched = pickRawRuleMatch(site, rawNames);
+    if (!matched) {
+      return [];
+    }
+    const alias =
+      site.localName === site.name ? '' : ` (aliased as "${site.name}")`;
+    return [
+      {
+        filePath,
+        line: offsetToLine(sourceCode, site.start),
+        message:
+          `warden-export-symmetry: raw rule export "${matched}"${alias} must not appear on the public barrel. ` +
+          'Raw WardenRule objects are internal; expose the matching *Trail wrapper instead (ADR-0036).',
+        rule: 'warden-export-symmetry',
+        severity: 'error' as const,
+      },
+    ];
+  });
+
+const collectDefaultExports = (ast: AstNode): readonly ExportSite[] => {
+  const sites: ExportSite[] = [];
+  walk(ast, (node) => {
+    if (node.type !== 'ExportDefaultDeclaration') {
+      return;
+    }
+    sites.push({ localName: 'default', name: 'default', start: node.start });
+  });
+  return sites;
+};
+
+const defaultExportDiagnostics = (
+  sourceCode: string,
+  filePath: string,
+  sites: readonly ExportSite[]
+): readonly WardenDiagnostic[] =>
+  sites.map((site) => ({
+    filePath,
+    line: offsetToLine(sourceCode, site.start),
+    message:
+      'warden-export-symmetry: default export is not permitted on the warden public barrel. ' +
+      'Use named exports only so registry ↔ trail symmetry is discoverable (ADR-0036).',
+    rule: 'warden-export-symmetry',
+    severity: 'error' as const,
+  }));
+
+const analyzeBarrel = (
+  sourceCode: string,
+  filePath: string,
+  ast: AstNode
+): readonly WardenDiagnostic[] => {
+  const exports = collectNamedExports(ast);
+  const presentExports = new Set(exports.map((site) => site.name));
+  const { expectedTrailExports, rawRuleCamelNames } = buildRegistryNameSets();
+
+  return [
+    ...namespaceReexportDiagnostics(
+      sourceCode,
       filePath,
-      line: offsetToLine(sourceCode, site.start),
-      message:
-        `warden-export-symmetry: raw rule export "${site.name}" must not appear on the public barrel. ` +
-        'Raw WardenRule objects are internal; expose the matching *Trail wrapper instead (ADR-0036).',
-      rule: 'warden-export-symmetry',
-      severity: 'error' as const,
-    }));
+      collectNamespaceReexports(ast)
+    ),
+    ...defaultExportDiagnostics(
+      sourceCode,
+      filePath,
+      collectDefaultExports(ast)
+    ),
+    ...missingTrailDiagnostics(filePath, expectedTrailExports, presentExports),
+    ...orphanTrailDiagnostics(
+      sourceCode,
+      filePath,
+      exports,
+      expectedTrailExports
+    ),
+    ...rawRuleLeakDiagnostics(sourceCode, filePath, exports, rawRuleCamelNames),
+  ];
+};
 
 /**
  * Warden rule enforcing ADR-0036 registry ↔ trail export symmetry on the
@@ -196,32 +347,7 @@ export const wardenExportSymmetry: WardenRule = {
     if (!ast) {
       return [];
     }
-
-    const exports = collectNamedExports(ast);
-    const presentExports = new Set(exports.map((site) => site.name));
-    const namespaceSites = collectNamespaceReexports(ast);
-    const { expectedTrailExports, rawRuleCamelNames } = buildRegistryNameSets();
-
-    return [
-      ...namespaceReexportDiagnostics(sourceCode, filePath, namespaceSites),
-      ...missingTrailDiagnostics(
-        filePath,
-        expectedTrailExports,
-        presentExports
-      ),
-      ...orphanTrailDiagnostics(
-        sourceCode,
-        filePath,
-        exports,
-        expectedTrailExports
-      ),
-      ...rawRuleLeakDiagnostics(
-        sourceCode,
-        filePath,
-        exports,
-        rawRuleCamelNames
-      ),
-    ];
+    return analyzeBarrel(sourceCode, filePath, ast);
   },
   description:
     'Enforces ADR-0036: every wardenRules / wardenTopoRules entry has a matching *Trail export, no orphan *Trail exports, and no raw rule objects leak onto the @ontrails/warden public barrel.',

--- a/packages/warden/src/rules/warden-export-symmetry.ts
+++ b/packages/warden/src/rules/warden-export-symmetry.ts
@@ -112,6 +112,148 @@ const namedSiteFromDeclId = (
   return name ? { localName: name, name, start } : null;
 };
 
+/**
+ * Extract an identifier or `AssignmentPattern`'s left-hand identifier as a
+ * single export site. Returns null for anything else (nested patterns should
+ * be routed through `sitesFromPattern`).
+ */
+const siteFromSimpleBinding = (
+  node: AstNode | undefined,
+  start: number
+): ExportSite | null => {
+  if (!node) {
+    return null;
+  }
+  if (node.type === 'Identifier') {
+    const name = readIdentifierOrStringName(node);
+    return name ? { localName: name, name, start } : null;
+  }
+  if (node.type === 'AssignmentPattern') {
+    const { left } = node as unknown as { left?: AstNode };
+    return left ? siteFromSimpleBinding(left, start) : null;
+  }
+  return null;
+};
+
+/** Callback type to break the recursion cycle without use-before-define. */
+type PatternSitesFn = (
+  pattern: AstNode | undefined,
+  start: number
+) => readonly ExportSite[];
+
+/**
+ * Compose a rename-pair site from an `ObjectPattern` property's `key` and a
+ * resolved value site. Rename pairs (`{ foo: bar }`) emit one site whose
+ * `localName` is the source binding `foo` and whose public `name` is the
+ * target `bar`, mirroring `extractSpecifierNames` for `export { foo as bar }`.
+ */
+const renamePairSite = (
+  key: AstNode | undefined,
+  valueSite: ExportSite,
+  start: number
+): ExportSite => {
+  const keyName = readIdentifierOrStringName(key);
+  return {
+    localName: keyName ?? valueSite.localName,
+    name: valueSite.name,
+    start,
+  };
+};
+
+const isNestedPatternValue = (value: AstNode | undefined): boolean =>
+  !!value && value.type !== 'Identifier' && value.type !== 'AssignmentPattern';
+
+/**
+ * Extract sites from a single `ObjectPattern` property.
+ */
+const sitesFromObjectProperty = (
+  prop: AstNode,
+  start: number,
+  recurse: PatternSitesFn
+): readonly ExportSite[] => {
+  if (prop.type === 'RestElement') {
+    const { argument } = prop as unknown as { argument?: AstNode };
+    return recurse(argument, start);
+  }
+  if (prop.type !== 'Property') {
+    return [];
+  }
+  const { key, value } = prop as unknown as {
+    key?: AstNode;
+    value?: AstNode;
+  };
+  if (isNestedPatternValue(value)) {
+    return recurse(value, start);
+  }
+  const valueSite = siteFromSimpleBinding(value, start);
+  return valueSite ? [renamePairSite(key, valueSite, start)] : [];
+};
+
+const sitesFromArrayElement = (
+  element: AstNode | null,
+  start: number,
+  recurse: PatternSitesFn
+): readonly ExportSite[] => {
+  if (!element) {
+    return [];
+  }
+  if (element.type === 'RestElement') {
+    const { argument } = element as unknown as { argument?: AstNode };
+    return recurse(argument, start);
+  }
+  return recurse(element, start);
+};
+
+const sitesFromObjectPattern = (
+  pattern: AstNode,
+  start: number,
+  recurse: PatternSitesFn
+): readonly ExportSite[] => {
+  const properties =
+    (pattern as unknown as { properties?: readonly AstNode[] }).properties ??
+    [];
+  return properties.flatMap((prop) =>
+    sitesFromObjectProperty(prop, start, recurse)
+  );
+};
+
+const sitesFromArrayPattern = (
+  pattern: AstNode,
+  start: number,
+  recurse: PatternSitesFn
+): readonly ExportSite[] => {
+  const elements =
+    (pattern as unknown as { elements?: readonly (AstNode | null)[] })
+      .elements ?? [];
+  return elements.flatMap((element) =>
+    sitesFromArrayElement(element, start, recurse)
+  );
+};
+
+/**
+ * Recursively extract export sites from a declarator id, supporting
+ * `ObjectPattern` and `ArrayPattern` destructuring. Without this, a
+ * destructured `export const { wardenExportSymmetry } = rulesModule` silently
+ * bypasses orphan-trail and raw-rule-leak checks because the id is not an
+ * `Identifier`.
+ */
+const sitesFromPattern: PatternSitesFn = (pattern, start) => {
+  if (!pattern) {
+    return [];
+  }
+  const simple = siteFromSimpleBinding(pattern, start);
+  if (simple) {
+    return [simple];
+  }
+  if (pattern.type === 'ObjectPattern') {
+    return sitesFromObjectPattern(pattern, start, sitesFromPattern);
+  }
+  if (pattern.type === 'ArrayPattern') {
+    return sitesFromArrayPattern(pattern, start, sitesFromPattern);
+  }
+  return [];
+};
+
 const sitesForDeclaration = (declaration: AstNode): readonly ExportSite[] => {
   if (TYPE_ONLY_DECL_TYPES.has(declaration.type)) {
     return [];
@@ -130,8 +272,7 @@ const sitesForDeclaration = (declaration: AstNode): readonly ExportSite[] => {
         .declarations ?? [];
     return declarations.flatMap((declarator) => {
       const { id } = declarator as unknown as { id?: AstNode };
-      const site = namedSiteFromDeclId(id, declarator.start);
-      return site ? [site] : [];
+      return sitesFromPattern(id, declarator.start);
     });
   }
   return [];

--- a/packages/warden/src/rules/warden-export-symmetry.ts
+++ b/packages/warden/src/rules/warden-export-symmetry.ts
@@ -1,0 +1,230 @@
+/**
+ * Enforces ADR-0036: `@ontrails/warden` exposes only a trail-wrapper + registry
+ * surface. Raw rule objects stay internal to `./rules/`. The public barrel
+ * (`packages/warden/src/index.ts`) must:
+ *
+ *  1. Export a matching `*Trail` identifier for every entry in
+ *     `wardenRules` / `wardenTopoRules`.
+ *  2. Not expose a `*Trail` identifier with no matching registry entry.
+ *  3. Not re-export a raw rule object by its camelCased name.
+ *
+ * Properties 1 and 2 cannot be fully derived today because the registry holds
+ * raw `WardenRule` objects whose `.check()` methods are called by the trail
+ * wrappers; flipping the dependency (registry ← trails) would require unwrapping
+ * trails at dispatch time and is out of scope for TRL-341. Enforcement therefore
+ * lives as a lint rule keyed on the warden barrel file path.
+ */
+import { walk, offsetToLine, parse } from './ast.js';
+import type { AstNode } from './ast.js';
+import { registeredRuleNames } from './registry-names.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const SELF_RULE_NAME = 'warden-export-symmetry';
+
+const TARGET_FILE_SUFFIX = 'packages/warden/src/index.ts';
+
+const normalize = (filePath: string): string => filePath.replaceAll('\\', '/');
+
+const isTargetFile = (filePath: string): boolean =>
+  normalize(filePath).endsWith(TARGET_FILE_SUFFIX);
+
+const kebabToCamel = (value: string): string =>
+  value.replaceAll(/-([a-z0-9])/g, (_, char: string) => char.toUpperCase());
+
+interface ExportSite {
+  readonly name: string;
+  readonly start: number;
+}
+
+const extractSpecifierName = (specifier: AstNode): string | null => {
+  const { exported } = specifier as unknown as { exported?: AstNode };
+  if (exported?.type === 'Identifier') {
+    return (exported as unknown as { name?: string }).name ?? null;
+  }
+  if (exported?.type === 'Literal' || exported?.type === 'StringLiteral') {
+    const { value } = exported as unknown as { value?: unknown };
+    return typeof value === 'string' ? value : null;
+  }
+  return null;
+};
+
+const isTypeExportSpecifier = (specifier: AstNode): boolean =>
+  (specifier as unknown as { exportKind?: string }).exportKind === 'type';
+
+const specifierSite = (specifier: AstNode): ExportSite | null => {
+  if (
+    specifier.type !== 'ExportSpecifier' ||
+    isTypeExportSpecifier(specifier)
+  ) {
+    return null;
+  }
+  const name = extractSpecifierName(specifier);
+  return name ? { name, start: specifier.start } : null;
+};
+
+const sitesForExportNode = (node: AstNode): readonly ExportSite[] => {
+  if (node.type !== 'ExportNamedDeclaration') {
+    return [];
+  }
+  if ((node as unknown as { exportKind?: string }).exportKind === 'type') {
+    return [];
+  }
+  const specifiers =
+    (node['specifiers'] as readonly AstNode[] | undefined) ?? [];
+  return specifiers.flatMap((specifier) => {
+    const site = specifierSite(specifier);
+    return site ? [site] : [];
+  });
+};
+
+const collectNamedExports = (ast: AstNode): readonly ExportSite[] => {
+  const sites: ExportSite[] = [];
+  walk(ast, (node) => {
+    sites.push(...sitesForExportNode(node));
+  });
+  return sites;
+};
+
+const collectNamespaceReexports = (ast: AstNode): readonly ExportSite[] => {
+  const sites: ExportSite[] = [];
+  walk(ast, (node) => {
+    if (node.type !== 'ExportAllDeclaration') {
+      return;
+    }
+    const { source } = node as unknown as {
+      source?: { value?: unknown };
+    };
+    const target =
+      typeof source?.value === 'string' ? source.value : '<unknown>';
+    sites.push({ name: target, start: node.start });
+  });
+  return sites;
+};
+
+const namespaceReexportDiagnostics = (
+  sourceCode: string,
+  filePath: string,
+  sites: readonly ExportSite[]
+): readonly WardenDiagnostic[] =>
+  sites.map((site) => ({
+    filePath,
+    line: offsetToLine(sourceCode, site.start),
+    message:
+      `warden-export-symmetry: namespace re-export "export * from '${site.name}'" is not permitted on the warden public barrel. ` +
+      'The rule cannot verify registry ↔ trail symmetry through a star export — list each *Trail by name instead (ADR-0036).',
+    rule: 'warden-export-symmetry',
+    severity: 'error' as const,
+  }));
+
+const buildRegistryNameSets = (): {
+  readonly ruleNames: readonly string[];
+  readonly expectedTrailExports: ReadonlySet<string>;
+  readonly rawRuleCamelNames: ReadonlySet<string>;
+} => {
+  const ruleNames = [...registeredRuleNames, SELF_RULE_NAME];
+  const camelNames = ruleNames.map(kebabToCamel);
+  return {
+    expectedTrailExports: new Set(camelNames.map((name) => `${name}Trail`)),
+    rawRuleCamelNames: new Set(camelNames),
+    ruleNames,
+  };
+};
+
+const missingTrailDiagnostics = (
+  filePath: string,
+  expected: ReadonlySet<string>,
+  present: ReadonlySet<string>
+): readonly WardenDiagnostic[] =>
+  [...expected]
+    .filter((name) => !present.has(name))
+    .map((name) => ({
+      filePath,
+      line: 1,
+      message:
+        `warden-export-symmetry: missing trail export "${name}" for registered warden rule. ` +
+        'Every wardenRules / wardenTopoRules entry must have a matching *Trail export on the public barrel (ADR-0036).',
+      rule: 'warden-export-symmetry',
+      severity: 'error' as const,
+    }));
+
+const orphanTrailDiagnostics = (
+  sourceCode: string,
+  filePath: string,
+  exports: readonly ExportSite[],
+  expected: ReadonlySet<string>
+): readonly WardenDiagnostic[] =>
+  exports
+    .filter((site) => site.name.endsWith('Trail') && !expected.has(site.name))
+    .map((site) => ({
+      filePath,
+      line: offsetToLine(sourceCode, site.start),
+      message:
+        `warden-export-symmetry: orphan trail export "${site.name}" has no matching wardenRules / wardenTopoRules entry. ` +
+        'Remove the export or register the corresponding rule (ADR-0036).',
+      rule: 'warden-export-symmetry',
+      severity: 'error' as const,
+    }));
+
+const rawRuleLeakDiagnostics = (
+  sourceCode: string,
+  filePath: string,
+  exports: readonly ExportSite[],
+  rawNames: ReadonlySet<string>
+): readonly WardenDiagnostic[] =>
+  exports
+    .filter((site) => rawNames.has(site.name))
+    .map((site) => ({
+      filePath,
+      line: offsetToLine(sourceCode, site.start),
+      message:
+        `warden-export-symmetry: raw rule export "${site.name}" must not appear on the public barrel. ` +
+        'Raw WardenRule objects are internal; expose the matching *Trail wrapper instead (ADR-0036).',
+      rule: 'warden-export-symmetry',
+      severity: 'error' as const,
+    }));
+
+/**
+ * Warden rule enforcing ADR-0036 registry ↔ trail export symmetry on the
+ * `@ontrails/warden` public barrel.
+ */
+export const wardenExportSymmetry: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (!isTargetFile(filePath)) {
+      return [];
+    }
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const exports = collectNamedExports(ast);
+    const presentExports = new Set(exports.map((site) => site.name));
+    const namespaceSites = collectNamespaceReexports(ast);
+    const { expectedTrailExports, rawRuleCamelNames } = buildRegistryNameSets();
+
+    return [
+      ...namespaceReexportDiagnostics(sourceCode, filePath, namespaceSites),
+      ...missingTrailDiagnostics(
+        filePath,
+        expectedTrailExports,
+        presentExports
+      ),
+      ...orphanTrailDiagnostics(
+        sourceCode,
+        filePath,
+        exports,
+        expectedTrailExports
+      ),
+      ...rawRuleLeakDiagnostics(
+        sourceCode,
+        filePath,
+        exports,
+        rawRuleCamelNames
+      ),
+    ];
+  },
+  description:
+    'Enforces ADR-0036: every wardenRules / wardenTopoRules entry has a matching *Trail export, no orphan *Trail exports, and no raw rule objects leak onto the @ontrails/warden public barrel.',
+  name: 'warden-export-symmetry',
+  severity: 'error',
+};

--- a/packages/warden/src/rules/warden-export-symmetry.ts
+++ b/packages/warden/src/rules/warden-export-symmetry.ts
@@ -160,6 +160,12 @@ const collectNamespaceReexports = (ast: AstNode): readonly ExportSite[] => {
     if (node.type !== 'ExportAllDeclaration') {
       return;
     }
+    // Mirror the `ExportNamedDeclaration` guard: `export type * from ...` and
+    // `export type * as ns from ...` propagate types only, never runtime
+    // identifiers, so they cannot leak raw rule objects and must be allowed.
+    if ((node as unknown as { exportKind?: string }).exportKind === 'type') {
+      return;
+    }
     const { source } = node as unknown as {
       source?: { value?: unknown };
     };

--- a/packages/warden/src/rules/warden-export-symmetry.ts
+++ b/packages/warden/src/rules/warden-export-symmetry.ts
@@ -14,6 +14,8 @@
  * trails at dispatch time and is out of scope for TRL-341. Enforcement therefore
  * lives as a lint rule keyed on the warden barrel file path.
  */
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { walk, offsetToLine, parse } from './ast.js';
 import type { AstNode } from './ast.js';
 import { registeredRuleNames } from './registry-names.js';
@@ -21,12 +23,20 @@ import type { WardenDiagnostic, WardenRule } from './types.js';
 
 const SELF_RULE_NAME = 'warden-export-symmetry';
 
-const TARGET_FILE_SUFFIX = 'packages/warden/src/index.ts';
-
-const normalize = (filePath: string): string => filePath.replaceAll('\\', '/');
+/**
+ * Absolute path to this package's own `src/index.ts`, resolved from the rule's
+ * own module URL. Anchoring to the real on-disk location prevents the rule
+ * from firing against a foreign `packages/warden/src/index.ts` in a consumer
+ * repository with the same folder structure — the rule would otherwise compare
+ * that unrelated barrel against `@ontrails/warden`'s internal registry and
+ * emit bogus missing/orphan diagnostics that break consumer CI.
+ */
+const SELF_BARREL_PATH = resolve(
+  fileURLToPath(new URL('../index.ts', import.meta.url))
+);
 
 const isTargetFile = (filePath: string): boolean =>
-  normalize(filePath).endsWith(TARGET_FILE_SUFFIX);
+  resolve(filePath) === SELF_BARREL_PATH;
 
 const kebabToCamel = (value: string): string =>
   value.replaceAll(/-([a-z0-9])/g, (_, char: string) => char.toUpperCase());
@@ -154,8 +164,18 @@ const collectNamedExports = (ast: AstNode): readonly ExportSite[] => {
   return sites;
 };
 
-const collectNamespaceReexports = (ast: AstNode): readonly ExportSite[] => {
-  const sites: ExportSite[] = [];
+interface NamespaceReexportSite {
+  /** Source module path, e.g. `'./trails/index.js'`. */
+  readonly target: string;
+  /** Alias for `export * as <alias> from '...'`, null for bare `export *`. */
+  readonly alias: string | null;
+  readonly start: number;
+}
+
+const collectNamespaceReexports = (
+  ast: AstNode
+): readonly NamespaceReexportSite[] => {
+  const sites: NamespaceReexportSite[] = [];
   walk(ast, (node) => {
     if (node.type !== 'ExportAllDeclaration') {
       return;
@@ -166,26 +186,36 @@ const collectNamespaceReexports = (ast: AstNode): readonly ExportSite[] => {
     if ((node as unknown as { exportKind?: string }).exportKind === 'type') {
       return;
     }
-    const { source } = node as unknown as {
+    const { source, exported } = node as unknown as {
       source?: { value?: unknown };
+      exported?: AstNode;
     };
     const target =
       typeof source?.value === 'string' ? source.value : '<unknown>';
-    sites.push({ localName: target, name: target, start: node.start });
+    // `export * as <alias> from '...'` exposes the alias as an
+    // `IdentifierName` / string-literal node on `exported`. Bare `export *`
+    // has `exported === null`.
+    const alias = readIdentifierOrStringName(exported);
+    sites.push({ alias, start: node.start, target });
   });
   return sites;
 };
 
+const formatNamespaceReexport = (site: NamespaceReexportSite): string =>
+  site.alias
+    ? `* as ${site.alias} from '${site.target}'`
+    : `* from '${site.target}'`;
+
 const namespaceReexportDiagnostics = (
   sourceCode: string,
   filePath: string,
-  sites: readonly ExportSite[]
+  sites: readonly NamespaceReexportSite[]
 ): readonly WardenDiagnostic[] =>
   sites.map((site) => ({
     filePath,
     line: offsetToLine(sourceCode, site.start),
     message:
-      `warden-export-symmetry: namespace re-export "export * from '${site.name}'" is not permitted on the warden public barrel. ` +
+      `warden-export-symmetry: namespace re-export "export ${formatNamespaceReexport(site)}" is not permitted on the warden public barrel. ` +
       'The rule cannot verify registry ↔ trail symmetry through a star export — list each *Trail by name instead (ADR-0036).',
     rule: 'warden-export-symmetry',
     severity: 'error' as const,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -29,6 +29,7 @@ export { resourceExistsTrail } from './resource-exists.trail.js';
 export { unreachableDetourShadowingTrail } from './unreachable-detour-shadowing.trail.js';
 export { validDescribeRefsTrail } from './valid-describe-refs.trail.js';
 export { validDetourRefsTrail } from './valid-detour-refs.trail.js';
+export { wardenExportSymmetryTrail } from './warden-export-symmetry.trail.js';
 
 export {
   diagnosticSchema,

--- a/packages/warden/src/trails/warden-export-symmetry.trail.ts
+++ b/packages/warden/src/trails/warden-export-symmetry.trail.ts
@@ -1,0 +1,16 @@
+import { wardenExportSymmetry } from '../rules/warden-export-symmetry.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const wardenExportSymmetryTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'packages/other-pkg/src/index.ts',
+        sourceCode: `export { somethingElse } from './other.js';\n`,
+      },
+      name: 'Ignores files outside the warden barrel',
+    },
+  ],
+  rule: wardenExportSymmetry,
+});


### PR DESCRIPTION
## Summary

Enforces ADR-0036 structurally: the warden package's public barrel (`packages/warden/src/index.ts`) must stay in symmetric correspondence with the `wardenRules` / `wardenTopoRules` registry. Drift now fails the build instead of depending on a reviewer's eye.

Closes [TRL-341](https://linear.app/outfitter/issue/TRL-341).

## The invariant

The rule `wardenExportSymmetry` (file-scoped to the public barrel, registered like every other rule, reached through the standard `runWarden` dispatch) enforces four properties:

1. **Registry → trail export.** Every entry in `wardenRules` and `wardenTopoRules` has a matching `<camelCase>Trail` export on the barrel. Rule id `warden.rule.foo-bar` ↔ export `fooBarTrail`.
2. **Trail export → registry entry.** No orphan `*Trail` exports — every public `*Trail` identifier on the barrel is grounded in a registry entry.
3. **No raw-rule escape.** No bare camelCase raw-rule identifier is reachable from the public barrel. Aliased forms (`export { wardenExportSymmetry as disguisedRule }`) are caught by checking both the public and local specifier names.
4. **No namespace re-exports.** `export * from '...'` on the barrel is rejected outright — the rule cannot verify symmetry through a star export. Type-only `export type * from '...'` is allowed; only runtime star exports are blocked.

The rule self-registers: `wardenExportSymmetryTrail` is on the barrel and `wardenExportSymmetry` is in `wardenRules`. If either disappears, the rule flags itself — no bootstrap paradox.

## Derivation considered, rejected

ADR-0000's drift guard prefers derivation over lint. Evaluated rebuilding `wardenRules` as a projection from the trail barrel (filter `Trail` instances whose `id` starts with `warden.rule.`). Rejected because trail wrappers call the raw rule's `.check` / `.checkWithContext` / `.checkTopo` methods — raw rules are the execution source, trails are consumers. Flipping that dependency is out of scope. Rationale inlined in `warden-export-symmetry.ts`.

A lightweight drift guard closes the remaining gap: `registry-names.ts` snapshots the rule names (breaking an import cycle with `rules/index.ts`), and a test asserts its symmetric-diff against the live `wardenRules` / `wardenTopoRules` keys is empty in both directions. Adding a rule without updating the snapshot fails the test, not silently.

## AST scope

`sitesForDeclaration` covers `VariableDeclaration` / `FunctionDeclaration` / `ClassDeclaration`; type declarations (`TSTypeAliasDeclaration` / `TSInterfaceDeclaration`) are excluded. `sitesForExportNode` routes both specifier and declaration paths. `collectDefaultExports` + `defaultExportDiagnostics` reject any `export default` on the barrel.

Handled export shapes:

- `export { foo } from '...'`
- `export { foo as bar } from '...'` (both sides checked for raw-rule leak)
- `export { default as foo } from '...'`
- `export const foo = ...` / `export function foo() {}` / `export class Foo {}`
- `export default ...` (always rejected on the barrel)
- `export * from '...'` (rejected with ADR-0036 pointer)
- `export type { ... }` / `export type * from '...'` (permitted, no diagnostics)

## Verification

- `bun run typecheck` — 31/31 green
- `bun test packages/warden` — 353 pass / 0 fail
- `bun run check` — 31/31 green, 0 warnings, 0 errors
- `wardenExportSymmetry` on current warden source — 0 diagnostics (clean baseline)

## Test plan

12 tests under `packages/warden/src/__tests__/warden-export-symmetry.test.ts`:

- File-path scoping (rule only runs on the warden barrel)
- Baseline clean against the real barrel
- Property 1: missing `*Trail` export for a registered rule → error
- Property 2: orphan `*Trail` specifier export → error
- Property 2: orphan declaration-form export (`export const fooTrail = ...`) → error
- Property 3: bare raw-rule re-export → error
- Property 3: aliased raw-rule re-export → error with alias called out
- Property 4: runtime `export * from '...'` → error
- Property 4: type-only `export type * from '...'` → permitted
- Property 4: type-only `export type * as ns from '...'` → permitted
- Default export rejection → error
- Snapshot drift guard: `registry-names.ts` ≡ live `wardenRules`/`wardenTopoRules` keys ∪ `SELF_RULE_NAME`

## Review arc

Initial implementation plus two rounds of Codex convergence review. Each round deepened AST coverage:

- Round 1 (Claude review): drift-guard test for the hand-maintained snapshot; `export *` rejection instead of silent bypass.
- Round 2 (Codex): aliased re-exports (`{ foo as bar }`) for raw-rule leak; declaration-form exports (`export const`) and default exports for orphan detection.
- Round 3 (Codex): type-only namespace re-exports (`export type * from ...`) incorrectly rejected — same guard that existed on `ExportNamedDeclaration` needed on `ExportAllDeclaration`.
- Round 4 (Codex): clean, no further findings.

## Related

- ADR-0036 (landed in #196) — ruling
- PR #197 (TRL-340) — made the invariant true
- This PR (TRL-341) — makes drift structurally catchable