### PR TITLE
feat(permits): configure auth resource connectors

### DIFF
--- a/.changeset/auth-resource-config.md
+++ b/.changeset/auth-resource-config.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/core": patch
+"@ontrails/cli": patch
+"@ontrails/permits": minor
+"@ontrails/trails": patch
+---
+
+Thread `ResourceSpec.config` through the built-in auth resource. Resource config schemas that accept `undefined` now receive their parsed default when config values are omitted, and `authResource` can materialize the no-op or JWT connector from typed config while preserving existing mock and override paths.

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -86,6 +86,7 @@ const maybeInstallTraceSession = (): TraceSession | undefined =>
 const resolveCliPermitFromToken: ResolveCliPermitFromToken = (input) =>
   resolvePermitFromBearerToken({
     bearerToken: input.token,
+    configValues: input.configValues,
     env: process.env as Record<string, string | undefined>,
     graph: input.graph,
     missingAuthResourceMessage:

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -76,6 +76,7 @@ export interface ActionResultContext {
 }
 
 export interface ResolveCliPermitFromTokenInput {
+  readonly configValues?: BaseSurfaceOptions['configValues'] | undefined;
   readonly graph: Topo;
   readonly requestId: string;
   readonly resources?: ResourceOverrideMap | undefined;
@@ -686,6 +687,7 @@ const resolvePermitForExecution = async (
   }
   const requestId = Bun.randomUUIDv7();
   return await options.resolvePermitFromToken({
+    configValues: options.configValues,
     graph,
     requestId,
     resources: options.resources,

--- a/packages/core/src/__tests__/service-config.test.ts
+++ b/packages/core/src/__tests__/service-config.test.ts
@@ -153,6 +153,32 @@ describe('ResourceContext.config', () => {
     expect(result.error.message).toContain(id);
   });
 
+  test('defaulted config schema receives its default when configValues omits the resource', async () => {
+    const id = nextId('defaulted-config');
+    let capturedConfig: unknown;
+
+    const svc = resource(id, {
+      config: z.object({ mode: z.literal('noop') }).default({ mode: 'noop' }),
+      create: (ctx: ResourceContext<{ mode: 'noop' }>) => {
+        capturedConfig = ctx.config;
+        return Result.ok({ mode: ctx.config.mode });
+      },
+    });
+
+    const svcTrail = trail('svc-config.defaulted', {
+      blaze: (_input, ctx) => Result.ok({ mode: svc.from(ctx).mode }),
+      input: z.object({}),
+      output: z.object({ mode: z.literal('noop') }),
+      resources: [svc],
+    });
+
+    const result = await executeTrail(svcTrail, {});
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ mode: 'noop' });
+    expect(capturedConfig).toEqual({ mode: 'noop' });
+  });
+
   test('resource override bypasses config validation', async () => {
     const id = nextId('override-bypass');
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,8 +107,11 @@ export {
   isResource,
   resource,
 } from './resource.js';
-export { drainResources } from './resource-config.js';
-export type { ResourceDrainReport } from './resource-config.js';
+export { drainResources, resolveResourceConfig } from './resource-config.js';
+export type {
+  ResourceConfigValues,
+  ResourceDrainReport,
+} from './resource-config.js';
 export type {
   AnyResource,
   Resource,

--- a/packages/core/src/resource-config.ts
+++ b/packages/core/src/resource-config.ts
@@ -11,6 +11,7 @@ import type {
   ResourceContext,
   ResourceOverrideMap,
 } from './resource.js';
+import type { SurfaceConfigValues } from './surface-derivation.js';
 import type { AnyTrail } from './trail.js';
 import type { TrailContext } from './types.js';
 
@@ -22,7 +23,9 @@ type MutableTrailContext = {
   -readonly [K in keyof TrailContext]: TrailContext[K];
 };
 
-type ConfigValues = Readonly<Record<string, Record<string, unknown>>>;
+export type ResourceConfigValues = SurfaceConfigValues;
+
+type ConfigValues = ResourceConfigValues;
 
 // ---------------------------------------------------------------------------
 // Singleton caches
@@ -84,7 +87,7 @@ const toResourceContextKey = (ctx: ResourceContext): string =>
 // ---------------------------------------------------------------------------
 
 /** Validate and resolve a resource's config from the provided configValues map. */
-const resolveResourceConfig = (
+export const resolveResourceConfig = (
   declaredResource: AnyResource,
   configValues?: ConfigValues
 ): Result<unknown, Error> => {
@@ -93,6 +96,10 @@ const resolveResourceConfig = (
   }
   const raw = configValues?.[declaredResource.id];
   if (raw === undefined) {
+    const parsed = declaredResource.config.safeParse(raw);
+    if (parsed.success) {
+      return Result.ok(parsed.data);
+    }
     return Result.err(
       new ValidationError(
         `Resource "${declaredResource.id}" declares a config schema but no config was provided`

--- a/packages/permits/src/__tests__/auth-resource.test.ts
+++ b/packages/permits/src/__tests__/auth-resource.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from 'bun:test';
 
 import type { ResourceContext } from '@ontrails/core';
 
+import type { AuthResourceConfig } from '../auth-resource.js';
 import type { AuthConnector } from '../connectors/connector.js';
-import { authResource } from '../auth-resource.js';
+import { authResource, authResourceConfigSchema } from '../auth-resource.js';
 import type { PermitExtractionInput } from '../extraction.js';
+import { TEST_SECRET, signJwt } from './helpers/jwt.js';
 
 /** Minimal extraction input for tests. */
 const testInput = (
@@ -19,8 +21,8 @@ const testInput = (
 // Helpers
 // ---------------------------------------------------------------------------
 
-const testSvcCtx: ResourceContext = {
-  config: undefined,
+const testSvcCtx: ResourceContext<AuthResourceConfig> = {
+  config: authResourceConfigSchema.parse(),
   cwd: '/tmp',
   env: {},
   workspaceRoot: '/tmp',
@@ -38,6 +40,12 @@ describe('authResource', () => {
 
   test('has infrastructure meta', () => {
     expect(authResource.meta).toEqual({ category: 'infrastructure' });
+  });
+
+  test('defaults config to the no-op connector', () => {
+    expect(authResourceConfigSchema.parse()).toEqual({
+      connector: 'none',
+    });
   });
 
   test('mock returns an AuthConnector', async () => {
@@ -58,5 +66,38 @@ describe('authResource', () => {
     const authResult = await connector.authenticate(testInput());
     expect(authResult.isOk()).toBe(true);
     expect(authResult.unwrap()).toBeNull();
+  });
+
+  test('create wires JWT config into a real connector', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, scope: 'read write', sub: 'user-42' },
+      TEST_SECRET
+    );
+
+    const result = await authResource.create({
+      ...testSvcCtx,
+      config: { connector: 'jwt', secret: TEST_SECRET },
+    });
+
+    expect(result.isOk()).toBe(true);
+    const connector = result.unwrap() as AuthConnector;
+    const authResult = await connector.authenticate(
+      testInput({ bearerToken: token })
+    );
+    expect(authResult.isOk()).toBe(true);
+    expect(authResult.unwrap()).toEqual({
+      id: 'user-42',
+      scopes: ['read', 'write'],
+    });
+  });
+
+  test('JWT config requires the implemented secret-backed connector path', () => {
+    const parsed = authResourceConfigSchema.safeParse({
+      connector: 'jwt',
+      jwksUrl: 'https://example.com/.well-known/jwks.json',
+    });
+
+    expect(parsed.success).toBe(false);
   });
 });

--- a/packages/permits/src/__tests__/auth-verify.test.ts
+++ b/packages/permits/src/__tests__/auth-verify.test.ts
@@ -178,6 +178,33 @@ describe('auth.verify trail', () => {
       expect(value.error).toBeUndefined();
     });
 
+    test('materializes the auth resource from configValues', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const token = await signJwt(
+        { exp: now + 3600, scope: 'read write', sub: 'user-42' },
+        TEST_SECRET
+      );
+
+      const result = await executeTrail(
+        authVerify,
+        { token },
+        {
+          configValues: {
+            [authResource.id]: { connector: 'jwt', secret: TEST_SECRET },
+          },
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toMatchObject({
+        permit: {
+          id: 'user-42',
+          scopes: ['read', 'write'],
+        },
+        valid: true,
+      });
+    });
+
     test('returns the full permit payload from the connector', async () => {
       const permit: Permit = {
         id: 'user-42',

--- a/packages/permits/src/__tests__/boundary.test.ts
+++ b/packages/permits/src/__tests__/boundary.test.ts
@@ -8,8 +8,10 @@ import {
   topo,
 } from '@ontrails/core';
 
+import { authResource } from '../auth-resource.js';
 import { resolvePermitFromBearerToken } from '../boundary.js';
 import type { PermitExtractionInput } from '../extraction.js';
+import { TEST_SECRET, signJwt } from './helpers/jwt.js';
 
 const authResourceDef = resource<{
   readonly authenticate: (
@@ -29,6 +31,9 @@ const authResourceDef = resource<{
 });
 
 const app = topo('auth-boundary-test', { auth: authResourceDef });
+const configuredApp = topo('auth-boundary-config-test', {
+  auth: authResource,
+});
 
 describe('resolvePermitFromBearerToken', () => {
   test('resolves a bearer token through an override auth connector', async () => {
@@ -70,6 +75,29 @@ describe('resolvePermitFromBearerToken', () => {
     expect(result.unwrap()).toEqual({
       id: 'created-user',
       scopes: ['created:read'],
+    });
+  });
+
+  test('materializes a declared auth resource with configValues', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { exp: now + 3600, scope: 'read write', sub: 'configured-user' },
+      TEST_SECRET
+    );
+
+    const result = await resolvePermitFromBearerToken({
+      bearerToken: token,
+      configValues: {
+        [authResource.id]: { connector: 'jwt', secret: TEST_SECRET },
+      },
+      graph: configuredApp,
+      requestId: 'req-config',
+      surface: 'cli',
+    });
+
+    expect(result.unwrap()).toEqual({
+      id: 'configured-user',
+      scopes: ['read', 'write'],
     });
   });
 

--- a/packages/permits/src/__tests__/helpers/jwt.ts
+++ b/packages/permits/src/__tests__/helpers/jwt.ts
@@ -1,0 +1,37 @@
+export const TEST_SECRET = 'test-secret-for-hmac-256';
+
+const base64url = (buf: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCodePoint(b);
+  }
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '');
+};
+
+const base64urlEncode = (str: string): string => {
+  const encoder = new TextEncoder();
+  return base64url(encoder.encode(str).buffer as ArrayBuffer);
+};
+
+export const signJwt = async (
+  payload: Record<string, unknown>,
+  secret = TEST_SECRET
+): Promise<string> => {
+  const header = base64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64urlEncode(JSON.stringify(payload));
+  const data = `${header}.${body}`;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(data));
+  return `${data}.${base64url(sig)}`;
+};

--- a/packages/permits/src/auth-resource.ts
+++ b/packages/permits/src/auth-resource.ts
@@ -1,26 +1,89 @@
 import { Result, resource } from '@ontrails/core';
+import { z } from 'zod';
 
 import type { AuthConnector } from './connectors/connector.js';
+import { createJwtConnector } from './connectors/jwt.js';
+import type { JwtConnectorOptions } from './connectors/jwt.js';
+
+const authNoneConfigSchema = z
+  .object({
+    connector: z.literal('none'),
+  })
+  .readonly();
+
+const authJwtConfigSchema = z
+  .object({
+    allowedAlgorithms: z.array(z.literal('HS256')).readonly().optional(),
+    audience: z.string().optional(),
+    clockSkewSeconds: z.number().int().nonnegative().optional(),
+    connector: z.literal('jwt'),
+    issuer: z.string().optional(),
+    requireExpiration: z.boolean().optional(),
+    rolesClaim: z.string().min(1).optional(),
+    scopesClaim: z.string().min(1).optional(),
+    secret: z.string().min(1),
+  })
+  .strict()
+  .readonly();
+
+export const authResourceConfigSchema = z
+  .discriminatedUnion('connector', [authNoneConfigSchema, authJwtConfigSchema])
+  .default({ connector: 'none' });
+
+export type AuthResourceConfig = z.infer<typeof authResourceConfigSchema>;
+
+const createNoopConnector = (): AuthConnector => ({
+  // oxlint-disable-next-line require-await -- no-op connector satisfies async interface
+  authenticate: async () => Result.ok(null),
+});
+
+const createConnector = (config: AuthResourceConfig): AuthConnector => {
+  switch (config.connector) {
+    case 'none': {
+      return createNoopConnector();
+    }
+    case 'jwt': {
+      const jwtOptions: JwtConnectorOptions = {
+        ...(config.allowedAlgorithms === undefined
+          ? {}
+          : { allowedAlgorithms: config.allowedAlgorithms }),
+        ...(config.audience === undefined ? {} : { audience: config.audience }),
+        ...(config.clockSkewSeconds === undefined
+          ? {}
+          : { clockSkewSeconds: config.clockSkewSeconds }),
+        ...(config.issuer === undefined ? {} : { issuer: config.issuer }),
+        ...(config.requireExpiration === undefined
+          ? {}
+          : { requireExpiration: config.requireExpiration }),
+        ...(config.rolesClaim === undefined
+          ? {}
+          : { rolesClaim: config.rolesClaim }),
+        ...(config.scopesClaim === undefined
+          ? {}
+          : { scopesClaim: config.scopesClaim }),
+        secret: config.secret,
+      };
+      return createJwtConnector(jwtOptions);
+    }
+    default: {
+      const exhaustive: never = config;
+      void exhaustive;
+      return createNoopConnector();
+    }
+  }
+};
 
 /**
  * Auth resource — manages the auth connector lifecycle.
  *
- * The v1 factory returns a no-op connector that always succeeds (null permit).
- * Real connector configuration will come through `ResourceSpec.config`
- * (TRL-620). The mock factory provides a synthetic connector that always
- * succeeds.
+ * Defaults to a no-op connector that always succeeds with a null permit, and
+ * can be configured through `ResourceSpec.config` to materialize built-in
+ * connectors such as JWT.
  */
 export const authResource = resource<AuthConnector>('auth', {
-  create: (_svc) =>
-    Result.ok({
-      // oxlint-disable-next-line require-await -- stub connector satisfies async interface
-      authenticate: async () => Result.ok(null),
-    } satisfies AuthConnector),
+  config: authResourceConfigSchema,
+  create: (svc) => Result.ok(createConnector(svc.config as AuthResourceConfig)),
   description: 'Authentication connector',
   meta: { category: 'infrastructure' },
-  mock: () =>
-    ({
-      // oxlint-disable-next-line require-await -- mock connector satisfies async interface
-      authenticate: async () => Result.ok(null),
-    }) satisfies AuthConnector,
+  mock: createNoopConnector,
 });

--- a/packages/permits/src/boundary.ts
+++ b/packages/permits/src/boundary.ts
@@ -2,6 +2,7 @@ import type {
   AnyResource,
   BasePermit,
   ResourceOverrideMap,
+  SurfaceConfigValues,
   Topo,
 } from '@ontrails/core';
 import {
@@ -9,6 +10,7 @@ import {
   Result,
   ValidationError,
   basePermitSchema,
+  resolveResourceConfig,
 } from '@ontrails/core';
 
 import type { AuthConnector } from './connectors/connector.js';
@@ -32,6 +34,7 @@ export interface ResolvePermitFromBearerTokenOptions {
   readonly requestId: string;
   readonly surface: PermitExtractionInput['surface'];
   readonly resources?: ResourceOverrideMap | undefined;
+  readonly configValues?: SurfaceConfigValues | undefined;
   readonly headers?: Headers | undefined;
   readonly sessionId?: string | undefined;
   readonly cwd?: string | undefined;
@@ -73,7 +76,7 @@ const materializeAuthConnector = async (
   resolved: LocatedAuthResource,
   options: Pick<
     ResolvePermitFromBearerTokenOptions,
-    'cwd' | 'env' | 'workspaceRoot'
+    'configValues' | 'cwd' | 'env' | 'workspaceRoot'
   >
 ): Promise<Result<AuthConnector, Error>> => {
   if (resolved.kind === 'override') {
@@ -89,8 +92,15 @@ const materializeAuthConnector = async (
   }
 
   const cwd = options.cwd ?? process.cwd();
+  const configResult = resolveResourceConfig(
+    resolved.resource,
+    options.configValues
+  );
+  if (configResult.isErr()) {
+    return configResult;
+  }
   const created = await resolved.resource.create({
-    config: undefined,
+    config: configResult.value,
     cwd,
     env: options.env ?? {},
     workspaceRoot: options.workspaceRoot ?? cwd,

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -9,7 +9,11 @@ export {
   type JwtAlgorithm,
   type JwtConnectorOptions,
 } from './connectors/jwt.js';
-export { authResource } from './auth-resource.js';
+export {
+  authResource,
+  authResourceConfigSchema,
+  type AuthResourceConfig,
+} from './auth-resource.js';
 export {
   AUTH_RESOURCE_ID,
   resolvePermitFromBearerToken,


### PR DESCRIPTION
## Context

TRL-620 wires `ResourceSpec.config` into the auth connector/resource path so auth-backed resources can be configured through the same contract/config machinery as other resources.

## What Changed

- Added config-schema support to resource specs and config collection.
- Wired auth resource configuration through permits and the Trails CLI app config path.
- Updated the JWT auth resource path to require the implemented `secret` configuration and reject JWKS-only config until JWKS verification is actually implemented.
- Added a changeset covering `@ontrails/core`, `@ontrails/cli`, `@ontrails/permits`, and `@ontrails/trails`.

## Tests Run

- `bun test packages/permits/src/__tests__/auth-resource.test.ts packages/permits/src/__tests__/auth-verify.test.ts packages/permits/src/__tests__/boundary.test.ts`
- `bun run --cwd packages/permits typecheck`
- `bun run --cwd packages/permits lint`
- `bun run changeset:check` with the branch-local file list
- Full tip gate: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`

## Risks / Rollout

Moderate package-surface risk because `ResourceSpec.config` is additive public API and auth resource configuration is now validated earlier. JWT remains secret-based for now; JWKS-only config is intentionally rejected rather than accepted and failed later at runtime.

Closes: TRL-620