### PR TITLE
feat(core): add typed layer input schema

### DIFF
--- a/.changeset/trl-471-typed-layer-middleware.md
+++ b/.changeset/trl-471-typed-layer-middleware.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/core': minor
+---
+
+Phase 7 starts: typed layers with optional object-shaped surface input. `Layer` gains an optional `input?: LayerInputSchema` field for surface projection (TRL-473/474 will project it onto CLI/MCP/HTTP). `executeTrail({ layers })` remains the canonical per-call wrapper option. Layers without `input` schemas stay surface-invisible and cover runtime-only concerns such as tenant guards, rate limiting, circuit breaking, and custom audit logging.

--- a/packages/core/src/__tests__/layer.test.ts
+++ b/packages/core/src/__tests__/layer.test.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { createTrailContext } from '../context';
 import { composeLayers } from '../layer';
 import type { Layer } from '../layer';
+import { executeTrail } from '../execute';
 import { Result } from '../result';
 import { trail } from '../trail';
 import type { TrailContext } from '../types';
@@ -21,6 +22,19 @@ const echoTrail = trail('echo', {
   meta: { domain: 'test' },
   output: z.object({ value: z.string() }),
 });
+
+const taggingLayer: Layer = {
+  name: 'tag',
+  wrap(_t, impl) {
+    return async (input, ctx) => {
+      const r = await impl(input, ctx);
+      return r.map((out) => ({
+        ...(out as { value: string }),
+        value: `tagged:${(out as { value: string }).value}`,
+      }));
+    };
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Layer tests
@@ -121,5 +135,72 @@ describe('Layer', () => {
   test('empty layers array returns implementation unchanged', () => {
     const wrapped = composeLayers([], echoTrail, echoTrail.blaze);
     expect(wrapped).toBe(echoTrail.blaze);
+  });
+
+  test('typed layer accepts optional input schema', () => {
+    const dryRun: Layer = {
+      input: z.object({ dryRun: z.boolean().default(false) }),
+      name: 'dry-run',
+      wrap(_t, impl) {
+        return impl;
+      },
+    };
+
+    expect(dryRun.input).toBeDefined();
+    expect(dryRun.name).toBe('dry-run');
+  });
+
+  test('typed layer without input schema still works (input is optional)', () => {
+    const noInput: Layer = {
+      name: 'no-input',
+      wrap(_t, impl) {
+        return impl;
+      },
+    };
+
+    expect(noInput.input).toBeUndefined();
+    expect(composeLayers([noInput], echoTrail, echoTrail.blaze)).toBeDefined();
+  });
+});
+
+describe('executeTrail layers option', () => {
+  test('layers option wraps the implementation without a deprecation warning', async () => {
+    const result = await executeTrail(
+      echoTrail,
+      { value: 'hello' },
+      { layers: [taggingLayer] }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ value: 'tagged:hello' });
+  });
+
+  test('layer without input schema wraps runtime-only concerns', async () => {
+    const tenantGuard: Layer = {
+      name: 'tenant-guard',
+      wrap(_trail, impl) {
+        return async (input, ctx) => {
+          const expectedTenant = ctx.extensions?.['tenantId'];
+          const actualTenant = (input as { tenantId?: string }).tenantId;
+          if (expectedTenant !== actualTenant) {
+            return Result.err(new Error('tenant mismatch'));
+          }
+          return await impl(input, ctx);
+        };
+      },
+    };
+    const tenantTrail = trail('tenant.echo', {
+      blaze: (input) => Result.ok({ value: input.value }),
+      input: z.object({ tenantId: z.string(), value: z.string() }),
+      output: z.object({ value: z.string() }),
+    });
+    const result = await executeTrail(
+      tenantTrail,
+      { tenantId: 'acme', value: 'hello' },
+      { ctx: { extensions: { tenantId: 'acme' } }, layers: [tenantGuard] }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ value: 'hello' });
   });
 });

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -86,7 +86,13 @@ export interface ExecuteTrailOptions {
   readonly ctx?: Partial<TrailContextInit> | undefined;
   /** AbortSignal override (takes final precedence over ctx and factory). */
   readonly abortSignal?: AbortSignal | undefined;
-  /** Layers to compose around the implementation. */
+  /**
+   * Typed layers supplied for this execution.
+   *
+   * Layers compose around the trail implementation. Layers without `input`
+   * schemas are surface-invisible wrappers for concerns such as tenant guards,
+   * rate limiting, circuit breaking, or custom audit logging.
+   */
   readonly layers?: readonly Layer[] | undefined;
   /** Factory that produces a base TrailContext (takes precedence over defaults). */
   readonly createContext?:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -347,7 +347,7 @@ export { validateEstablishedTopo } from './validate-established-topo.js';
 
 // Layer
 export { composeLayers } from './layer.js';
-export type { Layer } from './layer.js';
+export type { Layer, LayerInputSchema } from './layer.js';
 
 // Derive
 export { deriveCliPath, deriveFields } from './derive.js';

--- a/packages/core/src/layer.ts
+++ b/packages/core/src/layer.ts
@@ -1,3 +1,5 @@
+import type { z } from 'zod';
+
 import type { AnyTrail } from './trail.js';
 import type { Implementation } from './types.js';
 
@@ -5,10 +7,39 @@ import type { Implementation } from './types.js';
 // Layer interface
 // ---------------------------------------------------------------------------
 
-/** A composable layer that wraps trail implementations. */
+/**
+ * A composable, named layer that wraps trail implementations.
+ *
+ * Layers attach at trail, surface, or topo scope and may declare an object
+ * `input` schema describing the configuration they need from the surrounding
+ * surface. Surface packages (CLI, MCP, HTTP) project this schema onto their
+ * native idioms — flags, tool parameters, query strings — alongside the
+ * trail's own input schema.
+ *
+ * @remarks
+ * The `input` schema is metadata for surface projection. It must be an object
+ * schema so every surface can project named fields consistently. It is
+ * optional; layers without an `input` schema behave as plain wrappers. The
+ * layer's `wrap` function is the runtime contract.
+ */
+export type LayerInputSchema = z.ZodObject<z.ZodRawShape>;
+
 export interface Layer {
   readonly name: string;
   readonly description?: string | undefined;
+
+  /**
+   * Authored configuration the layer needs from the surrounding surface.
+   *
+   * Surface packages project this schema onto their native idioms (CLI flags,
+   * MCP tool parameters, HTTP query strings) so a layer's input fields appear
+   * alongside the trail's own input fields. Optional — layers that wrap purely
+   * by behavior, with no surface-visible inputs, may omit it.
+   *
+   * @see TRL-473 for CLI flag projection.
+   * @see TRL-474 for MCP and HTTP projection.
+   */
+  readonly input?: LayerInputSchema | undefined;
 
   /**
    * Wrap a trail's implementation, returning a new implementation.


### PR DESCRIPTION
## Summary
- Adds typed `Layer.input` metadata to `@ontrails/core`.
- Restricts layer input schemas to Zod object schemas so surfaces can safely project named fields.
- Keeps layers without input schemas valid for runtime-only wrapping concerns.

## Details
`LayerInputSchema` is now `z.ZodObject<z.ZodRawShape>`, and the public `Layer` interface accepts an optional `input` schema. This branch does not add a separate Middleware primitive or a new public execution option; it tightens the typed layer model that later branches project onto CLI, MCP, and HTTP surfaces. Tests cover object-schema acceptance, optional input, and runtime-only layers.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-471. Starts Phase 7 (Layer Evolution).