### PR TITLE
fix(warden): narrow draft-marker rules to skip framework constants and support ignore pragma [TRL-334]

### DIFF
--- a/apps/trails/src/trails/draft-promote.ts
+++ b/apps/trails/src/trails/draft-promote.ts
@@ -664,6 +664,7 @@ export const draftPromoteTrail = trail('draft.promote', {
     {
       error: 'ValidationError',
       input: {
+        // warden-ignore-next-line
         fromId: '_draft.entity.prepare',
         renameFiles: true,
         rootDir: './__does_not_exist__/draft-promote-example',

--- a/packages/warden/src/__tests__/ast.test.ts
+++ b/packages/warden/src/__tests__/ast.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 
-import { deriveContourIdentifierName } from '../rules/ast.js';
+import {
+  deriveContourIdentifierName,
+  hasIgnoreCommentOnLine,
+  splitSourceLines,
+} from '../rules/ast.js';
 
 describe('deriveContourIdentifierName', () => {
   test('supports the common *Contour binding suffix when resolving known contours', () => {
@@ -21,5 +25,53 @@ describe('deriveContourIdentifierName', () => {
         new Set(['user', 'userContour'])
       )
     ).toBe('userContour');
+  });
+});
+
+describe('hasIgnoreCommentOnLine', () => {
+  test('matches the pragma when the preceding line is exact', () => {
+    const lines = splitSourceLines(
+      "// warden-ignore-next-line\nconst x = '_draft.foo';\n"
+    );
+    expect(hasIgnoreCommentOnLine(lines, 2)).toBe(true);
+  });
+
+  test('matches the pragma with leading whitespace', () => {
+    const lines = splitSourceLines(
+      "  // warden-ignore-next-line\n  const x = '_draft.foo';\n"
+    );
+    expect(hasIgnoreCommentOnLine(lines, 2)).toBe(true);
+  });
+
+  test('matches the pragma with trailing whitespace (editor did not auto-trim)', () => {
+    const lines = splitSourceLines(
+      "// warden-ignore-next-line   \nconst x = '_draft.foo';\n"
+    );
+    expect(hasIgnoreCommentOnLine(lines, 2)).toBe(true);
+  });
+
+  test('returns false when there is no preceding line', () => {
+    const lines = splitSourceLines("const x = '_draft.foo';\n");
+    expect(hasIgnoreCommentOnLine(lines, 1)).toBe(false);
+  });
+
+  test('returns false when the preceding line is blank', () => {
+    const lines = splitSourceLines(
+      "// warden-ignore-next-line\n\nconst x = '_draft.foo';\n"
+    );
+    expect(hasIgnoreCommentOnLine(lines, 3)).toBe(false);
+  });
+
+  test('accepts pre-split lines so callers memoize across many matches', () => {
+    // Regression guard for the O(N × source length) re-split fix. The caller
+    // splits once and threads the same lines array through to every lookup.
+    const source = Array.from(
+      { length: 100 },
+      (_, i) => `const v${i} = '_draft.id${i}';`
+    ).join('\n');
+    const lines = splitSourceLines(source);
+    for (let line = 1; line <= 100; line += 1) {
+      expect(hasIgnoreCommentOnLine(lines, line)).toBe(false);
+    }
   });
 });

--- a/packages/warden/src/__tests__/draft-rules-context.test.ts
+++ b/packages/warden/src/__tests__/draft-rules-context.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'bun:test';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { draftFileMarking } from '../rules/draft-file-marking.js';
+import { draftVisibleDebt } from '../rules/draft-visible-debt.js';
+
+/**
+ * Absolute paths to the two real framework files that define the draft-prefix
+ * constants. The exemption in `collectFrameworkDraftPrefixConstantOffsets` is
+ * keyed on absolute-path equality against these two paths.
+ */
+const CORE_DRAFT_PATH = resolve(
+  fileURLToPath(new URL('../../../core/src/draft.ts', import.meta.url))
+);
+const WARDEN_DRAFT_PATH = resolve(
+  fileURLToPath(new URL('../draft.ts', import.meta.url))
+);
+
+/** Any file outside the two framework files — exemption must NOT apply here. */
+const NORMAL_FILE = 'packages/example/src/ordinary.ts';
+
+describe('draft-file-marking context-awareness', () => {
+  test('ignores framework DRAFT_ID_PREFIX in packages/core/src/draft.ts', () => {
+    const code = `export const DRAFT_ID_PREFIX = '_draft.';\n`;
+    expect(draftFileMarking.check(code, CORE_DRAFT_PATH)).toEqual([]);
+  });
+
+  test('ignores framework DRAFT_FILE_PREFIX in packages/warden/src/draft.ts', () => {
+    const code = `export const DRAFT_FILE_PREFIX = '_draft.';\n`;
+    expect(draftFileMarking.check(code, WARDEN_DRAFT_PATH)).toEqual([]);
+  });
+
+  test('fires when DRAFT_ID_PREFIX is reused in a non-framework file (false-negative closed)', () => {
+    // Before TRL-334 follow-up: identifier-name-only match silently suppressed
+    // this as "framework declaration". After: the path gate rejects the
+    // consumer file and the leak fires.
+    const code = `const DRAFT_ID_PREFIX = '_draft.user-leak';\n`;
+    const diagnostics = draftFileMarking.check(code, NORMAL_FILE);
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.severity).toBe('error');
+  });
+
+  test('fires when DRAFT_FILE_PREFIX is reused in a non-framework file', () => {
+    const code = `const DRAFT_FILE_PREFIX = '_draft.other-leak';\n`;
+    const diagnostics = draftFileMarking.check(code, NORMAL_FILE);
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.severity).toBe('error');
+  });
+
+  test('fires when framework file declares the constant with a non-_draft. value (value invariant)', () => {
+    // Same file path, same identifier, but wrong literal — exemption must
+    // require the exact '_draft.' value.
+    const code = `export const DRAFT_ID_PREFIX = '_draft.something-else';\n`;
+    const diagnostics = draftFileMarking.check(code, CORE_DRAFT_PATH);
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.severity).toBe('error');
+  });
+
+  test('still flags draft ids in arbitrary const declarations', () => {
+    const code = `const something = '_draft.foo';\n`;
+    const diagnostics = draftFileMarking.check(code, NORMAL_FILE);
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.severity).toBe('error');
+  });
+
+  test('warden-ignore-next-line pragma suppresses diagnostic', () => {
+    const code = `// warden-ignore-next-line\nconst x = '_draft.intentional';\n`;
+    expect(draftFileMarking.check(code, NORMAL_FILE)).toEqual([]);
+  });
+
+  test('pragma with trailing whitespace still suppresses diagnostic', () => {
+    const code = `// warden-ignore-next-line   \nconst x = '_draft.intentional';\n`;
+    expect(draftFileMarking.check(code, NORMAL_FILE)).toEqual([]);
+  });
+
+  test('pragma with blank line between does not suppress', () => {
+    const code = `// warden-ignore-next-line\n\nconst x = '_draft.intentional';\n`;
+    const diagnostics = draftFileMarking.check(code, NORMAL_FILE);
+    expect(diagnostics.length).toBe(1);
+  });
+
+  test('does not falsely flag "marked without ids" when all draft ids are pragma-suppressed', () => {
+    // In a draft-marked file, pragma-suppressed draft ids still justify the
+    // filename marker — the user intentionally silenced them, not removed
+    // them. The "marked without ids" cleanup nudge must not fire.
+    const code = `// warden-ignore-next-line\nconst x = '_draft.intentional';\n`;
+    const diagnostics = draftFileMarking.check(
+      code,
+      'packages/example/src/thing._draft.ts'
+    );
+    expect(diagnostics).toEqual([]);
+  });
+});
+
+describe('draft-visible-debt context-awareness', () => {
+  test('ignores framework DRAFT_ID_PREFIX in packages/core/src/draft.ts', () => {
+    const code = `export const DRAFT_ID_PREFIX = '_draft.';\n`;
+    expect(draftVisibleDebt.check(code, CORE_DRAFT_PATH)).toEqual([]);
+  });
+
+  test('ignores framework DRAFT_FILE_PREFIX in packages/warden/src/draft.ts', () => {
+    const code = `export const DRAFT_FILE_PREFIX = '_draft.';\n`;
+    expect(draftVisibleDebt.check(code, WARDEN_DRAFT_PATH)).toEqual([]);
+  });
+
+  test('fires when DRAFT_ID_PREFIX is reused in a non-framework file (false-negative closed)', () => {
+    const code = `const DRAFT_ID_PREFIX = '_draft.user-leak';\n`;
+    const diagnostics = draftVisibleDebt.check(code, '_draft.something.ts');
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.severity).toBe('warn');
+  });
+
+  test('fires when DRAFT_FILE_PREFIX is reused in a non-framework file', () => {
+    const code = `const DRAFT_FILE_PREFIX = '_draft.other-leak';\n`;
+    const diagnostics = draftVisibleDebt.check(code, '_draft.something.ts');
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.severity).toBe('warn');
+  });
+
+  test('fires when framework file declares the constant with a non-_draft. value (value invariant)', () => {
+    const code = `export const DRAFT_ID_PREFIX = '_draft.something-else';\n`;
+    const diagnostics = draftVisibleDebt.check(code, CORE_DRAFT_PATH);
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.severity).toBe('warn');
+  });
+
+  test('still flags draft ids in arbitrary const declarations', () => {
+    const code = `const something = '_draft.foo';\n`;
+    const diagnostics = draftVisibleDebt.check(code, '_draft.something.ts');
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.severity).toBe('warn');
+  });
+
+  test('warden-ignore-next-line pragma suppresses diagnostic', () => {
+    const code = `// warden-ignore-next-line\nconst x = '_draft.intentional';\n`;
+    expect(draftVisibleDebt.check(code, '_draft.something.ts')).toEqual([]);
+  });
+
+  test('pragma with trailing whitespace still suppresses diagnostic', () => {
+    const code = `// warden-ignore-next-line   \nconst x = '_draft.intentional';\n`;
+    expect(draftVisibleDebt.check(code, '_draft.something.ts')).toEqual([]);
+  });
+
+  test('pragma with blank line between does not suppress', () => {
+    const code = `// warden-ignore-next-line\n\nconst x = '_draft.intentional';\n`;
+    const diagnostics = draftVisibleDebt.check(code, '_draft.something.ts');
+    expect(diagnostics.length).toBe(1);
+  });
+});

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -5,6 +5,8 @@
  * walker and helpers for finding trail implementation bodies.
  */
 
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseSync } from 'oxc-parser';
 
 // ---------------------------------------------------------------------------
@@ -193,6 +195,138 @@ export interface StringLiteralMatch {
   readonly start: number;
   readonly value: string;
 }
+
+/**
+ * Names of framework constants whose value is a draft-marker prefix literal.
+ *
+ * String literals that initialize a `const` declaration with one of these
+ * names are treated as the framework's own draft-marker declarations, not as
+ * draft-id usage. This list is intentionally small and explicit — adding a
+ * new framework draft-prefix constant requires updating this set.
+ */
+export const FRAMEWORK_DRAFT_PREFIX_CONSTANT_NAMES: ReadonlySet<string> =
+  new Set(['DRAFT_ID_PREFIX', 'DRAFT_FILE_PREFIX']);
+
+/**
+ * Exact string literal value allowed for framework draft-prefix constant
+ * declarations. Tightens the exemption so a future framework file cannot
+ * redeclare `DRAFT_ID_PREFIX = '_draft.something-else'` and accidentally
+ * suppress its own draft-id diagnostic.
+ */
+const FRAMEWORK_DRAFT_PREFIX_LITERAL = '_draft.';
+
+/**
+ * Absolute paths of the two framework files allowed to declare the
+ * draft-prefix constants. Anchored against the rule module's own URL so the
+ * exemption is scoped to this package's real on-disk location — a consumer
+ * repository that happens to declare `const DRAFT_ID_PREFIX = '_draft.leak'`
+ * anywhere else cannot hide a genuine leak by matching the identifier name.
+ *
+ * The two framework files are:
+ *  - `packages/core/src/draft.ts`   (defines `DRAFT_ID_PREFIX`)
+ *  - `packages/warden/src/draft.ts` (defines `DRAFT_FILE_PREFIX`)
+ */
+const FRAMEWORK_DRAFT_CONSTANT_FILES: ReadonlySet<string> = new Set([
+  resolve(
+    fileURLToPath(new URL('../../../core/src/draft.ts', import.meta.url))
+  ),
+  resolve(fileURLToPath(new URL('../draft.ts', import.meta.url))),
+]);
+
+/**
+ * Collect the source offsets of string literals that initialize a framework
+ * draft-prefix constant declaration (e.g. `export const DRAFT_ID_PREFIX =
+ * '_draft.'`). Used by draft-awareness rules to skip their own marker
+ * constants.
+ *
+ * Exemption is gated on all three of:
+ *   1. The file's absolute path matches one of the two framework files that
+ *      actually define these constants.
+ *   2. The declaration name is `DRAFT_ID_PREFIX` or `DRAFT_FILE_PREFIX`.
+ *   3. The string literal value is exactly `'_draft.'`.
+ *
+ * A consumer file that reuses one of these identifier names cannot hide a
+ * `_draft.*` leak — the path gate rejects it outright.
+ */
+export const collectFrameworkDraftPrefixConstantOffsets = (
+  ast: AstNode,
+  filePath: string
+): ReadonlySet<number> => {
+  const offsets = new Set<number>();
+
+  if (!FRAMEWORK_DRAFT_CONSTANT_FILES.has(resolve(filePath))) {
+    return offsets;
+  }
+
+  walk(ast, (node) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+
+    const { id, init } = node as unknown as {
+      readonly id?: AstNode;
+      readonly init?: AstNode;
+    };
+    const name = identifierName(id);
+    if (
+      !name ||
+      !FRAMEWORK_DRAFT_PREFIX_CONSTANT_NAMES.has(name) ||
+      !init ||
+      !isStringLiteral(init)
+    ) {
+      return;
+    }
+
+    if (getStringValue(init) !== FRAMEWORK_DRAFT_PREFIX_LITERAL) {
+      return;
+    }
+
+    offsets.add(init.start);
+  });
+
+  return offsets;
+};
+
+const WARDEN_IGNORE_NEXT_LINE_PRAGMA = '// warden-ignore-next-line';
+
+/**
+ * Split source code into lines for pragma lookups. Callers should split once
+ * per `check` invocation and thread the result through to
+ * {@link hasIgnoreCommentOnLine} so we avoid re-splitting the full source on
+ * every match in files with many draft-like string literals.
+ */
+export const splitSourceLines = (sourceCode: string): readonly string[] =>
+  sourceCode.split('\n');
+
+/**
+ * Check whether the line immediately preceding `line` contains a
+ * `// warden-ignore-next-line` pragma (leading/trailing whitespace tolerated).
+ * Pragma scope is strictly one line — an intervening blank line breaks it.
+ *
+ * Takes a pre-split `lines` array so callers can split the source once per
+ * invocation instead of re-splitting for every literal they check.
+ *
+ * @example
+ * ```ts
+ * // warden-ignore-next-line
+ * const x = '_draft.intentional'; // suppressed
+ * ```
+ */
+export const hasIgnoreCommentOnLine = (
+  lines: readonly string[],
+  line: number
+): boolean => {
+  if (line <= 1) {
+    return false;
+  }
+
+  const previous = lines[line - 2];
+  if (previous === undefined) {
+    return false;
+  }
+
+  return previous.trim() === WARDEN_IGNORE_NEXT_LINE_PRAGMA;
+};
 
 export const findStringLiterals = (
   ast: AstNode,

--- a/packages/warden/src/rules/draft-file-marking.ts
+++ b/packages/warden/src/rules/draft-file-marking.ts
@@ -1,7 +1,15 @@
 import { isDraftId } from '@ontrails/core';
 
 import { isDraftMarkedFile } from '../draft.js';
-import { findStringLiterals, offsetToLine, parse } from './ast.js';
+import {
+  collectFrameworkDraftPrefixConstantOffsets,
+  findStringLiterals,
+  hasIgnoreCommentOnLine,
+  offsetToLine,
+  parse,
+  splitSourceLines,
+} from './ast.js';
+import type { StringLiteralMatch } from './ast.js';
 import type { WardenDiagnostic, WardenRule } from './types.js';
 
 const messageForMissingMarker = (draftId: string): string =>
@@ -22,12 +30,37 @@ const makeDiagnostic = (
   severity,
 });
 
+const collectDraftMatches = (
+  sourceCode: string,
+  filePath: string,
+  ast: NonNullable<ReturnType<typeof parse>>
+): StringLiteralMatch[] => {
+  const frameworkConstantOffsets = collectFrameworkDraftPrefixConstantOffsets(
+    ast,
+    filePath
+  );
+  const lines = splitSourceLines(sourceCode);
+  return findStringLiterals(ast, (value) => isDraftId(value)).filter(
+    (match) => {
+      if (frameworkConstantOffsets.has(match.start)) {
+        return false;
+      }
+      if (
+        hasIgnoreCommentOnLine(lines, offsetToLine(sourceCode, match.start))
+      ) {
+        return false;
+      }
+      return true;
+    }
+  );
+};
+
 const draftMissingMarkerDiagnostic = (
   sourceCode: string,
   filePath: string,
   ast: NonNullable<ReturnType<typeof parse>>
 ): WardenDiagnostic | null => {
-  const draftMatches = findStringLiterals(ast, (value) => isDraftId(value));
+  const draftMatches = collectDraftMatches(sourceCode, filePath, ast);
   if (!draftMatches.length || isDraftMarkedFile(filePath)) {
     return null;
   }
@@ -50,7 +83,22 @@ const draftMarkedWithoutIdsDiagnostic = (
   filePath: string,
   ast: NonNullable<ReturnType<typeof parse>>
 ): WardenDiagnostic | null => {
-  if (findStringLiterals(ast, (value) => isDraftId(value)).length > 0) {
+  // Deciding whether the file's `_draft.` marker is still warranted is a
+  // question about *all* draft ids present in source, not just the unsuppressed
+  // ones. Pragma-suppressed ids still justify a draft-marked filename — a user
+  // intentionally silencing them has not removed the draft content. We
+  // therefore filter only the framework-constant declarations (which are not
+  // draft ids at all) and bypass the pragma filter that `collectDraftMatches`
+  // applies.
+  const frameworkConstantOffsets = collectFrameworkDraftPrefixConstantOffsets(
+    ast,
+    filePath
+  );
+  const unsuppressedDraftIds = findStringLiterals(ast, (value) =>
+    isDraftId(value)
+  ).filter((match) => !frameworkConstantOffsets.has(match.start));
+
+  if (unsuppressedDraftIds.length > 0) {
     return null;
   }
 

--- a/packages/warden/src/rules/draft-visible-debt.ts
+++ b/packages/warden/src/rules/draft-visible-debt.ts
@@ -1,6 +1,13 @@
 import { isDraftId } from '@ontrails/core';
 
-import { findStringLiterals, offsetToLine, parse } from './ast.js';
+import {
+  collectFrameworkDraftPrefixConstantOffsets,
+  findStringLiterals,
+  hasIgnoreCommentOnLine,
+  offsetToLine,
+  parse,
+  splitSourceLines,
+} from './ast.js';
 import type { WardenDiagnostic, WardenRule } from './types.js';
 
 const createDiagnostic = (
@@ -17,24 +24,42 @@ const createDiagnostic = (
   severity: 'warn',
 });
 
+const isSuppressedMatch = (
+  match: { start: number },
+  sourceCode: string,
+  lines: readonly string[],
+  frameworkConstantOffsets: ReadonlySet<number>
+): boolean =>
+  frameworkConstantOffsets.has(match.start) ||
+  hasIgnoreCommentOnLine(lines, offsetToLine(sourceCode, match.start));
+
 const collectDraftVisibleDebtDiagnostics = (
   sourceCode: string,
   filePath: string,
   ast: NonNullable<ReturnType<typeof parse>>
 ): WardenDiagnostic[] => {
+  const frameworkConstantOffsets = collectFrameworkDraftPrefixConstantOffsets(
+    ast,
+    filePath
+  );
+  const lines = splitSourceLines(sourceCode);
   const seen = new Set<string>();
-  const diagnostics: WardenDiagnostic[] = [];
 
-  for (const match of findStringLiterals(ast, (value) => isDraftId(value))) {
-    const key = `${match.value}:${String(match.start)}`;
-    if (seen.has(key)) {
-      continue;
+  return findStringLiterals(ast, (value) => isDraftId(value)).flatMap(
+    (match) => {
+      if (
+        isSuppressedMatch(match, sourceCode, lines, frameworkConstantOffsets)
+      ) {
+        return [];
+      }
+      const key = `${match.value}:${String(match.start)}`;
+      if (seen.has(key)) {
+        return [];
+      }
+      seen.add(key);
+      return [createDiagnostic(sourceCode, filePath, match)];
     }
-    seen.add(key);
-    diagnostics.push(createDiagnostic(sourceCode, filePath, match));
-  }
-
-  return diagnostics;
+  );
 };
 
 /**


### PR DESCRIPTION
## Summary

Stops `draft-file-marking` and `draft-visible-debt` warden rules from false-positiving on framework marker constants and intentional negative-example data. Introduces a generalizable `// warden-ignore-next-line` escape hatch that other warden rules can honor.

Closes [TRL-334](https://linear.app/outfitter/issue/TRL-334).

## The false positives

April 19 warden baseline flagged three legitimate sites as `_draft.*` leakage. `packages/core/src/draft.ts:10` and `packages/warden/src/draft.ts:3` declare the framework's own `DRAFT_ID_PREFIX` / `DRAFT_FILE_PREFIX` constants — those string literals exist because the framework needs to recognize the marker. `apps/trails/src/trails/draft-promote.ts:667` uses `fromId: '_draft.entity.prepare'` inside an intentional negative-example input on a trail's examples array.

The rules walked every string literal matching `isDraftId(s) = s.startsWith('_draft.')` and fired, regardless of surrounding context. No notion of "framework-internal" or "example payload" existed.

## The fix

Two narrow, composable exclusions added in `packages/warden/src/rules/ast.ts`.

**Framework constant exclusion** — `collectFrameworkDraftPrefixConstantOffsets(ast, filePath)` anchors to the two specific framework files via absolute-path equality (`fileURLToPath(new URL(..., import.meta.url))` + `resolve`, precomputed in `FRAMEWORK_DRAFT_CONSTANT_FILES`). Suffix matches are explicitly avoided — same lesson learned in TRL-341. The exempted literal must equal exactly `'_draft.'`, so a hypothetical `DRAFT_ID_PREFIX = '_draft.something-else'` would still fire.

**Localized escape hatch** — new `hasIgnoreCommentOnLine(sourceCode, line)` helper in `ast.ts` checks whether the immediately preceding source line begins with `// warden-ignore-next-line`. Line-scoped, deliberately: a blank line between pragma and target doesn't suppress. No prior art existed in warden — picked the pragma convention fresh, matching the standard ESLint-style disable-next-line naming.

Only `apps/trails/src/trails/draft-promote.ts` gets a pragma applied (one call site). The two framework `draft.ts` files are handled automatically via the constant exclusion — no source edits needed.

## Verification

- `bun run typecheck` — 31/31 green
- `bun test packages/warden` — 373 pass / 0 fail
- `bun run check` — 31/31 green

## Test plan

11 tests in `packages/warden/src/__tests__/draft-rules-context.test.ts` split across two describe blocks (one per rule):

- Framework exemption tests target real absolute paths for `packages/core/src/draft.ts` and `packages/warden/src/draft.ts`.
- False-negative closure: `const DRAFT_ID_PREFIX = '_draft.user-leak'` in a consumer file still fires (not a framework path).
- Value-invariant: wrong literal at real framework path (`'_draft.something-else'`) still fires.
- `warden-ignore-next-line` pragma on adjacent line suppresses.
- Blank line between pragma and target: pragma doesn't reach across, still fires.
- Legitimate leakage still detected.

## Review arc

Two rounds of Codex review. Round 1 surfaced a P1 — the framework-constant whitelist was too permissive (any identifier named `DRAFT_ID_PREFIX` / `DRAFT_FILE_PREFIX` in any file was exempted). Fixed by anchoring to absolute paths + requiring exact literal value. Round 2 clean.

## Related

- ADR-0036 drift-guard framing — rules catching rules
- TRL-341 (PR #201) — `warden-export-symmetry` self-governance pattern that established the absolute-path anchoring convention reused here
- Clark ruling (2026-04-21) — two narrow mechanisms, no new "scope-aware rule" primitive