### PR TITLE
chore(plugin): republish at 0.3.0 with beta.15-aligned skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,16 +5,16 @@
     "url": "https://github.com/outfitter-dev"
   },
   "metadata": {
-    "description": "Build with the Trails framework — contract-first trails, trailheads, testing, and governance.",
-    "version": "0.2.0"
+    "description": "Build with the Trails framework — contract-first trails, surfaces, testing, and governance.",
+    "version": "0.3.0"
   },
   "repository": "https://github.com/outfitter-dev/trails",
   "plugins": [
     {
       "name": "trails",
       "source": "./plugin",
-      "version": "0.2.0",
-      "description": "Skills for building Trails applications — trail creation, trailheads, testing, debugging, migration, and governance."
+      "version": "0.3.0",
+      "description": "Skills for building Trails applications — trail creation, surfaces, testing, debugging, migration, and governance."
     }
   ]
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trails",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Build with the Trails framework — contract-first trails, surfaces, testing, and governance for agent-assisted development.",
   "author": {
     "name": "Outfitter",

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: trails
 description: Build with the Trails framework — define trail contracts, open CLI/MCP surfaces, test with examples, debug errors, migrate codebases, run governance. Use when creating trails, adding surfaces, testing, debugging Trails errors, migrating to Trails, running warden, or any work involving @ontrails/* packages.
+metadata:
+  trails:
+    version: 1.0.0-beta.15
 ---
 
 # Trails


### PR DESCRIPTION
The marketplace plugin was last published at 0.2.0 before the beta.15
lexicon refresh. New consumers running `claude plugin marketplace add
outfitter-dev/trails` were getting the pre-beta.15 skill, which still
references `trailhead()`, the old `provision`/`provisions` lexicon, and
the now-removed MCP `serverInfo` shape — broken on first compile against
@ontrails/* @ 1.0.0-beta.15.

Bumps:
- .claude-plugin/marketplace.json   metadata + plugins[0]   0.2.0 → 0.3.0
- plugin/.claude-plugin/plugin.json                          0.2.0 → 0.3.0

Also fixes two stale `trailheads` strings in the marketplace
descriptions and adds a `metadata.trails.version` field to SKILL.md
frontmatter so consumers (and future SessionStart hooks) can detect
when an installed skill is more than one prerelease behind the
framework it documents.

Closes: TRL-506