### PR TITLE
feat(observe): add renderTraceTree post-execution tree renderer

### DIFF
--- a/.changeset/trl-411-trace-tree-renderer.md
+++ b/.changeset/trl-411-trace-tree-renderer.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/observe': minor
+---
+
+Add `renderTraceTree(records: readonly TraceRecord[]): string` — a pure post-execution renderer that builds a readable execution tree from `TraceRecord` entries. Renders root spans with `●`, children with `├──`/`└──`, status glyphs (`✓`/`✗`/`⊘`), durations, and parallel-branch detection (overlapping siblings render as a bracketed group with wall-vs-total summary). Tolerates forward-compatible record shapes (signal/activation kinds, `attrs.layer` from upcoming layer composition) without crashing — unknown kinds fall through to a generic span renderer. No live streaming; the tree is drawn once after the trail completes.

--- a/packages/observe/src/__tests__/renderer.test.ts
+++ b/packages/observe/src/__tests__/renderer.test.ts
@@ -1,0 +1,477 @@
+import { describe, expect, test } from 'bun:test';
+import type { TraceRecord } from '@ontrails/observe';
+import { renderTraceTree } from '../renderer.js';
+
+interface RecordOverrides {
+  readonly id: string;
+  readonly parentId?: string;
+  readonly kind?: TraceRecord['kind'];
+  readonly name: string;
+  readonly startedAt: number;
+  readonly endedAt?: number;
+  readonly status?: TraceRecord['status'];
+  readonly errorCategory?: string;
+  readonly attrs?: Record<string, unknown>;
+  readonly trailId?: string;
+}
+
+const TRACE_ID = 'trace-1';
+
+const makeRecord = (input: RecordOverrides): TraceRecord => {
+  const record: TraceRecord = {
+    attrs: input.attrs ?? {},
+    endedAt: input.endedAt,
+    errorCategory: input.errorCategory,
+    id: input.id,
+    kind: input.kind ?? 'span',
+    name: input.name,
+    parentId: input.parentId,
+    rootId: input.id === 'root' ? input.id : 'root',
+    startedAt: input.startedAt,
+    status: input.status ?? 'ok',
+    traceId: TRACE_ID,
+    trailId: input.trailId,
+  };
+  return record;
+};
+
+describe('renderTraceTree', () => {
+  describe('edge cases', () => {
+    test('returns empty string for empty input', () => {
+      expect(renderTraceTree([])).toBe('');
+    });
+
+    test('renders a single span without children', () => {
+      const records = [
+        makeRecord({
+          endedAt: 50,
+          id: 'root',
+          kind: 'trail',
+          name: 'solo.task',
+          startedAt: 0,
+        }),
+      ];
+      const out = renderTraceTree(records);
+      expect(out).toBe(['● solo.task', '  └─ ✓ 50ms'].join('\n'));
+    });
+  });
+
+  describe('basic tree shapes', () => {
+    test('renders a trail with a single child crossing', () => {
+      const records = [
+        makeRecord({
+          endedAt: 100,
+          id: 'root',
+          kind: 'trail',
+          name: 'booking.confirm',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 45,
+          id: 'a',
+          kind: 'trail',
+          name: 'availability.reserve',
+          parentId: 'root',
+          startedAt: 5,
+        }),
+      ];
+      const out = renderTraceTree(records);
+      expect(out).toContain('● booking.confirm');
+      expect(out).toContain('└── availability.reserve');
+      expect(out).toContain('✓ 40ms');
+      expect(out).toContain('└─ ✓ 100ms');
+    });
+
+    test('renders multiple children with branch prefixes', () => {
+      const records = [
+        makeRecord({
+          endedAt: 200,
+          id: 'root',
+          kind: 'trail',
+          name: 'pipeline.run',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 50,
+          id: 'a',
+          name: 'step.one',
+          parentId: 'root',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 150,
+          id: 'b',
+          name: 'step.two',
+          parentId: 'root',
+          startedAt: 60,
+        }),
+      ];
+      const out = renderTraceTree(records);
+      const lines = out.split('\n');
+      const hasMidBranch = lines.some((line) => line.includes('├── step.one'));
+      const hasLastBranch = lines.some((line) => line.includes('└── step.two'));
+      expect(hasMidBranch).toBe(true);
+      expect(hasLastBranch).toBe(true);
+    });
+
+    test('orders children by startedAt deterministically', () => {
+      const records = [
+        makeRecord({
+          endedAt: 200,
+          id: 'root',
+          kind: 'trail',
+          name: 'sort.test',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 60,
+          id: 'late',
+          name: 'started.late',
+          parentId: 'root',
+          startedAt: 50,
+        }),
+        makeRecord({
+          endedAt: 20,
+          id: 'early',
+          name: 'started.early',
+          parentId: 'root',
+          startedAt: 10,
+        }),
+      ];
+      const out = renderTraceTree(records);
+      const earlyIndex = out.indexOf('started.early');
+      const lateIndex = out.indexOf('started.late');
+      expect(earlyIndex).toBeGreaterThan(-1);
+      expect(lateIndex).toBeGreaterThan(earlyIndex);
+    });
+  });
+
+  describe('status rendering', () => {
+    test('renders an err child with category and glyph', () => {
+      const records = [
+        makeRecord({
+          endedAt: 200,
+          id: 'root',
+          kind: 'trail',
+          name: 'booking.confirm',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 90,
+          errorCategory: 'ConflictError',
+          id: 'fail',
+          name: 'billing.charge',
+          parentId: 'root',
+          startedAt: 0,
+          status: 'err',
+        }),
+      ];
+      const out = renderTraceTree(records);
+      expect(out).toContain('✗ ConflictError');
+      expect(out).toContain('(90ms)');
+    });
+
+    test('renders cancelled status with the cancelled glyph', () => {
+      const records = [
+        makeRecord({
+          endedAt: 50,
+          id: 'root',
+          kind: 'trail',
+          name: 'cancel.test',
+          startedAt: 0,
+          status: 'cancelled',
+        }),
+      ];
+      const out = renderTraceTree(records);
+      expect(out).toContain('⊘ 50ms');
+    });
+  });
+
+  describe('parallel branches', () => {
+    test('detects overlapping siblings and brackets them', () => {
+      const records = [
+        makeRecord({
+          endedAt: 200,
+          id: 'root',
+          kind: 'trail',
+          name: 'fanout',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 150,
+          id: 'a',
+          name: 'notify.email',
+          parentId: 'root',
+          startedAt: 10,
+        }),
+        makeRecord({
+          endedAt: 180,
+          id: 'b',
+          name: 'notify.sms',
+          parentId: 'root',
+          startedAt: 12,
+        }),
+        makeRecord({
+          endedAt: 130,
+          id: 'c',
+          name: 'notify.push',
+          parentId: 'root',
+          startedAt: 15,
+        }),
+      ];
+      const out = renderTraceTree(records);
+      // Bracketed group uses ┌ / ├ / └ for the parallel siblings.
+      expect(out).toContain('┌ notify.email');
+      expect(out).toContain('├ notify.sms');
+      expect(out).toContain('└ notify.push');
+      // Summary line for parallel wall vs total.
+      expect(out).toMatch(/parallel: \d+ms wall, \d+ms total/);
+    });
+
+    test('does not bracket non-overlapping siblings', () => {
+      const records = [
+        makeRecord({
+          endedAt: 200,
+          id: 'root',
+          kind: 'trail',
+          name: 'serial',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 50,
+          id: 'a',
+          name: 'step.one',
+          parentId: 'root',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 150,
+          id: 'b',
+          name: 'step.two',
+          parentId: 'root',
+          startedAt: 60,
+        }),
+      ];
+      const out = renderTraceTree(records);
+      expect(out).not.toContain('parallel:');
+      expect(out).toContain('├── step.one');
+      expect(out).toContain('└── step.two');
+    });
+
+    test('keeps a parallel run open while later siblings overlap an earlier member', () => {
+      const records = [
+        makeRecord({
+          endedAt: 200,
+          id: 'root',
+          kind: 'trail',
+          name: 'fanout',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 150,
+          id: 'long',
+          name: 'notify.long',
+          parentId: 'root',
+          startedAt: 10,
+        }),
+        makeRecord({
+          endedAt: 40,
+          id: 'short-a',
+          name: 'notify.short-a',
+          parentId: 'root',
+          startedAt: 20,
+        }),
+        makeRecord({
+          endedAt: 80,
+          id: 'short-b',
+          name: 'notify.short-b',
+          parentId: 'root',
+          startedAt: 60,
+        }),
+      ];
+      const out = renderTraceTree(records);
+
+      expect(out).toContain('┌ notify.long');
+      expect(out).toContain('├ notify.short-a');
+      expect(out).toContain('└ notify.short-b');
+    });
+
+    test('renders descendants below members of a parallel group', () => {
+      const records = [
+        makeRecord({
+          endedAt: 200,
+          id: 'root',
+          kind: 'trail',
+          name: 'fanout',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 150,
+          id: 'a',
+          name: 'notify.email',
+          parentId: 'root',
+          startedAt: 10,
+        }),
+        makeRecord({
+          endedAt: 180,
+          id: 'b',
+          name: 'notify.sms',
+          parentId: 'root',
+          startedAt: 12,
+        }),
+        makeRecord({
+          endedAt: 70,
+          id: 'a-child',
+          name: 'email.template',
+          parentId: 'a',
+          startedAt: 30,
+        }),
+      ];
+      const out = renderTraceTree(records);
+
+      expect(out).toContain('notify.email');
+      expect(out).toContain('email.template');
+      expect(out).toContain('notify.sms');
+    });
+  });
+
+  describe('nesting', () => {
+    test('renders a 3-level deeply nested tree', () => {
+      const records = [
+        makeRecord({
+          endedAt: 300,
+          id: 'root',
+          kind: 'trail',
+          name: 'level0',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 250,
+          id: 'l1',
+          kind: 'trail',
+          name: 'level1',
+          parentId: 'root',
+          startedAt: 10,
+        }),
+        makeRecord({
+          endedAt: 200,
+          id: 'l2',
+          kind: 'trail',
+          name: 'level2',
+          parentId: 'l1',
+          startedAt: 20,
+        }),
+      ];
+      const out = renderTraceTree(records);
+      expect(out).toContain('level0');
+      expect(out).toContain('level1');
+      expect(out).toContain('level2');
+      // Continuation prefix for last child should preserve indent for grandchild.
+      const lines = out.split('\n');
+      const level2Line = lines.find((line) => line.includes('level2'));
+      expect(level2Line).toBeDefined();
+      // Last-child path means leading prefix uses spaces, not pipe.
+      expect(level2Line).not.toMatch(/^│/);
+    });
+  });
+
+  describe('multiple roots', () => {
+    test('renders independent root trails as separate trees joined by a blank line', () => {
+      const records = [
+        makeRecord({
+          endedAt: 100,
+          id: 'root',
+          kind: 'trail',
+          name: 'first.trail',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 200,
+          id: 'root2',
+          kind: 'trail',
+          name: 'second.trail',
+          startedAt: 50,
+        }),
+      ];
+      // root2 has no parent, but rootId points at itself.
+      const adjusted = records.map((record) =>
+        record.id === 'root2' ? { ...record, rootId: 'root2' } : record
+      );
+      const out = renderTraceTree(adjusted);
+      expect(out).toContain('first.trail');
+      expect(out).toContain('second.trail');
+      expect(out).toContain('\n\n');
+    });
+  });
+
+  describe('forward compatibility', () => {
+    test('renders a span carrying a layer attr without crashing', () => {
+      const records = [
+        makeRecord({
+          endedAt: 60,
+          id: 'root',
+          kind: 'trail',
+          name: 'with.layer',
+          startedAt: 0,
+        }),
+        makeRecord({
+          attrs: { layer: 'audit' },
+          endedAt: 30,
+          id: 'layer',
+          kind: 'span',
+          name: 'layer.audit',
+          parentId: 'root',
+          startedAt: 5,
+        }),
+      ];
+      const out = renderTraceTree(records);
+      expect(out).toContain('layer.audit');
+      expect(out).toContain('with.layer');
+    });
+
+    test('renders signal kind without crashing', () => {
+      const records = [
+        makeRecord({
+          endedAt: 60,
+          id: 'root',
+          kind: 'trail',
+          name: 'host',
+          startedAt: 0,
+        }),
+        makeRecord({
+          attrs: { emit: true },
+          endedAt: 30,
+          id: 'sig',
+          kind: 'signal',
+          name: 'booking.confirmed',
+          parentId: 'root',
+          startedAt: 5,
+        }),
+      ];
+      const out = renderTraceTree(records);
+      expect(out).toContain('booking.confirmed');
+    });
+
+    test('renders activation kind without crashing', () => {
+      const records = [
+        makeRecord({
+          endedAt: 60,
+          id: 'root',
+          kind: 'trail',
+          name: 'host',
+          startedAt: 0,
+        }),
+        makeRecord({
+          endedAt: 30,
+          id: 'act',
+          kind: 'activation',
+          name: 'activation.scheduled',
+          parentId: 'root',
+          startedAt: 5,
+        }),
+      ];
+      const out = renderTraceTree(records);
+      expect(out).toContain('activation.scheduled');
+    });
+  });
+});

--- a/packages/observe/src/index.ts
+++ b/packages/observe/src/index.ts
@@ -10,6 +10,7 @@
 export { combine } from './combine.js';
 export { createJsonFormatter, createPrettyFormatter } from './formatters.js';
 export { createBoundedMemorySink, createMemorySink } from './memory.js';
+export { renderTraceTree } from './renderer.js';
 export { createConsoleSink, createFileSink } from './sinks.js';
 export type { CombinedSink } from './combine.js';
 export type { PrettyFormatterOptions } from './formatters.js';

--- a/packages/observe/src/renderer.ts
+++ b/packages/observe/src/renderer.ts
@@ -1,0 +1,374 @@
+/**
+ * Post-execution trace tree renderer.
+ *
+ * Pure projection of a flat `TraceRecord[]` into a multi-line string suitable
+ * for stderr. The renderer is intentionally side-effect free: callers (such as
+ * the CLI's `--trace` flag) own the actual write to stderr. Live streaming is
+ * deferred per ADR-0028; this renderer assumes the records are complete.
+ *
+ * The output mirrors the sample in the direct-invocation draft ADR
+ * (`docs/adr/drafts/20260331-direct-invocation.md`):
+ *
+ * ```
+ * ● booking.confirm
+ *   ├── availability.reserve
+ *   │   └─ ✓ 45ms
+ *   ├── billing.charge
+ *   │   └─ ✗ ConflictError (90ms)
+ *   └─ ✓ 380ms
+ * ```
+ *
+ * Status glyphs:
+ *   - `✓` ok
+ *   - `✗` err (with error category)
+ *   - `⊘` cancelled
+ *
+ * Parallel siblings (overlapping `[startedAt, endedAt]` intervals) are
+ * bracketed with `┌` / `├` / `└` and followed by a parallel summary line.
+ *
+ * @see {@link https://github.com/outfitter-dev/trails/blob/main/docs/adr/drafts/20260331-direct-invocation.md | Direct Invocation draft ADR}
+ */
+
+import type { TraceRecord } from '@ontrails/core';
+
+/** Glyph used to mark the root of a rendered tree. */
+const ROOT_GLYPH = '●';
+
+/** Status glyph for an `ok` outcome. */
+const OK_GLYPH = '✓';
+
+/** Status glyph for an `err` outcome. */
+const ERR_GLYPH = '✗';
+
+/** Status glyph for a `cancelled` outcome. */
+const CANCELLED_GLYPH = '⊘';
+
+/** Branch prefix for a non-last child in a regular (non-parallel) group. */
+const BRANCH_MID = '├── ';
+
+/** Branch prefix for the last child in a regular (non-parallel) group. */
+const BRANCH_LAST = '└── ';
+
+/** Continuation prefix for descendants under a non-last child. */
+const CONTINUATION_MID = '│   ';
+
+/** Continuation prefix for descendants under the last child. */
+const CONTINUATION_LAST = '    ';
+
+/** Prefix for a parallel-group leader. */
+const PARALLEL_FIRST = '┌ ';
+
+/** Prefix for a middle entry in a parallel group. */
+const PARALLEL_MID = '├ ';
+
+/** Prefix for the final entry in a parallel group. */
+const PARALLEL_LAST = '└ ';
+
+interface ChildBlockArgs {
+  readonly children: readonly TraceRecord[];
+  readonly childrenByParent: ReadonlyMap<string, readonly TraceRecord[]>;
+  readonly indent: string;
+  readonly lines: string[];
+}
+
+interface GroupArgs extends ChildBlockArgs {
+  readonly group: readonly TraceRecord[];
+  readonly isLastGroup: boolean;
+  readonly renderDescendants: (
+    child: TraceRecord,
+    continuation: string
+  ) => void;
+}
+
+interface ParallelRun {
+  readonly kind: 'parallel' | 'serial';
+  readonly records: readonly TraceRecord[];
+}
+
+const durationOf = (record: TraceRecord): number => {
+  if (record.endedAt === undefined) {
+    return 0;
+  }
+  return Math.max(0, record.endedAt - record.startedAt);
+};
+
+const computeWallTime = (records: readonly TraceRecord[]): number => {
+  if (records.length === 0) {
+    return 0;
+  }
+  let earliest = Number.POSITIVE_INFINITY;
+  let latest = 0;
+  for (const record of records) {
+    if (record.startedAt < earliest) {
+      earliest = record.startedAt;
+    }
+    const end = record.endedAt ?? record.startedAt;
+    if (end > latest) {
+      latest = end;
+    }
+  }
+  return Math.max(0, latest - earliest);
+};
+
+const computeTotalTime = (records: readonly TraceRecord[]): number => {
+  let total = 0;
+  for (const record of records) {
+    total += durationOf(record);
+  }
+  return total;
+};
+
+const decorationForKind = (record: TraceRecord): string => {
+  switch (record.kind) {
+    case 'signal': {
+      return record.attrs['emit'] === true ? '↑ ' : '';
+    }
+    case 'activation': {
+      return '→ ';
+    }
+    case 'span':
+    case 'trail': {
+      return '';
+    }
+    default: {
+      // Forward-compatible: render unknown kinds as plain spans.
+      return '';
+    }
+  }
+};
+
+const formatRecordHeader = (record: TraceRecord): string => {
+  const decoration = decorationForKind(record);
+  return `${decoration}${record.name}`;
+};
+
+const formatStatus = (record: TraceRecord): string => {
+  const ms = durationOf(record);
+  switch (record.status) {
+    case 'ok': {
+      return `${OK_GLYPH} ${ms}ms`;
+    }
+    case 'err': {
+      const category = record.errorCategory ?? 'Error';
+      return `${ERR_GLYPH} ${category} (${ms}ms)`;
+    }
+    case 'cancelled': {
+      return `${CANCELLED_GLYPH} ${ms}ms`;
+    }
+    default: {
+      // Forward-compatible: unknown future statuses render as a neutral note.
+      return `${ms}ms`;
+    }
+  }
+};
+
+const sortByStartedAt = (
+  records: readonly TraceRecord[]
+): readonly TraceRecord[] => {
+  const copy = [...records];
+  copy.sort((left, right) => {
+    if (left.startedAt !== right.startedAt) {
+      return left.startedAt - right.startedAt;
+    }
+    if (left.id < right.id) {
+      return -1;
+    }
+    if (left.id > right.id) {
+      return 1;
+    }
+    return 0;
+  });
+  return copy;
+};
+
+const parallelInnerBranch = (index: number, count: number): string => {
+  if (index === 0) {
+    return PARALLEL_FIRST;
+  }
+  if (index === count - 1) {
+    return PARALLEL_LAST;
+  }
+  return PARALLEL_MID;
+};
+
+const groupParallelRuns = (
+  children: readonly TraceRecord[]
+): readonly ParallelRun[] => {
+  const [head, ...rest] = children;
+  if (head === undefined) {
+    return [];
+  }
+  const runs: ParallelRun[] = [];
+  let bucket: TraceRecord[] = [head];
+  let bucketEnd = head.endedAt ?? Number.POSITIVE_INFINITY;
+  let bucketIsParallel = false;
+  for (const current of rest) {
+    const overlaps = current.startedAt < bucketEnd;
+    if (overlaps && bucket.length === 1 && !bucketIsParallel) {
+      bucket.push(current);
+      bucketEnd = Math.max(
+        bucketEnd,
+        current.endedAt ?? Number.POSITIVE_INFINITY
+      );
+      bucketIsParallel = true;
+      continue;
+    }
+    if (overlaps && bucketIsParallel) {
+      bucket.push(current);
+      bucketEnd = Math.max(
+        bucketEnd,
+        current.endedAt ?? Number.POSITIVE_INFINITY
+      );
+      continue;
+    }
+    runs.push({
+      kind: bucketIsParallel ? 'parallel' : 'serial',
+      records: bucket,
+    });
+    bucket = [current];
+    bucketEnd = current.endedAt ?? Number.POSITIVE_INFINITY;
+    bucketIsParallel = false;
+  }
+  runs.push({
+    kind: bucketIsParallel ? 'parallel' : 'serial',
+    records: bucket,
+  });
+  return runs;
+};
+
+const appendParallelGroup = (args: GroupArgs): void => {
+  const { group, indent, isLastGroup, lines, renderDescendants } = args;
+  let index = 0;
+  for (const child of group) {
+    const branch = parallelInnerBranch(index, group.length);
+    const isLastEntryOfLastGroup = index === group.length - 1 && isLastGroup;
+    const outerBranch = isLastEntryOfLastGroup ? BRANCH_LAST : BRANCH_MID;
+    const continuation = isLastEntryOfLastGroup
+      ? CONTINUATION_LAST
+      : CONTINUATION_MID;
+    const header = formatRecordHeader(child);
+    const status = formatStatus(child);
+    lines.push(`${indent}${outerBranch}${branch}${header} ${status}`);
+    renderDescendants(child, continuation);
+    index += 1;
+  }
+  const wall = computeWallTime(group);
+  const total = computeTotalTime(group);
+  const continuation = isLastGroup ? CONTINUATION_LAST : CONTINUATION_MID;
+  lines.push(
+    `${indent}${continuation}(parallel: ${wall}ms wall, ${total}ms total)`
+  );
+};
+
+/**
+ * Render a contiguous block of sibling children, splitting them into runs
+ * of sequential and parallel groups. Self-recursive: parallel groups render
+ * as flat brackets, and serial entries recurse for grandchildren.
+ */
+const appendChildBlock = (args: ChildBlockArgs): void => {
+  const { childrenByParent, children, indent, lines } = args;
+  if (children.length === 0) {
+    return;
+  }
+  const groups = groupParallelRuns(children);
+  let groupIndex = 0;
+  for (const group of groups) {
+    const isLastGroup = groupIndex === groups.length - 1;
+    if (group.kind === 'parallel') {
+      appendParallelGroup({
+        ...args,
+        group: group.records,
+        isLastGroup,
+        renderDescendants: (child, continuation) => {
+          const grandchildren = sortByStartedAt(
+            childrenByParent.get(child.id) ?? []
+          );
+          appendChildBlock({
+            children: grandchildren,
+            childrenByParent,
+            indent: `${indent}${continuation}`,
+            lines,
+          });
+        },
+      });
+      groupIndex += 1;
+      continue;
+    }
+    let entryIndex = 0;
+    for (const child of group.records) {
+      const isLastChild =
+        isLastGroup && entryIndex === group.records.length - 1;
+      const branch = isLastChild ? BRANCH_LAST : BRANCH_MID;
+      const continuation = isLastChild ? CONTINUATION_LAST : CONTINUATION_MID;
+      lines.push(`${indent}${branch}${formatRecordHeader(child)}`);
+      const grandchildren = sortByStartedAt(
+        childrenByParent.get(child.id) ?? []
+      );
+      appendChildBlock({
+        children: grandchildren,
+        childrenByParent,
+        indent: `${indent}${continuation}`,
+        lines,
+      });
+      lines.push(`${indent}${continuation}└─ ${formatStatus(child)}`);
+      entryIndex += 1;
+    }
+    groupIndex += 1;
+  }
+};
+
+const renderRoot = (
+  root: TraceRecord,
+  childrenByParent: ReadonlyMap<string, readonly TraceRecord[]>
+): string => {
+  const header = `${ROOT_GLYPH} ${formatRecordHeader(root)}`;
+  const lines: string[] = [header];
+  const children = sortByStartedAt(childrenByParent.get(root.id) ?? []);
+  appendChildBlock({
+    children,
+    childrenByParent,
+    indent: '  ',
+    lines,
+  });
+  lines.push(`  └─ ${formatStatus(root)}`);
+  return lines.join('\n');
+};
+
+/**
+ * Render a flat array of trace records as a tree string.
+ *
+ * Returns an empty string for empty input. When multiple records have no
+ * `parentId`, each is rendered as a separate top-level tree joined by a
+ * blank line.
+ *
+ * @param records - Flat list of trace records, in any order.
+ * @returns Multi-line string. No trailing newline.
+ */
+export const renderTraceTree = (records: readonly TraceRecord[]): string => {
+  if (records.length === 0) {
+    return '';
+  }
+
+  const byId = new Map<string, TraceRecord>();
+  for (const record of records) {
+    byId.set(record.id, record);
+  }
+
+  const childrenByParent = new Map<string, TraceRecord[]>();
+  const roots: TraceRecord[] = [];
+  for (const record of records) {
+    if (record.parentId !== undefined && byId.has(record.parentId)) {
+      const siblings = childrenByParent.get(record.parentId) ?? [];
+      siblings.push(record);
+      childrenByParent.set(record.parentId, siblings);
+      continue;
+    }
+    roots.push(record);
+  }
+
+  const sortedRoots = sortByStartedAt(roots);
+  const renderedTrees = sortedRoots.map((root) =>
+    renderRoot(root, childrenByParent)
+  );
+  return renderedTrees.join('\n\n');
+};


### PR DESCRIPTION
## Summary
- Adds `renderTraceTree(records)` to `@ontrails/observe`.
- Produces a pure post-execution tree renderer for trace records without writing to stderr or console.
- Handles known and forward-looking trace kinds without coupling renderer behavior to core execution.

## Details
The renderer builds readable parent/child trace trees with status markers, durations, error categories, cancellation, and parallel sibling summaries. Unknown kinds fall through to generic span rendering, and future `signal`, `activation`, and layer attributes render without crashing. The implementation stays in `@ontrails/observe`; `@ontrails/core` is untouched.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-411.