### PR TITLE
refactor: move OpenAPI projection to HTTP

### DIFF
--- a/.changeset/http-surface-and-openapi.md
+++ b/.changeset/http-surface-and-openapi.md
@@ -1,6 +1,5 @@
 ---
 "@ontrails/http": minor
-"@ontrails/schema": minor
 "@ontrails/trails": minor
 ---
 
@@ -8,6 +7,4 @@ HTTP trailhead and OpenAPI generation.
 
 **http**: New `@ontrails/http` package — Hono-based HTTP connector. `trailhead()` derives routes from trail IDs, maps intent to HTTP verbs (read→GET, write→POST, destroy→DELETE), and maps error taxonomy to status codes. Returns the Hono instance.
 
-**schema**: Add `generateOpenApiSpec(topo)` — generates a complete OpenAPI 3.1 spec from the topo. Each trail becomes an operation with path, method, schemas, and error responses derived from the contract.
-
-**trails**: `trails survey --openapi` outputs the OpenAPI spec for any Trails app.
+**trails**: Depend on `@ontrails/http` for `trails survey --openapi`.

--- a/.changeset/openapi-http-home.md
+++ b/.changeset/openapi-http-home.md
@@ -1,0 +1,10 @@
+---
+"@ontrails/http": minor
+"@ontrails/schema": major
+---
+
+Move OpenAPI generation ownership to the HTTP surface.
+
+**http**: Export `deriveOpenApiSpec()` and its OpenAPI types from `@ontrails/http`.
+
+**schema**: Remove the OpenAPI helper export so schema stays focused on surface maps, locks, and semantic diffing.

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -25,6 +25,7 @@
     "@clack/prompts": "^1.1.0",
     "@ontrails/cli": "workspace:^",
     "@ontrails/core": "workspace:^",
+    "@ontrails/http": "workspace:^",
     "@ontrails/logging": "workspace:^",
     "@ontrails/schema": "workspace:^",
     "@ontrails/tracing": "workspace:^",

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -16,11 +16,11 @@ import {
   topo,
   trail,
 } from '@ontrails/core';
+import { deriveOpenApiSpec } from '@ontrails/http';
 import {
   deriveSurfaceMap,
   deriveSurfaceMapHash,
   deriveSurfaceMapDiff,
-  deriveOpenApiSpec,
   writeSurfaceMap,
 } from '@ontrails/schema';
 import type { SurfaceMap } from '@ontrails/schema';

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -9,10 +9,10 @@ import { join } from 'node:path';
 
 import type { Topo } from '@ontrails/core';
 import { NotFoundError, Result, trail } from '@ontrails/core';
+import { deriveOpenApiSpec } from '@ontrails/http';
 import type { DiffResult } from '@ontrails/schema';
 import {
   deriveSurfaceMapDiff,
-  deriveOpenApiSpec,
   deriveSurfaceMap,
   readSurfaceMap,
 } from '@ontrails/schema';

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "@clack/prompts": "^1.1.0",
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
+        "@ontrails/http": "workspace:^",
         "@ontrails/logging": "workspace:^",
         "@ontrails/schema": "workspace:^",
         "@ontrails/tracing": "workspace:^",
@@ -295,9 +296,9 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
-    "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
+    "@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
 
-    "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
+    "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -1021,8 +1022,6 @@
 
     "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "ultracite/@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
-
     "@manypkg/get-packages/globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "@manypkg/get-packages/globby/slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
@@ -1030,7 +1029,5 @@
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "ultracite/@clack/prompts/@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
   }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -156,8 +156,10 @@ McpToolResult, McpContent, McpExtra, McpAnnotations
 
 ```typescript
 deriveHttpRoutes(graph, options?)      // projection: route definitions without server; returns Result<HttpRouteDefinition[], Error>
+deriveOpenApiSpec(graph, options?)     // OpenAPI 3.1 spec for the HTTP surface
 
 DeriveHttpRoutesOptions, HttpMethod, HttpRouteDefinition, InputSource
+OpenApiOptions, OpenApiSpec, OpenApiServer
 ```
 
 ## `@ontrails/hono`
@@ -172,15 +174,12 @@ CreateAppOptions, SurfaceHttpResult
 ## `@ontrails/schema`
 
 ```typescript
-deriveOpenApiSpec(graph, options?) // OpenAPI 3.1 spec from topo
 deriveSurfaceMap(graph), deriveSurfaceMapHash(map), deriveSurfaceMapDiff(before, after)
 writeSurfaceMap(map, options?), readSurfaceMap(options?)
 writeSurfaceLock(lock, options?), readSurfaceLockData(options?), readSurfaceLock(options?)
 
 SurfaceMap, SurfaceMapEntry, SurfaceMapContourReference, SurfaceLock, DiffResult, DiffEntry, JsonSchema
 WriteOptions, ReadOptions
-
-OpenApiOptions, OpenApiSpec, OpenApiServer
 ```
 
 ## `@ontrails/store`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,7 +148,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 | `@ontrails/cli` | Framework-agnostic command model, flag derivation, output formatting | None beyond core |
 | `@ontrails/cli/commander` | Commander connector, `surface()` | `commander` (optional peer) |
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `surface()` | `@modelcontextprotocol/sdk` |
-| `@ontrails/http` | HTTP routes and error mapping | None beyond core |
+| `@ontrails/http` | HTTP routes, error mapping, and OpenAPI generation | None beyond core |
 | `@ontrails/hono` | Hono connector, `surface()` | `hono` |
 | `@ontrails/vite` | Vite middleware adapter, `vite()` | None (node:stream only) |
 
@@ -169,7 +169,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 | Package | What it does |
 | --- | --- |
 | `@ontrails/testing` | `testAll()`, `testExamples()`, `testTrail()`, contract testing, surface harnesses |
-| `@ontrails/schema` | Surface maps, semantic diffing, OpenAPI generation, lock helpers |
+| `@ontrails/schema` | Surface maps, semantic diffing, lock helpers |
 | `@ontrails/warden` | Lint rules, drift detection, CI gating |
 
 ### Apps
@@ -202,7 +202,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 @ontrails/logtape (logging)
 @ontrails/warden (core, schema)
      ^
-apps/trails (cli/commander, schema, tracing)
+apps/trails (cli/commander, http, schema, tracing)
 ```
 
 Clean DAG. Core at the center. No cycles. Surface connectors depend only on core. Framework connectors depend on their parent package.

--- a/docs/draft-state.md
+++ b/docs/draft-state.md
@@ -68,7 +68,7 @@ These outputs reject draft state at runtime via `validateEstablishedTopo()`:
 
 - **Surface projection** — no draft trails in current shipped surfaces
 - **Lockfile export** — no draft nodes in `.trails/trails.lock`
-- **OpenAPI generation** — established schema export excludes draft trails
+- **OpenAPI generation** — the HTTP OpenAPI projection excludes draft trails
 - **Topo exports** — standard topo accessors exclude draft declarations
 
 ## The promotion workflow

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -6,7 +6,7 @@
 
 **HTTP surface (`@ontrails/http`).** The third surface connector. `intent: 'read'` maps to GET, mutations to POST, `'destroy'` to DELETE. Route paths derived from trail IDs. Error taxonomy maps to HTTP status codes. One `surface()` call, same pattern as CLI and MCP. Built on Hono.
 
-**OpenAPI generation (`@ontrails/schema`).** `deriveOpenApiSpec()` produces a complete OpenAPI 3.1 spec from the topo. The topo already carries everything OpenAPI needs.
+**OpenAPI generation (`@ontrails/http`).** `deriveOpenApiSpec()` produces a complete OpenAPI 3.1 spec from the topo for HTTP clients. The topo already carries everything OpenAPI needs; the HTTP package owns the surface-specific projection.
 
 **Resources (`resource()` and trail `resources: [...]`).** Trails now declare infrastructure dependencies explicitly. `executeTrail()` resolves app-scoped singletons before layers and implementations run. Testing can auto-resolve `mock` factories, and survey / schema tooling exposes the full resource graph.
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -36,11 +36,23 @@ for (const route of result.value) {
 
 `deriveHttpRoutes` returns `Result<HttpRouteDefinition[], Error>` rather than a bare array. It returns `Result.err(ValidationError)` if two trails derive the same `(method, path)` pair.
 
+OpenAPI is the HTTP surface's persisted client contract projection:
+
+```typescript
+import { deriveOpenApiSpec } from '@ontrails/http';
+
+const spec = deriveOpenApiSpec(graph, { basePath: '/api' });
+```
+
+`deriveOpenApiSpec()` emits an OpenAPI 3.1 document from the same trail
+contracts used by `deriveHttpRoutes()`.
+
 ## API
 
 | Export | What it does |
 | --- | --- |
 | `deriveHttpRoutes(graph, options?)` | Build framework-agnostic route definitions from a topo |
+| `deriveOpenApiSpec(graph, options?)` | Generate an OpenAPI 3.1 document for the HTTP surface |
 
 ## Route derivation
 

--- a/packages/http/src/__tests__/openapi.test.ts
+++ b/packages/http/src/__tests__/openapi.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { Result, signal, topo, trail } from '@ontrails/core';
+import { Result, ValidationError, signal, topo, trail } from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -113,6 +113,45 @@ const registerPathAndMethodTests = () => {
 
       expect(spec.paths['/api/v1/entity/show']).toBeDefined();
       expect(spec.paths['/api/v1//entity/show']).toBeUndefined();
+    });
+
+    test('same derived path with different methods keeps both operations', () => {
+      const getItem = trail('item.resource', {
+        blaze: noop,
+        input: z.object({}),
+        intent: 'read',
+      });
+      const createItem = trail('item/resource', {
+        blaze: noop,
+        input: z.object({ name: z.string() }),
+      });
+      const spec = deriveOpenApiSpec(topoFrom({ createItem, getItem }));
+
+      expect(
+        Object.keys(spec.paths['/item/resource'] ?? {}).toSorted()
+      ).toEqual(['get', 'post']);
+    });
+
+    test('throws on duplicate method and path derivation', () => {
+      const dotTrail = trail('entity.show', {
+        blaze: noop,
+        input: z.object({}),
+        intent: 'read',
+      });
+      const slashTrail = trail('entity/show', {
+        blaze: noop,
+        input: z.object({}),
+        intent: 'read',
+      });
+
+      expect(() =>
+        deriveOpenApiSpec(topoFrom({ dotTrail, slashTrail }))
+      ).toThrow(ValidationError);
+      expect(() =>
+        deriveOpenApiSpec(topoFrom({ dotTrail, slashTrail }))
+      ).toThrow(
+        'HTTP route collision: trails "entity.show" and "entity/show" both derive GET /entity/show'
+      );
     });
   });
 };
@@ -320,8 +359,17 @@ const registerResponseTests = () => {
       const op = spec.paths['/entity/show']?.['get'] as Record<string, unknown>;
       const responses = op['responses'] as Record<string, unknown>;
 
-      // The example-derived 400 (description: 'ValidationError') overrides the default
-      expect(responses['400']).toEqual({ description: 'ValidationError' });
+      expect(responses['400']).toMatchObject({
+        description: 'Validation error',
+      });
+      expect(
+        getJsonSchema(responses['400'] as Record<string, unknown>)
+      ).toEqual(
+        expect.objectContaining({
+          required: ['error'],
+          type: 'object',
+        })
+      );
     });
   });
 };
@@ -350,6 +398,28 @@ const registerMetadataAndStructureTests = () => {
       const op = spec.paths['/search']?.['get'] as Record<string, unknown>;
 
       expect(op['operationId']).toBe('search');
+    });
+
+    test('throws on duplicate operationId derivation', () => {
+      const dotTrail = trail('foo.bar', {
+        blaze: noop,
+        input: z.object({}),
+        intent: 'read',
+      });
+      const underscoreTrail = trail('foo_bar', {
+        blaze: noop,
+        input: z.object({}),
+        intent: 'read',
+      });
+
+      expect(() =>
+        deriveOpenApiSpec(topoFrom({ dotTrail, underscoreTrail }))
+      ).toThrow(ValidationError);
+      expect(() =>
+        deriveOpenApiSpec(topoFrom({ dotTrail, underscoreTrail }))
+      ).toThrow(
+        'OpenAPI operationId collision: trails "foo.bar" and "foo_bar" both derive operationId "foo_bar"'
+      );
     });
   });
 
@@ -573,6 +643,18 @@ const registerMetadataAndStructureTests = () => {
 
       expect(() => deriveOpenApiSpec(topoFrom({ exportTrail }))).toThrowError(
         /draft/i
+      );
+    });
+
+    test('rejects structural validation issues', () => {
+      const exportTrail = trail('entity.export', {
+        blaze: noop,
+        crosses: ['entity.missing'],
+        input: z.object({}),
+      });
+
+      expect(() => deriveOpenApiSpec(topoFrom({ exportTrail }))).toThrowError(
+        /topo validation/i
       );
     });
   });

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -6,3 +6,7 @@ export {
   type HttpRouteDefinition,
   type InputSource,
 } from './build.js';
+
+// OpenAPI
+export { deriveOpenApiSpec } from './openapi.js';
+export type { OpenApiOptions, OpenApiSpec, OpenApiServer } from './openapi.js';

--- a/packages/http/src/openapi.ts
+++ b/packages/http/src/openapi.ts
@@ -6,14 +6,15 @@
  */
 
 import {
+  ValidationError,
   filterSurfaceTrails,
   statusCodeMap,
-  validateDraftFreeTopo,
+  validateEstablishedTopo,
   zodToJsonSchema,
 } from '@ontrails/core';
 import type { Intent, Topo, Trail } from '@ontrails/core';
 
-import type { JsonSchema } from './types.js';
+type JsonSchema = Readonly<Record<string, unknown>>;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -264,17 +265,20 @@ const buildResponses = (
   }[];
   return {
     ...buildSuccessResponse(t),
-    ...validationErrorResponse,
     ...errorResponsesFromExamples(examples),
+    ...validationErrorResponse,
   };
 };
+
+const operationIdFromTrailId = (trailId: string): string =>
+  trailId.replaceAll('.', '_');
 
 /** Build a complete OpenAPI operation for a trail. */
 const buildOperation = (
   t: Trail<unknown, unknown, unknown>,
   method: string
 ): Record<string, unknown> => ({
-  operationId: t.id.replaceAll('.', '_'),
+  operationId: operationIdFromTrailId(t.id),
   responses: buildResponses(t),
   tags: [tagFromId(t.id)],
   ...(t.description ? { summary: t.description } : {}),
@@ -292,6 +296,8 @@ const collectPaths = (
   options?: OpenApiOptions
 ): Record<string, Record<string, unknown>> => {
   const paths: Record<string, Record<string, unknown>> = {};
+  const seenRoutes = new Map<string, string>();
+  const seenOperationIds = new Map<string, string>();
 
   for (const t of filterSurfaceTrails(graph.list(), {
     exclude: options?.exclude,
@@ -299,9 +305,27 @@ const collectPaths = (
     intent: options?.intent,
   })) {
     const method = intentToMethod[t.intent] ?? 'post';
-    paths[trailIdToPath(t.id, basePath)] = {
-      [method]: buildOperation(t, method),
-    };
+    const path = trailIdToPath(t.id, basePath);
+    const routeKey = `${method.toUpperCase()} ${path}`;
+    const existingId = seenRoutes.get(routeKey);
+    if (existingId !== undefined) {
+      throw new ValidationError(
+        `HTTP route collision: trails "${existingId}" and "${t.id}" both derive ${routeKey}`
+      );
+    }
+    seenRoutes.set(routeKey, t.id);
+
+    const operationId = operationIdFromTrailId(t.id);
+    const existingOperationId = seenOperationIds.get(operationId);
+    if (existingOperationId !== undefined) {
+      throw new ValidationError(
+        `OpenAPI operationId collision: trails "${existingOperationId}" and "${t.id}" both derive operationId "${operationId}"`
+      );
+    }
+    seenOperationIds.set(operationId, t.id);
+
+    paths[path] ??= {};
+    paths[path][method] = buildOperation(t, method);
   }
 
   return paths;
@@ -332,7 +356,7 @@ export const deriveOpenApiSpec = (
   graph: Topo,
   options?: OpenApiOptions
 ): OpenApiSpec => {
-  const validated = validateDraftFreeTopo(graph);
+  const validated = validateEstablishedTopo(graph);
   if (validated.isErr()) {
     throw validated.error;
   }

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -11,7 +11,6 @@ Most applications reach this package through `trails topo export` and `trails to
 - stable hashing for CI drift detection
 - semantic diffing between two surface maps
 - file I/O helpers for `.trails/_surface.json` and `.trails/trails.lock`
-- OpenAPI generation from the same topo contract
 
 The package does not own topo history, pins, or `trails.db`. Those higher-level workflows live in the `trails` app and `@ontrails/core`. `@ontrails/schema` stays focused on serializable artifacts and diffing.
 
@@ -19,7 +18,6 @@ The package does not own topo history, pins, or `trails.db`. Those higher-level 
 
 ```typescript
 import {
-  deriveOpenApiSpec,
   deriveSurfaceMap,
   deriveSurfaceMapDiff,
   deriveSurfaceMapHash,
@@ -40,8 +38,6 @@ const diff = deriveSurfaceMapDiff(map, nextMap);
 if (diff.hasBreaking) {
   console.error('Breaking changes:', diff.breaking);
 }
-
-const openApi = deriveOpenApiSpec(graph);
 ```
 
 `deriveSurfaceMap()` rejects draft-contaminated topos. Only established state can be serialized into the committed artifacts.
@@ -67,7 +63,6 @@ The typical exported artifact pair is:
 | `writeSurfaceLock(lock, options?)` | Write `.trails/trails.lock` as either structured JSON or legacy hash text |
 | `readSurfaceLockData(options?)` | Read the full normalized lock payload from `.trails/trails.lock` |
 | `readSurfaceLock(options?)` | Read just the committed lock hash |
-| `deriveOpenApiSpec(topo, options?)` | Generate an OpenAPI 3.1 document from the topo |
 
 ## Breaking change detection
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -3,10 +3,6 @@ export { deriveSurfaceMap } from './derive.js';
 export { deriveSurfaceMapHash } from './hash.js';
 export { deriveSurfaceMapDiff } from './diff.js';
 
-// OpenAPI
-export { deriveOpenApiSpec } from './openapi.js';
-export type { OpenApiOptions, OpenApiSpec, OpenApiServer } from './openapi.js';
-
 // File I/O
 export {
   writeSurfaceMap,


### PR DESCRIPTION
## Context

[TRL-586](https://linear.app/outfitter/issue/TRL-586/relocate-openapi-generation-to-ontrailshttp-surface) moves OpenAPI projection ownership to the `@ontrails/http` surface so the framework grammar keeps transport-specific generation with HTTP.

## What changed

- Relocates OpenAPI projection APIs out of the general topo/survey path.
- Keeps HTTP-specific projection behavior anchored to the HTTP package surface.
- Updates imports, docs, and tests around the new ownership boundary.

## Testing

- `bun run check`
- `bun run test`
- `bun run build`
