### PR TITLE
chore(repo): wire symbol navigation setup

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,3 @@
+/cache
+/logs
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,20 @@
+project_name: trails
+languages:
+  - typescript
+encoding: utf-8
+line_ending: lf
+language_backend: LSP
+ignore_all_files_in_gitignore: true
+additional_workspace_folders: []
+ignored_paths: []
+read_only: false
+excluded_tools: []
+included_optional_tools: []
+fixed_tools: []
+initial_prompt: ''
+default_modes: []
+added_modes: []
+symbol_info_budget: 0
+read_only_memory_patterns: []
+ignored_memory_patterns: []
+ls_specific_settings: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ The architecture is designed to make consistency easier than drift. Agents build
    - Future directions for Trails are outlined in speculative or [draft ADRs](docs/adr/drafts/README.md).
 3. Durable Warden rule methodology lives in [Rule Design](docs/rule-design.md).
 4. We keep a log of our working notes, session recaps, learnings, etc. in `.agents/notes/` (gitignored — local only) as a historical record of our journey.
+5. Agent symbol-level navigation setup lives in [Agent Symbol Navigation](docs/agent-symbol-navigation.md). The committed `.serena/project.yml` is the repo-level Serena project config; client-specific MCP launch config stays local unless a client provides a portable project config shape.
 
 ## Lexicon
 

--- a/docs/agent-symbol-navigation.md
+++ b/docs/agent-symbol-navigation.md
@@ -1,0 +1,85 @@
+# Agent Symbol Navigation
+
+Trails keeps a repository-level Serena project configuration at
+`.serena/project.yml`. Serena is the default symbolic navigation path for
+agents because it provides TypeScript LSP-backed tools for symbol search,
+references, declarations, diagnostics, and rename support without requiring a
+paid IDE plugin or machine-local absolute paths.
+
+## Default: Serena
+
+Install the Serena CLI once from the same upstream source path used for local
+verification:
+
+```bash
+uv tool install -p 3.13 --from git+https://github.com/oraios/serena serena
+serena init
+```
+
+For Codex CLI/App, current Serena docs recommend user-level MCP configuration:
+
+```toml
+[mcp_servers.serena]
+startup_timeout_sec = 15
+command = "serena"
+args = ["start-mcp-server", "--project-from-cwd", "--context=codex"]
+```
+
+For clients that accept a per-workspace stdio MCP launch command, use the same
+project-bound server:
+
+```bash
+serena start-mcp-server --context=ide --project /absolute/path/to/trails
+```
+
+If installing Serena globally is not desirable, `uvx` can run the current
+source version directly:
+
+```bash
+uvx -p 3.13 --from git+https://github.com/oraios/serena serena start-mcp-server --project-from-cwd --context=codex
+```
+
+The `uvx` path is useful for one-off setup, but the installed `serena` command
+is preferred for regular work because a live GitHub source run may resync and
+slow MCP startup.
+
+## Local Verification
+
+Verified on 2026-05-06 against the upstream Serena docs and local CLI:
+
+```bash
+uvx -p 3.13 --from git+https://github.com/oraios/serena serena --help
+uvx -p 3.13 --from git+https://github.com/oraios/serena serena start-mcp-server --help
+uvx -p 3.13 --from git+https://github.com/oraios/serena serena tools list --all
+uvx -p 3.13 --from git+https://github.com/oraios/serena serena project health-check .
+```
+
+The health check passed with the LSP backend, started the TypeScript language
+server, used the workspace TypeScript version, and exercised `get_symbols_overview`,
+`find_symbol`, `find_referencing_symbols`, and text search. The available tool
+list includes the expected `find_symbol` and `find_referencing_symbols` tools.
+
+## Fallback: mcp-language-server
+
+Use `mcp-language-server` only when Serena is unavailable or a client needs a
+smaller tool surface. Current upstream setup requires both the Go MCP server
+and the TypeScript language server:
+
+```bash
+go install github.com/isaacphi/mcp-language-server@latest
+npm install -g typescript typescript-language-server
+mcp-language-server --workspace /absolute/path/to/trails --lsp typescript-language-server -- --stdio
+```
+
+This fallback exposes definition, references, diagnostics, hover, and rename
+tools, but it does not use `.serena/project.yml`, Serena contexts, or Serena's
+project workflow. Prefer Serena for the default Trails agent experience.
+
+## Notes
+
+- Do not commit machine-local client config such as `~/.codex/config.toml`.
+- Use absolute project paths in client config when the client does not launch
+  MCP servers from the repository root.
+- Keep `.serena/project.local.yml`, `.serena/cache/`, and `.serena/logs/` local.
+- If a client starts in a global context, activate the Trails project before
+  relying on symbol tools.


### PR DESCRIPTION
## Context

TRL-614 wires symbol-level repo navigation setup for agents, using current upstream Serena setup docs rather than stale local Trails skill guidance.

## What Changed

- Added versioned Serena project configuration under `.serena/project.yml`.
- Added `.serena/.gitignore` for local caches/logs/overrides.
- Added `docs/agent-symbol-navigation.md` with setup and usage guidance.
- Added an `AGENTS.md` pointer to the symbol-navigation docs.

## Tests Run

- Verified upstream Serena setup/help paths locally: `uvx -p 3.13 --from git+https://github.com/oraios/serena serena --help`, `serena start-mcp-server --help`, `serena tools list --all`, and `serena project health-check .`
- Full tip gate: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`

## Risks / Rollout

Low risk. This adds optional agent tooling configuration and docs; it does not require every contributor to run Serena. Client-specific MCP launch configuration remains local rather than checked in.

Closes: TRL-614