### PR TITLE
feat: promote BlobRef descriptor schema

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -15,6 +15,7 @@ resource(id, spec)                  // define a first-class resource dependency
 createResourceLookup(getContext)   // bind ctx.resource() to a specific context snapshot
 drainResources(resources, ctx, configValues?) // evict and dispose cached resource singletons
 topo(name, ...modules)             // assemble trails, contours, signals, and resources into a queryable topology
+blobRefSchema, createBlobRef(...)  // declare and create binary output references
 // Topo methods: .get(id), .has(id), .list(), .listSignals(), .ids(), .count
 //               .getContour(name), .hasContour(name), .listContours(), .contourIds(), .contourCount
 //               .getResource(id), .hasResource(id), .listResources(), .resourceIds(), .resourceCount
@@ -24,6 +25,7 @@ createTopoStore(options?), createMockTopoStore(seed?), topoStore
 Trail<I, O>, Signal<T>, Contour<TName, TShape, TIdentity>, Resource<T>, Topo, Intent
 TrailSpec<I, O>, SignalSpec<T>, ResourceSpec<T>, TrailExample<I, O>
 AnyTrail, AnySignal, AnyContour, AnyResource, ResourceContext, ResourceOverrideMap
+BlobRef, BlobRefDescriptor
 ContourOptions, ContourIdBrand, ContourIdMetadata, ContourIdSchema, ContourIdValue, ContourReference
 
 // Type utilities

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -111,10 +111,13 @@ Result.err(new NotFoundError('Entity not found'));
 
 **Binary data:**
 
-If the result contains a `BlobRef` with an image MIME type, it becomes an image content entry:
+If the result contains a `BlobRef` declared with `blobRefSchema`, MCP projects
+the core descriptor into `structuredContent` and materializes bytes through MCP
+content entries. Image MIME types become image content:
 
 ```typescript
 // -> { content: [{ type: "image", data: "<base64>", mimeType: "image/png" }] }
+// -> { structuredContent: { file: { kind: "blob", name, mimeType, size, uri } } }
 ```
 
 ## Progress Bridging

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,6 +45,7 @@ const onboard = trail('entity.onboard', {
 | `signal(id, spec)` | Define a server-originated notification with a typed data schema |
 | `resource(id, spec)` | Define an infrastructure dependency with `create`, `dispose`, and optional `mock` |
 | `drainResources(resources, ctx, configValues?)` | Evict and dispose cached resource singletons for surface/test shutdown |
+| `blobRefSchema` / `createBlobRef(...)` | Declare and create binary output references with a shared descriptor contract |
 | `topo(name, ...modules)` | Collect trail modules into a queryable topology |
 | `deriveTrail(contour, operation, spec)` | Derive CRUD-shaped trail contracts from a contour on the `@ontrails/core/trails` subpath |
 | `validateTopo(topo)` | Structural validation: cross targets exist, no cycles, examples parse, output schemas present |

--- a/packages/core/src/__tests__/blob-ref.test.ts
+++ b/packages/core/src/__tests__/blob-ref.test.ts
@@ -1,6 +1,14 @@
 import { describe, test, expect } from 'bun:test';
 
-import { createBlobRef, isBlobRef } from '../blob-ref';
+import {
+  blobRefDescriptorSchema,
+  blobRefJsonSchema,
+  blobRefSchema,
+  createBlobRef,
+  isBlobRef,
+  toBlobRefDescriptor,
+} from '../blob-ref';
+import { zodToJsonSchema } from '../validation';
 
 describe('BlobRef', () => {
   const sampleData = new Uint8Array([137, 80, 78, 71]);
@@ -98,6 +106,93 @@ describe('BlobRef', () => {
           size: 0,
         })
       ).toBe(false);
+    });
+  });
+
+  describe('schema projection', () => {
+    test('blobRefSchema validates BlobRef values', () => {
+      const ref = createBlobRef({
+        data: sampleData,
+        mimeType: 'image/png',
+        name: 'image.png',
+        size: 4,
+      });
+
+      expect(blobRefSchema.safeParse(ref).success).toBe(true);
+      expect(blobRefSchema.safeParse({ name: 'image.png' }).success).toBe(
+        false
+      );
+    });
+
+    test('toBlobRefDescriptor projects the canonical descriptor shape', () => {
+      const ref = createBlobRef({
+        data: sampleData,
+        mimeType: 'image/png',
+        name: 'image.png',
+        size: 4,
+      });
+
+      const descriptor = toBlobRefDescriptor(ref);
+
+      expect(descriptor).toEqual({
+        kind: 'blob',
+        mimeType: 'image/png',
+        name: 'image.png',
+        size: 4,
+        uri: 'blob://image.png',
+      });
+      expect(blobRefDescriptorSchema.parse(descriptor)).toEqual(descriptor);
+      expect(Object.isFrozen(descriptor)).toBe(true);
+    });
+
+    test('zodToJsonSchema projects blobRefSchema as the descriptor contract', () => {
+      expect(zodToJsonSchema(blobRefSchema)).toEqual({
+        properties: {
+          kind: { const: 'blob' },
+          mimeType: { type: 'string' },
+          name: { type: 'string' },
+          size: { type: 'number' },
+          uri: { type: 'string' },
+        },
+        required: ['kind', 'mimeType', 'name', 'size', 'uri'],
+        type: 'object',
+      });
+    });
+
+    test('zodToJsonSchema preserves blob descriptors through schema descriptions', () => {
+      expect(zodToJsonSchema(blobRefSchema.describe('Uploaded file'))).toEqual({
+        description: 'Uploaded file',
+        properties: {
+          kind: { const: 'blob' },
+          mimeType: { type: 'string' },
+          name: { type: 'string' },
+          size: { type: 'number' },
+          uri: { type: 'string' },
+        },
+        required: ['kind', 'mimeType', 'name', 'size', 'uri'],
+        type: 'object',
+      });
+    });
+
+    test('zodToJsonSchema returns an isolated blob descriptor schema', () => {
+      const first = zodToJsonSchema(blobRefSchema) as {
+        properties: { kind: { const: string } };
+      };
+      first.properties.kind.const = 'mutated';
+
+      expect(zodToJsonSchema(blobRefSchema)).toEqual({
+        properties: {
+          kind: { const: 'blob' },
+          mimeType: { type: 'string' },
+          name: { type: 'string' },
+          size: { type: 'number' },
+          uri: { type: 'string' },
+        },
+        required: ['kind', 'mimeType', 'name', 'size', 'uri'],
+        type: 'object',
+      });
+      expect(Object.isFrozen(blobRefJsonSchema.properties)).toBe(true);
+      expect(Object.isFrozen(blobRefJsonSchema.properties.kind)).toBe(true);
     });
   });
 });

--- a/packages/core/src/blob-ref.ts
+++ b/packages/core/src/blob-ref.ts
@@ -2,6 +2,11 @@
  * BlobRef — a frozen reference to binary data for @ontrails/core.
  */
 
+import { z } from 'zod';
+
+/** Metadata key used to recognize BlobRef schemas during JSON Schema projection. */
+export const BLOB_REF_SCHEMA_META_KEY = 'ontrails/blob-ref';
+
 /** Immutable reference to a blob of binary data. */
 export interface BlobRef {
   readonly name: string;
@@ -9,6 +14,37 @@ export interface BlobRef {
   readonly size: number;
   readonly data: Uint8Array | ReadableStream<Uint8Array>;
 }
+
+/** Schema-projected metadata for a BlobRef value. */
+export interface BlobRefDescriptor {
+  readonly kind: 'blob';
+  readonly mimeType: string;
+  readonly name: string;
+  readonly size: number;
+  readonly uri: string;
+}
+
+/** Public descriptor schema emitted to transport clients instead of raw bytes. */
+export const blobRefDescriptorSchema = z.object({
+  kind: z.literal('blob'),
+  mimeType: z.string(),
+  name: z.string(),
+  size: z.number(),
+  uri: z.string(),
+});
+
+/** Canonical JSON Schema for BlobRef descriptors across derived surfaces. */
+export const blobRefJsonSchema = Object.freeze({
+  properties: Object.freeze({
+    kind: Object.freeze({ const: 'blob' }),
+    mimeType: Object.freeze({ type: 'string' }),
+    name: Object.freeze({ type: 'string' }),
+    size: Object.freeze({ type: 'number' }),
+    uri: Object.freeze({ type: 'string' }),
+  }),
+  required: Object.freeze(['kind', 'mimeType', 'name', 'size', 'uri']),
+  type: 'object',
+});
 
 /** Creates a frozen BlobRef. */
 export const createBlobRef = (options: {
@@ -37,3 +73,18 @@ export const isBlobRef = (value: unknown): value is BlobRef => {
     (obj['data'] instanceof Uint8Array || obj['data'] instanceof ReadableStream)
   );
 };
+
+/** Zod schema for runtime BlobRef values with metadata for descriptor projection. */
+export const blobRefSchema = z
+  .custom<BlobRef>(isBlobRef, { error: 'Expected BlobRef' })
+  .meta({ [BLOB_REF_SCHEMA_META_KEY]: true });
+
+/** Convert a runtime BlobRef into its schema-aware transport descriptor. */
+export const toBlobRefDescriptor = (blob: BlobRef): BlobRefDescriptor =>
+  Object.freeze({
+    kind: 'blob',
+    mimeType: blob.mimeType,
+    name: blob.name,
+    size: blob.size,
+    uri: `blob://${blob.name}`,
+  });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -286,8 +286,16 @@ export {
 } from './workspace.js';
 
 // Blob
-export { createBlobRef, isBlobRef } from './blob-ref.js';
-export type { BlobRef } from './blob-ref.js';
+export {
+  BLOB_REF_SCHEMA_META_KEY,
+  blobRefDescriptorSchema,
+  blobRefJsonSchema,
+  blobRefSchema,
+  createBlobRef,
+  isBlobRef,
+  toBlobRefDescriptor,
+} from './blob-ref.js';
+export type { BlobRef, BlobRefDescriptor } from './blob-ref.js';
 
 // Guards
 export {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -7,6 +7,7 @@
 
 import type { z } from 'zod';
 
+import { BLOB_REF_SCHEMA_META_KEY, blobRefJsonSchema } from './blob-ref.js';
 import { ValidationError } from './errors.js';
 import { Result } from './result.js';
 
@@ -33,6 +34,43 @@ type JsonSchemaConverter = (schema: z.ZodType) => JsonSchema;
 const isOptionalLike = (s: ZodInternals): boolean => {
   const defType = s._zod.def['type'] as string;
   return defType === 'optional' || defType === 'default';
+};
+
+const getSchemaMeta = (
+  schema: z.ZodType
+): Readonly<Record<string, unknown>> | undefined => {
+  const maybeMeta = (schema as unknown as { meta?: () => unknown }).meta;
+  if (typeof maybeMeta !== 'function') {
+    return undefined;
+  }
+  const meta = maybeMeta.call(schema);
+  return typeof meta === 'object' && meta !== null
+    ? (meta as Readonly<Record<string, unknown>>)
+    : undefined;
+};
+
+const getSchemaJsonSchemaOverride = (
+  schema: z.ZodType
+): JsonSchema | undefined => {
+  const meta = getSchemaMeta(schema);
+  if (meta?.[BLOB_REF_SCHEMA_META_KEY] === true) {
+    const override: JsonSchema = {
+      properties: Object.fromEntries(
+        Object.entries(blobRefJsonSchema.properties).map(([key, value]) => [
+          key,
+          { ...value },
+        ])
+      ),
+      required: [...blobRefJsonSchema.required],
+      type: blobRefJsonSchema.type,
+    };
+    const { description } = schema as unknown as ZodInternals;
+    if (description) {
+      override['description'] = description;
+    }
+    return override;
+  }
+  return undefined;
 };
 
 // ---------------------------------------------------------------------------
@@ -132,6 +170,11 @@ const resolveDefault = (def: Record<string, unknown>): unknown => {
 export const zodToJsonSchema: JsonSchemaConverter = (
   schema: z.ZodType
 ): JsonSchema => {
+  const jsonSchemaOverride = getSchemaJsonSchemaOverride(schema);
+  if (jsonSchemaOverride !== undefined) {
+    return jsonSchemaOverride;
+  }
+
   const s = schema as unknown as ZodInternals;
 
   const collectObjectFields = (shape: Record<string, ZodInternals>) => {

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   Result,
   TRAILHEAD_KEY,
+  blobRefSchema,
   createBlobRef,
   resource,
   signal,
@@ -674,6 +675,38 @@ describe('deriveMcpTools', () => {
       expect(result?.content[0]?.mimeType).toBe('application/pdf');
     });
 
+    test('BlobRef resource content does not consume non-image streams', async () => {
+      const bytes = new Uint8Array([4, 5, 6]);
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(bytes);
+          controller.close();
+        },
+      });
+      const blobTrail = trail('blob.file-stream', {
+        blaze: () =>
+          Result.ok(
+            createBlobRef({
+              data: stream,
+              mimeType: 'application/pdf',
+              name: 'doc.pdf',
+              size: 3,
+            })
+          ),
+        input: z.object({}),
+      });
+
+      const tool = requireOnlyTool(buildTools(topo('myapp', { blobTrail })));
+      const result = await tool.handler({}, noExtra);
+      const reader = stream.getReader();
+      const read = await reader.read();
+      reader.releaseLock();
+
+      expect(result?.content[0]?.type).toBe('resource');
+      expect(read.done).toBe(false);
+      expect(read.value).toEqual(bytes);
+    });
+
     test('BlobRef with ReadableStream data is collected and serialized', async () => {
       const bytes = new Uint8Array([10, 20, 30]);
       const stream = new ReadableStream<Uint8Array>({
@@ -718,13 +751,30 @@ describe('deriveMcpTools', () => {
           }),
         input: z.object({}),
         output: z.object({
-          attachment: z.custom(),
+          attachment: blobRefSchema,
           label: z.string(),
         }),
       });
 
       const tool = requireOnlyTool(buildTools(topo('myapp', { blobTrail })));
-      expect(tool.outputSchema?.['type']).toBe('object');
+      expect(tool.outputSchema).toEqual({
+        properties: {
+          attachment: {
+            properties: {
+              kind: { const: 'blob' },
+              mimeType: { type: 'string' },
+              name: { type: 'string' },
+              size: { type: 'number' },
+              uri: { type: 'string' },
+            },
+            required: ['kind', 'mimeType', 'name', 'size', 'uri'],
+            type: 'object',
+          },
+          label: { type: 'string' },
+        },
+        required: ['attachment', 'label'],
+        type: 'object',
+      });
 
       const result = await tool.handler({}, noExtra);
 
@@ -741,12 +791,68 @@ describe('deriveMcpTools', () => {
       ]);
       expect(result?.structuredContent).toEqual({
         attachment: {
+          kind: 'blob',
           mimeType: 'application/pdf',
           name: 'doc.pdf',
           size: 3,
           uri: 'blob://doc.pdf',
         },
         label: 'report',
+      });
+    });
+
+    test('nested BlobRef output materializes MCP content entries', async () => {
+      const blobTrail = trail('blob.nested', {
+        blaze: () =>
+          Result.ok({
+            files: [
+              createBlobRef({
+                data: new Uint8Array([1, 2, 3]),
+                mimeType: 'image/png',
+                name: 'chart.png',
+                size: 3,
+              }),
+            ],
+            label: 'gallery',
+          }),
+        input: z.object({}),
+        output: z.object({
+          files: z.array(blobRefSchema),
+          label: z.string(),
+        }),
+      });
+
+      const tool = requireOnlyTool(buildTools(topo('myapp', { blobTrail })));
+      const result = await tool.handler({}, noExtra);
+
+      expect(parseJsonContent(result?.content[0])).toEqual({
+        files: [
+          {
+            kind: 'blob',
+            mimeType: 'image/png',
+            name: 'chart.png',
+            size: 3,
+            uri: 'blob://chart.png',
+          },
+        ],
+        label: 'gallery',
+      });
+      expect(result?.content[1]).toMatchObject({
+        mimeType: 'image/png',
+        type: 'image',
+      });
+      expect(result?.content[1]?.data).toBeDefined();
+      expect(result?.structuredContent).toEqual({
+        files: [
+          {
+            kind: 'blob',
+            mimeType: 'image/png',
+            name: 'chart.png',
+            size: 3,
+            uri: 'blob://chart.png',
+          },
+        ],
+        label: 'gallery',
       });
     });
   });

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -14,6 +14,7 @@ import {
   executeTrail,
   filterSurfaceTrails,
   isBlobRef,
+  toBlobRefDescriptor,
   validateEstablishedTopo,
   zodToJsonSchema,
 } from '@ontrails/core';
@@ -150,72 +151,20 @@ const uint8ArrayToBase64 = (bytes: Uint8Array): string => {
 };
 
 const blobToContent = async (blob: BlobRef): Promise<McpContent> => {
-  const bytes = await resolveBlobData(blob);
-  if (blob.mimeType.startsWith('image/')) {
+  if (!blob.mimeType.startsWith('image/')) {
     return {
-      data: uint8ArrayToBase64(bytes),
       mimeType: blob.mimeType,
-      type: 'image',
+      type: 'resource',
+      uri: `blob://${blob.name}`,
     };
   }
 
+  const bytes = await resolveBlobData(blob);
   return {
+    data: uint8ArrayToBase64(bytes),
     mimeType: blob.mimeType,
-    type: 'resource',
-    uri: `blob://${blob.name}`,
+    type: 'image',
   };
-};
-
-/** Separate blob fields from non-blob fields in an object. */
-const separateBlobFields = async (
-  obj: Record<string, unknown>
-): Promise<{
-  blobContents: McpContent[];
-  hasBlobFields: boolean;
-  textFields: Record<string, unknown>;
-}> => {
-  const blobContents: McpContent[] = [];
-  const textFields: Record<string, unknown> = {};
-  let hasBlobFields = false;
-  for (const [key, val] of Object.entries(obj)) {
-    if (isBlobRef(val)) {
-      hasBlobFields = true;
-      blobContents.push(await blobToContent(val));
-    } else {
-      textFields[key] = val;
-    }
-  }
-  return { blobContents, hasBlobFields, textFields };
-};
-
-/** Serialize a mixed blob/text object to MCP content. */
-const serializeMixedObject = async (
-  obj: Record<string, unknown>
-): Promise<readonly McpContent[] | undefined> => {
-  const { blobContents, hasBlobFields, textFields } =
-    await separateBlobFields(obj);
-  if (!hasBlobFields) {
-    return undefined;
-  }
-  if (Object.keys(textFields).length > 0) {
-    blobContents.unshift({ text: JSON.stringify(textFields), type: 'text' });
-  }
-  return blobContents;
-};
-
-const serializeOutput = async (
-  value: unknown
-): Promise<readonly McpContent[]> => {
-  if (isBlobRef(value)) {
-    return [await blobToContent(value)];
-  }
-  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-    const mixed = await serializeMixedObject(value as Record<string, unknown>);
-    if (mixed) {
-      return mixed;
-    }
-  }
-  return [{ text: JSON.stringify(value), type: 'text' }];
 };
 
 const containsBlobRef = (
@@ -242,21 +191,12 @@ const containsBlobRef = (
   );
 };
 
-const blobToStructuredValue = (
-  blob: BlobRef
-): Record<string, string | number> => ({
-  mimeType: blob.mimeType,
-  name: blob.name,
-  size: blob.size,
-  uri: `blob://${blob.name}`,
-});
-
 const toStructuredValue = (
   value: unknown,
   seen = new WeakSet<object>()
 ): unknown => {
   if (isBlobRef(value)) {
-    return blobToStructuredValue(value);
+    return toBlobRefDescriptor(value);
   }
   if (value === null || typeof value !== 'object') {
     return value;
@@ -276,6 +216,105 @@ const toStructuredValue = (
       toStructuredValue(item, seen),
     ])
   );
+};
+
+const collectBlobContents = async (
+  value: unknown,
+  seen = new WeakSet<object>()
+): Promise<McpContent[]> => {
+  if (isBlobRef(value)) {
+    return [await blobToContent(value)];
+  }
+  if (value === null || typeof value !== 'object') {
+    return [];
+  }
+  if (seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  const items = Array.isArray(value)
+    ? value
+    : Object.values(value as Record<string, unknown>);
+  const nested = await Promise.all(
+    items.map((item) => collectBlobContents(item, seen))
+  );
+  return nested.flat();
+};
+
+/** Separate blob fields from non-blob fields in an object. */
+const separateBlobFields = async (
+  obj: Record<string, unknown>
+): Promise<{
+  blobContents: McpContent[];
+  hasBlobFields: boolean;
+  textFields: Record<string, unknown>;
+}> => {
+  const blobContents: McpContent[] = [];
+  const textFields: Record<string, unknown> = {};
+  let hasBlobFields = false;
+  for (const [key, val] of Object.entries(obj)) {
+    if (isBlobRef(val)) {
+      hasBlobFields = true;
+      blobContents.push(await blobToContent(val));
+    } else if (containsBlobRef(val)) {
+      hasBlobFields = true;
+      blobContents.push(...(await collectBlobContents(val)));
+      textFields[key] = toStructuredValue(val);
+    } else {
+      textFields[key] = val;
+    }
+  }
+  return { blobContents, hasBlobFields, textFields };
+};
+
+/** Serialize a mixed blob/text object to MCP content. */
+const serializeMixedObject = async (
+  obj: Record<string, unknown>
+): Promise<readonly McpContent[] | undefined> => {
+  const { blobContents, hasBlobFields, textFields } =
+    await separateBlobFields(obj);
+  if (!hasBlobFields) {
+    return undefined;
+  }
+  if (Object.keys(textFields).length > 0) {
+    blobContents.unshift({ text: JSON.stringify(textFields), type: 'text' });
+  }
+  return blobContents;
+};
+
+const serializeBlobArray = async (
+  value: readonly unknown[]
+): Promise<readonly McpContent[] | undefined> => {
+  if (!containsBlobRef(value)) {
+    return undefined;
+  }
+  const blobContents = await collectBlobContents(value);
+  return [
+    { text: JSON.stringify(toStructuredValue(value)), type: 'text' },
+    ...blobContents,
+  ];
+};
+
+const serializeOutput = async (
+  value: unknown
+): Promise<readonly McpContent[]> => {
+  if (isBlobRef(value)) {
+    return [await blobToContent(value)];
+  }
+  if (Array.isArray(value)) {
+    const mixed = await serializeBlobArray(value);
+    if (mixed) {
+      return mixed;
+    }
+  }
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const mixed = await serializeMixedObject(value as Record<string, unknown>);
+    if (mixed) {
+      return mixed;
+    }
+  }
+  return [{ text: JSON.stringify(value), type: 'text' }];
 };
 
 // `wrapAsData` is decided at build time from the schema shape (see


### PR DESCRIPTION
## Context

[TRL-584](https://linear.app/outfitter/issue/TRL-584/promote-blobref-to-schema-aware-core-type-with-canonical-descriptor) promotes BlobRef from an ad hoc projection shape into a schema-aware core type with a canonical descriptor.

## What changed

- Adds a canonical BlobRef descriptor contract in the schema layer.
- Updates JSON Schema and OpenAPI projection paths to use the descriptor consistently.
- Adds coverage for the promoted descriptor behavior and downstream projection shape.

## Testing

- `bun run check`
- `bun run test`
- `bun run build`
