### PR TITLE
docs: consolidate warden rule methodology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,8 @@ The architecture is designed to make consistency easier than drift. Agents build
 1. Contracts are at the core of how Trails works, and the contract for how Trails is worked on is governed by our [Tenets](docs/tenets.md).
 2. Decisions that define what Trails is, and what it is not, are defined by our [ADRs](docs/adr/README.md).
    - Future directions for Trails are outlined in speculative or [draft ADRs](docs/adr/drafts/README.md).
-3. We keep a log of our working notes, session recaps, learnings, etc. in `.agents/notes/` (gitignored — local only) as a historical record of our journey.
+3. Durable Warden rule methodology lives in [Rule Design](docs/rule-design.md).
+4. We keep a log of our working notes, session recaps, learnings, etc. in `.agents/notes/` (gitignored — local only) as a historical record of our journey.
 
 ## Lexicon
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@
 ## Governing your codebase?
 
 - **[Warden](./warden.md)** — Trails correctness rules, rule-home boundaries, drift detection, CI integration
+- **[Rule Design](./rule-design.md)** — Methodology for durable Warden rules, owner-held rule data, and rule-family collapse
 - **[Schema](../packages/schema/README.md)** — Surface maps, topo compile helpers, semantic diffing, lock files
 
 ## Design decisions

--- a/docs/rule-design.md
+++ b/docs/rule-design.md
@@ -1,0 +1,222 @@
+# Rule Design
+
+This guide explains how to author and audit Trails correctness rules so they
+survive framework evolution instead of encoding one audit incident. It applies to
+Warden rules, repo-local lint delivery, advisory guidance, and temporary
+hardening scanners.
+
+Use it with [Warden](./warden.md), [ADR-0036](./adr/0036-warden-rules-ship-only-as-trails.md),
+and [ADR-0037](./adr/0037-owner-first-authority.md).
+
+## Rule Home Doctrine
+
+- Warden is the durable public correctness surface for Trails.
+- Warden owns source-static, project-static, topo-aware, drift, and advisory
+  checks when they enforce public Trails semantics.
+- The private `@ontrails/oxlint-plugin` package is repo-local lint delivery and
+  a possible future compiled destination for Warden-owned source checks. It is
+  not the public framework correctness surface.
+- Scratch scanners are prototypes. Proven checks graduate into Warden or retire.
+- Owner-first authority is the v1 rule-data model. Rules import framework data
+  from the natural owner module.
+- Trails does not use `canonicalSource()`, TSDoc `@canonical` tags,
+  topo-resident canonical tables, generic registries, loader APIs, or
+  `derivedFrom` metadata as the default answer to duplicated framework facts.
+
+The tier names here are authoring classifications. Runtime tier metadata,
+filtering, and advisory report shape land in the Warden metadata work; until
+then, classify rules with these names in docs, tests, and issue descriptions.
+
+## Core Principle
+
+Express rules as invariants the framework holds, not as instances of bugs found
+during an audit.
+
+Instance form:
+
+```ts
+{
+  name: 'mcp-error-map-not-consumed',
+  description: "MCP handler must call mapTransportError('mcp', err)",
+}
+```
+
+Invariant form:
+
+```ts
+{
+  name: 'registered-error-map-not-consumed',
+  invariant:
+    'Any surface that registers an error mapping must consume it in its error path.',
+  readsFrom: 'codesByCategory',
+}
+```
+
+The invariant form survives new surfaces, renamed helpers, and future
+extensions. Prefer it whenever deterministic detection is feasible.
+
+## Survival Tests
+
+Run these tests before landing a new rule or refactoring an old one.
+
+### Mechanism-Renamed Test
+
+If a helper gets renamed tomorrow, does the rule still enforce the same
+framework promise?
+
+- Bad: the rule requires a specific helper call when the helper is only
+  mechanism.
+- Better: the rule detects the role, owner data, or structural obligation.
+- Acceptable: exact symbol matching when the symbol itself is stable public
+  contract, such as `Result.ok`, `Result.err`, or `ctx.cross()`.
+
+### Family Test
+
+Can you name three instances of the same shape today?
+
+If yes, write the family-level rule. If no, either refuse the rule or give it a
+binding `retireWhen` clause with mechanical enforcement. A soft note is not an
+expiry plan.
+
+### Data-Source Test
+
+Does the rule duplicate framework data that an owner module already declares?
+
+Read owner exports for error classes, surface code mappings, intent values, CRUD
+doctrine, detour caps, Result accessor names, connector descriptors, and reserved
+lexicon terms. If the owner does not expose the data cleanly, strengthen the
+owner first.
+
+### Surface-Extension Test
+
+When a new surface, primitive, or extension lands, does the rule extend through
+owner data or do we need a sibling rule?
+
+Sibling rules per surface or primitive usually mean the invariant is too low
+level.
+
+### Context Test
+
+Is the rule universal, extension-only, internal-only, repo-local, temporary, or
+advisory?
+
+The limitation must be principled. "We only wrote the detector for one context"
+is not a principle.
+
+## Owner-First Authority
+
+Framework values live in the module that owns the concept.
+
+| Owner Source | Authoritative For |
+| --- | --- |
+| `errorClasses`, `codesByCategory`, and `TrailsError` classes | Error taxonomy and surface error-code mappings |
+| `intentValues` | Intent union values |
+| Store doctrine exports | CRUD operation set and accessor expectations |
+| `DETOUR_MAX_ATTEMPTS_CAP` | Detour retry limit |
+| `resultAccessorNames` | Result accessors that imply sync assumptions |
+| Lexicon reserved terms | Retired vocabulary for source-file checks |
+| Connector descriptors, once formalized | Extension and surface declarations |
+| Capability matrix, once formalized | Primitive lifecycle expectations |
+
+When a rule needs one of these values:
+
+1. Import from the natural owner.
+2. If the data is not exported, add a typed owner export.
+3. Use rule-owned configuration only when the list itself is policy, not a
+   projection of framework data.
+
+Curated rule data is valid when it is policy. For example,
+`context-no-surface-types` can own its denylist until another independent
+consumer appears or drift proves the list belongs elsewhere.
+
+Consumer apps do not author framework authority. Their topo is their local
+source of truth; framework rules read framework owners.
+
+## Rule Shapes
+
+Use recurring shapes to avoid writing the third sibling rule.
+
+| Shape | Form | Examples |
+| --- | --- | --- |
+| Declarations-match-usage | Static declaration matches runtime call | `crosses` and `ctx.cross`; `fires` and `ctx.fire`; `resources` and `db.from(ctx)` |
+| Owner-projection-parity | Derived data keeps reading its owner | Error-code maps, CRUD operations, intent literals |
+| Orphan-X | Primitive declared but never referenced | Orphan resource, signal, layer, contour |
+| Cycle-in-X-graph | Directed graph must not cycle | Cross graph, activation graph, layer dependency graph |
+| Collision-detection | Two declarations claim the same slot | HTTP route, webhook path, MCP tool name |
+| Schema-compatibility | Source schema satisfies consumer schema | Cross input, signal payload |
+| Vocabulary-banned-term | Source identifier uses retired vocabulary | Reserved terms in TS/JS source |
+| Declaration-requires-companion | Declaration needs infrastructure to run | Source kind and materializer, resource and adapter |
+
+Collapse only when data model, traversal, and diagnostic shape are genuinely
+shared. Similar English is not enough.
+
+## Source-File Vocabulary Rules
+
+Retired vocabulary checks apply to source files. Documentation vocabulary is an
+editorial review or docs-cutover concern.
+
+When a rule fires on a word, import path, or literal symbol, scope it to the role
+the rule owns.
+
+- Prefer AST positions over free-text matches.
+- Exclude unrelated third-party or domain uses.
+- List rule-owned roles explicitly when a word has legitimate meanings outside
+  the Trails concept being retired.
+
+## Existing Rule Audit Checklist
+
+For each existing rule:
+
+1. Write a one-line invariant.
+2. Run the survival tests.
+3. Identify owner sources.
+4. Classify the rule.
+
+Use these classifications:
+
+- **Durable:** keep as-is.
+- **Refactor:** same invariant, better owner data or wording needed.
+- **Replace:** instance-level rule must be promoted or retired.
+- **Merge:** sibling of another rule; collapse when the shared shape is real.
+- **Curated policy:** rule-owned data is the policy and should remain local for
+  now.
+
+## New Rule Checklist
+
+- [ ] One-line invariant.
+- [ ] Survival tests pass, or each failure has a principled reason.
+- [ ] Owner sources identified.
+- [ ] Family shape named.
+- [ ] Context named: external, extension, internal, repo-local, temporary, or
+  advisory.
+- [ ] Retirement criterion added if the family test fails.
+- [ ] Warden tier named: source-static, project-static, topo-aware, drift, or
+  advisory.
+- [ ] Private plugin delivery considered only as implementation plumbing.
+
+## Anti-Patterns
+
+- Rule name references one surface or helper when the invariant is broader.
+- Description says "X must call Y" when Y is mechanism.
+- Rule lists framework values inline instead of reading owner data.
+- Sibling rules appear per surface or primitive.
+- Single-file bug detector has no expiry.
+- Public docs tell users to install a lint package for framework correctness.
+- Scratch scanner becomes a permanent tool by inertia.
+- Generic registry machinery appears as the default solution before owner
+  modules are tested.
+
+## Hardening Loop
+
+When an audit produces a prevention candidate:
+
+1. Convert the observed bug into a framework invariant.
+2. Run the survival tests.
+3. Name the owner data source.
+4. Choose the narrowest Warden tier that can answer the question.
+5. Use the private plugin only for repo-local cleanup or delivery mechanics.
+6. Add tests that prove both accepted code and the diagnostic shape.
+7. Record any temporary rule's deletion trigger.
+
+Forward-looking skills, docs, and advisory reports can consume owner data and
+Warden findings. They do not become parallel authority.

--- a/docs/warden.md
+++ b/docs/warden.md
@@ -4,6 +4,10 @@ Warden is Trails' correctness surface. It catches code-level framework drift, re
 
 Structural graph checks that can be answered from the resolved topo belong in `validateTopo()` from `@ontrails/core`. Warden owns checks that need source inspection, project context, topo-aware analysis, or drift reporting.
 
+Use [Rule Design](./rule-design.md) when authoring or auditing rules. It defines
+the survival tests, owner-data expectations, and family-collapse criteria for
+durable rules.
+
 ## Rule Homes
 
 Use Warden for durable Trails correctness:

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -1,20 +1,23 @@
 # @ontrails/warden
 
-AST-based code convention rules for Trails. Built-in lint rules catch contract violations at development time, alongside lock drift detection and CI formatters.
+AST-based code convention rules for Trails. Built-in lint rules catch contract
+violations at development time, alongside lock drift detection and CI
+formatters.
 
-Structural checks (cross target existence, declared resource existence, recursive crossing, example schema validation) live in `validateTopo()` from `@ontrails/core`. Warden handles the code-level rules that need AST analysis.
+Structural checks (cross target existence, declared resource existence,
+recursive crossing, example schema validation) live in `validateTopo()` from
+`@ontrails/core`. Warden handles the code-level rules that need AST analysis.
 
-For rule-home boundaries and authoring doctrine, see the [Warden guide](../../docs/warden.md).
+For rule-home boundaries and authoring doctrine, see the
+[Warden guide](../../docs/warden.md) and
+[Rule Design](../../docs/rule-design.md).
 
 ## Usage
 
 From the Trails CLI:
 
 ```bash
-trails warden              # Run all checks
-trails warden --exit-code  # Non-zero exit on errors or drift
-trails warden --lint-only  # Skip drift detection
-trails warden --drift-only # Skip lint rules
+bunx trails warden # Run all checks
 ```
 
 Or programmatically:
@@ -28,24 +31,22 @@ console.log(formatWardenReport(report));
 
 ## Rules
 
-| Rule | Severity | What it catches |
-| --- | --- | --- |
-| `no-throw-in-implementation` | error | `throw` inside blaze bodies |
-| `implementation-returns-result` | error | Blaze functions returning raw values instead of `Result` |
-| `context-no-surface-types` | error | Surface type imports (`Request`, `McpSession`) in trail files |
-| `no-sync-result-assumption` | error | Missing `await` on `.blaze()` results |
-| `valid-detour-contract` | error | Detours with non-constructor `on` values or non-callable `recover` values |
-| `no-throw-in-detour-recover` | error | `throw` inside detour `recover` functions |
-| `unreachable-detour-shadowing` | error | Later detours made unreachable by earlier same-or-broader `on:` error types |
-| `no-direct-implementation-call` | warn | Direct `.blaze()` calls bypassing `ctx.cross()` |
-| `no-direct-impl-in-route` | warn | Direct `.blaze()` calls inside trail bodies with `crosses` |
-| `prefer-schema-inference` | warn | Redundant field overrides already derivable from the schema |
-| `cross-declarations` | error/warn | `ctx.cross()` calls that drift from declared `crosses: [...]` |
-| `resource-declarations` | error/warn | `resource.from(ctx)` / `ctx.resource()` usage that drifts from declared `resources: [...]` |
-| `resource-exists` | error | Declared or referenced resource IDs that do not resolve in project context |
-| `valid-describe-refs` | warn | `@see` refs in `.describe()` that do not resolve |
-| `draft-file-marking` | error | Draft-bearing files missing `_draft.*` or `*.draft.*` filename markers |
-| `draft-visible-debt` | warn | Draft IDs remaining in source files that need promotion or removal |
+Built-in rules are registered in `wardenRules` and `wardenTopoRules`; use those
+registries or `wardenTopo.ids()` for the current rule list instead of copying a
+static table into docs.
+
+Rules cover several families:
+
+- blaze and `Result` contract checks
+- cross, fire, resource, and detour declaration drift
+- draft-state containment
+- source-static guardrails such as surface-type leakage
+- topo-aware checks that need the resolved graph or resource mock shape
+
+When adding or auditing rules, follow [Rule Design](../../docs/rule-design.md):
+name the invariant, import owner-held framework data, choose the narrowest
+Warden tier, and collapse families only when the data model, traversal, and
+diagnostic shape are shared.
 
 ## Drift detection
 
@@ -68,14 +69,18 @@ Add to lefthook for pre-push enforcement:
 pre-push:
   commands:
     warden:
-      run: trails warden --exit-code
+      run: bunx trails warden
       tags: governance
 ```
 
 CI formatters for structured output:
 
 ```typescript
-import { formatGitHubAnnotations, formatJson, formatSummary } from '@ontrails/warden';
+import {
+  formatGitHubAnnotations,
+  formatJson,
+  formatSummary,
+} from '@ontrails/warden';
 ```
 
 Parser helpers for rule authoring and repo-local tooling live on the dedicated
@@ -87,7 +92,8 @@ import { findStringLiterals, parse, walk } from '@ontrails/warden/ast';
 
 ## Trail-based API
 
-Every built-in warden rule is also available as a composable trail. This makes rules queryable, testable, and invocable through any Trails surface.
+Every built-in warden rule is also available as a composable trail. This makes
+rules queryable, testable, and invocable through any Trails surface.
 
 ```typescript
 import {
@@ -109,7 +115,9 @@ const diagnostics = await runWardenTrails(filePath, sourceCode, {
 const topoDiagnostics = await runTopoAwareWardenTrails(myApp);
 ```
 
-To wrap a custom rule as a trail, use `wrapRule` (imported from `@ontrails/warden/trails/wrap-rule`). This is the same factory used internally to build all built-in rule trails.
+To wrap a custom rule as a trail, use `wrapRule` (imported from
+`@ontrails/warden/trails/wrap-rule`). This is the same factory used internally
+to build all built-in rule trails.
 
 ## API
 


### PR DESCRIPTION
## Context

Refs TRL-512. This restarts the Warden-first hardening stack after the previous doctrine PR was closed for a clean reset.

## Changes

- Adds `docs/rule-design.md` as the durable Warden rule methodology guide.
- Links the guide from `AGENTS.md`, `docs/index.md`, and `docs/warden.md`.
- Refreshes `packages/warden/README.md` so examples use the current `bunx trails warden` shape and point to the methodology doc instead of stale static rule tables.

## Testing

- `bun run format:check`
- `bun run check` from the top of the stack

## Risks

Docs-only branch. Main review risk is doctrine wording, especially whether the tier and lifecycle caveats are precise enough for later TRL-513 metadata work.