### PR TITLE
chore: tighten hardening discovery rails

### DIFF
--- a/packages/oxlint-plugin/src/__tests__/rule-test-helpers.ts
+++ b/packages/oxlint-plugin/src/__tests__/rule-test-helpers.ts
@@ -47,13 +47,53 @@ export const createMemberExpressionNode = (
   type: 'MemberExpression',
 });
 
-export const createImportDeclarationNode = (importSource: string): unknown => ({
+export const createImportDeclarationNode = (
+  importSource: string,
+  specifiers: readonly unknown[] = []
+): unknown => ({
   source: {
     type: 'Literal',
     value: importSource,
   },
+  specifiers,
   type: 'ImportDeclaration',
 });
+
+export const createNamedImportDeclarationNode = (
+  importSource: string,
+  imports: readonly {
+    readonly imported: string;
+    readonly local?: string;
+  }[]
+): unknown =>
+  createImportDeclarationNode(
+    importSource,
+    imports.map(({ imported, local }) => ({
+      imported: {
+        name: imported,
+        type: 'Identifier',
+      },
+      local: {
+        name: local ?? imported,
+        type: 'Identifier',
+      },
+      type: 'ImportSpecifier',
+    }))
+  );
+
+export const createNamespaceImportDeclarationNode = (
+  importSource: string,
+  localName: string
+): unknown =>
+  createImportDeclarationNode(importSource, [
+    {
+      local: {
+        name: localName,
+        type: 'Identifier',
+      },
+      type: 'ImportNamespaceSpecifier',
+    },
+  ]);
 
 export const createExportDeclarationNode = (
   importSource: string,
@@ -82,16 +122,54 @@ export const createRequireCallNode = (importSource: string): unknown => ({
   type: 'CallExpression',
 });
 
-export const runRuleForEvent = ({
-  event,
+export const createRequireBindingNode = (
+  importSource: string,
+  localName: string
+): unknown => ({
+  id: {
+    name: localName,
+    type: 'Identifier',
+  },
+  init: createRequireCallNode(importSource),
+  type: 'VariableDeclarator',
+});
+
+export const createRequireObjectPatternBindingNode = (
+  importSource: string,
+  imports: readonly {
+    readonly imported: string;
+    readonly local?: string;
+  }[]
+): unknown => ({
+  id: {
+    properties: imports.map(({ imported, local }) => ({
+      key: {
+        name: imported,
+        type: 'Identifier',
+      },
+      type: 'Property',
+      value: {
+        name: local ?? imported,
+        type: 'Identifier',
+      },
+    })),
+    type: 'ObjectPattern',
+  },
+  init: createRequireCallNode(importSource),
+  type: 'VariableDeclarator',
+});
+
+export const runRuleForEvents = ({
+  events,
   filename,
-  nodes,
   options,
   rule,
 }: {
-  readonly event: string;
+  readonly events: readonly {
+    readonly event: string;
+    readonly nodes: readonly unknown[];
+  }[];
   readonly filename: string;
-  readonly nodes: readonly unknown[];
   readonly options?: readonly unknown[];
   readonly rule: CreateRule;
 }): readonly CapturedReport[] => {
@@ -117,15 +195,37 @@ export const runRuleForEvent = ({
     string,
     ((node: unknown) => void) | undefined
   >;
-  const listener = listeners[event];
+  for (const { event, nodes } of events) {
+    const listener = listeners[event];
 
-  if (!listener) {
-    return reports;
-  }
+    if (!listener) {
+      continue;
+    }
 
-  for (const node of nodes) {
-    listener(node);
+    for (const node of nodes) {
+      listener(node);
+    }
   }
 
   return reports;
 };
+
+export const runRuleForEvent = ({
+  event,
+  filename,
+  nodes,
+  options,
+  rule,
+}: {
+  readonly event: string;
+  readonly filename: string;
+  readonly nodes: readonly unknown[];
+  readonly options?: readonly unknown[];
+  readonly rule: CreateRule;
+}): readonly CapturedReport[] =>
+  runRuleForEvents({
+    events: [{ event, nodes }],
+    filename,
+    options,
+    rule,
+  });

--- a/packages/oxlint-plugin/src/__tests__/rules.test.ts
+++ b/packages/oxlint-plugin/src/__tests__/rules.test.ts
@@ -15,8 +15,13 @@ import {
   createIdentifierCallNode,
   createImportDeclarationNode,
   createMemberExpressionNode,
+  createNamedImportDeclarationNode,
+  createNamespaceImportDeclarationNode,
+  createRequireBindingNode,
   createRequireCallNode,
+  createRequireObjectPatternBindingNode,
   runRuleForEvent,
+  runRuleForEvents,
 } from './rule-test-helpers.js';
 
 describe('repo-local rules', () => {
@@ -220,22 +225,184 @@ describe('repo-local rules', () => {
       nodes: [createCallExpressionNode('Bun', 'write')],
       rule: tempAuditDirectFrameworkWritesRule,
     });
-    const directWriteReports = runRuleForEvent({
-      event: 'CallExpression',
+    const directWriteReports = runRuleForEvents({
+      events: [
+        {
+          event: 'ImportDeclaration',
+          nodes: [
+            createNamedImportDeclarationNode('node:fs', [
+              { imported: 'mkdirSync' },
+            ]),
+          ],
+        },
+        {
+          event: 'CallExpression',
+          nodes: [createIdentifierCallNode('mkdirSync')],
+        },
+      ],
       filename: 'apps/trails/src/trails/draft-promote.ts',
-      nodes: [createIdentifierCallNode('mkdirSync')],
       rule: tempAuditDirectFrameworkWritesRule,
     });
-    const directRenameReports = runRuleForEvent({
-      event: 'CallExpression',
+    const directRenameReports = runRuleForEvents({
+      events: [
+        {
+          event: 'ImportDeclaration',
+          nodes: [
+            createNamedImportDeclarationNode('node:fs', [
+              { imported: 'renameSync' },
+            ]),
+          ],
+        },
+        {
+          event: 'CallExpression',
+          nodes: [createIdentifierCallNode('renameSync')],
+        },
+      ],
       filename: 'apps/trails/src/trails/draft-promote.ts',
-      nodes: [createIdentifierCallNode('renameSync')],
       rule: tempAuditDirectFrameworkWritesRule,
     });
-    const directWriteReportsFromImport = runRuleForEvent({
+    const directWriteReportsFromImport = runRuleForEvents({
+      events: [
+        {
+          event: 'ImportDeclaration',
+          nodes: [
+            createNamedImportDeclarationNode('node:fs/promises', [
+              { imported: 'writeFile' },
+            ]),
+          ],
+        },
+        {
+          event: 'CallExpression',
+          nodes: [createIdentifierCallNode('writeFile')],
+        },
+      ],
+      filename: 'apps/trails/src/trails/add-verify.ts',
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const directWriteReportsFromBarePromisesImport = runRuleForEvents({
+      events: [
+        {
+          event: 'ImportDeclaration',
+          nodes: [
+            createNamedImportDeclarationNode('fs/promises', [
+              { imported: 'writeFile' },
+            ]),
+          ],
+        },
+        {
+          event: 'CallExpression',
+          nodes: [createIdentifierCallNode('writeFile')],
+        },
+      ],
+      filename: 'apps/trails/src/trails/add-verify.ts',
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const namespaceWriteReports = runRuleForEvents({
+      events: [
+        {
+          event: 'ImportDeclaration',
+          nodes: [createNamespaceImportDeclarationNode('node:fs', 'nodeFs')],
+        },
+        {
+          event: 'CallExpression',
+          nodes: [createCallExpressionNode('nodeFs', 'writeFile')],
+        },
+      ],
+      filename: 'apps/trails/src/trails/add-verify.ts',
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const namespacePromisesWriteReports = runRuleForEvents({
+      events: [
+        {
+          event: 'ImportDeclaration',
+          nodes: [createNamespaceImportDeclarationNode('fs/promises', 'fsP')],
+        },
+        {
+          event: 'CallExpression',
+          nodes: [createCallExpressionNode('fsP', 'writeFile')],
+        },
+      ],
+      filename: 'apps/trails/src/trails/add-verify.ts',
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const importedPromisesNamespaceReports = runRuleForEvents({
+      events: [
+        {
+          event: 'ImportDeclaration',
+          nodes: [
+            createNamedImportDeclarationNode('node:fs', [
+              { imported: 'promises', local: 'fsPromises' },
+            ]),
+          ],
+        },
+        {
+          event: 'CallExpression',
+          nodes: [createCallExpressionNode('fsPromises', 'writeFile')],
+        },
+      ],
+      filename: 'apps/trails/src/trails/add-verify.ts',
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const requireNamespaceReports = runRuleForEvents({
+      events: [
+        {
+          event: 'VariableDeclarator',
+          nodes: [createRequireBindingNode('node:fs', 'nodeFs')],
+        },
+        {
+          event: 'CallExpression',
+          nodes: [createCallExpressionNode('nodeFs', 'writeFile')],
+        },
+      ],
+      filename: 'apps/trails/src/trails/add-verify.ts',
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const requireDirectReports = runRuleForEvents({
+      events: [
+        {
+          event: 'VariableDeclarator',
+          nodes: [
+            createRequireObjectPatternBindingNode('node:fs', [
+              { imported: 'writeFile' },
+            ]),
+          ],
+        },
+        {
+          event: 'CallExpression',
+          nodes: [createIdentifierCallNode('writeFile')],
+        },
+      ],
+      filename: 'apps/trails/src/trails/add-verify.ts',
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const requirePromisesNamespaceReports = runRuleForEvents({
+      events: [
+        {
+          event: 'VariableDeclarator',
+          nodes: [
+            createRequireObjectPatternBindingNode('fs', [
+              { imported: 'promises', local: 'fsPromises' },
+            ]),
+          ],
+        },
+        {
+          event: 'CallExpression',
+          nodes: [createCallExpressionNode('fsPromises', 'writeFile')],
+        },
+      ],
+      filename: 'apps/trails/src/trails/add-verify.ts',
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const localWrapperReports = runRuleForEvent({
       event: 'CallExpression',
       filename: 'apps/trails/src/trails/add-verify.ts',
       nodes: [createIdentifierCallNode('writeFile')],
+      rule: tempAuditDirectFrameworkWritesRule,
+    });
+    const localMemberReports = runRuleForEvent({
+      event: 'CallExpression',
+      filename: 'apps/trails/src/trails/add-verify.ts',
+      nodes: [createCallExpressionNode('fs', 'writeFile')],
       rule: tempAuditDirectFrameworkWritesRule,
     });
     const packageReports = runRuleForEvent({
@@ -257,6 +424,29 @@ describe('repo-local rules', () => {
     expect(directWriteReportsFromImport[0]?.data).toEqual({
       callName: 'writeFile',
     });
+    expect(directWriteReportsFromBarePromisesImport[0]?.data).toEqual({
+      callName: 'writeFile',
+    });
+    expect(namespaceWriteReports[0]?.data).toEqual({
+      callName: 'nodeFs.writeFile',
+    });
+    expect(namespacePromisesWriteReports[0]?.data).toEqual({
+      callName: 'fsP.writeFile',
+    });
+    expect(importedPromisesNamespaceReports[0]?.data).toEqual({
+      callName: 'fsPromises.writeFile',
+    });
+    expect(requireNamespaceReports[0]?.data).toEqual({
+      callName: 'nodeFs.writeFile',
+    });
+    expect(requireDirectReports[0]?.data).toEqual({
+      callName: 'writeFile',
+    });
+    expect(requirePromisesNamespaceReports[0]?.data).toEqual({
+      callName: 'fsPromises.writeFile',
+    });
+    expect(localWrapperReports).toHaveLength(0);
+    expect(localMemberReports).toHaveLength(0);
     expect(packageReports).toHaveLength(0);
     expect(testReports).toHaveLength(0);
   });

--- a/packages/oxlint-plugin/src/rules/temp-audit-direct-framework-writes.ts
+++ b/packages/oxlint-plugin/src/rules/temp-audit-direct-framework-writes.ts
@@ -1,5 +1,8 @@
 import {
   asIdentifierName,
+  asLiteralString,
+  getImportSourceFromImportDeclaration,
+  getImportSourceFromRequire,
   invokesMemberCall,
   normalizeFilePath,
   reportNode,
@@ -8,6 +11,14 @@ import type { RuleModule } from './shared.js';
 
 const DEFAULT_SCOPED_PATHS = ['apps/trails/src/trails/'] as const;
 const TEST_FILE_PATTERN = /(?:^|\/)__tests__\/|\.(test|spec)\.[cm]?[jt]sx?$/u;
+const FS_IMPORT_SOURCES = new Set([
+  'fs',
+  'node:fs',
+  'fs/promises',
+  'node:fs/promises',
+]);
+const FS_BASE_IMPORT_SOURCES = new Set(['fs', 'node:fs']);
+const FS_PROMISES_EXPORT = 'promises';
 
 const MEMBER_WRITE_CALLS = [
   ['Bun', 'write'],
@@ -39,6 +50,230 @@ const DIRECT_WRITE_CALLS = new Set([
   'writeFile',
   'writeFileSync',
 ]);
+
+const isFsImportSource = (source: string | undefined): boolean =>
+  typeof source === 'string' && FS_IMPORT_SOURCES.has(source);
+
+const getImportedBindingName = (specifier: unknown): string | undefined => {
+  if (!(specifier && typeof specifier === 'object')) {
+    return undefined;
+  }
+
+  const { local, imported, type } = specifier as {
+    imported?: unknown;
+    local?: unknown;
+    type?: unknown;
+  };
+
+  if (type !== 'ImportSpecifier') {
+    return undefined;
+  }
+
+  const importedName =
+    asIdentifierName(imported) ?? asLiteralString(imported) ?? undefined;
+
+  if (!(importedName && DIRECT_WRITE_CALLS.has(importedName))) {
+    return undefined;
+  }
+
+  return asIdentifierName(local) ?? importedName;
+};
+
+const getFsNamespaceBindingName = (specifier: unknown): string | undefined => {
+  if (!(specifier && typeof specifier === 'object')) {
+    return undefined;
+  }
+
+  const { local, type } = specifier as { local?: unknown; type?: unknown };
+
+  return type === 'ImportNamespaceSpecifier' ||
+    type === 'ImportDefaultSpecifier'
+    ? asIdentifierName(local)
+    : undefined;
+};
+
+const getImportedFsPromisesNamespaceName = (
+  specifier: unknown,
+  importSource: string | undefined
+): string | undefined => {
+  if (
+    !(importSource && FS_BASE_IMPORT_SOURCES.has(importSource)) ||
+    !(specifier && typeof specifier === 'object')
+  ) {
+    return undefined;
+  }
+
+  const { local, imported, type } = specifier as {
+    imported?: unknown;
+    local?: unknown;
+    type?: unknown;
+  };
+
+  if (type !== 'ImportSpecifier') {
+    return undefined;
+  }
+
+  const importedName =
+    asIdentifierName(imported) ?? asLiteralString(imported) ?? undefined;
+
+  return importedName === FS_PROMISES_EXPORT
+    ? (asIdentifierName(local) ?? importedName)
+    : undefined;
+};
+
+const collectFsImportBindings = ({
+  directWriteBindings,
+  fsNamespaceBindings,
+  node,
+}: {
+  readonly directWriteBindings: Set<string>;
+  readonly fsNamespaceBindings: Set<string>;
+  readonly node: unknown;
+}): void => {
+  const importSource = getImportSourceFromImportDeclaration(node);
+  if (!isFsImportSource(importSource)) {
+    return;
+  }
+
+  const { specifiers } = node as { specifiers?: unknown };
+
+  if (!Array.isArray(specifiers)) {
+    return;
+  }
+
+  for (const specifier of specifiers) {
+    const directBinding = getImportedBindingName(specifier);
+    if (directBinding) {
+      directWriteBindings.add(directBinding);
+      continue;
+    }
+
+    const importedPromisesNamespace = getImportedFsPromisesNamespaceName(
+      specifier,
+      importSource
+    );
+    if (importedPromisesNamespace) {
+      fsNamespaceBindings.add(importedPromisesNamespace);
+      continue;
+    }
+
+    const namespaceBinding = getFsNamespaceBindingName(specifier);
+    if (namespaceBinding) {
+      fsNamespaceBindings.add(namespaceBinding);
+    }
+  }
+};
+
+const asObjectPatternProperties = (
+  value: unknown
+): readonly unknown[] | undefined => {
+  if (!(value && typeof value === 'object')) {
+    return undefined;
+  }
+
+  const { properties, type } = value as {
+    properties?: unknown;
+    type?: unknown;
+  };
+
+  return type === 'ObjectPattern' && Array.isArray(properties)
+    ? properties
+    : undefined;
+};
+
+const collectFsObjectPatternBinding = ({
+  directWriteBindings,
+  fsNamespaceBindings,
+  importSource,
+  property,
+}: {
+  readonly directWriteBindings: Set<string>;
+  readonly fsNamespaceBindings: Set<string>;
+  readonly importSource: string;
+  readonly property: unknown;
+}): void => {
+  if (!(property && typeof property === 'object')) {
+    return;
+  }
+
+  const { key, type, value } = property as {
+    key?: unknown;
+    type?: unknown;
+    value?: unknown;
+  };
+
+  if (type !== 'Property') {
+    return;
+  }
+
+  const importedName = asIdentifierName(key) ?? asLiteralString(key);
+  const localName = asIdentifierName(value) ?? importedName;
+
+  if (!(importedName && localName)) {
+    return;
+  }
+
+  if (
+    FS_BASE_IMPORT_SOURCES.has(importSource) &&
+    importedName === FS_PROMISES_EXPORT
+  ) {
+    fsNamespaceBindings.add(localName);
+    return;
+  }
+
+  if (DIRECT_WRITE_CALLS.has(importedName)) {
+    directWriteBindings.add(localName);
+  }
+};
+
+const collectFsRequireBindings = ({
+  directWriteBindings,
+  fsNamespaceBindings,
+  node,
+}: {
+  readonly directWriteBindings: Set<string>;
+  readonly fsNamespaceBindings: Set<string>;
+  readonly node: unknown;
+}): void => {
+  if (!(node && typeof node === 'object')) {
+    return;
+  }
+
+  const { id, init, type } = node as {
+    id?: unknown;
+    init?: unknown;
+    type?: unknown;
+  };
+
+  if (type !== 'VariableDeclarator') {
+    return;
+  }
+
+  const importSource = getImportSourceFromRequire(init);
+  if (importSource === undefined || !isFsImportSource(importSource)) {
+    return;
+  }
+
+  const namespaceBinding = asIdentifierName(id);
+  if (namespaceBinding) {
+    fsNamespaceBindings.add(namespaceBinding);
+    return;
+  }
+
+  const properties = asObjectPatternProperties(id);
+  if (!properties) {
+    return;
+  }
+
+  for (const property of properties) {
+    collectFsObjectPatternBinding({
+      directWriteBindings,
+      fsNamespaceBindings,
+      importSource,
+      property,
+    });
+  }
+};
 
 const resolveScopedPaths = (options: readonly unknown[]): readonly string[] => {
   const scopedPaths = (options[0] as { scopedPaths?: unknown } | undefined)
@@ -77,7 +312,10 @@ const isScopedFile = ({
   );
 };
 
-const getDirectCallName = (node: unknown): string | undefined => {
+const getDirectCallName = (
+  node: unknown,
+  directWriteBindings: ReadonlySet<string>
+): string | undefined => {
   if (!(node && typeof node === 'object')) {
     return undefined;
   }
@@ -87,21 +325,36 @@ const getDirectCallName = (node: unknown): string | undefined => {
   }
 
   const callName = asIdentifierName((node as { callee?: unknown }).callee);
-  return callName && DIRECT_WRITE_CALLS.has(callName) ? callName : undefined;
+  return callName && directWriteBindings.has(callName) ? callName : undefined;
 };
 
-const getMemberWriteCallName = (node: unknown): string | undefined => {
-  for (const [objectName, propertyName] of MEMBER_WRITE_CALLS) {
-    if (invokesMemberCall({ node, objectName, propertyName })) {
-      return `${objectName}.${propertyName}`;
+const getMemberWriteCallName = (
+  node: unknown,
+  fsNamespaceBindings: ReadonlySet<string>
+): string | undefined => {
+  for (const [defaultObjectName, propertyName] of MEMBER_WRITE_CALLS) {
+    const objectNames =
+      defaultObjectName === 'fs'
+        ? fsNamespaceBindings
+        : new Set([defaultObjectName]);
+
+    for (const objectName of objectNames) {
+      if (invokesMemberCall({ node, objectName, propertyName })) {
+        return `${objectName}.${propertyName}`;
+      }
     }
   }
 
   return undefined;
 };
 
-const getWriteCallName = (node: unknown): string | undefined =>
-  getMemberWriteCallName(node) ?? getDirectCallName(node);
+const getWriteCallName = (
+  node: unknown,
+  directWriteBindings: ReadonlySet<string>,
+  fsNamespaceBindings: ReadonlySet<string>
+): string | undefined =>
+  getMemberWriteCallName(node, fsNamespaceBindings) ??
+  getDirectCallName(node, directWriteBindings);
 
 /**
  * Temporary TRL-575 audit rule.
@@ -118,9 +371,16 @@ export const tempAuditDirectFrameworkWritesRule: RuleModule = {
       return {};
     }
 
+    const directWriteBindings = new Set<string>();
+    const fsNamespaceBindings = new Set<string>();
+
     return {
       CallExpression(node) {
-        const callName = getWriteCallName(node);
+        const callName = getWriteCallName(
+          node,
+          directWriteBindings,
+          fsNamespaceBindings
+        );
 
         if (!callName) {
           return;
@@ -130,6 +390,20 @@ export const tempAuditDirectFrameworkWritesRule: RuleModule = {
           context,
           data: { callName },
           messageId: 'tempAuditDirectFrameworkWrites',
+          node,
+        });
+      },
+      ImportDeclaration(node) {
+        collectFsImportBindings({
+          directWriteBindings,
+          fsNamespaceBindings,
+          node,
+        });
+      },
+      VariableDeclarator(node) {
+        collectFsRequireBindings({
+          directWriteBindings,
+          fsNamespaceBindings,
           node,
         });
       },


### PR DESCRIPTION
## Summary
- Tightens the temporary direct framework write audit rule so scoped paths match on normalized boundaries instead of substrings.
- Reuses shared test-file detection and expands coverage around current direct-write calls.

## Validation
- bun run check
- bun run build
- bun run test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes: TRL-578