### PR TITLE
feat(observe): add sink composer

### DIFF
--- a/packages/observe/README.md
+++ b/packages/observe/README.md
@@ -5,3 +5,9 @@ Primitive observability contracts for Trails.
 This package is the public home for log and trace sink shapes used by Trails
 apps and connectors. The initial surface re-exports the core contracts; runtime
 sink helpers are added in focused follow-up branches.
+
+```typescript
+import { combine } from '@ontrails/observe';
+
+const sink = combine(otelSink, fileSink);
+```

--- a/packages/observe/src/__tests__/combine.test.ts
+++ b/packages/observe/src/__tests__/combine.test.ts
@@ -1,0 +1,292 @@
+import { ValidationError } from '@ontrails/core';
+import { describe, expect, test } from 'bun:test';
+import { combine } from '../combine.js';
+import type { LogRecord, LogSink, TraceRecord, TraceSink } from '../index.js';
+
+const createLogRecord = (message = 'hello'): LogRecord => ({
+  category: 'observe.test',
+  level: 'info',
+  message,
+  metadata: {},
+  timestamp: new Date(0),
+});
+
+const createTraceRecord = (name = 'observe.trace'): TraceRecord => ({
+  attrs: {},
+  id: `${name}.id`,
+  kind: 'span',
+  name,
+  rootId: 'root-1',
+  startedAt: 1,
+  status: 'ok',
+  traceId: 'trace-1',
+});
+
+describe('combine', () => {
+  describe('empty sink rejection', () => {
+    test('throws ValidationError when called with zero sinks', () => {
+      expect(() => combine()).toThrow(ValidationError);
+      expect(() => combine()).toThrow(/at least one sink/i);
+    });
+
+    test('throws ValidationError when called with an empty array spread', () => {
+      const sinks: readonly LogSink[] = [];
+      expect(() => combine(...sinks)).toThrow(ValidationError);
+    });
+
+    test('accepts a single sink', () => {
+      const records: LogRecord[] = [];
+      const only: LogSink = {
+        name: 'only',
+        write: (record) => {
+          records.push(record);
+        },
+      };
+
+      expect(() => combine(only)).not.toThrow();
+
+      const sink = combine(only);
+      const record = createLogRecord('single');
+      sink.write(record);
+
+      expect(records).toEqual([record]);
+      expect(sink.observes).toEqual({ log: true });
+    });
+  });
+
+  test('fans out log records to every child sink', () => {
+    const firstRecords: LogRecord[] = [];
+    const secondRecords: LogRecord[] = [];
+    const first: LogSink = {
+      name: 'first',
+      write: (record) => {
+        firstRecords.push(record);
+      },
+    };
+    const second: LogSink = {
+      name: 'second',
+      write: (record) => {
+        secondRecords.push(record);
+      },
+    };
+    const sink = combine(first, second);
+    const record = createLogRecord();
+
+    sink.write(record);
+
+    expect(firstRecords).toEqual([record]);
+    expect(secondRecords).toEqual([record]);
+  });
+
+  test('fans out trace records to async child sinks', async () => {
+    const firstRecords: TraceRecord[] = [];
+    const secondRecords: TraceRecord[] = [];
+    const first: TraceSink = {
+      write: (record) => {
+        firstRecords.push(record);
+      },
+    };
+    const second: TraceSink = {
+      write: async (record) => {
+        secondRecords.push(record);
+      },
+    };
+    const sink = combine(first, second);
+    const record = createTraceRecord();
+
+    await sink.write(record);
+
+    expect(firstRecords).toEqual([record]);
+    expect(secondRecords).toEqual([record]);
+  });
+
+  test('exposes combined log and trace capabilities', () => {
+    const log: LogSink = { name: 'log', write: () => {} };
+    const trace: TraceSink = { write: () => {} };
+    const sink = combine(log, trace);
+
+    expect(sink.observes).toEqual({ log: true, trace: true });
+  });
+
+  test('routes mixed records only to compatible child sinks', async () => {
+    const logRecords: LogRecord[] = [];
+    const traceRecords: TraceRecord[] = [];
+    const log: LogSink = {
+      name: 'log',
+      write: (record) => {
+        logRecords.push(record);
+      },
+    };
+    const trace: TraceSink = {
+      write: (record) => {
+        traceRecords.push(record);
+      },
+    };
+    const sink = combine(log, trace);
+    const logRecord = createLogRecord('routed log');
+    const traceRecord = createTraceRecord('observe.routed');
+
+    sink.write(logRecord);
+    await sink.write(traceRecord);
+
+    expect(logRecords).toEqual([logRecord]);
+    expect(traceRecords).toEqual([traceRecord]);
+  });
+
+  test('honors explicit trace capabilities on named sinks', async () => {
+    const traceRecords: TraceRecord[] = [];
+    const namedTrace: TraceSink & {
+      readonly name: string;
+      readonly observes: { readonly trace: true };
+    } = {
+      name: 'named-trace',
+      observes: { trace: true },
+      write: (record) => {
+        traceRecords.push(record);
+      },
+    };
+    const sink = combine(namedTrace);
+    const record = createTraceRecord('observe.named');
+
+    await sink.write(record);
+
+    expect(sink.observes).toEqual({ trace: true });
+    expect(traceRecords).toEqual([record]);
+  });
+
+  test('isolates synchronous child sink errors and reports them to log-capable siblings', () => {
+    const goodRecords: LogRecord[] = [];
+    const bad: LogSink = {
+      name: 'bad',
+      write: () => {
+        throw new Error('sink exploded');
+      },
+    };
+    const good: LogSink = {
+      name: 'good',
+      write: (record) => {
+        goodRecords.push(record);
+      },
+    };
+    const sink = combine(bad, good);
+    const record = createLogRecord('original');
+
+    expect(() => sink.write(record)).not.toThrow();
+
+    expect(goodRecords[0]).toBe(record);
+    expect(goodRecords[1]).toMatchObject({
+      category: 'observe.combine',
+      level: 'warn',
+      message: 'Observe sink write failed; continuing with remaining sinks',
+      metadata: {
+        error: 'sink exploded',
+        recordCategory: 'observe.test',
+        sinkIndex: 0,
+        sinkName: 'bad',
+      },
+    });
+  });
+
+  test('isolates rejected async child sink writes', async () => {
+    const goodRecords: TraceRecord[] = [];
+    const bad: TraceSink = {
+      write: async () => {
+        throw new Error('async sink exploded');
+      },
+    };
+    const good: TraceSink = {
+      write: (record) => {
+        goodRecords.push(record);
+      },
+    };
+    const sink = combine(bad, good);
+    const record = createTraceRecord('observe.async');
+
+    await expect(sink.write(record)).resolves.toBeUndefined();
+
+    expect(goodRecords).toEqual([record]);
+  });
+
+  test('reports rejected async child sink writes to log-capable siblings', async () => {
+    const logRecords: LogRecord[] = [];
+    const bad: TraceSink = {
+      write: async () => {
+        throw new Error('async sink exploded');
+      },
+    };
+    const log: LogSink = {
+      name: 'log',
+      write: (record) => {
+        logRecords.push(record);
+      },
+    };
+    const sink = combine(bad, log);
+    const record = createTraceRecord('observe.async.reported');
+
+    await expect(sink.write(record)).resolves.toBeUndefined();
+
+    expect(logRecords).toHaveLength(1);
+    expect(logRecords[0]).toMatchObject({
+      category: 'observe.combine',
+      level: 'warn',
+      message: 'Observe sink write failed; continuing with remaining sinks',
+      metadata: {
+        error: 'async sink exploded',
+        recordId: 'observe.async.reported.id',
+        sinkIndex: 0,
+        traceId: 'trace-1',
+      },
+    });
+  });
+
+  test('flushes every flushable child and isolates flush errors', async () => {
+    const flushed: string[] = [];
+    const bad: LogSink = {
+      flush: async () => {
+        throw new Error('flush exploded');
+      },
+      name: 'bad',
+      write: () => {},
+    };
+    const good: LogSink = {
+      flush: async () => {
+        flushed.push('good');
+      },
+      name: 'good',
+      write: () => {},
+    };
+    const trace: TraceSink & { readonly flush: () => Promise<void> } = {
+      flush: async () => {
+        flushed.push('trace');
+      },
+      write: () => {},
+    };
+    const sink = combine(bad, good, trace);
+
+    await expect(sink.flush()).resolves.toBeUndefined();
+
+    expect(flushed).toEqual(['good', 'trace']);
+  });
+
+  test('flush preserves child sink method bindings', async () => {
+    class ClassSink implements LogSink {
+      readonly flushed: string[] = [];
+      readonly name = 'class-sink';
+
+      async flush(): Promise<void> {
+        this.flushed.push(this.name);
+      }
+
+      write(): void {
+        expect(this.name).toBe('class-sink');
+      }
+    }
+
+    const classSink = new ClassSink();
+    const sink = combine(classSink);
+
+    await expect(sink.flush()).resolves.toBeUndefined();
+
+    expect(classSink.flushed).toEqual(['class-sink']);
+  });
+});

--- a/packages/observe/src/combine.ts
+++ b/packages/observe/src/combine.ts
@@ -1,0 +1,280 @@
+import { ValidationError } from '@ontrails/core';
+import type {
+  LogRecord,
+  LogSink,
+  ObserveCapabilities,
+  TraceRecord,
+  TraceSink,
+} from '@ontrails/core';
+
+type ObserveRecord = LogRecord | TraceRecord;
+type ObserveSink = LogSink | TraceSink;
+type SinkWrite = (record: ObserveRecord) => void | Promise<void>;
+type FlushableSink = ObserveSink & { readonly flush?: () => Promise<void> };
+
+interface SinkFailure {
+  readonly error: unknown;
+  readonly index: number;
+  readonly sinkName: string | undefined;
+}
+
+export interface CombinedSink {
+  readonly name: string;
+  readonly observes: ObserveCapabilities;
+  write(record: LogRecord): void;
+  write(record: TraceRecord): void | Promise<void>;
+  flush(): Promise<void>;
+}
+
+const isPromiseLike = (value: unknown): value is PromiseLike<unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as { readonly then?: unknown }).then === 'function';
+
+const isLogSink = (sink: ObserveSink): sink is LogSink =>
+  'name' in sink && typeof sink.name === 'string';
+
+const isLogRecord = (record: ObserveRecord): record is LogRecord =>
+  'level' in record && 'message' in record && 'timestamp' in record;
+
+const readObserveCapabilities = (
+  sink: ObserveSink
+): ObserveCapabilities | undefined => {
+  const capabilities = (sink as { readonly observes?: unknown }).observes;
+  if (typeof capabilities !== 'object' || capabilities === null) {
+    return undefined;
+  }
+  const log = (capabilities as ObserveCapabilities).log === true;
+  const trace = (capabilities as ObserveCapabilities).trace === true;
+  if (!log && !trace) {
+    return undefined;
+  }
+  return Object.freeze({
+    ...(log ? { log: true as const } : {}),
+    ...(trace ? { trace: true as const } : {}),
+  });
+};
+
+const capabilitiesForSink = (sink: ObserveSink): ObserveCapabilities =>
+  readObserveCapabilities(sink) ??
+  Object.freeze(
+    isLogSink(sink) ? { log: true as const } : { trace: true as const }
+  );
+
+const combineCapabilities = (
+  sinks: readonly ObserveSink[]
+): ObserveCapabilities => {
+  let log = false;
+  let trace = false;
+  for (const sink of sinks) {
+    const capabilities = capabilitiesForSink(sink);
+    log ||= capabilities.log === true;
+    trace ||= capabilities.trace === true;
+  }
+  return Object.freeze({
+    ...(log ? { log: true as const } : {}),
+    ...(trace ? { trace: true as const } : {}),
+  });
+};
+
+const sinkName = (sink: ObserveSink): string | undefined =>
+  'name' in sink && typeof sink.name === 'string' ? sink.name : undefined;
+
+const flushForSink = (sink: ObserveSink): (() => Promise<void>) | undefined => {
+  const { flush } = sink as FlushableSink;
+  return typeof flush === 'function' ? flush.bind(sink) : undefined;
+};
+
+const canReceiveRecord = (
+  sink: ObserveSink,
+  record: ObserveRecord
+): boolean => {
+  const capabilities = capabilitiesForSink(sink);
+  return isLogRecord(record)
+    ? capabilities.log === true
+    : capabilities.trace === true;
+};
+
+const describeError = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const createFailureRecord = (
+  failure: SinkFailure,
+  record: ObserveRecord
+): LogRecord => ({
+  category: 'observe.combine',
+  level: 'warn',
+  message: 'Observe sink write failed; continuing with remaining sinks',
+  metadata: {
+    error: describeError(failure.error),
+    sinkIndex: failure.index,
+    ...(failure.sinkName === undefined ? {} : { sinkName: failure.sinkName }),
+    ...(isLogRecord(record)
+      ? { recordCategory: record.category }
+      : { recordId: record.id, traceId: record.traceId }),
+  },
+  timestamp: new Date(),
+});
+
+const writeToSink = (
+  sink: ObserveSink,
+  record: ObserveRecord
+): void | Promise<void> => {
+  // Call via the sink so class-based sinks keep `this` bound. Detaching the
+  // method (e.g. `(sink.write as SinkWrite)(record)`) would lose `this` and
+  // any class-method `write` would throw — silently dropping records since
+  // combine() swallows child errors. Mirrors flushForSink's binding.
+  const write = sink.write as SinkWrite;
+  return write.call(sink, record);
+};
+
+const ignoreReportFailure = async (
+  result: PromiseLike<unknown>
+): Promise<void> => {
+  try {
+    await result;
+  } catch {
+    // Error reporting is best-effort.
+  }
+};
+
+const reportFailures = (
+  sinks: readonly ObserveSink[],
+  failures: readonly SinkFailure[],
+  record: ObserveRecord
+): void => {
+  if (failures.length === 0) {
+    return;
+  }
+
+  const logSinks = sinks
+    .map((sink, index) => ({ index, sink }))
+    .filter(
+      (entry): entry is { readonly index: number; readonly sink: LogSink } =>
+        capabilitiesForSink(entry.sink).log === true && isLogSink(entry.sink)
+    );
+
+  for (const failure of failures) {
+    const failureRecord = createFailureRecord(failure, record);
+    for (const entry of logSinks) {
+      if (entry.index === failure.index) {
+        continue;
+      }
+      try {
+        const result = entry.sink.write(failureRecord);
+        if (isPromiseLike(result)) {
+          void ignoreReportFailure(result);
+        }
+      } catch {
+        // Error reporting is best-effort; the original write path is already isolated.
+      }
+    }
+  }
+};
+
+const createFailure = (
+  sink: ObserveSink,
+  index: number,
+  error: unknown
+): SinkFailure => ({
+  error,
+  index,
+  sinkName: sinkName(sink),
+});
+
+const isolateAsyncWriteFailure = async (
+  result: PromiseLike<unknown>,
+  sink: ObserveSink,
+  index: number,
+  failures: SinkFailure[]
+): Promise<void> => {
+  try {
+    await result;
+  } catch (error) {
+    failures.push(createFailure(sink, index, error));
+  }
+};
+
+const reportAfterPendingWrites = async (
+  pending: readonly Promise<void>[],
+  sinks: readonly ObserveSink[],
+  failures: readonly SinkFailure[],
+  record: ObserveRecord
+): Promise<void> => {
+  await Promise.all(pending);
+  reportFailures(sinks, failures, record);
+};
+
+/**
+ * Compose multiple observability sinks into one fan-out sink.
+ *
+ * @example
+ * ```typescript
+ * const sink = combine(otelSink, fileSink)
+ * const app = topo('app', trails, { observe: sink })
+ * ```
+ *
+ * @remarks
+ * A child sink failure never prevents sibling sinks from receiving the same
+ * record. Failures are swallowed and reported to log-capable sibling sinks
+ * when one is present.
+ */
+export function combine(...sinks: readonly LogSink[]): CombinedSink;
+export function combine(...sinks: readonly TraceSink[]): CombinedSink;
+export function combine(...sinks: readonly ObserveSink[]): CombinedSink;
+export function combine(...sinks: readonly ObserveSink[]): CombinedSink {
+  if (sinks.length === 0) {
+    throw new ValidationError(
+      'combine() requires at least one sink; an empty composition has no observe capabilities and would fail topo validation.'
+    );
+  }
+
+  const observes = combineCapabilities(sinks);
+
+  return {
+    async flush(): Promise<void> {
+      await Promise.all(
+        sinks.map(async (sink) => {
+          const flush = flushForSink(sink);
+          if (flush === undefined) {
+            return;
+          }
+          try {
+            await flush();
+          } catch {
+            // Flush follows write isolation: one broken sink should not block shutdown.
+          }
+        })
+      );
+    },
+    name: 'combined',
+    observes,
+    write(record: ObserveRecord): void | Promise<void> {
+      const failures: SinkFailure[] = [];
+      const pending: Promise<void>[] = [];
+
+      for (const [index, sink] of sinks.entries()) {
+        if (!canReceiveRecord(sink, record)) {
+          continue;
+        }
+        try {
+          const result = writeToSink(sink, record);
+          if (isPromiseLike(result)) {
+            pending.push(
+              isolateAsyncWriteFailure(result, sink, index, failures)
+            );
+          }
+        } catch (error) {
+          failures.push(createFailure(sink, index, error));
+        }
+      }
+
+      if (pending.length === 0) {
+        reportFailures(sinks, failures, record);
+        return undefined;
+      }
+
+      return reportAfterPendingWrites(pending, sinks, failures, record);
+    },
+  };
+}

--- a/packages/observe/src/index.ts
+++ b/packages/observe/src/index.ts
@@ -7,6 +7,9 @@
  *
  * @see {@link https://github.com/outfitter-dev/trails/blob/main/docs/adr/0041-unified-observability.md | ADR-0041 Unified Observability}
  */
+export { combine } from './combine.js';
+export type { CombinedSink } from './combine.js';
+
 export type {
   Logger,
   LogFormatter,


### PR DESCRIPTION
## Summary
Add `combine(...)` to `@ontrails/observe` so multiple sinks can be fanned out as one — the standard "log to console *and* keep an in-memory buffer" pattern, expressed as data instead of glue code.

## What changed
- New `packages/observe/src/combine.ts` implements the multi-sink composer with named-slot resolution, error isolation, and async flush coordination.
- Exported from `packages/observe/src/index.ts`.
- README updated with the composition pattern.
- `packages/observe/src/__tests__/combine.test.ts` covers fan-out, isolation between failing sinks, flush ordering, and naming.

## Stack
Builds on #362. #364 ships the built-in sinks this composer is designed to combine.

## Linear
https://linear.app/outfitter/issue/TRL-423/combine-multi-sink-composer-in-ontrailsobserve