### PR TITLE
fix(ci): make governance failures block the workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
 
       - name: Warden
         run: bun apps/ci/bin/ci.ts --format github --fail-on error
-        continue-on-error: true
 
   ci-gate:
     name: CI Gate

--- a/apps/ci/src/__tests__/cli.test.ts
+++ b/apps/ci/src/__tests__/cli.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const repoRoot = join(import.meta.dir, '..', '..', '..', '..');
+const binPath = join(repoRoot, 'apps/ci/bin/ci.ts');
+const tempRoots: string[] = [];
+
+interface CliRunResult {
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+const runCli = (
+  rootDir: string,
+  options: {
+    readonly failOn: 'error' | 'warning';
+    readonly format?: 'github' | 'json' | 'summary';
+  }
+): CliRunResult => {
+  const proc = Bun.spawnSync({
+    cmd: [
+      'bun',
+      binPath,
+      '--root-dir',
+      rootDir,
+      '--fail-on',
+      options.failOn,
+      '--format',
+      options.format ?? 'github',
+    ],
+    cwd: repoRoot,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    stderr: proc.stderr.toString(),
+    stdout: proc.stdout.toString(),
+  };
+};
+
+const createFixtureRoot = (sourceFileContents: string): string => {
+  const rootDir = mkdtempSync(join(tmpdir(), 'trails-ci-governance-'));
+  tempRoots.push(rootDir);
+  const srcDir = join(rootDir, 'src');
+  mkdirSync(srcDir, { recursive: true });
+  writeFileSync(join(srcDir, 'fixture.ts'), sourceFileContents);
+  return rootDir;
+};
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const rootDir = tempRoots.pop();
+    if (!rootDir) {
+      continue;
+    }
+    rmSync(rootDir, { force: true, recursive: true });
+  }
+});
+
+describe('apps/ci bin', () => {
+  test('exits non-zero and emits GitHub annotations for error-level findings', () => {
+    const result = runCli(
+      createFixtureRoot(`import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const badTrail = trail('fixture.bad-trail', {
+  blaze: () => {
+    throw new Error('boom');
+    return Result.ok({ ok: true });
+  },
+  description: 'Fixture trail with an implementation throw for CI smoke tests',
+  examples: [{ input: {}, name: 'Default run' }],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+});
+`),
+      { failOn: 'error' }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('::error');
+    expect(result.stdout).toContain('title=no-throw-in-implementation');
+  });
+
+  test('keeps warning-only findings non-blocking when failOn is error', () => {
+    const result = runCli(
+      createFixtureRoot(`import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const internalTrail = trail('fixture.internal-trail', {
+  blaze: () => Result.ok({ ok: true }),
+  description:
+    'Fixture internal trail with no crossings or activation for CI smoke tests',
+  examples: [{ input: {}, name: 'Default run' }],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+  visibility: 'internal',
+});
+`),
+      { failOn: 'error' }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('::warning');
+    expect(result.stdout).toContain('title=dead-internal-trail');
+  });
+
+  test('promotes warning-only findings to blocking when failOn is warning', () => {
+    const result = runCli(
+      createFixtureRoot(`import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const internalTrail = trail('fixture.internal-trail', {
+  blaze: () => Result.ok({ ok: true }),
+  description:
+    'Fixture internal trail with no crossings or activation for CI smoke tests',
+  examples: [{ input: {}, name: 'Default run' }],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+  visibility: 'internal',
+});
+`),
+      { failOn: 'warning' }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('::warning');
+    expect(result.stdout).toContain('title=dead-internal-trail');
+  });
+});

--- a/apps/trails/src/trails/create.ts
+++ b/apps/trails/src/trails/create.ts
@@ -5,7 +5,6 @@
  * via ctx.cross.
  */
 
-import type { CrossFn } from '@ontrails/core';
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -42,6 +41,11 @@ interface ScaffoldedProject {
   readonly name: string;
 }
 
+interface SurfaceResult {
+  readonly created: string;
+  readonly dependency: string;
+}
+
 const buildScaffoldInput = (input: ScaffoldRequest) => ({
   ...(input.dir === undefined ? {} : { dir: input.dir }),
   name: input.name,
@@ -58,24 +62,14 @@ const buildVerifyInput = (input: VerifyRequest) => ({
   name: input.name,
 });
 
-const scaffoldProject = (
-  cross: CrossFn,
-  input: ScaffoldRequest
-): Promise<Result<ScaffoldedProject, Error>> =>
-  cross('create.scaffold', buildScaffoldInput(input));
-
-const addSurfaceFiles = async (
-  cross: CrossFn,
-  dir: string,
-  surfaces: readonly string[]
+const collectSurfaceFiles = async (
+  surfaces: readonly string[],
+  addSurface: (surface: string) => Promise<Result<SurfaceResult, Error>>
 ): Promise<Result<string[], Error>> => {
   const created: string[] = [];
 
   for (const surface of surfaces) {
-    const result = await cross<{ created: string; dependency: string }>(
-      'add.surface',
-      buildSurfaceInput(dir, surface)
-    );
+    const result = await addSurface(surface);
     if (result.isErr()) {
       return Result.err(result.error);
     }
@@ -86,17 +80,14 @@ const addSurfaceFiles = async (
 };
 
 const collectVerifyFiles = async (
-  cross: CrossFn,
-  input: VerifyRequest
+  shouldVerify: boolean,
+  addVerify: () => Promise<Result<{ created: string[] }, Error>>
 ): Promise<Result<string[], Error>> => {
-  if (!input.verify) {
+  if (!shouldVerify) {
     return Result.ok([]);
   }
 
-  const result = await cross<{ created: string[] }>(
-    'add.verify',
-    buildVerifyInput(input)
-  );
+  const result = await addVerify();
   return result.isErr()
     ? Result.err(result.error)
     : Result.ok(result.value.created);
@@ -108,53 +99,59 @@ const collectCreatedFiles = (
   verify: readonly string[]
 ): string[] => [...scaffolded, ...surfaces, ...verify];
 
-const runCreate = async (
-  cross: CrossFn,
-  input: CreateInput
-): Promise<Result<{ created: string[]; dir: string; name: string }, Error>> => {
-  const scaffolded = await scaffoldProject(cross, input);
-  if (scaffolded.isErr()) {
-    return Result.err(scaffolded.error);
-  }
-
-  const surfaceResults = await addSurfaceFiles(
-    cross,
-    scaffolded.value.dir,
-    input.surfaces
-  );
-  if (surfaceResults.isErr()) {
-    return Result.err(surfaceResults.error);
-  }
-
-  const verifyFiles = await collectVerifyFiles(cross, input);
-  if (verifyFiles.isErr()) {
-    return Result.err(verifyFiles.error);
-  }
-
-  return Result.ok({
-    created: collectCreatedFiles(
-      scaffolded.value.created,
-      surfaceResults.value,
-      verifyFiles.value
-    ),
-    dir: scaffolded.value.dir,
-    name: input.name,
-  });
-};
-
 // ---------------------------------------------------------------------------
 // Route definition
 // ---------------------------------------------------------------------------
 
 export const createRoute = trail('create', {
-  // Warden's cross-declarations rule can't see through helper functions, but
-  // these crossings are real — scaffoldProject, addSurfaceFiles, and
-  // collectVerifyFiles all delegate via the CrossFn passed from ctx.cross.
   blaze: async (input: CreateInput, ctx) => {
     if (!ctx.cross) {
       return Result.err(new Error('create route requires ctx.cross'));
     }
-    return await runCreate(ctx.cross, input);
+    const { cross } = ctx;
+
+    const scaffolded = await cross<ScaffoldedProject>(
+      'create.scaffold',
+      buildScaffoldInput(input)
+    );
+    if (scaffolded.isErr()) {
+      return Result.err(scaffolded.error);
+    }
+
+    const finishCreate = async (): Promise<
+      Result<{ created: string[]; dir: string; name: string }, Error>
+    > => {
+      const surfaceFiles = await collectSurfaceFiles(
+        input.surfaces,
+        (surface) =>
+          cross<SurfaceResult>(
+            'add.surface',
+            buildSurfaceInput(scaffolded.value.dir, surface)
+          )
+      );
+      if (surfaceFiles.isErr()) {
+        return Result.err(surfaceFiles.error);
+      }
+
+      const verifyFiles = await collectVerifyFiles(input.verify, () =>
+        cross<{ created: string[] }>('add.verify', buildVerifyInput(input))
+      );
+      if (verifyFiles.isErr()) {
+        return Result.err(verifyFiles.error);
+      }
+
+      return Result.ok({
+        created: collectCreatedFiles(
+          scaffolded.value.created,
+          surfaceFiles.value,
+          verifyFiles.value
+        ),
+        dir: scaffolded.value.dir,
+        name: input.name,
+      });
+    };
+
+    return finishCreate();
   },
   crosses: ['create.scaffold', 'add.surface', 'add.verify'],
   description: 'Create a new Trails project',

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -7,6 +7,8 @@
 
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { DRAFT_ID_PREFIX } from '@ontrails/core';
 import { parseSync } from 'oxc-parser';
 
 // ---------------------------------------------------------------------------
@@ -255,7 +257,7 @@ export const FRAMEWORK_DRAFT_PREFIX_CONSTANT_NAMES: ReadonlySet<string> =
  * redeclare `DRAFT_ID_PREFIX = '_draft.something-else'` and accidentally
  * suppress its own draft-id diagnostic.
  */
-const FRAMEWORK_DRAFT_PREFIX_LITERAL = '_draft.';
+const FRAMEWORK_DRAFT_PREFIX_LITERAL = DRAFT_ID_PREFIX;
 
 /**
  * Absolute paths of the two framework files allowed to declare the


### PR DESCRIPTION
## Summary
- make governance failures actually fail the CI workflow instead of being advisory
- preserve the contract that warning-only findings annotate without blocking when `failOn=error`
- add a CLI smoke path that proves the GitHub formatter and exit codes behave correctly for known-bad governance input

## Verification
- `cd apps/ci && bun test ./src/__tests__/cli.test.ts --bail`
- `bun run test`
- `bun run check`
- bottom-up branch verification pass on `trl-366-governance-failures-block-ci-gate`

Closes: TRL-366
