### PR TITLE
docs: codify warden authority model

### DIFF
--- a/docs/rule-design.md
+++ b/docs/rule-design.md
@@ -28,6 +28,39 @@ metadata exposes them from `@ontrails/warden`; runtime tier filtering and
 advisory report shape build on that metadata rather than inventing another rule
 registry.
 
+## Authority Model
+
+Use the narrowest effective authority layer. Trails should make mistakes
+impossible by type when it can, catch them with tests when runtime behavior is
+the contract, and put durable semantic checks in Warden when the invariant needs
+source, project, topo, or drift context. Prose or repo-local lint can orient,
+coach, and clean up, but they should not become parallel authority for framework
+facts.
+
+| Need | Authority | Notes |
+| --- | --- | --- |
+| Formatting | `oxfmt` / Ultracite | Style stays boring and mechanical. |
+| General JS/TS lint | Upstream `oxlint` rules | Standard language hygiene, not Trails doctrine. |
+| Repo-local JS/TS hygiene | Private `@ontrails/oxlint-plugin` | Console/process leakage, deep imports, barrels, Bun-native preference, retired source vocabulary, snapshot location, test naming, and temporary cleanup. |
+| Syntax tripwires and codemods | `ast-grep` | Useful for audits and high-confidence syntax shapes. New durable Trails rules should graduate into Warden instead of living here. |
+| Trails semantic correctness | Warden | The durable public correctness surface for trail/resource/signal/cross/permit/topo invariants. |
+| Topology and resolved-graph drift | Warden + Topographer | Lockfile drift, surface map drift, and topo-aware checks. |
+| Contract/runtime behavior | `testAll` and focused tests | Examples, output contracts, detours, and surface projection validation. |
+| Impossible-by-type constraints | TypeScript | Output schemas, typed `ctx.cross()`, `resource.from(ctx)`, and other compile-time contracts. |
+| Human and agent orientation | `AGENTS.md` | A map over the executable system, not the only enforcement point. |
+
+Owner-first data beats duplicated rule lists. If Warden needs framework facts
+such as reserved lexicon terms, intent values, error categories, permit rules,
+or Result accessors, it should read them from the module that owns the fact. If
+the owner does not expose a clean typed value, strengthen that owner before
+hardcoding a second list in the rule.
+
+Temporary repo-local rules are allowed when they have a clear lifecycle. TRL-575
+is the precedent: a temporary audit scanner needs an owner, reason, baseline
+count, deletion or promotion trigger, and issue reference. Temporary rules are
+visible debt; durable framework semantics belong in Warden once the invariant is
+understood.
+
 ## Core Principle
 
 Express rules as invariants the framework holds, not as instances of bugs found


### PR DESCRIPTION
## Context

Part of the Governance Maturity M1 stack. This bottom branch makes the Warden authority model explicit before the implementation branches add config, orchestration, bins, CLI surfaces, local gates, and CI reuse.

Closes: TRL-675

## What Changed

- Added the Warden authority model to `docs/rule-design.md`.
- Documented the owner-first data flow for durable Warden rules.
- Clarified the Warden / Oxlint / ast-grep split.
- Captured the AGENTS boundary and TRL-575 temporary-rule lifecycle precedent.

## Verification

- `bun scripts/adr.ts check`
- `bun run docs:snippets`
- `bun run format:check`
- Stack-tip verification also passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`.
- Local review passes 1-4 found no remaining P0/P1/P2 blockers.

## Risks / Rollout Notes

- Docs-only authority clarification. No runtime behavior changes.

## Changeset / Release Rationale

- `release:none`: docs-only change, no publishable package content changed.
