### PR TITLE
docs: add webhook activation source guide

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,6 +10,8 @@ Canonical public surface-facing reference. For naming conventions and decision h
 // Definitions
 trail(id, spec)                    // define a unit of work (with optional crosses for composition)
 signal(id, spec)                    // define a payload schema with provenance
+schedule(id, spec)                  // define an inert cron activation source
+webhook(id, spec)                   // define an inert HTTP webhook activation source
 contour(name, shape, options)       // define a first-class domain object with identity metadata
 resource(id, spec)                  // define a first-class resource dependency
 createResourceLookup(getContext)   // bind ctx.resource() to a specific context snapshot
@@ -28,12 +30,14 @@ countTopoSnapshots(db), countPinnedSnapshots(db), countPrunableSnapshots(db, opt
 pruneUnpinnedSnapshots(db, options?)
 
 // Types
-Trail<I, O>, Signal<T>, Contour<TName, TShape, TIdentity>, Resource<T>, Topo, Intent
-TrailSpec<I, O>, SignalSpec<T>, ResourceSpec<T>, TrailExample<I, O>
+Trail<I, O>, Signal<T>, ScheduleSource, WebhookSource<T>, Contour<TName, TShape, TIdentity>, Resource<T>, Topo, Intent
+TrailSpec<I, O>, SignalSpec<T>, ScheduleSpec, WebhookSpec<T>, ResourceSpec<T>, TrailExample<I, O>
 AnyTrail, AnySignal, AnyContour, AnyResource, ResourceContext, ResourceOverrideMap
 BlobRef, BlobRefDescriptor
 ContourOptions, ContourIdBrand, ContourIdMetadata, ContourIdSchema, ContourIdValue, ContourReference
 StoredTopoExport, TrailsDbLocationOptions, EnsureSubsystemSchemaOptions
+ActivationSource, ActivationEntry, ActivationProvenance
+WebhookMethod, WebhookVerify, WebhookVerifyRequest, WebhookVerifyHeaders, WebhookValidationIssue
 
 // Type utilities
 TrailInput<T>                      // extract input type from a Trail
@@ -96,6 +100,12 @@ Field, FieldOverride
 validateSurfaceTopo(topo, options?) // shared established-topo guard for surface projections
 withSurfaceMarker(surface, ctx?)    // merge a surface marker into execution context extensions
 BaseSurfaceOptions, SurfaceSelectionOptions, SurfaceValidationOptions, SurfaceConfigValues
+
+// Webhook activation sources
+webhookMethods
+validateWebhookSource(source)       // validate method/path/parse/verify shape
+verifyWebhookRequest(source, request) // run an optional source verify hook
+getWebhookHeader(request, name)     // case-insensitive helper for verify hooks
 
 // Draft state
 DRAFT_ID_PREFIX, isDraftId(value), deriveDraftReport(topo)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@
 
 - **[CLI Surface](./surfaces/cli.md)** — Shipped today. Flag derivation, output modes, exit codes, `--dry-run`
 - **[MCP Surface](./surfaces/mcp.md)** — Shipped today. Tool naming, annotations, progress bridge
-- **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, verb mapping, error responses, Hono connector
+- **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, webhook activation, verb mapping, error responses, Hono connector
 - **WebSocket Surface** — Planned, not yet implemented. See [Horizons](./horizons.md) for the current direction.
 
 ## Governing your codebase?

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -202,7 +202,7 @@ const updated = signal('entity.updated', {
 });
 ```
 
-Trails signals are authored, typed notifications in the contract graph. Future activation/source work may let schedules, webhooks, file watchers, and other external activation sources produce signals, but v1 signal support does not materialize those sources.
+Trails signals are authored, typed notifications in the contract graph. Schedule and webhook activation sources are separate `on:` source objects: schedules are materialized by the schedule runtime, and webhooks are materialized by the HTTP surface through the universal `webhook()` source shape. File watchers and other external activation sources remain future source kinds.
 
 ### `pin`
 

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -55,8 +55,95 @@ Input parsing depends on the HTTP method:
 
 - **GET** -- Query parameters are parsed into an object. Repeated keys become arrays; single keys stay strings. The trail's input schema owns any coercion.
 - **POST / DELETE** -- The JSON request body is parsed via `req.json()`.
+- **Webhook routes** -- The Hono connector reads the raw body first, runs the webhook `verify` hook if one is defined, parses JSON, then validates the parsed payload against the source's `parse` schema before executing the trail.
 
-In both cases, the parsed input is validated against the trail's Zod schema before the implementation runs.
+For direct routes, the parsed input is validated against the trail's Zod schema before the implementation runs. For webhook routes, the source `parse` schema validates the JSON payload first, then the receiving trail's `input` schema validates the value passed into the trail.
+
+## Webhook Activation Sources
+
+Webhook activation is declared in core with `webhook()` and materialized by the HTTP surface. The source is provider-agnostic: Stripe, GitHub, Slack, or an internal webhook connector should all produce the same universal source shape instead of inventing provider-specific activation kinds.
+
+```typescript
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import {
+  getWebhookHeader,
+  PermissionError,
+  Result,
+  topo,
+  trail,
+  webhook,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+const paymentReceived = webhook('webhook.payment.received', {
+  path: '/webhooks/payment',
+  parse: z.object({
+    amount: z.number(),
+    paymentId: z.string(),
+  }),
+  verify: (request) => {
+    const secret = process.env.PAYMENT_WEBHOOK_SECRET;
+    const signature = getWebhookHeader(request, 'x-payment-signature');
+    if (secret === undefined || signature === undefined) {
+      return Result.err(new PermissionError('Invalid webhook signature'));
+    }
+    // Compute the expected HMAC over the raw body and compare in
+    // constant time. `timingSafeEqual` requires equal-length buffers,
+    // so guard the length before calling it.
+    const body =
+      typeof request.body === 'string'
+        ? Buffer.from(request.body, 'utf8')
+        : Buffer.from(request.body);
+    const expected = createHmac('sha256', secret).update(body).digest();
+    // Validate the hex format strictly before decoding. `Buffer.from(_, 'hex')`
+    // silently truncates invalid or odd-length input rather than throwing,
+    // which could let a malformed signature decode to bytes that pass
+    // `timingSafeEqual`. Require an even-length string of hex characters.
+    if (signature.length === 0 || signature.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(signature)) {
+      return Result.err(new PermissionError('Invalid webhook signature format'));
+    }
+    const received = Buffer.from(signature, 'hex');
+    if (
+      received.length !== expected.length ||
+      !timingSafeEqual(received, expected)
+    ) {
+      return Result.err(new PermissionError('Invalid webhook signature'));
+    }
+    return Result.ok();
+  },
+});
+
+const receivePayment = trail('payment.receive', {
+  blaze: async (input) => Result.ok({ recorded: input.paymentId }),
+  input: z.object({
+    amount: z.number(),
+    paymentId: z.string(),
+  }),
+  on: [paymentReceived],
+  output: z.object({ recorded: z.string() }),
+});
+
+export const graph = topo('billing', { receivePayment });
+```
+
+When `surface(graph)` runs, the source above becomes `POST /webhooks/payment`. A `method` field can opt into `GET`, `PUT`, `PATCH`, `POST`, or `DELETE`; `POST` is the default.
+
+The `parse` schema describes the payload after JSON parsing and before the trail runs. Its output must be compatible with the receiving trail's `input` schema. The optional `verify` hook receives the raw body plus request headers, method, and path so signature checks can run before JSON parsing changes the bytes being signed.
+
+Provider connector helpers should wrap this shape, not replace it:
+
+```typescript
+export const stripePaymentSucceeded = webhook(
+  'webhook.stripe.payment-succeeded',
+  {
+    path: '/webhooks/stripe',
+    parse: stripePaymentSucceededPayload,
+    verify: verifyStripeSignature,
+  }
+);
+```
+
+Route collision handling is explicit. If two webhook sources claim the same method and path, or a webhook source collides with a derived direct trail route such as `trail('webhooks.payment', ...)`, `deriveHttpRoutes()` returns a `ValidationError` and Warden reports `webhook-route-collision`.
 
 ## Response Format
 
@@ -152,8 +239,10 @@ The handler reads `X-Request-ID` from inbound requests and passes it through to 
 For custom setups, use `deriveHttpRoutes()` from the base package to get framework-agnostic route definitions. Each route has an `execute` function that validates input, composes Layers, and runs the trail -- you wire it into whatever HTTP framework you use:
 
 ```typescript
+import { isTrailsError, mapSurfaceError } from '@ontrails/core';
 import { deriveHttpRoutes } from '@ontrails/http';
 import { Hono } from 'hono';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 const hono = new Hono();
 const routesResult = deriveHttpRoutes(graph, { basePath: '/api' });
@@ -162,9 +251,66 @@ if (routesResult.isErr()) {
   throw routesResult.error; // ValidationError if route collisions are detected
 }
 
+// Project any error onto an HTTP status using the shared error taxonomy.
+// `TrailsError` subclasses (validation, auth, permission, internal, ...) get
+// the documented status; anything else falls back to 500.
+const statusFor = (error: unknown): ContentfulStatusCode =>
+  isTrailsError(error)
+    ? (mapSurfaceError('http', error) as ContentfulStatusCode)
+    : 500;
+
 for (const route of routesResult.value) {
-  const method = route.method.toLowerCase() as 'get' | 'post' | 'delete';
+  const method = route.method.toLowerCase() as
+    | 'delete'
+    | 'get'
+    | 'patch'
+    | 'post'
+    | 'put';
   hono[method](route.path, async (c) => {
+    if (route.inputSource === 'webhook') {
+      const body = await c.req.text();
+      const verified = await route.verifyWebhook?.({
+        body,
+        headers: Object.fromEntries(c.req.raw.headers),
+        method: c.req.method,
+        path: new URL(c.req.url).pathname,
+      });
+      if (verified?.isErr()) {
+        // Route through the taxonomy: PermissionError -> 403, AuthError -> 401,
+        // wrapped InternalError -> 500, etc.
+        return c.json(
+          { error: { message: verified.error?.message } },
+          statusFor(verified.error)
+        );
+      }
+      let payload: unknown;
+      try {
+        payload = body.length === 0 ? {} : JSON.parse(body);
+      } catch {
+        return c.json({ error: { message: 'Invalid JSON in request body' } }, 400);
+      }
+      const parsed = route.parseWebhookInput?.(payload);
+      if (parsed === undefined) {
+        return c.json(
+          { error: { message: 'Webhook route is missing parse handler' } },
+          500
+        );
+      }
+      if (parsed.isErr()) {
+        return c.json(
+          { error: { message: parsed.error?.message } },
+          statusFor(parsed.error)
+        );
+      }
+      const result = await route.execute(parsed.value);
+      return result.isOk()
+        ? c.json({ data: result.value }, 200)
+        : c.json(
+            { error: { message: result.error?.message } },
+            statusFor(result.error)
+          );
+    }
+
     const input =
       route.inputSource === 'query'
         ? Object.fromEntries(new URL(c.req.url).searchParams)
@@ -172,7 +318,10 @@ for (const route of routesResult.value) {
     const result = await route.execute(input);
     return result.isOk()
       ? c.json({ data: result.value }, 200)
-      : c.json({ error: { message: result.error?.message } }, 500);
+      : c.json(
+          { error: { message: result.error?.message } },
+          statusFor(result.error)
+        );
   });
 }
 


### PR DESCRIPTION
## Summary
Document the new universal webhook activation source so contributors and agents have a single page to land on when wiring a webhook into a Trails app.

## What changed
- New webhook connector section in `docs/surfaces/http.md` covering `webhookSource`, the `verify` hook, shared-route fan-out, and Warden's collision rule.
- Cross-references added to `docs/api-reference.md`, `docs/index.md`, and `docs/lexicon.md`.

## Stack
Documentation companion to #347–#350.

## Linear
https://linear.app/outfitter/issue/TRL-495/docs-add-webhook-connector-guide-around-universal-source