### PR TITLE
feat(core,cli): add dryRun to TrailContext and wire --dry-run flag

### DIFF
--- a/.changeset/trl-407-dryrun-context-field.md
+++ b/.changeset/trl-407-dryrun-context-field.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/core': minor
+'@ontrails/cli': minor
+---
+
+Add `dryRun` to `TrailContext` and wire `--dry-run`. `TrailContext` gains an optional `dryRun?: boolean` field, defaulted to `false` in `createTrailContext`. `ExecuteTrailOptions` carries `dryRun?: boolean` through `applyContextOverrides` so `executeTrail(t, input, { dryRun: true })` produces `ctx.dryRun === true`. The CLI's existing `dryRunPreset` (auto-derived for `intent: 'write' | 'destroy'` trails) now flows through `META_FLAG_CANDIDATES` and reaches the executor via `runTrailOnce`, so `trails run booking.cancel … --dry-run` lands `ctx.dryRun === true` on the trail's blaze. Trails that don't read the field are unchanged. Read-intent trails don't get `--dry-run` exposed.

--- a/docs/adr/0008-deterministic-trailhead-derivation.md
+++ b/docs/adr/0008-deterministic-trailhead-derivation.md
@@ -32,7 +32,7 @@ Trail IDs map to CLI commands via deterministic path projection:
 - `deriveFields(schema)` introspects the Zod input schema to produce a surface-agnostic `Field[]` descriptor array
 - `toFlags(fields)` converts faithfully representable descriptors to CLI flag definitions, including kebab-casing (`dryRun` → `--dry-run`)
 - Structured input channels supplement flags for full-schema input on the CLI; that input model is defined in ADR-0020
-- Destroy-intent trails auto-merge a `--dry-run` flag via `dryRunPreset()`
+- Write- and destroy-intent trails auto-merge a `--dry-run` flag via `dryRunPreset()`
 
 ### MCP derivation
 
@@ -64,7 +64,7 @@ The following table shows how a single trail ID derives across all three surface
 | Surface | Derived artifact | Value |
 | --- | --- | --- |
 | CLI | Command path | `["user", "delete"]` |
-| CLI | Extra flags | `--dry-run` (auto-added for destroy intent) |
+| CLI | Extra flags | `--dry-run` (auto-added for write/destroy intent) |
 | MCP | Tool name | `myapp_user_delete` |
 | MCP | Annotations | `destructiveHint: true` |
 | HTTP | Method | `DELETE` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,7 +83,7 @@ These are deterministic transformations from authored information. If the input 
 | Trail ID | Full CLI command path (`entity show`, `topo pin`, `topo pin remove`), MCP tool name (`myapp_entity_show`) |
 | `.describe()` on Zod fields | `--help` text, MCP tool descriptions |
 | `intent: 'read'` | MCP `readOnlyHint`, HTTP GET, skip CLI confirmation |
-| `intent: 'destroy'` | Auto-add `--dry-run` flag on CLI, HTTP DELETE |
+| `intent: 'write'` / `intent: 'destroy'` | Auto-add `--dry-run` flag on CLI; map HTTP to POST / DELETE |
 | Error taxonomy class | Exit code, HTTP status, JSON-RPC code, retryability |
 | Examples | Test assertions via `testExamples()`, agent documentation |
 

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -183,7 +183,7 @@ Adds `--cwd <path>` flag.
 import { dryRunPreset } from '@ontrails/cli';
 ```
 
-Adds a `--dry-run` flag. Automatically added for trails with `intent: 'destroy'`. If the blaze needs to branch on it, declare `dryRun` in the trail input schema so validation preserves it.
+Adds a `--dry-run` flag. Automatically added for trails with `intent: 'write'` or `intent: 'destroy'`. If the blaze needs to branch on it, read `ctx.dryRun`; dry-run is execution context, not trail input.
 
 ## Output Formatting
 

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -157,6 +157,33 @@ describe('buildCommands path derivation', () => {
     expect(dryRunFlag).toBeDefined();
     expect(dryRunFlag?.type).toBe('boolean');
   });
+
+  test('adds --dry-run for write intent trails', () => {
+    const t = trail('entity.create', {
+      blaze: () => Result.ok({ id: 'x' }),
+      input: z.object({ name: z.string() }),
+      intent: 'write',
+      output: z.object({ id: z.string() }),
+    });
+    const app = makeApp(t);
+    const commands = buildCommands(app);
+    const dryRunFlag = commands[0]?.flags.find((f) => f.name === 'dry-run');
+    expect(dryRunFlag).toBeDefined();
+    expect(dryRunFlag?.type).toBe('boolean');
+  });
+
+  test('does not add --dry-run for read intent trails', () => {
+    const t = trail('entity.show', {
+      blaze: (input: { id: string }) => Result.ok({ id: input.id }),
+      input: z.object({ id: z.string() }),
+      intent: 'read',
+      output: z.object({ id: z.string() }),
+    });
+    const app = makeApp(t);
+    const commands = buildCommands(app);
+    const dryRunFlag = commands[0]?.flags.find((f) => f.name === 'dry-run');
+    expect(dryRunFlag).toBeUndefined();
+  });
 });
 
 describe('buildCommands execution', () => {
@@ -1119,5 +1146,128 @@ describe('buildCommands date-shortcut absorption', () => {
       throw new Error('expected ok');
     }
     expect(result.value).toBe('Hello, today');
+  });
+});
+
+describe('--dry-run wiring', () => {
+  test('--dry-run flag sets ctx.dryRun to true on the trail', async () => {
+    let observed: boolean | undefined;
+    const t = trail('thing.delete', {
+      blaze: (_input, ctx) => {
+        observed = ctx.dryRun;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      intent: 'destroy',
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { dryRun: true, id: 'abc' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(observed).toBe(true);
+  });
+
+  test('omitted --dry-run leaves ctx.dryRun as false', async () => {
+    let observed: boolean | undefined;
+    const t = trail('thing.delete-default', {
+      blaze: (_input, ctx) => {
+        observed = ctx.dryRun;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      intent: 'destroy',
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app));
+
+    const result = await cmd.execute({ id: 'abc' }, { id: 'abc' });
+
+    expect(result.isOk()).toBe(true);
+    expect(observed).toBe(false);
+  });
+
+  test('omitted --dry-run preserves a context factory dryRun default', async () => {
+    let observed: boolean | undefined;
+    const t = trail('thing.delete-factory-default', {
+      blaze: (_input, ctx) => {
+        observed = ctx.dryRun;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      intent: 'destroy',
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(
+      buildCommands(app, {
+        createContext: () => createTrailContext({ dryRun: true }),
+      })
+    );
+
+    const result = await cmd.execute({ id: 'abc' }, { id: 'abc' });
+
+    expect(result.isOk()).toBe(true);
+    expect(observed).toBe(true);
+  });
+
+  test('--dry-run does not leak into trail input', async () => {
+    let receivedInput: unknown;
+    const t = trail('thing.write', {
+      blaze: (input: { name: string }) => {
+        receivedInput = input;
+        return Result.ok({ name: input.name });
+      },
+      input: z.object({ name: z.string() }),
+      intent: 'write',
+      output: z.object({ name: z.string() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app));
+
+    const result = await cmd.execute(
+      { name: 'alpha' },
+      { dryRun: true, name: 'alpha' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(receivedInput).toEqual({ name: 'alpha' });
+  });
+
+  test('schema-authored dryRun remains trail input instead of a meta flag', async () => {
+    let observedInput: { dryRun: boolean; id: string } | undefined;
+    let observedCtxDryRun: boolean | undefined;
+    const t = trail('thing.preview', {
+      blaze: (input: { dryRun: boolean; id: string }, ctx) => {
+        observedInput = input;
+        observedCtxDryRun = ctx.dryRun;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ dryRun: z.boolean(), id: z.string() }),
+      intent: 'write',
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { dryRun: true, id: 'abc' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(observedInput).toEqual({ dryRun: true, id: 'abc' });
+    expect(observedCtxDryRun).toBe(false);
   });
 });

--- a/packages/cli/src/__tests__/flags.test.ts
+++ b/packages/cli/src/__tests__/flags.test.ts
@@ -214,6 +214,6 @@ describe('dryRunPreset', () => {
     expect(flags).toHaveLength(1);
     expect(flags[0]?.name).toBe('dry-run');
     expect(flags[0]?.type).toBe('boolean');
-    expect(flags[0]?.default).toBe(false);
+    expect(flags[0]?.default).toBeUndefined();
   });
 });

--- a/packages/cli/src/__tests__/to-commander.test.ts
+++ b/packages/cli/src/__tests__/to-commander.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, mock, test } from 'bun:test';
 
-import { NotFoundError, Result, trail, topo } from '@ontrails/core';
+import {
+  createTrailContext,
+  NotFoundError,
+  Result,
+  trail,
+  topo,
+} from '@ontrails/core';
 import { z } from 'zod';
 
 import { deriveCliCommands } from '../build.js';
@@ -815,6 +821,37 @@ describe('toCommander option wiring', () => {
 
       await program.parseAsync(['node', 'test', 'check', '--strict']);
       expect(spy.received['strict']).toBe(true);
+    });
+
+    test('omitted --dry-run preserves a createContext dryRun default through Commander', async () => {
+      let observed: boolean | undefined;
+      const t = trail('thing.delete', {
+        blaze: (_input, ctx) => {
+          observed = ctx.dryRun;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({ id: z.string() }),
+        intent: 'destroy',
+        output: z.object({ ok: z.boolean() }),
+      });
+      const app = makeApp(t);
+      const commands = buildCommands(app, {
+        createContext: () => createTrailContext({ dryRun: true }),
+        onResult: noopResult,
+      });
+      const program = toCommander(commands, { name: 'test' });
+      program.exitOverride();
+
+      await program.parseAsync([
+        'node',
+        'test',
+        'thing',
+        'delete',
+        '--id',
+        'abc',
+      ]);
+
+      expect(observed).toBe(true);
     });
   });
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -126,6 +126,7 @@ const validateCliCommandBuild = (
  */
 const META_FLAG_CANDIDATES = new Set([
   'all',
+  'dryRun',
   'input',
   'inputJson',
   'json',
@@ -377,16 +378,42 @@ const runTrailOnce = async (
   t: AnyTrail,
   ctxOverrides: Partial<TrailContext> | undefined,
   options: DeriveCliCommandsOptions | undefined,
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
+  dryRun: boolean | undefined
 ): Promise<Result<unknown, Error>> =>
   await executeTrail(t, input, {
     configValues: options?.configValues,
     createContext: options?.createContext,
     ctx: withSurfaceMarker('cli', ctxOverrides),
+    dryRun,
     layers: options?.layers,
     resources: options?.resources,
     topo: graph,
   });
+
+/**
+ * Read the parsed `--dry-run` flag value.
+ *
+ * Accepts both the kebab-case (`'dry-run'`) and camelCase (`'dryRun'`)
+ * forms so callers don't have to normalize before invoking `execute`.
+ * Returns `undefined` when the flag is absent so custom context factories can
+ * provide their own `ctx.dryRun` default.
+ */
+const readDryRunFlag = (
+  parsedFlags: Record<string, unknown>,
+  metaFlagNames: ReadonlySet<string>
+): boolean | undefined => {
+  if (!metaFlagNames.has('dryRun')) {
+    return undefined;
+  }
+  if (parsedFlags['dryRun'] === true || parsedFlags['dry-run'] === true) {
+    return true;
+  }
+  if (parsedFlags['dryRun'] === false || parsedFlags['dry-run'] === false) {
+    return false;
+  }
+  return undefined;
+};
 
 /**
  * Decide whether the executor should iterate this invocation.
@@ -424,7 +451,8 @@ const runPaginatedIteration = async (
   ctxOverrides: Partial<TrailContext> | undefined,
   options: DeriveCliCommandsOptions | undefined,
   baseInput: Record<string, unknown>,
-  jsonl: boolean
+  jsonl: boolean,
+  dryRun: boolean | undefined
 ): Promise<IterationOutcome> => {
   if (!inputHasCursorField(t)) {
     return {
@@ -441,7 +469,8 @@ const runPaginatedIteration = async (
     baseInput: stripAllFlag(baseInput),
     cursorField: 'cursor',
     onItem: jsonl ? writeJsonLine : undefined,
-    runPage: (input) => runTrailOnce(graph, t, ctxOverrides, options, input),
+    runPage: (input) =>
+      runTrailOnce(graph, t, ctxOverrides, options, input, dryRun),
   });
   return { result, streamed: jsonl && result.isOk() };
 };
@@ -485,6 +514,7 @@ const createExecute =
     }
     const { mergedInput, usedStructuredInput } = merged.value;
 
+    const dryRun = readDryRunFlag(parsedFlags, metaFlagNames);
     let result: Result<unknown, Error>;
     let streamed = false;
     if (shouldIteratePages(t, parsedFlags, metaFlagNames)) {
@@ -494,7 +524,8 @@ const createExecute =
         ctxOverrides,
         options,
         mergedInput,
-        isJsonlMode(parsedFlags)
+        isJsonlMode(parsedFlags),
+        dryRun
       );
       ({ result } = outcome);
       ({ streamed } = outcome);
@@ -504,7 +535,8 @@ const createExecute =
         t,
         ctxOverrides,
         options,
-        metaFlagNames.has('all') ? stripAllFlag(mergedInput) : mergedInput
+        metaFlagNames.has('all') ? stripAllFlag(mergedInput) : mergedInput,
+        dryRun
       );
     }
 
@@ -549,7 +581,7 @@ const buildFlags = (
   if (options?.presets) {
     flags = mergeFlags(options.presets.flat(), flags);
   }
-  if (intent === 'destroy') {
+  if (intent === 'destroy' || intent === 'write') {
     flags = mergeFlags(dryRunPreset(), flags);
   }
   return flags;

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -115,7 +115,6 @@ export const cwdPreset = (): CliFlag[] => [
 /** Flag for dry-run mode: --dry-run */
 export const dryRunPreset = (): CliFlag[] => [
   {
-    default: false,
     description: 'Execute without side effects',
     name: 'dry-run',
     required: false,

--- a/packages/core/src/__tests__/context.test.ts
+++ b/packages/core/src/__tests__/context.test.ts
@@ -74,4 +74,14 @@ describe('createTrailContext', () => {
     const b = createTrailContext();
     expect(a.requestId).not.toBe(b.requestId);
   });
+
+  test('defaults dryRun to false', () => {
+    const ctx = createTrailContext();
+    expect(ctx.dryRun).toBe(false);
+  });
+
+  test('respects dryRun override', () => {
+    const ctx = createTrailContext({ dryRun: true });
+    expect(ctx.dryRun).toBe(true);
+  });
 });

--- a/packages/core/src/__tests__/execute.test.ts
+++ b/packages/core/src/__tests__/execute.test.ts
@@ -2163,4 +2163,81 @@ describe('executeTrail', () => {
       });
     });
   });
+
+  describe('dryRun option', () => {
+    test('defaults ctx.dryRun to false when option omitted', async () => {
+      let observed: boolean | undefined;
+      const t = trail('observes-dry-run-default', {
+        blaze: (_input, ctx) => {
+          observed = ctx.dryRun;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+
+      const result = await executeTrail(t, {});
+
+      expect(result.isOk()).toBe(true);
+      expect(observed).toBe(false);
+    });
+
+    test('sets ctx.dryRun to true when dryRun option is true', async () => {
+      let observed: boolean | undefined;
+      const t = trail('observes-dry-run-true', {
+        blaze: (_input, ctx) => {
+          observed = ctx.dryRun;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+
+      const result = await executeTrail(t, {}, { dryRun: true });
+
+      expect(result.isOk()).toBe(true);
+      expect(observed).toBe(true);
+    });
+
+    test('option dryRun: true overrides ctx.dryRun: false', async () => {
+      let observed: boolean | undefined;
+      const t = trail('dry-run-precedence', {
+        blaze: (_input, ctx) => {
+          observed = ctx.dryRun;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+
+      const result = await executeTrail(
+        t,
+        {},
+        {
+          ctx: { dryRun: false },
+          dryRun: true,
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(observed).toBe(true);
+    });
+
+    test('preserves ctx.dryRun: true when dryRun option is omitted', async () => {
+      let observed: boolean | undefined;
+      const t = trail('dry-run-ctx-preserved', {
+        blaze: (_input, ctx) => {
+          observed = ctx.dryRun;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+
+      const result = await executeTrail(t, {}, { ctx: { dryRun: true } });
+
+      expect(result.isOk()).toBe(true);
+      expect(observed).toBe(true);
+    });
+  });
 });

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -310,6 +310,15 @@ describe('trail()', () => {
       expect(t.idempotent).toBe(true);
     });
 
+    test('dryRun capability is preserved when set', () => {
+      const t = trail('supports.dry-run', {
+        blaze: () => Result.ok(),
+        dryRun: true,
+        input: z.object({}),
+      });
+      expect(t.dryRun).toBe(true);
+    });
+
     test('visibility defaults to public', () => {
       const minimal = trail('visible', {
         blaze: () => Result.ok(),

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -34,6 +34,7 @@ export const createTrailContext = (
   const ctx = {
     abortSignal: new AbortController().signal,
     cwd: process.cwd(),
+    dryRun: false,
     env: process.env as Record<string, string | undefined>,
     requestId: Bun.randomUUIDv7(),
     trace: passthroughTrace,
@@ -43,6 +44,9 @@ export const createTrailContext = (
   ctx.resource = lookup;
   if (ctx.trace === undefined) {
     ctx.trace = passthroughTrace;
+  }
+  if (ctx.dryRun === undefined) {
+    ctx.dryRun = false;
   }
   return ctx;
 };

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -100,6 +100,14 @@ export interface ExecuteTrailOptions {
   /** Topo used for signal-driven activation; required for `ctx.fire()` to work. */
   readonly topo?: Topo | undefined;
   /**
+   * Whether this invocation is a dry run.
+   *
+   * Sets `ctx.dryRun` for the trail. Defaults to `false`. The framework
+   * never short-circuits execution on this field — it only carries the
+   * flag through. Trails that read `ctx.dryRun` decide what dry-run means.
+   */
+  readonly dryRun?: boolean | undefined;
+  /**
    * Override the validation schema used for input validation.
    *
    * When a trail is invoked via `ctx.cross()` and the target declares
@@ -130,9 +138,13 @@ const applyContextOverrides = (
       }
     : base;
 
-  return options?.abortSignal
+  const withAbort = options?.abortSignal
     ? { ...withOverrides, abortSignal: options.abortSignal }
     : withOverrides;
+
+  return options?.dryRun === undefined
+    ? withAbort
+    : { ...withAbort, dryRun: options.dryRun };
 };
 
 const bindResourceLookup = (
@@ -159,6 +171,8 @@ const bindResourceLookup = (
  * 1. Factory (`createContext`) or `createTrailContext()` defaults.
  * 2. Partial `ctx` overrides merged on top.
  * 3. `abortSignal` override takes final precedence.
+ * 4. `dryRun` option takes final precedence (defaults to `false` via
+ *    `createTrailContext` when neither option nor `ctx.dryRun` is provided).
  */
 const resolveContext = async (
   options?: ExecuteTrailOptions

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -102,6 +102,14 @@ export interface TrailSpec<I, O, CI = never> {
   readonly intent?: 'read' | 'write' | 'destroy' | undefined;
   /** Trail is idempotent (safe to retry) */
   readonly idempotent?: boolean | undefined;
+  /**
+   * Trail explicitly supports dry-run execution semantics.
+   *
+   * This is a declaration for governance, derivation, and surface tooling. It
+   * does not change runtime behavior by itself; the active invocation signal is
+   * `TrailContext.dryRun`.
+   */
+  readonly dryRun?: boolean | undefined;
   /** Whether trailheads expose this trail by default. */
   readonly visibility?: TrailVisibility | undefined;
   /** Arbitrary meta for tooling and filtering */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -216,6 +216,27 @@ export interface TrailContext {
   readonly extensions?: Readonly<Record<string, unknown>> | undefined;
   readonly resource?: ResourceLookup | undefined;
   /**
+   * Whether the current invocation is a dry run.
+   *
+   * Defaults to `false`. Trails that don't read this field are unaffected.
+   * Trails that do read it decide what dry-run means for their domain — for
+   * example: preview the change without committing, validate inputs without
+   * performing side effects, or return what would happen without actually
+   * doing it.
+   *
+   * The framework only carries the flag from the surface (e.g. CLI
+   * `--dry-run`) into the context. It never short-circuits trail execution
+   * on its own based on this field.
+   *
+   * Pair this runtime signal with `TrailSpec.dryRun`, which declares whether a
+   * trail supports dry-run semantics for governance, derivation, and surface
+   * tooling.
+   *
+   * @remarks Always defined on contexts produced by `executeTrail` or
+   * `createTrailContext` (normalized to `false` when not provided).
+   */
+  readonly dryRun?: boolean | undefined;
+  /**
    * Wrap a callback in a child trace span.
    *
    * Always present on contexts produced by `executeTrail` or

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -441,6 +441,7 @@ describe('deriveSurfaceMap', () => {
     test('safety markers are included when set', () => {
       const t = trail('safe.trail', {
         blaze: noop,
+        dryRun: true,
         idempotent: true,
         input: z.object({}),
         intent: 'read',
@@ -449,6 +450,7 @@ describe('deriveSurfaceMap', () => {
 
       expect(entry.intent).toBe('read');
       expect(entry.idempotent).toBe(true);
+      expect(entry.dryRunCapable).toBe(true);
     });
 
     test('exampleCount reflects the number of examples', () => {

--- a/packages/topographer/src/__tests__/diff.test.ts
+++ b/packages/topographer/src/__tests__/diff.test.ts
@@ -277,13 +277,28 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('safety marker changed classified as warning', () => {
-      const prev = surfaceMap([entry({ id: 'data.wipe', intent: 'read' })]);
-      const curr = surfaceMap([entry({ id: 'data.wipe', intent: 'destroy' })]);
+      const prev = surfaceMap([
+        entry({ id: 'data.wipe', intent: 'read' }),
+        entry({ id: 'data.preview' }),
+      ]);
+      const curr = surfaceMap([
+        entry({ id: 'data.wipe', intent: 'destroy' }),
+        entry({ dryRunCapable: true, id: 'data.preview' }),
+      ]);
       const result = deriveSurfaceMapDiff(prev, curr);
 
-      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings).toHaveLength(2);
       expect(
-        result.warnings[0]?.details.some((d) => d.includes('intent changed'))
+        result.warnings.some((warning) =>
+          warning.details.some((detail) => detail.includes('intent changed'))
+        )
+      ).toBe(true);
+      expect(
+        result.warnings.some((warning) =>
+          warning.details.some((detail) =>
+            detail.includes('dryRunCapable changed')
+          )
+        )
       ).toBe(true);
     });
 

--- a/packages/topographer/src/__tests__/topo-store.test.ts
+++ b/packages/topographer/src/__tests__/topo-store.test.ts
@@ -148,6 +148,7 @@ const exampleApp = () => {
     contours: [entityContour],
     crosses: ['entity.add'],
     description: 'List entities',
+    dryRun: true,
     idempotent: true,
     input: z.object({}),
     intent: 'read',
@@ -665,6 +666,13 @@ describe('topo store projection', () => {
           provenance: { source: 'trail.examples' },
         },
       ]);
+      const listEntry = entries?.find(
+        (entry) =>
+          typeof entry === 'object' &&
+          entry !== null &&
+          (entry as { id?: unknown }).id === 'entity.list'
+      ) as { dryRunCapable?: unknown } | undefined;
+      expect(listEntry?.dryRunCapable).toBe(true);
 
       const lock = JSON.parse(stored.lockContent);
       const lockTrail = lock.apps['projection-app'].trails['entity.add'];

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -351,6 +351,9 @@ const addSafetyMarkers = (
   if (t.idempotent === true) {
     entry['idempotent'] = true;
   }
+  if (t.dryRun === true) {
+    entry['dryRunCapable'] = true;
+  }
 };
 
 /** Add deprecation and detours to an entry. */

--- a/packages/topographer/src/diff.ts
+++ b/packages/topographer/src/diff.ts
@@ -270,6 +270,13 @@ const diffMetadata = (
       `idempotent changed: ${String(prev.idempotent ?? false)} -> ${String(curr.idempotent ?? false)}`
     );
   }
+  if (prev.dryRunCapable !== curr.dryRunCapable) {
+    addDetail(
+      acc,
+      'warning',
+      `dryRunCapable changed: ${String(prev.dryRunCapable ?? false)} -> ${String(curr.dryRunCapable ?? false)}`
+    );
+  }
   if (prev.description !== curr.description) {
     addDetail(acc, 'info', 'Description updated');
   }

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -876,6 +876,10 @@ const addSafetyMarkers = (
   if (trail.idempotent === true) {
     entry['idempotent'] = true;
   }
+
+  if (trail.dryRun === true) {
+    entry['dryRunCapable'] = true;
+  }
 };
 
 const addExtendedMetadata = (

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -99,6 +99,7 @@ export interface SurfaceMapEntry {
   readonly output?: JsonSchema | undefined;
   readonly intent?: 'read' | 'write' | 'destroy' | undefined;
   readonly idempotent?: boolean | undefined;
+  readonly dryRunCapable?: boolean | undefined;
   readonly pattern?: string | undefined;
   readonly deprecated?: boolean | undefined;
   readonly replacedBy?: string | undefined;


### PR DESCRIPTION
## Summary
- Adds `dryRun?: boolean` to `TrailContext` and `ExecuteTrailOptions`.
- Wires CLI-derived `--dry-run` into direct and paginated trail execution for write/destroy intent trails.
- Projects dry-run capability into topographer surface maps, diffs, and topo-store output.

## Details
`createTrailContext` defaults `ctx.dryRun` to `false`, while `applyContextOverrides` only overlays an explicit option so inherited/default context stays intact. The CLI strips `dryRun` as a meta flag, accepts both camelCase and kebab-case parsed forms, and only exposes the flag where the trail intent can mutate state. Topographer now records `dryRunCapable` so capability drift is visible in generated maps and audits.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-407.