### PR TITLE
feat: expose result accessor doctrine

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -40,6 +40,7 @@ getContourReferences(contour)      // read structural contour references declare
 
 // Result
 Result<T, E>
+resultAccessorNames                // canonical Result instance accessors used by Warden
 Result.ok(value?), Result.err(error), Result.combine(results)
 Result.fromFetch(url, opts?), Result.fromJson(string), Result.toJson(value)
 

--- a/packages/core/src/__tests__/result.test.ts
+++ b/packages/core/src/__tests__/result.test.ts
@@ -1,8 +1,29 @@
 import { describe, test, expect } from 'bun:test';
 
-import { Result } from '../result';
+import { Result, resultAccessorNames } from '../result';
+import type { ResultAccessorName } from '../result';
+
+const acceptsAccessorName = (name: ResultAccessorName) => name;
 
 describe('Result', () => {
+  describe('resultAccessorNames', () => {
+    test('exports the owner-held Result accessor surface', () => {
+      expect(acceptsAccessorName('unwrap')).toBe('unwrap');
+      expect(resultAccessorNames).toEqual([
+        'error',
+        'flatMap',
+        'isErr',
+        'isOk',
+        'map',
+        'mapErr',
+        'match',
+        'unwrap',
+        'unwrapOr',
+        'value',
+      ]);
+    });
+  });
+
   describe('construction', () => {
     test('Result.ok() creates a success result', () => {
       const result = Result.ok(42);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 // Result
-export { Result } from './result.js';
+export { Result, resultAccessorNames } from './result.js';
+export type { ResultAccessorName } from './result.js';
 
 // Errors
 export {

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -4,6 +4,24 @@
 
 import { InternalError, ValidationError } from './errors.js';
 
+export const resultAccessorNames = [
+  'error',
+  'flatMap',
+  'isErr',
+  'isOk',
+  'map',
+  'mapErr',
+  'match',
+  'unwrap',
+  'unwrapOr',
+  'value',
+] as const satisfies readonly (
+  | keyof Ok<unknown, unknown>
+  | keyof Err<unknown>
+)[];
+
+export type ResultAccessorName = (typeof resultAccessorNames)[number];
+
 class Ok<T, E> {
   readonly value: T;
 

--- a/packages/warden/src/__tests__/no-sync-result-assumption.test.ts
+++ b/packages/warden/src/__tests__/no-sync-result-assumption.test.ts
@@ -590,6 +590,34 @@ function run() {
     expect(diagnostics[0]?.message).toContain('Missing await');
   });
 
+  test('flags .unwrap() access on unawaited blaze call', () => {
+    const code = `
+function run() {
+  return entityShow.blaze({ id: "1" }, ctx).unwrap();
+}`;
+
+    const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('Missing await');
+  });
+
+  test.each([
+    ['flatMap', 'flatMap((value) => Result.ok(value))'],
+    ['mapErr', 'mapErr((error) => error)'],
+    ['unwrapOr', 'unwrapOr(null)'],
+  ])('flags .%s access on unawaited blaze call', (_name, expression) => {
+    const code = `
+function run() {
+  return entityShow.blaze({ id: "1" }, ctx).${expression};
+}`;
+
+    const diagnostics = noSyncResultAssumption.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('Missing await');
+  });
+
   describe('conditional-expression inits', () => {
     test('flags accessor use when blaze call is the consequent branch', () => {
       const code = `

--- a/packages/warden/src/rules/no-sync-result-assumption.ts
+++ b/packages/warden/src/rules/no-sync-result-assumption.ts
@@ -1,16 +1,13 @@
+import { resultAccessorNames } from '@ontrails/core';
+
 import { identifierName, isBlazeCall, offsetToLine, parse } from './ast.js';
 import type { AstNode } from './ast.js';
 import { isFrameworkInternalFile, isTestFile } from './scan.js';
 import type { WardenDiagnostic, WardenRule } from './types.js';
 
-const RESULT_ACCESSOR_PROPERTIES = new Set([
-  'error',
-  'isErr',
-  'isOk',
-  'map',
-  'match',
-  'value',
-]);
+const RESULT_ACCESSOR_PROPERTIES: ReadonlySet<string> = new Set(
+  resultAccessorNames
+);
 
 const MISSING_AWAIT_MESSAGE =
   'Missing await: .blaze() returns Promise<Result> after normalization. Use `const result = await trail.blaze(input, ctx)`.';


### PR DESCRIPTION
## Context

Moves Result accessor doctrine to core so Warden no longer maintains a partial shadow list.

## Changes

- Exports typed Result accessor names from core.
- Rewires no-sync-result-assumption to consume the owner export.
- Adds coverage for accessors that were previously missing from the rule list.

## Testing

- Focused core/warden tests plus PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->