### PR TITLE
chore: tighten npm package contents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,10 +133,16 @@ bunx changeset version
 # 3. Commit, push, publish
 git add -A && git commit -m "chore: version packages to 1.0.0-beta.N"
 git push
+bun run pack:check
 bun run publish:packages
 ```
 
 To exit pre-release mode for a stable release: `bunx changeset pre exit`, then version as usual.
+
+`bun run pack:check` runs the publish matrix through `npm pack --dry-run`.
+Packages intentionally ship source `.ts` files while their `exports` map points at
+`src`; test files, `dist`, `.turbo`, and `*.tsbuildinfo` should stay out of the
+published tarballs.
 
 ## Testing
 

--- a/apps/trails/README.md
+++ b/apps/trails/README.md
@@ -1,0 +1,27 @@
+# Trails CLI
+
+Command-line tools for working with Trails projects.
+
+Use the CLI to scaffold a Trails app, add surfaces, inspect the current topo, run
+warden checks, manage draft state, and keep local Trails project state tidy.
+
+```bash
+bunx @ontrails/trails create
+```
+
+Common workflows:
+
+- `trails create` starts a new Trails project with generated trail, topo, surface,
+  and verification files.
+- `trails add surface` adds another surface entrypoint to an existing project.
+- `trails topo` inspects, exports, verifies, pins, and unpins topo state.
+- `trails warden` runs Trails governance checks for contract and architecture
+  drift.
+- `trails guide` shows available trails and examples from a project.
+
+Trails is contract-first: define trails once with typed input, Result output,
+examples, and meta; the framework derives CLI, MCP, HTTP, and future surfaces from
+the same contracts.
+
+See the main Trails documentation for the full framework guide:
+<https://github.com/outfitter-dev/trails>

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -4,6 +4,15 @@
   "bin": {
     "trails": "./bin/trails.ts"
   },
+  "files": [
+    "bin/**/*.ts",
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "scripts": {
     "build": "tsc -b",

--- a/connectors/drizzle/package.json
+++ b/connectors/drizzle/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/drizzle",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/connectors/hono/package.json
+++ b/connectors/hono/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/hono",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/connectors/vite/package.json
+++ b/connectors/vite/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/vite",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "format:file": "bunx ultracite fix",
     "format:guard": "if git grep -nE \"(\\\\./)?node_modules/\\\\.bin/ultra[c]ite\" -- ':!bun.lock'; then echo 'Direct node_modules/.bin formatter invocation found'; exit 1; fi",
     "mdlint:fix": "./node_modules/.bin/markdownlint-cli2 --fix",
+    "pack:check": "./scripts/publish.sh --dry-run",
     "typecheck": "turbo run typecheck",
     "check": "bun run lint && bun run format:check && bun run typecheck && bun run docs:snippets && bun run scaffold-versions:check",
     "clean": "turbo run clean --no-cache && rm -rf node_modules",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/cli",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/config",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/core",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/http",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/logging",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/logtape/package.json
+++ b/packages/logtape/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/logtape",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/mcp",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/permits",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/schema",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/store",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/testing",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/tracing",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@ontrails/warden",
   "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,7 +2,7 @@
 #
 # publish.sh — Publish all @ontrails packages using bun publish
 #
-# Usage: ./scripts/publish.sh [--otp <code>]
+# Usage: ./scripts/publish.sh [--dry-run] [--otp <code>]
 #
 # Uses bun publish (not npm publish) so workspace:^ is automatically
 # replaced with the actual version. Changesets handles versioning,
@@ -14,10 +14,32 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 
+info() { echo -e "\033[0;34m▸\033[0m $1"; }
+success() { echo -e "\033[0;32m✓\033[0m $1"; }
+error() { echo -e "\033[0;31m✗\033[0m $1" >&2; }
+
+DRY_RUN=false
 OTP=""
-if [[ "${1:-}" == "--otp" ]] && [[ -n "${2:-}" ]]; then
-  OTP="$2"
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --otp)
+      if [[ -z "${2:-}" ]]; then
+        error "--otp requires a code"
+        exit 1
+      fi
+      OTP="${2:-}"
+      shift 2
+      ;;
+    *)
+      error "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
 
 # Packages in dependency order (core first, dependents after)
 PACKAGES=(
@@ -40,10 +62,6 @@ PACKAGES=(
   apps/trails
 )
 
-info() { echo -e "\033[0;34m▸\033[0m $1"; }
-success() { echo -e "\033[0;32m✓\033[0m $1"; }
-error() { echo -e "\033[0;31m✗\033[0m $1" >&2; }
-
 for pkg in "${PACKAGES[@]}"; do
   pkg_path="$REPO_ROOT/$pkg"
   pkg_name=$(jq -r '.name' "$pkg_path/package.json")
@@ -54,6 +72,21 @@ for pkg in "${PACKAGES[@]}"; do
   if [[ "$is_private" == "true" ]]; then
     info "Skipping $pkg_name (private)"
     continue
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "Checking package contents for $pkg_name@$pkg_version..."
+    pack_log=$(mktemp)
+    if (cd "$pkg_path" && npm pack --dry-run >"$pack_log" 2>&1); then
+      success "$pkg_name@$pkg_version pack check passed"
+      rm -f "$pack_log"
+      continue
+    fi
+
+    error "Failed pack check for $pkg_name"
+    cat "$pack_log" >&2
+    rm -f "$pack_log"
+    exit 1
   fi
 
   info "Publishing $pkg_name@$pkg_version..."
@@ -72,4 +105,8 @@ for pkg in "${PACKAGES[@]}"; do
 done
 
 echo ""
-success "All packages published!"
+if [[ "$DRY_RUN" == "true" ]]; then
+  success "All package pack checks passed!"
+else
+  success "All packages published!"
+fi


### PR DESCRIPTION
## Summary

- Adds explicit npm `files` allowlists to every package published by `scripts/publish.sh`.
- Extends `scripts/publish.sh` with `--dry-run` so the release matrix can be checked with `npm pack --dry-run` before publish.
- Adds `bun run pack:check` to the root scripts and documents the release hygiene expectation in `AGENTS.md`.

## Why

The beta.15 publish succeeded, but tarballs included build/test debris such as `.turbo/*`, `*.tsbuildinfo`, `dist`, and test files. These packages still intentionally ship source `.ts` files because their `exports` maps currently point at `src`.

## Verification

- `bun run format:check`
- `bun run pack:check`
- pre-push hook via Graphite: `turbo run test`
- pre-push hook via Graphite: `turbo run typecheck`

Closes TRL-503.