### PR TITLE
feat(http): materialize webhook activation routes

### DIFF
--- a/connectors/hono/src/__tests__/surface.test.ts
+++ b/connectors/hono/src/__tests__/surface.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
-import { Result, trail, topo } from '@ontrails/core';
+import {
+  PermissionError,
+  Result,
+  getWebhookHeader,
+  trail,
+  topo,
+  webhook,
+} from '@ontrails/core';
 import { z } from 'zod';
 
 import { createApp, surface } from '../surface.js';
@@ -46,6 +53,35 @@ const genericErrorTrail = trail('generic.error', {
   blaze: () => Result.err(new Error('database password=secret')),
   input: z.object({}),
   intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+});
+
+const webhookSecret = 'secret';
+const paymentWebhook = webhook('webhook.payment.received', {
+  parse: z.object({ paymentId: z.string() }),
+  path: '/webhooks/payment',
+  verify: (request) =>
+    getWebhookHeader(request, 'x-webhook-secret') === webhookSecret
+      ? Result.ok()
+      : Result.err(new PermissionError('Invalid webhook secret')),
+});
+
+const paymentWebhookTrail = trail('payment.receive', {
+  blaze: (input) => Result.ok({ paymentId: input.paymentId }),
+  input: z.object({ paymentId: z.string() }),
+  on: [paymentWebhook],
+  output: z.object({ paymentId: z.string() }),
+});
+
+const emptyWebhook = webhook('webhook.empty', {
+  parse: z.object({}),
+  path: '/webhooks/empty',
+});
+
+const emptyWebhookTrail = trail('webhook.empty.receive', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  on: [emptyWebhook],
   output: z.object({ ok: z.boolean() }),
 });
 
@@ -205,6 +241,85 @@ describe('surface API (Hono connector)', () => {
         code: 'ValidationError',
         message: 'JSON request body exceeds 20 bytes',
       },
+    });
+  });
+
+  test('materializes webhook sources as Hono routes', async () => {
+    const graph = topo('surface-api', { paymentWebhookTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/webhooks/payment', {
+      body: JSON.stringify({ paymentId: 'pay_1' }),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Webhook-Secret': webhookSecret,
+      },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: { paymentId: 'pay_1' },
+    });
+  });
+
+  test('webhook verification failures map through surface errors', async () => {
+    const graph = topo('surface-api', { paymentWebhookTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/webhooks/payment', {
+      body: JSON.stringify({ paymentId: 'pay_1' }),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Webhook-Secret': 'wrong',
+      },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'permission',
+        code: 'PermissionError',
+        message: 'Invalid webhook secret',
+      },
+    });
+  });
+
+  test('webhook payload validation failures return 400', async () => {
+    const graph = topo('surface-api', { paymentWebhookTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/webhooks/payment', {
+      body: JSON.stringify({ paymentId: 123 }),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Webhook-Secret': webhookSecret,
+      },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: {
+        category: 'validation',
+        code: 'ValidationError',
+      },
+    });
+  });
+
+  test('empty webhook bodies parse as empty objects', async () => {
+    const graph = topo('surface-api', { emptyWebhookTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/webhooks/empty', {
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: { ok: true },
     });
   });
 

--- a/connectors/hono/src/surface.ts
+++ b/connectors/hono/src/surface.ts
@@ -263,6 +263,38 @@ const readJsonBody = async (
   }
 };
 
+const parseJsonBodyText = (text: string): JsonBodyReadResult => {
+  try {
+    return JSON.parse(text) as JsonValue;
+  } catch {
+    return JSON_PARSE_ERROR;
+  }
+};
+
+const parseWebhookBodyText = (
+  c: HonoContext,
+  text: string
+): JsonBodyReadResult =>
+  isEmptyBody(c) || text.length === 0 ? {} : parseJsonBodyText(text);
+
+const readWebhookBodyText = async (
+  c: HonoContext,
+  maxJsonBodyBytes: number
+): Promise<
+  string | typeof JSON_BODY_INVALID_CONTENT_LENGTH | typeof JSON_BODY_TOO_LARGE
+> => {
+  if (
+    parseContentLength(c.req.header('Content-Length')) ===
+    JSON_BODY_INVALID_CONTENT_LENGTH
+  ) {
+    return JSON_BODY_INVALID_CONTENT_LENGTH;
+  }
+  if (hasOversizedContentLength(c, maxJsonBodyBytes)) {
+    return JSON_BODY_TOO_LARGE;
+  }
+  return await readBodyText(c, maxJsonBodyBytes);
+};
+
 /** Read input from request based on input source. */
 const readInput = async (
   c: HonoContext,
@@ -362,49 +394,158 @@ const handleCaughtError = (error: unknown, c: HonoContext): Response => {
   return c.json(body, status);
 };
 
+const invalidJsonResponse = (c: HonoContext): Response =>
+  c.json(
+    {
+      error: {
+        category: 'validation',
+        code: 'ValidationError',
+        message: 'Invalid JSON in request body',
+      },
+    },
+    400
+  );
+
+const invalidContentLengthResponse = (c: HonoContext): Response =>
+  c.json(
+    {
+      error: {
+        category: 'validation',
+        code: 'ValidationError',
+        message: 'Invalid Content-Length header',
+      },
+    },
+    400
+  );
+
+const oversizedJsonBodyResponse = (
+  c: HonoContext,
+  options: RuntimeOptions
+): Response =>
+  c.json(
+    {
+      error: {
+        category: 'validation',
+        code: 'ValidationError',
+        message: `JSON request body exceeds ${options.maxJsonBodyBytes} bytes`,
+      },
+    },
+    413
+  );
+
+const collectHeaders = (c: HonoContext): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of c.req.raw.headers) {
+    headers[key] = value;
+  }
+  return headers;
+};
+
+const createWebhookVerifyRequest = (
+  c: HonoContext,
+  body: string
+): {
+  readonly body: string;
+  readonly headers: Record<string, string>;
+  readonly method: string;
+  readonly path: string;
+} => ({
+  body,
+  headers: collectHeaders(c),
+  method: c.req.method,
+  path: new URL(c.req.url).pathname,
+});
+
+const recordInvalidWebhook = async (
+  route: HttpRouteDefinition,
+  errorCategory = 'validation'
+): Promise<void> => {
+  await route.recordWebhookInvalid?.(errorCategory);
+};
+
+const errorCategoryForWebhookFailure = (error: Error | undefined): string =>
+  error !== undefined && isTrailsError(error) ? error.category : 'internal';
+
+const handleWebhookRoute = async (
+  route: HttpRouteDefinition,
+  options: RuntimeOptions,
+  c: HonoContext
+): Promise<Response> => {
+  const rawBody = await readWebhookBodyText(c, options.maxJsonBodyBytes);
+
+  if (rawBody === JSON_BODY_INVALID_CONTENT_LENGTH) {
+    await recordInvalidWebhook(route);
+    return invalidContentLengthResponse(c);
+  }
+
+  if (rawBody === JSON_BODY_TOO_LARGE) {
+    await recordInvalidWebhook(route);
+    return oversizedJsonBodyResponse(c, options);
+  }
+
+  const verified = await route.verifyWebhook?.(
+    createWebhookVerifyRequest(c, rawBody)
+  );
+  if (verified?.isErr()) {
+    await recordInvalidWebhook(
+      route,
+      errorCategoryForWebhookFailure(verified.error)
+    );
+    return mapResultToResponse(verified, c);
+  }
+
+  const jsonBody = parseWebhookBodyText(c, rawBody);
+  if (jsonBody === JSON_PARSE_ERROR) {
+    await recordInvalidWebhook(route);
+    return invalidJsonResponse(c);
+  }
+
+  const parsed = route.parseWebhookInput?.(jsonBody);
+  if (parsed === undefined) {
+    await recordInvalidWebhook(route);
+    return mapResultToResponse(
+      {
+        error: new ValidationError('Webhook route is missing parse handler'),
+        isOk: () => false,
+      },
+      c
+    );
+  }
+  if (parsed.isErr()) {
+    await recordInvalidWebhook(route);
+    return mapResultToResponse(parsed, c);
+  }
+
+  const requestId = c.req.header('X-Request-ID') ?? undefined;
+  const { signal: abortSignal } = c.req.raw;
+  const result = await route.execute(parsed.value, requestId, abortSignal);
+  return mapResultToResponse(result, c);
+};
+
 /** Create a Hono handler from a route definition. */
 const createHonoHandler =
   (route: HttpRouteDefinition, options: RuntimeOptions) =>
   async (c: HonoContext): Promise<Response> => {
+    if (route.inputSource === 'webhook') {
+      try {
+        return await handleWebhookRoute(route, options, c);
+      } catch (error: unknown) {
+        return handleCaughtError(error, c);
+      }
+    }
+
     const rawInput = await readInput(c, route.inputSource, options);
 
     if (rawInput === JSON_PARSE_ERROR) {
-      return c.json(
-        {
-          error: {
-            category: 'validation',
-            code: 'ValidationError',
-            message: 'Invalid JSON in request body',
-          },
-        },
-        400
-      );
+      return invalidJsonResponse(c);
     }
 
     if (rawInput === JSON_BODY_INVALID_CONTENT_LENGTH) {
-      return c.json(
-        {
-          error: {
-            category: 'validation',
-            code: 'ValidationError',
-            message: 'Invalid Content-Length header',
-          },
-        },
-        400
-      );
+      return invalidContentLengthResponse(c);
     }
 
     if (rawInput === JSON_BODY_TOO_LARGE) {
-      return c.json(
-        {
-          error: {
-            category: 'validation',
-            code: 'ValidationError',
-            message: `JSON request body exceeds ${options.maxJsonBodyBytes} bytes`,
-          },
-        },
-        413
-      );
+      return oversizedJsonBodyResponse(c, options);
     }
 
     const requestId = c.req.header('X-Request-ID') ?? undefined;
@@ -433,8 +574,14 @@ const routeRegistrars: Record<
   GET: (hono, path, handler) => {
     hono.get(path, handler);
   },
+  PATCH: (hono, path, handler) => {
+    hono.patch(path, handler);
+  },
   POST: (hono, path, handler) => {
     hono.post(path, handler);
+  },
+  PUT: (hono, path, handler) => {
+    hono.put(path, handler);
   },
 };
 

--- a/packages/core/src/__tests__/surface-filter.test.ts
+++ b/packages/core/src/__tests__/surface-filter.test.ts
@@ -6,6 +6,7 @@ import { Result } from '../result.js';
 import { filterSurfaceTrails, matchesTrailPattern } from '../surface-filter.js';
 import { signal } from '../signal.js';
 import { trail } from '../trail.js';
+import { webhook } from '../webhook.js';
 
 const orderPlaced = signal('order.placed', {
   payload: z.object({ orderId: z.string() }),
@@ -49,6 +50,17 @@ const consumerTrail = trail('notify.email', {
   blaze: () => Result.ok({ ok: true }),
   input: z.object({}),
   on: [orderPlaced],
+});
+
+const webhookConsumerTrail = trail('payment.receive', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({ paymentId: z.string() }),
+  on: [
+    webhook('webhook.payment.received', {
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/payment',
+    }),
+  ],
 });
 
 describe('matchesTrailPattern', () => {
@@ -189,6 +201,14 @@ describe('filterSurfaceTrails', () => {
       expect(
         filterSurfaceTrails([consumerTrail], {
           include: ['notify.email'],
+        })
+      ).toEqual([]);
+    });
+
+    test('webhook-activated trails are not exposed as direct trailhead routes', () => {
+      expect(
+        filterSurfaceTrails([webhookConsumerTrail], {
+          include: ['payment.receive'],
         })
       ).toEqual([]);
     });

--- a/packages/core/src/surface-filter.ts
+++ b/packages/core/src/surface-filter.ts
@@ -151,7 +151,7 @@ export const shouldIncludeTrailForSurface = (
   trail: Trail<unknown, unknown, unknown>,
   options: SurfaceFilterOptions = {}
 ): boolean => {
-  if (trail.on.length > 0) {
+  if (trail.activationSources.length > 0) {
     return false;
   }
 

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -1,17 +1,19 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 
 import {
   InternalError,
   NotFoundError,
   Result,
   TRAILHEAD_KEY,
+  getActivationProvenance,
   resource,
   signal,
   ValidationError,
   trail,
   topo,
+  webhook,
 } from '@ontrails/core';
-import type { Layer, TrailContext } from '@ontrails/core';
+import type { ActivationSource, Layer, TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
 import { deriveHttpRoutes } from '../build.js';
@@ -91,6 +93,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.method).toBe('GET');
@@ -101,6 +106,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.method).toBe('DELETE');
@@ -111,6 +119,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.method).toBe('POST');
@@ -123,6 +134,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value[0]?.path).toBe('/item/create');
     });
 
@@ -131,6 +145,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value[0]?.path).toBe('/echo');
     });
 
@@ -139,6 +156,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app, { basePath: '/api/v1' });
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value[0]?.path).toBe('/api/v1/echo');
     });
 
@@ -147,6 +167,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app, { basePath: '/api/v1/' });
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value[0]?.path).toBe('/api/v1/echo');
     });
   });
@@ -157,6 +180,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value[0]?.inputSource).toBe('query');
     });
 
@@ -165,6 +191,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value[0]?.inputSource).toBe('body');
     });
 
@@ -173,6 +202,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value[0]?.inputSource).toBe('body');
     });
   });
@@ -183,6 +215,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.trailId).toBe('echo');
@@ -193,6 +228,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app, { include: ['secret'] });
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.trailId).toBe('secret');
@@ -203,6 +241,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app, { include: ['**'] });
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.trailId).toBe('echo');
@@ -216,6 +257,9 @@ describe('deriveHttpRoutes', () => {
       });
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value.map((route) => route.trailId)).toEqual(['echo']);
     });
 
@@ -224,6 +268,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app, { intent: ['read'] });
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value.map((route) => route.trailId)).toEqual(['echo']);
     });
 
@@ -235,6 +282,9 @@ describe('deriveHttpRoutes', () => {
       });
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value.map((route) => route.trailId)).toEqual([
         'item.delete',
       ]);
@@ -252,9 +302,509 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       const routes = result.value;
       expect(routes).toHaveLength(1);
       expect(routes[0]?.trailId).toBe('echo');
+    });
+  });
+
+  describe('webhook source materialization', () => {
+    test('materializes webhook activation sources as HTTP routes', () => {
+      const source = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      });
+      const receiver = trail('payment.receive', {
+        blaze: (input) => Result.ok({ paymentId: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ paymentId: z.string() }),
+      });
+
+      const result = deriveHttpRoutes(topo('billing', { receiver }));
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]).toMatchObject({
+        inputSource: 'webhook',
+        method: 'POST',
+        path: '/webhooks/payment',
+        trailId: 'payment.receive',
+        webhookSource: source,
+      });
+    });
+
+    test('fans out shared webhook source routes to every consumer trail', async () => {
+      const source = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      });
+      const invoked: string[] = [];
+      const audit = trail('payment.audit', {
+        blaze: (input) => {
+          invoked.push(`audit:${input.paymentId}`);
+          return Result.ok({ audited: input.paymentId });
+        },
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ audited: z.string() }),
+      });
+      const notify = trail('payment.notify', {
+        blaze: (input) => {
+          invoked.push(`notify:${input.paymentId}`);
+          return Result.ok({ notified: input.paymentId });
+        },
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ notified: z.string() }),
+      });
+
+      const result = deriveHttpRoutes(topo('billing', { audit, notify }));
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value).toHaveLength(1);
+      const [route] = result.value;
+      const parsed = route?.parseWebhookInput?.({ paymentId: 'pay_1' });
+      expect(parsed?.isOk()).toBe(true);
+      if (!parsed?.isOk()) {
+        return;
+      }
+      const executed = await route?.execute(parsed.value);
+      expect(executed?.isOk()).toBe(true);
+      if (!executed?.isOk()) {
+        return;
+      }
+      expect(executed.value).toEqual([
+        { audited: 'pay_1' },
+        { notified: 'pay_1' },
+      ]);
+      expect(invoked).toEqual(['audit:pay_1', 'notify:pay_1']);
+    });
+
+    test('merged webhook consumers share one activation fire ID per inbound request', async () => {
+      const source = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      });
+      const fireIds: (string | undefined)[] = [];
+      const rootFireIds: (string | undefined)[] = [];
+      const sourceIds: (string | undefined)[] = [];
+      const audit = trail('payment.audit', {
+        blaze: (input, ctx) => {
+          const activation = getActivationProvenance(ctx);
+          fireIds.push(activation?.fireId);
+          rootFireIds.push(activation?.rootFireId);
+          sourceIds.push(activation?.source.id);
+          return Result.ok({ audited: input.paymentId });
+        },
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ audited: z.string() }),
+      });
+      const notify = trail('payment.notify', {
+        blaze: (input, ctx) => {
+          const activation = getActivationProvenance(ctx);
+          fireIds.push(activation?.fireId);
+          rootFireIds.push(activation?.rootFireId);
+          sourceIds.push(activation?.source.id);
+          return Result.ok({ notified: input.paymentId });
+        },
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ notified: z.string() }),
+      });
+
+      let nextId = 0;
+      const randomUUID = mock(() => {
+        nextId += 1;
+        return `00000000-0000-4000-8000-00000000000${nextId}`;
+      });
+      const originalRandomUUID = globalThis.crypto.randomUUID;
+      Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        configurable: true,
+        value: randomUUID,
+      });
+
+      try {
+        const result = deriveHttpRoutes(topo('billing', { audit, notify }));
+        expect(result.isOk()).toBe(true);
+        if (!result.isOk()) {
+          return;
+        }
+        const [route] = result.value;
+        const parsed = route?.parseWebhookInput?.({ paymentId: 'pay_1' });
+        expect(parsed?.isOk()).toBe(true);
+        if (!parsed?.isOk()) {
+          return;
+        }
+        const executed = await route?.execute(parsed.value);
+        expect(executed?.isOk()).toBe(true);
+
+        expect(fireIds).toHaveLength(2);
+        expect(fireIds[0]).toBeDefined();
+        expect(fireIds[0]).toBe(fireIds[1]);
+        expect(rootFireIds[0]).toBe(fireIds[0]);
+        expect(rootFireIds[1]).toBe(fireIds[1]);
+        expect(sourceIds).toEqual([
+          'webhook.payment.received',
+          'webhook.payment.received',
+        ]);
+        // Exactly one activation fire ID is generated per inbound request,
+        // regardless of how many consumers fan out from it.
+        expect(randomUUID).toHaveBeenCalledTimes(1);
+      } finally {
+        Object.defineProperty(globalThis.crypto, 'randomUUID', {
+          configurable: true,
+          value: originalRandomUUID,
+        });
+      }
+    });
+
+    test('prepends basePath to webhook source paths', () => {
+      const source = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      });
+      const receiver = trail('payment.receive', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+      });
+
+      const result = deriveHttpRoutes(topo('billing', { receiver }), {
+        basePath: '/api',
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value[0]?.path).toBe('/api/webhooks/payment');
+    });
+
+    test('canonicalizes manual webhook source methods and paths', () => {
+      const source: ActivationSource = {
+        id: 'webhook.payment.received',
+        kind: 'webhook',
+        method: 'post',
+        parse: z.object({ paymentId: z.string() }),
+        path: ' /webhooks/payment ',
+      };
+      const receiver = trail('payment.receive', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+      });
+
+      const result = deriveHttpRoutes(topo('billing', { receiver }));
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value[0]?.method).toBe('POST');
+      expect(result.value[0]?.path).toBe('/webhooks/payment');
+      expect(result.value[0]?.webhookSource).toMatchObject({
+        method: 'POST',
+        path: '/webhooks/payment',
+      });
+    });
+
+    test('parses webhook payloads before executing the consumer trail', async () => {
+      const source = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      });
+      let activationSourceId: string | undefined;
+      let activationFireId: string | undefined;
+      const receiver = trail('payment.receive', {
+        blaze: (input, ctx) => {
+          const activation = getActivationProvenance(ctx);
+          activationSourceId = activation?.source.id;
+          activationFireId = activation?.fireId;
+          return Result.ok({ paymentId: input.paymentId });
+        },
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ paymentId: z.string() }),
+      });
+      const randomUUID = mock(() => '00000000-0000-4000-8000-000000000000');
+      const originalRandomUUID = globalThis.crypto.randomUUID;
+      Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        configurable: true,
+        value: randomUUID,
+      });
+
+      try {
+        const result = deriveHttpRoutes(topo('billing', { receiver }));
+
+        expect(result.isOk()).toBe(true);
+        if (!result.isOk()) {
+          return;
+        }
+        const [route] = result.value;
+        const parsed = route?.parseWebhookInput?.({ paymentId: 'pay_1' });
+        expect(parsed?.isOk()).toBe(true);
+        if (!parsed?.isOk()) {
+          return;
+        }
+
+        const executed = await route?.execute(parsed.value);
+        expect(executed?.isOk()).toBe(true);
+        if (!executed?.isOk()) {
+          return;
+        }
+        expect(executed.value).toEqual({ paymentId: 'pay_1' });
+        expect(activationSourceId).toBe('webhook.payment.received');
+        expect(activationFireId).toBe('00000000-0000-4000-8000-000000000000');
+        expect(randomUUID).toHaveBeenCalledTimes(1);
+      } finally {
+        Object.defineProperty(globalThis.crypto, 'randomUUID', {
+          configurable: true,
+          value: originalRandomUUID,
+        });
+      }
+    });
+
+    test('webhook where guards skip execution when they return false', async () => {
+      const source = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      });
+      let invoked = 0;
+      const receiver = trail('payment.receive', {
+        blaze: (input) => {
+          invoked += 1;
+          return Result.ok({ paymentId: input.paymentId });
+        },
+        input: z.object({ paymentId: z.string() }),
+        on: [{ source, where: () => false }],
+        output: z.object({ paymentId: z.string() }),
+      });
+      const result = deriveHttpRoutes(topo('billing', { receiver }));
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      const [route] = result.value;
+      const parsed = route?.parseWebhookInput?.({ paymentId: 'pay_1' });
+      expect(parsed?.isOk()).toBe(true);
+      if (!parsed?.isOk()) {
+        return;
+      }
+
+      const executed = await route?.execute(parsed.value);
+
+      expect(executed?.isOk()).toBe(true);
+      if (!executed?.isOk()) {
+        return;
+      }
+      expect(executed.value).toBeUndefined();
+      expect(invoked).toBe(0);
+    });
+
+    test('rejects webhook routes that collide with derived trail routes', () => {
+      const source = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      });
+      const receiver = trail('payment.receive', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+      });
+      const direct = trail('webhooks.payment', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+      });
+
+      const result = deriveHttpRoutes(topo('billing', { direct, receiver }));
+
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toContain('POST /webhooks/payment');
+    });
+
+    test('rejects shared webhook routes with mismatched verifier policies', () => {
+      const verifyA = mock(() => Promise.resolve(Result.ok()));
+      const verifyB = mock(() => Promise.resolve(Result.ok()));
+      const sourceA = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+        verify: verifyA,
+      });
+      const sourceB = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+        verify: verifyB,
+      });
+      const audit = trail('payment.audit', {
+        blaze: (input) => Result.ok({ audited: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [sourceA],
+        output: z.object({ audited: z.string() }),
+      });
+      const notify = trail('payment.notify', {
+        blaze: (input) => Result.ok({ notified: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [sourceB],
+        output: z.object({ notified: z.string() }),
+      });
+
+      // PR #348 tightened the upstream validator to reject mismatched
+      // verifier policies; bypass it here so we exercise the HTTP-level
+      // merge guard directly.
+      const result = deriveHttpRoutes(topo('billing', { audit, notify }), {
+        validate: false,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toContain('webhook verifier policy');
+      expect(result.error.message).toContain('POST /webhooks/payment');
+    });
+
+    test('merges shared webhook routes when verifier and parse identities match', () => {
+      const verify = mock(() => Promise.resolve(Result.ok()));
+      const parse = z.object({ paymentId: z.string() });
+      const sourceA = webhook('webhook.payment.received', {
+        parse,
+        path: '/webhooks/payment',
+        verify,
+      });
+      const sourceB = webhook('webhook.payment.received', {
+        parse,
+        path: '/webhooks/payment',
+        verify,
+      });
+      const audit = trail('payment.audit', {
+        blaze: (input) => Result.ok({ audited: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [sourceA],
+        output: z.object({ audited: z.string() }),
+      });
+      const notify = trail('payment.notify', {
+        blaze: (input) => Result.ok({ notified: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [sourceB],
+        output: z.object({ notified: z.string() }),
+      });
+
+      const result = deriveHttpRoutes(topo('billing', { audit, notify }), {
+        validate: false,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value).toHaveLength(1);
+    });
+
+    test('rejects shared webhook routes with mismatched parse contracts', () => {
+      const verify = mock(() => Promise.resolve(Result.ok()));
+      const sourceA = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+        verify,
+      });
+      const sourceB = webhook('webhook.payment.received', {
+        parse: z.object({ amount: z.number(), paymentId: z.string() }),
+        path: '/webhooks/payment',
+        verify,
+      });
+      const audit = trail('payment.audit', {
+        blaze: (input) => Result.ok({ audited: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [sourceA],
+        output: z.object({ audited: z.string() }),
+      });
+      const notify = trail('payment.notify', {
+        blaze: (input) => Result.ok({ notified: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [sourceB],
+        output: z.object({ notified: z.string() }),
+      });
+
+      // The upstream `activation-source-definition-unique` validator rejects
+      // mismatched parse contracts, so bypass it here to exercise the
+      // HTTP-level merge guard directly.
+      const result = deriveHttpRoutes(topo('billing', { audit, notify }), {
+        validate: false,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toContain('webhook parse contract');
+      expect(result.error.message).toContain('POST /webhooks/payment');
+    });
+
+    test('runs every fan-out consumer even when an earlier consumer fails', async () => {
+      const source = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      });
+      const invoked: string[] = [];
+      const failing = trail('payment.audit', {
+        blaze: (input) => {
+          invoked.push(`audit:${input.paymentId}`);
+          return Result.err(new ValidationError('audit blew up'));
+        },
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ audited: z.string() }),
+      });
+      const succeeding = trail('payment.notify', {
+        blaze: (input) => {
+          invoked.push(`notify:${input.paymentId}`);
+          return Result.ok({ notified: input.paymentId });
+        },
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ notified: z.string() }),
+      });
+
+      const built = deriveHttpRoutes(topo('billing', { failing, succeeding }));
+      expect(built.isOk()).toBe(true);
+      if (!built.isOk()) {
+        return;
+      }
+      const [route] = built.value;
+      const parsed = route?.parseWebhookInput?.({ paymentId: 'pay_1' });
+      expect(parsed?.isOk()).toBe(true);
+      if (!parsed?.isOk()) {
+        return;
+      }
+
+      const executed = await route?.execute(parsed.value);
+
+      // Every consumer attempted, regardless of order or earlier failures.
+      expect(invoked).toEqual(['audit:pay_1', 'notify:pay_1']);
+      // First error surfaces; later successes do not mask it.
+      expect(executed?.isErr()).toBe(true);
+      if (!executed?.isErr()) {
+        return;
+      }
+      expect(executed.error.message).toContain('audit blew up');
     });
   });
 
@@ -264,7 +814,10 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
-      expect(result.value[0]?.trail).toBe(echoTrail);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(Object.is(result.value[0]?.trail, echoTrail)).toBe(true);
     });
 
     test('execute is a function', () => {
@@ -272,6 +825,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(typeof result.value[0]?.execute).toBe('function');
     });
   });
@@ -282,11 +838,17 @@ describe('deriveHttpRoutes', () => {
       const buildResult = deriveHttpRoutes(app);
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       const result = await route?.execute({ message: 'hello' });
       expect(result?.isOk()).toBe(true);
-      expect(result?.value).toEqual({ reply: 'hello' });
+      if (!result?.isOk()) {
+        return;
+      }
+      expect(result.value).toEqual({ reply: 'hello' });
     });
 
     test('returns err Result on invalid input', async () => {
@@ -294,6 +856,9 @@ describe('deriveHttpRoutes', () => {
       const buildResult = deriveHttpRoutes(app);
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       const result = await route?.execute({});
@@ -305,11 +870,17 @@ describe('deriveHttpRoutes', () => {
       const buildResult = deriveHttpRoutes(app);
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       const result = await route?.execute({ id: 'missing' });
       expect(result?.isErr()).toBe(true);
-      expect(result?.error?.message).toBe('Item not found');
+      if (!result?.isErr()) {
+        return;
+      }
+      expect(result.error.message).toBe('Item not found');
     });
 
     test('returns err Result from internal error', async () => {
@@ -317,11 +888,17 @@ describe('deriveHttpRoutes', () => {
       const buildResult = deriveHttpRoutes(app);
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       const result = await route?.execute({});
       expect(result?.isErr()).toBe(true);
-      expect(result?.error?.message).toBe('Something broke');
+      if (!result?.isErr()) {
+        return;
+      }
+      expect(result.error.message).toBe('Something broke');
     });
 
     test('returns err Result when run function throws', async () => {
@@ -335,12 +912,18 @@ describe('deriveHttpRoutes', () => {
       const buildResult = deriveHttpRoutes(app);
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       const result = await route?.execute({});
       expect(result?.isErr()).toBe(true);
-      expect(result?.error).toBeInstanceOf(InternalError);
-      expect(result?.error?.message).toBe('unexpected throw');
+      if (!result?.isErr()) {
+        return;
+      }
+      expect(result.error).toBeInstanceOf(InternalError);
+      expect(result.error.message).toBe('unexpected throw');
     });
 
     test('returns err Result when createContext throws', async () => {
@@ -352,12 +935,18 @@ describe('deriveHttpRoutes', () => {
       });
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       const result = await route?.execute({ message: 'hi' });
       expect(result?.isErr()).toBe(true);
-      expect(result?.error).toBeInstanceOf(InternalError);
-      expect(result?.error?.message).toBe('context creation failed');
+      if (!result?.isErr()) {
+        return;
+      }
+      expect(result.error).toBeInstanceOf(InternalError);
+      expect(result.error.message).toBe('context creation failed');
     });
 
     test('passes topo to executeTrail so HTTP-invoked producers can fan out', async () => {
@@ -384,6 +973,9 @@ describe('deriveHttpRoutes', () => {
       const buildResult = deriveHttpRoutes(app);
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       const result = await route?.execute({ orderId: 'o-http' });
@@ -408,6 +1000,9 @@ describe('deriveHttpRoutes', () => {
       const buildResult = deriveHttpRoutes(app);
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       await route?.execute({}, 'custom-req-123');
@@ -430,6 +1025,9 @@ describe('deriveHttpRoutes', () => {
       const buildResult = deriveHttpRoutes(app);
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       await route?.execute({});
@@ -452,11 +1050,17 @@ describe('deriveHttpRoutes', () => {
       });
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       const result = await route?.execute({});
       expect(result?.isOk()).toBe(true);
-      expect(result?.value).toEqual({ source: 'override' });
+      if (!result?.isOk()) {
+        return;
+      }
+      expect(result.value).toEqual({ source: 'override' });
     });
   });
 
@@ -480,6 +1084,9 @@ describe('deriveHttpRoutes', () => {
       const buildResult = deriveHttpRoutes(app, { layers: [testGate] });
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       const result = await route?.execute({ message: 'hi' });
@@ -513,6 +1120,9 @@ describe('deriveHttpRoutes', () => {
       });
 
       expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
       const [route] = buildResult.value;
 
       const result = await route?.execute({});
@@ -543,8 +1153,11 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
       expect(result.error).toBeInstanceOf(ValidationError);
-      expect(result.error?.message).toContain('GET /entity/show');
+      expect(result.error.message).toContain('GET /entity/show');
     });
 
     test('same path with different methods is allowed', () => {
@@ -566,6 +1179,9 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
       expect(result.value).toHaveLength(2);
     });
 
@@ -586,7 +1202,10 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(app);
 
       expect(result.isErr()).toBe(true);
-      expect(result.error?.message).toContain('entity');
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error.message).toContain('entity');
     });
   });
 
@@ -601,7 +1220,10 @@ describe('deriveHttpRoutes', () => {
       const result = deriveHttpRoutes(topo('testapp', { draftTrail }));
 
       expect(result.isErr()).toBe(true);
-      expect(result.error?.message).toMatch(/draft/i);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error.message).toMatch(/draft/i);
     });
   });
 });

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -11,16 +11,26 @@ import {
   ValidationError,
   executeTrail,
   filterSurfaceTrails,
+  getActivationWherePredicate,
+  matchesTrailPattern,
+  validateInput,
+  validateWebhookSource,
   validateSurfaceTopo,
+  verifyWebhookRequest,
+  withActivationProvenance,
   withSurfaceMarker,
 } from '@ontrails/core';
 import type {
+  ActivationEntry,
+  ActivationSource,
   BaseSurfaceOptions,
   Layer,
   ResourceOverrideMap,
   Topo,
   Trail,
   TrailContextInit,
+  WebhookSource,
+  WebhookVerifyRequest,
 } from '@ontrails/core';
 
 import { deriveHttpInputSource, deriveHttpMethod } from './method.js';
@@ -47,6 +57,16 @@ export interface HttpRouteDefinition {
   readonly trailId: string;
   readonly inputSource: InputSource;
   readonly trail: Trail<unknown, unknown, unknown>;
+  readonly parseWebhookInput?:
+    | ((rawPayload: unknown) => Result<unknown, Error>)
+    | undefined;
+  readonly verifyWebhook?:
+    | ((request: WebhookVerifyRequest) => Promise<Result<void, Error>>)
+    | undefined;
+  readonly recordWebhookInvalid?:
+    | ((errorCategory?: string | undefined) => Promise<void>)
+    | undefined;
+  readonly webhookSource?: WebhookSource | undefined;
   /**
    * Validate input, compose layers, and execute the trail implementation.
    *
@@ -85,6 +105,29 @@ const withHttpTrailhead = (
 ): Partial<TrailContextInit> =>
   withSurfaceMarker('http', requestId === undefined ? {} : { requestId });
 
+const createWebhookActivationFireId = (): string => {
+  const randomUUID = globalThis.crypto?.randomUUID;
+  if (typeof randomUUID === 'function') {
+    return randomUUID.call(globalThis.crypto);
+  }
+  return `webhook_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+};
+
+const withWebhookActivation = (
+  source: WebhookSource,
+  requestId: string | undefined,
+  fireId: string
+): Partial<TrailContextInit> =>
+  withActivationProvenance(withHttpTrailhead(requestId), {
+    fireId,
+    rootFireId: fireId,
+    source: {
+      id: source.id,
+      kind: 'webhook',
+      ...(source.meta === undefined ? {} : { meta: source.meta }),
+    },
+  });
+
 // ---------------------------------------------------------------------------
 // Execute factory
 // ---------------------------------------------------------------------------
@@ -113,6 +156,76 @@ const createExecute =
       topo: graph,
     });
 
+/**
+ * Internal executor signature used for shared webhook source fan-out.
+ *
+ * Unlike the public `HttpRouteDefinition['execute']`, this accepts an
+ * `activationFireId` so a single inbound request can share one activation
+ * fire ID across every consumer fan-out — letting observability correlate
+ * sibling consumers as one activation root.
+ */
+type WebhookConsumerExecute = (
+  input: unknown,
+  requestId: string | undefined,
+  abortSignal: AbortSignal | undefined,
+  activationFireId: string
+) => Promise<Result<unknown, Error>>;
+
+const createWebhookConsumerExecute =
+  (
+    graph: Topo,
+    t: Trail<unknown, unknown, unknown>,
+    activationEntry: ActivationEntry,
+    layers: readonly Layer[],
+    options: DeriveHttpRoutesOptions
+  ): WebhookConsumerExecute =>
+  async (input, requestId, abortSignal, activationFireId) => {
+    const source = activationEntry.source as WebhookSource;
+    const predicate = getActivationWherePredicate(activationEntry.where);
+    if (predicate !== undefined) {
+      let shouldRun = false;
+      try {
+        shouldRun = await predicate(input);
+      } catch (error) {
+        return Result.err(
+          new ValidationError(
+            `Webhook source "${source.id}" activation predicate failed`,
+            { cause: error instanceof Error ? error : new Error(String(error)) }
+          )
+        );
+      }
+      if (!shouldRun) {
+        return Result.ok();
+      }
+    }
+
+    return await executeTrail(t, input, {
+      abortSignal,
+      configValues: options.configValues,
+      createContext: options.createContext,
+      ctx: withWebhookActivation(source, requestId, activationFireId),
+      layers,
+      resources: options.resources,
+      topo: graph,
+    });
+  };
+
+/**
+ * Wrap a single-consumer webhook executor as the public `execute` function.
+ *
+ * Generates one activation fire ID per inbound request, matching the fan-out
+ * behavior so single and merged routes share the same observability shape.
+ */
+const createWebhookExecute =
+  (consumerExecute: WebhookConsumerExecute): HttpRouteDefinition['execute'] =>
+  async (input, requestId, abortSignal) =>
+    await consumerExecute(
+      input,
+      requestId,
+      abortSignal,
+      createWebhookActivationFireId()
+    );
+
 // ---------------------------------------------------------------------------
 // Builder helpers
 // ---------------------------------------------------------------------------
@@ -126,6 +239,45 @@ const eligibleTrails = (
     exclude: options.exclude,
     include: options.include,
     intent: options.intent,
+  });
+
+const isInternalTrail = (trail: Trail<unknown, unknown, unknown>): boolean =>
+  trail.visibility === 'internal' || trail.meta?.['internal'] === true;
+
+const matchesAnyPattern = (
+  trailId: string,
+  patterns: readonly string[] | undefined
+): boolean =>
+  patterns !== undefined &&
+  patterns.some((pattern) => matchesTrailPattern(trailId, pattern));
+
+const passesIncludeFilter = (
+  trailId: string,
+  include: readonly string[] | undefined
+): boolean =>
+  include === undefined ||
+  include.length === 0 ||
+  matchesAnyPattern(trailId, include);
+
+const eligibleWebhookTrails = (
+  graph: Topo,
+  options: DeriveHttpRoutesOptions
+): Trail<unknown, unknown, unknown>[] =>
+  graph.list().filter((trail) => {
+    if (isInternalTrail(trail) && !options.include?.includes(trail.id)) {
+      return false;
+    }
+    if (matchesAnyPattern(trail.id, options.exclude)) {
+      return false;
+    }
+    if (!passesIncludeFilter(trail.id, options.include)) {
+      return false;
+    }
+    return (
+      options.intent === undefined ||
+      options.intent.length === 0 ||
+      options.intent.includes(trail.intent)
+    );
   });
 
 /** Build a single route definition from a trail. */
@@ -148,6 +300,131 @@ const buildRoute = (
   };
 };
 
+const normalizeSourcePath = (basePath: string, sourcePath: string): string => {
+  const base = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+  return `${base}${sourcePath}`;
+};
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+type ZodSchemaInput = Parameters<typeof validateInput>[0];
+
+const isZodSchema = (value: unknown): value is ZodSchemaInput =>
+  isObjectRecord(value) && typeof value['safeParse'] === 'function';
+
+const parseOutputSchema = (
+  parse: WebhookSource['parse'] | undefined
+): ZodSchemaInput | undefined => {
+  if (isZodSchema(parse)) {
+    return parse;
+  }
+  if (isObjectRecord(parse) && isZodSchema(parse['output'])) {
+    return parse['output'];
+  }
+  return undefined;
+};
+
+const webhookValidationMessage = (
+  source: ActivationSource,
+  issues: ReturnType<typeof validateWebhookSource>
+): string =>
+  `Webhook source "${source.id}" is invalid: ${issues.map((issue) => `${issue.field}: ${issue.message}`).join('; ')}`;
+
+const toWebhookSource = (
+  source: ActivationSource
+): Result<WebhookSource, Error> => {
+  const issues = validateWebhookSource(source);
+  if (issues.length > 0) {
+    return Result.err(
+      new ValidationError(webhookValidationMessage(source, issues), {
+        context: { issues },
+      })
+    );
+  }
+  const webhookSource = source as WebhookSource;
+  const method = (source.method ?? 'POST').trim().toUpperCase();
+  const path = source.path?.trim();
+  if (method === webhookSource.method && path === webhookSource.path) {
+    return Result.ok(webhookSource);
+  }
+  return Result.ok(
+    Object.freeze({
+      ...webhookSource,
+      method,
+      path,
+    }) as WebhookSource
+  );
+};
+
+const createWebhookInputParser =
+  (source: WebhookSource): HttpRouteDefinition['parseWebhookInput'] =>
+  (rawPayload) => {
+    const schema = parseOutputSchema(source.parse);
+    if (schema === undefined) {
+      return Result.err(
+        new ValidationError(
+          `Webhook source "${source.id}" does not expose a parse output schema`
+        )
+      );
+    }
+    const parsed = validateInput(schema, rawPayload);
+    if (parsed.isErr()) {
+      return Result.err(
+        new ValidationError(
+          `Webhook source "${source.id}" payload is invalid: ${parsed.error.message}`,
+          {
+            cause: parsed.error,
+            ...(parsed.error.context === undefined
+              ? {}
+              : { context: parsed.error.context }),
+          }
+        )
+      );
+    }
+    return parsed;
+  };
+
+const WEBHOOK_CONSUMERS = Symbol('webhookConsumers');
+
+type MergeableWebhookRoute = HttpRouteDefinition & {
+  readonly [WEBHOOK_CONSUMERS]?: readonly WebhookConsumerExecute[];
+};
+
+const buildWebhookRoute = (
+  graph: Topo,
+  trail: Trail<unknown, unknown, unknown>,
+  activation: ActivationEntry,
+  basePath: string,
+  layers: readonly Layer[],
+  options: DeriveHttpRoutesOptions
+): Result<HttpRouteDefinition, Error> => {
+  const source = toWebhookSource(activation.source);
+  if (source.isErr()) {
+    return source;
+  }
+  const consumerExecute = createWebhookConsumerExecute(
+    graph,
+    trail,
+    activation,
+    layers,
+    options
+  );
+  const route: MergeableWebhookRoute = {
+    [WEBHOOK_CONSUMERS]: [consumerExecute],
+    execute: createWebhookExecute(consumerExecute),
+    inputSource: 'webhook',
+    method: source.value.method,
+    parseWebhookInput: createWebhookInputParser(source.value),
+    path: normalizeSourcePath(basePath, source.value.path),
+    trail,
+    trailId: trail.id,
+    verifyWebhook: (request) => verifyWebhookRequest(source.value, request),
+    webhookSource: source.value,
+  };
+  return Result.ok(route);
+};
+
 // ---------------------------------------------------------------------------
 // Collision detection
 // ---------------------------------------------------------------------------
@@ -156,22 +433,157 @@ const buildRoute = (
 const routeKey = (route: HttpRouteDefinition): `${string} ${string}` =>
   `${route.method} ${route.path}`;
 
+const isSameWebhookSourceLocation = (
+  left: HttpRouteDefinition,
+  right: HttpRouteDefinition
+): boolean =>
+  left.inputSource === 'webhook' &&
+  right.inputSource === 'webhook' &&
+  left.webhookSource !== undefined &&
+  right.webhookSource !== undefined &&
+  left.webhookSource.id === right.webhookSource.id &&
+  left.webhookSource.method === right.webhookSource.method &&
+  left.webhookSource.path === right.webhookSource.path;
+
+/**
+ * Two webhook source routes can only merge when they declare the same
+ * verifier identity. Reference equality on `verify` matches the projection
+ * model used elsewhere — a shared source object always passes, while two
+ * separately-declared verifier functions are treated as distinct policies
+ * even when their bodies look equivalent.
+ */
+const hasMatchingWebhookVerifier = (
+  left: HttpRouteDefinition,
+  right: HttpRouteDefinition
+): boolean => left.webhookSource?.verify === right.webhookSource?.verify;
+
+/**
+ * Two webhook source routes can only merge when they declare the same parse
+ * contract identity. Reference equality on `parse` mirrors the verifier rule:
+ * a shared source object always passes, while two separately-declared parse
+ * schemas (or handlers) are treated as distinct contracts even when their
+ * shapes look equivalent. Without this check the merged route silently keeps
+ * whichever parser registered first, so payloads valid for later consumers
+ * could be rejected and unintended shapes could be passed downstream.
+ */
+const hasMatchingWebhookParse = (
+  left: HttpRouteDefinition,
+  right: HttpRouteDefinition
+): boolean => left.webhookSource?.parse === right.webhookSource?.parse;
+
+const webhookConsumers = (
+  route: MergeableWebhookRoute
+): readonly WebhookConsumerExecute[] | undefined => route[WEBHOOK_CONSUMERS];
+
+type MergeWebhookOutcome =
+  | { readonly kind: 'merged'; readonly route: HttpRouteDefinition }
+  | { readonly kind: 'verifier-mismatch'; readonly error: ValidationError }
+  | { readonly kind: 'parse-mismatch'; readonly error: ValidationError }
+  | { readonly kind: 'not-mergeable' };
+
+const mergeWebhookRoutes = (
+  existing: HttpRouteDefinition,
+  route: HttpRouteDefinition
+): MergeWebhookOutcome => {
+  if (!isSameWebhookSourceLocation(existing, route)) {
+    return { kind: 'not-mergeable' };
+  }
+  if (!hasMatchingWebhookVerifier(existing, route)) {
+    return {
+      error: new ValidationError(
+        `HTTP route collision: trails "${existing.trailId}" and "${route.trailId}" share webhook source "${existing.webhookSource?.id}" on ${route.method} ${route.path} but declare a mismatched webhook verifier policy. Reuse the same WebhookSource object so both consumers run under one verifier.`
+      ),
+      kind: 'verifier-mismatch',
+    };
+  }
+  if (!hasMatchingWebhookParse(existing, route)) {
+    return {
+      error: new ValidationError(
+        `HTTP route collision: trails "${existing.trailId}" and "${route.trailId}" share webhook source "${existing.webhookSource?.id}" on ${route.method} ${route.path} but declare a mismatched webhook parse contract. Reuse the same WebhookSource object so both consumers parse payloads under one contract.`
+      ),
+      kind: 'parse-mismatch',
+    };
+  }
+
+  const existingConsumers = webhookConsumers(existing as MergeableWebhookRoute);
+  const incomingConsumers = webhookConsumers(route as MergeableWebhookRoute);
+  if (existingConsumers === undefined || incomingConsumers === undefined) {
+    return { kind: 'not-mergeable' };
+  }
+  const consumers: readonly WebhookConsumerExecute[] = [
+    ...existingConsumers,
+    ...incomingConsumers,
+  ];
+
+  const merged: MergeableWebhookRoute = {
+    ...existing,
+    [WEBHOOK_CONSUMERS]: consumers,
+    async execute(input, requestId, abortSignal) {
+      // One activation fire ID per inbound webhook request, shared across every
+      // fan-out consumer so observability can correlate them as siblings of a
+      // single activation root.
+      const activationFireId = createWebhookActivationFireId();
+
+      // Fan-out: every consumer must get its attempt even when an earlier
+      // consumer fails. Remember the first error, run the rest, and only
+      // surface ok when every consumer succeeded.
+      const values: unknown[] = [];
+      let firstError: Result<unknown, Error> | undefined;
+      for (const consumerExecute of consumers) {
+        const result = await consumerExecute(
+          input,
+          requestId,
+          abortSignal,
+          activationFireId
+        );
+        if (result.isErr()) {
+          if (firstError === undefined) {
+            firstError = result;
+          }
+          continue;
+        }
+        values.push(result.value);
+      }
+      if (firstError !== undefined) {
+        return firstError;
+      }
+      return Result.ok(values);
+    },
+  };
+  return { kind: 'merged', route: merged };
+};
+
 /** Register a route, checking for (path, method) collisions. */
 const registerRoute = (
   route: HttpRouteDefinition,
-  seenRoutes: Map<string, string>,
+  seenRoutes: Map<string, HttpRouteDefinition>,
   routes: HttpRouteDefinition[]
 ): Result<void, Error> => {
   const key = routeKey(route);
-  const existingId = seenRoutes.get(key);
-  if (existingId !== undefined) {
+  const existing = seenRoutes.get(key);
+  if (existing !== undefined) {
+    const outcome = mergeWebhookRoutes(existing, route);
+    if (outcome.kind === 'merged') {
+      seenRoutes.set(key, outcome.route);
+      const routeIndex = routes.indexOf(existing);
+      if (routeIndex !== -1) {
+        routes[routeIndex] = outcome.route;
+      }
+      return Result.ok();
+    }
+    if (
+      outcome.kind === 'verifier-mismatch' ||
+      outcome.kind === 'parse-mismatch'
+    ) {
+      return Result.err(outcome.error);
+    }
     return Result.err(
       new ValidationError(
-        `HTTP route collision: trails "${existingId}" and "${route.trailId}" both derive ${route.method} ${route.path}`
+        `HTTP route collision: trails "${existing.trailId}" and "${route.trailId}" both derive ${route.method} ${route.path}`
       )
     );
   }
-  seenRoutes.set(key, route.trailId);
+  seenRoutes.set(key, route);
   routes.push(route);
   return Result.ok();
 };
@@ -180,18 +592,42 @@ const registerRoute = (
 const accumulateRoutes = (
   graph: Topo,
   trails: Trail<unknown, unknown, unknown>[],
+  webhookTrails: Trail<unknown, unknown, unknown>[],
   basePath: string,
   layers: readonly Layer[],
   options: DeriveHttpRoutesOptions
 ): Result<HttpRouteDefinition[], Error> => {
   const routes: HttpRouteDefinition[] = [];
-  const seenRoutes = new Map<string, string>();
+  const seenRoutes = new Map<string, HttpRouteDefinition>();
 
   for (const trail of trails) {
     const route = buildRoute(graph, trail, basePath, layers, options);
     const registered = registerRoute(route, seenRoutes, routes);
     if (registered.isErr()) {
       return registered;
+    }
+  }
+
+  for (const trail of webhookTrails) {
+    for (const activation of trail.activationSources) {
+      if (activation.source.kind !== 'webhook') {
+        continue;
+      }
+      const route = buildWebhookRoute(
+        graph,
+        trail,
+        activation,
+        basePath,
+        layers,
+        options
+      );
+      if (route.isErr()) {
+        return route;
+      }
+      const registered = registerRoute(route.value, seenRoutes, routes);
+      if (registered.isErr()) {
+        return registered;
+      }
     }
   }
 
@@ -228,6 +664,7 @@ export const deriveHttpRoutes = (
   return accumulateRoutes(
     graph,
     eligibleTrails(graph, options),
+    eligibleWebhookTrails(graph, options),
     basePath,
     layers,
     options

--- a/packages/http/src/method.ts
+++ b/packages/http/src/method.ts
@@ -1,10 +1,10 @@
-import type { Intent } from '@ontrails/core';
+import type { Intent, WebhookMethod } from '@ontrails/core';
 
-export type HttpMethod = 'GET' | 'POST' | 'DELETE';
+export type HttpMethod = 'GET' | 'POST' | 'DELETE' | WebhookMethod;
 
 export type HttpOperationMethod = Lowercase<HttpMethod>;
 
-export type InputSource = 'query' | 'body';
+export type InputSource = 'query' | 'body' | 'webhook';
 
 export const httpMethodByIntent = {
   destroy: 'DELETE',


### PR DESCRIPTION
## Summary
The HTTP surface now turns webhook activation sources into real, mounted routes. Multiple consumer trails can share a single inbound webhook path; the surface merges them into one route, fans the request out to every consumer, and reports back a single combined result.

## What changed
- `packages/http/src/build.ts` derives webhook routes from activation sources and supports shared-route fan-out across consumers.
- `connectors/hono/src/surface.ts` carries the materialized routes through to the Hono surface, with new tests in `connectors/hono/src/__tests__/surface.test.ts`.
- `packages/core/src/surface-filter.ts` includes webhook sources in surface filtering so the HTTP surface knows which trails are webhook-activated.
- `packages/http/src/__tests__/build.test.ts` covers single-consumer routes, shared-route merging, validator integration, and verifier identity matching across merged consumers.

## Why it matters
This is where the universal webhook shape becomes a real surface contract: agents can point a webhook provider at one URL and let multiple trails react to the event without each one owning its own path or duplicating verification.

## Stack
Builds on #347 and #348. #350 adds Warden coverage for collisions; #359 adds the activation-trace contract for these routes.

## Linear
https://linear.app/outfitter/issue/TRL-460/materialize-webhook-sources-from-the-http-surface