### PR TITLE
docs: align source vocabulary rule scope

### DIFF
--- a/.scratch/2026-04-25-hardening/review-stack/_draft.TRL-535-source-vocabulary-scope.md
+++ b/.scratch/2026-04-25-hardening/review-stack/_draft.TRL-535-source-vocabulary-scope.md
@@ -1,0 +1,40 @@
+# TRL-535 Source Vocabulary Rule Scope
+
+**Issue:** TRL-535
+**Target:** TRL-489
+**Branch:** `trl-535-align-trl-489-source-vocabulary-rule-scope`
+
+## Scope Decision
+
+Source-code vocabulary enforcement can become Warden work only when terms and diagnostics are precise enough to protect framework correctness.
+
+Markdown prose cleanup should remain editorial or advisory unless a separate docs-lint decision is made.
+
+## Candidate Warden Scope
+
+Good Warden candidates:
+
+- Source identifiers that expose rejected public concepts in package APIs.
+- Export names that conflict with the Trails lexicon.
+- Framework-owned type/function names that would teach agents the wrong primitive grammar.
+
+Required evidence:
+
+- Exact denied term.
+- Exact allowed replacement.
+- Source tier and file scope.
+- False-positive exceptions.
+- Fixture showing accepted and rejected source identifiers.
+
+## Non-Warden Scope
+
+Keep these out of durable Warden until separately justified:
+
+- General prose tone.
+- Historical references in ADRs.
+- User-facing docs where old wording is explicitly being explained.
+- Broad "find every word" sweeps without API or source-contract impact.
+
+## Decision
+
+Align TRL-489 around precise source-code vocabulary enforcement. Treat docs prose as editorial/advisory work, not a default durable Warden rule.


### PR DESCRIPTION
## Context

Follow-on branch for TRL-535 from the dogfood/prevention closeout handoff. This stack force-adds a reviewable draft scratch artifact under .scratch/2026-04-25-hardening/review-stack/ because Matt asked for the full Graphite stack even where the work is planning or tracker translation rather than runtime code.

## What changed

- Added .scratch/2026-04-25-hardening/review-stack/_draft.TRL-535-source-vocabulary-scope.md.
- Narrows source vocabulary enforcement to precise source-code diagnostics and keeps prose cleanup advisory.

## Validation

- bun run check passed on the top branch before v2 submission.
- git diff --check main...HEAD passed before v2 submission.
- bun run build passed on this branch during the bottom-up branch-local sweep.
- bun run test passed on this branch during the bottom-up branch-local sweep.

## Notes

This is a documentation/planning artifact branch. It does not change runtime code.