### PR TITLE
fix(warden): merge local contour definitions with project context

### DIFF
--- a/packages/warden/src/__tests__/contour-exists.test.ts
+++ b/packages/warden/src/__tests__/contour-exists.test.ts
@@ -81,4 +81,27 @@ trail('user.create', {
       })
     ).toEqual([]);
   });
+
+  test('keeps local contour declarations when project context is present', () => {
+    const code = `
+import { Result, contour, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  id: z.string().uuid(),
+}, { identity: 'id' });
+
+trail('user.create', {
+  contours: [user],
+  blaze: async () => Result.ok({ ok: true }),
+});
+`;
+
+    expect(
+      contourExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set<string>(),
+        knownTrailIds: new Set(['user.create']),
+      })
+    ).toEqual([]);
+  });
 });

--- a/packages/warden/src/__tests__/reference-exists.test.ts
+++ b/packages/warden/src/__tests__/reference-exists.test.ts
@@ -85,7 +85,7 @@ const gist = contour('gist', {
     ).toEqual([]);
   });
 
-  test('flags a missing namespaced inline contour reference target', () => {
+  test('keeps namespaced inline contour definitions when project context is present', () => {
     const code = `
 import * as core from '@ontrails/core';
 import { z } from 'zod';
@@ -96,14 +96,12 @@ const gist = core.contour('gist', {
 }, { identity: 'id' });
 `;
 
-    const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
-      knownContourIds: new Set(['gist']),
-      knownTrailIds: new Set<string>(),
-    });
-
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.rule).toBe('reference-exists');
-    expect(diagnostics[0]?.message).toContain('user');
+    expect(
+      referenceExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set(['gist']),
+        knownTrailIds: new Set<string>(),
+      })
+    ).toEqual([]);
   });
 
   test('flags a missing wrapped contour reference target', () => {
@@ -126,5 +124,28 @@ const gist = contour('gist', {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.rule).toBe('reference-exists');
     expect(diagnostics[0]?.message).toContain('user');
+  });
+
+  test('keeps local contour definitions when project context is present', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  id: z.string().uuid(),
+}, { identity: 'id' });
+
+const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: 'id' });
+`;
+
+    expect(
+      referenceExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set(['gist']),
+        knownTrailIds: new Set<string>(),
+      })
+    ).toEqual([]);
   });
 });

--- a/packages/warden/src/rules/contour-exists.ts
+++ b/packages/warden/src/rules/contour-exists.ts
@@ -11,6 +11,7 @@ import {
   deriveContourIdentifierName,
 } from './ast.js';
 import type { AstNode, TrailDefinition } from './ast.js';
+import { mergeKnownContourIds } from './contour-ids.js';
 import { isTestFile } from './scan.js';
 import type {
   ProjectAwareWardenRule,
@@ -192,7 +193,7 @@ export const contourExists: ProjectAwareWardenRule = {
       ast,
       sourceCode,
       filePath,
-      context.knownContourIds ?? localContourIds
+      mergeKnownContourIds(localContourIds, context.knownContourIds)
     );
   },
   description:

--- a/packages/warden/src/rules/contour-ids.ts
+++ b/packages/warden/src/rules/contour-ids.ts
@@ -1,0 +1,15 @@
+/**
+ * Merge a file's locally-defined contour IDs with the project-wide set.
+ *
+ * Rules that run with a `ProjectContext` need to treat both local and
+ * project-wide contour definitions as "known" so that declarations and
+ * references resolve correctly. When no project context is available — e.g.
+ * single-file lint runs via `check` — the local set is returned as-is.
+ */
+export const mergeKnownContourIds = (
+  localContourIds: ReadonlySet<string>,
+  projectContourIds?: ReadonlySet<string>
+): ReadonlySet<string> =>
+  projectContourIds
+    ? new Set([...projectContourIds, ...localContourIds])
+    : localContourIds;

--- a/packages/warden/src/rules/reference-exists.ts
+++ b/packages/warden/src/rules/reference-exists.ts
@@ -5,6 +5,7 @@ import {
   parse,
 } from './ast.js';
 import type { AstNode } from './ast.js';
+import { mergeKnownContourIds } from './contour-ids.js';
 import { isTestFile } from './scan.js';
 import type {
   ProjectAwareWardenRule,
@@ -87,7 +88,7 @@ export const referenceExists: ProjectAwareWardenRule = {
       ast,
       sourceCode,
       filePath,
-      context.knownContourIds ?? localContourIds
+      mergeKnownContourIds(localContourIds, context.knownContourIds)
     );
   },
   description:


### PR DESCRIPTION
## Summary
This makes project-aware contour checks additive instead of destructive. Local contour definitions now stay visible when `reference-exists` and `contour-exists` run with project context.

## What Changed
- changed `reference-exists` to merge file-local contour definitions with `knownContourIds` from project context instead of replacing them
- made the same merge in `contour-exists` so standalone and project-aware runs agree on the current file's contour truth
- added regressions for both rules, including the namespaced inline contour case that should remain valid when project context is present

## Verification
- `bun test packages/warden/src/__tests__/reference-exists.test.ts packages/warden/src/__tests__/contour-exists.test.ts packages/warden/src/__tests__/circular-refs.test.ts --bail`
- `bunx ultracite check packages/warden/src/rules/reference-exists.ts packages/warden/src/rules/contour-exists.ts packages/warden/src/__tests__/reference-exists.test.ts packages/warden/src/__tests__/contour-exists.test.ts packages/warden/src/__tests__/circular-refs.test.ts`
- `cd packages/warden && bun run build`

## Issues
Closes: TRL-358
