### PR TITLE
feat(trails): add run trail for direct invocation by ID

### DIFF
--- a/.changeset/trl-398-trails-run-trail.md
+++ b/.changeset/trl-398-trails-run-trail.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': minor
+---
+
+Add the `run` trail family to `apps/trails` for direct trail invocation by ID. `trails run <id> '<inline-json>'` resolves the trail in the current app's topo and executes it through the shared `run()` pipeline from `@ontrails/core`, returning a typed direct-invocation envelope. `run.examples` lists authored examples and `run.example` executes one named example with an actual-vs-expected comparison. Single-app resolution only on this branch; multi-app workspace resolution plus `--app` override land in TRL-406. Not-found maps to `Result.err(NotFoundError)` and CLI exit code 2 via the existing error taxonomy. Self-hosted: the trail family authors happy-path and not-found examples, exercised by `testExamples(app)`.

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -10,6 +10,9 @@ import * as devReset from './trails/dev-reset.js';
 import * as devStats from './trails/dev-stats.js';
 import * as draftPromote from './trails/draft-promote.js';
 import * as guide from './trails/guide.js';
+import * as run from './trails/run.js';
+import * as runExample from './trails/run-example.js';
+import * as runExamples from './trails/run-examples.js';
 import * as survey from './trails/survey.js';
 import * as topoCompile from './trails/topo-compile.js';
 import * as topoHistory from './trails/topo-history.js';
@@ -21,6 +24,9 @@ import * as warden from './trails/warden.js';
 
 export const app = topo(
   'trails',
+  run,
+  runExamples,
+  runExample,
   survey,
   topoCommand,
   topoCompile,

--- a/apps/trails/src/trails/run-example.ts
+++ b/apps/trails/src/trails/run-example.ts
@@ -1,0 +1,457 @@
+/**
+ * `run.example` trail -- run one named example and compare the result.
+ */
+
+import {
+  NotFoundError,
+  Result,
+  TrailsError,
+  deriveStructuredTrailExamples,
+  run,
+  trail,
+} from '@ontrails/core';
+import type { StructuredTrailExample, Topo } from '@ontrails/core';
+import { z } from 'zod';
+
+import { tryLoadFreshAppLease } from './load-app.js';
+import { resolveRunModulePath } from './run.js';
+import { resolveTrailRootDir } from './root-dir.js';
+import { createIsolatedExampleInput } from './topo-support.js';
+
+export const RUN_EXAMPLE_COMPARISON_KIND = 'example-comparison' as const;
+
+export const runExampleComparisonSchema = z.object({
+  actual: z.unknown(),
+  diff: z.array(z.string()).readonly().optional(),
+  exampleName: z.string(),
+  expected: z.unknown(),
+  input: z.unknown(),
+  kind: z.literal(RUN_EXAMPLE_COMPARISON_KIND),
+  match: z.boolean(),
+  mode: z.union([
+    z.literal('expected'),
+    z.literal('expectedMatch'),
+    z.literal('error'),
+  ]),
+  trailId: z.string(),
+});
+
+export type RunExampleComparison = z.infer<typeof runExampleComparisonSchema>;
+export type RunExampleComparisonMode = RunExampleComparison['mode'];
+
+interface ActualOutcomeOk {
+  readonly outcome: 'ok';
+  readonly value: unknown;
+}
+
+interface ActualOutcomeErr {
+  readonly errorCategory?: string;
+  readonly errorClassName: string;
+  readonly errorMessage: string;
+  readonly outcome: 'err';
+}
+
+type ActualOutcome = ActualOutcomeOk | ActualOutcomeErr;
+
+const buildHappyExampleInput = (): {
+  readonly exampleName: string;
+  readonly id: string;
+  readonly module: string;
+  readonly rootDir: string;
+} => ({
+  ...createIsolatedExampleInput('run-example-happy'),
+  exampleName: 'Brief capability report',
+  id: 'survey.brief',
+});
+
+const projectActual = (result: Result<unknown, Error>): ActualOutcome => {
+  if (result.isOk()) {
+    return { outcome: 'ok', value: result.value };
+  }
+  const { error } = result;
+  return {
+    errorClassName: error.constructor.name,
+    errorMessage: error.message,
+    outcome: 'err',
+    ...(error instanceof TrailsError ? { errorCategory: error.category } : {}),
+  };
+};
+
+const formatLeaf = (value: unknown): string => {
+  try {
+    const encoded = JSON.stringify(value);
+    return encoded === undefined ? String(value) : encoded;
+  } catch {
+    return String(value);
+  }
+};
+
+const formatPath = (segments: readonly string[]): string =>
+  segments.length === 0 ? 'value' : `value.${segments.join('.')}`;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const deepEqualWithDiff = (
+  actual: unknown,
+  expected: unknown,
+  path: readonly string[],
+  diffs: string[]
+): boolean => {
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual)) {
+      diffs.push(`${formatPath(path)}: expected array, got ${typeof actual}`);
+      return false;
+    }
+    if (actual.length !== expected.length) {
+      diffs.push(
+        `${formatPath(path)}: array length ${actual.length} != ${expected.length}`
+      );
+      return false;
+    }
+    let ok = true;
+    for (let i = 0; i < expected.length; i += 1) {
+      if (
+        !deepEqualWithDiff(actual[i], expected[i], [...path, `[${i}]`], diffs)
+      ) {
+        ok = false;
+      }
+    }
+    return ok;
+  }
+
+  if (isPlainObject(expected)) {
+    if (!isPlainObject(actual)) {
+      diffs.push(`${formatPath(path)}: expected object, got ${typeof actual}`);
+      return false;
+    }
+    let ok = true;
+    for (const key of Object.keys(expected)) {
+      if (!(key in actual)) {
+        diffs.push(`${formatPath([...path, key])}: missing in actual`);
+        ok = false;
+        continue;
+      }
+      if (
+        !deepEqualWithDiff(actual[key], expected[key], [...path, key], diffs)
+      ) {
+        ok = false;
+      }
+    }
+    for (const key of Object.keys(actual)) {
+      if (!(key in expected)) {
+        diffs.push(`${formatPath([...path, key])}: unexpected key in actual`);
+        ok = false;
+      }
+    }
+    return ok;
+  }
+
+  if (actual !== expected) {
+    if (
+      typeof actual === 'number' &&
+      typeof expected === 'number' &&
+      Number.isNaN(actual) &&
+      Number.isNaN(expected)
+    ) {
+      return true;
+    }
+    diffs.push(
+      `${formatPath(path)}: ${formatLeaf(actual)} != ${formatLeaf(expected)}`
+    );
+    return false;
+  }
+  return true;
+};
+
+const partialMatchWithDiff = (
+  actual: unknown,
+  expected: unknown,
+  path: readonly string[],
+  diffs: string[]
+): boolean => {
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual)) {
+      diffs.push(`${formatPath(path)}: expected array, got ${typeof actual}`);
+      return false;
+    }
+    let ok = true;
+    for (const [index, expectedEntry] of expected.entries()) {
+      const matched = actual.some((candidate) =>
+        partialMatchWithDiff(candidate, expectedEntry, [], [])
+      );
+      if (!matched) {
+        diffs.push(
+          `${formatPath([...path, `[${index}]`])}: expected array to contain ${formatLeaf(expectedEntry)}`
+        );
+        ok = false;
+      }
+    }
+    return ok;
+  }
+
+  if (isPlainObject(expected)) {
+    if (!isPlainObject(actual)) {
+      diffs.push(`${formatPath(path)}: expected object, got ${typeof actual}`);
+      return false;
+    }
+    let ok = true;
+    for (const key of Object.keys(expected)) {
+      if (!(key in actual)) {
+        diffs.push(`${formatPath([...path, key])}: missing in actual`);
+        ok = false;
+        continue;
+      }
+      if (
+        !partialMatchWithDiff(actual[key], expected[key], [...path, key], diffs)
+      ) {
+        ok = false;
+      }
+    }
+    return ok;
+  }
+
+  if (actual !== expected) {
+    diffs.push(
+      `${formatPath(path)}: ${formatLeaf(actual)} != ${formatLeaf(expected)}`
+    );
+    return false;
+  }
+  return true;
+};
+
+const compareExpected = (
+  result: Result<unknown, Error>,
+  expected: unknown
+): {
+  readonly diff?: readonly string[] | undefined;
+  readonly match: boolean;
+} => {
+  if (result.isErr()) {
+    return {
+      diff: [
+        `value: expected Result.ok(...), got Result.err(${result.error.constructor.name}: ${result.error.message})`,
+      ],
+      match: false,
+    };
+  }
+  const diffs: string[] = [];
+  const match = deepEqualWithDiff(result.value, expected, [], diffs);
+  return { diff: match ? undefined : diffs, match };
+};
+
+const compareExpectedMatch = (
+  result: Result<unknown, Error>,
+  expectedMatch: unknown
+): {
+  readonly diff?: readonly string[] | undefined;
+  readonly match: boolean;
+} => {
+  if (result.isErr()) {
+    return {
+      diff: [
+        `value: expected Result.ok(...), got Result.err(${result.error.constructor.name}: ${result.error.message})`,
+      ],
+      match: false,
+    };
+  }
+  const diffs: string[] = [];
+  const match = partialMatchWithDiff(result.value, expectedMatch, [], diffs);
+  return { diff: match ? undefined : diffs, match };
+};
+
+const compareError = (
+  result: Result<unknown, Error>,
+  expectedErrorName: string
+): {
+  readonly diff?: readonly string[] | undefined;
+  readonly match: boolean;
+} => {
+  if (result.isOk()) {
+    return {
+      diff: [
+        `value: expected Result.err(${expectedErrorName}), got Result.ok(${formatLeaf(result.value)})`,
+      ],
+      match: false,
+    };
+  }
+  const className = result.error.constructor.name;
+  if (className === expectedErrorName) {
+    return { diff: undefined, match: true };
+  }
+  return {
+    diff: [
+      `value: expected Result.err(${expectedErrorName}), got Result.err(${className}: ${result.error.message})`,
+    ],
+    match: false,
+  };
+};
+
+const findExample = (
+  app: Topo,
+  trailId: string,
+  exampleName: string
+): Result<StructuredTrailExample, Error> => {
+  const target = app.get(trailId);
+  if (target === undefined) {
+    return Result.err(
+      new NotFoundError(
+        `Trail '${trailId}' was not found in the resolved app.`,
+        { context: { trailId } }
+      )
+    );
+  }
+
+  const structured = deriveStructuredTrailExamples(target.examples) ?? [];
+  const match = structured.find((entry) => entry.name === exampleName);
+  if (match !== undefined) {
+    return Result.ok(match);
+  }
+
+  return Result.err(
+    new NotFoundError(
+      `Example '${exampleName}' not found on trail '${trailId}'.`,
+      {
+        context: {
+          available: structured.map((entry) => entry.name),
+          exampleName,
+          trailId,
+        },
+      }
+    )
+  );
+};
+
+const determineMode = (
+  example: StructuredTrailExample
+): RunExampleComparisonMode => {
+  if (example.error !== undefined) {
+    return 'error';
+  }
+  if (example.expectedMatch !== undefined) {
+    return 'expectedMatch';
+  }
+  return 'expected';
+};
+
+const buildComparisonEnvelope = async (
+  app: Topo,
+  trailId: string,
+  exampleName: string
+): Promise<Result<RunExampleComparison, Error>> => {
+  const exampleResult = findExample(app, trailId, exampleName);
+  if (exampleResult.isErr()) {
+    return Result.err(exampleResult.error);
+  }
+  const example = exampleResult.value;
+  const mode = determineMode(example);
+  const executed = await run(app, trailId, example.input);
+  const actual = projectActual(executed);
+
+  if (mode === 'error') {
+    const expectedName = example.error ?? '';
+    const { diff, match } = compareError(executed, expectedName);
+    return Result.ok({
+      actual,
+      diff,
+      exampleName,
+      expected: { errorClassName: expectedName },
+      input: example.input,
+      kind: RUN_EXAMPLE_COMPARISON_KIND,
+      match,
+      mode,
+      trailId,
+    });
+  }
+  if (mode === 'expectedMatch') {
+    const { diff, match } = compareExpectedMatch(
+      executed,
+      example.expectedMatch
+    );
+    return Result.ok({
+      actual,
+      diff,
+      exampleName,
+      expected: example.expectedMatch,
+      input: example.input,
+      kind: RUN_EXAMPLE_COMPARISON_KIND,
+      match,
+      mode,
+      trailId,
+    });
+  }
+
+  const { diff, match } = compareExpected(executed, example.expected);
+  return Result.ok({
+    actual,
+    diff,
+    exampleName,
+    expected: example.expected,
+    input: example.input,
+    kind: RUN_EXAMPLE_COMPARISON_KIND,
+    match,
+    mode,
+    trailId,
+  });
+};
+
+export const runExampleTrail = trail('run.example', {
+  args: ['id', 'exampleName'],
+  blaze: async (input, ctx) => {
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+    const moduleResolution = await resolveRunModulePath(
+      rootDir,
+      input.module,
+      input.id,
+      input.app
+    );
+    if (moduleResolution.isErr()) {
+      return Result.err(moduleResolution.error);
+    }
+
+    const leaseResult = await tryLoadFreshAppLease(
+      moduleResolution.value,
+      rootDir
+    );
+    if (leaseResult.isErr()) {
+      return Result.err(leaseResult.error);
+    }
+    const lease = leaseResult.value;
+
+    try {
+      return await buildComparisonEnvelope(
+        lease.app,
+        input.id,
+        input.exampleName
+      );
+    } finally {
+      lease.release();
+    }
+  },
+  description: 'Run a named example on a trail and compare actual vs expected',
+  examples: [
+    {
+      description: 'Run a named example on a target trail',
+      input: buildHappyExampleInput(),
+      name: 'Run named example',
+    },
+  ],
+  input: z.object({
+    app: z
+      .string()
+      .optional()
+      .describe(
+        'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
+      ),
+    exampleName: z.string().describe('Name of the example to run'),
+    id: z.string().describe('Trail ID whose example should run'),
+    module: z.string().optional().describe('Path to the app module'),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+  }),
+  intent: 'write',
+  output: runExampleComparisonSchema,
+});

--- a/apps/trails/src/trails/run-examples.ts
+++ b/apps/trails/src/trails/run-examples.ts
@@ -1,0 +1,139 @@
+/**
+ * `run.examples` trail -- list examples for a target trail.
+ */
+
+import {
+  NotFoundError,
+  Result,
+  deriveStructuredTrailExamples,
+  trail,
+} from '@ontrails/core';
+import type { StructuredTrailExample, Topo } from '@ontrails/core';
+import { z } from 'zod';
+
+import { tryLoadFreshAppLease } from './load-app.js';
+import { resolveRunModulePath } from './run.js';
+import { resolveTrailRootDir } from './root-dir.js';
+import { createIsolatedExampleInput } from './topo-support.js';
+
+export const RUN_EXAMPLES_LISTING_KIND = 'examples-listing' as const;
+
+export const structuredTrailExampleSchema = z.object({
+  description: z.string().optional(),
+  error: z.string().optional(),
+  expected: z.unknown().optional(),
+  expectedMatch: z.unknown().optional(),
+  input: z.unknown(),
+  kind: z.union([z.literal('success'), z.literal('error')]),
+  name: z.string(),
+  provenance: z.object({ source: z.literal('trail.examples') }),
+  signals: z
+    .array(
+      z.object({
+        payload: z.unknown().optional(),
+        payloadMatch: z.unknown().optional(),
+        signalId: z.string(),
+        times: z.number().optional(),
+      })
+    )
+    .readonly()
+    .optional(),
+});
+
+export const runExamplesListingSchema = z.object({
+  examples: z.array(structuredTrailExampleSchema).readonly(),
+  kind: z.literal(RUN_EXAMPLES_LISTING_KIND),
+  trailId: z.string(),
+});
+
+export type RunExamplesListing = z.infer<typeof runExamplesListingSchema>;
+
+const buildHappyExampleInput = (): {
+  readonly id: string;
+  readonly module: string;
+  readonly rootDir: string;
+} => ({
+  ...createIsolatedExampleInput('run-examples-happy'),
+  id: 'survey.brief',
+});
+
+const buildExamplesListing = (
+  app: Topo,
+  trailId: string
+): Result<RunExamplesListing, Error> => {
+  const target = app.get(trailId);
+  if (target === undefined) {
+    return Result.err(
+      new NotFoundError(
+        `Trail '${trailId}' was not found in the resolved app.`,
+        { context: { trailId } }
+      )
+    );
+  }
+
+  const structured =
+    (deriveStructuredTrailExamples(target.examples) as
+      | readonly StructuredTrailExample[]
+      | undefined) ?? [];
+  return Result.ok({
+    examples: structured,
+    kind: RUN_EXAMPLES_LISTING_KIND,
+    trailId,
+  });
+};
+
+export const runExamplesTrail = trail('run.examples', {
+  args: ['id'],
+  blaze: async (input, ctx) => {
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+    const moduleResolution = await resolveRunModulePath(
+      rootDir,
+      input.module,
+      input.id,
+      input.app
+    );
+    if (moduleResolution.isErr()) {
+      return Result.err(moduleResolution.error);
+    }
+
+    const leaseResult = await tryLoadFreshAppLease(
+      moduleResolution.value,
+      rootDir
+    );
+    if (leaseResult.isErr()) {
+      return Result.err(leaseResult.error);
+    }
+    const lease = leaseResult.value;
+
+    try {
+      return buildExamplesListing(lease.app, input.id);
+    } finally {
+      lease.release();
+    }
+  },
+  description: "List a trail's examples without executing it",
+  examples: [
+    {
+      description: 'List examples authored on a target trail',
+      input: buildHappyExampleInput(),
+      name: 'List trail examples',
+    },
+  ],
+  input: z.object({
+    app: z
+      .string()
+      .optional()
+      .describe(
+        'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
+      ),
+    id: z.string().describe('Trail ID whose examples should be listed'),
+    module: z.string().optional().describe('Path to the app module'),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+  }),
+  intent: 'read',
+  output: runExamplesListingSchema,
+});

--- a/apps/trails/src/trails/run.ts
+++ b/apps/trails/src/trails/run.ts
@@ -1,0 +1,144 @@
+/**
+ * `run` trail -- Direct trail invocation by ID.
+ *
+ * Resolves a trail in the current app's topo and executes it through the
+ * shared `run()` pipeline from `@ontrails/core`. The CLI surface drives this
+ * trail with `trails run <id> [inline-json]`; this branch only wires the
+ * single-app, inline-JSON path. Multi-app workspace resolution and additional
+ * input sources (stdin, file) are built in later branches.
+ *
+ * The trail's output keeps a typed discriminator around the heterogeneous
+ * inner trail value. The value itself remains `unknown` because direct
+ * invocation can target any trail in the loaded app.
+ */
+
+import { Result, run, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { tryLoadFreshAppLease } from './load-app.js';
+import { resolveTrailRootDir } from './root-dir.js';
+import { createIsolatedExampleInput } from './topo-support.js';
+
+export const INNER_TRAIL_RESULT_KIND = 'inner-trail-result' as const;
+
+export const innerTrailResultSchema = z.object({
+  kind: z.literal(INNER_TRAIL_RESULT_KIND),
+  trailId: z.string(),
+  value: z.unknown(),
+});
+
+export type InnerTrailResult = z.infer<typeof innerTrailResultSchema>;
+
+export const resolveRunModulePath = async (
+  _rootDir: string,
+  module: string | undefined,
+  _trailId: string,
+  _app: string | undefined
+): Promise<Result<string | undefined, Error>> =>
+  // The first run-family branch preserves the existing single-app loader
+  // behavior. Workspace-index resolution is layered in by the --app branch.
+  Result.ok(module);
+
+// ---------------------------------------------------------------------------
+// Example input helpers
+// ---------------------------------------------------------------------------
+
+const buildHappyExampleInput = (): {
+  readonly input: { readonly module: string; readonly rootDir: string };
+  readonly id: string;
+  readonly module: string;
+  readonly rootDir: string;
+} => {
+  const isolated = createIsolatedExampleInput('run-happy');
+  return {
+    id: 'survey.brief',
+    input: { module: isolated.module, rootDir: isolated.rootDir },
+    module: isolated.module,
+    rootDir: isolated.rootDir,
+  };
+};
+
+const buildNotFoundExampleInput = (): {
+  readonly id: string;
+  readonly module: string;
+  readonly rootDir: string;
+} => ({
+  ...createIsolatedExampleInput('run-not-found'),
+  id: 'does.not.exist',
+});
+
+// ---------------------------------------------------------------------------
+// Trail definition
+// ---------------------------------------------------------------------------
+
+export const runTrail = trail('run', {
+  args: ['id'],
+  blaze: async (input, ctx) => {
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+    const moduleResolution = await resolveRunModulePath(
+      rootDir,
+      input.module,
+      input.id,
+      input.app
+    );
+    if (moduleResolution.isErr()) {
+      return Result.err(moduleResolution.error);
+    }
+    const leaseResult = await tryLoadFreshAppLease(
+      moduleResolution.value,
+      rootDir
+    );
+    if (leaseResult.isErr()) {
+      return Result.err(leaseResult.error);
+    }
+    const lease = leaseResult.value;
+
+    try {
+      const result = await run(lease.app, input.id, input.input);
+      if (result.isErr()) {
+        return Result.err(result.error);
+      }
+      return Result.ok({
+        kind: INNER_TRAIL_RESULT_KIND,
+        trailId: input.id,
+        value: result.value,
+      });
+    } finally {
+      lease.release();
+    }
+  },
+  description:
+    'Resolve a trail by ID in the current app and execute it through the shared pipeline',
+  examples: [
+    {
+      description:
+        'Resolve and execute a trail by ID, returning the inner trail Result value',
+      input: buildHappyExampleInput(),
+      name: 'Run trail by ID',
+    },
+    {
+      description: 'Reject an unknown trail ID with NotFoundError',
+      error: 'NotFoundError',
+      input: buildNotFoundExampleInput(),
+      name: 'Reject unknown trail ID',
+    },
+  ],
+  input: z.object({
+    app: z.string().optional().describe('Workspace app name override'),
+    id: z.string().describe('Trail ID to invoke'),
+    input: z
+      .unknown()
+      .optional()
+      .describe(
+        'Parsed input for the resolved trail; the CLI surface JSON.parses the inline argument before passing it through'
+      ),
+    module: z.string().optional().describe('Path to the app module'),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+  }),
+  intent: 'write',
+  output: innerTrailResultSchema,
+});


### PR DESCRIPTION
## Summary
- Adds the self-hosted `trails run` trail family and registers it in the app topo.
- Supports direct invocation of a trail by ID through the shared `@ontrails/core` execution pipeline.
- Keeps this first branch single-app only; workspace app selection lands in the next PR.

## Details
The new run trail accepts the same app-loading inputs as existing Trails app trails (`module`, `rootDir`) and uses `tryLoadFreshAppLease()` rather than importing the app value directly. Unknown trail IDs return `NotFoundError`, preserving the established not-found exit mapping. The branch also establishes the run-family app routes that later PRs expose as `trails run example` and `trails run examples` commands.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-398.
