### PR TITLE
chore(workspace): scaffold @ontrails/wayfinder package shell

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -10,6 +10,7 @@
     "@ontrails/observe": "0.1.0",
     "@ontrails/mcp": "0.1.0",
     "@ontrails/topographer": "0.1.0",
+    "@ontrails/wayfinder": "0.1.0",
     "@ontrails/testing": "0.1.0",
     "@ontrails/warden": "0.1.0",
     "@ontrails/http": "1.0.0-beta.6",

--- a/.changeset/wayfinder-shell.md
+++ b/.changeset/wayfinder-shell.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/wayfinder': major
+---
+
+Scaffold the empty `@ontrails/wayfinder` package shell. Reserves the namespace and gives the v0 wayfinding trails a clean home; no trails ship yet. v0 catalog is specified in the wayfinding draft ADR (`docs/adr/drafts/20260503-wayfinding.md`).
+
+The `major` bump keeps the package in lockstep with the rest of the `@ontrails/*` workspace: with `initialVersions: "0.1.0"` in `.changeset/pre.json`, a `major` bump computes `1.0.0` on `changeset pre exit`, matching the other framework packages that carry `major` bumps in earlier changesets (`api-simplification-beta4`, `topo-store-relocation`).

--- a/bun.lock
+++ b/bun.lock
@@ -257,6 +257,14 @@
         "@ontrails/topographer": "workspace:^",
       },
     },
+    "packages/wayfinder": {
+      "name": "@ontrails/wayfinder",
+      "version": "1.0.0-beta.15",
+      "peerDependencies": {
+        "@ontrails/core": "workspace:^",
+        "@ontrails/topographer": "workspace:^",
+      },
+    },
   },
   "trustedDependencies": [
     "oxfmt",
@@ -369,6 +377,8 @@
     "@ontrails/vite": ["@ontrails/vite@workspace:connectors/vite"],
 
     "@ontrails/warden": ["@ontrails/warden@workspace:packages/warden"],
+
+    "@ontrails/wayfinder": ["@ontrails/wayfinder@workspace:packages/wayfinder"],
 
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.121.0", "", { "os": "android", "cpu": "arm" }, "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A=="],
 

--- a/packages/wayfinder/CHANGELOG.md
+++ b/packages/wayfinder/CHANGELOG.md
@@ -1,0 +1,6 @@
+# @ontrails/wayfinder
+
+## Unreleased
+
+- Initial package shell scaffolded; no trails yet. See
+  [`docs/adr/drafts/20260503-wayfinding.md`](../../docs/adr/drafts/20260503-wayfinding.md).

--- a/packages/wayfinder/README.md
+++ b/packages/wayfinder/README.md
@@ -1,0 +1,17 @@
+# @ontrails/wayfinder
+
+Agent-shaped wayfinding trails over `@ontrails/topographer` artifacts.
+
+`@ontrails/wayfinder` is the public package home for trails that let agents
+query a Trails app's resolved topo — overviews, searches, trail details,
+examples — without re-deriving the graph from `grep` plus file reads.
+
+**Status: shell only.** No trails ship yet. The v0 catalog and design are
+captured in the wayfinding draft ADR:
+
+- [`docs/adr/drafts/20260503-wayfinding.md`](../../docs/adr/drafts/20260503-wayfinding.md)
+
+This package currently exists to reserve the `@ontrails/wayfinder` namespace
+and give the v0 implementation a clean home. When wayfinding lands as an
+accepted ADR, trails such as `wayfind.overview`, `wayfind.search`,
+`wayfind.trail`, and `wayfind.examples` will be exported from here.

--- a/packages/wayfinder/package.json
+++ b/packages/wayfinder/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@ontrails/wayfinder",
+  "version": "1.0.0-beta.15",
+  "description": "Agent-shaped wayfinding trails over @ontrails/topographer artifacts. v0 trails defined in the wayfinding draft ADR; package shell only — no trails ship yet.",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@ontrails/core": "workspace:^",
+    "@ontrails/topographer": "workspace:^"
+  },
+  "peerDependenciesMeta": {
+    "@ontrails/core": {
+      "optional": true
+    },
+    "@ontrails/topographer": {
+      "optional": true
+    }
+  }
+}

--- a/packages/wayfinder/src/__tests__/shell.test.ts
+++ b/packages/wayfinder/src/__tests__/shell.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+
+import { WAYFINDER_SHELL } from '../index.ts';
+
+describe('@ontrails/wayfinder shell', () => {
+  test('exports the shell marker', () => {
+    expect(WAYFINDER_SHELL).toBe(true);
+  });
+});

--- a/packages/wayfinder/src/index.ts
+++ b/packages/wayfinder/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Agent-shaped wayfinding API for Trails.
+ *
+ * `@ontrails/wayfinder` is the public package home for trails that let agents
+ * query a Trails app's resolved topo without re-deriving it from `grep` and
+ * file reads. The v0 trail catalog (`wayfind.overview`, `wayfind.search`,
+ * `wayfind.trail`, `wayfind.examples`, etc.) is specified in the wayfinding
+ * draft ADR; this package currently ships as a marker only.
+ *
+ * No trails are exported yet. The shell exists to reserve the namespace and
+ * give the v0 trails a clean home when they land. Peer dependencies on
+ * `@ontrails/core` and `@ontrails/topographer` are declared optional in
+ * `peerDependenciesMeta` until real trails consume them.
+ *
+ * @see {@link https://github.com/outfitter-dev/trails/blob/main/docs/adr/drafts/20260503-wayfinding.md | Wayfinding (draft ADR)}
+ */
+
+/**
+ * Indicates the wayfinder shell is loaded but ships no trails yet.
+ *
+ * Consumers can branch on this to detect when the v0 catalog lands without
+ * inspecting the package version directly. Will be removed once real trails
+ * are exported.
+ */
+export const WAYFINDER_SHELL = true as const;

--- a/packages/wayfinder/tsconfig.json
+++ b/packages/wayfinder/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/packages/wayfinder/tsconfig.tests.json
+++ b/packages/wayfinder/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

Reserves the `@ontrails/wayfinder` namespace and gives the v0 wayfinding catalog (per the draft ADR landed in #370) a clean home. **No trails yet — package shell only.** The marker export (`WAYFINDER_SHELL`) lets consumers branch on shell-vs-real-catalog without inspecting package version, and gets removed when the v0 trails land.

## What changed

- `packages/wayfinder/package.json` — `peerDependencies` on `@ontrails/core` and `@ontrails/topographer`; lockstep version (`1.0.0-beta.15`).
- `packages/wayfinder/src/index.ts` — exports `WAYFINDER_SHELL = true as const` plus TSDoc cross-referencing the wayfinding draft ADR.
- `packages/wayfinder/src/__tests__/shell.test.ts` — smoke test on the marker.
- `packages/wayfinder/{README.md,CHANGELOG.md,tsconfig.json,tsconfig.tests.json}` — standard package scaffolding matching repo conventions.
- `.changeset/pre.json`: `initialVersion` entry for `@ontrails/wayfinder`.
- `.changeset/wayfinder-shell.md`: minor bump for the new package.
- `bun.lock` regenerated.

## Stack

Top of the topographer-foundation stack. Built on #370 (the package's TSDoc points at the wayfinding draft ADR landed there).

Closes TRL-613