### PR TITLE
feat: add resource lifecycle drain semantics

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,6 +13,7 @@ signal(id, spec)                    // define a payload schema with provenance
 contour(name, shape, options)       // define a first-class domain object with identity metadata
 resource(id, spec)                  // define a first-class resource dependency
 createResourceLookup(getContext)   // bind ctx.resource() to a specific context snapshot
+drainResources(resources, ctx, configValues?) // evict and dispose cached resource singletons
 topo(name, ...modules)             // assemble trails, contours, signals, and resources into a queryable topology
 // Topo methods: .get(id), .has(id), .list(), .listSignals(), .ids(), .count
 //               .getContour(name), .hasContour(name), .listContours(), .contourIds(), .contourCount

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -89,7 +89,7 @@ Both resolve the same way at runtime. Prefer `db.from(ctx)` -- it carries the ty
 
 ## Resource Lifecycle
 
-Resources are app-scoped singletons in v1. Created once on first resolution and cached for the process lifetime. A resource may declare a `dispose` callback; surface-specific shutdown wiring is still an implementation detail and should not be assumed unless the surface documents it.
+Resources are app-scoped singletons in v1. They are created once on first resolution and cached by resource definition plus stable resource context (`cwd`, `env`, `workspaceRoot`, and validated resource config). A resource may declare a `dispose` callback for cleanup.
 
 Resolution happens eagerly during `executeTrail`, after input validation and before layer composition:
 
@@ -101,7 +101,9 @@ Resolution happens eagerly during `executeTrail`, after input validation and bef
 
 This means failures surface at the boundary -- a missing `DATABASE_URL` fails before the implementation runs, not on line 47. It also means layers can access resources via `db.from(ctx)` because resolution is already complete.
 
-Shutdown signaling differs by surface. Treat `dispose` as the resource's cleanup contract, and check the surface package before relying on automatic disposal timing.
+If a later resource fails during eager resolution, Trails rolls back resource instances created during that same resolution pass in reverse declaration order. Rollback evicts an owned instance from the singleton cache before calling `dispose`, so the next execution gets a fresh create attempt. If the instance has already been shared with another in-flight execution, rollback leaves it cached and avoids disposing a resource that another trail may still be using.
+
+Surfaces and test harnesses own shutdown timing. At shutdown, call `drainResources(resources, ctx, configValues?)` with the topo's resources and the same stable context/config values used during execution. Draining evicts cached instances first, disposes them in reverse order, continues through sibling resources if one dispose fails, and reports disposal failures as `Result.err(InternalError)`. Partial drain errors include `disposed` and `evicted` arrays in the error context so shutdown callers can tell which cleanup already happened. Uncached configured resources are treated as no-ops when config is missing; if cached entries exist but supplied config no longer validates, drain evicts and disposes those cached entries while still reporting the config error.
 
 ## Testing with Resources
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,6 +44,7 @@ const onboard = trail('entity.onboard', {
 | `trail(id, spec)` | Define a unit of work with typed input and `Result` output; use `crosses` for composition |
 | `signal(id, spec)` | Define a server-originated notification with a typed data schema |
 | `resource(id, spec)` | Define an infrastructure dependency with `create`, `dispose`, and optional `mock` |
+| `drainResources(resources, ctx, configValues?)` | Evict and dispose cached resource singletons for surface/test shutdown |
 | `topo(name, ...modules)` | Collect trail modules into a queryable topology |
 | `deriveTrail(contour, operation, spec)` | Derive CRUD-shaped trail contracts from a contour on the `@ontrails/core/trails` subpath |
 | `validateTopo(topo)` | Structural validation: cross targets exist, no cycles, examples parse, output schemas present |

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -24,6 +24,7 @@ import { createTrailContext } from '../context';
 import type { Layer } from '../layer';
 import { Result } from '../result';
 import { resource } from '../resource';
+import { drainResources } from '../resource-config';
 import { topo } from '../topo';
 import { trail } from '../trail';
 import type { TrailContext, TrailContextInit } from '../types';
@@ -544,6 +545,431 @@ describe('executeTrail', () => {
 
         expect(first.unwrap()).toEqual({ value: 'first' });
         expect(second.unwrap()).toEqual({ value: 'second' });
+      });
+
+      test('rolls back newly created resources when a later resource fails', async () => {
+        const events: string[] = [];
+        const created = resource(nextResourceId('rollback-created'), {
+          create: () => {
+            events.push('create:first');
+            return Result.ok({ label: 'first' });
+          },
+          dispose: (instance) => {
+            events.push(`dispose:${instance.label}`);
+          },
+        });
+        const failing = resource(nextResourceId('rollback-failing'), {
+          create: () => {
+            events.push('create:second');
+            return Result.err(new ValidationError('second unavailable'));
+          },
+        });
+        const resourceTrail = trail('resource.rollback', {
+          blaze: () => Result.ok(null),
+          input: z.object({}),
+          resources: [created, failing],
+        });
+
+        const first = await executeTrail(resourceTrail, {});
+        const second = await executeTrail(resourceTrail, {});
+
+        expect(first.isErr()).toBe(true);
+        expect(first.error).toBeInstanceOf(ValidationError);
+        expect(second.isErr()).toBe(true);
+        expect(events).toEqual([
+          'create:first',
+          'create:second',
+          'dispose:first',
+          'create:first',
+          'create:second',
+          'dispose:first',
+        ]);
+      });
+
+      test('reports rollback disposal failures with the original create failure as cause', async () => {
+        const original = new ValidationError('second unavailable');
+        const created = resource(nextResourceId('rollback-dispose-failure'), {
+          create: () => Result.ok({ label: 'first' }),
+          dispose: () => {
+            throw new Error('dispose exploded');
+          },
+        });
+        const failing = resource(nextResourceId('rollback-original'), {
+          create: () => Result.err(original),
+        });
+        const resourceTrail = trail('resource.rollback-dispose-failure', {
+          blaze: () => Result.ok(null),
+          input: z.object({}),
+          resources: [created, failing],
+        });
+
+        const result = await executeTrail(resourceTrail, {});
+
+        expect(result.isErr()).toBe(true);
+        expect(result.error).toBeInstanceOf(InternalError);
+        expect(result.error.message).toContain('rollback also failed');
+        expect(result.error.cause).toBe(original);
+        expect(result.error.context?.failures).toEqual([
+          {
+            context: {
+              failures: [
+                {
+                  context: { resourceId: created.id },
+                  message: `Resource "${created.id}" failed to dispose: dispose exploded`,
+                  name: 'InternalError',
+                },
+              ],
+            },
+            message: 'Resource rollback failed during resource resolution',
+            name: 'InternalError',
+          },
+        ]);
+      });
+
+      test('does not dispose rollback resources shared with another in-flight execution', async () => {
+        const sharedCreated = Promise.withResolvers<undefined>();
+        const secondCanRead = Promise.withResolvers<undefined>();
+        const events: string[] = [];
+        const shared = resource(nextResourceId('rollback-shared'), {
+          create: async () => {
+            events.push('create:shared');
+            await sharedCreated.promise;
+            return Result.ok({ closed: false });
+          },
+          dispose: (instance) => {
+            instance.closed = true;
+            events.push('dispose:shared');
+          },
+        });
+        const failing = resource(nextResourceId('rollback-shared-failing'), {
+          create: () => Result.err(new ValidationError('second unavailable')),
+        });
+        const firstTrail = trail('resource.rollback-shared.first', {
+          blaze: () => Result.ok(null),
+          input: z.object({}),
+          resources: [shared, failing],
+        });
+        const secondTrail = trail('resource.rollback-shared.second', {
+          blaze: async (_input, ctx) => {
+            await secondCanRead.promise;
+            return Result.ok({ closed: shared.from(ctx).closed });
+          },
+          input: z.object({}),
+          output: z.object({ closed: z.boolean() }),
+          resources: [shared],
+        });
+
+        const first = executeTrail(firstTrail, {});
+        const second = executeTrail(secondTrail, {});
+        await Bun.sleep(0);
+        sharedCreated.resolve();
+        const firstResult = await first;
+        secondCanRead.resolve();
+        const secondResult = await second;
+
+        expect(firstResult.isErr()).toBe(true);
+        expect(secondResult.unwrap()).toEqual({ closed: false });
+        expect(events).toEqual(['create:shared']);
+      });
+
+      test('releases duplicate resource declarations before rollback disposal', async () => {
+        const events: string[] = [];
+        const shared = resource(nextResourceId('rollback-duplicate'), {
+          create: () => {
+            events.push('create:shared');
+            return Result.ok({ label: 'shared' });
+          },
+          dispose: (instance) => {
+            events.push(`dispose:${instance.label}`);
+          },
+        });
+        const failing = resource(nextResourceId('rollback-duplicate-failing'), {
+          create: () => {
+            events.push('create:failing');
+            return Result.err(new ValidationError('second unavailable'));
+          },
+        });
+        const resourceTrail = trail('resource.rollback-duplicate', {
+          blaze: () => Result.ok(null),
+          input: z.object({}),
+          resources: [shared, shared, failing],
+        });
+
+        const result = await executeTrail(resourceTrail, {});
+        const drained = await drainResources([shared], createTrailContext());
+
+        expect(result.isErr()).toBe(true);
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(drained.unwrap()).toEqual({ disposed: [], evicted: [] });
+        expect(events).toEqual([
+          'create:shared',
+          'create:failing',
+          'dispose:shared',
+        ]);
+      });
+
+      test('releases leases acquired from cached unconfigured resources', async () => {
+        const events: string[] = [];
+        const cached = resource(nextResourceId('cached-unconfigured'), {
+          create: () => {
+            events.push('create:cached');
+            return Result.ok({ label: 'cached' });
+          },
+          dispose: (instance) => {
+            events.push(`dispose:${instance.label}`);
+          },
+        });
+        const resourceTrail = trail('resource.cached-unconfigured', {
+          blaze: (_input, ctx) => Result.ok(cached.from(ctx).label),
+          input: z.object({}),
+          output: z.string(),
+          resources: [cached],
+        });
+
+        const first = await executeTrail(resourceTrail, {});
+        const second = await executeTrail(resourceTrail, {});
+        const drained = await drainResources([cached], createTrailContext());
+
+        expect(first.unwrap()).toBe('cached');
+        expect(second.unwrap()).toBe('cached');
+        expect(drained.unwrap()).toEqual({
+          disposed: [cached.id],
+          evicted: [cached.id],
+        });
+        expect(events).toEqual(['create:cached', 'dispose:cached']);
+      });
+
+      test('drain reports resources with in-flight creation as in use', async () => {
+        const createCanFinish = Promise.withResolvers<undefined>();
+        const events: string[] = [];
+        const pending = resource(nextResourceId('drain-pending'), {
+          create: async () => {
+            events.push('create:start');
+            await createCanFinish.promise;
+            events.push('create:finish');
+            return Result.ok({ label: 'pending' });
+          },
+          dispose: (instance) => {
+            events.push(`dispose:${instance.label}`);
+          },
+        });
+        const resourceTrail = trail('resource.drain-pending', {
+          blaze: (_input, ctx) =>
+            Result.ok({ label: pending.from(ctx).label as string }),
+          input: z.object({}),
+          output: z.object({ label: z.string() }),
+          resources: [pending],
+        });
+
+        const executing = executeTrail(resourceTrail, {});
+        await Bun.sleep(0);
+        const drainedWhilePending = await drainResources(
+          [pending],
+          createTrailContext()
+        );
+        createCanFinish.resolve();
+        const execution = await executing;
+        const drainedAfterExecution = await drainResources(
+          [pending],
+          createTrailContext()
+        );
+
+        expect(drainedWhilePending.isErr()).toBe(true);
+        expect(drainedWhilePending.error).toBeInstanceOf(InternalError);
+        expect(drainedWhilePending.error.message).toBe('Resource drain failed');
+        expect(drainedWhilePending.error.context).toMatchObject({
+          disposed: [],
+          evicted: [],
+          failures: [
+            {
+              context: {
+                activeLeases: 1,
+                resourceId: pending.id,
+              },
+              message: `Resource "${pending.id}" is still in use`,
+              name: 'InternalError',
+            },
+          ],
+        });
+        expect(execution.unwrap()).toEqual({ label: 'pending' });
+        expect(drainedAfterExecution.unwrap()).toEqual({
+          disposed: [pending.id],
+          evicted: [pending.id],
+        });
+        expect(events).toEqual([
+          'create:start',
+          'create:finish',
+          'dispose:pending',
+        ]);
+      });
+
+      test('draining an uncached configured resource is a no-op without config values', async () => {
+        const configured = resource(nextResourceId('drain-uncached-config'), {
+          config: z.object({ token: z.string() }),
+          create: () => Result.ok({ label: 'configured' }),
+          dispose: () => {
+            throw new Error('should not dispose');
+          },
+        });
+
+        const drained = await drainResources(
+          [configured],
+          createTrailContext()
+        );
+
+        expect(drained.unwrap()).toEqual({ disposed: [], evicted: [] });
+      });
+
+      test('drains cached resources in reverse order and evicts them', async () => {
+        const events: string[] = [];
+        const first = resource(nextResourceId('drain-first'), {
+          create: () => {
+            events.push('create:first');
+            return Result.ok({ label: 'first' });
+          },
+          dispose: (instance) => {
+            events.push(`dispose:${instance.label}`);
+          },
+        });
+        const second = resource(nextResourceId('drain-second'), {
+          create: () => {
+            events.push('create:second');
+            return Result.ok({ label: 'second' });
+          },
+          dispose: (instance) => {
+            events.push(`dispose:${instance.label}`);
+          },
+        });
+        const resourceTrail = trail('resource.drain', {
+          blaze: (_input, ctx) =>
+            Result.ok({
+              first: first.from(ctx).label,
+              second: second.from(ctx).label,
+            }),
+          input: z.object({}),
+          output: z.object({ first: z.string(), second: z.string() }),
+          resources: [first, second],
+        });
+
+        const beforeDrain = await executeTrail(resourceTrail, {});
+        const drained = await drainResources(
+          [first, second],
+          createTrailContext()
+        );
+        const afterDrain = await executeTrail(resourceTrail, {});
+
+        expect(beforeDrain.isOk()).toBe(true);
+        expect(afterDrain.isOk()).toBe(true);
+        expect(drained.unwrap()).toEqual({
+          disposed: [second.id, first.id],
+          evicted: [second.id, first.id],
+        });
+        expect(events).toEqual([
+          'create:first',
+          'create:second',
+          'dispose:second',
+          'dispose:first',
+          'create:first',
+          'create:second',
+        ]);
+      });
+
+      test('drain evicts cached configured resources even when supplied config is invalid', async () => {
+        const events: string[] = [];
+        const configured = resource(nextResourceId('drain-invalid-config'), {
+          config: z.object({ token: z.string() }),
+          create: (ctx) => {
+            events.push(`create:${ctx.config.token}`);
+            return Result.ok({ token: ctx.config.token });
+          },
+          dispose: (instance) => {
+            events.push(`dispose:${instance.token}`);
+          },
+        });
+        const resourceTrail = trail('resource.drain-invalid-config', {
+          blaze: (_input, ctx) =>
+            Result.ok({ token: configured.from(ctx).token }),
+          input: z.object({}),
+          output: z.object({ token: z.string() }),
+          resources: [configured],
+        });
+
+        const beforeDrain = await executeTrail(
+          resourceTrail,
+          {},
+          {
+            configValues: { [configured.id]: { token: 'valid' } },
+          }
+        );
+        const drained = await drainResources(
+          [configured],
+          createTrailContext(),
+          { [configured.id]: { token: 42 } }
+        );
+        const afterDrain = await executeTrail(
+          resourceTrail,
+          {},
+          {
+            configValues: { [configured.id]: { token: 'valid' } },
+          }
+        );
+
+        expect(beforeDrain.unwrap()).toEqual({ token: 'valid' });
+        expect(drained.isErr()).toBe(true);
+        expect(drained.error).toBeInstanceOf(InternalError);
+        expect(drained.error.context).toMatchObject({
+          disposed: [configured.id],
+          evicted: [configured.id],
+        });
+        expect(afterDrain.unwrap()).toEqual({ token: 'valid' });
+        expect(events).toEqual([
+          'create:valid',
+          'dispose:valid',
+          'create:valid',
+        ]);
+      });
+
+      test('drain reports disposal failures and still drains sibling resources', async () => {
+        const events: string[] = [];
+        const failing = resource(nextResourceId('drain-failing'), {
+          create: () => Result.ok({ label: 'failing' }),
+          dispose: () => {
+            events.push('dispose:failing');
+            throw new Error('close failed');
+          },
+        });
+        const succeeding = resource(nextResourceId('drain-succeeding'), {
+          create: () => Result.ok({ label: 'succeeding' }),
+          dispose: (instance) => {
+            events.push(`dispose:${instance.label}`);
+          },
+        });
+        const resourceTrail = trail('resource.drain-failure', {
+          blaze: (_input, ctx) =>
+            Result.ok({
+              failing: failing.from(ctx).label,
+              succeeding: succeeding.from(ctx).label,
+            }),
+          input: z.object({}),
+          output: z.object({ failing: z.string(), succeeding: z.string() }),
+          resources: [failing, succeeding],
+        });
+
+        const beforeDrain = await executeTrail(resourceTrail, {});
+        const drained = await drainResources(
+          [failing, succeeding],
+          createTrailContext()
+        );
+
+        expect(beforeDrain.isOk()).toBe(true);
+        expect(drained.isErr()).toBe(true);
+        expect(drained.error).toBeInstanceOf(InternalError);
+        expect(drained.error.message).toBe('Resource drain failed');
+        expect(drained.error.context).toMatchObject({
+          disposed: [succeeding.id],
+          evicted: [succeeding.id, failing.id],
+        });
+        expect(events).toEqual(['dispose:succeeding', 'dispose:failing']);
       });
     });
 

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -191,19 +191,30 @@ const enforcePermitRequirement = (
 const prepareContext = async (
   trail: AnyTrail,
   options?: ExecuteTrailOptions
-): Promise<Result<TrailContext, Error>> => {
+): Promise<
+  Result<
+    { readonly ctx: TrailContext; readonly releaseResources: () => void },
+    Error
+  >
+> => {
   const baseCtx = await resolveContext(options);
   const permitted = enforcePermitRequirement(trail, baseCtx);
   if (permitted.isErr()) {
-    return permitted;
+    return Result.err(permitted.error);
   }
 
-  return await createResources(
+  const resources = await createResources(
     trail,
     permitted.value,
     options?.resources,
     options?.configValues
   );
+  return resources.isErr()
+    ? Result.err(resources.error)
+    : Result.ok({
+        ctx: resources.value.ctx,
+        releaseResources: resources.value.release,
+      });
 };
 
 // ---------------------------------------------------------------------------
@@ -1027,17 +1038,21 @@ export const executeTrail = async (
 
     const resolvedCtx = await prepareContext(trail, options);
     if (resolvedCtx.isErr()) {
-      return resolvedCtx;
+      return Result.err(resolvedCtx.error);
     }
 
-    return await runTrail(
-      trail,
-      validated.value,
-      resolvedCtx.value,
-      options?.layers ?? [],
-      options?.topo,
-      options
-    );
+    try {
+      return await runTrail(
+        trail,
+        validated.value,
+        resolvedCtx.value.ctx,
+        options?.layers ?? [],
+        options?.topo,
+        options
+      );
+    } finally {
+      resolvedCtx.value.releaseResources();
+    }
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     return Result.err(new InternalError(message));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,8 @@ export {
   isResource,
   resource,
 } from './resource.js';
+export { drainResources } from './resource-config.js';
+export type { ResourceDrainReport } from './resource-config.js';
 export type {
   AnyResource,
   Resource,

--- a/packages/core/src/resource-config.ts
+++ b/packages/core/src/resource-config.ts
@@ -28,12 +28,31 @@ type ConfigValues = Readonly<Record<string, Record<string, unknown>>>;
 // Singleton caches
 // ---------------------------------------------------------------------------
 
-const singletonResources = new WeakMap<AnyResource, Map<string, unknown>>();
+interface SingletonResourceEntry {
+  readonly value: unknown;
+  activeLeases: number;
+}
+
+interface ResourceLease {
+  readonly key: string;
+  readonly resource: AnyResource;
+  readonly value: unknown;
+}
+
+const singletonResources = new WeakMap<
+  AnyResource,
+  Map<string, SingletonResourceEntry>
+>();
+
+interface PendingCreation {
+  readonly promise: Promise<Result<unknown, Error>>;
+  waiters: number;
+}
 
 /** In-flight resource creation promises, keyed by resource x context. */
 const pendingCreations = new WeakMap<
   AnyResource,
-  Map<string, Promise<Result<unknown, Error>>>
+  Map<string, PendingCreation>
 >();
 
 // ---------------------------------------------------------------------------
@@ -104,20 +123,24 @@ const hasOwnResourceOverride = (
 const getCachedSingletonResource = (
   declaredResource: AnyResource,
   resourceContext: ResourceContext
-): { readonly found: boolean; readonly value: unknown } => {
+):
+  | { readonly found: false }
+  | { readonly found: true; readonly lease: ResourceLease } => {
   const scopedCache = singletonResources.get(declaredResource);
   if (scopedCache === undefined) {
-    return { found: false, value: undefined };
+    return { found: false };
   }
 
   const key = toResourceContextKey(resourceContext);
-  if (!scopedCache.has(key)) {
-    return { found: false, value: undefined };
+  const entry = scopedCache.get(key);
+  if (entry === undefined) {
+    return { found: false };
   }
 
+  entry.activeLeases += 1;
   return {
     found: true,
-    value: scopedCache.get(key),
+    lease: { key, resource: declaredResource, value: entry.value },
   };
 };
 
@@ -126,19 +149,24 @@ const getProvidedResource = (
   overrides: ResourceOverrideMap | undefined,
   declaredResource: AnyResource,
   resourceContext: ResourceContext
-): Result<unknown, Error> | undefined => {
+):
+  | Result<
+      { readonly lease?: ResourceLease | undefined; readonly value: unknown },
+      Error
+    >
+  | undefined => {
   const { id } = declaredResource;
   if (hasOwnResourceOverride(overrides, id)) {
-    return Result.ok(overrides[id]);
+    return Result.ok({ value: overrides[id] });
   }
 
   if (Object.hasOwn(ctx.extensions ?? {}, id)) {
-    return Result.ok(ctx.extensions?.[id]);
+    return Result.ok({ value: ctx.extensions?.[id] });
   }
 
   const cached = getCachedSingletonResource(declaredResource, resourceContext);
   if (cached.found) {
-    return Result.ok(cached.value);
+    return Result.ok({ lease: cached.lease, value: cached.lease?.value });
   }
 
   return undefined;
@@ -148,15 +176,49 @@ const getOverrideOrExtension = (
   ctx: TrailContext,
   overrides: ResourceOverrideMap | undefined,
   declaredResource: AnyResource
-): Result<unknown, Error> | undefined =>
+):
+  | Result<
+      { readonly lease?: ResourceLease | undefined; readonly value: unknown },
+      Error
+    >
+  | undefined =>
   getProvidedResource(ctx, overrides, declaredResource, toResourceContext(ctx));
 
 type ConfigAwareResolution =
-  | Result<{ readonly kind: 'provided'; readonly value: unknown }, Error>
+  | Result<
+      {
+        readonly kind: 'provided';
+        readonly lease?: ResourceLease | undefined;
+        readonly value: unknown;
+      },
+      Error
+    >
   | Result<
       { readonly kind: 'context'; readonly resourceContext: ResourceContext },
       Error
     >;
+
+interface CreatedResourceInstance {
+  readonly key: string;
+  readonly lease: ResourceLease;
+  readonly resource: AnyResource;
+  readonly sharedDuringCreation: boolean;
+  readonly value: unknown;
+}
+
+interface ResourceResolution {
+  readonly created?: CreatedResourceInstance | undefined;
+  readonly lease?: ResourceLease | undefined;
+  readonly value: unknown;
+}
+
+/** Outcome from draining cached resource singletons. */
+export interface ResourceDrainReport {
+  /** Resource IDs whose cached singleton entries were disposed successfully. */
+  readonly disposed: readonly string[];
+  /** Resource IDs removed from the singleton cache before disposal. */
+  readonly evicted: readonly string[];
+}
 
 const resolveConfigAwareProvidedResource = (
   ctx: TrailContext,
@@ -176,9 +238,18 @@ const resolveConfigAwareProvidedResource = (
     resourceContext
   );
 
-  return provided
-    ? Result.ok({ kind: 'provided', value: provided.unwrap() })
-    : Result.ok({ kind: 'context', resourceContext });
+  if (provided === undefined) {
+    return Result.ok({ kind: 'context', resourceContext });
+  }
+  if (provided.isErr()) {
+    return provided;
+  }
+
+  return Result.ok({
+    kind: 'provided',
+    lease: provided.value.lease,
+    value: provided.value.value,
+  });
 };
 
 // ---------------------------------------------------------------------------
@@ -196,20 +267,118 @@ const toInternalResourceError = (id: string, error: unknown): InternalError => {
 
 const getSingletonResourceCache = (
   declaredResource: AnyResource
-): Map<string, unknown> => {
+): Map<string, SingletonResourceEntry> => {
   const existing = singletonResources.get(declaredResource);
   if (existing !== undefined) {
     return existing;
   }
 
-  const created = new Map<string, unknown>();
+  const created = new Map<string, SingletonResourceEntry>();
   singletonResources.set(declaredResource, created);
   return created;
 };
 
+const acquireCachedSingletonResourceByKey = (
+  declaredResource: AnyResource,
+  key: string
+): ResourceLease | undefined => {
+  const entry = singletonResources.get(declaredResource)?.get(key);
+  if (entry === undefined) {
+    return undefined;
+  }
+
+  entry.activeLeases += 1;
+  return { key, resource: declaredResource, value: entry.value };
+};
+
+const releaseResourceLease = (lease: ResourceLease): number => {
+  const entry = singletonResources.get(lease.resource)?.get(lease.key);
+  if (entry === undefined || entry.value !== lease.value) {
+    return 0;
+  }
+
+  entry.activeLeases = Math.max(0, entry.activeLeases - 1);
+  return entry.activeLeases;
+};
+
+const countActiveResourceLeases = (lease: ResourceLease): number => {
+  const entry = singletonResources.get(lease.resource)?.get(lease.key);
+  return entry === undefined || entry.value !== lease.value
+    ? 0
+    : entry.activeLeases;
+};
+
+const releaseResourceLeases = (leases: readonly ResourceLease[]): void => {
+  for (const lease of leases.toReversed()) {
+    releaseResourceLease(lease);
+  }
+};
+
+const deleteCachedSingletonResource = (
+  declaredResource: AnyResource,
+  key: string,
+  value: unknown
+): boolean => {
+  const cache = singletonResources.get(declaredResource);
+  const entry = cache?.get(key);
+  if (entry === undefined || entry.value !== value) {
+    return false;
+  }
+
+  cache?.delete(key);
+  return true;
+};
+
+const disposeResourceInstance = async (
+  resource: AnyResource,
+  value: unknown
+): Promise<Result<void, Error>> => {
+  if (resource.dispose === undefined) {
+    return Result.ok();
+  }
+
+  try {
+    await resource.dispose(value);
+    return Result.ok();
+  } catch (error: unknown) {
+    const cause = error instanceof Error ? error : undefined;
+    const message = cause?.message ?? String(error);
+    return Result.err(
+      new InternalError(
+        `Resource "${resource.id}" failed to dispose: ${message}`,
+        {
+          ...(cause ? { cause } : {}),
+          context: { resourceId: resource.id },
+        }
+      )
+    );
+  }
+};
+
+const toResourceLifecycleError = (
+  message: string,
+  errors: readonly Error[],
+  cause?: Error,
+  context?: Record<string, unknown>
+): InternalError =>
+  new InternalError(message, {
+    ...(cause ? { cause } : {}),
+    context: {
+      ...context,
+      failures: errors.map((error) => ({
+        message: error.message,
+        name: error.name,
+        ...(error instanceof InternalError && error.context !== undefined
+          ? { context: error.context }
+          : {}),
+      })),
+    },
+  });
+
 const doCreateResourceInstance = async (
   declaredResource: AnyResource,
-  resourceContext: ResourceContext
+  resourceContext: ResourceContext,
+  key: string
 ): Promise<Result<unknown, Error>> => {
   try {
     const created = await declaredResource.create(resourceContext);
@@ -218,10 +387,10 @@ const doCreateResourceInstance = async (
     }
 
     const instance = created.unwrap();
-    getSingletonResourceCache(declaredResource).set(
-      toResourceContextKey(resourceContext),
-      instance
-    );
+    getSingletonResourceCache(declaredResource).set(key, {
+      activeLeases: 1,
+      value: instance,
+    });
     return Result.ok(instance);
   } catch (error: unknown) {
     return Result.err(toInternalResourceError(declaredResource.id, error));
@@ -232,13 +401,15 @@ const trackPendingCreation = (
   declaredResource: AnyResource,
   key: string,
   promise: Promise<Result<unknown, Error>>
-): void => {
+): PendingCreation => {
+  const entry: PendingCreation = { promise, waiters: 0 };
   const pending = pendingCreations.get(declaredResource);
   if (pending) {
-    pending.set(key, promise);
+    pending.set(key, entry);
   } else {
-    pendingCreations.set(declaredResource, new Map([[key, promise]]));
+    pendingCreations.set(declaredResource, new Map([[key, entry]]));
   }
+  return entry;
 };
 
 /**
@@ -249,30 +420,96 @@ const trackPendingCreation = (
 const createResourceInstance = async (
   declaredResource: AnyResource,
   resourceContext: ResourceContext
-): Promise<Result<unknown, Error>> => {
+): Promise<Result<ResourceResolution, Error>> => {
   const key = toResourceContextKey(resourceContext);
   const inflight = pendingCreations.get(declaredResource)?.get(key);
   if (inflight) {
-    return inflight;
+    inflight.waiters += 1;
+    const resolved = await inflight.promise;
+    if (resolved.isErr()) {
+      return resolved;
+    }
+    const lease = acquireCachedSingletonResourceByKey(declaredResource, key);
+    return lease === undefined
+      ? Result.err(
+          new InternalError(
+            `Resource "${declaredResource.id}" was created but is no longer cached`,
+            { context: { resourceId: declaredResource.id } }
+          )
+        )
+      : Result.ok({ lease, value: lease.value });
   }
 
-  const promise = doCreateResourceInstance(declaredResource, resourceContext);
-  trackPendingCreation(declaredResource, key, promise);
+  const promise = doCreateResourceInstance(
+    declaredResource,
+    resourceContext,
+    key
+  );
+  const pending = trackPendingCreation(declaredResource, key, promise);
 
   try {
-    return await promise;
+    const resolved = await promise;
+    if (resolved.isErr()) {
+      return resolved;
+    }
+    const { value } = resolved;
+    const lease = { key, resource: declaredResource, value };
+    return Result.ok({
+      created: {
+        key,
+        lease,
+        resource: declaredResource,
+        sharedDuringCreation: pending.waiters > 0,
+        value,
+      },
+      lease,
+      value,
+    });
   } finally {
     pendingCreations.get(declaredResource)?.delete(key);
   }
 };
 
-/** Validate config and resolve a single declared resource. */
-const resolveDeclaredResource = async (
+const rollbackCreatedResources = async (
+  created: readonly CreatedResourceInstance[]
+): Promise<Result<void, Error>> => {
+  const failures: Error[] = [];
+
+  for (const entry of created.toReversed()) {
+    const activeLeases = countActiveResourceLeases(entry.lease);
+    if (activeLeases > 0 || entry.sharedDuringCreation) {
+      continue;
+    }
+    const deleted = deleteCachedSingletonResource(
+      entry.resource,
+      entry.key,
+      entry.value
+    );
+    if (!deleted) {
+      continue;
+    }
+    const disposed = await disposeResourceInstance(entry.resource, entry.value);
+    if (disposed.isErr()) {
+      failures.push(disposed.error);
+    }
+  }
+
+  return failures.length === 0
+    ? Result.ok()
+    : Result.err(
+        toResourceLifecycleError(
+          'Resource rollback failed during resource resolution',
+          failures
+        )
+      );
+};
+
+const resolveDeclaredResourceForCreation = async (
   declaredResource: AnyResource,
   ctx: TrailContext,
   overrides: ResourceOverrideMap | undefined,
   configValues: ConfigValues | undefined
-): Promise<Result<unknown, Error>> => {
+): Promise<Result<ResourceResolution, Error>> => {
   // Check overrides/extensions first — skip config validation entirely when
   // a resource instance is already provided.
   const overrideOrExtension = getOverrideOrExtension(
@@ -281,7 +518,12 @@ const resolveDeclaredResource = async (
     declaredResource
   );
   if (overrideOrExtension !== undefined) {
-    return overrideOrExtension;
+    return overrideOrExtension.isErr()
+      ? overrideOrExtension
+      : Result.ok({
+          lease: overrideOrExtension.value.lease,
+          value: overrideOrExtension.value.value,
+        });
   }
 
   // Resolve config before consulting the singleton cache so config-aware
@@ -298,7 +540,7 @@ const resolveDeclaredResource = async (
   // No provided instance — create via factory.
   const resolved = configAwareResource.unwrap();
   if (resolved.kind === 'provided') {
-    return Result.ok(resolved.value);
+    return Result.ok({ lease: resolved.lease, value: resolved.value });
   }
 
   return await createResourceInstance(
@@ -323,6 +565,16 @@ const withResolvedResources = (
 };
 
 /**
+ * Resolved trail context plus lease release for resources used by the run.
+ */
+interface ResolvedResourceScope {
+  readonly ctx: TrailContext;
+  release(): void;
+}
+
+const releaseNoResources = (): undefined => undefined;
+
+/**
  * Resolve all declared resources for a trail.
  *
  * Validates per-resource config, checks overrides and caches, and creates
@@ -334,26 +586,151 @@ export const createResources = async (
   ctx: TrailContext,
   overrides?: ResourceOverrideMap,
   configValues?: ConfigValues
-): Promise<Result<TrailContext, Error>> => {
-  const { resources } = trail;
+): Promise<Result<ResolvedResourceScope, Error>> => {
+  const resources = [...new Set(trail.resources)];
   if (resources.length === 0) {
-    return Result.ok(ctx);
+    return Result.ok({ ctx, release: releaseNoResources });
   }
 
   const resolvedResources: Record<string, unknown> = {};
+  const acquiredLeases: ResourceLease[] = [];
+  const createdResources: CreatedResourceInstance[] = [];
 
   for (const declaredResource of resources) {
-    const resolved = await resolveDeclaredResource(
+    const resolved = await resolveDeclaredResourceForCreation(
       declaredResource,
       ctx,
       overrides,
       configValues
     );
     if (resolved.isErr()) {
+      releaseResourceLeases(acquiredLeases);
+      const rolledBack = await rollbackCreatedResources(createdResources);
+      if (rolledBack.isErr()) {
+        return Result.err(
+          toResourceLifecycleError(
+            `Resource resolution failed for "${declaredResource.id}" and rollback also failed`,
+            [rolledBack.error],
+            resolved.error
+          )
+        );
+      }
       return resolved;
     }
-    resolvedResources[declaredResource.id] = resolved.unwrap();
+    const resolution = resolved.unwrap();
+    if (resolution.lease !== undefined) {
+      acquiredLeases.push(resolution.lease);
+    }
+    if (resolution.created !== undefined) {
+      createdResources.push(resolution.created);
+    }
+    resolvedResources[declaredResource.id] = resolution.value;
   }
 
-  return Result.ok(withResolvedResources(ctx, resolvedResources));
+  return Result.ok({
+    ctx: withResolvedResources(ctx, resolvedResources),
+    release: () => releaseResourceLeases(acquiredLeases),
+  });
+};
+
+const toResourceInUseError = (
+  resource: AnyResource,
+  activeLeases: number
+): InternalError =>
+  new InternalError(`Resource "${resource.id}" is still in use`, {
+    context: { activeLeases, resourceId: resource.id },
+  });
+
+const drainCachedEntry = async (
+  resource: AnyResource,
+  key: string,
+  entry: SingletonResourceEntry,
+  report: { readonly disposed: string[]; readonly evicted: string[] },
+  failures: Error[]
+): Promise<void> => {
+  if (entry.activeLeases > 0) {
+    failures.push(toResourceInUseError(resource, entry.activeLeases));
+    return;
+  }
+
+  const deleted = deleteCachedSingletonResource(resource, key, entry.value);
+  if (!deleted) {
+    return;
+  }
+  report.evicted.push(resource.id);
+
+  const result = await disposeResourceInstance(resource, entry.value);
+  if (result.isErr()) {
+    failures.push(result.error);
+  } else if (resource.dispose !== undefined) {
+    report.disposed.push(resource.id);
+  }
+};
+
+/**
+ * Evict and dispose cached resource singletons for a stable resource context.
+ *
+ * Call this from surface or test shutdown paths with the same `ctx` and
+ * `configValues` used for execution. The returned report lists resources
+ * removed from the singleton cache and resources whose `dispose` hook ran
+ * successfully. On partial failure, the `InternalError` context still includes
+ * the report arrays so callers can tell what cleanup already happened.
+ */
+export const drainResources = async (
+  resources: readonly AnyResource[],
+  ctx: TrailContext,
+  configValues?: ConfigValues
+): Promise<Result<ResourceDrainReport, Error>> => {
+  const report = { disposed: [] as string[], evicted: [] as string[] };
+  const failures: Error[] = [];
+
+  for (const resource of resources.toReversed()) {
+    const cache = singletonResources.get(resource);
+    const pending = pendingCreations.get(resource);
+    if (
+      (cache === undefined || cache.size === 0) &&
+      (pending === undefined || pending.size === 0)
+    ) {
+      continue;
+    }
+
+    const configResult = resolveResourceConfig(resource, configValues);
+    if (configResult.isErr()) {
+      failures.push(configResult.error);
+      if (cache !== undefined) {
+        for (const [key, entry] of [...cache.entries()].toReversed()) {
+          await drainCachedEntry(resource, key, entry, report, failures);
+        }
+      }
+      continue;
+    }
+
+    const key = toResourceContextKey(
+      toResourceContext(ctx, configResult.value)
+    );
+    const pendingForKey = pending?.get(key);
+    if (pendingForKey !== undefined) {
+      failures.push(toResourceInUseError(resource, pendingForKey.waiters + 1));
+      continue;
+    }
+
+    if (cache === undefined) {
+      continue;
+    }
+    const entry = cache.get(key);
+    if (entry === undefined) {
+      continue;
+    }
+
+    await drainCachedEntry(resource, key, entry, report, failures);
+  }
+
+  return failures.length === 0
+    ? Result.ok(report)
+    : Result.err(
+        toResourceLifecycleError('Resource drain failed', failures, undefined, {
+          disposed: report.disposed,
+          evicted: report.evicted,
+        })
+      );
 };


### PR DESCRIPTION
## Context

[TRL-558](https://linear.app/outfitter/issue/TRL-558/feat-add-resource-lifecycle-drain-and-disposal-semantics) establishes explicit resource lifecycle semantics for Trails-owned resources so hosts can drain and dispose app-scoped work without relying on incidental cleanup.

## What changed

- Adds the resource drain/disposal contract to the core app surface.
- Threads lifecycle handling through the runtime APIs that own resource cleanup.
- Covers the new lifecycle behavior with focused tests.

## Testing

- `bun run check`
- `bun run test`
- `bun run build`
