### PR TITLE
feat(core,cli,trails): add three attachment scopes for typed layers

### DIFF
--- a/.changeset/trl-472-attachment-scopes.md
+++ b/.changeset/trl-472-attachment-scopes.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/core': minor
+'@ontrails/cli': minor
+'@ontrails/trails': minor
+---
+
+Add three attachment scopes for typed layers — trail, surface, topo — with composition order **topo → surface → trail → blaze**. `TrailSpec` and `Trail` gain `layers?: readonly Layer[]` (default `[]`). `topo()` accepts `{ layers: [...] }` as the third options argument; the topo carries those layers and they reach the executor via `ExecuteTrailOptions.topoLayers`. The CLI's `surface()`/`createProgram()`/`deriveCliCommands` already supports a `layers` option; that now flows through `runTrailOnce` as `surfaceLayers`. The executor builds the layer chain `[...topoLayers, ...surfaceLayers, ...trail.layers, ...options.layers]` so topo wraps surface wraps trail wraps blaze (verified by composition-order tests at every level). Survey's `TrailDetailReport` adds `composedLayers: { topo, surface, trail }` so agents can introspect the layer chain per trail. Backward-compatible: every new field is optional with a non-undefined default; existing call sites are unchanged.

--- a/apps/trails/src/__tests__/guide.test.ts
+++ b/apps/trails/src/__tests__/guide.test.ts
@@ -119,6 +119,11 @@ describe('trails guide', () => {
           activationChains: [],
           activationEdges: [],
           activationSources: [],
+          composedLayers: {
+            surface: { cli: [], http: [], mcp: [] },
+            topo: [],
+            trail: [],
+          },
           crosses: [],
           description: 'Say hello',
           detours: [

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -12,6 +12,7 @@ import {
   ConflictError,
   DETOUR_MAX_ATTEMPTS_CAP,
   Result,
+  SURFACE_LAYER_NAMES_KEY,
   resource,
   schedule,
   signal,
@@ -40,6 +41,11 @@ import {
   surveyTrailDetailTrail,
 } from '../trails/survey.js';
 import { loadApp } from '../trails/load-app.js';
+import {
+  buildCurrentTopoMatches,
+  buildCurrentTrailDetail,
+  readSurfaceLayerNamesFromContext,
+} from '../trails/topo-read-support.js';
 import { topoCompileTrail } from '../trails/topo-compile.js';
 import type {
   BriefReport,
@@ -382,6 +388,111 @@ describe('trails survey detail', () => {
     expect(parsed.intent).toBe('read');
     expect(parsed.on).toEqual([]);
     expect(parsed.resources).toEqual(['db.main']);
+    expect(parsed.composedLayers).toEqual({
+      surface: { cli: [], http: [], mcp: [] },
+      topo: [],
+      trail: [],
+    });
+  });
+
+  test('trail detail surfaces composed layers from every scope', () => {
+    const trailLayer = {
+      name: 'trail-A',
+      wrap: (_t: unknown, impl: unknown) => impl as never,
+    };
+    const topoLayer = {
+      name: 'topo-Z',
+      wrap: (_t: unknown, impl: unknown) => impl as never,
+    };
+    const layered = trail('layered.surveyed', {
+      blaze: () => Result.ok({}),
+      input: z.object({}),
+      layers: [trailLayer],
+    });
+    const layeredApp = topo(
+      'layered-app',
+      { layered },
+      { layers: [topoLayer] }
+    );
+
+    const parsed = structuredClone(
+      deriveTrailDetail(layered, layeredApp, undefined, {
+        surfaceLayerNames: { cli: ['cli-B'] },
+      })
+    ) as TrailDetailReport;
+
+    expect(parsed.composedLayers.trail).toEqual(['trail-A']);
+    expect(parsed.composedLayers.topo).toEqual(['topo-Z']);
+    expect(parsed.composedLayers.surface).toEqual({
+      cli: ['cli-B'],
+      http: [],
+      mcp: [],
+    });
+  });
+
+  test('current topo read support forwards surface layer names', () => {
+    const layer = {
+      name: 'trail-A',
+      wrap: (_t: unknown, impl: unknown) => impl as never,
+    };
+    const layered = trail('layered.current', {
+      blaze: () => Result.ok({}),
+      input: z.object({}),
+      layers: [layer],
+    });
+    const layeredApp = topo('layered-app', { layered });
+
+    const detail = buildCurrentTrailDetail(layeredApp, layered.id, {
+      surfaceLayerNames: { cli: ['cli-B'], http: ['http-C'] },
+    });
+    const matches = buildCurrentTopoMatches(layeredApp, layered.id, {
+      surfaceLayerNames: { mcp: ['mcp-D'] },
+    });
+
+    expect(detail?.composedLayers.surface).toEqual({
+      cli: ['cli-B'],
+      http: ['http-C'],
+      mcp: [],
+    });
+    expect(matches[0]?.detail.kind).toBe('trail');
+    expect(
+      matches[0]?.detail.kind === 'trail'
+        ? matches[0].detail.composedLayers.surface
+        : undefined
+    ).toEqual({
+      cli: [],
+      http: [],
+      mcp: ['mcp-D'],
+    });
+  });
+
+  test('surface layer names tolerate explicit undefined values', () => {
+    const parsed = structuredClone(
+      deriveTrailDetail(helloTrail, undefined, undefined, {
+        surfaceLayerNames: {
+          cli: undefined,
+          mcp: ['mcp-A'],
+        } as Partial<TrailDetailReport['composedLayers']['surface']>,
+      })
+    ) as TrailDetailReport;
+
+    expect(parsed.composedLayers.surface).toEqual({
+      cli: [],
+      http: [],
+      mcp: ['mcp-A'],
+    });
+  });
+
+  test('surface layer names can be read from execution context', () => {
+    expect(
+      readSurfaceLayerNamesFromContext({
+        abortSignal: new AbortController().signal,
+        extensions: {
+          [SURFACE_LAYER_NAMES_KEY]: { cli: ['cli-A'], http: ['http-B'] },
+        },
+        requestId: 'req-1',
+      })
+    ).toEqual({ cli: ['cli-A'], http: ['http-B'] });
   });
 
   test('trail detail includes static activation graph chains', () => {

--- a/apps/trails/src/trails/guide.ts
+++ b/apps/trails/src/trails/guide.ts
@@ -12,6 +12,7 @@ import { trailDetailOutput } from './topo-output-schemas.js';
 import {
   buildCurrentGuideEntries,
   buildCurrentTopoDetail,
+  readSurfaceLayerNamesFromContext,
 } from './topo-read-support.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 import { resolveTrailRootDir } from './root-dir.js';
@@ -48,6 +49,7 @@ export const guideTrail = trail('guide', {
       if (input.trailId) {
         const detail = buildCurrentTopoDetail(lease.app, input.trailId, {
           rootDir,
+          surfaceLayerNames: readSurfaceLayerNamesFromContext(ctx),
         });
         if (detail === undefined || detail.kind !== 'trail') {
           return Result.err(

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -35,6 +35,7 @@ import {
   buildCurrentTrailDetail,
   buildCurrentResourceDetail,
   buildCurrentSignalDetail,
+  readSurfaceLayerNamesFromContext,
 } from './topo-read-support.js';
 import {
   activationOverviewOutput,
@@ -44,6 +45,7 @@ import {
 } from './topo-output-schemas.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 import { briefReportSchema } from './topo-reports.js';
+import type { SurfaceLayerNames } from './topo-reports.js';
 
 export {
   briefReportSchema,
@@ -56,6 +58,7 @@ export {
 export type {
   BriefReport,
   SignalDetailReport,
+  SurfaceLayerNames,
   SurveyListReport,
   TrailDetailReport,
 } from './topo-reports.js';
@@ -226,18 +229,26 @@ const buildSurveyDiff = async (
 const buildSurveyLookup = (
   app: Topo,
   entityId: string,
-  rootDir: string
+  rootDir: string,
+  surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Result<object, Error> => {
-  const matches = buildCurrentTopoMatches(app, entityId, { rootDir });
+  const matches = buildCurrentTopoMatches(app, entityId, {
+    rootDir,
+    surfaceLayerNames,
+  });
   return Result.ok({ matches });
 };
 
 const buildSurveyTrailDetail = (
   app: Topo,
   id: string,
-  rootDir: string
+  rootDir: string,
+  surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Result<object, Error> => {
-  const detail = buildCurrentTrailDetail(app, id, { rootDir });
+  const detail = buildCurrentTrailDetail(app, id, {
+    rootDir,
+    surfaceLayerNames,
+  });
   return detail === undefined
     ? Result.err(new NotFoundError(`Trail not found: ${id}`))
     : Result.ok(detail);
@@ -282,15 +293,16 @@ const deriveSurveyMode = (input: SurveyInput): SurveyMode =>
 type SurveyHandler = (
   app: Topo,
   input: SurveyInput,
-  rootDir: string
+  rootDir: string,
+  surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ) => Result<object, Error> | Promise<Result<object, Error>>;
 
 /** Handlers keyed by survey mode. */
 const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
-  lookup: (app, input, rootDir) =>
+  lookup: (app, input, rootDir, surfaceLayerNames) =>
     input.id === undefined || input.id === ''
       ? Result.err(new ValidationError('Survey lookup requires an id'))
-      : buildSurveyLookup(app, input.id, rootDir),
+      : buildSurveyLookup(app, input.id, rootDir, surfaceLayerNames),
   overview: (app, _input, rootDir) =>
     Result.ok(buildCurrentTopoList(app, { rootDir })),
 };
@@ -304,11 +316,12 @@ const envelopeSurveyValue = (
 const dispatchSurvey = async (
   app: Topo,
   input: SurveyInput,
-  rootDir: string
+  rootDir: string,
+  surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Promise<Result<SurveyEnvelope, Error>> => {
   const mode = deriveSurveyMode(input);
   const handler = surveyHandlers[mode];
-  const result = await handler(app, input, rootDir);
+  const result = await handler(app, input, rootDir, surfaceLayerNames);
   if (result.isErr()) {
     return result;
   }
@@ -402,7 +415,7 @@ export const surveyTrail = trail('survey', {
   args: ['id'],
   blaze: async (input, ctx) =>
     withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
-      dispatchSurvey(app, input, rootDir)
+      dispatchSurvey(app, input, rootDir, readSurfaceLayerNamesFromContext(ctx))
     ),
   description: 'Full topo introspection',
   examples: [
@@ -542,7 +555,12 @@ export const surveyTrailDetailTrail = trail('survey.trail', {
   args: ['id'],
   blaze: async (input, ctx) =>
     withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
-      buildSurveyTrailDetail(app, input.id, rootDir)
+      buildSurveyTrailDetail(
+        app,
+        input.id,
+        rootDir,
+        readSurfaceLayerNamesFromContext(ctx)
+      )
     ),
   description: 'Inspect one trail by ID',
   examples: [

--- a/apps/trails/src/trails/topo-output-schemas.ts
+++ b/apps/trails/src/trails/topo-output-schemas.ts
@@ -48,6 +48,15 @@ export const trailDetailOutput = z.object({
   activationChains: z.array(activationChainOutput).readonly(),
   activationEdges: z.array(activationEdgeOutput).readonly(),
   activationSources: z.array(activationSourceOutput).readonly(),
+  composedLayers: z.object({
+    surface: z.object({
+      cli: z.array(z.string()).readonly(),
+      http: z.array(z.string()).readonly(),
+      mcp: z.array(z.string()).readonly(),
+    }),
+    topo: z.array(z.string()).readonly(),
+    trail: z.array(z.string()).readonly(),
+  }),
   crosses: z.array(z.string()).readonly(),
   description: z.string().nullable(),
   detours: z

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -8,19 +8,21 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import type { Topo } from '@ontrails/core';
+import type { Topo, TrailContext } from '@ontrails/core';
 import {
   ConflictError,
   deriveTrailsDbPath,
   deriveTrailsDir,
   NotFoundError,
   Result,
+  SURFACE_LAYER_NAMES_KEY,
 } from '@ontrails/core';
 import { readSurfaceLockData } from '@ontrails/topographer';
 
 import type {
   BriefReport,
   SignalDetailReport,
+  SurfaceLayerNames,
   SurveyListReport,
 } from './topo-reports.js';
 import {
@@ -50,6 +52,15 @@ export interface CurrentTrailDetail {
   }[];
   readonly activationEdges: readonly ActivationEdgeReport[];
   readonly activationSources: readonly ActivationSourceReport[];
+  readonly composedLayers: {
+    readonly topo: readonly string[];
+    readonly trail: readonly string[];
+    readonly surface: {
+      readonly cli: readonly string[];
+      readonly http: readonly string[];
+      readonly mcp: readonly string[];
+    };
+  };
   readonly crosses: readonly string[];
   readonly description: string | null;
   readonly detours:
@@ -84,6 +95,29 @@ export interface CurrentTopoMatch {
   readonly kind: CurrentTopoDetail['kind'];
   readonly detail: CurrentTopoDetail;
 }
+
+export interface CurrentTopoReadOptions {
+  readonly rootDir?: string | undefined;
+  readonly surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined;
+}
+
+const isStringArray = (value: unknown): value is readonly string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+export const readSurfaceLayerNamesFromContext = (
+  ctx: TrailContext
+): Partial<SurfaceLayerNames> => {
+  const value = ctx.extensions?.[SURFACE_LAYER_NAMES_KEY];
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  const raw = value as Record<string, unknown>;
+  return {
+    ...(isStringArray(raw['cli']) ? { cli: raw['cli'] } : {}),
+    ...(isStringArray(raw['http']) ? { http: raw['http'] } : {}),
+    ...(isStringArray(raw['mcp']) ? { mcp: raw['mcp'] } : {}),
+  };
+};
 
 const hasCommittedLock = (trailsDir: string): boolean =>
   existsSync(join(trailsDir, 'trails.lock'));
@@ -139,10 +173,14 @@ export const buildCurrentGuideEntries = (
 export const buildCurrentTrailDetail = (
   app: Topo,
   id: string,
-  _options?: { readonly rootDir?: string }
+  options?: CurrentTopoReadOptions
 ): CurrentTrailDetail | undefined => {
   const trail = app.get(id);
-  return trail === undefined ? undefined : deriveTrailDetail(trail, app);
+  return trail === undefined
+    ? undefined
+    : deriveTrailDetail(trail, app, undefined, {
+        surfaceLayerNames: options?.surfaceLayerNames,
+      });
 };
 
 export const buildCurrentResourceDetail = (
@@ -163,16 +201,16 @@ export const buildCurrentSignalDetail = (
 export const buildCurrentTopoDetail = (
   app: Topo,
   id: string,
-  _options?: { readonly rootDir?: string }
+  options?: CurrentTopoReadOptions
 ): CurrentTopoDetail | undefined =>
-  buildCurrentTrailDetail(app, id) ??
+  buildCurrentTrailDetail(app, id, options) ??
   buildCurrentResourceDetail(app, id) ??
   buildCurrentSignalDetail(app, id);
 
 export const buildCurrentTopoMatches = (
   app: Topo,
   id: string,
-  _options?: { readonly rootDir?: string }
+  options?: CurrentTopoReadOptions
 ): readonly CurrentTopoMatch[] => {
   const matches: CurrentTopoMatch[] = [];
   let activationGraph: ActivationGraphReport | undefined;
@@ -182,7 +220,9 @@ export const buildCurrentTopoMatches = (
   const trail = app.get(id);
   if (trail !== undefined) {
     matches.push({
-      detail: deriveTrailDetail(trail, app, getActivationGraph()),
+      detail: deriveTrailDetail(trail, app, getActivationGraph(), {
+        surfaceLayerNames: options?.surfaceLayerNames,
+      }),
       kind: 'trail',
     });
   }

--- a/apps/trails/src/trails/topo-reports.ts
+++ b/apps/trails/src/trails/topo-reports.ts
@@ -51,6 +51,16 @@ export type BriefReport = Readonly<
   }
 >;
 
+export type SurfaceLayerKey = 'cli' | 'http' | 'mcp';
+
+export type SurfaceLayerNames = Readonly<
+  Record<SurfaceLayerKey, readonly string[]>
+>;
+
+export interface TrailDetailOptions {
+  readonly surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined;
+}
+
 export interface SurveyListReport {
   readonly activation: ActivationOverviewReport;
   readonly count: number;
@@ -90,6 +100,19 @@ export interface TrailDetailReport {
   readonly activationChains: readonly ActivationChainReport[];
   readonly activationEdges: readonly ActivationEdgeReport[];
   readonly activationSources: readonly ActivationSourceReport[];
+  /**
+   * Composed layer names visible at the survey boundary.
+   *
+   * Reports the names of typed layers that wrap this trail at execution time,
+   * in the framework's composition order: `topo → surface → trail`
+   * (outermost-first). Surface-scope layers are keyed by surface because
+   * each surface owns its own attachment set.
+   */
+  readonly composedLayers: {
+    readonly topo: readonly string[];
+    readonly surface: SurfaceLayerNames;
+    readonly trail: readonly string[];
+  };
   readonly description: string | null;
   readonly detours:
     | readonly { readonly on: string; readonly maxAttempts: number }[]
@@ -334,10 +357,31 @@ export const deriveSignalDetail = (
   };
 };
 
+const emptySurfaceLayerNames = (): SurfaceLayerNames => ({
+  cli: [],
+  http: [],
+  mcp: [],
+});
+
+const normalizeSurfaceLayerNames = (
+  names?: Partial<SurfaceLayerNames> | undefined
+): SurfaceLayerNames => {
+  const base = emptySurfaceLayerNames();
+  if (names === undefined) {
+    return base;
+  }
+  return {
+    cli: names.cli ?? base.cli,
+    http: names.http ?? base.http,
+    mcp: names.mcp ?? base.mcp,
+  };
+};
+
 export const deriveTrailDetail = (
   item: AnyTrail,
   app?: Topo | undefined,
-  activationGraph?: ActivationGraphReport | undefined
+  activationGraph?: ActivationGraphReport | undefined,
+  options: TrailDetailOptions = {}
 ): TrailDetailReport => {
   const activation =
     app === undefined
@@ -348,12 +392,20 @@ export const deriveTrailDetail = (
     item as unknown as { intent?: 'read' | 'write' | 'destroy' }
   );
 
+  const trailLayerNames = item.layers.map((layer) => layer.name);
+  const topoLayerNames = (app?.layers ?? []).map((layer) => layer.name);
+
   return {
     activatedBy: activation.activatedBy,
     activates: activation.activates,
     activationChains: activation.chains,
     activationEdges: activation.edges,
     activationSources: activation.sources,
+    composedLayers: {
+      surface: normalizeSurfaceLayerNames(options.surfaceLayerNames),
+      topo: topoLayerNames,
+      trail: trailLayerNames,
+    },
     crosses: item.crosses.toSorted(),
     description: item.description ?? null,
     detours:

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -338,6 +338,70 @@ describe('buildCommands execution', () => {
     ]);
   });
 
+  test('composes topo, surface, and trail layers in C → B → A → blaze order', async () => {
+    const order: string[] = [];
+
+    const trailLayer = {
+      name: 'A',
+      wrap:
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- declarative shape
+        (_t: unknown, impl: (i: unknown, c: unknown) => Promise<unknown>) =>
+          async (i: unknown, c: unknown) => {
+            order.push('A:before');
+            const r = (await impl(i, c)) as { isOk: () => boolean };
+            order.push('A:after');
+            return r as never;
+          },
+    } as never;
+
+    const surfaceLayer = {
+      name: 'B',
+      wrap:
+        (_t: unknown, impl: (i: unknown, c: unknown) => Promise<unknown>) =>
+        async (i: unknown, c: unknown) => {
+          order.push('B:before');
+          const r = await impl(i, c);
+          order.push('B:after');
+          return r as never;
+        },
+    } as never;
+
+    const topoLayer = {
+      name: 'C',
+      wrap:
+        (_t: unknown, impl: (i: unknown, c: unknown) => Promise<unknown>) =>
+        async (i: unknown, c: unknown) => {
+          order.push('C:before');
+          const r = await impl(i, c);
+          order.push('C:after');
+          return r as never;
+        },
+    } as never;
+
+    const t = trail('layered.scopes', {
+      blaze: (input: { x: string }) => {
+        order.push('impl');
+        return Result.ok(input.x);
+      },
+      input: z.object({ x: z.string() }),
+      layers: [trailLayer],
+    });
+    const app = topo('test-app', { [t.id]: t }, { layers: [topoLayer] });
+    const commands = buildCommands(app, { layers: [surfaceLayer] });
+
+    await commands[0]?.execute({}, { x: 'test' });
+
+    expect(order).toEqual([
+      'C:before',
+      'B:before',
+      'A:before',
+      'impl',
+      'A:after',
+      'B:after',
+      'C:after',
+    ]);
+  });
+
   test('uses provided createContext factory', async () => {
     let usedRequestId: string | undefined;
     let usedCustom = false;

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -21,7 +21,7 @@ import {
   executeTrail,
   filterSurfaceTrails,
   validateSurfaceTopo,
-  withSurfaceMarker,
+  withSurfaceLayerNames,
 } from '@ontrails/core';
 
 import type { AnyTrail, CliArg, CliCommand, CliFlag } from './command.js';
@@ -466,12 +466,13 @@ const runTrailOnce = async (
   await executeTrail(t, input, {
     configValues: options?.configValues,
     createContext: options?.createContext,
-    ctx: withSurfaceMarker('cli', ctxOverrides),
+    ctx: withSurfaceLayerNames('cli', options?.layers ?? [], ctxOverrides),
     dryRun,
-    layers: options?.layers,
     ...(permit === undefined ? {} : { permit }),
     resources: options?.resources,
+    surfaceLayers: options?.layers,
     topo: graph,
+    topoLayers: graph.layers,
   });
 
 /**

--- a/packages/core/src/__tests__/layer-scopes.test.ts
+++ b/packages/core/src/__tests__/layer-scopes.test.ts
@@ -1,0 +1,174 @@
+/**
+ * TRL-472: Three attachment scopes for typed layers — trail, surface, topo.
+ *
+ * Verifies that layers attach declaratively at each scope and compose at
+ * execute time in the order topo → surface → trail → blaze (outermost-first).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { executeTrail } from '../execute';
+import type { Layer } from '../layer';
+import { Result } from '../result';
+import { topo } from '../topo';
+import { trail } from '../trail';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const recordingLayer = (label: string, log: string[]): Layer => ({
+  name: label,
+  wrap(_t, impl) {
+    return async (input, ctx) => {
+      log.push(`${label}:before`);
+      const result = await impl(input, ctx);
+      log.push(`${label}:after`);
+      return result;
+    };
+  },
+});
+
+const buildEchoTrail = (extra: { readonly layers?: readonly Layer[] } = {}) =>
+  trail('echo', {
+    blaze: (input) => Result.ok({ value: input.value }),
+    input: z.object({ value: z.string() }),
+    output: z.object({ value: z.string() }),
+    ...(extra.layers === undefined ? {} : { layers: extra.layers }),
+  });
+
+// ---------------------------------------------------------------------------
+// Trail-level attachment
+// ---------------------------------------------------------------------------
+
+describe('trail-level layers', () => {
+  test('a trail with `layers` runs through those layers', async () => {
+    const log: string[] = [];
+    const layerA = recordingLayer('A', log);
+    const echo = buildEchoTrail({ layers: [layerA] });
+
+    const result = await executeTrail(echo, { value: 'hello' });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ value: 'hello' });
+    expect(log).toEqual(['A:before', 'A:after']);
+  });
+
+  test('trail.layers is normalized to a frozen array (default [])', () => {
+    const echo = buildEchoTrail();
+    expect(Array.isArray(echo.layers)).toBe(true);
+    expect(echo.layers.length).toBe(0);
+    expect(Object.isFrozen(echo.layers)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Surface-level attachment
+// ---------------------------------------------------------------------------
+
+describe('surface-level layers', () => {
+  test('surfaceLayers wrap the trail implementation', async () => {
+    const log: string[] = [];
+    const layerB = recordingLayer('B', log);
+    const echo = buildEchoTrail();
+
+    const result = await executeTrail(
+      echo,
+      { value: 'hi' },
+      { surfaceLayers: [layerB] }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(log).toEqual(['B:before', 'B:after']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Topo-level attachment
+// ---------------------------------------------------------------------------
+
+describe('topo-level layers', () => {
+  test('topo.layers is exposed via topo() third argument', () => {
+    const log: string[] = [];
+    const layerC = recordingLayer('C', log);
+    const echo = buildEchoTrail();
+    const app = topo('app', { echo }, { layers: [layerC] });
+
+    expect(app.layers.length).toBe(1);
+    expect(app.layers[0]?.name).toBe('C');
+  });
+
+  test('topo.layers default to [] when no options are passed', () => {
+    const echo = buildEchoTrail();
+    const app = topo('app', { echo });
+    expect(app.layers).toEqual([]);
+  });
+
+  test('topoLayers wrap the trail implementation', async () => {
+    const log: string[] = [];
+    const layerC = recordingLayer('C', log);
+    const echo = buildEchoTrail();
+    const app = topo('app', { echo }, { layers: [layerC] });
+
+    const result = await executeTrail(
+      echo,
+      { value: 'hi' },
+      { topo: app, topoLayers: app.layers }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(log).toEqual(['C:before', 'C:after']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composition order — topo outermost → trail innermost
+// ---------------------------------------------------------------------------
+
+describe('layer composition order', () => {
+  test('runs C → B → A → blaze when topo, surface, and trail layers all present', async () => {
+    const log: string[] = [];
+    const layerA = recordingLayer('A', log);
+    const layerB = recordingLayer('B', log);
+    const layerC = recordingLayer('C', log);
+
+    const echo = buildEchoTrail({ layers: [layerA] });
+    const app = topo('app', { echo }, { layers: [layerC] });
+
+    const result = await executeTrail(
+      echo,
+      { value: 'go' },
+      {
+        surfaceLayers: [layerB],
+        topo: app,
+        topoLayers: app.layers,
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(log).toEqual([
+      'C:before',
+      'B:before',
+      'A:before',
+      'A:after',
+      'B:after',
+      'C:after',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `topo.options` brand still accepts layers
+// ---------------------------------------------------------------------------
+
+describe('topo.options branding', () => {
+  test('layers can travel through topo.options() without ambiguity', () => {
+    const log: string[] = [];
+    const layerC = recordingLayer('C', log);
+    const echo = buildEchoTrail();
+    const app = topo('app', { echo }, topo.options({ layers: [layerC] }));
+
+    expect(app.layers.length).toBe(1);
+  });
+});

--- a/packages/core/src/__tests__/surface-derivation.test.ts
+++ b/packages/core/src/__tests__/surface-derivation.test.ts
@@ -6,11 +6,12 @@ import { Result } from '../result.js';
 import {
   shouldValidateSurfaceTopo,
   validateSurfaceTopo,
+  withSurfaceLayerNames,
   withSurfaceMarker,
 } from '../surface-derivation.js';
 import { topo } from '../topo.js';
 import { trail } from '../trail.js';
-import { SURFACE_KEY } from '../types.js';
+import { SURFACE_KEY, SURFACE_LAYER_NAMES_KEY } from '../types.js';
 
 const exportTrail = trail('entity.export', {
   blaze: () => Result.ok({ ok: true }),
@@ -45,6 +46,28 @@ describe('surface derivation helpers', () => {
     expect(marked.requestId).toBe('req-1');
     expect(marked.extensions).toEqual({
       [SURFACE_KEY]: 'cli',
+      existing: true,
+    });
+  });
+
+  test('surface layer marker records layer names by invoking surface', () => {
+    const marked = withSurfaceLayerNames(
+      'mcp',
+      [
+        { name: 'auth', wrap: (_trail, impl) => impl },
+        { name: 'audit', wrap: (_trail, impl) => impl },
+      ],
+      {
+        extensions: {
+          [SURFACE_LAYER_NAMES_KEY]: { cli: ['quiet'] },
+          existing: true,
+        },
+      }
+    );
+
+    expect(marked.extensions).toEqual({
+      [SURFACE_KEY]: 'mcp',
+      [SURFACE_LAYER_NAMES_KEY]: { cli: ['quiet'], mcp: ['auth', 'audit'] },
       existing: true,
     });
   });

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -94,6 +94,22 @@ export interface ExecuteTrailOptions {
    * rate limiting, circuit breaking, or custom audit logging.
    */
   readonly layers?: readonly Layer[] | undefined;
+  /**
+   * Typed layers attached at surface scope.
+   *
+   * Surfaces (CLI, MCP, HTTP) forward their `layers` option here so they
+   * compose around every trail dispatched through that surface. The final
+   * composition order is `topo → surface → trail → blaze` (outermost-first).
+   */
+  readonly surfaceLayers?: readonly Layer[] | undefined;
+  /**
+   * Typed layers attached at topo scope.
+   *
+   * The CLI/MCP/HTTP surfaces typically forward `topo.layers` here so the
+   * topo's declared layers wrap every trail invocation. The final
+   * composition order is `topo → surface → trail → blaze` (outermost-first).
+   */
+  readonly topoLayers?: readonly Layer[] | undefined;
   /** Factory that produces a base TrailContext (takes precedence over defaults). */
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
@@ -1179,6 +1195,24 @@ const runTrail = async (
 // ---------------------------------------------------------------------------
 
 /**
+ * Compose the typed layers attached at topo, surface, and trail scope.
+ *
+ * Composition order is topo → surface → trail → execution-supplied → blaze
+ * (outermost-first): trail-scope layers run inside surface/topo layers, and
+ * `executeTrail({ layers })` layers wrap closest to the blaze for per-call
+ * behavior.
+ */
+const composeAttachedLayers = (
+  trail: AnyTrail,
+  options: ExecuteTrailOptions | undefined
+): readonly Layer[] => [
+  ...(options?.topoLayers ?? []),
+  ...(options?.surfaceLayers ?? []),
+  ...trail.layers,
+  ...(options?.layers ?? []),
+];
+
+/**
  * Execute a trail through the standard validate-context-layers-run pipeline.
  *
  * The function never throws -- unexpected exceptions are caught and
@@ -1208,7 +1242,7 @@ export const executeTrail = async (
         trail,
         validated.value,
         resolvedCtx.value.ctx,
-        options?.layers ?? [],
+        composeAttachedLayers(trail, options),
         options?.topo,
         options
       );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,7 +80,7 @@ export type {
 } from './types.js';
 export { basePermitSchema } from './permits.js';
 export type { BasePermit } from './permits.js';
-export { SURFACE_KEY } from './types.js';
+export { SURFACE_KEY, SURFACE_LAYER_NAMES_KEY } from './types.js';
 export {
   ACTIVATION_PROVENANCE_KEY,
   buildActivationProvenanceTraceAttrs,
@@ -160,6 +160,7 @@ export type { SurfaceFilterOptions } from './surface-filter.js';
 export {
   shouldValidateSurfaceTopo,
   validateSurfaceTopo,
+  withSurfaceLayerNames,
   withSurfaceMarker,
 } from './surface-derivation.js';
 export type {

--- a/packages/core/src/observe.ts
+++ b/packages/core/src/observe.ts
@@ -1,5 +1,6 @@
 import { ValidationError } from './errors.js';
 import type { TraceSink } from './internal/tracing.js';
+import type { Layer } from './layer.js';
 import { safeStringify } from './serialization.js';
 import type { Logger, LogLevel, LogRecord, LogSink } from './types.js';
 
@@ -21,6 +22,15 @@ export type ObserveInput = Logger | LogSink | TraceSink | ObserveConfig;
 
 export interface TopoOptions {
   readonly observe?: ObserveInput | undefined;
+  /**
+   * Typed layers attached at topo scope.
+   *
+   * Layers declared here wrap every trail invoked through this topo, on every
+   * surface. The execution pipeline composes topo-scope layers outermost —
+   * around surface-scope and trail-scope layers — so the final order is
+   * `topo → surface → trail → blaze` (outermost-first).
+   */
+  readonly layers?: readonly Layer[] | undefined;
 }
 
 const OBSERVE_CONFIG_KEYS = new Set(['log', 'trace']);

--- a/packages/core/src/surface-derivation.ts
+++ b/packages/core/src/surface-derivation.ts
@@ -1,9 +1,10 @@
 import { Result } from './result.js';
+import type { Layer } from './layer.js';
 import type { Intent } from './trail.js';
 import type { Topo } from './topo.js';
 import type { SurfaceName } from './transport-error-map.js';
 import type { TrailContextInit } from './types.js';
-import { SURFACE_KEY } from './types.js';
+import { SURFACE_KEY, SURFACE_LAYER_NAMES_KEY } from './types.js';
 import { validateEstablishedTopo } from './validate-established-topo.js';
 
 export type SurfaceConfigValues = Readonly<
@@ -60,3 +61,31 @@ export const withSurfaceMarker = (
     [SURFACE_KEY]: surface,
   },
 });
+
+const readSurfaceLayerNameRecord = (
+  value: unknown
+): Record<string, readonly string[]> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, readonly string[]>)
+    : {};
+
+export const withSurfaceLayerNames = (
+  surface: SurfaceName,
+  layers: readonly Layer[],
+  ctx: Partial<TrailContextInit> = {}
+): SurfaceMarkedContext => {
+  const existing = readSurfaceLayerNameRecord(
+    ctx.extensions?.[SURFACE_LAYER_NAMES_KEY]
+  );
+  return {
+    ...ctx,
+    extensions: {
+      ...ctx.extensions,
+      [SURFACE_KEY]: surface,
+      [SURFACE_LAYER_NAMES_KEY]: {
+        ...existing,
+        [surface]: layers.map((layer) => layer.name),
+      },
+    },
+  };
+};

--- a/packages/core/src/topo.ts
+++ b/packages/core/src/topo.ts
@@ -9,6 +9,7 @@ import {
   getLateBoundSignalRef,
   parseLateBoundSignalMarker,
 } from './internal/signal-ref.js';
+import type { Layer } from './layer.js';
 import {
   hasObserveCapabilities,
   isLogger,
@@ -43,6 +44,15 @@ export interface Topo {
   readonly signals: ReadonlyMap<string, AnySignal>;
   readonly resources: ReadonlyMap<string, AnyResource>;
   readonly observe?: ObserveConfig | undefined;
+  /**
+   * Typed layers attached at topo scope (always present, default `[]`).
+   *
+   * The CLI/MCP/HTTP surfaces forward these into `executeTrail` as
+   * `topoLayers`, where they are composed outermost in the layer chain.
+   * The final composition order is `topo → surface → trail → blaze`
+   * (outermost-first).
+   */
+  readonly layers: readonly Layer[];
   readonly count: number;
   readonly contourCount: number;
   readonly resourceCount: number;
@@ -85,7 +95,8 @@ const createTopo = (
   trails: ReadonlyMap<string, AnyTrail>,
   signals: ReadonlyMap<string, AnySignal>,
   resources: ReadonlyMap<string, AnyResource>,
-  observe: ObserveConfig | undefined
+  observe: ObserveConfig | undefined,
+  layers: readonly Layer[]
 ): Topo => ({
   contourCount: contours.size,
   contourIds(): string[] {
@@ -135,6 +146,7 @@ const createTopo = (
     description: identity.description,
   }),
   ...(observe !== undefined && { observe }),
+  layers,
   resourceCount: resources.size,
   resourceIds(): string[] {
     return [...resources.keys()];
@@ -483,7 +495,7 @@ const registerModuleValues = (
   }
 };
 
-const TOPO_OPTION_KEYS = ['observe'] as const;
+const TOPO_OPTION_KEYS = ['layers', 'observe'] as const;
 const TOPO_OPTION_KEY_SET: ReadonlySet<string> = new Set(TOPO_OPTION_KEYS);
 
 /**
@@ -630,6 +642,18 @@ const classifyTrailingArgument = (
   // helper that should be treated as a (silently ignored) module
   // export.
   const observeValue = (value as TopoOptions).observe;
+  const layersValue = (value as TopoOptions).layers;
+
+  // A module export named `layers` would be a non-registrable array, but
+  // an explicit `topo.options({ layers: [...] })` is the documented escape
+  // hatch for that disambiguation. Without the brand, accept the trailing
+  // argument as options when `layers` is an array and `observe` is either
+  // unset or already an unambiguous option shape — this mirrors how
+  // `observe`-only options are accepted today.
+  if (Array.isArray(layersValue) && observeValue === undefined) {
+    return { kind: 'options', options: value as TopoOptions };
+  }
+
   if (hasRegistrableKind(observeValue)) {
     return { kind: 'module' };
   }
@@ -784,6 +808,7 @@ const topoImpl = (
       : nameOrIdentity;
   const { modules, options } = splitTopoArguments(modulesOrOptions);
   const observe = normalizeObserve(options?.observe);
+  const layers = Object.freeze([...(options?.layers ?? [])]);
 
   const contours = new Map<string, AnyContour>();
   const trails = new Map<string, AnyTrail>();
@@ -800,7 +825,8 @@ const topoImpl = (
     finalizeTrailSignals(trails, resources),
     signals,
     resources,
-    observe
+    observe,
+    layers
   );
 };
 

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -12,6 +12,7 @@ import {
 } from './activation-source.js';
 import type { AnyContour } from './contour.js';
 import type { FieldOverride } from './derive.js';
+import type { Layer } from './layer.js';
 import type { Result } from './result.js';
 import type { AnyResource } from './resource.js';
 import type { AnySignal } from './signal.js';
@@ -110,12 +111,25 @@ export interface TrailSpec<I, O, CI = never> {
    * `TrailContext.dryRun`.
    */
   readonly dryRun?: boolean | undefined;
-  /** Whether trailheads expose this trail by default. */
+  /** Whether surfaces expose this trail by default. */
   readonly visibility?: TrailVisibility | undefined;
   /** Arbitrary meta for tooling and filtering */
   readonly meta?: Readonly<Record<string, unknown>> | undefined;
   /** Recovery paths activated when blaze fails with a matching error class. */
   readonly detours?: readonly Detour<I, O, TrailsError>[] | undefined;
+  /**
+   * Typed layers attached at trail scope.
+   *
+   * Layers declared here wrap this trail's implementation on every execution,
+   * regardless of which surface invokes it. The execution pipeline composes
+   * trail-scope layers innermost — closer to the blaze than surface-scope
+   * or topo-scope layers — so the final order is
+   * `topo → surface → trail → blaze` (outermost-first).
+   *
+   * Layers are typed and inspectable. Omit `input` for surface-invisible
+   * wrappers that do not project any fields.
+   */
+  readonly layers?: readonly Layer[] | undefined;
   /** Per-field overrides for deriveFields() (labels, hints, options) */
   readonly fields?: Readonly<Record<string, FieldOverride>> | undefined;
   /** Contours this trail operates on. */
@@ -124,7 +138,7 @@ export interface TrailSpec<I, O, CI = never> {
   readonly crosses?: readonly (string | AnyTrail)[] | undefined;
   /**
    * Composition-only input schema — merged with `input` for `ctx.cross()` calls,
-   * invisible to public trailheads (CLI, MCP, HTTP).
+   * invisible to public surfaces (CLI, MCP, HTTP).
    *
    * Fields here are available in the blaze but are not derived into CLI flags,
    * MCP tool parameters, or HTTP request bodies. Use for data that only makes
@@ -172,7 +186,7 @@ export const intentValues = Object.freeze([
 
 export type Intent = (typeof intentValues)[number];
 
-/** Whether trailheads expose a trail by default. */
+/** Whether surfaces expose a trail by default. */
 export type TrailVisibility = 'public' | 'internal';
 
 /** A fully-defined trail — the unit of work in the Trails system */
@@ -186,6 +200,7 @@ export interface Trail<I, O, CI = never> extends Omit<
   | 'detours'
   | 'fires'
   | 'intent'
+  | 'layers'
   | 'on'
   | 'resources'
 > {
@@ -200,6 +215,13 @@ export interface Trail<I, O, CI = never> extends Omit<
   readonly crossInput?: z.ZodType<CI> | undefined;
   /** Recovery paths activated when blaze fails with a matching error (always present, default []). */
   readonly detours: readonly Detour<I, O, TrailsError>[];
+  /**
+   * Typed layers attached at trail scope (always present, default []).
+   *
+   * Composed innermost in the layer chain — closest to the blaze. The final
+   * composition order is `topo → surface → trail → blaze` (outermost-first).
+   */
+  readonly layers: readonly Layer[];
   /** Resources this trail may access via resource.from(ctx) (always present, default []) */
   readonly resources: readonly AnyResource[];
   /** IDs of signals this trail fires via ctx.fire() (always present, default []) */
@@ -213,7 +235,7 @@ export interface Trail<I, O, CI = never> extends Omit<
   readonly activationSources: readonly ActivationEntry[];
   /** What this trail does to the world (always present, default 'write') */
   readonly intent: Intent;
-  /** Whether trailheads expose this trail by default (always present, default 'public'). */
+  /** Whether surfaces expose this trail by default (always present, default 'public'). */
   readonly visibility: TrailVisibility;
   /** Primary input fields and their order (always present, default undefined) */
   readonly args?: readonly string[] | false | undefined;
@@ -349,6 +371,7 @@ const normalizeCollections = <I, O, CI>(
   readonly contours: readonly AnyContour[];
   readonly detours: readonly Detour<I, O, TrailsError>[];
   readonly fires: readonly string[];
+  readonly layers: readonly Layer[];
   readonly on: readonly string[];
   readonly resources: readonly AnyResource[];
 } => {
@@ -359,6 +382,7 @@ const normalizeCollections = <I, O, CI>(
     contours: Object.freeze([...(spec.contours ?? [])]),
     detours: Object.freeze([...(spec.detours ?? [])]),
     fires: Object.freeze((spec.fires ?? []).map(normalizeSignalRef)),
+    layers: Object.freeze([...(spec.layers ?? [])]),
     on: extractSignalActivationIds(activationSources),
     resources: Object.freeze([...(spec.resources ?? [])]),
   };
@@ -417,6 +441,7 @@ export function trail<I, O, CI = never>(
     contours: _c,
     detours: _d,
     fires: _f,
+    layers: _l,
     on: _o,
     resources: _r,
     ...spec

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -190,6 +190,11 @@ export interface LogFormatter {
  */
 export const SURFACE_KEY = '__trails_surface' as const;
 
+/**
+ * Context extension key for the layer names attached by the invoking surface.
+ */
+export const SURFACE_LAYER_NAMES_KEY = '__trails_surface_layer_names' as const;
+
 /** Runtime context threaded through every trail execution */
 export interface TrailContext {
   readonly activation?: ActivationProvenance | undefined;

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -1302,6 +1302,54 @@ describe('deriveHttpRoutes', () => {
       expect(result?.isOk()).toBe(true);
       expect(calls).toEqual(['before', 'after']);
     });
+
+    test('topo, surface, and trail layers compose in documented order', async () => {
+      const calls: string[] = [];
+      const makeLayer = (name: string): Layer => ({
+        name,
+        wrap(_trail, impl) {
+          return async (input, ctx) => {
+            calls.push(`${name}:before`);
+            const result = await impl(input, ctx);
+            calls.push(`${name}:after`);
+            return result;
+          };
+        },
+      });
+
+      const trailLayer = makeLayer('trail');
+      const surfaceLayer = makeLayer('surface');
+      const topoLayer = makeLayer('topo');
+      const layeredTrail = trail('layered.echo', {
+        blaze: (input) => {
+          calls.push('blaze');
+          return Result.ok({ reply: input.message });
+        },
+        input: z.object({ message: z.string() }),
+        layers: [trailLayer],
+        output: z.object({ reply: z.string() }),
+      });
+      const app = topo('testapp', { layeredTrail }, { layers: [topoLayer] });
+      const buildResult = deriveHttpRoutes(app, { layers: [surfaceLayer] });
+
+      expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
+      const [route] = buildResult.value;
+
+      const result = await route?.execute({ message: 'hi' });
+      expect(result?.isOk()).toBe(true);
+      expect(calls).toEqual([
+        'topo:before',
+        'surface:before',
+        'trail:before',
+        'blaze',
+        'trail:after',
+        'surface:after',
+        'topo:after',
+      ]);
+    });
   });
 
   describe('custom createContext', () => {

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -23,7 +23,7 @@ import {
   verifyWebhookRequest,
   writeActivationTraceRecord,
   withActivationProvenance,
-  withSurfaceMarker,
+  withSurfaceLayerNames,
 } from '@ontrails/core';
 import type {
   ActivationEntry,
@@ -108,9 +108,14 @@ const derivePath = (basePath: string, trailId: string): string => {
 
 /** Build per-request context overrides with the HTTP trailhead marker. */
 const withHttpTrailhead = (
-  requestId: string | undefined
+  requestId: string | undefined,
+  layers: readonly Layer[]
 ): Partial<TrailContextInit> =>
-  withSurfaceMarker('http', requestId === undefined ? {} : { requestId });
+  withSurfaceLayerNames(
+    'http',
+    layers,
+    requestId === undefined ? {} : { requestId }
+  );
 
 const createWebhookActivationFireId = (): string => {
   const randomUUID = globalThis.crypto?.randomUUID;
@@ -213,10 +218,11 @@ const createWebhookInvalidPublicRecorder =
 const withWebhookActivation = (
   activation: ActivationProvenance,
   requestId: string | undefined,
-  traceContext: TraceContext | undefined
+  traceContext: TraceContext | undefined,
+  layers: readonly Layer[]
 ): Partial<TrailContextInit> => {
   const ctx = withActivationProvenance(
-    withHttpTrailhead(requestId),
+    withHttpTrailhead(requestId, layers),
     activation
   );
   return traceContext === undefined
@@ -252,10 +258,11 @@ const createExecute =
       abortSignal,
       configValues: options.configValues,
       createContext: options.createContext,
-      ctx: withHttpTrailhead(requestId),
-      layers,
+      ctx: withHttpTrailhead(requestId, layers),
       resources: options.resources,
+      surfaceLayers: layers,
       topo: graph,
+      topoLayers: graph.layers,
     });
 
 /**
@@ -314,10 +321,11 @@ const createWebhookConsumerExecute =
       abortSignal,
       configValues: options.configValues,
       createContext: options.createContext,
-      ctx: withWebhookActivation(activation, requestId, traceContext),
-      layers,
+      ctx: withWebhookActivation(activation, requestId, traceContext, layers),
       resources: options.resources,
+      surfaceLayers: layers,
       topo: graph,
+      topoLayers: graph.layers,
     });
   };
 

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -573,6 +573,48 @@ describe('deriveMcpTools', () => {
       expect(calls).toEqual(['before', 'after']);
     });
 
+    test('topo, surface, and trail layers compose in documented order', async () => {
+      const calls: string[] = [];
+      const makeLayer = (name: string): Layer => ({
+        name,
+        wrap(_trail, impl) {
+          return async (input, ctx) => {
+            calls.push(`${name}:before`);
+            const result = await impl(input, ctx);
+            calls.push(`${name}:after`);
+            return result;
+          };
+        },
+      });
+
+      const trailLayer = makeLayer('trail');
+      const surfaceLayer = makeLayer('surface');
+      const topoLayer = makeLayer('topo');
+      const layeredTrail = trail('layered.echo', {
+        blaze: (input) => {
+          calls.push('blaze');
+          return Result.ok({ reply: input.message });
+        },
+        input: z.object({ message: z.string() }),
+        layers: [trailLayer],
+        output: z.object({ reply: z.string() }),
+      });
+      const app = topo('myapp', { layeredTrail }, { layers: [topoLayer] });
+      const tool = requireOnlyTool(buildTools(app, { layers: [surfaceLayer] }));
+
+      await tool.handler({ message: 'hi' }, noExtra);
+
+      expect(calls).toEqual([
+        'topo:before',
+        'surface:before',
+        'trail:before',
+        'blaze',
+        'trail:after',
+        'surface:after',
+        'topo:after',
+      ]);
+    });
+
     test('AbortSignal propagates from MCP extra to TrailContext', async () => {
       let capturedSignal: AbortSignal | undefined;
 

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -17,7 +17,7 @@ import {
   projectSurfaceError,
   toBlobRefDescriptor,
   validateSurfaceTopo,
-  withSurfaceMarker,
+  withSurfaceLayerNames,
   zodToJsonSchema,
 } from '@ontrails/core';
 import type {
@@ -438,10 +438,12 @@ const mcpError = (error: Error): McpToolResult => {
 
 /** Add the MCP trailhead marker while preserving any existing context extras. */
 const withMcpTrailhead = (
-  progressCb: TrailContextInit['progress']
+  progressCb: TrailContextInit['progress'],
+  layers: readonly Layer[]
 ): Partial<TrailContextInit> =>
-  withSurfaceMarker(
+  withSurfaceLayerNames(
     'mcp',
+    layers,
     progressCb === undefined ? {} : { progress: progressCb }
   );
 
@@ -462,10 +464,11 @@ const createHandler =
       abortSignal: extra.abortSignal,
       configValues: options.configValues,
       createContext: options.createContext,
-      ctx: withMcpTrailhead(progressCb),
-      layers,
+      ctx: withMcpTrailhead(progressCb, layers),
       resources: options.resources,
+      surfaceLayers: layers,
       topo: graph,
+      topoLayers: graph.layers,
     });
     if (result.isOk()) {
       return {


### PR DESCRIPTION
## Summary
- Adds three typed-layer attachment scopes: topo, surface, and trail.
- Composes attached layers in the documented outermost-to-innermost order: topo -> surface -> trail -> per-call layers -> blaze.
- Exposes composed layer names in Trails topo reports, including surface-scope layer names that only the surface can know.

## Details
`TopoOptions.layers`, `Topo.layers`, `TrailSpec.layers`, `Trail.layers`, `ExecuteTrailOptions.topoLayers`, and `ExecuteTrailOptions.surfaceLayers` make attachment scope explicit. The CLI forwards topo and surface layers through execution, and report schemas gain `composedLayers: { topo, surface, trail }`. Existing call sites stay compatible because all new fields are optional/defaulted.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-472.