### PR TITLE
fix(warden): unwrap wrapped contour id schemas

### DIFF
--- a/packages/warden/src/__tests__/ast.test.ts
+++ b/packages/warden/src/__tests__/ast.test.ts
@@ -471,4 +471,27 @@ describe('collectContourReferenceSites with namespaced inline contours', () => {
 
     expect(collectContourReferenceSites(ast)).toEqual([]);
   });
+
+  test('unwraps wrapped contour id schemas before resolving the target', () => {
+    const source = `
+      import { contour } from '@ontrails/core';
+      import { z } from 'zod';
+
+      const user = contour('user', {
+        id: z.string().uuid(),
+      });
+
+      const gist = contour('gist', {
+        id: z.string().uuid(),
+        ownerId: user.id().nullable().optional().default(null),
+      });
+    `;
+    const ast = parseOrThrow(source);
+    const refs = collectContourReferenceSites(ast);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.source).toBe('gist');
+    expect(refs[0]?.field).toBe('ownerId');
+    expect(refs[0]?.target).toBe('user');
+  });
 });

--- a/packages/warden/src/__tests__/circular-refs.test.ts
+++ b/packages/warden/src/__tests__/circular-refs.test.ts
@@ -72,4 +72,27 @@ const user = contour('user', {
       'user -> gist -> account -> user'
     );
   });
+
+  test('warns on local cycles formed through wrapped contour id schemas', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  gistId: gist.id().optional(),
+  id: z.string().uuid(),
+}, { identity: 'id' });
+
+const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id().nullable(),
+}, { identity: 'id' });
+`;
+
+    const diagnostics = circularRefs.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics[0]?.rule).toBe('circular-refs');
+    expect(diagnostics[0]?.message).toContain('user -> gist -> user');
+  });
 });

--- a/packages/warden/src/__tests__/reference-exists.test.ts
+++ b/packages/warden/src/__tests__/reference-exists.test.ts
@@ -105,4 +105,26 @@ const gist = core.contour('gist', {
     expect(diagnostics[0]?.rule).toBe('reference-exists');
     expect(diagnostics[0]?.message).toContain('user');
   });
+
+  test('flags a missing wrapped contour reference target', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+import { user } from './user';
+
+const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id().nullish(),
+}, { identity: 'id' });
+`;
+
+    const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
+      knownContourIds: new Set(['gist']),
+      knownTrailIds: new Set<string>(),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('reference-exists');
+    expect(diagnostics[0]?.message).toContain('user');
+  });
 });

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -1779,18 +1779,49 @@ const getContourReferenceTargetFromObject = (
   return extractContourDefinition(object, context)?.name ?? null;
 };
 
-const getContourIdCallObject = (node: AstNode | undefined): AstNode | null => {
-  if (!node || node.type !== 'CallExpression') {
-    return null;
-  }
+const CONTOUR_ID_WRAPPER_METHODS = new Set([
+  'brand',
+  'catch',
+  'default',
+  'describe',
+  'meta',
+  'nullable',
+  'nullish',
+  'optional',
+  'readonly',
+]);
 
+const getContourIdCallMember = (
+  node: AstNode
+): {
+  readonly member: NonNullable<ReturnType<typeof getContourReferenceMember>>;
+  readonly propertyName: string;
+} | null => {
   const callee = node['callee'] as AstNode | undefined;
   const member = callee ? getContourReferenceMember(callee) : null;
-  if (!member || identifierName(member.property) !== 'id') {
+  const propertyName = member ? identifierName(member.property) : null;
+  return member && propertyName ? { member, propertyName } : null;
+};
+
+const getContourIdCallObject = function getContourIdCallObject(
+  node: AstNode | undefined
+): AstNode | null {
+  const current = node;
+  if (!current || current.type !== 'CallExpression') {
     return null;
   }
 
-  return member.object ?? null;
+  const member = getContourIdCallMember(current);
+  if (!member) {
+    return null;
+  }
+  if (member.propertyName === 'id') {
+    return member.member.object ?? null;
+  }
+
+  return CONTOUR_ID_WRAPPER_METHODS.has(member.propertyName)
+    ? getContourIdCallObject(member.member.object)
+    : null;
 };
 
 const extractContourReferenceTarget = (


### PR DESCRIPTION
## Summary
This fixes the AST/runtime mismatch where wrapped contour id schemas like `user.id().optional()` disappeared from warden's contour-reference path even though runtime topo validation still recognized them.

## What Changed
- taught the AST contour-reference extraction path to unwrap common contour-id wrapper calls before resolving the underlying `.id()` target
- kept the fix in the shared AST helper layer so `reference-exists` and `circular-refs` both benefit from the same behavior
- added regressions for wrapped contour-id schemas in AST collection, missing-reference detection, and local cycle detection

## Verification
- `bun test packages/warden/src/__tests__/ast.test.ts packages/warden/src/__tests__/reference-exists.test.ts packages/warden/src/__tests__/circular-refs.test.ts --bail`
- `bunx ultracite check packages/warden/src/rules/ast.ts packages/warden/src/__tests__/ast.test.ts packages/warden/src/__tests__/reference-exists.test.ts packages/warden/src/__tests__/circular-refs.test.ts`
- `cd packages/warden && bun run build`

## Issues
Closes: TRL-357
