### PR TITLE
refactor(warden): port regex-scanning rules to AST traversal [TRL-335]

### DIFF
--- a/packages/warden/src/__tests__/no-sync-result-assumption.test.ts
+++ b/packages/warden/src/__tests__/no-sync-result-assumption.test.ts
@@ -3,83 +3,758 @@ import { describe, expect, test } from 'bun:test';
 import { noSyncResultAssumption } from '../rules/no-sync-result-assumption.js';
 
 describe('no-sync-result-assumption', () => {
-  test('flags direct result access on implementation calls', () => {
-    const code = `
+  describe('core behavior', () => {
+    test('flags direct result access on implementation calls', () => {
+      const code = `
 async function run() {
   const isOk = entityShow.blaze({ id: "1" }, ctx).isOk();
   return isOk;
 }`;
 
-    const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
 
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.rule).toBe('no-sync-result-assumption');
-    expect(diagnostics[0]?.severity).toBe('error');
-    expect(diagnostics[0]?.message).toContain('Missing await');
-  });
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.rule).toBe('no-sync-result-assumption');
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
 
-  test('flags a stored implementation result that is used synchronously', () => {
-    const code = `
+    test('flags a stored implementation result that is used synchronously', () => {
+      const code = `
 const result = entityShow.blaze({ id: "1" }, ctx);
 
 if (result.isOk()) {
   console.log("ok");
 }`;
 
-    const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
 
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.line).toBe(4);
-  });
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.line).toBe(4);
+    });
 
-  test('allows awaited implementation calls before result access', () => {
-    const code = `
+    test('allows awaited implementation calls before result access', () => {
+      const code = `
 async function run() {
   const result = await entityShow.blaze({ id: "1" }, ctx);
   return result.isOk();
 }`;
 
-    const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
 
-    expect(diagnostics).toHaveLength(0);
-  });
+      expect(diagnostics).toHaveLength(0);
+    });
 
-  test('allows awaited implementation calls when the property access is chained', () => {
-    const code = `
+    test('allows awaited implementation calls when the property access is chained', () => {
+      const code = `
 async function run() {
   return (await entityShow.blaze({ id: "1" }, ctx)).isOk();
 }`;
 
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('ignores test files', () => {
+      const code = `
+const result = entityShow.blaze({ id: "1" }, ctx);
+result.isOk();
+`;
+
+      const diagnostics = noSyncResultAssumption.check(
+        code,
+        'src/__tests__/app.test.ts'
+      );
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('ignores framework internals that intentionally call implementations', () => {
+      const code = `
+const result = entityShow.blaze({ id: "1" }, ctx);
+result.isOk();
+`;
+
+      const diagnostics = noSyncResultAssumption.check(
+        code,
+        '/repo/packages/testing/src/trail.ts'
+      );
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('ignores .blaze() inside a template-literal string payload', () => {
+      const code =
+        'const example = `const x = entityShow.blaze(input, ctx).isOk()`;';
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('ignores .blaze() inside a double-quoted string payload', () => {
+      const code = 'const example = "entityShow.blaze(input, ctx).isOk()";';
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('allows awaited indirection through destructured call', () => {
+      const code = `
+async function run() {
+  const result = (await entityShow.blaze({ id: "1" }, ctx));
+  return result.isErr();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe('lexical scoping', () => {
+    test('does not flag a parameter that shadows a pending binding', () => {
+      const code = `
+const result = entityShow.blaze({ id: "1" }, ctx);
+function ok(result) {
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('does not flag a local block-scoped shadow of a pending binding', () => {
+      const code = `
+const result = entityShow.blaze({ id: "1" }, ctx);
+{
+  const result = { isOk: () => true };
+  if (result.isOk()) {
+    console.log("inner");
+  }
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('does not flag a local block-scoped class that shadows a pending binding', () => {
+      const code = `
+const result = entityShow.blaze({ id: "1" }, ctx);
+{
+  class result {
+    static isOk() { return true; }
+  }
+  if (result.isOk()) {
+    console.log("inner");
+  }
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('does not flag an arrow parameter that shadows a pending binding', () => {
+      const code = `
+const result = entityShow.blaze({ id: "1" }, ctx);
+const f = (result) => result.isOk();`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('does not flag a deeply nested shadowed parameter', () => {
+      const code = `
+const result = entityShow.blaze({ id: "1" }, ctx);
+function outer() {
+  const result = 1;
+  function inner(result) {
+    return result.isOk();
+  }
+  return inner;
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('still flags outer pending binding referenced from a non-shadowing nested function', () => {
+      const code = `
+const result = entityShow.blaze({ id: "1" }, ctx);
+function ok() {
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('does not flag a destructured parameter that shadows a pending binding', () => {
+      const code = `
+const result = entityShow.blaze({ id: "1" }, ctx);
+function ok({ result }) {
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('does not flag a catch binding that shadows a pending binding', () => {
+      const code = `
+const result = entityShow.blaze({ id: "1" }, ctx);
+try {
+  doThing();
+} catch (result) {
+  if (result.isOk) console.log(result.isOk);
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe('var hoisting', () => {
+    test('var declared inside a block hoists to the enclosing function', () => {
+      const code = `
+function run() {
+  if (cond) {
+    var result = entityShow.blaze({ id: "1" }, ctx);
+  }
+  result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('var declared in a for-head hoists to the enclosing function', () => {
+      const code = `
+function run() {
+  for (var result = entityShow.blaze({ id: "1" }, ctx); ;) { break; }
+  result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('let declared inside a block stays block-scoped', () => {
+      const code = `
+function run() {
+  if (cond) {
+    let result = entityShow.blaze({ id: "1" }, ctx);
+  }
+  result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('var re-init of a same-named parameter registers as a pending binding', () => {
+      // `var` and parameters share the function's VariableEnvironment, so
+      // `var result = blaze(...)` writes to the parameter's slot. After the
+      // declaration runs, `result.isOk()` observes the blaze result and
+      // must fire, just as it would in the no-parameter case.
+      const code = `
+function run(result) {
+  var result = entityShow.blaze({ id: "1" }, ctx);
+  result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('var re-init of a parameter inside a block still hoists to function scope', () => {
+      const code = `
+function run(result) {
+  if (cond) {
+    var result = entityShow.blaze({ id: "1" }, ctx);
+  }
+  result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('var re-init of a parameter with no later result-shaped use is not flagged', () => {
+      // Registering the pending binding is fine, but nothing consumes it
+      // as a sync `Result`, so no diagnostic is emitted.
+      const code = `
+function run(result) {
+  var result = entityShow.blaze({ id: "1" }, ctx);
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('plain `=` re-assignment to a same-named parameter registers as a pending binding', () => {
+      // `result = blaze(...)` writes to the parameter's existing slot in
+      // the same VariableEnvironment, so the subsequent `result.isOk()`
+      // observes the blaze result and must fire.
+      const code = `
+function run(result) {
+  result = entityShow.blaze({ id: "1" }, ctx);
+  result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('parameter used directly as a Result without re-init is not flagged', () => {
+      // The parameter is the real binding; nothing made it a pending
+      // `.blaze()` result, so `result.isOk()` is just a call on whatever
+      // was passed in.
+      const code = `
+function run(result) {
+  result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe('static blocks', () => {
+    test('inner const in static block shadows outer pending binding', () => {
+      const code = `
+const result = trail.blaze({ id: "1" }, ctx);
+class Foo {
+  static {
+    const result = 42;
+    result.toString();
+  }
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('pending binding inside a static block flows to use inside the same static block', () => {
+      const code = `
+class Foo {
+  static {
+    const result = trail.blaze({ id: "1" }, ctx);
+    result.isOk();
+  }
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('static block bindings do not leak out to enclosing scope', () => {
+      const code = `
+class Foo {
+  static {
+    const result = trail.blaze({ id: "1" }, ctx);
+  }
+}
+result.isOk();`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe('parenthesized blaze calls', () => {
+    test('flags member access on a parens-wrapped blaze call', () => {
+      const code = `
+function run() {
+  return (entityShow.blaze({ id: "1" }, ctx)).isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags .value access on a parens-wrapped blaze call', () => {
+      const code = `
+function run() {
+  return (entityShow.blaze({ id: "1" }, ctx)).value;
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags member access through double-wrapped parens', () => {
+      const code = `
+function run() {
+  return ((entityShow.blaze({ id: "1" }, ctx))).isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags accessor use on a binding whose init is a parens-wrapped blaze call', () => {
+      const code = `
+function run() {
+  const result = (entityShow.blaze({ id: "1" }, ctx));
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags accessor use on a binding whose init is a double-parens blaze call', () => {
+      const code = `
+function run() {
+  const result = ((entityShow.blaze({ id: "1" }, ctx)));
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags destructuring of a Result accessor from a parens-wrapped blaze call', () => {
+      const code = `
+function run() {
+  const { isOk } = (entityShow.blaze({ id: "1" }, ctx));
+  return isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags accessor use on a binding whose init is a TSAsExpression-wrapped blaze call', () => {
+      const code = `
+function run() {
+  const result = entityShow.blaze({ id: "1" }, ctx) as any;
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags accessor use on a binding whose init is a TSSatisfiesExpression-wrapped blaze call', () => {
+      const code = `
+function run() {
+  const result = entityShow.blaze({ id: "1" }, ctx) satisfies unknown;
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags accessor use on a binding whose init is a TSNonNullExpression-wrapped blaze call', () => {
+      const code = `
+function run() {
+  const result = entityShow.blaze({ id: "1" }, ctx)!;
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+  });
+
+  describe('destructured bindings', () => {
+    test('flags object destructuring of a Result accessor from an unawaited blaze call', () => {
+      const code = `
+function run() {
+  const { isOk } = entityShow.blaze({ id: "1" }, ctx);
+  return isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags destructuring of value from an unawaited blaze call', () => {
+      const code = `
+function run() {
+  const { value } = entityShow.blaze({ id: "1" }, ctx);
+  return value;
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('does not flag destructuring of a Result accessor from an awaited blaze call', () => {
+      const code = `
+async function run() {
+  const { isOk } = await entityShow.blaze({ id: "1" }, ctx);
+  return isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+  });
+
+  test('flags .value access on unawaited blaze call', () => {
+    const code = `
+function run() {
+  return entityShow.blaze({ id: "1" }, ctx).value;
+}`;
+
     const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
 
-    expect(diagnostics).toHaveLength(0);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('Missing await');
   });
 
-  test('ignores test files', () => {
-    const code = `
-const result = entityShow.blaze({ id: "1" }, ctx);
-result.isOk();
-`;
+  describe('conditional-expression inits', () => {
+    test('flags accessor use when blaze call is the consequent branch', () => {
+      const code = `
+function run(cond, fallback) {
+  const result = cond ? entityShow.blaze({ id: "1" }, ctx) : fallback;
+  return result.isOk();
+}`;
 
-    const diagnostics = noSyncResultAssumption.check(
-      code,
-      'src/__tests__/app.test.ts'
-    );
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
 
-    expect(diagnostics).toHaveLength(0);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags accessor use when blaze call is the alternate branch', () => {
+      const code = `
+function run(cond, fallback) {
+  const result = cond ? fallback : entityShow.blaze({ id: "1" }, ctx);
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags accessor use when both branches are blaze calls', () => {
+      const code = `
+function run(cond) {
+  const result = cond
+    ? entityShow.blaze({ id: "1" }, ctx)
+    : entityEdit.blaze({ id: "1" }, ctx);
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics.length).toBeGreaterThanOrEqual(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('does not flag when the conditional is awaited as a whole', () => {
+      const code = `
+async function run(cond, fallback) {
+  const result = await (cond ? entityShow.blaze({ id: "1" }, ctx) : fallback);
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('flags destructuring of a Result accessor from a conditional branch', () => {
+      const code = `
+function run(cond, fallback) {
+  const { isOk } = cond ? entityShow.blaze({ id: "1" }, ctx) : fallback;
+  return isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags direct accessor call through a conditional wrapper', () => {
+      const code = `
+function run(cond, fallback) {
+  return (cond ? entityShow.blaze({ id: "1" }, ctx) : fallback).isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
   });
 
-  test('ignores framework internals that intentionally call implementations', () => {
-    const code = `
-const result = entityShow.blaze({ id: "1" }, ctx);
-result.isOk();
-`;
+  describe('logical-expression inits', () => {
+    test('flags accessor use when blaze is the right operand of &&', () => {
+      const code = `
+function run(cond) {
+  const result = cond && entityShow.blaze({ id: "1" }, ctx);
+  return result.isOk();
+}`;
 
-    const diagnostics = noSyncResultAssumption.check(
-      code,
-      '/repo/packages/testing/src/trail.ts'
-    );
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
 
-    expect(diagnostics).toHaveLength(0);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags accessor use when blaze is the right operand of ??', () => {
+      const code = `
+function run(maybe) {
+  const result = maybe ?? entityShow.blaze({ id: "1" }, ctx);
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags accessor use when blaze is the right operand of ||', () => {
+      const code = `
+function run(fallback) {
+  const result = fallback || entityShow.blaze({ id: "1" }, ctx);
+  return result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags direct accessor call through a logical wrapper', () => {
+      const code = `
+function run(cond) {
+  return (cond && entityShow.blaze({ id: "1" }, ctx)).isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('does not flag when the logical expression is awaited as a whole', () => {
+      const code = `
+async function run(cond) {
+  const result = await (cond && entityShow.blaze({ id: "1" }, ctx));
+  return result?.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe('assignment to pre-declared variable', () => {
+    test('flags bare identifier assignment followed by result access', () => {
+      const code = `
+async function run(ctx) {
+  let result;
+  result = entityShow.blaze({ id: "1" }, ctx);
+  result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags logical-wrapped assignment to pre-declared variable', () => {
+      const code = `
+async function run(cond, ctx) {
+  let result;
+  result = cond && entityShow.blaze({ id: "1" }, ctx);
+  result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('ignores member-expression assignment', () => {
+      const code = `
+async function run(obj, ctx) {
+  obj.result = entityShow.blaze({ id: "1" }, ctx);
+  obj.result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+
+    test('ignores plain assignments unrelated to blaze', () => {
+      const code = `
+async function run() {
+  let result = 0;
+  result = 42;
+  return result;
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
   });
 });

--- a/packages/warden/src/__tests__/rules.test.ts
+++ b/packages/warden/src/__tests__/rules.test.ts
@@ -172,6 +172,174 @@ trail("entity.onboard", {
     const diagnostics = validDetourRefs.check(code, TEST_FILE);
     expect(diagnostics.length).toBe(0);
   });
+
+  test('ignores trail/detour patterns embedded in template literal payloads', () => {
+    const code = `
+const sample = \`
+trail("entity.fallback", {
+  blaze: async (input, ctx) => Result.ok(data)
+})
+
+trail("entity.show", {
+  detours: [{ target: "entity.fallback" }],
+  blaze: async (input, ctx) => Result.ok(data)
+})
+\`;
+`;
+    const diagnostics = validDetourRefs.check(code, TEST_FILE);
+    expect(diagnostics.length).toBe(0);
+  });
+
+  test('flags string-literal detour entries without an object wrapper', () => {
+    const code = `
+trail("entity.show", {
+  detours: ["entity.missing"],
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+    const diagnostics = validDetourRefs.check(code, TEST_FILE);
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.message).toContain('entity.missing');
+  });
+
+  describe('backtick literals', () => {
+    test('flags backtick-literal detour target in an object wrapper', () => {
+      const code = `
+trail("entity.show", {
+  detours: [{ target: \`entity.missing\` }],
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+    });
+
+    test('passes when backtick-literal detour target exists', () => {
+      const code = `
+trail("entity.fallback", {
+  blaze: async (input, ctx) => Result.ok(data)
+})
+
+trail("entity.show", {
+  detours: [{ target: \`entity.fallback\` }],
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('flags bare backtick-literal detour entries', () => {
+      const code = `
+trail("entity.show", {
+  detours: [\`entity.missing\`],
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+    });
+
+    test('flags quoted "target" key inside detour object', () => {
+      const code = `
+trail("entity.show", {
+  detours: [{ "target": "entity.missing" }],
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+    });
+
+    test('flags detours when both "detours" and "target" keys are quoted', () => {
+      const code = `
+trail("entity.show", {
+  "detours": [{ "target": "entity.missing" }],
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+    });
+
+    test('flags mixed quoted-and-unquoted detour keys', () => {
+      const code = `
+trail("entity.show", {
+  detours: [{ "target": "entity.missing" }],
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+    });
+
+    test('flags detour target on a trail whose id is a backtick literal', () => {
+      const code = `
+trail(\`entity.show\`, {
+  detours: [{ target: "entity.missing" }],
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+      expect(diagnostics[0]?.message).toContain('entity.show');
+    });
+  });
+
+  describe('transparent expression wrappers', () => {
+    test('flags detour target when the detours array is wrapped in `as const`', () => {
+      const code = `
+trail("entity.show", {
+  detours: [{ target: "entity.missing" }] as const,
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+    });
+
+    test('flags detour target when the detours array uses `satisfies`', () => {
+      const code = `
+trail("entity.show", {
+  detours: [{ target: "entity.missing" }] satisfies readonly Detour[],
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+    });
+
+    test('flags detour target when the detours array is parenthesized', () => {
+      const code = `
+trail("entity.show", {
+  detours: ([{ target: "entity.missing" }]),
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+    });
+
+    test('flags detour target when the detours array uses a non-null assertion', () => {
+      const code = `
+trail("entity.show", {
+  detours: [{ target: "entity.missing" }]!,
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+    });
+
+    test('flags detour target when `target` property value uses `as const`', () => {
+      const code = `
+trail("entity.show", {
+  detours: [{ target: "entity.missing" as const }],
+  blaze: async (input, ctx) => Result.ok(data)
+})`;
+      const diagnostics = validDetourRefs.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('entity.missing');
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/warden/src/__tests__/valid-describe-refs.test.ts
+++ b/packages/warden/src/__tests__/valid-describe-refs.test.ts
@@ -58,6 +58,126 @@ trail("entity.show", {
     expect(diagnostics).toHaveLength(0);
   });
 
+  test('ignores @see tags embedded in unrelated string literals', () => {
+    const code = `
+const docs = "see also @see entity.ghost in the other doc";
+
+trail("entity.show", {
+  input: z.object({ query: z.string() }),
+  blaze: (input) => Result.ok(input),
+})`;
+
+    const diagnostics = validDescribeRefs.check(code, 'src/entity.ts');
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('ignores @see tags inside template-literal payloads that mimic describe calls', () => {
+    const code = `
+const example = \`
+trail("entity.show", {
+  input: z.object({
+    query: z.string().describe("@see entity.ghost"),
+  }),
+})\`;
+`;
+
+    const diagnostics = validDescribeRefs.check(code, 'src/entity.ts');
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('flags @see tags inside template-literal describe arguments', () => {
+    const code = `
+trail("entity.show", {
+  input: z.object({
+    query: z.string().describe(\`Search query. @see entity.ghost\`),
+  }),
+  blaze: (input) => Result.ok(input),
+})`;
+
+    const diagnostics = validDescribeRefs.check(code, 'src/entity.ts');
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('entity.ghost');
+  });
+
+  describe('template literals with expressions', () => {
+    test('detects @see refs with a leading interpolation', () => {
+      const code = `
+trail("entity.show", {
+  input: z.object({
+    query: z.string().describe(\`search for \${query}. @see entity.ghost\`),
+  }),
+  blaze: (input) => Result.ok(input),
+})`;
+
+      const diagnostics = validDescribeRefs.check(code, 'src/entity.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('entity.ghost');
+    });
+
+    test('detects @see refs across quasis separated by an interpolation', () => {
+      const code = `
+trail("entity.show", {
+  input: z.object({
+    query: z.string().describe(\`\${prefix} @see missing.trail\`),
+  }),
+  blaze: (input) => Result.ok(input),
+})`;
+
+      const diagnostics = validDescribeRefs.check(code, 'src/entity.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('missing.trail');
+    });
+
+    test('still detects @see refs across quasis containing escape sequences', () => {
+      const code = `
+trail("entity.show", {
+  input: z.object({
+    query: z.string().describe(\`path\\\\to\\\\docs. @see missing.trail\`),
+  }),
+  blaze: (input) => Result.ok(input),
+})`;
+
+      const diagnostics = validDescribeRefs.check(code, 'src/entity.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('missing.trail');
+    });
+
+    test('does not diagnose when quasis contain no @see token', () => {
+      const code = `
+trail("entity.show", {
+  input: z.object({
+    query: z.string().describe(\`\${prefix}\${suffix}\`),
+  }),
+  blaze: (input) => Result.ok(input),
+})`;
+
+      const diagnostics = validDescribeRefs.check(code, 'src/entity.ts');
+
+      expect(diagnostics).toHaveLength(0);
+    });
+  });
+
+  test('ignores describe calls whose argument is not a string literal', () => {
+    const code = `
+const mapFn = (x) => x;
+stream.describe(() => mapFn);
+
+trail("entity.show", {
+  input: z.object({ query: z.string() }),
+  blaze: (input) => Result.ok(input),
+})`;
+
+    const diagnostics = validDescribeRefs.check(code, 'src/entity.ts');
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
   test('does not treat legacy event declarations as valid trail refs', () => {
     const code = `
 event("entity.updated", {

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -189,6 +189,48 @@ export const extractStringLiteral = (
 ): string | null =>
   node && isStringLiteral(node) ? getStringValue(node) : null;
 
+/**
+ * Extract the cooked value from a `TemplateLiteral` with no interpolations
+ * (e.g. `` `entity.fallback` ``). Template literals with `${...}` expressions
+ * cannot be resolved at lint time and return null.
+ *
+ * Shared helper used by rules that accept both string literals and simple
+ * backtick-literal IDs (e.g. `valid-detour-refs`, `valid-describe-refs`).
+ */
+const getSingleQuasi = (node: AstNode): AstNode | null => {
+  const expressions =
+    (node['expressions'] as readonly AstNode[] | undefined) ?? [];
+  if (expressions.length > 0) {
+    return null;
+  }
+  const quasis = (node['quasis'] as readonly AstNode[] | undefined) ?? [];
+  return quasis.length === 1 ? (quasis[0] ?? null) : null;
+};
+
+export const extractPlainTemplateLiteral = (
+  node: AstNode | undefined
+): string | null => {
+  if (!node || node.type !== 'TemplateLiteral') {
+    return null;
+  }
+  const quasi = getSingleQuasi(node);
+  if (!quasi) {
+    return null;
+  }
+  const cooked = (quasi as unknown as { value?: { cooked?: unknown } }).value
+    ?.cooked;
+  return typeof cooked === 'string' ? cooked : null;
+};
+
+/**
+ * Extract a string value from either a string literal or a plain template
+ * literal (no `${...}` expressions). Returns null for anything else.
+ */
+export const extractStringOrTemplateLiteral = (
+  node: AstNode | undefined
+): string | null =>
+  extractStringLiteral(node) ?? extractPlainTemplateLiteral(node);
+
 export interface StringLiteralMatch {
   readonly end: number;
   readonly node: AstNode;
@@ -447,6 +489,32 @@ export const collectServiceDefinitionIds = collectResourceDefinitionIds;
 // Config property extraction helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Extract the identifying name of a `Property` key, supporting both
+ * identifier keys (`{ foo: 1 }`) and string-literal keys
+ * (`{ "foo": 1 }`). Computed keys are intentionally not resolved — a
+ * computed expression could evaluate to anything and we only want to
+ * match keys that are statically equivalent to a plain identifier.
+ */
+const staticPropertyKeyName = (key: AstNode): string | null => {
+  if (key.type === 'Identifier') {
+    return (key as unknown as { name?: string }).name ?? null;
+  }
+  return isStringLiteral(key) ? getStringValue(key) : null;
+};
+
+const propertyKeyName = (prop: AstNode): string | null => {
+  if (prop.type !== 'Property') {
+    return null;
+  }
+  const { computed } = prop as unknown as { computed?: boolean };
+  if (computed) {
+    return null;
+  }
+  const key = prop.key as AstNode | undefined;
+  return key ? staticPropertyKeyName(key) : null;
+};
+
 /** Find a Property node by key name inside an ObjectExpression config. */
 export const findConfigProperty = (
   config: AstNode,
@@ -460,7 +528,7 @@ export const findConfigProperty = (
     return null;
   }
   for (const prop of properties) {
-    if (prop.type === 'Property' && prop.key?.name === propertyName) {
+    if (propertyKeyName(prop) === propertyName) {
       return prop;
     }
   }
@@ -533,8 +601,7 @@ const extractIdFromConfig = (config: AstNode): string | null => {
   if (!idProp || !idProp.value) {
     return null;
   }
-  const val = (idProp.value as unknown as { value?: unknown }).value;
-  return typeof val === 'string' ? val : null;
+  return extractStringOrTemplateLiteral(idProp.value as AstNode);
 };
 
 const extractTrailId = (trailArgs: {
@@ -542,7 +609,7 @@ const extractTrailId = (trailArgs: {
   configArg: AstNode;
 }): string | null => {
   if (trailArgs.idArg) {
-    return (trailArgs.idArg as unknown as { value?: string }).value ?? null;
+    return extractStringOrTemplateLiteral(trailArgs.idArg);
   }
   return extractIdFromConfig(trailArgs.configArg);
 };

--- a/packages/warden/src/rules/no-sync-result-assumption.ts
+++ b/packages/warden/src/rules/no-sync-result-assumption.ts
@@ -1,42 +1,16 @@
+import { identifierName, isBlazeCall, offsetToLine, parse } from './ast.js';
+import type { AstNode } from './ast.js';
+import { isFrameworkInternalFile, isTestFile } from './scan.js';
 import type { WardenDiagnostic, WardenRule } from './types.js';
-import {
-  isFrameworkInternalFile,
-  isTestFile,
-  stripQuotedContent,
-} from './scan.js';
 
-const RESULT_ACCESS_PATTERN =
-  /\.(?:isOk|isErr|match|map)\s*\(|\.(?:value|error)\b/;
-const IMPLEMENTATION_CALL_PATTERN = /\.blaze\s*\(/;
-
-const isAwaitedImplementationCall = (line: string): boolean => {
-  const callIndex = line.indexOf('.blaze(');
-  if (callIndex === -1) {
-    return false;
-  }
-
-  const awaitIndex = line.indexOf('await');
-  return awaitIndex !== -1 && awaitIndex < callIndex;
-};
-
-const isDirectResultAccess = (line: string): boolean =>
-  IMPLEMENTATION_CALL_PATTERN.test(line) &&
-  RESULT_ACCESS_PATTERN.test(line) &&
-  !isAwaitedImplementationCall(line);
-
-const isPendingUse = (line: string, variableName: string): boolean => {
-  const escaped = variableName.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pendingPattern = new RegExp(
-    `\\b${escaped}\\s*(?:\\.(?:isOk|isErr|match|map)\\s*\\(|\\.(?:value|error)\\b)`
-  );
-  return pendingPattern.test(line);
-};
-
-interface PendingCall {
-  line: number;
-  remainingLines: number;
-  variableName: string;
-}
+const RESULT_ACCESSOR_PROPERTIES = new Set([
+  'error',
+  'isErr',
+  'isOk',
+  'map',
+  'match',
+  'value',
+]);
 
 const MISSING_AWAIT_MESSAGE =
   'Missing await: .blaze() returns Promise<Result> after normalization. Use `const result = await trail.blaze(input, ctx)`.';
@@ -52,91 +26,979 @@ const createMissingAwaitDiagnostic = (
   severity: 'error',
 });
 
-const trackPendingCall = (line: string): string | undefined => {
-  const match = line.match(
-    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([^;]*)/
-  );
-  if (!match?.[1] || !match[2] || !IMPLEMENTATION_CALL_PATTERN.test(match[2])) {
-    return undefined;
-  }
+const isAstLike = (value: unknown): value is AstNode =>
+  !!value && typeof value === 'object' && !!(value as AstNode).type;
 
-  if (isAwaitedImplementationCall(match[2])) {
-    return undefined;
-  }
+/**
+ * Build parent map for a full AST.
+ *
+ * Populates a `WeakMap` directly during traversal so we never materialize a
+ * strong `Map` holding references to every AST node — the WeakMap lets parent
+ * entries be reclaimed alongside their nodes once the rule invocation ends.
+ */
+const buildParentMap = (ast: AstNode): WeakMap<AstNode, AstNode> => {
+  const parents = new WeakMap<AstNode, AstNode>();
 
-  return match[1];
+  const recordAndVisit = (child: unknown, parent: AstNode): void => {
+    if (isAstLike(child)) {
+      parents.set(child, parent);
+      // eslint-disable-next-line no-use-before-define
+      visit(child);
+    }
+  };
+
+  const visit = (node: AstNode): void => {
+    for (const val of Object.values(node)) {
+      if (Array.isArray(val)) {
+        for (const item of val) {
+          recordAndVisit(item, node);
+        }
+      } else {
+        recordAndVisit(val, node);
+      }
+    }
+  };
+
+  visit(ast);
+  return parents;
 };
 
-const addPendingCall = (
-  pendingCalls: PendingCall[],
-  variableName: string,
-  lineNumber: number
+/**
+ * Walk up the parent chain and return true when the expression is awaited
+ * before any result-accessing member access fires on it.
+ *
+ * `await x.blaze(...)` → awaited.
+ * `(await x.blaze(...)).isOk()` → awaited (await wraps before member access).
+ * `x.blaze(...).isOk()` → NOT awaited (member access on raw call).
+ */
+const TRANSPARENT_WRAPPER_TYPES = new Set([
+  'ParenthesizedExpression',
+  'TSAsExpression',
+  'TSSatisfiesExpression',
+  'TSNonNullExpression',
+  'TSTypeAssertion',
+]);
+
+const skipParens = (
+  node: AstNode,
+  parents: WeakMap<AstNode, AstNode>
+): AstNode => {
+  let current = node;
+  let parent = parents.get(current);
+  while (parent?.type && TRANSPARENT_WRAPPER_TYPES.has(parent.type)) {
+    current = parent;
+    parent = parents.get(current);
+  }
+  return current;
+};
+
+/**
+ * Walk up through any wrapping parentheses and, when the current node sits
+ * in the `consequent` or `alternate` of a `ConditionalExpression`, through
+ * that conditional too. Returns the node whose parent should be inspected.
+ *
+ * Conservative: we only hop across a conditional when the node is one of
+ * its branches (not the `test` position). This lets us treat both
+ * `const r = cond ? x.blaze(...) : fallback` and
+ * `await (cond ? x.blaze(...) : fallback)` correctly without misattributing
+ * calls used as conditions.
+ */
+const isBranchOfConditional = (outer: AstNode, parent: AstNode): boolean => {
+  if (parent.type !== 'ConditionalExpression') {
+    return false;
+  }
+  const cond = parent as unknown as {
+    consequent?: AstNode;
+    alternate?: AstNode;
+  };
+  return cond.consequent === outer || cond.alternate === outer;
+};
+
+/**
+ * Logical expressions (`&&`, `||`, `??`) carry the blaze result through either
+ * side. A `.blaze()` on either operand may be the value ultimately bound to a
+ * declarator (e.g. `const r = cond && trail.blaze(...)`), so we treat both
+ * operands as carriers.
+ */
+const isOperandOfLogical = (outer: AstNode, parent: AstNode): boolean => {
+  if (parent.type !== 'LogicalExpression') {
+    return false;
+  }
+  const logical = parent as unknown as { left?: AstNode; right?: AstNode };
+  return logical.left === outer || logical.right === outer;
+};
+
+const skipParensAndBranchConditionals = (
+  node: AstNode,
+  parents: WeakMap<AstNode, AstNode>
+): AstNode => {
+  let outer = skipParens(node, parents);
+  while (true) {
+    const parent = parents.get(outer);
+    if (!parent) {
+      return outer;
+    }
+    if (
+      !(
+        isBranchOfConditional(outer, parent) ||
+        isOperandOfLogical(outer, parent)
+      )
+    ) {
+      return outer;
+    }
+    outer = skipParens(parent, parents);
+  }
+};
+
+const isAwaited = (
+  node: AstNode,
+  parents: WeakMap<AstNode, AstNode>
+): boolean => {
+  // Walk up through parens and any conditional whose branch is the blaze
+  // call. `await (c ? x.blaze(...) : fallback)` awaits the conditional as a
+  // whole, so the blaze call in a branch is effectively awaited.
+  const outer = skipParensAndBranchConditionals(node, parents);
+  return parents.get(outer)?.type === 'AwaitExpression';
+};
+
+const memberPropertyName = (node: AstNode): string | null => {
+  if (
+    node.type !== 'MemberExpression' &&
+    node.type !== 'StaticMemberExpression'
+  ) {
+    return null;
+  }
+  const prop = (node as unknown as { property?: AstNode }).property;
+  if (prop?.type !== 'Identifier') {
+    return null;
+  }
+  return (prop as unknown as { name?: string }).name ?? null;
+};
+
+/**
+ * Check if the blaze call is directly consumed by a result accessor
+ * (e.g. `foo.blaze(...).isOk()` or `foo.blaze(...).value`).
+ */
+const hasDirectResultAccess = (
+  blazeCall: AstNode,
+  parents: WeakMap<AstNode, AstNode>
+): boolean => {
+  // Unwrap wrapping parentheses, conditional branches, and logical-operator
+  // operands so `(x.blaze(...)).isOk()`,
+  // `(cond ? x.blaze(...) : fb).isOk()`, and
+  // `(cond && x.blaze(...)).isOk()` are all detected the same way as the
+  // bare `x.blaze(...).isOk()` shape.
+  const outer = skipParensAndBranchConditionals(blazeCall, parents);
+  const parent = parents.get(outer);
+  if (!parent) {
+    return false;
+  }
+  const property = memberPropertyName(parent);
+  return property !== null && RESULT_ACCESSOR_PROPERTIES.has(property);
+};
+
+/**
+ * If the blaze call is the init of a VariableDeclarator (directly, through
+ * parens, or as a branch of a ConditionalExpression init), return the bound
+ * identifier name. Otherwise null.
+ */
+const extractAssignedBinding = (
+  blazeCall: AstNode,
+  parents: WeakMap<AstNode, AstNode>
+): string | null => {
+  const outer = skipParensAndBranchConditionals(blazeCall, parents);
+  const parent = parents.get(outer);
+  if (!parent || parent.type !== 'VariableDeclarator') {
+    return null;
+  }
+  const { id } = parent as unknown as { id?: AstNode };
+  return identifierName(id);
+};
+
+interface PendingBinding {
+  readonly name: string;
+  readonly declarationNode: AstNode;
+  /** Unique id of the scope frame that owns this binding. */
+  readonly scopeId: number;
+}
+
+const isResultAccessorMember = (node: AstNode): boolean => {
+  if (
+    node.type !== 'MemberExpression' &&
+    node.type !== 'StaticMemberExpression'
+  ) {
+    return false;
+  }
+  const property = memberPropertyName(node);
+  return property !== null && RESULT_ACCESSOR_PROPERTIES.has(property);
+};
+
+const getIdentifierObjectName = (node: AstNode): string | null => {
+  const { object } = node as unknown as { object?: AstNode };
+  return object?.type === 'Identifier' ? identifierName(object) : null;
+};
+
+// ---------------------------------------------------------------------------
+// Scope tracking
+// ---------------------------------------------------------------------------
+
+const collectIdentifierBinding = (pattern: AstNode, out: Set<string>): void => {
+  const name = identifierName(pattern);
+  if (name) {
+    out.add(name);
+  }
+};
+
+const collectAssignmentPatternBindings = (
+  pattern: AstNode,
+  out: Set<string>
 ): void => {
-  pendingCalls.push({
-    line: lineNumber,
-    remainingLines: 6,
-    variableName,
+  const { left } = pattern as unknown as { left?: AstNode };
+  // eslint-disable-next-line no-use-before-define
+  collectPatternBindings(left, out);
+};
+
+const collectRestElementBindings = (
+  pattern: AstNode,
+  out: Set<string>
+): void => {
+  const { argument } = pattern as unknown as { argument?: AstNode };
+  // eslint-disable-next-line no-use-before-define
+  collectPatternBindings(argument, out);
+};
+
+type PatternHandler = (pattern: AstNode, out: Set<string>) => void;
+
+const PATTERN_HANDLERS: Record<string, PatternHandler> = {
+  // eslint-disable-next-line no-use-before-define
+  ArrayPattern: (p, out) => collectArrayPatternBindings(p, out),
+  AssignmentPattern: collectAssignmentPatternBindings,
+  Identifier: collectIdentifierBinding,
+  // eslint-disable-next-line no-use-before-define
+  ObjectPattern: (p, out) => collectObjectPatternBindings(p, out),
+  RestElement: collectRestElementBindings,
+};
+
+/**
+ * Collect binding names introduced by a destructuring / parameter pattern.
+ * Handles Identifier, AssignmentPattern, ObjectPattern, ArrayPattern,
+ * and RestElement shapes.
+ *
+ * `function` declaration (instead of an arrow) so it can be hoisted for the
+ * mutually recursive calls from the array / object pattern helpers below.
+ */
+// biome-ignore lint/style/useConst: hoisted for mutual recursion
+// eslint-disable-next-line func-style
+function collectPatternBindings(
+  pattern: AstNode | undefined,
+  out: Set<string>
+): void {
+  if (!pattern) {
+    return;
+  }
+  const handler = PATTERN_HANDLERS[pattern.type];
+  if (handler) {
+    handler(pattern, out);
+  }
+}
+
+const collectArrayPatternBindings = (
+  pattern: AstNode,
+  out: Set<string>
+): void => {
+  const { elements } = pattern as unknown as {
+    elements?: readonly (AstNode | null)[];
+  };
+  if (!elements) {
+    return;
+  }
+  for (const element of elements) {
+    if (element) {
+      // eslint-disable-next-line no-use-before-define
+      collectPatternBindings(element, out);
+    }
+  }
+};
+
+const collectObjectPatternBindings = (
+  pattern: AstNode,
+  out: Set<string>
+): void => {
+  const { properties } = pattern as unknown as {
+    properties?: readonly AstNode[];
+  };
+  if (!properties) {
+    return;
+  }
+  for (const prop of properties) {
+    if (prop.type === 'RestElement') {
+      // eslint-disable-next-line no-use-before-define
+      collectPatternBindings(prop, out);
+    } else {
+      // Property node: value holds the binding pattern.
+      const { value } = prop as unknown as { value?: AstNode };
+      // eslint-disable-next-line no-use-before-define
+      collectPatternBindings(value, out);
+    }
+  }
+};
+
+const SCOPE_NODE_TYPES = new Set([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+  'BlockStatement',
+  'StaticBlock',
+  'CatchClause',
+  'ForStatement',
+  'ForInStatement',
+  'ForOfStatement',
+]);
+
+const isScopeBoundary = (node: AstNode): boolean =>
+  SCOPE_NODE_TYPES.has(node.type);
+
+/**
+ * Collect the local binding names introduced directly in this scope's own
+ * declarations (params + var/let/const/catch/for declarations), without
+ * descending into nested function or block scopes.
+ *
+ * For function-like scopes, the body (a BlockStatement) is its own child
+ * scope — we do not merge params into it. Params and body bindings are
+ * treated as sibling frames via the scope walk: when entering the function,
+ * we push a frame with params; when entering its body block, we push another
+ * frame with the block's declarations. Nearest-scope resolution treats them
+ * as a single effective scope chain.
+ */
+const FUNCTION_SCOPE_TYPES = new Set([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+]);
+
+const collectVariableDeclarationBindings = (
+  declNode: AstNode | undefined,
+  out: Set<string>
+): void => {
+  if (!declNode || declNode.type !== 'VariableDeclaration') {
+    return;
+  }
+  const declarators = (
+    declNode as unknown as {
+      declarations?: readonly AstNode[];
+    }
+  ).declarations;
+  if (!declarators) {
+    return;
+  }
+  for (const d of declarators) {
+    const { id } = d as unknown as { id?: AstNode };
+    collectPatternBindings(id, out);
+  }
+};
+
+const getVariableDeclarationKind = (
+  declNode: AstNode | undefined
+): string | null => {
+  if (!declNode || declNode.type !== 'VariableDeclaration') {
+    return null;
+  }
+  return (declNode as unknown as { kind?: string }).kind ?? null;
+};
+
+/** True if declaration is `var` (function/program-scoped, hoistable). */
+const isVarDeclaration = (declNode: AstNode | undefined): boolean =>
+  getVariableDeclarationKind(declNode) === 'var';
+
+/** Collect only `let`/`const` declarator bindings (block-scoped). */
+const collectBlockScopedDeclaratorBindings = (
+  declNode: AstNode | undefined,
+  out: Set<string>
+): void => {
+  const kind = getVariableDeclarationKind(declNode);
+  if (!kind || kind === 'var') {
+    return;
+  }
+  collectVariableDeclarationBindings(declNode, out);
+};
+
+interface FunctionScopeBindings {
+  readonly bindings: Set<string>;
+  readonly paramBindings: Set<string>;
+}
+
+const collectParamBindings = (scope: AstNode): Set<string> => {
+  const paramBindings = new Set<string>();
+  const { params } = scope as unknown as { params?: readonly AstNode[] };
+  if (params) {
+    for (const param of params) {
+      collectPatternBindings(param, paramBindings);
+    }
+  }
+  return paramBindings;
+};
+
+const addHoistedVarsFromBody = (scope: AstNode, out: Set<string>): void => {
+  const { body } = scope as unknown as { body?: AstNode };
+  if (!(body && isAstLike(body))) {
+    return;
+  }
+  const hoisted = new Set<string>();
+  // eslint-disable-next-line no-use-before-define
+  collectHoistedVarBindings(body, hoisted);
+  for (const name of hoisted) {
+    out.add(name);
+  }
+};
+
+const collectFunctionScopeBindingsEx = (
+  scope: AstNode
+): FunctionScopeBindings => {
+  const paramBindings = collectParamBindings(scope);
+  const bindings = new Set<string>(paramBindings);
+  addHoistedVarsFromBody(scope, bindings);
+  return { bindings, paramBindings };
+};
+
+const collectFunctionScopeBindings = (scope: AstNode): Set<string> =>
+  collectFunctionScopeBindingsEx(scope).bindings;
+
+const collectCatchScopeBindings = (scope: AstNode): Set<string> => {
+  const bindings = new Set<string>();
+  const { param } = scope as unknown as { param?: AstNode };
+  collectPatternBindings(param, bindings);
+  return bindings;
+};
+
+const collectForScopeBindings = (scope: AstNode): Set<string> => {
+  const bindings = new Set<string>();
+  if (scope.type === 'ForStatement') {
+    const { init } = scope as unknown as { init?: AstNode };
+    collectBlockScopedDeclaratorBindings(init, bindings);
+  } else {
+    const { left } = scope as unknown as { left?: AstNode };
+    collectBlockScopedDeclaratorBindings(left, bindings);
+  }
+  return bindings;
+};
+
+const addFunctionDeclarationName = (stmt: AstNode, out: Set<string>): void => {
+  if (stmt.type !== 'FunctionDeclaration') {
+    return;
+  }
+  const { id } = stmt as unknown as { id?: AstNode };
+  const fnName = identifierName(id);
+  if (fnName) {
+    out.add(fnName);
+  }
+};
+
+const addClassDeclarationName = (stmt: AstNode, out: Set<string>): void => {
+  if (stmt.type !== 'ClassDeclaration') {
+    return;
+  }
+  const { id } = stmt as unknown as { id?: AstNode };
+  const className = identifierName(id);
+  if (className) {
+    out.add(className);
+  }
+};
+
+const collectBlockScopedStatementListBindings = (
+  statements: readonly AstNode[] | undefined,
+  out: Set<string>
+): void => {
+  if (!statements) {
+    return;
+  }
+  for (const stmt of statements) {
+    collectBlockScopedDeclaratorBindings(stmt, out);
+    addFunctionDeclarationName(stmt, out);
+    addClassDeclarationName(stmt, out);
+  }
+};
+
+const collectBlockStatementBindings = (scope: AstNode): Set<string> => {
+  const bindings = new Set<string>();
+  const { body } = scope as unknown as { body?: readonly AstNode[] };
+  collectBlockScopedStatementListBindings(body, bindings);
+  return bindings;
+};
+
+/**
+ * Collect the local binding names introduced directly in this scope's own
+ * declarations (params + var/let/const/catch/for declarations), without
+ * descending into nested function or block scopes.
+ */
+const collectScopeBindings = (scope: AstNode): Set<string> => {
+  if (FUNCTION_SCOPE_TYPES.has(scope.type)) {
+    return collectFunctionScopeBindings(scope);
+  }
+  if (scope.type === 'CatchClause') {
+    return collectCatchScopeBindings(scope);
+  }
+  if (
+    scope.type === 'ForStatement' ||
+    scope.type === 'ForInStatement' ||
+    scope.type === 'ForOfStatement'
+  ) {
+    return collectForScopeBindings(scope);
+  }
+  if (scope.type === 'BlockStatement' || scope.type === 'StaticBlock') {
+    return collectBlockStatementBindings(scope);
+  }
+  return new Set();
+};
+
+type ScopeKind = 'program' | 'function' | 'block' | 'for' | 'catch';
+
+interface ScopeFrame {
+  readonly id: number;
+  readonly kind: ScopeKind;
+  readonly bindings: Set<string>;
+  /**
+   * For function frames: names that came from parameters (not hoisted `var`s).
+   * A `var` declaration with the same name as a parameter is redundant in JS —
+   * the parameter is the real binding. We track params separately so we don't
+   * register a pending `.blaze()` binding that is actually shadowed by a param.
+   */
+  readonly paramBindings?: Set<string>;
+}
+
+const scopeKindForNode = (node: AstNode): ScopeKind => {
+  if (FUNCTION_SCOPE_TYPES.has(node.type)) {
+    return 'function';
+  }
+  if (node.type === 'CatchClause') {
+    return 'catch';
+  }
+  if (
+    node.type === 'ForStatement' ||
+    node.type === 'ForInStatement' ||
+    node.type === 'ForOfStatement'
+  ) {
+    return 'for';
+  }
+  return 'block';
+};
+
+/**
+ * True when a nested node owns its own VariableEnvironment and therefore stops
+ * `var` hoisting from crossing into the enclosing function/program scope.
+ * Covers function-like nodes and `StaticBlock` (ECMAScript: static blocks
+ * introduce their own LexicalEnvironment and VariableEnvironment).
+ */
+const ownsVariableEnvironment = (node: AstNode): boolean =>
+  FUNCTION_SCOPE_TYPES.has(node.type) || node.type === 'StaticBlock';
+
+const collectHoistedVarBindings = (root: AstNode, out: Set<string>): void => {
+  const visit = (node: AstNode, isRoot: boolean): void => {
+    // Nested var-environment owners (functions, static blocks) do not leak
+    // their `var`s to the enclosing scope.
+    if (!isRoot && ownsVariableEnvironment(node)) {
+      return;
+    }
+    if (node.type === 'VariableDeclaration' && isVarDeclaration(node)) {
+      collectVariableDeclarationBindings(node, out);
+    }
+    for (const val of Object.values(node)) {
+      if (Array.isArray(val)) {
+        for (const item of val) {
+          if (isAstLike(item)) {
+            visit(item, false);
+          }
+        }
+      } else if (isAstLike(val)) {
+        visit(val, false);
+      }
+    }
+  };
+  visit(root, true);
+};
+
+interface AnalyzeState {
+  readonly parents: WeakMap<AstNode, AstNode>;
+  readonly diagnostics: WardenDiagnostic[];
+  readonly sourceCode: string;
+  readonly filePath: string;
+  /** Pending `.blaze()` bindings seen so far, keyed by scope id + name. */
+  readonly pendingByScopeAndName: Map<string, PendingBinding>;
+  readonly scopeStack: ScopeFrame[];
+  readonly reportedAt: Set<number>;
+  nextScopeId: number;
+}
+
+const pendingKey = (scopeId: number, name: string): string =>
+  `${scopeId}\u0000${name}`;
+
+/**
+ * Resolve an identifier use to the nearest enclosing scope frame that binds
+ * the name. Returns `null` if no frame binds it.
+ */
+const resolveNearestScope = (
+  name: string,
+  stack: readonly ScopeFrame[]
+): ScopeFrame | null => {
+  for (let i = stack.length - 1; i >= 0; i -= 1) {
+    const frame = stack[i];
+    if (frame && frame.bindings.has(name)) {
+      return frame;
+    }
+  }
+  return null;
+};
+
+/**
+ * Resolve the blaze call to a `{ name, declarator }` pair when it is the init
+ * of a `VariableDeclarator` (directly, through parens, or as a branch of a
+ * `ConditionalExpression` init). Returns null otherwise.
+ */
+const resolveBlazeBinding = (
+  blazeCall: AstNode,
+  parents: WeakMap<AstNode, AstNode>
+): { readonly name: string; readonly declarator: AstNode } | null => {
+  const name = extractAssignedBinding(blazeCall, parents);
+  if (!name) {
+    return null;
+  }
+  // Mirror `extractAssignedBinding`: unwrap parens and branch-position
+  // conditionals so the stored declaration node points at the
+  // `VariableDeclarator`, not at an intermediate `ParenthesizedExpression`
+  // or `ConditionalExpression`.
+  const outer = skipParensAndBranchConditionals(blazeCall, parents);
+  const declarator = parents.get(outer);
+  return declarator ? { declarator, name } : null;
+};
+
+/**
+ * Resolve the blaze call to a `{ name, assignment }` pair when it is the RHS
+ * of a plain `=` `AssignmentExpression` with an `Identifier` LHS (directly,
+ * through parens, or as a branch of a conditional/logical expression).
+ *
+ * Covers patterns like:
+ *   let result;
+ *   result = trail.blaze(input, ctx);
+ *   result.isOk();
+ *
+ * Member-expression LHS (`obj.result = blaze(...)`) is intentionally skipped —
+ * those are property writes, not bare bindings we can track by name.
+ */
+const extractPlainIdentifierAssignmentName = (
+  parent: AstNode | undefined
+): string | null => {
+  if (!parent || parent.type !== 'AssignmentExpression') {
+    return null;
+  }
+  const { operator, left } = parent as unknown as {
+    operator?: string;
+    left?: AstNode;
+  };
+  // Only plain `=` assignments to a bare identifier. Member-expression LHS
+  // (`obj.result = blaze(...)`) is a property write, not a bare binding we
+  // can track by name.
+  if (operator !== '=' || !left || left.type !== 'Identifier') {
+    return null;
+  }
+  return identifierName(left);
+};
+
+const resolveBlazeAssignment = (
+  blazeCall: AstNode,
+  parents: WeakMap<AstNode, AstNode>
+): { readonly name: string; readonly assignment: AstNode } | null => {
+  const outer = skipParensAndBranchConditionals(blazeCall, parents);
+  const parent = parents.get(outer);
+  const name = extractPlainIdentifierAssignmentName(parent);
+  return name && parent ? { assignment: parent, name } : null;
+};
+
+/**
+ * True when `declarator` is a `VariableDeclarator` whose parent
+ * `VariableDeclaration` uses the `var` kind. Such declarators re-initialize
+ * a same-named function parameter rather than shadowing it, because `var`
+ * and parameters share the function's VariableEnvironment.
+ */
+const isVarDeclaratorOfParamName = (
+  declarator: AstNode,
+  parents: WeakMap<AstNode, AstNode>
+): boolean => {
+  if (declarator.type !== 'VariableDeclarator') {
+    return false;
+  }
+  const decl = parents.get(declarator);
+  return isVarDeclaration(decl);
+};
+
+/**
+ * True when `node` is a plain `=` `AssignmentExpression` with an `Identifier`
+ * LHS. Such an assignment writes to the existing binding for that name — if
+ * that name is a function parameter, the assignment re-initializes the
+ * parameter's slot in the VariableEnvironment, just like `var <name> = ...`.
+ * Compound assignments (`+=`, `??=`, etc.) are excluded because they do not
+ * unconditionally replace the slot with the blaze result.
+ */
+const isAssignmentToParamName = (node: AstNode): boolean => {
+  if (node.type !== 'AssignmentExpression') {
+    return false;
+  }
+  const { operator, left } = node as unknown as {
+    operator?: string;
+    left?: AstNode;
+  };
+  return operator === '=' && left?.type === 'Identifier';
+};
+
+const recordPendingBinding = (
+  blazeCall: AstNode,
+  state: AnalyzeState
+): void => {
+  const binding =
+    resolveBlazeBinding(blazeCall, state.parents) ??
+    (() => {
+      const asn = resolveBlazeAssignment(blazeCall, state.parents);
+      return asn ? { declarator: asn.assignment, name: asn.name } : null;
+    })();
+  if (!binding) {
+    return;
+  }
+  const { name, declarator } = binding;
+  // The pending binding lives in the nearest scope that declares `name`.
+  // That is always the innermost scope in the current stack, because the
+  // variable declaration's id was contributed to its enclosing scope's
+  // bindings when that scope was entered.
+  const owningFrame = resolveNearestScope(name, state.scopeStack);
+  if (!owningFrame) {
+    return;
+  }
+  // If the name resolves to a function parameter, the `var` that visually
+  // appears to declare it is redundant — the parameter is the real binding,
+  // and parameters are not pending `.blaze()` results.
+  //
+  // Carve-out: a `var <name> = blaze(...)` *initializer* inside the same
+  // function body legitimately re-binds the parameter at that point. `var`
+  // and parameters share the function's VariableEnvironment, so the `var`
+  // writes to the existing parameter slot and the subsequent use resolves
+  // to the freshly-assigned `.blaze()` result. Treat that as a pending
+  // binding.
+  //
+  // The same logic applies to a bare `result = blaze(...)` assignment: it
+  // writes to the parameter's existing slot in the same VariableEnvironment,
+  // so the subsequent `result.isOk()` observes the blaze result. Only
+  // compound assignments (`+=`, `??=`, etc.) and member-expression LHS fall
+  // through the param-shadow suppression, because they do not
+  // unconditionally replace the parameter slot with the blaze result.
+  if (
+    owningFrame.paramBindings?.has(name) &&
+    !isVarDeclaratorOfParamName(declarator, state.parents) &&
+    !isAssignmentToParamName(declarator)
+  ) {
+    return;
+  }
+  state.pendingByScopeAndName.set(pendingKey(owningFrame.id, name), {
+    declarationNode: declarator,
+    name,
+    scopeId: owningFrame.id,
   });
 };
 
-const advancePendingCalls = (
-  line: string,
-  filePath: string,
-  lineNumber: number,
-  pendingCalls: PendingCall[],
-  diagnostics: WardenDiagnostic[]
-): void => {
-  for (let j = pendingCalls.length - 1; j >= 0; j -= 1) {
-    const pendingCall = pendingCalls[j];
-    if (pendingCall && isPendingUse(line, pendingCall.variableName)) {
-      diagnostics.push(createMissingAwaitDiagnostic(filePath, lineNumber));
-      pendingCalls.splice(j, 1);
-    } else if (pendingCall) {
-      pendingCall.remainingLines -= 1;
-      if (pendingCall.remainingLines <= 0) {
-        pendingCalls.splice(j, 1);
+const reportMissingAwait = (node: AstNode, state: AnalyzeState): void => {
+  if (state.reportedAt.has(node.start)) {
+    return;
+  }
+  state.reportedAt.add(node.start);
+  state.diagnostics.push(
+    createMissingAwaitDiagnostic(
+      state.filePath,
+      offsetToLine(state.sourceCode, node.start)
+    )
+  );
+};
+
+const findPendingBindingForUse = (
+  node: AstNode,
+  state: AnalyzeState
+): PendingBinding | null => {
+  if (!isResultAccessorMember(node)) {
+    return null;
+  }
+  const name = getIdentifierObjectName(node);
+  if (!name) {
+    return null;
+  }
+  const frame = resolveNearestScope(name, state.scopeStack);
+  if (!frame) {
+    return null;
+  }
+  return state.pendingByScopeAndName.get(pendingKey(frame.id, name)) ?? null;
+};
+
+const checkPendingAccess = (node: AstNode, state: AnalyzeState): void => {
+  const binding = findPendingBindingForUse(node, state);
+  if (!binding) {
+    return;
+  }
+  // Declaration must precede the use. Use source offsets for ordering.
+  if (node.start < binding.declarationNode.end) {
+    return;
+  }
+  reportMissingAwait(node, state);
+};
+
+/**
+ * If the blaze call is the init of a VariableDeclarator whose id is an
+ * ObjectPattern that destructures any known Result accessor property,
+ * return the declarator node. Otherwise null.
+ *
+ * Catches the core missing-await shape when written as destructuring:
+ *   `const { isOk } = entityShow.blaze(input, ctx)` — no await, immediate
+ *   access to a Result accessor, should fire.
+ */
+const propertyDestructuresResultAccessor = (prop: AstNode): boolean => {
+  if (prop.type === 'RestElement') {
+    return false;
+  }
+  const { key } = prop as unknown as { key?: AstNode };
+  const keyName = identifierName(key);
+  return keyName !== null && RESULT_ACCESSOR_PROPERTIES.has(keyName);
+};
+
+const objectPatternHasResultAccessorKey = (pattern: AstNode): boolean => {
+  const { properties } = pattern as unknown as {
+    properties?: readonly AstNode[];
+  };
+  return properties?.some(propertyDestructuresResultAccessor) ?? false;
+};
+
+const getDestructuredResultAccessorDeclarator = (
+  blazeCall: AstNode,
+  parents: WeakMap<AstNode, AstNode>
+): AstNode | null => {
+  // Unwrap any wrapping parentheses and branch-position conditionals so
+  // `const { isOk } = (trail.blaze(...));` and
+  // `const { isOk } = cond ? trail.blaze(...) : fallback;` are treated as
+  // `const { isOk } = trail.blaze(...);`.
+  const outer = skipParensAndBranchConditionals(blazeCall, parents);
+  const parent = parents.get(outer);
+  if (!parent || parent.type !== 'VariableDeclarator') {
+    return null;
+  }
+  const { id } = parent as unknown as { id?: AstNode };
+  if (!id || id.type !== 'ObjectPattern') {
+    return null;
+  }
+  return objectPatternHasResultAccessorKey(id) ? parent : null;
+};
+
+const visitBlazeCall = (node: AstNode, state: AnalyzeState): void => {
+  if (!isBlazeCall(node) || isAwaited(node, state.parents)) {
+    return;
+  }
+  if (hasDirectResultAccess(node, state.parents)) {
+    reportMissingAwait(node, state);
+    return;
+  }
+  const destructuredDeclarator = getDestructuredResultAccessorDeclarator(
+    node,
+    state.parents
+  );
+  if (destructuredDeclarator) {
+    reportMissingAwait(destructuredDeclarator, state);
+    return;
+  }
+  recordPendingBinding(node, state);
+};
+
+const visitNode = (node: AstNode, state: AnalyzeState): void => {
+  visitBlazeCall(node, state);
+  checkPendingAccess(node, state);
+};
+
+const pushScopeIfBoundary = (node: AstNode, state: AnalyzeState): boolean => {
+  if (!isScopeBoundary(node)) {
+    return false;
+  }
+  const kind = scopeKindForNode(node);
+  if (kind === 'function') {
+    const { bindings, paramBindings } = collectFunctionScopeBindingsEx(node);
+    state.scopeStack.push({
+      bindings,
+      id: state.nextScopeId,
+      kind,
+      paramBindings,
+    });
+  } else {
+    state.scopeStack.push({
+      bindings: collectScopeBindings(node),
+      id: state.nextScopeId,
+      kind,
+    });
+  }
+  state.nextScopeId += 1;
+  return true;
+};
+
+const walkChild = (child: unknown, state: AnalyzeState): void => {
+  if (child && typeof child === 'object' && (child as AstNode).type) {
+    // eslint-disable-next-line no-use-before-define
+    walkWithScopes(child as AstNode, state);
+  }
+};
+
+const walkChildren = (node: AstNode, state: AnalyzeState): void => {
+  for (const val of Object.values(node)) {
+    if (Array.isArray(val)) {
+      for (const item of val) {
+        walkChild(item, state);
       }
+    } else {
+      walkChild(val, state);
     }
   }
 };
 
-const processLine = (
-  line: string,
-  filePath: string,
-  lineNumber: number,
-  pendingCalls: PendingCall[],
-  diagnostics: WardenDiagnostic[]
-): void => {
-  if (isDirectResultAccess(line)) {
-    diagnostics.push(createMissingAwaitDiagnostic(filePath, lineNumber));
-    return;
+// biome-ignore lint/style/useConst: hoisted for mutual recursion with walkChildren
+// eslint-disable-next-line func-style
+function walkWithScopes(node: AstNode, state: AnalyzeState): void {
+  const pushed = pushScopeIfBoundary(node, state);
+  visitNode(node, state);
+  walkChildren(node, state);
+  if (pushed) {
+    state.scopeStack.pop();
   }
+}
 
-  const variableName = trackPendingCall(line);
-  if (variableName) {
-    addPendingCall(pendingCalls, variableName, lineNumber);
-  }
-
-  advancePendingCalls(line, filePath, lineNumber, pendingCalls, diagnostics);
+const collectProgramBindings = (ast: AstNode): Set<string> => {
+  const bindings = new Set<string>();
+  const programBody = (ast as unknown as { body?: readonly AstNode[] }).body;
+  // Top-level `let`/`const`/function declarations.
+  collectBlockScopedStatementListBindings(programBody, bindings);
+  // Top-level `var`s are program-scoped; also hoist any `var`s nested
+  // inside blocks/loops at program level.
+  collectHoistedVarBindings(ast, bindings);
+  return bindings;
 };
 
-const scanSourceCode = (
+const analyze = (
+  ast: AstNode,
   sourceCode: string,
   filePath: string
 ): readonly WardenDiagnostic[] => {
-  const diagnostics: WardenDiagnostic[] = [];
-  const lines = sourceCode.split('\n');
-  const pendingCalls: PendingCall[] = [];
+  const state: AnalyzeState = {
+    diagnostics: [],
+    filePath,
+    nextScopeId: 1,
+    parents: buildParentMap(ast),
+    pendingByScopeAndName: new Map(),
+    reportedAt: new Set(),
+    scopeStack: [
+      { bindings: collectProgramBindings(ast), id: 0, kind: 'program' },
+    ],
+    sourceCode,
+  };
 
-  for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i];
-    if (!line) {
-      continue;
-    }
-    processLine(line, filePath, i + 1, pendingCalls, diagnostics);
-  }
+  walkWithScopes(ast, state);
 
-  return diagnostics;
+  return state.diagnostics;
 };
 
 /**
@@ -147,7 +1009,11 @@ export const noSyncResultAssumption: WardenRule = {
     if (isTestFile(filePath) || isFrameworkInternalFile(filePath)) {
       return [];
     }
-    return scanSourceCode(stripQuotedContent(sourceCode), filePath);
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+    return analyze(ast, sourceCode, filePath);
   },
   description:
     'Disallow treating .blaze() as synchronous after normalization. Always await the returned Promise<Result>.',

--- a/packages/warden/src/rules/valid-describe-refs.ts
+++ b/packages/warden/src/rules/valid-describe-refs.ts
@@ -1,13 +1,17 @@
+import {
+  extractStringOrTemplateLiteral,
+  offsetToLine,
+  parse,
+  walk,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isTestFile } from './scan.js';
+import { collectTrailIds } from './specs.js';
 import type {
   ProjectAwareWardenRule,
   ProjectContext,
   WardenDiagnostic,
 } from './types.js';
-import { isTestFile } from './scan.js';
-import { collectTrailIds, parseStringLiteral } from './specs.js';
-import { captureBalanced, lineNumberAt } from './structure.js';
-
-const DESCRIBE_PATTERN = /\.describe\s*\(/g;
 
 const SEE_PATTERN = /@see\s+([A-Za-z0-9_.-]+)/g;
 
@@ -16,41 +20,153 @@ interface DescribeRef {
   readonly ref: string;
 }
 
-const describeTextAt = (
-  sourceCode: string,
-  matchIndex: number
-): string | null => {
-  const openParen = sourceCode.indexOf('(', matchIndex);
-  if (openParen === -1) {
+const STRING_LITERAL_ARG_TYPES: ReadonlySet<string> = new Set([
+  'Literal',
+  'StringLiteral',
+  'TemplateLiteral',
+]);
+
+const MEMBER_CALLEE_TYPES: ReadonlySet<string> = new Set([
+  'MemberExpression',
+  'StaticMemberExpression',
+]);
+
+const isDescribeMemberCallee = (callee: AstNode | undefined): boolean => {
+  if (!callee || !MEMBER_CALLEE_TYPES.has(callee.type)) {
+    return false;
+  }
+  const prop = (callee as unknown as { property?: AstNode }).property;
+  return (
+    prop?.type === 'Identifier' &&
+    (prop as unknown as { name?: string }).name === 'describe'
+  );
+};
+
+const hasStringLiteralFirstArg = (node: AstNode): boolean => {
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  const firstArg = args?.[0];
+  return !!firstArg && STRING_LITERAL_ARG_TYPES.has(firstArg.type);
+};
+
+const isDescribeCall = (node: AstNode): boolean => {
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+  if (!isDescribeMemberCallee(node['callee'] as AstNode | undefined)) {
+    return false;
+  }
+  // Narrow to calls whose first argument is a string/template literal.
+  // Filters out RxJS-style `.describe(fn)` and other custom APIs whose
+  // `.describe()` overloads take non-string arguments. Zod's shape always
+  // passes a string literal here.
+  return hasStringLiteralFirstArg(node);
+};
+
+/**
+ * Extract scannable text from a template literal, even when it contains
+ * `${...}` expressions. Concatenates the cooked quasi chunks with an empty
+ * string between them — interpolated values are runtime-only and cannot
+ * contribute static `@see` tokens, but the surrounding quasi text can.
+ *
+ * This is intentionally describe-local: the shared
+ * {@link extractStringOrTemplateLiteral} helper preserves "plain template
+ * literal only" semantics for other rules (e.g. resolving trail/signal IDs)
+ * that require a single clean string value. Here we only need to scan for
+ * `@see` tokens, so concatenating quasi cooked text is sound.
+ *
+ * @remarks
+ * A quasi's `cooked` value can be `null` in tagged-template positions where
+ * the literal contains escape sequences the parser can't decode. `.describe`
+ * is a plain method call, not a tagged template, so in practice its quasis
+ * always have a `cooked` string today. The `raw` fallback is defensive: if a
+ * future refactor wraps `describe(\`...\`)` in a tagged template, we still
+ * scan the raw source rather than silently dropping the quasi text and
+ * missing an `@see` token.
+ */
+const extractQuasiText = (quasi: AstNode): string | null => {
+  const { value } = quasi as unknown as {
+    value?: { cooked?: unknown; raw?: unknown };
+  };
+  if (typeof value?.cooked === 'string') {
+    return value.cooked;
+  }
+  if (typeof value?.raw === 'string') {
+    return value.raw;
+  }
+  return null;
+};
+
+const extractTemplateLiteralQuasiText = (node: AstNode): string | null => {
+  if (node.type !== 'TemplateLiteral') {
     return null;
   }
-
-  return captureBalanced(sourceCode, openParen)?.text.slice(1, -1) ?? null;
+  const quasis = (node['quasis'] as readonly AstNode[] | undefined) ?? [];
+  const parts: string[] = [];
+  for (const quasi of quasis) {
+    const text = extractQuasiText(quasi);
+    if (text !== null) {
+      parts.push(text);
+    }
+  }
+  return parts.join('');
 };
 
-const refsInDescription = (
+const extractDescribeDescription = (node: AstNode): string | null => {
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  const [firstArg] = args ?? [];
+  if (!firstArg) {
+    return null;
+  }
+  return (
+    extractStringOrTemplateLiteral(firstArg) ??
+    extractTemplateLiteralQuasiText(firstArg)
+  );
+};
+
+/**
+ * Anchor the diagnostic on the string argument that actually contains the
+ * `@see` token, not on the call-expression start. For multi-line schema
+ * chains, the call-expression start can be many lines above the describe
+ * argument, which confuses editor tooling.
+ */
+const describeAnchorOffset = (node: AstNode): number => {
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  return args?.[0]?.start ?? node.start;
+};
+
+const collectRefsFromDescription = (
   description: string,
-  line: number
-): readonly DescribeRef[] =>
-  [...description.matchAll(SEE_PATTERN)].flatMap((see) =>
-    see[1] ? [{ line, ref: see[1] }] : []
-  );
-
-const refsForDescribe = (
-  sourceCode: string,
-  matchIndex: number
-): readonly DescribeRef[] => {
-  const args = describeTextAt(sourceCode, matchIndex);
-  const description = args ? parseStringLiteral(args) : null;
-  return description === null
-    ? []
-    : refsInDescription(description, lineNumberAt(sourceCode, matchIndex));
+  line: number,
+  out: DescribeRef[]
+): void => {
+  for (const match of description.matchAll(SEE_PATTERN)) {
+    const [, ref] = match;
+    if (ref) {
+      out.push({ line, ref });
+    }
+  }
 };
 
-const collectDescribeRefs = (sourceCode: string): readonly DescribeRef[] =>
-  [...sourceCode.matchAll(DESCRIBE_PATTERN)].flatMap((match) =>
-    match.index === undefined ? [] : refsForDescribe(sourceCode, match.index)
-  );
+const collectDescribeRefs = (
+  ast: AstNode,
+  sourceCode: string
+): readonly DescribeRef[] => {
+  const refs: DescribeRef[] = [];
+
+  walk(ast, (node) => {
+    if (!isDescribeCall(node)) {
+      return;
+    }
+    const description = extractDescribeDescription(node);
+    if (description === null) {
+      return;
+    }
+    const line = offsetToLine(sourceCode, describeAnchorOffset(node));
+    collectRefsFromDescription(description, line, refs);
+  });
+
+  return refs;
+};
 
 const checkDescribeRefs = (
   sourceCode: string,
@@ -61,7 +177,12 @@ const checkDescribeRefs = (
     return [];
   }
 
-  return collectDescribeRefs(sourceCode)
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  return collectDescribeRefs(ast, sourceCode)
     .filter(({ ref }) => !knownTrailIds.has(ref))
     .map(({ line, ref }) => ({
       filePath,

--- a/packages/warden/src/rules/valid-detour-refs.ts
+++ b/packages/warden/src/rules/valid-detour-refs.ts
@@ -1,5 +1,13 @@
 import { isDraftId } from '@ontrails/core';
 
+import {
+  extractStringOrTemplateLiteral,
+  findConfigProperty,
+  findTrailDefinitions,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import type { AstNode } from './ast.js';
 import { collectTrailIds } from './specs.js';
 import type {
   ProjectAwareWardenRule,
@@ -7,150 +15,116 @@ import type {
   WardenDiagnostic,
 } from './types.js';
 
-interface BraceState {
-  depth: number;
-  found: boolean;
+/**
+ * Node types that wrap an expression without changing its runtime value.
+ * These can legally surround a `detours: [...]` array or a `target: "..."`
+ * literal and must be peeled before we inspect the shape.
+ */
+const TRANSPARENT_WRAPPER_TYPES = new Set([
+  'ParenthesizedExpression',
+  'TSAsExpression',
+  'TSSatisfiesExpression',
+  'TSNonNullExpression',
+  'TSTypeAssertion',
+]);
+
+const unwrapExpression = (node: AstNode | undefined): AstNode | undefined => {
+  let current = node;
+  while (current && TRANSPARENT_WRAPPER_TYPES.has(current.type)) {
+    current = (current as AstNode)['expression'] as AstNode | undefined;
+  }
+  return current;
+};
+
+const getDetourElements = (config: AstNode): readonly (AstNode | null)[] => {
+  const detoursProp = findConfigProperty(config, 'detours');
+  if (!detoursProp) {
+    return [];
+  }
+
+  const detoursValue = unwrapExpression(
+    detoursProp.value as AstNode | undefined
+  );
+  if (!detoursValue || detoursValue.type !== 'ArrayExpression') {
+    return [];
+  }
+
+  const elements = (detoursValue as AstNode)['elements'] as
+    | readonly (AstNode | null)[]
+    | undefined;
+  return elements ?? [];
+};
+
+interface TargetRef {
+  readonly id: string;
+  readonly start: number;
 }
 
-const trackBraces = (line: string, state: BraceState): void => {
-  for (const ch of line) {
-    if (ch === '{') {
-      state.depth += 1;
-      state.found = true;
-    }
-    if (ch === '}') {
-      state.depth -= 1;
-    }
+const extractDetourTargetId = (node: AstNode | undefined): string | null =>
+  extractStringOrTemplateLiteral(node);
+
+const extractObjectTargetRef = (element: AstNode): TargetRef | null => {
+  if (element.type !== 'ObjectExpression') {
+    return null;
   }
+  const targetProp = findConfigProperty(element, 'target');
+  const rawTargetNode = targetProp?.value as AstNode | undefined;
+  const targetNode = unwrapExpression(rawTargetNode);
+  const targetId = extractDetourTargetId(targetNode);
+  return targetId !== null && targetNode
+    ? { id: targetId, start: targetNode.start }
+    : null;
 };
 
-const collectArrayText = (lines: readonly string[], start: number): string => {
-  let text = '';
-  for (let k = start; k < lines.length && k < start + 20; k += 1) {
-    const line = lines[k];
-    if (!line) {
+const extractDetourElementRef = (element: AstNode | null): TargetRef | null => {
+  if (!element) {
+    return null;
+  }
+  const unwrapped = unwrapExpression(element) ?? element;
+  // String-literal or backtick-literal detour:
+  //   detours: ["entity.fallback"] or detours: [`entity.fallback`]
+  const literalId = extractDetourTargetId(unwrapped);
+  if (literalId !== null) {
+    return { id: literalId, start: unwrapped.start };
+  }
+  return extractObjectTargetRef(unwrapped);
+};
+
+const extractDetourTargets = (config: AstNode): readonly TargetRef[] =>
+  getDetourElements(config).flatMap((element) => {
+    const ref = extractDetourElementRef(element);
+    return ref ? [ref] : [];
+  });
+
+const buildDiagnostics = (
+  ast: AstNode,
+  sourceCode: string,
+  filePath: string,
+  knownIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const definition of findTrailDefinitions(ast)) {
+    if (definition.kind !== 'trail') {
       continue;
     }
-    text += `${line}\n`;
-    if (text.includes(']')) {
-      break;
+
+    for (const ref of extractDetourTargets(definition.config)) {
+      if (knownIds.has(ref.id) || isDraftId(ref.id)) {
+        continue;
+      }
+
+      diagnostics.push({
+        filePath,
+        line: offsetToLine(sourceCode, ref.start),
+        message: `Trail "${definition.id}" has detour targeting "${ref.id}" which is not defined.`,
+        rule: 'valid-detour-refs',
+        severity: 'error',
+      });
     }
   }
-  return text;
-};
 
-const findMissingDetourTargets = (
-  text: string,
-  knownIds: ReadonlySet<string>
-): string[] => {
-  const missing: string[] = [];
-  for (const m of text.matchAll(/target\s*:\s*["'`]([^"'`]+)["'`]/g)) {
-    const [, id] = m;
-    if (id && !knownIds.has(id) && !isDraftId(id)) {
-      missing.push(id);
-    }
-  }
-  return missing;
-};
-
-const findMissingPlainDetours = (
-  text: string,
-  knownIds: ReadonlySet<string>
-): string[] => {
-  const missing: string[] = [];
-  const cleaned = text.replaceAll(/target\s*:\s*["'`][^"'`]+["'`]/g, '');
-  for (const m of cleaned.matchAll(/["'`]([^"'`]+)["'`]/g)) {
-    const [, id] = m;
-    if (id && id.includes('.') && !knownIds.has(id) && !isDraftId(id)) {
-      missing.push(id);
-    }
-  }
-  return missing;
-};
-
-const findAllMissingDetours = (
-  text: string,
-  knownIds: ReadonlySet<string>
-): string[] => [
-  ...findMissingDetourTargets(text, knownIds),
-  ...findMissingPlainDetours(text, knownIds),
-];
-
-const addMissingDetourDiagnostics = (
-  specLine: string,
-  j: number,
-  lines: readonly string[],
-  trailId: string,
-  lineNum: number,
-  filePath: string,
-  knownIds: ReadonlySet<string>,
-  diagnostics: WardenDiagnostic[]
-): void => {
-  if (!/\bdetours\s*:/.test(specLine)) {
-    return;
-  }
-  for (const targetId of findAllMissingDetours(
-    collectArrayText(lines, j),
-    knownIds
-  )) {
-    diagnostics.push({
-      filePath,
-      line: lineNum,
-      message: `Trail "${trailId}" has detour targeting "${targetId}" which is not defined.`,
-      rule: 'valid-detour-refs',
-      severity: 'error',
-    });
-  }
-};
-
-const scanTrailDetours = (
-  lines: readonly string[],
-  startIndex: number,
-  trailId: string,
-  filePath: string,
-  knownIds: ReadonlySet<string>,
-  diagnostics: WardenDiagnostic[]
-): void => {
-  const braceState: BraceState = { depth: 0, found: false };
-  for (let j = startIndex; j < lines.length && j < startIndex + 200; j += 1) {
-    const specLine = lines[j];
-    if (!specLine) {
-      continue;
-    }
-    trackBraces(specLine, braceState);
-    addMissingDetourDiagnostics(
-      specLine,
-      j,
-      lines,
-      trailId,
-      startIndex + 1,
-      filePath,
-      knownIds,
-      diagnostics
-    );
-    if (braceState.found && braceState.depth <= 0) {
-      break;
-    }
-  }
-};
-
-const processLine = (
-  line: string,
-  i: number,
-  lines: readonly string[],
-  filePath: string,
-  knownIds: ReadonlySet<string>,
-  diagnostics: WardenDiagnostic[]
-): void => {
-  const trailMatch = line.match(/\btrail\s*\(\s*["'`]([^"'`]+)["'`]/);
-  if (!trailMatch) {
-    return;
-  }
-  const [, trailId] = trailMatch;
-  if (!trailId) {
-    return;
-  }
-  scanTrailDetours(lines, i, trailId, filePath, knownIds, diagnostics);
+  return diagnostics;
 };
 
 const checkDetourRefs = (
@@ -158,15 +132,11 @@ const checkDetourRefs = (
   filePath: string,
   knownIds: ReadonlySet<string>
 ): readonly WardenDiagnostic[] => {
-  const diagnostics: WardenDiagnostic[] = [];
-  const lines = sourceCode.split('\n');
-  for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i];
-    if (line) {
-      processLine(line, i, lines, filePath, knownIds, diagnostics);
-    }
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
   }
-  return diagnostics;
+  return buildDiagnostics(ast, sourceCode, filePath, knownIds);
 };
 
 /**


### PR DESCRIPTION
## Summary

Ports three warden rules from regex-scanning raw source text to AST traversal. Eliminates the class of false positives where example payloads, docstrings, or template literals containing matching syntax fragments tripped the scanners.

Closes [TRL-335](https://linear.app/outfitter/issue/TRL-335).

## The three rules

April 19 baseline flagged `valid-detour-refs` producing a false positive in `packages/warden/src/trails/valid-detour-refs.trail.ts:15` — the rule scanned a `trail("...")` / `detours:` fragment embedded inside a template string assigned as a trail wrapper's `sourceCode` example payload. Investigation surfaced two siblings with the same structural vulnerability: `valid-describe-refs` regex-scanned for `.describe(` with balanced-paren text extraction, and `no-sync-result-assumption` line-by-line regex-matched against raw code.

All three shared one anti-pattern: scan raw file text with regexes instead of walking the AST that the parser already produced.

## Ports

**`valid-detour-refs`** — enumerates trail definitions via `findTrailDefinitions`, reads `detours` via `findConfigProperty`, walks the `ArrayExpression` elements. Both string-literal array entries (`detours: ["id"]`) and object-expression entries (`detours: [{ target: "id" }]`) are handled. Diagnostics now point at the offending target rather than the enclosing `trail(` call.

**`valid-describe-refs`** — walks `CallExpression`s whose callee is a `.describe` member access, extracts the argument as `StringLiteral` or expressionless `TemplateLiteral`, runs the existing `@see` regex only inside the extracted description. `@see` tokens in unrelated strings and template payloads no longer trigger.

**`no-sync-result-assumption`** — builds a parent map, walks `.blaze(...)` `CallExpression`s, classifies: awaited → skip; direct member access → flag; const-bound → register binding and flag later reads scoped to source-position "after declaration". Parenthesis-transparent await detection handles `(await x.blaze(...)).isOk()`. Replaces the previous 6-line distance heuristic with real source-position scoping. After three review rounds, the binding tracking uses a full lexical-scope frame stack with ES-spec-correct `var` hoisting (to nearest function/program scope, stopping at function boundaries) and `StaticBlock` scope isolation.

Each rule keeps its behavior and severity — only the inspection layer changes.

## Verification

- `bun run typecheck` — 31/31 green
- `bun test packages/warden` — 405 pass / 0 fail
- `bun run check` — 31/31 green
- Warden baseline on `packages/warden/src/rules/` — zero diagnostics from all three rules (previously: 1 false positive in `valid-detour-refs.trail.ts:15`)

## Test plan

21 tests total in `no-sync-result-assumption.test.ts` (core behavior + lexical scoping + `var` hoisting + static blocks) plus new fixtures in `rules.test.ts` and `valid-describe-refs.test.ts` covering template-literal payload, string-literal detour entry, `@see` in unrelated string, `@see` in embedded template payload, awaited-through-parens, `.value` on unawaited call.

## Review arc

Three rounds of Codex review.

Round 1 — P1: `no-sync-result-assumption` used name + source-position scoping only, so a parameter or local shadowing the outer pending binding in a nested function was falsely flagged. Replaced with a manual scope-frame stack tracking `program` / `function` / `block` / `for` / `catch` kinds, with destructuring-pattern binding collection.

Round 2 — P1: `collectBlockStatementBindings` swept all `VariableDeclaration`s into the block frame, losing `var` declarations when the block popped. Hoisting implemented: `var` bindings now land in the nearest `function` or `program` frame; `let` / `const` stay block-scoped.

Round 3 — P1: `StaticBlock` nodes weren't in `SCOPE_NODE_TYPES`, so class `static { ... }` initializers didn't get their own scope and outer pending bindings leaked in. Added to the scope set with a block-kind frame; `ownsVariableEnvironment` predicate stops `var`-hoisting at static-block boundaries per ES spec.

Round 4 clean.

## Related

- TRL-342 (`warden-rules-use-ast`) follows this PR as the capstone — a meta-rule that flags future regressions into the raw-text-scan pattern
- Clark ruling (2026-04-21) — the AST walker already is the affordance; no new "scope-aware rule" primitive
- Canonical AST-walker reference: `packages/warden/src/rules/warden-export-symmetry.ts` (TRL-341, PR #201)