### PR TITLE
feat: expose stable warden ast helpers

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -337,9 +337,13 @@ RuleInput, ProjectAwareRuleInput, RuleOutput, TopoAwareRuleInput
 
 ```typescript
 parse(filePath, sourceCode), walk(ast, visitor), offsetToLine(source, offset)
+walkScope(ast, visitor)
+findTrailDefinitions(ast), findBlazeBodies(node)
+findContourDefinitions(ast, context?, options?), isBlazeCall(node)
 findStringLiterals(ast, predicate?), isStringLiteral(node), getStringValue(node)
 
-AstNode, StringLiteralMatch
+AstNode, TrailDefinition, ContourDefinition, FindContourDefinitionsOptions
+FrameworkNamespaceContext, StringLiteralMatch
 ```
 
 ## `@ontrails/config`

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -138,7 +138,9 @@ to build all built-in rule trails.
 | `formatSummary(report)` | Compact summary line |
 
 AST parser helpers are exported from `@ontrails/warden/ast`, not the root
-runtime barrel.
+runtime barrel. The stable authoring surface includes `parse`, `walk`,
+`walkScope`, `offsetToLine`, `findTrailDefinitions`, `findBlazeBodies`,
+`findContourDefinitions`, `isBlazeCall`, and string-literal helpers.
 
 See the [API Reference](../../docs/api-reference.md) for the full list.
 

--- a/packages/warden/src/__tests__/public-api.test.ts
+++ b/packages/warden/src/__tests__/public-api.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from 'bun:test';
 
 import * as warden from '@ontrails/warden';
-import { parse, walk } from '@ontrails/warden/ast';
+import {
+  findBlazeBodies,
+  findContourDefinitions,
+  findTrailDefinitions,
+  isBlazeCall,
+  parse,
+  walk,
+  walkScope,
+} from '@ontrails/warden/ast';
+import type { FrameworkNamespaceContext } from '@ontrails/warden/ast';
 
 describe('@ontrails/warden public API', () => {
   test('exports built-in rule metadata from the root entrypoint', () => {
@@ -26,5 +35,57 @@ describe('@ontrails/warden public API', () => {
       });
     }
     expect(visited).toBeGreaterThan(0);
+  });
+
+  test('exposes stable rule-authoring helpers on the ast entrypoint', () => {
+    const source = `
+import { contour, trail } from '@ontrails/core';
+
+const user = contour('user', { id: z.string() });
+
+export const showUser = trail('user.show', {
+  blaze: async (input, ctx) => {
+    return userShow.blaze(input, ctx);
+  },
+});
+`;
+    const ast = parse('example.ts', source);
+    expect(ast).not.toBeNull();
+
+    if (!ast) {
+      return;
+    }
+
+    expect(
+      findTrailDefinitions(ast).map((definition) => definition.id)
+    ).toEqual(['user.show']);
+    expect(
+      findContourDefinitions(ast).map((definition) => definition.name)
+    ).toEqual(['user']);
+
+    const [blazeBody] = findBlazeBodies(ast);
+    expect(blazeBody).toBeDefined();
+
+    let sawBlazeCall = false;
+    walk(blazeBody, (node) => {
+      sawBlazeCall ||= isBlazeCall(node);
+    });
+    expect(sawBlazeCall).toBe(true);
+
+    const namespaceContext = {
+      namespaces: new Set(['core']),
+      safeCallStarts: new Set([0]),
+    } satisfies FrameworkNamespaceContext;
+    expect(namespaceContext.namespaces.has('core')).toBe(true);
+
+    const scopedNodeTypes: string[] = [];
+    let hasScopedBlazeCall = false;
+    walkScope(ast, (node) => {
+      scopedNodeTypes.push(node.type);
+      hasScopedBlazeCall ||= isBlazeCall(node);
+    });
+    expect(scopedNodeTypes.length).toBeGreaterThan(0);
+    expect(scopedNodeTypes).toContain('ArrowFunctionExpression');
+    expect(hasScopedBlazeCall).toBe(false);
   });
 });

--- a/packages/warden/src/ast.ts
+++ b/packages/warden/src/ast.ts
@@ -6,11 +6,23 @@
  * built-in rule implementation until they have a stable public contract.
  */
 export {
+  findBlazeBodies,
+  findContourDefinitions,
   findStringLiterals,
+  findTrailDefinitions,
   getStringValue,
+  isBlazeCall,
   isStringLiteral,
   offsetToLine,
   parse,
   walk,
+  walkScope,
 } from './rules/ast.js';
-export type { AstNode, StringLiteralMatch } from './rules/ast.js';
+export type {
+  AstNode,
+  ContourDefinition,
+  FindContourDefinitionsOptions,
+  FrameworkNamespaceContext,
+  StringLiteralMatch,
+  TrailDefinition,
+} from './rules/ast.js';


### PR DESCRIPTION
## Context

TRL-515 gives source-tier Warden rules a stable authoring surface instead of each rule reaching into ad hoc AST internals. This sits on top of the metadata branch and prepares the tier runner/rule work above it.

## What changed

- Expands `@ontrails/warden/ast` helpers for trail, contour, blaze, and scoped AST scans.
- Adds public API coverage for the AST entrypoint.
- Updates Warden API docs to describe the helper surface.

## Testing

- `bun test packages/warden/src/__tests__/public-api.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run check` from the top of the stack

## Risks

Low to medium. The helpers are new public Warden authoring API, so naming and shape should get review attention before more rules build on them.
