### PR TITLE
docs: surface API cutover migration table + tighten resource-access guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Use the project language consistently:
 - Prefer the most specific `TrailsError` subclass available.
 - Keep error taxonomy behavior aligned across surfaces so CLI, HTTP, and JSON-RPC mappings stay coherent.
 - Trails that use external dependencies declare them with `resources: [...]`.
-- Access resources through `db.from(ctx)` or `ctx.resource()`, never by constructing dependencies inline.
+- Access resources through `db.from(ctx)` whenever the resource definition is statically in scope. `ctx.resource(id|definition)` is the underlying primitive — reach for it only when the definition isn't in scope (dynamic IDs from config, generic harness/framework code over `AnyResource`, or `TrailContextInit.resource` injection seams). Never construct dependencies inline.
 - Keep `crosses` declarations for composition and `resources` declarations for infrastructure — they serve different purposes.
 - Every resource should define a `mock` factory so `testAll(app)` works without configuration.
 

--- a/docs/releases/beta15.md
+++ b/docs/releases/beta15.md
@@ -45,6 +45,31 @@ The package publishing script now includes the Vite connector. Active Changesets
 
 Beta 15 is not a broad API migration. Most existing Trails apps can upgrade by bumping package versions and aligning generated project files with the current scaffolder.
 
+### Surface API cutover (ADR-0035)
+
+The published `CHANGELOG.md` for `@ontrails/cli` and `@ontrails/mcp` attributes the lexicon work to ADR-0023, but the surface-API renames listed here are governed by [ADR-0035: Surface APIs Render the Graph](../adr/0035-surface-apis-render-the-graph.md). Both ADRs landed in the beta.15 cut.
+
+| Old (beta.14) | New (beta.15) | Where |
+| --- | --- | --- |
+| `import { trailhead } from '@ontrails/cli/commander'` | `import { surface } from '@ontrails/cli/commander'` | CLI entry |
+| `import { trailhead } from '@ontrails/mcp'` | `import { surface } from '@ontrails/mcp'` | MCP entry |
+| `trailhead(app)` / `await trailhead(app)` | `surface(app)` / `await surface(app)` | Both |
+| `TrailheadCliOptions` | `CreateProgramOptions` | `@ontrails/cli/commander` |
+| `TrailheadMcpOptions` | `CreateServerOptions` | `@ontrails/mcp` |
+| MCP options `serverInfo: { name, version }` | flat `name`, `version` on the options object | `@ontrails/mcp` |
+| MCP options `transport: ...` | dropped (stdio-only) | `@ontrails/mcp` |
+| Hono surface options `serve: false` | dropped (always serves) | `@ontrails/hono` |
+| `CliHarnessOptions.app` / `McpHarnessOptions.app` | `.graph` | `@ontrails/testing` |
+
+### Lexicon (ADR-0023)
+
+| Old (beta.14) | New (beta.15) |
+| --- | --- |
+| `provision()` factory + `provisions: [...]` field | `resource()` + `resources: [...]` |
+| `gate(...)` | `layer(...)` |
+| `loadout(...)` | `profile(...)` |
+| `tracker` package + `Track`/`TrackRecord` types | `@ontrails/tracing` + `TraceRecord` |
+
 | If you have | Do this for beta 15 |
 | --- | --- |
 | `workspace:^` or `workspace:*` ranges in a generated app | Replace them with published `^1.0.0-beta.15` ranges |


### PR DESCRIPTION
Two release-hygiene fixes the consumer (PatchOS) flagged after their
beta.14 → beta.15 upgrade.

1. docs/releases/beta15.md gains a "Surface API cutover (ADR-0035)"
   section under Migration. The published per-package CHANGELOG.md
   tarballs only mention ADR-0023 lexicon work and miss the
   trailhead → surface rename, the export renames (TrailheadCliOptions
   → CreateProgramOptions, TrailheadMcpOptions → CreateServerOptions),
   the MCP options flattening (serverInfo → flat name/version, dropped
   transport), the Hono surface options change (dropped serve), and
   the testing harness app → graph rename. Release notes now serve as
   the canonical landing for both ADRs.

2. AGENTS.md narrows the resource-access guidance per Clark's ruling:
   lead with db.from(ctx) when the definition is statically in scope;
   keep ctx.resource(id|definition) as the underlying primitive for
   the three legitimate dynamic cases (dynamic IDs, generic harness
   code, TrailContextInit.resource injection). Closes the consumer's
   "two ways to do the same thing" question.

Closes: TRL-507