### PR TITLE
fix: enforce load app trust boundary

### DIFF
--- a/apps/trails/src/__tests__/load-app.test.ts
+++ b/apps/trails/src/__tests__/load-app.test.ts
@@ -5,11 +5,15 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   utimesSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { PermissionError } from '@ontrails/core';
 
 import { loadApp, loadFreshAppLease } from '../trails/load-app.js';
 
@@ -230,6 +234,109 @@ describe('loadApp', () => {
     expect(app.get('survey')).toBeDefined();
   });
 
+  test('auto-discovers a workspace-relative module under the default trust boundary', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-discovery-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      writeLoadAppFixture(cwd, 'discovered');
+
+      const app = await loadApp(undefined, cwd);
+      expect(app.name).toBe('discovered');
+
+      const lease = await loadFreshAppLease(undefined, cwd);
+      try {
+        expect(lease.app.name).toBe('discovered');
+      } finally {
+        lease.release();
+      }
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects app module paths outside the default trust boundary', async () => {
+    const root = resolve(
+      tmpdir(),
+      `trails-load-app-boundary-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+    const cwd = resolve(root, 'workspace');
+    const outside = resolve(root, 'outside');
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      mkdirSync(resolve(outside, 'src'), { recursive: true });
+      writeLoadAppFixture(cwd, 'inside');
+      writeFileSync(
+        resolve(outside, 'src/app.ts'),
+        `export const app = {
+  name: 'outside',
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};`
+      );
+
+      await expect(loadApp(resolve(cwd, 'src/app.ts'), cwd)).rejects.toThrow(
+        PermissionError
+      );
+      await expect(
+        loadApp(pathToFileURL(resolve(cwd, 'src/app.ts')).href, cwd)
+      ).rejects.toThrow(PermissionError);
+      await expect(loadApp('../outside/src/app.ts', cwd)).rejects.toThrow(
+        PermissionError
+      );
+
+      const trustedAbsolute = await loadApp(resolve(cwd, 'src/app.ts'), cwd, {
+        trustedModulePath: true,
+      });
+      const trustedParentEscape = await loadApp('../outside/src/app.ts', cwd, {
+        trustedModulePath: true,
+      });
+
+      expect(trustedAbsolute.name).toBe('inside');
+      expect(trustedParentEscape.name).toBe('outside');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects symlink escapes outside the default trust boundary', async () => {
+    const root = resolve(
+      tmpdir(),
+      `trails-load-app-symlink-boundary-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+    const cwd = resolve(root, 'workspace');
+    const outside = resolve(root, 'outside');
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      mkdirSync(resolve(outside, 'src'), { recursive: true });
+      writeLoadAppFixture(outside, 'outside-symlink');
+      symlinkSync(outside, resolve(cwd, 'src/linked-outside'), 'dir');
+
+      await expect(
+        loadApp('./src/linked-outside/src/app.ts', cwd)
+      ).rejects.toThrow(PermissionError);
+
+      const trusted = await loadApp('./src/linked-outside/src/app.ts', cwd, {
+        trustedModulePath: true,
+      });
+      expect(trusted.name).toBe('outside-symlink');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test('can bypass module caching with fresh loading', async () => {
     const cwd = resolve(
       tmpdir(),
@@ -368,6 +475,47 @@ describe('loadApp fresh lifecycle', () => {
       expect(existsSync(lease.mirrorRoot)).toBe(false);
     } finally {
       rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('leased fresh loads use the same default trust boundary', async () => {
+    const root = resolve(
+      tmpdir(),
+      `trails-load-app-lease-boundary-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+    const cwd = resolve(root, 'workspace');
+    const outside = resolve(root, 'outside');
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      mkdirSync(resolve(outside, 'src'), { recursive: true });
+      writeLoadAppFixture(cwd, 'inside-lease');
+      writeFileSync(
+        resolve(outside, 'src/app.ts'),
+        `export const app = {
+  name: 'outside-lease',
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};`
+      );
+
+      await expect(
+        loadFreshAppLease('../outside/src/app.ts', cwd)
+      ).rejects.toThrow(PermissionError);
+
+      const lease = await loadFreshAppLease('../outside/src/app.ts', cwd, {
+        trustedModulePath: true,
+      });
+      try {
+        expect(lease.app.name).toBe('outside-lease');
+      } finally {
+        lease.release();
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
     }
   });
 

--- a/apps/trails/src/__tests__/local-state-io.test.ts
+++ b/apps/trails/src/__tests__/local-state-io.test.ts
@@ -8,6 +8,7 @@ import { PermissionError, ValidationError } from '@ontrails/core';
 import {
   createIsolatedExampleRoot,
   removeRootRelativeFileIfPresent,
+  writeIsolatedExampleAppModule,
 } from '../local-state-io.js';
 
 const tempRoot = (): string =>
@@ -84,5 +85,17 @@ describe('local state I/O helpers', () => {
     expect(() => createIsolatedExampleRoot('../outside')).toThrow(
       ValidationError
     );
+  });
+
+  test('requires absolute source modules for isolated example app wrappers', () => {
+    const root = tempRoot();
+
+    try {
+      expect(() => writeIsolatedExampleAppModule(root, 'src/app.ts')).toThrow(
+        ValidationError
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
   });
 });

--- a/apps/trails/src/local-state-io.ts
+++ b/apps/trails/src/local-state-io.ts
@@ -1,6 +1,7 @@
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import {
   deriveSafePath,
@@ -43,6 +44,40 @@ export const createIsolatedExampleRoot = (name: string): string => {
     throw new InternalError(`Failed to recreate example root "${name}"`, {
       cause: asError(error),
       context: { name, rootDir: root.value },
+    });
+  }
+};
+
+export const writeIsolatedExampleAppModule = (
+  rootDir: string,
+  sourceModulePath: string
+): string => {
+  if (!isAbsolute(sourceModulePath)) {
+    throw new ValidationError(
+      'Example app source module path must be absolute.',
+      {
+        context: { rootDir, sourceModulePath },
+      }
+    );
+  }
+
+  const modulePath = './src/app.ts';
+  const target = deriveSafePath(rootDir, modulePath);
+  if (target.isErr()) {
+    throw target.error;
+  }
+
+  try {
+    mkdirSync(dirname(target.value), { recursive: true });
+    writeFileSync(
+      target.value,
+      `export { app } from ${JSON.stringify(pathToFileURL(sourceModulePath).href)};\n`
+    );
+    return modulePath;
+  } catch (error) {
+    throw new InternalError('Failed to write isolated example app module', {
+      cause: asError(error),
+      context: { rootDir, sourceModulePath, targetPath: target.value },
     });
   }
 };

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -1,7 +1,15 @@
-import { existsSync, readdirSync, statSync } from 'node:fs';
-import { dirname, extname, isAbsolute, join, resolve } from 'node:path';
+import { existsSync, readdirSync, realpathSync, statSync } from 'node:fs';
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { deriveSafePath, PermissionError } from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 import { findAppModule } from '@ontrails/cli';
 
@@ -135,11 +143,97 @@ const resolveFilesystemModulePath = (
   return existsSync(tsPath) ? tsPath : absolutePath;
 };
 
-/** Resolve a module path from cwd so CLI defaults behave like shell paths. */
-const resolveAbsoluteModulePath = (modulePath: string, cwd: string): string =>
+const trustBoundaryError = (reason: string): PermissionError =>
+  new PermissionError(
+    `Refusing to load an app module outside the workspace trust boundary (${reason}). Use a workspace-relative module path, or pass trustedModulePath: true from trusted code.`
+  );
+
+const isPathInside = (root: string, target: string): boolean => {
+  const candidate = relative(root, target);
+  return (
+    candidate === '' || (!candidate.startsWith('..') && !isAbsolute(candidate))
+  );
+};
+
+const realpathIfPresent = (path: string): string | undefined => {
+  try {
+    return realpathSync(path);
+  } catch {
+    return undefined;
+  }
+};
+
+const ensureRealPathInsideCwd = (
+  resolvedModulePath: string,
+  cwd: string
+): string => {
+  const realRoot = realpathIfPresent(cwd);
+  const realModule = realpathIfPresent(resolvedModulePath);
+  if (
+    realRoot !== undefined &&
+    realModule !== undefined &&
+    !isPathInside(realRoot, realModule)
+  ) {
+    throw trustBoundaryError('symlink_escape');
+  }
+
+  return resolvedModulePath;
+};
+
+/** Resolve a caller-trusted module path using the legacy escape hatch policy. */
+const resolveTrustedModulePath = (modulePath: string, cwd: string): string =>
   URL_SCHEME.test(modulePath)
     ? resolveUrlModulePath(modulePath)
     : resolveFilesystemModulePath(modulePath, cwd);
+
+/**
+ * Resolve the default app module path inside cwd.
+ *
+ * @remarks
+ * CLI and trail callers accept user-supplied module specifiers, so the default
+ * policy is deliberately narrower than `import()` itself: no URL schemes, no
+ * absolute paths, and no parent traversal. Internal callers that intentionally
+ * load a path outside cwd must opt into `trustedModulePath`.
+ */
+const resolveContainedModulePath = (
+  modulePath: string,
+  cwd: string
+): string => {
+  if (URL_SCHEME.test(modulePath)) {
+    throw trustBoundaryError('url_scheme');
+  }
+  if (isAbsolute(modulePath)) {
+    throw trustBoundaryError('absolute_path');
+  }
+
+  const safePath = deriveSafePath(cwd, modulePath);
+  if (safePath.isErr()) {
+    throw trustBoundaryError('parent_escape');
+  }
+
+  return ensureRealPathInsideCwd(
+    resolveFilesystemModulePath(safePath.value, cwd),
+    cwd
+  );
+};
+
+interface LoadAppTrustOptions {
+  readonly trustedModulePath?: boolean | undefined;
+}
+
+const resolveLoadAppModulePath = (
+  modulePath: string,
+  cwd: string,
+  options: LoadAppTrustOptions = {}
+): string =>
+  options.trustedModulePath === true
+    ? resolveTrustedModulePath(modulePath, cwd)
+    : resolveContainedModulePath(modulePath, cwd);
+
+const findWorkspaceRelativeAppModule = (cwd: string): string => {
+  const discovered = findAppModule(cwd);
+  return isAbsolute(discovered) ? relative(cwd, discovered) : discovered;
+};
 
 const isLocalFilesystemImport = (importPath: string): boolean =>
   importPath.startsWith('.') ||
@@ -444,10 +538,10 @@ const prepareMirror = async (
 };
 
 const importFreshModule = async (
-  modulePath: string,
+  resolvedModulePath: string,
   cwd: string
 ): Promise<Record<string, unknown>> => {
-  const absolutePath = resolveAbsoluteModulePath(modulePath, cwd);
+  const absolutePath = resolvedModulePath;
   if (URL_SCHEME.test(absolutePath) && !absolutePath.startsWith('/')) {
     return await importWithCacheBust(absolutePath);
   }
@@ -480,6 +574,12 @@ export interface FreshAppLease {
   readonly app: Topo;
   readonly mirrorRoot: string;
   readonly release: () => void;
+}
+
+export type LoadAppLeaseOptions = LoadAppTrustOptions;
+
+export interface LoadAppOptions extends LoadAppTrustOptions {
+  readonly fresh?: boolean | undefined;
 }
 
 const noopRelease = (): void => undefined;
@@ -523,26 +623,39 @@ const createFilesystemLease = async (
 
 export const loadFreshAppLease = async (
   modulePath: string | undefined,
-  cwd: string
+  cwd: string,
+  options: LoadAppLeaseOptions = {}
 ): Promise<FreshAppLease> => {
   const effectivePath =
-    modulePath === undefined ? findAppModule(cwd) : modulePath;
-  const absolutePath = resolveAbsoluteModulePath(effectivePath, cwd);
+    modulePath === undefined ? findWorkspaceRelativeAppModule(cwd) : modulePath;
+  const absolutePath = resolveLoadAppModulePath(effectivePath, cwd, options);
 
   return URL_SCHEME.test(absolutePath) && !absolutePath.startsWith('/')
     ? await createUrlSchemeLease(absolutePath, effectivePath)
     : await createFilesystemLease(absolutePath, cwd, effectivePath);
 };
 
-/** Load a Topo export from a module path relative to cwd. */
+/**
+ * Load a Topo export from a module path relative to cwd.
+ *
+ * @remarks
+ * By default, `modulePath` must be workspace-relative and stay under `cwd`.
+ * URL-shaped, absolute, and parent-escape paths are rejected. Trusted internal
+ * callers can pass `trustedModulePath: true` to deliberately use the broader
+ * dynamic-import escape hatch.
+ */
 export const loadApp = async (
   modulePath: string | undefined,
   cwd: string,
-  options: { fresh?: boolean | undefined } = {}
+  options: LoadAppOptions = {}
 ): Promise<Topo> => {
   const effectivePath =
-    modulePath === undefined ? findAppModule(cwd) : modulePath;
-  const resolvedModulePath = resolveAbsoluteModulePath(effectivePath, cwd);
+    modulePath === undefined ? findWorkspaceRelativeAppModule(cwd) : modulePath;
+  const resolvedModulePath = resolveLoadAppModulePath(
+    effectivePath,
+    cwd,
+    options
+  );
   const mod =
     options.fresh === true
       ? await importFreshModule(resolvedModulePath, cwd)

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -11,7 +11,10 @@ import type { Topo, TopoSnapshot } from '@ontrails/core';
 import { deriveTrailsDbPath } from '@ontrails/core/internal/trails-db';
 import { z } from 'zod';
 
-import { createIsolatedExampleRoot } from '../local-state-io.js';
+import {
+  createIsolatedExampleRoot,
+  writeIsolatedExampleAppModule,
+} from '../local-state-io.js';
 
 import type { BriefReport, SurveyListReport } from './topo-reports.js';
 
@@ -139,7 +142,7 @@ export const createIsolatedExampleInput = (
 ): { readonly module: string; readonly rootDir: string } => {
   const rootDir = createIsolatedExampleRoot(name);
   return {
-    module: EXAMPLE_APP_MODULE,
+    module: writeIsolatedExampleAppModule(rootDir, EXAMPLE_APP_MODULE),
     rootDir,
   };
 };

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -314,6 +314,8 @@ The `trails` CLI commands (`topo`, `survey`, `guide`, etc.) automatically discov
 
 If multiple candidates are found, the CLI exits with an error listing them; pass `--module` to specify which one to use.
 
+`--module` is workspace-relative by default. The Trails CLI rejects URL-shaped paths, absolute paths, and `..` paths that escape the selected workspace root. Framework code that deliberately loads an app module outside that boundary must opt into `trustedModulePath: true` when calling `loadApp` or `loadFreshAppLease`.
+
 ## What's Next
 
 - [Architecture](./architecture.md) -- How the hexagonal model works


### PR DESCRIPTION
## Context

Completes the `TRL-554` load-app trust-boundary behavior after the mirror containment prep in #259 and the audit cleanup in #260. Default CLI/app loading previously accepted absolute, URL-shaped, and parent-escape module specifiers that reached dynamic import.

## What Changed

- Added default workspace-contained module resolution for `loadApp` and `loadFreshAppLease`.
- Rejected URL-shaped, absolute, and parent-escape entry module specifiers unless trusted code passes `trustedModulePath: true`.
- Kept the trusted escape hatch explicit for internal callers that deliberately load outside the workspace.
- Updated isolated trail examples to use a workspace-relative shim module instead of absolute example module paths.
- Documented the `--module` boundary in `docs/getting-started.md`.

## Stack

- #256 temporary framework write audit rule.
- #257 scaffold project writes.
- #258 draft promote writes.
- #259 load-app mirror writes.
- #260 dev/topo local state writes.
- This PR enforces the default load-app trust boundary.

## Testing

- `bun test apps/trails/src/__tests__/load-app.test.ts`
- `bun test apps/trails/src/__tests__/load-app.test.ts apps/trails/src/__tests__/topo-dev.test.ts`
- `bun run --cwd apps/trails test`
- `bun run --cwd apps/trails typecheck`
- `bun run check`

## Notes

The temporary direct framework write audit remains at zero warnings on this branch, and the default `--module` path is now workspace-relative unless trusted code opts into the escape hatch.

Closes: TRL-554