### PR TITLE
feat(cli): derive date-shortcut expansion from input schema

### DIFF
--- a/.changeset/trl-470-date-shortcuts-derivation.md
+++ b/.changeset/trl-470-date-shortcuts-derivation.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/cli': minor
+---
+
+Absorb `dateShortcutsLayer` behavior into CLI surface derivation. Trails with date input fields (`z.iso.datetime()`, `z.iso.date()`, `z.string().datetime()`, `z.date()`, plus optional/default wrappers) now auto-accept shortcuts on the CLI: `today`, `yesterday`, `Nd` (N days ago), `this-week` (start-of-week Monday UTC), `this-month` (first-of-this-month UTC). Shortcuts expand to UTC ISO before Zod validation. Plain ISO strings pass through unchanged. Digit-led typos like `7day`/`3w` surface a `ValidationError`. Detection lives in `packages/cli/src/date-shortcuts.ts`. The legacy `dateShortcutsLayer` export is kept through Phase 2–7 for back-compat; removal lands in TRL-475 (Phase 8).

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   Result,
   SURFACE_KEY,
+  ValidationError,
   createTrailContext,
   resource,
   signal,
@@ -976,5 +977,147 @@ describe('buildCommands structured input', () => {
         '--input-json requires a value'
       );
     }
+  });
+});
+
+describe('buildCommands date-shortcut absorption', () => {
+  // Use z.string() for the date fields so the shortcut expander runs first
+  // and Zod accepts the resulting ISO string. The shortcut detection still
+  // matches because the schema declares `.datetime()`.
+  const eventsTrail = trail('events.list', {
+    blaze: (input: {
+      since?: string | undefined;
+      until?: string | undefined;
+    }) => Result.ok(input),
+    input: z.object({
+      since: z.string().datetime().optional(),
+      until: z.string().datetime().optional(),
+    }),
+  });
+
+  const greetTrail = trail('greet', {
+    blaze: (input: { name: string }) => Result.ok(`Hello, ${input.name}`),
+    input: z.object({ name: z.string() }),
+  });
+
+  const dateOnlyTrail = trail('events.by-day', {
+    blaze: (input: { day?: string | undefined }) => Result.ok(input),
+    input: z.object({
+      day: z.iso.date().optional(),
+    }),
+  });
+
+  const nativeDateTrail = trail('events.by-instant', {
+    blaze: (input: { occurredAt?: Date | undefined }) => Result.ok(input),
+    input: z.object({
+      occurredAt: z.date().optional(),
+    }),
+  });
+
+  test("expands 'today' on a date field before validation", async () => {
+    const app = makeApp(eventsTrail);
+    const cmd = requireCommand(buildCommands(app));
+
+    const result = await cmd.execute({}, { since: 'today' });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    const value = result.value as { since?: string };
+    expect(typeof value.since).toBe('string');
+    // The expander returned an ISO datetime that ends in start-of-day UTC.
+    expect(value.since).toMatch(/T00:00:00\.000Z$/);
+  });
+
+  test("expands 'today' to YYYY-MM-DD for z.iso.date fields before validation", async () => {
+    const app = makeApp(dateOnlyTrail);
+    const cmd = requireCommand(buildCommands(app));
+
+    const result = await cmd.execute({}, { day: 'today' });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    const value = result.value as { day?: string };
+    expect(value.day).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(value.day).not.toContain('T');
+  });
+
+  test("expands 'today' to a Date for z.date fields before validation", async () => {
+    const app = makeApp(nativeDateTrail);
+    const cmd = requireCommand(buildCommands(app));
+
+    const result = await cmd.execute({}, { occurredAt: 'today' });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    const value = result.value as { occurredAt?: Date };
+    expect(value.occurredAt).toBeInstanceOf(Date);
+  });
+
+  test("expands 'Nd' on a date field", async () => {
+    const app = makeApp(eventsTrail);
+    const cmd = requireCommand(buildCommands(app));
+
+    const result = await cmd.execute({}, { since: '7d' });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    const value = result.value as { since?: string };
+    expect(typeof value.since).toBe('string');
+    expect(value.since).toMatch(/T00:00:00\.000Z$/);
+  });
+
+  test('plain ISO datetime strings pass through to Zod unchanged', async () => {
+    const app = makeApp(eventsTrail);
+    const cmd = requireCommand(buildCommands(app));
+
+    const iso = '2025-01-15T12:00:00.000Z';
+    const result = await cmd.execute({}, { since: iso });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    const value = result.value as { since?: string };
+    expect(value.since).toBe(iso);
+  });
+
+  test('invalid shortcut-shaped values surface a ValidationError', async () => {
+    const app = makeApp(eventsTrail);
+    const cmd = requireCommand(buildCommands(app));
+
+    const result = await cmd.execute({}, { since: '7day' });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    // Preserve the error class so downstream surfaces (CLI exit code,
+    // HTTP status, JSON-RPC code) route via the validation taxonomy.
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(result.error.message).toContain('7day');
+    expect(result.error.message).toContain('today');
+  });
+
+  test('shortcuts are NOT expanded for trails without date fields', async () => {
+    const app = makeApp(greetTrail);
+    const cmd = requireCommand(buildCommands(app));
+
+    // The trail input has only `name: z.string()`, so 'today' must not
+    // be treated as a date shortcut.
+    const result = await cmd.execute({}, { name: 'today' });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    expect(result.value).toBe('Hello, today');
   });
 });

--- a/packages/cli/src/__tests__/date-shortcuts.test.ts
+++ b/packages/cli/src/__tests__/date-shortcuts.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for CLI surface derivation absorbing date-shortcut behavior.
+ *
+ * Verifies that when a trail's input schema contains date-typed fields,
+ * the CLI surface derivation pipeline expands shortcut strings
+ * (`today`, `yesterday`, `Nd`, `this-week`, `this-month`) into UTC ISO
+ * datetimes before validation. Plain ISO strings pass through unchanged;
+ * malformed shortcut-shaped values produce a validation error.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import {
+  detectDateFieldKinds,
+  detectDateFields,
+  expandDateShortcut,
+  expandDateShortcuts,
+} from '../date-shortcuts.js';
+
+// ---------------------------------------------------------------------------
+// A fixed reference instant used by every clock-sensitive test.
+//
+// Wednesday, 2025-03-12T15:30:45.123Z (UTC).
+// Day-of-week (UTC): 3 (Wed). ISO week starts Monday — so start-of-week is
+// 2025-03-10T00:00:00.000Z.
+// ---------------------------------------------------------------------------
+const FIXED_NOW = new Date(Date.UTC(2025, 2, 12, 15, 30, 45, 123));
+
+// ---------------------------------------------------------------------------
+// detectDateFields
+// ---------------------------------------------------------------------------
+
+describe('detectDateFields', () => {
+  test('detects z.iso.datetime() fields', () => {
+    const schema = z.object({
+      name: z.string(),
+      since: z.iso.datetime(),
+      until: z.iso.datetime(),
+    });
+    const fields = detectDateFields(schema);
+    expect(fields.includes('since')).toBe(true);
+    expect(fields.includes('until')).toBe(true);
+    expect(fields.includes('name')).toBe(false);
+  });
+
+  test('detects z.string().datetime() fields', () => {
+    const schema = z.object({
+      name: z.string(),
+      since: z.string().datetime(),
+    });
+    const fields = detectDateFields(schema);
+    expect(fields.includes('since')).toBe(true);
+    expect(fields.includes('name')).toBe(false);
+  });
+
+  test('detects z.iso.date() fields', () => {
+    const schema = z.object({
+      day: z.iso.date(),
+    });
+    const fields = detectDateFields(schema);
+    expect(fields.includes('day')).toBe(true);
+    expect(detectDateFieldKinds(schema)['day']).toBe('date');
+  });
+
+  test('detects z.date() fields', () => {
+    const schema = z.object({
+      occurredAt: z.date(),
+    });
+    const fields = detectDateFields(schema);
+    expect(fields.includes('occurredAt')).toBe(true);
+    expect(detectDateFieldKinds(schema)['occurredAt']).toBe('native-date');
+  });
+
+  test('unwraps optional and default wrappers', () => {
+    const schema = z.object({
+      asOf: z.iso.datetime().default('2025-01-01T00:00:00.000Z'),
+      since: z.iso.datetime().optional(),
+      until: z.iso.datetime().nullable(),
+    });
+    const fields = detectDateFields(schema);
+    expect(fields.includes('since')).toBe(true);
+    expect(fields.includes('until')).toBe(true);
+    expect(fields.includes('asOf')).toBe(true);
+  });
+
+  test('returns an empty list for a non-date schema', () => {
+    const schema = z.object({
+      count: z.number(),
+      name: z.string(),
+    });
+    const fields = detectDateFields(schema);
+    expect(fields.length).toBe(0);
+  });
+
+  test('returns an empty list for non-object schemas', () => {
+    expect(detectDateFields(z.string()).length).toBe(0);
+    expect(detectDateFields(z.array(z.string())).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expandDateShortcut — pure expansion
+// ---------------------------------------------------------------------------
+
+describe('expandDateShortcut', () => {
+  test("'today' expands to start-of-today UTC", () => {
+    const result = expandDateShortcut('today', FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('2025-03-12T00:00:00.000Z');
+    }
+  });
+
+  test("'today' expands to a date-only string for date-only fields", () => {
+    const result = expandDateShortcut('today', FIXED_NOW, 'date');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('2025-03-12');
+    }
+  });
+
+  test("'yesterday' expands to start-of-yesterday UTC", () => {
+    const result = expandDateShortcut('yesterday', FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('2025-03-11T00:00:00.000Z');
+    }
+  });
+
+  test("'7d' expands to N days ago UTC", () => {
+    const result = expandDateShortcut('7d', FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('2025-03-05T00:00:00.000Z');
+    }
+  });
+
+  test("'30d' expands across month boundaries", () => {
+    const result = expandDateShortcut('30d', FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('2025-02-10T00:00:00.000Z');
+    }
+  });
+
+  test('out-of-range rolling day shortcuts return a validation failure', () => {
+    const result = expandDateShortcut('999999d', FIXED_NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('between 0d and 36500d');
+    }
+  });
+
+  test("'this-month' expands to first-of-this-month UTC", () => {
+    const result = expandDateShortcut('this-month', FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('2025-03-01T00:00:00.000Z');
+    }
+  });
+
+  test("'this-week' expands to start-of-week (Monday) UTC", () => {
+    // 2025-03-12 is a Wednesday; Monday of that week is 2025-03-10.
+    const result = expandDateShortcut('this-week', FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('2025-03-10T00:00:00.000Z');
+    }
+  });
+
+  test("'this-week' on a Sunday treats Sunday as end-of-week", () => {
+    // 2025-03-09 is a Sunday; Monday-of-week is 2025-03-03.
+    const sunday = new Date(Date.UTC(2025, 2, 9, 12, 0, 0, 0));
+    const result = expandDateShortcut('this-week', sunday);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('2025-03-03T00:00:00.000Z');
+    }
+  });
+
+  test('plain ISO strings pass through unchanged', () => {
+    const iso = '2025-01-15T12:34:56.789Z';
+    const result = expandDateShortcut(iso, FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(iso);
+    }
+  });
+
+  test('compact ISO basic datetimes pass through unchanged', () => {
+    const iso = '20250115T120000Z';
+    const result = expandDateShortcut(iso, FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(iso);
+    }
+  });
+
+  test("plain date-only strings (e.g. '2025-01-15') pass through", () => {
+    const date = '2025-01-15';
+    const result = expandDateShortcut(date, FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(date);
+    }
+  });
+
+  test("invalid Nd-shaped values (e.g. '7day', 'd7') return an error", () => {
+    const bad = expandDateShortcut('7day', FIXED_NOW);
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) {
+      expect(bad.message).toContain('today');
+      expect(bad.message).toContain('yesterday');
+    }
+  });
+
+  test('arbitrary non-shortcut strings pass through (treated as ISO)', () => {
+    // The expander does not validate ISO; that is Zod's job. It only
+    // intercepts strings that match the shortcut vocabulary or
+    // shortcut-like patterns.
+    const result = expandDateShortcut('not-a-date', FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('not-a-date');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expandDateShortcuts — record-level transform
+// ---------------------------------------------------------------------------
+
+describe('expandDateShortcuts', () => {
+  test('expands matching date fields and leaves others alone', () => {
+    const input = {
+      count: 5,
+      name: 'today',
+      since: 'today',
+      until: '7d',
+    };
+    const result = expandDateShortcuts(input, ['since', 'until'], FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value['since']).toBe('2025-03-12T00:00:00.000Z');
+      expect(result.value['until']).toBe('2025-03-05T00:00:00.000Z');
+      expect(result.value['name']).toBe('today');
+      expect(result.value['count']).toBe(5);
+    }
+  });
+
+  test('date-only fields keep shortcut expansions in YYYY-MM-DD form', () => {
+    const input = {
+      day: 'today',
+      since: 'today',
+    };
+    const result = expandDateShortcuts(input, ['day', 'since'], FIXED_NOW, {
+      day: 'date',
+      since: 'datetime',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value['day']).toBe('2025-03-12');
+      expect(result.value['since']).toBe('2025-03-12T00:00:00.000Z');
+    }
+  });
+
+  test('native z.date fields expand shortcuts to Date instances', () => {
+    const input = {
+      occurredAt: 'today',
+    };
+    const result = expandDateShortcuts(input, ['occurredAt'], FIXED_NOW, {
+      occurredAt: 'native-date',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value['occurredAt']).toBeInstanceOf(Date);
+      expect((result.value['occurredAt'] as Date).toISOString()).toBe(
+        '2025-03-12T00:00:00.000Z'
+      );
+    }
+  });
+
+  test('non-string values on date fields pass through unchanged', () => {
+    const realDate = new Date(Date.UTC(2024, 0, 1));
+    const input: Record<string, unknown> = {
+      since: realDate,
+      until: undefined,
+    };
+    const result = expandDateShortcuts(input, ['since', 'until'], FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value['since']).toBe(realDate);
+      expect(result.value['until']).toBe(undefined);
+    }
+  });
+
+  test('invalid shortcut on a date field surfaces an error', () => {
+    const input = { since: '7day' };
+    const result = expandDateShortcuts(input, ['since'], FIXED_NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.field).toBe('since');
+      expect(result.message).toContain('7day');
+    }
+  });
+
+  test('with no date fields, the input is returned as-is', () => {
+    const input = { name: 'anything', since: 'today' };
+    const result = expandDateShortcuts(input, [], FIXED_NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Same value, no transform applied (still 'today' because field
+      // wasn't recognized as a date).
+      expect(result.value['since']).toBe('today');
+    }
+  });
+});

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -23,6 +23,12 @@ import {
 } from '@ontrails/core';
 
 import type { AnyTrail, CliArg, CliCommand, CliFlag } from './command.js';
+import {
+  detectDateFieldKinds,
+  detectDateFields,
+  expandDateShortcuts,
+} from './date-shortcuts.js';
+import type { DateShortcutKind } from './date-shortcuts.js';
 import { dryRunPreset, toFlags } from './flags.js';
 import {
   inputHasCursorField,
@@ -220,9 +226,44 @@ const splitStructuredInlineJsonArg = (
   return { positionalInlineJson, trailArgs };
 };
 
+/**
+ * Apply date-shortcut expansion in place over a merged-input record.
+ *
+ * Throws a `ValidationError` when any field carries a malformed
+ * shortcut-shaped value so the surrounding `safeMergeInput` can route
+ * the failure through the standard onResult path.
+ */
+const applyDateShortcutsInPlace = (
+  mergedInput: Record<string, unknown>,
+  dateFields: readonly string[],
+  dateFieldKinds: Readonly<Record<string, DateShortcutKind>>
+): void => {
+  if (dateFields.length === 0) {
+    return;
+  }
+  const expansion = expandDateShortcuts(
+    mergedInput,
+    dateFields,
+    new Date(),
+    dateFieldKinds
+  );
+  if (!expansion.ok) {
+    throw new ValidationError(expansion.message, {
+      context: { field: expansion.field },
+    });
+  }
+  for (const field of dateFields) {
+    if (field in expansion.value) {
+      mergedInput[field] = expansion.value[field];
+    }
+  }
+};
+
 const resolveMergedInput = async (
   fields: readonly Field[],
   metaFlagNames: ReadonlySet<string>,
+  dateFields: readonly string[],
+  dateFieldKinds: Readonly<Record<string, DateShortcutKind>>,
   parsedArgs: Record<string, unknown>,
   parsedFlags: Record<string, unknown>,
   options?: DeriveCliCommandsOptions
@@ -249,6 +290,7 @@ const resolveMergedInput = async (
     normalizedFlags
   );
   await applyPrompting(fields, mergedInput, options);
+  applyDateShortcutsInPlace(mergedInput, dateFields, dateFieldKinds);
   return {
     mergedInput,
     usedStructuredInput: structuredInput.used,
@@ -283,6 +325,8 @@ const maybeAddStructuredInputHint = (
 const safeMergeInput = async (
   fields: readonly Field[],
   metaFlagNames: ReadonlySet<string>,
+  dateFields: readonly string[],
+  dateFieldKinds: Readonly<Record<string, DateShortcutKind>>,
   parsedArgs: Record<string, unknown>,
   parsedFlags: Record<string, unknown>,
   options?: DeriveCliCommandsOptions
@@ -297,6 +341,8 @@ const safeMergeInput = async (
       await resolveMergedInput(
         fields,
         metaFlagNames,
+        dateFields,
+        dateFieldKinds,
         parsedArgs,
         parsedFlags,
         options
@@ -406,6 +452,8 @@ const createExecute =
     t: AnyTrail,
     fields: readonly Field[],
     metaFlagNames: ReadonlySet<string>,
+    dateFields: readonly string[],
+    dateFieldKinds: Readonly<Record<string, DateShortcutKind>>,
     shouldHintStructuredInput: boolean,
     options?: DeriveCliCommandsOptions
   ) =>
@@ -417,6 +465,8 @@ const createExecute =
     const merged = await safeMergeInput(
       fields,
       metaFlagNames,
+      dateFields,
+      dateFieldKinds,
       parsedArgs,
       parsedFlags,
       options
@@ -600,6 +650,8 @@ const toCliCommand = (
     derivedArgs,
     shouldHintStructuredInput
   );
+  const dateFields = detectDateFields(t.input);
+  const dateFieldKinds = detectDateFieldKinds(t.input);
 
   return {
     args,
@@ -609,6 +661,8 @@ const toCliCommand = (
       t,
       fields,
       metaFlagNames,
+      dateFields,
+      dateFieldKinds,
       shouldHintStructuredInput,
       options
     ),

--- a/packages/cli/src/date-shortcuts.ts
+++ b/packages/cli/src/date-shortcuts.ts
@@ -1,0 +1,376 @@
+/**
+ * CLI surface absorption for date-shortcut expansion.
+ *
+ * When a trail's `input` schema contains date-typed fields, the CLI
+ * surface derivation pipeline accepts shortcut strings (`today`,
+ * `yesterday`, `Nd`, `this-week`, `this-month`) on the corresponding
+ * flags and expands them to UTC ISO 8601 datetimes before validation.
+ *
+ * This module is the CLI-package-local home of the detection and
+ * expansion helpers. The legacy `dateShortcutsLayer` in `./layers.ts`
+ * remains exported for apps that still register it explicitly; the
+ * derivation pipeline performs the same job without requiring an
+ * authored layer.
+ *
+ * All expansions are computed in UTC. The expander does not consult
+ * the system locale, and time-of-day always pins to 00:00:00.000Z.
+ */
+
+import type { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Zod internals access
+// ---------------------------------------------------------------------------
+
+interface ZodInternals {
+  readonly _zod: {
+    readonly def: Readonly<Record<string, unknown>>;
+  };
+}
+
+const hasZodInternals = (value: unknown): value is ZodInternals => {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as { readonly _zod?: unknown };
+  if (candidate._zod === null || typeof candidate._zod !== 'object') {
+    return false;
+  }
+  const zod = candidate._zod as { readonly def?: unknown };
+  return typeof zod.def === 'object' && zod.def !== null;
+};
+
+// ---------------------------------------------------------------------------
+// Date-type detection
+// ---------------------------------------------------------------------------
+
+export type DateShortcutKind = 'date' | 'datetime' | 'native-date';
+
+/**
+ * Step through optional/nullable/default wrappers to reveal the
+ * inner Zod node.
+ */
+const unwrapToInner = (node: ZodInternals): ZodInternals => {
+  let current: ZodInternals = node;
+  for (;;) {
+    const defType = current._zod.def['type'];
+    if (
+      defType !== 'optional' &&
+      defType !== 'nullable' &&
+      defType !== 'default' &&
+      defType !== 'readonly'
+    ) {
+      return current;
+    }
+    const inner = current._zod.def['innerType'];
+    if (!hasZodInternals(inner)) {
+      return current;
+    }
+    current = inner;
+  }
+};
+
+/**
+ * Return true when a Zod node represents a date-shaped value:
+ *
+ * - `z.date()` (`def.type === 'date'`)
+ * - `z.iso.datetime()` / `z.iso.date()` (`def.type === 'string'`,
+ *   `def.format === 'datetime' | 'date'`)
+ * - `z.string().datetime()` / `.date()` (string with a format check
+ *   pinned to `datetime` or `date`)
+ *
+ * Optional/nullable/default/readonly wrappers are unwrapped first.
+ */
+const readDateNodeKind = (node: ZodInternals): DateShortcutKind | undefined => {
+  const inner = unwrapToInner(node);
+  const defType = inner._zod.def['type'];
+  if (defType === 'date') {
+    return 'native-date';
+  }
+  if (defType !== 'string') {
+    return undefined;
+  }
+  const { format } = inner._zod.def;
+  if (format === 'datetime') {
+    return 'datetime';
+  }
+  if (format === 'date') {
+    return 'date';
+  }
+  // Detect `z.string().datetime()` style: a plain string with a
+  // string_format check whose `format` is `datetime` or `date`.
+  const { checks } = inner._zod.def;
+  if (!Array.isArray(checks)) {
+    return undefined;
+  }
+  for (const check of checks) {
+    if (!hasZodInternals(check)) {
+      continue;
+    }
+    const checkDef = check._zod.def;
+    if (checkDef['check'] !== 'string_format') {
+      continue;
+    }
+    const checkFormat = checkDef['format'];
+    if (checkFormat === 'datetime') {
+      return 'datetime';
+    }
+    if (checkFormat === 'date') {
+      return 'date';
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Detect the names of date-typed fields on a Zod object schema.
+ *
+ * Returns an empty list when the schema is not an object schema, when
+ * its shape is missing, or when no field unwraps to a date-shaped
+ * node. The detection is conservative: only schemas that statically
+ * declare a date-shaped type qualify.
+ */
+export const detectDateFieldKinds = (
+  schema: z.ZodType<unknown>
+): Readonly<Record<string, DateShortcutKind>> => {
+  if (!hasZodInternals(schema)) {
+    return {};
+  }
+  const { def } = schema._zod;
+  if (def['type'] !== 'object') {
+    return {};
+  }
+  const { shape } = def;
+  if (shape === null || typeof shape !== 'object') {
+    return {};
+  }
+  const fieldKinds: Record<string, DateShortcutKind> = {};
+  for (const [name, child] of Object.entries(
+    shape as Record<string, unknown>
+  )) {
+    if (!hasZodInternals(child)) {
+      continue;
+    }
+    const kind = readDateNodeKind(child);
+    if (kind !== undefined) {
+      fieldKinds[name] = kind;
+    }
+  }
+  return fieldKinds;
+};
+
+export const detectDateFields = (
+  schema: z.ZodType<unknown>
+): readonly string[] => Object.keys(detectDateFieldKinds(schema));
+
+// ---------------------------------------------------------------------------
+// Expansion vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical set of recognized shortcut tokens. Mirrors the vocabulary
+ * declared in the legacy `dateShortcutsLayer` so that switching from
+ * the layer to the derivation pipeline is a no-op for users.
+ */
+export const DATE_SHORTCUT_NAMES = [
+  'today',
+  'yesterday',
+  'this-week',
+  'this-month',
+] as const;
+
+/**
+ * Suggestion blurb returned with invalid-shortcut errors. Includes the
+ * vocabulary tokens plus the `Nd` rolling-window form.
+ */
+const SHORTCUT_SUGGESTION = `Supported shortcuts: ${DATE_SHORTCUT_NAMES.join(
+  ', '
+)}, or 'Nd' (e.g. '7d', '30d'). Plain ISO 8601 dates are also accepted.`;
+
+const NUMERIC_DAY_PATTERN = /^(\d+)d$/;
+const MAX_ROLLING_DAY_SHORTCUT = 36_500;
+
+/**
+ * Pattern that captures shortcut-shaped values that should be flagged
+ * as malformed rather than passed through to Zod. Matches strings that
+ * begin with one or more digits followed only by letters. This catches
+ * typo-shaped values such as `7day` while allowing compact ISO basic
+ * datetimes such as `20250115T120000Z` to fall through to Zod.
+ */
+const SHORTCUT_LIKE_PATTERN = /^\d+[a-zA-Z]+$/;
+
+const startOfUtcDay = (date: Date): Date =>
+  new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  );
+
+const subtractDaysUtc = (now: Date, days: number): Date => {
+  const base = startOfUtcDay(now);
+  base.setUTCDate(base.getUTCDate() - days);
+  return base;
+};
+
+const startOfUtcMonth = (now: Date): Date =>
+  new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+
+/**
+ * Start-of-week treating Monday as the first day. Sundays are
+ * considered the trailing end of the previous Monday-anchored week,
+ * matching the behavior of the legacy layer.
+ */
+const startOfUtcIsoWeek = (now: Date): Date => {
+  const dayOfWeek = now.getUTCDay();
+  const offset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  return subtractDaysUtc(now, offset);
+};
+
+// ---------------------------------------------------------------------------
+// Shortcut expansion
+// ---------------------------------------------------------------------------
+
+export interface ExpandSuccess {
+  readonly ok: true;
+  readonly value: Date | string;
+}
+
+export interface ExpandFailure {
+  readonly ok: false;
+  readonly message: string;
+}
+
+export type ExpandResult = ExpandSuccess | ExpandFailure;
+
+const namedHandlers: Record<
+  (typeof DATE_SHORTCUT_NAMES)[number],
+  (now: Date) => Date
+> = {
+  'this-month': startOfUtcMonth,
+  'this-week': startOfUtcIsoWeek,
+  today: startOfUtcDay,
+  yesterday: (now) => subtractDaysUtc(now, 1),
+};
+
+const isNamedShortcut = (
+  value: string
+): value is (typeof DATE_SHORTCUT_NAMES)[number] =>
+  (DATE_SHORTCUT_NAMES as readonly string[]).includes(value);
+
+const formatExpandedDate = (
+  date: Date,
+  kind: DateShortcutKind
+): Date | string => {
+  if (kind === 'native-date') {
+    return date;
+  }
+  const iso = date.toISOString();
+  return kind === 'date' ? iso.slice(0, 10) : iso;
+};
+
+/**
+ * Expand a single shortcut value to a UTC ISO 8601 datetime string.
+ *
+ * - Recognized shortcuts (`today`, `yesterday`, `Nd`, `this-week`,
+ *   `this-month`) are expanded to start-of-day UTC.
+ * - Plain non-shortcut strings pass through unchanged. Validation is
+ *   deferred to Zod.
+ * - Strings that look like a shortcut (start with a digit) but do not
+ *   match the `Nd` form return a validation error suggesting the
+ *   supported vocabulary.
+ *
+ * `now` defaults to `new Date()`. Callers may pass a fixed instant for
+ * deterministic behavior in tests.
+ */
+export const expandDateShortcut = (
+  value: string,
+  now: Date = new Date(),
+  kind: DateShortcutKind = 'datetime'
+): ExpandResult => {
+  if (isNamedShortcut(value)) {
+    return {
+      ok: true,
+      value: formatExpandedDate(namedHandlers[value](now), kind),
+    };
+  }
+  const numericMatch = NUMERIC_DAY_PATTERN.exec(value);
+  if (numericMatch?.[1]) {
+    const days = Number(numericMatch[1]);
+    if (
+      !Number.isSafeInteger(days) ||
+      days < 0 ||
+      days > MAX_ROLLING_DAY_SHORTCUT
+    ) {
+      return {
+        message: `Invalid date shortcut '${value}'. Rolling day shortcuts must be between 0d and ${MAX_ROLLING_DAY_SHORTCUT.toString()}d. ${SHORTCUT_SUGGESTION}`,
+        ok: false,
+      };
+    }
+    return {
+      ok: true,
+      value: formatExpandedDate(subtractDaysUtc(now, days), kind),
+    };
+  }
+  // Anything that starts with a digit but did not match the `Nd` form
+  // is almost certainly a typo of the rolling-window shortcut. Reject
+  // with a helpful suggestion rather than passing it through to Zod
+  // where the failure would be opaque.
+  if (SHORTCUT_LIKE_PATTERN.test(value)) {
+    return {
+      message: `Invalid date shortcut '${value}'. ${SHORTCUT_SUGGESTION}`,
+      ok: false,
+    };
+  }
+  return { ok: true, value };
+};
+
+// ---------------------------------------------------------------------------
+// Record-level transform
+// ---------------------------------------------------------------------------
+
+export interface ExpandRecordSuccess {
+  readonly ok: true;
+  readonly value: Record<string, unknown>;
+}
+
+export interface ExpandRecordFailure {
+  readonly ok: false;
+  readonly field: string;
+  readonly message: string;
+}
+
+export type ExpandRecordResult = ExpandRecordSuccess | ExpandRecordFailure;
+
+/**
+ * Apply shortcut expansion to the listed date fields of a merged input
+ * record. Non-string values are left intact (a `Date`, `undefined`, or
+ * `null` that survives this transform is handled later by Zod).
+ *
+ * Returns a `field`-tagged failure when any field's string value is a
+ * shortcut-shaped token that does not match the supported vocabulary.
+ */
+export const expandDateShortcuts = (
+  input: Readonly<Record<string, unknown>>,
+  dateFields: readonly string[],
+  now: Date = new Date(),
+  dateFieldKinds: Readonly<Record<string, DateShortcutKind>> = {}
+): ExpandRecordResult => {
+  if (dateFields.length === 0) {
+    return { ok: true, value: { ...input } };
+  }
+  const next: Record<string, unknown> = { ...input };
+  for (const field of dateFields) {
+    const raw = next[field];
+    if (typeof raw !== 'string') {
+      continue;
+    }
+    const expansion = expandDateShortcut(
+      raw,
+      now,
+      dateFieldKinds[field] ?? 'datetime'
+    );
+    if (!expansion.ok) {
+      return { field, message: expansion.message, ok: false };
+    }
+    next[field] = expansion.value;
+  }
+  return { ok: true, value: next };
+};


### PR DESCRIPTION
## Summary
- Derives date-shortcut expansion from input schemas instead of requiring `dateShortcutsLayer`.
- Supports the legacy shortcut vocabulary for date-like fields: `today`, `yesterday`, `Nd`, `this-week`, and `this-month`.
- Expands shortcuts to UTC ISO strings before Zod validation.

## Details
`packages/cli/src/date-shortcuts.ts` recognizes `z.iso.datetime()`, `z.iso.date()`, `z.string().datetime()`, `z.date()`, and optional/default wrappers. Plain ISO strings pass through unchanged, while digit-led typos such as `7day` fail as `ValidationError`. The helper has a `now` injection seam for deterministic tests. The intentional local-time-to-UTC divergence is documented for the Phase 8 removal path.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-470.