### PR TITLE
feat: add owner-held error code table

### DIFF
--- a/packages/core/src/__tests__/errors.test.ts
+++ b/packages/core/src/__tests__/errors.test.ts
@@ -16,6 +16,8 @@ import {
   AuthError,
   CancelledError,
   RetryExhaustedError,
+  codesByCategory,
+  errorCategories,
   exitCodeMap,
   statusCodeMap,
   jsonRpcCodeMap,
@@ -203,6 +205,69 @@ describe('RateLimitError.retryAfter', () => {
 // ---------------------------------------------------------------------------
 // Taxonomy maps
 // ---------------------------------------------------------------------------
+
+describe('codesByCategory', () => {
+  test('maps all categories to expected exit, HTTP, and JSON-RPC codes', () => {
+    expect(codesByCategory.validation).toEqual({
+      exit: 1,
+      http: 400,
+      jsonRpc: -32_602,
+    });
+    expect(codesByCategory.not_found).toEqual({
+      exit: 2,
+      http: 404,
+      jsonRpc: -32_601,
+    });
+    expect(codesByCategory.conflict).toEqual({
+      exit: 3,
+      http: 409,
+      jsonRpc: -32_603,
+    });
+    expect(codesByCategory.permission).toEqual({
+      exit: 4,
+      http: 403,
+      jsonRpc: -32_600,
+    });
+    expect(codesByCategory.timeout).toEqual({
+      exit: 5,
+      http: 504,
+      jsonRpc: -32_603,
+    });
+    expect(codesByCategory.rate_limit).toEqual({
+      exit: 6,
+      http: 429,
+      jsonRpc: -32_603,
+    });
+    expect(codesByCategory.network).toEqual({
+      exit: 7,
+      http: 502,
+      jsonRpc: -32_603,
+    });
+    expect(codesByCategory.internal).toEqual({
+      exit: 8,
+      http: 500,
+      jsonRpc: -32_603,
+    });
+    expect(codesByCategory.auth).toEqual({
+      exit: 9,
+      http: 401,
+      jsonRpc: -32_600,
+    });
+    expect(codesByCategory.cancelled).toEqual({
+      exit: 130,
+      http: 499,
+      jsonRpc: -32_603,
+    });
+  });
+
+  test('drives the legacy per-surface maps', () => {
+    for (const category of errorCategories) {
+      expect(exitCodeMap[category]).toBe(codesByCategory[category].exit);
+      expect(statusCodeMap[category]).toBe(codesByCategory[category].http);
+      expect(jsonRpcCodeMap[category]).toBe(codesByCategory[category].jsonRpc);
+    }
+  });
+});
 
 describe('exitCodeMap', () => {
   test('maps all categories to expected exit codes', () => {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -181,44 +181,50 @@ export class RetryExhaustedError<
 // Taxonomy maps
 // ---------------------------------------------------------------------------
 
-export const exitCodeMap = {
-  auth: 9,
-  cancelled: 130,
-  conflict: 3,
-  internal: 8,
-  network: 7,
-  not_found: 2,
-  permission: 4,
-  rate_limit: 6,
-  timeout: 5,
-  validation: 1,
-} as const satisfies Record<ErrorCategory, number>;
+export interface ErrorCategoryCodes {
+  readonly exit: number;
+  readonly http: number;
+  readonly jsonRpc: number;
+}
 
-export const statusCodeMap = {
-  auth: 401,
-  cancelled: 499,
-  conflict: 409,
-  internal: 500,
-  network: 502,
-  not_found: 404,
-  permission: 403,
-  rate_limit: 429,
-  timeout: 504,
-  validation: 400,
-} as const satisfies Record<ErrorCategory, number>;
+export const codesByCategory = {
+  auth: { exit: 9, http: 401, jsonRpc: -32_600 },
+  cancelled: { exit: 130, http: 499, jsonRpc: -32_603 },
+  conflict: { exit: 3, http: 409, jsonRpc: -32_603 },
+  internal: { exit: 8, http: 500, jsonRpc: -32_603 },
+  network: { exit: 7, http: 502, jsonRpc: -32_603 },
+  not_found: { exit: 2, http: 404, jsonRpc: -32_601 },
+  permission: { exit: 4, http: 403, jsonRpc: -32_600 },
+  rate_limit: { exit: 6, http: 429, jsonRpc: -32_603 },
+  timeout: { exit: 5, http: 504, jsonRpc: -32_603 },
+  validation: { exit: 1, http: 400, jsonRpc: -32_602 },
+} as const satisfies Record<ErrorCategory, ErrorCategoryCodes>;
 
-export const jsonRpcCodeMap = {
-  auth: -32_600,
-  cancelled: -32_603,
-  conflict: -32_603,
-  internal: -32_603,
-  network: -32_603,
-  not_found: -32_601,
-  permission: -32_600,
-  rate_limit: -32_603,
-  timeout: -32_603,
-  validation: -32_602,
-} as const satisfies Record<ErrorCategory, number>;
+const deriveCodeMap = <TCode extends keyof ErrorCategoryCodes>(
+  code: TCode
+): {
+  readonly [TCategory in ErrorCategory]: (typeof codesByCategory)[TCategory][TCode];
+} => ({
+  auth: codesByCategory.auth[code],
+  cancelled: codesByCategory.cancelled[code],
+  conflict: codesByCategory.conflict[code],
+  internal: codesByCategory.internal[code],
+  network: codesByCategory.network[code],
+  not_found: codesByCategory.not_found[code],
+  permission: codesByCategory.permission[code],
+  rate_limit: codesByCategory.rate_limit[code],
+  timeout: codesByCategory.timeout[code],
+  validation: codesByCategory.validation[code],
+});
+
+/** @deprecated Prefer `codesByCategory[category].exit`. */
+export const exitCodeMap = deriveCodeMap('exit');
+
+/** @deprecated Prefer `codesByCategory[category].http`. */
+export const statusCodeMap = deriveCodeMap('http');
+
+/** @deprecated Prefer `codesByCategory[category].jsonRpc`. */
+export const jsonRpcCodeMap = deriveCodeMap('jsonRpc');
 
 export const retryableMap: Record<ErrorCategory, boolean> = {
   auth: false,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export {
   AuthError,
   CancelledError,
   DerivationError,
+  codesByCategory,
   errorCategories,
   exitCodeMap,
   statusCodeMap,
@@ -28,7 +29,7 @@ export {
   isRetryable,
   isTrailsError,
 } from './errors.js';
-export type { ErrorCategory } from './errors.js';
+export type { ErrorCategory, ErrorCategoryCodes } from './errors.js';
 export {
   createTransportErrorMapper,
   mapTransportError,

--- a/packages/core/src/transport-error-map.ts
+++ b/packages/core/src/transport-error-map.ts
@@ -1,9 +1,24 @@
-import type { ErrorCategory, TrailsError } from './errors.js';
-import { exitCodeMap, jsonRpcCodeMap, statusCodeMap } from './errors.js';
+import type {
+  ErrorCategory,
+  ErrorCategoryCodes,
+  TrailsError,
+} from './errors.js';
+import {
+  codesByCategory,
+  exitCodeMap,
+  jsonRpcCodeMap,
+  statusCodeMap,
+} from './errors.js';
 
 export const transportNames = ['cli', 'http', 'mcp'] as const;
 
 export type TransportName = (typeof transportNames)[number];
+
+const transportCodeKeys = {
+  cli: 'exit',
+  http: 'http',
+  mcp: 'jsonRpc',
+} as const satisfies Record<TransportName, keyof ErrorCategoryCodes>;
 
 export type TransportErrorMapper<T> = (error: TrailsError) => T;
 
@@ -22,7 +37,7 @@ export type TransportErrorMappings<T> = Record<ErrorCategory, T>;
  * what `mapTransportError` returns at the call site.
  */
 export type TransportErrorCode =
-  (typeof transportErrorMap)[TransportName][ErrorCategory];
+  (typeof codesByCategory)[ErrorCategory][(typeof transportCodeKeys)[TransportName]];
 
 export const createTransportErrorMapper =
   <T>(mappings: TransportErrorMappings<T>): TransportErrorMapper<T> =>
@@ -58,4 +73,4 @@ export type MapTransportError = (
 export const mapTransportError: MapTransportError = (
   transport: TransportName,
   error: TrailsError
-) => transportErrorMap[transport][error.category];
+) => codesByCategory[error.category][transportCodeKeys[transport]];


### PR DESCRIPTION
## Context

Moves error-code grouping to the error owner so downstream projections stop maintaining parallel category tables.

## Changes

- Adds a typed owner-held codesByCategory table in core errors.
- Derives the legacy maps from the owner data for compatibility.
- Adds tests around the owner table and existing public behavior.

## Testing

- Focused core tests plus PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->