### PR TITLE
chore(repo): remove cross-package deep imports

### DIFF
--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -80,7 +80,7 @@ This exposes MCP tools: `demo_entity_show`, `demo_entity_add`, `demo_entity_dele
 ### Trail definition: `entity.show`
 
 ```typescript
-import { entityStoreResource } from '../src/resources/entity-store.js';
+import { entityStoreResource } from './src/resources/entity-store.js';
 
 export const show = trail('entity.show', {
   description: 'Show an entity by name',
@@ -147,8 +147,8 @@ export const onboard = trail('entity.onboard', {
 
 ```typescript
 import { testAll } from '@ontrails/testing';
-import { graph } from '../src/app.js';
-import { createMockEntityStore, entityStoreResource } from '../src/resources/entity-store.js';
+import { graph } from './src/app.js';
+import { createMockEntityStore, entityStoreResource } from './src/resources/entity-store.js';
 
 testAll(graph, () => ({
   resources: {
@@ -175,9 +175,9 @@ Pass a factory function (not a plain object) when your explicit resource overrid
 ### Custom scenarios
 
 ```typescript
-import { createStore } from '../src/store.js';
+import { createStore } from './src/store.js';
 import { testTrail } from '@ontrails/testing';
-import { entityStoreResource } from '../src/resources/entity-store.js';
+import { entityStoreResource } from './src/resources/entity-store.js';
 
 testTrail(
   show,

--- a/packages/store/src/__tests__/crud.test.ts
+++ b/packages/store/src/__tests__/crud.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, mock, test } from 'bun:test';
-import { Result, createTrailContext, resource, topo } from '@ontrails/core';
+import {
+  Result,
+  createTrailContext,
+  executeTrail,
+  resource,
+  topo,
+  validateTopo,
+} from '@ontrails/core';
 import { z } from 'zod';
 
 import type { EntityOf, InsertOf, StoreAccessor } from '../index.js';
-import { testAll } from '../../../testing/src/index.js';
 import { crudAccessorExpectations, crudOperations, store } from '../index.js';
 import {
   crud,
@@ -114,6 +120,17 @@ const [createNote, readNote, updateNote, deleteNote, listNote] = crud(
   notesResource
 );
 
+const crudTopo = topo('store-crud-app', {
+  createNote,
+  deleteNote,
+  listNote,
+  notesResource,
+  readNote,
+  updateNote,
+} as Record<string, unknown>);
+
+const crudTrails = [createNote, deleteNote, listNote, readNote, updateNote];
+
 type CreateNoteInput = Parameters<typeof createNote.blaze>[0];
 type UpdateNoteInput = Parameters<typeof updateNote.blaze>[0];
 
@@ -129,18 +146,6 @@ const updateInputHasIdentity: 'id' extends keyof UpdateNoteInput
 const updateInputHasWritableFields: 'title' extends keyof UpdateNoteInput
   ? true
   : false = true;
-
-// oxlint-disable-next-line jest/require-hook -- testAll generates describe/test blocks, not setup code
-testAll(
-  topo('store-crud-app', {
-    createNote,
-    deleteNote,
-    listNote,
-    notesResource,
-    readNote,
-    updateNote,
-  } as Record<string, unknown>)
-);
 
 const createCrudContext = () =>
   createTrailContext({
@@ -206,6 +211,61 @@ const expectOk = <T>(result: Result<T, Error>): T => {
 
   return result.value;
 };
+
+describe('governance', () => {
+  test('topo validates', () => {
+    const validation = validateTopo(crudTopo);
+    if (validation.isErr()) {
+      throw validation.error;
+    }
+
+    expect(validation.isOk()).toBe(true);
+  });
+
+  describe.each(crudTrails)('$id', (trail) => {
+    const examples = [...(trail.examples ?? [])];
+
+    test('has examples for governance coverage', () => {
+      expect(examples.length).toBeGreaterThan(0);
+    });
+
+    test.each(examples)('example: $name', async (example) => {
+      const result = await executeTrail(trail, example.input, {
+        ctx: createCrudContext(),
+        topo: crudTopo,
+      });
+
+      if (example.error !== undefined) {
+        expect(result.isErr()).toBe(true);
+        return;
+      }
+
+      const value = expectOk(result);
+      if (example.expected !== undefined) {
+        expect(value).toEqual(example.expected);
+      } else if (trail.output !== undefined) {
+        expect(trail.output.safeParse(value).success).toBe(true);
+      }
+    });
+
+    if (trail.output === undefined) {
+      return;
+    }
+
+    test.each(examples.filter((example) => example.error === undefined))(
+      'contract: $name',
+      async (example) => {
+        const result = await executeTrail(trail, example.input, {
+          ctx: createCrudContext(),
+          topo: crudTopo,
+        });
+        const value = expectOk(result);
+
+        expect(trail.output?.safeParse(value).success).toBe(true);
+      }
+    );
+  });
+});
 
 describe('crud()', () => {
   test('exports the store-owned CRUD doctrine constants', () => {

--- a/packages/tracing/scripts/benchmark-intrinsic-tracing.ts
+++ b/packages/tracing/scripts/benchmark-intrinsic-tracing.ts
@@ -9,7 +9,7 @@ import {
   trail,
   type AnyTrail,
   type TraceSink,
-} from '../../core/src/index.ts';
+} from '@ontrails/core';
 import { z } from 'zod';
 
 interface Scenario {


### PR DESCRIPTION
## Context

TRL-394 removes cross-package deep relative imports and cleans up the demo/reference path issue without taking on the separate Commander/npm package split work.

## What Changed

- Replaced audited cross-package deep relative imports with public package imports where that preserves package boundaries.
- Kept the store CRUD test cycle-safe by replacing its old cross-package testing helper import with a local governance/example/contract suite for the same CRUD topo.
- Fixed the demo/reference import path drift covered by the issue.
- Kept the change mechanical and package-boundary focused.

## Tests Run

- `bun --filter @ontrails/store test`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- `bun run check`
- Earlier full tip gate: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`

## Risks / Rollout

Low risk. This is import hygiene and demo/reference cleanup, with no intended public package behavior change. This PR carries `release:none` because it touches package source for boundary hygiene only and does not ship user-visible API or runtime behavior.

Closes: TRL-394