### PR TITLE
docs: align MCP layer example names

### DIFF
--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -163,7 +163,7 @@ await surface(graph, {
   name: 'myapp',
   version: '1.0.0',
   transport: 'stdio', // Only stdio for now; SSE/streamable HTTP planned
-  layers: [myAuthGate, myRateLimitGate],
+  layers: [myAuthLayer, myRateLimitLayer],
   createContext: () => createTrailContext({ logger: myLogger }),
 });
 ```


### PR DESCRIPTION
## Context

Docs freshness audit pass against current source/API reality. The public surface packages now export `surface()`, testing still intentionally exports both `testTrail()` and `testCrosses()`, and current signal guidance uses `ctx.fire()` with `fires:` / `on:`.

## What changed

- Updated the MCP surface guide's layer example variable names from `myAuthGate` / `myRateLimitGate` to `myAuthLayer` / `myRateLimitLayer`.

## Validation

- `bun install --frozen-lockfile`
- `bun run format:check`
- Focused `rg` sweeps for stale surface, signal, testing, resource/provision, and gate/layer patterns across agent/plugin docs, active docs, package/app READMEs, and repo guidance.
- `bun run vocab:audit -- --rule layers-term --rule surface-term --rule emit-call --rule abort-signal-field --rule service-factory --rule services-field --rule event-factory --rule emits-field` still exits non-zero on existing baseline noise: changelogs, historical release notes, generated ADR maps, draft ADRs, internal `TRAILHEAD_KEY`/trace fields, and one intentionally invalid warden fixture.

## Remaining decisions

- The vocabulary audit needs path/rule exclusions or a narrower default scope before it can serve as a clean CI-style docs freshness gate.
- Internal `trailhead` fields such as tracing attributes and `TRAILHEAD_KEY` look like compatibility/API state, not docs drift; renaming those would be broader than this docs-only pass.
