### PR TITLE
fix(hono): preserve raw query value shapes

### DIFF
--- a/connectors/hono/src/__tests__/surface.test.ts
+++ b/connectors/hono/src/__tests__/surface.test.ts
@@ -12,6 +12,13 @@ const echoTrail = trail('echo', {
   output: z.object({ reply: z.string() }),
 });
 
+const tagsTrail = trail('tags', {
+  blaze: (input) => Result.ok({ tags: input.tags }),
+  input: z.object({ tags: z.array(z.string()) }),
+  intent: 'read',
+  output: z.object({ tags: z.array(z.string()) }),
+});
+
 describe('surface API (Hono connector)', () => {
   test('createApp materializes the Hono surface without serving', async () => {
     const graph = topo('surface-api', { echoTrail });
@@ -36,5 +43,35 @@ describe('surface API (Hono connector)', () => {
     } finally {
       await handle.close();
     }
+  });
+
+  test('repeated query keys arrive as arrays for GET routes', async () => {
+    const graph = topo('surface-api', { tagsTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/tags?tags=red&tags=blue', {
+      method: 'GET',
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: { tags: ['red', 'blue'] },
+    });
+  });
+
+  test('single query values stay scalar even when the schema expects an array', async () => {
+    const graph = topo('surface-api', { tagsTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/tags?tags=solo', {
+      method: 'GET',
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: {
+        category: 'validation',
+      },
+    });
   });
 });

--- a/connectors/hono/src/surface.ts
+++ b/connectors/hono/src/surface.ts
@@ -21,8 +21,6 @@ import type {
 import { Hono } from 'hono';
 import type { Context as HonoContext } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
-import type { z } from 'zod';
-
 import { deriveHttpRoutes } from '@ontrails/http';
 import type { HttpMethod, HttpRouteDefinition } from '@ontrails/http';
 
@@ -61,71 +59,24 @@ export interface SurfaceHttpResult {
 // ---------------------------------------------------------------------------
 
 /**
- * Build a set of field names that the input schema expects as arrays.
+ * Parse query params into a plain object, preserving scalar-vs-array shape.
  *
- * Inspects the Zod v4 `_zod.def` internals to find top-level array fields.
- * Returns an empty set when the schema is not an object or cannot be inspected.
+ * A single `?tag=one` stays a scalar string, while repeated keys like
+ * `?tag=one&tag=two` become arrays. Schema validation owns whether that shape
+ * is accepted; the connector does not coerce singleton values into arrays.
  */
-interface ZodDef {
-  _zod: { def: Record<string, unknown> };
-}
-
-/** Unwrap optional/default wrappers to reach the underlying Zod type name. */
-const unwrapZodType = (node: ZodDef): string => {
-  let current = node;
-  while (
-    (current._zod.def['type'] as string) === 'optional' ||
-    (current._zod.def['type'] as string) === 'default'
-  ) {
-    current = current._zod.def['innerType'] as ZodDef;
-  }
-  return current._zod.def['type'] as string;
-};
-
-/** Extract the object shape from a Zod schema, or undefined if not an object. */
-const extractShape = (
-  schema: z.ZodType
-): Record<string, ZodDef> | undefined => {
-  const s = schema as unknown as ZodDef;
-  if ((s._zod.def['type'] as string) !== 'object') {
-    return undefined;
-  }
-  return s._zod.def['shape'] as Record<string, ZodDef> | undefined;
-};
-
-/** Collect top-level field names whose underlying type is array. */
-const collectArrayKeys = (
-  inputSchema: z.ZodType | undefined
-): ReadonlySet<string> => {
-  const shape = inputSchema ? extractShape(inputSchema) : undefined;
-  if (!shape) {
-    return new Set();
-  }
-  const keys = new Set<string>();
-  for (const [key, value] of Object.entries(shape)) {
-    if (unwrapZodType(value) === 'array') {
-      keys.add(key);
-    }
-  }
-  return keys;
-};
-
-/** Parse query params into a plain object, preserving raw strings for Zod. */
-const parseQueryParams = (
-  c: HonoContext,
-  inputSchema?: z.ZodType | undefined
-): Record<string, unknown> => {
+const parseQueryParams = (c: HonoContext): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
   const url = new URL(c.req.url);
-  const arrayKeys = collectArrayKeys(inputSchema);
+  const seenKeys = new Set<string>();
 
   for (const key of url.searchParams.keys()) {
-    // Already collected via getAll
-    if (key in result) {
+    if (seenKeys.has(key)) {
       continue;
     }
+    seenKeys.add(key);
     const all = url.searchParams.getAll(key);
-    result[key] = all.length > 1 || arrayKeys.has(key) ? all : all[0];
+    result[key] = all.length > 1 ? all : all[0];
   }
 
   return result;
@@ -147,11 +98,10 @@ const isEmptyBody = (c: HonoContext): boolean => {
 /** Read input from request based on input source. */
 const readInput = async (
   c: HonoContext,
-  inputSource: 'query' | 'body',
-  inputSchema?: z.ZodType | undefined
+  inputSource: 'query' | 'body'
 ): Promise<unknown> => {
   if (inputSource === 'query') {
-    return parseQueryParams(c, inputSchema);
+    return parseQueryParams(c);
   }
   if (isEmptyBody(c)) {
     return {};
@@ -224,7 +174,7 @@ const handleCaughtError = (error: unknown, c: HonoContext): Response => {
 const createHonoHandler =
   (route: HttpRouteDefinition) =>
   async (c: HonoContext): Promise<Response> => {
-    const rawInput = await readInput(c, route.inputSource, route.trail.input);
+    const rawInput = await readInput(c, route.inputSource);
 
     if (rawInput === JSON_PARSE_ERROR) {
       return c.json(

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -93,6 +93,11 @@ Each route definition produced by `deriveHttpRoutes` includes:
 | `trail` | `Trail` | The original trail definition |
 | `execute` | `(input, requestId?, abortSignal?) => Promise<Result>` | Validates, layers, and runs the implementation |
 
+For GET routes on the Hono surface, repeated query keys are passed through as
+arrays (`?tag=one&tag=two` -> `{ tag: ['one', 'two'] }`) while a single
+occurrence stays a scalar string. The connector does not coerce singleton query
+values into arrays.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- remove Zod-internal query-array introspection from the Hono surface
- preserve raw query value shapes so single query keys stay scalar and repeated keys become arrays
- let schema validation own scalar-vs-array acceptance instead of silently coercing singleton values

## Verification
- `cd connectors/hono && bun run build && bun test --bail`
- bottom-up branch verification pass on `trl-372-hono-query-ingress-semantics`

Closes: TRL-372
