### PR TITLE
docs(warden): clarify helper-scoped fire blind spots

### DIFF
--- a/packages/warden/src/__tests__/fires-declarations.test.ts
+++ b/packages/warden/src/__tests__/fires-declarations.test.ts
@@ -472,28 +472,6 @@ trail('shadowCtx', {
       expect(diagnostics.length).toBe(0);
     });
 
-    test('nested arrow with legitimate ctx.fire is not flagged as undeclared', () => {
-      const code = `
-trail('nestedLegit', {
-  fires: ['legitimate.signal'],
-  blaze: async (input, ctx) => {
-    const runLater = () => ctx.fire('legitimate.signal', {});
-    runLater();
-    return Result.ok({});
-  },
-});
-`;
-
-      const diagnostics = firesDeclarations.check(code, TEST_FILE);
-      // Precision tradeoff: the nested arrow isn't walked, so the warden sees
-      // the declared 'legitimate.signal' as "unused". What matters for the
-      // P1 bug is that it is NOT reported as undeclared (no false error).
-      const undeclared = diagnostics.filter((d) =>
-        d.message.includes('not declared in fires')
-      );
-      expect(undeclared.length).toBe(0);
-    });
-
     test('top-level ctx.fire with matching declaration still clean (regression)', () => {
       const code = `
 trail('regression', {
@@ -615,5 +593,60 @@ trail('checkout', {
       expect(diagnostics[0]?.message).toContain("'order.placed'");
       expect(diagnostics[0]?.message).toContain('object-form fires entries');
     });
+  });
+});
+
+describe('fires-declarations helper-scoped blind spots', () => {
+  test('helper-scoped ctx.fire stays a documented unused-only blind spot', () => {
+    const code = `
+trail('nestedLegit', {
+  fires: ['legitimate.signal'],
+  blaze: async (input, ctx) => {
+    const runLater = () => ctx.fire('legitimate.signal', {});
+    runLater();
+    return Result.ok({});
+  },
+});
+`;
+
+    const diagnostics = firesDeclarations.check(code, TEST_FILE);
+    // Precision tradeoff: helper-scoped ctx.fire isn't walked yet, so the
+    // rule sees the declared signal as "unused" today. What matters is that
+    // it is NOT reported as undeclared, and that the limitation stays
+    // stable until helper-aware analysis lands.
+    const undeclared = diagnostics.filter((d) =>
+      d.message.includes('not declared in fires')
+    );
+    const unused = diagnostics.filter((d) =>
+      d.message.includes("'legitimate.signal' declared in fires")
+    );
+    expect(undeclared.length).toBe(0);
+    expect(unused.length).toBe(1);
+  });
+
+  test('helper-local destructured fire stays a documented unused-only blind spot', () => {
+    const code = `
+trail('nestedDestructure', {
+  fires: ['helper.signal'],
+  blaze: async (input, ctx) => {
+    const runLater = () => {
+      const { fire } = ctx;
+      return fire('helper.signal', {});
+    };
+    runLater();
+    return Result.ok({});
+  },
+});
+`;
+
+    const diagnostics = firesDeclarations.check(code, TEST_FILE);
+    const undeclared = diagnostics.filter((d) =>
+      d.message.includes('not declared in fires')
+    );
+    const unused = diagnostics.filter((d) =>
+      d.message.includes("'helper.signal' declared in fires")
+    );
+    expect(undeclared.length).toBe(0);
+    expect(unused.length).toBe(1);
   });
 });

--- a/packages/warden/src/rules/fires-declarations.ts
+++ b/packages/warden/src/rules/fires-declarations.ts
@@ -416,10 +416,12 @@ const buildCtxNames = (body: AstNode): ReadonlySet<string> => {
  * }
  * ```
  *
- * Tradeoff: legitimate `ctx.fire(...)` calls inside nested helpers are not
- * statically analyzed. The runtime + signal-id cross-check still validate
- * them; the warden just can't prove them at lint time. A full scope walker is
- * a follow-up if this precision loss becomes meaningful in practice.
+ * Tradeoff: legitimate helper-scoped fire calls are not statically analyzed
+ * today. This includes both direct `ctx.fire(...)` inside a nested helper and
+ * helper-local destructures like `const { fire } = ctx` inside that helper.
+ * The runtime + signal-id cross-check still validate them; the warden just
+ * can't prove them at lint time. A fuller helper-aware scope walker remains
+ * follow-up work if this precision loss becomes meaningful in practice.
  */
 const extractCalledFires = (config: AstNode): ReadonlySet<string> => {
   const ids = new Set<string>();


### PR DESCRIPTION
## Summary
This takes the documentation-and-regression route for the known helper-scoped `ctx.fire(...)` blind spot in `fires-declarations`.

## What Changed
- tightened the rule comment so it explicitly calls out the current nested-helper limitation instead of leaving it as an implied behavior
- added regression coverage for helper-scoped `ctx.fire(...)` and helper-local `{ fire } = ctx` destructures so the blind spot is stable and documented
- kept the current rule behavior unchanged rather than widening the walker in a way that could reintroduce shadowing false positives mid-stack

## Verification
- `bun test packages/warden/src/__tests__/fires-declarations.test.ts --bail`
- `bunx ultracite check packages/warden/src/rules/fires-declarations.ts packages/warden/src/__tests__/fires-declarations.test.ts`
- `cd packages/warden && bun run build`

## Issues
Closes: TRL-359
