### PR TITLE
feat(core): define webhook activation source

### DIFF
--- a/packages/core/src/__tests__/activation-source-projection.test.ts
+++ b/packages/core/src/__tests__/activation-source-projection.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import {
+  activationSourceDeclarationSignature,
+  projectActivationSourceDeclaration,
+} from '../activation-source-projection.js';
+
+describe('activation source projection', () => {
+  test('canonicalizes webhook paths in declaration signatures', () => {
+    const source = {
+      id: 'billing.payment-received',
+      kind: 'webhook' as const,
+      method: 'post' as const,
+      parse: z.object({ paymentId: z.string() }),
+      path: ' /webhooks/payment ',
+    };
+
+    expect(projectActivationSourceDeclaration(source)).toMatchObject({
+      method: 'POST',
+      path: '/webhooks/payment',
+    });
+    expect(activationSourceDeclarationSignature(source)).toContain(
+      '"path":"/webhooks/payment"'
+    );
+  });
+});

--- a/packages/core/src/__tests__/topo-store.test.ts
+++ b/packages/core/src/__tests__/topo-store.test.ts
@@ -14,6 +14,7 @@ import {
   signal,
   topo,
   trail,
+  webhook,
 } from '../index.js';
 import { __topoStoreMigrationStats, createTopoStore } from '../topo-store.js';
 import {
@@ -1013,17 +1014,17 @@ describe('topo store projection', () => {
 
   test('activation source projection records source payload and parse schemas', () => {
     withProjectionDb((db) => {
-      const webhookSource = {
-        id: 'webhook.user.upsert',
-        kind: 'webhook' as const,
+      const webhookSource = webhook('webhook.user.upsert', {
+        method: 'post',
         parse: {
           output: z.object({
             email: z.string().optional(),
             userId: z.string(),
           }),
         },
+        path: '/webhooks/users/upsert',
         payload: z.object({ userId: z.string() }),
-      };
+      });
       const receiver = trail('user.webhook.receive', {
         blaze: () => Result.ok({ ok: true }),
         input: z.object({ userId: z.string() }),
@@ -1055,12 +1056,14 @@ describe('topo store projection', () => {
         id: 'webhook.user.upsert',
         key: 'webhook:webhook.user.upsert',
         kind: 'webhook',
+        method: 'POST',
         parseOutputSchema: {
           properties: {
             userId: { type: 'string' },
           },
           type: 'object',
         },
+        path: '/webhooks/users/upsert',
         payloadSchema: {
           properties: {
             userId: { type: 'string' },

--- a/packages/core/src/__tests__/topo.test.ts
+++ b/packages/core/src/__tests__/topo.test.ts
@@ -14,6 +14,7 @@ import { schedule } from '../schedule.js';
 import { signal } from '../signal.js';
 import { trail } from '../trail.js';
 import { topo } from '../topo.js';
+import { webhook } from '../webhook.js';
 
 // ---------------------------------------------------------------------------
 // Mock factories
@@ -188,18 +189,14 @@ describe('topo', () => {
     });
 
     test('keeps schedule and webhook activation sources inert during topo construction', () => {
-      let routeRegistered = false;
       const scheduleSource = schedule('schedule.nightly-close', {
         cron: '0 2 * * *',
         input: { olderThanDays: 90 },
       });
-      const webhookSource = {
-        id: 'webhook.stripe.payment',
-        kind: 'webhook' as const,
-        route: () => {
-          routeRegistered = true;
-        },
-      };
+      const webhookSource = webhook('webhook.stripe.payment', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/stripe/payment',
+      });
 
       const app = topo('billing', {
         reconcile: trail('billing.reconcile', {
@@ -210,7 +207,6 @@ describe('topo', () => {
         }),
       });
 
-      expect(routeRegistered).toBe(false);
       expect(app.get('billing.reconcile')?.activationSources).toEqual([
         { source: scheduleSource },
         { source: webhookSource },

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -11,6 +11,7 @@ import { schedule } from '../schedule';
 import { signal } from '../signal';
 import { intentValues, trail } from '../trail';
 import type { TrailContext } from '../types';
+import { webhook } from '../webhook';
 
 const stubCtx: TrailContext = createTrailContext({
   abortSignal: AbortSignal.timeout(5000),
@@ -467,11 +468,11 @@ describe('trail() fires/on normalization', () => {
       input: { olderThanDays: 90 },
       timezone: 'UTC',
     });
-    const webhookSource = {
-      id: 'webhook.stripe.payment',
-      kind: 'webhook' as const,
+    const webhookSource = webhook('webhook.stripe.payment', {
       meta: { provider: 'stripe' },
-    };
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/stripe/payment',
+    });
 
     const t = trail('billing.reconcile', {
       blaze: () => Result.ok({}),
@@ -490,6 +491,7 @@ describe('trail() fires/on normalization', () => {
         source: webhookSource,
       },
     ]);
+    expect(Object.isFrozen(webhookSource.meta)).toBe(true);
   });
 
   test('mixed string + Signal value in fires: is normalized', () => {

--- a/packages/core/src/__tests__/validate-topo.test.ts
+++ b/packages/core/src/__tests__/validate-topo.test.ts
@@ -11,6 +11,7 @@ import { trail } from '../trail.js';
 import { topo } from '../topo.js';
 import type { TopoIssue } from '../validate-topo.js';
 import { validateTopo } from '../validate-topo.js';
+import { webhook } from '../webhook.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -545,6 +546,37 @@ describe('validateTopo', () => {
       expect(issue?.sourceId).toBe('schedule.report.shared');
       expect(issue?.sourceKind).toBe('schedule');
     });
+
+    test('equivalent webhook default methods share one source signature', () => {
+      const parse = z.object({ paymentId: z.string() });
+      const app = topo('app', {
+        explicit: trail('payment.explicit', {
+          blaze: noop,
+          input: parse,
+          on: [webhook('webhook.payment', { parse, path: '/webhooks/pay' })],
+        }),
+        manual: trail('payment.manual', {
+          blaze: noop,
+          input: parse,
+          on: [
+            {
+              id: 'webhook.payment',
+              kind: 'webhook',
+              parse,
+              path: '/webhooks/pay',
+            },
+          ],
+        }),
+      });
+
+      const result = validateTopo(app);
+
+      expect(
+        extractIssues(result).some(
+          (entry) => entry.rule === 'activation-source-definition-unique'
+        )
+      ).toBe(false);
+    });
   });
 
   describe('activation source input compatibility', () => {
@@ -770,7 +802,7 @@ describe('validateTopo', () => {
       );
     });
 
-    test('compatible webhook parse output and trail input pass', () => {
+    test('invalid webhook path and parse shape produce source diagnostics', () => {
       const app = topo('app', {
         receive: trail('payment.receive', {
           blaze: noop,
@@ -779,10 +811,41 @@ describe('validateTopo', () => {
             {
               id: 'webhook.stripe.payment',
               kind: 'webhook',
+              method: 'POST',
+              path: 'webhooks/stripe/payment',
+            },
+          ],
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isErr()).toBe(true);
+
+      const issues = extractIssues(result).filter(
+        (entry) => entry.rule === 'activation-webhook-valid'
+      );
+      expect(issues).toHaveLength(2);
+      expect(issues.map((issue) => issue.inputPath)).toEqual([
+        ['path'],
+        ['parse'],
+      ]);
+      expect(issues.every((issue) => issue.sourceKind === 'webhook')).toBe(
+        true
+      );
+    });
+
+    test('compatible webhook parse output and trail input pass', () => {
+      const app = topo('app', {
+        receive: trail('payment.receive', {
+          blaze: noop,
+          input: z.object({ paymentId: z.string() }),
+          on: [
+            webhook('webhook.stripe.payment', {
               parse: {
                 output: z.object({ paymentId: z.string() }),
               },
-            },
+              path: '/webhooks/stripe/payment',
+            }),
           ],
         }),
       });
@@ -797,17 +860,16 @@ describe('validateTopo', () => {
           blaze: noop,
           input: z.object({ issueId: z.string() }),
           on: [
-            {
-              id: 'webhook.github.issue',
-              kind: 'webhook',
+            webhook('webhook.github.issue', {
               parse: {
                 output: z.object({ issueId: z.string() }),
               },
+              path: '/webhooks/github/issue',
               payload: z.object({
                 action: z.string(),
                 issue: z.object({ number: z.number() }),
               }),
-            },
+            }),
           ],
         }),
       });
@@ -822,13 +884,12 @@ describe('validateTopo', () => {
           blaze: noop,
           input: z.object({ paymentId: z.string() }),
           on: [
-            {
-              id: 'webhook.stripe.payment',
-              kind: 'webhook',
+            webhook('webhook.stripe.payment', {
               parse: {
                 output: z.object({ paymentId: z.number() }),
               },
-            },
+              path: '/webhooks/stripe/payment',
+            }),
           ],
         }),
       });

--- a/packages/core/src/__tests__/webhook.test.ts
+++ b/packages/core/src/__tests__/webhook.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { ValidationError } from '../errors.js';
+import { validateWebhookSource, webhook } from '../webhook.js';
+
+describe('webhook()', () => {
+  test('creates an inert webhook activation source with POST as the default method', () => {
+    const source = webhook('billing.payment-received', {
+      meta: { owner: 'billing' },
+      parse: z.object({ paymentId: z.string() }),
+      path: ' /webhooks/payment ',
+    });
+
+    expect(source).toEqual({
+      id: 'billing.payment-received',
+      kind: 'webhook',
+      meta: { owner: 'billing' },
+      method: 'POST',
+      parse: expect.any(Object),
+      path: '/webhooks/payment',
+    });
+    expect(Object.isFrozen(source)).toBe(true);
+    expect(Object.isFrozen(source.meta)).toBe(true);
+  });
+
+  test('normalizes supported lowercase methods', () => {
+    const source = webhook({
+      id: 'github.issue',
+      method: 'put',
+      parse: z.object({ issueId: z.string() }),
+      path: '/webhooks/github/issue',
+    });
+
+    expect(source.method).toBe('PUT');
+  });
+
+  test('requires an absolute webhook path', () => {
+    expect(() =>
+      webhook('billing.payment-received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: 'webhooks/payment',
+      })
+    ).toThrow(ValidationError);
+  });
+
+  test('rejects unsupported webhook methods', () => {
+    expect(() =>
+      webhook('billing.payment-received', {
+        method: 'OPTIONS' as never,
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      })
+    ).toThrow(ValidationError);
+  });
+
+  test('requires parse for trail input materialization', () => {
+    expect(
+      validateWebhookSource({
+        id: 'billing.payment-received',
+        kind: 'webhook',
+        method: 'POST',
+        path: '/webhooks/payment',
+      })
+    ).toEqual([
+      {
+        field: 'parse',
+        message: 'Webhook sources must define parse',
+      },
+    ]);
+  });
+
+  test('requires parse in the webhook factory', () => {
+    expect(() =>
+      webhook('billing.payment-received', {
+        path: '/webhooks/payment',
+      } as never)
+    ).toThrow(ValidationError);
+  });
+
+  test('requires parse objects to expose an output schema', () => {
+    expect(
+      validateWebhookSource({
+        id: 'billing.payment-received',
+        kind: 'webhook',
+        method: 'POST',
+        parse: {},
+        path: '/webhooks/payment',
+      })
+    ).toEqual([
+      {
+        field: 'parse',
+        message: 'Webhook parse must be a Zod schema or define parse.output',
+      },
+    ]);
+  });
+});

--- a/packages/core/src/activation-source-projection.ts
+++ b/packages/core/src/activation-source-projection.ts
@@ -108,6 +108,11 @@ const parseOutputSchema = (
   return undefined;
 };
 
+const normalizeWebhookMethod = (method: string | undefined): string =>
+  (method ?? 'POST').trim().toUpperCase();
+
+const normalizeWebhookPath = (path: string): string => path.trim();
+
 export const projectActivationSourceDeclaration = (
   source: ActivationSource
 ): ActivationSourceProjection => {
@@ -130,12 +135,23 @@ export const projectActivationSourceDeclaration = (
   if (source.meta !== undefined) {
     record['meta'] = canonicalize(source.meta);
   }
+  if (source.kind === 'webhook') {
+    record['method'] = normalizeWebhookMethod(source.method);
+  } else if (source.method !== undefined) {
+    record['method'] = source.method;
+  }
   if (source.parse !== undefined) {
     record['hasParse'] = true;
     const output = parseOutputSchema(source);
     if (output !== undefined) {
       record['parseOutputSchema'] = toSortedJsonSchema(output);
     }
+  }
+  if (source.path !== undefined) {
+    record['path'] =
+      source.kind === 'webhook'
+        ? normalizeWebhookPath(source.path)
+        : source.path;
   }
   if (source.payload !== undefined) {
     record['hasPayloadSchema'] = true;

--- a/packages/core/src/activation-source.ts
+++ b/packages/core/src/activation-source.ts
@@ -27,7 +27,9 @@ export interface ActivationSource {
   readonly cron?: string | undefined;
   readonly input?: unknown;
   readonly meta?: ActivationSourceMeta | undefined;
+  readonly method?: string | undefined;
   readonly parse?: ActivationSourceParse | undefined;
+  readonly path?: string | undefined;
   readonly payload?: z.ZodType<unknown> | undefined;
   readonly timezone?: string | undefined;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -197,6 +197,14 @@ export type {
   ScheduleSpec,
   ScheduleValidationIssue,
 } from './schedule.js';
+export { validateWebhookSource, webhook, webhookMethods } from './webhook.js';
+export type {
+  WebhookMethod,
+  WebhookMethodInput,
+  WebhookSource,
+  WebhookSpec,
+  WebhookValidationIssue,
+} from './webhook.js';
 export { createScheduleRuntime } from './schedule-runtime.js';
 export type {
   ScheduleCronFactory,

--- a/packages/core/src/validate-topo.ts
+++ b/packages/core/src/validate-topo.ts
@@ -24,6 +24,7 @@ import { Result } from './result.js';
 import type { Topo } from './topo.js';
 import type { AnyTrail } from './trail.js';
 import { validateInput } from './validation.js';
+import { validateWebhookSource } from './webhook.js';
 
 // ---------------------------------------------------------------------------
 // Issue shape
@@ -313,6 +314,21 @@ const checkActivationSources = (
           inputPath: [issue.field],
           message: `Trail declares schedule source "${activation.source.id}" with invalid ${issue.field}: ${issue.message}`,
           rule: 'activation-schedule-valid',
+          schemaIssues: [
+            { code: issue.field, message: issue.message, path: [issue.field] },
+          ],
+          sourceId: activation.source.id,
+          sourceKind: activation.source.kind,
+          trailId: id,
+        });
+      }
+
+      const webhookIssues = validateWebhookSource(activation.source);
+      for (const issue of webhookIssues) {
+        issues.push({
+          inputPath: [issue.field],
+          message: `Trail declares webhook source "${activation.source.id}" with invalid ${issue.field}: ${issue.message}`,
+          rule: 'activation-webhook-valid',
           schemaIssues: [
             { code: issue.field, message: issue.message, path: [issue.field] },
           ],

--- a/packages/core/src/webhook.ts
+++ b/packages/core/src/webhook.ts
@@ -1,0 +1,192 @@
+import type {
+  ActivationSource,
+  ActivationSourceMeta,
+  ActivationSourceParse,
+} from './activation-source.js';
+import { ValidationError } from './errors.js';
+
+export const webhookMethods = Object.freeze([
+  'DELETE',
+  'GET',
+  'PATCH',
+  'POST',
+  'PUT',
+] as const);
+
+export type WebhookMethod = (typeof webhookMethods)[number];
+export type WebhookMethodInput = WebhookMethod | Lowercase<WebhookMethod>;
+
+export interface WebhookSpec<TOutput = unknown> {
+  readonly meta?: ActivationSourceMeta | undefined;
+  readonly method?: WebhookMethodInput | undefined;
+  readonly parse: ActivationSourceParse<TOutput>;
+  readonly path: string;
+  readonly payload?: ActivationSource['payload'] | undefined;
+}
+
+export interface WebhookSource<TOutput = unknown> extends ActivationSource {
+  readonly kind: 'webhook';
+  readonly meta?: ActivationSourceMeta | undefined;
+  readonly method: WebhookMethod;
+  readonly parse: ActivationSourceParse<TOutput>;
+  readonly path: string;
+  readonly payload?: ActivationSource['payload'] | undefined;
+}
+
+export interface WebhookValidationIssue {
+  readonly field: 'method' | 'parse' | 'path';
+  readonly message: string;
+}
+
+const DEFAULT_WEBHOOK_METHOD = 'POST' as const;
+
+const normalizeMethod = (
+  method: WebhookMethodInput | string | undefined
+): string => (method ?? DEFAULT_WEBHOOK_METHOD).trim().toUpperCase();
+
+const normalizePath = (path: string): string => path.trim();
+
+const isWebhookMethod = (method: string): method is WebhookMethod =>
+  (webhookMethods as readonly string[]).includes(method);
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isZodSchema = (value: unknown): boolean =>
+  isObjectRecord(value) && typeof value['safeParse'] === 'function';
+
+const validateMethod = (
+  method: WebhookMethodInput | string | undefined
+): WebhookValidationIssue[] => {
+  const normalized = normalizeMethod(method);
+  return isWebhookMethod(normalized)
+    ? []
+    : [
+        {
+          field: 'method',
+          message: `Webhook method must be one of ${webhookMethods.join(', ')}`,
+        },
+      ];
+};
+
+const validatePath = (path: unknown): WebhookValidationIssue[] => {
+  if (typeof path !== 'string' || path.trim().length === 0) {
+    return [
+      {
+        field: 'path',
+        message: 'Webhook path must be a non-empty absolute path',
+      },
+    ];
+  }
+
+  const normalized = normalizePath(path);
+  return normalized.startsWith('/')
+    ? []
+    : [
+        {
+          field: 'path',
+          message: 'Webhook path must start with "/"',
+        },
+      ];
+};
+
+const validateRequiredParse = (parse: unknown): WebhookValidationIssue[] =>
+  parse === undefined
+    ? [
+        {
+          field: 'parse',
+          message: 'Webhook sources must define parse',
+        },
+      ]
+    : [];
+
+const validateParseShape = (parse: unknown): WebhookValidationIssue[] => {
+  if (parse === undefined || isZodSchema(parse)) {
+    return [];
+  }
+  if (isObjectRecord(parse) && isZodSchema(parse['output'])) {
+    return [];
+  }
+  return [
+    {
+      field: 'parse',
+      message: 'Webhook parse must be a Zod schema or define parse.output',
+    },
+  ];
+};
+
+const webhookIssuesMessage = (
+  id: string,
+  issues: readonly WebhookValidationIssue[]
+): string =>
+  `webhook("${id}") is invalid: ${issues.map((issue) => `${issue.field}: ${issue.message}`).join('; ')}`;
+
+const assertWebhookSpec = <TOutput>(
+  id: string,
+  spec: WebhookSpec<TOutput>
+): {
+  readonly method: WebhookMethod;
+  readonly path: string;
+} => {
+  const issues = [
+    ...validateMethod(spec.method),
+    ...validatePath(spec.path),
+    ...validateRequiredParse(spec.parse),
+    ...validateParseShape(spec.parse),
+  ];
+
+  if (issues.length > 0) {
+    throw new ValidationError(webhookIssuesMessage(id, issues), {
+      context: { issues },
+    });
+  }
+
+  return {
+    method: normalizeMethod(spec.method) as WebhookMethod,
+    path: normalizePath(spec.path),
+  };
+};
+
+export const validateWebhookSource = (
+  source: ActivationSource
+): readonly WebhookValidationIssue[] => {
+  if (source.kind !== 'webhook') {
+    return [];
+  }
+
+  return [
+    ...validateMethod(source.method),
+    ...validatePath(source.path),
+    ...validateRequiredParse(source.parse),
+    ...validateParseShape(source.parse),
+  ];
+};
+
+export function webhook<TOutput>(
+  id: string,
+  spec: WebhookSpec<TOutput>
+): WebhookSource<TOutput>;
+export function webhook<TOutput>(
+  spec: WebhookSpec<TOutput> & { readonly id: string }
+): WebhookSource<TOutput>;
+export function webhook<TOutput>(
+  idOrSpec: string | (WebhookSpec<TOutput> & { readonly id: string }),
+  maybeSpec?: WebhookSpec<TOutput>
+): WebhookSource<TOutput> {
+  const id = typeof idOrSpec === 'string' ? idOrSpec : idOrSpec.id;
+  // oxlint-disable-next-line no-non-null-assertion -- overload guarantees maybeSpec when idOrSpec is string
+  const spec = typeof idOrSpec === 'string' ? maybeSpec! : idOrSpec;
+  const normalized = assertWebhookSpec(id, spec);
+
+  return Object.freeze({
+    id,
+    kind: 'webhook' as const,
+    method: normalized.method,
+    parse: spec.parse,
+    path: normalized.path,
+    ...(spec.meta === undefined
+      ? {}
+      : { meta: Object.freeze({ ...spec.meta }) }),
+    ...(spec.payload === undefined ? {} : { payload: spec.payload }),
+  });
+}


### PR DESCRIPTION
## Summary
Introduce a universal `webhook` activation source shape so any surface that can receive HTTP-style payloads (HTTP today, others later) describes its inbound webhook trails the same way. This is the foundation the rest of the webhook hardening stack builds on.

## What changed
- New `packages/core/src/webhook.ts` module — `webhookSource(...)` factory, header helpers, and the canonical `WebhookActivationSource` shape.
- `activation-source.ts` and `activation-source-projection.ts` extended to recognize and project webhook sources alongside existing kinds.
- `validate-topo.ts` enforces uniqueness on `id + method + path` so two trails cannot silently claim the same webhook endpoint.
- Tests cover the projection, the validator, and the public `webhook(...)` API surface.

## Stack
Bottom of the webhook hardening run; #348 layers verification onto this shape and #349 materializes it on the HTTP surface.

## Linear
https://linear.app/outfitter/issue/TRL-458/define-universal-webhook-source-shape