### PR TITLE
feat: settle primitive parity for non-trail state

### DIFF
--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -8,7 +8,14 @@ import {
 } from 'node:fs';
 import { join, resolve } from 'node:path';
 
-import { ConflictError, Result, resource, topo, trail } from '@ontrails/core';
+import {
+  ConflictError,
+  Result,
+  resource,
+  signal,
+  topo,
+  trail,
+} from '@ontrails/core';
 import {
   deriveSurfaceMap,
   deriveSurfaceMapHash,
@@ -21,6 +28,7 @@ import { z } from 'zod';
 
 import {
   deriveBriefReport,
+  deriveSignalDetail,
   deriveSurveyList,
   deriveTrailDetail,
   surveyTrail,
@@ -28,6 +36,7 @@ import {
 import { loadApp } from '../trails/load-app.js';
 import type {
   BriefReport,
+  SignalDetailReport,
   SurveyListReport,
   TrailDetailReport,
 } from '../trails/survey.js';
@@ -82,6 +91,33 @@ const app = topo('test-app', {
   bye: byeTrail,
   dbResource,
   hello: helloTrail,
+});
+
+const helloGreeted = signal('hello.greeted', {
+  description: 'A greeting was produced',
+  examples: [{ name: 'Ada' }],
+  from: ['signal.producer'],
+  payload: z.object({ name: z.string() }),
+});
+
+const signalProducer = trail('signal.producer', {
+  blaze: (input) => Result.ok({ name: input.name }),
+  fires: [helloGreeted],
+  input: z.object({ name: z.string() }),
+  output: z.object({ name: z.string() }),
+});
+
+const signalConsumer = trail('signal.consumer', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  on: [helloGreeted],
+  output: z.object({ ok: z.boolean() }),
+});
+
+const signalApp = topo('signal-app', {
+  helloGreeted,
+  signalConsumer,
+  signalProducer,
 });
 
 const expectOk = <T>(result: Result<T, Error>): T => {
@@ -293,6 +329,47 @@ describe('trails survey resources section', () => {
   });
 });
 
+describe('trails survey signals section', () => {
+  test('list output includes signal examples and graph relations', () => {
+    const report = deriveSurveyList(signalApp);
+    const parsed = structuredClone(report) as SurveyListReport;
+    const entry = parsed.signals.find(
+      (signalEntry) => signalEntry.id === 'hello.greeted'
+    );
+
+    expect(parsed.signalCount).toBe(1);
+    expect(entry).toEqual({
+      consumers: ['signal.consumer'],
+      description: 'A greeting was produced',
+      examples: 1,
+      from: ['signal.producer'],
+      id: 'hello.greeted',
+      kind: 'signal',
+      payloadSchema: true,
+      producers: ['signal.producer'],
+    });
+  });
+
+  test('signal detail includes payload schema, examples, and relations', () => {
+    const detail = deriveSignalDetail(signalApp, 'hello.greeted');
+    const parsed = structuredClone(detail) as SignalDetailReport;
+
+    expect(parsed).toMatchObject({
+      consumers: ['signal.consumer'],
+      description: 'A greeting was produced',
+      examples: [{ name: 'Ada' }],
+      from: ['signal.producer'],
+      id: 'hello.greeted',
+      kind: 'signal',
+      producers: ['signal.producer'],
+    });
+    expect(parsed.payload).toMatchObject({
+      properties: { name: { type: 'string' } },
+      type: 'object',
+    });
+  });
+});
+
 describe('trails survey generate', () => {
   test('delegates to topo export and writes a structured lock', async () => {
     const dir = repoTempDir();
@@ -397,6 +474,12 @@ describe('trails survey output schema', () => {
     expect(
       surveyTrail.output.safeParse({
         detail: deriveTrailDetail(helloTrail),
+        mode: 'detail',
+      }).success
+    ).toBe(true);
+    expect(
+      surveyTrail.output.safeParse({
+        detail: deriveSignalDetail(signalApp, 'hello.greeted'),
         mode: 'detail',
       }).success
     ).toBe(true);

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -30,11 +30,13 @@ import { exportCurrentTopo } from './topo-store-support.js';
 export {
   deriveBriefReport,
   deriveResourceDetail,
+  deriveSignalDetail,
   deriveSurveyList,
   deriveTrailDetail,
 } from './topo-reports.js';
 export type {
   BriefReport,
+  SignalDetailReport,
   SurveyListReport,
   TrailDetailReport,
 } from './topo-reports.js';
@@ -75,15 +77,15 @@ const buildSurveyDiff = async (
 
 const buildSurveyDetail = (
   app: Topo,
-  trailId: string,
+  entityId: string,
   rootDir: string
 ): Result<object, Error> => {
-  const detail = buildCurrentTopoDetail(app, trailId, { rootDir });
+  const detail = buildCurrentTopoDetail(app, entityId, { rootDir });
   if (detail !== undefined) {
     return Result.ok(detail);
   }
   return Result.err(
-    new NotFoundError(`Trail or resource not found: ${trailId}`)
+    new NotFoundError(`Trail, resource, or signal not found: ${entityId}`)
   );
 };
 
@@ -241,7 +243,10 @@ export const surveyTrail = trail('survey', {
       .describe('Generate surface map and lock file'),
     module: z.string().optional().describe('Path to the app module'),
     openapi: z.boolean().default(false).describe('Output OpenAPI 3.1 spec'),
-    trailId: z.string().optional().describe('Trail ID for detail view'),
+    trailId: z
+      .string()
+      .optional()
+      .describe('Trail, resource, or signal ID for detail view'),
   }),
   intent: 'read',
   output: z.discriminatedUnion('mode', [
@@ -265,6 +270,19 @@ export const surveyTrail = trail('survey', {
           kind: z.literal('resource'),
           lifetime: z.literal('singleton'),
           usedBy: z.array(z.string()),
+        })
+      ),
+      signalCount: z.number(),
+      signals: z.array(
+        z.object({
+          consumers: z.array(z.string()).readonly(),
+          description: z.string().nullable(),
+          examples: z.number(),
+          from: z.array(z.string()).readonly(),
+          id: z.string(),
+          kind: z.literal('signal'),
+          payloadSchema: z.boolean(),
+          producers: z.array(z.string()).readonly(),
         })
       ),
     }),

--- a/apps/trails/src/trails/topo-output-schemas.ts
+++ b/apps/trails/src/trails/topo-output-schemas.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const trailDetailOutput = z.object({
-  crosses: z.array(z.string()),
+  crosses: z.array(z.string()).readonly(),
   description: z.string().nullable(),
   detours: z
     .array(
@@ -10,13 +10,14 @@ export const trailDetailOutput = z.object({
         on: z.string(),
       })
     )
+    .readonly()
     .nullable(),
-  examples: z.array(z.unknown()),
+  examples: z.array(z.unknown()).readonly(),
   id: z.string(),
   intent: z.enum(['read', 'write', 'destroy']),
   kind: z.literal('trail'),
   pattern: z.string().nullable(),
-  resources: z.array(z.string()),
+  resources: z.array(z.string()).readonly(),
   safety: z.string(),
 });
 
@@ -26,10 +27,26 @@ export const resourceDetailOutput = z.object({
   id: z.string(),
   kind: z.literal('resource'),
   lifetime: z.literal('singleton'),
-  usedBy: z.array(z.string()),
+  usedBy: z.array(z.string()).readonly(),
+});
+
+export const signalDetailOutput = z.object({
+  consumers: z.array(z.string()).readonly(),
+  description: z.string().nullable(),
+  examples: z.array(z.unknown()).readonly(),
+  from: z.array(z.string()).readonly(),
+  id: z.string(),
+  kind: z.literal('signal'),
+  // null when the surface-map entry is missing for this signal (e.g. partial
+  // import or schema migration). Coherent with the list view's
+  // `payloadSchema: false` flag — distinguishes "schema not found" from
+  // "schema accepts any value" (the latter would be `{}`).
+  payload: z.record(z.string(), z.unknown()).nullable(),
+  producers: z.array(z.string()).readonly(),
 });
 
 export const topoDetailOutput = z.discriminatedUnion('kind', [
   trailDetailOutput,
   resourceDetailOutput,
+  signalDetailOutput,
 ]);

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -23,7 +23,11 @@ import {
 } from '@ontrails/core/internal/trails-db';
 import { readSurfaceLockData } from '@ontrails/schema';
 
-import type { BriefReport, SurveyListReport } from './topo-reports.js';
+import type {
+  BriefReport,
+  SignalDetailReport,
+  SurveyListReport,
+} from './topo-reports.js';
 import type { TopoSummaryReport, TopoVerifyReport } from './topo-support.js';
 import { REPORT_CONTRACT_VERSION, REPORT_VERSION } from './topo-constants.js';
 import {
@@ -124,6 +128,7 @@ const buildSurveyListFromStore = (
 ): SurveyListReport => {
   const trails = store.trails.list({ snapshot: ref });
   const resources = store.resources.list({ snapshot: ref });
+  const signals = store.signals.list({ snapshot: ref });
 
   return {
     count: trails.length,
@@ -141,6 +146,17 @@ const buildSurveyListFromStore = (
       kind: resource.kind,
       lifetime: resource.lifetime,
       usedBy: resource.usedBy,
+    })),
+    signalCount: signals.length,
+    signals: signals.map((signal) => ({
+      consumers: signal.consumers,
+      description: signal.description,
+      examples: signal.exampleCount,
+      from: signal.from,
+      id: signal.id,
+      kind: signal.kind,
+      payloadSchema: signal.payloadSchema,
+      producers: signal.producers,
     })),
   };
 };
@@ -179,6 +195,21 @@ const buildResourceDetailFromStore = (
   kind: resource.kind,
   lifetime: resource.lifetime,
   usedBy: [...resource.usedBy],
+});
+
+const buildSignalDetailFromStore = (
+  signal: NonNullable<
+    ReturnType<ReturnType<typeof createTopoStore>['signals']['get']>
+  >
+): SignalDetailReport => ({
+  consumers: [...signal.consumers],
+  description: signal.description,
+  examples: [...signal.examples],
+  from: [...signal.from],
+  id: signal.id,
+  kind: signal.kind,
+  payload: signal.payload ?? null,
+  producers: [...signal.producers],
 });
 
 // ---------------------------------------------------------------------------
@@ -272,7 +303,11 @@ export const buildCurrentTopoDetail = (
   app: Topo,
   id: string,
   options?: { readonly rootDir?: string }
-): CurrentResourceDetail | CurrentTrailDetail | undefined => {
+):
+  | CurrentResourceDetail
+  | CurrentTrailDetail
+  | SignalDetailReport
+  | undefined => {
   const rootDir = deriveRootDir(options?.rootDir);
   return withCurrentTopoStore(app, rootDir, (store, ref) => {
     const trail = store.trails.get(id, { snapshot: ref });
@@ -281,9 +316,14 @@ export const buildCurrentTopoDetail = (
     }
 
     const resource = store.resources.get(id, { snapshot: ref });
-    return resource === undefined
+    if (resource !== undefined) {
+      return buildResourceDetailFromStore(resource);
+    }
+
+    const signal = store.signals.get(id, { snapshot: ref });
+    return signal === undefined
       ? undefined
-      : buildResourceDetailFromStore(resource);
+      : buildSignalDetailFromStore(signal);
   });
 };
 

--- a/apps/trails/src/trails/topo-reports.ts
+++ b/apps/trails/src/trails/topo-reports.ts
@@ -1,4 +1,5 @@
-import type { Topo, Trail } from '@ontrails/core';
+import { zodToJsonSchema } from '@ontrails/core';
+import type { Signal, Topo, Trail } from '@ontrails/core';
 
 import { REPORT_CONTRACT_VERSION, REPORT_VERSION } from './topo-constants.js';
 
@@ -35,6 +36,17 @@ export interface SurveyListReport {
     readonly lifetime: 'singleton';
     readonly usedBy: readonly string[];
   }[];
+  readonly signalCount: number;
+  readonly signals: readonly {
+    readonly consumers: readonly string[];
+    readonly description: string | null;
+    readonly examples: number;
+    readonly from: readonly string[];
+    readonly id: string;
+    readonly kind: 'signal';
+    readonly payloadSchema: boolean;
+    readonly producers: readonly string[];
+  }[];
 }
 
 export interface TrailDetailReport {
@@ -50,6 +62,24 @@ export interface TrailDetailReport {
   readonly pattern: string | null;
   readonly safety: string;
   readonly resources: readonly string[];
+}
+
+export interface SignalDetailReport {
+  readonly consumers: readonly string[];
+  readonly description: string | null;
+  readonly examples: readonly unknown[];
+  readonly from: readonly string[];
+  readonly id: string;
+  readonly kind: 'signal';
+  /**
+   * The signal's payload schema (JSON Schema object), or `null` when the
+   * surface-map entry is missing for this signal. `null` is meaningful:
+   * it matches the list view's `payloadSchema: false` flag and lets
+   * consumers distinguish "schema not found" from "schema accepts any
+   * value" (the latter would be an empty object `{}`).
+   */
+  readonly payload: Readonly<Record<string, unknown>> | null;
+  readonly producers: readonly string[];
 }
 
 const trailHas = (raw: Record<string, unknown>, key: string): boolean => {
@@ -141,6 +171,49 @@ const resourceHealthStatus = (resource: {
 }): 'available' | 'none' =>
   resource.health === undefined ? 'none' : 'available';
 
+interface SignalRelations {
+  readonly consumers: readonly string[];
+  readonly producers: readonly string[];
+}
+
+const buildSignalRelations = (
+  app: Topo
+): ReadonlyMap<string, SignalRelations> => {
+  const relations = new Map<
+    string,
+    { consumers: string[]; producers: string[] }
+  >();
+
+  const get = (signalId: string) => {
+    const existing = relations.get(signalId);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const created = { consumers: [], producers: [] };
+    relations.set(signalId, created);
+    return created;
+  };
+
+  for (const trailDef of app.list()) {
+    for (const signalId of trailDef.fires) {
+      get(signalId).producers.push(trailDef.id);
+    }
+    for (const signalId of trailDef.on) {
+      get(signalId).consumers.push(trailDef.id);
+    }
+  }
+
+  return new Map(
+    [...relations.entries()].map(([id, value]) => [
+      id,
+      {
+        consumers: value.consumers.toSorted(),
+        producers: value.producers.toSorted(),
+      },
+    ])
+  );
+};
+
 export const deriveResourceDetail = (app: Topo, resourceId: string): object => {
   const item = app.getResource(resourceId);
   const usedBy = buildResourceUsage(app).get(resourceId) ?? [];
@@ -170,6 +243,31 @@ const formatResourceList = (app: Topo): SurveyListReport['resources'] => {
     .toSorted((a, b) => a.id.localeCompare(b.id));
 };
 
+const formatSignalList = (app: Topo): SurveyListReport['signals'] => {
+  const relations = buildSignalRelations(app);
+  return app
+    .listSignals()
+    .map((signalDef) => {
+      const related = relations.get(signalDef.id);
+      return {
+        consumers: related?.consumers ?? [],
+        description: signalDef.description ?? null,
+        examples: signalDef.examples?.length ?? 0,
+        from: signalDef.from?.toSorted() ?? [],
+        id: signalDef.id,
+        kind: signalDef.kind,
+        // Mirror the store path (`mapSignalRow` in `topo-store-read.ts`) which
+        // derives this from the surface-map entry. SignalSpec<T> requires
+        // `payload` so this is `true` in practice today; the explicit check
+        // keeps the in-memory and store reports self-consistent if a future
+        // SignalSpec variant ever omits `payload`.
+        payloadSchema: signalDef.payload !== undefined,
+        producers: related?.producers ?? [],
+      };
+    })
+    .toSorted((a, b) => a.id.localeCompare(b.id));
+};
+
 export const deriveSurveyList = (app: Topo): SurveyListReport => {
   const items = app.list();
   const entries = items.map((item) => {
@@ -191,12 +289,37 @@ export const deriveSurveyList = (app: Topo): SurveyListReport => {
   });
 
   const resources = formatResourceList(app);
+  const signals = formatSignalList(app);
 
   return {
     count: items.length,
     entries,
     resourceCount: resources.length,
     resources,
+    signalCount: signals.length,
+    signals,
+  };
+};
+
+export const deriveSignalDetail = (
+  app: Topo,
+  signalId: string
+): SignalDetailReport | undefined => {
+  const signalDef = app.signals.get(signalId) as Signal<unknown> | undefined;
+  if (signalDef === undefined) {
+    return undefined;
+  }
+  const related = buildSignalRelations(app).get(signalId);
+
+  return {
+    consumers: [...(related?.consumers ?? [])],
+    description: signalDef.description ?? null,
+    examples: [...(signalDef.examples ?? [])],
+    from: signalDef.from?.toSorted() ?? [],
+    id: signalDef.id,
+    kind: 'signal',
+    payload: zodToJsonSchema(signalDef.payload),
+    producers: [...(related?.producers ?? [])],
   };
 };
 

--- a/apps/trails/src/trails/topo-show.ts
+++ b/apps/trails/src/trails/topo-show.ts
@@ -14,10 +14,10 @@ export const topoShowTrail = trail('topo.show', {
       return Result.ok(detail);
     }
     return Result.err(
-      new NotFoundError(`Trail or resource not found: ${input.id}`)
+      new NotFoundError(`Trail, resource, or signal not found: ${input.id}`)
     );
   },
-  description: 'Show detail for a current trail or resource',
+  description: 'Show detail for a current trail, resource, or signal',
   examples: [
     {
       input: { id: 'topo' },
@@ -25,7 +25,7 @@ export const topoShowTrail = trail('topo.show', {
     },
   ],
   input: z.object({
-    id: z.string().describe('Trail or resource ID to inspect'),
+    id: z.string().describe('Trail, resource, or signal ID to inspect'),
     module: z.string().optional().describe('Path to the app module'),
     rootDir: z.string().optional().describe('Workspace root directory'),
   }),

--- a/apps/trails/src/trails/topo.ts
+++ b/apps/trails/src/trails/topo.ts
@@ -42,6 +42,19 @@ const summaryOutput = z.object({
         usedBy: z.array(z.string()),
       })
     ),
+    signalCount: z.number(),
+    signals: z.array(
+      z.object({
+        consumers: z.array(z.string()).readonly(),
+        description: z.string().nullable(),
+        examples: z.number(),
+        from: z.array(z.string()).readonly(),
+        id: z.string(),
+        kind: z.literal('signal'),
+        payloadSchema: z.boolean(),
+        producers: z.array(z.string()).readonly(),
+      })
+    ),
   }),
   lockExists: z.boolean(),
   lockPath: z.string(),

--- a/docs/adr/drafts/20260409-layer-evolution.md
+++ b/docs/adr/drafts/20260409-layer-evolution.md
@@ -3,12 +3,18 @@ slug: layer-evolution
 title: Layer Evolution
 status: draft
 created: 2026-04-09
-updated: 2026-04-09
+updated: 2026-04-28
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [6, 12]
 ---
 
 # ADR: Layer Evolution
+
+> Current v1 posture: this ADR remains a future-facing draft. The shipped API
+> keeps `Layer` and `composeLayers()` as low-level execution plumbing passed
+> through `run()` and surface options. Layers are not topo primitives, trail spec
+> fields, or serialized graph nodes unless this evolution work is accepted and
+> implemented.
 
 ## Context
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -56,7 +56,7 @@ executeTrail(trail, rawInput, options?) // validate → resolve context → reso
 run(topo, id, input, options?)    // look up and execute a trail by ID; accepts ctx/resource overrides
 RunOptions
 
-// Layers
+// Execution layers (pipeline utility, not a v1 graph primitive)
 Layer                               // wrap(trail, implementation) → implementation
 composeLayers(layers, trail, implementation)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ Trails uses a hexagonal architecture. Core defines ports. Everything on the edge
                 |  signal() -> Signal   |
                 |  topo() -> Topo       |
                 |  Result, Errors       |
-                |  Layer, Topo           |
+                |  execute/run pipeline |
                 |                       |
                 +---------+-------------+
                           |
@@ -137,7 +137,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 
 ### Foundation
 
-`@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, `contour()`/`trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, layers, and connector port interfaces.
+`@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, `contour()`/`trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, execution pipeline utilities including `Layer`/`composeLayers()`, and connector port interfaces.
 
 **The test:** if you are building a surface connector or ecosystem package, you should only need `@ontrails/core`.
 
@@ -235,10 +235,10 @@ CLI input ("myapp entity show --name Alpha")
   -> Zod validates input against trail's schema
   -> TrailContext created (requestId, logger, abortSignal, env, cwd)
   -> Declared resources resolved into ctx
-  -> Layers run (auth, rate limit, telemetry)
+  -> Execution layers run (auth, rate limit, telemetry)
   -> implementation(validatedInput, ctx) called
   -> Result returned
-  -> Layers post-process
+  -> Execution layers post-process
   -> Result mapped to exit code + stdout output
 ```
 
@@ -292,7 +292,7 @@ executeTrail(trail, rawInput, options?)
   -> Zod validates rawInput against trail's input schema
   -> TrailContext resolved from options/createContext
   -> Declared resources resolved into ctx
-  -> Layers composed via composeLayers()
+  -> Execution layers composed via composeLayers()
   -> implementation(validatedInput, ctx) called
   -> Result returned
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 1. **[Why Trails](./why-trails.md)** — The problem, the approach, why contracts beat conventions
 2. **[Getting Started](./getting-started.md)** — Install, define your first trail, open CLI/MCP/HTTP surfaces, test it
-3. **[Lexicon](./lexicon.md)** — The terms you'll use every day: trail, blaze, topo, contour, surface, cross, resource, signal, layer, tracing
+3. **[Lexicon](./lexicon.md)** — The terms you'll use every day: trail, blaze, topo, contour, surface, cross, resource, signal, execution layers, tracing
 
 ## Release Notes
 

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -224,15 +224,20 @@ Terms that name concepts existing cleanly across software. The standard word wor
 
 ### `layer`
 
-A cross-cutting wrapper around trail execution. Layers add behavior to the
-execution pipeline: dry-run, pagination, verbose, telemetry. Most layers don't
-block — they augment. Attaches at three levels: trail, surface, or graph.
+A low-level wrapper around one trail execution. In v1, a layer is execution
+plumbing passed through `run()` or surface options. It is not a topo primitive,
+not a trail spec field, and not serialized as a graph node. Use it for
+surface- or invocation-scoped behavior such as auth gates, rate limits,
+telemetry wrappers, or CLI convenience behavior.
 
 ```typescript
-const graph = topo('myapp', entityModule, {
-  layers: [verboseLayer, paginationLayer],
+await surface(graph, {
+  layers: [authLayer, telemetryLayer],
 });
 ```
+
+Typed, queryable, graph-aware layers are future design work, tracked in the
+draft layer-evolution ADR.
 
 ### `resource` / `resources`
 
@@ -391,7 +396,7 @@ These are directional. They should not be reused for unrelated concepts.
 These rules carry over from ADR-0001 and govern how the lexicon composes:
 
 - **Singular nouns define:** `trail()`, `signal()`, `resource()`
-- **Plural fields declare:** `signals:`, `resources:`, `crosses:`, `layers:`, `fires:`, `on:`
+- **Plural fields declare:** `signals:`, `resources:`, `crosses:`, `fires:`, `on:`
 - **Runtime verbs are plain actions:** `run()`, `cross()`, `signal()`
 - **`create*` for runtime instances:** `createLogger()`, `createConsoleLogger()`
 - **`derive*` for derivations:** `deriveFields()`, `deriveFlags()`
@@ -421,7 +426,7 @@ When introducing Trails, use this order.
 
 ### Advanced
 
-1. `layer` — wrap execution with cross-cutting behavior
+1. `layer` — wrap execution through `run()` or surface options
 2. `tracing` / `ctx.trace()` — record what happened
 3. `permit` — auth and scopes
 4. `pin` — named graph snapshot for diffing and verification

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -250,7 +250,10 @@ await surface(graph, {
 });
 ```
 
-## Built-in Layers
+## CLI Execution Layers
+
+These are CLI-scoped execution helpers, not topo primitives or trail-spec
+fields. They are passed through the CLI surface's execution options.
 
 ### `autoIterateLayer`
 

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -105,9 +105,11 @@ Status codes come directly from the error taxonomy -- the same mapping used acro
 
 Unrecognized errors (non-`TrailsError` exceptions) return 500 with `category: 'internal'`.
 
-## Layers as Layers
+## Execution Layers
 
-Layers compose the same way as on CLI and MCP -- they wrap trail implementations:
+HTTP accepts execution layers in the surface options. They wrap trail
+implementations for requests on that surface; they are not declared on the topo
+or surfaced as contract graph nodes in v1.
 
 ```typescript
 import { surface } from '@ontrails/hono';
@@ -135,7 +137,7 @@ options bag. The most useful fields are:
 | `hostname` | `string` | `'0.0.0.0'` | Bind address used by `surface()` |
 | `include` | `readonly string[]` | *none* | Narrow the surface to matching trail IDs |
 | `intent` | `readonly Intent[]` | *none* | Filter exposed trails by intent |
-| `layers` | `readonly Layer[]` | `[]` | Layers to compose around implementations |
+| `layers` | `readonly Layer[]` | `[]` | Execution layers to compose around implementations |
 | `name` | `string` | *none* | Accepted but currently unused — reserved for future use |
 | `port` | `number` | `3000` | Listen port used by `surface()` |
 | `resources` | `ResourceOverrideMap` | *none* | Explicit resource instances for this surface |

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -192,9 +192,12 @@ const longTask = trail('long.task', {
 
 ## Layers
 
-Layers compose identically to CLI. The MCP connector uses `composeLayers()` from `@ontrails/core` to wrap the implementation.
+The MCP surface accepts execution layers in its options and uses
+`composeLayers()` from `@ontrails/core` to wrap the implementation.
 
-No MCP-specific Layers ship in v1. The infrastructure is wired and ready for domain-specific Layers (rate limiting, caching, auth) to be added later.
+No MCP-specific layers ship in v1. The infrastructure is wired for
+surface-scoped behavior such as rate limiting, caching, or auth gates, but these
+layers are not topo primitives or graph nodes.
 
 ## Building Tools Without `surface()`
 

--- a/docs/tenets.md
+++ b/docs/tenets.md
@@ -145,8 +145,13 @@ The framework has a small set of core primitives. Everything else is either a sp
 - **`signal()`** is the unit of notification. A schema-typed push with provenance.
 - **`topo()`** assembles primitives into a queryable graph.
 - **`Result`** is the universal return type. Ok or Err, never throw.
-- **Layers** are cross-cutting wrappers around trail execution.
 - **`cross()` / `crosses`** is the first-class compositional mechanism. `crosses` declares which trails a trail may compose, and `ctx.cross()` performs that composition at runtime. The warden verifies that declarations match actual usage.
+
+Execution layers exist in v1, but they are pipeline utilities rather than graph
+primitives. They wrap a trail execution through `run()` or surface options; they
+are not authored on trails, assembled by `topo()`, or serialized as graph nodes.
+The draft layer-evolution ADR tracks what it would take to promote them into a
+typed, governable primitive later.
 
 ### The bar for new primitives
 
@@ -188,9 +193,12 @@ A trail declares its defaults: intent, error behavior, crossing declarations, me
 
 The authored default documents intent. The override enables reuse. The resolved graph captures the final state. Governance can flag overrides that contradict intent.
 
-### One graph, many views
+### One Graph, Many Views
 
-The system is a single graph: trails, resources, signals, crossings, layers, and metadata. Different tools provide different views of the same underlying data.
+The system is a single graph: trails, resources, signals, crossings, and
+metadata. Different tools provide different views of the same underlying data.
+Runtime execution layers can wrap that graph at invocation time, but v1 does not
+persist them as nodes in the graph.
 
 Survey reveals what exists and how it connects. Guide explains how to use it. The warden reports what's missing and what's drifting. The lockfile captures the resolved state. The tracing system shows what's actually happening at runtime — live during execution, historical after the fact.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -140,7 +140,7 @@ The developer returns `Result.err(new NotFoundError(...))`. The framework maps i
 - **Resilience** -- `retry`, `withTimeout`, `shouldRetry`, `deriveBackoffDelay`
 - **Serialization** -- `serializeError`, `deserializeError`
 - **Branded types** -- `uuid`, `email`, `nonEmptyString`, `positiveInt`
-- **Layers** -- cross-cutting layers via `composeLayers`
+- **Execution layers** -- low-level pipeline wrappers via `composeLayers`
 - **Guards and collections** -- `isDefined`, `chunk`, `dedupe`, `groupBy`, `sortBy`
 - **Patterns** (`@ontrails/core/patterns`) -- reusable Zod schemas for pagination, bulk ops, timestamps, sorting
 - **Trail factories** (`@ontrails/core/trails`) -- derive CRUD-shaped trail contracts from contours without re-authoring IDs, schemas, examples, or intents

--- a/packages/core/src/__tests__/signal.test.ts
+++ b/packages/core/src/__tests__/signal.test.ts
@@ -11,6 +11,7 @@ const payloadSchema = z.object({
 
 const userAction = signal('user.action', {
   description: 'A user performed an action',
+  examples: [{ action: 'login', userId: 'u-1' }],
   from: ['auth.login', 'auth.signup'],
   meta: { domain: 'auth', priority: 1 },
   payload: payloadSchema,
@@ -40,6 +41,14 @@ describe('signal() basics', () => {
     expect(userAction.description).toBe('A user performed an action');
   });
 
+  test('preserves validated examples', () => {
+    expect(userAction.examples).toEqual([{ action: 'login', userId: 'u-1' }]);
+  });
+
+  test('examples array is frozen', () => {
+    expect(Object.isFrozen(userAction.examples)).toBe(true);
+  });
+
   test('result object is frozen', () => {
     expect(Object.isFrozen(userAction)).toBe(true);
   });
@@ -63,8 +72,18 @@ describe('signal() from and meta', () => {
       payload: z.string(),
     });
     expect(minimal.description).toBeUndefined();
+    expect(minimal.examples).toBeUndefined();
     expect(minimal.from).toBeUndefined();
     expect(minimal.meta).toBeUndefined();
+  });
+
+  test('throws when an example does not match the payload schema', () => {
+    expect(() =>
+      signal('bad.example', {
+        examples: [{ userId: 42 } as never],
+        payload: payloadSchema,
+      })
+    ).toThrow('signal("bad.example") example 0 is invalid');
   });
 });
 

--- a/packages/core/src/__tests__/topo-store-read.test.ts
+++ b/packages/core/src/__tests__/topo-store-read.test.ts
@@ -50,6 +50,7 @@ const exampleApp = () => {
 
   const entityAdded = signal('entity.added', {
     description: 'An entity was added',
+    examples: [{ id: 'ada' }],
     from: ['entity.add'],
     payload: z.object({ id: z.string() }),
   });
@@ -166,6 +167,20 @@ describe('read-only topo store', () => {
         usedBy: ['entity.add', 'entity.list'],
       }),
     ]);
+
+    expect(
+      store.signals.list({ snapshot: { snapshotId: snapshot.id } })
+    ).toEqual([
+      expect.objectContaining({
+        consumers: [],
+        description: 'An entity was added',
+        exampleCount: 1,
+        from: ['entity.add'],
+        hasExamples: true,
+        id: 'entity.added',
+        producers: [],
+      }),
+    ]);
   });
 
   test('filters trails by intent', () => {
@@ -207,6 +222,18 @@ describe('read-only topo store', () => {
     const exported = store.exports.get({ pin: 'baseline' });
     expect(exported?.snapshot.id).toBe(snapshot.id);
     expect(exported?.surfaceHash).toHaveLength(64);
+
+    const signalDetail = store.signals.get('entity.added', {
+      snapshot: { snapshotId: snapshot.id },
+    });
+    expect(signalDetail).toEqual(
+      expect.objectContaining({
+        examples: [{ id: 'ada' }],
+        from: ['entity.add'],
+        id: 'entity.added',
+        payload: expect.objectContaining({ type: 'object' }),
+      })
+    );
 
     const rows = store.query<{ id: string }>(
       'SELECT id FROM topo_trails WHERE snapshot_id = ? ORDER BY id ASC',

--- a/packages/core/src/__tests__/topo-store.test.ts
+++ b/packages/core/src/__tests__/topo-store.test.ts
@@ -87,6 +87,7 @@ const exampleApp = () => {
 
   const entityAdded = signal('entity.added', {
     description: 'An entity was added',
+    examples: [{ id: 'ada' }],
     from: ['entity.add'],
     payload: z.object({ id: z.string() }),
   });

--- a/packages/core/src/internal/topo-store-read.ts
+++ b/packages/core/src/internal/topo-store-read.ts
@@ -63,6 +63,24 @@ export interface TopoStoreResourceRecord {
   readonly usedBy: readonly string[];
 }
 
+export interface TopoStoreSignalRecord {
+  readonly consumers: readonly string[];
+  readonly description: string | null;
+  readonly exampleCount: number;
+  readonly from: readonly string[];
+  readonly hasExamples: boolean;
+  readonly id: string;
+  readonly kind: 'signal';
+  readonly payloadSchema: boolean;
+  readonly producers: readonly string[];
+  readonly snapshotId: string;
+}
+
+export interface TopoStoreSignalDetailRecord extends TopoStoreSignalRecord {
+  readonly examples: readonly unknown[];
+  readonly payload: Readonly<Record<string, unknown>> | null;
+}
+
 export interface TopoStoreExportRecord extends StoredTopoExport {
   readonly snapshot: TopoSnapshot;
 }
@@ -104,14 +122,28 @@ interface TopoResourceRow {
   readonly snapshot_id: string;
 }
 
+interface TopoSignalRow {
+  readonly description: string | null;
+  readonly id: string;
+  readonly snapshot_id: string;
+}
+
+interface TopoSignalRelationRow {
+  readonly trail_id: string;
+}
+
 interface StoredSurfaceMapEntry {
   readonly description?: string;
   readonly detours?: readonly {
     readonly on: string;
     readonly maxAttempts: number;
   }[];
+  readonly exampleCount?: number;
+  readonly examples?: readonly unknown[];
+  readonly from?: readonly string[];
   readonly healthcheck?: boolean;
   readonly id: string;
+  readonly input?: Readonly<Record<string, unknown>>;
   readonly kind: 'contour' | 'resource' | 'signal' | 'trail';
 }
 
@@ -284,6 +316,61 @@ const readResourceUsage = (
     [...usage.entries()].map(([id, trails]) => [id, trails] as const)
   );
 };
+
+type SignalRelationTable =
+  | 'topo_trail_fires'
+  | 'topo_trail_on'
+  | 'topo_trail_signals';
+
+// Hard-coded query strings keyed by the union variant. The TypeScript union
+// already constrains callers, but holding the literal SQL here removes any
+// runtime path where `${table}` could be substituted from an unconstrained
+// string.
+const SIGNAL_RELATION_QUERIES = {
+  topo_trail_fires: `SELECT trail_id
+       FROM topo_trail_fires
+       WHERE snapshot_id = ? AND signal_id = ?
+       ORDER BY trail_id ASC`,
+  topo_trail_on: `SELECT trail_id
+       FROM topo_trail_on
+       WHERE snapshot_id = ? AND signal_id = ?
+       ORDER BY trail_id ASC`,
+  topo_trail_signals: `SELECT trail_id
+       FROM topo_trail_signals
+       WHERE snapshot_id = ? AND signal_id = ?
+       ORDER BY trail_id ASC`,
+} as const satisfies Record<SignalRelationTable, string>;
+
+const readSignalTrailIds = (
+  db: Database,
+  table: SignalRelationTable,
+  snapshotId: string,
+  signalId: string
+): readonly string[] =>
+  db
+    .query<TopoSignalRelationRow, [string, string]>(
+      SIGNAL_RELATION_QUERIES[table]
+    )
+    .all(snapshotId, signalId)
+    .map((row) => row.trail_id);
+
+const signalExamplePayload = (example: unknown): unknown => {
+  if (typeof example !== 'object' || example === null) {
+    return example;
+  }
+  const candidate = example as {
+    readonly kind?: unknown;
+    readonly payload?: unknown;
+  };
+  return candidate.kind === 'payload' && 'payload' in candidate
+    ? candidate.payload
+    : example;
+};
+
+const signalExamplesFromEntry = (
+  storedEntry: StoredSurfaceMapEntry | undefined
+): readonly unknown[] =>
+  storedEntry?.examples?.map((example) => signalExamplePayload(example)) ?? [];
 
 export const readTopoStoreSnapshot = (
   db: Database,
@@ -469,6 +556,115 @@ export const getTopoStoreResource = (
     usage.get(resourceId) ?? [],
     readStoredEntry(db, snapshot.id, 'resource', resourceId)
   );
+};
+
+const mapSignalRow = (
+  row: TopoSignalRow,
+  storedEntry: StoredSurfaceMapEntry | undefined,
+  relations: {
+    readonly consumers: readonly string[];
+    readonly from: readonly string[];
+    readonly producers: readonly string[];
+  }
+): TopoStoreSignalRecord => {
+  const exampleCount =
+    storedEntry?.exampleCount ?? storedEntry?.examples?.length ?? 0;
+
+  return {
+    consumers: relations.consumers,
+    description: storedEntry?.description ?? row.description,
+    exampleCount,
+    from: relations.from,
+    hasExamples: exampleCount > 0,
+    id: row.id,
+    kind: 'signal',
+    // Derived from the stored surface-map entry rather than hard-coded so the
+    // list flag stays coherent with the detail record's `payload` field. If the
+    // surface-map entry is missing for a signal row (e.g. partial import or
+    // schema migration), `payload` would be null in the detail; signaling
+    // `payloadSchema: true` here would mislead consumers into skipping the
+    // detail call.
+    payloadSchema: storedEntry?.input !== undefined,
+    producers: relations.producers,
+    snapshotId: row.snapshot_id,
+  };
+};
+
+const readSignalRelations = (
+  db: Database,
+  snapshotId: string,
+  signalId: string
+) => ({
+  consumers: readSignalTrailIds(db, 'topo_trail_on', snapshotId, signalId),
+  from: readSignalTrailIds(db, 'topo_trail_signals', snapshotId, signalId),
+  producers: readSignalTrailIds(db, 'topo_trail_fires', snapshotId, signalId),
+});
+
+export const listTopoStoreSignals = (
+  db: Database,
+  options?: { readonly snapshot?: TopoStoreRef }
+): readonly TopoStoreSignalRecord[] => {
+  const snapshot = readSnapshotRef(db, options?.snapshot);
+  if (snapshot === undefined) {
+    return [];
+  }
+
+  const rows = db
+    .query<TopoSignalRow, [string]>(
+      `SELECT id, description, snapshot_id
+       FROM topo_signals
+       WHERE snapshot_id = ?
+       ORDER BY id ASC`
+    )
+    .all(snapshot.id);
+
+  const stored = getStoredTopoExport(db, snapshot.id);
+  const entries = stored
+    ? (JSON.parse(stored.surfaceMapJson) as StoredSurfaceMap).entries
+    : [];
+
+  return rows.map((row) =>
+    mapSignalRow(
+      row,
+      entries.find((entry) => entry.id === row.id && entry.kind === 'signal'),
+      readSignalRelations(db, snapshot.id, row.id)
+    )
+  );
+};
+
+export const getTopoStoreSignal = (
+  db: Database,
+  signalId: string,
+  options?: { readonly snapshot?: TopoStoreRef }
+): TopoStoreSignalDetailRecord | undefined => {
+  const snapshot = readSnapshotRef(db, options?.snapshot);
+  if (snapshot === undefined) {
+    return undefined;
+  }
+
+  const row = db
+    .query<TopoSignalRow, [string, string]>(
+      `SELECT id, description, snapshot_id
+       FROM topo_signals
+       WHERE snapshot_id = ? AND id = ?
+       LIMIT 1`
+    )
+    .get(snapshot.id, signalId);
+
+  if (row === null || row === undefined) {
+    return undefined;
+  }
+
+  const storedEntry = readStoredEntry(db, snapshot.id, 'signal', signalId);
+  return {
+    ...mapSignalRow(
+      row,
+      storedEntry,
+      readSignalRelations(db, snapshot.id, signalId)
+    ),
+    examples: signalExamplesFromEntry(storedEntry),
+    payload: storedEntry?.input ?? null,
+  };
 };
 
 export const queryTopoStore = <TRow extends Record<string, unknown>>(

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -376,13 +376,17 @@ const normalizeTrailSignalRows = (
   signals: readonly AnySignal[],
   snapshotId: string
 ): readonly TopoTrailSignalRow[] =>
-  signals.flatMap((signal) =>
-    [...new Set(signal.from)].toSorted().map((trailId) => ({
+  signals.flatMap((signal) => {
+    if (signal.from === undefined) {
+      return [];
+    }
+
+    return [...new Set(signal.from)].toSorted().map((trailId) => ({
       signalId: signal.id,
       snapshotId,
       trailId,
-    }))
-  );
+    }));
+  });
 
 /**
  * Project surface rows for stored topo.
@@ -777,8 +781,13 @@ const signalToEntryRecord = (
   payloadSchema: JsonRecord
 ): SurfaceMapEntryRecord => {
   const raw = signal as unknown as Record<string, unknown>;
+  const examples = signal.examples?.map((payload) => ({
+    kind: 'payload',
+    payload,
+    provenance: { source: 'signal.examples' },
+  }));
   const entry: Record<string, unknown> = {
-    exampleCount: 0,
+    exampleCount: signal.examples?.length ?? 0,
     id: signal.id,
     input: payloadSchema,
     kind: 'signal',
@@ -787,6 +796,14 @@ const signalToEntryRecord = (
 
   if (signal.description !== undefined) {
     entry['description'] = signal.description;
+  }
+
+  if (examples !== undefined && examples.length > 0) {
+    entry['examples'] = examples;
+  }
+
+  if (signal.from !== undefined && signal.from.length > 0) {
+    entry['from'] = signal.from.toSorted();
   }
 
   if (raw['deprecated'] === true) {

--- a/packages/core/src/signal.ts
+++ b/packages/core/src/signal.ts
@@ -4,6 +4,29 @@
 
 import type { z } from 'zod';
 
+const formatExampleIssues = (issues: readonly z.core.$ZodIssue[]): string =>
+  issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+      return `${path}: ${issue.message}`;
+    })
+    .join('; ');
+
+const assertSignalExamples = <T>(
+  id: string,
+  payload: z.ZodType<T>,
+  examples: readonly T[]
+): void => {
+  for (const [index, example] of examples.entries()) {
+    const parsed = payload.safeParse(example);
+    if (!parsed.success) {
+      throw new TypeError(
+        `signal("${id}") example ${index} is invalid: ${formatExampleIssues(parsed.error.issues)}`
+      );
+    }
+  }
+};
+
 // ---------------------------------------------------------------------------
 // Spec (input to the factory)
 // ---------------------------------------------------------------------------
@@ -11,6 +34,8 @@ import type { z } from 'zod';
 export interface SignalSpec<T> {
   readonly payload: z.ZodType<T>;
   readonly description?: string | undefined;
+  /** Example payloads validated against the signal payload schema. */
+  readonly examples?: readonly T[] | undefined;
   readonly meta?: Readonly<Record<string, unknown>> | undefined;
   /** Trail IDs that produce this signal (e.g. the trails it originates from). */
   readonly from?: readonly string[] | undefined;
@@ -25,6 +50,8 @@ export interface Signal<T> {
   readonly kind: 'signal';
   readonly payload: z.ZodType<T>;
   readonly description?: string | undefined;
+  /** Example payloads validated against the signal payload schema. */
+  readonly examples?: readonly T[] | undefined;
   readonly meta?: Readonly<Record<string, unknown>> | undefined;
   /** Trail IDs that produce this signal (e.g. the trails it originates from). */
   readonly from?: readonly string[] | undefined;
@@ -51,8 +78,18 @@ export function signal<T>(
   const resolvedId = typeof idOrSpec === 'string' ? idOrSpec : idOrSpec.id;
   // oxlint-disable-next-line no-non-null-assertion -- overload guarantees maybeSpec when idOrSpec is string
   const resolvedSpec = typeof idOrSpec === 'string' ? maybeSpec! : idOrSpec;
+  if (resolvedSpec.examples !== undefined) {
+    assertSignalExamples(
+      resolvedId,
+      resolvedSpec.payload,
+      resolvedSpec.examples
+    );
+  }
   return Object.freeze({
     description: resolvedSpec.description,
+    examples: resolvedSpec.examples
+      ? Object.freeze([...resolvedSpec.examples])
+      : undefined,
     from: resolvedSpec.from ? Object.freeze([...resolvedSpec.from]) : undefined,
     id: resolvedId,
     kind: 'signal' as const,

--- a/packages/core/src/topo-store.ts
+++ b/packages/core/src/topo-store.ts
@@ -21,14 +21,18 @@ import type {
   TopoStoreExportRecord,
   TopoStoreResourceRecord,
   TopoStoreRef,
+  TopoStoreSignalDetailRecord,
+  TopoStoreSignalRecord,
   TopoStoreTrailDetailRecord,
   TopoStoreTrailRecord,
 } from './internal/topo-store-read.js';
 import {
   getTopoStoreExport,
   getTopoStoreResource,
+  getTopoStoreSignal,
   getTopoStoreTrail,
   listTopoStoreResources,
+  listTopoStoreSignals,
   listTopoStoreSnapshots,
   listTopoStoreTrails,
   queryTopoStore,
@@ -170,6 +174,8 @@ export type {
   TopoStoreExportRecord,
   TopoStoreResourceRecord,
   TopoStoreRef,
+  TopoStoreSignalDetailRecord,
+  TopoStoreSignalRecord,
   TopoStoreTrailDetailRecord,
   TopoStoreTrailRecord,
 } from './internal/topo-store-read.js';
@@ -196,6 +202,15 @@ export interface ReadOnlyTopoStore {
       readonly snapshot?: TopoStoreRef;
     }): readonly TopoStoreResourceRecord[];
   };
+  readonly signals: {
+    get(
+      id: string,
+      options?: { readonly snapshot?: TopoStoreRef }
+    ): TopoStoreSignalDetailRecord | undefined;
+    list(options?: {
+      readonly snapshot?: TopoStoreRef;
+    }): readonly TopoStoreSignalRecord[];
+  };
   readonly snapshots: {
     get(ref?: TopoStoreRef): TopoSnapshot | undefined;
     latest(): TopoSnapshot | undefined;
@@ -216,6 +231,7 @@ export interface ReadOnlyTopoStore {
 export interface MockTopoStoreSeed {
   readonly exports?: readonly TopoStoreExportRecord[];
   readonly resources?: readonly TopoStoreResourceRecord[];
+  readonly signals?: readonly TopoStoreSignalDetailRecord[];
   readonly snapshots?: readonly TopoSnapshot[];
   readonly trails?: readonly TopoStoreTrailDetailRecord[];
 }
@@ -262,6 +278,7 @@ const createSeedResolver = (seed?: MockTopoStoreSeed) => {
   const snapshots = [...(seed?.snapshots ?? [])];
   const trails = [...(seed?.trails ?? [])];
   const resources = [...(seed?.resources ?? [])];
+  const signals = [...(seed?.signals ?? [])];
   const exports = [...(seed?.exports ?? [])];
 
   const resolveSnapshot = (ref?: TopoStoreRef): TopoSnapshot | undefined => {
@@ -278,6 +295,7 @@ const createSeedResolver = (seed?: MockTopoStoreSeed) => {
     exports,
     resolveSnapshot,
     resources,
+    signals,
     snapshots,
     trails,
   };
@@ -318,6 +336,26 @@ export const createMockTopoStore = (
           : resolved.resources.filter(
               (item) => item.snapshotId === snapshot.id
             );
+      },
+    },
+    signals: {
+      get(id, options) {
+        const snapshot = resolved.resolveSnapshot(options?.snapshot);
+        if (snapshot === undefined) {
+          return;
+        }
+        return resolved.signals.find(
+          (signal) => signal.id === id && signal.snapshotId === snapshot.id
+        );
+      },
+      list(options) {
+        const snapshot = resolved.resolveSnapshot(options?.snapshot);
+        if (snapshot === undefined) {
+          return [];
+        }
+        return resolved.signals.filter(
+          (signal) => signal.snapshotId === snapshot.id
+        );
       },
     },
     snapshots: {
@@ -402,6 +440,18 @@ export const createTopoStore = (
     list(queryOptions) {
       return withStoredTopoState(options, (db) =>
         listTopoStoreResources(db, queryOptions)
+      );
+    },
+  },
+  signals: {
+    get(id, queryOptions) {
+      return withStoredTopoState(options, (db) =>
+        getTopoStoreSignal(db, id, queryOptions)
+      );
+    },
+    list(queryOptions) {
+      return withStoredTopoState(options, (db) =>
+        listTopoStoreSignals(db, queryOptions)
       );
     },
   },

--- a/packages/schema/src/__tests__/derive.test.ts
+++ b/packages/schema/src/__tests__/derive.test.ts
@@ -179,9 +179,11 @@ describe('deriveSurfaceMap', () => {
       expect(crossesEntry?.crosses).toEqual(['user.get']);
     });
 
-    test("event entries are included with kind 'signal'", () => {
+    test("signal entries are included with kind 'signal'", () => {
       const e = signal('user.created', {
         description: 'A user was created',
+        examples: [{ userId: 'u-1' }],
+        from: ['user.create'],
         payload: z.object({ userId: z.string() }),
       });
       const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ e })));
@@ -190,6 +192,15 @@ describe('deriveSurfaceMap', () => {
       expect(entry.id).toBe('user.created');
       expect(entry.description).toBe('A user was created');
       expect(entry.input).toBeDefined();
+      expect(entry.exampleCount).toBe(1);
+      expect(entry.from).toEqual(['user.create']);
+      expect(entry.examples).toEqual([
+        {
+          kind: 'payload',
+          payload: { userId: 'u-1' },
+          provenance: { source: 'signal.examples' },
+        },
+      ]);
     });
 
     test('resource entries are included with description and healthcheck metadata', () => {

--- a/packages/schema/src/derive.ts
+++ b/packages/schema/src/derive.ts
@@ -3,8 +3,9 @@
  */
 
 import {
-  deriveStructuredTrailExamples,
   deriveCliPath,
+  deriveStructuredSignalExamples,
+  deriveStructuredTrailExamples,
   getContourReferences,
   validateDraftFreeTopo,
   zodToJsonSchema,
@@ -245,6 +246,13 @@ const addEventFields = (
   if (e.description !== undefined) {
     entry['description'] = e.description;
   }
+  if (e.from !== undefined && e.from.length > 0) {
+    entry['from'] = e.from.toSorted();
+  }
+  const examples = deriveStructuredSignalExamples(e.examples);
+  if (examples !== undefined) {
+    entry['examples'] = examples;
+  }
   if (raw['deprecated'] === true) {
     entry['deprecated'] = true;
   }
@@ -257,7 +265,7 @@ const signalToEntry = (e: Signal<unknown>): SurfaceMapEntry => {
   const raw = e as unknown as Record<string, unknown>;
   const trailheads = extractTrailheads(raw);
   const entry: Record<string, unknown> = {
-    exampleCount: 0,
+    exampleCount: e.examples?.length ?? 0,
     id: e.id,
     kind: 'signal',
     trailheads,

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -2,7 +2,14 @@
  * Types for surface maps, diffing, and lock files.
  */
 
-import type { StructuredTrailExample } from '@ontrails/core';
+import type {
+  StructuredSignalExample,
+  StructuredTrailExample,
+} from '@ontrails/core';
+
+export type SurfaceMapExample =
+  | StructuredSignalExample
+  | StructuredTrailExample;
 
 // ---------------------------------------------------------------------------
 // JSON Schema (lightweight alias)
@@ -57,13 +64,14 @@ export interface SurfaceMapEntry {
   readonly identity?: string | undefined;
   readonly references?: readonly SurfaceMapContourReference[] | undefined;
   readonly resources?: readonly string[] | undefined;
+  readonly from?: readonly string[] | undefined;
   readonly fieldOverrides?: readonly SurfaceMapFieldOverride[] | undefined;
   readonly detours?:
     | readonly { readonly on: string; readonly maxAttempts: number }[]
     | undefined;
   readonly healthcheck?: boolean | undefined;
   readonly exampleCount: number;
-  readonly examples?: readonly StructuredTrailExample[] | undefined;
+  readonly examples?: readonly SurfaceMapExample[] | undefined;
   readonly description?: string | undefined;
 }
 


### PR DESCRIPTION
## Summary
- Settles v1 docs and API posture for layers as execution plumbing rather than claiming mature primitive parity.
- Improves signal queryability by adding signal examples, store/read accessors, and survey/detail output for signal state.
- Closes the primitive parity coordination parent for this layer and signal slice.

## Validation
- bun run check
- bun run build
- bun run test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/trails/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes: TRL-568, TRL-569, TRL-573