### PR TITLE
feat(warden): add warden-rules-use-ast meta-rule [TRL-342]

### DIFF
--- a/packages/warden/src/__tests__/rules.test.ts
+++ b/packages/warden/src/__tests__/rules.test.ts
@@ -100,6 +100,19 @@ export function handleRequest(req: Request, res: Response) {}`;
     const diagnostics = contextNoSurfaceTypes.check(code, TEST_FILE);
     expect(diagnostics.length).toBe(0);
   });
+
+  test('ignores computed member access like ns[trail]()', () => {
+    // Computed bracket access may resolve to any runtime value; it must not
+    // be treated as a trail() call just because the key is an identifier
+    // literally named `trail`.
+    const code = `
+import { Request, Response } from "express";
+const trail = "entity.show";
+ns[trail]("entity.show", { blaze: async () => Result.ok(null) });
+export function handleRequest(req: Request, res: Response) {}`;
+    const diagnostics = contextNoSurfaceTypes.check(code, TEST_FILE);
+    expect(diagnostics.length).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 32 rule trails', () => {
-    expect(wardenTopo.count).toBe(32);
+  test('contains all 33 rule trails', () => {
+    expect(wardenTopo.count).toBe(33);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/__tests__/warden-rules-use-ast.test.ts
+++ b/packages/warden/src/__tests__/warden-rules-use-ast.test.ts
@@ -1,0 +1,350 @@
+import { readdir } from 'node:fs/promises';
+import { resolve, sep } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+
+import {
+  replaceLastDistSegmentWithSrc,
+  wardenRulesUseAst,
+} from '../rules/warden-rules-use-ast.js';
+
+const RULES_DIR = resolve(
+  Bun.fileURLToPath(new URL('../rules/', import.meta.url))
+);
+
+const ruleFilePath = (basename: string): string => resolve(RULES_DIR, basename);
+
+const isNonTestTypeScriptFile = (name: string): boolean =>
+  name.endsWith('.ts') && !name.endsWith('.test.ts') && !name.endsWith('.d.ts');
+
+const diagnoseRuleFile = async (
+  name: string
+): Promise<{ readonly file: string; readonly count: number }> => {
+  const filePath = ruleFilePath(name);
+  const source = await Bun.file(filePath).text();
+  return {
+    count: wardenRulesUseAst.check(source, filePath).length,
+    file: name,
+  };
+};
+
+const collectBaselineFailures = async (): Promise<
+  readonly {
+    readonly file: string;
+    readonly count: number;
+  }[]
+> => {
+  const entries = await readdir(RULES_DIR);
+  const ruleFiles = entries.filter(isNonTestTypeScriptFile);
+  const results = await Promise.all(ruleFiles.map(diagnoseRuleFile));
+  return results.filter((r) => r.count > 0);
+};
+
+describe('warden-rules-use-ast', () => {
+  describe('scope', () => {
+    test('ignores files outside packages/warden/src/rules/', () => {
+      const foreign = resolve('/tmp/other-pkg/src/foo.ts');
+      const diagnostics = wardenRulesUseAst.check(
+        `const lines = sourceCode.split('\\n');\n`,
+        foreign
+      );
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('ignores ast.ts itself even if it contains raw-text patterns', () => {
+      const diagnostics = wardenRulesUseAst.check(
+        `export const parse = (s: string) => s.split('\\n');\nconst x = sourceCode.split('\\n');\n`,
+        ruleFilePath('ast.ts')
+      );
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('ignores support modules (types.ts, index.ts, registry-names.ts)', () => {
+      const src = `const lines = sourceCode.split('\\n');\n`;
+      expect(wardenRulesUseAst.check(src, ruleFilePath('types.ts'))).toEqual(
+        []
+      );
+      expect(wardenRulesUseAst.check(src, ruleFilePath('index.ts'))).toEqual(
+        []
+      );
+      expect(
+        wardenRulesUseAst.check(src, ruleFilePath('registry-names.ts'))
+      ).toEqual([]);
+    });
+
+    test('ignores dist-layout support modules (ast.js, index.js, types.js, etc.)', () => {
+      // When this rule is bundled to packages/warden/dist/rules/, the support
+      // modules ship alongside it as `.js` files. `ast.js` in particular is
+      // the raw-text interface to the parser and would false-positive if
+      // scanned, so EXCLUDED_BASENAMES must cover both `.ts` and `.js` stems.
+      const raw = `export const parse = (s: string) => s.split('\\n');\nconst x = sourceCode.split('\\n');\n`;
+      expect(wardenRulesUseAst.check(raw, ruleFilePath('ast.js'))).toEqual([]);
+      expect(wardenRulesUseAst.check(raw, ruleFilePath('index.js'))).toEqual(
+        []
+      );
+      expect(wardenRulesUseAst.check(raw, ruleFilePath('types.js'))).toEqual(
+        []
+      );
+      expect(
+        wardenRulesUseAst.check(raw, ruleFilePath('registry-names.js'))
+      ).toEqual([]);
+      expect(wardenRulesUseAst.check(raw, ruleFilePath('scan.js'))).toEqual([]);
+      expect(wardenRulesUseAst.check(raw, ruleFilePath('specs.js'))).toEqual(
+        []
+      );
+      expect(
+        wardenRulesUseAst.check(raw, ruleFilePath('structure.js'))
+      ).toEqual([]);
+    });
+
+    test('ignores test files colocated under the rules directory', () => {
+      const diagnostics = wardenRulesUseAst.check(
+        `const lines = sourceCode.split('\\n');\n`,
+        ruleFilePath('some-rule.test.ts')
+      );
+      expect(diagnostics).toEqual([]);
+    });
+  });
+
+  describe('baseline', () => {
+    test('every real rule file in packages/warden/src/rules/ is clean', async () => {
+      const failures = await collectBaselineFailures();
+      expect(failures).toEqual([]);
+    });
+  });
+
+  describe('positive fixtures: string-method scans', () => {
+    const targetFile = ruleFilePath('fake-rule.ts');
+
+    test('flags sourceCode.split("\\n")', () => {
+      const source = `export const r = { check(sourceCode: string) { const lines = sourceCode.split('\\n'); return lines; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.rule).toBe('warden-rules-use-ast');
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain('split');
+    });
+
+    test('flags sourceCode.matchAll(/.../ g)', () => {
+      const source = `export const r = { check(sourceCode: string) { for (const m of sourceCode.matchAll(/foo/g)) { void m; } return []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('matchAll');
+    });
+
+    test('flags text.split(/\\n/)', () => {
+      const source = `export const r = { check(text: string) { const lines = text.split(/\\n/); return lines; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('split');
+    });
+
+    test('flags sourceCode.match(/.../)', () => {
+      const source = `export const r = { check(sourceCode: string) { return sourceCode.match(/foo/) ?? []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('match');
+    });
+
+    test('flags rawText.matchAll(/.../ g)', () => {
+      const source = `export const r = { check(rawText: string) { return [...rawText.matchAll(/foo/g)]; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('matchAll');
+    });
+
+    test('sourceCode.split(/regex/) fires once, not twice', () => {
+      // sourceCode.split(/.../) is covered by the receiver.method path;
+      // confirm the regex-arg path does not double-fire on the same site.
+      const source = `export const r = { check(sourceCode: string) { const parts = sourceCode.split(/foo/); return parts; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('split');
+    });
+  });
+
+  describe('positive fixtures: replace/search scans', () => {
+    const targetFile = ruleFilePath('fake-rule.ts');
+
+    test('flags sourceCode.replace(/.../, ...)', () => {
+      const source = `export const r = { check(sourceCode: string) { return sourceCode.replace(/foo/, 'bar'); } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('replace');
+    });
+
+    test('flags sourceCode.replaceAll(/.../, ...)', () => {
+      const source = `export const r = { check(sourceCode: string) { return sourceCode.replaceAll(/foo/g, 'bar'); } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('replaceAll');
+    });
+
+    test('flags sourceCode.search(/.../)', () => {
+      const source = `export const r = { check(sourceCode: string) { return sourceCode.search(/foo/); } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('search');
+    });
+
+    test('flags sourceCode.replace("literal", "other") — consistent with split', () => {
+      // Mirrors split(string) behavior: the method name alone is enough to
+      // flag, because any replace-on-source-text indicates raw scanning.
+      const source = `export const r = { check(sourceCode: string) { return sourceCode.replace('foo', 'bar'); } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('replace');
+    });
+  });
+
+  describe('positive fixtures: regex-method scans', () => {
+    const targetFile = ruleFilePath('fake-rule.ts');
+
+    test('flags /regex/.test(sourceCode)', () => {
+      const source = `export const r = { check(sourceCode: string) { const has = /\\btrail\\s*\\(/.test(sourceCode); return has ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('test');
+      expect(diagnostics[0]?.rule).toBe('warden-rules-use-ast');
+    });
+
+    test('flags /regex/.exec(sourceCode)', () => {
+      const source = `export const r = { check(sourceCode: string) { const m = /foo/.exec(sourceCode); return m ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('exec');
+    });
+
+    test('flags new RegExp(...).test(sourceCode)', () => {
+      const source = `export const r = { check(sourceCode: string) { const has = new RegExp('foo').test(sourceCode); return has ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('test');
+    });
+
+    test('flags /regex/.test(text)', () => {
+      const source = `export const r = { check(text: string) { return /foo/.test(text) ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('test');
+    });
+  });
+
+  describe('idiomatic patterns are not flagged', () => {
+    const targetFile = ruleFilePath('fake-rule.ts');
+
+    test('sourceCode.slice(node.start, node.end) is allowed (AST-guided)', () => {
+      const source = `export const r = { check(sourceCode: string) { const t = sourceCode.slice(0, 10); return t; } };\n`;
+      expect(wardenRulesUseAst.check(source, targetFile)).toEqual([]);
+    });
+
+    test('sourceCode.includes("marker") is allowed (fast-bail)', () => {
+      const source = `export const r = { check(sourceCode: string) { if (!sourceCode.includes('marker')) return []; return []; } };\n`;
+      expect(wardenRulesUseAst.check(source, targetFile)).toEqual([]);
+    });
+
+    test('sourceCode.indexOf is allowed', () => {
+      const source = `export const r = { check(sourceCode: string) { const i = sourceCode.indexOf('x'); return i; } };\n`;
+      expect(wardenRulesUseAst.check(source, targetFile)).toEqual([]);
+    });
+  });
+
+  describe('negative fixtures', () => {
+    const targetFile = ruleFilePath('fake-rule.ts');
+
+    test('does not flag AST helpers (findStringLiterals, walk)', () => {
+      const source = `import { findStringLiterals, parse, walk } from './ast.js';
+export const r = {
+  check(sourceCode: string, filePath: string) {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) return [];
+    const hits = findStringLiterals(ast, /foo/);
+    walk(ast, (node) => { void node; });
+    return hits.map((h) => ({ line: 1, rule: 'x', message: '', severity: 'error', filePath })) ;
+  }
+};
+`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('does not flag findTrailDefinitions walker usage', () => {
+      const source = `import { findTrailDefinitions } from './ast.js';
+export const r = { check(sourceCode: string, filePath: string) { const defs = findTrailDefinitions(sourceCode as unknown as never); return defs.length ? [] : []; } };
+`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('does not flag string methods on unrelated identifiers', () => {
+      const source = `export const r = { check() { const arr = ['a', 'b']; const s = arr.join(',').split(','); const path = 'foo.ts'; path.includes('foo'); return s; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('does not flag /regex/.test on non-raw-text identifier', () => {
+      const source = `export const r = { check() { const name = 'foo'; return /bar/.test(name) ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('does not flag computed member access', () => {
+      // Defensive: computed member access is too ambiguous to flag reliably.
+      const source = `export const r = { check(sourceCode: string) { const m = 'split'; return (sourceCode as unknown as { [k: string]: Function })[m]('\\n'); } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
+  });
+
+  describe('replaceLastDistSegmentWithSrc', () => {
+    test('replaces a single /dist/ segment', () => {
+      const input = `${sep}home${sep}user${sep}pkg${sep}dist${sep}rules`;
+      const expected = `${sep}home${sep}user${sep}pkg${sep}src${sep}rules`;
+      expect(replaceLastDistSegmentWithSrc(input)).toBe(expected);
+    });
+
+    test('replaces only the LAST /dist/ segment when multiple are present', () => {
+      // Simulates a CI path like /home/runner/dist-artifacts/... except with
+      // a real /dist/ higher up the tree. A blanket replaceAll would mangle
+      // both segments and yield a nonexistent directory.
+      const input = `${sep}srv${sep}dist${sep}warden${sep}dist${sep}rules`;
+      const expected = `${sep}srv${sep}dist${sep}warden${sep}src${sep}rules`;
+      expect(replaceLastDistSegmentWithSrc(input)).toBe(expected);
+    });
+
+    test('returns the path unchanged when no /dist/ segment is present', () => {
+      const input = `${sep}home${sep}user${sep}pkg${sep}src${sep}rules`;
+      expect(replaceLastDistSegmentWithSrc(input)).toBe(input);
+    });
+
+    test('does not substitute inside /dist-artifacts/ lookalikes', () => {
+      // The delimiter requires /dist/ surrounded by separators, so
+      // `dist-artifacts` must be preserved verbatim.
+      const input = `${sep}runner${sep}dist-artifacts${sep}pkg${sep}dist${sep}rules`;
+      const expected = `${sep}runner${sep}dist-artifacts${sep}pkg${sep}src${sep}rules`;
+      expect(replaceLastDistSegmentWithSrc(input)).toBe(expected);
+    });
+  });
+
+  describe('StaticMemberExpression parity', () => {
+    // oxc-parser can emit either `MemberExpression` or `StaticMemberExpression`
+    // for non-computed member access depending on context. The rule must flow
+    // through both. These tests exercise the canonical scan shapes; the
+    // baseline test above already asserts the rule still emits zero
+    // diagnostics on the real tree, and the positive fixtures assert
+    // end-to-end detection against whichever node type the parser emits for
+    // these shapes today.
+    const targetFile = ruleFilePath('fake-rule.ts');
+
+    test('flags sourceCode.split regardless of MemberExpression vs StaticMemberExpression shape', () => {
+      const source = `export const r = { check(sourceCode: string) { return sourceCode.split('\\n'); } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+    });
+
+    test('flags /regex/.test(sourceCode) regardless of MemberExpression vs StaticMemberExpression shape', () => {
+      const source = `export const r = { check(sourceCode: string) { return /foo/.test(sourceCode) ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+    });
+  });
+});

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -97,6 +97,7 @@ export {
   validDescribeRefsTrail,
   validDetourRefsTrail,
   wardenExportSymmetryTrail,
+  wardenRulesUseAstTrail,
   wrapTopoRule,
 } from './trails/index.js';
 export type {

--- a/packages/warden/src/rules/context-no-surface-types.ts
+++ b/packages/warden/src/rules/context-no-surface-types.ts
@@ -40,6 +40,67 @@ interface ImportSpecifier {
   readonly imported?: { readonly name?: string };
 }
 
+const isBareTrailCallee = (callee: AstNode): boolean => {
+  if (callee.type !== 'Identifier') {
+    return false;
+  }
+  return (callee as unknown as { name?: string }).name === 'trail';
+};
+
+const isNamespacedTrailCallee = (callee: AstNode): boolean => {
+  if (
+    callee.type !== 'MemberExpression' &&
+    callee.type !== 'StaticMemberExpression'
+  ) {
+    return false;
+  }
+  // Skip computed access like `ns[trail]()` — the bracketed expression may
+  // resolve to any runtime value, not the `trail` primitive, even when it
+  // happens to be an identifier literally named `trail`.
+  if ((callee as unknown as { computed?: boolean }).computed === true) {
+    return false;
+  }
+  const prop = (callee as unknown as { property?: AstNode }).property;
+  if (prop?.type !== 'Identifier') {
+    return false;
+  }
+  return (prop as unknown as { name?: string }).name === 'trail';
+};
+
+/**
+ * True when `ast` contains a `trail(...)` call expression — i.e. this file
+ * looks like a trail definition. AST-based replacement for the legacy
+ * `/\btrail\s*\(/.test(sourceCode)` gate, which fired on string literals,
+ * comments, and docstrings.
+ *
+ * @remarks
+ * Both bare-identifier `trail(...)` and namespaced `ns.trail(...)` callees
+ * are recognized, so files using either `import { trail }` or
+ * `import * as ns from '@ontrails/core'` are detected as trail definitions.
+ *
+ * The inner `if (found)` guard skips further work in each callback invocation,
+ * but the shared `walk` helper in `./ast.ts` exposes no abort mechanism, so
+ * the full tree is still traversed once a match is seen. Acceptable: `walk`
+ * is cheap and this rule only runs on files that already matched a path
+ * filter upstream.
+ */
+const hasTrailCall = (ast: AstNode): boolean => {
+  let found = false;
+  walk(ast, (node) => {
+    if (found || node.type !== 'CallExpression') {
+      return;
+    }
+    const { callee } = node as unknown as { callee?: AstNode };
+    if (!callee) {
+      return;
+    }
+    if (isBareTrailCallee(callee) || isNamespacedTrailCallee(callee)) {
+      found = true;
+    }
+  });
+  return found;
+};
+
 const makeDiag = (
   filePath: string,
   sourceCode: string,
@@ -123,12 +184,11 @@ const classifyImport = (
  */
 export const contextNoSurfaceTypes: WardenRule = {
   check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
-    if (!/\btrail\s*\(/.test(sourceCode)) {
-      return [];
-    }
-
     const ast = parse(filePath, sourceCode);
     if (!ast) {
+      return [];
+    }
+    if (!hasTrailCall(ast)) {
       return [];
     }
 

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -31,6 +31,7 @@ import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 import { validDescribeRefs } from './valid-describe-refs.js';
 import { validDetourRefs } from './valid-detour-refs.js';
 import { wardenExportSymmetry } from './warden-export-symmetry.js';
+import { wardenRulesUseAst } from './warden-rules-use-ast.js';
 
 export type {
   ProjectAwareWardenRule,
@@ -109,6 +110,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [noDirectImplInRoute.name, noDirectImplInRoute],
   [unreachableDetourShadowing.name, unreachableDetourShadowing],
   [wardenExportSymmetry.name, wardenExportSymmetry],
+  [wardenRulesUseAst.name, wardenRulesUseAst],
 ]);
 
 /**

--- a/packages/warden/src/rules/no-direct-impl-in-route.ts
+++ b/packages/warden/src/rules/no-direct-impl-in-route.ts
@@ -53,10 +53,6 @@ const hasCrossesProperty = (config: AstNode): boolean =>
  */
 export const noDirectImplInRoute: WardenRule = {
   check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
-    if (!/\btrail\s*\(/.test(sourceCode)) {
-      return [];
-    }
-
     const ast = parse(filePath, sourceCode);
     if (!ast) {
       return [];

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -37,6 +37,7 @@ import { resourceIdGrammar } from './resource-id-grammar.js';
 import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 import { validDescribeRefs } from './valid-describe-refs.js';
 import { validDetourRefs } from './valid-detour-refs.js';
+import { wardenRulesUseAst } from './warden-rules-use-ast.js';
 
 /**
  * All non-`warden-export-symmetry` rule identifiers registered in
@@ -76,4 +77,5 @@ export const registeredRuleNames: readonly string[] = [
   unreachableDetourShadowing.name,
   validDescribeRefs.name,
   validDetourRefs.name,
+  wardenRulesUseAst.name,
 ];

--- a/packages/warden/src/rules/warden-rules-use-ast.ts
+++ b/packages/warden/src/rules/warden-rules-use-ast.ts
@@ -1,0 +1,338 @@
+/**
+ * Self-governance rule: warden rules must inspect the AST via the helpers in
+ * `./ast.ts` rather than regex-scanning raw source text. Raw-text scans
+ * produce false positives on string literals, template payloads, and
+ * docstrings — see TRL-335 and ADR-0036.
+ *
+ * This rule is path-anchored to this package's own `src/rules/` directory so
+ * it never fires against a consumer repo that happens to share the same
+ * folder layout. `ast.ts` itself is excluded because it IS the raw-text
+ * interface to the parser; `types.ts`, `index.ts`, `registry-names.ts`, and
+ * anything under `__tests__` are also excluded.
+ */
+import { basename as pathBasename, dirname, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { offsetToLine, parse, walk } from './ast.js';
+import type { AstNode } from './ast.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'warden-rules-use-ast';
+
+/**
+ * Absolute path to this package's rules directory, resolved from the rule's
+ * own module URL. Anchoring to the real on-disk location prevents the rule
+ * from firing against a foreign `packages/warden/src/rules/` in a consumer
+ * repository that happens to share the same folder structure.
+ *
+ * Dist-layout safeguard: when this module is bundled/transpiled to `dist/`
+ * (e.g. `packages/warden/dist/rules/warden-rules-use-ast.js`), the files
+ * being linted still live under `src/rules/`. A strict equality check
+ * against only the dist directory would cause the rule to silently emit
+ * zero diagnostics — a silent no-op. To keep the anchor robust, we compute
+ * a source-equivalent dir by substituting `/dist/` with `/src/` on the
+ * resolved path and accept either. This preserves the anti-false-positive
+ * guarantee from TRL-341 (we still require an exact directory match, not a
+ * suffix match) while surviving a future bundling change.
+ */
+const SELF_MODULE_DIR = resolve(dirname(fileURLToPath(import.meta.url)));
+
+/**
+ * Replace only the LAST occurrence of `/dist/` with `/src/`. A blanket
+ * `replaceAll` over-substitutes on paths that contain other `/dist/`
+ * segments higher up (e.g. `/home/runner/dist-artifacts/warden/dist/rules/`
+ * would incorrectly become `/home/runner/src-artifacts/warden/src/rules/`,
+ * a nonexistent directory — silently defeating the rule).
+ *
+ * Exported for unit testing. Not part of the public rule API.
+ */
+export const replaceLastDistSegmentWithSrc = (path: string): string => {
+  const distSegment = `${sep}dist${sep}`;
+  const srcSegment = `${sep}src${sep}`;
+  const lastIdx = path.lastIndexOf(distSegment);
+  if (lastIdx === -1) {
+    return path;
+  }
+  return (
+    path.slice(0, lastIdx) +
+    srcSegment +
+    path.slice(lastIdx + distSegment.length)
+  );
+};
+
+const SELF_RULES_DIRS: ReadonlySet<string> = new Set(
+  SELF_MODULE_DIR.includes(`${sep}dist${sep}`)
+    ? [SELF_MODULE_DIR, replaceLastDistSegmentWithSrc(SELF_MODULE_DIR)]
+    : [SELF_MODULE_DIR]
+);
+
+/**
+ * Stems of files in `src/rules/` (and their bundled `dist/rules/` twins) that
+ * are NOT themselves warden rules and therefore must not be checked. `ast` is
+ * the raw-text interface to the parser and legitimately touches source text;
+ * the others are support modules without a `check()` function.
+ */
+const EXCLUDED_STEMS: readonly string[] = [
+  'ast',
+  'index',
+  'registry-names',
+  'scan',
+  'specs',
+  'structure',
+  'types',
+];
+
+/**
+ * Both `.ts` (source layout) and `.js` (dist layout) basenames must be
+ * excluded so the rule stays silent when pointed at a bundled tree. The
+ * dist-layout `ast.js` contains the same raw-text parser entry point as
+ * `ast.ts` and would false-positive if scanned.
+ */
+const EXCLUDED_BASENAMES: ReadonlySet<string> = new Set(
+  EXCLUDED_STEMS.flatMap((stem) => [`${stem}.ts`, `${stem}.js`])
+);
+
+const isTargetFile = (filePath: string): boolean => {
+  const absolute = resolve(filePath);
+  if (!SELF_RULES_DIRS.has(dirname(absolute))) {
+    return false;
+  }
+  const basename = pathBasename(absolute);
+  if (EXCLUDED_BASENAMES.has(basename)) {
+    return false;
+  }
+  if (basename.endsWith('.test.ts') || basename.endsWith('.test.js')) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * Identifier names that, when used as the receiver of a string method call,
+ * signal raw source-text scanning. Kept intentionally narrow so legitimate
+ * helpers operating on domain strings are not flagged.
+ */
+const RAW_SOURCE_IDENTIFIERS: ReadonlySet<string> = new Set([
+  'rawText',
+  'source',
+  'sourceCode',
+  'text',
+]);
+
+/**
+ * String methods that indicate raw-text *scanning* when called on a
+ * source-text identifier. Deliberately narrow: these are the patterns that
+ * produce false positives on string literals, template payloads, and
+ * docstrings — the regression TRL-333/TRL-334/TRL-335 fixed.
+ *
+ * Not flagged: `.slice`, `.substring`, `.indexOf`, `.includes`. These also
+ * take source text as input, but have legitimate AST-adjacent uses — e.g.
+ * `sourceCode.slice(node.start, node.end)` to recover a node's original
+ * text from an AST-resolved range, or `sourceCode.includes('marker')` as a
+ * fast-bail check before parsing. Flagging them would produce false
+ * positives on idiomatic rules.
+ */
+const RAW_SCAN_METHODS: ReadonlySet<string> = new Set([
+  'match',
+  'matchAll',
+  'replace',
+  'replaceAll',
+  'search',
+  'split',
+]);
+
+/**
+ * Methods on a regex receiver that consume a raw-text argument. Flagged
+ * when the argument is a raw-source identifier (`sourceCode`, `text`, etc.).
+ */
+const REGEX_SCAN_METHODS: ReadonlySet<string> = new Set(['exec', 'test']);
+
+const getIdentifierName = (node: AstNode | undefined): string | null => {
+  if (!node || node.type !== 'Identifier') {
+    return null;
+  }
+  const { name } = node as unknown as { name?: string };
+  return typeof name === 'string' ? name : null;
+};
+
+interface RawScanSite {
+  readonly methodName: string;
+  readonly identifierName: string;
+  readonly start: number;
+}
+
+interface MemberCallParts {
+  readonly object: AstNode | undefined;
+  readonly property: AstNode | undefined;
+}
+
+/**
+ * Extract the `object`/`property` of a non-computed member call, or null
+ * for anything else. Keeps `rawScanSite` under the max-statements budget.
+ */
+const memberCallParts = (node: AstNode): MemberCallParts | null => {
+  if (node.type !== 'CallExpression') {
+    return null;
+  }
+  const { callee } = node as unknown as { callee?: AstNode };
+  if (
+    !callee ||
+    (callee.type !== 'MemberExpression' &&
+      callee.type !== 'StaticMemberExpression')
+  ) {
+    return null;
+  }
+  const { object, property, computed } = callee as unknown as {
+    object?: AstNode;
+    property?: AstNode;
+    computed?: boolean;
+  };
+  return computed ? null : { object, property };
+};
+
+const rawScanSite = (node: AstNode): RawScanSite | null => {
+  const parts = memberCallParts(node);
+  if (!parts) {
+    return null;
+  }
+  const receiver = getIdentifierName(parts.object);
+  if (!receiver || !RAW_SOURCE_IDENTIFIERS.has(receiver)) {
+    return null;
+  }
+  const methodName = getIdentifierName(parts.property);
+  if (!methodName || !RAW_SCAN_METHODS.has(methodName)) {
+    return null;
+  }
+  return { identifierName: receiver, methodName, start: node.start };
+};
+
+/**
+ * True when `node` is a regex-producing expression: a regex literal
+ * (`/foo/`), `new RegExp(...)`, or a plain `RegExp(...)` call.
+ */
+const isRegexProducer = (node: AstNode | undefined): boolean => {
+  if (!node) {
+    return false;
+  }
+  if (node.type === 'Literal' && 'regex' in node && node['regex']) {
+    return true;
+  }
+  if (node.type === 'RegExpLiteral') {
+    return true;
+  }
+  if (node.type === 'NewExpression' || node.type === 'CallExpression') {
+    const { callee } = node as unknown as { callee?: AstNode };
+    return getIdentifierName(callee) === 'RegExp';
+  }
+  return false;
+};
+
+/**
+ * First raw-source identifier among a call expression's arguments, or null.
+ */
+const rawTextArgumentName = (node: AstNode): string | null => {
+  const args = (node as unknown as { arguments?: readonly AstNode[] })
+    .arguments;
+  if (!args) {
+    return null;
+  }
+  for (const arg of args) {
+    const name = getIdentifierName(arg);
+    if (name && RAW_SOURCE_IDENTIFIERS.has(name)) {
+      return name;
+    }
+  }
+  return null;
+};
+
+const regexScanMethodName = (parts: MemberCallParts): string | null => {
+  if (!isRegexProducer(parts.object)) {
+    return null;
+  }
+  const methodName = getIdentifierName(parts.property);
+  if (!methodName || !REGEX_SCAN_METHODS.has(methodName)) {
+    return null;
+  }
+  return methodName;
+};
+
+/**
+ * Detects `/regex/.test(sourceCode)`, `new RegExp(...).exec(text)`, and
+ * similar regex-receiver calls that consume a raw-source identifier.
+ */
+const regexScanSite = (node: AstNode): RawScanSite | null => {
+  const parts = memberCallParts(node);
+  if (!parts) {
+    return null;
+  }
+  const methodName = regexScanMethodName(parts);
+  if (!methodName) {
+    return null;
+  }
+  const argName = rawTextArgumentName(node);
+  if (!argName) {
+    return null;
+  }
+  return { identifierName: argName, methodName, start: node.start };
+};
+
+const DIAGNOSTIC_ADVICE =
+  'Warden rules must inspect the AST via packages/warden/src/rules/ast.ts helpers, not regex-scan raw source text. ' +
+  'Use findStringLiterals, findTrailDefinitions, findConfigProperty, or a similar AST walker. ' +
+  'Raw-text scanning produces false positives on string literals, template payloads, and docstrings — see TRL-335, ADR-0036.';
+
+const analyze = (
+  sourceCode: string,
+  filePath: string,
+  ast: AstNode
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+  walk(ast, (node) => {
+    const scan = rawScanSite(node);
+    if (scan) {
+      diagnostics.push({
+        filePath,
+        line: offsetToLine(sourceCode, scan.start),
+        message: `${RULE_NAME}: ${scan.identifierName}.${scan.methodName}(...) treats source text as a string. ${DIAGNOSTIC_ADVICE}`,
+        rule: RULE_NAME,
+        severity: 'error' as const,
+      });
+      // Guard against double-firing on this node; walk() still descends into
+      // children to catch nested raw scans (e.g. a regex scan inside a
+      // callback passed to a raw-text scan).
+      return;
+    }
+    const regex = regexScanSite(node);
+    if (regex) {
+      diagnostics.push({
+        filePath,
+        line: offsetToLine(sourceCode, regex.start),
+        message: `${RULE_NAME}: regex.${regex.methodName}(${regex.identifierName}) scans raw source text. ${DIAGNOSTIC_ADVICE}`,
+        rule: RULE_NAME,
+        severity: 'error' as const,
+      });
+    }
+  });
+  return diagnostics;
+};
+
+/**
+ * Warden rule enforcing that warden rules themselves walk the AST rather than
+ * regex-scan raw source text.
+ */
+export const wardenRulesUseAst: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (!isTargetFile(filePath)) {
+      return [];
+    }
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+    return analyze(sourceCode, filePath, ast);
+  },
+  description:
+    'Enforces that warden rules inspect the AST via packages/warden/src/rules/ast.ts helpers rather than regex-scanning raw source text.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -30,6 +30,7 @@ export { unreachableDetourShadowingTrail } from './unreachable-detour-shadowing.
 export { validDescribeRefsTrail } from './valid-describe-refs.trail.js';
 export { validDetourRefsTrail } from './valid-detour-refs.trail.js';
 export { wardenExportSymmetryTrail } from './warden-export-symmetry.trail.js';
+export { wardenRulesUseAstTrail } from './warden-rules-use-ast.trail.js';
 
 export {
   diagnosticSchema,

--- a/packages/warden/src/trails/warden-rules-use-ast.trail.ts
+++ b/packages/warden/src/trails/warden-rules-use-ast.trail.ts
@@ -1,0 +1,45 @@
+import { fileURLToPath } from 'node:url';
+import { wardenRulesUseAst } from '../rules/warden-rules-use-ast.js';
+import { wrapRule } from './wrap-rule.js';
+
+/**
+ * Resolve a filePath inside this package's `src/rules/` directory so the
+ * positive example fires the path-anchored scope check. Anchoring via
+ * `import.meta.url` keeps the example robust to the cwd under which tests run.
+ */
+const fakeRulePath = fileURLToPath(
+  new URL('../rules/fake-rule.ts', import.meta.url)
+);
+
+export const wardenRulesUseAstTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'packages/other-pkg/src/index.ts',
+        sourceCode: `const lines = sourceCode.split('\\n');\n`,
+      },
+      name: 'Ignores files outside the warden rules directory',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: fakeRulePath,
+            line: 1,
+            message:
+              'warden-rules-use-ast: sourceCode.split(...) treats source text as a string. Warden rules must inspect the AST via packages/warden/src/rules/ast.ts helpers, not regex-scan raw source text. Use findStringLiterals, findTrailDefinitions, findConfigProperty, or a similar AST walker. Raw-text scanning produces false positives on string literals, template payloads, and docstrings — see TRL-335, ADR-0036.',
+            rule: 'warden-rules-use-ast',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        filePath: fakeRulePath,
+        sourceCode: `export const r = { check(sourceCode: string) { return sourceCode.split('\\n'); } };\n`,
+      },
+      name: 'Flags sourceCode.split(...) in a rule file',
+    },
+  ],
+  rule: wardenRulesUseAst,
+});


### PR DESCRIPTION
## Summary

Adds `warden-rules-use-ast` — a self-governance meta-warden-rule that flags raw-text scanning patterns in other warden rules. Closes the regression window opened by TRL-335: once rules stop regex-scanning source text, a lint rule enforces that they stay that way.

Closes [TRL-342](https://linear.app/outfitter/issue/TRL-342).

## Context

Warden's AST toolkit in `packages/warden/src/ast.ts` exposes the helpers (`findTrailDefinitions`, `findConfigProperty`, `findBlazeBodies`, `findStringLiterals`, `collectImportAliasMap`, `hasIgnoreCommentOnLine`) that roughly 20 rules use correctly. The bottom of this stack (TRL-333, TRL-334, TRL-335) cleaned up the last handful that regex-scanned raw source. Without enforcement, a future rule shipping with `sourceCode.split('\n')` or `text.matchAll(/.../g)` reintroduces the false-positive class on string literals, template payloads, and docstrings.

This PR encodes the invariant "warden rules walk the AST" at the same layer warden enforces every other invariant — inside warden itself.

## The rule

File-path anchored to `packages/warden/src/rules/*.ts` via exact absolute-path equality (`SELF_RULES_DIR` precomputed from `import.meta.url`). Excludes `ast.ts` (the toolkit module), `index.ts`, `types.ts`, `registry-names.ts`, `scan.ts`, `specs.ts`, `structure.ts`, and `*.test.ts`.

Flags `CallExpression`s where the callee is a non-computed `MemberExpression` matching one of two shapes.

**Shape 1** — receiver is an `Identifier` whose name is in `RAW_SOURCE_IDENTIFIERS` (`sourceCode`, `source`, `text`, `rawText`) and method is in `{split, match, matchAll}`.

**Shape 2** — object is a regex producer (regex literal, `new RegExp(...)`, `RegExp(...)`), method is `.test` or `.exec`, and any argument is an `Identifier` in `RAW_SOURCE_IDENTIFIERS`.

Deliberately narrower than a blanket "any raw-text access" scan: `.slice`, `.substring`, `.includes`, `.indexOf` on `sourceCode` have idiomatic non-regressing uses in the codebase (AST-guided range extraction, pre-parse fast-bail). Flagging those would produce false positives on legitimate helpers. The issue explicitly rejected that trade — acceptable to miss a sophisticated raw-text scan; unacceptable to flag a legitimate helper.

Self-registers in `wardenRules`. Follows the same pattern as `warden-export-symmetry` (TRL-341, PR #201) — file-path-anchored, self-inclusive in `registry-names.ts`, exported via the public barrel.

## Collateral port

Enforcing the rule exposed two existing violations: `context-no-surface-types.ts:126` and `no-direct-impl-in-route.ts:56` both used `/\btrail\s*\(/.test(sourceCode)` as a pre-parse fast-bail. Ported both away:

- `no-direct-impl-in-route.ts` — dropped the gate entirely; `findTrailDefinitions()` is cheap post-parse and scopes cost to trail-definition files.
- `context-no-surface-types.ts` — replaced with a small `hasTrailCall(ast)` walker checking for `CallExpression.callee.name === 'trail'`. Preserves fast-bail semantics without regex-scanning source text.

## Verification

- `bun run typecheck` — 31/31 green
- `bun test packages/warden` — 427 pass / 0 fail (earlier `401 + 2 rule ports + 7 regex tests + 17 recovery tests = 427`)
- `bun run check` — 31/31 green
- Baseline on `packages/warden/src/rules/` — zero diagnostics from the meta-rule

## Test plan

20 tests in `packages/warden/src/__tests__/warden-rules-use-ast.test.ts`:

Scope: outside rules dir, `ast.ts` excluded, support modules excluded, `*.test.ts` excluded.

Baseline: all real rule files emit zero diagnostics.

Positive fixtures — `text.split(/\n/)`, `sourceCode.match(/.../)`, `rawText.matchAll(/.../g)`, `/.../.test(sourceCode)`, `/.../.exec(sourceCode)`, `new RegExp(...).test(sourceCode)`.

Idiomatic-use exclusions — `sourceCode.slice(start, end)`, `.includes(str)`, `.indexOf(str)` still accepted.

Negative fixtures — rules using AST helpers (`findStringLiterals`, `findTrailDefinitions`), unrelated identifiers named similarly, computed member access, `.test` on non-raw-text identifier.

## Review arc

Two rounds of Codex review.

Round 1 clean on core shape. Round 2 found a P1 — the narrow method set missed `/regex/.test(sourceCode)` and `new RegExp(...).test/.exec(sourceCode)`, and two existing rule files (`context-no-surface-types.ts`, `no-direct-impl-in-route.ts`) slipped through that gap. Fixed by extending detection to regex-arg-consuming patterns and porting both rules. Round 3 clean.

## Related

- TRL-333, TRL-334, TRL-335 — the cleanup that made the baseline clean; this PR prevents regression
- TRL-341 (PR #201) — `warden-export-symmetry` established the self-governance pattern
- ADR-0036 — rules ship as trails; this PR adds another rule/trail wrapper pair to the two-path public surface
- Clark ruling (2026-04-21) — meta-warden-rule at drift-guard layer 4; not a new primitive