### PR TITLE
feat: add warden rule metadata

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -301,6 +301,11 @@ wardenRules                        // ReadonlyMap<string, WardenRule> — built-
 wardenTopoRules                    // ReadonlyMap<string, TopoAwareWardenRule> — built-in topo-aware rules
 wardenTopo                         // pre-built Topo of all wrapped built-in warden rule trails
 
+// Built-in rule metadata
+builtinWardenRuleMetadata
+getWardenRuleMetadata(ruleOrName), listWardenRuleMetadata()
+wardenRuleTiers, wardenRuleScopes, wardenRuleLifecycleStates
+
 // Trail runners
 runWardenTrails(filePath, sourceCode, options?) // run file-scoped warden rules against a single file
 runTopoAwareWardenTrails(topo)     // run built-in topo-aware warden rule trails once per topo
@@ -324,6 +329,7 @@ ruleInput, projectAwareRuleInput, ruleOutput, topoAwareRuleInput, diagnosticSche
 // Types
 WardenOptions, WardenReport, WardenDiagnostic, WardenSeverity, DriftResult
 ProjectAwareWardenRule, ProjectContext, TopoAwareWardenRule, WardenRule
+WardenRuleMetadata, WardenRuleTier, WardenRuleScope, WardenRuleLifecycle
 RuleInput, ProjectAwareRuleInput, RuleOutput, TopoAwareRuleInput
 ```
 

--- a/docs/rule-design.md
+++ b/docs/rule-design.md
@@ -23,9 +23,10 @@ and [ADR-0037](./adr/0037-owner-first-authority.md).
   topo-resident canonical tables, generic registries, loader APIs, or
   `derivedFrom` metadata as the default answer to duplicated framework facts.
 
-The tier names here are authoring classifications. Runtime tier metadata,
-filtering, and advisory report shape land in the Warden metadata work; until
-then, classify rules with these names in docs, tests, and issue descriptions.
+The tier names here are authoring classifications. Built-in Warden rule
+metadata exposes them from `@ontrails/warden`; runtime tier filtering and
+advisory report shape build on that metadata rather than inventing another rule
+registry.
 
 ## Core Principle
 

--- a/docs/warden.md
+++ b/docs/warden.md
@@ -38,6 +38,9 @@ Warden rules can operate at several levels:
 - **Advisory** checks point at incomplete or risky framework usage without necessarily failing the build.
 
 The tier affects execution shape, not ownership. A source-static check can still be Warden-owned when it enforces public Trails semantics.
+Built-in rule classifications are exposed as metadata from `@ontrails/warden`;
+use that metadata when tooling needs to group rules by tier, scope, or
+lifecycle.
 
 ## Authoring Durable Rules
 

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -127,6 +127,9 @@ to build all built-in rule trails.
 | `formatWardenReport(report)` | Human-readable report |
 | `checkDrift(rootDir, topo?)` | Check if the lock file matches the current topo |
 | `wardenRules` | Registry of all built-in rules |
+| `builtinWardenRuleMetadata` | Tier, scope, lifecycle, and invariant metadata for built-in rules |
+| `getWardenRuleMetadata(ruleOrName)` | Resolve inline or built-in metadata for a Warden rule |
+| `listWardenRuleMetadata()` | List built-in rule metadata entries |
 | `wardenTopo` | `Topo` of all built-in rule trails (one per rule) |
 | `runWardenTrails(filePath, sourceCode, options?)` | Dispatch file-scoped rule trails for a file, collect diagnostics |
 | `runTopoAwareWardenTrails(topo)` | Dispatch built-in topo-aware rule trails once for a resolved topo |

--- a/packages/warden/src/__tests__/public-api.test.ts
+++ b/packages/warden/src/__tests__/public-api.test.ts
@@ -4,6 +4,14 @@ import * as warden from '@ontrails/warden';
 import { parse, walk } from '@ontrails/warden/ast';
 
 describe('@ontrails/warden public API', () => {
+  test('exports built-in rule metadata from the root entrypoint', () => {
+    expect(warden.getWardenRuleMetadata('permit-governance')?.tier).toBe(
+      'topo-aware'
+    );
+    expect(warden.wardenRuleTiers).toContain('source-static');
+    expect(warden.listWardenRuleMetadata().length).toBeGreaterThan(0);
+  });
+
   test('keeps parser helpers on the ast entrypoint', () => {
     expect('parse' in warden).toBe(false);
     expect('walk' in warden).toBe(false);

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -16,4 +16,15 @@ describe('wardenTopo', () => {
       expect(id).toMatch(/^warden\.rule\./);
     }
   });
+
+  test('all rule trails expose Warden metadata', () => {
+    for (const trail of wardenTopo.list()) {
+      const metadata = trail.meta?.warden as
+        | { lifecycle?: { state?: unknown }; tier?: unknown }
+        | undefined;
+
+      expect(typeof metadata?.lifecycle?.state).toBe('string');
+      expect(typeof metadata?.tier).toBe('string');
+    }
+  });
 });

--- a/packages/warden/src/__tests__/warden-rule-metadata.test.ts
+++ b/packages/warden/src/__tests__/warden-rule-metadata.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  builtinWardenRuleMetadata,
+  getWardenRuleMetadata,
+  listWardenRuleMetadata,
+  wardenRuleLifecycleStates,
+  wardenRuleScopes,
+  wardenRuleTiers,
+  wardenRules,
+  wardenTopoRules,
+} from '../rules/index.js';
+import type { WardenRuleMetadata } from '../rules/index.js';
+
+const allRuleNames = [...wardenRules.keys(), ...wardenTopoRules.keys()];
+const allRuleNameSet = new Set(allRuleNames);
+const metadataEntries = Object.entries(builtinWardenRuleMetadata);
+
+const isTemporaryLifecycle = (metadata: WardenRuleMetadata): boolean =>
+  metadata.lifecycle.state === 'temporary' ||
+  metadata.lifecycle.state === 'deprecated';
+
+describe('warden rule metadata', () => {
+  test('classifies every built-in rule and only built-in rules', () => {
+    const metadataNames = new Set(metadataEntries.map(([name]) => name));
+
+    expect(allRuleNames.filter((name) => !metadataNames.has(name))).toEqual([]);
+    expect(
+      [...metadataNames].filter((name) => !allRuleNameSet.has(name)).toSorted()
+    ).toEqual([]);
+  });
+
+  test('uses the supported tier, scope, and lifecycle vocabulary', () => {
+    for (const [, metadata] of metadataEntries) {
+      expect(wardenRuleTiers).toContain(metadata.tier);
+      expect(wardenRuleScopes).toContain(metadata.scope);
+      expect(wardenRuleLifecycleStates).toContain(metadata.lifecycle.state);
+    }
+  });
+
+  test('requires retirement criteria for non-durable rules', () => {
+    const missingRetirementCriteria = metadataEntries
+      .filter(([, metadata]) => isTemporaryLifecycle(metadata))
+      .filter(([, metadata]) => !metadata.lifecycle.retireWhen)
+      .map(([name]) => name);
+
+    expect(missingRetirementCriteria).toEqual([]);
+  });
+
+  test('exposes metadata lookup helpers for built-in rules', () => {
+    expect(getWardenRuleMetadata('permit-governance')?.tier).toBe('topo-aware');
+    expect(getWardenRuleMetadata('warden-export-symmetry')?.scope).toBe(
+      'repo-local'
+    );
+    expect(listWardenRuleMetadata().length).toBe(allRuleNames.length);
+  });
+});

--- a/packages/warden/src/__tests__/wrap-rule.test.ts
+++ b/packages/warden/src/__tests__/wrap-rule.test.ts
@@ -2,10 +2,22 @@ import { describe, expect, test } from 'bun:test';
 
 import { createTrailContext } from '@ontrails/core';
 
+import { noThrowInImplementation } from '../rules/no-throw-in-implementation.js';
 import { wrapRule } from '../trails/wrap-rule.js';
 import type { ProjectAwareWardenRule } from '../rules/types.js';
 
 describe('wrapRule', () => {
+  test('copies built-in rule metadata into trail meta', () => {
+    const wrapped = wrapRule({ examples: [], rule: noThrowInImplementation });
+
+    expect(wrapped.meta?.category).toBe('governance');
+    expect(wrapped.meta?.severity).toBe('error');
+    expect(wrapped.meta?.warden).toMatchObject({
+      lifecycle: { state: 'durable' },
+      tier: 'source-static',
+    });
+  });
+
   test('omits absent resource ids and defaults knownTrailIds to empty set', async () => {
     let capturedContext:
       | {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -9,16 +9,31 @@
 
 // Rule types
 export type {
+  BuiltinWardenRuleName,
   ProjectAwareWardenRule,
   ProjectContext,
   TopoAwareWardenRule,
   WardenDiagnostic,
   WardenRule,
+  WardenRuleLifecycle,
+  WardenRuleLifecycleState,
+  WardenRuleMetadata,
+  WardenRuleScope,
+  WardenRuleTier,
   WardenSeverity,
 } from './rules/index.js';
 
 // Rule registry
-export { wardenRules, wardenTopoRules } from './rules/index.js';
+export {
+  builtinWardenRuleMetadata,
+  getWardenRuleMetadata,
+  listWardenRuleMetadata,
+  wardenRuleLifecycleStates,
+  wardenRuleScopes,
+  wardenRuleTiers,
+  wardenRules,
+  wardenTopoRules,
+} from './rules/index.js';
 
 // Rule-scoped cache controls for long-lived consumers (watch mode, LSPs).
 export { clearImplementationReturnsResultCache } from './rules/implementation-returns-result.js';

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -34,13 +34,28 @@ import { wardenExportSymmetry } from './warden-export-symmetry.js';
 import { wardenRulesUseAst } from './warden-rules-use-ast.js';
 
 export type {
+  WardenRuleLifecycle,
+  WardenRuleLifecycleState,
+  WardenRuleMetadata,
+  WardenRuleScope,
   ProjectAwareWardenRule,
   ProjectContext,
   TopoAwareWardenRule,
   WardenDiagnostic,
   WardenRule,
+  WardenRuleTier,
   WardenSeverity,
 } from './types.js';
+
+export {
+  builtinWardenRuleMetadata,
+  getWardenRuleMetadata,
+  listWardenRuleMetadata,
+  wardenRuleLifecycleStates,
+  wardenRuleScopes,
+  wardenRuleTiers,
+} from './metadata.js';
+export type { BuiltinWardenRuleName } from './metadata.js';
 
 export { noThrowInImplementation } from './no-throw-in-implementation.js';
 export { circularRefs } from './circular-refs.js';

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -1,0 +1,243 @@
+import type {
+  WardenRule,
+  WardenRuleLifecycleState,
+  WardenRuleMetadata,
+  WardenRuleScope,
+  WardenRuleTier,
+} from './types.js';
+
+export const wardenRuleTiers = [
+  'source-static',
+  'project-static',
+  'topo-aware',
+  'drift',
+  'advisory',
+] as const satisfies readonly WardenRuleTier[];
+
+export const wardenRuleScopes = [
+  'external',
+  'extension',
+  'internal',
+  'repo-local',
+  'temporary',
+  'advisory',
+] as const satisfies readonly WardenRuleScope[];
+
+export const wardenRuleLifecycleStates = [
+  'durable',
+  'temporary',
+  'deprecated',
+] as const satisfies readonly WardenRuleLifecycleState[];
+
+const durableExternal = {
+  lifecycle: { state: 'durable' },
+  scope: 'external',
+} as const;
+
+const durableExtension = {
+  lifecycle: { state: 'durable' },
+  scope: 'extension',
+} as const;
+
+const durableRepoLocal = {
+  lifecycle: { state: 'durable' },
+  scope: 'repo-local',
+} as const;
+
+export const builtinWardenRuleMetadata = {
+  'circular-refs': {
+    ...durableExternal,
+    invariant: 'Contour reference graphs must be acyclic.',
+    tier: 'project-static',
+  },
+  'context-no-surface-types': {
+    ...durableExternal,
+    invariant: 'Trail logic stays surface-agnostic.',
+    tier: 'source-static',
+  },
+  'contour-exists': {
+    ...durableExternal,
+    invariant: 'Declared contour references resolve to known contours.',
+    tier: 'project-static',
+  },
+  'cross-declarations': {
+    ...durableExternal,
+    invariant: 'Declared crosses stay aligned with ctx.cross() usage.',
+    tier: 'source-static',
+  },
+  'dead-internal-trail': {
+    ...durableExternal,
+    invariant: 'Internal trails should be reachable through declared crosses.',
+    tier: 'project-static',
+  },
+  'draft-file-marking': {
+    ...durableExternal,
+    invariant: 'Draft-authored state is visibly marked in filenames.',
+    tier: 'source-static',
+  },
+  'draft-visible-debt': {
+    ...durableExternal,
+    invariant: 'Draft-authored IDs remain visible debt.',
+    tier: 'source-static',
+  },
+  'error-mapping-completeness': {
+    ...durableExtension,
+    invariant: 'Registered surface error mappers cover every error category.',
+    tier: 'source-static',
+  },
+  'example-valid': {
+    ...durableExternal,
+    invariant: 'Trail examples remain valid against their authored schema.',
+    tier: 'source-static',
+  },
+  'fires-declarations': {
+    ...durableExternal,
+    invariant: 'Declared fires stay aligned with signal firing usage.',
+    tier: 'source-static',
+  },
+  'implementation-returns-result': {
+    ...durableExternal,
+    invariant: 'Trail implementations return Result values.',
+    tier: 'source-static',
+  },
+  'incomplete-accessor-for-standard-op': {
+    ...durableExternal,
+    invariant: 'Standard CRUD operations expose the expected accessor shape.',
+    tier: 'topo-aware',
+  },
+  'incomplete-crud': {
+    ...durableExternal,
+    invariant: 'Versioned CRUD entities expose complete operation coverage.',
+    tier: 'project-static',
+  },
+  'intent-propagation': {
+    ...durableExternal,
+    invariant: 'Composite trail intent cannot be safer than crossed trails.',
+    tier: 'project-static',
+  },
+  'missing-reconcile': {
+    ...durableExternal,
+    invariant: 'Versioned CRUD store tables provide reconcile coverage.',
+    tier: 'project-static',
+  },
+  'missing-visibility': {
+    ...durableExternal,
+    invariant: 'Composition-only trails declare internal visibility.',
+    tier: 'project-static',
+  },
+  'no-direct-implementation-call': {
+    ...durableExternal,
+    invariant: 'Application code composes trails through ctx.cross().',
+    tier: 'source-static',
+  },
+  'no-sync-result-assumption': {
+    ...durableExternal,
+    invariant:
+      'Result accessors are not used before async results are awaited.',
+    tier: 'source-static',
+  },
+  'no-throw-in-detour-recover': {
+    ...durableExternal,
+    invariant: 'Detour recovery returns Result instead of throwing.',
+    tier: 'source-static',
+  },
+  'no-throw-in-implementation': {
+    ...durableExternal,
+    invariant: 'Trail implementations return Result.err() instead of throwing.',
+    tier: 'source-static',
+  },
+  'on-references-exist': {
+    ...durableExternal,
+    invariant: 'Trail on: declarations resolve to known signals.',
+    tier: 'project-static',
+  },
+  'orphaned-signal': {
+    ...durableExternal,
+    invariant:
+      'Derived store signals are consumed by matching trail listeners.',
+    tier: 'project-static',
+  },
+  'permit-governance': {
+    ...durableExternal,
+    invariant: 'Destroy trails declare explicit permit requirements.',
+    tier: 'topo-aware',
+  },
+  'prefer-schema-inference': {
+    invariant: 'Trail schemas should be inferred unless overrides add meaning.',
+    lifecycle: { state: 'durable' },
+    scope: 'advisory',
+    tier: 'source-static',
+  },
+  'reference-exists': {
+    ...durableExternal,
+    invariant: 'Reference declarations resolve to known contours.',
+    tier: 'project-static',
+  },
+  'resource-declarations': {
+    ...durableExternal,
+    invariant: 'Resource usage is declared on the trail contract.',
+    tier: 'source-static',
+  },
+  'resource-exists': {
+    ...durableExternal,
+    invariant: 'Declared resources resolve to known resource definitions.',
+    tier: 'project-static',
+  },
+  'resource-id-grammar': {
+    ...durableExternal,
+    invariant: 'Resource identifiers stay out of the scope separator grammar.',
+    tier: 'source-static',
+  },
+  'unreachable-detour-shadowing': {
+    ...durableExternal,
+    invariant: 'Specific detours are not shadowed by earlier broader detours.',
+    tier: 'source-static',
+  },
+  'valid-describe-refs': {
+    invariant: 'Describe references point at known Trails concepts.',
+    lifecycle: { state: 'durable' },
+    scope: 'advisory',
+    tier: 'project-static',
+  },
+  'valid-detour-contract': {
+    ...durableExternal,
+    invariant:
+      'Runtime detour contracts use error constructors and recover functions.',
+    tier: 'topo-aware',
+  },
+  'warden-export-symmetry': {
+    ...durableRepoLocal,
+    invariant: 'The Warden package exports trail wrappers, not raw rules.',
+    tier: 'source-static',
+  },
+  'warden-rules-use-ast': {
+    ...durableRepoLocal,
+    invariant: 'Warden source rules use AST helpers instead of ad hoc parsing.',
+    tier: 'source-static',
+  },
+} as const satisfies Record<string, WardenRuleMetadata>;
+
+export type BuiltinWardenRuleName = keyof typeof builtinWardenRuleMetadata;
+
+const metadataByName: Readonly<Record<string, WardenRuleMetadata>> =
+  builtinWardenRuleMetadata;
+
+export const getWardenRuleMetadata = (
+  rule: Pick<WardenRule, 'metadata' | 'name'> | string
+): WardenRuleMetadata | null => {
+  if (typeof rule !== 'string' && rule.metadata) {
+    return rule.metadata;
+  }
+
+  const name = typeof rule === 'string' ? rule : rule.name;
+  return metadataByName[name] ?? null;
+};
+
+export const listWardenRuleMetadata = (): readonly (readonly [
+  BuiltinWardenRuleName,
+  WardenRuleMetadata,
+])[] =>
+  Object.entries(builtinWardenRuleMetadata) as readonly (readonly [
+    BuiltinWardenRuleName,
+    WardenRuleMetadata,
+  ])[];

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -6,6 +6,60 @@ import type { Intent, Topo } from '@ontrails/core';
 export type WardenSeverity = 'error' | 'warn';
 
 /**
+ * Execution tier for a Warden rule.
+ *
+ * Tier names describe the narrowest runtime shape that can answer the rule's
+ * question. They do not change ownership: source-static rules can still be
+ * durable public Warden doctrine.
+ */
+export type WardenRuleTier =
+  | 'advisory'
+  | 'drift'
+  | 'project-static'
+  | 'source-static'
+  | 'topo-aware';
+
+/**
+ * Context where a Warden rule applies.
+ */
+export type WardenRuleScope =
+  | 'advisory'
+  | 'extension'
+  | 'external'
+  | 'internal'
+  | 'repo-local'
+  | 'temporary';
+
+/**
+ * Lifecycle state for a Warden rule.
+ */
+export type WardenRuleLifecycleState = 'deprecated' | 'durable' | 'temporary';
+
+/**
+ * Lifecycle metadata for a Warden rule.
+ */
+export interface WardenRuleLifecycle {
+  /** Current lifecycle state. */
+  readonly state: WardenRuleLifecycleState;
+  /** Required for temporary or deprecated rules. */
+  readonly retireWhen?: string | undefined;
+}
+
+/**
+ * Stable metadata used to classify Warden rules before dispatch filtering.
+ */
+export interface WardenRuleMetadata {
+  /** One-line invariant the rule protects. */
+  readonly invariant: string;
+  /** Rule lifecycle. */
+  readonly lifecycle: WardenRuleLifecycle;
+  /** Where the rule applies. */
+  readonly scope: WardenRuleScope;
+  /** Narrowest Warden tier that can answer the rule. */
+  readonly tier: WardenRuleTier;
+}
+
+/**
  * A single diagnostic reported by a warden rule.
  */
 export interface WardenDiagnostic {
@@ -22,10 +76,11 @@ export interface WardenDiagnostic {
 }
 
 /**
- * A warden rule is a function that analyzes source code and returns diagnostics.
+ * A warden rule analyzes one source file and returns diagnostics.
  *
- * Rules use string/regex analysis (not full AST parsing) to detect patterns
- * that violate Trails conventions.
+ * Rules should prefer structured AST helpers when they inspect TypeScript
+ * syntax. Simple string checks remain acceptable when the authored rule is
+ * explicitly about text that is not parseable syntax, such as generated output.
  */
 export interface WardenRule {
   /** Unique rule identifier */
@@ -34,6 +89,8 @@ export interface WardenRule {
   readonly severity: WardenSeverity;
   /** Human-readable description of what the rule enforces */
   readonly description: string;
+  /** Optional inline classification. Built-ins are classified by registry. */
+  readonly metadata?: WardenRuleMetadata | undefined;
   /** Run the rule against source code and return any diagnostics */
   readonly check: (
     sourceCode: string,
@@ -110,6 +167,8 @@ export interface TopoAwareWardenRule {
   readonly severity: WardenSeverity;
   /** Human-readable description of what the rule enforces */
   readonly description: string;
+  /** Optional inline classification. Built-ins are classified by registry. */
+  readonly metadata?: WardenRuleMetadata | undefined;
   /** Run the rule against the resolved topo and return any diagnostics */
   readonly checkTopo: (
     topo: Topo

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -13,6 +13,7 @@ import type {
   TopoAwareWardenRule,
   WardenRule,
 } from '../rules/types.js';
+import { getWardenRuleMetadata } from '../rules/metadata.js';
 import {
   projectAwareRuleInput,
   ruleInput,
@@ -39,6 +40,15 @@ interface WrapProjectAwareRuleOptions {
   /** Trail examples for testing and documentation. */
   readonly examples: Trail<ProjectAwareRuleInput, RuleOutput>['examples'];
 }
+
+const buildRuleMeta = (rule: WardenRule | TopoAwareWardenRule) => {
+  const metadata = getWardenRuleMetadata(rule);
+  return {
+    category: 'governance',
+    ...(metadata ? { warden: metadata } : {}),
+    severity: rule.severity,
+  };
+};
 
 const buildProjectContext = (input: ProjectAwareRuleInput): ProjectContext => ({
   ...(input.contourReferencesByName
@@ -122,7 +132,7 @@ export function wrapRule(
       >['examples'],
       input: projectAwareRuleInput,
       intent: 'read',
-      meta: { category: 'governance', severity: rule.severity },
+      meta: buildRuleMeta(rule),
       output: ruleOutput,
     });
   }
@@ -136,7 +146,7 @@ export function wrapRule(
     examples: examples as Trail<RuleInput, RuleOutput>['examples'],
     input: ruleInput,
     intent: 'read',
-    meta: { category: 'governance', severity: rule.severity },
+    meta: buildRuleMeta(rule),
     output: ruleOutput,
   });
 }
@@ -178,7 +188,7 @@ export const wrapTopoRule = (
     examples,
     input: topoAwareRuleInput,
     intent: 'read',
-    meta: { category: 'governance', severity: rule.severity },
+    meta: buildRuleMeta(rule),
     output: ruleOutput,
   });
 };


### PR DESCRIPTION
## Context

TRL-513 starts the Warden source-tier stack by making rule ownership explicit and machine-readable. The stack needs durable metadata before source-static rules can be filtered, wrapped as trails, or promoted safely.

## What changed

- Adds `WardenRuleMetadata` plus tier, scope, and lifecycle vocabulary.
- Adds a centralized rule metadata registry and public exports.
- Threads metadata through wrapped Warden trails under `meta.warden`.
- Documents the rule-design tiers and updates Warden/API docs.

## Testing

- `bun test packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/wrap-rule.test.ts packages/warden/src/__tests__/trails.test.ts packages/warden/src/__tests__/public-api.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run check` from the top of the stack

## Risks

Low. This is additive metadata and export plumbing; existing rule execution remains unchanged.
