### PR TITLE
fix(ci): make review-bot gate reactive to late artifacts

### DIFF
--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -1,8 +1,47 @@
+# Review Bot Gate
+#
+# Enforces that Greptile, Codex, and Devin have all posted on the current PR
+# revision (or been explicitly waived via `review-bot-na:` comment) before a
+# queue label (`queue:merge`, `queue:priority`, `queue:hotfix`) is allowed to
+# stick. If a required artifact is missing, the gate removes any queue labels
+# and fails the check.
+#
+# This workflow is intended to be a required check in main-branch protection.
+# Branch protection is not configured from code — repo maintainers must add
+# `Review Bot Gate / Review Bot Gate` to the required status checks list so
+# GitHub mergeability actually hinges on this gate rather than on advisory
+# label removal alone.
+#
+# Triggers cover label, code-push, and artifact events so the gate is reactive
+# to late-arriving bot reviews and waiver comments:
+#   - `pull_request` (labeled, reopened, synchronize, ready_for_review) picks
+#     up PR lifecycle changes and label additions.
+#   - `issue_comment` (created, edited) picks up late waiver and bot comments.
+#   - `pull_request_review` (submitted, edited, dismissed) picks up late bot
+#     reviews and state changes.
+#
+# Manual test scenarios (no unit tests — this is the regression checklist):
+#   1. Apply a queue label before all bots have posted -> gate removes the
+#      label. Then have the missing bot post on the current revision -> the
+#      `issue_comment` or `pull_request_review` trigger re-runs the gate and
+#      label re-application is allowed.
+#   2. Apply a queue label before all bots have posted -> gate removes the
+#      label. Then a repo member posts `review-bot-na: <bot>` -> the
+#      `issue_comment` trigger re-runs the gate and label re-application is
+#      allowed.
+#   3. Greptile posts an error comment ("Greptile encountered an error while
+#      reviewing this PR") on the current revision -> gate blocks queue entry
+#      even if the other bots are satisfied.
+
 name: Review Bot Gate
 
 on:
   pull_request:
     types: [labeled, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
 
 permissions:
   contents: read
@@ -54,9 +93,26 @@ jobs:
             const waiverPattern =
               /review-bot-na:\s*([a-z]+(?:\s*,\s*[a-z]+)*)/gi;
 
-            const pullRequest = context.payload.pull_request;
+            // Event-shape adapter. `pull_request` and `pull_request_review`
+            // events ship the full PR object on the payload. `issue_comment`
+            // events only attach an `issue` (with a `pull_request` marker if
+            // the comment is on a PR) — we have to fetch the PR to get the
+            // same shape (labels, head ref, number). One extra REST call per
+            // PR comment is acceptable given the artifact-trigger frequency;
+            // the subsequent GraphQL pagination dominates the rate-limit
+            // footprint either way.
+            let pullRequest = context.payload.pull_request ?? null;
+            if (!pullRequest && context.payload.issue?.pull_request) {
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number,
+              });
+              pullRequest = data;
+            }
+
             if (!pullRequest) {
-              core.info('No pull request payload present.');
+              core.info('Not a pull request event; skipping.');
               return;
             }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ Use Graphite for source control operations.
 - Keep PRs small, isolate mechanical changes when possible, and keep PRs in draft until CI is green.
 - Graphite queue labels are the last step, not the start of review. Do not add `queue:merge`, `queue:priority`, or `queue:hotfix` until Greptile, Codex, and Devin have each posted on the current PR revision, or a repo member has explicitly waived the missing reviewer with `review-bot-na: <greptile|codex|devin>`.
 - Treat a Greptile error comment (`Greptile encountered an error while reviewing this PR`) as a blocker, not as a completed review.
+- The `Review Bot Gate` check (see `.github/workflows/review-bot-gate.yml`) enforces the reviewer-posting policy above. It is expected to be listed as a required check in `main` branch protection so GitHub mergeability actually hinges on it; repo maintainers must configure this in GitHub settings since branch protection is not managed from code.
 - When performing fixes across stacked branches, always do so from the top most branch and use `gt absorb -a`
 
 ## Subagent Rules


### PR DESCRIPTION
## Summary

The review-bot gate consumes bot reviews and waiver comments to decide mergeability, but only triggered on `pull_request` lifecycle events. A qualifying comment or review arriving after a queue label was applied did nothing — the gate never re-ran to pick it up. This PR makes the gate reactive to the very artifacts it consumes by adding `issue_comment` and `pull_request_review` triggers, and documents the policy that this workflow is intended to be a required check in main-branch protection (which is a GitHub setting, not a code change, so the PR calls that out rather than trying to configure it).

## What changed

- **`on:` section** extended from `pull_request` only to include `issue_comment: [created, edited]` and `pull_request_review: [submitted, edited, dismissed]`. Late-arriving comments and reviews now re-run the gate so waivers and bot artifacts are picked up without a manual re-push.
- **Event-shape adapter** at the top of the script. `pull_request` and `pull_request_review` events ship the full PR on the payload and the existing code path is unchanged. `issue_comment` events only carry an `issue` reference with a `pull_request` marker, so we fetch the PR via `github.rest.pulls.get()` to normalize the downstream shape (labels, head ref, number). One extra REST call per PR comment; the subsequent GraphQL pagination dominates rate-limit usage either way.
- **Top-of-file comment block** documents the gate's purpose, the branch-protection policy, the three new triggers, and the three manual regression scenarios from the issue: bot posts after label attempt → gate re-runs and allows the label; waiver after label attempt → same; Greptile error comment → gate continues to block queue entry.
- **`AGENTS.md`** gains one bullet under Workflow pointing at the workflow and reminding repo maintainers that `Review Bot Gate / Review Bot Gate` must be added to required status checks in GitHub branch-protection settings for the gate to actually hinge on mergeability.

## Verification

- YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/review-bot-gate.yml'))"`).
- `bunx ultracite check` — clean on both touched files.
- `bun run check` — full repo check passes.

Manual regression scenarios are documented in the workflow's top comment (no unit tests for workflow code — the checklist is the contract).

## Issues

Closes: TRL-354
