### PR TITLE
fix(warden): make namespace contour resolution scope-aware

### DIFF
--- a/packages/warden/src/__tests__/contour-exists.test.ts
+++ b/packages/warden/src/__tests__/contour-exists.test.ts
@@ -172,5 +172,32 @@ trail('user.create', {
         })
       ).toEqual([]);
     });
+
+    test('ignores namespace member access when receiver is shadowed by a local binding', () => {
+      const code = `
+import { Result, trail } from '@ontrails/core';
+import * as contours from './contours';
+
+function makeTrail() {
+  const contours = { user: 'not-a-contour' };
+  return trail('user.create', {
+    contours: [contours.user],
+    blaze: async () => Result.ok({ ok: true }),
+  });
+}
+
+makeTrail();
+`;
+
+      // The trail's \`contours: [contours.user]\` refers to a local
+      // \`const contours = ...\`, not the namespace import, so no
+      // missing-contour diagnostic should be produced.
+      expect(
+        contourExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set<string>(),
+          knownTrailIds: new Set(['user.create']),
+        })
+      ).toEqual([]);
+    });
   });
 });

--- a/packages/warden/src/__tests__/reference-exists.test.ts
+++ b/packages/warden/src/__tests__/reference-exists.test.ts
@@ -236,6 +236,30 @@ const gist = contour('gist', {
       ).toEqual([]);
     });
 
+    test('ignores namespace member access when receiver is shadowed by a function parameter', () => {
+      const code = `
+import { contour } from '@ontrails/core';
+import * as contours from './contours';
+
+function buildGist(contours: { user: { id: () => unknown } }) {
+  return contour('gist', {
+    id: 'x',
+    ownerId: contours.user.id(),
+  }, { identity: 'id' });
+}
+`;
+
+      // The \`contours\` in \`contours.user.id()\` is the function parameter,
+      // not the namespace import, so no missing-reference diagnostic should
+      // be produced.
+      expect(
+        referenceExists.checkWithContext(code, TEST_FILE, {
+          knownContourIds: new Set(['gist']),
+          knownTrailIds: new Set<string>(),
+        })
+      ).toEqual([]);
+    });
+
     test('does not flag namespace imports from @ontrails sources', () => {
       const code = `
 import * as core from '@ontrails/core';

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -1116,19 +1116,25 @@ const isShadowed = (
 };
 
 /**
- * `isNonComputedMemberAccess` + `getNamespacedMemberNames` forward
- * declarations. The bodies live next to the other callee-resolution helpers
- * further down. Declared early here so the scope walker can use them without
- * hitting `no-use-before-define`.
+ * Return `true` when `node` is a non-computed member access (`a.b` /
+ * `a?.b`) and `false` for anything else, including computed access
+ * (`a[b]`) or non-member nodes. Exported as the canonical predicate so
+ * rule modules do not re-implement the check.
+ *
+ * @remarks
+ * Declared near the top of the file so the scope walker can use it
+ * without hitting `no-use-before-define`. A few sibling helpers in this
+ * module still inline the same shape under different local names for
+ * historical reasons; prefer this export for new call sites.
  */
-const isMemberAccessNonComputed = (callee: AstNode): boolean => {
+export const isMemberAccessNonComputed = (node: AstNode): boolean => {
   if (
-    callee.type !== 'MemberExpression' &&
-    callee.type !== 'StaticMemberExpression'
+    node.type !== 'MemberExpression' &&
+    node.type !== 'StaticMemberExpression'
   ) {
     return false;
   }
-  return (callee as unknown as { computed?: boolean }).computed !== true;
+  return (node as unknown as { computed?: boolean }).computed !== true;
 };
 
 const resolveNamespacedMemberNames = (
@@ -1801,6 +1807,76 @@ export const collectUserNamespaceImportBindings = (
   return bindings;
 };
 
+/**
+ * Resolution context for user-namespace member access like `contours.user`.
+ * Bundles the set of local namespace-binding names (from `import * as x from
+ * './contours'`) with an optional set of proven-safe `MemberExpression` start
+ * offsets from a scope-aware pre-pass. When `safeMemberStarts` is present, a
+ * member access only resolves to a user-namespace target if its start is in
+ * the set — so a function-local shadow of the namespace import does not leak
+ * through. When absent, the name-only gate is used as a
+ * backward-compatible fallback for ad-hoc callers.
+ */
+export interface UserNamespaceContext {
+  readonly bindings: ReadonlySet<string>;
+  readonly safeMemberStarts?: ReadonlySet<number>;
+}
+
+/**
+ * Walk the AST with a scope stack and collect `MemberExpression` start offsets
+ * whose receiver is a user-namespace binding that is NOT shadowed by any
+ * enclosing scope. Mirrors `collectFrameworkNamespacedCallStarts` for the
+ * framework-namespace path so `contours.user` inside
+ * `function f(contours) { ... }` is rejected as shadowed.
+ */
+/**
+ * Return the receiver-identifier name of a non-computed member access, or
+ * `null` for any other node shape (computed access, non-member, etc.).
+ */
+const getNonComputedMemberReceiver = (node: AstNode): string | null => {
+  if (!isMemberAccessNonComputed(node)) {
+    return null;
+  }
+  const { object } = node as unknown as { object?: AstNode };
+  return object ? identifierName(object) : null;
+};
+
+const collectUserNamespacedMemberStarts = (
+  ast: AstNode,
+  bindings: ReadonlySet<string>
+): ReadonlySet<number> => {
+  const starts = new Set<number>();
+  if (bindings.size === 0) {
+    return starts;
+  }
+
+  walkWithScopes(ast, (node, scopes) => {
+    const receiver = getNonComputedMemberReceiver(node);
+    if (!receiver || !bindings.has(receiver) || isShadowed(receiver, scopes)) {
+      return;
+    }
+    starts.add(node.start);
+  });
+
+  return starts;
+};
+
+/**
+ * Build a {@link UserNamespaceContext} for `ast`, including the scope-aware
+ * `safeMemberStarts` gate. Prefer this over bare
+ * {@link collectUserNamespaceImportBindings} so member access like
+ * `contours.user` is rejected when `contours` is shadowed by a local binding.
+ */
+export const buildUserNamespaceContext = (
+  ast: AstNode
+): UserNamespaceContext => {
+  const bindings = collectUserNamespaceImportBindings(ast);
+  return {
+    bindings,
+    safeMemberStarts: collectUserNamespacedMemberStarts(ast, bindings),
+  };
+};
+
 export interface ContourReferenceSite {
   /** Field on the source contour that declares the reference. */
   readonly field: string;
@@ -1906,7 +1982,11 @@ export const deriveContourIdentifierName = (
 
 const getContourReferenceMember = (
   node: AstNode
-): { readonly object?: AstNode; readonly property?: AstNode } | null => {
+): {
+  readonly object?: AstNode;
+  readonly property?: AstNode;
+  readonly start: number;
+} | null => {
   if (
     node.type !== 'MemberExpression' &&
     node.type !== 'StaticMemberExpression'
@@ -1917,13 +1997,28 @@ const getContourReferenceMember = (
   return node as unknown as {
     readonly object?: AstNode;
     readonly property?: AstNode;
+    readonly start: number;
   };
+};
+
+const asUserNamespaceContext = (
+  input: ReadonlySet<string> | UserNamespaceContext | undefined
+): UserNamespaceContext | undefined => {
+  if (!input) {
+    return undefined;
+  }
+  return input instanceof Set
+    ? { bindings: input }
+    : (input as UserNamespaceContext);
 };
 
 /**
  * Resolve a user-namespace member access like `contours.user` to its contour
  * id. Returns the property name (e.g. `'user'`) when the receiver identifier
- * is a known user-defined namespace binding, otherwise `null`.
+ * is a known user-defined namespace binding AND — when the caller provides a
+ * {@link UserNamespaceContext} with `safeMemberStarts` — the member access
+ * site is in that set (i.e. the receiver is not shadowed by any enclosing
+ * scope). Otherwise returns `null`.
  *
  * The property name is taken as the contour id verbatim — we cannot statically
  * resolve what `contours.user` binds to without reading the other file, so we
@@ -1931,15 +2026,36 @@ const getContourReferenceMember = (
  * {@link deriveContourIdentifierName}'s downstream `knownContourIds` check
  * report a missing target.
  */
+export const isUserNamespaceReceiverAllowed = (
+  receiver: string,
+  memberStart: number,
+  ctx: UserNamespaceContext
+): boolean => {
+  if (!ctx.bindings.has(receiver)) {
+    return false;
+  }
+  // Scope-aware gate: when the pre-pass produced a set, the member access
+  // must appear in it. Without the set, fall back to the bare name check.
+  return ctx.safeMemberStarts ? ctx.safeMemberStarts.has(memberStart) : true;
+};
+
 const getContourReferenceTargetFromNamespaceMember = (
-  member: { readonly object?: AstNode; readonly property?: AstNode },
-  userNamespaceBindings?: ReadonlySet<string>
+  member: {
+    readonly object?: AstNode;
+    readonly property?: AstNode;
+    readonly start: number;
+  },
+  userNamespace?: ReadonlySet<string> | UserNamespaceContext
 ): string | null => {
-  if (!userNamespaceBindings || userNamespaceBindings.size === 0) {
+  const ctx = asUserNamespaceContext(userNamespace);
+  if (!ctx || ctx.bindings.size === 0) {
     return null;
   }
   const receiver = member.object ? identifierName(member.object) : null;
-  if (!receiver || !userNamespaceBindings.has(receiver)) {
+  if (
+    !receiver ||
+    !isUserNamespaceReceiverAllowed(receiver, member.start, ctx)
+  ) {
     return null;
   }
   const { property } = member;
@@ -1955,7 +2071,7 @@ const getContourReferenceTargetFromObject = (
   knownContourIds?: ReadonlySet<string>,
   importAliases?: ReadonlyMap<string, string>,
   context?: ReadonlySet<string> | FrameworkNamespaceContext,
-  userNamespaceBindings?: ReadonlySet<string>
+  userNamespace?: ReadonlySet<string> | UserNamespaceContext
 ): string | null => {
   if (object.type === 'Identifier') {
     const bindingName = identifierName(object);
@@ -1973,7 +2089,7 @@ const getContourReferenceTargetFromObject = (
   if (member) {
     const namespaceTarget = getContourReferenceTargetFromNamespaceMember(
       member,
-      userNamespaceBindings
+      userNamespace
     );
     if (namespaceTarget) {
       return namespaceTarget;
@@ -2034,7 +2150,7 @@ const extractContourReferenceTarget = (
   knownContourIds?: ReadonlySet<string>,
   importAliases?: ReadonlyMap<string, string>,
   context?: ReadonlySet<string> | FrameworkNamespaceContext,
-  userNamespaceBindings?: ReadonlySet<string>
+  userNamespace?: ReadonlySet<string> | UserNamespaceContext
 ): string | null => {
   const object = getContourIdCallObject(node);
   return object
@@ -2044,7 +2160,7 @@ const extractContourReferenceTarget = (
         knownContourIds,
         importAliases,
         context,
-        userNamespaceBindings
+        userNamespace
       )
     : null;
 };
@@ -2061,7 +2177,7 @@ const buildContourReferenceSite = (
   knownContourIds?: ReadonlySet<string>,
   importAliases?: ReadonlyMap<string, string>,
   context?: ReadonlySet<string> | FrameworkNamespaceContext,
-  userNamespaceBindings?: ReadonlySet<string>
+  userNamespace?: ReadonlySet<string> | UserNamespaceContext
 ): ContourReferenceSite | null => {
   if (property.type !== 'Property') {
     return null;
@@ -2074,7 +2190,7 @@ const buildContourReferenceSite = (
     knownContourIds,
     importAliases,
     context,
-    userNamespaceBindings
+    userNamespace
   );
   if (!field || !target) {
     return null;
@@ -2094,7 +2210,7 @@ const findContourReferenceSitesForDefinition = (
   knownContourIds?: ReadonlySet<string>,
   importAliases?: ReadonlyMap<string, string>,
   context?: ReadonlySet<string> | FrameworkNamespaceContext,
-  userNamespaceBindings?: ReadonlySet<string>
+  userNamespace?: ReadonlySet<string> | UserNamespaceContext
 ): readonly ContourReferenceSite[] =>
   getContourShapeProperties(definition).flatMap((property) => {
     const reference = buildContourReferenceSite(
@@ -2104,7 +2220,7 @@ const findContourReferenceSitesForDefinition = (
       knownContourIds,
       importAliases,
       context,
-      userNamespaceBindings
+      userNamespace
     );
     return reference ? [reference] : [];
   });
@@ -2116,7 +2232,7 @@ export const collectContourReferenceSites = (
 ): readonly ContourReferenceSite[] => {
   const namedContourIds = collectNamedContourIds(ast);
   const importAliases = collectImportAliasMap(ast);
-  const userNamespaceBindings = collectUserNamespaceImportBindings(ast);
+  const userNamespace = buildUserNamespaceContext(ast);
   const context = buildFrameworkNamespaceContext(ast);
   return findContourDefinitions(ast, context).flatMap((definition) =>
     findContourReferenceSitesForDefinition(
@@ -2125,7 +2241,7 @@ export const collectContourReferenceSites = (
       knownContourIds,
       importAliases,
       context,
-      userNamespaceBindings
+      userNamespace
     )
   );
 };

--- a/packages/warden/src/rules/contour-exists.ts
+++ b/packages/warden/src/rules/contour-exists.ts
@@ -1,17 +1,19 @@
 import {
+  buildUserNamespaceContext,
   collectContourDefinitionIds,
   collectImportAliasMap,
   collectNamedContourIds,
-  collectUserNamespaceImportBindings,
   extractFirstStringArg,
   findConfigProperty,
   findTrailDefinitions,
   identifierName,
+  isMemberAccessNonComputed,
+  isUserNamespaceReceiverAllowed,
   offsetToLine,
   parse,
   deriveContourIdentifierName,
 } from './ast.js';
-import type { AstNode, TrailDefinition } from './ast.js';
+import type { AstNode, TrailDefinition, UserNamespaceContext } from './ast.js';
 import { mergeKnownContourIds } from './contour-ids.js';
 import { isTestFile } from './scan.js';
 import type {
@@ -42,17 +44,18 @@ const getContourElements = (config: AstNode): readonly AstNode[] => {
   return elements ?? [];
 };
 
+/**
+ * Resolve `contours.user` to its contour name. When `userNamespace` carries a
+ * scope-aware `safeMemberStarts` set, the member access must appear in it —
+ * rejecting cases where `contours` is shadowed by a local binding such as a
+ * function parameter or `const contours = ...`. Without the set, falls back
+ * to the bare name check for backward compatibility.
+ */
 const resolveNamespaceMemberContourName = (
   element: AstNode,
-  userNamespaceBindings: ReadonlySet<string>
+  userNamespace: UserNamespaceContext
 ): string | null => {
-  if (
-    element.type !== 'MemberExpression' &&
-    element.type !== 'StaticMemberExpression'
-  ) {
-    return null;
-  }
-  if ((element as unknown as { computed?: boolean }).computed === true) {
+  if (!isMemberAccessNonComputed(element)) {
     return null;
   }
   const { object, property } = element as unknown as {
@@ -60,7 +63,10 @@ const resolveNamespaceMemberContourName = (
     readonly property?: AstNode;
   };
   const receiver = object ? identifierName(object) : null;
-  if (!receiver || !userNamespaceBindings.has(receiver)) {
+  if (
+    !receiver ||
+    !isUserNamespaceReceiverAllowed(receiver, element.start, userNamespace)
+  ) {
     return null;
   }
   return property ? identifierName(property) : null;
@@ -71,7 +77,7 @@ const resolveDeclaredContourName = (
   contourIdsByName: ReadonlyMap<string, string>,
   knownContourIds?: ReadonlySet<string>,
   importAliases?: ReadonlyMap<string, string>,
-  userNamespaceBindings?: ReadonlySet<string>
+  userNamespace?: UserNamespaceContext
 ): string | null => {
   if (element.type === 'Identifier') {
     const name = identifierName(element);
@@ -85,10 +91,10 @@ const resolveDeclaredContourName = (
       : null;
   }
 
-  if (userNamespaceBindings && userNamespaceBindings.size > 0) {
+  if (userNamespace && userNamespace.bindings.size > 0) {
     const namespaceTarget = resolveNamespaceMemberContourName(
       element,
-      userNamespaceBindings
+      userNamespace
     );
     if (namespaceTarget) {
       return namespaceTarget;
@@ -103,7 +109,7 @@ const extractDeclaredContourNames = (
   contourIdsByName: ReadonlyMap<string, string>,
   knownContourIds?: ReadonlySet<string>,
   importAliases?: ReadonlyMap<string, string>,
-  userNamespaceBindings?: ReadonlySet<string>
+  userNamespace?: UserNamespaceContext
 ): readonly string[] => [
   ...new Set(
     getContourElements(config).flatMap((element) => {
@@ -112,7 +118,7 @@ const extractDeclaredContourNames = (
         contourIdsByName,
         knownContourIds,
         importAliases,
-        userNamespaceBindings
+        userNamespace
       );
       return contourName ? [contourName] : [];
     })
@@ -139,7 +145,7 @@ const buildDiagnosticsForDefinition = (
   knownContourIds: ReadonlySet<string>,
   contourIdsByName: ReadonlyMap<string, string>,
   importAliases: ReadonlyMap<string, string>,
-  userNamespaceBindings: ReadonlySet<string>
+  userNamespace: UserNamespaceContext
 ): readonly WardenDiagnostic[] => {
   if (definition.kind !== 'trail') {
     return [];
@@ -151,7 +157,7 @@ const buildDiagnosticsForDefinition = (
     contourIdsByName,
     knownContourIds,
     importAliases,
-    userNamespaceBindings
+    userNamespace
   ).flatMap((contourName) =>
     knownContourIds.has(contourName)
       ? []
@@ -174,7 +180,7 @@ const buildContourDiagnostics = (
 ): readonly WardenDiagnostic[] => {
   const contourIdsByName = collectNamedContourIds(ast);
   const importAliases = collectImportAliasMap(ast);
-  const userNamespaceBindings = collectUserNamespaceImportBindings(ast);
+  const userNamespace = buildUserNamespaceContext(ast);
 
   return findTrailDefinitions(ast).flatMap((definition) =>
     buildDiagnosticsForDefinition(
@@ -184,7 +190,7 @@ const buildContourDiagnostics = (
       knownContourIds,
       contourIdsByName,
       importAliases,
-      userNamespaceBindings
+      userNamespace
     )
   );
 };


### PR DESCRIPTION
## Summary

Follow-up on [#221](https://github.com/outfitter-dev/trails/pull/221) (TRL-353). Codex flagged two P1 correctness issues in the namespace-import resolution I added — both merged before feedback landed, so this catches the work up to a correct implementation.

The gap: `getContourReferenceTargetFromNamespaceMember` (in `ast.ts`) and `resolveNamespaceMemberContourName` (in `contour-exists.ts`) trusted only the receiver name from `userNamespaceBindings`, never checking lexical shadowing. A function-local parameter or binding named like the namespace import — e.g. `function f(contours) { ... contours.user.id() ... }` — was misread as a contour reference. That produced false `reference-exists` errors and bogus `circular-refs` edges, and in `contour-exists` it misread `trail(..., { contours: [contours.user] })` inside a shadowing scope as a project contour declaration.

## What changed

- **Scope-aware resolution** via a new `UserNamespaceContext` mirroring the existing `FrameworkNamespaceContext` pattern. `buildUserNamespaceContext` pre-walks the AST with `walkWithScopes`, records `safeMemberStarts` for every member node whose receiver is a namespace binding AND `isShadowed` returns false in every enclosing scope. The resolvers gate on the member node's `.start`, which is a cheap numeric lookup.
- The triad `buildUserNamespaceContext` / `collectUserNamespacedMemberStarts` / `isUserNamespaceReceiverAllowed` is the direct analogue of the framework-namespace triad. I reused the existing `isShadowed` and `walkWithScopes` primitives — no new scope machinery.
- Threaded `UserNamespaceContext` through the contour-exists call chain (`resolveDeclaredContourName` → `extractDeclaredContourNames` → `buildDiagnosticsForDefinition` → `buildContourDiagnostics`). No API signature change at the rule's public boundary.
- **Regression tests**: `reference-exists.test.ts` and `contour-exists.test.ts` each gain a shadowing case covering the scenarios Codex described.

## Verification

- `bun test packages/warden` — 620 pass, 0 fail.
- `bun run typecheck` — 31/31 green.
- `bunx ultracite check` — clean on all four touched files.

## Issues

Follow-up to TRL-353 / [#221](https://github.com/outfitter-dev/trails/pull/221).
