### PR TITLE
feat: add topo compile trail

### DIFF
--- a/.changeset/topo-compile-trail.md
+++ b/.changeset/topo-compile-trail.md
@@ -1,0 +1,9 @@
+---
+'@ontrails/trails': major
+'@ontrails/warden': patch
+'@ontrails/schema': patch
+---
+
+Introduce `topo.compile` as the canonical trail for writing `.trails` lockfile
+and surface artifacts, remove the `survey --generate` mode, and update drift
+guidance to point at the compile command.

--- a/apps/ci/src/__tests__/governance.test.ts
+++ b/apps/ci/src/__tests__/governance.test.ts
@@ -68,7 +68,7 @@ describe('evaluateCiGovernance', () => {
       [
         '::warning file=apps/example/src/foo.ts,line=12,title=missing-docs::Document this trail',
         '::error file=apps/example/src/bar.ts,line=24,title=implementation-returns-result::Return Result.ok/err instead of throwing',
-        '::error title=drift-detected::trails.lock is stale — regenerate with `trails topo export`',
+        '::error title=drift-detected::trails.lock is stale — regenerate with `trails topo compile`',
       ].join('\n')
     );
   });
@@ -131,7 +131,7 @@ describe('evaluateCiGovernance', () => {
 | error | implementation-returns-result | apps/example/src/bar.ts | 24 | Return Result.ok/err instead of throwing |
 
 ### Drift: stale
-The trails.lock file is out of date. Regenerate with \`trails topo export\`.
+The trails.lock file is out of date. Regenerate with \`trails topo compile\`.
 
 **Result: FAIL**`);
   });

--- a/apps/ci/src/formatters.ts
+++ b/apps/ci/src/formatters.ts
@@ -30,7 +30,7 @@ const formatGitHub = (output: CiOutput): string => {
 
   if (output.driftResult.stale) {
     lines.push(
-      '::error title=drift-detected::trails.lock is stale — regenerate with `trails topo export`'
+      '::error title=drift-detected::trails.lock is stale — regenerate with `trails topo compile`'
     );
   }
 
@@ -82,7 +82,7 @@ const summaryDriftSection = (drift: DriftResult): string[] => {
   if (drift.stale) {
     return [
       '### Drift: stale',
-      'The trails.lock file is out of date. Regenerate with `trails topo export`.',
+      'The trails.lock file is out of date. Regenerate with `trails topo compile`.',
     ];
   }
   return ['### Drift: clean'];

--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -243,8 +243,8 @@ trails survey trail --module ./src/app.ts entity.show
 # See saved topo history and pins
 trails topo history --root-dir .
 
-# Export the committed lock artifacts
-trails topo export --module ./src/app.ts
+# Compile the committed lock artifacts
+trails topo compile --module ./src/app.ts
 
 # Get the broader machine-readable report
 trails survey --module ./src/app.ts
@@ -252,7 +252,7 @@ trails survey brief --module ./src/app.ts
 trails survey diff --module ./src/app.ts
 ```
 
-Use `trails topo *` for the day-to-day operational flow: inspect the current topo, pin meaningful points, and export or verify the committed lock artifacts. `survey` remains the broader introspection surface for list, detail, diff, and OpenAPI output.
+Use `trails topo *` for the day-to-day operational flow: inspect the current topo, pin meaningful points, and compile or verify the committed lock artifacts. `survey` remains the broader introspection surface for list, detail, and diff output.
 
 ## Signals
 

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -38,6 +38,7 @@ import {
   surveyTrailDetailTrail,
 } from '../trails/survey.js';
 import { loadApp } from '../trails/load-app.js';
+import { topoCompileTrail } from '../trails/topo-compile.js';
 import type {
   BriefReport,
   SignalDetailReport,
@@ -587,34 +588,34 @@ describe('trails survey signals section', () => {
   });
 });
 
-describe('trails survey generate', () => {
-  test('delegates to topo export and writes a structured lock', async () => {
+describe('trails topo compile', () => {
+  test('writes the structured topo artifacts', async () => {
     const dir = repoTempDir();
 
     try {
       writeSurveyAppFixture(dir);
 
-      const generated = expectOk(
-        await surveyTrail.blaze({ generate: true, module: './src/app.ts' }, {
+      const compiled = expectOk(
+        await topoCompileTrail.blaze({ module: './src/app.ts' }, {
           cwd: dir,
         } as never)
       ) as {
         readonly hash: string;
         readonly lockPath: string;
         readonly mapPath: string;
-        readonly mode: 'generate';
+        readonly snapshot: unknown;
       };
 
-      expect(generated.mode).toBe('generate');
-      expect(generated.hash).toHaveLength(64);
+      expect(compiled.hash).toHaveLength(64);
       expect(existsSync(join(dir, '.trails', '_surface.json'))).toBe(true);
       expect(existsSync(join(dir, '.trails', 'trails.lock'))).toBe(true);
       expect(
         JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
       ).toMatchObject({
-        hash: generated.hash,
+        hash: compiled.hash,
         version: 1,
       });
+      expect(topoCompileTrail.output.safeParse(compiled).success).toBe(true);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
@@ -646,7 +647,7 @@ describe('trails survey diff', () => {
       } as never);
 
       expect(result.isErr()).toBe(true);
-      expect(result.error.message).toContain('Run `trails topo export` first');
+      expect(result.error.message).toContain('Run `trails topo compile` first');
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
@@ -797,11 +798,18 @@ describe('trails survey output schema', () => {
       }).success
     ).toBe(true);
     expect(
-      surveyTrail.output.safeParse({
+      topoCompileTrail.output.safeParse({
         hash: 'a'.repeat(64),
         lockPath: '.trails/trails.lock',
         mapPath: '.trails/_surface.json',
-        mode: 'generate',
+        snapshot: {
+          createdAt: new Date(0).toISOString(),
+          gitDirty: false,
+          id: 'snapshot-1',
+          resourceCount: 1,
+          signalCount: 0,
+          trailCount: 2,
+        },
       }).success
     ).toBe(true);
     expect(

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -23,7 +23,7 @@ import {
   surveyTrail,
   surveyTrailDetailTrail,
 } from '../trails/survey.js';
-import { topoExportTrail } from '../trails/topo-export.js';
+import { topoCompileTrail } from '../trails/topo-compile.js';
 import { topoHistoryTrail } from '../trails/topo-history.js';
 import { topoPinTrail } from '../trails/topo-pin.js';
 import { topoTrail } from '../trails/topo.js';
@@ -124,7 +124,7 @@ export const app = topo('fixture-app', { ${topoMembers} });
 };
 
 describe('topo and dev trails', () => {
-  test('topo surfaces current summary, detail, and export/verify flow', async () => {
+  test('topo surfaces current summary, detail, and compile/verify flow', async () => {
     const dir = repoTempDir();
 
     try {
@@ -150,17 +150,17 @@ describe('topo and dev trails', () => {
         true
       );
 
-      const exportResult = expectOk(
-        await topoExportTrail.blaze(moduleInput, { cwd: dir } as never)
+      const compileResult = expectOk(
+        await topoCompileTrail.blaze(moduleInput, { cwd: dir } as never)
       );
       const snapshotCountAfterExport = countTopoSnapshots(dir);
-      expect(exportResult.hash).toHaveLength(64);
+      expect(compileResult.hash).toHaveLength(64);
       expect(existsSync(join(dir, '.trails', '_surface.json'))).toBe(true);
       expect(existsSync(join(dir, '.trails', 'trails.lock'))).toBe(true);
       expect(
         JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
       ).toMatchObject({
-        hash: exportResult.hash,
+        hash: compileResult.hash,
         version: 1,
       });
 
@@ -311,17 +311,17 @@ describe('topo and dev trails', () => {
       );
       expect(firstPin.snapshot.pinnedAs).toBe('before-auth');
 
-      const firstExport = expectOk(
-        await topoExportTrail.blaze(moduleInput, { cwd: dir } as never)
+      const firstCompile = expectOk(
+        await topoCompileTrail.blaze(moduleInput, { cwd: dir } as never)
       );
-      const secondExport = expectOk(
-        await topoExportTrail.blaze(moduleInput, { cwd: dir } as never)
+      const secondCompile = expectOk(
+        await topoCompileTrail.blaze(moduleInput, { cwd: dir } as never)
       );
-      expect(firstExport.hash).toBe(secondExport.hash);
+      expect(firstCompile.hash).toBe(secondCompile.hash);
       expect(
         JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
       ).toMatchObject({
-        hash: secondExport.hash,
+        hash: secondCompile.hash,
         version: 1,
       });
 
@@ -336,7 +336,7 @@ describe('topo and dev trails', () => {
           .query<{ count: number }, [string]>(
             'SELECT COUNT(*) as count FROM topo_trails WHERE snapshot_id = ?'
           )
-          .get(firstExport.snapshot.id);
+          .get(firstCompile.snapshot.id);
         const projectedSaves = projectionDb
           .query<{ count: number }, []>(
             'SELECT COUNT(DISTINCT snapshot_id) as count FROM topo_trails'
@@ -400,7 +400,7 @@ describe('topo and dev trails', () => {
       ).toBe(true);
       expect(
         history.snapshots.some(
-          (snapshot) => snapshot.id === secondExport.snapshot.id
+          (snapshot) => snapshot.id === secondCompile.snapshot.id
         )
       ).toBe(true);
 

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -11,6 +11,7 @@ import * as devStats from './trails/dev-stats.js';
 import * as draftPromote from './trails/draft-promote.js';
 import * as guide from './trails/guide.js';
 import * as survey from './trails/survey.js';
+import * as topoCompile from './trails/topo-compile.js';
 import * as topoExport from './trails/topo-export.js';
 import * as topoHistory from './trails/topo-history.js';
 import * as topoPin from './trails/topo-pin.js';
@@ -23,6 +24,7 @@ export const app = topo(
   'trails',
   survey,
   topoCommand,
+  topoCompile,
   topoHistory,
   topoPin,
   topoUnpin,

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -1,8 +1,8 @@
 /**
  * `survey` trail -- Full topo introspection.
  *
- * Lists trails, looks up trails/resources/signals, generates surface maps,
- * and diffs against previous versions.
+ * Lists trails, looks up trails/resources/signals, and diffs against previous
+ * versions.
  */
 
 import { extname, join } from 'node:path';
@@ -42,7 +42,6 @@ import {
 } from './topo-output-schemas.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 import { briefReportSchema } from './topo-reports.js';
-import { exportCurrentTopo } from './topo-store-support.js';
 
 export {
   briefReportSchema,
@@ -158,7 +157,7 @@ const readAgainstSurfaceMap = async (
     return map === null
       ? Result.err(
           new NotFoundError(
-            'No saved surface map found. Run `trails topo export` first.'
+            'No saved surface map found. Run `trails topo compile` first.'
           )
         )
       : Result.ok({ against: 'saved', map });
@@ -244,41 +243,19 @@ const buildSurveySignalDetail = (
     : Result.ok(detail);
 };
 
-const buildSurveyGenerate = async (
-  app: Topo,
-  rootDir: string
-): Promise<Result<object, Error>> => {
-  const exported = await exportCurrentTopo(app, { rootDir });
-  if (exported.isErr()) {
-    return exported;
-  }
-  return Result.ok({
-    hash: exported.value.hash,
-    lockPath: exported.value.lockPath,
-    mapPath: exported.value.mapPath,
-  });
-};
-
 interface SurveyInput {
-  generate: boolean;
   id?: string | undefined;
   module?: string | undefined;
   rootDir?: string | undefined;
 }
 
-type SurveyMode = 'generate' | 'lookup' | 'overview';
+type SurveyMode = 'lookup' | 'overview';
 
 type SurveyEnvelope = { readonly mode: SurveyMode } & Record<string, unknown>;
 
-/** Ordered mode checks — first truthy predicate wins, otherwise 'overview'. */
-const modeChecks: readonly [(input: SurveyInput) => boolean, SurveyMode][] = [
-  [(i) => Boolean(i.id), 'lookup'],
-  [(i) => i.generate, 'generate'],
-];
-
 /** Determine which survey mode was requested, falling back to 'overview'. */
 const deriveSurveyMode = (input: SurveyInput): SurveyMode =>
-  modeChecks.find(([predicate]) => predicate(input))?.[1] ?? 'overview';
+  input.id === undefined || input.id === '' ? 'overview' : 'lookup';
 
 type SurveyHandler = (
   app: Topo,
@@ -288,7 +265,6 @@ type SurveyHandler = (
 
 /** Handlers keyed by survey mode. */
 const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
-  generate: (app, _input, rootDir) => buildSurveyGenerate(app, rootDir),
   lookup: (app, input, rootDir) =>
     input.id === undefined || input.id === ''
       ? Result.err(new ValidationError('Survey lookup requires an id'))
@@ -404,10 +380,6 @@ export const surveyTrail = trail('survey', {
     },
   ],
   input: z.object({
-    generate: z
-      .boolean()
-      .default(false)
-      .describe('Generate surface map and lock file'),
     id: z
       .string()
       .optional()
@@ -456,12 +428,6 @@ export const surveyTrail = trail('survey', {
     z.object({
       matches: z.array(surveyMatchOutput),
       mode: z.literal('lookup'),
-    }),
-    z.object({
-      hash: z.string(),
-      lockPath: z.string(),
-      mapPath: z.string(),
-      mode: z.literal('generate'),
     }),
   ]),
 });

--- a/apps/trails/src/trails/topo-compile.ts
+++ b/apps/trails/src/trails/topo-compile.ts
@@ -1,14 +1,21 @@
 import { trail } from '@ontrails/core';
+import type { Result, Topo } from '@ontrails/core';
 import { z } from 'zod';
 
 import { loadFreshAppLease } from './load-app.js';
-import { compileCurrentTopo } from './topo-compile.js';
+import { exportCurrentTopo } from './topo-store-support.js';
+import type { TopoExportReport } from './topo-support.js';
 import {
   createIsolatedExampleInput,
   topoSnapshotOutput,
 } from './topo-support.js';
 
-export const topoExportTrail = trail('topo.export', {
+export const compileCurrentTopo = async (
+  app: Topo,
+  options?: { readonly rootDir?: string }
+): Promise<Result<TopoExportReport, Error>> => exportCurrentTopo(app, options);
+
+export const topoCompileTrail = trail('topo.compile', {
   blaze: async (input, ctx) => {
     const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
     const lease = await loadFreshAppLease(input.module, rootDir);
@@ -18,11 +25,11 @@ export const topoExportTrail = trail('topo.export', {
       lease.release();
     }
   },
-  description: 'Legacy alias for compiling the current topo artifacts',
+  description: 'Compile the current topo to .trails artifacts',
   examples: [
     {
-      input: createIsolatedExampleInput('topo-export'),
-      name: 'Compile the current topo artifacts through the legacy export alias',
+      input: createIsolatedExampleInput('topo-compile'),
+      name: 'Compile the current topo artifacts',
     },
   ],
   input: z.object({

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -186,7 +186,7 @@ export const verifyCurrentTopo = async (
   if (committedLock === null) {
     return Result.err(
       new NotFoundError(
-        'No committed trails.lock found. Run `trails topo export` first.'
+        'No committed trails.lock found. Run `trails topo compile` first.'
       )
     );
   }
@@ -200,7 +200,7 @@ export const verifyCurrentTopo = async (
   if (committedLock.hash !== currentHash) {
     return Result.err(
       new ConflictError(
-        'trails.lock is stale. Run `trails topo export` to refresh it.'
+        'trails.lock is stale. Run `trails topo compile` to refresh it.'
       )
     );
   }

--- a/docs/adr/0014-core-database-primitive.md
+++ b/docs/adr/0014-core-database-primitive.md
@@ -144,7 +144,7 @@ trails topo history                 # List pins and recent autosaves
 trails topo pin "name"              # Pin the current topo snapshot
 trails topo diff --since "name"     # Structural diff since a pin or prior snapshot
 trails topo unpin "name"            # Remove a pin but keep the underlying snapshot eligible for pruning
-trails topo export                  # Write .trails/trails.lock from the current topo
+trails topo compile                 # Write .trails/trails.lock from the current topo
 trails topo verify                  # Verify .trails/trails.lock reflects the current topo
 
 # Developer maintenance

--- a/docs/adr/0015-topo-store.md
+++ b/docs/adr/0015-topo-store.md
@@ -284,7 +284,7 @@ This is the `trails topo diff` concept made continuous. The lockfile captures th
 The lockfile (`.trails/trails.lock`) becomes a deterministic text export of the current topo state:
 
 ```bash
-trails topo export          # Write .trails/trails.lock from the current topo
+trails topo compile         # Write .trails/trails.lock from the current topo
 trails topo diff --lock     # Compare current topo against .trails/trails.lock
 trails topo verify          # CI: fail if .trails/trails.lock is stale
 ```

--- a/docs/adr/0017-serialized-topo-graph.md
+++ b/docs/adr/0017-serialized-topo-graph.md
@@ -13,7 +13,7 @@ depends_on: [7, 8]
 
 ## Context
 
-Earlier implementations produced `trailhead.lock` via `trails survey generate`. That file captured the derived surface shape (MCP tool names, CLI commands, HTTP routes) as a diffable, hashable artifact. CI compared it against the current topo to detect unintentional contract changes.
+Earlier implementations produced `trailhead.lock` through the legacy survey generation mode. That file captured the derived surface shape (MCP tool names, CLI commands, HTTP routes) as a diffable, hashable artifact. CI compared it against the current topo to detect unintentional contract changes.
 
 As the framework grows, more resolved state needs the same treatment: surfaces, signals, fires, resources, config, the reactive graph. Each is "resolved state of the system that should be diffable and governable." Splitting them into separate lockfiles creates multiple files to commit, multiple CI checks to configure, and multiple commands to remember.
 
@@ -99,16 +99,16 @@ This means:
 ### Generation and lifecycle
 
 ```bash
-trails topo export           # write .trails/trails.lock from current topo
+trails topo compile          # write .trails/trails.lock from current topo
 trails topo verify           # verify .trails/trails.lock matches current topo (CI mode)
 trails topo diff --lock      # show lockfile drift against current topo
 ```
 
-`trails topo export` replaces the old lock-focused command shape. The command now centers on the thing being exported rather than on the artifact. `verify` is the CI layer. `diff --lock` is the developer feedback loop.
+`trails topo compile` replaces the old lock-focused command shape. The command now centers on the resolved topo artifacts rather than on only the lockfile. `trails topo export` remains a legacy alias for compile. `verify` is the CI layer. `diff --lock` is the developer feedback loop.
 
 The lockfile is:
 
-- **Generated** by `trails topo export` from the current code. In manual workflows this is explicit, like `bun install` generating `bun.lock`. Signal-driven flows can invoke the same trail automatically from topo snapshots or pins.
+- **Generated** by `trails topo compile` from the current code. In manual workflows this is explicit, like `bun install` generating `bun.lock`. Signal-driven flows can invoke the same trail automatically from topo snapshots or pins.
 - **Checked in** to source control. A PR that changes trail contracts produces a lockfile diff.
 - **CI-diffable.** `trails topo verify` fails if the lockfile doesn't match the current code. Drift between code and lockfile is caught before merge.
 - **The saved record of resolved state.** Not a cache, not a convenience. A commitment: "this is the resolved state of the system at this point in time."
@@ -139,9 +139,8 @@ The `--app` flag is an override for the collision case, not a required parameter
 
 The lockfile captures the full reactive graph: which signals trigger which trails, which trails fire which signals, the complete activation chain. This makes the reactive graph inspectable without running the app:
 
-```bash
+```text
 # Derived from the lockfile
-trails topo show --reactive
 webhook:stripe → booking.confirm → booking.confirmed → notify.booking-confirmed
                                                       → audit.log-write
 ```
@@ -160,13 +159,13 @@ webhook:stripe → booking.confirm → booking.confirmed → notify.booking-conf
 ### Tradeoffs
 
 - **Larger file over time.** As the topo grows, the lockfile grows. For most projects this is manageable. For very large workspaces, the graph structure helps: changes to one trail only affect that trail's node and its edges.
-- **Requires topo export to stay current.** A stale lockfile means stale resolution. `trails topo verify` in CI catches this, but a manual workflow must still export after contract changes unless a save- or pin-driven automation does it.
+- **Requires topo compile to stay current.** A stale lockfile means stale resolution. `trails topo verify` in CI catches this, but a manual workflow must still compile after contract changes unless a save- or pin-driven automation does it.
 - **Graph format is more complex than flat sections.** A section-per-concern format is simpler to understand at first glance. The graph format is more powerful but requires understanding the node/edge model. The tradeoff favors power: the lockfile is primarily machine-read (by agents, CI, framework commands), not human-read.
 
 ### What this does NOT decide
 
 - **The exact schema for each node type.** Trail nodes, signal nodes, and resource nodes will gain properties as their respective ADRs ship. The graph structure is stable; the node schemas evolve.
-- **Whether sections can be independently regenerated** (e.g., `trails topo export --only surfaces`). Future ergonomic improvement if needed.
+- **Whether sections can be independently regenerated** (e.g., `trails topo compile --only surfaces`). Future ergonomic improvement if needed.
 - **Whether the format is JSON, JSONC, or another structured format.** JSON is the default for machine-generated artifacts. If comments become valuable, JSONC is a backward-compatible extension.
 - **Resource contract snapshots.** How provisioned packs record their contract state in the lockfile. The resources ADR defines this.
 - **Rig lock state.** How rigged external surfaces record their resolved state. The rig ADR defines this.

--- a/docs/adr/0018-signal-driven-governance.md
+++ b/docs/adr/0018-signal-driven-governance.md
@@ -252,7 +252,7 @@ The trails are environment-agnostic. The topo composition determines what's acti
 - [ADR-0000: Core Premise](0000-core-premise.md) — "examples are structured data," "the contract is queryable"
 - [ADR-0014: Core Database Primitive](0014-core-database-primitive.md) — the `trails.db` foundation
 - [ADR-0015: Topo Store](0015-topo-store.md) — the read-only resource that governance trails query
-- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) — topo export, verify, and lockfile-as-projection semantics
+- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) — topo compile, verify, and lockfile-as-projection semantics
 - [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — app-level persistence using the same resource patterns
 
 ### Amendment log

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -115,7 +115,7 @@
           "fromPath": "docs/adr/0035-surface-apis-render-the-graph.md"
         },
         {
-          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) — \"the trail is the unit of everything\"; this ADR enforces that at the package boundary",
+          "context": "The [drift guard in ADR-0000](0000-core-premise.md) prefers derivation over lint-time checks. The implementation should evaluate structural derivation for properties 1 and 2 first, and fall back to a ",
           "from": "0036",
           "fromPath": "docs/adr/0036-warden-rules-ship-only-as-trails.md"
         },
@@ -643,7 +643,7 @@
           "fromPath": "docs/adr/0025-composition-testing.md"
         },
         {
-          "context": "[ADR-0007](0007-governance-as-trails.md) made warden rules into trails. Every rule is wrapped via `wrapRule()` into a trail with ID `warden.rule.<name>`, gets a schema, examples, and runs through t",
+          "context": "[ADR-0007](0007-governance-as-trails.md) made warden rules into trails internally. Every rule is wrapped via `wrapRule()` into a trail with ID `warden.rule.<name>`, gets a schema, examples, and runs t",
           "from": "0036",
           "fromPath": "docs/adr/0036-warden-rules-ship-only-as-trails.md"
         },
@@ -665,7 +665,7 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Governance as Trails with AST-Based Analysis",
-      "updated": "2026-04-01"
+      "updated": "2026-04-22"
     },
     {
       "created": "2026-03-29",
@@ -1208,7 +1208,7 @@
           "fromPath": "docs/adr/0015-topo-store.md"
         },
         {
-          "context": "- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) — topo export, verify, and lockfile-as-projection semantics",
+          "context": "- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) — topo compile, verify, and lockfile-as-projection semantics",
           "from": "0018",
           "fromPath": "docs/adr/0018-signal-driven-governance.md"
         },
@@ -1910,7 +1910,13 @@
     {
       "created": "2026-04-20",
       "depends_on": ["0", "7"],
-      "inbound": [],
+      "inbound": [
+        {
+          "context": "4. Wrap built-in rules as trails, in line with [ADR-0036](./adr/0036-warden-rules-ship-only-as-trails.md).",
+          "from": "warden",
+          "fromPath": "docs/warden.md"
+        }
+      ],
       "number": "0036",
       "owners": ["[galligan](https://github.com/galligan)"],
       "path": "docs/adr/0036-warden-rules-ship-only-as-trails.md",

--- a/docs/adr/drafts/20260331-direct-invocation.md
+++ b/docs/adr/drafts/20260331-direct-invocation.md
@@ -562,7 +562,7 @@ Trail IDs are completed from the topo. Example names are completed from the trai
 
 ### Tradeoffs
 
-- **Depends on the lockfile.** `trails run` resolves trails through `trails.lock`. The lockfile must be current. A stale lockfile could point to a trail that's been renamed or removed. `trails topo export` (or a pin-driven export workflow) becomes a prerequisite for accurate resolution.
+- **Depends on the lockfile.** `trails run` resolves trails through `trails.lock`. The lockfile must be current. A stale lockfile could point to a trail that's been renamed or removed. `trails topo compile` (or a pin-driven compile workflow) becomes a prerequisite for accurate resolution.
 - **Reactive chains can cascade.** `trails run` with triggers enabled means one invocation could trigger a chain of trail executions. With `--tracing` this is visible. Without it, the cascading triggers are silent. A developer exploring a trail might not expect their invocation to trigger five downstream trails.
 - **Watch mode requires file watching.** Adds a dependency on file system watching (Bun handles this natively). For large projects, file watching can be resource-intensive, though scoping to the trail's source file and its dependencies mitigates this.
 

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -188,7 +188,7 @@
       "status": "draft",
       "superseded_by": null,
       "title": "Layer Evolution",
-      "updated": "2026-04-09"
+      "updated": "2026-04-28"
     },
     {
       "created": "2026-04-09",

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@
 ## Governing your codebase?
 
 - **[Warden](./warden.md)** — Trails correctness rules, rule-home boundaries, drift detection, CI integration
-- **[Schema](../packages/schema/README.md)** — Surface maps, topo export helpers, semantic diffing, lock files
+- **[Schema](../packages/schema/README.md)** — Surface maps, topo compile helpers, semantic diffing, lock files
 
 ## Design decisions
 

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -16,12 +16,12 @@ Trails creates a `.trails/` directory in your workspace root on first use:
 ├── generated/             # Generated artifacts (gitignored)
 ├── trails.db              # SQLite database (topology store)
 ├── trails.lock            # Lockfile (text, git-tracked)
-└── _surface.json          # Full surface map (generated on export)
+└── _surface.json          # Full surface map (compiled artifact)
 ```
 
 - **`trails.db`** — SQLite database containing all topo saves, pins, and schema cache. Not git-tracked.
 - **`trails.lock`** — Committed lockfile. Text format, git-tracked. This is your contract's current state for CI.
-- **`_surface.json`** — Full surface map with all metadata, generated on export.
+- **`_surface.json`** — Full surface map with all metadata, written by `topo compile`.
 
 ## What trails.db contains
 
@@ -77,12 +77,12 @@ List saved topo states (pinned and recent autosaves).
 trails topo history --limit 20
 ```
 
-### `trails topo export`
+### `trails topo compile`
 
-Export the current topo to `.trails/trails.lock` and `.trails/_surface.json`.
+Compile the current topo to `.trails/trails.lock` and `.trails/_surface.json`.
 
 ```bash
-trails topo export
+trails topo compile
 ```
 
 ### `trails topo verify`
@@ -99,7 +99,7 @@ trails topo verify || exit 1
 ### Pre-deployment
 
 1. Make topology changes
-2. Export: `trails topo export`
+2. Compile: `trails topo compile`
 3. Commit `.trails/trails.lock`
 4. In CI, verify: `trails topo verify`
 
@@ -108,7 +108,7 @@ trails topo verify || exit 1
 ```bash
 trails topo pin --name pre-refactor
 # ... make changes ...
-trails topo export
+trails topo compile
 # Compare lockfile diff against the pinned baseline
 ```
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -2,7 +2,7 @@
 
 Deterministic surface maps, lockfile helpers, and semantic diffing for Trails.
 
-Most applications reach this package through `trails topo export` and `trails topo verify`. Those CLI trails layer workspace and topo-store behavior on top of the low-level building blocks in `@ontrails/schema`.
+Most applications reach this package through `trails topo compile` and `trails topo verify`. Those CLI trails layer workspace and topo-store behavior on top of the low-level building blocks in `@ontrails/schema`.
 
 ## What it owns
 
@@ -49,7 +49,7 @@ The typical exported artifact pair is:
 - `.trails/_surface.json` — detailed derived map, useful for inspection and diffing
 - `.trails/trails.lock` — committed lock artifact, stored as structured JSON or legacy hash-only text
 
-`trails topo export` writes both from the current topo. `trails topo verify` and `@ontrails/warden` use the lockfile helpers here to detect drift.
+`trails topo compile` writes both from the current topo. `trails topo verify` and `@ontrails/warden` use the lockfile helpers here to detect drift.
 
 ## API
 

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -56,7 +56,7 @@ import { checkDrift } from '@ontrails/warden';
 
 const drift = await checkDrift(process.cwd(), graph);
 if (drift.stale) {
-  console.log('lock file is stale -- regenerate with `trails topo export`');
+  console.log('lock file is stale -- regenerate with `trails topo compile`');
 }
 ```
 

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -693,7 +693,7 @@ const formatDriftSection = (drift: DriftResult | null): string[] => {
     return [`Drift: blocked (${drift.blockedReason})`, ''];
   }
   const label = drift.stale
-    ? 'Drift: trails.lock is stale (regenerate with `trails topo export`)'
+    ? 'Drift: trails.lock is stale (regenerate with `trails topo compile`)'
     : 'Drift: clean';
   return [label, ''];
 };

--- a/packages/warden/src/formatters.ts
+++ b/packages/warden/src/formatters.ts
@@ -36,7 +36,7 @@ export const formatGitHubAnnotations = (report: WardenReport): string => {
     lines.push(`::error::drift: ${report.drift.blockedReason}`);
   } else if (report.drift?.stale) {
     lines.push(
-      '::error::drift: trails.lock is stale (regenerate with `trails topo export`)'
+      '::error::drift: trails.lock is stale (regenerate with `trails topo compile`)'
     );
   }
 
@@ -99,7 +99,7 @@ const driftSection = (drift: WardenReport['drift']): readonly string[] => {
   return [
     '',
     '### Drift',
-    '- trails.lock is stale (regenerate with `trails topo export`)',
+    '- trails.lock is stale (regenerate with `trails topo compile`)',
   ];
 };
 

--- a/packages/warden/src/rules/draft-visible-debt.ts
+++ b/packages/warden/src/rules/draft-visible-debt.ts
@@ -68,7 +68,7 @@ const collectDraftVisibleDebtDiagnostics = (
  *
  * Severity is intentionally `warn`, not `error`. The hard rejection layer for
  * draft state leaking into established outputs is `validateEstablishedTopo` at
- * runtime — it blocks topo export, trailhead projection, and lockfile writes.
+ * runtime — it blocks topo compile, trailhead projection, and lockfile writes.
  * This rule surfaces the debt for human reviewers without duplicating that layer.
  */
 export const draftVisibleDebt: WardenRule = {

--- a/plugin/agents/trail-engineer.md
+++ b/plugin/agents/trail-engineer.md
@@ -46,7 +46,7 @@ If the feature is complex, sketch the contract and get user alignment before imp
 Add the module import to the topo file. Verify the trail appears:
 
 ```bash
-trails survey --brief
+trails survey brief
 ```
 
 ### 5. Test
@@ -96,7 +96,7 @@ If warden reports drift:
 
 ```bash
 trails warden --drift-only
-trails topo export
+trails topo compile
 trails topo verify
 ```
 

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -224,7 +224,7 @@ The warden enforces conventions and detects drift:
 ```bash
 trails warden          # Convention checks
 trails warden --drift-only # Contract drift vs lockfile
-trails topo export         # Regenerate committed topo artifacts
+trails topo compile        # Regenerate committed topo artifacts
 trails topo verify         # Verify committed topo artifacts
 ```
 

--- a/plugin/skills/trails/references/migration-checklist.md
+++ b/plugin/skills/trails/references/migration-checklist.md
@@ -62,7 +62,7 @@ For each handler:
 ## Phase 6: Governance
 
 - [ ] `trails warden` reports clean
-- [ ] Regenerate topo artifacts: `trails topo export`
+- [ ] Regenerate topo artifacts: `trails topo compile`
 - [ ] Verify topo artifacts: `trails topo verify`
 - [ ] Add lock check to CI
 


### PR DESCRIPTION
## Context

[TRL-589](https://linear.app/outfitter/issue/TRL-589/introduce-topocompile-for-lockfile-generation-remove-survey) makes topo artifact generation an explicit topo write operation instead of a `survey --generate` side effect.

## What changed

- Adds `topo.compile` as the canonical trail for writing `.trails` lockfile/map artifacts.
- Removes the survey generate mode so bare survey remains read-only overview/lookup behavior.
- Keeps `topo.export` as a legacy alias while updating active docs and drift guidance to `trails topo compile`.

## Testing

- `bun run check`
- `bun run test`
- `bun run build`
