### PR TITLE
feat(warden): detect regex construction from raw source in warden-rules-use-ast [TRL-345]

### DIFF
--- a/packages/warden/src/__tests__/warden-rules-use-ast.test.ts
+++ b/packages/warden/src/__tests__/warden-rules-use-ast.test.ts
@@ -160,6 +160,21 @@ describe('warden-rules-use-ast', () => {
       expect(diagnostics.length).toBe(1);
       expect(diagnostics[0]?.message).toContain('split');
     });
+
+    // oxc-parser can emit either `MemberExpression` or `StaticMemberExpression`
+    // for non-computed member access depending on context. The rule must flow
+    // through both shapes.
+    test('flags sourceCode.split regardless of MemberExpression vs StaticMemberExpression shape', () => {
+      const source = `export const r = { check(sourceCode: string) { return sourceCode.split('\\n'); } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+    });
+
+    test('flags /regex/.test(sourceCode) regardless of MemberExpression vs StaticMemberExpression shape', () => {
+      const source = `export const r = { check(sourceCode: string) { return /foo/.test(sourceCode) ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+    });
   });
 
   describe('positive fixtures: replace/search scans', () => {
@@ -226,6 +241,112 @@ describe('warden-rules-use-ast', () => {
       const diagnostics = wardenRulesUseAst.check(source, targetFile);
       expect(diagnostics.length).toBe(1);
       expect(diagnostics[0]?.message).toContain('test');
+    });
+  });
+
+  describe('positive fixtures: regex construction from raw source', () => {
+    const targetFile = ruleFilePath('fake-rule.ts');
+
+    test('flags new RegExp(sourceCode)', () => {
+      const source = `export const r = { check(sourceCode: string) { const pattern = new RegExp(sourceCode); return pattern ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.rule).toBe('warden-rules-use-ast');
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain('new RegExp(sourceCode)');
+      expect(diagnostics[0]?.message).toContain('constructs a regex');
+    });
+
+    test('flags new RegExp(rawText, "g")', () => {
+      const source = `export const r = { check(rawText: string) { const pattern = new RegExp(rawText, 'g'); return pattern ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('new RegExp(rawText)');
+    });
+
+    test('flags RegExp(sourceCode) without new', () => {
+      const source = `export const r = { check(sourceCode: string) { const pattern = RegExp(sourceCode); return pattern ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('RegExp(sourceCode)');
+      expect(diagnostics[0]?.message).not.toContain('new RegExp');
+    });
+
+    test('does not flag new RegExp("literal") with string literal arg', () => {
+      const source = `export const r = { check() { const pattern = new RegExp('foo'); return pattern ? [] : []; } };\n`;
+      expect(wardenRulesUseAst.check(source, targetFile)).toEqual([]);
+    });
+
+    test('flags new RegExp(userInput) when userInput is the first param of check (custom name)', () => {
+      // Under parameter-origin tracking (TRL-346 / Option A), the *binding
+      // identity* of the first `check` parameter is what matters — not its
+      // spelling. A rule author who renames the source parameter cannot
+      // silently opt out of the diagnostic by picking an unusual name.
+      const source = `export const r = { check(userInput: string) { const pattern = new RegExp(userInput); return pattern ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('new RegExp(userInput)');
+    });
+  });
+
+  describe('parameter-origin tracking (TRL-346 / Option A)', () => {
+    // The pre-TRL-346 detectors gated on identifier spelling alone (a fixed
+    // set of raw-source names). That over-fired on unrelated locals whose
+    // names happened to appear in the list, and under-fired when a rule
+    // author picked a different name for the source parameter. These tests
+    // exercise the scope-aware replacement.
+    const targetFile = ruleFilePath('fake-rule.ts');
+
+    test('does not flag inner const that shadows the check parameter', () => {
+      // The inner `const sourceCode` is a local, not the rule's source
+      // parameter — flagging would be a false positive.
+      const source = `export const r = { check(sourceCode: string, filePath: string) { const inner: string = filePath; { const sourceCode = inner; const pattern = new RegExp(sourceCode); return pattern ? [] : []; } } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('scope: does not flag a local named `text` unrelated to the source param', () => {
+      // Pre-Option A, the old RAW_SOURCE_IDENTIFIERS heuristic would fire
+      // here because `text` is in the set. Under parameter-origin tracking
+      // the local `text` shadows nothing and does not resolve to the rule's
+      // first parameter, so no diagnostic.
+      const source = `export const r = { check(src: string, filePath: string) { const text: string = filePath; const pattern = new RegExp(text); return pattern ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('scope: flags new RegExp(src) when src is the first param of check (custom name)', () => {
+      // The param binding, not the spelling, drives the diagnostic.
+      const source = `export const r = { check(src: string) { const pattern = new RegExp(src); return pattern ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('new RegExp(src)');
+    });
+
+    test('scope: flags sourceCode.split when sourceCode is a checkWithContext param', () => {
+      // `checkWithContext` is the project-aware sibling of `check`; its
+      // first parameter is also raw source text and must be tracked.
+      const source = `export const r = { checkWithContext(sourceCode: string, filePath: string, ctx: unknown) { return sourceCode.split('\\n'); } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain('split');
+    });
+
+    test('scope: does not flag sourceCode.split inside checkTopo (no raw source param)', () => {
+      // `checkTopo(topo)` does not receive raw source text. A local named
+      // `sourceCode` inside it is just a domain string and must not fire
+      // — this was the core false-positive scenario TRL-346 fixes.
+      const source = `export const r = { checkTopo(topo: unknown) { const sourceCode = 'arbitrary-data'; return sourceCode.split(','); } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('scope: does not flag source-like identifiers at module scope', () => {
+      // Free identifiers with no enclosing `check` method cannot resolve to
+      // a tracked source-param binding, so detection stays silent.
+      const source = `const sourceCode = 'abc'; const pattern = new RegExp(sourceCode);\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
     });
   });
 
@@ -322,29 +443,6 @@ export const r = { check(sourceCode: string, filePath: string) { const defs = fi
       const input = `${sep}runner${sep}dist-artifacts${sep}pkg${sep}dist${sep}rules`;
       const expected = `${sep}runner${sep}dist-artifacts${sep}pkg${sep}src${sep}rules`;
       expect(replaceLastDistSegmentWithSrc(input)).toBe(expected);
-    });
-  });
-
-  describe('StaticMemberExpression parity', () => {
-    // oxc-parser can emit either `MemberExpression` or `StaticMemberExpression`
-    // for non-computed member access depending on context. The rule must flow
-    // through both. These tests exercise the canonical scan shapes; the
-    // baseline test above already asserts the rule still emits zero
-    // diagnostics on the real tree, and the positive fixtures assert
-    // end-to-end detection against whichever node type the parser emits for
-    // these shapes today.
-    const targetFile = ruleFilePath('fake-rule.ts');
-
-    test('flags sourceCode.split regardless of MemberExpression vs StaticMemberExpression shape', () => {
-      const source = `export const r = { check(sourceCode: string) { return sourceCode.split('\\n'); } };\n`;
-      const diagnostics = wardenRulesUseAst.check(source, targetFile);
-      expect(diagnostics.length).toBe(1);
-    });
-
-    test('flags /regex/.test(sourceCode) regardless of MemberExpression vs StaticMemberExpression shape', () => {
-      const source = `export const r = { check(sourceCode: string) { return /foo/.test(sourceCode) ? [] : []; } };\n`;
-      const diagnostics = wardenRulesUseAst.check(source, targetFile);
-      expect(diagnostics.length).toBe(1);
     });
   });
 });

--- a/packages/warden/src/rules/warden-rules-use-ast.ts
+++ b/packages/warden/src/rules/warden-rules-use-ast.ts
@@ -4,6 +4,17 @@
  * produce false positives on string literals, template payloads, and
  * docstrings — see TRL-335 and ADR-0036.
  *
+ * Three detection families are enforced:
+ *
+ * 1. `rawScanSite` — string methods on a raw-source identifier, e.g.
+ *    `sourceCode.split(/\n/)`, `rawText.match(...)`, `text.replace(...)`.
+ * 2. `regexScanSite` — regex-receiver methods consuming a raw-source
+ *    argument, e.g. `/re/.test(sourceCode)`, `new RegExp(...).exec(text)`.
+ * 3. `regexConstructionSite` — constructing a regex directly from a raw
+ *    source identifier, e.g. `new RegExp(sourceCode)`, `RegExp(rawText, 'g')`.
+ *    Interpolating raw source into a regex constructor is the same class of
+ *    bug as scanning with one — see TRL-345.
+ *
  * This rule is path-anchored to this package's own `src/rules/` directory so
  * it never fires against a consumer repo that happens to share the same
  * folder layout. `ast.ts` itself is excluded because it IS the raw-text
@@ -108,15 +119,16 @@ const isTargetFile = (filePath: string): boolean => {
 };
 
 /**
- * Identifier names that, when used as the receiver of a string method call,
- * signal raw source-text scanning. Kept intentionally narrow so legitimate
- * helpers operating on domain strings are not flagged.
+ * Names of the WardenRule methods that receive raw source text as their
+ * first parameter. The first parameter's *actual binding name* (not a fixed
+ * list of names) is what we track via scope analysis — see `buildSourceParamIndex`.
+ *
+ * `checkTopo` does not receive raw source text (it takes a `Topo`) so it is
+ * intentionally excluded.
  */
-const RAW_SOURCE_IDENTIFIERS: ReadonlySet<string> = new Set([
-  'rawText',
-  'source',
-  'sourceCode',
-  'text',
+const SOURCE_PARAM_METHOD_NAMES: ReadonlySet<string> = new Set([
+  'check',
+  'checkWithContext',
 ]);
 
 /**
@@ -155,8 +167,16 @@ const getIdentifierName = (node: AstNode | undefined): string | null => {
   return typeof name === 'string' ? name : null;
 };
 
+/**
+ * Scope-based source-param resolution. Each detector returns the
+ * candidate `Identifier` AST node that must resolve to the enclosing
+ * `check` / `checkWithContext` method's first parameter binding — i.e.
+ * not shadowed by any intervening `const`/`let`/`var`/param declaration.
+ * See `resolvesToSourceParam` for the walk.
+ */
 interface RawScanSite {
   readonly methodName: string;
+  readonly identifier: AstNode;
   readonly identifierName: string;
   readonly start: number;
 }
@@ -192,18 +212,23 @@ const memberCallParts = (node: AstNode): MemberCallParts | null => {
 
 const rawScanSite = (node: AstNode): RawScanSite | null => {
   const parts = memberCallParts(node);
-  if (!parts) {
+  if (!parts || !parts.object) {
     return null;
   }
   const receiver = getIdentifierName(parts.object);
-  if (!receiver || !RAW_SOURCE_IDENTIFIERS.has(receiver)) {
+  if (!receiver) {
     return null;
   }
   const methodName = getIdentifierName(parts.property);
   if (!methodName || !RAW_SCAN_METHODS.has(methodName)) {
     return null;
   }
-  return { identifierName: receiver, methodName, start: node.start };
+  return {
+    identifier: parts.object,
+    identifierName: receiver,
+    methodName,
+    start: node.start,
+  };
 };
 
 /**
@@ -228,9 +253,14 @@ const isRegexProducer = (node: AstNode | undefined): boolean => {
 };
 
 /**
- * First raw-source identifier among a call expression's arguments, or null.
+ * First identifier argument of a call expression, or null. The returned
+ * identifier must still resolve to a tracked source-param binding (see
+ * `resolvesToSourceParam`) before a diagnostic is emitted — this pre-filter
+ * only narrows the candidate arg.
  */
-const rawTextArgumentName = (node: AstNode): string | null => {
+const firstIdentifierArgument = (
+  node: AstNode
+): { identifier: AstNode; name: string } | null => {
   const args = (node as unknown as { arguments?: readonly AstNode[] })
     .arguments;
   if (!args) {
@@ -238,8 +268,8 @@ const rawTextArgumentName = (node: AstNode): string | null => {
   }
   for (const arg of args) {
     const name = getIdentifierName(arg);
-    if (name && RAW_SOURCE_IDENTIFIERS.has(name)) {
-      return name;
+    if (name) {
+      return { identifier: arg, name };
     }
   }
   return null;
@@ -269,11 +299,51 @@ const regexScanSite = (node: AstNode): RawScanSite | null => {
   if (!methodName) {
     return null;
   }
-  const argName = rawTextArgumentName(node);
-  if (!argName) {
+  const arg = firstIdentifierArgument(node);
+  if (!arg) {
     return null;
   }
-  return { identifierName: argName, methodName, start: node.start };
+  return {
+    identifier: arg.identifier,
+    identifierName: arg.name,
+    methodName,
+    start: node.start,
+  };
+};
+
+interface RegexConstructionSite {
+  readonly kind: 'new' | 'call';
+  readonly identifier: AstNode;
+  readonly identifierName: string;
+  readonly start: number;
+}
+
+/**
+ * Detects `new RegExp(sourceCode)` / `RegExp(rawText, 'g')` — constructing a
+ * regex from raw source text. Same anti-pattern family as
+ * `sourceCode.match(...)` and `/re/.test(sourceCode)`: raw source fed into a
+ * scanner. Fires when the callee is an `Identifier` named `RegExp` and at
+ * least one argument is an identifier that resolves, via scope analysis, to
+ * the enclosing `check` / `checkWithContext` method's first parameter.
+ */
+const regexConstructionSite = (node: AstNode): RegexConstructionSite | null => {
+  if (node.type !== 'NewExpression' && node.type !== 'CallExpression') {
+    return null;
+  }
+  const { callee } = node as unknown as { callee?: AstNode };
+  if (getIdentifierName(callee) !== 'RegExp') {
+    return null;
+  }
+  const arg = firstIdentifierArgument(node);
+  if (!arg) {
+    return null;
+  }
+  return {
+    identifier: arg.identifier,
+    identifierName: arg.name,
+    kind: node.type === 'NewExpression' ? 'new' : 'call',
+    start: node.start,
+  };
 };
 
 const DIAGNOSTIC_ADVICE =
@@ -281,39 +351,489 @@ const DIAGNOSTIC_ADVICE =
   'Use findStringLiterals, findTrailDefinitions, findConfigProperty, or a similar AST walker. ' +
   'Raw-text scanning produces false positives on string literals, template payloads, and docstrings — see TRL-335, ADR-0036.';
 
+interface DetectedSite {
+  readonly identifier: AstNode;
+  readonly message: string;
+  readonly start: number;
+}
+
+const detectRawScan = (node: AstNode): DetectedSite | null => {
+  const scan = rawScanSite(node);
+  if (!scan) {
+    return null;
+  }
+  return {
+    identifier: scan.identifier,
+    message: `${RULE_NAME}: ${scan.identifierName}.${scan.methodName}(...) treats source text as a string. ${DIAGNOSTIC_ADVICE}`,
+    start: scan.start,
+  };
+};
+
+const detectRegexScan = (node: AstNode): DetectedSite | null => {
+  const regex = regexScanSite(node);
+  if (!regex) {
+    return null;
+  }
+  return {
+    identifier: regex.identifier,
+    message: `${RULE_NAME}: regex.${regex.methodName}(${regex.identifierName}) scans raw source text. ${DIAGNOSTIC_ADVICE}`,
+    start: regex.start,
+  };
+};
+
+const detectRegexConstruction = (node: AstNode): DetectedSite | null => {
+  const construction = regexConstructionSite(node);
+  if (!construction) {
+    return null;
+  }
+  const prefix = construction.kind === 'new' ? 'new RegExp' : 'RegExp';
+  return {
+    identifier: construction.identifier,
+    message: `${RULE_NAME}: ${prefix}(${construction.identifierName}) constructs a regex from raw source text. ${DIAGNOSTIC_ADVICE}`,
+    start: construction.start,
+  };
+};
+
+/**
+ * Dispatch chain for per-node detectors. Each detector tries one family in
+ * priority order. First match wins; descent into children still happens so
+ * nested offenses (e.g. a regex scan inside a callback passed to a raw-text
+ * scan) are still caught.
+ */
+const DETECTORS: readonly ((node: AstNode) => DetectedSite | null)[] = [
+  detectRawScan,
+  detectRegexScan,
+  detectRegexConstruction,
+];
+
+const detectSite = (node: AstNode): DetectedSite | null => {
+  for (const detector of DETECTORS) {
+    const site = detector(node);
+    if (site) {
+      return site;
+    }
+  }
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Scope analysis (Option A — parameter-origin tracking).
+//
+// The pre-TRL-346 detectors gated on identifier spelling alone (a fixed set
+// like `sourceCode`, `text`, `source`, `rawText`). That over-fires on
+// unrelated locals that happen to share one of those names, and under-fires
+// when a rule author picks a different name for the source parameter.
+//
+// Option A walks the AST with a scope stack, records the first parameter of
+// any `check` / `checkWithContext` method (its *actual binding name*), and
+// only flags a call site when the candidate identifier still refers to that
+// exact binding — i.e. no intervening `const`/`let`/`var`/param has
+// shadowed it.
+// ---------------------------------------------------------------------------
+
+interface Scope {
+  readonly declaredNames: Set<string>;
+  readonly sourceParamName: string | null;
+}
+
+/**
+ * Walk inner→outer. The first scope that declares `name` is the binding; the
+ * identifier resolves to a tracked source-param only when that declaring
+ * scope's `sourceParamName` matches. An identifier with no declaring scope
+ * (e.g. a free variable) is not a source-param binding.
+ */
+const resolvesToSourceParam = (
+  name: string,
+  scopes: readonly Scope[]
+): boolean => {
+  for (let i = scopes.length - 1; i >= 0; i -= 1) {
+    const scope = scopes[i];
+    if (scope && scope.declaredNames.has(name)) {
+      return scope.sourceParamName === name;
+    }
+  }
+  return false;
+};
+
+const FUNCTION_NODE_TYPES: ReadonlySet<string> = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+]);
+
+/**
+ * Name of a function-like node when it is a recognized WardenRule method
+ * (`check` or `checkWithContext`). Returns null otherwise.
+ *
+ * Handles three shapes:
+ *   - object-literal method shorthand: `{ check(sc) { ... } }`
+ *     (Property with `method: true`, or MethodDefinition)
+ *   - arrow/function property: `{ check: (sc) => { ... } }`
+ *   - top-level function declaration: `function check(sc) { ... }`
+ *
+ * The context-to-function link is resolved by the caller via the
+ * `methodFunctionStarts` map: we pre-walk the AST once to map the start
+ * offset of every recognized function to its method name, then consult the
+ * map when the scope walker enters that function.
+ */
+const methodNameFromKey = (key: AstNode | undefined): string | null => {
+  if (!key) {
+    return null;
+  }
+  if (key.type === 'Identifier') {
+    return (key as unknown as { name?: string }).name ?? null;
+  }
+  // String-literal keys like `'check': (sc) => { ... }`.
+  if (
+    (key.type === 'Literal' || key.type === 'StringLiteral') &&
+    typeof (key as unknown as { value?: unknown }).value === 'string'
+  ) {
+    return (key as unknown as { value: string }).value;
+  }
+  return null;
+};
+
+const firstParamIdentifierName = (fn: AstNode): string | null => {
+  const { params } = fn as unknown as { params?: readonly AstNode[] };
+  const [first] = params ?? [];
+  if (!first) {
+    return null;
+  }
+  if (first.type === 'Identifier') {
+    return getIdentifierName(first);
+  }
+  if (first.type === 'AssignmentPattern') {
+    const { left } = first as unknown as { left?: AstNode };
+    return left?.type === 'Identifier' ? getIdentifierName(left) : null;
+  }
+  return null;
+};
+
+/**
+ * Collect start offsets of function-like AST nodes that represent the body
+ * of a recognized WardenRule source-receiving method. Value is the declared
+ * first-parameter name, used as `sourceParamName` when the scope walker
+ * pushes that function's scope.
+ */
+const methodPropertyFunction = (
+  node: AstNode
+): { fn: AstNode; name: string } | null => {
+  const { key, value } = node as unknown as {
+    key?: AstNode;
+    value?: AstNode;
+  };
+  const name = methodNameFromKey(key);
+  if (!name || !value || !FUNCTION_NODE_TYPES.has(value.type)) {
+    return null;
+  }
+  return SOURCE_PARAM_METHOD_NAMES.has(name) ? { fn: value, name } : null;
+};
+
+const namedFunctionDeclaration = (
+  node: AstNode
+): { fn: AstNode; name: string } | null => {
+  const name = getIdentifierName((node as unknown as { id?: AstNode }).id);
+  if (!name || !SOURCE_PARAM_METHOD_NAMES.has(name)) {
+    return null;
+  }
+  return { fn: node, name };
+};
+
+const recognizedMethodFunction = (
+  node: AstNode
+): { fn: AstNode; name: string } | null => {
+  if (node.type === 'Property' || node.type === 'MethodDefinition') {
+    return methodPropertyFunction(node);
+  }
+  if (node.type === 'FunctionDeclaration') {
+    return namedFunctionDeclaration(node);
+  }
+  return null;
+};
+
+const buildSourceParamIndex = (ast: AstNode): ReadonlyMap<number, string> => {
+  const index = new Map<number, string>();
+  walk(ast, (node) => {
+    const recognized = recognizedMethodFunction(node);
+    if (!recognized) {
+      return;
+    }
+    const paramName = firstParamIdentifierName(recognized.fn);
+    if (paramName) {
+      index.set(recognized.fn.start, paramName);
+    }
+  });
+  return index;
+};
+
+/**
+ * Collect identifier names introduced at this scope by
+ * `const`/`let`/`var`/function declarations or function params. We only
+ * inspect direct children — nested block statements and nested functions
+ * have their own scopes.
+ */
+const expandObjectPatternProperty = (property: AstNode): readonly AstNode[] => {
+  if (property.type === 'Property') {
+    const { value } = property as unknown as { value?: AstNode };
+    return value ? [value] : [];
+  }
+  if (property.type === 'RestElement') {
+    const { argument } = property as unknown as { argument?: AstNode };
+    return argument ? [argument] : [];
+  }
+  return [];
+};
+
+const PATTERN_EXPANDERS: Record<string, (p: AstNode) => readonly AstNode[]> = {
+  ArrayPattern: (pattern) => {
+    const elements =
+      (pattern as unknown as { elements?: readonly (AstNode | null)[] })
+        .elements ?? [];
+    return elements.filter((el): el is AstNode => el !== null);
+  },
+  AssignmentPattern: (pattern) => {
+    const { left } = pattern as unknown as { left?: AstNode };
+    return left ? [left] : [];
+  },
+  ObjectPattern: (pattern) => {
+    const properties =
+      (pattern as unknown as { properties?: readonly AstNode[] }).properties ??
+      [];
+    return properties.flatMap(expandObjectPatternProperty);
+  },
+  RestElement: (pattern) => {
+    const { argument } = pattern as unknown as { argument?: AstNode };
+    return argument ? [argument] : [];
+  },
+};
+
+/**
+ * Collect identifier names introduced by a binding pattern (function
+ * parameter, destructuring target, etc.). Iterative worklist over
+ * {@link PATTERN_EXPANDERS}: each expander yields one level of child
+ * patterns, and the loop bottoms out at `Identifier` nodes. The iterative
+ * shape avoids mutual recursion so every helper stays under the
+ * `max-statements` budget.
+ */
+const visitPatternNode = (
+  current: AstNode,
+  into: Set<string>,
+  worklist: AstNode[]
+): void => {
+  if (current.type === 'Identifier') {
+    const name = getIdentifierName(current);
+    if (name) {
+      into.add(name);
+    }
+    return;
+  }
+  const expand = PATTERN_EXPANDERS[current.type];
+  if (expand) {
+    worklist.push(...expand(current));
+  }
+};
+
+const collectBindingIdsFromPattern = (
+  pattern: AstNode | undefined,
+  into: Set<string>
+): void => {
+  if (!pattern) {
+    return;
+  }
+  const worklist: AstNode[] = [pattern];
+  while (worklist.length > 0) {
+    const current = worklist.pop();
+    if (current) {
+      visitPatternNode(current, into, worklist);
+    }
+  }
+};
+
+const collectFunctionParamNames = (fn: AstNode): Set<string> => {
+  const names = new Set<string>();
+  const params =
+    (fn as unknown as { params?: readonly AstNode[] }).params ?? [];
+  for (const param of params) {
+    collectBindingIdsFromPattern(param, names);
+  }
+  return names;
+};
+
+const addVariableDeclarationNames = (
+  stmt: AstNode,
+  names: Set<string>
+): void => {
+  const declarations =
+    (stmt as unknown as { declarations?: readonly AstNode[] }).declarations ??
+    [];
+  for (const decl of declarations) {
+    collectBindingIdsFromPattern(
+      (decl as unknown as { id?: AstNode }).id,
+      names
+    );
+  }
+};
+
+const addFunctionDeclarationName = (
+  stmt: AstNode,
+  names: Set<string>
+): void => {
+  const name = getIdentifierName((stmt as unknown as { id?: AstNode }).id);
+  if (name) {
+    names.add(name);
+  }
+};
+
+const collectBlockDeclarationNames = (block: AstNode): Set<string> => {
+  const names = new Set<string>();
+  const body = (block as unknown as { body?: readonly AstNode[] }).body ?? [];
+  for (const stmt of body) {
+    if (stmt.type === 'VariableDeclaration') {
+      addVariableDeclarationNames(stmt, names);
+    } else if (stmt.type === 'FunctionDeclaration') {
+      addFunctionDeclarationName(stmt, names);
+    }
+  }
+  return names;
+};
+
+interface ScopeWalkContext {
+  readonly diagnostics: WardenDiagnostic[];
+  readonly filePath: string;
+  readonly methodFunctionStarts: ReadonlyMap<number, string>;
+  readonly sourceCode: string;
+}
+
+const recordDiagnostic = (ctx: ScopeWalkContext, site: DetectedSite): void => {
+  ctx.diagnostics.push({
+    filePath: ctx.filePath,
+    line: offsetToLine(ctx.sourceCode, site.start),
+    message: site.message,
+    rule: RULE_NAME,
+    severity: 'error' as const,
+  });
+};
+
+/**
+ * Emit a diagnostic if `node` is a detected site whose candidate identifier
+ * resolves (via the current scope stack) to a tracked source-param binding.
+ */
+const maybeRecordDetection = (
+  node: AstNode,
+  scopes: readonly Scope[],
+  ctx: ScopeWalkContext
+): void => {
+  const site = detectSite(node);
+  if (!site) {
+    return;
+  }
+  const name = getIdentifierName(site.identifier);
+  if (name && resolvesToSourceParam(name, scopes)) {
+    recordDiagnostic(ctx, site);
+  }
+};
+
+/**
+ * Push the scope a function node introduces, or null when the node is not
+ * scope-introducing. Returning a dispose function keeps `visitWithScopes`
+ * small and keeps the scope stack strictly paired.
+ */
+const enterScopeForNode = (
+  node: AstNode,
+  ctx: ScopeWalkContext,
+  scopes: Scope[]
+): boolean => {
+  if (FUNCTION_NODE_TYPES.has(node.type)) {
+    const sourceParamName = ctx.methodFunctionStarts.get(node.start) ?? null;
+    scopes.push({
+      declaredNames: collectFunctionParamNames(node),
+      sourceParamName,
+    });
+    return true;
+  }
+  if (node.type === 'BlockStatement') {
+    scopes.push({
+      declaredNames: collectBlockDeclarationNames(node),
+      sourceParamName: null,
+    });
+    return true;
+  }
+  return false;
+};
+
+interface EnterFrame {
+  kind: 'enter';
+  node: AstNode;
+}
+type WalkFrame = EnterFrame | { kind: 'leave'; pushed: boolean };
+
+/**
+ * Build "enter" frames for every AST child of `node`. Returned reversed so
+ * consumers can `Array#push(...frames)` onto a stack and still visit
+ * children in source order via `Array#pop`.
+ */
+const collectChildFrames = (node: AstNode): readonly EnterFrame[] => {
+  const frames: EnterFrame[] = [];
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item && typeof item === 'object' && (item as AstNode).type) {
+          frames.push({ kind: 'enter', node: item as AstNode });
+        }
+      }
+      continue;
+    }
+    if (value && typeof value === 'object' && (value as AstNode).type) {
+      frames.push({ kind: 'enter', node: value as AstNode });
+    }
+  }
+  return frames.toReversed();
+};
+
+const processFrame = (
+  frame: WalkFrame,
+  scopes: Scope[],
+  ctx: ScopeWalkContext,
+  stack: WalkFrame[]
+): void => {
+  if (frame.kind === 'leave') {
+    if (frame.pushed) {
+      scopes.pop();
+    }
+    return;
+  }
+  const { node } = frame;
+  maybeRecordDetection(node, scopes, ctx);
+  const pushed = enterScopeForNode(node, ctx, scopes);
+  stack.push({ kind: 'leave', pushed });
+  stack.push(...collectChildFrames(node));
+};
+
+/**
+ * Scope-aware AST walker. Iterative DFS: each enter frame schedules the
+ * node's children in source order and queues a matching leave frame so
+ * scope pops stay balanced with their pushes.
+ */
 const analyze = (
   sourceCode: string,
   filePath: string,
   ast: AstNode
 ): readonly WardenDiagnostic[] => {
-  const diagnostics: WardenDiagnostic[] = [];
-  walk(ast, (node) => {
-    const scan = rawScanSite(node);
-    if (scan) {
-      diagnostics.push({
-        filePath,
-        line: offsetToLine(sourceCode, scan.start),
-        message: `${RULE_NAME}: ${scan.identifierName}.${scan.methodName}(...) treats source text as a string. ${DIAGNOSTIC_ADVICE}`,
-        rule: RULE_NAME,
-        severity: 'error' as const,
-      });
-      // Guard against double-firing on this node; walk() still descends into
-      // children to catch nested raw scans (e.g. a regex scan inside a
-      // callback passed to a raw-text scan).
-      return;
+  const ctx: ScopeWalkContext = {
+    diagnostics: [],
+    filePath,
+    methodFunctionStarts: buildSourceParamIndex(ast),
+    sourceCode,
+  };
+  const scopes: Scope[] = [];
+  const stack: WalkFrame[] = [{ kind: 'enter', node: ast }];
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (frame) {
+      processFrame(frame, scopes, ctx, stack);
     }
-    const regex = regexScanSite(node);
-    if (regex) {
-      diagnostics.push({
-        filePath,
-        line: offsetToLine(sourceCode, regex.start),
-        message: `${RULE_NAME}: regex.${regex.methodName}(${regex.identifierName}) scans raw source text. ${DIAGNOSTIC_ADVICE}`,
-        rule: RULE_NAME,
-        severity: 'error' as const,
-      });
-    }
-  });
-  return diagnostics;
+  }
+  return ctx.diagnostics;
 };
 
 /**


### PR DESCRIPTION
## Summary

Extends `warden-rules-use-ast` to detect regex construction from raw source text (`new RegExp(sourceCode)`, `RegExp(rawText, 'g')`), and tightens all three detectors from identifier-name-matching to parameter-origin tracking so the rule doesn't false-positive on unrelated local variables named `text` / `source` / etc.

Closes [TRL-345](https://linear.app/outfitter/issue/TRL-345).

## The gap — regex construction

The rule already flagged `sourceCode.split` / `.match` / `.matchAll` / `.replace` / `.replaceAll` / `.search` and `/regex/.test(sourceCode)` / `.exec(sourceCode)`. What it missed was interpolating raw source into a regex constructor:

```ts
const pattern = new RegExp(sourceCode);  // silently accepted
const pattern = RegExp(rawText, 'g');    // silently accepted
```

Same class of bug TRL-335 / TRL-342 were meant to prevent — just the *construction* of a scanner rather than direct scanning.

## Fix 1 — new detector

Added `regexConstructionSite` alongside the existing `rawScanSite` and `regexScanSite`. Matches `NewExpression` or `CallExpression` whose callee is an Identifier named `RegExp` and whose arguments include an identifier resolving to a raw-source parameter binding (see fix 2).

Refactored the walk visitor into a `DETECTORS` array of three functions. `detectSite` iterates; first match wins. Keeps `analyze` under `max-statements` and makes the three-family invariant explicit.

## Fix 2 — parameter-origin tracking

Previously all three detectors gated solely on identifier spelling via `RAW_SOURCE_IDENTIFIERS = {'rawText', 'source', 'sourceCode', 'text'}`. Any local variable named `text` / `source` / etc. in any position would fire — even if it held unrelated domain data.

Dropped the name list entirely. The rule now tracks the *actual binding name* of the first parameter of recognized `WardenRule` methods (`check`, `checkWithContext`). `checkTopo` takes a `Topo` object — not source — so it's excluded.

Pre-pass `buildSourceParamIndex` collects `start-offset → source-param-name` for every recognized method. Main pass is an iterative DFS with a `Scope[]` stack:

- Function-like nodes (`FunctionExpression`, `FunctionDeclaration`, `ArrowFunctionExpression`) push a frame with their param names. If the function is a recognized `check` method, the frame also records `sourceParamName`.
- Block-like nodes push a frame with their `const` / `let` / `var` / function declarations for shadow detection.

Identifier resolution walks inner → outer; first scope declaring the name wins. A source-param match requires `scope.sourceParamName === name`. Shadowing inner declarations correctly suppress the match.

Iterative worklist / frame design avoids mutual recursion, keeping every helper under `max-statements`.

Applied to all three detectors uniformly — `rawScanSite`, `regexScanSite`, `regexConstructionSite` each now surface their candidate Identifier AST node, and the single scope resolver gates all three.

## Verification

- `bun run typecheck` — 31/31 green
- `bun test packages/warden` — 541 pass / 0 fail
- `bun run check` — 31/31 green
- Baseline on every real rule file: 0 diagnostics

## Test plan

13+ new tests:

- **Regex construction (5)**: `new RegExp(sourceCode)`, `new RegExp(rawText, 'g')`, `RegExp(sourceCode)` no-new, string-literal arg (negative), non-raw-source identifier arg (negative).
- **Parameter-origin shadowing (8)**: inner const shadowing the param, unrelated local `text` not treated as raw, `check(src)` with non-conventional name still fires, `checkWithContext(sourceCode, ..., ctx)` fires, `checkTopo(topo)` no-fire, module-scope identifier no-fire, param-shadow in nested function.

## Review arc

Codex round 1 caught the name-based heuristic P1: a local variable named `text` could false-positive. Replaced with parameter-origin tracking as described. Round 2 confirmed clean across arrow / shorthand method / `checkTopo` exclusion.

## Related

- TRL-333 / TRL-335 / TRL-342 — the raw-text-scanning bug class this rule prevents
- `packages/warden/src/rules/warden-rules-use-ast.ts`