### PR TITLE
refactor: clean duplicate public subpaths

### DIFF
--- a/apps/trails/src/trails/draft-promote.ts
+++ b/apps/trails/src/trails/draft-promote.ts
@@ -11,11 +11,10 @@ import {
 import type { Topo } from '@ontrails/core';
 import {
   DRAFT_FILE_PREFIX,
-  findStringLiterals,
   isDraftMarkedFile,
-  parse,
   stripDraftFileMarkers,
 } from '@ontrails/warden';
+import { findStringLiterals, parse } from '@ontrails/warden/ast';
 import { z } from 'zod';
 
 import {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -63,6 +63,8 @@ mapTransportError(surface, error)       // deprecated compatibility alias
 // Implementation & context
 Implementation<I, O>              // (input, ctx) => Result | Promise<Result>
 TrailContext, createTrailContext(overrides?)
+SURFACE_KEY                        // invoking surface extension key
+TRAILHEAD_KEY                      // deprecated compatibility alias for SURFACE_KEY
 CrossFn, ResourceLookup, ProgressCallback, ProgressEvent, Logger
 normalizeCrossBatchConcurrency(options?), createCrossBatchValidationResults(calls, error)
 claimNextCrossBatchIndex(counter, calls)
@@ -139,21 +141,28 @@ DeriveTrailSpec<TContour, TOp, TGenerated>
 Current shipped surface packages are `@ontrails/cli`, `@ontrails/mcp`, `@ontrails/http`, and `@ontrails/hono`. A WebSocket surface is planned but has no public package or API yet.
 
 ```typescript
-surface(graph, options?)               // one-liner: parse argv, execute, return exit code
-createProgram(graph, options?)         // create a Commander program without parsing argv
 deriveCliCommands(graph, options?)     // projection: Result-returning command definitions
 validateCliCommands(commands)          // validate command tree shape and collisions
-toCommander(commands, options?)        // translate commands to Commander.js program
 deriveFlags(schema, overrides?)        // Zod → CLI flags
 output(value, mode)                    // write to stdout in text/json/jsonl
 deriveOutputMode(flags, topoName)      // determine output format from flags/topo-derived env
 
-CreateProgramOptions, DeriveCliCommandsOptions, ActionResultContext, OutputMode
+DeriveCliCommandsOptions, ActionResultContext, OutputMode
 CliCommand, CliFlag, CliArg
 outputModePreset(), cwdPreset(), dryRunPreset()
 defaultOnResult(ctx), passthroughResolver, isInteractive(options?)
 InputResolver, ResolveInputOptions
 autoIterateLayer, dateShortcutsLayer
+```
+
+## `@ontrails/cli/commander`
+
+```typescript
+surface(graph, options?)               // one-liner: parse argv, execute, return exit code
+createProgram(graph, options?)         // create a Commander program without parsing argv
+toCommander(commands, options?)        // translate commands to Commander.js program
+
+CreateProgramOptions, SurfaceCliResult, ToCommanderOptions
 ```
 
 ## `@ontrails/mcp`
@@ -306,10 +315,6 @@ clearImplementationReturnsResultCache()
 DRAFT_FILE_PREFIX, DRAFT_FILE_SEGMENT
 isDraftMarkedFile(path), stripDraftFileMarkers(path)
 
-// AST helpers for repo-local tooling
-parse(filePath, sourceCode), walk(ast, visitor), offsetToLine(source, offset)
-findStringLiterals(ast, predicate?), isStringLiteral(node), getStringValue(node)
-
 // Trail-wrapping helpers and schemas
 wrapRule({ rule, examples })
 wrapTopoRule({ rule, examples })
@@ -320,6 +325,14 @@ ruleInput, projectAwareRuleInput, ruleOutput, topoAwareRuleInput, diagnosticSche
 WardenOptions, WardenReport, WardenDiagnostic, WardenSeverity, DriftResult
 ProjectAwareWardenRule, ProjectContext, TopoAwareWardenRule, WardenRule
 RuleInput, ProjectAwareRuleInput, RuleOutput, TopoAwareRuleInput
+```
+
+## `@ontrails/warden/ast`
+
+```typescript
+parse(filePath, sourceCode), walk(ast, visitor), offsetToLine(source, offset)
+findStringLiterals(ast, predicate?), isStringLiteral(node), getStringValue(node)
+
 AstNode, StringLiteralMatch
 ```
 
@@ -370,7 +383,7 @@ authLayer                            // layer that enforces permit scopes on tra
 // Permits
 getPermit(ctx)                       // extract the resolved permit from context
 Permit                               // { id, scopes, roles?, tenantId?, metadata? }
-PermitExtractionInput                // transport-agnostic auth input
+PermitExtractionInput                // surface-agnostic auth input
 
 // Connectors
 AuthConnector                        // interface: authenticate(input) → Result<Permit | null>
@@ -379,13 +392,16 @@ createJwtConnector(options)          // built-in HS256 JWT connector (from @ontr
 // Trail definitions
 authVerify                           // verify a bearer token and return a permit
 
-// Testing
-createTestPermit(overrides?)         // create a permit for tests
-createPermitForTrail(trail)          // create a permit matching a trail's requirements
-
 // Governance
 validatePermits(trails)              // check trails against permit governance rules
 PermitDiagnostic
+```
+
+## `@ontrails/permits/testing`
+
+```typescript
+createTestPermit(overrides?)         // create a permit for tests
+createPermitForTrail(trail)          // create a permit matching a trail's requirements
 ```
 
 ## `@ontrails/tracing`

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -12,7 +12,7 @@
 
 **Config resolution (`@ontrails/config`).** `defineConfig()` provides schema-validated config with profiles (named environment profiles), env variable mapping, and `ResourceSpec.config` for resource-level config schemas. Includes diagnostics (`checkConfig`), introspection (`deriveConfigFields`, `deriveConfigProvenance`), and generation (`deriveConfigEnvExample`).
 
-**Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. `authLayer` extracts credentials from surface-specific sources, `AuthConnector` resolves them to a `Permit` (identity, scopes, roles), and scope enforcement rejects unauthorized access. Includes JWT connector, governance rules (`validatePermits`), and test helpers (`createTestPermit`, `createPermitForTrail`).
+**Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. `authLayer` extracts credentials from surface-specific sources, `AuthConnector` resolves them to a `Permit` (identity, scopes, roles), and scope enforcement rejects unauthorized access. Includes JWT connector, governance rules (`validatePermits`), and test helpers through `@ontrails/permits/testing`.
 
 **Tracing (intrinsic in `@ontrails/core`, sinks in `@ontrails/tracing`).** With a real sink installed, `executeTrail` produces a `TraceRecord` automatically and `ctx.trace(label, fn)` records nested spans inside a trail blaze. With `NOOP_SINK`, the tracing path short-circuits without layer attachment or per-trail wiring. Pluggable sinks register via `registerTraceSink()`: `createMemorySink` for testing, `createDevStore` for local development, `createOtelConnector` for production OpenTelemetry export. Sampling configuration controls recording volume.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -381,7 +381,10 @@ The config, permits, and tracing packages each provide test-friendly primitives 
 **Synthetic permit creation.** `createTestPermit()` creates a `Permit` with exactly the scopes you specify -- no admin privileges, no wildcards. `createPermitForTrail()` reads a trail's `permit` declaration and creates a permit with exactly the declared scopes, so tests exercise the real authorization path without a running auth provider:
 
 ```typescript
-import { createTestPermit, createPermitForTrail } from '@ontrails/permits';
+import {
+  createTestPermit,
+  createPermitForTrail,
+} from '@ontrails/permits/testing';
 
 const permit = createTestPermit({ scopes: ['entity:read'] });
 const trailPermit = createPermitForTrail(showTrail);

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,8 +1,8 @@
 # @ontrails/cli
 
-CLI surface connector. One `surface()` call turns a topo into a full CLI
-with honest flags, structured input channels, subcommands, help text, and
-error-mapped exit codes -- all derived from the trail contracts.
+CLI surface model and Commander connector. Import framework-agnostic command
+derivation from `@ontrails/cli`; import the Commander runtime from
+`@ontrails/cli/commander`.
 
 ## Usage
 
@@ -55,13 +55,19 @@ commands.
 
 | Export | What it does |
 | --- | --- |
-| `surface(graph, options?)` | One-liner: build commands, wire Commander, parse argv |
 | `deriveCliCommands(graph)` | Framework-agnostic command builder, returns `Result<CliCommand[], Error>` |
 | `validateCliCommands(commands)` | Validate `CliCommand[]` shapes before wiring a CLI adapter |
-| `toCommander(commands, options?)` | Connect `CliCommand[]` to a Commander program |
 | `deriveFlags(schema)` | Extract honest CLI flags from a Zod schema |
 | `output(data, mode)` | Format output as JSON, JSONL, or text |
 | `deriveOutputMode(flags, topoName)` | Derive output mode from flags and topo-derived env vars (`<TOPO>_JSON`, `<TOPO>_JSONL`) |
+
+### `@ontrails/cli/commander`
+
+| Export | What it does |
+| --- | --- |
+| `surface(graph, options?)` | One-liner: build commands, wire Commander, parse argv |
+| `createProgram(graph, options?)` | Build a Commander program without parsing argv |
+| `toCommander(commands, options?)` | Connect `CliCommand[]` to a Commander program |
 
 See the [API Reference](../../docs/api-reference.md) for the full list.
 

--- a/packages/cli/src/__tests__/public-api.test.ts
+++ b/packages/cli/src/__tests__/public-api.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+
+import * as cli from '@ontrails/cli';
+import * as commander from '@ontrails/cli/commander';
+
+describe('@ontrails/cli public API', () => {
+  test('keeps Commander runtime helpers on the commander entrypoint', () => {
+    expect('surface' in cli).toBe(false);
+    expect('createProgram' in cli).toBe(false);
+
+    expect(typeof commander.surface).toBe('function');
+    expect(typeof commander.createProgram).toBe('function');
+    expect(typeof commander.toCommander).toBe('function');
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,10 +30,3 @@ export { findAppModuleCandidates, findAppModule } from './discover.js';
 
 // Layers
 export { autoIterateLayer, dateShortcutsLayer } from './layers.js';
-
-// Surface helpers (also available from @ontrails/cli/commander)
-export { createProgram, surface } from './commander/surface.js';
-export type {
-  CreateProgramOptions,
-  SurfaceCliResult,
-} from './commander/surface.js';

--- a/packages/core/src/__tests__/surface-derivation.test.ts
+++ b/packages/core/src/__tests__/surface-derivation.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../surface-derivation.js';
 import { topo } from '../topo.js';
 import { trail } from '../trail.js';
-import { TRAILHEAD_KEY } from '../types.js';
+import { SURFACE_KEY, TRAILHEAD_KEY } from '../types.js';
 
 const exportTrail = trail('entity.export', {
   blaze: () => Result.ok({ ok: true }),
@@ -19,6 +19,11 @@ const exportTrail = trail('entity.export', {
 });
 
 describe('surface derivation helpers', () => {
+  test('surface key preserves the legacy extension slot', () => {
+    expect(SURFACE_KEY).toBe('__trails_trailhead');
+    expect(TRAILHEAD_KEY).toBe(SURFACE_KEY);
+  });
+
   test('surface validation follows the shared validate option', () => {
     const app = topo('test-app', { exportTrail });
 
@@ -40,7 +45,7 @@ describe('surface derivation helpers', () => {
 
     expect(marked.requestId).toBe('req-1');
     expect(marked.extensions).toEqual({
-      [TRAILHEAD_KEY]: 'cli',
+      [SURFACE_KEY]: 'cli',
       existing: true,
     });
   });

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -54,7 +54,7 @@ import { Result } from './result.js';
 import { DETOUR_MAX_ATTEMPTS_CAP } from './detours.js';
 import { createResourceLookup } from './resource.js';
 import { createResources } from './resource-config.js';
-import { TRAILHEAD_KEY } from './types.js';
+import { SURFACE_KEY } from './types.js';
 import { validateInput, validateOutput } from './validation.js';
 
 type MutableTrailContext = {
@@ -330,7 +330,7 @@ const buildTracedContext = (
     rootId: parent?.rootId,
     traceId: parent?.traceId,
     trailId: trail.id,
-    trailhead: ctx.extensions?.[TRAILHEAD_KEY] as TraceRecord['trailhead'],
+    trailhead: ctx.extensions?.[SURFACE_KEY] as TraceRecord['trailhead'],
   });
 
   // Root trace context for this trail's span. When inheriting a parent, the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,7 +84,7 @@ export type {
   Logger,
   ResourceLookup,
 } from './types.js';
-export { TRAILHEAD_KEY } from './types.js';
+export { SURFACE_KEY, TRAILHEAD_KEY } from './types.js';
 
 // Context factory
 export { createTrailContext, passthroughTrace } from './context.js';

--- a/packages/core/src/surface-derivation.ts
+++ b/packages/core/src/surface-derivation.ts
@@ -3,7 +3,7 @@ import type { Intent } from './trail.js';
 import type { Topo } from './topo.js';
 import type { SurfaceName } from './transport-error-map.js';
 import type { TrailContextInit } from './types.js';
-import { TRAILHEAD_KEY } from './types.js';
+import { SURFACE_KEY } from './types.js';
 import { validateEstablishedTopo } from './validate-established-topo.js';
 
 export type SurfaceConfigValues = Readonly<
@@ -57,6 +57,6 @@ export const withSurfaceMarker = (
   ...ctx,
   extensions: {
     ...ctx.extensions,
-    [TRAILHEAD_KEY]: surface,
+    [SURFACE_KEY]: surface,
   },
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -167,8 +167,16 @@ export interface Logger {
   child(context: Record<string, unknown>): Logger;
 }
 
-/** Context extension key for the invoking trailhead name. */
-export const TRAILHEAD_KEY = '__trails_trailhead' as const;
+/**
+ * Context extension key for the invoking surface name.
+ *
+ * @remarks The string value is retained for beta compatibility with existing
+ * trace and permit metadata while public API vocabulary moves to surfaces.
+ */
+export const SURFACE_KEY = '__trails_trailhead' as const;
+
+/** @deprecated Prefer `SURFACE_KEY`. */
+export const TRAILHEAD_KEY = SURFACE_KEY;
 
 /** Minimal permit shape available on TrailContext. Permits extends this. */
 export interface BasePermit {

--- a/packages/permits/README.md
+++ b/packages/permits/README.md
@@ -26,7 +26,7 @@ export const search = trail('gist.search', {
 });
 ```
 
-### 2. Resolve a permit at the trailhead
+### 2. Resolve a permit at the surface
 
 ```typescript
 export const graph = topo('my-app', gistModule);
@@ -138,7 +138,10 @@ import { authVerify } from '@ontrails/permits';
 Use `createTestPermit()` and `createPermitForTrail()` in tests:
 
 ```typescript
-import { createTestPermit, createPermitForTrail } from '@ontrails/permits';
+import {
+  createTestPermit,
+  createPermitForTrail,
+} from '@ontrails/permits/testing';
 
 const permit = createTestPermit({
   id: 'user-123',

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./jwt": "./src/connectors/jwt.ts",
+    "./testing": "./src/testing.ts",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/permits/src/__tests__/public-api.test.ts
+++ b/packages/permits/src/__tests__/public-api.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+
+import * as permits from '@ontrails/permits';
+import {
+  createPermitForTrail,
+  createTestPermit,
+} from '@ontrails/permits/testing';
+
+describe('@ontrails/permits public API', () => {
+  test('keeps test helpers on the testing entrypoint', () => {
+    expect('createTestPermit' in permits).toBe(false);
+    expect('createPermitForTrail' in permits).toBe(false);
+
+    expect(createTestPermit({ scopes: ['entity:read'] }).scopes).toEqual([
+      'entity:read',
+    ]);
+    expect(createPermitForTrail({ permit: 'public' })).toBeUndefined();
+  });
+});

--- a/packages/permits/src/extraction.ts
+++ b/packages/permits/src/extraction.ts
@@ -1,18 +1,18 @@
 /**
  * Normalized input for auth connectors.
  *
- * Each trailhead extracts raw credentials from its transport and normalizes
- * them into this shape. No trailhead types (Request, McpSession, etc.) cross
- * into core — only this interface.
+ * Each surface extracts raw credentials from its transport and normalizes them
+ * into this shape. No surface types (Request, McpSession, etc.) cross into
+ * core -- only this interface.
  */
 export interface PermitExtractionInput {
-  /** Which trailhead produced this extraction */
+  /** Which surface produced this extraction. Field name retained for beta compatibility. */
   readonly trailhead: 'http' | 'mcp' | 'cli';
   /** Bearer token from Authorization header or equivalent */
   readonly bearerToken?: string;
   /** Session identifier from transport handshake */
   readonly sessionId?: string;
-  /** Raw headers (HTTP trailhead only, typically) */
+  /** Raw headers (HTTP surface only, typically) */
   readonly headers?: Headers;
   /** Correlation ID for tracing */
   readonly requestId: string;

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -15,4 +15,3 @@ export { PermitError } from './errors.js';
 export { type PermitExtractionInput } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';
 export { validatePermits, type PermitDiagnostic } from './rules.js';
-export { createTestPermit, createPermitForTrail } from './testing.js';

--- a/packages/permits/src/trails/auth-verify.ts
+++ b/packages/permits/src/trails/auth-verify.ts
@@ -1,4 +1,4 @@
-import { Result, TRAILHEAD_KEY, trail } from '@ontrails/core';
+import { Result, SURFACE_KEY, trail } from '@ontrails/core';
 import type { TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -30,7 +30,7 @@ const toOutputPermit = (permit: Permit) => ({
   scopes: [...permit.scopes],
 });
 
-const isTrailhead = (
+const isSurfaceName = (
   value: unknown
 ): value is PermitExtractionInput['trailhead'] =>
   value === 'http' || value === 'mcp' || value === 'cli';
@@ -38,8 +38,8 @@ const isTrailhead = (
 const getTrailhead = (
   ctx: TrailContext
 ): PermitExtractionInput['trailhead'] => {
-  const trailhead = ctx.extensions?.[TRAILHEAD_KEY];
-  return isTrailhead(trailhead) ? trailhead : 'http';
+  const surface = ctx.extensions?.[SURFACE_KEY];
+  return isSurfaceName(surface) ? surface : 'http';
 };
 
 /**

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -78,6 +78,13 @@ CI formatters for structured output:
 import { formatGitHubAnnotations, formatJson, formatSummary } from '@ontrails/warden';
 ```
 
+Parser helpers for rule authoring and repo-local tooling live on the dedicated
+AST entrypoint:
+
+```typescript
+import { findStringLiterals, parse, walk } from '@ontrails/warden/ast';
+```
+
 ## Trail-based API
 
 Every built-in warden rule is also available as a composable trail. This makes rules queryable, testable, and invocable through any Trails surface.
@@ -118,6 +125,9 @@ To wrap a custom rule as a trail, use `wrapRule` (imported from `@ontrails/warde
 | `formatGitHubAnnotations(report)` | GitHub Actions annotation format |
 | `formatJson(report)` | Machine-readable JSON |
 | `formatSummary(report)` | Compact summary line |
+
+AST parser helpers are exported from `@ontrails/warden/ast`, not the root
+runtime barrel.
 
 See the [API Reference](../../docs/api-reference.md) for the full list.
 

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -12,6 +12,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./ast": "./src/ast.ts",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -22,12 +23,12 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@ontrails/permits": "workspace:^"
+    "@ontrails/permits": "workspace:^",
+    "oxc-parser": "^0.121.0"
   },
   "devDependencies": {
     "@ontrails/testing": "workspace:^",
     "@oxc-project/types": "^0.122.0",
-    "oxc-parser": "^0.121.0",
     "zod": "catalog:"
   },
   "peerDependencies": {

--- a/packages/warden/src/__tests__/public-api.test.ts
+++ b/packages/warden/src/__tests__/public-api.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+
+import * as warden from '@ontrails/warden';
+import { parse, walk } from '@ontrails/warden/ast';
+
+describe('@ontrails/warden public API', () => {
+  test('keeps parser helpers on the ast entrypoint', () => {
+    expect('parse' in warden).toBe(false);
+    expect('walk' in warden).toBe(false);
+
+    const ast = parse('example.ts', 'export const value = 1;');
+    expect(ast).not.toBeNull();
+
+    let visited = 0;
+    if (ast) {
+      walk(ast, () => {
+        visited += 1;
+      });
+    }
+    expect(visited).toBeGreaterThan(0);
+  });
+});

--- a/packages/warden/src/ast.ts
+++ b/packages/warden/src/ast.ts
@@ -1,0 +1,16 @@
+/**
+ * Public Warden AST helper surface.
+ *
+ * These helpers are the supported parser primitives for repo-local tooling and
+ * rule authoring. Broader Trails-aware discovery helpers stay internal to the
+ * built-in rule implementation until they have a stable public contract.
+ */
+export {
+  findStringLiterals,
+  getStringValue,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  walk,
+} from './rules/ast.js';
+export type { AstNode, StringLiteralMatch } from './rules/ast.js';

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -46,17 +46,6 @@ export {
   stripDraftFileMarkers,
 } from './draft.js';
 
-// AST helpers for repo-local tooling
-export {
-  findStringLiterals,
-  getStringValue,
-  isStringLiteral,
-  offsetToLine,
-  parse,
-  walk,
-} from './rules/ast.js';
-export type { AstNode, StringLiteralMatch } from './rules/ast.js';
-
 // Trail layer
 export { wardenTopo } from './trails/topo.js';
 export { runTopoAwareWardenTrails, runWardenTrails } from './trails/run.js';


### PR DESCRIPTION
## Context

Finishes the package-boundary cleanup with smaller public subpath decisions and surface vocabulary compatibility.

## Changes

- Moves permits testing helpers to @ontrails/permits/testing and removes them from the root export.
- Keeps Commander runtime helpers on @ontrails/cli/commander instead of the CLI root.
- Adds @ontrails/warden/ast as the supported AST helper subpath and classifies oxc-parser as runtime dependency.
- Adds SURFACE_KEY while preserving TRAILHEAD_KEY as a deprecated alias over the same metadata slot.
- Updates API docs and public API tests for the supported paths.

## Testing

- bun test packages/core/src/__tests__/surface-derivation.test.ts packages/permits/src/__tests__/public-api.test.ts packages/permits/src/__tests__/auth-verify.test.ts packages/cli/src/__tests__/public-api.test.ts packages/cli/src/__tests__/surface.test.ts packages/warden/src/__tests__/public-api.test.ts apps/trails/src/__tests__/draft-promote.test.ts
- bun run format:check
- bun run lint
- bun run build
- bun run test
- bun run check
- PR CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->