### PR TITLE
test(store): reject ambiguous pre-bind signals

### DIFF
--- a/packages/store/src/__tests__/jsonfile.test.ts
+++ b/packages/store/src/__tests__/jsonfile.test.ts
@@ -499,4 +499,35 @@ describe('jsonfile connector — topo integration', () => {
       'primary-store:items.created'
     );
   });
+
+  test('rejects unresolved pre-bind handles when the same store is bound twice', () => {
+    const definition = defineStore({
+      items: { identity: 'id', schema: itemSchema },
+    });
+    const billing = jsonFile(definition, {
+      dir: join(topoDir, 'billing'),
+      id: 'billing',
+    });
+    const identity = jsonFile(definition, {
+      dir: join(topoDir, 'identity'),
+      id: 'identity',
+    });
+    const onCreated = trail('items.on-created', {
+      blaze: () => Result.ok({ seen: true }),
+      description:
+        'Consumer that must choose a scoped store signal when bindings are ambiguous.',
+      input: z.object({}).passthrough(),
+      on: [definition.tables.items.signals.created],
+    });
+
+    expect(() =>
+      topo('jsonfile-ambiguous-store-app', {
+        billing,
+        identity,
+        onCreated,
+      } as Record<string, unknown>)
+    ).toThrow(
+      'Trail "items.on-created" references late-bound signal "items.created" but it resolves to multiple bound resource signals'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
Pin the failure mode for ambiguous pre-bind signal handles: when a store is bound and the late-bound handle cannot be unambiguously resolved, the store should reject rather than silently pick one.

## What changed
- New test cases in `packages/store/src/__tests__/jsonfile.test.ts` covering the unresolved-handle rejection path on bind.

## Stack
Builds on #353. Continued in #355–#357; the migration note and accepted ADR land in #358.

## Linear
https://linear.app/outfitter/issue/TRL-435/reject-unresolved-pre-bind-handles-when-a-store-is-bound