### PR TITLE
perf(topographer): batch signal relation reads

### DIFF
--- a/.changeset/topo-store-signal-batching.md
+++ b/.changeset/topo-store-signal-batching.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/topographer": patch
+---
+
+Batch topo-store signal relation reads for list views so signal consumers, producers, and source trails are loaded with one bounded query per relation table instead of per signal.

--- a/packages/topographer/src/__tests__/topo-store-read.test.ts
+++ b/packages/topographer/src/__tests__/topo-store-read.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
+import type { Database } from 'bun:sqlite';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -24,6 +25,7 @@ import {
 } from '../index.js';
 import { pinTopoSnapshot } from '../internal/topo-snapshots.js';
 import type { TopoSnapshot } from '../internal/topo-snapshots.js';
+import { listTopoStoreSignals } from '../internal/topo-store-read.js';
 
 const noop = () => Result.ok({ ok: true });
 
@@ -42,6 +44,44 @@ const requireValue = <T>(value: T | undefined, message: string): T => {
     throw new Error(message);
   }
   return value;
+};
+
+const countSignalRelationQueries = (
+  db: Database
+): {
+  readonly counts: Record<
+    'topo_trail_fires' | 'topo_trail_on' | 'topo_trail_signals',
+    number
+  >;
+  readonly db: Database;
+} => {
+  const counts = {
+    topo_trail_fires: 0,
+    topo_trail_on: 0,
+    topo_trail_signals: 0,
+  };
+  const query = db.query.bind(db);
+  const proxied = new Proxy(db, {
+    get(target, prop, receiver) {
+      if (prop !== 'query') {
+        return Reflect.get(target, prop, receiver);
+      }
+      return ((sql: string) => {
+        if (sql.includes('FROM topo_trail_fires')) {
+          counts.topo_trail_fires += 1;
+        }
+        if (sql.includes('FROM topo_trail_on')) {
+          counts.topo_trail_on += 1;
+        }
+        if (sql.includes('FROM topo_trail_signals')) {
+          counts.topo_trail_signals += 1;
+        }
+        return query(sql);
+      }) as Database['query'];
+    },
+  });
+
+  return { counts, db: proxied };
 };
 
 const exampleApp = () => {
@@ -106,6 +146,75 @@ const exampleApp = () => {
     entityAdd,
     entityAdded,
     entityList,
+  });
+};
+
+const signalBatchApp = () => {
+  const created = signal('entity.created', {
+    from: ['entity.create'],
+    payload: z.object({ id: z.string() }),
+  });
+  const updated = signal('entity.updated', {
+    from: ['entity.update'],
+    payload: z.object({ id: z.string() }),
+  });
+  const deleted = signal('entity.deleted', {
+    from: ['entity.delete'],
+    payload: z.object({ id: z.string() }),
+  });
+  const archived = signal('entity.archived', {
+    from: ['entity.archive'],
+    payload: z.object({ id: z.string() }),
+  });
+
+  const createTrail = trail('entity.create', {
+    blaze: noop,
+    fires: ['entity.created', 'entity.updated'],
+    input: z.object({}),
+    output: z.object({ ok: z.boolean() }),
+  });
+  const updateTrail = trail('entity.update', {
+    blaze: noop,
+    fires: [updated],
+    input: z.object({}),
+    output: z.object({ ok: z.boolean() }),
+  });
+  const deleteTrail = trail('entity.delete', {
+    blaze: noop,
+    fires: [deleted],
+    input: z.object({}),
+    output: z.object({ ok: z.boolean() }),
+  });
+  const archiveTrail = trail('entity.archive', {
+    blaze: noop,
+    fires: [archived],
+    input: z.object({}),
+    output: z.object({ ok: z.boolean() }),
+  });
+  const auditTrail = trail('entity.audit', {
+    blaze: noop,
+    input: z.object({}),
+    on: ['entity.created', 'entity.updated', 'entity.deleted'],
+    output: z.object({ ok: z.boolean() }),
+  });
+  const indexTrail = trail('entity.index', {
+    blaze: noop,
+    input: z.object({}),
+    on: [created],
+    output: z.object({ ok: z.boolean() }),
+  });
+
+  return topo('signal-batch-app', {
+    archiveTrail,
+    archived,
+    auditTrail,
+    createTrail,
+    created,
+    deleteTrail,
+    deleted,
+    indexTrail,
+    updateTrail,
+    updated,
   });
 };
 
@@ -198,6 +307,48 @@ describe('read-only topo store', () => {
         producers: [],
       }),
     ]);
+  });
+
+  test('lists signal relations with three batched relation queries for multiple signals', async () => {
+    const rootDir = makeRoot();
+    const snapshot = await expectOk(
+      createTopoSnapshot(signalBatchApp(), {
+        createdAt: '2026-04-03T15:00:00.000Z',
+        gitSha: 'abc123',
+        rootDir,
+      })
+    );
+    const db = openWriteTrailsDb({ rootDir });
+
+    try {
+      const counted = countSignalRelationQueries(db);
+      const records = listTopoStoreSignals(counted.db, {
+        snapshot: { snapshotId: snapshot.id },
+      });
+
+      expect(records).toHaveLength(4);
+      expect(records.find((record) => record.id === 'entity.created')).toEqual(
+        expect.objectContaining({
+          consumers: ['entity.audit', 'entity.index'],
+          from: ['entity.create'],
+          producers: ['entity.create'],
+        })
+      );
+      expect(records.find((record) => record.id === 'entity.updated')).toEqual(
+        expect.objectContaining({
+          consumers: ['entity.audit'],
+          from: ['entity.update'],
+          producers: ['entity.create', 'entity.update'],
+        })
+      );
+      expect(counted.counts).toEqual({
+        topo_trail_fires: 1,
+        topo_trail_on: 1,
+        topo_trail_signals: 1,
+      });
+    } finally {
+      db.close();
+    }
   });
 
   test('filters trails by intent', () => {

--- a/packages/topographer/src/internal/topo-store-read.ts
+++ b/packages/topographer/src/internal/topo-store-read.ts
@@ -137,6 +137,10 @@ interface TopoSignalRelationRow {
   readonly trail_id: string;
 }
 
+interface TopoSignalRelationBatchRow extends TopoSignalRelationRow {
+  readonly signal_id: string;
+}
+
 interface StoredSurfaceMapEntry {
   readonly description?: string;
   readonly detours?: readonly {
@@ -321,9 +325,7 @@ const readResourceUsage = (
     usage.set(row.resource_id, trails);
   }
 
-  return new Map(
-    [...usage.entries()].map(([id, trails]) => [id, trails] as const)
-  );
+  return usage as ReadonlyMap<string, readonly string[]>;
 };
 
 type SignalRelationTable =
@@ -350,6 +352,21 @@ const SIGNAL_RELATION_QUERIES = {
        ORDER BY trail_id ASC`,
 } as const satisfies Record<SignalRelationTable, string>;
 
+const SIGNAL_RELATION_BATCH_QUERIES = {
+  topo_trail_fires: `SELECT signal_id, trail_id
+       FROM topo_trail_fires
+       WHERE snapshot_id = ?
+       ORDER BY signal_id ASC, trail_id ASC`,
+  topo_trail_on: `SELECT signal_id, trail_id
+       FROM topo_trail_on
+       WHERE snapshot_id = ?
+       ORDER BY signal_id ASC, trail_id ASC`,
+  topo_trail_signals: `SELECT signal_id, trail_id
+       FROM topo_trail_signals
+       WHERE snapshot_id = ?
+       ORDER BY signal_id ASC, trail_id ASC`,
+} as const satisfies Record<SignalRelationTable, string>;
+
 const readSignalTrailIds = (
   db: Database,
   table: SignalRelationTable,
@@ -362,6 +379,29 @@ const readSignalTrailIds = (
     )
     .all(snapshotId, signalId)
     .map((row) => row.trail_id);
+
+const readSignalRelationUsage = (
+  db: Database,
+  table: SignalRelationTable,
+  snapshotId: string
+): ReadonlyMap<string, readonly string[]> => {
+  const rows = db
+    .query<TopoSignalRelationBatchRow, [string]>(
+      SIGNAL_RELATION_BATCH_QUERIES[table]
+    )
+    .all(snapshotId);
+
+  const usage = new Map<string, string[]>();
+  for (const row of rows) {
+    const trails = usage.get(row.signal_id) ?? [];
+    trails.push(row.trail_id);
+    usage.set(row.signal_id, trails);
+  }
+
+  return new Map(
+    [...usage.entries()].map(([id, trails]) => [id, trails] as const)
+  );
+};
 
 const signalExamplePayload = (example: unknown): unknown => {
   if (typeof example !== 'object' || example === null) {
@@ -632,12 +672,31 @@ export const listTopoStoreSignals = (
   const entries = stored
     ? (JSON.parse(stored.surfaceMapJson) as StoredSurfaceMap).entries
     : [];
+  const consumersBySignal = readSignalRelationUsage(
+    db,
+    'topo_trail_on',
+    snapshot.id
+  );
+  const fromBySignal = readSignalRelationUsage(
+    db,
+    'topo_trail_signals',
+    snapshot.id
+  );
+  const producersBySignal = readSignalRelationUsage(
+    db,
+    'topo_trail_fires',
+    snapshot.id
+  );
 
   return rows.map((row) =>
     mapSignalRow(
       row,
       entries.find((entry) => entry.id === row.id && entry.kind === 'signal'),
-      readSignalRelations(db, snapshot.id, row.id)
+      {
+        consumers: consumersBySignal.get(row.id) ?? [],
+        from: fromBySignal.get(row.id) ?? [],
+        producers: producersBySignal.get(row.id) ?? [],
+      }
     )
   );
 };


### PR DESCRIPTION
## Context

TRL-583 removes the N+1 relation-read pattern from `readSignalRelations` / topo-store signal relation lookup.

## What Changed

- Batches signal relation reads instead of querying relations one signal at a time.
- Preserves the existing public relation shapes while reducing query pressure.
- Adds a changeset for the `@ontrails/topographer` performance improvement.

## Tests Run

- `bun test packages/topographer/src/__tests__/topo-store-read.test.ts packages/topographer/src/__tests__/topo-store.test.ts`
- `bun run --cwd packages/topographer typecheck`
- `bun run --cwd packages/topographer lint`
- Full tip gate: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`

## Risks / Rollout

Low-to-moderate risk. The intended behavior is equivalent result data with fewer queries; the main risk is relation ordering or dedupe drift, covered by topo-store read tests and the full suite.

Closes: TRL-583