### PR TITLE
docs(clark): align calibration vocabulary with current Trails lexicon

### DIFF
--- a/.claude/skills/clark/SKILL.md
+++ b/.claude/skills/clark/SKILL.md
@@ -51,7 +51,9 @@ If the developer has to author information the framework already has, that's a f
 
 ### The Compound Test
 
-New features must multiply the value of existing features, not just add to a list. Before endorsing any addition, ask: does this make every other feature smarter? Intent compounds with surfaces, provisions, testing, and governance simultaneously. That's the bar.
+New features must multiply the value of existing features, not just add to a list. Before endorsing any addition, ask: does this make every other feature smarter? Intent compounds with surfaces, resources, testing, and governance simultaneously. That's the bar.
+
+> **Source-of-truth note:** When this skill or its references disagree with `docs/tenets.md`, `docs/lexicon.md`, or `AGENTS.md`, the docs win. Calibration flags drift in the codebase, not vocabulary shifts in the doctrinal layer.
 
 ## Postures
 

--- a/.claude/skills/clark/references/calibrate.md
+++ b/.claude/skills/clark/references/calibrate.md
@@ -30,8 +30,20 @@ Scan all changed or new files for vocabulary violations. Highest-priority check.
 | linter, checker, validator | warden |
 | introspect, inspect, describe | survey |
 | docs, help, manual | guide |
-| middleware, layer | gate |
-| service, dependency | provision |
+| service, dependency | resource |
+| middleware (as plain English) | layer |
+| provision (legacy) | resource |
+| gate (legacy) | layer |
+
+The current Trails lexicon canonicalizes `resource` (the declared
+infrastructure primitive — see `docs/lexicon.md` and ADR-0009) and
+`layer` (typed cross-cutting wrapper — see ADR-0043 Layer Evolution).
+Older Clark passes coached toward `provision`/`gate`; those terms are
+historical and should not appear in current vocabulary checks unless
+explicitly framed as deprecated. **Source of truth hierarchy:** when
+this reference file disagrees with `docs/tenets.md`, `docs/lexicon.md`,
+or `AGENTS.md`, the docs win — calibrate flags drift, not lexicon
+shifts.
 
 Also check that standard terms stay standard. `config` is not "settings." `Result` is not "response."
 
@@ -48,7 +60,7 @@ Check against ADR-0001's thirteen conventions. Focus on new or changed exports:
 - **Convention 7 (derive prefix):** Do derivation functions use `derive*`?
 - **Convention 8 (validate prefix):** Do verification functions use `validate*`?
 - **Convention 9 (build prefix):** Do surface derivation builders use `build*`?
-- **Convention 10 (gate suffix):** Do gates follow the `*Gate` pattern?
+- **Convention 10 (layer suffix):** Do typed layers follow the `*Layer` pattern (per ADR-0043)?
 - **Convention 11 (of suffix):** Do schema extractors use `*Of`?
 - **Convention 12 (Zod boundary):** Does Zod leak past schema definitions?
 

--- a/.claude/skills/clark/references/debrief.md
+++ b/.claude/skills/clark/references/debrief.md
@@ -11,7 +11,7 @@ Did this sprint surface a recurring pattern that should be named?
 - A composition pattern that multiple trails used the same way
 - An error handling pattern that could become a framework utility
 - A testing pattern that should be added to the testing guide
-- A provision interaction pattern that suggests a new convenience
+- A resource interaction pattern that suggests a new convenience
 
 Apply the primitive-pattern-new-primitive hierarchy: is this a pattern that uses existing primitives well, or does it suggest a new primitive is warranted?
 


### PR DESCRIPTION
## Summary
- Aligns Clark calibration vocabulary with current Trails doctrine.
- Points Clark at the source-of-truth documents: `docs/tenets.md`, `docs/lexicon.md`, and `AGENTS.md`.
- Prevents future Clark passes from reporting historical `provision`/`gate` vocabulary as current framework drift.

## Details
The Clark calibration table now maps service/dependency language to `resource`, plain-English middleware language to `layer`, and the suffix convention to layer suffixes. The skill and calibration references explicitly state that tenets, lexicon, and project guidance win if skill references disagree. The debrief reference moves from provision interaction language to resource interaction language. No runtime code changes are included.

## Verification
- Branch walk-up gate: each branch in this submitted stack was checked from bottom to top with `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run build`, and `bun run test`.
- Branch-local extras were run where the change touched typed code or formatting-sensitive docs: focused tests, package-filtered typecheck, `bun run format:check`, `bun run lint`, and `git diff --check`.
- Final stack-tip gate after this PR was included: `bun run check`, `bun run build`, and `bun run test`.

## Tracking
Resolves TRL-604. Closes Phase 8 (Legacy removal + governance).

Related follow-ups: TRL-621 (vocabulary lint rule) and TRL-622 (broader audit cleanup) are related but not closed by this PR.