### PR TITLE
fix(warden): follow local imports in implementation-returns-result [TRL-333]

### DIFF
--- a/packages/warden/src/__tests__/implementation-returns-result.test.ts
+++ b/packages/warden/src/__tests__/implementation-returns-result.test.ts
@@ -1,8 +1,44 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, spyOn, test } from 'bun:test';
+import * as nodeFs from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { implementationReturnsResult } from '../rules/implementation-returns-result.js';
+import {
+  clearImplementationReturnsResultCache,
+  implementationReturnsResult,
+} from '../rules/implementation-returns-result.js';
 
 const TEST_FILE = 'test.ts';
+
+const writeReadCountFixture = (
+  writeFile: (name: string, content: string) => string
+): { readonly implPath: string; readonly caller: string } => {
+  const implPath = writeFile(
+    'impl-readcount.ts',
+    `const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+
+export default helper;
+`
+  );
+  writeFile(
+    'barrel-readcount.ts',
+    `export { default as foo } from './impl-readcount.js';
+`
+  );
+  const caller = writeFile(
+    'caller-readcount.ts',
+    `import { foo } from './barrel-readcount.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return foo();
+  }
+})`
+  );
+  return { caller, implPath };
+};
 
 describe('implementation-returns-result', () => {
   test('flags raw object return in trail implementation', () => {
@@ -102,6 +138,454 @@ trail("entity.list", {
 
     expect(diagnostics.length).toBe(1);
     expect(diagnostics[0]?.message).toContain('entity.list');
+  });
+
+  describe('imported helpers', () => {
+    let tmpDir: string;
+
+    beforeAll(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'warden-impl-result-'));
+    });
+
+    afterAll(() => {
+      rmSync(tmpDir, { force: true, recursive: true });
+    });
+
+    const writeFile = (name: string, content: string): string => {
+      const path = join(tmpDir, name);
+      writeFileSync(path, content);
+      return path;
+    };
+
+    test('allows imported helper with Promise<Result<...>> return annotation', () => {
+      writeFile(
+        'result-helper.ts',
+        `export const buildReport = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+      );
+      const caller = writeFile(
+        'caller.ts',
+        `import { buildReport } from './result-helper.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return buildReport();
+  }
+})`
+      );
+
+      const diagnostics = implementationReturnsResult.check(
+        readFileSync(caller, 'utf8'),
+        caller
+      );
+
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('flags imported helper without Result return annotation', () => {
+      writeFile(
+        'plain-helper.ts',
+        `export const buildReport = async () => ({ ok: true });
+`
+      );
+      const caller = writeFile(
+        'caller-plain.ts',
+        `import { buildReport } from './plain-helper.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return buildReport();
+  }
+})`
+      );
+
+      const diagnostics = implementationReturnsResult.check(
+        readFileSync(caller, 'utf8'),
+        caller
+      );
+
+      expect(diagnostics.length).toBe(1);
+    });
+
+    test('flags helper imported from bare specifier (node_modules)', () => {
+      const caller = writeFile(
+        'caller-bare.ts',
+        `import { buildReport } from 'some-package';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return buildReport();
+  }
+})`
+      );
+
+      const diagnostics = implementationReturnsResult.check(
+        readFileSync(caller, 'utf8'),
+        caller
+      );
+
+      expect(diagnostics.length).toBe(1);
+    });
+
+    test('flags gracefully when target file is unreadable', () => {
+      const caller = writeFile(
+        'caller-missing.ts',
+        `import { buildReport } from './does-not-exist.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return buildReport();
+  }
+})`
+      );
+
+      const diagnostics = implementationReturnsResult.check(
+        readFileSync(caller, 'utf8'),
+        caller
+      );
+
+      expect(diagnostics.length).toBe(1);
+    });
+
+    describe('specifier re-exports', () => {
+      test('allows specifier re-export with source (export { helper } from ...)', () => {
+        writeFile(
+          'impl-specifier.ts',
+          `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+        );
+        writeFile(
+          'barrel-specifier.ts',
+          `export { helper } from './impl-specifier.js';
+`
+        );
+        const caller = writeFile(
+          'caller-specifier.ts',
+          `import { helper } from './barrel-specifier.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return helper();
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(0);
+      });
+
+      test('allows aliased specifier re-export (export { helper as aliased })', () => {
+        writeFile(
+          'impl-aliased.ts',
+          `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+        );
+        writeFile(
+          'barrel-aliased.ts',
+          `export { helper as aliased } from './impl-aliased.js';
+`
+        );
+        const caller = writeFile(
+          'caller-aliased.ts',
+          `import { aliased } from './barrel-aliased.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return aliased();
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(0);
+      });
+
+      test('allows specifier re-export without source (same-file)', () => {
+        writeFile(
+          'barrel-samefile.ts',
+          `const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+
+export { helper };
+`
+        );
+        const caller = writeFile(
+          'caller-samefile.ts',
+          `import { helper } from './barrel-samefile.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return helper();
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(0);
+      });
+
+      test('allows default re-export (export { default as foo } from ...)', () => {
+        writeFile(
+          'impl-default.ts',
+          `const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+
+export default helper;
+`
+        );
+        writeFile(
+          'barrel-default.ts',
+          `export { default as foo } from './impl-default.js';
+`
+        );
+        const caller = writeFile(
+          'caller-default.ts',
+          `import { foo } from './barrel-default.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return foo();
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(0);
+      });
+
+      test('reads the re-export target file only once per check (default specifier)', () => {
+        // Regression for PR #204: `export { default as foo } from './impl.js'`
+        // previously triggered two reads/parses of impl.js within a single
+        // check() call — once via the downstream-names walk and once for the
+        // default-specifier AST lookup. The loaded target is now threaded
+        // through, so impl.js should be read exactly once.
+        const { implPath, caller } = writeReadCountFixture(writeFile);
+
+        clearImplementationReturnsResultCache();
+        const readSpy = spyOn(nodeFs, 'readFileSync');
+
+        try {
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+          expect(diagnostics.length).toBe(0);
+          const implReads = readSpy.mock.calls.filter(
+            (call) => call[0] === implPath
+          );
+          expect(implReads.length).toBe(1);
+        } finally {
+          readSpy.mockRestore();
+        }
+      });
+
+      test('caps re-export chains beyond one transitive hop', () => {
+        // A -> B -> C: caller imports from A, which re-exports from B,
+        // which re-exports from C where the helper is declared. The
+        // MAX_RERESOLVE_DEPTH=1 cap should prevent resolving C, so the
+        // helper name is NOT recognized through the 2-hop chain.
+        writeFile(
+          'depth-c.ts',
+          `export const deepHelper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+        );
+        writeFile(
+          'depth-b.ts',
+          `export { deepHelper } from './depth-c.js';
+`
+        );
+        writeFile(
+          'depth-a.ts',
+          `export { deepHelper } from './depth-b.js';
+`
+        );
+        const caller = writeFile(
+          'caller-depth.ts',
+          `import { deepHelper } from './depth-a.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return deepHelper();
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        // 2-hop re-export chain exceeds MAX_RERESOLVE_DEPTH, so the helper's
+        // Result annotation is not discoverable and the return is flagged.
+        expect(diagnostics.length).toBe(1);
+      });
+
+      test('cache does not bleed cycle-truncated results into direct imports', () => {
+        // A -> B -> A cycle. When A is resolved first (e.g. through a caller
+        // that imports from A), resolving B is attempted while A is in the
+        // visited set, which truncates B's transitive view back to A. A naive
+        // per-target cache would then persist an empty set for B and wrongly
+        // flag a later direct import from B.
+        writeFile(
+          'ctx-a.ts',
+          `export { helper } from './ctx-b.js';
+`
+        );
+        writeFile(
+          'ctx-b.ts',
+          `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+
+export { helper as aliasedFromA } from './ctx-a.js';
+`
+        );
+        const callerA = writeFile(
+          'caller-ctx-a.ts',
+          `import { helper } from './ctx-a.js';
+
+trail("entity.first", {
+  blaze: async (input, ctx) => {
+    return helper();
+  }
+})`
+        );
+        const callerB = writeFile(
+          'caller-ctx-b.ts',
+          `import { helper } from './ctx-b.js';
+
+trail("entity.second", {
+  blaze: async (input, ctx) => {
+    return helper();
+  }
+})`
+        );
+
+        // Resolve A first — this walks A -> B (and B -> A is cycle-guarded).
+        implementationReturnsResult.check(
+          readFileSync(callerA, 'utf8'),
+          callerA
+        );
+
+        // Now resolve B directly. B's own inline helper must still be
+        // recognized as Result-returning, even though an earlier transitive
+        // walk touched B under a non-empty parentVisited.
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(callerB, 'utf8'),
+          callerB
+        );
+
+        expect(diagnostics.length).toBe(0);
+      });
+
+      test('allows default-imported Result helper (import foo from ...)', () => {
+        writeFile(
+          'impl-default-import.ts',
+          `const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+
+export default helper;
+`
+        );
+        const caller = writeFile(
+          'caller-default-import.ts',
+          `import buildReport from './impl-default-import.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return buildReport();
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(0);
+      });
+
+      test('still flags namespace-imported Result helper (documented gap)', () => {
+        // `import * as ns from './foo.js'` with `ns.helper(...)` is not yet
+        // resolved — the binding is `ns`, not `helper`, so the member call is
+        // unrecognized. Documented skip in buildImportBinding.
+        writeFile(
+          'impl-namespace.ts',
+          `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+        );
+        const caller = writeFile(
+          'caller-namespace.ts',
+          `import * as ns from './impl-namespace.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return ns.helper();
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(1);
+      });
+
+      test('falls back gracefully on re-export cycle', () => {
+        writeFile(
+          'cycle-a.ts',
+          `export { helper } from './cycle-b.js';
+`
+        );
+        writeFile(
+          'cycle-b.ts',
+          `export { helper } from './cycle-a.js';
+`
+        );
+        const caller = writeFile(
+          'caller-cycle.ts',
+          `import { helper } from './cycle-a.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return helper();
+  }
+})`
+        );
+
+        // Should not hang. Since the helper's annotation cannot be resolved
+        // through the cycle, it falls back to flagging the return as non-Result.
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(1);
+      });
+    });
   });
 
   test('allows returning explicitly Result-typed local helpers', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -20,6 +20,9 @@ export type {
 // Rule registry
 export { wardenRules, wardenTopoRules } from './rules/index.js';
 
+// Rule-scoped cache controls for long-lived consumers (watch mode, LSPs).
+export { clearImplementationReturnsResultCache } from './rules/implementation-returns-result.js';
+
 // CLI runner
 export type { WardenOptions, WardenReport } from './cli.js';
 export { formatWardenReport, runWarden } from './cli.js';

--- a/packages/warden/src/rules/implementation-returns-result.ts
+++ b/packages/warden/src/rules/implementation-returns-result.ts
@@ -6,6 +6,8 @@
  * or a tracked Result-typed variable.
  */
 
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
 import {
   findBlazeBodies,
   findTrailDefinitions,
@@ -309,6 +311,808 @@ const collectResultHelperNames = (
 };
 
 // ---------------------------------------------------------------------------
+// Imported Result helper resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-target-file cache of exported Result-helper names keyed by the absolute
+ * target path. Saves re-parsing when multiple rule invocations resolve the
+ * same file during a single warden run.
+ *
+ * @remarks
+ * Long-running processes calling `implementationReturnsResult.check` after
+ * source files change (e.g. watch mode, editor language servers) should call
+ * `clearImplementationReturnsResultCache()` between runs to avoid returning
+ * stale helper-name sets. The cache is intentionally not auto-invalidated per
+ * invocation — that would defeat its purpose within a single warden run.
+ */
+const targetFileResultExportCache = new Map<string, ReadonlySet<string>>();
+
+/**
+ * Clear the module-level cache used by the `implementation-returns-result`
+ * rule to remember which exported names on a target file carry a `Result<...>`
+ * return annotation.
+ *
+ * Call this between runs in long-lived processes where the set of Trails
+ * source files may have changed on disk since the last check.
+ */
+export const clearImplementationReturnsResultCache = (): void => {
+  targetFileResultExportCache.clear();
+};
+
+interface ImportBinding {
+  /** Local alias used in the importing file. */
+  readonly localName: string;
+  /** Original exported name from the target module. */
+  readonly importedName: string;
+  /** Raw import source specifier (e.g. './foo.js'). */
+  readonly source: string;
+}
+
+const getImportSourceValue = (node: AstNode): string | null => {
+  const sourceNode = (node as unknown as { source?: AstNode }).source;
+  const sourceValue = sourceNode
+    ? (sourceNode as unknown as { value?: unknown }).value
+    : undefined;
+  return typeof sourceValue === 'string' ? sourceValue : null;
+};
+
+const extractIdentifierName = (node: AstNode | undefined): string | null =>
+  node?.type === 'Identifier'
+    ? ((node as unknown as { name: string }).name ?? null)
+    : null;
+
+const buildDefaultImportBinding = (
+  specifier: AstNode,
+  source: string
+): ImportBinding | null => {
+  const { local } = specifier as unknown as { local?: AstNode };
+  const localName = extractIdentifierName(local);
+  if (!localName) {
+    return null;
+  }
+  return { importedName: 'default', localName, source };
+};
+
+const buildNamedImportBinding = (
+  specifier: AstNode,
+  source: string
+): ImportBinding | null => {
+  const { local, imported } = specifier as unknown as {
+    local?: AstNode;
+    imported?: AstNode;
+  };
+  const localName = extractIdentifierName(local);
+  const importedName = extractIdentifierName(imported) ?? localName;
+  if (!(localName && importedName)) {
+    return null;
+  }
+  return { importedName, localName, source };
+};
+
+/**
+ * @remarks
+ * `import foo from './bar.js'` is treated as a re-export of `default` so the
+ * target file's `export default` declaration is considered as a potential
+ * Result helper. `import * as ns from './bar.js'` is intentionally not
+ * supported — recognizing `ns.helper(...)` member calls would require mapping
+ * the namespace binding back to the target's exported names. Callers using
+ * namespace imports of Result helpers will get false-positive diagnostics and
+ * can work around with a named import instead.
+ */
+const buildImportBinding = (
+  specifier: AstNode,
+  source: string
+): ImportBinding | null => {
+  if (specifier.type === 'ImportDefaultSpecifier') {
+    return buildDefaultImportBinding(specifier, source);
+  }
+  if (specifier.type === 'ImportSpecifier') {
+    return buildNamedImportBinding(specifier, source);
+  }
+  return null;
+};
+
+const collectBindingsFromImportDeclaration = (
+  node: AstNode
+): readonly ImportBinding[] => {
+  const source = getImportSourceValue(node);
+  if (!source) {
+    return [];
+  }
+  const specifiers =
+    (node['specifiers'] as readonly AstNode[] | undefined) ?? [];
+  return specifiers.flatMap((specifier) => {
+    const binding = buildImportBinding(specifier, source);
+    return binding ? [binding] : [];
+  });
+};
+
+/** Collect `import { foo as bar } from './...'` bindings keyed by local name. */
+const collectResolvableImports = (ast: AstNode): readonly ImportBinding[] => {
+  const imports: ImportBinding[] = [];
+  walk(ast, (node) => {
+    if (node.type === 'ImportDeclaration') {
+      imports.push(...collectBindingsFromImportDeclaration(node));
+    }
+  });
+  return imports;
+};
+
+/**
+ * Resolve a relative import source specifier to an absolute on-disk file path,
+ * or null when the source is not a relative path we can resolve locally.
+ *
+ * Handles `.js` -> `.ts` rewriting (the convention in this repo), plain `.ts`
+ * imports, and extensionless paths.
+ */
+const buildResolutionCandidates = (resolved: string): readonly string[] => {
+  if (resolved.endsWith('.ts') || resolved.endsWith('.tsx')) {
+    return [resolved];
+  }
+  if (resolved.endsWith('.js')) {
+    return [
+      resolved.replace(/\.js$/, '.ts'),
+      resolved.replace(/\.js$/, '.tsx'),
+      resolved,
+    ];
+  }
+  if (resolved.endsWith('.jsx')) {
+    return [resolved.replace(/\.jsx$/, '.tsx'), resolved];
+  }
+  return [`${resolved}.ts`, `${resolved}.tsx`];
+};
+
+const resolveRelativeImportPath = (
+  source: string,
+  fromFile: string
+): string | null => {
+  if (!(source.startsWith('./') || source.startsWith('../'))) {
+    return null;
+  }
+  const baseDir = isAbsolute(fromFile)
+    ? dirname(fromFile)
+    : dirname(resolve(fromFile));
+  const resolved = resolve(baseDir, source);
+  return (
+    buildResolutionCandidates(resolved).find((candidate) =>
+      existsSync(candidate)
+    ) ?? null
+  );
+};
+
+/** Extract the declaration wrapped by an ExportNamedDeclaration, if any. */
+const getExportedDeclaration = (node: AstNode): AstNode | null => {
+  if (node.type !== 'ExportNamedDeclaration') {
+    return null;
+  }
+  const decl = (node as unknown as { declaration?: AstNode }).declaration;
+  return decl ?? null;
+};
+
+const addExportedVariableResultHelper = (
+  decl: AstNode,
+  source: string,
+  collected: Set<string>
+): void => {
+  const declarations =
+    (decl['declarations'] as readonly AstNode[] | undefined) ?? [];
+  for (const declarator of declarations) {
+    const { id, init } = declarator as unknown as {
+      id?: AstNode;
+      init?: AstNode;
+    };
+    const name = extractIdentifierName(id);
+    if (
+      name &&
+      init &&
+      isFunctionLikeExpression(init) &&
+      hasResultReturnType(init, source)
+    ) {
+      collected.add(name);
+    }
+  }
+};
+
+const addExportedFunctionResultHelper = (
+  decl: AstNode,
+  source: string,
+  collected: Set<string>
+): void => {
+  const name = extractIdentifierName((decl as unknown as { id?: AstNode }).id);
+  if (name && hasResultReturnType(decl, source)) {
+    collected.add(name);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Same-file declaration index (for specifier re-exports without a source)
+// ---------------------------------------------------------------------------
+
+/**
+ * Index a file's top-level function-like declarations (both exported-inline
+ * and plain) by name to the declaration node, so we can look up the original
+ * binding referenced by a specifier re-export like `export { helper }`.
+ *
+ * Each entry carries the init/declaration node so the caller can check the
+ * return-type annotation without re-walking.
+ */
+type DeclarationIndex = ReadonlyMap<string, AstNode>;
+
+const indexVariableDeclarationInto = (
+  decl: AstNode,
+  index: Map<string, AstNode>
+): void => {
+  const declarators =
+    (decl['declarations'] as readonly AstNode[] | undefined) ?? [];
+  for (const declarator of declarators) {
+    const { id, init } = declarator as unknown as {
+      id?: AstNode;
+      init?: AstNode;
+    };
+    const name = extractIdentifierName(id);
+    if (name && init && isFunctionLikeExpression(init)) {
+      index.set(name, init);
+    }
+  }
+};
+
+const indexFunctionDeclarationInto = (
+  decl: AstNode,
+  index: Map<string, AstNode>
+): void => {
+  const name = extractIdentifierName((decl as unknown as { id?: AstNode }).id);
+  if (name) {
+    index.set(name, decl);
+  }
+};
+
+const indexDeclarationInto = (
+  decl: AstNode | null | undefined,
+  index: Map<string, AstNode>
+): void => {
+  if (!decl) {
+    return;
+  }
+  if (decl.type === 'VariableDeclaration') {
+    indexVariableDeclarationInto(decl, index);
+  } else if (decl.type === 'FunctionDeclaration') {
+    indexFunctionDeclarationInto(decl, index);
+  }
+};
+
+const indexBodyNodeInto = (
+  node: AstNode,
+  index: Map<string, AstNode>
+): void => {
+  if (node.type === 'ExportNamedDeclaration') {
+    indexDeclarationInto(getExportedDeclaration(node), index);
+    return;
+  }
+  indexDeclarationInto(node, index);
+};
+
+const indexLocalDeclarations = (ast: AstNode): DeclarationIndex => {
+  const index = new Map<string, AstNode>();
+  const program = ast as unknown as { body?: readonly AstNode[] };
+  const bodyNodes = program.body ?? [];
+  for (const node of bodyNodes) {
+    indexBodyNodeInto(node, index);
+  }
+  return index;
+};
+
+// ---------------------------------------------------------------------------
+// Export-specifier handling
+// ---------------------------------------------------------------------------
+
+interface ExportSpecifierInfo {
+  /** Name this export is exposed as to consumers (after `as` alias). */
+  readonly exportedName: string;
+  /** Name referenced inside the re-export (`helper` in `export { helper }`). */
+  readonly localName: string;
+  /** True when the specifier is `default` (i.e. `export { default as X }`). */
+  readonly isDefault: boolean;
+}
+
+const getSpecifierNameNode = (
+  spec: AstNode,
+  key: 'exported' | 'local'
+): string | null => {
+  const node = (spec as unknown as Record<string, AstNode | undefined>)[key];
+  if (!node) {
+    return null;
+  }
+  if (node.type === 'Identifier') {
+    return (node as unknown as { name?: string }).name ?? null;
+  }
+  // Support string-literal specifiers (`export { "default" as X }`, etc).
+  const { value } = node as unknown as { value?: unknown };
+  return typeof value === 'string' ? value : null;
+};
+
+const buildExportSpecifierInfo = (
+  spec: AstNode
+): ExportSpecifierInfo | null => {
+  if (spec.type !== 'ExportSpecifier') {
+    return null;
+  }
+  const localName = getSpecifierNameNode(spec, 'local');
+  const exportedName = getSpecifierNameNode(spec, 'exported') ?? localName;
+  if (!(localName && exportedName)) {
+    return null;
+  }
+  return {
+    exportedName,
+    isDefault: localName === 'default',
+    localName,
+  };
+};
+
+const getExportDefaultDeclaration = (ast: AstNode): AstNode | null => {
+  const program = ast as unknown as { body?: readonly AstNode[] };
+  const bodyNodes = program.body ?? [];
+  for (const node of bodyNodes) {
+    if (node.type === 'ExportDefaultDeclaration') {
+      const decl = (node as unknown as { declaration?: AstNode }).declaration;
+      return decl ?? null;
+    }
+  }
+  return null;
+};
+
+// Bounded recursion: one transitive hop through `export { ... } from`.
+const MAX_RERESOLVE_DEPTH = 1;
+
+/** Check whether a local declaration node has a `Result<...>` return annotation. */
+const isResultHelperDeclaration = (
+  declarationNode: AstNode | undefined,
+  source: string
+): boolean => {
+  if (!declarationNode) {
+    return false;
+  }
+  if (isFunctionLikeExpression(declarationNode)) {
+    return hasResultReturnType(declarationNode, source);
+  }
+  if (declarationNode.type === 'FunctionDeclaration') {
+    return hasResultReturnType(declarationNode, source);
+  }
+  return false;
+};
+
+/** Resolve an `export default ...` declaration, following one identifier hop. */
+const checkDefaultDeclarationIsResultHelper = (
+  defaultDecl: AstNode,
+  targetSource: string,
+  targetLocalDeclarations: DeclarationIndex
+): boolean => {
+  if (isResultHelperDeclaration(defaultDecl, targetSource)) {
+    return true;
+  }
+  if (defaultDecl.type === 'Identifier') {
+    const name = extractIdentifierName(defaultDecl);
+    const referenced = name ? targetLocalDeclarations.get(name) : undefined;
+    return isResultHelperDeclaration(referenced, targetSource);
+  }
+  return false;
+};
+
+interface LoadedTargetFile {
+  readonly ast: AstNode;
+  readonly source: string;
+  readonly localDeclarations: DeclarationIndex;
+}
+
+const loadTargetFile = (targetPath: string): LoadedTargetFile | null => {
+  try {
+    const source = readFileSync(targetPath, 'utf8');
+    const ast = parse(targetPath, source) as AstNode | null;
+    if (!ast) {
+      return null;
+    }
+    return {
+      ast,
+      localDeclarations: indexLocalDeclarations(ast),
+      source,
+    };
+  } catch {
+    return null;
+  }
+};
+
+interface ReExportContext {
+  readonly loadedTarget: LoadedTargetFile | null;
+  readonly downstreamResultNames: ReadonlySet<string>;
+}
+
+const applyDefaultSpecifier = (
+  info: ExportSpecifierInfo,
+  loadedTarget: LoadedTargetFile | null,
+  collected: Set<string>
+): void => {
+  if (!loadedTarget) {
+    return;
+  }
+  const defaultDecl = getExportDefaultDeclaration(loadedTarget.ast);
+  if (!defaultDecl) {
+    return;
+  }
+  if (
+    checkDefaultDeclarationIsResultHelper(
+      defaultDecl,
+      loadedTarget.source,
+      loadedTarget.localDeclarations
+    )
+  ) {
+    collected.add(info.exportedName);
+  }
+};
+
+const applySpecifierInfo = (
+  info: ExportSpecifierInfo,
+  ctx: ReExportContext,
+  collected: Set<string>
+): void => {
+  if (info.isDefault) {
+    applyDefaultSpecifier(info, ctx.loadedTarget, collected);
+    return;
+  }
+  if (ctx.downstreamResultNames.has(info.localName)) {
+    collected.add(info.exportedName);
+  }
+};
+
+const resolveReExportTargetPath = (
+  node: AstNode,
+  targetPath: string,
+  visited: ReadonlySet<string>,
+  depth: number
+): string | null => {
+  if (depth >= MAX_RERESOLVE_DEPTH) {
+    return null;
+  }
+  const reSource = getImportSourceValue(node);
+  if (!reSource) {
+    return null;
+  }
+  const reTargetPath = resolveRelativeImportPath(reSource, targetPath);
+  if (!reTargetPath || visited.has(reTargetPath)) {
+    return null;
+  }
+  return reTargetPath;
+};
+
+const buildReExportContext = (
+  reTargetPath: string,
+  specifierInfos: readonly ExportSpecifierInfo[],
+  targetPath: string,
+  visited: ReadonlySet<string>,
+  depth: number
+): ReExportContext => {
+  const needsDefault = specifierInfos.some((info) => info.isDefault);
+  // Load once when the default specifier branch needs the target AST; the
+  // same loaded object is threaded into the downstream walk so it isn't
+  // read and parsed a second time within this check() call.
+  const loadedTarget = needsDefault ? loadTargetFile(reTargetPath) : null;
+  // eslint-disable-next-line no-use-before-define
+  const downstreamResultNames = collectTargetExportedResultHelperNames(
+    reTargetPath,
+    visited,
+    targetPath,
+    depth + 1,
+    loadedTarget
+  );
+  return {
+    downstreamResultNames,
+    loadedTarget,
+  };
+};
+
+/**
+ * Resolve a re-export with source (`export { ... } from './x.js'`) by pulling
+ * the matching names off the target file, honoring aliases and `default`.
+ */
+const resolveReExportWithSource = (
+  node: AstNode,
+  specifiers: readonly AstNode[],
+  targetPath: string,
+  visited: ReadonlySet<string>,
+  depth: number,
+  collected: Set<string>
+): void => {
+  const reTargetPath = resolveReExportTargetPath(
+    node,
+    targetPath,
+    visited,
+    depth
+  );
+  if (!reTargetPath) {
+    return;
+  }
+  const specifierInfos = specifiers.flatMap((spec) => {
+    const info = buildExportSpecifierInfo(spec);
+    return info ? [info] : [];
+  });
+  const ctx = buildReExportContext(
+    reTargetPath,
+    specifierInfos,
+    targetPath,
+    visited,
+    depth
+  );
+  for (const info of specifierInfos) {
+    applySpecifierInfo(info, ctx, collected);
+  }
+};
+
+/** Resolve a specifier-only re-export (`export { helper };`) against same-file declarations. */
+const resolveReExportWithoutSource = (
+  specifiers: readonly AstNode[],
+  localDeclarations: DeclarationIndex,
+  source: string,
+  collected: Set<string>
+): void => {
+  for (const spec of specifiers) {
+    const info = buildExportSpecifierInfo(spec);
+    if (!info || info.isDefault) {
+      continue;
+    }
+    if (
+      isResultHelperDeclaration(localDeclarations.get(info.localName), source)
+    ) {
+      collected.add(info.exportedName);
+    }
+  }
+};
+
+const processInlineExportedDeclaration = (
+  exportedDecl: AstNode,
+  source: string,
+  collected: Set<string>
+): boolean => {
+  if (exportedDecl.type === 'VariableDeclaration') {
+    addExportedVariableResultHelper(exportedDecl, source, collected);
+    return true;
+  }
+  if (exportedDecl.type === 'FunctionDeclaration') {
+    addExportedFunctionResultHelper(exportedDecl, source, collected);
+    return true;
+  }
+  return false;
+};
+
+const processExportNamedDeclaration = (
+  node: AstNode,
+  source: string,
+  targetPath: string,
+  visited: ReadonlySet<string>,
+  depth: number,
+  localDeclarations: DeclarationIndex,
+  collected: Set<string>
+): void => {
+  const exportedDecl = getExportedDeclaration(node);
+  if (
+    exportedDecl &&
+    processInlineExportedDeclaration(exportedDecl, source, collected)
+  ) {
+    return;
+  }
+  const specifiers =
+    (node['specifiers'] as readonly AstNode[] | undefined) ?? [];
+  if (specifiers.length === 0) {
+    return;
+  }
+  if (getImportSourceValue(node)) {
+    resolveReExportWithSource(
+      node,
+      specifiers,
+      targetPath,
+      visited,
+      depth,
+      collected
+    );
+    return;
+  }
+  resolveReExportWithoutSource(
+    specifiers,
+    localDeclarations,
+    source,
+    collected
+  );
+};
+
+const processExportDefaultDeclaration = (
+  node: AstNode,
+  source: string,
+  localDeclarations: DeclarationIndex,
+  collected: Set<string>
+): void => {
+  const defaultDecl = (node as unknown as { declaration?: AstNode })
+    .declaration;
+  if (!defaultDecl) {
+    return;
+  }
+  if (
+    checkDefaultDeclarationIsResultHelper(
+      defaultDecl,
+      source,
+      localDeclarations
+    )
+  ) {
+    collected.add('default');
+  }
+};
+
+const collectExportedResultHelpersFromAst = (
+  ast: AstNode,
+  source: string,
+  targetPath: string,
+  visited: ReadonlySet<string>,
+  depth: number,
+  preloadedLocalDeclarations: DeclarationIndex | null = null
+): ReadonlySet<string> => {
+  const collected = new Set<string>();
+  // Reuse the preloaded declaration index when available (e.g., threaded in
+  // from `loadTargetFile`) to avoid re-walking the same AST.
+  const localDeclarations =
+    preloadedLocalDeclarations ?? indexLocalDeclarations(ast);
+  const program = ast as unknown as { body?: readonly AstNode[] };
+  const bodyNodes = program.body ?? [];
+
+  for (const node of bodyNodes) {
+    if (node.type === 'ExportNamedDeclaration') {
+      processExportNamedDeclaration(
+        node,
+        source,
+        targetPath,
+        visited,
+        depth,
+        localDeclarations,
+        collected
+      );
+    } else if (node.type === 'ExportDefaultDeclaration') {
+      processExportDefaultDeclaration(
+        node,
+        source,
+        localDeclarations,
+        collected
+      );
+    }
+  }
+
+  return collected;
+};
+
+const parseTargetResultHelperNames = (
+  targetPath: string,
+  visited: ReadonlySet<string>,
+  depth: number,
+  preloaded: LoadedTargetFile | null = null
+): ReadonlySet<string> => {
+  const loaded = preloaded ?? loadTargetFile(targetPath);
+  if (!loaded) {
+    return new Set<string>();
+  }
+  return collectExportedResultHelpersFromAst(
+    loaded.ast,
+    loaded.source,
+    targetPath,
+    visited,
+    depth,
+    loaded.localDeclarations
+  );
+};
+
+const buildVisitedPathSet = (
+  parentVisited: ReadonlySet<string>,
+  targetPath: string,
+  parentPath: string | undefined
+): ReadonlySet<string> => {
+  const seeds = [...parentVisited, targetPath];
+  if (parentPath) {
+    seeds.push(parentPath);
+  }
+  return new Set<string>(seeds);
+};
+
+/**
+ * Collect the set of exported names from a target file whose declaration has
+ * an explicit `Result<...>` / `Promise<Result<...>>` return annotation.
+ *
+ * Uses a visited-set on the recursion path to guard against `export { ... }
+ * from` import cycles between files. Depth is capped at a single transitive
+ * hop (see `MAX_RERESOLVE_DEPTH`) — deeper chains silently fall back.
+ */
+// Only the direct-import path (no parents visited) is safe to cache: the
+// computed set is a function of (targetPath, parentVisited), and
+// cycle-truncated results from transitive walks must not bleed into later
+// direct lookups. See PR #204 review.
+const readCachedResultExports = (
+  targetPath: string,
+  parentVisited: ReadonlySet<string>
+): ReadonlySet<string> | undefined => {
+  if (parentVisited.size !== 0) {
+    return;
+  }
+  return targetFileResultExportCache.get(targetPath);
+};
+
+// biome-ignore lint/style/useConst: declared as a function so hoisting lets `buildReExportContext` (a const declared earlier) reference it before its textual definition
+// eslint-disable-next-line func-style, no-use-before-define
+function collectTargetExportedResultHelperNames(
+  targetPath: string,
+  parentVisited: ReadonlySet<string> = new Set<string>(),
+  parentPath?: string,
+  depth = 0,
+  preloaded: LoadedTargetFile | null = null
+): ReadonlySet<string> {
+  if (parentVisited.has(targetPath)) {
+    return new Set<string>();
+  }
+  const cached = readCachedResultExports(targetPath, parentVisited);
+  if (cached) {
+    return cached;
+  }
+  const visited = buildVisitedPathSet(parentVisited, targetPath, parentPath);
+  const names = parseTargetResultHelperNames(
+    targetPath,
+    visited,
+    depth,
+    preloaded
+  );
+  if (parentVisited.size === 0) {
+    targetFileResultExportCache.set(targetPath, names);
+  }
+  return names;
+}
+
+/**
+ * Extend a local-helper-name set with Result-returning helpers imported from
+ * relative modules. Falls back silently on any resolution/parse failure.
+ */
+const collectImportedResultHelperNames = (
+  ast: AstNode,
+  filePath: string
+): ReadonlySet<string> => {
+  const names = new Set<string>();
+
+  for (const binding of collectResolvableImports(ast)) {
+    const targetPath = resolveRelativeImportPath(binding.source, filePath);
+    if (!targetPath) {
+      continue;
+    }
+    const exportedResultNames =
+      collectTargetExportedResultHelperNames(targetPath);
+    if (exportedResultNames.has(binding.importedName)) {
+      names.add(binding.localName);
+    }
+  }
+
+  return names;
+};
+
+/**
+ * Combine same-file helper names with helpers imported from relative modules.
+ */
+const collectAllResultHelperNames = (
+  ast: AstNode,
+  sourceCode: string,
+  filePath: string
+): ReadonlySet<string> => {
+  const local = collectResultHelperNames(ast, sourceCode);
+  const imported = collectImportedResultHelperNames(ast, filePath);
+  if (imported.size === 0) {
+    return local;
+  }
+  const merged = new Set<string>(local);
+  for (const name of imported) {
+    merged.add(name);
+  }
+  return merged;
+};
+
+// ---------------------------------------------------------------------------
 // Per-implementation checking
 // ---------------------------------------------------------------------------
 
@@ -358,7 +1162,7 @@ const checkAllDefinitions = (
   sourceCode: string
 ): WardenDiagnostic[] => {
   const diagnostics: WardenDiagnostic[] = [];
-  const helperNames = collectResultHelperNames(ast, sourceCode);
+  const helperNames = collectAllResultHelperNames(ast, sourceCode, filePath);
 
   for (const def of findTrailDefinitions(ast)) {
     const info = { id: def.id, label: 'Trail' };


### PR DESCRIPTION
## Summary

Extends `implementation-returns-result` warden rule to recognize imported helpers whose declared return types are `Result<...>` / `Promise<Result<...>>`. Previously the rule only whitelisted same-file helpers with explicit return annotations, so valid `return importedHelper(...)` expressions in trail blazes false-positived.

Closes [TRL-333](https://linear.app/outfitter/issue/TRL-333).

## The false positives

April 19 warden baseline flagged two sites. `apps/trails/src/trails/topo-export.ts:15` returns `exportCurrentTopo(app, {...})`; `apps/trails/src/trails/topo-verify.ts:11` returns `verifyCurrentTopo(app, {...})`. Both helpers are declared in local repo files with explicit `Promise<Result<..., Error>>` return types. The rule flagged both as raw-value returns.

The class of bug is broader than the two cited sites — roughly 127 functions in the repo return `Promise<Result<...>>` and many are consumed via the same pattern.

## Root cause

`collectResultHelperNames` in `packages/warden/src/rules/implementation-returns-result.ts` walked the AST for function and const declarations with explicit `Result<...>` return annotations, but only in the same file as the caller. Imports were never resolved — the walker never followed `import` declarations, so no cross-file helpers reached the name set. `isHelperCall` then failed to match and the return fell through to the raw-value diagnostic.

## The fix

Helper-name collection now follows local imports using `collectImportAliasMap` (already exposed by `packages/warden/src/ast.ts`). The resolver walks each `ImportDeclaration`, filters to repo-local relative paths (skipping `node:`, bare specifiers, `@ontrails/*` cross-package — that scope needs a TS program), resolves candidates (`.ts` → `.tsx` → `.js` → `.jsx` → extensionless), reads + parses the target file with the existing OXC parser, and finds named exports with the right return annotation.

Four export shapes handled: inline declarations (`export const foo = ...`, `export function foo() {...}`), specifier with source (`export { helper } from './foo.js'`), aliased re-export (`export { helper as aliased }`), and default re-export (`export { default as foo } from ...`). Recursion bounded at one transitive hop (`MAX_RERESOLVE_DEPTH = 1`) with a visited-path cycle guard.

Module-level `Map<string, ReadonlySet<string>>` caches per-file helper names. Warden runs are short-lived — a plain Map is fine.

Every failure path (unresolvable candidate, read error, parse error, missing export, wrong annotation) silently returns an empty set. The existing same-file logic still runs, so a failed resolution leaves original diagnostic behavior intact.

## Verification

- `bun run typecheck` — 31/31 green
- `bun test packages/warden` — 382 pass / 0 fail
- `bun run check` — 31/31 green

## Test plan

9 tests added to `packages/warden/src/__tests__/implementation-returns-result.test.ts`:

Round 1 (inline exports): imported helper with `Promise<Result<...>>` → no diagnostic; imported helper without `Result` return → still fires; bare-specifier import → still fires (local scope only); import from non-existent file → gracefully falls back.

Round 2 (specifier re-exports): `export { helper } from './impl.js'`, aliased re-export, same-file specifier re-export, `export { default as foo } from ...`, cycle guard on mutual re-export.

Real-world confirmation: `apps/trails/src/trails/topo-export.ts` and `topo-verify.ts` now emit zero diagnostics from this rule.

## Review arc

Two rounds of Codex review. Round 1 surfaced a P1 — specifier-form re-exports (the common barrel shape in this repo) were skipped, so valid Result-returning helpers re-exported via `export { helper } from ...` still false-positived. Fixed by handling four specifier shapes plus cycle-guarded one-hop recursion. Round 2 clean.

## Related

- Clark ruling (2026-04-21) — extend the existing rule using existing AST affordances (`collectImportAliasMap`), not a new primitive
- ADR-0036 drift-guard framing — rules catching rules