### PR TITLE
docs(clark): log TopoAwareWardenRule decision (2026-04-20)

### DIFF
--- a/.trails/clark/decisions.md
+++ b/.trails/clark/decisions.md
@@ -42,3 +42,16 @@
 - Callable primitive namespace `pattern.crud(...)` — rejected on structural grounds (gist §8b/§8c/§8e; cross-package composition complexity; case-of-one rule).
 - Inferred pattern (no field; reconstruct from provenance) — rejected because the contract should be queryable directly on the trail, not reconstructed.
 **Follow-up:** TRL-301 adds the field and stamps the four shipped factories (`crud`, `sync`, `reconcile`, `ingest`); amends ADR-0032 to correct the two untrue claims and capture the "factory owns the label" / "connector-extensible" framing.
+
+### 2026-04-20 TopoAwareWardenRule — proceed with TRL-268 + TRL-269 as tracer bullet
+
+**Question:** Does landing TRL-301 (`pattern` field now live on `TrailSpec`/`Trail`) change the April 12 deferral ruling that set a "3+ concrete rules blocked" bar before introducing `TopoAwareWardenRule`? Should TRL-268 and TRL-269 ship together now, or should TRL-269 stay runtime-only until a second concrete blocked rule appears?
+**Decision:** Proceed with TRL-268 + TRL-269 together. Drop the 3+ rule bar.
+**Basis:** Drift guard hierarchy — TRL-269's current defensive runtime check at `derive-trail.ts:546-575` lives at step 5 (runtime diff catches it). Moving it to step 4 (warden catches it) is strictly better per the tenets; the framework already has the data, so requiring developers to discover the accessor mismatch at runtime when a lint rule could catch it earlier is a framework bug. TRL-301 materially changed the inputs: `pattern` is now real authored data on every trail, and the resolved graph carries structured operational intent — the exact surface a topo-aware rule is meant to read. The original 3+ bar was a guard against designing an interface around one speculative consumer only to have the second want a different shape; with TRL-301 landed, the motivation has shifted from speculative to concrete. Tracer bullet (one primitive, one real consumer) beats speculation across two future consumers — learn whether the interface shape holds, then let TRL-271 validate reusability once its own simplification lands.
+**Confidence:** High
+**Alternatives considered:**
+
+- Hold and keep the 3+ rule bar — rejected because TRL-301 changed the inputs, and leaving TRL-269 runtime-only keeps a framework-bug shape (step-5 detection for a check that belongs at step 4) in place for no architectural gain.
+- Ship TRL-268 alone, no consumer — rejected because a primitive without a real consumer is exactly what the original bar was designed to prevent. TRL-269 is the test of the interface shape.
+- Design TRL-268 against TRL-269 + TRL-271 + detour coverage simultaneously — rejected because TRL-271's consumer shape is downstream of its own simplification, and detour coverage has no concrete issue. Designing against speculative consumers is the failure mode the April 12 ruling was trying to avoid.
+**Follow-up:** TRL-268 lands `TopoAwareWardenRule` interface; TRL-269 converts the runtime defensive check at `derive-trail.ts:546-575` into a topo-aware warden rule and removes the runtime fallback if the rule makes it unreachable. TRL-271's future simplification to use `pattern` field becomes the second consumer once its primary work lands.


### PR DESCRIPTION
## Summary
- Records the 2026-04-20 Clark decision to proceed with TRL-268 and TRL-269 as the TopoAwareWardenRule tracer bullet.
- Captures why TRL-301 changed the earlier deferral calculus by making `pattern` authored trail data.
- Preserves the alternatives considered and follow-up path for TRL-268, TRL-269, and TRL-271.

## Details
This is a documentation-only update to `.trails/clark/decisions.md`. It logs the decision basis: moving an accessor-mismatch check from runtime fallback into a topo-aware Warden rule improves the drift guard hierarchy, and TRL-269 provides the concrete consumer needed to validate the interface without designing around speculative future rules.

## Verification
- Inspected the PR diff and confirmed it only appends the Clark decision note.
- No repo build/test gate was rerun for this separate non-TRL PR during the stack verification pass.