### PR TITLE
feat(trails): add shell completion infrastructure and trail-id completion

### DIFF
--- a/.changeset/trl-415-shell-completions.md
+++ b/.changeset/trl-415-shell-completions.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': minor
+---
+
+Add shell completion infrastructure and trail-ID completion. New `apps/trails/src/completions.ts` exposes `renderCompletionScript('bash' | 'zsh' | 'fish', binName)` and `renderTrailIdCompletions(workspaceRoot, prefix)` (reads the workspace topo via `buildWorkspaceTrailIndex`). Two new trails register on the topo: `completions` (returns the completion script for a chosen shell) and `completions.__complete` (the dynamic suggestion endpoint that the static script delegates to at tab-press time). Per-shell logic lives in a `Record<CompletionShell, ScriptRenderer>` lookup; the dynamic dispatch table is keyed by subcommand so TRL-416 (example-name completion) lands as a new entry.

--- a/apps/trails/src/__tests__/completions.test.ts
+++ b/apps/trails/src/__tests__/completions.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { executeTrail, ValidationError } from '@ontrails/core';
+
+import {
+  renderCompletionScript,
+  renderTrailIdCompletions,
+} from '../completions.js';
+import { completionsTrail } from '../trails/completions.js';
+import { completionsCompleteTrail } from '../trails/completions-complete.js';
+
+interface AppSpec {
+  readonly name: string;
+  readonly trailIds: readonly string[];
+}
+
+const writeFile = (filePath: string, contents: string): void => {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, contents);
+};
+
+const writeWorkspace = (root: string, apps: readonly AppSpec[]): void => {
+  writeFile(
+    join(root, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'completions-test-fixture',
+        private: true,
+        type: 'module',
+        workspaces: ['apps/*'],
+      },
+      null,
+      2
+    )}\n`
+  );
+  for (const spec of apps) {
+    const appDir = join(root, 'apps', spec.name);
+    writeFile(
+      join(appDir, 'package.json'),
+      `${JSON.stringify(
+        {
+          name: spec.name,
+          private: true,
+          trails: { module: 'src/app.ts' },
+          type: 'module',
+        },
+        null,
+        2
+      )}\n`
+    );
+    writeFile(
+      join(appDir, 'src/app.ts'),
+      [
+        `const trailIds = ${JSON.stringify(spec.trailIds)};`,
+        `export const app = {`,
+        `  name: '${spec.name}',`,
+        `  ids: () => trailIds,`,
+        `};`,
+        '',
+      ].join('\n')
+    );
+  }
+};
+
+let workspaceRoot: string;
+
+beforeEach(() => {
+  workspaceRoot = join(
+    tmpdir(),
+    `completions-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(workspaceRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { force: true, recursive: true });
+});
+
+describe('renderCompletionScript', () => {
+  test('emits a bash completion script that registers a complete handler', () => {
+    const script = renderCompletionScript('bash', 'trails').unwrap();
+    expect(script).toContain('_trails_complete');
+    expect(script).toContain('complete -F');
+    expect(script).toContain('trails');
+    expect(script).toContain('completions __complete');
+    expect(script).toContain('while IFS= read -r suggestion');
+    expect(script).not.toContain('readarray');
+  });
+
+  test('emits a zsh completion script with a compdef handler', () => {
+    const script = renderCompletionScript('zsh', 'trails').unwrap();
+    expect(script).toContain('#compdef trails');
+    expect(script).toContain('_trails_complete');
+    expect(script).toContain('completions __complete');
+    expect(script).toContain('trail_words');
+    expect(script).toContain('if [[ -n "$output" ]]');
+  });
+
+  test('emits a fish completion script that uses complete -c', () => {
+    const script = renderCompletionScript('fish', 'trails').unwrap();
+    expect(script).toContain('complete -c trails');
+    expect(script).toContain('completions __complete');
+  });
+
+  test('substitutes the bin name into bash idioms', () => {
+    const script = renderCompletionScript('bash', 'mybin').unwrap();
+    expect(script).toContain('complete -F _mybin_complete mybin');
+  });
+
+  test('returns a validation error for unsafe bin names', () => {
+    const result = renderCompletionScript('bash', 'trails;rm');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toContain('binName must match');
+    }
+  });
+});
+
+describe('renderTrailIdCompletions', () => {
+  test('returns trail ids matching the prefix, sorted', async () => {
+    writeWorkspace(workspaceRoot, [
+      {
+        name: 'docs',
+        trailIds: ['book.read', 'book.write', 'guide.list'],
+      },
+    ]);
+
+    const matches = await renderTrailIdCompletions(workspaceRoot, 'book');
+    expect(matches).toEqual(['book.read', 'book.write']);
+  });
+
+  test('empty prefix returns all trail ids sorted', async () => {
+    writeWorkspace(workspaceRoot, [
+      {
+        name: 'docs',
+        trailIds: ['guide.list', 'book.read'],
+      },
+    ]);
+
+    const matches = await renderTrailIdCompletions(workspaceRoot, '');
+    expect(matches).toEqual(['book.read', 'guide.list']);
+  });
+
+  test('unknown prefix returns an empty list', async () => {
+    writeWorkspace(workspaceRoot, [
+      {
+        name: 'docs',
+        trailIds: ['book.read', 'guide.list'],
+      },
+    ]);
+
+    const matches = await renderTrailIdCompletions(workspaceRoot, 'xyz');
+    expect(matches).toEqual([]);
+  });
+
+  test('indexing failures degrade to an empty suggestion list', async () => {
+    const matches = await renderTrailIdCompletions(
+      join(workspaceRoot, 'missing'),
+      ''
+    );
+    expect(matches).toEqual([]);
+  });
+
+  test('includes ids from collisions across multiple apps', async () => {
+    writeWorkspace(workspaceRoot, [
+      { name: 'app-a', trailIds: ['shared.id', 'a.only'] },
+      { name: 'app-b', trailIds: ['shared.id', 'b.only'] },
+    ]);
+
+    const matches = await renderTrailIdCompletions(workspaceRoot, '');
+    expect(matches).toEqual(['a.only', 'b.only', 'shared.id']);
+  });
+});
+
+describe('completionsTrail', () => {
+  test('returns a bash script for shell=bash', async () => {
+    const result = await executeTrail(completionsTrail, { shell: 'bash' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toContain('_trails_complete');
+      expect(result.value).toContain('complete -F');
+    }
+  });
+
+  test('returns a zsh script for shell=zsh', async () => {
+    const result = await executeTrail(completionsTrail, { shell: 'zsh' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toContain('#compdef trails');
+    }
+  });
+
+  test('returns a fish script for shell=fish', async () => {
+    const result = await executeTrail(completionsTrail, { shell: 'fish' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toContain('complete -c trails');
+    }
+  });
+});
+
+describe('completionsCompleteTrail', () => {
+  test('returns trail-id suggestions for `trails run <prefix>`', async () => {
+    writeWorkspace(workspaceRoot, [
+      {
+        name: 'docs',
+        trailIds: ['book.read', 'book.write', 'guide.list'],
+      },
+    ]);
+
+    const result = await executeTrail(completionsCompleteTrail, {
+      args: ['run', 'book'],
+      rootDir: workspaceRoot,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('book.read\nbook.write');
+    }
+  });
+
+  test('returns all ids when prefix is empty after `run`', async () => {
+    writeWorkspace(workspaceRoot, [
+      {
+        name: 'docs',
+        trailIds: ['book.read', 'guide.list'],
+      },
+    ]);
+
+    const result = await executeTrail(completionsCompleteTrail, {
+      args: ['run', ''],
+      rootDir: workspaceRoot,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('book.read\nguide.list');
+    }
+  });
+
+  test('does not suggest trail ids when cursor is past the trail-id slot', async () => {
+    writeWorkspace(workspaceRoot, [
+      {
+        name: 'docs',
+        trailIds: ['book.read', 'guide.list'],
+      },
+    ]);
+
+    const result = await executeTrail(completionsCompleteTrail, {
+      args: ['run', 'book.read', ''],
+      rootDir: workspaceRoot,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('');
+    }
+  });
+
+  test('returns no suggestions when args do not target a known position', async () => {
+    writeWorkspace(workspaceRoot, [
+      {
+        name: 'docs',
+        trailIds: ['book.read'],
+      },
+    ]);
+
+    const result = await executeTrail(completionsCompleteTrail, {
+      args: ['unknown-subcommand'],
+      rootDir: workspaceRoot,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('');
+    }
+  });
+});

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -3,6 +3,8 @@ import { topo } from '@ontrails/core';
 import * as addSurface from './trails/add-surface.js';
 import * as addTrail from './trails/add-trail.js';
 import * as addVerify from './trails/add-verify.js';
+import * as completions from './trails/completions.js';
+import * as completionsComplete from './trails/completions-complete.js';
 import * as create from './trails/create.js';
 import * as createScaffold from './trails/create-scaffold.js';
 import * as devClean from './trails/dev-clean.js';
@@ -44,5 +46,7 @@ export const app = topo(
   createScaffold,
   addSurface,
   addVerify,
-  addTrail
+  addTrail,
+  completions,
+  completionsComplete
 );

--- a/apps/trails/src/completions.ts
+++ b/apps/trails/src/completions.ts
@@ -1,0 +1,142 @@
+/**
+ * Shell completion infrastructure for the `trails` CLI.
+ *
+ * The completion model is a two-part system:
+ *
+ *  1. A small, static **shell script** registered with the user's shell. The
+ *     script's only job is to invoke the binary's internal completion subcommand
+ *     (`trails completions __complete`) with the partial argv at tab-press time
+ *     and feed the resulting lines back to the shell.
+ *  2. A dynamic **`__complete` trail** that parses the partial argv and emits
+ *     a sorted list of suggestions (e.g. trail IDs).
+ *
+ * This split keeps the shell-side script tiny and standardish (no rich shell
+ * DSL), while the heavy lifting stays in TypeScript where it can reuse the
+ * workspace trail index for accurate, live suggestions.
+ */
+
+import { Result, ValidationError } from '@ontrails/core';
+import { buildWorkspaceTrailIndex } from '@ontrails/topographer';
+
+/** Shells supported by the completion generator. */
+export type CompletionShell = 'bash' | 'zsh' | 'fish';
+
+type ScriptRenderer = (binName: string) => string;
+
+const renderBashScript: ScriptRenderer = (binName) =>
+  `# ${binName} bash completion
+_${binName}_complete() {
+  local cur words
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  words=("\${COMP_WORDS[@]:1:COMP_CWORD}")
+  COMPREPLY=()
+  while IFS= read -r suggestion; do
+    COMPREPLY+=("$suggestion")
+  done < <(${binName} completions __complete "\${words[@]}" 2>/dev/null)
+  return 0
+}
+complete -F _${binName}_complete ${binName}
+`;
+
+const renderZshScript: ScriptRenderer = (binName) =>
+  `#compdef ${binName}
+# ${binName} zsh completion
+_${binName}_complete() {
+  local -a suggestions trail_words
+  local output
+  trail_words=("\${(@)words[2,CURRENT]}")
+  output="$(${binName} completions __complete "\${trail_words[@]}" 2>/dev/null)"
+  if [[ -n "$output" ]]; then
+    suggestions=("\${(@f)output}")
+    if (( \${#suggestions} )); then
+      compadd -- "\${suggestions[@]}"
+    fi
+  fi
+}
+compdef _${binName}_complete ${binName}
+`;
+
+const renderFishScript: ScriptRenderer = (binName) =>
+  `# ${binName} fish completion
+function __${binName}_complete
+  set -l tokens (commandline -opc) (commandline -ct)
+  set -e tokens[1]
+  ${binName} completions __complete $tokens 2>/dev/null
+end
+complete -c ${binName} -f -a '(__${binName}_complete)'
+`;
+
+const SCRIPT_RENDERERS: Readonly<Record<CompletionShell, ScriptRenderer>> = {
+  bash: renderBashScript,
+  fish: renderFishScript,
+  zsh: renderZshScript,
+};
+
+/** Pattern that `binName` must match — alphanumerics, underscore, hyphen. */
+const BIN_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Render a static shell completion script that delegates dynamic completion
+ * to `<binName> completions __complete <args...>`.
+ *
+ * @param shell - target shell flavor.
+ * @param binName - binary name to register the completion against (typically
+ *   `'trails'`). Used both as the registered command and as the prefix for the
+ *   shell function name. Must match `/^[a-zA-Z0-9_-]+$/` — the value is
+ *   interpolated verbatim into shell source, so any non-trivial input would
+ *   be a shell-injection vector. We validate at the boundary per
+ *   "validate at the boundary, trust internally" (docs/tenets.md).
+ */
+export const renderCompletionScript = (
+  shell: CompletionShell,
+  binName: string
+): Result<string, ValidationError> => {
+  if (!BIN_NAME_PATTERN.test(binName)) {
+    return Result.err(
+      new ValidationError(
+        `renderCompletionScript: binName must match /^[a-zA-Z0-9_-]+$/ (got: ${JSON.stringify(binName)})`
+      )
+    );
+  }
+  return Result.ok(SCRIPT_RENDERERS[shell](binName));
+};
+
+/**
+ * Read trail IDs from the live workspace topo and return those matching
+ * `prefix`, sorted lexicographically. Includes IDs that collide across multiple
+ * apps — the shell only needs the unique set of identifiers, not their owners.
+ *
+ * @param workspaceRoot - workspace root directory used to resolve apps.
+ * @param prefix - prefix to filter by; an empty prefix returns every ID.
+ */
+export const renderTrailIdCompletions = async (
+  workspaceRoot: string,
+  prefix: string
+): Promise<readonly string[]> => {
+  let result: Awaited<ReturnType<typeof buildWorkspaceTrailIndex>>;
+  try {
+    result = await buildWorkspaceTrailIndex({ cwd: workspaceRoot });
+  } catch {
+    return [];
+  }
+  const ids = new Set<string>(Object.keys(result.index));
+  for (const collision of result.collisions) {
+    ids.add(collision.trailId);
+  }
+  const matching: string[] = [];
+  for (const id of ids) {
+    if (id.startsWith(prefix)) {
+      matching.push(id);
+    }
+  }
+  matching.sort((a, b) => {
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+    return 0;
+  });
+  return matching;
+};

--- a/apps/trails/src/trails/completions-complete.ts
+++ b/apps/trails/src/trails/completions-complete.ts
@@ -1,0 +1,108 @@
+/**
+ * `completions __complete` internal trail -- dynamic completion suggestions.
+ *
+ * The static shell scripts emitted by {@link completionsTrail} delegate to this
+ * trail at tab-press time. The trail receives the partial argv that the user
+ * has typed (after the binary name) and returns newline-delimited suggestions
+ * the shell should offer.
+ *
+ * For TRL-415 the only completion this trail knows about is trail IDs in the
+ * `trails run <prefix>` position. Later branches in the completions phase will
+ * extend the dispatch table to cover `--example`, `--app`, and other context.
+ */
+
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { renderTrailIdCompletions } from '../completions.js';
+import { resolveTrailRootDir } from './root-dir.js';
+
+const EMPTY_SUGGESTIONS = '';
+
+interface CompleteContext {
+  readonly args: readonly string[];
+  readonly rootDir: string;
+}
+
+type CompletionHandler = (ctx: CompleteContext) => Promise<readonly string[]>;
+
+/**
+ * Handler for `trails run <prefix>` — return matching trail IDs.
+ *
+ * The user has typed `trails run` and is completing the next positional
+ * argument; `args[1]` is the partial trail ID prefix (possibly empty).
+ */
+const completeRunPosition: CompletionHandler = async ({ args, rootDir }) => {
+  if (args.length !== 2) {
+    return [];
+  }
+  const prefix = args[1] ?? '';
+  return await renderTrailIdCompletions(rootDir, prefix);
+};
+
+const renderSuggestions = (suggestions: readonly string[]): string =>
+  suggestions.join('\n');
+
+/**
+ * Subcommand → handler dispatch table.
+ *
+ * Keep this a pure lookup so adding a new completion target (`run example`,
+ * `--app`, etc.) is a new entry rather than a new branch.
+ *
+ * @remarks As more handlers grow per-token-shape logic (e.g. distinguishing
+ * `--app <TAB>` vs `<trail-id> <TAB>` for the same subcommand), expect this
+ * table to evolve into a sub-table of (token-pattern → completion-fn) per
+ * subcommand or a small parser yielding a discriminated `CompletionContext`
+ * union. Today the single `'run'` entry is small enough that explicit
+ * branching inside `completeRunPosition` is cleaner.
+ */
+const SUBCOMMAND_HANDLERS: Readonly<Record<string, CompletionHandler>> = {
+  run: completeRunPosition,
+};
+
+export const completionsCompleteTrail = trail('completions.__complete', {
+  blaze: async (input, ctx) => {
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return Result.err(rootDirResult.error);
+    }
+    const rootDir = rootDirResult.value;
+
+    const [subcommand] = input.args;
+    if (subcommand === undefined) {
+      return Result.ok(EMPTY_SUGGESTIONS);
+    }
+
+    const handler = SUBCOMMAND_HANDLERS[subcommand];
+    if (handler === undefined) {
+      return Result.ok(EMPTY_SUGGESTIONS);
+    }
+
+    const suggestions = await handler({ args: input.args, rootDir });
+    return Result.ok(renderSuggestions(suggestions));
+  },
+  description:
+    'Internal: emit dynamic completion suggestions for the current partial argv. Invoked by the static shell completion script at tab-press time.',
+  examples: [
+    {
+      description: 'Empty argv yields no suggestions',
+      input: { args: [] },
+      name: 'Empty args',
+    },
+  ],
+  input: z.object({
+    args: z
+      .array(z.string())
+      .readonly()
+      .describe(
+        'Partial argv after the binary name; the last element is the token being completed'
+      ),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+  }),
+  intent: 'read',
+  output: z
+    .string()
+    .describe(
+      'Newline-delimited suggestions the shell should offer for the current token'
+    ),
+});

--- a/apps/trails/src/trails/completions.ts
+++ b/apps/trails/src/trails/completions.ts
@@ -1,0 +1,47 @@
+/**
+ * `completions` trail -- Print a shell completion script for the `trails` CLI.
+ *
+ * The trail's responsibility is small: render a static shell script that, when
+ * sourced by the user's shell, registers a tab-completion handler that
+ * delegates to `trails completions __complete <args...>` for the live
+ * suggestions. See {@link renderCompletionScript} for the per-shell shape.
+ */
+
+import { trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { renderCompletionScript } from '../completions.js';
+
+const COMPLETIONS_BIN_NAME = 'trails';
+
+export const completionsTrail = trail('completions', {
+  args: ['shell'],
+  blaze: async (input) =>
+    renderCompletionScript(input.shell, COMPLETIONS_BIN_NAME),
+  description:
+    'Print a shell completion script for the trails CLI; pipe into your shell rc to register tab-completion',
+  examples: [
+    {
+      description: 'Render a bash completion script',
+      input: { shell: 'bash' },
+      name: 'Render bash completion',
+    },
+    {
+      description: 'Render a zsh completion script',
+      input: { shell: 'zsh' },
+      name: 'Render zsh completion',
+    },
+    {
+      description: 'Render a fish completion script',
+      input: { shell: 'fish' },
+      name: 'Render fish completion',
+    },
+  ],
+  input: z.object({
+    shell: z
+      .enum(['bash', 'zsh', 'fish'])
+      .describe('Target shell flavor for the completion script'),
+  }),
+  intent: 'read',
+  output: z.string(),
+});


### PR DESCRIPTION
## Summary
- Adds shell completion infrastructure for bash, zsh, and fish.
- Adds dynamic trail-id completion through the internal `completions.__complete` trail.
- Fixes completion script rendering to return a `Result` so surface error handling remains explicit.

## Details
`apps/trails/src/completions.ts` renders static shell scripts that delegate tab-press completion to `trails completions __complete`. Dynamic suggestions read the workspace trail index. The internal completion trail returns newline-separated suggestions to shell adapters and keeps subcommand completion dispatch table-driven so later branches can add more completion targets.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-415.