### PR TITLE
feat(warden): handle export * and namespace imports in implementation-returns-result [TRL-346]

### DIFF
--- a/packages/warden/src/__tests__/implementation-returns-result.test.ts
+++ b/packages/warden/src/__tests__/implementation-returns-result.test.ts
@@ -524,11 +524,10 @@ trail("entity.report", {
 
         expect(diagnostics.length).toBe(0);
       });
+    });
 
-      test('still flags namespace-imported Result helper (documented gap)', () => {
-        // `import * as ns from './foo.js'` with `ns.helper(...)` is not yet
-        // resolved — the binding is `ns`, not `helper`, so the member call is
-        // unrecognized. Documented skip in buildImportBinding.
+    describe('namespace imports and barrel export *', () => {
+      test('allows namespace-imported Result helper (import * as ns)', () => {
         writeFile(
           'impl-namespace.ts',
           `export const helper = async (): Promise<Result<object, Error>> =>
@@ -546,6 +545,319 @@ trail("entity.report", {
 })`
         );
 
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(0);
+      });
+
+      test('flags namespace-imported non-Result member call', () => {
+        writeFile(
+          'impl-namespace-mixed.ts',
+          `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+
+export const nonResultFn = async () => ({ ok: true });
+`
+        );
+        const caller = writeFile(
+          'caller-namespace-mixed.ts',
+          `import * as ns from './impl-namespace-mixed.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return ns.nonResultFn();
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(1);
+      });
+
+      test('falls back gracefully on unresolvable namespace import target', () => {
+        const caller = writeFile(
+          'caller-namespace-missing.ts',
+          `import * as ns from './missing-namespace.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return ns.helper();
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(1);
+      });
+
+      test('flags ns.helper() when blaze parameter shadows the namespace import', () => {
+        writeFile(
+          'impl-ns-shadow-param.ts',
+          `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+        );
+        const caller = writeFile(
+          'caller-ns-shadow-param.ts',
+          `import * as ns from './impl-ns-shadow-param.js';
+
+trail("entity.report", {
+  blaze: async (ns, ctx) => {
+    return ns.helper(ctx);
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        // The blaze parameter \`ns\` shadows the namespace import; \`ns.helper()\`
+        // is a call on the parameter, not on the namespace, so the return
+        // must be flagged rather than silently treated as a Result helper.
+        expect(diagnostics.length).toBe(1);
+      });
+
+      test('flags ns.helper() when a local const shadows the namespace import', () => {
+        writeFile(
+          'impl-ns-shadow-const.ts',
+          `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+        );
+        const caller = writeFile(
+          'caller-ns-shadow-const.ts',
+          `import * as ns from './impl-ns-shadow-const.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    const ns = { helper: () => ({ ok: true }) };
+    return ns.helper(input);
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(1);
+      });
+
+      test('flags ns.helper() when a local let shadows the namespace import', () => {
+        writeFile(
+          'impl-ns-shadow-let.ts',
+          `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+        );
+        const caller = writeFile(
+          'caller-ns-shadow-let.ts',
+          `import * as ns from './impl-ns-shadow-let.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    let ns = input;
+    return ns.helper(input);
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(1);
+      });
+
+      describe('shadowing in for/catch scopes', () => {
+        test('flags ns.helper() when a for-init const shadows the namespace import', () => {
+          writeFile(
+            'impl-ns-shadow-for-init.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-for-init.ts',
+            `import * as ns from './impl-ns-shadow-for-init.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    for (const ns = 0; ns < 1; ns++) {
+      return ns.helper(input);
+    }
+    return Result.ok({});
+  }
+})`
+          );
+
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+
+          expect(diagnostics.length).toBe(1);
+        });
+
+        test('flags ns.helper() when a for-of binding shadows the namespace import', () => {
+          writeFile(
+            'impl-ns-shadow-for-of.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-for-of.ts',
+            `import * as ns from './impl-ns-shadow-for-of.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    for (const ns of [1, 2, 3]) {
+      return ns.helper(input);
+    }
+    return Result.ok({});
+  }
+})`
+          );
+
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+
+          expect(diagnostics.length).toBe(1);
+        });
+
+        test('flags ns.helper() when a catch param shadows the namespace import', () => {
+          writeFile(
+            'impl-ns-shadow-catch.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-catch.ts',
+            `import * as ns from './impl-ns-shadow-catch.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    try {
+      return Result.ok({});
+    } catch (ns) {
+      return ns.helper(input);
+    }
+  }
+})`
+          );
+
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+
+          expect(diagnostics.length).toBe(1);
+        });
+
+        test('flags ns.helper() when a catch param destructures the namespace name', () => {
+          writeFile(
+            'impl-ns-shadow-catch-destructure.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-catch-destructure.ts',
+            `import * as ns from './impl-ns-shadow-catch-destructure.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    try {
+      return Result.ok({});
+    } catch ({ ns }) {
+      return ns.helper(input);
+    }
+  }
+})`
+          );
+
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+
+          expect(diagnostics.length).toBe(1);
+        });
+      });
+
+      test('allows named import through `export * from` barrel', () => {
+        writeFile(
+          'impl-star.ts',
+          `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+        );
+        writeFile(
+          'barrel-star.ts',
+          `export * from './impl-star.js';
+`
+        );
+        const caller = writeFile(
+          'caller-star.ts',
+          `import { helper } from './barrel-star.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return helper();
+  }
+})`
+        );
+
+        const diagnostics = implementationReturnsResult.check(
+          readFileSync(caller, 'utf8'),
+          caller
+        );
+
+        expect(diagnostics.length).toBe(0);
+      });
+
+      test('falls back gracefully on `export * from` cycle', () => {
+        writeFile(
+          'star-cycle-a.ts',
+          `export * from './star-cycle-b.js';
+`
+        );
+        writeFile(
+          'star-cycle-b.ts',
+          `export * from './star-cycle-a.js';
+`
+        );
+        const caller = writeFile(
+          'caller-star-cycle.ts',
+          `import { helper } from './star-cycle-a.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return helper();
+  }
+})`
+        );
+
+        // Should not hang; the helper is not resolvable through the cycle.
         const diagnostics = implementationReturnsResult.check(
           readFileSync(caller, 'utf8'),
           caller

--- a/packages/warden/src/rules/implementation-returns-result.ts
+++ b/packages/warden/src/rules/implementation-returns-result.ts
@@ -90,10 +90,46 @@ const isResultExpression = (node: AstNode): boolean => {
   return false;
 };
 
+/** Map of namespace-import local name to the set of Result-helper names exported by the target module. */
+type NamespaceHelperMap = ReadonlyMap<string, ReadonlySet<string>>;
+
+/**
+ * Check whether a namespace-member call like `ns.helper(...)` resolves to a
+ * known Result helper.
+ *
+ * When a non-empty `scopes` stack is provided, the namespace binding must not
+ * be shadowed by a parameter or local declaration in any enclosing scope at
+ * the call site. Without this check, any local `ns` (e.g. a blaze parameter
+ * named `ns`, or `const ns = ...` inside the body) would be misread as the
+ * module-scope namespace import.
+ */
+const isNamespaceHelperMemberCall = (
+  callee: AstNode,
+  namespaceHelpers: NamespaceHelperMap,
+  scopes: readonly ReadonlySet<string>[] = []
+): boolean => {
+  if (!isMemberExpression(callee)) {
+    return false;
+  }
+  const { objName, propName } = extractMemberNames(callee);
+  if (!(objName && propName)) {
+    return false;
+  }
+  for (const scope of scopes) {
+    if (scope.has(objName)) {
+      // Nearest binding is a local, not the namespace import.
+      return false;
+    }
+  }
+  return namespaceHelpers.get(objName)?.has(propName) ?? false;
+};
+
 /** Check if a node is a call to a known Result-returning helper. */
 const isHelperCall = (
   node: AstNode,
-  helperNames: ReadonlySet<string>
+  helperNames: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap = new Map(),
+  scopes: readonly ReadonlySet<string>[] = []
 ): boolean => {
   const target =
     node.type === 'AwaitExpression'
@@ -110,7 +146,9 @@ const isHelperCall = (
     return helperNames.has(name);
   }
 
-  return false;
+  return callee
+    ? isNamespaceHelperMemberCall(callee, namespaceHelpers, scopes)
+    : false;
 };
 
 /** Unwrap an optional AwaitExpression to get the inner identifier name. */
@@ -131,12 +169,14 @@ const resolveIdentifierName = (node: AstNode): string | null => {
 const isAllowedReturnArgument = (
   argument: AstNode,
   helperNames: ReadonlySet<string>,
-  resultVars: ReadonlySet<string>
+  resultVars: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap,
+  scopes: readonly ReadonlySet<string>[] = []
 ): boolean => {
   if (isResultExpression(argument)) {
     return true;
   }
-  if (isHelperCall(argument, helperNames)) {
+  if (isHelperCall(argument, helperNames, namespaceHelpers, scopes)) {
     return true;
   }
 
@@ -176,44 +216,269 @@ const isFunctionBoundary = (val: unknown): boolean =>
   typeof val === 'object' &&
   FUNCTION_BOUNDARY_TYPES.has((val as AstNode).type);
 
+// ---------------------------------------------------------------------------
+// Scope tracking (namespace-shadowing awareness)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-pattern-type expanders yielding the nested binding nodes to keep
+ * visiting. Identifier is the base case; all other patterns bottom out at
+ * Identifier nodes through one or more expansion steps.
+ */
+const expandObjectPatternProperty = (prop: AstNode): readonly AstNode[] => {
+  if (prop.type === 'Property') {
+    const { value } = prop as unknown as { value?: AstNode };
+    return value ? [value] : [];
+  }
+  if (prop.type === 'RestElement') {
+    const { argument } = prop as unknown as { argument?: AstNode };
+    return argument ? [argument] : [];
+  }
+  return [];
+};
+
+const PATTERN_EXPANDERS: Record<string, (node: AstNode) => readonly AstNode[]> =
+  {
+    ArrayPattern: (node) => {
+      const elements =
+        (node as unknown as { elements?: readonly (AstNode | null)[] })
+          .elements ?? [];
+      return elements.filter((el): el is AstNode => el !== null);
+    },
+    AssignmentPattern: (node) => {
+      const { left } = node as unknown as { left?: AstNode };
+      return left ? [left] : [];
+    },
+    ObjectPattern: (node) => {
+      const properties =
+        (node as unknown as { properties?: readonly AstNode[] }).properties ??
+        [];
+      return properties.flatMap(expandObjectPatternProperty);
+    },
+    RestElement: (node) => {
+      const { argument } = node as unknown as { argument?: AstNode };
+      return argument ? [argument] : [];
+    },
+  };
+
+/**
+ * Collect identifier names introduced by a binding pattern (parameter,
+ * `const`/`let`/`var` declarator target, etc.). Iterative worklist over
+ * {@link PATTERN_EXPANDERS}: each expander yields one level of child
+ * patterns and the loop bottoms out at `Identifier` nodes.
+ */
+const visitPatternNode = (
+  current: AstNode,
+  into: Set<string>,
+  worklist: AstNode[]
+): void => {
+  if (current.type === 'Identifier') {
+    const { name } = current as unknown as { name?: string };
+    if (name) {
+      into.add(name);
+    }
+    return;
+  }
+  const expand = PATTERN_EXPANDERS[current.type];
+  if (expand) {
+    worklist.push(...expand(current));
+  }
+};
+
+const collectPatternNames = (
+  pattern: AstNode | undefined,
+  into: Set<string>
+): void => {
+  if (!pattern) {
+    return;
+  }
+  const worklist: AstNode[] = [pattern];
+  while (worklist.length > 0) {
+    const current = worklist.pop();
+    if (current) {
+      visitPatternNode(current, into, worklist);
+    }
+  }
+};
+
+const addVariableDeclarationNames = (
+  stmt: AstNode,
+  into: Set<string>
+): void => {
+  const declarations =
+    (stmt as unknown as { declarations?: readonly AstNode[] }).declarations ??
+    [];
+  for (const decl of declarations) {
+    collectPatternNames((decl as unknown as { id?: AstNode }).id, into);
+  }
+};
+
+const addFunctionDeclarationName = (stmt: AstNode, into: Set<string>): void => {
+  const { id } = stmt as unknown as { id?: AstNode };
+  if (id?.type !== 'Identifier') {
+    return;
+  }
+  const { name } = id as unknown as { name?: string };
+  if (name) {
+    into.add(name);
+  }
+};
+
+/** Collect the declared identifier names that a BlockStatement introduces. */
+const collectBlockBindingNames = (block: AstNode): ReadonlySet<string> => {
+  const names = new Set<string>();
+  const body = (block as unknown as { body?: readonly AstNode[] }).body ?? [];
+  for (const stmt of body) {
+    if (stmt.type === 'VariableDeclaration') {
+      addVariableDeclarationNames(stmt, names);
+    } else if (stmt.type === 'FunctionDeclaration') {
+      addFunctionDeclarationName(stmt, names);
+    }
+  }
+  return names;
+};
+
+/**
+ * Collect bindings introduced by a `for (init; ...; ...)` statement's init
+ * clause. Only `VariableDeclaration` inits introduce new bindings; identifier
+ * or expression inits reference existing ones.
+ */
+const collectForStatementBindingNames = (
+  node: AstNode
+): ReadonlySet<string> => {
+  const names = new Set<string>();
+  const { init } = node as unknown as { init?: AstNode };
+  if (init && init.type === 'VariableDeclaration') {
+    addVariableDeclarationNames(init, names);
+  }
+  return names;
+};
+
+/**
+ * Collect bindings introduced by a `for (left of right)` / `for (left in right)`
+ * statement's left-hand side. Only `VariableDeclaration` lefts introduce new
+ * bindings.
+ */
+const collectForInOfBindingNames = (node: AstNode): ReadonlySet<string> => {
+  const names = new Set<string>();
+  const { left } = node as unknown as { left?: AstNode };
+  if (left && left.type === 'VariableDeclaration') {
+    addVariableDeclarationNames(left, names);
+  }
+  return names;
+};
+
+/**
+ * Collect the binding introduced by a `catch (param)` clause. The param may be
+ * an identifier or a destructuring pattern; `catch {}` (no param) contributes
+ * nothing.
+ */
+const collectCatchClauseBindingNames = (node: AstNode): ReadonlySet<string> => {
+  const names = new Set<string>();
+  const { param } = node as unknown as { param?: AstNode };
+  collectPatternNames(param, names);
+  return names;
+};
+
+const SCOPE_FRAME_COLLECTORS: Record<
+  string,
+  (node: AstNode) => ReadonlySet<string>
+> = {
+  BlockStatement: collectBlockBindingNames,
+  CatchClause: collectCatchClauseBindingNames,
+  ForInStatement: collectForInOfBindingNames,
+  ForOfStatement: collectForInOfBindingNames,
+  ForStatement: collectForStatementBindingNames,
+};
+
+/** Collect parameter names from a function-like node. */
+const collectFunctionParamNames = (fn: AstNode): ReadonlySet<string> => {
+  const names = new Set<string>();
+  const params =
+    (fn as unknown as { params?: readonly AstNode[] }).params ?? [];
+  for (const param of params) {
+    collectPatternNames(param, names);
+  }
+  return names;
+};
+
+type ScopeVisitor = (
+  node: AstNode,
+  scopes: readonly ReadonlySet<string>[]
+) => void;
+
 /** Recurse into a single AST property value, skipping function boundaries. */
-const visitValue = (
+const recurseIntoChildValue = (
   val: unknown,
-  visit: (node: AstNode) => void,
-  recurse: (node: unknown, visit: (node: AstNode) => void) => void
+  scopes: ReadonlySet<string>[],
+  visit: ScopeVisitor
 ): void => {
   if (Array.isArray(val)) {
     for (const item of val) {
       if (!isFunctionBoundary(item)) {
-        recurse(item, visit);
+        // eslint-disable-next-line no-use-before-define
+        walkShallowWithScopes(item, scopes, visit);
       }
     }
-  } else if (
+    return;
+  }
+  if (
     val &&
     typeof val === 'object' &&
     (val as AstNode).type &&
     !isFunctionBoundary(val)
   ) {
-    recurse(val, visit);
+    // eslint-disable-next-line no-use-before-define
+    walkShallowWithScopes(val, scopes, visit);
   }
 };
 
 /**
- * Walk an AST node tree without recursing into nested function bodies.
+ * Shallow walker that threads a scope-frame stack through the traversal so
+ * visitors can resolve identifier shadowing. Stops at nested function
+ * boundaries (their returns are not implementation-level).
  *
- * This ensures that return statements inside `.map()`, `.filter()`, `.then()`
- * callbacks etc. are not mistakenly checked as implementation-level returns.
+ * The stack is ordered inner-to-outer (index 0 = innermost) so callers can
+ * iterate forwards and bail on the first declaring scope.
  */
-const walkShallow = (node: unknown, visit: (node: AstNode) => void): void => {
+const visitNodeWithScopes = (
+  n: AstNode,
+  scopes: ReadonlySet<string>[],
+  visit: ScopeVisitor
+): void => {
+  visit(n, scopes);
+  for (const val of Object.values(n)) {
+    recurseIntoChildValue(val, scopes, visit);
+  }
+};
+
+const asAstNode = (node: unknown): AstNode | null => {
   if (!node || typeof node !== 'object') {
-    return;
+    return null;
   }
   const n = node as AstNode;
-  if (n.type) {
-    visit(n);
+  return n.type ? n : null;
+};
+
+const walkShallowWithScopes = (
+  node: unknown,
+  scopes: ReadonlySet<string>[],
+  visit: ScopeVisitor
+): void => {
+  const n = asAstNode(node);
+  if (!n) {
+    return;
   }
-  for (const val of Object.values(n)) {
-    visitValue(val, visit, walkShallow);
+  const collector = SCOPE_FRAME_COLLECTORS[n.type];
+  if (collector) {
+    scopes.unshift(collector(n));
+  }
+  try {
+    visitNodeWithScopes(n, scopes, visit);
+  } finally {
+    if (collector) {
+      scopes.shift();
+    }
   }
 };
 
@@ -228,11 +493,16 @@ const checkReturnStatements = (
   filePath: string,
   sourceCode: string,
   helperNames: ReadonlySet<string>,
-  diagnostics: WardenDiagnostic[]
+  namespaceHelpers: NamespaceHelperMap,
+  diagnostics: WardenDiagnostic[],
+  implParams: ReadonlySet<string> = new Set<string>()
 ): void => {
   const resultVars = new Set<string>();
+  // Seed the stack with the blaze's own parameter names so a parameter that
+  // shadows a namespace import is visible to every nested block-scope visit.
+  const scopes: ReadonlySet<string>[] = implParams.size > 0 ? [implParams] : [];
 
-  walkShallow(blockBody, (node) => {
+  walkShallowWithScopes(blockBody, scopes, (node, currentScopes) => {
     if (node.type === 'VariableDeclarator') {
       trackResultVariable(node, resultVars);
     }
@@ -247,7 +517,15 @@ const checkReturnStatements = (
       return;
     }
 
-    if (isAllowedReturnArgument(argument, helperNames, resultVars)) {
+    if (
+      isAllowedReturnArgument(
+        argument,
+        helperNames,
+        resultVars,
+        namespaceHelpers,
+        currentScopes
+      )
+    ) {
       return;
     }
 
@@ -394,11 +672,10 @@ const buildNamedImportBinding = (
  * @remarks
  * `import foo from './bar.js'` is treated as a re-export of `default` so the
  * target file's `export default` declaration is considered as a potential
- * Result helper. `import * as ns from './bar.js'` is intentionally not
- * supported — recognizing `ns.helper(...)` member calls would require mapping
- * the namespace binding back to the target's exported names. Callers using
- * namespace imports of Result helpers will get false-positive diagnostics and
- * can work around with a named import instead.
+ * Result helper. `import * as ns from './bar.js'` is handled separately by
+ * `collectNamespaceHelperImports`, which maps the namespace binding to the
+ * target's exported Result-helper names so `ns.helper(...)` member calls are
+ * recognized.
  */
 const buildImportBinding = (
   specifier: AstNode,
@@ -978,10 +1255,56 @@ const collectExportedResultHelpersFromAst = (
         localDeclarations,
         collected
       );
+    } else if (node.type === 'ExportAllDeclaration') {
+      // eslint-disable-next-line no-use-before-define
+      processExportAllDeclaration(node, targetPath, visited, depth, collected);
     }
   }
 
   return collected;
+};
+
+/**
+ * Handle `export * from './x.js'` by recursing into the target module and
+ * unioning its exported Result-helper names. Type-only re-exports
+ * (`export type * from '...'`) contribute nothing. Bounded by
+ * `MAX_RERESOLVE_DEPTH` and the visited-set cycle guard shared with the
+ * specifier re-export path.
+ */
+const processExportAllDeclaration = (
+  node: AstNode,
+  targetPath: string,
+  visited: ReadonlySet<string>,
+  depth: number,
+  collected: Set<string>
+): void => {
+  const { exportKind } = node as unknown as { exportKind?: string };
+  if (exportKind === 'type') {
+    return;
+  }
+  const reTargetPath = resolveReExportTargetPath(
+    node,
+    targetPath,
+    visited,
+    depth
+  );
+  if (!reTargetPath) {
+    return;
+  }
+  // eslint-disable-next-line no-use-before-define
+  const downstream = collectTargetExportedResultHelperNames(
+    reTargetPath,
+    visited,
+    targetPath,
+    depth + 1
+  );
+  // `export * from` does NOT re-export the default binding, so we union
+  // only the named Result helpers from the downstream module.
+  for (const name of downstream) {
+    if (name !== 'default') {
+      collected.add(name);
+    }
+  }
 };
 
 const parseTargetResultHelperNames = (
@@ -1092,6 +1415,80 @@ const collectImportedResultHelperNames = (
   return names;
 };
 
+interface NamespaceEntry {
+  readonly localName: string;
+  readonly names: ReadonlySet<string>;
+}
+
+/** Extract a namespace specifier's local name if it is a namespace import. */
+const getNamespaceLocalName = (spec: AstNode): string | null => {
+  if (spec.type !== 'ImportNamespaceSpecifier') {
+    return null;
+  }
+  const { local } = spec as unknown as { local?: AstNode };
+  return extractIdentifierName(local);
+};
+
+/** Resolve a single namespace specifier to (localName, resultHelperNames) or null. */
+const resolveNamespaceSpecifier = (
+  spec: AstNode,
+  source: string,
+  filePath: string
+): NamespaceEntry | null => {
+  const localName = getNamespaceLocalName(spec);
+  if (!localName) {
+    return null;
+  }
+  const targetPath = resolveRelativeImportPath(source, filePath);
+  if (!targetPath) {
+    return null;
+  }
+  const names = collectTargetExportedResultHelperNames(targetPath);
+  return names.size > 0 ? { localName, names } : null;
+};
+
+/** Extract namespace helper entries from a single ImportDeclaration node. */
+const namespaceEntriesFromImport = (
+  node: AstNode,
+  filePath: string
+): readonly NamespaceEntry[] => {
+  const source = getImportSourceValue(node);
+  if (!source) {
+    return [];
+  }
+  const specifiers =
+    (node['specifiers'] as readonly AstNode[] | undefined) ?? [];
+  return specifiers.flatMap((spec) => {
+    const entry = resolveNamespaceSpecifier(spec, source, filePath);
+    return entry ? [entry] : [];
+  });
+};
+
+/**
+ * Collect `import * as ns from './foo.js'` bindings and map each local
+ * namespace name to the set of Result-returning helper names exported by the
+ * resolved target module. Returns an empty map if no namespace imports are
+ * found or none resolve to local files.
+ */
+const collectNamespaceHelperImports = (
+  ast: AstNode,
+  filePath: string
+): NamespaceHelperMap => {
+  const map = new Map<string, ReadonlySet<string>>();
+  walk(ast, (node) => {
+    if (node.type !== 'ImportDeclaration') {
+      return;
+    }
+    for (const { localName, names } of namespaceEntriesFromImport(
+      node,
+      filePath
+    )) {
+      map.set(localName, names);
+    }
+  });
+  return map;
+};
+
 /**
  * Combine same-file helper names with helpers imported from relative modules.
  */
@@ -1122,12 +1519,17 @@ const checkImplementation = (
   filePath: string,
   sourceCode: string,
   helperNames: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap,
   diagnostics: WardenDiagnostic[]
 ): void => {
   const fnBody = (implValue as unknown as { body?: AstNode }).body;
   if (!fnBody) {
     return;
   }
+
+  // Blaze parameter names seed the scope stack so shadowing is respected by
+  // both block-body and concise-body checks.
+  const implParams = collectFunctionParamNames(implValue);
 
   if (fnBody.type === 'BlockStatement' || fnBody.type === 'FunctionBody') {
     checkReturnStatements(
@@ -1136,12 +1538,19 @@ const checkImplementation = (
       filePath,
       sourceCode,
       helperNames,
-      diagnostics
+      namespaceHelpers,
+      diagnostics,
+      implParams
     );
     return;
   }
 
-  if (!isResultExpression(fnBody) && !isHelperCall(fnBody, helperNames)) {
+  const conciseScopes: readonly ReadonlySet<string>[] =
+    implParams.size > 0 ? [implParams] : [];
+  if (
+    !isResultExpression(fnBody) &&
+    !isHelperCall(fnBody, helperNames, namespaceHelpers, conciseScopes)
+  ) {
     diagnostics.push({
       filePath,
       line: offsetToLine(sourceCode, implValue.start),
@@ -1163,6 +1572,7 @@ const checkAllDefinitions = (
 ): WardenDiagnostic[] => {
   const diagnostics: WardenDiagnostic[] = [];
   const helperNames = collectAllResultHelperNames(ast, sourceCode, filePath);
+  const namespaceHelpers = collectNamespaceHelperImports(ast, filePath);
 
   for (const def of findTrailDefinitions(ast)) {
     const info = { id: def.id, label: 'Trail' };
@@ -1173,6 +1583,7 @@ const checkAllDefinitions = (
         filePath,
         sourceCode,
         helperNames,
+        namespaceHelpers,
         diagnostics
       );
     }


### PR DESCRIPTION
## Summary

Closes two documented scope gaps in `implementation-returns-result` — the warden rule that recognizes `Result`-returning imported helpers so trail blazes can safely `return helper(...)` without triggering a raw-value diagnostic.

Closes [TRL-346](https://linear.app/outfitter/issue/TRL-346).

## Scope gaps closed

### Gap 1 — `export * from '...'` barrel re-exports

Prior behavior: a barrel file re-exporting everything from a sibling module wasn't traversed. Callers importing a named specifier from that barrel would still false-positive on `return helper(...)` even when the underlying declaration had the right `Promise<Result<...>>` return type.

Fix: added `processExportAllDeclaration` invoked from the body-loop inside `collectExportedResultHelpersFromAst`. Skips `exportKind === 'type'`, runs the same `resolveReExportTargetPath` used by specifier re-exports (so `MAX_RERESOLVE_DEPTH = 1` and the visited-set cycle guard apply uniformly), recurses via `collectTargetExportedResultHelperNames`, unions downstream names into the current target's helper set. Drops `default` since `export *` doesn't re-export defaults.

Cache gating preserved: skip cache when `parentVisited.size !== 0` (cycle-safe-but-avoid-stale).

### Gap 2 — Namespace imports

Prior behavior: `import * as ns from './impl.js'; return ns.helper(input)` wasn't resolved. Binding on the caller side was `ns`; the rule's `isHelperCall` didn't know how to follow through a `MemberExpression` to the target module's exports.

Fix: new helpers `getNamespaceLocalName`, `resolveNamespaceSpecifier`, `namespaceEntriesFromImport`, `collectNamespaceHelperImports` walk `ImportNamespaceSpecifier` nodes at the caller level and build a `NamespaceHelperMap` (`Map<nsLocalName, ReadonlySet<helperNames>>`) reusing the cached `collectTargetExportedResultHelperNames` pipeline. The map threads through `checkAllDefinitions → checkImplementation → checkReturnStatements → isAllowedReturnArgument → isHelperCall`. New `isNamespaceHelperMemberCall` branch matches `MemberExpression` callees, confirms the namespace binding isn't shadowed, checks the property against the target module's Result exports.

Only local relative paths resolve — bare and absolute specifiers (`@ontrails/*`, package specifiers) silently fall back.

## Shadow-aware namespace resolution

The critical correctness piece on this PR: `isNamespaceHelperMemberCall` MUST verify that the `ns` identifier at the call site actually resolves to the module-scope `ImportNamespaceSpecifier`, not a shadowing local binding.

```ts
import * as ns from './impl.js';

function weird(ns) {          // param shadows the namespace import
  return ns.helper();         // this is the param, not the namespace
}
```

Implemented a local `ScopeVisitor` + `walkShallowWithScopes` threading a `ReadonlySet<string>[]` frame stack. `SCOPE_FRAME_COLLECTORS` lookup handles `BlockStatement`, `ForStatement`, `ForInStatement`, `ForOfStatement`, `CatchClause`. `checkImplementation` seeds the initial frame with the blaze's own parameter names.

`isNamespaceHelperMemberCall` short-circuits to `false` when any scope frame declares the namespace local name — module-scope imports sit outside these frames, so any frame hit is a shadow.

## Verification

- `bun run typecheck` — 31/31 green
- `bun test packages/warden` — 552 pass / 0 fail
- `bun run check` — 31/31 green

## Test plan

11 new tests total:

- **`export *` barrel (2)**: barrel re-exporting Result helper → no diagnostic; `export *` cycle A ↔ B → fires (doesn't hang).
- **Namespace imports (3)**: simple unshadowed `ns.helper()` passes, non-Result `ns.helper()` still fires, unresolvable target `ns.helper()` still fires (graceful fallback).
- **Shadow detection (6)**: blaze-param shadow, local const shadow, local let shadow, for-init const shadow, for-of binding shadow, catch-identifier shadow, destructured `catch ({ ns })` shadow.

## Review arc

Codex round 1 flagged the name-only namespace check P1 — shadowing local bindings fooled the rule. Added scope-aware resolution. Round 2 flagged that the scope tracker only handled `BlockStatement` — `ForStatement` / `ForInStatement` / `ForOfStatement` / `CatchClause` frames weren't pushed. Extended via `SCOPE_FRAME_COLLECTORS`. Round 3 clean.

## Related

- TRL-333 (PR #204) — the original rule that this PR extends the scope of
- `packages/warden/src/rules/implementation-returns-result.ts`