### PR TITLE
test(store): expect bound scoped signal ids

### DIFF
--- a/packages/store/src/__tests__/store.test.ts
+++ b/packages/store/src/__tests__/store.test.ts
@@ -573,6 +573,11 @@ describe('bindStoreDefinition', () => {
 
   test('accepts valid scopes and scopes store signal ids', () => {
     const bound = bindStoreDefinition(definition, 'primary');
+    expect(bound.signals.map((candidate) => candidate.id)).toEqual([
+      'primary:gists.created',
+      'primary:gists.updated',
+      'primary:gists.removed',
+    ]);
     expect(bound.tables.gists.signals.created.id).toBe('primary:gists.created');
     expect(bound.tables.gists.signals.updated.id).toBe('primary:gists.updated');
     expect(bound.tables.gists.signals.removed.id).toBe('primary:gists.removed');


### PR DESCRIPTION
## Summary
Update `packages/store/src/__tests__/store.test.ts` expectations from bare scoped IDs to the bound, fully-qualified scoped IDs the store now emits — closing the loop on the scope-injection work in #355.

## What changed
- Five new assertions in `store.test.ts` pinning the bound scoped signal ID format.

## Stack
Builds on #355. #357 carries the same expectation through the dogfood apps.

## Linear
https://linear.app/outfitter/issue/TRL-436/update-storetestts-expectations-from-bare-scoped-ids