### PR TITLE
feat(apps): require authored trail scaffold metadata

### DIFF
--- a/apps/trails/src/__tests__/add-trail.test.ts
+++ b/apps/trails/src/__tests__/add-trail.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import type { Result } from '@ontrails/core';
+import { ValidationError, validateInput } from '@ontrails/core';
+
+import { addTrail } from '../trails/add-trail.js';
+
+const repoTempDir = (): string =>
+  join(
+    resolve(import.meta.dir, '../..'),
+    '.tmp-tests',
+    `add-trail-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+
+const expectOk = <T>(result: Result<T, Error>): T => {
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const expectValidationError = (
+  result: Result<unknown, Error>
+): ValidationError => {
+  if (result.isOk()) {
+    throw new Error('Expected validation error');
+  }
+  expect(result.error).toBeInstanceOf(ValidationError);
+  return result.error as ValidationError;
+};
+
+const readGeneratedFile = (dir: string, relativePath: string): string => {
+  const filePath = join(dir, relativePath);
+  expect(existsSync(filePath)).toBe(true);
+  return readFileSync(filePath, 'utf8');
+};
+
+const assertGeneratedScaffold = (dir: string): void => {
+  const trailSource = readGeneratedFile(dir, 'src/trails/entity-prepare.ts');
+  const testSource = readGeneratedFile(dir, '__tests__/entity-prepare.test.ts');
+
+  expect(trailSource).toContain('description: "Prepare an entity for export"');
+  expect(trailSource).toContain('name: "Prepare a draft entity"');
+  expect(trailSource).toContain(
+    'expected: { message: "entity.prepare completed" }'
+  );
+  expect(testSource).toContain('description: "Prepare a draft entity"');
+  expect(testSource).toContain(
+    'expectValue: { message: "entity.prepare completed" }'
+  );
+  expect(trailSource).not.toContain('TODO');
+  expect(testSource).not.toContain('TODO');
+};
+
+describe('add.trail', () => {
+  test('requires authored description and example metadata', () => {
+    const error = expectValidationError(
+      validateInput(addTrail.input, {
+        id: 'entity.prepare',
+        intent: 'write',
+      })
+    );
+
+    expect(error.message).toContain('description');
+    expect(error.message).toContain('exampleName');
+  });
+
+  test('writes starter files without TODO placeholders', async () => {
+    const dir = repoTempDir();
+
+    try {
+      mkdirSync(dir, { recursive: true });
+
+      const result = expectOk(
+        await addTrail.blaze(
+          {
+            description: 'Prepare an entity for export',
+            exampleName: 'Prepare a draft entity',
+            id: 'entity.prepare',
+            intent: 'write',
+          },
+          { cwd: dir } as never
+        )
+      );
+
+      expect(result.created).toEqual([
+        'src/trails/entity-prepare.ts',
+        '__tests__/entity-prepare.test.ts',
+      ]);
+      assertGeneratedScaffold(dir);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/trails/src/trails/add-trail.ts
+++ b/apps/trails/src/trails/add-trail.ts
@@ -12,40 +12,53 @@ import { z } from 'zod';
 // Helpers
 // ---------------------------------------------------------------------------
 
+const literal = (value: string): string => JSON.stringify(value);
+
+const deriveExampleMessage = (id: string): string => `${id} completed`;
+
 const generateTrailFile = (
   id: string,
+  description: string,
+  exampleName: string,
   intent: 'read' | 'write' | 'destroy'
 ): string => {
   const intentLine = intent === 'write' ? '' : `\n  intent: '${intent}',`;
+  const exampleMessage = deriveExampleMessage(id);
 
   return `import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 export const ${id.replaceAll('.', '_')} = trail('${id}', {
-  description: 'TODO: describe this trail',
+  blaze: async () => {
+    return Result.ok({ message: ${literal(exampleMessage)} });
+  },
+  description: ${literal(description)},
   examples: [
     {
+      expected: { message: ${literal(exampleMessage)} },
       input: {},
-      name: 'TODO: add example',
+      name: ${literal(exampleName)},
     },
   ],
-  blaze: async (input) => {
-    return Result.ok({ message: 'TODO' });
-  },
   input: z.object({}),${intentLine}
   output: z.object({ message: z.string() }),
 });
 `;
 };
 
-const generateTestFile = (id: string): string => {
+const generateTestFile = (id: string, exampleName: string): string => {
   const moduleName = id.replaceAll('.', '-');
   const trailName = id.replaceAll('.', '_');
+  const exampleMessage = deriveExampleMessage(id);
   return `import { testTrail } from '@ontrails/testing';
 import { ${trailName} } from '../src/trails/${moduleName}.js';
 
 testTrail(${trailName}, [
-  { description: 'basic test', input: {}, expectOk: true },
+  {
+    description: ${literal(exampleName)},
+    expectValue: { message: ${literal(exampleMessage)} },
+    input: {},
+  },
 ]);
 `;
 };
@@ -64,14 +77,26 @@ const writeWithDirs = async (
 };
 
 export const addTrail = trail('add.trail', {
+  args: ['id'],
   blaze: async (input, ctx) => {
     const { id } = input;
     const moduleName = id.replaceAll('.', '-');
     const cwd = resolve(ctx.cwd ?? '.');
 
     const files = new Map<string, string>([
-      [`src/trails/${moduleName}.ts`, generateTrailFile(id, input.intent)],
-      [`__tests__/${moduleName}.test.ts`, generateTestFile(id)],
+      [
+        `src/trails/${moduleName}.ts`,
+        generateTrailFile(
+          id,
+          input.description,
+          input.exampleName,
+          input.intent
+        ),
+      ],
+      [
+        `__tests__/${moduleName}.test.ts`,
+        generateTestFile(id, input.exampleName),
+      ],
     ]);
 
     for (const [relativePath, content] of files) {
@@ -82,7 +107,18 @@ export const addTrail = trail('add.trail', {
   },
   description: 'Scaffold a new trail with tests and examples',
   input: z.object({
-    id: z.string().describe('Trail ID (e.g., entity.update)'),
+    description: z
+      .string()
+      .min(1, 'Trail description is required')
+      .describe('Trail description'),
+    exampleName: z
+      .string()
+      .min(1, 'Starter example name is required')
+      .describe('Starter example name'),
+    id: z
+      .string()
+      .min(1, 'Trail ID is required')
+      .describe('Trail ID (e.g., entity.update)'),
     intent: z
       .enum(['read', 'write', 'destroy'])
       .default('write')


### PR DESCRIPTION
## Summary
- make `add.trail` require real authored scaffold metadata instead of emitting TODO placeholders
- use the existing prompt-resolution path for missing scalar inputs rather than introducing prompt logic inside the trail itself
- generate starter files and examples that are immediately coherent and reviewable

## Verification
- `cd apps/trails && bun test ./src/__tests__/add-trail.test.ts --bail`
- bottom-up branch verification pass on `trl-381-contract-first-add-trail-scaffolding`

Closes: TRL-381
