### PR TITLE
feat(topographer): add workspace topo discovery and cross-app trail index

### DIFF
--- a/.changeset/trl-404-workspace-topo-discovery.md
+++ b/.changeset/trl-404-workspace-topo-discovery.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/topographer': minor
+---
+
+Add `buildWorkspaceTrailIndex()` for runtime workspace topo discovery and cross-app trail-ID resolution. Discovers apps via root `package.json` workspaces, identifies Trails apps by `package.json.trails.module` or a `src/app.ts` convention, and builds an enriched `{ trailId → { trailId, appName, modulePath } }` index. Prefers the lockfile's `workspaceTrails` map (from TRL-403) when present for fast paths; falls back to dynamic loader-based discovery otherwise. The loader is injectable for testing. This is the runtime substrate that `trails run <id>` (TRL-398) will use to resolve trail IDs to owning apps without scanning source. Per the TRL-608 boundary rule, this is Topographer-owned tooling — `@ontrails/core` is not modified.

--- a/packages/topographer/src/__tests__/workspace-topos.test.ts
+++ b/packages/topographer/src/__tests__/workspace-topos.test.ts
@@ -1,0 +1,453 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { topo } from '@ontrails/core';
+import type { Topo } from '@ontrails/core';
+
+import { writeSurfaceLock } from '../io.js';
+import { buildWorkspaceTrailIndex } from '../workspace-topos.js';
+import type { WorkspaceTopoLoader } from '../workspace-topos.js';
+
+const LOCKFILE_FALLBACK_WARNING = 'No workspace lockfile found';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+interface AppFixture {
+  readonly name: string;
+  readonly trailIds: readonly string[];
+  /**
+   * Optional declaration field controlling which file the loader resolves.
+   * Defaults to omitted (convention: `src/app.ts`).
+   */
+  readonly entry?: string | undefined;
+  /** When true, the loader throws when invoked for this app. */
+  readonly loadFails?: boolean | undefined;
+}
+
+interface WorkspaceFixture {
+  readonly root: string;
+  readonly appPaths: ReadonlyMap<string, string>;
+}
+
+const writeJson = async (filePath: string, value: unknown): Promise<void> => {
+  await Bun.write(filePath, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const writeWorkspace = async (
+  root: string,
+  apps: readonly AppFixture[]
+): Promise<WorkspaceFixture> => {
+  await writeJson(join(root, 'package.json'), {
+    name: 'workspace-fixture',
+    private: true,
+    type: 'module',
+    workspaces: ['apps/*'],
+  });
+
+  const appPaths = new Map<string, string>();
+  for (const app of apps) {
+    const appDir = join(root, 'apps', app.name);
+    appPaths.set(app.name, appDir);
+
+    const pkg: Record<string, unknown> = {
+      name: app.name,
+      private: true,
+      // The fixture loader is injected, so the entry file does not need to
+      // exist on disk — but the discovery layer must still recognize this
+      // member as a Trails app, so we declare `trails.module` explicitly.
+      trails: { module: app.entry ?? 'src/app.ts' },
+      type: 'module',
+    };
+    await writeJson(join(appDir, 'package.json'), pkg);
+  }
+
+  return { appPaths, root };
+};
+
+const buildTopo = (name: string, ids: readonly string[]): Topo => {
+  // Construct a fake trail-shaped object for each id. The loader pipeline only
+  // calls topo.ids(), so we never actually invoke a blaze; the shape just has
+  // to satisfy the registrable kind discriminant.
+  const trailModules = ids.map((id, index) => ({
+    [`trail_${index}`]: {
+      // biome-ignore lint/suspicious/useAwait: trail blaze placeholder
+      blaze: async () => {
+        throw new Error(`fixture trail ${id} should never run`);
+      },
+      crosses: [],
+      examples: [],
+      id,
+      input: undefined,
+      kind: 'trail' as const,
+      output: undefined,
+    },
+  }));
+  return topo({ name }, ...trailModules);
+};
+
+const makeLoader =
+  (registry: ReadonlyMap<string, AppFixture>): WorkspaceTopoLoader =>
+  async (appDir: string, _root: string, _entryRelative?: string) => {
+    const segments = appDir.split('/');
+    const lastIndex = segments.length - 1;
+    const appName = segments[lastIndex];
+    if (appName === undefined || appName === '') {
+      throw new Error('app name missing');
+    }
+    const fixture = registry.get(appName);
+    if (fixture === undefined) {
+      throw new Error(`no fixture for ${appName}`);
+    }
+    if (fixture.loadFails === true) {
+      throw new Error('synthetic load failure');
+    }
+    return buildTopo(appName, fixture.trailIds);
+  };
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+let workspaceRoot: string;
+
+beforeEach(async () => {
+  workspaceRoot = await mkdtemp(join(tmpdir(), 'trails-workspace-topos-'));
+});
+
+afterEach(async () => {
+  await rm(workspaceRoot, { force: true, recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('buildWorkspaceTrailIndex (discovery path)', () => {
+  test('indexes trail ids across two apps to their owning app names', async () => {
+    const fixtures = [
+      { name: 'app-a', trailIds: ['a.create', 'a.read'] },
+      { name: 'app-b', trailIds: ['b.write'] },
+    ];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: makeLoader(registry),
+    });
+
+    expect(result.source).toBe('discovery');
+    expect(result.index).toEqual({
+      'a.create': {
+        appName: 'app-a',
+        modulePath: 'apps/app-a/src/app.ts',
+        trailId: 'a.create',
+      },
+      'a.read': {
+        appName: 'app-a',
+        modulePath: 'apps/app-a/src/app.ts',
+        trailId: 'a.read',
+      },
+      'b.write': {
+        appName: 'app-b',
+        modulePath: 'apps/app-b/src/app.ts',
+        trailId: 'b.write',
+      },
+    });
+    expect(result.apps).toEqual(expect.arrayContaining(['app-a', 'app-b']));
+    expect(result.apps.length).toBe(2);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+    ]);
+  });
+
+  test('indexes a single-app workspace', async () => {
+    const fixtures = [{ name: 'only-app', trailIds: ['only.ping'] }];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: makeLoader(registry),
+    });
+
+    expect(result.source).toBe('discovery');
+    expect(result.index).toEqual({
+      'only.ping': {
+        appName: 'only-app',
+        modulePath: 'apps/only-app/src/app.ts',
+        trailId: 'only.ping',
+      },
+    });
+    expect(result.apps).toEqual(['only-app']);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+    ]);
+  });
+
+  test('passes the already-resolved entry path to the loader', async () => {
+    const fixtures = [
+      {
+        entry: 'src/custom-app.ts',
+        name: 'custom-entry',
+        trailIds: ['custom.run'],
+      },
+    ];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+    const entries: string[] = [];
+    const trackingLoader: WorkspaceTopoLoader = async (
+      appDir,
+      root,
+      entryRelative
+    ) => {
+      entries.push(entryRelative ?? '');
+      return makeLoader(registry)(appDir, root, entryRelative);
+    };
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: trackingLoader,
+    });
+
+    expect(result.index['custom.run']).toEqual({
+      appName: 'custom-entry',
+      modulePath: 'apps/custom-entry/src/custom-app.ts',
+      trailId: 'custom.run',
+    });
+    expect(entries).toEqual(['src/custom-app.ts']);
+  });
+
+  test('returns an empty index for a workspace with no apps', async () => {
+    await writeWorkspace(workspaceRoot, []);
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: makeLoader(new Map()),
+    });
+
+    expect(result.source).toBe('discovery');
+    expect(result.index).toEqual({});
+    expect(result.apps).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+    ]);
+  });
+
+  test('does not list apps that load but expose zero trail ids', async () => {
+    const fixtures: readonly AppFixture[] = [
+      { name: 'empty-app', trailIds: [] },
+    ];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: makeLoader(registry),
+    });
+
+    expect(result.source).toBe('discovery');
+    expect(result.index).toEqual({});
+    expect(result.apps).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+    ]);
+  });
+
+  test('records a warning and partial index when one app fails to load', async () => {
+    const fixtures: readonly AppFixture[] = [
+      { name: 'good-app', trailIds: ['good.run'] },
+      { loadFails: true, name: 'broken-app', trailIds: [] },
+    ];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: makeLoader(registry),
+    });
+
+    expect(result.source).toBe('discovery');
+    expect(result.index).toEqual({
+      'good.run': {
+        appName: 'good-app',
+        modulePath: 'apps/good-app/src/app.ts',
+        trailId: 'good.run',
+      },
+    });
+    expect(result.apps).toEqual(['good-app']);
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings[0]).toContain(LOCKFILE_FALLBACK_WARNING);
+    expect(result.warnings[1]).toContain('broken-app');
+  });
+
+  test('warns and last-write-wins on cross-app trail id collision', async () => {
+    const fixtures = [
+      { name: 'app-a', trailIds: ['shared.id'] },
+      { name: 'app-b', trailIds: ['shared.id'] },
+    ];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: makeLoader(registry),
+    });
+
+    expect(result.source).toBe('discovery');
+    // last-write-wins; with deterministic discovery order, app-b wins.
+    expect(result.index['shared.id']).toEqual({
+      appName: 'app-b',
+      modulePath: 'apps/app-b/src/app.ts',
+      trailId: 'shared.id',
+    });
+    expect(result.warnings.some((w: string) => w.includes('shared.id'))).toBe(
+      true
+    );
+    expect(
+      result.warnings.some((w: string) => w.includes(LOCKFILE_FALLBACK_WARNING))
+    ).toBe(true);
+  });
+});
+
+describe('buildWorkspaceTrailIndex (lockfile path)', () => {
+  test('reads the index from a fresh workspace lock without loading apps', async () => {
+    const fixtures = [{ name: 'lock-app', trailIds: ['lock.read'] }];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+
+    await writeSurfaceLock(
+      {
+        hash: 'deadbeef'.repeat(8),
+        workspaceTrails: {
+          'lock.entry': {
+            appName: 'lock-app',
+            modulePath: 'apps/lock-app/src/app.ts',
+            trailId: 'lock.entry',
+          },
+        },
+      },
+      { dir: join(workspaceRoot, '.trails') }
+    );
+
+    let loaderCalls = 0;
+    const trackingLoader: WorkspaceTopoLoader = async (
+      appDir: string,
+      root: string
+    ) => {
+      loaderCalls += 1;
+      return makeLoader(registry)(appDir, root);
+    };
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: trackingLoader,
+    });
+
+    expect(result.source).toBe('lockfile');
+    expect(result.index).toEqual({
+      'lock.entry': {
+        appName: 'lock-app',
+        modulePath: 'apps/lock-app/src/app.ts',
+        trailId: 'lock.entry',
+      },
+    });
+    expect(loaderCalls).toBe(0);
+    expect(result.warnings).toEqual([]);
+    expect(Object.isFrozen(result.index)).toBe(true);
+    // apps reflect what the lockfile asserts.
+    expect(result.apps).toEqual(['lock-app']);
+  });
+
+  test('resolves a relative lockDir against cwd', async () => {
+    const fixtures = [{ name: 'lock-app', trailIds: ['lock.read'] }];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+
+    await writeSurfaceLock(
+      {
+        hash: 'cafebabe'.repeat(8),
+        workspaceTrails: {
+          'relative.lock': {
+            appName: 'lock-app',
+            modulePath: 'apps/lock-app/src/app.ts',
+            trailId: 'relative.lock',
+          },
+        },
+      },
+      { dir: join(workspaceRoot, '.custom-trails') }
+    );
+
+    let loaderCalls = 0;
+    const trackingLoader: WorkspaceTopoLoader = async (
+      appDir: string,
+      root: string,
+      entryRelative?: string
+    ) => {
+      loaderCalls += 1;
+      return makeLoader(registry)(appDir, root, entryRelative);
+    };
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: trackingLoader,
+      lockDir: '.custom-trails',
+    });
+
+    expect(result.source).toBe('lockfile');
+    expect(result.index['relative.lock']).toEqual({
+      appName: 'lock-app',
+      modulePath: 'apps/lock-app/src/app.ts',
+      trailId: 'relative.lock',
+    });
+    expect(loaderCalls).toBe(0);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test('falls back to discovery when no workspace lock is present', async () => {
+    const fixtures = [{ name: 'app-only', trailIds: ['only.go'] }];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: makeLoader(registry),
+    });
+
+    expect(result.source).toBe('discovery');
+    expect(result.warnings).toEqual([
+      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+    ]);
+    expect(result.index).toEqual({
+      'only.go': {
+        appName: 'app-only',
+        modulePath: 'apps/app-only/src/app.ts',
+        trailId: 'only.go',
+      },
+    });
+  });
+
+  test('preserves lockfile fallback warning when discovery has no workspace globs', async () => {
+    await writeJson(join(workspaceRoot, 'package.json'), {
+      name: 'no-workspaces',
+      private: true,
+      type: 'module',
+    });
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: makeLoader(new Map()),
+    });
+
+    expect(result.source).toBe('discovery');
+    expect(result.apps).toEqual([]);
+    expect(result.index).toEqual({});
+    expect(result.warnings).toEqual([
+      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+    ]);
+  });
+});

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -23,6 +23,23 @@ export {
   workspaceTrailIndexSchema,
 } from './types.js';
 
+// Workspace-wide trail-id index (cross-app resolution for `trails run <id>`).
+export {
+  buildWorkspaceTrailIndex,
+  defaultLoadTopo,
+  isAppManifest,
+  isRootManifest,
+  readAppManifest,
+  readWorkspacesGlobs,
+} from './workspace-topos.js';
+export type {
+  AppManifest,
+  BuildWorkspaceTrailIndexOptions,
+  RootManifest,
+  WorkspaceTopoLoader,
+  WorkspaceTrailIndexResult,
+} from './workspace-topos.js';
+
 // Types
 export type {
   SurfaceMap,

--- a/packages/topographer/src/workspace-topos.ts
+++ b/packages/topographer/src/workspace-topos.ts
@@ -1,0 +1,416 @@
+/**
+ * Workspace-wide trail-id index for cross-app resolution.
+ *
+ * Builds a `{ trailId → appName }` index that lets `trails run <id>` resolve
+ * a trail to its owning app without scanning every app's source. The index is
+ * either read from a committed workspace lockfile (the cached, fast path) or
+ * discovered by walking the workspace's `workspaces` glob, loading each app's
+ * topo, and reading its trail ids.
+ *
+ * @remarks
+ * **Boundary.** This module lives in `@ontrails/topographer` because it
+ * persists artifacts derived from the resolved graph (per ADR-0042). Cross-app
+ * resolution is CLI tooling that reads Topographer artifacts before runtime
+ * begins — `@ontrails/core` resolves a single in-memory graph and stays
+ * unaware of workspace topology.
+ */
+
+import { basename, isAbsolute, join, relative } from 'node:path';
+
+import type { Topo } from '@ontrails/core';
+
+import { readWorkspaceLock } from './io.js';
+import type { WorkspaceTrailEntry, WorkspaceTrailIndex } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Loader contract for a single workspace app.
+ *
+ * Receives the resolved app directory and the workspace root, and returns the
+ * loaded `Topo`. The default loader (see {@link defaultLoadTopo}) imports the
+ * app's entry module and reads a `default`, `graph`, or `app` export. Tests
+ * can substitute their own loader to avoid the dynamic-import dance against a
+ * temp directory.
+ */
+export type WorkspaceTopoLoader = (
+  appDir: string,
+  workspaceRoot: string,
+  entryRelative?: string | undefined
+) => Promise<Topo>;
+
+/**
+ * Options accepted by {@link buildWorkspaceTrailIndex}.
+ */
+export interface BuildWorkspaceTrailIndexOptions {
+  /** Workspace root (a directory containing a `package.json` with `workspaces`). */
+  readonly cwd: string;
+  /**
+   * Loader for individual app topos. Defaults to {@link defaultLoadTopo} which
+   * imports the resolved entry module via `await import()`.
+   */
+  readonly loadTopo?: WorkspaceTopoLoader;
+  /**
+   * Lock directory consulted before discovery runs. Defaults to `.trails`
+   * relative to `cwd` — matches {@link readWorkspaceLock}'s default.
+   */
+  readonly lockDir?: string;
+}
+
+/**
+ * Structured result of building the workspace trail-id index.
+ *
+ * @remarks
+ * `index` is the trail-id-to-app-name map. `source` distinguishes a cache hit
+ * (the lockfile already carried `workspaceTrails`) from discovery (apps were
+ * walked and loaded). `apps` lists the app names actually represented in the
+ * index; `warnings` reports load failures and last-write-wins collisions.
+ */
+export interface WorkspaceTrailIndexResult {
+  readonly index: WorkspaceTrailIndex;
+  readonly source: 'lockfile' | 'discovery';
+  readonly apps: readonly string[];
+  readonly warnings: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — package.json reading
+// ---------------------------------------------------------------------------
+
+/** A small subset of app `package.json` fields the discovery layer cares about. */
+export interface AppManifest {
+  readonly name?: string | undefined;
+  readonly trails?: { readonly module?: string | undefined } | undefined;
+}
+
+export const isAppManifest = (value: unknown): value is AppManifest => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  if ('name' in candidate && typeof candidate['name'] !== 'string') {
+    return false;
+  }
+  if ('trails' in candidate) {
+    const trailsField = candidate['trails'];
+    if (typeof trailsField !== 'object' || trailsField === null) {
+      return false;
+    }
+    const moduleField = (trailsField as Record<string, unknown>)['module'];
+    if (moduleField !== undefined && typeof moduleField !== 'string') {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const readAppManifest = async (
+  appDir: string
+): Promise<AppManifest | null> => {
+  const file = Bun.file(join(appDir, 'package.json'));
+  if (!(await file.exists())) {
+    return null;
+  }
+  try {
+    const parsed: unknown = await file.json();
+    return isAppManifest(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+export interface RootManifest {
+  readonly workspaces?: readonly string[] | undefined;
+}
+
+export const isRootManifest = (value: unknown): value is RootManifest => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (!('workspaces' in candidate)) {
+    return true;
+  }
+  const ws = candidate['workspaces'];
+  return Array.isArray(ws) && ws.every((entry) => typeof entry === 'string');
+};
+
+export const readWorkspacesGlobs = async (
+  cwd: string
+): Promise<readonly string[]> => {
+  const file = Bun.file(join(cwd, 'package.json'));
+  if (!(await file.exists())) {
+    return [];
+  }
+  try {
+    const parsed: unknown = await file.json();
+    if (!isRootManifest(parsed) || parsed.workspaces === undefined) {
+      return [];
+    }
+    return parsed.workspaces;
+  } catch {
+    return [];
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Discovery — walk workspaces and identify Trails apps
+// ---------------------------------------------------------------------------
+
+interface CandidateApp {
+  readonly appDir: string;
+  readonly appName: string;
+  readonly entryRelative: string;
+  readonly modulePath: string;
+}
+
+/**
+ * Resolve a single workspace member into a candidate app, or `null` if it
+ * does not look like a Trails app (no `package.json`, or no Trails entry).
+ *
+ * The convention:
+ * 1. The package.json must exist and parse.
+ * 2. Either an explicit `trails.module` field must be present, OR a default
+ *    `src/app.ts` file must exist in the member.
+ * 3. The package's `name` field becomes the app name; if missing, the last
+ *    path segment of the member directory is used as a stable fallback.
+ */
+const resolveCandidateApp = async (
+  memberDir: string,
+  workspaceRoot: string
+): Promise<CandidateApp | null> => {
+  const manifest = await readAppManifest(memberDir);
+  if (manifest === null) {
+    return null;
+  }
+
+  const explicitEntry = manifest.trails?.module;
+  const entryRelative = explicitEntry ?? 'src/app.ts';
+  if (manifest.trails?.module === undefined) {
+    const conventionEntry = Bun.file(join(memberDir, 'src/app.ts'));
+    if (!(await conventionEntry.exists())) {
+      return null;
+    }
+  }
+
+  const fallbackName = basename(memberDir) || memberDir;
+  const appName = manifest.name ?? fallbackName;
+  const modulePath = relative(workspaceRoot, join(memberDir, entryRelative));
+  return { appDir: memberDir, appName, entryRelative, modulePath };
+};
+
+/**
+ * Expand the workspace's `workspaces` globs into concrete member directories.
+ *
+ * Only directory-shaped globs are supported (`apps/*`, `packages/*`). The
+ * scanner uses {@link Bun.Glob} so we stay Bun-native and avoid pulling in
+ * extra glob libraries.
+ */
+const expandWorkspaceMembers = async (
+  cwd: string,
+  globs: readonly string[]
+): Promise<readonly string[]> => {
+  const members: string[] = [];
+  for (const pattern of globs) {
+    const glob = new Bun.Glob(pattern);
+    for await (const match of glob.scan({ cwd, onlyFiles: false })) {
+      members.push(join(cwd, match));
+    }
+  }
+  // Sort for deterministic discovery order. Collision resolution depends on
+  // a stable order so that "last-write-wins" is reproducible across runs.
+  return [...members].toSorted();
+};
+
+// ---------------------------------------------------------------------------
+// Default loader
+// ---------------------------------------------------------------------------
+
+/** Property names checked, in order, when extracting a Topo from a module. */
+const TOPO_EXPORT_NAMES = ['default', 'graph', 'app'] as const;
+
+const isTopo = (value: unknown): value is Topo => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate['ids'] === 'function' &&
+    typeof candidate['name'] === 'string'
+  );
+};
+
+/**
+ * Default loader: imports the app's entry module and returns the first export
+ * matching the `default` / `graph` / `app` convention.
+ */
+export const defaultLoadTopo: WorkspaceTopoLoader = async (
+  appDir,
+  _workspaceRoot,
+  entryRelative
+) => {
+  const entryAbsolute = join(appDir, entryRelative ?? 'src/app.ts');
+  const mod = (await import(entryAbsolute)) as Record<string, unknown>;
+  for (const exportName of TOPO_EXPORT_NAMES) {
+    const candidate = mod[exportName];
+    if (isTopo(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `App at "${appDir}" does not export a Topo via default, graph, or app.`
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+interface IndexAccumulator {
+  readonly entries: Map<string, WorkspaceTrailEntry>;
+  readonly apps: Set<string>;
+  readonly warnings: string[];
+}
+
+const recordTrails = (
+  accumulator: IndexAccumulator,
+  app: CandidateApp,
+  trailIds: readonly string[]
+): void => {
+  for (const trailId of trailIds) {
+    accumulator.apps.add(app.appName);
+    const previousOwner = accumulator.entries.get(trailId);
+    if (previousOwner !== undefined && previousOwner.appName !== app.appName) {
+      accumulator.warnings.push(
+        `Trail id "${trailId}" is registered by both "${previousOwner.appName}" and "${app.appName}"; last-write-wins until TRL-405 collision handling lands.`
+      );
+    }
+    accumulator.entries.set(trailId, {
+      appName: app.appName,
+      modulePath: app.modulePath,
+      trailId,
+    });
+  }
+};
+
+const buildFromLockfile = (
+  workspaceTrails: WorkspaceTrailIndex
+): WorkspaceTrailIndexResult => {
+  const apps = new Set<string>();
+  for (const entry of Object.values(workspaceTrails)) {
+    apps.add(entry.appName);
+  }
+  return {
+    apps: [...apps].toSorted(),
+    index: Object.freeze({ ...workspaceTrails }),
+    source: 'lockfile',
+    warnings: [],
+  };
+};
+
+const buildFromDiscovery = async (
+  cwd: string,
+  loadTopo: WorkspaceTopoLoader,
+  initialWarnings: readonly string[] = []
+): Promise<WorkspaceTrailIndexResult> => {
+  const accumulator: IndexAccumulator = {
+    apps: new Set<string>(),
+    entries: new Map<string, WorkspaceTrailEntry>(),
+    warnings: [...initialWarnings],
+  };
+
+  const globs = await readWorkspacesGlobs(cwd);
+  if (globs.length === 0) {
+    return {
+      apps: [],
+      index: Object.freeze({}),
+      source: 'discovery',
+      warnings: [...accumulator.warnings],
+    };
+  }
+
+  const members = await expandWorkspaceMembers(cwd, globs);
+  const resolvedCandidates = await Promise.all(
+    members.map((memberDir) => resolveCandidateApp(memberDir, cwd))
+  );
+  const candidates = resolvedCandidates.filter(
+    (candidate): candidate is CandidateApp => candidate !== null
+  );
+  const settled = await Promise.allSettled(
+    candidates.map(async (candidate) => {
+      const loaded = await loadTopo(
+        candidate.appDir,
+        cwd,
+        candidate.entryRelative
+      );
+      return { candidate, trailIds: loaded.ids() };
+    })
+  );
+  for (const [index, result] of settled.entries()) {
+    const candidate = candidates[index];
+    if (candidate === undefined) {
+      continue;
+    }
+    if (result.status === 'fulfilled') {
+      recordTrails(accumulator, result.value.candidate, result.value.trailIds);
+      continue;
+    }
+    const message =
+      result.reason instanceof Error
+        ? result.reason.message
+        : String(result.reason);
+    accumulator.warnings.push(
+      `Failed to load app "${candidate.appName}" at ${candidate.appDir}: ${message}`
+    );
+  }
+
+  return {
+    apps: [...accumulator.apps].toSorted(),
+    index: Object.freeze(Object.fromEntries(accumulator.entries)),
+    source: 'discovery',
+    warnings: [...accumulator.warnings],
+  };
+};
+
+/**
+ * Build a workspace-wide trail-id-to-app-name index.
+ *
+ * Prefers a committed workspace lockfile (`.trails/trails.lock` carrying a
+ * `workspaceTrails` entry) when present; otherwise walks the workspace's
+ * `workspaces` globs, loads each app's topo, and reads its trail ids.
+ *
+ * @example
+ * ```ts
+ * const result = await buildWorkspaceTrailIndex({ cwd: process.cwd() });
+ * if (result.source === 'lockfile') {
+ *   // Cached path — no app loading happened.
+ * }
+ * const owningApp = result.index['my-app.do-thing'];
+ * ```
+ */
+export const buildWorkspaceTrailIndex = async (
+  options: BuildWorkspaceTrailIndexOptions
+): Promise<WorkspaceTrailIndexResult> => {
+  const { cwd, loadTopo = defaultLoadTopo, lockDir } = options;
+
+  let resolvedLockDir: string;
+  if (lockDir === undefined) {
+    resolvedLockDir = join(cwd, '.trails');
+  } else if (isAbsolute(lockDir)) {
+    resolvedLockDir = lockDir;
+  } else {
+    resolvedLockDir = join(cwd, lockDir);
+  }
+  const lockedIndex = await readWorkspaceLock({
+    dir: resolvedLockDir,
+  });
+  if (lockedIndex !== null) {
+    return buildFromLockfile(lockedIndex);
+  }
+
+  return await buildFromDiscovery(cwd, loadTopo, [
+    `No workspace lockfile found in "${resolvedLockDir}"; falling back to discovery.`,
+  ]);
+};


### PR DESCRIPTION
## Summary
- Adds workspace topo discovery for Bun workspaces.
- Builds a runtime trail-id -> app-name index from either the new lockfile catalog or dynamic app loading.
- Keeps discovery in `@ontrails/topographer` so workspace indexing does not become a core concern.

## Details
`buildWorkspaceTrailIndex()` reads root `package.json` workspaces, identifies Trails apps via `package.json.trails.module` or `src/app.ts`, and uses an injectable loader that mirrors the app-loading pattern in `apps/trails`. Fresh lockfiles take the fast path with `source: 'lockfile'`; missing or stale locks fall back to discovery with warnings. Collision hardening is intentionally left to the next PR.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-404.