### PR TITLE
fix(warden): accept namespaced trail/signal callees in findTrailDefinitions [TRL-343]

### DIFF
--- a/packages/warden/src/__tests__/ast.test.ts
+++ b/packages/warden/src/__tests__/ast.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  __getTrailCalleeNameForTest,
   deriveContourIdentifierName,
+  findTrailDefinitions,
   hasIgnoreCommentOnLine,
+  parse,
   splitSourceLines,
 } from '../rules/ast.js';
 
@@ -73,5 +76,100 @@ describe('hasIgnoreCommentOnLine', () => {
     for (let line = 1; line <= 100; line += 1) {
       expect(hasIgnoreCommentOnLine(lines, line)).toBe(false);
     }
+  });
+});
+
+const parseOrThrow = (source: string) =>
+  parse('test.ts', source) ??
+  (() => {
+    throw new Error('failed to parse');
+  })();
+
+const parseCallee = (source: string) => {
+  const ast = parseOrThrow(source);
+  // The first statement is an ExpressionStatement wrapping the CallExpression.
+  const [stmt] = (ast as unknown as { body: readonly unknown[] }).body;
+  const { expression } = stmt as { expression: unknown };
+  return expression as Parameters<typeof __getTrailCalleeNameForTest>[0];
+};
+
+describe('getTrailCalleeName', () => {
+  test('matches bare trail(...) identifier callees', () => {
+    expect(__getTrailCalleeNameForTest(parseCallee('trail("foo", {});'))).toBe(
+      'trail'
+    );
+  });
+
+  test('matches namespaced ns.trail(...) callees', () => {
+    expect(
+      __getTrailCalleeNameForTest(parseCallee('core.trail("foo", {});'))
+    ).toBe('trail');
+  });
+
+  test('matches bare signal(...) identifier callees', () => {
+    expect(__getTrailCalleeNameForTest(parseCallee('signal("evt", {});'))).toBe(
+      'signal'
+    );
+  });
+
+  test('matches namespaced ns.signal(...) callees', () => {
+    expect(
+      __getTrailCalleeNameForTest(parseCallee('core.signal("evt", {});'))
+    ).toBe('signal');
+  });
+
+  test('rejects computed member access like ns[trail](...)', () => {
+    expect(
+      __getTrailCalleeNameForTest(parseCallee('ns[trail]("foo", {});'))
+    ).toBeNull();
+  });
+
+  test('rejects unrelated bare callees', () => {
+    expect(
+      __getTrailCalleeNameForTest(parseCallee('other("foo", {});'))
+    ).toBeNull();
+  });
+
+  test('rejects unrelated namespaced callees', () => {
+    expect(
+      __getTrailCalleeNameForTest(parseCallee('ns.other("foo", {});'))
+    ).toBeNull();
+  });
+});
+
+describe('findTrailDefinitions with namespaced callees', () => {
+  test('discovers core.trail("id", { ... }) definitions', () => {
+    const source = `
+      import * as core from '@ontrails/core';
+      export const t = core.trail('entity.show', {
+        input: {},
+      });
+    `;
+    const ast = parseOrThrow(source);
+    const defs = findTrailDefinitions(ast);
+    expect(defs).toHaveLength(1);
+    expect(defs[0]?.id).toBe('entity.show');
+    expect(defs[0]?.kind).toBe('trail');
+  });
+
+  test('discovers core.signal("id", { ... }) definitions', () => {
+    const source = `
+      import * as core from '@ontrails/core';
+      export const s = core.signal('entity.created', { payload: {} });
+    `;
+    const ast = parseOrThrow(source);
+    const defs = findTrailDefinitions(ast);
+    expect(defs).toHaveLength(1);
+    expect(defs[0]?.id).toBe('entity.created');
+    expect(defs[0]?.kind).toBe('signal');
+  });
+
+  test('still ignores computed-member access ns[trail]("id", ...)', () => {
+    const source = `
+      const trail = 'x';
+      ns[trail]('entity.show', { input: {} });
+    `;
+    const ast = parseOrThrow(source);
+    expect(findTrailDefinitions(ast)).toHaveLength(0);
   });
 });

--- a/packages/warden/src/__tests__/intent-propagation.test.ts
+++ b/packages/warden/src/__tests__/intent-propagation.test.ts
@@ -66,6 +66,31 @@ trail('entity.lookup', {
     expect(intentPropagation.check(code, TEST_FILE)).toEqual([]);
   });
 
+  test('warns when namespaced core.trail(...) read crosses a write trail', () => {
+    // Regression guard for TRL-343: the shared findTrailDefinitions helper
+    // must recognize `core.trail("id", { ... })` as a trail definition, not
+    // just bare `trail("id", { ... })`. Before the fix these definitions were
+    // silently skipped and this rule stayed quiet on namespaced-import files.
+    const code = `
+core.trail('entity.read', {
+  intent: 'read',
+  crosses: ['entity.refresh'],
+  blaze: async (_input, ctx) => ctx.cross('entity.refresh', {}),
+});
+
+core.trail('entity.refresh', {
+  intent: 'write',
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = intentPropagation.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('entity.refresh');
+    expect(diagnostics[0]?.message).toContain("intent: 'write'");
+  });
+
   test('stays quiet when the entry trail is not read-only', () => {
     const code = `
 trail('entity.update', {

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -558,17 +558,64 @@ export interface TrailDefinition {
  */
 const TRAIL_CALLEE_NAMES = new Set(['signal', 'trail']);
 
+const matchTrailPrimitiveName = (
+  name: string | undefined | null
+): string | null => (name && TRAIL_CALLEE_NAMES.has(name) ? name : null);
+
+const getBareTrailCalleeName = (callee: AstNode): string | null => {
+  if (callee.type !== 'Identifier') {
+    return null;
+  }
+  return matchTrailPrimitiveName((callee as unknown as { name?: string }).name);
+};
+
+/**
+ * Resolve a namespaced `ns.trail(...)` / `ns.signal(...)` callee to its
+ * primitive name. Computed access (`ns[trail]()`) is intentionally rejected:
+ * the bracketed expression may resolve to any runtime value, so we cannot
+ * prove the call targets the framework primitive.
+ */
+const getNamespacedTrailCalleeName = (callee: AstNode): string | null => {
+  if (
+    callee.type !== 'MemberExpression' &&
+    callee.type !== 'StaticMemberExpression'
+  ) {
+    return null;
+  }
+  if ((callee as unknown as { computed?: boolean }).computed === true) {
+    return null;
+  }
+  const prop = (callee as unknown as { property?: AstNode }).property;
+  if (prop?.type !== 'Identifier') {
+    return null;
+  }
+  return matchTrailPrimitiveName((prop as unknown as { name?: string }).name);
+};
+
+/**
+ * Resolve the callee name of a trail/signal call expression.
+ *
+ * Matches both bare `trail(...)` / `signal(...)` identifiers and namespaced
+ * member-expression callees like `core.trail(...)` or `ns.signal(...)`.
+ */
 const getTrailCalleeName = (node: AstNode): string | null => {
   if (node.type !== 'CallExpression') {
     return null;
   }
   const callee = node['callee'] as AstNode | undefined;
-  if (!callee || callee.type !== 'Identifier') {
+  if (!callee) {
     return null;
   }
-  const { name } = callee as unknown as { name?: string };
-  return name && TRAIL_CALLEE_NAMES.has(name) ? name : null;
+  return getBareTrailCalleeName(callee) ?? getNamespacedTrailCalleeName(callee);
 };
+
+/**
+ * Test hook: exposes {@link getTrailCalleeName} for unit tests.
+ *
+ * Kept unexported from the module's public surface (no re-export from
+ * `index.ts`) so internal refactors stay free.
+ */
+export const __getTrailCalleeNameForTest = getTrailCalleeName;
 
 /** Extract args from a trail() call, handling both two-arg and single-object forms. */
 const extractTrailArgs = (


### PR DESCRIPTION
## Summary

Widens `getTrailCalleeName` in `packages/warden/src/ast.ts` to recognize namespaced `ns.trail(...)` and `ns.signal(...)` callees alongside bare `trail(...)` / `signal(...)`. Eliminates an asymmetry where `context-no-surface-types.ts:hasTrailCall` saw namespaced trails but every other rule walking trail definitions silently skipped them.

Closes [TRL-343](https://linear.app/outfitter/issue/TRL-343).

## The asymmetry

Landed in PR #206, `hasTrailCall` in `context-no-surface-types.ts` handles both `trail(...)` (Identifier callee) and `ns.trail(...)` (MemberExpression callee). The shared `findTrailDefinitions` in `ast.ts` — consumed by ~15 other rules — still matched Identifier callees only. Consumer code using `import * as core from '@ontrails/core'; core.trail('foo', {...})` was detected by one rule and silently skipped by the rest.

## Fix

Replaced the Identifier-only check in `getTrailCalleeName` with a two-strategy resolver:

- `getBareTrailCalleeName` preserves the existing Identifier behavior.
- `getNamespacedTrailCalleeName` matches `MemberExpression` / `StaticMemberExpression` callees with a non-computed property named `trail` or `signal`. Rejects `computed: true` — `ns[trail]()` must not match (same guard as `isNamespacedTrailCallee` in `warden-rules-use-ast.ts`).

Both strategies funnel through `matchTrailPrimitiveName` against the existing `TRAIL_CALLEE_NAMES` set.

The fix lives at the shared helper level — no per-rule patches. Every consumer of `findTrailDefinitions` / `TrailDefinition.{id, config, kind}` now discovers namespaced definitions symmetrically.

## Rules affected

All inherit the widening automatically: `valid-detour-refs`, `valid-describe-refs`, `intent-propagation`, `cross-declarations`, `resource-declarations`, `resource-exists`, `dead-internal-trail`, `on-references-exist`, `unreachable-detour-shadowing`, `contour-exists`, `no-throw-in-detour-target`, `no-throw-in-implementation`, `no-direct-impl-in-route`, `implementation-returns-result`, `fires-declarations`.

No rule inspects the callee shape directly, so none needed a carve-out. Every rule's existing enforcement logic applies symmetrically to both call shapes.

## Verification

- `bun run typecheck` — 31/31 green
- `bun test packages/warden` — 519 pass / 0 fail (up from 509)
- `bun run check` — 31/31 green
- Warden baseline remains clean; no false positives on any real rule file

## Test plan

10 new tests:

- 7 unit tests on `getTrailCalleeName` in `ast.test.ts`: bare `trail`, bare `signal`, namespaced `ns.trail`, namespaced `ns.signal`, computed rejection (`ns[trail]`), unrelated bare (`other`), unrelated namespaced (`ns.other`).
- 3 integration tests on `findTrailDefinitions` with namespaced + computed shapes.
- 1 regression test on `intent-propagation` firing against namespaced trail — would have stayed silent pre-fix.

## Review arc

Single round of Codex review, clean on first pass.

## Related

- [ADR-0036](../docs/adr/0036-warden-rule-public-shape-is-the-trail.md) — warden rule self-governance context
- PR #206 — Devin surfaced the asymmetry during review
- `packages/warden/src/rules/warden-rules-use-ast.ts` — `isNamespacedTrailCallee` reference pattern reused here