### PR TITLE
docs(framework): align surface and contour guidance

### DIFF
--- a/.claude/rules/coding-conventions.md
+++ b/.claude/rules/coding-conventions.md
@@ -8,7 +8,7 @@ TSDoc explains the contract of exported APIs. Start there before reaching for in
 
 ### When to Add TSDoc
 
-- Add TSDoc to exported functions, classes, interfaces, and types that define package or trailhead boundaries.
+- Add TSDoc to exported functions, classes, interfaces, and types that define package or surface boundaries.
 - Add TSDoc to exported constants when their role or runtime behavior is not obvious from the name and type alone.
 - Add `@example` blocks for APIs that are easier to understand from a concrete call site than from prose.
 - Skip obvious one-line aliases and small internal helpers unless their intent is genuinely hard to infer.
@@ -30,9 +30,9 @@ TSDoc explains the contract of exported APIs. Start there before reaching for in
 
 ### Trails-Specific TSDoc
 
-- Describe the contract a helper or trailhead exposes, especially derived names, validation boundaries, and `Result` behavior.
+- Describe the contract a helper or surface exposes, especially derived names, validation boundaries, and `Result` behavior.
 - For APIs that return `Result`, document the success shape and the error types callers should expect.
-- Prefer examples that mirror how agents or trailhead connectors will actually consume the API.
+- Prefer examples that mirror how agents or surface connectors will actually consume the API.
 - For resource definitions, document the `create` factory's dependencies and the type it produces. Document `dispose` if cleanup is non-trivial. Skip `mock` TSDoc unless the mock behavior differs significantly from the real implementation.
 
 ## Code Shape Patterns
@@ -166,7 +166,7 @@ const processField = (field: Field, provided: Record<string, unknown>) => {
 
 ## Bun-Native Defaults
 
-Trails is Bun-native. Use Bun APIs where they improve the developer experience and keep compatibility concerns at the trailhead boundary.
+Trails is Bun-native. Use Bun APIs where they improve the developer experience and keep compatibility concerns at the surface boundary.
 
 - Use `Bun.file()` and `Bun.write()` for file I/O.
 - Use `Bun.Glob` for discovery.

--- a/.claude/skills/clark-decision/SKILL.md
+++ b/.claude/skills/clark-decision/SKILL.md
@@ -49,14 +49,14 @@ Append to `.trails/clark/decisions.md`:
 ## Examples of Decisions Clark Makes
 
 - **Naming:** "Should this factory be called `buildTrailRunner` or `createTrailRunner`?"
-  - Decide based on ADR-0001 Convention 6 (`create*` for factories) vs Convention 9 (`build*` for trailhead derivation).
+  - Decide based on ADR-0001 Convention 6 (`create*` for factories) vs Convention 9 (`build*` for surface derivation).
     - If it creates a runtime instance, `create*`.
-    - If it derives trailhead configuration, `build*`.
+    - If it derives surface configuration, `build*`.
 - **Lexicon:** "Can we call this a 'middleware'?"
   - Decide based on `lexicon.md`. If it is a layer, call it a layer. "Middleware" is not in the Trails lexicon.
 - **Architecture:** "Should this logic go in the trail blaze or in a gate?"
   - Decide based on the hexagonal model.
-    - If it is trailhead-agnostic domain logic, it belongs in the blaze.
+    - If it is surface-agnostic domain logic, it belongs in the blaze.
     - If it is cross-cutting, it is a gate.
 - **Scope:** "Should we add this feature now or defer it?"
   - Decide based on the current sprint plan, the horizons doc, and the compound test.

--- a/.claude/skills/clark-survey/SKILL.md
+++ b/.claude/skills/clark-survey/SKILL.md
@@ -40,9 +40,9 @@ Check for: factories without `create*`, derivations without `derive*`, test help
 
 Look for code smells that indicate architectural drift:
 
-- **Trailhead types in blazes:** imports of `Request`, `Response`, `McpSession` in trail files
+- **Surface types in blazes:** imports of `Request`, `Response`, `McpSession` in trail files
 - **Direct throws:** `throw` statements in blaze code (should be `Result.err()`)
-- **Console usage:** `console.log`, `console.error` in non-trailhead code
+- **Console usage:** `console.log`, `console.error` in non-surface code
 - **Direct `.run()` calls:** should be `ctx.cross()`
 
 ```bash

--- a/.claude/skills/clark/SKILL.md
+++ b/.claude/skills/clark/SKILL.md
@@ -51,7 +51,7 @@ If the developer has to author information the framework already has, that's a f
 
 ### The Compound Test
 
-New features must multiply the value of existing features, not just add to a list. Before endorsing any addition, ask: does this make every other feature smarter? Intent compounds with trailheads, provisions, testing, and governance simultaneously. That's the bar.
+New features must multiply the value of existing features, not just add to a list. Before endorsing any addition, ask: does this make every other feature smarter? Intent compounds with surfaces, provisions, testing, and governance simultaneously. That's the bar.
 
 ## Postures
 

--- a/.claude/skills/clark/references/assess.md
+++ b/.claude/skills/clark/references/assess.md
@@ -6,7 +6,7 @@ Milestone review. Check the work against the plan. Trail posture applied to a bo
 
 ### 1. Contract Fidelity
 
-Did what was built match what was planned? Compare the implemented trails, schemas, and trailheads against the ADR, spec, or planning document that authorized the work.
+Did what was built match what was planned? Compare the implemented trails, schemas, and surfaces against the ADR, spec, or planning document that authorized the work.
 
 - Are the trail IDs what was specified?
 - Do the schemas match the agreed shapes?
@@ -20,9 +20,9 @@ Run `trails warden` and `trails survey --brief` to get the current state. Do not
 
 Does the implementation honor the hexagonal model?
 
-- Implementations are pure. No trailhead-specific types in trail logic.
+- Implementations are pure. No surface-specific types in trail logic.
 - Provisions accessed through declared dependencies, not ambient imports.
-- Trailheads delegate to the execution pipeline. No reimplementation of `validate-resolve-execute`.
+- Surfaces delegate to the execution pipeline. No reimplementation of `validate-resolve-execute`.
 - New packages or subpaths follow the framework's port/adapter pattern.
 
 ### 3. Information Architecture

--- a/.claude/skills/clark/references/calibrate.md
+++ b/.claude/skills/clark/references/calibrate.md
@@ -21,9 +21,9 @@ Scan all changed or new files for vocabulary violations. Highest-priority check.
 | handler, action, endpoint | trail |
 | route (for composition) | cross |
 | registry, collection, manifest | topo |
-| serve, start, wire up | trailhead |
+| serve, start, wire up | surface |
 | call, invoke, dispatch (for cross) | cross |
-| transport, adapter, interface | trailhead |
+| transport, adapter, interface | surface |
 | impl, fn, handler (for run function) | blaze |
 | annotations, tags | metadata |
 | fallbacks, retries, recovery | detours |
@@ -47,7 +47,7 @@ Check against ADR-0001's thirteen conventions. Focus on new or changed exports:
 - **Convention 6 (create prefix):** Do runtime factories use `create*`?
 - **Convention 7 (derive prefix):** Do derivation functions use `derive*`?
 - **Convention 8 (validate prefix):** Do verification functions use `validate*`?
-- **Convention 9 (build prefix):** Do trailhead derivation builders use `build*`?
+- **Convention 9 (build prefix):** Do surface derivation builders use `build*`?
 - **Convention 10 (gate suffix):** Do gates follow the `*Gate` pattern?
 - **Convention 11 (of suffix):** Do schema extractors use `*Of`?
 - **Convention 12 (Zod boundary):** Does Zod leak past schema definitions?

--- a/.claude/skills/trails-adrs/SKILL.md
+++ b/.claude/skills/trails-adrs/SKILL.md
@@ -255,7 +255,7 @@ Synthesized from ADR-000 (Core Premise) and ADR-001 (Naming Conventions).
 
 ### Vocabulary
 
-Use the accepted project vocabulary consistently: trail (not action/handler), topo (not registry), cross (not follow), blaze (not serve/mount), trailhead (not transport), and tracing (not crumbs or tracker).
+Use the accepted project vocabulary consistently: trail (not action/handler), topo (not registry), cross (not follow), blaze (not serve/mount), surface (not transport), and tracing (not crumbs or tracker).
 
 Read `docs/tenets.md` before writing. Every ADR must be consistent with the tenets.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ The architecture is designed to make consistency easier than drift. Agents build
 
 ## Project Documentation
 
+`AGENTS.md` is the canonical project guidance file. Tool-specific compatibility files such as `CLAUDE.md` should stay as thin pointers here plus any tool-bootstrap-specific notes.
+
 1. Contracts are at the core of how Trails works, and the contract for how Trails is worked on is governed by our [Tenets](docs/tenets.md).
 2. Decisions that define what Trails is, and what it is not, are defined by our [ADRs](docs/adr/README.md).
    - Future directions for Trails are outlined in speculative or [draft ADRs](docs/adr/drafts/README.md).
@@ -85,7 +87,7 @@ Use the project language consistently:
 
 ## Shared Conventions
 
-Shared TSDoc and code-shape guidance for packages and apps lives in [`.claude/rules/coding-conventions.md`](.claude/rules/coding-conventions.md). `apps/AGENTS.md` and `packages/AGENTS.md` point there.
+Shared TSDoc and code-shape guidance for packages and apps lives in [`.claude/rules/coding-conventions.md`](.claude/rules/coding-conventions.md). `apps/AGENTS.md` and `packages/AGENTS.md` should remain thin pointers there plus any small local overrides.
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # CLAUDE.md
 
-## Claude-Specific Instruction
+## Compatibility Shim
 
-- Unless otherwise specified, updates to this file should be made directly in `./AGENTS.md`.
+Keep shared project guidance in `./AGENTS.md`. Only Claude-specific bootstrap notes belong here.
 
 ## Agent Instructions
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **Define once. Surface everywhere.**
 
-Trails is a contract-first TypeScript framework. Define a trail — typed input, Result output, examples, intent — and the framework projects it onto CLI, MCP, HTTP, or WebSocket. One definition, every trailhead, zero drift.
+Trails is a contract-first TypeScript framework. Define a trail — typed input, Result output, examples, intent — and the framework projects it onto CLI, MCP, HTTP, or WebSocket. One definition, every surface, zero drift.
+
+Trails ships CLI, MCP, and HTTP surfaces today. WebSocket is part of the architecture and roadmap, but not yet built.
 
 ## Get started
 
@@ -21,7 +23,7 @@ claude plugin install trails@trails
 npx skills outfitter-dev/trails
 ```
 
-The skill gives your agent the full Trails reference: lexicon, patterns, error taxonomy, trailhead wiring, testing, and before/after migration examples.
+The skill gives your agent the full Trails reference: lexicon, patterns, error taxonomy, surface wiring, testing, and before/after migration examples.
 
 ### With code
 
@@ -81,26 +83,26 @@ Same logic. But now the framework derives:
 - **CLI**: `myapp project show --id p_1` with `--help` text, exit code 2 for not-found
 - **MCP**: tool `myapp_project_show` with JSON Schema input, `readOnlyHint` annotation
 - **Tests**: both examples run as assertions — `testAll(graph)` validates the happy path and the error path
-- **Governance**: warden checks for throws, trailhead imports, missing output schemas
+- **Governance**: warden checks for throws, surface-specific imports in trail code, missing output schemas
 
 You authored the contract. The framework did the rest.
 
 ## What compounds
 
-Each declaration you add to a trail unlocks derived behavior across every trailhead:
+Each declaration you add to a trail unlocks derived behavior across every surface:
 
 | You add | You get for free |
 |---------|-----------------|
 | `input` (Zod schema) | CLI flags + `--help` text, MCP JSON Schema, input validation |
-| `output` (Zod schema) | Contract tests, MCP response typing, trailhead map entries |
+| `output` (Zod schema) | Contract tests, MCP response typing, surface map entries |
 | `intent: 'read'` | MCP `readOnlyHint`, CLI skips confirmation, HTTP GET |
 | `intent: 'destroy'` | MCP `destructiveHint`, CLI auto-adds `--dry-run`, HTTP DELETE |
 | `examples` | Tests (happy + error path), agent guidance, documentation |
 | `crosses` | Composition graph, cycle detection, cross coverage in tests |
 | `resources: [db]` | Singleton lifecycle, test mock auto-resolution, warden governance |
-| `detours` | Recovery paths, warden validates targets exist |
+| `detours` | Recovery paths, detour contract validation, shadowing checks |
 
-The value isn't any single feature. It's that they multiply — each declaration makes every trailhead smarter without additional wiring.
+The value isn't any single feature. It's that they multiply — each declaration makes every surface smarter without additional wiring.
 
 ## How it works
 
@@ -126,6 +128,8 @@ await cliSurface(graph);      // CLI
 // await mcpSurface(graph);   // MCP — same trails, same run function
 ```
 
+The same topo can be opened on HTTP today with `@ontrails/hono`. WebSocket follows the same peer-surface model, but is still planned.
+
 ```bash
 $ myapp greet --name World
 { "message": "Hello, World!" }
@@ -135,13 +139,14 @@ $ myapp greet --name World
 
 | Package | What it does |
 |---------|-------------|
-| [`@ontrails/core`](./packages/core) | Result, errors, trail/event/topo, validation, schema derivation |
-| [`@ontrails/cli`](./packages/cli) | CLI trailhead — flag derivation, output formatting, Commander connector |
-| [`@ontrails/mcp`](./packages/mcp) | MCP trailhead — tool generation, annotations, progress bridge |
-| [`@ontrails/http`](./packages/http) | HTTP trailhead — route derivation, verb mapping, error responses, Hono connector |
+| [`@ontrails/core`](./packages/core) | Result, errors, trail/signal/contour/topo, validation, schema derivation |
+| [`@ontrails/cli`](./packages/cli) | CLI surface — flag derivation, output formatting, Commander connector |
+| [`@ontrails/mcp`](./packages/mcp) | MCP surface — tool generation, annotations, progress bridge |
+| [`@ontrails/http`](./packages/http) | HTTP surface model — route derivation, verb mapping, error responses |
+| [`@ontrails/hono`](./connectors/hono) | Hono connector that opens a topo on the HTTP surface |
 | [`@ontrails/store`](./packages/store) | Schema-derived store definitions, typed accessors, Drizzle bindings, read-only stores |
-| [`@ontrails/testing`](./packages/testing) | `testAll()`, `testTrail()`, `testCrosses()`, contract testing, trailhead harnesses |
-| [`@ontrails/schema`](./packages/schema) | Trailhead maps, semantic diffing, lock files for CI governance |
+| [`@ontrails/testing`](./packages/testing) | `testAll()`, `testTrail()`, `testCrosses()`, contract testing, surface harnesses |
+| [`@ontrails/schema`](./packages/schema) | Surface maps, semantic diffing, lock files for CI governance |
 | [`@ontrails/tracing`](./packages/tracing) | Execution recording, `trails.db` dev-state storage, telemetry helpers |
 | [`@ontrails/warden`](./packages/warden) | AST-based convention rules, drift detection, CI formatters |
 | [`@ontrails/logging`](./packages/logging) | Structured logging — sinks, formatters, LogTape connector |
@@ -161,4 +166,4 @@ bun run typecheck      # TypeScript strict mode
 
 ## Status
 
-v1 beta. The contract layer, CLI/MCP/HTTP trailheads, `trails topo` and `trails dev` workflows, shared `trails.db`, tracing-backed developer state, schema-derived stores, and the Drizzle runtime are implemented and shipping. WebSocket trailhead is designed but not yet built. See [Horizons](./docs/horizons.md) for what's next.
+v1 beta. The contract layer, CLI/MCP/HTTP surfaces, `trails topo` and `trails dev` workflows, shared `trails.db`, tracing-backed developer state, schema-derived stores, and the Drizzle runtime are implemented and shipping. The WebSocket surface is designed but not yet built. See [Horizons](./docs/horizons.md) for what's next.

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -1,1 +1,8 @@
-../.claude/rules/coding-conventions.md
+# AGENTS.md
+
+This file is a thin compatibility pointer.
+
+- Canonical project guidance lives in [../AGENTS.md](../AGENTS.md).
+- Shared TSDoc and code-shape conventions live in [../.claude/rules/coding-conventions.md](../.claude/rules/coding-conventions.md).
+
+Add app-specific instructions here only when an app needs behavior beyond those shared sources.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,17 +10,20 @@ Canonical public surface-facing reference. For naming conventions and decision h
 // Definitions
 trail(id, spec)                    // define a unit of work (with optional crosses for composition)
 signal(id, spec)                    // define a payload schema with provenance
+contour(name, shape, options)       // define a first-class domain object with identity metadata
 resource(id, spec)                  // define a first-class resource dependency
 createResourceLookup(getContext)   // bind ctx.resource() to a specific context snapshot
-topo(name, ...modules)             // assemble trails, signals, and resources into a queryable topology
+topo(name, ...modules)             // assemble trails, contours, signals, and resources into a queryable topology
 // Topo methods: .get(id), .has(id), .list(), .listSignals(), .ids(), .count
+//               .getContour(name), .hasContour(name), .listContours(), .contourIds(), .contourCount
 //               .getResource(id), .hasResource(id), .listResources(), .resourceIds(), .resourceCount
 createTopoStore(options?), createMockTopoStore(seed?), topoStore
 
 // Types
-Trail<I, O>, Signal<T>, Resource<T>, Topo, Intent
+Trail<I, O>, Signal<T>, Contour<TName, TShape, TIdentity>, Resource<T>, Topo, Intent
 TrailSpec<I, O>, SignalSpec<T>, ResourceSpec<T>, TrailExample<I, O>
-AnyTrail, AnySignal, AnyResource, ResourceContext, ResourceOverrideMap
+AnyTrail, AnySignal, AnyContour, AnyResource, ResourceContext, ResourceOverrideMap
+ContourOptions, ContourIdBrand, ContourIdMetadata, ContourIdSchema, ContourIdValue, ContourReference
 
 // Type utilities
 TrailInput<T>                      // extract input type from a Trail
@@ -28,6 +31,8 @@ TrailOutput<T>                     // extract output type from a Trail
 TrailResult<T>                     // extract Result<Output, Error> from a Trail
 inputOf(trail)                     // get the input Zod schema
 outputOf(trail)                    // get the output Zod schema (or undefined)
+getContourIdMetadata(schema)       // read runtime contour identity metadata from a branded schema
+getContourReferences(contour)      // read structural contour references declared inside a contour
 
 // Result
 Result<T, E>
@@ -106,6 +111,8 @@ DeriveTrailSpec<TContour, TOp, TGenerated>
 ```
 
 ## `@ontrails/cli`
+
+Current shipped surface packages are `@ontrails/cli`, `@ontrails/mcp`, `@ontrails/http`, and `@ontrails/hono`. A WebSocket surface is planned but has no public package or API yet.
 
 ```typescript
 surface(graph, options?)               // one-liner: parse argv, execute, return exit code
@@ -403,7 +410,7 @@ ConsoleSinkOptions, FileSinkOptions, PrettyFormatterOptions
 | Name | Intent |
 | --- | --- |
 | `trailblaze(topo, options?)` | Full hosted runtime |
-| `trailhead` | Conceptual boundary where a graph becomes reachable (reserved noun) |
+| `trailhead` | Historical boundary term retired from active user-facing vocabulary |
 | `scout` | Agent-side runtime discovery |
 | `validateExample`, `validateCross` | Contract verification family |
 | `generateDocs`, `generateOpenApi`, `generateLlmsTxt` | Build-time doc generation |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,7 @@ Trails uses a hexagonal architecture. Core defines ports. Everything on the edge
                 |                       |
                 |    @ontrails/core     |
                 |                       |
+                |  contour() -> Contour |
                 |  trail() -> Trail     |
                 |  signal() -> Signal   |
                 |  topo() -> Topo       |
@@ -45,13 +46,15 @@ The left side is where the world calls in -- CLI commands, MCP tool calls, HTTP 
 
 **Drift is structurally harder than alignment.** One schema, one `Result` type, one error taxonomy. You cannot have different parameter names across surfaces because there is only one schema.
 
-**Surfaces are peers.** No surface is privileged. CLI, MCP, HTTP, and WebSocket are all equal connectors reading from the same topo. Adding a surface is a `surface()` call, not an architecture change.
+**Surfaces are peers.** No surface is privileged. CLI, MCP, HTTP, and WebSocket are all equal connectors reading from the same topo. CLI, MCP, and HTTP ship today; WebSocket is still planned. Adding a surface is a `surface()` call, not an architecture change.
 
 **Implementations are pure functions.** Input in, `Result` out. No `process.exit()`, no `console.log()`, no `req.headers`. The implementation does not know which surface invoked it. Authoring can be sync or async; runtime execution is normalized to one awaitable shape before layers and surfaces run.
 
 **The framework defines ports -- everything concrete is a connector.** CLI framework (Commander, yargs), logging backend (LogTape, pino), storage engine, telemetry exporter -- all pluggable. The framework never imports a concrete implementation.
 
 **The contract is machine-readable at runtime.** The topo, survey, guide, and committed lock artifacts make the trail system queryable by agents, tooling, and CI.
+
+**Contours are graph nodes; trails are executable edges.** Contours declare the domain objects the graph is about. Trails declare the typed work that moves through that graph. The topo carries both so surfaces, testing, and governance can reason about nouns and verbs from the same authored source.
 
 ## Information Architecture
 
@@ -64,6 +67,7 @@ These are the creative contributions. They can't be derived because they don't e
 | What you author | Why it can't be derived |
 | --- | --- |
 | Input and output Zod schemas | The shape of your domain data |
+| Contour schemas, identities, and examples | The domain nodes your trails operate on |
 | Safety properties: `intent`, `idempotent` | Behavioral assertions about intent |
 | Examples (input plus expected result or error) | Concrete specifications of behavior |
 | The implementation function | Your business logic |
@@ -133,7 +137,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 
 ### Foundation
 
-`@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, `trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, layers, and connector port interfaces.
+`@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, `contour()`/`trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, layers, and connector port interfaces.
 
 **The test:** if you are building a surface connector or ecosystem package, you should only need `@ontrails/core`.
 

--- a/docs/draft-state.md
+++ b/docs/draft-state.md
@@ -66,7 +66,7 @@ One draft dependency can turn surprising amounts of downstream work into draft s
 
 These outputs reject draft state at runtime via `validateEstablishedTopo()`:
 
-- **Surface projection** — no draft trails in CLI, MCP, or HTTP surfaces
+- **Surface projection** — no draft trails in current shipped surfaces
 - **Lockfile export** — no draft nodes in `.trails/trails.lock`
 - **OpenAPI generation** — established schema export excludes draft trails
 - **Topo exports** — standard topo accessors exclude draft declarations

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,8 @@
 # Getting Started
 
-Install the core packages, define your first trail, open surfaces on CLI and MCP, and test it with one line.
+Install the core packages, define your first trail, open surfaces on CLI, MCP, or HTTP, and test it with one line.
+
+This guide demonstrates CLI and MCP first because they are the shortest path to a working app. HTTP is equally shipped today, and WebSocket is still planned.
 
 ## Installation
 
@@ -18,6 +20,9 @@ bun add commander
 
 # Add MCP surface (optional)
 bun add @ontrails/mcp
+
+# Add HTTP surface (optional, shipped today)
+bun add @ontrails/http @ontrails/hono
 
 # Add testing (dev dependency)
 bun add -d @ontrails/testing
@@ -81,7 +86,7 @@ import * as greetModule from './trails/greet';
 export const graph = topo('myapp', greetModule);
 ```
 
-`topo()` scans the module exports for `Trail` shapes and builds the internal topo (the trail collection).
+`topo()` scans the module exports for trails, signals, contours, and resources and builds the resolved graph.
 
 ## Open a CLI Surface
 
@@ -144,6 +149,25 @@ Same trail. Same implementation. Different surface. The MCP server exposes a `my
 - Examples available for agent planning
 
 Pure trails can return `Result` directly. Trails with `crosses` and I/O-heavy trails can stay `async`; Trails normalizes both forms before surfaces run them.
+
+## Open an HTTP Surface
+
+Create `src/http.ts`:
+
+```typescript
+import { surface } from '@ontrails/hono';
+import { graph } from './app';
+
+await surface(graph, { port: 3000 });
+```
+
+Same topo. Same implementation. Different shipped surface. The HTTP connector derives routes from trail IDs and verbs from `intent`:
+
+- `greet` becomes `GET /greet` because the trail declares `intent: 'read'`
+- Input validation still comes from the same Zod schema
+- The same `Result` and error taxonomy map to HTTP responses instead of CLI or MCP output
+
+See the [HTTP surface guide](./surfaces/http.md) for the full route and error model. WebSocket follows the same peer-surface design, but does not have a public package yet.
 
 ## Test with `testAll`
 

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -18,6 +18,8 @@
 
 ## Mid-term (v1.3+)
 
+**WebSocket surface.** A peer surface to CLI, MCP, and HTTP for long-lived request/response sessions plus subscription-style updates where the contract supports them. The design goal is the same as every other surface: derive names, validation, and error mapping from the topo instead of hand-authoring a separate runtime model.
+
 **Derived dependency graphs.** Instead of hand-maintaining `crosses` declarations, the framework infers them from `ctx.cross()` calls in the implementation via static analysis. The same idea could eventually extend beyond today's declared `resources: [...]` model to richer resource capability inference. The surface map captures the graph. Changes show up in diffs.
 
 **Implementation synthesis from examples.** For trails with comprehensive examples that fully specify behavior (pure transformations, mapping logic, validation rules), an agent could synthesize the implementation from the examples alone. The examples become the source of truth; the code becomes the derived artifact.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@
 ## New to Trails?
 
 1. **[Why Trails](./why-trails.md)** — The problem, the approach, why contracts beat conventions
-2. **[Getting Started](./getting-started.md)** — Install, define your first trail, open a CLI surface, test it
-3. **[Lexicon](./lexicon.md)** — The terms you'll use every day: trail, blaze, topo, surface, cross, resource, signal, layer, tracing
+2. **[Getting Started](./getting-started.md)** — Install, define your first trail, open CLI/MCP/HTTP surfaces, test it
+3. **[Lexicon](./lexicon.md)** — The terms you'll use every day: trail, blaze, topo, contour, surface, cross, resource, signal, layer, tracing
 
 ## Building something?
 
@@ -19,9 +19,10 @@
 
 ## Adding a surface?
 
-- **[CLI Surface](./surfaces/cli.md)** — Flag derivation, output modes, exit codes, `--dry-run`
-- **[MCP Surface](./surfaces/mcp.md)** — Tool naming, annotations, progress bridge
-- **[HTTP Surface](./surfaces/http.md)** — Route derivation, verb mapping, error responses, Hono connector
+- **[CLI Surface](./surfaces/cli.md)** — Shipped today. Flag derivation, output modes, exit codes, `--dry-run`
+- **[MCP Surface](./surfaces/mcp.md)** — Shipped today. Tool naming, annotations, progress bridge
+- **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, verb mapping, error responses, Hono connector
+- **WebSocket Surface** — Planned, not yet implemented. See [Horizons](./horizons.md) for the current direction.
 
 ## Governing your codebase?
 
@@ -57,4 +58,4 @@
 
 ## Where to next?
 
-- **[Horizons](./horizons.md)** — HTTP surface, permits, mounts, tracing, and the road to v1 stable
+- **[Horizons](./horizons.md)** — WebSocket, mounts, packs, guide-driven SDKs, and the post-v1 roadmap

--- a/docs/why-trails.md
+++ b/docs/why-trails.md
@@ -8,7 +8,7 @@ When you define a trail, you author the things only you know: the input schema, 
 
 This is DRY applied not just to code, but to information. Frameworks have always been good at eliminating duplicate code. Trails extends that principle to duplicate authorship — across the entire surface area of a project, from the implementation to the CLI to the MCP tools to the tests to the agent documentation.
 
-Trails is Bun-native — the framework uses Bun APIs throughout for I/O, hashing, discovery, and storage. But the surfaces it produces are universally consumable: CLI binaries, MCP servers, and HTTP endpoints work with any runtime on the consuming side.
+Trails is Bun-native — the framework uses Bun APIs throughout for I/O, hashing, discovery, and storage. But the shipped surfaces it produces are universally consumable: CLI binaries, MCP servers, and HTTP endpoints work with any runtime on the consuming side. WebSocket is part of the architecture, but still planned.
 
 ---
 
@@ -70,6 +70,8 @@ await surface(graph);
 import { surface as mcpSurface } from '@ontrails/mcp';
 await mcpSurface(graph);
 ```
+
+The same topo can also open on HTTP today via `@ontrails/hono`. WebSocket follows the same peer-surface model, but does not ship yet.
 
 One definition. Every surface. The rest is derived.
 
@@ -147,7 +149,7 @@ One write, three reads. If someone changes the business rule, they change the ex
 
 Great tools already exist for each surface. tRPC, Hono, and Fastify are excellent for HTTP. Commander and oclif are battle-tested for CLIs. FastMCP and the official SDK make MCP server development straightforward. NestJS spans multiple transports with a mature ecosystem.
 
-Trails doesn't try to replace any of them. It occupies a different layer: the **contract layer** that sits above individual surface implementations. A trail definition captures the schema, examples, error types, intent and metadata, and composition graph in one place. Surface connectors — CLI, MCP, HTTP, WebSocket — project that contract into whatever runtime format the surface needs.
+Trails doesn't try to replace any of them. It occupies a different layer: the **contract layer** that sits above individual surface implementations. A trail definition captures the schema, examples, error types, intent and metadata, and composition graph in one place. Surface connectors — CLI, MCP, and HTTP today, with WebSocket planned — project that contract into whatever runtime format the surface needs.
 
 The value isn't in being better at any single surface. It's in making the contract the source of truth so that every surface stays consistent with it — not because anyone was careful, but because the framework derives each surface from the same definition.
 
@@ -176,7 +178,7 @@ The answers became the principles: author what's new, derive what's known, overr
 
 ## What's Next
 
-The v1 implementation delivers the foundation: Result types, error taxonomy, trail and signal definitions, CLI and MCP surfaces, contract-driven testing, schema governance, and the warden. These establish the contract layer and prove the core loop — define once, surface everywhere.
+The v1 implementation delivers the foundation: Result types, error taxonomy, trail, signal, and contour definitions, CLI/MCP/HTTP surfaces, contract-driven testing, schema governance, and the warden. These establish the contract layer and prove the core loop — define once, surface everywhere.
 
 The architecture points toward capabilities that follow naturally — resource capability shaping, derived dependency graphs, cross-app contract negotiation, implementation synthesis from examples. Each follows from the same principle: if the information exists in the system, don't ask the developer to restate it.
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,1 +1,8 @@
-../.claude/rules/coding-conventions.md
+# AGENTS.md
+
+This file is a thin compatibility pointer.
+
+- Canonical project guidance lives in [../AGENTS.md](../AGENTS.md).
+- Shared TSDoc and code-shape conventions live in [../.claude/rules/coding-conventions.md](../.claude/rules/coding-conventions.md).
+
+Add package-specific instructions here only when a package needs behavior beyond those shared sources.


### PR DESCRIPTION
## Summary
- refresh the top-level docs so CLI, MCP, and HTTP are presented as shipped peer surfaces and WebSocket is described honestly as planned
- restore contours to the public README, architecture, API reference, and onboarding story as first-class graph nodes
- make `AGENTS.md` the explicit canonical agent-guidance file and keep the tool-specific wrappers as thin pointers

## Verification
- `bun run format:check`
- `bun run build`
- `bun run test`
- `bun run check`
- bottom-up branch verification pass ending on `trl-385-docs-parity-tail`

Closes: TRL-385, TRL-386, TRL-387
