### PR TITLE
feat: add plan/apply for framework writes

### DIFF
--- a/apps/trails/src/__tests__/create.test.ts
+++ b/apps/trails/src/__tests__/create.test.ts
@@ -301,6 +301,61 @@ describe('trails create', () => {
       });
     });
 
+    test('plans scaffold writes without touching disk and applies the same operations', async () => {
+      await withTempProject(async (dir) => {
+        const dryRun = expectOk(
+          await createScaffold.blaze(
+            {
+              dir: dirname(dir),
+              dryRun: true,
+              name: basename(dir),
+              starter: 'hello',
+            },
+            {} as never
+          )
+        );
+
+        expect(dryRun.dryRun).toBe(true);
+        expect(dryRun.created).toEqual([]);
+        expect(dryRun.plannedOperations).toEqual(
+          expect.arrayContaining([
+            { kind: 'write', path: 'package.json' },
+            { kind: 'write', path: 'src/app.ts' },
+            { kind: 'mkdir', path: '.trails' },
+          ])
+        );
+        expect(existsSync(dir)).toBe(false);
+
+        const applied = expectOk(
+          await createScaffold.blaze(
+            {
+              dir: dirname(dir),
+              name: basename(dir),
+              starter: 'hello',
+            },
+            {} as never
+          )
+        );
+
+        expect(applied.dryRun).toBe(false);
+        expect(applied.plannedOperations).toEqual(dryRun.plannedOperations);
+        expectPaths(
+          dir,
+          [
+            'package.json',
+            'tsconfig.json',
+            '.gitignore',
+            'oxlint.config.ts',
+            '.oxfmtrc.jsonc',
+            'src/app.ts',
+            '.trails',
+            'src/trails/hello.ts',
+          ],
+          true
+        );
+      });
+    });
+
     test('generates with entity starter', async () => {
       await withTempProject(async (dir) => {
         expectOk(await runCreate(dir, { starter: 'entity' }));

--- a/apps/trails/src/__tests__/draft-promote.test.ts
+++ b/apps/trails/src/__tests__/draft-promote.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -63,7 +64,10 @@ export const draftPrepare = trail('_draft.entity.prepare', {
   writeFileSync(
     join(dir, 'src', 'export.ts'),
     `import { Result, trail } from '@ontrails/core';
+import { draftPrepare } from './_draft.prepare.js';
 import { z } from 'zod';
+
+export const dependencies = [draftPrepare];
 
 export const exportTrail = trail('entity.export', {
   blaze: async () => Result.ok({ exported: true }),
@@ -83,6 +87,9 @@ const expectDraftPromoteResults = (dir: string): void => {
   );
   expect(readFileSync(join(dir, 'src', 'export.ts'), 'utf8')).toContain(
     "crosses: ['entity.prepare']"
+  );
+  expect(readFileSync(join(dir, 'src', 'export.ts'), 'utf8')).toContain(
+    "from './prepare.js'"
   );
   expect(readFileSync(join(dir, 'src', 'app.ts'), 'utf8')).toContain(
     "from './prepare.js'"
@@ -119,6 +126,79 @@ describe('draft.promote', () => {
           to: 'src/prepare.ts',
         },
       ]);
+      expectDraftPromoteResults(dir);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('plans promotion rewrites without touching disk and applies the same operations', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeDraftPromoteFixture(dir);
+      const originalDraft = readFileSync(
+        join(dir, 'src', '_draft.prepare.ts'),
+        'utf8'
+      );
+      const originalApp = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
+
+      const dryRun = expectOk(
+        await draftPromoteTrail.blaze(
+          {
+            dryRun: true,
+            fromId: '_draft.entity.prepare',
+            renameFiles: true,
+            rootDir: dir,
+            toId: 'entity.prepare',
+          },
+          { cwd: dir } as never
+        )
+      );
+
+      expect(dryRun.dryRun).toBe(true);
+      expect(dryRun.promotedEstablished).toBe(false);
+      expect(dryRun.plannedOperations).toEqual(
+        expect.arrayContaining([
+          { kind: 'write', path: 'src/_draft.prepare.ts' },
+          {
+            from: 'src/_draft.prepare.ts',
+            kind: 'rename',
+            to: 'src/prepare.ts',
+          },
+          { kind: 'write', path: 'src/app.ts' },
+        ])
+      );
+      expect(
+        dryRun.plannedOperations.filter(
+          (operation) =>
+            operation.kind === 'write' && operation.path === 'src/export.ts'
+        )
+      ).toHaveLength(1);
+      expect(existsSync(join(dir, 'src', '_draft.prepare.ts'))).toBe(true);
+      expect(existsSync(join(dir, 'src', 'prepare.ts'))).toBe(false);
+      expect(readFileSync(join(dir, 'src', '_draft.prepare.ts'), 'utf8')).toBe(
+        originalDraft
+      );
+      expect(readFileSync(join(dir, 'src', 'app.ts'), 'utf8')).toBe(
+        originalApp
+      );
+
+      const applied = expectOk(
+        await draftPromoteTrail.blaze(
+          {
+            fromId: '_draft.entity.prepare',
+            renameFiles: true,
+            rootDir: dir,
+            toId: 'entity.prepare',
+          },
+          { cwd: dir } as never
+        )
+      );
+
+      expect(applied.dryRun).toBe(false);
+      expect(applied.plannedOperations).toEqual(dryRun.plannedOperations);
+      expect(applied.promotedEstablished).toBe(true);
       expectDraftPromoteResults(dir);
     } finally {
       rmSync(dir, { force: true, recursive: true });
@@ -203,5 +283,32 @@ describe('draft.promote', () => {
 
     expect(error).toBeInstanceOf(ValidationError);
     expect(error.message).toContain('rootDir does not exist');
+  });
+
+  test('returns ValidationError when a source file cannot be read', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeDraftPromoteFixture(dir);
+      chmodSync(join(dir, 'src', 'export.ts'), 0o000);
+
+      const error = expectErr(
+        await draftPromoteTrail.blaze(
+          {
+            fromId: '_draft.entity.prepare',
+            renameFiles: true,
+            rootDir: dir,
+            toId: 'entity.prepare',
+          },
+          { cwd: dir } as never
+        )
+      );
+
+      expect(error).toBeInstanceOf(ValidationError);
+      expect(error.message).toContain('Cannot read source file');
+      expect(error.message).toContain('export.ts');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
   });
 });

--- a/apps/trails/src/project-writes.ts
+++ b/apps/trails/src/project-writes.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, renameSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 
 import {
   DRAFT_ID_PREFIX,
@@ -21,6 +21,20 @@ export const TRAIL_ID_MESSAGE =
 
 const asError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
+
+export type PlannedProjectOperation =
+  | { readonly kind: 'mkdir'; readonly path: string }
+  | { readonly kind: 'rename'; readonly from: string; readonly to: string }
+  | { readonly kind: 'write'; readonly path: string };
+
+export type ProjectWriteOperation =
+  | { readonly kind: 'mkdir'; readonly path: string }
+  | { readonly kind: 'rename'; readonly from: string; readonly to: string }
+  | {
+      readonly content: string | Uint8Array;
+      readonly kind: 'write';
+      readonly path: string;
+    };
 
 export const validateProjectName = (
   name: string
@@ -60,31 +74,6 @@ export const resolveProjectPath = (
   projectDir: string,
   relativePath: string
 ): TrailsResult<string, Error> => deriveSafePath(projectDir, relativePath);
-
-export const ensureProjectDirectory = (
-  projectDir: string,
-  relativePath: string
-): TrailsResult<string, Error> => {
-  const target = resolveProjectPath(projectDir, relativePath);
-  if (target.isErr()) {
-    return target;
-  }
-
-  try {
-    mkdirSync(target.value, { recursive: true });
-    return Result.ok(target.value);
-  } catch (error) {
-    return Result.err(
-      new InternalError(
-        `Failed to create project directory "${relativePath}"`,
-        {
-          cause: asError(error),
-          context: { projectDir, relativePath },
-        }
-      )
-    );
-  }
-};
 
 export const projectPathExists = (
   projectDir: string,
@@ -180,4 +169,152 @@ export const renameContainedProjectPath = (
       )
     );
   }
+};
+
+const toProjectRelativePath = (
+  projectDir: string,
+  pathWithinProject: string
+): TrailsResult<string, Error> => {
+  const target = resolveProjectPath(projectDir, pathWithinProject);
+  if (target.isErr()) {
+    return target;
+  }
+
+  return Result.ok(
+    relative(resolve(projectDir), target.value).replaceAll('\\', '/')
+  );
+};
+
+export const planProjectOperation = (
+  projectDir: string,
+  operation: ProjectWriteOperation
+): TrailsResult<PlannedProjectOperation, Error> => {
+  switch (operation.kind) {
+    case 'mkdir': {
+      const path = toProjectRelativePath(projectDir, operation.path);
+      return path.isErr()
+        ? path
+        : Result.ok({ kind: 'mkdir', path: path.value });
+    }
+    case 'rename': {
+      const from = toProjectRelativePath(projectDir, operation.from);
+      if (from.isErr()) {
+        return from;
+      }
+      const to = toProjectRelativePath(projectDir, operation.to);
+      return to.isErr()
+        ? to
+        : Result.ok({ from: from.value, kind: 'rename', to: to.value });
+    }
+    case 'write': {
+      const path = toProjectRelativePath(projectDir, operation.path);
+      return path.isErr()
+        ? path
+        : Result.ok({ kind: 'write', path: path.value });
+    }
+    default: {
+      return Result.err(
+        new InternalError('Unknown project operation kind', {
+          context: { operation },
+        })
+      );
+    }
+  }
+};
+
+export const planProjectOperations = (
+  projectDir: string,
+  operations: readonly ProjectWriteOperation[]
+): TrailsResult<PlannedProjectOperation[], Error> => {
+  const planned: PlannedProjectOperation[] = [];
+  for (const operation of operations) {
+    const result = planProjectOperation(projectDir, operation);
+    if (result.isErr()) {
+      return Result.err(result.error);
+    }
+    planned.push(result.value);
+  }
+  return Result.ok(planned);
+};
+
+const applyProjectOperation = async (
+  projectDir: string,
+  operation: ProjectWriteOperation
+): Promise<TrailsResult<void, Error>> => {
+  switch (operation.kind) {
+    case 'mkdir': {
+      const target = resolveProjectPath(projectDir, operation.path);
+      if (target.isErr()) {
+        return Result.err(target.error);
+      }
+      try {
+        mkdirSync(target.value, { recursive: true });
+        return Result.ok();
+      } catch (error) {
+        return Result.err(
+          new InternalError(
+            `Failed to create project directory "${operation.path}"`,
+            {
+              cause: asError(error),
+              context: { projectDir, relativePath: operation.path },
+            }
+          )
+        );
+      }
+    }
+    case 'rename': {
+      return renameContainedProjectPath(
+        projectDir,
+        operation.from,
+        operation.to
+      );
+    }
+    case 'write': {
+      const target = resolveProjectPath(projectDir, operation.path);
+      if (target.isErr()) {
+        return Result.err(target.error);
+      }
+      try {
+        mkdirSync(dirname(target.value), { recursive: true });
+        await Bun.write(target.value, operation.content);
+        return Result.ok();
+      } catch (error) {
+        return Result.err(
+          new InternalError(
+            `Failed to write project file "${operation.path}"`,
+            {
+              cause: asError(error),
+              context: { projectDir, relativePath: operation.path },
+            }
+          )
+        );
+      }
+    }
+    default: {
+      return Result.err(
+        new InternalError('Unknown project operation kind', {
+          context: { operation },
+        })
+      );
+    }
+  }
+};
+
+export const applyProjectOperations = async (
+  projectDir: string,
+  operations: readonly ProjectWriteOperation[]
+): Promise<TrailsResult<PlannedProjectOperation[], Error>> => {
+  const planned = planProjectOperations(projectDir, operations);
+  if (planned.isErr()) {
+    return Result.err(planned.error);
+  }
+
+  for (const operation of operations) {
+    const applied = await applyProjectOperation(projectDir, operation);
+    if (applied.isErr()) {
+      return Result.err(applied.error);
+    }
+  }
+
+  return planned;
 };

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -10,11 +10,15 @@ import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import {
-  ensureProjectDirectory,
+  applyProjectOperations,
+  planProjectOperations,
   PROJECT_NAME_MESSAGE,
   PROJECT_NAME_PATTERN,
   resolveProjectDir,
-  writeProjectFile,
+} from '../project-writes.js';
+import type {
+  PlannedProjectOperation,
+  ProjectWriteOperation,
 } from '../project-writes.js';
 import {
   ontrailsPackageRange,
@@ -30,7 +34,9 @@ type Starter = 'empty' | 'entity' | 'hello';
 interface ScaffoldResult {
   readonly created: string[];
   readonly dir: string;
+  readonly dryRun: boolean;
   readonly name: string;
+  readonly plannedOperations: PlannedProjectOperation[];
 }
 
 // ---------------------------------------------------------------------------
@@ -327,20 +333,16 @@ const collectScaffoldFiles = (
     ...starterFileGenerators[starter](),
   ]);
 
-const writeScaffoldFiles = async (
-  projectDir: string,
+const collectScaffoldOperations = (
   fileMap: Map<string, string>
-): Promise<Result<string[], Error>> => {
-  const files: string[] = [];
-  for (const [relativePath, content] of fileMap) {
-    const written = await writeProjectFile(projectDir, relativePath, content);
-    if (written.isErr()) {
-      return written;
-    }
-    files.push(written.value);
-  }
-  return Result.ok(files);
-};
+): ProjectWriteOperation[] => [
+  ...[...fileMap].map(([path, content]) => ({
+    content,
+    kind: 'write' as const,
+    path,
+  })),
+  { kind: 'mkdir' as const, path: '.trails' },
+];
 
 // ---------------------------------------------------------------------------
 // Trail definition
@@ -355,26 +357,33 @@ export const createScaffold = trail('create.scaffold', {
 
     const projectDir = projectDirResult.value;
     const starter = (input.starter ?? 'hello') as Starter;
+    const dryRun = input.dryRun === true;
     const fileMap = collectScaffoldFiles(input.name, starter);
-    const files = await writeScaffoldFiles(projectDir, fileMap);
-    if (files.isErr()) {
-      return Result.err(files.error);
+    const operations = collectScaffoldOperations(fileMap);
+    const plannedOperations = dryRun
+      ? planProjectOperations(projectDir, operations)
+      : await applyProjectOperations(projectDir, operations);
+    if (plannedOperations.isErr()) {
+      return Result.err(plannedOperations.error);
     }
 
-    const trailsDir = ensureProjectDirectory(projectDir, '.trails');
-    if (trailsDir.isErr()) {
-      return Result.err(trailsDir.error);
-    }
+    const created = dryRun ? [] : [...fileMap.keys()];
 
     return Result.ok({
-      created: files.value,
+      created,
       dir: resolve(projectDir),
+      dryRun,
       name: input.name,
+      plannedOperations: plannedOperations.value,
     } satisfies ScaffoldResult);
   },
   description: 'Scaffold a new Trails project',
   input: z.object({
     dir: z.string().optional().describe('Parent directory'),
+    dryRun: z
+      .boolean()
+      .default(false)
+      .describe('Plan scaffold writes without touching the project directory'),
     name: z
       .string()
       .regex(PROJECT_NAME_PATTERN, PROJECT_NAME_MESSAGE)
@@ -386,8 +395,22 @@ export const createScaffold = trail('create.scaffold', {
   }),
   meta: { internal: true },
   output: z.object({
-    created: z.array(z.string()),
+    created: z
+      .array(z.string())
+      .describe('Project-relative paths of files written (empty in dry-run)'),
     dir: z.string(),
+    dryRun: z.boolean(),
     name: z.string(),
+    plannedOperations: z.array(
+      z.discriminatedUnion('kind', [
+        z.object({ kind: z.literal('mkdir'), path: z.string() }),
+        z.object({
+          from: z.string(),
+          kind: z.literal('rename'),
+          to: z.string(),
+        }),
+        z.object({ kind: z.literal('write'), path: z.string() }),
+      ])
+    ),
   }),
 });

--- a/apps/trails/src/trails/draft-promote.ts
+++ b/apps/trails/src/trails/draft-promote.ts
@@ -19,8 +19,12 @@ import {
 import { z } from 'zod';
 
 import {
-  renameContainedProjectPath,
-  writeContainedProjectPath,
+  applyProjectOperations,
+  planProjectOperations,
+} from '../project-writes.js';
+import type {
+  PlannedProjectOperation,
+  ProjectWriteOperation,
 } from '../project-writes.js';
 import { loadFreshAppLease } from './load-app.js';
 import { findTopoPath } from './project.js';
@@ -181,6 +185,7 @@ const toProjectModulePath = (sourceImport: string): string =>
     : sourceImport;
 
 interface PromotionRewriteState {
+  readonly plannedOperations: PlannedProjectOperation[];
   readonly renames: FileRename[];
   readonly updatedSourceFiles: Set<string>;
 }
@@ -255,37 +260,83 @@ const resolveValidatedPromotionRoot = (
   return Result.ok(rootDir);
 };
 
-const rewritePromotedSourceFiles = async (
-  rootDir: string,
+type SourceFileMap = Map<string, string>;
+type WriteProjectOperation = Extract<
+  ProjectWriteOperation,
+  { readonly kind: 'write' }
+>;
+
+const pushWriteOperation = (
+  operations: ProjectWriteOperation[],
+  operation: WriteProjectOperation
+): void => {
+  for (let index = operations.length - 1; index >= 0; index -= 1) {
+    const existing = operations[index];
+    if (
+      existing?.kind === 'rename' &&
+      (existing.from === operation.path || existing.to === operation.path)
+    ) {
+      break;
+    }
+    if (existing?.kind === 'write' && existing.path === operation.path) {
+      operations[index] = operation;
+      return;
+    }
+  }
+
+  operations.push(operation);
+};
+
+const readSourceFiles = async (
+  filePaths: readonly string[]
+): Promise<Result<SourceFileMap, Error>> => {
+  const sources = new Map<string, string>();
+  for (const filePath of filePaths) {
+    try {
+      sources.set(filePath, await Bun.file(filePath).text());
+    } catch (error) {
+      return Result.err(
+        new ValidationError(
+          `Cannot read source file "${filePath}"`,
+          error instanceof Error ? { cause: error } : undefined
+        )
+      );
+    }
+  }
+  return Result.ok(sources);
+};
+
+const planPromotedSourceFiles = (
   filePaths: readonly string[],
+  sources: SourceFileMap,
   fromId: string,
   toId: string,
-  updatedSourceFiles: Set<string>
-): Promise<Result<void, Error>> => {
+  updatedSourceFiles: Set<string>,
+  operations: ProjectWriteOperation[]
+): Result<void, Error> => {
   for (const filePath of filePaths) {
-    const sourceCode = await Bun.file(filePath).text();
+    const sourceCode = sources.get(filePath);
+    if (sourceCode === undefined) {
+      return Result.err(
+        new ValidationError(`Cannot read source file "${filePath}"`)
+      );
+    }
+
     const replaced = replaceIdLiterals(sourceCode, filePath, fromId, toId);
     if (!replaced.changed) {
       continue;
     }
 
-    const written = await writeContainedProjectPath(
-      rootDir,
-      filePath,
-      replaced.nextSource
-    );
-    if (written.isErr()) {
-      return Result.err(written.error);
-    }
+    sources.set(filePath, replaced.nextSource);
+    pushWriteOperation(operations, {
+      content: replaced.nextSource,
+      kind: 'write',
+      path: filePath,
+    });
     updatedSourceFiles.add(filePath);
   }
 
   return Result.ok();
-};
-
-const hasDraftIdsInFile = async (filePath: string): Promise<boolean> => {
-  const sourceCode = await Bun.file(filePath).text();
-  return hasDraftIds(sourceCode, filePath);
 };
 
 const buildPromotableFileRename = (
@@ -309,9 +360,10 @@ const buildPromotableFileRename = (
   return Result.ok({ from: filePath, to: nextPath });
 };
 
-const collectPromotableFileRename = async (
-  filePath: string
-): Promise<Result<FileRename | null, Error>> => {
+const collectPromotableFileRename = (
+  filePath: string,
+  sourceCode: string
+): Result<FileRename | null, Error> => {
   if (!isDraftMarkedFile(filePath)) {
     return Result.ok(null);
   }
@@ -321,7 +373,7 @@ const collectPromotableFileRename = async (
     return Result.ok(null);
   }
 
-  if (await hasDraftIdsInFile(filePath)) {
+  if (hasDraftIds(sourceCode, filePath)) {
     return Result.ok(null);
   }
 
@@ -353,41 +405,24 @@ const validateRenameTargets = (
   return Result.ok();
 };
 
-const collectFileRenames = async (
-  filePaths: readonly string[]
-): Promise<Result<FileRename[], Error>> => {
+const collectFileRenames = (
+  filePaths: readonly string[],
+  sources: SourceFileMap
+): Result<FileRename[], Error> => {
   const renames: FileRename[] = [];
   for (const filePath of filePaths) {
-    const renameResult = await collectPromotableFileRename(filePath);
+    const sourceCode = sources.get(filePath);
+    if (sourceCode === undefined) {
+      return Result.err(
+        new ValidationError(`Cannot read source file "${filePath}"`)
+      );
+    }
+    const renameResult = collectPromotableFileRename(filePath, sourceCode);
     if (renameResult.isErr()) {
       return renameResult;
     }
     if (renameResult.value !== null) {
       renames.push(renameResult.value);
-    }
-  }
-  return Result.ok(renames);
-};
-
-const collectAndApplyFileRenames = async (
-  rootDir: string,
-  filePaths: readonly string[]
-): Promise<Result<FileRename[], Error>> => {
-  const collected = await collectFileRenames(filePaths);
-  if (collected.isErr()) {
-    return collected;
-  }
-
-  const renames = collected.value;
-  const valid = validateRenameTargets(renames);
-  if (valid.isErr()) {
-    return valid;
-  }
-
-  for (const r of renames) {
-    const renamed = renameContainedProjectPath(rootDir, r.from, r.to);
-    if (renamed.isErr()) {
-      return Result.err(renamed.error);
     }
   }
   return Result.ok(renames);
@@ -402,6 +437,30 @@ const applyRenameEffects = (
       updatedSourceFiles.add(rename.to);
     }
   }
+};
+
+const applySourceRenameEffects = (
+  sources: SourceFileMap,
+  renames: readonly FileRename[]
+): void => {
+  for (const rename of renames) {
+    const sourceCode = sources.get(rename.from);
+    if (sourceCode === undefined) {
+      continue;
+    }
+    sources.delete(rename.from);
+    sources.set(rename.to, sourceCode);
+  }
+};
+
+const applyFilePathRenames = (
+  filePaths: readonly string[],
+  renames: readonly FileRename[]
+): string[] => {
+  const renamedBySource = new Map(
+    renames.map((rename) => [rename.from, rename.to])
+  );
+  return filePaths.map((filePath) => renamedBySource.get(filePath) ?? filePath);
 };
 
 const applyRelativeImportRename = (
@@ -449,95 +508,128 @@ const rewriteRelativeImportsForFile = (
   return { changed, sourceCode: nextSourceCode };
 };
 
-const updateRelativeImportsForFile = async (
-  rootDir: string,
+const planRelativeImportsForFile = (
   filePath: string,
-  renames: readonly FileRename[]
-): Promise<Result<boolean, Error>> => {
-  const sourceCode = await Bun.file(filePath).text();
+  renames: readonly FileRename[],
+  sources: SourceFileMap,
+  operations: ProjectWriteOperation[]
+): Result<boolean, Error> => {
+  const sourceCode = sources.get(filePath);
+  if (sourceCode === undefined) {
+    return Result.err(
+      new ValidationError(`Cannot read source file "${filePath}"`)
+    );
+  }
+
   const updated = rewriteRelativeImportsForFile(filePath, renames, sourceCode);
   if (updated.changed) {
-    const written = await writeContainedProjectPath(
-      rootDir,
-      filePath,
-      updated.sourceCode
-    );
-    if (written.isErr()) {
-      return Result.err(written.error);
-    }
+    sources.set(filePath, updated.sourceCode);
+    pushWriteOperation(operations, {
+      content: updated.sourceCode,
+      kind: 'write',
+      path: filePath,
+    });
     return Result.ok(true);
   }
 
   return Result.ok(false);
 };
 
-const updateRelativeImports = async (
-  rootDir: string,
+const planRelativeImports = (
   filePaths: readonly string[],
-  renames: readonly FileRename[]
-): Promise<Result<string[], Error>> => {
-  const updatedFiles = new Set<string>();
-
+  renames: readonly FileRename[],
+  sources: SourceFileMap,
+  updatedSourceFiles: Set<string>,
+  operations: ProjectWriteOperation[]
+): Result<void, Error> => {
   for (const filePath of filePaths) {
-    const changed = await updateRelativeImportsForFile(
-      rootDir,
+    const changed = planRelativeImportsForFile(
       filePath,
-      renames
+      renames,
+      sources,
+      operations
     );
     if (changed.isErr()) {
       return Result.err(changed.error);
     }
     if (changed.value) {
-      updatedFiles.add(filePath);
+      updatedSourceFiles.add(filePath);
     }
   }
 
-  return Result.ok([...updatedFiles].toSorted());
+  return Result.ok();
 };
 
 const rewritePromotionState = async (
   rootDir: string,
   input: {
+    readonly dryRun?: boolean | undefined;
     readonly fromId: string;
     readonly renameFiles: boolean;
     readonly toId: string;
   }
 ): Promise<Result<PromotionRewriteState, Error>> => {
   const initialFiles = collectTsFiles(rootDir);
+  const sourcesResult = await readSourceFiles(initialFiles);
+  if (sourcesResult.isErr()) {
+    return Result.err(sourcesResult.error);
+  }
+  const sources = sourcesResult.value;
+  const operations: ProjectWriteOperation[] = [];
   const updatedSourceFiles = new Set<string>();
 
-  const rewritten = await rewritePromotedSourceFiles(
-    rootDir,
+  const rewritten = planPromotedSourceFiles(
     initialFiles,
+    sources,
     input.fromId,
     input.toId,
-    updatedSourceFiles
+    updatedSourceFiles,
+    operations
   );
   if (rewritten.isErr()) {
     return Result.err(rewritten.error);
   }
 
   const renamesResult = input.renameFiles
-    ? await collectAndApplyFileRenames(rootDir, initialFiles)
+    ? collectFileRenames(initialFiles, sources)
     : Result.ok([] as FileRename[]);
   if (renamesResult.isErr()) {
     return Result.err(renamesResult.error);
   }
 
+  const valid = validateRenameTargets(renamesResult.value);
+  if (valid.isErr()) {
+    return valid;
+  }
+
+  for (const rename of renamesResult.value) {
+    operations.push({ from: rename.from, kind: 'rename', to: rename.to });
+  }
+
   applyRenameEffects(updatedSourceFiles, renamesResult.value);
-  const importUpdates = await updateRelativeImports(
-    rootDir,
-    collectTsFiles(rootDir),
-    renamesResult.value
+  applySourceRenameEffects(sources, renamesResult.value);
+  const importUpdates = planRelativeImports(
+    applyFilePathRenames(initialFiles, renamesResult.value),
+    renamesResult.value,
+    sources,
+    updatedSourceFiles,
+    operations
   );
   if (importUpdates.isErr()) {
     return Result.err(importUpdates.error);
   }
 
-  for (const f of importUpdates.value) {
-    updatedSourceFiles.add(f);
+  const plannedOperations = input.dryRun
+    ? planProjectOperations(rootDir, operations)
+    : await applyProjectOperations(rootDir, operations);
+  if (plannedOperations.isErr()) {
+    return Result.err(plannedOperations.error);
   }
-  return Result.ok({ renames: renamesResult.value, updatedSourceFiles });
+  return Result.ok({
+    plannedOperations: plannedOperations.value,
+    renames: renamesResult.value,
+    updatedSourceFiles,
+  });
 };
 
 const resolvePromotionAppModule = async (
@@ -618,19 +710,33 @@ const toUpdatedFiles = (rootDir: string, updatedSourceFiles: Set<string>) =>
     .toSorted()
     .map((filePath) => toRelativeOutputPath(rootDir, filePath));
 
+const buildUnverifiedPromotionMessage = (
+  loadError: string | null,
+  dryRun: boolean
+): string => {
+  if (dryRun) {
+    return 'Promotion plan is valid. Re-run without dryRun to apply it.';
+  }
+
+  return loadError === null
+    ? 'Promotion rewrote source files, but no topo entrypoint could be loaded for verification.'
+    : `Promotion rewrote source files, but verification failed: ${loadError}`;
+};
+
 const buildUnverifiedPromotionResult = (
   rootDir: string,
   loadError: string | null,
   renames: readonly FileRename[],
   updatedSourceFiles: Set<string>,
-  appModule: string | null
+  appModule: string | null,
+  plannedOperations: readonly PlannedProjectOperation[],
+  dryRun: boolean
 ) =>
   Result.ok({
     appModule,
-    message:
-      loadError === null
-        ? 'Promotion rewrote source files, but no topo entrypoint could be loaded for verification.'
-        : `Promotion rewrote source files, but verification failed: ${loadError}`,
+    dryRun,
+    message: buildUnverifiedPromotionMessage(loadError, dryRun),
+    plannedOperations,
     promotedEstablished: false,
     remainingDraftIds: [],
     renamedFiles: toRenamedFiles(rootDir, renames),
@@ -644,6 +750,7 @@ const buildVerifiedPromotionResult = (
   renames: readonly FileRename[],
   updatedSourceFiles: Set<string>,
   appModule: string | null,
+  plannedOperations: readonly PlannedProjectOperation[],
   toId: string
 ) => {
   const blockingFinding = analysis.findings.find(
@@ -652,11 +759,13 @@ const buildVerifiedPromotionResult = (
 
   return Result.ok({
     appModule,
+    dryRun: false,
     message:
       blockingFinding?.message ??
       (promotedEstablished
         ? `Promoted "${toId}" is now established.`
         : `Promoted "${toId}" could not be verified as established.`),
+    plannedOperations,
     promotedEstablished,
     remainingDraftIds: [...analysis.declaredDraftIds].toSorted(),
     renamedFiles: toRenamedFiles(rootDir, renames),
@@ -670,6 +779,7 @@ const buildVerifiedPromotionResultFromApp = (
   renames: readonly FileRename[],
   updatedSourceFiles: Set<string>,
   appModule: string | null,
+  plannedOperations: readonly PlannedProjectOperation[],
   toId: string
 ) => {
   const analysis = deriveDraftReport(loadedApp);
@@ -684,6 +794,7 @@ const buildVerifiedPromotionResultFromApp = (
     renames,
     updatedSourceFiles,
     appModule,
+    plannedOperations,
     toId
   );
 };
@@ -691,6 +802,7 @@ const buildVerifiedPromotionResultFromApp = (
 const promoteDraftState = async (
   input: {
     readonly appModule?: string | undefined;
+    readonly dryRun?: boolean | undefined;
     readonly fromId: string;
     readonly renameFiles: boolean;
     readonly rootDir?: string | undefined;
@@ -710,6 +822,18 @@ const promoteDraftState = async (
 
   const { renames, updatedSourceFiles } = rewriteResult.value;
   const appModule = await resolvePromotionAppModule(input, rootDirResult.value);
+  if (input.dryRun === true) {
+    return buildUnverifiedPromotionResult(
+      rootDirResult.value,
+      null,
+      renames,
+      updatedSourceFiles,
+      appModule,
+      rewriteResult.value.plannedOperations,
+      true
+    );
+  }
+
   const { load, value } = await withVerifiedApp(
     appModule,
     rootDirResult.value,
@@ -720,6 +844,7 @@ const promoteDraftState = async (
         renames,
         updatedSourceFiles,
         appModule,
+        rewriteResult.value.plannedOperations,
         input.toId
       )
   );
@@ -731,7 +856,9 @@ const promoteDraftState = async (
       load.loadError,
       renames,
       updatedSourceFiles,
-      appModule
+      appModule,
+      rewriteResult.value.plannedOperations,
+      false
     )
   );
 };
@@ -758,6 +885,10 @@ export const draftPromoteTrail = trail('draft.promote', {
       .string()
       .optional()
       .describe('Optional app module to verify after promotion'),
+    dryRun: z
+      .boolean()
+      .default(false)
+      .describe('Plan promotion rewrites without touching source files'),
     fromId: z.string().describe('Draft id to promote'),
     renameFiles: z
       .boolean()
@@ -771,7 +902,19 @@ export const draftPromoteTrail = trail('draft.promote', {
   intent: 'write',
   output: z.object({
     appModule: z.string().nullable(),
+    dryRun: z.boolean(),
     message: z.string(),
+    plannedOperations: z.array(
+      z.discriminatedUnion('kind', [
+        z.object({ kind: z.literal('mkdir'), path: z.string() }),
+        z.object({
+          from: z.string(),
+          kind: z.literal('rename'),
+          to: z.string(),
+        }),
+        z.object({ kind: z.literal('write'), path: z.string() }),
+      ])
+    ),
     promotedEstablished: z.boolean(),
     remainingDraftIds: z.array(z.string()),
     renamedFiles: z.array(


### PR DESCRIPTION
## Summary
- Adds dry-run plan output for scaffold and draft-promote write flows.
- Routes apply mode through the same validated plan so reported operations and writes stay aligned.
- Covers no-write dry runs and applied writes in the relevant app and Trails tests.

## Validation
- bun run check
- bun run build
- bun run test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes: TRL-565, TRL-570