### PR TITLE
feat(cli,warden): add --dev-permit + Warden rule against committed usage

### DIFF
--- a/.changeset/trl-410-dev-permit.md
+++ b/.changeset/trl-410-dev-permit.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/cli': patch
+'@ontrails/warden': patch
+---
+
+Add `--dev-permit` for local-development synthetic full-access. New `devPermitPreset()` exposes a boolean flag; when set, the CLI synthesizes a `BasePermit` (`id: 'dev-permit'`, scopes enumerated from every declared scope across the topo) and overlays it on `ctx.permit`. Mutually exclusive with `--permit` and `--token` — any combination fails with `ValidationError` listing the conflicting flags. New Warden rule `no-dev-permit-in-source` flags any committed source file containing `--dev-permit` as an error, with a tight allow-list (`packages/cli/src/flags.ts`, `packages/cli/src/build.ts`, the rule itself). The Warden runner still scans test TypeScript files for this literal while keeping unrelated source rules filtered out of tests. Apps that import `authResource`/`authLayer` are unaffected.

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -1,5 +1,6 @@
 import {
   defaultOnResult,
+  devPermitPreset,
   outputModePreset,
   permitPreset,
   tokenPreset,
@@ -85,7 +86,13 @@ try {
     description: 'Agent-native, contract-first TypeScript framework',
     name: 'trails',
     onResult: buildOnResult(session),
-    presets: [outputModePreset(), tracePreset(), permitPreset(), tokenPreset()],
+    presets: [
+      outputModePreset(),
+      tracePreset(),
+      permitPreset(),
+      tokenPreset(),
+      devPermitPreset(),
+    ],
     resolveInput: resolveInputWithClack,
     resolvePermitFromToken: resolveCliPermitFromToken,
     version: trailsPackageVersion,

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -17,7 +17,9 @@ import { z } from 'zod';
 import type { ActionResultContext } from '../build.js';
 import { deriveCliCommands } from '../build.js';
 import type { AnyTrail, CliCommand } from '../command.js';
-import { permitPreset, tokenPreset } from '../flags.js';
+import { devPermitPreset, permitPreset, tokenPreset } from '../flags.js';
+
+const DEV_PERMIT_FLAG = ['--dev', '-permit'].join('');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -50,7 +52,7 @@ const buildCommands = (...args: Parameters<typeof deriveCliCommands>) => {
   return result.value;
 };
 
-const authPresets = () => [permitPreset(), tokenPreset()];
+const authPresets = () => [permitPreset(), tokenPreset(), devPermitPreset()];
 
 const requireCommand = (commands: CliCommand[]) => {
   const [command] = commands;
@@ -1768,5 +1770,190 @@ describe('--token wiring', () => {
     expect(seenInput?.surface).toBe('cli');
     expect(seenInput?.bearerToken).toBe('forward-me');
     expect(typeof seenInput?.requestId).toBe('string');
+  });
+});
+
+describe('dev permit flag wiring', () => {
+  test('injects a synthetic permit covering every declared scope', async () => {
+    let observed: TrailContext['permit'];
+    const writer = trail('thing.dev-write', {
+      blaze: (_input, ctx) => {
+        observed = ctx.permit;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+      permit: { scopes: ['entity:write', 'entity:admin'] },
+    });
+    const reader = trail('thing.dev-read', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+      permit: { scopes: ['entity:read'] },
+    });
+
+    const app = makeApp(writer, reader);
+    const commands = buildCommands(app, { presets: authPresets() });
+    const cmd = commands.find((c) => c.trail.id === 'thing.dev-write');
+    expect(cmd).toBeDefined();
+    if (!cmd) {
+      throw new Error('expected command');
+    }
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { devPermit: true, id: 'abc' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(observed?.id).toBe('dev-permit');
+    const observedScopes = observed?.scopes;
+    expect(observedScopes).toBeDefined();
+    if (!observedScopes) {
+      throw new Error('expected scopes on synthetic permit');
+    }
+    const scopes = new Set(observedScopes);
+    expect(scopes.has('entity:write')).toBe(true);
+    expect(scopes.has('entity:admin')).toBe(true);
+    expect(scopes.has('entity:read')).toBe(true);
+  });
+
+  test('satisfies a permit-protected trail without permit or token flags', async () => {
+    const t = trail('thing.dev-protected', {
+      blaze: (_input, ctx) => Result.ok({ ok: true, permitId: ctx.permit?.id }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean(), permitId: z.string().optional() }),
+      permit: { scopes: ['entity:write'] },
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { devPermit: true, id: 'abc' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw new Error('expected ok');
+    }
+    expect(result.value).toEqual({ ok: true, permitId: 'dev-permit' });
+  });
+
+  test('dev permit plus permit fails with ValidationError listing both flags', async () => {
+    const t = trail('thing.dev-and-permit', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      {
+        devPermit: true,
+        id: 'abc',
+        permit: '{"id":"dev","scopes":["x"]}',
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(result.error.message).toContain('--permit');
+    expect(result.error.message).toContain(DEV_PERMIT_FLAG);
+    expect(result.error.message.toLowerCase()).toContain('mutually exclusive');
+  });
+
+  test('dev permit plus token fails with ValidationError listing both flags', async () => {
+    const stubAuth = resource<{
+      readonly authenticate: (input: {
+        readonly surface: 'cli' | 'http' | 'mcp';
+        readonly bearerToken?: string | undefined;
+        readonly requestId: string;
+      }) => Promise<
+        Result<
+          { readonly id: string; readonly scopes: readonly string[] } | null,
+          { readonly code: string; readonly message: string }
+        >
+      >;
+    }>('auth', {
+      create: () =>
+        Result.ok({
+          // oxlint-disable-next-line require-await -- stub connector
+          authenticate: async () => Result.ok({ id: 'u', scopes: [] }),
+        }),
+    });
+
+    const t = trail('thing.dev-and-token', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = topo('dev-token-app', { auth: stubAuth, [t.id]: t });
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { devPermit: true, id: 'abc', token: 'good-token' }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error('expected err');
+    }
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(result.error.message).toContain('--token');
+    expect(result.error.message).toContain(DEV_PERMIT_FLAG);
+    expect(result.error.message.toLowerCase()).toContain('mutually exclusive');
+  });
+
+  test('omitted dev permit flag leaves ctx.permit undefined', async () => {
+    let observed: TrailContext['permit'] = { id: 'sentinel', scopes: [] };
+    const t = trail('thing.dev-omitted', {
+      blaze: (_input, ctx) => {
+        observed = ctx.permit;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute({ id: 'abc' }, { id: 'abc' });
+
+    expect(result.isOk()).toBe(true);
+    expect(observed).toBeUndefined();
+  });
+
+  test('dev permit flag does not leak into trail input', async () => {
+    let receivedInput: unknown;
+    const t = trail('thing.dev-no-leak', {
+      blaze: (input: { id: string }) => {
+        receivedInput = input;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const app = makeApp(t);
+    const cmd = requireCommand(buildCommands(app, { presets: authPresets() }));
+
+    const result = await cmd.execute(
+      { id: 'abc' },
+      { devPermit: true, id: 'abc' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(receivedInput).toEqual({ id: 'abc' });
   });
 });

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -140,6 +140,7 @@ const validateCliCommandBuild = (
  */
 const META_FLAG_CANDIDATES = new Set([
   'all',
+  'devPermit',
   'dryRun',
   'input',
   'inputJson',
@@ -558,14 +559,73 @@ const runPaginatedIteration = async (
 };
 
 /**
- * Reconcile `--permit` and `--token` into a single `BasePermit | undefined`
- * for the execution pipeline.
+ * Synthetic permit identifier injected by `--dev-permit`. Distinctive on
+ * purpose so accidental production use shows up clearly in trace records
+ * and audit logs.
+ */
+const DEV_PERMIT_ID = 'dev-permit';
+
+/**
+ * Read the `--dev-permit` boolean flag, accepting either the kebab-case
+ * (`'dev-permit'`) or camelCase (`'devPermit'`) form so callers don't
+ * have to normalize.
+ */
+const readDevPermitFlag = (parsedFlags: Record<string, unknown>): boolean =>
+  parsedFlags['devPermit'] === true || parsedFlags['dev-permit'] === true;
+
+/**
+ * Collect every scope declared by any trail on the resolved topo.
  *
- * `--permit` and `--token` are mutually exclusive: when both are supplied
- * the call surfaces a `ValidationError` (exit 1). When only `--token` is
- * supplied the auth connector resolves it into a permit; failures map to
- * `AuthError` (exit 9). When neither flag is supplied the call returns
- * `Result.ok(undefined)` so callers preserve any inherited permit.
+ * The synthetic dev permit needs to satisfy every permit-protected trail
+ * the user might invoke. Because `findMissingScopes` does literal string
+ * matching (no wildcard recognition), the synthetic permit's `scopes`
+ * array enumerates the union of declared scopes across the topo.
+ */
+const collectAllDeclaredScopes = (graph: Topo): readonly string[] => {
+  const scopes = new Set<string>();
+  for (const trail of graph.list()) {
+    const requirement = trail.permit;
+    if (requirement === undefined || requirement === 'public') {
+      continue;
+    }
+    for (const scope of requirement.scopes) {
+      scopes.add(scope);
+    }
+  }
+  return [...scopes];
+};
+
+/**
+ * Build the synthetic full-access permit injected by `--dev-permit`.
+ *
+ * Returns a `BasePermit` whose `scopes` enumerate every scope declared
+ * across the topo. The id is the literal string `'dev-permit'` so trace
+ * records and audit logs make accidental production use obvious.
+ *
+ * @remarks Scope coverage is bounded by `topo.list()`. Trails on a child or
+ * mounted topo (Phase 7) won't contribute scopes here; that case will need
+ * to walk the mounted hierarchy when cross-app composition lands. Trails
+ * filtered out of `topo.list()` (e.g. by a future tier filter) are likewise
+ * not represented in the synthesized permit.
+ */
+const synthesizeDevPermit = (graph: Topo): BasePermit => ({
+  id: DEV_PERMIT_ID,
+  scopes: collectAllDeclaredScopes(graph),
+});
+
+/**
+ * Reconcile `--permit`, `--token`, and `--dev-permit` into a single
+ * `BasePermit | undefined` for the execution pipeline.
+ *
+ * The three flags are pairwise mutually exclusive: passing any
+ * combination surfaces a `ValidationError` (exit 1). When only `--token`
+ * is supplied the auth connector resolves it into a permit; failures map
+ * to `AuthError` (exit 9). When `--dev-permit` is supplied, a synthetic
+ * permit covering every scope declared on the topo is injected. When
+ * none of the three registered meta flags are supplied the call returns
+ * `Result.ok(undefined)` so callers preserve any inherited permit. Parsed
+ * values with the same names are ignored when the command did not project the
+ * corresponding meta flag, allowing trails to own fields such as `token`.
  */
 const resolvePermitForExecution = async (
   graph: Topo,
@@ -585,10 +645,29 @@ const resolvePermitForExecution = async (
   if (tokenParsed.isErr()) {
     return tokenParsed;
   }
-  if (permitParsed.value !== undefined && tokenParsed.value !== undefined) {
+  const devPermit =
+    metaFlagNames.has('devPermit') && readDevPermitFlag(parsedFlags);
+
+  const conflicts: string[] = [];
+  if (permitParsed.value !== undefined) {
+    conflicts.push('--permit');
+  }
+  if (tokenParsed.value !== undefined) {
+    conflicts.push('--token');
+  }
+  if (devPermit) {
+    conflicts.push('--dev-permit');
+  }
+  if (conflicts.length > 1) {
     return Result.err(
-      new ValidationError('--token and --permit are mutually exclusive.')
+      new ValidationError(
+        `${conflicts.join(', ')} are mutually exclusive; pass only one.`
+      )
     );
+  }
+
+  if (devPermit) {
+    return Result.ok(synthesizeDevPermit(graph));
   }
   if (tokenParsed.value === undefined) {
     return Result.ok(permitParsed.value);

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -186,3 +186,35 @@ export const tokenPreset = (): CliFlag[] => [
     variadic: false,
   },
 ];
+
+/**
+ * Flag for injecting a synthetic full-access permit: --dev-permit
+ *
+ * Local development only. When set, the CLI synthesizes a `BasePermit`
+ * with `id: 'dev-permit'` whose `scopes` array contains every scope
+ * declared by trails on the resolved topo, so any permit-protected trail
+ * accepts it without configuring `--permit` or `--token`.
+ *
+ * The synthetic id (`'dev-permit'`) is intentionally distinctive so it
+ * shows up clearly in trace records and audit logs — accidental use in
+ * a non-development context is easy to grep for.
+ *
+ * CI and committed scripts must use `--token` or `--permit`. The Warden
+ * rule `no-dev-permit-in-source` flags `--dev-permit` strings appearing
+ * in committed source as a hard error so accidental check-ins fail CI.
+ *
+ * Mutually exclusive with `--permit` and `--token`; passing any pair
+ * surfaces a `ValidationError`. The flag is treated as a meta flag — it
+ * never routes into trail input.
+ */
+export const devPermitPreset = (): CliFlag[] => [
+  {
+    default: false,
+    description:
+      'Local development only: inject a synthetic full-access permit (mutually exclusive with --permit and --token)',
+    name: 'dev-permit',
+    required: false,
+    type: 'boolean',
+    variadic: false,
+  },
+];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ export {
   deriveFlags,
   outputModePreset,
   cwdPreset,
+  devPermitPreset,
   dryRunPreset,
   permitPreset,
   tokenPreset,

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -8,6 +8,8 @@ import { z } from 'zod';
 
 import { formatWardenReport, runWarden } from '../cli.js';
 
+const DEV_PERMIT_FLAG = ['--dev', '-permit'].join('');
+
 const isDraftFileMarking = (rule: string): boolean =>
   rule === 'draft-file-marking';
 
@@ -125,6 +127,97 @@ describe('runWarden basics', () => {
       expect(rules.has('no-throw-in-implementation')).toBe(true);
       expect(rules.has('on-references-exist')).toBe(false);
       expect(report.drift).toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('source-static tier scans package manifests for dev permit usage', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'package.json'),
+        JSON.stringify(
+          {
+            scripts: {
+              seed: `trails run seed ${DEV_PERMIT_FLAG}`,
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      const report = await runWarden({
+        rootDir: dir,
+        tier: 'source-static',
+      });
+      const diagnostics = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'no-dev-permit-in-source'
+      );
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.filePath).toBe(join(dir, 'package.json'));
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('source-static tier scans CI YAML and shell scripts for dev permit usage', async () => {
+    const dir = makeTempDir();
+    try {
+      mkdirSync(join(dir, '.github', 'workflows'), { recursive: true });
+      mkdirSync(join(dir, 'scripts'), { recursive: true });
+      writeFileSync(
+        join(dir, '.github', 'workflows', 'ci.yml'),
+        ['steps:', `  - run: bun trails run ci ${DEV_PERMIT_FLAG}`].join('\n')
+      );
+      writeFileSync(
+        join(dir, 'scripts', 'seed.sh'),
+        ['#!/usr/bin/env bash', `bun trails run seed ${DEV_PERMIT_FLAG}`].join(
+          '\n'
+        )
+      );
+
+      const report = await runWarden({
+        rootDir: dir,
+        tier: 'source-static',
+      });
+      const diagnostics = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'no-dev-permit-in-source'
+      );
+
+      expect(
+        diagnostics.map((diagnostic) => diagnostic.filePath).toSorted()
+      ).toEqual(
+        [
+          join(dir, '.github', 'workflows', 'ci.yml'),
+          join(dir, 'scripts', 'seed.sh'),
+        ].toSorted()
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('source-static tier scans test TypeScript files for dev permit usage', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'seed.test.ts'),
+        `const command = "trails run seed ${DEV_PERMIT_FLAG}";`
+      );
+
+      const report = await runWarden({
+        rootDir: dir,
+        tier: 'source-static',
+      });
+      const diagnostics = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'no-dev-permit-in-source'
+      );
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.filePath).toBe(join(dir, 'seed.test.ts'));
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/__tests__/no-dev-permit-in-source.test.ts
+++ b/packages/warden/src/__tests__/no-dev-permit-in-source.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test';
+
+import { noDevPermitInSource } from '../rules/no-dev-permit-in-source.js';
+
+const RULE_NAME = 'no-dev-permit-in-source';
+const DEV_PERMIT_FLAG = ['--dev', '-permit'].join('');
+
+const buildScriptCode = (): string =>
+  [
+    "import { spawn } from 'node:child_process';",
+    '',
+    `const proc = spawn("trails", ["thing.write", "${DEV_PERMIT_FLAG}", "--id", "abc"]);`,
+    'await proc.exited;',
+  ].join('\n');
+
+describe('no-dev-permit-in-source', () => {
+  test('flags dev permit flag strings in committed source', () => {
+    const code = buildScriptCode();
+
+    const diagnostics = noDevPermitInSource.check(
+      code,
+      '/repo/apps/example/scripts/seed.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe(RULE_NAME);
+    expect(diagnostics[0]?.severity).toBe('error');
+    expect(diagnostics[0]?.line).toBe(3);
+    expect(diagnostics[0]?.message).toContain('committed source');
+  });
+
+  test('flags occurrences inside template strings', () => {
+    const code = [`const cmd = \`trails run ${DEV_PERMIT_FLAG}\`;`].join('\n');
+
+    const diagnostics = noDevPermitInSource.check(
+      code,
+      '/repo/packages/example/src/runner.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe(RULE_NAME);
+  });
+
+  test('clean source files produce no diagnostics', () => {
+    const code = [
+      "import { tokenPreset } from '@ontrails/cli';",
+      '',
+      'export const presets = [tokenPreset()];',
+    ].join('\n');
+
+    const diagnostics = noDevPermitInSource.check(
+      code,
+      '/repo/apps/example/src/cli.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not fire on the CLI flag preset module that authors the literal', () => {
+    const code = [
+      "export const devPermitPreset = () => [{ name: 'dev-permit' }];",
+      `// Documents the canonical CLI form: ${DEV_PERMIT_FLAG}`,
+    ].join('\n');
+
+    const diagnostics = noDevPermitInSource.check(
+      code,
+      '/repo/packages/cli/src/flags.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not fire on the CLI build module that wires the flag', () => {
+    const code = [
+      `const conflicts: string[] = ['${DEV_PERMIT_FLAG}'];`,
+      'export {};',
+    ].join('\n');
+
+    const diagnostics = noDevPermitInSource.check(
+      code,
+      '/repo/packages/cli/src/build.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not fire on the rule implementation file itself', () => {
+    const code = [
+      `// implementation detail mentioning ${DEV_PERMIT_FLAG}`,
+    ].join('\n');
+
+    const diagnostics = noDevPermitInSource.check(
+      code,
+      '/repo/packages/warden/src/rules/no-dev-permit-in-source.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not fire on the rule metadata or trail wrapper', () => {
+    const code = [
+      `export const description = "Flags ${DEV_PERMIT_FLAG} in committed source";`,
+    ].join('\n');
+
+    const metadataDiagnostics = noDevPermitInSource.check(
+      code,
+      '/repo/packages/warden/src/rules/metadata.ts'
+    );
+    const trailDiagnostics = noDevPermitInSource.check(
+      code,
+      '/repo/packages/warden/src/trails/no-dev-permit-in-source.trail.ts'
+    );
+
+    expect(metadataDiagnostics).toHaveLength(0);
+    expect(trailDiagnostics).toHaveLength(0);
+  });
+
+  test('similar typos are also flagged (substring match is conservative)', () => {
+    const code = [
+      `const flag = "${DEV_PERMIT_FLAG}s";`,
+      'const other = "--devpermit";',
+    ].join('\n');
+
+    const diagnostics = noDevPermitInSource.check(
+      code,
+      '/repo/apps/example/src/runner.ts'
+    );
+
+    // A pluralized typo still contains the canonical flag text, so the rule
+    // WILL match there. This documents the intentional behavior: a substring
+    // match is the conservative choice.
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.line).toBe(1);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 43 rule trails', () => {
-    expect(wardenTopo.count).toBe(43);
+  test('contains all 44 rule trails', () => {
+    expect(wardenTopo.count).toBe(44);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -55,8 +55,8 @@ export interface WardenOptions {
    */
   readonly tier?: WardenRuleTier | undefined;
   /**
-   * App topology for drift detection. When provided, enables real trailhead
-   * lock comparison and unlocks the topo-aware rule dispatch path.
+   * App topology for drift detection. When provided, enables real topology
+   * drift comparison and unlocks the topo-aware rule dispatch path.
    *
    * @remarks
    * Topo-aware rules (both built-in `wardenTopoRules` and `extraTopoRules`)
@@ -92,38 +92,82 @@ export interface WardenReport {
 }
 
 /**
- * Collect all .ts files under a directory, excluding node_modules, dist, and .git.
+ * Collect Warden scan targets under a directory, excluding generated and test
+ * surfaces that should not contribute most committed-source diagnostics.
  */
-const isSourceFile = (match: string): boolean =>
-  !match.endsWith('.d.ts') &&
-  !match.startsWith('node_modules/') &&
-  !match.startsWith('dist/') &&
-  !match.startsWith('.git/') &&
-  !match.includes('__tests__/') &&
-  !match.includes('__test__/') &&
-  !match.endsWith('.test.ts') &&
-  !match.endsWith('.spec.ts');
+const isInfrastructureScanTarget = (match: string): boolean =>
+  match.endsWith('.d.ts') ||
+  match.startsWith('node_modules/') ||
+  match.startsWith('dist/') ||
+  match.startsWith('.git/');
 
-const collectTsFiles = (dir: string): readonly string[] => {
-  const glob = new Bun.Glob('**/*.ts');
+const isTestScanTarget = (match: string): boolean =>
+  match.includes('__tests__/') ||
+  match.includes('__test__/') ||
+  match.endsWith('.test.ts') ||
+  match.endsWith('.spec.ts');
+
+const isAllowedScanTarget = (match: string): boolean =>
+  !isInfrastructureScanTarget(match) && !isTestScanTarget(match);
+
+const isDevPermitTestScanTarget = (match: string): boolean =>
+  !isInfrastructureScanTarget(match) && isTestScanTarget(match);
+
+const collectFilesMatching = (
+  dir: string,
+  pattern: string,
+  dot = false
+): readonly string[] => {
+  const glob = new Bun.Glob(pattern);
   let matches: IterableIterator<string>;
   try {
-    matches = glob.scanSync({ cwd: dir, dot: false, onlyFiles: true });
+    matches = glob.scanSync({ cwd: dir, dot, onlyFiles: true });
   } catch {
     return [];
   }
 
   const files: string[] = [];
   for (const match of matches) {
-    if (isSourceFile(match)) {
+    if (isAllowedScanTarget(match)) {
       files.push(`${dir}/${match}`);
     }
   }
   return files;
 };
 
+const collectTsFiles = (dir: string): readonly string[] =>
+  collectFilesMatching(dir, '**/*.ts');
+
+const collectDevPermitTestFiles = (dir: string): readonly string[] => {
+  const glob = new Bun.Glob('**/*.ts');
+  let matches: IterableIterator<string>;
+  try {
+    matches = glob.scanSync({ cwd: dir, onlyFiles: true });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const match of matches) {
+    if (isDevPermitTestScanTarget(match)) {
+      files.push(`${dir}/${match}`);
+    }
+  }
+  return files;
+};
+
+const collectTextScanFiles = (dir: string): readonly string[] => [
+  ...collectFilesMatching(dir, '**/*.sh', true),
+  ...collectFilesMatching(dir, '**/*.bash', true),
+  ...collectFilesMatching(dir, '**/*.zsh', true),
+  ...collectFilesMatching(dir, '**/*.yml', true),
+  ...collectFilesMatching(dir, '**/*.yaml', true),
+  ...collectFilesMatching(dir, '**/package.json', true),
+];
+
 interface SourceFile {
   readonly filePath: string;
+  readonly kind: 'text' | 'typescript';
   readonly sourceCode: string;
 }
 
@@ -366,6 +410,31 @@ const loadSourceFiles = async (
     try {
       sourceFiles.push({
         filePath,
+        kind: 'typescript',
+        sourceCode: await Bun.file(filePath).text(),
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  for (const filePath of collectTextScanFiles(rootDir)) {
+    try {
+      sourceFiles.push({
+        filePath,
+        kind: 'text',
+        sourceCode: await Bun.file(filePath).text(),
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  for (const filePath of collectDevPermitTestFiles(rootDir)) {
+    try {
+      sourceFiles.push({
+        filePath,
+        kind: 'text',
         sourceCode: await Bun.file(filePath).text(),
       });
     } catch {
@@ -531,19 +600,22 @@ const buildProjectContext = (
   appTopo?: Topo | undefined
 ): ProjectContext => {
   const context = createMutableProjectContext();
+  const typeScriptSourceFiles = sourceFiles.filter(
+    (sourceFile) => sourceFile.kind === 'typescript'
+  );
 
   if (appTopo) {
     collectTopoTrailContext(appTopo, context);
-    for (const sourceFile of sourceFiles) {
+    for (const sourceFile of typeScriptSourceFiles) {
       collectFileSupplementalProjectContext(sourceFile, context);
     }
   } else {
-    for (const sourceFile of sourceFiles) {
+    for (const sourceFile of typeScriptSourceFiles) {
       collectFileProjectContext(sourceFile, context);
     }
   }
 
-  for (const sourceFile of sourceFiles) {
+  for (const sourceFile of typeScriptSourceFiles) {
     collectFileContourReferences(sourceFile, context);
   }
 
@@ -643,6 +715,13 @@ const lintSourceFiles = (
   const diagnostics: WardenDiagnostic[] = [];
   for (const sourceFile of sourceFiles) {
     for (const rule of wardenRules.values()) {
+      if (
+        sourceFile.kind === 'text' &&
+        rule.name !== 'no-dev-permit-in-source'
+      ) {
+        continue;
+      }
+
       if (!isSelectedRule(rule, tier)) {
         continue;
       }

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -83,6 +83,7 @@ export {
   intentPropagationTrail,
   missingVisibilityTrail,
   missingReconcileTrail,
+  noDevPermitInSourceTrail,
   noDirectImplementationCallTrail,
   noNativeErrorResultTrail,
   noSyncResultAssumptionTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -15,6 +15,7 @@ import { incompleteCrud } from './incomplete-crud.js';
 import { intentPropagation } from './intent-propagation.js';
 import { missingVisibility } from './missing-visibility.js';
 import { missingReconcile } from './missing-reconcile.js';
+import { noDevPermitInSource } from './no-dev-permit-in-source.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noNativeErrorResult } from './no-native-error-result.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
@@ -85,6 +86,7 @@ export { intentPropagation } from './intent-propagation.js';
 export { missingVisibility } from './missing-visibility.js';
 export { missingReconcile } from './missing-reconcile.js';
 export { onReferencesExist } from './on-references-exist.js';
+export { noDevPermitInSource } from './no-dev-permit-in-source.js';
 export { noDirectImplementationCall } from './no-direct-implementation-call.js';
 export { noNativeErrorResult } from './no-native-error-result.js';
 export { noSyncResultAssumption } from './no-sync-result-assumption.js';
@@ -140,6 +142,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [resourceExists.name, resourceExists],
   [preferSchemaInference.name, preferSchemaInference],
   [validDescribeRefs.name, validDescribeRefs],
+  [noDevPermitInSource.name, noDevPermitInSource],
   [noDirectImplementationCall.name, noDirectImplementationCall],
   [noNativeErrorResult.name, noNativeErrorResult],
   [noSyncResultAssumption.name, noSyncResultAssumption],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -131,6 +131,12 @@ export const builtinWardenRuleMetadata = {
     invariant: 'Composition-only trails declare internal visibility.',
     tier: 'project-static',
   },
+  'no-dev-permit-in-source': {
+    ...durableExternal,
+    invariant:
+      'The `--dev-permit` CLI flag string never appears in committed source.',
+    tier: 'source-static',
+  },
   'no-direct-implementation-call': {
     ...durableExternal,
     invariant: 'Application code composes trails through ctx.cross().',

--- a/packages/warden/src/rules/no-dev-permit-in-source.ts
+++ b/packages/warden/src/rules/no-dev-permit-in-source.ts
@@ -1,0 +1,99 @@
+/**
+ * Flags occurrences of the `--dev-permit` CLI flag string in source code.
+ *
+ * `--dev-permit` is a local-development ergonomic that injects a synthetic
+ * full-access permit into the CLI execution pipeline (see TRL-410). It must
+ * never appear in committed scripts, CI configs, or library source — its
+ * presence in checked-in code defeats permit governance.
+ *
+ * The rule scans source text for the literal token `--dev-permit` (string
+ * literal, comment, or code). It is intentionally text-based rather than
+ * AST-based: the failure modes the rule targets (a developer pasting a CLI
+ * invocation into a script or doc, or wiring it into a `package.json`-like
+ * manifest) appear in places the AST cannot reason about.
+ *
+ * Allow-list: the CLI flag/build modules and the Warden rule surfaces that
+ * define this rule's own metadata are exempt. The Warden runner invokes this
+ * rule across TypeScript source plus committed script/config surfaces such as
+ * shell scripts, CI YAML, and `package.json`. Unlike most Warden source rules,
+ * test TypeScript files are still scanned for this literal because checked-in
+ * tests can become copied scripts or examples.
+ */
+import { resolve, sep } from 'node:path';
+
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'no-dev-permit-in-source';
+
+/** Literal CLI flag string the rule searches for. */
+const DEV_PERMIT_LITERAL = '--dev-permit';
+
+/**
+ * Path suffixes (in POSIX form) for source files that legitimately contain
+ * the literal `--dev-permit` string. Other files are flagged.
+ *
+ * Each entry is matched against the normalized (forward-slash) absolute
+ * path with a trailing-segment match, so the rule stays correct regardless
+ * of the consumer's repository root.
+ */
+const ALLOWED_PATH_SUFFIXES: readonly string[] = [
+  // The CLI flag preset module authors `--dev-permit` as the canonical name.
+  '/packages/cli/src/flags.ts',
+  // The build module spells the kebab-case form when reading the parsed flag.
+  '/packages/cli/src/build.ts',
+  // The rule's own implementation file references the literal it searches for.
+  '/packages/warden/src/rules/no-dev-permit-in-source.ts',
+  // Rule metadata and trail wrapper document the same literal for users.
+  '/packages/warden/src/rules/metadata.ts',
+  '/packages/warden/src/trails/no-dev-permit-in-source.trail.ts',
+];
+
+const normalizePath = (filePath: string): string =>
+  resolve(filePath).split(sep).join('/');
+
+const isAllowedFile = (filePath: string): boolean => {
+  const normalized = normalizePath(filePath);
+  return ALLOWED_PATH_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+};
+
+const findLineOfFirstMatch = (sourceCode: string): number => {
+  const idx = sourceCode.indexOf(DEV_PERMIT_LITERAL);
+  if (idx === -1) {
+    return 1;
+  }
+  let line = 1;
+  for (let i = 0; i < idx; i += 1) {
+    if (sourceCode.codePointAt(i) === 10) {
+      line += 1;
+    }
+  }
+  return line;
+};
+
+/**
+ * Flags occurrences of the `--dev-permit` flag string in committed source.
+ */
+export const noDevPermitInSource: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isAllowedFile(filePath)) {
+      return [];
+    }
+    if (!sourceCode.includes(DEV_PERMIT_LITERAL)) {
+      return [];
+    }
+    return [
+      {
+        filePath,
+        line: findLineOfFirstMatch(sourceCode),
+        message:
+          '`--dev-permit` is a local-development flag and must not appear in committed source. Use `--token` or `--permit` for CI and scripted invocations.',
+        rule: RULE_NAME,
+        severity: 'error',
+      },
+    ];
+  },
+  description:
+    'Disallow the `--dev-permit` CLI flag string in committed source code.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -23,6 +23,7 @@ import { incompleteCrud } from './incomplete-crud.js';
 import { intentPropagation } from './intent-propagation.js';
 import { missingReconcile } from './missing-reconcile.js';
 import { missingVisibility } from './missing-visibility.js';
+import { noDevPermitInSource } from './no-dev-permit-in-source.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noNativeErrorResult } from './no-native-error-result.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
@@ -73,6 +74,7 @@ export const registeredRuleNames: readonly string[] = [
   intentPropagation.name,
   missingReconcile.name,
   missingVisibility.name,
+  noDevPermitInSource.name,
   noDirectImplementationCall.name,
   noNativeErrorResult.name,
   noSyncResultAssumption.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -16,6 +16,7 @@ export { intentPropagationTrail } from './intent-propagation.trail.js';
 export { missingVisibilityTrail } from './missing-visibility.trail.js';
 export { missingReconcileTrail } from './missing-reconcile.trail.js';
 export { onReferencesExistTrail } from './on-references-exist.trail.js';
+export { noDevPermitInSourceTrail } from './no-dev-permit-in-source.trail.js';
 export { noDirectImplementationCallTrail } from './no-direct-implementation-call.trail.js';
 export { noNativeErrorResultTrail } from './no-native-error-result.trail.js';
 export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.js';

--- a/packages/warden/src/trails/no-dev-permit-in-source.trail.ts
+++ b/packages/warden/src/trails/no-dev-permit-in-source.trail.ts
@@ -1,0 +1,16 @@
+import { noDevPermitInSource } from '../rules/no-dev-permit-in-source.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const noDevPermitInSourceTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'apps/example/src/cli.ts',
+        sourceCode: `import { tokenPreset } from '@ontrails/cli';\n`,
+      },
+      name: 'Source files without --dev-permit are clean',
+    },
+  ],
+  rule: noDevPermitInSource,
+});


### PR DESCRIPTION
## Summary
- Adds development-only `--dev-permit` support for local `trails run` execution.
- Synthesizes a distinctive full-access permit from all scopes declared in the topo.
- Adds a Warden rule that blocks committed `--dev-permit` usage across source, scripts, CI YAML, and package manifests.

## Details
`--permit`, `--token`, and `--dev-permit` are mutually exclusive; any combination returns `ValidationError`. The synthetic permit uses id `dev-permit` and enumerates declared scopes rather than relying on wildcard semantics in core. `no-dev-permit-in-source` scans for the literal token, with narrow allow-lists for the CLI implementation and the rule/trail itself, so accidental production scripts or package commands are caught.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-410. Closes Phase 4 (Permits + dry-run).