### PR TITLE
feat(cli,trails): add --token permit resolver hook

### DIFF
--- a/.changeset/trl-408-permit-flag.md
+++ b/.changeset/trl-408-permit-flag.md
@@ -1,7 +1,7 @@
 ---
-'@ontrails/core': patch
-'@ontrails/cli': patch
-'@ontrails/topographer': patch
+'@ontrails/core': minor
+'@ontrails/cli': minor
+'@ontrails/topographer': minor
 ---
 
 Add `--permit '<json>'` to inject an inline permit on `trails run`. New `permitPreset()` exposes a `--permit` string flag that the CLI build parses and validates against the `BasePermit` shape (`{ id: string, scopes: string[] }`) using a small Zod schema. Valid permits flow through `ExecuteTrailOptions.permit` → `applyContextOverrides` → `ctx.permit` so existing `enforcePermitRequirement` behavior just sees a populated permit. Invalid JSON or schema mismatch surface as `Result.err(ValidationError)` (exit code 1) before the trail runs, avoiding spurious `PermitError` results from malformed input. The flag is global, never routed into trail input (added to `META_FLAG_CANDIDATES`), and overlays only when defined.

--- a/.changeset/trl-409-token-flag.md
+++ b/.changeset/trl-409-token-flag.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/cli': minor
+---
+
+Add `--token <token>` to `trails run` for permit resolution via the topo's auth connector. New `tokenPreset()` exposes the flag; `'token'` is added to `META_FLAG_CANDIDATES`. The CLI resolves the `auth` resource through the shared permit-boundary helper, calls `connector.authenticate({ surface: 'cli', bearerToken, requestId })`, and projects the resolved `Permit` into `ExecuteTrailOptions.permit` (added in TRL-408) so it reaches `ctx.permit`. Failures: missing connector → `ValidationError` (exit 1); connector returns `Err(AuthError)` or `Ok(null)` → `AuthError` (category `'auth'`, exit 9, with the connector's code preserved on `error.context.code`). `--token` and `--permit` are mutually exclusive — supplying both yields `ValidationError`.

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -28,6 +28,7 @@
     "@ontrails/http": "workspace:^",
     "@ontrails/logging": "workspace:^",
     "@ontrails/observe": "workspace:^",
+    "@ontrails/permits": "workspace:^",
     "@ontrails/topographer": "workspace:^",
     "@ontrails/tracing": "workspace:^",
     "@ontrails/warden": "workspace:^",

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -2,10 +2,15 @@ import {
   defaultOnResult,
   outputModePreset,
   permitPreset,
+  tokenPreset,
   tracePreset,
 } from '@ontrails/cli';
-import type { ActionResultContext } from '@ontrails/cli';
+import type {
+  ActionResultContext,
+  ResolveCliPermitFromToken,
+} from '@ontrails/cli';
 import { surface } from '@ontrails/cli/commander';
+import { resolvePermitFromBearerToken } from '@ontrails/permits';
 
 import { app } from './app.js';
 import { resolveInputWithClack } from './clack.js';
@@ -61,14 +66,28 @@ const session: TraceSession | undefined = argvHasTraceFlag(process.argv)
   ? installTraceSink()
   : undefined;
 
+const resolveCliPermitFromToken: ResolveCliPermitFromToken = (input) =>
+  resolvePermitFromBearerToken({
+    bearerToken: input.token,
+    env: process.env as Record<string, string | undefined>,
+    graph: input.graph,
+    missingAuthResourceMessage:
+      '--token requires an auth connector. Register authResource from @ontrails/permits in your topo.',
+    nullPermitMessage: 'Auth connector did not produce a permit for --token',
+    requestId: input.requestId,
+    resources: input.resources,
+    surface: 'cli',
+  });
+
 try {
   // oxlint-disable-next-line require-hook -- CLI entry point
   await surface(app, {
     description: 'Agent-native, contract-first TypeScript framework',
     name: 'trails',
     onResult: buildOnResult(session),
-    presets: [outputModePreset(), tracePreset(), permitPreset()],
+    presets: [outputModePreset(), tracePreset(), permitPreset(), tokenPreset()],
     resolveInput: resolveInputWithClack,
+    resolvePermitFromToken: resolveCliPermitFromToken,
     version: trailsPackageVersion,
   });
 } finally {

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "@ontrails/http": "workspace:^",
         "@ontrails/logging": "workspace:^",
         "@ontrails/observe": "workspace:^",
+        "@ontrails/permits": "workspace:^",
         "@ontrails/topographer": "workspace:^",
         "@ontrails/tracing": "workspace:^",
         "@ontrails/warden": "workspace:^",

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  AuthError,
   Result,
   SURFACE_KEY,
   ValidationError,
@@ -16,7 +17,7 @@ import { z } from 'zod';
 import type { ActionResultContext } from '../build.js';
 import { deriveCliCommands } from '../build.js';
 import type { AnyTrail, CliCommand } from '../command.js';
-import { permitPreset } from '../flags.js';
+import { permitPreset, tokenPreset } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -49,7 +50,7 @@ const buildCommands = (...args: Parameters<typeof deriveCliCommands>) => {
   return result.value;
 };
 
-const authPresets = () => permitPreset();
+const authPresets = () => [permitPreset(), tokenPreset()];
 
 const requireCommand = (commands: CliCommand[]) => {
   const [command] = commands;
@@ -1433,5 +1434,339 @@ describe('--permit wiring', () => {
       throw new Error('expected ok');
     }
     expect(result.value).toEqual({ ok: true, permitId: 'dev' });
+  });
+});
+
+describe('--token wiring', () => {
+  interface StubAuthConnector {
+    readonly authenticate: (input: {
+      readonly bearerToken?: string | undefined;
+      readonly requestId: string;
+      readonly surface: 'cli' | 'http' | 'mcp';
+    }) => Promise<
+      Result<
+        { readonly id: string; readonly scopes: readonly string[] } | null,
+        { readonly code: string; readonly message: string }
+      >
+    >;
+  }
+
+  /**
+   * Build a topo containing a trail plus an auth resource whose connector is
+   * supplied via `options.resources` so the test does not need to instantiate
+   * the real `@ontrails/permits` factory.
+   */
+  const authResourceDef = resource<{
+    readonly authenticate: (input: {
+      readonly surface: 'cli' | 'http' | 'mcp';
+      readonly bearerToken?: string | undefined;
+      readonly requestId: string;
+    }) => Promise<
+      Result<
+        {
+          readonly id: string;
+          readonly scopes: readonly string[];
+        } | null,
+        { readonly code: string; readonly message: string }
+      >
+    >;
+  }>('auth', {
+    create: () =>
+      Result.ok({
+        // oxlint-disable-next-line require-await -- fallback connector
+        authenticate: async () => Result.ok(null),
+      }),
+  });
+
+  const makeAuthApp = (t: AnyTrail) =>
+    topo('auth-test-app', { auth: authResourceDef, [t.id]: t });
+
+  const resolvePermitFromTokenForTest: ResolveCliPermitFromToken = async ({
+    requestId,
+    resources,
+    token,
+  }) => {
+    const connector = resources?.['auth'] as StubAuthConnector | undefined;
+    if (connector === undefined) {
+      return Result.err(
+        new ValidationError(
+          '--token requires an auth connector. Register authResource from @ontrails/permits in your topo.'
+        )
+      );
+    }
+    const authResult = await connector.authenticate({
+      bearerToken: token,
+      requestId,
+      surface: 'cli',
+    });
+    if (authResult.isErr()) {
+      return Result.err(
+        new AuthError(authResult.error.message, {
+          context: { code: authResult.error.code },
+        })
+      );
+    }
+    if (authResult.value === null) {
+      return Result.err(
+        new AuthError('Auth connector did not produce a permit for --token', {
+          context: { code: 'missing_credentials' },
+        })
+      );
+    }
+    return Result.ok(authResult.value);
+  };
+
+  const buildAuthCommands = (
+    app: Parameters<typeof buildCommands>[0],
+    resources?: Record<string, unknown>
+  ) =>
+    buildCommands(app, {
+      ...(resources === undefined ? {} : { resources }),
+      presets: authPresets(),
+      resolvePermitFromToken: resolvePermitFromTokenForTest,
+    });
+
+  test('--token resolves a permit via the auth connector and lands ctx.permit', async () => {
+    let observed: TrailContext['permit'];
+    const t = trail('thing.token-read', {
+      blaze: (_input, ctx) => {
+        observed = ctx.permit;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const stubConnector = {
+      authenticate: (input: { readonly bearerToken?: string | undefined }) =>
+        Promise.resolve(
+          input.bearerToken === 'good-token'
+            ? Result.ok({ id: 'user-42', scopes: ['read', 'write'] })
+            : Result.err({ code: 'invalid_token', message: 'rejected' })
+        ),
+    };
+
+    const app = makeAuthApp(t);
+    const cmd = requireCommand(buildAuthCommands(app, { auth: stubConnector }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', token: 'good-token' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(observed).toEqual({ id: 'user-42', scopes: ['read', 'write'] });
+  });
+
+  test('--token without a registered auth resource fails with ValidationError', async () => {
+    const t = trail('thing.no-auth', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    // Topo without an auth resource registered.
+    const app = makeApp(t);
+    const cmd = requireCommand(buildAuthCommands(app));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', token: 'any-token' }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(result.error.message.toLowerCase()).toContain('auth');
+  });
+
+  test('--token with invalid token surfaces an AuthError (auth category, exit 9)', async () => {
+    const t = trail('thing.bad-token', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const stubConnector = {
+      // oxlint-disable-next-line require-await -- stub connector
+      authenticate: async () =>
+        Result.err({ code: 'invalid_token', message: 'bad signature' }),
+    };
+
+    const app = makeAuthApp(t);
+    const cmd = requireCommand(buildAuthCommands(app, { auth: stubConnector }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', token: 'nope' }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(AuthError);
+    expect(result.error.message.toLowerCase()).toContain('bad signature');
+    if (result.error instanceof AuthError) {
+      expect(result.error.context).toMatchObject({ code: 'invalid_token' });
+    }
+  });
+
+  test('--token returning a null permit fails with AuthError (missing credentials)', async () => {
+    const t = trail('thing.null-permit', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const stubConnector = {
+      // oxlint-disable-next-line require-await -- stub connector
+      authenticate: async () => Result.ok(null),
+    };
+
+    const app = makeAuthApp(t);
+    const cmd = requireCommand(buildAuthCommands(app, { auth: stubConnector }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', token: 'opaque' }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(AuthError);
+    if (result.error instanceof AuthError) {
+      expect(result.error.context).toMatchObject({
+        code: 'missing_credentials',
+      });
+    }
+  });
+
+  test('--token and --permit together fail with ValidationError', async () => {
+    const t = trail('thing.both-flags', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const stubConnector = {
+      // oxlint-disable-next-line require-await -- stub connector
+      authenticate: async () => Result.ok({ id: 'u', scopes: [] }),
+    };
+
+    const app = makeAuthApp(t);
+    const cmd = requireCommand(buildAuthCommands(app, { auth: stubConnector }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      {
+        id: 'abc',
+        permit: '{"id":"dev","scopes":["x"]}',
+        token: 'good-token',
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(result.error.message.toLowerCase()).toContain('mutually exclusive');
+  });
+
+  test('omitted --token and --permit leaves ctx.permit undefined', async () => {
+    let observed: TrailContext['permit'] = { id: 'sentinel', scopes: [] };
+    const t = trail('thing.no-flags', {
+      blaze: (_input, ctx) => {
+        observed = ctx.permit;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const stubConnector = {
+      // oxlint-disable-next-line require-await -- stub connector
+      authenticate: async () => Result.ok({ id: 'u', scopes: [] }),
+    };
+
+    const app = makeAuthApp(t);
+    const cmd = requireCommand(buildAuthCommands(app, { auth: stubConnector }));
+
+    const result = await cmd.execute({ id: 'abc' }, { id: 'abc' });
+
+    expect(result.isOk()).toBe(true);
+    expect(observed).toBeUndefined();
+  });
+
+  test('--token does not leak into trail input', async () => {
+    let receivedInput: unknown;
+    const t = trail('thing.token-no-leak', {
+      blaze: (input: { id: string }) => {
+        receivedInput = input;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const stubConnector = {
+      // oxlint-disable-next-line require-await -- stub connector
+      authenticate: async () => Result.ok({ id: 'user-42', scopes: ['read'] }),
+    };
+
+    const app = makeAuthApp(t);
+    const cmd = requireCommand(buildAuthCommands(app, { auth: stubConnector }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', token: 'good-token' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(receivedInput).toEqual({ id: 'abc' });
+  });
+
+  test('--token forwards surface "cli" and a bearer token to the connector', async () => {
+    let seenInput:
+      | {
+          readonly surface?: string;
+          readonly bearerToken?: string;
+          readonly requestId?: string;
+        }
+      | undefined;
+    const t = trail('thing.token-forward', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const stubConnector = {
+      authenticate: (input: {
+        readonly surface: string;
+        readonly bearerToken?: string | undefined;
+        readonly requestId: string;
+      }) => {
+        seenInput = input;
+        return Promise.resolve(Result.ok({ id: 'user-42', scopes: ['read'] }));
+      },
+    };
+
+    const app = makeAuthApp(t);
+    const cmd = requireCommand(buildAuthCommands(app, { auth: stubConnector }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { id: 'abc', token: 'forward-me' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(seenInput?.surface).toBe('cli');
+    expect(seenInput?.bearerToken).toBe('forward-me');
+    expect(typeof seenInput?.requestId).toBe('string');
   });
 });

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -70,6 +70,17 @@ export interface ActionResultContext {
   readonly streamed?: boolean | undefined;
 }
 
+export interface ResolveCliPermitFromTokenInput {
+  readonly graph: Topo;
+  readonly requestId: string;
+  readonly resources?: ResourceOverrideMap | undefined;
+  readonly token: string;
+}
+
+export type ResolveCliPermitFromToken = (
+  input: ResolveCliPermitFromTokenInput
+) => Promise<Result<BasePermit, Error>> | Result<BasePermit, Error>;
+
 /** Options for CLI command projection. */
 export interface DeriveCliCommandsOptions extends BaseSurfaceOptions {
   createContext?:
@@ -79,6 +90,7 @@ export interface DeriveCliCommandsOptions extends BaseSurfaceOptions {
   onResult?: ((ctx: ActionResultContext) => Promise<void>) | undefined;
   presets?: readonly (readonly CliFlag[])[] | undefined;
   resources?: ResourceOverrideMap | undefined;
+  resolvePermitFromToken?: ResolveCliPermitFromToken | undefined;
   resolveInput?: InputResolver | undefined;
 }
 
@@ -136,6 +148,7 @@ const META_FLAG_CANDIDATES = new Set([
   'output',
   'permit',
   'quiet',
+  'token',
   'trace',
 ]);
 
@@ -184,6 +197,31 @@ const parsePermitFlag = (
     );
   }
   return Result.ok(validated.data);
+};
+
+// ---------------------------------------------------------------------------
+// --token resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and validate the `--token <value>` flag.
+ *
+ * Returns `Result.ok(undefined)` when the flag is unset so callers can skip
+ * the configured permit resolver.
+ */
+const parseTokenFlag = (
+  raw: unknown
+): Result<string | undefined, ValidationError> => {
+  if (raw === undefined) {
+    return Result.ok();
+  }
+  if (typeof raw !== 'string') {
+    return Result.err(new ValidationError('--token expects a string value'));
+  }
+  if (raw.length === 0) {
+    return Result.err(new ValidationError('--token must not be empty'));
+  }
+  return Result.ok(raw);
 };
 
 /** Auto-derived flag for paginated trails: --all triggers iteration. */
@@ -519,6 +557,58 @@ const runPaginatedIteration = async (
   return { result, streamed: jsonl && result.isOk() };
 };
 
+/**
+ * Reconcile `--permit` and `--token` into a single `BasePermit | undefined`
+ * for the execution pipeline.
+ *
+ * `--permit` and `--token` are mutually exclusive: when both are supplied
+ * the call surfaces a `ValidationError` (exit 1). When only `--token` is
+ * supplied the auth connector resolves it into a permit; failures map to
+ * `AuthError` (exit 9). When neither flag is supplied the call returns
+ * `Result.ok(undefined)` so callers preserve any inherited permit.
+ */
+const resolvePermitForExecution = async (
+  graph: Topo,
+  parsedFlags: Record<string, unknown>,
+  metaFlagNames: ReadonlySet<string>,
+  options: DeriveCliCommandsOptions | undefined
+): Promise<Result<BasePermit | undefined, Error>> => {
+  const permitParsed = metaFlagNames.has('permit')
+    ? parsePermitFlag(parsedFlags['permit'])
+    : Result.ok<BasePermit | undefined>();
+  if (permitParsed.isErr()) {
+    return permitParsed;
+  }
+  const tokenParsed = metaFlagNames.has('token')
+    ? parseTokenFlag(parsedFlags['token'])
+    : Result.ok<string | undefined>();
+  if (tokenParsed.isErr()) {
+    return tokenParsed;
+  }
+  if (permitParsed.value !== undefined && tokenParsed.value !== undefined) {
+    return Result.err(
+      new ValidationError('--token and --permit are mutually exclusive.')
+    );
+  }
+  if (tokenParsed.value === undefined) {
+    return Result.ok(permitParsed.value);
+  }
+  if (options?.resolvePermitFromToken === undefined) {
+    return Result.err(
+      new ValidationError(
+        '--token requires a CLI permit resolver supplied via resolvePermitFromToken.'
+      )
+    );
+  }
+  const requestId = Bun.randomUUIDv7();
+  return await options.resolvePermitFromToken({
+    graph,
+    requestId,
+    resources: options.resources,
+    token: tokenParsed.value,
+  });
+};
+
 /** Create the execute function for a CLI command. */
 const createExecute =
   (
@@ -558,9 +648,16 @@ const createExecute =
     }
     const { mergedInput, usedStructuredInput } = merged.value;
 
-    const permitParsed = parsePermitFlag(parsedFlags['permit']);
-    if (permitParsed.isErr()) {
-      const errResult: Result<unknown, Error> = Result.err(permitParsed.error);
+    const permitResolution = await resolvePermitForExecution(
+      graph,
+      parsedFlags,
+      metaFlagNames,
+      options
+    );
+    if (permitResolution.isErr()) {
+      const errResult: Result<unknown, Error> = Result.err(
+        permitResolution.error
+      );
       await reportResult(options, {
         args: parsedArgs,
         flags: parsedFlags,
@@ -571,7 +668,7 @@ const createExecute =
       });
       return errResult;
     }
-    const permit = permitParsed.value;
+    const permit = permitResolution.value;
 
     const dryRun = readDryRunFlag(parsedFlags, metaFlagNames);
     let result: Result<unknown, Error>;

--- a/packages/cli/src/commander/surface.ts
+++ b/packages/cli/src/commander/surface.ts
@@ -10,7 +10,10 @@ import type {
   TrailContextInit,
 } from '@ontrails/core';
 
-import type { ActionResultContext } from '../build.js';
+import type {
+  ActionResultContext,
+  ResolveCliPermitFromToken,
+} from '../build.js';
 import { deriveCliCommands } from '../build.js';
 import type { CliFlag } from '../command.js';
 import { defaultOnResult } from '../on-result.js';
@@ -33,6 +36,7 @@ export interface CreateProgramOptions extends BaseSurfaceOptions {
   readonly presets?: CliFlag[][] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
   readonly resolveInput?: InputResolver | undefined;
+  readonly resolvePermitFromToken?: ResolveCliPermitFromToken | undefined;
   readonly version?: string | undefined;
 }
 
@@ -81,6 +85,7 @@ export const createProgram = (
     onResult: options.onResult ?? defaultOnResult,
     presets: options.presets,
     resolveInput: options.resolveInput,
+    resolvePermitFromToken: options.resolvePermitFromToken,
     resources: options.resources,
     validate: options.validate,
   });

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -1,5 +1,5 @@
 /**
- * Flag derivation from trailhead-agnostic fields and reusable flag presets.
+ * Flag derivation from surface-agnostic fields and reusable flag presets.
  */
 
 import { deriveFields } from '@ontrails/core';
@@ -150,11 +150,37 @@ export const tracePreset = (): CliFlag[] => [
  * `ctx.permit`. Failures (invalid JSON, schema mismatch) are surfaced as
  * `ValidationError`. The flag is treated as a meta flag — it never routes
  * into trail input.
+ *
+ * Mutually exclusive with `--token`; passing both surfaces a
+ * `ValidationError`.
  */
 export const permitPreset = (): CliFlag[] => [
   {
     description: 'Inline permit JSON: \'{"id":"...","scopes":["..."]}\'',
     name: 'permit',
+    required: false,
+    type: 'string',
+    variadic: false,
+  },
+];
+
+/**
+ * Flag for resolving a permit through the CLI resolver: --token <value>
+ *
+ * The surface caller supplies `resolvePermitFromToken` to turn the token into
+ * a `Permit`, which is overlaid onto `ctx.permit`. The `apps/trails` binary
+ * wires this to `@ontrails/permits`; the CLI package itself stays
+ * connector-agnostic.
+ *
+ * Mutually exclusive with `--permit`; passing both surfaces a
+ * `ValidationError`. The flag is treated as a meta flag — it never routes
+ * into trail input.
+ */
+export const tokenPreset = (): CliFlag[] => [
+  {
+    description:
+      'Bearer token resolved to a permit by the CLI resolver (mutually exclusive with --permit)',
+    name: 'token',
     required: false,
     type: 'string',
     variadic: false,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,12 @@ export type { AnyTrail, CliCommand, CliFlag, CliArg } from './command.js';
 
 // Build
 export { deriveCliCommands } from './build.js';
-export type { DeriveCliCommandsOptions, ActionResultContext } from './build.js';
+export type {
+  ActionResultContext,
+  DeriveCliCommandsOptions,
+  ResolveCliPermitFromToken,
+  ResolveCliPermitFromTokenInput,
+} from './build.js';
 export { validateCliCommands } from './validate.js';
 
 // Flags
@@ -13,6 +18,7 @@ export {
   cwdPreset,
   dryRunPreset,
   permitPreset,
+  tokenPreset,
   tracePreset,
 } from './flags.js';
 

--- a/packages/permits/src/__tests__/auth-resource.test.ts
+++ b/packages/permits/src/__tests__/auth-resource.test.ts
@@ -11,7 +11,7 @@ const testInput = (
   overrides?: Partial<PermitExtractionInput>
 ): PermitExtractionInput => ({
   requestId: 'test-svc-req',
-  trailhead: 'http',
+  surface: 'http',
   ...overrides,
 });
 

--- a/packages/permits/src/__tests__/auth-verify.test.ts
+++ b/packages/permits/src/__tests__/auth-verify.test.ts
@@ -64,7 +64,7 @@ const runVerify = async (
   token: string,
   connector: AuthConnector,
   options?: {
-    trailhead?: 'http' | 'mcp' | 'cli';
+    surface?: 'http' | 'mcp' | 'cli';
   }
 ): Promise<
   Result<
@@ -92,9 +92,9 @@ const runVerify = async (
     { token },
     {
       ctx:
-        options?.trailhead === undefined
+        options?.surface === undefined
           ? undefined
-          : { extensions: { [SURFACE_KEY]: options.trailhead } },
+          : { extensions: { [SURFACE_KEY]: options.surface } },
       resources: { [authResource.id]: connector },
     }
   );
@@ -203,12 +203,12 @@ describe('auth.verify trail', () => {
       });
     });
 
-    test('forwards the invoking trailhead from trail context', async () => {
-      let seenTrailhead: string | undefined;
+    test('forwards the invoking surface from trail context', async () => {
+      let seenSurface: string | undefined;
       const connector: AuthConnector = {
         // oxlint-disable-next-line require-await -- captures connector input
         authenticate: async (input) => {
-          seenTrailhead = input.trailhead;
+          seenSurface = input.surface;
           return Result.ok({
             id: 'user-42',
             scopes: ['read'],
@@ -216,12 +216,12 @@ describe('auth.verify trail', () => {
         },
       };
 
-      const result = await runVerify('trailhead-aware-token', connector, {
-        trailhead: 'mcp',
+      const result = await runVerify('surface-aware-token', connector, {
+        surface: 'mcp',
       });
 
       expect(result.isOk()).toBe(true);
-      expect(seenTrailhead).toBe('mcp');
+      expect(seenSurface).toBe('mcp');
     });
   });
 

--- a/packages/permits/src/__tests__/boundary.test.ts
+++ b/packages/permits/src/__tests__/boundary.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  AuthError,
+  Result,
+  ValidationError,
+  resource,
+  topo,
+} from '@ontrails/core';
+
+import { resolvePermitFromBearerToken } from '../boundary.js';
+import type { PermitExtractionInput } from '../extraction.js';
+
+const authResourceDef = resource<{
+  readonly authenticate: (
+    input: PermitExtractionInput
+  ) => Promise<
+    Result<
+      { readonly id: string; readonly scopes: readonly string[] } | null,
+      { readonly code: 'invalid_token'; readonly message: string }
+    >
+  >;
+}>('auth', {
+  create: () =>
+    Result.ok({
+      authenticate: async () =>
+        Result.ok({ id: 'created-user', scopes: ['created:read'] }),
+    }),
+});
+
+const app = topo('auth-boundary-test', { auth: authResourceDef });
+
+describe('resolvePermitFromBearerToken', () => {
+  test('resolves a bearer token through an override auth connector', async () => {
+    let observed: PermitExtractionInput | undefined;
+    const result = await resolvePermitFromBearerToken({
+      bearerToken: 'good-token',
+      graph: app,
+      requestId: 'req-1',
+      resources: {
+        auth: {
+          authenticate: async (input: PermitExtractionInput) => {
+            observed = input;
+            return Result.ok({ id: 'override-user', scopes: ['entity:read'] });
+          },
+        },
+      },
+      surface: 'http',
+    });
+
+    expect(result.unwrap()).toEqual({
+      id: 'override-user',
+      scopes: ['entity:read'],
+    });
+    expect(observed).toMatchObject({
+      bearerToken: 'good-token',
+      requestId: 'req-1',
+      surface: 'http',
+    });
+  });
+
+  test('uses the declared auth resource when no override is supplied', async () => {
+    const result = await resolvePermitFromBearerToken({
+      bearerToken: 'declared-token',
+      graph: app,
+      requestId: 'req-2',
+      surface: 'mcp',
+    });
+
+    expect(result.unwrap()).toEqual({
+      id: 'created-user',
+      scopes: ['created:read'],
+    });
+  });
+
+  test('returns ValidationError when no auth connector is registered', async () => {
+    const result = await resolvePermitFromBearerToken({
+      bearerToken: 'no-auth',
+      graph: topo('without-auth'),
+      missingAuthResourceMessage: 'missing auth connector',
+      requestId: 'req-3',
+      surface: 'cli',
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toBe('missing auth connector');
+    }
+  });
+
+  test('normalizes connector errors to AuthError', async () => {
+    const result = await resolvePermitFromBearerToken({
+      bearerToken: 'bad-token',
+      graph: app,
+      requestId: 'req-4',
+      resources: {
+        auth: {
+          authenticate: async () =>
+            Result.err({ code: 'invalid_token', message: 'bad signature' }),
+        },
+      },
+      surface: 'http',
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(AuthError);
+      expect(result.error.message).toBe('bad signature');
+      expect(result.error.context).toMatchObject({ code: 'invalid_token' });
+    }
+  });
+
+  test('normalizes null permits to missing-credentials AuthError', async () => {
+    const result = await resolvePermitFromBearerToken({
+      bearerToken: 'null-token',
+      graph: app,
+      nullPermitMessage: 'no permit',
+      requestId: 'req-5',
+      resources: {
+        auth: {
+          authenticate: async () => Result.ok(null),
+        },
+      },
+      surface: 'mcp',
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(AuthError);
+      expect(result.error.message).toBe('no permit');
+      expect(result.error.context).toMatchObject({
+        code: 'missing_credentials',
+      });
+    }
+  });
+
+  test('returns ValidationError for invalid extraction input instead of throwing', async () => {
+    const result = await resolvePermitFromBearerToken({
+      bearerToken: 'bad-surface-token',
+      graph: app,
+      requestId: 'req-6',
+      resources: {
+        auth: {
+          authenticate: async () =>
+            Result.ok({ id: 'unused', scopes: ['unused:read'] }),
+        },
+      },
+      surface: 'smtp' as never,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toBe(
+        'Invalid bearer token extraction input.'
+      );
+    }
+  });
+
+  test('normalizes thrown connector failures to AuthError', async () => {
+    const result = await resolvePermitFromBearerToken({
+      bearerToken: 'throw-token',
+      graph: app,
+      requestId: 'req-7',
+      resources: {
+        auth: {
+          authenticate: async () => {
+            throw new Error('connector exploded');
+          },
+        },
+      },
+      surface: 'mcp',
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(AuthError);
+      expect(result.error.message).toBe(
+        'Auth connector threw while authenticating bearer token'
+      );
+      expect(result.error.context).toMatchObject({ code: 'invalid_token' });
+    }
+  });
+
+  test('normalizes malformed connector permits to AuthError', async () => {
+    const result = await resolvePermitFromBearerToken({
+      bearerToken: 'malformed-token',
+      graph: app,
+      requestId: 'req-8',
+      resources: {
+        auth: {
+          authenticate: async () =>
+            Result.ok({ id: 'missing-scopes' } as never),
+        },
+      },
+      surface: 'cli',
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(AuthError);
+      expect(result.error.message).toBe(
+        'Auth connector returned a malformed permit'
+      );
+      expect(result.error.context).toMatchObject({ code: 'invalid_token' });
+    }
+  });
+});

--- a/packages/permits/src/__tests__/connector.test.ts
+++ b/packages/permits/src/__tests__/connector.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, test } from 'bun:test';
 import { Result } from '@ontrails/core';
 
 import type { AuthConnector, AuthError } from '../connectors/connector.js';
+import {
+  authConnectorSchema,
+  authErrorSchema,
+} from '../connectors/connector.js';
 import type { PermitExtractionInput } from '../extraction.js';
 import type { Permit } from '../permit.js';
 import { createJwtConnector } from '../connectors/jwt.js';
@@ -69,7 +73,7 @@ const testInput = (
   overrides?: Partial<PermitExtractionInput>
 ): PermitExtractionInput => ({
   requestId: 'test-req',
-  trailhead: 'http',
+  surface: 'http',
   ...overrides,
 });
 
@@ -81,6 +85,28 @@ describe('AuthConnector interface', () => {
     };
     const result = await connector.authenticate(testInput());
     expect(result.isOk()).toBe(true);
+  });
+
+  test('authConnectorSchema validates the connector shape', () => {
+    expect(
+      authConnectorSchema.safeParse({
+        authenticate: () => Promise.resolve(Result.ok(null)),
+      }).success
+    ).toBe(true);
+    expect(
+      authConnectorSchema.safeParse({ authenticate: 'nope' }).success
+    ).toBe(false);
+  });
+
+  test('authErrorSchema validates canonical connector error codes', () => {
+    const parsed = authErrorSchema.parse({
+      code: 'invalid_token',
+      message: 'bad token',
+    });
+    expect(parsed).toEqual({ code: 'invalid_token', message: 'bad token' });
+    expect(
+      authErrorSchema.safeParse({ code: 'other', message: 'bad token' }).success
+    ).toBe(false);
   });
 });
 

--- a/packages/permits/src/__tests__/permit.test.ts
+++ b/packages/permits/src/__tests__/permit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { Permit, PermitExtractionInput } from '../index';
-import { getPermit } from '../index';
+import { getPermit, permitExtractionInputSchema } from '../index';
 
 describe('Permit type', () => {
   test('accepts a valid permit with required fields only', () => {
@@ -77,42 +77,63 @@ describe('getPermit()', () => {
 });
 
 describe('PermitExtractionInput', () => {
-  test('accepts HTTP trailhead extraction', () => {
+  test('permitExtractionInputSchema parses the canonical CLI extraction shape', () => {
+    const parsed = permitExtractionInputSchema.parse({
+      bearerToken: 'cli-token-from-keyring',
+      requestId: 'req-cli-schema',
+      surface: 'cli',
+    });
+    expect(parsed).toEqual({
+      bearerToken: 'cli-token-from-keyring',
+      requestId: 'req-cli-schema',
+      surface: 'cli',
+    });
+  });
+
+  test('permitExtractionInputSchema rejects unknown surface values', () => {
+    const parsed = permitExtractionInputSchema.safeParse({
+      requestId: 'req-bad-surface',
+      surface: 'not-a-surface',
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test('accepts HTTP surface extraction', () => {
     const input: PermitExtractionInput = {
       bearerToken: 'eyJhbGciOiJSUzI1NiJ9.test',
       headers: new Headers({
         authorization: 'Bearer eyJhbGciOiJSUzI1NiJ9.test',
       }),
       requestId: 'req-http-1',
-      trailhead: 'http',
+      surface: 'http',
     };
-    expect(input.trailhead).toBe('http');
+    expect(input.surface).toBe('http');
     expect(input.bearerToken).toBeDefined();
   });
 
-  test('accepts MCP trailhead extraction', () => {
+  test('accepts MCP surface extraction', () => {
     const input: PermitExtractionInput = {
       requestId: 'req-mcp-1',
       sessionId: 'mcp-session-abc',
-      trailhead: 'mcp',
+      surface: 'mcp',
     };
-    expect(input.trailhead).toBe('mcp');
+    expect(input.surface).toBe('mcp');
     expect(input.sessionId).toBe('mcp-session-abc');
   });
 
-  test('accepts CLI trailhead extraction', () => {
+  test('accepts CLI surface extraction', () => {
     const input: PermitExtractionInput = {
       bearerToken: 'cli-token-from-keyring',
       requestId: 'req-cli-1',
-      trailhead: 'cli',
+      surface: 'cli',
     };
-    expect(input.trailhead).toBe('cli');
+    expect(input.surface).toBe('cli');
   });
 
   test('accepts minimal extraction with only required fields', () => {
     const input: PermitExtractionInput = {
       requestId: 'req-minimal',
-      trailhead: 'http',
+      surface: 'http',
     };
     expect(input.requestId).toBe('req-minimal');
     expect(input.bearerToken).toBeUndefined();

--- a/packages/permits/src/auth-resource.ts
+++ b/packages/permits/src/auth-resource.ts
@@ -7,7 +7,7 @@ import type { AuthConnector } from './connectors/connector.js';
  *
  * The v1 factory returns a no-op connector that always succeeds (null permit).
  * Real connector configuration will come through `ResourceSpec.config`
- * (TRL-91). The mock factory provides a synthetic connector that always
+ * (TRL-620). The mock factory provides a synthetic connector that always
  * succeeds.
  */
 export const authResource = resource<AuthConnector>('auth', {

--- a/packages/permits/src/boundary.ts
+++ b/packages/permits/src/boundary.ts
@@ -1,0 +1,196 @@
+import type {
+  AnyResource,
+  BasePermit,
+  ResourceOverrideMap,
+  Topo,
+} from '@ontrails/core';
+import {
+  AuthError,
+  Result,
+  ValidationError,
+  basePermitSchema,
+} from '@ontrails/core';
+
+import type { AuthConnector } from './connectors/connector.js';
+import {
+  authConnectorSchema,
+  authErrorSchema,
+} from './connectors/connector.js';
+import type { PermitExtractionInput } from './extraction.js';
+import { permitExtractionInputSchema } from './extraction.js';
+
+/** Resource id of the auth connector resource provided by `@ontrails/permits`. */
+export const AUTH_RESOURCE_ID = 'auth';
+
+type LocatedAuthResource =
+  | { readonly kind: 'override'; readonly value: unknown }
+  | { readonly kind: 'declared'; readonly resource: AnyResource };
+
+export interface ResolvePermitFromBearerTokenOptions {
+  readonly bearerToken: string;
+  readonly graph: Topo;
+  readonly requestId: string;
+  readonly surface: PermitExtractionInput['surface'];
+  readonly resources?: ResourceOverrideMap | undefined;
+  readonly headers?: Headers | undefined;
+  readonly sessionId?: string | undefined;
+  readonly cwd?: string | undefined;
+  readonly env?: Record<string, string | undefined> | undefined;
+  readonly workspaceRoot?: string | undefined;
+  readonly missingAuthResourceMessage?: string | undefined;
+  readonly nullPermitMessage?: string | undefined;
+}
+
+/** Resolve the auth resource override or registered resource on the topo. */
+const lookupAuthResource = (
+  graph: Topo,
+  resources: ResourceOverrideMap | undefined,
+  missingAuthResourceMessage: string | undefined
+): Result<LocatedAuthResource, ValidationError> => {
+  if (resources !== undefined && Object.hasOwn(resources, AUTH_RESOURCE_ID)) {
+    return Result.ok({
+      kind: 'override',
+      value: resources[AUTH_RESOURCE_ID],
+    });
+  }
+  const declared = graph.getResource(AUTH_RESOURCE_ID);
+  if (declared !== undefined) {
+    return Result.ok({ kind: 'declared', resource: declared });
+  }
+  return Result.err(
+    new ValidationError(
+      missingAuthResourceMessage ??
+        'Bearer token auth requires an auth connector. Register authResource from @ontrails/permits in your topo.'
+    )
+  );
+};
+
+/**
+ * Materialize the auth connector from an override or by invoking the declared
+ * resource's `create()` factory.
+ */
+const materializeAuthConnector = async (
+  resolved: LocatedAuthResource,
+  options: Pick<
+    ResolvePermitFromBearerTokenOptions,
+    'cwd' | 'env' | 'workspaceRoot'
+  >
+): Promise<Result<AuthConnector, Error>> => {
+  if (resolved.kind === 'override') {
+    const parsed = authConnectorSchema.safeParse(resolved.value);
+    if (!parsed.success) {
+      return Result.err(
+        new ValidationError(
+          'Override for resource "auth" does not expose an authenticate() function.'
+        )
+      );
+    }
+    return Result.ok(resolved.value as AuthConnector);
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const created = await resolved.resource.create({
+    config: undefined,
+    cwd,
+    env: options.env ?? {},
+    workspaceRoot: options.workspaceRoot ?? cwd,
+  });
+  if (created.isErr()) {
+    return created;
+  }
+  const parsed = authConnectorSchema.safeParse(created.value);
+  if (!parsed.success) {
+    return Result.err(
+      new ValidationError(
+        'Auth resource factory returned a value without an authenticate() function.'
+      )
+    );
+  }
+  return Result.ok(created.value as AuthConnector);
+};
+
+/**
+ * Resolve a surface-extracted bearer token to a `BasePermit`.
+ *
+ * Surfaces own credential extraction. This helper owns the shared auth
+ * connector lookup, invocation, error normalization, and BasePermit projection.
+ */
+export const resolvePermitFromBearerToken = async (
+  options: ResolvePermitFromBearerTokenOptions
+): Promise<Result<BasePermit, Error>> => {
+  const located = lookupAuthResource(
+    options.graph,
+    options.resources,
+    options.missingAuthResourceMessage
+  );
+  if (located.isErr()) {
+    return located;
+  }
+  const connectorResult = await materializeAuthConnector(
+    located.value,
+    options
+  );
+  if (connectorResult.isErr()) {
+    return connectorResult;
+  }
+  const inputResult = permitExtractionInputSchema.safeParse({
+    bearerToken: options.bearerToken,
+    ...(options.headers === undefined ? {} : { headers: options.headers }),
+    requestId: options.requestId,
+    ...(options.sessionId === undefined
+      ? {}
+      : { sessionId: options.sessionId }),
+    surface: options.surface,
+  });
+  if (!inputResult.success) {
+    return Result.err(
+      new ValidationError('Invalid bearer token extraction input.', {
+        context: { issues: inputResult.error.issues },
+      })
+    );
+  }
+  let authResult: Awaited<ReturnType<AuthConnector['authenticate']>>;
+  try {
+    authResult = await connectorResult.value.authenticate(inputResult.data);
+  } catch (error) {
+    const errorOptions =
+      error instanceof Error
+        ? { cause: error, context: { code: 'invalid_token' } }
+        : { context: { code: 'invalid_token' } };
+    return Result.err(
+      new AuthError('Auth connector threw while authenticating bearer token', {
+        ...errorOptions,
+      })
+    );
+  }
+  if (authResult.isErr()) {
+    const parsedError = authErrorSchema.safeParse(authResult.error);
+    const { code, message } = parsedError.success
+      ? parsedError.data
+      : {
+          code: 'invalid_token' as const,
+          message: 'Auth connector returned a malformed error',
+        };
+    return Result.err(new AuthError(message, { context: { code } }));
+  }
+  if (authResult.value === null) {
+    return Result.err(
+      new AuthError(
+        options.nullPermitMessage ??
+          'Auth connector did not produce a permit for bearer token',
+        {
+          context: { code: 'missing_credentials' },
+        }
+      )
+    );
+  }
+  const permit = basePermitSchema.safeParse(authResult.value);
+  if (!permit.success) {
+    return Result.err(
+      new AuthError('Auth connector returned a malformed permit', {
+        context: { code: 'invalid_token', issues: permit.error.issues },
+      })
+    );
+  }
+  return Result.ok(permit.data);
+};

--- a/packages/permits/src/connectors/connector.ts
+++ b/packages/permits/src/connectors/connector.ts
@@ -1,24 +1,36 @@
+import { z } from 'zod';
 import type { Result } from '@ontrails/core';
 
 import type { PermitExtractionInput } from '../extraction.js';
 import type { Permit } from '../permit.js';
 
 /** Errors from auth connectors. */
-export interface AuthError {
-  readonly code:
-    | 'expired_token'
-    | 'insufficient_scope'
-    | 'invalid_token'
-    | 'missing_credentials';
-  readonly message: string;
-}
+export const authErrorSchema = z
+  .object({
+    code: z.enum([
+      'expired_token',
+      'insufficient_scope',
+      'invalid_token',
+      'missing_credentials',
+    ]),
+    message: z.string(),
+  })
+  .readonly();
+
+export type AuthError = z.infer<typeof authErrorSchema>;
+
+export const authConnectorSchema = z
+  .object({
+    authenticate: z.function(),
+  })
+  .readonly();
 
 /**
  * Auth connector port. Given extraction input, produce a permit or an error.
  *
- * The connector receives the full {@link PermitExtractionInput} — trailhead,
+ * The connector receives the full {@link PermitExtractionInput} — surface,
  * headers, requestId, and credential fields — so it can make richer
- * decisions (e.g., rate-limit by trailhead or correlate via requestId).
+ * decisions (e.g., rate-limit by surface or correlate via requestId).
  *
  * Deliberately narrow — no session management, no token refresh.
  */

--- a/packages/permits/src/extraction.ts
+++ b/packages/permits/src/extraction.ts
@@ -1,19 +1,25 @@
+import { z } from 'zod';
+
+export const permitExtractionInputSchema = z
+  .object({
+    /** Bearer token from Authorization header or equivalent. */
+    bearerToken: z.string().optional(),
+    /** Raw headers (HTTP surface only, typically). */
+    headers: z.instanceof(Headers).optional(),
+    /** Correlation ID for tracing. */
+    requestId: z.string(),
+    /** Session identifier from transport handshake. */
+    sessionId: z.string().optional(),
+    /** Which surface produced this extraction. */
+    surface: z.enum(['http', 'mcp', 'cli']),
+  })
+  .readonly();
+
 /**
  * Normalized input for auth connectors.
  *
  * Each surface extracts raw credentials from its transport and normalizes them
  * into this shape. No surface types (Request, McpSession, etc.) cross into
- * core -- only this interface.
+ * core -- only this schema-derived contract.
  */
-export interface PermitExtractionInput {
-  /** Which surface produced this extraction. Field name retained for beta compatibility. */
-  readonly trailhead: 'http' | 'mcp' | 'cli';
-  /** Bearer token from Authorization header or equivalent */
-  readonly bearerToken?: string;
-  /** Session identifier from transport handshake */
-  readonly sessionId?: string;
-  /** Raw headers (HTTP surface only, typically) */
-  readonly headers?: Headers;
-  /** Correlation ID for tracing */
-  readonly requestId: string;
-}
+export type PermitExtractionInput = z.infer<typeof permitExtractionInputSchema>;

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -1,4 +1,9 @@
-export { type AuthConnector, type AuthError } from './connectors/connector.js';
+export {
+  authConnectorSchema,
+  authErrorSchema,
+  type AuthConnector,
+  type AuthError,
+} from './connectors/connector.js';
 export {
   createJwtConnector,
   type JwtAlgorithm,
@@ -6,8 +11,16 @@ export {
 } from './connectors/jwt.js';
 export { authLayer } from './auth-layer.js';
 export { authResource } from './auth-resource.js';
+export {
+  AUTH_RESOURCE_ID,
+  resolvePermitFromBearerToken,
+  type ResolvePermitFromBearerTokenOptions,
+} from './boundary.js';
 export { authVerify } from './trails/auth-verify.js';
 export { PermitError } from './errors.js';
-export { type PermitExtractionInput } from './extraction.js';
+export {
+  permitExtractionInputSchema,
+  type PermitExtractionInput,
+} from './extraction.js';
 export { type Permit, getPermit } from './permit.js';
 export { validatePermits, type PermitDiagnostic } from './rules.js';

--- a/packages/permits/src/trails/auth-verify.ts
+++ b/packages/permits/src/trails/auth-verify.ts
@@ -32,12 +32,10 @@ const toOutputPermit = (permit: Permit) => ({
 
 const isSurfaceName = (
   value: unknown
-): value is PermitExtractionInput['trailhead'] =>
+): value is PermitExtractionInput['surface'] =>
   value === 'http' || value === 'mcp' || value === 'cli';
 
-const getTrailhead = (
-  ctx: TrailContext
-): PermitExtractionInput['trailhead'] => {
+const getSurface = (ctx: TrailContext): PermitExtractionInput['surface'] => {
   const surface = ctx.extensions?.[SURFACE_KEY];
   return isSurfaceName(surface) ? surface : 'http';
 };
@@ -55,7 +53,7 @@ export const authVerify = trail('auth.verify', {
     const result = await connector.authenticate({
       bearerToken: input.token,
       requestId: ctx.requestId,
-      trailhead: getTrailhead(ctx),
+      surface: getSurface(ctx),
     });
 
     if (result.isErr()) {


### PR DESCRIPTION
## Summary
- Adds `--token <token>` as a CLI meta flag for resolving a permit before trail execution.
- Keeps `@ontrails/cli` connector-agnostic by exposing a caller-supplied `resolvePermitFromToken` hook.
- Wires the Trails app CLI to resolve bearer tokens through `@ontrails/permits`.

## Details
`--token` is mutually exclusive with inline `--permit` and the later `--dev-permit` path. The reusable CLI package owns flag parsing, conflict validation, and the resolver hook; it does not depend on `@ontrails/permits` or materialize auth resources internally. `apps/trails` supplies the concrete resolver using `resolvePermitFromBearerToken()`, then forwards the returned permit into execution. Missing resolver wiring and flag conflicts are `ValidationError`; connector failures and null permits become `AuthError` with auth-specific exit behavior.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-409.
