### PR TITLE
feat: add read intent fires warden rule

### DIFF
--- a/packages/warden/src/__tests__/read-intent-fires.test.ts
+++ b/packages/warden/src/__tests__/read-intent-fires.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test';
+
+import { readIntentFires } from '../rules/read-intent-fires.js';
+
+const TEST_FILE = 'entity.ts';
+
+describe('read-intent-fires', () => {
+  test('warns when a read trail declares a signal-object fire', () => {
+    const code = `
+const entityLoaded = signal('entity.loaded', { payload: z.object({}) });
+
+trail('entity.read', {
+  intent: 'read',
+  fires: [entityLoaded],
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = readIntentFires.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('read-intent-fires');
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toContain('entity.read');
+    expect(diagnostics[0]?.message).toContain('entity.loaded');
+    expect(diagnostics[0]?.message).toContain('fires');
+    expect(diagnostics[0]?.message).toContain('ctx.fire');
+  });
+
+  test('reports multiple declared signal ids', () => {
+    const code = `
+const entityLoaded = signal('entity.loaded', { payload: z.object({}) });
+const auditLogged = signal('audit.logged', { payload: z.object({}) });
+
+trail('entity.read', {
+  intent: 'read',
+  fires: [entityLoaded, auditLogged],
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = readIntentFires.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('entity.loaded');
+    expect(diagnostics[0]?.message).toContain('audit.logged');
+  });
+
+  test('warns for identifier-based fires declarations', () => {
+    const code = `
+const entityLoaded = signal('entity.loaded', { payload: z.object({}) });
+const fires = [entityLoaded];
+
+trail('entity.read', {
+  intent: 'read',
+  fires,
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = readIntentFires.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.line).toBe(7);
+    expect(diagnostics[0]?.message).toContain('entity.loaded');
+  });
+
+  test('warns for string fires declarations', () => {
+    const code = `
+trail('entity.read', {
+  intent: 'read',
+  fires: ['entity.loaded'],
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = readIntentFires.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('entity.loaded');
+  });
+
+  test('warns for single-object trail form', () => {
+    const code = `
+const entityLoaded = signal('entity.loaded', { payload: z.object({}) });
+
+trail({
+  id: 'entity.read',
+  intent: 'read',
+  fires: [entityLoaded],
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = readIntentFires.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('entity.read');
+    expect(diagnostics[0]?.message).toContain('entity.loaded');
+  });
+
+  test('warns for namespaced core.trail definitions', () => {
+    const code = `
+import * as core from '@ontrails/core';
+
+const entityLoaded = core.signal('entity.loaded', { payload: z.object({}) });
+
+core.trail('entity.read', {
+  intent: 'read',
+  fires: [entityLoaded],
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    const diagnostics = readIntentFires.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('entity.loaded');
+  });
+
+  test('stays quiet for write, destroy, and unspecified intent trails', () => {
+    const code = `
+const entityLoaded = signal('entity.loaded', { payload: z.object({}) });
+
+trail('entity.write', {
+  intent: 'write',
+  fires: [entityLoaded],
+  blaze: async () => Result.ok({}),
+});
+
+trail('entity.delete', {
+  intent: 'destroy',
+  fires: [entityLoaded],
+  blaze: async () => Result.ok({}),
+});
+
+trail('entity.default', {
+  fires: [entityLoaded],
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    expect(readIntentFires.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('stays quiet for read trails without non-empty fires declarations', () => {
+    const code = `
+trail('entity.read', {
+  intent: 'read',
+  blaze: async () => Result.ok({}),
+});
+
+trail('entity.inspect', {
+  intent: 'read',
+  fires: [],
+  blaze: async () => Result.ok({}),
+});
+`;
+
+    expect(readIntentFires.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 37 rule trails', () => {
-    expect(wardenTopo.count).toBe(37);
+  test('contains all 38 rule trails', () => {
+    expect(wardenTopo.count).toBe(38);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -95,6 +95,7 @@ export {
   projectAwareRuleInput,
   publicInternalDeepImportsTrail,
   publicUnionOutputDiscriminantsTrail,
+  readIntentFiresTrail,
   referenceExistsTrail,
   ruleInput,
   ruleOutput,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -26,6 +26,7 @@ import { permitGovernance } from './permit-governance.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
 import { publicInternalDeepImports } from './public-internal-deep-imports.js';
 import { publicUnionOutputDiscriminants } from './public-union-output-discriminants.js';
+import { readIntentFires } from './read-intent-fires.js';
 import { referenceExists } from './reference-exists.js';
 import { resourceDeclarations } from './resource-declarations.js';
 import { resourceExists } from './resource-exists.js';
@@ -89,6 +90,7 @@ export { permitGovernance } from './permit-governance.js';
 export { preferSchemaInference } from './prefer-schema-inference.js';
 export { publicInternalDeepImports } from './public-internal-deep-imports.js';
 export { publicUnionOutputDiscriminants } from './public-union-output-discriminants.js';
+export { readIntentFires } from './read-intent-fires.js';
 export { referenceExists } from './reference-exists.js';
 export { resourceDeclarations } from './resource-declarations.js';
 export { resourceExists } from './resource-exists.js';
@@ -122,6 +124,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [ownerProjectionParity.name, ownerProjectionParity],
   [publicInternalDeepImports.name, publicInternalDeepImports],
   [resourceDeclarations.name, resourceDeclarations],
+  [readIntentFires.name, readIntentFires],
   [referenceExists.name, referenceExists],
   [resourceIdGrammar.name, resourceIdGrammar],
   [resourceExists.name, resourceExists],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -190,6 +190,11 @@ export const builtinWardenRuleMetadata = {
     invariant: 'Public output object unions expose branch discriminants.',
     tier: 'topo-aware',
   },
+  'read-intent-fires': {
+    ...durableExternal,
+    invariant: 'Read trails should not declare signal fires side effects.',
+    tier: 'source-static',
+  },
   'reference-exists': {
     ...durableExternal,
     invariant: 'Reference declarations resolve to known contours.',

--- a/packages/warden/src/rules/read-intent-fires.ts
+++ b/packages/warden/src/rules/read-intent-fires.ts
@@ -1,0 +1,187 @@
+import {
+  buildSignalIdentifierResolver,
+  deriveConstString,
+  extractStringLiteral,
+  findConfigProperty,
+  findTrailDefinitions,
+  getStringValue,
+  identifierName,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  walk,
+} from './ast.js';
+import type { AstNode, SignalIdentifierResolver } from './ast.js';
+import { isTestFile } from './scan.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+interface DeclaredFireSummary {
+  readonly count: number;
+  readonly ids: readonly string[];
+  readonly line: number;
+}
+
+const isReadIntent = (config: AstNode): boolean => {
+  const intentProp = findConfigProperty(config, 'intent');
+  const intentValue = intentProp?.value as AstNode | undefined;
+  return isStringLiteral(intentValue) && getStringValue(intentValue) === 'read';
+};
+
+const collectArrayBindings = (ast: AstNode): ReadonlyMap<string, AstNode> => {
+  const bindings = new Map<string, AstNode>();
+  walk(ast, (node) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+
+    const { id, init } = node as unknown as {
+      readonly id?: AstNode;
+      readonly init?: AstNode;
+    };
+    const name = identifierName(id);
+    if (name && init?.type === 'ArrayExpression') {
+      bindings.set(name, init);
+    }
+  });
+  return bindings;
+};
+
+const getFiresArray = (
+  config: AstNode,
+  arrayBindings: ReadonlyMap<string, AstNode>
+): AstNode | null => {
+  const firesProp = findConfigProperty(config, 'fires');
+  const value = firesProp?.value as AstNode | undefined;
+  if (value?.type === 'ArrayExpression') {
+    return value;
+  }
+
+  const name = identifierName(value);
+  return name ? (arrayBindings.get(name) ?? null) : null;
+};
+
+const getFiresElements = (
+  config: AstNode,
+  arrayBindings: ReadonlyMap<string, AstNode>
+): readonly AstNode[] => {
+  const array = getFiresArray(config, arrayBindings);
+  if (!array) {
+    return [];
+  }
+
+  return (
+    (array as unknown as { readonly elements?: readonly (AstNode | null)[] })
+      .elements ?? []
+  ).filter((element): element is AstNode => element !== null);
+};
+
+const resolveFireElementId = (
+  element: AstNode,
+  sourceCode: string,
+  signalIds: SignalIdentifierResolver
+): string | null => {
+  const literalValue = extractStringLiteral(element);
+  if (literalValue !== null) {
+    return literalValue;
+  }
+
+  if (element.type !== 'Identifier') {
+    return null;
+  }
+
+  const resolved = signalIds.resolve(element);
+  if (resolved.kind === 'signal' || resolved.kind === 'string') {
+    return resolved.id;
+  }
+
+  const name = identifierName(element);
+  return name ? deriveConstString(name, sourceCode) : null;
+};
+
+const summarizeDeclaredFires = (
+  config: AstNode,
+  arrayBindings: ReadonlyMap<string, AstNode>,
+  sourceCode: string,
+  signalIds: SignalIdentifierResolver
+): DeclaredFireSummary | null => {
+  const firesProp = findConfigProperty(config, 'fires');
+  const elements = getFiresElements(config, arrayBindings);
+  if (elements.length === 0) {
+    return null;
+  }
+
+  const ids: string[] = [];
+  for (const element of elements) {
+    const resolved = resolveFireElementId(element, sourceCode, signalIds);
+    if (resolved) {
+      ids.push(resolved);
+    }
+  }
+
+  const [firstElement] = elements;
+  const lineNode = firesProp ?? firstElement;
+  return {
+    count: elements.length,
+    ids,
+    line: lineNode ? offsetToLine(sourceCode, lineNode.start) : 1,
+  };
+};
+
+const formatSignalList = (summary: DeclaredFireSummary): string => {
+  const named = summary.ids.map((id) => `"${id}"`);
+  const unresolvedCount = summary.count - summary.ids.length;
+  const unresolved =
+    unresolvedCount > 0
+      ? [
+          unresolvedCount === 1
+            ? '1 unresolved signal reference'
+            : `${unresolvedCount} unresolved signal references`,
+        ]
+      : [];
+  return [...named, ...unresolved].join(', ');
+};
+
+const buildDiagnostic = (
+  trailId: string,
+  summary: DeclaredFireSummary,
+  filePath: string
+): WardenDiagnostic => ({
+  filePath,
+  line: summary.line,
+  message: `Trail "${trailId}" declares intent: 'read' but also declares fires: [${formatSignalList(summary)}]. Read trails should remain side-effect-free; change the trail intent or move ctx.fire behavior to an appropriate write trail.`,
+  rule: 'read-intent-fires',
+  severity: 'warn',
+});
+
+export const readIntentFires: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isTestFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const signalIds = buildSignalIdentifierResolver(ast);
+    const arrayBindings = collectArrayBindings(ast);
+    return findTrailDefinitions(ast).flatMap((def) => {
+      if (def.kind !== 'trail' || !isReadIntent(def.config)) {
+        return [];
+      }
+
+      const summary = summarizeDeclaredFires(
+        def.config,
+        arrayBindings,
+        sourceCode,
+        signalIds
+      );
+      return summary ? [buildDiagnostic(def.id, summary, filePath)] : [];
+    });
+  },
+  description:
+    'Warn when read-intent trails declare signal fires side effects.',
+  name: 'read-intent-fires',
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -34,6 +34,7 @@ import { permitGovernance } from './permit-governance.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
 import { publicInternalDeepImports } from './public-internal-deep-imports.js';
 import { publicUnionOutputDiscriminants } from './public-union-output-discriminants.js';
+import { readIntentFires } from './read-intent-fires.js';
 import { referenceExists } from './reference-exists.js';
 import { resourceDeclarations } from './resource-declarations.js';
 import { resourceExists } from './resource-exists.js';
@@ -78,6 +79,7 @@ export const registeredRuleNames: readonly string[] = [
   preferSchemaInference.name,
   publicInternalDeepImports.name,
   publicUnionOutputDiscriminants.name,
+  readIntentFires.name,
   referenceExists.name,
   resourceDeclarations.name,
   resourceExists.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -26,6 +26,7 @@ export { permitGovernanceTrail } from './permit-governance.trail.js';
 export { preferSchemaInferenceTrail } from './prefer-schema-inference.trail.js';
 export { publicInternalDeepImportsTrail } from './public-internal-deep-imports.trail.js';
 export { publicUnionOutputDiscriminantsTrail } from './public-union-output-discriminants.trail.js';
+export { readIntentFiresTrail } from './read-intent-fires.trail.js';
 export { referenceExistsTrail } from './reference-exists.trail.js';
 export { resourceDeclarationsTrail } from './resource-declarations.trail.js';
 export { resourceIdGrammarTrail } from './resource-id-grammar.trail.js';

--- a/packages/warden/src/trails/read-intent-fires.trail.ts
+++ b/packages/warden/src/trails/read-intent-fires.trail.ts
@@ -1,0 +1,20 @@
+import { readIntentFires } from '../rules/read-intent-fires.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const readIntentFiresTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        sourceCode: `const entityLoaded = signal('entity.loaded', { payload: z.object({}) });
+trail('entity.read', {
+  intent: 'read',
+  blaze: async () => Result.ok({}),
+});`,
+      },
+      name: 'Read trails without fires stay quiet',
+    },
+  ],
+  rule: readIntentFires,
+});


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->