### PR TITLE
fix(warden): resolve default and namespace contour imports

### DIFF
--- a/packages/warden/src/__tests__/circular-refs.test.ts
+++ b/packages/warden/src/__tests__/circular-refs.test.ts
@@ -95,4 +95,27 @@ const gist = contour('gist', {
     expect(diagnostics[0]?.rule).toBe('circular-refs');
     expect(diagnostics[0]?.message).toContain('user -> gist -> user');
   });
+
+  test('warns on local cycles formed through namespace-imported references', () => {
+    const code = `
+import { contour } from '@ontrails/core';
+import * as contours from './contours';
+
+const user = contour('user', {
+  id: 'x',
+  gistId: contours.gist.id(),
+}, { identity: 'id' });
+
+const gist = contour('gist', {
+  id: 'x',
+  ownerId: contours.user.id(),
+}, { identity: 'id' });
+`;
+
+    const diagnostics = circularRefs.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics[0]?.rule).toBe('circular-refs');
+    expect(diagnostics[0]?.message).toContain('user -> gist -> user');
+  });
 });

--- a/packages/warden/src/__tests__/contour-exists.test.ts
+++ b/packages/warden/src/__tests__/contour-exists.test.ts
@@ -5,8 +5,9 @@ import { contourExists } from '../rules/contour-exists.js';
 const TEST_FILE = 'entity.ts';
 
 describe('contour-exists', () => {
-  test('passes when a locally declared contour exists', () => {
-    const code = `
+  describe('local declarations', () => {
+    test('passes when a locally declared contour exists', () => {
+      const code = `
 import { Result, contour, trail } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -20,11 +21,36 @@ trail('user.create', {
 });
 `;
 
-    expect(contourExists.check(code, TEST_FILE)).toEqual([]);
+      expect(contourExists.check(code, TEST_FILE)).toEqual([]);
+    });
+
+    test('keeps local contour declarations when project context is present', () => {
+      const code = `
+import { Result, contour, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  id: z.string().uuid(),
+}, { identity: 'id' });
+
+trail('user.create', {
+  contours: [user],
+  blaze: async () => Result.ok({ ok: true }),
+});
+`;
+
+      expect(
+        contourExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set<string>(),
+          knownTrailIds: new Set(['user.create']),
+        })
+      ).toEqual([]);
+    });
   });
 
-  test('flags a missing contour declaration', () => {
-    const code = `
+  describe('named imports', () => {
+    test('flags a missing contour declaration', () => {
+      const code = `
 import { Result, trail } from '@ontrails/core';
 import { user } from './contours';
 
@@ -34,18 +60,18 @@ trail('user.create', {
 });
 `;
 
-    const diagnostics = contourExists.checkWithContext(code, TEST_FILE, {
-      knownContourIds: new Set<string>(),
-      knownTrailIds: new Set(['user.create']),
+      const diagnostics = contourExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set<string>(),
+        knownTrailIds: new Set(['user.create']),
+      });
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.rule).toBe('contour-exists');
+      expect(diagnostics[0]?.message).toContain('user');
     });
 
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.rule).toBe('contour-exists');
-    expect(diagnostics[0]?.message).toContain('user');
-  });
-
-  test('resolves aliased imports to the original contour name', () => {
-    const code = `
+    test('resolves aliased imports to the original contour name', () => {
+      const code = `
 import { Result, trail } from '@ontrails/core';
 import { user as userModel } from './contours';
 
@@ -55,16 +81,16 @@ trail('user.create', {
 });
 `;
 
-    expect(
-      contourExists.checkWithContext(code, TEST_FILE, {
-        knownContourIds: new Set(['user']),
-        knownTrailIds: new Set(['user.create']),
-      })
-    ).toEqual([]);
-  });
+      expect(
+        contourExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set(['user']),
+          knownTrailIds: new Set(['user.create']),
+        })
+      ).toEqual([]);
+    });
 
-  test('passes when project context includes an imported contour', () => {
-    const code = `
+    test('passes when project context includes an imported contour', () => {
+      const code = `
 import { Result, trail } from '@ontrails/core';
 import { user } from './contours';
 
@@ -74,34 +100,77 @@ trail('user.create', {
 });
 `;
 
-    expect(
-      contourExists.checkWithContext(code, TEST_FILE, {
-        knownContourIds: new Set(['user']),
-        knownTrailIds: new Set(['user.create']),
-      })
-    ).toEqual([]);
+      expect(
+        contourExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set(['user']),
+          knownTrailIds: new Set(['user.create']),
+        })
+      ).toEqual([]);
+    });
   });
 
-  test('keeps local contour declarations when project context is present', () => {
-    const code = `
-import { Result, contour, trail } from '@ontrails/core';
-import { z } from 'zod';
-
-const user = contour('user', {
-  id: z.string().uuid(),
-}, { identity: 'id' });
+  describe('default imports', () => {
+    test('flags missing default-imported contour declarations', () => {
+      const code = `
+import { Result, trail } from '@ontrails/core';
+import userModel from './contours';
 
 trail('user.create', {
-  contours: [user],
+  contours: [userModel],
   blaze: async () => Result.ok({ ok: true }),
 });
 `;
 
-    expect(
-      contourExists.checkWithContext(code, TEST_FILE, {
+      const diagnostics = contourExists.checkWithContext(code, TEST_FILE, {
         knownContourIds: new Set<string>(),
         knownTrailIds: new Set(['user.create']),
-      })
-    ).toEqual([]);
+      });
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.rule).toBe('contour-exists');
+      expect(diagnostics[0]?.message).toContain('userModel');
+    });
+  });
+
+  describe('namespace imports', () => {
+    test('flags missing namespace-imported contour declarations', () => {
+      const code = `
+import { Result, trail } from '@ontrails/core';
+import * as contours from './contours';
+
+trail('user.create', {
+  contours: [contours.user],
+  blaze: async () => Result.ok({ ok: true }),
+});
+`;
+
+      const diagnostics = contourExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set<string>(),
+        knownTrailIds: new Set(['user.create']),
+      });
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.rule).toBe('contour-exists');
+      expect(diagnostics[0]?.message).toContain('user');
+    });
+
+    test('resolves namespace-imported contour declarations when known', () => {
+      const code = `
+import { Result, trail } from '@ontrails/core';
+import * as contours from './contours';
+
+trail('user.create', {
+  contours: [contours.user],
+  blaze: async () => Result.ok({ ok: true }),
+});
+`;
+
+      expect(
+        contourExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set(['user']),
+          knownTrailIds: new Set(['user.create']),
+        })
+      ).toEqual([]);
+    });
   });
 });

--- a/packages/warden/src/__tests__/reference-exists.test.ts
+++ b/packages/warden/src/__tests__/reference-exists.test.ts
@@ -5,8 +5,9 @@ import { referenceExists } from '../rules/reference-exists.js';
 const TEST_FILE = 'contours.ts';
 
 describe('reference-exists', () => {
-  test('passes when a local contour reference exists', () => {
-    const code = `
+  describe('local references', () => {
+    test('passes when a local contour reference exists', () => {
+      const code = `
 import { contour } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -20,11 +21,36 @@ const gist = contour('gist', {
 }, { identity: 'id' });
 `;
 
-    expect(referenceExists.check(code, TEST_FILE)).toEqual([]);
+      expect(referenceExists.check(code, TEST_FILE)).toEqual([]);
+    });
+
+    test('keeps local contour definitions when project context is present', () => {
+      const code = `
+import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+const user = contour('user', {
+  id: z.string().uuid(),
+}, { identity: 'id' });
+
+const gist = contour('gist', {
+  id: z.string().uuid(),
+  ownerId: user.id(),
+}, { identity: 'id' });
+`;
+
+      expect(
+        referenceExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set(['gist']),
+          knownTrailIds: new Set<string>(),
+        })
+      ).toEqual([]);
+    });
   });
 
-  test('flags a missing contour reference target', () => {
-    const code = `
+  describe('named imports', () => {
+    test('flags a missing contour reference target', () => {
+      const code = `
 import { contour } from '@ontrails/core';
 import { z } from 'zod';
 import { user } from './user';
@@ -35,18 +61,18 @@ const gist = contour('gist', {
 }, { identity: 'id' });
 `;
 
-    const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
-      knownContourIds: new Set(['gist']),
-      knownTrailIds: new Set<string>(),
+      const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set(['gist']),
+        knownTrailIds: new Set<string>(),
+      });
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.rule).toBe('reference-exists');
+      expect(diagnostics[0]?.message).toContain('user');
     });
 
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.rule).toBe('reference-exists');
-    expect(diagnostics[0]?.message).toContain('user');
-  });
-
-  test('resolves aliased imports to the original contour id', () => {
-    const code = `
+    test('resolves aliased imports to the original contour id', () => {
+      const code = `
 import { contour } from '@ontrails/core';
 import { z } from 'zod';
 import { user as userModel } from './user';
@@ -57,16 +83,16 @@ const gist = contour('gist', {
 }, { identity: 'id' });
 `;
 
-    const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
-      knownContourIds: new Set(['gist', 'user']),
-      knownTrailIds: new Set<string>(),
+      const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set(['gist', 'user']),
+        knownTrailIds: new Set<string>(),
+      });
+
+      expect(diagnostics).toEqual([]);
     });
 
-    expect(diagnostics).toEqual([]);
-  });
-
-  test('passes when project context includes an imported contour', () => {
-    const code = `
+    test('passes when project context includes an imported contour', () => {
+      const code = `
 import { contour } from '@ontrails/core';
 import { z } from 'zod';
 import { user } from './user';
@@ -77,35 +103,16 @@ const gist = contour('gist', {
 }, { identity: 'id' });
 `;
 
-    expect(
-      referenceExists.checkWithContext(code, TEST_FILE, {
-        knownContourIds: new Set(['gist', 'user']),
-        knownTrailIds: new Set<string>(),
-      })
-    ).toEqual([]);
-  });
+      expect(
+        referenceExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set(['gist', 'user']),
+          knownTrailIds: new Set<string>(),
+        })
+      ).toEqual([]);
+    });
 
-  test('keeps namespaced inline contour definitions when project context is present', () => {
-    const code = `
-import * as core from '@ontrails/core';
-import { z } from 'zod';
-
-const gist = core.contour('gist', {
-  id: z.string().uuid(),
-  ownerId: core.contour('user', { id: z.string().uuid() }).id(),
-}, { identity: 'id' });
-`;
-
-    expect(
-      referenceExists.checkWithContext(code, TEST_FILE, {
-        knownContourIds: new Set(['gist']),
-        knownTrailIds: new Set<string>(),
-      })
-    ).toEqual([]);
-  });
-
-  test('flags a missing wrapped contour reference target', () => {
-    const code = `
+    test('flags a missing wrapped contour reference target', () => {
+      const code = `
 import { contour } from '@ontrails/core';
 import { z } from 'zod';
 import { user } from './user';
@@ -116,36 +123,135 @@ const gist = contour('gist', {
 }, { identity: 'id' });
 `;
 
-    const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
-      knownContourIds: new Set(['gist']),
-      knownTrailIds: new Set<string>(),
-    });
+      const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set(['gist']),
+        knownTrailIds: new Set<string>(),
+      });
 
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.rule).toBe('reference-exists');
-    expect(diagnostics[0]?.message).toContain('user');
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.rule).toBe('reference-exists');
+      expect(diagnostics[0]?.message).toContain('user');
+    });
   });
 
-  test('keeps local contour definitions when project context is present', () => {
-    const code = `
+  describe('default imports', () => {
+    test('flags missing default-imported contour references', () => {
+      const code = `
 import { contour } from '@ontrails/core';
-import { z } from 'zod';
-
-const user = contour('user', {
-  id: z.string().uuid(),
-}, { identity: 'id' });
+import userModel from './user';
 
 const gist = contour('gist', {
-  id: z.string().uuid(),
+  id: 'x',
+  ownerId: userModel.id(),
+}, { identity: 'id' });
+`;
+
+      const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
+        knownContourIds: new Set(['gist']),
+        knownTrailIds: new Set<string>(),
+      });
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.rule).toBe('reference-exists');
+      expect(diagnostics[0]?.message).toContain('userModel');
+    });
+
+    test('resolves default-imported contour references when known', () => {
+      const code = `
+import { contour } from '@ontrails/core';
+import user from './user';
+
+const gist = contour('gist', {
+  id: 'x',
   ownerId: user.id(),
 }, { identity: 'id' });
 `;
 
-    expect(
-      referenceExists.checkWithContext(code, TEST_FILE, {
+      expect(
+        referenceExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set(['gist', 'user']),
+          knownTrailIds: new Set<string>(),
+        })
+      ).toEqual([]);
+    });
+  });
+
+  describe('namespace imports', () => {
+    test('keeps namespaced inline contour definitions when project context is present', () => {
+      const code = `
+import * as core from '@ontrails/core';
+import { z } from 'zod';
+
+const gist = core.contour('gist', {
+  id: z.string().uuid(),
+  ownerId: core.contour('user', { id: z.string().uuid() }).id(),
+}, { identity: 'id' });
+`;
+
+      expect(
+        referenceExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set(['gist']),
+          knownTrailIds: new Set<string>(),
+        })
+      ).toEqual([]);
+    });
+
+    test('flags missing namespace-imported contour references', () => {
+      const code = `
+import { contour } from '@ontrails/core';
+import * as contours from './contours';
+
+const gist = contour('gist', {
+  id: 'x',
+  ownerId: contours.user.id(),
+}, { identity: 'id' });
+`;
+
+      const diagnostics = referenceExists.checkWithContext(code, TEST_FILE, {
         knownContourIds: new Set(['gist']),
         knownTrailIds: new Set<string>(),
-      })
-    ).toEqual([]);
+      });
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.rule).toBe('reference-exists');
+      expect(diagnostics[0]?.message).toContain('user');
+    });
+
+    test('resolves namespace-imported contour references when known', () => {
+      const code = `
+import { contour } from '@ontrails/core';
+import * as contours from './contours';
+
+const gist = contour('gist', {
+  id: 'x',
+  ownerId: contours.user.id(),
+}, { identity: 'id' });
+`;
+
+      expect(
+        referenceExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set(['gist', 'user']),
+          knownTrailIds: new Set<string>(),
+        })
+      ).toEqual([]);
+    });
+
+    test('does not flag namespace imports from @ontrails sources', () => {
+      const code = `
+import * as core from '@ontrails/core';
+
+const gist = core.contour('gist', {
+  id: 'x',
+  ownerId: core.contour('user', { id: 'y' }).id(),
+}, { identity: 'id' });
+`;
+
+      expect(
+        referenceExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set(['gist']),
+          knownTrailIds: new Set<string>(),
+        })
+      ).toEqual([]);
+    });
   });
 });

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -1638,30 +1638,55 @@ export const collectNamedContourIds = (
   return ids;
 };
 
+const resolveNamedImportedName = (
+  specifier: AstNode,
+  localName: string
+): string => {
+  const { imported } = specifier as unknown as { imported?: AstNode };
+  const importedName = imported
+    ? (identifierName(imported) ?? extractStringLiteral(imported))
+    : null;
+  return importedName ?? localName;
+};
+
 const extractImportSpecifierAlias = (
   specifier: AstNode
 ): { readonly localName: string; readonly importedName: string } | null => {
-  if (specifier.type !== 'ImportSpecifier') {
+  if (
+    specifier.type !== 'ImportSpecifier' &&
+    specifier.type !== 'ImportDefaultSpecifier'
+  ) {
     return null;
   }
 
-  const { imported } = specifier as unknown as { imported?: AstNode };
   const { local } = specifier as unknown as { local?: AstNode };
   const localName = identifierName(local);
   if (!localName) {
     return null;
   }
 
-  const importedName = imported
-    ? (identifierName(imported) ?? extractStringLiteral(imported))
-    : null;
-  return { importedName: importedName ?? localName, localName };
+  // Default imports bind the default export of the source module to the local
+  // name. We cannot statically recover the exported name without cross-file
+  // analysis, so the local name is the best identifier we have for resolving
+  // against `knownContourIds`. Treat the alias as an identity mapping; the
+  // downstream resolver will fall through to `knownContourIds` on the binding
+  // name and report it as missing when not found.
+  if (specifier.type === 'ImportDefaultSpecifier') {
+    return { importedName: localName, localName };
+  }
+
+  return {
+    importedName: resolveNamedImportedName(specifier, localName),
+    localName,
+  };
 };
 
 /**
- * Collect `import { foo as bar } from '...'` specifier mappings keyed by
- * local binding name. The value is the original exported name. Bindings
- * without an alias map to themselves.
+ * Collect `import { foo as bar } from '...'` and `import bar from '...'`
+ * specifier mappings keyed by local binding name. The value is the original
+ * exported name for named imports. Default imports map to themselves because
+ * the exported name cannot be recovered statically — callers should fall
+ * through to `knownContourIds` membership on the local binding name.
  */
 export const collectImportAliasMap = (
   ast: AstNode
@@ -1684,6 +1709,55 @@ export const collectImportAliasMap = (
   });
 
   return aliases;
+};
+
+const addUserNamespaceBindingsFromDeclaration = (
+  node: AstNode,
+  into: Set<string>
+): void => {
+  if (isFrameworkNamespaceSource(getImportSourceValue(node))) {
+    return;
+  }
+  const specifiers =
+    (node['specifiers'] as readonly AstNode[] | undefined) ?? [];
+  for (const specifier of specifiers) {
+    if (specifier.type !== 'ImportNamespaceSpecifier') {
+      continue;
+    }
+    const { local } = specifier as unknown as { local?: AstNode };
+    const localName = identifierName(local);
+    if (localName) {
+      into.add(localName);
+    }
+  }
+};
+
+/**
+ * Collect local binding names introduced by `import * as <name> from '<src>'`
+ * declarations whose source is NOT an `@ontrails/*` framework package. These
+ * are user-defined namespace imports of contour modules (e.g. `import * as
+ * contours from './contours'`), used to resolve `contours.user` member-access
+ * references to contour ids.
+ *
+ * Framework namespace imports (`import * as core from '@ontrails/core'`) are
+ * intentionally excluded — they carry framework primitives like
+ * `core.contour(...)` and are resolved by {@link buildFrameworkNamespaceContext}.
+ * Mixing them here would treat `core.contour` as a reference to a contour
+ * named "contour", producing false positives.
+ */
+export const collectUserNamespaceImportBindings = (
+  ast: AstNode
+): ReadonlySet<string> => {
+  const bindings = new Set<string>();
+
+  walk(ast, (node) => {
+    if (node.type !== 'ImportDeclaration') {
+      return;
+    }
+    addUserNamespaceBindingsFromDeclaration(node, bindings);
+  });
+
+  return bindings;
 };
 
 export interface ContourReferenceSite {
@@ -1805,12 +1879,42 @@ const getContourReferenceMember = (
   };
 };
 
+/**
+ * Resolve a user-namespace member access like `contours.user` to its contour
+ * id. Returns the property name (e.g. `'user'`) when the receiver identifier
+ * is a known user-defined namespace binding, otherwise `null`.
+ *
+ * The property name is taken as the contour id verbatim — we cannot statically
+ * resolve what `contours.user` binds to without reading the other file, so we
+ * treat the member name as the candidate target and let
+ * {@link deriveContourIdentifierName}'s downstream `knownContourIds` check
+ * report a missing target.
+ */
+const getContourReferenceTargetFromNamespaceMember = (
+  member: { readonly object?: AstNode; readonly property?: AstNode },
+  userNamespaceBindings?: ReadonlySet<string>
+): string | null => {
+  if (!userNamespaceBindings || userNamespaceBindings.size === 0) {
+    return null;
+  }
+  const receiver = member.object ? identifierName(member.object) : null;
+  if (!receiver || !userNamespaceBindings.has(receiver)) {
+    return null;
+  }
+  const { property } = member;
+  if (!property || property.type !== 'Identifier') {
+    return null;
+  }
+  return identifierName(property);
+};
+
 const getContourReferenceTargetFromObject = (
   object: AstNode,
   namedContourIds: ReadonlyMap<string, string>,
   knownContourIds?: ReadonlySet<string>,
   importAliases?: ReadonlyMap<string, string>,
-  context?: ReadonlySet<string> | FrameworkNamespaceContext
+  context?: ReadonlySet<string> | FrameworkNamespaceContext,
+  userNamespaceBindings?: ReadonlySet<string>
 ): string | null => {
   if (object.type === 'Identifier') {
     const bindingName = identifierName(object);
@@ -1822,6 +1926,17 @@ const getContourReferenceTargetFromObject = (
           importAliases
         )
       : null;
+  }
+
+  const member = getContourReferenceMember(object);
+  if (member) {
+    const namespaceTarget = getContourReferenceTargetFromNamespaceMember(
+      member,
+      userNamespaceBindings
+    );
+    if (namespaceTarget) {
+      return namespaceTarget;
+    }
   }
 
   return extractContourDefinition(object, context)?.name ?? null;
@@ -1877,7 +1992,8 @@ const extractContourReferenceTarget = (
   namedContourIds: ReadonlyMap<string, string>,
   knownContourIds?: ReadonlySet<string>,
   importAliases?: ReadonlyMap<string, string>,
-  context?: ReadonlySet<string> | FrameworkNamespaceContext
+  context?: ReadonlySet<string> | FrameworkNamespaceContext,
+  userNamespaceBindings?: ReadonlySet<string>
 ): string | null => {
   const object = getContourIdCallObject(node);
   return object
@@ -1886,7 +2002,8 @@ const extractContourReferenceTarget = (
         namedContourIds,
         knownContourIds,
         importAliases,
-        context
+        context,
+        userNamespaceBindings
       )
     : null;
 };
@@ -1902,7 +2019,8 @@ const buildContourReferenceSite = (
   namedContourIds: ReadonlyMap<string, string>,
   knownContourIds?: ReadonlySet<string>,
   importAliases?: ReadonlyMap<string, string>,
-  context?: ReadonlySet<string> | FrameworkNamespaceContext
+  context?: ReadonlySet<string> | FrameworkNamespaceContext,
+  userNamespaceBindings?: ReadonlySet<string>
 ): ContourReferenceSite | null => {
   if (property.type !== 'Property') {
     return null;
@@ -1914,7 +2032,8 @@ const buildContourReferenceSite = (
     namedContourIds,
     knownContourIds,
     importAliases,
-    context
+    context,
+    userNamespaceBindings
   );
   if (!field || !target) {
     return null;
@@ -1933,7 +2052,8 @@ const findContourReferenceSitesForDefinition = (
   namedContourIds: ReadonlyMap<string, string>,
   knownContourIds?: ReadonlySet<string>,
   importAliases?: ReadonlyMap<string, string>,
-  context?: ReadonlySet<string> | FrameworkNamespaceContext
+  context?: ReadonlySet<string> | FrameworkNamespaceContext,
+  userNamespaceBindings?: ReadonlySet<string>
 ): readonly ContourReferenceSite[] =>
   getContourShapeProperties(definition).flatMap((property) => {
     const reference = buildContourReferenceSite(
@@ -1942,7 +2062,8 @@ const findContourReferenceSitesForDefinition = (
       namedContourIds,
       knownContourIds,
       importAliases,
-      context
+      context,
+      userNamespaceBindings
     );
     return reference ? [reference] : [];
   });
@@ -1954,6 +2075,7 @@ export const collectContourReferenceSites = (
 ): readonly ContourReferenceSite[] => {
   const namedContourIds = collectNamedContourIds(ast);
   const importAliases = collectImportAliasMap(ast);
+  const userNamespaceBindings = collectUserNamespaceImportBindings(ast);
   const context = buildFrameworkNamespaceContext(ast);
   return findContourDefinitions(ast, context).flatMap((definition) =>
     findContourReferenceSitesForDefinition(
@@ -1961,7 +2083,8 @@ export const collectContourReferenceSites = (
       namedContourIds,
       knownContourIds,
       importAliases,
-      context
+      context,
+      userNamespaceBindings
     )
   );
 };

--- a/packages/warden/src/rules/contour-exists.ts
+++ b/packages/warden/src/rules/contour-exists.ts
@@ -2,6 +2,7 @@ import {
   collectContourDefinitionIds,
   collectImportAliasMap,
   collectNamedContourIds,
+  collectUserNamespaceImportBindings,
   extractFirstStringArg,
   findConfigProperty,
   findTrailDefinitions,
@@ -41,11 +42,36 @@ const getContourElements = (config: AstNode): readonly AstNode[] => {
   return elements ?? [];
 };
 
+const resolveNamespaceMemberContourName = (
+  element: AstNode,
+  userNamespaceBindings: ReadonlySet<string>
+): string | null => {
+  if (
+    element.type !== 'MemberExpression' &&
+    element.type !== 'StaticMemberExpression'
+  ) {
+    return null;
+  }
+  if ((element as unknown as { computed?: boolean }).computed === true) {
+    return null;
+  }
+  const { object, property } = element as unknown as {
+    readonly object?: AstNode;
+    readonly property?: AstNode;
+  };
+  const receiver = object ? identifierName(object) : null;
+  if (!receiver || !userNamespaceBindings.has(receiver)) {
+    return null;
+  }
+  return property ? identifierName(property) : null;
+};
+
 const resolveDeclaredContourName = (
   element: AstNode,
   contourIdsByName: ReadonlyMap<string, string>,
   knownContourIds?: ReadonlySet<string>,
-  importAliases?: ReadonlyMap<string, string>
+  importAliases?: ReadonlyMap<string, string>,
+  userNamespaceBindings?: ReadonlySet<string>
 ): string | null => {
   if (element.type === 'Identifier') {
     const name = identifierName(element);
@@ -59,6 +85,16 @@ const resolveDeclaredContourName = (
       : null;
   }
 
+  if (userNamespaceBindings && userNamespaceBindings.size > 0) {
+    const namespaceTarget = resolveNamespaceMemberContourName(
+      element,
+      userNamespaceBindings
+    );
+    if (namespaceTarget) {
+      return namespaceTarget;
+    }
+  }
+
   return isContourCall(element) ? extractFirstStringArg(element) : null;
 };
 
@@ -66,7 +102,8 @@ const extractDeclaredContourNames = (
   config: AstNode,
   contourIdsByName: ReadonlyMap<string, string>,
   knownContourIds?: ReadonlySet<string>,
-  importAliases?: ReadonlyMap<string, string>
+  importAliases?: ReadonlyMap<string, string>,
+  userNamespaceBindings?: ReadonlySet<string>
 ): readonly string[] => [
   ...new Set(
     getContourElements(config).flatMap((element) => {
@@ -74,7 +111,8 @@ const extractDeclaredContourNames = (
         element,
         contourIdsByName,
         knownContourIds,
-        importAliases
+        importAliases,
+        userNamespaceBindings
       );
       return contourName ? [contourName] : [];
     })
@@ -100,7 +138,8 @@ const buildDiagnosticsForDefinition = (
   filePath: string,
   knownContourIds: ReadonlySet<string>,
   contourIdsByName: ReadonlyMap<string, string>,
-  importAliases: ReadonlyMap<string, string>
+  importAliases: ReadonlyMap<string, string>,
+  userNamespaceBindings: ReadonlySet<string>
 ): readonly WardenDiagnostic[] => {
   if (definition.kind !== 'trail') {
     return [];
@@ -111,7 +150,8 @@ const buildDiagnosticsForDefinition = (
     definition.config,
     contourIdsByName,
     knownContourIds,
-    importAliases
+    importAliases,
+    userNamespaceBindings
   ).flatMap((contourName) =>
     knownContourIds.has(contourName)
       ? []
@@ -134,6 +174,7 @@ const buildContourDiagnostics = (
 ): readonly WardenDiagnostic[] => {
   const contourIdsByName = collectNamedContourIds(ast);
   const importAliases = collectImportAliasMap(ast);
+  const userNamespaceBindings = collectUserNamespaceImportBindings(ast);
 
   return findTrailDefinitions(ast).flatMap((definition) =>
     buildDiagnosticsForDefinition(
@@ -142,7 +183,8 @@ const buildContourDiagnostics = (
       filePath,
       knownContourIds,
       contourIdsByName,
-      importAliases
+      importAliases,
+      userNamespaceBindings
     )
   );
 };


### PR DESCRIPTION
## Summary

Contour-aware warden rules (`reference-exists`, `contour-exists`, `circular-refs`) only resolved bare identifiers and inline `contour(...)` calls. Valid TypeScript module patterns — default imports (`import userModel from './user'`) and namespace imports (`import * as contours from './contours'; contours.user.id()`) — went silently unresolved, producing false negatives exactly where project-aware checks matter most. This PR broadens the shared contour resolution helpers so all four issue repros now flag correctly, without changing the resolution contract for existing identifier and inline-contour shapes.

## What changed

- **`collectImportAliasMap`** now consumes `ImportDefaultSpecifier` alongside named specifiers, registering an identity alias for the default binding. Existing `deriveContourIdentifierName` resolution then surfaces missing defaults under their binding name via `knownContourIds`.
- **New `collectUserNamespaceImportBindings`** records local names from `import * as X from '<non-@ontrails source>'` so member access on those bindings can be resolved. The `@ontrails/*` framework-namespace case is deliberately excluded so `core.contour(...)` is never misread as a reference to a contour named `contour`.
- **`getContourReferenceTargetFromObject`** (and the companion `resolveNamespaceMemberContourName` in `contour-exists`) now resolve non-computed `MemberExpression` receivers that sit in the user-namespace set. The property name becomes the contour id target; `knownContourIds` remains the authority on whether it exists. Computed access (`contours['user']`) is rejected — we can't prove the target statically.
- **`contour-exists` threads `userNamespaceBindings`** through `resolveDeclaredContourName` → `extractDeclaredContourNames` → `buildDiagnosticsForDefinition` so `trail('...', { contours: [contours.user] })` metadata resolves the namespaced element.
- **`reference-exists` and `circular-refs` need no rule-side changes** — they consume `collectContourReferenceSites` / `collectContourReferenceTargetsByName`, which pick up the new resolution automatically.
- Regression tests for all four issue repros plus a framework-namespace exclusion guard.

## Verification

- `bun test packages/warden` — 609 pass, 0 fail.
- `bun run typecheck` — 31/31 green.
- `bunx ultracite check` — clean on all seven touched files.

## Issues

Closes: TRL-353
