### PR TITLE
fix(warden): apply ambient-ctx + defaulted-param fixes across trail-context rules

### DIFF
--- a/packages/warden/src/__tests__/cross-declarations.test.ts
+++ b/packages/warden/src/__tests__/cross-declarations.test.ts
@@ -218,6 +218,87 @@ trail('onboard', {
 
       expect(diagnostics.length).toBe(0);
     });
+
+    test('blaze with no second parameter: unrelated closure ctx.cross is not tracked', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+
+const ctx = { cross: () => ({}) };
+
+trail('demo', {
+  blaze: async () => {
+    ctx.cross('entity.add');
+    return Result.ok({ ok: true });
+  },
+  crosses: [],
+});
+`;
+
+      const diagnostics = crossDeclarations.check(code, TEST_FILE);
+      // The blaze has no context parameter, so `ctx` in the body is an
+      // unrelated closure-scoped binding, not the trail context. It must
+      // not be tracked — no diagnostics.
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('blaze with no second parameter: unrelated closure context.cross is not tracked', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+
+const context = { cross: () => ({}) };
+
+trail('demo', {
+  blaze: async () => {
+    context.cross('entity.add');
+    return Result.ok({ ok: true });
+  },
+  crosses: [],
+});
+`;
+
+      const diagnostics = crossDeclarations.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(0);
+    });
+
+    test('real blaze ctx.cross to undeclared target is still flagged', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+
+trail('demo', {
+  blaze: async (_, ctx) => {
+    await ctx.cross('undeclared');
+    return Result.ok({ ok: true });
+  },
+  crosses: [],
+});
+`;
+
+      const diagnostics = crossDeclarations.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain("ctx.cross('undeclared')");
+    });
+
+    test('defaulted context param is detected (AssignmentPattern)', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+
+const fallbackCtx = { cross: async () => Result.ok({}) };
+
+trail('demo', {
+  blaze: async (_input, ctx = fallbackCtx) => {
+    await ctx.cross('undeclared');
+    return Result.ok({ ok: true });
+  },
+  crosses: [],
+});
+`;
+
+      const diagnostics = crossDeclarations.check(code, TEST_FILE);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain("ctx.cross('undeclared')");
+    });
   });
 
   describe('nested run false positives', () => {

--- a/packages/warden/src/__tests__/resource-declarations.test.ts
+++ b/packages/warden/src/__tests__/resource-declarations.test.ts
@@ -362,6 +362,31 @@ trail('demo', {
       expect(diagnostics.length).toBe(0);
     });
 
+    test('defaulted context param is detected (AssignmentPattern)', () => {
+      const code = `
+import { trail, Result } from '@ontrails/core';
+
+const fallbackCtx = { resource: () => ({}) };
+
+trail('demo', {
+  blaze: async (_input, ctx = fallbackCtx) => {
+    ctx.resource('db.main');
+    return Result.ok({ ok: true });
+  },
+  resources: [],
+});
+`;
+
+      const diagnostics = resourceDeclarations.check(code, TEST_FILE);
+      // The param is an AssignmentPattern; its `.left` is the Identifier `ctx`.
+      // Without AssignmentPattern handling in extractContextParamName, ctx-access
+      // analysis would silently drop and this undeclared access would go
+      // unreported.
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain("ctx.resource('db.main')");
+    });
+
     test('custom-named context param: only that name is tracked', () => {
       const code = `
 import { trail, Result } from '@ontrails/core';

--- a/packages/warden/src/rules/cross-declarations.ts
+++ b/packages/warden/src/rules/cross-declarations.ts
@@ -207,15 +207,22 @@ const extractMemberPair = (
 /**
  * Extract the second parameter name from a blaze function node.
  *
- * Handles `(input, ctx) => ...`, `async (input, context) => ...`, and
- * `function(input, ctx) { ... }` forms.
+ * Handles `(input, ctx) => ...`, `async (input, context) => ...`,
+ * `function(input, ctx) { ... }`, and defaulted params like
+ * `(input, ctx = fallback) => ...` (AssignmentPattern whose `.left` is the
+ * Identifier).
  */
 const extractContextParamName = (blazeBody: AstNode): string | null => {
   const params = blazeBody['params'] as readonly AstNode[] | undefined;
   if (!params || params.length < 2) {
     return null;
   }
-  return identifierName(params[1]);
+  const [, param] = params;
+  if (param?.type === 'AssignmentPattern') {
+    const { left } = param as unknown as { left?: AstNode };
+    return identifierName(left);
+  }
+  return identifierName(param);
 };
 
 /** Check if a callee is a member-style cross call: <ctxName>.cross(...). */
@@ -358,9 +365,20 @@ const extractCrossCall = (
   return resolveCrossCallTargets(extractCrossFirstArg(crossCall), sourceCode);
 };
 
-/** Build the set of context parameter names to match against. */
+/**
+ * Build the set of context parameter names to match against.
+ *
+ * Returns ONLY the actual second-parameter name from the blaze signature.
+ * No seeded defaults: if the blaze has no second parameter, the returned set
+ * is empty and no `ctx.cross(...)` / `context.cross(...)` calls are tracked
+ * for that blaze. An unrelated closure-scoped `ctx` identifier is not the
+ * trail context and must not be treated as one.
+ *
+ * Mirrors `fires-declarations.ts` and `resource-declarations.ts` for the same
+ * reason.
+ */
 const buildCtxNames = (body: AstNode): ReadonlySet<string> => {
-  const ctxNames = new Set(['ctx', 'context']);
+  const ctxNames = new Set<string>();
   const paramName = extractContextParamName(body);
   if (paramName) {
     ctxNames.add(paramName);

--- a/packages/warden/src/rules/fires-declarations.ts
+++ b/packages/warden/src/rules/fires-declarations.ts
@@ -210,10 +210,21 @@ const collectFireNamesFromPattern = (
  * Returns null when the parameter is not a plain Identifier (e.g. when the
  * author destructures `{ fire }` in the parameter list). Parameter-level
  * destructuring is handled separately by `collectParamFireNames`.
+ *
+ * Also handles defaulted parameters like `(input, ctx = fallback) => ...`
+ * (AssignmentPattern whose `.left` is the Identifier). Without this, valid
+ * signatures would silently drop out of ctx-access analysis.
  */
 const extractContextParamName = (blazeBody: AstNode): string | null => {
   const param = extractContextParamNode(blazeBody);
-  return param ? identifierName(param) : null;
+  if (!param) {
+    return null;
+  }
+  if (param.type === 'AssignmentPattern') {
+    const { left } = param as unknown as { left?: AstNode };
+    return identifierName(left);
+  }
+  return identifierName(param);
 };
 
 /**

--- a/packages/warden/src/rules/resource-declarations.ts
+++ b/packages/warden/src/rules/resource-declarations.ts
@@ -141,10 +141,21 @@ const extractContextParamNode = (blazeBody: AstNode): AstNode | null => {
  * Returns null when the parameter is not a plain Identifier (e.g. when the
  * author destructures `{ resource }` in the parameter list). Parameter-level
  * destructuring is handled separately by `collectParamResourceAliases`.
+ *
+ * Also handles defaulted parameters like `(input, ctx = fallback) => ...`
+ * (AssignmentPattern whose `.left` is the Identifier). Without this, valid
+ * signatures would silently drop out of ctx-access analysis.
  */
 const extractContextParamName = (blazeBody: AstNode): string | null => {
   const param = extractContextParamNode(blazeBody);
-  return param ? identifierName(param) : null;
+  if (!param) {
+    return null;
+  }
+  if (param.type === 'AssignmentPattern') {
+    const { left } = param as unknown as { left?: AstNode };
+    return identifierName(left);
+  }
+  return identifierName(param);
 };
 
 /** Extract the alias name from a Property node whose key is `resource`. */


### PR DESCRIPTION
## Summary

Follow-up on [#219](https://github.com/outfitter-dev/trails/pull/219) (TRL-356). While reviewing the ambient-ctx fix in `resource-declarations`, Codex flagged a sibling-rule equivalent and a defaulted-parameter edge case. Both landed after the original PR merged, so this catches the work up to what the review asked for.

The Codex P1 observation: `cross-declarations.ts` still seeded `ctx`/`context` as ambient names even when the blaze had no second parameter — the same false-positive class we just fixed in `resource-declarations`. The Codex P2 observation: across all three trail-context rules, `extractContextParamName` was identifier-only, so a valid `blaze: async (_input, ctx = fallbackCtx)` signature (`AssignmentPattern`) silently dropped ctx-access detection.

## What changed

- **`cross-declarations.ts`**: `buildCtxNames` no longer seeds `ctx`/`context` defaults, mirroring the `resource-declarations` and `fires-declarations` shape. The rule only tracks ctx-access when a real second parameter is declared.
- **`cross-declarations.ts`, `resource-declarations.ts`, `fires-declarations.ts`**: each rule's local `extractContextParamName` now unwraps `AssignmentPattern.left` so a defaulted signature like `blaze: async (_input, ctx = fallback)` still exposes `ctx` as the trail-context name. The three rules keep local helpers rather than sharing to stay close to existing patterns.
- **Regression tests**: `cross-declarations.test.ts` gains four tests (ambient `ctx`, ambient `context`, real blaze still flags undeclared targets, defaulted-param detection). `resource-declarations.test.ts` gains a defaulted-param test.

## Verification

- `bun test packages/warden` — 618 pass, 0 fail.
- `bun run typecheck` — 31/31 green.
- `bunx ultracite check` — clean on all five touched files.

## Issues

Follow-up to TRL-356 / [#219](https://github.com/outfitter-dev/trails/pull/219).
