### PR TITLE
feat(trails): wire workspace index into run trail with --app override

### DIFF
--- a/.changeset/trl-406-app-override-collision-ux.md
+++ b/.changeset/trl-406-app-override-collision-ux.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': minor
+---
+
+Wire workspace topo discovery into the `run` trail with collision UX. `run` accepts an optional `app?: string` input that auto-projects as `--app <name>` on the CLI. Resolution flow: `--app` provided → use it; else if the trail ID is unambiguous in the workspace index → use the single owning app; else if colliding → return `Result.err(AmbiguousError)` whose message names the candidates and suggests `--app`. The CLI surface adds a TTY-aware bridge (`tryRecoverFromRunCollision`) that prompts via clack when stdin is a TTY and the trail returned an `AmbiguousError`, then re-executes with the chosen app. Non-TTY contexts surface the error and exit with code 1. Trail logic stays surface-agnostic; TTY detection and prompts live in the CLI bridge.

--- a/apps/trails/src/__tests__/run-collision.test.ts
+++ b/apps/trails/src/__tests__/run-collision.test.ts
@@ -1,0 +1,233 @@
+/* oxlint-disable-next-line eslint-plugin-jest/no-conditional-expect -- result-shape assertions branch on isOk/isErr */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ActionResultContext } from '@ontrails/cli';
+import {
+  AmbiguousError,
+  Result,
+  ValidationError,
+  executeTrail,
+} from '@ontrails/core';
+
+import { app } from '../app.js';
+import { tryRecoverFromRunCollision } from '../run-collision.js';
+import { runTrail } from '../trails/run.js';
+
+interface AppSpec {
+  readonly name: string;
+  readonly trailIds: readonly string[];
+}
+
+const writeFile = (filePath: string, contents: string): void => {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, contents);
+};
+
+const writeWorkspace = (root: string, apps: readonly AppSpec[]): void => {
+  writeFile(
+    join(root, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'run-collision-test-fixture',
+        private: true,
+        type: 'module',
+        workspaces: ['apps/*'],
+      },
+      null,
+      2
+    )}\n`
+  );
+  for (const spec of apps) {
+    const appDir = join(root, 'apps', spec.name);
+    writeFile(
+      join(appDir, 'package.json'),
+      `${JSON.stringify(
+        {
+          name: spec.name,
+          private: true,
+          trails: { module: 'src/app.ts' },
+          type: 'module',
+        },
+        null,
+        2
+      )}\n`
+    );
+    writeFile(
+      join(appDir, 'src/app.ts'),
+      [
+        `const trailIds = ${JSON.stringify(spec.trailIds)};`,
+        `export const app = {`,
+        `  name: '${spec.name}',`,
+        `  ids: () => trailIds,`,
+        `};`,
+        '',
+      ].join('\n')
+    );
+  }
+};
+
+const buildAmbiguousContext = async (
+  workspaceRoot: string
+): Promise<ActionResultContext> => {
+  const result = await executeTrail(runTrail, {
+    id: 'shared.id',
+    rootDir: workspaceRoot,
+  });
+  return {
+    args: { id: 'shared.id' },
+    flags: {},
+    input: { id: 'shared.id', rootDir: workspaceRoot },
+    result,
+    topoName: 'trails',
+    trail: runTrail as unknown as ActionResultContext['trail'],
+  };
+};
+
+let workspaceRoot: string;
+
+beforeEach(() => {
+  workspaceRoot = join(
+    tmpdir(),
+    `run-collision-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(workspaceRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { force: true, recursive: true });
+});
+
+describe('tryRecoverFromRunCollision', () => {
+  test('returns undefined when stdin is not a TTY (non-interactive surface)', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['shared.id'] },
+      { name: 'app-b', trailIds: ['shared.id'] },
+    ]);
+
+    const ctx = await buildAmbiguousContext(workspaceRoot);
+    expect(ctx.result.isErr()).toBe(true);
+
+    const recovered = await tryRecoverFromRunCollision(ctx, {
+      graph: app,
+      isTTY: () => false,
+    });
+
+    expect(recovered).toBeUndefined();
+  });
+
+  test('prompts when TTY and re-executes the trail with the chosen app, surfacing inner errors verbatim', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['shared.id'] },
+      { name: 'app-b', trailIds: ['shared.id'] },
+    ]);
+
+    const ctx = await buildAmbiguousContext(workspaceRoot);
+    let promptedCandidates: readonly string[] = [];
+    let promptedTrailId = '';
+
+    const recovered = await tryRecoverFromRunCollision(ctx, {
+      graph: app,
+      isTTY: () => true,
+      promptForApp: async (candidates, trailId) => {
+        promptedCandidates = candidates;
+        promptedTrailId = trailId;
+        return await Promise.resolve('app-a');
+      },
+    });
+
+    expect(promptedCandidates).toEqual(['app-a', 'app-b']);
+    expect(promptedTrailId).toBe('shared.id');
+    expect(recovered).toBeDefined();
+
+    // The fixture apps export stub topos that lack the `trails` field, so the
+    // load-app boundary surfaces a ValidationError. That is the *correct*
+    // post-recovery outcome here: the prompt produced a single-owner
+    // resolution, then real loading kicked in. The collision is no longer
+    // surfaced as Ambiguous.
+    if (recovered !== undefined && recovered.isErr()) {
+      expect(recovered.error).toBeInstanceOf(ValidationError);
+      expect(recovered.error).not.toBeInstanceOf(AmbiguousError);
+    }
+  });
+
+  test('returns undefined when the user cancels the prompt', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['shared.id'] },
+      { name: 'app-b', trailIds: ['shared.id'] },
+    ]);
+
+    const ctx = await buildAmbiguousContext(workspaceRoot);
+
+    const recovered = await tryRecoverFromRunCollision(ctx, {
+      graph: app,
+      isTTY: () => true,
+      promptForApp: async () => await Promise.resolve(),
+    });
+
+    expect(recovered).toBeUndefined();
+  });
+
+  test('does not prompt again when the user already supplied an app override', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['shared.id'] },
+      { name: 'app-b', trailIds: ['shared.id'] },
+      { name: 'app-c', trailIds: ['c.only'] },
+    ]);
+
+    const input = {
+      app: 'app-c',
+      id: 'shared.id',
+      rootDir: workspaceRoot,
+    };
+    const result = await executeTrail(runTrail, input);
+    let prompted = false;
+
+    const recovered = await tryRecoverFromRunCollision(
+      {
+        args: { id: 'shared.id' },
+        flags: { app: 'app-c' },
+        input,
+        result,
+        topoName: 'trails',
+        trail: runTrail as unknown as ActionResultContext['trail'],
+      },
+      {
+        graph: app,
+        isTTY: () => true,
+        promptForApp: async () => {
+          prompted = true;
+          return 'app-a';
+        },
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(AmbiguousError);
+    }
+    expect(recovered).toBeUndefined();
+    expect(prompted).toBe(false);
+  });
+
+  test('returns undefined for non-collision errors (no recovery attempted)', async () => {
+    const ctx: ActionResultContext = {
+      args: { id: 'unknown.trail' },
+      flags: {},
+      input: { id: 'unknown.trail', rootDir: workspaceRoot },
+      result: Result.err(new ValidationError('boom')),
+      topoName: 'trails',
+      trail: runTrail as unknown as ActionResultContext['trail'],
+    };
+
+    const recovered = await tryRecoverFromRunCollision(ctx, {
+      graph: app,
+      isTTY: () => true,
+      promptForApp: async () => await Promise.resolve('app-a'),
+    });
+
+    expect(recovered).toBeUndefined();
+  });
+});

--- a/apps/trails/src/__tests__/run.test.ts
+++ b/apps/trails/src/__tests__/run.test.ts
@@ -1,0 +1,224 @@
+/* oxlint-disable-next-line eslint-plugin-jest/no-conditional-expect -- result-shape assertions branch on isOk/isErr */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { AmbiguousError, NotFoundError, executeTrail } from '@ontrails/core';
+import type { Result } from '@ontrails/core';
+
+import { resolveRunModulePath, runTrail } from '../trails/run.js';
+
+interface AppSpec {
+  readonly name: string;
+  readonly trailIds: readonly string[];
+}
+
+const writeFixture = (filePath: string, contents: string): void => {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, contents);
+};
+
+const writeWorkspace = (
+  workspaceRoot: string,
+  apps: readonly AppSpec[]
+): void => {
+  writeFixture(
+    join(workspaceRoot, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'run-trail-test-fixture',
+        private: true,
+        type: 'module',
+        workspaces: ['apps/*'],
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  for (const spec of apps) {
+    const appDir = join(workspaceRoot, 'apps', spec.name);
+    writeFixture(
+      join(appDir, 'package.json'),
+      `${JSON.stringify(
+        {
+          name: spec.name,
+          private: true,
+          trails: { module: 'src/app.ts' },
+          type: 'module',
+        },
+        null,
+        2
+      )}\n`
+    );
+    // Stub Topo shape: only `ids()` and `name` are read by the discovery layer.
+    writeFixture(
+      join(appDir, 'src/app.ts'),
+      [
+        `const trailIds = ${JSON.stringify(spec.trailIds)};`,
+        `export const app = {`,
+        `  name: '${spec.name}',`,
+        `  ids: () => trailIds,`,
+        `};`,
+        '',
+      ].join('\n')
+    );
+  }
+};
+
+const expectErr = <T, E extends Error>(result: Result<T, E>): E => {
+  if (result.isOk()) {
+    throw new Error('Expected Result.err but got Result.ok');
+  }
+  return result.error;
+};
+
+let workspaceRoot: string;
+
+beforeEach(() => {
+  workspaceRoot = join(
+    tmpdir(),
+    `run-trail-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(workspaceRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { force: true, recursive: true });
+});
+
+describe('runTrail collision resolution', () => {
+  test('returns AmbiguousError when trail id is exposed by multiple apps and no --app is given', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['shared.id', 'a.only'] },
+      { name: 'app-b', trailIds: ['shared.id', 'b.only'] },
+    ]);
+
+    const result = await executeTrail(runTrail, {
+      id: 'shared.id',
+      rootDir: workspaceRoot,
+    });
+
+    const error = expectErr(result);
+    expect(error).toBeInstanceOf(AmbiguousError);
+    expect(error.message).toBe(
+      "Trail ID 'shared.id' exists in apps: app-a, app-b. Re-run with --app <name>."
+    );
+    if (error instanceof AmbiguousError) {
+      expect(error.context).toEqual({
+        candidates: ['app-a', 'app-b'],
+        trailId: 'shared.id',
+      });
+    }
+  });
+
+  test('returns NotFoundError when trail id is not present in any workspace app', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['a.only'] },
+      { name: 'app-b', trailIds: ['b.only'] },
+    ]);
+
+    const result = await executeTrail(runTrail, {
+      id: 'never.here',
+      rootDir: workspaceRoot,
+    });
+
+    const error = expectErr(result);
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(error.message).toContain("Trail 'never.here' was not found");
+  });
+
+  test('includes the requested --app when an override cannot find the trail id', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['a.only'] },
+      { name: 'app-b', trailIds: ['b.only'] },
+    ]);
+
+    const result = await executeTrail(runTrail, {
+      app: 'app-a',
+      id: 'never.here',
+      rootDir: workspaceRoot,
+    });
+
+    const error = expectErr(result);
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(error.message).toContain("Trail 'never.here' was not found");
+    expect(error.message).toContain("for app 'app-a'");
+    if (error instanceof NotFoundError) {
+      expect(error.context).toEqual({
+        requestedApp: 'app-a',
+        rootDir: workspaceRoot,
+        trailId: 'never.here',
+      });
+    }
+  });
+
+  test('rejects an --app override that does not own the requested trail id with AmbiguousError', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['shared.id'] },
+      { name: 'app-b', trailIds: ['shared.id'] },
+      { name: 'app-c', trailIds: ['c.only'] },
+    ]);
+
+    const result = await executeTrail(runTrail, {
+      app: 'app-c',
+      id: 'shared.id',
+      rootDir: workspaceRoot,
+    });
+
+    const error = expectErr(result);
+    expect(error).toBeInstanceOf(AmbiguousError);
+    if (error instanceof AmbiguousError) {
+      expect(error.context).toEqual({
+        candidates: ['app-a', 'app-b'],
+        trailId: 'shared.id',
+      });
+    }
+  });
+
+  test('rejects an --app override that does not own a sole-owner trail id with NotFoundError naming the actual owner', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['unique.id'] },
+      { name: 'app-b', trailIds: ['b.only'] },
+    ]);
+
+    const result = await executeTrail(runTrail, {
+      app: 'app-b',
+      id: 'unique.id',
+      rootDir: workspaceRoot,
+    });
+
+    const error = expectErr(result);
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(error.message).toContain("'unique.id'");
+    expect(error.message).toContain("'app-a'");
+    expect(error.message).toContain("'app-b'");
+    if (error instanceof NotFoundError) {
+      expect(error.context).toEqual({
+        actualOwner: 'app-a',
+        requestedApp: 'app-b',
+        trailId: 'unique.id',
+      });
+    }
+  });
+
+  test('resolves a colliding trail id through an owning --app override', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['shared.id'] },
+      { name: 'app-b', trailIds: ['shared.id'] },
+    ]);
+
+    const result = await resolveRunModulePath(
+      workspaceRoot,
+      undefined,
+      'shared.id',
+      'app-b'
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('apps/app-b/src/app.ts');
+    }
+  });
+});

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -1,14 +1,32 @@
-import { outputModePreset } from '@ontrails/cli';
+import { defaultOnResult, outputModePreset } from '@ontrails/cli';
+import type { ActionResultContext } from '@ontrails/cli';
 import { surface } from '@ontrails/cli/commander';
 
 import { app } from './app.js';
 import { resolveInputWithClack } from './clack.js';
+import { tryRecoverFromRunCollision } from './run-collision.js';
 import { trailsPackageVersion } from './versions.js';
+
+const onResult = async (ctx: ActionResultContext): Promise<void> => {
+  const recovered = await tryRecoverFromRunCollision(ctx, { graph: app });
+  if (recovered === undefined) {
+    await defaultOnResult(ctx);
+    return;
+  }
+  await defaultOnResult({
+    ...ctx,
+    input: recovered.isOk()
+      ? (ctx.trail.input.safeParse(ctx.input).data ?? ctx.input)
+      : ctx.input,
+    result: recovered,
+  });
+};
 
 // oxlint-disable-next-line require-hook -- CLI entry point
 await surface(app, {
   description: 'Agent-native, contract-first TypeScript framework',
   name: 'trails',
+  onResult,
   presets: [outputModePreset()],
   resolveInput: resolveInputWithClack,
   version: trailsPackageVersion,

--- a/apps/trails/src/local-state-io.ts
+++ b/apps/trails/src/local-state-io.ts
@@ -104,6 +104,28 @@ export const writeIsolatedExampleJsonFile = (
   }
 };
 
+export const writeIsolatedExampleTextFile = (
+  rootDir: string,
+  relativePath: string,
+  contents: string
+): string => {
+  const target = deriveSafePath(rootDir, relativePath);
+  if (target.isErr()) {
+    throw target.error;
+  }
+
+  try {
+    mkdirSync(dirname(target.value), { recursive: true });
+    writeFileSync(target.value, contents);
+    return relativePath;
+  } catch (error) {
+    throw new InternalError('Failed to write isolated example text file', {
+      cause: asError(error),
+      context: { relativePath, rootDir, targetPath: target.value },
+    });
+  }
+};
+
 export const removeRootRelativeFileIfPresent = (
   rootDir: string,
   relativePath: string

--- a/apps/trails/src/run-collision.ts
+++ b/apps/trails/src/run-collision.ts
@@ -1,0 +1,125 @@
+/**
+ * CLI-surface bridge for the `run` trail's collision UX.
+ *
+ * The `run` trail is surface-agnostic: when a trail id collides across two or
+ * more workspace apps and no `--app` override is provided, the trail returns
+ * `Result.err(AmbiguousError)` with the candidate app names in `error.context`.
+ *
+ * The CLI surface decides whether to prompt the user (TTY) or surface the
+ * error verbatim (non-TTY). This module owns that surface decision so the
+ * trail itself never reads `process.stdin.isTTY` or imports a prompt library.
+ */
+
+import type { ActionResultContext } from '@ontrails/cli';
+import { AmbiguousError, executeTrail, isPlainObject } from '@ontrails/core';
+import type { Result, Topo } from '@ontrails/core';
+import * as clack from '@clack/prompts';
+
+/** Runtime dependencies the wrapper resolves through; injectable for tests. */
+export interface RunCollisionDeps {
+  readonly graph: Topo;
+  readonly isTTY?: () => boolean;
+  readonly promptForApp?: (
+    candidates: readonly string[],
+    trailId: string
+  ) => Promise<string | undefined>;
+}
+
+const defaultIsTTY = (): boolean => process.stdin.isTTY === true;
+
+const defaultPromptForApp = async (
+  candidates: readonly string[],
+  trailId: string
+): Promise<string | undefined> => {
+  const choice = await clack.select({
+    message: `Trail ID '${trailId}' is exposed by multiple apps. Choose one:`,
+    options: candidates.map((appName) => ({
+      label: appName,
+      value: appName,
+    })),
+  });
+  return clack.isCancel(choice) ? undefined : (choice as string);
+};
+
+const isAmbiguousCollision = (
+  ctx: ActionResultContext
+): ctx is ActionResultContext & {
+  readonly result: { readonly error: AmbiguousError };
+} =>
+  ctx.trail.id === 'run' &&
+  ctx.result.isErr() &&
+  ctx.result.error instanceof AmbiguousError;
+
+const readCandidates = (error: AmbiguousError): readonly string[] => {
+  const ctx = error.context;
+  if (!isPlainObject(ctx)) {
+    return [];
+  }
+  const raw = ctx['candidates'];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.filter((entry): entry is string => typeof entry === 'string');
+};
+
+const readTrailId = (error: AmbiguousError): string | undefined => {
+  const ctx = error.context;
+  if (!isPlainObject(ctx)) {
+    return;
+  }
+  const raw = ctx['trailId'];
+  return typeof raw === 'string' ? raw : undefined;
+};
+
+const hasAppOverride = (input: unknown): boolean =>
+  isPlainObject(input) && typeof input['app'] === 'string';
+
+const mergeAppOverride = (
+  input: unknown,
+  app: string
+): Record<string, unknown> => ({
+  ...(isPlainObject(input) ? input : {}),
+  app,
+});
+
+/**
+ * Try to recover from an ambiguous-trail-id collision on the run trail.
+ *
+ * Returns the re-execution result when a TTY prompt yielded a chosen app, or
+ * `undefined` when there is nothing to recover (non-TTY, non-collision, or the
+ * user cancelled). The caller forwards `undefined` to the default result
+ * handler, which surfaces the error verbatim and maps it to exit code 1.
+ */
+export const tryRecoverFromRunCollision = async (
+  ctx: ActionResultContext,
+  deps: RunCollisionDeps
+): Promise<Result<unknown, Error> | undefined> => {
+  if (!isAmbiguousCollision(ctx)) {
+    return;
+  }
+  if (hasAppOverride(ctx.input)) {
+    return;
+  }
+
+  const isTTY = deps.isTTY ?? defaultIsTTY;
+  if (!isTTY()) {
+    return;
+  }
+
+  const { error } = ctx.result;
+  const candidates = readCandidates(error);
+  const trailId = readTrailId(error);
+  if (candidates.length === 0 || trailId === undefined) {
+    return;
+  }
+
+  const promptForApp = deps.promptForApp ?? defaultPromptForApp;
+  const chosen = await promptForApp(candidates, trailId);
+  if (chosen === undefined) {
+    return;
+  }
+
+  return await executeTrail(ctx.trail, mergeAppOverride(ctx.input, chosen), {
+    topo: deps.graph,
+  });
+};

--- a/apps/trails/src/trails/run.ts
+++ b/apps/trails/src/trails/run.ts
@@ -3,17 +3,51 @@
  *
  * Resolves a trail in the current app's topo and executes it through the
  * shared `run()` pipeline from `@ontrails/core`. The CLI surface drives this
- * trail with `trails run <id> [inline-json]`; this branch only wires the
- * single-app, inline-JSON path. Multi-app workspace resolution and additional
- * input sources (stdin, file) are built in later branches.
+ * trail with `trails run <id> [--app <name>] [inline-json]`.
+ *
+ * Resolution order:
+ *
+ *  1. If `module` is provided, load that module directly. This preserves the
+ *     single-app code path used by `testExamples` and tests that hand-build a
+ *     workspace fixture.
+ *  2. Otherwise, build the workspace trail-id index via
+ *     {@link buildWorkspaceTrailIndex}.
+ *     - If `app` is provided, resolve `app -> appDir -> module` and load that
+ *       app's topo. The trail id must exist in the chosen app.
+ *     - Else if the trail id has exactly one owner in the workspace index, use
+ *       that owner.
+ *     - Else if the trail id collides across multiple apps, return
+ *       `Result.err(AmbiguousError)`. The CLI surface decides whether to prompt
+ *       (TTY) or surface the error (non-TTY); the trail itself stays
+ *       surface-agnostic.
+ *     - Else return `Result.err(NotFoundError)`.
  *
  * The trail's output keeps a typed discriminator around the heterogeneous
  * inner trail value. The value itself remains `unknown` because direct
  * invocation can target any trail in the loaded app.
  */
 
-import { Result, run, trail } from '@ontrails/core';
+import { join } from 'node:path';
+
+import {
+  AmbiguousError,
+  NotFoundError,
+  Result,
+  run,
+  trail,
+} from '@ontrails/core';
+import { buildWorkspaceTrailIndex } from '@ontrails/topographer';
+import type {
+  WorkspaceTrailCollision,
+  WorkspaceTrailEntry,
+} from '@ontrails/topographer';
 import { z } from 'zod';
+
+import {
+  createIsolatedExampleRoot,
+  writeIsolatedExampleJsonFile,
+  writeIsolatedExampleTextFile,
+} from '../local-state-io.js';
 
 import { tryLoadFreshAppLease } from './load-app.js';
 import { resolveTrailRootDir } from './root-dir.js';
@@ -29,15 +63,215 @@ export const innerTrailResultSchema = z.object({
 
 export type InnerTrailResult = z.infer<typeof innerTrailResultSchema>;
 
+// ---------------------------------------------------------------------------
+// Resolution outcomes
+// ---------------------------------------------------------------------------
+
+type ResolveAppOutcome =
+  | { readonly kind: 'resolved'; readonly module: string }
+  | {
+      readonly kind: 'ambiguous';
+      readonly candidates: readonly string[];
+    }
+  | {
+      readonly kind: 'wrong-app';
+      readonly actualOwner: string;
+      readonly requestedApp: string;
+    }
+  | { readonly kind: 'not-found'; readonly requestedApp?: string | undefined };
+
+const collectCandidates = (
+  trailId: string,
+  index: Readonly<Record<string, WorkspaceTrailEntry>>,
+  collision: WorkspaceTrailCollision | undefined
+): readonly string[] => {
+  if (collision !== undefined) {
+    return collision.apps;
+  }
+  const sole = index[trailId];
+  return sole === undefined ? [] : [sole.appName];
+};
+
+const findOwner = (
+  trailId: string,
+  index: Readonly<Record<string, WorkspaceTrailEntry>>,
+  collision: WorkspaceTrailCollision | undefined,
+  appName: string
+): WorkspaceTrailEntry | undefined => {
+  const sole = index[trailId];
+  if (sole?.appName === appName) {
+    return sole;
+  }
+  return collision?.owners.find((owner) => owner.appName === appName);
+};
+
+const resolveOwningAppViaIndex = async (
+  workspaceRoot: string,
+  trailId: string,
+  appOverride: string | undefined
+): Promise<ResolveAppOutcome> => {
+  const result = await buildWorkspaceTrailIndex({ cwd: workspaceRoot });
+
+  const matchingCollision = result.collisions.find(
+    (entry) => entry.trailId === trailId
+  );
+
+  // Honor an explicit app override when provided.
+  if (appOverride !== undefined) {
+    const candidatesForId = collectCandidates(
+      trailId,
+      result.index,
+      matchingCollision
+    );
+    if (candidatesForId.length > 0 && !candidatesForId.includes(appOverride)) {
+      // Sole-owner mismatch: trail is owned uniquely by another app.
+      // Surface a wrong-app outcome so the user sees the actual owner,
+      // not an "ambiguous" message that doesn't apply.
+      if (candidatesForId.length === 1) {
+        const [actualOwner] = candidatesForId;
+        if (actualOwner !== undefined) {
+          return {
+            actualOwner,
+            kind: 'wrong-app',
+            requestedApp: appOverride,
+          };
+        }
+      }
+      return { candidates: candidatesForId, kind: 'ambiguous' };
+    }
+    const owner = findOwner(
+      trailId,
+      result.index,
+      matchingCollision,
+      appOverride
+    );
+    if (owner === undefined) {
+      return { kind: 'not-found', requestedApp: appOverride };
+    }
+    return { kind: 'resolved', module: owner.modulePath };
+  }
+
+  if (matchingCollision !== undefined) {
+    return {
+      candidates: matchingCollision.apps,
+      kind: 'ambiguous',
+    };
+  }
+
+  const owner = result.index[trailId];
+  if (owner === undefined) {
+    return { kind: 'not-found' };
+  }
+
+  return { kind: 'resolved', module: owner.modulePath };
+};
+
+const ambiguousMessage = (
+  trailId: string,
+  candidates: readonly string[]
+): string =>
+  `Trail ID '${trailId}' exists in apps: ${candidates.join(', ')}. Re-run with --app <name>.`;
+
 export const resolveRunModulePath = async (
-  _rootDir: string,
+  rootDir: string,
   module: string | undefined,
-  _trailId: string,
-  _app: string | undefined
-): Promise<Result<string | undefined, Error>> =>
-  // The first run-family branch preserves the existing single-app loader
-  // behavior. Workspace-index resolution is layered in by the --app branch.
-  Result.ok(module);
+  trailId: string,
+  app: string | undefined
+): Promise<Result<string, Error>> => {
+  if (module !== undefined) {
+    return Result.ok(module);
+  }
+
+  const outcome = await resolveOwningAppViaIndex(rootDir, trailId, app);
+  if (outcome.kind === 'resolved') {
+    return Result.ok(outcome.module);
+  }
+  if (outcome.kind === 'ambiguous') {
+    return Result.err(
+      new AmbiguousError(ambiguousMessage(trailId, outcome.candidates), {
+        context: { candidates: outcome.candidates, trailId },
+      })
+    );
+  }
+  if (outcome.kind === 'wrong-app') {
+    return Result.err(
+      new NotFoundError(
+        `Trail '${trailId}' is owned by '${outcome.actualOwner}', not '${outcome.requestedApp}'.`,
+        {
+          context: {
+            actualOwner: outcome.actualOwner,
+            requestedApp: outcome.requestedApp,
+            trailId,
+          },
+        }
+      )
+    );
+  }
+  const appContext =
+    outcome.requestedApp === undefined
+      ? ''
+      : ` for app '${outcome.requestedApp}'`;
+  return Result.err(
+    new NotFoundError(
+      `Trail '${trailId}' was not found${appContext} in any workspace app under ${rootDir}.`,
+      {
+        context: {
+          ...(outcome.requestedApp === undefined
+            ? {}
+            : { requestedApp: outcome.requestedApp }),
+          rootDir,
+          trailId,
+        },
+      }
+    )
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Ambiguous-example workspace fixture
+// ---------------------------------------------------------------------------
+
+const buildStubTopoSource = (appName: string): string =>
+  [
+    `const sharedIds = ['shared.id'];`,
+    `export const app = {`,
+    `  name: '${appName}',`,
+    `  ids: () => sharedIds,`,
+    `};`,
+    '',
+  ].join('\n');
+
+const writeAmbiguousWorkspaceFixture = (workspaceRoot: string): void => {
+  // Root package.json declaring two workspace apps.
+  writeIsolatedExampleJsonFile(workspaceRoot, 'package.json', {
+    name: 'run-ambiguous-fixture',
+    private: true,
+    type: 'module',
+    workspaces: ['apps/*'],
+  });
+
+  // Each app declares a Trails-app shape so discovery picks it up. The
+  // discovery layer only calls `topo.ids()` and reads `topo.name`, so a
+  // hand-rolled stub satisfies the `isTopo` shape without pulling in
+  // `@ontrails/core` from a temp directory that has no node_modules.
+  for (const appName of ['app-a', 'app-b'] as const) {
+    writeIsolatedExampleJsonFile(
+      workspaceRoot,
+      join('apps', appName, 'package.json'),
+      {
+        name: appName,
+        private: true,
+        trails: { module: 'src/app.ts' },
+        type: 'module',
+      }
+    );
+    writeIsolatedExampleTextFile(
+      workspaceRoot,
+      join('apps', appName, 'src/app.ts'),
+      buildStubTopoSource(appName)
+    );
+  }
+};
 
 // ---------------------------------------------------------------------------
 // Example input helpers
@@ -67,6 +301,18 @@ const buildNotFoundExampleInput = (): {
   id: 'does.not.exist',
 });
 
+const uniqueAmbiguousExampleName = (): string =>
+  `run-ambiguous-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+
+const buildAmbiguousExampleInput = (): {
+  readonly id: string;
+  readonly rootDir: string;
+} => {
+  const root = createIsolatedExampleRoot(uniqueAmbiguousExampleName());
+  writeAmbiguousWorkspaceFixture(root);
+  return { id: 'shared.id', rootDir: root };
+};
+
 // ---------------------------------------------------------------------------
 // Trail definition
 // ---------------------------------------------------------------------------
@@ -79,6 +325,8 @@ export const runTrail = trail('run', {
       return Result.err(rootDirResult.error);
     }
     const rootDir = rootDirResult.value;
+
+    // Single-app back-compat: if the caller provided `module`, trust it.
     const moduleResolution = await resolveRunModulePath(
       rootDir,
       input.module,
@@ -88,10 +336,9 @@ export const runTrail = trail('run', {
     if (moduleResolution.isErr()) {
       return Result.err(moduleResolution.error);
     }
-    const leaseResult = await tryLoadFreshAppLease(
-      moduleResolution.value,
-      rootDir
-    );
+    const modulePath = moduleResolution.value;
+
+    const leaseResult = await tryLoadFreshAppLease(modulePath, rootDir);
     if (leaseResult.isErr()) {
       return Result.err(leaseResult.error);
     }
@@ -126,9 +373,21 @@ export const runTrail = trail('run', {
       input: buildNotFoundExampleInput(),
       name: 'Reject unknown trail ID',
     },
+    {
+      description:
+        'Reject an ambiguous trail ID without --app with AmbiguousError so non-TTY callers see exit code 1',
+      error: 'AmbiguousError',
+      input: buildAmbiguousExampleInput(),
+      name: 'Reject ambiguous trail ID without --app',
+    },
   ],
   input: z.object({
-    app: z.string().optional().describe('Workspace app name override'),
+    app: z
+      .string()
+      .optional()
+      .describe(
+        'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
+      ),
     id: z.string().describe('Trail ID to invoke'),
     input: z
       .unknown()


### PR DESCRIPTION
## Summary
- Wires the workspace trail index into `trails run`.
- Adds schema-derived `--app <name>` support through the run trail's `app?: string` input.
- Adds CLI-only collision recovery for interactive terminals while keeping trail logic surface-agnostic.

## Details
Resolution now prefers an explicit app name, otherwise uses an unambiguous workspace owner, otherwise returns an `AmbiguousError` listing candidate apps. The CLI bridge detects that error on TTY stdin, prompts with clack, and reruns with the selected app. Non-TTY callers receive the structured error without prompt behavior leaking into trail code.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-406.