### PR TITLE
docs: evaluate prefer bun api mappings

### DIFF
--- a/.scratch/2026-04-25-hardening/review-stack/_draft.TRL-552-prefer-bun-api-evaluation.md
+++ b/.scratch/2026-04-25-hardening/review-stack/_draft.TRL-552-prefer-bun-api-evaluation.md
@@ -1,0 +1,37 @@
+# TRL-552 Prefer Bun API Evaluation
+
+**Issue:** TRL-552
+**Branch:** `trl-552-evaluate-expanded-prefer-bun-api-mappings-for-repo-local`
+
+## Rule Baseline
+
+`trails-local/prefer-bun-api` currently maps:
+
+- `better-sqlite3` -> `bun:sqlite`
+- `glob` -> `Bun.Glob`
+- `semver` -> `Bun.semver`
+- `uuid` -> `Bun.randomUUIDv7()`
+
+The rule ignores type-only imports and allows custom mapping overrides.
+
+## Evidence
+
+Command:
+
+```bash
+rg -n "from ['\"](better-sqlite3|glob|semver|uuid|node:crypto|fs-extra|rimraf)|import .* from ['\"](better-sqlite3|glob|semver|uuid|node:crypto|fs-extra|rimraf)" packages apps connectors scripts docs -g '!node_modules'
+```
+
+Result: no production imports were found for the currently mapped packages or the sampled expansion candidates.
+
+## Expansion Candidates
+
+Do not add blanket mappings yet for:
+
+- `node:crypto`: Bun alternatives depend on API shape and security semantics.
+- `fs-extra`: replacements vary by operation and should not be suggested as one mapping.
+- `rimraf`: may be replaceable by `rm(..., { recursive: true })`, but needs call-site context rather than import-source replacement.
+
+## Decision
+
+Keep the current mapping narrow. Expand only when a live import pattern appears and the replacement is safe enough for automated agent guidance.


### PR DESCRIPTION
## Context

Follow-on branch for TRL-552 from the dogfood/prevention closeout handoff. This stack force-adds a reviewable draft scratch artifact under .scratch/2026-04-25-hardening/review-stack/ because Matt asked for the full Graphite stack even where the work is planning or tracker translation rather than runtime code.

## What changed

- Added .scratch/2026-04-25-hardening/review-stack/_draft.TRL-552-prefer-bun-api-evaluation.md.
- Evaluates expanded prefer-bun-api mappings and records why no new mappings are currently justified.

## Validation

- bun run check passed on the top branch before v2 submission.
- git diff --check main...HEAD passed before v2 submission.
- bun run build passed on this branch during the bottom-up branch-local sweep.
- bun run test passed on this branch during the bottom-up branch-local sweep.

## Notes

This is a documentation/planning artifact branch. It does not change runtime code.