### PR TITLE
feat(observe): scaffold observe package

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -7,6 +7,7 @@
     "@ontrails/cli": "0.1.0",
     "@ontrails/core": "0.1.0",
     "@ontrails/logging": "0.1.0",
+    "@ontrails/observe": "0.1.0",
     "@ontrails/mcp": "0.1.0",
     "@ontrails/schema": "0.1.0",
     "@ontrails/testing": "0.1.0",

--- a/bun.lock
+++ b/bun.lock
@@ -176,6 +176,13 @@
         "zod": "catalog:",
       },
     },
+    "packages/observe": {
+      "name": "@ontrails/observe",
+      "version": "1.0.0-beta.15",
+      "peerDependencies": {
+        "@ontrails/core": "workspace:^",
+      },
+    },
     "packages/oxlint-plugin": {
       "name": "@ontrails/oxlint-plugin",
       "version": "1.0.0-beta.15",
@@ -342,6 +349,8 @@
     "@ontrails/logtape": ["@ontrails/logtape@workspace:packages/logtape"],
 
     "@ontrails/mcp": ["@ontrails/mcp@workspace:packages/mcp"],
+
+    "@ontrails/observe": ["@ontrails/observe@workspace:packages/observe"],
 
     "@ontrails/oxlint-plugin": ["@ontrails/oxlint-plugin@workspace:packages/oxlint-plugin"],
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,6 +79,7 @@ export type {
   FireFn,
   BasePermit,
   LogLevel,
+  LogFormatter,
   LogRecord,
   LogSink,
   PermitRequirement,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -180,6 +180,10 @@ export interface LogSink {
   readonly flush?: (() => Promise<void>) | undefined;
 }
 
+export interface LogFormatter {
+  format(record: LogRecord): string;
+}
+
 /**
  * Context extension key for the invoking surface name.
  *

--- a/packages/observe/README.md
+++ b/packages/observe/README.md
@@ -1,0 +1,7 @@
+# @ontrails/observe
+
+Primitive observability contracts for Trails.
+
+This package is the public home for log and trace sink shapes used by Trails
+apps and connectors. The initial surface re-exports the core contracts; runtime
+sink helpers are added in focused follow-up branches.

--- a/packages/observe/package.json
+++ b/packages/observe/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ontrails/observe",
+  "version": "1.0.0-beta.15",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@ontrails/core": "workspace:^"
+  }
+}

--- a/packages/observe/src/__tests__/index.test.ts
+++ b/packages/observe/src/__tests__/index.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+import type {
+  Logger,
+  LogFormatter,
+  LogLevel,
+  LogRecord,
+  LogSink,
+  ObserveCapabilities,
+  TraceContext,
+  TraceRecord,
+  TraceSink,
+} from '@ontrails/observe';
+
+const createLogRecord = (level: LogLevel): LogRecord => ({
+  category: 'observe.test',
+  level,
+  message: 'observability package type smoke',
+  metadata: { package: '@ontrails/observe' },
+  timestamp: new Date(0),
+});
+
+const createTraceRecord = (): TraceRecord => ({
+  attrs: {},
+  id: 'span-1',
+  kind: 'span',
+  name: 'observe.smoke',
+  rootId: 'root-1',
+  startedAt: 1,
+  status: 'ok',
+  traceId: 'trace-1',
+});
+
+describe('@ontrails/observe', () => {
+  test('re-exports core log and trace contracts', async () => {
+    const logRecords: LogRecord[] = [];
+    const traceRecords: TraceRecord[] = [];
+    const messages: string[] = [];
+    const context: TraceContext = {
+      rootId: 'root-1',
+      sampled: true,
+      spanId: 'span-1',
+      traceId: 'trace-1',
+    };
+    const capabilities: ObserveCapabilities = { log: true, trace: true };
+    const formatter: LogFormatter = {
+      format: (record) => `${record.level}:${record.message}`,
+    };
+    const logSink: LogSink = {
+      name: 'capture',
+      write: (record) => {
+        logRecords.push(record);
+      },
+    };
+    const traceSink: TraceSink = {
+      write: (record) => {
+        traceRecords.push(record);
+      },
+    };
+    const logger: Logger = {
+      child: () => logger,
+      debug: (message) => messages.push(message),
+      error: (message) => messages.push(message),
+      fatal: (message) => messages.push(message),
+      info: (message) => messages.push(message),
+      name: 'observe.test',
+      trace: (message) => messages.push(message),
+      warn: (message) => messages.push(message),
+    };
+
+    const record = createLogRecord('info');
+    logSink.write(record);
+    await traceSink.write(createTraceRecord());
+    logger.info(context.traceId);
+
+    expect(formatter.format(record)).toBe(
+      'info:observability package type smoke'
+    );
+    expect(logRecords).toEqual([record]);
+    expect(traceRecords[0]?.traceId).toBe(context.traceId);
+    expect(capabilities).toEqual({ log: true, trace: true });
+    expect(messages).toEqual([context.traceId]);
+  });
+});

--- a/packages/observe/src/index.ts
+++ b/packages/observe/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Primitive observability API for Trails.
+ *
+ * `@ontrails/observe` is the public package for log and trace sink contracts.
+ * Connector packages should build on these types instead of importing
+ * framework internals directly.
+ *
+ * @see {@link https://github.com/outfitter-dev/trails/blob/main/docs/adr/0041-unified-observability.md | ADR-0041 Unified Observability}
+ */
+export type {
+  Logger,
+  LogFormatter,
+  LogLevel,
+  LogRecord,
+  LogSink,
+  ObserveCapabilities,
+  ObserveConfig,
+  ObserveInput,
+  TraceContext,
+  TraceRecord,
+  TraceSink,
+} from '@ontrails/core';

--- a/packages/observe/tsconfig.json
+++ b/packages/observe/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/packages/observe/tsconfig.tests.json
+++ b/packages/observe/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
Scaffold the new `@ontrails/observe` package — the contract surface for sinks that consume the activation trace records from #359, configured via the `topo({ observe })` option from #361.

## What changed
- New package at `packages/observe` with `package.json`, `tsconfig.json`, `tsconfig.tests.json`, and a starter `README.md`.
- Public surface in `packages/observe/src/index.ts` re-exports the observe types from core and defines the package contract.
- `packages/core/src/types.ts` and `index.ts` extended with the shared observe types so core and observe stay in lockstep.
- Workspace registered in `bun.lock` and `.changeset/pre.json`.
- `packages/observe/src/__tests__/index.test.ts` pins the public contract.

## Stack
Builds on #361. #363 adds the multi-sink composer; #364 ships the built-in console/memory/file sinks.

## Linear
https://linear.app/outfitter/issue/TRL-432/scaffold-ontrailsobserve-package