### PR TITLE
feat: expose core intent values

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -15,6 +15,7 @@ resource(id, spec)                  // define a first-class resource dependency
 createResourceLookup(getContext)   // bind ctx.resource() to a specific context snapshot
 drainResources(resources, ctx, configValues?) // evict and dispose cached resource singletons
 topo(name, ...modules)             // assemble trails, contours, signals, and resources into a queryable topology
+intentValues                       // owner-held runtime vocabulary for trail intent
 blobRefSchema, createBlobRef(...)  // declare and create binary output references
 // Topo methods: .get(id), .has(id), .list(), .listSignals(), .ids(), .count
 //               .getContour(name), .hasContour(name), .listContours(), .contourIds(), .contourCount

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -8,7 +8,7 @@ import { ConflictError } from '../errors';
 import { Result } from '../result';
 import { resource } from '../resource';
 import { signal } from '../signal';
-import { trail } from '../trail';
+import { intentValues, trail } from '../trail';
 import type { TrailContext } from '../types';
 
 const stubCtx: TrailContext = createTrailContext({
@@ -269,6 +269,11 @@ describe('trail()', () => {
   });
 
   describe('intent and idempotent', () => {
+    test('intentValues is the owner-held runtime vocabulary', () => {
+      expect(intentValues).toEqual(['read', 'write', 'destroy']);
+      expect(Object.isFrozen(intentValues)).toBe(true);
+    });
+
     test('intent defaults to write', () => {
       const minimal = trail('bare', {
         blaze: () => Result.ok(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,7 +106,7 @@ export type {
 } from './resource.js';
 
 // Trail
-export { trail } from './trail.js';
+export { intentValues, trail } from './trail.js';
 export type {
   AnyTrail,
   BlazeInput,

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -130,8 +130,14 @@ export interface TrailSpec<I, O, CI = never> {
 // Trail (the frozen runtime object)
 // ---------------------------------------------------------------------------
 
-/** Intent describes what a trail does to the world */
-export type Intent = 'read' | 'write' | 'destroy';
+/** Intent describes what a trail does to the world. */
+export const intentValues = Object.freeze([
+  'read',
+  'write',
+  'destroy',
+] as const);
+
+export type Intent = (typeof intentValues)[number];
 
 /** Whether trailheads expose a trail by default. */
 export type TrailVisibility = 'public' | 'internal';


### PR DESCRIPTION
## Context

Moves intent values to core as owner-held runtime data so governance and surfaces do not carry parallel intent lists.

## Changes

- Exports a typed intentValues runtime constant from core.
- Rewires consumers that need runtime intent enumeration.
- Adds coverage around the public export.

## Testing

- Focused core/warden tests plus PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->