### PR TITLE
test(store): pin late-bound signal handles

### DIFF
--- a/packages/store/src/__tests__/store.test.ts
+++ b/packages/store/src/__tests__/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { ValidationError } from '@ontrails/core';
+import { getLateBoundSignalRef, ValidationError } from '@ontrails/core';
 import { z } from 'zod';
 
 import type {
@@ -218,6 +218,47 @@ describe('@ontrails/store', () => {
     expectNormalizedGistTable(table);
     expect(db.get('users')).toBe(db.tables.users);
     expectDerivedSchemas(table);
+  });
+
+  test('marks pre-bind table signal handles as store-derived late-bound refs', () => {
+    const db = createStoreDefinition();
+    const { created, removed, updated } = db.tables.gists.signals;
+
+    expect(getLateBoundSignalRef(created)).toMatchObject({
+      kind: 'store-derived',
+    });
+    expect(getLateBoundSignalRef(updated)).toMatchObject({
+      kind: 'store-derived',
+    });
+    expect(getLateBoundSignalRef(removed)).toMatchObject({
+      kind: 'store-derived',
+    });
+    expect(getLateBoundSignalRef(created)?.token).not.toBe(
+      getLateBoundSignalRef(updated)?.token
+    );
+    expect(getLateBoundSignalRef(created)?.token).not.toBe(
+      getLateBoundSignalRef(removed)?.token
+    );
+    expect(getLateBoundSignalRef(updated)?.token).not.toBe(
+      getLateBoundSignalRef(removed)?.token
+    );
+
+    expect(
+      created.payload.parse({
+        createdAt: '2026-04-03T12:00:00.000Z',
+        id: 'gist-1',
+        ownerId: 'user-1',
+        updatedAt: '2026-04-03T12:00:00.000Z',
+      })
+    ).toEqual({
+      createdAt: '2026-04-03T12:00:00.000Z',
+      description: null,
+      id: 'gist-1',
+      isPublic: true,
+      ownerId: 'user-1',
+      tags: [],
+      updatedAt: '2026-04-03T12:00:00.000Z',
+    });
   });
 
   test('accepts an explicit backend-agnostic kind', () => {
@@ -535,5 +576,8 @@ describe('bindStoreDefinition', () => {
     expect(bound.tables.gists.signals.created.id).toBe('primary:gists.created');
     expect(bound.tables.gists.signals.updated.id).toBe('primary:gists.updated');
     expect(bound.tables.gists.signals.removed.id).toBe('primary:gists.removed');
+    expect(getLateBoundSignalRef(bound.tables.gists.signals.created)).toBe(
+      getLateBoundSignalRef(definition.tables.gists.signals.created)
+    );
   });
 });


### PR DESCRIPTION
## Summary
Add focused tests pinning the contract for late-bound signal handles in `@ontrails/store`: handles created before a store is bound resolve to the bound store's scoped signal, and the late-binding path stays observable in tests.

## What changed
- New cases in `packages/store/src/__tests__/store.test.ts` exercising pre-bind handle creation, post-bind resolution, and identity stability across the bind boundary.

## Stack
First of four `@ontrails/store` signal-identity test PRs (#353–#356). The accepted ADR lands in #358.

## Linear
https://linear.app/outfitter/issue/TRL-434/pre-bind-signal-handles-as-late-bound-references