### PR TITLE
fix: contain load app mirror writes

### DIFF
--- a/apps/trails/src/__tests__/load-app-mirror.test.ts
+++ b/apps/trails/src/__tests__/load-app-mirror.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { PermissionError, ValidationError } from '@ontrails/core';
+
+import {
+  createLoadAppMirrorRootPath,
+  removeLoadAppMirrorRoot,
+  resolveLoadAppMirrorFilePath,
+  writeLoadAppMirrorFile,
+} from '../load-app-mirror.js';
+
+const tempRoot = (): string =>
+  join(
+    tmpdir(),
+    `trails-load-app-mirror-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}`
+  );
+
+describe('load-app mirror helpers', () => {
+  test('writes source bytes under the load-app mirror root', async () => {
+    const root = tempRoot();
+
+    try {
+      const sourcePath = join(root, 'src', 'app.ts');
+      const mirrorRoot = createLoadAppMirrorRootPath(root);
+      mkdirSync(dirname(sourcePath), { recursive: true });
+      writeFileSync(sourcePath, 'export const app = true;\n');
+
+      const mirrorPath = resolveLoadAppMirrorFilePath(sourcePath, mirrorRoot);
+      expect(mirrorPath.isOk()).toBe(true);
+
+      const written = await writeLoadAppMirrorFile(sourcePath, mirrorRoot);
+      expect(written.isOk()).toBe(true);
+
+      if (written.isErr()) {
+        throw written.error;
+      }
+
+      expect(written.value).toBe(mirrorPath.unwrap());
+      expect(readFileSync(written.value, 'utf8')).toBe(
+        'export const app = true;\n'
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects mirror writes outside load-app mirror roots', async () => {
+    const root = tempRoot();
+
+    try {
+      const sourcePath = join(root, 'src', 'app.ts');
+      const invalidMirrorRoot = join(root, 'not-a-mirror');
+      mkdirSync(dirname(sourcePath), { recursive: true });
+      writeFileSync(sourcePath, 'export const app = true;\n');
+
+      const written = await writeLoadAppMirrorFile(
+        sourcePath,
+        invalidMirrorRoot
+      );
+      expect(written.isErr()).toBe(true);
+      if (written.isErr()) {
+        expect(written.error).toBeInstanceOf(PermissionError);
+      }
+
+      expect(existsSync(invalidMirrorRoot)).toBe(false);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects relative source paths before deriving a mirror target', () => {
+    const root = tempRoot();
+    const mirrorRoot = createLoadAppMirrorRootPath(root);
+
+    const resolved = resolveLoadAppMirrorFilePath('src/app.ts', mirrorRoot);
+
+    expect(resolved.isErr()).toBe(true);
+    if (resolved.isErr()) {
+      expect(resolved.error).toBeInstanceOf(ValidationError);
+    }
+  });
+
+  test('removes only load-app mirror roots', () => {
+    const root = tempRoot();
+
+    try {
+      const mirrorRoot = createLoadAppMirrorRootPath(root);
+      const protectedDir = join(root, 'project');
+      mkdirSync(mirrorRoot, { recursive: true });
+      mkdirSync(protectedDir, { recursive: true });
+
+      const rejected = removeLoadAppMirrorRoot(protectedDir);
+      expect(rejected.isErr()).toBe(true);
+      if (rejected.isErr()) {
+        expect(rejected.error).toBeInstanceOf(PermissionError);
+      }
+      expect(existsSync(protectedDir)).toBe(true);
+
+      const removed = removeLoadAppMirrorRoot(mirrorRoot);
+      expect(removed.isOk()).toBe(true);
+      expect(existsSync(mirrorRoot)).toBe(false);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/trails/src/load-app-mirror.ts
+++ b/apps/trails/src/load-app-mirror.ts
@@ -1,0 +1,156 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  parse as parsePath,
+  relative,
+  resolve,
+} from 'node:path';
+
+import {
+  deriveSafePath,
+  InternalError,
+  PermissionError,
+  Result,
+  ValidationError,
+} from '@ontrails/core';
+// Result is imported as a value for factories above; this alias keeps returned
+// Result types readable without colliding with the value import.
+import type { Result as TrailsResult } from '@ontrails/core';
+
+export const LOAD_APP_MIRROR_PARENT_DIRNAME = '.trails-tmp';
+
+export const LOAD_APP_MIRROR_ENTRY_PREFIX = 'load-app-fresh-';
+
+const asError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const validateMirrorRoot = (
+  mirrorRoot: string
+): TrailsResult<string, PermissionError> => {
+  const resolved = resolve(mirrorRoot);
+  const mirrorParent = dirname(resolved);
+
+  return basename(mirrorParent) === LOAD_APP_MIRROR_PARENT_DIRNAME &&
+    basename(resolved).startsWith(LOAD_APP_MIRROR_ENTRY_PREFIX)
+    ? Result.ok(resolved)
+    : Result.err(
+        new PermissionError(
+          `Refusing to write or remove non-load-app mirror path "${mirrorRoot}"`,
+          { context: { mirrorRoot: resolved } }
+        )
+      );
+};
+
+const resolveAbsoluteSourcePath = (
+  sourcePath: string
+): TrailsResult<string, ValidationError> =>
+  isAbsolute(sourcePath)
+    ? Result.ok(sourcePath)
+    : Result.err(
+        new ValidationError(
+          `Load-app mirror source path must be absolute: "${sourcePath}"`,
+          { context: { sourcePath } }
+        )
+      );
+
+/**
+ * Convert an absolute source path to the deterministic location inside a
+ * load-app fresh mirror.
+ */
+export const resolveLoadAppMirrorFilePath = (
+  sourcePath: string,
+  mirrorRoot: string
+): TrailsResult<string, Error> => {
+  const root = validateMirrorRoot(mirrorRoot);
+  if (root.isErr()) {
+    return root;
+  }
+
+  const source = resolveAbsoluteSourcePath(sourcePath);
+  if (source.isErr()) {
+    return source;
+  }
+
+  const mirrorRelativePath = relative(
+    parsePath(source.value).root,
+    source.value
+  );
+  return deriveSafePath(root.value, mirrorRelativePath);
+};
+
+/**
+ * Copy a source file into its load-app fresh mirror by raw bytes.
+ *
+ * @remarks
+ * Reading via `.bytes()` rather than `.text()` preserves binary payloads
+ * (`.wasm`, `.node`, compiled assets) that may sit alongside source files in
+ * the app's graph. Text decoding would corrupt them on the way through the
+ * mirror.
+ */
+export const writeLoadAppMirrorFile = async (
+  sourcePath: string,
+  mirrorRoot: string
+): Promise<TrailsResult<string, Error>> => {
+  const mirrorPath = resolveLoadAppMirrorFilePath(sourcePath, mirrorRoot);
+  if (mirrorPath.isErr()) {
+    return mirrorPath;
+  }
+
+  try {
+    mkdirSync(dirname(mirrorPath.value), { recursive: true });
+    const bytes = await Bun.file(sourcePath).bytes();
+    await Bun.write(mirrorPath.value, bytes);
+    return Result.ok(mirrorPath.value);
+  } catch (error) {
+    return Result.err(
+      new InternalError(`Failed to mirror load-app file "${sourcePath}"`, {
+        cause: asError(error),
+        context: { mirrorPath: mirrorPath.value, mirrorRoot, sourcePath },
+      })
+    );
+  }
+};
+
+export const removeLoadAppMirrorRoot = (
+  mirrorRoot: string
+): TrailsResult<void, Error> => {
+  const root = validateMirrorRoot(mirrorRoot);
+  if (root.isErr()) {
+    return root;
+  }
+
+  try {
+    rmSync(root.value, { force: true, recursive: true });
+    return Result.ok();
+  } catch (error) {
+    return Result.err(
+      new InternalError(`Failed to remove load-app mirror "${mirrorRoot}"`, {
+        cause: asError(error),
+        context: { mirrorRoot: root.value },
+      })
+    );
+  }
+};
+
+/**
+ * Best-effort cleanup for process-exit and stale-sweep paths.
+ *
+ * This intentionally suppresses validation and filesystem failures because the
+ * caller is already abandoning a temporary mirror and cleanup must not turn
+ * into an application-load failure.
+ */
+export const removeLoadAppMirrorRootQuietly = (mirrorRoot: string): void => {
+  removeLoadAppMirrorRoot(mirrorRoot);
+};
+
+export const createLoadAppMirrorRootPath = (cwd: string): string =>
+  join(
+    cwd,
+    LOAD_APP_MIRROR_PARENT_DIRNAME,
+    `${LOAD_APP_MIRROR_ENTRY_PREFIX}${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}`
+  );

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -1,17 +1,18 @@
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
-import {
-  dirname,
-  extname,
-  isAbsolute,
-  join,
-  parse as parsePath,
-  relative,
-  resolve,
-} from 'node:path';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { dirname, extname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { Topo } from '@ontrails/core';
 import { findAppModule } from '@ontrails/cli';
+
+import {
+  createLoadAppMirrorRootPath,
+  LOAD_APP_MIRROR_ENTRY_PREFIX,
+  LOAD_APP_MIRROR_PARENT_DIRNAME,
+  removeLoadAppMirrorRootQuietly,
+  resolveLoadAppMirrorFilePath,
+  writeLoadAppMirrorFile,
+} from '../load-app-mirror.js';
 
 const URL_SCHEME = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
@@ -58,7 +59,7 @@ const RETAINED_MIRROR_ROOTS = new Set<string>();
 
 const cleanupAllMirrorRoots = (): void => {
   for (const root of [...ACTIVE_MIRROR_ROOTS, ...RETAINED_MIRROR_ROOTS]) {
-    rmSync(root, { force: true, recursive: true });
+    removeLoadAppMirrorRootQuietly(root);
   }
   ACTIVE_MIRROR_ROOTS.clear();
   RETAINED_MIRROR_ROOTS.clear();
@@ -110,7 +111,7 @@ const acquireMirrorLease = (mirrorRoot: string): (() => void) => {
 
     released = true;
     ACTIVE_MIRROR_ROOTS.delete(mirrorRoot);
-    rmSync(mirrorRoot, { force: true, recursive: true });
+    removeLoadAppMirrorRootQuietly(mirrorRoot);
   };
 };
 
@@ -139,19 +140,6 @@ const resolveAbsoluteModulePath = (modulePath: string, cwd: string): string =>
   URL_SCHEME.test(modulePath)
     ? resolveUrlModulePath(modulePath)
     : resolveFilesystemModulePath(modulePath, cwd);
-
-const MIRROR_PARENT_DIRNAME = '.trails-tmp';
-
-const MIRROR_ENTRY_PREFIX = 'load-app-fresh-';
-
-/**
- * Convert an absolute path to a drive-safe relative form before appending it
- * to the mirror root. `path.parse(...).root` returns `'/'` on POSIX and
- * `'C:\\'` (or similar) on Windows, so `relative` strips the platform root
- * in both cases.
- */
-const freshMirrorPath = (absolutePath: string, mirrorRoot: string): string =>
-  join(mirrorRoot, relative(parsePath(absolutePath).root, absolutePath));
 
 const isLocalFilesystemImport = (importPath: string): boolean =>
   importPath.startsWith('.') ||
@@ -192,15 +180,6 @@ const collectImportedModulePaths = (
     .map((importPath) => resolveImportedModulePath(modulePath, importPath));
 };
 
-/**
- * Copy a single file into the mirror by raw bytes.
- *
- * @remarks
- * Reading via `.bytes()` rather than `.text()` preserves binary payloads
- * (`.wasm`, `.node`, compiled assets) that may sit alongside source files in
- * the app's graph. Text decoding would corrupt them on the way through the
- * mirror.
- */
 const copyFileToMirror = async (
   sourcePath: string,
   mirrorRoot: string,
@@ -211,10 +190,10 @@ const copyFileToMirror = async (
   }
   copied.add(sourcePath);
 
-  const mirrorPath = freshMirrorPath(sourcePath, mirrorRoot);
-  mkdirSync(dirname(mirrorPath), { recursive: true });
-  const bytes = await Bun.file(sourcePath).bytes();
-  await Bun.write(mirrorPath, bytes);
+  const written = await writeLoadAppMirrorFile(sourcePath, mirrorRoot);
+  if (written.isErr()) {
+    throw written.error;
+  }
 };
 
 /**
@@ -301,14 +280,11 @@ const isStaleMirrorEntry = (entryPath: string, now: number): boolean => {
 };
 
 const removeStaleMirrorEntry = (entryPath: string): void => {
-  try {
-    rmSync(entryPath, { force: true, recursive: true });
-  } catch {
-    /*
-     * Another concurrent load may own it. Safe to ignore — the next sweep
-     * will retry.
-     */
-  }
+  /*
+   * Another concurrent load may own it. Safe to ignore — the next sweep
+   * will retry.
+   */
+  removeLoadAppMirrorRootQuietly(entryPath);
 };
 
 /**
@@ -322,7 +298,7 @@ const cleanupStaleMirrorRoots = (mirrorParent: string): void => {
   }
   const now = Date.now();
   for (const entry of entries) {
-    if (!entry.startsWith(MIRROR_ENTRY_PREFIX)) {
+    if (!entry.startsWith(LOAD_APP_MIRROR_ENTRY_PREFIX)) {
       continue;
     }
     const entryPath = join(mirrorParent, entry);
@@ -333,12 +309,9 @@ const cleanupStaleMirrorRoots = (mirrorParent: string): void => {
 };
 
 const freshMirrorRootPath = (cwd: string): string => {
-  const mirrorParent = join(cwd, MIRROR_PARENT_DIRNAME);
+  const mirrorParent = join(cwd, LOAD_APP_MIRROR_PARENT_DIRNAME);
   cleanupStaleMirrorRoots(mirrorParent);
-  return join(
-    mirrorParent,
-    `${MIRROR_ENTRY_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2)}`
-  );
+  return createLoadAppMirrorRootPath(cwd);
 };
 
 interface MirrorWalkContext {
@@ -429,7 +402,11 @@ const mirrorFreshImportGraph = async (
   };
 
   await visit(entryPath);
-  return freshMirrorPath(entryPath, mirrorRoot);
+  const freshPath = resolveLoadAppMirrorFilePath(entryPath, mirrorRoot);
+  if (freshPath.isErr()) {
+    throw freshPath.error;
+  }
+  return freshPath.value;
 };
 
 /**
@@ -461,7 +438,7 @@ const prepareMirror = async (
     const freshPath = await mirrorFreshImportGraph(absolutePath, mirrorRoot);
     return { freshPath, mirrorRoot };
   } catch (error) {
-    rmSync(mirrorRoot, { force: true, recursive: true });
+    removeLoadAppMirrorRootQuietly(mirrorRoot);
     throw error;
   }
 };


### PR DESCRIPTION
## Context

Continues `TRL-554` on top of #258. Before enforcing the load-app trust boundary, the temporary `TRL-575` audit still flagged six direct write/delete calls in `apps/trails/src/trails/load-app.ts` for fresh import mirror creation and cleanup.

## What Changed

- Added a load-app mirror helper that validates mirror roots use `.trails-tmp/load-app-fresh-*` before writing or removing paths.
- Routed fresh import mirror file writes and lifecycle cleanup through the helper while preserving byte-level copy behavior.
- Added helper coverage for valid mirror writes, invalid mirror roots, relative source rejection, and mirror-only removal.

## Stack

- #256 temporary framework write audit rule.
- #257 scaffold project writes.
- #258 draft promote writes.
- This PR contains the load-app mirror write containment needed before the trust-boundary enforcement in #261.

## Testing

- `bun test apps/trails/src/__tests__/load-app.test.ts apps/trails/src/__tests__/load-app-mirror.test.ts`
- `bun run --cwd apps/trails test`
- `bun run --cwd apps/trails typecheck`
- `bun run format:check`
- `bun run check`

## Notes

Temporary audit warnings drop from 9 to 3 on this branch. Remaining findings are `dev-support.ts` and `topo-support.ts`, handled by #260.

Closes: TRL-554