### PR TITLE
feat(tooling): add agent-aware bootstrap commands

### DIFF
--- a/scripts/__tests__/bootstrap.test.ts
+++ b/scripts/__tests__/bootstrap.test.ts
@@ -1,32 +1,207 @@
-import { expect, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { isBunVersionAllowed } from '../bootstrap/bun.ts';
+import { loadBootstrapConfig } from '../bootstrap/config.ts';
+import { isLinkedWorktree } from '../bootstrap/git.ts';
+import { detectHost, resolveRepoRoot } from '../bootstrap/host.ts';
+import { parseBootstrapArgs } from '../bootstrap/main.ts';
+import { ensureBunPolicy, listWorkspaceGlobs } from '../bootstrap/repo.ts';
+import { resolveCleanupTarget } from '../bootstrap/sweep.ts';
+import { collectToolStatus } from '../bootstrap/tools.ts';
+
 const repoRoot = join(import.meta.dir, '..', '..');
-const bootstrapPath = join(repoRoot, 'scripts/bootstrap.sh');
-const packageJsonPath = join(repoRoot, 'package.json');
-const packageJson = JSON.parse(await Bun.file(packageJsonPath).text()) as {
+const packageJson = JSON.parse(
+  await Bun.file(join(repoRoot, 'package.json')).text()
+) as {
   workspaces?: string[];
 };
 const expectedWorkspaces = Array.isArray(packageJson.workspaces)
   ? packageJson.workspaces
   : [];
 
-test('bootstrap workspace globs stay aligned with root package.json', () => {
-  const proc = Bun.spawnSync({
-    cmd: ['bash', '-lc', `source "${bootstrapPath}"; list_workspace_globs`],
-    cwd: repoRoot,
-    stderr: 'pipe',
-    stdout: 'pipe',
+const makeRepoRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bootstrap-root-'));
+  writeFileSync(join(root, 'package.json'), '{"workspaces":[]}\n');
+  writeFileSync(join(root, '.bun-version'), '1.3.10\n');
+  return root;
+};
+
+describe('bootstrap dispatcher', () => {
+  test('keeps legacy flags routed to repo', () => {
+    expect(parseBootstrapArgs(['--force'])).toEqual({
+      command: 'repo',
+      force: true,
+      update: false,
+    });
+    expect(parseBootstrapArgs(['--update'])).toEqual({
+      command: 'repo',
+      force: false,
+      update: true,
+    });
   });
 
-  expect(proc.exitCode).toBe(0);
-  expect(proc.stderr.toString()).toBe('');
+  test('parses explicit subcommands', () => {
+    expect(parseBootstrapArgs(['agent', '--update'])).toEqual({
+      command: 'agent',
+      force: false,
+      update: true,
+    });
+    expect(parseBootstrapArgs(['doctor'])).toEqual({
+      command: 'doctor',
+      force: false,
+      update: false,
+    });
+  });
 
-  const actual = proc.stdout
-    .toString()
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+  test('shell entrypoint exposes help without mutating setup state', () => {
+    const proc = Bun.spawnSync({
+      cmd: ['bash', './scripts/bootstrap.sh', '--help'],
+      cwd: repoRoot,
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
 
-  expect(actual).toEqual(expectedWorkspaces);
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stdout.toString()).toContain('repo|agent|doctor|sweep');
+  });
+});
+
+describe('bootstrap repo policy', () => {
+  test('workspace globs stay aligned with root package.json', async () => {
+    await expect(listWorkspaceGlobs(repoRoot)).resolves.toEqual(
+      expectedWorkspaces
+    );
+  });
+
+  test('Bun policy accepts newer local patch versions but not remote strict mismatches', () => {
+    expect(isBunVersionAllowed('1.3.12', '1.3.10', 'compatible')).toBe(true);
+    expect(isBunVersionAllowed('1.3.10-canary.1', '1.3.10', 'compatible')).toBe(
+      true
+    );
+    expect(isBunVersionAllowed('1.3.12', '1.3.10', 'strict')).toBe(false);
+  });
+
+  test('stale Bun is repaired before policy enforcement fails', async () => {
+    const config = loadBootstrapConfig();
+    const root = makeRepoRoot();
+    const installs: string[] = [];
+    let checks = 0;
+    try {
+      await ensureBunPolicy(
+        {
+          config,
+          force: false,
+          host: {
+            bunPolicy: 'compatible',
+            provider: 'generic',
+            remote: false,
+          },
+          repoRoot: root,
+          update: false,
+        },
+        {
+          checkBunVersion: (_repoRoot, policy) => {
+            checks += 1;
+            return checks === 1
+              ? {
+                  actual: '1.3.9',
+                  ok: false,
+                  pinned: '1.3.10',
+                  policy,
+                  reason:
+                    'Expected Bun 1.3.10 or newer compatible patch, found 1.3.9',
+                }
+              : {
+                  actual: '1.3.10',
+                  ok: true,
+                  pinned: '1.3.10',
+                  policy,
+                };
+          },
+          installPinnedBun: async (installRoot, versionFile) => {
+            installs.push(`${installRoot}:${versionFile ?? ''}`);
+          },
+        }
+      );
+
+      expect(checks).toBe(2);
+      expect(installs).toEqual([`${root}:.bun-version`]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('root resolution prefers provider env vars before cwd', () => {
+    const config = loadBootstrapConfig();
+    const codexRoot = makeRepoRoot();
+    const claudeRoot = makeRepoRoot();
+    try {
+      expect(
+        resolveRepoRoot(
+          claudeRoot,
+          {
+            CLAUDE_PROJECT_DIR: claudeRoot,
+            CODEX_WORKTREE_PATH: codexRoot,
+          } as NodeJS.ProcessEnv,
+          config
+        )
+      ).toBe(codexRoot);
+    } finally {
+      rmSync(codexRoot, { force: true, recursive: true });
+      rmSync(claudeRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('root resolution accepts CLAUDECODE when it carries a repo path', () => {
+    const config = loadBootstrapConfig();
+    const claudeRoot = makeRepoRoot();
+    try {
+      expect(
+        resolveRepoRoot(
+          tmpdir(),
+          { CLAUDECODE: claudeRoot } as NodeJS.ProcessEnv,
+          config
+        )
+      ).toBe(claudeRoot);
+    } finally {
+      rmSync(claudeRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('host detection honors explicit provider and remote overrides', () => {
+    const config = loadBootstrapConfig();
+    expect(
+      detectHost(
+        {
+          TRAILS_AGENT_ENV_PROVIDER: 'factory',
+          TRAILS_AGENT_ENV_REMOTE: 'true',
+        } as NodeJS.ProcessEnv,
+        config
+      )
+    ).toMatchObject({
+      bunPolicy: 'strict',
+      provider: 'factory',
+      remote: true,
+    });
+  });
+
+  test('linked worktree detection compares git dir and common dir', () => {
+    expect(isLinkedWorktree('.git/worktrees/branch', '.git')).toBe(true);
+    expect(isLinkedWorktree('.git', '.git')).toBe(false);
+  });
+
+  test('optional tool absence is reported without throwing', () => {
+    expect(collectToolStatus(['definitely-not-a-real-tool'], repoRoot)).toEqual(
+      [{ name: 'definitely-not-a-real-tool', present: false }]
+    );
+  });
+
+  test('sweep rejects cleanup targets outside the repo', () => {
+    expect(() => resolveCleanupTarget(repoRoot, '../outside')).toThrow(
+      'outside repo'
+    );
+  });
 });

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,22 +1,11 @@
 #!/usr/bin/env bash
 #
-# bootstrap.sh — Get this repo from clone to runnable
+# bootstrap.sh — cold-start trampoline for Trails repo lifecycle commands.
 #
-# Usage: ./scripts/bootstrap.sh [--force] [--update]
-#
-# By default, exits immediately if all tools and deps are present.
-# Use --force to run full bootstrap regardless.
-#
-# This script is safe to run repeatedly. Cloud agents (Claude Code, Codex)
-# should run this before any other commands.
-#
-# Runtime requirements:
-#   - bash 4+
-#   - one of: bun, node, python3, or python — used to parse package.json
-#     before dependency install checks can trust workspace state. Prefer
-#     Bun or Node when available so agent and CI environments do not depend
-#     on Python being present.
-#
+# Usage:
+#   ./scripts/bootstrap.sh [repo|agent|doctor|sweep] [--force] [--update]
+#   ./scripts/bootstrap.sh --force   # legacy alias for repo --force
+#   ./scripts/bootstrap.sh --update  # legacy alias for repo --update
 
 set -euo pipefail
 
@@ -24,399 +13,111 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 BUN_VERSION_FILE="$REPO_ROOT/.bun-version"
 
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/bootstrap.sh [repo|agent|doctor|sweep] [--force] [--update]
+
+Commands:
+  repo     Make this checkout runnable (default)
+  agent    Repo bootstrap plus agent lifecycle diagnostics
+  doctor   Diagnostics only; no install, cleanup, or mutation
+  sweep    Conservative cleanup of configured runtime artifacts only
+
+Compatibility:
+  ./scripts/bootstrap.sh --force
+  ./scripts/bootstrap.sh --update
+EOF
+}
+
 if [[ ! -f "$BUN_VERSION_FILE" ]]; then
   echo "Error: Missing .bun-version at $BUN_VERSION_FILE" >&2
   exit 1
 fi
 
-PINNED_BUN_VERSION="$(tr -d '[:space:]' < "$BUN_VERSION_FILE")"
+SUBCOMMAND="${1:-repo}"
+case "$SUBCOMMAND" in
+  repo|agent|doctor|sweep)
+    shift || true
+    ;;
+  --force|--update)
+    SUBCOMMAND="repo"
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Unknown bootstrap subcommand: $SUBCOMMAND" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
 
-if [[ -z "$PINNED_BUN_VERSION" ]]; then
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+
+# Lifecycle-safe PATH. Normal agent command shells keep their provider shims;
+# bootstrap install paths need real system tools first so installer-style
+# commands such as curl | bash are not intercepted by local host shims.
+export PATH="$BUN_INSTALL/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+hash -r 2>/dev/null || true
+
+cd "$REPO_ROOT"
+
+read_pinned_bun_version() {
+  tr -d '[:space:]' < "$BUN_VERSION_FILE"
+}
+
+install_pinned_bun() {
+  local pinned_version="$1"
+  echo "Installing Bun $pinned_version..." >&2
+  curl -fsSL https://bun.sh/install | bash -s -- "bun-v$pinned_version"
+  export PATH="$BUN_INSTALL/bin:$PATH"
+  hash -r 2>/dev/null || true
+}
+
+bun_version_is_compatible() {
+  local actual="$1"
+  local pinned="$2"
+  local actual_major actual_minor actual_patch_raw actual_patch
+  local pinned_major pinned_minor pinned_patch_raw pinned_patch
+
+  IFS=. read -r actual_major actual_minor actual_patch_raw <<< "$actual"
+  IFS=. read -r pinned_major pinned_minor pinned_patch_raw <<< "$pinned"
+  actual_patch="${actual_patch_raw%%[^0-9]*}"
+  pinned_patch="${pinned_patch_raw%%[^0-9]*}"
+
+  [[ "${actual_major:-0}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${actual_minor:-0}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${actual_patch:-0}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${pinned_major:-0}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${pinned_minor:-0}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${pinned_patch:-0}" =~ ^[0-9]+$ ]] || return 1
+
+  [[ "$actual_major" -eq "$pinned_major" ]] &&
+    [[ "$actual_minor" -eq "$pinned_minor" ]] &&
+    [[ "$actual_patch" -ge "$pinned_patch" ]]
+}
+
+pinned_version="$(read_pinned_bun_version)"
+if [[ -z "$pinned_version" ]]; then
   echo "Error: .bun-version is empty" >&2
   exit 1
 fi
 
-usage() {
-  cat <<'EOF'
-Usage: ./scripts/bootstrap.sh [--force] [--update]
-
-  --force   Run the full bootstrap even if tools and dependencies look present.
-  --update  Refresh dependencies with a non-frozen install.
-EOF
-}
-
-# Colors (disabled when stderr is not a terminal — all log helpers write there)
-if [[ -t 2 ]]; then
-  RED='\033[0;31m'
-  GREEN='\033[0;32m'
-  YELLOW='\033[0;33m'
-  BLUE='\033[0;34m'
-  NC='\033[0m'
-else
-  RED='' GREEN='' YELLOW='' BLUE='' NC=''
-fi
-
-info() { echo -e "${BLUE}▸${NC} $1" >&2; }
-success() { echo -e "${GREEN}✓${NC} $1" >&2; }
-warn() { echo -e "${YELLOW}!${NC} $1" >&2; }
-error() { echo -e "${RED}✗${NC} $1" >&2; }
-
-# Check if command exists
-has() { command -v "$1" &>/dev/null; }
-
-list_workspace_globs() {
-  if has bun; then
-    TRAILS_PACKAGE_JSON="$REPO_ROOT/package.json" bun --eval '
-      const packageJson = JSON.parse(
-        await Bun.file(process.env.TRAILS_PACKAGE_JSON).text()
-      );
-      for (const workspace of packageJson.workspaces ?? []) {
-        console.log(workspace);
-      }
-    '
-  elif has node; then
-    TRAILS_PACKAGE_JSON="$REPO_ROOT/package.json" node --input-type=module --eval '
-      import { readFileSync } from "node:fs";
-
-      const packageJson = JSON.parse(
-        readFileSync(process.env.TRAILS_PACKAGE_JSON, "utf8")
-      );
-      for (const workspace of packageJson.workspaces ?? []) {
-        console.log(workspace);
-      }
-    '
-  elif has python3; then
-    TRAILS_PACKAGE_JSON="$REPO_ROOT/package.json" python3 - <<'PY'
-import json
-import os
-
-with open(os.environ["TRAILS_PACKAGE_JSON"], "r", encoding="utf-8") as fh:
-    package = json.load(fh)
-
-for workspace in package.get("workspaces", []):
-    print(workspace)
-PY
-  elif has python; then
-    TRAILS_PACKAGE_JSON="$REPO_ROOT/package.json" python - <<'PY'
-import json
-import os
-
-with open(os.environ["TRAILS_PACKAGE_JSON"], "r", encoding="utf-8") as fh:
-    package = json.load(fh)
-
-for workspace in package.get("workspaces", []):
-    print(workspace)
-PY
-  else
-    warn "No Bun, Node, or Python runtime found; workspace install-state check skipped"
-    return 1
-  fi
-}
-
-has_repo_install_state() {
-  [[ -e "$REPO_ROOT/node_modules" ]] || return 1
-
-  local dir
-  local workspace_glob
-  local workspace_globs=()
-  local nullglob_state
-  local ws_output
-  nullglob_state="$(shopt -p nullglob)"
-
-  # Capture list_workspace_globs output into a variable so its exit code is
-  # visible. Using process substitution hides failures (e.g. missing Python
-  # or malformed JSON) and would cause the caller to skip install entirely.
-  if ! ws_output="$(list_workspace_globs)"; then
-    return 1
-  fi
-
-  shopt -s nullglob
-  if [[ -n "$ws_output" ]]; then
-    while IFS= read -r workspace_glob; do
-      [[ -n "$workspace_glob" ]] || continue
-      workspace_globs+=("$workspace_glob")
-    done <<< "$ws_output"
-  fi
-  for workspace_glob in "${workspace_globs[@]}"; do
-    [[ -n "$workspace_glob" ]] || continue
-    for dir in "$REPO_ROOT"/$workspace_glob; do
-      [[ -f "$dir/package.json" ]] || continue
-      if [[ ! -e "$dir/node_modules" ]]; then
-        eval "$nullglob_state"
-        return 1
-      fi
-    done
-  done
-  eval "$nullglob_state"
-}
-
-FORCE=false
-UPDATE_INSTALL=false
-IS_MACOS=false
-
-parse_args() {
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --force)
-        FORCE=true
-        ;;
-      --update)
-        UPDATE_INSTALL=true
-        ;;
-      -h|--help)
-        usage
-        exit 0
-        ;;
-      *)
-        error "Unknown option: $1"
-        usage >&2
-        exit 1
-        ;;
-    esac
-    shift
-  done
-}
-
-# Fast path — returns 0 if everything is present and we should exit early.
-fast_path_ready() {
-  if $FORCE || $UPDATE_INSTALL; then
-    return 1
-  fi
-
-  local installed_bun_version
-  if command -v bun &>/dev/null; then
-    installed_bun_version="$(bun --version)"
-    [[ "$installed_bun_version" == "$PINNED_BUN_VERSION" ]] || return 1
-  else
-    return 1
-  fi
-
-  command -v gh &>/dev/null || return 1
-  command -v gt &>/dev/null || return 1
-  has_repo_install_state || return 1
-  return 0
-}
-
-detect_os() {
-  local os
-  os="$(uname -s)"
-  case "$os" in
-    Darwin) IS_MACOS=true ;;
-    Linux)  IS_MACOS=false ;;
-    *)      error "Unsupported OS: $os"; exit 1 ;;
-  esac
-}
-
-# -----------------------------------------------------------------------------
-# Homebrew (macOS only)
-# -----------------------------------------------------------------------------
-install_homebrew() {
-  if $IS_MACOS && ! has brew; then
-    info "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-    # Add Homebrew to PATH for the rest of this script
-    if [[ -x /opt/homebrew/bin/brew ]]; then
-      eval "$(/opt/homebrew/bin/brew shellenv)"
-    elif [[ -x /usr/local/bin/brew ]]; then
-      eval "$(/usr/local/bin/brew shellenv)"
-    fi
-
-    success "Homebrew installed"
-  fi
-}
-
-# -----------------------------------------------------------------------------
-# Bun
-# -----------------------------------------------------------------------------
-install_bun() {
-  local installed_bun_version=""
-
-  if has bun; then
-    installed_bun_version="$(bun --version)"
-  fi
-
-  if [[ "$installed_bun_version" == "$PINNED_BUN_VERSION" ]]; then
-    success "Bun already installed ($installed_bun_version)"
-    return
-  fi
-
-  if [[ -n "$installed_bun_version" ]]; then
-    info "Updating Bun from $installed_bun_version to $PINNED_BUN_VERSION..."
-  else
-    info "Installing Bun $PINNED_BUN_VERSION..."
-  fi
-
-  curl -fsSL https://bun.sh/install | bash -s -- "bun-v$PINNED_BUN_VERSION"
-
-  # Source the updated profile
-  export BUN_INSTALL="$HOME/.bun"
-  export PATH="$BUN_INSTALL/bin:$PATH"
-  hash -r
-
-  local resolved_bun_version
-  resolved_bun_version="$(bun --version)"
-
-  if [[ "$resolved_bun_version" != "$PINNED_BUN_VERSION" ]]; then
-    error "Expected Bun $PINNED_BUN_VERSION but found $resolved_bun_version after install"
+if ! command -v bun >/dev/null 2>&1; then
+  if [[ "$SUBCOMMAND" == "doctor" || "$SUBCOMMAND" == "sweep" ]]; then
+    echo "Error: Bun is required for '$SUBCOMMAND' and will not be installed by that command." >&2
     exit 1
   fi
 
-  success "Bun ready ($resolved_bun_version)"
-}
-
-# -----------------------------------------------------------------------------
-# GitHub CLI (gh)
-# -----------------------------------------------------------------------------
-install_gh() {
-  if has gh; then
-    success "GitHub CLI already installed ($(gh --version | head -1))"
-  else
-    info "Installing GitHub CLI..."
-    if $IS_MACOS; then
-      brew install gh
-    else
-      # Linux: use official apt repo
-      curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
-      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-      sudo apt-get update -qq && sudo apt-get install -y -qq gh
-    fi
-    success "GitHub CLI installed"
+  install_pinned_bun "$pinned_version"
+else
+  actual_version="$(bun --version 2>/dev/null || true)"
+  if [[ "$SUBCOMMAND" != "doctor" && "$SUBCOMMAND" != "sweep" ]] &&
+    ! bun_version_is_compatible "$actual_version" "$pinned_version"; then
+    echo "Bun $actual_version is not compatible with pinned $pinned_version; repairing bootstrap runtime..." >&2
+    install_pinned_bun "$pinned_version"
   fi
-}
-
-# -----------------------------------------------------------------------------
-# Graphite CLI (gt)
-# -----------------------------------------------------------------------------
-install_graphite() {
-  if has gt; then
-    success "Graphite CLI already installed ($(gt --version 2>/dev/null || echo 'unknown'))"
-  else
-    info "Installing Graphite CLI..."
-    if $IS_MACOS && has brew; then
-      brew install withgraphite/tap/graphite
-    else
-      bun install -g @withgraphite/graphite-cli
-    fi
-    success "Graphite CLI installed"
-  fi
-}
-
-# -----------------------------------------------------------------------------
-# Auth checks
-# -----------------------------------------------------------------------------
-check_auth() {
-  echo ""
-  info "Checking authentication..."
-
-  # GitHub CLI
-  if [[ -n "${GH_TOKEN:-}" ]] || [[ -n "${GITHUB_TOKEN:-}" ]]; then
-    success "GitHub CLI token found in environment"
-  elif gh auth status &>/dev/null; then
-    success "GitHub CLI already authenticated"
-  else
-    warn "GitHub CLI not authenticated. Run 'gh auth login' or set GH_TOKEN"
-  fi
-
-  # Graphite CLI
-  if [[ -n "${GT_AUTH_TOKEN:-}" ]]; then
-    info "Authenticating Graphite CLI..."
-    gt auth --token "$GT_AUTH_TOKEN"
-    success "Graphite CLI authenticated"
-  elif gt auth status &>/dev/null 2>&1; then
-    success "Graphite CLI already authenticated"
-  else
-    warn "Graphite CLI not authenticated. Run 'gt auth' or set GT_AUTH_TOKEN"
-  fi
-}
-
-# -----------------------------------------------------------------------------
-# Project dependencies
-# -----------------------------------------------------------------------------
-install_deps() {
-  if $UPDATE_INSTALL; then
-    info "Refreshing project dependencies with Bun..."
-  else
-    info "Installing project dependencies with Bun (frozen lockfile)..."
-  fi
-  (
-    cd "$REPO_ROOT"
-    if $UPDATE_INSTALL; then
-      bun install
-    else
-      bun install --frozen-lockfile
-    fi
-  )
-  success "Dependencies installed"
-}
-
-ensure_project_deps() {
-  if ! $FORCE && ! $UPDATE_INSTALL && has_repo_install_state; then
-    success "Dependencies already available"
-    return
-  fi
-
-  if git -C "$REPO_ROOT" rev-parse --is-inside-work-tree &>/dev/null; then
-    local git_dir=""
-    local common_dir=""
-
-    git_dir="$(git -C "$REPO_ROOT" rev-parse --git-dir)"
-    common_dir="$(git -C "$REPO_ROOT" rev-parse --git-common-dir)"
-
-    if [[ "$git_dir" != "$common_dir" ]]; then
-      info "Linked worktree detected; installing dependencies locally for this checkout"
-    fi
-  fi
-
-  install_deps
-}
-
-# -----------------------------------------------------------------------------
-# Main
-# -----------------------------------------------------------------------------
-main() {
-  parse_args "$@"
-
-  if fast_path_ready; then
-    exit 0  # All good, nothing to do
-  fi
-
-  detect_os
-
-  echo "" >&2
-  echo -e "${BLUE}Trails Bootstrap${NC}" >&2
-  echo "────────────────────" >&2
-  echo "" >&2
-
-  # Prerequisites
-  if $IS_MACOS; then
-    install_homebrew
-  fi
-
-  # Core tools
-  install_bun
-  install_gh
-  install_graphite
-
-  # Auth status
-  check_auth
-
-  echo "" >&2
-
-  # Project setup
-  ensure_project_deps
-
-  echo "" >&2
-  echo -e "${GREEN}Bootstrap complete!${NC}" >&2
-  echo "" >&2
-  echo "Next steps:" >&2
-  echo "  bun run build      # Build all packages" >&2
-  echo "  bun run test       # Run tests" >&2
-  echo "  bun run check      # Lint + format + typecheck" >&2
-  echo "  ./scripts/bootstrap.sh --update   # Refresh dependencies intentionally" >&2
-  echo "" >&2
-}
-
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-  main "$@"
 fi
+
+exec bun "$SCRIPT_DIR/bootstrap/main.ts" "$SUBCOMMAND" "$@"

--- a/scripts/bootstrap/agent.ts
+++ b/scripts/bootstrap/agent.ts
@@ -1,0 +1,22 @@
+import type { BootstrapConfig } from './config.js';
+import type { HostInfo } from './host.js';
+import { printAgentGitDiagnostics } from './git.js';
+import { runRepoBootstrap } from './repo.js';
+
+export interface AgentBootstrapOptions {
+  readonly config: BootstrapConfig;
+  readonly force: boolean;
+  readonly host: HostInfo;
+  readonly repoRoot: string;
+  readonly update: boolean;
+}
+
+export const runAgentBootstrap = async (
+  options: AgentBootstrapOptions
+): Promise<void> => {
+  await runRepoBootstrap(options);
+  printAgentGitDiagnostics(
+    options.repoRoot,
+    options.config.agent.graphiteStackMaxLines
+  );
+};

--- a/scripts/bootstrap/bun.ts
+++ b/scripts/bootstrap/bun.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs';
+
+import type { BunPolicy } from './config.js';
+import { repoFile, run, runInherit } from './shared.js';
+
+export interface BunCheck {
+  readonly actual: string | undefined;
+  readonly ok: boolean;
+  readonly pinned: string;
+  readonly policy: BunPolicy;
+  readonly reason?: string | undefined;
+}
+
+const parseVersionPart = (part: string): number => {
+  const numeric = part.match(/^\d+/)?.[0] ?? '0';
+  return Number(numeric);
+};
+
+const parseVersion = (version: string): readonly [number, number, number] => {
+  const [major = '0', minor = '0', patch = '0'] = version.split('.');
+  return [
+    parseVersionPart(major),
+    parseVersionPart(minor),
+    parseVersionPart(patch),
+  ];
+};
+
+export const isCompatibleBunVersion = (
+  actual: string,
+  pinned: string
+): boolean => {
+  const [actualMajor, actualMinor, actualPatch] = parseVersion(actual);
+  const [pinnedMajor, pinnedMinor, pinnedPatch] = parseVersion(pinned);
+  return (
+    actualMajor === pinnedMajor &&
+    actualMinor === pinnedMinor &&
+    actualPatch >= pinnedPatch
+  );
+};
+
+export const isBunVersionAllowed = (
+  actual: string,
+  pinned: string,
+  policy: BunPolicy
+): boolean =>
+  policy === 'strict'
+    ? actual === pinned
+    : isCompatibleBunVersion(actual, pinned);
+
+export const readPinnedBunVersion = (
+  repoRoot: string,
+  versionFile = '.bun-version'
+): string => readFileSync(repoFile(repoRoot, versionFile), 'utf8').trim();
+
+export const checkBunVersion = (
+  repoRoot: string,
+  policy: BunPolicy,
+  versionFile?: string
+): BunCheck => {
+  const pinned = readPinnedBunVersion(repoRoot, versionFile);
+  const result = run(['bun', '--version'], repoRoot);
+  const actual = result.exitCode === 0 ? result.stdout.trim() : undefined;
+
+  if (actual === undefined || actual.length === 0) {
+    return {
+      actual,
+      ok: false,
+      pinned,
+      policy,
+      reason: 'Bun is not available on PATH',
+    };
+  }
+
+  const ok = isBunVersionAllowed(actual, pinned, policy);
+  return {
+    actual,
+    ok,
+    pinned,
+    policy,
+    ...(ok
+      ? {}
+      : {
+          reason:
+            policy === 'strict'
+              ? `Expected Bun ${pinned}, found ${actual}`
+              : `Expected Bun ${pinned} or newer compatible patch, found ${actual}`,
+        }),
+  };
+};
+
+export const installPinnedBun = async (
+  repoRoot: string,
+  versionFile?: string
+): Promise<void> => {
+  const pinned = readPinnedBunVersion(repoRoot, versionFile);
+  const code = await runInherit(
+    [
+      'bash',
+      '-lc',
+      'curl -fsSL https://bun.sh/install | bash -s -- "$1"',
+      'bash',
+      `bun-v${pinned}`,
+    ],
+    repoRoot
+  );
+  if (code !== 0) {
+    throw new Error(`Bun install failed with exit code ${String(code)}`);
+  }
+};

--- a/scripts/bootstrap/config.toml
+++ b/scripts/bootstrap/config.toml
@@ -1,0 +1,97 @@
+[defaults]
+command = "repo"
+local_bun_policy = "compatible"
+remote_bun_policy = "strict"
+
+[root]
+env_vars = [
+  "CODEX_WORKTREE_PATH",
+  "CLAUDE_PROJECT_DIR",
+  "CLAUDECODE",
+  "FACTORY_PROJECT_DIR",
+  "GITHUB_WORKSPACE",
+]
+fallback_to_git_root = true
+
+[bun]
+version_file = ".bun-version"
+install_dir_env = "BUN_INSTALL"
+install_dir_default = "$HOME/.bun"
+
+[paths.lifecycle]
+prepend = [
+  "$BUN_INSTALL/bin",
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+  "/usr/bin",
+  "/bin",
+  "/usr/sbin",
+  "/sbin",
+]
+
+[paths.working_shell]
+prepend = ["$BUN_INSTALL/bin"]
+
+[commands.repo]
+install_dependencies = true
+check_optional_tools = true
+
+[commands.agent]
+runs_repo = true
+show_worktree_notice = true
+show_graphite_stack = true
+graphite_stack_max_lines = 120
+
+[commands.doctor]
+mutates = false
+
+[commands.sweep]
+mutates = true
+git_mutation_allowed = false
+
+[checks.required]
+tools = ["bun"]
+
+[checks.optional]
+tools = ["git", "gh", "gt", "rg", "jq", "direnv"]
+
+[graphite]
+enabled_if_tool_exists = true
+forbidden_lifecycle_commands = [
+  "gt sync",
+  "gt restack",
+  "gt submit",
+  "gt branch delete",
+  "gt branch untrack",
+]
+
+[cleanup]
+directories = [".turbo", ".trails-tmp", ".tmp-tests", ".try"]
+files = [
+  ".trails/trails.db",
+  ".trails/trails.db-shm",
+  ".trails/trails.db-wal",
+  ".trails/dev/tracing.db",
+  ".trails/dev/tracing.db-shm",
+  ".trails/dev/tracing.db-wal",
+]
+
+[providers.codex]
+root_env_vars = ["CODEX_WORKTREE_PATH"]
+local_bun_policy = "compatible"
+
+[providers.claude]
+root_env_vars = ["CLAUDE_PROJECT_DIR", "CLAUDECODE"]
+remote_env_var = "CLAUDE_CODE_REMOTE"
+remote_env_value = "true"
+remote_bun_policy = "strict"
+persist_env_file_var = "CLAUDE_ENV_FILE"
+
+[providers.factory]
+root_env_vars = ["FACTORY_PROJECT_DIR"]
+remote_bun_policy = "strict"
+
+[providers.devin]
+root_env_vars = ["GITHUB_WORKSPACE"]
+persist_env_file_var = "ENVRC"
+remote_bun_policy = "strict"

--- a/scripts/bootstrap/config.ts
+++ b/scripts/bootstrap/config.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { BOOTSTRAP_DIR } from './shared.js';
+
+export interface BootstrapConfig {
+  readonly bun: {
+    readonly installDirDefault: string;
+    readonly installDirEnv: string;
+    readonly versionFile: string;
+  };
+  readonly checks: {
+    readonly optionalTools: readonly string[];
+    readonly requiredTools: readonly string[];
+  };
+  readonly cleanup: {
+    readonly directories: readonly string[];
+    readonly files: readonly string[];
+  };
+  readonly defaults: {
+    readonly command: BootstrapCommand;
+    readonly localBunPolicy: BunPolicy;
+    readonly remoteBunPolicy: BunPolicy;
+  };
+  readonly graphite: {
+    readonly enabledIfToolExists: boolean;
+    readonly forbiddenLifecycleCommands: readonly string[];
+  };
+  readonly root: {
+    readonly envVars: readonly string[];
+    readonly fallbackToGitRoot: boolean;
+  };
+  readonly agent: {
+    readonly graphiteStackMaxLines: number;
+  };
+}
+
+export type BootstrapCommand = 'agent' | 'doctor' | 'repo' | 'sweep';
+export type BunPolicy = 'compatible' | 'strict';
+
+interface RawConfig {
+  readonly agent?: { readonly graphite_stack_max_lines?: number };
+  readonly bun?: {
+    readonly install_dir_default?: string;
+    readonly install_dir_env?: string;
+    readonly version_file?: string;
+  };
+  readonly checks?: {
+    readonly optional?: { readonly tools?: string[] };
+    readonly required?: { readonly tools?: string[] };
+  };
+  readonly cleanup?: {
+    readonly directories?: string[];
+    readonly files?: string[];
+  };
+  readonly commands?: {
+    readonly agent?: { readonly graphite_stack_max_lines?: number };
+  };
+  readonly defaults?: {
+    readonly command?: BootstrapCommand;
+    readonly local_bun_policy?: BunPolicy;
+    readonly remote_bun_policy?: BunPolicy;
+  };
+  readonly graphite?: {
+    readonly enabled_if_tool_exists?: boolean;
+    readonly forbidden_lifecycle_commands?: string[];
+  };
+  readonly root?: {
+    readonly env_vars?: string[];
+    readonly fallback_to_git_root?: boolean;
+  };
+}
+
+const configPath = join(BOOTSTRAP_DIR, 'config.toml');
+
+const DEFAULT_OPTIONAL_TOOLS = [
+  'git',
+  'gh',
+  'gt',
+  'rg',
+  'jq',
+  'direnv',
+] as const;
+
+const DEFAULT_ROOT_ENV_VARS = [
+  'CODEX_WORKTREE_PATH',
+  'CLAUDE_PROJECT_DIR',
+  'CLAUDECODE',
+  'FACTORY_PROJECT_DIR',
+  'GITHUB_WORKSPACE',
+] as const;
+
+const agentConfig = (raw: RawConfig): BootstrapConfig['agent'] => ({
+  graphiteStackMaxLines:
+    raw.commands?.agent?.graphite_stack_max_lines ??
+    raw.agent?.graphite_stack_max_lines ??
+    120,
+});
+
+const bunConfig = (raw: RawConfig): BootstrapConfig['bun'] => ({
+  installDirDefault: raw.bun?.install_dir_default ?? '$HOME/.bun',
+  installDirEnv: raw.bun?.install_dir_env ?? 'BUN_INSTALL',
+  versionFile: raw.bun?.version_file ?? '.bun-version',
+});
+
+const checksConfig = (raw: RawConfig): BootstrapConfig['checks'] => ({
+  optionalTools: raw.checks?.optional?.tools ?? DEFAULT_OPTIONAL_TOOLS,
+  requiredTools: raw.checks?.required?.tools ?? ['bun'],
+});
+
+const cleanupConfig = (raw: RawConfig): BootstrapConfig['cleanup'] => ({
+  directories: raw.cleanup?.directories ?? [],
+  files: raw.cleanup?.files ?? [],
+});
+
+const defaultsConfig = (raw: RawConfig): BootstrapConfig['defaults'] => ({
+  command: raw.defaults?.command ?? 'repo',
+  localBunPolicy: raw.defaults?.local_bun_policy ?? 'compatible',
+  remoteBunPolicy: raw.defaults?.remote_bun_policy ?? 'strict',
+});
+
+const graphiteConfig = (raw: RawConfig): BootstrapConfig['graphite'] => ({
+  enabledIfToolExists: raw.graphite?.enabled_if_tool_exists ?? true,
+  forbiddenLifecycleCommands: raw.graphite?.forbidden_lifecycle_commands ?? [],
+});
+
+const rootConfig = (raw: RawConfig): BootstrapConfig['root'] => ({
+  envVars: raw.root?.env_vars ?? DEFAULT_ROOT_ENV_VARS,
+  fallbackToGitRoot: raw.root?.fallback_to_git_root ?? true,
+});
+
+export const loadBootstrapConfig = (): BootstrapConfig => {
+  const raw = Bun.TOML.parse(readFileSync(configPath, 'utf8')) as RawConfig;
+
+  return {
+    agent: agentConfig(raw),
+    bun: bunConfig(raw),
+    checks: checksConfig(raw),
+    cleanup: cleanupConfig(raw),
+    defaults: defaultsConfig(raw),
+    graphite: graphiteConfig(raw),
+    root: rootConfig(raw),
+  };
+};

--- a/scripts/bootstrap/doctor.ts
+++ b/scripts/bootstrap/doctor.ts
@@ -1,0 +1,34 @@
+import type { BootstrapConfig } from './config.js';
+import type { HostInfo } from './host.js';
+import { checkBunVersion } from './bun.js';
+import { hasRepoInstallState } from './repo.js';
+import { collectToolStatus, printToolStatuses } from './tools.js';
+
+export const runDoctor = async (
+  repoRoot: string,
+  config: BootstrapConfig,
+  host: HostInfo
+): Promise<void> => {
+  console.error('Trails Bootstrap Doctor');
+  console.error('───────────────────────');
+  console.error(`repo root: ${repoRoot}`);
+  console.error(`provider: ${host.provider}`);
+  console.error(`remote: ${String(host.remote)}`);
+
+  const bun = checkBunVersion(repoRoot, host.bunPolicy, config.bun.versionFile);
+  console.error('');
+  console.error('Required checks');
+  console.error(
+    `  bun: ${bun.ok ? 'ok' : 'failed'}${bun.actual ? ` ${bun.actual}` : ''} (${bun.policy}; pinned ${bun.pinned})`
+  );
+  console.error(
+    `  dependencies: ${(await hasRepoInstallState(repoRoot)) ? 'ok' : 'missing'}`
+  );
+
+  console.error('');
+  printToolStatuses(
+    'Optional capabilities',
+    collectToolStatus(config.checks.optionalTools, repoRoot),
+    true
+  );
+};

--- a/scripts/bootstrap/git.ts
+++ b/scripts/bootstrap/git.ts
@@ -1,0 +1,76 @@
+import { has, run } from './shared.js';
+
+export interface WorktreeInfo {
+  readonly branch: string | undefined;
+  readonly commonDir: string | undefined;
+  readonly gitDir: string | undefined;
+  readonly linked: boolean;
+}
+
+export const isLinkedWorktree = (
+  gitDir: string | undefined,
+  commonDir: string | undefined
+): boolean =>
+  gitDir !== undefined &&
+  commonDir !== undefined &&
+  gitDir.length > 0 &&
+  commonDir.length > 0 &&
+  gitDir !== commonDir;
+
+export const readWorktreeInfo = (repoRoot: string): WorktreeInfo => {
+  const gitDir = run(['git', 'rev-parse', '--git-dir'], repoRoot);
+  const commonDir = run(['git', 'rev-parse', '--git-common-dir'], repoRoot);
+  const branch = run(['git', 'branch', '--show-current'], repoRoot);
+  const resolvedGitDir =
+    gitDir.exitCode === 0 ? gitDir.stdout.trim() : undefined;
+  const resolvedCommonDir =
+    commonDir.exitCode === 0 ? commonDir.stdout.trim() : undefined;
+
+  return {
+    branch: branch.exitCode === 0 ? branch.stdout.trim() : undefined,
+    commonDir: resolvedCommonDir,
+    gitDir: resolvedGitDir,
+    linked: isLinkedWorktree(resolvedGitDir, resolvedCommonDir),
+  };
+};
+
+export const printAgentGitDiagnostics = (
+  repoRoot: string,
+  maxGraphiteLines: number
+): void => {
+  const info = readWorktreeInfo(repoRoot);
+  if (!info.linked) {
+    return;
+  }
+
+  console.error('');
+  console.error('Linked worktree detected');
+  console.error(
+    `  branch: ${info.branch && info.branch.length > 0 ? info.branch : 'detached HEAD'}`
+  );
+  console.error(
+    '  Graphite branches and metadata are shared with the main checkout.'
+  );
+  console.error(
+    '  Lifecycle hooks must not run gt sync/restack/submit or branch deletion commands.'
+  );
+
+  if (!has('gt')) {
+    console.error('  gt: missing (Graphite stack inspection disabled)');
+    return;
+  }
+
+  const log = run(['gt', 'log', '--no-interactive'], repoRoot);
+  if (log.exitCode !== 0) {
+    console.error('  gt log unavailable');
+    return;
+  }
+
+  console.error('');
+  console.error(`Graphite stack (first ${String(maxGraphiteLines)} lines)`);
+  for (const line of log.stdout.split('\n').slice(0, maxGraphiteLines)) {
+    if (line.length > 0) {
+      console.error(line);
+    }
+  }
+};

--- a/scripts/bootstrap/host.ts
+++ b/scripts/bootstrap/host.ts
@@ -1,0 +1,98 @@
+import { resolve } from 'node:path';
+
+import type { BootstrapConfig, BunPolicy } from './config.js';
+import { DEFAULT_REPO_ROOT, isRepoRoot, run } from './shared.js';
+
+export type HostProvider = 'claude' | 'codex' | 'devin' | 'factory' | 'generic';
+
+export interface HostInfo {
+  readonly provider: HostProvider;
+  readonly remote: boolean;
+  readonly bunPolicy: BunPolicy;
+}
+
+const readBoolean = (value: string | undefined): boolean | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  return ['1', 'true', 'yes'].includes(value.toLowerCase());
+};
+
+const detectProvider = (env: NodeJS.ProcessEnv): HostProvider => {
+  const explicitProvider = env['TRAILS_AGENT_ENV_PROVIDER'] as
+    | HostProvider
+    | undefined;
+  if (explicitProvider !== undefined) {
+    return explicitProvider;
+  }
+  if (env['CODEX_WORKTREE_PATH'] !== undefined) {
+    return 'codex';
+  }
+  if (
+    env['CLAUDE_PROJECT_DIR'] !== undefined ||
+    env['CLAUDECODE'] !== undefined
+  ) {
+    return 'claude';
+  }
+  if (env['FACTORY_PROJECT_DIR'] !== undefined) {
+    return 'factory';
+  }
+  if (env['GITHUB_WORKSPACE'] !== undefined) {
+    return 'devin';
+  }
+  return 'generic';
+};
+
+export const detectHost = (
+  env: NodeJS.ProcessEnv,
+  config: BootstrapConfig
+): HostInfo => {
+  const provider = detectProvider(env);
+
+  const explicitRemote = readBoolean(env['TRAILS_AGENT_ENV_REMOTE']);
+  const remote =
+    explicitRemote ??
+    (env['CLAUDE_CODE_REMOTE'] === 'true' ||
+      env['GITHUB_ACTIONS'] === 'true' ||
+      env['CI'] === 'true');
+  const explicitPolicy = env['TRAILS_AGENT_BUN_POLICY'] as
+    | BunPolicy
+    | undefined;
+
+  return {
+    bunPolicy:
+      explicitPolicy ??
+      (remote
+        ? config.defaults.remoteBunPolicy
+        : config.defaults.localBunPolicy),
+    provider,
+    remote,
+  };
+};
+
+export const resolveRepoRoot = (
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  config: BootstrapConfig
+): string => {
+  for (const name of config.root.envVars) {
+    const candidate = env[name];
+    if (candidate !== undefined && isRepoRoot(candidate)) {
+      return resolve(candidate);
+    }
+  }
+
+  if (isRepoRoot(cwd)) {
+    return resolve(cwd);
+  }
+
+  if (config.root.fallbackToGitRoot) {
+    const result = run(['git', 'rev-parse', '--show-toplevel'], cwd);
+    const candidate = result.stdout.trim();
+    if (result.exitCode === 0 && isRepoRoot(candidate)) {
+      return resolve(candidate);
+    }
+  }
+
+  return DEFAULT_REPO_ROOT;
+};

--- a/scripts/bootstrap/main.ts
+++ b/scripts/bootstrap/main.ts
@@ -1,0 +1,126 @@
+import type { BootstrapCommand } from './config.js';
+import { detectHost, resolveRepoRoot } from './host.js';
+import { loadBootstrapConfig } from './config.js';
+import { runAgentBootstrap } from './agent.js';
+import { runDoctor } from './doctor.js';
+import { runRepoBootstrap } from './repo.js';
+import { runSweep } from './sweep.js';
+
+export interface ParsedBootstrapArgs {
+  readonly command: BootstrapCommand;
+  readonly force: boolean;
+  readonly update: boolean;
+}
+
+const COMMANDS: ReadonlySet<string> = new Set([
+  'agent',
+  'doctor',
+  'repo',
+  'sweep',
+]);
+
+export const parseBootstrapArgs = (
+  args: readonly string[]
+): ParsedBootstrapArgs => {
+  const [first, ...rest] = args;
+  const command = COMMANDS.has(first ?? '') ? first : 'repo';
+  const flags = command === first ? rest : args;
+  let force = false;
+  let update = false;
+
+  for (const flag of flags) {
+    switch (flag) {
+      case '--force': {
+        force = true;
+        break;
+      }
+      case '--update': {
+        update = true;
+        break;
+      }
+      case '-h':
+      case '--help': {
+        break;
+      }
+      default: {
+        throw new Error(`Unknown bootstrap option: ${flag}`);
+      }
+    }
+  }
+
+  return {
+    command: command as BootstrapCommand,
+    force,
+    update,
+  };
+};
+
+export const printUsage = (): void => {
+  console.error(`Usage: ./scripts/bootstrap.sh [repo|agent|doctor|sweep] [--force] [--update]
+
+Commands:
+  repo     Make this checkout runnable (default)
+  agent    Repo bootstrap plus agent lifecycle diagnostics
+  doctor   Diagnostics only; no install, cleanup, or mutation
+  sweep    Conservative cleanup of configured runtime artifacts only
+
+Compatibility:
+  ./scripts/bootstrap.sh --force
+  ./scripts/bootstrap.sh --update`);
+};
+
+const runMain = async (): Promise<void> => {
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const config = loadBootstrapConfig();
+  const parsed = parseBootstrapArgs(process.argv.slice(2));
+  const host = detectHost(process.env, config);
+  const repoRoot = resolveRepoRoot(process.cwd(), process.env, config);
+
+  switch (parsed.command) {
+    case 'repo': {
+      await runRepoBootstrap({
+        config,
+        force: parsed.force,
+        host,
+        repoRoot,
+        update: parsed.update,
+      });
+      return;
+    }
+    case 'agent': {
+      await runAgentBootstrap({
+        config,
+        force: parsed.force,
+        host,
+        repoRoot,
+        update: parsed.update,
+      });
+      return;
+    }
+    case 'doctor': {
+      await runDoctor(repoRoot, config, host);
+      return;
+    }
+    case 'sweep': {
+      runSweep(repoRoot, config);
+      return;
+    }
+    default: {
+      const exhaustive: never = parsed.command;
+      throw new Error(`Unknown bootstrap command: ${exhaustive}`);
+    }
+  }
+};
+
+if (import.meta.main) {
+  try {
+    await runMain();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/bootstrap/repo.ts
+++ b/scripts/bootstrap/repo.ts
@@ -1,0 +1,155 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { BootstrapConfig } from './config.js';
+import type { HostInfo } from './host.js';
+import type { BunCheck } from './bun.js';
+import { checkBunVersion, installPinnedBun } from './bun.js';
+import { info, runInherit, success, warn } from './shared.js';
+import { collectToolStatus, printToolStatuses } from './tools.js';
+import { readWorktreeInfo } from './git.js';
+
+export interface RepoBootstrapOptions {
+  readonly config: BootstrapConfig;
+  readonly force: boolean;
+  readonly host: HostInfo;
+  readonly repoRoot: string;
+  readonly update: boolean;
+}
+
+export interface BunPolicyDeps {
+  readonly checkBunVersion?: (
+    repoRoot: string,
+    policy: HostInfo['bunPolicy'],
+    versionFile?: string
+  ) => BunCheck;
+  readonly installPinnedBun?: (
+    repoRoot: string,
+    versionFile?: string
+  ) => Promise<void>;
+}
+
+export const listWorkspaceGlobs = async (
+  repoRoot: string
+): Promise<readonly string[]> => {
+  const packageJson = (await Bun.file(
+    join(repoRoot, 'package.json')
+  ).json()) as {
+    readonly workspaces?: readonly string[];
+  };
+  return packageJson.workspaces ?? [];
+};
+
+const expandWorkspaceGlob = (
+  repoRoot: string,
+  workspaceGlob: string
+): readonly string[] => {
+  if (!workspaceGlob.endsWith('/*')) {
+    return [join(repoRoot, workspaceGlob)];
+  }
+  const base = join(repoRoot, workspaceGlob.slice(0, -2));
+  if (!existsSync(base)) {
+    return [];
+  }
+  return readdirSync(base)
+    .map((entry) => join(base, entry))
+    .filter((entry) => statSync(entry).isDirectory());
+};
+
+export const hasRepoInstallState = async (
+  repoRoot: string
+): Promise<boolean> => {
+  if (!existsSync(join(repoRoot, 'node_modules'))) {
+    return false;
+  }
+  for (const workspaceGlob of await listWorkspaceGlobs(repoRoot)) {
+    for (const dir of expandWorkspaceGlob(repoRoot, workspaceGlob)) {
+      if (
+        existsSync(join(dir, 'package.json')) &&
+        !existsSync(join(dir, 'node_modules'))
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+export const ensureBunPolicy = async (
+  options: RepoBootstrapOptions,
+  deps: BunPolicyDeps = {}
+): Promise<void> => {
+  const readCheck = deps.checkBunVersion ?? checkBunVersion;
+  const repairBun = deps.installPinnedBun ?? installPinnedBun;
+  let check = readCheck(
+    options.repoRoot,
+    options.host.bunPolicy,
+    options.config.bun.versionFile
+  );
+  if (!check.ok) {
+    warn(check.reason ?? 'Bun version check failed');
+    info(`Repairing Bun runtime to pinned ${check.pinned}`);
+    await repairBun(options.repoRoot, options.config.bun.versionFile);
+    check = readCheck(
+      options.repoRoot,
+      options.host.bunPolicy,
+      options.config.bun.versionFile
+    );
+    if (!check.ok) {
+      throw new Error(check.reason ?? 'Bun version check failed');
+    }
+  }
+  success(
+    `Bun ready (${check.actual}, ${check.policy} policy; pinned ${check.pinned})`
+  );
+};
+
+const installDependencies = async (
+  repoRoot: string,
+  update: boolean
+): Promise<void> => {
+  info(
+    update
+      ? 'Refreshing project dependencies with Bun'
+      : 'Installing project dependencies with Bun (frozen lockfile)'
+  );
+  const code = await runInherit(
+    update ? ['bun', 'install'] : ['bun', 'install', '--frozen-lockfile'],
+    repoRoot
+  );
+  if (code !== 0) {
+    throw new Error(`bun install failed with exit code ${String(code)}`);
+  }
+  success('Dependencies installed');
+};
+
+export const runRepoBootstrap = async (
+  options: RepoBootstrapOptions
+): Promise<void> => {
+  await ensureBunPolicy(options);
+
+  const installStateReady = await hasRepoInstallState(options.repoRoot);
+  if (!options.force && !options.update && installStateReady) {
+    success('Dependencies already available');
+  } else {
+    const worktree = readWorktreeInfo(options.repoRoot);
+    if (worktree.linked) {
+      info(
+        'Linked worktree detected; installing dependencies locally for this checkout'
+      );
+    }
+    await installDependencies(options.repoRoot, options.update);
+  }
+
+  if (options.config.checks.optionalTools.length > 0) {
+    const statuses = collectToolStatus(
+      options.config.checks.optionalTools,
+      options.repoRoot
+    );
+    console.error('');
+    printToolStatuses('Optional capabilities', statuses, true);
+    if (statuses.some((status) => !status.present)) {
+      warn('Missing optional capabilities do not block bootstrap.');
+    }
+  }
+};

--- a/scripts/bootstrap/shared.ts
+++ b/scripts/bootstrap/shared.ts
@@ -1,0 +1,60 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const BOOTSTRAP_DIR = dirname(fileURLToPath(import.meta.url));
+export const SCRIPTS_DIR = resolve(BOOTSTRAP_DIR, '..');
+export const DEFAULT_REPO_ROOT = resolve(SCRIPTS_DIR, '..');
+
+export interface ExecResult {
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+export const has = (tool: string): boolean => Bun.which(tool) !== null;
+
+export const run = (cmd: readonly string[], cwd: string): ExecResult => {
+  const result = Bun.spawnSync({
+    cmd,
+    cwd,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  return {
+    exitCode: result.exitCode,
+    stderr: new TextDecoder().decode(result.stderr),
+    stdout: new TextDecoder().decode(result.stdout),
+  };
+};
+
+export const runInherit = async (
+  cmd: readonly string[],
+  cwd: string
+): Promise<number> => {
+  const proc = Bun.spawn(cmd, {
+    cwd,
+    stderr: 'inherit',
+    stdout: 'inherit',
+  });
+  return await proc.exited;
+};
+
+export const repoFile = (repoRoot: string, path: string): string =>
+  resolve(repoRoot, path);
+
+export const isRepoRoot = (path: string): boolean =>
+  existsSync(repoFile(path, 'package.json')) &&
+  existsSync(repoFile(path, '.bun-version'));
+
+export const info = (message: string): void => {
+  console.error(`▸ ${message}`);
+};
+
+export const success = (message: string): void => {
+  console.error(`✓ ${message}`);
+};
+
+export const warn = (message: string): void => {
+  console.error(`! ${message}`);
+};

--- a/scripts/bootstrap/sweep.ts
+++ b/scripts/bootstrap/sweep.ts
@@ -1,0 +1,39 @@
+import { existsSync, rmSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+
+import type { BootstrapConfig } from './config.js';
+import { info, success } from './shared.js';
+
+export const resolveCleanupTarget = (
+  repoRoot: string,
+  configuredPath: string
+): string => {
+  const target = resolve(repoRoot, configuredPath);
+  const relativePath = relative(repoRoot, target);
+  if (
+    relativePath === '' ||
+    relativePath.startsWith('..') ||
+    relativePath.startsWith('/')
+  ) {
+    throw new Error(`Refusing cleanup target outside repo: ${configuredPath}`);
+  }
+  return target;
+};
+
+export const runSweep = (repoRoot: string, config: BootstrapConfig): void => {
+  const targets = [...config.cleanup.directories, ...config.cleanup.files].map(
+    (target) => resolveCleanupTarget(repoRoot, target)
+  );
+
+  let removed = 0;
+  for (const target of targets) {
+    if (!existsSync(target)) {
+      continue;
+    }
+    info(`Removing ${relative(repoRoot, target)}`);
+    rmSync(target, { force: true, recursive: true });
+    removed += 1;
+  }
+
+  success(`Sweep complete (${String(removed)} targets removed)`);
+};

--- a/scripts/bootstrap/tools.ts
+++ b/scripts/bootstrap/tools.ts
@@ -1,0 +1,47 @@
+import { has, run } from './shared.js';
+
+export interface ToolStatus {
+  readonly name: string;
+  readonly present: boolean;
+  readonly version?: string | undefined;
+}
+
+const firstLine = (value: string): string | undefined => {
+  const [line] = value.trim().split('\n');
+  return line && line.length > 0 ? line : undefined;
+};
+
+export const collectToolStatus = (
+  tools: readonly string[],
+  cwd: string
+): readonly ToolStatus[] =>
+  tools.map((tool) => {
+    if (!has(tool)) {
+      return { name: tool, present: false };
+    }
+    const version = run([tool, '--version'], cwd);
+    return {
+      name: tool,
+      present: true,
+      ...(version.exitCode === 0 ? { version: firstLine(version.stdout) } : {}),
+    };
+  });
+
+export const printToolStatuses = (
+  title: string,
+  statuses: readonly ToolStatus[],
+  optional = false
+): void => {
+  console.error(title);
+  for (const status of statuses) {
+    if (status.present) {
+      console.error(
+        `  ${status.name}: ok${status.version ? ` ${status.version}` : ''}`
+      );
+    } else {
+      console.error(
+        `  ${status.name}: missing${optional ? ' (ok; capability disabled)' : ''}`
+      );
+    }
+  }
+};


### PR DESCRIPTION
## Context

TRL-618 refactors bootstrap into configurable, agent-aware subcommands so repo setup and agent setup can be run deliberately instead of through one broad script path.

## What Changed

- Added TypeScript bootstrap modules for repo, agent, doctor, and sweep flows.
- Kept the shell entrypoint as the stable invocation path while delegating richer behavior to the TS modules.
- Fixed stale/incompatible Bun repair so `repo` and `agent` flows repair before enforcing the pinned runtime policy.
- Cleaned the shell wording so incompatible Bun is not always described as merely older.

## Tests Run

- `bash -n scripts/bootstrap.sh`
- `bun test scripts/__tests__/bootstrap.test.ts`
- `./scripts/bootstrap.sh doctor`
- Full tip gate: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`

## Risks / Rollout

Moderate developer-tooling risk because bootstrap is a first-touch script. The changes preserve the shell entrypoint and add tests around the agent-aware flows and Bun repair behavior.

Closes: TRL-618