### PR TITLE
feat(trails): compose run example --watch with --trace

### DIFF
--- a/.changeset/trl-410-dev-permit.md
+++ b/.changeset/trl-410-dev-permit.md
@@ -1,6 +1,6 @@
 ---
-'@ontrails/cli': patch
-'@ontrails/warden': patch
+'@ontrails/cli': minor
+'@ontrails/warden': minor
 ---
 
 Add `--dev-permit` for local-development synthetic full-access. New `devPermitPreset()` exposes a boolean flag; when set, the CLI synthesizes a `BasePermit` (`id: 'dev-permit'`, scopes enumerated from every declared scope across the topo) and overlays it on `ctx.permit`. Mutually exclusive with `--permit` and `--token` — any combination fails with `ValidationError` listing the conflicting flags. New Warden rule `no-dev-permit-in-source` flags any committed source file containing `--dev-permit` as an error, with a tight allow-list (`packages/cli/src/flags.ts`, `packages/cli/src/build.ts`, the rule itself). The Warden runner still scans test TypeScript files for this literal while keeping unrelated source rules filtered out of tests. Apps that import `authResource`/`authLayer` are unaffected.

--- a/.changeset/trl-413-watch-mode.md
+++ b/.changeset/trl-413-watch-mode.md
@@ -1,6 +1,6 @@
 ---
-'@ontrails/cli': patch
-'@ontrails/trails': patch
+'@ontrails/cli': minor
+'@ontrails/trails': minor
 ---
 
 Add `--watch` for the `trails run` family. File-system events are cheap wake-ups; the rerun gate compares the resolved trail's surface-map entry hash so edits only rerun when the public contract for the watched trail changes. New `watchPreset()` exposes the boolean flag; `'watch'` is added to `META_FLAG_CANDIDATES` so the flag never routes into trail input. The watch loop in `apps/trails/src/run-watch.ts` runs once, then sets up a debounced (`100ms`) `node:fs.watch` filtered to `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs` extensions in the trail's source directory. SIGINT closes the watcher cleanly. A short startup warmup window (`150ms`) suppresses the macOS FSEvents replay event that would otherwise produce a phantom rerun on first invocation.

--- a/.changeset/trl-414-watch-compose.md
+++ b/.changeset/trl-414-watch-compose.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': minor
+---
+
+Compose `--watch` with the split `run example` command and `--trace` cleanly. Moves the `--trace` session install/finalize bracket inside `runSurfaceOnce` so each watch rerun gets a fresh memory sink and stderr tree (previously the sink was process-scoped and accumulated records across reruns, suppressing the per-rerun tree until SIGINT). Adds integration tests covering the example-comparison rerun loop, trace-record freshness across reruns, and error recovery (a thrown rerun does not exit the watch loop). Documents the TDD-in-terminal workflow in the Direct Invocation ADR draft.

--- a/apps/trails/src/__tests__/run-watch-compose.test.ts
+++ b/apps/trails/src/__tests__/run-watch-compose.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Composition tests for `run example --watch` and `--watch + --trace`.
+ *
+ * These are unit-level tests against {@link runWatchLoop} and
+ * {@link createTrailWatcher}: they drive the watcher via real filesystem
+ * writes and stub the surface call so we can observe the per-rerun
+ * behavior without spawning a subprocess.
+ *
+ * The compositions covered here are intentionally narrow:
+ *
+ * - `run example --watch`: each rerun runs the example helper afresh, so
+ *   the comparison envelope reflects the current trail source. Flipping
+ *   match -> mismatch is observable as a change in the captured output.
+ * - `--watch + --trace`: each rerun gets a fresh trace session — records
+ *   from a previous rerun do not bleed into the next sink.
+ * - Error recovery: a rerun whose `run` callback throws does not tear
+ *   down the watcher; a subsequent file change still triggers another
+ *   rerun.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Result, executeTrail, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { installTraceSink } from '../run-trace.js';
+import {
+  WATCH_DEBOUNCE_MS,
+  WATCH_WARMUP_MS,
+  createTrailWatcher,
+  runWatchLoop,
+} from '../run-watch.js';
+
+// ---------------------------------------------------------------------------
+// Stub trail used to drive executeTrail in the trace composition test.
+// ---------------------------------------------------------------------------
+
+const greetTrail = trail('greet', {
+  blaze: ({ name }: { name: string }) => Result.ok({ greeting: `hi ${name}` }),
+  description: 'simple trail used to drive executeTrail and emit a record',
+  input: z.object({ name: z.string() }),
+  output: z.object({ greeting: z.string() }),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WATCHER_SETTLE_MS = WATCH_WARMUP_MS + 50;
+
+const waitFor = async (
+  predicate: () => boolean,
+  timeoutMs: number
+): Promise<void> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+    await Bun.sleep(20);
+  }
+};
+
+interface TestFixture {
+  readonly watchedDir: string;
+  readonly cleanup: () => void;
+}
+
+const setupFixture = (): TestFixture => {
+  const root = mkdtempSync(join(tmpdir(), 'run-watch-compose-'));
+  const watchedDir = join(root, 'watched');
+  mkdirSync(watchedDir, { recursive: true });
+  writeFileSync(join(watchedDir, 'trail.ts'), 'export const v = 1;\n');
+  return {
+    cleanup: () => {
+      rmSync(root, { force: true, recursive: true });
+    },
+    watchedDir,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// run example --watch
+// ---------------------------------------------------------------------------
+
+describe('runWatchLoop with run.example', () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    fixture = setupFixture();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test('rebuilds the comparison envelope on each rerun', async () => {
+    // Simulate the `run.example` trail's behavior: the trail
+    // returns a fresh comparison envelope per invocation. We model the
+    // implementation flipping from a passing example to a failing one
+    // by mutating a flag the stub reads each rerun.
+    let nextMatch = true;
+    let surfaceHash = 'contract:v1';
+    const envelopes: { readonly match: boolean }[] = [];
+
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: surfaceHash,
+      onRerun: () => {
+        // Imagine the run trail produces a fresh comparison envelope
+        // each invocation. The `run example --watch` contract is that
+        // each rerun observes the current source state, so flipping
+        // `nextMatch` between writes simulates an edit that breaks
+        // the example.
+        envelopes.push({ match: nextMatch });
+      },
+      readSurfaceHash: () => surfaceHash,
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+
+      // First edit: example matches.
+      surfaceHash = 'contract:v2';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const v = 2;\n'
+      );
+      await waitFor(() => envelopes.length >= 1, WATCH_DEBOUNCE_MS + 1000);
+
+      // Second edit: implementation drifts, example mismatches.
+      nextMatch = false;
+      surfaceHash = 'contract:v3';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const v = 3;\n'
+      );
+      await waitFor(() => envelopes.length >= 2, WATCH_DEBOUNCE_MS + 1000);
+
+      expect(envelopes.length).toBeGreaterThanOrEqual(2);
+      const [first, second] = envelopes;
+      expect(first?.match).toBe(true);
+      expect(second?.match).toBe(false);
+    } finally {
+      watcher.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --watch + --trace
+// ---------------------------------------------------------------------------
+
+describe('runWatchLoop with --trace', () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    fixture = setupFixture();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test('each rerun gets a fresh trace sink (records do not bleed)', async () => {
+    let surfaceHash = 'contract:v1';
+    const recordCounts: number[] = [];
+
+    // Simulate `runSurfaceOnce` under `--trace`: each invocation installs
+    // its own session, executes work, and finalizes. The watch loop
+    // composes by invoking this per rerun, so records from a previous
+    // rerun must never appear in the next session.
+    const performRun = async (): Promise<void> => {
+      const session = installTraceSink();
+      try {
+        await executeTrail(greetTrail, { name: 'compose' });
+      } finally {
+        const records = session.finalize();
+        recordCounts.push(records.length);
+      }
+    };
+
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: surfaceHash,
+      onRerun: performRun,
+      readSurfaceHash: () => surfaceHash,
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+
+      surfaceHash = 'contract:v2';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const v = 2;\n'
+      );
+      await waitFor(() => recordCounts.length >= 1, WATCH_DEBOUNCE_MS + 1000);
+
+      surfaceHash = 'contract:v3';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const v = 3;\n'
+      );
+      await waitFor(() => recordCounts.length >= 2, WATCH_DEBOUNCE_MS + 1000);
+
+      expect(recordCounts.length).toBeGreaterThanOrEqual(2);
+      const [first, second] = recordCounts;
+      expect(first).toBeGreaterThan(0);
+      expect(second).toBeGreaterThan(0);
+      // If sessions bled into one another, the second count would be
+      // strictly greater than the first (records would accumulate).
+      // A fresh sink per rerun produces equal counts for the same trail.
+      expect(second).toBe(first ?? 0);
+    } finally {
+      watcher.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error recovery
+// ---------------------------------------------------------------------------
+
+describe('runWatchLoop error recovery', () => {
+  let fixture: TestFixture;
+  let originalStderrWrite: typeof process.stderr.write;
+  let stderrChunks: string[];
+
+  beforeEach(() => {
+    fixture = setupFixture();
+    stderrChunks = [];
+    originalStderrWrite = process.stderr.write;
+    process.stderr.write = ((chunk: string) => {
+      stderrChunks.push(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalStderrWrite;
+    fixture.cleanup();
+  });
+
+  test('a thrown rerun does not exit the watch loop; subsequent saves still trigger reruns', async () => {
+    let runs = 0;
+    let surfaceHash = 'contract:v1';
+    let throwOnNextRun = false;
+
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: surfaceHash,
+      onRerun: () => {
+        runs += 1;
+        if (throwOnNextRun) {
+          throwOnNextRun = false;
+          throw new Error('synthetic syntax error');
+        }
+      },
+      readSurfaceHash: () => surfaceHash,
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+
+      // First save: rerun throws.
+      throwOnNextRun = true;
+      surfaceHash = 'contract:v2';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const v = 2;\n'
+      );
+      await waitFor(() => runs >= 1, WATCH_DEBOUNCE_MS + 1000);
+
+      // Watcher must still be live: a second save triggers another rerun.
+      surfaceHash = 'contract:v3';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const v = 3;\n'
+      );
+      await waitFor(() => runs >= 2, WATCH_DEBOUNCE_MS + 1000);
+
+      expect(runs).toBeGreaterThanOrEqual(2);
+      // The synthetic error was reported on stderr.
+      const stderrText = stderrChunks.join('');
+      expect(stderrText).toContain('synthetic syntax error');
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('runWatchLoop continues across a thrown run() and exits cleanly on SIGINT', async () => {
+    let runs = 0;
+    let surfaceHash = 'contract:v1';
+    let throwOnNextRun = false;
+
+    const loopPromise = runWatchLoop({
+      clearScreen: false,
+      readSurfaceHash: () => surfaceHash,
+      run: async () => {
+        runs += 1;
+        if (throwOnNextRun) {
+          throwOnNextRun = false;
+          throw new Error('synthetic run failure');
+        }
+        await Promise.resolve();
+      },
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      // Wait for the initial run to complete.
+      await waitFor(() => runs >= 1, 1000);
+
+      await Bun.sleep(WATCHER_SETTLE_MS);
+
+      // First save throws.
+      throwOnNextRun = true;
+      surfaceHash = 'contract:v2';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const v = 2;\n'
+      );
+      await waitFor(() => runs >= 2, WATCH_DEBOUNCE_MS + 1000);
+
+      // Second save: loop is still alive, rerun succeeds.
+      surfaceHash = 'contract:v3';
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const v = 3;\n'
+      );
+      await waitFor(() => runs >= 3, WATCH_DEBOUNCE_MS + 1000);
+
+      expect(runs).toBeGreaterThanOrEqual(3);
+    } finally {
+      // SIGINT cleanly tears down the loop.
+      process.emit('SIGINT');
+      const exitCode = await loopPromise;
+      expect(exitCode).toBe(0);
+    }
+  });
+});

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -78,8 +78,9 @@ const buildOnResult =
     await defaultOnResult(resolvedCtx);
   };
 
+const traceEnabled = argvHasTraceFlag(process.argv);
 const maybeInstallTraceSession = (): TraceSession | undefined =>
-  argvHasTraceFlag(process.argv) ? installTraceSink() : undefined;
+  traceEnabled ? installTraceSink() : undefined;
 
 const resolveCliPermitFromToken: ResolveCliPermitFromToken = (input) =>
   resolvePermitFromBearerToken({
@@ -209,6 +210,15 @@ const readWatchSurfaceHash = async (
   }
 };
 
+/**
+ * Invoke `surface()` once with an optional fresh trace session.
+ *
+ * When `--trace` is set, a fresh {@link TraceSession} is installed for the
+ * duration of the call and finalized in the `finally` block. Under
+ * `--watch`, this produces a fresh sink (and a fresh stderr tree) per
+ * rerun rather than letting records accumulate in a single
+ * process-lifetime sink.
+ */
 const runSurfaceOnce = async (): Promise<void> => {
   const session = maybeInstallTraceSession();
   try {
@@ -240,6 +250,7 @@ const runSurfaceOnce = async (): Promise<void> => {
 const watchTarget = argvHasWatchFlag(process.argv)
   ? resolveWatchRunTarget(process.argv)
   : null;
+
 await (argvHasWatchFlag(process.argv)
   ? runWatchLoop({
       readSurfaceHash: () => readWatchSurfaceHash(watchTarget),

--- a/docs/adr/drafts/20260331-direct-invocation.md
+++ b/docs/adr/drafts/20260331-direct-invocation.md
@@ -452,6 +452,10 @@ trails run example entity.show "Found" --watch
 
 Edit the implementation, save, the example reruns, match/mismatch updates instantly. This is TDD without leaving the terminal. The example is the assertion. The watch loop is the runner.
 
+The feedback loop is straightforward: write an example that captures the behavior you want, watch the trail under that example, and edit the implementation until the comparison envelope flips from `MISMATCH` to `OK`. The example envelope is rebuilt per rerun, so each save shows the current diff between expected and actual without any state carrying over from the previous attempt. When the example matches, the watch loop is quiet — no diff block, just the compact match summary. When it does not, the `input / expected / actual / diff` block is the next step the developer needs to take.
+
+Because the example is structured data on the trail, not a separate test file, the assertion travels with the trail definition. A trail that ships with examples ships with its own test suite. `trails run example <id> <exampleName> --watch` is the inner loop that drives each example to green; `bun test` is the outer loop that asserts every example on every trail across the workspace. The two surfaces share the same source of truth, so an example tightened in the terminal during development is the same example exercised in CI.
+
 Combined with `--trace`:
 
 ```bash


### PR DESCRIPTION
## Summary
- Composes `trails run example <id> <name> --watch` with `--trace`.
- Gives every watch rerun a fresh trace session and stderr tree.
- Keeps thrown reruns inside the watch loop so later saves can recover.

## Details
Trace sink install/finalize moves inside `runSurfaceOnce()`, preventing records from bleeding across watch reruns and ensuring each rerun renders independently. Integration tests cover example comparison flipping from mismatch to OK across saves, trace isolation per rerun, thrown rerun recovery, and clean SIGINT shutdown. The direct-invocation ADR draft documents the example-driven watch loop using the final `run example` command grammar.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-414. Closes Phase 5 (Watch).
