### PR TITLE
docs: evaluate max file lines enforcement

### DIFF
--- a/.scratch/2026-04-25-hardening/review-stack/_draft.TRL-550-max-file-lines-evaluation.md
+++ b/.scratch/2026-04-25-hardening/review-stack/_draft.TRL-550-max-file-lines-evaluation.md
@@ -1,0 +1,49 @@
+# TRL-550 Max File Lines Evaluation
+
+**Issue:** TRL-550
+**Branch:** `trl-550-evaluate-progressive-max-file-lines-enforcement-for-trails`
+
+## Question
+
+Should Trails add a repo-local `max-file-lines` rule now?
+
+## Evidence
+
+Command:
+
+```bash
+fd '\.(ts|tsx|md)$' packages apps connectors docs scripts | xargs wc -l | sort -nr | sed -n '1,40p'
+```
+
+Largest source files observed:
+
+- `packages/warden/src/rules/ast.ts`: 3054 lines
+- `packages/core/src/__tests__/execute.test.ts`: 2166 lines
+- `connectors/drizzle/src/runtime.ts`: 1345 lines
+- `packages/warden/src/rules/implementation-returns-result.ts`: 1320 lines
+- `packages/core/src/internal/topo-store.ts`: 1213 lines
+- `packages/warden/src/rules/no-sync-result-assumption.ts`: 1191 lines
+- `scripts/vocab-cutover-rewrite.ts`: 1146 lines
+- `packages/warden/src/__tests__/implementation-returns-result.test.ts`: 1143 lines
+- `packages/mcp/src/__tests__/build.test.ts`: 1139 lines
+- `packages/core/src/__tests__/fire.test.ts`: 1100 lines
+- `packages/core/src/execute.ts`: 1059 lines
+
+## Evaluation
+
+A hard threshold now would create a broad refactor queue. The largest files include rule implementations, runtime internals, and test suites where mechanical splitting should be planned carefully.
+
+## Recommendation
+
+Do not add a blocking max-file-lines rule in this closeout stack.
+
+If the repo wants progressive enforcement later:
+
+- Start as advisory/private repo-local hygiene, not Warden doctrine.
+- Use a high initial threshold above the current worst offender or a warn-only/report-only mode.
+- Exclude or separately plan tests and generated/migration scripts.
+- Add deletion triggers for each large-file exception.
+
+## Decision
+
+Treat file length as private hygiene/advisory pressure for now. Do not promote it to public Warden correctness.


### PR DESCRIPTION
## Context

Follow-on branch for TRL-550 from the dogfood/prevention closeout handoff. This stack force-adds a reviewable draft scratch artifact under .scratch/2026-04-25-hardening/review-stack/ because Matt asked for the full Graphite stack even where the work is planning or tracker translation rather than runtime code.

## What changed

- Added .scratch/2026-04-25-hardening/review-stack/_draft.TRL-550-max-file-lines-evaluation.md.
- Evaluates progressive max-file-lines enforcement and keeps it private/advisory rather than public Warden doctrine.

## Validation

- bun run check passed on the top branch before v2 submission.
- git diff --check main...HEAD passed before v2 submission.
- bun run build passed on this branch during the bottom-up branch-local sweep.
- bun run test passed on this branch during the bottom-up branch-local sweep.

## Notes

This is a documentation/planning artifact branch. It does not change runtime code.