### PR TITLE
fix(tooling): handle json-only staged formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "scaffold-versions:check": "bun scripts/sync-scaffold-versions.ts --check",
     "format:check": "bun run oxlint-plugin:build && bunx ultracite check .",
     "format:fix": "bun run oxlint-plugin:build && bunx ultracite fix .",
-    "format:file": "bun run oxlint-plugin:build && bunx ultracite fix",
+    "format:file": "bun run oxlint-plugin:build && bun scripts/format-staged.ts",
     "format:guard": "if git grep -nE \"(\\\\./)?node_modules/\\\\.bin/ultra[c]ite\" -- ':!bun.lock'; then echo 'Direct node_modules/.bin formatter invocation found'; exit 1; fi",
     "mdlint:fix": "./node_modules/.bin/markdownlint-cli2 --fix",
     "typecheck": "turbo run typecheck",

--- a/scripts/__tests__/format-staged.test.ts
+++ b/scripts/__tests__/format-staged.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { partitionFormatTargets } from '../format-staged.ts';
+
+describe('format-staged', () => {
+  test('partitions code and JSON inputs', () => {
+    expect(
+      partitionFormatTargets([
+        'src/app.ts',
+        'src/app.test.tsx',
+        'package.json',
+        'tsconfig.jsonc',
+        'README.md',
+      ])
+    ).toEqual({
+      code: ['src/app.ts', 'src/app.test.tsx'],
+      json: ['package.json', 'tsconfig.jsonc'],
+    });
+  });
+
+  test('formats JSON-only inputs without invoking the code lint path', () => {
+    const root = mkdtempSync(join(tmpdir(), 'format-staged-'));
+    const jsonPath = join(root, 'package.json');
+    writeFileSync(jsonPath, '{"b":1,"a":2}\n');
+
+    try {
+      const result = Bun.spawnSync({
+        cmd: [process.execPath, 'scripts/format-staged.ts', jsonPath],
+        cwd: resolve(import.meta.dir, '..', '..'),
+        stderr: 'pipe',
+        stdout: 'pipe',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(readFileSync(jsonPath, 'utf8')).toBe(
+        '{\n  "a": 2,\n  "b": 1\n}\n'
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/scripts/format-staged.ts
+++ b/scripts/format-staged.ts
@@ -1,0 +1,67 @@
+const CODE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx']);
+const JSON_EXTENSIONS = new Set(['.json', '.jsonc']);
+
+export interface FormatTargets {
+  readonly code: readonly string[];
+  readonly json: readonly string[];
+}
+
+const extensionOf = (path: string): string => {
+  const dot = path.lastIndexOf('.');
+  return dot === -1 ? '' : path.slice(dot).toLowerCase();
+};
+
+export const partitionFormatTargets = (
+  paths: readonly string[]
+): FormatTargets => {
+  const code: string[] = [];
+  const json: string[] = [];
+
+  for (const path of paths) {
+    const extension = extensionOf(path);
+    if (CODE_EXTENSIONS.has(extension)) {
+      code.push(path);
+      continue;
+    }
+    if (JSON_EXTENSIONS.has(extension)) {
+      json.push(path);
+    }
+  }
+
+  return { code, json };
+};
+
+const run = async (cmd: readonly string[]): Promise<number> => {
+  const proc = Bun.spawn(cmd, {
+    stderr: 'inherit',
+    stdout: 'inherit',
+  });
+  return await proc.exited;
+};
+
+export const formatStaged = async (
+  paths: readonly string[]
+): Promise<number> => {
+  const targets = partitionFormatTargets(paths);
+
+  if (targets.code.length > 0) {
+    const code = await run(['bunx', 'ultracite', 'fix', ...targets.code]);
+    if (code !== 0) {
+      return code;
+    }
+  }
+
+  if (targets.json.length > 0) {
+    const code = await run(['bunx', 'oxfmt', '--write', ...targets.json]);
+    if (code !== 0) {
+      return code;
+    }
+  }
+
+  return 0;
+};
+
+if (import.meta.main) {
+  const code = await formatStaged(process.argv.slice(2));
+  process.exit(code);
+}


### PR DESCRIPTION
## Context

TRL-617 fixes the staged formatter pre-commit path for JSON-only commits, where the staged-file grouping could route the wrong tool path and fail before Oxlint/Ultracite had anything meaningful to inspect.

## What Changed

- Updated `scripts/format-staged.ts` so JSON/JSONC files are handled by `oxfmt` and TS/JS files are handled by Ultracite.
- Keeps staged-file formatting scoped to the file types that the relevant formatter can actually process.
- Preserves the repo-level formatter guard that prevents direct `node_modules/.bin/ultracite` invocation.

## Tests Run

- Full tip gate: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`

## Risks / Rollout

Low risk, but it affects developer workflow. The intended rollout impact is fewer false pre-commit failures on JSON-only staged changes while keeping formatting enforcement intact.

Closes: TRL-617