### PR TITLE
refactor: centralize surface error projection

### DIFF
--- a/connectors/hono/src/surface.ts
+++ b/connectors/hono/src/surface.ts
@@ -12,7 +12,7 @@
 
 import {
   isTrailsError,
-  mapTransportError,
+  projectSurfaceError,
   ValidationError,
 } from '@ontrails/core';
 import type {
@@ -296,15 +296,16 @@ const mapErrorResponse = (
   error: Error
 ): { body: Record<string, unknown>; status: ContentfulStatusCode } => {
   if (isTrailsError(error)) {
+    const projection = projectSurfaceError('http', error);
     return {
       body: {
         error: {
-          category: error.category,
-          code: error.name,
-          message: error.message,
+          category: projection.category,
+          code: projection.name,
+          message: projection.message,
         },
       },
-      status: mapTransportError('http', error) as ContentfulStatusCode,
+      status: projection.code as ContentfulStatusCode,
     };
   }
   return {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,6 +48,9 @@ ConflictError, PermissionError, AuthError, TimeoutError, RateLimitError,
 NetworkError, InternalError, DerivationError, CancelledError, AmbiguousError,
 AssertionError, RetryExhaustedError
 ErrorCategory, isTrailsError(value?), isRetryable(error)
+mapSurfaceError(surface, error), projectSurfaceError(surface, error)
+projectErrorClassSurface(surface, errorName)
+mapTransportError(surface, error)       // deprecated compatibility alias
 
 // Implementation & context
 Implementation<I, O>              // (input, ctx) => Result | Promise<Result>

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -106,8 +106,27 @@ Result.ok({ name: 'Alpha', type: 'concept' });
 
 ```typescript
 Result.err(new NotFoundError('Entity not found'));
-// -> { content: [{ type: "text", text: "Entity not found" }], isError: true }
+// -> {
+//   content: [{ type: "text", text: "Entity not found" }],
+//   isError: true,
+//   _meta: {
+//     "ontrails/error": {
+//       name: "NotFoundError",
+//       category: "not_found",
+//       code: -32601,
+//       retryable: false,
+//       message: "Entity not found",
+//       surface: "mcp"
+//     }
+//   }
+// }
 ```
+
+Trail failures are MCP tool-result errors, not JSON-RPC protocol errors. The
+model-visible payload stays text-only on error, while `_meta["ontrails/error"]`
+contains the same JSON-RPC-family code projection used by
+`mapSurfaceError('mcp', error)`. Protocol errors remain reserved for invalid
+MCP requests such as malformed methods or unknown tools.
 
 **Binary data:**
 

--- a/packages/cli/src/commander/to-commander.ts
+++ b/packages/cli/src/commander/to-commander.ts
@@ -2,7 +2,7 @@
  * Adapt framework-agnostic CliCommand[] to a Commander program.
  */
 
-import { isTrailsError, mapTransportError } from '@ontrails/core';
+import { isTrailsError, mapSurfaceError } from '@ontrails/core';
 import { Command, InvalidArgumentError, Option } from 'commander';
 
 import type { CliCommand, CliFlag } from '../command.js';
@@ -172,7 +172,7 @@ const handleError = (error: unknown): void => {
   if (error instanceof Error) {
     process.stderr.write(`Error: ${error.message}\n`);
     if (isTrailsError(error)) {
-      process.exit(mapTransportError('cli', error));
+      process.exit(mapSurfaceError('cli', error));
     }
   } else {
     process.stderr.write(`Error: ${String(error)}\n`);

--- a/packages/core/src/__tests__/transport-error-map.test.ts
+++ b/packages/core/src/__tests__/transport-error-map.test.ts
@@ -24,12 +24,48 @@ import {
   statusCodeMap,
 } from '../errors.js';
 import {
+  createSurfaceErrorMapper,
   createTransportErrorMapper,
+  mapSurfaceError,
   mapTransportError,
+  projectErrorClassSurface,
+  projectSurfaceError,
+  surfaceErrorMap,
+  surfaceErrorRegistry,
+  surfaceNames,
   transportErrorMap,
   transportErrorRegistry,
   transportNames,
 } from '../transport-error-map.js';
+
+describe('surfaceErrorMap', () => {
+  test('covers every error category for every surface', () => {
+    for (const surface of surfaceNames) {
+      const mappings = surfaceErrorMap[surface];
+      for (const category of errorCategories) {
+        expect(category in mappings).toBe(true);
+      }
+    }
+  });
+
+  test('reuses the owner-held public code maps', () => {
+    expect(surfaceErrorMap.cli).toBe(exitCodeMap);
+    expect(surfaceErrorMap.http).toBe(statusCodeMap);
+    expect(surfaceErrorMap.jsonRpc).toBe(jsonRpcCodeMap);
+    expect(surfaceErrorMap.mcp).toBe(jsonRpcCodeMap);
+  });
+});
+
+describe('surfaceErrorRegistry', () => {
+  test('exposes a callable mapper for each surface', () => {
+    const notFound = new NotFoundError('missing');
+
+    expect(surfaceErrorRegistry.cli.map(notFound)).toBe(2);
+    expect(surfaceErrorRegistry.http.map(notFound)).toBe(404);
+    expect(surfaceErrorRegistry.jsonRpc.map(notFound)).toBe(-32_601);
+    expect(surfaceErrorRegistry.mcp.map(notFound)).toBe(-32_601);
+  });
+});
 
 describe('transportErrorMap', () => {
   test('covers every error category for every transport', () => {
@@ -42,9 +78,9 @@ describe('transportErrorMap', () => {
   });
 
   test('reuses the existing public transport maps', () => {
-    expect(transportErrorMap.cli).toBe(exitCodeMap);
-    expect(transportErrorMap.http).toBe(statusCodeMap);
-    expect(transportErrorMap.mcp).toBe(jsonRpcCodeMap);
+    expect(transportErrorMap.cli).toBe(surfaceErrorMap.cli);
+    expect(transportErrorMap.http).toBe(surfaceErrorMap.http);
+    expect(transportErrorMap.mcp).toBe(surfaceErrorMap.mcp);
   });
 });
 
@@ -169,6 +205,92 @@ describe('mapTransportError', () => {
       expect(mapTransportError('mcp', error)).toBe(values.mcp);
     }
   );
+});
+
+describe('mapSurfaceError', () => {
+  test('maps known error instances through public surface names', () => {
+    const notFound = new NotFoundError('missing');
+
+    expect(mapSurfaceError('cli', notFound)).toBe(2);
+    expect(mapSurfaceError('http', notFound)).toBe(404);
+    expect(mapSurfaceError('jsonRpc', notFound)).toBe(-32_601);
+    expect(mapSurfaceError('mcp', notFound)).toBe(-32_601);
+  });
+
+  test('keeps mapTransportError as a compatibility alias', () => {
+    const error = new ValidationError('bad input');
+
+    expect(mapTransportError('cli', error)).toBe(mapSurfaceError('cli', error));
+    expect(mapTransportError('http', error)).toBe(
+      mapSurfaceError('http', error)
+    );
+    expect(mapTransportError('mcp', error)).toBe(mapSurfaceError('mcp', error));
+  });
+});
+
+describe('projectSurfaceError', () => {
+  test('returns surface metadata for a runtime error', () => {
+    const error = new RetryExhaustedError(new NotFoundError('missing'), {
+      attempts: 5,
+      detour: 'recoverMissing',
+    });
+
+    expect(projectSurfaceError('http', error)).toEqual({
+      category: 'not_found',
+      code: 404,
+      message: 'Recovery exhausted after 5 attempts: missing',
+      name: 'RetryExhaustedError',
+      retryable: false,
+      surface: 'http',
+    });
+  });
+});
+
+describe('projectErrorClassSurface', () => {
+  test('projects fixed error class names without constructing errors', () => {
+    expect(projectErrorClassSurface('http', 'DerivationError')).toEqual({
+      category: 'internal',
+      code: 500,
+      name: 'DerivationError',
+      retryable: false,
+      surface: 'http',
+    });
+    expect(projectErrorClassSurface('mcp', 'PermissionError')).toEqual({
+      category: 'permission',
+      code: -32_600,
+      name: 'PermissionError',
+      retryable: false,
+      surface: 'mcp',
+    });
+  });
+
+  test('does not invent fixed projections for dynamic or unknown class names', () => {
+    expect(
+      projectErrorClassSurface('http', 'RetryExhaustedError')
+    ).toBeUndefined();
+    expect(projectErrorClassSurface('http', 'CustomError')).toBeUndefined();
+  });
+});
+
+describe('createSurfaceErrorMapper', () => {
+  test('uses the error category to project into surface-specific values', () => {
+    const mapper = createSurfaceErrorMapper({
+      auth: 'auth',
+      cancelled: 'cancelled',
+      conflict: 'conflict',
+      internal: 'internal',
+      network: 'network',
+      not_found: 'not_found',
+      permission: 'permission',
+      rate_limit: 'rate_limit',
+      timeout: 'timeout',
+      validation: 'validation',
+    });
+
+    expect(mapper(new ValidationError('bad input'))).toBe('validation');
+    expect(mapper(new NetworkError('offline'))).toBe('network');
+    expect(mapper(new CancelledError('cancelled'))).toBe('cancelled');
+  });
 });
 
 describe('createTransportErrorMapper', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,14 +39,27 @@ export type {
   FixedErrorClassRegistryEntry,
 } from './errors.js';
 export {
+  createSurfaceErrorMapper,
   createTransportErrorMapper,
+  mapSurfaceError,
   mapTransportError,
+  projectErrorClassSurface,
+  projectSurfaceError,
+  surfaceErrorMap,
+  surfaceErrorRegistry,
+  surfaceNames,
   transportErrorMap,
   transportErrorRegistry,
   transportNames,
 } from './transport-error-map.js';
 export type {
+  ErrorClassSurfaceProjection,
   MapTransportError,
+  SurfaceErrorCode,
+  SurfaceErrorMapper,
+  SurfaceErrorMappings,
+  SurfaceErrorProjection,
+  SurfaceName,
   TransportErrorCode,
   TransportErrorMapper,
   TransportErrorMappings,

--- a/packages/core/src/transport-error-map.ts
+++ b/packages/core/src/transport-error-map.ts
@@ -1,76 +1,186 @@
 import type {
   ErrorCategory,
   ErrorCategoryCodes,
+  ErrorClassRegistryEntry,
+  FixedErrorClassRegistryEntry,
   TrailsError,
 } from './errors.js';
 import {
   codesByCategory,
+  errorClasses,
   exitCodeMap,
   jsonRpcCodeMap,
   statusCodeMap,
 } from './errors.js';
 
+export const surfaceNames = ['cli', 'http', 'jsonRpc', 'mcp'] as const;
+
+export type SurfaceName = (typeof surfaceNames)[number];
+
+const surfaceCodeKeys = {
+  cli: 'exit',
+  http: 'http',
+  jsonRpc: 'jsonRpc',
+  mcp: 'jsonRpc',
+} as const satisfies Record<SurfaceName, keyof ErrorCategoryCodes>;
+
+export type SurfaceErrorMapper<T> = (error: TrailsError) => T;
+
+export type SurfaceErrorMappings<T> = Record<ErrorCategory, T>;
+
+/**
+ * Union of every surface-specific error code emitted by {@link surfaceErrorMap}.
+ *
+ * @remarks
+ * Previously parameterized by surface (`SurfaceErrorCode<'cli'>` etc.), but
+ * the generic collapsed to `number` because the underlying maps were typed as
+ * `Record<ErrorCategory, number>`. With `as const satisfies` on the maps the
+ * per-surface literals are now observable, but TypeScript cannot narrow
+ * `surfaceErrorMap[surface][error.category]` through a generic `TSurface`
+ * without an unsound cast. The non-generic union honestly reflects what
+ * `mapSurfaceError` returns at the call site.
+ */
+export type SurfaceErrorCode =
+  (typeof codesByCategory)[ErrorCategory][(typeof surfaceCodeKeys)[SurfaceName]];
+
+export interface SurfaceErrorProjection {
+  readonly category: ErrorCategory;
+  readonly code: SurfaceErrorCode;
+  readonly message: string;
+  readonly name: string;
+  readonly retryable: boolean;
+  readonly surface: SurfaceName;
+}
+
+export interface ErrorClassSurfaceProjection {
+  readonly category: ErrorCategory;
+  readonly code: SurfaceErrorCode;
+  readonly name: string;
+  readonly retryable: boolean;
+  readonly surface: SurfaceName;
+}
+
+export const createSurfaceErrorMapper =
+  <T>(mappings: SurfaceErrorMappings<T>): SurfaceErrorMapper<T> =>
+  (error) =>
+    mappings[error.category];
+
+export const surfaceErrorMap = {
+  cli: exitCodeMap,
+  http: statusCodeMap,
+  jsonRpc: jsonRpcCodeMap,
+  mcp: jsonRpcCodeMap,
+} as const satisfies Record<SurfaceName, SurfaceErrorMappings<number>>;
+
+export const surfaceErrorRegistry = {
+  cli: {
+    map: createSurfaceErrorMapper(surfaceErrorMap.cli),
+    values: surfaceErrorMap.cli,
+  },
+  http: {
+    map: createSurfaceErrorMapper(surfaceErrorMap.http),
+    values: surfaceErrorMap.http,
+  },
+  jsonRpc: {
+    map: createSurfaceErrorMapper(surfaceErrorMap.jsonRpc),
+    values: surfaceErrorMap.jsonRpc,
+  },
+  mcp: {
+    map: createSurfaceErrorMapper(surfaceErrorMap.mcp),
+    values: surfaceErrorMap.mcp,
+  },
+} as const;
+
+export const mapSurfaceError = (
+  surface: SurfaceName,
+  error: TrailsError
+): SurfaceErrorCode =>
+  codesByCategory[error.category][surfaceCodeKeys[surface]];
+
+export const projectSurfaceError = (
+  surface: SurfaceName,
+  error: TrailsError
+): SurfaceErrorProjection => ({
+  category: error.category,
+  code: mapSurfaceError(surface, error),
+  message: error.message,
+  name: error.name,
+  retryable: error.retryable,
+  surface,
+});
+
+const isFixedErrorClassEntry = (
+  entry: ErrorClassRegistryEntry
+): entry is FixedErrorClassRegistryEntry => entry.category !== 'dynamic';
+
+const fixedErrorClassByName: ReadonlyMap<string, FixedErrorClassRegistryEntry> =
+  new Map(
+    errorClasses.flatMap((entry): [string, FixedErrorClassRegistryEntry][] =>
+      isFixedErrorClassEntry(entry) ? [[entry.name, entry]] : []
+    )
+  );
+
+/**
+ * Project a known error class name onto a surface without constructing it.
+ *
+ * Dynamic-category errors such as `RetryExhaustedError` return `undefined`
+ * because their surface code depends on the wrapped runtime error.
+ */
+export const projectErrorClassSurface = (
+  surface: SurfaceName,
+  errorName: string
+): ErrorClassSurfaceProjection | undefined => {
+  const entry = fixedErrorClassByName.get(errorName);
+  if (entry === undefined) {
+    return undefined;
+  }
+  return {
+    category: entry.category,
+    code: codesByCategory[entry.category][surfaceCodeKeys[surface]],
+    name: entry.name,
+    retryable: entry.retryable,
+    surface,
+  };
+};
+
 export const transportNames = ['cli', 'http', 'mcp'] as const;
 
 export type TransportName = (typeof transportNames)[number];
 
-const transportCodeKeys = {
-  cli: 'exit',
-  http: 'http',
-  mcp: 'jsonRpc',
-} as const satisfies Record<TransportName, keyof ErrorCategoryCodes>;
+/** @deprecated Prefer `SurfaceErrorMapper`. */
+export type TransportErrorMapper<T> = SurfaceErrorMapper<T>;
 
-export type TransportErrorMapper<T> = (error: TrailsError) => T;
+/** @deprecated Prefer `SurfaceErrorMappings`. */
+export type TransportErrorMappings<T> = SurfaceErrorMappings<T>;
 
-export type TransportErrorMappings<T> = Record<ErrorCategory, T>;
+/** @deprecated Prefer `SurfaceErrorCode`. */
+export type TransportErrorCode = SurfaceErrorCode;
 
-/**
- * Union of every transport-specific error code emitted by {@link transportErrorMap}.
- *
- * @remarks
- * Previously parameterised by transport (`TransportErrorCode<'cli'>` etc.), but
- * the generic collapsed to `number` because the underlying maps were typed as
- * `Record<ErrorCategory, number>`. With `as const satisfies` on the maps the
- * per-transport literals are now observable, but TypeScript cannot narrow
- * `transportErrorMap[transport][error.category]` through a generic
- * `TTransport` without an unsound cast. The non-generic union honestly reflects
- * what `mapTransportError` returns at the call site.
- */
-export type TransportErrorCode =
-  (typeof codesByCategory)[ErrorCategory][(typeof transportCodeKeys)[TransportName]];
+/** @deprecated Prefer `createSurfaceErrorMapper`. */
+export const createTransportErrorMapper = createSurfaceErrorMapper;
 
-export const createTransportErrorMapper =
-  <T>(mappings: TransportErrorMappings<T>): TransportErrorMapper<T> =>
-  (error) =>
-    mappings[error.category];
-
+/** @deprecated Prefer `surfaceErrorMap`. */
 export const transportErrorMap = {
-  cli: exitCodeMap,
-  http: statusCodeMap,
-  mcp: jsonRpcCodeMap,
-} as const satisfies Record<TransportName, TransportErrorMappings<number>>;
+  cli: surfaceErrorMap.cli,
+  http: surfaceErrorMap.http,
+  mcp: surfaceErrorMap.mcp,
+} as const satisfies Record<TransportName, SurfaceErrorMappings<number>>;
 
+/** @deprecated Prefer `surfaceErrorRegistry`. */
 export const transportErrorRegistry = {
-  cli: {
-    map: createTransportErrorMapper(transportErrorMap.cli),
-    values: transportErrorMap.cli,
-  },
-  http: {
-    map: createTransportErrorMapper(transportErrorMap.http),
-    values: transportErrorMap.http,
-  },
-  mcp: {
-    map: createTransportErrorMapper(transportErrorMap.mcp),
-    values: transportErrorMap.mcp,
-  },
+  cli: surfaceErrorRegistry.cli,
+  http: surfaceErrorRegistry.http,
+  mcp: surfaceErrorRegistry.mcp,
 } as const;
 
+/** @deprecated Prefer `MapSurfaceError` once available, or `typeof mapSurfaceError`. */
 export type MapTransportError = (
   transport: TransportName,
   error: TrailsError
 ) => TransportErrorCode;
 
+/** @deprecated Prefer `mapSurfaceError`. */
 export const mapTransportError: MapTransportError = (
   transport: TransportName,
   error: TrailsError
-) => codesByCategory[error.category][transportCodeKeys[transport]];
+) => mapSurfaceError(transport, error);

--- a/packages/http/src/openapi.ts
+++ b/packages/http/src/openapi.ts
@@ -7,9 +7,8 @@
 
 import {
   ValidationError,
-  codesByCategory,
-  errorClasses,
   filterSurfaceTrails,
+  projectErrorClassSurface,
   validateEstablishedTopo,
   zodToJsonSchema,
 } from '@ontrails/core';
@@ -52,38 +51,6 @@ export interface OpenApiSpec {
   readonly paths: Record<string, Record<string, unknown>>;
   readonly components: { readonly schemas: Record<string, unknown> };
 }
-
-// ---------------------------------------------------------------------------
-// Owner-derived error metadata
-// ---------------------------------------------------------------------------
-
-type ErrorClassEntry = (typeof errorClasses)[number];
-type FixedErrorClassEntry = Exclude<
-  ErrorClassEntry,
-  { readonly category: 'dynamic' }
->;
-type DynamicErrorClassEntry = Extract<
-  ErrorClassEntry,
-  { readonly category: 'dynamic' }
->;
-
-const isFixedErrorClassEntry = (
-  entry: ErrorClassEntry
-): entry is FixedErrorClassEntry => entry.category !== 'dynamic';
-
-const isDynamicErrorClassEntry = (
-  entry: ErrorClassEntry
-): entry is DynamicErrorClassEntry => entry.category === 'dynamic';
-
-const errorNameToStatusCode = new Map<string, number>(
-  errorClasses
-    .filter(isFixedErrorClassEntry)
-    .map(({ category, name }) => [name, codesByCategory[category].http])
-);
-
-const dynamicErrorNames = new Set<string>(
-  errorClasses.filter(isDynamicErrorClassEntry).map(({ name }) => name)
-);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -137,15 +104,12 @@ const errorExampleToEntry = (
   errorName: string,
   seen: Set<number>
 ): [string, { description: string }] | undefined => {
-  if (dynamicErrorNames.has(errorName)) {
+  const projection = projectErrorClassSurface('http', errorName);
+  if (projection === undefined) {
     return undefined;
   }
 
-  const code = errorNameToStatusCode.get(errorName);
-  if (code === undefined) {
-    return undefined;
-  }
-
+  const { code } = projection;
   if (seen.has(code)) {
     return undefined;
   }

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  NotFoundError,
   Result,
   TRAILHEAD_KEY,
   blobRefSchema,
@@ -13,7 +14,11 @@ import {
 import type { Layer, TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
-import { MCP_TOOL_EXAMPLES_META_KEY, deriveMcpTools } from '../build.js';
+import {
+  MCP_TOOL_ERROR_META_KEY,
+  MCP_TOOL_EXAMPLES_META_KEY,
+  deriveMcpTools,
+} from '../build.js';
 import type { McpExtra, McpToolDefinition } from '../build.js';
 
 // ---------------------------------------------------------------------------
@@ -39,6 +44,12 @@ const failTrail = trail('fail', {
   blaze: (input) => Result.err(new Error(input.reason)),
   description: 'Always fails',
   input: z.object({ reason: z.string() }),
+});
+
+const notFoundTrail = trail('item.find', {
+  blaze: () => Result.err(new NotFoundError('Item not found')),
+  description: 'Always fails with a TrailsError',
+  input: z.object({ id: z.string() }),
 });
 
 const exampleTrail = trail('with.examples', {
@@ -420,6 +431,27 @@ describe('deriveMcpTools', () => {
       const result = await tool.handler({ reason: 'broken' }, noExtra);
       expect(result?.isError).toBe(true);
       expect(result?.content[0]?.text).toBe('broken');
+    });
+
+    test('handler projects TrailsError metadata onto MCP tool-result errors', async () => {
+      const app = topo('myapp', { notFoundTrail });
+      const tool = requireOnlyTool(buildTools(app));
+
+      const result = await tool.handler({ id: 'missing' }, noExtra);
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content).toEqual([
+        { text: 'Item not found', type: 'text' },
+      ]);
+      expect(result?._meta?.[MCP_TOOL_ERROR_META_KEY]).toEqual({
+        category: 'not_found',
+        code: -32_601,
+        message: 'Item not found',
+        name: 'NotFoundError',
+        retryable: false,
+        surface: 'mcp',
+      });
+      expect(result?.structuredContent).toBeUndefined();
     });
 
     test('handler catches thrown exceptions', async () => {

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -14,6 +14,8 @@ import {
   executeTrail,
   filterSurfaceTrails,
   isBlobRef,
+  isTrailsError,
+  projectSurfaceError,
   toBlobRefDescriptor,
   validateEstablishedTopo,
   zodToJsonSchema,
@@ -23,6 +25,7 @@ import type {
   Intent,
   Layer,
   ResourceOverrideMap,
+  SurfaceErrorProjection,
   Topo,
   Trail,
   TrailContextInit,
@@ -34,6 +37,8 @@ import { createMcpProgressCallback } from './progress.js';
 import { deriveToolName } from './tool-name.js';
 
 export const MCP_TOOL_EXAMPLES_META_KEY = 'ontrails/examples';
+
+export const MCP_TOOL_ERROR_META_KEY = 'ontrails/error';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -80,10 +85,15 @@ export interface McpExtra {
 }
 
 export interface McpToolResult {
+  readonly _meta?: Record<string, unknown> | undefined;
   readonly content: readonly McpContent[];
   readonly isError?: boolean | undefined;
   readonly structuredContent?: Record<string, unknown> | undefined;
 }
+
+export type McpToolErrorMeta = Omit<SurfaceErrorProjection, 'surface'> & {
+  readonly surface: 'mcp';
+};
 
 export interface McpContent {
   readonly data?: string | undefined;
@@ -410,11 +420,30 @@ const toStructuredContent = (
 // Handler factory
 // ---------------------------------------------------------------------------
 
+const buildMcpErrorMeta = (
+  error: Error
+): Record<string, McpToolErrorMeta> | undefined => {
+  if (!isTrailsError(error)) {
+    return undefined;
+  }
+  const projection = projectSurfaceError('mcp', error);
+  return {
+    [MCP_TOOL_ERROR_META_KEY]: {
+      ...projection,
+      surface: 'mcp',
+    },
+  };
+};
+
 /** Create an error result for MCP responses. */
-const mcpError = (message: string): McpToolResult => ({
-  content: [{ text: message, type: 'text' }],
-  isError: true,
-});
+const mcpError = (error: Error): McpToolResult => {
+  const meta = buildMcpErrorMeta(error);
+  return {
+    ...(meta === undefined ? {} : { _meta: meta }),
+    content: [{ text: error.message, type: 'text' }],
+    isError: true,
+  };
+};
 
 /** Add the MCP trailhead marker while preserving any existing context extras. */
 const withMcpTrailhead = (
@@ -457,7 +486,7 @@ const createHandler =
             : toStructuredContent(result.value, wrapAsData),
       };
     }
-    return mcpError(result.error.message);
+    return mcpError(result.error);
   };
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,10 +1,12 @@
 // Build
 export {
+  MCP_TOOL_ERROR_META_KEY,
   MCP_TOOL_EXAMPLES_META_KEY,
   deriveMcpTools,
   type DeriveMcpToolsOptions,
   type McpToolDefinition,
   type McpToolResult,
+  type McpToolErrorMeta,
   type McpContent,
   type McpExtra,
 } from './build.js';


### PR DESCRIPTION
## Context

Centralizes surface error projection so CLI, HTTP, MCP, and schema consumers read the same owner projection instead of recomputing it.

## Changes

- Adds shared surface error projection helpers in core.
- Rewires existing surface consumers to the shared projection.
- Keeps compatibility aliases and tests public behavior.

## Testing

- Focused surface derivation tests plus PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->