### PR TITLE
fix(warden): consolidated cleanup of PR #207-#210 review findings [TRL-347]

### DIFF
--- a/packages/warden/src/__tests__/ast.test.ts
+++ b/packages/warden/src/__tests__/ast.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  __collectFrameworkNamespaceBindingsForTest,
   __getTrailCalleeNameForTest,
   deriveContourIdentifierName,
+  findContourDefinitions,
   findTrailDefinitions,
   hasIgnoreCommentOnLine,
   parse,
@@ -93,6 +95,8 @@ const parseCallee = (source: string) => {
   return expression as Parameters<typeof __getTrailCalleeNameForTest>[0];
 };
 
+const coreNamespaces: ReadonlySet<string> = new Set(['core']);
+
 describe('getTrailCalleeName', () => {
   test('matches bare trail(...) identifier callees', () => {
     expect(__getTrailCalleeNameForTest(parseCallee('trail("foo", {});'))).toBe(
@@ -100,9 +104,12 @@ describe('getTrailCalleeName', () => {
     );
   });
 
-  test('matches namespaced ns.trail(...) callees', () => {
+  test('matches namespaced ns.trail(...) callees when the namespace is from @ontrails/*', () => {
     expect(
-      __getTrailCalleeNameForTest(parseCallee('core.trail("foo", {});'))
+      __getTrailCalleeNameForTest(
+        parseCallee('core.trail("foo", {});'),
+        coreNamespaces
+      )
     ).toBe('trail');
   });
 
@@ -112,15 +119,21 @@ describe('getTrailCalleeName', () => {
     );
   });
 
-  test('matches namespaced ns.signal(...) callees', () => {
+  test('matches namespaced ns.signal(...) callees when the namespace is from @ontrails/*', () => {
     expect(
-      __getTrailCalleeNameForTest(parseCallee('core.signal("evt", {});'))
+      __getTrailCalleeNameForTest(
+        parseCallee('core.signal("evt", {});'),
+        coreNamespaces
+      )
     ).toBe('signal');
   });
 
   test('rejects computed member access like ns[trail](...)', () => {
     expect(
-      __getTrailCalleeNameForTest(parseCallee('ns[trail]("foo", {});'))
+      __getTrailCalleeNameForTest(
+        parseCallee('ns[trail]("foo", {});'),
+        new Set(['ns'])
+      )
     ).toBeNull();
   });
 
@@ -132,8 +145,57 @@ describe('getTrailCalleeName', () => {
 
   test('rejects unrelated namespaced callees', () => {
     expect(
-      __getTrailCalleeNameForTest(parseCallee('ns.other("foo", {});'))
+      __getTrailCalleeNameForTest(
+        parseCallee('ns.other("foo", {});'),
+        new Set(['ns'])
+      )
     ).toBeNull();
+  });
+
+  test('rejects namespaced callees when the receiver is not a framework namespace', () => {
+    // `analytics.trail(...)` must not be mistaken for `core.trail(...)` when
+    // the `analytics` binding is not an `@ontrails/*` namespace import.
+    expect(
+      __getTrailCalleeNameForTest(
+        parseCallee('analytics.trail("foo", {});'),
+        coreNamespaces
+      )
+    ).toBeNull();
+  });
+});
+
+describe('collectFrameworkNamespaceBindings', () => {
+  test('collects the local name of an @ontrails/core namespace import', () => {
+    const ast = parseOrThrow(`
+      import * as core from '@ontrails/core';
+    `);
+    expect(
+      [...__collectFrameworkNamespaceBindingsForTest(ast)].toSorted()
+    ).toEqual(['core']);
+  });
+
+  test('collects bindings for any @ontrails/* scoped package', () => {
+    const ast = parseOrThrow(`
+      import * as core from '@ontrails/core';
+      import * as warden from '@ontrails/warden';
+    `);
+    expect(
+      [...__collectFrameworkNamespaceBindingsForTest(ast)].toSorted()
+    ).toEqual(['core', 'warden']);
+  });
+
+  test('ignores namespace imports from non-framework packages', () => {
+    const ast = parseOrThrow(`
+      import * as analytics from 'analytics';
+    `);
+    expect([...__collectFrameworkNamespaceBindingsForTest(ast)]).toEqual([]);
+  });
+
+  test('ignores named imports from @ontrails/* packages', () => {
+    const ast = parseOrThrow(`
+      import { trail } from '@ontrails/core';
+    `);
+    expect([...__collectFrameworkNamespaceBindingsForTest(ast)]).toEqual([]);
   });
 });
 
@@ -144,6 +206,20 @@ describe('findTrailDefinitions with namespaced callees', () => {
       export const t = core.trail('entity.show', {
         input: {},
       });
+    `;
+    const ast = parseOrThrow(source);
+    const defs = findTrailDefinitions(ast);
+    expect(defs).toHaveLength(1);
+    expect(defs[0]?.id).toBe('entity.show');
+    expect(defs[0]?.kind).toBe('trail');
+  });
+
+  test('discovers core.trail({ id: "x", ... }) single-object form', () => {
+    // Regression: confirms the single-object form (`trail({ id: 'x', ... })`)
+    // is discovered the same way as the two-arg form via a namespaced callee.
+    const source = `
+      import * as core from '@ontrails/core';
+      export const t = core.trail({ id: 'entity.show', input: {} });
     `;
     const ast = parseOrThrow(source);
     const defs = findTrailDefinitions(ast);
@@ -171,5 +247,139 @@ describe('findTrailDefinitions with namespaced callees', () => {
     `;
     const ast = parseOrThrow(source);
     expect(findTrailDefinitions(ast)).toHaveLength(0);
+  });
+
+  test('ignores unrelated ns.trail(...) where ns is not an @ontrails import', () => {
+    // Regression: `analytics.trail(...)` where `analytics` is not a framework
+    // namespace must not be picked up as a trail definition.
+    const source = `
+      import * as analytics from 'analytics';
+      analytics.trail('entity.show', { input: {} });
+    `;
+    const ast = parseOrThrow(source);
+    expect(findTrailDefinitions(ast)).toHaveLength(0);
+  });
+});
+
+describe('findTrailDefinitions scope-aware shadowing', () => {
+  test('ignores core.trail(...) inside a function that locally shadows the namespace', () => {
+    // Regression: a function-local `const core = {...}` must shadow the
+    // module-level `import * as core from '@ontrails/core'` for the duration
+    // of that function. A name-only check would let the local `core.trail()`
+    // through; scope-aware resolution rejects it.
+    const source = `
+      import * as core from '@ontrails/core';
+      function weird() {
+        const core = { trail: (_id: string, _cfg: object) => undefined };
+        core.trail('entity.show', { input: {} });
+      }
+    `;
+    const ast = parseOrThrow(source);
+    expect(findTrailDefinitions(ast)).toHaveLength(0);
+  });
+
+  test('still discovers module-level core.trail(...) when a sibling function shadows the namespace', () => {
+    // Sanity check: a shadow inside one function must not suppress a
+    // legitimate `core.trail(...)` at module scope.
+    const source = `
+      import * as core from '@ontrails/core';
+      function weird() {
+        const core = { trail: (_id: string, _cfg: object) => undefined };
+        core.trail('entity.local', { input: {} });
+      }
+      export const t = core.trail('entity.show', { input: {} });
+    `;
+    const ast = parseOrThrow(source);
+    const defs = findTrailDefinitions(ast);
+    expect(defs).toHaveLength(1);
+    expect(defs[0]?.id).toBe('entity.show');
+  });
+
+  test('ignores core.trail(...) when a function parameter shadows the namespace', () => {
+    const source = `
+      import * as core from '@ontrails/core';
+      function weird(core: { trail: (id: string, cfg: object) => void }) {
+        core.trail('entity.show', { input: {} });
+      }
+    `;
+    const ast = parseOrThrow(source);
+    expect(findTrailDefinitions(ast)).toHaveLength(0);
+  });
+
+  test('ignores core.trail(...) when a ClassDeclaration shadows the namespace', () => {
+    // A class declaration binds its name in the enclosing scope. Inside the
+    // class body the name refers to the class, shadowing any module-level
+    // namespace import of the same name.
+    const source = `
+      import * as core from '@ontrails/core';
+      class core {
+        field = core.trail('entity.show', { input: {} });
+      }
+    `;
+    const ast = parseOrThrow(source);
+    expect(findTrailDefinitions(ast)).toHaveLength(0);
+  });
+
+  test('ignores core.trail(...) when a named ClassExpression shadows the namespace inside its body', () => {
+    // A named class expression's name is visible only inside its own body.
+    const source = `
+      import * as core from '@ontrails/core';
+      const C = class core {
+        field = core.trail('entity.show', { input: {} });
+      };
+    `;
+    const ast = parseOrThrow(source);
+    expect(findTrailDefinitions(ast)).toHaveLength(0);
+  });
+
+  test('ignores core.trail(...) when a TSEnumDeclaration shadows the namespace', () => {
+    const source = `
+      import * as core from '@ontrails/core';
+      enum core { A, B }
+      core.trail('entity.show', { input: {} });
+    `;
+    const ast = parseOrThrow(source);
+    expect(findTrailDefinitions(ast)).toHaveLength(0);
+  });
+
+  test('ignores core.trail(...) when a TSModuleDeclaration (namespace) shadows the namespace', () => {
+    const source = `
+      import * as core from '@ontrails/core';
+      namespace core { export const x = 1; }
+      core.trail('entity.show', { input: {} });
+    `;
+    const ast = parseOrThrow(source);
+    expect(findTrailDefinitions(ast)).toHaveLength(0);
+  });
+});
+
+describe('findContourDefinitions with namespaced callees', () => {
+  test('discovers core.contour("name", { ... }) definitions', () => {
+    const source = `
+      import * as core from '@ontrails/core';
+      export const user = core.contour('user', { id: 'string' });
+    `;
+    const ast = parseOrThrow(source);
+    const defs = findContourDefinitions(ast);
+    expect(defs).toHaveLength(1);
+    expect(defs[0]?.name).toBe('user');
+  });
+
+  test('ignores unrelated ns.contour(...) where ns is not @ontrails/*', () => {
+    const source = `
+      import * as analytics from 'analytics';
+      analytics.contour('user', { id: 'string' });
+    `;
+    const ast = parseOrThrow(source);
+    expect(findContourDefinitions(ast)).toHaveLength(0);
+  });
+
+  test('still rejects computed member access', () => {
+    const source = `
+      const contour = 'x';
+      ns[contour]('user', { id: 'string' });
+    `;
+    const ast = parseOrThrow(source);
+    expect(findContourDefinitions(ast)).toHaveLength(0);
   });
 });

--- a/packages/warden/src/__tests__/implementation-returns-result.test.ts
+++ b/packages/warden/src/__tests__/implementation-returns-result.test.ts
@@ -601,45 +601,46 @@ trail("entity.report", {
         expect(diagnostics.length).toBe(1);
       });
 
-      test('flags ns.helper() when blaze parameter shadows the namespace import', () => {
-        writeFile(
-          'impl-ns-shadow-param.ts',
-          `export const helper = async (): Promise<Result<object, Error>> =>
+      describe('shadowing by param/const/let', () => {
+        test('flags ns.helper() when blaze parameter shadows the namespace import', () => {
+          writeFile(
+            'impl-ns-shadow-param.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
   Result.ok({ ok: true });
 `
-        );
-        const caller = writeFile(
-          'caller-ns-shadow-param.ts',
-          `import * as ns from './impl-ns-shadow-param.js';
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-param.ts',
+            `import * as ns from './impl-ns-shadow-param.js';
 
 trail("entity.report", {
   blaze: async (ns, ctx) => {
     return ns.helper(ctx);
   }
 })`
-        );
+          );
 
-        const diagnostics = implementationReturnsResult.check(
-          readFileSync(caller, 'utf8'),
-          caller
-        );
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
 
-        // The blaze parameter \`ns\` shadows the namespace import; \`ns.helper()\`
-        // is a call on the parameter, not on the namespace, so the return
-        // must be flagged rather than silently treated as a Result helper.
-        expect(diagnostics.length).toBe(1);
-      });
+          // The blaze parameter \`ns\` shadows the namespace import; \`ns.helper()\`
+          // is a call on the parameter, not on the namespace, so the return
+          // must be flagged rather than silently treated as a Result helper.
+          expect(diagnostics.length).toBe(1);
+        });
 
-      test('flags ns.helper() when a local const shadows the namespace import', () => {
-        writeFile(
-          'impl-ns-shadow-const.ts',
-          `export const helper = async (): Promise<Result<object, Error>> =>
+        test('flags ns.helper() when a local const shadows the namespace import', () => {
+          writeFile(
+            'impl-ns-shadow-const.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
   Result.ok({ ok: true });
 `
-        );
-        const caller = writeFile(
-          'caller-ns-shadow-const.ts',
-          `import * as ns from './impl-ns-shadow-const.js';
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-const.ts',
+            `import * as ns from './impl-ns-shadow-const.js';
 
 trail("entity.report", {
   blaze: async (input, ctx) => {
@@ -647,26 +648,26 @@ trail("entity.report", {
     return ns.helper(input);
   }
 })`
-        );
+          );
 
-        const diagnostics = implementationReturnsResult.check(
-          readFileSync(caller, 'utf8'),
-          caller
-        );
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
 
-        expect(diagnostics.length).toBe(1);
-      });
+          expect(diagnostics.length).toBe(1);
+        });
 
-      test('flags ns.helper() when a local let shadows the namespace import', () => {
-        writeFile(
-          'impl-ns-shadow-let.ts',
-          `export const helper = async (): Promise<Result<object, Error>> =>
+        test('flags ns.helper() when a local let shadows the namespace import', () => {
+          writeFile(
+            'impl-ns-shadow-let.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
   Result.ok({ ok: true });
 `
-        );
-        const caller = writeFile(
-          'caller-ns-shadow-let.ts',
-          `import * as ns from './impl-ns-shadow-let.js';
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-let.ts',
+            `import * as ns from './impl-ns-shadow-let.js';
 
 trail("entity.report", {
   blaze: async (input, ctx) => {
@@ -674,14 +675,15 @@ trail("entity.report", {
     return ns.helper(input);
   }
 })`
-        );
+          );
 
-        const diagnostics = implementationReturnsResult.check(
-          readFileSync(caller, 'utf8'),
-          caller
-        );
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
 
-        expect(diagnostics.length).toBe(1);
+          expect(diagnostics.length).toBe(1);
+        });
       });
 
       describe('shadowing in for/catch scopes', () => {
@@ -791,6 +793,222 @@ trail("entity.report", {
     } catch ({ ns }) {
       return ns.helper(input);
     }
+  }
+})`
+          );
+
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+
+          expect(diagnostics.length).toBe(1);
+        });
+      });
+
+      describe('scope-frame coverage (TRL-347)', () => {
+        test('flags ns.helper() when a const ns shadow sits in a function-expression blaze body (FunctionBody frame)', () => {
+          // Regression: oxc-parser emits `FunctionBody` for regular
+          // `function expression() { ... }` bodies, not `BlockStatement`. Without
+          // a FunctionBody scope-frame collector, the `const ns = ...` at the
+          // top of this body would not push a frame and the module-level
+          // namespace import would leak through.
+          writeFile(
+            'impl-ns-shadow-fn-expr.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-fn-expr.ts',
+            `import * as ns from './impl-ns-shadow-fn-expr.js';
+
+trail("entity.report", {
+  blaze: async function(input, ctx) {
+    const ns = { helper: () => ({ ok: true }) };
+    return ns.helper(input);
+  }
+})`
+          );
+
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+
+          expect(diagnostics.length).toBe(1);
+        });
+
+        test('flags ns.helper() when a hoisted var ns shadows the namespace import', () => {
+          // Regression: a `var ns` nested inside a block hoists to the
+          // enclosing blaze's function scope. Without function-body-level var
+          // hoisting, the namespace import is read as the receiver and the
+          // return is silently treated as a Result helper.
+          writeFile(
+            'impl-ns-shadow-hoisted-var.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-hoisted-var.ts',
+            `import * as ns from './impl-ns-shadow-hoisted-var.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    if (input) {
+      var ns = { helper: () => ({ ok: true }) };
+    }
+    return ns.helper(input);
+  }
+})`
+          );
+
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+
+          expect(diagnostics.length).toBe(1);
+        });
+
+        test('flags ns.helper() when an unbraced switch case declares a shadowing const', () => {
+          // Regression: an unbraced switch case (`case N: const ns = ...;`)
+          // does not push a BlockStatement frame. Without a SwitchCase
+          // collector, the shadow is invisible to the walker.
+          writeFile(
+            'impl-ns-shadow-switch.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-switch.ts',
+            `import * as ns from './impl-ns-shadow-switch.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    switch (input.kind) {
+      case 'a':
+        const ns = { helper: () => ({ ok: true }) };
+        return ns.helper(input);
+      default:
+        return Result.ok({});
+    }
+  }
+})`
+          );
+
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+
+          expect(diagnostics.length).toBe(1);
+        });
+
+        test('flags ns.helper() in a sibling switch case when an earlier case declares a shadowing const', () => {
+          // Regression: `switch` shares a single lexical scope across every
+          // case. A `const ns = ...` in case 'a' shadows the module-level
+          // namespace import for every sibling case (including via
+          // fall-through). A per-SwitchCase frame would pop the binding when
+          // case 'a' ended and miss the shadow in case 'b'.
+          writeFile(
+            'impl-ns-shadow-switch-fallthrough.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-switch-fallthrough.ts',
+            `import * as ns from './impl-ns-shadow-switch-fallthrough.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    switch (input.kind) {
+      case 'a':
+        const ns = { helper: () => ({ ok: true }) };
+        return ns.helper(input);
+      case 'b':
+        return ns.helper(input);
+      default:
+        return Result.ok({});
+    }
+  }
+})`
+          );
+
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+
+          // Both case 'a' and case 'b' should fire — the const declared in
+          // case 'a' is visible across the entire switch scope.
+          expect(diagnostics.length).toBe(2);
+        });
+
+        test('still resolves ns.helper() correctly when the switch case is braced', () => {
+          // Regression: braced cases create a BlockStatement frame nested
+          // inside the SwitchStatement frame. The shadow must still apply
+          // inside that block, and the sibling case must still see the
+          // namespace import (no SwitchStatement-level binding leaks).
+          writeFile(
+            'impl-ns-shadow-switch-braced.ts',
+            `export const helper = async (): Promise<Result<object, Error>> =>
+  Result.ok({ ok: true });
+`
+          );
+          const caller = writeFile(
+            'caller-ns-shadow-switch-braced.ts',
+            `import * as ns from './impl-ns-shadow-switch-braced.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    switch (input.kind) {
+      case 'a': {
+        const ns = { helper: () => ({ ok: true }) };
+        return ns.helper(input);
+      }
+      case 'b':
+        return ns.helper(input);
+      default:
+        return Result.ok({});
+    }
+  }
+})`
+          );
+
+          const diagnostics = implementationReturnsResult.check(
+            readFileSync(caller, 'utf8'),
+            caller
+          );
+
+          // Only the braced case 'a' should fire — the `const ns` is scoped
+          // to the inner block and does not leak into case 'b'.
+          expect(diagnostics.length).toBe(1);
+        });
+
+        test('flags ns.anything() when the namespace target exports zero Result helpers', () => {
+          // Regression: when the target file has no Result-returning exports,
+          // `resolveNamespaceSpecifier` used to drop the entry entirely. That
+          // made `isNamespaceHelperMemberCall` return false because the
+          // namespace binding was absent from the map — the general return-
+          // value analysis then fired for the wrong reason. The entry is now
+          // recorded with an empty set so the call is correctly identified as
+          // a non-Result-helper namespace member call.
+          writeFile(
+            'impl-ns-empty.ts',
+            `export const nonResultFn = async () => ({ ok: true });
+`
+          );
+          const caller = writeFile(
+            'caller-ns-empty.ts',
+            `import * as ns from './impl-ns-empty.js';
+
+trail("entity.report", {
+  blaze: async (input, ctx) => {
+    return ns.nonResultFn();
   }
 })`
           );

--- a/packages/warden/src/__tests__/intent-propagation.test.ts
+++ b/packages/warden/src/__tests__/intent-propagation.test.ts
@@ -71,7 +71,13 @@ trail('entity.lookup', {
     // must recognize `core.trail("id", { ... })` as a trail definition, not
     // just bare `trail("id", { ... })`. Before the fix these definitions were
     // silently skipped and this rule stayed quiet on namespaced-import files.
+    //
+    // Per TRL-347 the namespace receiver must resolve to an `@ontrails/*`
+    // import — the `import * as core from '@ontrails/core'` below is what
+    // licenses the `core.trail(...)` recognition.
     const code = `
+import * as core from '@ontrails/core';
+
 core.trail('entity.read', {
   intent: 'read',
   crosses: ['entity.refresh'],

--- a/packages/warden/src/__tests__/no-sync-result-assumption.test.ts
+++ b/packages/warden/src/__tests__/no-sync-result-assumption.test.ts
@@ -861,6 +861,41 @@ async function run(ctx, fallback) {
       expect(diagnostics[0]?.message).toContain('Missing await');
     });
 
+    test('keeps pending after a logical compound assignment (||=)', () => {
+      // Mirrors the `??=` case: `||=` only writes when the LHS is falsy, and
+      // a pending `Promise<Result>` is truthy, so the pending binding must
+      // survive.
+      const code = `
+async function run(ctx, fallback) {
+  let result = entityShow.blaze({ id: "1" }, ctx);
+  result ||= fallback;
+  result.isOk();
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
+    test('flags self-referential re-assignment that accesses Result members on RHS', () => {
+      // Regression for the pre-order-clear bug. `result = result.value` must
+      // fire on the RHS `result.value` BEFORE the assignment clears the
+      // pending binding — otherwise the missing-await diagnostic would
+      // silently disappear even though the RHS reads a Result accessor from
+      // the same pending slot.
+      const code = `
+async function run(ctx) {
+  let result = entityShow.blaze({ id: "1" }, ctx);
+  result = result.value;
+}`;
+
+      const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('Missing await');
+    });
+
     test('clears pending after a logical-AND compound assignment (&&=)', () => {
       // `&&=` writes the RHS when the LHS is truthy. A pending
       // Promise<Result> is truthy, so the RHS always runs and the pending

--- a/packages/warden/src/__tests__/warden-rules-use-ast.test.ts
+++ b/packages/warden/src/__tests__/warden-rules-use-ast.test.ts
@@ -348,6 +348,26 @@ describe('warden-rules-use-ast', () => {
       const diagnostics = wardenRulesUseAst.check(source, targetFile);
       expect(diagnostics).toEqual([]);
     });
+
+    test('scope: catch-clause param shadowing does not fire', () => {
+      // The `catch (sourceCode)` binding is a different scope from the
+      // enclosing `check` parameter. The `.split()` inside the catch block
+      // reads the catch param, not the rule's source-text parameter.
+      const source =
+        "export const r = { check(sourceCode: string, filePath: string) { try { return []; } catch (sourceCode) { return sourceCode.split('\\n'); } } };\n";
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('scope: hoisted var inside a block shadows the check param', () => {
+      // `var sourceCode` inside `if (cond) { ... }` hoists to the function
+      // body and shadows the parameter. The `.split(...)` after the block
+      // reads the hoisted var, not the param, so no diagnostic.
+      const source =
+        "export const r = { check(sourceCode: string, filePath: string) { if (filePath) { var sourceCode = 'local'; } return sourceCode.split('\\n'); } };\n";
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
   });
 
   describe('idiomatic patterns are not flagged', () => {

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -558,6 +558,575 @@ export interface TrailDefinition {
  */
 const TRAIL_CALLEE_NAMES = new Set(['signal', 'trail']);
 
+/**
+ * Source prefix for the Trails framework package whose namespace imports are
+ * recognized as carriers of `trail()` / `signal()` / `contour()` primitives.
+ *
+ * A namespaced callee like `core.trail(...)` is only treated as a framework
+ * call when the receiver identifier resolves to an `import * as core from
+ * '@ontrails/...'` in the same file. An unrelated `analytics.trail(...)`
+ * whose `analytics` comes from a different module (or no import at all)
+ * is ignored.
+ */
+const FRAMEWORK_NAMESPACE_SOURCE_PREFIX = '@ontrails/';
+
+const isFrameworkNamespaceSource = (value: unknown): boolean =>
+  typeof value === 'string' &&
+  value.startsWith(FRAMEWORK_NAMESPACE_SOURCE_PREFIX);
+
+/**
+ * Collect local binding names introduced by `import * as <name> from
+ * '@ontrails/...'` declarations. Used to gate namespaced framework-primitive
+ * calls so an unrelated `analytics.trail(...)` doesn't match.
+ */
+const getImportSourceValue = (node: AstNode): unknown => {
+  const sourceNode = (node as unknown as { source?: AstNode }).source;
+  return sourceNode
+    ? (sourceNode as unknown as { value?: unknown }).value
+    : undefined;
+};
+
+const addNamespaceImportBindings = (
+  node: AstNode,
+  names: Set<string>
+): void => {
+  const specifiers =
+    (node['specifiers'] as readonly AstNode[] | undefined) ?? [];
+  for (const spec of specifiers) {
+    if (spec.type !== 'ImportNamespaceSpecifier') {
+      continue;
+    }
+    const { local } = spec as unknown as { local?: AstNode };
+    const localName = identifierName(local);
+    if (localName) {
+      names.add(localName);
+    }
+  }
+};
+
+const TOP_LEVEL_NAMED_DECL_TYPES = new Set([
+  'ClassDeclaration',
+  'FunctionDeclaration',
+  'TSEnumDeclaration',
+  'TSModuleDeclaration',
+]);
+
+const removeVarDeclarationShadowedNames = (
+  stmt: AstNode,
+  names: Set<string>
+): void => {
+  const declarations =
+    (stmt as unknown as { declarations?: readonly AstNode[] }).declarations ??
+    [];
+  for (const d of declarations) {
+    const { id } = d as unknown as { id?: AstNode };
+    const n = identifierName(id);
+    if (n) {
+      names.delete(n);
+    }
+  }
+};
+
+const removeNamedDeclShadowedName = (
+  stmt: AstNode,
+  names: Set<string>
+): void => {
+  const { id } = stmt as unknown as { id?: AstNode };
+  const n = identifierName(id);
+  if (n) {
+    names.delete(n);
+  }
+};
+
+const removeTopLevelShadowedNames = (
+  stmt: AstNode,
+  names: Set<string>
+): void => {
+  if (
+    stmt.type === 'ExportNamedDeclaration' ||
+    stmt.type === 'ExportDefaultDeclaration'
+  ) {
+    const { declaration } = stmt as unknown as { declaration?: AstNode };
+    if (declaration) {
+      removeTopLevelShadowedNames(declaration, names);
+    }
+    return;
+  }
+  if (stmt.type === 'VariableDeclaration') {
+    removeVarDeclarationShadowedNames(stmt, names);
+    return;
+  }
+  if (TOP_LEVEL_NAMED_DECL_TYPES.has(stmt.type)) {
+    removeNamedDeclShadowedName(stmt, names);
+  }
+};
+
+const collectFrameworkNamespaceBindings = (
+  ast: AstNode
+): ReadonlySet<string> => {
+  const names = new Set<string>();
+  walk(ast, (node) => {
+    if (node.type !== 'ImportDeclaration') {
+      return;
+    }
+    if (!isFrameworkNamespaceSource(getImportSourceValue(node))) {
+      return;
+    }
+    addNamespaceImportBindings(node, names);
+  });
+  if (names.size === 0) {
+    return names;
+  }
+  // A same-named top-level declaration (class / enum / namespace / var /
+  // function / lexical binding) shadows the namespace import at module scope.
+  // The scope walker treats Program as the outermost frame and skips it when
+  // testing for inner shadows, so we have to strip these collisions here.
+  if (ast.type === 'Program') {
+    const body = (ast as unknown as { body?: readonly AstNode[] }).body ?? [];
+    for (const stmt of body) {
+      removeTopLevelShadowedNames(stmt, names);
+    }
+  }
+  return names;
+};
+
+// ---------------------------------------------------------------------------
+// Scope-aware framework-namespace resolution
+// ---------------------------------------------------------------------------
+//
+// A module-level `import * as core from '@ontrails/core'` makes `core` a
+// framework-namespace binding, but a function-local `const core = {...}` (or
+// param, `let`, `var`, `function`, class, catch param) shadows the import for
+// the duration of that scope. A name-only check is not enough to trust
+// `core.trail(...)` — we have to walk scopes outward from each call site and
+// verify the first declaration of the receiver IS the namespace import.
+//
+// {@link collectFrameworkNamespacedCallStarts} performs that walk once per
+// AST and returns the set of `CallExpression` start offsets whose receiver is
+// provably the framework binding. Downstream helpers gate on this set instead
+// of the bare names, so a local shadow cannot sneak through.
+
+type PatternExpander = (node: AstNode) => readonly AstNode[];
+
+const expandAssignmentPattern: PatternExpander = (node) => {
+  const { left } = node as unknown as { left?: AstNode };
+  return left ? [left] : [];
+};
+
+const expandRestElement: PatternExpander = (node) => {
+  const { argument } = node as unknown as { argument?: AstNode };
+  return argument ? [argument] : [];
+};
+
+const expandArrayPattern: PatternExpander = (node) => {
+  const elements =
+    (node as unknown as { elements?: readonly (AstNode | null)[] }).elements ??
+    [];
+  return elements.filter((e): e is AstNode => e !== null);
+};
+
+const expandObjectPatternProperty = (prop: AstNode): AstNode | null => {
+  if (prop.type === 'RestElement') {
+    return prop;
+  }
+  const { value } = prop as unknown as { value?: AstNode };
+  return value ?? null;
+};
+
+const expandObjectPattern: PatternExpander = (node) => {
+  const properties =
+    (node as unknown as { properties?: readonly AstNode[] }).properties ?? [];
+  return properties
+    .map(expandObjectPatternProperty)
+    .filter((n): n is AstNode => n !== null);
+};
+
+const PATTERN_EXPANDERS: Record<string, PatternExpander> = {
+  ArrayPattern: expandArrayPattern,
+  AssignmentPattern: expandAssignmentPattern,
+  ObjectPattern: expandObjectPattern,
+  RestElement: expandRestElement,
+};
+
+const processPatternNode = (
+  node: AstNode,
+  into: Set<string>,
+  stack: AstNode[]
+): void => {
+  if (node.type === 'Identifier') {
+    const { name } = node as unknown as { name?: string };
+    if (name) {
+      into.add(name);
+    }
+    return;
+  }
+  const expand = PATTERN_EXPANDERS[node.type];
+  if (expand) {
+    stack.push(...expand(node));
+  }
+};
+
+const addPatternBindingNames = (
+  pattern: AstNode | undefined,
+  into: Set<string>
+): void => {
+  if (!pattern) {
+    return;
+  }
+  const stack: AstNode[] = [pattern];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (node) {
+      processPatternNode(node, into, stack);
+    }
+  }
+};
+
+const addVarDeclarationBindingNames = (
+  decl: AstNode,
+  into: Set<string>
+): void => {
+  const declarations =
+    (decl as unknown as { declarations?: readonly AstNode[] }).declarations ??
+    [];
+  for (const d of declarations) {
+    addPatternBindingNames((d as unknown as { id?: AstNode }).id, into);
+  }
+};
+
+const addFunctionOrClassBindingName = (
+  node: AstNode,
+  into: Set<string>
+): void => {
+  const { id } = node as unknown as { id?: AstNode };
+  const name = identifierName(id);
+  if (name) {
+    into.add(name);
+  }
+};
+
+const addBlockStatementBindings = (stmt: AstNode, into: Set<string>): void => {
+  if (stmt.type === 'VariableDeclaration') {
+    addVarDeclarationBindingNames(stmt, into);
+    return;
+  }
+  if (
+    stmt.type === 'FunctionDeclaration' ||
+    stmt.type === 'ClassDeclaration' ||
+    stmt.type === 'TSEnumDeclaration' ||
+    stmt.type === 'TSModuleDeclaration'
+  ) {
+    addFunctionOrClassBindingName(stmt, into);
+  }
+};
+
+const collectTopLevelStatementBindings = (
+  stmt: AstNode,
+  into: Set<string>
+): void => {
+  if (
+    stmt.type === 'ExportNamedDeclaration' ||
+    stmt.type === 'ExportDefaultDeclaration'
+  ) {
+    const { declaration } = stmt as unknown as { declaration?: AstNode };
+    if (declaration) {
+      collectTopLevelStatementBindings(declaration, into);
+    }
+    return;
+  }
+  addBlockStatementBindings(stmt, into);
+};
+
+const FUNCTION_BOUNDARY_TYPES = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'StaticBlock',
+]);
+
+const forEachAstChild = (
+  node: AstNode,
+  visit: (child: AstNode) => void
+): void => {
+  for (const val of Object.values(node)) {
+    if (Array.isArray(val)) {
+      for (const item of val) {
+        if (item && typeof item === 'object' && (item as AstNode).type) {
+          visit(item as AstNode);
+        }
+      }
+    } else if (val && typeof val === 'object' && (val as AstNode).type) {
+      visit(val as AstNode);
+    }
+  }
+};
+
+const recordHoistedBinding = (node: AstNode, into: Set<string>): void => {
+  if (node.type === 'VariableDeclaration') {
+    const { kind } = node as unknown as { kind?: string };
+    if (kind === 'var') {
+      addVarDeclarationBindingNames(node, into);
+    }
+    return;
+  }
+  if (
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'ClassDeclaration' ||
+    node.type === 'TSEnumDeclaration' ||
+    node.type === 'TSModuleDeclaration'
+  ) {
+    addFunctionOrClassBindingName(node, into);
+  }
+};
+
+const visitForHoisted = (
+  node: AstNode,
+  isRoot: boolean,
+  into: Set<string>
+): void => {
+  if (!isRoot && FUNCTION_BOUNDARY_TYPES.has(node.type)) {
+    return;
+  }
+  recordHoistedBinding(node, into);
+  forEachAstChild(node, (child) => {
+    visitForHoisted(child, false, into);
+  });
+};
+
+/**
+ * Collect `var` declarations and `function` declarations hoisted to the
+ * nearest function scope from anywhere inside `root`, without crossing a
+ * nested function or static-block boundary.
+ */
+const collectHoistedVarAndFunctionBindings = (
+  root: AstNode,
+  into: Set<string>
+): void => {
+  visitForHoisted(root, true, into);
+};
+
+type FrameCollector = (node: AstNode, into: Set<string>) => void;
+
+const collectProgramFrame: FrameCollector = (node, into) => {
+  const body = (node as unknown as { body?: readonly AstNode[] }).body ?? [];
+  for (const stmt of body) {
+    collectTopLevelStatementBindings(stmt, into);
+  }
+};
+
+const collectFunctionFrame: FrameCollector = (node, into) => {
+  const params =
+    (node as unknown as { params?: readonly AstNode[] }).params ?? [];
+  for (const param of params) {
+    addPatternBindingNames(param, into);
+  }
+  // Hoisted vars and function declarations inside the body live in the
+  // function's var-environment. A `var ns = ...;` inside an `if` still
+  // shadows a module-level `ns` for the whole function.
+  const { body } = node as unknown as { body?: AstNode };
+  if (body) {
+    collectHoistedVarAndFunctionBindings(body, into);
+  }
+};
+
+const collectBlockFrame: FrameCollector = (node, into) => {
+  const body = (node as unknown as { body?: readonly AstNode[] }).body ?? [];
+  for (const stmt of body) {
+    addBlockStatementBindings(stmt, into);
+  }
+};
+
+const collectForStatementFrame: FrameCollector = (node, into) => {
+  const { init } = node as unknown as { init?: AstNode };
+  if (init && init.type === 'VariableDeclaration') {
+    addVarDeclarationBindingNames(init, into);
+  }
+};
+
+const collectForInOfFrame: FrameCollector = (node, into) => {
+  const { left } = node as unknown as { left?: AstNode };
+  if (left && left.type === 'VariableDeclaration') {
+    addVarDeclarationBindingNames(left, into);
+  }
+};
+
+const collectSwitchStatementFrame: FrameCollector = (node, into) => {
+  // `switch` shares one scope across every case. A binding in one case
+  // shadows the namespace across sibling cases (fall-through or otherwise).
+  const cases = (node as unknown as { cases?: readonly AstNode[] }).cases ?? [];
+  for (const c of cases) {
+    const consequent =
+      (c as unknown as { consequent?: readonly AstNode[] }).consequent ?? [];
+    for (const stmt of consequent) {
+      addBlockStatementBindings(stmt, into);
+    }
+  }
+};
+
+const collectCatchClauseFrame: FrameCollector = (node, into) => {
+  const { param } = node as unknown as { param?: AstNode };
+  addPatternBindingNames(param, into);
+};
+
+const collectClassExpressionFrame: FrameCollector = (node, into) => {
+  // A named `class expr` (`const C = class foo { ... }`) binds its own name
+  // inside its body only. ClassDeclaration names are hoisted into the
+  // enclosing block/program frame instead, so only class *expression* names
+  // need their own frame here.
+  addFunctionOrClassBindingName(node, into);
+};
+
+const SCOPE_FRAME_COLLECTORS: Record<string, FrameCollector> = {
+  ArrowFunctionExpression: collectFunctionFrame,
+  BlockStatement: collectBlockFrame,
+  CatchClause: collectCatchClauseFrame,
+  ClassExpression: collectClassExpressionFrame,
+  ForInStatement: collectForInOfFrame,
+  ForOfStatement: collectForInOfFrame,
+  ForStatement: collectForStatementFrame,
+  FunctionDeclaration: collectFunctionFrame,
+  FunctionExpression: collectFunctionFrame,
+  Program: collectProgramFrame,
+  StaticBlock: collectBlockFrame,
+  SwitchStatement: collectSwitchStatementFrame,
+};
+
+/**
+ * Collect the identifier bindings introduced *directly* by a scope frame
+ * node. Scope frames correspond to JS lexical scopes (function bodies, blocks,
+ * catch clauses, for-statements, switch statements, module/script roots).
+ */
+const collectScopeFrameBindings = (node: AstNode): ReadonlySet<string> => {
+  const names = new Set<string>();
+  const collector = SCOPE_FRAME_COLLECTORS[node.type];
+  if (collector) {
+    collector(node, names);
+  }
+  return names;
+};
+
+const isShadowed = (
+  receiverName: string,
+  scopeStack: readonly ReadonlySet<string>[]
+): boolean => {
+  // The module-level Program frame is the last entry and contains the
+  // namespace imports themselves. A "shadow" must come from a frame *inside*
+  // that one — i.e. any frame except the outermost.
+  for (let i = 0; i < scopeStack.length - 1; i += 1) {
+    const frame = scopeStack[i];
+    if (frame?.has(receiverName)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * `isNonComputedMemberAccess` + `getNamespacedMemberNames` forward
+ * declarations. The bodies live next to the other callee-resolution helpers
+ * further down. Declared early here so the scope walker can use them without
+ * hitting `no-use-before-define`.
+ */
+const isMemberAccessNonComputed = (callee: AstNode): boolean => {
+  if (
+    callee.type !== 'MemberExpression' &&
+    callee.type !== 'StaticMemberExpression'
+  ) {
+    return false;
+  }
+  return (callee as unknown as { computed?: boolean }).computed !== true;
+};
+
+const resolveNamespacedMemberNames = (
+  callee: AstNode
+): { readonly receiver: string; readonly property: string } | null => {
+  if (!isMemberAccessNonComputed(callee)) {
+    return null;
+  }
+  const { object } = callee as unknown as { object?: AstNode };
+  const receiver = identifierName(object);
+  if (!receiver) {
+    return null;
+  }
+  const prop = (callee as unknown as { property?: AstNode }).property;
+  const property =
+    prop?.type === 'Identifier'
+      ? ((prop as unknown as { name?: string }).name ?? null)
+      : null;
+  return property ? { property, receiver } : null;
+};
+
+interface ScopeWalkState {
+  readonly frameworkNamespaces: ReadonlySet<string>;
+  readonly stack: ReadonlySet<string>[];
+  readonly starts: Set<number>;
+}
+
+const getFrameworkCallReceiver = (
+  node: AstNode,
+  frameworkNamespaces: ReadonlySet<string>
+): string | null => {
+  if (node.type !== 'CallExpression') {
+    return null;
+  }
+  const callee = node['callee'] as AstNode | undefined;
+  if (!callee) {
+    return null;
+  }
+  const names = resolveNamespacedMemberNames(callee);
+  if (!names || !frameworkNamespaces.has(names.receiver)) {
+    return null;
+  }
+  return names.receiver;
+};
+
+const recordFrameworkNamespacedCall = (
+  node: AstNode,
+  state: ScopeWalkState
+): void => {
+  const receiver = getFrameworkCallReceiver(node, state.frameworkNamespaces);
+  if (!receiver || isShadowed(receiver, state.stack)) {
+    return;
+  }
+  state.starts.add(node.start);
+};
+
+const recurseWithScope = (node: AstNode, state: ScopeWalkState): void => {
+  const isScope = node.type in SCOPE_FRAME_COLLECTORS;
+  if (isScope) {
+    state.stack.unshift(collectScopeFrameBindings(node));
+  }
+  try {
+    recordFrameworkNamespacedCall(node, state);
+    forEachAstChild(node, (child) => {
+      recurseWithScope(child, state);
+    });
+  } finally {
+    if (isScope) {
+      state.stack.shift();
+    }
+  }
+};
+
+/**
+ * Walk the AST with a scope stack and collect `CallExpression` start offsets
+ * whose callee is `<receiver>.<property>` where `<receiver>` is proven to
+ * resolve to a framework namespace import (i.e. not shadowed by any
+ * enclosing scope). Used to gate namespaced `core.trail(...)` /
+ * `core.signal(...)` / `core.contour(...)` resolution against local shadows.
+ */
+const collectFrameworkNamespacedCallStarts = (
+  ast: AstNode,
+  frameworkNamespaces: ReadonlySet<string>
+): ReadonlySet<number> => {
+  const starts = new Set<number>();
+  if (frameworkNamespaces.size === 0) {
+    return starts;
+  }
+  recurseWithScope(ast, { frameworkNamespaces, stack: [], starts });
+  return starts;
+};
+
 const matchTrailPrimitiveName = (
   name: string | undefined | null
 ): string | null => (name && TRAIL_CALLEE_NAMES.has(name) ? name : null);
@@ -570,35 +1139,114 @@ const getBareTrailCalleeName = (callee: AstNode): string | null => {
 };
 
 /**
- * Resolve a namespaced `ns.trail(...)` / `ns.signal(...)` callee to its
- * primitive name. Computed access (`ns[trail]()`) is intentionally rejected:
- * the bracketed expression may resolve to any runtime value, so we cannot
- * prove the call targets the framework primitive.
+ * Extract the `{ receiverName, propertyName }` of a non-computed member-call
+ * callee, or null for anything else. Computed access (`ns[trail]()`) is
+ * intentionally rejected: the bracketed expression may resolve to any runtime
+ * value, so we cannot prove the call targets a specific member.
  */
-const getNamespacedTrailCalleeName = (callee: AstNode): string | null => {
+const isNonComputedMemberAccess = (callee: AstNode): boolean => {
   if (
     callee.type !== 'MemberExpression' &&
     callee.type !== 'StaticMemberExpression'
   ) {
+    return false;
+  }
+  return (callee as unknown as { computed?: boolean }).computed !== true;
+};
+
+const getNamespacedMemberNames = (
+  callee: AstNode
+): { readonly receiver: string; readonly property: string } | null => {
+  if (!isNonComputedMemberAccess(callee)) {
     return null;
   }
-  if ((callee as unknown as { computed?: boolean }).computed === true) {
+  const { object } = callee as unknown as { object?: AstNode };
+  const receiver = identifierName(object);
+  if (!receiver) {
     return null;
   }
   const prop = (callee as unknown as { property?: AstNode }).property;
-  if (prop?.type !== 'Identifier') {
+  const property =
+    prop?.type === 'Identifier'
+      ? ((prop as unknown as { name?: string }).name ?? null)
+      : null;
+  return property ? { property, receiver } : null;
+};
+
+/**
+ * Resolution context for namespaced framework-primitive calls. Bundles the
+ * bare namespace-binding set with an optional set of proven-safe
+ * `CallExpression` start offsets from a scope-aware pre-pass. When the set of
+ * safe starts is present, a namespaced call only resolves if its start is in
+ * that set — so a function-local shadow of the namespace import does not
+ * leak through. When absent (e.g. from test helpers), the name-only gate is
+ * used as a backward-compatible fallback.
+ */
+interface FrameworkNamespaceContext {
+  readonly namespaces: ReadonlySet<string>;
+  readonly safeCallStarts?: ReadonlySet<number>;
+}
+
+const asNamespaceContext = (
+  input: ReadonlySet<string> | FrameworkNamespaceContext | undefined
+): FrameworkNamespaceContext | undefined => {
+  if (!input) {
+    return undefined;
+  }
+  return input instanceof Set
+    ? { namespaces: input }
+    : (input as FrameworkNamespaceContext);
+};
+
+const isNamespacedCallAllowed = (
+  callStart: number,
+  receiver: string,
+  ctx: FrameworkNamespaceContext
+): boolean => {
+  if (!ctx.namespaces.has(receiver)) {
+    return false;
+  }
+  // When `safeCallStarts` is present, it is the authoritative gate — it was
+  // built by a scope-aware pre-pass and already excludes shadowed receivers.
+  // Without it, fall back to the bare name check (used by unit-test hooks).
+  return ctx.safeCallStarts ? ctx.safeCallStarts.has(callStart) : true;
+};
+
+/**
+ * Resolve a namespaced `ns.trail(...)` / `ns.signal(...)` callee to its
+ * primitive name. When a {@link FrameworkNamespaceContext} is provided, the
+ * receiver must be a framework namespace binding AND — when a
+ * `safeCallStarts` set is present — the call site must appear in that set,
+ * meaning the receiver is not shadowed by any enclosing scope.
+ */
+const getNamespacedTrailCalleeName = (
+  callExpr: AstNode,
+  callee: AstNode,
+  context?: ReadonlySet<string> | FrameworkNamespaceContext
+): string | null => {
+  const names = getNamespacedMemberNames(callee);
+  if (!names) {
     return null;
   }
-  return matchTrailPrimitiveName((prop as unknown as { name?: string }).name);
+  const ctx = asNamespaceContext(context);
+  if (!ctx || !isNamespacedCallAllowed(callExpr.start, names.receiver, ctx)) {
+    return null;
+  }
+  return matchTrailPrimitiveName(names.property);
 };
 
 /**
  * Resolve the callee name of a trail/signal call expression.
  *
  * Matches both bare `trail(...)` / `signal(...)` identifiers and namespaced
- * member-expression callees like `core.trail(...)` or `ns.signal(...)`.
+ * member-expression callees like `core.trail(...)` or `ns.signal(...)`, where
+ * the namespace must come from an `@ontrails/*` import and, when the scope
+ * pre-pass is wired in, be unshadowed at the call site.
  */
-const getTrailCalleeName = (node: AstNode): string | null => {
+const getTrailCalleeName = (
+  node: AstNode,
+  context?: ReadonlySet<string> | FrameworkNamespaceContext
+): string | null => {
   if (node.type !== 'CallExpression') {
     return null;
   }
@@ -606,7 +1254,10 @@ const getTrailCalleeName = (node: AstNode): string | null => {
   if (!callee) {
     return null;
   }
-  return getBareTrailCalleeName(callee) ?? getNamespacedTrailCalleeName(callee);
+  return (
+    getBareTrailCalleeName(callee) ??
+    getNamespacedTrailCalleeName(node, callee, context)
+  );
 };
 
 /**
@@ -616,6 +1267,15 @@ const getTrailCalleeName = (node: AstNode): string | null => {
  * `index.ts`) so internal refactors stay free.
  */
 export const __getTrailCalleeNameForTest = getTrailCalleeName;
+
+/**
+ * Test hook: exposes {@link collectFrameworkNamespaceBindings} for unit tests.
+ *
+ * Not re-exported from `index.ts`; the double-underscore prefix marks it as an
+ * internal-only handle so consumer code cannot rely on it.
+ */
+export const __collectFrameworkNamespaceBindingsForTest =
+  collectFrameworkNamespaceBindings;
 
 /** Extract args from a trail() call, handling both two-arg and single-object forms. */
 const extractTrailArgs = (
@@ -661,8 +1321,11 @@ const extractTrailId = (trailArgs: {
   return extractIdFromConfig(trailArgs.configArg);
 };
 
-const extractTrailDefinition = (node: AstNode): TrailDefinition | null => {
-  const calleeName = getTrailCalleeName(node);
+const extractTrailDefinition = (
+  node: AstNode,
+  context?: ReadonlySet<string> | FrameworkNamespaceContext
+): TrailDefinition | null => {
+  const calleeName = getTrailCalleeName(node, context);
   if (!calleeName) {
     return null;
   }
@@ -685,11 +1348,22 @@ const extractTrailDefinition = (node: AstNode): TrailDefinition | null => {
   };
 };
 
+const buildFrameworkNamespaceContext = (
+  ast: AstNode
+): FrameworkNamespaceContext => {
+  const namespaces = collectFrameworkNamespaceBindings(ast);
+  return {
+    namespaces,
+    safeCallStarts: collectFrameworkNamespacedCallStarts(ast, namespaces),
+  };
+};
+
 export const findTrailDefinitions = (ast: AstNode): TrailDefinition[] => {
   const definitions: TrailDefinition[] = [];
+  const context = buildFrameworkNamespaceContext(ast);
 
   walk(ast, (node) => {
-    const def = extractTrailDefinition(node);
+    const def = extractTrailDefinition(node, context);
     if (def) {
       definitions.push(def);
     }
@@ -717,22 +1391,71 @@ export interface ContourDefinition {
   readonly start: number;
 }
 
-const getContourCalleeName = (node: AstNode): string | null => {
+const CONTOUR_PRIMITIVE_NAME = 'contour';
+
+const matchContourPrimitiveName = (
+  name: string | undefined | null
+): string | null => (name === CONTOUR_PRIMITIVE_NAME ? name : null);
+
+const getBareContourCalleeName = (callee: AstNode): string | null => {
+  if (callee.type !== 'Identifier') {
+    return null;
+  }
+  return matchContourPrimitiveName(
+    (callee as unknown as { name?: string }).name
+  );
+};
+
+/**
+ * Resolve a namespaced `ns.contour(...)` callee to its primitive name. Mirrors
+ * {@link getNamespacedTrailCalleeName}: the receiver identifier must resolve
+ * to an `@ontrails/*` namespace import, and — when a scope-aware
+ * `safeCallStarts` set is provided — the call site must not be shadowed by a
+ * local binding of the same name.
+ */
+const getNamespacedContourCalleeName = (
+  callExpr: AstNode,
+  callee: AstNode,
+  context?: ReadonlySet<string> | FrameworkNamespaceContext
+): string | null => {
+  const names = getNamespacedMemberNames(callee);
+  if (!names) {
+    return null;
+  }
+  const ctx = asNamespaceContext(context);
+  if (!ctx || !isNamespacedCallAllowed(callExpr.start, names.receiver, ctx)) {
+    return null;
+  }
+  return matchContourPrimitiveName(names.property);
+};
+
+/**
+ * Resolve the callee name of a contour call expression. Matches both bare
+ * `contour(...)` identifiers and namespaced `core.contour(...)` callees where
+ * the namespace comes from an `@ontrails/*` import and is unshadowed.
+ */
+const getContourCalleeName = (
+  node: AstNode,
+  context?: ReadonlySet<string> | FrameworkNamespaceContext
+): string | null => {
   if (node.type !== 'CallExpression') {
     return null;
   }
   const callee = node['callee'] as AstNode | undefined;
-  if (!callee || callee.type !== 'Identifier') {
+  if (!callee) {
     return null;
   }
-  const { name } = callee as unknown as { name?: string };
-  return name === 'contour' ? name : null;
+  return (
+    getBareContourCalleeName(callee) ??
+    getNamespacedContourCalleeName(node, callee, context)
+  );
 };
 
 const extractContourDefinition = (
-  node: AstNode
+  node: AstNode,
+  context?: ReadonlySet<string> | FrameworkNamespaceContext
 ): Omit<ContourDefinition, 'bindingName'> | null => {
-  if (!getContourCalleeName(node)) {
+  if (!getContourCalleeName(node, context)) {
     return null;
   }
 
@@ -755,6 +1478,7 @@ const extractContourDefinition = (
 export const findContourDefinitions = (ast: AstNode): ContourDefinition[] => {
   const definitions: ContourDefinition[] = [];
   const seenStarts = new Set<number>();
+  const context = buildFrameworkNamespaceContext(ast);
 
   const addContourDefinition = (definition: ContourDefinition): void => {
     if (seenStarts.has(definition.start)) {
@@ -773,7 +1497,7 @@ export const findContourDefinitions = (ast: AstNode): ContourDefinition[] => {
       return;
     }
 
-    const definition = extractContourDefinition(init);
+    const definition = extractContourDefinition(init, context);
     if (!definition) {
       return;
     }
@@ -797,7 +1521,7 @@ export const findContourDefinitions = (ast: AstNode): ContourDefinition[] => {
       return;
     }
 
-    const definition = extractContourDefinition(node);
+    const definition = extractContourDefinition(node, context);
     if (definition) {
       addContourDefinition(definition);
     }
@@ -1208,6 +1932,7 @@ export const collectNamedTrailIds = (
   ast: AstNode
 ): ReadonlyMap<string, string> => {
   const ids = new Map<string, string>();
+  const context = buildFrameworkNamespaceContext(ast);
 
   walk(ast, (node) => {
     if (node.type !== 'VariableDeclarator') {
@@ -1222,7 +1947,7 @@ export const collectNamedTrailIds = (
       return;
     }
 
-    const def = extractTrailDefinition(init);
+    const def = extractTrailDefinition(init, context);
     const name = extractBindingName(id);
     if (def?.kind === 'trail' && name) {
       ids.set(name, def.id);

--- a/packages/warden/src/rules/implementation-returns-result.ts
+++ b/packages/warden/src/rules/implementation-returns-result.ts
@@ -380,24 +380,115 @@ const collectCatchClauseBindingNames = (node: AstNode): ReadonlySet<string> => {
   return names;
 };
 
+/**
+ * Collect bindings introduced by any `consequent` statement of any `case`
+ * inside a `SwitchStatement`. JavaScript `switch` bodies share a single
+ * lexical scope across all cases — a `const ns = ...` declared in one case is
+ * visible in every other case via fall-through or direct reference. A
+ * per-`SwitchCase` frame would pop the binding when the case ended, missing
+ * the shadow from sibling cases.
+ *
+ * Braced cases (`case 'a': { const ns = ...; ... }`) still get their own
+ * `BlockStatement` frame nested inside this one, as before.
+ */
+const collectSwitchStatementBindingNames = (
+  node: AstNode
+): ReadonlySet<string> => {
+  const names = new Set<string>();
+  const cases = (node as unknown as { cases?: readonly AstNode[] }).cases ?? [];
+  for (const switchCase of cases) {
+    const consequent =
+      (switchCase as unknown as { consequent?: readonly AstNode[] })
+        .consequent ?? [];
+    for (const stmt of consequent) {
+      if (stmt.type === 'VariableDeclaration') {
+        addVariableDeclarationNames(stmt, names);
+      } else if (stmt.type === 'FunctionDeclaration') {
+        addFunctionDeclarationName(stmt, names);
+      }
+    }
+  }
+  return names;
+};
+
 const SCOPE_FRAME_COLLECTORS: Record<
   string,
   (node: AstNode) => ReadonlySet<string>
 > = {
+  // `FunctionBody` is the oxc-parser shape for the body of a regular
+  // `function expression() { ... }`. Arrow functions use `BlockStatement`.
+  // Without this entry, a `const ns = ...` at the top of a function-expression
+  // blaze body would not push a scope frame, and a module-level namespace
+  // import with the same name would be incorrectly recognized inside.
   BlockStatement: collectBlockBindingNames,
   CatchClause: collectCatchClauseBindingNames,
   ForInStatement: collectForInOfBindingNames,
   ForOfStatement: collectForInOfBindingNames,
   ForStatement: collectForStatementBindingNames,
+  FunctionBody: collectBlockBindingNames,
+  SwitchStatement: collectSwitchStatementBindingNames,
 };
 
-/** Collect parameter names from a function-like node. */
+const FUNCTION_VAR_ENV_TYPES = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'StaticBlock',
+]);
+
+const isVarDeclarationNode = (node: AstNode): boolean =>
+  node.type === 'VariableDeclaration' &&
+  (node as unknown as { kind?: string }).kind === 'var';
+
+/**
+ * Collect `var` declarations that hoist to the nearest function scope from
+ * anywhere inside `root`, without crossing a nested function or static-block
+ * boundary. Mirrors the hoisting rule used by
+ * `./no-sync-result-assumption.ts`.
+ *
+ * Used to seed a blaze's implParams with function-body `var`s so a pattern
+ * like `if (cond) { var ns = local; } return ns.helper();` correctly sees
+ * `ns` as a shadow of any module-level namespace import.
+ */
+const collectHoistedVarNamesInto = (root: AstNode, out: Set<string>): void => {
+  const walkVars = (node: AstNode, isRoot: boolean): void => {
+    if (!isRoot && FUNCTION_VAR_ENV_TYPES.has(node.type)) {
+      return;
+    }
+    if (isVarDeclarationNode(node)) {
+      addVariableDeclarationNames(node, out);
+    }
+    for (const val of Object.values(node)) {
+      if (Array.isArray(val)) {
+        for (const item of val) {
+          if (item && typeof item === 'object' && (item as AstNode).type) {
+            walkVars(item as AstNode, false);
+          }
+        }
+      } else if (val && typeof val === 'object' && (val as AstNode).type) {
+        walkVars(val as AstNode, false);
+      }
+    }
+  };
+  walkVars(root, true);
+};
+
+/**
+ * Collect parameter names from a function-like node, including `var`
+ * declarations hoisted from anywhere in the function body. The hoisted vars
+ * seed the scope stack so shadowing detection works for patterns like
+ * `if (cond) { var ns = local; } return ns.helper();`.
+ */
 const collectFunctionParamNames = (fn: AstNode): ReadonlySet<string> => {
   const names = new Set<string>();
   const params =
     (fn as unknown as { params?: readonly AstNode[] }).params ?? [];
   for (const param of params) {
     collectPatternNames(param, names);
+  }
+  const { body } = fn as unknown as { body?: AstNode };
+  if (body && typeof body === 'object' && (body as AstNode).type) {
+    collectHoistedVarNamesInto(body as AstNode, names);
   }
   return names;
 };
@@ -1429,7 +1520,17 @@ const getNamespaceLocalName = (spec: AstNode): string | null => {
   return extractIdentifierName(local);
 };
 
-/** Resolve a single namespace specifier to (localName, resultHelperNames) or null. */
+/**
+ * Resolve a single namespace specifier to (localName, resultHelperNames), or
+ * null when the specifier is not a resolvable namespace import.
+ *
+ * We intentionally record the namespace even when the target file exports no
+ * Result helpers (empty set). `isNamespaceHelperMemberCall` can then identify
+ * `ns.anything()` as a namespace member call against a non-Result-helper
+ * target — which correctly falls through to the general return-value
+ * diagnostic path. Dropping the entry would misclassify the call as a
+ * *non-namespace* member call and skip the namespace-shadowing scope check.
+ */
 const resolveNamespaceSpecifier = (
   spec: AstNode,
   source: string,
@@ -1444,7 +1545,7 @@ const resolveNamespaceSpecifier = (
     return null;
   }
   const names = collectTargetExportedResultHelperNames(targetPath);
-  return names.size > 0 ? { localName, names } : null;
+  return { localName, names };
 };
 
 /** Extract namespace helper entries from a single ImportDeclaration node. */

--- a/packages/warden/src/rules/no-sync-result-assumption.ts
+++ b/packages/warden/src/rules/no-sync-result-assumption.ts
@@ -873,21 +873,6 @@ function rhsCarriesBlazeReinit(expr: AstNode | undefined): boolean {
 }
 
 /**
- * Handle a plain `=` assignment to a bare identifier whose name currently has
- * a pending `.blaze()` binding in scope.
- *
- * If the RHS is (or carries) another blaze call, leave the pending entry
- * alone — `recordPendingBinding` will re-register it when the blaze call
- * itself is visited. Otherwise, clear the pending entry: the identifier has
- * been overwritten with a non-Result value, so the original
- * `result.isOk()`-style diagnostic no longer applies.
- *
- * Compound assignments (`+=`, `??=`, etc.) and member-expression LHS are
- * ignored here: compound operators do not unconditionally replace the slot
- * (and `??=`/`||=` may preserve the Result when the LHS is truthy), and
- * member writes do not rebind the tracked identifier at all.
- */
-/**
  * Nullish/falsy-skip compound assignments (`??=`, `||=`) only write to the slot
  * when the LHS is nullish or falsy. A pending `.blaze()` binding holds a
  * truthy `Promise<Result>`, so the RHS never runs and the pending binding must
@@ -1083,8 +1068,20 @@ const visitBlazeCall = (node: AstNode, state: AnalyzeState): void => {
 
 const visitNode = (node: AstNode, state: AnalyzeState): void => {
   visitBlazeCall(node, state);
-  handleAssignmentReassignment(node, state);
   checkPendingAccess(node, state);
+};
+
+/**
+ * Post-order visitor for assignment re-assignment clearing.
+ *
+ * `handleAssignmentReassignment` must run *after* the RHS subtree has been
+ * walked. Otherwise a self-referential `result = result.value` would clear
+ * the pending entry before the RHS `result.value` access is observed — the
+ * missing-await diagnostic would disappear even though the write produced
+ * a non-Result value from the same pending slot.
+ */
+const visitNodePost = (node: AstNode, state: AnalyzeState): void => {
+  handleAssignmentReassignment(node, state);
 };
 
 const pushScopeIfBoundary = (node: AstNode, state: AnalyzeState): boolean => {
@@ -1136,6 +1133,7 @@ function walkWithScopes(node: AstNode, state: AnalyzeState): void {
   const pushed = pushScopeIfBoundary(node, state);
   visitNode(node, state);
   walkChildren(node, state);
+  visitNodePost(node, state);
   if (pushed) {
     state.scopeStack.pop();
   }

--- a/packages/warden/src/rules/warden-rules-use-ast.ts
+++ b/packages/warden/src/rules/warden-rules-use-ast.ts
@@ -432,7 +432,7 @@ const detectSite = (node: AstNode): DetectedSite | null => {
 // ---------------------------------------------------------------------------
 
 interface Scope {
-  readonly declaredNames: Set<string>;
+  readonly declaredNames: ReadonlySet<string>;
   readonly sourceParamName: string | null;
 }
 
@@ -649,14 +649,53 @@ const collectBindingIdsFromPattern = (
   }
 };
 
-const collectFunctionParamNames = (fn: AstNode): Set<string> => {
-  const names = new Set<string>();
+interface FunctionScopeBindingsEx {
+  /** Param names exactly — used to identify the source-param binding. */
+  readonly paramNames: Set<string>;
+  /** Hoisted `var` names inside the function body. May overlap with params. */
+  readonly hoistedVarNames: Set<string>;
+  /** Combined set of declared names visible in this function scope. */
+  readonly declaredNames: Set<string>;
+}
+
+const collectParamBindingsFromFunction = (fn: AstNode): Set<string> => {
+  const paramNames = new Set<string>();
   const params =
     (fn as unknown as { params?: readonly AstNode[] }).params ?? [];
   for (const param of params) {
-    collectBindingIdsFromPattern(param, names);
+    collectBindingIdsFromPattern(param, paramNames);
   }
-  return names;
+  return paramNames;
+};
+
+const collectHoistedVarsFromFunctionBody = (fn: AstNode): Set<string> => {
+  const hoistedVarNames = new Set<string>();
+  const { body } = fn as unknown as { body?: AstNode };
+  if (body && typeof body === 'object' && (body as AstNode).type) {
+    // eslint-disable-next-line no-use-before-define
+    collectHoistedVarBindings(body, hoistedVarNames);
+  }
+  return hoistedVarNames;
+};
+
+/**
+ * Combine param names and body-level hoisted `var` names into a single
+ * declared-names set, while keeping the two subsets addressable. The
+ * hoisted set is kept separate so the scope walker can tell whether a
+ * source-param identity has been overwritten by a same-named hoisted local —
+ * a shadow that would otherwise be invisible because both names live in the
+ * same function-scope binding set.
+ */
+const collectFunctionScopeBindingsEx = (
+  fn: AstNode
+): FunctionScopeBindingsEx => {
+  const paramNames = collectParamBindingsFromFunction(fn);
+  const hoistedVarNames = collectHoistedVarsFromFunctionBody(fn);
+  const declaredNames = new Set<string>(paramNames);
+  for (const name of hoistedVarNames) {
+    declaredNames.add(name);
+  }
+  return { declaredNames, hoistedVarNames, paramNames };
 };
 
 const addVariableDeclarationNames = (
@@ -674,6 +713,47 @@ const addVariableDeclarationNames = (
   }
 };
 
+const isVarVariableDeclaration = (stmt: AstNode): boolean =>
+  stmt.type === 'VariableDeclaration' &&
+  (stmt as unknown as { kind?: string }).kind === 'var';
+
+/**
+ * True when `node` owns its own VariableEnvironment and therefore stops `var`
+ * hoisting from crossing into the enclosing function/program scope.
+ */
+const ownsVariableEnvironmentForHoisting = (node: AstNode): boolean =>
+  FUNCTION_NODE_TYPES.has(node.type) || node.type === 'StaticBlock';
+
+/**
+ * Collect `var` declarations that hoist to the nearest function (or program)
+ * scope from anywhere inside `root`, without crossing a nested function or
+ * static-block boundary. Mirrors the hoisting semantics used by
+ * {@link ./no-sync-result-assumption.ts} so `if (cond) { var sourceCode = ... }`
+ * inside a `check()` body correctly shadows the method's first parameter.
+ */
+const collectHoistedVarBindings = (root: AstNode, out: Set<string>): void => {
+  const walkVar = (node: AstNode, isRoot: boolean): void => {
+    if (!isRoot && ownsVariableEnvironmentForHoisting(node)) {
+      return;
+    }
+    if (isVarVariableDeclaration(node)) {
+      addVariableDeclarationNames(node, out);
+    }
+    for (const val of Object.values(node)) {
+      if (Array.isArray(val)) {
+        for (const item of val) {
+          if (item && typeof item === 'object' && (item as AstNode).type) {
+            walkVar(item as AstNode, false);
+          }
+        }
+      } else if (val && typeof val === 'object' && (val as AstNode).type) {
+        walkVar(val as AstNode, false);
+      }
+    }
+  };
+  walkVar(root, true);
+};
+
 const addFunctionDeclarationName = (
   stmt: AstNode,
   names: Set<string>
@@ -688,12 +768,33 @@ const collectBlockDeclarationNames = (block: AstNode): Set<string> => {
   const names = new Set<string>();
   const body = (block as unknown as { body?: readonly AstNode[] }).body ?? [];
   for (const stmt of body) {
-    if (stmt.type === 'VariableDeclaration') {
+    // `var` is function-scoped, not block-scoped — hoisted into the nearest
+    // enclosing function (or program) scope by
+    // {@link collectHoistedVarBindings}. Registering it here would make
+    // `if (cond) { var x = ... }` look block-local and fail to shadow a
+    // same-named outer binding when the write escapes the block.
+    if (
+      stmt.type === 'VariableDeclaration' &&
+      !isVarVariableDeclaration(stmt)
+    ) {
       addVariableDeclarationNames(stmt, names);
     } else if (stmt.type === 'FunctionDeclaration') {
       addFunctionDeclarationName(stmt, names);
     }
   }
+  return names;
+};
+
+/**
+ * Collect the names a `CatchClause` parameter introduces into its body. The
+ * catch clause has its own binding scope distinct from the surrounding block;
+ * without this, `try {} catch (sourceCode) { sourceCode.split(...) }` would
+ * resolve `sourceCode` to the enclosing `check()` parameter and fire.
+ */
+const collectCatchClauseDeclarationNames = (node: AstNode): Set<string> => {
+  const names = new Set<string>();
+  const { param } = node as unknown as { param?: AstNode };
+  collectBindingIdsFromPattern(param, names);
   return names;
 };
 
@@ -734,6 +835,46 @@ const maybeRecordDetection = (
 };
 
 /**
+ * Resolve the effective source-param name for a function scope. A hoisted
+ * `var` with the same name as the source param overwrites the param's slot
+ * in the function's VariableEnvironment, so the enclosing identifier no
+ * longer resolves to the raw-source binding.
+ */
+const resolveScopeSourceParamName = (
+  methodParamName: string | null,
+  hoistedVarNames: ReadonlySet<string>
+): string | null =>
+  methodParamName && hoistedVarNames.has(methodParamName)
+    ? null
+    : methodParamName;
+
+const pushFunctionScope = (
+  node: AstNode,
+  ctx: ScopeWalkContext,
+  scopes: Scope[]
+): void => {
+  const methodParamName = ctx.methodFunctionStarts.get(node.start) ?? null;
+  const { declaredNames, hoistedVarNames } =
+    collectFunctionScopeBindingsEx(node);
+  scopes.push({
+    declaredNames,
+    sourceParamName: resolveScopeSourceParamName(
+      methodParamName,
+      hoistedVarNames
+    ),
+  });
+};
+
+/** Collector for scope frames that carry no source-param identity. */
+const SIMPLE_SCOPE_COLLECTORS: Record<
+  string,
+  (node: AstNode) => ReadonlySet<string>
+> = {
+  BlockStatement: collectBlockDeclarationNames,
+  CatchClause: collectCatchClauseDeclarationNames,
+};
+
+/**
  * Push the scope a function node introduces, or null when the node is not
  * scope-introducing. Returning a dispose function keeps `visitWithScopes`
  * small and keeps the scope stack strictly paired.
@@ -744,16 +885,13 @@ const enterScopeForNode = (
   scopes: Scope[]
 ): boolean => {
   if (FUNCTION_NODE_TYPES.has(node.type)) {
-    const sourceParamName = ctx.methodFunctionStarts.get(node.start) ?? null;
-    scopes.push({
-      declaredNames: collectFunctionParamNames(node),
-      sourceParamName,
-    });
+    pushFunctionScope(node, ctx, scopes);
     return true;
   }
-  if (node.type === 'BlockStatement') {
+  const collector = SIMPLE_SCOPE_COLLECTORS[node.type];
+  if (collector) {
     scopes.push({
-      declaredNames: collectBlockDeclarationNames(node),
+      declaredNames: collector(node),
       sourceParamName: null,
     });
     return true;


### PR DESCRIPTION
## Summary

Consolidated cleanup of 14 review findings left unresolved when PRs #207–#210 were merged (via `queue:merge` before remote reviewer comments completed). Two additional scope-resolution P1s surfaced during this cleanup's Codex review and were also fixed in the same pass.

Closes [TRL-347](https://linear.app/outfitter/issue/TRL-347).

## What was missed on the prior stack

When #207–#210 went through the merge queue, Greptile / Codex / Devin had posted comments within 1–5 minutes, but the CI-gated `queue:merge` label landed the PRs before reviewer sign-off. Most findings were P2, but two Devin 🟡 false-negative regressions slipped through (items 7 and 12 below). All 16 items are consolidated here so every rule in the affected set is correct on this PR's base.

## ast.ts — framework namespace + scope walker

**1. `getContourCalleeName` accepts namespaced callees.** Split into `getBareContourCalleeName` + `getNamespacedContourCalleeName` funneled through `matchContourPrimitiveName`. `core.contour(...)` is now recognized alongside bare `contour(...)`, closing the Devin 🚩 from PR #207.

**2. Single-object namespaced test coverage.** Added `core.trail({ id: 'x' }, ...)` test fixture for the existing two-arg-or-single-object path.

**3. Framework namespace restriction with scope resolution.** This is the largest correctness piece on this PR. A new `FrameworkNamespaceContext` + `collectFrameworkNamespacedCallStarts` walks every lexical scope (Program, function, block, for-variants, switch, catch, static block, class body) and builds a `Set<offset>` of call sites where the `ns.trail(...)` / `ns.contour(...)` / `ns.signal(...)` receiver IS the unshadowed namespace import from `@ontrails/*`. `isNamespacedCallAllowed(start)` then gates every downstream resolver. The net effect: unrelated calls like `analytics.trail('x', {})` and locally-shadowed `const core = {}; core.trail(...)` no longer produce phantom framework definitions in any consumer of `findTrailDefinitions` / `findContourDefinitions` / `collectNamedTrailIds`.

**4–5. Scope walker recognizes class and TS binding forms.** Surfaced by Codex during this cleanup's own review. `ClassDeclaration` names hoist into the enclosing frame; `ClassExpression` names live in their own body frame (visible to initializers, invisible outside); `TSEnumDeclaration` and `TSModuleDeclaration` bind into the enclosing frame. Prevents false positives like `class core { field = core.trail(...) }` and `enum core { A } core.trail(...)`.

**6. `SwitchStatement` one-frame scoping.** Codex-flagged P1 during review. JavaScript `switch` statements share one lexical scope across all cases — a binding declared in `case 'a'` is visible in `case 'b'` after fall-through. Replaced per-`SwitchCase` frames with a single `SwitchStatement` frame covering every case's `consequent[]`. Braced `case { ... }` bodies still get their own nested `BlockStatement` frame.

## no-sync-result-assumption.ts — visitor ordering + operators

**7. Devin 🟡 — post-order reassignment clear.** The pre-order visitor cleared pending bindings on `AssignmentExpression` before `walkChildren` visited the RHS, so `let r = blaze(); r = r.value; r.isOk()` silently passed because the inner `r.value` MemberExpression found no pending entry at visit time. Moved the clearing into a new `visitNodePost` pass invoked after children walk. The `r.value` MemberExpression now fires correctly, and the subsequent outer clear runs after child diagnostics land.

**8.** Orphaned JSDoc block removed — was a displaced comment that had drifted from its declaration during prior review churn.

**9.** Added missing `||=` preservation test mirroring the existing `??=` case.

## warden-rules-use-ast.ts — scope and var semantics

**10. `CatchClause` param binding tracked.** `enterScopeForNode` now pushes a frame for catch clauses with the param bound (including destructured forms). Prevents false positives when a catch param shadows the source param of the enclosing `check` method.

**11. `var` function-scoping.** New `collectHoistedVarBindings` + `collectFunctionScopeBindingsEx` returning `{ paramNames, hoistedVarNames, declaredNames }`. `collectBlockDeclarationNames` no longer collects `var` (which belongs to function scope, not block). A hoisted `var` with the same name as the source param correctly invalidates the tracking, so `check(sourceCode) { if (cond) { var sourceCode = 'local'; } return sourceCode.split('\n'); }` does NOT fire on the post-block `.split`.

## implementation-returns-result.ts — namespace shadow detection

**12. Devin 🟡 — `FunctionBody` frame.** oxc-parser emits `FunctionBody` for regular `function` expression bodies (vs `BlockStatement` for arrows). Added `FunctionBody` to `SCOPE_FRAME_COLLECTORS` so regular `blaze: async function(...) { const ns = {}; ... }` registers the top-level shadow that was previously invisible.

**13. Hoisted `var` in namespace checks.** Function-body-level `var` hoist walks nested blocks (stopping at nested function boundaries) and seeds impl params. `if (cond) { var ns = local; } return ns.helper();` now correctly detects the shadow and fires.

**14. `SwitchStatement` one-frame.** Same fix shape as item 6, applied to this rule's `SCOPE_FRAME_COLLECTORS`.

**15. Empty-namespace tracking.** `resolveNamespaceSpecifier` now records namespace imports with zero Result exports (empty Set instead of null). `isNamespaceHelperMemberCall` routes these through shadow-checking rather than falling through to general return-value analysis — correct diagnostic behavior for the right reason.

## Verification

- `bun run typecheck` — 31/31 green
- `bun test packages/warden` — 579 pass / 0 fail (up from 552)
- `bun run check` — 31/31 green

## Test plan

17 new tests across four rule suites, plus updates to `intent-propagation.test.ts` to include the `@ontrails/core` import per item 3. Coverage breakdown: `ast.ts` scope shadowing (7 cases — function / sibling / param / class-declaration / class-expression / enum / namespace); `no-sync-result-assumption` (`r = r.value` post-order fire + `||=` preservation); `warden-rules-use-ast` (catch-clause shadow + hoisted-var shadow of check param); `implementation-returns-result` (`FunctionBody` shadow, hoisted-var shadow, `SwitchStatement` fall-through, braced switch-case scoped, empty-namespace path).

## Review arc

Three rounds of Codex convergence on top of the initial engineer pass. Round 1 caught two P1 scope-resolution holes — namespace restriction wasn't walking scopes (local `const core = {}` fooled it) and per-`SwitchCase` frames didn't match JS switch semantics. Round 2 caught two more P1s — `ClassDeclaration` / `ClassExpression` / `TSEnumDeclaration` / `TSModuleDeclaration` name bindings missing from the scope walker. Round 3 clean across all 16 findings.

## Related

- PR #207 (TRL-343), PR #208 (TRL-344), PR #209 (TRL-345), PR #210 (TRL-346) — the merged stack whose review feedback seeded this cleanup
- [ADR-0036](../docs/adr/0036-warden-rule-public-shape-is-the-trail.md) — warden rule self-governance context