### PR TITLE
feat: add survey brief trail

### DIFF
--- a/.changeset/survey-brief-trail.md
+++ b/.changeset/survey-brief-trail.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": major
+---
+
+Move the brief capability report from the bare `survey` flag surface to the role-anchored `survey.brief` trail.

--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -248,6 +248,7 @@ trails topo export --module ./src/app.ts
 
 # Get the broader machine-readable report
 trails survey --module ./src/app.ts
+trails survey brief --module ./src/app.ts
 ```
 
 Use `trails topo *` for the day-to-day operational flow: inspect the current topo, pin meaningful points, and export or verify the committed lock artifacts. `survey` remains the broader introspection surface for list, detail, diff, and OpenAPI output.

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -30,6 +30,7 @@ import {
   deriveSignalDetail,
   deriveSurveyList,
   deriveTrailDetail,
+  surveyBriefTrail,
   surveyResourceTrail,
   surveySignalTrail,
   surveyTrail,
@@ -292,7 +293,7 @@ describe('trails survey', () => {
 // Brief mode (formerly scout)
 // ---------------------------------------------------------------------------
 
-describe('trails survey --brief', () => {
+describe('trails survey brief', () => {
   test('produces a valid capability report', () => {
     const report = deriveBriefReport(app);
     expect(report.name).toBe('test-app');
@@ -333,6 +334,29 @@ describe('trails survey --brief', () => {
     expect(report.features.detours).toBe(false);
     expect(report.features.resources).toBe(false);
   });
+
+  test('survey.brief returns the brief report directly', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+
+      const report = expectOk(
+        await surveyBriefTrail.blaze({ module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      ) as BriefReport;
+
+      expect(report).toMatchObject({
+        name: 'survey-fixture',
+        resources: 1,
+        trails: 1,
+      });
+      expect('mode' in report).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });
 
 describe('trails survey detail', () => {
@@ -354,24 +378,34 @@ describe('trails survey lookup', () => {
     const detailExample = surveyTrailDetailTrail.examples?.find(
       (example) => example.name === 'Trail detail'
     );
+    const briefExample = surveyBriefTrail.examples?.find(
+      (example) => example.name === 'Brief capability report'
+    );
     const overviewInput = overviewExample?.input as
       | { readonly module?: string; readonly rootDir?: string }
       | undefined;
     const detailInput = detailExample?.input as
       | { readonly module?: string; readonly rootDir?: string }
       | undefined;
+    const briefInput = briefExample?.input as
+      | { readonly module?: string; readonly rootDir?: string }
+      | undefined;
 
     expect(overviewInput?.rootDir).toBeDefined();
     expect(detailInput?.rootDir).toBeDefined();
+    expect(briefInput?.rootDir).toBeDefined();
 
     const parsedOverview = surveyTrail.input.safeParse(overviewInput);
     const parsedDetail = surveyTrailDetailTrail.input.safeParse(detailInput);
+    const parsedBrief = surveyBriefTrail.input.safeParse(briefInput);
 
     expect(parsedOverview.success).toBe(true);
     expect(parsedDetail.success).toBe(true);
-    if (parsedOverview.success && parsedDetail.success) {
+    expect(parsedBrief.success).toBe(true);
+    if (parsedOverview.success && parsedDetail.success && parsedBrief.success) {
       expect(parsedOverview.data.rootDir).toBe(overviewInput?.rootDir);
       expect(parsedDetail.data.rootDir).toBe(detailInput?.rootDir);
+      expect(parsedBrief.data.rootDir).toBe(briefInput?.rootDir);
     }
   });
 
@@ -649,12 +683,6 @@ describe('trails survey output schema', () => {
     ).toBe(true);
     expect(
       surveyTrail.output.safeParse({
-        ...deriveBriefReport(app),
-        mode: 'brief',
-      }).success
-    ).toBe(true);
-    expect(
-      surveyTrail.output.safeParse({
         matches: [
           { detail: deriveTrailDetail(helloTrail), kind: 'trail' },
           {
@@ -675,6 +703,9 @@ describe('trails survey output schema', () => {
         ],
         mode: 'lookup',
       }).success
+    ).toBe(true);
+    expect(
+      surveyBriefTrail.output.safeParse(deriveBriefReport(app)).success
     ).toBe(true);
     expect(
       surveyTrail.output.safeParse({

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -18,7 +18,11 @@ import { devCleanTrail } from '../trails/dev-clean.js';
 import { devResetTrail } from '../trails/dev-reset.js';
 import { devStatsTrail } from '../trails/dev-stats.js';
 import { guideTrail } from '../trails/guide.js';
-import { surveyTrail, surveyTrailDetailTrail } from '../trails/survey.js';
+import {
+  surveyBriefTrail,
+  surveyTrail,
+  surveyTrailDetailTrail,
+} from '../trails/survey.js';
 import { topoExportTrail } from '../trails/topo-export.js';
 import { topoHistoryTrail } from '../trails/topo-history.js';
 import { topoPinTrail } from '../trails/topo-pin.js';
@@ -215,7 +219,7 @@ describe('topo and dev trails', () => {
       });
 
       const surveyBrief = expectOk(
-        await surveyTrail.blaze({ brief: true, module: './src/app.ts' }, {
+        await surveyBriefTrail.blaze({ module: './src/app.ts' }, {
           cwd: dir,
         } as never)
       );
@@ -225,7 +229,6 @@ describe('topo and dev trails', () => {
           outputSchemas: true,
           resources: true,
         },
-        mode: 'brief',
         name: 'fixture-app',
         trails: 2,
       });

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -32,9 +32,11 @@ import {
   trailDetailOutput,
 } from './topo-output-schemas.js';
 import { createIsolatedExampleInput } from './topo-support.js';
+import { briefReportSchema } from './topo-reports.js';
 import { exportCurrentTopo } from './topo-store-support.js';
 
 export {
+  briefReportSchema,
   deriveBriefReport,
   deriveResourceDetail,
   deriveSignalDetail,
@@ -49,7 +51,7 @@ export type {
 } from './topo-reports.js';
 
 // ---------------------------------------------------------------------------
-// Brief report (formerly scout)
+// Survey diff helpers
 // ---------------------------------------------------------------------------
 
 const formatDiff = (diff: DiffResult): object => ({
@@ -141,7 +143,6 @@ const buildSurveyGenerate = async (
 
 interface SurveyInput {
   breakingOnly: boolean;
-  brief: boolean;
   diffSaved: boolean;
   generate: boolean;
   id?: string | undefined;
@@ -149,13 +150,12 @@ interface SurveyInput {
   rootDir?: string | undefined;
 }
 
-type SurveyMode = 'brief' | 'diff' | 'generate' | 'lookup' | 'overview';
+type SurveyMode = 'diff' | 'generate' | 'lookup' | 'overview';
 
 type SurveyEnvelope = { readonly mode: SurveyMode } & Record<string, unknown>;
 
 /** Ordered mode checks — first truthy predicate wins, otherwise 'overview'. */
 const modeChecks: readonly [(input: SurveyInput) => boolean, SurveyMode][] = [
-  [(i) => i.brief, 'brief'],
   [(i) => i.diffSaved, 'diff'],
   [(i) => Boolean(i.id), 'lookup'],
   [(i) => i.generate, 'generate'],
@@ -173,8 +173,6 @@ type SurveyHandler = (
 
 /** Handlers keyed by survey mode. */
 const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
-  brief: (app, _input, rootDir) =>
-    Result.ok(buildCurrentTopoBrief(app, { rootDir })),
   diff: (app, input, rootDir) =>
     buildSurveyDiff(app, rootDir, input.breakingOnly),
   generate: (app, _input, rootDir) => buildSurveyGenerate(app, rootDir),
@@ -230,6 +228,11 @@ const withFreshSurveyApp = async <T>(
   }
 };
 
+const moduleInputSchema = z.object({
+  module: z.string().optional().describe('Path to the app module'),
+  rootDir: z.string().optional().describe('Workspace root directory'),
+});
+
 const surveyMatchOutput = z.discriminatedUnion('kind', [
   z.object({
     detail: trailDetailOutput,
@@ -269,21 +272,12 @@ export const surveyTrail = trail('survey', {
       input: { ...createIsolatedExampleInput('survey-lookup'), id: 'survey' },
       name: 'Lookup by ID',
     },
-    {
-      description: 'Quick capability summary with counts and feature flags',
-      input: {
-        ...createIsolatedExampleInput('survey-brief'),
-        brief: true,
-      },
-      name: 'Brief capability report',
-    },
   ],
   input: z.object({
     breakingOnly: z
       .boolean()
       .default(false)
       .describe('Only show breaking changes'),
-    brief: z.boolean().default(false).describe('Quick capability summary'),
     diffSaved: z
       .boolean()
       .default(false)
@@ -342,22 +336,6 @@ export const surveyTrail = trail('survey', {
       mode: z.literal('lookup'),
     }),
     z.object({
-      contractVersion: z.string(),
-      features: z.object({
-        detours: z.boolean(),
-        examples: z.boolean(),
-        outputSchemas: z.boolean(),
-        resources: z.boolean(),
-        signals: z.boolean(),
-      }),
-      mode: z.literal('brief'),
-      name: z.string(),
-      resources: z.number(),
-      signals: z.number(),
-      trails: z.number(),
-      version: z.string(),
-    }),
-    z.object({
       breaking: z.array(z.unknown()),
       hasBreaking: z.boolean(),
       info: z.array(z.unknown()),
@@ -371,6 +349,26 @@ export const surveyTrail = trail('survey', {
       mode: z.literal('generate'),
     }),
   ]),
+});
+
+export const surveyBriefTrail = trail('survey.brief', {
+  blaze: async (input, ctx) => {
+    const rootDir = resolveRootDir(input, ctx.cwd);
+    return withFreshSurveyApp(input, rootDir, (app) =>
+      Result.ok(buildCurrentTopoBrief(app, { rootDir }))
+    );
+  },
+  description: 'Summarize topo capabilities',
+  examples: [
+    {
+      description: 'Show counts and feature flags',
+      input: createIsolatedExampleInput('survey-brief'),
+      name: 'Brief capability report',
+    },
+  ],
+  input: moduleInputSchema,
+  intent: 'read',
+  output: briefReportSchema,
 });
 
 export const surveyTrailDetailTrail = trail('survey.trail', {

--- a/apps/trails/src/trails/topo-reports.ts
+++ b/apps/trails/src/trails/topo-reports.ts
@@ -1,23 +1,32 @@
 import { zodToJsonSchema } from '@ontrails/core';
 import type { AnyTrail, Signal, Topo } from '@ontrails/core';
+import { z } from 'zod';
 
 import { REPORT_CONTRACT_VERSION, REPORT_VERSION } from './topo-constants.js';
 
-export interface BriefReport {
-  readonly name: string;
-  readonly version: string;
-  readonly contractVersion: string;
-  readonly features: {
-    readonly resources: boolean;
-    readonly outputSchemas: boolean;
-    readonly examples: boolean;
-    readonly detours: boolean;
-    readonly signals: boolean;
-  };
-  readonly trails: number;
-  readonly signals: number;
-  readonly resources: number;
-}
+export const briefReportSchema = z.object({
+  contractVersion: z.string(),
+  features: z.object({
+    detours: z.boolean(),
+    examples: z.boolean(),
+    outputSchemas: z.boolean(),
+    resources: z.boolean(),
+    signals: z.boolean(),
+  }),
+  name: z.string(),
+  resources: z.number(),
+  signals: z.number(),
+  trails: z.number(),
+  version: z.string(),
+});
+
+type BriefReportShape = z.infer<typeof briefReportSchema>;
+
+export type BriefReport = Readonly<
+  Omit<BriefReportShape, 'features'> & {
+    readonly features: Readonly<BriefReportShape['features']>;
+  }
+>;
 
 export interface SurveyListReport {
   readonly count: number;


### PR DESCRIPTION
## Context

[TRL-587](https://linear.app/outfitter/issue/TRL-587/promote-survey-brief-to-surveybrief-trail) promotes brief generation out of the overloaded survey command into its own explicit read-only trail.

## What changed

- Adds the `survey.brief` trail for app briefing output.
- Keeps brief-specific output and tests separate from bare survey overview/lookup behavior.
- Updates CLI coverage around the dedicated brief command.

## Testing

- `bun run check`
- `bun run test`
- `bun run build`
