### PR TITLE
docs(adr): accept unified observability

### DIFF
--- a/.changeset/unified-observability-adr.md
+++ b/.changeset/unified-observability-adr.md
@@ -1,0 +1,13 @@
+---
+"@ontrails/core": minor
+"@ontrails/http": minor
+"@ontrails/observe": minor
+"@ontrails/tracing": minor
+"@ontrails/warden": minor
+---
+
+Accept ADR-0041 Unified Observability and ship the first activation and
+observability primitives it depends on: activation trace records, topo-level
+observe configuration, webhook activation materialization, signal/webhook
+warden coaching, the `@ontrails/observe` package, sink composition, and
+zero-dependency observe sinks.

--- a/docs/adr/0039-reactive-trail-activation.md
+++ b/docs/adr/0039-reactive-trail-activation.md
@@ -335,7 +335,7 @@ Reactive activation v1 does not define:
   materialization, validation, Warden, survey, serialized graph state, and
   tracing provenance.
 - **Activation runtime records are shared observability data.** The
-  [Unified Observability](drafts/20260409-unified-observability.md) draft
+  [Unified Observability](0041-unified-observability.md) ADR
   defines the public `activation.*` trace record names for schedule, webhook,
   and safety boundaries.
 - **External inbound activation is surface-derived.** Webhook paths are rendered
@@ -387,5 +387,5 @@ Reactive activation v1 does not define:
 - [ADR-0038: Typed Signal Emission](0038-typed-signal-emission.md) - signal
   activation builds on typed `ctx.fire()`.
 - [HTTP Surface](../surfaces/http.md) - current webhook materialization guide.
-- [ADR: Unified Observability](drafts/20260409-unified-observability.md)
-  (draft) - decides the public observe package and sink composition layer.
+- [ADR-0041: Unified Observability](0041-unified-observability.md) - decides
+  the public observe package and sink composition layer.

--- a/docs/adr/0041-unified-observability.md
+++ b/docs/adr/0041-unified-observability.md
@@ -1,15 +1,15 @@
 ---
+id: 41
 slug: unified-observability
 title: Unified Observability
-status: draft
+status: accepted
 created: 2026-04-09
 updated: 2026-05-02
 owners: ['[galligan](https://github.com/galligan)']
-depends_on: [6, 13]
-supersedes: ['13']
+depends_on: [6, 13, 39]
 ---
 
-# ADR: Unified Observability
+# ADR-0041: Unified Observability
 
 ## Context
 
@@ -18,7 +18,7 @@ supersedes: ['13']
 Trails currently ships two packages for understanding what an app does at runtime:
 
 - **`@ontrails/logging`** — structured logging with sinks and formatters. The developer writes `ctx.logger.info('creating gist')`.
-- **`@ontrails/tracker`** — execution recording with trace propagation. The framework writes a `TraceRecord` for every trail invocation via the execution pipeline.
+- **`@ontrails/tracing`** — execution recording with trace propagation. The framework writes a `TraceRecord` for every trail invocation via the execution pipeline.
 
 These packages are configured separately, installed separately, and documented separately. But they serve the same fundamental need: tell me what happened in my app.
 
@@ -30,7 +30,7 @@ In practice, a developer setting up observability configures two packages, two s
 
 `executeTrail` is in core. `TrailContext` with its `logger` is in core. The `Logger` interface is in core. Trace context propagation flows through `TrailContext`, which is in core. The infrastructure for observability already lives where it belongs. The implementations just live in the wrong packages.
 
-A new developer installing Trails today needs `@ontrails/core` and a trailhead package to get started. If they want to see what their trails are doing, they need to also install `@ontrails/logging` and `@ontrails/tracker`, configure both, and wire them in. That is two extra packages before "hello world" has observability.
+A new developer installing Trails today needs `@ontrails/core` and a trailhead package to get started. If they want to send runtime evidence somewhere durable, they have to understand separate logging and tracing packages, configure separate sinks, and wire them in. That is too much package and setup vocabulary before "hello world" has production-grade observability.
 
 ### The vocabulary question
 
@@ -53,10 +53,10 @@ The `Logger` interface is already in core. The following join it:
 - **Default console logger.** Structured logging to stdout with no configuration. Available on `ctx.logger` automatically.
 - **Built-in tracing.** Automatic execution recording for every trail invocation, intrinsic to the `executeTrail` pipeline. Records which trail ran, how long, what result, what errors, which crossings happened, trace ID propagation. Not an optional layer the developer attaches — it just happens.
 - **Trace record data model.** The `TraceRecord` interface describing one recorded execution footprint. The developer-facing word is "trace" (as verb and noun). The internal type is `TraceRecord` to avoid overloading "trace" (which can mean one record or an entire execution tree in industry usage). Records can describe trail execution, manual spans, signal lifecycle points, or activation boundaries.
-- **Memory trace sink.** Bounded in-memory trace storage, sufficient for development and `trails run --trace` without unbounded process growth.
+- **Trace sink contract and registry.** Core owns the `TraceSink` contract, the process-level trace sink registry, and the `NOOP_SINK` disabled baseline. Core does not own durable or developer-configurable trace storage.
 - **`ctx.trace()` method.** Manual sub-step recording within a blaze, replacing `tracker.from(ctx).track()`.
 
-This also resolves the `tracingLayer` concern named in [ADR: Layer Evolution](20260409-layer-evolution.md): tracing is a core pipeline capability, not a user-authored layer.
+This also resolves the `tracingLayer` concern named in [ADR: Layer Evolution](drafts/20260409-layer-evolution.md): tracing is a core pipeline capability, not a user-authored layer.
 
 A developer who installs `@ontrails/core` and `@ontrails/cli` gets:
 
@@ -120,32 +120,25 @@ This keeps activation visible in traces even when no normal trail record exists,
 
 ### Production observability in `@ontrails/observe`
 
-`@ontrails/logging` and `@ontrails/tracker` merge into a single package: `@ontrails/observe`. This package provides observability connectors — the same pattern Trails uses everywhere (Hono connector, Commander connector, Drizzle connector). Each connector bridges the framework's internal observability data to an external system:
+`@ontrails/observe` is the public package for production and durable observability adapters. The first shipped surface is intentionally small and dependency-free: root exports for log/trace sink contracts, `combine(...)`, console/file log sinks, and bounded memory trace sinks. Connector packages can build on those contracts without importing framework internals directly.
 
-| Connector | Purpose |
+| Initial primitive | Purpose |
 | --- | --- |
-| `otel(options)` | Unified OpenTelemetry export for logs and traces. Owns sampling, batching, and formatting. |
-| `file(options)` | Persistent log output for server environments. |
-| `devStore(options?)` | SQLite-backed persistent trace storage for local development with query support. |
-| `combine(...connectors)` | Compose multiple connectors into one `observe:` declaration. |
+| `combine(...sinks)` | Compose log and trace sinks into one `observe:` declaration. |
+| `createConsoleSink(options?)` | Write log records to the process console. |
+| `createFileSink(options)` | Append log records to a file; retention and rotation stay external. |
+| `createMemorySink(options?)` | Retain bounded trace records for local tooling and tests. |
 
-Subpath exports keep concerns accessible:
-
-```text
-@ontrails/observe
-  /otel      — OpenTelemetry connector
-  /dev       — SQLite dev store
-  /file      — file output connector
-```
+Future connector exports, such as OpenTelemetry export or a SQLite dev store, remain packaging decisions. They belong in or beside `@ontrails/observe`, but this ADR does not canonize exact subpath names or the complete connector set.
 
 ### Dev-time tracing vs production observability
 
 The split is deliberate. Core handles the inner development loop. `@ontrails/observe` handles production.
 
-| Concern | Core (dev-time) | `@ontrails/observe` (production) |
+| Concern | Core (intrinsic) | `@ontrails/observe` and connectors |
 | --- | --- | --- |
 | Logging | Console logger, `ctx.logger` | OTel export, file sinks, pretty formatter |
-| Tracing | In-memory sink, `--trace` rendering | OTel export, SQLite dev store |
+| Tracing | `TraceRecord`, `ctx.trace()`, propagation, sink registry, `NOOP_SINK` | Bounded memory sink, OTel export, SQLite dev store |
 | Configuration | Zero — works out of the box | Connector-level options (sampling, batching, levels) |
 | Dependencies | None beyond core | OpenTelemetry SDK, `bun:sqlite` |
 
@@ -156,9 +149,11 @@ A developer never needs `@ontrails/observe` to build, test, or debug locally. Th
 Observability follows the Trails posture: zero config by default, one declaration to customize.
 
 The process-level sink registry still keeps `NOOP_SINK` as the disabled
-baseline. Bounded memory tracing is the built-in sink used by observe-aware
-tooling and explicit registration; core does not allocate trace records until a
-real sink is installed.
+baseline. Core owns that registry and the trace record contract, but not a
+storage sink. Bounded memory tracing is a package-level sink exposed by
+`@ontrails/observe` for app code and local tooling, and by `@ontrails/tracing`
+as compatibility while the earlier tracing package migrates. Core does not
+allocate trace records until a real sink is installed.
 
 Without `@ontrails/observe`, the default execution path stays inert:
 
@@ -171,34 +166,38 @@ const app = topo('myapp', trails)
 For local tooling or production, plug in a connector or sink:
 
 ```typescript
-import { otel } from '@ontrails/observe/otel'
+import { createMemorySink } from '@ontrails/observe'
 
 const app = topo('myapp', trails, {
-  observe: otel({ endpoint: 'https://otel.example.com' }),
+  observe: createMemorySink({ maxRecords: 500 }),
 })
 ```
 
-The connector owns the details: sampling rates, log levels, formatting, batching. These are connector configuration, not topo configuration. The topo says "observe with this." One declaration.
+The sink or connector owns the details: sampling rates, log levels, formatting, batching. These are connector configuration, not topo configuration. The topo says "observe with this." One declaration.
 
 ```typescript
-otel({
+futureOtelConnector({
   endpoint: 'https://otel.example.com',
   sampling: { read: 0.1, write: 1.0, destroy: 1.0 },
   logging: { level: 'warn' },
 })
 ```
 
-If a developer needs two outputs (OTel for traces, file for logs):
+If a developer needs two outputs:
 
 ```typescript
-import { otel } from '@ontrails/observe/otel'
-import { file } from '@ontrails/observe/file'
-import { combine } from '@ontrails/observe'
+import {
+  combine,
+  createConsoleSink,
+  createFileSink,
+  createMemorySink,
+} from '@ontrails/observe'
 
 const app = topo('myapp', trails, {
   observe: combine(
-    otel({ endpoint: '...' }),
-    file({ path: './logs/app.log' }),
+    createConsoleSink(),
+    createFileSink('./logs/app.log'),
+    createMemorySink({ maxRecords: 500 }),
   ),
 })
 ```
@@ -213,8 +212,8 @@ Still one `observe:` declaration. The complexity lives in the connector, not the
 | `Track` | `TraceRecord` (internal type; developer-facing word is "trace") |
 | `trackerGate` | built-in tracing (intrinsic to `executeTrail`, not a separately attached layer) |
 | `tracker.from(ctx).track('name', fn)` | `ctx.trace('name', fn)` |
-| `@ontrails/tracker` | `@ontrails/observe` (merged) |
-| `@ontrails/logging` | `@ontrails/observe` (merged) |
+| `@ontrails/tracing` sinks | `@ontrails/observe` contracts and adapters |
+| `@ontrails/logging` sinks | `@ontrails/observe` contracts and adapters |
 | `crumbs` (original) | no longer relevant |
 
 The developer-facing logger vocabulary does not change. `ctx.logger.info()`, `ctx.logger.error()` — these are already plain language.
@@ -231,17 +230,18 @@ Logger, TrailContext, executeTrail
 TraceRecord                          // one recorded execution footprint
 createConsoleLogger(options?)        // default logger, no deps
 ctx.trace(name, fn)                  // manual sub-step recording
+TraceSink, NOOP_SINK                 // sink contract and disabled baseline
+registerTraceSink, getTraceSink      // process-level sink registry
 // Built-in tracing intrinsic to executeTrail
-// In-memory trace storage for --trace rendering
 ```
 
-Everything else — OTel, file sinks, SQLite dev stores, pretty formatters, sampling configuration — belongs in `@ontrails/observe`.
+Everything else — developer-configurable memory sinks, OTel, file sinks, SQLite dev stores, pretty formatters, sampling configuration — belongs in `@ontrails/observe` or compatibility/connector packages that build on the same contracts.
 
 ## Non-goals
 
 - **Metrics.** Core does not ship a metrics primitive. If metrics are needed, `@ontrails/observe` can add a metrics connector. Trace data (duration, error rates) can be derived into metrics at the OTel layer.
 - **Distributed tracing.** Trace context propagation across trail crossings within a single process is in scope. Propagation across network boundaries (cross-app) is a future concern for the mount/pack system.
-- **Replacing OpenTelemetry.** The framework maintains a Trails-native model internally. OTel is the export format, not the internal representation. `@ontrails/observe/otel` translates outward from `TraceRecord` to OTel spans.
+- **Replacing OpenTelemetry.** The framework maintains a Trails-native model internally. OTel is the export format, not the internal representation. An OTel connector translates outward from `TraceRecord` to OTel spans.
 
 ## Consequences
 
@@ -256,7 +256,7 @@ Everything else — OTel, file sinks, SQLite dev stores, pretty formatters, samp
 ### Tradeoffs
 
 - **Core grows.** Adding built-in tracing, the trace record model, and console logger to core increases its surface area. This is justified because `executeTrail` is already in core and tracing wraps it — the natural home for automatic recording is next to the thing being recorded.
-- **Migration from `tracker`.** Package rename, API rename (`tracker.from(ctx).track()` to `ctx.trace()`), configuration restructure. This is a pre-1.0 change, so the migration cost is limited to internal and early adopters.
+- **Migration from earlier trace packaging.** Package imports and sink configuration restructure around `@ontrails/observe`. This is a pre-1.0 change, so the migration cost is limited to internal and early adopters.
 - **Connector owns config details.** Sampling, log level, and formatting are connector concerns, not topo concerns. This keeps the topo config surface minimal but means developers configure observability behavior through their connector, not through a central config object.
 
 ### Risks
@@ -274,11 +274,12 @@ Everything else — OTel, file sinks, SQLite dev stores, pretty formatters, samp
 
 ## References
 
-- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) — `executeTrail` is the chokepoint where tracing wraps. Moving tracing into core puts it next to the pipeline it instruments.
-- [ADR-0013: Tracing](../0013-tracing.md) — the decision this supersedes. The architectural choices (flat records, callback-only manual API, root-level sampling, crossing propagation through execution scope) remain valid. The change is packaging and vocabulary, not mechanism.
-- [ADR: Layer Evolution](20260409-layer-evolution.md) — identifies `tracingLayer` as framework behavior dressed as user configuration; this ADR resolves it by making tracing core.
-- [Tenets: One write, many reads](../../tenets.md) — the governing principle. Trace data authored once feeds `--trace` rendering, OTel export, SQLite dev store, and future replay.
+- [ADR-0006: Shared Execution Pipeline](0006-shared-execution-pipeline.md) — `executeTrail` is the chokepoint where tracing wraps. Moving tracing into core puts it next to the pipeline it instruments.
+- [ADR-0013: Tracing](0013-tracing.md) — the runtime recording primitive this decision updates. The architectural choices (flat records, callback-only manual API, root-level sampling, crossing propagation through execution scope) remain valid. The change is packaging and vocabulary, not mechanism.
+- [ADR-0039: Reactive Trail Activation](0039-reactive-trail-activation.md) — activation source boundaries define the runtime events this ADR makes observable through `activation.*` trace records.
+- [ADR: Layer Evolution](drafts/20260409-layer-evolution.md) — identifies `tracingLayer` as framework behavior dressed as user configuration; this ADR resolves it by making tracing core.
+- [Tenets: One write, many reads](../tenets.md) — the governing principle. Trace data authored once feeds `--trace` rendering, OTel export, SQLite dev store, and future replay.
 - OpenTelemetry specification — the industry standard this aligns with for vocabulary and export format.
 
-[^1]: [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) — `executeTrail` as the shared chokepoint for every trail invocation
-[^2]: [Tenets: The information architecture](../../tenets.md) — authored vs derived information categories
+[^1]: [ADR-0006: Shared Execution Pipeline](0006-shared-execution-pipeline.md) — `executeTrail` as the shared chokepoint for every trail invocation
+[^2]: [Tenets: The information architecture](../tenets.md) — authored vs derived information categories

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,3 +47,4 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0038](0038-typed-signal-emission.md) | Typed Signal Emission | Accepted |
 | [0039](0039-reactive-trail-activation.md) | Reactive Trail Activation | Accepted |
 | [0040](0040-resource-scoped-store-signal-identity.md) | Resource-Scoped Store Signal Identity | Accepted |
+| [0041](0041-unified-observability.md) | Unified Observability | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -579,6 +579,11 @@
           "fromPath": "docs/adr/0038-typed-signal-emission.md"
         },
         {
+          "context": "- [ADR-0006: Shared Execution Pipeline](0006-shared-execution-pipeline.md) — `executeTrail` is the chokepoint where tracing wraps. Moving tracing into core puts it next to the pipeline it instruments.",
+          "from": "0041",
+          "fromPath": "docs/adr/0041-unified-observability.md"
+        },
+        {
           "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) -- `trails run` executes through the pipeline, the same as every trailhead",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
@@ -602,11 +607,6 @@
           "context": "- [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md) -- the execution pipeline that layers currently compose into",
           "from": "20260409",
           "fromPath": "docs/adr/drafts/20260409-layer-evolution.md"
-        },
-        {
-          "context": "- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md) — `executeTrail` is the chokepoint where tracing wraps. Moving tracing into core puts it next to the pipeline it instrumen",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-unified-observability.md"
         },
         {
           "context": "- **[ADR-0006: Shared Execution Pipeline](./adr/0006-shared-execution-pipeline.md)** — One `executeTrail`, Result-returning builders",
@@ -1017,6 +1017,11 @@
           "fromPath": "docs/adr/0039-reactive-trail-activation.md"
         },
         {
+          "context": "- [ADR-0013: Tracing](0013-tracing.md) — the runtime recording primitive this decision updates. The architectural choices (flat records, callback-only manual API, root-level sampling, crossing propaga",
+          "from": "0041",
+          "fromPath": "docs/adr/0041-unified-observability.md"
+        },
+        {
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) -- the tracing primitive; live tracing during `trails run`, historical tracing via `trails trace`",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
@@ -1050,11 +1055,6 @@
           "context": "- [ADR-0013: Tracing](../0013-tracing.md) — runtime recording that powers version traffic monitoring",
           "from": "20260409",
           "fromPath": "docs/adr/drafts/20260409-trail-versioning.md"
-        },
-        {
-          "context": "- [ADR-0013: Tracing](../0013-tracing.md) — the decision this supersedes. The architectural choices (flat records, callback-only manual API, root-level sampling, crossing propagation through execution",
-          "from": "20260409",
-          "fromPath": "docs/adr/drafts/20260409-unified-observability.md"
         },
         {
           "context": "- **[ADR-0013: Tracing](./adr/0013-tracing.md)** — Runtime recording primitive",
@@ -2085,6 +2085,40 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Resource-Scoped Store Signal Identity",
+      "updated": "2026-05-02"
+    },
+    {
+      "created": "2026-04-09",
+      "depends_on": ["6", "13", "39"],
+      "inbound": [
+        {
+          "context": "Unified Observability](0041-unified-observability.md) defines the public",
+          "from": "0039",
+          "fromPath": "docs/adr/0039-reactive-trail-activation.md"
+        },
+        {
+          "context": "- [ADR-0041: Unified Observability](../0041-unified-observability.md) -- `--trace` flag, `ctx.trace()`, and the tracing vocabulary used throughout this draft. Note: this draft uses `--tracing` as the ",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
+        },
+        {
+          "context": "- [ADR-0041: Unified Observability](../0041-unified-observability.md) -- tracing system that provides WebSocket connection observability",
+          "from": "20260331",
+          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
+        },
+        {
+          "context": "The `tracingLayer` row is resolved by [ADR-0041: Unified Observability](../0041-unified-observability.md): tracing is core execution-pipeline behavior, not an authored layer.",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-layer-evolution.md"
+        }
+      ],
+      "number": "0041",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0041-unified-observability.md",
+      "slug": "unified-observability",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Unified Observability",
       "updated": "2026-05-02"
     }
   ],

--- a/docs/adr/drafts/20260331-direct-invocation.md
+++ b/docs/adr/drafts/20260331-direct-invocation.md
@@ -584,6 +584,6 @@ Trail IDs are completed from the topo. Example names are completed from the trai
 - ADR: Typed Signal Emission (draft) -- events emitted during `trails run` flow through normal routing, triggers fire
 - [ADR-0028: Concurrent Trail Crossing](../0028-concurrent-crossing.md) -- `--trace` renders concurrent crossings as parallel branches in the execution tree
 - [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)
-- [ADR: Unified Observability](20260409-unified-observability.md) (draft) -- `--trace` flag, `ctx.trace()`, and the tracing vocabulary used throughout this draft. Note: this draft uses `--tracing` as the flag name; the canonical flag is `--trace` per the observability ADR.
+- [ADR-0041: Unified Observability](../0041-unified-observability.md) -- `--trace` flag, `ctx.trace()`, and the tracing vocabulary used throughout this draft. Note: this draft uses `--tracing` as the flag name; the canonical flag is `--trace` per the observability ADR.
 - ADR: Packs as Namespace Boundaries (draft) -- `trails run` can invoke any trail in any pack, regardless of visibility
 - [ADR-0013: Tracing](../0013-tracing.md) -- the tracing primitive; live tracing during `trails run`, historical tracing via `trails trace`

--- a/docs/adr/drafts/20260331-websocket-trailhead.md
+++ b/docs/adr/drafts/20260331-websocket-trailhead.md
@@ -350,7 +350,7 @@ clients.
 - [ADR-0008: Deterministic Trailhead Derivation](../0008-deterministic-trailhead-derivation.md) -- trail IDs map to WebSocket method names; future delivery would map signal IDs to signal channels
 - [ADR-0013: Tracing](../0013-tracing.md) -- observability and replay buffer backing store
 - [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) -- WebSocket close code mapping deferred there; the error taxonomy extends to WebSocket as a transport
-- [ADR: Unified Observability](20260409-unified-observability.md) (draft) -- tracing system that provides WebSocket connection observability
+- [ADR-0041: Unified Observability](../0041-unified-observability.md) -- tracing system that provides WebSocket connection observability
 - [ADR-0038: Typed Signal Emission](../0038-typed-signal-emission.md) -- provides typed `ctx.fire(signal, payload)` records; external subscription delivery remains deferred to this draft
 - [ADR-0027: Trail Visibility and Trailhead Filtering](../0027-visibility-and-filtering.md) -- visibility and intent filtering apply to WebSocket trail discovery and invocation
 - [ADR-0039: Reactive Trail Activation](../0039-reactive-trail-activation.md) -- activation sources and WebSocket subscriptions would both consume typed signal contracts

--- a/docs/adr/drafts/20260409-layer-evolution.md
+++ b/docs/adr/drafts/20260409-layer-evolution.md
@@ -36,7 +36,7 @@ The five layers shipped today break down as follows:
 | `autoIterateLayer` | CLI-specific pagination behavior | Yes -- from output schema shape |
 | `dateShortcutsLayer` | CLI-specific date expansion | Yes -- from input schema shape |
 
-The `tracingLayer` row is resolved by [ADR: Unified Observability](20260409-unified-observability.md): tracing is core execution-pipeline behavior, not an authored layer.
+The `tracingLayer` row is resolved by [ADR-0041: Unified Observability](../0041-unified-observability.md): tracing is core execution-pipeline behavior, not an authored layer.
 
 None are genuinely authored cross-cutting concerns. All five are either derivable from trail declarations or intrinsic pipeline behavior. To get basic framework capabilities (auth, recording), the developer imports layers, creates instances, and passes them to every `blaze()` call. That's requiring Level 2 ceremony for Level 0 behavior -- the same anti-pattern as if input validation were a layer you had to import and wire.
 
@@ -319,7 +319,7 @@ The name change from `layers` to `middleware` is intentional. `layers` implied f
 - [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md) -- the execution pipeline that layers currently compose into
 - [ADR-0012: Connector-Agnostic Permits](../0012-connector-agnostic-permits.md) -- permit declarations that become pipeline-enforced
 - [ADR-0013: Tracing -- Runtime Recording Primitive](../0013-tracing.md) -- recording that becomes a pipeline stage
-- [ADR: Unified Observability](20260409-unified-observability.md) -- resolves the obsolete `tracingLayer` concept by moving tracing into core rather than preserving it as a layer
+- [ADR-0041: Unified Observability](../0041-unified-observability.md) -- resolves the obsolete `tracingLayer` concept by moving tracing into core rather than preserving it as a layer
 - [ADR-0004: Intent as a First-Class Property](../0004-intent-as-first-class-property.md) -- intent compounds with layers for surface derivation and governance
 - [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md) -- `crossInput` follows the same "compose schemas, project the union" pattern as layer input schemas
 - [Tenets: One write, many reads](../../tenets.md) -- layer input schemas exemplify one authoring point feeding CLI flags, MCP parameters, HTTP query params, and lockfile diffing simultaneously

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -32,5 +32,3 @@ Proposed decisions under discussion. Promoted to `docs/adr/` when accepted.
   - depends on [ADR-0009: First-Class Resources](../0009-first-class-resources.md), [ADR-0016: Schema-Derived Persistence](../0016-schema-derived-persistence.md), [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](../0022-drizzle-store-connector.md)
 - [Trail Versioning](20260409-trail-versioning.md)
   - depends on [ADR-0003: Unified Trail Primitive](../0003-unified-trail-primitive.md), [ADR-0008: Deterministic Surface Derivation](../0008-deterministic-trailhead-derivation.md), [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md)
-- [Unified Observability](20260409-unified-observability.md)
-  - depends on [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md), [ADR-0013: Tracing — Runtime Recording Primitive](../0013-tracing.md)

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -134,6 +134,11 @@
       "depends_on": ["6", "12"],
       "inbound": [
         {
+          "context": "This also resolves the `tracingLayer` concern named in [ADR: Layer Evolution](drafts/20260409-layer-evolution.md): tracing is a core pipeline capability, not a user-authored layer.",
+          "from": "0041",
+          "fromPath": "docs/adr/0041-unified-observability.md"
+        },
+        {
           "context": "- [ADR: Layer Evolution](20260409-layer-evolution.md) (draft) -- layers gain input schemas and three attachment levels; packs can carry trail-level layers",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
@@ -151,7 +156,7 @@
       "status": "draft",
       "superseded_by": null,
       "title": "Layer Evolution",
-      "updated": "2026-04-28"
+      "updated": "2026-05-02"
     },
     {
       "created": "2026-04-09",
@@ -214,35 +219,6 @@
       "status": "draft",
       "superseded_by": null,
       "title": "Trail Versioning",
-      "updated": "2026-04-09"
-    },
-    {
-      "created": "2026-04-09",
-      "depends_on": ["6", "13"],
-      "inbound": [
-        {
-          "context": "[Unified Observability](drafts/20260409-unified-observability.md) draft",
-          "from": "0039",
-          "fromPath": "docs/adr/0039-reactive-trail-activation.md"
-        },
-        {
-          "context": "- [ADR: Unified Observability](20260409-unified-observability.md) (draft) -- `--trace` flag, `ctx.trace()`, and the tracing vocabulary used throughout this draft. Note: this draft uses `--tracing` as ",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
-        },
-        {
-          "context": "- [ADR: Unified Observability](20260409-unified-observability.md) (draft) -- tracing system that provides WebSocket connection observability",
-          "from": "20260331",
-          "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
-        }
-      ],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260409-unified-observability.md",
-      "slug": "unified-observability",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Unified Observability",
       "updated": "2026-04-09"
     }
   ],


### PR DESCRIPTION
## Summary
Promote the unified observability draft to an accepted ADR (now `docs/adr/0041-unified-observability.md`). This codifies the contract the rest of this stack delivered: one activation-trace shape, one `observe` option on the topo, one set of built-in sinks.

## What changed
- Draft promoted to `docs/adr/0041-unified-observability.md`; references in the reactive-trail-activation ADR (0039) and other drafts updated.
- ADR README, root `decision-map.json`, and drafts decision-map updated; draft entry removed.
- New changeset entry at `.changeset/unified-observability-adr.md`.

## Stack
Top of the stack — closes the unified observability story (#359 trace records, #360 default sink, #361 topo option, #362–#364 the `@ontrails/observe` package, #365 cross-references).

## Linear
https://linear.app/outfitter/issue/TRL-431/promote-unified-observability-draft-adr-to-accepted