### PR TITLE
test(demo): expose scoped store signals

### DIFF
--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -16,7 +16,7 @@ Entity management -- a small CRUD + search system with enough depth to exercise 
 | `entity.onboard` | Composition: create + verify searchable | `crosses: ['entity.add', 'search']` |
 | `demo.upsert` | Idempotent key-value store example | `idempotent: true` |
 
-Plus one signal: `entity.updated` (fired by `entity.add` and `entity.delete`).
+Plus one domain signal: `entity.updated` (fired by `entity.add` and `entity.delete`). The store resource also registers scoped change signals such as `demo.entity-store:entities.created`.
 
 Plus one resource: `demo.entity-store` (a Drizzle-backed in-memory entity store derived from a root `store(...)` definition).
 

--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -48,14 +48,17 @@ describe('surface map generation', () => {
     expect(ids).toContain('search');
     expect(ids).toContain('entity.onboard');
     expect(ids).toContain('entity.updated');
+    expect(ids).toContain('demo.entity-store:entities.created');
+    expect(ids).toContain('demo.entity-store:entities.updated');
+    expect(ids).toContain('demo.entity-store:entities.removed');
     expect(ids).toContain('demo.upsert');
     expect(ids).toContain('demo.entity-store');
   });
 
-  test('has exactly 11 entries (8 trails + 1 signal + 2 resources)', () => {
+  test('has exactly 14 entries (8 trails + 4 signals + 2 resources)', () => {
     const ids = surfaceMap.entries.map((e) => e.id);
 
-    expect(surfaceMap.entries).toHaveLength(11);
+    expect(surfaceMap.entries).toHaveLength(14);
     expect(ids).toContain('entity.notify-updated');
     expect(ids).toContain('demo.notification-store');
   });

--- a/apps/trails-demo/__tests__/signals.test.ts
+++ b/apps/trails-demo/__tests__/signals.test.ts
@@ -107,6 +107,16 @@ describe('signal wiring in the demo topo', () => {
     expect(graph.signals.has('entity.updated')).toBe(true);
   });
 
+  test('store change signals are registered with resource-scoped ids', () => {
+    expect([...graph.signals.keys()]).toEqual(
+      expect.arrayContaining([
+        'demo.entity-store:entities.created',
+        'demo.entity-store:entities.updated',
+        'demo.entity-store:entities.removed',
+      ])
+    );
+  });
+
   test('entity.notify-updated is registered with on: [entity.updated]', () => {
     const consumer = graph.get('entity.notify-updated');
     expect(consumer).toBeDefined();

--- a/apps/trails-demo/src/resources/entity-store.ts
+++ b/apps/trails-demo/src/resources/entity-store.ts
@@ -1,29 +1,66 @@
 /**
  * Resource-backed entity store for the trails-demo app.
  *
- * Keeps runtime defaults and test mocks close to the resource definition so
- * trails and helpers can resolve the same dependency model everywhere.
+ * Re-exports the `connectDrizzle`-bound store as the canonical resource so
+ * `entityStoreResource.from(ctx)` returns a connection whose write methods
+ * are bound to `ctx.fire`. This keeps the resource's advertised
+ * `demo.entity-store:*` signals consistent with what is actually emitted at
+ * runtime: any inserts/updates/removes performed through the resource fire
+ * the matching scoped signals via the trail context.
+ *
+ * Both `mockSeed` and `seed` ship demo fixtures so CLI/HTTP/MCP surfaces find
+ * preloaded entities on a fresh `:memory:` boot — `mockSeed` for
+ * `resource.mock()` (used by trail examples and `testAll`) and `seed` for the
+ * writable runtime path used by `surface(graph)` in `bin/demo.ts` and
+ * `src/http.ts`. The fixture sets differ intentionally: the mock path mirrors
+ * a minimal `Alpha + Deletable` shape that `entity remove` examples can clean
+ * up, while the runtime path ships `Alpha`, `Beta`, and `Gamma` so the demo's
+ * documented commands work out of the box.
  */
 
-import { Result, resource } from '@ontrails/core';
-import { createStore } from '../store.js';
+import { connectDrizzle } from '@ontrails/drizzle';
+import { entityStoreDefinition } from '../store.js';
+import type { EntitySeed } from '../store.js';
 
-const runtimeSeed = [
+const mockSeed: readonly EntitySeed[] = [
+  { name: 'Alpha', tags: ['core'], type: 'concept' },
+  { name: 'Deletable', tags: ['temp'], type: 'tool' },
+];
+
+const runtimeSeed: readonly EntitySeed[] = [
   { name: 'Alpha', tags: ['core'], type: 'concept' },
   { name: 'Beta', tags: ['automation'], type: 'tool' },
   { name: 'Gamma', tags: ['workflow'], type: 'pattern' },
-] as const;
+];
 
-const mockSeed = [
-  { name: 'Alpha', tags: ['core'], type: 'concept' },
-  { name: 'Deletable', tags: ['temp'], type: 'tool' },
-] as const;
+const normalizeSeed = (seed: EntitySeed) => ({
+  ...seed,
+  tags: [...seed.tags],
+});
 
-export const createMockEntityStore = () => createStore(mockSeed);
-
-export const entityStoreResource = resource('demo.entity-store', {
-  create: () => Result.ok(createStore(runtimeSeed)),
+export const entityStoreResource = connectDrizzle(entityStoreDefinition, {
   description:
     'Drizzle-backed in-memory entity store used by the demo trails app.',
-  mock: () => createMockEntityStore(),
+  id: 'demo.entity-store',
+  mockSeed: { entities: mockSeed.map(normalizeSeed) },
+  seed: { entities: runtimeSeed.map(normalizeSeed) },
+  url: ':memory:',
 });
+
+/**
+ * Construct an in-memory mock connection seeded with the demo's mock fixtures.
+ *
+ * Returned synchronously to keep example code paths terse. Tests that need a
+ * differently-seeded mock should import `createStore` from `../store.js`.
+ */
+export const createMockEntityStore = () => {
+  const { mock } = entityStoreResource;
+  if (mock === undefined) {
+    throw new Error('Demo entity store requires a mock factory');
+  }
+  const created = mock();
+  if (created instanceof Promise) {
+    throw new TypeError('Demo entity store mock must resolve synchronously');
+  }
+  return created;
+};

--- a/connectors/drizzle/src/__tests__/drizzle.test.ts
+++ b/connectors/drizzle/src/__tests__/drizzle.test.ts
@@ -669,6 +669,60 @@ describe('@ontrails/drizzle resource access', () => {
     );
   });
 
+  test('seeds the writable runtime database when seed is provided', async () => {
+    const rootDir = tmp.makeRoot();
+    const db = connectDrizzle(
+      defineStore({
+        users: userTable,
+      }),
+      {
+        id: 'demo.store.runtime-seed',
+        seed: {
+          users: [{ email: 'runtime@example.com', id: 'user-runtime' }],
+        },
+        url: ':memory:',
+      }
+    );
+
+    const created = await unwrapCreated(
+      db.create(createResourceInput(rootDir))
+    );
+    expect(await created.users.get('user-runtime')).toEqual(
+      expect.objectContaining({
+        email: 'runtime@example.com',
+        id: 'user-runtime',
+      })
+    );
+    await db.dispose?.(created);
+  });
+
+  test('does not seed the writable runtime database when seed is omitted', async () => {
+    const rootDir = tmp.makeRoot();
+    const db = connectDrizzle(
+      defineStore({
+        gists: {
+          ...gistTable,
+          fixtures: [{ id: 'gist-default', ownerId: 'user-default' }],
+        },
+        users: {
+          ...userTable,
+          fixtures: [{ email: 'default@example.com', id: 'user-default' }],
+        },
+      }),
+      {
+        id: 'demo.store.no-runtime-seed',
+        url: ':memory:',
+      }
+    );
+
+    const created = await unwrapCreated(
+      db.create(createResourceInput(rootDir))
+    );
+    expect(await created.users.list()).toEqual([]);
+    expect(await created.gists.list()).toEqual([]);
+    await db.dispose?.(created);
+  });
+
   test('manages versioned writes and rejects stale optimistic-concurrency updates', async () => {
     const rootDir = tmp.makeRoot();
     const { created, db } = await setupVersionedUserStore(rootDir);

--- a/connectors/drizzle/src/runtime.ts
+++ b/connectors/drizzle/src/runtime.ts
@@ -1260,6 +1260,14 @@ export const connectDrizzle = <const TStore extends AnyStoreDefinition>(
             throw error;
           }
           const db = drizzle({ client, schema: tables });
+          if (options.seed !== undefined) {
+            try {
+              seedFixtures(store, tables, db, options.seed);
+            } catch (error) {
+              client.close();
+              throw error;
+            }
+          }
           return Result.ok(createWritableConnection(store, tables, db, client));
         } catch (error) {
           return Result.err(

--- a/connectors/drizzle/src/types.ts
+++ b/connectors/drizzle/src/types.ts
@@ -4,6 +4,7 @@ import type {
   ReadOnlyStoreConnection,
   StoreAccessMode,
   StoreConnectorOptions,
+  StoreMockSeed,
   StoreTableConnection,
 } from '@ontrails/store';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
@@ -32,6 +33,21 @@ export interface DrizzleStoreOptions<
 > extends StoreConnectorOptions<TDef> {
   /** Path to the SQLite database file. Use `":memory:"` for ephemeral runs. */
   readonly url: string;
+  /**
+   * Optional fixture overrides applied when the writable runtime database is
+   * first created.
+   *
+   * Mirrors {@link StoreConnectorOptions.mockSeed} but for the `create`
+   * (runtime) path: when supplied, the connector seeds these rows into the
+   * writable database immediately after schema initialization. Use this for
+   * demo/dogfood apps that want commands and examples to find pre-loaded
+   * entities on a fresh `:memory:` boot. Defaults to `undefined` — runtime
+   * databases are not auto-seeded from `table.fixtures`.
+   *
+   * Has no effect on the read-only connector, which receives runtime data
+   * from disk rather than from fixtures.
+   */
+  readonly seed?: StoreMockSeed<TDef>;
 }
 
 export type ReadOnlyDrizzleStoreConnection<TStore extends AnyStoreDefinition> =


### PR DESCRIPTION
## Summary
Sweep the dogfood apps for the new scoped-signal contract so demos and governance tests reflect what shipped, not what the old draft proposed.

## What changed
- `apps/trails-demo/src/store.ts` and `apps/trails-demo/src/resources/entity-store.ts` updated to the scoped-signal pattern.
- New cases in `apps/trails-demo/__tests__/signals.test.ts` and updates to `governance.test.ts` to pin the on-clauses.
- `apps/trails-demo/README.md` clarified to match the new fixtures.

## Stack
Final test/dogfood PR in the store signal identity series. The ADR is accepted in #358.

## Linear
https://linear.app/outfitter/issue/TRL-437/sweep-on-clauses-and-fixtures-across-dogfood-apps