### PR TITLE
fix(warden): scope no-throw-in-implementation to the blaze body

### DIFF
--- a/packages/warden/src/__tests__/no-throw-in-implementation.test.ts
+++ b/packages/warden/src/__tests__/no-throw-in-implementation.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+
+import { noThrowInImplementation } from '../rules/no-throw-in-implementation.js';
+
+const TEST_FILE = 'test.ts';
+
+describe('no-throw-in-implementation', () => {
+  test('flags direct throw inside blaze body', () => {
+    const code = `
+trail("entity.show", {
+  blaze: async (input, ctx) => {
+    throw new Error("boom");
+  }
+})`;
+    const diagnostics = noThrowInImplementation.check(code, TEST_FILE);
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.rule).toBe('no-throw-in-implementation');
+    expect(diagnostics[0]?.severity).toBe('error');
+  });
+
+  test('allows Result.err() in blaze body', () => {
+    const code = `
+trail("entity.show", {
+  blaze: async (input, ctx) => {
+    return Result.err(new NotFoundError("not found"));
+  }
+})`;
+    const diagnostics = noThrowInImplementation.check(code, TEST_FILE);
+    expect(diagnostics.length).toBe(0);
+  });
+
+  test('does not flag throw inside a nested .map() callback', () => {
+    const code = `
+trail("demo", {
+  blaze: async () => {
+    [1].map(() => {
+      throw new Error("boom");
+    });
+    return Result.ok({ ok: true });
+  }
+})`;
+    const diagnostics = noThrowInImplementation.check(code, TEST_FILE);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not flag throw inside a nested .filter() callback', () => {
+    const code = `
+trail("demo", {
+  blaze: async () => {
+    [1].filter(() => {
+      throw new Error("boom");
+    });
+    return Result.ok({ ok: true });
+  }
+})`;
+    const diagnostics = noThrowInImplementation.check(code, TEST_FILE);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not flag throw inside a nested function declaration', () => {
+    const code = `
+trail("demo", {
+  blaze: async () => {
+    function helper() {
+      throw new Error("boom");
+    }
+    return Result.ok({ ok: true });
+  }
+})`;
+    const diagnostics = noThrowInImplementation.check(code, TEST_FILE);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('still flags direct throw alongside a safe nested callback', () => {
+    const code = `
+trail("demo", {
+  blaze: async () => {
+    [1].map(() => {
+      throw new Error("inner — allowed");
+    });
+    throw new Error("outer — flagged");
+  }
+})`;
+    const diagnostics = noThrowInImplementation.check(code, TEST_FILE);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('no-throw-in-implementation');
+  });
+});

--- a/packages/warden/src/rules/no-throw-in-implementation.ts
+++ b/packages/warden/src/rules/no-throw-in-implementation.ts
@@ -1,11 +1,13 @@
 /**
  * Finds `throw` statements inside `blaze:` function bodies.
  *
- * Uses AST parsing for accurate detection — no false positives from
- * throw in comments, strings, or nested non-implementation functions.
+ * Uses scope-aware AST walking so throws inside nested callbacks
+ * (e.g. `.map()`, `.filter()`, inner helpers) are not attributed to
+ * the blaze body itself. ADR-0007 requires this class of false positive
+ * to be avoided — only throws in the blaze body scope should be flagged.
  */
 
-import { findBlazeBodies, offsetToLine, parse, walk } from './ast.js';
+import { findBlazeBodies, offsetToLine, parse, walkScope } from './ast.js';
 import type { WardenDiagnostic, WardenRule } from './types.js';
 
 export const noThrowInImplementation: WardenRule = {
@@ -18,7 +20,7 @@ export const noThrowInImplementation: WardenRule = {
     const diagnostics: WardenDiagnostic[] = [];
 
     for (const body of findBlazeBodies(ast)) {
-      walk(body, (node) => {
+      walkScope(body, (node) => {
         if (node.type === 'ThrowStatement') {
           diagnostics.push({
             filePath,


### PR DESCRIPTION
## Summary

`no-throw-in-implementation` walked blaze bodies with `walk()`, which descends into nested callback bodies. A `throw` inside `.map()`, `.filter()`, or any function expression nested in the blaze got flagged as an implementation throw — the exact class of false positive ADR-0007 claimed scope-aware walking had already solved. This PR swaps the rule to `walkScope`, which stops at function boundaries, so only throws in the blaze body itself surface. Direct throws at the blaze top level still flag as before.

## What changed

- `packages/warden/src/rules/no-throw-in-implementation.ts` now imports `walkScope` from `./ast.js` and uses it instead of `walk()`. The rule's name, severity, and `check()` signature are unchanged.
- TSDoc on the rule now references ADR-0007 and the scope-aware requirement so future readers understand why `walkScope` is the right primitive here.
- New dedicated test file `packages/warden/src/__tests__/no-throw-in-implementation.test.ts` covers: direct throw (flags), `Result.err` (allowed), `.map()` callback throw (no longer flags — the repro from the issue), `.filter()` callback throw, nested function-declaration throw, and a mixed case with an inner-safe callback throw plus an outer blaze-body throw that still flags.

## Verification

- `bun test packages/warden` — 600 pass, 0 fail.
- `bun run typecheck` — 31/31 green.
- `bunx ultracite check` — clean on both touched files.

## Issues

Closes: TRL-355
