### PR TITLE
feat(cli,trails): add --watch flag with debounced rerun on source change

### DIFF
--- a/.changeset/trl-413-watch-mode.md
+++ b/.changeset/trl-413-watch-mode.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/cli': patch
+'@ontrails/trails': patch
+---
+
+Add `--watch` for the `trails run` family. File-system events are cheap wake-ups; the rerun gate compares the resolved trail's surface-map entry hash so edits only rerun when the public contract for the watched trail changes. New `watchPreset()` exposes the boolean flag; `'watch'` is added to `META_FLAG_CANDIDATES` so the flag never routes into trail input. The watch loop in `apps/trails/src/run-watch.ts` runs once, then sets up a debounced (`100ms`) `node:fs.watch` filtered to `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs` extensions in the trail's source directory. SIGINT closes the watcher cleanly. A short startup warmup window (`150ms`) suppresses the macOS FSEvents replay event that would otherwise produce a phantom rerun on first invocation.

--- a/apps/trails/src/__tests__/run-watch.test.ts
+++ b/apps/trails/src/__tests__/run-watch.test.ts
@@ -1,0 +1,455 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { SurfaceMapEntry } from '@ontrails/topographer';
+
+import {
+  WATCH_DEBOUNCE_MS,
+  WATCH_WARMUP_MS,
+  argvHasWatchFlag,
+  createTrailWatcher,
+  hashSurfaceMapEntry,
+  readRunTrailId,
+} from '../run-watch.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Settle delay between watcher install and triggering test changes.
+ *
+ * Slightly longer than `WATCH_WARMUP_MS` so the watcher's warmup window
+ * has fully expired before the test write fires. Keeps the rerun counter
+ * deterministic across the FSEvents phantom-event behavior on macOS.
+ */
+const WATCHER_SETTLE_MS = WATCH_WARMUP_MS + 50;
+
+const waitFor = async (
+  predicate: () => boolean,
+  timeoutMs: number
+): Promise<void> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+    await Bun.sleep(20);
+  }
+};
+
+interface TestFixture {
+  readonly watchedDir: string;
+  readonly otherDir: string;
+  readonly cleanup: () => void;
+}
+
+const setupFixture = (): TestFixture => {
+  const root = mkdtempSync(join(tmpdir(), 'run-watch-'));
+  const watchedDir = join(root, 'watched');
+  const otherDir = join(root, 'other');
+  mkdirSync(watchedDir, { recursive: true });
+  mkdirSync(otherDir, { recursive: true });
+  // Seed an initial trail file in the watched dir so resolved paths exist.
+  writeFileSync(join(watchedDir, 'trail.ts'), 'export const v = 1;\n');
+  return {
+    cleanup: () => {
+      rmSync(root, { force: true, recursive: true });
+    },
+    otherDir,
+    watchedDir,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Argv detection
+// ---------------------------------------------------------------------------
+
+describe('argvHasWatchFlag', () => {
+  test('returns true when --watch is present', () => {
+    expect(argvHasWatchFlag(['node', 'trails', 'run', 'foo', '--watch'])).toBe(
+      true
+    );
+  });
+
+  test('returns false when --watch is absent', () => {
+    expect(argvHasWatchFlag(['node', 'trails', 'run', 'foo'])).toBe(false);
+  });
+
+  test('does not match arbitrary substrings', () => {
+    expect(
+      argvHasWatchFlag(['node', 'trails', 'run', '--watch-something'])
+    ).toBe(false);
+  });
+});
+
+describe('readRunTrailId', () => {
+  test('reads the direct run trail id', () => {
+    expect(readRunTrailId(['run', 'entity.show', '--watch'])).toBe(
+      'entity.show'
+    );
+  });
+
+  test('skips short output and quiet flags before the trail id', () => {
+    expect(readRunTrailId(['run', '-o', 'json', '-q', 'entity.show'])).toBe(
+      'entity.show'
+    );
+  });
+
+  test('skips compact short output flag before the trail id', () => {
+    expect(readRunTrailId(['run', '-ojson', 'entity.show'])).toBe(
+      'entity.show'
+    );
+  });
+
+  test('reads the trail id from run example invocations with flags', () => {
+    expect(
+      readRunTrailId(['run', '-o', 'json', 'example', 'entity.show', 'happy'])
+    ).toBe('entity.show');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Watcher
+// ---------------------------------------------------------------------------
+
+describe('createTrailWatcher', () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    fixture = setupFixture();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test('exposes the debounce window', () => {
+    expect(WATCH_DEBOUNCE_MS).toBeGreaterThanOrEqual(50);
+    expect(WATCH_DEBOUNCE_MS).toBeLessThanOrEqual(200);
+  });
+
+  test('hashes a surface-map entry deterministically', () => {
+    const entry: SurfaceMapEntry = {
+      exampleCount: 0,
+      id: 'entity.show',
+      input: { type: 'object' },
+      intent: 'read',
+      kind: 'trail',
+      output: { type: 'object' },
+      surfaces: ['cli'],
+    } as const;
+
+    expect(hashSurfaceMapEntry(entry)).toBe(hashSurfaceMapEntry(entry));
+    expect(hashSurfaceMapEntry({ ...entry, intent: 'write' })).not.toBe(
+      hashSurfaceMapEntry(entry)
+    );
+  });
+
+  test('triggers a rerun when the watched surface-map entry changes', async () => {
+    const reruns: number[] = [];
+    let surfaceHash = 'contract:v1';
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: surfaceHash,
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => surfaceHash,
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+      surfaceHash = 'contract:v2';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const v = 2;\n'
+      );
+
+      await waitFor(() => reruns.length >= 1, WATCH_DEBOUNCE_MS + 1000);
+
+      expect(reruns.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('does not rerun for comment-only edits with the same surface hash', async () => {
+    const reruns: number[] = [];
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: 'contract:v1',
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => 'contract:v1',
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        '// comment-only edit\nexport const v = 1;\n'
+      );
+
+      await Bun.sleep(WATCH_DEBOUNCE_MS + 200);
+
+      expect(reruns.length).toBe(0);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('does not rerun for sibling source edits when the watched contract is unchanged', async () => {
+    const reruns: number[] = [];
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: 'contract:v1',
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => 'contract:v1',
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+      writeFileSync(
+        join(fixture.watchedDir, 'sibling.ts'),
+        'export const typo = "fixed";\n'
+      );
+
+      await Bun.sleep(WATCH_DEBOUNCE_MS + 200);
+
+      expect(reruns.length).toBe(0);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('does not rerun for non .ts/.js files', async () => {
+    const reruns: number[] = [];
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: 'contract:v1',
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => 'contract:v1',
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+      writeFileSync(join(fixture.watchedDir, 'notes.md'), '# notes\n');
+
+      // Wait beyond the debounce window plus margin.
+      await Bun.sleep(WATCH_DEBOUNCE_MS + 200);
+
+      expect(reruns.length).toBe(0);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('does not rerun for changes in unrelated directories', async () => {
+    const reruns: number[] = [];
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: 'contract:v1',
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => 'contract:v1',
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+      writeFileSync(
+        join(fixture.otherDir, 'unrelated.ts'),
+        'export const u = 1;\n'
+      );
+
+      await Bun.sleep(WATCH_DEBOUNCE_MS + 200);
+
+      expect(reruns.length).toBe(0);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('debounces rapid changes into a single rerun', async () => {
+    const reruns: number[] = [];
+    let surfaceHash = 'contract:v1';
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: surfaceHash,
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => surfaceHash,
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+      // Burst of writes within the debounce window.
+      for (let i = 0; i < 5; i += 1) {
+        surfaceHash = `contract:v${i + 2}`;
+        writeFileSync(
+          join(fixture.watchedDir, 'trail.ts'),
+          `export const v = ${i};\n`
+        );
+      }
+
+      await waitFor(() => reruns.length >= 1, WATCH_DEBOUNCE_MS + 1000);
+
+      // Allow any extra debounced firings to settle, then assert just one.
+      await Bun.sleep(WATCH_DEBOUNCE_MS + 100);
+      expect(reruns.length).toBe(1);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('skips invalid surface states and resumes on the next valid contract change', async () => {
+    const reruns: number[] = [];
+    let mode: 'invalid' | 'valid' = 'invalid';
+    let surfaceHash = 'contract:v1';
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: surfaceHash,
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => {
+        if (mode === 'invalid') {
+          throw new Error('schema invalid');
+        }
+        return surfaceHash;
+      },
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const broken = ;\n'
+      );
+      await Bun.sleep(WATCH_DEBOUNCE_MS + 200);
+      expect(reruns.length).toBe(0);
+
+      mode = 'valid';
+      surfaceHash = 'contract:v2';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const fixed = 1;\n'
+      );
+      await waitFor(() => reruns.length >= 1, WATCH_DEBOUNCE_MS + 1000);
+      expect(reruns.length).toBe(1);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('holds when the watched trail is removed and reruns once it returns changed', async () => {
+    const reruns: number[] = [];
+    let surfaceHash: string | null = null;
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: 'contract:v1',
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => surfaceHash,
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+      writeFileSync(join(fixture.watchedDir, 'trail.ts'), 'export {};\n');
+      await Bun.sleep(WATCH_DEBOUNCE_MS + 200);
+      expect(reruns.length).toBe(0);
+
+      surfaceHash = 'contract:v2';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const restored = 1;\n'
+      );
+      await waitFor(() => reruns.length >= 1, WATCH_DEBOUNCE_MS + 1000);
+      expect(reruns.length).toBe(1);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('close() stops further reruns', async () => {
+    const reruns: number[] = [];
+    const watcher = createTrailWatcher({
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => 'contract:v1',
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    watcher.close();
+
+    writeFileSync(
+      join(fixture.watchedDir, 'trail.ts'),
+      'export const v = 99;\n'
+    );
+
+    await Bun.sleep(WATCH_DEBOUNCE_MS + 200);
+
+    expect(reruns.length).toBe(0);
+  });
+
+  test('close() suppresses rerun when surface hash read is already in flight', async () => {
+    const reruns: number[] = [];
+    const hashRead = Promise.withResolvers<string>();
+    let readStarted = false;
+    const watcher = createTrailWatcher({
+      debounceMs: 10,
+      initialSurfaceHash: 'contract:v1',
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => {
+        readStarted = true;
+        return hashRead.promise;
+      },
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+      warmupMs: 0,
+    });
+
+    try {
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const v = 100;\n'
+      );
+      await waitFor(() => readStarted, WATCH_DEBOUNCE_MS + 1000);
+
+      watcher.close();
+      hashRead.resolve('contract:v2');
+
+      await Bun.sleep(WATCH_DEBOUNCE_MS + 100);
+      expect(reruns.length).toBe(0);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('close() is idempotent', () => {
+    const watcher = createTrailWatcher({
+      onRerun: () => {
+        // no-op
+      },
+      readSurfaceHash: () => 'contract:v1',
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    watcher.close();
+    expect(() => {
+      watcher.close();
+    }).not.toThrow();
+  });
+});

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -1,3 +1,7 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { isAbsolute, join, resolve } from 'node:path';
+
 import {
   defaultOnResult,
   devPermitPreset,
@@ -5,6 +9,7 @@ import {
   permitPreset,
   tokenPreset,
   tracePreset,
+  watchPreset,
 } from '@ontrails/cli';
 import type {
   ActionResultContext,
@@ -12,6 +17,7 @@ import type {
 } from '@ontrails/cli';
 import { surface } from '@ontrails/cli/commander';
 import { resolvePermitFromBearerToken } from '@ontrails/permits';
+import { deriveSurfaceMap } from '@ontrails/topographer';
 
 import { app } from './app.js';
 import { resolveInputWithClack } from './clack.js';
@@ -26,6 +32,15 @@ import {
   writeTraceTreeToStderr,
 } from './run-trace.js';
 import type { TraceSession } from './run-trace.js';
+import {
+  argvHasWatchFlag,
+  hashSurfaceMapEntry,
+  readRunTrailId,
+  runWatchLoop,
+} from './run-watch.js';
+import { tryLoadFreshAppLease } from './trails/load-app.js';
+import { resolveRunModulePath } from './trails/run.js';
+import { resolveTrailRootDir } from './trails/root-dir.js';
 import { trailsPackageVersion } from './versions.js';
 
 const buildOnResult =
@@ -63,9 +78,8 @@ const buildOnResult =
     await defaultOnResult(resolvedCtx);
   };
 
-const session: TraceSession | undefined = argvHasTraceFlag(process.argv)
-  ? installTraceSink()
-  : undefined;
+const maybeInstallTraceSession = (): TraceSession | undefined =>
+  argvHasTraceFlag(process.argv) ? installTraceSink() : undefined;
 
 const resolveCliPermitFromToken: ResolveCliPermitFromToken = (input) =>
   resolvePermitFromBearerToken({
@@ -80,26 +94,156 @@ const resolveCliPermitFromToken: ResolveCliPermitFromToken = (input) =>
     surface: 'cli',
   });
 
-try {
-  // oxlint-disable-next-line require-hook -- CLI entry point
-  await surface(app, {
-    description: 'Agent-native, contract-first TypeScript framework',
-    name: 'trails',
-    onResult: buildOnResult(session),
-    presets: [
-      outputModePreset(),
-      tracePreset(),
-      permitPreset(),
-      tokenPreset(),
-      devPermitPreset(),
-    ],
-    resolveInput: resolveInputWithClack,
-    resolvePermitFromToken: resolveCliPermitFromToken,
-    version: trailsPackageVersion,
-  });
-} finally {
-  if (session !== undefined) {
-    const records = session.finalize();
-    writeTraceTreeToStderr(records);
-  }
+interface WatchRunTarget {
+  readonly app?: string | undefined;
+  readonly id: string;
+  readonly module?: string | undefined;
+  readonly rootDir?: string | undefined;
 }
+
+const readFlagValue = (
+  args: readonly string[],
+  flagName: string
+): string | undefined => {
+  const longFlag = `--${flagName}`;
+  const prefixedFlag = `${longFlag}=`;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === longFlag) {
+      return args[i + 1];
+    }
+    if (arg?.startsWith(prefixedFlag)) {
+      return arg.slice(prefixedFlag.length);
+    }
+  }
+  return undefined;
+};
+
+const resolveWatchRunTarget = (
+  argv: readonly string[]
+): WatchRunTarget | null => {
+  const args = argv.slice(2);
+  const id = readRunTrailId(args);
+  if (id === undefined) {
+    return null;
+  }
+  return {
+    app: readFlagValue(args, 'app'),
+    id,
+    module: readFlagValue(args, 'module'),
+    rootDir: readFlagValue(args, 'root-dir'),
+  };
+};
+
+/**
+ * Resolve the directory whose source-file events wake the `--watch` loop.
+ * Reruns still depend on the resolved surface-map entry hash; this path is
+ * only the cheap filesystem event source.
+ */
+const toWatchSourcePath = (rootDir: string, modulePath: string): string => {
+  if (modulePath.startsWith('file:')) {
+    return fileURLToPath(modulePath);
+  }
+  return isAbsolute(modulePath) ? modulePath : resolve(rootDir, modulePath);
+};
+
+const resolveWatchDirectorySourcePath = async (
+  target: WatchRunTarget | null
+): Promise<string> => {
+  if (target !== null) {
+    const rootDirResult = resolveTrailRootDir(target.rootDir, process.cwd());
+    if (rootDirResult.isErr()) {
+      throw rootDirResult.error;
+    }
+    const moduleResult = await resolveRunModulePath(
+      rootDirResult.value,
+      target.module,
+      target.id,
+      target.app
+    );
+    if (moduleResult.isOk()) {
+      return toWatchSourcePath(rootDirResult.value, moduleResult.value);
+    }
+  }
+  const cwd = process.cwd();
+  const srcDir = join(cwd, 'src');
+  if (existsSync(srcDir)) {
+    return join(srcDir, 'app.ts');
+  }
+  return join(cwd, 'app.ts');
+};
+
+const readWatchSurfaceHash = async (
+  target: WatchRunTarget | null
+): Promise<string | null> => {
+  if (target === null) {
+    return null;
+  }
+  const rootDirResult = resolveTrailRootDir(target.rootDir, process.cwd());
+  if (rootDirResult.isErr()) {
+    throw rootDirResult.error;
+  }
+  const rootDir = rootDirResult.value;
+  const moduleResult = await resolveRunModulePath(
+    rootDir,
+    target.module,
+    target.id,
+    target.app
+  );
+  if (moduleResult.isErr()) {
+    throw moduleResult.error;
+  }
+  const leaseResult = await tryLoadFreshAppLease(moduleResult.value, rootDir);
+  if (leaseResult.isErr()) {
+    throw leaseResult.error;
+  }
+  const lease = leaseResult.value;
+  try {
+    const surfaceMap = deriveSurfaceMap(lease.app);
+    const entry = surfaceMap.entries.find(
+      (candidate) => candidate.kind === 'trail' && candidate.id === target.id
+    );
+    return entry === undefined ? null : hashSurfaceMapEntry(entry);
+  } finally {
+    lease.release();
+  }
+};
+
+const runSurfaceOnce = async (): Promise<void> => {
+  const session = maybeInstallTraceSession();
+  try {
+    // oxlint-disable-next-line require-hook -- CLI entry point
+    await surface(app, {
+      description: 'Agent-native, contract-first TypeScript framework',
+      name: 'trails',
+      onResult: buildOnResult(session),
+      presets: [
+        outputModePreset(),
+        tracePreset(),
+        permitPreset(),
+        tokenPreset(),
+        devPermitPreset(),
+        watchPreset(),
+      ],
+      resolveInput: resolveInputWithClack,
+      resolvePermitFromToken: resolveCliPermitFromToken,
+      version: trailsPackageVersion,
+    });
+  } finally {
+    if (session !== undefined) {
+      const records = session.finalize();
+      writeTraceTreeToStderr(records);
+    }
+  }
+};
+
+const watchTarget = argvHasWatchFlag(process.argv)
+  ? resolveWatchRunTarget(process.argv)
+  : null;
+await (argvHasWatchFlag(process.argv)
+  ? runWatchLoop({
+      readSurfaceHash: () => readWatchSurfaceHash(watchTarget),
+      run: runSurfaceOnce,
+      sourcePath: await resolveWatchDirectorySourcePath(watchTarget),
+    })
+  : runSurfaceOnce());

--- a/apps/trails/src/run-watch.ts
+++ b/apps/trails/src/run-watch.ts
@@ -1,0 +1,427 @@
+/**
+ * CLI-surface bridge for the `--watch` flag (`trails run --watch`).
+ *
+ * `--watch` is a local-development ergonomics affordance for `trails run`.
+ * After the first invocation completes, the CLI installs a filesystem
+ * watcher as a cheap event source. On each debounced event, the watcher
+ * re-derives the watched trail's resolved-contract hash from its surface-map
+ * entry and invokes the supplied `onRerun` callback only when that hash
+ * changes. The loop runs until the user sends `SIGINT`.
+ *
+ * Design notes:
+ *
+ * - **Scope.** Watching is intentionally narrow. Filesystem events only wake
+ *   the loop; the rerun decision is the watched trail's surface-map entry.
+ *   Comments, whitespace, and unrelated sibling trail changes wake the loop
+ *   but do not rerun unless the resolved contract changes.
+ * - **Debounce.** Editor saves often produce multiple `fs.watch` events
+ *   per logical change (write tmp, rename, touch mtime). The debounce
+ *   coalesces these into a single rerun and dampens AFS / iCloud sync
+ *   bursts.
+ * - **No external deps.** Uses `node:fs.watch` (re-exported by Bun) so
+ *   we avoid pulling in `chokidar` or similar.
+ */
+
+import { once } from 'node:events';
+import { watch as nodeWatch } from 'node:fs';
+import type { FSWatcher } from 'node:fs';
+import { dirname, extname } from 'node:path';
+
+import type { SurfaceMapEntry } from '@ontrails/topographer';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Debounce window (ms) for coalescing rapid filesystem events into a single
+ * rerun. Sized small enough to feel instantaneous but large enough to
+ * absorb editor save bursts and sync-driven duplicate notifications.
+ */
+export const WATCH_DEBOUNCE_MS = 100;
+
+/**
+ * Warmup window (ms) after the watcher is created during which incoming
+ * events are ignored.
+ *
+ * On macOS, `fs.watch` (FSEvents) routinely emits a phantom `rename`
+ * event for files that already existed in the watched directory shortly
+ * after the watcher is installed. Ignoring events within this short
+ * warmup prevents a spurious rerun on the first invocation without
+ * meaningfully delaying real edits.
+ *
+ * Applied uniformly across platforms — the cost is negligible (no human
+ * saves within ~150ms of starting `trails run --watch`), and a
+ * platform-specific branch isn't worth the complexity.
+ */
+export const WATCH_WARMUP_MS = 150;
+
+/** Extensions considered relevant to a trail rerun. */
+const WATCHED_EXTENSIONS: ReadonlySet<string> = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.mjs',
+  '.cjs',
+]);
+
+const ANSI_CLEAR_SCREEN = '\u001B[2J\u001B[H';
+
+const WATCH_SCHEMA_INVALID_MESSAGE =
+  '[watch] schema invalid; skipping rerun until valid\n';
+const WATCH_TRAIL_REMOVED_MESSAGE = '[watch] trail removed; awaiting return\n';
+
+// ---------------------------------------------------------------------------
+// Argv detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect whether `--watch` appears in argv.
+ *
+ * Pre-parsed argv detection lets the CLI install the watcher loop before
+ * `surface()` parses argv. The flag is also wired through the build
+ * pipeline as a meta flag, so trail input is unaffected.
+ */
+export const argvHasWatchFlag = (argv: readonly string[]): boolean =>
+  argv.includes('--watch');
+
+const RUN_FLAGS_WITH_VALUES: ReadonlySet<string> = new Set([
+  '--app',
+  '--input',
+  '--input-json',
+  '--module',
+  '--output',
+  '--root-dir',
+  '--token',
+  '--permit',
+]);
+
+const RUN_SHORT_FLAGS_WITH_VALUES: ReadonlySet<string> = new Set(['-o']);
+
+/**
+ * Read the target trail id from a `trails run ...` argv slice.
+ *
+ * Accepts args after the binary name (for example
+ * `['run', '-o', 'json', 'trail.id', '--watch']`). The parser is intentionally
+ * small and conservative: it skips known CLI meta flags and their values so the
+ * watch loop resolves the same trail the run command will execute.
+ */
+export const readRunTrailId = (args: readonly string[]): string | undefined => {
+  const runIndex = args.indexOf('run');
+  if (runIndex === -1) {
+    return undefined;
+  }
+  const positionals: string[] = [];
+  for (let i = runIndex + 1; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === undefined) {
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      if (!arg.includes('=') && RUN_FLAGS_WITH_VALUES.has(arg)) {
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      if (RUN_SHORT_FLAGS_WITH_VALUES.has(arg)) {
+        i += 1;
+      }
+      continue;
+    }
+    positionals.push(arg);
+  }
+  const [first, second] = positionals;
+  if (first === 'examples' || first === 'example') {
+    return second;
+  }
+  return first;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const formatError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+};
+
+const isRelevantFilename = (filename: string | null): boolean => {
+  if (filename === null || filename.length === 0) {
+    return false;
+  }
+  return WATCHED_EXTENSIONS.has(extname(filename));
+};
+
+const canonicalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value !== null && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).toSorted()) {
+      sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+};
+
+export const hashSurfaceMapEntry = (entry: SurfaceMapEntry): string => {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(JSON.stringify(canonicalize(entry)));
+  return hasher.digest('hex');
+};
+
+export type ReadSurfaceHash = () => Promise<string | null> | string | null;
+
+// ---------------------------------------------------------------------------
+// Watcher
+// ---------------------------------------------------------------------------
+
+/** Options for {@link createTrailWatcher}. */
+export interface CreateTrailWatcherOptions {
+  /**
+   * Absolute path to the resolved trail's source file. The watcher targets
+   * the directory containing this file (non-recursive) and filters events
+   * to relevant extensions only.
+   */
+  readonly sourcePath: string;
+  /**
+   * Invoked once per debounced change burst. Errors thrown by the callback
+   * are caught and reported to stderr so a misbehaving handler does not
+   * tear down the watcher loop.
+   */
+  readonly onRerun: () => void | Promise<void>;
+  /**
+   * Derive the watched trail's current resolved-contract hash. Return `null`
+   * when the watched trail is temporarily absent. Throw when the current
+   * source state cannot produce a valid surface map.
+   */
+  readonly readSurfaceHash: ReadSurfaceHash;
+  /**
+   * Last known good resolved-contract hash captured after the initial run.
+   * When omitted, the next valid changed hash becomes the first rerun signal.
+   */
+  readonly initialSurfaceHash?: string | null | undefined;
+  /**
+   * Override for the debounce window. Primarily a test seam; production
+   * callers should rely on {@link WATCH_DEBOUNCE_MS}.
+   */
+  readonly debounceMs?: number | undefined;
+  /**
+   * Override for the warmup window. Primarily a test seam; production
+   * callers should rely on {@link WATCH_WARMUP_MS}.
+   */
+  readonly warmupMs?: number | undefined;
+}
+
+/** Handle returned by {@link createTrailWatcher}. */
+export interface TrailWatcher {
+  /**
+   * Stop the watcher and clear any pending debounce timer. Idempotent —
+   * subsequent calls are no-ops.
+   */
+  readonly close: () => void;
+}
+
+/**
+ * Create a filesystem watcher that triggers `onRerun` whenever a relevant
+ * filesystem event changes the watched trail's resolved contract.
+ *
+ * The watcher targets the directory of `sourcePath` (non-recursive). Events
+ * are filtered to TypeScript/JavaScript file extensions and coalesced through
+ * a short debounce window. Each debounced event re-reads the watched trail's
+ * surface-map entry hash; only a hash change reruns the trail.
+ *
+ * @remarks Reruns are not serialized. If a save lands while a previous
+ * rerun is still awaiting `onRerun`, the new debounce window can fire
+ * concurrently. In practice the {@link WATCH_DEBOUNCE_MS} window plus
+ * realistic save cadences make this uncommon, and each `surface()` call
+ * from the loop is independent. Callers that share mutable surface
+ * state (e.g. a global trace sink) must scope it per invocation —
+ * `runSurfaceOnce` in `apps/trails/src/cli.ts` does this for `--trace`.
+ */
+export const createTrailWatcher = (
+  options: CreateTrailWatcherOptions
+): TrailWatcher => {
+  const debounceMs = options.debounceMs ?? WATCH_DEBOUNCE_MS;
+  const warmupMs = options.warmupMs ?? WATCH_WARMUP_MS;
+  const watchDir = dirname(options.sourcePath);
+  const startedAt = Date.now();
+
+  let closed = false;
+  let currentSurfaceHash = options.initialSurfaceHash ?? null;
+  let invalidSurfaceWarned = false;
+  let trailRemovedWarned = false;
+  let pending: ReturnType<typeof setTimeout> | undefined;
+  let watcher: FSWatcher | undefined;
+
+  const readNextSurfaceHash = async (): Promise<string | null | undefined> => {
+    try {
+      const nextHash = await options.readSurfaceHash();
+      invalidSurfaceWarned = false;
+      if (nextHash !== null) {
+        trailRemovedWarned = false;
+      } else if (!trailRemovedWarned) {
+        process.stderr.write(WATCH_TRAIL_REMOVED_MESSAGE);
+        trailRemovedWarned = true;
+      }
+      return nextHash;
+    } catch {
+      if (!invalidSurfaceWarned) {
+        process.stderr.write(WATCH_SCHEMA_INVALID_MESSAGE);
+        invalidSurfaceWarned = true;
+      }
+      return undefined;
+    }
+  };
+
+  const fireRerun = async (): Promise<void> => {
+    pending = undefined;
+    if (closed) {
+      return;
+    }
+    const nextHash = await readNextSurfaceHash();
+    if (closed) {
+      return;
+    }
+    if (nextHash === undefined || nextHash === null) {
+      return;
+    }
+    if (nextHash === currentSurfaceHash) {
+      return;
+    }
+    currentSurfaceHash = nextHash;
+    try {
+      await options.onRerun();
+    } catch (error: unknown) {
+      process.stderr.write(`watch: rerun failed: ${formatError(error)}\n`);
+    }
+  };
+
+  const scheduleRerun = (): void => {
+    if (closed) {
+      return;
+    }
+    if (pending !== undefined) {
+      clearTimeout(pending);
+    }
+    pending = setTimeout(() => {
+      void fireRerun();
+    }, debounceMs);
+  };
+
+  watcher = nodeWatch(
+    watchDir,
+    { persistent: true, recursive: false },
+    (_event, filename) => {
+      if (Date.now() - startedAt < warmupMs) {
+        // Suppress FSEvents replay of pre-existing files on macOS.
+        return;
+      }
+      if (!isRelevantFilename(filename)) {
+        return;
+      }
+      scheduleRerun();
+    }
+  );
+
+  watcher.on('error', (error: Error) => {
+    process.stderr.write(`watch: watcher error: ${error.message}\n`);
+  });
+
+  return {
+    close: () => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      if (pending !== undefined) {
+        clearTimeout(pending);
+        pending = undefined;
+      }
+      if (watcher !== undefined) {
+        watcher.close();
+        watcher = undefined;
+      }
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Watch loop
+// ---------------------------------------------------------------------------
+
+/** Options for {@link runWatchLoop}. */
+export interface RunWatchLoopOptions {
+  /** Absolute path to the resolved trail's source file. */
+  readonly sourcePath: string;
+  /** Invoked once per debounced change burst (and once initially). */
+  readonly run: () => Promise<void>;
+  /** Derive the watched trail's current resolved-contract hash. */
+  readonly readSurfaceHash: ReadSurfaceHash;
+  /**
+   * Override for the debounce window. Primarily a test seam.
+   */
+  readonly debounceMs?: number | undefined;
+  /**
+   * Whether to clear the terminal between reruns. Defaults to `true` for
+   * the standard interactive experience; tests pass `false` to keep
+   * captured output legible.
+   */
+  readonly clearScreen?: boolean | undefined;
+}
+
+/**
+ * Run the trail once, then install a watcher and re-run on changes until
+ * `SIGINT` is received. Returns the exit code (always `0` on a clean
+ * SIGINT shutdown).
+ *
+ * @remarks This is the high-level entry point used by the CLI binary.
+ * Tests should target {@link createTrailWatcher} directly rather than
+ * spawning a subprocess to drive this loop.
+ */
+export const runWatchLoop = async (
+  options: RunWatchLoopOptions
+): Promise<number> => {
+  const clearScreen = options.clearScreen ?? true;
+
+  const performRun = async (): Promise<void> => {
+    if (clearScreen) {
+      process.stdout.write(ANSI_CLEAR_SCREEN);
+    }
+    try {
+      await options.run();
+    } catch (error: unknown) {
+      process.stderr.write(`watch: run failed: ${formatError(error)}\n`);
+    }
+  };
+
+  await performRun();
+
+  let initialSurfaceHash: string | null = null;
+  try {
+    initialSurfaceHash = await options.readSurfaceHash();
+  } catch {
+    process.stderr.write(WATCH_SCHEMA_INVALID_MESSAGE);
+  }
+
+  const watcher = createTrailWatcher({
+    debounceMs: options.debounceMs,
+    initialSurfaceHash,
+    onRerun: performRun,
+    readSurfaceHash: options.readSurfaceHash,
+    sourcePath: options.sourcePath,
+  });
+
+  // `once(emitter, 'event')` returns a Promise that resolves when the
+  // event fires. Cleaner than `new Promise(resolve => emitter.on(...))`
+  // and aligns with `eslint-plugin-promise/avoid-new`.
+  await once(process, 'SIGINT');
+  watcher.close();
+  return 0;
+};

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -151,6 +151,7 @@ const META_FLAG_CANDIDATES = new Set([
   'quiet',
   'token',
   'trace',
+  'watch',
 ]);
 
 const STRUCTURED_INLINE_JSON_ARG_NAME = 'inline-json';

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -188,6 +188,31 @@ export const tokenPreset = (): CliFlag[] => [
 ];
 
 /**
+ * Flag for live re-execution of `trails run`: --watch
+ *
+ * When set, the CLI runs the resolved trail once, installs a filesystem
+ * watcher scoped to the trail's source file (and its sibling
+ * `*.ts`/`*.js` files in the same directory), and reruns the trail
+ * whenever a watched file changes. The loop runs until the user sends
+ * `SIGINT`. The flag is treated as a meta flag — it never routes into
+ * trail input.
+ *
+ * `--watch` is local-development ergonomics only and is implemented in
+ * the `apps/trails` binary's `run` entrypoint, not in surface-agnostic
+ * trail code. Other surfaces (MCP, HTTP) ignore the flag.
+ */
+export const watchPreset = (): CliFlag[] => [
+  {
+    default: false,
+    description: 'Rerun the trail when its source file or siblings change',
+    name: 'watch',
+    required: false,
+    type: 'boolean',
+    variadic: false,
+  },
+];
+
+/**
  * Flag for injecting a synthetic full-access permit: --dev-permit
  *
  * Local development only. When set, the CLI synthesizes a `BasePermit`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ export {
   permitPreset,
   tokenPreset,
   tracePreset,
+  watchPreset,
 } from './flags.js';
 
 // Output


### PR DESCRIPTION
## Summary
- Adds `--watch` as a CLI meta flag for `trails run`.
- Uses filesystem events only as a wake-up signal, then reruns only when the watched trail's surface-map entry hash changes.
- Handles debounce, warmup, invalid schema, temporary trail removal, idempotent watcher shutdown, and late in-flight hash reads after shutdown.

## Details
The watcher targets the resolved trail source directory non-recursively, filters relevant file events, and re-reads the target trail's resolved-contract hash after each debounced event. Sibling edits that do not change the target contract no longer trigger reruns. The watcher also suppresses reruns if `close()` happens while a surface-hash read is already in flight, so shutdown stays quiet even when async reads resolve late. The CLI factors a single run into `runSurfaceOnce()` and dispatches to the watch loop only when `--watch` appears in argv.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Focused watch coverage: `bun test apps/trails/src/__tests__/run-watch.test.ts`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-413.