### PR TITLE
refactor: derive OpenAPI errors from core owner metadata

### DIFF
--- a/packages/http/src/__tests__/openapi.test.ts
+++ b/packages/http/src/__tests__/openapi.test.ts
@@ -325,6 +325,58 @@ const registerResponseTests = () => {
       expect(responses['404']).toEqual({ description: 'NotFoundError' });
     });
 
+    test('fixed-category error examples derive status codes from owner metadata', () => {
+      const t = trail('entity.create', {
+        blaze: noop,
+        examples: [
+          {
+            error: 'PermitError',
+            input: { name: 'Ada' },
+            name: 'missing permit',
+          },
+          {
+            error: 'DerivationError',
+            input: { name: 'Ada' },
+            name: 'projection failed',
+          },
+        ],
+        input: z.object({ name: z.string() }),
+      });
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
+      const op = spec.paths['/entity/create']?.['post'] as Record<
+        string,
+        unknown
+      >;
+      const responses = op['responses'] as Record<string, unknown>;
+
+      expect(responses['403']).toEqual({ description: 'PermitError' });
+      expect(responses['500']).toEqual({ description: 'DerivationError' });
+    });
+
+    test('dynamic-category error examples are not projected to a fixed response code', () => {
+      const t = trail('entity.create', {
+        blaze: noop,
+        examples: [
+          {
+            error: 'RetryExhaustedError',
+            input: { name: 'Ada' },
+            name: 'recovery exhausted',
+          },
+        ],
+        input: z.object({ name: z.string() }),
+      });
+      const spec = deriveOpenApiSpec(topoFrom({ t }));
+      const op = spec.paths['/entity/create']?.['post'] as Record<
+        string,
+        unknown
+      >;
+      const responses = op['responses'] as Record<string, unknown>;
+
+      expect(Object.values(responses)).not.toContainEqual({
+        description: 'RetryExhaustedError',
+      });
+    });
+
     test('every trail includes a default 400 validation error response', () => {
       const t = trail('entity.show', {
         blaze: noop,

--- a/packages/http/src/openapi.ts
+++ b/packages/http/src/openapi.ts
@@ -7,8 +7,9 @@
 
 import {
   ValidationError,
+  codesByCategory,
+  errorClasses,
   filterSurfaceTrails,
-  statusCodeMap,
   validateEstablishedTopo,
   zodToJsonSchema,
 } from '@ontrails/core';
@@ -53,24 +54,36 @@ export interface OpenApiSpec {
 }
 
 // ---------------------------------------------------------------------------
-// Error name → category lookup
+// Owner-derived error metadata
 // ---------------------------------------------------------------------------
 
-const errorNameToCategory: Record<string, keyof typeof statusCodeMap> = {
-  AlreadyExistsError: 'conflict',
-  AmbiguousError: 'validation',
-  AssertionError: 'internal',
-  AuthError: 'auth',
-  CancelledError: 'cancelled',
-  ConflictError: 'conflict',
-  InternalError: 'internal',
-  NetworkError: 'network',
-  NotFoundError: 'not_found',
-  PermissionError: 'permission',
-  RateLimitError: 'rate_limit',
-  TimeoutError: 'timeout',
-  ValidationError: 'validation',
-};
+type ErrorClassEntry = (typeof errorClasses)[number];
+type FixedErrorClassEntry = Exclude<
+  ErrorClassEntry,
+  { readonly category: 'dynamic' }
+>;
+type DynamicErrorClassEntry = Extract<
+  ErrorClassEntry,
+  { readonly category: 'dynamic' }
+>;
+
+const isFixedErrorClassEntry = (
+  entry: ErrorClassEntry
+): entry is FixedErrorClassEntry => entry.category !== 'dynamic';
+
+const isDynamicErrorClassEntry = (
+  entry: ErrorClassEntry
+): entry is DynamicErrorClassEntry => entry.category === 'dynamic';
+
+const errorNameToStatusCode = new Map<string, number>(
+  errorClasses
+    .filter(isFixedErrorClassEntry)
+    .map(({ category, name }) => [name, codesByCategory[category].http])
+);
+
+const dynamicErrorNames = new Set<string>(
+  errorClasses.filter(isDynamicErrorClassEntry).map(({ name }) => name)
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -124,11 +137,15 @@ const errorExampleToEntry = (
   errorName: string,
   seen: Set<number>
 ): [string, { description: string }] | undefined => {
-  const category = errorNameToCategory[errorName];
-  if (!category) {
+  if (dynamicErrorNames.has(errorName)) {
     return undefined;
   }
-  const code = statusCodeMap[category];
+
+  const code = errorNameToStatusCode.get(errorName);
+  if (code === undefined) {
+    return undefined;
+  }
+
   if (seen.has(code)) {
     return undefined;
   }


### PR DESCRIPTION
## Context

Removes an OpenAPI-side shadow table now that core owns the error metadata.

## Changes

- Rewires OpenAPI derivation to read core owner error metadata.
- Deletes the local error-name-to-category table.
- Preserves generated error response behavior.

## Testing

- Focused OpenAPI/core tests plus PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->