### PR TITLE
feat(cli): derive --all flag for paginated trail outputs

### DIFF
--- a/.changeset/trl-469-pagination-derivation.md
+++ b/.changeset/trl-469-pagination-derivation.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/cli': minor
+---
+
+Absorb `autoIterateLayer` behavior into CLI surface derivation. Trails whose output schema matches the paginated shape (`{ items, hasMore, nextCursor }`) now auto-emit a `--all` flag on the CLI command. When `--all` is set, the executor iterates pages with the trail's cursor field until `hasMore: false` and aggregates `items[]` across pages. With `--jsonl --all`, items stream one per line as they arrive (no in-memory aggregation). If a page reports `hasMore: true` without a non-empty `nextCursor`, `--all` now fails with `ValidationError` instead of silently truncating results. Detection lives in `packages/cli/src/pagination.ts`. The legacy `autoIterateLayer` export is **kept** through Phase 2–7 for back-compat; removal lands in TRL-475 (Phase 8).

--- a/packages/cli/src/__tests__/pagination.test.ts
+++ b/packages/cli/src/__tests__/pagination.test.ts
@@ -1,0 +1,476 @@
+/**
+ * Tests for CLI surface derivation absorbing pagination behavior.
+ *
+ * Verifies that when a trail's output has the paginated shape
+ * (`items`, `hasMore`, optional `nextCursor`), the CLI command:
+ *   - exposes an auto-derived `--all` flag,
+ *   - aggregates pages when `--all` is set,
+ *   - streams per-item JSONL when `--all --jsonl` are set together,
+ *   - leaves non-paginated trails alone.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import type { ActionResultContext } from '../build.js';
+import type { CliCommand } from '../command.js';
+import { deriveCliCommands } from '../build.js';
+import { Result, ValidationError, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const buildCommands = (...args: Parameters<typeof deriveCliCommands>) => {
+  const result = deriveCliCommands(...args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const requireCommand = (commands: CliCommand[]): CliCommand => {
+  const [command] = commands;
+  if (!command) {
+    throw new Error('Expected at least one command');
+  }
+  return command;
+};
+
+interface PageInput {
+  readonly cursor?: string | undefined;
+}
+
+interface StringPage {
+  readonly items: string[];
+  readonly hasMore: boolean;
+  readonly nextCursor?: string | undefined;
+}
+
+const PaginatedInput = z.object({
+  cursor: z.string().optional(),
+});
+
+const PaginatedOutput = z.object({
+  hasMore: z.boolean(),
+  items: z.array(z.string()),
+  nextCursor: z.string().optional(),
+});
+
+const makePaginatedTrail = (
+  pages: readonly StringPage[]
+): {
+  readonly t: ReturnType<typeof trail<PageInput, StringPage>>;
+  readonly callCount: () => number;
+  readonly cursorsSeen: () => readonly (string | undefined)[];
+} => {
+  let calls = 0;
+  const cursors: (string | undefined)[] = [];
+  const t = trail('items.list', {
+    blaze: (input: PageInput): Result<StringPage, Error> => {
+      cursors.push(input.cursor);
+      const idx = calls;
+      calls += 1;
+      const page = pages[idx];
+      if (!page) {
+        return Result.err(new Error(`No page at index ${idx}`));
+      }
+      return Result.ok(page);
+    },
+    input: PaginatedInput,
+    output: PaginatedOutput,
+  });
+  return {
+    callCount: () => calls,
+    cursorsSeen: () => cursors,
+    t,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Flag derivation
+// ---------------------------------------------------------------------------
+
+describe('CLI surface absorbs pagination — flag derivation', () => {
+  test('paginated trail exposes auto-derived --all flag', () => {
+    const { t } = makePaginatedTrail([{ hasMore: false, items: [] }]);
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    const allFlag = command.flags.find((f) => f.name === 'all');
+    expect(allFlag).toBeDefined();
+    expect(allFlag?.type).toBe('boolean');
+    expect(allFlag?.required).toBe(false);
+  });
+
+  test('non-paginated trail does NOT get --all flag', () => {
+    const t = trail('greet', {
+      blaze: (input: { name: string }) => Result.ok(`Hello, ${input.name}`),
+      input: z.object({ name: z.string() }),
+    });
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    const allFlag = command.flags.find((f) => f.name === 'all');
+    expect(allFlag).toBeUndefined();
+  });
+
+  test('trail whose output has items but no hasMore does NOT get --all', () => {
+    const t = trail('partial', {
+      blaze: () => Result.ok({ items: [] }),
+      input: z.object({}),
+      output: z.object({ items: z.array(z.string()) }),
+    });
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    expect(command.flags.find((f) => f.name === 'all')).toBeUndefined();
+  });
+
+  test('trail whose output has items + hasMore but no nextCursor does NOT get --all', () => {
+    const t = trail('partial-no-cursor', {
+      blaze: () => Result.ok({ hasMore: false, items: [] }),
+      input: z.object({}),
+      output: z.object({
+        hasMore: z.boolean(),
+        items: z.array(z.string()),
+      }),
+    });
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    expect(command.flags.find((f) => f.name === 'all')).toBeUndefined();
+  });
+
+  test('trail with paginated output but no input cursor does NOT get --all', () => {
+    const t = trail('custom-cursor', {
+      blaze: () =>
+        Result.ok({
+          hasMore: false,
+          items: [],
+          nextCursor: undefined,
+        }),
+      input: z.object({ pageToken: z.string().optional() }),
+      output: PaginatedOutput,
+    });
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    expect(command.flags.find((f) => f.name === 'all')).toBeUndefined();
+  });
+
+  test('non-paginated trail can own an all field without the meta flag stripping it', async () => {
+    let receivedInput: { readonly all: boolean } | undefined;
+    const t = trail('all-field', {
+      blaze: (input: { all: boolean }) => {
+        receivedInput = input;
+        return Result.ok({ all: input.all });
+      },
+      input: z.object({ all: z.boolean() }),
+      output: z.object({ all: z.boolean() }),
+    });
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    const result = await command.execute({}, { all: true });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    expect(command.flags.find((f) => f.name === 'all')).toBeDefined();
+    expect(receivedInput).toEqual({ all: true });
+    expect(result.value).toEqual({ all: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Iteration behavior — aggregate
+// ---------------------------------------------------------------------------
+
+describe('CLI surface absorbs pagination — --all aggregates pages', () => {
+  test('aggregates items across 3 pages when --all is set', async () => {
+    const { t, callCount, cursorsSeen } = makePaginatedTrail([
+      { hasMore: true, items: ['a', 'b'], nextCursor: 'p2' },
+      { hasMore: true, items: ['c', 'd'], nextCursor: 'p3' },
+      { hasMore: false, items: ['e'] },
+    ]);
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    const result = await command.execute({}, { all: true });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    const value = result.value as {
+      readonly items: readonly string[];
+      readonly hasMore: boolean;
+    };
+    expect(value.items).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(value.hasMore).toBe(false);
+    expect(callCount()).toBe(3);
+    expect(cursorsSeen()).toEqual([undefined, 'p2', 'p3']);
+  });
+
+  test('aggregates unusually large pages without spreading items as call arguments', async () => {
+    const items = Array.from({ length: 70_000 }, (_, idx) => `item-${idx}`);
+    const { t } = makePaginatedTrail([{ hasMore: false, items }]);
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    const result = await command.execute({}, { all: true });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    const value = result.value as {
+      readonly items: readonly string[];
+    };
+    expect(value.items).toHaveLength(items.length);
+    expect(value.items.at(0)).toBe('item-0');
+    expect(value.items.at(-1)).toBe('item-69999');
+  });
+
+  test('--all with single first page (nextCursor undefined) returns just that page', async () => {
+    const { t, callCount } = makePaginatedTrail([
+      { hasMore: false, items: ['only'] },
+    ]);
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    const result = await command.execute({}, { all: true });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    const value = result.value as { readonly items: readonly string[] };
+    expect(value.items).toEqual(['only']);
+    expect(callCount()).toBe(1);
+  });
+
+  test('without --all, runs implementation once and returns the first page verbatim', async () => {
+    const { t, callCount } = makePaginatedTrail([
+      { hasMore: true, items: ['a'], nextCursor: 'p2' },
+    ]);
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    const result = await command.execute({}, {});
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    const value = result.value as {
+      readonly items: readonly string[];
+      readonly hasMore: boolean;
+      readonly nextCursor?: string;
+    };
+    expect(value.items).toEqual(['a']);
+    expect(value.hasMore).toBe(true);
+    expect(value.nextCursor).toBe('p2');
+    expect(callCount()).toBe(1);
+  });
+
+  test('hasMore with empty nextCursor fails instead of truncating', async () => {
+    const { t, callCount } = makePaginatedTrail([
+      { hasMore: true, items: ['only'], nextCursor: '' },
+    ]);
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    const result = await command.execute({}, { all: true });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(result.error.message).toContain('hasMore=true');
+    expect(callCount()).toBe(1);
+  });
+
+  test('hasMore without nextCursor fails instead of truncating', async () => {
+    const { t, callCount } = makePaginatedTrail([
+      { hasMore: true, items: ['partial'] },
+    ]);
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    const result = await command.execute({}, { all: true });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(result.error.message).toContain('non-empty nextCursor');
+    expect(callCount()).toBe(1);
+  });
+
+  test('repeated non-empty nextCursor fails instead of looping forever', async () => {
+    const { t, callCount, cursorsSeen } = makePaginatedTrail([
+      { hasMore: true, items: ['a'], nextCursor: 'p2' },
+      { hasMore: true, items: ['b'], nextCursor: 'p2' },
+    ]);
+    const app = topo('test-app', { [t.id]: t });
+    const command = requireCommand(buildCommands(app));
+
+    const result = await command.execute({}, { all: true });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(result.error.message).toContain('repeated nextCursor "p2"');
+    expect(callCount()).toBe(2);
+    expect(cursorsSeen()).toEqual([undefined, 'p2']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming — --all --jsonl
+// ---------------------------------------------------------------------------
+
+describe('CLI surface absorbs pagination — --all --jsonl streaming', () => {
+  test('streams one item per line across pages and signals streamed=true', async () => {
+    const { t } = makePaginatedTrail([
+      { hasMore: true, items: ['a', 'b'], nextCursor: 'p2' },
+      { hasMore: true, items: ['c'], nextCursor: 'p3' },
+      { hasMore: false, items: ['d', 'e'] },
+    ]);
+    const app = topo('test-app', { [t.id]: t });
+
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    // Override write so we can capture without touching the real stdout.
+    process.stdout.write = ((chunk: unknown): boolean => {
+      writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    let captured: ActionResultContext | undefined;
+    try {
+      const command = requireCommand(
+        buildCommands(app, {
+          onResult: (ctx) => {
+            captured = ctx;
+            return Promise.resolve();
+          },
+        })
+      );
+
+      const result = await command.execute({}, { all: true, jsonl: true });
+      expect(result.isOk()).toBe(true);
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    // Five items total, each emitted on its own line.
+    expect(writes).toEqual([
+      `${JSON.stringify('a')}\n`,
+      `${JSON.stringify('b')}\n`,
+      `${JSON.stringify('c')}\n`,
+      `${JSON.stringify('d')}\n`,
+      `${JSON.stringify('e')}\n`,
+    ]);
+
+    // The onResult ctx should advertise streaming so handlers can skip
+    // re-writing the aggregated value.
+    expect(captured).toBeDefined();
+    expect(captured?.streamed).toBe(true);
+  });
+
+  test('streams a terminal non-page value when runtime pagination drifts', async () => {
+    let calls = 0;
+    const t = trail('items.list', {
+      blaze: (): Result<unknown, Error> => {
+        calls += 1;
+        return Result.ok(
+          calls === 1
+            ? { hasMore: true, items: ['a'], nextCursor: 'p2' }
+            : { message: 'done early' }
+        );
+      },
+      input: PaginatedInput,
+      output: z
+        .object({
+          hasMore: z.boolean().optional(),
+          items: z.array(z.string()).optional(),
+          nextCursor: z.string().optional(),
+        })
+        .passthrough(),
+    });
+    const app = topo('test-app', { [t.id]: t });
+
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown): boolean => {
+      writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    let captured: ActionResultContext | undefined;
+    try {
+      const command = requireCommand(
+        buildCommands(app, {
+          onResult: (ctx) => {
+            captured = ctx;
+            return Promise.resolve();
+          },
+        })
+      );
+
+      const result = await command.execute({}, { all: true, jsonl: true });
+      expect(result.isOk()).toBe(true);
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    expect(writes).toEqual([
+      `${JSON.stringify('a')}\n`,
+      `${JSON.stringify({ message: 'done early' })}\n`,
+    ]);
+    expect(captured?.streamed).toBe(true);
+  });
+
+  test('--jsonl without --all does NOT stream from the iteration helper', async () => {
+    const { t, callCount } = makePaginatedTrail([
+      { hasMore: true, items: ['a'], nextCursor: 'p2' },
+    ]);
+    const app = topo('test-app', { [t.id]: t });
+
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown): boolean => {
+      writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    let captured: ActionResultContext | undefined;
+    try {
+      const command = requireCommand(
+        buildCommands(app, {
+          onResult: (ctx) => {
+            captured = ctx;
+            return Promise.resolve();
+          },
+        })
+      );
+
+      await command.execute({}, { jsonl: true });
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    // No streaming occurred — the iteration helper was never engaged.
+    expect(writes).toEqual([]);
+    expect(callCount()).toBe(1);
+    expect(captured?.streamed).toBeFalsy();
+  });
+});

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -24,6 +24,12 @@ import {
 
 import type { AnyTrail, CliArg, CliCommand, CliFlag } from './command.js';
 import { dryRunPreset, toFlags } from './flags.js';
+import {
+  inputHasCursorField,
+  isPaginatedOutput,
+  iteratePages,
+  writeJsonLine,
+} from './pagination.js';
 import type { InputResolver } from './prompt.js';
 import {
   STRUCTURED_INPUT_HINT,
@@ -48,6 +54,12 @@ export interface ActionResultContext {
   readonly result: Result<unknown, Error>;
   readonly topoName: string;
   readonly trail: AnyTrail;
+  /**
+   * True when the executor already streamed the trail's items to stdout
+   * (e.g. paginated `--all --jsonl`). Result handlers should skip writing
+   * the result value to avoid duplicate output.
+   */
+  readonly streamed?: boolean | undefined;
 }
 
 /** Options for CLI command projection. */
@@ -107,6 +119,7 @@ const validateCliCommandBuild = (
  * layer composition, and onResult handling.
  */
 const META_FLAG_CANDIDATES = new Set([
+  'all',
   'input',
   'inputJson',
   'json',
@@ -123,6 +136,18 @@ const STRUCTURED_INLINE_JSON_ARG: CliArg = {
   required: false,
   variadic: false,
 };
+
+/** Auto-derived flag for paginated trails: --all triggers iteration. */
+const paginatePreset = (): CliFlag[] => [
+  {
+    default: false,
+    description: 'Iterate all pages and aggregate results',
+    name: 'all',
+    required: false,
+    type: 'boolean',
+    variadic: false,
+  },
+];
 
 /** Merge parsed args and flags into a camelCase input record. */
 const mergeArgsAndFlags = (
@@ -284,6 +309,96 @@ const safeMergeInput = async (
   }
 };
 
+/** Strip the --all meta flag from input so the trail's blaze never sees it. */
+const stripAllFlag = (
+  input: Record<string, unknown>
+): Record<string, unknown> => {
+  if (!('all' in input)) {
+    return input;
+  }
+  const { all: _ignored, ...rest } = input;
+  return rest;
+};
+
+/**
+ * Run the trail once via `executeTrail`, returning the trail's Result.
+ * Used both for non-paginated commands and as the per-page runner for
+ * paginated `--all` iteration.
+ */
+const runTrailOnce = async (
+  graph: Topo,
+  t: AnyTrail,
+  ctxOverrides: Partial<TrailContext> | undefined,
+  options: DeriveCliCommandsOptions | undefined,
+  input: Record<string, unknown>
+): Promise<Result<unknown, Error>> =>
+  await executeTrail(t, input, {
+    configValues: options?.configValues,
+    createContext: options?.createContext,
+    ctx: withSurfaceMarker('cli', ctxOverrides),
+    layers: options?.layers,
+    resources: options?.resources,
+    topo: graph,
+  });
+
+/**
+ * Decide whether the executor should iterate this invocation.
+ *
+ * Iteration kicks in when the trail's output schema matches the paginated
+ * shape AND the user passed `--all`.
+ */
+const shouldIteratePages = (
+  t: AnyTrail,
+  parsedFlags: Record<string, unknown>,
+  metaFlagNames: ReadonlySet<string>
+): boolean =>
+  metaFlagNames.has('all') &&
+  isPaginatedOutput(t) &&
+  parsedFlags['all'] === true;
+
+const isJsonlMode = (parsedFlags: Record<string, unknown>): boolean =>
+  parsedFlags['jsonl'] === true ||
+  (typeof parsedFlags['output'] === 'string' &&
+    parsedFlags['output'] === 'jsonl');
+
+interface IterationOutcome {
+  readonly result: Result<unknown, Error>;
+  readonly streamed: boolean;
+}
+
+/**
+ * Drain a paginated trail across pages and return the aggregated/streamed
+ * outcome. The base input is what the user provided (after merging args +
+ * flags); the iteration helper rewrites the cursor field per page.
+ */
+const runPaginatedIteration = async (
+  graph: Topo,
+  t: AnyTrail,
+  ctxOverrides: Partial<TrailContext> | undefined,
+  options: DeriveCliCommandsOptions | undefined,
+  baseInput: Record<string, unknown>,
+  jsonl: boolean
+): Promise<IterationOutcome> => {
+  if (!inputHasCursorField(t)) {
+    return {
+      result: Result.err(
+        new ValidationError(
+          `Trail '${t.id}' has paginated output but no 'cursor' field on its input schema; cannot iterate with --all.`,
+          { context: { trailId: t.id } }
+        )
+      ),
+      streamed: false,
+    };
+  }
+  const result = await iteratePages({
+    baseInput: stripAllFlag(baseInput),
+    cursorField: 'cursor',
+    onItem: jsonl ? writeJsonLine : undefined,
+    runPage: (input) => runTrailOnce(graph, t, ctxOverrides, options, input),
+  });
+  return { result, streamed: jsonl && result.isOk() };
+};
+
 /** Create the execute function for a CLI command. */
 const createExecute =
   (
@@ -319,14 +434,29 @@ const createExecute =
     }
     const { mergedInput, usedStructuredInput } = merged.value;
 
-    const result = await executeTrail(t, mergedInput, {
-      configValues: options?.configValues,
-      createContext: options?.createContext,
-      ctx: withSurfaceMarker('cli', ctxOverrides),
-      layers: options?.layers,
-      resources: options?.resources,
-      topo: graph,
-    });
+    let result: Result<unknown, Error>;
+    let streamed = false;
+    if (shouldIteratePages(t, parsedFlags, metaFlagNames)) {
+      const outcome = await runPaginatedIteration(
+        graph,
+        t,
+        ctxOverrides,
+        options,
+        mergedInput,
+        isJsonlMode(parsedFlags)
+      );
+      ({ result } = outcome);
+      ({ streamed } = outcome);
+    } else {
+      result = await runTrailOnce(
+        graph,
+        t,
+        ctxOverrides,
+        options,
+        metaFlagNames.has('all') ? stripAllFlag(mergedInput) : mergedInput
+      );
+    }
+
     const finalResult = maybeAddStructuredInputHint(
       result,
       shouldHintStructuredInput,
@@ -344,6 +474,7 @@ const createExecute =
       flags: parsedFlags,
       input: reportInput,
       result: finalResult,
+      streamed,
       topoName: graph.name,
       trail: t,
     });
@@ -360,6 +491,9 @@ const buildFlags = (
   let flags = toFlags(fields);
   if (supportsStructuredInput(t.input)) {
     flags = mergeStructuredInputFlags(flags);
+  }
+  if (isPaginatedOutput(t) && inputHasCursorField(t)) {
+    flags = mergeFlags(paginatePreset(), flags);
   }
   if (options?.presets) {
     flags = mergeFlags(options.presets.flat(), flags);

--- a/packages/cli/src/on-result.ts
+++ b/packages/cli/src/on-result.ts
@@ -26,6 +26,12 @@ export const defaultOnResult = async (
     throw ctx.result.error;
   }
 
+  // Iteration helpers (e.g. paginated `--all --jsonl`) may have already
+  // streamed the items to stdout. Skip re-writing in that case.
+  if (ctx.streamed) {
+    return;
+  }
+
   const { mode } = deriveOutputMode(ctx.flags, ctx.topoName);
   await output(ctx.result.value, mode);
 };

--- a/packages/cli/src/pagination.ts
+++ b/packages/cli/src/pagination.ts
@@ -1,0 +1,229 @@
+/**
+ * CLI surface absorption for paginated trail outputs.
+ *
+ * When a trail's `output` schema matches the pagination shape
+ * (`items`, `hasMore`, optional `nextCursor`), the CLI surface
+ * derivation auto-emits an `--all` flag and, when set, iterates
+ * the trail across pages — aggregating in memory by default, or
+ * streaming per-item JSONL when `--jsonl` is also set.
+ *
+ * This module is the CLI-package-local home of the detection and
+ * iteration helpers. The legacy `autoIterateLayer` in `./layers.ts`
+ * remains exported for apps that still register it explicitly; the
+ * derivation pipeline performs the same job without requiring an
+ * authored layer.
+ */
+
+import type { Result } from '@ontrails/core';
+import { Result as ResultNs, ValidationError } from '@ontrails/core';
+import { z } from 'zod';
+
+import type { AnyTrail } from './command.js';
+
+// ---------------------------------------------------------------------------
+// Paginated-shape detection
+// ---------------------------------------------------------------------------
+
+const objectShapeOf = (schema: unknown): Record<string, unknown> | null =>
+  schema instanceof z.ZodObject
+    ? (schema.shape as Record<string, unknown>)
+    : null;
+
+/**
+ * Return true if a trail's output schema looks like a paginated response:
+ * an object with `items`, `hasMore`, and `nextCursor` declared as fields.
+ *
+ * All three fields must be present in the schema's shape. The `nextCursor`
+ * field's value can be optional or nullable, but the field itself must be
+ * declared. Extra fields beyond the canonical three are tolerated.
+ */
+export const isPaginatedOutput = (trail: AnyTrail): boolean => {
+  const fields = objectShapeOf(trail.output);
+  if (fields === null) {
+    return false;
+  }
+  return 'items' in fields && 'hasMore' in fields && 'nextCursor' in fields;
+};
+
+/**
+ * Return true if a trail's input schema declares a `cursor` field.
+ * When false, the iteration helper falls back to writing `nextCursor`
+ * onto the merged input record.
+ */
+export const inputHasCursorField = (trail: AnyTrail): boolean => {
+  const fields = objectShapeOf(trail.input);
+  if (fields === null) {
+    return false;
+  }
+  return 'cursor' in fields;
+};
+
+// ---------------------------------------------------------------------------
+// Iteration
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape we expect to see on each successful iteration. The runtime check
+ * below is permissive: we treat anything that does not match as a
+ * non-iterable result and stop after the first page.
+ */
+interface PaginatedPage {
+  readonly items: readonly unknown[];
+  readonly hasMore: boolean;
+  readonly nextCursor?: string | undefined;
+}
+
+const isPaginatedPage = (value: unknown): value is PaginatedPage => {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<PaginatedPage>;
+  return (
+    Array.isArray(candidate.items) && typeof candidate.hasMore === 'boolean'
+  );
+};
+
+/**
+ * Run a trail once for the given input and return the typed page result.
+ * Used by the iteration loop below; never invoked when `--all` is unset.
+ */
+export type RunPageOnce = (
+  input: Record<string, unknown>
+) => Promise<Result<unknown, Error>>;
+
+export interface IteratePagesOptions {
+  /**
+   * The user-merged input record before iteration begins. Each page
+   * call is `{ ...baseInput, [cursorField]: <cursor> }`.
+   */
+  readonly baseInput: Record<string, unknown>;
+  /** Field name to write the cursor onto. Defaults to `cursor`. */
+  readonly cursorField: string;
+  /** Per-page sink. When provided, items stream out as they arrive. */
+  readonly onItem?: ((item: unknown) => void) | undefined;
+  /** Run a single page. */
+  readonly runPage: RunPageOnce;
+}
+
+/**
+ * Resolve the next cursor for iteration. Returns `undefined` only when the
+ * page declares `hasMore: false`. A truthy `hasMore` without a usable cursor
+ * is a contract violation because `--all` cannot safely continue.
+ */
+const nextCursorOf = (
+  page: PaginatedPage
+): Result<string | undefined, ValidationError> => {
+  if (!page.hasMore) {
+    return ResultNs.ok();
+  }
+  if (typeof page.nextCursor === 'string' && page.nextCursor.length > 0) {
+    return ResultNs.ok(page.nextCursor);
+  }
+  return ResultNs.err(
+    new ValidationError(
+      'Paginated trail returned hasMore=true without a non-empty nextCursor; --all iteration cannot continue without silently truncating results.'
+    )
+  );
+};
+
+const buildPageInput = (
+  baseInput: Record<string, unknown>,
+  cursorField: string,
+  cursor: string | undefined
+): Record<string, unknown> => {
+  if (cursor === undefined) {
+    return baseInput;
+  }
+  return { ...baseInput, [cursorField]: cursor };
+};
+
+const initialCursorOf = (
+  baseInput: Record<string, unknown>,
+  cursorField: string
+): string | undefined => {
+  const cursor = baseInput[cursorField];
+  return typeof cursor === 'string' && cursor.length > 0 ? cursor : undefined;
+};
+
+const repeatedCursorError = (cursor: string): ValidationError =>
+  new ValidationError(
+    `Paginated trail returned repeated nextCursor ${JSON.stringify(
+      cursor
+    )}; --all iteration requires each page to advance the cursor.`
+  );
+
+/**
+ * Drain pages by repeatedly invoking `runPage` until the trail reports
+ * `hasMore === false`. Returns a Result whose ok value matches the
+ * canonical paginated shape with all collected items aggregated into
+ * a single array.
+ *
+ * If a page is reached whose value does not match the paginated shape,
+ * iteration stops and that page's value is returned verbatim — this is
+ * a safety valve for trails that drift away from the contract at runtime.
+ */
+export const iteratePages = async (
+  options: IteratePagesOptions
+): Promise<Result<unknown, Error>> => {
+  const { baseInput, cursorField, onItem, runPage } = options;
+  const aggregated: unknown[] = [];
+  const seenCursors = new Set<string>();
+  const initialCursor = initialCursorOf(baseInput, cursorField);
+  if (initialCursor !== undefined) {
+    seenCursors.add(initialCursor);
+  }
+  let cursor: string | undefined;
+
+  for (;;) {
+    const pageInput = buildPageInput(baseInput, cursorField, cursor);
+    const pageResult = await runPage(pageInput);
+    if (pageResult.isErr()) {
+      return pageResult;
+    }
+    const { value } = pageResult;
+    if (!isPaginatedPage(value)) {
+      if (onItem) {
+        onItem(value);
+        return ResultNs.ok({ hasMore: false, items: [] });
+      }
+      // Drift safety: hand the value back unchanged.
+      return ResultNs.ok(value);
+    }
+    const nextResult = nextCursorOf(value);
+    if (nextResult.isErr()) {
+      return nextResult;
+    }
+    const next = nextResult.value;
+    if (next !== undefined && seenCursors.has(next)) {
+      return ResultNs.err(repeatedCursorError(next));
+    }
+    if (onItem) {
+      for (const item of value.items) {
+        onItem(item);
+      }
+    } else {
+      for (const item of value.items) {
+        aggregated.push(item);
+      }
+    }
+    if (next === undefined) {
+      break;
+    }
+    seenCursors.add(next);
+    cursor = next;
+  }
+
+  return ResultNs.ok({ hasMore: false, items: onItem ? [] : aggregated });
+};
+
+// ---------------------------------------------------------------------------
+// Streaming sink
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a single item as one JSON line to stdout. Mirrors the JSONL
+ * shape that `output('jsonl')` would produce for an array element.
+ */
+export const writeJsonLine = (item: unknown): void => {
+  process.stdout.write(`${JSON.stringify(item)}\n`);
+};


### PR DESCRIPTION
## Summary
- Derives `--all` from paginated output schemas instead of relying on the legacy `autoIterateLayer` export.
- Aggregates paginated results in normal output mode and streams one item per line in `--jsonl` mode.
- Preserves single-call behavior unless `--all` is present.

## Details
`packages/cli/src/pagination.ts` detects the `{ items, hasMore, nextCursor }` output shape and adds the meta flag. `runPaginatedIteration` loops by cursor until `hasMore` is false; JSONL streaming marks the result context as already streamed so the on-result chain does not rewrite stdout. The legacy layer export remains until the Phase 8 removal PR.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-469.