### PR TITLE
chore(ci): fan out checks and drop duplicate builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
 
       - name: Build
@@ -36,11 +36,10 @@ jobs:
 
   lint:
     name: Lint & Format
-    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
 
       - name: Lint
@@ -51,30 +50,22 @@ jobs:
 
   typecheck:
     name: Typecheck
-    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
-
-      - name: Build
-        run: bun run build
 
       - name: Typecheck
         run: bun run typecheck
 
   test:
     name: Test
-    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
-
-      - name: Build
-        run: bun run build
 
       - name: Test
         run: bun run test
@@ -86,15 +77,11 @@ jobs:
 
   governance:
     name: Governance
-    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
-
-      - name: Build
-        run: bun run build
 
       - name: Warden
         run: bun apps/ci/bin/ci.ts --format github --fail-on error

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,7 @@
       "cache": false
     },
     "typecheck": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^typecheck"]
     },
     "lint": {
       "inputs": ["src/**", ".oxlintrc.json", ".oxfmtrc.jsonc"],


### PR DESCRIPTION
## Summary
- speed up the default CI workflow by letting `Lint & Format`, `Typecheck`, `Test`, and `Governance` start immediately instead of waiting on the standalone `Build` job
- remove the duplicate top-level `bun run build` steps from `Typecheck`, `Test`, and `Governance`
- drop the Turbo `typecheck -> ^build` dependency after verifying the repo still typechecks cleanly from source-only workspace resolution

## What Changed
- removed `needs: build` from the non-build jobs in `.github/workflows/ci.yml`
- deleted the redundant workflow-level build steps from `Typecheck`, `Test`, and `Governance`
- removed the `typecheck.dependsOn = ["^build"]` edge from `turbo.json`
- left the dedicated `Build` job in place as its own check

## Verification
- `bun run typecheck` after deleting all `dist/` directories and `*.tsbuildinfo`
- `bun run build`
- `bun run test`
- `bun run check`
- bottom-up branch-local `build` + `test` verification from `trl-370` through `trl-385` after restacking

Closes: TRL-390
