### PR TITLE
fix: dogfood trail runtime result boundaries

### DIFF
--- a/apps/ci/src/trails/ci-drift.ts
+++ b/apps/ci/src/trails/ci-drift.ts
@@ -8,9 +8,15 @@ import { z } from 'zod';
 
 import { createDriftOnlyReport, evaluateCiGovernance } from '../governance.js';
 
+import { resolveCiRootDir } from './root-dir.js';
+
 export const ciDriftTrail = trail('ci.drift', {
   blaze: async (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
+    const rootDirResult = resolveCiRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
     const driftResult = await checkDrift(rootDir);
     const output = evaluateCiGovernance({
       driftResult,

--- a/apps/ci/src/trails/ci-warden.ts
+++ b/apps/ci/src/trails/ci-warden.ts
@@ -9,9 +9,15 @@ import type { CiFormat } from '../formatters.js';
 import type { CiFailOn } from '../governance.js';
 import { runCiGovernance } from '../governance.js';
 
+import { resolveCiRootDir } from './root-dir.js';
+
 export const ciWardenTrail = trail('ci.warden', {
   blaze: async (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
+    const rootDirResult = resolveCiRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
     const format: CiFormat = input.format ?? 'json';
     const failOn: CiFailOn = input.failOn ?? 'error';
     const result = await runCiGovernance({ failOn, format, rootDir });

--- a/apps/ci/src/trails/root-dir.ts
+++ b/apps/ci/src/trails/root-dir.ts
@@ -1,0 +1,15 @@
+import { Result, ValidationError } from '@ontrails/core';
+
+export const resolveCiRootDir = (
+  rootDir: string | undefined,
+  cwd: string | undefined
+): Result<string, ValidationError> => {
+  const resolved = rootDir ?? cwd;
+  return resolved === undefined
+    ? Result.err(
+        new ValidationError(
+          'CI trail execution requires rootDir input or ctx.cwd from the runtime context.'
+        )
+      )
+    : Result.ok(resolved);
+};

--- a/apps/trails/src/__tests__/draft-promote.test.ts
+++ b/apps/trails/src/__tests__/draft-promote.test.ts
@@ -268,6 +268,37 @@ describe('draft.promote', () => {
     }
   });
 
+  test('promotes an absolute root without context cwd', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeDraftPromoteFixture(dir);
+
+      const result = expectOk(
+        await draftPromoteTrail.blaze(
+          {
+            fromId: '_draft.entity.prepare',
+            renameFiles: true,
+            rootDir: dir,
+            toId: 'entity.prepare',
+          },
+          {} as never
+        )
+      );
+
+      expect(result.promotedEstablished).toBe(true);
+      expect(result.renamedFiles).toEqual([
+        {
+          from: 'src/_draft.prepare.ts',
+          to: 'src/prepare.ts',
+        },
+      ]);
+      expectDraftPromoteResults(dir);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('returns ValidationError when rootDir does not exist', async () => {
     const error = expectErr(
       await draftPromoteTrail.blaze(

--- a/apps/trails/src/trails/add-verify.ts
+++ b/apps/trails/src/trails/add-verify.ts
@@ -125,8 +125,8 @@ export const addVerify = trail('add.verify', {
       .regex(PROJECT_NAME_PATTERN, PROJECT_NAME_MESSAGE)
       .describe('Project name'),
   }),
-  meta: { internal: true },
   output: z.object({
     created: z.array(z.string()),
   }),
+  visibility: 'internal',
 });

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -393,7 +393,6 @@ export const createScaffold = trail('create.scaffold', {
       .default('hello')
       .describe('Starter trail'),
   }),
-  meta: { internal: true },
   output: z.object({
     created: z
       .array(z.string())
@@ -413,4 +412,5 @@ export const createScaffold = trail('create.scaffold', {
       ])
     ),
   }),
+  visibility: 'internal',
 });

--- a/apps/trails/src/trails/dev-clean.ts
+++ b/apps/trails/src/trails/dev-clean.ts
@@ -5,6 +5,7 @@ import {
   cleanDevState,
   DEFAULT_TOPO_SNAPSHOT_RETENTION,
 } from './dev-support.js';
+import { resolveTrailRootDir } from './root-dir.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 
 export const devCleanTrail = trail('dev.clean', {
@@ -17,7 +18,11 @@ export const devCleanTrail = trail('dev.clean', {
       );
     }
 
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
     return Result.ok(
       cleanDevState({
         dryRun: input.dryRun,

--- a/apps/trails/src/trails/dev-reset.ts
+++ b/apps/trails/src/trails/dev-reset.ts
@@ -2,6 +2,7 @@ import { Result, ValidationError, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { resetDevState } from './dev-support.js';
+import { resolveTrailRootDir } from './root-dir.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 
 export const devResetTrail = trail('dev.reset', {
@@ -14,7 +15,11 @@ export const devResetTrail = trail('dev.reset', {
       );
     }
 
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
     return Result.ok(resetDevState({ dryRun: input.dryRun, rootDir }));
   },
   description: 'Remove local Trails database artifacts',

--- a/apps/trails/src/trails/dev-stats.ts
+++ b/apps/trails/src/trails/dev-stats.ts
@@ -5,11 +5,16 @@ import {
   buildDevStats,
   DEFAULT_TOPO_SNAPSHOT_RETENTION,
 } from './dev-support.js';
+import { resolveTrailRootDir } from './root-dir.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 
 export const devStatsTrail = trail('dev.stats', {
   blaze: (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
     return Result.ok(
       buildDevStats({
         maxAge: input.traceAgeMs,

--- a/apps/trails/src/trails/dev-support.ts
+++ b/apps/trails/src/trails/dev-support.ts
@@ -21,9 +21,11 @@ import {
 
 import { removeRootRelativeFileIfPresent } from '../local-state-io.js';
 
+import { requireTrailRootDir } from './root-dir.js';
+
 export const DEFAULT_TOPO_SNAPSHOT_RETENTION = 50;
 
-const deriveRootDir = (cwd?: string): string => cwd ?? process.cwd();
+const deriveRootDir = (cwd?: string): string => requireTrailRootDir(cwd);
 
 const removeResetFileIfPresent = (
   rootDir: string,

--- a/apps/trails/src/trails/draft-promote.ts
+++ b/apps/trails/src/trails/draft-promote.ts
@@ -1,5 +1,12 @@
 import { existsSync, statSync } from 'node:fs';
-import { basename, dirname, join, relative, resolve } from 'node:path';
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from 'node:path';
 
 import {
   Result,
@@ -25,8 +32,10 @@ import type {
   PlannedProjectOperation,
   ProjectWriteOperation,
 } from '../project-writes.js';
-import { loadFreshAppLease } from './load-app.js';
+import type { FreshAppLease } from './load-app.js';
+import { tryLoadFreshAppLease } from './load-app.js';
 import { findTopoPath } from './project.js';
+import { resolveTrailRootDir } from './root-dir.js';
 
 interface PromotionEdit {
   readonly end: number;
@@ -248,9 +257,22 @@ const resolveValidatedPromotionRoot = (
     return validation;
   }
 
-  const cwd = resolve(ctx.cwd ?? process.cwd());
-  const rootDir =
-    input.rootDir === undefined ? cwd : resolve(cwd, input.rootDir);
+  let rootDir: string;
+  if (input.rootDir === undefined) {
+    const cwdResult = resolveTrailRootDir(undefined, ctx.cwd);
+    if (cwdResult.isErr()) {
+      return cwdResult;
+    }
+    rootDir = resolve(cwdResult.value);
+  } else if (isAbsolute(input.rootDir)) {
+    rootDir = resolve(input.rootDir);
+  } else {
+    const cwdResult = resolveTrailRootDir(undefined, ctx.cwd);
+    if (cwdResult.isErr()) {
+      return cwdResult;
+    }
+    rootDir = resolve(cwdResult.value, input.rootDir);
+  }
   const rootValidation = validatePromotionRoot(rootDir);
   if (rootValidation.isErr()) {
     return rootValidation;
@@ -660,7 +682,7 @@ const resolvePromotionAppModule = async (
 type LeaseAttempt =
   | {
       readonly ok: true;
-      readonly lease: Awaited<ReturnType<typeof loadFreshAppLease>>;
+      readonly lease: FreshAppLease;
     }
   | { readonly ok: false; readonly loadError: string };
 
@@ -668,12 +690,11 @@ const tryAcquireLease = async (
   appModule: string,
   rootDir: string
 ): Promise<LeaseAttempt> => {
-  try {
-    return { lease: await loadFreshAppLease(appModule, rootDir), ok: true };
-  } catch (error) {
-    const loadError = error instanceof Error ? error.message : String(error);
-    return { loadError, ok: false };
+  const loaded = await tryLoadFreshAppLease(appModule, rootDir);
+  if (loaded.isErr()) {
+    return { loadError: loaded.error.message, ok: false };
   }
+  return { lease: loaded.value, ok: true };
 };
 
 const withVerifiedApp = async <T>(

--- a/apps/trails/src/trails/guide.ts
+++ b/apps/trails/src/trails/guide.ts
@@ -7,13 +7,14 @@
 import { NotFoundError, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { loadFreshAppLease } from './load-app.js';
+import { tryLoadFreshAppLease } from './load-app.js';
 import { trailDetailOutput } from './topo-output-schemas.js';
 import {
   buildCurrentGuideEntries,
   buildCurrentTopoDetail,
 } from './topo-read-support.js';
 import { createIsolatedExampleInput } from './topo-support.js';
+import { resolveTrailRootDir } from './root-dir.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,8 +33,16 @@ interface GuideEntry {
 
 export const guideTrail = trail('guide', {
   blaze: async (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
-    const lease = await loadFreshAppLease(input.module, rootDir);
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
+    if (leaseResult.isErr()) {
+      return Result.err(leaseResult.error);
+    }
+    const lease = leaseResult.value;
 
     try {
       if (input.trailId) {

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -15,7 +15,14 @@ import {
 } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { deriveSafePath, PermissionError } from '@ontrails/core';
+import {
+  deriveSafePath,
+  InternalError,
+  isTrailsError,
+  PermissionError,
+  Result,
+  ValidationError,
+} from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 import { findAppModule } from '@ontrails/cli';
 
@@ -153,6 +160,13 @@ const trustBoundaryError = (reason: string): PermissionError =>
   new PermissionError(
     `Refusing to load an app module outside the workspace trust boundary (${reason}). Use a workspace-relative module path, or pass trustedModulePath: true from trusted code.`
   );
+
+const toLoadAppError = (error: unknown): Error =>
+  isTrailsError(error)
+    ? error
+    : new InternalError('Failed to load app module', {
+        cause: error instanceof Error ? error : new Error(String(error)),
+      });
 
 const isPathInside = (root: string, target: string): boolean => {
   const candidate = relative(root, target);
@@ -641,7 +655,7 @@ const resolveLoadedTopo = (
     | Topo
     | undefined;
   if (!app?.trails) {
-    throw new Error(
+    throw new ValidationError(
       `Could not find a Topo export in "${effectivePath}". ` +
         "Expected a default, 'graph', or 'app' named export created with topo()."
     );
@@ -714,6 +728,18 @@ export const loadFreshAppLease = async (
     : await createFilesystemLease(absolutePath, cwd, effectivePath);
 };
 
+export const tryLoadFreshAppLease = async (
+  modulePath: string | undefined,
+  cwd: string,
+  options: LoadAppLeaseOptions = {}
+): Promise<Result<FreshAppLease, Error>> => {
+  try {
+    return Result.ok(await loadFreshAppLease(modulePath, cwd, options));
+  } catch (error) {
+    return Result.err(toLoadAppError(error));
+  }
+};
+
 /**
  * Load a Topo export from a module path relative to cwd.
  *
@@ -745,4 +771,16 @@ export const loadApp = async (
             : pathToFileURL(resolvedModulePath).href
         )) as Record<string, unknown>);
   return resolveLoadedTopo(effectivePath, mod);
+};
+
+export const tryLoadApp = async (
+  modulePath: string | undefined,
+  cwd: string,
+  options: LoadAppOptions = {}
+): Promise<Result<Topo, Error>> => {
+  try {
+    return Result.ok(await loadApp(modulePath, cwd, options));
+  } catch (error) {
+    return Result.err(toLoadAppError(error));
+  }
 };

--- a/apps/trails/src/trails/root-dir.ts
+++ b/apps/trails/src/trails/root-dir.ts
@@ -1,0 +1,21 @@
+import { Result, ValidationError } from '@ontrails/core';
+
+const ROOT_DIR_MESSAGE =
+  'Trail execution requires rootDir input or ctx.cwd from the runtime context.';
+
+export const resolveTrailRootDir = (
+  rootDir: string | undefined,
+  cwd: string | undefined
+): Result<string, ValidationError> => {
+  const resolved = rootDir ?? cwd;
+  return resolved === undefined
+    ? Result.err(new ValidationError(ROOT_DIR_MESSAGE))
+    : Result.ok(resolved);
+};
+
+export const requireTrailRootDir = (rootDir: string | undefined): string => {
+  if (rootDir === undefined) {
+    throw new ValidationError(ROOT_DIR_MESSAGE);
+  }
+  return rootDir;
+};

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -26,7 +26,8 @@ import { z } from 'zod';
 
 import { writeIsolatedExampleJsonFile } from '../local-state-io.js';
 
-import { loadFreshAppLease } from './load-app.js';
+import { tryLoadFreshAppLease } from './load-app.js';
+import { resolveTrailRootDir } from './root-dir.js';
 import {
   buildCurrentTopoBrief,
   buildCurrentTopoList,
@@ -311,22 +312,40 @@ const detailInputSchema = z.object({
   rootDir: z.string().optional().describe('Workspace root directory'),
 });
 
-const resolveRootDir = (
-  input: { readonly rootDir?: string | undefined },
-  cwd?: string | undefined
-): string => input.rootDir ?? cwd ?? process.cwd();
-
 const withFreshSurveyApp = async <T>(
   input: { readonly module?: string | undefined },
   rootDir: string,
   consume: (app: Topo) => Promise<Result<T, Error>> | Result<T, Error>
 ): Promise<Result<T, Error>> => {
-  const lease = await loadFreshAppLease(input.module, rootDir);
+  const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
+  if (leaseResult.isErr()) {
+    return Result.err(leaseResult.error);
+  }
+  const lease = leaseResult.value;
   try {
     return await consume(lease.app);
   } finally {
     lease.release();
   }
+};
+
+const withResolvedSurveyApp = async <T>(
+  input: {
+    readonly module?: string | undefined;
+    readonly rootDir?: string | undefined;
+  },
+  cwd: string | undefined,
+  consume: (
+    app: Topo,
+    rootDir: string
+  ) => Promise<Result<T, Error>> | Result<T, Error>
+): Promise<Result<T, Error>> => {
+  const rootDirResult = resolveTrailRootDir(input.rootDir, cwd);
+  if (rootDirResult.isErr()) {
+    return Result.err(rootDirResult.error);
+  }
+  const rootDir = rootDirResult.value;
+  return withFreshSurveyApp(input, rootDir, (app) => consume(app, rootDir));
 };
 
 const moduleInputSchema = z.object({
@@ -372,12 +391,10 @@ const surveyMatchOutput = z.discriminatedUnion('kind', [
 
 export const surveyTrail = trail('survey', {
   args: ['id'],
-  blaze: async (input, ctx) => {
-    const rootDir = resolveRootDir(input, ctx.cwd);
-    return withFreshSurveyApp(input, rootDir, (app) =>
+  blaze: async (input, ctx) =>
+    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
       dispatchSurvey(app, input, rootDir)
-    );
-  },
+    ),
   description: 'Full topo introspection',
   examples: [
     {
@@ -445,12 +462,10 @@ export const surveyTrail = trail('survey', {
 });
 
 export const surveyBriefTrail = trail('survey.brief', {
-  blaze: async (input, ctx) => {
-    const rootDir = resolveRootDir(input, ctx.cwd);
-    return withFreshSurveyApp(input, rootDir, (app) =>
+  blaze: async (input, ctx) =>
+    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
       Result.ok(buildCurrentTopoBrief(app, { rootDir }))
-    );
-  },
+    ),
   description: 'Summarize topo capabilities',
   examples: [
     {
@@ -465,12 +480,10 @@ export const surveyBriefTrail = trail('survey.brief', {
 });
 
 export const surveyDiffTrail = trail('survey.diff', {
-  blaze: async (input, ctx) => {
-    const rootDir = resolveRootDir(input, ctx.cwd);
-    return withFreshSurveyApp(input, rootDir, (app) =>
+  blaze: async (input, ctx) =>
+    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
       buildSurveyDiff(app, rootDir, input.breakingOnly, input.against)
-    );
-  },
+    ),
   description: 'Diff the current topo against a saved surface map',
   examples: [
     {
@@ -515,12 +528,10 @@ export const surveyDiffTrail = trail('survey.diff', {
 
 export const surveyTrailDetailTrail = trail('survey.trail', {
   args: ['id'],
-  blaze: async (input, ctx) => {
-    const rootDir = resolveRootDir(input, ctx.cwd);
-    return withFreshSurveyApp(input, rootDir, (app) =>
+  blaze: async (input, ctx) =>
+    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
       buildSurveyTrailDetail(app, input.id, rootDir)
-    );
-  },
+    ),
   description: 'Inspect one trail by ID',
   examples: [
     {
@@ -539,12 +550,10 @@ export const surveyTrailDetailTrail = trail('survey.trail', {
 
 export const surveyResourceTrail = trail('survey.resource', {
   args: ['id'],
-  blaze: async (input, ctx) => {
-    const rootDir = resolveRootDir(input, ctx.cwd);
-    return withFreshSurveyApp(input, rootDir, (app) =>
+  blaze: async (input, ctx) =>
+    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
       buildSurveyResourceDetail(app, input.id, rootDir)
-    );
-  },
+    ),
   description: 'Inspect one resource by ID',
   examples: [
     {
@@ -564,12 +573,10 @@ export const surveyResourceTrail = trail('survey.resource', {
 
 export const surveySignalTrail = trail('survey.signal', {
   args: ['id'],
-  blaze: async (input, ctx) => {
-    const rootDir = resolveRootDir(input, ctx.cwd);
-    return withFreshSurveyApp(input, rootDir, (app) =>
+  blaze: async (input, ctx) =>
+    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
       buildSurveySignalDetail(app, input.id, rootDir)
-    );
-  },
+    ),
   description: 'Inspect one signal by ID',
   examples: [
     {

--- a/apps/trails/src/trails/topo-compile.ts
+++ b/apps/trails/src/trails/topo-compile.ts
@@ -1,8 +1,9 @@
-import { trail } from '@ontrails/core';
-import type { Result, Topo } from '@ontrails/core';
+import { Result, trail } from '@ontrails/core';
+import type { Topo } from '@ontrails/core';
 import { z } from 'zod';
 
-import { loadFreshAppLease } from './load-app.js';
+import { tryLoadFreshAppLease } from './load-app.js';
+import { resolveTrailRootDir } from './root-dir.js';
 import { exportCurrentTopo } from './topo-store-support.js';
 import type { TopoExportReport } from './topo-support.js';
 import {
@@ -17,8 +18,16 @@ export const compileCurrentTopo = async (
 
 export const topoCompileTrail = trail('topo.compile', {
   blaze: async (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
-    const lease = await loadFreshAppLease(input.module, rootDir);
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
+    if (leaseResult.isErr()) {
+      return Result.err(leaseResult.error);
+    }
+    const lease = leaseResult.value;
     try {
       return await compileCurrentTopo(lease.app, { rootDir });
     } finally {

--- a/apps/trails/src/trails/topo-export.ts
+++ b/apps/trails/src/trails/topo-export.ts
@@ -1,7 +1,8 @@
-import { trail } from '@ontrails/core';
+import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { loadFreshAppLease } from './load-app.js';
+import { tryLoadFreshAppLease } from './load-app.js';
+import { resolveTrailRootDir } from './root-dir.js';
 import { compileCurrentTopo } from './topo-compile.js';
 import {
   createIsolatedExampleInput,
@@ -10,8 +11,16 @@ import {
 
 export const topoExportTrail = trail('topo.export', {
   blaze: async (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
-    const lease = await loadFreshAppLease(input.module, rootDir);
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
+    if (leaseResult.isErr()) {
+      return Result.err(leaseResult.error);
+    }
+    const lease = leaseResult.value;
     try {
       return await compileCurrentTopo(lease.app, { rootDir });
     } finally {

--- a/apps/trails/src/trails/topo-history.ts
+++ b/apps/trails/src/trails/topo-history.ts
@@ -7,10 +7,15 @@ import {
   listTopoHistory,
   topoSnapshotOutput,
 } from './topo-support.js';
+import { resolveTrailRootDir } from './root-dir.js';
 
 export const topoHistoryTrail = trail('topo.history', {
   blaze: (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
     return Result.ok(listTopoHistory({ limit: input.limit, rootDir }));
   },
   description: 'List saved topo snapshots, including pinned references',

--- a/apps/trails/src/trails/topo-pin.ts
+++ b/apps/trails/src/trails/topo-pin.ts
@@ -1,7 +1,8 @@
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { loadFreshAppLease } from './load-app.js';
+import { tryLoadFreshAppLease } from './load-app.js';
+import { resolveTrailRootDir } from './root-dir.js';
 import {
   createIsolatedExampleInput,
   pinCurrentTopoSnapshot,
@@ -10,8 +11,16 @@ import {
 
 export const topoPinTrail = trail('topo.pin', {
   blaze: async (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
-    const lease = await loadFreshAppLease(input.module, rootDir);
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
+    if (leaseResult.isErr()) {
+      return Result.err(leaseResult.error);
+    }
+    const lease = leaseResult.value;
     try {
       return Result.ok(
         pinCurrentTopoSnapshot(lease.app, { name: input.name, rootDir })

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -16,6 +16,7 @@ import {
   writeIsolatedExampleAppModule,
 } from '../local-state-io.js';
 
+import { requireTrailRootDir } from './root-dir.js';
 import type { BriefReport, SurveyListReport } from './topo-reports.js';
 
 /** Output schema for a topo snapshot record. Shared across topo trails. */
@@ -68,7 +69,7 @@ export interface TopoVerifyReport {
   readonly stale: false;
 }
 
-export const deriveRootDir = (cwd?: string): string => cwd ?? process.cwd();
+export const deriveRootDir = (cwd?: string): string => requireTrailRootDir(cwd);
 
 const safeGit = (cwd: string, args: readonly string[]): string | undefined => {
   const proc = Bun.spawnSync({

--- a/apps/trails/src/trails/topo-unpin.ts
+++ b/apps/trails/src/trails/topo-unpin.ts
@@ -6,6 +6,7 @@ import {
   removePinnedTopoSnapshot,
   topoSnapshotOutput,
 } from './topo-support.js';
+import { resolveTrailRootDir } from './root-dir.js';
 
 export const topoUnpinTrail = trail('topo.unpin', {
   blaze: (input, ctx) => {
@@ -17,7 +18,11 @@ export const topoUnpinTrail = trail('topo.unpin', {
       );
     }
 
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
     return Result.ok(
       removePinnedTopoSnapshot({
         dryRun: input.dryRun,

--- a/apps/trails/src/trails/topo-verify.ts
+++ b/apps/trails/src/trails/topo-verify.ts
@@ -1,13 +1,22 @@
-import { trail } from '@ontrails/core';
+import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { loadFreshAppLease } from './load-app.js';
+import { tryLoadFreshAppLease } from './load-app.js';
+import { resolveTrailRootDir } from './root-dir.js';
 import { verifyCurrentTopo } from './topo-read-support.js';
 
 export const topoVerifyTrail = trail('topo.verify', {
   blaze: async (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
-    const lease = await loadFreshAppLease(input.module, rootDir);
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
+    if (leaseResult.isErr()) {
+      return Result.err(leaseResult.error);
+    }
+    const lease = leaseResult.value;
     try {
       return await verifyCurrentTopo(lease.app, { rootDir });
     } finally {

--- a/apps/trails/src/trails/topo.ts
+++ b/apps/trails/src/trails/topo.ts
@@ -1,7 +1,8 @@
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { loadFreshAppLease } from './load-app.js';
+import { tryLoadFreshAppLease } from './load-app.js';
+import { resolveTrailRootDir } from './root-dir.js';
 import { buildTopoSummary } from './topo-read-support.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 
@@ -63,8 +64,16 @@ const summaryOutput = z.object({
 
 export const topoTrail = trail('topo', {
   blaze: async (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
-    const lease = await loadFreshAppLease(input.module, rootDir);
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
+    if (leaseResult.isErr()) {
+      return Result.err(leaseResult.error);
+    }
+    const lease = leaseResult.value;
     try {
       return Result.ok(buildTopoSummary(lease.app, { rootDir }));
     } finally {

--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -5,6 +5,7 @@
  */
 
 import { Result, trail } from '@ontrails/core';
+import type { Topo } from '@ontrails/core';
 import {
   formatGitHubAnnotations,
   formatJson,
@@ -15,7 +16,8 @@ import {
 } from '@ontrails/warden';
 import { z } from 'zod';
 
-import { loadApp } from './load-app.js';
+import { tryLoadApp } from './load-app.js';
+import { resolveTrailRootDir } from './root-dir.js';
 
 // ---------------------------------------------------------------------------
 // Trail definition
@@ -23,16 +25,20 @@ import { loadApp } from './load-app.js';
 
 export const wardenTrail = trail('warden', {
   blaze: async (input, ctx) => {
-    const rootDir = input.rootDir ?? ctx.cwd ?? process.cwd();
-    // oxlint-disable-next-line prefer-await-to-then -- catch preserves graceful degradation
-    const topo = await loadApp(input.module, rootDir).catch(
-      (error: unknown): undefined => {
-        ctx.logger?.warn('Could not load app for topo-aware governance', {
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return undefined;
-      }
-    );
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+    const loadedTopo = await tryLoadApp(input.module, rootDir);
+    let topo: Topo | undefined;
+    if (loadedTopo.isOk()) {
+      topo = loadedTopo.value;
+    } else {
+      ctx.logger?.warn('Could not load app for topo-aware governance', {
+        error: loadedTopo.error.message,
+      });
+    }
 
     const report = await runWarden({
       driftOnly: input.driftOnly,

--- a/connectors/hono/src/surface.ts
+++ b/connectors/hono/src/surface.ts
@@ -468,6 +468,10 @@ const registerErrorHandler = (hono: Hono): void => {
 
 /**
  * Build HTTP routes from a topo and register them on a Hono app.
+ *
+ * @remarks This is a host materialization boundary. Derivation failures are
+ * thrown for HTTP bootstrap code after `deriveHttpRoutes` has already
+ * represented the framework error as a Result.
  */
 export const createApp = (
   graph: Topo,

--- a/packages/cli/src/commander/surface.ts
+++ b/packages/cli/src/commander/surface.ts
@@ -62,6 +62,10 @@ const deriveCommanderOptions = (
 
 /**
  * Create a Commander program from a topo without parsing argv.
+ *
+ * @remarks This is a host materialization boundary. Derivation failures are
+ * thrown for the caller's CLI bootstrap code after `deriveCliCommands` has
+ * already represented the framework error as a Result.
  */
 export const createProgram = (
   graph: Topo,

--- a/packages/cli/src/on-result.ts
+++ b/packages/cli/src/on-result.ts
@@ -12,8 +12,12 @@ import { output, deriveOutputMode } from './output.js';
 /**
  * The batteries-included result handler.
  *
- * - On error: throws the error (lets the program's error handler produce exit code)
+ * - On error: throws at the CLI presentation boundary, where Commander maps
+ *   the error to process output and an exit code.
  * - On success: resolves output mode from flags, pipes value through `output()`
+ *
+ * @remarks Trail logic should return `Result.err(...)` instead of throwing.
+ * This host-boundary throw is intentionally outside trail execution.
  */
 export const defaultOnResult = async (
   ctx: ActionResultContext

--- a/packages/mcp/src/surface.ts
+++ b/packages/mcp/src/surface.ts
@@ -141,6 +141,10 @@ const createMcpServer = (
 
 /**
  * Build MCP tools from a topo and create an MCP server.
+ *
+ * @remarks This is a host materialization boundary. Derivation failures are
+ * thrown for server bootstrap code after `deriveMcpTools` has already
+ * represented the framework error as a Result.
  */
 export const createServer = (
   graph: Topo,


### PR DESCRIPTION
## Context

Closeout implementation for TRL-564 from the dogfood prevention plan. The previous hardening stack landed the native Warden result-error rule; this branch cleans up the remaining Trails dogfood runtime boundaries that the audit kept finding by hand.

## What changed

- Added shared `rootDir` resolution helpers for the Trails app and CI app so runtime preconditions return `Result.err(ValidationError)` instead of falling through to ambient `process.cwd()`.
- Added `tryLoadApp` / `tryLoadFreshAppLease` wrappers and moved app-loading callsites onto Result-returning boundaries.
- Updated `warden`, `survey`, `guide`, `topo`, topo dev, draft promotion, verify, and scaffold dogfood trails to use explicit Result errors for expected runtime failures.
- Removed remaining live `meta.internal` usage from app trail definitions.
- Documented the intentional construction/materializer throw boundaries in CLI, MCP, and Hono surfaces.
- Wrote a local closeout translation note for the accepted advisory-skill and future Warden-rule follow-ups.

## Validation

- `bun test apps/trails/src/__tests__/load-app.test.ts apps/trails/src/__tests__/create.test.ts apps/trails/src/__tests__/survey.test.ts apps/trails/src/__tests__/topo-dev.test.ts apps/trails/src/__tests__/draft-promote.test.ts apps/trails/src/__tests__/guide.test.ts apps/trails/src/__tests__/warden.test.ts`
- `bun test apps/ci/src`
- `bun test packages/cli/src/__tests__/on-result.test.ts packages/cli/src/__tests__/surface.test.ts`
- `bun test packages/mcp/src/__tests__/surface.test.ts connectors/hono/src/__tests__/surface.test.ts`
- `bun run check`
- `git diff --check`

## Risks / rollout

The main behavior shift is that missing `rootDir`/`cwd` and app-load failures now surface as typed validation errors where these trails can model them. Remaining prevention rails are tracked separately as Linear follow-ups TRL-593 through TRL-601.