### PR TITLE
fix(warden): stop resource-declarations from treating ambient ctx as trail context

### DIFF
--- a/packages/warden/src/__tests__/resource-declarations.test.ts
+++ b/packages/warden/src/__tests__/resource-declarations.test.ts
@@ -320,6 +320,69 @@ trail('entity.show', {
 
       expect(diagnostics.length).toBe(0);
     });
+
+    test('blaze with no second parameter: unrelated closure ctx.resource is not tracked', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+
+const ctx = { resource: () => ({}) };
+
+trail('demo', {
+  blaze: async () => {
+    ctx.resource('db.main');
+    return Result.ok({ ok: true });
+  },
+  resources: [],
+});
+`;
+
+      const diagnostics = resourceDeclarations.check(code, TEST_FILE);
+      // The blaze has no context parameter, so `ctx` in the body is an
+      // unrelated closure-scoped binding, not the trail context. It must
+      // not be tracked — no diagnostics.
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('blaze with no second parameter: unrelated closure context.resource is not tracked', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+
+const context = { resource: () => ({}) };
+
+trail('demo', {
+  blaze: async () => {
+    context.resource('db.main');
+    return Result.ok({ ok: true });
+  },
+  resources: [],
+});
+`;
+
+      const diagnostics = resourceDeclarations.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('custom-named context param: only that name is tracked', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+
+const ctx = { resource: () => ({}) };
+
+trail('customCtx', {
+  blaze: async (_input, c) => {
+    ctx.resource('whatever');
+    return Result.ok(c);
+  },
+  resources: [],
+});
+`;
+
+      const diagnostics = resourceDeclarations.check(code, TEST_FILE);
+      // `c` is the real trail context (unused here, but it's the param).
+      // The closure `ctx.resource('whatever')` must not be flagged because
+      // `ctx` is not the trail context — only `c` is.
+      expect(diagnostics.length).toBe(0);
+    });
   });
 
   describe('nested run false positives', () => {

--- a/packages/warden/src/rules/resource-declarations.ts
+++ b/packages/warden/src/rules/resource-declarations.ts
@@ -188,9 +188,19 @@ const collectParamResourceAliases = (body: AstNode): ReadonlySet<string> => {
   return aliases;
 };
 
-/** Build the set of context parameter names to match against. */
+/**
+ * Build the set of context parameter names to match against.
+ *
+ * Returns ONLY the actual second-parameter name from the blaze signature.
+ * No seeded defaults: if the blaze has no second parameter, the returned set
+ * is empty and no `ctx.resource(...)` / `context.resource(...)` calls are
+ * tracked for that blaze. An unrelated closure-scoped `ctx` identifier is not
+ * the trail context and must not be treated as one.
+ *
+ * Mirrors `fires-declarations.ts` `buildCtxNames` for the same reason.
+ */
 const buildCtxNames = (body: AstNode): ReadonlySet<string> => {
-  const ctxNames = new Set(['ctx', 'context']);
+  const ctxNames = new Set<string>();
   const paramName = extractContextParamName(body);
   if (paramName) {
     ctxNames.add(paramName);


### PR DESCRIPTION
## Summary

`resource-declarations` was seeding `ctx` and `context` as valid trail-context identifier names even when the blaze body had no second parameter. Any closure-scoped variable named `ctx` inside such a blaze was therefore mis-read as the trail context, and `ctx.resource('...')` calls against unrelated ambient bindings got flagged against the trail's declared `resources: [...]` list. The sibling `fires-declarations` rule already gates the same detection on an actually-declared parameter; this PR mirrors that contract so the two governance rules agree on what counts as trail context.

## What changed

- `buildCtxNames` in `packages/warden/src/rules/resource-declarations.ts` no longer seeds `ctx`/`context` — the set is empty unless `extractContextParamName` finds a real second parameter on the blaze.
- TSDoc on the helper now spells out the rule and points at `fires-declarations` as the source of truth.
- Three regression tests added to `packages/warden/src/__tests__/resource-declarations.test.ts`: ambient `ctx` closure with no param, ambient `context` closure with no param, and a custom-named param where an outer `ctx` must stay silent. Existing positive tests (real `blaze: async (_, ctx)` misuse) still assert the rule flags real misuse.

## Verification

- `bun test packages/warden` — 594 pass, 0 fail.
- `bun run typecheck` — 31/31 green.
- `bunx ultracite check` — clean on both touched files.

## Issues

Closes: TRL-356
