### PR TITLE
feat: add owner-held error class registry

### DIFF
--- a/packages/core/src/__tests__/errors.test.ts
+++ b/packages/core/src/__tests__/errors.test.ts
@@ -9,14 +9,17 @@ import {
   AlreadyExistsError,
   ConflictError,
   PermissionError,
+  PermitError,
   TimeoutError,
   RateLimitError,
   NetworkError,
   InternalError,
+  DerivationError,
   AuthError,
   CancelledError,
   RetryExhaustedError,
   codesByCategory,
+  errorClasses,
   errorCategories,
   exitCodeMap,
   statusCodeMap,
@@ -83,6 +86,12 @@ const errorMatrix: readonly {
     retryable: false,
   },
   {
+    Class: PermitError,
+    category: 'permission',
+    name: 'PermitError',
+    retryable: false,
+  },
+  {
     Class: TimeoutError,
     category: 'timeout',
     name: 'TimeoutError',
@@ -104,6 +113,12 @@ const errorMatrix: readonly {
     Class: InternalError,
     category: 'internal',
     name: 'InternalError',
+    retryable: false,
+  },
+  {
+    Class: DerivationError,
+    category: 'internal',
+    name: 'DerivationError',
     retryable: false,
   },
   { Class: AuthError, category: 'auth', name: 'AuthError', retryable: false },
@@ -172,6 +187,50 @@ describe('error classes', () => {
       });
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Error class registry
+// ---------------------------------------------------------------------------
+
+describe('errorClasses', () => {
+  test('represents every concrete TrailsError subclass', () => {
+    const registeredConstructors = new Set(
+      errorClasses.map(({ ctor }) => ctor)
+    );
+    const expectedConstructors = new Set([
+      ...errorMatrix.map(({ Class }) => Class),
+      RetryExhaustedError,
+    ]);
+
+    expect(registeredConstructors).toEqual(expectedConstructors);
+    expect(errorClasses).toHaveLength(expectedConstructors.size);
+  });
+
+  test('carries fixed category metadata without requiring instantiation', () => {
+    const fixedErrorClasses = errorClasses.filter(
+      (entry) => entry.category !== 'dynamic'
+    );
+
+    expect(fixedErrorClasses).toEqual(
+      errorMatrix.map(({ Class, category, name, retryable }) => ({
+        category,
+        ctor: Class,
+        name,
+        retryable,
+      }))
+    );
+  });
+
+  test('models RetryExhaustedError as a dynamic-category class', () => {
+    expect(errorClasses.at(-1)).toEqual({
+      category: 'dynamic',
+      ctor: RetryExhaustedError,
+      inheritsCategoryFrom: 'wrapped-error',
+      name: 'RetryExhaustedError',
+      retryable: false,
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -178,6 +178,135 @@ export class RetryExhaustedError<
 }
 
 // ---------------------------------------------------------------------------
+// Class registry
+// ---------------------------------------------------------------------------
+
+export type ErrorClassConstructor = new (...args: never[]) => TrailsError;
+
+export interface FixedErrorClassRegistryEntry {
+  readonly category: ErrorCategory;
+  readonly ctor: ErrorClassConstructor;
+  readonly name: string;
+  readonly retryable: boolean;
+}
+
+export interface DynamicErrorClassRegistryEntry {
+  readonly category: 'dynamic';
+  readonly ctor: ErrorClassConstructor;
+  readonly inheritsCategoryFrom: 'wrapped-error';
+  readonly name: string;
+  readonly retryable: false;
+}
+
+export type ErrorClassRegistryEntry =
+  | DynamicErrorClassRegistryEntry
+  | FixedErrorClassRegistryEntry;
+
+/**
+ * Authored registry of concrete TrailsError classes.
+ *
+ * JavaScript cannot enumerate subclasses at runtime, so rule and projection
+ * tooling should walk this owner-held list instead of hardcoding parallel
+ * class-name tables. `RetryExhaustedError` is marked dynamic because it
+ * inherits its runtime category from the wrapped error rather than always
+ * mapping as `internal`.
+ */
+export const errorClasses = [
+  {
+    category: 'validation',
+    ctor: ValidationError,
+    name: 'ValidationError',
+    retryable: false,
+  },
+  {
+    category: 'validation',
+    ctor: AmbiguousError,
+    name: 'AmbiguousError',
+    retryable: false,
+  },
+  {
+    category: 'internal',
+    ctor: AssertionError,
+    name: 'AssertionError',
+    retryable: false,
+  },
+  {
+    category: 'not_found',
+    ctor: NotFoundError,
+    name: 'NotFoundError',
+    retryable: false,
+  },
+  {
+    category: 'conflict',
+    ctor: AlreadyExistsError,
+    name: 'AlreadyExistsError',
+    retryable: false,
+  },
+  {
+    category: 'conflict',
+    ctor: ConflictError,
+    name: 'ConflictError',
+    retryable: false,
+  },
+  {
+    category: 'permission',
+    ctor: PermissionError,
+    name: 'PermissionError',
+    retryable: false,
+  },
+  {
+    category: 'permission',
+    ctor: PermitError,
+    name: 'PermitError',
+    retryable: false,
+  },
+  {
+    category: 'timeout',
+    ctor: TimeoutError,
+    name: 'TimeoutError',
+    retryable: true,
+  },
+  {
+    category: 'rate_limit',
+    ctor: RateLimitError,
+    name: 'RateLimitError',
+    retryable: true,
+  },
+  {
+    category: 'network',
+    ctor: NetworkError,
+    name: 'NetworkError',
+    retryable: true,
+  },
+  {
+    category: 'internal',
+    ctor: InternalError,
+    name: 'InternalError',
+    retryable: false,
+  },
+  {
+    category: 'internal',
+    ctor: DerivationError,
+    name: 'DerivationError',
+    retryable: false,
+  },
+  { category: 'auth', ctor: AuthError, name: 'AuthError', retryable: false },
+  {
+    category: 'cancelled',
+    ctor: CancelledError,
+    name: 'CancelledError',
+    retryable: false,
+  },
+  {
+    category: 'dynamic',
+    ctor: RetryExhaustedError,
+    inheritsCategoryFrom: 'wrapped-error',
+    name: 'RetryExhaustedError',
+    retryable: false,
+  },
+] as const satisfies readonly ErrorClassRegistryEntry[];
+
+// ---------------------------------------------------------------------------
 // Taxonomy maps
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export {
   CancelledError,
   DerivationError,
   codesByCategory,
+  errorClasses,
   errorCategories,
   exitCodeMap,
   statusCodeMap,
@@ -29,7 +30,14 @@ export {
   isRetryable,
   isTrailsError,
 } from './errors.js';
-export type { ErrorCategory, ErrorCategoryCodes } from './errors.js';
+export type {
+  DynamicErrorClassRegistryEntry,
+  ErrorCategory,
+  ErrorCategoryCodes,
+  ErrorClassConstructor,
+  ErrorClassRegistryEntry,
+  FixedErrorClassRegistryEntry,
+} from './errors.js';
 export {
   createTransportErrorMapper,
   mapTransportError,


### PR DESCRIPTION
## Context

Continues the error-owner stack by making error classes themselves owner metadata instead of duplicated surface knowledge.

## Changes

- Adds an owner-held errorClasses registry in core.
- Includes dynamic RetryExhausted behavior in the registry shape.
- Keeps existing exports compatible while adding coverage for the registry.

## Testing

- Focused core tests plus PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->