### PR TITLE
fix(warden): topLevelOnly surfaces top-level statement-form contour calls

### DIFF
--- a/packages/warden/src/__tests__/ast.test.ts
+++ b/packages/warden/src/__tests__/ast.test.ts
@@ -497,6 +497,60 @@ describe('findContourDefinitions inline discovery', () => {
     expect(defs[0]?.name).toBe('outer');
     expect(defs[0]?.bindingName).toBe('outer');
   });
+
+  test('topLevelOnly: true still surfaces top-level statement-form calls', () => {
+    // Regression for Codex P2 on PR #222: the `topLevelOnly` guard must only
+    // exclude inline nested contour calls. Top-level bare-statement forms
+    // (`core.contour('name', {...});` directly in the program body, not
+    // bound to a variable) are top-level and should still be returned.
+    const statementFormSource = `
+      import * as core from '@ontrails/core';
+      import { z } from 'zod';
+
+      export const bound = core.contour('bound', {
+        id: z.string().uuid(),
+      });
+
+      core.contour('bare', { id: z.string().uuid() });
+    `;
+    const ast = parseOrThrow(statementFormSource);
+    const defs = findContourDefinitions(ast, undefined, {
+      topLevelOnly: true,
+    });
+
+    const names = defs.map((d) => d.name).toSorted();
+    expect(names).toEqual(['bare', 'bound']);
+
+    const bound = defs.find((d) => d.name === 'bound');
+    const bare = defs.find((d) => d.name === 'bare');
+    expect(bound?.bindingName).toBe('bound');
+    // Bare statement-form calls have no local binding.
+    expect(bare?.bindingName).toBeUndefined();
+  });
+
+  test('topLevelOnly: true surfaces export default core.contour(...) form', () => {
+    // Regression for Greptile P2 on PR #227: collectTopLevelStatementCallStarts
+    // branches on ExportDefaultDeclaration via getCandidateCallHosts, so an
+    // export-default contour declaration must still be surfaced under the
+    // topLevelOnly: true flag.
+    const exportDefaultSource = `
+      import * as core from '@ontrails/core';
+      import { z } from 'zod';
+
+      export default core.contour('default-export', {
+        id: z.string().uuid(),
+      });
+    `;
+    const ast = parseOrThrow(exportDefaultSource);
+    const defs = findContourDefinitions(ast, undefined, {
+      topLevelOnly: true,
+    });
+
+    expect(defs).toHaveLength(1);
+    expect(defs[0]?.name).toBe('default-export');
+    // Export-default call expressions have no local binding name.
+    expect(defs[0]?.bindingName).toBeUndefined();
+  });
 });
 
 describe('collectContourReferenceSites with namespaced inline contours', () => {

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -1560,11 +1560,75 @@ const extractContourDefinition = (
   };
 };
 
+const getCallStartFromCandidate = (
+  node: AstNode | undefined
+): number | null => {
+  if (!node) {
+    return null;
+  }
+  if (node.type === 'CallExpression') {
+    return node.start;
+  }
+  if (node.type !== 'ExpressionStatement') {
+    return null;
+  }
+  const { expression } = node as unknown as { expression?: AstNode };
+  return expression?.type === 'CallExpression' ? expression.start : null;
+};
+
+// Statement forms that can directly contain a top-level contour call:
+//   `core.contour(...)` as a bare statement,
+//   `export const ... = core.contour(...)` (handled via VariableDeclarator),
+//   `export default core.contour(...);`.
+const getCandidateCallHosts = (
+  statement: AstNode
+): readonly (AstNode | undefined)[] => {
+  if (
+    statement.type !== 'ExportNamedDeclaration' &&
+    statement.type !== 'ExportDefaultDeclaration'
+  ) {
+    return [statement];
+  }
+  const { declaration } = statement as unknown as {
+    declaration?: AstNode;
+  };
+  return [statement, declaration];
+};
+
+const getTopLevelCallStartsFrom = (statement: AstNode): readonly number[] => {
+  const hosts = getCandidateCallHosts(statement);
+  const starts: number[] = [];
+  for (const host of hosts) {
+    const start = getCallStartFromCandidate(host);
+    if (start !== null) {
+      starts.push(start);
+    }
+  }
+  return starts;
+};
+
+/**
+ * Collect the `start` offsets of `CallExpression` nodes that appear as
+ * top-level `ExpressionStatement`s in a program body — including inside a
+ * top-level `ExportNamedDeclaration` / `ExportDefaultDeclaration` wrapper.
+ * Used to discriminate top-level statement-form calls from inline nested
+ * calls when `topLevelOnly` is enabled.
+ */
+const collectTopLevelStatementCallStarts = (
+  ast: AstNode
+): ReadonlySet<number> => {
+  const body = (ast as unknown as { body?: readonly AstNode[] }).body ?? [];
+  return new Set(body.flatMap(getTopLevelCallStartsFrom));
+};
+
 export interface FindContourDefinitionsOptions {
   /**
    * When true, skip contour calls nested inside other expressions (e.g.
    * `core.contour('inner', {...}).id()` used as a field of an outer contour).
-   * Only top-level declarations and statements surface as definitions.
+   * Top-level forms are still surfaced: both `const foo = contour(...)`
+   * declarations and bare `contour('name', {...});` statement-form calls that
+   * appear directly in the program body (optionally wrapped in `export`) are
+   * returned.
    *
    * Defaults to `false`: both top-level and inline contours are returned so
    * that reference-site resolution can reach anonymous inline contours.
@@ -1632,6 +1696,15 @@ export const findContourDefinitions = (
     addContourDefinition(definition);
   };
 
+  // When `topLevelOnly` is set, collect the start offsets of call expressions
+  // that sit directly in the program body as `ExpressionStatement`s (optionally
+  // wrapped in `export`). These are top-level statement-form contour calls and
+  // should still surface alongside `VariableDeclarator` bindings; only calls
+  // nested inside other expressions are excluded.
+  const topLevelStatementCallStarts = topLevelOnly
+    ? collectTopLevelStatementCallStarts(ast)
+    : null;
+
   walk(ast, (node) => {
     if (node.type === 'VariableDeclarator') {
       const { id, init } = node as unknown as {
@@ -1642,7 +1715,10 @@ export const findContourDefinitions = (
       return;
     }
 
-    if (topLevelOnly) {
+    if (
+      topLevelStatementCallStarts &&
+      !topLevelStatementCallStarts.has(node.start)
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Follow-up on [#222](https://github.com/outfitter-dev/trails/pull/222) (TRL-362). Codex flagged a P2 follow-up after #222 merged: when `findContourDefinitions` was called with `topLevelOnly: true`, the fallback guard short-circuited the whole non-`VariableDeclarator` path, which also dropped legitimate top-level statement-form calls like `core.contour('x', {...});` — not assigned to a variable, not nested, but genuinely top level. Only inline nested contours were supposed to be excluded under the flag.

## What changed

- Replaced the unconditional `if (topLevelOnly) return;` guard with a pre-computed `ReadonlySet<number>` of approved call starts, built from `program.body` via new helpers (`getCallStartFromCandidate`, `getCandidateCallHosts`, `getTopLevelCallStartsFrom`, `collectTopLevelStatementCallStarts`).
- The fallback extraction now runs by default; when `topLevelOnly` is true, only calls whose `node.start` is in the allow-list proceed. Inline nested contours stay excluded; the existing `VariableDeclarator` path is unaffected.
- TSDoc on `FindContourDefinitionsOptions.topLevelOnly` updated to spell out that both bound and statement-form top-level contours surface — only inline nested contours are excluded.
- **Regression test**: asserts `topLevelOnly: true` surfaces both `export const bound = core.contour('bound', ...)` (bound form) and a bare `core.contour('bare', ...);` statement-form, with the bare form correctly having no `bindingName`.

## Verification

- `bun test packages/warden` — 621 pass, 0 fail.
- `bun run typecheck` — 31/31 green.
- `bunx ultracite check` — clean on both touched files.

## Issues

Follow-up to TRL-362 / [#222](https://github.com/outfitter-dev/trails/pull/222).
