### PR TITLE
feat(trails): add completions install CLI bridge

### DIFF
--- a/.changeset/trl-417-completions-install.md
+++ b/.changeset/trl-417-completions-install.md
@@ -1,0 +1,11 @@
+---
+'@ontrails/trails': minor
+---
+
+Add `trails completions install [--shell bash|zsh|fish]` for installing the completion script to the standard per-shell location. This is a CLI bridge command, not a topo trail: it uses `renderCompletionScript`, auto-detects `$SHELL` when `--shell` is omitted, creates parent directories as needed, and writes to:
+
+- bash → `~/.local/share/bash-completion/completions/trails`
+- zsh → `~/.local/share/zsh/site-functions/_trails` (user must add to `$fpath` if not already)
+- fish → `~/.config/fish/completions/trails.fish`
+
+Output reports `{ shell, path, created, message }`. Idempotent — second run reports `created: false` and overwrites with the freshest script. Detection failure (missing/unsupported `$SHELL`) returns `Result.err(ValidationError)` with a message naming the supported shells. Test seam allows injecting `homeDir` and `shellEnv` so the trail never mutates global state.

--- a/apps/trails/src/__tests__/completions-install.test.ts
+++ b/apps/trails/src/__tests__/completions-install.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Command } from 'commander';
+
+import { renderCompletionScript } from '../completions.js';
+import {
+  attachCompletionsInstallCommand,
+  runCompletionsInstall,
+} from '../run-completions-install.js';
+import type { CompletionShell } from '../completions.js';
+
+interface InstallOutput {
+  readonly shell: string;
+  readonly path: string;
+  readonly created: boolean;
+  readonly message?: string;
+}
+
+const asInstallOutput = (value: unknown): InstallOutput =>
+  value as InstallOutput;
+
+const expectedScript = (shell: CompletionShell): string =>
+  renderCompletionScript(shell, 'trails').unwrap();
+
+let homeDir: string;
+
+beforeEach(() => {
+  homeDir = join(
+    tmpdir(),
+    `completions-install-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(homeDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(homeDir, { force: true, recursive: true });
+});
+
+describe('runCompletionsInstall', () => {
+  describe('explicit shell', () => {
+    test('writes a bash completion script to the standard path', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shell: 'bash',
+      });
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(asInstallOutput(result.value).shell).toBe('bash');
+      expect(asInstallOutput(result.value).created).toBe(true);
+      const expectedPath = join(
+        homeDir,
+        '.local/share/bash-completion/completions/trails'
+      );
+      expect(asInstallOutput(result.value).path).toBe(expectedPath);
+      const written = await readFile(expectedPath, 'utf8');
+      expect(written).toBe(expectedScript('bash'));
+    });
+
+    test('writes a zsh completion script to the per-user site-functions path', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shell: 'zsh',
+      });
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      const expectedPath = join(
+        homeDir,
+        '.local/share/zsh/site-functions/_trails'
+      );
+      expect(asInstallOutput(result.value).shell).toBe('zsh');
+      expect(asInstallOutput(result.value).path).toBe(expectedPath);
+      const written = await readFile(expectedPath, 'utf8');
+      expect(written).toBe(expectedScript('zsh'));
+    });
+
+    test('writes a fish completion script to the standard fish path', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shell: 'fish',
+      });
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      const expectedPath = join(
+        homeDir,
+        '.config/fish/completions/trails.fish'
+      );
+      expect(asInstallOutput(result.value).shell).toBe('fish');
+      expect(asInstallOutput(result.value).path).toBe(expectedPath);
+      const written = await readFile(expectedPath, 'utf8');
+      expect(written).toBe(expectedScript('fish'));
+    });
+
+    test('returns a message that mentions the install path', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shell: 'bash',
+      });
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(asInstallOutput(result.value).message).toContain(
+        asInstallOutput(result.value).path
+      );
+    });
+  });
+
+  describe('shell auto-detection', () => {
+    test('detects zsh from $SHELL=/bin/zsh', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shellEnv: '/bin/zsh',
+      });
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(asInstallOutput(result.value).shell).toBe('zsh');
+    });
+
+    test('detects bash from $SHELL=/usr/local/bin/bash', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shellEnv: '/usr/local/bin/bash',
+      });
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(asInstallOutput(result.value).shell).toBe('bash');
+    });
+
+    test('detects fish from $SHELL=/opt/homebrew/bin/fish', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shellEnv: '/opt/homebrew/bin/fish',
+      });
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(asInstallOutput(result.value).shell).toBe('fish');
+    });
+
+    test('explicit shell input overrides shellEnv detection', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shell: 'fish',
+        shellEnv: '/bin/zsh',
+      });
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(asInstallOutput(result.value).shell).toBe('fish');
+    });
+  });
+
+  describe('detection failure', () => {
+    test('returns ValidationError when shellEnv is empty and shell unset', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shellEnv: '',
+      });
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error.name).toBe('ValidationError');
+      expect(result.error.message).toMatch(/shell|--shell/i);
+    });
+
+    test('returns ValidationError when shellEnv is an unsupported shell', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shellEnv: '/bin/csh',
+      });
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error.name).toBe('ValidationError');
+    });
+
+    test('returns ValidationError when explicit shell input is unsupported', async () => {
+      const result = await runCompletionsInstall({
+        homeDir,
+        shell: 'csh',
+      });
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error.name).toBe('ValidationError');
+    });
+  });
+
+  describe('idempotency', () => {
+    test('writing twice succeeds; second call reports created=false', async () => {
+      const first = await runCompletionsInstall({
+        homeDir,
+        shell: 'bash',
+      });
+      expect(first.isOk()).toBe(true);
+      if (!first.isOk()) {
+        return;
+      }
+      expect(asInstallOutput(first.value).created).toBe(true);
+
+      const second = await runCompletionsInstall({
+        homeDir,
+        shell: 'bash',
+      });
+      expect(second.isOk()).toBe(true);
+      if (!second.isOk()) {
+        return;
+      }
+      expect(asInstallOutput(second.value).created).toBe(false);
+      expect(asInstallOutput(second.value).message).toContain('Updated bash');
+      expect(asInstallOutput(second.value).path).toBe(
+        asInstallOutput(first.value).path
+      );
+
+      // Verify byte-equality across the two writes — true idempotency.
+      const { path } = asInstallOutput(first.value);
+      const writtenBytes = await readFile(path);
+      const expectedBytes = Buffer.from(expectedScript('bash'));
+      expect(writtenBytes.equals(expectedBytes)).toBe(true);
+    });
+  });
+
+  describe('write failures', () => {
+    test('returns Result.err when filesystem writes fail', async () => {
+      rmSync(homeDir, { force: true, recursive: true });
+      writeFileSync(homeDir, 'not a directory');
+
+      const result = await runCompletionsInstall({
+        homeDir,
+        shell: 'bash',
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error).toBeInstanceOf(Error);
+    });
+  });
+});
+
+describe('attachCompletionsInstallCommand', () => {
+  test('wires a CLI command that invokes the install bridge', async () => {
+    const program = new Command();
+    let stdout = '';
+
+    attachCompletionsInstallCommand(program, {
+      homeDir,
+      stdout: {
+        write: (chunk) => {
+          stdout += chunk;
+          return true;
+        },
+      },
+    });
+
+    await program.parseAsync(
+      ['node', 'trails', 'completions', 'install', '--shell', 'bash'],
+      { from: 'node' }
+    );
+
+    const expectedPath = join(
+      homeDir,
+      '.local/share/bash-completion/completions/trails'
+    );
+    expect(stdout).toContain(expectedPath);
+    expect(await readFile(expectedPath, 'utf8')).toBe(expectedScript('bash'));
+  });
+});

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -15,12 +15,13 @@ import type {
   ActionResultContext,
   ResolveCliPermitFromToken,
 } from '@ontrails/cli';
-import { surface } from '@ontrails/cli/commander';
+import { createProgram } from '@ontrails/cli/commander';
 import { resolvePermitFromBearerToken } from '@ontrails/permits';
 import { deriveSurfaceMap } from '@ontrails/topographer';
 
 import { app } from './app.js';
 import { resolveInputWithClack } from './clack.js';
+import { attachCompletionsInstallCommand } from './run-completions-install.js';
 import { tryRecoverFromRunCollision } from './run-collision.js';
 import { tryExampleRunOutput } from './run-example.js';
 import { tryExamplesRunOutput } from './run-examples.js';
@@ -222,8 +223,7 @@ const readWatchSurfaceHash = async (
 const runSurfaceOnce = async (): Promise<void> => {
   const session = maybeInstallTraceSession();
   try {
-    // oxlint-disable-next-line require-hook -- CLI entry point
-    await surface(app, {
+    const program = createProgram(app, {
       description: 'Agent-native, contract-first TypeScript framework',
       name: 'trails',
       onResult: buildOnResult(session),
@@ -239,6 +239,8 @@ const runSurfaceOnce = async (): Promise<void> => {
       resolvePermitFromToken: resolveCliPermitFromToken,
       version: trailsPackageVersion,
     });
+    attachCompletionsInstallCommand(program);
+    await program.parseAsync();
   } finally {
     if (session !== undefined) {
       const records = session.finalize();

--- a/apps/trails/src/run-completions-install.ts
+++ b/apps/trails/src/run-completions-install.ts
@@ -1,0 +1,182 @@
+/**
+ * CLI bridge for installing shell completion scripts.
+ *
+ * This is intentionally not a trail: it resolves CLI-local defaults such as
+ * `$SHELL` and the user's home directory, then writes to the user's completion
+ * directory. The surface-agnostic trail remains `completions`, which renders a
+ * script string for any caller.
+ */
+
+import { mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import {
+  isTrailsError,
+  mapSurfaceError,
+  Result,
+  ValidationError,
+} from '@ontrails/core';
+import type { Command } from 'commander';
+
+import { renderCompletionScript } from './completions.js';
+import type { CompletionShell } from './completions.js';
+
+export const COMPLETIONS_BIN_NAME = 'trails';
+
+const SHELLS = new Set<CompletionShell>(['bash', 'fish', 'zsh']);
+
+const INSTALL_PATH_BY_SHELL: Readonly<Record<CompletionShell, string>> = {
+  bash: '.local/share/bash-completion/completions/trails',
+  fish: '.config/fish/completions/trails.fish',
+  zsh: '.local/share/zsh/site-functions/_trails',
+};
+
+export interface CompletionsInstallOptions {
+  readonly binName?: string | undefined;
+  readonly homeDir?: string | undefined;
+  readonly shell?: string | undefined;
+  readonly shellEnv?: string | undefined;
+}
+
+export interface CompletionsInstallResult {
+  readonly created: boolean;
+  readonly message: string;
+  readonly path: string;
+  readonly shell: CompletionShell;
+}
+
+interface StdoutLike {
+  write(chunk: string): unknown;
+}
+
+export interface AttachCompletionsInstallOptions {
+  readonly binName?: string | undefined;
+  readonly homeDir?: string | undefined;
+  readonly shellEnv?: string | undefined;
+  readonly stdout?: StdoutLike | undefined;
+}
+
+const isCompletionShell = (value: string): value is CompletionShell =>
+  SHELLS.has(value as CompletionShell);
+
+const detectShellFromEnv = (shellEnv: string): CompletionShell | null => {
+  if (shellEnv.length === 0) {
+    return null;
+  }
+  const slashIndex = shellEnv.lastIndexOf('/');
+  const base = slashIndex === -1 ? shellEnv : shellEnv.slice(slashIndex + 1);
+  return isCompletionShell(base) ? base : null;
+};
+
+const unsupportedShellMessage =
+  'Could not detect shell from $SHELL. Pass --shell with one of: bash, zsh, fish.';
+
+const resolveTargetShell = (input: {
+  readonly shell?: string | undefined;
+  readonly shellEnv?: string | undefined;
+}): Result<CompletionShell, ValidationError> => {
+  if (input.shell !== undefined) {
+    if (isCompletionShell(input.shell)) {
+      return Result.ok(input.shell);
+    }
+    return Result.err(
+      new ValidationError(
+        `Unsupported shell "${input.shell}". Pass one of: bash, zsh, fish.`
+      )
+    );
+  }
+  const envValue = input.shellEnv ?? process.env['SHELL'] ?? '';
+  const detected = detectShellFromEnv(envValue);
+  return detected === null
+    ? Result.err(new ValidationError(unsupportedShellMessage))
+    : Result.ok(detected);
+};
+
+const fileExists = async (path: string): Promise<boolean> =>
+  await Bun.file(path).exists();
+
+export const runCompletionsInstall = async (
+  options: CompletionsInstallOptions = {}
+): Promise<Result<CompletionsInstallResult, Error>> => {
+  const shellResult = resolveTargetShell(options);
+  if (shellResult.isErr()) {
+    return Result.err(shellResult.error);
+  }
+
+  const shell = shellResult.value;
+  const home = options.homeDir ?? homedir();
+  const path = join(home, INSTALL_PATH_BY_SHELL[shell]);
+  const scriptResult = renderCompletionScript(
+    shell,
+    options.binName ?? COMPLETIONS_BIN_NAME
+  );
+  if (scriptResult.isErr()) {
+    return Result.err(scriptResult.error);
+  }
+
+  let existed: boolean;
+  try {
+    existed = await fileExists(path);
+    await mkdir(dirname(path), { recursive: true });
+    await Bun.write(path, scriptResult.value);
+  } catch (error) {
+    return Result.err(
+      error instanceof Error ? error : new Error(String(error))
+    );
+  }
+  const created = !existed;
+
+  return Result.ok({
+    created,
+    message: created
+      ? `Installed ${shell} completions to ${path}. Run \`exec $SHELL\` or restart your shell to activate.`
+      : `Updated ${shell} completions at ${path}.`,
+    path,
+    shell,
+  });
+};
+
+const handleCliError = (error: unknown): void => {
+  if (error instanceof Error) {
+    process.stderr.write(`Error: ${error.message}\n`);
+    process.exit(isTrailsError(error) ? mapSurfaceError('cli', error) : 8);
+  }
+  process.stderr.write(`Error: ${String(error)}\n`);
+  process.exit(8);
+};
+
+const findCompletionsCommand = (program: Command): Command | undefined =>
+  program.commands.find((command) => command.name() === 'completions');
+
+export const attachCompletionsInstallCommand = (
+  program: Command,
+  options: AttachCompletionsInstallOptions = {}
+): void => {
+  const completionsCommand =
+    findCompletionsCommand(program) ??
+    program
+      .command('completions')
+      .description('Render and install shell completion scripts');
+
+  completionsCommand
+    .command('install')
+    .description('Install a shell completion script for the trails CLI')
+    .option(
+      '-s, --shell <shell>',
+      'Target shell; auto-detected from $SHELL when omitted.'
+    )
+    .action(async (flags: { readonly shell?: string | undefined }) => {
+      const result = await runCompletionsInstall({
+        binName: options.binName,
+        homeDir: options.homeDir,
+        shell: flags.shell,
+        shellEnv: options.shellEnv,
+      });
+      if (result.isErr()) {
+        handleCliError(result.error);
+        return;
+      }
+      (options.stdout ?? process.stdout).write(`${result.value.message}\n`);
+    });
+};


### PR DESCRIPTION
## Summary
- Adds `trails completions install` for installing generated shell completion scripts.
- Keeps filesystem writes in the CLI bridge (`run-completions-install.ts`) rather than modeling local shell installation as a trail.
- Supports bash, zsh, and fish install paths with deterministic test seams.

## Details
The command renders the same completion scripts introduced earlier in the stack, auto-detects shell from `$SHELL` when `--shell` is omitted, and writes to user-local completion locations. Re-running the command is idempotent and reports whether a file was created. `homeDir`/`shellEnv` seams keep tests from mutating the real machine environment while preserving the actual CLI behavior.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-417. Closes Phase 6 (Completions).