### PR TITLE
feat(core): add topo observe option

### DIFF
--- a/docs/adr/drafts/20260409-unified-observability.md
+++ b/docs/adr/drafts/20260409-unified-observability.md
@@ -158,16 +158,15 @@ baseline. Bounded memory tracing is the built-in sink used by observe-aware
 tooling and explicit registration; core does not allocate trace records until a
 real sink is installed.
 
-Without `@ontrails/observe`, the default works:
+Without `@ontrails/observe`, the default execution path stays inert:
 
 ```typescript
 const app = topo('myapp', trails)
-// Console logging at 'info' level
-// Memory tracing, visible via --trace
-// Zero configuration
+// No process-level trace allocation until tooling or app code installs a sink
+// Still zero configuration
 ```
 
-For production, plug in a connector:
+For local tooling or production, plug in a connector or sink:
 
 ```typescript
 import { otel } from '@ontrails/observe/otel'

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,7 +16,7 @@ contour(name, shape, options)       // define a first-class domain object with i
 resource(id, spec)                  // define a first-class resource dependency
 createResourceLookup(getContext)   // bind ctx.resource() to a specific context snapshot
 drainResources(resources, ctx, configValues?) // evict and dispose cached resource singletons
-topo(name, ...modules)             // assemble trails, contours, signals, and resources into a queryable topology
+topo(name, ...modules, options?)   // assemble trails, contours, signals, resources, and optional observe sinks
 intentValues                       // owner-held runtime vocabulary for trail intent
 blobRefSchema, createBlobRef(...)  // declare and create binary output references
 // Topo methods: .get(id), .has(id), .list(), .listSignals(), .ids(), .count
@@ -31,6 +31,7 @@ pruneUnpinnedSnapshots(db, options?)
 
 // Types
 Trail<I, O>, Signal<T>, ScheduleSource, WebhookSource<T>, Contour<TName, TShape, TIdentity>, Resource<T>, Topo, Intent
+ObserveConfig, ObserveInput, LogSink, TraceSink
 TrailSpec<I, O>, SignalSpec<T>, ScheduleSpec, WebhookSpec<T>, ResourceSpec<T>, TrailExample<I, O>
 AnyTrail, AnySignal, AnyContour, AnyResource, ResourceContext, ResourceOverrideMap
 BlobRef, BlobRefDescriptor

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,7 +46,7 @@ const onboard = trail('entity.onboard', {
 | `resource(id, spec)` | Define an infrastructure dependency with `create`, `dispose`, and optional `mock` |
 | `drainResources(resources, ctx, configValues?)` | Evict and dispose cached resource singletons for surface/test shutdown |
 | `blobRefSchema` / `createBlobRef(...)` | Declare and create binary output references with a shared descriptor contract |
-| `topo(name, ...modules)` | Collect trail modules into a queryable topology |
+| `topo(name, ...modules, options?)` | Collect trail modules into a queryable topology with optional `observe:` sinks |
 | `deriveTrail(contour, operation, spec)` | Derive CRUD-shaped trail contracts from a contour on the `@ontrails/core/trails` subpath |
 | `validateTopo(topo)` | Structural validation: cross targets exist, no cycles, examples parse, output schemas present |
 

--- a/packages/core/src/__tests__/observe.test.ts
+++ b/packages/core/src/__tests__/observe.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { TraceSink } from '../internal/tracing.js';
+import { isObserveInput, normalizeObserve } from '../observe.js';
+import type { LogSink, Logger } from '../types.js';
+
+const makeLogger = (): Logger => ({
+  child: () => makeLogger(),
+  debug: () => {},
+  error: () => {},
+  fatal: () => {},
+  info: () => {},
+  name: 'test',
+  trace: () => {},
+  warn: () => {},
+});
+
+describe('isObserveInput', () => {
+  test('accepts undefined', () => {
+    expect(isObserveInput()).toBe(true);
+  });
+
+  test('accepts a Logger', () => {
+    expect(isObserveInput(makeLogger())).toBe(true);
+  });
+
+  test('accepts an explicit ObserveConfig with log', () => {
+    expect(isObserveInput({ log: makeLogger() })).toBe(true);
+  });
+
+  test('accepts an explicit ObserveConfig with trace', () => {
+    const trace: TraceSink = { write: () => {} };
+    expect(isObserveInput({ trace })).toBe(true);
+  });
+
+  test('accepts a bare TraceSink (no name)', () => {
+    const trace: TraceSink = { write: () => {} };
+    expect(isObserveInput(trace)).toBe(true);
+  });
+
+  test('rejects capability-only payloads', () => {
+    // The exported guard must agree with `normalizeObserve`. A bare
+    // capability declaration without an accompanying `write` method is
+    // metadata about a missing implementation, not a valid input.
+    expect(isObserveInput({ observes: { trace: true } })).toBe(false);
+    expect(isObserveInput({ observes: { log: true } })).toBe(false);
+    expect(isObserveInput({ observes: { log: true, trace: true } })).toBe(
+      false
+    );
+  });
+
+  test('rejects bare LogSink shorthand (ambiguous with TraceSink)', () => {
+    // `normalizeObserve` rejects bare LogSink shorthand because the shape
+    // is ambiguous between a log sink and a trace sink. The guard must
+    // match that behavior so callers do not narrow to `ObserveInput` and
+    // then watch normalization throw.
+    const log: LogSink = { name: 'capture', write: () => {} };
+    expect(isObserveInput(log)).toBe(false);
+  });
+
+  test('rejects unrelated objects', () => {
+    expect(isObserveInput({})).toBe(false);
+    expect(isObserveInput({ foo: 'bar' })).toBe(false);
+    expect(isObserveInput(42)).toBe(false);
+    expect(isObserveInput('observe')).toBe(false);
+    expect(isObserveInput(null)).toBe(false);
+  });
+
+  test('guard remains consistent with normalizeObserve', () => {
+    // For every value the guard accepts, `normalizeObserve` must not
+    // throw. Capability-only and bare LogSink inputs would throw, so
+    // they must be rejected by the guard above.
+    const trace: TraceSink = { write: () => {} };
+    const accepted: readonly unknown[] = [
+      undefined,
+      makeLogger(),
+      { log: makeLogger() },
+      { trace },
+      trace,
+    ];
+    for (const value of accepted) {
+      expect(isObserveInput(value)).toBe(true);
+      expect(() =>
+        normalizeObserve(value as Parameters<typeof normalizeObserve>[0])
+      ).not.toThrow();
+    }
+  });
+});

--- a/packages/core/src/__tests__/topo.test.ts
+++ b/packages/core/src/__tests__/topo.test.ts
@@ -10,10 +10,13 @@ import {
 } from '../internal/signal-ref.js';
 import { resource } from '../resource.js';
 import { Result } from '../result.js';
+import { run } from '../run.js';
 import { schedule } from '../schedule.js';
 import { signal } from '../signal.js';
 import { trail } from '../trail.js';
 import { topo } from '../topo.js';
+import type { TraceRecord, TraceSink } from '../internal/tracing.js';
+import type { LogRecord, LogSink } from '../types.js';
 import { webhook } from '../webhook.js';
 
 // ---------------------------------------------------------------------------
@@ -66,6 +69,11 @@ const mockResource = (
     signals,
   });
 
+// Hoisted to module scope so unicorn/consistent-function-scoping does not
+// flag it as recreated per test invocation. Used by the classifier
+// fallback test to model a non-sink helper exported as `observe`.
+const helperObserveFunction = (): string => 'not a sink';
+
 // ---------------------------------------------------------------------------
 // topo()
 // ---------------------------------------------------------------------------
@@ -82,6 +90,560 @@ describe('topo', () => {
       expect(t.name).toBe('my-app');
       expect(t.version).toBe('1.2.3');
       expect(t.description).toBe('Demo topo');
+    });
+  });
+
+  describe('observe options', () => {
+    test('stores an explicit trace sink from a branded options payload', () => {
+      const sink: TraceSink = { write: () => {} };
+      const mod = { myTrail: mockTrail('observe.trace') };
+      const t = topo('app', mod, topo.options({ observe: sink }));
+
+      expect(t.observe?.trace).toBe(sink);
+      expect(t.trails.get('observe.trace')).toBe(mod.myTrail);
+    });
+
+    test('stores combined log and trace sinks', () => {
+      const log: LogSink = { name: 'capture', write: () => {} };
+      const trace: TraceSink = { write: () => {} };
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.combined') },
+        {
+          observe: { log, trace },
+        }
+      );
+
+      expect(t.observe?.log).toBe(log);
+      expect(t.observe?.trace).toBe(trace);
+    });
+
+    test('stores a named trace sink from the explicit trace slot', () => {
+      const trace = {
+        name: 'named-trace',
+        write: () => {},
+      } satisfies TraceSink & Readonly<{ name: string }>;
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.named-trace') },
+        { observe: { trace } }
+      );
+
+      expect(t.observe?.trace).toBe(trace);
+    });
+
+    test('uses trace capabilities to disambiguate named trace shorthand', () => {
+      const trace = {
+        name: 'trace-capable',
+        observes: { trace: true } as const,
+        write: () => {},
+      };
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.trace-capable') },
+        { observe: trace }
+      );
+
+      expect(t.observe?.log).toBeUndefined();
+      expect(t.observe?.trace).toBe(trace);
+    });
+
+    test('stores capability-marked combined sinks as log and trace targets', async () => {
+      const records: TraceRecord[] = [];
+      const combined = {
+        name: 'combined',
+        observes: { log: true, trace: true } as const,
+        write(record: LogRecord | TraceRecord): void {
+          if ('traceId' in record) {
+            records.push(record);
+          }
+        },
+      };
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.capable') },
+        { observe: combined }
+      );
+
+      expect(t.observe?.log).toBe(combined);
+      expect(t.observe?.trace).toBe(combined);
+
+      const result = await run(t, 'observe.capable', { x: 1 });
+
+      expect(result.isOk()).toBe(true);
+      expect(records).toHaveLength(1);
+      expect(records[0]?.trailId).toBe('observe.capable');
+    });
+
+    test('leaves unconfigured topos on the default observe path', () => {
+      const t = topo('app', { myTrail: mockTrail('observe.default') });
+
+      expect(t.observe).toBeUndefined();
+    });
+
+    test('keeps an export named observe when it is a trail', () => {
+      const observe = mockTrail('observe');
+      const t = topo('app', { observe });
+
+      expect(t.get('observe')).toBe(observe);
+    });
+
+    test('routes trail trace records to the topo trace sink', async () => {
+      const records: TraceRecord[] = [];
+      const trace: TraceSink = {
+        write: (record) => {
+          records.push(record);
+        },
+      };
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.run') },
+        topo.options({ observe: trace })
+      );
+
+      const result = await run(t, 'observe.run', { x: 1 });
+
+      expect(result.isOk()).toBe(true);
+      expect(records).toHaveLength(1);
+      expect(records[0]?.trailId).toBe('observe.run');
+    });
+
+    test('adapts an observe log sink into ctx.logger', async () => {
+      const records: LogRecord[] = [];
+      const log: LogSink = {
+        name: 'capture',
+        write: (record) => records.push(record),
+      };
+      const logged = trail('observe.log', {
+        blaze: (_input, ctx) => {
+          ctx.logger?.info('observed trail', { step: 'blaze' });
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const t = topo('app', { logged }, { observe: { log } });
+
+      const result = await run(t, 'observe.log', {});
+
+      expect(result.isOk()).toBe(true);
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        category: 'observe.log',
+        level: 'info',
+        message: 'observed trail',
+        metadata: {
+          step: 'blaze',
+          topo: 'app',
+          trailId: 'observe.log',
+        },
+      });
+    });
+
+    test('rebinds observe loggers for crossed trails', async () => {
+      const records: LogRecord[] = [];
+      const log: LogSink = {
+        name: 'capture',
+        write: (record) => records.push(record),
+      };
+      const child = trail('observe.child', {
+        blaze: (_input, ctx) => {
+          ctx.logger?.info('child trail');
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const parent = trail('observe.parent', {
+        blaze: async (_input, ctx) => {
+          ctx.logger?.info('parent trail');
+          const crossed = await ctx.cross?.('observe.child', {});
+          if (!crossed) {
+            return Result.err(new Error('missing ctx.cross'));
+          }
+          if (crossed.isErr()) {
+            return Result.err(crossed.error);
+          }
+          return Result.ok({ ok: true });
+        },
+        crosses: [child],
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const t = topo('app', { child, parent }, { observe: { log } });
+
+      const result = await run(t, 'observe.parent', {});
+
+      expect(result.isOk()).toBe(true);
+      expect(records.map((record) => record.category)).toEqual([
+        'observe.parent',
+        'observe.child',
+      ]);
+      expect(records.map((record) => record.metadata?.['trailId'])).toEqual([
+        'observe.parent',
+        'observe.child',
+      ]);
+    });
+
+    test('preserves fan-out metadata when rebinding observe logger for signal consumers', async () => {
+      const records: LogRecord[] = [];
+      const log: LogSink = {
+        name: 'capture',
+        write: (record) => records.push(record),
+      };
+      const orderPlaced = signal('observe.order.placed', {
+        payload: z.object({ orderId: z.string() }),
+      });
+      const consumer = trail('observe.consumer', {
+        blaze: (_input, ctx) => {
+          ctx.logger?.info('consumer trail');
+          return Result.ok({ ok: true });
+        },
+        input: z.object({ orderId: z.string() }),
+        on: [orderPlaced],
+        output: z.object({ ok: z.boolean() }),
+      });
+      const producer = trail('observe.producer', {
+        blaze: async (input, ctx) => {
+          ctx.logger?.info('producer trail');
+          await ctx.fire?.(orderPlaced, { orderId: input.orderId });
+          return Result.ok({ ok: true });
+        },
+        fires: [orderPlaced],
+        input: z.object({ orderId: z.string() }),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const t = topo(
+        'app',
+        { consumer, orderPlaced, producer },
+        { observe: { log } }
+      );
+
+      const result = await run(t, 'observe.producer', { orderId: 'o1' });
+
+      expect(result.isOk()).toBe(true);
+      const consumerRecord = records.find(
+        (record) => record.category === 'observe.consumer'
+      );
+      expect(consumerRecord).toBeDefined();
+      expect(consumerRecord?.metadata).toMatchObject({
+        consumerId: 'observe.consumer',
+        signalId: 'observe.order.placed',
+        topo: 'app',
+        trailId: 'observe.consumer',
+      });
+    });
+
+    test('preserves cross-branch metadata when rebinding observe logger for concurrent crosses', async () => {
+      const records: LogRecord[] = [];
+      const log: LogSink = {
+        name: 'capture',
+        write: (record) => records.push(record),
+      };
+      const left = trail('observe.branch.left', {
+        blaze: (_input, ctx) => {
+          ctx.logger?.info('left branch');
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const right = trail('observe.branch.right', {
+        blaze: (_input, ctx) => {
+          ctx.logger?.info('right branch');
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const parent = trail('observe.branch.parent', {
+        blaze: async (_input, ctx) => {
+          const { cross } = ctx;
+          if (cross === undefined) {
+            return Result.err(new Error('missing ctx.cross'));
+          }
+          const crossed = await cross([
+            [left, {}],
+            [right, {}],
+          ] as const);
+          if (crossed.some((result) => result.isErr())) {
+            return Result.err(new Error('branch failure'));
+          }
+          return Result.ok({ ok: true });
+        },
+        crosses: [left, right],
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const t = topo('app', { left, parent, right }, { observe: { log } });
+
+      const result = await run(t, 'observe.branch.parent', {});
+
+      expect(result.isOk()).toBe(true);
+      const leftRecord = records.find(
+        (record) => record.category === 'observe.branch.left'
+      );
+      const rightRecord = records.find(
+        (record) => record.category === 'observe.branch.right'
+      );
+      expect(leftRecord).toBeDefined();
+      expect(rightRecord).toBeDefined();
+      expect(leftRecord?.metadata).toMatchObject({
+        branchIndex: 0,
+        crossedTrailId: 'observe.branch.left',
+        topo: 'app',
+        trailId: 'observe.branch.left',
+      });
+      expect(rightRecord?.metadata).toMatchObject({
+        branchIndex: 1,
+        crossedTrailId: 'observe.branch.right',
+        topo: 'app',
+        trailId: 'observe.branch.right',
+      });
+    });
+
+    test('rejects ambiguous named sink shorthand', () => {
+      const sink = { name: 'named-sink', write: () => {} };
+
+      expect(() =>
+        topo(
+          'app',
+          { myTrail: mockTrail('observe.ambiguous') },
+          { observe: sink }
+        )
+      ).toThrow(ValidationError);
+    });
+
+    test('rejects ambiguous bare trace sink shorthand', () => {
+      // A bare TraceSink (`{ write }`) is structurally indistinguishable
+      // from a module export named `observe`. The classifier must refuse
+      // to guess and steer the caller toward `topo.options()` rather
+      // than silently picking either interpretation.
+      const sink: TraceSink = { write: () => {} };
+
+      expect(() =>
+        topo(
+          'app',
+          { myTrail: mockTrail('observe.ambiguous-trace') },
+          { observe: sink }
+        )
+      ).toThrow(ValidationError);
+    });
+
+    test('treats a non-sink helper named observe as a module export', () => {
+      // A function value cannot satisfy LogSink / TraceSink / Logger /
+      // ObserveConfig, so the classifier should fall back to module
+      // semantics: the helper is silently ignored as a non-registrable
+      // export, matching how any other unrecognized module value is
+      // handled. No throw.
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.helper-fn') },
+        // Single-arg trailing module whose only export is `observe`.
+        // The trail in the first module still registers normally.
+        { observe: helperObserveFunction as unknown as never }
+      );
+
+      expect(t.observe).toBeUndefined();
+      expect(t.trails.get('observe.helper-fn')).toBeDefined();
+    });
+
+    test('treats a non-sink helper object named observe as a module export', () => {
+      // A plain object literal without `write` does not pass any sink
+      // predicate. The classifier must fall back to module semantics
+      // rather than rejecting the call as malformed.
+      const helperObject = { description: 'not a sink' };
+
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.helper-obj') },
+        { observe: helperObject as unknown as never }
+      );
+
+      expect(t.observe).toBeUndefined();
+      expect(t.trails.get('observe.helper-obj')).toBeDefined();
+    });
+
+    test('treats a primitive observe value as a non-registrable module export', () => {
+      // A primitive (e.g. a number) cannot be confused with any sink
+      // shape and is not registrable. Previously this threw; the
+      // softened classifier silently ignores it as a module export.
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.bad-number') },
+        { observe: 123 as unknown as never }
+      );
+
+      expect(t.observe).toBeUndefined();
+      expect(t.trails.get('observe.bad-number')).toBeDefined();
+    });
+
+    test('treats an empty observe object as a non-registrable module export', () => {
+      // `{}` is an object but does not pass `isLogSink` / `isTraceSink`
+      // (no `write` function). The classifier falls back to module
+      // semantics rather than rejecting the call.
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.empty') },
+        { observe: {} as unknown as never }
+      );
+
+      expect(t.observe).toBeUndefined();
+      expect(t.trails.get('observe.empty')).toBeDefined();
+    });
+
+    test('rejects unknown option keys when using topo.options()', () => {
+      // Branding via topo.options() forces the trailing arg to be
+      // interpreted as options. Unknown keys (typos like "observ") must
+      // throw rather than be silently ignored.
+      expect(() =>
+        topo(
+          'app',
+          { myTrail: mockTrail('observe.typo') },
+          topo.options({ observ: {} } as unknown as never)
+        )
+      ).toThrow(ValidationError);
+    });
+
+    test('topo.options() brands an explicit options payload', () => {
+      const sink: TraceSink = { write: () => {} };
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.branded') },
+        topo.options({ observe: sink })
+      );
+
+      expect(t.observe?.trace).toBe(sink);
+      expect(t.trails.get('observe.branded')).toBeDefined();
+    });
+
+    test('topo.options() accepts a frozen payload without mutating it', () => {
+      // Callers passing `Object.freeze(...)` or otherwise non-extensible
+      // payloads must not trigger a TypeError. Branding clones the input
+      // rather than mutating it in place, so the frozen payload survives
+      // unchanged and downstream classification still works.
+      const sink: TraceSink = { write: () => {} };
+      const frozen = Object.freeze({ observe: sink });
+
+      expect(() => topo.options(frozen)).not.toThrow();
+
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.frozen') },
+        topo.options(frozen)
+      );
+
+      expect(t.observe?.trace).toBe(sink);
+      expect(t.trails.get('observe.frozen')).toBeDefined();
+      // The original frozen payload is untouched.
+      expect(Object.isFrozen(frozen)).toBe(true);
+      expect(Object.getOwnPropertySymbols(frozen)).toHaveLength(0);
+    });
+
+    test('topo.options() lets a module export named observe round-trip a sink', () => {
+      // Without branding, a module whose sole export is `observe` and
+      // whose value is a TraceSink would be misclassified as the inline
+      // options shorthand. topo.options() is the documented escape hatch
+      // for users who genuinely need that module shape.
+      const moduleExport: TraceSink = { write: () => {} };
+      const sinkOptions: TraceSink = { write: () => {} };
+      const t = topo(
+        'app',
+        // The first argument is a module — but because the trailing
+        // argument is branded, it is unambiguously options. The first
+        // argument is then registered as a module (and its `observe`
+        // value, not being a registrable, is silently ignored — same
+        // behavior as any other non-registrable module value).
+        { observe: moduleExport },
+        topo.options({ observe: sinkOptions })
+      );
+
+      expect(t.observe?.trace).toBe(sinkOptions);
+    });
+
+    test('rejects topo.options() in a non-trailing position', () => {
+      const sink: TraceSink = { write: () => {} };
+      const mod = { myTrail: mockTrail('observe.misplaced') };
+
+      expect(() => topo('app', topo.options({ observe: sink }), mod)).toThrow(
+        ValidationError
+      );
+    });
+
+    test('topo.options() routes a bare LogSink to the explicit log slot', () => {
+      // The brand is the documented escape hatch for bare-sink shorthand.
+      // A bare LogSink (`{ name, write }`) under branding must auto-route
+      // to `{ log: sink }` rather than tripping `normalizeObserve`'s
+      // ambiguity guard, which assumes no brand was applied.
+      const log: LogSink = { name: 'capture', write: () => {} };
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.branded-log') },
+        topo.options({ observe: log })
+      );
+
+      expect(t.observe?.log).toBe(log);
+      expect(t.observe?.trace).toBeUndefined();
+      expect(t.trails.get('observe.branded-log')).toBeDefined();
+    });
+
+    test('topo.options() leaves an explicit { log } payload untouched', () => {
+      // Already-disambiguated payloads must round-trip without rewriting.
+      const log: LogSink = { name: 'capture', write: () => {} };
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.branded-log-explicit') },
+        topo.options({ observe: { log } })
+      );
+
+      expect(t.observe?.log).toBe(log);
+      expect(t.observe?.trace).toBeUndefined();
+    });
+
+    test('rejects a bare LogSink shorthand without topo.options()', () => {
+      // The auto-routing only kicks in under branding. Without the brand
+      // the call remains genuinely ambiguous and must continue to throw,
+      // preserving the documented behavior that only `topo.options()`
+      // unlocks the escape hatch.
+      const log: LogSink = { name: 'capture', write: () => {} };
+
+      expect(() =>
+        topo(
+          'app',
+          { myTrail: mockTrail('observe.unbranded-log') },
+          { observe: log }
+        )
+      ).toThrow(ValidationError);
+    });
+
+    test('topo.options() rejects null input', () => {
+      expect(() => topo.options(null as unknown as never)).toThrow(
+        ValidationError
+      );
+    });
+
+    test('topo.options() rejects undefined input', () => {
+      expect(() => topo.options(undefined as unknown as never)).toThrow(
+        ValidationError
+      );
+    });
+
+    test('topo.options() rejects number input', () => {
+      expect(() => topo.options(42 as unknown as never)).toThrow(
+        ValidationError
+      );
+    });
+
+    test('topo.options() rejects string input', () => {
+      expect(() => topo.options('observe' as unknown as never)).toThrow(
+        ValidationError
+      );
+    });
+
+    test('topo.options() rejects array input', () => {
+      expect(() => topo.options([] as unknown as never)).toThrow(
+        ValidationError
+      );
     });
   });
 
@@ -435,7 +997,7 @@ describe('topo accessors', () => {
     const a = mockTrail('alpha');
     const b = mockTrail('beta');
     const app = topo('test', { a, b });
-    expect(app.ids().toSorted()).toEqual(['alpha', 'beta']);
+    expect([...app.ids()].toSorted()).toEqual(['alpha', 'beta']);
   });
 
   test('count returns number of trails', () => {
@@ -472,14 +1034,17 @@ describe('topo accessors', () => {
     const db = mockResource('db.main');
     const cache = mockResource('cache.main');
     const app = topo('test', { cache, db });
-    expect(app.resourceIds().toSorted()).toEqual(['cache.main', 'db.main']);
+    expect([...app.resourceIds()].toSorted()).toEqual([
+      'cache.main',
+      'db.main',
+    ]);
   });
 
   test('contourIds() returns all contour names', () => {
     const gist = mockContour('gist');
     const user = mockContour('user');
     const app = topo('test', { gist, user });
-    expect(app.contourIds().toSorted()).toEqual(['gist', 'user']);
+    expect([...app.contourIds()].toSorted()).toEqual(['gist', 'user']);
   });
 });
 

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -59,6 +59,11 @@ import {
   isTracingDisabled,
   writeToSink,
 } from './internal/tracing.js';
+import {
+  OBSERVE_LOGGER_CONTEXT_KEY,
+  OBSERVE_LOGGER_METADATA_KEY,
+  createObserveLogger,
+} from './observe.js';
 import { Result } from './result.js';
 import { DETOUR_MAX_ATTEMPTS_CAP } from './detours.js';
 import { createResourceLookup } from './resource.js';
@@ -166,6 +171,47 @@ const resolveContext = async (
   return bindResourceLookup(resolved, options);
 };
 
+const readObserveLoggerMetadata = (
+  ctx: TrailContext
+): Record<string, unknown> => {
+  const value = ctx.extensions?.[OBSERVE_LOGGER_METADATA_KEY];
+  return value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {};
+};
+
+const applyTopoObserveContext = (
+  trail: AnyTrail,
+  ctx: TrailContext,
+  topo: Topo | undefined
+): TrailContext => {
+  if (topo?.observe?.log === undefined) {
+    return ctx;
+  }
+  const hasTopoObserveLogger =
+    ctx.extensions?.[OBSERVE_LOGGER_CONTEXT_KEY] === true;
+  if (ctx.logger !== undefined && !hasTopoObserveLogger) {
+    return ctx;
+  }
+  const { log } = topo.observe;
+  // Accumulated metadata (e.g. signal fan-out fields) takes precedence over
+  // the previous observe logger's `topo`/`trailId` values, but the new trail's
+  // identity wins so log records keep pointing at the trail currently running.
+  const accumulated = readObserveLoggerMetadata(ctx);
+  return {
+    ...ctx,
+    extensions: {
+      ...ctx.extensions,
+      [OBSERVE_LOGGER_CONTEXT_KEY]: true,
+    },
+    logger: createObserveLogger(log, trail.id, {
+      ...accumulated,
+      topo: topo.name,
+      trailId: trail.id,
+    }),
+  };
+};
+
 const findMissingScopes = (
   required: readonly string[],
   held: readonly string[]
@@ -207,7 +253,11 @@ const prepareContext = async (
     Error
   >
 > => {
-  const baseCtx = await resolveContext(options);
+  const baseCtx = applyTopoObserveContext(
+    trail,
+    await resolveContext(options),
+    options?.topo
+  );
   const permitted = enforcePermitRequirement(trail, baseCtx);
   if (permitted.isErr()) {
     return Result.err(permitted.error);
@@ -460,6 +510,45 @@ const stripInheritedResourceExtensions = (
   return Object.fromEntries(entries);
 };
 
+const deriveConcurrentBranchObserveMetadata = (
+  ctx: TrailContext,
+  target: AnyTrail,
+  branchIndex: number
+): Record<string, unknown> | undefined => {
+  // Only carry observe metadata forward when the parent ctx is using a
+  // topo-managed observe logger. Otherwise we'd attach branch fields to
+  // caller-supplied loggers that didn't opt into the structured contract.
+  if (ctx.extensions?.[OBSERVE_LOGGER_CONTEXT_KEY] !== true) {
+    return;
+  }
+  return {
+    ...readObserveLoggerMetadata(ctx),
+    branchIndex,
+    crossedTrailId: target.id,
+  };
+};
+
+const buildConcurrentBranchExtensions = (
+  ctx: TrailContext,
+  target: AnyTrail,
+  topo: Topo | undefined,
+  branchIndex: number
+): Record<string, unknown> => {
+  const stripped = stripInheritedResourceExtensions(ctx, target, topo);
+  const observeMetadata = deriveConcurrentBranchObserveMetadata(
+    ctx,
+    target,
+    branchIndex
+  );
+  if (observeMetadata === undefined) {
+    return stripped;
+  }
+  return {
+    ...stripped,
+    [OBSERVE_LOGGER_METADATA_KEY]: observeMetadata,
+  };
+};
+
 const deriveConcurrentBranchLogger = (
   ctx: TrailContext,
   target: AnyTrail,
@@ -490,7 +579,7 @@ const buildConcurrentBranchContext = (
   branchIndex: number
 ): TrailContext =>
   forkCtx(ctx, {
-    extensions: stripInheritedResourceExtensions(ctx, target, topo),
+    extensions: buildConcurrentBranchExtensions(ctx, target, topo, branchIndex),
     logger: deriveConcurrentBranchLogger(ctx, target, branchIndex),
   });
 
@@ -1040,7 +1129,7 @@ const runTrail = async (
   topo: Topo | undefined,
   options: ExecuteTrailOptions | undefined
 ): Promise<Result<unknown, Error>> => {
-  const sink = getTraceSink();
+  const sink = topo?.observe?.trace ?? getTraceSink();
   return isTracingDisabled(sink)
     ? await runImplWithoutTracing(trail, input, ctx, layers, topo, options)
     : await runTrailWithTracing(trail, input, ctx, layers, topo, options, sink);

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -40,13 +40,17 @@ import { activationSourceKey } from './activation-source-projection.js';
 import { NotFoundError, TrailsError, ValidationError } from './errors.js';
 import { forkCtx } from './internal/fork-ctx.js';
 import {
+  OBSERVE_LOGGER_CONTEXT_KEY,
+  OBSERVE_LOGGER_METADATA_KEY,
+} from './observe.js';
+import {
   getTraceContext,
   getTraceSink,
   isTracingDisabled,
   writeActivationTraceRecord,
   writeSignalTraceRecord,
 } from './internal/tracing.js';
-import type { SignalTraceRecordName } from './internal/tracing.js';
+import type { SignalTraceRecordName, TraceSink } from './internal/tracing.js';
 import { Result } from './result.js';
 import type { AnySignal } from './signal.js';
 import {
@@ -185,15 +189,51 @@ const deriveConsumerEnv = (
 ): TrailContextInit['env'] =>
   producerCtx?.env ? { ...producerCtx.env } : undefined;
 
+const readExistingObserveMetadata = (
+  producerCtx: TrailContextInit | undefined
+): Record<string, unknown> => {
+  const value = producerCtx?.extensions?.[OBSERVE_LOGGER_METADATA_KEY];
+  return value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {};
+};
+
+const deriveConsumerObserveMetadata = (
+  producerCtx: TrailContextInit | undefined,
+  signalId: string,
+  consumerId: string
+): Record<string, unknown> | undefined => {
+  // Only carry observe metadata forward when the producer ctx is using a
+  // topo-managed observe logger. Otherwise we'd attach signal fan-out fields
+  // to caller-supplied loggers that didn't opt into the structured contract.
+  if (producerCtx?.extensions?.[OBSERVE_LOGGER_CONTEXT_KEY] !== true) {
+    return undefined;
+  }
+  return {
+    ...readExistingObserveMetadata(producerCtx),
+    consumerId,
+    signalId,
+  };
+};
+
 const deriveConsumerExtensions = (
   producerCtx: TrailContextInit | undefined,
-  signalId: string
+  signalId: string,
+  consumerId: string
 ): TrailContextInit['extensions'] => {
   const { [FIRE_PENDING_DISPATCHES_KEY]: _pending, ...extensions } =
     producerCtx?.extensions ?? {};
+  const observeMetadata = deriveConsumerObserveMetadata(
+    producerCtx,
+    signalId,
+    consumerId
+  );
   return {
     ...extensions,
     [FIRE_STACK_KEY]: [...getFireStack(producerCtx), signalId],
+    ...(observeMetadata === undefined
+      ? {}
+      : { [OBSERVE_LOGGER_METADATA_KEY]: observeMetadata }),
   };
 };
 
@@ -207,7 +247,11 @@ const deriveConsumerCtx = (
     producerCtx
       ? forkCtx(producerCtx as MutableConsumerContext, {
           env: deriveConsumerEnv(producerCtx),
-          extensions: deriveConsumerExtensions(producerCtx, signalId),
+          extensions: deriveConsumerExtensions(
+            producerCtx,
+            signalId,
+            consumerId
+          ),
           logger: deriveConsumerLogger(producerCtx, signalId, consumerId),
         })
       : {},
@@ -342,12 +386,20 @@ const recordSignalLifecycleTrace = async (
   name: SignalTraceRecordName,
   attrs: Readonly<Record<string, unknown>>,
   status?: Parameters<typeof writeSignalTraceRecord>[3],
-  errorCategory?: string | undefined
+  errorCategory?: string | undefined,
+  sink?: TraceSink | undefined
 ): Promise<void> => {
   if (producerCtx === undefined) {
     return;
   }
-  await writeSignalTraceRecord(producerCtx, name, attrs, status, errorCategory);
+  await writeSignalTraceRecord(
+    producerCtx,
+    name,
+    attrs,
+    status,
+    errorCategory,
+    sink
+  );
 };
 
 const recordActivationGuardTrace = async (
@@ -356,7 +408,8 @@ const recordActivationGuardTrace = async (
   reason: 'cycle' | 'depth',
   signalId: string,
   fireStack: readonly string[],
-  limit?: number | undefined
+  limit?: number | undefined,
+  sink?: TraceSink | undefined
 ): Promise<void> => {
   const attrs: Record<string, unknown> = {
     ...buildActivationProvenanceTraceAttrs(diagnosticMetadata.activation),
@@ -372,7 +425,8 @@ const recordActivationGuardTrace = async (
     attrs,
     'ok',
     undefined,
-    producerCtx === undefined ? undefined : getTraceContext(producerCtx)
+    producerCtx === undefined ? undefined : getTraceContext(producerCtx),
+    sink
   );
 };
 
@@ -425,17 +479,19 @@ const consumerTrailsFromActivations = (
 ];
 
 const hasActiveSignalTraceContext = (
-  producerCtx: TrailContextInit | undefined
+  producerCtx: TrailContextInit | undefined,
+  sink: TraceSink
 ): boolean =>
   producerCtx !== undefined &&
   getTraceContext(producerCtx) !== undefined &&
-  !isTracingDisabled(getTraceSink());
+  !isTracingDisabled(sink);
 
 const summarizeSignalPayloadForTrace = (
   producerCtx: TrailContextInit | undefined,
-  payload: unknown
+  payload: unknown,
+  sink: TraceSink
 ): SignalPayloadSummary | undefined => {
-  if (!hasActiveSignalTraceContext(producerCtx)) {
+  if (!hasActiveSignalTraceContext(producerCtx, sink)) {
     return undefined;
   }
   try {
@@ -462,6 +518,7 @@ const recordPredicateTrace = async (
     readonly payloadSummary?: SignalPayloadSummary | undefined;
     readonly signalId: string;
     readonly status?: Parameters<typeof recordSignalLifecycleTrace>[3];
+    readonly traceSink: TraceSink;
   }
 ): Promise<void> => {
   await recordSignalLifecycleTrace(
@@ -477,7 +534,8 @@ const recordPredicateTrace = async (
       signalId: input.signalId,
     }),
     input.status,
-    input.errorCategory
+    input.errorCategory,
+    input.traceSink
   );
 };
 
@@ -488,7 +546,8 @@ const shouldInvokeConsumer = async (
   signalId: string,
   producerCtx: TrailContextInit | undefined,
   diagnosticMetadata: FireDiagnosticMetadata,
-  logger: Logger | undefined
+  logger: Logger | undefined,
+  traceSink: TraceSink
 ): Promise<boolean> => {
   if (activation.wheres.length === 0) {
     return true;
@@ -512,6 +571,7 @@ const shouldInvokeConsumer = async (
           handlerTrailId: activation.trail.id,
           payloadSummary,
           signalId,
+          traceSink,
         }
       );
       if (matched) {
@@ -538,6 +598,7 @@ const shouldInvokeConsumer = async (
           payloadSummary,
           signalId,
           status: 'err',
+          traceSink,
         }
       );
       logger?.warn('Signal activation predicate failed', {
@@ -578,9 +639,14 @@ const fanOutToConsumers = async (
   diagnosticMetadata: FireDiagnosticMetadata,
   bindFire: ConsumerFireBinder,
   executor: ConsumerExecutor,
-  logger: Logger | undefined
+  logger: Logger | undefined,
+  traceSink: TraceSink
 ): Promise<void> => {
-  const payloadSummary = summarizeSignalPayloadForTrace(producerCtx, payload);
+  const payloadSummary = summarizeSignalPayloadForTrace(
+    producerCtx,
+    payload,
+    traceSink
+  );
   const settled = await Promise.allSettled(
     activations.map(async (activation) => {
       const consumer = activation.trail;
@@ -591,7 +657,8 @@ const fanOutToConsumers = async (
         signalId,
         producerCtx,
         diagnosticMetadata,
-        logger
+        logger,
+        traceSink
       );
       if (!shouldInvoke) {
         return consumer.id;
@@ -615,7 +682,10 @@ const fanOutToConsumers = async (
           producerTrailId: diagnosticMetadata.producerTrailId,
           runId: diagnosticMetadata.runId,
           signalId,
-        })
+        }),
+        undefined,
+        undefined,
+        traceSink
       );
       try {
         const consumerResult = await executor(consumer, payload, consumerCtx);
@@ -642,7 +712,8 @@ const fanOutToConsumers = async (
               signalId,
             }),
             'err',
-            deriveSignalErrorCategory(consumerResult.error)
+            deriveSignalErrorCategory(consumerResult.error),
+            traceSink
           );
           (consumerCtx.logger ?? logger)?.warn('Signal consumer failed', {
             consumerId: consumer.id,
@@ -661,7 +732,10 @@ const fanOutToConsumers = async (
             producerTrailId: diagnosticMetadata.producerTrailId,
             runId: diagnosticMetadata.runId,
             signalId,
-          })
+          }),
+          undefined,
+          undefined,
+          traceSink
         );
         return consumer.id;
       } catch (error) {
@@ -687,7 +761,8 @@ const fanOutToConsumers = async (
             signalId,
           }),
           'err',
-          deriveSignalErrorCategory(error)
+          deriveSignalErrorCategory(error),
+          traceSink
         );
         throw error;
       }
@@ -782,7 +857,8 @@ const resolveFireDispatch = async (
   signalId: string,
   payload: unknown,
   producerCtx: TrailContextInit | undefined,
-  diagnosticMetadata: FireDiagnosticMetadata
+  diagnosticMetadata: FireDiagnosticMetadata,
+  traceSink: TraceSink
 ): Promise<
   Result<
     {
@@ -830,7 +906,8 @@ const resolveFireDispatch = async (
         signalId,
       }),
       'err',
-      'validation'
+      'validation',
+      traceSink
     );
     return Result.err(
       createInvalidPayloadError(signalId, parsed.message, diagnostic, promoted)
@@ -895,6 +972,7 @@ export const createFireFn = (
     producerCtx === undefined
       ? undefined
       : withFireDispatchTracking(producerCtx);
+  const traceSink = topo.observe?.trace ?? getTraceSink();
   const bindConsumerFire: ConsumerFireBinder = (consumerCtx, consumerId) => ({
     ...consumerCtx,
     // Pre-bind fire on the consumer ctx as a safety net for direct
@@ -921,7 +999,8 @@ export const createFireFn = (
       signalId,
       payload,
       trackedProducerCtx,
-      diagnosticMetadata
+      diagnosticMetadata,
+      traceSink
     );
     if (dispatch.isErr()) {
       return Result.err(dispatch.error);
@@ -934,12 +1013,16 @@ export const createFireFn = (
         consumerIds: dispatch.value.consumers.map((consumer) => consumer.id),
         payload: summarizeSignalPayloadForTrace(
           trackedProducerCtx,
-          dispatch.value.payload
+          dispatch.value.payload,
+          traceSink
         ),
         producerTrailId: diagnosticMetadata.producerTrailId,
         runId: diagnosticMetadata.runId,
         signalId,
-      })
+      }),
+      undefined,
+      undefined,
+      traceSink
     );
     const completion = (async (): Promise<void> => {
       try {
@@ -951,7 +1034,8 @@ export const createFireFn = (
           diagnosticMetadata,
           bindConsumerFire,
           executor,
-          trackedProducerCtx?.logger
+          trackedProducerCtx?.logger,
+          traceSink
         );
       } catch (error: unknown) {
         trackedProducerCtx?.logger?.debug(
@@ -994,7 +1078,8 @@ export const createFireFn = (
         'depth',
         signalId,
         stack,
-        MAX_FIRE_DEPTH
+        MAX_FIRE_DEPTH,
+        traceSink
       );
       return Result.ok();
     }
@@ -1024,7 +1109,9 @@ export const createFireFn = (
         diagnosticMetadata,
         'cycle',
         signalId,
-        stack
+        stack,
+        undefined,
+        traceSink
       );
       return Result.ok();
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,9 @@ export type {
   CrossFn,
   FireFn,
   BasePermit,
+  LogLevel,
+  LogRecord,
+  LogSink,
   PermitRequirement,
   ProgressCallback,
   ProgressEvent,
@@ -413,6 +416,22 @@ export type {
   TraceSink,
 } from './internal/tracing.js';
 export type { TraceFn } from './types.js';
+
+// Observe
+export {
+  createObserveLogger,
+  isLogSink,
+  isLogger,
+  isObserveInput,
+  isTraceSink,
+  normalizeObserve,
+} from './observe.js';
+export type {
+  ObserveCapabilities,
+  ObserveConfig,
+  ObserveInput,
+  TopoOptions,
+} from './observe.js';
 
 // Run
 export { run } from './run.js';

--- a/packages/core/src/internal/tracing.ts
+++ b/packages/core/src/internal/tracing.ts
@@ -292,9 +292,9 @@ export const writeSignalTraceRecord = async (
   name: SignalTraceRecordName,
   attrs: Readonly<Record<string, unknown>>,
   status: TraceRecord['status'] = 'ok',
-  errorCategory?: string | undefined
+  errorCategory?: string | undefined,
+  sink: TraceSink = getTraceSink()
 ): Promise<void> => {
-  const sink = getTraceSink();
   const parent = getTraceContext(ctx);
   if (parent === undefined || isTracingDisabled(sink)) {
     return;
@@ -315,9 +315,9 @@ export const writeActivationTraceRecord = async (
   attrs: Readonly<Record<string, unknown>>,
   status: TraceRecord['status'] = 'ok',
   errorCategory?: string | undefined,
-  parent?: TraceContext | undefined
+  parent?: TraceContext | undefined,
+  sink: TraceSink = getTraceSink()
 ): Promise<TraceRecord | undefined> => {
-  const sink = getTraceSink();
   if (isTracingDisabled(sink)) {
     return undefined;
   }

--- a/packages/core/src/observe.ts
+++ b/packages/core/src/observe.ts
@@ -1,0 +1,272 @@
+import { ValidationError } from './errors.js';
+import type { TraceSink } from './internal/tracing.js';
+import type { Logger, LogLevel, LogSink } from './types.js';
+
+export interface ObserveConfig {
+  readonly log?: Logger | LogSink | undefined;
+  readonly trace?: TraceSink | undefined;
+}
+
+export interface ObserveCapabilities {
+  readonly log?: true | undefined;
+  readonly trace?: true | undefined;
+}
+
+interface ObserveCapable {
+  readonly observes?: ObserveCapabilities | undefined;
+}
+
+export type ObserveInput = Logger | LogSink | TraceSink | ObserveConfig;
+
+export interface TopoOptions {
+  readonly observe?: ObserveInput | undefined;
+}
+
+const OBSERVE_CONFIG_KEYS = new Set(['log', 'trace']);
+export const OBSERVE_LOGGER_CONTEXT_KEY = '__trails_observe_logger';
+
+/**
+ * Context extension key that carries metadata accumulated on the observe
+ * logger across rebindings (e.g. signal fan-out metadata such as `consumerId`
+ * and `signalId`). When `applyTopoObserveContext` rebinds the logger for a
+ * new trail, it merges this metadata into the freshly built observe logger
+ * so consumer log records retain provenance back to the triggering signal.
+ */
+export const OBSERVE_LOGGER_METADATA_KEY = '__trails_observe_logger_metadata';
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const hasFunction = (value: Record<string, unknown>, key: string): boolean =>
+  typeof value[key] === 'function';
+
+export const isLogger = (value: unknown): value is Logger =>
+  isObject(value) &&
+  hasFunction(value, 'child') &&
+  hasFunction(value, 'debug') &&
+  hasFunction(value, 'error') &&
+  hasFunction(value, 'fatal') &&
+  hasFunction(value, 'info') &&
+  hasFunction(value, 'trace') &&
+  hasFunction(value, 'warn');
+
+export const isLogSink = (value: unknown): value is LogSink =>
+  isObject(value) &&
+  typeof value['name'] === 'string' &&
+  hasFunction(value, 'write');
+
+const readObserveCapabilities = (
+  value: unknown
+): ObserveCapabilities | undefined => {
+  if (!isObject(value)) {
+    return undefined;
+  }
+  const capabilities = (value as ObserveCapable).observes;
+  if (!isObject(capabilities)) {
+    return undefined;
+  }
+  const log = capabilities['log'] === true;
+  const trace = capabilities['trace'] === true;
+  if (!log && !trace) {
+    return undefined;
+  }
+  return Object.freeze({
+    ...(log ? { log: true as const } : {}),
+    ...(trace ? { trace: true as const } : {}),
+  });
+};
+
+export const isTraceSink = (value: unknown): value is TraceSink =>
+  isObject(value) && hasFunction(value, 'write');
+
+const isObserveConfigShape = (value: unknown): value is ObserveConfig => {
+  if (!isObject(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  return (
+    keys.length > 0 &&
+    keys.every((key) => OBSERVE_CONFIG_KEYS.has(key)) &&
+    ('log' in value || 'trace' in value)
+  );
+};
+
+/**
+ * Type guard for the `ObserveInput` union. Returns `true` only for shapes
+ * that {@link normalizeObserve} will accept without throwing — i.e. a
+ * `Logger`, an explicit `ObserveConfig`, or a `TraceSink`. Capability-only
+ * payloads (`{ observes: { trace: true } }` without an accompanying
+ * `write` method) and bare `LogSink` shorthand are intentionally rejected:
+ * the former is metadata about a missing implementation, and the latter
+ * is ambiguous between a `LogSink` and a `TraceSink` and is rejected by
+ * `normalizeObserve` accordingly. Keeping the guard tighter than the
+ * runtime accepts would let callers narrow to `ObserveInput` and then
+ * see `normalizeObserve` throw at runtime.
+ */
+export const isObserveInput = (
+  value: unknown
+): value is ObserveInput | undefined => {
+  if (value === undefined) {
+    return true;
+  }
+  if (isLogger(value)) {
+    return true;
+  }
+  if (isObserveConfigShape(value)) {
+    return true;
+  }
+  if (isTraceSink(value) && !isLogSink(value)) {
+    // A bare TraceSink (no `name`) is unambiguous — `normalizeObserve`
+    // routes it via the `isTraceSink` fallthrough. A LogSink shape is
+    // ambiguous (matches both guards) and would be rejected by
+    // `normalizeObserve`, so the guard rejects it here too.
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Returns true when `value` carries explicit observe capabilities via the
+ * `observes` discriminator. Used by the topo classifier to distinguish
+ * an `ObserveCapable` sink (clearly options) from a bare sink (ambiguous
+ * with a module export named `observe`).
+ */
+export const hasObserveCapabilities = (value: unknown): boolean =>
+  readObserveCapabilities(value) !== undefined;
+
+/**
+ * Returns true when `value` is shaped like the explicit `{ log?, trace? }`
+ * `ObserveConfig` payload. Exposed for the topo classifier so a config-style
+ * trailing argument is unambiguously routed to options.
+ */
+export const isObserveConfig = (value: unknown): value is ObserveConfig =>
+  isObserveConfigShape(value);
+
+const normalizeLogTarget = (
+  target: ObserveConfig['log']
+): ObserveConfig['log'] => {
+  if (target === undefined || isLogger(target) || isLogSink(target)) {
+    return target;
+  }
+  throw new ValidationError('topo observe.log must be a Logger or LogSink');
+};
+
+const normalizeTraceTarget = (
+  target: ObserveConfig['trace']
+): ObserveConfig['trace'] => {
+  if (target === undefined || isTraceSink(target)) {
+    return target;
+  }
+  throw new ValidationError('topo observe.trace must be a TraceSink');
+};
+
+export const normalizeObserve = (
+  observe: ObserveInput | undefined
+): ObserveConfig | undefined => {
+  if (observe === undefined) {
+    return undefined;
+  }
+
+  const capabilities = readObserveCapabilities(observe);
+  if (capabilities !== undefined) {
+    const log =
+      capabilities.log === true
+        ? normalizeLogTarget(observe as Logger | LogSink)
+        : undefined;
+    const trace =
+      capabilities.trace === true
+        ? normalizeTraceTarget(observe as TraceSink)
+        : undefined;
+    return Object.freeze({
+      ...(log === undefined ? {} : { log }),
+      ...(trace === undefined ? {} : { trace }),
+    });
+  }
+
+  if (isLogger(observe)) {
+    return Object.freeze({ log: observe });
+  }
+
+  if (isObserveConfigShape(observe)) {
+    const log = normalizeLogTarget(observe.log);
+    const trace = normalizeTraceTarget(observe.trace);
+    if (log === undefined && trace === undefined) {
+      return undefined;
+    }
+    return Object.freeze({
+      ...(log === undefined ? {} : { log }),
+      ...(trace === undefined ? {} : { trace }),
+    });
+  }
+
+  if (isLogSink(observe)) {
+    throw new ValidationError(
+      'topo observe shorthand is ambiguous for named sinks; use { log: sink } or { trace: sink }'
+    );
+  }
+
+  if (isTraceSink(observe)) {
+    return Object.freeze({ trace: observe });
+  }
+
+  throw new ValidationError(
+    'topo observe must be a Logger, LogSink, TraceSink, or { log, trace } object'
+  );
+};
+
+const createLogSinkLogger = (
+  sink: LogSink,
+  category: string,
+  baseMetadata: Record<string, unknown>
+): Logger => {
+  const write = (
+    level: LogLevel,
+    message: string,
+    metadata?: Record<string, unknown>
+  ): void => {
+    sink.write({
+      category,
+      level,
+      message,
+      metadata: { ...baseMetadata, ...metadata },
+      timestamp: new Date(),
+    });
+  };
+
+  return {
+    child(metadata: Record<string, unknown>): Logger {
+      return createLogSinkLogger(sink, category, {
+        ...baseMetadata,
+        ...metadata,
+      });
+    },
+    debug(message, metadata): void {
+      write('debug', message, metadata);
+    },
+    error(message, metadata): void {
+      write('error', message, metadata);
+    },
+    fatal(message, metadata): void {
+      write('fatal', message, metadata);
+    },
+    info(message, metadata): void {
+      write('info', message, metadata);
+    },
+    name: category,
+    trace(message, metadata): void {
+      write('trace', message, metadata);
+    },
+    warn(message, metadata): void {
+      write('warn', message, metadata);
+    },
+  };
+};
+
+export const createObserveLogger = (
+  log: Logger | LogSink,
+  category: string,
+  metadata: Record<string, unknown>
+): Logger =>
+  isLogger(log)
+    ? log.child(metadata)
+    : createLogSinkLogger(log, category, metadata);

--- a/packages/core/src/schedule-runtime.ts
+++ b/packages/core/src/schedule-runtime.ts
@@ -10,6 +10,7 @@ import { createTrailContext } from './context.js';
 import type { ExecuteTrailOptions } from './execute.js';
 import { ConflictError, InternalError } from './errors.js';
 import {
+  getTraceSink,
   TRACE_CONTEXT_KEY,
   traceContextFromRecord,
   writeActivationTraceRecord,
@@ -274,11 +275,16 @@ const scheduleActivationTraceAttrs = (
 
 const recordScheduleActivationTrace = async (
   registration: ScheduleActivationRegistration,
-  activation: ActivationProvenance
+  activation: ActivationProvenance,
+  graph: Topo
 ): Promise<TraceContext | undefined> => {
   const record = await writeActivationTraceRecord(
     'activation.scheduled',
-    scheduleActivationTraceAttrs(registration, activation)
+    scheduleActivationTraceAttrs(registration, activation),
+    'ok',
+    undefined,
+    undefined,
+    graph.observe?.trace ?? getTraceSink()
   );
   return record === undefined ? undefined : traceContextFromRecord(record);
 };
@@ -408,7 +414,8 @@ const executeScheduleActivation = async (
 
   const traceContext = await recordScheduleActivationTrace(
     registration,
-    activation
+    activation,
+    graph
   );
 
   try {

--- a/packages/core/src/topo.ts
+++ b/packages/core/src/topo.ts
@@ -9,6 +9,16 @@ import {
   getLateBoundSignalRef,
   parseLateBoundSignalMarker,
 } from './internal/signal-ref.js';
+import {
+  hasObserveCapabilities,
+  isLogger,
+  isLogSink,
+  isObserveConfig,
+  isObserveInput,
+  isTraceSink,
+  normalizeObserve,
+} from './observe.js';
+import type { ObserveConfig, TopoOptions } from './observe.js';
 import type { AnySignal } from './signal.js';
 import type { AnyResource } from './resource.js';
 import { isResource } from './resource.js';
@@ -32,6 +42,7 @@ export interface Topo {
   readonly trails: ReadonlyMap<string, AnyTrail>;
   readonly signals: ReadonlyMap<string, AnySignal>;
   readonly resources: ReadonlyMap<string, AnyResource>;
+  readonly observe?: ObserveConfig | undefined;
   readonly count: number;
   readonly contourCount: number;
   readonly resourceCount: number;
@@ -73,7 +84,8 @@ const createTopo = (
   contours: ReadonlyMap<string, AnyContour>,
   trails: ReadonlyMap<string, AnyTrail>,
   signals: ReadonlyMap<string, AnySignal>,
-  resources: ReadonlyMap<string, AnyResource>
+  resources: ReadonlyMap<string, AnyResource>,
+  observe: ObserveConfig | undefined
 ): Topo => ({
   contourCount: contours.size,
   contourIds(): string[] {
@@ -122,6 +134,7 @@ const createTopo = (
   ...(identity.description !== undefined && {
     description: identity.description,
   }),
+  ...(observe !== undefined && { observe }),
   resourceCount: resources.size,
   resourceIds(): string[] {
     return [...resources.keys()];
@@ -470,14 +483,307 @@ const registerModuleValues = (
   }
 };
 
-export const topo = (
+const TOPO_OPTION_KEYS = ['observe'] as const;
+const TOPO_OPTION_KEY_SET: ReadonlySet<string> = new Set(TOPO_OPTION_KEYS);
+
+/**
+ * Brand symbol applied by `topo.options()`. The presence of this symbol
+ * marks an object as an explicit `TopoOptions` payload, which is the
+ * unambiguous way to disambiguate a trailing options object from a
+ * trailing module export. Use `topo.options()` whenever a module might
+ * legitimately export only fields whose names collide with topo options
+ * (for example a module whose sole export is `observe`).
+ */
+const TOPO_OPTIONS_BRAND: unique symbol = Symbol('trails.topo.options');
+
+const hasOptionsBrand = (value: object): boolean =>
+  (value as { [TOPO_OPTIONS_BRAND]?: true })[TOPO_OPTIONS_BRAND] === true;
+
+const looksLikeTopoOptionsShape = (value: object): boolean => {
+  const keys = Object.keys(value);
+  if (keys.length === 0) {
+    return false;
+  }
+  return keys.every((key) => TOPO_OPTION_KEY_SET.has(key));
+};
+
+const detectUnknownOptionKeys = (value: object): readonly string[] => {
+  const unknown: string[] = [];
+  for (const key of Object.keys(value)) {
+    if (!TOPO_OPTION_KEY_SET.has(key)) {
+      unknown.push(key);
+    }
+  }
+  return unknown;
+};
+
+const hasRegistrableKind = (value: unknown): boolean => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const { kind } = value as { kind?: unknown };
+  return (
+    kind === 'contour' ||
+    kind === 'trail' ||
+    kind === 'signal' ||
+    kind === 'resource'
+  );
+};
+
+/**
+ * When a branded `topo.options()` payload carries a bare `LogSink` in the
+ * `observe` slot, rewrite it to the explicit `{ log: sink }` form. The brand
+ * already signals "this is options, not a module"; once that is settled, a
+ * bare `LogSink` unambiguously names a log target and should not be rejected
+ * as ambiguous downstream.
+ *
+ * Bare `TraceSink` values (no `name` field) are left untouched — they already
+ * round-trip through `normalizeObserve` via the `isTraceSink` fallthrough.
+ * Already-disambiguated shapes (`{ log }`, `{ trace }`, `Logger`,
+ * `ObserveCapable`, etc.) are also left untouched.
+ */
+const disambiguateBrandedObserve = (options: TopoOptions): TopoOptions => {
+  const { observe } = options;
+  if (
+    observe === undefined ||
+    isLogger(observe) ||
+    isObserveConfig(observe) ||
+    hasObserveCapabilities(observe)
+  ) {
+    return options;
+  }
+  if (isLogSink(observe)) {
+    return { ...options, observe: { log: observe } };
+  }
+  return options;
+};
+
+/**
+ * Decide whether the trailing argument should be treated as a
+ * `TopoOptions` payload, a module export, or rejected as ambiguous.
+ *
+ * Resolution rules (in order):
+ *   1. Branded via `topo.options()` → always options. Unknown option
+ *      keys throw, and downstream `normalizeObserve` rejects malformed
+ *      values. A bare `LogSink` (`{ name, write }`) in the `observe`
+ *      slot is auto-routed to `{ log: sink }` so the brand is the
+ *      complete escape hatch the docs promise.
+ *   2. The shape does not look like `TopoOptions` (mixed keys or no
+ *      keys) → module.
+ *   3. The trailing arg is a registrable module export
+ *      (`kind: 'trail' | 'contour' | …`) under a known option key →
+ *      module. Preserves the "module exporting a single trail named
+ *      `observe`" case that the warden and existing apps rely on.
+ *   4. The `observe` value is a bare `LogSink` or `TraceSink` (a sink
+ *      shape that could equally plausibly be a module export named
+ *      `observe`) → throw, since the call is genuinely ambiguous.
+ *      `topo.options()` exists to disambiguate.
+ *   5. The `observe` value is otherwise a recognizable `ObserveInput`
+ *      (`Logger`, `ObserveConfig`, or `ObserveCapable`) → options.
+ *      Those shapes carry enough structure that they cannot be
+ *      mistaken for a generic module export.
+ *   6. Otherwise (non-sink helper object, function, primitive, etc.)
+ *      → module. The non-registrable export is silently ignored, the
+ *      same as any other unrecognized value in a module record.
+ */
+const classifyTrailingArgument = (
+  value: unknown
+):
+  | { readonly kind: 'options'; readonly options: TopoOptions }
+  | { readonly kind: 'module' }
+  | { readonly kind: 'invalid'; readonly message: string } => {
+  if (typeof value !== 'object' || value === null) {
+    return { kind: 'module' };
+  }
+
+  if (hasOptionsBrand(value)) {
+    const unknown = detectUnknownOptionKeys(value);
+    if (unknown.length > 0) {
+      return {
+        kind: 'invalid',
+        message: `topo.options() received unknown option keys: ${unknown
+          .map((key) => `"${key}"`)
+          .join(', ')}. Expected one of: ${TOPO_OPTION_KEYS.map(
+          (key) => `"${key}"`
+        ).join(', ')}.`,
+      };
+    }
+    // Branding via `topo.options()` is the documented escape hatch for
+    // disambiguating bare-sink shorthand. Route a bare `LogSink` into the
+    // explicit `{ log: sink }` slot before handing off to `normalizeObserve`,
+    // which would otherwise reject it as ambiguous (a LogSink shape matches
+    // both `isLogSink` and `isTraceSink`). A bare TraceSink (no `name`) does
+    // not need rewriting because `normalizeObserve` already routes it via
+    // the `isTraceSink` fallthrough.
+    return {
+      kind: 'options',
+      options: disambiguateBrandedObserve(value as TopoOptions),
+    };
+  }
+
+  if (!looksLikeTopoOptionsShape(value)) {
+    return { kind: 'module' };
+  }
+
+  // The shape matches `TopoOptions`. Decide whether the values are
+  // valid options, a registrable module export, or a non-registrable
+  // helper that should be treated as a (silently ignored) module
+  // export.
+  const observeValue = (value as TopoOptions).observe;
+  if (hasRegistrableKind(observeValue)) {
+    return { kind: 'module' };
+  }
+  // Unambiguous option shapes: `Logger`, `ObserveConfig`, and
+  // `ObserveCapable` carry enough structure that they cannot be
+  // confused with a generic module export. Check these first so the
+  // sink-ambiguity guard below does not accidentally reject an
+  // `ObserveCapable` whose underlying shape happens to also satisfy
+  // `isLogSink` / `isTraceSink`.
+  if (
+    isLogger(observeValue) ||
+    isObserveConfig(observeValue) ||
+    hasObserveCapabilities(observeValue)
+  ) {
+    return { kind: 'options', options: value as TopoOptions };
+  }
+  // Bare sink shapes (`{ write }` / `{ name, write }`) are genuinely
+  // ambiguous — they may equally plausibly be a module export named
+  // `observe`. Refuse to guess; require `topo.options()` to make the
+  // intent explicit.
+  if (isLogSink(observeValue) || isTraceSink(observeValue)) {
+    return {
+      kind: 'invalid',
+      message:
+        'topo() received a trailing argument shaped like `{ observe: sink }` that is ambiguous: ' +
+        'the value matches both a TopoOptions sink and a non-registrable module export. ' +
+        'Wrap the options with `topo.options({ observe: sink })` to disambiguate.',
+    };
+  }
+  if (isObserveInput(observeValue)) {
+    // Catch-all for any future `ObserveInput` variant added to the
+    // type. Today this branch is unreachable given the guards above.
+    return { kind: 'options', options: value as TopoOptions };
+  }
+  // Non-registrable, non-sink helper. Treat as a module export; the
+  // unrecognized value is silently ignored during registration, matching
+  // the behavior of any other non-registrable export.
+  return { kind: 'module' };
+};
+
+const splitTopoArguments = (
+  modulesOrOptions: readonly (Record<string, unknown> | TopoOptions)[]
+): {
+  readonly modules: readonly Record<string, unknown>[];
+  readonly options: TopoOptions | undefined;
+} => {
+  // A branded `topo.options(...)` payload is an explicit user signal and must
+  // appear last. If it shows up in a non-trailing position the caller almost
+  // certainly intended it as options but lost the configuration silently.
+  // Reject it so the misconfiguration is visible at construction.
+  for (let i = 0; i < modulesOrOptions.length - 1; i += 1) {
+    const arg = modulesOrOptions[i];
+    if (typeof arg === 'object' && arg !== null && hasOptionsBrand(arg)) {
+      throw new ValidationError(
+        `topo.options(...) must be the final argument to topo(); received at position ${i + 2} of ${modulesOrOptions.length + 1}.`
+      );
+    }
+  }
+
+  const last = modulesOrOptions.at(-1);
+  const classification = classifyTrailingArgument(last);
+
+  if (classification.kind === 'invalid') {
+    throw new ValidationError(classification.message);
+  }
+  if (classification.kind === 'options') {
+    return {
+      modules: modulesOrOptions.slice(0, -1) as Record<string, unknown>[],
+      options: classification.options,
+    };
+  }
+  return {
+    modules: modulesOrOptions as readonly Record<string, unknown>[],
+    options: undefined,
+  };
+};
+
+/**
+ * Brand a plain `TopoOptions` payload so `topo()` treats the trailing
+ * argument as options unambiguously, regardless of which keys it
+ * contains. Useful when a module export shape would otherwise collide
+ * with the inline shorthand (e.g. a module exporting only `observe`).
+ *
+ * @example
+ * ```ts
+ * topo('app', userTrails, topo.options({ observe: traceSink }));
+ * ```
+ */
+const describeNonPlainObject = (value: unknown): string => {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  return typeof value;
+};
+
+const brandTopoOptions = (options: TopoOptions): TopoOptions => {
+  // Reject non-plain-object inputs up front. `{ ...options }` happily
+  // accepts `null`, `undefined`, primitives, and arrays, silently
+  // producing an empty branded payload that callers would then assume
+  // carried real options. Throwing here mirrors the strict handling
+  // applied to other malformed options elsewhere in the classifier.
+  if (
+    typeof options !== 'object' ||
+    options === null ||
+    Array.isArray(options)
+  ) {
+    throw new ValidationError(
+      `topo.options() expects a plain options object; received ${describeNonPlainObject(
+        options
+      )}`
+    );
+  }
+  // Return a fresh object rather than mutating the caller's payload.
+  // Mutating in place breaks frozen / non-extensible inputs (for example
+  // `topo.options(Object.freeze({ observe: sink }))`), which would throw
+  // a `TypeError` from `Object.defineProperty` even though the value is
+  // a valid `TopoOptions` shape.
+  const branded = { ...options };
+  Object.defineProperty(branded, TOPO_OPTIONS_BRAND, {
+    configurable: false,
+    enumerable: false,
+    value: true,
+    writable: false,
+  });
+  return branded;
+};
+
+interface TopoFn {
+  (
+    nameOrIdentity: string | TopoIdentity,
+    ...modulesOrOptions: (Record<string, unknown> | TopoOptions)[]
+  ): Topo;
+  /**
+   * Brand a plain `TopoOptions` payload so `topo()` treats the trailing
+   * argument as options unambiguously, regardless of key shape. Use this
+   * when a module export shape might otherwise collide with the inline
+   * options shorthand.
+   */
+  readonly options: (options: TopoOptions) => TopoOptions;
+}
+
+const topoImpl = (
   nameOrIdentity: string | TopoIdentity,
-  ...modules: Record<string, unknown>[]
+  ...modulesOrOptions: (Record<string, unknown> | TopoOptions)[]
 ): Topo => {
   const identity: TopoIdentity =
     typeof nameOrIdentity === 'string'
       ? { name: nameOrIdentity }
       : nameOrIdentity;
+  const { modules, options } = splitTopoArguments(modulesOrOptions);
+  const observe = normalizeObserve(options?.observe);
 
   const contours = new Map<string, AnyContour>();
   const trails = new Map<string, AnyTrail>();
@@ -493,6 +799,11 @@ export const topo = (
     contours,
     finalizeTrailSignals(trails, resources),
     signals,
-    resources
+    resources,
+    observe
   );
 };
+
+export const topo: TopoFn = Object.assign(topoImpl, {
+  options: brandTopoOptions,
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -157,6 +157,29 @@ export interface Logger {
   child(context: Record<string, unknown>): Logger;
 }
 
+export type LogLevel =
+  | 'debug'
+  | 'error'
+  | 'fatal'
+  | 'info'
+  | 'silent'
+  | 'trace'
+  | 'warn';
+
+export interface LogRecord {
+  readonly category: string;
+  readonly level: LogLevel;
+  readonly message: string;
+  readonly metadata: Record<string, unknown>;
+  readonly timestamp: Date;
+}
+
+export interface LogSink {
+  readonly name: string;
+  readonly write: (record: LogRecord) => void;
+  readonly flush?: (() => Promise<void>) | undefined;
+}
+
 /**
  * Context extension key for the invoking surface name.
  *

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -13,6 +13,7 @@ import {
   executeTrail,
   filterSurfaceTrails,
   getActivationWherePredicate,
+  getTraceSink,
   matchesTrailPattern,
   TRACE_CONTEXT_KEY,
   traceContextFromRecord,
@@ -144,6 +145,7 @@ const webhookActivationTraceAttrs = (
 });
 
 const recordWebhookActivationTrace = async (
+  graph: Topo,
   source: WebhookSource,
   activation: ActivationProvenance,
   trailId: string,
@@ -155,7 +157,9 @@ const recordWebhookActivationTrace = async (
     name,
     webhookActivationTraceAttrs(source, activation, trailId),
     status,
-    errorCategory
+    errorCategory,
+    undefined,
+    graph.observe?.trace ?? getTraceSink()
   );
   return record === undefined ? undefined : traceContextFromRecord(record);
 };
@@ -175,10 +179,15 @@ type WebhookInvalidConsumerRecorder = (
 ) => Promise<void>;
 
 const createWebhookInvalidRecorder =
-  (source: WebhookSource, trailId: string): WebhookInvalidConsumerRecorder =>
+  (
+    graph: Topo,
+    source: WebhookSource,
+    trailId: string
+  ): WebhookInvalidConsumerRecorder =>
   async (errorCategory, activationFireId) => {
     const activation = webhookActivationProvenance(source, activationFireId);
     await recordWebhookActivationTrace(
+      graph,
       source,
       activation,
       trailId,
@@ -294,6 +303,7 @@ const createWebhookConsumerExecute =
 
     const activation = webhookActivationProvenance(source, activationFireId);
     const traceContext = await recordWebhookActivationTrace(
+      graph,
       source,
       activation,
       t.id,
@@ -519,6 +529,7 @@ const buildWebhookRoute = (
     options
   );
   const consumerInvalidRecorder = createWebhookInvalidRecorder(
+    graph,
     source.value,
     trail.id
   );


### PR DESCRIPTION
## Summary
`topo()` now takes an `observe` option so apps can declare which sinks receive activation traces directly on the topo, alongside resources and modules. No more wiring observers through ambient state or surface-specific glue.

## What changed
- New `packages/core/src/observe.ts` defines the `observe` option shape and resolution rules (named slots, default sink, ambiguity errors).
- `packages/core/src/topo.ts` learns the new option and threads it through to the execution and fire paths.
- `packages/core/src/execute.ts`, `fire.ts`, `schedule-runtime.ts`, and `internal/tracing.ts` consume the resolved observers.
- `packages/http/src/build.ts` carries the resolved observers through HTTP-side activation traces.
- New `types.ts` exports for the observe option; `packages/core/src/__tests__/topo.test.ts` adds extensive coverage of slots, defaults, and rejection of malformed options.
- `packages/core/README.md`, `docs/api-reference.md`, and the unified-observability draft updated.

## Stack
Builds on #359 (record contract) and #360 (default sink). #362–#364 ship `@ontrails/observe`, the package this option is designed to plug into.

## Linear
https://linear.app/outfitter/issue/TRL-422/add-observe-parameter-to-topo