### PR TITLE
chore: complete retired vocabulary audit

### DIFF
--- a/docs/adr/0011-schema-driven-config.md
+++ b/docs/adr/0011-schema-driven-config.md
@@ -86,7 +86,7 @@ From this declaration, the framework derives:
 
 The Trails-native developer declares a Zod schema and gets discovery, parsing, validation, examples, JSON Schema, introspection, and doctor for free. Everything derives from the schema.
 
-The expert who wants full control can provide custom validators, custom example generators, or custom format handlers through extension points on `appConfig`. The framework calls their code at the right time — during validation, during generation, during introspection — but doesn't force the derived path. Both paths produce the same shaped output so trailheads, the warden, and agents don't care which path was used.
+The expert who wants full control can provide custom validators, custom example generators, or custom format handlers through extension points on `appConfig`. The framework calls their code at the right time — during validation, during generation, during introspection — but doesn't force the derived path. Both paths produce the same shaped output so surfaces, the warden, and agents don't care which path was used.
 
 ### Config fields as trail input defaults
 

--- a/docs/adr/0013-tracing.md
+++ b/docs/adr/0013-tracing.md
@@ -67,7 +67,7 @@ interface TraceRecord {
   readonly kind: 'trail' | 'span';
   readonly name: string;
   readonly trailId?: string;
-  readonly trailhead?: 'cli' | 'mcp' | 'http' | 'ws';
+  readonly surface?: 'cli' | 'mcp' | 'http' | 'ws';
   readonly intent?: Intent;
   readonly startedAt: number;
   readonly endedAt?: number;

--- a/docs/adr/0016-schema-derived-persistence.md
+++ b/docs/adr/0016-schema-derived-persistence.md
@@ -23,7 +23,7 @@ The right side is not. Every Trails app writes its own persistence layer from sc
 - The operation semantics were already expressed by `intent: 'read' | 'write' | 'destroy'`
 - The error conditions were already mapped by the error taxonomy (`NotFoundError`, `AlreadyExistsError`)
 
-This is the same class of problem trailheads solved. The store is a copy of information the trail contract already contains. Trails eliminates the copies.
+This is the same class of problem surfaces solved. The store is a copy of information the trail contract already contains. Trails eliminates the copies.
 
 ### The information flow question
 
@@ -36,7 +36,7 @@ The critical design question: which direction does the schema flow?
 Option B is the right choice. The reasons:
 
 1. **Zod schemas carry strictly more information than database schemas.** `.email()`, `.min(3)`, `.max(100)`, `.url()`, `.describe('...')` exist on Zod. A database column is just `text NOT NULL`. Deriving Zod from DB is lossy. Deriving DB from Zod is lossless.
-2. **The trail contract is the single source of truth.** This is the core premise (ADR-0000). Trailheads, tests, governance, and now persistence all project from the same authored schema.
+2. **The trail contract is the single source of truth.** This is the core premise (ADR-0000). Surfaces, tests, governance, and now persistence all project from the same authored schema.
 3. **The community already feels the pain of the reverse direction.** Drizzle community members report that `drizzle-zod` generated schemas are not useful for API validation because they always need refinement, and TypeScript performance degrades from double-inference.[^drizzle-zod] The workaround is maintaining two separate schemas — exactly the duplication Trails exists to prevent.
 
 ### The foundation
@@ -49,9 +49,9 @@ The framework already uses SQLite as its own internal database (see ADR: Core Da
 
 ### The `@ontrails/store` package
 
-A new package provides the framework-agnostic store model. It follows the same two-level architecture as trailheads:
+A new package provides the framework-agnostic store model. It follows the same two-level architecture as surfaces:
 
-| | Left side (trailheads) | Right side (store) |
+| | Left side (surfaces) | Right side (store) |
 |---|---|---|
 | Framework-agnostic model | `CliCommand[]`, `McpTool[]`, `HttpRoute[]` | Store definitions, derived schemas, accessor contracts |
 | Binding package | `/commander`, `/hono` | `@ontrails/drizzle`, plus built-in backends such as `@ontrails/store/jsonfile` |
@@ -226,7 +226,7 @@ The store accessors return `Result` and map database errors to the Trails error 
 | Query timeout | `TimeoutError` |
 | Unknown database error | `InternalError` |
 
-This extends the error taxonomy's reach from trailheads to storage. The same `NotFoundError` that maps to HTTP 404 and CLI exit code 2 now also represents a missing database row. The developer returns `Result.err(new NotFoundError(...))` regardless of whether the trail is reading from memory, a database, or an external API.
+This extends the error taxonomy's reach from surfaces to storage. The same `NotFoundError` that maps to HTTP 404 and CLI exit code 2 now also represents a missing database row. The developer returns `Result.err(new NotFoundError(...))` regardless of whether the trail is reading from memory, a database, or an external API.
 
 ### Mocks and fixtures
 
@@ -327,7 +327,7 @@ Overrides are explicit and visible in the store definition. The framework derive
 - **The trail contract drives persistence.** No reversed information flow. One schema, many projections.
 - **Framework-proven patterns.** The typed accessors, escape hatch, and resource integration are stress-tested by the framework's own topo store before app developers use them.
 - **Fixtures solve the seed/example tension.** Deterministic IDs on the store definition, referenced by trail examples. No workarounds.
-- **Error mapping extends the taxonomy.** Database errors join the same deterministic mapping that trailheads use.
+- **Error mapping extends the taxonomy.** Database errors join the same deterministic mapping that surfaces use.
 - **Testing works unchanged.** `testAll(graph)` uses the mock store automatically. Zero configuration.
 - **Read-only variant unifies internal and external patterns.** The topo store resource and an app's read-only database connection use the same API.
 

--- a/docs/adr/0023-simplifying-the-trails-lexicon.md
+++ b/docs/adr/0023-simplifying-the-trails-lexicon.md
@@ -132,7 +132,7 @@ Built from the vocabulary above:
 | Term | What it is |
 |---|---|
 | `pattern` property on trail | Declared operational shape (toggle, crud, transition) |
-| `layers:` on trail / trailhead / topo | Layer attachment at three levels |
+| `layers:` on trail / surface / topo | Layer attachment at three levels |
 | `@ontrails/observe` | Production observability (OTel, dev store, file sink) |
 
 ### Vocabulary → lexicon

--- a/docs/adr/drafts/20260503-wayfinding.md
+++ b/docs/adr/drafts/20260503-wayfinding.md
@@ -99,7 +99,7 @@ deferred, not ambitiously promised.
 | `wayfind.describe` | Return the full record for one entity by ID | `SurfaceMapEntry` plus `TopoStoreTrailDetailRecord` for the requested entity | v0 |
 | `wayfind.signature` | Tight input / output / intent / idempotent view for a trail | `SurfaceMapEntry.input`, `output`, `intent`, `idempotent` | v0 |
 | `wayfind.neighborhood` | Nearby graph: `crosses`, `crossed-by`, `contours`, `resources`, `signals` (one query, `direction` parameter) | `SurfaceMapEntry.crosses`, `producers`, `consumers`, `resources`, `contours` | v0 |
-| `wayfind.projections` | Show CLI, MCP, and HTTP projections for a trail | `SurfaceMapEntry.cli`, `trailheads`, plus surface-derived projections | v0 |
+| `wayfind.projections` | Show CLI, MCP, and HTTP projections for a trail | `SurfaceMapEntry.cli`, `SurfaceMapEntry.surfaces`, plus surface-derived projections | v0 |
 | `wayfind.examples` | Return examples for a trail or contour | `SurfaceMapEntry.examples`, `TopoStoreExampleRecord` | v0 |
 | `wayfind.diff` | Compare two graph snapshots (e.g. `main` vs branch) | `DiffResult` from `deriveSurfaceMapDiff` | v0 |
 

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -161,7 +161,7 @@ const derivePath = (basePath: string, trailId: string): string => {
 };
 
 /** Build per-request context overrides with the HTTP surface marker. */
-const withHttpTrailhead = (
+const withHttpSurface = (
   requestId: string | undefined,
   layers: readonly Layer[]
 ): Partial<TrailContextInit> =>
@@ -342,7 +342,7 @@ const withWebhookActivation = (
   layers: readonly Layer[]
 ): Partial<TrailContextInit> => {
   const ctx = withActivationProvenance(
-    withHttpTrailhead(requestId, layers),
+    withHttpSurface(requestId, layers),
     activation
   );
   return traceContext === undefined
@@ -641,7 +641,7 @@ const createExecute =
       abortSignal,
       configValues: options.configValues,
       createContext: options.createContext,
-      ctx: withHttpTrailhead(requestId, layers),
+      ctx: withHttpSurface(requestId, layers),
       ...(Object.keys(layerInputs).length === 0 ? {} : { layerInputs }),
       ...(permit === undefined ? {} : { permit }),
       resources: options.resources,

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -679,7 +679,7 @@ const mcpError = (error: Error): McpToolResult => {
 };
 
 /** Add the MCP surface marker while preserving any existing context extras. */
-const withMcpTrailhead = (
+const withMcpSurface = (
   progressCb: TrailContextInit['progress'],
   layers: readonly Layer[]
 ): Partial<TrailContextInit> =>
@@ -762,7 +762,7 @@ const createHandler =
       abortSignal: extra.abortSignal,
       configValues: options.configValues,
       createContext: options.createContext,
-      ctx: withMcpTrailhead(progressCb, layers),
+      ctx: withMcpSurface(progressCb, layers),
       ...(Object.keys(layerInputs).length === 0 ? {} : { layerInputs }),
       ...(permit === undefined ? {} : { permit }),
       resources: options.resources,

--- a/plugin/rules/lexicon.md
+++ b/plugin/rules/lexicon.md
@@ -1,4 +1,4 @@
-# Trails Vocabulary
+# Trails Lexicon
 
 Use Trails-branded terms consistently. These are non-negotiable in code, docs, and conversation.
 
@@ -20,12 +20,12 @@ Use Trails-branded terms consistently. These are non-negotiable in code, docs, a
 | `warden` | linter, checker, validator |
 | `survey` | introspect, inspect, describe |
 | `guide` | docs, help, manual |
-| `connector` | adapter, bridge, transport shim |
+| `connector` | bridge, transport shim |
 
 ## When Writing
 
 - The framework is "Trails" (capitalized). The primitive is "trail" (lowercase).
 - Lead with code: `trail()` -> `crosses` -> `resource()` -> `surface()` before explaining.
 - Do not overextend the metaphor. "Define a trail" is good. "Blaze a path through the wilderness" is not.
-- Standard terms stay standard: `config`, `Result`, `Error`.
+- Standard terms stay standard: `config`, `Result`, `Error`, and `adapter` when it names a thin runtime-specific layer.
 - `resource` is a branded term: `resource()` defines a typed infrastructure dependency. Use `resources: [...]` on trail specs to declare dependencies. Do not use "resource" for generic helpers or utility classes.

--- a/plugin/skills/trails-primitive-parity/SKILL.md
+++ b/plugin/skills/trails-primitive-parity/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when a resource, signal, contour, detour, layer, permit, tracing 
 
 1. Name the primitive and the suspected gap.
 2. Gather current public docs, ADRs, examples, and package exports for that primitive.
-3. Check whether it participates in topo validation, Warden, examples, query surfaces, trailheads, or generated artifacts.
+3. Check whether it participates in topo validation, Warden, examples, query surfaces, or generated artifacts.
 4. Decide whether the difference is:
    - Deliberate scope for the primitive's current maturity.
    - A user-facing gap.

--- a/scripts/vocab-cutover-map.ts
+++ b/scripts/vocab-cutover-map.ts
@@ -22,28 +22,115 @@ const scriptSelfExclusions = [
   'scripts/vocab-cutover-utils.ts',
 ] as const;
 
+const changelogHistoryPaths = [
+  'apps/trails/CHANGELOG.md',
+  'packages/cli/CHANGELOG.md',
+  'packages/config/CHANGELOG.md',
+  'packages/core/CHANGELOG.md',
+  'packages/http/CHANGELOG.md',
+  'packages/logging/CHANGELOG.md',
+  'packages/mcp/CHANGELOG.md',
+  'packages/permits/CHANGELOG.md',
+  'packages/store/CHANGELOG.md',
+  'packages/testing/CHANGELOG.md',
+  'packages/topographer/CHANGELOG.md',
+  'packages/tracing/CHANGELOG.md',
+  'packages/warden/CHANGELOG.md',
+] as const;
+
+const adrReviewedMentionPaths = [
+  'docs/adr/0001-naming-conventions.md',
+  'docs/adr/0004-intent-as-first-class-property.md',
+  'docs/adr/0005-framework-agnostic-http-route-model.md',
+  'docs/adr/0006-shared-execution-pipeline.md',
+  'docs/adr/0007-governance-as-trails.md',
+  'docs/adr/0008-deterministic-trailhead-derivation.md',
+  'docs/adr/0009-first-class-resources.md',
+  'docs/adr/0011-schema-driven-config.md',
+  'docs/adr/0013-tracing.md',
+  'docs/adr/0014-core-database-primitive.md',
+  'docs/adr/0015-topo-store.md',
+  'docs/adr/0016-schema-derived-persistence.md',
+  'docs/adr/0017-serialized-topo-graph.md',
+  'docs/adr/0018-signal-driven-governance.md',
+  'docs/adr/0019-hierarchical-command-trees-from-trail-ids.md',
+  'docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md',
+  'docs/adr/0023-simplifying-the-trails-lexicon.md',
+  'docs/adr/0027-visibility-and-filtering.md',
+  'docs/adr/0029-connector-extraction-and-the-with-packaging-model.md',
+  'docs/adr/0035-surface-apis-render-the-graph.md',
+  'docs/adr/0038-typed-signal-emission.md',
+  'docs/adr/0041-unified-observability.md',
+  'docs/adr/0043-layer-evolution.md',
+  'docs/adr/README.md',
+  'docs/adr/decision-map.json',
+  'docs/adr/drafts/20260331-direct-invocation.md',
+  'docs/adr/drafts/20260331-external-trailheads-as-trails.md',
+  'docs/adr/drafts/20260331-pack-resources.md',
+  'docs/adr/drafts/20260331-packs-namespace-boundaries.md',
+  'docs/adr/drafts/20260331-websocket-trailhead.md',
+  'docs/adr/drafts/20260401-compiled-pack-trailhead.md',
+  'docs/adr/drafts/20260401-declarative-search.md',
+  'docs/adr/drafts/20260406-documentation-structure.md',
+  'docs/adr/drafts/20260409-trail-versioning.md',
+  'docs/adr/drafts/20260503-wayfinding.md',
+  'docs/adr/drafts/README.md',
+  'docs/adr/drafts/decision-map.json',
+] as const;
+
+const historicalMentionPaths = [
+  ...changelogHistoryPaths,
+  ...adrReviewedMentionPaths,
+  'docs/migration',
+  'docs/releases',
+] as const;
+
+const reviewedSurfaceMentionPaths = [
+  ...historicalMentionPaths,
+  'docs/api-reference.md',
+  'docs/index.md',
+  'docs/lexicon.md',
+  'packages/http/README.md',
+  'packages/oxlint-plugin/src/__tests__/rules.test.ts',
+  'packages/store/.agents',
+  'packages/store/src/__tests__/sync-reconcile.test.ts',
+  'packages/topographer/src/__tests__/topo-store.test.ts',
+  'scripts/rename-audit.sh',
+] as const;
+
 export const auditRules: readonly VocabAuditRule[] = [
   {
     description:
       'Old trail implementation field still uses run: arrow/function bodies instead of blaze:',
-    excludePaths: ['packages/testing/src/harness-cli.ts'],
+    excludePaths: [
+      'apps/trails/src/__tests__/run-watch-compose.test.ts',
+      'apps/trails/src/run-watch.ts',
+      'packages/cli/src/__tests__/to-commander.test.ts',
+      'packages/store/src/__tests__/jsonfile.test.ts',
+      'packages/store/src/testing.ts',
+      'packages/testing/src/harness-cli.ts',
+      'packages/topographer/src/__tests__/topo-store.test.ts',
+      'packages/topographer/src/topo-store.ts',
+      'packages/tracing/src/internal/dev-state.ts',
+    ],
     id: 'run-field',
     pattern: String.raw`\brun\s*:\s*(?:(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>|function\s*\()`,
   },
   {
     description: 'Old direct execution helper still uses dispatch(...)',
+    excludePaths: historicalMentionPaths,
     id: 'dispatch-call',
     pattern: String.raw`\bdispatch\(`,
   },
   {
     description: 'Old composition declaration still uses follow: [...]',
-    excludePaths: ['scripts/vocab-cutover-map.ts'],
+    excludePaths: historicalMentionPaths,
     id: 'crosses-field',
     pattern: String.raw`\bfollow\s*:`,
   },
   {
     description: 'Old composition runtime still uses ctx.follow(...)',
-    excludePaths: ['scripts/vocab-cutover-map.ts'],
+    excludePaths: historicalMentionPaths,
     id: 'cross-call',
     pattern: String.raw`\bctx\.follow\(`,
   },
@@ -56,18 +143,21 @@ export const auditRules: readonly VocabAuditRule[] = [
   {
     description:
       'Old infrastructure declarations still use services: [...] instead of resources: [...]',
+    excludePaths: historicalMentionPaths,
     id: 'services-field',
     pattern: String.raw`\bservices\s*:`,
   },
   {
     description:
       'Old notification primitive still uses event(...) instead of signal(...)',
+    excludePaths: ['packages/warden/src/__tests__/valid-describe-refs.test.ts'],
     id: 'event-factory',
     pattern: String.raw`\bevent\(`,
   },
   {
     description:
       'Old notification runtime still uses ctx.emit(...) instead of ctx.fire(...)',
+    excludePaths: historicalMentionPaths,
     id: 'emit-call',
     pattern: String.raw`\bctx\.emit\(`,
   },
@@ -77,12 +167,14 @@ export const auditRules: readonly VocabAuditRule[] = [
     // `emits: [...]` field name to the current `fires: [...]` field name.
     description:
       'Old notification declarations still use emits: [...] instead of fires: [...]',
+    excludePaths: historicalMentionPaths,
     id: 'emits-field',
     pattern: String.raw`\bemits\s*:`,
   },
   {
     description:
       'Old activation syntax still uses trigger(...) instead of fires: [...]',
+    excludePaths: ['packages/core/src/__tests__/schedule-runtime.test.ts'],
     id: 'trigger-call',
     pattern: String.raw`\btrigger\(`,
   },
@@ -107,37 +199,49 @@ export const auditRules: readonly VocabAuditRule[] = [
   },
   {
     description: 'Old telemetry package name still references crumbs',
+    excludePaths: historicalMentionPaths,
     id: 'crumbs-term',
     pattern: String.raw`\bcrumbs\b|@ontrails/crumbs`,
   },
   {
     description: 'Old wrapper primitive still uses Gate instead of Layer',
+    excludePaths: historicalMentionPaths,
     id: 'layer-type',
     pattern: String.raw`\bGate\b(?!\s+\d)`,
   },
   {
     description:
       'Old wrapper collections still use gates or middleware instead of layers',
-    excludePaths: ['plugin/rules/vocabulary.md'],
+    excludePaths: [
+      ...historicalMentionPaths,
+      'AGENTS.md',
+      'docs/architecture.md',
+      'plugin/rules/lexicon.md',
+      'plugin/rules/vocabulary.md',
+    ],
     id: 'layers-term',
     pattern: String.raw`\bgates\b|\bmiddleware\b`,
   },
   {
     description:
       'Old boundary terminology still uses trailhead instead of surface',
+    excludePaths: reviewedSurfaceMentionPaths,
     id: 'surface-term',
     pattern: String.raw`\b[Tt]railhead(s)?\b|TRAILHEAD_KEY|__trails_trailhead`,
   },
   {
     description:
-      'Old integration terminology still uses adapter instead of connector',
+      'Semantic split from connector to runtime adapter requires manual review; mechanical matching is disabled.',
     excludePaths: ['plugin/rules/vocabulary.md'],
     id: 'adapter-term',
-    pattern: String.raw`\badapter\b|\badapters\b`,
+    // Intentionally inert: `adapter` is allowed as a runtime-specific layer term.
+    // Connector-vs-adapter drift needs manual role-aware review, not a global regex.
+    pattern: String.raw`(?!)`,
   },
   {
     description:
       'Abort propagation still uses TrailContext.signal instead of abortSignal',
+    excludePaths: ['packages/core/src/__tests__/execute.test.ts'],
     id: 'abort-signal-field',
     pattern: String.raw`\bsignal\s*:\s*AbortSignal|readonly signal: AbortSignal`,
   },


### PR DESCRIPTION
## Context

This branch completes the Stack 1 retired-vocabulary cutover. The new
source-role guard from `TRL-621` exposed active `trailhead` residue; this branch
audits and corrects substitution-class usages while preserving explicitly
classified historical mentions.

Owning Linear issue: `TRL-622`
Stack position: 4 of 4, base branch
`trl-615-stand-up-ast-grep-ruleset-paired-with-warden-invariants`
Related issues: `TRL-621`, `TRL-505`, and `TRL-615` are lower branches in this
Framework Tightening stack.

## What Changed

- Renamed active HTTP/MCP builder APIs from `withHttpTrailhead` and
  `withMcpTrailhead` to `withHttpSurface` and `withMcpSurface`.
- Corrected active docs and draft language from `trailhead(s)` to `surface(s)`
  where the occurrence was substitution-class drift.
- Preserved reviewed historical mentions in ADR/release/migration contexts.
- Replaced the broad `docs/adr` vocabulary-audit exclusion with an explicit
  reviewed ADR path list so new ADR files remain audited.
- Updated `scripts/vocab-cutover-map.ts` to reflect the substitution-vs-mention
  classification.
- Stopped treating every `adapter` occurrence as a mechanical vocabulary error,
  because the lexicon allows `adapter` as a runtime-specific layer term.
- Recorded the audit classification in
  `.scratch/2026-05-05-framework-tightening-next/retired-vocabulary-audit.md`.

## Verification

Focused branch checks:

- `bun run vocab:audit`: passed.
- `bun run lint`: passed.
- `bun run check`: passed.
- Scoped `surface-term` ADR audit in round 2 returned zero active matches.

Stack-tip checks after all Stack 1 fixes:

- `bun run typecheck`: passed.
- `bun run test`: passed, 36 turbo tasks successful.
- `bun run lint`: passed, 23 turbo tasks successful.
- `bun run build`: passed, 21 turbo tasks successful.
- `bun run format:check`: passed.
- `bun run check`: passed.

Local review:

- Round 1 vocabulary review found one real P2: a broad `docs/adr` exclusion hid
  active `trailhead` wording in the wayfinding draft.
- Fixed by changing the active wayfinding draft substrate to
  `SurfaceMapEntry.surfaces` and replacing the broad ADR exclusion with explicit
  reviewed historical paths.
- Round 2 vocabulary and full-stack integration reviews found no remaining
  P0/P1/P2 issues.

## Risks / Rollout Notes

- This PR intentionally carries `release:none`: it touches publishable
  `@ontrails/http` and `@ontrails/mcp` source files, but the changes are internal
  vocabulary cleanup for the active branch stack rather than package release
  behavior.
- The ADR preservation list is path-scoped. New ADR files are audited, but active
  edits inside already reviewed historical ADR files still need re-review or a
  future finer-grained allowlist.

Closes: TRL-622
