### PR TITLE
fix(warden): post-merge scope-walker fixes from PR #211 review

### DIFF
--- a/packages/warden/src/__tests__/ast.test.ts
+++ b/packages/warden/src/__tests__/ast.test.ts
@@ -351,6 +351,58 @@ describe('findTrailDefinitions scope-aware shadowing', () => {
     const ast = parseOrThrow(source);
     expect(findTrailDefinitions(ast)).toHaveLength(0);
   });
+
+  test('ignores core.trail(...) inside a FunctionExpression body that locally shadows the namespace', () => {
+    // oxc-parser emits `FunctionBody` for `function` expression bodies, not
+    // `BlockStatement`. Without a `FunctionBody` entry in the scope-frame
+    // collectors, a local `const core = {...}` at the top of the expression
+    // body would not push a frame and the shadow would be missed.
+    const source = `
+      import * as core from '@ontrails/core';
+      const fn = function weird() {
+        const core = { trail: (_id: string, _cfg: object) => undefined };
+        core.trail('entity.show', { input: {} });
+      };
+    `;
+    const ast = parseOrThrow(source);
+    expect(findTrailDefinitions(ast)).toHaveLength(0);
+  });
+
+  test('does not hoist block-local function declarations out of their block', () => {
+    // A `function core(){}` inside an `if` block is block-scoped in strict
+    // (module) code. Hoisting it to the enclosing function frame would
+    // wrongly shadow the module-level `core` namespace for later code in
+    // the same function, dropping the trail detection below.
+    const source = `
+      import * as core from '@ontrails/core';
+      export function outer() {
+        if (Math.random() > 0) {
+          function core() { return 0; }
+          core();
+        }
+        return core.trail('entity.show', { input: {} });
+      }
+    `;
+    const ast = parseOrThrow(source);
+    const defs = findTrailDefinitions(ast);
+    expect(defs).toHaveLength(1);
+    expect(defs[0]?.id).toBe('entity.show');
+  });
+});
+
+describe('getTrailCalleeName permissive fallback', () => {
+  test('resolves namespaced core.trail(...) when no context is provided', () => {
+    // Inline resolution paths (`crosses: [core.trail(...)]`,
+    // `on: [core.signal(...)]`) do not have access to the surrounding file
+    // AST and so cannot build a FrameworkNamespaceContext. They must still
+    // be able to recognize the trail/signal primitive by name.
+    expect(
+      __getTrailCalleeNameForTest(parseCallee('core.trail("foo", {});'))
+    ).toBe('trail');
+    expect(
+      __getTrailCalleeNameForTest(parseCallee('core.signal("evt", {});'))
+    ).toBe('signal');
+  });
 });
 
 describe('findContourDefinitions with namespaced callees', () => {

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -861,12 +861,23 @@ const forEachAstChild = (
   }
 };
 
-const recordHoistedBinding = (node: AstNode, into: Set<string>): void => {
+const recordHoistedBinding = (
+  node: AstNode,
+  into: Set<string>,
+  inNestedBlock: boolean
+): void => {
   if (node.type === 'VariableDeclaration') {
     const { kind } = node as unknown as { kind?: string };
     if (kind === 'var') {
       addVarDeclarationBindingNames(node, into);
     }
+    return;
+  }
+  // In strict/module code, function/class/enum/module declarations inside a
+  // nested block (`if { function foo() {} }`, `switch` case, etc.) are
+  // block-scoped. Only hoist them to the enclosing function frame when they
+  // sit directly in the function body, not inside a further block.
+  if (inNestedBlock) {
     return;
   }
   if (
@@ -879,17 +890,29 @@ const recordHoistedBinding = (node: AstNode, into: Set<string>): void => {
   }
 };
 
+const NESTED_BLOCK_BOUNDARY_TYPES = new Set([
+  'BlockStatement',
+  'ForStatement',
+  'ForInStatement',
+  'ForOfStatement',
+  'SwitchStatement',
+  'CatchClause',
+]);
+
 const visitForHoisted = (
   node: AstNode,
   isRoot: boolean,
-  into: Set<string>
+  into: Set<string>,
+  inNestedBlock: boolean
 ): void => {
   if (!isRoot && FUNCTION_BOUNDARY_TYPES.has(node.type)) {
     return;
   }
-  recordHoistedBinding(node, into);
+  recordHoistedBinding(node, into, inNestedBlock);
+  const childInNestedBlock =
+    inNestedBlock || (!isRoot && NESTED_BLOCK_BOUNDARY_TYPES.has(node.type));
   forEachAstChild(node, (child) => {
-    visitForHoisted(child, false, into);
+    visitForHoisted(child, false, into, childInNestedBlock);
   });
 };
 
@@ -902,7 +925,7 @@ const collectHoistedVarAndFunctionBindings = (
   root: AstNode,
   into: Set<string>
 ): void => {
-  visitForHoisted(root, true, into);
+  visitForHoisted(root, true, into, false);
 };
 
 type FrameCollector = (node: AstNode, into: Set<string>) => void;
@@ -984,6 +1007,11 @@ const SCOPE_FRAME_COLLECTORS: Record<string, FrameCollector> = {
   ForInStatement: collectForInOfFrame,
   ForOfStatement: collectForInOfFrame,
   ForStatement: collectForStatementFrame,
+  // oxc-parser emits `FunctionBody` for `function` expression bodies; without
+  // this entry, a `const ns = ...` at the top of a function-expression body
+  // would not push a scope frame, and a module-level namespace import with
+  // the same name would be incorrectly recognized inside.
+  FunctionBody: collectBlockFrame,
   FunctionDeclaration: collectFunctionFrame,
   FunctionExpression: collectFunctionFrame,
   Program: collectProgramFrame,
@@ -1218,6 +1246,13 @@ const isNamespacedCallAllowed = (
  * receiver must be a framework namespace binding AND — when a
  * `safeCallStarts` set is present — the call site must appear in that set,
  * meaning the receiver is not shadowed by any enclosing scope.
+ *
+ * When `context` is `undefined`, this falls back to permissive matching
+ * (any `ns.trail(...)` shape resolves). Inline resolution paths that do
+ * not have the surrounding AST available (e.g. `crosses: [core.trail(...)]`
+ * or `on: [core.signal(...)]`) rely on this fallback. Scope-aware call
+ * sites always pass a context, so this only affects inline contexts where
+ * a best-effort name match is the intended behavior.
  */
 const getNamespacedTrailCalleeName = (
   callExpr: AstNode,
@@ -1229,7 +1264,7 @@ const getNamespacedTrailCalleeName = (
     return null;
   }
   const ctx = asNamespaceContext(context);
-  if (!ctx || !isNamespacedCallAllowed(callExpr.start, names.receiver, ctx)) {
+  if (ctx && !isNamespacedCallAllowed(callExpr.start, names.receiver, ctx)) {
     return null;
   }
   return matchTrailPrimitiveName(names.property);
@@ -1422,6 +1457,10 @@ const getNamespacedContourCalleeName = (
   if (!names) {
     return null;
   }
+  // Unlike the trail/signal variant, contour has no inline-resolution callers
+  // that legitimately invoke this without a FrameworkNamespaceContext, so the
+  // strict namespace gate stays on. If a future caller needs the permissive
+  // fallback, mirror the trail shape and add a regression test first.
   const ctx = asNamespaceContext(context);
   if (!ctx || !isNamespacedCallAllowed(callExpr.start, names.receiver, ctx)) {
     return null;


### PR DESCRIPTION
## Summary

Post-merge follow-up for [PR #211](https://github.com/outfitter-dev/trails/pull/211). Codex and Devin both posted review findings after the Graphite merge queue had already landed #211, so those findings are addressed in a fresh PR. Three scope-walker bugs in `packages/warden/src/rules/ast.ts`:

1. **Function-expression body shadows were missed (Devin 🔴).** `oxc-parser` emits `FunctionBody` for `function` expression bodies rather than `BlockStatement`. Without a `FunctionBody` entry in `SCOPE_FRAME_COLLECTORS`, a local `const core = { ... }` at the top of a function-expression body would not push a scope frame, and a module-level `import * as core from '@ontrails/core'` would be incorrectly recognized as a framework call inside that body. The parallel map in `implementation-returns-result.ts` already has this entry — `ast.ts` now matches.
2. **Inline `core.trail(...)` / `core.signal(...)` stopped resolving (Codex + Devin 🟡).** `getNamespacedTrailCalleeName` (and its contour twin) returned `null` whenever the caller did not supply a `FrameworkNamespaceContext`. The inline resolution paths used by `collectCrossTargetTrailIds` and `collectOnTargetSignalIds` legitimately do not have the surrounding AST and cannot build such a context. They now fall through to a permissive name match when no context is provided, preserving pre-refactor behavior while leaving scope-aware call sites strictly gated.
3. **Block-local `function core(){}` was over-hoisted (Codex 🟡).** The hoisting pass treated any nested `FunctionDeclaration` / `ClassDeclaration` / `TSEnumDeclaration` / `TSModuleDeclaration` as function-scoped, but in strict/module code those are block-scoped. A `function core(){}` inside an `if` block was shadowing the module-level `core` namespace for later code in the same function. Hoisting now applies only to `var` declarations once we have crossed a block/for/switch/catch boundary; block-local function/class/enum/module bindings remain on their block frame.

Three regression tests were added alongside the fixes: one for each scenario.

## Why not roll into #211

#211 was already merged by the time the Devin review comment landed, triggered by the `queue:merge` label applying at submit time. To avoid a repeat, this PR ships without the merge label and will wait for the review bots to complete before being queued.

## Test plan

- [x] `bun test` in `packages/warden` — 582 pass, 0 fail (3 new regression tests)
- [x] `bun run build` — green across the monorepo
- [x] `bun run typecheck` — green
- [x] `bunx ultracite check packages/warden/src` — 0 warnings, 0 errors
- [ ] Devin / Codex / Greptile review convergence before queueing

Refs TRL-347, closes TRL-348.