### PR TITLE
feat(warden): reject webhook route collisions

### DIFF
--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 42 rule trails', () => {
-    expect(wardenTopo.count).toBe(42);
+  test('contains all 43 rule trails', () => {
+    expect(wardenTopo.count).toBe(43);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/__tests__/unmaterialized-activation-source.test.ts
+++ b/packages/warden/src/__tests__/unmaterialized-activation-source.test.ts
@@ -3,18 +3,16 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { Result, schedule, signal, topo, trail } from '@ontrails/core';
-import type { ActivationSource } from '@ontrails/core';
+import { Result, schedule, signal, topo, trail, webhook } from '@ontrails/core';
 import { z } from 'zod';
 
 import { runWarden } from '../cli.js';
 import { unmaterializedActivationSource } from '../rules/unmaterialized-activation-source.js';
 
-const webhookSource = {
-  id: 'webhook.invoice.paid',
-  kind: 'webhook',
-  payload: z.object({ invoiceId: z.string() }),
-} as const satisfies ActivationSource;
+const webhookSource = webhook('webhook.invoice.paid', {
+  parse: z.object({ invoiceId: z.string() }),
+  path: '/webhooks/invoice/paid',
+});
 
 const webhookConsumer = trail('invoice.audit-webhook', {
   blaze: () => Result.ok({ ok: true }),
@@ -43,7 +41,7 @@ const signalConsumer = trail('invoice.index', {
 });
 
 describe('unmaterialized-activation-source', () => {
-  test('warns once for a webhook source and lists all consuming trails', async () => {
+  test('stays quiet for webhook sources now that HTTP materializes them', async () => {
     const notifyConsumer = trail('invoice.notify-webhook', {
       blaze: () => Result.ok({ ok: true }),
       input: z.object({ invoiceId: z.string() }),
@@ -63,19 +61,10 @@ describe('unmaterialized-activation-source', () => {
       })
     );
 
-    expect(diagnostics).toEqual([
-      {
-        filePath: '<topo>',
-        line: 1,
-        message:
-          'Activation source "webhook.invoice.paid" of kind "webhook" activates trails "invoice.audit-webhook", "invoice.notify-webhook" but no built-in materializer is available in this stack. Add the materializer before relying on runtime delivery, or defer the source declaration until the materializer lands.',
-        rule: 'unmaterialized-activation-source',
-        severity: 'warn',
-      },
-    ]);
+    expect(diagnostics).toEqual([]);
   });
 
-  test('stays quiet for schedule and signal activation sources', async () => {
+  test('stays quiet for schedule, signal, and webhook activation sources', async () => {
     const scheduleConsumer = trail('invoice.reconcile', {
       blaze: () => Result.ok({ ok: true }),
       input: z.object({}),
@@ -89,6 +78,7 @@ describe('unmaterialized-activation-source', () => {
         scheduleConsumer,
         signalConsumer,
         signalProducer,
+        webhookConsumer,
       })
     );
 
@@ -96,11 +86,10 @@ describe('unmaterialized-activation-source', () => {
   });
 
   test('keeps source kind in the materialization key', async () => {
-    const sameIdWebhook = {
-      id: 'shared.source',
-      kind: 'webhook',
-      payload: z.object({ id: z.string() }),
-    } as const satisfies ActivationSource;
+    const sameIdWebhook = webhook('shared.source', {
+      parse: z.object({ id: z.string() }),
+      path: '/webhooks/shared',
+    });
     const sameIdSignal = signal('shared.source', {
       from: ['shared.producer'],
       payload: z.object({ id: z.string() }),
@@ -133,15 +122,10 @@ describe('unmaterialized-activation-source', () => {
       })
     );
 
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.message).toContain(
-      'Activation source "shared.source" of kind "webhook"'
-    );
-    expect(diagnostics[0]?.message).toContain('"shared.webhook-consumer"');
-    expect(diagnostics[0]?.message).not.toContain('"shared.signal-consumer"');
+    expect(diagnostics).toEqual([]);
   });
 
-  test('runWarden includes unmaterialized source coaching when topo is supplied', async () => {
+  test('runWarden does not warn for webhook sources once materialized', async () => {
     const rootDir = mkdtempSync(
       join(tmpdir(), 'warden-unmaterialized-source-')
     );
@@ -152,16 +136,16 @@ describe('unmaterialized-activation-source', () => {
         topo: topo('unmaterialized-webhook', { webhookConsumer }),
       });
 
-      expect(report.diagnostics).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            message: expect.stringContaining('no built-in materializer'),
-            rule: 'unmaterialized-activation-source',
-            severity: 'warn',
-          }),
-        ])
+      expect(
+        report.diagnostics.some(
+          (diagnostic) => diagnostic.rule === 'unmaterialized-activation-source'
+        )
+      ).toBe(false);
+      expect(report.warnCount).toBe(
+        report.diagnostics.filter(
+          (diagnostic) => diagnostic.severity === 'warn'
+        ).length
       );
-      expect(report.warnCount).toBeGreaterThan(0);
     } finally {
       rmSync(rootDir, { force: true, recursive: true });
     }

--- a/packages/warden/src/__tests__/webhook-route-collision.test.ts
+++ b/packages/warden/src/__tests__/webhook-route-collision.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Result, topo, trail, webhook } from '@ontrails/core';
+import { z } from 'zod';
+
+import { runWarden } from '../cli.js';
+import { webhookRouteCollision } from '../rules/webhook-route-collision.js';
+
+const paymentWebhook = webhook('webhook.payment.received', {
+  parse: z.object({ paymentId: z.string() }),
+  path: '/webhooks/payment',
+});
+
+const paymentReceiver = trail('payment.receive', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({ paymentId: z.string() }),
+  on: [paymentWebhook],
+  output: z.object({ ok: z.boolean() }),
+});
+
+describe('webhook-route-collision', () => {
+  test('stays quiet for distinct webhook route paths', async () => {
+    const invoiceWebhook = webhook('webhook.invoice.received', {
+      parse: z.object({ invoiceId: z.string() }),
+      path: '/webhooks/invoice',
+    });
+    const invoiceReceiver = trail('invoice.receive', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ invoiceId: z.string() }),
+      on: [invoiceWebhook],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-clean', {
+        invoiceReceiver,
+        paymentReceiver,
+      })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('errors when two webhook sources share method and path', async () => {
+    const duplicateWebhook = webhook('webhook.payment.duplicate', {
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/payment',
+    });
+    const duplicateReceiver = trail('payment.duplicate-receive', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ paymentId: z.string() }),
+      on: [duplicateWebhook],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-duplicate', {
+        duplicateReceiver,
+        paymentReceiver,
+      })
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        filePath: '<topo>',
+        line: 1,
+        message:
+          'HTTP webhook route collision on POST /webhooks/payment: webhook source "webhook.payment.duplicate" on trail "payment.duplicate-receive", webhook source "webhook.payment.received" on trail "payment.receive". Give each webhook source a distinct method/path pair or move the direct trail route before materializing the HTTP surface.',
+        rule: 'webhook-route-collision',
+        severity: 'error',
+      },
+    ]);
+  });
+
+  test('allows one webhook source to fan out to multiple trails', async () => {
+    const auditReceiver = trail('payment.audit-receive', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ paymentId: z.string() }),
+      on: [paymentWebhook],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-fanout', {
+        auditReceiver,
+        paymentReceiver,
+      })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('allows the same webhook path with different methods', async () => {
+    const patchWebhook = webhook('webhook.payment.patch', {
+      method: 'PATCH',
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/payment',
+    });
+    const patchReceiver = trail('payment.patch-receive', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ paymentId: z.string() }),
+      on: [patchWebhook],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-method-distinct', {
+        patchReceiver,
+        paymentReceiver,
+      })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('errors when a webhook route collides with a derived direct HTTP route', async () => {
+    const directRoute = trail('webhooks.payment', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-direct-collision', {
+        directRoute,
+        paymentReceiver,
+      })
+    );
+
+    expect(diagnostics[0]).toMatchObject({
+      filePath: '<topo>',
+      line: 1,
+      rule: 'webhook-route-collision',
+      severity: 'error',
+    });
+    expect(diagnostics[0]?.message).toContain(
+      'derived trail route "webhooks.payment"'
+    );
+    expect(diagnostics[0]?.message).toContain(
+      'webhook source "webhook.payment.received" on trail "payment.receive"'
+    );
+  });
+
+  test('stays quiet when a webhook overlaps an internal direct trail (not materialized by default)', async () => {
+    const directRoute = trail('webhooks.payment', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      visibility: 'internal',
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-internal-direct-noop', {
+        directRoute,
+        paymentReceiver,
+      })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('stays quiet when a webhook overlaps a legacy meta.internal direct trail', async () => {
+    const directRoute = trail('webhooks.payment', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      meta: { internal: true },
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-legacy-internal-direct-noop', {
+        directRoute,
+        paymentReceiver,
+      })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('stays quiet when an internal trail consumes a webhook (not materialized by default)', async () => {
+    const internalConsumer = trail('payment.internal-consumer', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ paymentId: z.string() }),
+      on: [paymentWebhook],
+      output: z.object({ ok: z.boolean() }),
+      visibility: 'internal',
+    });
+
+    const distinctWebhook = webhook('webhook.payment.distinct', {
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/payment',
+    });
+    const publicConsumer = trail('payment.public-consumer', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ paymentId: z.string() }),
+      on: [distinctWebhook],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-internal-webhook-noop', {
+        internalConsumer,
+        publicConsumer,
+      })
+    );
+
+    // Two distinct webhook ids share method/path, but the only public consumer
+    // claims one of them. The internal consumer would not be materialized.
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('errors when two trails share a webhook id but declare different verify functions', async () => {
+    const sharedId = 'webhook.payment.shared';
+    const sharedPath = '/webhooks/payment-shared';
+    const verifierA = async (): Promise<Result<void, Error>> => Result.ok();
+    const verifierB = async (): Promise<Result<void, Error>> => Result.ok();
+
+    const sourceA = webhook(sharedId, {
+      parse: z.object({ paymentId: z.string() }),
+      path: sharedPath,
+      verify: verifierA,
+    });
+    const sourceB = webhook(sharedId, {
+      parse: z.object({ paymentId: z.string() }),
+      path: sharedPath,
+      verify: verifierB,
+    });
+
+    const trailA = trail('payment.shared-a', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ paymentId: z.string() }),
+      on: [sourceA],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const trailB = trail('payment.shared-b', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ paymentId: z.string() }),
+      on: [sourceB],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-verifier-mismatch', {
+        trailA,
+        trailB,
+      })
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      filePath: '<topo>',
+      line: 1,
+      rule: 'webhook-route-collision',
+      severity: 'error',
+    });
+    expect(diagnostics[0]?.message).toContain('verifier');
+    expect(diagnostics[0]?.message).toContain(`"${sharedId}"`);
+  });
+
+  test('errors when two trails share a webhook id but declare different parse contracts', async () => {
+    const sharedId = 'webhook.payment.shared-parse';
+    const sharedPath = '/webhooks/payment-shared-parse';
+
+    const sourceA = webhook(sharedId, {
+      parse: z.object({ paymentId: z.string() }),
+      path: sharedPath,
+    });
+    const sourceB = webhook(sharedId, {
+      parse: z.object({ paymentId: z.string() }),
+      path: sharedPath,
+    });
+
+    const trailA = trail('payment.shared-parse-a', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ paymentId: z.string() }),
+      on: [sourceA],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const trailB = trail('payment.shared-parse-b', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ paymentId: z.string() }),
+      on: [sourceB],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-parse-mismatch', {
+        trailA,
+        trailB,
+      })
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      filePath: '<topo>',
+      line: 1,
+      rule: 'webhook-route-collision',
+      severity: 'error',
+    });
+    expect(diagnostics[0]?.message).toContain('parse');
+    expect(diagnostics[0]?.message).toContain(`"${sharedId}"`);
+  });
+
+  test('runWarden includes webhook route collision checks when topo is supplied', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'warden-webhook-route-'));
+    const directRoute = trail('webhooks.payment', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    try {
+      const report = await runWarden({
+        rootDir,
+        topo: topo('webhook-routes-run-warden', {
+          directRoute,
+          paymentReceiver,
+        }),
+      });
+
+      expect(report.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rule: 'webhook-route-collision',
+            severity: 'error',
+          }),
+        ])
+      );
+      expect(report.errorCount).toBeGreaterThan(0);
+    } finally {
+      rmSync(rootDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -112,6 +112,7 @@ export {
   validDescribeRefsTrail,
   wardenExportSymmetryTrail,
   wardenRulesUseAstTrail,
+  webhookRouteCollisionTrail,
   wrapRule,
   wrapTopoRule,
 } from './trails/index.js';

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -41,6 +41,7 @@ import { validDetourContract } from './valid-detour-contract.js';
 import { validDescribeRefs } from './valid-describe-refs.js';
 import { wardenExportSymmetry } from './warden-export-symmetry.js';
 import { wardenRulesUseAst } from './warden-rules-use-ast.js';
+import { webhookRouteCollision } from './webhook-route-collision.js';
 
 export type {
   WardenRuleLifecycle,
@@ -106,6 +107,7 @@ export { unmaterializedActivationSource } from './unmaterialized-activation-sour
 export { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 export { validDetourContract } from './valid-detour-contract.js';
 export { validDescribeRefs } from './valid-describe-refs.js';
+export { webhookRouteCollision } from './webhook-route-collision.js';
 
 /** All built-in warden rules, keyed by rule name. */
 export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
@@ -171,4 +173,5 @@ export const wardenTopoRules: ReadonlyMap<string, TopoAwareWardenRule> =
     [signalGraphCoaching.name, signalGraphCoaching],
     [unmaterializedActivationSource.name, unmaterializedActivationSource],
     [validDetourContract.name, validDetourContract],
+    [webhookRouteCollision.name, webhookRouteCollision],
   ]);

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -266,6 +266,12 @@ export const builtinWardenRuleMetadata = {
     invariant: 'Warden source rules use AST helpers instead of ad hoc parsing.',
     tier: 'source-static',
   },
+  'webhook-route-collision': {
+    ...durableExternal,
+    invariant:
+      'Webhook routes do not collide with each other or direct HTTP trail routes.',
+    tier: 'topo-aware',
+  },
 } as const satisfies Record<string, WardenRuleMetadata>;
 
 export type BuiltinWardenRuleName = keyof typeof builtinWardenRuleMetadata;

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -47,6 +47,7 @@ import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 import { validDetourContract } from './valid-detour-contract.js';
 import { validDescribeRefs } from './valid-describe-refs.js';
 import { wardenRulesUseAst } from './warden-rules-use-ast.js';
+import { webhookRouteCollision } from './webhook-route-collision.js';
 
 /**
  * All non-`warden-export-symmetry` rule identifiers registered in
@@ -96,4 +97,5 @@ export const registeredRuleNames: readonly string[] = [
   validDetourContract.name,
   validDescribeRefs.name,
   wardenRulesUseAst.name,
+  webhookRouteCollision.name,
 ];

--- a/packages/warden/src/rules/unmaterialized-activation-source.ts
+++ b/packages/warden/src/rules/unmaterialized-activation-source.ts
@@ -8,9 +8,10 @@ const TOPO_FILE = '<topo>';
 const MATERIALIZED_SOURCE_KINDS = new Set<ActivationSourceKind>([
   'schedule',
   'signal',
+  'webhook',
 ]);
 
-const PENDING_SOURCE_KINDS = new Set<ActivationSourceKind>(['webhook']);
+const PENDING_SOURCE_KINDS = new Set<ActivationSourceKind>();
 
 interface SourceConsumers {
   readonly id: string;

--- a/packages/warden/src/rules/webhook-route-collision.ts
+++ b/packages/warden/src/rules/webhook-route-collision.ts
@@ -1,0 +1,243 @@
+import { shouldIncludeTrailForSurface } from '@ontrails/core';
+import type { Topo, Trail } from '@ontrails/core';
+
+import type { TopoAwareWardenRule, WardenDiagnostic } from './types.js';
+
+const RULE_NAME = 'webhook-route-collision';
+const TOPO_FILE = '<topo>';
+
+type RouteMethod = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
+
+interface RouteClaim {
+  readonly method: RouteMethod;
+  readonly parse?: unknown;
+  readonly path: string;
+  readonly sourceId?: string | undefined;
+  readonly trailId: string;
+  readonly type: 'derived-trail' | 'webhook';
+  readonly verify?: unknown;
+}
+
+const methodByIntent = {
+  destroy: 'DELETE',
+  read: 'GET',
+  write: 'POST',
+} as const satisfies Record<string, RouteMethod>;
+
+const derivedTrailPath = (trailId: string): string =>
+  `/${trailId.replaceAll('.', '/')}`;
+
+const derivedTrailMethod = (
+  trail: Trail<unknown, unknown, unknown>
+): RouteMethod =>
+  (methodByIntent as Partial<Record<string, RouteMethod>>)[trail.intent] ??
+  'POST';
+
+const routeKey = ({ method, path }: Pick<RouteClaim, 'method' | 'path'>) =>
+  `${method} ${path}`;
+
+const sortedClaims = (claims: readonly RouteClaim[]): readonly RouteClaim[] =>
+  [...claims].toSorted((a, b) => {
+    const byType = a.type.localeCompare(b.type);
+    if (byType !== 0) {
+      return byType;
+    }
+    const byTrail = a.trailId.localeCompare(b.trailId);
+    if (byTrail !== 0) {
+      return byTrail;
+    }
+    return (a.sourceId ?? '').localeCompare(b.sourceId ?? '');
+  });
+
+/**
+ * Mirror the HTTP builder's default materialization policy. A derived trail
+ * route is only emitted when {@link shouldIncludeTrailForSurface} accepts the
+ * trail under empty options — internal trails are excluded unless callers
+ * explicitly include them by id, which the warden cannot anticipate. Without
+ * this filter the rule reports collisions against routes that HTTP would never
+ * materialize. See `packages/http/src/build.ts` (`eligibleTrails`).
+ */
+const collectDerivedTrailClaims = (topo: Topo): readonly RouteClaim[] =>
+  topo
+    .list()
+    .filter((trail) => shouldIncludeTrailForSurface(trail))
+    .map((trail) => ({
+      method: derivedTrailMethod(trail),
+      path: derivedTrailPath(trail.id),
+      trailId: trail.id,
+      type: 'derived-trail' as const,
+    }));
+
+const webhookMethod = (method: string | undefined): RouteMethod =>
+  (method?.trim().toUpperCase() as RouteMethod | undefined) ?? 'POST';
+
+/**
+ * Mirror the HTTP builder's default materialization policy for webhook
+ * consumers. HTTP's `eligibleWebhookTrails` skips internal trails unless
+ * callers explicitly include them by id, which the warden cannot anticipate.
+ * Without this filter the rule reports collisions against webhook routes that
+ * HTTP would never materialize. See `packages/http/src/build.ts`
+ * (`eligibleWebhookTrails`, `isInternalTrail`).
+ *
+ * `shouldIncludeTrailForSurface` cannot be reused here because it short-
+ * circuits on any trail with `activationSources.length > 0` — those are exactly
+ * the webhook consumer trails we need to inspect. Replicate the visibility
+ * shape inline: `visibility: 'internal'` and the legacy `meta.internal === true`
+ * convention both opt out of default materialization.
+ */
+const isInternalConsumer = (trail: Trail<unknown, unknown, unknown>): boolean =>
+  trail.visibility === 'internal' || trail.meta?.['internal'] === true;
+
+const collectWebhookClaims = (topo: Topo): readonly RouteClaim[] => {
+  const claims: RouteClaim[] = [];
+
+  for (const trail of topo.list()) {
+    if (isInternalConsumer(trail)) {
+      continue;
+    }
+    for (const activation of trail.activationSources) {
+      if (
+        activation.source.kind !== 'webhook' ||
+        typeof activation.source.path !== 'string'
+      ) {
+        continue;
+      }
+      claims.push({
+        method: webhookMethod(activation.source.method),
+        parse: activation.source.parse,
+        path: activation.source.path.trim(),
+        sourceId: activation.source.id,
+        trailId: trail.id,
+        type: 'webhook',
+        verify: activation.source.verify,
+      });
+    }
+  }
+
+  return claims;
+};
+
+const claimLabel = (claim: RouteClaim): string =>
+  claim.type === 'webhook'
+    ? `webhook source "${claim.sourceId}" on trail "${claim.trailId}"`
+    : `derived trail route "${claim.trailId}"`;
+
+const buildDiagnostic = (
+  key: string,
+  claims: readonly RouteClaim[]
+): WardenDiagnostic => ({
+  filePath: TOPO_FILE,
+  line: 1,
+  message: `HTTP webhook route collision on ${key}: ${sortedClaims(claims)
+    .map(claimLabel)
+    .join(
+      ', '
+    )}. Give each webhook source a distinct method/path pair or move the direct trail route before materializing the HTTP surface.`,
+  rule: RULE_NAME,
+  severity: 'error',
+});
+
+const buildPolicyMismatchDiagnostic = (
+  key: string,
+  sourceId: string | undefined,
+  field: 'parse' | 'verifier',
+  claims: readonly RouteClaim[]
+): WardenDiagnostic => {
+  const labels = sortedClaims(claims).map(claimLabel).join(', ');
+  const remediation =
+    field === 'verifier'
+      ? 'Reuse the same WebhookSource object so both consumers run under one verifier.'
+      : 'Reuse the same WebhookSource object so both consumers parse payloads under one contract.';
+  return {
+    filePath: TOPO_FILE,
+    line: 1,
+    message: `HTTP webhook route collision on ${key}: trails sharing webhook source "${sourceId ?? '<unknown>'}" declare a mismatched ${field} policy (${labels}). ${remediation}`,
+    rule: RULE_NAME,
+    severity: 'error',
+  };
+};
+
+/**
+ * Within a group of webhook claims that share the same `sourceId`, surface a
+ * diagnostic when the underlying source declarations diverge on `verify` or
+ * `parse`. The HTTP builder rejects the same combination at runtime in
+ * {@link mergeWebhookRoutes}; flagging it here surfaces the failure at lint
+ * time instead of waiting for surface construction. Reference equality matches
+ * the runtime check (a shared `WebhookSource` always passes; two separately
+ * declared schemas or callbacks are treated as distinct policies).
+ */
+const collectPolicyMismatchDiagnostics = (
+  key: string,
+  webhookClaims: readonly RouteClaim[]
+): WardenDiagnostic[] => {
+  const claimsBySourceId = new Map<string, RouteClaim[]>();
+  for (const claim of webhookClaims) {
+    const id = claim.sourceId ?? '';
+    const current = claimsBySourceId.get(id) ?? [];
+    current.push(claim);
+    claimsBySourceId.set(id, current);
+  }
+
+  const diagnostics: WardenDiagnostic[] = [];
+  for (const [id, grouped] of claimsBySourceId) {
+    if (grouped.length < 2) {
+      continue;
+    }
+    const verifyRefs = new Set(grouped.map((claim) => claim.verify));
+    if (verifyRefs.size > 1) {
+      diagnostics.push(
+        buildPolicyMismatchDiagnostic(key, id, 'verifier', grouped)
+      );
+      continue;
+    }
+    const parseRefs = new Set(grouped.map((claim) => claim.parse));
+    if (parseRefs.size > 1) {
+      diagnostics.push(
+        buildPolicyMismatchDiagnostic(key, id, 'parse', grouped)
+      );
+    }
+  }
+  return diagnostics;
+};
+
+const buildDiagnostics = (claims: readonly RouteClaim[]) => {
+  const claimsByRoute = new Map<string, RouteClaim[]>();
+  for (const claim of claims) {
+    const key = routeKey(claim);
+    const current = claimsByRoute.get(key) ?? [];
+    current.push(claim);
+    claimsByRoute.set(key, current);
+  }
+
+  const diagnostics: WardenDiagnostic[] = [];
+  for (const [key, grouped] of claimsByRoute) {
+    const webhookClaims = grouped.filter((claim) => claim.type === 'webhook');
+    if (webhookClaims.length === 0) {
+      continue;
+    }
+    const webhookSourceIds = new Set(
+      webhookClaims.map((claim) => claim.sourceId)
+    );
+    if (
+      webhookSourceIds.size > 1 ||
+      grouped.some((claim) => claim.type === 'derived-trail')
+    ) {
+      diagnostics.push(buildDiagnostic(key, grouped));
+      continue;
+    }
+    diagnostics.push(...collectPolicyMismatchDiagnostics(key, webhookClaims));
+  }
+  return diagnostics;
+};
+
+export const webhookRouteCollision: TopoAwareWardenRule = {
+  checkTopo: (topo) =>
+    buildDiagnostics([
+      ...collectDerivedTrailClaims(topo),
+      ...collectWebhookClaims(topo),
+    ]),
+  description:
+    'Reject webhook source method/path pairs that collide with each other or derived HTTP trail routes.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -40,6 +40,7 @@ export { validDetourContractTrail } from './valid-detour-contract.trail.js';
 export { validDescribeRefsTrail } from './valid-describe-refs.trail.js';
 export { wardenExportSymmetryTrail } from './warden-export-symmetry.trail.js';
 export { wardenRulesUseAstTrail } from './warden-rules-use-ast.trail.js';
+export { webhookRouteCollisionTrail } from './webhook-route-collision.trail.js';
 
 export {
   diagnosticSchema,

--- a/packages/warden/src/trails/unmaterialized-activation-source.trail.ts
+++ b/packages/warden/src/trails/unmaterialized-activation-source.trail.ts
@@ -1,15 +1,13 @@
-import { Result, schedule, signal, topo, trail } from '@ontrails/core';
-import type { ActivationSource } from '@ontrails/core';
+import { Result, schedule, signal, topo, trail, webhook } from '@ontrails/core';
 import { z } from 'zod';
 
 import { unmaterializedActivationSource } from '../rules/unmaterialized-activation-source.js';
 import { wrapTopoRule } from './wrap-rule.js';
 
-const invoicePaidWebhook = {
-  id: 'webhook.invoice.paid',
-  kind: 'webhook',
-  payload: z.object({ invoiceId: z.string() }),
-} as const satisfies ActivationSource;
+const invoicePaidWebhook = webhook('webhook.invoice.paid', {
+  parse: z.object({ invoiceId: z.string() }),
+  path: '/webhooks/invoice/paid',
+});
 
 const webhookConsumer = trail('invoice.audit-webhook', {
   blaze: () => Result.ok({ ok: true }),
@@ -47,22 +45,11 @@ const scheduleConsumer = trail('invoice.reconcile', {
 export const unmaterializedActivationSourceTrail = wrapTopoRule({
   examples: [
     {
-      expected: {
-        diagnostics: [
-          {
-            filePath: '<topo>',
-            line: 1,
-            message:
-              'Activation source "webhook.invoice.paid" of kind "webhook" activates trail "invoice.audit-webhook" but no built-in materializer is available in this stack. Add the materializer before relying on runtime delivery, or defer the source declaration until the materializer lands.',
-            rule: 'unmaterialized-activation-source',
-            severity: 'warn',
-          },
-        ],
-      },
+      expected: { diagnostics: [] },
       input: {
-        topo: topo('trl-496-webhook-pending', { webhookConsumer }),
+        topo: topo('trl-461-webhook-materialized', { webhookConsumer }),
       },
-      name: 'Webhook activation sources warn until materialized',
+      name: 'Webhook activation sources are materialized by HTTP',
     },
     {
       expected: { diagnostics: [] },
@@ -72,9 +59,10 @@ export const unmaterializedActivationSourceTrail = wrapTopoRule({
           scheduleConsumer,
           signalConsumer,
           signalProducer,
+          webhookConsumer,
         }),
       },
-      name: 'Signal and schedule activation sources are materialized',
+      name: 'Signal, schedule, and webhook activation sources are materialized',
     },
   ],
   rule: unmaterializedActivationSource,

--- a/packages/warden/src/trails/webhook-route-collision.trail.ts
+++ b/packages/warden/src/trails/webhook-route-collision.trail.ts
@@ -1,0 +1,50 @@
+import { Result, topo, trail, webhook } from '@ontrails/core';
+import { z } from 'zod';
+
+import { webhookRouteCollision } from '../rules/webhook-route-collision.js';
+import { wrapTopoRule } from './wrap-rule.js';
+
+const paymentWebhook = webhook('webhook.payment.received', {
+  parse: z.object({ paymentId: z.string() }),
+  path: '/webhooks/payment',
+});
+
+const paymentReceiver = trail('payment.receive', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({ paymentId: z.string() }),
+  on: [paymentWebhook],
+  output: z.object({ ok: z.boolean() }),
+});
+
+const directRoute = trail('webhooks.payment', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+});
+
+export const webhookRouteCollisionTrail = wrapTopoRule({
+  examples: [
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: '<topo>',
+            line: 1,
+            message:
+              'HTTP webhook route collision on POST /webhooks/payment: derived trail route "webhooks.payment", webhook source "webhook.payment.received" on trail "payment.receive". Give each webhook source a distinct method/path pair or move the direct trail route before materializing the HTTP surface.',
+            rule: 'webhook-route-collision',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        topo: topo('trl-461-webhook-route-collision', {
+          directRoute,
+          paymentReceiver,
+        }),
+      },
+      name: 'Webhook route colliding with a derived direct HTTP route',
+    },
+  ],
+  rule: webhookRouteCollision,
+});


### PR DESCRIPTION
## Summary
Warden now rejects webhook route collisions before they ever reach the HTTP surface. Two trails declaring the same webhook `method + path` with incompatible verifiers (or with one materialized and one not) is a contract bug, and lint should catch it.

## What changed
- New rule `webhook-route-collision` in `packages/warden/src/rules/webhook-route-collision.ts`, paired with the trail at `packages/warden/src/trails/webhook-route-collision.trail.ts`.
- Existing `unmaterialized-activation-source` rule scoped down so it does not double-flag webhook collisions; the trail file is now a thin re-export.
- Comprehensive tests in `packages/warden/src/__tests__/webhook-route-collision.test.ts` covering matched verifiers (allowed merge), mismatched verifiers (rejected), and non-materialized internal routes.

## Why it matters
Shared webhook routes are deliberate and supported (#349); shared routes that disagree about how they verify the payload are a security footgun. Warden is the right place to draw that line.

## Stack
Builds on #349 (HTTP webhook materialization).

## Linear
https://linear.app/outfitter/issue/TRL-461/reject-webhook-path-collisions-in-warden