### PR TITLE
fix(apps): make survey freshness explicit

### DIFF
--- a/apps/trails/src/__tests__/load-app.test.ts
+++ b/apps/trails/src/__tests__/load-app.test.ts
@@ -11,7 +11,7 @@ import {
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
-import { loadApp } from '../trails/load-app.js';
+import { loadApp, loadFreshAppLease } from '../trails/load-app.js';
 
 const writeLoadAppFixture = (cwd: string, name: string): void => {
   writeFileSync(
@@ -188,6 +188,17 @@ const assertStaleDirCleaned = (cwd: string, staleDir: string): void => {
   expect(remaining.length).toBeGreaterThan(0);
 };
 
+const countFreshMirrorRoots = (cwd: string): number => {
+  const mirrorParent = resolve(cwd, '.trails-tmp');
+  if (!existsSync(mirrorParent)) {
+    return 0;
+  }
+
+  return readdirSync(mirrorParent).filter((entry) =>
+    entry.startsWith('load-app-fresh-')
+  ).length;
+};
+
 const workspaceTmpRoot = resolve(import.meta.dir, '../..', '.tmp-tests');
 
 describe('loadApp', () => {
@@ -328,6 +339,58 @@ export const app = {
       const staleDir = seedStaleMirrorDir(cwd);
       await loadApp('./src/app.ts', cwd, { fresh: true });
       assertStaleDirCleaned(cwd, staleDir);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('loadApp fresh lifecycle', () => {
+  test('leased fresh loads remove their mirror root when released', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-lease-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      writeLoadAppFixture(cwd, 'leased');
+
+      const lease = await loadFreshAppLease('./src/app.ts', cwd);
+
+      expect(lease.app.name).toBe('leased');
+      expect(existsSync(lease.mirrorRoot)).toBe(true);
+
+      lease.release();
+
+      expect(existsSync(lease.mirrorRoot)).toBe(false);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('fresh loading retains mirrors so deferred imports from earlier apps still resolve', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-retained-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+
+      for (let index = 0; index < 6; index += 1) {
+        writeLoadAppFixture(cwd, `retained-${String(index)}`);
+        await loadApp('./src/app.ts', cwd, { fresh: true });
+      }
+
+      // All fresh mirrors stay on disk for the lifetime of the process so a
+      // previously returned Topo can still resolve deferred relative
+      // `import()` calls. Cleanup happens on process exit, not by LRU age.
+      expect(countFreshMirrorRoots(cwd)).toBe(6);
     } finally {
       rmSync(cwd, { force: true, recursive: true });
     }

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -13,6 +13,7 @@ import {
   deriveSurfaceMap,
   deriveSurfaceMapHash,
   deriveSurfaceMapDiff,
+  writeSurfaceMap,
 } from '@ontrails/schema';
 import type { SurfaceMap } from '@ontrails/schema';
 import { z } from 'zod';
@@ -23,6 +24,7 @@ import {
   deriveTrailDetail,
   surveyTrail,
 } from '../trails/survey.js';
+import { loadApp } from '../trails/load-app.js';
 import type {
   BriefReport,
   SurveyListReport,
@@ -88,8 +90,24 @@ const expectOk = <T>(result: Result<T, Error>): T => {
   return result.value;
 };
 
-const writeSurveyAppFixture = (dir: string): void => {
+const writeSurveyAppFixture = (
+  dir: string,
+  options?: { withBye?: boolean }
+) => {
   mkdirSync(join(dir, 'src'), { recursive: true });
+  const byeSource = options?.withBye
+    ? `
+const bye = trail('bye', {
+  blaze: async (input) => Result.ok({ message: \`Bye, \${input.name ?? 'world'}!\` }),
+  input: z.object({ name: z.string().optional() }),
+  intent: 'read',
+  output: z.object({ message: z.string() }),
+});
+`
+    : '';
+  const topoMembers = options?.withBye
+    ? '{ bye, dbMain, hello }'
+    : '{ dbMain, hello }';
   writeFileSync(
     join(dir, 'src', 'app.ts'),
     `import { Result, resource, topo, trail } from '@ontrails/core';
@@ -112,7 +130,9 @@ if (!dbMain) {
   throw new Error('expected hello to declare db.main');
 }
 
-export const app = topo('survey-fixture', { dbMain, hello });
+${byeSource}
+
+export const app = topo('survey-fixture', ${topoMembers});
 `
   );
 };
@@ -297,6 +317,58 @@ describe('trails survey generate', () => {
       ).toMatchObject({
         hash: generated.hash,
         version: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('trails survey diffSaved', () => {
+  test('returns an error when no saved surface map exists yet', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+
+      const result = await surveyTrail.blaze(
+        { diffSaved: true, module: './src/app.ts' },
+        { cwd: dir } as never
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error.message).toContain('Run `trails topo export` first');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('diffs against the saved local surface map', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+      const baselineApp = await loadApp('./src/app.ts', dir);
+      await writeSurfaceMap(deriveSurfaceMap(baselineApp), {
+        dir: join(dir, '.trails'),
+      });
+
+      writeSurveyAppFixture(dir, { withBye: true });
+
+      const result = await surveyTrail.blaze(
+        { diffSaved: true, module: './src/app.ts' },
+        { cwd: dir } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.value).toMatchObject({
+        hasBreaking: false,
+        info: [
+          expect.objectContaining({
+            change: 'added',
+            id: 'bye',
+          }),
+        ],
       });
     } finally {
       rmSync(dir, { force: true, recursive: true });

--- a/apps/trails/src/trails/draft-promote.ts
+++ b/apps/trails/src/trails/draft-promote.ts
@@ -8,6 +8,7 @@ import {
   isDraftId,
   trail,
 } from '@ontrails/core';
+import type { Topo } from '@ontrails/core';
 import {
   DRAFT_FILE_PREFIX,
   findStringLiterals,
@@ -17,7 +18,7 @@ import {
 } from '@ontrails/warden';
 import { z } from 'zod';
 
-import { loadApp } from './load-app.js';
+import { loadFreshAppLease } from './load-app.js';
 import { findTopoPath } from './project.js';
 
 interface PromotionEdit {
@@ -164,10 +165,8 @@ const replaceLiteralValue = (
   };
 };
 
-const collectOutputId = (
-  app: Awaited<ReturnType<typeof loadApp>>,
-  id: string
-) => app.get(id) ?? app.signals.get(id) ?? app.getResource(id);
+const collectOutputId = (app: Topo, id: string) =>
+  app.get(id) ?? app.signals.get(id) ?? app.getResource(id);
 
 const toRelativeOutputPath = (rootDir: string, filePath: string): string =>
   relative(rootDir, filePath).replaceAll('\\', '/');
@@ -185,7 +184,6 @@ interface PromotionRewriteState {
 interface PromotionLoadState {
   readonly appModule: string | null;
   readonly loadError: string | null;
-  readonly loadedApp: Awaited<ReturnType<typeof loadApp>> | undefined;
 }
 
 const validatePromotionInput = (input: {
@@ -511,23 +509,56 @@ const resolvePromotionAppModule = async (
   );
 };
 
-const loadVerifiedApp = async (
-  appModule: string | null,
+/**
+ * Run `consume` while holding a fresh-load lease on `appModule`.
+ *
+ * @remarks
+ * The lease deletes its on-disk mirror on release. Any Topo consumption that
+ * may trigger deferred filesystem imports (for example inside a trail's
+ * `blaze` or a lazy relative `import()`) must run before the lease is
+ * released, otherwise those resolutions race the mirror teardown. Collapsing
+ * consumption into the leased critical section keeps that contract
+ * structural rather than relying on the caller to discover it.
+ */
+type LeaseAttempt =
+  | {
+      readonly ok: true;
+      readonly lease: Awaited<ReturnType<typeof loadFreshAppLease>>;
+    }
+  | { readonly ok: false; readonly loadError: string };
+
+const tryAcquireLease = async (
+  appModule: string,
   rootDir: string
-): Promise<PromotionLoadState> => {
+): Promise<LeaseAttempt> => {
+  try {
+    return { lease: await loadFreshAppLease(appModule, rootDir), ok: true };
+  } catch (error) {
+    const loadError = error instanceof Error ? error.message : String(error);
+    return { loadError, ok: false };
+  }
+};
+
+const withVerifiedApp = async <T>(
+  appModule: string | null,
+  rootDir: string,
+  consume: (app: Topo) => T | Promise<T>
+): Promise<{ readonly load: PromotionLoadState; readonly value: T | null }> => {
   if (appModule === null) {
-    return { appModule, loadError: null, loadedApp: undefined };
+    return { load: { appModule, loadError: null }, value: null };
   }
 
-  let loadError: string | null = null;
-  const loadedApp = await loadApp(appModule, rootDir, { fresh: true }).catch(
-    (error: unknown): undefined => {
-      loadError = error instanceof Error ? error.message : String(error);
-      return undefined;
-    }
-  );
+  const attempt = await tryAcquireLease(appModule, rootDir);
+  if (!attempt.ok) {
+    return { load: { appModule, loadError: attempt.loadError }, value: null };
+  }
 
-  return { appModule, loadError, loadedApp };
+  try {
+    const value = await consume(attempt.lease.app);
+    return { load: { appModule, loadError: null }, value };
+  } finally {
+    attempt.lease.release();
+  }
 };
 
 const toRenamedFiles = (rootDir: string, renames: readonly FileRename[]) =>
@@ -589,7 +620,7 @@ const buildVerifiedPromotionResult = (
 
 const buildVerifiedPromotionResultFromApp = (
   rootDir: string,
-  loadedApp: Awaited<ReturnType<typeof loadApp>>,
+  loadedApp: Topo,
   renames: readonly FileRename[],
   updatedSourceFiles: Set<string>,
   appModule: string | null,
@@ -633,13 +664,11 @@ const promoteDraftState = async (
 
   const { renames, updatedSourceFiles } = rewriteResult.value;
   const appModule = await resolvePromotionAppModule(input, rootDirResult.value);
-  const { loadError, loadedApp } = await loadVerifiedApp(
+  const { load, value } = await withVerifiedApp(
     appModule,
-    rootDirResult.value
-  );
-
-  return loadedApp
-    ? buildVerifiedPromotionResultFromApp(
+    rootDirResult.value,
+    (loadedApp) =>
+      buildVerifiedPromotionResultFromApp(
         rootDirResult.value,
         loadedApp,
         renames,
@@ -647,13 +676,18 @@ const promoteDraftState = async (
         appModule,
         input.toId
       )
-    : buildUnverifiedPromotionResult(
-        rootDirResult.value,
-        loadError,
-        renames,
-        updatedSourceFiles,
-        appModule
-      );
+  );
+
+  return (
+    value ??
+    buildUnverifiedPromotionResult(
+      rootDirResult.value,
+      load.loadError,
+      renames,
+      updatedSourceFiles,
+      appModule
+    )
+  );
 };
 
 export const draftPromoteTrail = trail('draft.promote', {

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -54,12 +54,14 @@ const getImportScanner = (loader: TranspilerLoader): Bun.Transpiler => {
  * the mirrors on disk and clean them up once, on process exit.
  */
 const ACTIVE_MIRROR_ROOTS = new Set<string>();
+const RETAINED_MIRROR_ROOTS = new Set<string>();
 
 const cleanupAllMirrorRoots = (): void => {
-  for (const root of ACTIVE_MIRROR_ROOTS) {
+  for (const root of [...ACTIVE_MIRROR_ROOTS, ...RETAINED_MIRROR_ROOTS]) {
     rmSync(root, { force: true, recursive: true });
   }
   ACTIVE_MIRROR_ROOTS.clear();
+  RETAINED_MIRROR_ROOTS.clear();
 };
 
 const mirrorCleanup = (() => {
@@ -77,6 +79,39 @@ const mirrorCleanup = (() => {
 
 const ensureMirrorCleanupHook = (): void => {
   mirrorCleanup.ensureRegistered();
+};
+
+/**
+ * Retain a fresh-import mirror for the lifetime of the process. A previously
+ * returned `loadApp` result may hold deferred relative `import()` calls whose
+ * resolution requires the mirror directory to still exist, so we cannot prune
+ * these by age without risking ENOENT in long-lived sessions (dev server,
+ * survey polling, concurrent fresh loads). Cleanup happens once on process
+ * exit via `cleanupAllMirrorRoots`.
+ */
+const retainMirrorRoot = (mirrorRoot: string): void => {
+  if (RETAINED_MIRROR_ROOTS.has(mirrorRoot)) {
+    return;
+  }
+  RETAINED_MIRROR_ROOTS.add(mirrorRoot);
+  ensureMirrorCleanupHook();
+};
+
+const acquireMirrorLease = (mirrorRoot: string): (() => void) => {
+  ACTIVE_MIRROR_ROOTS.add(mirrorRoot);
+  ensureMirrorCleanupHook();
+
+  let released = false;
+
+  return () => {
+    if (released) {
+      return;
+    }
+
+    released = true;
+    ACTIVE_MIRROR_ROOTS.delete(mirrorRoot);
+    rmSync(mirrorRoot, { force: true, recursive: true });
+  };
 };
 
 const resolveUrlModulePath = (modulePath: string): string => {
@@ -251,7 +286,10 @@ const safeStat = (
 const STALE_MIRROR_THRESHOLD_MS = 10 * 60 * 1000;
 
 const isStaleMirrorEntry = (entryPath: string, now: number): boolean => {
-  if (ACTIVE_MIRROR_ROOTS.has(entryPath)) {
+  if (
+    ACTIVE_MIRROR_ROOTS.has(entryPath) ||
+    RETAINED_MIRROR_ROOTS.has(entryPath)
+  ) {
     return false;
   }
   const entryStat = safeStat(entryPath);
@@ -438,12 +476,85 @@ const importFreshModule = async (
   }
 
   const { mirrorRoot, freshPath } = await prepareMirror(absolutePath, cwd);
-  ACTIVE_MIRROR_ROOTS.add(mirrorRoot);
-  ensureMirrorCleanupHook();
+  retainMirrorRoot(mirrorRoot);
   return (await import(pathToFileURL(freshPath).href)) as Record<
     string,
     unknown
   >;
+};
+
+const resolveLoadedTopo = (
+  effectivePath: string,
+  mod: Record<string, unknown>
+): Topo => {
+  const app = (mod['default'] ?? mod['graph'] ?? mod['app']) as
+    | Topo
+    | undefined;
+  if (!app?.trails) {
+    throw new Error(
+      `Could not find a Topo export in "${effectivePath}". ` +
+        "Expected a default, 'graph', or 'app' named export created with topo()."
+    );
+  }
+  return app;
+};
+
+export interface FreshAppLease {
+  readonly app: Topo;
+  readonly mirrorRoot: string;
+  readonly release: () => void;
+}
+
+const noopRelease = (): void => undefined;
+
+const createUrlSchemeLease = async (
+  absolutePath: string,
+  effectivePath: string
+): Promise<FreshAppLease> => ({
+  app: resolveLoadedTopo(
+    effectivePath,
+    await importWithCacheBust(absolutePath)
+  ),
+  mirrorRoot: absolutePath,
+  release: noopRelease,
+});
+
+const createFilesystemLease = async (
+  absolutePath: string,
+  cwd: string,
+  effectivePath: string
+): Promise<FreshAppLease> => {
+  const { mirrorRoot, freshPath } = await prepareMirror(absolutePath, cwd);
+  const release = acquireMirrorLease(mirrorRoot);
+
+  try {
+    const mod = (await import(pathToFileURL(freshPath).href)) as Record<
+      string,
+      unknown
+    >;
+
+    return {
+      app: resolveLoadedTopo(effectivePath, mod),
+      mirrorRoot,
+      release,
+    };
+  } catch (error) {
+    release();
+    throw error;
+  }
+};
+
+export const loadFreshAppLease = async (
+  modulePath: string | undefined,
+  cwd: string
+): Promise<FreshAppLease> => {
+  const effectivePath =
+    modulePath === undefined ? findAppModule(cwd) : modulePath;
+  const absolutePath = resolveAbsoluteModulePath(effectivePath, cwd);
+
+  return URL_SCHEME.test(absolutePath) && !absolutePath.startsWith('/')
+    ? await createUrlSchemeLease(absolutePath, effectivePath)
+    : await createFilesystemLease(absolutePath, cwd, effectivePath);
 };
 
 /** Load a Topo export from a module path relative to cwd. */
@@ -464,14 +575,5 @@ export const loadApp = async (
             ? new URL(resolvedModulePath).href
             : pathToFileURL(resolvedModulePath).href
         )) as Record<string, unknown>);
-  const app = (mod['default'] ?? mod['graph'] ?? mod['app']) as
-    | Topo
-    | undefined;
-  if (!app?.trails) {
-    throw new Error(
-      `Could not find a Topo export in "${effectivePath}". ` +
-        "Expected a default, 'graph', or 'app' named export created with topo()."
-    );
-  }
-  return app;
+  return resolveLoadedTopo(effectivePath, mod);
 };

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -5,6 +5,8 @@
  * and diffs against previous versions.
  */
 
+import { join } from 'node:path';
+
 import type { Topo } from '@ontrails/core';
 import { NotFoundError, Result, trail } from '@ontrails/core';
 import type { DiffResult } from '@ontrails/schema';
@@ -16,7 +18,7 @@ import {
 } from '@ontrails/schema';
 import { z } from 'zod';
 
-import { loadApp } from './load-app.js';
+import { loadApp, loadFreshAppLease } from './load-app.js';
 import {
   buildCurrentTopoBrief,
   buildCurrentTopoDetail,
@@ -49,14 +51,15 @@ const formatDiff = (diff: DiffResult): object => ({
 
 const buildSurveyDiff = async (
   app: Topo,
+  rootDir: string,
   breakingOnly: boolean
 ): Promise<Result<object, Error>> => {
   const currentMap = deriveSurfaceMap(app);
-  const previousMap = await readSurfaceMap();
+  const previousMap = await readSurfaceMap({ dir: join(rootDir, '.trails') });
   if (!previousMap) {
     return Result.err(
       new NotFoundError(
-        'No previous surface map found. Run `trails topo export` first.'
+        'No saved surface map found. Run `trails topo export` first.'
       )
     );
   }
@@ -106,7 +109,7 @@ const buildSurveyGenerate = async (
 interface SurveyInput {
   breakingOnly: boolean;
   brief: boolean;
-  diff?: string | undefined;
+  diffSaved: boolean;
   generate: boolean;
   openapi: boolean;
   trailId?: string | undefined;
@@ -117,7 +120,7 @@ type SurveyMode = 'brief' | 'detail' | 'diff' | 'generate' | 'list' | 'openapi';
 /** Ordered mode checks — first truthy predicate wins, otherwise 'list'. */
 const modeChecks: readonly [(input: SurveyInput) => boolean, SurveyMode][] = [
   [(i) => i.brief, 'brief'],
-  [(i) => Boolean(i.diff), 'diff'],
+  [(i) => i.diffSaved, 'diff'],
   [(i) => Boolean(i.trailId), 'detail'],
   [(i) => i.generate, 'generate'],
   [(i) => i.openapi, 'openapi'],
@@ -139,7 +142,8 @@ const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
     Result.ok(buildCurrentTopoBrief(app, { rootDir })),
   detail: (app, input, rootDir) =>
     buildSurveyDetail(app, input.trailId ?? '', rootDir),
-  diff: (app, input) => buildSurveyDiff(app, input.breakingOnly),
+  diff: (app, input, rootDir) =>
+    buildSurveyDiff(app, rootDir, input.breakingOnly),
   generate: (app, _input, rootDir) => buildSurveyGenerate(app, rootDir),
   list: (app, _input, rootDir) =>
     Result.ok(buildCurrentTopoList(app, { rootDir })),
@@ -164,6 +168,27 @@ const dispatchSurvey = (
 export const surveyTrail = trail('survey', {
   blaze: async (input, ctx) => {
     const rootDir = ctx.cwd ?? '.';
+    const mode = deriveSurveyMode(input);
+    // Fresh load only for diffSaved: comparing against a previously-saved
+    // surface map requires the current app's source state, not any cached
+    // module graph that a prior import may have frozen. Other modes read
+    // the in-memory topo and benefit from the standard import cache.
+    //
+    // For diff specifically, use a disposable lease rather than retained
+    // fresh mirrors — the returned diff result is serialisable data, not
+    // a Topo reference with deferred imports, so the mirror can be
+    // released the moment dispatchSurvey returns. That keeps MCP/dev
+    // sessions that poll diff repeatedly from growing .trails-tmp/
+    // without bound.
+    if (mode === 'diff') {
+      const lease = await loadFreshAppLease(input.module, rootDir);
+      try {
+        return await dispatchSurvey(lease.app, input, rootDir);
+      } finally {
+        lease.release();
+      }
+    }
+
     const app = await loadApp(input.module, rootDir);
     return dispatchSurvey(app, input, rootDir);
   },
@@ -191,7 +216,10 @@ export const surveyTrail = trail('survey', {
       .default(false)
       .describe('Only show breaking changes'),
     brief: z.boolean().default(false).describe('Quick capability summary'),
-    diff: z.string().optional().describe('Diff against a git ref'),
+    diffSaved: z
+      .boolean()
+      .default(false)
+      .describe('Diff against the saved local surface map'),
     generate: z
       .boolean()
       .default(false)


### PR DESCRIPTION
## Summary
- replace the misleading survey diff-ref mode with explicit `diffSaved` behavior against the saved local surface map
- keep fresh app mirrors under repo-local `.trails-tmp` for workspace-resolution correctness
- add leased fresh-load lifecycle cleanup plus bounded mirror retention so long-lived sessions do not leak mirror roots indefinitely

## Verification
- `cd apps/trails && bun test ./src/__tests__/survey.test.ts ./src/__tests__/load-app.test.ts --bail`
- bottom-up branch verification pass on `trl-371-survey-honesty-and-fresh-load-lifecycle`

Closes: TRL-371, TRL-373
