### PR TITLE
feat(core): default ctx.logger when no observe option is provided

### DIFF
--- a/.changeset/trl-420-default-ctx-logger.md
+++ b/.changeset/trl-420-default-ctx-logger.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/core': minor
+---
+
+Default `ctx.logger` to a structured stdout console sink when `topo()` is called without an `observe:` option. Apps now get observability for free with zero configuration, per ADR-0041. Explicit `observe:` values (including `combine()` with no sinks, an explicit `Logger`, or an explicit `{ log }` config) are preserved untouched — the default is only injected when no `observe:` is supplied.

--- a/.claude/rules/coding-conventions.md
+++ b/.claude/rules/coding-conventions.md
@@ -35,6 +35,68 @@ TSDoc explains the contract of exported APIs. Start there before reaching for in
 - Prefer examples that mirror how agents or surface connectors will actually consume the API.
 - For resource definitions, document the `create` factory's dependencies and the type it produces. Document `dispose` if cleanup is non-trivial. Skip `mock` TSDoc unless the mock behavior differs significantly from the real implementation.
 
+## Cross-References in Source
+
+Cross-references in source are part of the framework's queryable contract: they should point future readers to durable source-of-truth artifacts, not make local prose look authoritative.
+
+### Source-of-Truth Anchoring
+
+When implementation must port behavior from existing code, the new code's TSDoc should name the source location with a file:line anchor. This is the difference between "this function happens to look like X" and "this function intentionally mirrors X." Future readers, human or agent, need to know which.
+
+The discipline applies in two distinct cases. Both produce the same artifact, a file:line TSDoc anchor, but differ in motivation and detectability.
+
+#### When Mirroring Established Semantics
+
+Apply this when authoring code that intentionally mirrors existing semantics: porting behavior from a sibling module, paralleling an established pattern, or building parallel infrastructure that must stay synchronized through a deprecation window.
+
+For example, a helper that ports subset-matching semantics from `packages/testing/src/assertions.ts` should say so in TSDoc and name the source helper. A date shortcut helper that intentionally matches a legacy layer's behavior should leave a short anchor to that legacy behavior while both surfaces coexist.
+
+This case rejects local summaries that hide the source of the semantics:
+
+```typescript
+/** Deep equality check for our test fixtures. */
+const deepEqual = (a: unknown, b: unknown): boolean => {
+  // ...logic intentionally ported from another framework helper...
+};
+```
+
+If the helper is intentionally porting existing behavior, the TSDoc should name that behavior's source. Otherwise readers cannot tell whether the author was unaware of the existing helper, deliberately diverging, or intentionally mirroring.
+
+This case is author discipline, not a good Warden target. "Looks similar" versus "intentionally mirrors" is a semantic judgment that a lint rule would either over-flag or miss.
+
+#### When Declining to Reuse
+
+Apply this when the framework or a sibling module exposes a helper that would serve, but the implementation authors a local copy or parallel version for a stated reason. The TSDoc should name the constraint that justified the inlining.
+
+The test surface is the framework-helper case: "This file exports its own `isPlainObject` even though `@ontrails/core` exports one, because of this named constraint." If you cannot write the reason, use the framework helper.
+
+This case is partially Warden-detectable for framework helpers: a future rule could flag function declarations that match exported framework helpers by name and signature without a TSDoc anchor explaining the local copy. The broader sibling-module case remains author discipline.
+
+### No Draft-ADR Anchors
+
+Source code, including TSDoc, inline comments, runtime strings, error messages, and log payloads, should reference accepted ADRs by stable number, such as `docs/adr/0043-layer-evolution.md`. It should not directly reference `docs/adr/drafts/<path>` unless the same stack promotes that draft below the implementing branch and the exception is explicitly documented.
+
+Draft paths are not durable anchors. Drafts can be renamed, promoted, replaced, or deleted while source comments still compile. Accepted ADRs carry stable numbers, are versioned explicitly, and survive promotion.
+
+When a feature is implemented from draft doctrine, prefer one of these anchors instead of the draft path:
+
+- Promote the draft first, then reference the accepted ADR.
+- Anchor to the source helper, sibling module, or branch that provides the current behavior.
+- Reference the introducing Linear issue when the doctrine is still pending.
+
+Do not invent ADR citations to make prose look authoritative. Verify the target exists and names the decision being cited.
+
+### Public Escape-Hatch Gate
+
+An escape hatch earns public-export status only when all four conditions hold:
+
+- **Structural necessity:** the existing primitive cannot express the case. Awkward expression is not enough.
+- **Desirable bareness:** the lack of metadata, schema, or governance is actively desirable, not merely tolerated.
+- **Downstream legibility:** the escape hatch produces something Warden, survey, traces, error attribution, or agents reading the resolved graph can understand.
+- **Empirical exhaustion:** concrete cases prove the existing primitive's options inadequate. Speculative scenarios do not qualify.
+
+When any condition fails, keep the seam internal or strengthen the existing primitive. Public exports are contracts, not convenience handles.
+
 ## Code Shape Patterns
 
 These patterns help keep code under the `max-statements` limit without normalizing suppressions. They also tend to produce code that is easier to test, extend, and read.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,55 @@ Subagents must not perform `git` or `gt` write operations. Only the main agent h
 - Subagents do not create branches, make commits, or push anything.
 - The main agent collects subagent work and commits it.
 
+### Brief Discipline
+
+Two principles gate whether a subagent dispatch produces usable findings versus fabricated output. Apply both.
+
+#### Principle 1: Concrete anchors beat semantic descriptions
+
+Briefs should name the artifacts the subagent must read, not just the semantics it should produce. Paraphrasing source code, types, or conventions leaves room for the subagent to invent what those artifacts contain.
+
+##### 1.1 Pin the data shape
+
+When the task involves subtle data structures or framework types, name the canonical declaration and file:line in the brief. Do not rely on prose like "render the trace as a tree" when the exact `TraceRecord` fields matter. Pin the field names, discriminants, and source type before asking for implementation or review.
+
+##### 1.2 Port from a named source and line
+
+When the task ports behavior from existing code, name the source helper and line range. A brief that says "implement partial matching" is weaker than one that says "port the semantics of `assertSubset` and `findObjectMatch` from `packages/testing/src/assertions.ts:<line>`." The named source makes alignment testable instead of aspirational.
+
+##### 1.3 Name the narrowing or type-guard pattern
+
+When the codebase has converged patterns, cite them. Examples include `instanceof TrailsError` for error narrowing, `isPlainObject` from `@ontrails/core` for object guards, or established casts in test fixtures. Without the pattern anchor, subagents tend to produce locally plausible but inconsistent checks.
+
+#### Principle 2: Unknowns demand grounding, not invention
+
+When the subagent cannot verify something, the correct output is an explicit unknown, not a plausible guess.
+
+##### 2.1 Scope-fit
+
+Before dispatching, ask whether the task can be expressed as bounded predicates over known artifacts, where "predicate fails" and "artifact missing" are both legible answers. If the task is "look around and tell me what you find," keep it in the main context or break it into bounded predicates first.
+
+##### 2.2 Anti-fabrication framing
+
+Briefs should say that "unable to verify" is acceptable and invented references are not. A subagent that cannot cite a claim should report that gap and continue or stop, depending on the brief. Inventing file paths, line numbers, branch descriptions, or source content is a hard failure.
+
+##### 2.3 Quote, do not paraphrase
+
+Every claim about file contents should include a verbatim quote with file path and line range when the task is evidentiary. If the subagent cannot quote the exact text, it should report "unable to quote" rather than approximate from memory.
+
+#### How the principles compose
+
+Anchor what you can; ground the rest. Principle 1 reduces the unknown surface area before dispatch. Principle 2 handles the residue when an otherwise bounded task hits missing or ambiguous evidence.
+
+#### Operational constraints
+
+Use these constraints alongside the two principles:
+
+- Do not ask subagents to create their own task lists. The main agent owns task tracking.
+- Do not let subagents run source-control write commands.
+- Specify exact write targets when a subagent is allowed to write findings.
+- Name known pre-existing noise upfront so subagents do not rediscover unrelated issues.
+
 ## Releasing
 
 All `@ontrails/*` packages are versioned in lockstep using [Changesets](https://github.com/changesets/changesets) in pre-release (`beta`) mode. We use Changesets only for versioning and changelogs — **not** `changeset publish`. Publishing goes through `bun publish` via our script, which correctly resolves `workspace:^` to real versions (npm publish does not).

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -228,6 +228,16 @@ Verb-friendly. A pin captures the graph; an export serializes it.
 
 Terms that name concepts existing cleanly across software. The standard word works.
 
+### Scope of Branded-Role Enforcement
+
+Lexicon enforcement is role-scoped. The framework bans generic synonyms when a word is claiming the canonical slot for a Trails concept, not whenever the word appears in ordinary explanation.
+
+A substitution claim should use the Trails term. For example, code or docs should not describe a `topo` as a registry, a `trail` as an action, a `blaze` as a handler, or a `surface` as transport terminology when the sentence is naming the framework concept itself.
+
+A mention can use the external or generic word when it is doing a different job: contrasting Trails with another system, naming an upstream library concept, quoting external API vocabulary, or explaining why a standard word is not the Trails term. The sentence "MCP calls these tools, while Trails authors trails" is a valid mention; the sentence "register this action in the topo" is a substitution and should be corrected.
+
+When in doubt, ask whether the word is occupying the Trails concept's canonical noun slot. If yes, use the lexicon. If it is apposition, contrast, quotation, or external-system vocabulary, keep the sentence accurate and avoid theatrical rewriting.
+
 ### `layer`
 
 A low-level wrapper around one trail execution. In v1, a layer is execution

--- a/packages/core/src/__tests__/observe.test.ts
+++ b/packages/core/src/__tests__/observe.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { TraceSink } from '../internal/tracing.js';
-import { isObserveInput, normalizeObserve } from '../observe.js';
-import type { LogSink, Logger } from '../types.js';
+import { isLogSink, isObserveInput, normalizeObserve } from '../observe.js';
+import type { LogRecord, LogSink, Logger } from '../types.js';
 
 const makeLogger = (): Logger => ({
   child: () => makeLogger(),
@@ -17,7 +17,8 @@ const makeLogger = (): Logger => ({
 
 describe('isObserveInput', () => {
   test('accepts undefined', () => {
-    expect(isObserveInput()).toBe(true);
+    const value: unknown = undefined;
+    expect(isObserveInput(value)).toBe(true);
   });
 
   test('accepts a Logger', () => {
@@ -66,6 +67,18 @@ describe('isObserveInput', () => {
     expect(isObserveInput(null)).toBe(false);
   });
 
+  test('guard remains consistent with normalizeObserve (default sink case)', () => {
+    // The guard accepts `undefined` and `normalizeObserve(undefined)` now
+    // returns the in-core default observe config rather than `undefined`.
+    // The guard contract is that normalization does not throw — the
+    // specific resolved shape is asserted in the dedicated suite below.
+    const value: unknown = undefined;
+    expect(isObserveInput(value)).toBe(true);
+    expect(() =>
+      normalizeObserve(value as Parameters<typeof normalizeObserve>[0])
+    ).not.toThrow();
+  });
+
   test('guard remains consistent with normalizeObserve', () => {
     // For every value the guard accepts, `normalizeObserve` must not
     // throw. Capability-only and bare LogSink inputs would throw, so
@@ -83,6 +96,39 @@ describe('isObserveInput', () => {
       expect(() =>
         normalizeObserve(value as Parameters<typeof normalizeObserve>[0])
       ).not.toThrow();
+    }
+  });
+});
+
+describe('normalizeObserve default sink', () => {
+  test('tolerates non-serializable metadata', () => {
+    const lines: string[] = [];
+    const originalInfo = console.info;
+    console.info = (line: unknown): void => {
+      lines.push(typeof line === 'string' ? line : String(line));
+    };
+
+    try {
+      const sink = normalizeObserve()?.log;
+      if (!isLogSink(sink)) {
+        throw new Error('expected default observe log target to be a LogSink');
+      }
+      const circular: Record<string, unknown> = {};
+      circular['self'] = circular;
+      const record: LogRecord = {
+        category: 'observe.default',
+        level: 'info',
+        message: 'metadata fallback',
+        metadata: { circular, token: 1n },
+        timestamp: new Date('2026-01-01T00:00:00.000Z'),
+      };
+
+      expect(() => sink.write(record)).not.toThrow();
+      expect(lines).toHaveLength(1);
+      const parsed = JSON.parse(lines[0] ?? '{}') as Record<string, unknown>;
+      expect(parsed['metadata']).toBe('[unserializable]');
+    } finally {
+      console.info = originalInfo;
     }
   });
 });

--- a/packages/core/src/__tests__/topo.test.ts
+++ b/packages/core/src/__tests__/topo.test.ts
@@ -175,8 +175,128 @@ describe('topo', () => {
       expect(records[0]?.trailId).toBe('observe.capable');
     });
 
-    test('leaves unconfigured topos on the default observe path', () => {
+    test('applies the default console log sink when no observe is provided', () => {
+      // ADR 0041 promises a non-null `ctx.logger` with zero configuration.
+      // The default observe config carries an in-core console log sink so
+      // the existing adapter path projects it onto `ctx.logger`.
       const t = topo('app', { myTrail: mockTrail('observe.default') });
+
+      expect(t.observe).toBeDefined();
+      expect(t.observe?.log).toBeDefined();
+      expect(t.observe?.trace).toBeUndefined();
+      // The default sink mirrors the shape of `@ontrails/observe`'s
+      // `createConsoleSink` without depending on it.
+      const log = t.observe?.log;
+      if (log === undefined || !('write' in log)) {
+        throw new Error('expected default observe log target to be a LogSink');
+      }
+      expect(log.name).toBe('console');
+      expect(typeof log.write).toBe('function');
+    });
+
+    test('default ctx.logger is non-null and routes records to stdout', async () => {
+      // The brief: with no `observe:` option, `ctx.logger` must be callable
+      // and emit a structured record to stdout via the default console sink.
+      const lines: string[] = [];
+      const originalInfo = console.info;
+      console.info = (line: unknown): void => {
+        lines.push(typeof line === 'string' ? line : String(line));
+      };
+      try {
+        const logged = trail('observe.default-logger', {
+          blaze: (_input, ctx) => {
+            ctx.logger?.info('default observed', { step: 'blaze' });
+            return Result.ok({ ok: true });
+          },
+          input: z.object({}),
+          output: z.object({ ok: z.boolean() }),
+        });
+        const t = topo('app', { logged });
+
+        const result = await run(t, 'observe.default-logger', {});
+
+        expect(result.isOk()).toBe(true);
+        expect(lines).toHaveLength(1);
+        const parsed = JSON.parse(lines[0] ?? '{}') as Record<string, unknown>;
+        expect(parsed['category']).toBe('observe.default-logger');
+        expect(parsed['level']).toBe('info');
+        expect(parsed['message']).toBe('default observed');
+        expect(parsed['metadata']).toMatchObject({
+          step: 'blaze',
+          topo: 'app',
+          trailId: 'observe.default-logger',
+        });
+      } finally {
+        console.info = originalInfo;
+      }
+    });
+
+    test('preserves an explicit Logger and does not merge in the default sink', async () => {
+      // When the caller hands in an explicit Logger, it must reach the
+      // adapter intact — the default console sink must not be added.
+      const calls: { message: string; data?: Record<string, unknown> }[] = [];
+      const explicitLogger = {
+        child(_metadata: Record<string, unknown>) {
+          return explicitLogger;
+        },
+        debug(): void {},
+        error(): void {},
+        fatal(): void {},
+        info(message: string, data?: Record<string, unknown>): void {
+          calls.push({ data, message });
+        },
+        name: 'explicit',
+        trace(): void {},
+        warn(): void {},
+      };
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.explicit-logger') },
+        { observe: explicitLogger }
+      );
+
+      expect(t.observe?.log).toBe(explicitLogger);
+      expect(t.observe?.trace).toBeUndefined();
+
+      const logged = trail('observe.explicit-logger.run', {
+        blaze: (_input, ctx) => {
+          ctx.logger?.info('explicit', { step: 'blaze' });
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const t2 = topo('app', { logged }, { observe: explicitLogger });
+      const result = await run(t2, 'observe.explicit-logger.run', {});
+      expect(result.isOk()).toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.message).toBe('explicit');
+    });
+
+    test('preserves an explicit { log } target without merging the default sink', () => {
+      const explicitLog: LogSink = {
+        name: 'capture',
+        write: () => {},
+      };
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.explicit-log') },
+        { observe: { log: explicitLog } }
+      );
+
+      expect(t.observe?.log).toBe(explicitLog);
+      expect(t.observe?.trace).toBeUndefined();
+    });
+
+    test('respects an explicit empty observe config without injecting the default sink', () => {
+      // An ObserveConfig shape with both `log` and `trace` set to `undefined`
+      // is an explicit "no sinks" declaration. The default console sink must
+      // not be silently merged in — the resolved observe stays absent.
+      const t = topo(
+        'app',
+        { myTrail: mockTrail('observe.explicit-empty') },
+        { observe: { log: undefined, trace: undefined } }
+      );
 
       expect(t.observe).toBeUndefined();
     });
@@ -444,7 +564,11 @@ describe('topo', () => {
         { observe: helperObserveFunction as unknown as never }
       );
 
-      expect(t.observe).toBeUndefined();
+      // The helper is ignored as a non-registrable module export, so the
+      // topo lands on the default observe path (in-core console sink),
+      // exactly as if no `observe:` had been provided at all.
+      expect(t.observe?.log?.name).toBe('console');
+      expect(t.observe?.trace).toBeUndefined();
       expect(t.trails.get('observe.helper-fn')).toBeDefined();
     });
 
@@ -460,7 +584,10 @@ describe('topo', () => {
         { observe: helperObject as unknown as never }
       );
 
-      expect(t.observe).toBeUndefined();
+      // Falling back to module semantics means the topo is unconfigured
+      // for observe and resolves to the default in-core console sink.
+      expect(t.observe?.log?.name).toBe('console');
+      expect(t.observe?.trace).toBeUndefined();
       expect(t.trails.get('observe.helper-obj')).toBeDefined();
     });
 
@@ -474,7 +601,8 @@ describe('topo', () => {
         { observe: 123 as unknown as never }
       );
 
-      expect(t.observe).toBeUndefined();
+      expect(t.observe?.log?.name).toBe('console');
+      expect(t.observe?.trace).toBeUndefined();
       expect(t.trails.get('observe.bad-number')).toBeDefined();
     });
 
@@ -488,7 +616,8 @@ describe('topo', () => {
         { observe: {} as unknown as never }
       );
 
-      expect(t.observe).toBeUndefined();
+      expect(t.observe?.log?.name).toBe('console');
+      expect(t.observe?.trace).toBeUndefined();
       expect(t.trails.get('observe.empty')).toBeDefined();
     });
 

--- a/packages/core/src/observe.ts
+++ b/packages/core/src/observe.ts
@@ -1,6 +1,7 @@
 import { ValidationError } from './errors.js';
 import type { TraceSink } from './internal/tracing.js';
-import type { Logger, LogLevel, LogSink } from './types.js';
+import { safeStringify } from './serialization.js';
+import type { Logger, LogLevel, LogRecord, LogSink } from './types.js';
 
 export interface ObserveConfig {
   readonly log?: Logger | LogSink | undefined;
@@ -160,11 +161,89 @@ const normalizeTraceTarget = (
   throw new ValidationError('topo observe.trace must be a TraceSink');
 };
 
+/**
+ * Maps observe log levels to the `console` method that should receive the
+ * formatted record. `silent` is intentionally absent — records at that level
+ * are dropped before reaching `console`.
+ */
+const DEFAULT_SINK_CONSOLE_METHOD: Record<
+  LogLevel,
+  'debug' | 'error' | 'info' | 'warn' | undefined
+> = {
+  debug: 'debug',
+  error: 'error',
+  fatal: 'error',
+  info: 'info',
+  silent: undefined,
+  trace: 'debug',
+  warn: 'warn',
+};
+
+const stringifyDefaultConsoleRecord = (record: LogRecord): string => {
+  const serialized = safeStringify({
+    category: record.category,
+    level: record.level,
+    message: record.message,
+    metadata: record.metadata,
+    timestamp: record.timestamp.toISOString(),
+  });
+  if (serialized.isOk()) {
+    return serialized.value;
+  }
+  return JSON.stringify({
+    category: record.category,
+    level: record.level,
+    message: record.message,
+    metadata: '[unserializable]',
+    timestamp: record.timestamp.toISOString(),
+  });
+};
+
+/**
+ * In-core mirror of `@ontrails/observe`'s `createConsoleSink` shape, kept
+ * minimal and private to avoid a reverse dependency from `@ontrails/core`
+ * onto `@ontrails/observe`. It mirrors the console level routing in
+ * `packages/observe/src/sinks.ts:50` and emits each record as a single-line
+ * JSON object routed to the matching `console.{debug|info|warn|error}` method.
+ *
+ * @remarks
+ * Used as the default `observe.log` target when `topo()` is called without an
+ * explicit `observe` option, so every app gets a non-null `ctx.logger` with
+ * structured stdout output and zero configuration. Apps that want richer
+ * formatting, file destinations, or custom routing should pass an explicit
+ * `observe` option, which fully replaces this default.
+ */
+const createDefaultConsoleSink = (): LogSink => ({
+  name: 'console',
+  write(record): void {
+    const method = DEFAULT_SINK_CONSOLE_METHOD[record.level];
+    if (method === undefined) {
+      return;
+    }
+    const payload = stringifyDefaultConsoleRecord(record);
+    // oxlint-disable-next-line trails-local/no-console-in-packages -- ADR 0041 mandates a default console logger in core; this is the single sanctioned console boundary, mirroring `@ontrails/observe`'s `createConsoleSink`.
+    console[method](payload);
+  },
+});
+
+/**
+ * The default observe configuration applied when `topo()` receives no
+ * `observe` option. Frozen so callers cannot mutate the shared default; the
+ * sink itself is shared across topos because it has no per-topo state.
+ */
+const DEFAULT_OBSERVE_CONFIG: ObserveConfig = Object.freeze({
+  log: createDefaultConsoleSink(),
+});
+
 export const normalizeObserve = (
   observe: ObserveInput | undefined
 ): ObserveConfig | undefined => {
   if (observe === undefined) {
-    return undefined;
+    // ADR 0041 promises a non-null `ctx.logger` with zero configuration.
+    // Returning the default config here lets the existing topo → adapter
+    // path project this log sink into `ctx.logger` without a second
+    // resolution point or a reverse dependency on `@ontrails/observe`.
+    return DEFAULT_OBSERVE_CONFIG;
   }
 
   const capabilities = readObserveCapabilities(observe);


### PR DESCRIPTION
## Summary
- Makes `ctx.logger` available by default when an app does not pass an `observe` option.
- Keeps the default sink inside `@ontrails/core` so the dependency direction stays `@ontrails/observe` -> `@ontrails/core`, not the reverse.
- Codifies the audit-authoring and lexicon guidance that came out of the course-correction pass.

## Details
`normalizeObserve(undefined)` now returns a frozen `ObserveConfig` with a core-local structured console sink. Explicit configs still win: `observe: combine()`, an explicit `Logger`, or an explicit `{ log }` object bypasses the default. Tests cover the default path, explicit overrides, and topo construction with the implicit logger.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-420.