### PR TITLE
docs: retire deprecated package name references (TRL-501 sweep)

### DIFF
--- a/docs/releases/beta15.md
+++ b/docs/releases/beta15.md
@@ -195,4 +195,4 @@ New or newly publishable packages in the beta.15 publish flow include:
 - `@ontrails/logtape`
 - `@ontrails/tracing`
 
-Deprecated package names such as `@ontrails/tracker` and `@ontrails/crumbs` should be retired separately from the beta.15 code changes.
+Deprecated package names `@ontrails/tracker` and `@ontrails/crumbs` have been retired on npm with `npm deprecate`. Both point at `@ontrails/tracing` in their deprecation messages; new installs surface a visible warning.


### PR DESCRIPTION
## Summary

Closes **TRL-501** (retire deprecated npm package names before beta.15).

The npm-side work is done out of band:
- `npm deprecate '@ontrails/crumbs@*' "Deprecated before 1.0. Use @ontrails/tracing instead."`
- `npm deprecate '@ontrails/tracker@*' "Renamed to @ontrails/tracing. Please upgrade to @ontrails/tracing."`

This PR's residual code change is one line of release-notes housekeeping reflecting that the deprecations have actually run.

## Changes

- `docs/releases/beta15.md` — update the deprecated-name paragraph from forward-looking ("should be retired separately") to past tense, naming the replacement and noting the install-time deprecation warning.

## What this PR doesn't change

Originally this PR also rewrote retired package names in ADR-0031 and ADR-0032 code examples. Those changes were unwound after review feedback: accepted ADRs document the state of the world at acceptance, so rewriting their code examples after the fact would falsify the historical record. CHANGELOGs, vocab-cutover scripts, ADR-0022 / ADR-0029, draft ADRs, and prior-release notes are all left intentionally historical for the same reason.

Closes: TRL-501