### PR TITLE
feat(cli,trails): wire --trace flag with stderr tree + JSON tracing

### DIFF
--- a/.changeset/trl-412-trace-flag-wiring.md
+++ b/.changeset/trl-412-trace-flag-wiring.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/cli': minor
+'@ontrails/trails': minor
+---
+
+Wire the `--trace` flag for the `trails run` family. Adds `tracePreset()` to `@ontrails/cli` (registered via the `presets` option) and threads `'trace'` through `META_FLAG_CANDIDATES` so the flag is treated as CLI metadata (never routed into trail input). On activation, `apps/trails/src/cli.ts` installs a per-invocation memory sink before `surface()` runs and finalizes it in a `finally` block: the post-execution tree (rendered via `renderTraceTree` from TRL-411) goes to stderr; the result still goes to stdout. With `--trace --json`, regular `trails run <id>` emits a single JSON envelope on stdout that includes `tracing: TraceRecord[]`; `trails run example <id> <exampleName>` keeps its comparison envelope, and `trails run examples <id>` remains a metadata read. `--quiet` keeps the tree on stderr and the unwrapped value on stdout, while `--jsonl` streams items as before. Sink registration is per-invocation so concurrent runs don't bleed records.

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -27,6 +27,7 @@
     "@ontrails/core": "workspace:^",
     "@ontrails/http": "workspace:^",
     "@ontrails/logging": "workspace:^",
+    "@ontrails/observe": "workspace:^",
     "@ontrails/topographer": "workspace:^",
     "@ontrails/tracing": "workspace:^",
     "@ontrails/warden": "workspace:^",

--- a/apps/trails/src/__tests__/run-trace.test.ts
+++ b/apps/trails/src/__tests__/run-trace.test.ts
@@ -1,0 +1,488 @@
+/* oxlint-disable-next-line eslint-plugin-jest/no-conditional-expect -- result-shape assertions branch on isOk/isErr */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import type { ActionResultContext } from '@ontrails/cli';
+import {
+  NOOP_SINK,
+  Result,
+  ValidationError,
+  clearTraceSink,
+  executeTrail,
+  getTraceSink,
+  registerTraceSink,
+  trail,
+} from '@ontrails/core';
+import type { TraceRecord } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  argvHasTraceFlag,
+  buildTraceJsonEnvelope,
+  installTraceSink,
+  tryTraceJsonOutput,
+  writeTraceTreeToStderr,
+} from '../run-trace.js';
+
+// ---------------------------------------------------------------------------
+// Captured-IO helper
+// ---------------------------------------------------------------------------
+
+interface CapturedIO {
+  readonly stdout: string[];
+  readonly stderr: string[];
+}
+
+const withCapturedIO = async (
+  fn: (io: CapturedIO) => Promise<void> | void
+): Promise<CapturedIO> => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+  process.stdout.write = ((chunk: string) => {
+    stdout.push(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string) => {
+    stderr.push(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await fn({ stderr, stdout });
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+  return { stderr, stdout };
+};
+
+// ---------------------------------------------------------------------------
+// Stub trails for unit-level helper tests
+// ---------------------------------------------------------------------------
+
+const stubRunTrail = trail('run', {
+  blaze: () => Result.ok(),
+  description: 'stub run trail for trace tests',
+  input: z.object({ trailId: z.string() }),
+  output: z.unknown(),
+});
+
+const greetTrail = trail('greet', {
+  blaze: ({ name }: { name: string }) => Result.ok({ greeting: `hi ${name}` }),
+  description: 'simple trail used to drive executeTrail and emit a record',
+  input: z.object({ name: z.string() }),
+  output: z.object({ greeting: z.string() }),
+});
+
+const failingTrail = trail('fail', {
+  blaze: () => Result.err(new ValidationError('intentional failure')),
+  description: 'trail that always fails for trace-error tests',
+  input: z.object({}),
+  output: z.unknown(),
+});
+
+const buildCtx = (
+  flags: Record<string, unknown>,
+  result: Result<unknown, Error>,
+  trailId = 'run'
+): ActionResultContext => ({
+  args: {},
+  flags,
+  input: {},
+  result,
+  topoName: 'trails',
+  trail: {
+    ...stubRunTrail,
+    id: trailId,
+  } as unknown as ActionResultContext['trail'],
+});
+
+// ---------------------------------------------------------------------------
+// Argv detection
+// ---------------------------------------------------------------------------
+
+describe('argvHasTraceFlag', () => {
+  test('returns true when --trace is present', () => {
+    expect(argvHasTraceFlag(['node', 'trails', 'run', 'foo', '--trace'])).toBe(
+      true
+    );
+  });
+
+  test('returns false when --trace is absent', () => {
+    expect(argvHasTraceFlag(['node', 'trails', 'run', 'foo'])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON envelope
+// ---------------------------------------------------------------------------
+
+describe('buildTraceJsonEnvelope', () => {
+  test('shapes a successful Result into { ok: true, value, tracing }', () => {
+    const records: readonly TraceRecord[] = [];
+    const envelope = buildTraceJsonEnvelope(
+      Result.ok({ greeting: 'hi Alpha' }),
+      records
+    );
+    expect(envelope).toEqual({
+      ok: true,
+      tracing: [],
+      value: { greeting: 'hi Alpha' },
+    });
+  });
+
+  test('shapes a failing Result into { ok: false, error, tracing }', () => {
+    const error = new ValidationError('bad input');
+    const records: readonly TraceRecord[] = [];
+    const envelope = buildTraceJsonEnvelope(Result.err(error), records);
+    expect(envelope).toEqual({
+      error: { message: 'bad input', name: 'ValidationError' },
+      ok: false,
+      tracing: [],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sink session
+// ---------------------------------------------------------------------------
+
+describe('installTraceSink', () => {
+  beforeEach(() => {
+    clearTraceSink();
+  });
+
+  afterEach(() => {
+    clearTraceSink();
+  });
+
+  test('replaces the registry sink and finalize() restores the previous one', () => {
+    expect(getTraceSink()).toBe(NOOP_SINK);
+    const session = installTraceSink();
+    expect(getTraceSink()).toBe(session.sink);
+    const records = session.finalize();
+    expect(records).toEqual([]);
+    expect(getTraceSink()).toBe(NOOP_SINK);
+  });
+
+  test('captures records emitted during executeTrail', async () => {
+    const session = installTraceSink();
+    const result = await executeTrail(greetTrail, { name: 'Alpha' });
+    const records = session.finalize();
+    expect(result.isOk()).toBe(true);
+    expect(records.length).toBeGreaterThan(0);
+    const trailRecord = records.find((r) => r.trailId === 'greet');
+    expect(trailRecord).toBeDefined();
+    expect(trailRecord?.status).toBe('ok');
+  });
+
+  test('captures records when the trail fails (status: err)', async () => {
+    const session = installTraceSink();
+    await executeTrail(failingTrail, {});
+    const records = session.finalize();
+    const trailRecord = records.find((r) => r.trailId === 'fail');
+    expect(trailRecord).toBeDefined();
+    expect(trailRecord?.status).toBe('err');
+  });
+
+  test('two consecutive sessions do not bleed records', async () => {
+    const first = installTraceSink();
+    await executeTrail(greetTrail, { name: 'first' });
+    const firstRecords = first.finalize();
+
+    const second = installTraceSink();
+    await executeTrail(greetTrail, { name: 'second' });
+    const secondRecords = second.finalize();
+
+    const firstIds = new Set(firstRecords.map((r) => r.id));
+    const secondIds = new Set(secondRecords.map((r) => r.id));
+    for (const id of secondIds) {
+      expect(firstIds.has(id)).toBe(false);
+    }
+    // Sanity: each session captured at least the trail's own root record.
+    expect(firstRecords.some((r) => r.trailId === 'greet')).toBe(true);
+    expect(secondRecords.some((r) => r.trailId === 'greet')).toBe(true);
+  });
+
+  test('finalize() is idempotent: subsequent calls return an empty snapshot', () => {
+    const session = installTraceSink();
+    session.finalize();
+    expect(session.finalize()).toEqual([]);
+  });
+
+  test('installs nothing when --trace is absent (sink stays NOOP)', () => {
+    expect(getTraceSink()).toBe(NOOP_SINK);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stderr tree
+// ---------------------------------------------------------------------------
+
+describe('writeTraceTreeToStderr', () => {
+  test('renders the tree to stderr with a trailing newline', async () => {
+    const session = installTraceSink();
+    await executeTrail(greetTrail, { name: 'Alpha' });
+    const records = session.finalize();
+
+    const io = await withCapturedIO(() => {
+      writeTraceTreeToStderr(records);
+    });
+
+    expect(io.stdout.join('')).toBe('');
+    const stderr = io.stderr.join('');
+    expect(stderr.length).toBeGreaterThan(0);
+    expect(stderr.endsWith('\n')).toBe(true);
+    expect(stderr).toContain('greet');
+  });
+
+  test('no-ops on an empty record list', async () => {
+    const io = await withCapturedIO(() => {
+      writeTraceTreeToStderr([]);
+    });
+    expect(io.stdout.join('')).toBe('');
+    expect(io.stderr.join('')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onResult bridge: tryTraceJsonOutput
+// ---------------------------------------------------------------------------
+
+describe('tryTraceJsonOutput', () => {
+  beforeEach(() => {
+    clearTraceSink();
+  });
+
+  afterEach(() => {
+    clearTraceSink();
+  });
+
+  test('returns false when --trace is not set', async () => {
+    const session = installTraceSink();
+    const ctx = buildCtx({ json: true }, Result.ok({ name: 'Alpha' }));
+    const io = await withCapturedIO(() => {
+      const handled = tryTraceJsonOutput(ctx, session);
+      expect(handled).toBe(false);
+    });
+    session.finalize();
+    expect(io.stdout.join('')).toBe('');
+  });
+
+  test('returns false when --trace is set but --json is not', async () => {
+    const session = installTraceSink();
+    const ctx = buildCtx({ trace: true }, Result.ok({ name: 'Alpha' }));
+    const io = await withCapturedIO(() => {
+      const handled = tryTraceJsonOutput(ctx, session);
+      expect(handled).toBe(false);
+    });
+    session.finalize();
+    expect(io.stdout.join('')).toBe('');
+  });
+
+  test('returns false under --trace --quiet (deferred to quiet handler)', async () => {
+    const session = installTraceSink();
+    const ctx = buildCtx(
+      { json: true, quiet: true, trace: true },
+      Result.ok({ name: 'Alpha' })
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryTraceJsonOutput(ctx, session);
+      expect(handled).toBe(false);
+    });
+    session.finalize();
+    expect(io.stdout.join('')).toBe('');
+  });
+
+  test('returns false for run.example under --trace --json', async () => {
+    const session = installTraceSink();
+    const ctx = buildCtx(
+      { json: true, trace: true },
+      Result.ok({ kind: 'run.example.comparison' }),
+      'run.example'
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryTraceJsonOutput(ctx, session);
+      expect(handled).toBe(false);
+    });
+    session.finalize();
+    expect(io.stdout.join('')).toBe('');
+  });
+
+  test('returns false for run.examples under --trace --json', async () => {
+    const session = installTraceSink();
+    const ctx = buildCtx(
+      { json: true, trace: true },
+      Result.ok({ examples: [], kind: 'run.examples.listing' }),
+      'run.examples'
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryTraceJsonOutput(ctx, session);
+      expect(handled).toBe(false);
+    });
+    session.finalize();
+    expect(io.stdout.join('')).toBe('');
+  });
+
+  test('returns false under --trace --jsonl (line-delimited stream)', async () => {
+    const session = installTraceSink();
+    const ctx = buildCtx({ jsonl: true, trace: true }, Result.ok([1, 2, 3]));
+    const io = await withCapturedIO(() => {
+      const handled = tryTraceJsonOutput(ctx, session);
+      expect(handled).toBe(false);
+    });
+    session.finalize();
+    expect(io.stdout.join('')).toBe('');
+  });
+
+  test('emits envelope on stdout under --trace --json', async () => {
+    const session = installTraceSink();
+    await executeTrail(greetTrail, { name: 'Alpha' });
+    const ctx = buildCtx(
+      { json: true, trace: true },
+      Result.ok({ greeting: 'hi Alpha' })
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryTraceJsonOutput(ctx, session);
+      expect(handled).toBe(true);
+    });
+    const records = session.finalize();
+
+    expect(io.stderr.join('')).toBe('');
+    const stdout = io.stdout.join('');
+    expect(stdout.endsWith('\n')).toBe(true);
+    const parsed: unknown = JSON.parse(stdout);
+    expect(parsed).toMatchObject({
+      ok: true,
+      value: { greeting: 'hi Alpha' },
+    });
+    expect(parsed).toHaveProperty('tracing');
+    const parsedRecord = parsed as { readonly tracing: readonly unknown[] };
+    expect(Array.isArray(parsedRecord.tracing)).toBe(true);
+    expect(parsedRecord.tracing.length).toBe(records.length);
+    // Each round-tripped record must carry the canonical TraceRecord
+    // identity fields. Optional `undefined` fields are dropped by JSON, so
+    // we assert the load-bearing identifiers rather than deep-equality.
+    const trailRecord = records.find((r) => r.trailId === 'greet');
+    expect(trailRecord).toBeDefined();
+    expect(parsedRecord.tracing).toContainEqual(
+      expect.objectContaining({
+        id: trailRecord?.id,
+        kind: 'trail',
+        name: 'greet',
+        status: 'ok',
+        trailId: 'greet',
+      })
+    );
+  });
+
+  test('emits envelope on stdout under --output json (non-shorthand form)', async () => {
+    const session = installTraceSink();
+    const ctx = buildCtx(
+      { output: 'json', trace: true },
+      Result.ok({ greeting: 'hi Alpha' })
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryTraceJsonOutput(ctx, session);
+      expect(handled).toBe(true);
+    });
+    session.finalize();
+
+    const parsed: unknown = JSON.parse(io.stdout.join(''));
+    expect(parsed).toMatchObject({
+      ok: true,
+      value: { greeting: 'hi Alpha' },
+    });
+  });
+
+  test('emits ok=false envelope when the result is Err', async () => {
+    const session = installTraceSink();
+    const ctx = buildCtx(
+      { json: true, trace: true },
+      Result.err(new ValidationError('bad input'))
+    );
+    const io = await withCapturedIO(() => {
+      const handled = tryTraceJsonOutput(ctx, session);
+      expect(handled).toBe(true);
+    });
+    session.finalize();
+
+    const parsed: unknown = JSON.parse(io.stdout.join(''));
+    expect(parsed).toEqual({
+      error: { message: 'bad input', name: 'ValidationError' },
+      ok: false,
+      tracing: [],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stream isolation (stderr never contaminates stdout)
+// ---------------------------------------------------------------------------
+
+describe('stream isolation under --trace', () => {
+  beforeEach(() => {
+    clearTraceSink();
+  });
+
+  afterEach(() => {
+    clearTraceSink();
+  });
+
+  test('tree never appears on stdout when --trace --json is set', async () => {
+    const session = installTraceSink();
+    await executeTrail(greetTrail, { name: 'Alpha' });
+    const ctx = buildCtx(
+      { json: true, trace: true },
+      Result.ok({ greeting: 'hi Alpha' })
+    );
+
+    const io = await withCapturedIO(() => {
+      tryTraceJsonOutput(ctx, session);
+    });
+    const records = session.finalize();
+    const treeIO = await withCapturedIO(() => {
+      writeTraceTreeToStderr(records);
+    });
+
+    // The first capture only saw the JSON envelope (stdout) -- no tree.
+    expect(io.stderr.join('')).toBe('');
+    const stdout = io.stdout.join('');
+    expect(stdout).not.toContain('●');
+    expect(stdout).not.toContain('└─');
+
+    // The tree only appears on stderr in the second capture.
+    expect(treeIO.stdout.join('')).toBe('');
+    expect(treeIO.stderr.join('')).toContain('greet');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-existing sink restoration
+// ---------------------------------------------------------------------------
+
+describe('previous sink restoration', () => {
+  beforeEach(() => {
+    clearTraceSink();
+  });
+
+  afterEach(() => {
+    clearTraceSink();
+  });
+
+  test('restores a host-installed sink, not the noop, after finalize', () => {
+    const collected: TraceRecord[] = [];
+    const hostSink = {
+      write: (record: TraceRecord) => {
+        collected.push(record);
+      },
+    };
+    registerTraceSink(hostSink);
+    expect(getTraceSink()).toBe(hostSink);
+
+    const session = installTraceSink();
+    expect(getTraceSink()).toBe(session.sink);
+    session.finalize();
+    expect(getTraceSink()).toBe(hostSink);
+  });
+});

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -1,4 +1,4 @@
-import { defaultOnResult, outputModePreset } from '@ontrails/cli';
+import { defaultOnResult, outputModePreset, tracePreset } from '@ontrails/cli';
 import type { ActionResultContext } from '@ontrails/cli';
 import { surface } from '@ontrails/cli/commander';
 
@@ -8,39 +8,67 @@ import { tryRecoverFromRunCollision } from './run-collision.js';
 import { tryExampleRunOutput } from './run-example.js';
 import { tryExamplesRunOutput } from './run-examples.js';
 import { tryQuietRunOutput } from './run-quiet.js';
+import {
+  argvHasTraceFlag,
+  installTraceSink,
+  tryTraceJsonOutput,
+  writeTraceTreeToStderr,
+} from './run-trace.js';
+import type { TraceSession } from './run-trace.js';
 import { trailsPackageVersion } from './versions.js';
 
-const onResult = async (ctx: ActionResultContext): Promise<void> => {
-  const recovered = await tryRecoverFromRunCollision(ctx, { graph: app });
-  const resolvedCtx: ActionResultContext =
-    recovered === undefined
-      ? ctx
-      : {
-          ...ctx,
-          input: recovered.isOk()
-            ? (ctx.trail.input.safeParse(ctx.input).data ?? ctx.input)
-            : ctx.input,
-          result: recovered,
-        };
+const buildOnResult =
+  (session: TraceSession | undefined) =>
+  async (ctx: ActionResultContext): Promise<void> => {
+    const recovered = await tryRecoverFromRunCollision(ctx, { graph: app });
+    const resolvedCtx: ActionResultContext =
+      recovered === undefined
+        ? ctx
+        : {
+            ...ctx,
+            input: recovered.isOk()
+              ? (ctx.trail.input.safeParse(ctx.input).data ?? ctx.input)
+              : ctx.input,
+            result: recovered,
+          };
 
-  if (tryExampleRunOutput(resolvedCtx)) {
-    return;
-  }
-  if (tryExamplesRunOutput(resolvedCtx)) {
-    return;
-  }
-  if (await tryQuietRunOutput(resolvedCtx)) {
-    return;
-  }
-  await defaultOnResult(resolvedCtx);
-};
+    // `--trace --json` (without `--quiet`) emits a single Result-shaped
+    // envelope on stdout that includes the captured records under
+    // `tracing`. Hand that case off before the regular chain so the
+    // existing handlers do not also write to stdout.
+    if (session !== undefined && tryTraceJsonOutput(resolvedCtx, session)) {
+      return;
+    }
 
-// oxlint-disable-next-line require-hook -- CLI entry point
-await surface(app, {
-  description: 'Agent-native, contract-first TypeScript framework',
-  name: 'trails',
-  onResult,
-  presets: [outputModePreset()],
-  resolveInput: resolveInputWithClack,
-  version: trailsPackageVersion,
-});
+    if (tryExampleRunOutput(resolvedCtx)) {
+      return;
+    }
+    if (tryExamplesRunOutput(resolvedCtx)) {
+      return;
+    }
+    if (await tryQuietRunOutput(resolvedCtx)) {
+      return;
+    }
+    await defaultOnResult(resolvedCtx);
+  };
+
+const session: TraceSession | undefined = argvHasTraceFlag(process.argv)
+  ? installTraceSink()
+  : undefined;
+
+try {
+  // oxlint-disable-next-line require-hook -- CLI entry point
+  await surface(app, {
+    description: 'Agent-native, contract-first TypeScript framework',
+    name: 'trails',
+    onResult: buildOnResult(session),
+    presets: [outputModePreset(), tracePreset()],
+    resolveInput: resolveInputWithClack,
+    version: trailsPackageVersion,
+  });
+} finally {
+  if (session !== undefined) {
+    const records = session.finalize();
+    writeTraceTreeToStderr(records);
+  }
+}

--- a/apps/trails/src/run-trace.ts
+++ b/apps/trails/src/run-trace.ts
@@ -1,0 +1,290 @@
+/**
+ * CLI-surface bridge for the `--trace` flag.
+ *
+ * `--trace` installs a per-invocation in-memory {@link TraceSink} so the
+ * intrinsic tracing pipeline in `@ontrails/core` records every trail-,
+ * span-, signal-, and activation-level event during the invocation. After
+ * the trail completes (success or failure), the records are rendered as a
+ * tree to stderr via `renderTraceTree` from `@ontrails/observe`. Under
+ * `--json`, the structured `TraceRecord[]` is also emitted on stdout as
+ * the `tracing` field of a Result envelope.
+ *
+ * Design notes:
+ *
+ * - The sink is **per-invocation**, not module-global. Each call to
+ *   {@link installTraceSink} replaces the registry entry with a fresh
+ *   `MemoryTraceSink` and returns a handle whose {@link TraceSession.finalize}
+ *   restores the previous sink and returns the captured records.
+ * - Tracing output is split across streams: the tree always goes to stderr,
+ *   structured records only enter stdout when both `--trace` and `--json`
+ *   are set. Under `--quiet`, the inner trail value remains the only stdout
+ *   payload (no envelope) per ADR-0044's pipe-friendly contract.
+ * - `--trace` on `run.examples` is a metadata read; the run trail short-circuits
+ *   before any execution, so no trace tree is rendered.
+ */
+
+import { getTraceSink, registerTraceSink } from '@ontrails/core';
+import type { TraceRecord, TraceSink } from '@ontrails/core';
+import { createMemorySink, renderTraceTree } from '@ontrails/observe';
+import type { MemoryTraceSink } from '@ontrails/observe';
+
+// ---------------------------------------------------------------------------
+// Argv detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect whether `--trace` appears in argv.
+ *
+ * Pre-parsed argv detection lets the CLI install the sink before
+ * `surface()` parses argv. The flag is also wired through the build
+ * pipeline as a meta flag, so trail input is unaffected.
+ */
+export const argvHasTraceFlag = (argv: readonly string[]): boolean =>
+  argv.includes('--trace');
+
+// ---------------------------------------------------------------------------
+// Sink session
+// ---------------------------------------------------------------------------
+
+/** Handle returned by {@link installTraceSink}. */
+export interface TraceSession {
+  /** The fresh in-memory sink that received records during this invocation. */
+  readonly sink: MemoryTraceSink;
+  /**
+   * Restore the previous trace sink and return a stable snapshot of the
+   * records collected during this session. Safe to call once; subsequent
+   * calls return an empty array.
+   */
+  readonly finalize: () => readonly TraceRecord[];
+}
+
+const restoreSink = (previous: TraceSink): void => {
+  // `registerTraceSink(undefined)` collapses back to `NOOP_SINK`, which is
+  // what we want when the prior sink was the default no-op singleton. For
+  // any other prior sink (e.g. an OTel adapter wired by the host), restore
+  // it directly so we do not accidentally drop the host's configured sink.
+  registerTraceSink(previous);
+};
+
+/**
+ * Register a fresh {@link MemoryTraceSink} as the active trace sink and
+ * return a handle that can later restore the previous sink.
+ */
+export const installTraceSink = (): TraceSession => {
+  const previous = getTraceSink();
+  const sink = createMemorySink();
+  registerTraceSink(sink);
+
+  let finalized = false;
+  return {
+    finalize: () => {
+      if (finalized) {
+        return [];
+      }
+      finalized = true;
+      const records = sink.records();
+      restoreSink(previous);
+      return records;
+    },
+    sink,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Stderr rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the captured records as a tree to stderr, followed by a newline.
+ *
+ * No-ops on an empty record list so that quiet trails (e.g. metadata reads
+ * that never invoke `executeTrail`) do not produce a stray blank line.
+ */
+export const writeTraceTreeToStderr = (
+  records: readonly TraceRecord[]
+): void => {
+  if (records.length === 0) {
+    return;
+  }
+  const tree = renderTraceTree(records);
+  if (tree.length === 0) {
+    return;
+  }
+  process.stderr.write(`${tree}\n`);
+};
+
+// ---------------------------------------------------------------------------
+// JSON envelope shaping
+// ---------------------------------------------------------------------------
+
+/**
+ * Result-style envelope emitted on stdout under `--trace --json`.
+ *
+ * Mirrors the shape of `Result<T, E>` but adds a `tracing` field so a
+ * downstream consumer can deserialize the run outcome and the structured
+ * trace from a single document.
+ */
+export type TraceJsonEnvelope =
+  | {
+      readonly ok: true;
+      readonly value: unknown;
+      readonly tracing: readonly TraceRecord[];
+    }
+  | {
+      readonly ok: false;
+      readonly error: { readonly message: string; readonly name: string };
+      readonly tracing: readonly TraceRecord[];
+    };
+
+/**
+ * Minimal Result-shape contract used by the JSON envelope builder.
+ *
+ * The `value` and `error` properties may be present at the same time on a
+ * Result instance (the discriminated union narrows by `isOk` / `isErr`),
+ * so this interface keeps both optional and lets the builder branch on the
+ * type guard rather than asserting either side.
+ */
+interface ResultLike {
+  readonly isOk: () => boolean;
+  readonly isErr: () => boolean;
+  readonly value?: unknown;
+  readonly error?: unknown;
+}
+
+const hasResultMethods = (value: unknown): value is ResultLike => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate: { isOk?: unknown; isErr?: unknown } = value;
+  return (
+    typeof candidate.isOk === 'function' &&
+    typeof candidate.isErr === 'function'
+  );
+};
+
+const errorFromUnknown = (
+  value: unknown
+): { readonly message: string; readonly name: string } => {
+  if (value instanceof Error) {
+    return { message: value.message, name: value.name };
+  }
+  return { message: String(value), name: 'Error' };
+};
+
+/**
+ * Build the stdout envelope for `--trace --json`.
+ *
+ * On success, the inner value is taken straight from the trail's
+ * `Result.ok(...)` payload. On failure the envelope captures the error's
+ * `name` and `message` -- both safe to serialize and consistent with how
+ * other Trails surfaces project errors.
+ */
+export const buildTraceJsonEnvelope = (
+  result: ResultLike,
+  records: readonly TraceRecord[]
+): TraceJsonEnvelope => {
+  if (result.isOk()) {
+    return {
+      ok: true,
+      tracing: records,
+      value: result.value,
+    };
+  }
+  return {
+    error: errorFromUnknown(result.error),
+    ok: false,
+    tracing: records,
+  };
+};
+
+/**
+ * Serialize a {@link TraceJsonEnvelope} as a single JSON document for stdout.
+ *
+ * Indented with two spaces to match the rest of the CLI's `--json`
+ * formatting (see `output()` in `@ontrails/cli`).
+ */
+export const formatTraceJsonEnvelope = (envelope: TraceJsonEnvelope): string =>
+  `${JSON.stringify(envelope, null, 2)}\n`;
+
+// ---------------------------------------------------------------------------
+// onResult bridge
+// ---------------------------------------------------------------------------
+
+interface TryTraceCtx {
+  readonly flags: Record<string, unknown>;
+  readonly result: ResultLike;
+  readonly trail?: { readonly id: string } | undefined;
+}
+
+const isJsonMode = (flags: Record<string, unknown>): boolean => {
+  if (flags['json'] === true) {
+    return true;
+  }
+  if (typeof flags['output'] === 'string' && flags['output'] === 'json') {
+    return true;
+  }
+  return false;
+};
+
+const shouldEmitTraceEnvelope = (flags: Record<string, unknown>): boolean => {
+  if (flags['trace'] !== true) {
+    return false;
+  }
+  if (flags['quiet'] === true) {
+    // `--quiet` is the explicit pipe-friendly mode. Adding the tracing
+    // envelope to stdout would defeat the contract -- defer to the
+    // existing quiet handler for stdout and only render the tree on
+    // stderr (handled outside this helper).
+    return false;
+  }
+  if (flags['jsonl'] === true) {
+    // `--jsonl` streams items per line; the structured envelope cannot be
+    // expressed without breaking the line-delimited contract.
+    return false;
+  }
+  return isJsonMode(flags);
+};
+
+const traceOutputIsOwnedByRunFamily = (ctx: TryTraceCtx): boolean => {
+  if (ctx.trail?.id === 'run.example') {
+    // `run.example` owns stdout via its comparison envelope. Still render the
+    // trace tree to stderr, but do not override the example helper output.
+    return false;
+  }
+  if (ctx.trail?.id === 'run.examples') {
+    // Pure metadata read; no execution to trace.
+    return false;
+  }
+  return true;
+};
+
+/**
+ * If the invocation requested both `--trace` and `--json`, serialize the
+ * trace envelope to stdout and return `true`. Otherwise return `false` so
+ * the caller falls through to the regular on-result chain.
+ *
+ * The stderr tree is **not** rendered here -- it is rendered uniformly
+ * for every `--trace` invocation in the CLI entry-point's `finally`
+ * block, even when this helper short-circuits.
+ */
+export const tryTraceJsonOutput = (
+  ctx: TryTraceCtx,
+  session: TraceSession
+): boolean => {
+  if (
+    !shouldEmitTraceEnvelope(ctx.flags) ||
+    !traceOutputIsOwnedByRunFamily(ctx)
+  ) {
+    return false;
+  }
+  const records = session.sink.records();
+  const envelope = buildTraceJsonEnvelope(ctx.result, records);
+  process.stdout.write(formatTraceJsonEnvelope(envelope));
+  return true;
+};
+
+// ---------------------------------------------------------------------------
+// Result-shape detection helpers (re-exported for consumers in cli.ts)
+// ---------------------------------------------------------------------------
+
+export const isResultShape = hasResultMethods;

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "@ontrails/core": "workspace:^",
         "@ontrails/http": "workspace:^",
         "@ontrails/logging": "workspace:^",
+        "@ontrails/observe": "workspace:^",
         "@ontrails/topographer": "workspace:^",
         "@ontrails/tracing": "workspace:^",
         "@ontrails/warden": "workspace:^",
@@ -264,6 +265,10 @@
         "@ontrails/core": "workspace:^",
         "@ontrails/topographer": "workspace:^",
       },
+      "optionalPeers": [
+        "@ontrails/core",
+        "@ontrails/topographer",
+      ],
     },
   },
   "trustedDependencies": [

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -132,6 +132,7 @@ const META_FLAG_CANDIDATES = new Set([
   'jsonl',
   'output',
   'quiet',
+  'trace',
 ]);
 
 const STRUCTURED_INLINE_JSON_ARG_NAME = 'inline-json';

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -123,3 +123,22 @@ export const dryRunPreset = (): CliFlag[] => [
     variadic: false,
   },
 ];
+
+/**
+ * Flag for trace collection: --trace
+ *
+ * When set, the CLI installs a per-invocation in-memory trace sink, renders
+ * the resulting trace tree to stderr after execution, and (under `--json`)
+ * includes the structured `TraceRecord[]` on the stdout envelope. The flag
+ * is treated as a meta flag — it never routes into trail input.
+ */
+export const tracePreset = (): CliFlag[] => [
+  {
+    default: false,
+    description: 'Collect a per-invocation trace tree to stderr',
+    name: 'trace',
+    required: false,
+    type: 'boolean',
+    variadic: false,
+  },
+];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ export {
   outputModePreset,
   cwdPreset,
   dryRunPreset,
+  tracePreset,
 } from './flags.js';
 
 // Output


### PR DESCRIPTION
## Summary
- Adds the `--trace` CLI preset and wires it into `trails run`.
- Emits a post-execution trace tree to stderr while preserving stdout formats.
- Adds JSON trace envelopes for `--trace --json` without changing core runtime behavior.

## Details
The CLI detects `--trace` before `surface()` runs, installs a per-invocation memory sink, finalizes in a `finally` block, renders through `renderTraceTree`, and restores the previous sink afterward. The path composes with `--quiet`, `trails run example`, `trails run examples`, `--watch`, `--json`, and `--jsonl`; JSONL streaming keeps stdout item-oriented while the tree goes to stderr.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-412. Closes Phase 3 (Trace).
