### PR TITLE
feat: add native result error warden rule

### DIFF
--- a/apps/trails-demo/src/trails/onboard.ts
+++ b/apps/trails-demo/src/trails/onboard.ts
@@ -5,7 +5,7 @@
  * error propagation from downstream trails.
  */
 
-import { trail, Result } from '@ontrails/core';
+import { InternalError, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
@@ -15,7 +15,7 @@ import { z } from 'zod';
 export const onboard = trail('entity.onboard', {
   blaze: async (input, ctx) => {
     if (!ctx.cross) {
-      return Result.err(new Error('Route requires a cross function'));
+      return Result.err(new InternalError('Route requires a cross function'));
     }
 
     const added = await ctx.cross<{

--- a/apps/trails/src/trails/add-surface.ts
+++ b/apps/trails/src/trails/add-surface.ts
@@ -7,7 +7,7 @@
 import { existsSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 
-import { Result, trail } from '@ontrails/core';
+import { AlreadyExistsError, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import {
@@ -143,7 +143,7 @@ export const addSurface = trail('add.surface', {
 
     if (entryExists.value) {
       return Result.err(
-        new Error(
+        new AlreadyExistsError(
           `${surface.toUpperCase()} surface already exists. Nothing to do.`
         )
       );

--- a/apps/trails/src/trails/create.ts
+++ b/apps/trails/src/trails/create.ts
@@ -5,7 +5,7 @@
  * via ctx.cross.
  */
 
-import { Result, trail } from '@ontrails/core';
+import { InternalError, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import {
@@ -111,7 +111,7 @@ const collectCreatedFiles = (
 export const createRoute = trail('create', {
   blaze: async (input: CreateInput, ctx) => {
     if (!ctx.cross) {
-      return Result.err(new Error('create route requires ctx.cross'));
+      return Result.err(new InternalError('create route requires ctx.cross'));
     }
     const { cross } = ctx;
 

--- a/packages/config/src/resolve.ts
+++ b/packages/config/src/resolve.ts
@@ -5,7 +5,7 @@
 
 import type { z } from 'zod';
 
-import { Result } from '@ontrails/core';
+import { Result, ValidationError } from '@ontrails/core';
 
 import { collectConfigMeta } from './collect.js';
 import { deepMerge } from './merge.js';
@@ -275,5 +275,7 @@ export const deriveConfig = <T extends z.ZodType>(
     return Result.ok(parsed.data as z.infer<T>);
   }
 
-  return Result.err(new Error(formatValidationError(parsed.error.issues)));
+  return Result.err(
+    new ValidationError(formatValidationError(parsed.error.issues))
+  );
 };

--- a/packages/warden/src/__tests__/no-native-error-result.test.ts
+++ b/packages/warden/src/__tests__/no-native-error-result.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+
+import { noNativeErrorResult } from '../rules/no-native-error-result.js';
+
+const TEST_FILE = 'src/trails/entity.ts';
+
+describe('no-native-error-result', () => {
+  test('flags Result.err(new Error(...))', () => {
+    const code = `
+import { Result } from '@ontrails/core';
+
+export const load = () => Result.err(new Error('failed'));
+`;
+
+    const diagnostics = noNativeErrorResult.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('no-native-error-result');
+    expect(diagnostics[0]?.severity).toBe('error');
+    expect(diagnostics[0]?.message).toContain('TrailsError');
+  });
+
+  test.each([
+    'AggregateError',
+    'Error',
+    'EvalError',
+    'RangeError',
+    'ReferenceError',
+    'SyntaxError',
+    'TypeError',
+    'URIError',
+  ])('flags Result.err(new %s(...))', (constructorName) => {
+    const aggregateArg = constructorName === 'AggregateError' ? '[],' : '';
+    const code = `
+import { Result } from '@ontrails/core';
+
+export const load = () => Result.err(new ${constructorName}(${aggregateArg}'failed'));
+`;
+
+    const diagnostics = noNativeErrorResult.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('flags namespaced Result.err(new Error(...))', () => {
+    const code = `
+import * as core from '@ontrails/core';
+
+export const load = () => core.Result.err(new Error('failed'));
+`;
+
+    const diagnostics = noNativeErrorResult.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('flags namespaced Result.err(new native Error subclass)', () => {
+    const code = `
+import * as core from '@ontrails/core';
+
+export const load = () => core.Result.err(new RangeError('failed'));
+`;
+
+    const diagnostics = noNativeErrorResult.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('flags formatted Result.err(new Error(...)) despite whitespace and comments', () => {
+    const code = `
+import { Result } from '@ontrails/core';
+
+export const spaced = () => Result
+  .err(new Error('failed'));
+export const commented = () => Result /* comment */ .err(new Error('failed'));
+export const splitConstructor = () => Result.err(new
+  Error('failed'));
+`;
+
+    const diagnostics = noNativeErrorResult.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(3);
+  });
+
+  test('allows specific TrailsError subclasses', () => {
+    const code = `
+import { InternalError, Result } from '@ontrails/core';
+
+export const load = () => Result.err(new InternalError('failed'));
+`;
+
+    expect(noNativeErrorResult.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not flag constructor-boundary throws', () => {
+    const code = `
+export const load = () => {
+  throw new Error('failed');
+};
+`;
+
+    expect(noNativeErrorResult.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not flag native Error subclasses outside Result.err', () => {
+    const code = `
+export const load = () => {
+  throw new TypeError('failed');
+};
+`;
+
+    expect(noNativeErrorResult.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('ignores framework-internal test helpers', () => {
+    const code = `
+import { Result } from '@ontrails/core';
+
+export const inject = () => Result.err(new Error('AlreadyExistsError'));
+`;
+
+    const diagnostics = noNativeErrorResult.check(
+      code,
+      '/workspace/packages/testing/src/crosses.ts'
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 33 rule trails', () => {
-    expect(wardenTopo.count).toBe(33);
+  test('contains all 34 rule trails', () => {
+    expect(wardenTopo.count).toBe(34);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -83,6 +83,7 @@ export {
   missingVisibilityTrail,
   missingReconcileTrail,
   noDirectImplementationCallTrail,
+  noNativeErrorResultTrail,
   noSyncResultAssumptionTrail,
   noThrowInDetourRecoverTrail,
   noThrowInImplementationTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -15,6 +15,7 @@ import { intentPropagation } from './intent-propagation.js';
 import { missingVisibility } from './missing-visibility.js';
 import { missingReconcile } from './missing-reconcile.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
+import { noNativeErrorResult } from './no-native-error-result.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
@@ -75,6 +76,7 @@ export { missingVisibility } from './missing-visibility.js';
 export { missingReconcile } from './missing-reconcile.js';
 export { onReferencesExist } from './on-references-exist.js';
 export { noDirectImplementationCall } from './no-direct-implementation-call.js';
+export { noNativeErrorResult } from './no-native-error-result.js';
 export { noSyncResultAssumption } from './no-sync-result-assumption.js';
 export { implementationReturnsResult } from './implementation-returns-result.js';
 export { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
@@ -118,6 +120,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [preferSchemaInference.name, preferSchemaInference],
   [validDescribeRefs.name, validDescribeRefs],
   [noDirectImplementationCall.name, noDirectImplementationCall],
+  [noNativeErrorResult.name, noNativeErrorResult],
   [noSyncResultAssumption.name, noSyncResultAssumption],
   [implementationReturnsResult.name, implementationReturnsResult],
   [noThrowInDetourRecover.name, noThrowInDetourRecover],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -130,6 +130,11 @@ export const builtinWardenRuleMetadata = {
     invariant: 'Application code composes trails through ctx.cross().',
     tier: 'source-static',
   },
+  'no-native-error-result': {
+    ...durableExternal,
+    invariant: 'Result error boundaries carry specific TrailsError subclasses.',
+    tier: 'source-static',
+  },
   'no-sync-result-assumption': {
     ...durableExternal,
     invariant:

--- a/packages/warden/src/rules/no-native-error-result.ts
+++ b/packages/warden/src/rules/no-native-error-result.ts
@@ -1,0 +1,111 @@
+import { identifierName, offsetToLine, parse, walk } from './ast.js';
+import { isFrameworkInternalFile } from './scan.js';
+import type { AstNode } from './ast.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'no-native-error-result';
+
+const NATIVE_ERROR_CONSTRUCTORS = new Set([
+  'AggregateError',
+  'Error',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+]);
+
+const getMemberPropertyName = (node: AstNode): string | null => {
+  if (
+    node.type !== 'MemberExpression' &&
+    node.type !== 'StaticMemberExpression'
+  ) {
+    return null;
+  }
+
+  return identifierName((node as unknown as { property?: AstNode }).property);
+};
+
+const isResultObject = (node: AstNode | undefined): boolean => {
+  if (!node) {
+    return false;
+  }
+
+  if (identifierName(node) === 'Result') {
+    return true;
+  }
+
+  return getMemberPropertyName(node) === 'Result';
+};
+
+const isResultErrCall = (node: AstNode): boolean => {
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+
+  const { callee } = node as unknown as { callee?: AstNode };
+  if (!callee || getMemberPropertyName(callee) !== 'err') {
+    return false;
+  }
+
+  return isResultObject((callee as unknown as { object?: AstNode }).object);
+};
+
+const isNativeErrorConstruction = (node: AstNode | undefined): boolean => {
+  if (!node || node.type !== 'NewExpression') {
+    return false;
+  }
+
+  const constructorName = identifierName(
+    (node as unknown as { callee?: AstNode }).callee
+  );
+  return constructorName
+    ? NATIVE_ERROR_CONSTRUCTORS.has(constructorName)
+    : false;
+};
+
+const getFirstArgument = (node: AstNode): AstNode | undefined =>
+  (node as unknown as { arguments?: readonly AstNode[] }).arguments?.[0];
+
+const createDiagnostic = (
+  filePath: string,
+  sourceCode: string,
+  node: AstNode
+): WardenDiagnostic => ({
+  filePath,
+  line: offsetToLine(sourceCode, node.start),
+  message:
+    'Use a specific TrailsError subclass with Result.err(...) instead of native Error.',
+  rule: RULE_NAME,
+  severity: 'error',
+});
+
+export const noNativeErrorResult: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isFrameworkInternalFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const diagnostics: WardenDiagnostic[] = [];
+    walk(ast, (node) => {
+      if (
+        isResultErrCall(node) &&
+        isNativeErrorConstruction(getFirstArgument(node))
+      ) {
+        diagnostics.push(createDiagnostic(filePath, sourceCode, node));
+      }
+    });
+
+    return diagnostics;
+  },
+  description:
+    'Require Result.err(...) calls to carry specific TrailsError subclasses instead of native Error.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -23,6 +23,7 @@ import { intentPropagation } from './intent-propagation.js';
 import { missingReconcile } from './missing-reconcile.js';
 import { missingVisibility } from './missing-visibility.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
+import { noNativeErrorResult } from './no-native-error-result.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
@@ -63,6 +64,7 @@ export const registeredRuleNames: readonly string[] = [
   missingReconcile.name,
   missingVisibility.name,
   noDirectImplementationCall.name,
+  noNativeErrorResult.name,
   noSyncResultAssumption.name,
   noThrowInDetourRecover.name,
   noThrowInImplementation.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -16,6 +16,7 @@ export { missingVisibilityTrail } from './missing-visibility.trail.js';
 export { missingReconcileTrail } from './missing-reconcile.trail.js';
 export { onReferencesExistTrail } from './on-references-exist.trail.js';
 export { noDirectImplementationCallTrail } from './no-direct-implementation-call.trail.js';
+export { noNativeErrorResultTrail } from './no-native-error-result.trail.js';
 export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.js';
 export { noThrowInDetourRecoverTrail } from './no-throw-in-detour-recover.trail.js';
 export { noThrowInImplementationTrail } from './no-throw-in-implementation.trail.js';

--- a/packages/warden/src/trails/no-native-error-result.trail.ts
+++ b/packages/warden/src/trails/no-native-error-result.trail.ts
@@ -1,0 +1,18 @@
+import { noNativeErrorResult } from '../rules/no-native-error-result.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const noNativeErrorResultTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'entity.ts',
+        sourceCode: `import { InternalError, Result } from "@ontrails/core";
+
+export const load = () => Result.err(new InternalError("failed"));`,
+      },
+      name: 'Specific TrailsError subclasses stay clean',
+    },
+  ],
+  rule: noNativeErrorResult,
+});


### PR DESCRIPTION
## Context

TRL-514 implements the first durable source-static Warden rule chosen during the hardening audit: block `Result.err(new Error(...))` in framework/application code and require a specific TrailsError subclass. TRL-519 validation is folded into this PR so the rule branch is clean on its own.

## What changed

- Adds `no-native-error-result` source-static Warden rule.
- Registers the rule, metadata, exports, and wrapped trail.
- Covers direct and namespaced `Result.err(new Error(...))` calls while allowing specific TrailsError subclasses.
- Keeps framework-internal Warden/testing helper files out of the rule, matching existing source-scanner precedent.
- Replaces native `Error` in real framework `Result.err(...)` paths with `InternalError`, `AlreadyExistsError`, or `ValidationError`.
- Updates Warden trail/export symmetry tests and validates a repo-wide source-static run.

## Testing

- `bun -e "import { runWarden } from './packages/warden/src/cli.ts'; const report = await runWarden({ rootDir: process.cwd(), tier: 'source-static' }); const hits = report.diagnostics.filter((d) => d.rule === 'no-native-error-result'); console.log(JSON.stringify({ total: report.diagnostics.length, hits }, null, 2));"`
- `bun test packages/warden/src/__tests__/no-native-error-result.test.ts packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/trails.test.ts packages/warden/src/__tests__/warden-export-symmetry.test.ts`
- `bun test apps/trails/src/__tests__/create.test.ts apps/trails-demo/__tests__/onboard.test.ts apps/trails-demo/__tests__/governance.test.ts`
- `bun test packages/config/src/__tests__/resolve.test.ts packages/warden/src/__tests__/no-native-error-result.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run check`

## Risks

Medium. This adds a new enforced Warden rule, but the branch includes the framework validation pass and exits with a clean source-static report.
