### PR TITLE
feat(warden): add signal graph coaching

### DIFF
--- a/packages/warden/src/__tests__/signal-graph-coaching.test.ts
+++ b/packages/warden/src/__tests__/signal-graph-coaching.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Result, resource, signal, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { runWarden } from '../cli.js';
+import { signalGraphCoaching } from '../rules/signal-graph-coaching.js';
+
+const invoiceCreated = signal('invoice.created', {
+  payload: z.object({ invoiceId: z.string() }),
+});
+
+const invoiceProducer = trail('invoice.create', {
+  blaze: () => Result.ok({ invoiceId: 'inv_1' }),
+  fires: [invoiceCreated],
+  input: z.object({}),
+  output: z.object({ invoiceId: z.string() }),
+});
+
+const invoiceConsumer = trail('invoice.index', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({ invoiceId: z.string() }),
+  on: [invoiceCreated],
+  output: z.object({ ok: z.boolean() }),
+});
+
+describe('signal-graph-coaching', () => {
+  test('stays quiet when a typed signal has producer and consumer trail edges', async () => {
+    const diagnostics = await signalGraphCoaching.checkTopo(
+      topo('signal-graph-clean', {
+        invoiceConsumer,
+        invoiceCreated,
+        invoiceProducer,
+      })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('warns for a declared signal with no producer or consumer edges', async () => {
+    const diagnostics = await signalGraphCoaching.checkTopo(
+      topo('signal-graph-dead', { invoiceCreated })
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        filePath: '<topo>',
+        line: 1,
+        message:
+          'Signal "invoice.created" is declared in the topo but has no producer trails, producer resources, or consumer trails. Add fires:/on: edges, attach producer metadata, or remove the unused signal contract.',
+        rule: 'signal-graph-coaching',
+        severity: 'warn',
+      },
+    ]);
+  });
+
+  test('warns for a produced signal with no consumers', async () => {
+    const diagnostics = await signalGraphCoaching.checkTopo(
+      topo('signal-graph-produced-no-consumer', {
+        invoiceCreated,
+        invoiceProducer,
+      })
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        filePath: '<topo>',
+        line: 1,
+        message:
+          'Signal "invoice.created" is produced by producer trail "invoice.create" but has no consumer trails. Add an on: consumer if the signal is meant to drive reactive work, or remove the unused fires:/producer declaration.',
+        rule: 'signal-graph-coaching',
+        severity: 'warn',
+      },
+    ]);
+  });
+
+  test('includes signal from: producer metadata when no trail fires declaration exists', async () => {
+    const metadataProduced = signal('invoice.metadata-produced', {
+      from: ['invoice.external-producer'],
+      payload: z.object({ invoiceId: z.string() }),
+    });
+
+    const diagnostics = await signalGraphCoaching.checkTopo(
+      topo('signal-graph-from-metadata', { metadataProduced })
+    );
+
+    expect(diagnostics[0]?.message).toContain(
+      'producer trail "invoice.external-producer"'
+    );
+  });
+
+  test('includes resource producer ids for resource-owned signals', async () => {
+    const stored = signal('store:invoice.created', {
+      payload: z.object({ invoiceId: z.string() }),
+    });
+    const store = resource('store', {
+      create: () => Result.ok({ ok: true }),
+      signals: [stored],
+    });
+
+    const diagnostics = await signalGraphCoaching.checkTopo(
+      topo('signal-graph-resource-produced', { store })
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        filePath: '<topo>',
+        line: 1,
+        message:
+          'Signal "store:invoice.created" is produced by producer resource "store" but has no consumer trails. Add an on: consumer if the signal is meant to drive reactive work, or remove the unused fires:/producer declaration.',
+        rule: 'signal-graph-coaching',
+        severity: 'warn',
+      },
+    ]);
+  });
+
+  test('leaves consumed-without-producer coaching to activation-orphan', async () => {
+    const diagnostics = await signalGraphCoaching.checkTopo(
+      topo('signal-graph-consumer-only', {
+        invoiceConsumer,
+        invoiceCreated,
+      })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('runWarden includes signal graph coaching when topo is supplied', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'warden-signal-graph-'));
+
+    try {
+      const report = await runWarden({
+        rootDir,
+        topo: topo('signal-graph-run-warden', {
+          invoiceCreated,
+          invoiceProducer,
+        }),
+      });
+
+      expect(report.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining('has no consumer trails'),
+            rule: 'signal-graph-coaching',
+            severity: 'warn',
+          }),
+        ])
+      );
+      expect(report.warnCount).toBeGreaterThan(0);
+    } finally {
+      rmSync(rootDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 41 rule trails', () => {
-    expect(wardenTopo.count).toBe(41);
+  test('contains all 42 rule trails', () => {
+    expect(wardenTopo.count).toBe(42);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -104,6 +104,7 @@ export {
   resourceIdGrammarTrail,
   resourceExistsTrail,
   scheduledDestroyIntentTrail,
+  signalGraphCoachingTrail,
   unmaterializedActivationSourceTrail,
   topoAwareRuleInput,
   unreachableDetourShadowingTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -33,6 +33,7 @@ import { resourceDeclarations } from './resource-declarations.js';
 import { resourceExists } from './resource-exists.js';
 import { resourceIdGrammar } from './resource-id-grammar.js';
 import { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
+import { signalGraphCoaching } from './signal-graph-coaching.js';
 import type { TopoAwareWardenRule, WardenRule } from './types.js';
 import { unmaterializedActivationSource } from './unmaterialized-activation-source.js';
 import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
@@ -100,6 +101,7 @@ export { resourceDeclarations } from './resource-declarations.js';
 export { resourceExists } from './resource-exists.js';
 export { resourceIdGrammar } from './resource-id-grammar.js';
 export { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
+export { signalGraphCoaching } from './signal-graph-coaching.js';
 export { unmaterializedActivationSource } from './unmaterialized-activation-source.js';
 export { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 export { validDetourContract } from './valid-detour-contract.js';
@@ -166,6 +168,7 @@ export const wardenTopoRules: ReadonlyMap<string, TopoAwareWardenRule> =
     [permitGovernance.name, permitGovernance],
     [publicUnionOutputDiscriminants.name, publicUnionOutputDiscriminants],
     [scheduledDestroyIntent.name, scheduledDestroyIntent],
+    [signalGraphCoaching.name, signalGraphCoaching],
     [unmaterializedActivationSource.name, unmaterializedActivationSource],
     [validDetourContract.name, validDetourContract],
   ]);

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -227,6 +227,12 @@ export const builtinWardenRuleMetadata = {
       'Schedule-activated destroy trails make unattended destructive work visible for review.',
     tier: 'topo-aware',
   },
+  'signal-graph-coaching': {
+    ...durableExternal,
+    invariant:
+      'Typed signal contracts either declare a producer or participate in reactive consumption.',
+    tier: 'topo-aware',
+  },
   'unmaterialized-activation-source': {
     ...durableExternal,
     invariant:

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -41,6 +41,7 @@ import { resourceDeclarations } from './resource-declarations.js';
 import { resourceExists } from './resource-exists.js';
 import { resourceIdGrammar } from './resource-id-grammar.js';
 import { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
+import { signalGraphCoaching } from './signal-graph-coaching.js';
 import { unmaterializedActivationSource } from './unmaterialized-activation-source.js';
 import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 import { validDetourContract } from './valid-detour-contract.js';
@@ -89,6 +90,7 @@ export const registeredRuleNames: readonly string[] = [
   resourceExists.name,
   resourceIdGrammar.name,
   scheduledDestroyIntent.name,
+  signalGraphCoaching.name,
   unmaterializedActivationSource.name,
   unreachableDetourShadowing.name,
   validDetourContract.name,

--- a/packages/warden/src/rules/signal-graph-coaching.ts
+++ b/packages/warden/src/rules/signal-graph-coaching.ts
@@ -1,0 +1,191 @@
+import type { Topo } from '@ontrails/core';
+
+import type { TopoAwareWardenRule, WardenDiagnostic } from './types.js';
+
+const RULE_NAME = 'signal-graph-coaching';
+const TOPO_FILE = '<topo>';
+
+interface SignalRelations {
+  readonly consumers: readonly string[];
+  readonly producerResources: readonly string[];
+  readonly producerTrails: readonly string[];
+}
+
+const sortedUnique = (values: Iterable<string>): readonly string[] =>
+  [...new Set(values)].toSorted();
+
+const collectSignalIds = (topo: Topo): readonly string[] =>
+  sortedUnique(topo.listSignals().map((signal) => signal.id));
+
+const collectProducerTrails = (
+  topo: Topo
+): ReadonlyMap<string, readonly string[]> => {
+  const producersBySignal = new Map<string, Set<string>>();
+
+  for (const signal of topo.listSignals()) {
+    if ((signal.from?.length ?? 0) === 0) {
+      continue;
+    }
+    const producers = producersBySignal.get(signal.id) ?? new Set<string>();
+    for (const producerTrailId of signal.from ?? []) {
+      producers.add(producerTrailId);
+    }
+    producersBySignal.set(signal.id, producers);
+  }
+
+  for (const trail of topo.list()) {
+    for (const signalId of trail.fires) {
+      const producers = producersBySignal.get(signalId) ?? new Set<string>();
+      producers.add(trail.id);
+      producersBySignal.set(signalId, producers);
+    }
+  }
+
+  return new Map(
+    [...producersBySignal.entries()].map(([signalId, producers]) => [
+      signalId,
+      sortedUnique(producers),
+    ])
+  );
+};
+
+const collectProducerResources = (
+  topo: Topo
+): ReadonlyMap<string, readonly string[]> => {
+  const resourcesBySignal = new Map<string, Set<string>>();
+
+  for (const resource of topo.listResources()) {
+    for (const signal of resource.signals ?? []) {
+      const resources = resourcesBySignal.get(signal.id) ?? new Set<string>();
+      resources.add(resource.id);
+      resourcesBySignal.set(signal.id, resources);
+    }
+  }
+
+  return new Map(
+    [...resourcesBySignal.entries()].map(([signalId, resources]) => [
+      signalId,
+      sortedUnique(resources),
+    ])
+  );
+};
+
+const collectConsumers = (
+  topo: Topo
+): ReadonlyMap<string, readonly string[]> => {
+  const consumersBySignal = new Map<string, Set<string>>();
+
+  for (const trail of topo.list()) {
+    for (const activation of trail.activationSources) {
+      if (activation.source.kind !== 'signal') {
+        continue;
+      }
+      const consumers =
+        consumersBySignal.get(activation.source.id) ?? new Set<string>();
+      consumers.add(trail.id);
+      consumersBySignal.set(activation.source.id, consumers);
+    }
+  }
+
+  return new Map(
+    [...consumersBySignal.entries()].map(([signalId, consumers]) => [
+      signalId,
+      sortedUnique(consumers),
+    ])
+  );
+};
+
+const collectRelations = (topo: Topo): ReadonlyMap<string, SignalRelations> => {
+  const producerTrails = collectProducerTrails(topo);
+  const producerResources = collectProducerResources(topo);
+  const consumers = collectConsumers(topo);
+
+  return new Map(
+    collectSignalIds(topo).map((signalId) => [
+      signalId,
+      {
+        consumers: consumers.get(signalId) ?? [],
+        producerResources: producerResources.get(signalId) ?? [],
+        producerTrails: producerTrails.get(signalId) ?? [],
+      },
+    ])
+  );
+};
+
+const quoteList = (values: readonly string[]): string =>
+  values.map((value) => `"${value}"`).join(', ');
+
+const formatProducerClause = ({
+  producerResources,
+  producerTrails,
+}: SignalRelations): string => {
+  const clauses: string[] = [];
+  if (producerTrails.length > 0) {
+    clauses.push(
+      `producer trail${producerTrails.length === 1 ? '' : 's'} ${quoteList(producerTrails)}`
+    );
+  }
+  if (producerResources.length > 0) {
+    clauses.push(
+      `producer resource${producerResources.length === 1 ? '' : 's'} ${quoteList(producerResources)}`
+    );
+  }
+  return clauses.join(' and ');
+};
+
+const buildDeadSignalDiagnostic = (signalId: string): WardenDiagnostic => ({
+  filePath: TOPO_FILE,
+  line: 1,
+  message: `Signal "${signalId}" is declared in the topo but has no producer trails, producer resources, or consumer trails. Add fires:/on: edges, attach producer metadata, or remove the unused signal contract.`,
+  rule: RULE_NAME,
+  severity: 'warn',
+});
+
+const buildProducedWithoutConsumerDiagnostic = (
+  signalId: string,
+  relations: SignalRelations
+): WardenDiagnostic => ({
+  filePath: TOPO_FILE,
+  line: 1,
+  message: `Signal "${signalId}" is produced by ${formatProducerClause(relations)} but has no consumer trails. Add an on: consumer if the signal is meant to drive reactive work, or remove the unused fires:/producer declaration.`,
+  rule: RULE_NAME,
+  severity: 'warn',
+});
+
+const hasProducer = ({
+  producerResources,
+  producerTrails,
+}: SignalRelations): boolean =>
+  producerResources.length > 0 || producerTrails.length > 0;
+
+const hasConsumer = ({ consumers }: SignalRelations): boolean =>
+  consumers.length > 0;
+
+const buildDiagnostics = (
+  relationsBySignal: ReadonlyMap<string, SignalRelations>
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const [signalId, relations] of relationsBySignal) {
+    if (!hasProducer(relations) && !hasConsumer(relations)) {
+      diagnostics.push(buildDeadSignalDiagnostic(signalId));
+      continue;
+    }
+
+    if (hasProducer(relations) && !hasConsumer(relations)) {
+      diagnostics.push(
+        buildProducedWithoutConsumerDiagnostic(signalId, relations)
+      );
+    }
+  }
+
+  return diagnostics;
+};
+
+export const signalGraphCoaching: TopoAwareWardenRule = {
+  checkTopo: (topo) => buildDiagnostics(collectRelations(topo)),
+  description:
+    'Warn when typed signal contracts are declared or produced without reactive consumers.',
+  name: RULE_NAME,
+  severity: 'warn',
+};

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -33,6 +33,7 @@ export { resourceDeclarationsTrail } from './resource-declarations.trail.js';
 export { resourceIdGrammarTrail } from './resource-id-grammar.trail.js';
 export { resourceExistsTrail } from './resource-exists.trail.js';
 export { scheduledDestroyIntentTrail } from './scheduled-destroy-intent.trail.js';
+export { signalGraphCoachingTrail } from './signal-graph-coaching.trail.js';
 export { unmaterializedActivationSourceTrail } from './unmaterialized-activation-source.trail.js';
 export { unreachableDetourShadowingTrail } from './unreachable-detour-shadowing.trail.js';
 export { validDetourContractTrail } from './valid-detour-contract.trail.js';

--- a/packages/warden/src/trails/signal-graph-coaching.trail.ts
+++ b/packages/warden/src/trails/signal-graph-coaching.trail.ts
@@ -1,0 +1,74 @@
+import { Result, resource, signal, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { signalGraphCoaching } from '../rules/signal-graph-coaching.js';
+import { wrapTopoRule } from './wrap-rule.js';
+
+const unusedSignal = signal('invoice.unused', {
+  payload: z.object({ invoiceId: z.string() }),
+});
+
+const producedSignal = signal('invoice.created', {
+  payload: z.object({ invoiceId: z.string() }),
+});
+
+const producerTrail = trail('invoice.create', {
+  blaze: () => Result.ok({ invoiceId: 'inv_1' }),
+  fires: [producedSignal],
+  input: z.object({}),
+  output: z.object({ invoiceId: z.string() }),
+});
+
+const resourceSignal = signal('store:invoice.created', {
+  payload: z.object({ invoiceId: z.string() }),
+});
+
+const invoiceStore = resource('store', {
+  create: () => Result.ok({ ok: true }),
+  signals: [resourceSignal],
+});
+
+export const signalGraphCoachingTrail = wrapTopoRule({
+  examples: [
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: '<topo>',
+            line: 1,
+            message:
+              'Signal "invoice.created" is produced by producer trail "invoice.create" but has no consumer trails. Add an on: consumer if the signal is meant to drive reactive work, or remove the unused fires:/producer declaration.',
+            rule: 'signal-graph-coaching',
+            severity: 'warn',
+          },
+          {
+            filePath: '<topo>',
+            line: 1,
+            message:
+              'Signal "invoice.unused" is declared in the topo but has no producer trails, producer resources, or consumer trails. Add fires:/on: edges, attach producer metadata, or remove the unused signal contract.',
+            rule: 'signal-graph-coaching',
+            severity: 'warn',
+          },
+          {
+            filePath: '<topo>',
+            line: 1,
+            message:
+              'Signal "store:invoice.created" is produced by producer resource "store" but has no consumer trails. Add an on: consumer if the signal is meant to drive reactive work, or remove the unused fires:/producer declaration.',
+            rule: 'signal-graph-coaching',
+            severity: 'warn',
+          },
+        ],
+      },
+      input: {
+        topo: topo('trl-447-signal-graph-coaching', {
+          invoiceStore,
+          producedSignal,
+          producerTrail,
+          unusedSignal,
+        }),
+      },
+      name: 'Declared and produced signals without consumers get coaching',
+    },
+  ],
+  rule: signalGraphCoaching,
+});


### PR DESCRIPTION
## Summary
Teach Warden to coach developers through signal-graph problems before they ship: orphan signals (declared but never received) and dead signals (received but never fired) now surface as advisory findings with concrete next-step suggestions.

## What changed
- New rule `signal-graph-coaching` in `packages/warden/src/rules/signal-graph-coaching.ts`, paired with a coaching trail at `packages/warden/src/trails/signal-graph-coaching.trail.ts`.
- Rule wired into Warden registry, metadata, and trails index.
- Coverage for the orphan and dead signal cases in `packages/warden/src/__tests__/signal-graph-coaching.test.ts`.

## Why it matters
The signal graph is one of the easiest places for drift to creep in — a fire site without a receiver, or a receiver wired to a signal that nobody fires. Catching that at lint time is cheaper than catching it at runtime, and the coaching framing keeps the finding actionable instead of just noisy.

## Linear
https://linear.app/outfitter/issue/TRL-447/warden-orphan-and-dead-signal-graph-coaching