### PR TITLE
docs: document warden lint boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ Each package's main `tsconfig.json` excludes test files so build output stays cl
 - `docs/getting-started.md`
 - `docs/architecture.md`
 - `docs/lexicon.md`
+- `docs/warden.md`
 - `docs/why-trails.md`
 - `docs/testing.md`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@
 
 ## Governing your codebase?
 
-- **[Warden](../packages/warden/README.md)** — AST-based convention rules, drift detection, CI integration
+- **[Warden](./warden.md)** — Trails correctness rules, rule-home boundaries, drift detection, CI integration
 - **[Schema](../packages/schema/README.md)** — Surface maps, topo export helpers, semantic diffing, lock files
 
 ## Design decisions

--- a/docs/warden.md
+++ b/docs/warden.md
@@ -1,0 +1,76 @@
+# Warden
+
+Warden is Trails' correctness surface. It catches code-level framework drift, reports stale topo lock state, and exposes built-in rules as trails so governance stays inspectable and composable.
+
+Structural graph checks that can be answered from the resolved topo belong in `validateTopo()` from `@ontrails/core`. Warden owns checks that need source inspection, project context, topo-aware analysis, or drift reporting.
+
+## Rule Homes
+
+Use Warden for durable Trails correctness:
+
+- trail, blaze, `Result`, detour, resource, topo, or surface doctrine
+- checks that compare declarations to actual usage, such as `crosses` or `resources`
+- checks that need project-wide context or the resolved topo
+- checks that should be available through the public Trails CLI or programmatic Warden API
+- checks whose rule shape should itself remain a Trails trail
+
+Use the private `@ontrails/oxlint-plugin` package for repo-local hygiene:
+
+- temporary cleanup checks used during hardening
+- house-style preferences for this repository, not Trails consumers
+- file-local checks that are useful through Ultracite/Oxlint editor feedback
+- checks that do not need topology, derivation, runtime invocation, or cross-trail comparison
+
+The private plugin is a convenience for this repo. It is not a consumer-facing dependency, and it should not become the place where framework doctrine quietly accumulates.
+
+## Warden Tiers
+
+Warden rules can operate at several levels:
+
+- **Source-static** rules inspect one file at a time.
+- **Project-static** rules inspect source with package or project context.
+- **Topo-aware** rules inspect the resolved topo.
+- **Drift** checks compare generated artifacts with current source truth.
+- **Advisory** checks point at incomplete or risky framework usage without necessarily failing the build.
+
+The tier affects execution shape, not ownership. A source-static check can still be Warden-owned when it enforces public Trails semantics.
+
+## Authoring Durable Rules
+
+Durable Warden rules should explain the doctrine they enforce. When adding one:
+
+1. Name the Trails concept the rule protects.
+2. Decide the narrowest tier that can answer the question.
+3. Keep framework knowledge in owner modules when possible instead of duplicating string lists inside the rule.
+4. Wrap built-in rules as trails, in line with [ADR-0036](./adr/0036-warden-rules-ship-only-as-trails.md).
+5. Add TSDoc to exported helpers, rule types, and public rule factories when the contract is not obvious from the type.
+6. Add examples or focused tests that show both the accepted shape and the diagnostic shape.
+
+Rule-owned deny lists are still allowed when they are intentionally policy, not duplicated framework data. For example, a curated set of forbidden surface type names can remain local to a rule until another independent consumer needs the same list.
+
+## Repo-Local Oxlint Plugin
+
+The repo-local plugin lives in `packages/oxlint-plugin`, builds to `dist`, and is loaded by the root `oxlint.config.ts`. The root format scripts build it before Ultracite loads the config.
+
+Current local rules are intentionally low-blast:
+
+- `no-console-in-packages` keeps package code quiet, with logging as the explicit owner.
+- `no-process-exit-in-packages` keeps hard exits out of packages except the CLI.
+- `no-process-env-in-packages` keeps environment access close to config, CLI, core, and logging boundaries.
+- `no-deep-relative-import` discourages fragile upward imports.
+- `no-nested-barrel` starts permissive with `maxDepth: 2`.
+- `prefer-bun-api` nudges agents toward Bun-native APIs where the mapping is clear.
+- `snapshot-location` keeps snapshots near the tests that own them.
+- `test-file-naming` keeps test discovery predictable.
+
+If a local rule starts enforcing Trails semantics rather than repository hygiene, promote the idea to Warden or write a follow-up issue explaining why it should stay local.
+
+## Deferred Tightening
+
+Progressive hygiene belongs in separate issues with baselines and deletion triggers. Current follow-ups:
+
+- `TRL-550` evaluates progressive `max-file-lines` enforcement.
+- `TRL-551` audits whether nested barrels can tighten from `maxDepth: 2` to `maxDepth: 1`.
+- `TRL-552` evaluates additional `prefer-bun-api` mappings.
+
+These stay out of the initial rule branch because each one needs evidence before it becomes policy.

--- a/packages/oxlint-plugin/src/index.ts
+++ b/packages/oxlint-plugin/src/index.ts
@@ -2,6 +2,13 @@ import { definePlugin, eslintCompatPlugin } from '@oxlint/plugins';
 
 import { rules } from './rules/registry.js';
 
+/**
+ * Private Oxlint plugin loaded by this repository's root `oxlint.config.ts`.
+ *
+ * @remarks
+ * This package is for Trails repo-local hygiene and temporary hardening checks.
+ * Durable framework correctness belongs in Warden.
+ */
 const plugin = eslintCompatPlugin(
   definePlugin({
     meta: {

--- a/packages/oxlint-plugin/src/rules/registry.ts
+++ b/packages/oxlint-plugin/src/rules/registry.ts
@@ -9,6 +9,13 @@ import { preferBunApiRule } from './prefer-bun-api.js';
 import { snapshotLocationRule } from './snapshot-location.js';
 import { testFileNamingRule } from './test-file-naming.js';
 
+/**
+ * Repo-local Oxlint rules enabled by the root `oxlint.config.ts`.
+ *
+ * @remarks
+ * Keep this registry limited to private repository hygiene. Rules that enforce
+ * public Trails semantics should move to Warden.
+ */
 export const rules = {
   'no-console-in-packages': noConsoleInPackagesRule,
   'no-deep-relative-import': noDeepRelativeImportRule,

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -4,6 +4,8 @@ AST-based code convention rules for Trails. Built-in lint rules catch contract v
 
 Structural checks (cross target existence, declared resource existence, recursive crossing, example schema validation) live in `validateTopo()` from `@ontrails/core`. Warden handles the code-level rules that need AST analysis.
 
+For rule-home boundaries and authoring doctrine, see the [Warden guide](../../docs/warden.md).
+
 ## Usage
 
 From the Trails CLI:


### PR DESCRIPTION
## Context

This is the top PR in the Warden/lint hardening stack, built on #253 and #254.

The code stack creates a private repo-local Oxlint plugin and adds low-blast hygiene rules. This PR documents the boundary so future rule authors know when a check belongs in Warden versus the private plugin.

Linear: [TRL-518](https://linear.app/outfitter/issue/TRL-518/document-warden-source-tier-authoring-and-repo-local-plugin-boundary)
Stack: #253 -> #254 -> this PR

## What Changed

- Adds `docs/warden.md` as the tracked Warden guide for rule-home boundaries and source-tier authoring doctrine.
- Updates `docs/index.md` so the docs entry points to the Warden guide rather than only the package README.
- Adds `docs/warden.md` to the project reference docs in `AGENTS.md`.
- Links `packages/warden/README.md` back to the new Warden guide.
- Adds TSDoc to the private Oxlint plugin entrypoint and rule registry to make the local-vs-public boundary explicit at the package export surface.

## Doctrine Captured

The guide states that Warden owns durable Trails correctness:

- trail, blaze, `Result`, detour, resource, topo, and surface doctrine
- declaration-vs-usage checks such as `crosses` and `resources`
- project-static, topo-aware, drift, and advisory checks
- public CLI/programmatic Warden behavior
- built-in rules that should themselves ship as Trails trails

The private Oxlint plugin owns repo-local hygiene only:

- temporary hardening checks
- house-style preferences for this repo
- file-local checks that benefit from Ultracite/Oxlint editor feedback
- checks that do not need topology, derivation, runtime invocation, or cross-trail comparison

## Review Notes

The important review question is whether the guide makes the boundary operational enough for the next agent or contributor. The doc intentionally does not revive the older public `@ontrails/oxlint` direction; it keeps Warden as the public correctness surface and describes the private plugin as repo-local tooling.

## Verification

- `bun run oxlint-plugin:build`
- `bunx ultracite check AGENTS.md docs/index.md docs/warden.md packages/warden/README.md packages/oxlint-plugin/src/index.ts packages/oxlint-plugin/src/rules/registry.ts`
- `bun run check`
- GitHub CI: Build, Lint & Format, Typecheck, Test, Governance, and CI Gate are green.
