### PR TITLE
feat: export warden config schema

### DIFF
--- a/.changeset/warden-config-schema.md
+++ b/.changeset/warden-config-schema.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": minor
+---
+
+Export `wardenConfigSchema` for composing Warden options into `trails.config.ts`.

--- a/bun.lock
+++ b/bun.lock
@@ -249,11 +249,12 @@
         "@ontrails/permits": "workspace:^",
         "@ontrails/store": "workspace:^",
         "oxc-parser": "^0.121.0",
+        "zod": "catalog:",
       },
       "devDependencies": {
+        "@ontrails/config": "workspace:^",
         "@ontrails/testing": "workspace:^",
         "@oxc-project/types": "^0.122.0",
-        "zod": "catalog:",
       },
       "peerDependencies": {
         "@ontrails/core": "workspace:^",

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -25,12 +25,13 @@
   "dependencies": {
     "@ontrails/permits": "workspace:^",
     "@ontrails/store": "workspace:^",
-    "oxc-parser": "^0.121.0"
+    "oxc-parser": "^0.121.0",
+    "zod": "catalog:"
   },
   "devDependencies": {
+    "@ontrails/config": "workspace:^",
     "@ontrails/testing": "workspace:^",
-    "@oxc-project/types": "^0.122.0",
-    "zod": "catalog:"
+    "@oxc-project/types": "^0.122.0"
   },
   "peerDependencies": {
     "@ontrails/core": "workspace:^",

--- a/packages/warden/src/__tests__/config.test.ts
+++ b/packages/warden/src/__tests__/config.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import { defineConfig } from '@ontrails/config';
+import { z } from 'zod';
+
+import { wardenConfigSchema } from '../config.js';
+
+describe('wardenConfigSchema', () => {
+  test('applies Warden defaults when the section is omitted', () => {
+    const omittedSection: unknown = undefined;
+    const result = wardenConfigSchema.safeParse(omittedSection);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      depth: 'all',
+      drafts: 'include',
+      failOn: 'error',
+      format: 'summary',
+      lock: 'auto',
+    });
+  });
+
+  test('validates every Sprint 1 config dimension', () => {
+    const result = wardenConfigSchema.safeParse({
+      apps: ['demo', 'admin'],
+      depth: 'project',
+      drafts: 'exclude',
+      failOn: 'warning',
+      format: 'github',
+      lock: 'cached',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      apps: ['demo', 'admin'],
+      depth: 'project',
+      drafts: 'exclude',
+      failOn: 'warning',
+      format: 'github',
+      lock: 'cached',
+    });
+  });
+
+  test('rejects invalid enum values and unknown config keys', () => {
+    const result = wardenConfigSchema.safeParse({
+      depth: 'shallow',
+      experimentalRuleOverrides: {},
+      failOn: 'notice',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((issue) => issue.path.join('.'));
+      expect(paths).toContain('depth');
+      expect(paths).toContain('failOn');
+      expect(
+        result.error.issues.some((issue) => issue.code === 'unrecognized_keys')
+      ).toBe(true);
+    }
+  });
+
+  test('composes into defineConfig without a Warden-specific helper', async () => {
+    const config = defineConfig({
+      base: {},
+      schema: z.object({
+        warden: wardenConfigSchema,
+      }),
+    });
+
+    const result = await config.resolve({ env: { TRAILS_ENV: 'test' } });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({
+      warden: {
+        depth: 'all',
+        drafts: 'include',
+        failOn: 'error',
+        format: 'summary',
+        lock: 'auto',
+      },
+    });
+  });
+});

--- a/packages/warden/src/__tests__/public-api.test.ts
+++ b/packages/warden/src/__tests__/public-api.test.ts
@@ -21,6 +21,15 @@ describe('@ontrails/warden public API', () => {
     expect(warden.listWardenRuleMetadata().length).toBeGreaterThan(0);
   });
 
+  test('exports the composable Warden config schema from the root entrypoint', () => {
+    const omittedSection: unknown = undefined;
+    const result = warden.wardenConfigSchema.safeParse(omittedSection);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.depth).toBe('all');
+    expect(result.data?.failOn).toBe('error');
+  });
+
   test('keeps parser helpers on the ast entrypoint', () => {
     expect('parse' in warden).toBe(false);
     expect('walk' in warden).toBe(false);

--- a/packages/warden/src/config.ts
+++ b/packages/warden/src/config.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const wardenDepthValues = ['source', 'project', 'topo', 'all'] as const;
+export const wardenFailOnValues = ['error', 'warning'] as const;
+export const wardenFormatValues = ['summary', 'github', 'json'] as const;
+export const wardenLockValues = ['auto', 'cached', 'refresh', 'skip'] as const;
+export const wardenDraftsValues = ['include', 'exclude', 'only'] as const;
+
+const appNameSchema = z.string().min(1);
+
+const wardenConfigObjectSchema = z
+  .object({
+    apps: z.array(appNameSchema).min(1).optional(),
+    depth: z.enum(wardenDepthValues).default('all'),
+    drafts: z.enum(wardenDraftsValues).default('include'),
+    failOn: z.enum(wardenFailOnValues).default('error'),
+    format: z.enum(wardenFormatValues).default('summary'),
+    lock: z.enum(wardenLockValues).default('auto'),
+  })
+  .strict();
+
+export const wardenConfigSchema = wardenConfigObjectSchema
+  .optional()
+  .transform((value) => wardenConfigObjectSchema.parse(value ?? {}));
+
+export type WardenConfig = z.output<typeof wardenConfigSchema>;
+export type WardenConfigInput = z.input<typeof wardenConfigSchema>;
+export type WardenDepth = (typeof wardenDepthValues)[number];
+export type WardenDraftsMode = (typeof wardenDraftsValues)[number];
+export type WardenFailOn = (typeof wardenFailOnValues)[number];
+export type WardenFormat = (typeof wardenFormatValues)[number];
+export type WardenLockMode = (typeof wardenLockValues)[number];

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -42,6 +42,25 @@ export { clearImplementationReturnsResultCache } from './rules/implementation-re
 export type { WardenOptions, WardenReport } from './cli.js';
 export { formatWardenReport, runWarden } from './cli.js';
 
+// Config schema
+export {
+  wardenConfigSchema,
+  wardenDepthValues,
+  wardenDraftsValues,
+  wardenFailOnValues,
+  wardenFormatValues,
+  wardenLockValues,
+} from './config.js';
+export type {
+  WardenConfig,
+  WardenConfigInput,
+  WardenDepth,
+  WardenDraftsMode,
+  WardenFailOn,
+  WardenFormat,
+  WardenLockMode,
+} from './config.js';
+
 // CI formatters
 export {
   formatGitHubAnnotations,


### PR DESCRIPTION
## Context

Part of the Governance Maturity M1 stack. This branch gives Trails config files a typed Warden section to compose through `defineConfig`.

Closes: TRL-667

## What Changed

- Added `wardenConfigSchema` and related inferred types/defaults to `@ontrails/warden`.
- Exported the schema and Warden config vocabulary from the root package entrypoint.
- Added config and public API tests, including a `defineConfig` composition path.
- Added runtime `zod` dependency and test-only `@ontrails/config` dev dependency for the Warden package.

## Verification

- `bun test packages/warden/src/__tests__/config.test.ts packages/warden/src/__tests__/public-api.test.ts`
- `bun run --cwd packages/warden test`
- `bun run --cwd packages/warden typecheck`
- `bun run format:check`
- Stack-tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`.
- Local review passes 1-4 found no remaining P0/P1/P2 blockers.

## Risks / Rollout Notes

- Adds a public config schema export from `@ontrails/warden`.
- `zod` is now a runtime dependency because consumers import the exported schema at runtime.

## Changeset / Release Rationale

- Includes `.changeset/warden-config-schema.md` for the `@ontrails/warden` package surface change.
