### PR TITLE
fix: contain draft promote writes

### DIFF
--- a/apps/trails/src/__tests__/draft-promote.test.ts
+++ b/apps/trails/src/__tests__/draft-promote.test.ts
@@ -6,7 +6,7 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 
 import type { Result } from '@ontrails/core';
 import { ValidationError } from '@ontrails/core';
@@ -122,6 +122,69 @@ describe('draft.promote', () => {
       expectDraftPromoteResults(dir);
     } finally {
       rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('promotes from a relative root without duplicating path containment', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeDraftPromoteFixture(dir);
+
+      const result = expectOk(
+        await draftPromoteTrail.blaze(
+          {
+            fromId: '_draft.entity.prepare',
+            renameFiles: true,
+            rootDir: relative(process.cwd(), dir),
+            toId: 'entity.prepare',
+          },
+          { cwd: process.cwd() } as never
+        )
+      );
+
+      expect(result.promotedEstablished).toBe(true);
+      expect(result.renamedFiles).toEqual([
+        {
+          from: 'src/_draft.prepare.ts',
+          to: 'src/prepare.ts',
+        },
+      ]);
+      expectDraftPromoteResults(dir);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('promotes a relative root from the context cwd', async () => {
+    const workspaceDir = repoTempDir();
+    const dir = join(workspaceDir, 'nested-project');
+
+    try {
+      writeDraftPromoteFixture(dir);
+
+      const result = expectOk(
+        await draftPromoteTrail.blaze(
+          {
+            fromId: '_draft.entity.prepare',
+            renameFiles: true,
+            rootDir: 'nested-project',
+            toId: 'entity.prepare',
+          },
+          { cwd: workspaceDir } as never
+        )
+      );
+
+      expect(result.promotedEstablished).toBe(true);
+      expect(result.renamedFiles).toEqual([
+        {
+          from: 'src/_draft.prepare.ts',
+          to: 'src/prepare.ts',
+        },
+      ]);
+      expectDraftPromoteResults(dir);
+    } finally {
+      rmSync(workspaceDir, { force: true, recursive: true });
     }
   });
 

--- a/apps/trails/src/__tests__/project-writes.test.ts
+++ b/apps/trails/src/__tests__/project-writes.test.ts
@@ -6,10 +6,12 @@ import { dirname, join } from 'node:path';
 import { PermissionError, ValidationError } from '@ontrails/core';
 
 import {
+  renameProjectPath,
   resolveProjectDir,
   validateProjectName,
   validateTrailId,
   writeProjectFile,
+  writeProjectPath,
 } from '../project-writes.js';
 
 const tempRoot = (): string =>
@@ -72,6 +74,64 @@ describe('project write helpers', () => {
       expect(existsSync(join(dirname(projectDir.value), 'escape.ts'))).toBe(
         false
       );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('contains absolute project writes and renames under their root', async () => {
+    const root = tempRoot();
+
+    try {
+      const projectDir = resolveProjectDir(root, 'safe-project');
+      expect(projectDir.isOk()).toBe(true);
+
+      if (projectDir.isErr()) {
+        throw projectDir.error;
+      }
+
+      const sourcePath = join(projectDir.value, 'src', 'before.ts');
+      const targetPath = join(projectDir.value, 'src', 'after.ts');
+      const outsidePath = join(root, 'outside.ts');
+
+      const written = await writeProjectPath(
+        projectDir.value,
+        sourcePath,
+        'export const before = true;\n'
+      );
+      expect(written.isOk()).toBe(true);
+
+      const escapedWrite = await writeProjectPath(
+        projectDir.value,
+        outsidePath,
+        'export const outside = true;\n'
+      );
+      expect(escapedWrite.isErr()).toBe(true);
+      if (escapedWrite.isErr()) {
+        expect(escapedWrite.error).toBeInstanceOf(PermissionError);
+      }
+
+      const escapedRename = renameProjectPath(
+        projectDir.value,
+        sourcePath,
+        outsidePath
+      );
+      expect(escapedRename.isErr()).toBe(true);
+      if (escapedRename.isErr()) {
+        expect(escapedRename.error).toBeInstanceOf(PermissionError);
+      }
+
+      const renamed = renameProjectPath(
+        projectDir.value,
+        sourcePath,
+        targetPath
+      );
+      expect(renamed.isOk()).toBe(true);
+      expect(existsSync(sourcePath)).toBe(false);
+      expect(readFileSync(targetPath, 'utf8')).toBe(
+        'export const before = true;\n'
+      );
+      expect(existsSync(outsidePath)).toBe(false);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/apps/trails/src/project-writes.ts
+++ b/apps/trails/src/project-writes.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, renameSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 import {
@@ -105,6 +105,58 @@ export const writeProjectFile = async (
       new InternalError(`Failed to write project file "${relativePath}"`, {
         cause: asError(error),
         context: { projectDir, relativePath },
+      })
+    );
+  }
+};
+
+export const writeProjectPath = async (
+  projectDir: string,
+  filePath: string,
+  content: string | Uint8Array
+): Promise<TrailsResult<string, Error>> => {
+  const target = resolveProjectPath(projectDir, filePath);
+  if (target.isErr()) {
+    return target;
+  }
+
+  try {
+    mkdirSync(dirname(target.value), { recursive: true });
+    await Bun.write(target.value, content);
+    return Result.ok(target.value);
+  } catch (error) {
+    return Result.err(
+      new InternalError(`Failed to write project path "${filePath}"`, {
+        cause: asError(error),
+        context: { filePath, projectDir },
+      })
+    );
+  }
+};
+
+export const renameProjectPath = (
+  projectDir: string,
+  fromPath: string,
+  toPath: string
+): TrailsResult<void, Error> => {
+  const from = resolveProjectPath(projectDir, fromPath);
+  if (from.isErr()) {
+    return Result.err(from.error);
+  }
+
+  const to = resolveProjectPath(projectDir, toPath);
+  if (to.isErr()) {
+    return Result.err(to.error);
+  }
+
+  try {
+    renameSync(from.value, to.value);
+    return Result.ok();
+  } catch (error) {
+    return Result.err(
+      new InternalError(`Failed to rename project path "${fromPath}"`, {
+        cause: asError(error),
+        context: { fromPath, projectDir, toPath },
       })
     );
   }

--- a/apps/trails/src/trails/draft-promote.ts
+++ b/apps/trails/src/trails/draft-promote.ts
@@ -1,5 +1,5 @@
-import { existsSync, renameSync, statSync } from 'node:fs';
-import { basename, dirname, join, relative } from 'node:path';
+import { existsSync, statSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
 
 import {
   Result,
@@ -18,6 +18,7 @@ import {
 } from '@ontrails/warden';
 import { z } from 'zod';
 
+import { renameProjectPath, writeProjectPath } from '../project-writes.js';
 import { loadFreshAppLease } from './load-app.js';
 import { findTopoPath } from './project.js';
 
@@ -240,7 +241,9 @@ const resolveValidatedPromotionRoot = (
     return validation;
   }
 
-  const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
+  const cwd = resolve(ctx.cwd ?? process.cwd());
+  const rootDir =
+    input.rootDir === undefined ? cwd : resolve(cwd, input.rootDir);
   const rootValidation = validatePromotionRoot(rootDir);
   if (rootValidation.isErr()) {
     return rootValidation;
@@ -250,11 +253,12 @@ const resolveValidatedPromotionRoot = (
 };
 
 const rewritePromotedSourceFiles = async (
+  rootDir: string,
   filePaths: readonly string[],
   fromId: string,
   toId: string,
   updatedSourceFiles: Set<string>
-): Promise<void> => {
+): Promise<Result<void, Error>> => {
   for (const filePath of filePaths) {
     const sourceCode = await Bun.file(filePath).text();
     const replaced = replaceIdLiterals(sourceCode, filePath, fromId, toId);
@@ -262,9 +266,18 @@ const rewritePromotedSourceFiles = async (
       continue;
     }
 
-    await Bun.write(filePath, replaced.nextSource);
+    const written = await writeProjectPath(
+      rootDir,
+      filePath,
+      replaced.nextSource
+    );
+    if (written.isErr()) {
+      return Result.err(written.error);
+    }
     updatedSourceFiles.add(filePath);
   }
+
+  return Result.ok();
 };
 
 const hasDraftIdsInFile = async (filePath: string): Promise<boolean> => {
@@ -354,6 +367,7 @@ const collectFileRenames = async (
 };
 
 const collectAndApplyFileRenames = async (
+  rootDir: string,
   filePaths: readonly string[]
 ): Promise<Result<FileRename[], Error>> => {
   const collected = await collectFileRenames(filePaths);
@@ -368,7 +382,10 @@ const collectAndApplyFileRenames = async (
   }
 
   for (const r of renames) {
-    renameSync(r.from, r.to);
+    const renamed = renameProjectPath(rootDir, r.from, r.to);
+    if (renamed.isErr()) {
+      return Result.err(renamed.error);
+    }
   }
   return Result.ok(renames);
 };
@@ -430,33 +447,49 @@ const rewriteRelativeImportsForFile = (
 };
 
 const updateRelativeImportsForFile = async (
+  rootDir: string,
   filePath: string,
   renames: readonly FileRename[]
-): Promise<boolean> => {
+): Promise<Result<boolean, Error>> => {
   const sourceCode = await Bun.file(filePath).text();
   const updated = rewriteRelativeImportsForFile(filePath, renames, sourceCode);
   if (updated.changed) {
-    await Bun.write(filePath, updated.sourceCode);
-    return true;
+    const written = await writeProjectPath(
+      rootDir,
+      filePath,
+      updated.sourceCode
+    );
+    if (written.isErr()) {
+      return Result.err(written.error);
+    }
+    return Result.ok(true);
   }
 
-  return false;
+  return Result.ok(false);
 };
 
 const updateRelativeImports = async (
+  rootDir: string,
   filePaths: readonly string[],
   renames: readonly FileRename[]
-): Promise<string[]> => {
+): Promise<Result<string[], Error>> => {
   const updatedFiles = new Set<string>();
 
   for (const filePath of filePaths) {
-    const changed = await updateRelativeImportsForFile(filePath, renames);
-    if (changed) {
+    const changed = await updateRelativeImportsForFile(
+      rootDir,
+      filePath,
+      renames
+    );
+    if (changed.isErr()) {
+      return Result.err(changed.error);
+    }
+    if (changed.value) {
       updatedFiles.add(filePath);
     }
   }
 
-  return [...updatedFiles].toSorted();
+  return Result.ok([...updatedFiles].toSorted());
 };
 
 const rewritePromotionState = async (
@@ -470,25 +503,35 @@ const rewritePromotionState = async (
   const initialFiles = collectTsFiles(rootDir);
   const updatedSourceFiles = new Set<string>();
 
-  await rewritePromotedSourceFiles(
+  const rewritten = await rewritePromotedSourceFiles(
+    rootDir,
     initialFiles,
     input.fromId,
     input.toId,
     updatedSourceFiles
   );
+  if (rewritten.isErr()) {
+    return Result.err(rewritten.error);
+  }
 
   const renamesResult = input.renameFiles
-    ? await collectAndApplyFileRenames(initialFiles)
+    ? await collectAndApplyFileRenames(rootDir, initialFiles)
     : Result.ok([] as FileRename[]);
   if (renamesResult.isErr()) {
     return Result.err(renamesResult.error);
   }
 
   applyRenameEffects(updatedSourceFiles, renamesResult.value);
-  for (const f of await updateRelativeImports(
+  const importUpdates = await updateRelativeImports(
+    rootDir,
     collectTsFiles(rootDir),
     renamesResult.value
-  )) {
+  );
+  if (importUpdates.isErr()) {
+    return Result.err(importUpdates.error);
+  }
+
+  for (const f of importUpdates.value) {
     updatedSourceFiles.add(f);
   }
   return Result.ok({ renames: renamesResult.value, updatedSourceFiles });


### PR DESCRIPTION
## Context

Completes the second `TRL-553` containment slice after #257. The temporary audit rule still flagged `draft-promote` writes, and the promotion flow also renames files that should be checked under the same project root.

## What Changed

- Extended the project write helper with absolute-path write and rename helpers that still validate against the project root.
- Routed `draft-promote` source rewrites through contained project-path writes.
- Routed draft file renames through contained project-path renames.
- Preserved existing promoted-file reporting by tracking absolute paths internally and rendering relative output paths at the edge.
- Added helper tests for absolute write containment and rename containment.

## Stack

- #256 introduces the temporary warning-mode audit rule.
- #257 contains scaffold/add/surface/verify writes.
- This PR contains `draft-promote` writes and renames.

## Testing

- `bun test apps/trails/src/__tests__/project-writes.test.ts apps/trails/src/__tests__/draft-promote.test.ts`
- `bun run --cwd apps/trails test`
- `bun run --cwd apps/trails typecheck`
- `bun run format:check`
- `bun run check`

## Notes

The temporary audit warning count drops from 11 to 9 on this branch. The remaining findings are in `load-app` and dev/topo support, which are handled by later stack slices.

Closes: TRL-553