### PR TITLE
feat: expose detour attempt cap

### DIFF
--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -10,6 +10,7 @@ import { join, resolve } from 'node:path';
 
 import {
   ConflictError,
+  DETOUR_MAX_ATTEMPTS_CAP,
   Result,
   resource,
   signal,
@@ -369,6 +370,26 @@ describe('trails survey detail', () => {
     expect(parsed.crosses).toEqual([]);
     expect(parsed.intent).toBe('read');
     expect(parsed.resources).toEqual(['db.main']);
+  });
+
+  test('trail detail clamps detour maxAttempts to the owner cap', () => {
+    const detail = deriveTrailDetail(
+      trail('retrying', {
+        blaze: () => Result.ok(),
+        detours: [
+          {
+            maxAttempts: 100,
+            on: ConflictError,
+            recover: () => Result.ok(),
+          },
+        ],
+        input: z.object({}),
+      })
+    );
+
+    expect(detail.detours).toEqual([
+      { maxAttempts: DETOUR_MAX_ATTEMPTS_CAP, on: 'ConflictError' },
+    ]);
   });
 });
 

--- a/apps/trails/src/trails/topo-reports.ts
+++ b/apps/trails/src/trails/topo-reports.ts
@@ -1,4 +1,4 @@
-import { zodToJsonSchema } from '@ontrails/core';
+import { DETOUR_MAX_ATTEMPTS_CAP, zodToJsonSchema } from '@ontrails/core';
 import type { AnyTrail, Signal, Topo } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -343,7 +343,10 @@ export const deriveTrailDetail = (item: AnyTrail): TrailDetailReport => {
     detours:
       item.detours.length > 0
         ? item.detours.map((d) => ({
-            maxAttempts: d.maxAttempts ?? 1,
+            maxAttempts: Math.max(
+              1,
+              Math.min(d.maxAttempts ?? 1, DETOUR_MAX_ATTEMPTS_CAP)
+            ),
             on: d.on.name,
           }))
         : null,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -60,6 +60,7 @@ TrailContext, createTrailContext(overrides?)
 CrossFn, ResourceLookup, ProgressCallback, ProgressEvent, Logger
 
 // Execution pipeline
+DETOUR_MAX_ATTEMPTS_CAP
 executeTrail(trail, rawInput, options?) // validate → resolve context → resolve resources → compose layers → run
 run(topo, id, input, options?)    // look up and execute a trail by ID; accepts ctx/resource overrides
 RunOptions

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -13,6 +13,7 @@ import {
   TrailsError,
   ValidationError,
 } from '../errors';
+import { DETOUR_MAX_ATTEMPTS_CAP } from '../detours';
 import { executeTrail } from '../execute';
 import {
   TRACE_CONTEXT_KEY,
@@ -2049,7 +2050,7 @@ describe('executeTrail', () => {
       expect(result.error).toBeInstanceOf(InternalError);
     });
 
-    test('maxAttempts hard cap at 5', async () => {
+    test('maxAttempts hard cap is owner-held', async () => {
       let recoverCalls = 0;
       const detourTrail = trail('detour.cap', {
         blaze: () => Result.err(new ConflictError('conflict')),
@@ -2070,7 +2071,7 @@ describe('executeTrail', () => {
 
       expect(result.isErr()).toBe(true);
       expect(result.error).toBeInstanceOf(RetryExhaustedError);
-      expect(recoverCalls).toBe(5);
+      expect(recoverCalls).toBe(DETOUR_MAX_ATTEMPTS_CAP);
     });
 
     test('no detours declared — baseline unchanged', async () => {

--- a/packages/core/src/__tests__/topo-store-read.test.ts
+++ b/packages/core/src/__tests__/topo-store-read.test.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 
 import {
   ConflictError,
+  DETOUR_MAX_ATTEMPTS_CAP,
   createMockTopoStore,
   createTopoSnapshot,
   createTopoStore,
@@ -76,7 +77,13 @@ const exampleApp = () => {
     crosses: ['entity.add'],
     description: 'List entities',
     /* oxlint-disable-next-line require-await -- test stub */
-    detours: [{ on: ConflictError, recover: async () => Result.ok() }],
+    detours: [
+      {
+        maxAttempts: 100,
+        on: ConflictError,
+        recover: async () => Result.ok(),
+      },
+    ],
     idempotent: true,
     input: z.object({}),
     intent: 'read',
@@ -212,7 +219,9 @@ describe('read-only topo store', () => {
     expect(detail).toEqual(
       expect.objectContaining({
         crosses: ['entity.add'],
-        detours: [{ maxAttempts: 1, on: 'ConflictError' }],
+        detours: [
+          { maxAttempts: DETOUR_MAX_ATTEMPTS_CAP, on: 'ConflictError' },
+        ],
         id: 'entity.list',
         resources: ['db.main'],
       })
@@ -240,6 +249,34 @@ describe('read-only topo store', () => {
       [snapshot.id]
     );
     expect(rows).toEqual([{ id: 'entity.add' }, { id: 'entity.list' }]);
+  });
+
+  test('defaults omitted detour maxAttempts to one in detailed views', async () => {
+    const rootDir = makeRoot();
+    const withDefaultDetour = trail('entity.with-default-detour', {
+      blaze: noop,
+      /* oxlint-disable-next-line require-await -- test stub */
+      detours: [
+        {
+          on: ConflictError,
+          recover: async () => Result.ok(),
+        },
+      ],
+      input: z.object({}),
+    });
+    const snapshot = await expectOk(
+      createTopoSnapshot(topo('default-detour-app', { withDefaultDetour }), {
+        createdAt: '2026-04-03T14:00:00.000Z',
+        gitSha: 'abc123',
+        rootDir,
+      })
+    );
+    const store = createTopoStore({ rootDir });
+    const detail = store.trails.get('entity.with-default-detour', {
+      snapshot: { snapshotId: snapshot.id },
+    });
+
+    expect(detail?.detours).toEqual([{ maxAttempts: 1, on: 'ConflictError' }]);
   });
 
   test('fails loudly when no saved topo state exists', () => {

--- a/packages/core/src/detours.ts
+++ b/packages/core/src/detours.ts
@@ -1,0 +1,8 @@
+/**
+ * Hard upper bound for detour recovery attempts.
+ *
+ * Execution and derived surface/topo projections both clamp declared detour
+ * attempts to this value so runtime behavior and inspectable contracts stay in
+ * lockstep.
+ */
+export const DETOUR_MAX_ATTEMPTS_CAP = 5;

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -51,6 +51,7 @@ import {
   writeToSink,
 } from './internal/tracing.js';
 import { Result } from './result.js';
+import { DETOUR_MAX_ATTEMPTS_CAP } from './detours.js';
 import { createResourceLookup } from './resource.js';
 import { createResources } from './resource-config.js';
 import { TRAILHEAD_KEY } from './types.js';
@@ -727,8 +728,6 @@ const bindFireAtLayerBoundary = <I, O>(
 // ---------------------------------------------------------------------------
 // Detour loop
 // ---------------------------------------------------------------------------
-
-const DETOUR_MAX_ATTEMPTS_CAP = 5;
 
 /**
  * Find the first detour whose `on` class matches the error via `instanceof`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -222,6 +222,7 @@ export type { Field, FieldOverride } from './derive.js';
 export { buildCrossValidationSchema } from './cross-schema.js';
 
 // Execute
+export { DETOUR_MAX_ATTEMPTS_CAP } from './detours.js';
 export { executeTrail } from './execute.js';
 export type { ExecuteTrailOptions } from './execute.js';
 

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -1,6 +1,7 @@
 import type { Database, SQLQueryBindings } from 'bun:sqlite';
 
 import { getContourReferences } from '../contour.js';
+import { DETOUR_MAX_ATTEMPTS_CAP } from '../detours.js';
 import { deriveCliPath } from '../derive.js';
 import { Result } from '../result.js';
 import type { AnyContour } from '../contour.js';
@@ -697,7 +698,10 @@ const addExtendedMetadata = (
 
   if (trail.detours.length > 0) {
     entry['detours'] = trail.detours.map((d) => ({
-      maxAttempts: Math.max(1, Math.min(d.maxAttempts ?? 1, 5)),
+      maxAttempts: Math.max(
+        1,
+        Math.min(d.maxAttempts ?? 1, DETOUR_MAX_ATTEMPTS_CAP)
+      ),
       on: d.on.name,
     }));
   }

--- a/packages/schema/src/__tests__/derive.test.ts
+++ b/packages/schema/src/__tests__/derive.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'bun:test';
 
 import {
   ConflictError,
+  DETOUR_MAX_ATTEMPTS_CAP,
   contour,
   signal,
   resource,
@@ -362,6 +363,26 @@ describe('deriveSurfaceMap', () => {
 
     test('detours are included with error class names', () => {
       const t = trail('with.detours', {
+        blaze: noop,
+        detours: [
+          {
+            maxAttempts: 100,
+            on: ConflictError,
+            /* oxlint-disable-next-line require-await -- test stub, no real async work */
+            recover: async () => Result.ok(),
+          },
+        ],
+        input: z.object({}),
+      });
+      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ t })));
+
+      expect(entry.detours).toEqual([
+        { maxAttempts: DETOUR_MAX_ATTEMPTS_CAP, on: 'ConflictError' },
+      ]);
+    });
+
+    test('detours preserve in-range maxAttempts values', () => {
+      const t = trail('with.in-range.detour', {
         blaze: noop,
         detours: [
           {

--- a/packages/schema/src/derive.ts
+++ b/packages/schema/src/derive.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  DETOUR_MAX_ATTEMPTS_CAP,
   deriveCliPath,
   deriveStructuredSignalExamples,
   deriveStructuredTrailExamples,
@@ -119,7 +120,10 @@ const addExtendedMetadata = (
   }
   if (t.detours.length > 0) {
     entry['detours'] = t.detours.map((d) => ({
-      maxAttempts: Math.max(1, Math.min(d.maxAttempts ?? 1, 5)),
+      maxAttempts: Math.max(
+        1,
+        Math.min(d.maxAttempts ?? 1, DETOUR_MAX_ATTEMPTS_CAP)
+      ),
       on: d.on.name,
     }));
   }


### PR DESCRIPTION
## Context

Deduplicates the detour attempt cap so schema and topo projections read the same core-owned value as execution.

## Changes

- Exports the detour max-attempts cap from core.
- Rewires schema and topo derivation to use the shared cap.
- Adds coverage for the owner export and clamping behavior.

## Testing

- Focused core/schema tests plus PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->