### PR TITLE
chore: add temporary framework write audit rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
     ],
     'trails-local/prefer-bun-api': 'warn',
     'trails-local/snapshot-location': 'warn',
+    'trails-local/temp-audit-direct-framework-writes': 'warn',
     'trails-local/test-file-naming': 'warn',
     'typescript/require-await': 'off',
     'unicorn/custom-error-definition': 'off',

--- a/packages/oxlint-plugin/README.md
+++ b/packages/oxlint-plugin/README.md
@@ -25,3 +25,9 @@ Initial rules cover low-blast repo hygiene:
 
 These rules may carry Trails-specific carve-outs in `oxlint.config.ts`. Keep
 semantic framework correctness in Warden.
+
+Temporary audit rules use a `temp-*` prefix and must name the issue or state
+that deletes them. During discovery, they may run from the root config at
+warning severity so follow-up branches can burn down findings while CI stays
+green. Promote a temporary rule to error only after its findings are fixed,
+intentionally baselined, or rehomed as durable Warden coverage.

--- a/packages/oxlint-plugin/src/__tests__/plugin.test.ts
+++ b/packages/oxlint-plugin/src/__tests__/plugin.test.ts
@@ -17,6 +17,7 @@ describe('@ontrails/oxlint-plugin', () => {
       'no-process-exit-in-packages',
       'prefer-bun-api',
       'snapshot-location',
+      'temp-audit-direct-framework-writes',
       'test-file-naming',
     ]);
   });

--- a/packages/oxlint-plugin/src/__tests__/rule-test-helpers.ts
+++ b/packages/oxlint-plugin/src/__tests__/rule-test-helpers.ts
@@ -24,6 +24,14 @@ export const createCallExpressionNode = (
   type: 'CallExpression',
 });
 
+export const createIdentifierCallNode = (callName: string): unknown => ({
+  callee: {
+    name: callName,
+    type: 'Identifier',
+  },
+  type: 'CallExpression',
+});
+
 export const createMemberExpressionNode = (
   objectName: string,
   propertyName: string

--- a/packages/oxlint-plugin/src/__tests__/rules.test.ts
+++ b/packages/oxlint-plugin/src/__tests__/rules.test.ts
@@ -7,10 +7,12 @@ import { noProcessEnvInPackagesRule } from '../rules/no-process-env-in-packages.
 import { noProcessExitInPackagesRule } from '../rules/no-process-exit-in-packages.js';
 import { preferBunApiRule } from '../rules/prefer-bun-api.js';
 import { snapshotLocationRule } from '../rules/snapshot-location.js';
+import { tempAuditDirectFrameworkWritesRule } from '../rules/temp-audit-direct-framework-writes.js';
 import { testFileNamingRule } from '../rules/test-file-naming.js';
 import {
   createCallExpressionNode,
   createExportDeclarationNode,
+  createIdentifierCallNode,
   createImportDeclarationNode,
   createMemberExpressionNode,
   createRequireCallNode,
@@ -209,5 +211,53 @@ describe('repo-local rules', () => {
       'snapshotLocation',
     ]);
     expect(nestedSnapshotReports).toHaveLength(0);
+  });
+
+  test('reports direct framework writes in scoped audit paths', () => {
+    const bunWriteReports = runRuleForEvent({
+      event: 'CallExpression',
+      filename: 'apps/trails/src/trails/create-scaffold.ts',
+      nodes: [createCallExpressionNode('Bun', 'write')],
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const directWriteReports = runRuleForEvent({
+      event: 'CallExpression',
+      filename: 'apps/trails/src/trails/draft-promote.ts',
+      nodes: [createIdentifierCallNode('mkdirSync')],
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const directRenameReports = runRuleForEvent({
+      event: 'CallExpression',
+      filename: 'apps/trails/src/trails/draft-promote.ts',
+      nodes: [createIdentifierCallNode('renameSync')],
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const directWriteReportsFromImport = runRuleForEvent({
+      event: 'CallExpression',
+      filename: 'apps/trails/src/trails/add-verify.ts',
+      nodes: [createIdentifierCallNode('writeFile')],
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const packageReports = runRuleForEvent({
+      event: 'CallExpression',
+      filename: 'packages/core/src/internal/topo-store.ts',
+      nodes: [createCallExpressionNode('Bun', 'write')],
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const testReports = runRuleForEvent({
+      event: 'CallExpression',
+      filename: 'apps/trails/src/trails/__tests__/create-scaffold.test.ts',
+      nodes: [createCallExpressionNode('Bun', 'write')],
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+
+    expect(bunWriteReports[0]?.data).toEqual({ callName: 'Bun.write' });
+    expect(directWriteReports[0]?.data).toEqual({ callName: 'mkdirSync' });
+    expect(directRenameReports[0]?.data).toEqual({ callName: 'renameSync' });
+    expect(directWriteReportsFromImport[0]?.data).toEqual({
+      callName: 'writeFile',
+    });
+    expect(packageReports).toHaveLength(0);
+    expect(testReports).toHaveLength(0);
   });
 });

--- a/packages/oxlint-plugin/src/rules/registry.ts
+++ b/packages/oxlint-plugin/src/rules/registry.ts
@@ -7,6 +7,7 @@ import { noProcessEnvInPackagesRule } from './no-process-env-in-packages.js';
 import { noProcessExitInPackagesRule } from './no-process-exit-in-packages.js';
 import { preferBunApiRule } from './prefer-bun-api.js';
 import { snapshotLocationRule } from './snapshot-location.js';
+import { tempAuditDirectFrameworkWritesRule } from './temp-audit-direct-framework-writes.js';
 import { testFileNamingRule } from './test-file-naming.js';
 
 /**
@@ -24,5 +25,6 @@ export const rules = {
   'no-process-exit-in-packages': noProcessExitInPackagesRule,
   'prefer-bun-api': preferBunApiRule,
   'snapshot-location': snapshotLocationRule,
+  'temp-audit-direct-framework-writes': tempAuditDirectFrameworkWritesRule,
   'test-file-naming': testFileNamingRule,
 } satisfies Record<string, Rule>;

--- a/packages/oxlint-plugin/src/rules/temp-audit-direct-framework-writes.ts
+++ b/packages/oxlint-plugin/src/rules/temp-audit-direct-framework-writes.ts
@@ -1,0 +1,165 @@
+import {
+  asIdentifierName,
+  invokesMemberCall,
+  normalizeFilePath,
+  reportNode,
+} from './shared.js';
+import type { RuleModule } from './shared.js';
+
+const DEFAULT_SCOPED_PATHS = ['apps/trails/src/trails/'] as const;
+const TEST_FILE_PATTERN = /(?:^|\/)__tests__\/|\.(test|spec)\.[cm]?[jt]sx?$/u;
+
+const MEMBER_WRITE_CALLS = [
+  ['Bun', 'write'],
+  ['fs', 'cp'],
+  ['fs', 'cpSync'],
+  ['fs', 'copyFile'],
+  ['fs', 'copyFileSync'],
+  ['fs', 'mkdir'],
+  ['fs', 'mkdirSync'],
+  ['fs', 'rename'],
+  ['fs', 'renameSync'],
+  ['fs', 'rm'],
+  ['fs', 'rmSync'],
+  ['fs', 'writeFile'],
+  ['fs', 'writeFileSync'],
+] as const;
+
+const DIRECT_WRITE_CALLS = new Set([
+  'cp',
+  'cpSync',
+  'copyFile',
+  'copyFileSync',
+  'mkdir',
+  'mkdirSync',
+  'rename',
+  'renameSync',
+  'rm',
+  'rmSync',
+  'writeFile',
+  'writeFileSync',
+]);
+
+const resolveScopedPaths = (options: readonly unknown[]): readonly string[] => {
+  const scopedPaths = (options[0] as { scopedPaths?: unknown } | undefined)
+    ?.scopedPaths;
+
+  if (!Array.isArray(scopedPaths)) {
+    return DEFAULT_SCOPED_PATHS;
+  }
+
+  const normalizedPaths = scopedPaths.filter(
+    (path): path is string => typeof path === 'string' && path.length > 0
+  );
+
+  return normalizedPaths.length > 0 ? normalizedPaths : DEFAULT_SCOPED_PATHS;
+};
+
+const isScopedFile = ({
+  filePath,
+  scopedPaths,
+}: {
+  readonly filePath: string | undefined;
+  readonly scopedPaths: readonly string[];
+}): boolean => {
+  if (!filePath) {
+    return false;
+  }
+
+  const normalized = normalizeFilePath(filePath);
+
+  if (TEST_FILE_PATTERN.test(normalized)) {
+    return false;
+  }
+
+  return scopedPaths.some((scopedPath) =>
+    normalized.includes(normalizeFilePath(scopedPath))
+  );
+};
+
+const getDirectCallName = (node: unknown): string | undefined => {
+  if (!(node && typeof node === 'object')) {
+    return undefined;
+  }
+
+  if ((node as { type?: unknown }).type !== 'CallExpression') {
+    return undefined;
+  }
+
+  const callName = asIdentifierName((node as { callee?: unknown }).callee);
+  return callName && DIRECT_WRITE_CALLS.has(callName) ? callName : undefined;
+};
+
+const getMemberWriteCallName = (node: unknown): string | undefined => {
+  for (const [objectName, propertyName] of MEMBER_WRITE_CALLS) {
+    if (invokesMemberCall({ node, objectName, propertyName })) {
+      return `${objectName}.${propertyName}`;
+    }
+  }
+
+  return undefined;
+};
+
+const getWriteCallName = (node: unknown): string | undefined =>
+  getMemberWriteCallName(node) ?? getDirectCallName(node);
+
+/**
+ * Temporary TRL-575 audit rule.
+ *
+ * Delete after the framework write-path audit either routes these calls through
+ * containment/plan/apply helpers or classifies the remaining call sites as
+ * intentional framework boundaries.
+ */
+export const tempAuditDirectFrameworkWritesRule: RuleModule = {
+  create(context) {
+    const scopedPaths = resolveScopedPaths(context.options);
+
+    if (!isScopedFile({ filePath: context.filename, scopedPaths })) {
+      return {};
+    }
+
+    return {
+      CallExpression(node) {
+        const callName = getWriteCallName(node);
+
+        if (!callName) {
+          return;
+        }
+
+        reportNode({
+          context,
+          data: { callName },
+          messageId: 'tempAuditDirectFrameworkWrites',
+          node,
+        });
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description:
+        'Temporarily report direct filesystem writes in Trails framework trail code during TRL-575 audit discovery.',
+      recommended: false,
+    },
+    messages: {
+      tempAuditDirectFrameworkWrites:
+        "Temporary TRL-575 audit: '{{callName}}' writes directly from framework trail code. Route writes through containment/plan/apply helpers or document this as an intentional boundary.",
+    },
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          scopedPaths: {
+            description:
+              'Path fragments where direct filesystem writes should be reported.',
+            items: { type: 'string' },
+            type: 'array',
+            uniqueItems: true,
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'problem',
+  },
+};


### PR DESCRIPTION
## Context

Starts the `TRL-575` static-discovery lane for audit-derived, repo-local Oxlint checks. The goal of this base branch is discovery, not permanent doctrine: surface direct filesystem writes in framework trail code while keeping CI green so the stack can burn findings down safely.

## What Changed

- Added `trails-local/temp-audit-direct-framework-writes` to the private `@ontrails/oxlint-plugin`.
- Enabled the rule at `warn` in the root Oxlint config so it discovers write-path audit findings without blocking CI.
- Documented the temporary rule lifecycle in the plugin README.
- Added fixture and registry coverage for the new rule.

## Stack

- This PR introduces the temporary warning-mode audit rule.
- #257 and #258 contain the scaffold/add/draft-promote write findings.
- #259 through #261 contain the load-app, dev/topo, and trust-boundary follow-ups.

## Testing

- `bun run --cwd packages/oxlint-plugin test`
- `bun run format:check`
- `bun run check`

## Notes

Warning mode is deliberate. The base branch exposes the remaining direct framework writes while exiting green, so follow-up branches can reduce the warning set before the rule is promoted, retired, or replaced by durable Warden coverage.

Closes: TRL-575