### PR TITLE
feat(governance): add established verification and permit checks

### DIFF
--- a/apps/ci/package.json
+++ b/apps/ci/package.json
@@ -8,6 +8,7 @@
     "test": "bun test src"
   },
   "dependencies": {
+    "@ontrails/cli": "workspace:^",
     "@ontrails/core": "workspace:^",
     "@ontrails/schema": "workspace:^",
     "@ontrails/warden": "workspace:^",

--- a/apps/ci/src/__tests__/governance-topo.test.ts
+++ b/apps/ci/src/__tests__/governance-topo.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { runCiGovernance } from '../governance.js';
+
+const repoTempDir = (): string =>
+  join(
+    resolve(import.meta.dir, '../..'),
+    '.tmp-tests',
+    `ci-governance-topo-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+
+const writePermitFixture = (dir: string): void => {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    `import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const destroyTrail = trail('entity.delete', {
+  blaze: async () => Result.ok({ ok: true }),
+  input: z.object({}),
+  intent: 'destroy',
+  output: z.object({ ok: z.boolean() }),
+});
+
+export const app = topo('permit-ci-fixture', { destroyTrail });
+`
+  );
+};
+
+describe('runCiGovernance topo loading', () => {
+  test('surfaces permit governance when an app topo is discoverable', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writePermitFixture(dir);
+
+      const result = await runCiGovernance({
+        failOn: 'error',
+        format: 'json',
+        rootDir: dir,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errorCount).toBeGreaterThan(0);
+      expect(result.output).toContain('permit.destroyWithoutPermit');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/ci/src/governance.ts
+++ b/apps/ci/src/governance.ts
@@ -1,7 +1,16 @@
+import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
+import { findAppModule } from '@ontrails/cli';
+import type { Topo } from '@ontrails/core';
+import { AmbiguousError, NotFoundError } from '@ontrails/core';
 import { runWarden } from '@ontrails/warden';
-import type { DriftResult, WardenReport } from '@ontrails/warden';
+import type {
+  DriftResult,
+  WardenDiagnostic,
+  WardenReport,
+} from '@ontrails/warden';
 
 import type { CiFormat } from './formatters.js';
 import { formatCiOutput } from './formatters.js';
@@ -30,6 +39,162 @@ const fallbackDriftResult: DriftResult = {
   currentHash: 'unknown',
   stale: false,
 };
+
+const resolveAppModulePath = (rootDir: string): string => {
+  const modulePath = resolve(rootDir, findAppModule(rootDir));
+  if (!modulePath.endsWith('.js') || existsSync(modulePath)) {
+    return modulePath;
+  }
+
+  const tsPath = modulePath.replace(/\.js$/, '.ts');
+  return existsSync(tsPath) ? tsPath : modulePath;
+};
+
+const TOPO_EXPORT_KEYS = ['default', 'graph', 'app'] as const;
+
+const isTopo = (value: unknown): value is Topo => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  // Require the shape runWarden actually uses: readonly Maps for trails,
+  // signals, resources, contours, plus core accessor methods. A bare object
+  // with a `trails` field (PR metadata, docs snippet, etc.) would fail at
+  // runtime inside the topo-aware rules; gate it here.
+  return (
+    candidate['trails'] instanceof Map &&
+    candidate['signals'] instanceof Map &&
+    candidate['resources'] instanceof Map &&
+    candidate['contours'] instanceof Map &&
+    typeof candidate['get'] === 'function' &&
+    typeof candidate['list'] === 'function' &&
+    typeof candidate['name'] === 'string'
+  );
+};
+
+const extractTopo = (
+  modulePath: string,
+  loaded: Record<string, unknown>
+): Topo => {
+  // Prefer the first export that is actually a Topo rather than the first
+  // key present. A module can legally expose a non-Topo `default` alongside
+  // a named `graph`/`app` topo (for example when default is the Topo's
+  // metadata object), and nullish-coalescing would silently pick the wrong
+  // one and fall back to no-topo governance.
+  for (const key of TOPO_EXPORT_KEYS) {
+    const candidate = loaded[key];
+    if (isTopo(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `Could not find a Topo export in "${modulePath}". Expected a default, "graph", or "app" export created with topo().`
+  );
+};
+
+interface TopoLoadResult {
+  readonly topo?: Topo;
+  readonly loadError?: {
+    readonly message: string;
+    readonly filePath: string;
+  };
+  readonly ambiguous?: {
+    readonly message: string;
+  };
+}
+
+const loadErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+type TopoLoadError = NonNullable<TopoLoadResult['loadError']>;
+
+type ResolvedPath =
+  | { readonly kind: 'path'; readonly modulePath: string }
+  | { readonly kind: 'missing' }
+  | { readonly kind: 'ambiguous'; readonly message: string }
+  | { readonly kind: 'error'; readonly loadError: TopoLoadError };
+
+const resolveModulePathForGovernance = (rootDir: string): ResolvedPath => {
+  try {
+    return { kind: 'path', modulePath: resolveAppModulePath(rootDir) };
+  } catch (error) {
+    // Discovery failures are configuration concerns, not real load failures:
+    // - NotFoundError: repo has no Trails app; topo-aware rules have nothing
+    //   to inspect. Silently skip.
+    // - AmbiguousError: repo has multiple Trails apps (e.g. the Trails
+    //   monorepo itself). Governance can't pick one without help, but
+    //   staying completely silent hides the fact that topo-aware rules
+    //   (permits etc.) are being skipped. Emit a warn diagnostic so the
+    //   gap is visible in the report; callers can pass `--module <path>`
+    //   to govern a specific app.
+    if (error instanceof NotFoundError) {
+      return { kind: 'missing' };
+    }
+    if (error instanceof AmbiguousError) {
+      return { kind: 'ambiguous', message: loadErrorMessage(error) };
+    }
+    return {
+      kind: 'error',
+      loadError: { filePath: rootDir, message: loadErrorMessage(error) },
+    };
+  }
+};
+
+const importTopoFromModulePath = async (
+  modulePath: string
+): Promise<TopoLoadResult> => {
+  try {
+    const loaded = (await import(pathToFileURL(modulePath).href)) as Record<
+      string,
+      unknown
+    >;
+    const topo = extractTopo(modulePath, loaded);
+    return topo ? { topo } : {};
+  } catch (error) {
+    // App module is present but failed to load (import-time throw, missing
+    // dependency, bad topo export). Surface this so CI doesn't silently skip
+    // topo-aware rules including permit governance.
+    return {
+      loadError: { filePath: modulePath, message: loadErrorMessage(error) },
+    };
+  }
+};
+
+const loadTopoForGovernance = (rootDir: string): Promise<TopoLoadResult> => {
+  const resolved = resolveModulePathForGovernance(rootDir);
+  if (resolved.kind === 'missing') {
+    return Promise.resolve({});
+  }
+  if (resolved.kind === 'ambiguous') {
+    return Promise.resolve({ ambiguous: { message: resolved.message } });
+  }
+  if (resolved.kind === 'error') {
+    return Promise.resolve({ loadError: resolved.loadError });
+  }
+  return importTopoFromModulePath(resolved.modulePath);
+};
+
+const topoLoadFailureDiagnostic = (
+  loadError: NonNullable<TopoLoadResult['loadError']>
+): WardenDiagnostic => ({
+  filePath: loadError.filePath,
+  line: 1,
+  message: `Failed to load Trails app for governance: ${loadError.message}`,
+  rule: 'topo-load',
+  severity: 'error',
+});
+
+const ambiguousTopoDiagnostic = (
+  rootDir: string,
+  message: string
+): WardenDiagnostic => ({
+  filePath: rootDir,
+  line: 1,
+  message: `Multiple Trails apps discovered; skipping topo-aware rules. Pass \`--module <path>\` to govern a specific app. ${message}`,
+  rule: 'topo-load',
+  severity: 'warn',
+});
 
 export const createDriftOnlyReport = (
   driftResult: DriftResult
@@ -84,12 +249,38 @@ export const runCiGovernance = async ({
   rootDir = process.cwd(),
 }: RunCiGovernanceOptions = {}): Promise<CiGovernanceResult> => {
   const resolvedRootDir = resolve(rootDir);
-  const wardenReport = await runWarden({ rootDir: resolvedRootDir });
+  const topoResult = await loadTopoForGovernance(resolvedRootDir);
+  const wardenReport = await runWarden({
+    rootDir: resolvedRootDir,
+    topo: topoResult.topo,
+  });
+
+  let finalReport: WardenReport = wardenReport;
+  if (topoResult.loadError) {
+    finalReport = {
+      ...finalReport,
+      diagnostics: [
+        topoLoadFailureDiagnostic(topoResult.loadError),
+        ...finalReport.diagnostics,
+      ],
+      errorCount: finalReport.errorCount + 1,
+      passed: false,
+    };
+  } else if (topoResult.ambiguous) {
+    finalReport = {
+      ...finalReport,
+      diagnostics: [
+        ambiguousTopoDiagnostic(resolvedRootDir, topoResult.ambiguous.message),
+        ...finalReport.diagnostics,
+      ],
+      warnCount: finalReport.warnCount + 1,
+    };
+  }
 
   return evaluateCiGovernance({
-    driftResult: wardenReport.drift ?? fallbackDriftResult,
+    driftResult: finalReport.drift ?? fallbackDriftResult,
     failOn,
     format,
-    wardenReport,
+    wardenReport: finalReport,
   });
 };

--- a/apps/trails-demo/__tests__/examples.test.ts
+++ b/apps/trails-demo/__tests__/examples.test.ts
@@ -1,11 +1,12 @@
 /**
- * The one-liner: validates the topo, tests every example, checks contracts,
- * and verifies detour targets.
+ * The one-liner for shipped surfaces: validates the established topo, tests
+ * every example, checks contracts, verifies detours, and ensures CLI/MCP
+ * projections still build.
  */
 
-import { testAll } from '@ontrails/testing';
+import { testAllEstablished } from '@ontrails/testing';
 
 import { graph } from '../src/app.js';
 
-// oxlint-disable-next-line require-hook -- testAll registers tests at module level by design
-testAll(graph);
+// oxlint-disable-next-line require-hook -- testAllEstablished registers tests at module level by design
+testAllEstablished(graph);

--- a/apps/trails/src/trails/add-verify.ts
+++ b/apps/trails/src/trails/add-verify.ts
@@ -13,10 +13,10 @@ import { z } from 'zod';
 // ---------------------------------------------------------------------------
 
 const generateTestFile = (): string =>
-  `import { testAll } from '@ontrails/testing';
+  `import { testAllEstablished } from '@ontrails/testing';
 import { app } from '../src/app.js';
 
-testAll(app);
+testAllEstablished(app);
 `;
 
 const generateLefthookYml = (): string =>

--- a/bun.lock
+++ b/bun.lock
@@ -25,9 +25,10 @@
     "apps/ci": {
       "name": "trails-ci",
       "dependencies": {
-        "@ontrails/core": "workspace:*",
-        "@ontrails/schema": "workspace:*",
-        "@ontrails/warden": "workspace:*",
+        "@ontrails/cli": "workspace:^",
+        "@ontrails/core": "workspace:^",
+        "@ontrails/schema": "workspace:^",
+        "@ontrails/warden": "workspace:^",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -228,6 +229,9 @@
     "packages/warden": {
       "name": "@ontrails/warden",
       "version": "1.0.0-beta.14",
+      "dependencies": {
+        "@ontrails/permits": "workspace:^",
+      },
       "devDependencies": {
         "@ontrails/testing": "workspace:^",
         "@oxc-project/types": "^0.122.0",

--- a/packages/testing/src/__tests__/all.test.ts
+++ b/packages/testing/src/__tests__/all.test.ts
@@ -1,4 +1,6 @@
-import { afterAll, describe, expect, mock } from 'bun:test';
+import { afterAll, describe, expect, mock, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 import { contour, Result, trail, topo } from '@ontrails/core';
 import { connectDrizzle } from '@ontrails/drizzle';
@@ -150,6 +152,53 @@ const contourDerivedTrail = trail('contour.derived.all', {
   output: contourFixture,
 });
 
+const repoTempDir = (): string =>
+  join(
+    resolve(import.meta.dir, '../..'),
+    '.tmp-tests',
+    `test-all-established-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+
+const runGeneratedGovernanceSuite = (
+  helperName: 'testAll' | 'testAllEstablished'
+): { readonly exitCode: number; readonly output: string } => {
+  const dir = repoTempDir();
+  const testFile = join(dir, `${helperName}.test.ts`);
+
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    testFile,
+    `import { Result, trail, topo } from '@ontrails/core';
+import { ${helperName} } from '../../src/index.ts';
+import { z } from 'zod';
+
+const draftTrail = trail('_draft.entity.prepare', {
+  blaze: async () => Result.ok({ ok: true }),
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+});
+
+${helperName}(topo('draft-topo', { draftTrail }));
+`
+  );
+
+  try {
+    const proc = Bun.spawnSync({
+      cmd: ['bun', 'test', testFile, '--bail'],
+      cwd: resolve(import.meta.dir, '..', '..', '..'),
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
+
+    return {
+      exitCode: proc.exitCode,
+      output: `${proc.stdout.toString()}\n${proc.stderr.toString()}`,
+    };
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+};
+
 describe('testAll resource mocks', () => {
   // eslint-disable-next-line jest/require-hook
   testAll(
@@ -186,5 +235,20 @@ describe('testAll contour-derived fixtures', () => {
 
   afterAll(() => {
     expect(contourDerivedBlaze).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('testAllEstablished draft hygiene', () => {
+  test('keeps testAll draft-friendly for in-progress graphs', () => {
+    const result = runGeneratedGovernanceSuite('testAll');
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('fails draft-contaminated graphs under testAllEstablished', () => {
+    const result = runGeneratedGovernanceSuite('testAllEstablished');
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('_draft.entity.prepare');
   });
 });

--- a/packages/testing/src/__tests__/harness-cli.test.ts
+++ b/packages/testing/src/__tests__/harness-cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { Result, topo, trail } from '@ontrails/core';
+import { resource, Result, topo, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { createCliHarness } from '../harness-cli.js';
@@ -62,5 +62,29 @@ describe('createCliHarness', () => {
     expect(child.exitCode).toBe(0);
     expect(parent.exitCode).toBe(0);
     expect(calls).toEqual(['topo.pin', 'topo']);
+  });
+
+  test('threads resource overrides through CLI projection options', async () => {
+    const dbResource = resource('db.main', {
+      create: () => Result.ok({ source: 'factory' }),
+    });
+    const readResource = trail('resource.read', {
+      blaze: (_input, ctx) =>
+        Result.ok({ source: dbResource.from(ctx).source as string }),
+      input: z.object({}),
+      output: z.object({ source: z.string() }),
+      resources: [dbResource],
+    });
+    const harness = createCliHarness({
+      graph: topo('test-app', { dbResource, readResource }),
+      resources: {
+        'db.main': { source: 'override' },
+      },
+    });
+
+    const result = await harness.run('resource read --output json');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('"override"');
   });
 });

--- a/packages/testing/src/__tests__/harness-mcp.test.ts
+++ b/packages/testing/src/__tests__/harness-mcp.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resource, Result, topo, trail } from '@ontrails/core';
+import { deriveToolName } from '@ontrails/mcp';
+import { z } from 'zod';
+
+import { createMcpHarness } from '../harness-mcp.js';
+
+describe('createMcpHarness', () => {
+  test('threads resource overrides through MCP projection options', async () => {
+    const dbResource = resource('db.main', {
+      create: () => Result.ok({ source: 'factory' }),
+    });
+    const readResource = trail('resource.read', {
+      blaze: (_input, ctx) =>
+        Result.ok({ source: dbResource.from(ctx).source as string }),
+      input: z.object({}),
+      output: z.object({ source: z.string() }),
+      resources: [dbResource],
+    });
+    const graph = topo('test-app', { dbResource, readResource });
+    const harness = createMcpHarness({
+      graph,
+      resources: {
+        'db.main': { source: 'override' },
+      },
+    });
+
+    const result = await harness.callTool(
+      deriveToolName(graph.name, readResource.id),
+      {}
+    );
+
+    expect(result.isError).toBe(false);
+    expect(JSON.stringify(result.content)).toContain('override');
+  });
+});

--- a/packages/testing/src/all.ts
+++ b/packages/testing/src/all.ts
@@ -8,12 +8,15 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { Topo, TrailContext } from '@ontrails/core';
-import { validateTopo } from '@ontrails/core';
+import { validateEstablishedTopo, validateTopo } from '@ontrails/core';
 
+import { createCliHarness } from './harness-cli.js';
+import { createMcpHarness } from './harness-mcp.js';
 import { testContracts } from './contracts.js';
 import type { TestExecutionOptions } from './context.js';
 import { testDetours } from './detours.js';
 import { testExamples } from './examples.js';
+import type { TestAllEstablishedOptions } from './types.js';
 
 /**
  * Run the full governance test suite for a Topo.
@@ -36,17 +39,48 @@ import { testExamples } from './examples.js';
  * testAll(graph);
  * ```
  */
-export const testAll = (
+type TestAllInput =
+  | Partial<TrailContext>
+  | TestExecutionOptions
+  | (() => Partial<TrailContext> | TestExecutionOptions);
+
+const formatValidationFailure = (error: Error): string => {
+  const issues = (
+    error as {
+      context?: { issues?: readonly Record<string, unknown>[] };
+    }
+  ).context?.issues;
+
+  if (issues === undefined || issues.length === 0) {
+    return error.message;
+  }
+
+  const details = issues.map((issue) => {
+    const id = typeof issue['id'] === 'string' ? issue['id'] : undefined;
+    const message =
+      typeof issue['message'] === 'string' ? issue['message'] : undefined;
+    const rule = typeof issue['rule'] === 'string' ? issue['rule'] : undefined;
+
+    return [rule, id, message].filter(Boolean).join(': ');
+  });
+
+  return [error.message, ...details].join('\n');
+};
+
+const assertValidTopo = (result: ReturnType<typeof validateTopo>): void => {
+  if (result.isErr()) {
+    throw new Error(formatValidationFailure(result.error));
+  }
+};
+
+const registerGovernanceSuite = (
   topo: Topo,
-  ctxOrFactory?:
-    | Partial<TrailContext>
-    | TestExecutionOptions
-    | (() => Partial<TrailContext> | TestExecutionOptions)
+  ctxOrFactory: TestAllInput | undefined,
+  validate: (topo: Topo) => ReturnType<typeof validateTopo>
 ): void => {
   describe('governance', () => {
     test('topo validates', () => {
-      const result = validateTopo(topo);
-      expect(result.isOk()).toBe(true);
+      expect(() => assertValidTopo(validate(topo))).not.toThrow();
     });
 
     // oxlint-disable-next-line jest/require-hook -- these generate describe/test blocks, not setup code
@@ -56,4 +90,107 @@ export const testAll = (
     // oxlint-disable-next-line jest/require-hook -- these generate describe/test blocks, not setup code
     testDetours(topo);
   });
+};
+
+export const testAll = (topo: Topo, ctxOrFactory?: TestAllInput): void => {
+  registerGovernanceSuite(topo, ctxOrFactory, validateTopo);
+};
+
+type EstablishedInput =
+  | Partial<TrailContext>
+  | TestAllEstablishedOptions
+  | (() => Partial<TrailContext> | TestAllEstablishedOptions);
+
+const isEstablishedOptions = (
+  input: Partial<TrailContext> | TestAllEstablishedOptions | undefined
+): input is TestAllEstablishedOptions =>
+  input !== undefined &&
+  (Object.hasOwn(input, 'cli') ||
+    Object.hasOwn(input, 'createPermit') ||
+    Object.hasOwn(input, 'ctx') ||
+    Object.hasOwn(input, 'mcp') ||
+    Object.hasOwn(input, 'resources') ||
+    Object.hasOwn(input, 'strictPermits'));
+
+const normalizeEstablishedOptions = (
+  input?: Partial<TrailContext> | TestAllEstablishedOptions
+): TestAllEstablishedOptions =>
+  isEstablishedOptions(input) ? input : { ctx: input };
+
+const toExecutionOptions = (
+  options: TestAllEstablishedOptions
+): TestExecutionOptions => ({
+  ...(options.createPermit === undefined
+    ? {}
+    : { createPermit: options.createPermit }),
+  ...(options.ctx === undefined ? {} : { ctx: options.ctx }),
+  ...(options.resources === undefined ? {} : { resources: options.resources }),
+  ...(options.strictPermits === undefined
+    ? {}
+    : { strictPermits: options.strictPermits }),
+});
+
+const toCliHarnessOptions = (
+  topo: Topo,
+  options: TestAllEstablishedOptions
+) => {
+  const cliOptions = {
+    graph: topo,
+    ...options.cli,
+  };
+
+  if (options.ctx !== undefined) {
+    cliOptions.ctx = options.ctx;
+  }
+
+  return cliOptions;
+};
+
+const toMcpHarnessOptions = (
+  topo: Topo,
+  options: TestAllEstablishedOptions
+) => ({
+  graph: topo,
+  ...options.mcp,
+});
+
+const registerEstablishedSurfaceSuite = (
+  topo: Topo,
+  resolveInput: () =>
+    | Partial<TrailContext>
+    | TestAllEstablishedOptions
+    | undefined
+): void => {
+  describe('surfaces', () => {
+    test('CLI projection validates established topo', () => {
+      const options = normalizeEstablishedOptions(resolveInput());
+      expect(() =>
+        createCliHarness(toCliHarnessOptions(topo, options))
+      ).not.toThrow();
+    });
+
+    test('MCP projection validates established topo', () => {
+      const options = normalizeEstablishedOptions(resolveInput());
+      expect(() =>
+        createMcpHarness(toMcpHarnessOptions(topo, options))
+      ).not.toThrow();
+    });
+  });
+};
+
+export const testAllEstablished = (
+  topo: Topo,
+  optionsOrFactory?: EstablishedInput
+): void => {
+  const resolveInput =
+    typeof optionsOrFactory === 'function'
+      ? optionsOrFactory
+      : () => optionsOrFactory;
+
+  registerGovernanceSuite(
+    topo,
+    () => toExecutionOptions(normalizeEstablishedOptions(resolveInput())),
+    validateEstablishedTopo
+  );
+  registerEstablishedSurfaceSuite(topo, resolveInput);
 };

--- a/packages/testing/src/harness-cli.ts
+++ b/packages/testing/src/harness-cli.ts
@@ -7,8 +7,9 @@
 
 import { deriveCliCommands } from '@ontrails/cli';
 import type { CliCommand } from '@ontrails/cli';
+import type { TrailContext } from '@ontrails/core';
 
-import { createTestContext } from './context.js';
+import { mergeTestContext } from './context.js';
 import type {
   CliHarness,
   CliHarnessOptions,
@@ -218,9 +219,10 @@ const buildErrorResult = (
 const executeCommand = async (
   command: CliCommand,
   flags: Record<string, unknown>,
-  streams: CapturedStreams
+  streams: CapturedStreams,
+  ctxOverrides?: Partial<TrailContext>
 ): Promise<CliHarnessResult> => {
-  const ctx = createTestContext();
+  const ctx = mergeTestContext(ctxOverrides);
   const result = await command.execute({}, flags, ctx);
   streams.restore();
 
@@ -238,7 +240,8 @@ const executeCommand = async (
 /** Run the full command pipeline: resolve, parse, execute. */
 const runCommand = async (
   commands: CliCommand[],
-  commandString: string
+  commandString: string,
+  ctxOverrides?: Partial<TrailContext>
 ): Promise<CliHarnessResult> => {
   const parts = parseCommandString(commandString);
   const resolved = resolveCommand(commands, parts);
@@ -255,7 +258,7 @@ const runCommand = async (
   const streams = captureStreams();
 
   try {
-    return await executeCommand(command, flags, streams);
+    return await executeCommand(command, flags, streams, ctxOverrides);
   } catch (error: unknown) {
     return buildErrorResult(error, streams);
   }
@@ -278,13 +281,14 @@ const runCommand = async (
  * ```
  */
 export const createCliHarness = (options: CliHarnessOptions): CliHarness => {
-  const commandsResult = deriveCliCommands(options.graph);
+  const { ctx, graph, ...deriveOptions } = options;
+  const commandsResult = deriveCliCommands(graph, deriveOptions);
   if (commandsResult.isErr()) {
     throw commandsResult.error;
   }
   const commands = commandsResult.value;
 
   return {
-    run: (commandString: string) => runCommand(commands, commandString),
+    run: (commandString: string) => runCommand(commands, commandString, ctx),
   };
 };

--- a/packages/testing/src/harness-mcp.ts
+++ b/packages/testing/src/harness-mcp.ts
@@ -31,7 +31,8 @@ import type {
  * ```
  */
 export const createMcpHarness = (options: McpHarnessOptions): McpHarness => {
-  const toolsResult = deriveMcpTools(options.graph);
+  const { extra, graph, ...deriveOptions } = options;
+  const toolsResult = deriveMcpTools(graph, deriveOptions);
   if (toolsResult.isErr()) {
     throw toolsResult.error;
   }
@@ -54,9 +55,9 @@ export const createMcpHarness = (options: McpHarnessOptions): McpHarness => {
       }
 
       const result = await tool.handler(args, {
-        abortSignal: undefined,
-        progressToken: undefined,
-        sendProgress: undefined,
+        abortSignal: extra?.abortSignal,
+        progressToken: extra?.progressToken,
+        sendProgress: extra?.sendProgress,
       });
 
       return {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,5 +1,6 @@
 // Contract-driven testing
 export { testAll } from './all.js';
+export { testAllEstablished } from './all.js';
 export { testExamples } from './examples.js';
 export { testCrosses } from './crosses.js';
 export { testTrail } from './trail.js';
@@ -46,6 +47,7 @@ export type {
   CrossScenario,
   RefToken,
   ScenarioStep,
+  TestAllEstablishedOptions,
   TestScenario,
   TestLogger,
   TestTrailContextOptions,

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -2,7 +2,15 @@
  * Shared types for @ontrails/testing.
  */
 
-import type { AnyTrail, Logger, Topo, TraceFn } from '@ontrails/core';
+import type { DeriveCliCommandsOptions } from '@ontrails/cli';
+import type { McpExtra, DeriveMcpToolsOptions } from '@ontrails/mcp';
+import type {
+  AnyTrail,
+  Logger,
+  Topo,
+  TraceFn,
+  TrailContext,
+} from '@ontrails/core';
 import type { LogLevel, LogRecord } from '@ontrails/logging';
 
 // ---------------------------------------------------------------------------
@@ -74,7 +82,11 @@ export interface TestTrailContextOptions {
 // ---------------------------------------------------------------------------
 
 /** Options for creating a CLI harness. */
-export interface CliHarnessOptions {
+export interface CliHarnessOptions extends Omit<
+  DeriveCliCommandsOptions,
+  'onResult' | 'presets' | 'resolveInput'
+> {
+  readonly ctx?: Partial<TrailContext> | undefined;
   readonly graph: Topo;
 }
 
@@ -98,7 +110,8 @@ export interface CliHarnessResult {
 // ---------------------------------------------------------------------------
 
 /** Options for creating an MCP harness. */
-export interface McpHarnessOptions {
+export interface McpHarnessOptions extends DeriveMcpToolsOptions {
+  readonly extra?: Partial<McpExtra> | undefined;
   readonly graph: Topo;
 }
 
@@ -115,6 +128,31 @@ export interface McpHarness {
 export interface McpHarnessResult {
   readonly content: unknown;
   readonly isError: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Established verification
+// ---------------------------------------------------------------------------
+
+export interface TestAllEstablishedOptions {
+  readonly cli?: Omit<CliHarnessOptions, 'graph'> | undefined;
+  readonly createPermit?:
+    | ((trail: {
+        readonly permit?:
+          | { readonly scopes: readonly string[] }
+          | 'public'
+          | undefined;
+      }) =>
+        | {
+            readonly id: string;
+            readonly scopes: readonly string[];
+          }
+        | undefined)
+    | undefined;
+  readonly ctx?: Partial<TrailContext> | undefined;
+  readonly mcp?: Omit<McpHarnessOptions, 'graph'> | undefined;
+  readonly resources?: Record<string, unknown> | undefined;
+  readonly strictPermits?: boolean | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -13,6 +13,9 @@
     "lint": "oxlint ./src",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
+  "dependencies": {
+    "@ontrails/permits": "workspace:^"
+  },
   "devDependencies": {
     "@ontrails/testing": "workspace:^",
     "@oxc-project/types": "^0.122.0",

--- a/packages/warden/src/__tests__/permit-governance.test.ts
+++ b/packages/warden/src/__tests__/permit-governance.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { runWarden } from '../cli.js';
+import { permitGovernance } from '../rules/permit-governance.js';
+
+describe('permitGovernance', () => {
+  test('emits permit diagnostics from the compiled topo', async () => {
+    const destroyTrail = trail('entity.delete', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      intent: 'destroy',
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await permitGovernance.checkTopo(
+      topo('permit-topo', { destroyTrail })
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        filePath: '<topo>',
+        line: 1,
+        message:
+          'Trail "entity.delete" has intent \'destroy\' but no permit declaration',
+        rule: 'permit.destroyWithoutPermit',
+        severity: 'error',
+      },
+    ]);
+  });
+
+  test('runWarden includes permit governance when topo is supplied', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'warden-permit-'));
+    const destroyTrail = trail('entity.delete', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      intent: 'destroy',
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    try {
+      const report = await runWarden({
+        rootDir,
+        topo: topo('permit-topo', { destroyTrail }),
+      });
+
+      expect(report.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining('no permit declaration'),
+            rule: 'permit.destroyWithoutPermit',
+            severity: 'error',
+          }),
+        ])
+      );
+      expect(report.errorCount).toBeGreaterThan(0);
+    } finally {
+      rmSync(rootDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 33 rule trails', () => {
-    expect(wardenTopo.count).toBe(33);
+  test('contains all 34 rule trails', () => {
+    expect(wardenTopo.count).toBe(34);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -85,6 +85,7 @@ export {
   noThrowInImplementationTrail,
   onReferencesExistTrail,
   orphanedSignalTrail,
+  permitGovernanceTrail,
   preferSchemaInferenceTrail,
   projectAwareRuleInput,
   referenceExistsTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -21,6 +21,7 @@ import { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
 import { onReferencesExist } from './on-references-exist.js';
 import { orphanedSignal } from './orphaned-signal.js';
+import { permitGovernance } from './permit-governance.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
 import { referenceExists } from './reference-exists.js';
 import { resourceDeclarations } from './resource-declarations.js';
@@ -66,6 +67,7 @@ export { noSyncResultAssumption } from './no-sync-result-assumption.js';
 export { implementationReturnsResult } from './implementation-returns-result.js';
 export { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 export { orphanedSignal } from './orphaned-signal.js';
+export { permitGovernance } from './permit-governance.js';
 export { preferSchemaInference } from './prefer-schema-inference.js';
 export { referenceExists } from './reference-exists.js';
 export { resourceDeclarations } from './resource-declarations.js';
@@ -129,4 +131,5 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
 export const wardenTopoRules: ReadonlyMap<string, TopoAwareWardenRule> =
   new Map<string, TopoAwareWardenRule>([
     [incompleteAccessorForStandardOp.name, incompleteAccessorForStandardOp],
+    [permitGovernance.name, permitGovernance],
   ]);

--- a/packages/warden/src/rules/permit-governance.ts
+++ b/packages/warden/src/rules/permit-governance.ts
@@ -1,0 +1,25 @@
+import type { Trail } from '@ontrails/core';
+import { validatePermits } from '@ontrails/permits';
+
+import type { TopoAwareWardenRule, WardenDiagnostic } from './types.js';
+
+const toWardenDiagnostic = (
+  diagnostic: ReturnType<typeof validatePermits>[number]
+): WardenDiagnostic => ({
+  filePath: '<topo>',
+  line: 1,
+  message: diagnostic.message,
+  rule: `permit.${diagnostic.rule}`,
+  severity: diagnostic.severity === 'error' ? 'error' : 'warn',
+});
+
+export const permitGovernance: TopoAwareWardenRule = {
+  checkTopo: (topo) =>
+    validatePermits(
+      topo.list() as readonly Trail<unknown, unknown, unknown>[]
+    ).map(toWardenDiagnostic),
+  description:
+    'Enforces permit declarations and scope hygiene across the compiled topo',
+  name: 'permit-governance',
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -29,6 +29,7 @@ import { noThrowInDetourTarget } from './no-throw-in-detour-target.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
 import { onReferencesExist } from './on-references-exist.js';
 import { orphanedSignal } from './orphaned-signal.js';
+import { permitGovernance } from './permit-governance.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
 import { referenceExists } from './reference-exists.js';
 import { resourceDeclarations } from './resource-declarations.js';
@@ -69,6 +70,7 @@ export const registeredRuleNames: readonly string[] = [
   noThrowInImplementation.name,
   onReferencesExist.name,
   orphanedSignal.name,
+  permitGovernance.name,
   preferSchemaInference.name,
   referenceExists.name,
   resourceDeclarations.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -21,6 +21,7 @@ export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.j
 export { noThrowInDetourTargetTrail } from './no-throw-in-detour-target.trail.js';
 export { noThrowInImplementationTrail } from './no-throw-in-implementation.trail.js';
 export { orphanedSignalTrail } from './orphaned-signal.trail.js';
+export { permitGovernanceTrail } from './permit-governance.trail.js';
 export { preferSchemaInferenceTrail } from './prefer-schema-inference.trail.js';
 export { referenceExistsTrail } from './reference-exists.trail.js';
 export { resourceDeclarationsTrail } from './resource-declarations.trail.js';

--- a/packages/warden/src/trails/permit-governance.trail.ts
+++ b/packages/warden/src/trails/permit-governance.trail.ts
@@ -1,0 +1,51 @@
+import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { permitGovernance } from '../rules/permit-governance.js';
+import { wrapTopoRule } from './wrap-rule.js';
+
+const destroyWithoutPermit = trail('entity.delete', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  intent: 'destroy',
+  output: z.object({ ok: z.boolean() }),
+});
+
+const scopedDestroy = trail('entity.delete', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  intent: 'destroy',
+  output: z.object({ ok: z.boolean() }),
+  permit: { scopes: ['entity:delete'] },
+});
+
+export const permitGovernanceTrail = wrapTopoRule({
+  examples: [
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: '<topo>',
+            line: 1,
+            message:
+              'Trail "entity.delete" has intent \'destroy\' but no permit declaration',
+            rule: 'permit.destroyWithoutPermit',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        topo: topo('trl-377-missing-permit', { destroyWithoutPermit }),
+      },
+      name: 'Destroy trails without permits emit an error',
+    },
+    {
+      expected: { diagnostics: [] },
+      input: {
+        topo: topo('trl-377-scoped-destroy', { scopedDestroy }),
+      },
+      name: 'Scoped destroy permits keep permit governance clean',
+    },
+  ],
+  rule: permitGovernance,
+});


### PR DESCRIPTION
## Summary
- add `testAllEstablished(...)` as the established-surface verification path while keeping `testAll()` draft-friendly
- wire permit governance into the default Warden path so permit issues surface in the normal governance formatter
- keep Warden's registry snapshot in lockstep with the live permit-governance rule/trail export set

## Verification
- `cd packages/warden && bun test ./src/__tests__/permit-governance.test.ts ./src/__tests__/warden-export-symmetry.test.ts --bail`
- `cd packages/testing && bun test ./src/__tests__/all.test.ts --bail`
- bottom-up branch verification pass on `trl-374-established-surface-and-permit-governance`

Closes: TRL-374, TRL-377
