### PR TITLE
chore: tighten bootstrap and repo follow-up guards

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,12 +2,15 @@ pre-commit:
   piped: true
   commands:
     format_guard:
+      priority: 1
       run: bun run format:guard
     format:
+      priority: 2
       glob: '**/*.{ts,tsx,js,jsx,json,jsonc}'
       run: bun run format:file {staged_files}
       stage_fixed: true
     markdownlint:
+      priority: 3
       glob: '*.md'
       run: bun run mdlint:fix {staged_files}
       stage_fixed: true

--- a/plugin/skills/trails/references/testing-patterns.md
+++ b/plugin/skills/trails/references/testing-patterns.md
@@ -96,12 +96,12 @@ Composition-specific fields: `expectCrossed` (ordered trail IDs), `expectCrossed
 
 ## `testContracts(graph)` / `testDetours(graph)`
 
-`testContracts` verifies every trail's implementation output matches its declared output schema -- catches drift. `testDetours` checks that every detour target references a trail that exists in the topo. Both are included in `testAll` automatically; use standalone when debugging a specific failure.
+`testContracts` verifies every trail's implementation output matches its declared output schema -- catches drift. `testDetours` validates detour constructor, `recover`, and shadowing semantics. Both are included in `testAll` automatically; use standalone when debugging a specific failure.
 
 ```typescript
 import { testContracts, testDetours } from '@ontrails/testing';
 testContracts(graph);  // schema drift detection
-testDetours(graph);    // structural detour validation
+testDetours(graph);    // detour contract validation
 ```
 
 ## Service Mocking

--- a/scripts/__tests__/check-readme-snippets.test.ts
+++ b/scripts/__tests__/check-readme-snippets.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseImportedBindings } from '../check-readme-snippets.ts';
+
+describe('parseImportedBindings', () => {
+  test('captures multiline named imports', () => {
+    const bindings = parseImportedBindings(`import {
+  createMemorySink,
+  registerTraceSink,
+} from '@ontrails/tracing';`);
+
+    expect(bindings).toEqual([
+      {
+        moduleSpecifier: '@ontrails/tracing',
+        name: 'createMemorySink',
+      },
+      {
+        moduleSpecifier: '@ontrails/tracing',
+        name: 'registerTraceSink',
+      },
+    ]);
+  });
+
+  test('skips type-only imports while keeping runtime bindings', () => {
+    const bindings = parseImportedBindings(`import {
+  type MemorySink,
+  createMemorySink as makeMemorySink,
+  registerTraceSink,
+} from '@ontrails/tracing';
+import type { Topo } from '@ontrails/core';`);
+
+    expect(bindings).toEqual([
+      {
+        moduleSpecifier: '@ontrails/tracing',
+        name: 'createMemorySink',
+      },
+      {
+        moduleSpecifier: '@ontrails/tracing',
+        name: 'registerTraceSink',
+      },
+    ]);
+  });
+});

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,11 +12,10 @@
 #
 # Runtime requirements:
 #   - bash 4+
-#   - python3 (or python) — used by `python_json` to parse package.json
-#     before Bun is available. Nearly ubiquitous on macOS and Linux; on
-#     minimal container images it may need to be installed first. If
-#     Python is absent, bootstrap fails loudly rather than silently
-#     skipping the workspace dependency check.
+#   - one of: bun, node, python3, or python — used to parse package.json
+#     before dependency install checks can trust workspace state. Prefer
+#     Bun or Node when available so agent and CI environments do not depend
+#     on Python being present.
 #
 
 set -euo pipefail
@@ -65,28 +64,53 @@ error() { echo -e "${RED}✗${NC} $1" >&2; }
 # Check if command exists
 has() { command -v "$1" &>/dev/null; }
 
-python_json() {
-  if command -v python3 &>/dev/null; then
-    python3 "$@"
-  elif command -v python &>/dev/null; then
-    python "$@"
-  else
-    warn "Python not found; workspace install-state check skipped"
-    return 1
-  fi
-}
-
 list_workspace_globs() {
-  python_json - "$REPO_ROOT/package.json" <<'PY'
-import json
-import sys
+  if has bun; then
+    TRAILS_PACKAGE_JSON="$REPO_ROOT/package.json" bun --eval '
+      const packageJson = JSON.parse(
+        await Bun.file(process.env.TRAILS_PACKAGE_JSON).text()
+      );
+      for (const workspace of packageJson.workspaces ?? []) {
+        console.log(workspace);
+      }
+    '
+  elif has node; then
+    TRAILS_PACKAGE_JSON="$REPO_ROOT/package.json" node --input-type=module --eval '
+      import { readFileSync } from "node:fs";
 
-with open(sys.argv[1], "r", encoding="utf-8") as fh:
+      const packageJson = JSON.parse(
+        readFileSync(process.env.TRAILS_PACKAGE_JSON, "utf8")
+      );
+      for (const workspace of packageJson.workspaces ?? []) {
+        console.log(workspace);
+      }
+    '
+  elif has python3; then
+    TRAILS_PACKAGE_JSON="$REPO_ROOT/package.json" python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["TRAILS_PACKAGE_JSON"], "r", encoding="utf-8") as fh:
     package = json.load(fh)
 
 for workspace in package.get("workspaces", []):
     print(workspace)
 PY
+  elif has python; then
+    TRAILS_PACKAGE_JSON="$REPO_ROOT/package.json" python - <<'PY'
+import json
+import os
+
+with open(os.environ["TRAILS_PACKAGE_JSON"], "r", encoding="utf-8") as fh:
+    package = json.load(fh)
+
+for workspace in package.get("workspaces", []):
+    print(workspace)
+PY
+  else
+    warn "No Bun, Node, or Python runtime found; workspace install-state check skipped"
+    return 1
+  fi
 }
 
 has_repo_install_state() {

--- a/scripts/check-readme-snippets.ts
+++ b/scripts/check-readme-snippets.ts
@@ -169,15 +169,15 @@ export const parseImportedBindings = (
   );
 
   for (const statement of sourceFile.statements) {
-    const { importClause, moduleSpecifier } = statement;
-
     if (
       !ts.isImportDeclaration(statement) ||
-      !importClause ||
-      !ts.isStringLiteralLike(moduleSpecifier)
+      !statement.importClause ||
+      !ts.isStringLiteralLike(statement.moduleSpecifier)
     ) {
       continue;
     }
+
+    const { importClause, moduleSpecifier } = statement;
 
     // Whole statement is type-only (`import type { ... }`) — none of these
     // bindings exist at runtime, so skip the verify-exported-bindings step

--- a/scripts/check-readme-snippets.ts
+++ b/scripts/check-readme-snippets.ts
@@ -11,6 +11,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { join, resolve } from 'node:path';
+import ts from 'typescript';
 
 interface ReadmeSnippetConfig {
   readonly prelude?: string | undefined;
@@ -100,9 +101,6 @@ declare function trail(
 ] as const;
 
 const TYPESCRIPT_FENCE_PATTERN = /^(?:ts|tsx|typescript)$/;
-const IMPORT_PATTERN =
-  /^import\s+(type\s+)?\{([^}]+)\}\s+from\s+['"]([^'"]+)['"];?$/gm;
-
 const extractSnippets = (
   markdown: string,
   sourcePath?: string
@@ -157,37 +155,51 @@ const extractSnippets = (
   return snippets;
 };
 
-const parseImportedBindings = (snippet: string): readonly ImportedBinding[] => {
+export const parseImportedBindings = (
+  snippet: string
+): readonly ImportedBinding[] => {
   const bindings: ImportedBinding[] = [];
 
-  for (const match of snippet.matchAll(IMPORT_PATTERN)) {
-    const [, typeModifier, imported, moduleSpecifier] = match;
+  const sourceFile = ts.createSourceFile(
+    'readme-snippet.ts',
+    snippet,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
 
-    if (!imported || !moduleSpecifier) {
+  for (const statement of sourceFile.statements) {
+    const { importClause, moduleSpecifier } = statement;
+
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !importClause ||
+      !ts.isStringLiteralLike(moduleSpecifier)
+    ) {
       continue;
     }
 
     // Whole statement is type-only (`import type { ... }`) — none of these
     // bindings exist at runtime, so skip the verify-exported-bindings step
     // entirely rather than false-positive on every specifier.
-    if (typeModifier) {
+    if (importClause.isTypeOnly) {
       continue;
     }
 
-    for (const specifier of imported.split(',')) {
-      const trimmed = specifier.trim();
-      // Per-binding `type` modifier (`import { type Foo, Bar }`) also makes
-      // that specifier type-only — skip it without recording a binding.
-      if (trimmed.startsWith('type ') || trimmed.startsWith('type\t')) {
+    const { namedBindings } = importClause;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      continue;
+    }
+
+    for (const specifier of namedBindings.elements) {
+      if (specifier.isTypeOnly) {
         continue;
       }
 
-      const [name] = trimmed.split(/\s+as\s+/);
-      if (!name) {
-        continue;
-      }
-
-      bindings.push({ moduleSpecifier, name });
+      bindings.push({
+        moduleSpecifier: moduleSpecifier.text,
+        name: specifier.propertyName?.text ?? specifier.name.text,
+      });
     }
   }
 
@@ -434,4 +446,6 @@ const main = async (): Promise<void> => {
   }
 };
 
-await main();
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
## Summary
- prefer Bun or Node over Python when bootstrap parses workspace globs, while keeping Python as the final fallback
- make the root pre-commit Lefthook ordering explicit so `format_guard` is guaranteed to run before formatting work
- teach the README snippet export checker to understand multiline named imports and cover that with a regression test
- refresh the stale agent testing reference for current `testDetours` semantics

## What Changed
- updated [scripts/bootstrap.sh](/Users/mg/Developer/outfitter/trails/scripts/bootstrap.sh) so `list_workspace_globs` uses `bun`, then `node`, then `python3`/`python`
- added explicit `priority` ordering in [lefthook.yml](/Users/mg/Developer/outfitter/trails/lefthook.yml) for the `pre-commit` piped commands
- replaced the single-line import regex in [scripts/check-readme-snippets.ts](/Users/mg/Developer/outfitter/trails/scripts/check-readme-snippets.ts) with AST-based import parsing and made the parser testable
- added [scripts/__tests__/check-readme-snippets.test.ts](/Users/mg/Developer/outfitter/trails/scripts/__tests__/check-readme-snippets.test.ts) to lock in multiline and type-only import handling
- updated [plugin/skills/trails/references/testing-patterns.md](/Users/mg/Developer/outfitter/trails/plugin/skills/trails/references/testing-patterns.md) so `testDetours` matches the shipped constructor/recover/shadowing behavior

## Verification
- `bun test scripts/__tests__/bootstrap.test.ts scripts/__tests__/check-readme-snippets.test.ts --bail`
- `bun run docs:snippets`
- `bunx lefthook validate`
- `bun run build`
- `bun run test`
- `bun run check`

Closes: TRL-391, TRL-395, TRL-396, TRL-397
