### PR TITLE
docs(adr): cross-reference tracing ownership

### DIFF
--- a/docs/adr/drafts/20260409-layer-evolution.md
+++ b/docs/adr/drafts/20260409-layer-evolution.md
@@ -3,7 +3,7 @@ slug: layer-evolution
 title: Layer Evolution
 status: draft
 created: 2026-04-09
-updated: 2026-04-28
+updated: 2026-05-02
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [6, 12]
 ---
@@ -35,6 +35,8 @@ The five layers shipped today break down as follows:
 | `configLayer` | Pass-through placeholder | N/A -- delete |
 | `autoIterateLayer` | CLI-specific pagination behavior | Yes -- from output schema shape |
 | `dateShortcutsLayer` | CLI-specific date expansion | Yes -- from input schema shape |
+
+The `tracingLayer` row is resolved by [ADR: Unified Observability](20260409-unified-observability.md): tracing is core execution-pipeline behavior, not an authored layer.
 
 None are genuinely authored cross-cutting concerns. All five are either derivable from trail declarations or intrinsic pipeline behavior. To get basic framework capabilities (auth, recording), the developer imports layers, creates instances, and passes them to every `blaze()` call. That's requiring Level 2 ceremony for Level 0 behavior -- the same anti-pattern as if input validation were a layer you had to import and wire.
 
@@ -317,6 +319,7 @@ The name change from `layers` to `middleware` is intentional. `layers` implied f
 - [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md) -- the execution pipeline that layers currently compose into
 - [ADR-0012: Connector-Agnostic Permits](../0012-connector-agnostic-permits.md) -- permit declarations that become pipeline-enforced
 - [ADR-0013: Tracing -- Runtime Recording Primitive](../0013-tracing.md) -- recording that becomes a pipeline stage
+- [ADR: Unified Observability](20260409-unified-observability.md) -- resolves the obsolete `tracingLayer` concept by moving tracing into core rather than preserving it as a layer
 - [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- intent compounds with layers for surface derivation and governance
 - [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- `crossInput` follows the same "compose schemas, project the union" pattern as layer input schemas
 - [Tenets: One write, many reads](../../tenets.md) -- layer input schemas exemplify one authoring point feeding CLI flags, MCP parameters, HTTP query params, and lockfile diffing simultaneously

--- a/docs/adr/drafts/20260409-unified-observability.md
+++ b/docs/adr/drafts/20260409-unified-observability.md
@@ -3,7 +3,7 @@ slug: unified-observability
 title: Unified Observability
 status: draft
 created: 2026-04-09
-updated: 2026-04-09
+updated: 2026-05-02
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [6, 13]
 supersedes: ['13']
@@ -55,6 +55,8 @@ The `Logger` interface is already in core. The following join it:
 - **Trace record data model.** The `TraceRecord` interface describing one recorded execution footprint. The developer-facing word is "trace" (as verb and noun). The internal type is `TraceRecord` to avoid overloading "trace" (which can mean one record or an entire execution tree in industry usage). Records can describe trail execution, manual spans, signal lifecycle points, or activation boundaries.
 - **Memory trace sink.** Bounded in-memory trace storage, sufficient for development and `trails run --trace` without unbounded process growth.
 - **`ctx.trace()` method.** Manual sub-step recording within a blaze, replacing `tracker.from(ctx).track()`.
+
+This also resolves the `tracingLayer` concern named in [ADR: Layer Evolution](20260409-layer-evolution.md): tracing is a core pipeline capability, not a user-authored layer.
 
 A developer who installs `@ontrails/core` and `@ontrails/cli` gets:
 
@@ -274,6 +276,7 @@ Everything else — OTel, file sinks, SQLite dev stores, pretty formatters, samp
 
 - [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) — `executeTrail` is the chokepoint where tracing wraps. Moving tracing into core puts it next to the pipeline it instruments.
 - [ADR-0013: Tracing](../0013-tracing.md) — the decision this supersedes. The architectural choices (flat records, callback-only manual API, root-level sampling, crossing propagation through execution scope) remain valid. The change is packaging and vocabulary, not mechanism.
+- [ADR: Layer Evolution](20260409-layer-evolution.md) — identifies `tracingLayer` as framework behavior dressed as user configuration; this ADR resolves it by making tracing core.
 - [Tenets: One write, many reads](../../tenets.md) — the governing principle. Trace data authored once feeds `--trace` rendering, OTel export, SQLite dev store, and future replay.
 - OpenTelemetry specification — the industry standard this aligns with for vocabulary and export format.
 


### PR DESCRIPTION
## Summary
Cross-reference the layer-evolution and unified-observability drafts so the doctrinal record is clear: tracing is core, not a layer. Layers wrap execution; tracing is part of the trail contract.

## What changed
- `docs/adr/drafts/20260409-layer-evolution.md` and `docs/adr/drafts/20260409-unified-observability.md` now link to each other in the relevant sections.

## Stack
Final pre-acceptance docs polish before #366 promotes unified observability.

## Linear
https://linear.app/outfitter/issue/TRL-440/cross-reference-layer-evolution-tracing-is-core-not-a-layer