### PR TITLE
feat: add retired lexicon oxlint guard

### DIFF
--- a/docs/rule-design.md
+++ b/docs/rule-design.md
@@ -164,6 +164,14 @@ the rule owns.
 - List rule-owned roles explicitly when a word has legitimate meanings outside
   the Trails concept being retired.
 
+The repo-local `no-retired-lexicon-terms` Oxlint rule is the source-file guard
+for retired lexicon terms. It reads retired terms from the `docs/lexicon.md`
+Reserved Terms table and checks source-owned symbol roles such as identifiers,
+local or `@ontrails/*` import paths, object keys, and literal member properties.
+It intentionally does not lint Markdown prose; docs and historical mention-class
+coverage stays in the vocabulary audit path so migration docs, changelogs, ADRs,
+and contrastive explanations can be classified instead of blindly rewritten.
+
 ## Existing Rule Audit Checklist
 
 For each existing rule:

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       'error',
       { allowedPackages: ['cli'] },
     ],
+    'trails-local/no-retired-lexicon-terms': 'warn',
     'trails-local/prefer-bun-api': 'warn',
     'trails-local/snapshot-location': 'warn',
     'trails-local/temp-audit-direct-framework-writes': 'warn',

--- a/packages/oxlint-plugin/src/__tests__/plugin.test.ts
+++ b/packages/oxlint-plugin/src/__tests__/plugin.test.ts
@@ -15,6 +15,7 @@ describe('@ontrails/oxlint-plugin', () => {
       'no-nested-barrel',
       'no-process-env-in-packages',
       'no-process-exit-in-packages',
+      'no-retired-lexicon-terms',
       'prefer-bun-api',
       'snapshot-location',
       'temp-audit-direct-framework-writes',

--- a/packages/oxlint-plugin/src/__tests__/rules.test.ts
+++ b/packages/oxlint-plugin/src/__tests__/rules.test.ts
@@ -5,6 +5,10 @@ import { noDeepRelativeImportRule } from '../rules/no-deep-relative-import.js';
 import { noNestedBarrelRule } from '../rules/no-nested-barrel.js';
 import { noProcessEnvInPackagesRule } from '../rules/no-process-env-in-packages.js';
 import { noProcessExitInPackagesRule } from '../rules/no-process-exit-in-packages.js';
+import {
+  noRetiredLexiconTermsRule,
+  parseRetiredLexiconTerms,
+} from '../rules/no-retired-lexicon-terms.js';
 import { preferBunApiRule } from '../rules/prefer-bun-api.js';
 import { snapshotLocationRule } from '../rules/snapshot-location.js';
 import { tempAuditDirectFrameworkWritesRule } from '../rules/temp-audit-direct-framework-writes.js';
@@ -125,6 +129,231 @@ describe('repo-local rules', () => {
       'noDeepRelativeImport',
     ]);
     expect(allowedReports).toHaveLength(0);
+  });
+
+  test('parses retired terms from the lexicon reserved table', () => {
+    const terms = parseRetiredLexiconTerms(`
+## Reserved Terms
+
+| Term | Concept |
+| --- | --- |
+| \`trailhead\` | Historical boundary term retired from active user-facing vocabulary. Use \`surface\` in docs, examples, and public APIs. |
+| \`dispatch\` | Retired runtime wording; use \`cross\` in active APIs. |
+| \`pack\` | Distributable capability bundle |
+
+## Grammar
+`);
+
+    expect(terms).toEqual([
+      {
+        concept:
+          'Historical boundary term retired from active user-facing vocabulary. Use `surface` in docs, examples, and public APIs.',
+        replacement: 'surface',
+        term: 'trailhead',
+      },
+      {
+        concept: 'Retired runtime wording; use `cross` in active APIs.',
+        replacement: 'cross',
+        term: 'dispatch',
+      },
+    ]);
+  });
+
+  test('reports retired lexicon terms in source symbol roles', () => {
+    const identifierReports = runRuleForEvent({
+      event: 'Identifier',
+      filename: 'packages/http/src/build.ts',
+      nodes: [{ name: 'withHttpTrailhead', type: 'Identifier' }],
+      options: [
+        {
+          retiredTerms: [
+            {
+              replacement: 'surface',
+              term: 'trailhead',
+            },
+          ],
+        },
+      ],
+      rule: noRetiredLexiconTermsRule,
+    });
+    const importReports = runRuleForEvent({
+      event: 'ImportDeclaration',
+      filename: 'packages/cli/src/index.ts',
+      nodes: [createImportDeclarationNode('@ontrails/cli/trailhead')],
+      options: [
+        {
+          retiredTerms: [
+            {
+              replacement: 'surface',
+              term: 'trailhead',
+            },
+          ],
+        },
+      ],
+      rule: noRetiredLexiconTermsRule,
+    });
+    const propertyReports = runRuleForEvent({
+      event: 'MemberExpression',
+      filename: 'packages/core/src/runtime.ts',
+      nodes: [
+        {
+          object: {
+            name: 'metadata',
+            type: 'Identifier',
+          },
+          property: {
+            type: 'Literal',
+            value: '__trails_trailhead',
+          },
+          type: 'MemberExpression',
+        },
+      ],
+      options: [
+        {
+          retiredTerms: [
+            {
+              replacement: 'surface',
+              term: 'trailhead',
+            },
+          ],
+        },
+      ],
+      rule: noRetiredLexiconTermsRule,
+    });
+    const objectKeyReports = runRuleForEvent({
+      event: 'Property',
+      filename: 'packages/core/src/runtime.ts',
+      nodes: [
+        {
+          computed: false,
+          key: {
+            type: 'Literal',
+            value: '__trails_trailhead',
+          },
+          type: 'Property',
+        },
+      ],
+      options: [
+        {
+          retiredTerms: [
+            {
+              replacement: 'surface',
+              term: 'trailhead',
+            },
+          ],
+        },
+      ],
+      rule: noRetiredLexiconTermsRule,
+    });
+
+    expect(identifierReports[0]?.data).toEqual({
+      replacement: " Use 'surface'.",
+      role: 'identifier',
+      term: 'trailhead',
+      value: 'withHttpTrailhead',
+    });
+    expect(importReports.map((report) => report.messageId)).toEqual([
+      'noRetiredLexiconTerms',
+    ]);
+    expect(propertyReports.map((report) => report.messageId)).toEqual([
+      'noRetiredLexiconTerms',
+    ]);
+    expect(objectKeyReports[0]?.data).toEqual({
+      replacement: " Use 'surface'.",
+      role: 'object key',
+      term: 'trailhead',
+      value: '__trails_trailhead',
+    });
+  });
+
+  test('does not report retired terms outside source-owned roles', () => {
+    const externalImportReports = runRuleForEvent({
+      event: 'ImportDeclaration',
+      filename: 'packages/http/src/build.ts',
+      nodes: [createImportDeclarationNode('external-trailhead-sdk')],
+      options: [
+        {
+          retiredTerms: [
+            {
+              replacement: 'surface',
+              term: 'trailhead',
+            },
+          ],
+        },
+      ],
+      rule: noRetiredLexiconTermsRule,
+    });
+    const docsPathReports = runRuleForEvent({
+      event: 'Identifier',
+      filename: 'docs/migration/trailhead-to-surface.md',
+      nodes: [{ name: 'trailhead', type: 'Identifier' }],
+      options: [
+        {
+          retiredTerms: [
+            {
+              replacement: 'surface',
+              term: 'trailhead',
+            },
+          ],
+        },
+      ],
+      rule: noRetiredLexiconTermsRule,
+    });
+    const identifierObjectKeyReports = runRuleForEvent({
+      event: 'Property',
+      filename: 'packages/core/src/runtime.ts',
+      nodes: [
+        {
+          computed: false,
+          key: {
+            name: 'trailhead',
+            type: 'Identifier',
+          },
+          type: 'Property',
+        },
+      ],
+      options: [
+        {
+          retiredTerms: [
+            {
+              replacement: 'surface',
+              term: 'trailhead',
+            },
+          ],
+        },
+      ],
+      rule: noRetiredLexiconTermsRule,
+    });
+    const computedObjectKeyReports = runRuleForEvent({
+      event: 'Property',
+      filename: 'packages/core/src/runtime.ts',
+      nodes: [
+        {
+          computed: true,
+          key: {
+            name: 'trailheadConfig',
+            type: 'Identifier',
+          },
+          type: 'Property',
+        },
+      ],
+      options: [
+        {
+          retiredTerms: [
+            {
+              replacement: 'surface',
+              term: 'trailhead',
+            },
+          ],
+        },
+      ],
+      rule: noRetiredLexiconTermsRule,
+    });
+
+    expect(externalImportReports).toHaveLength(0);
+    expect(docsPathReports).toHaveLength(0);
+    expect(identifierObjectKeyReports).toHaveLength(0);
+    expect(computedObjectKeyReports).toHaveLength(0);
   });
 
   test('allows first-level package barrels and reports deeper barrels', () => {

--- a/packages/oxlint-plugin/src/rules/no-retired-lexicon-terms.ts
+++ b/packages/oxlint-plugin/src/rules/no-retired-lexicon-terms.ts
@@ -1,0 +1,326 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import {
+  asIdentifierName,
+  asLiteralString,
+  getImportSourceFromImportDeclaration,
+  getImportSourceFromReExportDeclaration,
+  getImportSourceFromRequire,
+  isRepoSourceFile,
+  normalizeFilePath,
+  reportNode,
+} from './shared.js';
+import type { RuleModule } from './shared.js';
+
+interface RetiredLexiconTerm {
+  readonly concept: string;
+  readonly replacement?: string;
+  readonly term: string;
+}
+
+const RESERVED_TERMS_HEADING = '## Reserved Terms';
+const NEXT_HEADING_PATTERN = /^## /mu;
+const TABLE_ROW_PATTERN = /^\|\s*`([^`]+)`\s*\|\s*(.+?)\s*\|\s*$/u;
+const VOCAB_CUTOVER_SCRIPT_PATTERN =
+  /(?:^|\/)scripts\/vocab-cutover-(?:audit|map|rewrite|utils)\.ts$/u;
+const TERM_OPTION_KEY = 'retiredTerms';
+
+let retiredTermsCache: readonly RetiredLexiconTerm[] | undefined;
+let lexiconPathCache: string | undefined;
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object');
+
+const extractReservedTermsSection = (content: string): string => {
+  const headingIndex = content.indexOf(RESERVED_TERMS_HEADING);
+
+  if (headingIndex === -1) {
+    return '';
+  }
+
+  const afterHeading = content.slice(
+    headingIndex + RESERVED_TERMS_HEADING.length
+  );
+  const nextHeadingIndex = afterHeading.search(NEXT_HEADING_PATTERN);
+
+  return nextHeadingIndex === -1
+    ? afterHeading
+    : afterHeading.slice(0, nextHeadingIndex);
+};
+
+const extractReplacement = (concept: string): string | undefined =>
+  concept.match(/\bUse\s+`([^`]+)`/iu)?.[1];
+
+const findLexiconPath = (
+  startDirectory = process.cwd()
+): string | undefined => {
+  let currentDirectory = startDirectory;
+
+  while (true) {
+    const candidate = join(currentDirectory, 'docs', 'lexicon.md');
+
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+
+    const parentDirectory = dirname(currentDirectory);
+
+    if (parentDirectory === currentDirectory) {
+      return undefined;
+    }
+
+    currentDirectory = parentDirectory;
+  }
+};
+
+export const parseRetiredLexiconTerms = (
+  content: string
+): readonly RetiredLexiconTerm[] =>
+  extractReservedTermsSection(content)
+    .split(/\r?\n/u)
+    .flatMap((line): RetiredLexiconTerm[] => {
+      const match = line.match(TABLE_ROW_PATTERN);
+
+      if (!match) {
+        return [];
+      }
+
+      const [, term, concept] = match;
+
+      if (!term || !concept || !/\b(?:historical|retired)\b/iu.test(concept)) {
+        return [];
+      }
+
+      const replacement = extractReplacement(concept);
+      const base = {
+        concept,
+        term,
+      };
+
+      return [replacement ? { ...base, replacement } : base];
+    });
+
+const loadRetiredLexiconTerms = (): readonly RetiredLexiconTerm[] => {
+  if (retiredTermsCache) {
+    return retiredTermsCache;
+  }
+
+  lexiconPathCache = findLexiconPath();
+  retiredTermsCache = lexiconPathCache
+    ? parseRetiredLexiconTerms(readFileSync(lexiconPathCache, 'utf8'))
+    : [];
+
+  return retiredTermsCache;
+};
+
+const resolveRetiredTerms = (
+  options: readonly unknown[]
+): readonly RetiredLexiconTerm[] => {
+  const configured = (options[0] as Record<string, unknown> | undefined)?.[
+    TERM_OPTION_KEY
+  ];
+
+  if (!Array.isArray(configured)) {
+    return loadRetiredLexiconTerms();
+  }
+
+  return configured.flatMap((candidate): RetiredLexiconTerm[] => {
+    if (!isObject(candidate) || typeof candidate['term'] !== 'string') {
+      return [];
+    }
+
+    const concept =
+      typeof candidate['concept'] === 'string'
+        ? candidate['concept']
+        : 'configured';
+    const base = {
+      concept,
+      term: candidate['term'],
+    };
+
+    return typeof candidate['replacement'] === 'string'
+      ? [{ ...base, replacement: candidate['replacement'] }]
+      : [base];
+  });
+};
+
+const normalizeForMatch = (value: string): string => value.toLowerCase();
+
+const findRetiredTerm = (
+  value: string,
+  terms: readonly RetiredLexiconTerm[]
+): RetiredLexiconTerm | undefined => {
+  const normalized = normalizeForMatch(value);
+  return terms.find((term) =>
+    normalized.includes(normalizeForMatch(term.term))
+  );
+};
+
+const isLocalOrOnTrailsImport = (importSource: string): boolean =>
+  importSource.startsWith('.') ||
+  importSource.startsWith('/') ||
+  importSource.startsWith('@ontrails/');
+
+const getPropertyName = (node: unknown): string | undefined => {
+  if (!isObject(node) || node['type'] !== 'Property') {
+    return undefined;
+  }
+
+  if (node['computed']) {
+    return undefined;
+  }
+
+  return asLiteralString(node['key']);
+};
+
+const getLiteralMemberPropertyName = (node: unknown): string | undefined => {
+  if (!isObject(node) || node['type'] !== 'MemberExpression') {
+    return undefined;
+  }
+
+  const { property } = node;
+
+  if (!isObject(property) || property['type'] !== 'Literal') {
+    return undefined;
+  }
+
+  return asLiteralString(property);
+};
+
+const shouldCheckFile = (filePath: string | undefined): boolean => {
+  if (!isRepoSourceFile(filePath)) {
+    return false;
+  }
+
+  return !VOCAB_CUTOVER_SCRIPT_PATTERN.test(normalizeFilePath(filePath ?? ''));
+};
+
+const formatReplacement = (term: RetiredLexiconTerm): string =>
+  term.replacement ? ` Use '${term.replacement}'.` : '';
+
+export const noRetiredLexiconTermsRule: RuleModule = {
+  create(context) {
+    if (!shouldCheckFile(context.filename)) {
+      return {};
+    }
+
+    const retiredTerms = resolveRetiredTerms(context.options);
+
+    if (retiredTerms.length === 0) {
+      return {};
+    }
+
+    const reportIfRetiredTerm = (
+      node: unknown,
+      value: string | undefined,
+      role: string
+    ): void => {
+      if (!value) {
+        return;
+      }
+
+      const retiredTerm = findRetiredTerm(value, retiredTerms);
+
+      if (!retiredTerm) {
+        return;
+      }
+
+      reportNode({
+        context,
+        data: {
+          replacement: formatReplacement(retiredTerm),
+          role,
+          term: retiredTerm.term,
+          value,
+        },
+        messageId: 'noRetiredLexiconTerms',
+        node,
+      });
+    };
+
+    const reportIfRetiredImport = (
+      node: unknown,
+      importSource: string | undefined
+    ): void => {
+      if (!importSource || !isLocalOrOnTrailsImport(importSource)) {
+        return;
+      }
+
+      reportIfRetiredTerm(node, importSource, 'import path');
+    };
+
+    return {
+      CallExpression(node) {
+        reportIfRetiredImport(node, getImportSourceFromRequire(node));
+      },
+      ExportAllDeclaration(node) {
+        reportIfRetiredImport(
+          node,
+          getImportSourceFromReExportDeclaration(node)
+        );
+      },
+      ExportNamedDeclaration(node) {
+        reportIfRetiredImport(
+          node,
+          getImportSourceFromReExportDeclaration(node)
+        );
+      },
+      Identifier(node) {
+        reportIfRetiredTerm(node, asIdentifierName(node), 'identifier');
+      },
+      ImportDeclaration(node) {
+        reportIfRetiredImport(node, getImportSourceFromImportDeclaration(node));
+      },
+      MemberExpression(node) {
+        reportIfRetiredTerm(
+          node,
+          getLiteralMemberPropertyName(node),
+          'literal member property'
+        );
+      },
+      Property(node) {
+        reportIfRetiredTerm(node, getPropertyName(node), 'object key');
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description:
+        'Warn when source identifiers, import paths, or literal symbols use retired Trails lexicon terms.',
+      recommended: true,
+    },
+    messages: {
+      noRetiredLexiconTerms:
+        "Retired Trails vocabulary '{{term}}' appears in a source {{role}} ('{{value}}').{{replacement}} Keep historical or external mentions out of source symbol slots.",
+    },
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          [TERM_OPTION_KEY]: {
+            items: {
+              additionalProperties: false,
+              properties: {
+                concept: {
+                  type: 'string',
+                },
+                replacement: {
+                  type: 'string',
+                },
+                term: {
+                  type: 'string',
+                },
+              },
+              required: ['term'],
+              type: 'object',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'suggestion',
+  },
+};

--- a/packages/oxlint-plugin/src/rules/registry.ts
+++ b/packages/oxlint-plugin/src/rules/registry.ts
@@ -5,6 +5,7 @@ import { noDeepRelativeImportRule } from './no-deep-relative-import.js';
 import { noNestedBarrelRule } from './no-nested-barrel.js';
 import { noProcessEnvInPackagesRule } from './no-process-env-in-packages.js';
 import { noProcessExitInPackagesRule } from './no-process-exit-in-packages.js';
+import { noRetiredLexiconTermsRule } from './no-retired-lexicon-terms.js';
 import { preferBunApiRule } from './prefer-bun-api.js';
 import { snapshotLocationRule } from './snapshot-location.js';
 import { tempAuditDirectFrameworkWritesRule } from './temp-audit-direct-framework-writes.js';
@@ -23,6 +24,7 @@ export const rules = {
   'no-nested-barrel': noNestedBarrelRule,
   'no-process-env-in-packages': noProcessEnvInPackagesRule,
   'no-process-exit-in-packages': noProcessExitInPackagesRule,
+  'no-retired-lexicon-terms': noRetiredLexiconTermsRule,
   'prefer-bun-api': preferBunApiRule,
   'snapshot-location': snapshotLocationRule,
   'temp-audit-direct-framework-writes': tempAuditDirectFrameworkWritesRule,

--- a/packages/oxlint-plugin/src/rules/shared.ts
+++ b/packages/oxlint-plugin/src/rules/shared.ts
@@ -10,6 +10,9 @@ export type RuleModule = CreateRule;
 
 const PACKAGES_SRC_PATTERN = /(?:^|\/)packages\/[^/]+\/src\//u;
 const PACKAGE_NAME_PATTERN = /(?:^|\/)packages\/([^/]+)\/src\//u;
+const REPO_SOURCE_PATTERN =
+  /(?:^|\/)(?:apps|connectors|packages)\/[^/]+\/src\/.+\.[cm]?[jt]sx?$/u;
+const SCRIPT_SOURCE_PATTERN = /(?:^|\/)scripts\/.+\.[cm]?[jt]sx?$/u;
 const TEST_FILE_PATTERN = /(?:^|\/)__tests__\/|\.(test|spec)\.[cm]?[jt]sx?$/u;
 const TEMPLATE_FILE_PATTERN = /\.template\.[cm]?[jt]sx?$/u;
 
@@ -53,6 +56,26 @@ export const isPackageSourceFile = (filePath: string | undefined): boolean => {
   }
 
   return !TEMPLATE_FILE_PATTERN.test(normalized);
+};
+
+export const isRepoSourceFile = (filePath: string | undefined): boolean => {
+  if (!filePath) {
+    return false;
+  }
+
+  const normalized = normalizeFilePath(filePath);
+
+  if (
+    TEST_FILE_PATTERN.test(normalized) ||
+    TEMPLATE_FILE_PATTERN.test(normalized)
+  ) {
+    return false;
+  }
+
+  return (
+    REPO_SOURCE_PATTERN.test(normalized) ||
+    SCRIPT_SOURCE_PATTERN.test(normalized)
+  );
 };
 
 export const extractPackageName = (


### PR DESCRIPTION
## Context

Stack 1 starts by adding the repo-local guard for retired lexicon terms. The
framework already documents `trailhead` as retired in favor of `surface`; this
branch makes source-owned vocabulary drift visible before it reaches active APIs
or import paths.

Owning Linear issue: `TRL-621`
Stack position: 1 of 4, base branch `main`
Related issues: `TRL-622` performs the active cutover that this guard exposes.

## What Changed

- Added `trails-local/no-retired-lexicon-terms` to the private repo Oxlint
  plugin.
- Parse retired/historical terms and replacement hints from
  `docs/lexicon.md`.
- Scope diagnostics to source-owned symbol roles: identifiers, local or
  `@ontrails/*` import/re-export paths, `require()` sources, object keys, and
  literal member properties.
- Keep ordinary prose, test fixtures, templates, and the vocabulary cutover
  scripts out of this source-role rule.
- Documented the source-vs-docs enforcement split in `docs/rule-design.md`.

## Verification

Focused branch checks:

- `bun run oxlint-plugin:build`: passed after implementation fixes.
- `bun test packages/oxlint-plugin/src/__tests__/rules.test.ts packages/oxlint-plugin/src/__tests__/plugin.test.ts`: passed.
- `bun run --cwd packages/oxlint-plugin lint`: passed.
- Root-config Oxlint probe against `packages/http/src`: produced the expected
  pre-cutover `withHttpTrailhead` warnings, which were intentionally left for
  `TRL-622`.

Stack-tip checks after all Stack 1 fixes:

- `bun run typecheck`: passed.
- `bun run test`: passed, 36 turbo tasks successful.
- `bun run lint`: passed, 23 turbo tasks successful.
- `bun run build`: passed, 21 turbo tasks successful.
- `bun run format:check`: passed.
- `bun run check`: passed.

Local review:

- Round 1 vocabulary review found no blocking issue in the TRL-621 guard.
- Round 2 vocabulary review found no remaining P0/P1/P2 issues.

## Risks / Rollout Notes

- The rule is intentionally role-scoped and does not try to lint all Markdown.
  Markdown/docs coverage is handled by the companion vocabulary audit in
  `TRL-622`.
- The rule is configured as a warning so it surfaces drift without abruptly
  expanding Oxlint's blocking scope before the cutover branch lands.

Closes: TRL-621
