### PR TITLE
feat(core): define activation trace records

### DIFF
--- a/connectors/hono/src/__tests__/surface.test.ts
+++ b/connectors/hono/src/__tests__/surface.test.ts
@@ -3,11 +3,14 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import {
   PermissionError,
   Result,
+  clearTraceSink,
   getWebhookHeader,
+  registerTraceSink,
   trail,
   topo,
   webhook,
 } from '@ontrails/core';
+import type { TraceRecord, TraceSink } from '@ontrails/core';
 import { z } from 'zod';
 
 import { createApp, surface } from '../surface.js';
@@ -83,6 +86,12 @@ const emptyWebhookTrail = trail('webhook.empty.receive', {
   input: z.object({}),
   on: [emptyWebhook],
   output: z.object({ ok: z.boolean() }),
+});
+
+const createCapturingSink = (records: TraceRecord[]): TraceSink => ({
+  write(record) {
+    records.push(record);
+  },
 });
 
 describe('surface API (Hono connector)', () => {
@@ -284,6 +293,38 @@ describe('surface API (Hono connector)', () => {
         message: 'Invalid webhook secret',
       },
     });
+  });
+
+  test('webhook verification failures emit invalid activation trace records', async () => {
+    const records: TraceRecord[] = [];
+    const graph = topo('surface-api', { paymentWebhookTrail });
+    const app = createApp(graph);
+    registerTraceSink(createCapturingSink(records));
+
+    try {
+      const response = await app.request('/webhooks/payment', {
+        body: JSON.stringify({ paymentId: 'pay_1' }),
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Secret': 'wrong',
+        },
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(403);
+      expect(
+        records.find(
+          (record) =>
+            record.kind === 'activation' &&
+            record.name === 'activation.webhook.invalid'
+        )
+      ).toMatchObject({
+        errorCategory: 'permission',
+        status: 'err',
+      });
+    } finally {
+      clearTraceSink();
+    }
   });
 
   test('webhook payload validation failures return 400', async () => {

--- a/docs/adr/drafts/20260409-unified-observability.md
+++ b/docs/adr/drafts/20260409-unified-observability.md
@@ -52,7 +52,7 @@ The `Logger` interface is already in core. The following join it:
 
 - **Default console logger.** Structured logging to stdout with no configuration. Available on `ctx.logger` automatically.
 - **Built-in tracing.** Automatic execution recording for every trail invocation, intrinsic to the `executeTrail` pipeline. Records which trail ran, how long, what result, what errors, which crossings happened, trace ID propagation. Not an optional layer the developer attaches — it just happens.
-- **Trace record data model.** The `TraceRecord` interface describing one recorded execution footprint. The developer-facing word is "trace" (as verb and noun). The internal type is `TraceRecord` to avoid overloading "trace" (which can mean one record or an entire execution tree in industry usage).
+- **Trace record data model.** The `TraceRecord` interface describing one recorded execution footprint. The developer-facing word is "trace" (as verb and noun). The internal type is `TraceRecord` to avoid overloading "trace" (which can mean one record or an entire execution tree in industry usage). Records can describe trail execution, manual spans, signal lifecycle points, or activation boundaries.
 - **Memory trace sink.** In-memory trace storage, sufficient for development and `trails run --trace`.
 - **`ctx.trace()` method.** Manual sub-step recording within a blaze, replacing `tracker.from(ctx).track()`.
 
@@ -95,6 +95,26 @@ The API is callback-based to guarantee closure. No raw `start` / `end` pair. Str
 This is not an attached layer or gate. It is intrinsic to `executeTrail`. The developer does not install it, configure it, or opt into it. Every trail execution is recorded.
 
 Storage stays flat. Each `TraceRecord` is an independent row with explicit lineage (`traceId`, `rootId`, `parentId`). Tree rendering happens at query time. Storage, retention, and export stay simple.
+
+### Activation trace record contract
+
+Activation uses a documented mix:
+
+- Activated trail and signal records carry `trails.activation.*` provenance attributes.
+- Runtime activation boundaries also emit `kind: "activation"` trace records when a real sink is installed.
+- Boundary records parent the trail they activate when the materializer owns the trigger, such as schedule ticks and webhook delivery.
+- Safety records capture activation that was intentionally suppressed before another trail could run.
+
+The initial activation record names are:
+
+| Record name | Meaning |
+| --- | --- |
+| `activation.scheduled` | A schedule materializer received a tick for a declared schedule source. |
+| `activation.webhook` | The HTTP surface accepted a webhook source and invoked the receiving trail. |
+| `activation.webhook.invalid` | A webhook source failed payload parsing before any receiving trail ran. |
+| `activation.cycle_detected` | Signal fan-out safety suppressed a cyclic or over-depth activation chain. |
+
+This keeps activation visible in traces even when no normal trail record exists, while avoiding a second event model beside `TraceRecord`. Activation records use the same flat lineage fields, status vocabulary, and sink path as trail, span, and signal records.
 
 ### Production observability in `@ontrails/observe`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -427,7 +427,7 @@ createPermitForTrail(trail)          // create a permit matching a trail's requi
 
 ## `@ontrails/tracing`
 
-Tracing is intrinsic in `executeTrail`. With a real sink installed, a trail execution writes a root `TraceRecord`, `ctx.trace(label, fn)` writes child spans, and typed signal fan-out records `signal.*` lifecycle entries. With `NOOP_SINK`, `executeTrail` short-circuits the tracing allocation path and `ctx.trace(label, fn)` stays a passthrough.
+Tracing is intrinsic in `executeTrail`. With a real sink installed, a trail execution writes a root `TraceRecord`, `ctx.trace(label, fn)` writes child spans, typed signal fan-out records `signal.*` lifecycle entries, and activation materializers record `activation.*` boundary entries. With `NOOP_SINK`, `executeTrail` short-circuits the tracing allocation path and `ctx.trace(label, fn)` stays a passthrough.
 
 ```typescript
 // Sink registration (from @ontrails/core and re-exported from @ontrails/tracing)
@@ -437,6 +437,10 @@ clearTraceSink()                     // revert to the default no-op sink
 NOOP_SINK                            // stable disabled-tracing sentinel
 TRACE_CONTEXT_KEY                    // context extensions key for the active trace context
 createTraceRecord(options)           // construct a root or child TraceRecord explicitly
+
+// Activation boundary helpers (from @ontrails/core and re-exported from @ontrails/tracing)
+createActivationTraceRecord(name, options?) // construct an activation boundary TraceRecord
+writeActivationTraceRecord(name, attrs, status?, category?, parent?) // write an activation boundary TraceRecord
 
 // Signal lifecycle helpers (from @ontrails/tracing)
 createSignalTraceRecord(parent, name, attrs?) // construct a signal lifecycle TraceRecord

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -14,7 +14,7 @@
 
 **Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. `authLayer` extracts credentials from surface-specific sources, `AuthConnector` resolves them to a `Permit` (identity, scopes, roles), and scope enforcement rejects unauthorized access. Includes JWT connector, governance rules (`validatePermits`), and test helpers through `@ontrails/permits/testing`.
 
-**Tracing (intrinsic in `@ontrails/core`, sinks in `@ontrails/tracing`).** With a real sink installed, `executeTrail` produces a `TraceRecord` automatically and `ctx.trace(label, fn)` records nested spans inside a trail blaze. With `NOOP_SINK`, the tracing path short-circuits without layer attachment or per-trail wiring. Pluggable sinks register via `registerTraceSink()`: `createMemorySink` for testing, `createDevStore` for local development, `createOtelConnector` for production OpenTelemetry export. Sampling configuration controls recording volume.
+**Tracing (intrinsic in `@ontrails/core`, sinks in `@ontrails/tracing`).** With a real sink installed, `executeTrail` produces a `TraceRecord` automatically, `ctx.trace(label, fn)` records nested spans inside a trail blaze, and activation materializers record `activation.*` boundary entries. With `NOOP_SINK`, the tracing path short-circuits without layer attachment or per-trail wiring. Pluggable sinks register via `registerTraceSink()`: `createMemorySink` for testing, `createDevStore` for local development, `createOtelConnector` for production OpenTelemetry export. Sampling configuration controls recording volume.
 
 ## Mid-term (v1.3+)
 

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -276,7 +276,7 @@ A named config set for a deployment environment. "Dev profile, staging profile, 
 
 ### `tracing` / `TraceRecord`
 
-Automatic execution recording. Tracing is intrinsic to the execution pipeline. The internal record type is `TraceRecord`; the developer-facing word is just "trace."
+Automatic execution recording. Tracing is intrinsic to the execution pipeline. The internal record type is `TraceRecord`; records can describe trail execution, spans, signal lifecycle entries, and activation boundaries. The developer-facing word is just "trace."
 
 ```typescript
 const result = await ctx.trace('db.query', async () => {

--- a/packages/core/src/__tests__/fire.test.ts
+++ b/packages/core/src/__tests__/fire.test.ts
@@ -696,6 +696,23 @@ const expectConsumerCrossAttribution = (
 const signalTraceRecords = (records: readonly TraceRecord[]): TraceRecord[] =>
   records.filter((record) => record.kind === 'signal');
 
+const activationTraceRecords = (
+  records: readonly TraceRecord[]
+): TraceRecord[] => records.filter((record) => record.kind === 'activation');
+
+const findActivationTraceRecord = (
+  records: readonly TraceRecord[],
+  name: string
+): TraceRecord => {
+  const record = activationTraceRecords(records).find(
+    (entry) => entry.name === name
+  );
+  if (!record) {
+    throw new Error(`Expected activation trace record "${name}"`);
+  }
+  return record;
+};
+
 const findSignalTraceRecord = (
   records: readonly TraceRecord[],
   name: string,
@@ -1948,6 +1965,39 @@ describe('fire', () => {
           signalId: 'loop.a',
         }),
       ]);
+    });
+
+    test('cycle suppression records an activation safety trace event', async () => {
+      const records: TraceRecord[] = [];
+      const invocations: string[] = [];
+      const app = createCycleScenario(invocations);
+      registerTraceSink(createCapturingSink(records));
+
+      try {
+        const result = await run(app, 'loop.producer', { id: 'loop-1' });
+
+        expect(result.isOk()).toBe(true);
+        const guard = findActivationTraceRecord(
+          records,
+          'activation.cycle_detected'
+        );
+        const consumerB = findTrailRecord(records, 'loop.consumer.b');
+        expect(guard.parentId).toBe(consumerB.id);
+        expect(guard.traceId).toBe(consumerB.traceId);
+        expect(guard.rootId).toBe(consumerB.rootId);
+        expect(guard.status).toBe('ok');
+        expect(guard.attrs['trails.activation.fire_id']).toBeString();
+        expect(guard.attrs).toMatchObject({
+          'trails.activation.guard.fire_stack': 'loop.a,loop.b',
+          'trails.activation.guard.reason': 'cycle',
+          'trails.activation.source.id': 'loop.a',
+          'trails.activation.source.kind': 'signal',
+          'trails.activation.source.producer_trail.id': 'loop.consumer.b',
+          'trails.signal.id': 'loop.a',
+        });
+      } finally {
+        clearTraceSink();
+      }
     });
 
     test('does not emit suppression debug logs for ordinary fan-out', async () => {

--- a/packages/core/src/__tests__/schedule-runtime.test.ts
+++ b/packages/core/src/__tests__/schedule-runtime.test.ts
@@ -11,6 +11,8 @@ import type {
 } from '../schedule-runtime.js';
 import { createTrailContext } from '../context.js';
 import { ValidationError } from '../errors.js';
+import { clearTraceSink, registerTraceSink } from '../internal/tracing.js';
+import type { TraceRecord, TraceSink } from '../internal/tracing.js';
 import { Result } from '../result.js';
 import { resource } from '../resource.js';
 import { createScheduleRuntime } from '../schedule-runtime.js';
@@ -62,6 +64,24 @@ const createFakeCron = (): {
 
 const scheduleRuntimeId = (name: string): string =>
   `schedule.runtime.${name}.${Bun.randomUUIDv7()}`;
+
+const createCapturingSink = (records: TraceRecord[]): TraceSink => ({
+  write(record) {
+    records.push(record);
+  },
+});
+
+const findTraceRecord = (
+  records: readonly TraceRecord[],
+  predicate: (record: TraceRecord) => boolean,
+  label: string
+): TraceRecord => {
+  const record = records.find(predicate);
+  if (record === undefined) {
+    throw new Error(`Expected ${label} trace record`);
+  }
+  return record;
+};
 
 describe('createScheduleRuntime()', () => {
   test('keeps topo construction and runtime creation inert until start', async () => {
@@ -178,6 +198,58 @@ describe('createScheduleRuntime()', () => {
     });
   });
 
+  test('scheduled runs emit activation trace records parented to trail execution', async () => {
+    const fakeCron = createFakeCron();
+    const records: TraceRecord[] = [];
+    const worker = trail('provenance.trace', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      on: [
+        schedule('schedule.provenance.trace', {
+          cron: '0 3 * * *',
+          timezone: 'UTC',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const graph = topo('schedule-provenance-trace', { worker });
+    const runtime = createScheduleRuntime(graph, { cron: fakeCron.factory });
+    registerTraceSink(createCapturingSink(records));
+
+    try {
+      await runtime.start();
+      await fakeCron.entries[0]?.trigger();
+
+      const activation = findTraceRecord(
+        records,
+        (entry) =>
+          entry.kind === 'activation' && entry.name === 'activation.scheduled',
+        'activation.scheduled'
+      );
+      const trailRecord = findTraceRecord(
+        records,
+        (entry) =>
+          entry.kind === 'trail' && entry.trailId === 'provenance.trace',
+        'provenance.trace'
+      );
+      expect(trailRecord.parentId).toBe(activation.id);
+      expect(trailRecord.traceId).toBe(activation.traceId);
+      expect(trailRecord.rootId).toBe(activation.rootId);
+      expect(activation.attrs).toMatchObject({
+        'trails.activation.source.cron': '0 3 * * *',
+        'trails.activation.source.id': 'schedule.provenance.trace',
+        'trails.activation.source.kind': 'schedule',
+        'trails.activation.source.timezone': 'UTC',
+        'trails.activation.target_trail.id': 'provenance.trace',
+      });
+      expect(trailRecord.attrs['trails.activation.fire_id']).toBe(
+        activation.attrs['trails.activation.fire_id']
+      );
+    } finally {
+      clearTraceSink();
+    }
+  });
+
   test('stop cancels cron handles and ignores ticks after stop', async () => {
     const fakeCron = createFakeCron();
     const seenInputs: unknown[] = [];
@@ -282,6 +354,9 @@ describe('createScheduleRuntime()', () => {
 
     expect(started.isOk()).toBe(true);
     expect(stopped.isErr()).toBe(true);
+    if (!stopped.isErr()) {
+      return;
+    }
     expect(stopped.error.message).toBe('Schedule runtime stop failed');
     expect(stopped.error.cause).toBeInstanceOf(Error);
     expect((stopped.error.cause as Error | undefined)?.message).toBe(
@@ -471,6 +546,52 @@ describe('createScheduleRuntime()', () => {
       'where_error',
       'where_false',
     ]);
+  });
+
+  test('does not emit activation.scheduled trace when where predicate skips the run', async () => {
+    const fakeCron = createFakeCron();
+    const records: TraceRecord[] = [];
+    const skipped = trail('where.trace.skipped', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      on: [
+        {
+          source: schedule('schedule.where.trace.false', { cron: '* * * * *' }),
+          where: () => false,
+        },
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const broken = trail('where.trace.broken', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      on: [
+        {
+          source: schedule('schedule.where.trace.error', { cron: '* * * * *' }),
+          where: () => {
+            throw new Error('where exploded');
+          },
+        },
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const graph = topo('where-trace', { broken, skipped });
+    const runtime = createScheduleRuntime(graph, { cron: fakeCron.factory });
+    registerTraceSink(createCapturingSink(records));
+
+    try {
+      await runtime.start();
+      await fakeCron.entries[0]?.trigger();
+      await fakeCron.entries[1]?.trigger();
+
+      const activationTraces = records.filter(
+        (entry) =>
+          entry.kind === 'activation' && entry.name === 'activation.scheduled'
+      );
+      expect(activationTraces).toHaveLength(0);
+    } finally {
+      clearTraceSink();
+    }
   });
 
   test('passes execution options through the normal run pipeline', async () => {

--- a/packages/core/src/__tests__/tracing.test.ts
+++ b/packages/core/src/__tests__/tracing.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import {
+  clearTraceSink,
+  registerTraceSink,
+  writeActivationTraceRecord,
+} from '../internal/tracing';
+import type { TraceSink } from '../internal/tracing';
+
+afterEach(() => {
+  clearTraceSink();
+});
+
+describe('writeActivationTraceRecord', () => {
+  test('returns the written record when the sink accepts it', async () => {
+    const writes: unknown[] = [];
+    const sink: TraceSink = {
+      write(record) {
+        writes.push(record);
+      },
+    };
+    registerTraceSink(sink);
+
+    const record = await writeActivationTraceRecord(
+      'activation.webhook',
+      { 'trails.activation.target_trail.id': 'demo' },
+      'ok'
+    );
+
+    expect(record).toBeDefined();
+    expect(writes).toHaveLength(1);
+    expect(record?.name).toBe('activation.webhook');
+  });
+
+  test('returns undefined when the sink synchronously throws', async () => {
+    const sink: TraceSink = {
+      write() {
+        throw new Error('synchronous sink failure');
+      },
+    };
+    registerTraceSink(sink);
+
+    const record = await writeActivationTraceRecord(
+      'activation.webhook',
+      { 'trails.activation.target_trail.id': 'demo' },
+      'ok'
+    );
+
+    // Caller must not adopt the record as a parent trace context when the
+    // sink dropped it -- doing so would create a child span that points at
+    // an activation record that never reached storage.
+    expect(record).toBeUndefined();
+  });
+
+  test('returns undefined when the sink asynchronously rejects', async () => {
+    const sink: TraceSink = {
+      write() {
+        return Promise.reject(new Error('async sink failure'));
+      },
+    };
+    registerTraceSink(sink);
+
+    const record = await writeActivationTraceRecord(
+      'activation.webhook',
+      { 'trails.activation.target_trail.id': 'demo' },
+      'ok'
+    );
+
+    expect(record).toBeUndefined();
+  });
+
+  test('defaults sampled to true on parentless activation records', async () => {
+    const writes: unknown[] = [];
+    const sink: TraceSink = {
+      write(record) {
+        writes.push(record);
+      },
+    };
+    registerTraceSink(sink);
+
+    const record = await writeActivationTraceRecord(
+      'activation.webhook',
+      { 'trails.activation.target_trail.id': 'demo' },
+      'ok'
+    );
+
+    // Without a parent context, the activation record is the root span. It
+    // must carry sampled=true so child trail records (which derive sampled
+    // via traceContextFromRecord, defaulting to true) stay consistent with
+    // their activation parent. Otherwise filters/exporters that gate on the
+    // activation boundary's sampled flag drop the entire trace tree.
+    expect(record?.sampled).toBe(true);
+    expect(writes).toHaveLength(1);
+    const written = writes[0] as { sampled?: boolean };
+    expect(written.sampled).toBe(true);
+  });
+
+  test('inherits sampled from parent when provided', async () => {
+    const writes: unknown[] = [];
+    const sink: TraceSink = {
+      write(record) {
+        writes.push(record);
+      },
+    };
+    registerTraceSink(sink);
+
+    const record = await writeActivationTraceRecord(
+      'activation.webhook',
+      { 'trails.activation.target_trail.id': 'demo' },
+      'ok',
+      undefined,
+      {
+        rootId: 'root-1',
+        sampled: false,
+        spanId: 'span-1',
+        traceId: 'trace-1',
+      }
+    );
+
+    expect(record?.sampled).toBe(false);
+  });
+});

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -337,6 +337,7 @@ const buildTracedContext = (
     parentId: parent?.spanId,
     permit: extractPermit(ctx),
     rootId: parent?.rootId,
+    sampled: parent?.sampled ?? true,
     traceId: parent?.traceId,
     trailId: trail.id,
     trailhead: ctx.extensions?.[SURFACE_KEY] as TraceRecord['trailhead'],
@@ -354,7 +355,7 @@ const buildTracedContext = (
   // traceId/rootId carry forward and only spanId advances to the new record.
   const rootTrace: TraceContext = {
     rootId: parent?.rootId ?? record.id,
-    sampled: true,
+    sampled: recordWithAttrs.sampled ?? true,
     spanId: recordWithAttrs.id,
     traceId: recordWithAttrs.traceId,
   };

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -43,6 +43,7 @@ import {
   getTraceContext,
   getTraceSink,
   isTracingDisabled,
+  writeActivationTraceRecord,
   writeSignalTraceRecord,
 } from './internal/tracing.js';
 import type { SignalTraceRecordName } from './internal/tracing.js';
@@ -347,6 +348,32 @@ const recordSignalLifecycleTrace = async (
     return;
   }
   await writeSignalTraceRecord(producerCtx, name, attrs, status, errorCategory);
+};
+
+const recordActivationGuardTrace = async (
+  producerCtx: TrailContextInit | undefined,
+  diagnosticMetadata: FireDiagnosticMetadata,
+  reason: 'cycle' | 'depth',
+  signalId: string,
+  fireStack: readonly string[],
+  limit?: number | undefined
+): Promise<void> => {
+  const attrs: Record<string, unknown> = {
+    ...buildActivationProvenanceTraceAttrs(diagnosticMetadata.activation),
+    'trails.activation.guard.fire_stack': fireStack.join(','),
+    'trails.activation.guard.reason': reason,
+    'trails.signal.id': signalId,
+  };
+  if (limit !== undefined) {
+    attrs['trails.activation.guard.limit'] = limit;
+  }
+  await writeActivationTraceRecord(
+    'activation.cycle_detected',
+    attrs,
+    'ok',
+    undefined,
+    producerCtx === undefined ? undefined : getTraceContext(producerCtx)
+  );
 };
 
 const activationEntriesForSignal = (
@@ -961,6 +988,14 @@ export const createFireFn = (
           signalId,
         })
       );
+      await recordActivationGuardTrace(
+        trackedProducerCtx,
+        diagnosticMetadata,
+        'depth',
+        signalId,
+        stack,
+        MAX_FIRE_DEPTH
+      );
       return Result.ok();
     }
     if (stack.includes(signalId)) {
@@ -983,6 +1018,13 @@ export const createFireFn = (
           reason: 'cycle',
           signalId,
         })
+      );
+      await recordActivationGuardTrace(
+        trackedProducerCtx,
+        diagnosticMetadata,
+        'cycle',
+        signalId,
+        stack
       );
       return Result.ok();
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,7 @@ export type {
 export { SURFACE_KEY, TRAILHEAD_KEY } from './types.js';
 export {
   ACTIVATION_PROVENANCE_KEY,
+  buildActivationProvenanceTraceAttrs,
   getActivationProvenance,
   withActivationProvenance,
 } from './activation-provenance.js';
@@ -394,14 +395,19 @@ export type { ExecuteTrailOptions } from './execute.js';
 // Intrinsic tracing
 export {
   clearTraceSink,
+  createActivationTraceRecord,
   createTraceRecord,
   getTraceContext,
   getTraceSink,
   NOOP_SINK,
   registerTraceSink,
   TRACE_CONTEXT_KEY,
+  traceContextFromRecord,
+  writeActivationTraceRecord,
 } from './internal/tracing.js';
 export type {
+  ActivationTraceRecordName,
+  SignalTraceRecordName,
   TraceContext,
   TraceRecord,
   TraceSink,

--- a/packages/core/src/internal/tracing.ts
+++ b/packages/core/src/internal/tracing.ts
@@ -25,13 +25,20 @@ export type SignalTraceRecordName =
   | 'signal.handler.predicate_skipped'
   | 'signal.invalid';
 
-/** Evidence of a single trail execution, manual span, or signal lifecycle point. */
+/** Activation boundary records emitted by runtime materializers. */
+export type ActivationTraceRecordName =
+  | 'activation.cycle_detected'
+  | 'activation.scheduled'
+  | 'activation.webhook'
+  | 'activation.webhook.invalid';
+
+/** Evidence of a single trail execution, manual span, activation boundary, or signal lifecycle point. */
 export interface TraceRecord {
   readonly id: string;
   readonly traceId: string;
   readonly rootId: string;
   readonly parentId?: string | undefined;
-  readonly kind: 'signal' | 'span' | 'trail';
+  readonly kind: 'activation' | 'signal' | 'span' | 'trail';
   readonly name: string;
   readonly trailId?: string | undefined;
   readonly trailhead?: 'cli' | 'mcp' | 'http' | 'ws' | undefined;
@@ -40,6 +47,7 @@ export interface TraceRecord {
   readonly endedAt?: number | undefined;
   readonly status: 'ok' | 'err' | 'cancelled';
   readonly errorCategory?: string | undefined;
+  readonly sampled?: boolean | undefined;
   readonly permit?:
     | { readonly id: string; readonly tenantId?: string }
     | undefined;
@@ -123,9 +131,18 @@ interface CreateTraceRecordOptions {
   readonly rootId?: string | undefined;
   readonly trailhead?: TraceRecord['trailhead'];
   readonly intent?: TraceRecord['intent'];
+  readonly sampled?: boolean | undefined;
   readonly permit?:
     | { readonly id: string; readonly tenantId?: string }
     | undefined;
+}
+
+interface CreateActivationTraceRecordOptions {
+  readonly attrs?: Readonly<Record<string, unknown>> | undefined;
+  readonly parentId?: string | undefined;
+  readonly rootId?: string | undefined;
+  readonly traceId?: string | undefined;
+  readonly sampled?: boolean | undefined;
 }
 
 /** Create a fresh trail-kind {@link TraceRecord}. */
@@ -145,11 +162,40 @@ export const createTraceRecord = (
     parentId: options.parentId,
     permit: options.permit,
     rootId: options.rootId ?? id,
+    sampled: options.sampled,
     startedAt: Date.now(),
     status: 'ok',
     traceId,
     trailId: options.trailId,
     trailhead: options.trailhead,
+  };
+};
+
+/** Create an activation-kind {@link TraceRecord}. */
+export const createActivationTraceRecord = (
+  name: ActivationTraceRecordName,
+  options: CreateActivationTraceRecordOptions = {}
+): TraceRecord => {
+  const id = Bun.randomUUIDv7();
+  const traceId = options.traceId ?? Bun.randomUUIDv7();
+
+  return {
+    attrs: options.attrs ?? {},
+    endedAt: undefined,
+    errorCategory: undefined,
+    id,
+    intent: undefined,
+    kind: 'activation',
+    name,
+    parentId: options.parentId,
+    permit: undefined,
+    rootId: options.rootId ?? id,
+    sampled: options.sampled,
+    startedAt: Date.now(),
+    status: 'ok',
+    traceId,
+    trailId: undefined,
+    trailhead: undefined,
   };
 };
 
@@ -167,6 +213,7 @@ export const createSpanRecord = (
   name: label,
   parentId: parent.spanId,
   rootId: parent.rootId,
+  sampled: parent.sampled,
   startedAt: Date.now(),
   status: 'ok',
   traceId: parent.traceId,
@@ -189,11 +236,20 @@ export const createSignalTraceRecord = (
   name,
   parentId: parent.spanId,
   rootId: parent.rootId,
+  sampled: parent.sampled,
   startedAt: Date.now(),
   status: 'ok',
   traceId: parent.traceId,
   trailId: undefined,
   trailhead: undefined,
+});
+
+/** Use a completed record as the current trace parent for subsequent trail execution. */
+export const traceContextFromRecord = (record: TraceRecord): TraceContext => ({
+  rootId: record.rootId,
+  sampled: record.sampled ?? true,
+  spanId: record.id,
+  traceId: record.traceId,
 });
 
 /** Mark a record as completed with timing and status. */
@@ -208,15 +264,25 @@ export const completeRecord = (
   status,
 });
 
-/** Best-effort sink write that never throws. */
+/**
+ * Best-effort sink write that never throws.
+ *
+ * Returns `true` when the sink accepted the record, `false` when the write
+ * threw. Most callers can ignore the return value -- it exists so that
+ * callers that hand the written record back as a parent trace context
+ * (e.g. {@link writeActivationTraceRecord}) can refuse to do so when the
+ * record never actually made it to storage.
+ */
 export const writeToSink = async (
   sink: TraceSink,
   record: TraceRecord
-): Promise<void> => {
+): Promise<boolean> => {
   try {
     await Promise.resolve(sink.write(record));
+    return true;
   } catch {
     // Sink failures must never affect trail result delivery.
+    return false;
   }
 };
 
@@ -241,4 +307,39 @@ export const writeSignalTraceRecord = async (
       errorCategory
     )
   );
+};
+
+/** Best-effort write for activation boundary records, no-op when tracing is disabled. */
+export const writeActivationTraceRecord = async (
+  name: ActivationTraceRecordName,
+  attrs: Readonly<Record<string, unknown>>,
+  status: TraceRecord['status'] = 'ok',
+  errorCategory?: string | undefined,
+  parent?: TraceContext | undefined
+): Promise<TraceRecord | undefined> => {
+  const sink = getTraceSink();
+  if (isTracingDisabled(sink)) {
+    return undefined;
+  }
+  const record = completeRecord(
+    createActivationTraceRecord(name, {
+      attrs,
+      parentId: parent?.spanId,
+      rootId: parent?.rootId,
+      // Parentless activations are the root span of their trace tree. Default
+      // sampled to true so the activation boundary stays consistent with
+      // child trail records, which default sampled=true via
+      // traceContextFromRecord. Inconsistent sampled flags within a trace
+      // break filters/exporters that gate on the activation boundary.
+      sampled: parent?.sampled ?? true,
+      traceId: parent?.traceId,
+    }),
+    status,
+    errorCategory
+  );
+  const written = await writeToSink(sink, record);
+  // When the sink dropped the record we must not hand it back to callers as
+  // a parent trace context -- subsequent child writes would reference an
+  // activation span that never reached storage, producing broken lineage.
+  return written ? record : undefined;
 };

--- a/packages/core/src/schedule-runtime.ts
+++ b/packages/core/src/schedule-runtime.ts
@@ -1,11 +1,20 @@
 import type { ActivationEntry } from './activation-source.js';
 import { activationSourceKey } from './activation-source-projection.js';
-import { withActivationProvenance } from './activation-provenance.js';
+import {
+  buildActivationProvenanceTraceAttrs,
+  withActivationProvenance,
+} from './activation-provenance.js';
 import type { ActivationProvenance } from './activation-provenance.js';
 import { getActivationWherePredicate } from './activation-source.js';
 import { createTrailContext } from './context.js';
 import type { ExecuteTrailOptions } from './execute.js';
 import { ConflictError, InternalError } from './errors.js';
+import {
+  TRACE_CONTEXT_KEY,
+  traceContextFromRecord,
+  writeActivationTraceRecord,
+} from './internal/tracing.js';
+import type { TraceContext } from './internal/tracing.js';
 import { Result } from './result.js';
 import { drainResources } from './resource-config.js';
 import type { ResourceDrainReport } from './resource-config.js';
@@ -255,6 +264,25 @@ const scheduleActivationProvenance = (
   };
 };
 
+const scheduleActivationTraceAttrs = (
+  registration: ScheduleActivationRegistration,
+  activation: ActivationProvenance
+): Readonly<Record<string, unknown>> => ({
+  ...buildActivationProvenanceTraceAttrs(activation),
+  'trails.activation.target_trail.id': registration.trail.id,
+});
+
+const recordScheduleActivationTrace = async (
+  registration: ScheduleActivationRegistration,
+  activation: ActivationProvenance
+): Promise<TraceContext | undefined> => {
+  const record = await writeActivationTraceRecord(
+    'activation.scheduled',
+    scheduleActivationTraceAttrs(registration, activation)
+  );
+  return record === undefined ? undefined : traceContextFromRecord(record);
+};
+
 const emitRunRecord = async (
   options: ScheduleRuntimeOptions,
   record: ScheduleRuntimeRunRecord
@@ -272,17 +300,33 @@ const emitRunRecord = async (
 
 const runContextOption = (
   options: ScheduleRuntimeOptions,
-  activation: ActivationProvenance | undefined
+  activation: ActivationProvenance | undefined,
+  traceContext?: TraceContext | undefined
 ): Pick<ExecuteTrailOptions, 'ctx'> | Record<string, never> => {
-  if (activation !== undefined) {
-    return { ctx: withActivationProvenance(options.ctx ?? {}, activation) };
+  if (activation === undefined && traceContext === undefined) {
+    return options.ctx === undefined ? {} : { ctx: options.ctx };
   }
-  return options.ctx === undefined ? {} : { ctx: options.ctx };
+  const withActivation =
+    activation === undefined
+      ? (options.ctx ?? {})
+      : withActivationProvenance(options.ctx ?? {}, activation);
+  const ctx =
+    traceContext === undefined
+      ? withActivation
+      : {
+          ...withActivation,
+          extensions: {
+            ...withActivation.extensions,
+            [TRACE_CONTEXT_KEY]: traceContext,
+          },
+        };
+  return { ctx };
 };
 
 const runOptions = (
   options: ScheduleRuntimeOptions,
-  activation?: ActivationProvenance | undefined
+  activation?: ActivationProvenance | undefined,
+  traceContext?: TraceContext | undefined
 ): Pick<
   ExecuteTrailOptions,
   | 'abortSignal'
@@ -301,7 +345,7 @@ const runOptions = (
   ...(options.createContext === undefined
     ? {}
     : { createContext: options.createContext }),
-  ...runContextOption(options, activation),
+  ...runContextOption(options, activation, traceContext),
   ...(options.layers === undefined ? {} : { layers: options.layers }),
   ...(options.resources === undefined ? {} : { resources: options.resources }),
 });
@@ -362,12 +406,17 @@ const executeScheduleActivation = async (
     return;
   }
 
+  const traceContext = await recordScheduleActivationTrace(
+    registration,
+    activation
+  );
+
   try {
     const result = await run(
       graph,
       registration.trail.id,
       registration.input,
-      runOptions(options, activation)
+      runOptions(options, activation, traceContext)
     );
     if (result.isErr()) {
       options.logger?.warn('Scheduled trail failed', {

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -5,18 +5,44 @@ import {
   NotFoundError,
   Result,
   TRAILHEAD_KEY,
+  clearTraceSink,
   getActivationProvenance,
   resource,
+  registerTraceSink,
   signal,
   ValidationError,
   trail,
   topo,
   webhook,
 } from '@ontrails/core';
-import type { ActivationSource, Layer, TrailContext } from '@ontrails/core';
+import type {
+  ActivationSource,
+  Layer,
+  TraceRecord,
+  TraceSink,
+  TrailContext,
+} from '@ontrails/core';
 import { z } from 'zod';
 
 import { deriveHttpRoutes } from '../build.js';
+
+const createCapturingSink = (records: TraceRecord[]): TraceSink => ({
+  write(record) {
+    records.push(record);
+  },
+});
+
+const findTraceRecord = (
+  records: readonly TraceRecord[],
+  predicate: (record: TraceRecord) => boolean,
+  label: string
+): TraceRecord => {
+  const record = records.find(predicate);
+  if (record === undefined) {
+    throw new Error(`Expected ${label} trace record`);
+  }
+  return record;
+};
 
 // ---------------------------------------------------------------------------
 // Test trails
@@ -613,6 +639,115 @@ describe('deriveHttpRoutes', () => {
       expect(invoked).toBe(0);
     });
 
+    test('webhook execution emits an activation trace record parented to the receiver', async () => {
+      const records: TraceRecord[] = [];
+      const source: ActivationSource = {
+        id: 'webhook.payment.received',
+        kind: 'webhook',
+        method: 'post',
+        parse: z.object({ paymentId: z.string() }),
+        path: ' /webhooks/payment ',
+      };
+      const receiver = trail('payment.receive', {
+        blaze: (input) => Result.ok({ paymentId: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ paymentId: z.string() }),
+      });
+      const result = deriveHttpRoutes(topo('billing', { receiver }));
+      registerTraceSink(createCapturingSink(records));
+
+      try {
+        expect(result.isOk()).toBe(true);
+        if (!result.isOk()) {
+          return;
+        }
+        const [route] = result.value;
+        const parsed = route?.parseWebhookInput?.({ paymentId: 'pay_1' });
+        expect(parsed?.isOk()).toBe(true);
+        if (!parsed?.isOk()) {
+          return;
+        }
+
+        const executed = await route?.execute(parsed.value);
+
+        expect(executed?.isOk()).toBe(true);
+        const activation = findTraceRecord(
+          records,
+          (entry) =>
+            entry.kind === 'activation' && entry.name === 'activation.webhook',
+          'activation.webhook'
+        );
+        const trailRecord = findTraceRecord(
+          records,
+          (entry) =>
+            entry.kind === 'trail' && entry.trailId === 'payment.receive',
+          'payment.receive'
+        );
+        expect(trailRecord.parentId).toBe(activation.id);
+        expect(trailRecord.traceId).toBe(activation.traceId);
+        expect(trailRecord.rootId).toBe(activation.rootId);
+        expect(activation.attrs).toMatchObject({
+          'trails.activation.source.id': 'webhook.payment.received',
+          'trails.activation.source.kind': 'webhook',
+          'trails.activation.target_trail.id': 'payment.receive',
+          'trails.activation.webhook.method': 'POST',
+          'trails.activation.webhook.path': '/webhooks/payment',
+        });
+        expect(trailRecord.attrs['trails.activation.fire_id']).toBe(
+          activation.attrs['trails.activation.fire_id']
+        );
+      } finally {
+        clearTraceSink();
+      }
+    });
+
+    test('webhook parse failures emit invalid activation trace records', async () => {
+      const records: TraceRecord[] = [];
+      const source = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      });
+      const receiver = trail('payment.receive', {
+        blaze: (input) => Result.ok({ paymentId: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ paymentId: z.string() }),
+      });
+      const result = deriveHttpRoutes(topo('billing', { receiver }));
+      registerTraceSink(createCapturingSink(records));
+
+      try {
+        expect(result.isOk()).toBe(true);
+        if (!result.isOk()) {
+          return;
+        }
+        const [route] = result.value;
+        const parsed = route?.parseWebhookInput?.({});
+
+        expect(parsed?.isErr()).toBe(true);
+        await route?.recordWebhookInvalid?.();
+        const invalid = findTraceRecord(
+          records,
+          (entry) =>
+            entry.kind === 'activation' &&
+            entry.name === 'activation.webhook.invalid',
+          'activation.webhook.invalid'
+        );
+        expect(invalid.status).toBe('err');
+        expect(invalid.errorCategory).toBe('validation');
+        expect(invalid.attrs).toMatchObject({
+          'trails.activation.source.id': 'webhook.payment.received',
+          'trails.activation.source.kind': 'webhook',
+          'trails.activation.target_trail.id': 'payment.receive',
+          'trails.activation.webhook.method': 'POST',
+          'trails.activation.webhook.path': '/webhooks/payment',
+        });
+      } finally {
+        clearTraceSink();
+      }
+    });
+
     test('rejects webhook routes that collide with derived trail routes', () => {
       const source = webhook('webhook.payment.received', {
         parse: z.object({ paymentId: z.string() }),
@@ -756,6 +891,80 @@ describe('deriveHttpRoutes', () => {
       expect(result.error).toBeInstanceOf(ValidationError);
       expect(result.error.message).toContain('webhook parse contract');
       expect(result.error.message).toContain('POST /webhooks/payment');
+    });
+
+    test('records an invalid activation trace for every merged consumer', async () => {
+      const records: TraceRecord[] = [];
+      const verify = mock(() => Promise.resolve(Result.ok()));
+      const parse = z.object({ paymentId: z.string() });
+      const sourceA = webhook('webhook.payment.received', {
+        parse,
+        path: '/webhooks/payment',
+        verify,
+      });
+      const sourceB = webhook('webhook.payment.received', {
+        parse,
+        path: '/webhooks/payment',
+        verify,
+      });
+      const audit = trail('payment.audit', {
+        blaze: (input) => Result.ok({ audited: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [sourceA],
+        output: z.object({ audited: z.string() }),
+      });
+      const notify = trail('payment.notify', {
+        blaze: (input) => Result.ok({ notified: input.paymentId }),
+        input: z.object({ paymentId: z.string() }),
+        on: [sourceB],
+        output: z.object({ notified: z.string() }),
+      });
+
+      const built = deriveHttpRoutes(topo('billing', { audit, notify }), {
+        validate: false,
+      });
+      expect(built.isOk()).toBe(true);
+      if (!built.isOk()) {
+        return;
+      }
+      expect(built.value).toHaveLength(1);
+      const [route] = built.value;
+
+      registerTraceSink(createCapturingSink(records));
+      try {
+        await route?.recordWebhookInvalid?.('validation');
+
+        const invalids = records.filter(
+          (entry) =>
+            entry.kind === 'activation' &&
+            entry.name === 'activation.webhook.invalid'
+        );
+        // Two consumers share the source -> two invalid records, one per
+        // consumer. Neither receiver may be silently dropped from telemetry.
+        expect(invalids).toHaveLength(2);
+        const targets = invalids
+          .map(
+            (entry) =>
+              entry.attrs['trails.activation.target_trail.id'] as string
+          )
+          .toSorted();
+        expect(targets).toEqual(['payment.audit', 'payment.notify']);
+        for (const invalid of invalids) {
+          expect(invalid.status).toBe('err');
+          expect(invalid.errorCategory).toBe('validation');
+        }
+        // Sibling invalid records from a single failed inbound request must
+        // share one activation fire ID so observability can correlate them
+        // as one activation root, mirroring the success path.
+        const fireIds = invalids.map(
+          (entry) => entry.attrs['trails.activation.fire_id']
+        );
+        expect(fireIds).toHaveLength(2);
+        expect(fireIds[0]).toBeString();
+        expect(fireIds[0]).toBe(fireIds[1]);
+      } finally {
+        clearTraceSink();
+      }
     });
 
     test('runs every fan-out consumer even when an earlier consumer fails', async () => {

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -9,23 +9,29 @@
 import {
   Result,
   ValidationError,
+  buildActivationProvenanceTraceAttrs,
   executeTrail,
   filterSurfaceTrails,
   getActivationWherePredicate,
   matchesTrailPattern,
+  TRACE_CONTEXT_KEY,
+  traceContextFromRecord,
   validateInput,
   validateWebhookSource,
   validateSurfaceTopo,
   verifyWebhookRequest,
+  writeActivationTraceRecord,
   withActivationProvenance,
   withSurfaceMarker,
 } from '@ontrails/core';
 import type {
   ActivationEntry,
+  ActivationProvenance,
   ActivationSource,
   BaseSurfaceOptions,
   Layer,
   ResourceOverrideMap,
+  TraceContext,
   Topo,
   Trail,
   TrailContextInit,
@@ -113,20 +119,107 @@ const createWebhookActivationFireId = (): string => {
   return `webhook_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
 };
 
-const withWebhookActivation = (
+const webhookActivationProvenance = (
   source: WebhookSource,
-  requestId: string | undefined,
   fireId: string
-): Partial<TrailContextInit> =>
-  withActivationProvenance(withHttpTrailhead(requestId), {
-    fireId,
-    rootFireId: fireId,
-    source: {
-      id: source.id,
-      kind: 'webhook',
-      ...(source.meta === undefined ? {} : { meta: source.meta }),
-    },
-  });
+): ActivationProvenance => ({
+  fireId,
+  rootFireId: fireId,
+  source: {
+    id: source.id,
+    kind: 'webhook',
+    ...(source.meta === undefined ? {} : { meta: source.meta }),
+  },
+});
+
+const webhookActivationTraceAttrs = (
+  source: WebhookSource,
+  activation: ActivationProvenance,
+  trailId: string
+): Readonly<Record<string, unknown>> => ({
+  ...buildActivationProvenanceTraceAttrs(activation),
+  'trails.activation.target_trail.id': trailId,
+  'trails.activation.webhook.method': source.method,
+  'trails.activation.webhook.path': source.path,
+});
+
+const recordWebhookActivationTrace = async (
+  source: WebhookSource,
+  activation: ActivationProvenance,
+  trailId: string,
+  name: 'activation.webhook' | 'activation.webhook.invalid',
+  status: 'err' | 'ok',
+  errorCategory?: string | undefined
+): Promise<TraceContext | undefined> => {
+  const record = await writeActivationTraceRecord(
+    name,
+    webhookActivationTraceAttrs(source, activation, trailId),
+    status,
+    errorCategory
+  );
+  return record === undefined ? undefined : traceContextFromRecord(record);
+};
+
+/**
+ * Internal recorder signature for webhook invalid traces.
+ *
+ * Unlike the public `HttpRouteDefinition['recordWebhookInvalid']`, this
+ * accepts an `activationFireId` so a single inbound failed request can share
+ * one activation fire ID across every consumer fan-out — letting
+ * observability correlate sibling consumers' invalid records as one
+ * activation root, mirroring the success path.
+ */
+type WebhookInvalidConsumerRecorder = (
+  errorCategory: string | undefined,
+  activationFireId: string
+) => Promise<void>;
+
+const createWebhookInvalidRecorder =
+  (source: WebhookSource, trailId: string): WebhookInvalidConsumerRecorder =>
+  async (errorCategory, activationFireId) => {
+    const activation = webhookActivationProvenance(source, activationFireId);
+    await recordWebhookActivationTrace(
+      source,
+      activation,
+      trailId,
+      'activation.webhook.invalid',
+      'err',
+      errorCategory ?? 'validation'
+    );
+  };
+
+/**
+ * Wrap a single-consumer invalid recorder as the public `recordWebhookInvalid`
+ * function. Generates one activation fire ID per inbound failed request,
+ * matching the fan-out behavior so single and merged routes share the same
+ * observability shape.
+ */
+const createWebhookInvalidPublicRecorder =
+  (
+    consumerRecorder: WebhookInvalidConsumerRecorder
+  ): NonNullable<HttpRouteDefinition['recordWebhookInvalid']> =>
+  async (errorCategory = 'validation') =>
+    await consumerRecorder(errorCategory, createWebhookActivationFireId());
+
+const withWebhookActivation = (
+  activation: ActivationProvenance,
+  requestId: string | undefined,
+  traceContext: TraceContext | undefined
+): Partial<TrailContextInit> => {
+  const ctx = withActivationProvenance(
+    withHttpTrailhead(requestId),
+    activation
+  );
+  return traceContext === undefined
+    ? ctx
+    : {
+        ...ctx,
+        extensions: {
+          ...ctx.extensions,
+          [TRACE_CONTEXT_KEY]: traceContext,
+        },
+      };
+};
 
 // ---------------------------------------------------------------------------
 // Execute factory
@@ -176,11 +269,11 @@ const createWebhookConsumerExecute =
     graph: Topo,
     t: Trail<unknown, unknown, unknown>,
     activationEntry: ActivationEntry,
+    source: WebhookSource,
     layers: readonly Layer[],
     options: DeriveHttpRoutesOptions
   ): WebhookConsumerExecute =>
   async (input, requestId, abortSignal, activationFireId) => {
-    const source = activationEntry.source as WebhookSource;
     const predicate = getActivationWherePredicate(activationEntry.where);
     if (predicate !== undefined) {
       let shouldRun = false;
@@ -199,11 +292,19 @@ const createWebhookConsumerExecute =
       }
     }
 
+    const activation = webhookActivationProvenance(source, activationFireId);
+    const traceContext = await recordWebhookActivationTrace(
+      source,
+      activation,
+      t.id,
+      'activation.webhook',
+      'ok'
+    );
     return await executeTrail(t, input, {
       abortSignal,
       configValues: options.configValues,
       createContext: options.createContext,
-      ctx: withWebhookActivation(source, requestId, activationFireId),
+      ctx: withWebhookActivation(activation, requestId, traceContext),
       layers,
       resources: options.resources,
       topo: graph,
@@ -386,9 +487,15 @@ const createWebhookInputParser =
   };
 
 const WEBHOOK_CONSUMERS = Symbol('webhookConsumers');
+const WEBHOOK_INVALID_RECORDERS = Symbol('webhookInvalidRecorders');
+
+type WebhookInvalidRecorder = NonNullable<
+  HttpRouteDefinition['recordWebhookInvalid']
+>;
 
 type MergeableWebhookRoute = HttpRouteDefinition & {
   readonly [WEBHOOK_CONSUMERS]?: readonly WebhookConsumerExecute[];
+  readonly [WEBHOOK_INVALID_RECORDERS]?: readonly WebhookInvalidConsumerRecorder[];
 };
 
 const buildWebhookRoute = (
@@ -407,16 +514,25 @@ const buildWebhookRoute = (
     graph,
     trail,
     activation,
+    source.value,
     layers,
     options
   );
+  const consumerInvalidRecorder = createWebhookInvalidRecorder(
+    source.value,
+    trail.id
+  );
   const route: MergeableWebhookRoute = {
     [WEBHOOK_CONSUMERS]: [consumerExecute],
+    [WEBHOOK_INVALID_RECORDERS]: [consumerInvalidRecorder],
     execute: createWebhookExecute(consumerExecute),
     inputSource: 'webhook',
     method: source.value.method,
     parseWebhookInput: createWebhookInputParser(source.value),
     path: normalizeSourcePath(basePath, source.value.path),
+    recordWebhookInvalid: createWebhookInvalidPublicRecorder(
+      consumerInvalidRecorder
+    ),
     trail,
     trailId: trail.id,
     verifyWebhook: (request) => verifyWebhookRequest(source.value, request),
@@ -475,6 +591,11 @@ const webhookConsumers = (
   route: MergeableWebhookRoute
 ): readonly WebhookConsumerExecute[] | undefined => route[WEBHOOK_CONSUMERS];
 
+const webhookInvalidRecorders = (
+  route: MergeableWebhookRoute
+): readonly WebhookInvalidConsumerRecorder[] =>
+  route[WEBHOOK_INVALID_RECORDERS] ?? [];
+
 type MergeWebhookOutcome =
   | { readonly kind: 'merged'; readonly route: HttpRouteDefinition }
   | { readonly kind: 'verifier-mismatch'; readonly error: ValidationError }
@@ -515,9 +636,41 @@ const mergeWebhookRoutes = (
     ...incomingConsumers,
   ];
 
+  const recorders = [
+    ...webhookInvalidRecorders(existing as MergeableWebhookRoute),
+    ...webhookInvalidRecorders(route as MergeableWebhookRoute),
+  ] as const;
+
+  // Fan-out: every consumer's recorder must fire on parse/verify failures so
+  // each trail emits its own activation.webhook.invalid trace record. A
+  // single activation fire ID is generated per inbound failed request and
+  // shared across all recorders so observability can correlate the sibling
+  // invalid records as one activation root, mirroring the success path. A
+  // recorder failure must not prevent the remaining recorders from running.
+  const recordWebhookInvalidFanOut: WebhookInvalidRecorder | undefined =
+    recorders.length === 0
+      ? undefined
+      : async (errorCategory) => {
+          const activationFireId = createWebhookActivationFireId();
+          await Promise.all(
+            recorders.map(async (record) => {
+              try {
+                await record(errorCategory, activationFireId);
+              } catch {
+                // Recorder failures must never short-circuit the fan-out;
+                // sink errors are already swallowed inside writeToSink.
+              }
+            })
+          );
+        };
+
   const merged: MergeableWebhookRoute = {
     ...existing,
     [WEBHOOK_CONSUMERS]: consumers,
+    [WEBHOOK_INVALID_RECORDERS]: recorders,
+    ...(recordWebhookInvalidFanOut === undefined
+      ? {}
+      : { recordWebhookInvalid: recordWebhookInvalidFanOut }),
     async execute(input, requestId, abortSignal) {
       // One activation fire ID per inbound webhook request, shared across every
       // fan-out consumer so observability can correlate them as siblings of a

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -2,7 +2,7 @@
 
 Sinks and query trails for the intrinsic tracing that ships in `@ontrails/core`.
 
-Tracing is built into `executeTrail`. When a real sink is installed, each trail execution writes a root `TraceRecord` automatically, `ctx.trace()` writes child spans, and typed signal fan-out writes `signal.*` lifecycle records. When `NOOP_SINK` is installed, the tracing path short-circuits and `ctx.trace()` remains a passthrough. This package provides the pluggable sinks, the `NOOP_SINK` sentinel, the manual span API via `ctx.trace()`, and query trails that let you inspect recorded history. See [ADR-0023](../../docs/adr/0023-simplifying-the-trails-lexicon.md) for the design rationale.
+Tracing is built into `executeTrail`. When a real sink is installed, each trail execution writes a root `TraceRecord` automatically, `ctx.trace()` writes child spans, typed signal fan-out writes `signal.*` lifecycle records, and runtime materializers write activation boundary records. When `NOOP_SINK` is installed, the tracing path short-circuits and `ctx.trace()` remains a passthrough. This package provides the pluggable sinks, the `NOOP_SINK` sentinel, the manual span API via `ctx.trace()`, and query trails that let you inspect recorded history. See [ADR-0023](../../docs/adr/0023-simplifying-the-trails-lexicon.md) for the design rationale.
 
 ## The core pattern
 
@@ -15,9 +15,11 @@ const sink = createMemorySink();
 registerTraceSink(sink);
 ```
 
-Sinks receive completed `TraceRecord` records. The default sink is `NOOP_SINK` — tracing APIs still work without configuration, but root/span/signal record allocation is skipped until you register a real sink. Use a memory sink for testing, a dev store for local development, or an OTel connector to forward to your collector. Use `registerTraceSink(NOOP_SINK)` or `clearTraceSink()` to switch back to the silent baseline.
+Sinks receive completed `TraceRecord` records. The default sink is `NOOP_SINK` — tracing APIs still work without configuration, but root/span/signal/activation record allocation is skipped until you register a real sink. Use a memory sink for testing, a dev store for local development, or an OTel connector to forward to your collector. Use `registerTraceSink(NOOP_SINK)` or `clearTraceSink()` to switch back to the silent baseline.
 
 Signal fan-out records use lexicon-aligned names: `signal.fired`, `signal.invalid`, `signal.handler.invoked`, `signal.handler.completed`, and `signal.handler.failed`. Signal record attrs carry IDs and redacted payload summaries, never raw payloads by default.
+
+Activation boundaries record as `kind: "activation"` when a runtime materializer owns the trigger. The built-in names are `activation.scheduled`, `activation.webhook`, `activation.webhook.invalid`, and `activation.cycle_detected`. Activated trail and signal records still carry `trails.activation.*` attrs, so activation can be read either from the boundary event or from the work it caused.
 
 ### 2. Run trails
 

--- a/packages/tracing/src/__tests__/signal-trace.test.ts
+++ b/packages/tracing/src/__tests__/signal-trace.test.ts
@@ -41,6 +41,18 @@ describe('signal trace helpers', () => {
     });
   });
 
+  test('accepts core predicate lifecycle record names', () => {
+    const record = createSignalTraceRecord(
+      parent,
+      'signal.handler.predicate_skipped',
+      {
+        handlerTrailId: 'notify.email',
+      }
+    );
+
+    expect(record.name).toBe('signal.handler.predicate_skipped');
+  });
+
   test('writes signal lifecycle records through the core trace sink registry', async () => {
     const records: TraceRecord[] = [];
     const sink: TraceSink = {

--- a/packages/tracing/src/__tests__/trace-context.test.ts
+++ b/packages/tracing/src/__tests__/trace-context.test.ts
@@ -5,7 +5,9 @@ import {
   createChildTraceContext,
   getTraceContext,
 } from '../trace-context.js';
+import { traceContextFromRecord } from '../index.js';
 import type { TraceContext } from '../trace-context.js';
+import type { TraceRecord } from '../trace-record.js';
 
 describe('getTraceContext', () => {
   test('returns undefined when no extensions', () => {
@@ -86,5 +88,34 @@ describe('createChildTraceContext', () => {
 
     expect(child.rootId).toBe('the-root');
     expect(child.rootId).not.toBe(child.spanId);
+  });
+});
+
+describe('traceContextFromRecord', () => {
+  const baseRecord: TraceRecord = {
+    attrs: {},
+    id: 'span-from-record',
+    kind: 'activation',
+    name: 'activation.webhook',
+    rootId: 'root-from-record',
+    sampled: false,
+    startedAt: 1,
+    status: 'ok',
+    traceId: 'trace-from-record',
+  };
+
+  test('inherits sampled false from the record', () => {
+    expect(traceContextFromRecord(baseRecord)).toEqual({
+      rootId: 'root-from-record',
+      sampled: false,
+      spanId: 'span-from-record',
+      traceId: 'trace-from-record',
+    });
+  });
+
+  test('defaults legacy records without sampled state to sampled', () => {
+    const legacyRecord: TraceRecord = { ...baseRecord, sampled: undefined };
+
+    expect(traceContextFromRecord(legacyRecord).sampled).toBe(true);
   });
 });

--- a/packages/tracing/src/__tests__/tracing-query.test.ts
+++ b/packages/tracing/src/__tests__/tracing-query.test.ts
@@ -189,6 +189,42 @@ describe('tracing.query', () => {
       expect(value.records[0]?.trailId).toBeUndefined();
     });
 
+    test('returns activation trace records from store in state', async () => {
+      const testStore = createTestStore();
+      ({ cleanup } = testStore);
+      testStore.store.write(
+        makeRecord({
+          attrs: {
+            'trails.activation.source.id': 'webhook.payment.received',
+            'trails.activation.source.kind': 'webhook',
+          },
+          id: 'activation-webhook',
+          kind: 'activation',
+          name: 'activation.webhook',
+          rootId: 'root-activation',
+          trailId: undefined,
+        })
+      );
+
+      const ctx = buildCtx(stateWithStore(testStore.store));
+      const result = await tracingQuery.blaze({}, ctx);
+      const value = result.unwrap();
+
+      expect(value.count).toBe(1);
+      expect(value.records[0]).toMatchObject({
+        attrs: {
+          'trails.activation.source.id': 'webhook.payment.received',
+          'trails.activation.source.kind': 'webhook',
+        },
+        id: 'activation-webhook',
+        kind: 'activation',
+        name: 'activation.webhook',
+        rootId: 'root-activation',
+        status: 'ok',
+      });
+      expect(value.records[0]?.trailId).toBeUndefined();
+    });
+
     test('filters by trailId', async () => {
       const testStore = createTestStore();
       ({ cleanup } = testStore);

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -6,13 +6,17 @@ export {
   type TraceRecord,
   type TraceSink,
   clearTraceSink,
+  createActivationTraceRecord,
   createTraceRecord,
   getTraceContext,
   getTraceSink,
   NOOP_SINK,
   registerTraceSink,
   TRACE_CONTEXT_KEY,
+  traceContextFromRecord,
+  writeActivationTraceRecord,
 } from '@ontrails/core';
+export type { ActivationTraceRecordName } from '@ontrails/core';
 
 export {
   type SignalTraceRecordName,

--- a/packages/tracing/src/signal-trace.ts
+++ b/packages/tracing/src/signal-trace.ts
@@ -1,13 +1,13 @@
 import { getTraceContext, getTraceSink, NOOP_SINK } from '@ontrails/core';
-import type { TraceContext, TraceRecord, TraceSink } from '@ontrails/core';
+import type {
+  SignalTraceRecordName as CoreSignalTraceRecordName,
+  TraceContext,
+  TraceRecord,
+  TraceSink,
+} from '@ontrails/core';
 
 /** Signal lifecycle records emitted by the typed signal runtime. */
-export type SignalTraceRecordName =
-  | 'signal.fired'
-  | 'signal.handler.completed'
-  | 'signal.handler.failed'
-  | 'signal.handler.invoked'
-  | 'signal.invalid';
+export type SignalTraceRecordName = CoreSignalTraceRecordName;
 
 /** Build a signal lifecycle record from a parent trace context. */
 export const createSignalTraceRecord = (

--- a/packages/tracing/src/trails/tracing-query.ts
+++ b/packages/tracing/src/trails/tracing-query.ts
@@ -11,7 +11,7 @@ const traceRecordOutput = z.object({
   errorCategory: z.string().optional(),
   id: z.string(),
   intent: z.string().optional(),
-  kind: z.enum(['signal', 'span', 'trail']),
+  kind: z.enum(['activation', 'signal', 'span', 'trail']),
   name: z.string(),
   parentId: z.string().optional(),
   rootId: z.string(),
@@ -35,7 +35,7 @@ const mapRecord = (r: {
   readonly errorCategory?: string | undefined;
   readonly id: string;
   readonly intent?: string | undefined;
-  readonly kind: 'signal' | 'span' | 'trail';
+  readonly kind: 'activation' | 'signal' | 'span' | 'trail';
   readonly name: string;
   readonly parentId?: string | undefined;
   readonly rootId: string;


### PR DESCRIPTION
## Summary
Define the activation-specific trace/observe record contract so signal fires, scheduled trails, and webhook activations all emit structured trace records that downstream sinks can reason about — not generic execution traces with ad-hoc fields.

## What changed
- `packages/core/src/internal/tracing.ts` learns the new activation record shapes (`activation.signal`, `activation.schedule`, `activation.webhook`, plus the `.invalid` variant for failed webhook decoding).
- Producers updated: `packages/core/src/fire.ts`, `packages/core/src/schedule-runtime.ts`, and `packages/http/src/build.ts` emit the new records on their respective entry paths.
- `packages/tracing` exposes the new record types via `signal-trace.ts`, `trace-context.ts`, and the `tracing-query` trail; tests cover each shape.
- Connector and surface tests (`connectors/hono/src/__tests__/surface.test.ts`, `packages/http/src/__tests__/build.test.ts`) assert the full activation trace path through the webhook surface.
- Lexicon, API reference, horizons, and the unified-observability draft updated to reflect the contract.

## Why it matters
"Observability" is only useful if every entry point produces records that line up. With this in place, a single sink can render signal fires, scheduled invocations, and webhook deliveries side-by-side — which is exactly the story the rest of this stack (#360–#366) is here to deliver.

## Stack
Builds on the webhook materialization in #349. #360 plugs a real default sink in; #361–#366 wire it up end-to-end.

## Linear
https://linear.app/outfitter/issue/TRL-603/decide-activation-specific-traceobserve-record-contract