### PR TITLE
refactor: converge surface derivation owner data

### DIFF
--- a/connectors/hono/src/surface.ts
+++ b/connectors/hono/src/surface.ts
@@ -16,7 +16,7 @@ import {
   ValidationError,
 } from '@ontrails/core';
 import type {
-  Intent,
+  BaseSurfaceOptions,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -32,27 +32,18 @@ import type { HttpMethod, HttpRouteDefinition } from '@ontrails/http';
 // Options
 // ---------------------------------------------------------------------------
 
-export interface CreateAppOptions {
+export interface CreateAppOptions extends BaseSurfaceOptions {
   readonly basePath?: string | undefined;
-  /** Config values for resources that declare a `config` schema, keyed by resource ID. */
-  readonly configValues?:
-    | Readonly<Record<string, Record<string, unknown>>>
-    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
-  readonly exclude?: readonly string[] | undefined;
   readonly hostname?: string | undefined;
-  readonly include?: readonly string[] | undefined;
-  readonly intent?: readonly Intent[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   /** Maximum JSON request body size in bytes. Defaults to 1 MiB. */
   readonly maxJsonBodyBytes?: number | undefined;
   readonly name?: string | undefined;
   readonly port?: number | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
-  /** Set to `false` to skip topo validation at startup. Defaults to `true`. */
-  readonly validate?: boolean | undefined;
 }
 
 interface RuntimeOptions {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -81,6 +81,11 @@ deriveFields(schema, overrides?)   // → Field[] (faithfully representable fiel
 deriveCliPath(trailId)             // trail ID → hierarchical CLI command path
 Field, FieldOverride
 
+// Surface derivation
+validateSurfaceTopo(topo, options?) // shared established-topo guard for surface projections
+withSurfaceMarker(surface, ctx?)    // merge a surface marker into execution context extensions
+BaseSurfaceOptions, SurfaceSelectionOptions, SurfaceValidationOptions, SurfaceConfigValues
+
 // Draft state
 DRAFT_ID_PREFIX, isDraftId(value), deriveDraftReport(topo)
 validateDraftFreeTopo(topo)        // reject draft-contaminated IDs and schemas
@@ -163,8 +168,12 @@ McpToolResult, McpContent, McpExtra, McpAnnotations
 ```typescript
 deriveHttpRoutes(graph, options?)      // projection: route definitions without server; returns Result<HttpRouteDefinition[], Error>
 deriveOpenApiSpec(graph, options?)     // OpenAPI 3.1 spec for the HTTP surface
+deriveHttpMethod(intent)               // intent → HTTP method
+deriveHttpOperationMethod(intent)      // intent → OpenAPI operation method
+deriveHttpInputSource(method)          // HTTP method → input source
+httpMethodByIntent
 
-DeriveHttpRoutesOptions, HttpMethod, HttpRouteDefinition, InputSource
+DeriveHttpRoutesOptions, HttpMethod, HttpOperationMethod, HttpRouteDefinition, InputSource
 OpenApiOptions, OpenApiSpec, OpenApiServer
 ```
 

--- a/packages/cli/src/__tests__/surface.test.ts
+++ b/packages/cli/src/__tests__/surface.test.ts
@@ -105,13 +105,17 @@ describe('surface', () => {
       })
     ).not.toThrow();
     const opts: Parameters<typeof surface>[1] = {
+      configValues: { 'db.main': { url: 'memory://' } },
       exclude: ['entity.secret'],
       include: ['entity.show'],
+      intent: ['read'],
       resources: {},
       validate: false,
     };
+    expect(opts.configValues).toEqual({ 'db.main': { url: 'memory://' } });
     expect(opts.exclude).toEqual(['entity.secret']);
     expect(opts.include).toEqual(['entity.show']);
+    expect(opts.intent).toEqual(['read']);
     expect(opts.validate).toBe(false);
     expect(opts.resources).toEqual({});
   });

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -3,8 +3,8 @@
  */
 
 import type {
+  BaseSurfaceOptions,
   Field,
-  Intent,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -13,13 +13,13 @@ import type {
 } from '@ontrails/core';
 import {
   Result,
-  TRAILHEAD_KEY,
   ValidationError,
   deriveCliPath,
   deriveFields,
   executeTrail,
   filterSurfaceTrails,
-  validateEstablishedTopo,
+  validateSurfaceTopo,
+  withSurfaceMarker,
 } from '@ontrails/core';
 
 import type { AnyTrail, CliArg, CliCommand, CliFlag } from './command.js';
@@ -51,22 +51,15 @@ export interface ActionResultContext {
 }
 
 /** Options for CLI command projection. */
-export interface DeriveCliCommandsOptions {
-  /** Config values for resources that declare a `config` schema, keyed by resource ID. */
-  configValues?: Readonly<Record<string, Record<string, unknown>>> | undefined;
+export interface DeriveCliCommandsOptions extends BaseSurfaceOptions {
   createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
-  exclude?: readonly string[] | undefined;
-  include?: readonly string[] | undefined;
-  intent?: readonly Intent[] | undefined;
   layers?: readonly Layer[] | undefined;
   onResult?: ((ctx: ActionResultContext) => Promise<void>) | undefined;
   presets?: readonly (readonly CliFlag[])[] | undefined;
   resources?: ResourceOverrideMap | undefined;
   resolveInput?: InputResolver | undefined;
-  /** Set to `false` to skip topo validation while building commands. */
-  validate?: boolean | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,18 +84,7 @@ const mergeFlags = (presets: CliFlag[], derived: CliFlag[]): CliFlag[] => {
 const validateCliCommandBuild = (
   graph: Topo,
   options?: DeriveCliCommandsOptions
-): Result<void, Error> => {
-  if (options?.validate === false) {
-    return Result.ok();
-  }
-
-  const validated = validateEstablishedTopo(graph);
-  if (validated.isErr()) {
-    return Result.err(validated.error);
-  }
-
-  return Result.ok();
-};
+): Result<void, Error> => validateSurfaceTopo(graph, options);
 
 // ---------------------------------------------------------------------------
 // deriveCliCommands
@@ -172,17 +154,6 @@ const reportResult = async (
     await options.onResult(ctx);
   }
 };
-
-/** Merge context overrides with the CLI trailhead marker. */
-const withCliTrailhead = (
-  ctxOverrides: Partial<TrailContext> | undefined
-): Partial<TrailContext> => ({
-  ...ctxOverrides,
-  extensions: {
-    ...ctxOverrides?.extensions,
-    [TRAILHEAD_KEY]: 'cli' as const,
-  },
-});
 
 const selectStructuredInputFlags = (
   normalizedFlags: Record<string, unknown>,
@@ -320,7 +291,7 @@ const createExecute =
     const result = await executeTrail(t, mergedInput, {
       configValues: options?.configValues,
       createContext: options?.createContext,
-      ctx: withCliTrailhead(ctxOverrides),
+      ctx: withSurfaceMarker('cli', ctxOverrides),
       layers: options?.layers,
       resources: options?.resources,
       topo: graph,

--- a/packages/cli/src/commander/surface.ts
+++ b/packages/cli/src/commander/surface.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  BaseSurfaceOptions,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -21,21 +22,17 @@ import { toCommander } from './to-commander.js';
 // Options
 // ---------------------------------------------------------------------------
 
-export interface CreateProgramOptions {
+export interface CreateProgramOptions extends BaseSurfaceOptions {
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
   readonly description?: string | undefined;
-  readonly exclude?: readonly string[] | undefined;
-  readonly include?: readonly string[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly name?: string | undefined;
   readonly onResult?: ((ctx: ActionResultContext) => Promise<void>) | undefined;
   readonly presets?: CliFlag[][] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
   readonly resolveInput?: InputResolver | undefined;
-  /** Set to `false` to skip topo validation at startup. Defaults to `true`. */
-  readonly validate?: boolean | undefined;
   readonly version?: string | undefined;
 }
 
@@ -71,9 +68,11 @@ export const createProgram = (
   options: CreateProgramOptions = {}
 ) => {
   const commandsResult = deriveCliCommands(graph, {
+    configValues: options.configValues,
     createContext: options.createContext,
     exclude: options.exclude,
     include: options.include,
+    intent: options.intent,
     layers: options.layers,
     onResult: options.onResult ?? defaultOnResult,
     presets: options.presets,

--- a/packages/core/src/__tests__/surface-derivation.test.ts
+++ b/packages/core/src/__tests__/surface-derivation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { Result } from '../result.js';
+import {
+  shouldValidateSurfaceTopo,
+  validateSurfaceTopo,
+  withSurfaceMarker,
+} from '../surface-derivation.js';
+import { topo } from '../topo.js';
+import { trail } from '../trail.js';
+import { TRAILHEAD_KEY } from '../types.js';
+
+const exportTrail = trail('entity.export', {
+  blaze: () => Result.ok({ ok: true }),
+  crosses: ['_draft.entity.prepare'],
+  input: z.object({}),
+});
+
+describe('surface derivation helpers', () => {
+  test('surface validation follows the shared validate option', () => {
+    const app = topo('test-app', { exportTrail });
+
+    expect(shouldValidateSurfaceTopo()).toBe(true);
+    expect(shouldValidateSurfaceTopo({ validate: false })).toBe(false);
+
+    const validated = validateSurfaceTopo(app);
+    expect(validated.isErr()).toBe(true);
+    expect(validated.error?.message).toMatch(/draft/i);
+
+    expect(validateSurfaceTopo(app, { validate: false }).isOk()).toBe(true);
+  });
+
+  test('surface marker preserves existing context extensions', () => {
+    const marked = withSurfaceMarker('cli', {
+      extensions: { existing: true },
+      requestId: 'req-1',
+    });
+
+    expect(marked.requestId).toBe('req-1');
+    expect(marked.extensions).toEqual({
+      [TRAILHEAD_KEY]: 'cli',
+      existing: true,
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,6 +124,18 @@ export {
 } from './surface-filter.js';
 export type { SurfaceFilterOptions } from './surface-filter.js';
 export {
+  shouldValidateSurfaceTopo,
+  validateSurfaceTopo,
+  withSurfaceMarker,
+} from './surface-derivation.js';
+export type {
+  BaseSurfaceOptions,
+  SurfaceConfigValues,
+  SurfaceSelectionOptions,
+  SurfaceMarkedContext,
+  SurfaceValidationOptions,
+} from './surface-derivation.js';
+export {
   deriveStructuredSignalExamples,
   deriveStructuredTrailExamples,
 } from './structured-examples.js';

--- a/packages/core/src/surface-derivation.ts
+++ b/packages/core/src/surface-derivation.ts
@@ -1,0 +1,62 @@
+import { Result } from './result.js';
+import type { Intent } from './trail.js';
+import type { Topo } from './topo.js';
+import type { SurfaceName } from './transport-error-map.js';
+import type { TrailContextInit } from './types.js';
+import { TRAILHEAD_KEY } from './types.js';
+import { validateEstablishedTopo } from './validate-established-topo.js';
+
+export type SurfaceConfigValues = Readonly<
+  Record<string, Record<string, unknown>>
+>;
+
+export interface SurfaceSelectionOptions {
+  /** Glob patterns that remove matching trail IDs. */
+  readonly exclude?: readonly string[] | undefined;
+  /** Glob patterns that keep only matching trail IDs when provided. */
+  readonly include?: readonly string[] | undefined;
+  /** Allowed intents for exposed surfaces. Empty arrays act as no filter. */
+  readonly intent?: readonly Intent[] | undefined;
+}
+
+export interface SurfaceValidationOptions {
+  /** Set to `false` to skip established-topo validation during projection. */
+  readonly validate?: boolean | undefined;
+}
+
+export interface BaseSurfaceOptions
+  extends SurfaceSelectionOptions, SurfaceValidationOptions {
+  /** Config values for resources that declare a `config` schema, keyed by resource ID. */
+  readonly configValues?: SurfaceConfigValues | undefined;
+}
+
+export const shouldValidateSurfaceTopo = (
+  options?: SurfaceValidationOptions
+): boolean => options?.validate !== false;
+
+export const validateSurfaceTopo = (
+  graph: Topo,
+  options?: SurfaceValidationOptions
+): Result<void, Error> => {
+  if (!shouldValidateSurfaceTopo(options)) {
+    return Result.ok();
+  }
+
+  const validated = validateEstablishedTopo(graph);
+  return validated.isErr() ? Result.err(validated.error) : Result.ok();
+};
+
+export type SurfaceMarkedContext = Partial<TrailContextInit> & {
+  readonly extensions: Readonly<Record<string, unknown>>;
+};
+
+export const withSurfaceMarker = (
+  surface: SurfaceName,
+  ctx: Partial<TrailContextInit> = {}
+): SurfaceMarkedContext => ({
+  ...ctx,
+  extensions: {
+    ...ctx.extensions,
+    [TRAILHEAD_KEY]: surface,
+  },
+});

--- a/packages/core/src/surface-filter.ts
+++ b/packages/core/src/surface-filter.ts
@@ -1,17 +1,11 @@
 import type { Intent, Trail } from './trail.js';
+import type { SurfaceSelectionOptions } from './surface-derivation.js';
 
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
-export interface SurfaceFilterOptions {
-  /** Glob patterns that keep only matching trail IDs when provided. */
-  readonly include?: readonly string[] | undefined;
-  /** Glob patterns that remove matching trail IDs. */
-  readonly exclude?: readonly string[] | undefined;
-  /** Allowed intents for exposed trailheads. Empty arrays act as no filter. */
-  readonly intent?: readonly Intent[] | undefined;
-}
+export type SurfaceFilterOptions = SurfaceSelectionOptions;
 
 // ---------------------------------------------------------------------------
 // Glob matching

--- a/packages/http/src/__tests__/method.test.ts
+++ b/packages/http/src/__tests__/method.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+
+import { intentValues } from '@ontrails/core';
+
+import {
+  deriveHttpInputSource,
+  deriveHttpMethod,
+  deriveHttpOperationMethod,
+  httpMethodByIntent,
+} from '../method.js';
+
+describe('HTTP method derivation', () => {
+  test('method map covers the core intent vocabulary', () => {
+    expect(Object.keys(httpMethodByIntent).toSorted()).toEqual(
+      [...intentValues].toSorted()
+    );
+  });
+
+  test('derives route and OpenAPI methods from one owner table', () => {
+    expect(deriveHttpMethod('read')).toBe('GET');
+    expect(deriveHttpOperationMethod('read')).toBe('get');
+    expect(deriveHttpMethod('write')).toBe('POST');
+    expect(deriveHttpOperationMethod('write')).toBe('post');
+    expect(deriveHttpMethod('destroy')).toBe('DELETE');
+    expect(deriveHttpOperationMethod('destroy')).toBe('delete');
+  });
+
+  test('falls back to POST for invalid runtime intent values', () => {
+    expect(deriveHttpMethod('custom' as never)).toBe('POST');
+    expect(deriveHttpOperationMethod('custom' as never)).toBe('post');
+  });
+
+  test('derives input source from the HTTP method', () => {
+    expect(deriveHttpInputSource('GET')).toBe('query');
+    expect(deriveHttpInputSource('POST')).toBe('body');
+    expect(deriveHttpInputSource('DELETE')).toBe('body');
+  });
+});

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -8,14 +8,14 @@
 
 import {
   Result,
-  TRAILHEAD_KEY,
   ValidationError,
   executeTrail,
   filterSurfaceTrails,
-  validateEstablishedTopo,
+  validateSurfaceTopo,
+  withSurfaceMarker,
 } from '@ontrails/core';
 import type {
-  Intent,
+  BaseSurfaceOptions,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -23,32 +23,23 @@ import type {
   TrailContextInit,
 } from '@ontrails/core';
 
+import { deriveHttpInputSource, deriveHttpMethod } from './method.js';
+import type { HttpMethod, InputSource } from './method.js';
+
+export type { HttpMethod, InputSource } from './method.js';
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
-export interface DeriveHttpRoutesOptions {
+export interface DeriveHttpRoutesOptions extends BaseSurfaceOptions {
   readonly basePath?: string | undefined;
-  /** Config values for resources that declare a `config` schema, keyed by resource ID. */
-  readonly configValues?:
-    | Readonly<Record<string, Record<string, unknown>>>
-    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
-  readonly exclude?: readonly string[] | undefined;
-  readonly include?: readonly string[] | undefined;
-  readonly intent?: readonly Intent[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
-  /** Set to `false` to skip topo validation while building routes. */
-  readonly validate?: boolean | undefined;
 }
-
-export type HttpMethod = 'GET' | 'POST' | 'DELETE';
-
-/** Input source derived from the HTTP method. */
-export type InputSource = 'query' | 'body';
 
 export interface HttpRouteDefinition {
   readonly method: HttpMethod;
@@ -77,16 +68,9 @@ export interface HttpRouteDefinition {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** Explicit intent → HTTP method mapping. */
-const intentToMethod: Record<string, HttpMethod> = {
-  destroy: 'DELETE',
-  read: 'GET',
-  write: 'POST',
-};
-
 /** Derive HTTP method from trail intent. */
 const deriveMethod = (trail: Trail<unknown, unknown, unknown>): HttpMethod =>
-  intentToMethod[trail.intent] ?? 'POST';
+  deriveHttpMethod(trail.intent);
 
 /** Derive HTTP path from trail ID: `entity.show` -> `/entity/show`. */
 const derivePath = (basePath: string, trailId: string): string => {
@@ -95,19 +79,11 @@ const derivePath = (basePath: string, trailId: string): string => {
   return `${base}/${segments}`;
 };
 
-/** Derive input source from HTTP method. */
-const deriveInputSource = (method: HttpMethod): InputSource =>
-  method === 'GET' ? 'query' : 'body';
-
 /** Build per-request context overrides with the HTTP trailhead marker. */
 const withHttpTrailhead = (
   requestId: string | undefined
-): Partial<TrailContextInit> => ({
-  ...(requestId === undefined ? {} : { requestId }),
-  extensions: {
-    [TRAILHEAD_KEY]: 'http' as const,
-  },
-});
+): Partial<TrailContextInit> =>
+  withSurfaceMarker('http', requestId === undefined ? {} : { requestId });
 
 // ---------------------------------------------------------------------------
 // Execute factory
@@ -164,7 +140,7 @@ const buildRoute = (
   const path = derivePath(basePath, trail.id);
   return {
     execute: createExecute(graph, trail, layers, options),
-    inputSource: deriveInputSource(method),
+    inputSource: deriveHttpInputSource(method),
     method,
     path,
     trail,
@@ -242,11 +218,9 @@ export const deriveHttpRoutes = (
   graph: Topo,
   options: DeriveHttpRoutesOptions = {}
 ): Result<HttpRouteDefinition[], Error> => {
-  if (options.validate !== false) {
-    const validated = validateEstablishedTopo(graph);
-    if (validated.isErr()) {
-      return Result.err(validated.error);
-    }
+  const validated = validateSurfaceTopo(graph, options);
+  if (validated.isErr()) {
+    return Result.err(validated.error);
   }
 
   const basePath = (options.basePath ?? '').replace(/\/+$/, '');

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -2,10 +2,15 @@
 export {
   deriveHttpRoutes,
   type DeriveHttpRoutesOptions,
-  type HttpMethod,
   type HttpRouteDefinition,
-  type InputSource,
 } from './build.js';
+export {
+  deriveHttpInputSource,
+  deriveHttpMethod,
+  deriveHttpOperationMethod,
+  httpMethodByIntent,
+} from './method.js';
+export type { HttpMethod, HttpOperationMethod, InputSource } from './method.js';
 
 // OpenAPI
 export { deriveOpenApiSpec } from './openapi.js';

--- a/packages/http/src/method.ts
+++ b/packages/http/src/method.ts
@@ -1,0 +1,24 @@
+import type { Intent } from '@ontrails/core';
+
+export type HttpMethod = 'GET' | 'POST' | 'DELETE';
+
+export type HttpOperationMethod = Lowercase<HttpMethod>;
+
+export type InputSource = 'query' | 'body';
+
+export const httpMethodByIntent = {
+  destroy: 'DELETE',
+  read: 'GET',
+  write: 'POST',
+} as const satisfies Record<Intent, HttpMethod>;
+
+export const deriveHttpMethod = (intent: Intent): HttpMethod =>
+  (httpMethodByIntent as Partial<Record<string, HttpMethod>>)[intent] ?? 'POST';
+
+export const deriveHttpOperationMethod = (
+  intent: Intent
+): HttpOperationMethod =>
+  deriveHttpMethod(intent).toLowerCase() as HttpOperationMethod;
+
+export const deriveHttpInputSource = (method: HttpMethod): InputSource =>
+  method === 'GET' ? 'query' : 'body';

--- a/packages/http/src/openapi.ts
+++ b/packages/http/src/openapi.ts
@@ -9,10 +9,17 @@ import {
   ValidationError,
   filterSurfaceTrails,
   projectErrorClassSurface,
-  validateEstablishedTopo,
+  validateSurfaceTopo,
   zodToJsonSchema,
 } from '@ontrails/core';
-import type { Intent, Topo, Trail } from '@ontrails/core';
+import type {
+  SurfaceSelectionOptions,
+  SurfaceValidationOptions,
+  Topo,
+  Trail,
+} from '@ontrails/core';
+
+import { deriveHttpOperationMethod } from './method.js';
 
 type JsonSchema = Readonly<Record<string, unknown>>;
 
@@ -25,7 +32,8 @@ export interface OpenApiServer {
   readonly description?: string | undefined;
 }
 
-export interface OpenApiOptions {
+export interface OpenApiOptions
+  extends SurfaceSelectionOptions, SurfaceValidationOptions {
   /** Default: `graph.name` */
   readonly title?: string | undefined;
   /** Default: `'1.0.0'` */
@@ -34,9 +42,6 @@ export interface OpenApiOptions {
   readonly servers?: readonly OpenApiServer[] | undefined;
   /** Prefix for all paths. Default: `''` */
   readonly basePath?: string | undefined;
-  readonly exclude?: readonly string[] | undefined;
-  readonly include?: readonly string[] | undefined;
-  readonly intent?: readonly Intent[] | undefined;
 }
 
 /** Minimal OpenAPI 3.1 spec shape — intentionally plain objects, no heavy library. */
@@ -55,12 +60,6 @@ export interface OpenApiSpec {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-const intentToMethod: Record<string, string> = {
-  destroy: 'delete',
-  read: 'get',
-  write: 'post',
-};
 
 /** `entity.show` → `/entity/show` */
 const trailIdToPath = (id: string, basePath: string): string =>
@@ -285,7 +284,7 @@ const collectPaths = (
     include: options?.include,
     intent: options?.intent,
   })) {
-    const method = intentToMethod[t.intent] ?? 'post';
+    const method = deriveHttpOperationMethod(t.intent);
     const path = trailIdToPath(t.id, basePath);
     const routeKey = `${method.toUpperCase()} ${path}`;
     const existingId = seenRoutes.get(routeKey);
@@ -337,7 +336,7 @@ export const deriveOpenApiSpec = (
   graph: Topo,
   options?: OpenApiOptions
 ): OpenApiSpec => {
-  const validated = validateEstablishedTopo(graph);
+  const validated = validateSurfaceTopo(graph, options);
   if (validated.isErr()) {
     throw validated.error;
   }

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -8,7 +8,6 @@
 
 import {
   Result,
-  TRAILHEAD_KEY,
   ValidationError,
   deriveStructuredTrailExamples,
   executeTrail,
@@ -17,12 +16,13 @@ import {
   isTrailsError,
   projectSurfaceError,
   toBlobRefDescriptor,
-  validateEstablishedTopo,
+  validateSurfaceTopo,
+  withSurfaceMarker,
   zodToJsonSchema,
 } from '@ontrails/core';
 import type {
+  BaseSurfaceOptions,
   BlobRef,
-  Intent,
   Layer,
   ResourceOverrideMap,
   SurfaceErrorProjection,
@@ -44,21 +44,12 @@ export const MCP_TOOL_ERROR_META_KEY = 'ontrails/error';
 // Public types
 // ---------------------------------------------------------------------------
 
-export interface DeriveMcpToolsOptions {
-  /** Config values for resources that declare a `config` schema, keyed by resource ID. */
-  readonly configValues?:
-    | Readonly<Record<string, Record<string, unknown>>>
-    | undefined;
+export interface DeriveMcpToolsOptions extends BaseSurfaceOptions {
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
-  readonly exclude?: readonly string[] | undefined;
-  readonly include?: readonly string[] | undefined;
-  readonly intent?: readonly Intent[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
-  /** Set to `false` to skip topo validation while building tools. */
-  readonly validate?: boolean | undefined;
 }
 
 export interface McpToolDefinition {
@@ -448,12 +439,11 @@ const mcpError = (error: Error): McpToolResult => {
 /** Add the MCP trailhead marker while preserving any existing context extras. */
 const withMcpTrailhead = (
   progressCb: TrailContextInit['progress']
-): Partial<TrailContextInit> => ({
-  ...(progressCb === undefined ? {} : { progress: progressCb }),
-  extensions: {
-    [TRAILHEAD_KEY]: 'mcp' as const,
-  },
-});
+): Partial<TrailContextInit> =>
+  withSurfaceMarker(
+    'mcp',
+    progressCb === undefined ? {} : { progress: progressCb }
+  );
 
 const createHandler =
   (
@@ -622,14 +612,7 @@ const eligibleTrails = (
 const validateToolBuild = (
   graph: Topo,
   options: DeriveMcpToolsOptions
-): Result<void, Error> => {
-  if (options.validate === false) {
-    return Result.ok();
-  }
-
-  const validated = validateEstablishedTopo(graph);
-  return validated.isErr() ? Result.err(validated.error) : Result.ok();
-};
+): Result<void, Error> => validateSurfaceTopo(graph, options);
 
 const registerTools = (
   graph: Topo,

--- a/packages/mcp/src/surface.ts
+++ b/packages/mcp/src/surface.ts
@@ -8,7 +8,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type {
-  Intent,
+  BaseSurfaceOptions,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -23,23 +23,14 @@ import { connectStdio } from './stdio.js';
 // Options
 // ---------------------------------------------------------------------------
 
-export interface CreateServerOptions {
-  /** Config values for resources that declare a `config` schema, keyed by resource ID. */
-  readonly configValues?:
-    | Readonly<Record<string, Record<string, unknown>>>
-    | undefined;
+export interface CreateServerOptions extends BaseSurfaceOptions {
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
   readonly description?: string | undefined;
-  readonly exclude?: readonly string[] | undefined;
-  readonly include?: readonly string[] | undefined;
-  readonly intent?: readonly Intent[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly name?: string | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
-  /** Set to `false` to skip topo validation at startup. Defaults to `true`. */
-  readonly validate?: boolean | undefined;
   readonly version?: string | undefined;
 }
 


### PR DESCRIPTION
## Context

Converges repeated surface derivation data after the owner constants are in place.

## Changes

- Centralizes base surface options, marker helpers, topo validation guard, and HTTP method derivation.
- Rewires surface consumers to the shared owner helpers.
- Documents remaining connector-descriptor questions as out of scope for this branch.

## Testing

- Focused surface tests, bun run check on the stack, and PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->