### PR TITLE
fix: harden jwt claim validation

### DIFF
--- a/.changeset/jwt-claim-boundary-hardening.md
+++ b/.changeset/jwt-claim-boundary-hardening.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/permits": patch
+---
+
+Harden JWT permit validation by requiring `exp` by default, validating the
+header algorithm allowlist before signature verification, and enforcing finite
+clock skew for `exp` and `nbf` checks.

--- a/packages/permits/src/__tests__/connector.test.ts
+++ b/packages/permits/src/__tests__/connector.test.ts
@@ -6,6 +6,7 @@ import type { AuthConnector, AuthError } from '../connectors/connector.js';
 import type { PermitExtractionInput } from '../extraction.js';
 import type { Permit } from '../permit.js';
 import { createJwtConnector } from '../connectors/jwt.js';
+import type { JwtAlgorithm } from '../connectors/jwt.js';
 
 // ---------------------------------------------------------------------------
 // Test helper: sign a JWT with HMAC-SHA256 using crypto.subtle
@@ -28,12 +29,15 @@ const base64urlEncode = (str: string): string => {
   return base64url(encoder.encode(str).buffer as ArrayBuffer);
 };
 
-const signJwt = async (
-  payload: Record<string, unknown>,
-  secret: string
+const signJwtPayload = async (
+  payloadJson: string,
+  secret: string,
+  headerOverrides?: Record<string, unknown>
 ): Promise<string> => {
-  const header = base64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
-  const body = base64urlEncode(JSON.stringify(payload));
+  const header = base64urlEncode(
+    JSON.stringify({ alg: 'HS256', typ: 'JWT', ...headerOverrides })
+  );
+  const body = base64urlEncode(payloadJson);
   const data = `${header}.${body}`;
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
@@ -46,6 +50,13 @@ const signJwt = async (
   const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(data));
   return `${data}.${base64url(sig)}`;
 };
+
+const signJwt = (
+  payload: Record<string, unknown>,
+  secret: string,
+  headerOverrides?: Record<string, unknown>
+): Promise<string> =>
+  signJwtPayload(JSON.stringify(payload), secret, headerOverrides);
 
 const TEST_SECRET = 'test-secret-for-hmac-256';
 
@@ -113,6 +124,176 @@ describe('createJwtConnector', () => {
     expect(err.code).toBe('expired_token');
   });
 
+  test('accepts an exp just inside the default clock skew', async () => {
+    const connector = createJwtConnector({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now - 30, sub: 'user-skew-exp' },
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  test('rejects expired tokens when clock skew is non-finite', async () => {
+    const connector = createJwtConnector({
+      clockSkewSeconds: Number.NaN,
+      secret: TEST_SECRET,
+    });
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signJwt(
+      { exp: past, sub: 'user-nan-skew-exp' },
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('expired_token');
+  });
+
+  test('uses the default clock skew when configured skew is non-finite', async () => {
+    const connector = createJwtConnector({
+      clockSkewSeconds: Number.NaN,
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now - 30, nbf: now + 30, sub: 'user-nan-skew-default' },
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  test('rejects tokens missing an expiration claim by default', async () => {
+    const connector = createJwtConnector({ secret: TEST_SECRET });
+    const token = await signJwt({ sub: 'user-no-exp' }, TEST_SECRET);
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Missing expiration claim');
+  });
+
+  test('allows missing expiration only when explicitly configured', async () => {
+    const connector = createJwtConnector({
+      requireExpiration: false,
+      secret: TEST_SECRET,
+    });
+    const token = await signJwt({ sub: 'user-no-exp-allowed' }, TEST_SECRET);
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+    const permit = result.unwrap() as Permit;
+    expect(permit.id).toBe('user-no-exp-allowed');
+  });
+
+  test('rejects expired tokens even when expiration is optional', async () => {
+    const connector = createJwtConnector({
+      requireExpiration: false,
+      secret: TEST_SECRET,
+    });
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signJwt(
+      { exp: past, sub: 'user-expired-optional' },
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('expired_token');
+  });
+
+  test('rejects non-finite expiration claims', async () => {
+    const connector = createJwtConnector({ secret: TEST_SECRET });
+    const token = await signJwtPayload(
+      '{"exp":1e9999,"sub":"user-infinite-exp"}',
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Invalid expiration claim');
+  });
+
+  test('rejects tokens before nbf outside clock skew', async () => {
+    const connector = createJwtConnector({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, nbf: now + 120, sub: 'user-future' },
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('not valid yet');
+  });
+
+  test('rejects non-finite not-before claims', async () => {
+    const connector = createJwtConnector({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwtPayload(
+      `{"exp":${now + 3600},"nbf":1e9999,"sub":"user-infinite-nbf"}`,
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Invalid not-before claim');
+  });
+
+  test('accepts nbf inside the default clock skew', async () => {
+    const connector = createJwtConnector({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, nbf: now + 30, sub: 'user-future-skew' },
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  test('rejects future nbf claims when clock skew is non-finite', async () => {
+    const connector = createJwtConnector({
+      clockSkewSeconds: Number.NaN,
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, nbf: now + 120, sub: 'user-nan-skew-nbf' },
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('not valid yet');
+  });
+
   test('rejects an invalid signature', async () => {
     const connector = createJwtConnector({ secret: TEST_SECRET });
     const now = Math.floor(Date.now() / 1000);
@@ -126,6 +307,96 @@ describe('createJwtConnector', () => {
     expect(result.isErr()).toBe(true);
     const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
     expect(err.code).toBe('invalid_token');
+  });
+
+  test('rejects tokens with missing alg headers', async () => {
+    const connector = createJwtConnector({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-no-alg' },
+      TEST_SECRET,
+      { alg: undefined }
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Missing JWT alg');
+  });
+
+  test('rejects tokens with unexpected alg headers', async () => {
+    const connector = createJwtConnector({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-wrong-alg' },
+      TEST_SECRET,
+      { alg: 'HS512' }
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Unsupported JWT alg');
+  });
+
+  test('reports an empty algorithm allowlist as connector misconfiguration', async () => {
+    const connector = createJwtConnector({
+      allowedAlgorithms: [],
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-empty-alg-list' },
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('allowedAlgorithms');
+  });
+
+  test('rejects unsupported runtime algorithms even when config is malformed', async () => {
+    const connector = createJwtConnector({
+      allowedAlgorithms: ['HS512' as JwtAlgorithm],
+      secret: TEST_SECRET,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-configured-unsupported-alg' },
+      TEST_SECRET,
+      { alg: 'HS512' }
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Unsupported JWT alg');
+  });
+
+  test('rejects tokens with alg none headers', async () => {
+    const connector = createJwtConnector({ secret: TEST_SECRET });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, sub: 'user-none-alg' },
+      TEST_SECRET,
+      { alg: 'none' }
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Unsupported JWT alg');
   });
 
   test('rejects tokens with a missing subject claim', async () => {

--- a/packages/permits/src/connectors/jwt.ts
+++ b/packages/permits/src/connectors/jwt.ts
@@ -6,8 +6,14 @@ import type { Permit } from '../permit.js';
 
 /** Configuration for the JWT auth connector. */
 export interface JwtConnectorOptions {
+  /** Accepted JWT header algorithms (default: ['HS256']). */
+  readonly allowedAlgorithms?: readonly JwtAlgorithm[];
+  /** Clock skew tolerated for exp/nbf checks, in seconds (default: 60). */
+  readonly clockSkewSeconds?: number;
   /** HMAC secret for HS256 verification. */
   readonly secret?: string;
+  /** Whether accepted tokens must include exp (default: true). */
+  readonly requireExpiration?: boolean;
   /** JWKS endpoint for RS256/ES256 (not yet implemented). */
   readonly jwksUrl?: string;
   /** Expected issuer claim. */
@@ -20,18 +26,36 @@ export interface JwtConnectorOptions {
   readonly rolesClaim?: string;
 }
 
+/** JWT algorithms this connector can verify today. */
+export type JwtAlgorithm = 'HS256';
+
+interface JwtHeader {
+  readonly alg?: unknown;
+  readonly typ?: unknown;
+  readonly [key: string]: unknown;
+}
+
 /** JWT payload with standard claims. */
 interface JwtPayload {
   readonly sub?: string;
   readonly iss?: string;
   readonly aud?: string | readonly string[];
   readonly exp?: number;
+  readonly nbf?: number;
   readonly [key: string]: unknown;
 }
 
 // ---------------------------------------------------------------------------
 // Helpers (defined before callers)
 // ---------------------------------------------------------------------------
+
+const DEFAULT_ALLOWED_ALGORITHMS = [
+  'HS256',
+] as const satisfies readonly JwtAlgorithm[];
+const SUPPORTED_JWT_ALGORITHMS = [
+  'HS256',
+] as const satisfies readonly JwtAlgorithm[];
+const DEFAULT_CLOCK_SKEW_SECONDS = 60;
 
 const authErr = (
   code: AuthError['code'],
@@ -52,18 +76,64 @@ const base64urlDecode = (input: string): Uint8Array => {
   return bytes;
 };
 
-/** Decode a JWT payload without verifying the signature. */
-const decodePayload = (token: string): JwtPayload | undefined => {
+const splitToken = (
+  token: string
+): readonly [string, string, string] | undefined => {
   const parts = token.split('.');
   if (parts.length !== 3) {
     return undefined;
   }
+  return [parts[0] ?? '', parts[1] ?? '', parts[2] ?? ''];
+};
+
+const decodeJsonPart = <T>(part: string): T | undefined => {
   try {
-    const json = new TextDecoder().decode(base64urlDecode(parts[1] ?? ''));
-    return JSON.parse(json) as JwtPayload;
+    const json = new TextDecoder().decode(base64urlDecode(part));
+    return JSON.parse(json) as T;
   } catch {
     return undefined;
   }
+};
+
+const normalizeClockSkewSeconds = (options: JwtConnectorOptions): number => {
+  const raw = options.clockSkewSeconds ?? DEFAULT_CLOCK_SKEW_SECONDS;
+  const value = Math.floor(raw);
+  return Number.isFinite(value)
+    ? Math.max(0, value)
+    : DEFAULT_CLOCK_SKEW_SECONDS;
+};
+
+const allowedAlgorithms = (
+  options: JwtConnectorOptions
+): readonly JwtAlgorithm[] =>
+  options.allowedAlgorithms ?? DEFAULT_ALLOWED_ALGORITHMS;
+
+const isSupportedJwtAlgorithm = (
+  algorithm: string
+): algorithm is JwtAlgorithm =>
+  (SUPPORTED_JWT_ALGORITHMS as readonly string[]).includes(algorithm);
+
+const validateHeader = (
+  header: JwtHeader,
+  options: JwtConnectorOptions
+): Result<JwtAlgorithm, AuthError> => {
+  if (typeof header.alg !== 'string') {
+    return authErr('invalid_token', 'Missing JWT alg header');
+  }
+  if (!isSupportedJwtAlgorithm(header.alg)) {
+    return authErr('invalid_token', 'Unsupported JWT alg header');
+  }
+  const configuredAlgorithms = allowedAlgorithms(options);
+  if (configuredAlgorithms.length === 0) {
+    return authErr(
+      'invalid_token',
+      'JWT allowedAlgorithms must include at least one algorithm'
+    );
+  }
+  if (!configuredAlgorithms.includes(header.alg)) {
+    return authErr('invalid_token', 'Unsupported JWT alg header');
+  }
+  return Result.ok(header.alg);
 };
 
 /** Import a secret as an HMAC CryptoKey. */
@@ -98,16 +168,53 @@ const verifyHmacSignature = (
   );
 };
 
+const verifyJwtSignature = async (
+  token: string,
+  secret: string,
+  algorithm: JwtAlgorithm
+): Promise<boolean> => {
+  switch (algorithm) {
+    case 'HS256': {
+      const key = await importHmacKey(secret);
+      return await verifyHmacSignature(token, key);
+    }
+    default: {
+      const exhaustive: never = algorithm;
+      void exhaustive;
+      return false;
+    }
+  }
+};
+
 /** Validate standard claims (exp, iss, aud). */
 const validateClaims = (
   payload: JwtPayload,
   options: JwtConnectorOptions
 ): AuthError | undefined => {
+  const now = Math.floor(Date.now() / 1000);
+  const skew = normalizeClockSkewSeconds(options);
+  if (payload.exp === undefined && options.requireExpiration !== false) {
+    return { code: 'invalid_token', message: 'Missing expiration claim (exp)' };
+  }
   if (
     payload.exp !== undefined &&
-    payload.exp < Math.floor(Date.now() / 1000)
+    (typeof payload.exp !== 'number' || !Number.isFinite(payload.exp))
   ) {
+    return { code: 'invalid_token', message: 'Invalid expiration claim (exp)' };
+  }
+  if (payload.exp !== undefined && payload.exp < now - skew) {
     return { code: 'expired_token', message: 'Token has expired' };
+  }
+  if (payload.nbf !== undefined) {
+    if (typeof payload.nbf !== 'number' || !Number.isFinite(payload.nbf)) {
+      return {
+        code: 'invalid_token',
+        message: 'Invalid not-before claim (nbf)',
+      };
+    }
+    if (payload.nbf > now + skew) {
+      return { code: 'invalid_token', message: 'Token is not valid yet' };
+    }
   }
   if (options.issuer && payload.iss !== options.issuer) {
     return { code: 'invalid_token', message: 'Issuer mismatch' };
@@ -172,15 +279,28 @@ const buildPermit = (
 /** Verify the signature and return the decoded payload, or an error. */
 const decodeAndVerify = async (
   token: string,
-  secret: string
+  secret: string,
+  options: JwtConnectorOptions
 ): Promise<Result<JwtPayload, AuthError>> => {
-  const payload = decodePayload(token);
+  const parts = splitToken(token);
+  if (!parts) {
+    return authErr('invalid_token', 'Malformed JWT');
+  }
+  const [rawHeader, rawPayload] = parts;
+  const header = decodeJsonPart<JwtHeader>(rawHeader);
+  if (!header) {
+    return authErr('invalid_token', 'Malformed JWT header');
+  }
+  const headerResult = validateHeader(header, options);
+  if (headerResult.isErr()) {
+    return headerResult;
+  }
+  const payload = decodeJsonPart<JwtPayload>(rawPayload);
   if (!payload) {
     return authErr('invalid_token', 'Malformed JWT');
   }
   try {
-    const key = await importHmacKey(secret);
-    const valid = await verifyHmacSignature(token, key);
+    const valid = await verifyJwtSignature(token, secret, headerResult.value);
     return valid
       ? Result.ok(payload)
       : authErr('invalid_token', 'Invalid signature');
@@ -224,7 +344,11 @@ export const createJwtConnector = (
     if (!options.secret) {
       return authErr('invalid_token', 'No secret configured');
     }
-    const decoded = await decodeAndVerify(input.bearerToken, options.secret);
+    const decoded = await decodeAndVerify(
+      input.bearerToken,
+      options.secret,
+      options
+    );
     return decoded.isErr() ? decoded : payloadToPermit(decoded.value, options);
   };
 

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -5,6 +5,7 @@ export {
 } from './connectors/connector.js';
 export {
   createJwtConnector,
+  type JwtAlgorithm,
   type JwtConnectorOptions,
 } from './connectors/jwt.js';
 export { authLayer } from './auth-layer.js';


### PR DESCRIPTION
## Summary

- Validates JWT headers before signature verification and restricts accepted algorithms to the configured allowlist.
- Requires `exp` by default with an explicit opt-out, and validates `exp`/`nbf` types with bounded clock skew.
- Adds focused connector tests for missing/unsupported algorithms, expiration requirements, and time-claim skew behavior.
- Adds an `@ontrails/permits` changeset calling out the stricter JWT validation behavior.

## Testing

- `bun test packages/permits/src/__tests__/connector.test.ts`
- `bun run --cwd packages/permits typecheck`
- `bun run build`
- `bun run test`
- `bun run check`

Closes: TRL-555