### PR TITLE
feat(topographer): detect trail-ID collisions across apps

### DIFF
--- a/.changeset/trl-405-collision-detection.md
+++ b/.changeset/trl-405-collision-detection.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/topographer': minor
+---
+
+Detect trail-ID collisions across apps in `buildWorkspaceTrailIndex()`. Replaces last-write-wins behavior with structured collision facts: `WorkspaceTrailIndexResult` now carries `collisions: WorkspaceTrailCollision[]` where each collision records the trail ID and the sorted list of owning apps. Colliding IDs are **omitted from `index`** so silent ambiguity is impossible; callers such as `trails run` must explicitly resolve via `--app` or prompt. Non-colliding IDs continue to resolve through the enriched `index` entries. Lockfile path always returns `collisions: []` because the lockfile is already a flat map and cannot collide.

--- a/packages/topographer/src/__tests__/workspace-topos.test.ts
+++ b/packages/topographer/src/__tests__/workspace-topos.test.ts
@@ -163,6 +163,7 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
     expect(result.warnings).toEqual([
       expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
     ]);
+    expect(result.collisions).toEqual([]);
   });
 
   test('indexes a single-app workspace', async () => {
@@ -220,6 +221,7 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
       trailId: 'custom.run',
     });
     expect(entries).toEqual(['src/custom-app.ts']);
+    expect(result.collisions).toEqual([]);
   });
 
   test('returns an empty index for a workspace with no apps', async () => {
@@ -256,6 +258,7 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
     expect(result.warnings).toEqual([
       expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
     ]);
+    expect(result.collisions).toEqual([]);
   });
 
   test('records a warning and partial index when one app fails to load', async () => {
@@ -283,12 +286,13 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
     expect(result.warnings).toHaveLength(2);
     expect(result.warnings[0]).toContain(LOCKFILE_FALLBACK_WARNING);
     expect(result.warnings[1]).toContain('broken-app');
+    expect(result.collisions).toEqual([]);
   });
 
-  test('warns and last-write-wins on cross-app trail id collision', async () => {
+  test('records a structured collision and omits the colliding id from the index', async () => {
     const fixtures = [
-      { name: 'app-a', trailIds: ['shared.id'] },
-      { name: 'app-b', trailIds: ['shared.id'] },
+      { name: 'app-a', trailIds: ['shared.id', 'a.only'] },
+      { name: 'app-b', trailIds: ['shared.id', 'b.only'] },
     ];
     const registry = new Map(fixtures.map((f) => [f.name, f]));
     await writeWorkspace(workspaceRoot, fixtures);
@@ -299,18 +303,87 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
     });
 
     expect(result.source).toBe('discovery');
-    // last-write-wins; with deterministic discovery order, app-b wins.
-    expect(result.index['shared.id']).toEqual({
-      appName: 'app-b',
-      modulePath: 'apps/app-b/src/app.ts',
-      trailId: 'shared.id',
+    // Colliding ids are NOT in the index — callers must resolve via collisions.
+    expect(result.index).toEqual({
+      'a.only': {
+        appName: 'app-a',
+        modulePath: 'apps/app-a/src/app.ts',
+        trailId: 'a.only',
+      },
+      'b.only': {
+        appName: 'app-b',
+        modulePath: 'apps/app-b/src/app.ts',
+        trailId: 'b.only',
+      },
     });
-    expect(result.warnings.some((w: string) => w.includes('shared.id'))).toBe(
-      true
-    );
-    expect(
-      result.warnings.some((w: string) => w.includes(LOCKFILE_FALLBACK_WARNING))
-    ).toBe(true);
+    expect(result.collisions).toEqual([
+      {
+        apps: ['app-a', 'app-b'],
+        owners: [
+          {
+            appName: 'app-a',
+            modulePath: 'apps/app-a/src/app.ts',
+            trailId: 'shared.id',
+          },
+          {
+            appName: 'app-b',
+            modulePath: 'apps/app-b/src/app.ts',
+            trailId: 'shared.id',
+          },
+        ],
+        trailId: 'shared.id',
+      },
+    ]);
+    // Collisions are reported via the structured field, not the warnings list.
+    expect(result.warnings).toEqual([
+      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+    ]);
+  });
+
+  test('records a 3-way collision with all owning apps sorted', async () => {
+    const fixtures = [
+      { name: 'app-a', trailIds: ['triple'] },
+      { name: 'app-b', trailIds: ['triple'] },
+      { name: 'app-c', trailIds: ['triple'] },
+    ];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: makeLoader(registry),
+    });
+
+    expect(result.source).toBe('discovery');
+    expect(result.index).toEqual({});
+    expect(result.collisions).toHaveLength(1);
+    const [collision] = result.collisions;
+    expect(collision).toBeDefined();
+    if (collision === undefined) {
+      throw new Error('expected at least one collision');
+    }
+    expect(collision.trailId).toBe('triple');
+    expect(collision.apps).toEqual(['app-a', 'app-b', 'app-c']);
+    expect(collision.owners).toEqual([
+      {
+        appName: 'app-a',
+        modulePath: 'apps/app-a/src/app.ts',
+        trailId: 'triple',
+      },
+      {
+        appName: 'app-b',
+        modulePath: 'apps/app-b/src/app.ts',
+        trailId: 'triple',
+      },
+      {
+        appName: 'app-c',
+        modulePath: 'apps/app-c/src/app.ts',
+        trailId: 'triple',
+      },
+    ]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+    ]);
   });
 });
 
@@ -359,6 +432,7 @@ describe('buildWorkspaceTrailIndex (lockfile path)', () => {
     expect(loaderCalls).toBe(0);
     expect(result.warnings).toEqual([]);
     expect(Object.isFrozen(result.index)).toBe(true);
+    expect(result.collisions).toEqual([]);
     // apps reflect what the lockfile asserts.
     expect(result.apps).toEqual(['lock-app']);
   });

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -37,6 +37,7 @@ export type {
   BuildWorkspaceTrailIndexOptions,
   RootManifest,
   WorkspaceTopoLoader,
+  WorkspaceTrailCollision,
   WorkspaceTrailIndexResult,
 } from './workspace-topos.js';
 

--- a/packages/topographer/src/workspace-topos.ts
+++ b/packages/topographer/src/workspace-topos.ts
@@ -60,19 +60,46 @@ export interface BuildWorkspaceTrailIndexOptions {
 }
 
 /**
+ * A trail id exported by more than one app in the workspace.
+ *
+ * @remarks
+ * Collisions are facts, not warnings. Callers (e.g. `trails run <id>`) decide
+ * whether to prompt the user, error out, or honor an explicit `--app` override
+ * — none of which the discovery layer can decide on its own.
+ *
+ * `owners` carries the same app/module-path entries as non-colliding index
+ * values so consumers can resolve an explicit app override without repeating
+ * workspace manifest discovery. `apps` is the stable, display-ready projection
+ * of those owners and is guaranteed to contain at least two entries.
+ */
+export interface WorkspaceTrailCollision {
+  readonly trailId: string;
+  readonly apps: readonly string[];
+  readonly owners: readonly WorkspaceTrailEntry[];
+}
+
+/**
  * Structured result of building the workspace trail-id index.
  *
  * @remarks
- * `index` is the trail-id-to-app-name map. `source` distinguishes a cache hit
- * (the lockfile already carried `workspaceTrails`) from discovery (apps were
- * walked and loaded). `apps` lists the app names actually represented in the
- * index; `warnings` reports load failures and last-write-wins collisions.
+ * `index` is the trail-id-to-app-name map for **non-colliding** ids. When a
+ * trail id is exported by more than one app, it is **omitted** from `index`
+ * and recorded in `collisions` instead — callers must consult `collisions`
+ * to resolve ambiguous ids deterministically.
+ *
+ * `source` distinguishes a cache hit (the lockfile already carried
+ * `workspaceTrails`) from discovery (apps were walked and loaded). The
+ * lockfile path cannot collide because the lockfile is itself a flat
+ * `{ trailId → appName }` map. `apps` lists the app names actually represented
+ * in the index. `warnings` reports load failures and other non-collision
+ * issues; collisions live in their own structured field.
  */
 export interface WorkspaceTrailIndexResult {
   readonly index: WorkspaceTrailIndex;
   readonly source: 'lockfile' | 'discovery';
   readonly apps: readonly string[];
   readonly warnings: readonly string[];
+  readonly collisions: readonly WorkspaceTrailCollision[];
 }
 
 // ---------------------------------------------------------------------------
@@ -269,7 +296,8 @@ export const defaultLoadTopo: WorkspaceTopoLoader = async (
 // ---------------------------------------------------------------------------
 
 interface IndexAccumulator {
-  readonly entries: Map<string, WorkspaceTrailEntry>;
+  /** All apps each trail id was registered by, in registration order. */
+  readonly owners: Map<string, WorkspaceTrailEntry[]>;
   readonly apps: Set<string>;
   readonly warnings: string[];
 }
@@ -281,18 +309,52 @@ const recordTrails = (
 ): void => {
   for (const trailId of trailIds) {
     accumulator.apps.add(app.appName);
-    const previousOwner = accumulator.entries.get(trailId);
-    if (previousOwner !== undefined && previousOwner.appName !== app.appName) {
-      accumulator.warnings.push(
-        `Trail id "${trailId}" is registered by both "${previousOwner.appName}" and "${app.appName}"; last-write-wins until TRL-405 collision handling lands.`
-      );
-    }
-    accumulator.entries.set(trailId, {
+    const entry: WorkspaceTrailEntry = {
       appName: app.appName,
       modulePath: app.modulePath,
       trailId,
+    };
+    const owners = accumulator.owners.get(trailId);
+    if (owners === undefined) {
+      accumulator.owners.set(trailId, [entry]);
+      continue;
+    }
+    if (!owners.some((owner) => owner.appName === app.appName)) {
+      owners.push(entry);
+    }
+  }
+};
+
+interface ResolvedOwners {
+  readonly index: WorkspaceTrailIndex;
+  readonly collisions: readonly WorkspaceTrailCollision[];
+}
+
+const resolveOwners = (
+  owners: ReadonlyMap<string, readonly WorkspaceTrailEntry[]>
+): ResolvedOwners => {
+  const index: WorkspaceTrailIndex = {};
+  const collisions: WorkspaceTrailCollision[] = [];
+  for (const [trailId, entries] of owners) {
+    if (entries.length === 1) {
+      // Safe: length-1 array, so destructured element is defined.
+      const [sole] = entries;
+      if (sole !== undefined) {
+        index[trailId] = sole;
+      }
+      continue;
+    }
+    const sortedOwners = [...entries].toSorted((a, b) =>
+      a.appName < b.appName ? -1 : 1
+    );
+    collisions.push({
+      apps: sortedOwners.map((entry) => entry.appName),
+      owners: sortedOwners,
+      trailId,
     });
   }
+  collisions.sort((a, b) => (a.trailId < b.trailId ? -1 : 1));
+  return { collisions, index };
 };
 
 const buildFromLockfile = (
@@ -304,6 +366,7 @@ const buildFromLockfile = (
   }
   return {
     apps: [...apps].toSorted(),
+    collisions: [],
     index: Object.freeze({ ...workspaceTrails }),
     source: 'lockfile',
     warnings: [],
@@ -317,7 +380,7 @@ const buildFromDiscovery = async (
 ): Promise<WorkspaceTrailIndexResult> => {
   const accumulator: IndexAccumulator = {
     apps: new Set<string>(),
-    entries: new Map<string, WorkspaceTrailEntry>(),
+    owners: new Map<string, WorkspaceTrailEntry[]>(),
     warnings: [...initialWarnings],
   };
 
@@ -325,6 +388,7 @@ const buildFromDiscovery = async (
   if (globs.length === 0) {
     return {
       apps: [],
+      collisions: [],
       index: Object.freeze({}),
       source: 'discovery',
       warnings: [...accumulator.warnings],
@@ -366,9 +430,11 @@ const buildFromDiscovery = async (
     );
   }
 
+  const { index, collisions } = resolveOwners(accumulator.owners);
   return {
     apps: [...accumulator.apps].toSorted(),
-    index: Object.freeze(Object.fromEntries(accumulator.entries)),
+    collisions,
+    index: Object.freeze(index),
     source: 'discovery',
     warnings: [...accumulator.warnings],
   };


### PR DESCRIPTION
## Summary
- Replaces last-write-wins workspace trail resolution with structured collision facts.
- Omits colliding trail IDs from the resolved index so ambiguity cannot silently execute the wrong app.
- Preserves non-colliding resolution and lockfile compatibility.

## Details
`WorkspaceTrailIndexResult` now includes `collisions: WorkspaceTrailCollision[]`, with each collision recording the trail ID and sorted owning apps. Callers such as `trails run` must choose an app explicitly, via `--app` or the later interactive prompt path, when a collision exists. Load warnings remain string-shaped warnings; trail ID collisions are their own structured category.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-405.