### PR TITLE
refactor(tracing): re-export only public core tracing APIs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -357,11 +357,14 @@ registerTraceSink(sink)              // install a sink for trace records
 getTraceSink()                       // get the currently registered sink
 clearTraceSink()                     // revert to the default no-op sink
 NOOP_SINK                            // stable disabled-tracing sentinel
+TRACE_CONTEXT_KEY                    // context extensions key for the active trace context
+createTraceRecord(options)           // construct a root or child TraceRecord explicitly
 
 // Sinks
 createMemorySink()                   // in-memory sink for testing
 createDevStore(options?)             // SQLite-backed persistent sink for development
 createOtelConnector(options?)        // OpenTelemetry span exporter
+toTraceStore(store)                  // read-only TraceStore view that does not own the writable connection
 
 // Resource & trails
 tracingResource                      // resource for tracing state

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -190,10 +190,12 @@ export type { ExecuteTrailOptions } from './execute.js';
 // Intrinsic tracing
 export {
   clearTraceSink,
+  createTraceRecord,
   getTraceContext,
   getTraceSink,
   NOOP_SINK,
   registerTraceSink,
+  TRACE_CONTEXT_KEY,
 } from './internal/tracing.js';
 export type {
   TraceContext,

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -110,17 +110,19 @@ try {
 SQLite-backed persistence for local development:
 
 ```typescript
-import { createDevStore, toTraceStore, registerTraceSink } from '@ontrails/tracing';
+import { createDevStore, registerTraceSink } from '@ontrails/tracing';
 
 const store = createDevStore({
   path: './debug.db',
   maxRecords: 50000,
   maxAge: 1000 * 60 * 60 * 24 * 30,
 });
-registerTraceSink(toTraceStore(store));
+registerTraceSink(store);
 ```
 
-The dev store uses WAL mode and prunes automatically.
+The dev store uses WAL mode and prunes automatically. Use `toTraceStore(store)`
+only when you need a read-only view for consumers that must not own the
+underlying writable connection.
 
 ### OpenTelemetry connector
 

--- a/packages/tracing/src/__tests__/intrinsic-tracing.test.ts
+++ b/packages/tracing/src/__tests__/intrinsic-tracing.test.ts
@@ -12,8 +12,8 @@ import {
   signal,
   trail,
   topo,
+  TRACE_CONTEXT_KEY,
 } from '@ontrails/core';
-import { TRACE_CONTEXT_KEY } from '@ontrails/core/internal/tracing';
 import type {
   AnyTrail,
   CrossBatchOptions,

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -6,15 +6,13 @@ export {
   type TraceRecord,
   type TraceSink,
   clearTraceSink,
+  createTraceRecord,
   getTraceContext,
   getTraceSink,
   NOOP_SINK,
   registerTraceSink,
-} from '@ontrails/core';
-export {
   TRACE_CONTEXT_KEY,
-  createTraceRecord,
-} from '@ontrails/core/internal/tracing';
+} from '@ontrails/core';
 
 // Tracing-package-owned utilities
 export { createMemorySink } from './memory-sink.js';

--- a/packages/tracing/src/trace-context.ts
+++ b/packages/tracing/src/trace-context.ts
@@ -8,7 +8,7 @@
 import type { TraceContext } from '@ontrails/core';
 
 export { getTraceContext, type TraceContext } from '@ontrails/core';
-export { TRACE_CONTEXT_KEY } from '@ontrails/core/internal/tracing';
+export { TRACE_CONTEXT_KEY } from '@ontrails/core';
 
 /** Create a child trace context inheriting from a parent. */
 export const createChildTraceContext = (

--- a/packages/tracing/src/trace-record.ts
+++ b/packages/tracing/src/trace-record.ts
@@ -5,4 +5,4 @@
  * duplicating the definition.
  */
 export { type TraceRecord } from '@ontrails/core';
-export { createTraceRecord } from '@ontrails/core/internal/tracing';
+export { createTraceRecord } from '@ontrails/core';


### PR DESCRIPTION
## Summary
- promote the stable trace primitives to public `@ontrails/core` exports
- have `@ontrails/tracing` re-export those tracing APIs from the public core path instead of the internal module path
- fix the tracing README so the dev-store flow uses `createDevStore(...)` as the writable sink and keeps `toTraceStore()` read-only

## Verification
- `cd packages/core && bun run build`
- `cd packages/tracing && bun run build && bun test --bail`
- bottom-up branch verification pass on `trl-378-tracing-public-contract-cleanup`

Closes: TRL-378, TRL-383
