### PR TITLE
fix(ci): align governance formatter status

### DIFF
--- a/apps/ci/src/__tests__/governance.test.ts
+++ b/apps/ci/src/__tests__/governance.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import type { DriftResult, WardenReport } from '@ontrails/warden';
 
+import { formatCiOutput } from '../formatters.js';
 import { createDriftOnlyReport, evaluateCiGovernance } from '../governance.js';
 
 const staleDrift: DriftResult = {
@@ -156,6 +157,31 @@ The trails.lock file is out of date. Regenerate with \`trails topo compile\`.
     });
 
     expect(result.passed).toBe(false);
+    expect(JSON.parse(result.output) as { passed: boolean }).toMatchObject({
+      passed: false,
+    });
+    expect(result.summary).toContain('**Result: FAIL**');
+  });
+
+  test('formats warning-only summary output as failing when failOn is warning', () => {
+    const result = evaluateCiGovernance({
+      driftResult: cleanDrift,
+      failOn: 'warning',
+      format: 'summary',
+      wardenReport: warningOnlyReport,
+    });
+
+    expect(result.output).toContain('**Result: FAIL**');
+  });
+
+  test('formats warning-only fallback output as failing when failOn is warning', () => {
+    const output = formatCiOutput('summary', {
+      driftResult: cleanDrift,
+      failOn: 'warning',
+      wardenReport: warningOnlyReport,
+    });
+
+    expect(output).toContain('**Result: FAIL**');
   });
 
   test('fails when error diagnostics are present', () => {

--- a/apps/ci/src/formatters.ts
+++ b/apps/ci/src/formatters.ts
@@ -11,11 +11,22 @@ import type { DriftResult, WardenReport } from '@ontrails/warden';
 
 /** Supported CI output formats */
 export type CiFormat = 'github' | 'json' | 'summary';
+export type CiFailOn = 'error' | 'warning';
 
 interface CiOutput {
   readonly wardenReport: WardenReport;
   readonly driftResult: DriftResult;
+  readonly failOn?: CiFailOn | undefined;
+  readonly passed?: boolean | undefined;
 }
+
+const resolvePassed = (output: CiOutput): boolean =>
+  output.passed ??
+  (!output.driftResult.stale &&
+    output.driftResult.blockedReason === undefined &&
+    output.wardenReport.passed &&
+    ((output.failOn ?? 'error') !== 'warning' ||
+      output.wardenReport.warnCount === 0));
 
 /** Format warden diagnostics as GitHub Actions annotations */
 const formatGitHub = (output: CiOutput): string => {
@@ -45,7 +56,7 @@ const formatJson = (output: CiOutput): string =>
         hasDrift: output.driftResult.stale,
         ...output.driftResult,
       },
-      passed: output.wardenReport.passed && !output.driftResult.stale,
+      passed: resolvePassed(output),
       warden: {
         diagnostics: output.wardenReport.diagnostics,
         errorCount: output.wardenReport.errorCount,
@@ -90,7 +101,7 @@ const summaryDriftSection = (drift: DriftResult): string[] => {
 
 /** Format as markdown summary */
 const formatSummary = (output: CiOutput): string => {
-  const passed = output.wardenReport.passed && !output.driftResult.stale;
+  const passed = resolvePassed(output);
   const result = passed ? '**Result: PASS**' : '**Result: FAIL**';
 
   return [

--- a/apps/ci/src/governance.ts
+++ b/apps/ci/src/governance.ts
@@ -12,10 +12,10 @@ import type {
   WardenReport,
 } from '@ontrails/warden';
 
-import type { CiFormat } from './formatters.js';
+import type { CiFailOn, CiFormat } from './formatters.js';
 import { formatCiOutput } from './formatters.js';
 
-export type CiFailOn = 'error' | 'warning';
+export type { CiFailOn } from './formatters.js';
 
 export interface CiGovernanceResult {
   readonly driftResult: DriftResult;
@@ -212,25 +212,30 @@ export const evaluateCiGovernance = ({
   format,
   wardenReport,
 }: EvaluateCiGovernanceOptions): CiGovernanceResult => {
-  const output = formatCiOutput(format, {
-    driftResult,
-    wardenReport,
-  });
-  const summary = formatCiOutput('summary', {
-    driftResult,
-    wardenReport,
-  });
   const failedByErrors = wardenReport.errorCount > 0;
   const failedByWarnings = failOn === 'warning' && wardenReport.warnCount > 0;
   const hasDrift = driftResult.stale;
   const hasBlockedDrift = driftResult.blockedReason !== undefined;
+  const passed =
+    !failedByErrors && !failedByWarnings && !hasDrift && !hasBlockedDrift;
+  const output = formatCiOutput(format, {
+    driftResult,
+    failOn,
+    passed,
+    wardenReport,
+  });
+  const summary = formatCiOutput('summary', {
+    driftResult,
+    failOn,
+    passed,
+    wardenReport,
+  });
 
   return {
     driftResult,
     errorCount: wardenReport.errorCount,
     output,
-    passed:
-      !failedByErrors && !failedByWarnings && !hasDrift && !hasBlockedDrift,
+    passed,
     summary,
     wardenReport,
     warningCount: wardenReport.warnCount,


### PR DESCRIPTION
## Context

TRL-392 fixes a CI governance reporting mismatch where formatter/governance output could present a passed state that did not line up with the computed exit status under warning/error policy combinations.

## What Changed

- Aligned the governance formatter's JSON/GitHub/summary output around the durable evaluated status.
- Kept warning-only runs passing or failing according to the configured `failOn` threshold.
- Preserved the existing output shape while making the displayed status match the exit-code decision.

## Tests Run

- `bun scripts/adr.ts map`
- `bun scripts/adr.ts check`
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run build`
- `bun run format:check`
- `bun run check`

## Risks / Rollout

Low risk. This changes CI governance reporting semantics, not runtime framework behavior. The intended user-facing effect is clearer CI output when governance warnings are configured as non-fatal or fatal.

Closes: TRL-392