### PR TITLE
refactor: use owner error data in warden rules

### DIFF
--- a/packages/warden/src/__tests__/error-mapping-completeness.test.ts
+++ b/packages/warden/src/__tests__/error-mapping-completeness.test.ts
@@ -2,10 +2,33 @@ import { describe, expect, test } from 'bun:test';
 
 import { errorMappingCompleteness } from '../rules/error-mapping-completeness.js';
 
-const TEST_FILE = 'transport-error-map.ts';
+const TEST_FILE = 'surface-error-map.ts';
 
 describe('error-mapping-completeness', () => {
-  test('passes complete mapper registrations', () => {
+  test('passes complete surface mapper registrations', () => {
+    const code = `
+import { createSurfaceErrorMapper } from '@ontrails/core';
+
+const cliMapper = createSurfaceErrorMapper({
+  auth: 9,
+  cancelled: 130,
+  conflict: 3,
+  internal: 8,
+  network: 7,
+  not_found: 2,
+  permission: 4,
+  rate_limit: 6,
+  timeout: 5,
+  validation: 1,
+});
+`;
+
+    const diagnostics = errorMappingCompleteness.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('passes complete compatibility mapper registrations', () => {
     const code = `
 import { createTransportErrorMapper } from '@ontrails/core';
 
@@ -28,11 +51,11 @@ const cliMapper = createTransportErrorMapper({
     expect(diagnostics).toHaveLength(0);
   });
 
-  test('catches incomplete mapper registrations resolved through object properties', () => {
+  test('catches incomplete surface mapper registrations resolved through object properties', () => {
     const code = `
-import { createTransportErrorMapper } from '@ontrails/core';
+import { createSurfaceErrorMapper } from '@ontrails/core';
 
-const transportErrorMap = {
+const surfaceErrorMap = {
   cli: {
     conflict: 3,
     internal: 8,
@@ -41,7 +64,7 @@ const transportErrorMap = {
   },
 };
 
-const cliMapper = createTransportErrorMapper(transportErrorMap.cli);
+const cliMapper = createSurfaceErrorMapper(surfaceErrorMap.cli);
 `;
 
     const diagnostics = errorMappingCompleteness.check(code, TEST_FILE);

--- a/packages/warden/src/__tests__/unreachable-detour-shadowing.test.ts
+++ b/packages/warden/src/__tests__/unreachable-detour-shadowing.test.ts
@@ -56,6 +56,23 @@ trail('entity.save', {
     expect(diagnostics[0]?.message).toContain('StoreConflictError');
   });
 
+  test('flags a later owner-registered subclass shadowed by its parent detour', () => {
+    const code = `
+trail('entity.permit', {
+  detours: [
+    { on: PermissionError, recover: async () => Result.ok({ winner: 'permission' }) },
+    { on: PermitError, recover: async () => Result.ok({ winner: 'permit' }) },
+  ],
+});
+`;
+
+    const diagnostics = unreachableDetourShadowing.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('PermissionError');
+    expect(diagnostics[0]?.message).toContain('PermitError');
+  });
+
   test('flags a later detour shadowed by an earlier DerivationError detour', () => {
     const code = `
 trail('entity.derive', {

--- a/packages/warden/src/rules/error-mapping-completeness.ts
+++ b/packages/warden/src/rules/error-mapping-completeness.ts
@@ -1,12 +1,14 @@
 /**
- * Validates that registered transport error mappers cover every error category.
+ * Validates that registered surface error mappers cover every error category.
  *
- * Scans `createTransportErrorMapper(...)` calls and resolves simple object
- * literals, identifier bindings, and object-property references in the same
- * file so incomplete mapper registrations are caught before they ship.
+ * Scans `createSurfaceErrorMapper(...)` and compatibility
+ * `createTransportErrorMapper(...)` calls, then resolves simple object
+ * literals, identifier bindings, and object-property references in the same file
+ * so incomplete mapper registrations are caught before they ship.
  */
 
-import { errorCategories } from '@ontrails/core';
+import { codesByCategory, errorClasses } from '@ontrails/core';
+import type { ErrorCategory } from '@ontrails/core';
 
 import {
   getStringValue,
@@ -24,6 +26,21 @@ const MEMBER_EXPRESSION_TYPES = new Set([
   'MemberExpression',
   'StaticMemberExpression',
 ]);
+
+const MAPPER_FACTORY_NAMES = new Set([
+  'createSurfaceErrorMapper',
+  'createTransportErrorMapper',
+]);
+
+const mappedErrorClassCategories = new Set(
+  errorClasses.flatMap((entry) =>
+    entry.category === 'dynamic' ? [] : [entry.category]
+  )
+);
+
+const requiredErrorCategories = (
+  Object.keys(codesByCategory) as ErrorCategory[]
+).filter((category) => mappedErrorClassCategories.has(category));
 
 const getPropertyName = (node: AstNode | undefined): string | null => {
   if (!node) {
@@ -176,7 +193,7 @@ const createDiagnostic = (
 ): WardenDiagnostic => ({
   filePath,
   line,
-  message: `Transport error mapper is missing mappings for: ${missingCategories.join(', ')}. Registered createTransportErrorMapper() calls must cover every ErrorCategory.`,
+  message: `Surface error mapper is missing mappings for: ${missingCategories.join(', ')}. Registered createSurfaceErrorMapper() and compatibility createTransportErrorMapper() calls must cover every ErrorCategory.`,
   rule: 'error-mapping-completeness',
   severity: 'error',
 });
@@ -189,12 +206,12 @@ const getCallCallee = (node: AstNode): AstNode | undefined =>
 
 const isMapperFactoryCall = (node: AstNode): boolean =>
   node.type === 'CallExpression' &&
-  identifierName(getCallCallee(node)) === 'createTransportErrorMapper';
+  MAPPER_FACTORY_NAMES.has(identifierName(getCallCallee(node)) ?? '');
 
 const findMissingCategories = (
   mappedCategories: ReadonlySet<string>
 ): readonly string[] =>
-  errorCategories.filter((category) => !mappedCategories.has(category));
+  requiredErrorCategories.filter((category) => !mappedCategories.has(category));
 
 const resolveMappedCategories = (
   node: AstNode,
@@ -233,13 +250,15 @@ const inspectMapperCall = (
 };
 
 /**
- * Flags `createTransportErrorMapper()` registrations that omit error categories.
+ * Flags registered surface error mapper calls that omit error categories.
  */
 export const errorMappingCompleteness: WardenRule = {
   check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
     if (
       isTestFile(filePath) ||
-      !sourceCode.includes('createTransportErrorMapper')
+      ![...MAPPER_FACTORY_NAMES].some((factoryName) =>
+        sourceCode.includes(factoryName)
+      )
     ) {
       return [];
     }
@@ -267,7 +286,7 @@ export const errorMappingCompleteness: WardenRule = {
     return diagnostics;
   },
   description:
-    'Require registered transport error mappers to cover every ErrorCategory.',
+    'Require registered surface error mappers to cover every ErrorCategory.',
   name: 'error-mapping-completeness',
   severity: 'error',
 };

--- a/packages/warden/src/rules/unreachable-detour-shadowing.ts
+++ b/packages/warden/src/rules/unreachable-detour-shadowing.ts
@@ -1,21 +1,4 @@
-import {
-  AlreadyExistsError,
-  AmbiguousError,
-  AssertionError,
-  AuthError,
-  CancelledError,
-  ConflictError,
-  DerivationError,
-  InternalError,
-  NetworkError,
-  NotFoundError,
-  PermissionError,
-  RateLimitError,
-  RetryExhaustedError,
-  TimeoutError,
-  TrailsError,
-  ValidationError,
-} from '@ontrails/core';
+import { TrailsError, errorClasses } from '@ontrails/core';
 
 import {
   extractStringLiteral,
@@ -42,21 +25,7 @@ interface DetourOnType {
 
 const knownErrorConstructors = new Map<string, ErrorTypeShape>([
   [TrailsError.name, TrailsError],
-  [ValidationError.name, ValidationError],
-  [AmbiguousError.name, AmbiguousError],
-  [AssertionError.name, AssertionError],
-  [NotFoundError.name, NotFoundError],
-  [AlreadyExistsError.name, AlreadyExistsError],
-  [ConflictError.name, ConflictError],
-  [PermissionError.name, PermissionError],
-  [TimeoutError.name, TimeoutError],
-  [RateLimitError.name, RateLimitError],
-  [NetworkError.name, NetworkError],
-  [InternalError.name, InternalError],
-  [DerivationError.name, DerivationError],
-  [AuthError.name, AuthError],
-  [CancelledError.name, CancelledError],
-  [RetryExhaustedError.name, RetryExhaustedError],
+  ...errorClasses.map(({ ctor, name }) => [name, ctor] as const),
 ]);
 
 const knownErrorParents = new Map<string, string | null>(

--- a/packages/warden/src/trails/error-mapping-completeness.trail.ts
+++ b/packages/warden/src/trails/error-mapping-completeness.trail.ts
@@ -6,10 +6,10 @@ export const errorMappingCompletenessTrail = wrapRule({
     {
       expected: { diagnostics: [] },
       input: {
-        filePath: 'transport-error-map.ts',
-        sourceCode: `import { createTransportErrorMapper } from "@ontrails/core";
+        filePath: 'surface-error-map.ts',
+        sourceCode: `import { createSurfaceErrorMapper } from "@ontrails/core";
 
-const cliMapper = createTransportErrorMapper({
+const cliMapper = createSurfaceErrorMapper({
   auth: 9,
   cancelled: 130,
   conflict: 3,
@@ -22,7 +22,7 @@ const cliMapper = createTransportErrorMapper({
   validation: 1,
 });`,
       },
-      name: 'Complete transport error mapper',
+      name: 'Complete surface error mapper',
     },
   ],
   rule: errorMappingCompleteness,


### PR DESCRIPTION
## Context

Refs TRL-529. After the owner error taxonomy work, Warden error rules should read core error owner data instead of hardcoding class and category lists.

## Changes

- Builds `unreachable-detour-shadowing` from `TrailsError` plus the `errorClasses` registry, covering owner-registered subclasses such as `PermitError`.
- Builds `error-mapping-completeness` from `codesByCategory` and `errorClasses`.
- Treats `createSurfaceErrorMapper` as the primary API while keeping `createTransportErrorMapper` compatibility coverage.

## Testing

- `bun test packages/warden/src/__tests__/unreachable-detour-shadowing.test.ts packages/warden/src/__tests__/error-mapping-completeness.test.ts packages/warden/src/__tests__/trails.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run check` from the top of the stack

## Risks

Diagnostics now use surface-error terminology. Compatibility mapper calls are still scanned, but reviewers should check the message wording and category ordering.