### PR TITLE
feat(trails): add run example command for named example comparison

### DIFF
--- a/.changeset/trl-401-example-comparison.md
+++ b/.changeset/trl-401-example-comparison.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': minor
+---
+
+Add `run.example` for named example execution. It loads a named example, executes the inner trail with the example's input, and compares actual vs expected per the example's contract (`expected` deep-equal, `expectedMatch` partial-match, or `error` class match). Returns a structured `RunExampleComparison` envelope with input/expected/actual/match/diff. The CLI surface helper prints an OK summary on match (exit 0), or a diff and `ValidationError` on mismatch (exit 1). Unknown example names produce `NotFoundError` (exit 2) with the available examples listed.

--- a/apps/trails/src/__tests__/run-example.test.ts
+++ b/apps/trails/src/__tests__/run-example.test.ts
@@ -1,0 +1,791 @@
+/* oxlint-disable-next-line eslint-plugin-jest/no-conditional-expect -- result-shape assertions branch on isOk/isErr */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import type { ActionResultContext } from '@ontrails/cli';
+import {
+  NotFoundError,
+  Result,
+  ValidationError,
+  executeTrail,
+  trail,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+import { tryExampleRunOutput } from '../run-example.js';
+import {
+  RUN_EXAMPLE_COMPARISON_KIND,
+  runExampleTrail,
+} from '../trails/run-example.js';
+import type { RunExampleComparison } from '../trails/run-example.js';
+
+// ---------------------------------------------------------------------------
+// Captured-IO helper
+// ---------------------------------------------------------------------------
+
+interface CapturedIO {
+  readonly stdout: string[];
+  readonly stderr: string[];
+}
+
+const withCapturedIO = async (
+  fn: (io: CapturedIO) => Promise<void> | void
+): Promise<CapturedIO> => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+  process.stdout.write = ((chunk: string) => {
+    stdout.push(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string) => {
+    stderr.push(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await fn({ stderr, stdout });
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+  return { stderr, stdout };
+};
+
+// ---------------------------------------------------------------------------
+// Stub trails for unit-level helper tests
+// ---------------------------------------------------------------------------
+
+const stubRunTrail = trail('run.example', {
+  blaze: () => Result.ok(),
+  description: 'stub run trail for example-comparison tests',
+  input: z.object({ trailId: z.string() }),
+  output: z.unknown(),
+});
+
+const stubOtherTrail = trail('other', {
+  blaze: () => Result.ok(),
+  description: 'stub non-run trail',
+  input: z.object({}),
+  output: z.unknown(),
+});
+
+const buildCtx = (
+  trailObj: typeof stubRunTrail | typeof stubOtherTrail,
+  flags: Record<string, unknown>,
+  result: Result<unknown, Error>
+): ActionResultContext => ({
+  args: {},
+  flags,
+  input: {},
+  result,
+  topoName: 'trails',
+  trail: trailObj as unknown as ActionResultContext['trail'],
+});
+
+const buildEnvelope = (
+  overrides: Partial<RunExampleComparison>
+): RunExampleComparison => ({
+  actual: { outcome: 'ok', value: { name: 'Alpha' } },
+  exampleName: 'Run trail by ID',
+  expected: { name: 'Alpha' },
+  input: { id: 'demo.alpha' },
+  kind: RUN_EXAMPLE_COMPARISON_KIND,
+  match: true,
+  mode: 'expected',
+  trailId: 'demo.alpha',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// tryExampleRunOutput unit tests
+// ---------------------------------------------------------------------------
+
+describe('tryExampleRunOutput', () => {
+  let originalTrailsJson: string | undefined;
+  let originalTrailsJsonl: string | undefined;
+
+  beforeEach(() => {
+    originalTrailsJson = process.env['TRAILS_JSON'];
+    originalTrailsJsonl = process.env['TRAILS_JSONL'];
+    delete process.env.TRAILS_JSON;
+    delete process.env.TRAILS_JSONL;
+  });
+
+  afterEach(() => {
+    if (originalTrailsJson === undefined) {
+      delete process.env.TRAILS_JSON;
+    } else {
+      process.env.TRAILS_JSON = originalTrailsJson;
+    }
+    if (originalTrailsJsonl === undefined) {
+      delete process.env.TRAILS_JSONL;
+    } else {
+      process.env.TRAILS_JSONL = originalTrailsJsonl;
+    }
+  });
+
+  test('returns false on the base run trail', async () => {
+    const ctx = buildCtx(
+      trail('run', {
+        blaze: () => Result.ok(),
+        input: z.object({}),
+        output: z.unknown(),
+      }) as typeof stubRunTrail,
+      {},
+      Result.ok(buildEnvelope({}))
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryExampleRunOutput(ctx);
+      expect(handled).toBe(false);
+    });
+    expect(io.stdout.join('')).toBe('');
+    expect(io.stderr.join('')).toBe('');
+  });
+
+  test('returns false on a non-run.example trail', async () => {
+    const ctx = buildCtx(stubOtherTrail, {}, Result.ok(buildEnvelope({})));
+    const handled = tryExampleRunOutput(ctx);
+    expect(handled).toBe(false);
+  });
+
+  test('returns false when the outer Result is Err (defer to default handler)', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      {},
+      Result.err(new NotFoundError('no such trail'))
+    );
+    const handled = tryExampleRunOutput(ctx);
+    expect(handled).toBe(false);
+  });
+
+  test('text mode prints OK summary on match without throwing', async () => {
+    const ctx = buildCtx(stubRunTrail, {}, Result.ok(buildEnvelope({})));
+    const io = await withCapturedIO(() => {
+      const handled = tryExampleRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    const out = io.stdout.join('');
+    expect(out).toContain('OK');
+    expect(out).toContain('demo.alpha');
+    expect(out).toContain('Run trail by ID');
+    expect(io.stderr.join('')).toBe('');
+  });
+
+  test('text mode throws ValidationError on mismatch and writes diff to stderr', async () => {
+    const envelope = buildEnvelope({
+      actual: { outcome: 'ok', value: { name: 'Beta' } },
+      diff: ['value.name: "Beta" != "Alpha"'],
+      match: false,
+    });
+    const ctx = buildCtx(stubRunTrail, {}, Result.ok(envelope));
+    let thrown: unknown;
+    const io = await withCapturedIO(() => {
+      try {
+        tryExampleRunOutput(ctx);
+      } catch (error) {
+        thrown = error;
+      }
+    });
+    expect(thrown).toBeInstanceOf(ValidationError);
+    const err = thrown;
+    if (err instanceof ValidationError) {
+      expect(err.message).toContain('did not match');
+    }
+    const stderr = io.stderr.join('');
+    expect(stderr).toContain('MISMATCH');
+    expect(stderr).toContain('value.name');
+  });
+
+  test('json mode emits the full envelope on match', async () => {
+    const ctx = buildCtx(
+      stubRunTrail,
+      { exampleName: 'happy', json: true },
+      Result.ok(buildEnvelope({}))
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryExampleRunOutput(ctx);
+      expect(handled).toBe(true);
+    });
+    const parsed: unknown = JSON.parse(io.stdout.join(''));
+    expect(parsed).toMatchObject({
+      exampleName: 'Run trail by ID',
+      kind: RUN_EXAMPLE_COMPARISON_KIND,
+      match: true,
+      mode: 'expected',
+      trailId: 'demo.alpha',
+    });
+  });
+
+  test('json mode emits envelope and throws ValidationError on mismatch', async () => {
+    const envelope = buildEnvelope({
+      actual: { outcome: 'ok', value: { name: 'Beta' } },
+      diff: ['value.name: "Beta" != "Alpha"'],
+      match: false,
+    });
+    const ctx = buildCtx(
+      stubRunTrail,
+      { exampleName: 'happy', json: true },
+      Result.ok(envelope)
+    );
+    let thrown: unknown;
+    const io = await withCapturedIO(() => {
+      try {
+        tryExampleRunOutput(ctx);
+      } catch (error) {
+        thrown = error;
+      }
+    });
+    expect(thrown).toBeInstanceOf(ValidationError);
+    const parsed: unknown = JSON.parse(io.stdout.join(''));
+    expect(parsed).toMatchObject({ match: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run.example blaze integration tests (workspace-fixture)
+// ---------------------------------------------------------------------------
+
+interface ExampleSpec {
+  readonly name: string;
+  readonly description?: string;
+  readonly error?: string;
+  readonly expected?: unknown;
+  readonly expectedMatch?: unknown;
+  readonly returnValue?: unknown;
+  readonly returnError?: { class: string; message: string };
+}
+
+const writeFixture = (filePath: string, contents: string): void => {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, contents);
+};
+
+/**
+ * Build a stub Topo whose trails have:
+ * - examples on disk (so run.example can look them up)
+ * - blaze functions that return either a fixed value (returnValue) or a
+ *   fixed error (returnError) keyed by example.name. The blaze inspects
+ *   `input.__exampleName` to choose; the example fixtures embed that key
+ *   into their input so dispatch is deterministic.
+ */
+const writeWorkspace = (
+  workspaceRoot: string,
+  trailId: string,
+  examples: readonly ExampleSpec[],
+  appName = 'app-a'
+): void => {
+  writeFixture(
+    join(workspaceRoot, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'run-example-test-fixture',
+        private: true,
+        type: 'module',
+        workspaces: ['apps/*'],
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  const appDir = join(workspaceRoot, 'apps', appName);
+  writeFixture(
+    join(appDir, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: appName,
+        private: true,
+        trails: { module: 'src/app.ts' },
+        type: 'module',
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  // Build the per-example dispatch table and the examples literal. The
+  // examples on the trail definition mirror the structured-trail-example
+  // shape (`expected` / `expectedMatch` / `error`), and each example's
+  // input embeds `__exampleName` so the blaze can dispatch deterministically
+  // via the in-memory `dispatch` map.
+  const buildExampleFragment = (ex: ExampleSpec): string => {
+    const baseFragments: readonly string[] = [
+      `name: ${JSON.stringify(ex.name)}`,
+      `input: { __exampleName: ${JSON.stringify(ex.name)}, trailId: ${JSON.stringify(trailId)} }`,
+    ];
+    const optionalFragments: readonly (string | null)[] = [
+      ex.description === undefined
+        ? null
+        : `description: ${JSON.stringify(ex.description)}`,
+      ex.expected === undefined
+        ? null
+        : `expected: ${JSON.stringify(ex.expected)}`,
+      ex.expectedMatch === undefined
+        ? null
+        : `expectedMatch: ${JSON.stringify(ex.expectedMatch)}`,
+      ex.error === undefined ? null : `error: ${JSON.stringify(ex.error)}`,
+    ];
+    const fragments = [
+      ...baseFragments,
+      ...optionalFragments.filter((entry): entry is string => entry !== null),
+    ];
+    return `    { ${fragments.join(', ')} }`;
+  };
+
+  const examplesArrayLiteral = `[\n${examples
+    .map(buildExampleFragment)
+    .join(',\n')}\n  ]`;
+
+  const dispatchEntries = examples
+    .map((ex) => {
+      if (ex.returnError !== undefined) {
+        return `  [${JSON.stringify(ex.name)}, { kind: 'err', className: ${JSON.stringify(ex.returnError.class)}, message: ${JSON.stringify(ex.returnError.message)} }]`;
+      }
+      return `  [${JSON.stringify(ex.name)}, { kind: 'ok', value: ${JSON.stringify(ex.returnValue)} }]`;
+    })
+    .join(',\n');
+
+  // The fixture imports `@ontrails/core` at the workspace level so the trail
+  // is a real `trail()` definition with all required fields (detours,
+  // contours, etc.). This lets `executeTrail` run end-to-end without
+  // hand-rolling every internal field on a stub object.
+  writeFixture(
+    join(appDir, 'src/app.ts'),
+    [
+      `import {`,
+      `  ConflictError,`,
+      `  NotFoundError,`,
+      `  Result,`,
+      `  ValidationError,`,
+      `  topo,`,
+      `  trail,`,
+      `} from '@ontrails/core';`,
+      `import { z } from 'zod';`,
+      '',
+      `const errorClasses = {`,
+      `  NotFoundError,`,
+      `  ValidationError,`,
+      `  ConflictError,`,
+      `};`,
+      '',
+      `const dispatch = new Map([`,
+      dispatchEntries,
+      `]);`,
+      '',
+      `const targetTrail = trail(${JSON.stringify(trailId)}, {`,
+      `  description: 'fixture trail for run-example tests',`,
+      `  input: z.object({ __exampleName: z.string(), trailId: z.string() }),`,
+      `  output: z.unknown(),`,
+      `  examples: ${examplesArrayLiteral},`,
+      `  blaze: (input) => {`,
+      `    const config = dispatch.get(input.__exampleName);`,
+      `    if (!config) {`,
+      `      return Result.ok(undefined);`,
+      `    }`,
+      `    if (config.kind === 'err') {`,
+      `      const Ctor = errorClasses[config.className] ?? NotFoundError;`,
+      `      return Result.err(new Ctor(config.message));`,
+      `    }`,
+      `    return Result.ok(config.value);`,
+      `  },`,
+      `});`,
+      '',
+      `export const app = topo(${JSON.stringify(appName)}, [targetTrail]);`,
+      '',
+    ].join('\n')
+  );
+};
+
+// Use `.tmp-tests` under the trails app so node_modules resolution from the
+// fixture climbs up to the workspace's node_modules (system tmpdir would
+// break package resolution for `@ontrails/core` and `zod`).
+const workspaceTmpRoot = resolve(import.meta.dir, '../..', '.tmp-tests');
+
+let workspaceRoot: string;
+
+beforeEach(() => {
+  mkdirSync(workspaceTmpRoot, { recursive: true });
+  workspaceRoot = join(
+    workspaceTmpRoot,
+    `run-example-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(workspaceRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { force: true, recursive: true });
+});
+
+const expectOk = <T, E extends Error>(result: Result<T, E>): T => {
+  if (result.isErr()) {
+    throw new Error(`Expected Result.ok but got Err: ${result.error.message}`);
+  }
+  return result.value;
+};
+
+const expectErr = <T, E extends Error>(result: Result<T, E>): E => {
+  if (result.isOk()) {
+    throw new Error('Expected Result.err but got Ok');
+  }
+  return result.error;
+};
+
+describe('run.example trail', () => {
+  test('expected-mode match returns envelope with match=true and no diff', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        expected: { name: 'Alpha' },
+        name: 'happy',
+        returnValue: { name: 'Alpha' },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'happy',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.kind).toBe(RUN_EXAMPLE_COMPARISON_KIND);
+    expect(envelope.mode).toBe('expected');
+    expect(envelope.match).toBe(true);
+    expect(envelope.diff).toBeUndefined();
+    expect(envelope.trailId).toBe('demo.alpha');
+    expect(envelope.exampleName).toBe('happy');
+  });
+
+  test('expected-mode mismatch returns envelope with match=false and a diff', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        expected: { name: 'Alpha' },
+        name: 'wrong',
+        returnValue: { name: 'Beta' },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'wrong',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.match).toBe(false);
+    expect(envelope.mode).toBe('expected');
+    expect(envelope.diff).toBeDefined();
+    expect(envelope.diff?.length ?? 0).toBeGreaterThan(0);
+    const diffText = (envelope.diff ?? []).join(' ');
+    expect(diffText).toContain('name');
+  });
+
+  test('input-only example runs in no-assertion mode', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        name: 'smoke',
+        returnValue: { name: 'Alpha' },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'smoke',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.mode).toBe('none');
+    expect(envelope.match).toBe(true);
+    expect(envelope.diff).toBeUndefined();
+    expect(envelope.actual).toEqual({
+      outcome: 'ok',
+      value: { name: 'Alpha' },
+    });
+  });
+
+  test('expectedMatch-mode partial match passes when extras are present', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        expectedMatch: { name: 'Alpha' },
+        name: 'partial',
+        returnValue: { extra: 'extra-value', name: 'Alpha' },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'partial',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.mode).toBe('expectedMatch');
+    expect(envelope.match).toBe(true);
+  });
+
+  test('expectedMatch-mode mismatch returns diff for missing expected key', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        expectedMatch: { name: 'Alpha' },
+        name: 'partial-mismatch',
+        returnValue: { other: 'thing' },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'partial-mismatch',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.match).toBe(false);
+    expect(envelope.mode).toBe('expectedMatch');
+    const diffText = (envelope.diff ?? []).join(' ');
+    expect(diffText).toContain('missing in actual');
+  });
+
+  test('expectedMatch-mode array subset matches order-independent (mirrors testExamples)', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        expectedMatch: { items: [{ id: 'b' }] },
+        name: 'array-subset',
+        returnValue: { items: [{ id: 'a' }, { id: 'b' }] },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'array-subset',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.match).toBe(true);
+    expect(envelope.mode).toBe('expectedMatch');
+  });
+
+  test('expectedMatch-mode duplicate elements require distinct actual entries', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        expectedMatch: { items: ['a', 'a'] },
+        name: 'duplicates',
+        returnValue: { items: ['a'] },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'duplicates',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.match).toBe(false);
+    expect(envelope.mode).toBe('expectedMatch');
+  });
+
+  test('error-mode envelope includes errorCategory when actual is a TrailsError', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        error: 'NotFoundError',
+        name: 'not-found-error',
+        returnError: { class: 'NotFoundError', message: 'missing' },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'not-found-error',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.match).toBe(true);
+    expect(envelope.mode).toBe('error');
+    expect(envelope.actual).toMatchObject({
+      errorCategory: 'not_found',
+      errorClassName: 'NotFoundError',
+      outcome: 'err',
+    });
+  });
+
+  test('error-mode match when actual is Err with the expected class name', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        error: 'NotFoundError',
+        name: 'rejects-unknown',
+        returnError: { class: 'NotFoundError', message: 'not found' },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'rejects-unknown',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.mode).toBe('error');
+    expect(envelope.match).toBe(true);
+  });
+
+  test('error-mode mismatch when actual is Err of different class', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        error: 'NotFoundError',
+        name: 'rejects-with-wrong-class',
+        returnError: { class: 'ConflictError', message: 'conflict' },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'rejects-with-wrong-class',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.match).toBe(false);
+    expect(envelope.mode).toBe('error');
+  });
+
+  test('error-mode mismatch when actual is Ok but example expected an error', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        error: 'NotFoundError',
+        name: 'expects-error-but-ok',
+        returnValue: { ok: true },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'expects-error-but-ok',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.match).toBe(false);
+  });
+
+  test('unknown example name returns NotFoundError listing available examples', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        expected: { name: 'Alpha' },
+        name: 'happy',
+        returnValue: { name: 'Alpha' },
+      },
+      {
+        expected: { name: 'Beta' },
+        name: 'other',
+        returnValue: { name: 'Beta' },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'does-not-exist',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const error = expectErr(result);
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(error.message).toContain("Example 'does-not-exist' not found");
+    expect(error.message).toContain('happy');
+    expect(error.message).toContain('other');
+  });
+
+  test('unknown trail id returns NotFoundError', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      { expected: 1, name: 'happy', returnValue: 1 },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      exampleName: 'happy',
+      id: 'never.here',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const error = expectErr(result);
+    expect(error).toBeInstanceOf(NotFoundError);
+  });
+
+  test('resolves trail through workspace --app override and runs the example', async () => {
+    writeWorkspace(workspaceRoot, 'demo.alpha', [
+      {
+        expected: { name: 'Alpha' },
+        name: 'happy',
+        returnValue: { name: 'Alpha' },
+      },
+    ]);
+
+    const result = await executeTrail(runExampleTrail, {
+      app: 'app-a',
+      exampleName: 'happy',
+      id: 'demo.alpha',
+      module: 'apps/app-a/src/app.ts',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.kind).toBe(RUN_EXAMPLE_COMPARISON_KIND);
+    expect(envelope.match).toBe(true);
+  });
+
+  test('resolves ambiguous workspace trail through --app without module', async () => {
+    writeWorkspace(
+      workspaceRoot,
+      'shared.demo',
+      [
+        {
+          expected: { owner: 'app-a' },
+          name: 'happy',
+          returnValue: { owner: 'app-a' },
+        },
+      ],
+      'app-a'
+    );
+    writeWorkspace(
+      workspaceRoot,
+      'shared.demo',
+      [
+        {
+          expected: { owner: 'app-b' },
+          name: 'happy',
+          returnValue: { owner: 'app-b' },
+        },
+      ],
+      'app-b'
+    );
+
+    const result = await executeTrail(runExampleTrail, {
+      app: 'app-b',
+      exampleName: 'happy',
+      id: 'shared.demo',
+      rootDir: workspaceRoot,
+    });
+
+    const envelope = expectOk(result) as RunExampleComparison;
+    expect(envelope.match).toBe(true);
+    expect(envelope.actual).toMatchObject({
+      outcome: 'ok',
+      value: { owner: 'app-b' },
+    });
+  });
+});

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -5,6 +5,7 @@ import { surface } from '@ontrails/cli/commander';
 import { app } from './app.js';
 import { resolveInputWithClack } from './clack.js';
 import { tryRecoverFromRunCollision } from './run-collision.js';
+import { tryExampleRunOutput } from './run-example.js';
 import { tryExamplesRunOutput } from './run-examples.js';
 import { tryQuietRunOutput } from './run-quiet.js';
 import { trailsPackageVersion } from './versions.js';
@@ -22,6 +23,9 @@ const onResult = async (ctx: ActionResultContext): Promise<void> => {
           result: recovered,
         };
 
+  if (tryExampleRunOutput(resolvedCtx)) {
+    return;
+  }
   if (tryExamplesRunOutput(resolvedCtx)) {
     return;
   }

--- a/apps/trails/src/run-example.ts
+++ b/apps/trails/src/run-example.ts
@@ -1,0 +1,149 @@
+/**
+ * CLI-surface bridge for the `run.example` trail.
+ *
+ * `run.example` resolves the named example on the target trail, executes it
+ * through the full pipeline, and packages an actual-vs-expected comparison
+ * into a structured envelope on the trail's outer `Result.ok(...)`. This module
+ * owns the surface decision of how to render that envelope:
+ *
+ * - Text mode (default): a compact summary on match, an `input / expected /
+ *   actual / diff` block on mismatch.
+ * - JSON / JSONL: emits the full {@link RunExampleComparison} envelope so
+ *   downstream consumers can parse the comparison shape directly.
+ *
+ * Match/mismatch is a comparison outcome, not an execution error: the trail
+ * always returns `Result.ok(envelope)`. This helper maps mismatch onto a
+ * non-zero exit code by throwing a `ValidationError` (category `validation`,
+ * exit 1) so Commander's error path runs.
+ *
+ * Outer Err on the run trail (NotFound, Ambiguous, Validation) is unaffected
+ * by `run.example`: this helper defers to the default handler so existing
+ * exit-code mapping and recovery hooks stay intact.
+ */
+
+import type { ActionResultContext } from '@ontrails/cli';
+import { deriveOutputMode, output } from '@ontrails/cli';
+import { ValidationError } from '@ontrails/core';
+
+import { runExampleComparisonSchema } from './trails/run-example.js';
+import type { RunExampleComparison } from './trails/run-example.js';
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+const isExampleRunCtx = (ctx: ActionResultContext): boolean =>
+  ctx.trail.id === 'run.example';
+
+// ---------------------------------------------------------------------------
+// Text formatting
+// ---------------------------------------------------------------------------
+
+const formatJson = (value: unknown): string => {
+  try {
+    const encoded = JSON.stringify(value, null, 2);
+    return encoded === undefined ? String(value) : encoded;
+  } catch {
+    return String(value);
+  }
+};
+
+const formatMatchText = (envelope: RunExampleComparison): string =>
+  [
+    `OK  ${envelope.trailId} :: ${envelope.exampleName}`,
+    `mode: ${envelope.mode}`,
+    'actual matches expected.',
+  ].join('\n');
+
+const formatMismatchText = (envelope: RunExampleComparison): string => {
+  const diffBlock =
+    envelope.diff !== undefined && envelope.diff.length > 0
+      ? envelope.diff.map((line) => `  - ${line}`).join('\n')
+      : '  - <no diff lines>';
+
+  return [
+    `MISMATCH  ${envelope.trailId} :: ${envelope.exampleName}`,
+    `mode: ${envelope.mode}`,
+    'input:',
+    formatJson(envelope.input),
+    'expected:',
+    formatJson(envelope.expected),
+    'actual:',
+    formatJson(envelope.actual),
+    'diff:',
+    diffBlock,
+  ].join('\n');
+};
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Return value:
+ * - `false` — `run.example` did not apply; caller should fall through to its
+ *   default handler.
+ * - `true` — `run.example` handled the result and wrote output. Caller should
+ *   not invoke the default handler.
+ *
+ * Throws a {@link ValidationError} on mismatch so Commander's error path runs
+ * and the run trail surface exits with the validation category exit code.
+ */
+export const tryExampleRunOutput = (ctx: ActionResultContext): boolean => {
+  if (!isExampleRunCtx(ctx)) {
+    return false;
+  }
+
+  // Outer Err on the run.example trail (NotFound, Ambiguous, Validation) is not
+  // in scope here: defer to the default handler so existing
+  // exit-code mapping and recovery hooks stay intact.
+  if (ctx.result.isErr()) {
+    return false;
+  }
+
+  const envelope = runExampleComparisonSchema.safeParse(ctx.result.value);
+  if (!envelope.success) {
+    // Defensive fallback: the trail owns the output schema, so this branch is
+    // unreachable in practice. Defer to the default handler if anything else
+    // slips through.
+    return false;
+  }
+  const comparison = envelope.data;
+
+  const { mode } = deriveOutputMode(ctx.flags, ctx.topoName);
+
+  if (mode === 'text') {
+    if (comparison.match) {
+      output(formatMatchText(comparison), mode);
+      return true;
+    }
+    process.stderr.write(`${formatMismatchText(comparison)}\n`);
+    throw new ValidationError(
+      `Example '${comparison.exampleName}' on trail '${comparison.trailId}' did not match expected outcome.`,
+      {
+        context: {
+          exampleName: comparison.exampleName,
+          mode: comparison.mode,
+          trailId: comparison.trailId,
+        },
+      }
+    );
+  }
+
+  // JSON / JSONL: emit the full envelope so downstream consumers can parse
+  // the comparison shape directly.
+  output(comparison, mode);
+  if (!comparison.match) {
+    throw new ValidationError(
+      `Example '${comparison.exampleName}' on trail '${comparison.trailId}' did not match expected outcome.`,
+      {
+        context: {
+          exampleName: comparison.exampleName,
+          mode: comparison.mode,
+          trailId: comparison.trailId,
+        },
+      }
+    );
+  }
+  return true;
+};

--- a/apps/trails/src/trails/run-example.ts
+++ b/apps/trails/src/trails/run-example.ts
@@ -32,6 +32,7 @@ export const runExampleComparisonSchema = z.object({
     z.literal('expected'),
     z.literal('expectedMatch'),
     z.literal('error'),
+    z.literal('none'),
   ]),
   trailId: z.string(),
 });
@@ -176,16 +177,23 @@ const partialMatchWithDiff = (
       return false;
     }
     let ok = true;
+    const consumed = new Set<number>();
     for (const [index, expectedEntry] of expected.entries()) {
-      const matched = actual.some((candidate) =>
-        partialMatchWithDiff(candidate, expectedEntry, [], [])
-      );
-      if (!matched) {
+      const matchIndex = actual.findIndex((candidate, candidateIndex) => {
+        if (consumed.has(candidateIndex)) {
+          return false;
+        }
+        const probe: string[] = [];
+        return partialMatchWithDiff(candidate, expectedEntry, [], probe);
+      });
+      if (matchIndex === -1) {
         diffs.push(
           `${formatPath([...path, `[${index}]`])}: expected array to contain ${formatLeaf(expectedEntry)}`
         );
         ok = false;
+        continue;
       }
+      consumed.add(matchIndex);
     }
     return ok;
   }
@@ -308,12 +316,14 @@ const findExample = (
     return Result.ok(match);
   }
 
+  const available = structured.map((entry) => entry.name);
+  const listing = available.length === 0 ? '<none>' : available.join(', ');
   return Result.err(
     new NotFoundError(
-      `Example '${exampleName}' not found on trail '${trailId}'.`,
+      `Example '${exampleName}' not found on trail '${trailId}'. Available: ${listing}.`,
       {
         context: {
-          available: structured.map((entry) => entry.name),
+          available,
           exampleName,
           trailId,
         },
@@ -331,7 +341,10 @@ const determineMode = (
   if (example.expectedMatch !== undefined) {
     return 'expectedMatch';
   }
-  return 'expected';
+  if (example.expected !== undefined) {
+    return 'expected';
+  }
+  return 'none';
 };
 
 const buildComparisonEnvelope = async (
@@ -376,6 +389,18 @@ const buildComparisonEnvelope = async (
       input: example.input,
       kind: RUN_EXAMPLE_COMPARISON_KIND,
       match,
+      mode,
+      trailId,
+    });
+  }
+  if (mode === 'none') {
+    return Result.ok({
+      actual,
+      exampleName,
+      expected: undefined,
+      input: example.input,
+      kind: RUN_EXAMPLE_COMPARISON_KIND,
+      match: true,
       mode,
       trailId,
     });

--- a/docs/adr/drafts/20260331-direct-invocation.md
+++ b/docs/adr/drafts/20260331-direct-invocation.md
@@ -36,7 +36,7 @@ A trail's examples are structured input/output pairs. They're already the closes
 
 ```bash
 # Run the trail with example input
-trails run entity.show --example "Found"
+trails run example entity.show "Found"
 ```
 
 The example named "Found" has `input: { id: 'p_1' }`. `trails run` feeds that input to the trail and shows the result alongside the expected output. Did the actual result match? The developer sees immediately. No test harness needed.
@@ -92,7 +92,7 @@ trails run entity.show '{"name": "Alpha"}'
 **Named example:**
 
 ```bash
-trails run entity.show --example "Found"
+trails run example entity.show "Found"
 # Uses the example's input, shows actual vs expected
 ```
 
@@ -315,10 +315,10 @@ trails tracing --chain exec_abc
 
 ### Example-driven execution
 
-Running a trail with `--example` feeds the example's input and compares the result:
+Running `trails run example` feeds the example's input and compares the result:
 
 ```bash
-$ trails run entity.show --example "Found"
+$ trails run example entity.show "Found"
 Input (from example "Found"):
   { "name": "Alpha" }
 
@@ -334,7 +334,7 @@ Actual:
 On mismatch:
 
 ```bash
-$ trails run entity.show --example "Found"
+$ trails run example entity.show "Found"
 Input (from example "Found"):
   { "name": "Alpha" }
 
@@ -351,7 +351,7 @@ Actual:
 For error examples:
 
 ```bash
-$ trails run entity.show --example "Missing"
+$ trails run example entity.show "Missing"
 Input (from example "Missing"):
   { "name": "nonexistent" }
 
@@ -432,10 +432,10 @@ trails run entity.show '{"name": "Alpha"}' --watch
 
 Reruns the trail whenever the trail's source file, schema definitions, or resource implementations change. The developer edits the trail's `run` function, saves, and sees the new result immediately. Same hot-reload loop as `bun --watch` but scoped to one trail's execution.
 
-Combined with `--example`:
+Combined with `trails run example`:
 
 ```bash
-trails run entity.show --example "Found" --watch
+trails run example entity.show "Found" --watch
 ```
 
 Edit the implementation, save, the example reruns, match/mismatch updates instantly. This is TDD without leaving the terminal. The example is the assertion. The watch loop is the runner.
@@ -543,7 +543,7 @@ trails run book<TAB>
 booking.confirm    booking.cancel    booking.show    booking.send-reminders
 
 # Tab-complete example names
-trails run entity.show --example <TAB>
+trails run example entity.show <TAB>
 Found    Missing    Filtered
 ```
 
@@ -554,10 +554,10 @@ Trail IDs are completed from the topo. Example names are completed from the trai
 ### Positive
 
 - **Zero-ceremony invocation.** Run any trail from the terminal with one command. No trailhead setup, no bin entry, no server. The topo is the interface.
-- **Examples become directly executable.** `--example` bridges exploration and testing. The developer runs a specific example, sees actual vs expected, adjusts the implementation. TDD in the terminal.
+- **Examples become directly executable.** `trails run example` bridges exploration and testing. The developer runs a specific example, sees actual vs expected, adjusts the implementation. TDD in the terminal.
 - **Unix-native composition.** JSON in, JSON out, exit codes, pipes. `trails run` composes with `jq`, `xargs`, other `trails run` invocations, and any JSONL-aware tool. Trails become first-class Unix citizens.
 - **Full pipeline execution.** Validation, layers, resources, events, triggers, tracing. Everything fires. The developer sees production-equivalent behavior without production infrastructure (via mock resources).
-- **Watch mode tightens the loop.** Edit, save, see the result. Combined with `--example`, it's TDD without a test framework. The example is the assertion. The file system is the trigger.
+- **Watch mode tightens the loop.** Edit, save, see the result. Combined with `trails run example`, it's TDD without a test framework. The example is the assertion. The file system is the trigger.
 - **`--tracing` makes composition visible.** The live execution tree shows crossings, events, triggers, parallel branches, and timing as they happen. The developer understands the reactive chain without reading code. Tracing stream to stderr while the result goes to stdout, composing cleanly with standard flags and Unix pipes.
 
 ### Tradeoffs


### PR DESCRIPTION
## Summary
- Adds `trails run example <id> <name>` for named example execution and comparison.
- Runs the example through the full run pipeline and compares actual output to the example contract.
- Reports comparison mismatches as validation failures at the CLI surface, not execution failures in trail logic.

## Details
`run.example` is a separate run-family trail dedicated to named example execution. The comparison supports exact `expected`, partial `expectedMatch`, and error-class matching for `error` examples. The run trail returns `Result.ok(RunExampleComparison)` for both matches and mismatches; `tryExampleRunOutput` converts mismatches into `ValidationError` for CLI exit behavior. Unknown example names return `NotFoundError` with available examples listed.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-401. Closes Phase 1 (Direct Run foundation + UX).
