### PR TITLE
feat: add warden tier filtering

### DIFF
--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -11,6 +11,7 @@ import {
   formatSummary,
   formatWardenReport,
   runWarden,
+  wardenRuleTiers,
 } from '@ontrails/warden';
 import { z } from 'zod';
 
@@ -37,6 +38,7 @@ export const wardenTrail = trail('warden', {
       driftOnly: input.driftOnly,
       lintOnly: input.lintOnly,
       rootDir,
+      tier: input.tier,
       topo,
     });
 
@@ -86,6 +88,10 @@ export const wardenTrail = trail('warden', {
       .optional()
       .describe('App module path (auto-discovered if omitted)'),
     rootDir: z.string().optional().describe('Root directory to scan'),
+    tier: z
+      .enum(wardenRuleTiers)
+      .optional()
+      .describe('Run only one Warden tier'),
   }),
   intent: 'read',
   output: z.object({

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -295,6 +295,7 @@ McpHarness, McpHarnessOptions, McpHarnessResult
 ```typescript
 // Main runtime
 runWarden(options?), formatWardenReport(report), checkDrift(rootDir, topo?)
+// WardenOptions includes optional tier: source-static | project-static | topo-aware | drift | advisory
 
 // Built-in registries and wrapped topo
 wardenRules                        // ReadonlyMap<string, WardenRule> — built-in per-file rules (file-scoped and project-aware)

--- a/docs/warden.md
+++ b/docs/warden.md
@@ -41,6 +41,8 @@ The tier affects execution shape, not ownership. A source-static check can still
 Built-in rule classifications are exposed as metadata from `@ontrails/warden`;
 use that metadata when tooling needs to group rules by tier, scope, or
 lifecycle.
+`runWarden({ tier })` can execute one tier at a time; omitting `tier` preserves
+the full lint-plus-drift run.
 
 ## Authoring Durable Rules
 

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -142,6 +142,9 @@ runtime barrel. The stable authoring surface includes `parse`, `walk`,
 `walkScope`, `offsetToLine`, `findTrailDefinitions`, `findBlazeBodies`,
 `findContourDefinitions`, `isBlazeCall`, and string-literal helpers.
 
+`runWarden({ tier })` can narrow a run to `source-static`, `project-static`,
+`topo-aware`, `drift`, or `advisory`. Omit `tier` for the default full run.
+
 See the [API Reference](../../docs/api-reference.md) for the full list.
 
 ## Installation

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -102,6 +102,178 @@ describe('runWarden basics', () => {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+
+  test('source-static tier runs source rules and skips project rules plus drift', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'mixed.ts'),
+        `trail('entity.show', {
+  on: ['entity.changed'],
+  blaze: async () => {
+    throw new Error('boom');
+  },
+});`
+      );
+
+      const report = await runWarden({
+        rootDir: dir,
+        tier: 'source-static',
+      });
+      const rules = new Set(report.diagnostics.map((d) => d.rule));
+
+      expect(rules.has('no-throw-in-implementation')).toBe(true);
+      expect(rules.has('on-references-exist')).toBe(false);
+      expect(report.drift).toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('project-static tier runs project rules and skips source rules plus drift', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'mixed.ts'),
+        `trail('entity.show', {
+  on: ['entity.changed'],
+  blaze: async () => {
+    throw new Error('boom');
+  },
+});`
+      );
+
+      const report = await runWarden({
+        rootDir: dir,
+        tier: 'project-static',
+      });
+      const rules = new Set(report.diagnostics.map((d) => d.rule));
+
+      expect(rules.has('no-throw-in-implementation')).toBe(false);
+      expect(rules.has('on-references-exist')).toBe(true);
+      expect(report.drift).toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('drift tier skips lint and runs drift', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'bad.ts'),
+        `trail('x', { blaze: async () => { throw new Error('x'); } })`
+      );
+
+      const report = await runWarden({ rootDir: dir, tier: 'drift' });
+
+      expect(report.diagnostics).toHaveLength(0);
+      expect(report.drift).not.toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('tier takes precedence over legacy driftOnly for source-static', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'bad.ts'),
+        `trail('x', { blaze: async () => { throw new Error('x'); } })`
+      );
+
+      const report = await runWarden({
+        driftOnly: true,
+        rootDir: dir,
+        tier: 'source-static',
+      });
+      const rules = new Set(report.diagnostics.map((d) => d.rule));
+
+      expect(rules.has('no-throw-in-implementation')).toBe(true);
+      expect(report.drift).toBeNull();
+      expect(report.passed).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('tier takes precedence over legacy lintOnly for drift', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'bad.ts'),
+        `trail('x', { blaze: async () => { throw new Error('x'); } })`
+      );
+
+      const report = await runWarden({
+        lintOnly: true,
+        rootDir: dir,
+        tier: 'drift',
+      });
+
+      expect(report.diagnostics).toHaveLength(0);
+      expect(report.drift).not.toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('legacy lintOnly and driftOnly together fail visibly', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, 'empty.ts'), 'export {}');
+
+      const report = await runWarden({
+        driftOnly: true,
+        lintOnly: true,
+        rootDir: dir,
+      });
+
+      expect(report.diagnostics).toEqual([
+        {
+          filePath: '<warden-options>',
+          line: 1,
+          message:
+            'lintOnly and driftOnly cannot both be true. Use tier to select a single Warden mode.',
+          rule: 'warden-options',
+          severity: 'error',
+        },
+      ]);
+      expect(report.passed).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('advisory tier runs advisory-scoped rules only', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'advisory.ts'),
+        `trail("entity.show", {
+  input: z.object({ firstName: z.string() }),
+  fields: {
+    firstName: { label: "First Name" },
+  },
+  blaze: async () => {
+    throw new Error("boom");
+  },
+})`
+      );
+
+      const report = await runWarden({
+        rootDir: dir,
+        tier: 'advisory',
+      });
+      const rules = new Set(report.diagnostics.map((d) => d.rule));
+
+      expect(rules.has('prefer-schema-inference')).toBe(true);
+      expect(rules.has('no-throw-in-implementation')).toBe(false);
+      expect(report.drift).toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });
 
 describe('runWarden project context', () => {

--- a/packages/warden/src/__tests__/topo-aware-rule.test.ts
+++ b/packages/warden/src/__tests__/topo-aware-rule.test.ts
@@ -88,6 +88,69 @@ describe('TopoAwareWardenRule dispatch', () => {
     }
   });
 
+  test('CLI dispatches topo-aware tier rules when selected explicitly', async () => {
+    const dir = makeTempDir();
+    try {
+      const seen: string[] = [];
+      const report = await runWarden({
+        extraTopoRules: [buildPlaceholderRule(seen)],
+        rootDir: dir,
+        tier: 'topo-aware',
+        topo: buildFixtureTopo(),
+      });
+
+      expect(seen).toEqual(['fixture']);
+      expect(
+        report.diagnostics.some((d) => d.rule === 'placeholder-topo-aware')
+      ).toBe(true);
+      expect(report.drift).toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('topo-aware tier does not dispatch source rules', async () => {
+    const dir = makeTempDir();
+    try {
+      await Bun.write(
+        join(dir, 'bad-source.ts'),
+        `trail('x', { blaze: async () => { throw new Error('x'); } })`
+      );
+      const seen: string[] = [];
+      const report = await runWarden({
+        extraTopoRules: [buildPlaceholderRule(seen)],
+        rootDir: dir,
+        tier: 'topo-aware',
+        topo: buildFixtureTopo(),
+      });
+      const rules = new Set(report.diagnostics.map((d) => d.rule));
+
+      expect(seen).toEqual(['fixture']);
+      expect(rules.has('placeholder-topo-aware')).toBe(true);
+      expect(rules.has('no-throw-in-implementation')).toBe(false);
+      expect(report.drift).toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI skips topo-aware rules when another tier is selected', async () => {
+    const dir = makeTempDir();
+    try {
+      const seen: string[] = [];
+      await runWarden({
+        extraTopoRules: [buildPlaceholderRule(seen)],
+        rootDir: dir,
+        tier: 'source-static',
+        topo: buildFixtureTopo(),
+      });
+
+      expect(seen).toEqual([]);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('CLI skips topo-aware rules when no topo is provided', async () => {
     const dir = makeTempDir();
     try {

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -27,12 +27,14 @@ import {
 } from './rules/ast.js';
 import { collectFileCrudCoverage } from './rules/incomplete-crud.js';
 import { wardenRules, wardenTopoRules } from './rules/index.js';
+import { getWardenRuleMetadata } from './rules/metadata.js';
 import type {
   ProjectAwareWardenRule,
   ProjectContext,
   TopoAwareWardenRule,
   WardenDiagnostic,
   WardenRule,
+  WardenRuleTier,
 } from './rules/types.js';
 
 /**
@@ -45,6 +47,13 @@ export interface WardenOptions {
   readonly lintOnly?: boolean | undefined;
   /** Only run drift detection, skip lint rules */
   readonly driftOnly?: boolean | undefined;
+  /**
+   * Run a single Warden tier. Defaults to all lint tiers plus drift.
+   *
+   * Selecting a non-drift tier skips drift detection; selecting `drift` skips
+   * lint rule dispatch. `lintOnly` and `driftOnly` remain compatibility shims.
+   */
+  readonly tier?: WardenRuleTier | undefined;
   /**
    * App topology for drift detection. When provided, enables real trailhead
    * lock comparison and unlocks the topo-aware rule dispatch path.
@@ -544,6 +553,48 @@ const buildProjectContext = (
 const isProjectAwareRule = (rule: WardenRule): rule is ProjectAwareWardenRule =>
   'checkWithContext' in rule;
 
+const createOptionsDiagnostic = (message: string): WardenDiagnostic => ({
+  filePath: '<warden-options>',
+  line: 1,
+  message,
+  rule: 'warden-options',
+  severity: 'error',
+});
+
+const ruleMatchesTier = (
+  metadata: ReturnType<typeof getWardenRuleMetadata>,
+  tier: WardenRuleTier | undefined
+): boolean => {
+  if (!tier) {
+    return true;
+  }
+
+  if (!metadata) {
+    return false;
+  }
+
+  return tier === 'advisory'
+    ? metadata.scope === 'advisory'
+    : metadata.tier === tier;
+};
+
+const isSelectedRule = (
+  rule: WardenRule | TopoAwareWardenRule,
+  tier: WardenRuleTier | undefined
+): boolean => ruleMatchesTier(getWardenRuleMetadata(rule), tier);
+
+const isSelectedTopoRule = (
+  rule: TopoAwareWardenRule,
+  tier: WardenRuleTier | undefined
+): boolean => {
+  if (!tier) {
+    return true;
+  }
+
+  const metadata = getWardenRuleMetadata(rule);
+  return metadata ? ruleMatchesTier(metadata, tier) : tier === 'topo-aware';
+};
+
 const topoRuleFailureDiagnostic = (
   rule: TopoAwareWardenRule,
   error: unknown
@@ -566,13 +617,14 @@ const topoRuleFailureDiagnostic = (
  */
 const lintTopo = async (
   appTopo: Topo,
-  extraTopoRules: readonly TopoAwareWardenRule[]
+  extraTopoRules: readonly TopoAwareWardenRule[],
+  tier: WardenRuleTier | undefined
 ): Promise<readonly WardenDiagnostic[]> => {
   const diagnostics: WardenDiagnostic[] = [];
   const rules: readonly TopoAwareWardenRule[] = [
     ...wardenTopoRules.values(),
     ...extraTopoRules,
-  ];
+  ].filter((rule) => isSelectedTopoRule(rule, tier));
   for (const rule of rules) {
     try {
       diagnostics.push(...(await rule.checkTopo(appTopo)));
@@ -585,11 +637,16 @@ const lintTopo = async (
 
 const lintSourceFiles = (
   sourceFiles: readonly SourceFile[],
-  context: ProjectContext
+  context: ProjectContext,
+  tier: WardenRuleTier | undefined
 ): readonly WardenDiagnostic[] => {
   const diagnostics: WardenDiagnostic[] = [];
   for (const sourceFile of sourceFiles) {
     for (const rule of wardenRules.values()) {
+      if (!isSelectedRule(rule, tier)) {
+        continue;
+      }
+
       if (isProjectAwareRule(rule)) {
         diagnostics.push(
           ...rule.checkWithContext(
@@ -614,16 +671,21 @@ const lintSourceFiles = (
 const lintFiles = async (
   rootDir: string,
   appTopo?: Topo | undefined,
-  extraTopoRules: readonly TopoAwareWardenRule[] = []
+  extraTopoRules: readonly TopoAwareWardenRule[] = [],
+  tier?: WardenRuleTier | undefined
 ): Promise<WardenDiagnostic[]> => {
+  if (tier === 'topo-aware') {
+    return appTopo ? [...(await lintTopo(appTopo, extraTopoRules, tier))] : [];
+  }
+
   const sourceFiles = await loadSourceFiles(rootDir);
   const context = buildProjectContext(sourceFiles, appTopo);
   const allDiagnostics: WardenDiagnostic[] = [
-    ...lintSourceFiles(sourceFiles, context),
+    ...lintSourceFiles(sourceFiles, context, tier),
   ];
 
-  if (appTopo) {
-    allDiagnostics.push(...(await lintTopo(appTopo, extraTopoRules)));
+  if (appTopo && (!tier || tier === 'advisory')) {
+    allDiagnostics.push(...(await lintTopo(appTopo, extraTopoRules, tier)));
   }
 
   return allDiagnostics;
@@ -636,12 +698,29 @@ export const runWarden = async (
   options: WardenOptions = {}
 ): Promise<WardenReport> => {
   const rootDir = resolve(options.rootDir ?? process.cwd());
-  const allDiagnostics = options.driftOnly
-    ? []
-    : await lintFiles(rootDir, options.topo, options.extraTopoRules ?? []);
-  const drift = options.lintOnly
-    ? null
-    : await checkDrift(rootDir, options.topo);
+  const optionDiagnostics =
+    !options.tier && options.lintOnly && options.driftOnly
+      ? [
+          createOptionsDiagnostic(
+            'lintOnly and driftOnly cannot both be true. Use tier to select a single Warden mode.'
+          ),
+        ]
+      : [];
+  const runLint = options.tier ? options.tier !== 'drift' : !options.driftOnly;
+  const runDrift = options.tier ? options.tier === 'drift' : !options.lintOnly;
+
+  const allDiagnostics = [
+    ...optionDiagnostics,
+    ...(runLint
+      ? await lintFiles(
+          rootDir,
+          options.topo,
+          options.extraTopoRules ?? [],
+          options.tier
+        )
+      : []),
+  ];
+  const drift = runDrift ? await checkDrift(rootDir, options.topo) : null;
 
   const errorCount = allDiagnostics.filter(
     (d) => d.severity === 'error'


### PR DESCRIPTION
## Context

TRL-516 wires the metadata vocabulary into execution. The goal is to let agents and CI run a focused Warden tier without splitting Warden into separate tools.

## What changed

- Adds `tier` filtering to `runWarden` for source-static, project-static, topo-aware, and drift checks.
- Exposes `tier` on the `trails warden` trail input.
- Keeps default behavior broad while making `tier: 'drift'` and non-drift tier runs explicit.
- Adds docs and tests for tier filtering.

## Testing

- `bun test packages/warden/src/__tests__/cli.test.ts packages/warden/src/__tests__/topo-aware-rule.test.ts apps/trails/src/__tests__/warden.test.ts packages/warden/src/__tests__/public-api.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run check` from the top of the stack

## Risks

Medium. Filtering changes Warden execution selection, so review should verify default behavior stays compatible and topo/drift-only paths remain intentional.
