### PR TITLE
fix: close execution contract lifecycle holes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -171,7 +171,7 @@
         "@ontrails/core": "workspace:^",
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.0",
+        "@modelcontextprotocol/sdk": "^1.28.0",
         "zod": "catalog:",
       },
     },

--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -11,7 +11,7 @@ import { run } from '../run';
 import { signal } from '../signal';
 import { topo } from '../topo';
 import { trail } from '../trail';
-import type { Logger } from '../types';
+import type { Logger, TrailContext } from '../types';
 
 const noopLogger: Logger = {
   child() {
@@ -761,6 +761,50 @@ describe('fire', () => {
       const result = await executeTrail(standalone, {});
       expect(result.isOk()).toBe(true);
       expect((result.unwrap() as { hasFire: boolean }).hasFire).toBe(false);
+    });
+
+    test('caller-supplied ctx.fire is preserved even when topo is provided', async () => {
+      // Symmetry with bindCrossToCtx: a test harness or runtime that injects
+      // a custom ctx.fire mock should observe its calls, not have them
+      // silently rebound to the topo-backed dispatcher.
+      const { executeTrail } = await import('../execute');
+      const captured: { signalId?: string; payload?: unknown } = {};
+      const fireMock: NonNullable<TrailContext['fire']> = ((
+        signalArg: unknown,
+        payload: unknown
+      ) => {
+        const id =
+          typeof signalArg === 'string'
+            ? signalArg
+            : (signalArg as { id: string }).id;
+        captured.signalId = id;
+        captured.payload = payload;
+        return Promise.resolve(Result.ok(null as unknown));
+      }) as NonNullable<TrailContext['fire']>;
+
+      const producer = trail('order.create-with-injected-fire', {
+        blaze: async (_input, ctx) => {
+          await ctx.fire?.(orderPlaced, {
+            orderId: 'o-injected',
+            total: 1,
+          });
+          return Result.ok({ ok: true });
+        },
+        fires: ['order.placed'],
+        input: z.object({}),
+      });
+      const consumer = makeConsumer('notify.email', createCapture());
+      const app = topo('preserve-fire', { consumer, orderPlaced, producer });
+
+      const result = await executeTrail(
+        producer,
+        {},
+        { ctx: { fire: fireMock }, topo: app }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(captured.signalId).toBe('order.placed');
+      expect(captured.payload).toEqual({ orderId: 'o-injected', total: 1 });
     });
   });
 

--- a/packages/core/src/__tests__/resilience.test.ts
+++ b/packages/core/src/__tests__/resilience.test.ts
@@ -229,6 +229,16 @@ describe('withTimeout', () => {
     expect(err3.error.message).toBe('unexpected');
   });
 
+  test('handles synchronous throws and settles with a Result', async () => {
+    const result = await withTimeout(() => {
+      throw new Error('sync unexpected');
+    }, 1000);
+
+    expect(result.isErr()).toBe(true);
+    const err = result as unknown as { error: Error };
+    expect(err.error.message).toBe('sync unexpected');
+  });
+
   test('includes timeout ms in error context', async () => {
     const result = await withTimeout(
       () =>

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -657,6 +657,14 @@ const bindFireToCtx = (
   topo: Topo | undefined,
   options: ExecuteTrailOptions | undefined
 ): TrailContext => {
+  // Symmetric with bindCrossToCtx: a caller-supplied ctx.fire (e.g. test
+  // helper, scenario harness, or runtime intercepting signal fan-out) is
+  // preserved as-is. Without this guard, passing both `topo: app` and a
+  // custom `ctx.fire` would silently clobber the injected mock with the
+  // topo-backed dispatcher.
+  if (ctx.fire !== undefined) {
+    return ctx;
+  }
   if (topo === undefined) {
     return ctx;
   }

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -203,10 +203,9 @@ export const withTimeout = <T>(
       );
     }, ms);
 
-    // oxlint-disable-next-line prefer-await-to-then, no-void -- .then() needed inside Promise constructor; void discards unhandled rejection
-    void fn().then(
-      // oxlint-disable-next-line prefer-await-to-callbacks -- callback required inside .then()
-      (result) => {
+    const run = async () => {
+      try {
+        const result = await fn();
         if (settled) {
           return;
         }
@@ -215,9 +214,7 @@ export const withTimeout = <T>(
         signal?.removeEventListener('abort', onAbort);
         // oxlint-disable-next-line promise/no-multiple-resolved -- settled guard ensures single resolution
         resolve(result);
-      },
-      // oxlint-disable-next-line prefer-await-to-callbacks -- rejection handler required inside .then()
-      (error: unknown) => {
+      } catch (error: unknown) {
         if (settled) {
           return;
         }
@@ -229,6 +226,9 @@ export const withTimeout = <T>(
           Result.err(error instanceof Error ? error : new Error(String(error)))
         );
       }
-    );
+    };
+
+    // oxlint-disable-next-line no-void -- fire-and-settle inside Promise constructor
+    void run();
   });
 };

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,7 +25,7 @@
     "@ontrails/core": "workspace:^"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@modelcontextprotocol/sdk": "^1.28.0",
     "zod": "catalog:"
   }
 }

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -701,6 +701,7 @@ describe('deriveMcpTools', () => {
       expect(result?.content[0]?.type).toBe('image');
       expect(result?.content[0]?.mimeType).toBe('image/gif');
       expect(result?.content[0]?.data).toBeDefined();
+      expect(stream.locked).toBe(false);
     });
 
     test('BlobRef output with outputSchema keeps structuredContent present', async () => {

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -117,13 +117,17 @@ const collectStream = async (
   const reader = stream.getReader();
   const chunks: Uint8Array[] = [];
   let totalLength = 0;
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(value);
+      totalLength += value.length;
     }
-    chunks.push(value);
-    totalLength += value.length;
+  } finally {
+    reader.releaseLock();
   }
   return concatChunks(chunks, totalLength);
 };

--- a/packages/mcp/src/surface.ts
+++ b/packages/mcp/src/surface.ts
@@ -96,47 +96,50 @@ const createMcpServer = (
   }));
 
   // Register tools/call handler
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const tool = toolMap.get(request.params.name);
-    if (tool === undefined) {
-      return {
-        content: [
-          {
-            text: `Unknown tool: ${request.params.name}`,
-            type: 'text' as const,
-          },
-        ],
-        isError: true,
-      } as Record<string, unknown>;
+  server.setRequestHandler(
+    CallToolRequestSchema,
+    async (request, requestExtra) => {
+      const tool = toolMap.get(request.params.name);
+      if (tool === undefined) {
+        return {
+          content: [
+            {
+              text: `Unknown tool: ${request.params.name}`,
+              type: 'text' as const,
+            },
+          ],
+          isError: true,
+        } as Record<string, unknown>;
+      }
+
+      const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+      const progressToken = request.params._meta?.progressToken;
+
+      const sendProgress =
+        progressToken === undefined
+          ? undefined
+          : async (current: number, total: number) => {
+              await server.notification({
+                method: 'notifications/progress',
+                params: {
+                  progress: current,
+                  progressToken,
+                  total,
+                },
+              });
+            };
+
+      const extra = {
+        abortSignal: requestExtra.signal,
+        progressToken,
+        sendProgress,
+      };
+
+      const result = await tool.handler(args, extra);
+      // Spread to satisfy MCP SDK's index-signature requirement
+      return { ...result } as Record<string, unknown>;
     }
-
-    const args = (request.params.arguments ?? {}) as Record<string, unknown>;
-    const progressToken = request.params._meta?.progressToken;
-
-    const sendProgress =
-      progressToken === undefined
-        ? undefined
-        : async (current: number, total: number) => {
-            await server.notification({
-              method: 'notifications/progress',
-              params: {
-                progress: current,
-                progressToken,
-                total,
-              },
-            });
-          };
-
-    const extra = {
-      abortSignal: undefined as AbortSignal | undefined,
-      progressToken,
-      sendProgress,
-    };
-
-    const result = await tool.handler(args, extra);
-    // Spread to satisfy MCP SDK's index-signature requirement
-    return { ...result } as Record<string, unknown>;
-  });
+  );
 
   return server;
 };

--- a/packages/testing/src/__tests__/contracts.test.ts
+++ b/packages/testing/src/__tests__/contracts.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, describe, expect, mock, test } from 'bun:test';
 
-import { contour, Result, resource, trail, topo } from '@ontrails/core';
+import { contour, Result, resource, signal, trail, topo } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
 import { testContracts } from '../contracts.js';
@@ -53,11 +54,31 @@ const noExamplesTrail = trail('noexamples', {
 // Composition trail
 // ---------------------------------------------------------------------------
 
+const compositionChildBlaze = mock((value: number) =>
+  Result.ok({ total: value })
+);
+
+const compositionChildTrail = trail('composition.child', {
+  blaze: (input: { value: number }) => compositionChildBlaze(input.value),
+  input: z.object({ value: z.number() }),
+  output: z.object({ total: z.number() }),
+});
+
 /** Composition trail whose implementation matches the output schema. */
 const compositionTrail = trail('composition.valid', {
-  blaze: (input: { a: number; b: number }) =>
-    Result.ok({ total: input.a + input.b }),
-  crosses: ['valid'],
+  blaze: async (input: { a: number; b: number }, ctx) => {
+    const crossed = await ctx.cross?.(compositionChildTrail, {
+      value: input.a + input.b,
+    });
+    if (crossed === undefined) {
+      return Result.err(new Error('missing cross context'));
+    }
+    if (crossed.isErr()) {
+      return Result.err(crossed.error);
+    }
+    return Result.ok({ total: crossed.value.total });
+  },
+  crosses: [compositionChildTrail],
   examples: [
     {
       expected: { total: 3 },
@@ -67,6 +88,35 @@ const compositionTrail = trail('composition.valid', {
   ],
   input: z.object({ a: z.number(), b: z.number() }),
   output: z.object({ total: z.number() }),
+});
+
+const compositionContractSignal = signal('composition.contract.fired', {
+  payload: z.object({ id: z.string() }),
+});
+
+const compositionWithFireTrail = trail('composition.withFire', {
+  blaze: async (_input: Record<string, never>, ctx) => {
+    const crossed = await ctx.cross?.(compositionChildTrail, { value: 3 });
+    const fired = await ctx.fire?.(compositionContractSignal, {
+      id: 'contract',
+    });
+
+    return Result.ok({
+      crossed: crossed?.isOk() === true,
+      fired: fired?.isOk() === true,
+    });
+  },
+  crosses: [compositionChildTrail],
+  examples: [
+    {
+      expected: { crossed: true, fired: true },
+      input: {},
+      name: 'Custom cross still keeps fire binding',
+    },
+  ],
+  fires: [compositionContractSignal],
+  input: z.object({}),
+  output: z.object({ crossed: z.literal(true), fired: z.literal(true) }),
 });
 
 const transformedInputTrail = trail('contract.transformed', {
@@ -186,8 +236,56 @@ describe('testContracts: skips trails without examples', () => {
 describe('testContracts: validates output schemas for trails with crossings', () => {
   // eslint-disable-next-line jest/require-hook
   testContracts(
-    topo('test-app', { compositionTrail } as Record<string, unknown>)
+    topo('test-app', {
+      compositionChildTrail,
+      compositionTrail,
+    } as Record<string, unknown>)
   );
+
+  afterAll(() => {
+    expect(compositionChildBlaze).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('testContracts: preserves provided cross context', () => {
+  const providedCross = mock(async () => Result.ok({ total: 3 }));
+
+  // eslint-disable-next-line jest/require-hook
+  testContracts(
+    topo('custom-cross-contract-app', {
+      compositionTrail,
+    } as Record<string, unknown>),
+    {
+      ctx: {
+        cross: providedCross as TrailContext['cross'],
+      },
+    }
+  );
+
+  afterAll(() => {
+    expect(providedCross).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('testContracts: preserves custom cross without suppressing fire', () => {
+  const providedCross = mock(async () => Result.ok({ total: 3 }));
+
+  // eslint-disable-next-line jest/require-hook
+  testContracts(
+    topo('custom-cross-fire-contract-app', {
+      compositionContractSignal,
+      compositionWithFireTrail,
+    } as Record<string, unknown>),
+    {
+      ctx: {
+        cross: providedCross as TrailContext['cross'],
+      },
+    }
+  );
+
+  afterAll(() => {
+    expect(providedCross).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('testContracts: raw transformed input', () => {

--- a/packages/testing/src/contracts.ts
+++ b/packages/testing/src/contracts.ts
@@ -26,18 +26,6 @@ import { deriveTrailExamples } from './effective-examples.js';
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Check if a trail requires cross() but the context doesn't provide it. */
-const needsCrossContext = (
-  t: unknown,
-  resolveCtx: () => Partial<TrailContext> | TestExecutionOptions | undefined
-): boolean => {
-  const spec = t as { crosses?: readonly string[] };
-  if (!spec.crosses || spec.crosses.length === 0) {
-    return false;
-  }
-  return !normalizeTestExecutionOptions(resolveCtx()).ctx?.cross;
-};
-
 const validateOutputSchema = (
   outputSchema: z.ZodType,
   value: unknown,
@@ -87,10 +75,6 @@ export const testContracts = (
       if (t.examples.length === 0) {
         return;
       }
-      if (needsCrossContext(t, resolveInput)) {
-        return;
-      }
-
       const { examples, output: outputSchema } = t;
       const successExamples = examples.filter((e) => e.error === undefined);
 
@@ -111,6 +95,7 @@ export const testContracts = (
           const result = await executeTrail(t, example.input, {
             ctx: testCtx,
             resources,
+            topo: app,
           });
           const resultValue = expectOk(result);
 


### PR DESCRIPTION
## Summary
- Closes focused execution lifecycle gaps around withTimeout, MCP stream reader cleanup, MCP request abort propagation, and contract tests for crossed trails.
- Keeps MCP close and drain semantics scoped to the broader resource lifecycle design instead of overclaiming it here.

## Validation
- bun run check
- bun run build
- bun run test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes: TRL-559