### PR TITLE
refactor(core,topographer): relocate topo-store public API to topographer

### DIFF
--- a/.changeset/topo-store-relocation.md
+++ b/.changeset/topo-store-relocation.md
@@ -1,0 +1,19 @@
+---
+'@ontrails/core': major
+'@ontrails/topographer': minor
+'@ontrails/warden': patch
+'@ontrails/trails': patch
+---
+
+Relocate the topo-store public API from `@ontrails/core` to `@ontrails/topographer` per ADR-0042. Generic `trails-db` helpers (`openReadTrailsDb`, `openWriteTrailsDb`, `ensureSubsystemSchema`, `deriveTrailsDbPath`, `deriveTrailsDir`) stay in core because tracing and other subsystems share them.
+
+Breaking pre-1.0 beta change. Update consumer imports:
+
+```diff
+- import { topoStore, createTopoStore, createMockTopoStore, createTopoSnapshot, listTopoSnapshots, pinTopoSnapshot, unpinTopoSnapshot, createStoredTopoSnapshot, getStoredTopoExport, countTopoSnapshots, countPinnedSnapshots, countPrunableSnapshots, pruneUnpinnedSnapshots } from '@ontrails/core';
++ import { topoStore, createTopoStore, createMockTopoStore, createTopoSnapshot, listTopoSnapshots, pinTopoSnapshot, unpinTopoSnapshot, createStoredTopoSnapshot, getStoredTopoExport, countTopoSnapshots, countPinnedSnapshots, countPrunableSnapshots, pruneUnpinnedSnapshots } from '@ontrails/topographer';
+```
+
+The same move applies to types `ReadOnlyTopoStore`, `MockTopoStoreSeed`, `TopoSnapshot`, `TopoStoreRef`, `TopoStoreExportRecord`, `TopoStoreResourceRecord`, `TopoStoreTrailRecord`, `TopoStoreTrailDetailRecord`, `CreateTopoSnapshotInput`, `ListTopoSnapshotsOptions`, and `StoredTopoExport`.
+
+Core newly exports `activationSourceKey`, `projectActivationSourceDeclaration`, `activationSourceDeclarationSignature`, and the `ActivationSourceProjection` type — these were already used internally and are now part of the public surface so `@ontrails/topographer` (the only consumer that needs them) can import them through normal package channels.

--- a/apps/trails/src/trails/dev-support.ts
+++ b/apps/trails/src/trails/dev-support.ts
@@ -2,15 +2,17 @@ import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
-  countPinnedSnapshots,
-  countPrunableSnapshots,
-  countTopoSnapshots,
   openReadTrailsDb,
   openWriteTrailsDb,
   deriveTrailsDbPath,
   deriveTrailsDir,
-  pruneUnpinnedSnapshots,
 } from '@ontrails/core';
+import {
+  countPinnedSnapshots,
+  countPrunableSnapshots,
+  countTopoSnapshots,
+  pruneUnpinnedSnapshots,
+} from '@ontrails/topographer';
 import {
   DEFAULT_MAX_AGE,
   DEFAULT_MAX_RECORDS,

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -9,7 +9,6 @@ import { extname, join } from 'node:path';
 
 import type { Topo } from '@ontrails/core';
 import {
-  createTopoStore,
   deriveSafePath,
   NotFoundError,
   Result,
@@ -18,6 +17,7 @@ import {
 } from '@ontrails/core';
 import type { DiffEntry, DiffResult, SurfaceMap } from '@ontrails/topographer';
 import {
+  createTopoStore,
   deriveSurfaceMapDiff,
   deriveSurfaceMap,
   readSurfaceMap,

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -7,17 +7,25 @@
 
 import { Database } from 'bun:sqlite';
 
-import type { StoredTopoExport, Topo, TopoSnapshot } from '@ontrails/core';
+import type { Topo } from '@ontrails/core';
 import {
-  createStoredTopoSnapshot,
   deriveTrailsDir,
-  getStoredTopoExport,
   InternalError,
   openWriteTrailsDb,
   Result,
 } from '@ontrails/core';
-import type { SurfaceLock, SurfaceMap } from '@ontrails/topographer';
-import { writeSurfaceLock, writeSurfaceMap } from '@ontrails/topographer';
+import type {
+  StoredTopoExport,
+  SurfaceLock,
+  SurfaceMap,
+  TopoSnapshot,
+} from '@ontrails/topographer';
+import {
+  createStoredTopoSnapshot,
+  getStoredTopoExport,
+  writeSurfaceLock,
+  writeSurfaceMap,
+} from '@ontrails/topographer';
 
 import type { TopoExportReport } from './topo-support.js';
 import {

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -1,14 +1,15 @@
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
+import { deriveTrailsDbPath } from '@ontrails/core';
+import type { Topo } from '@ontrails/core';
 import {
   createTopoSnapshot as persistTopoSnapshot,
-  deriveTrailsDbPath,
   listTopoSnapshots as readTopoSnapshots,
   pinTopoSnapshot,
   unpinTopoSnapshot,
-} from '@ontrails/core';
-import type { Topo, TopoSnapshot } from '@ontrails/core';
+} from '@ontrails/topographer';
+import type { TopoSnapshot } from '@ontrails/topographer';
 import { z } from 'zod';
 
 import {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -22,12 +22,10 @@ blobRefSchema, createBlobRef(...)  // declare and create binary output reference
 // Topo methods: .get(id), .has(id), .list(), .listSignals(), .ids(), .count
 //               .getContour(name), .hasContour(name), .listContours(), .contourIds(), .contourCount
 //               .getResource(id), .hasResource(id), .listResources(), .resourceIds(), .resourceCount
-createTopoStore(options?), createMockTopoStore(seed?), topoStore
-createStoredTopoSnapshot(db, topo, input?), getStoredTopoExport(db, snapshotId)
 openReadTrailsDb(options?), openWriteTrailsDb(options?), ensureSubsystemSchema(db, options)
 deriveTrailsDir(options?), deriveTrailsDbPath(options?)
-countTopoSnapshots(db), countPinnedSnapshots(db), countPrunableSnapshots(db, options?)
-pruneUnpinnedSnapshots(db, options?)
+// topo-store API (createTopoStore, createMockTopoStore, topoStore, snapshot helpers, etc.)
+// has moved to @ontrails/topographer per ADR-0042. See that section below.
 
 // Types
 Trail<I, O>, Signal<T>, ScheduleSource, WebhookSource<T>, Contour<TName, TShape, TIdentity>, Resource<T>, Topo, Intent
@@ -36,7 +34,7 @@ TrailSpec<I, O>, SignalSpec<T>, ScheduleSpec, WebhookSpec<T>, ResourceSpec<T>, T
 AnyTrail, AnySignal, AnyContour, AnyResource, ResourceContext, ResourceOverrideMap
 BlobRef, BlobRefDescriptor
 ContourOptions, ContourIdBrand, ContourIdMetadata, ContourIdSchema, ContourIdValue, ContourReference
-StoredTopoExport, TrailsDbLocationOptions, EnsureSubsystemSchemaOptions
+TrailsDbLocationOptions, EnsureSubsystemSchemaOptions
 ActivationSource, ActivationEntry, ActivationProvenance
 WebhookMethod, WebhookVerify, WebhookVerifyRequest, WebhookVerifyHeaders, WebhookValidationIssue
 
@@ -218,12 +216,24 @@ CreateAppOptions, SurfaceHttpResult
 ## `@ontrails/topographer`
 
 ```typescript
+// Surface maps and lockfile helpers
 deriveSurfaceMap(graph), deriveSurfaceMapHash(map), deriveSurfaceMapDiff(before, after)
 writeSurfaceMap(map, options?), readSurfaceMap(options?)
 writeSurfaceLock(lock, options?), readSurfaceLockData(options?), readSurfaceLock(options?)
 
+// Topo store (durable graph substrate; relocated from @ontrails/core per ADR-0042)
+createTopoStore(options?), createMockTopoStore(seed?), topoStore
+createTopoSnapshot(topo, options?), listTopoSnapshots(options?)
+pinTopoSnapshot(id, name, options?), unpinTopoSnapshot(nameOrId, options?)
+createStoredTopoSnapshot(db, topo, input?), getStoredTopoExport(db, snapshotId)
+countTopoSnapshots(db), countPinnedSnapshots(db), countPrunableSnapshots(db, options?)
+pruneUnpinnedSnapshots(db, options?)
+
 SurfaceMap, SurfaceMapEntry, SurfaceMapContourReference, SurfaceLock, DiffResult, DiffEntry, JsonSchema
 WriteOptions, ReadOptions
+ReadOnlyTopoStore, MockTopoStoreSeed, TopoSnapshot, TopoStoreRef
+TopoStoreExportRecord, TopoStoreResourceRecord, TopoStoreTrailRecord, TopoStoreTrailDetailRecord
+CreateTopoSnapshotInput, ListTopoSnapshotsOptions, StoredTopoExport
 ```
 
 ## `@ontrails/store`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,7 +137,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 
 ### Foundation
 
-`@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, `contour()`/`trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, execution pipeline utilities including `Layer`/`composeLayers()`, and connector port interfaces.
+`@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, `contour()`/`trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, execution pipeline utilities including `Layer`/`composeLayers()`, generic `trails-db` helpers (`openReadTrailsDb`, `ensureSubsystemSchema`, etc.), and connector port interfaces. Persistence of the resolved topo graph (the topo-store API) lives in `@ontrails/topographer` per ADR-0042.
 
 **The test:** if you are building a surface connector or ecosystem package, you should only need `@ontrails/core`.
 
@@ -169,7 +169,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 | Package | What it does |
 | --- | --- |
 | `@ontrails/testing` | `testAll()`, `testExamples()`, `testTrail()`, contract testing, surface harnesses |
-| `@ontrails/topographer` | Surface maps, semantic diffing, lock helpers |
+| `@ontrails/topographer` | Surface maps, semantic diffing, lock helpers, topo-store persistence (relocated from `@ontrails/core` per ADR-0042) |
 | `@ontrails/warden` | Lint rules, drift detection, CI gating |
 
 ### Apps

--- a/docs/topo-store-reference.md
+++ b/docs/topo-store-reference.md
@@ -270,7 +270,7 @@ SELECT id FROM closure
 Create a read-only interface.
 
 ```typescript
-import { createTopoStore } from '@ontrails/core';
+import { createTopoStore } from '@ontrails/topographer';
 
 const store = createTopoStore({ rootDir: '/path/to/workspace' });
 store.trails.list({ intent: 'write' });
@@ -284,7 +284,7 @@ store.snapshots.latest();
 Create a mock for testing.
 
 ```typescript
-import { createMockTopoStore } from '@ontrails/core';
+import { createMockTopoStore } from '@ontrails/topographer';
 
 const mock = createMockTopoStore({
   trails: [{ id: 'auth.login', intent: 'write', hasOutput: true, ... }],
@@ -297,7 +297,7 @@ const mock = createMockTopoStore({
 Read-only resource for accessing the topo store in trails.
 
 ```typescript
-import { topoStore } from '@ontrails/core';
+import { topoStore } from '@ontrails/topographer';
 
 trail('warden.check', {
   resources: [topoStore],

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -117,7 +117,7 @@ trails topo compile
 Use the `topoStore` resource for programmatic access:
 
 ```typescript
-import { topoStore } from '@ontrails/core';
+import { topoStore } from '@ontrails/topographer';
 
 trail('warden.check-outputs', {
   resources: [topoStore],

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -150,6 +150,19 @@ The developer returns `Result.err(new NotFoundError(...))`. The framework maps i
 
 See the [API Reference](../../docs/api-reference.md) for the full list.
 
+## Migration: topo-store moved to `@ontrails/topographer`
+
+Per [ADR-0042](../../docs/adr/0042-core-topographer-boundary-doctrine.md), the topo-store public API previously exported from `@ontrails/core` now lives in `@ontrails/topographer`. Generic `trails-db` helpers (`openReadTrailsDb`, `openWriteTrailsDb`, `ensureSubsystemSchema`, `deriveTrailsDbPath`, `deriveTrailsDir`) stay in core because tracing and other subsystems share them.
+
+Update consumer imports:
+
+```diff
+- import { topoStore, createTopoStore, createMockTopoStore, createTopoSnapshot, listTopoSnapshots, pinTopoSnapshot, unpinTopoSnapshot, createStoredTopoSnapshot, getStoredTopoExport, countTopoSnapshots, countPinnedSnapshots, countPrunableSnapshots, pruneUnpinnedSnapshots } from '@ontrails/core';
++ import { topoStore, createTopoStore, createMockTopoStore, createTopoSnapshot, listTopoSnapshots, pinTopoSnapshot, unpinTopoSnapshot, createStoredTopoSnapshot, getStoredTopoExport, countTopoSnapshots, countPinnedSnapshots, countPrunableSnapshots, pruneUnpinnedSnapshots } from '@ontrails/topographer';
+```
+
+Types `ReadOnlyTopoStore`, `MockTopoStoreSeed`, `TopoSnapshot`, `TopoStoreRef`, `TopoStoreExportRecord`, `TopoStoreResourceRecord`, `TopoStoreTrailRecord`, `TopoStoreTrailDetailRecord`, `CreateTopoSnapshotInput`, `ListTopoSnapshotsOptions`, and `StoredTopoExport` follow the same move.
+
 ## Installation
 
 ```bash

--- a/packages/core/src/__tests__/trails-db.test.ts
+++ b/packages/core/src/__tests__/trails-db.test.ts
@@ -9,13 +9,6 @@ import {
   openWriteTrailsDb,
   deriveTrailsDbPath,
 } from '../internal/trails-db.js';
-import {
-  createTopoSnapshot,
-  ensureTopoSnapshotSchema,
-  listTopoSnapshots,
-  pinTopoSnapshot,
-  pruneUnpinnedSnapshots,
-} from '../internal/topo-snapshots.js';
 
 describe('trails db foundation', () => {
   let tmpRoot: string | undefined;
@@ -120,77 +113,6 @@ describe('trails db foundation', () => {
       });
 
       expect(calls).toBe(2);
-    } finally {
-      db.close();
-    }
-  });
-});
-
-describe('topo snapshot primitives', () => {
-  let tmpRoot: string | undefined;
-
-  afterEach(() => {
-    if (tmpRoot) {
-      rmSync(tmpRoot, { force: true, recursive: true });
-      tmpRoot = undefined;
-    }
-  });
-
-  const makeRoot = (): string => {
-    tmpRoot = mkdtempSync(join(tmpdir(), 'topo-snapshots-'));
-    return tmpRoot;
-  };
-
-  const seedHistory = (db: ReturnType<typeof openWriteTrailsDb>) => {
-    ensureTopoSnapshotSchema(db);
-
-    const pinned = createTopoSnapshot(db, {
-      createdAt: '2026-04-01T00:00:00.000Z',
-      gitDirty: false,
-      gitSha: 'abc123',
-      resourceCount: 2,
-      signalCount: 1,
-      trailCount: 3,
-    });
-    const disposable = createTopoSnapshot(db, {
-      createdAt: '2026-04-02T00:00:00.000Z',
-      gitDirty: true,
-      gitSha: 'def456',
-      resourceCount: 3,
-      signalCount: 2,
-      trailCount: 4,
-    });
-
-    return {
-      disposable,
-      pinned,
-      pinnedSnapshot: pinTopoSnapshot(db, {
-        id: pinned.id,
-        name: 'before-auth',
-      }),
-    };
-  };
-
-  test('creates snapshots, pins them, and prunes only unpinned history', () => {
-    const rootDir = makeRoot();
-    const db = openWriteTrailsDb({ rootDir });
-
-    try {
-      const { disposable, pinned, pinnedSnapshot } = seedHistory(db);
-
-      expect(pinnedSnapshot?.pinnedAs).toBe('before-auth');
-      expect(
-        listTopoSnapshots(db, { pinned: true }).map((snapshot) => snapshot.id)
-      ).toEqual([pinned.id]);
-      expect(listTopoSnapshots(db).map((snapshot) => snapshot.id)).toEqual([
-        disposable.id,
-        pinned.id,
-      ]);
-
-      expect(pruneUnpinnedSnapshots(db, { keep: 0 })).toBe(1);
-      expect(listTopoSnapshots(db).map((snapshot) => snapshot.id)).toEqual([
-        pinned.id,
-      ]);
     } finally {
       db.close();
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,6 +142,12 @@ export type {
   ActivationWhereSpec,
   BuiltinActivationSourceKind,
 } from './activation-source.js';
+export {
+  activationSourceDeclarationSignature,
+  activationSourceKey,
+  projectActivationSourceDeclaration,
+} from './activation-source-projection.js';
+export type { ActivationSourceProjection } from './activation-source-projection.js';
 export { intentValues, trail } from './trail.js';
 export type {
   AnyTrail,
@@ -312,42 +318,10 @@ export type {
 // Topo
 export { topo } from './topo.js';
 export type { Topo, TopoIdentity } from './topo.js';
-// Topo-store public API. Per ADR-0042, these exports relocate to
-// `@ontrails/topographer` in a follow-up commit on this stack;
-// consumers should plan to import from `@ontrails/topographer` once
-// the package lands.
-export {
-  createTopoSnapshot,
-  createMockTopoStore,
-  createTopoStore,
-  listTopoSnapshots,
-  pinTopoSnapshot,
-  topoStore,
-  unpinTopoSnapshot,
-} from './topo-store.js';
-export type {
-  CreateTopoSnapshotInput,
-  ListTopoSnapshotsOptions,
-  MockTopoStoreSeed,
-  ReadOnlyTopoStore,
-  TopoSnapshot,
-  TopoStoreExportRecord,
-  TopoStoreResourceRecord,
-  TopoStoreRef,
-  TopoStoreTrailDetailRecord,
-  TopoStoreTrailRecord,
-} from './topo-store.js';
-export {
-  countPinnedSnapshots,
-  countPrunableSnapshots,
-  countTopoSnapshots,
-  pruneUnpinnedSnapshots,
-} from './internal/topo-snapshots.js';
-export {
-  createTopoSnapshot as createStoredTopoSnapshot,
-  getStoredTopoExport,
-} from './internal/topo-store.js';
-export type { StoredTopoExport } from './internal/topo-store.js';
+
+// Generic trails-db helpers (shared framework infrastructure per ADR-0014).
+// The topo-store public API that previously lived here moved to
+// `@ontrails/topographer` per ADR-0042.
 export {
   deriveTrailsDbPath,
   deriveTrailsDir,

--- a/packages/topographer/README.md
+++ b/packages/topographer/README.md
@@ -2,7 +2,7 @@
 
 Durable graph substrate for Trails: deterministic surface maps, lockfile helpers, and semantic diffing.
 
-Most applications reach this package through `trails topo compile` and `trails topo verify`. Those CLI trails layer workspace and topo-store behavior on top of the low-level building blocks in `@ontrails/topographer`.
+Most applications reach this package through `trails topo compile` and `trails topo verify`. Those CLI trails layer workspace and topo-store behavior on top of the building blocks in `@ontrails/topographer`.
 
 ## What it owns
 
@@ -11,8 +11,9 @@ Most applications reach this package through `trails topo compile` and `trails t
 - stable hashing for CI drift detection
 - semantic diffing between two surface maps
 - file I/O helpers for `.trails/_surface.json` and `.trails/trails.lock`
+- the topo-store: queryable persistence of the resolved topo graph in `trails.db`, including snapshots, pinning, history, and read-only query accessors (relocated from `@ontrails/core` per ADR-0042)
 
-The package does not own topo history, pins, or `trails.db`. Those higher-level workflows live in the `trails` app and `@ontrails/core`. `@ontrails/topographer` stays focused on serializable artifacts and diffing.
+`@ontrails/topographer` is the durable graph substrate for Trails. Generic `trails-db` plumbing (read/write SQLite handles, subsystem schema management, derived paths) stays in `@ontrails/core` so other subsystems (tracing, signals) can share it without depending on topographer.
 
 ## Usage
 
@@ -63,6 +64,14 @@ The typical exported artifact pair is:
 | `writeSurfaceLock(lock, options?)` | Write `.trails/trails.lock` as either structured JSON or legacy hash text |
 | `readSurfaceLockData(options?)` | Read the full normalized lock payload from `.trails/trails.lock` |
 | `readSurfaceLock(options?)` | Read just the committed lock hash |
+| `createTopoStore(options?)` | Read-only query interface over the persisted topo state in `trails.db` |
+| `createMockTopoStore(seed?)` | Seeded in-memory mock for tests that need a `ReadOnlyTopoStore` |
+| `topoStore` | Read-only `resource()` wrapper around `createTopoStore`, suitable for `resources: [...]` |
+| `createTopoSnapshot(topo, options?)` | Persist a new topo snapshot row plus its denormalized projections |
+| `listTopoSnapshots(options?)` | List historical topo snapshots (filterable by pinned status) |
+| `pinTopoSnapshot(id, name, options?)` / `unpinTopoSnapshot(nameOrId, options?)` | Manage human-named pins |
+| `countTopoSnapshots(db)` / `countPinnedSnapshots(db)` / `countPrunableSnapshots(db, options?)` / `pruneUnpinnedSnapshots(db, options?)` | Lower-level snapshot counters and pruning over an open `trails.db` handle |
+| `createStoredTopoSnapshot(db, topo, input?)` / `getStoredTopoExport(db, snapshotId)` | Direct DB-handle variants for callers that already hold an open writer |
 
 ## Breaking change detection
 

--- a/packages/topographer/src/__tests__/topo-snapshots.test.ts
+++ b/packages/topographer/src/__tests__/topo-snapshots.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { openWriteTrailsDb } from '@ontrails/core';
+
+import {
+  createTopoSnapshot,
+  ensureTopoSnapshotSchema,
+  listTopoSnapshots,
+  pinTopoSnapshot,
+  pruneUnpinnedSnapshots,
+} from '../internal/topo-snapshots.js';
+
+describe('topo snapshot primitives', () => {
+  let tmpRoot: string | undefined;
+
+  afterEach(() => {
+    if (tmpRoot) {
+      rmSync(tmpRoot, { force: true, recursive: true });
+      tmpRoot = undefined;
+    }
+  });
+
+  const makeRoot = (): string => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'topo-snapshots-'));
+    return tmpRoot;
+  };
+
+  const seedHistory = (db: ReturnType<typeof openWriteTrailsDb>) => {
+    ensureTopoSnapshotSchema(db);
+
+    const pinned = createTopoSnapshot(db, {
+      createdAt: '2026-04-01T00:00:00.000Z',
+      gitDirty: false,
+      gitSha: 'abc123',
+      resourceCount: 2,
+      signalCount: 1,
+      trailCount: 3,
+    });
+    const disposable = createTopoSnapshot(db, {
+      createdAt: '2026-04-02T00:00:00.000Z',
+      gitDirty: true,
+      gitSha: 'def456',
+      resourceCount: 3,
+      signalCount: 2,
+      trailCount: 4,
+    });
+
+    return {
+      disposable,
+      pinned,
+      pinnedSnapshot: pinTopoSnapshot(db, {
+        id: pinned.id,
+        name: 'before-auth',
+      }),
+    };
+  };
+
+  test('creates snapshots, pins them, and prunes only unpinned history', () => {
+    const rootDir = makeRoot();
+    const db = openWriteTrailsDb({ rootDir });
+
+    try {
+      const { disposable, pinned, pinnedSnapshot } = seedHistory(db);
+
+      expect(pinnedSnapshot?.pinnedAs).toBe('before-auth');
+      expect(
+        listTopoSnapshots(db, { pinned: true }).map((snapshot) => snapshot.id)
+      ).toEqual([pinned.id]);
+      expect(listTopoSnapshots(db).map((snapshot) => snapshot.id)).toEqual([
+        disposable.id,
+        pinned.id,
+      ]);
+
+      expect(pruneUnpinnedSnapshots(db, { keep: 0 })).toBe(1);
+      expect(listTopoSnapshots(db).map((snapshot) => snapshot.id)).toEqual([
+        pinned.id,
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/topographer/src/__tests__/topo-store-read.test.ts
+++ b/packages/topographer/src/__tests__/topo-store-read.test.ts
@@ -8,19 +8,22 @@ import { z } from 'zod';
 import {
   ConflictError,
   DETOUR_MAX_ATTEMPTS_CAP,
-  createMockTopoStore,
-  createTopoSnapshot,
-  createTopoStore,
   resource,
   Result,
   signal,
   topo,
-  topoStore,
   trail,
+  openWriteTrailsDb,
+} from '@ontrails/core';
+
+import {
+  createMockTopoStore,
+  createTopoSnapshot,
+  createTopoStore,
+  topoStore,
 } from '../index.js';
 import { pinTopoSnapshot } from '../internal/topo-snapshots.js';
 import type { TopoSnapshot } from '../internal/topo-snapshots.js';
-import { openWriteTrailsDb } from '../internal/trails-db.js';
 
 const noop = () => Result.ok({ ok: true });
 

--- a/packages/topographer/src/__tests__/topo-store.test.ts
+++ b/packages/topographer/src/__tests__/topo-store.test.ts
@@ -5,8 +5,8 @@ import { join } from 'node:path';
 
 import { z } from 'zod';
 
-import { NotFoundError } from '../errors.js';
 import {
+  NotFoundError,
   contour,
   Result,
   resource,
@@ -15,7 +15,9 @@ import {
   topo,
   trail,
   webhook,
-} from '../index.js';
+  openWriteTrailsDb,
+} from '@ontrails/core';
+
 import { __topoStoreMigrationStats, createTopoStore } from '../topo-store.js';
 import {
   ensureTopoSnapshotSchema,
@@ -30,7 +32,6 @@ import {
   normalizeFiresRows,
   normalizeOnRows,
 } from '../internal/topo-store.js';
-import { openWriteTrailsDb } from '../internal/trails-db.js';
 
 const noop = () => Result.ok({ ok: true });
 

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -26,3 +26,39 @@ export type {
   WriteOptions,
   ReadOptions,
 } from './types.js';
+
+// Topo-store public API. Persistence layer for the resolved topo graph; relies
+// on `@ontrails/core` for primitive types and the generic `trails-db` helpers.
+// See ADR-0042 for the core/topographer boundary doctrine.
+export {
+  createTopoSnapshot,
+  createMockTopoStore,
+  createTopoStore,
+  listTopoSnapshots,
+  pinTopoSnapshot,
+  topoStore,
+  unpinTopoSnapshot,
+} from './topo-store.js';
+export type {
+  CreateTopoSnapshotInput,
+  ListTopoSnapshotsOptions,
+  MockTopoStoreSeed,
+  ReadOnlyTopoStore,
+  TopoSnapshot,
+  TopoStoreExportRecord,
+  TopoStoreResourceRecord,
+  TopoStoreRef,
+  TopoStoreTrailDetailRecord,
+  TopoStoreTrailRecord,
+} from './topo-store.js';
+export {
+  countPinnedSnapshots,
+  countPrunableSnapshots,
+  countTopoSnapshots,
+  pruneUnpinnedSnapshots,
+} from './internal/topo-snapshots.js';
+export {
+  createTopoSnapshot as createStoredTopoSnapshot,
+  getStoredTopoExport,
+} from './internal/topo-store.js';
+export type { StoredTopoExport } from './internal/topo-store.js';

--- a/packages/topographer/src/internal/topo-snapshots.ts
+++ b/packages/topographer/src/internal/topo-snapshots.ts
@@ -1,6 +1,6 @@
 import type { Database, SQLQueryBindings } from 'bun:sqlite';
 
-import { ensureSubsystemSchema } from './trails-db.js';
+import { ensureSubsystemSchema } from '@ontrails/core';
 
 const TOPO_SUBSYSTEM = 'topo';
 const TOPO_TABLE_STATEMENTS = [

--- a/packages/topographer/src/internal/topo-store-read.ts
+++ b/packages/topographer/src/internal/topo-store-read.ts
@@ -1,6 +1,7 @@
 import type { Database, SQLQueryBindings } from 'bun:sqlite';
 
-import { ValidationError } from '../errors.js';
+import { ValidationError } from '@ontrails/core';
+
 import type {
   ListTopoSnapshotsOptions,
   TopoSnapshot,

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -1,29 +1,28 @@
 import type { Database, SQLQueryBindings } from 'bun:sqlite';
 
+import {
+  DETOUR_MAX_ATTEMPTS_CAP,
+  Result,
+  activationSourceKey,
+  deriveCliPath,
+  deriveStructuredSignalExamples,
+  deriveStructuredTrailExamples,
+  getContourReferences,
+  projectActivationSourceDeclaration,
+  signalDiagnosticDefinitions,
+  validateEstablishedTopo,
+  zodToJsonSchema,
+} from '@ontrails/core';
 import type {
   ActivationEntry,
   ActivationSource,
-} from '../activation-source.js';
-import {
-  activationSourceKey,
-  projectActivationSourceDeclaration,
-} from '../activation-source-projection.js';
-import { getContourReferences } from '../contour.js';
-import { DETOUR_MAX_ATTEMPTS_CAP } from '../detours.js';
-import { deriveCliPath } from '../derive.js';
-import { Result } from '../result.js';
-import { signalDiagnosticDefinitions } from '../signal-diagnostics.js';
-import {
-  deriveStructuredSignalExamples,
-  deriveStructuredTrailExamples,
-} from '../structured-examples.js';
-import type { AnyContour } from '../contour.js';
-import type { AnyResource } from '../resource.js';
-import type { AnySignal } from '../signal.js';
-import type { Topo } from '../topo.js';
-import type { AnyTrail } from '../trail.js';
-import { validateEstablishedTopo } from '../validate-established-topo.js';
-import { zodToJsonSchema } from '../validation.js';
+  AnyContour,
+  AnyResource,
+  AnySignal,
+  AnyTrail,
+  Topo,
+} from '@ontrails/core';
+
 import type {
   CreateTopoSnapshotInput,
   TopoSnapshot,

--- a/packages/topographer/src/topo-store.ts
+++ b/packages/topographer/src/topo-store.ts
@@ -1,10 +1,16 @@
 import type { SQLQueryBindings } from 'bun:sqlite';
 import { existsSync, statSync } from 'node:fs';
 
-import { NotFoundError } from './errors.js';
-import type { Topo } from './topo.js';
-import { resource } from './resource.js';
-import { Result } from './result.js';
+import {
+  NotFoundError,
+  Result,
+  deriveTrailsDbPath,
+  openReadTrailsDb,
+  openWriteTrailsDb,
+  resource,
+} from '@ontrails/core';
+import type { Topo, TrailsDbLocationOptions } from '@ontrails/core';
+
 import {
   TOPO_SCHEMA_VERSION,
   ensureTopoSnapshotSchema,
@@ -39,12 +45,6 @@ import {
   readTopoStoreSnapshot,
 } from './internal/topo-store-read.js';
 import { createTopoSnapshot as storeTopoSnapshot } from './internal/topo-store.js';
-import {
-  openReadTrailsDb,
-  openWriteTrailsDb,
-  deriveTrailsDbPath,
-} from './internal/trails-db.js';
-import type { TrailsDbLocationOptions } from './internal/trails-db.js';
 
 interface MigratedDbIdentity {
   readonly mtimeMs: number;

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -4,8 +4,6 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import {
-  createStoredTopoSnapshot,
-  createTopoStore,
   deriveTrailsDir,
   openWriteTrailsDb,
   trail,
@@ -13,6 +11,8 @@ import {
   Result,
 } from '@ontrails/core';
 import {
+  createStoredTopoSnapshot,
+  createTopoStore,
   deriveSurfaceMapHash,
   deriveSurfaceMap,
   writeSurfaceLock,

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -11,12 +11,12 @@ import { existsSync, statSync } from 'node:fs';
 
 import type { Topo } from '@ontrails/core';
 import {
-  createTopoStore,
   deriveTrailsDir,
   NotFoundError,
   ValidationError,
 } from '@ontrails/core';
 import {
+  createTopoStore,
   deriveSurfaceMap,
   deriveSurfaceMapHash,
   readSurfaceLockData,


### PR DESCRIPTION
## Summary

Per ADR-0042, durable graph artifacts belong in `@ontrails/topographer`. The topo store is exactly that — a read-only projection of a *persisted snapshot* that writes rows to `.trails/trails.db`, tracks history across builds, and feeds lockfile exports. None of it runs to dispatch a trail. This PR moves the topo-store public API and its internal substrate out of `@ontrails/core` and into `@ontrails/topographer`.

**Breaking pre-1.0 beta change.** Every consumer that previously did `import { topoStore, createTopoStore, ... } from '@ontrails/core'` now imports from `@ontrails/topographer`. After this lands, core no longer ships any persistence-shaped API.

## What changed

**Moved out of core into topographer:**
- `packages/core/src/topo-store.ts` → `packages/topographer/src/topo-store.ts`
- `packages/core/src/internal/topo-store{,-read,-snapshots}.ts` → `packages/topographer/src/internal/...`
- Topo-store test files plus a split-out topo-snapshots suite that previously lived inside `packages/core/src/__tests__/trails-db.test.ts`.

**Stayed in core (per ADR-0014):** the generic trails-db helpers — `openReadTrailsDb`, `openWriteTrailsDb`, `ensureSubsystemSchema`, `deriveTrailsDbPath`, `deriveTrailsDir`. Topographer imports these from core. Core does NOT import topographer.

**Newly public from core:** `activationSourceKey`, `projectActivationSourceDeclaration`, `activationSourceDeclarationSignature`, and `ActivationSourceProjection`. These were single-consumer pre-existing internals; promoting them avoids reaching into core internals from topographer.

**Consumers updated:** `apps/trails/src/trails/{survey,topo-store-support,topo-support,dev-support}.ts`, `packages/warden/src/drift.ts` and its test.

**Docs:** `docs/topo-store.md`, `docs/topo-store-reference.md`, `docs/architecture.md`, `docs/api-reference.md`, `packages/topographer/README.md` (expanded), `packages/core/README.md` (migration section).

**Changeset:** `.changeset/topo-store-relocation.md` — core major, topographer minor, warden + trails patch.

Verified: typecheck (21/21), build (20/20), full repo tests green (core 1051/1051; topographer 84/84), lint (22/22), `format:check`, `check`.

## Stack

Built on #368 (the rename must land first because this relocation moves files INTO the renamed `packages/topographer/` directory). Built on by #370 and #371.

Closes TRL-610