### PR TITLE
fix: contain dev topo local state writes

### DIFF
--- a/apps/trails/src/__tests__/local-state-io.test.ts
+++ b/apps/trails/src/__tests__/local-state-io.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+
+import { PermissionError, ValidationError } from '@ontrails/core';
+
+import {
+  createIsolatedExampleRoot,
+  removeRootRelativeFileIfPresent,
+} from '../local-state-io.js';
+
+const tempRoot = (): string =>
+  join(
+    tmpdir(),
+    `trails-local-state-io-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+
+describe('local state I/O helpers', () => {
+  test('removes root-relative files without escaping the root', () => {
+    const root = tempRoot();
+
+    try {
+      const relativePath = '.trails/trails.db';
+      const targetPath = join(root, relativePath);
+      const outsideName = `${basename(root)}-outside.db`;
+      const outsidePath = join(dirname(root), outsideName);
+      mkdirSync(dirname(targetPath), { recursive: true });
+      writeFileSync(targetPath, '');
+      writeFileSync(outsidePath, '');
+
+      const removed = removeRootRelativeFileIfPresent(root, relativePath);
+      expect(removed.isOk()).toBe(true);
+      if (removed.isErr()) {
+        throw removed.error;
+      }
+      expect(removed.value).toBe(true);
+      expect(existsSync(targetPath)).toBe(false);
+
+      const missing = removeRootRelativeFileIfPresent(root, relativePath);
+      expect(missing.isOk()).toBe(true);
+      if (missing.isErr()) {
+        throw missing.error;
+      }
+      expect(missing.value).toBe(false);
+
+      const escaped = removeRootRelativeFileIfPresent(
+        root,
+        `../${outsideName}`
+      );
+      expect(escaped.isErr()).toBe(true);
+      if (escaped.isErr()) {
+        expect(escaped.error).toBeInstanceOf(PermissionError);
+      }
+      expect(existsSync(outsidePath)).toBe(true);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+      rmSync(join(dirname(root), `${basename(root)}-outside.db`), {
+        force: true,
+      });
+    }
+  });
+
+  test('recreates isolated example roots with constrained names', () => {
+    const name = `local-state-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}`;
+    const root = createIsolatedExampleRoot(name);
+    const markerPath = join(root, 'marker.txt');
+
+    try {
+      writeFileSync(markerPath, 'stale');
+      const recreated = createIsolatedExampleRoot(name);
+
+      expect(recreated).toBe(root);
+      expect(existsSync(root)).toBe(true);
+      expect(existsSync(markerPath)).toBe(false);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects path-shaped isolated example names', () => {
+    expect(() => createIsolatedExampleRoot('../outside')).toThrow(
+      ValidationError
+    );
+  });
+});

--- a/apps/trails/src/local-state-io.ts
+++ b/apps/trails/src/local-state-io.ts
@@ -1,0 +1,74 @@
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  deriveSafePath,
+  InternalError,
+  Result,
+  ValidationError,
+} from '@ontrails/core';
+import type { Result as TrailsResult } from '@ontrails/core';
+
+const EXAMPLE_ROOT_PARENT = join(tmpdir(), 'ontrails-trails-examples');
+const EXAMPLE_ROOT_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/u;
+
+const asError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const resolveExampleRoot = (name: string): TrailsResult<string, Error> => {
+  if (!EXAMPLE_ROOT_NAME_PATTERN.test(name)) {
+    return Result.err(
+      new ValidationError(
+        'Example root name must be lowercase and contain only letters, digits, ".", "_", or "-".',
+        { context: { name } }
+      )
+    );
+  }
+
+  return deriveSafePath(EXAMPLE_ROOT_PARENT, name);
+};
+
+export const createIsolatedExampleRoot = (name: string): string => {
+  const root = resolveExampleRoot(name);
+  if (root.isErr()) {
+    throw root.error;
+  }
+
+  try {
+    rmSync(root.value, { force: true, recursive: true });
+    mkdirSync(root.value, { recursive: true });
+    return root.value;
+  } catch (error) {
+    throw new InternalError(`Failed to recreate example root "${name}"`, {
+      cause: asError(error),
+      context: { name, rootDir: root.value },
+    });
+  }
+};
+
+export const removeRootRelativeFileIfPresent = (
+  rootDir: string,
+  relativePath: string
+): TrailsResult<boolean, Error> => {
+  const target = deriveSafePath(rootDir, relativePath);
+  if (target.isErr()) {
+    return target;
+  }
+
+  if (!existsSync(target.value)) {
+    return Result.ok(false);
+  }
+
+  try {
+    rmSync(target.value, { force: true });
+    return Result.ok(true);
+  } catch (error) {
+    return Result.err(
+      new InternalError(`Failed to remove local state file "${relativePath}"`, {
+        cause: asError(error),
+        context: { relativePath, rootDir, targetPath: target.value },
+      })
+    );
+  }
+};

--- a/apps/trails/src/trails/dev-support.ts
+++ b/apps/trails/src/trails/dev-support.ts
@@ -1,4 +1,4 @@
-import { existsSync, rmSync, statSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
@@ -21,16 +21,21 @@ import {
   previewTraceCleanup,
 } from '@ontrails/tracing/internal/dev-state';
 
+import { removeRootRelativeFileIfPresent } from '../local-state-io.js';
+
 export const DEFAULT_TOPO_SNAPSHOT_RETENTION = 50;
 
 const deriveRootDir = (cwd?: string): string => cwd ?? process.cwd();
 
-const removeIfPresent = (filePath: string): boolean => {
-  if (!existsSync(filePath)) {
-    return false;
+const removeResetFileIfPresent = (
+  rootDir: string,
+  relativePath: string
+): boolean => {
+  const removed = removeRootRelativeFileIfPresent(rootDir, relativePath);
+  if (removed.isErr()) {
+    throw removed.error;
   }
-  rmSync(filePath, { force: true });
-  return true;
+  return removed.value;
 };
 
 export interface DevStatsReport {
@@ -317,7 +322,7 @@ export const resetDevState = (options?: {
   }
 
   const removedFiles = files.filter((relativePath) =>
-    removeIfPresent(join(rootDir, relativePath))
+    removeResetFileIfPresent(rootDir, relativePath)
   );
 
   return {

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -1,6 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -12,6 +10,8 @@ import {
 import type { Topo, TopoSnapshot } from '@ontrails/core';
 import { deriveTrailsDbPath } from '@ontrails/core/internal/trails-db';
 import { z } from 'zod';
+
+import { createIsolatedExampleRoot } from '../local-state-io.js';
 
 import type { BriefReport, SurveyListReport } from './topo-reports.js';
 
@@ -137,9 +137,7 @@ const buildSnapshotInput = (
 export const createIsolatedExampleInput = (
   name: string
 ): { readonly module: string; readonly rootDir: string } => {
-  const rootDir = join(tmpdir(), 'ontrails-trails-examples', name);
-  rmSync(rootDir, { force: true, recursive: true });
-  mkdirSync(rootDir, { recursive: true });
+  const rootDir = createIsolatedExampleRoot(name);
   return {
     module: EXAMPLE_APP_MODULE,
     rootDir,


### PR DESCRIPTION
## Context

Final cleanup branch for the temporary `TRL-575` direct framework write audit rule. After #259, only three warnings remained: known local state deletes in `dev-support.ts` and example temp-dir recreation in `topo-support.ts`.

## What Changed

- Added a local-state I/O helper outside `src/trails/` for contained root-relative file removal and isolated example root recreation.
- Routed `dev.reset` local database artifact removal through the helper while preserving the existing report shape.
- Routed topo/dev example fixture root recreation through the helper with constrained example names.
- Added helper coverage for root escape rejection, stale example root recreation, and invalid example names.

## Stack

- #256 temporary framework write audit rule.
- #257 scaffold project writes.
- #258 draft promote writes.
- #259 load-app mirror writes.
- This PR burns down the final warnings from the temporary audit rule.

## Testing

- `bun test apps/trails/src/__tests__/local-state-io.test.ts apps/trails/src/__tests__/topo-dev.test.ts`
- `bun test apps/trails/src/__tests__/local-state-io.test.ts`
- `bun run --cwd apps/trails test`
- `bun run --cwd apps/trails typecheck`
- `bun run format:check`
- `bun run check`

## Notes

The temporary `temp-audit-direct-framework-writes` rule reports zero warnings in `bun run check` on this branch.

Closes: TRL-575