### PR TITLE
ci: add ast-grep structural lint

### DIFF
--- a/.ast-grep/rules/no-direct-blaze-call.yml
+++ b/.ast-grep/rules/no-direct-blaze-call.yml
@@ -1,0 +1,12 @@
+id: trails-no-direct-blaze-call
+language: TypeScript
+severity: error
+message: Use ctx.cross(...) instead of direct .blaze() calls.
+ignores:
+  - '**/__tests__/**'
+  - '**/*.test.ts'
+  - '**/*.spec.ts'
+  - 'packages/testing/**'
+  - 'packages/warden/**'
+rule:
+  pattern: $TARGET.blaze($$$ARGS)

--- a/.ast-grep/rules/no-native-error-result.yml
+++ b/.ast-grep/rules/no-native-error-result.yml
@@ -1,0 +1,19 @@
+id: trails-no-native-error-result
+language: TypeScript
+severity: error
+message: Use a specific TrailsError subclass with Result.err(...) instead of native Error.
+ignores:
+  - '**/__tests__/**'
+  - '**/*.test.ts'
+  - '**/*.spec.ts'
+  - 'packages/testing/**'
+  - 'packages/warden/**'
+rule:
+  any:
+    - pattern: Result.err(new $ERROR($$$ARGS))
+    - pattern: $NAMESPACE.Result.err(new $ERROR($$$ARGS))
+    - pattern: Result.err(new $ERROR)
+    - pattern: $NAMESPACE.Result.err(new $ERROR)
+constraints:
+  ERROR:
+    regex: '^(AggregateError|Error|EvalError|RangeError|ReferenceError|SyntaxError|TypeError|URIError)$'

--- a/.ast-grep/sgconfig.yml
+++ b/.ast-grep/sgconfig.yml
@@ -1,0 +1,2 @@
+ruleDirs:
+  - rules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Structural lint
+        run: bun run lint:ast-grep
+
       - name: Format check
         run: bun run format:check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Use repo scripts first:
 bun run build
 bun run test
 bun run lint
+bun run lint:ast-grep
 bun run typecheck
 bun run check
 bun run clean

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "commander": "^14.0.0",
       },
       "devDependencies": {
+        "@ast-grep/cli": "0.42.1",
         "@changesets/cli": "^2.29.8",
         "@ontrails/oxlint-plugin": "workspace:*",
         "@types/bun": "^1.3.11",
@@ -273,6 +274,7 @@
     },
   },
   "trustedDependencies": [
+    "@ast-grep/cli",
     "oxfmt",
     "oxlint",
     "lefthook",
@@ -282,6 +284,22 @@
     "zod": "^4.3.5",
   },
   "packages": {
+    "@ast-grep/cli": ["@ast-grep/cli@0.42.1", "", { "dependencies": { "detect-libc": "2.1.2" }, "optionalDependencies": { "@ast-grep/cli-darwin-arm64": "0.42.1", "@ast-grep/cli-darwin-x64": "0.42.1", "@ast-grep/cli-linux-arm64-gnu": "0.42.1", "@ast-grep/cli-linux-x64-gnu": "0.42.1", "@ast-grep/cli-win32-arm64-msvc": "0.42.1", "@ast-grep/cli-win32-ia32-msvc": "0.42.1", "@ast-grep/cli-win32-x64-msvc": "0.42.1" }, "bin": { "sg": "sg", "ast-grep": "ast-grep" } }, "sha512-L1D7JX7p/RohtvE4IViKelWCtEYjQDvmlZ85aP4LmJVoQth/iC/+z/fCXmg6qSK8zr9IjC9okpxDZX7x1arKbQ=="],
+
+    "@ast-grep/cli-darwin-arm64": ["@ast-grep/cli-darwin-arm64@0.42.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-G9rk0NAN10mybxi611CVNqwPtPO+yF0rFqPzpdgHBa4roeCq5FYsg2q/WqxM95st3jilNS9UIfZFD0i3BDfKEw=="],
+
+    "@ast-grep/cli-darwin-x64": ["@ast-grep/cli-darwin-x64@0.42.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-IZ1HY69zj6sj4QnHKPR71FjtuCDImhLW5v5QhTGq6Fl0T9fjhQP/g9aEk7PrJB1puOk4HhTw/J/u0wZOPmp4bA=="],
+
+    "@ast-grep/cli-linux-arm64-gnu": ["@ast-grep/cli-linux-arm64-gnu@0.42.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-eirVmtAciL1cXwvODYkqKEFtWgxxYyhNLTTNchdKynktFixuAmAvn0OUX0bcQnhXH5DgsdT4+1+CtvjuPc5uGQ=="],
+
+    "@ast-grep/cli-linux-x64-gnu": ["@ast-grep/cli-linux-x64-gnu@0.42.1", "", { "os": "linux", "cpu": "x64" }, "sha512-DrsV3+LkzwcaCw2AkLqM5o9ISaS4ZfJIL96RIdFRD+ydp5Mirsdw3aZdDmBqpa6nxt2NjMsFWgOivvzPiKzGAw=="],
+
+    "@ast-grep/cli-win32-arm64-msvc": ["@ast-grep/cli-win32-arm64-msvc@0.42.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-9DabeCAtOQEUTiCVB6fpoJ0mI21brEAa5oY2jjOzaz1SBwYuh9TPLnKBn8F+PYbUU/4Umyy26YwVg+xw4+J/Ug=="],
+
+    "@ast-grep/cli-win32-ia32-msvc": ["@ast-grep/cli-win32-ia32-msvc@0.42.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-xQlxTwaqiCzOUZc5lB6rp/glS0DmQd67ID6MliRZ3TH1PvX+a3oiP+QEdSgcvfcArObuKxtRGNKlOfgwMe+J8Q=="],
+
+    "@ast-grep/cli-win32-x64-msvc": ["@ast-grep/cli-win32-x64-msvc@0.42.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bOMSGeTKGfYBB1m+S0WLiA2GUkNVBaHOy+mKw27mf/kd6W2KNG3DJwAWry35qargLL0WP9PBcCaOkdnzeNyZ3A=="],
+
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.0", "", { "dependencies": { "@changesets/config": "^3.1.3", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ=="],
@@ -601,6 +619,8 @@
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 

--- a/docs/rule-design.md
+++ b/docs/rule-design.md
@@ -172,6 +172,19 @@ It intentionally does not lint Markdown prose; docs and historical mention-class
 coverage stays in the vocabulary audit path so migration docs, changelogs, ADRs,
 and contrastive explanations can be classified instead of blindly rewritten.
 
+## Ast-Grep Structural Rules
+
+The `.ast-grep/` ruleset is repo-local structural lint, paired with Warden rather
+than replacing it. Use it for high-confidence syntax shapes where the invariant
+is already owned and named by Warden, such as direct `.blaze()` calls or
+`Result.err(new Error(...))`. Keep topo-aware, project-static, owner-projection,
+and scope-sensitive checks in Warden.
+
+Experimental ast-grep queries may live outside `.ast-grep/rules/` so they are
+available for audits without blocking CI. Promote one into the blocking rule
+directory only after it is clean on the current tree and its false-positive
+profile is understood.
+
 ## Existing Rule Audit Checklist
 
 For each existing rule:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "turbo run build",
     "test": "turbo run test",
     "lint": "turbo run lint",
+    "lint:ast-grep": "ast-grep scan --config .ast-grep/sgconfig.yml",
     "changeset:check": "bun scripts/check-changeset-gate.ts",
     "vocab:audit": "bun scripts/vocab-cutover-audit.ts",
     "vocab:audit:json": "bun scripts/vocab-cutover-audit.ts --json",
@@ -28,7 +29,7 @@
     "format:guard": "if git grep -nE \"(\\\\./)?node_modules/\\\\.bin/ultra[c]ite\" -- ':!bun.lock'; then echo 'Direct node_modules/.bin formatter invocation found'; exit 1; fi",
     "mdlint:fix": "./node_modules/.bin/markdownlint-cli2 --fix",
     "typecheck": "turbo run typecheck",
-    "check": "bun run lint && bun run format:check && bun run typecheck && bun run docs:snippets && bun run scaffold-versions:check",
+    "check": "bun run lint && bun run lint:ast-grep && bun run format:check && bun run typecheck && bun run docs:snippets && bun run scaffold-versions:check",
     "clean": "turbo run clean --no-cache && rm -rf node_modules",
     "oxlint-plugin:build": "bun run --cwd packages/oxlint-plugin build:oxlint",
     "publish:check": "bun scripts/publish.ts --check",
@@ -39,6 +40,7 @@
     "commander": "^14.0.0"
   },
   "devDependencies": {
+    "@ast-grep/cli": "0.42.1",
     "@changesets/cli": "^2.29.8",
     "@ontrails/oxlint-plugin": "workspace:*",
     "@types/bun": "^1.3.11",
@@ -61,6 +63,7 @@
     "zod": "^4.3.5"
   },
   "trustedDependencies": [
+    "@ast-grep/cli",
     "lefthook",
     "oxfmt",
     "oxlint"


### PR DESCRIPTION
## Context

This branch stands up a small repo-local ast-grep ruleset for high-confidence
structural checks. It is intentionally paired with Warden rather than replacing
Warden: ast-grep handles syntax-only patterns, while topo-aware and type-aware
framework invariants stay in Warden.

Owning Linear issue: `TRL-615`
Stack position: 3 of 4, base branch
`trl-505-add-ci-gate-that-blocks-prs-missing-changesets-for-breaking`
Related issues: `TRL-621` and `TRL-622` cover vocabulary enforcement in adjacent
lanes.

## What Changed

- Added `.ast-grep/sgconfig.yml`.
- Added `no-direct-blaze-call` to catch direct `.blaze(...)` calls outside test
  and framework-owned enforcement areas.
- Added `no-native-error-result` to catch `Result.err(new Error(...))` style
  native error construction.
- Added `@ast-grep/cli` and trusted its Bun postinstall so the real binary is
  available.
- Added `bun run lint:ast-grep`.
- Wired ast-grep into the root `check` script and CI lint job.
- Documented the ast-grep/Warden boundary in `docs/rule-design.md` and
  `AGENTS.md`.

## Verification

Focused branch checks:

- `bun run lint:ast-grep`: passed.
- Positive fixture for `Result.err(new Error(...))`: failed as expected under the
  new rule.
- Positive fixture for direct `.blaze(...)`: failed as expected under the new
  rule.
- Negative fixture probes passed.

Stack-tip checks after all Stack 1 fixes:

- `bun run typecheck`: passed.
- `bun run test`: passed, 36 turbo tasks successful.
- `bun run lint`: passed, 23 turbo tasks successful.
- `bun run build`: passed, 21 turbo tasks successful.
- `bun run format:check`: passed.
- `bun run check`: passed.

Local review:

- Round 1 ast-grep review found no P0/P1/P2 issues.
- Round 2 full-stack integration review found no P0/P1/P2 issues across the
  structural lint integration.

## Risks / Rollout Notes

- These rules are intentionally narrow. They do not attempt to prove topo-aware,
  type-aware, or cross-file invariants; those remain Warden's job.
- The `.blaze(...)` rule ignores tests and Warden/testing internals where direct
  execution references are expected.

Closes: TRL-615
