### PR TITLE
docs(warden): document findContourDefinitions inline-discovery + add topLevelOnly flag

### DIFF
--- a/packages/warden/src/__tests__/ast.test.ts
+++ b/packages/warden/src/__tests__/ast.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   __collectFrameworkNamespaceBindingsForTest,
+  collectContourDefinitionIds,
   collectContourReferenceSites,
+  collectNamedContourIds,
   __getTrailCalleeNameForTest,
   deriveContourIdentifierName,
   findContourDefinitions,
@@ -434,6 +436,66 @@ describe('findContourDefinitions with namespaced callees', () => {
     `;
     const ast = parseOrThrow(source);
     expect(findContourDefinitions(ast)).toHaveLength(0);
+  });
+});
+
+describe('findContourDefinitions inline discovery', () => {
+  // Regression: `findContourDefinitions` descends into nested object
+  // expressions and surfaces inline `core.contour('inner', ...)` calls as
+  // definitions alongside the outer binding. This behavior is load-bearing for
+  // reference-site resolution (see `collectContourReferenceSites`) and must
+  // not silently regress.
+  const inlineSource = `
+      import * as core from '@ontrails/core';
+      import { z } from 'zod';
+
+      export const outer = core.contour('outer', {
+        id: z.string().uuid(),
+        inner: core.contour('inner', { id: z.string().uuid() }).id(),
+      });
+    `;
+
+  test('returns both outer and inline contour definitions by default', () => {
+    const ast = parseOrThrow(inlineSource);
+    const defs = findContourDefinitions(ast);
+
+    expect(defs).toHaveLength(2);
+    const names = defs.map((d) => d.name).toSorted();
+    expect(names).toEqual(['inner', 'outer']);
+
+    const outer = defs.find((d) => d.name === 'outer');
+    const inner = defs.find((d) => d.name === 'inner');
+    expect(outer?.bindingName).toBe('outer');
+    // Inline contours are anonymous call expressions — no binding name.
+    expect(inner?.bindingName).toBeUndefined();
+  });
+
+  test('collectContourDefinitionIds includes inline contour ids', () => {
+    const ast = parseOrThrow(inlineSource);
+    const ids = collectContourDefinitionIds(ast);
+
+    expect(ids.has('outer')).toBe(true);
+    expect(ids.has('inner')).toBe(true);
+  });
+
+  test('collectNamedContourIds excludes inline contours (no bindingName)', () => {
+    const ast = parseOrThrow(inlineSource);
+    const named = collectNamedContourIds(ast);
+
+    expect([...named.keys()].toSorted()).toEqual(['outer']);
+    expect(named.get('outer')).toBe('outer');
+    expect(named.has('inner')).toBe(false);
+  });
+
+  test('topLevelOnly: true skips inline contour discovery', () => {
+    const ast = parseOrThrow(inlineSource);
+    const defs = findContourDefinitions(ast, undefined, {
+      topLevelOnly: true,
+    });
+
+    expect(defs).toHaveLength(1);
+    expect(defs[0]?.name).toBe('outer');
+    expect(defs[0]?.bindingName).toBe('outer');
   });
 });
 

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -1554,18 +1554,46 @@ const extractContourDefinition = (
   };
 };
 
+export interface FindContourDefinitionsOptions {
+  /**
+   * When true, skip contour calls nested inside other expressions (e.g.
+   * `core.contour('inner', {...}).id()` used as a field of an outer contour).
+   * Only top-level declarations and statements surface as definitions.
+   *
+   * Defaults to `false`: both top-level and inline contours are returned so
+   * that reference-site resolution can reach anonymous inline contours.
+   */
+  readonly topLevelOnly?: boolean;
+}
+
+/**
+ * Return every `contour('name', ...)` definition reachable from the AST, in
+ * source order, deduplicated by call-expression start offset.
+ *
+ * Includes both top-level bindings (`const user = contour('user', ...)`) and
+ * inline contour calls nested inside other expressions (e.g.
+ * `contour('outer', { inner: contour('inner', ...).id() })`). Inline contours
+ * carry no `bindingName` because they have no local binding — this asymmetry
+ * is why {@link collectNamedContourIds} returns only the top-level subset
+ * while {@link collectContourDefinitionIds} returns the full set.
+ *
+ * Pass `{ topLevelOnly: true }` via `options` to opt out of inline discovery
+ * without disturbing callers that rely on the default behavior.
+ *
+ * @remarks
+ * Supplying a pre-built `context` skips the second full-AST traversal inside
+ * `buildFrameworkNamespaceContext` — useful for callers (such as
+ * {@link collectContourReferenceSites}) that already built one.
+ */
 export const findContourDefinitions = (
   ast: AstNode,
-  /**
-   * Optional pre-built namespace context. When provided, the second full-AST
-   * traversal inside `buildFrameworkNamespaceContext` is skipped — useful for
-   * callers (such as `collectContourReferenceSites`) that already built one.
-   */
-  context?: FrameworkNamespaceContext
+  context?: FrameworkNamespaceContext,
+  options?: FindContourDefinitionsOptions
 ): ContourDefinition[] => {
   const definitions: ContourDefinition[] = [];
   const seenStarts = new Set<number>();
   const resolvedContext = context ?? buildFrameworkNamespaceContext(ast);
+  const topLevelOnly = options?.topLevelOnly === true;
 
   const addContourDefinition = (definition: ContourDefinition): void => {
     if (seenStarts.has(definition.start)) {
@@ -1608,6 +1636,10 @@ export const findContourDefinitions = (
       return;
     }
 
+    if (topLevelOnly) {
+      return;
+    }
+
     const definition = extractContourDefinition(node, resolvedContext);
     if (definition) {
       addContourDefinition(definition);
@@ -1617,13 +1649,22 @@ export const findContourDefinitions = (
   return definitions.toSorted((left, right) => left.start - right.start);
 };
 
-/** Collect all inline `contour('name', ...)` definition names from a parsed file. */
+/**
+ * Collect the `name` of every contour definition in a parsed file, including
+ * inline contours nested inside other expressions. Returns the same set of
+ * names that {@link findContourDefinitions} discovers under default options.
+ */
 export const collectContourDefinitionIds = (
   ast: AstNode
 ): ReadonlySet<string> =>
   new Set(findContourDefinitions(ast).map((def) => def.name));
 
-/** Collect `const foo = contour('name', ...)` bindings from a parsed file. */
+/**
+ * Collect the `localBinding → contourName` map for `const foo = contour(...)`
+ * declarations. Inline contour calls are intentionally excluded because they
+ * have no local binding — use {@link collectContourDefinitionIds} when the
+ * full set of declared names is required.
+ */
 export const collectNamedContourIds = (
   ast: AstNode
 ): ReadonlyMap<string, string> => {


### PR DESCRIPTION
## Summary

Recent namespace-context work inside warden's AST layer made `findContourDefinitions` walk into nested object expressions and surface inline `core.contour('name', {...})` calls as top-level definitions. That change was intentional for reference-site resolution, but it was silent in TSDoc and had no regression test — a downstream rule assuming "only top-level bindings appear here" would be surprised. This PR documents the contract on three related helpers, adds tests pinning the current inline-discovery behavior, and introduces an opt-in `topLevelOnly` flag so callers that need stricter semantics have a surgical tool without rewriting the walker.

## What changed

- **TSDoc** on `findContourDefinitions`, `collectContourDefinitionIds`, and `collectNamedContourIds` now spells out the inline-inclusion rule and the `bindingName` asymmetry (inline contours have no `bindingName`, so they surface in `collectContourDefinitionIds` but are excluded from `collectNamedContourIds`).
- **New optional third parameter** `options?: { topLevelOnly?: boolean }` on `findContourDefinitions`. When `topLevelOnly: true`, the walker short-circuits before the fallback `extractContourDefinition` path that catches non-`VariableDeclarator` call expressions. Default remains `false` — no existing caller regresses, the flag is opt-in only. Positioned after the pre-existing `context` parameter so call-site arity is unchanged.
- **Four regression tests** in `packages/warden/src/__tests__/ast.test.ts` sharing one `inlineSource` fixture: outer + inner discovered by default, `collectContourDefinitionIds` includes both ids, `collectNamedContourIds` excludes the inline one, and `topLevelOnly: true` yields only the outer definition.

## Verification

- `bun test packages/warden` — 613 pass, 0 fail.
- `bun run typecheck` — 31/31 green.
- `bunx ultracite check` — clean on both touched files.

## Issues

Closes: TRL-362
