### PR TITLE
feat(core,cli): add --permit flag to inject inline permit JSON on trails run

### DIFF
--- a/.changeset/trl-408-permit-flag.md
+++ b/.changeset/trl-408-permit-flag.md
@@ -1,0 +1,9 @@
+---
+'@ontrails/core': patch
+'@ontrails/cli': patch
+'@ontrails/topographer': patch
+---
+
+Add `--permit '<json>'` to inject an inline permit on `trails run`. New `permitPreset()` exposes a `--permit` string flag that the CLI build parses and validates against the `BasePermit` shape (`{ id: string, scopes: string[] }`) using a small Zod schema. Valid permits flow through `ExecuteTrailOptions.permit` → `applyContextOverrides` → `ctx.permit` so existing `enforcePermitRequirement` behavior just sees a populated permit. Invalid JSON or schema mismatch surface as `Result.err(ValidationError)` (exit code 1) before the trail runs, avoiding spurious `PermitError` results from malformed input. The flag is global, never routed into trail input (added to `META_FLAG_CANDIDATES`), and overlays only when defined.
+
+Topographer now projects permit requirements into surface-map entries and classifies permit-tightening diffs as breaking when new scopes are required.

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -1,4 +1,9 @@
-import { defaultOnResult, outputModePreset, tracePreset } from '@ontrails/cli';
+import {
+  defaultOnResult,
+  outputModePreset,
+  permitPreset,
+  tracePreset,
+} from '@ontrails/cli';
 import type { ActionResultContext } from '@ontrails/cli';
 import { surface } from '@ontrails/cli/commander';
 
@@ -62,7 +67,7 @@ try {
     description: 'Agent-native, contract-first TypeScript framework',
     name: 'trails',
     onResult: buildOnResult(session),
-    presets: [outputModePreset(), tracePreset()],
+    presets: [outputModePreset(), tracePreset(), permitPreset()],
     resolveInput: resolveInputWithClack,
     version: trailsPackageVersion,
   });

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -16,6 +16,7 @@ import { z } from 'zod';
 import type { ActionResultContext } from '../build.js';
 import { deriveCliCommands } from '../build.js';
 import type { AnyTrail, CliCommand } from '../command.js';
+import { permitPreset } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -47,6 +48,8 @@ const buildCommands = (...args: Parameters<typeof deriveCliCommands>) => {
   }
   return result.value;
 };
+
+const authPresets = () => permitPreset();
 
 const requireCommand = (commands: CliCommand[]) => {
   const [command] = commands;
@@ -1269,5 +1272,166 @@ describe('--dry-run wiring', () => {
     expect(result.isOk()).toBe(true);
     expect(observedInput).toEqual({ dryRun: true, id: 'abc' });
     expect(observedCtxDryRun).toBe(false);
+  });
+});
+
+describe('--permit wiring', () => {
+  test('--permit JSON sets ctx.permit to the parsed permit object', async () => {
+    let observed: TrailContext['permit'];
+    const t = trail('thing.read', {
+      blaze: (_input, ctx) => {
+        observed = ctx.permit;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', permit: '{"id":"dev","scopes":["admin:write"]}' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(observed).toEqual({ id: 'dev', scopes: ['admin:write'] });
+  });
+
+  test('omitted --permit leaves ctx.permit undefined', async () => {
+    let observed: TrailContext['permit'] = { id: 'sentinel', scopes: [] };
+    const t = trail('thing.read-default', {
+      blaze: (_input, ctx) => {
+        observed = ctx.permit;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute({ id: 'abc' }, { id: 'abc' });
+
+    expect(result.isOk()).toBe(true);
+    expect(observed).toBeUndefined();
+  });
+
+  test('--permit with invalid JSON fails with ValidationError', async () => {
+    const t = trail('thing.read-bad-json', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', permit: 'not-json' }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(result.error.message.toLowerCase()).toContain('permit');
+  });
+
+  test('--permit missing scopes field fails with ValidationError', async () => {
+    const t = trail('thing.read-missing-scopes', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', permit: '{"id":"dev"}' }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(ValidationError);
+  });
+
+  test('--permit with non-string id fails with ValidationError', async () => {
+    const t = trail('thing.read-bad-id', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', permit: '{"id":42,"scopes":["x"]}' }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(ValidationError);
+  });
+
+  test('--permit does not leak into trail input', async () => {
+    let receivedInput: unknown;
+    const t = trail('thing.read-no-leak', {
+      blaze: (input: { id: string }) => {
+        receivedInput = input;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', permit: '{"id":"dev","scopes":["admin:write"]}' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(receivedInput).toEqual({ id: 'abc' });
+  });
+
+  test('--permit satisfies permit-protected trails when scopes match', async () => {
+    const t = trail('thing.write-protected', {
+      blaze: (_input, ctx) => Result.ok({ ok: true, permitId: ctx.permit?.id }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean(), permitId: z.string().optional() }),
+      permit: { scopes: ['entity:write'] },
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      {
+        id: 'abc',
+        permit: '{"id":"dev","scopes":["entity:write","entity:read"]}',
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    expect(result.value).toEqual({ ok: true, permitId: 'dev' });
   });
 });

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  BasePermit,
   BaseSurfaceOptions,
   Field,
   Layer,
@@ -14,6 +15,7 @@ import type {
 import {
   Result,
   ValidationError,
+  basePermitSchema,
   deriveCliPath,
   deriveFields,
   executeTrail,
@@ -132,6 +134,7 @@ const META_FLAG_CANDIDATES = new Set([
   'json',
   'jsonl',
   'output',
+  'permit',
   'quiet',
   'trace',
 ]);
@@ -143,6 +146,44 @@ const STRUCTURED_INLINE_JSON_ARG: CliArg = {
   name: STRUCTURED_INLINE_JSON_ARG_NAME,
   required: false,
   variadic: false,
+};
+
+/**
+ * Parse and validate the `--permit '<json>'` flag value.
+ *
+ * Returns `Result.err(ValidationError)` for non-string inputs, JSON parse
+ * failures, or schema mismatches. Returns `Result.ok(undefined)` when the
+ * flag is unset so callers can avoid clobbering an inherited permit.
+ */
+const parsePermitFlag = (
+  raw: unknown
+): Result<BasePermit | undefined, ValidationError> => {
+  if (raw === undefined) {
+    return Result.ok();
+  }
+  if (typeof raw !== 'string') {
+    return Result.err(
+      new ValidationError('--permit expects a JSON string value')
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return Result.err(
+      new ValidationError(`--permit value is not valid JSON: ${detail}`)
+    );
+  }
+  const validated = basePermitSchema.safeParse(parsed);
+  if (!validated.success) {
+    return Result.err(
+      new ValidationError(
+        `--permit JSON does not match the BasePermit shape ({ id: string; scopes: string[] }): ${validated.error.message}`
+      )
+    );
+  }
+  return Result.ok(validated.data);
 };
 
 /** Auto-derived flag for paginated trails: --all triggers iteration. */
@@ -379,7 +420,8 @@ const runTrailOnce = async (
   ctxOverrides: Partial<TrailContext> | undefined,
   options: DeriveCliCommandsOptions | undefined,
   input: Record<string, unknown>,
-  dryRun: boolean | undefined
+  dryRun: boolean | undefined,
+  permit: BasePermit | undefined
 ): Promise<Result<unknown, Error>> =>
   await executeTrail(t, input, {
     configValues: options?.configValues,
@@ -387,6 +429,7 @@ const runTrailOnce = async (
     ctx: withSurfaceMarker('cli', ctxOverrides),
     dryRun,
     layers: options?.layers,
+    ...(permit === undefined ? {} : { permit }),
     resources: options?.resources,
     topo: graph,
   });
@@ -452,7 +495,8 @@ const runPaginatedIteration = async (
   options: DeriveCliCommandsOptions | undefined,
   baseInput: Record<string, unknown>,
   jsonl: boolean,
-  dryRun: boolean | undefined
+  dryRun: boolean | undefined,
+  permit: BasePermit | undefined
 ): Promise<IterationOutcome> => {
   if (!inputHasCursorField(t)) {
     return {
@@ -470,7 +514,7 @@ const runPaginatedIteration = async (
     cursorField: 'cursor',
     onItem: jsonl ? writeJsonLine : undefined,
     runPage: (input) =>
-      runTrailOnce(graph, t, ctxOverrides, options, input, dryRun),
+      runTrailOnce(graph, t, ctxOverrides, options, input, dryRun, permit),
   });
   return { result, streamed: jsonl && result.isOk() };
 };
@@ -514,6 +558,21 @@ const createExecute =
     }
     const { mergedInput, usedStructuredInput } = merged.value;
 
+    const permitParsed = parsePermitFlag(parsedFlags['permit']);
+    if (permitParsed.isErr()) {
+      const errResult: Result<unknown, Error> = Result.err(permitParsed.error);
+      await reportResult(options, {
+        args: parsedArgs,
+        flags: parsedFlags,
+        input: mergedInput,
+        result: errResult,
+        topoName: graph.name,
+        trail: t,
+      });
+      return errResult;
+    }
+    const permit = permitParsed.value;
+
     const dryRun = readDryRunFlag(parsedFlags, metaFlagNames);
     let result: Result<unknown, Error>;
     let streamed = false;
@@ -525,7 +584,8 @@ const createExecute =
         options,
         mergedInput,
         isJsonlMode(parsedFlags),
-        dryRun
+        dryRun,
+        permit
       );
       ({ result } = outcome);
       ({ streamed } = outcome);
@@ -536,7 +596,8 @@ const createExecute =
         ctxOverrides,
         options,
         metaFlagNames.has('all') ? stripAllFlag(mergedInput) : mergedInput,
-        dryRun
+        dryRun,
+        permit
       );
     }
 

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -141,3 +141,22 @@ export const tracePreset = (): CliFlag[] => [
     variadic: false,
   },
 ];
+
+/**
+ * Flag for inline permit JSON: --permit '<json>'
+ *
+ * Accepts a JSON-encoded `BasePermit` (`{ id: string; scopes: string[] }`)
+ * which the CLI parses, validates, and overlays onto the trail's
+ * `ctx.permit`. Failures (invalid JSON, schema mismatch) are surfaced as
+ * `ValidationError`. The flag is treated as a meta flag — it never routes
+ * into trail input.
+ */
+export const permitPreset = (): CliFlag[] => [
+  {
+    description: 'Inline permit JSON: \'{"id":"...","scopes":["..."]}\'',
+    name: 'permit',
+    required: false,
+    type: 'string',
+    variadic: false,
+  },
+];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ export {
   outputModePreset,
   cwdPreset,
   dryRunPreset,
+  permitPreset,
   tracePreset,
 } from './flags.js';
 

--- a/packages/core/src/__tests__/trail-permit.test.ts
+++ b/packages/core/src/__tests__/trail-permit.test.ts
@@ -2,9 +2,28 @@ import { describe, expect, test } from 'bun:test';
 
 import { z } from 'zod';
 
+import { basePermitSchema } from '../permits';
 import { Result } from '../result';
 import { trail } from '../trail';
 import type { PermitRequirement } from '../types';
+
+describe('basePermitSchema', () => {
+  test('parses the canonical BasePermit shape', () => {
+    const parsed = basePermitSchema.parse({
+      id: 'permit-user-1',
+      scopes: ['user:read'],
+    });
+    expect(parsed).toEqual({ id: 'permit-user-1', scopes: ['user:read'] });
+  });
+
+  test('rejects malformed permit payloads', () => {
+    const parsed = basePermitSchema.safeParse({
+      id: 123,
+      scopes: ['user:read'],
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
 
 describe('PermitRequirement type', () => {
   test('accepts a scopes object', () => {

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -24,6 +24,7 @@ import {
   waitForPendingFireDispatches,
   withFireDispatchTracking,
 } from './fire.js';
+import type { BasePermit } from './permits.js';
 import type {
   CrossBatchOptions,
   CrossFn,
@@ -108,6 +109,16 @@ export interface ExecuteTrailOptions {
    */
   readonly dryRun?: boolean | undefined;
   /**
+   * Permit to overlay onto `ctx.permit` for this invocation.
+   *
+   * When provided, this overrides any permit supplied via `ctx.permit` on
+   * the partial context overrides or via the `createContext` factory. Leave
+   * unset to inherit the permit from the resolved context (typically
+   * `undefined`). Surfaces parse and validate the permit at their boundary
+   * (e.g. CLI `--permit '<json>'`) before passing it here.
+   */
+  readonly permit?: BasePermit | undefined;
+  /**
    * Override the validation schema used for input validation.
    *
    * When a trail is invoked via `ctx.cross()` and the target declares
@@ -142,9 +153,14 @@ const applyContextOverrides = (
     ? { ...withOverrides, abortSignal: options.abortSignal }
     : withOverrides;
 
-  return options?.dryRun === undefined
-    ? withAbort
-    : { ...withAbort, dryRun: options.dryRun };
+  const withDryRun =
+    options?.dryRun === undefined
+      ? withAbort
+      : { ...withAbort, dryRun: options.dryRun };
+
+  return options?.permit === undefined
+    ? withDryRun
+    : { ...withDryRun, permit: options.permit };
 };
 
 const bindResourceLookup = (
@@ -173,6 +189,9 @@ const bindResourceLookup = (
  * 3. `abortSignal` override takes final precedence.
  * 4. `dryRun` option takes final precedence (defaults to `false` via
  *    `createTrailContext` when neither option nor `ctx.dryRun` is provided).
+ * 5. `permit` option takes final precedence over any inherited permit when
+ *    provided; leaving it unset preserves whatever the resolved context
+ *    already carries.
  */
 const resolveContext = async (
   options?: ExecuteTrailOptions

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,7 +67,6 @@ export type {
   CrossBatchOptions,
   CrossFn,
   FireFn,
-  BasePermit,
   LogLevel,
   LogFormatter,
   LogRecord,
@@ -78,6 +77,8 @@ export type {
   Logger,
   ResourceLookup,
 } from './types.js';
+export { basePermitSchema } from './permits.js';
+export type { BasePermit } from './permits.js';
 export { SURFACE_KEY } from './types.js';
 export {
   ACTIVATION_PROVENANCE_KEY,

--- a/packages/core/src/permits.ts
+++ b/packages/core/src/permits.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+/** Minimal permit shape available on TrailContext. */
+export interface BasePermit {
+  readonly id: string;
+  readonly scopes: readonly string[];
+}
+
+export const basePermitSchema: z.ZodType<BasePermit> = z.object({
+  id: z.string(),
+  scopes: z.array(z.string()).readonly(),
+});

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -11,6 +11,7 @@
 
 import type { Trail } from './trail.js';
 import type { Signal } from './signal.js';
+import type { BasePermit } from './permits.js';
 import type { FireFn } from './types.js';
 import type { CrossInput, TrailInput } from './type-utils.js';
 
@@ -123,6 +124,16 @@ type AssertFireReturnsVoid = FireFn extends {
 export type FireReturnsVoid = [AssertFireReturnsVoid] extends [true]
   ? 'pass'
   : never;
+
+// ---------------------------------------------------------------------------
+// BasePermit preserves readonly fields across schema inference
+// ---------------------------------------------------------------------------
+
+declare const permit: BasePermit;
+// @ts-expect-error BasePermit.id is immutable once installed on TrailContext.
+permit.id = 'next';
+// @ts-expect-error BasePermit.scopes is immutable once installed on TrailContext.
+permit.scopes.push('next');
 
 type AssertFireAcceptsSignalValue = FireFn extends {
   (signal: OrderPlacedSignal, payload: { orderId: string }): Promise<void>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,5 @@
 import type { TrailsError } from './errors.js';
+import type { BasePermit } from './permits.js';
 import type { Result } from './result.js';
 import type { Signal } from './signal.js';
 import type { AnyTrail } from './trail.js';
@@ -188,12 +189,6 @@ export interface LogFormatter {
  * Context extension key for the invoking surface name.
  */
 export const SURFACE_KEY = '__trails_surface' as const;
-
-/** Minimal permit shape available on TrailContext. Permits extends this. */
-export interface BasePermit {
-  readonly id: string;
-  readonly scopes: readonly string[];
-}
 
 /** Runtime context threaded through every trail execution */
 export interface TrailContext {

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -453,6 +453,27 @@ describe('deriveSurfaceMap', () => {
       expect(entry.dryRunCapable).toBe(true);
     });
 
+    test('trail permit requirements are included when declared', () => {
+      const scoped = trail('secure.write', {
+        blaze: noop,
+        input: z.object({}),
+        permit: { scopes: ['write:entity', 'read:entity'] },
+      });
+      const publicTrail = trail('status.read', {
+        blaze: noop,
+        input: z.object({}),
+        permit: 'public',
+      });
+      const { entries } = deriveSurfaceMap(topoFrom({ publicTrail, scoped }));
+
+      expect(
+        entries.find((entry) => entry.id === 'secure.write')?.permit
+      ).toEqual({ scopes: ['read:entity', 'write:entity'] });
+      expect(entries.find((entry) => entry.id === 'status.read')?.permit).toBe(
+        'public'
+      );
+    });
+
     test('exampleCount reflects the number of examples', () => {
       const t = trail('with.examples', {
         blaze: noop,

--- a/packages/topographer/src/__tests__/diff.test.ts
+++ b/packages/topographer/src/__tests__/diff.test.ts
@@ -276,18 +276,24 @@ describe('deriveSurfaceMapDiff', () => {
       ).toBe(true);
     });
 
-    test('safety marker changed classified as warning', () => {
+    test('safety marker changes partition by severity', () => {
       const prev = surfaceMap([
         entry({ id: 'data.wipe', intent: 'read' }),
         entry({ id: 'data.preview' }),
+        entry({ id: 'data.secure', permit: 'public' }),
       ]);
       const curr = surfaceMap([
         entry({ id: 'data.wipe', intent: 'destroy' }),
         entry({ dryRunCapable: true, id: 'data.preview' }),
+        entry({
+          id: 'data.secure',
+          permit: { scopes: ['data:write'] },
+        }),
       ]);
       const result = deriveSurfaceMapDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(2);
+      expect(result.breaking).toHaveLength(1);
       expect(
         result.warnings.some((warning) =>
           warning.details.some((detail) => detail.includes('intent changed'))
@@ -300,6 +306,51 @@ describe('deriveSurfaceMapDiff', () => {
           )
         )
       ).toBe(true);
+      expect(
+        result.breaking.some((breaking) =>
+          breaking.details.some((detail) => detail.includes('permit changed'))
+        )
+      ).toBe(true);
+    });
+
+    test('adding permit scopes is classified as breaking', () => {
+      const prev = surfaceMap([
+        entry({
+          id: 'data.secure',
+          permit: { scopes: ['data:read'] },
+        }),
+      ]);
+      const curr = surfaceMap([
+        entry({
+          id: 'data.secure',
+          permit: { scopes: ['data:read', 'data:write'] },
+        }),
+      ]);
+      const result = deriveSurfaceMapDiff(prev, curr);
+
+      expect(result.hasBreaking).toBe(true);
+      expect(result.breaking[0]?.details).toContain(
+        'permit changed: {"scopes":["data:read"]} -> {"scopes":["data:read","data:write"]}'
+      );
+    });
+
+    test('permit scope order does not produce a warning', () => {
+      const prev = surfaceMap([
+        entry({
+          id: 'data.secure',
+          permit: { scopes: ['data:write', 'data:read'] },
+        }),
+      ]);
+      const curr = surfaceMap([
+        entry({
+          id: 'data.secure',
+          permit: { scopes: ['data:read', 'data:write'] },
+        }),
+      ]);
+      const result = deriveSurfaceMapDiff(prev, curr);
+
+      expect(result.warnings).toHaveLength(0);
+      expect(result.hasBreaking).toBe(false);
     });
 
     test('description change classified as info', () => {

--- a/packages/topographer/src/__tests__/topo-store.test.ts
+++ b/packages/topographer/src/__tests__/topo-store.test.ts
@@ -153,6 +153,7 @@ const exampleApp = () => {
     input: z.object({}),
     intent: 'read',
     output: z.object({ items: z.array(z.string()) }),
+    permit: { scopes: ['entity:read'] },
     resources: [dbMain],
   });
 
@@ -671,8 +672,9 @@ describe('topo store projection', () => {
           typeof entry === 'object' &&
           entry !== null &&
           (entry as { id?: unknown }).id === 'entity.list'
-      ) as { dryRunCapable?: unknown } | undefined;
+      ) as { dryRunCapable?: unknown; permit?: unknown } | undefined;
       expect(listEntry?.dryRunCapable).toBe(true);
+      expect(listEntry?.permit).toEqual({ scopes: ['entity:read'] });
 
       const lock = JSON.parse(stored.lockContent);
       const lockTrail = lock.apps['projection-app'].trails['entity.add'];

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -23,6 +23,7 @@ import type {
   Trail,
 } from '@ontrails/core';
 
+import { addPermitRequirement } from './permit.js';
 import type {
   JsonSchema,
   SurfaceMap,
@@ -494,6 +495,7 @@ const trailToEntry = (t: Trail<unknown, unknown, unknown>): SurfaceMapEntry => {
 
   addSchemas(entry, t);
   addMetadata(entry, t, raw);
+  addPermitRequirement(entry, t);
   addTrailRelations(entry, t);
   addFieldOverrides(entry, t);
   addExamples(entry, t);

--- a/packages/topographer/src/diff.ts
+++ b/packages/topographer/src/diff.ts
@@ -57,6 +57,50 @@ const labelForKind = (kind: SurfaceMapEntry['kind']): string => {
   return 'Trail';
 };
 
+const stableStringify = (value: unknown): string =>
+  JSON.stringify(value, (_key, nested) => {
+    if (Array.isArray(nested)) {
+      return [...nested].toSorted((a, b) =>
+        JSON.stringify(a).localeCompare(JSON.stringify(b))
+      );
+    }
+    if (
+      nested !== null &&
+      typeof nested === 'object' &&
+      !Array.isArray(nested)
+    ) {
+      return Object.fromEntries(Object.entries(nested).toSorted());
+    }
+    return nested;
+  });
+
+const permitScopes = (
+  permit: SurfaceMapEntry['permit'] | undefined
+): ReadonlySet<string> | undefined =>
+  permit === undefined || permit === 'public'
+    ? undefined
+    : new Set(permit.scopes);
+
+const permitChangeSeverity = (
+  prevPermit: SurfaceMapEntry['permit'] | undefined,
+  currPermit: SurfaceMapEntry['permit'] | undefined
+): Severity => {
+  const prevScopes = permitScopes(prevPermit);
+  const currScopes = permitScopes(currPermit);
+  if (currScopes === undefined) {
+    return 'warning';
+  }
+  if (prevScopes === undefined) {
+    return 'breaking';
+  }
+  for (const scope of currScopes) {
+    if (!prevScopes.has(scope)) {
+      return 'breaking';
+    }
+  }
+  return 'warning';
+};
+
 // ---------------------------------------------------------------------------
 // Schema field diffing
 // ---------------------------------------------------------------------------
@@ -275,6 +319,15 @@ const diffMetadata = (
       acc,
       'warning',
       `dryRunCapable changed: ${String(prev.dryRunCapable ?? false)} -> ${String(curr.dryRunCapable ?? false)}`
+    );
+  }
+  const prevPermit = stableStringify(prev.permit ?? 'undeclared');
+  const currPermit = stableStringify(curr.permit ?? 'undeclared');
+  if (prevPermit !== currPermit) {
+    addDetail(
+      acc,
+      permitChangeSeverity(prev.permit, curr.permit),
+      `permit changed: ${prevPermit} -> ${currPermit}`
     );
   }
   if (prev.description !== curr.description) {

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -23,6 +23,7 @@ import type {
   Topo,
 } from '@ontrails/core';
 
+import { addPermitRequirement } from '../permit.js';
 import type {
   CreateTopoSnapshotInput,
   TopoSnapshot,
@@ -993,6 +994,7 @@ const trailToEntryRecord = (
 ): SurfaceMapEntryRecord => {
   const { entry, raw } = buildTrailEntryBase(trail, trailSchema);
   addSafetyMarkers(entry, trail);
+  addPermitRequirement(entry, trail);
   addExtendedMetadata(entry, raw, trail);
   addTrailRelations(entry, trail);
   return sortKeys(entry) as SurfaceMapEntryRecord;

--- a/packages/topographer/src/permit.ts
+++ b/packages/topographer/src/permit.ts
@@ -1,0 +1,19 @@
+import type { AnyTrail, PermitRequirement } from '@ontrails/core';
+
+export type ProjectedPermitRequirement =
+  | 'public'
+  | { readonly scopes: readonly string[] };
+
+export const projectPermitRequirement = (
+  permit: PermitRequirement
+): ProjectedPermitRequirement =>
+  permit === 'public' ? 'public' : { scopes: [...permit.scopes].toSorted() };
+
+export const addPermitRequirement = (
+  entry: Record<string, unknown>,
+  trail: AnyTrail
+): void => {
+  if (trail.permit !== undefined) {
+    entry['permit'] = projectPermitRequirement(trail.permit);
+  }
+};

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -81,6 +81,10 @@ export interface SurfaceMapActivationEntry {
   readonly where?: { readonly predicate: true } | undefined;
 }
 
+export interface SurfaceMapPermitRequirement {
+  readonly scopes: readonly string[];
+}
+
 // ---------------------------------------------------------------------------
 // Surface Map
 // ---------------------------------------------------------------------------
@@ -100,6 +104,7 @@ export interface SurfaceMapEntry {
   readonly intent?: 'read' | 'write' | 'destroy' | undefined;
   readonly idempotent?: boolean | undefined;
   readonly dryRunCapable?: boolean | undefined;
+  readonly permit?: 'public' | SurfaceMapPermitRequirement | undefined;
   readonly pattern?: string | undefined;
   readonly deprecated?: boolean | undefined;
   readonly replacedBy?: string | undefined;


### PR DESCRIPTION
## Summary
- Adds the canonical `BasePermit` shape and `basePermitSchema` in `@ontrails/core`.
- Adds `executeTrail(..., { permit })` support so surfaces can populate `ctx.permit` for one invocation.
- Adds CLI `--permit <json>` parsing plus topographer projection of trail permit requirements.

## Details
The CLI validates inline permit JSON at the boundary and returns `ValidationError` for malformed payloads, rather than allowing bad input to masquerade as a permit-scope failure. `permit` is a meta flag and never routes into trail input. Existing `enforcePermitRequirement` remains the single enforcement point; this branch only supplies the permit and makes declared requirements visible in surface maps, diffs, and topo-store entries.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-408.