### PR TITLE
ci: add changeset coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [labeled, opened, reopened, synchronize, unlabeled]
     branches-ignore:
       - '**/graphite-base/**'
   push:
@@ -86,10 +86,42 @@ jobs:
       - name: Warden
         run: bun apps/ci/bin/ci.ts --format github --fail-on error
 
+  changeset:
+    name: Changeset
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+
+      - name: Collect PR file list
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files" \
+            --jq '.[].filename' \
+            > "$RUNNER_TEMP/changed-files.txt"
+
+      - name: Check changeset
+        env:
+          RELEASE_NONE: ${{ contains(github.event.pull_request.labels.*.name, 'release:none') }}
+        run: |
+          args=(--changed-files "$RUNNER_TEMP/changed-files.txt")
+          if [ "$RELEASE_NONE" = "true" ]; then
+            args+=(--release-none)
+          fi
+          bun run changeset:check -- "${args[@]}"
+
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [build, lint, typecheck, test, governance]
+    needs: [build, lint, typecheck, test, governance, changeset]
     runs-on: ubuntu-latest
     steps:
       - name: Summary
@@ -103,6 +135,7 @@ jobs:
           echo "| Typecheck | \`${{ needs.typecheck.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Test | \`${{ needs.test.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Governance | \`${{ needs.governance.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Changeset | \`${{ needs.changeset.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Require all jobs to pass
         if: contains(needs.*.result, 'failure') && !cancelled()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,13 @@ bun run publish:check
 bun run publish:packages
 ```
 
+Every PR that changes publishable `@ontrails/*` package contents must include a
+branch-local `.changeset/*.md` entry for the affected package unless the PR is
+explicitly labeled `release:none`. The CI changeset gate reads the GitHub PR file
+list, so stacked PRs are checked against their immediate PR diff rather than the
+whole local stack. Use `release:none` only for package-touching changes that
+truly do not ship user-visible package content.
+
 To exit pre-release mode for a stable release: `bunx changeset pre exit`, then version as usual.
 
 `bun run publish:check` auto-discovers every non-private workspace, topo-sorts by `workspace:` dep edges, runs `bun pm pack --dry-run` per package (required because `npm pack` does not resolve `catalog:`), and asserts the packed `package.json` contains no unresolved `workspace:` or `catalog:` ranges. `bun run publish:packages` uses the same discovery and applies the explicit dist-tag from `.changeset/pre.json` (falling back to `latest` outside prerelease mode). Packages intentionally ship source `.ts` files while their `exports` map points at `src`; test files, `dist`, `.turbo`, and `*.tsbuildinfo` should stay out of the published tarballs.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "turbo run build",
     "test": "turbo run test",
     "lint": "turbo run lint",
+    "changeset:check": "bun scripts/check-changeset-gate.ts",
     "vocab:audit": "bun scripts/vocab-cutover-audit.ts",
     "vocab:audit:json": "bun scripts/vocab-cutover-audit.ts --json",
     "vocab:rewrite": "bun scripts/vocab-cutover-rewrite.ts",

--- a/scripts/__tests__/check-changeset-gate.test.ts
+++ b/scripts/__tests__/check-changeset-gate.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  checkChangesetGate,
+  discoverWorkspaces,
+} from '../check-changeset-gate.ts';
+import type { WorkspaceInfo } from '../check-changeset-gate.ts';
+
+const workspaces: readonly WorkspaceInfo[] = [
+  {
+    isPrivate: false,
+    name: '@ontrails/core',
+    relativePath: 'packages/core',
+  },
+  {
+    isPrivate: false,
+    name: '@ontrails/http',
+    relativePath: 'packages/http',
+  },
+  {
+    isPrivate: true,
+    name: '@ontrails/oxlint-plugin',
+    relativePath: 'packages/oxlint-plugin',
+  },
+  {
+    isPrivate: false,
+    name: 'trails-demo',
+    relativePath: 'apps/demo',
+  },
+];
+
+const withTempRepo = <T>(
+  setup: (repoRoot: string) => T
+): { readonly repoRoot: string; readonly value: T } => {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'trails-changeset-gate-'));
+  mkdirSync(join(repoRoot, '.changeset'), { recursive: true });
+
+  try {
+    return {
+      repoRoot,
+      value: setup(repoRoot),
+    };
+  } catch (error) {
+    rmSync(repoRoot, { force: true, recursive: true });
+    throw error;
+  }
+};
+
+describe('checkChangesetGate', () => {
+  test('fails package-affecting publishable workspace changes without a covering changeset', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkChangesetGate({
+        changedFiles: ['packages/core/src/index.ts'],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.affectedPackages).toEqual(['@ontrails/core']);
+      expect(result.errors).toEqual([
+        'Package-affecting changes need changeset entries for: @ontrails/core',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('passes package-affecting changes with a real matching changeset entry', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'core-change.md'),
+        "---\n'@ontrails/core': minor\n---\n\nAdd the thing.\n"
+      );
+    });
+
+    try {
+      const result = checkChangesetGate({
+        changedFiles: [
+          'packages/core/src/index.ts',
+          '.changeset/core-change.md',
+        ],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.changedChangesets).toEqual(['.changeset/core-change.md']);
+      expect(result.coveredPackages).toEqual(['@ontrails/core']);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('requires changeset coverage for each affected publishable package', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'core-change.md'),
+        "---\n'@ontrails/core': patch\n---\n\nCore only.\n"
+      );
+    });
+
+    try {
+      const result = checkChangesetGate({
+        changedFiles: [
+          'packages/core/src/index.ts',
+          'packages/http/src/build.ts',
+          '.changeset/core-change.md',
+        ],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        'Package-affecting changes need changeset entries for: @ontrails/http',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('ignores non-shipping package test artifacts and private workspaces', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkChangesetGate({
+        changedFiles: [
+          'packages/core/src/__tests__/result.test.ts',
+          'packages/core/dist/index.js',
+          'packages/core/tsconfig.tsbuildinfo',
+          'packages/oxlint-plugin/src/rules/shared.ts',
+          'apps/demo/src/main.ts',
+        ],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.affectedPackages).toEqual([]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('honors release:none and rejects contradictory changesets', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'core-change.md'),
+        "---\n'@ontrails/core': patch\n---\n\nCore.\n"
+      );
+    });
+
+    try {
+      const bypass = checkChangesetGate({
+        changedFiles: ['packages/core/src/index.ts'],
+        releaseNone: true,
+        repoRoot,
+        workspaces,
+      });
+      const contradiction = checkChangesetGate({
+        changedFiles: [
+          'packages/core/src/index.ts',
+          '.changeset/core-change.md',
+        ],
+        releaseNone: true,
+        repoRoot,
+        workspaces,
+      });
+
+      expect(bypass.passed).toBe(true);
+      expect(contradiction.passed).toBe(false);
+      expect(contradiction.errors).toEqual([
+        '`release:none` conflicts with changed changeset files. Remove the label or the changeset.',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('release:none conflicts with changed changeset files even when they are unparsable or deleted', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'empty-change.md'),
+        'This file is not a valid changeset frontmatter block.\n'
+      );
+    });
+
+    try {
+      const malformed = checkChangesetGate({
+        changedFiles: ['.changeset/empty-change.md'],
+        releaseNone: true,
+        repoRoot,
+        workspaces,
+      });
+      const deleted = checkChangesetGate({
+        changedFiles: ['.changeset/deleted-change.md'],
+        releaseNone: true,
+        repoRoot,
+        workspaces,
+      });
+
+      expect(malformed.passed).toBe(false);
+      expect(malformed.changedChangesets).toEqual([
+        '.changeset/empty-change.md',
+      ]);
+      expect(deleted.passed).toBe(false);
+      expect(deleted.changedChangesets).toEqual([
+        '.changeset/deleted-change.md',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('discoverWorkspaces', () => {
+  test('discovers publish metadata from root workspace globs', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-workspaces-'));
+
+    try {
+      mkdirSync(join(repoRoot, 'packages', 'core'), { recursive: true });
+      mkdirSync(join(repoRoot, 'packages', 'private-tool'), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['packages/*'] })
+      );
+      writeFileSync(
+        join(repoRoot, 'packages', 'core', 'package.json'),
+        JSON.stringify({ name: '@ontrails/core' })
+      );
+      writeFileSync(
+        join(repoRoot, 'packages', 'private-tool', 'package.json'),
+        JSON.stringify({ name: '@ontrails/private-tool', private: true })
+      );
+
+      await expect(discoverWorkspaces(repoRoot)).resolves.toEqual([
+        {
+          isPrivate: false,
+          name: '@ontrails/core',
+          relativePath: 'packages/core',
+        },
+        {
+          isPrivate: true,
+          name: '@ontrails/private-tool',
+          relativePath: 'packages/private-tool',
+        },
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects unsupported workspace glob patterns instead of ignoring them', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-workspaces-'));
+
+    try {
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['packages/**'] })
+      );
+
+      await expect(discoverWorkspaces(repoRoot)).rejects.toThrow(
+        "Unsupported workspace pattern 'packages/**'"
+      );
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/scripts/check-changeset-gate.ts
+++ b/scripts/check-changeset-gate.ts
@@ -1,0 +1,395 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+
+interface PackageJson {
+  readonly name?: string;
+  readonly private?: boolean;
+  readonly workspaces?: readonly string[];
+}
+
+export interface WorkspaceInfo {
+  readonly isPrivate: boolean;
+  readonly name: string;
+  readonly relativePath: string;
+}
+
+export interface ChangesetGateInput {
+  readonly changedFiles: readonly string[];
+  readonly releaseNone?: boolean;
+  readonly repoRoot: string;
+  readonly workspaces: readonly WorkspaceInfo[];
+}
+
+export interface ChangesetGateResult {
+  readonly affectedPackages: readonly string[];
+  readonly changedChangesets: readonly string[];
+  readonly coveredPackages: readonly string[];
+  readonly errors: readonly string[];
+  readonly passed: boolean;
+  readonly releaseNone: boolean;
+}
+
+interface CliOptions {
+  readonly changedFilesPath?: string;
+  readonly releaseNone: boolean;
+  readonly repoRoot: string;
+}
+
+const NON_SHIPPING_PACKAGE_PATTERNS = [
+  /(?:^|\/)__tests__(?:\/|$)/u,
+  /(?:^|\/)__snapshots__(?:\/|$)/u,
+  /(?:^|\/)dist(?:\/|$)/u,
+  /(?:^|\/)\.turbo(?:\/|$)/u,
+  /(?:^|\/)node_modules(?:\/|$)/u,
+  /\.(?:test|spec|snap)\.[cm]?[jt]sx?$/u,
+  /\.test-d\.ts$/u,
+  /\.tsbuildinfo$/u,
+] as const;
+
+const CHANGESET_PATH_PATTERN = /^\.changeset\/[^/]+\.md$/u;
+const CHANGESET_PACKAGE_PATTERN =
+  /^['"]?(@ontrails\/[^'":]+)['"]?\s*:\s*(?:major|minor|patch)$/u;
+const WORKSPACE_GLOB_SYNTAX_PATTERN = /[*?[\]{}]/u;
+
+const normalizePath = (path: string): string =>
+  path.replaceAll('\\', '/').replace(/^\.\//u, '');
+
+const hasWorkspaceGlobSyntax = (pattern: string): boolean =>
+  WORKSPACE_GLOB_SYNTAX_PATTERN.test(pattern);
+
+const readJson = async <T>(path: string): Promise<T> =>
+  (await Bun.file(path).json()) as T;
+
+const discoverWorkspaceDirs = async (
+  repoRoot: string,
+  patterns: readonly string[]
+): Promise<string[]> => {
+  const dirs: string[] = [];
+
+  for (const pattern of patterns) {
+    if (pattern.endsWith('/*')) {
+      const parent = join(repoRoot, pattern.slice(0, -2));
+      let names: string[] = [];
+
+      try {
+        const entries = await readdir(parent, { withFileTypes: true });
+        names = entries
+          .filter((entry) => entry.isDirectory())
+          .map((entry) =>
+            typeof entry.name === 'string' ? entry.name : String(entry.name)
+          );
+      } catch {
+        continue;
+      }
+
+      for (const name of names) {
+        const dir = join(parent, name);
+
+        if (await Bun.file(join(dir, 'package.json')).exists()) {
+          dirs.push(dir);
+        }
+      }
+
+      continue;
+    }
+
+    const dir = join(repoRoot, pattern);
+
+    if (await Bun.file(join(dir, 'package.json')).exists()) {
+      dirs.push(dir);
+      continue;
+    }
+
+    if (hasWorkspaceGlobSyntax(pattern)) {
+      throw new Error(
+        `Unsupported workspace pattern '${pattern}'. The changeset gate supports exact workspace paths and one-level '/*' globs.`
+      );
+    }
+
+    throw new Error(
+      `Workspace pattern '${pattern}' did not resolve to a package.json`
+    );
+  }
+
+  return dirs;
+};
+
+export const discoverWorkspaces = async (
+  repoRoot: string
+): Promise<readonly WorkspaceInfo[]> => {
+  const root = await readJson<PackageJson>(join(repoRoot, 'package.json'));
+
+  if (!root.workspaces || root.workspaces.length === 0) {
+    throw new Error('Root package.json has no workspaces field');
+  }
+
+  const dirs = await discoverWorkspaceDirs(repoRoot, root.workspaces);
+  const workspaces: WorkspaceInfo[] = [];
+
+  for (const dir of dirs) {
+    const pkg = await readJson<PackageJson>(join(dir, 'package.json'));
+
+    if (!pkg.name) {
+      continue;
+    }
+
+    workspaces.push({
+      isPrivate: pkg.private === true,
+      name: pkg.name,
+      relativePath: normalizePath(relative(repoRoot, dir)),
+    });
+  }
+
+  return workspaces;
+};
+
+const isPublishableOnTrailsWorkspace = (workspace: WorkspaceInfo): boolean =>
+  !workspace.isPrivate && workspace.name.startsWith('@ontrails/');
+
+const isUnderWorkspace = (filePath: string, workspacePath: string): boolean =>
+  filePath === workspacePath || filePath.startsWith(`${workspacePath}/`);
+
+const getWorkspaceRelativePath = (
+  filePath: string,
+  workspacePath: string
+): string => filePath.slice(workspacePath.length + 1);
+
+const isNonShippingPackagePath = (workspaceRelativePath: string): boolean =>
+  NON_SHIPPING_PACKAGE_PATTERNS.some((pattern) =>
+    pattern.test(workspaceRelativePath)
+  );
+
+const findAffectedPackages = (
+  changedFiles: readonly string[],
+  workspaces: readonly WorkspaceInfo[]
+): readonly string[] => {
+  const affected = new Set<string>();
+  const publishableWorkspaces = workspaces.filter(
+    isPublishableOnTrailsWorkspace
+  );
+
+  for (const file of changedFiles.map(normalizePath)) {
+    for (const workspace of publishableWorkspaces) {
+      if (!isUnderWorkspace(file, workspace.relativePath)) {
+        continue;
+      }
+
+      const workspaceRelativePath = getWorkspaceRelativePath(
+        file,
+        workspace.relativePath
+      );
+
+      if (isNonShippingPackagePath(workspaceRelativePath)) {
+        continue;
+      }
+
+      affected.add(workspace.name);
+    }
+  }
+
+  return [...affected].toSorted();
+};
+
+const parseChangesetPackages = (content: string): readonly string[] => {
+  const lines = content.split(/\r?\n/u);
+
+  if (lines[0] !== '---') {
+    return [];
+  }
+
+  const closingIndex = lines.slice(1).indexOf('---');
+
+  if (closingIndex === -1) {
+    return [];
+  }
+
+  return lines.slice(1, closingIndex + 1).flatMap((line): string[] => {
+    const match = line.match(CHANGESET_PACKAGE_PATTERN);
+    return match?.[1] ? [match[1]] : [];
+  });
+};
+
+const findChangedChangesetPaths = (
+  changedFiles: readonly string[]
+): readonly string[] =>
+  changedFiles
+    .map(normalizePath)
+    .filter((path) => CHANGESET_PATH_PATTERN.test(path));
+
+const findChangedChangesets = (
+  changedChangesetPaths: readonly string[],
+  repoRoot: string
+): readonly {
+  readonly packages: readonly string[];
+  readonly path: string;
+}[] =>
+  changedChangesetPaths.flatMap((path) => {
+    const absolutePath = join(repoRoot, path);
+
+    if (!existsSync(absolutePath)) {
+      return [];
+    }
+
+    const packages = parseChangesetPackages(readFileSync(absolutePath, 'utf8'));
+
+    return packages.length === 0 ? [] : [{ packages, path }];
+  });
+
+export const checkChangesetGate = (
+  input: ChangesetGateInput
+): ChangesetGateResult => {
+  const releaseNone = input.releaseNone === true;
+  const affectedPackages = findAffectedPackages(
+    input.changedFiles,
+    input.workspaces
+  );
+  const changedChangesets = findChangedChangesetPaths(input.changedFiles);
+  const changesets = findChangedChangesets(changedChangesets, input.repoRoot);
+  const coveredPackages = [
+    ...new Set(changesets.flatMap((changeset) => changeset.packages)),
+  ].toSorted();
+  const uncoveredPackages = affectedPackages.filter(
+    (packageName) => !coveredPackages.includes(packageName)
+  );
+  const errors: string[] = [];
+
+  if (releaseNone && changedChangesets.length > 0) {
+    errors.push(
+      '`release:none` conflicts with changed changeset files. Remove the label or the changeset.'
+    );
+  }
+
+  if (!releaseNone && uncoveredPackages.length > 0) {
+    errors.push(
+      `Package-affecting changes need changeset entries for: ${uncoveredPackages.join(', ')}`
+    );
+  }
+
+  return {
+    affectedPackages,
+    changedChangesets,
+    coveredPackages,
+    errors,
+    passed: errors.length === 0,
+    releaseNone,
+  };
+};
+
+const readChangedFiles = (path: string): readonly string[] =>
+  readFileSync(path, 'utf8')
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+const parseArgs = (args: readonly string[]): CliOptions => {
+  let changedFilesPath: string | undefined;
+  let releaseNone = false;
+  let repoRoot = resolve(import.meta.dir, '..');
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--release-none') {
+      releaseNone = true;
+      continue;
+    }
+
+    if (arg === '--changed-files') {
+      const value = args[index + 1];
+
+      if (!value) {
+        throw new Error('--changed-files requires a file path');
+      }
+
+      changedFilesPath = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--repo-root') {
+      const value = args[index + 1];
+
+      if (!value) {
+        throw new Error('--repo-root requires a directory path');
+      }
+
+      repoRoot = resolve(value);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg ?? ''}`);
+  }
+
+  return {
+    changedFilesPath,
+    releaseNone,
+    repoRoot,
+  };
+};
+
+const renderResult = (result: ChangesetGateResult): void => {
+  if (result.passed) {
+    if (result.affectedPackages.length === 0) {
+      console.log(
+        'Changeset gate passed: no publishable package-affecting files changed.'
+      );
+      return;
+    }
+
+    if (result.releaseNone) {
+      console.log(
+        `Changeset gate passed via release:none for: ${result.affectedPackages.join(', ')}`
+      );
+      return;
+    }
+
+    console.log(
+      `Changeset gate passed for: ${result.affectedPackages.join(', ')}`
+    );
+    console.log(`Changed changesets: ${result.changedChangesets.join(', ')}`);
+    return;
+  }
+
+  for (const error of result.errors) {
+    console.error(error);
+  }
+
+  if (result.affectedPackages.length > 0) {
+    console.error(`Affected packages: ${result.affectedPackages.join(', ')}`);
+  }
+
+  if (result.changedChangesets.length > 0) {
+    console.error(`Changed changesets: ${result.changedChangesets.join(', ')}`);
+  }
+};
+
+const main = async (): Promise<number> => {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (!options.changedFilesPath) {
+    throw new Error('Pass --changed-files <path> with the PR-local file list');
+  }
+
+  const workspaces = await discoverWorkspaces(options.repoRoot);
+  const result = checkChangesetGate({
+    changedFiles: readChangedFiles(options.changedFilesPath),
+    releaseNone: options.releaseNone,
+    repoRoot: options.repoRoot,
+    workspaces,
+  });
+
+  renderResult(result);
+
+  return result.passed ? 0 : 1;
+};
+
+if (import.meta.main) {
+  try {
+    process.exit(await main());
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Context

Stack 1's second branch adds the CI/release guard for package-affecting PRs that
forget branch-local changesets. This is intentionally PR-local so Graphite stacks
are checked branch by branch, not as one accumulated diff.

Owning Linear issue: `TRL-505`
Stack position: 2 of 4, base branch
`trl-621-role-scoped-vocabulary-lint-rule-for-retired-lexicon-terms`
Related issues: `TRL-622` is the first package-touching branch expected to use
the `release:none` path.

## What Changed

- Added `scripts/check-changeset-gate.ts`.
- Added unit coverage for package source changes, non-shipping package paths,
  valid changesets, `release:none`, malformed changesets, and deleted changeset
  paths.
- Added `bun run changeset:check`.
- Added a CI `changeset` job and made the aggregate `ci-gate` depend on it.
- CI collects the GitHub PR file list so stacked PRs are checked against their
  immediate PR diff.
- CI reruns on `labeled` and `unlabeled` pull request events so `release:none`
  changes retrigger the gate.
- Documented the policy in `AGENTS.md`.

## Verification

Focused branch checks:

- `bun test scripts/__tests__/check-changeset-gate.test.ts`: passed, 7 tests.
- Package source without changeset: failed as expected.
- Package source with `--release-none`: passed as expected.
- Package source plus a valid changeset: passed as expected.
- Package source plus a changed changeset with `--release-none`: failed as
  expected.
- Deleted `.changeset/*.md` path with `--release-none`: failed as expected.

Stack-tip checks after all Stack 1 fixes:

- `bun run typecheck`: passed.
- `bun run test`: passed, 36 turbo tasks successful.
- `bun run lint`: passed, 23 turbo tasks successful.
- `bun run build`: passed, 21 turbo tasks successful.
- `bun run format:check`: passed.
- `bun run check`: passed.

Local review:

- Round 1 changeset review found three real issues: label changes did not rerun
  CI, deleted PR files were filtered out, and `release:none` conflicts only saw
  parseable changed changesets.
- All three findings were fixed on this branch.
- Round 2 changeset review found no remaining P0/P1/P2 issues.

## Risks / Rollout Notes

- `release:none` is deliberately exclusive with changed changeset files. A PR
  should either declare release impact through changesets or explicitly opt out
  with the label, not both.
- The gate depends on GitHub PR file-list semantics in CI; local invocations must
  pass `--changed-files` explicitly.
- The repo needed a `release:none` GitHub label for the escape hatch to be
  usable on package-touching PRs.

Closes: TRL-505
