### PR TITLE
fix: finish boundary authority follow-ups

### DIFF
--- a/apps/trails/src/__tests__/create.test.ts
+++ b/apps/trails/src/__tests__/create.test.ts
@@ -16,6 +16,7 @@ import { addVerify } from '../trails/add-verify.js';
 import { createRoute } from '../trails/create.js';
 import { createScaffold } from '../trails/create-scaffold.js';
 import { isInsideProject } from '../trails/project.js';
+import { PROJECT_NAME_MESSAGE } from '../project-writes.js';
 import {
   ontrailsPackageRange,
   scaffoldDependencyVersions,
@@ -347,6 +348,21 @@ describe('trails create', () => {
         expect(error).toBeInstanceOf(ValidationError);
         expect(existsSync(join(dirname(dir), 'escape'))).toBe(false);
       });
+    });
+
+    test('rejects path-shaped project names at the create route boundary', () => {
+      const result = createRoute.input.safeParse({
+        dir: tmpdir(),
+        name: '../escape',
+        starter: 'hello',
+        surfaces: ['cli'],
+        verify: true,
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(PROJECT_NAME_MESSAGE);
+      }
     });
   });
 

--- a/apps/trails/src/__tests__/load-app-mirror.test.ts
+++ b/apps/trails/src/__tests__/load-app-mirror.test.ts
@@ -7,13 +7,14 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 
 import { PermissionError, ValidationError } from '@ontrails/core';
 
 import {
   createLoadAppMirrorRootPath,
   removeLoadAppMirrorRoot,
+  removeLoadAppMirrorRootQuietly,
   resolveLoadAppMirrorFilePath,
   writeLoadAppMirrorFile,
 } from '../load-app-mirror.js';
@@ -27,6 +28,13 @@ const tempRoot = (): string =>
   );
 
 describe('load-app mirror helpers', () => {
+  test('creates absolute mirror roots under the load-app mirror parent', () => {
+    const mirrorRoot = createLoadAppMirrorRootPath('relative-project');
+
+    expect(isAbsolute(mirrorRoot)).toBe(true);
+    expect(mirrorRoot).toContain('.trails-tmp/load-app-fresh-');
+  });
+
   test('writes source bytes under the load-app mirror root', async () => {
     const root = tempRoot();
 
@@ -110,6 +118,20 @@ describe('load-app mirror helpers', () => {
       const removed = removeLoadAppMirrorRoot(mirrorRoot);
       expect(removed.isOk()).toBe(true);
       expect(existsSync(mirrorRoot)).toBe(false);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('quiet removal ignores invalid mirror roots', () => {
+    const root = tempRoot();
+
+    try {
+      const protectedDir = join(root, 'project');
+      mkdirSync(protectedDir, { recursive: true });
+
+      expect(() => removeLoadAppMirrorRootQuietly(protectedDir)).not.toThrow();
+      expect(existsSync(protectedDir)).toBe(true);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/apps/trails/src/__tests__/project-writes.test.ts
+++ b/apps/trails/src/__tests__/project-writes.test.ts
@@ -6,12 +6,13 @@ import { dirname, join } from 'node:path';
 import { PermissionError, ValidationError } from '@ontrails/core';
 
 import {
-  renameProjectPath,
+  projectPathExists,
+  renameContainedProjectPath,
   resolveProjectDir,
   validateProjectName,
   validateTrailId,
+  writeContainedProjectPath,
   writeProjectFile,
-  writeProjectPath,
 } from '../project-writes.js';
 
 const tempRoot = (): string =>
@@ -79,7 +80,7 @@ describe('project write helpers', () => {
     }
   });
 
-  test('contains absolute project writes and renames under their root', async () => {
+  test('contains derived project paths under their root', async () => {
     const root = tempRoot();
 
     try {
@@ -94,14 +95,32 @@ describe('project write helpers', () => {
       const targetPath = join(projectDir.value, 'src', 'after.ts');
       const outsidePath = join(root, 'outside.ts');
 
-      const written = await writeProjectPath(
+      const missing = projectPathExists(projectDir.value, sourcePath);
+      expect(missing.isOk()).toBe(true);
+      if (missing.isOk()) {
+        expect(missing.value).toBe(false);
+      }
+
+      const written = await writeContainedProjectPath(
         projectDir.value,
         sourcePath,
         'export const before = true;\n'
       );
       expect(written.isOk()).toBe(true);
 
-      const escapedWrite = await writeProjectPath(
+      const existing = projectPathExists(projectDir.value, sourcePath);
+      expect(existing.isOk()).toBe(true);
+      if (existing.isOk()) {
+        expect(existing.value).toBe(true);
+      }
+
+      const escapedExists = projectPathExists(projectDir.value, outsidePath);
+      expect(escapedExists.isErr()).toBe(true);
+      if (escapedExists.isErr()) {
+        expect(escapedExists.error).toBeInstanceOf(PermissionError);
+      }
+
+      const escapedWrite = await writeContainedProjectPath(
         projectDir.value,
         outsidePath,
         'export const outside = true;\n'
@@ -111,7 +130,7 @@ describe('project write helpers', () => {
         expect(escapedWrite.error).toBeInstanceOf(PermissionError);
       }
 
-      const escapedRename = renameProjectPath(
+      const escapedRename = renameContainedProjectPath(
         projectDir.value,
         sourcePath,
         outsidePath
@@ -121,7 +140,7 @@ describe('project write helpers', () => {
         expect(escapedRename.error).toBeInstanceOf(PermissionError);
       }
 
-      const renamed = renameProjectPath(
+      const renamed = renameContainedProjectPath(
         projectDir.value,
         sourcePath,
         targetPath

--- a/apps/trails/src/load-app-mirror.ts
+++ b/apps/trails/src/load-app-mirror.ts
@@ -143,12 +143,16 @@ export const removeLoadAppMirrorRoot = (
  * into an application-load failure.
  */
 export const removeLoadAppMirrorRootQuietly = (mirrorRoot: string): void => {
-  removeLoadAppMirrorRoot(mirrorRoot);
+  try {
+    removeLoadAppMirrorRoot(mirrorRoot);
+  } catch {
+    // Best-effort cleanup must never become the failure path.
+  }
 };
 
 export const createLoadAppMirrorRootPath = (cwd: string): string =>
   join(
-    cwd,
+    resolve(cwd),
     LOAD_APP_MIRROR_PARENT_DIRNAME,
     `${LOAD_APP_MIRROR_ENTRY_PREFIX}${Date.now()}-${Math.random()
       .toString(36)

--- a/apps/trails/src/project-writes.ts
+++ b/apps/trails/src/project-writes.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, renameSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 import {
@@ -86,6 +86,19 @@ export const ensureProjectDirectory = (
   }
 };
 
+export const projectPathExists = (
+  projectDir: string,
+  pathWithinProject: string
+): TrailsResult<boolean, Error> => {
+  const target = resolveProjectPath(projectDir, pathWithinProject);
+  if (target.isErr()) {
+    return target;
+  }
+
+  return Result.ok(existsSync(target.value));
+};
+
+/** Write a generated project-relative file and return the relative path. */
 export const writeProjectFile = async (
   projectDir: string,
   relativePath: string,
@@ -110,12 +123,13 @@ export const writeProjectFile = async (
   }
 };
 
-export const writeProjectPath = async (
+/** Write an already-derived path that must stay contained under the project. */
+export const writeContainedProjectPath = async (
   projectDir: string,
-  filePath: string,
+  pathWithinProject: string,
   content: string | Uint8Array
 ): Promise<TrailsResult<string, Error>> => {
-  const target = resolveProjectPath(projectDir, filePath);
+  const target = resolveProjectPath(projectDir, pathWithinProject);
   if (target.isErr()) {
     return target;
   }
@@ -126,15 +140,18 @@ export const writeProjectPath = async (
     return Result.ok(target.value);
   } catch (error) {
     return Result.err(
-      new InternalError(`Failed to write project path "${filePath}"`, {
-        cause: asError(error),
-        context: { filePath, projectDir },
-      })
+      new InternalError(
+        `Failed to write contained project path "${pathWithinProject}"`,
+        {
+          cause: asError(error),
+          context: { pathWithinProject, projectDir },
+        }
+      )
     );
   }
 };
 
-export const renameProjectPath = (
+export const renameContainedProjectPath = (
   projectDir: string,
   fromPath: string,
   toPath: string
@@ -154,10 +171,13 @@ export const renameProjectPath = (
     return Result.ok();
   } catch (error) {
     return Result.err(
-      new InternalError(`Failed to rename project path "${fromPath}"`, {
-        cause: asError(error),
-        context: { fromPath, projectDir, toPath },
-      })
+      new InternalError(
+        `Failed to rename contained project path "${fromPath}"`,
+        {
+          cause: asError(error),
+          context: { fromPath, projectDir, toPath },
+        }
+      )
     );
   }
 };

--- a/apps/trails/src/trails/add-surface.ts
+++ b/apps/trails/src/trails/add-surface.ts
@@ -5,12 +5,16 @@
  */
 
 import { existsSync } from 'node:fs';
-import { basename, join, resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { resolveProjectPath, writeProjectFile } from '../project-writes.js';
+import {
+  projectPathExists,
+  resolveProjectPath,
+  writeProjectFile,
+} from '../project-writes.js';
 import {
   ontrailsPackageRange,
   scaffoldDependencyVersions,
@@ -132,8 +136,12 @@ export const addSurface = trail('add.surface', {
     const cwd = resolve(input.dir ?? '.');
     const { surface } = input;
     const entryFile = getEntryFile(surface);
+    const entryExists = projectPathExists(cwd, entryFile);
+    if (entryExists.isErr()) {
+      return Result.err(entryExists.error);
+    }
 
-    if (existsSync(join(cwd, entryFile))) {
+    if (entryExists.value) {
       return Result.err(
         new Error(
           `${surface.toUpperCase()} surface already exists. Nothing to do.`

--- a/apps/trails/src/trails/create.ts
+++ b/apps/trails/src/trails/create.ts
@@ -8,6 +8,11 @@
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
+import {
+  PROJECT_NAME_MESSAGE,
+  PROJECT_NAME_PATTERN,
+} from '../project-writes.js';
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -189,7 +194,10 @@ export const createRoute = trail('create', {
   },
   input: z.object({
     dir: z.string().optional().describe('Parent directory'),
-    name: z.string().describe('Project name'),
+    name: z
+      .string()
+      .regex(PROJECT_NAME_PATTERN, PROJECT_NAME_MESSAGE)
+      .describe('Project name'),
     starter: z
       .enum(['hello', 'entity', 'empty'])
       .default('hello')

--- a/apps/trails/src/trails/draft-promote.ts
+++ b/apps/trails/src/trails/draft-promote.ts
@@ -18,7 +18,10 @@ import {
 } from '@ontrails/warden';
 import { z } from 'zod';
 
-import { renameProjectPath, writeProjectPath } from '../project-writes.js';
+import {
+  renameContainedProjectPath,
+  writeContainedProjectPath,
+} from '../project-writes.js';
 import { loadFreshAppLease } from './load-app.js';
 import { findTopoPath } from './project.js';
 
@@ -266,7 +269,7 @@ const rewritePromotedSourceFiles = async (
       continue;
     }
 
-    const written = await writeProjectPath(
+    const written = await writeContainedProjectPath(
       rootDir,
       filePath,
       replaced.nextSource
@@ -382,7 +385,7 @@ const collectAndApplyFileRenames = async (
   }
 
   for (const r of renames) {
-    const renamed = renameProjectPath(rootDir, r.from, r.to);
+    const renamed = renameContainedProjectPath(rootDir, r.from, r.to);
     if (renamed.isErr()) {
       return Result.err(renamed.error);
     }
@@ -454,7 +457,7 @@ const updateRelativeImportsForFile = async (
   const sourceCode = await Bun.file(filePath).text();
   const updated = rewriteRelativeImportsForFile(filePath, renames, sourceCode);
   if (updated.changed) {
-    const written = await writeProjectPath(
+    const written = await writeContainedProjectPath(
       rootDir,
       filePath,
       updated.sourceCode

--- a/connectors/hono/src/__tests__/surface.test.ts
+++ b/connectors/hono/src/__tests__/surface.test.ts
@@ -1,9 +1,25 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 import { Result, trail, topo } from '@ontrails/core';
 import { z } from 'zod';
 
 import { createApp, surface } from '../surface.js';
+
+let originalConsoleError = console.error;
+let loggedErrors: unknown[][] = [];
+
+beforeEach(() => {
+  originalConsoleError = console.error;
+  loggedErrors = [];
+  console.error = mock((...args: unknown[]) => {
+    loggedErrors.push(args);
+  });
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+  loggedErrors = [];
+});
 
 const echoTrail = trail('echo', {
   blaze: (input) => Result.ok({ reply: input.message }),
@@ -110,6 +126,25 @@ describe('surface API (Hono connector)', () => {
     });
   });
 
+  test('malformed Content-Length is rejected as invalid body metadata', async () => {
+    const graph = topo('surface-api', { echoBodyTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/echo/body', {
+      headers: { 'Content-Length': 'abc' },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'validation',
+        code: 'ValidationError',
+        message: 'Invalid Content-Length header',
+      },
+    });
+  });
+
   test('maxJsonBodyBytes overrides the default JSON body cap', async () => {
     const graph = topo('surface-api', { echoBodyTrail });
     const app = createApp(graph, { maxJsonBodyBytes: 2 * 1024 * 1024 });
@@ -174,128 +209,88 @@ describe('surface API (Hono connector)', () => {
   });
 
   test('generic non-TrailsError results redact public 500 responses and keep diagnostics', async () => {
-    const originalError = console.error;
-    const logged: unknown[][] = [];
-    console.error = mock((...args: unknown[]) => {
-      logged.push(args);
+    const graph = topo('surface-api', { genericErrorTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/generic/error', {
+      headers: { 'X-Request-ID': 'req-123' },
+      method: 'GET',
     });
 
-    try {
-      const graph = topo('surface-api', { genericErrorTrail });
-      const app = createApp(graph);
-
-      const response = await app.request('/generic/error', {
-        headers: { 'X-Request-ID': 'req-123' },
-        method: 'GET',
-      });
-
-      expect(response.status).toBe(500);
-      expect(await response.json()).toEqual({
-        error: {
-          category: 'internal',
-          code: 'InternalError',
-          message: 'Internal server error',
-        },
-      });
-      expect(logged).toHaveLength(1);
-      expect(logged[0]?.[0]).toBe('[ontrails:hono] Internal error (req-123)');
-      const loggedError = logged[0]?.[1];
-      expect(loggedError).toBeInstanceOf(Error);
-      expect((loggedError as Error).message).toBe('database password=secret');
-    } finally {
-      console.error = originalError;
-    }
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'internal',
+        code: 'InternalError',
+        message: 'Internal server error',
+      },
+    });
+    expect(loggedErrors).toHaveLength(1);
+    expect(loggedErrors[0]?.[0]).toBe(
+      '[ontrails:hono] Internal error (req-123)'
+    );
+    const loggedError = loggedErrors[0]?.[1];
+    expect(loggedError).toBeInstanceOf(Error);
+    expect((loggedError as Error).message).toBe('database password=secret');
   });
 
   test('sanitizes request ids before logging diagnostics', async () => {
-    const originalError = console.error;
-    const logged: unknown[][] = [];
-    console.error = mock((...args: unknown[]) => {
-      logged.push(args);
+    const graph = topo('surface-api', { genericErrorTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/generic/error', {
+      headers: { 'X-Request-ID': 'req-123 forged/line' },
+      method: 'GET',
     });
 
-    try {
-      const graph = topo('surface-api', { genericErrorTrail });
-      const app = createApp(graph);
-
-      const response = await app.request('/generic/error', {
-        headers: { 'X-Request-ID': 'req-123 forged/line' },
-        method: 'GET',
-      });
-
-      expect(response.status).toBe(500);
-      expect(logged).toHaveLength(1);
-      const label = logged[0]?.[0];
-      expect(label).toBe(
-        '[ontrails:hono] Internal error (req-123_forged_line)'
-      );
-      expect(String(label)).not.toContain('req-123 forged');
-      expect(String(label)).not.toContain('forged/line');
-    } finally {
-      console.error = originalError;
-    }
+    expect(response.status).toBe(500);
+    expect(loggedErrors).toHaveLength(1);
+    const label = loggedErrors[0]?.[0];
+    expect(label).toBe('[ontrails:hono] Internal error (req-123_forged_line)');
+    expect(String(label)).not.toContain('req-123 forged');
+    expect(String(label)).not.toContain('forged/line');
   });
 
   test('caps request ids before logging diagnostics', async () => {
-    const originalError = console.error;
-    const logged: unknown[][] = [];
-    console.error = mock((...args: unknown[]) => {
-      logged.push(args);
+    const graph = topo('surface-api', { genericErrorTrail });
+    const app = createApp(graph);
+    const requestId = 'x'.repeat(160);
+
+    const response = await app.request('/generic/error', {
+      headers: { 'X-Request-ID': requestId },
+      method: 'GET',
     });
 
-    try {
-      const graph = topo('surface-api', { genericErrorTrail });
-      const app = createApp(graph);
-      const requestId = 'x'.repeat(160);
-
-      const response = await app.request('/generic/error', {
-        headers: { 'X-Request-ID': requestId },
-        method: 'GET',
-      });
-
-      expect(response.status).toBe(500);
-      expect(logged).toHaveLength(1);
-      expect(logged[0]?.[0]).toBe(
-        `[ontrails:hono] Internal error (${'x'.repeat(128)})`
-      );
-    } finally {
-      console.error = originalError;
-    }
+    expect(response.status).toBe(500);
+    expect(loggedErrors).toHaveLength(1);
+    expect(loggedErrors[0]?.[0]).toBe(
+      `[ontrails:hono] Internal error (${'x'.repeat(128)})`
+    );
   });
 
   test('global Hono errors use the same redacted 500 response', async () => {
-    const originalError = console.error;
-    const logged: unknown[][] = [];
-    console.error = mock((...args: unknown[]) => {
-      logged.push(args);
+    const graph = topo('surface-api', { echoTrail });
+    const app = createApp(graph);
+    app.get('/boom', () => {
+      throw new Error('token=secret');
     });
 
-    try {
-      const graph = topo('surface-api', { echoTrail });
-      const app = createApp(graph);
-      app.get('/boom', () => {
-        throw new Error('token=secret');
-      });
+    const response = await app.request('/boom', {
+      method: 'GET',
+    });
 
-      const response = await app.request('/boom', {
-        method: 'GET',
-      });
-
-      expect(response.status).toBe(500);
-      expect(await response.json()).toEqual({
-        error: {
-          category: 'internal',
-          code: 'InternalError',
-          message: 'Internal server error',
-        },
-      });
-      expect(logged).toHaveLength(1);
-      expect(logged[0]?.[0]).toBe('[ontrails:hono] Internal error');
-      const loggedError = logged[0]?.[1];
-      expect(loggedError).toBeInstanceOf(Error);
-      expect((loggedError as Error).message).toBe('token=secret');
-    } finally {
-      console.error = originalError;
-    }
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'internal',
+        code: 'InternalError',
+        message: 'Internal server error',
+      },
+    });
+    expect(loggedErrors).toHaveLength(1);
+    expect(loggedErrors[0]?.[0]).toBe('[ontrails:hono] Internal error');
+    const loggedError = loggedErrors[0]?.[1];
+    expect(loggedError).toBeInstanceOf(Error);
+    expect((loggedError as Error).message).toBe('token=secret');
   });
 });

--- a/connectors/hono/src/surface.ts
+++ b/connectors/hono/src/surface.ts
@@ -100,6 +100,11 @@ const JSON_PARSE_ERROR = Symbol('JSON_PARSE_ERROR');
 /** Sentinel indicating a JSON body rejected before parsing. */
 const JSON_BODY_TOO_LARGE = Symbol('JSON_BODY_TOO_LARGE');
 
+/** Sentinel indicating malformed body metadata. */
+const JSON_BODY_INVALID_CONTENT_LENGTH = Symbol(
+  'JSON_BODY_INVALID_CONTENT_LENGTH'
+);
+
 interface JsonObject {
   readonly [key: string]: JsonValue;
 }
@@ -113,6 +118,7 @@ type JsonValue =
   | JsonObject;
 type JsonBodyReadResult =
   | JsonValue
+  | typeof JSON_BODY_INVALID_CONTENT_LENGTH
   | typeof JSON_PARSE_ERROR
   | typeof JSON_BODY_TOO_LARGE;
 type JsonBodyTextReadResult = string | typeof JSON_BODY_TOO_LARGE;
@@ -121,14 +127,19 @@ type InputReadResult = Record<string, unknown> | JsonBodyReadResult;
 const CONTENT_LENGTH_DECIMAL_PATTERN = /^\d+$/;
 
 /** Return true when the request has no body content. */
+type ParsedContentLength =
+  | number
+  | typeof JSON_BODY_INVALID_CONTENT_LENGTH
+  | undefined;
+
 const parseContentLength = (
   contentLength: string | undefined
-): number | undefined => {
+): ParsedContentLength => {
   if (contentLength === undefined) {
     return undefined;
   }
   if (!CONTENT_LENGTH_DECIMAL_PATTERN.test(contentLength)) {
-    return undefined;
+    return JSON_BODY_INVALID_CONTENT_LENGTH;
   }
   const size = Number(contentLength);
   return Number.isSafeInteger(size) ? size : Number.MAX_SAFE_INTEGER;
@@ -136,6 +147,9 @@ const parseContentLength = (
 
 const isEmptyBody = (c: HonoContext): boolean => {
   const contentLength = parseContentLength(c.req.header('Content-Length'));
+  if (contentLength === JSON_BODY_INVALID_CONTENT_LENGTH) {
+    return false;
+  }
   if (contentLength !== undefined) {
     return contentLength === 0;
   }
@@ -164,6 +178,9 @@ const hasOversizedContentLength = (
     return false;
   }
   const size = parseContentLength(contentLength);
+  if (size === JSON_BODY_INVALID_CONTENT_LENGTH) {
+    return false;
+  }
   return size !== undefined && size > maxJsonBodyBytes;
 };
 
@@ -232,6 +249,13 @@ const readJsonBody = async (
   c: HonoContext,
   maxJsonBodyBytes: number
 ): Promise<JsonBodyReadResult> => {
+  if (
+    parseContentLength(c.req.header('Content-Length')) ===
+    JSON_BODY_INVALID_CONTENT_LENGTH
+  ) {
+    return JSON_BODY_INVALID_CONTENT_LENGTH;
+  }
+
   if (hasOversizedContentLength(c, maxJsonBodyBytes)) {
     return JSON_BODY_TOO_LARGE;
   }
@@ -359,6 +383,19 @@ const createHonoHandler =
             category: 'validation',
             code: 'ValidationError',
             message: 'Invalid JSON in request body',
+          },
+        },
+        400
+      );
+    }
+
+    if (rawInput === JSON_BODY_INVALID_CONTENT_LENGTH) {
+      return c.json(
+        {
+          error: {
+            category: 'validation',
+            code: 'ValidationError',
+            message: 'Invalid Content-Length header',
           },
         },
         400

--- a/docs/adr/0012-connector-agnostic-permits.md
+++ b/docs/adr/0012-connector-agnostic-permits.md
@@ -66,7 +66,7 @@ Core enforcement keys off `scopes` only. Roles are connector output — the auth
 
 ### `ctx.permit` is `Permit | undefined`
 
-`undefined` means no permit declaration or public trail. `Permit` means auth succeeded. Failed auth never reaches the implementation — the auth layer short-circuits with `Result.err(AuthError)` before `run` executes.
+`undefined` means no permit declaration or public trail. `Permit` means auth succeeded. Failed auth never reaches the implementation — the execution pipeline short-circuits with `Result.err(PermitError)` before the blaze runs.
 
 This means implementations can trust `ctx.permit` structurally. If it's present, it's valid. No defensive checks inside domain logic.
 
@@ -76,7 +76,7 @@ The permit model separates into three distinct responsibilities:
 
 1. **Trail declaration.** `permit: { scopes: ['entity:write'] }` on the spec. Declares what's required.
 2. **Surface extraction.** Each surface normalizes raw credentials into `PermitExtractionInput`. No surface types cross into core.
-3. **Auth layer.** A shared layer that checks `ctx.permit.scopes` against the trail's declared scopes. Same layer, every surface.
+3. **Pipeline enforcement.** Core `executeTrail` checks `ctx.permit.scopes` against the trail's declared scopes. Same stage, every surface.
 
 ### Normalized extraction input
 

--- a/packages/core/src/__tests__/execute-permit.test.ts
+++ b/packages/core/src/__tests__/execute-permit.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { PermitError } from '../errors';
+import { executeTrail } from '../execute';
+import type { Layer } from '../layer';
+import { Result } from '../result';
+import { resource } from '../resource';
+import { topo } from '../topo';
+import { trail } from '../trail';
+
+const protectedTrail = trail('permit.protected', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  permit: { scopes: ['entity:write'] },
+});
+
+describe('executeTrail permit enforcement', () => {
+  test('runs scoped trails when the context permit has all required scopes', async () => {
+    const result = await executeTrail(
+      protectedTrail,
+      {},
+      {
+        ctx: {
+          permit: { id: 'permit-1', scopes: ['entity:read', 'entity:write'] },
+        },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ ok: true });
+  });
+
+  test('rejects scoped trails when no permit is available', async () => {
+    let ran = false;
+    const t = trail('permit.missing', {
+      blaze: () => {
+        ran = true;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      permit: { scopes: ['entity:write'] },
+    });
+
+    const result = await executeTrail(t, {});
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error).toBeInstanceOf(PermitError);
+    expect(result.error.message).toContain('No permit');
+    expect(ran).toBe(false);
+  });
+
+  test('rejects scoped trails when required scopes are missing', async () => {
+    const result = await executeTrail(
+      protectedTrail,
+      {},
+      {
+        ctx: { permit: { id: 'permit-1', scopes: ['entity:read'] } },
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error).toBeInstanceOf(PermitError);
+    expect(result.error.message).toContain('entity:write');
+    expect(result.error.context).toEqual({
+      missing: ['entity:write'],
+      required: ['entity:write'],
+      trailId: 'permit.protected',
+    });
+  });
+
+  test('allows public and undeclared trails without a permit', async () => {
+    const publicTrail = trail('permit.public', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      permit: 'public',
+    });
+    const undeclaredTrail = trail('permit.undeclared', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const publicResult = await executeTrail(publicTrail, {});
+    const undeclaredResult = await executeTrail(undeclaredTrail, {});
+
+    expect(publicResult.isOk()).toBe(true);
+    expect(undeclaredResult.isOk()).toBe(true);
+  });
+
+  test('rejects before resource creation and layer composition', async () => {
+    let created = false;
+    let wrapped = false;
+    const protectedResource = resource('permit.protected.resource', {
+      create: () => {
+        created = true;
+        return Result.ok({ ok: true });
+      },
+    });
+    const probeLayer: Layer = {
+      name: 'probe',
+      wrap: (_trail, impl) => async (input, ctx) => {
+        wrapped = true;
+        return await impl(input, ctx);
+      },
+    };
+    const t = trail('permit.before-effects', {
+      blaze: (_input, ctx) => Result.ok({ ok: protectedResource.from(ctx).ok }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      permit: { scopes: ['entity:write'] },
+      resources: [protectedResource],
+    });
+
+    const result = await executeTrail(t, {}, { layers: [probeLayer] });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error).toBeInstanceOf(PermitError);
+    expect(created).toBe(false);
+    expect(wrapped).toBe(false);
+  });
+
+  test('rechecks permit requirements across ctx.cross boundaries', async () => {
+    const child = trail('permit.child', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      permit: { scopes: ['child:write'] },
+      visibility: 'internal',
+    });
+    const parent = trail('permit.parent', {
+      blaze: async (_input, ctx) => {
+        const crossed = await ctx.cross?.(child, {});
+        return Result.ok({
+          childError:
+            crossed?.isErr() === true ? crossed.error.message : undefined,
+        });
+      },
+      crosses: [child],
+      input: z.object({}),
+      output: z.object({ childError: z.string().optional() }),
+      permit: { scopes: ['parent:write'] },
+    });
+    const app = topo('permit-cross-topo', { child, parent });
+
+    const result = await executeTrail(
+      parent,
+      {},
+      {
+        ctx: { permit: { id: 'permit-1', scopes: ['parent:write'] } },
+        topo: app,
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({
+      childError: 'Missing scopes: child:write',
+    });
+  });
+});

--- a/packages/core/src/__tests__/serialization.test.ts
+++ b/packages/core/src/__tests__/serialization.test.ts
@@ -12,6 +12,7 @@ import {
   AlreadyExistsError,
   ConflictError,
   PermissionError,
+  PermitError,
   AuthError,
   CancelledError,
 } from '../errors.js';
@@ -177,6 +178,7 @@ describe('deserializeError', () => {
       { Ctor: AlreadyExistsError, category: 'conflict' },
       { Ctor: ConflictError, category: 'conflict' },
       { Ctor: PermissionError, category: 'permission' },
+      { Ctor: PermitError, category: 'permission' },
       { Ctor: TimeoutError, category: 'timeout' },
       { Ctor: NetworkError, category: 'network' },
       { Ctor: InternalError, category: 'internal' },

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -83,6 +83,16 @@ export class PermissionError extends TrailsError {
   readonly retryable = false as const;
 }
 
+export class PermitError extends PermissionError {
+  constructor(
+    message: string,
+    options?: { cause?: Error; context?: Record<string, unknown> }
+  ) {
+    super(message, options);
+    this.name = 'PermitError';
+  }
+}
+
 export class TimeoutError extends TrailsError {
   readonly category = 'timeout' as const;
   readonly retryable = true as const;

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -31,6 +31,7 @@ import {
   CancelledError,
   InternalError,
   NotFoundError,
+  PermitError,
   RetryExhaustedError,
   TrailsError,
 } from './errors.js';
@@ -155,14 +156,51 @@ const resolveContext = async (
   return bindResourceLookup(resolved, options);
 };
 
+const findMissingScopes = (
+  required: readonly string[],
+  held: readonly string[]
+): readonly string[] => required.filter((scope) => !held.includes(scope));
+
+const enforcePermitRequirement = (
+  trail: AnyTrail,
+  ctx: TrailContext
+): Result<TrailContext, Error> => {
+  const requirement = trail.permit;
+  if (requirement === undefined || requirement === 'public') {
+    return Result.ok(ctx);
+  }
+
+  if (ctx.permit === undefined) {
+    return Result.err(
+      new PermitError('No permit provided', {
+        context: { required: requirement.scopes, trailId: trail.id },
+      })
+    );
+  }
+
+  const missing = findMissingScopes(requirement.scopes, ctx.permit.scopes);
+  return missing.length === 0
+    ? Result.ok(ctx)
+    : Result.err(
+        new PermitError(`Missing scopes: ${missing.join(', ')}`, {
+          context: { missing, required: requirement.scopes, trailId: trail.id },
+        })
+      );
+};
+
 const prepareContext = async (
   trail: AnyTrail,
   options?: ExecuteTrailOptions
 ): Promise<Result<TrailContext, Error>> => {
   const baseCtx = await resolveContext(options);
+  const permitted = enforcePermitRequirement(trail, baseCtx);
+  if (permitted.isErr()) {
+    return permitted;
+  }
+
   return await createResources(
     trail,
-    baseCtx,
+    permitted.value,
     options?.resources,
     options?.configValues
   );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export {
   AlreadyExistsError,
   ConflictError,
   PermissionError,
+  PermitError,
   TimeoutError,
   RateLimitError,
   NetworkError,

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -14,6 +14,7 @@ import {
   AlreadyExistsError,
   ConflictError,
   PermissionError,
+  PermitError,
   TimeoutError,
   RateLimitError,
   NetworkError,
@@ -106,6 +107,7 @@ const errorConstructorsByName: Record<string, ErrorFactory> = {
   NetworkError: (msg, opts) => new NetworkError(msg, opts),
   NotFoundError: (msg, opts) => new NotFoundError(msg, opts),
   PermissionError: (msg, opts) => new PermissionError(msg, opts),
+  PermitError: (msg, opts) => new PermitError(msg, opts),
   RateLimitError: (msg, opts, retryAfter) => {
     const rlOpts: { context?: Record<string, unknown>; retryAfter?: number } = {
       ...opts,

--- a/packages/permits/README.md
+++ b/packages/permits/README.md
@@ -2,7 +2,7 @@
 
 Scope-based authorization for Trails.
 
-The permits package owns the connector-agnostic `authResource` and `authLayer`. Connector packages bind those declarations to concrete auth logic, just like a surface connector binds a topo to CLI, MCP, or HTTP.
+The permits package owns connector-agnostic auth resources, connectors, and helpers. Core `executeTrail` enforces trail `permit` declarations once a surface has resolved a permit into `ctx.permit`.
 
 ## The core pattern
 
@@ -12,7 +12,7 @@ The permits package owns the connector-agnostic `authResource` and `authLayer`. 
 export const create = trail('gist.create', {
   permit: { scopes: ['gist:write'] },
   blaze: async (input, ctx) => {
-    // authLayer enforces scopes before blaze runs
+    // executeTrail enforces scopes before blaze runs
     return Result.ok(newGist);
   },
 });
@@ -26,19 +26,19 @@ export const search = trail('gist.search', {
 });
 ```
 
-### 2. Register the auth layer
+### 2. Resolve a permit at the trailhead
 
 ```typescript
-import { authLayer } from '@ontrails/permits';
-
 export const graph = topo('my-app', gistModule);
-// Register authLayer with your surface
+// Surface auth verifies credentials and passes { permit } into executeTrail.
 ```
 
-The layer reads each trail's `permit` field:
+The execution pipeline reads each trail's `permit` field:
 
-- `'public'` or `undefined` — layer passes through
-- `{ scopes: [...] }` — layer checks that `ctx.permit` contains all required scopes
+- `'public'` or `undefined` — execution passes through
+- `{ scopes: [...] }` — execution checks that `ctx.permit` contains all required scopes
+
+`authLayer` remains exported as a deprecated compatibility wrapper for older app configuration, but it no longer owns permit enforcement.
 
 ### 3. Bind a connector at bootstrap
 

--- a/packages/permits/src/__tests__/auth-layer.test.ts
+++ b/packages/permits/src/__tests__/auth-layer.test.ts
@@ -6,7 +6,6 @@ import type { TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
 import { authLayer } from '../auth-layer';
-import { PermitError } from '../errors';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -64,7 +63,7 @@ describe('authLayer', () => {
     });
   });
 
-  describe('scope enforcement', () => {
+  describe('compatibility pass-through', () => {
     const scopedTrail = trail('test.scoped', {
       blaze: okImpl,
       input: z.object({}),
@@ -83,17 +82,15 @@ describe('authLayer', () => {
       expect(result.unwrap()).toEqual({ done: true });
     });
 
-    test('returns error when ctx has no permit', async () => {
+    test('does not enforce missing permits directly', async () => {
       const wrapped = authLayer.wrap(scopedTrail, okImpl);
       const result = await wrapped({}, makeCtx());
 
-      expect(result.isErr()).toBe(true);
-      const err = (result as unknown as { error: PermitError }).error;
-      expect(err).toBeInstanceOf(PermitError);
-      expect(err.message).toContain('No permit');
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
     });
 
-    test('returns error when permit is missing required scopes', async () => {
+    test('does not enforce missing scopes directly', async () => {
       const multiScopeTrail = trail('test.multi', {
         blaze: okImpl,
         input: z.object({}),
@@ -107,10 +104,8 @@ describe('authLayer', () => {
         makeCtx({ id: 'usr-1', scopes: ['user:read'] })
       );
 
-      expect(result.isErr()).toBe(true);
-      const err = (result as unknown as { error: PermitError }).error;
-      expect(err).toBeInstanceOf(PermitError);
-      expect(err.message).toContain('user:write');
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toEqual({ done: true });
     });
 
     test('passes when permit has superset of required scopes', async () => {

--- a/packages/permits/src/__tests__/connector.test.ts
+++ b/packages/permits/src/__tests__/connector.test.ts
@@ -183,6 +183,21 @@ describe('createJwtConnector', () => {
     expect(err.message).toContain('Missing expiration claim');
   });
 
+  test('treats null expiration as missing when expiration is required', async () => {
+    const connector = createJwtConnector({ secret: TEST_SECRET });
+    const token = await signJwtPayload(
+      '{"exp":null,"sub":"user-null-exp"}',
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Missing expiration claim');
+  });
+
   test('allows missing expiration only when explicitly configured', async () => {
     const connector = createJwtConnector({
       requireExpiration: false,
@@ -195,6 +210,24 @@ describe('createJwtConnector', () => {
     expect(result.isOk()).toBe(true);
     const permit = result.unwrap() as Permit;
     expect(permit.id).toBe('user-no-exp-allowed');
+  });
+
+  test('rejects null expiration even when expiration is optional', async () => {
+    const connector = createJwtConnector({
+      requireExpiration: false,
+      secret: TEST_SECRET,
+    });
+    const token = await signJwtPayload(
+      '{"exp":null,"sub":"user-null-exp-optional"}',
+      TEST_SECRET
+    );
+    const result = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(result.isErr()).toBe(true);
+    const err = (result as ReturnType<typeof Result.err<AuthError>>).error;
+    expect(err.code).toBe('invalid_token');
+    expect(err.message).toContain('Invalid expiration claim');
   });
 
   test('rejects expired tokens even when expiration is optional', async () => {

--- a/packages/permits/src/auth-layer.ts
+++ b/packages/permits/src/auth-layer.ts
@@ -1,80 +1,17 @@
-import { Result } from '@ontrails/core';
 import type { Layer } from '@ontrails/core';
-
-import { PermitError } from './errors.js';
-import { getPermit } from './permit.js';
-
-// ---------------------------------------------------------------------------
-// Helpers (defined before callers — no use-before-define)
-// ---------------------------------------------------------------------------
-
-/**
- * Returns `true` when the permit requirement means "no enforcement needed."
- * Either the trail hasn't declared a permit posture or has explicitly
- * opted out with `'public'`.
- */
-const isPassThrough = (
-  requirement: unknown
-): requirement is undefined | 'public' =>
-  requirement === undefined || requirement === 'public';
-
-/** Returns scopes present in `required` but absent from `held`. */
-const findMissing = (
-  required: readonly string[],
-  held: readonly string[]
-): readonly string[] => required.filter((s) => !held.includes(s));
 
 // ---------------------------------------------------------------------------
 // Auth layer
 // ---------------------------------------------------------------------------
 
 /**
- * A {@link Layer} that enforces permit scopes declared on trails.
+ * Compatibility layer for older apps that still include `authLayer`.
  *
- * The layer reads the trail's `permit` field (a `PermitRequirement`):
- *
- * - If `permit` is `'public'` or `undefined` the layer passes through.
- * - If `permit` has `scopes`, the layer checks that `ctx.permit` contains
- *   all required scopes. A superset is fine; missing scopes produce a
- *   `PermitError`.
- *
- * Because `ctx.cross()` re-enters `executeTrail` (which applies layers),
- * this layer automatically re-checks on every invocation in a crossing chain.
- * No special crossing-chain handling is needed — it is built into the
- * architecture.
+ * @deprecated Permit scope enforcement is an intrinsic `executeTrail` pipeline
+ * stage. Keep this layer only while migrating existing app configuration.
  */
 export const authLayer: Layer = {
-  description: 'Enforces permit scopes declared on trails',
+  description: 'Compatibility wrapper; permit enforcement is intrinsic',
   name: 'auth',
-  wrap: (_trail, impl) => {
-    const requirement = _trail.permit;
-
-    if (isPassThrough(requirement)) {
-      return impl;
-    }
-
-    return (input, ctx) => {
-      const permit = getPermit(ctx);
-
-      if (!permit) {
-        return Promise.resolve(
-          Result.err(new PermitError('No permit provided'))
-        );
-      }
-
-      const missing = findMissing(requirement.scopes, permit.scopes);
-
-      if (missing.length > 0) {
-        return Promise.resolve(
-          Result.err(
-            new PermitError(`Missing scopes: ${missing.join(', ')}`, {
-              context: { missing, required: requirement.scopes },
-            })
-          )
-        );
-      }
-
-      return Promise.resolve(impl(input, ctx));
-    };
-  },
+  wrap: (_trail, impl) => impl,
 };

--- a/packages/permits/src/connectors/jwt.ts
+++ b/packages/permits/src/connectors/jwt.ts
@@ -40,7 +40,7 @@ interface JwtPayload {
   readonly sub?: string;
   readonly iss?: string;
   readonly aud?: string | readonly string[];
-  readonly exp?: number;
+  readonly exp?: number | null;
   readonly nbf?: number;
   readonly [key: string]: unknown;
 }
@@ -193,7 +193,8 @@ const validateClaims = (
 ): AuthError | undefined => {
   const now = Math.floor(Date.now() / 1000);
   const skew = normalizeClockSkewSeconds(options);
-  if (payload.exp === undefined && options.requireExpiration !== false) {
+  const hasExpirationClaim = payload.exp !== undefined && payload.exp !== null;
+  if (!hasExpirationClaim && options.requireExpiration !== false) {
     return { code: 'invalid_token', message: 'Missing expiration claim (exp)' };
   }
   if (
@@ -202,7 +203,11 @@ const validateClaims = (
   ) {
     return { code: 'invalid_token', message: 'Invalid expiration claim (exp)' };
   }
-  if (payload.exp !== undefined && payload.exp < now - skew) {
+  if (
+    payload.exp !== undefined &&
+    payload.exp !== null &&
+    payload.exp < now - skew
+  ) {
     return { code: 'expired_token', message: 'Token has expired' };
   }
   if (payload.nbf !== undefined) {

--- a/packages/permits/src/errors.ts
+++ b/packages/permits/src/errors.ts
@@ -1,18 +1,1 @@
-import { PermissionError } from '@ontrails/core';
-
-/**
- * Error returned when permit scope enforcement fails.
- *
- * Extends `PermissionError` (category `'permission'`, HTTP 403) because
- * it represents an *authorization* failure — the caller's identity is known
- * but lacks the required scopes.
- */
-export class PermitError extends PermissionError {
-  constructor(
-    message: string,
-    options?: { cause?: Error; context?: Record<string, unknown> }
-  ) {
-    super(message, options);
-    this.name = 'PermitError';
-  }
-}
+export { PermitError } from '@ontrails/core';

--- a/packages/testing/src/__tests__/examples.test.ts
+++ b/packages/testing/src/__tests__/examples.test.ts
@@ -548,12 +548,12 @@ describe('testExamples auto-minting permits', () => {
     const strictScopedTrail = trail('strict.scoped', {
       blaze: (_input, ctx) =>
         Result.ok({ hasPermit: ctx.permit !== undefined }),
-      description: 'Trail that expects no permit under strictPermits',
+      description: 'Trail that requires an explicit permit under strictPermits',
       examples: [
         {
-          expected: { hasPermit: false },
+          error: 'PermitError',
           input: {},
-          name: 'No auto-minted permit when strictPermits is true',
+          name: 'Fails without an explicit permit when strictPermits is true',
         },
       ],
       input: z.object({}),

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -31,6 +31,7 @@ import {
   NetworkError,
   NotFoundError,
   PermissionError,
+  PermitError,
   RateLimitError,
   RetryExhaustedError,
   executeTrail,
@@ -74,6 +75,7 @@ const ERROR_MAP: Record<string, new (...args: never[]) => Error> = {
   NetworkError: NetworkError as new (...args: never[]) => Error,
   NotFoundError: NotFoundError as new (...args: never[]) => Error,
   PermissionError: PermissionError as new (...args: never[]) => Error,
+  PermitError: PermitError as new (...args: never[]) => Error,
   RateLimitError: RateLimitError as new (...args: never[]) => Error,
   RetryExhaustedError: RetryExhaustedError as unknown as new (
     ...args: never[]


### PR DESCRIPTION
## Summary
- Moves scoped permit enforcement into the shared execution pipeline while preserving the compatibility wrapper.
- Cleans up boundary follow-ups for create-route project name validation, project write helper contracts, load-app mirror cleanup, Hono body/test hardening, and JWT null-exp semantics.
- Updates testing strict-permit expectations so scoped trails fail without explicit permits when auto-minting is disabled.

## Validation
- bun run check
- bun run build
- bun run test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes: TRL-468, TRL-576, TRL-577, TRL-579, TRL-580, TRL-581, TRL-582