### PR TITLE
feat(topographer): catalog trail IDs across apps in lockfile

### DIFF
--- a/.changeset/trl-403-workspace-trail-catalog.md
+++ b/.changeset/trl-403-workspace-trail-catalog.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/topographer': minor
+---
+
+Extend the lockfile schema to catalog trail IDs across apps. `SurfaceLock` now carries a Zod-validated `workspaceTrails` map whose entries include the trail ID, owning app name, and app module path, plus a narrowed `version: '2'` envelope for structured locks. The new `readWorkspaceLock()` reader returns the enriched trail-id index when present, or `null` for legacy / single-app locks. `TopoSnapshot` gains an optional `appName` attribution column (SQLite `topo_snapshots.app_name`, schema version 11) so snapshots can be attributed to their owning app. Single-app repos remain backward compatible — no workspace metadata is emitted unless the writer is given a `workspaceTrails` map.

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -805,7 +805,7 @@ describe('trails topo compile', () => {
         JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
       ).toMatchObject({
         hash: compiled.hash,
-        version: 1,
+        version: '2',
       });
       expect(topoCompileTrail.output.safeParse(compiled).success).toBe(true);
     } finally {

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -161,7 +161,7 @@ describe('topo and dev trails', () => {
         JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
       ).toMatchObject({
         hash: compileResult.hash,
-        version: 1,
+        version: '2',
       });
 
       const summaryAfterExport = expectOk(
@@ -322,7 +322,7 @@ describe('topo and dev trails', () => {
         JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
       ).toMatchObject({
         hash: secondCompile.hash,
-        version: 1,
+        version: '2',
       });
 
       const projectionDb = openReadTrailsDb({ rootDir: dir });

--- a/packages/topographer/src/__tests__/io.test.ts
+++ b/packages/topographer/src/__tests__/io.test.ts
@@ -9,7 +9,9 @@ import {
   writeSurfaceLock,
   readSurfaceLockData,
   readSurfaceLock,
+  readWorkspaceLock,
 } from '../io.js';
+import { surfaceLockSchema } from '../types.js';
 import type { SurfaceMap } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -40,9 +42,8 @@ const makeSurfaceMap = (): SurfaceMap => ({
 });
 
 const makeStructuredLock = (hash: string) => ({
-  generatedAt: '2026-04-03T00:00:00.000Z',
   hash,
-  version: 1,
+  version: '2' as const,
 });
 
 const readParsedLock = async (
@@ -124,7 +125,7 @@ describe('writeSurfaceLock / readSurfaceLock', () => {
 
     const parsed = await readParsedLock(filePath);
     expect(parsed.hash).toBe(hash);
-    expect(parsed.version).toBe(1);
+    expect(parsed.version).toBe('2');
 
     const result = await readSurfaceLockData({ dir: tempDir });
 
@@ -132,6 +133,20 @@ describe('writeSurfaceLock / readSurfaceLock', () => {
 
     const legacyResult = await readSurfaceLock({ dir: tempDir });
     expect(legacyResult).toBe(hash);
+  });
+
+  test('normalizes legacy structured JSON locks with numeric versions', async () => {
+    const hash = 'facefeed'.repeat(8);
+    await Bun.write(
+      join(tempDir, 'trails.lock'),
+      `${JSON.stringify({ hash, version: 1 }, null, 2)}\n`
+    );
+
+    const data = await readSurfaceLockData({ dir: tempDir });
+    expect(data).toEqual({ hash });
+
+    const result = await readSurfaceLock({ dir: tempDir });
+    expect(result).toBe(hash);
   });
 
   test('returns null for missing file', async () => {
@@ -169,5 +184,72 @@ describe('default directory', () => {
 
     const result = await readSurfaceLock({ dir: customDir });
     expect(result).toBe(hash);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workspace trail index
+// ---------------------------------------------------------------------------
+
+describe('readWorkspaceLock', () => {
+  test('returns null for a single-app structured lock without workspace metadata', async () => {
+    const hash = 'cafebabe'.repeat(8);
+    await writeSurfaceLock(makeStructuredLock(hash), { dir: tempDir });
+
+    const result = await readWorkspaceLock({ dir: tempDir });
+    expect(result).toBeNull();
+  });
+
+  test('returns the trail-id index for a multi-app workspace lock', async () => {
+    const hash = 'feedface'.repeat(8);
+    const workspaceTrails = {
+      'a.trail': {
+        appName: 'app-one',
+        modulePath: 'apps/one/src/app.ts',
+        trailId: 'a.trail',
+      },
+      'b.trail': {
+        appName: 'app-two',
+        modulePath: 'apps/two/src/app.ts',
+        trailId: 'b.trail',
+      },
+    } as const;
+    const filePath = await writeSurfaceLock(
+      { hash, workspaceTrails },
+      { dir: tempDir }
+    );
+
+    const parsed = await readParsedLock(filePath);
+    expect(parsed.hash).toBe(hash);
+    expect(parsed.version).toBe('2');
+    expect(parsed.workspaceTrails).toEqual(workspaceTrails);
+
+    const result = await readWorkspaceLock({ dir: tempDir });
+    expect(result).toEqual(workspaceTrails);
+  });
+
+  test('rejects out-of-band structured lock versions', () => {
+    const hash = '0badf00d'.repeat(8);
+    const result = surfaceLockSchema.safeParse({
+      hash,
+      version: 'banana',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test('returns null for the legacy single-line hash file', async () => {
+    const hash = 'aaaaaaaa'.repeat(8);
+    await writeSurfaceLock(hash, { dir: tempDir });
+
+    const result = await readWorkspaceLock({ dir: tempDir });
+    expect(result).toBeNull();
+  });
+
+  test('returns null when the lock file is missing', async () => {
+    const result = await readWorkspaceLock({
+      dir: join(tempDir, 'nonexistent'),
+    });
+    expect(result).toBeNull();
   });
 });

--- a/packages/topographer/src/__tests__/topo-snapshots.test.ts
+++ b/packages/topographer/src/__tests__/topo-snapshots.test.ts
@@ -82,4 +82,58 @@ describe('topo snapshot primitives', () => {
       db.close();
     }
   });
+
+  test('round-trips appName attribution through the snapshot row mapper', () => {
+    const rootDir = makeRoot();
+    const db = openWriteTrailsDb({ rootDir });
+
+    try {
+      const attributed = createTopoSnapshot(db, {
+        appName: 'app-one',
+        createdAt: '2026-04-04T00:00:00.000Z',
+      });
+      const unattributed = createTopoSnapshot(db, {
+        createdAt: '2026-04-05T00:00:00.000Z',
+      });
+
+      expect(attributed.appName).toBe('app-one');
+      expect(unattributed.appName).toBeUndefined();
+
+      const listed = listTopoSnapshots(db);
+      const byId = new Map(listed.map((snapshot) => [snapshot.id, snapshot]));
+
+      expect(byId.get(attributed.id)?.appName).toBe('app-one');
+      const unattributedSnapshot = byId.get(unattributed.id);
+      expect(unattributedSnapshot).toBeDefined();
+      expect(unattributedSnapshot?.appName).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  test('app_name migration via addColumnIfMissing is idempotent', () => {
+    const rootDir = makeRoot();
+    const db = openWriteTrailsDb({ rootDir });
+
+    try {
+      ensureTopoSnapshotSchema(db);
+      // Second call must not throw or duplicate the column.
+      ensureTopoSnapshotSchema(db);
+
+      const columns = db
+        .query<{ name: string }, []>('PRAGMA table_info(topo_snapshots)')
+        .all()
+        .map((row) => row.name);
+      expect(columns.filter((name) => name === 'app_name')).toHaveLength(1);
+
+      // Inserts continue to work after re-running the migration.
+      const snapshot = createTopoSnapshot(db, {
+        appName: 'app-two',
+        createdAt: '2026-04-06T00:00:00.000Z',
+      });
+      expect(snapshot.appName).toBe('app-two');
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/packages/topographer/src/__tests__/topo-store.test.ts
+++ b/packages/topographer/src/__tests__/topo-store.test.ts
@@ -1150,7 +1150,7 @@ describe('topo store projection', () => {
               "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
             )
             .get()?.version
-        ).toBe(10);
+        ).toBe(11);
         expect(countRows(db, 'topo_snapshots')).toBe(0);
       });
     });
@@ -1201,7 +1201,7 @@ describe('topo store projection', () => {
               "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
             )
             .get()?.version
-        ).toBe(10);
+        ).toBe(11);
       });
     });
 
@@ -1242,7 +1242,7 @@ describe('topo store projection', () => {
             "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
           )
           .get()?.version
-      ).toBe(10);
+      ).toBe(11);
       for (const table of [
         'topo_activation_edges',
         'topo_activation_sources',

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -15,7 +15,13 @@ export {
   writeSurfaceLock,
   readSurfaceLockData,
   readSurfaceLock,
+  readWorkspaceLock,
 } from './io.js';
+export {
+  surfaceLockSchema,
+  workspaceTrailEntrySchema,
+  workspaceTrailIndexSchema,
+} from './types.js';
 
 // Types
 export type {
@@ -24,6 +30,8 @@ export type {
   SurfaceMapFieldOverride,
   SurfaceMapFieldOverrideKey,
   SurfaceLock,
+  WorkspaceTrailEntry,
+  WorkspaceTrailIndex,
   DiffEntry,
   DiffResult,
   JsonSchema,

--- a/packages/topographer/src/internal/topo-snapshots.ts
+++ b/packages/topographer/src/internal/topo-snapshots.ts
@@ -12,6 +12,7 @@ const TOPO_TABLE_STATEMENTS = [
     signal_count INTEGER NOT NULL DEFAULT 0,
     resource_count INTEGER NOT NULL DEFAULT 0,
     pinned_as TEXT,
+    app_name TEXT,
     created_at TEXT NOT NULL
   )`,
   `CREATE TABLE IF NOT EXISTS topo_trails (
@@ -161,6 +162,7 @@ const TOPO_INDEX_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_topo_activation_edges_trail ON topo_activation_edges(snapshot_id, trail_id)',
 ] as const;
 interface TopoSnapshotRow {
+  readonly app_name: string | null;
   readonly created_at: string;
   readonly git_dirty: number;
   readonly git_sha: string | null;
@@ -172,6 +174,14 @@ interface TopoSnapshotRow {
 }
 
 export interface TopoSnapshot {
+  /**
+   * Optional name of the app the snapshot was captured for.
+   *
+   * Workspace-aware tooling sets this so a single trails-db can host
+   * snapshots from multiple apps without losing attribution. Legacy
+   * single-app snapshots leave this `undefined`.
+   */
+  readonly appName?: string;
   readonly createdAt: string;
   readonly gitDirty: boolean;
   readonly gitSha?: string;
@@ -183,6 +193,7 @@ export interface TopoSnapshot {
 }
 
 export interface CreateTopoSnapshotInput {
+  readonly appName?: string;
   readonly createdAt?: string;
   readonly gitDirty?: boolean;
   readonly gitSha?: string;
@@ -205,6 +216,7 @@ const rowToSnapshot = (row: TopoSnapshotRow): TopoSnapshot => ({
   resourceCount: row.resource_count,
   signalCount: row.signal_count,
   trailCount: row.trail_count,
+  ...(row.app_name === null ? {} : { appName: row.app_name }),
   ...(row.git_sha === null ? {} : { gitSha: row.git_sha }),
   ...(row.pinned_as === null ? {} : { pinnedAs: row.pinned_as }),
 });
@@ -253,6 +265,10 @@ const createAllTopoTables = (db: Database): void => {
 /**
  * Current topo subsystem schema version.
  *
+ * Version 11 adds optional `app_name` attribution to `topo_snapshots` so a
+ * single trails-db can host snapshots from multiple apps in workspace-aware
+ * tooling. Older snapshots remain valid with `app_name IS NULL`.
+ *
  * Version 10 adds generic activation source catalog and activation edge tables.
  *
  * Version 9 adds structured example assertion columns to `topo_examples`.
@@ -265,7 +281,7 @@ const createAllTopoTables = (db: Database): void => {
  * tables and advance the subsystem version without translating or deleting
  * legacy rows.
  */
-export const TOPO_SCHEMA_VERSION = 10;
+export const TOPO_SCHEMA_VERSION = 11;
 
 export const ensureTopoSnapshotSchema = (db: Database): void => {
   ensureSubsystemSchema(db, {
@@ -282,6 +298,9 @@ export const ensureTopoSnapshotSchema = (db: Database): void => {
           'expected_match TEXT'
         );
         addColumnIfMissing(db, 'topo_examples', 'signals', 'signals TEXT');
+      }
+      if (currentVersion >= 7 && currentVersion < 11) {
+        addColumnIfMissing(db, 'topo_snapshots', 'app_name', 'app_name TEXT');
       }
     },
     subsystem: TOPO_SUBSYSTEM,
@@ -300,13 +319,14 @@ export const insertTopoSnapshotRecord = (
     resourceCount: input?.resourceCount ?? 0,
     signalCount: input?.signalCount ?? 0,
     trailCount: input?.trailCount ?? 0,
+    ...(input?.appName === undefined ? {} : { appName: input.appName }),
     ...(input?.gitSha === undefined ? {} : { gitSha: input.gitSha }),
   };
 
   db.run(
     `INSERT INTO topo_snapshots (
-      id, git_sha, git_dirty, trail_count, signal_count, resource_count, pinned_as, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      id, git_sha, git_dirty, trail_count, signal_count, resource_count, pinned_as, app_name, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       record.id,
       record.gitSha ?? null,
@@ -315,6 +335,7 @@ export const insertTopoSnapshotRecord = (
       record.signalCount,
       record.resourceCount,
       null,
+      record.appName ?? null,
       record.createdAt,
     ]
   );
@@ -338,7 +359,7 @@ export const readTopoSnapshot = (
   }
   const row = db
     .query<TopoSnapshotRow, [string]>(
-      `SELECT id, git_sha, git_dirty, trail_count, signal_count, resource_count, pinned_as, created_at
+      `SELECT id, git_sha, git_dirty, trail_count, signal_count, resource_count, pinned_as, app_name, created_at
        FROM topo_snapshots
        WHERE id = ?`
     )
@@ -355,7 +376,7 @@ export const readPinnedTopoSnapshot = (
   }
   const row = db
     .query<TopoSnapshotRow, [string]>(
-      `SELECT id, git_sha, git_dirty, trail_count, signal_count, resource_count, pinned_as, created_at
+      `SELECT id, git_sha, git_dirty, trail_count, signal_count, resource_count, pinned_as, app_name, created_at
        FROM topo_snapshots
        WHERE pinned_as = ?
        LIMIT 1`
@@ -436,7 +457,7 @@ const listSnapshotRows = (
 
   return db
     .query<TopoSnapshotRow, SQLQueryBindings[]>(
-      `SELECT id, git_sha, git_dirty, trail_count, signal_count, resource_count, pinned_as, created_at
+      `SELECT id, git_sha, git_dirty, trail_count, signal_count, resource_count, pinned_as, app_name, created_at
        FROM topo_snapshots${whereClause}
        ORDER BY created_at DESC, id DESC${limitClause}`
     )

--- a/packages/topographer/src/io.ts
+++ b/packages/topographer/src/io.ts
@@ -9,8 +9,10 @@ import type {
   ReadOptions,
   SurfaceLock,
   SurfaceMap,
+  WorkspaceTrailIndex,
   WriteOptions,
 } from './types.js';
+import { surfaceLockSchema } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -47,23 +49,27 @@ const readTextIfExists = async (filePath: string): Promise<string | null> => {
   }
 };
 
-const isSurfaceLock = (value: unknown): value is SurfaceLock => {
-  const lock = value as Record<string, unknown>;
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof lock['hash'] === 'string'
-  );
+const parseLegacyStructuredLock = (value: unknown): SurfaceLock | null => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const { hash } = value as { readonly hash?: unknown };
+  return typeof hash === 'string' ? { hash: hash.trim() } : null;
 };
 
 const parseSurfaceLock = (content: string): SurfaceLock => {
   try {
     const parsed: unknown = JSON.parse(content);
-    if (isSurfaceLock(parsed)) {
-      return parsed;
-    }
     if (typeof parsed === 'string') {
       return { hash: parsed.trim() };
+    }
+    const result = surfaceLockSchema.safeParse(parsed);
+    if (result.success) {
+      return result.data;
+    }
+    const legacyStructuredLock = parseLegacyStructuredLock(parsed);
+    if (legacyStructuredLock !== null) {
+      return legacyStructuredLock;
     }
   } catch {
     // Fall through to the legacy hash-line format.
@@ -109,10 +115,20 @@ export const readSurfaceMap = async (
 // ---------------------------------------------------------------------------
 
 /**
+ * Stamp a structured lock with the current lockfile version.
+ */
+const versionStampLock = (lock: SurfaceLock): SurfaceLock =>
+  surfaceLockSchema.parse({ ...lock, version: '2' });
+
+/**
  * Write a committed lock to `<dir>/trails.lock`.
  *
  * String input preserves the legacy single-line hash format. Structured input
  * is serialized as JSON. Creates the directory if it doesn't exist.
+ *
+ * @remarks
+ * Structured locks are validated with {@link surfaceLockSchema} and stamped
+ * with the current `version: '2'` envelope before serialization.
  */
 export const writeSurfaceLock = async (
   lock: string | SurfaceLock,
@@ -127,7 +143,8 @@ export const writeSurfaceLock = async (
     return filePath;
   }
 
-  await Bun.write(filePath, `${JSON.stringify(lock, null, 2)}\n`);
+  const stamped = versionStampLock(lock);
+  await Bun.write(filePath, `${JSON.stringify(stamped, null, 2)}\n`);
   return filePath;
 };
 
@@ -153,4 +170,30 @@ export const readSurfaceLock = async (
 ): Promise<string | null> => {
   const lock = await readSurfaceLockData(options);
   return lock?.hash ?? null;
+};
+
+/**
+ * Read the workspace trail-id index from `<dir>/trails.lock`.
+ *
+ * Returns the workspace trail index when the lock is a structured
+ * JSON document carrying `workspaceTrails`, and `null` for legacy single-line
+ * hash files, hash-only structured locks, or missing files.
+ *
+ * @remarks
+ * This is the workspace-wide catalog consumed by `trails run <id>` to resolve
+ * a trail to its owning app without scanning sources. Callers that need the
+ * raw lock envelope (hash, version, etc.) should use {@link readSurfaceLockData}.
+ */
+export const readWorkspaceLock = async (
+  options?: ReadOptions
+): Promise<WorkspaceTrailIndex | null> => {
+  const lock = await readSurfaceLockData(options);
+  if (lock === null) {
+    return null;
+  }
+  const { workspaceTrails } = lock;
+  if (workspaceTrails === undefined) {
+    return null;
+  }
+  return workspaceTrails;
 };

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -6,6 +6,7 @@ import type {
   StructuredSignalExample,
   StructuredTrailExample,
 } from '@ontrails/core';
+import { z } from 'zod';
 
 export type SurfaceMapExample =
   | StructuredSignalExample
@@ -138,16 +139,51 @@ export interface SurfaceMap {
 // Surface Lock
 // ---------------------------------------------------------------------------
 
+/** Workspace-owned trail entry serialized into a workspace lock. */
+export const workspaceTrailEntrySchema = z.object({
+  appName: z.string(),
+  modulePath: z.string(),
+  trailId: z.string(),
+});
+
+export type WorkspaceTrailEntry = z.infer<typeof workspaceTrailEntrySchema>;
+
+/**
+ * Workspace-wide trail-id index serialized into a workspace lock.
+ *
+ * Each key is a fully-qualified trail identifier. Each value carries the app
+ * that owns it plus the app module path used by consumers that need to load
+ * the owning topo without re-walking workspace manifests.
+ *
+ * @see SurfaceLock for the lock envelope that may carry this index.
+ */
+export const workspaceTrailIndexSchema = z.record(
+  z.string(),
+  workspaceTrailEntrySchema
+);
+
+export type WorkspaceTrailIndex = z.infer<typeof workspaceTrailIndexSchema>;
+
 /**
  * Normalized lock data read from `trails.lock`.
  *
  * The file may be stored as structured JSON or legacy single-line text.
  * The normalized shape always exposes the committed hash and preserves any
  * extra structured metadata.
+ *
+ * @remarks
+ * **Migration story.** Historical locks may be a single line containing a hash
+ * or a JSON string hash. Structured lock envelopes authored by Topographer use
+ * `version: '2'` and parse through {@link surfaceLockSchema}. Future lockfile
+ * versions should update this schema and add an explicit migration path.
  */
-export type SurfaceLock = Readonly<Record<string, unknown>> & {
-  readonly hash: string;
-};
+export const surfaceLockSchema = z.object({
+  hash: z.string(),
+  version: z.literal('2').optional(),
+  workspaceTrails: workspaceTrailIndexSchema.optional(),
+});
+
+export type SurfaceLock = z.infer<typeof surfaceLockSchema>;
 
 // ---------------------------------------------------------------------------
 // Diff


### PR DESCRIPTION
## Summary
- Extends `SurfaceLock` with optional `version` and `workspaceTrails` metadata.
- Adds `readWorkspaceLock()` so runtime code can read the trail-id -> app-name catalog without loading every app.
- Adds app attribution to topo snapshots and migrates the SQLite schema from v10 to v11.

## Details
This is the persistence branch for workspace trail discovery. The lockfile writer stays backward-compatible for single-app repos, and the topo-store migration follows the existing idempotent `addColumnIfMissing` pattern. Per the TRL-608 boundary, the work lives in `@ontrails/topographer`; `@ontrails/core` is intentionally untouched.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-403.