### PR TITLE
feat(core,cli,mcp,http): project typed layer input onto MCP and HTTP surfaces

### DIFF
--- a/.changeset/trl-474-layer-input-mcp-http.md
+++ b/.changeset/trl-474-layer-input-mcp-http.md
@@ -1,0 +1,8 @@
+---
+'@ontrails/core': minor
+'@ontrails/cli': minor
+'@ontrails/mcp': minor
+'@ontrails/http': minor
+---
+
+Project typed-layer `input` schemas onto MCP and HTTP surfaces. Closes Phase 7. Lifts `collectAttachedTypedLayers` and `projectLayerFieldName` (collision-rename rule) into `@ontrails/core/internal/layer-projection` so all three surfaces share one source of truth. The CLI surface refactors to consume the lifted helpers (no behavior change). MCP merges layer fields into each tool's `inputSchema` and partitions inbound args at invocation time. HTTP merges layer fields into the route's request schema (query for reads, body for writes) and exposes new optional `HttpRouteDefinition.inputSchema` + `layerInputProjections` for surface adapters / OpenAPI generators. Collision rule matches TRL-473's: deterministic rename to a layer-prefixed camelCase name with the original captured in the routing table. Side fix: MCP and HTTP handlers now forward `topoLayers: graph.layers` + `surfaceLayers: layers` so topo-scope layers actually compose at runtime (previously the handlers used the deprecated `layers` alias and never read `graph.layers`).

--- a/docs/adr/0005-framework-agnostic-http-route-model.md
+++ b/docs/adr/0005-framework-agnostic-http-route-model.md
@@ -44,7 +44,7 @@ The core function takes a topo and returns an array of framework-agnostic route 
 - **`inputSource`** — `query` for reads, `body` for writes, derived from the method
 - **`trailId`** — the trail's ID, for debugging and logging
 - **`trail`** — the full trail definition, for `meta` access
-- **`execute(input, requestId?, abortSignal?)`** — validates input, composes layers, runs the implementation, returns `Result`
+- **`execute(input, requestId?, abortSignal?, context?)`** — validates input, composes layers, resolves request auth when configured, runs the implementation, returns `Result`
 
 The `execute` function is the important part. It does everything *except* touch HTTP framework types. It doesn't parse a `Request`. It doesn't construct a `Response`. It doesn't set status codes. It takes validated input, runs the trail, and returns a `Result`. Everything HTTP-specific happens in the connector.
 

--- a/docs/adr/0012-connector-agnostic-permits.md
+++ b/docs/adr/0012-connector-agnostic-permits.md
@@ -82,7 +82,7 @@ The permit model separates into three distinct responsibilities:
 
 ```typescript
 interface PermitExtractionInput {
-  readonly trailhead: 'http' | 'mcp' | 'cli';
+  readonly surface: 'http' | 'mcp' | 'cli';
   readonly bearerToken?: string;
   readonly sessionId?: string;
   readonly headers?: Headers;
@@ -144,7 +144,7 @@ No cookies. No session-based auth at the framework level. Session management via
 ### Positive
 
 - **Auth requirements are part of the trail contract.** Visible, verifiable, introspectable. An agent can query a topo and see every trail's auth posture without reading implementation code.
-- **Same auth layer works across all surfaces.** HTTP, MCP, CLI — one enforcement path. No surface-specific auth bugs.
+- **Same auth model works across all surfaces.** HTTP, MCP, CLI — one enforcement path. No surface-specific auth bugs.
 - **Testing fails closed.** Auto-minted permits match declared scopes exactly. No silent privilege escalation in tests. Strict mode proves the full auth path.
 - **Warden catches unprotected destructive trails before deployment.** The `destroy` + no permit rule is a structural guarantee, not a code review convention.
 

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -302,7 +302,12 @@ for (const route of routesResult.value) {
           statusFor(parsed.error)
         );
       }
-      const result = await route.execute(parsed.value);
+      const result = await route.execute(
+        parsed.value,
+        undefined,
+        c.req.raw.signal,
+        { headers: c.req.raw.headers }
+      );
       return result.isOk()
         ? c.json({ data: result.value }, 200)
         : c.json(
@@ -315,7 +320,9 @@ for (const route of routesResult.value) {
       route.inputSource === 'query'
         ? Object.fromEntries(new URL(c.req.url).searchParams)
         : await c.req.json();
-    const result = await route.execute(input);
+    const result = await route.execute(input, undefined, c.req.raw.signal, {
+      headers: c.req.raw.headers,
+    });
     return result.isOk()
       ? c.json({ data: result.value }, 200)
       : c.json(
@@ -332,9 +339,9 @@ This gives you full control over the HTTP framework while still deriving routes 
 
 `deriveHttpRoutes()` returns `Result<HttpRouteDefinition[], Error>`. If two trails resolve to the same method + path (e.g. two trails both map to `POST /entity/add`), it returns a `ValidationError` describing the collision instead of silently overwriting a route.
 
-## AbortSignal Propagation
+## Request Context and AbortSignal Propagation
 
-The HTTP request's abort signal is forwarded to `TrailContext.abortSignal`. If the client disconnects or cancels the request mid-flight, the implementation's signal is aborted.
+The HTTP request's abort signal is forwarded to `TrailContext.abortSignal`. If the client disconnects or cancels the request mid-flight, the implementation's signal is aborted. Pass request headers as the fourth `execute` argument when the HTTP surface should resolve Bearer credentials into `ctx.permit`.
 
 ```typescript
 const longTask = trail('report.generate', {

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -14,7 +14,10 @@ import {
 import type { TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
-import type { ActionResultContext } from '../build.js';
+import type {
+  ActionResultContext,
+  ResolveCliPermitFromToken,
+} from '../build.js';
 import { deriveCliCommands } from '../build.js';
 import type { AnyTrail, CliCommand } from '../command.js';
 import { devPermitPreset, permitPreset, tokenPreset } from '../flags.js';

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -17,11 +17,14 @@ import {
   Result,
   ValidationError,
   basePermitSchema,
+  collectAttachedTypedLayers as collectTypedLayers,
   deriveCliPath,
   deriveFields,
   executeTrail,
   filterSurfaceTrails,
   LAYER_FIELD_RESERVED_NAMES,
+  LAYER_FIELD_RESERVED_NAMES_KEBAB,
+  projectLayerFieldName,
   validateSurfaceTopo,
   withSurfaceLayerNames,
 } from '@ontrails/core';
@@ -716,32 +719,17 @@ interface LayerFlagProjection {
  * Collect every typed layer attached to a trail, in the same composition
  * order the executor uses (topo → surface → trail). Layers without an
  * `input` schema are skipped — they have nothing to project.
+ *
+ * Thin adapter over the surface-agnostic `collectAttachedTypedLayers`
+ * helper from `@ontrails/core` so the CLI continues to operate on a flat
+ * `readonly Layer[]` while every surface shares one collection rule.
  */
 const collectAttachedTypedLayers = (
   graph: Topo,
   t: AnyTrail,
   options?: DeriveCliCommandsOptions
-): readonly Layer[] => {
-  const layers: Layer[] = [];
-  for (const layer of graph.layers) {
-    if (layer.input !== undefined) {
-      layers.push(layer);
-    }
-  }
-  if (options?.layers) {
-    for (const layer of options.layers) {
-      if (layer.input !== undefined) {
-        layers.push(layer);
-      }
-    }
-  }
-  for (const layer of t.layers) {
-    if (layer.input !== undefined) {
-      layers.push(layer);
-    }
-  }
-  return layers;
-};
+): readonly Layer[] =>
+  collectTypedLayers(graph, t, options?.layers).map(({ layer }) => layer);
 
 /**
  * Convert a `Layer.name` (typically camelCase) into a kebab-case prefix
@@ -793,35 +781,33 @@ const projectSingleLayerFlags = (
   const routing = new Map<string, string>();
 
   for (const flag of toFlags(layerFields)) {
-    const camelKey = kebabToCamel(flag.name);
-    const collidesWithClaimed = claimedFlagNames.has(flag.name);
-    const collidesWithMeta = LAYER_FIELD_RESERVED_NAMES.has(camelKey);
-
-    if (!collidesWithClaimed && !collidesWithMeta) {
+    const projection = projectLayerFieldName(
+      layer.name,
+      flag.name,
+      flag.name,
+      `${layerKebab}-${flag.name}`,
+      claimedFlagNames,
+      LAYER_FIELD_RESERVED_NAMES_KEBAB
+    );
+    const claimedKebab = projection.claimedName;
+    const claimedCamel = kebabToCamel(claimedKebab);
+    const originalCamel = kebabToCamel(projection.routingTarget);
+    if (projection.renamed) {
+      const reason =
+        projection.reason === 'reserved-name'
+          ? `--${projection.originalName} collides with a CLI meta flag`
+          : `--${projection.originalName} collides with another flag`;
+      warnLayerFlagRenamed(
+        layer.name,
+        projection.originalName,
+        projection.claimedName,
+        reason
+      );
+      flags.push({ ...flag, name: claimedKebab });
+    } else {
       flags.push(flag);
-      claimedFlagNames.add(flag.name);
-      routing.set(camelKey, camelKey);
-      continue;
     }
-
-    const fallbackKebab = `${layerKebab}-${flag.name}`;
-    let renamedKebab = fallbackKebab;
-    let suffix = 2;
-    while (
-      claimedFlagNames.has(renamedKebab) ||
-      LAYER_FIELD_RESERVED_NAMES.has(kebabToCamel(renamedKebab))
-    ) {
-      renamedKebab = `${fallbackKebab}${suffix}`;
-      suffix += 1;
-    }
-    const renamedCamel = kebabToCamel(renamedKebab);
-    const reason = collidesWithMeta
-      ? `--${flag.name} collides with a CLI meta flag`
-      : `--${flag.name} collides with another flag`;
-    warnLayerFlagRenamed(layer.name, flag.name, renamedKebab, reason);
-    flags.push({ ...flag, name: renamedKebab });
-    claimedFlagNames.add(renamedKebab);
-    routing.set(renamedCamel, camelKey);
+    routing.set(claimedCamel, originalCamel);
   }
 
   return { flags, input: layerInput, layerName: layer.name, routing };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,7 +96,6 @@ export type {
   ActivationProvenanceCarrier,
   ActivationProvenanceSource,
 } from './activation-provenance.js';
-export { LAYER_FIELD_RESERVED_NAMES } from './internal/layer-projection.js';
 
 // Context factory
 export { createTrailContext, passthroughTrace } from './context.js';
@@ -354,6 +353,20 @@ export { validateEstablishedTopo } from './validate-established-topo.js';
 // Layer
 export { composeLayers } from './layer.js';
 export type { Layer, LayerInputSchema } from './layer.js';
+export {
+  collectAttachedTypedLayers,
+  LAYER_FIELD_RESERVED_NAMES,
+  LAYER_FIELD_RESERVED_NAMES_KEBAB,
+  projectLayerFieldName,
+} from './internal/layer-projection.js';
+export type {
+  AttachedLayerScope,
+  AttachedTypedLayer,
+  LayerFieldProjection,
+  LayerFieldRenameReason,
+  ProjectedLayerField,
+  RenamedLayerFieldProjection,
+} from './internal/layer-projection.js';
 
 // Derive
 export { deriveCliPath, deriveFields } from './derive.js';

--- a/packages/core/src/internal/layer-projection.ts
+++ b/packages/core/src/internal/layer-projection.ts
@@ -1,10 +1,30 @@
 /**
- * Shared vocabulary for projecting layer input fields onto surface parameters.
+ * Shared, surface-agnostic helpers for projecting typed layer `input` schemas
+ * onto a surface's native idiom.
  *
- * Layer input is authored once on `Layer.input`, then rendered by CLI, MCP, and
- * HTTP surfaces. Reserved names live here so a layer field that conflicts with
- * framework-owned surface parameters is renamed consistently everywhere.
+ * Layer projection has two halves:
+ *   1. **Collection** — walk the trail's effective layers (topo → surface →
+ *      trail) and keep only the ones that declare an `input` schema. These
+ *      are the layers a surface needs to project.
+ *   2. **Naming/collision policy** — when a layer field's projected name
+ *      collides with a name already claimed by the trail, by another layer,
+ *      or by a surface-reserved name, the field is renamed using the
+ *      deterministic `<layerName>-<originalField>` rule. The collision-detection
+ *      logic itself is surface-agnostic; the *shape* of the projected name
+ *      (kebab-case CLI flag, camelCase MCP parameter, HTTP request field)
+ *      stays per-surface.
+ *
+ * This module owns the surface-agnostic half. CLI/MCP/HTTP each layer their
+ * own projection on top: see `@ontrails/cli/build`, `@ontrails/mcp/build`,
+ * and `@ontrails/http/build`.
+ *
+ * @see TRL-473 for the CLI projection that introduced this contract.
+ * @see TRL-474 for the MCP and HTTP projections that lifted these helpers.
  */
+
+import type { Layer } from '../layer.js';
+import type { Topo } from '../topo.js';
+import type { AnyTrail } from '../trail.js';
 
 export const LAYER_FIELD_RESERVED_NAMES: ReadonlySet<string> = new Set([
   'all',
@@ -21,3 +41,152 @@ export const LAYER_FIELD_RESERVED_NAMES: ReadonlySet<string> = new Set([
   'trace',
   'watch',
 ]);
+
+const toKebabCase = (name: string): string =>
+  name.replaceAll(/[A-Z]/g, (ch) => `-${ch.toLowerCase()}`);
+
+export const LAYER_FIELD_RESERVED_NAMES_KEBAB: ReadonlySet<string> = new Set(
+  [...LAYER_FIELD_RESERVED_NAMES].map(toKebabCase)
+);
+
+// ---------------------------------------------------------------------------
+// Collection
+// ---------------------------------------------------------------------------
+
+/**
+ * Source of a typed layer attached to a trail.
+ *
+ * Surfaces may want to know whether a layer came from topo-, surface-, or
+ * trail-scope (e.g. for descriptive errors). The collection helper preserves
+ * this information so callers don't have to recompute it.
+ */
+export type AttachedLayerScope = 'topo' | 'surface' | 'trail';
+
+export interface AttachedTypedLayer {
+  readonly layer: Layer;
+  readonly scope: AttachedLayerScope;
+}
+
+/**
+ * Collect every typed layer attached to a trail in the same composition order
+ * the executor uses (topo → surface → trail). Layers without an `input`
+ * schema are skipped — they have nothing to project onto a surface.
+ *
+ * @param graph - The topo carrying topo-scope layers.
+ * @param trail - The trail whose effective layers we are projecting.
+ * @param surfaceLayers - Layers attached at surface scope (`options.layers`
+ *   on the surface builder).
+ */
+export const collectAttachedTypedLayers = (
+  graph: Topo,
+  trail: AnyTrail,
+  surfaceLayers?: readonly Layer[] | undefined
+): readonly AttachedTypedLayer[] => {
+  const layers: AttachedTypedLayer[] = [];
+  for (const layer of graph.layers) {
+    if (layer.input !== undefined) {
+      layers.push({ layer, scope: 'topo' });
+    }
+  }
+  if (surfaceLayers !== undefined) {
+    for (const layer of surfaceLayers) {
+      if (layer.input !== undefined) {
+        layers.push({ layer, scope: 'surface' });
+      }
+    }
+  }
+  for (const layer of trail.layers) {
+    if (layer.input !== undefined) {
+      layers.push({ layer, scope: 'trail' });
+    }
+  }
+  return layers;
+};
+
+// ---------------------------------------------------------------------------
+// Collision rename rule
+// ---------------------------------------------------------------------------
+
+/**
+ * Reason a layer field was renamed during projection.
+ *
+ * Surfaces map this onto their own warning/error idiom. CLI emits a stderr
+ * warning, while MCP/HTTP rely on the projected schema as the source of truth.
+ */
+export type LayerFieldRenameReason = 'reserved-name' | 'flag-collision';
+
+/**
+ * Outcome of projecting a single layer field's name.
+ *
+ * `claimedName` is the name the surface will publish to consumers; it is the
+ * field name when no collision was detected, or `<layerName>-<fieldName>` (or
+ * an analogous transformed form, depending on the surface's convention) when
+ * a collision required a rename. `routingTarget` is the original field name
+ * the value should be assigned back to inside the layer's runtime input.
+ */
+export interface LayerFieldProjection {
+  readonly claimedName: string;
+  readonly routingTarget: string;
+  readonly renamed: false;
+}
+
+export interface RenamedLayerFieldProjection {
+  readonly claimedName: string;
+  readonly routingTarget: string;
+  readonly renamed: true;
+  readonly originalName: string;
+  readonly reason: LayerFieldRenameReason;
+}
+
+export type ProjectedLayerField =
+  | LayerFieldProjection
+  | RenamedLayerFieldProjection;
+
+/**
+ * Apply the deterministic collision rename rule to a single projected layer
+ * field name.
+ *
+ * @param layerName - The layer's logical name (used as the rename prefix).
+ * @param originalName - The layer field's name as authored on its schema.
+ * @param projectedName - The candidate name in the surface's native idiom
+ *   (e.g. kebab-case for CLI, camelCase for MCP, request field for HTTP).
+ * @param renamedName - The fallback name applied when a collision is detected.
+ *   Surfaces compute this with their own casing rule.
+ * @param claimedNames - Names already taken by the trail's input or by
+ *   previous layer projections. Updated in place when a name is claimed.
+ * @param reservedNames - Framework-owned names that force a rename across
+ *   surface projections.
+ */
+export const projectLayerFieldName = (
+  _layerName: string,
+  originalName: string,
+  projectedName: string,
+  renamedName: string,
+  claimedNames: Set<string>,
+  reservedNames: ReadonlySet<string>
+): ProjectedLayerField => {
+  const collidesWithClaimed = claimedNames.has(projectedName);
+  const collidesWithReserved = reservedNames.has(projectedName);
+
+  if (!collidesWithClaimed && !collidesWithReserved) {
+    claimedNames.add(projectedName);
+    return {
+      claimedName: projectedName,
+      renamed: false,
+      routingTarget: originalName,
+    };
+  }
+
+  let claimedName = renamedName;
+  for (let suffix = 2; claimedNames.has(claimedName); suffix += 1) {
+    claimedName = `${renamedName}${suffix}`;
+  }
+  claimedNames.add(claimedName);
+  return {
+    claimedName,
+    originalName: projectedName,
+    reason: collidesWithReserved ? 'reserved-name' : 'flag-collision',
+    renamed: true,
+    routingTarget: originalName,
+  };
+};

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -88,9 +88,9 @@ const result = deriveHttpRoutes(graph, {
 with `visibility: 'internal'` stay hidden unless you include their exact trail
 ID intentionally.
 
-## AbortSignal propagation
+## Request context and abort propagation
 
-The `execute` function on each `HttpRouteDefinition` accepts an optional `abortSignal`. The Hono connector extracts `signal` from `c.req.raw` and forwards it as `abortSignal`, so client disconnects propagate into trail execution.
+The `execute` function on each `HttpRouteDefinition` accepts optional `requestId`, `abortSignal`, and request context arguments. HTTP adapters should pass the request's `AbortSignal` so client disconnects propagate into trail execution, and pass headers in the request context when Bearer auth should resolve into `ctx.permit`.
 
 ## `HttpRouteDefinition`
 
@@ -103,7 +103,7 @@ Each route definition produced by `deriveHttpRoutes` includes:
 | `trailId` | `string` | The trail ID this route was derived from |
 | `inputSource` | `'query' \| 'body'` | Where to read input |
 | `trail` | `Trail` | The original trail definition |
-| `execute` | `(input, requestId?, abortSignal?) => Promise<Result>` | Validates, layers, and runs the implementation |
+| `execute` | `(input, requestId?, abortSignal?, context?) => Promise<Result>` | Validates, layers, resolves request auth when configured, and runs the implementation |
 
 For GET routes on the Hono surface, repeated query keys are passed through as
 arrays (`?tag=one&tag=two` -> `{ tag: ['one', 'two'] }`) while a single

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, mock, test } from 'bun:test';
 
 import {
+  AuthError,
   InternalError,
+  LAYER_INPUTS_KEY,
   NotFoundError,
+  PermitError,
   Result,
   SURFACE_KEY,
   clearTraceSink,
@@ -414,6 +417,55 @@ describe('deriveHttpRoutes', () => {
         { notified: 'pay_1' },
       ]);
       expect(invoked).toEqual(['audit:pay_1', 'notify:pay_1']);
+    });
+
+    test('webhook execution partitions typed layer input and composes route layers', async () => {
+      const source = webhook('webhook.payment.received', {
+        parse: z.object({ paymentId: z.string() }),
+        path: '/webhooks/payment',
+      });
+      const captured: unknown[] = [];
+      const auditLayer: Layer = {
+        input: z.object({ auditMode: z.string() }),
+        name: 'audit',
+        wrap(_trail, impl) {
+          return async (input, ctx) => {
+            const all = ctx.extensions?.[LAYER_INPUTS_KEY] as
+              | Record<string, unknown>
+              | undefined;
+            captured.push(all?.['audit']);
+            return await impl(input, ctx);
+          };
+        },
+      };
+      let observedInput: unknown;
+      const receiver = trail('payment.receive', {
+        blaze: (input) => {
+          observedInput = input;
+          return Result.ok({ paymentId: input.paymentId });
+        },
+        input: z.object({ paymentId: z.string() }),
+        on: [source],
+        output: z.object({ paymentId: z.string() }),
+      });
+
+      const result = deriveHttpRoutes(topo('billing', { receiver }), {
+        layers: [auditLayer],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      const [route] = result.value;
+      const executed = await route?.execute({
+        auditMode: 'full',
+        paymentId: 'pay_1',
+      });
+
+      expect(executed?.isOk()).toBe(true);
+      expect(observedInput).toEqual({ paymentId: 'pay_1' });
+      expect(captured).toEqual([{ auditMode: 'full' }]);
     });
 
     test('merged webhook consumers share one activation fire ID per inbound request', async () => {
@@ -1270,6 +1322,179 @@ describe('deriveHttpRoutes', () => {
         return;
       }
       expect(result.value).toEqual({ source: 'override' });
+    });
+
+    test('resolves Authorization Bearer credentials into ctx.permit', async () => {
+      let observedPermit: TrailContext['permit'];
+      const protectedTrail = trail('permit.read', {
+        blaze: (_input, ctx) => {
+          observedPermit = ctx.permit;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        intent: 'read',
+        output: z.object({ ok: z.boolean() }),
+        permit: { scopes: ['thing:read'] },
+      });
+      const app = topo('permit-http', { protectedTrail });
+      const buildResult = deriveHttpRoutes(app, {
+        resolvePermit: ({ bearerToken }) =>
+          Result.ok(
+            bearerToken === 'good'
+              ? { id: 'user-1', scopes: ['thing:read'] }
+              : { id: 'user-1', scopes: [] }
+          ),
+      });
+
+      expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
+      const [route] = buildResult.value;
+      const result = await route?.execute({}, 'req-1', undefined, {
+        headers: { authorization: 'Bearer good' },
+      });
+
+      expect(result?.isOk()).toBe(true);
+      expect(observedPermit).toEqual({ id: 'user-1', scopes: ['thing:read'] });
+    });
+
+    test('missing Authorization on a protected route falls through to PermitError', async () => {
+      const protectedTrail = trail('permit.missing', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        intent: 'read',
+        permit: { scopes: ['thing:read'] },
+      });
+      const app = topo('permit-http', { protectedTrail });
+      const buildResult = deriveHttpRoutes(app, {
+        resolvePermit: () =>
+          Result.ok({ id: 'user-1', scopes: ['thing:read'] }),
+      });
+
+      expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
+      const [route] = buildResult.value;
+      const result = await route?.execute({});
+
+      expect(result?.isErr()).toBe(true);
+      if (!result?.isErr()) {
+        return;
+      }
+      expect(result.error).toBeInstanceOf(PermitError);
+    });
+
+    test('Bearer Authorization without a resolver falls through for public routes', async () => {
+      const app = topo('permit-http', { echoTrail });
+      const buildResult = deriveHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
+      const [route] = buildResult.value;
+      const result = await route?.execute(
+        { message: 'hello' },
+        'req-1',
+        undefined,
+        {
+          headers: { authorization: 'Bearer gateway-token' },
+        }
+      );
+
+      expect(result?.isOk()).toBe(true);
+      if (result?.isOk()) {
+        expect(result.value).toEqual({ reply: 'hello' });
+      }
+    });
+
+    test('Bearer Authorization without a resolver still lets protected routes fail at the permit gate', async () => {
+      const protectedTrail = trail('permit.no-resolver', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        intent: 'read',
+        permit: { scopes: ['thing:read'] },
+      });
+      const app = topo('permit-http', { protectedTrail });
+      const buildResult = deriveHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
+      const [route] = buildResult.value;
+      const result = await route?.execute({}, 'req-1', undefined, {
+        headers: { authorization: 'Bearer gateway-token' },
+      });
+
+      expect(result?.isErr()).toBe(true);
+      if (result?.isErr()) {
+        expect(result.error).toBeInstanceOf(PermitError);
+      }
+    });
+
+    test('malformed Authorization header fails before execution', async () => {
+      let invoked = false;
+      const protectedTrail = trail('permit.malformed', {
+        blaze: () => {
+          invoked = true;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        intent: 'read',
+        permit: { scopes: ['thing:read'] },
+      });
+      const app = topo('permit-http', { protectedTrail });
+      const buildResult = deriveHttpRoutes(app, {
+        resolvePermit: () =>
+          Result.ok({ id: 'user-1', scopes: ['thing:read'] }),
+      });
+
+      expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
+      const [route] = buildResult.value;
+      const result = await route?.execute({}, 'req-1', undefined, {
+        headers: { authorization: 'Basic nope' },
+      });
+
+      expect(result?.isErr()).toBe(true);
+      if (!result?.isErr()) {
+        return;
+      }
+      expect(result.error).toBeInstanceOf(AuthError);
+      expect(invoked).toBe(false);
+    });
+
+    test('resolved permit with missing scopes returns PermitError', async () => {
+      const protectedTrail = trail('permit.scope', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        intent: 'read',
+        permit: { scopes: ['thing:read'] },
+      });
+      const app = topo('permit-http', { protectedTrail });
+      const buildResult = deriveHttpRoutes(app, {
+        resolvePermit: () => Result.ok({ id: 'user-1', scopes: [] }),
+      });
+
+      expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
+      const [route] = buildResult.value;
+      const result = await route?.execute({}, 'req-1', undefined, {
+        headers: { authorization: 'Bearer weak' },
+      });
+
+      expect(result?.isErr()).toBe(true);
+      if (!result?.isErr()) {
+        return;
+      }
+      expect(result.error).toBeInstanceOf(PermitError);
     });
   });
 

--- a/packages/http/src/__tests__/layer-input-projection.test.ts
+++ b/packages/http/src/__tests__/layer-input-projection.test.ts
@@ -1,0 +1,438 @@
+/**
+ * TRL-474: Project typed layer input onto the HTTP surface.
+ *
+ * When a layer attached at trail/surface/topo scope declares an `input`
+ * schema, the HTTP route definition merges that schema into the published
+ * `inputSchema`, partitions the parsed request input into trail input vs.
+ * per-layer input, and routes layer values through
+ * `ctx.extensions[LAYER_INPUTS_KEY][layer.name]`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { LAYER_INPUTS_KEY, Result, topo, trail, webhook } from '@ontrails/core';
+import type { Implementation, Layer } from '@ontrails/core';
+import { z } from 'zod';
+
+import { deriveHttpRoutes } from '../build.js';
+import type { HttpRouteDefinition } from '../build.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const buildRoutes = (
+  ...args: Parameters<typeof deriveHttpRoutes>
+): readonly HttpRouteDefinition[] => {
+  const result = deriveHttpRoutes(...args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const requireRoute = (
+  routes: readonly HttpRouteDefinition[]
+): HttpRouteDefinition => {
+  const [route] = routes;
+  expect(route).toBeDefined();
+  if (!route) {
+    throw new Error('Expected at least one route');
+  }
+  return route;
+};
+
+interface InputBucket {
+  value: unknown;
+}
+
+const captureLayerInput = (
+  layerName: string,
+  schema: z.ZodType<unknown>,
+  bucket: InputBucket
+): Layer => ({
+  input: schema,
+  name: layerName,
+  wrap<I, O>(_t, impl: Implementation<I, O>): Implementation<I, O> {
+    return async (input, ctx) => {
+      const all = ctx.extensions?.[LAYER_INPUTS_KEY] as
+        | Record<string, unknown>
+        | undefined;
+      bucket.value = all?.[layerName];
+      return await impl(input, ctx);
+    };
+  },
+});
+
+const makeReadEcho = (overrides: { readonly layers?: readonly Layer[] } = {}) =>
+  trail('echo', {
+    blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+    input: z.object({ value: z.string() }),
+    intent: 'read',
+    output: z.object({ value: z.string() }),
+    ...(overrides.layers === undefined ? {} : { layers: overrides.layers }),
+  });
+
+const makeWriteCreate = (
+  overrides: { readonly layers?: readonly Layer[] } = {}
+) =>
+  trail('item.create', {
+    blaze: (input: { name: string }) =>
+      Result.ok({ id: '123', name: input.name }),
+    input: z.object({ name: z.string() }),
+    intent: 'write',
+    output: z.object({ id: z.string(), name: z.string() }),
+    ...(overrides.layers === undefined ? {} : { layers: overrides.layers }),
+  });
+
+interface JsonObjectSchema {
+  readonly type?: unknown;
+  readonly properties?: Record<string, unknown>;
+  readonly required?: readonly string[];
+}
+
+const asJsonObject = (value: unknown): JsonObjectSchema => {
+  expect(typeof value === 'object' && value !== null).toBe(true);
+  return value as JsonObjectSchema;
+};
+
+// ---------------------------------------------------------------------------
+// Schema projection — query (read) and body (write/destroy)
+// ---------------------------------------------------------------------------
+
+describe('TRL-474 HTTP layer input projection — schema merge', () => {
+  test('a typed trail-scope layer adds a property to the read route input schema', () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'trace',
+      z.object({ verbose: z.boolean() }),
+      bucket
+    );
+    const echo = makeReadEcho({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const route = requireRoute(buildRoutes(app));
+    expect(route.method).toBe('GET');
+    expect(route.inputSource).toBe('query');
+    const schema = asJsonObject(route.inputSchema);
+    const properties = schema.properties ?? {};
+    expect(Object.keys(properties)).toContain('value');
+    expect(Object.keys(properties)).toContain('verbose');
+    expect(schema.required ?? []).toContain('verbose');
+  });
+
+  test('a typed trail-scope layer adds a property to the write route input schema', () => {
+    const layer: Layer = {
+      input: z.object({ tenantId: z.string() }),
+      name: 'tenant',
+      wrap: (_t, impl) => impl,
+    };
+    const create = makeWriteCreate({ layers: [layer] });
+    const app = topo('app', { [create.id]: create });
+
+    const route = requireRoute(buildRoutes(app));
+    expect(route.method).toBe('POST');
+    expect(route.inputSource).toBe('body');
+    const schema = asJsonObject(route.inputSchema);
+    const properties = schema.properties ?? {};
+    expect(Object.keys(properties)).toContain('name');
+    expect(Object.keys(properties)).toContain('tenantId');
+  });
+
+  test('topo-scope layer schema appears on every route', () => {
+    const layer: Layer = {
+      input: z.object({ auditMode: z.enum(['off', 'full']) }),
+      name: 'audit',
+      wrap: (_t, impl) => impl,
+    };
+    const a = trail('alpha', {
+      blaze: () => Result.ok(1),
+      input: z.object({}),
+      intent: 'read',
+    });
+    const b = trail('beta', {
+      blaze: () => Result.ok(2),
+      input: z.object({}),
+      intent: 'write',
+    });
+    const app = topo('app', { [a.id]: a, [b.id]: b }, { layers: [layer] });
+
+    const routes = buildRoutes(app);
+    expect(routes).toHaveLength(2);
+    for (const route of routes) {
+      const schema = asJsonObject(route.inputSchema);
+      const properties = schema.properties ?? {};
+      expect(Object.keys(properties)).toContain('auditMode');
+    }
+  });
+
+  test('layers without an input schema do not change the published schema', () => {
+    const layer: Layer = {
+      name: 'noop',
+      wrap: (_t, impl) => impl,
+    };
+    const echo = makeReadEcho({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+    const baseline = makeReadEcho();
+    const baselineApp = topo('app', { [baseline.id]: baseline });
+
+    const withLayer = requireRoute(buildRoutes(app));
+    const baselineRoute = requireRoute(buildRoutes(baselineApp));
+
+    const propsWith = Object.keys(
+      asJsonObject(withLayer.inputSchema).properties ?? {}
+    );
+    const propsBaseline = Object.keys(
+      asJsonObject(baselineRoute.inputSchema).properties ?? {}
+    );
+    expect(new Set(propsWith)).toEqual(new Set(propsBaseline));
+    expect(withLayer.layerInputProjections ?? []).toHaveLength(0);
+  });
+
+  test('merged webhook routes publish layer input fields from every consumer', () => {
+    const source = webhook('webhook.payment.received', {
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/payment',
+    });
+    const auditLayer: Layer = {
+      input: z.object({ auditMode: z.enum(['off', 'full']) }),
+      name: 'audit',
+      wrap: (_t, impl) => impl,
+    };
+    const tenantLayer: Layer = {
+      input: z.object({ tenantId: z.string() }),
+      name: 'tenant',
+      wrap: (_t, impl) => impl,
+    };
+    const audit = trail('payment.audit', {
+      blaze: (input: { paymentId: string }) =>
+        Result.ok({ audited: input.paymentId }),
+      input: z.object({ paymentId: z.string() }),
+      layers: [auditLayer],
+      on: [source],
+      output: z.object({ audited: z.string() }),
+    });
+    const notify = trail('payment.notify', {
+      blaze: (input: { paymentId: string }) =>
+        Result.ok({ notified: input.paymentId }),
+      input: z.object({ paymentId: z.string() }),
+      layers: [tenantLayer],
+      on: [source],
+      output: z.object({ notified: z.string() }),
+    });
+    const app = topo('billing', { audit, notify });
+
+    const route = requireRoute(buildRoutes(app));
+    const schema = asJsonObject(route.inputSchema);
+    const properties = schema.properties ?? {};
+
+    expect(Object.keys(properties)).toEqual(
+      expect.arrayContaining(['paymentId', 'auditMode', 'tenantId'])
+    );
+    expect(schema.required ?? []).toEqual(
+      expect.arrayContaining(['paymentId', 'auditMode', 'tenantId'])
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime routing — query and body
+// ---------------------------------------------------------------------------
+
+describe('TRL-474 HTTP layer input projection — runtime routing', () => {
+  test('parsed query parameters are routed to the layer at runtime (read)', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'trace',
+      z.object({ verbose: z.boolean() }),
+      bucket
+    );
+    const echo = makeReadEcho({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const route = requireRoute(buildRoutes(app));
+    const result = await route.execute({ value: 'hi', verbose: true });
+
+    expect(result.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ verbose: true });
+  });
+
+  test('parsed body fields are routed to the layer at runtime (write)', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'tenant',
+      z.object({ tenantId: z.string() }),
+      bucket
+    );
+    const create = makeWriteCreate({ layers: [layer] });
+    const app = topo('app', { [create.id]: create });
+
+    const route = requireRoute(buildRoutes(app));
+    const result = await route.execute({
+      name: 'thing',
+      tenantId: 'acme',
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ tenantId: 'acme' });
+  });
+
+  test('layer input does not pollute the trail input', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'trace',
+      z.object({ verbose: z.boolean() }),
+      bucket
+    );
+    let observedInput: unknown;
+    const recorded = trail('rec', {
+      blaze: (input: { value: string }) => {
+        observedInput = input;
+        return Result.ok({ value: input.value });
+      },
+      input: z.object({ value: z.string() }),
+      intent: 'read',
+      layers: [layer],
+      output: z.object({ value: z.string() }),
+    });
+    const app = topo('app', { [recorded.id]: recorded });
+
+    const route = requireRoute(buildRoutes(app));
+    const result = await route.execute({ value: 'hi', verbose: true });
+
+    expect(result.isOk()).toBe(true);
+    expect(observedInput).toEqual({ value: 'hi' });
+  });
+
+  test('topo-scope layer routes runtime input through ctx.extensions', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'audit',
+      z.object({ auditMode: z.enum(['off', 'full']) }),
+      bucket
+    );
+    const echo = makeReadEcho();
+    const app = topo('app', { [echo.id]: echo }, { layers: [layer] });
+
+    const route = requireRoute(buildRoutes(app));
+    const result = await route.execute({ auditMode: 'full', value: 'hi' });
+
+    expect(result.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ auditMode: 'full' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Collisions
+// ---------------------------------------------------------------------------
+
+describe('TRL-474 HTTP layer input projection — collisions', () => {
+  test('a layer field colliding with a trail field is renamed and routed', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const collidingLayer = captureLayerInput(
+      'collide',
+      z.object({ value: z.boolean() }),
+      bucket
+    );
+    const echo = trail('echo', {
+      blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+      input: z.object({ value: z.string() }),
+      intent: 'read',
+      layers: [collidingLayer],
+      output: z.object({ value: z.string() }),
+    });
+    const app = topo('app', { [echo.id]: echo });
+
+    const route = requireRoute(buildRoutes(app));
+    const schema = asJsonObject(route.inputSchema);
+    const properties = schema.properties ?? {};
+    // Trail's `value` parameter remains unchanged.
+    expect(Object.keys(properties)).toContain('value');
+    // Layer's colliding `value` is renamed under the layer's name (camelCase).
+    expect(Object.keys(properties)).toContain('collideValue');
+
+    const result = await route.execute({ collideValue: true, value: 'hi' });
+    expect(result.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ value: true });
+  });
+
+  test('a layer field colliding with a reserved route field is renamed and routed', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const reservedLayer = captureLayerInput(
+      'audit',
+      z.object({ all: z.boolean() }),
+      bucket
+    );
+    const echo = makeReadEcho({ layers: [reservedLayer] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const route = requireRoute(buildRoutes(app));
+    const schema = asJsonObject(route.inputSchema);
+    const properties = schema.properties ?? {};
+    expect(Object.keys(properties)).not.toContain('all');
+    expect(Object.keys(properties)).toContain('auditAll');
+
+    const result = await route.execute({ auditAll: true, value: 'hi' });
+    expect(result.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ all: true });
+  });
+
+  test('a renamed layer field gets a deterministic suffix when the fallback also collides', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const authLayer = captureLayerInput(
+      'auth',
+      z.object({ token: z.string() }),
+      bucket
+    );
+    const echo = trail('echo', {
+      blaze: (input: { authToken: string; token: string; value: string }) =>
+        Result.ok({ value: input.value }),
+      input: z.object({
+        authToken: z.string(),
+        token: z.string(),
+        value: z.string(),
+      }),
+      intent: 'read',
+      layers: [authLayer],
+      output: z.object({ value: z.string() }),
+    });
+    const app = topo('app', { [echo.id]: echo });
+
+    const route = requireRoute(buildRoutes(app));
+    const schema = asJsonObject(route.inputSchema);
+    const properties = schema.properties ?? {};
+    expect(Object.keys(properties)).toContain('authToken');
+    expect(Object.keys(properties)).toContain('authToken2');
+
+    const result = await route.execute({
+      authToken: 'trail-auth',
+      authToken2: 'layer-auth',
+      token: 'trail-token',
+      value: 'hi',
+    });
+    expect(result.isOk()).toBe(true);
+    expect(bucket.value).toEqual({ token: 'layer-auth' });
+  });
+
+  test('the rename rule is deterministic across builds', () => {
+    const buildOnce = () => {
+      const collidingLayer: Layer = {
+        input: z.object({ value: z.boolean() }),
+        name: 'collide',
+        wrap: (_t, impl) => impl,
+      };
+      const echo = trail('echo', {
+        blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+        input: z.object({ value: z.string() }),
+        intent: 'read',
+        layers: [collidingLayer],
+        output: z.object({ value: z.string() }),
+      });
+      const app = topo('app', { [echo.id]: echo });
+      const route = requireRoute(buildRoutes(app));
+      const schema = asJsonObject(route.inputSchema);
+      return new Set(Object.keys(schema.properties ?? {}));
+    };
+    expect(buildOnce()).toEqual(buildOnce());
+  });
+});

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -7,14 +7,18 @@
  */
 
 import {
+  AuthError,
   Result,
   ValidationError,
   buildActivationProvenanceTraceAttrs,
+  collectAttachedTypedLayers,
   executeTrail,
   filterSurfaceTrails,
   getActivationWherePredicate,
   getTraceSink,
+  LAYER_FIELD_RESERVED_NAMES,
   matchesTrailPattern,
+  projectLayerFieldName,
   TRACE_CONTEXT_KEY,
   traceContextFromRecord,
   validateInput,
@@ -24,11 +28,14 @@ import {
   writeActivationTraceRecord,
   withActivationProvenance,
   withSurfaceLayerNames,
+  zodToJsonSchema,
 } from '@ontrails/core';
 import type {
   ActivationEntry,
   ActivationProvenance,
   ActivationSource,
+  AttachedTypedLayer,
+  BasePermit,
   BaseSurfaceOptions,
   Layer,
   ResourceOverrideMap,
@@ -56,7 +63,29 @@ export interface DeriveHttpRoutesOptions extends BaseSurfaceOptions {
     | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
+  readonly resolvePermit?: ResolveHttpPermit | undefined;
 }
+
+export type HttpHeaderSource =
+  | Headers
+  | Readonly<Record<string, string | readonly string[] | undefined>>;
+
+export interface HttpExecutionContext {
+  readonly headers?: HttpHeaderSource | undefined;
+}
+
+export interface ResolveHttpPermitInput {
+  readonly authorization?: string | undefined;
+  readonly bearerToken?: string | undefined;
+  readonly headers?: HttpHeaderSource | undefined;
+  readonly requestId?: string | undefined;
+}
+
+export type ResolveHttpPermit = (
+  input: ResolveHttpPermitInput
+) =>
+  | Promise<Result<BasePermit | null | undefined, Error>>
+  | Result<BasePermit | null | undefined, Error>;
 
 export interface HttpRouteDefinition {
   readonly method: HttpMethod;
@@ -64,6 +93,28 @@ export interface HttpRouteDefinition {
   readonly trailId: string;
   readonly inputSource: InputSource;
   readonly trail: Trail<unknown, unknown, unknown>;
+  /**
+   * JSON Schema for the merged request input (trail input + projected layer
+   * input fields). Empty/undefined when the trail declares no input and no
+   * typed layer is attached. Surface adapters and OpenAPI generators read
+   * this to build the published request shape.
+   *
+   * @see TRL-474.
+   */
+  readonly inputSchema?: Record<string, unknown> | undefined;
+  /**
+   * Per-layer projections describing the parameter names the route accepts
+   * for typed layers and the routing target back onto each layer's input
+   * schema. Empty when the trail has no typed layer attached.
+   *
+   * Surface adapters use this to partition the parsed request into
+   * `{ trailInput, layerInputs }` before invoking `execute`. The `execute`
+   * function published below performs the same partitioning for callers
+   * that pass the full merged record straight through.
+   *
+   * @see TRL-474.
+   */
+  readonly layerInputProjections?: readonly HttpLayerInputProjection[];
   readonly parseWebhookInput?:
     | ((rawPayload: unknown) => Result<unknown, Error>)
     | undefined;
@@ -83,11 +134,14 @@ export interface HttpRouteDefinition {
    * @param abortSignal - Optional AbortSignal from the HTTP request. When provided,
    *   it takes final precedence over any context factory signal, allowing
    *   client-initiated cancellation to propagate into trail execution.
+   * @param context - Optional request context such as headers. When supplied,
+   *   HTTP Bearer credentials can be resolved into `ctx.permit`.
    */
   readonly execute: (
     input: unknown,
     requestId?: string | undefined,
-    abortSignal?: AbortSignal | undefined
+    abortSignal?: AbortSignal | undefined,
+    context?: HttpExecutionContext | undefined
   ) => Promise<Result<unknown, Error>>;
 }
 
@@ -106,7 +160,7 @@ const derivePath = (basePath: string, trailId: string): string => {
   return `${base}/${segments}`;
 };
 
-/** Build per-request context overrides with the HTTP trailhead marker. */
+/** Build per-request context overrides with the HTTP surface marker. */
 const withHttpTrailhead = (
   requestId: string | undefined,
   layers: readonly Layer[]
@@ -116,6 +170,72 @@ const withHttpTrailhead = (
     layers,
     requestId === undefined ? {} : { requestId }
   );
+
+const readHeader = (
+  headers: HttpHeaderSource | undefined,
+  name: string
+): string | undefined => {
+  if (headers === undefined) {
+    return undefined;
+  }
+  if (headers instanceof Headers) {
+    return headers.get(name) ?? undefined;
+  }
+  const needle = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== needle || value === undefined) {
+      continue;
+    }
+    return typeof value === 'string' ? value : value[0];
+  }
+  return undefined;
+};
+
+const parseBearerAuthorization = (
+  authorization: string | undefined
+): Result<string | undefined, Error> => {
+  if (authorization === undefined || authorization.length === 0) {
+    return Result.ok();
+  }
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  const token = match?.[1]?.trim();
+  if (token === undefined || token.length === 0) {
+    return Result.err(
+      new AuthError('Malformed Authorization header; expected Bearer token', {
+        context: { code: 'invalid_authorization_header' },
+      })
+    );
+  }
+  return Result.ok(token);
+};
+
+const resolveHttpPermit = async (
+  options: DeriveHttpRoutesOptions,
+  request: HttpExecutionContext | undefined,
+  requestId: string | undefined
+): Promise<Result<BasePermit | undefined, Error>> => {
+  const authorization = readHeader(request?.headers, 'authorization');
+  const token = parseBearerAuthorization(authorization);
+  if (token.isErr()) {
+    return token;
+  }
+  if (token.value === undefined) {
+    return Result.ok();
+  }
+  if (options.resolvePermit === undefined) {
+    return Result.ok();
+  }
+  const resolved = await options.resolvePermit({
+    authorization,
+    bearerToken: token.value,
+    headers: request?.headers,
+    requestId,
+  });
+  if (resolved.isErr()) {
+    return resolved;
+  }
+  return Result.ok(resolved.value ?? undefined);
+};
 
 const createWebhookActivationFireId = (): string => {
   const randomUUID = globalThis.crypto?.randomUUID;
@@ -237,6 +357,255 @@ const withWebhookActivation = (
 };
 
 // ---------------------------------------------------------------------------
+// Layer input projection (TRL-474)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-layer projection onto an HTTP route's request input.
+ *
+ * `routing` maps the parameter name a consumer sees on the request (a query
+ * key for `intent: 'read'`, a body field for write/destroy) to the authored
+ * field name on the layer's input schema. When no rename was required the
+ * two are the same; on collision the parameter name carries the layer
+ * prefix while the routing target preserves the original field.
+ */
+export interface HttpLayerInputProjection {
+  readonly layerName: string;
+  /** parameterName → originalFieldName for this layer. */
+  readonly routing: ReadonlyMap<string, string>;
+  /** Fragment merged into the route's `inputSchema.properties`. */
+  readonly properties: Readonly<Record<string, unknown>>;
+  /** Field names appended to the route's `inputSchema.required` list. */
+  readonly required: readonly string[];
+}
+
+const buildHttpRenameTarget = (
+  layerName: string,
+  originalName: string
+): string => {
+  if (originalName.length === 0) {
+    return layerName;
+  }
+  const [head, ...rest] = originalName;
+  if (head === undefined) {
+    return layerName;
+  }
+  return `${layerName}${head.toUpperCase()}${rest.join('')}`;
+};
+
+const isJsonObjectSchema = (
+  value: unknown
+): value is { properties?: Record<string, unknown>; required?: string[] } =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readRequiredFields = (value: unknown): readonly string[] => {
+  if (!isJsonObjectSchema(value) || !Array.isArray(value.required)) {
+    return [];
+  }
+  return value.required.every((field) => typeof field === 'string')
+    ? value.required
+    : [];
+};
+
+const projectHttpLayerInput = (
+  layer: Layer,
+  claimedNames: Set<string>
+): HttpLayerInputProjection => {
+  if (layer.input === undefined) {
+    return {
+      layerName: layer.name,
+      properties: {},
+      required: [],
+      routing: new Map(),
+    };
+  }
+
+  const layerSchema = zodToJsonSchema(layer.input);
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  const routing = new Map<string, string>();
+
+  if (
+    !isJsonObjectSchema(layerSchema) ||
+    layerSchema.properties === undefined
+  ) {
+    return {
+      layerName: layer.name,
+      properties,
+      required,
+      routing,
+    };
+  }
+
+  const requiredSet = new Set<string>(layerSchema.required);
+  for (const [fieldName, fieldSchema] of Object.entries(
+    layerSchema.properties
+  )) {
+    const renamed = buildHttpRenameTarget(layer.name, fieldName);
+    const projection = projectLayerFieldName(
+      layer.name,
+      fieldName,
+      fieldName,
+      renamed,
+      claimedNames,
+      LAYER_FIELD_RESERVED_NAMES
+    );
+    properties[projection.claimedName] = fieldSchema;
+    if (requiredSet.has(fieldName)) {
+      required.push(projection.claimedName);
+    }
+    routing.set(projection.claimedName, projection.routingTarget);
+  }
+
+  return { layerName: layer.name, properties, required, routing };
+};
+
+interface HttpInputProjection {
+  readonly schema: Record<string, unknown> | undefined;
+  readonly projections: readonly HttpLayerInputProjection[];
+}
+
+const projectHttpInputSchema = (
+  trail: Trail<unknown, unknown, unknown>,
+  attachedLayers: readonly AttachedTypedLayer[]
+): HttpInputProjection => {
+  const baseSchema = zodToJsonSchema(trail.input);
+  if (attachedLayers.length === 0) {
+    return { projections: [], schema: baseSchema };
+  }
+
+  const baseProperties =
+    isJsonObjectSchema(baseSchema) && baseSchema.properties !== undefined
+      ? baseSchema.properties
+      : undefined;
+  const baseRequired =
+    isJsonObjectSchema(baseSchema) && Array.isArray(baseSchema.required)
+      ? baseSchema.required
+      : [];
+
+  const claimedNames = new Set<string>(
+    baseProperties === undefined ? [] : Object.keys(baseProperties)
+  );
+
+  const mergedProperties: Record<string, unknown> = {
+    ...baseProperties,
+  };
+  const mergedRequired = [...baseRequired];
+  const projections: HttpLayerInputProjection[] = [];
+
+  for (const { layer } of attachedLayers) {
+    const projection = projectHttpLayerInput(layer, claimedNames);
+    if (projection.routing.size === 0) {
+      continue;
+    }
+    Object.assign(mergedProperties, projection.properties);
+    mergedRequired.push(...projection.required);
+    projections.push(projection);
+  }
+
+  if (projections.length === 0) {
+    return { projections: [], schema: baseSchema };
+  }
+
+  const mergedSchema: Record<string, unknown> = isJsonObjectSchema(baseSchema)
+    ? { ...baseSchema, properties: mergedProperties, type: 'object' }
+    : { properties: mergedProperties, type: 'object' };
+  if (mergedRequired.length > 0) {
+    mergedSchema['required'] = mergedRequired;
+  } else if ('required' in mergedSchema) {
+    delete mergedSchema['required'];
+  }
+
+  return { projections, schema: mergedSchema };
+};
+
+const mergeHttpInputSchemas = (
+  left: Record<string, unknown> | undefined,
+  right: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined => {
+  if (left === undefined) {
+    return right;
+  }
+  if (right === undefined) {
+    return left;
+  }
+  const leftProperties =
+    isJsonObjectSchema(left) && left.properties !== undefined
+      ? left.properties
+      : undefined;
+  const rightProperties =
+    isJsonObjectSchema(right) && right.properties !== undefined
+      ? right.properties
+      : undefined;
+  const merged: Record<string, unknown> = {
+    ...left,
+    ...right,
+    properties: {
+      ...leftProperties,
+      ...rightProperties,
+    },
+    type: 'object',
+  };
+  const required = [
+    ...new Set([...readRequiredFields(left), ...readRequiredFields(right)]),
+  ];
+  if (required.length > 0) {
+    merged['required'] = required;
+  } else {
+    delete merged['required'];
+  }
+  return merged;
+};
+
+/**
+ * Partition a parsed request input into the trail input plus per-layer
+ * inputs, using each layer's routing table.
+ *
+ * Layer-projected parameter names are stripped from the trail input so the
+ * trail's schema validation only ever sees its own fields. A layer that
+ * received no parameters is omitted from `layerInputs` so consumers can
+ * cleanly assert which layers were activated by the request.
+ */
+const partitionHttpInput = (
+  input: unknown,
+  projections: readonly HttpLayerInputProjection[]
+): {
+  readonly trailInput: unknown;
+  readonly layerInputs: Record<string, unknown>;
+} => {
+  if (projections.length === 0 || !isJsonObjectSchema(input)) {
+    return { layerInputs: {}, trailInput: input };
+  }
+  const record = input as Record<string, unknown>;
+  const claimedKeys = new Set<string>();
+  const layerInputs: Record<string, unknown> = {};
+  for (const projection of projections) {
+    const layerInput: Record<string, unknown> = {};
+    let received = false;
+    for (const [paramName, fieldName] of projection.routing) {
+      claimedKeys.add(paramName);
+      const value = record[paramName];
+      if (value === undefined) {
+        continue;
+      }
+      layerInput[fieldName] = value;
+      received = true;
+    }
+    if (received) {
+      layerInputs[projection.layerName] = layerInput;
+    }
+  }
+  const trailInput: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (claimedKeys.has(key)) {
+      continue;
+    }
+    trailInput[key] = value;
+  }
+  return { layerInputs, trailInput };
+};
+
+// ---------------------------------------------------------------------------
 // Execute factory
 // ---------------------------------------------------------------------------
 
@@ -251,19 +620,36 @@ const createExecute =
     graph: Topo,
     t: Trail<unknown, unknown, unknown>,
     layers: readonly Layer[],
-    options: DeriveHttpRoutesOptions
+    options: DeriveHttpRoutesOptions,
+    layerProjections: readonly HttpLayerInputProjection[]
   ): HttpRouteDefinition['execute'] =>
-  (input, requestId, abortSignal) =>
-    executeTrail(t, input, {
+  async (input, requestId, abortSignal, request) => {
+    const { trailInput, layerInputs } = partitionHttpInput(
+      input,
+      layerProjections
+    );
+    const permitResolution = await resolveHttpPermit(
+      options,
+      request,
+      requestId
+    );
+    if (permitResolution.isErr()) {
+      return Result.err(permitResolution.error);
+    }
+    const permit = permitResolution.value;
+    return await executeTrail(t, trailInput, {
       abortSignal,
       configValues: options.configValues,
       createContext: options.createContext,
       ctx: withHttpTrailhead(requestId, layers),
+      ...(Object.keys(layerInputs).length === 0 ? {} : { layerInputs }),
+      ...(permit === undefined ? {} : { permit }),
       resources: options.resources,
       surfaceLayers: layers,
       topo: graph,
       topoLayers: graph.layers,
     });
+  };
 
 /**
  * Internal executor signature used for shared webhook source fan-out.
@@ -277,6 +663,7 @@ type WebhookConsumerExecute = (
   input: unknown,
   requestId: string | undefined,
   abortSignal: AbortSignal | undefined,
+  request: HttpExecutionContext | undefined,
   activationFireId: string
 ) => Promise<Result<unknown, Error>>;
 
@@ -287,9 +674,10 @@ const createWebhookConsumerExecute =
     activationEntry: ActivationEntry,
     source: WebhookSource,
     layers: readonly Layer[],
-    options: DeriveHttpRoutesOptions
+    options: DeriveHttpRoutesOptions,
+    layerProjections: readonly HttpLayerInputProjection[]
   ): WebhookConsumerExecute =>
-  async (input, requestId, abortSignal, activationFireId) => {
+  async (input, requestId, abortSignal, request, activationFireId) => {
     const predicate = getActivationWherePredicate(activationEntry.where);
     if (predicate !== undefined) {
       let shouldRun = false;
@@ -317,11 +705,26 @@ const createWebhookConsumerExecute =
       'activation.webhook',
       'ok'
     );
-    return await executeTrail(t, input, {
+    const { trailInput, layerInputs } = partitionHttpInput(
+      input,
+      layerProjections
+    );
+    const permitResolution = await resolveHttpPermit(
+      options,
+      request,
+      requestId
+    );
+    if (permitResolution.isErr()) {
+      return Result.err(permitResolution.error);
+    }
+    const permit = permitResolution.value;
+    return await executeTrail(t, trailInput, {
       abortSignal,
       configValues: options.configValues,
       createContext: options.createContext,
       ctx: withWebhookActivation(activation, requestId, traceContext, layers),
+      ...(Object.keys(layerInputs).length === 0 ? {} : { layerInputs }),
+      ...(permit === undefined ? {} : { permit }),
       resources: options.resources,
       surfaceLayers: layers,
       topo: graph,
@@ -337,11 +740,12 @@ const createWebhookConsumerExecute =
  */
 const createWebhookExecute =
   (consumerExecute: WebhookConsumerExecute): HttpRouteDefinition['execute'] =>
-  async (input, requestId, abortSignal) =>
+  async (input, requestId, abortSignal, request) =>
     await consumerExecute(
       input,
       requestId,
       abortSignal,
+      request,
       createWebhookActivationFireId()
     );
 
@@ -409,9 +813,27 @@ const buildRoute = (
 ): HttpRouteDefinition => {
   const method = deriveMethod(trail);
   const path = derivePath(basePath, trail.id);
+  const attachedLayers = collectAttachedTypedLayers(
+    graph,
+    trail,
+    options.layers
+  );
+  const inputProjection = projectHttpInputSchema(trail, attachedLayers);
   return {
-    execute: createExecute(graph, trail, layers, options),
+    execute: createExecute(
+      graph,
+      trail,
+      layers,
+      options,
+      inputProjection.projections
+    ),
+    ...(inputProjection.schema === undefined
+      ? {}
+      : { inputSchema: inputProjection.schema }),
     inputSource: deriveHttpInputSource(method),
+    ...(inputProjection.projections.length === 0
+      ? {}
+      : { layerInputProjections: inputProjection.projections }),
     method,
     path,
     trail,
@@ -528,13 +950,20 @@ const buildWebhookRoute = (
   if (source.isErr()) {
     return source;
   }
+  const attachedLayers = collectAttachedTypedLayers(
+    graph,
+    trail,
+    options.layers
+  );
+  const inputProjection = projectHttpInputSchema(trail, attachedLayers);
   const consumerExecute = createWebhookConsumerExecute(
     graph,
     trail,
     activation,
     source.value,
     layers,
-    options
+    options,
+    inputProjection.projections
   );
   const consumerInvalidRecorder = createWebhookInvalidRecorder(
     graph,
@@ -545,7 +974,13 @@ const buildWebhookRoute = (
     [WEBHOOK_CONSUMERS]: [consumerExecute],
     [WEBHOOK_INVALID_RECORDERS]: [consumerInvalidRecorder],
     execute: createWebhookExecute(consumerExecute),
+    ...(inputProjection.schema === undefined
+      ? {}
+      : { inputSchema: inputProjection.schema }),
     inputSource: 'webhook',
+    ...(inputProjection.projections.length === 0
+      ? {}
+      : { layerInputProjections: inputProjection.projections }),
     method: source.value.method,
     parseWebhookInput: createWebhookInputParser(source.value),
     path: normalizeSourcePath(basePath, source.value.path),
@@ -687,10 +1122,15 @@ const mergeWebhookRoutes = (
     ...existing,
     [WEBHOOK_CONSUMERS]: consumers,
     [WEBHOOK_INVALID_RECORDERS]: recorders,
+    inputSchema: mergeHttpInputSchemas(existing.inputSchema, route.inputSchema),
+    layerInputProjections: [
+      ...(existing.layerInputProjections ?? []),
+      ...(route.layerInputProjections ?? []),
+    ],
     ...(recordWebhookInvalidFanOut === undefined
       ? {}
       : { recordWebhookInvalid: recordWebhookInvalidFanOut }),
-    async execute(input, requestId, abortSignal) {
+    async execute(input, requestId, abortSignal, request) {
       // One activation fire ID per inbound webhook request, shared across every
       // fan-out consumer so observability can correlate them as siblings of a
       // single activation root.
@@ -706,6 +1146,7 @@ const mergeWebhookRoutes = (
           input,
           requestId,
           abortSignal,
+          request,
           activationFireId
         );
         if (result.isErr()) {

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -2,7 +2,12 @@
 export {
   deriveHttpRoutes,
   type DeriveHttpRoutesOptions,
+  type HttpExecutionContext,
+  type HttpHeaderSource,
+  type HttpLayerInputProjection,
   type HttpRouteDefinition,
+  type ResolveHttpPermit,
+  type ResolveHttpPermitInput,
 } from './build.js';
 export {
   deriveHttpInputSource,

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -699,6 +699,190 @@ describe('deriveMcpTools', () => {
         source: 'override',
       });
     });
+
+    test('session permit from MCP extra lands in ctx.permit', async () => {
+      let observedPermit: TrailContext['permit'];
+      const protectedTrail = trail('permit.read', {
+        blaze: (_input, ctx) => {
+          observedPermit = ctx.permit;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+        permit: { scopes: ['thing:read'] },
+      });
+      const tool = requireOnlyTool(
+        buildTools(topo('myapp', { protectedTrail }))
+      );
+
+      const result = await tool.handler(
+        {},
+        { permit: { id: 'user-1', scopes: ['thing:read'] } }
+      );
+
+      expect(result.isError ?? false).toBe(false);
+      expect(observedPermit).toEqual({ id: 'user-1', scopes: ['thing:read'] });
+    });
+
+    test('MCP Bearer credentials resolve through the configured permit resolver', async () => {
+      let seenSession: string | undefined;
+      let observedPermit: TrailContext['permit'];
+      const protectedTrail = trail('permit.token', {
+        blaze: (_input, ctx) => {
+          observedPermit = ctx.permit;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+        permit: { scopes: ['thing:read'] },
+      });
+      const tool = requireOnlyTool(
+        buildTools(topo('myapp', { protectedTrail }), {
+          resolvePermit: ({ bearerToken, sessionId }) => {
+            seenSession = sessionId;
+            return Result.ok(
+              bearerToken === 'good'
+                ? { id: 'user-1', scopes: ['thing:read'] }
+                : { id: 'user-1', scopes: [] }
+            );
+          },
+        })
+      );
+
+      const result = await tool.handler(
+        {},
+        { authorization: 'Bearer good', sessionId: 'session-1' }
+      );
+
+      expect(result.isError ?? false).toBe(false);
+      expect(seenSession).toBe('session-1');
+      expect(observedPermit).toEqual({ id: 'user-1', scopes: ['thing:read'] });
+    });
+
+    test('MCP Bearer credentials without a resolver do not block public tools', async () => {
+      const publicTrail = trail('permit.public', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const tool = requireOnlyTool(buildTools(topo('myapp', { publicTrail })));
+
+      const result = await tool.handler(
+        {},
+        { authorization: 'Bearer gateway-token' }
+      );
+
+      expect(result.isError ?? false).toBe(false);
+      expect(parseJsonContent(result.content[0])).toEqual({ ok: true });
+    });
+
+    test('MCP Bearer credentials without a resolver fall through to the permit gate', async () => {
+      const protectedTrail = trail('permit.unresolved-token', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+        permit: { scopes: ['thing:read'] },
+      });
+      const tool = requireOnlyTool(
+        buildTools(topo('myapp', { protectedTrail }))
+      );
+
+      const result = await tool.handler(
+        {},
+        { authorization: 'Bearer gateway-token' }
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('No permit provided');
+    });
+
+    test('per-call MCP permit override wins over session authorization', async () => {
+      let observedPermit: TrailContext['permit'];
+      const protectedTrail = trail('permit.override', {
+        blaze: (_input, ctx) => {
+          observedPermit = ctx.permit;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+        permit: { scopes: ['thing:read'] },
+      });
+      const tool = requireOnlyTool(
+        buildTools(topo('myapp', { protectedTrail }), {
+          resolvePermit: () =>
+            Result.ok({ id: 'session-user', scopes: ['thing:read'] }),
+        })
+      );
+
+      const result = await tool.handler(
+        {},
+        {
+          authorization: 'Bearer session-token',
+          permit: { id: 'override-user', scopes: ['thing:read'] },
+        }
+      );
+
+      expect(result.isError ?? false).toBe(false);
+      expect(observedPermit).toEqual({
+        id: 'override-user',
+        scopes: ['thing:read'],
+      });
+    });
+
+    test('missing MCP credentials on a protected tool returns a permit error response', async () => {
+      const protectedTrail = trail('permit.missing', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        permit: { scopes: ['thing:read'] },
+      });
+      const tool = requireOnlyTool(
+        buildTools(topo('myapp', { protectedTrail }))
+      );
+
+      const result = await tool.handler({}, noExtra);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('No permit provided');
+    });
+
+    test('malformed MCP authorization fails before execution', async () => {
+      let invoked = false;
+      const protectedTrail = trail('permit.malformed', {
+        blaze: () => {
+          invoked = true;
+          return Result.ok({ ok: true });
+        },
+        input: z.object({}),
+        permit: { scopes: ['thing:read'] },
+      });
+      const tool = requireOnlyTool(
+        buildTools(topo('myapp', { protectedTrail }))
+      );
+
+      const result = await tool.handler({}, { authorization: 'Basic nope' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('Malformed MCP authorization');
+      expect(invoked).toBe(false);
+    });
+
+    test('resolved MCP permit with missing scopes returns a permit error response', async () => {
+      const protectedTrail = trail('permit.scope', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        permit: { scopes: ['thing:read'] },
+      });
+      const tool = requireOnlyTool(
+        buildTools(topo('myapp', { protectedTrail }), {
+          resolvePermit: () => Result.ok({ id: 'user-1', scopes: [] }),
+        })
+      );
+
+      const result = await tool.handler({}, { authorization: 'Bearer weak' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('Missing scopes');
+    });
   });
 
   describe('blob outputs', () => {

--- a/packages/mcp/src/__tests__/layer-input-projection.test.ts
+++ b/packages/mcp/src/__tests__/layer-input-projection.test.ts
@@ -1,0 +1,380 @@
+/**
+ * TRL-474: Project typed layer input onto the MCP surface.
+ *
+ * When a layer attached at trail/surface/topo scope declares an `input`
+ * schema, the MCP tool definition merges that schema into the published
+ * `inputSchema`, parses values from the incoming `args`, and routes them
+ * into the layer's runtime input via
+ * `ctx.extensions[LAYER_INPUTS_KEY][layer.name]`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { LAYER_INPUTS_KEY, Result, topo, trail } from '@ontrails/core';
+import type { Implementation, Layer } from '@ontrails/core';
+import { z } from 'zod';
+
+import { deriveMcpTools } from '../build.js';
+import type { McpExtra, McpToolDefinition } from '../build.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const buildTools = (
+  ...args: Parameters<typeof deriveMcpTools>
+): readonly McpToolDefinition[] => {
+  const result = deriveMcpTools(...args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const requireTool = (
+  tools: readonly McpToolDefinition[]
+): McpToolDefinition => {
+  const [tool] = tools;
+  expect(tool).toBeDefined();
+  if (!tool) {
+    throw new Error('Expected at least one tool');
+  }
+  return tool;
+};
+
+interface InputBucket {
+  value: unknown;
+}
+
+const captureLayerInput = (
+  layerName: string,
+  schema: z.ZodType<unknown>,
+  bucket: InputBucket
+): Layer => ({
+  input: schema,
+  name: layerName,
+  wrap<I, O>(_t, impl: Implementation<I, O>): Implementation<I, O> {
+    return async (input, ctx) => {
+      const all = ctx.extensions?.[LAYER_INPUTS_KEY] as
+        | Record<string, unknown>
+        | undefined;
+      bucket.value = all?.[layerName];
+      return await impl(input, ctx);
+    };
+  },
+});
+
+const makeEchoTrail = (
+  overrides: { readonly layers?: readonly Layer[] } = {}
+) =>
+  trail('echo', {
+    blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+    input: z.object({ value: z.string() }),
+    output: z.object({ value: z.string() }),
+    ...(overrides.layers === undefined ? {} : { layers: overrides.layers }),
+  });
+
+const emptyExtra: McpExtra = {};
+
+interface JsonObjectSchema {
+  readonly type?: unknown;
+  readonly properties?: Record<string, unknown>;
+  readonly required?: readonly string[];
+}
+
+const asJsonObject = (value: unknown): JsonObjectSchema => {
+  expect(typeof value === 'object' && value !== null).toBe(true);
+  return value as JsonObjectSchema;
+};
+
+// ---------------------------------------------------------------------------
+// Schema projection
+// ---------------------------------------------------------------------------
+
+describe('TRL-474 MCP layer input projection — schema merge', () => {
+  test('a typed trail-scope layer adds a property to the tool input schema', () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'trace',
+      z.object({ verbose: z.boolean() }),
+      bucket
+    );
+    const echo = makeEchoTrail({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const tool = requireTool(buildTools(app));
+    const schema = asJsonObject(tool.inputSchema);
+    const properties = schema.properties ?? {};
+    expect(Object.keys(properties)).toContain('value');
+    expect(Object.keys(properties)).toContain('verbose');
+    expect(schema.required ?? []).toContain('verbose');
+  });
+
+  test('surface-scope layer schema appears on every tool', () => {
+    const layer: Layer = {
+      input: z.object({ tenantId: z.string() }),
+      name: 'tenant',
+      wrap: (_t, impl) => impl,
+    };
+    const a = trail('alpha', {
+      blaze: () => Result.ok(1),
+      input: z.object({}),
+    });
+    const b = trail('beta', {
+      blaze: () => Result.ok(2),
+      input: z.object({}),
+    });
+    const app = topo('app', { [a.id]: a, [b.id]: b });
+
+    const tools = buildTools(app, { layers: [layer] });
+    expect(tools).toHaveLength(2);
+    for (const tool of tools) {
+      const schema = asJsonObject(tool.inputSchema);
+      const properties = schema.properties ?? {};
+      expect(Object.keys(properties)).toContain('tenantId');
+    }
+  });
+
+  test('topo-scope layer schema appears on every tool', () => {
+    const layer: Layer = {
+      input: z.object({ auditMode: z.enum(['off', 'full']) }),
+      name: 'audit',
+      wrap: (_t, impl) => impl,
+    };
+    const a = trail('alpha', {
+      blaze: () => Result.ok(1),
+      input: z.object({}),
+    });
+    const b = trail('beta', {
+      blaze: () => Result.ok(2),
+      input: z.object({}),
+    });
+    const app = topo('app', { [a.id]: a, [b.id]: b }, { layers: [layer] });
+
+    const tools = buildTools(app);
+    expect(tools).toHaveLength(2);
+    for (const tool of tools) {
+      const schema = asJsonObject(tool.inputSchema);
+      const properties = schema.properties ?? {};
+      expect(Object.keys(properties)).toContain('auditMode');
+    }
+  });
+
+  test('layers without an input schema do not change the published schema', () => {
+    const layer: Layer = {
+      name: 'noop',
+      wrap: (_t, impl) => impl,
+    };
+    const echo = makeEchoTrail({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+    const echoBaseline = makeEchoTrail();
+    const baselineApp = topo('app', { [echoBaseline.id]: echoBaseline });
+
+    const withLayer = requireTool(buildTools(app));
+    const baseline = requireTool(buildTools(baselineApp));
+
+    const propsWith = Object.keys(
+      asJsonObject(withLayer.inputSchema).properties ?? {}
+    );
+    const propsBaseline = Object.keys(
+      asJsonObject(baseline.inputSchema).properties ?? {}
+    );
+    expect(new Set(propsWith)).toEqual(new Set(propsBaseline));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime routing
+// ---------------------------------------------------------------------------
+
+describe('TRL-474 MCP layer input projection — runtime routing', () => {
+  test('parsed layer parameters are routed to the layer at runtime', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'trace',
+      z.object({ verbose: z.boolean() }),
+      bucket
+    );
+    const echo = makeEchoTrail({ layers: [layer] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const tool = requireTool(buildTools(app));
+    const result = await tool.handler(
+      { value: 'hi', verbose: true },
+      emptyExtra
+    );
+
+    expect(result.isError ?? false).toBe(false);
+    expect(bucket.value).toEqual({ verbose: true });
+  });
+
+  test('layer input does not pollute the trail input', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'trace',
+      z.object({ verbose: z.boolean() }),
+      bucket
+    );
+    let observedInput: unknown;
+    const recorded = trail('rec', {
+      blaze: (input: { value: string }) => {
+        observedInput = input;
+        return Result.ok({ value: input.value });
+      },
+      input: z.object({ value: z.string() }),
+      layers: [layer],
+      output: z.object({ value: z.string() }),
+    });
+    const app = topo('app', { [recorded.id]: recorded });
+
+    const tool = requireTool(buildTools(app));
+    const result = await tool.handler(
+      { value: 'hi', verbose: true },
+      emptyExtra
+    );
+
+    expect(result.isError ?? false).toBe(false);
+    expect(observedInput).toEqual({ value: 'hi' });
+  });
+
+  test('topo-scope layer routes runtime input through ctx.extensions', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const layer = captureLayerInput(
+      'audit',
+      z.object({ auditMode: z.enum(['off', 'full']) }),
+      bucket
+    );
+    const echo = makeEchoTrail();
+    const app = topo('app', { [echo.id]: echo }, { layers: [layer] });
+
+    const tool = requireTool(buildTools(app));
+    const result = await tool.handler(
+      { auditMode: 'full', value: 'hi' },
+      emptyExtra
+    );
+
+    expect(result.isError ?? false).toBe(false);
+    expect(bucket.value).toEqual({ auditMode: 'full' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Collisions
+// ---------------------------------------------------------------------------
+
+describe('TRL-474 MCP layer input projection — collisions', () => {
+  test('a layer field colliding with a trail field is renamed and routed', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const collidingLayer = captureLayerInput(
+      'collide',
+      z.object({ value: z.boolean() }),
+      bucket
+    );
+    const echo = trail('echo', {
+      blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+      input: z.object({ value: z.string() }),
+      layers: [collidingLayer],
+      output: z.object({ value: z.string() }),
+    });
+    const app = topo('app', { [echo.id]: echo });
+
+    const tool = requireTool(buildTools(app));
+    const schema = asJsonObject(tool.inputSchema);
+    const properties = schema.properties ?? {};
+    // Trail's `value` parameter remains.
+    expect(Object.keys(properties)).toContain('value');
+    // Layer's `value` is renamed under the layer's name (camelCase).
+    expect(Object.keys(properties)).toContain('collideValue');
+
+    const result = await tool.handler(
+      { collideValue: true, value: 'hi' },
+      emptyExtra
+    );
+    expect(result.isError ?? false).toBe(false);
+    expect(bucket.value).toEqual({ value: true });
+  });
+
+  test('a layer field colliding with a reserved tool field is renamed and routed', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const reservedLayer = captureLayerInput(
+      'audit',
+      z.object({ all: z.boolean() }),
+      bucket
+    );
+    const echo = makeEchoTrail({ layers: [reservedLayer] });
+    const app = topo('app', { [echo.id]: echo });
+
+    const tool = requireTool(buildTools(app));
+    const schema = asJsonObject(tool.inputSchema);
+    const properties = schema.properties ?? {};
+    expect(Object.keys(properties)).not.toContain('all');
+    expect(Object.keys(properties)).toContain('auditAll');
+
+    const result = await tool.handler(
+      { auditAll: true, value: 'hi' },
+      emptyExtra
+    );
+    expect(result.isError ?? false).toBe(false);
+    expect(bucket.value).toEqual({ all: true });
+  });
+
+  test('a renamed layer field gets a deterministic suffix when the fallback also collides', async () => {
+    const bucket: InputBucket = { value: undefined };
+    const authLayer = captureLayerInput(
+      'auth',
+      z.object({ token: z.string() }),
+      bucket
+    );
+    const echo = trail('echo', {
+      blaze: (input: { authToken: string; token: string; value: string }) =>
+        Result.ok({ value: input.value }),
+      input: z.object({
+        authToken: z.string(),
+        token: z.string(),
+        value: z.string(),
+      }),
+      layers: [authLayer],
+      output: z.object({ value: z.string() }),
+    });
+    const app = topo('app', { [echo.id]: echo });
+
+    const tool = requireTool(buildTools(app));
+    const schema = asJsonObject(tool.inputSchema);
+    const properties = schema.properties ?? {};
+    expect(Object.keys(properties)).toContain('authToken');
+    expect(Object.keys(properties)).toContain('authToken2');
+
+    const result = await tool.handler(
+      {
+        authToken: 'trail-auth',
+        authToken2: 'layer-auth',
+        token: 'trail-token',
+        value: 'hi',
+      },
+      emptyExtra
+    );
+    expect(result.isError ?? false).toBe(false);
+    expect(bucket.value).toEqual({ token: 'layer-auth' });
+  });
+
+  test('the rename rule is deterministic across builds', () => {
+    const buildOnce = () => {
+      const collidingLayer: Layer = {
+        input: z.object({ value: z.boolean() }),
+        name: 'collide',
+        wrap: (_t, impl) => impl,
+      };
+      const echo = trail('echo', {
+        blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+        input: z.object({ value: z.string() }),
+        layers: [collidingLayer],
+        output: z.object({ value: z.string() }),
+      });
+      const app = topo('app', { [echo.id]: echo });
+      const tool = requireTool(buildTools(app));
+      const schema = asJsonObject(tool.inputSchema);
+      return new Set(Object.keys(schema.properties ?? {}));
+    };
+    expect(buildOnce()).toEqual(buildOnce());
+  });
+});

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -7,13 +7,17 @@
  */
 
 import {
+  AuthError,
   Result,
   ValidationError,
+  collectAttachedTypedLayers,
   deriveStructuredTrailExamples,
   executeTrail,
   filterSurfaceTrails,
   isBlobRef,
   isTrailsError,
+  LAYER_FIELD_RESERVED_NAMES,
+  projectLayerFieldName,
   projectSurfaceError,
   toBlobRefDescriptor,
   validateSurfaceTopo,
@@ -21,6 +25,8 @@ import {
   zodToJsonSchema,
 } from '@ontrails/core';
 import type {
+  AttachedTypedLayer,
+  BasePermit,
   BaseSurfaceOptions,
   BlobRef,
   Layer,
@@ -50,7 +56,20 @@ export interface DeriveMcpToolsOptions extends BaseSurfaceOptions {
     | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
+  readonly resolvePermit?: ResolveMcpPermit | undefined;
 }
+
+export interface ResolveMcpPermitInput {
+  readonly authorization?: string | undefined;
+  readonly bearerToken?: string | undefined;
+  readonly sessionId?: string | undefined;
+}
+
+export type ResolveMcpPermit = (
+  input: ResolveMcpPermitInput
+) =>
+  | Promise<Result<BasePermit | null | undefined, Error>>
+  | Result<BasePermit | null | undefined, Error>;
 
 export interface McpToolDefinition {
   readonly _meta?: Record<string, unknown> | undefined;
@@ -68,11 +87,14 @@ export interface McpToolDefinition {
 }
 
 export interface McpExtra {
+  readonly authorization?: string | undefined;
   readonly progressToken?: string | number | undefined;
   readonly sendProgress?:
     | ((current: number, total: number) => Promise<void>)
     | undefined;
   readonly abortSignal?: AbortSignal | undefined;
+  readonly permit?: BasePermit | undefined;
+  readonly sessionId?: string | undefined;
 }
 
 export interface McpToolResult {
@@ -408,6 +430,226 @@ const toStructuredContent = (
 };
 
 // ---------------------------------------------------------------------------
+// Layer input projection (TRL-474)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-layer projection onto an MCP tool's input schema.
+ *
+ * `routing` maps the parameter name a consumer sees on the tool to the
+ * authored field name on the layer's input schema. When no rename was
+ * required the two are the same; on collision the parameter name carries
+ * the layer prefix while the routing target preserves the original field.
+ */
+interface McpLayerInputProjection {
+  readonly layerName: string;
+  /** parameterName → originalFieldName for this layer. */
+  readonly routing: ReadonlyMap<string, string>;
+  /** Fragment merged into the top-level input schema's `properties`. */
+  readonly properties: Readonly<Record<string, unknown>>;
+  /** Field names appended to the top-level `required` list. */
+  readonly required: readonly string[];
+}
+
+/**
+ * Build the camelCase rename target for a layer field collision.
+ *
+ * The CLI projection uses `kebab-case` (`<layerName>-<field>`); MCP exposes
+ * fields as JSON properties so the corresponding shape is camelCase
+ * (`<layerName><FieldCapitalized>`). The shared collision policy lives in
+ * `projectLayerFieldName`; this helper just supplies the surface-specific
+ * fallback name.
+ */
+const buildMcpRenameTarget = (
+  layerName: string,
+  originalName: string
+): string => {
+  if (originalName.length === 0) {
+    return layerName;
+  }
+  const [head, ...rest] = originalName;
+  if (head === undefined) {
+    return layerName;
+  }
+  return `${layerName}${head.toUpperCase()}${rest.join('')}`;
+};
+
+const isJsonObjectSchema = (
+  value: unknown
+): value is { properties?: Record<string, unknown>; required?: string[] } =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Project a single layer's input schema into MCP-shaped property and
+ * required fragments, applying the deterministic collision rename rule.
+ */
+const projectMcpLayerInput = (
+  layer: Layer,
+  claimedNames: Set<string>
+): McpLayerInputProjection => {
+  if (layer.input === undefined) {
+    return {
+      layerName: layer.name,
+      properties: {},
+      required: [],
+      routing: new Map(),
+    };
+  }
+
+  const layerSchema = zodToJsonSchema(layer.input);
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  const routing = new Map<string, string>();
+
+  if (
+    !isJsonObjectSchema(layerSchema) ||
+    layerSchema.properties === undefined
+  ) {
+    return {
+      layerName: layer.name,
+      properties,
+      required,
+      routing,
+    };
+  }
+
+  const requiredSet = new Set<string>(layerSchema.required);
+  for (const [fieldName, fieldSchema] of Object.entries(
+    layerSchema.properties
+  )) {
+    const renamed = buildMcpRenameTarget(layer.name, fieldName);
+    const projection = projectLayerFieldName(
+      layer.name,
+      fieldName,
+      fieldName,
+      renamed,
+      claimedNames,
+      LAYER_FIELD_RESERVED_NAMES
+    );
+    properties[projection.claimedName] = fieldSchema;
+    if (requiredSet.has(fieldName)) {
+      required.push(projection.claimedName);
+    }
+    routing.set(projection.claimedName, projection.routingTarget);
+  }
+
+  return { layerName: layer.name, properties, required, routing };
+};
+
+interface McpInputProjection {
+  readonly schema: Record<string, unknown>;
+  readonly projections: readonly McpLayerInputProjection[];
+}
+
+/**
+ * Merge typed layer input schemas into the trail's input schema.
+ *
+ * Returns the merged input schema published on the MCP tool plus the
+ * per-layer routing tables consumed by the handler when partitioning
+ * incoming parameters.
+ */
+const projectMcpInputSchema = (
+  trail: Trail<unknown, unknown, unknown>,
+  attachedLayers: readonly AttachedTypedLayer[]
+): McpInputProjection => {
+  const baseSchema = zodToJsonSchema(trail.input);
+  if (attachedLayers.length === 0) {
+    return { projections: [], schema: baseSchema };
+  }
+
+  const baseProperties =
+    isJsonObjectSchema(baseSchema) && baseSchema.properties !== undefined
+      ? baseSchema.properties
+      : undefined;
+  const baseRequired =
+    isJsonObjectSchema(baseSchema) && Array.isArray(baseSchema.required)
+      ? baseSchema.required
+      : [];
+
+  const claimedNames = new Set<string>(
+    baseProperties === undefined ? [] : Object.keys(baseProperties)
+  );
+
+  const mergedProperties: Record<string, unknown> = {
+    ...baseProperties,
+  };
+  const mergedRequired = [...baseRequired];
+  const projections: McpLayerInputProjection[] = [];
+
+  for (const { layer } of attachedLayers) {
+    const projection = projectMcpLayerInput(layer, claimedNames);
+    if (projection.routing.size === 0) {
+      continue;
+    }
+    Object.assign(mergedProperties, projection.properties);
+    mergedRequired.push(...projection.required);
+    projections.push(projection);
+  }
+
+  if (projections.length === 0) {
+    return { projections: [], schema: baseSchema };
+  }
+
+  const mergedSchema: Record<string, unknown> = isJsonObjectSchema(baseSchema)
+    ? { ...baseSchema, properties: mergedProperties, type: 'object' }
+    : { properties: mergedProperties, type: 'object' };
+  if (mergedRequired.length > 0) {
+    mergedSchema['required'] = mergedRequired;
+  } else if ('required' in mergedSchema) {
+    delete mergedSchema['required'];
+  }
+
+  return { projections, schema: mergedSchema };
+};
+
+/**
+ * Partition a parsed MCP `args` record into the trail input plus per-layer
+ * inputs, using each layer's routing table.
+ *
+ * Layer-projected parameter names are stripped from the trail input so the
+ * trail's schema validation only ever sees its own fields. A layer that
+ * received no parameters is omitted from `layerInputs` so consumers can
+ * cleanly assert which layers were activated by the request.
+ */
+const partitionMcpArgs = (
+  args: Record<string, unknown>,
+  projections: readonly McpLayerInputProjection[]
+): {
+  readonly trailInput: Record<string, unknown>;
+  readonly layerInputs: Record<string, unknown>;
+} => {
+  if (projections.length === 0) {
+    return { layerInputs: {}, trailInput: { ...args } };
+  }
+  const claimedKeys = new Set<string>();
+  const layerInputs: Record<string, unknown> = {};
+  for (const projection of projections) {
+    const layerInput: Record<string, unknown> = {};
+    let received = false;
+    for (const [paramName, fieldName] of projection.routing) {
+      claimedKeys.add(paramName);
+      const value = args[paramName];
+      if (value === undefined) {
+        continue;
+      }
+      layerInput[fieldName] = value;
+      received = true;
+    }
+    if (received) {
+      layerInputs[projection.layerName] = layerInput;
+    }
+  }
+  const trailInput: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (claimedKeys.has(key)) {
+      continue;
+    }
+    trailInput[key] = value;
+  }
+  return { layerInputs, trailInput };
+};
+
+// ---------------------------------------------------------------------------
 // Handler factory
 // ---------------------------------------------------------------------------
 
@@ -436,7 +678,7 @@ const mcpError = (error: Error): McpToolResult => {
   };
 };
 
-/** Add the MCP trailhead marker while preserving any existing context extras. */
+/** Add the MCP surface marker while preserving any existing context extras. */
 const withMcpTrailhead = (
   progressCb: TrailContextInit['progress'],
   layers: readonly Layer[]
@@ -447,24 +689,82 @@ const withMcpTrailhead = (
     progressCb === undefined ? {} : { progress: progressCb }
   );
 
+const parseBearerAuthorization = (
+  authorization: string | undefined
+): Result<string | undefined, Error> => {
+  if (authorization === undefined || authorization.length === 0) {
+    return Result.ok();
+  }
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  const token = match?.[1]?.trim();
+  if (token === undefined || token.length === 0) {
+    return Result.err(
+      new AuthError('Malformed MCP authorization; expected Bearer token', {
+        context: { code: 'invalid_authorization_header' },
+      })
+    );
+  }
+  return Result.ok(token);
+};
+
+const resolveMcpPermit = async (
+  options: DeriveMcpToolsOptions,
+  extra: McpExtra
+): Promise<Result<BasePermit | undefined, Error>> => {
+  if (extra.permit !== undefined) {
+    return Result.ok(extra.permit);
+  }
+  const token = parseBearerAuthorization(extra.authorization);
+  if (token.isErr()) {
+    return token;
+  }
+  if (token.value === undefined) {
+    return Result.ok();
+  }
+  if (options.resolvePermit === undefined) {
+    return Result.ok();
+  }
+  const resolved = await options.resolvePermit({
+    authorization: extra.authorization,
+    bearerToken: token.value,
+    sessionId: extra.sessionId,
+  });
+  if (resolved.isErr()) {
+    return resolved;
+  }
+  return Result.ok(resolved.value ?? undefined);
+};
+
 const createHandler =
   (
     graph: Topo,
     t: Trail<unknown, unknown, unknown>,
     layers: readonly Layer[],
     options: DeriveMcpToolsOptions,
-    wrapAsData: boolean
+    wrapAsData: boolean,
+    layerProjections: readonly McpLayerInputProjection[]
   ): ((
     args: Record<string, unknown>,
     extra: McpExtra
   ) => Promise<McpToolResult>) =>
   async (args, extra): Promise<McpToolResult> => {
     const progressCb = createMcpProgressCallback(extra);
-    const result = await executeTrail(t, args, {
+    const { trailInput, layerInputs } = partitionMcpArgs(
+      args,
+      layerProjections
+    );
+    const permitResolution = await resolveMcpPermit(options, extra);
+    if (permitResolution.isErr()) {
+      return mcpError(permitResolution.error);
+    }
+    const permit = permitResolution.value;
+    const result = await executeTrail(t, trailInput, {
       abortSignal: extra.abortSignal,
       configValues: options.configValues,
       createContext: options.createContext,
       ctx: withMcpTrailhead(progressCb, layers),
+      ...(Object.keys(layerInputs).length === 0 ? {} : { layerInputs }),
+      ...(permit === undefined ? {} : { permit }),
       resources: options.resources,
       surfaceLayers: layers,
       topo: graph,
@@ -560,6 +860,12 @@ const buildToolDefinition = (
   const annotations =
     Object.keys(rawAnnotations).length > 0 ? rawAnnotations : undefined;
   const projection = buildOutputSchemaProjection(trail);
+  const attachedLayers = collectAttachedTypedLayers(
+    graph,
+    trail,
+    options.layers
+  );
+  const inputProjection = projectMcpInputSchema(trail, attachedLayers);
   return {
     _meta: buildMeta(trail),
     annotations,
@@ -569,9 +875,10 @@ const buildToolDefinition = (
       trail,
       layers,
       options,
-      projection?.wrapAsData ?? false
+      projection?.wrapAsData ?? false,
+      inputProjection.projections
     ),
-    inputSchema: zodToJsonSchema(trail.input),
+    inputSchema: inputProjection.schema,
     name: deriveToolName(graph.name, trail.id),
     outputSchema: projection?.schema,
     trailId: trail.id,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -9,6 +9,8 @@ export {
   type McpToolErrorMeta,
   type McpContent,
   type McpExtra,
+  type ResolveMcpPermit,
+  type ResolveMcpPermitInput,
 } from './build.js';
 
 // Tool naming

--- a/packages/mcp/src/surface.ts
+++ b/packages/mcp/src/surface.ts
@@ -15,7 +15,7 @@ import type {
   TrailContextInit,
 } from '@ontrails/core';
 
-import type { McpToolDefinition } from './build.js';
+import type { McpToolDefinition, ResolveMcpPermit } from './build.js';
 import { deriveMcpTools } from './build.js';
 import { connectStdio } from './stdio.js';
 
@@ -31,6 +31,7 @@ export interface CreateServerOptions extends BaseSurfaceOptions {
   readonly layers?: readonly Layer[] | undefined;
   readonly name?: string | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
+  readonly resolvePermit?: ResolveMcpPermit | undefined;
   readonly version?: string | undefined;
 }
 
@@ -105,6 +106,16 @@ const createMcpServer = (
 
       const args = (request.params.arguments ?? {}) as Record<string, unknown>;
       const progressToken = request.params._meta?.progressToken;
+      const { authInfo } = requestExtra as {
+        readonly authInfo?:
+          | {
+              readonly accessToken?: string | undefined;
+              readonly sessionId?: string | undefined;
+              readonly token?: string | undefined;
+            }
+          | undefined;
+      };
+      const authorizationToken = authInfo?.accessToken ?? authInfo?.token;
 
       const sendProgress =
         progressToken === undefined
@@ -122,8 +133,14 @@ const createMcpServer = (
 
       const extra = {
         abortSignal: requestExtra.signal,
+        ...(authorizationToken === undefined
+          ? {}
+          : { authorization: `Bearer ${authorizationToken}` }),
         progressToken,
         sendProgress,
+        ...(authInfo?.sessionId === undefined
+          ? {}
+          : { sessionId: authInfo.sessionId }),
       };
 
       const result = await tool.handler(args, extra);
@@ -157,6 +174,7 @@ export const createServer = (
     include: options.include,
     intent: options.intent,
     layers: options.layers,
+    resolvePermit: options.resolvePermit,
     resources: options.resources,
     validate: options.validate,
   });


### PR DESCRIPTION
## Summary
- Projects typed layer input schemas onto MCP and HTTP surfaces.
- Lifts shared layer collection and field projection helpers into core so CLI, MCP, and HTTP use one naming rule.
- Fixes MCP, HTTP, and webhook execution to forward permits, layer inputs, topo-scope layers, and surface-scope layers explicitly.

## Details
MCP merges projected layer fields into the tool input schema and partitions inbound args into `trailInput` and `layerInputs` before execution. HTTP uses the same projection and partitioning model for query/body parsed records and exposes route metadata for OpenAPI adapters. Both surfaces can resolve bearer credentials through caller-supplied `resolvePermit` hooks, then pass the resulting permit into the shared execution path. Webhook consumers now use the same typed-layer partitioning and request context instead of bypassing the new execution shape. Collision handling reuses the core projection helper, including numeric suffixes when the fallback name also collides.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-474. Closes Phase 7 (Layer Evolution typed model).
