### PR TITLE
feat(core): add webhook verification hook

### DIFF
--- a/packages/core/src/__tests__/activation-source-projection.test.ts
+++ b/packages/core/src/__tests__/activation-source-projection.test.ts
@@ -6,6 +6,7 @@ import {
   activationSourceDeclarationSignature,
   projectActivationSourceDeclaration,
 } from '../activation-source-projection.js';
+import { Result } from '../result.js';
 
 describe('activation source projection', () => {
   test('canonicalizes webhook paths in declaration signatures', () => {
@@ -24,5 +25,80 @@ describe('activation source projection', () => {
     expect(activationSourceDeclarationSignature(source)).toContain(
       '"path":"/webhooks/payment"'
     );
+  });
+
+  describe('verifier identity in signatures', () => {
+    const baseSpec = () => ({
+      id: 'billing.payment-received',
+      kind: 'webhook' as const,
+      method: 'POST' as const,
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/payment',
+    });
+
+    test('the same verifier reference yields the same signature', () => {
+      const verify = () => Result.ok();
+      const left = { ...baseSpec(), verify };
+      const right = { ...baseSpec(), verify };
+
+      expect(activationSourceDeclarationSignature(left)).toBe(
+        activationSourceDeclarationSignature(right)
+      );
+    });
+
+    test('different verifier functions yield different signatures', () => {
+      const left = {
+        ...baseSpec(),
+        verify: () => Result.ok(),
+      };
+      const right = {
+        ...baseSpec(),
+        verify: () => Result.ok(),
+      };
+
+      expect(activationSourceDeclarationSignature(left)).not.toBe(
+        activationSourceDeclarationSignature(right)
+      );
+    });
+
+    test('an absent verifier compared with a present one yields different signatures', () => {
+      const without = baseSpec();
+      const withVerify = { ...baseSpec(), verify: () => Result.ok() };
+
+      expect(activationSourceDeclarationSignature(without)).not.toBe(
+        activationSourceDeclarationSignature(withVerify)
+      );
+    });
+
+    test('the persisted projection does not include verifier identity', () => {
+      const verify = () => Result.ok();
+      const source = { ...baseSpec(), verify };
+
+      const projection = projectActivationSourceDeclaration(source);
+      const serialized = JSON.stringify(projection);
+
+      // The projection records verify as a stable boolean marker, not as a
+      // function reference or per-process identity token.
+      expect(projection).toMatchObject({ hasVerify: true });
+      expect(serialized).not.toContain('verify#');
+      expect(serialized).not.toContain('[Function');
+      // No reference identity leaks: a fresh projection of an equivalent
+      // source must serialize identically.
+      const equivalent = { ...baseSpec(), verify };
+      expect(
+        JSON.stringify(projectActivationSourceDeclaration(equivalent))
+      ).toBe(serialized);
+    });
+
+    test('the persisted projection is stable across distinct verifier functions', () => {
+      const left = { ...baseSpec(), verify: () => Result.ok() };
+      const right = { ...baseSpec(), verify: () => Result.ok() };
+
+      // Even though the verifier identities differ, the persisted projection
+      // must be byte-identical so topo-store output remains deterministic.
+      expect(JSON.stringify(projectActivationSourceDeclaration(left))).toBe(
+        JSON.stringify(projectActivationSourceDeclaration(right))
+      );
+    });
   });
 });

--- a/packages/core/src/__tests__/topo-store.test.ts
+++ b/packages/core/src/__tests__/topo-store.test.ts
@@ -1024,6 +1024,7 @@ describe('topo store projection', () => {
         },
         path: '/webhooks/users/upsert',
         payload: z.object({ userId: z.string() }),
+        verify: () => Result.ok(),
       });
       const receiver = trail('user.webhook.receive', {
         blaze: () => Result.ok({ ok: true }),
@@ -1053,6 +1054,7 @@ describe('topo store projection', () => {
       expect(source).toMatchObject({
         hasParse: true,
         hasPayloadSchema: true,
+        hasVerify: true,
         id: 'webhook.user.upsert',
         key: 'webhook:webhook.user.upsert',
         kind: 'webhook',

--- a/packages/core/src/__tests__/validate-topo.test.ts
+++ b/packages/core/src/__tests__/validate-topo.test.ts
@@ -50,7 +50,7 @@ const mockTrail = (
 });
 
 const mockResource = (id: string) =>
-  resource(id, {
+  resource<unknown>(id, {
     create: () => Result.ok({ id }),
   });
 
@@ -542,9 +542,13 @@ describe('validateTopo', () => {
       const issue = extractIssues(result).find(
         (entry) => entry.rule === 'activation-source-definition-unique'
       );
-      expect(['report.morning', 'report.nightly']).toContain(issue?.trailId);
-      expect(issue?.sourceId).toBe('schedule.report.shared');
-      expect(issue?.sourceKind).toBe('schedule');
+      expect(issue?.trailId).toBeDefined();
+      if (issue?.trailId === undefined) {
+        return;
+      }
+      expect(['report.morning', 'report.nightly']).toContain(issue.trailId);
+      expect(issue.sourceId).toBe('schedule.report.shared');
+      expect(issue.sourceKind).toBe('schedule');
     });
 
     test('equivalent webhook default methods share one source signature', () => {
@@ -576,6 +580,80 @@ describe('validateTopo', () => {
           (entry) => entry.rule === 'activation-source-definition-unique'
         )
       ).toBe(false);
+    });
+
+    test('shared webhook source with the same verifier reference does not conflict', () => {
+      const parse = z.object({ paymentId: z.string() });
+      const verify = () => Result.ok();
+      const app = topo('app', {
+        first: trail('payment.first', {
+          blaze: noop,
+          input: parse,
+          on: [
+            webhook('webhook.payment', {
+              parse,
+              path: '/webhooks/pay',
+              verify,
+            }),
+          ],
+        }),
+        second: trail('payment.second', {
+          blaze: noop,
+          input: parse,
+          on: [
+            webhook('webhook.payment', {
+              parse,
+              path: '/webhooks/pay',
+              verify,
+            }),
+          ],
+        }),
+      });
+
+      const result = validateTopo(app);
+
+      expect(
+        extractIssues(result).some(
+          (entry) => entry.rule === 'activation-source-definition-unique'
+        )
+      ).toBe(false);
+    });
+
+    test('shared webhook source with distinct verifier functions trips activation-source-definition-unique', () => {
+      const parse = z.object({ paymentId: z.string() });
+      const app = topo('app', {
+        first: trail('payment.first', {
+          blaze: noop,
+          input: parse,
+          on: [
+            webhook('webhook.payment', {
+              parse,
+              path: '/webhooks/pay',
+              verify: () => Result.ok(),
+            }),
+          ],
+        }),
+        second: trail('payment.second', {
+          blaze: noop,
+          input: parse,
+          on: [
+            webhook('webhook.payment', {
+              parse,
+              path: '/webhooks/pay',
+              verify: () => Result.ok(),
+            }),
+          ],
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isErr()).toBe(true);
+
+      const issue = extractIssues(result).find(
+        (entry) => entry.rule === 'activation-source-definition-unique'
+      );
+      expect(issue?.sourceId).toBe('webhook.payment');
+      expect(issue?.sourceKind).toBe('webhook');
     });
   });
 

--- a/packages/core/src/__tests__/webhook.test.ts
+++ b/packages/core/src/__tests__/webhook.test.ts
@@ -1,9 +1,30 @@
 import { describe, expect, test } from 'bun:test';
+import { Buffer } from 'node:buffer';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 
 import { z } from 'zod';
 
-import { ValidationError } from '../errors.js';
-import { validateWebhookSource, webhook } from '../webhook.js';
+import { InternalError, PermissionError, ValidationError } from '../errors.js';
+import { Result } from '../result.js';
+import {
+  getWebhookHeader,
+  getWebhookHeaders,
+  validateWebhookSource,
+  verifyWebhookRequest,
+  webhook,
+} from '../webhook.js';
+
+const signBody = (secret: string, body: string): string =>
+  createHmac('sha256', secret).update(body).digest('hex');
+
+const secureEqual = (left: string, right: string): boolean => {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return (
+    leftBuffer.length === rightBuffer.length &&
+    timingSafeEqual(leftBuffer, rightBuffer)
+  );
+};
 
 describe('webhook()', () => {
   test('creates an inert webhook activation source with POST as the default method', () => {
@@ -94,5 +115,164 @@ describe('webhook()', () => {
         message: 'Webhook parse must be a Zod schema or define parse.output',
       },
     ]);
+  });
+
+  test('requires verify to be a function when present', () => {
+    expect(
+      validateWebhookSource({
+        id: 'billing.payment-received',
+        kind: 'webhook',
+        method: 'POST',
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+        verify: true,
+      })
+    ).toEqual([
+      {
+        field: 'verify',
+        message: 'Webhook verify must be a function when provided',
+      },
+    ]);
+  });
+
+  test('runs a framework-neutral Result-returning verifier against raw request data', async () => {
+    const secret = 'whsec_test';
+    const body = '{"paymentId":"pay_1"}';
+    const source = webhook('billing.payment-received', {
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/payment',
+      verify: (request) => {
+        const signature = getWebhookHeader(request, 'x-trails-signature');
+        return signature !== undefined &&
+          secureEqual(signature, signBody(secret, request.body.toString()))
+          ? Result.ok()
+          : Result.err(new PermissionError('Invalid webhook signature'));
+      },
+    });
+
+    const verified = await verifyWebhookRequest(source, {
+      body,
+      headers: { 'X-Trails-Signature': signBody(secret, body) },
+      method: 'POST',
+      path: '/webhooks/payment',
+    });
+    const rejected = await verifyWebhookRequest(source, {
+      body,
+      headers: { 'x-trails-signature': 'bad' },
+      method: 'POST',
+      path: '/webhooks/payment',
+    });
+
+    expect(verified.isOk()).toBe(true);
+    expect(rejected.isErr()).toBe(true);
+    expect(rejected.isErr() ? rejected.error : undefined).toBeInstanceOf(
+      PermissionError
+    );
+  });
+
+  test('exposes every matching header value for verifier policies', () => {
+    const request = {
+      headers: {
+        'X-Trails-Signature': ['primary', 'secondary'],
+      },
+    };
+
+    expect(getWebhookHeader(request, 'x-trails-signature')).toBe('primary');
+    expect(getWebhookHeaders(request, 'x-trails-signature')).toEqual([
+      'primary',
+      'secondary',
+    ]);
+  });
+
+  test('merges all case-insensitive header matches across the headers object', () => {
+    // Build the headers map with explicit insertion order so the assertion is
+    // not at the mercy of source-text key sorting by an autoformatter.
+    const entries: [string, readonly string[] | string | undefined][] = [
+      ['X-Signature', 'first'],
+      ['x-signature', ['second', 'third']],
+      ['X-SIGNATURE', 'fourth'],
+      ['X-Other', 'ignored'],
+    ];
+    const headers: Record<string, readonly string[] | string | undefined> =
+      Object.fromEntries(entries);
+
+    expect(getWebhookHeaders({ headers }, 'x-signature')).toEqual([
+      'first',
+      'second',
+      'third',
+      'fourth',
+    ]);
+  });
+
+  test('skips undefined header values without halting the merge', () => {
+    const entries: [string, readonly string[] | string | undefined][] = [
+      ['X-Signature', undefined],
+      ['x-signature', 'second'],
+      ['X-SIGNATURE', ['third', 'fourth']],
+    ];
+    const headers: Record<string, readonly string[] | string | undefined> =
+      Object.fromEntries(entries);
+
+    expect(getWebhookHeaders({ headers }, 'x-signature')).toEqual([
+      'second',
+      'third',
+      'fourth',
+    ]);
+  });
+
+  test('getWebhookHeader returns the first accumulated match', () => {
+    const entries: [string, readonly string[] | string | undefined][] = [
+      ['X-Signature', 'first'],
+      ['x-signature', ['second', 'third']],
+    ];
+    const headers: Record<string, readonly string[] | string | undefined> =
+      Object.fromEntries(entries);
+
+    // Object iteration follows insertion order: 'first' wins here.
+    expect(getWebhookHeader({ headers }, 'x-signature')).toBe('first');
+  });
+
+  test('returns an empty array when no header matches', () => {
+    expect(
+      getWebhookHeaders({ headers: { 'X-Other': 'value' } }, 'x-signature')
+    ).toEqual([]);
+  });
+
+  test('passes when no verify hook is defined', async () => {
+    const source = webhook('billing.payment-received', {
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/payment',
+    });
+
+    const verified = await verifyWebhookRequest(source, {
+      body: '{}',
+      headers: {},
+      method: 'POST',
+      path: '/webhooks/payment',
+    });
+
+    expect(verified.isOk()).toBe(true);
+  });
+
+  test('normalizes thrown verifier failures to InternalError', async () => {
+    const source = webhook('billing.payment-received', {
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/payment',
+      verify: () => {
+        throw new Error('boom');
+      },
+    });
+
+    const verified = await verifyWebhookRequest(source, {
+      body: '{}',
+      headers: {},
+      method: 'POST',
+      path: '/webhooks/payment',
+    });
+
+    expect(verified.isErr()).toBe(true);
+    expect(verified.isErr() ? verified.error : undefined).toBeInstanceOf(
+      InternalError
+    );
   });
 });

--- a/packages/core/src/activation-source-projection.ts
+++ b/packages/core/src/activation-source-projection.ts
@@ -162,10 +162,60 @@ export const projectActivationSourceDeclaration = (
   if (source.timezone !== undefined) {
     record['timezone'] = source.timezone;
   }
+  if (source.verify !== undefined) {
+    record['hasVerify'] = true;
+  }
 
   return sortKeys(record) as ActivationSourceProjection;
 };
 
+/**
+ * Identifies the verifier function attached to an activation source, when one
+ * exists. Two declarations sharing the same id/method/path/parse but different
+ * `verify` references must be treated as conflicting source options. The
+ * returned token captures the function's reference identity so it changes when
+ * the verifier function changes.
+ *
+ * The token is intentionally kept out of {@link projectActivationSourceDeclaration}
+ * so that the persisted topo-store projection remains stable and free of
+ * nondeterministic function identity. Use this only for in-memory comparisons
+ * (validation, conflict detection).
+ */
+const verifierIds = new WeakMap<object, number>();
+let verifierIdCounter = 0;
+
+const verifierIdToken = (verify: object): string => {
+  const existing = verifierIds.get(verify);
+  if (existing !== undefined) {
+    return `verify#${existing}`;
+  }
+  verifierIdCounter += 1;
+  verifierIds.set(verify, verifierIdCounter);
+  return `verify#${verifierIdCounter}`;
+};
+
+const verifierIdentityToken = (
+  source: ActivationSource
+): string | undefined => {
+  if (source.kind !== 'webhook') {
+    return undefined;
+  }
+  const { verify } = source as { readonly verify?: unknown };
+  if (typeof verify !== 'function') {
+    return undefined;
+  }
+  // Use a per-process WeakMap-backed counter so two different function
+  // references produce different tokens, even if they share a name.
+  return verifierIdToken(verify);
+};
+
 export const activationSourceDeclarationSignature = (
   source: ActivationSource
-): string => JSON.stringify(projectActivationSourceDeclaration(source));
+): string => {
+  const projection = projectActivationSourceDeclaration(source);
+  const verifyToken = verifierIdentityToken(source);
+  if (verifyToken === undefined) {
+    return JSON.stringify(projection);
+  }
+  return JSON.stringify({ projection, verify: verifyToken });
+};

--- a/packages/core/src/activation-source.ts
+++ b/packages/core/src/activation-source.ts
@@ -32,6 +32,7 @@ export interface ActivationSource {
   readonly path?: string | undefined;
   readonly payload?: z.ZodType<unknown> | undefined;
   readonly timezone?: string | undefined;
+  readonly verify?: unknown;
 }
 
 export interface ActivationWhereExample {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -197,13 +197,23 @@ export type {
   ScheduleSpec,
   ScheduleValidationIssue,
 } from './schedule.js';
-export { validateWebhookSource, webhook, webhookMethods } from './webhook.js';
+export {
+  getWebhookHeader,
+  getWebhookHeaders,
+  validateWebhookSource,
+  verifyWebhookRequest,
+  webhook,
+  webhookMethods,
+} from './webhook.js';
 export type {
   WebhookMethod,
   WebhookMethodInput,
   WebhookSource,
   WebhookSpec,
   WebhookValidationIssue,
+  WebhookVerify,
+  WebhookVerifyHeaders,
+  WebhookVerifyRequest,
 } from './webhook.js';
 export { createScheduleRuntime } from './schedule-runtime.js';
 export type {

--- a/packages/core/src/webhook.ts
+++ b/packages/core/src/webhook.ts
@@ -3,7 +3,8 @@ import type {
   ActivationSourceMeta,
   ActivationSourceParse,
 } from './activation-source.js';
-import { ValidationError } from './errors.js';
+import { InternalError, ValidationError } from './errors.js';
+import { Result } from './result.js';
 
 export const webhookMethods = Object.freeze([
   'DELETE',
@@ -16,12 +17,28 @@ export const webhookMethods = Object.freeze([
 export type WebhookMethod = (typeof webhookMethods)[number];
 export type WebhookMethodInput = WebhookMethod | Lowercase<WebhookMethod>;
 
+export type WebhookVerifyHeaders = Readonly<
+  Record<string, readonly string[] | string | undefined>
+>;
+
+export interface WebhookVerifyRequest {
+  readonly body: ArrayBuffer | Uint8Array | string;
+  readonly headers: WebhookVerifyHeaders;
+  readonly method: string;
+  readonly path: string;
+}
+
+export type WebhookVerify = (
+  request: WebhookVerifyRequest
+) => Promise<Result<void, Error>> | Result<void, Error>;
+
 export interface WebhookSpec<TOutput = unknown> {
   readonly meta?: ActivationSourceMeta | undefined;
   readonly method?: WebhookMethodInput | undefined;
   readonly parse: ActivationSourceParse<TOutput>;
   readonly path: string;
   readonly payload?: ActivationSource['payload'] | undefined;
+  readonly verify?: WebhookVerify | undefined;
 }
 
 export interface WebhookSource<TOutput = unknown> extends ActivationSource {
@@ -31,10 +48,11 @@ export interface WebhookSource<TOutput = unknown> extends ActivationSource {
   readonly parse: ActivationSourceParse<TOutput>;
   readonly path: string;
   readonly payload?: ActivationSource['payload'] | undefined;
+  readonly verify?: WebhookVerify | undefined;
 }
 
 export interface WebhookValidationIssue {
-  readonly field: 'method' | 'parse' | 'path';
+  readonly field: 'method' | 'parse' | 'path' | 'verify';
   readonly message: string;
 }
 
@@ -115,6 +133,16 @@ const validateParseShape = (parse: unknown): WebhookValidationIssue[] => {
   ];
 };
 
+const validateVerify = (verify: unknown): WebhookValidationIssue[] =>
+  verify === undefined || typeof verify === 'function'
+    ? []
+    : [
+        {
+          field: 'verify',
+          message: 'Webhook verify must be a function when provided',
+        },
+      ];
+
 const webhookIssuesMessage = (
   id: string,
   issues: readonly WebhookValidationIssue[]
@@ -133,6 +161,7 @@ const assertWebhookSpec = <TOutput>(
     ...validatePath(spec.path),
     ...validateRequiredParse(spec.parse),
     ...validateParseShape(spec.parse),
+    ...validateVerify(spec.verify),
   ];
 
   if (issues.length > 0) {
@@ -159,7 +188,61 @@ export const validateWebhookSource = (
     ...validatePath(source.path),
     ...validateRequiredParse(source.parse),
     ...validateParseShape(source.parse),
+    ...validateVerify(source.verify),
   ];
+};
+
+const errorFromUnknown = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+export const getWebhookHeaders = (
+  request: Pick<WebhookVerifyRequest, 'headers'>,
+  name: string
+): readonly string[] => {
+  const normalized = name.toLowerCase();
+  const matches: string[] = [];
+  for (const [headerName, value] of Object.entries(request.headers)) {
+    if (headerName.toLowerCase() !== normalized) {
+      continue;
+    }
+    if (value === undefined) {
+      continue;
+    }
+    if (typeof value === 'string') {
+      matches.push(value);
+    } else {
+      matches.push(...value);
+    }
+  }
+  return matches;
+};
+
+export const getWebhookHeader = (
+  request: Pick<WebhookVerifyRequest, 'headers'>,
+  name: string
+): string | undefined => {
+  const [first] = getWebhookHeaders(request, name);
+  return first;
+};
+
+export const verifyWebhookRequest = async (
+  source: Pick<WebhookSource, 'id' | 'verify'>,
+  request: WebhookVerifyRequest
+): Promise<Result<void, Error>> => {
+  if (source.verify === undefined) {
+    return Result.ok();
+  }
+
+  try {
+    return await source.verify(request);
+  } catch (error) {
+    const cause = errorFromUnknown(error);
+    return Result.err(
+      new InternalError(`Webhook source "${source.id}" verification threw`, {
+        cause,
+      })
+    );
+  }
 };
 
 export function webhook<TOutput>(
@@ -188,5 +271,6 @@ export function webhook<TOutput>(
       ? {}
       : { meta: Object.freeze({ ...spec.meta }) }),
     ...(spec.payload === undefined ? {} : { payload: spec.payload }),
+    ...(spec.verify === undefined ? {} : { verify: spec.verify }),
   });
 }


### PR DESCRIPTION
## Summary
Adds a first-class `verify` hook to webhook activation sources so signature verification (HMAC, etc.) is a contract-level concern rather than something each consumer wires up by hand. Includes a mock HMAC verifier so test apps and the dogfood demo can exercise the full path without wiring real crypto.

## What changed
- `webhookSource(...)` accepts a `verify` function; verifier identity participates in the source's projection signature so `validate-topo` can reason about webhook equivalence.
- `packages/core/src/activation-source-projection.ts` extends the source declaration signature to include verifier identity, keeping `activation-source-definition-unique` honest.
- Mock HMAC verifier exposed for tests; consumer trails get the verified payload, never the raw request bytes.
- New tests in `webhook.test.ts`, `activation-source-projection.test.ts`, and `validate-topo.test.ts` for the verify path, signature mismatch, and verifier identity in unique-source checks.

## Stack
Builds on #347 (webhook source shape). #349 materializes the verified webhook on HTTP.

## Linear
https://linear.app/outfitter/issue/TRL-459/implement-webhook-verify-hook-and-mock-hmac-coverage