### PR TITLE
feat: expose store CRUD doctrine

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -190,6 +190,8 @@ WriteOptions, ReadOptions
 
 ```typescript
 store(tables)                      // connector-agnostic store definition
+crudOperations                     // canonical create/read/update/delete/list order
+crudAccessorExpectations           // canonical accessor methods/fallbacks per CRUD operation
 // every normalized table exposes derived schemas and signals directly:
 // table.schema          — normalized full entity schema
 // table.insertSchema    — entity schema minus generated fields
@@ -203,6 +205,7 @@ EntityOf<T>, InsertOf<T>, UpdateOf<T>, UpsertOf<T>, FixtureInputOf<T>, FixtureOf
 FiltersOf<T>, StoreListOptions
 StoreConnection<T>, StoreTableConnection<T>, ReadOnlyStoreConnection<T>
 StoreAccessor<T>, StoreTableAccessor<T>, ReadOnlyStoreTableAccessor<T>
+CrudOperation, CrudAccessorExpectation
 
 // `versioned: true` on a store table adds a framework-managed integer `version`
 // field to returned entities and allows `upsert()` optimistic concurrency.

--- a/packages/store/src/__tests__/crud.test.ts
+++ b/packages/store/src/__tests__/crud.test.ts
@@ -4,8 +4,12 @@ import { z } from 'zod';
 
 import type { EntityOf, InsertOf, StoreAccessor } from '../index.js';
 import { testAll } from '../../../testing/src/index.js';
-import { store } from '../index.js';
-import { crud } from '../trails/index.js';
+import { crudAccessorExpectations, crudOperations, store } from '../index.js';
+import {
+  crud,
+  crudAccessorExpectations as trailsCrudAccessorExpectations,
+  crudOperations as trailsCrudOperations,
+} from '../trails/index.js';
 
 const noteSchema = z.object({
   body: z.string().default('draft'),
@@ -204,6 +208,44 @@ const expectOk = <T>(result: Result<T, Error>): T => {
 };
 
 describe('crud()', () => {
+  test('exports the store-owned CRUD doctrine constants', () => {
+    expect(crudOperations).toEqual([
+      'create',
+      'read',
+      'update',
+      'delete',
+      'list',
+    ]);
+    expect(crudAccessorExpectations).toEqual({
+      create: {
+        fallback: 'upsert',
+        preferred: 'insert',
+        severityWhenNoFallback: 'error',
+        severityWhenPreferredMissingWithFallback: 'warn',
+      },
+      delete: {
+        preferred: 'remove',
+        severityWhenNoFallback: 'error',
+      },
+      list: {
+        preferred: 'list',
+        severityWhenNoFallback: 'error',
+      },
+      read: {
+        preferred: 'get',
+        severityWhenNoFallback: 'error',
+      },
+      update: {
+        fallback: 'upsert',
+        preferred: 'update',
+        severityWhenNoFallback: 'error',
+        severityWhenPreferredMissingWithFallback: 'warn',
+      },
+    });
+    expect(trailsCrudOperations).toBe(crudOperations);
+    expect(trailsCrudAccessorExpectations).toBe(crudAccessorExpectations);
+  });
+
   test('produces the five standard CRUD trails with derived schemas', () => {
     expect(createInputHasTitle).toBe(true);
     expect(createInputOmitsGeneratedId).toBe(true);

--- a/packages/store/src/crud-doctrine.ts
+++ b/packages/store/src/crud-doctrine.ts
@@ -1,0 +1,43 @@
+export const crudOperations = [
+  'create',
+  'read',
+  'update',
+  'delete',
+  'list',
+] as const;
+
+export type CrudOperation = (typeof crudOperations)[number];
+
+export interface CrudAccessorExpectation {
+  readonly fallback?: string | undefined;
+  readonly preferred: string;
+  readonly severityWhenNoFallback: 'error';
+  readonly severityWhenPreferredMissingWithFallback?: 'warn' | undefined;
+}
+
+export const crudAccessorExpectations = {
+  create: {
+    fallback: 'upsert',
+    preferred: 'insert',
+    severityWhenNoFallback: 'error',
+    severityWhenPreferredMissingWithFallback: 'warn',
+  },
+  delete: {
+    preferred: 'remove',
+    severityWhenNoFallback: 'error',
+  },
+  list: {
+    preferred: 'list',
+    severityWhenNoFallback: 'error',
+  },
+  read: {
+    preferred: 'get',
+    severityWhenNoFallback: 'error',
+  },
+  update: {
+    fallback: 'upsert',
+    preferred: 'update',
+    severityWhenNoFallback: 'error',
+    severityWhenPreferredMissingWithFallback: 'warn',
+  },
+} as const satisfies Record<CrudOperation, CrudAccessorExpectation>;

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,3 +1,8 @@
+export { crudAccessorExpectations, crudOperations } from './crud-doctrine.js';
+export type {
+  CrudAccessorExpectation,
+  CrudOperation,
+} from './crud-doctrine.js';
 export { store, versionFieldName } from './store.js';
 export type {
   AnyStoreDefinition,

--- a/packages/store/src/trails/crud.ts
+++ b/packages/store/src/trails/crud.ts
@@ -15,6 +15,7 @@ import type {
   StoreIdentifierOf,
   UpdateOf,
 } from '../types.js';
+import type { CrudOperation } from '../crud-doctrine.js';
 import { createTableContour } from './utils.js';
 import type { TableContour } from './utils.js';
 
@@ -44,7 +45,7 @@ type GeneratedFieldsOf<TTable extends AnyStoreTable> =
  */
 type DerivedInput<
   TTable extends AnyStoreTable,
-  TOperation extends 'create' | 'read' | 'update' | 'delete' | 'list',
+  TOperation extends CrudOperation,
 > = DeriveTrailInput<
   TableContour<TTable>,
   TOperation,
@@ -57,7 +58,7 @@ type DerivedInput<
  */
 type DerivedOutput<
   TTable extends AnyStoreTable,
-  TOperation extends 'create' | 'read' | 'update' | 'delete' | 'list',
+  TOperation extends CrudOperation,
 > = DeriveTrailOutput<TableContour<TTable>, TOperation>;
 
 type InternalCreateTrailOf<TTable extends AnyStoreTable> = Trail<

--- a/packages/store/src/trails/index.ts
+++ b/packages/store/src/trails/index.ts
@@ -1,3 +1,8 @@
+export { crudAccessorExpectations, crudOperations } from '../crud-doctrine.js';
+export type {
+  CrudAccessorExpectation,
+  CrudOperation,
+} from '../crud-doctrine.js';
 export { crud } from './crud.js';
 export type { CrudBlazeOverrides, CrudOptions, CrudTrails } from './crud.js';
 export { reconcile } from './reconcile.js';


### PR DESCRIPTION
## Context

Moves store CRUD doctrine to the store owner so Warden reads the package that owns CRUD semantics.

## Changes

- Exports CRUD operation and accessor expectation data from store.
- Rewires Warden rules to import the owner-held data.
- Adds tests to protect the shared doctrine surface.

## Testing

- Focused store/warden tests plus PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->