### PR TITLE
feat(warden): flag legacy layer imports

### DIFF
--- a/.changeset/trl-476-warden-legacy-layer-rules.md
+++ b/.changeset/trl-476-warden-legacy-layer-rules.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/warden': minor
+---
+
+Add one warden rule coaching against the removed legacy layer API. `no-legacy-layer-imports` (error) flags any source-string reference to `authLayer`, `autoIterateLayer`, or `dateShortcutsLayer` and points the developer at the migration paths (CLI surface derivation for pagination/date-shortcuts; intrinsic permit enforcement for auth). Allow-list covers the migration notes in `packages/cli/src/{pagination,date-shortcuts}.ts` and the rule's own files. The rule is classified `lifecycle: temporary` with a `retireWhen` string tying it to the legacy layer migration window. Trail count bumps 45 → 46.

--- a/packages/warden/src/__tests__/no-legacy-layer-imports.test.ts
+++ b/packages/warden/src/__tests__/no-legacy-layer-imports.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from 'bun:test';
+
+import { noLegacyLayerImports } from '../rules/no-legacy-layer-imports.js';
+
+const RULE_NAME = 'no-legacy-layer-imports';
+
+describe('no-legacy-layer-imports', () => {
+  test('flags `authLayer` references in committed source', () => {
+    const code = [
+      "import { authLayer } from '@ontrails/permits';",
+      '',
+      'export const layers = [authLayer()];',
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/apps/example/src/cli.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe(RULE_NAME);
+    expect(diagnostics[0]?.severity).toBe('error');
+    expect(diagnostics[0]?.line).toBe(1);
+    expect(diagnostics[0]?.message).toContain("Legacy layer 'authLayer'");
+    expect(diagnostics[0]?.message).toContain('TRL-475');
+    expect(diagnostics[0]?.message).toContain(
+      'docs/adr/drafts/20260409-layer-evolution.md'
+    );
+  });
+
+  test('flags `autoIterateLayer` references in committed source', () => {
+    const code = [
+      "import { autoIterateLayer } from '@ontrails/cli';",
+      '',
+      'export const layers = [autoIterateLayer()];',
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/apps/example/src/runner.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain(
+      "Legacy layer 'autoIterateLayer'"
+    );
+    expect(diagnostics[0]?.message).toContain('TRL-476');
+    expect(diagnostics[0]?.message).toContain('TRL-469');
+  });
+
+  test('flags `dateShortcutsLayer` references in committed source', () => {
+    const code = [
+      "import { dateShortcutsLayer } from '@ontrails/cli';",
+      '',
+      'export const layers = [dateShortcutsLayer()];',
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/apps/example/src/runner.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain(
+      "Legacy layer 'dateShortcutsLayer'"
+    );
+    expect(diagnostics[0]?.message).toContain('TRL-476');
+    expect(diagnostics[0]?.message).toContain('TRL-470');
+  });
+
+  test('reports the earliest legacy reference when multiple appear', () => {
+    const code = [
+      '// migration note',
+      "import { autoIterateLayer } from '@ontrails/cli';",
+      "import { authLayer } from '@ontrails/permits';",
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/apps/example/src/runner.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.line).toBe(2);
+    expect(diagnostics[0]?.message).toContain(
+      "Legacy layer 'autoIterateLayer'"
+    );
+  });
+
+  test('clean source files produce no diagnostics', () => {
+    const code = [
+      "import { tokenPreset } from '@ontrails/cli';",
+      '',
+      'export const presets = [tokenPreset()];',
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/apps/example/src/cli.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not flag legacy names embedded in longer identifiers', () => {
+    const code = [
+      'type authLayerConfig = { enabled: boolean };',
+      'const withoutauthLayer = true;',
+      'const legacy_authLayer = true;',
+      'const autoIterateLayerShim = () => undefined;',
+      'const dateShortcutsLayer$adapter = () => undefined;',
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/apps/example/src/runner.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not fire on the CLI pagination module migration note', () => {
+    const code = [
+      '/** Earlier betas exposed an `autoIterateLayer` that ... */',
+      'export const paginate = () => undefined;',
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/packages/cli/src/pagination.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not fire on the CLI date-shortcuts module migration note', () => {
+    const code = [
+      '/** Earlier betas exposed a `dateShortcutsLayer` ... */',
+      'export const expand = () => undefined;',
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/packages/cli/src/date-shortcuts.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not fire on the rule implementation file itself', () => {
+    const code = [
+      '// implementation references authLayer / autoIterateLayer / dateShortcutsLayer',
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/packages/warden/src/rules/no-legacy-layer-imports.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not fire on Warden rule metadata', () => {
+    const code = [
+      "'no-legacy-layer-imports': {",
+      "  invariant: 'authLayer / autoIterateLayer / dateShortcutsLayer stay removed',",
+      '},',
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/packages/warden/src/rules/metadata.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not fire on its rule trail examples', () => {
+    const code = [
+      'message: "Legacy layer \'authLayer\' was removed in TRL-475."',
+      "sourceCode: `import { authLayer } from '@ontrails/permits';\\n`,",
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/packages/warden/src/trails/no-legacy-layer-imports.trail.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('flags references inside string literals and JSDoc', () => {
+    const code = [
+      '/** TODO: replace authLayer wiring */',
+      'export const note = "uses authLayer";',
+    ].join('\n');
+
+    const diagnostics = noLegacyLayerImports.check(
+      code,
+      '/repo/apps/example/src/runner.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.line).toBe(1);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 45 rule trails', () => {
-    expect(wardenTopo.count).toBe(45);
+  test('contains all 46 rule trails', () => {
+    expect(wardenTopo.count).toBe(46);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -86,6 +86,7 @@ export {
   missingReconcileTrail,
   noDevPermitInSourceTrail,
   noDirectImplementationCallTrail,
+  noLegacyLayerImportsTrail,
   noNativeErrorResultTrail,
   noSyncResultAssumptionTrail,
   noThrowInDetourRecoverTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -17,6 +17,7 @@ import { layerFieldNameDrift } from './layer-field-name-drift.js';
 import { missingVisibility } from './missing-visibility.js';
 import { missingReconcile } from './missing-reconcile.js';
 import { noDevPermitInSource } from './no-dev-permit-in-source.js';
+import { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noNativeErrorResult } from './no-native-error-result.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
@@ -89,6 +90,7 @@ export { missingVisibility } from './missing-visibility.js';
 export { missingReconcile } from './missing-reconcile.js';
 export { onReferencesExist } from './on-references-exist.js';
 export { noDevPermitInSource } from './no-dev-permit-in-source.js';
+export { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 export { noDirectImplementationCall } from './no-direct-implementation-call.js';
 export { noNativeErrorResult } from './no-native-error-result.js';
 export { noSyncResultAssumption } from './no-sync-result-assumption.js';
@@ -147,6 +149,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [validDescribeRefs.name, validDescribeRefs],
   [noDevPermitInSource.name, noDevPermitInSource],
   [noDirectImplementationCall.name, noDirectImplementationCall],
+  [noLegacyLayerImports.name, noLegacyLayerImports],
   [noNativeErrorResult.name, noNativeErrorResult],
   [noSyncResultAssumption.name, noSyncResultAssumption],
   [implementationReturnsResult.name, implementationReturnsResult],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -148,6 +148,17 @@ export const builtinWardenRuleMetadata = {
     invariant: 'Application code composes trails through ctx.cross().',
     tier: 'source-static',
   },
+  'no-legacy-layer-imports': {
+    invariant:
+      'Legacy layer exports removed across TRL-475/TRL-476 (authLayer, autoIterateLayer, dateShortcutsLayer) do not reappear in committed source.',
+    lifecycle: {
+      retireWhen:
+        'Layer Evolution legacy layer migration window closes (one minor release after the legacy exports are removed).',
+      state: 'temporary',
+    },
+    scope: 'external',
+    tier: 'source-static',
+  },
   'no-native-error-result': {
     ...durableExternal,
     invariant: 'Result error boundaries carry specific TrailsError subclasses.',

--- a/packages/warden/src/rules/no-legacy-layer-imports.ts
+++ b/packages/warden/src/rules/no-legacy-layer-imports.ts
@@ -1,0 +1,193 @@
+/**
+ * Flags references to legacy layer symbols removed during Layer Evolution.
+ *
+ * The pre-TRL-469 era of Trails shipped three first-party layers as ergonomics
+ * over `executeTrail`:
+ *
+ *   - `authLayer` — re-exposed permit enforcement, even though permits were
+ *     intrinsic to `executeTrail`.
+ *   - `autoIterateLayer` — wrapped the CLI iteration ergonomics that the
+ *     surface now derives directly via `--all` (TRL-469).
+ *   - `dateShortcutsLayer` — wrapped the CLI date-expansion helpers that the
+ *     surface now derives directly (TRL-470).
+ *
+ * TRL-475 removed `authLayer`; TRL-476 removed the CLI layer exports
+ * `autoIterateLayer` and `dateShortcutsLayer`. Importing them from
+ * `@ontrails/permits` or `@ontrails/cli` produces a TypeScript error today;
+ * this rule layers a coaching diagnostic on top so authors that still type
+ * the symbol — in a comment, a string, or a stale import — get a redirect to
+ * the migration ADR during the deprecation window.
+ *
+ * The rule is intentionally text-based: legacy names appear in a mix of
+ * imports, JSDoc, error messages, and migration notes, all of which should
+ * surface a coaching message.
+ *
+ * Allow-list: a small set of files documenting the removal itself reference
+ * the literal symbol names. The rule's own implementation file references
+ * each name and is also exempt.
+ *
+ * Test files (`__tests__/`, `*.test.ts`) are filtered before this rule is
+ * invoked by the warden runner, so the regression test referencing
+ * `authLayer` in its name (`packages/core/src/__tests__/execute-permit.test.ts`)
+ * does not need a separate exemption.
+ */
+import { resolve, sep } from 'node:path';
+
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'no-legacy-layer-imports';
+
+/**
+ * Legacy layer symbol names that were removed during Layer Evolution.
+ *
+ * Listed longest-first is not required for correctness (none of these names
+ * are substrings of one another), but kept alphabetized for stable output
+ * across rule runs.
+ */
+const LEGACY_LAYER_NAMES = [
+  'authLayer',
+  'autoIterateLayer',
+  'dateShortcutsLayer',
+] as const;
+
+type LegacyLayerName = (typeof LEGACY_LAYER_NAMES)[number];
+
+interface LegacyLayerMigration {
+  readonly guidance: string;
+  readonly removedIn: 'TRL-475' | 'TRL-476';
+}
+
+const LEGACY_LAYER_MIGRATIONS: Record<LegacyLayerName, LegacyLayerMigration> = {
+  authLayer: {
+    guidance: 'Permit enforcement is intrinsic to executeTrail',
+    removedIn: 'TRL-475',
+  },
+  autoIterateLayer: {
+    guidance: 'Pagination uses CLI surface derivation (--all) per TRL-469',
+    removedIn: 'TRL-476',
+  },
+  dateShortcutsLayer: {
+    guidance: 'Date shortcuts use CLI surface derivation per TRL-470',
+    removedIn: 'TRL-476',
+  },
+};
+
+/**
+ * Path suffixes (in POSIX form) for source files that legitimately reference
+ * one or more removed legacy layer names. Other files are flagged.
+ *
+ * Each entry is matched against the normalized (forward-slash) absolute path
+ * with a trailing-segment match, so the rule stays correct regardless of the
+ * consumer's repository root.
+ */
+const ALLOWED_PATH_SUFFIXES: readonly string[] = [
+  // The CLI pagination module documents the removed `autoIterateLayer` in a
+  // migration note for apps moving onto the derived `--all` ergonomics.
+  '/packages/cli/src/pagination.ts',
+  // The CLI date-shortcuts module documents the removed `dateShortcutsLayer`
+  // in a migration note for apps moving onto the derived expansion helpers.
+  '/packages/cli/src/date-shortcuts.ts',
+  // The rule's own implementation file references the literals it searches for.
+  '/packages/warden/src/rules/no-legacy-layer-imports.ts',
+  // Warden rule metadata names the legacy symbols in the rule's invariant
+  // string for traceability between the rule and the removed exports.
+  '/packages/warden/src/rules/metadata.ts',
+  // The rule trail includes an executable example that demonstrates the
+  // diagnostic emitted for legacy layer imports.
+  '/packages/warden/src/trails/no-legacy-layer-imports.trail.ts',
+];
+
+const normalizePath = (filePath: string): string =>
+  resolve(filePath).split(sep).join('/');
+
+const isAllowedFile = (filePath: string): boolean => {
+  const normalized = normalizePath(filePath);
+  return ALLOWED_PATH_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+};
+
+interface Match {
+  readonly name: LegacyLayerName;
+  readonly index: number;
+}
+
+const IDENTIFIER_CHAR = /[$0-9A-Z_a-z]/u;
+
+const isIdentifierChar = (value: string): boolean =>
+  value !== '' && IDENTIFIER_CHAR.test(value);
+
+const indexOfStandaloneName = (
+  sourceCode: string,
+  name: LegacyLayerName
+): number => {
+  let fromIndex = 0;
+  while (fromIndex < sourceCode.length) {
+    const index = sourceCode.indexOf(name, fromIndex);
+    if (index === -1) {
+      return -1;
+    }
+    const before = index === 0 ? '' : (sourceCode[index - 1] ?? '');
+    const after = sourceCode[index + name.length] ?? '';
+    if (!(isIdentifierChar(before) || isIdentifierChar(after))) {
+      return index;
+    }
+    fromIndex = index + name.length;
+  }
+  return -1;
+};
+
+const findFirstMatch = (sourceCode: string): Match | null => {
+  let earliest: Match | null = null;
+  for (const name of LEGACY_LAYER_NAMES) {
+    const index = indexOfStandaloneName(sourceCode, name);
+    if (index === -1) {
+      continue;
+    }
+    if (earliest === null || index < earliest.index) {
+      earliest = { index, name };
+    }
+  }
+  return earliest;
+};
+
+const lineForOffset = (sourceCode: string, offset: number): number => {
+  let line = 1;
+  for (let i = 0; i < offset; i += 1) {
+    if (sourceCode.codePointAt(i) === 10) {
+      line += 1;
+    }
+  }
+  return line;
+};
+
+const buildMessage = (name: LegacyLayerName): string => {
+  const migration = LEGACY_LAYER_MIGRATIONS[name];
+  return `Legacy layer '${name}' was removed in ${migration.removedIn}. ${migration.guidance}. See docs/adr/drafts/20260409-layer-evolution.md.`;
+};
+
+/**
+ * Flags references to the removed legacy layer symbols in committed source.
+ */
+export const noLegacyLayerImports: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isAllowedFile(filePath)) {
+      return [];
+    }
+    const match = findFirstMatch(sourceCode);
+    if (!match) {
+      return [];
+    }
+    return [
+      {
+        filePath,
+        line: lineForOffset(sourceCode, match.index),
+        message: buildMessage(match.name),
+        rule: RULE_NAME,
+        severity: 'error',
+      },
+    ];
+  },
+  description:
+    'Disallow references to legacy layer exports (authLayer, autoIterateLayer, dateShortcutsLayer) removed across TRL-475/TRL-476.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -25,6 +25,7 @@ import { layerFieldNameDrift } from './layer-field-name-drift.js';
 import { missingReconcile } from './missing-reconcile.js';
 import { missingVisibility } from './missing-visibility.js';
 import { noDevPermitInSource } from './no-dev-permit-in-source.js';
+import { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noNativeErrorResult } from './no-native-error-result.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
@@ -77,6 +78,7 @@ export const registeredRuleNames: readonly string[] = [
   missingReconcile.name,
   missingVisibility.name,
   noDevPermitInSource.name,
+  noLegacyLayerImports.name,
   noDirectImplementationCall.name,
   noNativeErrorResult.name,
   noSyncResultAssumption.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -18,6 +18,7 @@ export { missingVisibilityTrail } from './missing-visibility.trail.js';
 export { missingReconcileTrail } from './missing-reconcile.trail.js';
 export { onReferencesExistTrail } from './on-references-exist.trail.js';
 export { noDevPermitInSourceTrail } from './no-dev-permit-in-source.trail.js';
+export { noLegacyLayerImportsTrail } from './no-legacy-layer-imports.trail.js';
 export { noDirectImplementationCallTrail } from './no-direct-implementation-call.trail.js';
 export { noNativeErrorResultTrail } from './no-native-error-result.trail.js';
 export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.js';

--- a/packages/warden/src/trails/no-legacy-layer-imports.trail.ts
+++ b/packages/warden/src/trails/no-legacy-layer-imports.trail.ts
@@ -1,0 +1,35 @@
+import { noLegacyLayerImports } from '../rules/no-legacy-layer-imports.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const noLegacyLayerImportsTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'apps/example/src/cli.ts',
+        sourceCode: `import { tokenPreset } from '@ontrails/cli';\n`,
+      },
+      name: 'Source files without legacy layer references are clean',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'apps/example/src/cli.ts',
+            line: 1,
+            message:
+              "Legacy layer 'authLayer' was removed in TRL-475. Permit enforcement is intrinsic to executeTrail. See docs/adr/drafts/20260409-layer-evolution.md.",
+            rule: 'no-legacy-layer-imports',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        filePath: 'apps/example/src/cli.ts',
+        sourceCode: `import { authLayer } from '@ontrails/permits';\n`,
+      },
+      name: 'Legacy layer imports produce migration diagnostics',
+    },
+  ],
+  rule: noLegacyLayerImports,
+});


### PR DESCRIPTION
## Summary
- Adds the temporary Warden rule `no-legacy-layer-imports`.
- Flags committed references to the removed `authLayer`, `autoIterateLayer`, and `dateShortcutsLayer` exports.
- Registers the rule, metadata, trail wrapper, and focused tests without adding a deprecated-`executeTrail({ layers })` rule.

## Details
The rule is a source-static migration guard for the TRL-475/TRL-476 removals. Its coaching distinguishes `authLayer` as removed in TRL-475 from the CLI layer exports removed in TRL-476, and points developers to intrinsic permit enforcement, `--all` schema derivation, and date-shortcut schema derivation. Narrow allow-lists let the migration helper modules, Warden rule metadata, the rule implementation, and the rule trail examples mention the legacy names. The withdrawn deprecated-execute-layers check is intentionally not present in this PR.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Focused Warden coverage: `bun test packages/warden/src/__tests__/no-legacy-layer-imports.test.ts`.
- Governance check: `bun apps/ci/bin/ci.ts --format github --fail-on error`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-476.