### PR TITLE
fix: validate native result error rule

### DIFF
--- a/apps/trails-demo/src/trails/onboard.ts
+++ b/apps/trails-demo/src/trails/onboard.ts
@@ -5,7 +5,7 @@
  * error propagation from downstream trails.
  */
 
-import { trail, Result } from '@ontrails/core';
+import { InternalError, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
@@ -15,7 +15,7 @@ import { z } from 'zod';
 export const onboard = trail('entity.onboard', {
   blaze: async (input, ctx) => {
     if (!ctx.cross) {
-      return Result.err(new Error('Route requires a cross function'));
+      return Result.err(new InternalError('Route requires a cross function'));
     }
 
     const added = await ctx.cross<{

--- a/apps/trails/src/trails/add-surface.ts
+++ b/apps/trails/src/trails/add-surface.ts
@@ -7,7 +7,7 @@
 import { existsSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 
-import { Result, trail } from '@ontrails/core';
+import { AlreadyExistsError, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import {
@@ -143,7 +143,7 @@ export const addSurface = trail('add.surface', {
 
     if (entryExists.value) {
       return Result.err(
-        new Error(
+        new AlreadyExistsError(
           `${surface.toUpperCase()} surface already exists. Nothing to do.`
         )
       );

--- a/apps/trails/src/trails/create.ts
+++ b/apps/trails/src/trails/create.ts
@@ -5,7 +5,7 @@
  * via ctx.cross.
  */
 
-import { Result, trail } from '@ontrails/core';
+import { InternalError, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import {
@@ -111,7 +111,7 @@ const collectCreatedFiles = (
 export const createRoute = trail('create', {
   blaze: async (input: CreateInput, ctx) => {
     if (!ctx.cross) {
-      return Result.err(new Error('create route requires ctx.cross'));
+      return Result.err(new InternalError('create route requires ctx.cross'));
     }
     const { cross } = ctx;
 

--- a/packages/config/src/resolve.ts
+++ b/packages/config/src/resolve.ts
@@ -5,7 +5,7 @@
 
 import type { z } from 'zod';
 
-import { Result } from '@ontrails/core';
+import { Result, ValidationError } from '@ontrails/core';
 
 import { collectConfigMeta } from './collect.js';
 import { deepMerge } from './merge.js';
@@ -275,5 +275,7 @@ export const deriveConfig = <T extends z.ZodType>(
     return Result.ok(parsed.data as z.infer<T>);
   }
 
-  return Result.err(new Error(formatValidationError(parsed.error.issues)));
+  return Result.err(
+    new ValidationError(formatValidationError(parsed.error.issues))
+  );
 };

--- a/packages/warden/src/__tests__/no-native-error-result.test.ts
+++ b/packages/warden/src/__tests__/no-native-error-result.test.ts
@@ -51,4 +51,19 @@ export const load = () => {
 
     expect(noNativeErrorResult.check(code, TEST_FILE)).toEqual([]);
   });
+
+  test('ignores framework-internal test helpers', () => {
+    const code = `
+import { Result } from '@ontrails/core';
+
+export const inject = () => Result.err(new Error('AlreadyExistsError'));
+`;
+
+    const diagnostics = noNativeErrorResult.check(
+      code,
+      '/workspace/packages/testing/src/crosses.ts'
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
 });

--- a/packages/warden/src/rules/no-native-error-result.ts
+++ b/packages/warden/src/rules/no-native-error-result.ts
@@ -1,4 +1,5 @@
 import { identifierName, offsetToLine, parse, walk } from './ast.js';
+import { isFrameworkInternalFile } from './scan.js';
 import type { AstNode } from './ast.js';
 import type { WardenDiagnostic, WardenRule } from './types.js';
 
@@ -69,6 +70,7 @@ const createDiagnostic = (
 export const noNativeErrorResult: WardenRule = {
   check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
     if (
+      isFrameworkInternalFile(filePath) ||
       !sourceCode.includes('Result.err') ||
       !sourceCode.includes('new Error')
     ) {


### PR DESCRIPTION
## Context

TRL-519 validates the new source-static Warden rule against the Trails framework code before the stack leaves draft. The first probe found six native-error hits; this branch handles the real positives and narrows framework-internal helper noise.

## What changed

- Replaces native `Error` in real `Result.err(...)` paths with `InternalError`, `AlreadyExistsError`, or `ValidationError`.
- Keeps the new rule out of `packages/testing` and `packages/warden` internals, matching existing scanner precedent.
- Adds a test for the framework-internal skip.
- Confirms `runWarden({ tier: 'source-static' })` reports zero diagnostics on the full repo.

## Testing

- `bun -e "import { runWarden } from './packages/warden/src/cli.ts'; const report = await runWarden({ rootDir: process.cwd(), tier: 'source-static' }); const hits = report.diagnostics.filter((d) => d.rule === 'no-native-error-result'); console.log(JSON.stringify({ total: report.diagnostics.length, hits }, null, 2));"`
- `bun test apps/trails/src/__tests__/create.test.ts apps/trails-demo/__tests__/onboard.test.ts apps/trails-demo/__tests__/governance.test.ts`
- `bun test packages/config/src/__tests__/resolve.test.ts packages/warden/src/__tests__/no-native-error-result.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run check`

## Risks

Low. The behavior changes are limited to more specific TrailsError subclasses and a source-rule internal exclusion matching existing Warden scanner policy.
