### PR TITLE
test(store): pin scoped signal registration

### DIFF
--- a/packages/store/src/__tests__/jsonfile.test.ts
+++ b/packages/store/src/__tests__/jsonfile.test.ts
@@ -450,7 +450,7 @@ describe('jsonfile connector', () => {
   });
 });
 
-describe('jsonfile connector — topo integration', () => {
+describe('signal registration', () => {
   let topoDir: string;
 
   beforeEach(async () => {
@@ -477,6 +477,24 @@ describe('jsonfile connector — topo integration', () => {
     });
     return { onCreated, storeResource };
   };
+
+  test('injects the resource scope into registered store signal ids', () => {
+    const storeResource = jsonFile(itemStore, {
+      dir: topoDir,
+      id: 'primary-store',
+    });
+
+    expect(itemStore.signals.map((candidate) => candidate.id)).toEqual([
+      'items.created',
+      'items.updated',
+      'items.removed',
+    ]);
+    expect(storeResource.signals?.map((candidate) => candidate.id)).toEqual([
+      'primary-store:items.created',
+      'primary-store:items.updated',
+      'primary-store:items.removed',
+    ]);
+  });
 
   test('topo construction does not throw for on: with scoped store signal', () => {
     const { onCreated, storeResource } = scopedSetup(topoDir);


### PR DESCRIPTION
## Summary
Test that scope is injected into live signal registration at bind time, so a store-scoped signal carries the resource scope all the way through to the topo, not just at first declaration.

## What changed
- Additional cases in `packages/store/src/__tests__/jsonfile.test.ts` asserting scope injection on live signal registration.

## Stack
Builds on #354. Followed by #356 which updates `store.test.ts` expectations to match the bound, scoped IDs.

## Linear
https://linear.app/outfitter/issue/TRL-439/wire-scope-injection-into-live-signal-registration-at-bind-time