### PR TITLE
fix(trails): scope watch reruns to resolved contracts

### DIFF
--- a/.changeset/surface-map-layer-attachments.md
+++ b/.changeset/surface-map-layer-attachments.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/topographer": minor
+---
+
+Record topo and trail layer attachments in trail surface-map entries, including layer input schemas, so resolved-contract hashing and diffing can detect layer contract changes.

--- a/apps/trails/src/__tests__/run-watch.test.ts
+++ b/apps/trails/src/__tests__/run-watch.test.ts
@@ -3,7 +3,11 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { Result, resource, signal, topo, trail } from '@ontrails/core';
+import type { Layer, Topo } from '@ontrails/core';
+import { deriveSurfaceMap } from '@ontrails/topographer';
 import type { SurfaceMapEntry } from '@ontrails/topographer';
+import { z } from 'zod';
 
 import {
   WATCH_DEBOUNCE_MS,
@@ -62,6 +66,79 @@ const setupFixture = (): TestFixture => {
     watchedDir,
   };
 };
+
+const noopBlaze = () => Result.ok({ ok: true });
+
+const passThroughLayer = (name: string, input?: Layer['input']): Layer => ({
+  ...(input === undefined ? {} : { input }),
+  name,
+  wrap: (_trail, implementation) => implementation,
+});
+
+interface WatchedAppOptions {
+  readonly crosses?: boolean | undefined;
+  readonly examples?:
+    | readonly [
+        {
+          readonly expected: { readonly ok: true };
+          readonly input: Record<string, unknown>;
+          readonly name: string;
+        },
+      ]
+    | undefined;
+  readonly fires?: boolean | undefined;
+  readonly helperInput?: z.ZodType | undefined;
+  readonly input?: z.ZodType | undefined;
+  readonly intent?: 'destroy' | 'read' | 'write' | undefined;
+  readonly layers?: readonly Layer[] | undefined;
+  readonly output?: z.ZodType | undefined;
+  readonly resources?: boolean | undefined;
+}
+
+const buildWatchedApp = (options: WatchedAppOptions = {}): Topo => {
+  const auditResource = resource('audit.log', {
+    create: () => Result.ok({ write: () => null }),
+  });
+  const changed = signal('entity.changed', {
+    payload: z.object({ id: z.string() }),
+  });
+  const helper = trail('entity.helper', {
+    blaze: noopBlaze,
+    input: options.helperInput ?? z.object({}),
+    output: z.object({ ok: z.boolean() }),
+  });
+  const watched = trail('entity.watch', {
+    blaze: noopBlaze,
+    ...(options.crosses === true ? { crosses: ['entity.helper'] } : {}),
+    ...(options.examples === undefined ? {} : { examples: options.examples }),
+    ...(options.fires === true ? { fires: ['entity.changed'] } : {}),
+    input: options.input ?? z.object({ id: z.string() }),
+    ...(options.intent === undefined ? {} : { intent: options.intent }),
+    ...(options.layers === undefined ? {} : { layers: options.layers }),
+    output: options.output ?? z.object({ ok: z.boolean() }),
+    ...(options.resources === true ? { resources: [auditResource] } : {}),
+  });
+
+  return topo('watch-contract-app', {
+    auditResource,
+    changed,
+    helper,
+    watched,
+  });
+};
+
+const watchedEntry = (app: Topo): SurfaceMapEntry => {
+  const entry = deriveSurfaceMap(app).entries.find(
+    (candidate) => candidate.kind === 'trail' && candidate.id === 'entity.watch'
+  );
+  if (entry === undefined) {
+    throw new Error('Expected watched trail entry');
+  }
+  return entry;
+};
+
+const watchedEntryHash = (app: Topo): string =>
+  hashSurfaceMapEntry(watchedEntry(app));
 
 // ---------------------------------------------------------------------------
 // Argv detection
@@ -148,6 +225,74 @@ describe('createTrailWatcher', () => {
     );
   });
 
+  test('derived watched entry hash changes for resolved contract fields', () => {
+    const baseline = watchedEntryHash(buildWatchedApp());
+    const cases = [
+      {
+        app: buildWatchedApp({
+          input: z.object({ id: z.string(), verbose: z.boolean() }),
+        }),
+        name: 'input schema',
+      },
+      {
+        app: buildWatchedApp({
+          output: z.object({ id: z.string(), ok: z.boolean() }),
+        }),
+        name: 'output schema',
+      },
+      {
+        app: buildWatchedApp({
+          examples: [
+            {
+              expected: { ok: true },
+              input: { id: 'entity-1' },
+              name: 'happy path',
+            },
+          ],
+        }),
+        name: 'examples',
+      },
+      {
+        app: buildWatchedApp({ intent: 'read' }),
+        name: 'intent',
+      },
+      {
+        app: buildWatchedApp({ resources: true }),
+        name: 'resources',
+      },
+      {
+        app: buildWatchedApp({ fires: true }),
+        name: 'signals',
+      },
+      {
+        app: buildWatchedApp({ crosses: true }),
+        name: 'crosses',
+      },
+      {
+        app: buildWatchedApp({
+          layers: [passThroughLayer('audit', z.object({ token: z.string() }))],
+        }),
+        name: 'layers',
+      },
+    ];
+
+    for (const { app, name } of cases) {
+      expect(watchedEntryHash(app), name).not.toBe(baseline);
+    }
+  });
+
+  test('derived watched entry hash ignores sibling trail contract changes', () => {
+    const baseline = watchedEntryHash(buildWatchedApp({ crosses: true }));
+    const changedSibling = watchedEntryHash(
+      buildWatchedApp({
+        crosses: true,
+        helperInput: z.object({ changed: z.boolean() }),
+      })
+    );
+
+    expect(changedSibling).toBe(baseline);
+  });
+
   test('triggers a rerun when the watched surface-map entry changes', async () => {
     const reruns: number[] = [];
     let surfaceHash = 'contract:v1';
@@ -171,6 +316,39 @@ describe('createTrailWatcher', () => {
       await waitFor(() => reruns.length >= 1, WATCH_DEBOUNCE_MS + 1000);
 
       expect(reruns.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test('triggers exactly one rerun for a derived contract hash change', async () => {
+    const reruns: number[] = [];
+    let surfaceHash = watchedEntryHash(buildWatchedApp());
+    const watcher = createTrailWatcher({
+      initialSurfaceHash: surfaceHash,
+      onRerun: () => {
+        reruns.push(Date.now());
+      },
+      readSurfaceHash: () => surfaceHash,
+      sourcePath: join(fixture.watchedDir, 'trail.ts'),
+    });
+
+    try {
+      await Bun.sleep(WATCHER_SETTLE_MS);
+      surfaceHash = watchedEntryHash(
+        buildWatchedApp({
+          input: z.object({ id: z.string(), verbose: z.boolean() }),
+        })
+      );
+      writeFileSync(
+        join(fixture.watchedDir, 'trail.ts'),
+        'export const inputChanged = true;\n'
+      );
+
+      await waitFor(() => reruns.length >= 1, WATCH_DEBOUNCE_MS + 1000);
+      await Bun.sleep(WATCH_DEBOUNCE_MS + 100);
+
+      expect(reruns).toHaveLength(1);
     } finally {
       watcher.close();
     }

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -12,7 +12,7 @@ import {
   topo,
   trail,
 } from '@ontrails/core';
-import type { Topo, TopoIssue } from '@ontrails/core';
+import type { Layer, Topo, TopoIssue } from '@ontrails/core';
 import { z } from 'zod';
 
 import { deriveSurfaceMap } from '../derive.js';
@@ -29,6 +29,12 @@ const dbResource = resource('db.main', {
   create: () => Result.ok({ source: 'factory' }),
   description: 'Primary database',
   health: () => Result.ok({ ok: true }),
+});
+
+const passThroughLayer = (name: string, input?: Layer['input']): Layer => ({
+  ...(input === undefined ? {} : { input }),
+  name,
+  wrap: (_trail, implementation) => implementation,
 });
 const userContour = contour(
   'user',
@@ -154,6 +160,51 @@ describe('deriveSurfaceMap', () => {
         name: { type: 'string' },
       });
       expect(entry.resources).toEqual(['db.main']);
+    });
+
+    test('trail entries include topo and trail layer attachments', () => {
+      const topoLayer = passThroughLayer(
+        'topo.auth',
+        z.object({ token: z.string() })
+      );
+      const trailLayer = passThroughLayer(
+        'trail.retry',
+        z.object({ attempts: z.number().int() })
+      );
+      const t = trail('entity.layered', {
+        blaze: noop,
+        input: z.object({}),
+        layers: [trailLayer],
+      });
+      const map = deriveSurfaceMap(
+        topo('layered-app', { t }, { layers: [topoLayer] })
+      );
+      const entry = map.entries.find(
+        (candidate) => candidate.id === 'entity.layered'
+      );
+
+      expect(entry?.layers).toEqual([
+        expect.objectContaining({
+          input: expect.objectContaining({
+            properties: expect.objectContaining({
+              token: { type: 'string' },
+            }),
+            type: 'object',
+          }),
+          name: 'topo.auth',
+          scope: 'topo',
+        }),
+        expect.objectContaining({
+          input: expect.objectContaining({
+            properties: expect.objectContaining({
+              attempts: { type: 'number' },
+            }),
+            type: 'object',
+          }),
+          name: 'trail.retry',
+          scope: 'trail',
+        }),
+      ]);
     });
 
     test('trail entries include declared contours when present', () => {

--- a/packages/topographer/src/__tests__/topo-store.test.ts
+++ b/packages/topographer/src/__tests__/topo-store.test.ts
@@ -17,6 +17,7 @@ import {
   webhook,
   openWriteTrailsDb,
 } from '@ontrails/core';
+import type { Layer } from '@ontrails/core';
 
 import { __topoStoreMigrationStats, createTopoStore } from '../topo-store.js';
 import {
@@ -701,6 +702,100 @@ describe('topo store projection', () => {
           signalId: 'entity.added',
         },
       ]);
+    });
+  });
+
+  test('stored surface map and lock include trail signal and layer contract fields', () => {
+    withProjectionDb((db) => {
+      const topoPolicy: Layer = {
+        input: z.object({ tenant: z.string() }),
+        name: 'topo.policy',
+        wrap: (_trail, impl) => impl,
+      };
+      const trailAudit: Layer = {
+        input: z.object({ requestId: z.string() }),
+        name: 'trail.audit',
+        wrap: (_trail, impl) => impl,
+      };
+      const created = signal('entity.created', {
+        payload: z.object({ id: z.string() }),
+      });
+      const updated = signal('entity.updated', {
+        payload: z.object({ id: z.string() }),
+      });
+      const process = trail('entity.process', {
+        blaze: () => Result.ok({ ok: true }),
+        fires: [created],
+        input: z.object({ id: z.string() }),
+        layers: [trailAudit],
+        on: [updated],
+        output: z.object({ ok: z.boolean() }),
+      });
+
+      const snapshot = unwrap(
+        createTopoSnapshot(
+          db,
+          topo(
+            'contract-export-app',
+            {
+              created,
+              process,
+              updated,
+            },
+            { layers: [topoPolicy] }
+          ),
+          { createdAt: '2026-04-03T12:00:00.000Z' }
+        )
+      );
+
+      const stored = requireStoredExport(db, snapshot.id);
+      const surfaceMap = JSON.parse(stored.surfaceMapJson) as {
+        entries: readonly unknown[];
+      };
+      const entry = surfaceMap.entries.find(
+        (candidate) =>
+          typeof candidate === 'object' &&
+          candidate !== null &&
+          (candidate as { id?: unknown }).id === 'entity.process'
+      ) as
+        | {
+            fires?: unknown;
+            layers?: readonly {
+              readonly input?: { readonly properties?: unknown };
+              readonly name?: unknown;
+              readonly scope?: unknown;
+            }[];
+            on?: unknown;
+          }
+        | undefined;
+
+      expect(entry?.fires).toEqual(['entity.created']);
+      expect(entry?.on).toEqual(['entity.updated']);
+      expect(entry?.layers).toEqual([
+        {
+          input: expect.objectContaining({
+            properties: { tenant: { type: 'string' } },
+            type: 'object',
+          }),
+          name: 'topo.policy',
+          scope: 'topo',
+        },
+        {
+          input: expect.objectContaining({
+            properties: { requestId: { type: 'string' } },
+            type: 'object',
+          }),
+          name: 'trail.audit',
+          scope: 'trail',
+        },
+      ]);
+
+      const lock = JSON.parse(stored.lockContent);
+      const lockTrail =
+        lock.apps['contract-export-app'].trails['entity.process'];
+      expect(lockTrail.fires).toEqual(['entity.created']);
+      expect(lockTrail.on).toEqual(['entity.updated']);
+      expect(lockTrail.layers).toEqual(entry?.layers);
     });
   });
 

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -18,6 +18,7 @@ import type {
   AnyContour,
   AnyResource,
   FieldOverride,
+  Layer,
   Signal,
   Topo,
   Trail,
@@ -416,11 +417,51 @@ const addTrailRelations = (
   if (t.crosses.length > 0) {
     entry['crosses'] = t.crosses.toSorted();
   }
+  if (t.fires.length > 0) {
+    entry['fires'] = t.fires.toSorted();
+  }
+  if (t.on.length > 0) {
+    entry['on'] = t.on.toSorted();
+  }
   if (t.contours.length > 0) {
     entry['contours'] = t.contours.map((contour) => contour.name).toSorted();
   }
   if (t.resources.length > 0) {
     entry['resources'] = t.resources.map((resource) => resource.id).toSorted();
+  }
+};
+
+const layerToReference = (
+  scope: 'topo' | 'trail',
+  layer: Layer
+): Record<string, unknown> => {
+  const reference: Record<string, unknown> = {
+    name: layer.name,
+    scope,
+  };
+  if (layer.input !== undefined) {
+    reference['input'] = toSortedJsonSchema(layer.input);
+  }
+  return sortKeys(reference);
+};
+
+const addLayerAttachments = (
+  entry: Record<string, unknown>,
+  topoLayers: readonly Layer[],
+  t: Trail<unknown, unknown, unknown>
+): void => {
+  const layers = [
+    ...topoLayers.map((layer) => layerToReference('topo', layer)),
+    ...t.layers.map((layer) => layerToReference('trail', layer)),
+  ].toSorted((left, right) => {
+    const scope = String(left['scope']).localeCompare(String(right['scope']));
+    return scope === 0
+      ? String(left['name']).localeCompare(String(right['name']))
+      : scope;
+  });
+
+  if (layers.length > 0) {
+    entry['layers'] = layers;
   }
 };
 
@@ -482,7 +523,10 @@ const addExamples = (
   }
 };
 
-const trailToEntry = (t: Trail<unknown, unknown, unknown>): SurfaceMapEntry => {
+const trailToEntry = (
+  t: Trail<unknown, unknown, unknown>,
+  topoLayers: readonly Layer[]
+): SurfaceMapEntry => {
   const raw = t as unknown as Record<string, unknown>;
   const surfaces = extractSurfaces(raw);
   const entry: Record<string, unknown> = {
@@ -497,6 +541,7 @@ const trailToEntry = (t: Trail<unknown, unknown, unknown>): SurfaceMapEntry => {
   addMetadata(entry, t, raw);
   addPermitRequirement(entry, t);
   addTrailRelations(entry, t);
+  addLayerAttachments(entry, topoLayers, t);
   addFieldOverrides(entry, t);
   addExamples(entry, t);
 
@@ -605,7 +650,7 @@ const collectEntries = (topo: Topo): SurfaceMapEntry[] => {
   return [
     ...[...topo.contours.values()].map((contour) => contourToEntry(contour)),
     ...[...topo.trails.values()].map((trail) =>
-      trailToEntry(trail as Trail<unknown, unknown, unknown>)
+      trailToEntry(trail as Trail<unknown, unknown, unknown>, topo.layers)
     ),
     ...[...topo.signals.values()].map((signal) =>
       signalToEntry(

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -47,6 +47,7 @@ export type {
   SurfaceMapEntry,
   SurfaceMapFieldOverride,
   SurfaceMapFieldOverrideKey,
+  SurfaceMapLayerReference,
   SurfaceLock,
   WorkspaceTrailEntry,
   WorkspaceTrailIndex,

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -20,6 +20,7 @@ import type {
   AnyResource,
   AnySignal,
   AnyTrail,
+  Layer,
   Topo,
 } from '@ontrails/core';
 
@@ -929,6 +930,14 @@ const addTrailRelations = (
     entry['crosses'] = trail.crosses.toSorted();
   }
 
+  if (trail.fires.length > 0) {
+    entry['fires'] = trail.fires.toSorted();
+  }
+
+  if (trail.on.length > 0) {
+    entry['on'] = trail.on.toSorted();
+  }
+
   if (trail.contours.length > 0) {
     entry['contours'] = trail.contours
       .map((contour) => contour.name)
@@ -939,6 +948,42 @@ const addTrailRelations = (
     entry['resources'] = trail.resources
       .map((resource) => resource.id)
       .toSorted();
+  }
+};
+
+const layerToReferenceRecord = (
+  scope: 'topo' | 'trail',
+  layer: Layer
+): Record<string, unknown> => {
+  const reference: Record<string, unknown> = {
+    name: layer.name,
+    scope,
+  };
+  if (layer.input !== undefined) {
+    reference['input'] = parseJsonRecord(
+      stableJson(zodToJsonSchema(layer.input as ZodSchemaInput))
+    );
+  }
+  return sortKeys(reference);
+};
+
+const addLayerAttachments = (
+  entry: Record<string, unknown>,
+  topoLayers: readonly Layer[],
+  trail: AnyTrail
+): void => {
+  const layers = [
+    ...topoLayers.map((layer) => layerToReferenceRecord('topo', layer)),
+    ...trail.layers.map((layer) => layerToReferenceRecord('trail', layer)),
+  ].toSorted((left, right) => {
+    const scope = String(left['scope']).localeCompare(String(right['scope']));
+    return scope === 0
+      ? String(left['name']).localeCompare(String(right['name']))
+      : scope;
+  });
+
+  if (layers.length > 0) {
+    entry['layers'] = layers;
   }
 };
 
@@ -987,6 +1032,7 @@ const buildTrailEntryBase = (
 
 const trailToEntryRecord = (
   trail: AnyTrail,
+  topoLayers: readonly Layer[],
   trailSchema: Readonly<{
     readonly input: JsonRecord;
     readonly output?: JsonRecord;
@@ -997,6 +1043,7 @@ const trailToEntryRecord = (
   addPermitRequirement(entry, trail);
   addExtendedMetadata(entry, raw, trail);
   addTrailRelations(entry, trail);
+  addLayerAttachments(entry, topoLayers, trail);
   return sortKeys(entry) as SurfaceMapEntryRecord;
 };
 
@@ -1149,6 +1196,7 @@ const buildSurfaceMap = (
   resources: readonly AnyResource[],
   signalPayloads: ReadonlyMap<string, JsonRecord>,
   signals: readonly AnySignal[],
+  topoLayers: readonly Layer[],
   trailSchemas: ReadonlyMap<
     string,
     Readonly<{
@@ -1164,7 +1212,11 @@ const buildSurfaceMap = (
   const entries = [
     ...contours.map((contour) => contourToEntryRecord(contour)),
     ...trails.map((trail) =>
-      trailToEntryRecord(trail, requireTrailSchema(trailSchemas, trail.id))
+      trailToEntryRecord(
+        trail,
+        topoLayers,
+        requireTrailSchema(trailSchemas, trail.id)
+      )
     ),
     ...signals.map((signal) =>
       signalToEntryRecord(
@@ -1255,6 +1307,7 @@ const buildStoredTopoExport = (
     resources,
     schemas.signalPayloads,
     signals,
+    topo.layers,
     schemas.trailSchemas,
     trails
   );

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -39,6 +39,12 @@ export interface SurfaceMapFieldOverride {
   };
 }
 
+export interface SurfaceMapLayerReference {
+  readonly input?: JsonSchema | undefined;
+  readonly name: string;
+  readonly scope: 'topo' | 'trail';
+}
+
 export interface SurfaceMapActivationSource extends Readonly<
   Record<string, unknown>
 > {
@@ -115,6 +121,8 @@ export interface SurfaceMapEntry {
   readonly identity?: string | undefined;
   readonly references?: readonly SurfaceMapContourReference[] | undefined;
   readonly resources?: readonly string[] | undefined;
+  readonly fires?: readonly string[] | undefined;
+  readonly on?: readonly string[] | undefined;
   readonly from?: readonly string[] | undefined;
   readonly producers?: readonly string[] | undefined;
   readonly consumers?: readonly string[] | undefined;
@@ -122,6 +130,7 @@ export interface SurfaceMapEntry {
   readonly governance?: Readonly<Record<string, unknown>> | undefined;
   readonly meta?: Readonly<Record<string, unknown>> | undefined;
   readonly fieldOverrides?: readonly SurfaceMapFieldOverride[] | undefined;
+  readonly layers?: readonly SurfaceMapLayerReference[] | undefined;
   readonly detours?:
     | readonly { readonly on: string; readonly maxAttempts: number }[]
     | undefined;


### PR DESCRIPTION
## Context

TRL-619 scopes `trails observe` / watch reruns to resolved contract changes instead of rerunning on source edits that do not change the watched surface contract.

## What Changed

- Watches derived surface-map entry hashes for the selected trail instead of treating every relevant source edit as a rerun trigger.
- Keeps reruns firing for meaningful resolved-contract changes.
- Includes fires/on and layer attachment fields in stored topo exports and serialized lock content so persisted graph artifacts match live surface-map derivation.
- Adds a changeset for the `@ontrails/topographer` / Trails graph artifact behavior.

## Tests Run

- `bun test packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/derive.test.ts apps/trails/src/__tests__/run-watch.test.ts`
- `bun run --cwd packages/topographer typecheck`
- `bun run --cwd packages/topographer lint`
- Full tip gate: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`

## Risks / Rollout

Moderate behavior risk: the desired result is fewer unnecessary reruns, but missed meaningful reruns would be bad. The watcher tests cover comment-only edits, sibling source edits, invalid states, removal/return, and resolved hash changes.

Closes: TRL-619