### PR TITLE
docs: refresh taxonomy and layer guidance

### DIFF
--- a/docs/adr/0002-built-in-result-type.md
+++ b/docs/adr/0002-built-in-result-type.md
@@ -80,7 +80,9 @@ const result = await Result.fromFetch('https://api.example.com/data');
 
 ### Error taxonomy integration
 
-The Result type exists in tight partnership with the error taxonomy. Trails defines 13 concrete error classes, each extending `TrailsError` with a `category` and `retryable` flag:
+The Result type exists in tight partnership with the error taxonomy. Trails
+defines 15 fixed-category error classes, each extending `TrailsError` with a
+`category` and `retryable` flag:
 
 | Error class | Category | HTTP | CLI exit | JSON-RPC | Retryable |
 | --- | --- | --- | --- | --- | --- |
@@ -90,13 +92,19 @@ The Result type exists in tight partnership with the error taxonomy. Trails defi
 | `ConflictError` | `conflict` | 409 | 3 | -32603 | no |
 | `AlreadyExistsError` | `conflict` | 409 | 3 | -32603 | no |
 | `PermissionError` | `permission` | 403 | 4 | -32600 | no |
+| `PermitError` | `permission` | 403 | 4 | -32600 | no |
 | `TimeoutError` | `timeout` | 504 | 5 | -32603 | yes |
 | `RateLimitError` | `rate_limit` | 429 | 6 | -32603 | yes |
 | `NetworkError` | `network` | 502 | 7 | -32603 | yes |
 | `InternalError` | `internal` | 500 | 8 | -32603 | no |
 | `AssertionError` | `internal` | 500 | 8 | -32603 | no |
+| `DerivationError` | `internal` | 500 | 8 | -32603 | no |
 | `AuthError` | `auth` | 401 | 9 | -32600 | no |
 | `CancelledError` | `cancelled` | 499 | 130 | -32603 | no |
+
+`RetryExhaustedError` is dynamic: it wraps another `TrailsError`, inherits the
+wrapped error's category for surface mappings, and always reports
+`retryable: false`.
 
 The mapping is deterministic and lives in three lookup tables (`statusCodeMap`, `exitCodeMap`, `jsonRpcCodeMap`). The developer returns `Result.err(new NotFoundError('User not found'))`. The framework looks up the category and renders the right status code, exit code, or JSON-RPC code for the current surface. The developer never thinks about surface-specific error codes.
 

--- a/docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md
+++ b/docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md
@@ -37,7 +37,9 @@ If every new transport repeats this pattern ad hoc, the mappings will drift. A q
 
 ### The error taxonomy is a transport-independent behavior contract
 
-The 17 error classes define *behavioral categories*, not transport-specific codes. Each category carries two properties that any transport can read:
+The 17 error classes define *behavioral categories*, not transport-specific
+codes. `RetryExhaustedError` inherits the wrapped error's category. Each error
+exposes two properties that any transport can read:
 
 - **`retryable`** — should the transport attempt redelivery?
 - **`category`** — what family of failure is this?
@@ -77,7 +79,10 @@ The queue mapping is mechanical:
 - **`CancelledError`** → nack with discard. The trail was cancelled (e.g., by shutdown). The message is neither retried nor dead-lettered — it's discarded. The cancellation is an operational concern, not a message problem.
 - **Success** → ack.
 
-A queue connector (`@ontrails/with-kafka`, `@ontrails/with-sqs`) reads `retryable` from the error and makes the ack/nack decision. The connector doesn't need to understand 17 error classes. It understands one boolean.
+A queue connector (`@ontrails/with-kafka`, `@ontrails/with-sqs`) reads
+`retryable` from the error and makes the ack/nack decision. The connector
+doesn't need to understand 17 error classes or retry-exhaustion wrapping. It
+understands one boolean.
 
 ### Signal delivery follows the same pattern
 
@@ -111,7 +116,7 @@ The deliberate friction from ADR-0002 applies: adding a new error class or categ
 
 - **Queue and signal delivery semantics are derived, not designed.** A queue connector reads `retryable` and makes the ack/nack decision. No transport-specific error logic to author.
 - **New transports get error handling for free.** WebSocket close codes, gRPC status codes, any future transport — one mapping function, and the 17 error classes work everywhere.
-- **The taxonomy proves its design.** ADR-0002 designed the taxonomy with three transports. This ADR validates that the same behavioral categories and the `retryable` flag extend to five transports without modification. The abstraction holds.
+- **The taxonomy proves its design.** ADR-0002 designed the taxonomy with three transports. This ADR validates that the same category mappings and the `retryable` flag extend to five transports without modification. The abstraction holds.
 
 ### Tradeoffs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -301,7 +301,9 @@ This guarantees consistent validation, layer ordering, and error handling regard
 
 ## Error Taxonomy
 
-17 error classes across 10 categories. Each maps to CLI exit codes, HTTP status codes, JSON-RPC codes, and retryability:
+17 error classes across 10 categories. `RetryExhaustedError` inherits the
+wrapped error's category; each class maps to CLI exit codes, HTTP status codes,
+JSON-RPC codes, and retryability:
 
 | Category | Exit | HTTP | Retryable | Classes |
 | --- | --- | --- | --- | --- |

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -218,8 +218,8 @@ The MCP surface accepts execution layers in its options and uses
 `composeLayers()` from `@ontrails/core` to wrap the implementation.
 
 No MCP-specific layers ship in v1. The infrastructure is wired for
-surface-scoped behavior such as rate limiting, caching, or auth gates, but these
-layers are not topo primitives or graph nodes.
+surface-scoped behavior such as rate limiting, caching, or auth layers, but
+these layers are not topo primitives or graph nodes.
 
 ## Building Tools Without `surface()`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -115,7 +115,9 @@ result.unwrapOr(fallback);   // Value or fallback
 
 ### Error taxonomy
 
-17 error classes across 10 categories. Each maps deterministically to exit codes, HTTP status, and JSON-RPC codes on every surface.
+17 error classes across 10 categories. `RetryExhaustedError` inherits the
+wrapped error's category. Each maps deterministically to exit codes, HTTP
+status, and JSON-RPC codes on every surface.
 
 | Category | Classes | HTTP | Retryable |
 | --- | --- | --- | --- |

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -183,14 +183,14 @@ See [testing-patterns.md](references/testing-patterns.md) for the full testing A
 
 ## Error Taxonomy
 
-15 error classes across 10 categories, with deterministic mapping to exit codes, HTTP status, and JSON-RPC codes:
+15 fixed-category error classes across 10 categories, plus the dynamic `RetryExhaustedError` wrapper, with deterministic mapping to exit codes, HTTP status, and JSON-RPC codes:
 
 | Category | Classes | Exit | HTTP | Retry |
 |----------|---------|------|------|-------|
 | validation | ValidationError, AmbiguousError | 1 | 400 | No |
 | not_found | NotFoundError | 2 | 404 | No |
 | conflict | AlreadyExistsError, ConflictError | 3 | 409 | No |
-| permission | PermissionError | 4 | 403 | No |
+| permission | PermissionError, PermitError | 4 | 403 | No |
 | timeout | TimeoutError | 5 | 504 | Yes |
 | rate_limit | RateLimitError | 6 | 429 | Yes |
 | network | NetworkError | 7 | 502 | Yes |
@@ -240,7 +240,7 @@ Key rules: no throw in blaze functions, no surface imports, crosses declarations
 | CLI surface docs | Flag derivation, output modes, exit codes |
 | MCP surface docs | Tool naming, annotations, progress |
 | [testing-patterns.md](references/testing-patterns.md) | testAll, testTrail, harnesses |
-| [error-taxonomy.md](references/error-taxonomy.md) | All 15 error classes with signatures |
+| [error-taxonomy.md](references/error-taxonomy.md) | Error classes and signatures |
 | [common-pitfalls.md](references/common-pitfalls.md) | 12 anti-patterns with fixes |
 | [migration-checklist.md](references/migration-checklist.md) | Step-by-step conversion guide |
 | [trail.md](templates/trail.md) | Annotated trail skeleton |

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -194,14 +194,16 @@ The implementation is identical across all paths. Only the edges change.
 
 ## Error Taxonomy
 
-15 error classes across 10 categories. All extend `TrailsError`. Pattern match with `instanceof` or `error.category`.
+15 fixed-category error classes across 10 categories, plus the dynamic
+`RetryExhaustedError` wrapper. All extend `TrailsError`. Pattern match with
+`instanceof` or `error.category`.
 
 | Category | Exit | HTTP | Retryable | Classes |
 |----------|------|------|-----------|---------|
 | `validation` | 1 | 400 | No | `ValidationError`, `AmbiguousError` |
 | `not_found` | 2 | 404 | No | `NotFoundError` |
 | `conflict` | 3 | 409 | No | `AlreadyExistsError`, `ConflictError` |
-| `permission` | 4 | 403 | No | `PermissionError` |
+| `permission` | 4 | 403 | No | `PermissionError`, `PermitError` |
 | `timeout` | 5 | 504 | Yes | `TimeoutError` |
 | `rate_limit` | 6 | 429 | Yes | `RateLimitError` |
 | `network` | 7 | 502 | Yes | `NetworkError` |

--- a/plugin/skills/trails/references/error-taxonomy.md
+++ b/plugin/skills/trails/references/error-taxonomy.md
@@ -1,6 +1,9 @@
 # Error Taxonomy Reference
 
-## All 15 Error Classes
+## Error Classes
+
+The taxonomy has 15 fixed-category classes across 10 categories, plus the
+dynamic `RetryExhaustedError` wrapper.
 
 ### validation (exit 1, HTTP 400)
 
@@ -19,6 +22,7 @@
 ### permission (exit 4, HTTP 403)
 
 - **PermissionError** — Authenticated but not authorized. `new PermissionError('cannot delete admin users')`
+- **PermitError** — Permit extraction or enforcement failed before the blaze ran. `new PermitError('Missing required scope', { context: { scope: 'entity:write' } })`
 
 ### timeout (exit 5, HTTP 504)
 

--- a/plugin/skills/trails/references/testing-patterns.md
+++ b/plugin/skills/trails/references/testing-patterns.md
@@ -154,7 +154,7 @@ Applied automatically per example based on which fields are present:
 { name: 'Not found', input: { name: 'nope' }, error: 'NotFoundError' }
 ```
 
-Error class names: `ValidationError`, `NotFoundError`, `AlreadyExistsError`, `ConflictError`, `AuthError`, `PermissionError`, `TimeoutError`, `NetworkError`, `RateLimitError`, `InternalError`, `DerivationError`, `AmbiguousError`, `CancelledError`, `AssertionError`, `RetryExhaustedError`.
+Error class names: `ValidationError`, `NotFoundError`, `AlreadyExistsError`, `ConflictError`, `AuthError`, `PermissionError`, `PermitError`, `TimeoutError`, `NetworkError`, `RateLimitError`, `InternalError`, `DerivationError`, `AmbiguousError`, `CancelledError`, `AssertionError`, `RetryExhaustedError`.
 
 ## `createCrossContext()` -- Mock Cross for Composite Trails
 


### PR DESCRIPTION
## Context
Docs freshness audit found two clear current-facing drifts against live source/API reality:

- `PermitError` is exported and registered in the live core taxonomy, but several docs only listed `PermissionError` for the `permission` category.
- `RetryExhaustedError` is dynamic, so docs should describe the taxonomy as 15 fixed-category classes plus the dynamic wrapper instead of calling it the fifteenth class.
- A couple of surface/layer docs still used "auth gates" where the current lexicon uses layers.

## What changed
- Added `PermitError` to current-facing taxonomy tables and export lists.
- Clarified `RetryExhaustedError` as the dynamic category-inheriting wrapper.
- Replaced current-facing "auth gates" examples with "auth layers".
- Updated accepted ADRs 0002 and 0026 where they describe current taxonomy behavior.

## Validation
- `bun scripts/adr.ts check` passed with 0 errors / 0 warnings during the docs freshness pass.
- `bunx markdownlint-cli2 ...changed files...` passed with 0 errors during the docs freshness pass.
- `git diff --check` passed during the docs freshness pass.
- Focused stale-pattern sweeps ran for `trailhead(`, `ctx.signal`, `ctx.emit`, `testHike`, old Hono package names, auth gates, and error-taxonomy counts. Remaining matches were historical ADR/release/migration context or intentional current internals.

## Notes
- This is a separate docs-only freshness-audit PR; it is not part of the TRL implementation stack reverified through PR #405.
- Broad `bun run vocab:audit` still has known baseline noise from changelogs, historical release notes, generated ADR maps, draft ADRs, internal compatibility fields, and intentionally invalid fixtures.