### PR TITLE
refactor(core): codify forkCtx helper for ctx-fork sites [TRL-336]

### DIFF
--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -551,6 +551,47 @@ const expectSiblingTraceShape = (
   expectSiblingOverlap(left, right);
 };
 
+const createConsumerCrossScenario = () => {
+  const crossTarget = trail('notify.audit', {
+    blaze: () => Result.ok({ audited: true }),
+    input: z.object({ orderId: z.string() }),
+    output: z.object({ audited: z.boolean() }),
+  });
+  const consumer = trail('notify.email', {
+    blaze: async (input, ctx) => {
+      const crossFn = ctx.cross as NonNullable<typeof ctx.cross>;
+      return (await crossFn(crossTarget, {
+        orderId: input.orderId,
+      })) as Result<unknown, Error>;
+    },
+    crosses: [crossTarget],
+    input: z.object({ orderId: z.string(), total: z.number() }),
+    on: ['order.placed'],
+  });
+  const fireBox: { result?: Result<void, Error> } = {};
+  return topo('fire-consumer-cross-attribution', {
+    consumer,
+    crossTarget,
+    orderPlaced,
+    producer: makeProducer(fireBox),
+  });
+};
+
+const expectConsumerCrossAttribution = (
+  records: readonly TraceRecord[]
+): void => {
+  const producerRecord = findTrailRecord(records, 'order.create');
+  const consumerRecord = findTrailRecord(records, 'notify.email');
+  const crossRecord = findTrailRecord(records, 'notify.audit');
+  // The consumer span parents the crossed call — NOT the producer.
+  // Before the forkCtx fix, the consumer inherited the producer's
+  // `cross` closure, which attributed the crossed span to the
+  // producer's scope.
+  expect(crossRecord.parentId).toBe(consumerRecord.id);
+  expect(crossRecord.parentId).not.toBe(producerRecord.id);
+  expect(crossRecord.traceId).toBe(producerRecord.traceId);
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -866,6 +907,25 @@ describe('fire', () => {
           producerTrailId: 'order.create',
           rightTrailId: 'notify.slack',
         });
+      } finally {
+        clearTraceSink();
+      }
+    });
+  });
+
+  describe('per-consumer cross binding', () => {
+    test('cross calls from a consumer are attributed to the consumer span', async () => {
+      const records: TraceRecord[] = [];
+      registerTraceSink(createCapturingSink(records));
+
+      try {
+        const app = createConsumerCrossScenario();
+        const result = await run(app, 'order.create', {
+          orderId: 'o-cross-attr',
+          total: 4,
+        });
+        expect(result.isOk()).toBe(true);
+        expectConsumerCrossAttribution(records);
       } finally {
         clearTraceSink();
       }

--- a/packages/core/src/__tests__/fork-ctx.test.ts
+++ b/packages/core/src/__tests__/fork-ctx.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+
+import { forkCtx } from '../internal/fork-ctx';
+import type { CrossFn, FireFn, TrailContext } from '../types';
+
+// Sentinel values — the helper never invokes these, so their shapes are
+// irrelevant. What matters is identity: a forked ctx must either clear
+// them or preserve the exact reference.
+const noopCross = {} as unknown as CrossFn;
+const noopFire = {} as unknown as FireFn;
+const noopResource = {} as unknown as TrailContext['resource'];
+
+describe('forkCtx', () => {
+  test('clears cross, fire, and resource by default', () => {
+    const parent = {
+      cross: noopCross,
+      env: { NODE_ENV: 'test' },
+      extensions: { trailhead: 'cli' },
+      fire: noopFire,
+      logger: undefined,
+      resource: noopResource,
+    };
+
+    const forked = forkCtx(parent, {});
+
+    expect(forked.cross).toBeUndefined();
+    expect(forked.fire).toBeUndefined();
+    expect(forked.resource).toBeUndefined();
+    // Non-reset keys are preserved.
+    expect(forked.env).toEqual({ NODE_ENV: 'test' });
+    expect(forked.extensions).toEqual({ trailhead: 'cli' });
+  });
+
+  test('applies overrides after reset so overrides win', () => {
+    const parent = {
+      cross: noopCross,
+      env: { NODE_ENV: 'test' },
+      extensions: { a: 1 },
+      fire: noopFire,
+      resource: noopResource,
+    };
+
+    const forked = forkCtx(parent, {
+      env: { NODE_ENV: 'prod' },
+      extensions: { b: 2 },
+    });
+
+    expect(forked.env).toEqual({ NODE_ENV: 'prod' });
+    expect(forked.extensions).toEqual({ b: 2 });
+    expect(forked.cross).toBeUndefined();
+    expect(forked.fire).toBeUndefined();
+    expect(forked.resource).toBeUndefined();
+  });
+
+  test('does not mutate the parent context', () => {
+    const parent = {
+      cross: noopCross,
+      fire: noopFire,
+      resource: noopResource,
+    };
+
+    forkCtx(parent, {});
+
+    expect(parent.cross).toBe(noopCross);
+    expect(parent.fire).toBe(noopFire);
+    expect(parent.resource).toBe(noopResource);
+  });
+
+  test('honours a caller-supplied reset list', () => {
+    const parent = {
+      cross: noopCross,
+      fire: noopFire,
+      resource: noopResource,
+    };
+
+    const forked = forkCtx(parent, {}, ['fire']);
+
+    expect(forked.fire).toBeUndefined();
+    // Only `fire` is reset when caller overrides the list.
+    expect(forked.cross).toBe(noopCross);
+    expect(forked.resource).toBe(noopResource);
+  });
+});

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -39,6 +39,7 @@ import {
   createCrossBatchValidationResults,
   normalizeCrossBatchConcurrency,
 } from './internal/cross-batch.js';
+import { forkCtx } from './internal/fork-ctx.js';
 import {
   TRACE_CONTEXT_KEY,
   completeRecord,
@@ -417,14 +418,11 @@ const buildConcurrentBranchContext = (
   target: AnyTrail,
   topo: Topo | undefined,
   branchIndex: number
-): TrailContext => ({
-  ...ctx,
-  cross: undefined,
-  extensions: stripInheritedResourceExtensions(ctx, target, topo),
-  fire: undefined,
-  logger: deriveConcurrentBranchLogger(ctx, target, branchIndex),
-  resource: undefined,
-});
+): TrailContext =>
+  forkCtx(ctx, {
+    extensions: stripInheritedResourceExtensions(ctx, target, topo),
+    logger: deriveConcurrentBranchLogger(ctx, target, branchIndex),
+  });
 
 const executeResolvedCrossTarget = async (
   target: AnyTrail,

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -26,6 +26,7 @@
  */
 
 import { NotFoundError, ValidationError } from './errors.js';
+import { forkCtx } from './internal/fork-ctx.js';
 import { Result } from './result.js';
 import type { Topo } from './topo.js';
 import type { AnyTrail } from './trail.js';
@@ -91,12 +92,11 @@ const deriveConsumerCtx = (
   consumerId: string
 ): MutableConsumerContext =>
   producerCtx
-    ? {
-        ...producerCtx,
+    ? forkCtx(producerCtx as MutableConsumerContext, {
         env: deriveConsumerEnv(producerCtx),
         extensions: deriveConsumerExtensions(producerCtx, signalId),
         logger: deriveConsumerLogger(producerCtx, signalId, consumerId),
-      }
+      })
     : {};
 
 /**

--- a/packages/core/src/internal/fork-ctx.ts
+++ b/packages/core/src/internal/fork-ctx.ts
@@ -1,0 +1,69 @@
+/**
+ * Internal helper for "forking" a trail context.
+ *
+ * Several execution sites need to derive a child context from a parent
+ * context while **resetting** a well-known set of bound closures (`cross`,
+ * `fire`, `resource`). Those closures capture the parent scope, so reusing
+ * them on the child would re-enter execution with the wrong attribution,
+ * the wrong resource scope, or the wrong fan-out identity. The reset list
+ * is the same at every fork site.
+ *
+ * Codifying the reset list in one helper keeps that contract in a single
+ * place. Callers supply the overrides they need (typically `env`,
+ * `extensions`, and `logger`) and let the helper handle the reset.
+ *
+ * This module is internal — do not export it from the package entry point.
+ *
+ * @remarks
+ * The helper is intentionally generic over the concrete context shape. Some
+ * callers work with the fully-resolved `TrailContext` produced inside the
+ * executor; others work with `Partial<TrailContextInit>` during consumer
+ * context derivation in `fire.ts`. Both shapes share the same reset keys.
+ */
+
+import type { TrailContext, TrailContextInit } from '../types.js';
+
+/** Keys cleared by default when forking a context. */
+export type ForkCtxResetKey = 'cross' | 'fire' | 'resource';
+
+/** Override fields callers are allowed to apply when forking a context. */
+export type ForkCtxOverrides = Readonly<
+  Partial<Pick<TrailContext, 'env' | 'extensions' | 'logger'>>
+>;
+
+const DEFAULT_RESET_KEYS: readonly ForkCtxResetKey[] = [
+  'cross',
+  'fire',
+  'resource',
+];
+
+/**
+ * Fork a parent context into a child context.
+ *
+ * Spreads the parent, clears each reset key to `undefined`, and applies the
+ * supplied overrides last so callers may replace logger, env, and extensions
+ * with branch-local values.
+ *
+ * The generic parameter is constrained to the minimal shape the helper
+ * reads and writes. This lets the helper serve both `TrailContext`
+ * (executor scope) and `Partial<TrailContextInit>` (fire-consumer scope)
+ * without widening the public surface of either type.
+ */
+export const forkCtx = <
+  TCtx extends Partial<
+    Pick<
+      TrailContextInit,
+      'cross' | 'env' | 'extensions' | 'fire' | 'logger' | 'resource'
+    >
+  >,
+>(
+  parentCtx: TCtx,
+  overrides: ForkCtxOverrides = {},
+  reset: readonly ForkCtxResetKey[] = DEFAULT_RESET_KEYS
+): TCtx => {
+  const forked: TCtx = { ...parentCtx };
+  for (const key of reset) {
+    forked[key as keyof TCtx] = undefined as TCtx[keyof TCtx];
+  }
+  return { ...forked, ...overrides };
+};


### PR DESCRIPTION
## Summary

Codifies a shared internal `forkCtx` helper in `@ontrails/core` so the two ctx-forking sites in the framework (`buildConcurrentBranchContext` in `execute.ts`, `deriveConsumerCtx` in `fire.ts`) share identical reset semantics by construction. Fixes a latent inheritance bug Devin surfaced during PR #187 review.

Closes [TRL-336](https://linear.app/outfitter/issue/TRL-336).

## The drift

Two sites that build a child context from a parent had drifted apart.

`execute.ts:415-427` (`buildConcurrentBranchContext`, cross-execution path) explicitly cleared `cross: undefined`, `fire: undefined`, `resource: undefined` before layering in per-branch overrides, forcing the bind pipeline to rebind each one for the new branch.

`fire.ts:88-100` (`deriveConsumerCtx`, signal-consumer path) only overrode `env`, `extensions`, `logger`. `cross`, `fire`, and `resource` propagated from the producer via `...producerCtx`. Because `bindCrossToCtx` has an early-return guard when `ctx.cross !== undefined`, signal consumers inherited the producer's cross closure — any `ctx.cross()` call from inside a consumer would have attributed trace spans to the producer, not the consumer.

The immediate impact was latent (no signal consumer currently calls `ctx.cross()`, and `fire` / `resource` get overridden downstream anyway), but the compiler let both shapes compile and a future third forking site could re-introduce the same class of bug.

## The fix

New internal helper at `packages/core/src/internal/fork-ctx.ts` encodes the reset list by construction. Both call sites now route through it, passing only their legitimate overrides (env, extensions, logger). The reset list defaults to `['cross', 'fire', 'resource']` — so any future fork site gets the right semantics for free unless the caller explicitly narrows it.

`bindCrossToCtx`'s early-return guard at `execute.ts:573-580` stays untouched — the guard is correct at the *bind* site. The fix belongs at the *fork* site.

Not exported from the `@ontrails/core` public surface. Internal helper only, zero public API change.

## Verification

- `bun run typecheck` — 31/31 green
- `bun test packages/core` — 807 pass / 0 fail (was 802; +5 new tests)
- `bun run check` — 31/31 green

## Test plan

Five new tests across two files.

`packages/core/src/__tests__/fork-ctx.test.ts` — 4 unit tests: default reset list, overrides win over parent values, parent context is not mutated, custom reset list honored.

`packages/core/src/__tests__/fire.test.ts` — 1 regression test under `describe('per-consumer cross binding')` asserting that a signal consumer calling `ctx.cross(...)` produces a trace where the crossed trail's `parentId` matches the consumer's span, not the producer's. Verified to fail when `deriveConsumerCtx` is reverted to the pre-fix shape.

## Review arc

Single-round Codex review, clean on the first pass.

## Related

- Devin review: https://app.devin.ai/review/outfitter-dev/trails/pull/187
- PR #187 — parallel signal consumer fan-out
- Clark ruling (2026-04-21) on TRL-333/334/335/336 — codify the pattern, don't invent a new primitive