### PR TITLE
fix: contain scaffold project writes

### DIFF
--- a/apps/trails/src/__tests__/add-trail.test.ts
+++ b/apps/trails/src/__tests__/add-trail.test.ts
@@ -94,4 +94,63 @@ describe('add.trail', () => {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+
+  test('writes draft trail ids with draft-marked filenames', async () => {
+    const dir = repoTempDir();
+
+    try {
+      mkdirSync(dir, { recursive: true });
+
+      const result = expectOk(
+        await addTrail.blaze(
+          {
+            description: 'Prepare a draft entity',
+            exampleName: 'Prepare draft',
+            id: '_draft.entity.prepare',
+            intent: 'read',
+          },
+          { cwd: dir } as never
+        )
+      );
+
+      expect(result.created).toEqual([
+        'src/trails/_draft.entity-prepare.ts',
+        '__tests__/_draft.entity-prepare.test.ts',
+      ]);
+
+      const trailSource = readGeneratedFile(
+        dir,
+        'src/trails/_draft.entity-prepare.ts'
+      );
+      expect(trailSource).toContain('trail("_draft.entity.prepare"');
+      expect(trailSource).toContain('intent: "read"');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects path-shaped trail ids before writing files', async () => {
+    const dir = repoTempDir();
+
+    try {
+      mkdirSync(dir, { recursive: true });
+
+      const error = expectValidationError(
+        await addTrail.blaze(
+          {
+            description: 'Escape the project',
+            exampleName: 'Escape',
+            id: '../escape',
+            intent: 'write',
+          },
+          { cwd: dir } as never
+        )
+      );
+
+      expect(error.message).toContain('Trail ID');
+      expect(existsSync(join(dir, 'escape.ts'))).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });

--- a/apps/trails/src/__tests__/create.test.ts
+++ b/apps/trails/src/__tests__/create.test.ts
@@ -9,7 +9,7 @@ import {
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 
-import { Result } from '@ontrails/core';
+import { Result, ValidationError } from '@ontrails/core';
 
 import { addSurface } from '../trails/add-surface.js';
 import { addVerify } from '../trails/add-verify.js';
@@ -184,7 +184,7 @@ const assertGeneratedToolingDeps = (dir: string): void => {
 const assertHelloApp = (dir: string): void => {
   expectContainsAll(readText(dir, 'src/app.ts'), [
     'topo',
-    `'${basename(dir)}'`,
+    JSON.stringify(basename(dir)),
     'hello',
   ]);
   expectContainsAll(readText(dir, 'src/trails/hello.ts'), [
@@ -272,7 +272,7 @@ const assertEmptyStarter = (dir: string): void => {
   expectPaths(dir, ['src/trails/.gitkeep'], true);
   expectPaths(dir, ['src/trails/hello.ts'], false);
   const appContent = readText(dir, 'src/app.ts');
-  expect(appContent).toContain(`topo('${basename(dir)}')`);
+  expect(appContent).toContain(`topo(${JSON.stringify(basename(dir))})`);
   expect(appContent).not.toContain('import * as');
 };
 
@@ -332,6 +332,20 @@ describe('trails create', () => {
       await withTempProject(async (dir) => {
         expectOk(await runCreate(dir, { starter: 'empty' }));
         assertEmptyStarter(dir);
+      });
+    });
+
+    test('rejects path-shaped project names before writing', async () => {
+      await withTempProject(async (dir) => {
+        const error = expectErr(
+          await createScaffold.blaze(
+            { dir: dirname(dir), name: '../escape', starter: 'hello' },
+            {} as never
+          )
+        );
+
+        expect(error).toBeInstanceOf(ValidationError);
+        expect(existsSync(join(dirname(dir), 'escape'))).toBe(false);
       });
     });
   });

--- a/apps/trails/src/__tests__/project-writes.test.ts
+++ b/apps/trails/src/__tests__/project-writes.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { PermissionError, ValidationError } from '@ontrails/core';
+
+import {
+  resolveProjectDir,
+  validateProjectName,
+  validateTrailId,
+  writeProjectFile,
+} from '../project-writes.js';
+
+const tempRoot = (): string =>
+  join(
+    tmpdir(),
+    `trails-project-writes-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+
+describe('project write helpers', () => {
+  test('rejects path-shaped project names before resolving a project directory', () => {
+    for (const name of ['../outside', 'nested/name', 'bad\nname']) {
+      const result = validateProjectName(name);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+      }
+    }
+  });
+
+  test('rejects path-shaped trail ids before deriving file or export names', () => {
+    for (const id of ['../outside', 'entity..show', 'entity.show-now']) {
+      const result = validateTrailId(id);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+      }
+    }
+  });
+
+  test('contains project directories and file writes under their root', async () => {
+    const root = tempRoot();
+
+    try {
+      const projectDir = resolveProjectDir(root, 'safe-project');
+      expect(projectDir.isOk()).toBe(true);
+
+      if (projectDir.isErr()) {
+        throw projectDir.error;
+      }
+
+      const written = await writeProjectFile(
+        projectDir.value,
+        'src/app.ts',
+        'export const ok = true;\n'
+      );
+      expect(written.isOk()).toBe(true);
+      expect(readFileSync(join(projectDir.value, 'src/app.ts'), 'utf8')).toBe(
+        'export const ok = true;\n'
+      );
+
+      const escaped = await writeProjectFile(
+        projectDir.value,
+        '../escape.ts',
+        'export const escaped = true;\n'
+      );
+      expect(escaped.isErr()).toBe(true);
+      if (escaped.isErr()) {
+        expect(escaped.error).toBeInstanceOf(PermissionError);
+      }
+      expect(existsSync(join(dirname(projectDir.value), 'escape.ts'))).toBe(
+        false
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/trails/src/project-writes.ts
+++ b/apps/trails/src/project-writes.ts
@@ -1,0 +1,111 @@
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import {
+  DRAFT_ID_PREFIX,
+  deriveSafePath,
+  InternalError,
+  Result,
+  ValidationError,
+} from '@ontrails/core';
+import type { Result as TrailsResult } from '@ontrails/core';
+
+export const PROJECT_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/u;
+export const PROJECT_NAME_MESSAGE =
+  'Project name must start with a lowercase letter or digit and contain only lowercase letters, digits, ".", "_", or "-".';
+
+export const TRAIL_ID_PATTERN =
+  /^(?:_draft\.)?[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)*$/u;
+export const TRAIL_ID_MESSAGE =
+  'Trail ID must be lowercase dotted segments, optionally prefixed with "_draft.", with each non-draft segment starting with a letter and containing only letters or digits.';
+
+const asError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+export const validateProjectName = (
+  name: string
+): TrailsResult<string, ValidationError> =>
+  PROJECT_NAME_PATTERN.test(name)
+    ? Result.ok(name)
+    : Result.err(new ValidationError(PROJECT_NAME_MESSAGE));
+
+export const validateTrailId = (
+  trailId: string
+): TrailsResult<string, ValidationError> =>
+  TRAIL_ID_PATTERN.test(trailId)
+    ? Result.ok(trailId)
+    : Result.err(new ValidationError(TRAIL_ID_MESSAGE));
+
+export const trailIdToModuleName = (trailId: string): string =>
+  trailId.startsWith(DRAFT_ID_PREFIX)
+    ? `${DRAFT_ID_PREFIX}${trailId.slice(DRAFT_ID_PREFIX.length).replaceAll('.', '-')}`
+    : trailId.replaceAll('.', '-');
+
+export const trailIdToExportName = (trailId: string): string =>
+  trailId.replaceAll('.', '_');
+
+export const resolveProjectDir = (
+  parentDir: string,
+  projectName: string
+): TrailsResult<string, Error> => {
+  const validated = validateProjectName(projectName);
+  if (validated.isErr()) {
+    return validated;
+  }
+
+  return deriveSafePath(resolve(parentDir), validated.value);
+};
+
+export const resolveProjectPath = (
+  projectDir: string,
+  relativePath: string
+): TrailsResult<string, Error> => deriveSafePath(projectDir, relativePath);
+
+export const ensureProjectDirectory = (
+  projectDir: string,
+  relativePath: string
+): TrailsResult<string, Error> => {
+  const target = resolveProjectPath(projectDir, relativePath);
+  if (target.isErr()) {
+    return target;
+  }
+
+  try {
+    mkdirSync(target.value, { recursive: true });
+    return Result.ok(target.value);
+  } catch (error) {
+    return Result.err(
+      new InternalError(
+        `Failed to create project directory "${relativePath}"`,
+        {
+          cause: asError(error),
+          context: { projectDir, relativePath },
+        }
+      )
+    );
+  }
+};
+
+export const writeProjectFile = async (
+  projectDir: string,
+  relativePath: string,
+  content: string | Uint8Array
+): Promise<TrailsResult<string, Error>> => {
+  const target = resolveProjectPath(projectDir, relativePath);
+  if (target.isErr()) {
+    return target;
+  }
+
+  try {
+    mkdirSync(dirname(target.value), { recursive: true });
+    await Bun.write(target.value, content);
+    return Result.ok(relativePath);
+  } catch (error) {
+    return Result.err(
+      new InternalError(`Failed to write project file "${relativePath}"`, {
+        cause: asError(error),
+        context: { projectDir, relativePath },
+      })
+    );
+  }
+};

--- a/apps/trails/src/trails/add-surface.ts
+++ b/apps/trails/src/trails/add-surface.ts
@@ -4,12 +4,13 @@
  * Generates surface entry points and updates package.json dependencies.
  */
 
-import { existsSync, mkdirSync } from 'node:fs';
-import { basename, dirname, join, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
 
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
+import { resolveProjectPath, writeProjectFile } from '../project-writes.js';
 import {
   ontrailsPackageRange,
   scaffoldDependencyVersions,
@@ -88,24 +89,32 @@ const patchPkgDeps = (
 const updatePkgJsonForSurface = async (
   cwd: string,
   surface: Surface
-): Promise<string> => {
-  const pkgPath = join(cwd, 'package.json');
+): Promise<Result<string, Error>> => {
+  const pkgPathResult = resolveProjectPath(cwd, 'package.json');
+  if (pkgPathResult.isErr()) {
+    return Result.err(pkgPathResult.error);
+  }
+
+  const pkgPath = pkgPathResult.value;
   if (!existsSync(pkgPath)) {
-    return surfaceDependencies[surface][0] ?? '';
+    return Result.ok(surfaceDependencies[surface][0] ?? '');
   }
   const pkg = (await Bun.file(pkgPath).json()) as Record<string, unknown>;
   const depName = patchPkgDeps(pkg, surface, cwd);
-  await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-  return depName;
+  const written = await writeProjectFile(
+    cwd,
+    'package.json',
+    `${JSON.stringify(pkg, null, 2)}\n`
+  );
+  return written.isErr() ? Result.err(written.error) : Result.ok(depName);
 };
 
 /** Create the entry file for a surface and return the relative path. */
 const writeSurfaceEntry = async (
   cwd: string,
   surface: Surface
-): Promise<string> => {
+): Promise<Result<string, Error>> => {
   const entryFile = getEntryFile(surface);
-  const fullEntryPath = join(cwd, entryFile);
   const appImport = (await findTopoPath(cwd)) ?? './app.js';
   const generators = {
     cli: generateCliEntry,
@@ -114,9 +123,8 @@ const writeSurfaceEntry = async (
   } satisfies Record<Surface, (appImportPath: string) => string>;
   const content = generators[surface](appImport);
 
-  mkdirSync(dirname(fullEntryPath), { recursive: true });
-  await Bun.write(fullEntryPath, content);
-  return entryFile;
+  const written = await writeProjectFile(cwd, entryFile, content);
+  return written.isErr() ? Result.err(written.error) : Result.ok(entryFile);
 };
 
 export const addSurface = trail('add.surface', {
@@ -133,9 +141,19 @@ export const addSurface = trail('add.surface', {
       );
     }
 
+    const created = await writeSurfaceEntry(cwd, surface);
+    if (created.isErr()) {
+      return Result.err(created.error);
+    }
+
+    const dependency = await updatePkgJsonForSurface(cwd, surface);
+    if (dependency.isErr()) {
+      return Result.err(dependency.error);
+    }
+
     return Result.ok({
-      created: await writeSurfaceEntry(cwd, surface),
-      dependency: await updatePkgJsonForSurface(cwd, surface),
+      created: created.value,
+      dependency: dependency.value,
     });
   },
   description: 'Add a surface to an existing project',

--- a/apps/trails/src/trails/add-trail.ts
+++ b/apps/trails/src/trails/add-trail.ts
@@ -2,11 +2,19 @@
  * `add.trail` trail -- Scaffold a new trail file with tests.
  */
 
-import { mkdirSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
+
+import {
+  trailIdToExportName,
+  trailIdToModuleName,
+  TRAIL_ID_MESSAGE,
+  TRAIL_ID_PATTERN,
+  validateTrailId,
+  writeProjectFile,
+} from '../project-writes.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -22,13 +30,15 @@ const generateTrailFile = (
   exampleName: string,
   intent: 'read' | 'write' | 'destroy'
 ): string => {
-  const intentLine = intent === 'write' ? '' : `\n  intent: '${intent}',`;
+  const intentLine =
+    intent === 'write' ? '' : `\n  intent: ${literal(intent)},`;
   const exampleMessage = deriveExampleMessage(id);
+  const trailName = trailIdToExportName(id);
 
   return `import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-export const ${id.replaceAll('.', '_')} = trail('${id}', {
+export const ${trailName} = trail(${literal(id)}, {
   blaze: async () => {
     return Result.ok({ message: ${literal(exampleMessage)} });
   },
@@ -47,8 +57,8 @@ export const ${id.replaceAll('.', '_')} = trail('${id}', {
 };
 
 const generateTestFile = (id: string, exampleName: string): string => {
-  const moduleName = id.replaceAll('.', '-');
-  const trailName = id.replaceAll('.', '_');
+  const moduleName = trailIdToModuleName(id);
+  const trailName = trailIdToExportName(id);
   const exampleMessage = deriveExampleMessage(id);
   return `import { testTrail } from '@ontrails/testing';
 import { ${trailName} } from '../src/trails/${moduleName}.js';
@@ -67,20 +77,16 @@ testTrail(${trailName}, [
 // Trail definition
 // ---------------------------------------------------------------------------
 
-/** Write a file, creating parent directories as needed. */
-const writeWithDirs = async (
-  filePath: string,
-  content: string
-): Promise<void> => {
-  mkdirSync(dirname(filePath), { recursive: true });
-  await Bun.write(filePath, content);
-};
-
 export const addTrail = trail('add.trail', {
   args: ['id'],
   blaze: async (input, ctx) => {
     const { id } = input;
-    const moduleName = id.replaceAll('.', '-');
+    const validated = validateTrailId(id);
+    if (validated.isErr()) {
+      return Result.err(validated.error);
+    }
+
+    const moduleName = trailIdToModuleName(validated.value);
     const cwd = resolve(ctx.cwd ?? '.');
 
     const files = new Map<string, string>([
@@ -100,7 +106,10 @@ export const addTrail = trail('add.trail', {
     ]);
 
     for (const [relativePath, content] of files) {
-      await writeWithDirs(join(cwd, relativePath), content);
+      const written = await writeProjectFile(cwd, relativePath, content);
+      if (written.isErr()) {
+        return Result.err(written.error);
+      }
     }
 
     return Result.ok({ created: [...files.keys()] });
@@ -118,6 +127,7 @@ export const addTrail = trail('add.trail', {
     id: z
       .string()
       .min(1, 'Trail ID is required')
+      .regex(TRAIL_ID_PATTERN, TRAIL_ID_MESSAGE)
       .describe('Trail ID (e.g., entity.update)'),
     intent: z
       .enum(['read', 'write', 'destroy'])

--- a/apps/trails/src/trails/add-verify.ts
+++ b/apps/trails/src/trails/add-verify.ts
@@ -2,12 +2,18 @@
  * `add.verify` trail -- Add testing + warden setup to a project.
  */
 
-import { existsSync, mkdirSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
 
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
+import {
+  PROJECT_NAME_MESSAGE,
+  PROJECT_NAME_PATTERN,
+  resolveProjectDir,
+  resolveProjectPath,
+  writeProjectFile,
+} from '../project-writes.js';
 import {
   ontrailsPackageRange,
   scaffoldDependencyVersions,
@@ -45,14 +51,24 @@ const patchVerifyDeps = (pkg: Record<string, unknown>): void => {
 /** Update package.json in the target project with verify dependencies. */
 const updatePackageJsonForVerify = async (
   projectDir: string
-): Promise<void> => {
-  const pkgPath = join(projectDir, 'package.json');
+): Promise<Result<void, Error>> => {
+  const pkgPathResult = resolveProjectPath(projectDir, 'package.json');
+  if (pkgPathResult.isErr()) {
+    return Result.err(pkgPathResult.error);
+  }
+
+  const pkgPath = pkgPathResult.value;
   if (!existsSync(pkgPath)) {
-    return;
+    return Result.ok();
   }
   const pkg = (await Bun.file(pkgPath).json()) as Record<string, unknown>;
   patchVerifyDeps(pkg);
-  await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+  const written = await writeProjectFile(
+    projectDir,
+    'package.json',
+    `${JSON.stringify(pkg, null, 2)}\n`
+  );
+  return written.isErr() ? Result.err(written.error) : Result.ok();
 };
 
 // ---------------------------------------------------------------------------
@@ -61,29 +77,53 @@ const updatePackageJsonForVerify = async (
 
 export const addVerify = trail('add.verify', {
   blaze: async (input) => {
-    const projectDir = resolve(input.dir ?? '.', input.name);
+    const projectDirResult = resolveProjectDir(input.dir ?? '.', input.name);
+    if (projectDirResult.isErr()) {
+      return Result.err(projectDirResult.error);
+    }
+
+    const projectDir = projectDirResult.value;
     const files: string[] = [];
 
     const writeFile = async (
       relativePath: string,
       content: string
-    ): Promise<void> => {
-      const fullPath = join(projectDir, relativePath);
-      mkdirSync(dirname(fullPath), { recursive: true });
-      await Bun.write(fullPath, content);
-      files.push(relativePath);
+    ): Promise<Result<void, Error>> => {
+      const written = await writeProjectFile(projectDir, relativePath, content);
+      if (written.isErr()) {
+        return Result.err(written.error);
+      }
+      files.push(written.value);
+      return Result.ok();
     };
 
-    await writeFile('__tests__/examples.test.ts', generateTestFile());
-    await writeFile('lefthook.yml', generateLefthookYml());
-    await updatePackageJsonForVerify(projectDir);
+    const testFile = await writeFile(
+      '__tests__/examples.test.ts',
+      generateTestFile()
+    );
+    if (testFile.isErr()) {
+      return Result.err(testFile.error);
+    }
+
+    const lefthookFile = await writeFile('lefthook.yml', generateLefthookYml());
+    if (lefthookFile.isErr()) {
+      return Result.err(lefthookFile.error);
+    }
+
+    const packageResult = await updatePackageJsonForVerify(projectDir);
+    if (packageResult.isErr()) {
+      return Result.err(packageResult.error);
+    }
 
     return Result.ok({ created: files });
   },
   description: 'Add testing and warden verification',
   input: z.object({
     dir: z.string().optional().describe('Parent directory'),
-    name: z.string().describe('Project name'),
+    name: z
+      .string()
+      .regex(PROJECT_NAME_PATTERN, PROJECT_NAME_MESSAGE)
+      .describe('Project name'),
   }),
   meta: { internal: true },
   output: z.object({

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -4,12 +4,18 @@
  * Generates package.json, tsconfig, app.ts, starter trails, and .trails/ directory.
  */
 
-import { mkdirSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
+import {
+  ensureProjectDirectory,
+  PROJECT_NAME_MESSAGE,
+  PROJECT_NAME_PATTERN,
+  resolveProjectDir,
+  writeProjectFile,
+} from '../project-writes.js';
 import {
   ontrailsPackageRange,
   scaffoldDependencyVersions,
@@ -276,8 +282,11 @@ const starterImports: Record<
 
 const generateAppTs = (name: string, starter: Starter): string => {
   const { imports, modules } = starterImports[starter];
+  const appNameLiteral = JSON.stringify(name);
   const topoArgs =
-    modules.length > 0 ? `'${name}', ${modules.join(', ')}` : `'${name}'`;
+    modules.length > 0
+      ? `${appNameLiteral}, ${modules.join(', ')}`
+      : appNameLiteral;
 
   return [
     "import { topo } from '@ontrails/core';",
@@ -321,15 +330,16 @@ const collectScaffoldFiles = (
 const writeScaffoldFiles = async (
   projectDir: string,
   fileMap: Map<string, string>
-): Promise<string[]> => {
+): Promise<Result<string[], Error>> => {
   const files: string[] = [];
   for (const [relativePath, content] of fileMap) {
-    const fullPath = join(projectDir, relativePath);
-    mkdirSync(dirname(fullPath), { recursive: true });
-    await Bun.write(fullPath, content);
-    files.push(relativePath);
+    const written = await writeProjectFile(projectDir, relativePath, content);
+    if (written.isErr()) {
+      return written;
+    }
+    files.push(written.value);
   }
-  return files;
+  return Result.ok(files);
 };
 
 // ---------------------------------------------------------------------------
@@ -338,22 +348,37 @@ const writeScaffoldFiles = async (
 
 export const createScaffold = trail('create.scaffold', {
   blaze: async (input) => {
-    const projectDir = resolve(input.dir ?? '.', input.name);
+    const projectDirResult = resolveProjectDir(input.dir ?? '.', input.name);
+    if (projectDirResult.isErr()) {
+      return Result.err(projectDirResult.error);
+    }
+
+    const projectDir = projectDirResult.value;
     const starter = (input.starter ?? 'hello') as Starter;
     const fileMap = collectScaffoldFiles(input.name, starter);
     const files = await writeScaffoldFiles(projectDir, fileMap);
-    mkdirSync(join(projectDir, '.trails'), { recursive: true });
+    if (files.isErr()) {
+      return Result.err(files.error);
+    }
+
+    const trailsDir = ensureProjectDirectory(projectDir, '.trails');
+    if (trailsDir.isErr()) {
+      return Result.err(trailsDir.error);
+    }
 
     return Result.ok({
-      created: files,
-      dir: projectDir,
+      created: files.value,
+      dir: resolve(projectDir),
       name: input.name,
     } satisfies ScaffoldResult);
   },
   description: 'Scaffold a new Trails project',
   input: z.object({
     dir: z.string().optional().describe('Parent directory'),
-    name: z.string().describe('Project name'),
+    name: z
+      .string()
+      .regex(PROJECT_NAME_PATTERN, PROJECT_NAME_MESSAGE)
+      .describe('Project name'),
     starter: z
       .enum(['hello', 'entity', 'empty'])
       .default('hello')


### PR DESCRIPTION
## Context

Addresses the first `TRL-553` containment slice exposed by the temporary framework-write audit rule. Scaffold/add trails were deriving project paths directly from user input, and generated TypeScript was interpolating project or trail names without a systematic grammar boundary.

## What Changed

- Added app-local project write helpers that reuse `@ontrails/core` path containment.
- Validated project names before resolving scaffold/add-verify target directories.
- Validated trail IDs before deriving module filenames and export identifiers.
- Routed `create.scaffold`, `add.trail`, `add.verify`, and `add.surface` writes through contained project-file helpers.
- Serialized generated topo/trail string literals with JSON stringification.
- Added regression coverage for project-name escape, trail-ID escape, and contained writes.

## Stack

- Depends on #256, which introduces the temporary warning-mode audit rule.
- This PR contains the create/add/scaffold cluster.
- #258 completes the remaining `TRL-553` draft-promote write/rename slice.

## Testing

- `bun test apps/trails/src/__tests__/project-writes.test.ts apps/trails/src/__tests__/add-trail.test.ts apps/trails/src/__tests__/create.test.ts`
- `bun run --cwd apps/trails test`
- `bun run --cwd apps/trails typecheck`
- `bun run --cwd apps/trails lint`
- `bun run format:check`
- `bun run check`

## Notes

`bun run check` passes with the temporary audit rule at warning severity. On this branch the warning set drops to the next bounded groups: `draft-promote`, `load-app`, and dev/topo support.

Closes: TRL-553