### PR TITLE
fix: preserve duplicate activation where predicates

### DIFF
--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -853,6 +853,44 @@ describe('fire', () => {
       expect(capture.invocations[0]?.trailId).toBe('notify.dedupe');
     });
 
+    test('duplicate guarded signal entries match when any predicate matches', async () => {
+      const capture = createCapture();
+      const consumer = trail('notify.guarded-dedupe', {
+        blaze: (input) => {
+          capture.invocations.push({
+            payload: input,
+            trailId: 'notify.guarded-dedupe',
+          });
+          return Result.ok({ received: input });
+        },
+        input: z.object({ orderId: z.string(), total: z.number() }),
+        on: [
+          {
+            source: orderPlaced,
+            where: (payload) => payload.total > 100,
+          },
+          {
+            source: orderPlaced,
+            where: (payload) => payload.total > 10,
+          },
+        ],
+      });
+      const app = topo('fire-guarded-dedupe-activation-edge', {
+        consumer,
+        orderPlaced,
+        producer: makeProducer({}),
+      });
+
+      const result = await run(app, 'order.create', {
+        orderId: 'o-guarded-dedupe',
+        total: 42,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(capture.invocations).toHaveLength(1);
+      expect(capture.invocations[0]?.trailId).toBe('notify.guarded-dedupe');
+    });
+
     test('consumer contexts carry signal activation provenance', async () => {
       const activations: ActivationProvenance[] = [];
       const consumer = trail('provenance.consumer', {

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -34,10 +34,7 @@ import {
   withActivationProvenance,
 } from './activation-provenance.js';
 import type { ActivationProvenance } from './activation-provenance.js';
-import type {
-  ActivationEntry,
-  ActivationWhereSpec,
-} from './activation-source.js';
+import type { ActivationWhereSpec } from './activation-source.js';
 import { getActivationWherePredicate } from './activation-source.js';
 import { activationSourceKey } from './activation-source-projection.js';
 import { NotFoundError, TrailsError, ValidationError } from './errors.js';
@@ -85,7 +82,7 @@ type MutableConsumerContext = {
 
 interface ConsumerActivation {
   readonly trail: AnyTrail;
-  readonly where?: ActivationWhereSpec | undefined;
+  readonly wheres: readonly ActivationWhereSpec[];
 }
 
 const FIRE_STACK_KEY = '__trails_fire_stack';
@@ -356,7 +353,7 @@ const activationEntriesForSignal = (
   trail: AnyTrail,
   signalId: string
 ): readonly ConsumerActivation[] => {
-  const activations = new Map<string, ActivationEntry>();
+  const activations = new Map<string, readonly ActivationWhereSpec[]>();
   for (const activation of trail.activationSources ?? []) {
     if (
       activation.source.kind !== 'signal' ||
@@ -365,21 +362,25 @@ const activationEntriesForSignal = (
       continue;
     }
     const key = activationSourceKey(activation.source);
-    const previous = activations.get(key);
-    if (
-      previous === undefined ||
-      (previous.where === undefined && activation.where !== undefined)
-    ) {
-      activations.set(key, activation);
+    if (activation.where === undefined) {
+      activations.set(key, []);
+      continue;
+    }
+
+    const wheres = activations.get(key);
+    if (wheres === undefined) {
+      activations.set(key, [activation.where]);
+    } else if (wheres.length > 0) {
+      activations.set(key, [...wheres, activation.where]);
     }
   }
   if (activations.size > 0) {
-    return [...activations.values()].map((activation) => ({
+    return [...activations.values()].map((wheres) => ({
       trail,
-      where: activation.where,
+      wheres,
     }));
   }
-  return trail.on.includes(signalId) ? [{ trail }] : [];
+  return trail.on.includes(signalId) ? [{ trail, wheres: [] }] : [];
 };
 
 const listConsumerActivations = (
@@ -462,52 +463,65 @@ const shouldInvokeConsumer = async (
   diagnosticMetadata: FireDiagnosticMetadata,
   logger: Logger | undefined
 ): Promise<boolean> => {
-  const predicate = getActivationWherePredicate(activation.where);
-  if (predicate === undefined) {
+  if (activation.wheres.length === 0) {
     return true;
   }
 
-  try {
-    const matched = await predicate(payload);
-    await recordPredicateTrace(
-      producerCtx,
-      matched
-        ? 'signal.handler.predicate_matched'
-        : 'signal.handler.predicate_skipped',
-      {
-        diagnosticMetadata,
-        handlerTrailId: activation.trail.id,
-        payloadSummary,
-        signalId,
+  for (const where of activation.wheres) {
+    const predicate = getActivationWherePredicate(where);
+    if (predicate === undefined) {
+      return true;
+    }
+
+    try {
+      const matched = await predicate(payload);
+      await recordPredicateTrace(
+        producerCtx,
+        matched
+          ? 'signal.handler.predicate_matched'
+          : 'signal.handler.predicate_skipped',
+        {
+          diagnosticMetadata,
+          handlerTrailId: activation.trail.id,
+          payloadSummary,
+          signalId,
+        }
+      );
+      if (matched) {
+        return true;
       }
-    );
-    return matched;
-  } catch (error) {
-    const cause = signalDiagnosticCauseFromUnknown(error);
-    const diagnostic = createSignalPredicateFailedDiagnostic({
-      ...diagnosticMetadata,
-      cause: error,
-      handlerTrailId: activation.trail.id,
-      payload,
-      signalId,
-    });
-    await recordRuntimeSignalDiagnostic(producerCtx, diagnostic);
-    await recordPredicateTrace(producerCtx, 'signal.handler.predicate_failed', {
-      diagnosticMetadata,
-      errorCategory: deriveSignalErrorCategory(error),
-      errorName: cause.name,
-      handlerTrailId: activation.trail.id,
-      payloadSummary,
-      signalId,
-      status: 'err',
-    });
-    logger?.warn('Signal activation predicate failed', {
-      consumerId: activation.trail.id,
-      error: cause.message,
-      signalId,
-    });
-    return false;
+    } catch (error) {
+      const cause = signalDiagnosticCauseFromUnknown(error);
+      const diagnostic = createSignalPredicateFailedDiagnostic({
+        ...diagnosticMetadata,
+        cause: error,
+        handlerTrailId: activation.trail.id,
+        payload,
+        signalId,
+      });
+      await recordRuntimeSignalDiagnostic(producerCtx, diagnostic);
+      await recordPredicateTrace(
+        producerCtx,
+        'signal.handler.predicate_failed',
+        {
+          diagnosticMetadata,
+          errorCategory: deriveSignalErrorCategory(error),
+          errorName: cause.name,
+          handlerTrailId: activation.trail.id,
+          payloadSummary,
+          signalId,
+          status: 'err',
+        }
+      );
+      logger?.warn('Signal activation predicate failed', {
+        consumerId: activation.trail.id,
+        error: cause.message,
+        signalId,
+      });
+    }
   }
+
+  return false;
 };
 
 /**


### PR DESCRIPTION
## Context

Follow-up for the Greptile P1 left on #335: duplicate object-form `on` entries for the same signal could drop the second `where` predicate because the fan-out map deduped by source key before evaluating predicates.

## What changed

- Aggregates duplicate guarded activation entries for the same signal/consumer and evaluates them with OR semantics.
- Keeps unguarded duplicates unconditional while still dispatching only one consumer edge.
- Adds regression coverage where the first predicate is false and the second predicate matches.

## Verification

- `bun test packages/core/src/__tests__/fire.test.ts`
- `bun run build`
- `bun run test`
- `bun run check`

## Notes

This is intentionally a narrow follow-up to close the stale P1 from the merged activation stack.