### PR TITLE
fix: enforce runtime output contracts

### DIFF
--- a/apps/trails/src/__tests__/guide.test.ts
+++ b/apps/trails/src/__tests__/guide.test.ts
@@ -4,6 +4,8 @@ import type { AnyTrail } from '@ontrails/core';
 import { ConflictError, trail, topo, Result } from '@ontrails/core';
 import { z } from 'zod';
 
+import { guideTrail } from '../trails/guide.js';
+
 // ---------------------------------------------------------------------------
 // Test fixtures
 // ---------------------------------------------------------------------------
@@ -92,5 +94,44 @@ describe('trails guide', () => {
     expect(t).toBeDefined();
     expect(t.detours).toHaveLength(1);
     expect(t.detours[0]?.on).toBe(ConflictError);
+  });
+
+  test('output schema uses mode as the public discriminant', () => {
+    expect(
+      guideTrail.output.safeParse({
+        entries: [
+          {
+            description: 'Say hello',
+            exampleCount: 2,
+            id: 'hello',
+            kind: 'trail',
+          },
+        ],
+        mode: 'list',
+      }).success
+    ).toBe(true);
+
+    expect(
+      guideTrail.output.safeParse({
+        detail: {
+          crosses: [],
+          description: 'Say hello',
+          detours: [
+            {
+              maxAttempts: 1,
+              on: 'ConflictError',
+            },
+          ],
+          examples: [],
+          id: 'hello',
+          intent: 'read',
+          kind: 'trail',
+          pattern: null,
+          resources: [],
+          safety: 'read',
+        },
+        mode: 'detail',
+      }).success
+    ).toBe(true);
   });
 });

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -13,6 +13,7 @@ import {
   deriveSurfaceMap,
   deriveSurfaceMapHash,
   deriveSurfaceMapDiff,
+  deriveOpenApiSpec,
   writeSurfaceMap,
 } from '@ontrails/schema';
 import type { SurfaceMap } from '@ontrails/schema';
@@ -307,8 +308,10 @@ describe('trails survey generate', () => {
         readonly hash: string;
         readonly lockPath: string;
         readonly mapPath: string;
+        readonly mode: 'generate';
       };
 
+      expect(generated.mode).toBe('generate');
       expect(generated.hash).toHaveLength(64);
       expect(existsSync(join(dir, '.trails', '_surface.json'))).toBe(true);
       expect(existsSync(join(dir, '.trails', 'trails.lock'))).toBe(true);
@@ -369,9 +372,98 @@ describe('trails survey diffSaved', () => {
             id: 'bye',
           }),
         ],
+        mode: 'diff',
       });
     } finally {
       rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('trails survey output schema', () => {
+  test('uses mode as the public discriminant', () => {
+    expect(
+      surveyTrail.output.safeParse({
+        ...deriveSurveyList(app),
+        mode: 'list',
+      }).success
+    ).toBe(true);
+    expect(
+      surveyTrail.output.safeParse({
+        ...deriveBriefReport(app),
+        mode: 'brief',
+      }).success
+    ).toBe(true);
+    expect(
+      surveyTrail.output.safeParse({
+        detail: deriveTrailDetail(helloTrail),
+        mode: 'detail',
+      }).success
+    ).toBe(true);
+    expect(
+      surveyTrail.output.safeParse({
+        breaking: [],
+        hasBreaking: false,
+        info: [],
+        mode: 'diff',
+        warnings: [],
+      }).success
+    ).toBe(true);
+    expect(
+      surveyTrail.output.safeParse({
+        hash: 'a'.repeat(64),
+        lockPath: '.trails/trails.lock',
+        mapPath: '.trails/_surface.json',
+        mode: 'generate',
+      }).success
+    ).toBe(true);
+    expect(
+      surveyTrail.output.safeParse({
+        mode: 'openapi',
+        spec: deriveOpenApiSpec(app),
+      }).success
+    ).toBe(true);
+
+    // Regression: the openapi spec schema must NOT silently strip extra
+    // fields produced by deriveOpenApiSpec or richer real-world specs.
+    // Zod's default strip mode would drop these; .loose() preserves them.
+    const richSpec = {
+      ...deriveOpenApiSpec(app),
+      components: {
+        schemas: {},
+        securitySchemes: { bearerAuth: { scheme: 'bearer', type: 'http' } },
+      },
+      externalDocs: { url: 'https://example.com/docs' },
+      info: {
+        contact: { email: 'maintainer@example.com', name: 'Maintainer' },
+        license: { name: 'MIT' },
+        title: 'Test',
+        version: '1.0.0',
+      },
+      security: [{ bearerAuth: [] }],
+      tags: [{ description: 'Trail operations', name: 'trails' }],
+    };
+    const parsed = surveyTrail.output.safeParse({
+      mode: 'openapi',
+      spec: richSpec,
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.mode === 'openapi') {
+      const spec = parsed.data.spec as Record<string, unknown>;
+      expect(spec['security']).toEqual([{ bearerAuth: [] }]);
+      expect(spec['tags']).toEqual([
+        { description: 'Trail operations', name: 'trails' },
+      ]);
+      expect(spec['externalDocs']).toEqual({
+        url: 'https://example.com/docs',
+      });
+      expect(
+        (spec['components'] as Record<string, unknown>)['securitySchemes']
+      ).toEqual({ bearerAuth: { scheme: 'bearer', type: 'http' } });
+      expect((spec['info'] as Record<string, unknown>)['contact']).toEqual({
+        email: 'maintainer@example.com',
+        name: 'Maintainer',
+      });
     }
   });
 });

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -109,7 +109,9 @@ describe('topo and dev trails', () => {
         } as never)
       );
       expect(detail.id).toBe('hello');
+      expect(detail.kind).toBe('trail');
       expect(detail.resources).toEqual(['db.main']);
+      expect(topoShowTrail.output.safeParse(detail).success).toBe(true);
 
       const exportResult = expectOk(
         await topoExportTrail.blaze(moduleInput, { cwd: dir } as never)
@@ -157,6 +159,7 @@ describe('topo and dev trails', () => {
       );
       expect(surveyList).toMatchObject({
         count: 2,
+        mode: 'list',
         resourceCount: 1,
       });
 
@@ -171,6 +174,7 @@ describe('topo and dev trails', () => {
           outputSchemas: true,
           resources: true,
         },
+        mode: 'brief',
         name: 'fixture-app',
         trails: 2,
       });
@@ -181,8 +185,11 @@ describe('topo and dev trails', () => {
         } as never)
       );
       expect(surveyDetail).toMatchObject({
-        id: 'hello',
-        resources: ['db.main'],
+        detail: {
+          id: 'hello',
+          resources: ['db.main'],
+        },
+        mode: 'detail',
       });
 
       const guideList = expectOk(
@@ -190,20 +197,23 @@ describe('topo and dev trails', () => {
           cwd: dir,
         } as never)
       );
-      expect(guideList).toEqual([
-        {
-          description: '(no description)',
-          exampleCount: 0,
-          id: 'goodbye',
-          kind: 'trail',
-        },
-        {
-          description: '(no description)',
-          exampleCount: 1,
-          id: 'hello',
-          kind: 'trail',
-        },
-      ]);
+      expect(guideList).toEqual({
+        entries: [
+          {
+            description: '(no description)',
+            exampleCount: 0,
+            id: 'goodbye',
+            kind: 'trail',
+          },
+          {
+            description: '(no description)',
+            exampleCount: 1,
+            id: 'hello',
+            kind: 'trail',
+          },
+        ],
+        mode: 'list',
+      });
 
       const guideDetail = expectOk(
         await guideTrail.blaze({ module: './src/app.ts', trailId: 'hello' }, {
@@ -211,15 +221,18 @@ describe('topo and dev trails', () => {
         } as never)
       );
       expect(guideDetail).toMatchObject({
-        description: null,
-        examples: [
-          {
-            input: {},
-            name: 'Default greeting',
-          },
-        ],
-        id: 'hello',
-        kind: 'trail',
+        detail: {
+          description: null,
+          examples: [
+            {
+              input: {},
+              name: 'Default greeting',
+            },
+          ],
+          id: 'hello',
+          kind: 'trail',
+        },
+        mode: 'detail',
       });
     } finally {
       rmSync(dir, { force: true, recursive: true });

--- a/apps/trails/src/trails/guide.ts
+++ b/apps/trails/src/trails/guide.ts
@@ -8,6 +8,7 @@ import { NotFoundError, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { loadApp } from './load-app.js';
+import { trailDetailOutput } from './topo-output-schemas.js';
 import {
   buildCurrentGuideEntries,
   buildCurrentTopoDetail,
@@ -21,7 +22,7 @@ interface GuideEntry {
   readonly description: string;
   readonly exampleCount: number;
   readonly id: string;
-  readonly kind: string;
+  readonly kind: 'trail';
 }
 
 // ---------------------------------------------------------------------------
@@ -41,17 +42,15 @@ export const guideTrail = trail('guide', {
         );
       }
       return Result.ok({
-        description: detail.description,
-        detours: detail.detours,
-        examples: detail.examples,
-        id: detail.id,
-        kind: detail.kind,
+        detail,
+        mode: 'detail' as const,
       });
     }
 
-    return Result.ok(
-      buildCurrentGuideEntries(app, { rootDir }) as GuideEntry[]
-    );
+    return Result.ok({
+      entries: buildCurrentGuideEntries(app, { rootDir }) as GuideEntry[],
+      mode: 'list' as const,
+    });
   },
   description: 'Runtime guidance for trails',
   examples: [
@@ -66,21 +65,21 @@ export const guideTrail = trail('guide', {
     trailId: z.string().optional().describe('Trail ID for detailed guidance'),
   }),
   intent: 'read',
-  output: z.union([
-    z.array(
-      z.object({
-        description: z.string(),
-        exampleCount: z.number(),
-        id: z.string(),
-        kind: z.string(),
-      })
-    ),
+  output: z.discriminatedUnion('mode', [
     z.object({
-      description: z.string().nullable(),
-      detours: z.unknown().nullable(),
-      examples: z.array(z.unknown()),
-      id: z.string(),
-      kind: z.string(),
+      entries: z.array(
+        z.object({
+          description: z.string(),
+          exampleCount: z.number(),
+          id: z.string(),
+          kind: z.literal('trail'),
+        })
+      ),
+      mode: z.literal('list'),
+    }),
+    z.object({
+      detail: trailDetailOutput,
+      mode: z.literal('detail'),
     }),
   ]),
 });

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -24,6 +24,7 @@ import {
   buildCurrentTopoDetail,
   buildCurrentTopoList,
 } from './topo-read-support.js';
+import { topoDetailOutput } from './topo-output-schemas.js';
 import { exportCurrentTopo } from './topo-store-support.js';
 
 export {
@@ -67,12 +68,7 @@ const buildSurveyDiff = async (
   const diff = deriveSurfaceMapDiff(previousMap, currentMap);
   return Result.ok(
     breakingOnly
-      ? formatDiff({
-          ...diff,
-          entries: diff.breaking,
-          info: [],
-          warnings: [],
-        })
+      ? formatDiff({ ...diff, info: [], warnings: [] })
       : formatDiff(diff)
   );
 };
@@ -117,6 +113,8 @@ interface SurveyInput {
 
 type SurveyMode = 'brief' | 'detail' | 'diff' | 'generate' | 'list' | 'openapi';
 
+type SurveyEnvelope = { readonly mode: SurveyMode } & Record<string, unknown>;
+
 /** Ordered mode checks — first truthy predicate wins, otherwise 'list'. */
 const modeChecks: readonly [(input: SurveyInput) => boolean, SurveyMode][] = [
   [(i) => i.brief, 'brief'],
@@ -150,15 +148,32 @@ const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
   openapi: (app) => Result.ok(deriveOpenApiSpec(app)),
 };
 
+const envelopeSurveyValue = (
+  mode: SurveyMode,
+  value: object
+): SurveyEnvelope => {
+  if (mode === 'detail') {
+    return { detail: value, mode };
+  }
+  if (mode === 'openapi') {
+    return { mode, spec: value };
+  }
+  return { ...value, mode };
+};
+
 /** Dispatch to the appropriate survey sub-command based on input flags. */
-const dispatchSurvey = (
+const dispatchSurvey = async (
   app: Topo,
   input: SurveyInput,
   rootDir: string
-): Result<object, Error> | Promise<Result<object, Error>> => {
+): Promise<Result<SurveyEnvelope, Error>> => {
   const mode = deriveSurveyMode(input);
   const handler = surveyHandlers[mode];
-  return handler(app, input, rootDir);
+  const result = await handler(app, input, rootDir);
+  if (result.isErr()) {
+    return result;
+  }
+  return Result.ok(envelopeSurveyValue(mode, result.value));
 };
 
 // ---------------------------------------------------------------------------
@@ -229,7 +244,7 @@ export const surveyTrail = trail('survey', {
     trailId: z.string().optional().describe('Trail ID for detail view'),
   }),
   intent: 'read',
-  output: z.union([
+  output: z.discriminatedUnion('mode', [
     z.object({
       count: z.number(),
       entries: z.array(
@@ -240,6 +255,7 @@ export const surveyTrail = trail('survey', {
           safety: z.string(),
         })
       ),
+      mode: z.literal('list'),
       resourceCount: z.number(),
       resources: z.array(
         z.object({
@@ -261,6 +277,7 @@ export const surveyTrail = trail('survey', {
         resources: z.boolean(),
         signals: z.boolean(),
       }),
+      mode: z.literal('brief'),
       name: z.string(),
       resources: z.number(),
       signals: z.number(),
@@ -271,51 +288,55 @@ export const surveyTrail = trail('survey', {
       breaking: z.array(z.unknown()),
       hasBreaking: z.boolean(),
       info: z.array(z.unknown()),
+      mode: z.literal('diff'),
       warnings: z.array(z.unknown()),
     }),
     z.object({
-      crosses: z.array(z.string()),
-      description: z.unknown().nullable(),
-      detours: z.unknown().nullable(),
-      examples: z.array(z.unknown()),
-      id: z.string(),
-      intent: z.enum(['read', 'write', 'destroy']),
-      kind: z.string(),
-      resources: z.array(z.string()),
-      safety: z.string(),
-    }),
-    z.object({
-      description: z.string().nullable(),
-      health: z.enum(['available', 'none']),
-      id: z.string(),
-      kind: z.literal('resource'),
-      lifetime: z.literal('singleton'),
-      usedBy: z.array(z.string()),
+      detail: topoDetailOutput,
+      mode: z.literal('detail'),
     }),
     z.object({
       hash: z.string(),
       lockPath: z.string(),
       mapPath: z.string(),
+      mode: z.literal('generate'),
     }),
     z.object({
-      components: z.object({
-        schemas: z.record(z.string(), z.unknown()),
-      }),
-      info: z.object({
-        description: z.string().optional(),
-        title: z.string(),
-        version: z.string(),
-      }),
-      openapi: z.literal('3.1.0'),
-      paths: z.record(z.string(), z.record(z.string(), z.unknown())),
-      servers: z
-        .array(
-          z.object({
-            description: z.string().optional(),
-            url: z.string(),
-          })
-        )
-        .optional(),
+      mode: z.literal('openapi'),
+      // OpenAPI 3.1 has many legal top-level and nested fields this schema
+      // doesn't enumerate (security schemes, tags, externalDocs, info.contact
+      // / info.license, etc.). Zod's default strip mode would silently drop
+      // those when wrapWithOutputValidation parses the value, so we pass
+      // extras through and let deriveOpenApiSpec's output reach callers
+      // unchanged.
+      spec: z
+        .object({
+          components: z
+            .object({
+              schemas: z.record(z.string(), z.unknown()),
+            })
+            .loose(),
+          info: z
+            .object({
+              description: z.string().optional(),
+              title: z.string(),
+              version: z.string(),
+            })
+            .loose(),
+          openapi: z.literal('3.1.0'),
+          paths: z.record(z.string(), z.record(z.string(), z.unknown())),
+          servers: z
+            .array(
+              z
+                .object({
+                  description: z.string().optional(),
+                  url: z.string(),
+                })
+                .loose()
+            )
+            .optional(),
+        })
+        .loose(),
     }),
   ]),
 });

--- a/apps/trails/src/trails/topo-output-schemas.ts
+++ b/apps/trails/src/trails/topo-output-schemas.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+export const trailDetailOutput = z.object({
+  crosses: z.array(z.string()),
+  description: z.string().nullable(),
+  detours: z
+    .array(
+      z.object({
+        maxAttempts: z.number(),
+        on: z.string(),
+      })
+    )
+    .nullable(),
+  examples: z.array(z.unknown()),
+  id: z.string(),
+  intent: z.enum(['read', 'write', 'destroy']),
+  kind: z.literal('trail'),
+  pattern: z.string().nullable(),
+  resources: z.array(z.string()),
+  safety: z.string(),
+});
+
+export const resourceDetailOutput = z.object({
+  description: z.string().nullable(),
+  health: z.enum(['available', 'none']),
+  id: z.string(),
+  kind: z.literal('resource'),
+  lifetime: z.literal('singleton'),
+  usedBy: z.array(z.string()),
+});
+
+export const topoDetailOutput = z.discriminatedUnion('kind', [
+  trailDetailOutput,
+  resourceDetailOutput,
+]);

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -44,22 +44,22 @@ interface StoredSurfaceMapEntry {
   readonly kind: 'resource' | 'signal' | 'trail';
 }
 
-interface CurrentTrailDetail {
+export interface CurrentTrailDetail {
   readonly crosses: string[];
   readonly description: string | null;
   readonly detours:
-    | readonly { readonly on: string; readonly maxAttempts: number }[]
+    | { readonly on: string; readonly maxAttempts: number }[]
     | null;
   readonly examples: unknown[];
   readonly id: string;
   readonly intent: 'destroy' | 'read' | 'write';
-  readonly kind: string;
+  readonly kind: 'trail';
   readonly pattern: string | null;
   readonly resources: string[];
   readonly safety: string;
 }
 
-interface CurrentResourceDetail {
+export interface CurrentResourceDetail {
   readonly description: string | null;
   readonly health: 'available' | 'none';
   readonly id: string;
@@ -152,11 +152,17 @@ const buildTrailDetailFromStore = (
 ): CurrentTrailDetail => ({
   crosses: [...detail.crosses],
   description: detail.description,
-  detours: detail.detours,
+  detours:
+    detail.detours === null
+      ? null
+      : detail.detours.map((detour) => ({
+          maxAttempts: detour.maxAttempts,
+          on: detour.on,
+        })),
   examples: [...detail.examples],
   id: detail.id,
   intent: detail.intent,
-  kind: detail.kind,
+  kind: 'trail',
   pattern: detail.pattern,
   resources: [...detail.resources],
   safety: detail.safety,
@@ -249,7 +255,7 @@ export const buildCurrentGuideEntries = (
   readonly description: string;
   readonly exampleCount: number;
   readonly id: string;
-  readonly kind: string;
+  readonly kind: 'trail';
 }[] => {
   const rootDir = deriveRootDir(options?.rootDir);
   return withCurrentTopoStore(app, rootDir, (store, ref) =>
@@ -257,7 +263,7 @@ export const buildCurrentGuideEntries = (
       description: trail.description ?? '(no description)',
       exampleCount: trail.exampleCount,
       id: trail.id,
-      kind: trail.kind,
+      kind: 'trail',
     }))
   );
 };

--- a/apps/trails/src/trails/topo-reports.ts
+++ b/apps/trails/src/trails/topo-reports.ts
@@ -46,7 +46,7 @@ export interface TrailDetailReport {
   readonly crosses: readonly string[];
   readonly id: string;
   readonly intent: 'read' | 'write' | 'destroy';
-  readonly kind: string;
+  readonly kind: 'trail';
   readonly pattern: string | null;
   readonly safety: string;
   readonly resources: readonly string[];
@@ -220,7 +220,7 @@ export const deriveTrailDetail = (
     examples: item.examples ?? [],
     id: item.id,
     intent: item.intent,
-    kind: item.kind,
+    kind: 'trail',
     pattern: item.pattern ?? null,
     resources: item.resources.map((resource) => resource.id).toSorted(),
     safety,

--- a/apps/trails/src/trails/topo-show.ts
+++ b/apps/trails/src/trails/topo-show.ts
@@ -2,28 +2,8 @@ import { NotFoundError, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { loadApp } from './load-app.js';
+import { topoDetailOutput } from './topo-output-schemas.js';
 import { buildCurrentTopoDetail } from './topo-read-support.js';
-
-const trailDetailOutput = z.object({
-  crosses: z.array(z.string()),
-  description: z.unknown().nullable(),
-  detours: z.unknown().nullable(),
-  examples: z.array(z.unknown()),
-  id: z.string(),
-  intent: z.enum(['read', 'write', 'destroy']),
-  kind: z.string(),
-  resources: z.array(z.string()),
-  safety: z.string(),
-});
-
-const resourceDetailOutput = z.object({
-  description: z.string().nullable(),
-  health: z.enum(['available', 'none']),
-  id: z.string(),
-  kind: z.literal('resource'),
-  lifetime: z.literal('singleton'),
-  usedBy: z.array(z.string()),
-});
 
 export const topoShowTrail = trail('topo.show', {
   blaze: async (input, ctx) => {
@@ -50,5 +30,5 @@ export const topoShowTrail = trail('topo.show', {
     rootDir: z.string().optional().describe('Workspace root directory'),
   }),
   intent: 'read',
-  output: z.union([trailDetailOutput, resourceDetailOutput]),
+  output: topoDetailOutput,
 });

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -62,6 +62,12 @@ Produces the JSON Schema:
 
 `.describe()` annotations on Zod fields become `description` in the JSON Schema -- these are what agents see.
 
+## Output Schema and Examples
+
+When a trail declares `output`, the MCP tool definition includes an `outputSchema` derived from that Zod schema. Schemas whose JSON representation has a top-level `type: "object"` project directly into `structuredContent`. All other schemas -- arrays, scalars, discriminated unions (`anyOf`), intersections (`allOf`), and `z.any()` -- are wrapped in `{ data: ... }` because MCP requires the root of `outputSchema` to be `type: "object"`.
+
+Trail examples are exposed as structured tool metadata under `_meta["ontrails/examples"]`. Each example keeps the authored input, expected output or error, a success/error kind, and provenance pointing back to `trail.examples`; clients do not need to scrape example JSON from prose descriptions.
+
 ## Annotations
 
 Trail intent maps directly to MCP tool annotations:
@@ -90,7 +96,10 @@ Trail results are mapped to MCP tool responses:
 
 ```typescript
 Result.ok({ name: 'Alpha', type: 'concept' });
-// -> { content: [{ type: "text", text: '{"name":"Alpha","type":"concept"}' }] }
+// -> {
+//   content: [{ type: "text", text: '{"name":"Alpha","type":"concept"}' }],
+//   structuredContent: { name: "Alpha", type: "concept" }
+// }
 ```
 
 **Error:**

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -14,7 +14,12 @@ import {
   ValidationError,
 } from '../errors';
 import { executeTrail } from '../execute';
-import { TRACE_CONTEXT_KEY, clearTraceSink } from '../internal/tracing';
+import {
+  TRACE_CONTEXT_KEY,
+  clearTraceSink,
+  registerTraceSink,
+} from '../internal/tracing';
+import type { TraceRecord } from '../internal/tracing';
 import { createTrailContext } from '../context';
 import type { Layer } from '../layer';
 import { Result } from '../result';
@@ -400,6 +405,35 @@ describe('executeTrail', () => {
 
         expect(result.isOk()).toBe(true);
         expect(result.unwrap()).toEqual({ value: 'hello' });
+      });
+
+      test('validates successful output before returning it', async () => {
+        const invalidOutputTrail = trail('output.invalid', {
+          blaze: () => Result.ok({ value: 42 }),
+          input: z.object({}),
+          output: z.object({ value: z.string() }),
+        });
+
+        const result = await executeTrail(invalidOutputTrail, {});
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+          expect(result.error).toBeInstanceOf(ValidationError);
+          expect(result.error.message).toContain('Output validation failed');
+        }
+      });
+
+      test('returns parsed output schema values', async () => {
+        const defaultedOutputTrail = trail('output.defaulted', {
+          blaze: () => Result.ok({}),
+          input: z.object({}),
+          output: z.object({ ok: z.boolean().default(true) }),
+        });
+
+        const result = await executeTrail(defaultedOutputTrail, {});
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toEqual({ ok: true });
       });
 
       test('eagerly resolves declared resources before layers and implementation run', async () => {
@@ -1138,6 +1172,30 @@ describe('executeTrail', () => {
 
       expect(result).toEqual(Result.ok({ value: 42 }));
       expect(sawTraceContext).toBe(false);
+    });
+
+    test('records output validation failures as validation trace errors', async () => {
+      const records: TraceRecord[] = [];
+      registerTraceSink({ write: (record) => records.push(record) });
+
+      try {
+        const invalidOutputTrail = trail('trace.output.invalid', {
+          blaze: () => Result.ok({ value: 42 }),
+          input: z.object({}),
+          output: z.object({ value: z.string() }),
+        });
+
+        const result = await executeTrail(invalidOutputTrail, {});
+
+        expect(result.isErr()).toBe(true);
+        const root = records.find(
+          (record) => record.trailId === 'trace.output.invalid'
+        );
+        expect(root?.status).toBe('err');
+        expect(root?.errorCategory).toBe('validation');
+      } finally {
+        clearTraceSink();
+      }
     });
 
     test('rebinds ctx.resource after merging extension overrides from createContext', async () => {

--- a/packages/core/src/__tests__/structured-examples.test.ts
+++ b/packages/core/src/__tests__/structured-examples.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  deriveStructuredSignalExamples,
+  deriveStructuredTrailExamples,
+} from '../structured-examples.js';
+import type { TrailExample } from '../trail.js';
+
+const okExample = (
+  overrides: Partial<TrailExample<unknown, unknown>> = {}
+): TrailExample<unknown, unknown> => ({
+  input: { name: 'ada' },
+  name: 'ok',
+  ...overrides,
+});
+
+describe('deriveStructuredTrailExamples', () => {
+  test('projects plain JSON-serializable inputs', () => {
+    const projected = deriveStructuredTrailExamples([
+      okExample({ expected: { ok: true } }),
+    ]);
+    expect(projected).toBeDefined();
+    expect(projected?.[0]?.input).toEqual({ name: 'ada' });
+    expect(projected?.[0]?.expected).toEqual({ ok: true });
+    expect(projected?.[0]?.kind).toBe('success');
+  });
+
+  test('drops examples whose input contains a function leaf', () => {
+    const projected = deriveStructuredTrailExamples([
+      okExample({ input: { fn: () => 'nope' } }),
+    ]);
+    expect(projected).toBeUndefined();
+  });
+
+  test('drops examples whose input contains a nested symbol leaf', () => {
+    const projected = deriveStructuredTrailExamples([
+      okExample({ input: { meta: { token: Symbol('secret') } } }),
+    ]);
+    expect(projected).toBeUndefined();
+  });
+
+  test('drops examples whose expected contains a function leaf', () => {
+    const projected = deriveStructuredTrailExamples([
+      okExample({ expected: [() => 'nope'] }),
+    ]);
+    expect(projected).toBeUndefined();
+  });
+
+  test('drops examples whose input contains a BigInt leaf', () => {
+    const projected = deriveStructuredTrailExamples([
+      okExample({ input: { count: 1n } }),
+    ]);
+    expect(projected).toBeUndefined();
+  });
+
+  test('drops examples whose input contains a Date leaf', () => {
+    const projected = deriveStructuredTrailExamples([
+      okExample({ input: { createdAt: new Date('2024-01-01') } }),
+    ]);
+    expect(projected).toBeUndefined();
+  });
+
+  test('drops examples whose input contains a RegExp leaf', () => {
+    const projected = deriveStructuredTrailExamples([
+      okExample({ input: { pattern: /^x$/ } }),
+    ]);
+    expect(projected).toBeUndefined();
+  });
+
+  test('drops examples whose input contains a Map leaf', () => {
+    const projected = deriveStructuredTrailExamples([
+      okExample({ input: { lookup: new Map([['k', 'v']]) } }),
+    ]);
+    expect(projected).toBeUndefined();
+  });
+
+  test('drops examples whose input contains a Set leaf', () => {
+    const projected = deriveStructuredTrailExamples([
+      okExample({ input: { tags: new Set(['a', 'b']) } }),
+    ]);
+    expect(projected).toBeUndefined();
+  });
+
+  test('preserves examples with undefined optional fields', () => {
+    const projected = deriveStructuredTrailExamples([
+      okExample({ input: { name: 'ada', nickname: undefined } }),
+    ]);
+    expect(projected).toBeDefined();
+    expect(projected?.[0]?.input).toEqual({ name: 'ada' });
+  });
+});
+
+describe('deriveStructuredSignalExamples', () => {
+  test('projects valid payloads', () => {
+    const projected = deriveStructuredSignalExamples([{ event: 'sent' }]);
+    expect(projected?.[0]?.payload).toEqual({ event: 'sent' });
+    expect(projected?.[0]?.kind).toBe('payload');
+  });
+
+  test('drops payloads with non-serializable leaves', () => {
+    const projected = deriveStructuredSignalExamples([
+      { cb: () => {}, event: 'sent' },
+    ]);
+    expect(projected).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/validation.test.ts
+++ b/packages/core/src/__tests__/validation.test.ts
@@ -260,6 +260,34 @@ describe('zodToJsonSchema', () => {
       });
     });
 
+    test('converts z.discriminatedUnion()', () => {
+      const schema = z.discriminatedUnion('mode', [
+        z.object({ mode: z.literal('list'), value: z.string() }),
+        z.object({ count: z.number(), mode: z.literal('count') }),
+      ]);
+
+      expect(zodToJsonSchema(schema)).toEqual({
+        anyOf: [
+          {
+            properties: {
+              mode: { const: 'list' },
+              value: { type: 'string' },
+            },
+            required: ['mode', 'value'],
+            type: 'object',
+          },
+          {
+            properties: {
+              count: { type: 'number' },
+              mode: { const: 'count' },
+            },
+            required: ['count', 'mode'],
+            type: 'object',
+          },
+        ],
+      });
+    });
+
     test('preserves z.describe()', () => {
       const schema = z.string().describe('A user name');
       expect(zodToJsonSchema(schema)).toEqual({

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -54,7 +54,7 @@ import { Result } from './result.js';
 import { createResourceLookup } from './resource.js';
 import { createResources } from './resource-config.js';
 import { TRAILHEAD_KEY } from './types.js';
-import { validateInput } from './validation.js';
+import { validateInput, validateOutput } from './validation.js';
 
 type MutableTrailContext = {
   -readonly [K in keyof TrailContext]: TrailContext[K];
@@ -856,6 +856,28 @@ const wrapWithDetours = (
   };
 };
 
+const wrapWithOutputValidation = (
+  trail: AnyTrail,
+  implementation: Implementation<unknown, unknown>
+): Implementation<unknown, unknown> => {
+  const { output } = trail;
+  if (output === undefined) {
+    return implementation;
+  }
+
+  return async (input, ctx) => {
+    const result = await implementation(input, ctx);
+    if (result.isErr()) {
+      return result;
+    }
+
+    const validated = validateOutput(output, result.value);
+    return validated.isErr()
+      ? Result.err(validated.error)
+      : Result.ok(validated.value);
+  };
+};
+
 const prepareRunImpl = (
   trail: AnyTrail,
   ctx: TrailContext,
@@ -902,7 +924,7 @@ const prepareRunImpl = (
 
   return {
     ctxWithIntrinsics,
-    impl,
+    impl: wrapWithOutputValidation(trail, impl),
   };
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,17 @@ export {
   shouldIncludeTrailForSurface,
 } from './surface-filter.js';
 export type { SurfaceFilterOptions } from './surface-filter.js';
+export {
+  deriveStructuredSignalExamples,
+  deriveStructuredTrailExamples,
+} from './structured-examples.js';
+export type {
+  StructuredSignalExample,
+  StructuredSignalExampleProvenance,
+  StructuredTrailExample,
+  StructuredTrailExampleKind,
+  StructuredTrailExampleProvenance,
+} from './structured-examples.js';
 
 // Type utilities
 export type {

--- a/packages/core/src/structured-examples.ts
+++ b/packages/core/src/structured-examples.ts
@@ -1,0 +1,173 @@
+import type { TrailExample } from './trail.js';
+
+export interface StructuredTrailExampleProvenance {
+  readonly source: 'trail.examples';
+}
+
+export interface StructuredSignalExampleProvenance {
+  readonly source: 'signal.examples';
+}
+
+export type StructuredTrailExampleKind = 'success' | 'error';
+
+export interface StructuredTrailExample {
+  readonly description?: string | undefined;
+  readonly error?: string | undefined;
+  readonly expected?: unknown | undefined;
+  readonly expectedMatch?: unknown | undefined;
+  readonly input: unknown;
+  readonly kind: StructuredTrailExampleKind;
+  readonly name: string;
+  readonly provenance: StructuredTrailExampleProvenance;
+}
+
+export interface StructuredSignalExample {
+  readonly kind: 'payload';
+  readonly payload: unknown;
+  readonly provenance: StructuredSignalExampleProvenance;
+}
+
+// `Date`, `RegExp`, `Map`, and `Set` are objects (`typeof === 'object'`),
+// so they would pass the structural walk and reach `JSON.stringify`, which
+// silently coerces them: a `Date` becomes its ISO string, a `RegExp` and
+// any `Map`/`Set` become `{}`. Either way the projected shape diverges
+// from the example author's declared input. Treat them as non-serializable
+// leaves so the example is dropped rather than misrepresented to MCP
+// clients.
+const isNonJsonLeaf = (value: unknown): boolean => {
+  const kind = typeof value;
+  if (kind === 'function' || kind === 'symbol' || kind === 'bigint') {
+    return true;
+  }
+  return (
+    value instanceof Date ||
+    value instanceof RegExp ||
+    value instanceof Map ||
+    value instanceof Set
+  );
+};
+
+// `JSON.stringify` silently drops function / symbol property values rather than
+// throwing, so we walk the value first and reject any example whose graph
+// contains a non-serializable leaf. Without this, an MCP client consuming
+// `ontrails/examples` would receive structurally incorrect inputs.
+const containsNonSerializableLeaf = (
+  value: unknown,
+  seen: WeakSet<object>
+): boolean => {
+  if (isNonJsonLeaf(value)) {
+    return true;
+  }
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const obj = value as object;
+  if (seen.has(obj)) {
+    return false;
+  }
+  seen.add(obj);
+  if (Array.isArray(value)) {
+    return value.some((entry) => containsNonSerializableLeaf(entry, seen));
+  }
+  return Object.values(obj).some((entry) =>
+    containsNonSerializableLeaf(entry, seen)
+  );
+};
+
+const toJsonSerializable = (value: unknown): unknown | undefined => {
+  if (containsNonSerializableLeaf(value, new WeakSet<object>())) {
+    return undefined;
+  }
+  try {
+    const encoded = JSON.stringify(value);
+    return encoded === undefined ? undefined : JSON.parse(encoded);
+  } catch {
+    return undefined;
+  }
+};
+
+const projectExample = (
+  example: TrailExample<unknown, unknown>
+): StructuredTrailExample | undefined => {
+  const input = toJsonSerializable(example.input);
+  if (input === undefined) {
+    return undefined;
+  }
+
+  const projected: Record<string, unknown> = {
+    input,
+    kind: example.error === undefined ? 'success' : 'error',
+    name: example.name,
+    provenance: { source: 'trail.examples' },
+  };
+
+  if (example.description !== undefined) {
+    projected['description'] = example.description;
+  }
+  if (example.expected !== undefined) {
+    const expected = toJsonSerializable(example.expected);
+    if (expected === undefined) {
+      return undefined;
+    }
+    projected['expected'] = expected;
+  }
+  if (example.expectedMatch !== undefined) {
+    const expectedMatch = toJsonSerializable(example.expectedMatch);
+    if (expectedMatch === undefined) {
+      return undefined;
+    }
+    projected['expectedMatch'] = expectedMatch;
+  }
+  if (example.error !== undefined) {
+    projected['error'] = example.error;
+  }
+
+  return Object.freeze(projected) as unknown as StructuredTrailExample;
+};
+
+const projectSignalExample = (
+  payload: unknown
+): StructuredSignalExample | undefined => {
+  const serializablePayload = toJsonSerializable(payload);
+  if (serializablePayload === undefined) {
+    return undefined;
+  }
+
+  return Object.freeze({
+    kind: 'payload',
+    payload: serializablePayload,
+    provenance: { source: 'signal.examples' },
+  } satisfies StructuredSignalExample);
+};
+
+export const deriveStructuredTrailExamples = (
+  examples: readonly TrailExample<unknown, unknown>[] | undefined
+): readonly StructuredTrailExample[] | undefined => {
+  if (examples === undefined || examples.length === 0) {
+    return undefined;
+  }
+
+  const projected = examples
+    .map(projectExample)
+    .filter(
+      (example): example is StructuredTrailExample => example !== undefined
+    );
+
+  return projected.length > 0 ? Object.freeze(projected) : undefined;
+};
+
+export const deriveStructuredSignalExamples = (
+  examples: readonly unknown[] | undefined
+): readonly StructuredSignalExample[] | undefined => {
+  if (examples === undefined || examples.length === 0) {
+    return undefined;
+  }
+
+  const projected = examples
+    .map(projectSignalExample)
+    .filter(
+      (example): example is StructuredSignalExample => example !== undefined
+    );
+
+  return projected.length > 0 ? Object.freeze(projected) : undefined;
+};

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -11,15 +11,23 @@ import { z } from 'zod';
 
 const greet = trail('greet', {
   input: z.object({ name: z.string().describe('Who to greet') }),
+  output: z.object({ greeting: z.string() }),
   intent: 'read',
-  blaze: (input) => Result.ok(`Hello, ${input.name}!`),
+  examples: [
+    {
+      expected: { greeting: 'Hello, Ada!' },
+      input: { name: 'Ada' },
+      name: 'Ada',
+    },
+  ],
+  blaze: (input) => Result.ok({ greeting: `Hello, ${input.name}!` }),
 });
 
 const graph = topo('myapp', { greet });
 await surface(graph);
 ```
 
-This starts an MCP server over stdio with a `myapp_greet` tool. The tool gets `readOnlyHint: true` and a JSON Schema input -- both derived from the trail definition.
+This starts an MCP server over stdio with a `myapp_greet` tool. The tool gets `readOnlyHint: true`, JSON Schema input, JSON Schema output, and structured examples -- all derived from the trail definition.
 
 For more control, build the tools yourself:
 
@@ -31,7 +39,9 @@ if (result.isErr()) throw result.error; // ValidationError on tool-name collisio
 for (const tool of result.value) {
   server.registerTool(tool.name, tool.handler, {
     inputSchema: tool.inputSchema,
+    outputSchema: tool.outputSchema,
     annotations: tool.annotations,
+    _meta: tool._meta,
   });
 }
 ```
@@ -62,6 +72,12 @@ Trail intent, idempotency, and description map directly to MCP annotations:
 | `description` | `title` |
 
 No manual annotation definitions. The contract is the source of truth.
+
+## Schemas and Examples
+
+MCP tool definitions include the trail's input schema, and trails with an `output` schema also project that schema into MCP `outputSchema`. Non-object trail outputs are wrapped in a `{ data: ... }` object because MCP structured tool results are object-shaped.
+
+Trail examples are projected as structured metadata under `_meta["ontrails/examples"]`. Each projected example preserves its input, expected output or error, a success/error kind, and provenance pointing back to the authored `trail.examples` field.
 
 ## Tool naming
 

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -12,7 +12,7 @@ import {
 import type { Layer, TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
-import { deriveMcpTools } from '../build.js';
+import { MCP_TOOL_EXAMPLES_META_KEY, deriveMcpTools } from '../build.js';
 import type { McpExtra, McpToolDefinition } from '../build.js';
 
 // ---------------------------------------------------------------------------
@@ -51,6 +51,7 @@ const exampleTrail = trail('with.examples', {
     },
   ],
   input: z.object({ name: z.string() }),
+  output: z.object({ greeting: z.string() }),
 });
 
 const internalTrail = trail('internal.secret', {
@@ -161,6 +162,139 @@ describe('deriveMcpTools', () => {
       expect(props['message']).toEqual({ type: 'string' });
     });
 
+    test('output schema is projected when declared', () => {
+      const app = topo('myapp', { echoTrail });
+      const schema = requireOnlyTool(buildTools(app)).outputSchema;
+
+      expect(schema?.['type']).toBe('object');
+      const props = schema?.['properties'] as Record<string, unknown>;
+      expect(props['reply']).toEqual({ type: 'string' });
+    });
+
+    test('non-object output schemas are wrapped for MCP structured content', () => {
+      const listTrail = trail('items.list', {
+        blaze: () => Result.ok(['one', 'two']),
+        input: z.object({}),
+        output: z.array(z.string()),
+      });
+
+      const schema = requireOnlyTool(
+        buildTools(topo('myapp', { listTrail }))
+      ).outputSchema;
+
+      expect(schema).toEqual({
+        properties: {
+          data: { items: { type: 'string' }, type: 'array' },
+        },
+        required: ['data'],
+        type: 'object',
+      });
+    });
+
+    test('scalar union output schemas are wrapped for MCP structured content', () => {
+      const scalarUnionTrail = trail('scalar.union', {
+        blaze: () => Result.ok('one'),
+        input: z.object({}),
+        output: z.union([z.string(), z.number()]),
+      });
+
+      const schema = requireOnlyTool(
+        buildTools(topo('myapp', { scalarUnionTrail }))
+      ).outputSchema;
+
+      expect(schema).toEqual({
+        properties: {
+          data: { anyOf: [{ type: 'string' }, { type: 'number' }] },
+        },
+        required: ['data'],
+        type: 'object',
+      });
+    });
+
+    test('mixed-shape unions wrap structured content even when value is an object', async () => {
+      // `z.union([z.object(...), z.string()])` projects to a wrapped
+      // outputSchema (`{ data: ... }`) because the schema is not
+      // homogeneously object-shaped. The runtime structuredContent must
+      // therefore also wrap, even when the value happens to be the object
+      // branch — otherwise outputSchema and structuredContent diverge.
+      const mixedTrail = trail('mixed.union', {
+        blaze: () => Result.ok({ a: 'hello' }),
+        input: z.object({}),
+        output: z.union([z.object({ a: z.string() }), z.string()]),
+      });
+
+      const tool = requireOnlyTool(buildTools(topo('myapp', { mixedTrail })));
+      const schema = tool.outputSchema as Record<string, unknown>;
+      expect(schema['type']).toBe('object');
+      expect(schema['required']).toEqual(['data']);
+
+      const result = await tool.handler({}, noExtra);
+      expect(result?.structuredContent).toEqual({ data: { a: 'hello' } });
+    });
+
+    test('z.any() output wraps object structured content under data envelope', async () => {
+      const anyTrail = trail('anything', {
+        blaze: () => Result.ok({ shape: 'object' }),
+        input: z.object({}),
+        output: z.any(),
+      });
+
+      const tool = requireOnlyTool(buildTools(topo('myapp', { anyTrail })));
+      const schema = tool.outputSchema as Record<string, unknown>;
+      expect(schema['type']).toBe('object');
+      expect(schema['required']).toEqual(['data']);
+
+      const result = await tool.handler({}, noExtra);
+      expect(result?.structuredContent).toEqual({ data: { shape: 'object' } });
+    });
+
+    test('object union output schemas wrap under data envelope (MCP spec)', async () => {
+      // MCP's Tool schema requires `outputSchema` to have literal
+      // `type: "object"` at the root (see @modelcontextprotocol/sdk's
+      // `outputSchema: z.object({ type: z.literal('object'), ... })`).
+      // Discriminated unions emit as `{ anyOf: [...] }`, so they go
+      // through the `wrapAsData` path: schema becomes
+      // `{ type: 'object', properties: { data: { anyOf: [...] } }, required: ['data'] }`,
+      // and structuredContent matches under `data`.
+      const unionTrail = trail('surveyish', {
+        blaze: () => Result.ok({ entries: [], mode: 'list' as const }),
+        input: z.object({}),
+        output: z.discriminatedUnion('mode', [
+          z.object({ entries: z.array(z.unknown()), mode: z.literal('list') }),
+          z.object({ detail: z.string(), mode: z.literal('detail') }),
+        ]),
+      });
+
+      const tool = requireOnlyTool(buildTools(topo('myapp', { unionTrail })));
+      const schema = tool.outputSchema as Record<string, unknown>;
+      expect(schema['type']).toBe('object');
+      expect(schema['required']).toEqual(['data']);
+      const props = schema['properties'] as Record<string, unknown>;
+      expect((props['data'] as Record<string, unknown>)['anyOf']).toEqual([
+        {
+          properties: {
+            entries: { items: {}, type: 'array' },
+            mode: { const: 'list' },
+          },
+          required: ['entries', 'mode'],
+          type: 'object',
+        },
+        {
+          properties: {
+            detail: { type: 'string' },
+            mode: { const: 'detail' },
+          },
+          required: ['detail', 'mode'],
+          type: 'object',
+        },
+      ]);
+
+      const result = await tool.handler({}, noExtra);
+      expect(result?.structuredContent).toEqual({
+        data: { entries: [], mode: 'list' },
+      });
+    });
+
     test('annotations are correctly derived', () => {
       const app = topo('myapp', { deleteTrail, echoTrail });
       const tools = buildTools(app);
@@ -208,6 +342,20 @@ describe('deriveMcpTools', () => {
       expect(parseJsonContent(result?.content[0])).toEqual({
         reply: 'hello',
       });
+      expect(result?.structuredContent).toEqual({ reply: 'hello' });
+    });
+
+    test('handler wraps non-object outputs as structured content data', async () => {
+      const listTrail = trail('items.list', {
+        blaze: () => Result.ok(['one', 'two']),
+        input: z.object({}),
+        output: z.array(z.string()),
+      });
+
+      const tool = requireOnlyTool(buildTools(topo('myapp', { listTrail })));
+      const result = await tool.handler({}, noExtra);
+
+      expect(result?.structuredContent).toEqual({ data: ['one', 'two'] });
     });
 
     test('passes topo to executeTrail so MCP-invoked producers can fan out', async () => {
@@ -413,12 +561,20 @@ describe('deriveMcpTools', () => {
       expect(capturedSignal).toBe(controller.signal);
     });
 
-    test('description includes first example input when present', () => {
+    test('examples are projected as structured MCP metadata', () => {
       const app = topo('myapp', { exampleTrail });
       const tool = requireOnlyTool(buildTools(app));
 
-      expect(tool.description).toContain('A trail with examples');
-      expect(tool.description).toContain('"name":"world"');
+      expect(tool.description).toBe('A trail with examples');
+      expect(tool._meta?.[MCP_TOOL_EXAMPLES_META_KEY]).toEqual([
+        {
+          expected: { greeting: 'hello world' },
+          input: { name: 'world' },
+          kind: 'success',
+          name: 'basic',
+          provenance: { source: 'trail.examples' },
+        },
+      ]);
     });
 
     test('custom createContext is used when provided', async () => {
@@ -546,6 +702,52 @@ describe('deriveMcpTools', () => {
       expect(result?.content[0]?.mimeType).toBe('image/gif');
       expect(result?.content[0]?.data).toBeDefined();
     });
+
+    test('BlobRef output with outputSchema keeps structuredContent present', async () => {
+      const blobTrail = trail('blob.structured', {
+        blaze: () =>
+          Result.ok({
+            attachment: createBlobRef({
+              data: new Uint8Array([1, 2, 3]),
+              mimeType: 'application/pdf',
+              name: 'doc.pdf',
+              size: 3,
+            }),
+            label: 'report',
+          }),
+        input: z.object({}),
+        output: z.object({
+          attachment: z.custom(),
+          label: z.string(),
+        }),
+      });
+
+      const tool = requireOnlyTool(buildTools(topo('myapp', { blobTrail })));
+      expect(tool.outputSchema?.['type']).toBe('object');
+
+      const result = await tool.handler({}, noExtra);
+
+      expect(result?.content).toEqual([
+        {
+          text: JSON.stringify({ label: 'report' }),
+          type: 'text',
+        },
+        {
+          mimeType: 'application/pdf',
+          type: 'resource',
+          uri: 'blob://doc.pdf',
+        },
+      ]);
+      expect(result?.structuredContent).toEqual({
+        attachment: {
+          mimeType: 'application/pdf',
+          name: 'doc.pdf',
+          size: 3,
+          uri: 'blob://doc.pdf',
+        },
+        label: 'report',
+      });
+    });
   });
 
   describe('tool-name collision detection', () => {
@@ -623,6 +825,9 @@ describe('deriveMcpTools', () => {
       const successResult = await tool.handler({ name: 'World' }, noExtra);
       expect(successResult?.isError).toBeUndefined();
       expect(parseJsonContent(successResult?.content[0])).toEqual({
+        greeting: 'Hello, World!',
+      });
+      expect(successResult?.structuredContent).toEqual({
         greeting: 'Hello, World!',
       });
 

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -10,6 +10,7 @@ import {
   Result,
   TRAILHEAD_KEY,
   ValidationError,
+  deriveStructuredTrailExamples,
   executeTrail,
   filterSurfaceTrails,
   isBlobRef,
@@ -30,6 +31,8 @@ import type { McpAnnotations } from './annotations.js';
 import { deriveAnnotations } from './annotations.js';
 import { createMcpProgressCallback } from './progress.js';
 import { deriveToolName } from './tool-name.js';
+
+export const MCP_TOOL_EXAMPLES_META_KEY = 'ontrails/examples';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -53,6 +56,7 @@ export interface DeriveMcpToolsOptions {
 }
 
 export interface McpToolDefinition {
+  readonly _meta?: Record<string, unknown> | undefined;
   readonly annotations: McpAnnotations | undefined;
   readonly description: string | undefined;
   readonly handler: (
@@ -61,6 +65,7 @@ export interface McpToolDefinition {
   ) => Promise<McpToolResult>;
   readonly inputSchema: Record<string, unknown>;
   readonly name: string;
+  readonly outputSchema?: Record<string, unknown> | undefined;
   /** The trail ID this tool was derived from. */
   readonly trailId: string;
 }
@@ -76,6 +81,7 @@ export interface McpExtra {
 export interface McpToolResult {
   readonly content: readonly McpContent[];
   readonly isError?: boolean | undefined;
+  readonly structuredContent?: Record<string, unknown> | undefined;
 }
 
 export interface McpContent {
@@ -208,6 +214,99 @@ const serializeOutput = async (
   return [{ text: JSON.stringify(value), type: 'text' }];
 };
 
+const containsBlobRef = (
+  value: unknown,
+  seen = new WeakSet<object>()
+): boolean => {
+  if (isBlobRef(value)) {
+    return true;
+  }
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsBlobRef(item, seen));
+  }
+
+  return Object.values(value as Record<string, unknown>).some((item) =>
+    containsBlobRef(item, seen)
+  );
+};
+
+const blobToStructuredValue = (
+  blob: BlobRef
+): Record<string, string | number> => ({
+  mimeType: blob.mimeType,
+  name: blob.name,
+  size: blob.size,
+  uri: `blob://${blob.name}`,
+});
+
+const toStructuredValue = (
+  value: unknown,
+  seen = new WeakSet<object>()
+): unknown => {
+  if (isBlobRef(value)) {
+    return blobToStructuredValue(value);
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (seen.has(value)) {
+    return undefined;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => toStructuredValue(item, seen));
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+      key,
+      toStructuredValue(item, seen),
+    ])
+  );
+};
+
+// `wrapAsData` is decided at build time from the schema shape (see
+// `buildOutputSchemaProjection`). It must be threaded through to the runtime
+// because the schema's wrap decision and the runtime value's wrap decision
+// can diverge — e.g. for `z.union([z.object(...), z.string()])` or
+// `z.any()`, the schema declares a `{ data: ... }` envelope but a runtime
+// object value would otherwise be returned unwrapped, breaking the
+// outputSchema/structuredContent contract.
+const toStructuredContent = (
+  value: unknown,
+  wrapAsData: boolean
+): Record<string, unknown> | undefined => {
+  const structuredValue = containsBlobRef(value)
+    ? toStructuredValue(value)
+    : value;
+  if (wrapAsData) {
+    return { data: structuredValue };
+  }
+  if (
+    structuredValue !== null &&
+    typeof structuredValue === 'object' &&
+    !Array.isArray(structuredValue)
+  ) {
+    return structuredValue as Record<string, unknown>;
+  }
+  // When wrapAsData is false the schema's top-level type is `'object'`, and
+  // output validation has already constrained the runtime value to that
+  // shape — a primitive or array reaching this branch indicates the
+  // validation contract was bypassed. Return `undefined` so any future
+  // bypass surfaces as a missing `structuredContent` rather than a silently
+  // wrapped envelope that contradicts the published `outputSchema`.
+  return undefined;
+};
+
 // ---------------------------------------------------------------------------
 // Handler factory
 // ---------------------------------------------------------------------------
@@ -233,7 +332,8 @@ const createHandler =
     graph: Topo,
     t: Trail<unknown, unknown, unknown>,
     layers: readonly Layer[],
-    options: DeriveMcpToolsOptions
+    options: DeriveMcpToolsOptions,
+    wrapAsData: boolean
   ): ((
     args: Record<string, unknown>,
     extra: McpExtra
@@ -250,7 +350,13 @@ const createHandler =
       topo: graph,
     });
     if (result.isOk()) {
-      return { content: await serializeOutput(result.value) };
+      return {
+        content: await serializeOutput(result.value),
+        structuredContent:
+          t.output === undefined
+            ? undefined
+            : toStructuredContent(result.value, wrapAsData),
+      };
     }
     return mcpError(result.error.message);
   };
@@ -269,22 +375,57 @@ const createHandler =
  * - A handler that validates, composes layers, executes, and maps results
  */
 
-/** Build a description with optional example input appended. */
 const buildDescription = (
   trail: Trail<unknown, unknown, unknown>
-): string | undefined => {
-  let { description } = trail;
-  if (
-    description !== undefined &&
-    trail.examples !== undefined &&
-    trail.examples.length > 0
-  ) {
-    const [firstExample] = trail.examples;
-    if (firstExample !== undefined) {
-      description = `${description}\n\nExample input: ${JSON.stringify(firstExample.input)}`;
-    }
+): string | undefined => trail.description;
+
+// MCP requires `outputSchema` to have literal `type: "object"` at the root
+// (see `@modelcontextprotocol/sdk` Tool schema — `outputSchema: z.object({
+// type: z.literal('object'), ... })`). Object-shaped unions like
+// `z.discriminatedUnion(...)` emit as `{ anyOf: [...] }` from
+// `zodToJsonSchema` with no top-level `type`, so we publish them under the
+// data envelope. The shape of `structuredContent` then flows from the
+// `wrapAsData` flag, keeping the runtime aligned with what the schema
+// declares.
+const isMcpStructuredObjectSchema = (
+  schema: Record<string, unknown>
+): boolean => schema['type'] === 'object';
+
+interface OutputSchemaProjection {
+  readonly schema: Record<string, unknown>;
+  readonly wrapAsData: boolean;
+}
+
+const projectMcpOutputSchema = (
+  schema: Parameters<typeof zodToJsonSchema>[0]
+): OutputSchemaProjection => {
+  const raw = zodToJsonSchema(schema);
+  if (isMcpStructuredObjectSchema(raw)) {
+    return { schema: raw, wrapAsData: false };
   }
-  return description;
+  return {
+    schema: {
+      properties: { data: raw },
+      required: ['data'],
+      type: 'object',
+    },
+    wrapAsData: true,
+  };
+};
+
+const buildOutputSchemaProjection = (
+  trail: Trail<unknown, unknown, unknown>
+): OutputSchemaProjection | undefined =>
+  trail.output === undefined ? undefined : projectMcpOutputSchema(trail.output);
+
+const buildMeta = (
+  trail: Trail<unknown, unknown, unknown>
+): Record<string, unknown> | undefined => {
+  const examples = deriveStructuredTrailExamples(trail.examples);
+  if (examples === undefined) {
+    return undefined;
+  }
+  return { [MCP_TOOL_EXAMPLES_META_KEY]: examples };
 };
 
 /** Build a single MCP tool definition from a trail. */
@@ -297,12 +438,21 @@ const buildToolDefinition = (
   const rawAnnotations = deriveAnnotations(trail);
   const annotations =
     Object.keys(rawAnnotations).length > 0 ? rawAnnotations : undefined;
+  const projection = buildOutputSchemaProjection(trail);
   return {
+    _meta: buildMeta(trail),
     annotations,
     description: buildDescription(trail),
-    handler: createHandler(graph, trail, layers, options),
+    handler: createHandler(
+      graph,
+      trail,
+      layers,
+      options,
+      projection?.wrapAsData ?? false
+    ),
     inputSchema: zodToJsonSchema(trail.input),
     name: deriveToolName(graph.name, trail.id),
+    outputSchema: projection?.schema,
     trailId: trail.id,
   };
 };

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,5 +1,6 @@
 // Build
 export {
+  MCP_TOOL_EXAMPLES_META_KEY,
   deriveMcpTools,
   type DeriveMcpToolsOptions,
   type McpToolDefinition,

--- a/packages/mcp/src/surface.ts
+++ b/packages/mcp/src/surface.ts
@@ -86,10 +86,12 @@ const createMcpServer = (
   // oxlint-disable-next-line require-await -- MCP SDK requires async handler
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: tools.map((t) => ({
+      _meta: t._meta,
       annotations: t.annotations,
       description: t.description,
       inputSchema: t.inputSchema,
       name: t.name,
+      outputSchema: t.outputSchema,
     })),
   }));
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -7,6 +7,7 @@ Most applications reach this package through `trails topo export` and `trails to
 ## What it owns
 
 - deterministic surface-map generation from an established topo
+- structured example and field-override provenance projection for surface-map entries
 - stable hashing for CI drift detection
 - semantic diffing between two surface maps
 - file I/O helpers for `.trails/_surface.json` and `.trails/trails.lock`

--- a/packages/schema/src/__tests__/derive.test.ts
+++ b/packages/schema/src/__tests__/derive.test.ts
@@ -257,6 +257,98 @@ describe('deriveSurfaceMap', () => {
       expect(map.entries[0]?.exampleCount).toBe(3);
     });
 
+    test('trail entries preserve structured examples with provenance', () => {
+      const t = trail('with.examples', {
+        blaze: noop,
+        examples: [
+          {
+            description: 'Happy path',
+            expected: { y: 2 },
+            input: { x: 1 },
+            name: 'basic',
+          },
+          {
+            error: 'ValidationError',
+            input: { x: -1 },
+            name: 'negative',
+          },
+        ],
+        input: z.object({ x: z.number() }),
+        output: z.object({ y: z.number() }),
+      });
+      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ t })));
+
+      expect(entry.examples).toEqual([
+        {
+          description: 'Happy path',
+          expected: { y: 2 },
+          input: { x: 1 },
+          kind: 'success',
+          name: 'basic',
+          provenance: { source: 'trail.examples' },
+        },
+        {
+          error: 'ValidationError',
+          input: { x: -1 },
+          kind: 'error',
+          name: 'negative',
+          provenance: { source: 'trail.examples' },
+        },
+      ]);
+    });
+
+    test('omits structured examples that cannot be JSON serialized', () => {
+      const t = trail('with.dynamic.examples', {
+        blaze: noop,
+        examples: [
+          {
+            input: { value: 1n },
+            name: 'bigint input',
+          },
+        ],
+        input: z.any(),
+      });
+      const map = deriveSurfaceMap(topoFrom({ t }));
+      const entry = getFirstEntry(map);
+
+      expect(entry.exampleCount).toBe(1);
+      expect(entry.examples).toBeUndefined();
+      expect(() => JSON.stringify(map)).not.toThrow();
+    });
+
+    test('field overrides expose projection-local provenance', () => {
+      const t = trail('with.field.overrides', {
+        blaze: noop,
+        fields: {
+          name: { hint: 'Shown in prompts' },
+          status: {
+            label: 'State',
+            options: [
+              { hint: 'Ready for use', label: 'Active', value: 'active' },
+            ],
+          },
+        },
+        input: z.object({
+          name: z.string(),
+          status: z.enum(['active', 'inactive']),
+        }),
+      });
+      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ t })));
+
+      expect(entry.fieldOverrides).toEqual([
+        {
+          field: 'name',
+          overrides: ['hint'],
+          provenance: { source: 'trail.fields' },
+        },
+        {
+          field: 'status',
+          overrides: ['label', 'options'],
+          provenance: { source: 'trail.fields' },
+        },
+      ]);
+    });
+
     test('detours are included with error class names', () => {
       const t = trail('with.detours', {
         blaze: noop,

--- a/packages/schema/src/derive.ts
+++ b/packages/schema/src/derive.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  deriveStructuredTrailExamples,
   deriveCliPath,
   getContourReferences,
   validateDraftFreeTopo,
@@ -11,12 +12,19 @@ import {
 import type {
   AnyContour,
   AnyResource,
+  FieldOverride,
   Signal,
   Topo,
   Trail,
 } from '@ontrails/core';
 
-import type { JsonSchema, SurfaceMap, SurfaceMapEntry } from './types.js';
+import type {
+  JsonSchema,
+  SurfaceMap,
+  SurfaceMapEntry,
+  SurfaceMapFieldOverride,
+  SurfaceMapFieldOverrideKey,
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -147,6 +155,64 @@ const addTrailRelations = (
   }
 };
 
+const FIELD_OVERRIDE_KEYS: readonly SurfaceMapFieldOverrideKey[] = [
+  'hint',
+  'label',
+  'message',
+  'options',
+];
+
+const collectFieldOverrideKeys = (
+  override: FieldOverride
+): readonly SurfaceMapFieldOverrideKey[] =>
+  FIELD_OVERRIDE_KEYS.filter((key) => override[key] !== undefined);
+
+const deriveFieldOverrides = (
+  fields: Readonly<Record<string, FieldOverride>> | undefined
+): readonly SurfaceMapFieldOverride[] | undefined => {
+  if (fields === undefined) {
+    return undefined;
+  }
+
+  const overrides = Object.entries(fields)
+    .flatMap(([field, override]) => {
+      const overrideKeys = collectFieldOverrideKeys(override);
+      if (overrideKeys.length === 0) {
+        return [];
+      }
+      return [
+        {
+          field,
+          overrides: overrideKeys,
+          provenance: { source: 'trail.fields' as const },
+        },
+      ];
+    })
+    .toSorted((a, b) => a.field.localeCompare(b.field));
+
+  return overrides.length > 0 ? overrides : undefined;
+};
+
+const addFieldOverrides = (
+  entry: Record<string, unknown>,
+  t: Trail<unknown, unknown, unknown>
+): void => {
+  const fieldOverrides = deriveFieldOverrides(t.fields);
+  if (fieldOverrides !== undefined) {
+    entry['fieldOverrides'] = fieldOverrides;
+  }
+};
+
+const addExamples = (
+  entry: Record<string, unknown>,
+  t: Trail<unknown, unknown, unknown>
+): void => {
+  const examples = deriveStructuredTrailExamples(t.examples);
+  if (examples !== undefined) {
+    entry['examples'] = examples;
+  }
+};
+
 const trailToEntry = (t: Trail<unknown, unknown, unknown>): SurfaceMapEntry => {
   const raw = t as unknown as Record<string, unknown>;
   const trailheads = extractTrailheads(raw);
@@ -161,6 +227,8 @@ const trailToEntry = (t: Trail<unknown, unknown, unknown>): SurfaceMapEntry => {
   addSchemas(entry, t);
   addMetadata(entry, t, raw);
   addTrailRelations(entry, t);
+  addFieldOverrides(entry, t);
+  addExamples(entry, t);
 
   return sortKeys(entry) as unknown as SurfaceMapEntry;
 };

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -20,6 +20,8 @@ export {
 export type {
   SurfaceMap,
   SurfaceMapEntry,
+  SurfaceMapFieldOverride,
+  SurfaceMapFieldOverrideKey,
   SurfaceLock,
   DiffEntry,
   DiffResult,

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -2,6 +2,8 @@
  * Types for surface maps, diffing, and lock files.
  */
 
+import type { StructuredTrailExample } from '@ontrails/core';
+
 // ---------------------------------------------------------------------------
 // JSON Schema (lightweight alias)
 // ---------------------------------------------------------------------------
@@ -13,6 +15,20 @@ export interface SurfaceMapContourReference {
   readonly contour: string;
   readonly field: string;
   readonly identity: string;
+}
+
+export type SurfaceMapFieldOverrideKey =
+  | 'hint'
+  | 'label'
+  | 'message'
+  | 'options';
+
+export interface SurfaceMapFieldOverride {
+  readonly field: string;
+  readonly overrides: readonly SurfaceMapFieldOverrideKey[];
+  readonly provenance: {
+    readonly source: 'trail.fields';
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -41,11 +57,13 @@ export interface SurfaceMapEntry {
   readonly identity?: string | undefined;
   readonly references?: readonly SurfaceMapContourReference[] | undefined;
   readonly resources?: readonly string[] | undefined;
+  readonly fieldOverrides?: readonly SurfaceMapFieldOverride[] | undefined;
   readonly detours?:
     | readonly { readonly on: string; readonly maxAttempts: number }[]
     | undefined;
   readonly healthcheck?: boolean | undefined;
   readonly exampleCount: number;
+  readonly examples?: readonly StructuredTrailExample[] | undefined;
   readonly description?: string | undefined;
 }
 


### PR DESCRIPTION
## Summary
- Enforces runtime output validation in executeTrail before successful results are returned or traced.
- Makes query trail outputs discriminable for agent-friendly branching.
- Projects output schemas and structured examples through MCP and schema surfaces from shared derivation helpers.

## Compatibility Notes
- Guide, survey, and topo query outputs intentionally use discriminated wrapper objects now; consumers of the old flat/list shapes should branch on `mode`.
- Shared topo detail schemas are tighter and are enforced by runtime output validation.

## Validation
- bun run check
- bun run build
- bun run test

Closes: TRL-557, TRL-566, TRL-567