### PR TITLE
feat(cli,trails): unify structured input sources

### DIFF
--- a/.changeset/trl-399-stdin-input-file.md
+++ b/.changeset/trl-399-stdin-input-file.md
@@ -1,0 +1,11 @@
+---
+'@ontrails/cli': minor
+'@ontrails/trails': minor
+---
+
+Unify structured CLI input around `--input <path|->` and `--input-json`.
+`--input` reads JSON from a file path or from stdin when the value is `-`;
+`--input-file`, `--stdin`, and the `structuredInputFieldByTrail` routing
+option are removed. Structured payloads now merge directly into each trail's
+typed input object, so `trails run` callers provide the inner trail payload
+under the run trail's `input` field.

--- a/apps/trails/src/__tests__/run-input-sources.test.ts
+++ b/apps/trails/src/__tests__/run-input-sources.test.ts
@@ -1,0 +1,239 @@
+/**
+ * End-to-end coverage for `trails run` structured input.
+ *
+ * Structured input merges into the `run` trail's typed input object. The
+ * inner trail payload therefore lives under the `input` field in the supplied
+ * JSON object, without any per-trail CLI routing table.
+ *
+ * The inner `run()` invocation then fails (the workspace fixture has no
+ * matching trail), but that is by design — what matters here is that
+ * structured-input payloads were routed to `input.input` before execution.
+ */
+/* oxlint-disable-next-line eslint-plugin-jest/no-conditional-expect -- Result-shape assertions branch on isOk/isErr */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { deriveCliCommands } from '@ontrails/cli';
+import type { ActionResultContext, CliCommand } from '@ontrails/cli';
+
+import { app } from '../app.js';
+
+const findRunCommand = (
+  commands: readonly CliCommand[]
+): CliCommand | undefined => commands.find((c) => c.path[0] === 'run');
+
+interface CapturedInvocation {
+  input?: unknown;
+  trailId?: string | undefined;
+}
+
+const buildRunCommand = (capture?: CapturedInvocation): CliCommand => {
+  const onResult =
+    capture === undefined
+      ? undefined
+      : (ctx: ActionResultContext): Promise<void> => {
+          capture.input = ctx.input;
+          capture.trailId = ctx.trail.id;
+          return Promise.resolve();
+        };
+
+  const result = deriveCliCommands(app, {
+    onResult,
+  });
+  if (result.isErr()) {
+    throw result.error;
+  }
+  const cmd = findRunCommand(result.value);
+  if (!cmd) {
+    throw new Error('Expected run command in derived CLI commands');
+  }
+  return cmd;
+};
+
+const isInputRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+let workspaceRoot: string;
+
+beforeEach(() => {
+  workspaceRoot = join(
+    tmpdir(),
+    `run-input-sources-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(workspaceRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { force: true, recursive: true });
+});
+
+describe('trails run structured-input routing', () => {
+  test('exposes id and inline JSON as run command positional arguments', () => {
+    const cmd = buildRunCommand();
+    expect(cmd.args.map((a) => a.name)).toEqual(['id', 'inline-json']);
+  });
+
+  test('merges --input-json into the run trail input', async () => {
+    const captured: CapturedInvocation = {};
+    const cmd = buildRunCommand(captured);
+
+    await cmd.execute(
+      { id: 'never.exists' },
+      {
+        inputJson: '{"input":{"name":"Alpha"}}',
+        rootDir: workspaceRoot,
+      }
+    );
+
+    expect(captured.trailId).toBe('run');
+    expect(isInputRecord(captured.input)).toBe(true);
+    if (isInputRecord(captured.input)) {
+      expect(captured.input['id']).toBe('never.exists');
+      expect(captured.input['input']).toEqual({ name: 'Alpha' });
+    }
+  });
+
+  test('merges positional inline JSON into the run trail input', async () => {
+    const captured: CapturedInvocation = {};
+    const cmd = buildRunCommand(captured);
+
+    await cmd.execute(
+      {
+        id: 'never.exists',
+        'inline-json': '{"input":{"name":"Echo"}}',
+      },
+      {
+        rootDir: workspaceRoot,
+      }
+    );
+
+    expect(captured.trailId).toBe('run');
+    expect(isInputRecord(captured.input)).toBe(true);
+    if (isInputRecord(captured.input)) {
+      expect(captured.input['id']).toBe('never.exists');
+      expect(captured.input['input']).toEqual({ name: 'Echo' });
+    }
+  });
+
+  test('rejects when positional inline JSON conflicts with --input-json', async () => {
+    const cmd = buildRunCommand();
+
+    const result = await cmd.execute(
+      {
+        id: 'never.exists',
+        'inline-json': '{"input":{"name":"Echo"}}',
+      },
+      {
+        inputJson: '{"input":{"name":"Foxtrot"}}',
+        rootDir: workspaceRoot,
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        'Use only one structured input source at a time'
+      );
+    }
+  });
+
+  test('merges --input file payloads into the run trail input', async () => {
+    const captured: CapturedInvocation = {};
+    const cmd = buildRunCommand(captured);
+
+    const inputPath = join(workspaceRoot, 'payload.json');
+    writeFileSync(inputPath, '{"input":{"name":"Bravo"}}');
+
+    await cmd.execute(
+      { id: 'never.exists' },
+      {
+        input: inputPath,
+        rootDir: workspaceRoot,
+      }
+    );
+
+    expect(isInputRecord(captured.input)).toBe(true);
+    if (isInputRecord(captured.input)) {
+      expect(captured.input['input']).toEqual({ name: 'Bravo' });
+    }
+  });
+
+  test('rejects when --input and --input-json are both provided', async () => {
+    const cmd = buildRunCommand();
+
+    const result = await cmd.execute(
+      { id: 'never.exists' },
+      {
+        input: join(workspaceRoot, 'payload.json'),
+        inputJson: '{"name":"Y"}',
+        rootDir: workspaceRoot,
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        'Use only one structured input source at a time'
+      );
+    }
+  });
+
+  test('merges --input - payloads into the run trail input', async () => {
+    const captured: CapturedInvocation = {};
+    const cmd = buildRunCommand(captured);
+
+    interface StdinSubset {
+      isTTY: boolean | undefined;
+      [Symbol.asyncIterator]: () => AsyncIterableIterator<Buffer>;
+    }
+    const originalStdin = process.stdin;
+    const fakeStdin: StdinSubset = {
+      isTTY: false,
+      [Symbol.asyncIterator]: () => {
+        let yielded = false;
+        const iterator: AsyncIterableIterator<Buffer> = {
+          next: () => {
+            if (yielded) {
+              return Promise.resolve({ done: true, value: undefined });
+            }
+            yielded = true;
+            return Promise.resolve({
+              done: false,
+              value: Buffer.from('{"input":{"name":"Delta"}}', 'utf8'),
+            });
+          },
+          [Symbol.asyncIterator]() {
+            return iterator;
+          },
+        };
+        return iterator;
+      },
+    };
+    Object.defineProperty(process, 'stdin', {
+      configurable: true,
+      value: fakeStdin,
+    });
+
+    try {
+      await cmd.execute(
+        { id: 'never.exists' },
+        {
+          input: '-',
+          rootDir: workspaceRoot,
+        }
+      );
+    } finally {
+      Object.defineProperty(process, 'stdin', {
+        configurable: true,
+        value: originalStdin,
+      });
+    }
+
+    expect(isInputRecord(captured.input)).toBe(true);
+    if (isInputRecord(captured.input)) {
+      expect(captured.input['input']).toEqual({ name: 'Delta' });
+    }
+  });
+});

--- a/docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md
+++ b/docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md
@@ -82,12 +82,11 @@ Positional fields keep their flag alias. `myapp file copy source.txt dest.txt` a
 The CLI exposes structured-input channels for input shapes that cannot be faithfully represented as flags:
 
 - `--input-json <json>` — inline JSON payload
-- `--input-file <path>` — file path to JSON
-- `--stdin` — read JSON from stdin
+- `--input <path|->` — file path to JSON, or `-` to read JSON from stdin
 
 ```bash
 myapp gist create --input-json '{"files":[{"filename":"hello.ts","content":"export {}"}]}'
-cat payload.json | myapp gist create --stdin
+cat payload.json | myapp gist create --input -
 ```
 
 If a field cannot be represented faithfully as a derived flag, the framework does not invent a misleading one. Arrays of objects do not become fake variadic string flags. Nested objects do not become ad hoc flattened flags. The rule is simple: derive flags only when the projection is truthful.

--- a/docs/adr/drafts/20260331-direct-invocation.md
+++ b/docs/adr/drafts/20260331-direct-invocation.md
@@ -381,7 +381,7 @@ Trails produce JSON. Unix pipes compose JSON. `trails run` naturally chains:
 
 ```bash
 # Run one trail, feed its output to another
-trails run entity.show '{"name": "Alpha"}' --quiet | trails run entity.update --stdin
+trails run entity.show --input-json '{"input":{"name":"Alpha"}}' --quiet | trails run entity.update --input -
 
 # Extract a field with jq, feed to next trail
 trails run entity.list '{"limit": 5}' --quiet | jq '.[0].id' | xargs -I {} trails run entity.show '{"id": "{}"}'

--- a/docs/releases/beta14.md
+++ b/docs/releases/beta14.md
@@ -28,11 +28,10 @@ Trail IDs now derive nested command trees. `entity.create` becomes `trails entit
 
 ### Structured CLI input
 
-Three new channels for passing complex input to CLI trails:
+Two new channels for passing complex input to CLI trails:
 
 - `--input-json '<json>'` — inline JSON
-- `--input-file <path>` — read from file
-- `--stdin` — pipe from stdin
+- `--input <path|->` — read from file, or pipe from stdin with `-`
 
 Channels merge with individual flags in a deterministic priority order.
 

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -129,11 +129,10 @@ trail('config.set', {
 
 ## Structured Input
 
-Every non-empty object input schema also gets three structured input channels:
+Every non-empty object input schema also gets two structured input channels:
 
 - `--input-json <json>` to pass the full input object inline
-- `--input-file <path>` to load the full input object from a JSON file
-- `--stdin` to read the full input object as JSON from stdin
+- `--input <path|->` to load the full input object from a JSON file or stdin
 
 These channels merge into one final input object before validation:
 
@@ -151,7 +150,7 @@ myapp gist create \
 ```
 
 ```bash
-cat payload.json | myapp gist create --stdin
+cat payload.json | myapp gist create --input -
 ```
 
 When a schema includes fields that cannot be expressed truthfully as flags, the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -151,8 +151,7 @@ for programmatic access.
 For every non-empty object input schema, the CLI also exposes:
 
 - `--input-json <json>`
-- `--input-file <path>`
-- `--stdin`
+- `--input <path|->`
 
 These channels supply the full input object before positional args and explicit
 flags are merged on top. Explicit CLI inputs always win on conflict, and the

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -442,7 +442,7 @@ describe('buildCommands execution', () => {
 
     expect(result?.isErr()).toBe(true);
     expect(result?.error.message).toContain(
-      'Use --input-json, --input-file, or --stdin for full structured input.'
+      'Use --input <path|-> or --input-json for full structured input.'
     );
   });
 
@@ -813,5 +813,168 @@ describe('buildCommands established graph enforcement', () => {
     });
 
     expect(() => buildCommands(makeApp(draftTrail))).toThrowError(/draft/i);
+  });
+});
+
+const captureInput =
+  (captured: {
+    input?: unknown;
+  }): ((ctx: ActionResultContext) => Promise<void>) =>
+  (ctx) => {
+    captured.input = ctx.input;
+    return Promise.resolve();
+  };
+
+describe('buildCommands structured input', () => {
+  test('merges --input file payloads at the top level', async () => {
+    const t = trail('search', {
+      blaze: (input: { query: string }) => Result.ok({ received: input }),
+      input: z.object({ query: z.string() }),
+    });
+    const captured: { input?: unknown } = {};
+    const cmd = requireCommand(
+      buildCommands(makeApp(t), { onResult: captureInput(captured) })
+    );
+    const tmpPath = `${process.env['TMPDIR'] ?? '/tmp'}/structured-input-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}.json`;
+    await Bun.write(tmpPath, '{"query":"from file"}');
+
+    try {
+      const result = await cmd.execute({}, { input: tmpPath });
+      expect(result.isOk()).toBe(true);
+      expect(captured.input).toEqual({ query: 'from file' });
+    } finally {
+      await Bun.file(tmpPath).delete();
+    }
+  });
+
+  test('keeps --input reserved for file payloads when the schema has an input field', async () => {
+    const t = trail('echo-input', {
+      blaze: (input: { input: string }) => Result.ok({ received: input }),
+      input: z.object({ input: z.string() }),
+    });
+    const captured: { input?: unknown } = {};
+    const cmd = requireCommand(
+      buildCommands(makeApp(t), { onResult: captureInput(captured) })
+    );
+    const tmpPath = `${process.env['TMPDIR'] ?? '/tmp'}/structured-input-collision-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}.json`;
+    await Bun.write(tmpPath, '{"input":"from file"}');
+
+    try {
+      const result = await cmd.execute({}, { input: tmpPath });
+      expect(result.isOk()).toBe(true);
+      expect(captured.input).toEqual({ input: 'from file' });
+    } finally {
+      await Bun.file(tmpPath).delete();
+    }
+  });
+
+  test('rejects when --input and --input-json are both provided', async () => {
+    const t = trail('search', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ query: z.string() }),
+    });
+    const cmd = requireCommand(buildCommands(makeApp(t)));
+
+    const result = await cmd.execute(
+      {},
+      { input: '/tmp/in.json', inputJson: '{"query":"from json"}' }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        'Use only one structured input source at a time'
+      );
+    }
+  });
+
+  test('merges positional inline JSON for structured-only fields', async () => {
+    const t = trail('gist.create', {
+      blaze: (input: {
+        files: readonly {
+          readonly content: string;
+          readonly filename: string;
+        }[];
+      }) => Result.ok({ received: input }),
+      input: z.object({
+        files: z.array(
+          z.object({
+            content: z.string(),
+            filename: z.string(),
+          })
+        ),
+      }),
+    });
+    const captured: { input?: unknown } = {};
+    const cmd = requireCommand(
+      buildCommands(makeApp(t), { onResult: captureInput(captured) })
+    );
+
+    expect(cmd.args.map((arg) => arg.name)).toEqual(['inline-json']);
+
+    const result = await cmd.execute(
+      {
+        'inline-json': '{"files":[{"filename":"README.md","content":"Hello"}]}',
+      },
+      {}
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(captured.input).toEqual({
+      files: [{ content: 'Hello', filename: 'README.md' }],
+    });
+  });
+
+  test('rejects when positional inline JSON conflicts with structured flags', async () => {
+    const t = trail('gist.create', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({
+        files: z.array(
+          z.object({
+            content: z.string(),
+            filename: z.string(),
+          })
+        ),
+      }),
+    });
+    const cmd = requireCommand(buildCommands(makeApp(t)));
+
+    const result = await cmd.execute(
+      {
+        'inline-json': '{"files":[{"filename":"README.md","content":"Hello"}]}',
+      },
+      {
+        inputJson: '{"files":[{"filename":"README.md","content":"Hello"}]}',
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        'Use only one structured input source at a time: --input, --input-json, or the positional inline-JSON argument'
+      );
+    }
+  });
+
+  test('rejects missing structured flag values before schema validation', async () => {
+    const t = trail('search', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ query: z.string() }),
+    });
+    const cmd = requireCommand(buildCommands(makeApp(t)));
+
+    const inputResult = await cmd.execute({}, { input: true });
+    expect(inputResult.isErr()).toBe(true);
+    if (inputResult.isErr()) {
+      expect(inputResult.error.message).toContain('--input requires a value');
+    }
+
+    const inputJsonResult = await cmd.execute({}, { inputJson: true });
+    expect(inputJsonResult.isErr()).toBe(true);
+    if (inputJsonResult.isErr()) {
+      expect(inputJsonResult.error.message).toContain(
+        '--input-json requires a value'
+      );
+    }
   });
 });

--- a/packages/cli/src/__tests__/structured-input.test.ts
+++ b/packages/cli/src/__tests__/structured-input.test.ts
@@ -6,7 +6,9 @@ import { z } from 'zod';
 import {
   hasStructuredOnlyFields,
   normalizeParsedFlags,
+  parsePositionalInlineJson,
   readStructuredInput,
+  resolveStructuredInput,
   structuredInputPreset,
   supportsStructuredInput,
 } from '../structured-input.js';
@@ -15,20 +17,24 @@ describe('structured input helpers', () => {
   test('normalizeParsedFlags converts kebab-case names to camelCase', () => {
     expect(
       normalizeParsedFlags({
-        'input-file': '/tmp/input.json',
+        input: '/tmp/input.json',
         'sort-order': 'asc',
       })
     ).toEqual({
-      inputFile: '/tmp/input.json',
+      input: '/tmp/input.json',
       sortOrder: 'asc',
     });
   });
 
-  test('structuredInputPreset exposes JSON, file, and stdin channels', () => {
-    expect(structuredInputPreset().map((flag) => flag.name)).toEqual([
-      'input-json',
-      'input-file',
-      'stdin',
+  test('structuredInputPreset exposes path/stdin and inline JSON channels', () => {
+    expect(
+      structuredInputPreset().map((flag) => ({
+        name: flag.name,
+        required: flag.required,
+      }))
+    ).toEqual([
+      { name: 'input', required: true },
+      { name: 'input-json', required: true },
     ]);
   });
 
@@ -69,11 +75,11 @@ describe('readStructuredInput', () => {
   test('rejects multiple structured sources at once', async () => {
     await expect(
       readStructuredInput({
+        input: '/tmp/input.json',
         inputJson: '{"query":"hello"}',
-        stdin: true,
       })
     ).rejects.toThrow(
-      'Use only one structured input source at a time: --input-json, --input-file, or --stdin'
+      'Use only one structured input source at a time: --input or --input-json'
     );
   });
 
@@ -96,6 +102,15 @@ describe('readStructuredInput', () => {
     ).rejects.toThrow('Invalid JSON for --input-json');
   });
 
+  test('rejects missing values for structured flags', async () => {
+    await expect(readStructuredInput({ input: true })).rejects.toThrow(
+      '--input requires a value'
+    );
+    await expect(readStructuredInput({ inputJson: true })).rejects.toThrow(
+      '--input-json requires a value'
+    );
+  });
+
   test('rejects non-object JSON payloads', async () => {
     await expect(
       readStructuredInput({
@@ -106,11 +121,11 @@ describe('readStructuredInput', () => {
     );
   });
 
-  test('parses --input-file payloads via the injected file reader', async () => {
+  test('parses --input file payloads via the injected file reader', async () => {
     await expect(
       readStructuredInput(
         {
-          inputFile: '/tmp/input.json',
+          input: '/tmp/input.json',
         },
         {
           readFileText: (path) => {
@@ -122,11 +137,11 @@ describe('readStructuredInput', () => {
     ).resolves.toEqual({ query: 'from file' });
   });
 
-  test('parses --stdin payloads via the injected stdin reader', async () => {
+  test('parses --input - payloads via the injected stdin reader', async () => {
     await expect(
       readStructuredInput(
         {
-          stdin: true,
+          input: '-',
         },
         {
           readStdinText: () => Promise.resolve('{"query":"from stdin"}'),
@@ -139,14 +154,104 @@ describe('readStructuredInput', () => {
     await expect(
       readStructuredInput(
         {
-          stdin: true,
+          input: '-',
         },
         {
           readStdinText: () => Promise.resolve('   '),
         }
       )
     ).rejects.toThrow(
-      '--stdin was provided but no JSON payload was read from stdin'
+      '--input - was provided but no JSON payload was read from stdin'
+    );
+  });
+});
+
+describe('parsePositionalInlineJson', () => {
+  test('returns undefined when the value is not a string', () => {
+    expect(parsePositionalInlineJson()).toBeUndefined();
+    expect(parsePositionalInlineJson(123)).toBeUndefined();
+    expect(parsePositionalInlineJson({})).toBeUndefined();
+  });
+
+  test('returns undefined for an empty string', () => {
+    expect(parsePositionalInlineJson('')).toBeUndefined();
+  });
+
+  test('parses a JSON object string into an object', () => {
+    expect(parsePositionalInlineJson('{"name":"Alpha","limit":3}')).toEqual({
+      limit: 3,
+      name: 'Alpha',
+    });
+  });
+
+  test('rejects invalid JSON with a parse error', () => {
+    expect(() => parsePositionalInlineJson('{bad json}')).toThrow(
+      'Invalid JSON for <inline-json>'
+    );
+  });
+
+  test('rejects non-object JSON payloads', () => {
+    expect(() => parsePositionalInlineJson('[1,2,3]')).toThrow(
+      '<inline-json> must provide a JSON object at the top level'
+    );
+  });
+});
+
+describe('resolveStructuredInput', () => {
+  test('returns no payload when neither flags nor positional are provided', async () => {
+    const result = await resolveStructuredInput({});
+    expect(result.payload).toBeUndefined();
+    expect(result.used).toBe(false);
+  });
+
+  test('parses the positional inline JSON when no flags are provided', async () => {
+    const result = await resolveStructuredInput({}, '{"name":"Alpha"}');
+    expect(result.payload).toEqual({ name: 'Alpha' });
+    expect(result.used).toBe(true);
+  });
+
+  test('reads --input-json when no positional is provided', async () => {
+    const result = await resolveStructuredInput({ inputJson: '{"k":1}' });
+    expect(result.payload).toEqual({ k: 1 });
+    expect(result.used).toBe(true);
+  });
+
+  test('reads --input file via injected reader', async () => {
+    const result = await resolveStructuredInput(
+      { input: '/tmp/in.json' },
+      undefined,
+      {
+        readFileText: (path) => {
+          expect(path).toBe('/tmp/in.json');
+          return Promise.resolve('{"from":"file"}');
+        },
+      }
+    );
+    expect(result.payload).toEqual({ from: 'file' });
+    expect(result.used).toBe(true);
+  });
+
+  test('reads --input - via injected reader', async () => {
+    const result = await resolveStructuredInput({ input: '-' }, undefined, {
+      readStdinText: () => Promise.resolve('{"from":"stdin"}'),
+    });
+    expect(result.payload).toEqual({ from: 'stdin' });
+    expect(result.used).toBe(true);
+  });
+
+  test('rejects when both --input-json and positional are provided', async () => {
+    await expect(
+      resolveStructuredInput({ inputJson: '{"a":1}' }, '{"b":2}')
+    ).rejects.toThrow(
+      'Use only one structured input source at a time: --input, --input-json, or the positional inline-JSON argument'
+    );
+  });
+
+  test('rejects when both --input and positional are provided', async () => {
+    await expect(
+      resolveStructuredInput({ input: '/tmp/in.json' }, '{"b":2}')
+    ).rejects.toThrow(
+      'Use only one structured input source at a time: --input, --input-json, or the positional inline-JSON argument'
     );
   });
 });

--- a/packages/cli/src/__tests__/to-commander.test.ts
+++ b/packages/cli/src/__tests__/to-commander.test.ts
@@ -765,9 +765,7 @@ describe('toCommander option wiring', () => {
     const opts = requireNestedCommand(program, ['gist', 'create']).options;
     const longs = opts.map((option) => option.long);
 
-    expect(longs).toEqual(
-      expect.arrayContaining(['--input-file', '--input-json', '--stdin'])
-    );
+    expect(longs).toEqual(expect.arrayContaining(['--input', '--input-json']));
     expect(longs).not.toContain('--files');
   });
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -30,7 +30,7 @@ import {
   hasStructuredOnlyFields,
   kebabToCamel,
   normalizeParsedFlags,
-  readStructuredInput,
+  resolveStructuredInput,
   structuredInputPreset,
   supportsStructuredInput,
 } from './structured-input.js';
@@ -81,6 +81,15 @@ const mergeFlags = (presets: CliFlag[], derived: CliFlag[]): CliFlag[] => {
   return merged;
 };
 
+const RESERVED_STRUCTURED_INPUT_META_FLAGS = new Set(['input']);
+
+const mergeStructuredInputFlags = (derived: CliFlag[]): CliFlag[] => {
+  const filteredDerived = derived.filter(
+    (flag) => !RESERVED_STRUCTURED_INPUT_META_FLAGS.has(kebabToCamel(flag.name))
+  );
+  return mergeFlags(structuredInputPreset(), filteredDerived);
+};
+
 const validateCliCommandBuild = (
   graph: Topo,
   options?: DeriveCliCommandsOptions
@@ -98,13 +107,21 @@ const validateCliCommandBuild = (
  * layer composition, and onResult handling.
  */
 const META_FLAG_CANDIDATES = new Set([
-  'inputFile',
+  'input',
   'inputJson',
   'json',
   'jsonl',
   'output',
-  'stdin',
 ]);
+
+const STRUCTURED_INLINE_JSON_ARG_NAME = 'inline-json';
+
+const STRUCTURED_INLINE_JSON_ARG: CliArg = {
+  description: 'Inline JSON object to merge before explicit flags',
+  name: STRUCTURED_INLINE_JSON_ARG_NAME,
+  required: false,
+  variadic: false,
+};
 
 /** Merge parsed args and flags into a camelCase input record. */
 const mergeArgsAndFlags = (
@@ -114,11 +131,12 @@ const mergeArgsAndFlags = (
   parsedFlags: Record<string, unknown>
 ): Record<string, unknown> => {
   const mergedInput: Record<string, unknown> = { ...structuredInput };
-  // Only merge defined positional args — undefined means the user omitted it
+  // Only merge defined positional args — undefined means the user omitted it.
   for (const [key, value] of Object.entries(parsedArgs)) {
-    if (value !== undefined) {
-      mergedInput[key] = value;
+    if (value === undefined) {
+      continue;
     }
+    mergedInput[key] = value;
   }
   for (const [key, value] of Object.entries(parsedFlags)) {
     if (!metaFlagNames.has(key) && value !== undefined) {
@@ -163,12 +181,18 @@ const selectStructuredInputFlags = (
     Object.entries(normalizedFlags).filter(([key]) => metaFlagNames.has(key))
   );
 
-const usesStructuredInput = (
-  structuredInputFlags: Record<string, unknown>
-): boolean =>
-  structuredInputFlags['inputJson'] !== undefined ||
-  structuredInputFlags['inputFile'] !== undefined ||
-  structuredInputFlags['stdin'] === true;
+const splitStructuredInlineJsonArg = (
+  parsedArgs: Record<string, unknown>
+): {
+  readonly positionalInlineJson: unknown;
+  readonly trailArgs: Record<string, unknown>;
+} => {
+  const {
+    [STRUCTURED_INLINE_JSON_ARG_NAME]: positionalInlineJson,
+    ...trailArgs
+  } = parsedArgs;
+  return { positionalInlineJson, trailArgs };
+};
 
 const resolveMergedInput = async (
   fields: readonly Field[],
@@ -185,17 +209,23 @@ const resolveMergedInput = async (
     normalizedFlags,
     metaFlagNames
   );
-  const structuredInput = await readStructuredInput(structuredInputFlags);
+  const { positionalInlineJson, trailArgs } =
+    splitStructuredInlineJsonArg(parsedArgs);
+
+  const structuredInput = await resolveStructuredInput(
+    structuredInputFlags,
+    positionalInlineJson
+  );
   const mergedInput = mergeArgsAndFlags(
     metaFlagNames,
-    structuredInput,
-    parsedArgs,
+    structuredInput.payload ?? {},
+    trailArgs,
     normalizedFlags
   );
   await applyPrompting(fields, mergedInput, options);
   return {
     mergedInput,
-    usedStructuredInput: usesStructuredInput(structuredInputFlags),
+    usedStructuredInput: structuredInput.used,
   };
 };
 
@@ -328,7 +358,7 @@ const buildFlags = (
 ): CliFlag[] => {
   let flags = toFlags(fields);
   if (supportsStructuredInput(t.input)) {
-    flags = mergeFlags(structuredInputPreset(), flags);
+    flags = mergeStructuredInputFlags(flags);
   }
   if (options?.presets) {
     flags = mergeFlags(options.presets.flat(), flags);
@@ -389,11 +419,18 @@ const derivePositionalArgs = (
     (f) => f.type === 'string' && f.required && f.default === undefined
   );
   if (candidates.length === 1 && candidates[0]) {
-    return { args: [fieldToArg(candidates[0])] };
+    return {
+      args: [fieldToArg(candidates[0])],
+    };
   }
 
   return { args: [] };
 };
+
+const addStructuredInlineJsonArg = (
+  args: readonly CliArg[],
+  shouldAdd: boolean
+): CliArg[] => (shouldAdd ? [...args, STRUCTURED_INLINE_JSON_ARG] : [...args]);
 
 /** Convert a trail or route into a CLI command when it is publicly exposed. */
 const toCliCommand = (
@@ -402,11 +439,15 @@ const toCliCommand = (
   options?: DeriveCliCommandsOptions
 ): CliCommand => {
   const fields = deriveFields(t.input, t.fields);
-  const { args } = derivePositionalArgs(t, fields);
   // All fields generate flags — positional fields keep their --flag alias
   const flags = buildFlags(t, fields, t.intent, options);
+  const structuredInputReservedNames = supportsStructuredInput(t.input)
+    ? RESERVED_STRUCTURED_INPUT_META_FLAGS
+    : new Set<string>();
   const derivedFlagNames = new Set(
-    toFlags(fields).map((flag) => kebabToCamel(flag.name))
+    toFlags(fields)
+      .map((flag) => kebabToCamel(flag.name))
+      .filter((name) => !structuredInputReservedNames.has(name))
   );
   const metaFlagNames = new Set(
     flags
@@ -418,6 +459,11 @@ const toCliCommand = (
   const shouldHintStructuredInput = hasStructuredOnlyFields(
     t.input,
     fields.length
+  );
+  const { args: derivedArgs } = derivePositionalArgs(t, fields);
+  const args = addStructuredInlineJsonArg(
+    derivedArgs,
+    shouldHintStructuredInput
   );
 
   return {

--- a/packages/cli/src/structured-input.ts
+++ b/packages/cli/src/structured-input.ts
@@ -10,6 +10,13 @@ import type { z } from 'zod';
 
 import type { CliFlag } from './command.js';
 
+/**
+ * Label used in error messages when the inline-JSON positional argument is
+ * involved. Kept here so the structured-input source taxonomy stays in one
+ * place.
+ */
+export const POSITIONAL_INLINE_JSON_LABEL = '<inline-json>';
+
 interface ZodInternals {
   readonly _zod: {
     readonly def: Readonly<Record<string, unknown>>;
@@ -17,31 +24,23 @@ interface ZodInternals {
 }
 
 export const STRUCTURED_INPUT_HINT =
-  'Use --input-json, --input-file, or --stdin for full structured input.';
+  'Use --input <path|-> or --input-json for full structured input.';
 
 export const structuredInputPreset = (): CliFlag[] => [
+  {
+    description:
+      'Path to a JSON file (or `-` for stdin) to merge before explicit positional args and flags',
+    name: 'input',
+    required: true,
+    type: 'string',
+    variadic: false,
+  },
   {
     description:
       'JSON object to merge before explicit positional args and flags',
     name: 'input-json',
     required: true,
     type: 'string',
-    variadic: false,
-  },
-  {
-    description:
-      'Path to a JSON file to merge before explicit positional args and flags',
-    name: 'input-file',
-    required: true,
-    type: 'string',
-    variadic: false,
-  },
-  {
-    description:
-      'Read a JSON object from stdin before explicit positional args and flags',
-    name: 'stdin',
-    required: false,
-    type: 'boolean',
     variadic: false,
   },
 ];
@@ -89,23 +88,41 @@ interface StructuredInputReaders {
 }
 
 type StructuredSource =
+  | { readonly kind: 'input'; readonly value: string }
   | { readonly kind: 'input-json'; readonly value: string }
-  | { readonly kind: 'input-file'; readonly value: string }
-  | { readonly kind: 'stdin' };
+  | { readonly kind: 'positional'; readonly value: Record<string, unknown> };
+
+const resolveOptionalStringFlag = (
+  flags: Record<string, unknown>,
+  key: 'input' | 'inputJson',
+  label: '--input' | '--input-json'
+): string | undefined => {
+  const value = flags[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new ValidationError(`${label} requires a value`);
+  }
+  return value;
+};
 
 const resolveStructuredSources = (
   flags: Record<string, unknown>
 ): StructuredSource[] => {
   const sources: StructuredSource[] = [];
+  const input = resolveOptionalStringFlag(flags, 'input', '--input');
+  const inputJson = resolveOptionalStringFlag(
+    flags,
+    'inputJson',
+    '--input-json'
+  );
 
-  if (typeof flags['inputJson'] === 'string') {
-    sources.push({ kind: 'input-json', value: flags['inputJson'] });
+  if (input !== undefined) {
+    sources.push({ kind: 'input', value: input });
   }
-  if (typeof flags['inputFile'] === 'string') {
-    sources.push({ kind: 'input-file', value: flags['inputFile'] });
-  }
-  if (flags['stdin'] === true) {
-    sources.push({ kind: 'stdin' });
+  if (inputJson !== undefined) {
+    sources.push({ kind: 'input-json', value: inputJson });
   }
 
   return sources;
@@ -113,7 +130,7 @@ const resolveStructuredSources = (
 
 const parseStructuredObject = (
   raw: string,
-  sourceLabel: '--input-json' | '--input-file' | '--stdin'
+  sourceLabel: '--input-json' | '--input'
 ): Record<string, unknown> => {
   let parsed: unknown;
   try {
@@ -135,7 +152,7 @@ const parseStructuredObject = (
 const readStdinText = async (): Promise<string> => {
   if (process.stdin.isTTY ?? false) {
     throw new ValidationError(
-      '--stdin was provided but no piped input is available on stdin'
+      '--input - was provided but no piped input is available on stdin'
     );
   }
 
@@ -147,16 +164,6 @@ const readStdinText = async (): Promise<string> => {
   return Buffer.concat(chunks).toString('utf8');
 };
 
-const readStructuredFile = async (
-  path: string,
-  readers?: StructuredInputReaders
-): Promise<Record<string, unknown>> => {
-  const read =
-    readers?.readFileText ?? ((filePath: string) => Bun.file(filePath).text());
-  const contents = await read(path);
-  return parseStructuredObject(contents, '--input-file');
-};
-
 const readStructuredStdin = async (
   readers?: StructuredInputReaders
 ): Promise<Record<string, unknown>> => {
@@ -164,10 +171,23 @@ const readStructuredStdin = async (
   const contents = await read();
   if (contents.trim().length === 0) {
     throw new ValidationError(
-      '--stdin was provided but no JSON payload was read from stdin'
+      '--input - was provided but no JSON payload was read from stdin'
     );
   }
-  return parseStructuredObject(contents, '--stdin');
+  return parseStructuredObject(contents, '--input');
+};
+
+const readStructuredPath = async (
+  path: string,
+  readers?: StructuredInputReaders
+): Promise<Record<string, unknown>> => {
+  if (path === '-') {
+    return await readStructuredStdin(readers);
+  }
+  const read =
+    readers?.readFileText ?? ((filePath: string) => Bun.file(filePath).text());
+  const contents = await read(path);
+  return parseStructuredObject(contents, '--input');
 };
 
 const readStructuredSource = async (
@@ -175,14 +195,14 @@ const readStructuredSource = async (
   readers?: StructuredInputReaders
 ): Promise<Record<string, unknown>> => {
   switch (source.kind) {
+    case 'input': {
+      return await readStructuredPath(source.value, readers);
+    }
     case 'input-json': {
       return parseStructuredObject(source.value, '--input-json');
     }
-    case 'input-file': {
-      return await readStructuredFile(source.value, readers);
-    }
-    case 'stdin': {
-      return await readStructuredStdin(readers);
+    case 'positional': {
+      return source.value;
     }
     default: {
       throw new ValidationError('Unsupported structured input source');
@@ -209,7 +229,7 @@ export const readStructuredInput = async (
 
   if (sources.length > 1) {
     throw new ValidationError(
-      'Use only one structured input source at a time: --input-json, --input-file, or --stdin'
+      'Use only one structured input source at a time: --input or --input-json'
     );
   }
 
@@ -218,4 +238,82 @@ export const readStructuredInput = async (
     return {};
   }
   return await readStructuredSource(source, readers);
+};
+
+/**
+ * Parse a positional inline-JSON argument as a top-level JSON object.
+ *
+ * Returns `undefined` when the value is not a non-empty string, so callers can
+ * branch cleanly on "no positional given".
+ */
+export const parsePositionalInlineJson = (
+  value?: unknown
+): Record<string, unknown> | undefined => {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ValidationError(
+      `Invalid JSON for ${POSITIONAL_INLINE_JSON_LABEL}: ${message}`
+    );
+  }
+  if (!isPlainObject(parsed)) {
+    throw new ValidationError(
+      `${POSITIONAL_INLINE_JSON_LABEL} must provide a JSON object at the top level`
+    );
+  }
+  return parsed;
+};
+
+/**
+ * Resolve a routed structured-input payload from flags or a positional
+ * inline-JSON argument.
+ *
+ * Returns the parsed object plus a flag indicating whether any structured
+ * source contributed (used to suppress the structured-input hint when the
+ * caller already used one). Throws when more than one source was provided so
+ * conflicts surface early at the surface boundary.
+ */
+export interface ResolvedStructuredInput {
+  readonly payload: Record<string, unknown> | undefined;
+  readonly used: boolean;
+}
+
+export const resolveStructuredInput = async (
+  parsedFlags: Record<string, unknown>,
+  positionalValue?: unknown,
+  readers?: StructuredInputReaders
+): Promise<ResolvedStructuredInput> => {
+  const flags = normalizeParsedFlags(parsedFlags);
+  const sources = resolveStructuredSources(flags);
+  const positional = parsePositionalInlineJson(positionalValue);
+
+  const totalSources = sources.length + (positional === undefined ? 0 : 1);
+
+  if (totalSources === 0) {
+    return { payload: undefined, used: false };
+  }
+
+  if (totalSources > 1) {
+    throw new ValidationError(
+      'Use only one structured input source at a time: --input, --input-json, or the positional inline-JSON argument'
+    );
+  }
+
+  if (positional !== undefined) {
+    return { payload: positional, used: true };
+  }
+
+  const [source] = sources;
+  if (!source) {
+    return { payload: undefined, used: false };
+  }
+  return {
+    payload: await readStructuredSource(source, readers),
+    used: true,
+  };
 };


### PR DESCRIPTION
## Summary
- Replaces separate structured-input surfaces with one `--input <path|->` path plus inline `--input-json`.
- Preserves positional input and field-flag merging while rejecting conflicting structured input sources.
- Updates CLI docs, ADR text, release notes, and package docs to the unified input grammar.

## Details
`packages/cli/src/structured-input.ts` now normalizes inline JSON, file input, and stdin input through the same loader. `--input -` is the canonical stdin spelling; file paths use the same flag. The CLI build path strips meta flags before trail input assembly, and the Trails app integration tests cover positional IDs, inline JSON, file payloads, stdin, and conflict handling.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-399.