### PR TITLE
feat(core,cli): project typed layer input onto CLI flags

### DIFF
--- a/.changeset/trl-473-layer-input-cli-projection.md
+++ b/.changeset/trl-473-layer-input-cli-projection.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/core': minor
+'@ontrails/cli': minor
+---
+
+Project typed-layer `input` schemas onto CLI flags. Each effective layer (topo + surface + trail composition order) with a non-undefined `input` schema gets its fields auto-derived into `--flag` options on every command it attaches to. Parsed values route to the layer at runtime via `ctx.extensions[LAYER_INPUTS_KEY][layer.name]` — `Layer.wrap` is unchanged. Collision rule: if a layer field name collides with a trail input field, another layer's projected name, or a CLI meta flag, the layer's flag is renamed to `--<layer-name>-<original-flag-name>` and a one-line warning emits to stderr (`[trails] ...`). Renames are deterministic across builds. New `LAYER_INPUTS_KEY` (exported from `@ontrails/core`) reserves the `ctx.extensions` slot.

--- a/packages/cli/src/__tests__/layer-input-projection.test.ts
+++ b/packages/cli/src/__tests__/layer-input-projection.test.ts
@@ -1,0 +1,429 @@
+/**
+ * TRL-473: Project typed layer input onto the CLI surface.
+ *
+ * When a layer attached at trail/surface/topo scope declares an `input`
+ * schema, the CLI command derives flags from that schema, parses values from
+ * argv, and routes them into the layer's runtime input via
+ * `ctx.extensions[LAYER_INPUTS_KEY][layer.name]`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import {
+  LAYER_FIELD_RESERVED_NAMES,
+  LAYER_INPUTS_KEY,
+  Result,
+  topo,
+  trail,
+} from '@ontrails/core';
+import type { Implementation, Layer } from '@ontrails/core';
+import { z } from 'zod';
+
+import { deriveCliCommands } from '../build.js';
+import type { CliCommand } from '../command.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const buildCommands = (...args: Parameters<typeof deriveCliCommands>) => {
+  const result = deriveCliCommands(...args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const requireCommand = (commands: CliCommand[]): CliCommand => {
+  const [command] = commands;
+  expect(command).toBeDefined();
+  if (!command) {
+    throw new Error('Expected command');
+  }
+  return command;
+};
+
+interface InputBucket {
+  value: unknown;
+}
+
+const captureLayerInput = (
+  layerName: string,
+  schema: z.ZodType<unknown>,
+  bucket: InputBucket
+): Layer => ({
+  input: schema,
+  name: layerName,
+  wrap<I, O>(_t, impl: Implementation<I, O>): Implementation<I, O> {
+    return async (input, ctx) => {
+      const all = ctx.extensions?.[LAYER_INPUTS_KEY] as
+        | Record<string, unknown>
+        | undefined;
+      bucket.value = all?.[layerName];
+      return await impl(input, ctx);
+    };
+  },
+});
+
+const makeEchoTrail = (
+  overrides: { readonly layers?: readonly Layer[] } = {}
+) =>
+  trail('echo', {
+    blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+    input: z.object({ value: z.string() }),
+    output: z.object({ value: z.string() }),
+    ...(overrides.layers === undefined ? {} : { layers: overrides.layers }),
+  });
+
+const withMutedStderr = <T>(fn: () => T): { result: T; stderr: string } => {
+  const chunks: string[] = [];
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  type WriteFn = typeof process.stderr.write;
+  const stub: WriteFn = ((chunk: unknown) => {
+    chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  }) as WriteFn;
+  process.stderr.write = stub;
+  try {
+    const result = fn();
+    return { result, stderr: chunks.join('') };
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Flag projection
+// ---------------------------------------------------------------------------
+
+describe('TRL-473 layer input projection — flag derivation', () => {
+  test('a typed trail-scope layer adds a flag derived from its input schema', () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'trace',
+      z.object({ verbose: z.boolean() }),
+      bucket
+    );
+
+    const echo = makeEchoTrail({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const command = requireCommand(buildCommands(app));
+    const flagNames = command.flags.map((f) => f.name);
+    expect(flagNames).toContain('verbose');
+  });
+
+  test('surface-scope layer flags appear on every command', () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'tenant',
+      z.object({ tenantId: z.string() }),
+      bucket
+    );
+    const a = trail('alpha', {
+      blaze: () => Result.ok(1),
+      input: z.object({}),
+    });
+    const b = trail('beta', {
+      blaze: () => Result.ok(2),
+      input: z.object({}),
+    });
+    const app = topo('app', { [a.id]: a, [b.id]: b });
+
+    const commands = buildCommands(app, { layers: [layer] });
+    expect(commands).toHaveLength(2);
+    for (const command of commands) {
+      const flagNames = command.flags.map((f) => f.name);
+      expect(flagNames).toContain('tenant-id');
+    }
+  });
+
+  test('topo-scope layer flags appear on every command', () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'audit',
+      z.object({ auditMode: z.enum(['off', 'full']) }),
+      bucket
+    );
+    const a = trail('alpha', {
+      blaze: () => Result.ok(1),
+      input: z.object({}),
+    });
+    const b = trail('beta', {
+      blaze: () => Result.ok(2),
+      input: z.object({}),
+    });
+    const app = topo('app', { [a.id]: a, [b.id]: b }, { layers: [layer] });
+
+    const commands = buildCommands(app);
+    expect(commands).toHaveLength(2);
+    for (const command of commands) {
+      const flagNames = command.flags.map((f) => f.name);
+      expect(flagNames).toContain('audit-mode');
+    }
+  });
+
+  test('multiple layers with disjoint fields each emit their own flags', () => {
+    const layerA: Layer = {
+      input: z.object({ alpha: z.boolean() }),
+      name: 'layerA',
+      wrap: (_t, impl) => impl,
+    };
+    const layerB: Layer = {
+      input: z.object({ beta: z.string() }),
+      name: 'layerB',
+      wrap: (_t, impl) => impl,
+    };
+
+    const echo = makeEchoTrail({ layers: [layerA, layerB] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const command = requireCommand(buildCommands(app));
+    const flagNames = command.flags.map((f) => f.name);
+    expect(flagNames).toContain('alpha');
+    expect(flagNames).toContain('beta');
+  });
+
+  test('layers without an input schema contribute no flags', () => {
+    const layer: Layer = {
+      name: 'noop',
+      wrap: (_t, impl) => impl,
+    };
+    const echo = makeEchoTrail({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+    const echoBaseline = makeEchoTrail();
+    const baselineApp = topo('app', { [echoBaseline.id]: echoBaseline });
+
+    const flagsWithLayer = new Set(
+      requireCommand(buildCommands(app)).flags.map((f) => f.name)
+    );
+    const baselineFlags = new Set(
+      requireCommand(buildCommands(baselineApp)).flags.map((f) => f.name)
+    );
+    expect(flagsWithLayer).toEqual(baselineFlags);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime routing
+// ---------------------------------------------------------------------------
+
+describe('TRL-473 layer input projection — runtime routing', () => {
+  test('parsed flag values are routed to the layer at runtime', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'trace',
+      z.object({ verbose: z.boolean() }),
+      bucket
+    );
+    const echo = makeEchoTrail({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const command = requireCommand(buildCommands(app));
+    const result = await command.execute(
+      { value: 'hi' },
+      { value: 'hi', verbose: true }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ verbose: true });
+  });
+
+  test('layer input does not pollute the trail input', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'trace',
+      z.object({ verbose: z.boolean() }),
+      bucket
+    );
+    let trailInput: unknown;
+    const recorded = trail('rec', {
+      blaze: (input: { value: string }) => {
+        trailInput = input;
+        return Result.ok({ value: input.value });
+      },
+      input: z.object({ value: z.string() }),
+      layers: [layer],
+      output: z.object({ value: z.string() }),
+    });
+    const app = topo('app', { [recorded.id]: recorded });
+
+    const command = requireCommand(buildCommands(app));
+    const result = await command.execute(
+      { value: 'hi' },
+      { value: 'hi', verbose: true }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(trailInput).toEqual({ value: 'hi' });
+  });
+
+  test('topo-scope layer routes runtime input through ctx.extensions', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'audit',
+      z.object({ auditMode: z.enum(['off', 'full']) }),
+      bucket
+    );
+    const echo = makeEchoTrail();
+    const app = topo('app', { [echo.id]: echo }, { layers: [layer] });
+
+    const command = requireCommand(buildCommands(app));
+    const result = await command.execute(
+      { value: 'hi' },
+      { auditMode: 'full', value: 'hi' }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ auditMode: 'full' });
+  });
+
+  test('omitted layer flags still materialize schema defaults', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'trace',
+      z.object({
+        enabled: z.boolean().default(false),
+        mode: z.enum(['audit', 'off']).default('audit'),
+      }),
+      bucket
+    );
+    const echo = makeEchoTrail({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const command = requireCommand(buildCommands(app));
+    const result = await command.execute({ value: 'hi' }, { value: 'hi' });
+
+    expect(result.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ enabled: false, mode: 'audit' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Collisions
+// ---------------------------------------------------------------------------
+
+describe('TRL-473 layer input projection — collisions', () => {
+  test('a layer field colliding with a trail field is renamed and routed', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const collidingLayer = captureLayerInput(
+      'collide',
+      z.object({ value: z.boolean() }),
+      bucket
+    );
+
+    const echo = trail('echo', {
+      blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+      input: z.object({ value: z.string() }),
+      layers: [collidingLayer],
+      output: z.object({ value: z.string() }),
+    });
+    const app = topo('app', { [echo.id]: echo });
+
+    const { result: commands, stderr } = withMutedStderr(() =>
+      buildCommands(app)
+    );
+
+    const command = requireCommand(commands);
+    const flagNames = command.flags.map((f) => f.name);
+    // Trail's `value` flag remains unchanged.
+    expect(flagNames).toContain('value');
+    // Layer's colliding `value` is renamed under the layer's kebab name.
+    expect(flagNames).toContain('collide-value');
+    // A warning was emitted on stderr.
+    expect(stderr).toContain('collide');
+    expect(stderr).toContain('--value');
+    expect(stderr).toContain('--collide-value');
+
+    const execResult = await command.execute(
+      { value: 'hi' },
+      { collideValue: true, value: 'hi' }
+    );
+    expect(execResult.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ value: true });
+  });
+
+  test('a layer field colliding with a meta flag is renamed', () => {
+    const layer: Layer = {
+      // `quiet` is a shared LAYER_FIELD_RESERVED_NAMES entry.
+      input: z.object({ quiet: z.boolean() }),
+      name: 'shh',
+      wrap: (_t, impl) => impl,
+    };
+    const echo = makeEchoTrail({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const { result: commands, stderr } = withMutedStderr(() =>
+      buildCommands(app)
+    );
+
+    const command = requireCommand(commands);
+    const flagNames = command.flags.map((f) => f.name);
+    expect(flagNames).toContain('shh-quiet');
+    expect(LAYER_FIELD_RESERVED_NAMES.has('quiet')).toBe(true);
+    expect(stderr).toContain('shh');
+    expect(stderr).toContain('CLI meta flag');
+  });
+
+  test('a renamed layer field gets a deterministic suffix when the fallback also collides', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const authLayer = captureLayerInput(
+      'auth',
+      z.object({ token: z.string() }),
+      bucket
+    );
+    const echo = trail('echo', {
+      blaze: (input: { authToken: string; token: string; value: string }) =>
+        Result.ok({ value: input.value }),
+      input: z.object({
+        authToken: z.string(),
+        token: z.string(),
+        value: z.string(),
+      }),
+      layers: [authLayer],
+      output: z.object({ value: z.string() }),
+    });
+    const app = topo('app', { [echo.id]: echo });
+
+    const { result: commands } = withMutedStderr(() => buildCommands(app));
+    const command = requireCommand(commands);
+    const flagNames = command.flags.map((f) => f.name);
+    expect(flagNames).toContain('auth-token');
+    expect(flagNames).toContain('auth-token2');
+
+    const execResult = await command.execute(
+      { value: 'hi' },
+      {
+        authToken: 'trail-auth',
+        authToken2: 'layer-auth',
+        token: 'trail-token',
+        value: 'hi',
+      }
+    );
+    if (execResult.isErr()) {
+      throw execResult.error;
+    }
+    expect(execResult.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ token: 'layer-auth' });
+  });
+
+  test('the rename rule is deterministic across builds', () => {
+    const buildOnce = () => {
+      const collidingLayer: Layer = {
+        input: z.object({ value: z.boolean() }),
+        name: 'collide',
+        wrap: (_t, impl) => impl,
+      };
+      const echo = trail('echo', {
+        blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+        input: z.object({ value: z.string() }),
+        layers: [collidingLayer],
+        output: z.object({ value: z.string() }),
+      });
+      const app = topo('app', { [echo.id]: echo });
+      const { result: commands } = withMutedStderr(() => buildCommands(app));
+      return new Set(requireCommand(commands).flags.map((f) => f.name));
+    };
+    expect(buildOnce()).toEqual(buildOnce());
+  });
+});

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -7,6 +7,7 @@ import type {
   BaseSurfaceOptions,
   Field,
   Layer,
+  LayerInputSchema,
   ResourceOverrideMap,
   Topo,
   TrailContext,
@@ -20,6 +21,7 @@ import {
   deriveFields,
   executeTrail,
   filterSurfaceTrails,
+  LAYER_FIELD_RESERVED_NAMES,
   validateSurfaceTopo,
   withSurfaceLayerNames,
 } from '@ontrails/core';
@@ -138,22 +140,6 @@ const validateCliCommandBuild = (
  * dot-notation, and wires up the execute function with validation,
  * layer composition, and onResult handling.
  */
-const META_FLAG_CANDIDATES = new Set([
-  'all',
-  'devPermit',
-  'dryRun',
-  'input',
-  'inputJson',
-  'json',
-  'jsonl',
-  'output',
-  'permit',
-  'quiet',
-  'token',
-  'trace',
-  'watch',
-]);
-
 const STRUCTURED_INLINE_JSON_ARG_NAME = 'inline-json';
 
 const STRUCTURED_INLINE_JSON_ARG: CliArg = {
@@ -461,13 +447,17 @@ const runTrailOnce = async (
   options: DeriveCliCommandsOptions | undefined,
   input: Record<string, unknown>,
   dryRun: boolean | undefined,
-  permit: BasePermit | undefined
+  permit: BasePermit | undefined,
+  layerInputs: Readonly<Record<string, unknown>> | undefined
 ): Promise<Result<unknown, Error>> =>
   await executeTrail(t, input, {
     configValues: options?.configValues,
     createContext: options?.createContext,
     ctx: withSurfaceLayerNames('cli', options?.layers ?? [], ctxOverrides),
     dryRun,
+    ...(layerInputs === undefined || Object.keys(layerInputs).length === 0
+      ? {}
+      : { layerInputs }),
     ...(permit === undefined ? {} : { permit }),
     resources: options?.resources,
     surfaceLayers: options?.layers,
@@ -537,7 +527,8 @@ const runPaginatedIteration = async (
   baseInput: Record<string, unknown>,
   jsonl: boolean,
   dryRun: boolean | undefined,
-  permit: BasePermit | undefined
+  permit: BasePermit | undefined,
+  layerInputs: Readonly<Record<string, unknown>> | undefined
 ): Promise<IterationOutcome> => {
   if (!inputHasCursorField(t)) {
     return {
@@ -555,7 +546,16 @@ const runPaginatedIteration = async (
     cursorField: 'cursor',
     onItem: jsonl ? writeJsonLine : undefined,
     runPage: (input) =>
-      runTrailOnce(graph, t, ctxOverrides, options, input, dryRun, permit),
+      runTrailOnce(
+        graph,
+        t,
+        ctxOverrides,
+        options,
+        input,
+        dryRun,
+        permit,
+        layerInputs
+      ),
   });
   return { result, streamed: jsonl && result.isOk() };
 };
@@ -690,16 +690,231 @@ const resolvePermitForExecution = async (
   });
 };
 
+// ---------------------------------------------------------------------------
+// Layer flag projection (TRL-473)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-layer flag projection: the rendered flags plus the routing map that
+ * sends parsed flag values back into the layer's runtime input slot.
+ */
+interface LayerFlagProjection {
+  /** The rendered `CliFlag` set contributed by this layer. */
+  readonly flags: readonly CliFlag[];
+  /** The layer input schema, kept so omitted CLI flags can still materialize defaults. */
+  readonly input: LayerInputSchema;
+  /**
+   * Map from camelCase parsed-flag key to the layer-input field name the
+   * value should be assigned to. Used by the executor to rebuild the
+   * per-layer input record before calling `executeTrail`.
+   */
+  readonly routing: ReadonlyMap<string, string>;
+  readonly layerName: string;
+}
+
+/**
+ * Collect every typed layer attached to a trail, in the same composition
+ * order the executor uses (topo → surface → trail). Layers without an
+ * `input` schema are skipped — they have nothing to project.
+ */
+const collectAttachedTypedLayers = (
+  graph: Topo,
+  t: AnyTrail,
+  options?: DeriveCliCommandsOptions
+): readonly Layer[] => {
+  const layers: Layer[] = [];
+  for (const layer of graph.layers) {
+    if (layer.input !== undefined) {
+      layers.push(layer);
+    }
+  }
+  if (options?.layers) {
+    for (const layer of options.layers) {
+      if (layer.input !== undefined) {
+        layers.push(layer);
+      }
+    }
+  }
+  for (const layer of t.layers) {
+    if (layer.input !== undefined) {
+      layers.push(layer);
+    }
+  }
+  return layers;
+};
+
+/**
+ * Convert a `Layer.name` (typically camelCase) into a kebab-case prefix
+ * usable in flag names. Mirrors `flags.ts` `toKebab` so the prefix stays
+ * consistent with derived flag names.
+ */
+const layerNameToKebab = (name: string): string =>
+  name.replaceAll(/[A-Z]/g, (ch) => `-${ch.toLowerCase()}`).replace(/^-/, '');
+
+/**
+ * Emit the deprecation-style stderr warning fired when a layer flag is
+ * renamed because of a collision. Using `process.stderr.write` follows
+ * the same boundary used elsewhere in the CLI surface.
+ */
+const warnLayerFlagRenamed = (
+  layerName: string,
+  originalName: string,
+  renamedName: string,
+  reason: string
+): void => {
+  process.stderr.write(
+    `[trails] layer "${layerName}" flag --${originalName} renamed to --${renamedName} (${reason})\n`
+  );
+};
+
+/**
+ * Project a single layer's `input` schema onto a CLI flag set, applying
+ * the deterministic collision rename rule.
+ *
+ * Collision rule: if the layer's derived flag name (after kebab-casing)
+ * conflicts with an already-claimed flag name (trail-derived flag,
+ * meta flag, or a previous layer's flag), the field is renamed to
+ * `<layerNameKebab>-<fieldKebab>`. Renames emit a one-line warning to
+ * stderr so the operator can see the projected name.
+ */
+const projectSingleLayerFlags = (
+  layer: Layer,
+  claimedFlagNames: Set<string>
+): LayerFlagProjection => {
+  if (layer.input === undefined) {
+    throw new Error(
+      `Cannot project CLI flags for layer '${layer.name}' without an input schema.`
+    );
+  }
+  const layerInput = layer.input;
+  const layerFields = deriveFields(layer.input);
+  const layerKebab = layerNameToKebab(layer.name);
+  const flags: CliFlag[] = [];
+  const routing = new Map<string, string>();
+
+  for (const flag of toFlags(layerFields)) {
+    const camelKey = kebabToCamel(flag.name);
+    const collidesWithClaimed = claimedFlagNames.has(flag.name);
+    const collidesWithMeta = LAYER_FIELD_RESERVED_NAMES.has(camelKey);
+
+    if (!collidesWithClaimed && !collidesWithMeta) {
+      flags.push(flag);
+      claimedFlagNames.add(flag.name);
+      routing.set(camelKey, camelKey);
+      continue;
+    }
+
+    const fallbackKebab = `${layerKebab}-${flag.name}`;
+    let renamedKebab = fallbackKebab;
+    let suffix = 2;
+    while (
+      claimedFlagNames.has(renamedKebab) ||
+      LAYER_FIELD_RESERVED_NAMES.has(kebabToCamel(renamedKebab))
+    ) {
+      renamedKebab = `${fallbackKebab}${suffix}`;
+      suffix += 1;
+    }
+    const renamedCamel = kebabToCamel(renamedKebab);
+    const reason = collidesWithMeta
+      ? `--${flag.name} collides with a CLI meta flag`
+      : `--${flag.name} collides with another flag`;
+    warnLayerFlagRenamed(layer.name, flag.name, renamedKebab, reason);
+    flags.push({ ...flag, name: renamedKebab });
+    claimedFlagNames.add(renamedKebab);
+    routing.set(renamedCamel, camelKey);
+  }
+
+  return { flags, input: layerInput, layerName: layer.name, routing };
+};
+
+/**
+ * Project every attached layer's input schema onto the command's flag set.
+ *
+ * Returns the full list of layer-derived flags (in composition order) plus
+ * the per-layer routing maps the executor needs to partition parsed flag
+ * values back into per-layer input objects.
+ */
+const projectLayerFlags = (
+  attachedLayers: readonly Layer[],
+  trailDerivedFlagNames: ReadonlySet<string>
+): {
+  readonly flags: readonly CliFlag[];
+  readonly projections: readonly LayerFlagProjection[];
+} => {
+  const claimed = new Set<string>(trailDerivedFlagNames);
+  const allFlags: CliFlag[] = [];
+  const projections: LayerFlagProjection[] = [];
+  for (const layer of attachedLayers) {
+    const projection = projectSingleLayerFlags(layer, claimed);
+    if (projection.flags.length === 0) {
+      continue;
+    }
+    allFlags.push(...projection.flags);
+    projections.push(projection);
+  }
+  return { flags: allFlags, projections };
+};
+
+/**
+ * Build the `layerInputs` map from parsed flags using each layer's
+ * projection routing table. Only includes layers that actually received
+ * at least one parsed value, so tests can assert presence cleanly.
+ */
+const buildLayerInputs = (
+  projections: readonly LayerFlagProjection[],
+  parsedFlags: Record<string, unknown>
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  for (const projection of projections) {
+    const layerInput: Record<string, unknown> = {};
+    let received = false;
+    for (const [parsedKey, fieldName] of projection.routing) {
+      const value = parsedFlags[parsedKey];
+      if (value === undefined) {
+        continue;
+      }
+      layerInput[fieldName] = value;
+      received = true;
+    }
+    if (received) {
+      result[projection.layerName] = layerInput;
+      continue;
+    }
+    if (projection.input.safeParse({}).success) {
+      result[projection.layerName] = {};
+    }
+  }
+  return result;
+};
+
+/**
+ * Collect every camelCase key that any layer projection routes through —
+ * those are flag names the executor must keep out of the trail's input
+ * record (alongside the existing meta flags).
+ */
+const collectLayerRoutedKeys = (
+  projections: readonly LayerFlagProjection[]
+): ReadonlySet<string> => {
+  const keys = new Set<string>();
+  for (const projection of projections) {
+    for (const key of projection.routing.keys()) {
+      keys.add(key);
+    }
+  }
+  return keys;
+};
+
 /** Create the execute function for a CLI command. */
 const createExecute =
   (
     graph: Topo,
     t: AnyTrail,
     fields: readonly Field[],
-    metaFlagNames: ReadonlySet<string>,
+    trailInputExcludeKeys: ReadonlySet<string>,
     dateFields: readonly string[],
     dateFieldKinds: Readonly<Record<string, DateShortcutKind>>,
     shouldHintStructuredInput: boolean,
+    layerProjections: readonly LayerFlagProjection[],
     options?: DeriveCliCommandsOptions
   ) =>
   async (
@@ -709,7 +924,7 @@ const createExecute =
   ): Promise<Result<unknown, Error>> => {
     const merged = await safeMergeInput(
       fields,
-      metaFlagNames,
+      trailInputExcludeKeys,
       dateFields,
       dateFieldKinds,
       parsedArgs,
@@ -732,7 +947,7 @@ const createExecute =
     const permitResolution = await resolvePermitForExecution(
       graph,
       parsedFlags,
-      metaFlagNames,
+      trailInputExcludeKeys,
       options
     );
     if (permitResolution.isErr()) {
@@ -751,10 +966,17 @@ const createExecute =
     }
     const permit = permitResolution.value;
 
-    const dryRun = readDryRunFlag(parsedFlags, metaFlagNames);
+    // Partition parsed flags into per-layer input objects via the
+    // projection routing tables. Projected camelCase keys are normalized
+    // first because Commander emits camelCase-looking keys, but tests and
+    // adapters may pass either kebab- or camelCase.
+    const normalizedFlags = normalizeParsedFlags(parsedFlags);
+    const layerInputs = buildLayerInputs(layerProjections, normalizedFlags);
+
+    const dryRun = readDryRunFlag(parsedFlags, trailInputExcludeKeys);
     let result: Result<unknown, Error>;
     let streamed = false;
-    if (shouldIteratePages(t, parsedFlags, metaFlagNames)) {
+    if (shouldIteratePages(t, parsedFlags, trailInputExcludeKeys)) {
       const outcome = await runPaginatedIteration(
         graph,
         t,
@@ -763,7 +985,8 @@ const createExecute =
         mergedInput,
         isJsonlMode(parsedFlags),
         dryRun,
-        permit
+        permit,
+        layerInputs
       );
       ({ result } = outcome);
       ({ streamed } = outcome);
@@ -773,9 +996,12 @@ const createExecute =
         t,
         ctxOverrides,
         options,
-        metaFlagNames.has('all') ? stripAllFlag(mergedInput) : mergedInput,
+        trailInputExcludeKeys.has('all')
+          ? stripAllFlag(mergedInput)
+          : mergedInput,
         dryRun,
-        permit
+        permit,
+        layerInputs
       );
     }
 
@@ -897,7 +1123,7 @@ const toCliCommand = (
 ): CliCommand => {
   const fields = deriveFields(t.input, t.fields);
   // All fields generate flags — positional fields keep their --flag alias
-  const flags = buildFlags(t, fields, t.intent, options);
+  const trailFlags = buildFlags(t, fields, t.intent, options);
   const structuredInputReservedNames = supportsStructuredInput(t.input)
     ? RESERVED_STRUCTURED_INPUT_META_FLAGS
     : new Set<string>();
@@ -907,12 +1133,33 @@ const toCliCommand = (
       .filter((name) => !structuredInputReservedNames.has(name))
   );
   const metaFlagNames = new Set(
-    flags
+    trailFlags
       .map((flag) => kebabToCamel(flag.name))
       .filter(
-        (name) => META_FLAG_CANDIDATES.has(name) && !derivedFlagNames.has(name)
+        (name) =>
+          LAYER_FIELD_RESERVED_NAMES.has(name) && !derivedFlagNames.has(name)
       )
   );
+
+  // Project each typed layer's `input` schema onto the command's flag set,
+  // applying the deterministic collision rename rule. The routing map
+  // returned per layer is consumed at execute time to rebuild a per-layer
+  // input object from parsed flags. (TRL-473)
+  const attachedTypedLayers = collectAttachedTypedLayers(graph, t, options);
+  const claimedFlagKebabs = new Set<string>(trailFlags.map((f) => f.name));
+  const layerProjection = projectLayerFlags(
+    attachedTypedLayers,
+    claimedFlagKebabs
+  );
+  const flags = [...trailFlags, ...layerProjection.flags];
+  const layerRoutedKeys = collectLayerRoutedKeys(layerProjection.projections);
+  // The executor strips both meta flags and layer-routed flag values from
+  // the trail input so layer-only flags never reach trail validation.
+  const trailInputExcludeKeys = new Set<string>([
+    ...metaFlagNames,
+    ...layerRoutedKeys,
+  ]);
+
   const shouldHintStructuredInput = hasStructuredOnlyFields(
     t.input,
     fields.length
@@ -932,10 +1179,11 @@ const toCliCommand = (
       graph,
       t,
       fields,
-      metaFlagNames,
+      trailInputExcludeKeys,
       dateFields,
       dateFieldKinds,
       shouldHintStructuredInput,
+      layerProjection.projections,
       options
     ),
     flags,

--- a/packages/core/src/__tests__/layer.test.ts
+++ b/packages/core/src/__tests__/layer.test.ts
@@ -4,11 +4,13 @@ import { describe, test, expect } from 'bun:test';
 import { z } from 'zod';
 
 import { createTrailContext } from '../context';
+import { ValidationError } from '../errors';
 import { composeLayers } from '../layer';
 import type { Layer } from '../layer';
 import { executeTrail } from '../execute';
 import { Result } from '../result';
 import { trail } from '../trail';
+import { LAYER_INPUTS_KEY } from '../types';
 import type { TrailContext } from '../types';
 
 const stubCtx: TrailContext = createTrailContext({
@@ -198,6 +200,101 @@ describe('executeTrail layers option', () => {
       tenantTrail,
       { tenantId: 'acme', value: 'hello' },
       { ctx: { extensions: { tenantId: 'acme' } }, layers: [tenantGuard] }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ value: 'hello' });
+  });
+
+  test('validates layer input slots before wrapping and exposes parsed values', async () => {
+    let captured: unknown;
+    const typedLayer: Layer = {
+      input: z.object({ retries: z.coerce.number().int() }),
+      name: 'retry',
+      wrap(_trail, impl) {
+        return async (input, ctx) => {
+          const all = ctx.extensions?.[LAYER_INPUTS_KEY] as
+            | Readonly<Record<string, unknown>>
+            | undefined;
+          captured = all?.['retry'];
+          return await impl(input, ctx);
+        };
+      },
+    };
+
+    const result = await executeTrail(
+      echoTrail,
+      { value: 'hello' },
+      { layerInputs: { retry: { retries: '3' } }, layers: [typedLayer] }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(captured).toEqual({ retries: 3 });
+  });
+
+  test('invalid layer input returns ValidationError before any layer wraps', async () => {
+    let wrapped = false;
+    const typedLayer: Layer = {
+      input: z.object({ token: z.string() }),
+      name: 'auth',
+      wrap(_trail, impl) {
+        return async (input, ctx) => {
+          wrapped = true;
+          return await impl(input, ctx);
+        };
+      },
+    };
+
+    const result = await executeTrail(
+      echoTrail,
+      { value: 'hello' },
+      { layerInputs: { auth: { token: 42 } }, layers: [typedLayer] }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect(result.error.message).toContain("Invalid input for layer 'auth'");
+    expect(wrapped).toBe(false);
+  });
+
+  test('layers without input schemas preserve their unvalidated runtime slot', async () => {
+    let captured: unknown;
+    const runtimeLayer: Layer = {
+      name: 'runtime',
+      wrap(_trail, impl) {
+        return async (input, ctx) => {
+          const all = ctx.extensions?.[LAYER_INPUTS_KEY] as
+            | Readonly<Record<string, unknown>>
+            | undefined;
+          captured = all?.['runtime'];
+          return await impl(input, ctx);
+        };
+      },
+    };
+
+    const result = await executeTrail(
+      echoTrail,
+      { value: 'hello' },
+      { layerInputs: { runtime: { raw: true } }, layers: [runtimeLayer] }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(captured).toEqual({ raw: true });
+  });
+
+  test('omitted layer input is a no-op for typed layers', async () => {
+    const typedLayer: Layer = {
+      input: z.object({ token: z.string() }),
+      name: 'auth',
+      wrap(_trail, impl) {
+        return impl;
+      },
+    };
+
+    const result = await executeTrail(
+      echoTrail,
+      { value: 'hello' },
+      { layers: [typedLayer] }
     );
 
     expect(result.isOk()).toBe(true);

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -44,6 +44,7 @@ import {
   PermitError,
   RetryExhaustedError,
   TrailsError,
+  ValidationError,
 } from './errors.js';
 import {
   claimNextCrossBatchIndex,
@@ -69,7 +70,7 @@ import { Result } from './result.js';
 import { DETOUR_MAX_ATTEMPTS_CAP } from './detours.js';
 import { createResourceLookup } from './resource.js';
 import { createResources } from './resource-config.js';
-import { SURFACE_KEY } from './types.js';
+import { LAYER_INPUTS_KEY, SURFACE_KEY } from './types.js';
 import { validateInput, validateOutput } from './validation.js';
 
 type MutableTrailContext = {
@@ -141,6 +142,18 @@ export interface ExecuteTrailOptions {
    */
   readonly permit?: BasePermit | undefined;
   /**
+   * Per-layer runtime input keyed by `Layer.name`.
+   *
+   * Surfaces (CLI, MCP, HTTP) parse their native idiom into a per-layer
+   * input object — usually projected from each layer's `input` schema —
+   * and pass it here. The executor merges these into
+   * `ctx.extensions[LAYER_INPUTS_KEY]` so layers can read their own slot
+   * via `ctx.extensions?.[LAYER_INPUTS_KEY]?.[layer.name]`.
+   *
+   * @see TRL-473 for the CLI projection contract.
+   */
+  readonly layerInputs?: Readonly<Record<string, unknown>> | undefined;
+  /**
    * Override the validation schema used for input validation.
    *
    * When a trail is invoked via `ctx.cross()` and the target declares
@@ -180,9 +193,30 @@ const applyContextOverrides = (
       ? withAbort
       : { ...withAbort, dryRun: options.dryRun };
 
-  return options?.permit === undefined
-    ? withDryRun
-    : { ...withDryRun, permit: options.permit };
+  const withPermit =
+    options?.permit === undefined
+      ? withDryRun
+      : { ...withDryRun, permit: options.permit };
+
+  if (options?.layerInputs === undefined) {
+    return withPermit;
+  }
+  // Merge per-layer inputs onto any inherited LAYER_INPUTS_KEY slot so
+  // crossed/forked contexts can preserve outer-surface routing.
+  const inheritedExtensions = withPermit.extensions ?? {};
+  const inheritedLayerInputs = (inheritedExtensions[LAYER_INPUTS_KEY] ?? {}) as
+    | Readonly<Record<string, unknown>>
+    | Record<string, unknown>;
+  return {
+    ...withPermit,
+    extensions: {
+      ...inheritedExtensions,
+      [LAYER_INPUTS_KEY]: {
+        ...inheritedLayerInputs,
+        ...options.layerInputs,
+      },
+    },
+  };
 };
 
 const bindResourceLookup = (
@@ -1212,6 +1246,84 @@ const composeAttachedLayers = (
   ...(options?.layers ?? []),
 ];
 
+const isLayerInputMap = (
+  value: unknown
+): value is Readonly<Record<string, unknown>> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const readContextLayerInputs = (
+  ctx: TrailContext
+): Result<Readonly<Record<string, unknown>> | undefined, ValidationError> => {
+  const value = ctx.extensions?.[LAYER_INPUTS_KEY];
+  if (value === undefined) {
+    return Result.ok();
+  }
+  return isLayerInputMap(value)
+    ? Result.ok(value)
+    : Result.err(
+        new ValidationError(
+          'Layer inputs must be an object keyed by layer name',
+          {
+            context: { extensionKey: LAYER_INPUTS_KEY },
+          }
+        )
+      );
+};
+
+const validateLayerInputs = (
+  layers: readonly Layer[],
+  layerInputs: Readonly<Record<string, unknown>>
+): Result<Readonly<Record<string, unknown>>, ValidationError> => {
+  const validated: Record<string, unknown> = { ...layerInputs };
+  for (const layer of layers) {
+    if (layer.input === undefined) {
+      continue;
+    }
+    const slot = layerInputs[layer.name];
+    if (slot === undefined) {
+      continue;
+    }
+    const parsed = layer.input.safeParse(slot);
+    if (!parsed.success) {
+      return Result.err(
+        new ValidationError(
+          `Invalid input for layer '${layer.name}': ${parsed.error.message}`,
+          {
+            cause: parsed.error,
+            context: { issues: parsed.error.issues, layerName: layer.name },
+          }
+        )
+      );
+    }
+    validated[layer.name] = parsed.data;
+  }
+  return Result.ok(validated);
+};
+
+const validateContextLayerInputs = (
+  ctx: TrailContext,
+  layers: readonly Layer[]
+): Result<TrailContext, ValidationError> => {
+  const layerInputs = readContextLayerInputs(ctx);
+  if (layerInputs.isErr()) {
+    return Result.err(layerInputs.error);
+  }
+  if (layerInputs.value === undefined) {
+    return Result.ok(ctx);
+  }
+  const validated = validateLayerInputs(layers, layerInputs.value);
+  if (validated.isErr()) {
+    return Result.err(validated.error);
+  }
+  return Result.ok({
+    ...ctx,
+    extensions: {
+      ...ctx.extensions,
+      [LAYER_INPUTS_KEY]: validated.value,
+    },
+  });
+};
+
 /**
  * Execute a trail through the standard validate-context-layers-run pipeline.
  *
@@ -1237,12 +1349,20 @@ export const executeTrail = async (
       return Result.err(resolvedCtx.error);
     }
 
+    const layers = composeAttachedLayers(trail, options);
     try {
+      const layerCtx = validateContextLayerInputs(
+        resolvedCtx.value.ctx,
+        layers
+      );
+      if (layerCtx.isErr()) {
+        return Result.err(layerCtx.error);
+      }
       return await runTrail(
         trail,
         validated.value,
-        resolvedCtx.value.ctx,
-        composeAttachedLayers(trail, options),
+        layerCtx.value,
+        layers,
         options?.topo,
         options
       );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,7 +80,11 @@ export type {
 } from './types.js';
 export { basePermitSchema } from './permits.js';
 export type { BasePermit } from './permits.js';
-export { SURFACE_KEY, SURFACE_LAYER_NAMES_KEY } from './types.js';
+export {
+  LAYER_INPUTS_KEY,
+  SURFACE_KEY,
+  SURFACE_LAYER_NAMES_KEY,
+} from './types.js';
 export {
   ACTIVATION_PROVENANCE_KEY,
   buildActivationProvenanceTraceAttrs,
@@ -92,6 +96,7 @@ export type {
   ActivationProvenanceCarrier,
   ActivationProvenanceSource,
 } from './activation-provenance.js';
+export { LAYER_FIELD_RESERVED_NAMES } from './internal/layer-projection.js';
 
 // Context factory
 export { createTrailContext, passthroughTrace } from './context.js';

--- a/packages/core/src/internal/layer-projection.ts
+++ b/packages/core/src/internal/layer-projection.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared vocabulary for projecting layer input fields onto surface parameters.
+ *
+ * Layer input is authored once on `Layer.input`, then rendered by CLI, MCP, and
+ * HTTP surfaces. Reserved names live here so a layer field that conflicts with
+ * framework-owned surface parameters is renamed consistently everywhere.
+ */
+
+export const LAYER_FIELD_RESERVED_NAMES: ReadonlySet<string> = new Set([
+  'all',
+  'devPermit',
+  'dryRun',
+  'input',
+  'inputJson',
+  'json',
+  'jsonl',
+  'output',
+  'permit',
+  'quiet',
+  'token',
+  'trace',
+  'watch',
+]);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -195,6 +195,19 @@ export const SURFACE_KEY = '__trails_surface' as const;
  */
 export const SURFACE_LAYER_NAMES_KEY = '__trails_surface_layer_names' as const;
 
+/**
+ * Context extension key carrying per-layer runtime input.
+ *
+ * Surfaces (CLI, MCP, HTTP) project each typed layer's `input` schema onto
+ * their native idioms (flags, tool params, query strings). At execute time
+ * the parsed values are partitioned per layer and stored under this key as
+ * `Record<layerName, unknown>`. Layers that need runtime input read their
+ * own slot via `ctx.extensions?.[LAYER_INPUTS_KEY]?.[layer.name]`.
+ *
+ * @see TRL-473 for the CLI projection contract.
+ */
+export const LAYER_INPUTS_KEY = '__trails_layer_inputs' as const;
+
 /** Runtime context threaded through every trail execution */
 export interface TrailContext {
   readonly activation?: ActivationProvenance | undefined;

--- a/packages/warden/src/__tests__/layer-field-name-drift.test.ts
+++ b/packages/warden/src/__tests__/layer-field-name-drift.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+
+import { layerFieldNameDrift } from '../rules/layer-field-name-drift.js';
+
+describe('layer-field-name-drift', () => {
+  test('allows surfaces to consume the shared core reserved-name set', () => {
+    const diagnostics = layerFieldNameDrift.check(
+      `import { LAYER_FIELD_RESERVED_NAMES } from '@ontrails/core';
+
+const collides = LAYER_FIELD_RESERVED_NAMES.has('all');
+`,
+      '/repo/packages/cli/src/build.ts'
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('flags the legacy CLI-local meta flag set', () => {
+    const diagnostics = layerFieldNameDrift.check(
+      `const META_FLAG_CANDIDATES = new Set(['all', 'dryRun']);
+`,
+      '/repo/packages/cli/src/build.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('layer-field-name-drift');
+    expect(diagnostics[0]?.message).toContain('META_FLAG_CANDIDATES');
+  });
+
+  test('flags surface-local layer reserved name arrays', () => {
+    const diagnostics = layerFieldNameDrift.check(
+      `const MCP_LAYER_RESERVED_NAMES = ['all', 'dryRun'];
+`,
+      '/repo/packages/mcp/src/build.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('layer-field-name-drift');
+    expect(diagnostics[0]?.message).toContain('MCP_LAYER_RESERVED_NAMES');
+  });
+
+  test('ignores similarly named sets outside surface packages', () => {
+    const diagnostics = layerFieldNameDrift.check(
+      `const MCP_LAYER_RESERVED_NAMES = ['all', 'dryRun'];
+`,
+      '/repo/packages/warden/src/rules/example.ts'
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 44 rule trails', () => {
-    expect(wardenTopo.count).toBe(44);
+  test('contains all 45 rule trails', () => {
+    expect(wardenTopo.count).toBe(45);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -81,6 +81,7 @@ export {
   incompleteAccessorForStandardOpTrail,
   incompleteCrudTrail,
   intentPropagationTrail,
+  layerFieldNameDriftTrail,
   missingVisibilityTrail,
   missingReconcileTrail,
   noDevPermitInSourceTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -13,6 +13,7 @@ import { implementationReturnsResult } from './implementation-returns-result.js'
 import { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 import { incompleteCrud } from './incomplete-crud.js';
 import { intentPropagation } from './intent-propagation.js';
+import { layerFieldNameDrift } from './layer-field-name-drift.js';
 import { missingVisibility } from './missing-visibility.js';
 import { missingReconcile } from './missing-reconcile.js';
 import { noDevPermitInSource } from './no-dev-permit-in-source.js';
@@ -83,6 +84,7 @@ export { firesDeclarations } from './fires-declarations.js';
 export { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 export { incompleteCrud } from './incomplete-crud.js';
 export { intentPropagation } from './intent-propagation.js';
+export { layerFieldNameDrift } from './layer-field-name-drift.js';
 export { missingVisibility } from './missing-visibility.js';
 export { missingReconcile } from './missing-reconcile.js';
 export { onReferencesExist } from './on-references-exist.js';
@@ -129,6 +131,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [firesDeclarations.name, firesDeclarations],
   [incompleteCrud.name, incompleteCrud],
   [intentPropagation.name, intentPropagation],
+  [layerFieldNameDrift.name, layerFieldNameDrift],
   [missingVisibility.name, missingVisibility],
   [missingReconcile.name, missingReconcile],
   [onReferencesExist.name, onReferencesExist],

--- a/packages/warden/src/rules/layer-field-name-drift.ts
+++ b/packages/warden/src/rules/layer-field-name-drift.ts
@@ -1,0 +1,96 @@
+import { sep } from 'node:path';
+
+import { identifierName, offsetToLine, parse, walk } from './ast.js';
+import type { AstNode } from './ast.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'layer-field-name-drift';
+
+const LEGACY_RESERVED_SET_NAMES = new Set(['META_FLAG_CANDIDATES']);
+
+const normalizePath = (filePath: string): string =>
+  filePath.split(sep).join('/');
+
+const isSurfaceSourceFile = (filePath: string): boolean => {
+  const normalized = normalizePath(filePath);
+  return /(^|\/)packages\/(cli|http|mcp)\/src\//.test(normalized);
+};
+
+const isTestFile = (filePath: string): boolean => {
+  const normalized = normalizePath(filePath);
+  return (
+    normalized.includes('/__tests__/') || /\.test\.[cm]?tsx?$/.test(normalized)
+  );
+};
+
+const looksLikeLayerReservedNameSet = (name: string): boolean => {
+  const lower = name.toLowerCase();
+  return (
+    LEGACY_RESERVED_SET_NAMES.has(name) ||
+    (lower.includes('layer') &&
+      lower.includes('reserved') &&
+      (lower.includes('name') || lower.includes('flag')))
+  );
+};
+
+const isSetConstruction = (node: AstNode | undefined): boolean => {
+  if (node?.type !== 'NewExpression') {
+    return false;
+  }
+  const { callee } = node as unknown as { callee?: AstNode };
+  return identifierName(callee) === 'Set';
+};
+
+const isLocalReservedSetInitializer = (node: AstNode | undefined): boolean =>
+  node?.type === 'ArrayExpression' || isSetConstruction(node);
+
+const buildDiagnostic = (
+  sourceCode: string,
+  filePath: string,
+  node: AstNode,
+  name: string
+): WardenDiagnostic => ({
+  filePath,
+  line: offsetToLine(sourceCode, node.start),
+  message: `layer-field-name-drift: surface-local reserved name set "${name}" can make layer input fields project differently across surfaces. Import LAYER_FIELD_RESERVED_NAMES from @ontrails/core instead.`,
+  rule: RULE_NAME,
+  severity: 'error',
+});
+
+export const layerFieldNameDrift: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (!isSurfaceSourceFile(filePath) || isTestFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const diagnostics: WardenDiagnostic[] = [];
+    walk(ast, (node) => {
+      if (node.type !== 'VariableDeclarator') {
+        return;
+      }
+      const { id, init } = node as unknown as {
+        id?: AstNode;
+        init?: AstNode;
+      };
+      const name = identifierName(id);
+      if (
+        name &&
+        looksLikeLayerReservedNameSet(name) &&
+        isLocalReservedSetInitializer(init)
+      ) {
+        diagnostics.push(buildDiagnostic(sourceCode, filePath, node, name));
+      }
+    });
+
+    return diagnostics;
+  },
+  description:
+    'Prevent surface-local reserved-name sets from drifting layer input field projection across surfaces.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -121,6 +121,12 @@ export const builtinWardenRuleMetadata = {
     invariant: 'Composite trail intent cannot be safer than crossed trails.',
     tier: 'project-static',
   },
+  'layer-field-name-drift': {
+    ...durableExternal,
+    invariant:
+      'Layer input field reserved names are shared across surface projections.',
+    tier: 'source-static',
+  },
   'missing-reconcile': {
     ...durableExternal,
     invariant: 'Versioned CRUD store tables provide reconcile coverage.',

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -21,6 +21,7 @@ import { implementationReturnsResult } from './implementation-returns-result.js'
 import { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 import { incompleteCrud } from './incomplete-crud.js';
 import { intentPropagation } from './intent-propagation.js';
+import { layerFieldNameDrift } from './layer-field-name-drift.js';
 import { missingReconcile } from './missing-reconcile.js';
 import { missingVisibility } from './missing-visibility.js';
 import { noDevPermitInSource } from './no-dev-permit-in-source.js';
@@ -72,6 +73,7 @@ export const registeredRuleNames: readonly string[] = [
   incompleteAccessorForStandardOp.name,
   incompleteCrud.name,
   intentPropagation.name,
+  layerFieldNameDrift.name,
   missingReconcile.name,
   missingVisibility.name,
   noDevPermitInSource.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -13,6 +13,7 @@ export { implementationReturnsResultTrail } from './implementation-returns-resul
 export { incompleteAccessorForStandardOpTrail } from './incomplete-accessor-for-standard-op.trail.js';
 export { incompleteCrudTrail } from './incomplete-crud.trail.js';
 export { intentPropagationTrail } from './intent-propagation.trail.js';
+export { layerFieldNameDriftTrail } from './layer-field-name-drift.trail.js';
 export { missingVisibilityTrail } from './missing-visibility.trail.js';
 export { missingReconcileTrail } from './missing-reconcile.trail.js';
 export { onReferencesExistTrail } from './on-references-exist.trail.js';

--- a/packages/warden/src/trails/layer-field-name-drift.trail.ts
+++ b/packages/warden/src/trails/layer-field-name-drift.trail.ts
@@ -1,0 +1,39 @@
+import { layerFieldNameDrift } from '../rules/layer-field-name-drift.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const layerFieldNameDriftTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'packages/cli/src/build.ts',
+        sourceCode: `import { LAYER_FIELD_RESERVED_NAMES } from '@ontrails/core';
+
+const collides = LAYER_FIELD_RESERVED_NAMES.has('all');
+`,
+      },
+      name: 'Allows shared core reserved-name set',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'packages/cli/src/build.ts',
+            line: 1,
+            message:
+              'layer-field-name-drift: surface-local reserved name set "META_FLAG_CANDIDATES" can make layer input fields project differently across surfaces. Import LAYER_FIELD_RESERVED_NAMES from @ontrails/core instead.',
+            rule: 'layer-field-name-drift',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        filePath: 'packages/cli/src/build.ts',
+        sourceCode: `const META_FLAG_CANDIDATES = new Set(['all']);
+`,
+      },
+      name: 'Flags surface-local reserved-name sets',
+    },
+  ],
+  rule: layerFieldNameDrift,
+});


### PR DESCRIPTION
## Summary
- Projects typed layer input schemas onto CLI flags.
- Validates per-layer input slots before wrapping the blaze so invalid layer configuration fails early.
- Adds Warden coverage for persistent layer field-name drift.

## Details
The CLI collects attached typed layers in composition order, derives fields with the existing schema-to-flag pipeline, and assembles `layerInputs` for `executeTrail`. Name collisions with trail input, meta flags, or other layer fields are deterministically renamed to `--<layer-name>-<field>` and warned once. If that fallback name is already claimed, the shared projection helper adds a numeric suffix so the CLI never silently maps two fields onto one flag. Core now owns validation of layer input slots, and shared reserved names/projection helpers prevent the CLI and Warden from drifting.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-473.
