### PR TITLE
refactor: read warden rule data from owners

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -237,11 +237,12 @@
       "version": "1.0.0-beta.15",
       "dependencies": {
         "@ontrails/permits": "workspace:^",
+        "@ontrails/store": "workspace:^",
+        "oxc-parser": "^0.121.0",
       },
       "devDependencies": {
         "@ontrails/testing": "workspace:^",
         "@oxc-project/types": "^0.122.0",
-        "oxc-parser": "^0.121.0",
         "zod": "catalog:",
       },
       "peerDependencies": {

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@ontrails/permits": "workspace:^",
+    "@ontrails/store": "workspace:^",
     "oxc-parser": "^0.121.0"
   },
   "devDependencies": {

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -8,7 +8,8 @@
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { DRAFT_ID_PREFIX } from '@ontrails/core';
+import { DRAFT_ID_PREFIX, intentValues } from '@ontrails/core';
+import type { Intent } from '@ontrails/core';
 import { parseSync } from 'oxc-parser';
 
 // ---------------------------------------------------------------------------
@@ -2528,21 +2529,27 @@ export const collectCrossTargetTrailIds = (
   return ids;
 };
 
-const extractTrailIntent = (config: AstNode): 'destroy' | 'read' | 'write' => {
+const INTENT_VALUE_SET = new Set<string>(intentValues);
+const DEFAULT_INTENT: Intent = 'write';
+
+const normalizeTrailIntent = (value: string): Intent =>
+  INTENT_VALUE_SET.has(value) ? (value as Intent) : DEFAULT_INTENT;
+
+const extractTrailIntent = (config: AstNode): Intent => {
   const intentProp = findConfigProperty(config, 'intent');
   if (!intentProp || !isStringLiteral(intentProp.value as AstNode)) {
-    return 'write';
+    return DEFAULT_INTENT;
   }
 
   const value = getStringValue(intentProp.value as AstNode);
-  return value === 'destroy' || value === 'read' ? value : 'write';
+  return value ? normalizeTrailIntent(value) : DEFAULT_INTENT;
 };
 
 /** Collect the normalized intent for every trail definition in a parsed file. */
 export const collectTrailIntentsById = (
   ast: AstNode
-): ReadonlyMap<string, 'destroy' | 'read' | 'write'> => {
-  const intents = new Map<string, 'destroy' | 'read' | 'write'>();
+): ReadonlyMap<string, Intent> => {
+  const intents = new Map<string, Intent>();
 
   for (const def of findTrailDefinitions(ast)) {
     if (def.kind === 'trail') {

--- a/packages/warden/src/rules/incomplete-accessor-for-standard-op.ts
+++ b/packages/warden/src/rules/incomplete-accessor-for-standard-op.ts
@@ -16,58 +16,14 @@
  */
 
 import type { AnyResource, AnyTrail, Topo } from '@ontrails/core';
+import { crudAccessorExpectations, crudOperations } from '@ontrails/store';
+import type { CrudAccessorExpectation, CrudOperation } from '@ontrails/store';
 
 import type { TopoAwareWardenRule, WardenDiagnostic } from './types.js';
 
-type StandardOp = 'create' | 'read' | 'update' | 'delete' | 'list';
+type StandardOp = CrudOperation;
 
-type AccessorExpectation =
-  | {
-      readonly preferred: string;
-      readonly fallback: string;
-      readonly severityWhenPreferredMissingWithFallback: 'warn';
-      readonly severityWhenNoFallback: 'error';
-    }
-  | {
-      readonly preferred: string;
-      readonly fallback?: undefined;
-      readonly severityWhenNoFallback: 'error';
-    };
-
-const STANDARD_OPS: ReadonlySet<StandardOp> = new Set([
-  'create',
-  'read',
-  'update',
-  'delete',
-  'list',
-]);
-
-const EXPECTATIONS: Readonly<Record<StandardOp, AccessorExpectation>> = {
-  create: {
-    fallback: 'upsert',
-    preferred: 'insert',
-    severityWhenNoFallback: 'error',
-    severityWhenPreferredMissingWithFallback: 'warn',
-  },
-  delete: {
-    preferred: 'remove',
-    severityWhenNoFallback: 'error',
-  },
-  list: {
-    preferred: 'list',
-    severityWhenNoFallback: 'error',
-  },
-  read: {
-    preferred: 'get',
-    severityWhenNoFallback: 'error',
-  },
-  update: {
-    fallback: 'upsert',
-    preferred: 'update',
-    severityWhenNoFallback: 'error',
-    severityWhenPreferredMissingWithFallback: 'warn',
-  },
-};
+const STANDARD_OPS: ReadonlySet<StandardOp> = new Set(crudOperations);
 
 const RULE_NAME = 'incomplete-accessor-for-standard-op';
 
@@ -239,7 +195,7 @@ const extractStandardOpContext = (
 const diagnoseMissingMethod = (
   ctx: StandardOpContext,
   methods: ReadonlySet<string>,
-  expectation: AccessorExpectation
+  expectation: CrudAccessorExpectation
 ): WardenDiagnostic | undefined => {
   if (methods.has(expectation.preferred)) {
     return undefined;
@@ -259,7 +215,8 @@ const diagnoseMissingMethod = (
       ctx.trailId,
       ctx.operation,
       `${base} is missing preferred method "${expectation.preferred}"; falls back to "${fallback}"`,
-      expectation.severityWhenPreferredMissingWithFallback
+      expectation.severityWhenPreferredMissingWithFallback ??
+        expectation.severityWhenNoFallback
     );
   }
   return formatDiagnostic(
@@ -284,7 +241,7 @@ const evaluateTrail = async (
   const diagnostic = diagnoseMissingMethod(
     ctx,
     methods,
-    EXPECTATIONS[ctx.operation]
+    crudAccessorExpectations[ctx.operation]
   );
   return diagnostic === undefined ? [] : [diagnostic];
 };

--- a/packages/warden/src/rules/incomplete-crud.ts
+++ b/packages/warden/src/rules/incomplete-crud.ts
@@ -1,13 +1,15 @@
+import { crudOperations } from '@ontrails/store';
+
 import {
   collectNamedContourIds,
   collectNamedStoreTableIds,
+  deriveStoreTableId,
   getStringValue,
   identifierName,
   isNamedCall,
   isStringLiteral,
   offsetToLine,
   parse,
-  deriveStoreTableId,
   walk,
 } from './ast.js';
 import type { AstNode } from './ast.js';
@@ -18,8 +20,7 @@ import type {
   WardenDiagnostic,
 } from './types.js';
 
-const CRUD_OPERATIONS = ['create', 'read', 'update', 'delete', 'list'] as const;
-const CRUD_OPERATION_SET = new Set<string>(CRUD_OPERATIONS);
+const CRUD_OPERATION_SET = new Set<string>(crudOperations);
 
 /** Sentinel entity id prefix for contours imported from another module. */
 const IMPORTED_CONTOUR_PREFIX = 'imported:';
@@ -318,7 +319,7 @@ const collectTupleOperations = (
   // check below intentionally treats those the same as out-of-bounds slots.
   // If OXC ever switches to a non-null placeholder node, update this to an
   // explicit null check so elisions still count as absent.
-  CRUD_OPERATIONS.flatMap((operation, index) =>
+  crudOperations.flatMap((operation, index) =>
     elements[index] ? [operation] : []
   );
 
@@ -488,7 +489,7 @@ const collectIncompleteEntities = (
     if (!combined || combined.size === 0) {
       return [];
     }
-    if (combined.size >= CRUD_OPERATIONS.length) {
+    if (combined.size >= crudOperations.length) {
       return [];
     }
     return [
@@ -512,10 +513,10 @@ const buildIncompleteCrudDiagnostic = (
   coverage: CrudCoverage,
   filePath: string
 ): WardenDiagnostic => {
-  const present = CRUD_OPERATIONS.filter((operation) =>
+  const present = crudOperations.filter((operation) =>
     coverage.operations.has(operation)
   );
-  const missing = CRUD_OPERATIONS.filter(
+  const missing = crudOperations.filter(
     (operation) => !coverage.operations.has(operation)
   );
 

--- a/packages/warden/src/rules/intent-propagation.ts
+++ b/packages/warden/src/rules/intent-propagation.ts
@@ -3,10 +3,7 @@ import {
   collectNamedTrailIds,
   collectTrailIntentsById,
   extractDefinitionCrossTargetIds,
-  findConfigProperty,
   findTrailDefinitions,
-  getStringValue,
-  isStringLiteral,
   offsetToLine,
   parse,
 } from './ast.js';
@@ -17,17 +14,6 @@ import type {
   ProjectContext,
   WardenDiagnostic,
 } from './types.js';
-
-const extractTrailIntent = (config: AstNode): Intent => {
-  const intentProp = findConfigProperty(config, 'intent');
-  const intentValue = intentProp?.value as AstNode | undefined;
-  if (!intentValue || !isStringLiteral(intentValue)) {
-    return 'write';
-  }
-
-  const value = getStringValue(intentValue);
-  return value === 'destroy' || value === 'read' ? value : 'write';
-};
 
 const buildIntentPropagationDiagnostic = (
   trailId: string,
@@ -74,7 +60,7 @@ const buildDiagnosticsForTrail = (
   namedTrailIds: ReadonlyMap<string, string>,
   trailIntentsById: ReadonlyMap<string, Intent>
 ): readonly WardenDiagnostic[] => {
-  if (def.kind !== 'trail' || extractTrailIntent(def.config) !== 'read') {
+  if (def.kind !== 'trail' || trailIntentsById.get(def.id) !== 'read') {
     return [];
   }
 
@@ -128,12 +114,11 @@ export const intentPropagation: ProjectAwareWardenRule = {
     const localTrailIntentsById = ast
       ? collectTrailIntentsById(ast)
       : new Map<string, Intent>();
-    return checkIntentPropagation(
-      ast,
-      sourceCode,
-      filePath,
-      context.trailIntentsById ?? localTrailIntentsById
-    );
+    const trailIntentsById = new Map(localTrailIntentsById);
+    for (const [trailId, intent] of context.trailIntentsById ?? []) {
+      trailIntentsById.set(trailId, intent);
+    }
+    return checkIntentPropagation(ast, sourceCode, filePath, trailIntentsById);
   },
   description:
     "Warn when a trail declaring intent: 'read' crosses a trail whose normalized intent is write or destroy.",

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -1,4 +1,4 @@
-import type { Topo } from '@ontrails/core';
+import type { Intent, Topo } from '@ontrails/core';
 
 /**
  * Severity level for warden diagnostics.
@@ -64,7 +64,7 @@ export interface ProjectContext {
   /** Store table IDs used with reconcile trails across the project. */
   readonly reconcileTableIds?: ReadonlySet<string>;
   /** Normalized trail intents by trail ID across the project. */
-  readonly trailIntentsById?: ReadonlyMap<string, 'destroy' | 'read' | 'write'>;
+  readonly trailIntentsById?: ReadonlyMap<string, Intent>;
   /**
    * CRUD operation coverage per entity aggregated across the project.
    *

--- a/packages/warden/src/trails/run.ts
+++ b/packages/warden/src/trails/run.ts
@@ -6,7 +6,7 @@
  * so callers that loop files do not duplicate graph-level findings.
  */
 
-import type { Topo } from '@ontrails/core';
+import type { Intent, Topo } from '@ontrails/core';
 import { run } from '@ontrails/core';
 
 import { wardenTopoRules } from '../rules/index.js';
@@ -29,7 +29,7 @@ const appendDiagnostics = (
   }
 };
 
-type TrailIntentMap = Readonly<Record<string, 'destroy' | 'read' | 'write'>>;
+type TrailIntentMap = Readonly<Record<string, Intent>>;
 
 interface ProjectRuleOptions {
   readonly contourReferencesByName?: Readonly<

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -5,6 +5,7 @@
  * (array of diagnostics) shape.
  */
 
+import { intentValues } from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -73,7 +74,7 @@ export const projectAwareRuleInput = ruleInput.extend({
     .optional()
     .describe('Store table IDs used with reconcile trails across the project'),
   trailIntentsById: z
-    .record(z.string(), z.enum(['read', 'write', 'destroy']))
+    .record(z.string(), z.enum(intentValues))
     .optional()
     .describe('Normalized trail intents keyed by trail ID'),
 });


### PR DESCRIPTION
## Context

Refs TRL-528. The owner-authority stack landed first, so Warden can stop carrying parallel copies of core intent values, store CRUD operations, and result accessor expectations.

## Changes

- Reads intent values from `@ontrails/core` for intent propagation parsing and trail schemas.
- Reads CRUD operation names and accessor expectations from `@ontrails/store`.
- Adds `@ontrails/store` as a Warden dependency and refreshes the lockfile.

## Testing

- `bun test packages/warden/src/__tests__/intent-propagation.test.ts packages/warden/src/__tests__/incomplete-crud.test.ts packages/warden/src/__tests__/incomplete-accessor-for-standard-op.test.ts packages/warden/src/__tests__/missing-reconcile.test.ts packages/warden/src/__tests__/no-sync-result-assumption.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run check` from the top of the stack

## Risks

Warden now has a runtime package dependency on `@ontrails/store`. That is intentional for owner-held rule data, but it is the main package-boundary point to review.