### PR TITLE
feat: support activation where predicates

### DIFF
--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -74,6 +74,23 @@ const makeConsumer = (
     on: ['order.placed'],
   });
 
+const makeWhereConsumer = (
+  id: string,
+  capture: Capture,
+  where: (payload: {
+    orderId: string;
+    total: number;
+  }) => boolean | Promise<boolean>
+) =>
+  trail(id, {
+    blaze: (input) => {
+      capture.invocations.push({ payload: input, trailId: id });
+      return Result.ok({ received: input });
+    },
+    input: z.object({ orderId: z.string(), total: z.number() }),
+    on: [{ source: orderPlaced, where }],
+  });
+
 const makeProducer = (fireCapture: { fired?: boolean }) =>
   trail('order.create', {
     blaze: async (input, ctx) => {
@@ -770,6 +787,71 @@ describe('fire', () => {
       expect(result.isOk()).toBe(true);
       expect(scenario.state.consumerCompleted).toBe(true);
     });
+
+    test('object-form where predicates match or skip only their consumer trail', async () => {
+      const capture = createCapture();
+      const app = topo('fire-where-match-skip', {
+        matched: makeWhereConsumer(
+          'notify.large-order',
+          capture,
+          async (payload) => payload.total > 10
+        ),
+        orderPlaced,
+        plain: makeConsumer('notify.audit', capture),
+        producer: makeProducer({}),
+        skipped: makeWhereConsumer(
+          'notify.huge-order',
+          capture,
+          (payload) => payload.total > 100
+        ),
+      });
+
+      const result = await run(app, 'order.create', {
+        orderId: 'o-where',
+        total: 42,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(observedConsumerIds(capture)).toEqual([
+        'notify.audit',
+        'notify.large-order',
+      ]);
+    });
+
+    test('duplicate signal activation entries dispatch one consumer edge', async () => {
+      const capture = createCapture();
+      const consumer = trail('notify.dedupe', {
+        blaze: (input) => {
+          capture.invocations.push({
+            payload: input,
+            trailId: 'notify.dedupe',
+          });
+          return Result.ok({ received: input });
+        },
+        input: z.object({ orderId: z.string(), total: z.number() }),
+        on: [
+          'order.placed',
+          {
+            source: orderPlaced,
+            where: () => true,
+          },
+        ],
+      });
+      const app = topo('fire-dedupe-activation-edge', {
+        consumer,
+        orderPlaced,
+        producer: makeProducer({}),
+      });
+
+      const result = await run(app, 'order.create', {
+        orderId: 'o-dedupe',
+        total: 42,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(capture.invocations).toHaveLength(1);
+      expect(capture.invocations[0]?.trailId).toBe('notify.dedupe');
+    });
   });
 
   describe('validation', () => {
@@ -1348,6 +1430,47 @@ describe('fire', () => {
       });
     });
 
+    test('predicate failures record diagnostics and do not block siblings', async () => {
+      const capture = createCapture();
+      const diagnostics: SignalDiagnostic[] = [];
+      const app = topo('fire-where-failure', {
+        broken: makeWhereConsumer('notify.broken-predicate', capture, () => {
+          throw new Error('predicate exploded');
+        }),
+        healthy: makeConsumer('notify.audit', capture),
+        orderPlaced,
+        producer: makeProducer({}),
+      });
+
+      const result = await run(
+        app,
+        'order.create',
+        { orderId: 'o-where-failure', total: 42 },
+        {
+          ctx: {
+            extensions: {
+              [SIGNAL_DIAGNOSTICS_SINK_KEY]: (diagnostic: SignalDiagnostic) => {
+                diagnostics.push(diagnostic);
+              },
+            },
+          },
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(observedConsumerIds(capture)).toEqual(['notify.audit']);
+      expect(diagnostics).toContainEqual(
+        expect.objectContaining({
+          category: 'activation',
+          code: 'signal.handler.predicate_failed',
+          handlerTrailId: 'notify.broken-predicate',
+          origin: 'predicate',
+          producerTrailId: 'order.create',
+          signalId: 'order.placed',
+        })
+      );
+    });
+
     test('executor rejections record a signal.handler.rejected diagnostic', async () => {
       const diagnostics: SignalDiagnostic[] = [];
       const diagnosticRecorded = Promise.withResolvers<undefined>();
@@ -1779,6 +1902,61 @@ describe('fire', () => {
         expect(JSON.stringify(signalTraceRecords(records))).not.toContain(
           'o-trace'
         );
+      } finally {
+        clearTraceSink();
+      }
+    });
+
+    test('records predicate match, skip, and failure trace records', async () => {
+      const capture = createCapture();
+      const records: TraceRecord[] = [];
+      const app = topo('fire-where-trace', {
+        failed: makeWhereConsumer('notify.failed-predicate', capture, () => {
+          throw new Error('predicate failed');
+        }),
+        matched: makeWhereConsumer(
+          'notify.matched-predicate',
+          capture,
+          (payload) => payload.total > 10
+        ),
+        orderPlaced,
+        producer: makeProducer({}),
+        skipped: makeWhereConsumer(
+          'notify.skipped-predicate',
+          capture,
+          (payload) => payload.total > 100
+        ),
+      });
+      registerTraceSink(createCapturingSink(records));
+
+      try {
+        const result = await run(app, 'order.create', {
+          orderId: 'o-where-trace',
+          total: 42,
+        });
+
+        expect(result.isOk()).toBe(true);
+        expect(
+          findSignalTraceRecord(
+            records,
+            'signal.handler.predicate_matched',
+            'notify.matched-predicate'
+          ).status
+        ).toBe('ok');
+        expect(
+          findSignalTraceRecord(
+            records,
+            'signal.handler.predicate_skipped',
+            'notify.skipped-predicate'
+          ).status
+        ).toBe('ok');
+        const failed = findSignalTraceRecord(
+          records,
+          'signal.handler.predicate_failed',
+          'notify.failed-predicate'
+        );
+        expect(failed.status).toBe('err');
+        expect(failed.errorCategory).toBe('internal');
       } finally {
         clearTraceSink();
       }

--- a/packages/core/src/__tests__/signal-diagnostics.test.ts
+++ b/packages/core/src/__tests__/signal-diagnostics.test.ts
@@ -45,6 +45,7 @@ describe('signal diagnostics', () => {
     expect(Object.keys(signalDiagnosticDefinitions).toSorted()).toEqual([
       'signal.fire.suppressed',
       'signal.handler.failed',
+      'signal.handler.predicate_failed',
       'signal.handler.rejected',
       'signal.invalid',
       'signal.unknown',

--- a/packages/core/src/__tests__/topo-store.test.ts
+++ b/packages/core/src/__tests__/topo-store.test.ts
@@ -713,7 +713,12 @@ describe('topo store projection', () => {
       const indexTrail = trail('entity.index', {
         blaze: () => Result.ok({ ok: true }),
         input: z.object({}),
-        on: ['entity.created'],
+        on: [
+          {
+            source: created,
+            where: (payload) => payload.id.startsWith('idx_'),
+          },
+        ],
         output: z.object({ ok: z.boolean() }),
       });
       const auditTrail = trail('entity.audit', {
@@ -768,11 +773,16 @@ describe('topo store projection', () => {
       ) as {
         apps: Record<
           string,
-          { signals: Record<string, Record<string, unknown>> }
+          {
+            signals: Record<string, Record<string, unknown>>;
+            trails: Record<string, Record<string, unknown>>;
+          }
         >;
       };
       const createdLockEntry =
         lock.apps['signal-edges-app']?.signals['entity.created'];
+      const indexLockEntry =
+        lock.apps['signal-edges-app']?.trails['entity.index'];
       expect(createdLockEntry).toMatchObject({
         consumers: ['entity.audit', 'entity.index'],
         diagnostics: expect.objectContaining({
@@ -789,6 +799,12 @@ describe('topo store projection', () => {
         producers: ['entity.create'],
       });
       expect(createdLockEntry?.payload).toEqual(createdLockEntry?.input);
+      expect(indexLockEntry?.activationSources).toEqual([
+        {
+          source: { id: 'entity.created', kind: 'signal' },
+          where: { predicate: true },
+        },
+      ]);
     });
   });
 

--- a/packages/core/src/activation-source.ts
+++ b/packages/core/src/activation-source.ts
@@ -26,16 +26,19 @@ export interface ActivationWhereExample {
   readonly payload?: unknown;
 }
 
-export type ActivationWherePredicate = (
-  payload: unknown
+/* oxlint-disable no-explicit-any -- contextual predicate authoring needs source-specific payload inference; unknown would make inline predicates unusable until a helper API exists. */
+export type ActivationWherePredicate<TPayload = any> = (
+  payload: TPayload
 ) => boolean | Promise<boolean>;
 
-export interface ActivationWhere {
+export interface ActivationWhere<TPayload = any> {
   readonly examples?: readonly ActivationWhereExample[] | undefined;
-  readonly predicate: ActivationWherePredicate;
+  readonly predicate: ActivationWherePredicate<TPayload>;
 }
 
-export type ActivationWhereSpec = ActivationWhere | ActivationWherePredicate;
+export type ActivationWhereSpec<TPayload = any> =
+  | ActivationWhere<TPayload>
+  | ActivationWherePredicate<TPayload>;
 
 export type ActivationSourceRef = string | AnySignal | ActivationSource;
 
@@ -50,6 +53,11 @@ export interface ActivationEntry {
   readonly meta?: ActivationSourceMeta | undefined;
   readonly where?: ActivationWhereSpec | undefined;
 }
+
+export const getActivationWherePredicate = (
+  where: ActivationWhereSpec | undefined
+): ActivationWherePredicate | undefined =>
+  typeof where === 'function' ? where : where?.predicate;
 
 export const isKnownActivationSourceKind = (
   kind: string

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -28,6 +28,11 @@
 
 import type { z } from 'zod';
 
+import type {
+  ActivationEntry,
+  ActivationWhereSpec,
+} from './activation-source.js';
+import { getActivationWherePredicate } from './activation-source.js';
 import { NotFoundError, TrailsError, ValidationError } from './errors.js';
 import { forkCtx } from './internal/fork-ctx.js';
 import {
@@ -44,6 +49,7 @@ import {
   createSignalHandlerFailedDiagnostic,
   createSignalHandlerRejectedDiagnostic,
   createSignalInvalidDiagnostic,
+  createSignalPredicateFailedDiagnostic,
   createSignalUnknownDiagnostic,
   recordSignalDiagnostic,
   signalDiagnosticCauseFromUnknown,
@@ -69,6 +75,11 @@ export type ConsumerExecutor = (
 type MutableConsumerContext = {
   -readonly [K in keyof Partial<TrailContextInit>]: Partial<TrailContextInit>[K];
 };
+
+interface ConsumerActivation {
+  readonly trail: AnyTrail;
+  readonly where?: ActivationWhereSpec | undefined;
+}
 
 const FIRE_STACK_KEY = '__trails_fire_stack';
 const FIRE_PENDING_DISPATCHES_KEY = '__trails_fire_pending_dispatches';
@@ -314,6 +325,50 @@ const recordSignalLifecycleTrace = async (
   await writeSignalTraceRecord(producerCtx, name, attrs, status, errorCategory);
 };
 
+const activationEntriesForSignal = (
+  trail: AnyTrail,
+  signalId: string
+): readonly ConsumerActivation[] => {
+  const activations = new Map<string, ActivationEntry>();
+  for (const activation of trail.activationSources ?? []) {
+    if (
+      activation.source.kind !== 'signal' ||
+      activation.source.id !== signalId
+    ) {
+      continue;
+    }
+    const key = `${activation.source.kind}:${activation.source.id}`;
+    const previous = activations.get(key);
+    if (
+      previous === undefined ||
+      (previous.where === undefined && activation.where !== undefined)
+    ) {
+      activations.set(key, activation);
+    }
+  }
+  if (activations.size > 0) {
+    return [...activations.values()].map((activation) => ({
+      trail,
+      where: activation.where,
+    }));
+  }
+  return trail.on.includes(signalId) ? [{ trail }] : [];
+};
+
+const listConsumerActivations = (
+  topo: Topo,
+  signalId: string
+): readonly ConsumerActivation[] =>
+  topo.list().flatMap((trail) => activationEntriesForSignal(trail, signalId));
+
+const consumerTrailsFromActivations = (
+  activations: readonly ConsumerActivation[]
+): readonly AnyTrail[] => [
+  ...new Map(
+    activations.map((activation) => [activation.trail.id, activation.trail])
+  ).values(),
+];
+
 const hasActiveSignalTraceContext = (
   producerCtx: TrailContextInit | undefined
 ): boolean =>
@@ -338,6 +393,95 @@ const summarizeSignalPayloadForTrace = (
   }
 };
 
+const recordPredicateTrace = async (
+  producerCtx: TrailContextInit | undefined,
+  name:
+    | 'signal.handler.predicate_failed'
+    | 'signal.handler.predicate_matched'
+    | 'signal.handler.predicate_skipped',
+  input: {
+    readonly diagnosticMetadata: FireDiagnosticMetadata;
+    readonly errorCategory?: string | undefined;
+    readonly errorName?: string | undefined;
+    readonly handlerTrailId: string;
+    readonly payloadSummary?: SignalPayloadSummary | undefined;
+    readonly signalId: string;
+    readonly status?: Parameters<typeof recordSignalLifecycleTrace>[3];
+  }
+): Promise<void> => {
+  await recordSignalLifecycleTrace(
+    producerCtx,
+    name,
+    buildSignalTraceAttrs({
+      errorName: input.errorName,
+      handlerTrailId: input.handlerTrailId,
+      payload: input.payloadSummary,
+      producerTrailId: input.diagnosticMetadata.producerTrailId,
+      runId: input.diagnosticMetadata.runId,
+      signalId: input.signalId,
+    }),
+    input.status,
+    input.errorCategory
+  );
+};
+
+const shouldInvokeConsumer = async (
+  activation: ConsumerActivation,
+  payload: unknown,
+  payloadSummary: SignalPayloadSummary | undefined,
+  signalId: string,
+  producerCtx: TrailContextInit | undefined,
+  diagnosticMetadata: FireDiagnosticMetadata,
+  logger: Logger | undefined
+): Promise<boolean> => {
+  const predicate = getActivationWherePredicate(activation.where);
+  if (predicate === undefined) {
+    return true;
+  }
+
+  try {
+    const matched = await predicate(payload);
+    await recordPredicateTrace(
+      producerCtx,
+      matched
+        ? 'signal.handler.predicate_matched'
+        : 'signal.handler.predicate_skipped',
+      {
+        diagnosticMetadata,
+        handlerTrailId: activation.trail.id,
+        payloadSummary,
+        signalId,
+      }
+    );
+    return matched;
+  } catch (error) {
+    const cause = signalDiagnosticCauseFromUnknown(error);
+    const diagnostic = createSignalPredicateFailedDiagnostic({
+      ...diagnosticMetadata,
+      cause: error,
+      handlerTrailId: activation.trail.id,
+      payload,
+      signalId,
+    });
+    await recordRuntimeSignalDiagnostic(producerCtx, diagnostic);
+    await recordPredicateTrace(producerCtx, 'signal.handler.predicate_failed', {
+      diagnosticMetadata,
+      errorCategory: deriveSignalErrorCategory(error),
+      errorName: cause.name,
+      handlerTrailId: activation.trail.id,
+      payloadSummary,
+      signalId,
+      status: 'err',
+    });
+    logger?.warn('Signal activation predicate failed', {
+      consumerId: activation.trail.id,
+      error: cause.message,
+      signalId,
+    });
+    return false;
+  }
+};
+
 /**
  * Fan out a validated signal payload to its consumer trails.
  *
@@ -357,7 +501,7 @@ const summarizeSignalPayloadForTrace = (
  * part of the pre-v1 runtime contract.
  */
 const fanOutToConsumers = async (
-  consumers: readonly AnyTrail[],
+  activations: readonly ConsumerActivation[],
   payload: unknown,
   signalId: string,
   producerCtx: TrailContextInit | undefined,
@@ -368,7 +512,20 @@ const fanOutToConsumers = async (
 ): Promise<void> => {
   const payloadSummary = summarizeSignalPayloadForTrace(producerCtx, payload);
   const settled = await Promise.allSettled(
-    consumers.map(async (consumer) => {
+    activations.map(async (activation) => {
+      const consumer = activation.trail;
+      const shouldInvoke = await shouldInvokeConsumer(
+        activation,
+        payload,
+        payloadSummary,
+        signalId,
+        producerCtx,
+        diagnosticMetadata,
+        logger
+      );
+      if (!shouldInvoke) {
+        return consumer.id;
+      }
       const consumerCtx = bindFire(
         deriveConsumerCtx(producerCtx, signalId, consumer.id),
         consumer.id
@@ -466,7 +623,7 @@ const fanOutToConsumers = async (
     // unexpectedly. Log at debug to preserve provenance without propagating
     // the failure to the producer (fire-and-forget semantics).
     logger?.debug('Signal consumer rejected unexpectedly', {
-      consumerId: consumers[index]?.id,
+      consumerId: activations[index]?.trail.id,
       error:
         entry.reason instanceof Error
           ? entry.reason.message
@@ -549,7 +706,11 @@ const resolveFireDispatch = async (
   diagnosticMetadata: FireDiagnosticMetadata
 ): Promise<
   Result<
-    { readonly consumers: readonly AnyTrail[]; readonly payload: unknown },
+    {
+      readonly activations: readonly ConsumerActivation[];
+      readonly consumers: readonly AnyTrail[];
+      readonly payload: unknown;
+    },
     Error
   >
 > => {
@@ -595,8 +756,10 @@ const resolveFireDispatch = async (
       createInvalidPayloadError(signalId, parsed.message, diagnostic, promoted)
     );
   }
+  const activations = listConsumerActivations(topo, signalId);
   return Result.ok({
-    consumers: topo.list().filter((trail) => trail.on.includes(signalId)),
+    activations,
+    consumers: consumerTrailsFromActivations(activations),
     payload: parsed.data,
   });
 };
@@ -703,7 +866,7 @@ export const createFireFn = (
     const completion = (async (): Promise<void> => {
       try {
         await fanOutToConsumers(
-          dispatch.value.consumers,
+          dispatch.value.activations,
           dispatch.value.payload,
           signalId,
           trackedProducerCtx,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,6 +109,7 @@ export type {
 // Trail
 export {
   activationSourceKinds,
+  getActivationWherePredicate,
   isActivationEntrySpec,
   isActivationSource,
   isKnownActivationSourceKind,
@@ -187,6 +188,7 @@ export {
   createSignalHandlerFailedDiagnostic,
   createSignalHandlerRejectedDiagnostic,
   createSignalInvalidDiagnostic,
+  createSignalPredicateFailedDiagnostic,
   createSignalUnknownDiagnostic,
   recordSignalDiagnostic,
   shouldPromoteSignalDiagnostic,
@@ -215,6 +217,7 @@ export type {
   SignalHandlerFailedDiagnostic,
   SignalHandlerRejectedDiagnostic,
   SignalInvalidDiagnostic,
+  SignalPredicateFailedDiagnostic,
   SignalPayloadShape,
   SignalPayloadSummary,
   SignalUnknownDiagnostic,

--- a/packages/core/src/internal/topo-store.ts
+++ b/packages/core/src/internal/topo-store.ts
@@ -745,6 +745,20 @@ const addTrailRelations = (
   entry: Record<string, unknown>,
   trail: AnyTrail
 ): void => {
+  if (trail.activationSources.length > 0) {
+    entry['activationSources'] = trail.activationSources.map((activation) =>
+      sortKeys({
+        source: sortKeys({
+          id: activation.source.id,
+          kind: activation.source.kind,
+        }),
+        ...(activation.where === undefined
+          ? {}
+          : { where: sortKeys({ predicate: true }) }),
+      })
+    );
+  }
+
   if (trail.crosses.length > 0) {
     entry['crosses'] = trail.crosses.toSorted();
   }

--- a/packages/core/src/internal/tracing.ts
+++ b/packages/core/src/internal/tracing.ts
@@ -20,6 +20,9 @@ export type SignalTraceRecordName =
   | 'signal.handler.completed'
   | 'signal.handler.failed'
   | 'signal.handler.invoked'
+  | 'signal.handler.predicate_failed'
+  | 'signal.handler.predicate_matched'
+  | 'signal.handler.predicate_skipped'
   | 'signal.invalid';
 
 /** Evidence of a single trail execution, manual span, or signal lifecycle point. */

--- a/packages/core/src/signal-diagnostics.ts
+++ b/packages/core/src/signal-diagnostics.ts
@@ -29,6 +29,11 @@ export const signalDiagnosticDefinitions = {
     description: 'A signal consumer returned a failed Result.',
     level: 'error',
   },
+  'signal.handler.predicate_failed': {
+    category: 'activation',
+    description: 'A signal consumer activation predicate threw or rejected.',
+    level: 'error',
+  },
   'signal.handler.rejected': {
     category: 'handler',
     description: 'A signal consumer rejected outside Result normalization.',
@@ -58,7 +63,8 @@ export type SignalDiagnosticCategory =
 export type SignalDiagnosticOrigin =
   | 'fan-out-guard'
   | 'fire-boundary'
-  | 'handler';
+  | 'handler'
+  | 'predicate';
 
 export type SignalPayloadShape =
   | 'array'
@@ -146,6 +152,15 @@ export interface SignalHandlerRejectedDiagnostic extends SignalDiagnosticBase<
   readonly payload?: SignalPayloadSummary | undefined;
 }
 
+export interface SignalPredicateFailedDiagnostic extends SignalDiagnosticBase<
+  'signal.handler.predicate_failed',
+  'predicate'
+> {
+  readonly cause: SignalDiagnosticCause;
+  readonly handlerTrailId: string;
+  readonly payload?: SignalPayloadSummary | undefined;
+}
+
 export interface SignalFireSuppressedDiagnostic extends SignalDiagnosticBase<
   'signal.fire.suppressed',
   'fan-out-guard'
@@ -159,6 +174,7 @@ export type SignalDiagnostic =
   | SignalFireSuppressedDiagnostic
   | SignalHandlerFailedDiagnostic
   | SignalHandlerRejectedDiagnostic
+  | SignalPredicateFailedDiagnostic
   | SignalInvalidDiagnostic
   | SignalUnknownDiagnostic;
 
@@ -545,6 +561,33 @@ export const createSignalHandlerRejectedDiagnostic = (
       input.message ??
       `Signal handler "${input.handlerTrailId}" rejected for "${input.signalId}"`,
     origin: 'handler',
+    payload:
+      input.payload === undefined
+        ? undefined
+        : summarizeSignalPayload(input.payload),
+    producerTrailId: input.producerTrailId,
+    runId: input.runId,
+    signalId: input.signalId,
+    sourceLocation: input.sourceLocation,
+    traceId: input.traceId,
+  };
+};
+
+export const createSignalPredicateFailedDiagnostic = (
+  input: CreateSignalHandlerDiagnosticInput
+): SignalPredicateFailedDiagnostic => {
+  const definition =
+    signalDiagnosticDefinitions['signal.handler.predicate_failed'];
+  return {
+    category: definition.category,
+    cause: signalDiagnosticCauseFromUnknown(input.cause),
+    code: 'signal.handler.predicate_failed',
+    handlerTrailId: input.handlerTrailId,
+    level: definition.level,
+    message:
+      input.message ??
+      `Signal handler predicate for "${input.handlerTrailId}" failed for "${input.signalId}"`,
+    origin: 'predicate',
     payload:
       input.payload === undefined
         ? undefined


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outfitter-dev/codesmith/trails/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->