### PR TITLE
docs(adr): accept store signal identity

### DIFF
--- a/docs/adr/0040-resource-scoped-store-signal-identity.md
+++ b/docs/adr/0040-resource-scoped-store-signal-identity.md
@@ -1,14 +1,15 @@
 ---
+id: 40
 slug: resource-scoped-store-signal-identity
 title: Resource-Scoped Store Signal Identity
-status: draft
+status: accepted
 created: 2026-04-19
-updated: 2026-04-19
+updated: 2026-05-02
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [9, 16, 22, 23]
 ---
 
-# ADR: Resource-Scoped Store Signal Identity
+# ADR-0040: Resource-Scoped Store Signal Identity
 
 ## Context
 
@@ -70,6 +71,8 @@ identity.store.tables.users.signals.created.id;
 
 If the same store definition is bound more than once, pre-bind signal handles become ambiguous. In that case the framework rejects the unresolved reference and asks the author to use the canonical scoped id explicitly.
 
+Migration guidance lives in [Store Signal Identity Migration](../store-signal-identity-migration.md).
+
 ## Consequences
 
 ### Positive
@@ -93,7 +96,7 @@ If the same store definition is bound more than once, pre-bind signal handles be
 
 ## References
 
-- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — resources provide the stable binding identity store signals now derive from
-- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — store tables and their reactive surfaces are derived from one authored schema
-- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md) — Drizzle is the first binding surface that needs the scoped signal form
-- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — keeps the signal vocabulary aligned with the current framework grammar
+- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — resources provide the stable binding identity store signals now derive from
+- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — store tables and their reactive surfaces are derived from one authored schema
+- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](0022-drizzle-store-connector.md) — Drizzle is the first binding surface that needs the scoped signal form
+- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — keeps the signal vocabulary aligned with the current framework grammar

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,3 +46,4 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0037](0037-owner-first-authority.md) | Owner-First Authority | Accepted |
 | [0038](0038-typed-signal-emission.md) | Typed Signal Emission | Accepted |
 | [0039](0039-reactive-trail-activation.md) | Reactive Trail Activation | Accepted |
+| [0040](0040-resource-scoped-store-signal-identity.md) | Resource-Scoped Store Signal Identity | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -836,6 +836,11 @@
           "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
         },
         {
+          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — resources provide the stable binding identity store signals now derive from",
+          "from": "0040",
+          "fromPath": "docs/adr/0040-resource-scoped-store-signal-identity.md"
+        },
+        {
           "context": "- [ADR-0009: Resources](../0009-first-class-resources.md) -- the resource primitive that packs scope and compose",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
@@ -854,11 +859,6 @@
           "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — the resource primitive that bundles group and distribute",
           "from": "20260409",
           "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
-        },
-        {
-          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md) — resources provide the stable binding identity store signals now derive from",
-          "from": "20260419",
-          "fromPath": "docs/adr/drafts/20260419-resource-scoped-store-signal-identity.md"
         },
         {
           "context": "- **[ADR-0009: First-Class Resources](./adr/0009-first-class-resources.md)** — Dependency declarations, lifecycle, testing, governance",
@@ -1184,6 +1184,11 @@
           "fromPath": "docs/adr/0032-derivetrail-and-trail-factories.md"
         },
         {
+          "context": "- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — store tables and their reactive surfaces are derived from one authored schema",
+          "from": "0040",
+          "fromPath": "docs/adr/0040-resource-scoped-store-signal-identity.md"
+        },
+        {
           "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) -- the store abstraction that search extends",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
@@ -1192,11 +1197,6 @@
           "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — the store contract that bundle resources satisfy",
           "from": "20260409",
           "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
-        },
-        {
-          "context": "- [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md) — store tables and their reactive surfaces are derived from one authored schema",
-          "from": "20260419",
-          "fromPath": "docs/adr/drafts/20260419-resource-scoped-store-signal-identity.md"
         },
         {
           "context": "- **[ADR-0016: Schema-Derived Persistence](./adr/0016-schema-derived-persistence.md)** — `store()` declaration, connector binding, fixtures",
@@ -1408,14 +1408,14 @@
           "fromPath": "docs/adr/0031-backend-agnostic-store-schemas.md"
         },
         {
+          "context": "- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](0022-drizzle-store-connector.md) — Drizzle is the first binding surface that needs the scoped signal form",
+          "from": "0040",
+          "fromPath": "docs/adr/0040-resource-scoped-store-signal-identity.md"
+        },
+        {
           "context": "- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md) — the first connector, now understood as a single-resource bundle",
           "from": "20260409",
           "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
-        },
-        {
-          "context": "- [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md) — Drizzle is the first binding surface that needs the scoped signal form",
-          "from": "20260419",
-          "fromPath": "docs/adr/drafts/20260419-resource-scoped-store-signal-identity.md"
         },
         {
           "context": "- **[ADR-0022: Drizzle Store Connector](./adr/0022-drizzle-store-connector.md)** — Drizzle binds schema-derived stores to SQLite",
@@ -1467,6 +1467,11 @@
           "fromPath": "docs/adr/0033-detour-execution-for-recovery.md"
         },
         {
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — keeps the signal vocabulary aligned with the current framework grammar",
+          "from": "0040",
+          "fromPath": "docs/adr/0040-resource-scoped-store-signal-identity.md"
+        },
+        {
           "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) -- the lexicon renames; note that `resource` in this ADR refers to the distribution unit, distinct from `resourc",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
@@ -1485,11 +1490,6 @@
           "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — the vocabulary→lexicon rename that this structure codifies",
           "from": "20260406",
           "fromPath": "docs/adr/drafts/20260406-documentation-structure.md"
-        },
-        {
-          "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) — keeps the signal vocabulary aligned with the current framework grammar",
-          "from": "20260419",
-          "fromPath": "docs/adr/drafts/20260419-resource-scoped-store-signal-identity.md"
         },
         {
           "context": "- **[ADR-0023: Simplifying the Trails Lexicon](./adr/0023-simplifying-the-trails-lexicon.md)** — Brand-vs-plain heuristic, four pre-1.0 renames, vocabulary → lexicon",
@@ -2066,6 +2066,25 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Reactive Trail Activation",
+      "updated": "2026-05-02"
+    },
+    {
+      "created": "2026-04-19",
+      "depends_on": ["9", "16", "22", "23"],
+      "inbound": [
+        {
+          "context": "- [ADR-0040: Resource-Scoped Store Signal Identity](./adr/0040-resource-scoped-store-signal-identity.md)",
+          "from": "store-signal-identity-migration",
+          "fromPath": "docs/store-signal-identity-migration.md"
+        }
+      ],
+      "number": "0040",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0040-resource-scoped-store-signal-identity.md",
+      "slug": "resource-scoped-store-signal-identity",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Resource-Scoped Store Signal Identity",
       "updated": "2026-05-02"
     }
   ],

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -34,5 +34,3 @@ Proposed decisions under discussion. Promoted to `docs/adr/` when accepted.
   - depends on [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md), [ADR-0008: Deterministic Surface Derivation](../0008-deterministic-trailhead-derivation.md), [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md)
 - [Unified Observability](20260409-unified-observability.md)
   - depends on [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md), [ADR-0013: Tracing — Runtime Recording Primitive](../0013-tracing.md)
-- [Resource-Scoped Store Signal Identity](20260419-resource-scoped-store-signal-identity.md)
-  - depends on [ADR-0009: First-Class Resources](../0009-first-class-resources.md), [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md), [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md), [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md)

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -244,19 +244,6 @@
       "superseded_by": null,
       "title": "Unified Observability",
       "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-04-19",
-      "depends_on": ["9", "16", "22", "23"],
-      "inbound": [],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260419-resource-scoped-store-signal-identity.md",
-      "slug": "resource-scoped-store-signal-identity",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Resource-Scoped Store Signal Identity",
-      "updated": "2026-04-19"
     }
   ],
   "version": 1

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@
 - **[API Reference](./api-reference.md)** — Every public export across all packages
 - **[Resources Guide](./resources.md)** — Define resources, declare them on trails, test with mock factories
 - **[Store Guide](../packages/store/README.md)** — Declare schema-derived stores, bind them with Drizzle, use fixtures and read-only access
+- **[Store Signal Identity Migration](./store-signal-identity-migration.md)** — Update store-derived signal ids from bare table changes to resource-scoped form
 - **[Config Guide](../packages/config/README.md)** — Schema-derived configuration, resolution stack, extensions, profiles
 - **[Permits Guide](../packages/permits/README.md)** — Scope-based authorization, auth connectors, permit governance
 - **[Tracing Guide](../packages/tracing/README.md)** — Execution recording, sinks, sampling, manual instrumentation

--- a/docs/store-signal-identity-migration.md
+++ b/docs/store-signal-identity-migration.md
@@ -1,0 +1,88 @@
+# Store Signal Identity Migration
+
+Store-derived change signals now get their canonical identity from the resource
+that binds the store. Authored store definitions still expose typed pre-bind
+handles, but those handles are references. They are not the final external
+signal ids.
+
+## What Changed
+
+Before binding, a table signal handle still looks table-local:
+
+```typescript
+const created = definition.tables.users.signals.created;
+
+created.id;
+// "users.created"
+```
+
+After a connector binds the store to a resource, the canonical id includes the
+resource scope:
+
+```typescript
+const identity = connectDrizzle(definition, {
+  id: 'identity',
+  url: ':memory:',
+});
+
+identity.store.tables.users.signals.created.id;
+// "identity:users.created"
+```
+
+The scoped form is the only stable external identity for topo output, signal
+lookups, persisted graph rows, and string-based `on:` declarations.
+
+## How To Migrate
+
+If a trail uses the typed pre-bind handle and the store is bound once in the
+same topo, no code change is needed:
+
+```typescript
+trail('users.notify', {
+  on: [definition.tables.users.signals.created],
+  blaze: (input) => Result.ok(input),
+});
+```
+
+Topo assembly resolves that handle to the bound signal id.
+
+If the same store definition is bound more than once, update the trail to use
+the scoped id that names the intended resource:
+
+```typescript
+trail('users.notify-identity', {
+  on: ['identity:users.created'],
+  blaze: (input) => Result.ok(input),
+});
+```
+
+If an app wraps a connector resource in a custom resource, carry the connector
+signals onto the wrapper so the topo can see the scoped store signals:
+
+```typescript
+const bound = connectDrizzle(definition, {
+  id: 'demo.entity-store',
+  url: ':memory:',
+});
+
+export const entityStoreResource = resource('demo.entity-store', {
+  create: () => Result.ok(createConnection()),
+  mock: () => createMockConnection(),
+  signals: bound.signals,
+});
+```
+
+Update tests, fixtures, and documentation that assert signal ids from bare
+`table.change` strings to scoped `<resource>:<table>.<change>` strings once the
+store is bound.
+
+## Validation Notes
+
+Resource ids used as store signal scopes cannot contain `:` or whitespace. A
+store definition bound twice cannot resolve a pre-bind handle implicitly; Trails
+rejects the ambiguity and asks for an explicit scoped id.
+
+## References
+
+- [ADR-0040: Resource-Scoped Store Signal Identity](./adr/0040-resource-scoped-store-signal-identity.md)
+- [Store Guide](../packages/store/README.md)

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -146,6 +146,8 @@ created.id;
 
 Writable bindings fire those canonical scoped signals automatically when you access the resource through `db.from(ctx)` inside a trail context.
 
+See [Store Signal Identity Migration](../../docs/store-signal-identity-migration.md) when updating existing `on:` clauses, surface-map fixtures, or custom resource wrappers from bare ids to scoped ids.
+
 Tabular connectors such as `@ontrails/drizzle` also expose `insert()` and `update()` as convenience methods when the backend natively distinguishes create and patch operations.
 
 ## Fixtures and mocks


### PR DESCRIPTION
## Summary
Accept the resource-scoped store signal identity ADR (now `docs/adr/0040-...`) and ship a migration note for apps that were on the old bare-ID model. This codifies the contract the test PRs (#353–#357) have been pinning.

## What changed
- Draft ADR promoted to `docs/adr/0040-resource-scoped-store-signal-identity.md`.
- ADR README, root `decision-map.json`, and drafts index updated; the draft entry is removed from the drafts decision map.
- New `docs/store-signal-identity-migration.md` walks through what changes for app authors.
- `docs/index.md` and `packages/store/README.md` cross-link to the migration note.

## Stack
Closes the store-signal-identity sub-stack (#353–#357).

## Linear
https://linear.app/outfitter/issue/TRL-438/promote-the-adr-to-accepted-and-write-migration-note