### PR TITLE
feat(trails): add run examples command for listing trail examples

### DIFF
--- a/.changeset/trl-402-examples-listing.md
+++ b/.changeset/trl-402-examples-listing.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': minor
+---
+
+Add `run.examples` for listing a trail's examples without executing. The split run family gives examples listing its own typed input and structured `RunExamplesListing` output (`{ kind: 'examples-listing', trailId, examples }`) instead of adding an `--examples` mode flag to `run`. The CLI surface helper formats text-mode tables (name + truncated input + outcome) and unwraps to a JSON/JSONL array when `--json`/`--jsonl` is set. Trails with no examples emit `No examples defined` (text) or `[]` (JSON). Unknown trail IDs still surface `NotFoundError` (exit code 2).

--- a/apps/trails/src/__tests__/run-examples.test.ts
+++ b/apps/trails/src/__tests__/run-examples.test.ts
@@ -1,0 +1,536 @@
+/* oxlint-disable-next-line eslint-plugin-jest/no-conditional-expect -- result-shape assertions branch on isOk/isErr */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ActionResultContext } from '@ontrails/cli';
+import { NotFoundError, Result, executeTrail, trail } from '@ontrails/core';
+import type { StructuredTrailExample } from '@ontrails/core';
+import { z } from 'zod';
+
+import { tryExamplesRunOutput } from '../run-examples.js';
+import {
+  RUN_EXAMPLES_LISTING_KIND,
+  runExamplesTrail,
+  structuredTrailExampleSchema,
+} from '../trails/run-examples.js';
+import type { RunExamplesListing } from '../trails/run-examples.js';
+
+// ---------------------------------------------------------------------------
+// Shared captured-IO helper
+// ---------------------------------------------------------------------------
+
+interface CapturedIO {
+  readonly stdout: string[];
+  readonly stderr: string[];
+}
+
+const withCapturedIO = async (
+  fn: (io: CapturedIO) => Promise<void> | void
+): Promise<CapturedIO> => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+  process.stdout.write = ((chunk: string) => {
+    stdout.push(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string) => {
+    stderr.push(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await fn({ stderr, stdout });
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+  return { stderr, stdout };
+};
+
+// ---------------------------------------------------------------------------
+// tryExamplesRunOutput formatting tests (unit-level, in-memory ctx)
+// ---------------------------------------------------------------------------
+
+const stubRunTrail = trail('run.examples', {
+  blaze: () => Result.ok(),
+  description: 'stub run trail for examples-listing tests',
+  input: z.object({ trailId: z.string() }),
+  output: z.unknown(),
+});
+
+const stubOtherTrail = trail('other', {
+  blaze: () => Result.ok(),
+  description: 'stub non-run trail',
+  input: z.object({}),
+  output: z.unknown(),
+});
+
+const buildCtx = (
+  trailObj: typeof stubRunTrail | typeof stubOtherTrail,
+  flags: Record<string, unknown>,
+  result: Result<unknown, Error>
+): ActionResultContext => ({
+  args: {},
+  flags,
+  input: {},
+  result,
+  topoName: 'trails',
+  trail: trailObj as unknown as ActionResultContext['trail'],
+});
+
+const successExample: StructuredTrailExample = Object.freeze({
+  description: 'happy path',
+  input: { id: '' },
+  kind: 'success',
+  name: 'Run trail by ID',
+  provenance: { source: 'trail.examples' as const },
+});
+
+test('structured trail example schema preserves future structured fields', () => {
+  const parsed = structuredTrailExampleSchema.parse({
+    input: { id: 'demo.alpha' },
+    kind: 'success',
+    name: 'Alpha happy',
+    provenance: { source: 'trail.examples' },
+    trace: { spanId: 'span-1' },
+  });
+
+  expect(parsed).toMatchObject({
+    trace: { spanId: 'span-1' },
+  });
+});
+
+const errorExample: StructuredTrailExample = Object.freeze({
+  description: 'unknown id',
+  error: 'NotFoundError',
+  input: { id: '' },
+  kind: 'error',
+  name: 'Reject unknown trail ID',
+  provenance: { source: 'trail.examples' as const },
+});
+
+const buildListing = (
+  examples: readonly StructuredTrailExample[]
+): RunExamplesListing => ({
+  examples,
+  kind: RUN_EXAMPLES_LISTING_KIND,
+  trailId: 'run',
+});
+
+describe('tryExamplesRunOutput', () => {
+  let originalTrailsJson: string | undefined;
+  let originalTrailsJsonl: string | undefined;
+
+  beforeEach(() => {
+    originalTrailsJson = process.env['TRAILS_JSON'];
+    originalTrailsJsonl = process.env['TRAILS_JSONL'];
+    delete process.env.TRAILS_JSON;
+    delete process.env.TRAILS_JSONL;
+  });
+
+  afterEach(() => {
+    if (originalTrailsJson === undefined) {
+      delete process.env.TRAILS_JSON;
+    } else {
+      process.env.TRAILS_JSON = originalTrailsJson;
+    }
+    if (originalTrailsJsonl === undefined) {
+      delete process.env.TRAILS_JSONL;
+    } else {
+      process.env.TRAILS_JSONL = originalTrailsJsonl;
+    }
+  });
+
+  test('returns false on the run trail because listings now come from run.examples', async () => {
+    const ctx = buildCtx(
+      trail('run', {
+        blaze: () => Result.ok(),
+        input: z.object({}),
+        output: z.unknown(),
+      }) as typeof stubRunTrail,
+      {},
+      Result.ok(buildListing([]))
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryExamplesRunOutput(ctx);
+      expect(handled).toBe(false);
+    });
+    expect(io.stdout.join('')).toBe('');
+    expect(io.stderr.join('')).toBe('');
+  });
+
+  test('returns false on a non-run.examples trail', async () => {
+    const ctx = buildCtx(
+      stubOtherTrail,
+      {},
+      Result.ok(buildListing([successExample]))
+    );
+    const handled = tryExamplesRunOutput(ctx);
+    expect(handled).toBe(false);
+  });
+
+  test('returns false when the outer Result is Err (defer to default handler)', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      {},
+      Result.err(new NotFoundError('no such trail'))
+    );
+    const handled = tryExamplesRunOutput(ctx);
+    expect(handled).toBe(false);
+  });
+
+  test('text mode formats a table-like listing with name + truncated input + outcome', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      {},
+      Result.ok(buildListing([successExample, errorExample]))
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryExamplesRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    const out = io.stdout.join('');
+    expect(out).toContain('NAME');
+    expect(out).toContain('INPUT');
+    expect(out).toContain('OUTCOME');
+    expect(out).toContain('Run trail by ID');
+    expect(out).toContain('Reject unknown trail ID');
+    expect(out).toContain('ok');
+    expect(out).toContain('error: NotFoundError');
+    // No raw envelope keys leak into text output.
+    expect(out).not.toContain('"kind"');
+    expect(out).not.toContain('"provenance"');
+  });
+
+  test('text mode prints "No examples defined" when the listing is empty', async () => {
+    const ctx = buildCtx(stubRunTrail, {}, Result.ok(buildListing([])));
+    const io = await withCapturedIO(() => {
+      const handled = tryExamplesRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    expect(io.stdout.join('')).toBe('No examples defined\n');
+  });
+
+  test('json mode emits the structured examples array (no envelope)', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { json: true },
+      Result.ok(buildListing([successExample, errorExample]))
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryExamplesRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    const out = io.stdout.join('');
+    const parsed: unknown = JSON.parse(out);
+    expect(Array.isArray(parsed)).toBe(true);
+    if (Array.isArray(parsed)) {
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0]).toMatchObject({
+        kind: 'success',
+        name: 'Run trail by ID',
+      });
+      expect(parsed[1]).toMatchObject({
+        error: 'NotFoundError',
+        kind: 'error',
+        name: 'Reject unknown trail ID',
+      });
+    }
+  });
+
+  test('json mode emits an empty array when the listing has no examples', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { json: true },
+      Result.ok(buildListing([]))
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryExamplesRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    expect(io.stdout.join('').trim()).toBe('[]');
+  });
+
+  test('jsonl mode emits one structured example per line', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { jsonl: true },
+      Result.ok(buildListing([successExample, errorExample]))
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryExamplesRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    const lines = io.stdout
+      .join('')
+      .split('\n')
+      .filter((line) => line.length > 0);
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0] ?? '')).toMatchObject({
+      kind: 'success',
+      name: 'Run trail by ID',
+    });
+    expect(JSON.parse(lines[1] ?? '')).toMatchObject({
+      kind: 'error',
+      name: 'Reject unknown trail ID',
+    });
+  });
+
+  test('truncates very long input previews with an ellipsis', async () => {
+    const longInput = { id: 'x'.repeat(200) };
+    const longExample: StructuredTrailExample = Object.freeze({
+      input: longInput,
+      kind: 'success',
+      name: 'Long input',
+      provenance: { source: 'trail.examples' as const },
+    });
+    const ctx = buildCtx(
+      stubRunTrail,
+      {},
+      Result.ok(buildListing([longExample]))
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryExamplesRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    const out = io.stdout.join('');
+    expect(out).toContain('…');
+    // The full 200-char trailId must not appear in full.
+    expect(out).not.toContain('x'.repeat(200));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run.examples blaze (workspace-fixture integration)
+// ---------------------------------------------------------------------------
+
+interface AppSpec {
+  readonly name: string;
+  readonly trailIds: readonly string[];
+}
+
+const writeFixture = (filePath: string, contents: string): void => {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, contents);
+};
+
+const buildExampleFragment = (
+  trailId: string,
+  examples: readonly { name: string; description?: string; error?: string }[]
+): string => {
+  const json = JSON.stringify(
+    examples.map((example) => ({
+      ...(example.description === undefined
+        ? {}
+        : { description: example.description }),
+      ...(example.error === undefined ? {} : { error: example.error }),
+      input: { trailId },
+      name: example.name,
+    }))
+  );
+  return json;
+};
+
+const writeWorkspace = (
+  workspaceRoot: string,
+  apps: readonly (AppSpec & {
+    readonly examplesByTrail?: Readonly<
+      Record<
+        string,
+        readonly { name: string; description?: string; error?: string }[]
+      >
+    >;
+  })[]
+): void => {
+  writeFixture(
+    join(workspaceRoot, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'run-examples-test-fixture',
+        private: true,
+        type: 'module',
+        workspaces: ['apps/*'],
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  for (const spec of apps) {
+    const appDir = join(workspaceRoot, 'apps', spec.name);
+    writeFixture(
+      join(appDir, 'package.json'),
+      `${JSON.stringify(
+        {
+          name: spec.name,
+          private: true,
+          trails: { module: 'src/app.ts' },
+          type: 'module',
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const trailsBody = spec.trailIds
+      .map((trailId) => {
+        const examples = spec.examplesByTrail?.[trailId] ?? [];
+        const examplesLiteral = buildExampleFragment(trailId, examples);
+        return `  ['${trailId}', { id: '${trailId}', kind: 'trail', examples: ${examplesLiteral} }]`;
+      })
+      .join(',\n');
+
+    // Stub Topo shape: discovery layer reads `name` and `ids()`; the
+    // `loadFreshAppLease` resolver checks `trails` (truthy); and the
+    // run.examples trail calls `app.get(trailId)` and reads `examples` from the
+    // resolved trail. Hand-rolled stub satisfies all three code paths without
+    // pulling in `@ontrails/core`.
+    writeFixture(
+      join(appDir, 'src/app.ts'),
+      [
+        `const trailMap = new Map([`,
+        trailsBody,
+        `]);`,
+        `export const app = {`,
+        `  name: '${spec.name}',`,
+        `  trails: trailMap,`,
+        `  ids: () => Array.from(trailMap.keys()),`,
+        `  get: (id) => trailMap.get(id),`,
+        `};`,
+        '',
+      ].join('\n')
+    );
+  }
+};
+
+let workspaceRoot: string;
+
+beforeEach(() => {
+  workspaceRoot = join(
+    tmpdir(),
+    `run-examples-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(workspaceRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { force: true, recursive: true });
+});
+
+const expectOk = <T, E extends Error>(result: Result<T, E>): T => {
+  if (result.isErr()) {
+    throw new Error(`Expected Result.ok but got Err: ${result.error.message}`);
+  }
+  return result.value;
+};
+
+const expectErr = <T, E extends Error>(result: Result<T, E>): E => {
+  if (result.isOk()) {
+    throw new Error('Expected Result.err but got Ok');
+  }
+  return result.error;
+};
+
+describe('run.examples trail', () => {
+  test('returns the structured examples listing without executing the trail', async () => {
+    writeWorkspace(workspaceRoot, [
+      {
+        examplesByTrail: {
+          'demo.alpha': [
+            { description: 'happy path', name: 'Alpha happy' },
+            {
+              description: 'unknown id',
+              error: 'NotFoundError',
+              name: 'Alpha not found',
+            },
+          ],
+        },
+        name: 'app-a',
+        trailIds: ['demo.alpha'],
+      },
+    ]);
+
+    const result = await executeTrail(runExamplesTrail, {
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const value = expectOk(result) as RunExamplesListing;
+    expect(value.kind).toBe(RUN_EXAMPLES_LISTING_KIND);
+    expect(value.trailId).toBe('demo.alpha');
+    expect(value.examples).toHaveLength(2);
+    expect(value.examples[0]).toMatchObject({
+      kind: 'success',
+      name: 'Alpha happy',
+    });
+    expect(value.examples[1]).toMatchObject({
+      error: 'NotFoundError',
+      kind: 'error',
+      name: 'Alpha not found',
+    });
+  });
+
+  test('resolves ambiguous workspace trail through --app without module', async () => {
+    writeWorkspace(workspaceRoot, [
+      {
+        examplesByTrail: {
+          'shared.demo': [{ description: 'app a path', name: 'App A' }],
+        },
+        name: 'app-a',
+        trailIds: ['shared.demo'],
+      },
+      {
+        examplesByTrail: {
+          'shared.demo': [{ description: 'app b path', name: 'App B' }],
+        },
+        name: 'app-b',
+        trailIds: ['shared.demo'],
+      },
+    ]);
+
+    const result = await executeTrail(runExamplesTrail, {
+      app: 'app-b',
+      id: 'shared.demo',
+      rootDir: workspaceRoot,
+    });
+
+    const value = expectOk(result) as RunExamplesListing;
+    expect(value.trailId).toBe('shared.demo');
+    expect(value.examples.map((example) => example.name)).toEqual(['App B']);
+  });
+
+  test('returns an empty examples array when the resolved trail has no examples', async () => {
+    writeWorkspace(workspaceRoot, [{ name: 'app-a', trailIds: ['demo.bare'] }]);
+
+    const result = await executeTrail(runExamplesTrail, {
+      id: 'demo.bare',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const value = expectOk(result) as RunExamplesListing;
+    expect(value.kind).toBe(RUN_EXAMPLES_LISTING_KIND);
+    expect(value.trailId).toBe('demo.bare');
+    expect(value.examples).toEqual([]);
+  });
+
+  test('still surfaces NotFoundError from workspace-index resolution for an unknown trail id', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['only.alpha'] },
+    ]);
+
+    const result = await executeTrail(runExamplesTrail, {
+      id: 'never.here',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const error = expectErr(result);
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(error.message).toContain("Trail 'never.here' was not found");
+  });
+});

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -5,6 +5,7 @@ import { surface } from '@ontrails/cli/commander';
 import { app } from './app.js';
 import { resolveInputWithClack } from './clack.js';
 import { tryRecoverFromRunCollision } from './run-collision.js';
+import { tryExamplesRunOutput } from './run-examples.js';
 import { tryQuietRunOutput } from './run-quiet.js';
 import { trailsPackageVersion } from './versions.js';
 
@@ -21,6 +22,9 @@ const onResult = async (ctx: ActionResultContext): Promise<void> => {
           result: recovered,
         };
 
+  if (tryExamplesRunOutput(resolvedCtx)) {
+    return;
+  }
   if (await tryQuietRunOutput(resolvedCtx)) {
     return;
   }

--- a/apps/trails/src/run-examples.ts
+++ b/apps/trails/src/run-examples.ts
@@ -1,0 +1,148 @@
+/**
+ * CLI-surface bridge for the `run.examples` trail.
+ *
+ * `run.examples` is a pure metadata read: the trail returns a
+ * {@link RunExamplesListing} on its outer Ok value.
+ * This module owns the surface decision of how to render that listing:
+ *
+ * - Text mode (default): a table-like list with `name`, truncated `input`,
+ *   and outcome (`ok` / `error: <code>`). Empty listings print
+ *   `No examples defined`.
+ * - JSON / JSONL: the structured `examples` array is emitted directly via
+ *   the resolved output mode, so agents and downstream consumers can parse
+ *   the full structured shape (`name`, `input`, `expected`, `expectedMatch`,
+ *   `error`, `signals`, `kind`, `provenance`).
+ *
+ * Errors at the outer layer (NotFoundError, AmbiguousError, ValidationError)
+ * are unaffected by `run.examples`: we always defer to the supplied default
+ * handler so the existing exit-code mapping and recovery hooks stay intact.
+ */
+
+import type { ActionResultContext } from '@ontrails/cli';
+import { deriveOutputMode, output } from '@ontrails/cli';
+import type { StructuredTrailExample } from '@ontrails/core';
+
+import { runExamplesListingSchema } from './trails/run-examples.js';
+import type { RunExamplesListing } from './trails/run-examples.js';
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+const isExamplesRunCtx = (ctx: ActionResultContext): boolean =>
+  ctx.trail.id === 'run.examples';
+
+// ---------------------------------------------------------------------------
+// Text formatting
+// ---------------------------------------------------------------------------
+
+const INPUT_PREVIEW_LIMIT = 60;
+
+const truncate = (value: string, limit: number): string =>
+  value.length <= limit ? value : `${value.slice(0, limit - 1)}…`;
+
+const formatInputPreview = (input: unknown): string => {
+  if (input === undefined) {
+    return '';
+  }
+  let encoded: string;
+  try {
+    encoded = JSON.stringify(input) ?? '';
+  } catch {
+    encoded = String(input);
+  }
+  return truncate(encoded, INPUT_PREVIEW_LIMIT);
+};
+
+const formatOutcome = (example: StructuredTrailExample): string => {
+  if (example.kind === 'error') {
+    const code = example.error;
+    return code === undefined || code.length === 0 ? 'error' : `error: ${code}`;
+  }
+  return 'ok';
+};
+
+interface ExampleRow {
+  readonly name: string;
+  readonly input: string;
+  readonly outcome: string;
+}
+
+const buildRows = (
+  examples: readonly StructuredTrailExample[]
+): readonly ExampleRow[] =>
+  examples.map((example) => ({
+    input: formatInputPreview(example.input),
+    name: example.name,
+    outcome: formatOutcome(example),
+  }));
+
+const padRight = (value: string, width: number): string =>
+  value.length >= width ? value : value + ' '.repeat(width - value.length);
+
+const formatTable = (rows: readonly ExampleRow[]): string => {
+  const headers = { input: 'INPUT', name: 'NAME', outcome: 'OUTCOME' };
+  const allRows: readonly ExampleRow[] = [headers, ...rows];
+
+  const widths = {
+    input: Math.max(...allRows.map((row) => row.input.length)),
+    name: Math.max(...allRows.map((row) => row.name.length)),
+    outcome: Math.max(...allRows.map((row) => row.outcome.length)),
+  };
+
+  const formatRow = (row: ExampleRow): string =>
+    `${padRight(row.name, widths.name)}  ${padRight(row.input, widths.input)}  ${row.outcome}`;
+
+  return allRows.map(formatRow).join('\n');
+};
+
+const formatTextListing = (listing: RunExamplesListing): string => {
+  if (listing.examples.length === 0) {
+    return 'No examples defined';
+  }
+  return formatTable(buildRows(listing.examples));
+};
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Return value:
+ * - `false` — `run.examples` did not apply; caller should fall through to its
+ *   default handler.
+ * - `true` — `run.examples` handled the result and wrote output. Caller should
+ *   not invoke the default handler.
+ */
+export const tryExamplesRunOutput = (ctx: ActionResultContext): boolean => {
+  if (!isExamplesRunCtx(ctx)) {
+    return false;
+  }
+
+  // Outer Err on `run.examples` (NotFound, Ambiguous, Validation) is not in
+  // scope for this renderer: defer to the default handler so existing
+  // exit-code mapping and recovery hooks stay intact.
+  if (ctx.result.isErr()) {
+    return false;
+  }
+
+  const listing = runExamplesListingSchema.safeParse(ctx.result.value);
+  if (!listing.success) {
+    // Defensive fallback: the trail owns the output schema, so this branch is
+    // unreachable in practice. Defer to the default handler if anything else
+    // slips through.
+    return false;
+  }
+
+  const { mode } = deriveOutputMode(ctx.flags, ctx.topoName);
+
+  if (mode === 'text') {
+    output(formatTextListing(listing.data), mode);
+    return true;
+  }
+
+  // JSON / JSONL: emit the structured examples array directly so downstream
+  // consumers can parse the full structured shape per example.
+  output(listing.data.examples, mode);
+  return true;
+};

--- a/apps/trails/src/trails/run-examples.ts
+++ b/apps/trails/src/trails/run-examples.ts
@@ -18,27 +18,29 @@ import { createIsolatedExampleInput } from './topo-support.js';
 
 export const RUN_EXAMPLES_LISTING_KIND = 'examples-listing' as const;
 
-export const structuredTrailExampleSchema = z.object({
-  description: z.string().optional(),
-  error: z.string().optional(),
-  expected: z.unknown().optional(),
-  expectedMatch: z.unknown().optional(),
-  input: z.unknown(),
-  kind: z.union([z.literal('success'), z.literal('error')]),
-  name: z.string(),
-  provenance: z.object({ source: z.literal('trail.examples') }),
-  signals: z
-    .array(
-      z.object({
-        payload: z.unknown().optional(),
-        payloadMatch: z.unknown().optional(),
-        signalId: z.string(),
-        times: z.number().optional(),
-      })
-    )
-    .readonly()
-    .optional(),
-});
+export const structuredTrailExampleSchema = z
+  .object({
+    description: z.string().optional(),
+    error: z.string().optional(),
+    expected: z.unknown().optional(),
+    expectedMatch: z.unknown().optional(),
+    input: z.unknown(),
+    kind: z.union([z.literal('success'), z.literal('error')]),
+    name: z.string(),
+    provenance: z.object({ source: z.literal('trail.examples') }),
+    signals: z
+      .array(
+        z.object({
+          payload: z.unknown().optional(),
+          payloadMatch: z.unknown().optional(),
+          signalId: z.string(),
+          times: z.number().optional(),
+        })
+      )
+      .readonly()
+      .optional(),
+  })
+  .passthrough();
 
 export const runExamplesListingSchema = z.object({
   examples: z.array(structuredTrailExampleSchema).readonly(),
@@ -76,7 +78,7 @@ const buildExamplesListing = (
       | readonly StructuredTrailExample[]
       | undefined) ?? [];
   return Result.ok({
-    examples: structured,
+    examples: structured as unknown as RunExamplesListing['examples'],
     kind: RUN_EXAMPLES_LISTING_KIND,
     trailId,
   });

--- a/docs/adr/drafts/20260331-direct-invocation.md
+++ b/docs/adr/drafts/20260331-direct-invocation.md
@@ -368,7 +368,7 @@ This bridges the gap between ad-hoc exploration and structured testing. The deve
 **List available examples:**
 
 ```bash
-$ trails run entity.show --examples
+$ trails run examples entity.show
 Available examples for entity.show:
   Found     input: { name: "Alpha" }           expects: ok
   Missing   input: { name: "nonexistent" }     expects: NotFoundError


### PR DESCRIPTION
## Summary
- Adds `trails run examples <id>` as the run-family command for listing authored examples.
- Lists examples for the resolved target trail without executing its blaze.
- Formats text, JSON, and JSONL output through the Trails app surface helper.

## Details
`run.examples` is a separate run-family trail dedicated to example listing. It reuses the same workspace/app resolution path, including `--app`, and returns an examples-listing payload for structured output. Text mode prints a compact listing or `No examples defined`. Because this is metadata inspection rather than trail execution, it intentionally has its own output path and does not depend on `--quiet`.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-402.
