### PR TITLE
refactor: replace public internal export maps

### DIFF
--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -11,7 +11,7 @@ import {
 import { join, resolve } from 'node:path';
 
 import type { Result } from '@ontrails/core';
-import { openReadTrailsDb } from '@ontrails/core/internal/trails-db';
+import { openReadTrailsDb } from '@ontrails/core';
 import { createDevStore } from '@ontrails/tracing';
 
 import { devCleanTrail } from '../trails/dev-clean.js';

--- a/apps/trails/src/trails/dev-support.ts
+++ b/apps/trails/src/trails/dev-support.ts
@@ -5,21 +5,19 @@ import {
   countPinnedSnapshots,
   countPrunableSnapshots,
   countTopoSnapshots,
-  pruneUnpinnedSnapshots,
-} from '@ontrails/core/internal/topo-snapshots';
-import {
   openReadTrailsDb,
   openWriteTrailsDb,
   deriveTrailsDbPath,
   deriveTrailsDir,
-} from '@ontrails/core/internal/trails-db';
+  pruneUnpinnedSnapshots,
+} from '@ontrails/core';
 import {
   DEFAULT_MAX_AGE,
   DEFAULT_MAX_RECORDS,
   applyTraceCleanup,
   countTraceRecords,
   previewTraceCleanup,
-} from '@ontrails/tracing/internal/dev-state';
+} from '@ontrails/tracing';
 
 import { removeRootRelativeFileIfPresent } from '../local-state-io.js';
 

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -8,12 +8,14 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { ConflictError, NotFoundError, Result } from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 import {
+  ConflictError,
   deriveTrailsDbPath,
   deriveTrailsDir,
-} from '@ontrails/core/internal/trails-db';
+  NotFoundError,
+  Result,
+} from '@ontrails/core';
 import { readSurfaceLockData } from '@ontrails/schema';
 
 import type {

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -7,17 +7,15 @@
 
 import { Database } from 'bun:sqlite';
 
-import type { Topo, TopoSnapshot } from '@ontrails/core';
-import { InternalError, Result } from '@ontrails/core';
-import type { StoredTopoExport } from '@ontrails/core/internal/topo-store';
+import type { StoredTopoExport, Topo, TopoSnapshot } from '@ontrails/core';
 import {
-  createTopoSnapshot,
-  getStoredTopoExport,
-} from '@ontrails/core/internal/topo-store';
-import {
-  openWriteTrailsDb,
+  createStoredTopoSnapshot,
   deriveTrailsDir,
-} from '@ontrails/core/internal/trails-db';
+  getStoredTopoExport,
+  InternalError,
+  openWriteTrailsDb,
+  Result,
+} from '@ontrails/core';
 import type { SurfaceLock, SurfaceMap } from '@ontrails/schema';
 import { writeSurfaceLock, writeSurfaceMap } from '@ontrails/schema';
 
@@ -36,7 +34,7 @@ const persistAndReadStoredExport = (
   { snapshot: TopoSnapshot; storedExport: StoredTopoExport },
   Error
 > => {
-  const snapshotResult = createTopoSnapshot(db, app, {
+  const snapshotResult = createStoredTopoSnapshot(db, app, {
     ...readGitState(rootDir),
     ...deriveTopoCounts(app),
   });

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -3,12 +3,12 @@ import { fileURLToPath } from 'node:url';
 
 import {
   createTopoSnapshot as persistTopoSnapshot,
+  deriveTrailsDbPath,
   listTopoSnapshots as readTopoSnapshots,
   pinTopoSnapshot,
   unpinTopoSnapshot,
 } from '@ontrails/core';
 import type { Topo, TopoSnapshot } from '@ontrails/core';
-import { deriveTrailsDbPath } from '@ontrails/core/internal/trails-db';
 import { z } from 'zod';
 
 import {

--- a/connectors/drizzle/src/runtime.ts
+++ b/connectors/drizzle/src/runtime.ts
@@ -10,8 +10,7 @@ import {
   ValidationError,
   resource,
 } from '@ontrails/core';
-import { versionFieldName } from '@ontrails/store';
-import { bindStoreDefinition } from '@ontrails/store/internal/signal-identity';
+import { bindStoreDefinition, versionFieldName } from '@ontrails/store';
 import type {
   AnyStoreDefinition,
   AnyStoreTable,

--- a/docs/adr/0014-core-database-primitive.md
+++ b/docs/adr/0014-core-database-primitive.md
@@ -61,8 +61,7 @@ The database has two connection modes:
 
 ```typescript
 // Conceptual — illustrates the write-restriction architecture.
-// Actual internal paths: @ontrails/core/internal/trails-db (openWriteTrailsDb)
-import { getWriteConnection } from '@ontrails/core/internal/db';
+import { openWriteTrailsDb } from '@ontrails/core';
 
 // Resource for warden trails and dev tooling
 import { topoStore } from '@ontrails/core';

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,6 +21,11 @@ blobRefSchema, createBlobRef(...)  // declare and create binary output reference
 //               .getContour(name), .hasContour(name), .listContours(), .contourIds(), .contourCount
 //               .getResource(id), .hasResource(id), .listResources(), .resourceIds(), .resourceCount
 createTopoStore(options?), createMockTopoStore(seed?), topoStore
+createStoredTopoSnapshot(db, topo, input?), getStoredTopoExport(db, snapshotId)
+openReadTrailsDb(options?), openWriteTrailsDb(options?), ensureSubsystemSchema(db, options)
+deriveTrailsDir(options?), deriveTrailsDbPath(options?)
+countTopoSnapshots(db), countPinnedSnapshots(db), countPrunableSnapshots(db, options?)
+pruneUnpinnedSnapshots(db, options?)
 
 // Types
 Trail<I, O>, Signal<T>, Contour<TName, TShape, TIdentity>, Resource<T>, Topo, Intent
@@ -28,6 +33,7 @@ TrailSpec<I, O>, SignalSpec<T>, ResourceSpec<T>, TrailExample<I, O>
 AnyTrail, AnySignal, AnyContour, AnyResource, ResourceContext, ResourceOverrideMap
 BlobRef, BlobRefDescriptor
 ContourOptions, ContourIdBrand, ContourIdMetadata, ContourIdSchema, ContourIdValue, ContourReference
+StoredTopoExport, TrailsDbLocationOptions, EnsureSubsystemSchemaOptions
 
 // Type utilities
 TrailInput<T>                      // extract input type from a Trail
@@ -58,6 +64,8 @@ mapTransportError(surface, error)       // deprecated compatibility alias
 Implementation<I, O>              // (input, ctx) => Result | Promise<Result>
 TrailContext, createTrailContext(overrides?)
 CrossFn, ResourceLookup, ProgressCallback, ProgressEvent, Logger
+normalizeCrossBatchConcurrency(options?), createCrossBatchValidationResults(calls, error)
+claimNextCrossBatchIndex(counter, calls)
 
 // Execution pipeline
 DETOUR_MAX_ATTEMPTS_CAP
@@ -72,6 +80,7 @@ composeLayers(layers, trail, implementation)
 // Validation
 validateInput(schema, data)        // → Result<T, ValidationError>
 validateOutput(schema, data)       // → Result<T, ValidationError>
+stripDefaultWrappers(schema), stripDefaultsFromShape(schema)
 validateTopo(topo)                 // → Result<void, ValidationError>; called by testAll()
 validateEstablishedTopo(topo)      // → Result<void, ValidationError>; rejects draft-contaminated outputs
 TopoIssue
@@ -203,6 +212,9 @@ WriteOptions, ReadOptions
 store(tables)                      // connector-agnostic store definition
 crudOperations                     // canonical create/read/update/delete/list order
 crudAccessorExpectations           // canonical accessor methods/fallbacks per CRUD operation
+bindStoreDefinition(definition, scope) // bind derived store signals to a resource scope
+createStoreTableSignals(tableName, payload), composeStoreSignalId(scope, tableName, event)
+isValidResourceId(resourceId)
 // every normalized table exposes derived schemas and signals directly:
 // table.schema          — normalized full entity schema
 // table.insertSchema    — entity schema minus generated fields
@@ -217,6 +229,7 @@ FiltersOf<T>, StoreListOptions
 StoreConnection<T>, StoreTableConnection<T>, ReadOnlyStoreConnection<T>
 StoreAccessor<T>, StoreTableAccessor<T>, ReadOnlyStoreTableAccessor<T>
 CrudOperation, CrudAccessorExpectation
+StoreSignalEvent
 
 // `versioned: true` on a store table adds a framework-managed integer `version`
 // field to returned entities and allows `upsert()` optimistic concurrency.
@@ -393,6 +406,9 @@ createMemorySink()                   // in-memory sink for testing
 createDevStore(options?)             // SQLite-backed persistent sink for development
 createOtelConnector(options?)        // OpenTelemetry span exporter
 toTraceStore(store)                  // read-only TraceStore view that does not own the writable connection
+countTraceRecords(db), previewTraceCleanup(db, options?), applyTraceCleanup(db, options?)
+withTraceStoreDb(options, run), ensureTraceSchema(db)
+DEFAULT_MAX_RECORDS, DEFAULT_MAX_AGE
 
 // Resource & trails
 tracingResource                      // resource for tracing state
@@ -408,7 +424,7 @@ createChildTraceContext(parent)      // create a child trace context
 shouldSample(intent, config?)        // sampling decision based on intent
 DEFAULT_SAMPLING                     // default sampling rates by intent
 
-TraceRecord, TraceSink, SamplingConfig, TraceContext, TraceFn
+TraceRecord, TraceSink, SamplingConfig, TraceContext, TraceFn, TraceCleanupReport
 ```
 
 ## `@ontrails/logging`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,13 +12,6 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./internal/cross-batch": "./src/internal/cross-batch.ts",
-    "./internal/signal-ref": "./src/internal/signal-ref.ts",
-    "./internal/topo-snapshots": "./src/internal/topo-snapshots.ts",
-    "./internal/topo-store": "./src/internal/topo-store.ts",
-    "./internal/tracing": "./src/internal/tracing.ts",
-    "./internal/trails-db": "./src/internal/trails-db.ts",
-    "./internal/zod-wrappers": "./src/internal/zod-wrappers.ts",
     "./patterns": "./src/patterns/index.ts",
     "./redaction": "./src/redaction/index.ts",
     "./store": "./src/store/index.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -159,6 +159,17 @@ export { inputOf, outputOf } from './type-utils.js';
 // Signal
 export { signal } from './signal.js';
 export type { AnySignal, Signal, SignalSpec } from './signal.js';
+export {
+  attachLateBoundSignalRef,
+  cloneSignalWithId,
+  createLateBoundSignalMarker,
+  getLateBoundSignalRef,
+  parseLateBoundSignalMarker,
+} from './internal/signal-ref.js';
+export type {
+  LateBoundSignalMarker,
+  LateBoundSignalRef,
+} from './internal/signal-ref.js';
 
 // Contour
 export { contour } from './contour.js';
@@ -202,6 +213,28 @@ export type {
   TopoStoreTrailDetailRecord,
   TopoStoreTrailRecord,
 } from './topo-store.js';
+export {
+  countPinnedSnapshots,
+  countPrunableSnapshots,
+  countTopoSnapshots,
+  pruneUnpinnedSnapshots,
+} from './internal/topo-snapshots.js';
+export {
+  createTopoSnapshot as createStoredTopoSnapshot,
+  getStoredTopoExport,
+} from './internal/topo-store.js';
+export type { StoredTopoExport } from './internal/topo-store.js';
+export {
+  deriveTrailsDbPath,
+  deriveTrailsDir,
+  ensureSubsystemSchema,
+  openReadTrailsDb,
+  openWriteTrailsDb,
+} from './internal/trails-db.js';
+export type {
+  EnsureSubsystemSchemaOptions,
+  TrailsDbLocationOptions,
+} from './internal/trails-db.js';
 
 // Draft state
 export {
@@ -232,6 +265,11 @@ export type { Field, FieldOverride } from './derive.js';
 
 // Cross schema
 export { buildCrossValidationSchema } from './cross-schema.js';
+export {
+  claimNextCrossBatchIndex,
+  createCrossBatchValidationResults,
+  normalizeCrossBatchConcurrency,
+} from './internal/cross-batch.js';
 
 // Execute
 export { DETOUR_MAX_ATTEMPTS_CAP } from './detours.js';
@@ -277,6 +315,10 @@ export {
   formatZodIssues,
   zodToJsonSchema,
 } from './validation.js';
+export {
+  stripDefaultWrappers,
+  stripDefaultsFromShape,
+} from './internal/zod-wrappers.js';
 
 // Serialization
 export { serializeError, deserializeError } from './serialization.js';

--- a/packages/core/src/internal/cross-batch.ts
+++ b/packages/core/src/internal/cross-batch.ts
@@ -7,8 +7,6 @@
  * runner in `@ontrails/testing`. Extracting them here keeps the validation
  * rule, error message, and worker-pool semantics authored in one place so
  * the two call sites cannot drift.
- *
- * @internal
  */
 
 import { ValidationError } from '../errors.js';
@@ -22,8 +20,6 @@ import type { CrossBatchOptions } from '../types.js';
  * positive integer is supplied, and `Err(ValidationError)` for any other
  * value. The error message is load-bearing: callers and tests depend on
  * the exact string.
- *
- * @internal
  */
 export const normalizeCrossBatchConcurrency = (
   options: CrossBatchOptions | undefined
@@ -48,8 +44,6 @@ export const normalizeCrossBatchConcurrency = (
  * Produce one validation-error result per call, preserving the original
  * call order. Used when `normalizeCrossBatchConcurrency` fails so the caller
  * can surface a uniform batch shape to the trail implementation.
- *
- * @internal
  */
 export const createCrossBatchValidationResults = <TCall>(
   calls: readonly TCall[],
@@ -60,8 +54,6 @@ export const createCrossBatchValidationResults = <TCall>(
  * Claim the next branch index from a shared counter. Safe to call from
  * multiple worker coroutines because JavaScript is single-threaded between
  * awaits — the read/increment pair runs without interleaving.
- *
- * @internal
  */
 export const claimNextCrossBatchIndex = <TCall>(
   nextIndex: { value: number },

--- a/packages/core/src/internal/zod-wrappers.ts
+++ b/packages/core/src/internal/zod-wrappers.ts
@@ -15,8 +15,6 @@
  * would be redundant at best and would produce an `OptionalOptional<T>` shape
  * in edge cases at worst. `nullable` wrappers are preserved because nullability
  * is a semantic constraint that `.partial()` does not reintroduce.
- *
- * @internal
  */
 
 import type { z } from 'zod';
@@ -35,8 +33,6 @@ const readInnerType = (schema: z.ZodType): z.ZodType =>
  * (`default`, `optional`, `nullable`), drops defaults, drops `optional` (the
  * downstream `.partial()` reintroduces it across the whole shape), and
  * preserves `nullable` so explicit nullability survives.
- *
- * @internal
  */
 export const stripDefaultWrappers = (schema: z.ZodType): z.ZodType => {
   let current = schema;
@@ -61,8 +57,6 @@ const asObjectSchema = (schema: z.ZodType): AnyObjectSchema =>
  * Apply {@link stripDefaultWrappers} to every field in a Zod object shape and
  * return the resulting shape record. Callers typically feed the result to
  * `.extend()` + `.partial()`.
- *
- * @internal
  */
 export const stripDefaultsFromShape = (
   schema: z.ZodType

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -12,7 +12,6 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./internal/signal-identity": "./src/internal/signal-identity.ts",
     "./jsonfile": "./src/jsonfile/index.ts",
     "./trails": "./src/trails/index.ts",
     "./testing": "./src/testing.ts",

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -3,6 +3,13 @@ export type {
   CrudAccessorExpectation,
   CrudOperation,
 } from './crud-doctrine.js';
+export {
+  bindStoreDefinition,
+  composeStoreSignalId,
+  createStoreTableSignals,
+  isValidResourceId,
+} from './internal/signal-identity.js';
+export type { StoreSignalEvent } from './internal/signal-identity.js';
 export { store, versionFieldName } from './store.js';
 export type {
   AnyStoreDefinition,

--- a/packages/store/src/internal/signal-identity.ts
+++ b/packages/store/src/internal/signal-identity.ts
@@ -1,9 +1,10 @@
-import { signal, ValidationError } from '@ontrails/core';
-import type { Signal } from '@ontrails/core';
 import {
   attachLateBoundSignalRef,
   cloneSignalWithId,
-} from '@ontrails/core/internal/signal-ref';
+  signal,
+  ValidationError,
+} from '@ontrails/core';
+import type { Signal } from '@ontrails/core';
 import type { z } from 'zod';
 
 import type {

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,6 +1,5 @@
-import { ValidationError } from '@ontrails/core';
+import { stripDefaultsFromShape, ValidationError } from '@ontrails/core';
 import type { AnySignal } from '@ontrails/core';
-import { stripDefaultsFromShape } from '@ontrails/core/internal/zod-wrappers';
 import { z } from 'zod';
 
 import { createStoreTableSignals } from './internal/signal-identity.js';

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -18,15 +18,13 @@ import type {
 } from '@ontrails/core';
 import {
   buildCrossValidationSchema,
-  executeTrail,
-  InternalError,
-  Result as R,
-} from '@ontrails/core';
-import {
   claimNextCrossBatchIndex,
   createCrossBatchValidationResults,
+  executeTrail,
+  InternalError,
   normalizeCrossBatchConcurrency,
-} from '@ontrails/core/internal/cross-batch';
+  Result as R,
+} from '@ontrails/core';
 
 import { assertPartialMatch, expectOk } from './assertions.js';
 import { createTestContext, createMockResources } from './context.js';

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -12,7 +12,6 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./internal/dev-state": "./src/internal/dev-state.ts",
     "./otel": "./src/connectors/otel.ts",
     "./package.json": "./package.json"
   },

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -48,6 +48,16 @@ export {
   type TraceStore,
   toTraceStore,
 } from './stores/dev.js';
+export {
+  applyTraceCleanup,
+  countTraceRecords,
+  DEFAULT_MAX_AGE,
+  DEFAULT_MAX_RECORDS,
+  ensureTraceSchema,
+  previewTraceCleanup,
+  withTraceStoreDb,
+} from './internal/dev-state.js';
+export type { TraceCleanupReport } from './internal/dev-state.js';
 
 // OTel connector
 export {

--- a/packages/tracing/src/internal/dev-state.ts
+++ b/packages/tracing/src/internal/dev-state.ts
@@ -1,9 +1,6 @@
 import type { Database } from 'bun:sqlite';
 
-import {
-  ensureSubsystemSchema,
-  openWriteTrailsDb,
-} from '@ontrails/core/internal/trails-db';
+import { ensureSubsystemSchema, openWriteTrailsDb } from '@ontrails/core';
 
 import type { DevStoreOptions } from '../stores/dev.js';
 

--- a/packages/tracing/src/stores/dev.ts
+++ b/packages/tracing/src/stores/dev.ts
@@ -3,7 +3,7 @@ import { Database } from 'bun:sqlite';
 import { existsSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { openWriteTrailsDb } from '@ontrails/core/internal/trails-db';
+import { openWriteTrailsDb } from '@ontrails/core';
 
 import {
   DEFAULT_MAX_AGE,

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -3,12 +3,15 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { createTopoStore, trail, topo, Result } from '@ontrails/core';
-import { createTopoSnapshot } from '@ontrails/core/internal/topo-store';
 import {
-  openWriteTrailsDb,
+  createStoredTopoSnapshot,
+  createTopoStore,
   deriveTrailsDir,
-} from '@ontrails/core/internal/trails-db';
+  openWriteTrailsDb,
+  trail,
+  topo,
+  Result,
+} from '@ontrails/core';
 import {
   deriveSurfaceMapHash,
   deriveSurfaceMap,
@@ -42,7 +45,7 @@ const committedLockDir = (dir: string): string => {
 const seedSavedTopo = (dir: string): string | undefined => {
   const db = openWriteTrailsDb({ rootDir: dir });
   try {
-    const result = createTopoSnapshot(db, makeTopo(), {
+    const result = createStoredTopoSnapshot(db, makeTopo(), {
       createdAt: '2026-04-03T15:00:00.000Z',
     });
     if (result.isErr()) {

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -12,10 +12,10 @@ import { existsSync, statSync } from 'node:fs';
 import type { Topo } from '@ontrails/core';
 import {
   createTopoStore,
+  deriveTrailsDir,
   NotFoundError,
   ValidationError,
 } from '@ontrails/core';
-import { deriveTrailsDir } from '@ontrails/core/internal/trails-db';
 import {
   deriveSurfaceMap,
   deriveSurfaceMapHash,


### PR DESCRIPTION
## Context

Replaces public internal export-map pressure valves with deliberate owner-first APIs before v1.

## Changes

- Adds named public owner exports for core signal refs, topo snapshots, Trails DB helpers, cross-batch helpers, and Zod wrappers.
- Adds store signal-binding exports and tracing dev-state exports through package owners.
- Removes public ./internal/* export maps and rewires publishable consumers away from internal subpaths.
- Updates API docs to reflect the supported public paths.

## Testing

- Focused public API tests, bun run check on the stack, and PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->