### PR TITLE
feat(cli,trails): add --quiet flag to strip Result wrapper on trails run

### DIFF
--- a/.changeset/trl-400-quiet-flag.md
+++ b/.changeset/trl-400-quiet-flag.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/cli': minor
+'@ontrails/trails': minor
+---
+
+Add `--quiet` / `-q` flag to strip the `inner-trail-result` envelope from `trails run` stdout. On success, stdout becomes the inner value JSON only (no `{ kind, trailId, value }` wrapper). Composes with `--json` / `--jsonl` (those control format; `--quiet` controls envelope vs unwrapped). Wired as a global CLI flag via `outputModePreset()` so all commands surface it; the run-trail-specific unwrap logic lives in `apps/trails/src/cli.ts` next to the existing collision-recovery wrapper.

--- a/apps/trails/src/__tests__/run-quiet.test.ts
+++ b/apps/trails/src/__tests__/run-quiet.test.ts
@@ -1,0 +1,281 @@
+/* oxlint-disable-next-line eslint-plugin-jest/no-conditional-expect -- result-shape assertions branch on isOk/isErr */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import type { ActionResultContext } from '@ontrails/cli';
+import { NotFoundError, Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { tryQuietRunOutput } from '../run-quiet.js';
+import { INNER_TRAIL_RESULT_KIND } from '../trails/run.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const stubRunTrail = trail('run', {
+  blaze: () => Result.ok(),
+  description: 'stub run trail for quiet tests',
+  input: z.object({ id: z.string() }),
+  output: z.unknown(),
+});
+
+const stubOtherTrail = trail('other', {
+  blaze: () => Result.ok(),
+  description: 'stub non-run trail',
+  input: z.object({}),
+  output: z.unknown(),
+});
+
+const buildCtx = (
+  trailObj: typeof stubRunTrail | typeof stubOtherTrail,
+  flags: Record<string, unknown>,
+  result: Result<unknown, Error>
+): ActionResultContext => ({
+  args: {},
+  flags,
+  input: {},
+  result,
+  topoName: 'trails',
+  trail: trailObj as unknown as ActionResultContext['trail'],
+});
+
+const innerTrailResult = (value: unknown) => ({
+  kind: INNER_TRAIL_RESULT_KIND,
+  trailId: 'entity.show',
+  value,
+});
+
+interface CapturedIO {
+  readonly stdout: string[];
+  readonly stderr: string[];
+}
+
+const withCapturedIO = async (
+  fn: (io: CapturedIO) => Promise<void>
+): Promise<CapturedIO> => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+  process.stdout.write = ((chunk: string) => {
+    stdout.push(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string) => {
+    stderr.push(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await fn({ stderr, stdout });
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+  return { stderr, stdout };
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('tryQuietRunOutput', () => {
+  let originalTrailsJson: string | undefined;
+  let originalTrailsJsonl: string | undefined;
+
+  const restoreEnv = (key: 'TRAILS_JSON' | 'TRAILS_JSONL'): void => {
+    const original =
+      key === 'TRAILS_JSON' ? originalTrailsJson : originalTrailsJsonl;
+    if (original === undefined) {
+      // Static keys avoid the dynamic-delete lint rule.
+      if (key === 'TRAILS_JSON') {
+        delete process.env.TRAILS_JSON;
+      } else {
+        delete process.env.TRAILS_JSONL;
+      }
+      return;
+    }
+    process.env[key] = original;
+  };
+
+  beforeEach(() => {
+    // Capture env vars that deriveOutputMode reads so per-topo flags from a
+    // host environment cannot leak into assertions.
+    originalTrailsJson = process.env['TRAILS_JSON'];
+    originalTrailsJsonl = process.env['TRAILS_JSONL'];
+    delete process.env.TRAILS_JSON;
+    delete process.env.TRAILS_JSONL;
+  });
+
+  afterEach(() => {
+    restoreEnv('TRAILS_JSON');
+    restoreEnv('TRAILS_JSONL');
+  });
+
+  test('returns false when --quiet is not set on the run trail', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      {},
+      Result.ok(innerTrailResult({ name: 'Alpha' }))
+    );
+    const io = await withCapturedIO(async () => {
+      const handled = await tryQuietRunOutput(ctx);
+      expect(handled).toBe(false);
+    });
+    expect(io.stdout.join('')).toBe('');
+    expect(io.stderr.join('')).toBe('');
+  });
+
+  test('returns false on a non-run trail even with --quiet', async () => {
+    const ctx = buildCtx(
+      stubOtherTrail,
+      { quiet: true },
+      Result.ok({ name: 'Alpha' })
+    );
+    const handled = await tryQuietRunOutput(ctx);
+    expect(handled).toBe(false);
+  });
+
+  test('returns false when the outer run-trail Result is Err (defer to default)', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { quiet: true },
+      Result.err(new NotFoundError('no such trail'))
+    );
+    const handled = await tryQuietRunOutput(ctx);
+    expect(handled).toBe(false);
+  });
+
+  test('inner result writes only the inner value to stdout (text mode, no provenance envelope)', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { quiet: true },
+      Result.ok(innerTrailResult({ name: 'Alpha' }))
+    );
+    const io = await withCapturedIO(async () => {
+      const handled = await tryQuietRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    const out = io.stdout.join('');
+    // Text mode prints non-strings as JSON.stringify(value, null, 2).
+    expect(out).toBe(`${JSON.stringify({ name: 'Alpha' }, null, 2)}\n`);
+    expect(out).not.toContain('"kind"');
+    expect(out).not.toContain('"trailId"');
+    expect(out).not.toContain('"value"');
+    expect(io.stderr.join('')).toBe('');
+  });
+
+  test('inner result composes with --json (single JSON document on stdout)', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { json: true, quiet: true },
+      Result.ok(innerTrailResult({ name: 'Alpha' }))
+    );
+    const io = await withCapturedIO(async () => {
+      const handled = await tryQuietRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    expect(io.stdout.join('')).toBe(
+      `${JSON.stringify({ name: 'Alpha' }, null, 2)}\n`
+    );
+  });
+
+  test('inner void result composes with --json as valid JSON null', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { json: true, quiet: true },
+      Result.ok(innerTrailResult())
+    );
+    const io = await withCapturedIO(async () => {
+      const handled = await tryQuietRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    expect(io.stdout.join('')).toBe('null\n');
+    expect(JSON.parse(io.stdout.join(''))).toBeNull();
+  });
+
+  test('inner void result composes in text mode as JSON null', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { quiet: true },
+      Result.ok(innerTrailResult())
+    );
+    const io = await withCapturedIO(async () => {
+      const handled = await tryQuietRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    expect(io.stdout.join('')).toBe('null\n');
+    expect(JSON.parse(io.stdout.join(''))).toBeNull();
+  });
+
+  test('inner result composes with --jsonl (one line per array item)', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { jsonl: true, quiet: true },
+      Result.ok(innerTrailResult([{ id: 'a' }, { id: 'b' }]))
+    );
+    const io = await withCapturedIO(async () => {
+      const handled = await tryQuietRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    expect(io.stdout.join('')).toBe(
+      `${JSON.stringify({ id: 'a' })}\n${JSON.stringify({ id: 'b' })}\n`
+    );
+  });
+
+  test('inner void result composes with --jsonl as valid JSON null', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { jsonl: true, quiet: true },
+      Result.ok(innerTrailResult())
+    );
+    const io = await withCapturedIO(async () => {
+      const handled = await tryQuietRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    expect(io.stdout.join('')).toBe('null\n');
+    expect(JSON.parse(io.stdout.join(''))).toBeNull();
+  });
+
+  test('returns false when the run result is not an inner-result envelope', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { quiet: true },
+      Result.ok({ raw: true })
+    );
+    const io = await withCapturedIO(async () => {
+      const handled = await tryQuietRunOutput(ctx);
+      expect(handled).toBe(false);
+    });
+    expect(io.stdout.join('')).toBe('');
+    expect(io.stderr.join('')).toBe('');
+  });
+});
+
+describe('--quiet | --input - pipe smoke test', () => {
+  test('output of `run --quiet` is shaped to feed `run --input -` of another trail', async () => {
+    // Stage 1: produce inner-value JSON on captured stdout under --quiet.
+    const upstreamCtx = buildCtx(
+      stubRunTrail,
+      { json: true, quiet: true },
+      Result.ok(innerTrailResult({ name: 'Alpha' }))
+    );
+
+    const captured = await withCapturedIO(async () => {
+      const handled = await tryQuietRunOutput(upstreamCtx);
+      expect(handled).toBe(true);
+    });
+
+    const piped = captured.stdout.join('');
+    // Stage 2: confirm the captured stdout parses as the inner value (no
+    // inner-result envelope), so a downstream `--input -` consumer
+    // gets the trail's payload directly.
+    const parsed: unknown = JSON.parse(piped);
+    expect(parsed).toEqual({ name: 'Alpha' });
+    if (typeof parsed === 'object' && parsed !== null) {
+      expect('ok' in parsed).toBe(false);
+      expect('kind' in parsed).toBe(false);
+      expect('trailId' in parsed).toBe(false);
+      expect('value' in parsed).toBe(false);
+    }
+  });
+});

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -5,21 +5,26 @@ import { surface } from '@ontrails/cli/commander';
 import { app } from './app.js';
 import { resolveInputWithClack } from './clack.js';
 import { tryRecoverFromRunCollision } from './run-collision.js';
+import { tryQuietRunOutput } from './run-quiet.js';
 import { trailsPackageVersion } from './versions.js';
 
 const onResult = async (ctx: ActionResultContext): Promise<void> => {
   const recovered = await tryRecoverFromRunCollision(ctx, { graph: app });
-  if (recovered === undefined) {
-    await defaultOnResult(ctx);
+  const resolvedCtx: ActionResultContext =
+    recovered === undefined
+      ? ctx
+      : {
+          ...ctx,
+          input: recovered.isOk()
+            ? (ctx.trail.input.safeParse(ctx.input).data ?? ctx.input)
+            : ctx.input,
+          result: recovered,
+        };
+
+  if (await tryQuietRunOutput(resolvedCtx)) {
     return;
   }
-  await defaultOnResult({
-    ...ctx,
-    input: recovered.isOk()
-      ? (ctx.trail.input.safeParse(ctx.input).data ?? ctx.input)
-      : ctx.input,
-    result: recovered,
-  });
+  await defaultOnResult(resolvedCtx);
 };
 
 // oxlint-disable-next-line require-hook -- CLI entry point

--- a/apps/trails/src/run-quiet.ts
+++ b/apps/trails/src/run-quiet.ts
@@ -1,0 +1,75 @@
+/**
+ * CLI-surface bridge for the `run` trail's `--quiet` flag.
+ *
+ * The `run` trail returns an `inner-trail-result` envelope as the `value` of
+ * its own outer `Result.ok(...)`. The default CLI on-result handler unwraps
+ * once, leaving stdout as `{ "kind": "inner-trail-result", "trailId": "...",
+ * "value": ... }` — useful when a caller wants provenance, but noisy when the
+ * caller only wants the inner value to feed downstream pipes.
+ *
+ * `--quiet` strips that envelope:
+ *
+ * - Inner result envelope → write the inner value to stdout via the resolved
+ *   output mode.
+ *
+ * Errors at the outer layer (the run trail itself failing — `NotFoundError`,
+ * `AmbiguousError`, `ValidationError` from input) are unaffected by `--quiet`:
+ * we always defer to the supplied default handler so collision-recovery and
+ * the existing error surface stay intact.
+ */
+
+import type { ActionResultContext } from '@ontrails/cli';
+import { deriveOutputMode, output } from '@ontrails/cli';
+
+import { INNER_TRAIL_RESULT_KIND } from './trails/run.js';
+
+interface InnerTrailResultEnvelope {
+  readonly kind: typeof INNER_TRAIL_RESULT_KIND;
+  readonly trailId: string;
+  readonly value: unknown;
+}
+
+const isInnerTrailResultEnvelope = (
+  value: unknown
+): value is InnerTrailResultEnvelope =>
+  typeof value === 'object' &&
+  value !== null &&
+  (value as { readonly kind?: unknown }).kind === INNER_TRAIL_RESULT_KIND &&
+  typeof (value as { readonly trailId?: unknown }).trailId === 'string' &&
+  'value' in value;
+
+const isQuietRunCtx = (ctx: ActionResultContext): boolean =>
+  ctx.trail.id === 'run' && ctx.flags['quiet'] === true;
+
+/**
+ * Return value:
+ * - `false` — `--quiet` did not apply; caller should fall through to its
+ *   default handler.
+ * - `true` — `--quiet` handled the result and wrote output. Caller should not
+ *   invoke the default handler.
+ *
+ */
+export const tryQuietRunOutput = async (
+  ctx: ActionResultContext
+): Promise<boolean> => {
+  if (!isQuietRunCtx(ctx)) {
+    return false;
+  }
+
+  // Outer Err on the run trail (collision, not-found, validation) is not in
+  // scope for --quiet: defer to the default handler so existing exit-code
+  // mapping and recovery hooks stay intact.
+  if (ctx.result.isErr()) {
+    return false;
+  }
+
+  const inner: unknown = ctx.result.value;
+  if (!isInnerTrailResultEnvelope(inner)) {
+    return false;
+  }
+
+  const { mode } = deriveOutputMode(ctx.flags, ctx.topoName);
+  const value = inner.value === undefined ? null : inner.value;
+  output(value, mode);
+  return true;
+};

--- a/packages/cli/src/__tests__/flags.test.ts
+++ b/packages/cli/src/__tests__/flags.test.ts
@@ -178,19 +178,23 @@ describe('deriveFlags', () => {
 });
 
 describe('outputModePreset', () => {
-  test('returns --output, --json, --jsonl flags', () => {
+  test('returns --output, --json, --jsonl, --quiet flags', () => {
     const flags = outputModePreset();
-    expect(flags).toHaveLength(3);
+    expect(flags).toHaveLength(4);
 
     const outputFlag = requireFlag(flags, 'output');
     const jsonFlag = requireFlag(flags, 'json');
     const jsonlFlag = requireFlag(flags, 'jsonl');
+    const quietFlag = requireFlag(flags, 'quiet');
 
     expect(outputFlag.short).toBe('o');
     expect(outputFlag.choices).toEqual(['text', 'json', 'jsonl']);
     expect(outputFlag.default).toBe('text');
     expect(jsonFlag.type).toBe('boolean');
     expect(jsonlFlag.type).toBe('boolean');
+    expect(quietFlag.type).toBe('boolean');
+    expect(quietFlag.short).toBe('q');
+    expect(quietFlag.required).toBe(false);
   });
 });
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -112,6 +112,7 @@ const META_FLAG_CANDIDATES = new Set([
   'json',
   'jsonl',
   'output',
+  'quiet',
 ]);
 
 const STRUCTURED_INLINE_JSON_ARG_NAME = 'inline-json';

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -64,7 +64,7 @@ export const deriveFlags = (
 // Presets
 // ---------------------------------------------------------------------------
 
-/** Flags for output mode selection: --output, --json, --jsonl */
+/** Flags for output mode selection: --output, --json, --jsonl, --quiet */
 export const outputModePreset = (): CliFlag[] => [
   {
     choices: ['text', 'json', 'jsonl'],
@@ -87,6 +87,15 @@ export const outputModePreset = (): CliFlag[] => [
     description: 'Shorthand for --output jsonl',
     name: 'jsonl',
     required: false,
+    type: 'boolean',
+    variadic: false,
+  },
+  {
+    description:
+      'Strip outer Result wrapper from `trails run` (pipe-friendly: value only on stdout, error message on stderr)',
+    name: 'quiet',
+    required: false,
+    short: 'q',
     type: 'boolean',
     variadic: false,
   },


### PR DESCRIPTION
## Summary
- Adds the global `--quiet` / `-q` CLI flag.
- Makes `trails run --quiet` unwrap successful inner `Result.ok(value)` output instead of printing the outer Result envelope.
- Keeps error paths and existing collision handling unchanged.

## Details
`outputModePreset()` now contributes quiet mode, and `apps/trails/src/run-quiet.ts` handles the run-specific unwrap in the on-result chain. The flag composes with JSON/JSONL output and unified `--input` piping. `quiet` is included in `META_FLAG_CANDIDATES` so it never becomes trail input, and no `@ontrails/core` changes are needed.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-400.