### PR TITLE
docs: promote hardening doctrine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ Each package's main `tsconfig.json` excludes test files so build output stays cl
 - `docs/getting-started.md`
 - `docs/architecture.md`
 - `docs/lexicon.md`
+- `docs/rule-design.md`
 - `docs/why-trails.md`
 - `docs/testing.md`
 

--- a/docs/adr/0037-oxlint-plugin-and-warden-boundary.md
+++ b/docs/adr/0037-oxlint-plugin-and-warden-boundary.md
@@ -1,0 +1,189 @@
+---
+id: 37
+slug: oxlint-plugin-and-warden-boundary
+title: Oxlint Plugin and the Warden Boundary
+status: accepted
+created: 2026-04-25
+updated: 2026-04-26
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [7, 23, 36]
+---
+
+# ADR-0037: Oxlint Plugin and the Warden Boundary
+
+## Context
+
+Trails has one rule home today: the warden. Per ADR-0036, every warden rule ships as a trail — a typed, contract-first unit that operates against the framework's resolved topo. That decision is correct for governance rules whose authority comes from cross-trail awareness, runtime invocation, derivation, or any other relationship the topo expresses.
+
+But the v1 hardening pass surfaced a class of rules where the warden's shape is structural overhead. Several recurring patterns are file-level:
+
+- `Result.err(new Error(...))` outside testing helpers
+- `process.cwd()` inside trail blazes and other pure layers
+- Output schemas declared as `z.union([...])` without a discriminant
+- Numeric literals matching exported framework constants in scope
+- `node:fs` sync APIs in async-capable contexts
+
+None of these need the topo. None require runtime invocation. None need cross-trail comparison. They are AST-and-imports-level checks. Implementing them as warden trails forces them through topo machinery they don't use, and ships them through a tool that consumers run less frequently than their normal lint pass.
+
+A second, related observation: Trails apps already run oxlint via ultracite. The lint pipeline is the place where consumer code is checked file-by-file at editor speed. If the framework can reach into that pipeline, framework-shipped lint rules run on consumer code with no extra ceremony. And — more importantly — the same plugin can expose the AST primitives consumers and extensions need to write their own framework-aware lint rules.
+
+There is no current mechanism for extension authors or consumers to write framework-aware custom rules. They can hand-write oxlint rules using bare oxc-parser, but they lose the framework's vocabulary: `findTrailDefinitions`, `findBlazeBodies`, `isBlazeCall`, and contour-reference resolution. Several of these primitives already exist inside `@ontrails/warden`'s implementation; they are not currently part of any public surface that supports custom-rule authoring.
+
+The question is whether to keep all rules inside warden — making the topo-as-rule-home assumption universal — or to carve out a second rule home where file-level rules and authoring primitives can live with shapes that match what they actually do.
+
+## Decision
+
+Ship `@ontrails/oxlint` as a second framework-shipped rule home, with a **bright-line boundary** against warden.
+
+### The bright line
+
+A rule belongs in **warden** if it requires any of:
+
+- The resolved topo (cross-trail relationships, declared-vs-called comparisons, project-wide ID resolution, signal/resource graph traversal)
+- Runtime invocation of framework helpers (`mock()`, `contour()`, `deriveFields()`, etc.)
+- Derivation that depends on resolved framework state
+- Advisory / suggestion modes that operate against compiled topo state
+
+A rule belongs in **`@ontrails/oxlint`** otherwise. The default is oxlint when the rule can answer its question from a single file's AST plus its imports plus values resolved through their owner modules (per the [Owner-First Authority ADR](0038-owner-first-authority.md)).
+
+In practice, this resolves to three tiers, not two:
+
+| Tier | Scope | Home |
+|---|---|---|
+| File-local static | Single file's AST + literal imports | oxlint |
+| Project-aware static | Bounded import and symbol resolution, but no resolved topo | oxlint, if bounded and fast |
+| Resolved-graph / runtime / advisory | Topo, runtime invocation, or compiled framework state | warden |
+
+The middle tier is real because a rule may need bounded import and symbol resolution without needing the resolved topo. A rule that needs to know whether an imported symbol resolves to a Trails primitive is project-aware but not topo-aware. Such rules belong in oxlint as long as the resolution stays bounded and fast — once a rule needs the full resolved topo, runtime invocation, or compiled framework state, it crosses into warden.
+
+The line is principled, not preference-driven: it tracks what the rule structurally depends on, not what the rule feels like. A rule's home is determined by what it needs, not by who wrote it or which contexts it applies to.
+
+**Failure mode test.** A boundary is only real if putting the rule in the wrong home has a named cost:
+
+- **File-level rule misplaced in warden:** ships through topo machinery it doesn't use; runs at warden cadence rather than editor cadence; consumers see violations later than they should.
+- **Topo-aware rule misplaced in oxlint:** can't see the cross-file relationships it needs; either produces false negatives (silent gaps) or attempts heuristic resolution that drifts from real topo state.
+- **Project-aware rule misclassified as file-local:** can't resolve imports it needs; misses the rule's actual invariant.
+
+When classifying a candidate rule, name its failure mode. If you can't, the classification isn't load-bearing yet.
+
+### What `@ontrails/oxlint` ships
+
+The plugin contains three kinds of artifact:
+
+1. **Pre-built rules** — universal file-level rules that apply across `external` / `extension` / `internal` contexts (e.g., `result-err-new-error`, `process-cwd-in-pure-layer`, `union-output-without-discriminant`). Plus internal-only file-level rules where an oxlint home is more useful than warden (e.g., framework-internal hardening rules during pre-1.0).
+2. **Trails-aware AST primitives** — a public API for traversing Trails-shaped TypeScript code. The initial stable set starts with semantic helpers that already exist inside warden, such as `findTrailDefinitions`, `findBlazeBodies`, `findContourDefinitions`, and `isBlazeCall`. Lower-level node walking, generalized result-context discovery, and broader project-aware resolution live behind an explicitly experimental subpath until their API shape is proven by real rules.
+3. **Custom-rule scaffolding** — `defineTrailsRule(...)` wrapping oxlint's normal rule shape with Trails context detection (`external` / `extension` / `internal`) and the AST primitives above.
+
+Framework authoritative data (error class hierarchies, intent values, CRUD operations, etc.) is consumed via direct imports from owner modules per the [Owner-First Authority ADR](0038-owner-first-authority.md) — no separate registry mechanism is shipped or required.
+
+Custom-rule authoring looks like this:
+
+```typescript
+import { defineTrailsRule, findTrailDefinitions, isBlazeCall } from '@ontrails/oxlint';
+
+export default defineTrailsRule({
+  name: 'acme/no-direct-payment-call',
+  contexts: ['external'],
+  meta: {
+    type: 'problem',
+    docs: { description: 'Payment trails must compose via ctx.cross()' },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (isBlazeCall(node) && isPaymentTrail(node)) {
+          context.report({
+            node,
+            message: 'Use ctx.cross("payment.charge") instead of direct .blaze().',
+          });
+        }
+      },
+    };
+  },
+});
+```
+
+The same rule shape is what warden rules can't be — warden rules are trails (per ADR-0036), and trails operate on the topo, not on syntax. The two shapes match what each tool can do.
+
+### How the two homes compose
+
+The plugin and warden are independent rule homes that share the same data layer — owner-module imports, per the [Owner-First Authority ADR](0038-owner-first-authority.md). Both consume framework authoritative values by importing from the modules that own them.
+
+Warden continues to be Trails-native and trail-shaped per ADR-0036. Its rules are still trails. Its scope tightens to the rules that genuinely require topo or derivation.
+
+The plugin is mechanism-shaped — oxlint-native rules, not trails. Its scope is anything file-level. Crucially, this is where the **custom-rule authoring story lives**: extension authors and consumers using oxlint can write their own framework-aware rules with the exposed primitives.
+
+### What this means for consumers
+
+A consumer running `bunx ultracite check` (or oxlint directly) gets framework-shipped lint rules automatically. Universal rules apply to their code; framework-internal rules don't fire (context detection skips them in `external` context).
+
+A consumer wanting to enforce their own conventions writes an oxlint rule using `defineTrailsRule` and the exposed primitives. Their rule sits alongside the framework's rules in the same lint pass. No separate runner, no extra ceremony.
+
+### What this means for extensions
+
+A connector author (today: first-party `@ontrails/*` connectors; tomorrow: third-party connectors using `trails.extends`) can ship their own oxlint rules as part of their package. Those rules use the same AST primitives. Connector authors who need topo still ship warden rules per ADR-0036; connector authors with file-level concerns ship oxlint rules alongside.
+
+## Consequences
+
+### Positive
+
+- **Right home per rule shape.** Rules that need topo get topo; rules that don't get a faster, lighter pipeline. Forcing every rule through warden makes neither home good at its job.
+- **Consumer benefit at zero ceremony.** Consumers running their normal lint pipeline get framework rules for free. No new runner, no Trails-specific CLI invocation needed.
+- **Custom-rule authoring becomes a first-class story.** Extensions and consumers gain a supported path to write framework-aware rules, using the same primitives the framework uses. This is a material expansion of the framework's "extension as first-class" story.
+- **Warden tightens to its strength.** Removing file-level rules from warden lets warden focus on topo-aware governance and advisory modes — including the suggest-next-tightening behavior that several tenets describe but is not yet shipped.
+- **Faster feedback during development.** Oxlint runs incrementally in editors and CI. File-level rules surface violations at typing speed rather than at warden-run cadence.
+
+### Tradeoffs
+
+- **Two homes to maintain and document.** Anyone authoring or auditing rules must know which home applies. The bright line is principled, but it introduces a discrimination step that didn't previously exist.
+- **Potential for drift between homes.** If the same rule could plausibly live in either home, choosing wrong creates duplication or omission. Mitigated by the bright line being structural (file-vs-topo) rather than aesthetic.
+- **Two authoring shapes.** Warden rules are trail-shaped; oxlint rules use oxlint's visitor pattern. This is unavoidable: each shape matches what its tool can do. Pretending they're the same would be ceremony, not coherence.
+- **Pre-1.0 surface commitment.** Shipping `@ontrails/oxlint` adds a public package. Once shipped, its API is semver-contracted. Mitigation: scope the v1 plugin tightly — universal rules, AST primitives, and `defineTrailsRule` — with intentional headroom for adding rules and primitives without breaking changes.
+
+## Non-decisions
+
+- This ADR does not specify which file-level rules ship in the v1 plugin beyond the boundary criterion. Specific rules are decided in the hardening work.
+- This ADR does not define the full set of exposed AST primitives. The initial set comes from what warden already uses internally; further additions follow consumer and extension demand.
+- This ADR does not define a separate rule home for ESLint or other linters. Trails uses oxlint[^oxlint] via ultracite; multi-engine support, if ever needed, is a future-extension concern.
+- This ADR does not introduce a generic authority registry, loader, or tag format. Framework authoritative data follows the owner-first resolution model in [ADR: Owner-First Authority](0038-owner-first-authority.md).
+
+## Boundary examples
+
+To make the bright line concrete, here is how rules from the existing warden inventory and the v1 hardening backlog sort:
+
+### Stays in warden (topo-aware or runtime-dependent)
+
+- `cross-declarations`, `fires-declarations`, `resource-declarations` — declared-vs-called requires project-wide call-site resolution
+- `contour-exists`, `reference-exists`, `resource-exists`, `on-references-exist` — workspace-wide ID resolution
+- `unreachable-detour-shadowing` — needs the `TrailsError` class hierarchy resolved at runtime
+- `valid-detour-contract`, `permit-governance` — operate on compiled topo
+- `intent-propagation` — cross-trail intent comparison
+- `incomplete-crud`, `missing-reconcile`, `incomplete-accessor-for-standard-op` — project-wide CRUD pattern detection plus runtime mock invocation
+- `error-mapping-completeness` — needs `errorCategories` enumeration at runtime
+- `example-valid` — invokes `contour()` to evaluate examples
+- `prefer-schema-inference` — needs `deriveFields()` semantics
+- `dead-internal-trail`, `missing-visibility`, `valid-describe-refs`, `orphaned-signal` — cross-file or topo-aware
+
+### Moves to (or starts in) `@ontrails/oxlint`
+
+- `result-err-new-error` — universal; file-level
+- `process-cwd-in-pure-layer` — universal; file-level (purity check)
+- `union-output-without-discriminant` — universal; file-level
+- `parsed-error-message-direct` — universal; file-level
+- `node-fs-sync-in-async-context` — universal; file-level
+- `process-exit-numeric-literal` — internal-only; file-level (lives in oxlint with `internal` context tag)
+- `throw-typeerror-in-framework` — internal-only; file-level
+- Closed-grammar verb prefix (when authored) — universal; file-level
+
+### Existing warden rules that could be reconsidered
+
+A handful of existing warden rules are file-level and could conceptually move (`no-throw-in-implementation`, `no-throw-in-detour-recover`, `implementation-returns-result`). The hardening audit marked them durable in their current home; reclassifying them is a follow-up, not a v1 requirement. The default is to leave existing warden rules in place unless their move into oxlint produces material consumer benefit.
+
+## References
+
+- [ADR-0007: Governance as Trails with AST-Based Analysis](0007-governance-as-trails.md) — warden's foundational decision; the trail-shape for rules
+- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — vocabulary alignment for `external` / `extension` / `internal` contexts
+- [ADR-0036: Warden Rules Ship Only as Trails](0036-warden-rules-ship-only-as-trails.md) — establishes warden's rule shape; this ADR carves out a complementary home for non-trail rules
+- [Rule Design](../rule-design.md) — rule-design methodology; the survival heuristic and owner-first authority pattern apply equally in both homes
+
+[^oxlint]: [oxlint](https://oxc.rs/docs/guide/usage/linter.html) — fast Rust-based JavaScript/TypeScript linter that powers Trails' lint pipeline via ultracite.

--- a/docs/adr/0038-owner-first-authority.md
+++ b/docs/adr/0038-owner-first-authority.md
@@ -1,0 +1,162 @@
+---
+id: 38
+slug: owner-first-authority
+title: Owner-First Authority
+status: accepted
+created: 2026-04-25
+updated: 2026-04-26
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [7, 23, 36, 37]
+---
+
+# ADR-0038: Owner-First Authority
+
+## Context
+
+The v1 hardening pass surfaced rules duplicating framework knowledge. `errorNameToCategory` is a parallel table to `TrailsError.category`. `CRUD_OPERATIONS` is identical in two warden rule files. The `TrailsError` class hierarchy is hardcoded inside `unreachable-detour-shadowing`. Story 5 in the hardening tracker named the meta-pattern: *"should be derived but is authored."*
+
+The first design move was to introduce a generic mechanism — a `canonicalSource()` helper, a build-time registry artifact, a typed loader — so rules could discover and consume framework data through one machinery. Walking that direction against the tenets, it came out as the wrong center of gravity. Almost every candidate has a natural owner already: the error class hierarchy owns the error taxonomy, `@ontrails/store` owns CRUD doctrine, `@ontrails/core` owns intent values and detour caps. Building a generic registry on top of those owners adds ceremony without adding capability, and creates an abstraction gravity well — exactly the pattern *"add with intent, not trend"* warns about.
+
+## Decision
+
+Framework authoritative values resolve through their natural owner module. Rules and tooling consume the owner's exports directly via TypeScript imports, runtime reflection on classes, or other native language mechanisms. No generic authority helper, no registry artifact, no loader is shipped in v1.
+
+### Resolution hierarchy
+
+When a rule or tool needs framework-authoritative data:
+
+1. **Natural owner first.** The data lives in the module that conceptually owns the concept. The rule or tool imports from that owner.
+2. **Strengthen the owner if needed.** If the owner doesn't expose the data cleanly, refactor the owner. Add typed `as const` arrays alongside type unions for runtime access. Add static or instance fields to classes when class-hierarchy data needs to be readable. Export class registries when reflection alone cannot enumerate subclasses.
+3. **Generic fallback only when forced.** A generic mechanism (build-time registry, typed helper, loader) ships only when *all three* of these hold:
+   - No natural owner module exists for the value.
+   - Two or more independent consumers need it.
+   - Drift between consumers has been observed in practice.
+
+Today, no candidate in the v1 hardening backlog clears all three conditions.
+
+### What this looks like in practice
+
+**Error taxonomy.** Each `TrailsError` subclass already declares `readonly category` in source. Codes per category live in a single typed table next to the error classes:
+
+```typescript
+export const codesByCategory = {
+  validation: { exit: 1, http: 400, jsonRpc: -32602 },
+  not_found: { exit: 2, http: 404, jsonRpc: -32601 },
+  conflict: { exit: 3, http: 409, jsonRpc: -32603 },
+  internal: { exit: 8, http: 500, jsonRpc: -32603 },
+} as const;
+
+// Discoverability: explicit metadata for error classes,
+// since JavaScript cannot reflect on all subclasses of TrailsError
+// and some classes have dynamic runtime categories.
+export const errorClasses = [
+  { ctor: ValidationError, category: 'validation', retryable: false },
+  { ctor: NotFoundError, category: 'not_found', retryable: false },
+  { ctor: ConflictError, category: 'conflict', retryable: false },
+  {
+    ctor: RetryExhaustedError,
+    category: 'dynamic',
+    retryable: false,
+    inheritsCategoryFrom: 'wrapped-error',
+  },
+  // ...
+] as const;
+```
+
+The three previous parallel maps (`exitCodeMap`, `statusCodeMap`, `jsonRpcCodeMap`) collapse into one. The `errorNameToCategory` parallel in `packages/schema/src/openapi.ts` retires — OpenAPI generation walks `errorClasses` and reads fixed-category metadata from each entry. Dynamic-category entries such as `RetryExhaustedError`, whose category is inherited from the wrapped error, are modeled explicitly instead of being projected as a single category. Rules that need to walk the hierarchy (`unreachable-detour-shadowing`) import `errorClasses` and iterate.
+
+**Type-union runtime values.** Provide a runtime `as const` array alongside the type:
+
+```typescript
+export const intentValues = ['read', 'write', 'destroy'] as const;
+export type Intent = typeof intentValues[number];
+```
+
+A single declaration is the source of truth for both type and runtime values. Rules import `intentValues` directly.
+
+**Doctrine constants.** The owning package exports them as typed values:
+
+```typescript
+// In @ontrails/store
+export const crudOperations = ['create', 'read', 'update', 'delete', 'list'] as const;
+export type CrudOperation = typeof crudOperations[number];
+
+export const crudAccessorExpectations = { /* ... */ } as const;
+```
+
+**Pure constants.** Just typed exports:
+
+```typescript
+// In @ontrails/core
+export const DETOUR_MAX_ATTEMPTS_CAP = 5;
+```
+
+Rules import directly. No metadata, no registration ceremony.
+
+**Curated denylists.** Curated lists are not framework data; they are a rule's own knowledge. They stay co-located with the rule that owns them. The surface-module denylist used by `context-no-surface-types` is an example: `'express'`, `'hono'`, `'fastify'`, etc. are not values the framework owns; they are forbidden imports the rule curates. A rule may export its denylist as a named constant if a second consumer materializes — but that promotion is consumer-driven, not preemptive.
+
+**Interface accessor names.** When a rule needs runtime names of interface accessors (e.g., `Result.value`, `Result.error`, `Result.match`), the owner module exports a typed constant:
+
+```typescript
+// In @ontrails/core
+export const resultAccessorNames = [
+  'value',
+  'error',
+  'isOk',
+  'isErr',
+  'map',
+  'flatMap',
+  'mapErr',
+  'match',
+  'unwrap',
+  'unwrapOr',
+] as const;
+```
+
+This is cleaner than instructing rules to inspect TypeScript interfaces at lint time, and keeps the source of truth at the owner.
+
+### Why this respects the tenets
+
+The tenet hierarchy biases toward strengthening existing primitives or codifying patterns over introducing new mechanisms. Owner-first resolution lands at *strengthen the existing owners*. Each module already carries the concept it owns; this decision asks owners to expose their data cleanly, then trusts TypeScript and runtime to be the canonical mechanism. No new public surface, no new helper, no new artifact format.
+
+The decision also respects *"few primitives, many derivations"* directly: aggregate maps (`exitCodeMap` etc.) become derived from owner-resident data rather than being separate sources of truth. The framework's own type system and class hierarchy *are* the canonical mechanism — the deepest form of dogfooding the resolved-graph and queryable-contract tenets allow without overreaching their scope.
+
+### Cautions
+
+A few realities the lighter answer must respect:
+
+- **Class-hierarchy walking is not free.** JavaScript cannot enumerate all subclasses of a base class by reflection alone. Owner modules must export an explicit array (e.g., `errorClasses`) for tooling to walk. Strengthening the owner means adding that registry; it is not magical reflection.
+- **Some lookups are easier as direct typed exports than introspection.** When a rule needs runtime names that live on a TypeScript interface, a small typed constant in the owner module is cleaner than instructing rules to introspect the interface from lint code. Prefer the constant.
+- **Curated lists stay curated.** The surface-module denylist, vocabulary banlists, and similar policy lists are not framework data; they are explicit rule-owned curation. Don't promote them to canonical authority just because the methodology has a category for it.
+- **Consumer-local rule data is not framework canonical.** When a consumer app needs to govern its own domain registries (scope lists, feature flags, PII classes), the path is rule configuration or extension-owned exports — not framework authority. Framework authority is for framework concepts.
+
+## Consequences
+
+### Positive
+
+- **The framework dogfoods more deeply.** Each owner module exposes its doctrine directly. Rules read from owners. The framework's type system and class hierarchy become the canonical mechanism — no parallel layer to maintain.
+- **No new public surface in v1.** No `canonicalSource()` helper, no registry artifact format, no loader API, no `derivedFrom` declaration shape. The framework's existing typed surface is the mechanism.
+- **Story 5 ("authored where derivable") gets a structural fix at the owner-module layer.** When each owner exposes its data cleanly, rules duplicating that data become a lint finding, not a load-bearing pattern.
+- **The hardening pass gets materially lighter.** Stage 2 reshapes from "tag canonicals + build registry" to "refactor owner modules to expose doctrine." The audit's top promotions flow through owner refactors.
+- **The fallback is preserved as a reserved safety valve.** If a value emerges that has no natural owner, multiple consumers, and demonstrated drift, the framework adds the generic mechanism then. Until those conditions hold, the mechanism doesn't ship.
+
+### Tradeoffs
+
+- **Class hierarchies need explicit class registries.** Adding `errorClasses` (and similar) to owner modules is real authoring work. Mitigated: it is one array per hierarchy, kept current alongside class declarations, and strengthens owner discoverability for any consumer.
+- **No machine-discoverable "registry of framework authority" exists.** A future tool that wants to enumerate framework authoritative values must walk known owners explicitly. Mitigated: the consumers we know about (warden rules, oxlint plugin rules) do this naturally by import. Speculative consumers can be designed against their actual needs when they exist.
+- **The fallback is reserved but undesigned.** If a real orphaned case ever emerges, design happens then. This is intentional — pre-designing for hypothetical demand creates the abstraction gravity well the tenets warn against.
+
+## Non-decisions
+
+- This ADR does not specify the fallback mechanism's shape. If the fallback is ever needed, that is its own ADR with concrete consumer evidence.
+- This ADR does not enumerate every framework module that owns authoritative data. The hardening pass identifies the immediate set; further owners surface as concepts mature.
+- This ADR does not define a mechanism for consumer-authored rule data. Consumers needing rule-time configuration use rule-author-provided config, not framework authority.
+- This ADR does not amend the resolved-graph tenet. Owner-first resolution operates beneath the topo, not by extending it.
+
+## References
+
+- [ADR-0007: Governance as Trails with AST-Based Analysis](0007-governance-as-trails.md) — warden's foundational model; owner-first resolution is how warden rules read framework data without duplicating it
+- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — vocabulary alignment
+- [ADR-0036: Warden Rules Ship Only as Trails](0036-warden-rules-ship-only-as-trails.md) — establishes warden's rule shape; this ADR provides the data layer warden rules consume from owner modules
+- [Oxlint Plugin and the Warden Boundary](0037-oxlint-plugin-and-warden-boundary.md) — companion ADR; the rule-home split applies regardless of how rules access framework data
+- [Rule Design](../rule-design.md) — rule-design methodology; the survival heuristic operates on owner-module imports

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,5 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0034](0034-store-accessor-contract-refinement-lessons-from-two-backends.md) | Store Accessor Contract Refinement: Lessons from Two Backends | Accepted |
 | [0035](0035-surface-apis-render-the-graph.md) | Surface APIs Render the Graph | Accepted |
 | [0036](0036-warden-rules-ship-only-as-trails.md) | Warden rules ship only as trails | Accepted |
+| [0037](0037-oxlint-plugin-and-warden-boundary.md) | Oxlint Plugin and the Warden Boundary | Accepted |
+| [0038](0038-owner-first-authority.md) | Owner-First Authority | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -115,7 +115,7 @@
           "fromPath": "docs/adr/0035-surface-apis-render-the-graph.md"
         },
         {
-          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) — \"the trail is the unit of everything\"; this ADR enforces that at the package boundary",
+          "context": "The [drift guard in ADR-0000](0000-core-premise.md) prefers derivation over lint-time checks. The implementation should evaluate structural derivation for properties 1 and 2 first, and fall back to a ",
           "from": "0036",
           "fromPath": "docs/adr/0036-warden-rules-ship-only-as-trails.md"
         },
@@ -643,9 +643,19 @@
           "fromPath": "docs/adr/0025-composition-testing.md"
         },
         {
-          "context": "[ADR-0007](0007-governance-as-trails.md) made warden rules into trails. Every rule is wrapped via `wrapRule()` into a trail with ID `warden.rule.<name>`, gets a schema, examples, and runs through t",
+          "context": "[ADR-0007](0007-governance-as-trails.md) made warden rules into trails internally. Every rule is wrapped via `wrapRule()` into a trail with ID `warden.rule.<name>`, gets a schema, examples, and runs t",
           "from": "0036",
           "fromPath": "docs/adr/0036-warden-rules-ship-only-as-trails.md"
+        },
+        {
+          "context": "- [ADR-0007: Governance as Trails with AST-Based Analysis](0007-governance-as-trails.md) — warden's foundational decision; the trail-shape for rules",
+          "from": "0037",
+          "fromPath": "docs/adr/0037-oxlint-plugin-and-warden-boundary.md"
+        },
+        {
+          "context": "- [ADR-0007: Governance as Trails with AST-Based Analysis](0007-governance-as-trails.md) — warden's foundational model; owner-first resolution is how warden rules read framework data without duplicati",
+          "from": "0038",
+          "fromPath": "docs/adr/0038-owner-first-authority.md"
         },
         {
           "context": "- [ADR-0007: Governance as Trails](../0007-governance-as-trails.md) — warden rules for event declarations",
@@ -665,7 +675,7 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Governance as Trails with AST-Based Analysis",
-      "updated": "2026-04-01"
+      "updated": "2026-04-22"
     },
     {
       "created": "2026-03-29",
@@ -1442,6 +1452,16 @@
           "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
         },
         {
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — vocabulary alignment for `external` / `extension` / `internal` contexts",
+          "from": "0037",
+          "fromPath": "docs/adr/0037-oxlint-plugin-and-warden-boundary.md"
+        },
+        {
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — vocabulary alignment",
+          "from": "0038",
+          "fromPath": "docs/adr/0038-owner-first-authority.md"
+        },
+        {
           "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) -- the lexicon renames; note that `resource` in this ADR refers to the distribution unit, distinct from `resourc",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
@@ -1910,7 +1930,18 @@
     {
       "created": "2026-04-20",
       "depends_on": ["0", "7"],
-      "inbound": [],
+      "inbound": [
+        {
+          "context": "- [ADR-0036: Warden Rules Ship Only as Trails](0036-warden-rules-ship-only-as-trails.md) — establishes warden's rule shape; this ADR carves out a complementary home for non-trail rules",
+          "from": "0037",
+          "fromPath": "docs/adr/0037-oxlint-plugin-and-warden-boundary.md"
+        },
+        {
+          "context": "- [ADR-0036: Warden Rules Ship Only as Trails](0036-warden-rules-ship-only-as-trails.md) — establishes warden's rule shape; this ADR provides the data layer warden rules consume from owner modules",
+          "from": "0038",
+          "fromPath": "docs/adr/0038-owner-first-authority.md"
+        }
+      ],
       "number": "0036",
       "owners": ["[galligan](https://github.com/galligan)"],
       "path": "docs/adr/0036-warden-rules-ship-only-as-trails.md",
@@ -1919,6 +1950,54 @@
       "superseded_by": null,
       "title": "Warden rules ship only as trails",
       "updated": "2026-04-20"
+    },
+    {
+      "created": "2026-04-25",
+      "depends_on": ["7", "23", "36"],
+      "inbound": [
+        {
+          "context": "- [Oxlint Plugin and the Warden Boundary](0037-oxlint-plugin-and-warden-boundary.md) — companion ADR; the rule-home split applies regardless of how rules access framework data",
+          "from": "0038",
+          "fromPath": "docs/adr/0038-owner-first-authority.md"
+        },
+        {
+          "context": "The methodology applies in both rule homes. The bright line between them is structural, per [ADR-0037: Oxlint Plugin and the Warden Boundary](adr/0037-oxlint-plugin-and-warden-boundary.md):",
+          "from": "rule-design",
+          "fromPath": "docs/rule-design.md"
+        }
+      ],
+      "number": "0037",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0037-oxlint-plugin-and-warden-boundary.md",
+      "slug": "oxlint-plugin-and-warden-boundary",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Oxlint Plugin and the Warden Boundary",
+      "updated": "2026-04-26"
+    },
+    {
+      "created": "2026-04-25",
+      "depends_on": ["7", "23", "36", "37"],
+      "inbound": [
+        {
+          "context": "A rule belongs in **`@ontrails/oxlint`** otherwise. The default is oxlint when the rule can answer its question from a single file's AST plus its imports plus values resolved through their owner modul",
+          "from": "0037",
+          "fromPath": "docs/adr/0037-oxlint-plugin-and-warden-boundary.md"
+        },
+        {
+          "context": "The mechanism is **owner-first**, per [ADR-0038: Owner-First Authority](adr/0038-owner-first-authority.md). Rules import authoritative data directly from the module that owns the concept. The error cl",
+          "from": "rule-design",
+          "fromPath": "docs/rule-design.md"
+        }
+      ],
+      "number": "0038",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0038-owner-first-authority.md",
+      "slug": "owner-first-authority",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Owner-First Authority",
+      "updated": "2026-04-26"
     }
   ],
   "version": 1

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@
 ## Governing your codebase?
 
 - **[Warden](../packages/warden/README.md)** — AST-based convention rules, drift detection, CI integration
+- **[Rule Design](./rule-design.md)** — Methodology for durable warden, oxlint, and agent rules
 - **[Schema](../packages/schema/README.md)** — Surface maps, topo export helpers, semantic diffing, lock files
 
 ## Design decisions

--- a/docs/rule-design.md
+++ b/docs/rule-design.md
@@ -1,0 +1,302 @@
+# Rule Design
+
+How we author rules — warden rules, lint rules, agent rules — so they hold up over time. This doc applies to **existing rules** (audit through this lens) AND **new rules** (draft through this lens). It surfaces early because it shapes everything downstream.
+
+## TL;DR
+
+Express rules as **invariants** the framework holds, not as **instances** of bugs we found.
+
+> Don't write *"MCP must call `mapTransportError`"*. Write *"any registered transport error map must be consumed by its surface."* The first rule catches one bug. The second catches the same bug **plus every future drift of the same shape**. Both are deterministic; the second is durable.
+
+When invariant-level expression is feasible, prefer it. When it isn't, accept the instance form and mark it explicitly so we know to revisit when the family grows.
+
+The deepest form of "deterministic > vibes" is **deterministic AND derived from authoritative data the framework already owns.** Rules consume framework knowledge from owner modules; they don't re-encode it.
+
+## Why this matters
+
+Every rule is a forever commitment unless we deliberately expire it. Rules accumulate. Stale rules generate noise; noisy rules get ignored; ignored rules let regressions land.
+
+The hardening pass is finding many similar bugs because the rules that would have caught them never existed — and it's surfacing candidate rules with the same generality problem. If we encode *"MCP must do X"* today, we'll write *"WS must do X"* tomorrow when WebSocket lands. Both rules say the same thing in a less-general voice. Worse, they can drift from each other.
+
+The dogfooding insight applies recursively: **the framework derives behavior from owner-held contracts. So should our rules.** Authored rules duplicate framework knowledge. Derived rules read it.
+
+## The core move
+
+Two ways to write the MCP error-map rule:
+
+**Instance form (instance-of-bug):**
+
+```ts
+{
+  name: 'mcp-error-map-not-consumed',
+  description: "MCP handler must call mapTransportError('mcp', err)",
+  // ...mechanism-coupled scan
+}
+```
+
+**Invariant form (invariant-of-framework):**
+
+```ts
+{
+  name: 'registered-error-map-not-consumed',
+  invariant: 'Any surface that registers an entry in transportErrorMap must consume it in its error path.',
+  readsFrom: 'transportErrorMap',
+  // ...imports the owner export, asks "for each entry, does the corresponding surface consume it?"
+}
+```
+
+What changed:
+
+- **Name describes the violation, not the missing call.** "Registration without consumption" survives renaming.
+- **Reads owner source at scan time.** The rule doesn't list surfaces inline; it reads `transportErrorMap`.
+- **New surface registers → automatically covered.** No new rule when `ws` is added.
+- **Mechanism rename works.** If `mapTransportError` becomes `surfaceErrorFor`, the rule still asks the right question (consumption), just at a new symbol.
+
+The same move applies to most of our scanner candidates. Some are already invariant-form; others need promotion.
+
+## The survival heuristic
+
+Apply these five tests to any candidate rule. Failing any is a signal — generalize, or accept the limitation explicitly.
+
+### 1. Mechanism-renamed test
+
+If the framework renames its helpers tomorrow, does the rule still work?
+
+A rule that names a function by symbol (`mapTransportError`) fails. Re-express in terms of *roles* ("consumer of `transportErrorMap`") instead of *names* ("call site of `mapTransportError`"). Symbols change; roles don't.
+
+### 2. Family test
+
+Can I name 3+ instances of this same shape today? If yes, the rule belongs at the family level.
+
+The MCP error-map bug is one instance of *"registered map not consumed."* `errorNameToCategory` parallel to `TrailsError.category` is another. `transportNames` mismatching `TraceRecord.trailhead` union is another. Three instances → rule lives at the family level.
+
+If you can only name one instance, the rule must declare a binding `retireWhen:` clause with mechanical CI enforcement — or be refused. 'Tag and forget' is not an option; migration banlists accumulate when the entry condition is logged but no exit criterion is enforced. Acceptable `retireWhen:` forms:
+
+- Time-bound: `'after v1.2'`, `'2027-01-01'`
+- Code-bound: `'when no consumer imports @ontrails/legacy/foo-bar for 90 days'`
+- Issue-bound: `'when TRL-NNN closes'`
+
+CI fires when the condition is met and either auto-retires the rule or fails the build until the rule is removed. A `retireWhen:` clause without a mechanical enforcement path is a comment, not a contract.
+
+### 3. Data-source test
+
+Does the rule re-encode something the framework already declares?
+
+A rule that hardcodes `'cli' | 'http' | 'mcp'` inline duplicates the surface-kind owner. Read the owner export at scan time. Same for retired vocabulary (read the lexicon's Reserved Terms table), error categories (read `TrailsError.category` / `errorClasses`), exit codes (read `codesByCategory`), intent values (read `intentValues`), and CRUD doctrine (read store-owned exports).
+
+This is the dogfooding test for rules: are we authoring framework knowledge into the rule, or reading it from where the framework already has it?
+
+### 4. Surface-extension test
+
+When a new surface, primitive, or extension lands, does the rule extend automatically, or do we write a sibling rule per surface?
+
+If per-surface, raise the level. The right shape is *"any registered surface must satisfy invariant Y"* with the surface registry as input. Same for primitives, extensions, error classes.
+
+### 5. Context test
+
+Is the rule applicable across `external` / `extension` / `internal`, or just one?
+
+This isn't strictly a generalization test — sometimes the answer is genuinely "internal only." But verify the limitation is **principled**, not **accidental**:
+
+- "Framework must use `exitCodeMap`" is principled-internal — external apps don't have an `exitCodeMap` concept.
+- "Result.err must wrap typed `TrailsError`" is universal — applies everywhere.
+- A rule scoped to internal only because we wrote it that way without thinking is accidental.
+
+## Where rules live: warden or `@ontrails/oxlint`
+
+The methodology applies in both rule homes. The bright line between them is structural, per [ADR-0037: Oxlint Plugin and the Warden Boundary](adr/0037-oxlint-plugin-and-warden-boundary.md):
+
+- **Warden** if the rule needs the topo, derivation, runtime invocation, or cross-trail comparison.
+- **`@ontrails/oxlint`** otherwise — file-level rules that can answer their question from a single file's AST plus its imports plus values resolved through owner modules.
+
+Both homes follow this methodology when authoring or auditing rules. The only difference is what the rule has access to at scan time — a topo (warden) vs. a parsed file plus imports (oxlint). Apply the survival heuristic regardless of which home the rule lands in.
+
+The plugin also exposes Trails-aware AST primitives to extension and consumer authors. Rules they write follow this methodology too — the survival heuristic isn't framework-internal.
+
+## Owner-first authority
+
+The framework already has authoritative values for many things — error categories, intent values, CRUD operations, detour caps, exit codes. Rules should read them, not re-encode them.
+
+The mechanism is **owner-first**, per [ADR-0038: Owner-First Authority](adr/0038-owner-first-authority.md). Rules import authoritative data directly from the module that owns the concept. The error class hierarchy owns the error taxonomy. `@ontrails/store` owns CRUD doctrine. `@ontrails/core` owns intent values and detour caps. The methodology operates against those imports.
+
+When a rule needs framework-authoritative data:
+
+1. **Import from the natural owner.** Find the module that owns the concept; import the typed export.
+2. **If the owner doesn't expose the data cleanly, strengthen the owner.** Add `as const` runtime arrays alongside type unions. Add static or instance fields to classes when class-hierarchy data needs to be readable. Export class registries when reflection cannot enumerate subclasses.
+3. **Generic fallback only when forced.** A generic registry mechanism is reserved for the case of no natural owner + 2+ independent consumers + demonstrated drift. Today, no v1 hardening candidate clears that bar.
+
+This shapes the survival heuristic: a rule's *data-source test* asks whether the rule reads from the owner, not whether the rule consumes a registry.
+
+### Authoring scope
+
+Owner-first authority is a *framework-and-extension* concern. Consumer apps don't author framework authoritative values — their topo is the canonical source for their own data. If a consumer feels they need an authoritative value the framework hasn't given them, that's a framework gap (an owner module that should expose more), not an instruction to start authoring consumer-side. Consumer-local rule data uses rule configuration or extension-owned exports, not framework authority.
+
+### What counts as owner authority?
+
+Anything the framework already declares as authoritative for a concept should be readable at that owner:
+
+| Owner source | Authoritative for |
+|---|---|
+| `TrailsError` classes plus `errorClasses` / `codesByCategory` | Error taxonomy and surface error-code mappings |
+| `intentValues` | Intent union values |
+| Store doctrine exports (`crudOperations`, `crudAccessorExpectations`) | CRUD operation set and accessor expectations |
+| `DETOUR_MAX_ATTEMPTS_CAP` | Detour retry limit |
+| `resultAccessorNames` | Result accessors that imply sync assumptions |
+| Lexicon's Reserved Terms table | Retired vocabulary |
+| TRL-504 connector descriptors | Extension and surface declarations |
+| Capability matrix (once formalized) | Primitive lifecycle expectations |
+
+When a rule cites one of these, it should **read the owner** — not duplicate its contents.
+
+Curated rule data is different. A denylist such as `context-no-surface-types` may be owned by the rule itself when it represents policy curation rather than framework doctrine. The bar for extracting curated data is the same owner-first bar: another independent consumer or demonstrated drift.
+
+### No v1 registry
+
+No `canonicalSource()` helper, TSDoc marker, registry artifact, loader API, or `derivedFrom` rule metadata ships in v1. Those are fallback mechanisms, not the default architecture. Build them only if a future value has no natural owner, has multiple independent consumers, and has already shown drift pressure.
+
+## Family-collapse-by-shape
+
+The family test (test 2) asks whether you can name 3+ instances. As primitives evolve, the same *rule shape* keeps recurring across primitives — and naming the shape lets future rule authors recognize the family before writing the third sibling. Most are graph shapes (cycle, orphan, collision, schema-compat); some are file-local patterns (vocabulary-banned-term, owner-projection-parity).
+
+The recurring shapes seen so far:
+
+| Shape | Form | Examples |
+|---|---|---|
+| **Declarations-match-usage** | Static declaration on the trail must match runtime usage in the blaze body | `crosses` ↔ `ctx.cross()`; `fires` ↔ `ctx.fire()`; `resources` ↔ `ctx.resource()` / `db.from(ctx)` |
+| **Owner-projection-parity** | Derived/projected data must keep reading its owner, not duplicate it. The meta-pattern behind owner-first authority. | `errorNameToCategory` parallel to `TrailsError.category`; CRUD ops duplicated across rules; intent literals hardcoded; `transportNames` parallel to actual surface set |
+| **Orphan-X** | Primitive declared but never referenced in the topo | Orphan resource; orphan signal; orphan layer; orphan contour |
+| **Cycle-in-X-graph** | Cycle detection across a directed primitive graph | `crosses` cycle; activation cycle; layer dependency cycle |
+| **Collision-detection** | Two declarations claim the same routing slot | HTTP route collision; webhook path collision; MCP tool name collision |
+| **Schema-compatibility** | Source schema must satisfy consumer schema | Cross input ↔ caller's args; signal payload ↔ source emitter |
+| **Vocabulary-banned-term** | Identifier references retired vocabulary | Reads lexicon's Reserved Terms |
+| **Declaration-requires-companion** | A registered declaration of kind X requires a companion of kind Y *on the resolved app* — distinct from orphan-X (which is "declared but never used"); this is "consumed but no infrastructure to run it" | Source-kind ↔ materializer; error class ↔ surface code mapping; resource ↔ adapter |
+
+When a new primitive ships and a candidate rule like "orphan signal" gets filed, ask: is `orphaned-{primitive}` parametrized over the topo a more durable rule than authoring `orphan-signal` next to existing `orphan-resource`?
+
+The family-collapse principle: **prefer parametrizing one rule over the primitive than authoring sibling rules per primitive.**
+
+**Caveat:** only collapse when data model, traversal, and diagnostic shape are genuinely shared. English-similar rules can still deserve separate implementations if their false-positive surfaces or severity expectations differ. The shape catalog names *recurring* patterns; it doesn't mandate fusion of every superficially-similar rule.
+
+This is the family test (test 2) applied prospectively — naming the shape catalog lets future rule authors recognize their rule belongs to a family before they write the third sibling.
+
+### Empirical origin
+
+These shapes emerged from two sources:
+
+1. **The existing-rules audit.** Several existing warden rules cluster around these shapes (cross/fires/resource declaration helpers, route-collision checks, vocabulary scans).
+2. **In-flight Backlog projects.** Rules filed by Layer Evolution, Typed Signal Emission, and Reactive Trail Activation (TRL-444/447/452/454/461 and others) all instantiate one of these shapes for a new primitive.
+
+Empirical proof of the family test: every one of those filed rules has at least one prior sibling already in the warden inventory. They aren't novel rule shapes — they're the same shape applied to a new primitive.
+
+### When the shape catalog grows
+
+These shapes are working artifacts, not closed. As new primitives and patterns ship, expect new shapes. When you find one:
+
+1. Name it.
+2. Add it to the table.
+3. If 2+ existing rules now fit the new shape, evaluate them for collapse.
+
+### Vocab rules and scope
+
+The `vocabulary-banned-term` shape applies to **source files** — TS/JS via `@ontrails/oxlint`. It does not extend to documentation files (markdown). Doc vocabulary alignment is an editorial-review concern (docs review, content lint, or a docs-cutover skill), outside the rule-home boundary.
+
+If a retired term needs enforcement in both source and docs, that's two enforcement mechanisms — the oxlint rule covers code, an editorial pass covers docs. Don't conflate them in one rule.
+
+### Word-level rewrites and false positives
+
+When a rule fires on a literal symbol, import path, or word match (vocabulary retirements, migration banlists, banned-symbol rules), scope it to **the role the rule actually owns**, not every textual occurrence.
+
+A rule banning the identifier `handler` (because the framework retired that concept as a synonym for `trail`) should fire on a function or type named `handler` representing the old framework concept — not on identifiers from third-party imports, comment text about unrelated handler patterns, or domain-specific uses where the word means something different (e.g., "event handler" in DOM code, "service worker" elsewhere).
+
+A rule banning imports from `@ontrails/legacy/foo-bar` should fire on imports of that exact path — not on other references to `foo-bar` in unrelated namespaces.
+
+The scoping question for the rule author: **does this token's role overlap with what the rule actually owns?** If a fresh reader would parse the use as an instance of the rule's target, fire. If the same string means a different concept here, don't.
+
+Implementation hints:
+
+- Prefer position-aware AST checks (identifier names in declaration position, type names, import paths) over free-text matches.
+- Exclude third-party imports from the rule's scope unless the rule explicitly owns them.
+- When the same word legitimately appears in multiple roles, list the rule-owned roles explicitly rather than banning all uses.
+
+This applies generally to any word-level rewrite rule, not just vocab-banned-term — anywhere the framework asks "ban this string," the rule must specify *which uses of the string* are banned.
+
+## Applying this to existing warden rules
+
+Before we add new rules, audit the existing ones through this lens. The audit doesn't have to refactor everything; it surfaces which rules are durable already and which need reframing.
+
+### Audit methodology
+
+For each existing warden rule:
+
+1. **Find a one-line invariant statement.** "What does the framework promise that this rule enforces?" If you can't write the invariant in one sentence, the rule may be enforcing too many things or none clearly.
+2. **Run the five survival tests.** Annotate which it passes and which it fails.
+3. **Identify owner sources.** What is the rule's data dependency? Is the rule reading from the owner or hardcoding?
+4. **Classify:**
+   - ✅ **Durable** — passes all tests; no refactor needed
+   - ⚠️ **Refactor** — passes most; small changes promote it
+   - ❌ **Replace** — instance-level; needs promotion to family level OR explicit retirement tag
+   - 🔄 **Merge** — duplicates another rule's invariant; collapse into a single rule
+
+### What to look for in the existing inventory
+
+Likely refactor candidates based on common patterns:
+
+- **Rules that name a specific surface** (CLI / MCP / HTTP) but should apply to "any registered surface"
+- **Rules that hardcode lists** (vocab, error names, intent values) that exist as owner exports elsewhere
+- **Rules that reference a specific helper by symbol** rather than role
+- **Rules that fire only for one primitive** but state an invariant that applies to all
+- **Rules whose description starts with "X must..."** where X is a specific name — usually instance-level
+
+### Phased application
+
+Don't refactor everything at once. Phased:
+
+1. **Phase 0 — Inventory.** List existing rules with one-line invariants and classifications. Output: a table.
+2. **Phase 1 — Lossless promotions.** Rules that pass tests 1-4 but have a small naming/wording fix. Refactor in place.
+3. **Phase 2 — Substantive promotions.** Rules that need to read owner data instead of hardcoding. Requires the owner module to expose that data first.
+4. **Phase 3 — Family collapses.** Rules that are siblings of one invariant. Merge into one.
+5. **Phase 4 — Acceptance / retirement.** Rules that don't generalize and don't need to. Tag explicitly: `phase: 'v1-hardening'` or `@deprecated`.
+
+## Applying this to new rules
+
+Drafting checklist for any new rule:
+
+- [ ] **One-line invariant.** What framework promise does this enforce?
+- [ ] **Survival tests.** Pass all five; if not, document the principled reason or accept and tag.
+- [ ] **Owner sources.** Identify what the rule reads. If it reads nothing, why not?
+- [ ] **Family check.** Name three instances. If you can't, ask whether the rule belongs.
+- [ ] **Context.** Which of `external` / `extension` / `internal` does this apply to? Is the limitation principled?
+- [ ] **Retirement criterion.** If the family test fails (only one instance), the rule MUST declare a binding `retireWhen:` clause with mechanical CI enforcement. Soft phase tags are not sufficient — they don't expire.
+
+A rule that doesn't pass the checklist either gets refactored before landing, or gets explicit dispensation with a recorded reason.
+
+## Anti-patterns to avoid
+
+These are signals that a rule is at the wrong level:
+
+- **Rule name references a specific symbol** — `mcp-error-map-not-consumed` references `'mcp'`. Better: `registered-error-map-not-consumed`.
+- **Description says "X must call Y"** — coupling to mechanism. Better: "X must satisfy invariant Z" where Z is mechanism-independent.
+- **Rule lists framework values inline** — duplicates owner data. Better: read the owner source.
+- **Sibling rules per surface / per primitive** — same invariant, different subject. Better: one rule parameterized by owner data.
+- **Rule has no owner data dependency at all** — possibly fine, but ask whether one *should* exist. Many invariants implicitly reference framework metadata.
+- **Rule fires on a single file** — almost certainly an instance rule. Require a binding `retireWhen:` clause with CI enforcement, or refuse. Tagging for retirement without enforcement leads to permanent cruft.
+
+## How this connects to the rest of the work
+
+- **Bucket 08 (prevention rails)** — every rule listed in bucket 08's accumulated recommendations gets the survival treatment before it lands. This doc is the gate.
+- **Story 5 (authored where derivable)** — the meta-pattern this doc operationalizes. Rules following this design *cannot* duplicate framework knowledge.
+- **Story 11 (dogfooding)** — rules consuming owner-held framework data is dogfooding at the audit-tooling layer.
+- **Forward-looking advocate skills** — `trails-warden-advisory`, `trails-dogfood-check`, etc. become consumers of owner-held framework data too. Their suggestions derive from the same metadata the rules read. Advice doesn't get hardcoded into skill prompts; it gets derived from the framework's own contracts.
+
+## Design cautions
+
+- **When should curated rule data be extracted?** `context-no-surface-types` keeps its denylist because it is policy curation, not duplicated framework doctrine. Extract only if another independent consumer appears or drift is observed.
+
+- **What exactly is the fallback bar?** The owner-first ADR names no natural owner + 2+ independent consumers + demonstrated drift. Keep that bar visible so we don't rebuild a registry by habit.
+
+- **How do we handle false positives in derivation-bypass rules?** Some literal `5`s aren't bypasses of `DETOUR_MAX_ATTEMPTS_CAP`. The rule needs scope ("when in retry-config code") or an explicit rule-local suppression path.
+
+## Cross-references
+
+- [ADR-0037: Oxlint Plugin and the Warden Boundary](adr/0037-oxlint-plugin-and-warden-boundary.md) — establishes the rule-home boundary between warden and `@ontrails/oxlint`
+- [ADR-0038: Owner-First Authority](adr/0038-owner-first-authority.md) — establishes owner-module exports as the data source for framework-authoritative rule inputs


### PR DESCRIPTION
Closes TRL-510
Closes TRL-511
Closes TRL-512

Summary:
- Promote the oxlint/warden boundary ADR as ADR-0037.
- Promote owner-first authority as ADR-0038.
- Promote rule-design methodology into docs and link it from the docs index and agent guide.
- Regenerate the ADR index and decision map.

Validation:
- bun scripts/adr.ts check
- bun run format:check
- bun run check