### PR TITLE
chore(repo): add per-package tsconfig.tests.json for LSP type-check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,8 @@ To exit pre-release mode for a stable release: `bunx changeset pre exit`, then v
 - Follow TDD when the work is substantial: red, green, refactor.
 - Trail examples are the happy-path tests. Add focused tests for edge cases, error paths, and integrations when examples are not enough.
 
+Each package's main `tsconfig.json` excludes test files so build output stays clean. A sibling `tsconfig.tests.json` includes them so editors' LSP can resolve tests (e.g. `Array.prototype.toSorted`). Neither affects the `tsc --noEmit` CI gate, which still uses the main config.
+
 ## Reference Docs
 
 - `docs/getting-started.md`

--- a/apps/trails-demo/tsconfig.tests.json
+++ b/apps/trails-demo/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["bun"]
+  },
+  "include": ["__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/apps/trails/tsconfig.tests.json
+++ b/apps/trails/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts", "__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/connectors/drizzle/tsconfig.tests.json
+++ b/connectors/drizzle/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/connectors/hono/tsconfig.tests.json
+++ b/connectors/hono/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/connectors/vite/tsconfig.tests.json
+++ b/connectors/vite/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/cli/tsconfig.tests.json
+++ b/packages/cli/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/config/tsconfig.tests.json
+++ b/packages/config/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/core/tsconfig.tests.json
+++ b/packages/core/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/http/tsconfig.tests.json
+++ b/packages/http/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/logging/tsconfig.tests.json
+++ b/packages/logging/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/logtape/tsconfig.tests.json
+++ b/packages/logtape/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/mcp/tsconfig.tests.json
+++ b/packages/mcp/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/permits/tsconfig.tests.json
+++ b/packages/permits/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/schema/tsconfig.tests.json
+++ b/packages/schema/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/store/tsconfig.tests.json
+++ b/packages/store/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/testing/tsconfig.tests.json
+++ b/packages/testing/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/tracing/tsconfig.tests.json
+++ b/packages/tracing/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/warden/tsconfig.tests.json
+++ b/packages/warden/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

Every package's main `tsconfig.json` excludes test files via `"exclude": ["**/__tests__/**", "**/*.test.ts", ...]` so declaration emit stays clean. That's correct for the `tsc --noEmit` CI gate and build output, but it means the language server has no project config to resolve test files against — it falls back to defaults that don't include the ES2023 lib pulled in by `target: ESNext` in the main config. The practical symptom is that `Array.prototype.toSorted` / `.toReversed` / `.toSpliced` / `.with` compile cleanly in source files but raise LSP diagnostics in test files. This PR adds a sibling `tsconfig.tests.json` per package so the LSP resolves tests against the project's real target and lib settings. CI still runs `tsc` against the main config, so the build contract is untouched.

## What changed

- **18 new `tsconfig.tests.json` files** across `packages/*` (13), `apps/trails` and `apps/trails-demo` (2), and `connectors/*` (3). Each extends the package's existing `tsconfig.json`, sets `noEmit: true`, pulls in bun types, and includes `src/**/*.test.ts` + `src/__tests__/**/*.ts` (or the app-specific layout). `apps/ci` is skipped because it has no tests.
- **`AGENTS.md`** gains a short note under the Testing section explaining the split — main config excludes tests so build output stays clean, the sibling tests config includes them so the LSP can resolve them, and neither affects the CI `tsc --noEmit` gate.

## Verification

- `bun run typecheck` — 31/31 green (unchanged, main configs untouched).
- `bun run test` — all packages green via turbo.
- `bunx tsc --project packages/warden/tsconfig.tests.json --noEmit` — zero ES2023 lib errors on canary packages (`warden`, `core`). Pre-existing latent test-file type issues are out of scope here.
- `bunx ultracite check` — clean on all 18 new configs and `AGENTS.md`.

## Issues

Closes: TRL-364
