### PR TITLE
feat: extend warden shared orchestrator

### DIFF
--- a/.changeset/warden-shared-orchestrator.md
+++ b/.changeset/warden-shared-orchestrator.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/warden": minor
+"@ontrails/trails": patch
+---
+
+Extend `runWarden` into the shared Warden orchestration entrypoint with effective config resolution, depth/fail thresholds, rule facets, and multi-topo report metadata.
+
+Adapt the built-in `trails warden` wrapper to consume the readonly Warden report diagnostics contract without weakening its output schema.

--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -58,7 +58,7 @@ export const wardenTrail = trail('warden', {
     const formatted = formatter(report);
 
     return Result.ok({
-      diagnostics: report.diagnostics,
+      diagnostics: [...report.diagnostics],
       drift: report.drift,
       errorCount: report.errorCount,
       formatted,

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -3,10 +3,22 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { ConflictError, Result, topo, trail } from '@ontrails/core';
+import {
+  ConflictError,
+  deriveTrailsDir,
+  Result,
+  topo,
+  trail,
+} from '@ontrails/core';
+import {
+  deriveSurfaceMap,
+  deriveSurfaceMapHash,
+  writeSurfaceLock,
+} from '@ontrails/topographer';
 import { z } from 'zod';
 
 import { formatWardenReport, runWarden } from '../cli.js';
+import type { TopoAwareWardenRule, WardenDiagnostic } from '../rules/types.js';
 
 const DEV_PERMIT_FLAG = ['--dev', '-permit'].join('');
 
@@ -36,6 +48,42 @@ const makeTempDir = (): string => {
   mkdirSync(dir, { recursive: true });
   return dir;
 };
+
+const buildFixtureTopo = (name = 'fixture') => {
+  const echo = trail('fixture.echo', {
+    blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+    input: z.object({ value: z.string() }),
+    intent: 'read',
+    output: z.object({ value: z.string() }),
+  });
+  return topo(name, { echo });
+};
+
+const PLACEHOLDER_TOPO_FINDING: WardenDiagnostic = {
+  filePath: '<topo>',
+  line: 1,
+  message: 'synthetic topo-level finding',
+  rule: 'placeholder-topo-aware',
+  severity: 'warn',
+};
+
+const buildPlaceholderTopoRule = (seen: string[]): TopoAwareWardenRule => ({
+  checkTopo: (inspectedTopo) => {
+    seen.push(inspectedTopo.name);
+    return [PLACEHOLDER_TOPO_FINDING];
+  },
+  description: 'placeholder rule returning one diagnostic',
+  name: 'placeholder-topo-aware',
+  severity: 'warn',
+});
+
+const throwDiagnosticFilePaths = (
+  report: Awaited<ReturnType<typeof runWarden>>
+): readonly string[] =>
+  report.diagnostics
+    .filter((diagnostic) => diagnostic.rule === 'no-throw-in-implementation')
+    .map((diagnostic) => diagnostic.filePath)
+    .toSorted();
 
 describe('runWarden basics', () => {
   test('produces a report with diagnostics for bad code', async () => {
@@ -367,6 +415,147 @@ describe('runWarden basics', () => {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+
+  test('depth project runs source and project rules but skips topo and drift', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'mixed.ts'),
+        `trail('entity.show', {
+  on: ['entity.changed'],
+  blaze: async () => {
+    throw new Error('boom');
+  },
+});`
+      );
+      const seen: string[] = [];
+      const report = await runWarden({
+        depth: 'project',
+        extraTopoRules: [buildPlaceholderTopoRule(seen)],
+        rootDir: dir,
+        topo: buildFixtureTopo(),
+      });
+      const rules = new Set(report.diagnostics.map((d) => d.rule));
+
+      expect(rules.has('no-throw-in-implementation')).toBe(true);
+      expect(rules.has('on-references-exist')).toBe(true);
+      expect(rules.has('placeholder-topo-aware')).toBe(false);
+      expect(seen).toEqual([]);
+      expect(report.drift).toBeNull();
+      expect(report.effectiveConfig?.depth).toBe('project');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('depth source ignores deeper project findings', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'source-only.ts'),
+        `trail('entity.show', {
+  on: ['entity.changed'],
+  blaze: async () => Result.ok({ ok: true }),
+});`
+      );
+      const report = await runWarden({
+        depth: 'source',
+        rootDir: dir,
+      });
+      const rules = new Set(report.diagnostics.map((d) => d.rule));
+
+      expect(rules.has('on-references-exist')).toBe(false);
+      expect(report.errorCount).toBe(0);
+      expect(report.passed).toBe(true);
+      expect(report.drift).toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('failOn warning turns warning-only reports into failures', async () => {
+    const dir = makeTempDir();
+    try {
+      const seen: string[] = [];
+      const report = await runWarden({
+        depth: 'topo',
+        extraTopoRules: [buildPlaceholderTopoRule(seen)],
+        failOn: 'warning',
+        rootDir: dir,
+        topo: buildFixtureTopo(),
+      });
+
+      expect(seen).toEqual(['fixture']);
+      expect(report.errorCount).toBe(0);
+      expect(report.warnCount).toBeGreaterThan(0);
+      expect(report.passed).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('multi-topo runs tag topo-aware diagnostics', async () => {
+    const dir = makeTempDir();
+    try {
+      const seen: string[] = [];
+      const report = await runWarden({
+        depth: 'topo',
+        extraTopoRules: [buildPlaceholderTopoRule(seen)],
+        rootDir: dir,
+        topos: [
+          { name: 'primary', topo: buildFixtureTopo('fixture.primary') },
+          { name: 'admin', topo: buildFixtureTopo('fixture.admin') },
+        ],
+      });
+
+      const emitted = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'placeholder-topo-aware'
+      );
+
+      expect(seen).toEqual(['fixture.primary', 'fixture.admin']);
+      expect(emitted.map((diagnostic) => diagnostic.topoName)).toEqual([
+        'primary',
+        'admin',
+      ]);
+      expect(report.topoNames).toEqual(['primary', 'admin']);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('multi-topo drift compares every supplied topo when no stored hash exists', async () => {
+    const dir = makeTempDir();
+    try {
+      const primary = buildFixtureTopo('fixture.primary');
+      const adminTrail = trail('admin.echo', {
+        blaze: (input: { value: string }) => Result.ok({ value: input.value }),
+        input: z.object({ value: z.string() }),
+        intent: 'read',
+        output: z.object({ value: z.string() }),
+      });
+      const admin = topo('fixture.admin', { adminTrail });
+      const primaryHash = deriveSurfaceMapHash(deriveSurfaceMap(primary));
+      await writeSurfaceLock(primaryHash, {
+        dir: deriveTrailsDir({ rootDir: dir }),
+      });
+
+      const report = await runWarden({
+        depth: 'all',
+        rootDir: dir,
+        topos: [
+          { name: 'primary', topo: primary },
+          { name: 'admin', topo: admin },
+        ],
+      });
+
+      expect(report.drift?.committedHash).toBe(primaryHash);
+      expect(report.drift?.currentHash).not.toBe(primaryHash);
+      expect(report.drift?.stale).toBe(true);
+      expect(report.passed).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });
 
 describe('runWarden project context', () => {
@@ -694,6 +883,61 @@ describe('runWarden draft markers', () => {
 
       expect(hasDraftFileMarkingError).toBe(false);
       expect(hasDraftVisibleDebt).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('filters source files by draft mode', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, '_draft.entity.ts'),
+        `trail("_draft.entity.prepare", {
+  blaze: async () => {
+    throw new Error("draft boom");
+  },
+})`
+      );
+      writeFileSync(
+        join(dir, 'entity.ts'),
+        `trail("entity.show", {
+  blaze: async () => {
+    throw new Error("established boom");
+  },
+})`
+      );
+
+      const includeReport = await runWarden({
+        drafts: 'include',
+        rootDir: dir,
+      });
+      const excludeReport = await runWarden({
+        drafts: 'exclude',
+        rootDir: dir,
+      });
+      const onlyReport = await runWarden({ drafts: 'only', rootDir: dir });
+
+      expect(throwDiagnosticFilePaths(includeReport)).toEqual([
+        join(dir, '_draft.entity.ts'),
+        join(dir, 'entity.ts'),
+      ]);
+      expect(throwDiagnosticFilePaths(excludeReport)).toEqual([
+        join(dir, 'entity.ts'),
+      ]);
+      expect(throwDiagnosticFilePaths(onlyReport)).toEqual([
+        join(dir, '_draft.entity.ts'),
+      ]);
+      expect(
+        excludeReport.diagnostics.some((diagnostic) =>
+          isDraftVisibleDebt(diagnostic.rule)
+        )
+      ).toBe(false);
+      expect(
+        onlyReport.diagnostics.some((diagnostic) =>
+          isDraftVisibleDebt(diagnostic.rule)
+        )
+      ).toBe(true);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/__tests__/config.test.ts
+++ b/packages/warden/src/__tests__/config.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { defineConfig } from '@ontrails/config';
 import { z } from 'zod';
 
-import { wardenConfigSchema } from '../config.js';
+import { resolveWardenConfig, wardenConfigSchema } from '../config.js';
 
 describe('wardenConfigSchema', () => {
   test('applies Warden defaults when the section is omitted', () => {
@@ -78,5 +78,52 @@ describe('wardenConfigSchema', () => {
         lock: 'auto',
       },
     });
+  });
+
+  test('resolves config with CLI over env over config over defaults precedence', () => {
+    const { diagnostics, effectiveConfig } = resolveWardenConfig({
+      cli: { failOn: 'error', format: 'json' },
+      config: { depth: 'source', failOn: 'warning', lock: 'cached' },
+      defaults: { lock: 'skip' },
+      env: {
+        TRAILS_DEPTH: 'project',
+        TRAILS_FAIL_ON: 'warning',
+        TRAILS_FORMAT: 'github',
+      },
+    });
+
+    expect(diagnostics).toEqual([]);
+    expect(effectiveConfig).toEqual({
+      depth: 'project',
+      drafts: 'include',
+      failOn: 'error',
+      format: 'json',
+      lock: 'cached',
+      noLockMutation: false,
+    });
+  });
+
+  test('surfaces invalid environment config as diagnostics', () => {
+    const { diagnostics, effectiveConfig } = resolveWardenConfig({
+      env: {
+        TRAILS_DEPTH: 'shallow',
+      },
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('warden-config');
+    expect(diagnostics[0]?.message).toContain('Invalid environment');
+    expect(effectiveConfig.depth).toBe('all');
+  });
+
+  test('carries no-lock-mutation as invocation state, not config schema', () => {
+    const { diagnostics, effectiveConfig } = resolveWardenConfig({
+      cli: {
+        noLockMutation: true,
+      },
+    });
+
+    expect(diagnostics).toEqual([]);
+    expect(effectiveConfig.noLockMutation).toBe(true);
   });
 });

--- a/packages/warden/src/__tests__/warden-rule-metadata.test.ts
+++ b/packages/warden/src/__tests__/warden-rule-metadata.test.ts
@@ -5,6 +5,7 @@ import {
   getWardenRuleMetadata,
   listWardenRuleMetadata,
   wardenRuleLifecycleStates,
+  wardenRuleConcerns,
   wardenRuleScopes,
   wardenRuleTiers,
   wardenRules,
@@ -30,12 +31,23 @@ describe('warden rule metadata', () => {
     ).toEqual([]);
   });
 
-  test('uses the supported tier, scope, and lifecycle vocabulary', () => {
+  test('uses the supported tier, depth, concern, scope, and lifecycle vocabulary', () => {
     for (const [, metadata] of metadataEntries) {
       expect(wardenRuleTiers).toContain(metadata.tier);
+      expect(['source', 'project', 'topo', 'all']).toContain(metadata.depth);
+      expect(wardenRuleConcerns).toContain(metadata.concern);
       expect(wardenRuleScopes).toContain(metadata.scope);
       expect(wardenRuleLifecycleStates).toContain(metadata.lifecycle.state);
     }
+  });
+
+  test('derives queryable rule depth from the execution tier', () => {
+    expect(getWardenRuleMetadata('no-throw-in-implementation')?.depth).toBe(
+      'source'
+    );
+    expect(getWardenRuleMetadata('on-references-exist')?.depth).toBe('project');
+    expect(getWardenRuleMetadata('permit-governance')?.depth).toBe('topo');
+    expect(getWardenRuleMetadata('prefer-schema-inference')?.depth).toBe('all');
   });
 
   test('requires retirement criteria for non-durable rules', () => {
@@ -49,6 +61,7 @@ describe('warden rule metadata', () => {
 
   test('exposes metadata lookup helpers for built-in rules', () => {
     expect(getWardenRuleMetadata('permit-governance')?.tier).toBe('topo-aware');
+    expect(getWardenRuleMetadata('permit-governance')?.concern).toBe('permits');
     expect(getWardenRuleMetadata('warden-export-symmetry')?.scope).toBe(
       'repo-local'
     );

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -10,6 +10,17 @@ import { resolve } from 'node:path';
 import type { Topo } from '@ontrails/core';
 import { getContourReferences } from '@ontrails/core';
 
+import type {
+  EffectiveWardenConfig,
+  WardenConfigInput,
+  WardenConfigLayer,
+  WardenDepth,
+  WardenFailOn,
+  WardenFormat,
+  WardenLockMode,
+} from './config.js';
+import { resolveWardenConfig } from './config.js';
+import { isDraftMarkedFile } from './draft.js';
 import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
 import {
@@ -38,11 +49,39 @@ import type {
 } from './rules/types.js';
 
 /**
- * Options for the warden CLI runner.
+ * Resolved topo input for Warden runs that govern multiple apps.
  */
-export interface WardenOptions {
+export interface WardenTopoTarget {
+  /** Stable app/topo label used to tag topo-aware diagnostics. */
+  readonly name?: string | undefined;
+  /** Resolved topo module to inspect. */
+  readonly topo: Topo;
+}
+
+/**
+ * Options for the shared Warden runner.
+ */
+export interface WardenRunOptions {
   /** Root directory to scan for TypeScript files. Defaults to cwd. */
   readonly rootDir?: string | undefined;
+  /** Warden config section from `trails.config.ts`, if already loaded. */
+  readonly config?: WardenConfigInput | undefined;
+  /** CLI/config-layer app names carried through shared resolution. */
+  readonly apps?: readonly string[] | undefined;
+  /** Cumulative analysis depth for the final M1 surfaces. */
+  readonly depth?: WardenDepth | undefined;
+  /** Draft-state handling mode for final M1 surfaces. */
+  readonly drafts?: EffectiveWardenConfig['drafts'] | undefined;
+  /** Failure threshold used to compute `report.passed`. */
+  readonly failOn?: WardenFailOn | undefined;
+  /** Output format requested by the caller. */
+  readonly format?: WardenFormat | undefined;
+  /** Lockfile mode requested by the caller. */
+  readonly lock?: WardenLockMode | undefined;
+  /** Suppress lockfile mutation for CI/pre-push callers. */
+  readonly noLockMutation?: boolean | undefined;
+  /** Environment layer for config resolution. Pass `process.env` at process boundaries. */
+  readonly env?: Record<string, string | undefined> | undefined;
   /** Only run lint rules, skip drift detection */
   readonly lintOnly?: boolean | undefined;
   /** Only run drift detection, skip lint rules */
@@ -66,6 +105,12 @@ export interface WardenOptions {
    */
   readonly topo?: Topo | undefined;
   /**
+   * Multiple resolved topos to govern in one invocation.
+   *
+   * Source/project rules run once; topo-aware rules run once per target.
+   */
+  readonly topos?: readonly WardenTopoTarget[] | undefined;
+  /**
    * Extra topo-aware rules to run in addition to the built-in registry.
    *
    * Primarily a test hook — production callers should register rules via
@@ -74,6 +119,9 @@ export interface WardenOptions {
    */
   readonly extraTopoRules?: readonly TopoAwareWardenRule[] | undefined;
 }
+
+/** Backwards-compatible name for older consumers. */
+export type WardenOptions = WardenRunOptions;
 
 /**
  * Result of a warden run.
@@ -89,6 +137,10 @@ export interface WardenReport {
   readonly drift: DriftResult | null;
   /** Whether the warden run passed (no errors, no drift) */
   readonly passed: boolean;
+  /** Effective shared config consumed by this run. */
+  readonly effectiveConfig?: EffectiveWardenConfig | undefined;
+  /** Resolved topo/app labels governed by this run. */
+  readonly topoNames?: readonly string[] | undefined;
 }
 
 /**
@@ -137,6 +189,30 @@ const collectFilesMatching = (
 
 const collectTsFiles = (dir: string): readonly string[] =>
   collectFilesMatching(dir, '**/*.ts');
+
+const draftModeIncludesFile = (
+  filePath: string,
+  drafts: EffectiveWardenConfig['drafts']
+): boolean => {
+  const isDraftFile = isDraftMarkedFile(filePath);
+  if (drafts === 'exclude') {
+    return !isDraftFile;
+  }
+  if (drafts === 'only') {
+    return isDraftFile;
+  }
+  return true;
+};
+
+const filterSourceFilesByDraftMode = (
+  sourceFiles: readonly SourceFile[],
+  drafts: EffectiveWardenConfig['drafts']
+): readonly SourceFile[] =>
+  drafts === 'include'
+    ? sourceFiles
+    : sourceFiles.filter((sourceFile) =>
+        draftModeIncludesFile(sourceFile.filePath, drafts)
+      );
 
 const collectDevPermitTestFiles = (dir: string): readonly string[] => {
   const glob = new Bun.Glob('**/*.ts');
@@ -597,15 +673,17 @@ const collectFileContourReferences = (
 
 const buildProjectContext = (
   sourceFiles: readonly SourceFile[],
-  appTopo?: Topo | undefined
+  appTopos: readonly Topo[] = []
 ): ProjectContext => {
   const context = createMutableProjectContext();
   const typeScriptSourceFiles = sourceFiles.filter(
     (sourceFile) => sourceFile.kind === 'typescript'
   );
 
-  if (appTopo) {
-    collectTopoTrailContext(appTopo, context);
+  if (appTopos.length > 0) {
+    for (const appTopo of appTopos) {
+      collectTopoTrailContext(appTopo, context);
+    }
     for (const sourceFile of typeScriptSourceFiles) {
       collectFileSupplementalProjectContext(sourceFile, context);
     }
@@ -633,6 +711,38 @@ const createOptionsDiagnostic = (message: string): WardenDiagnostic => ({
   severity: 'error',
 });
 
+interface WardenRuleSelector {
+  readonly depth?: WardenDepth | undefined;
+  readonly tier?: WardenRuleTier | undefined;
+}
+
+const depthIncludesTier = (
+  depth: WardenDepth,
+  tier: WardenRuleTier
+): boolean => {
+  switch (depth) {
+    case 'source': {
+      return tier === 'source-static';
+    }
+    case 'project': {
+      return tier === 'source-static' || tier === 'project-static';
+    }
+    case 'topo': {
+      return (
+        tier === 'source-static' ||
+        tier === 'project-static' ||
+        tier === 'topo-aware'
+      );
+    }
+    case 'all': {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
 const ruleMatchesTier = (
   metadata: ReturnType<typeof getWardenRuleMetadata>,
   tier: WardenRuleTier | undefined
@@ -650,21 +760,47 @@ const ruleMatchesTier = (
     : metadata.tier === tier;
 };
 
-const isSelectedRule = (
-  rule: WardenRule | TopoAwareWardenRule,
-  tier: WardenRuleTier | undefined
-): boolean => ruleMatchesTier(getWardenRuleMetadata(rule), tier);
-
-const isSelectedTopoRule = (
-  rule: TopoAwareWardenRule,
-  tier: WardenRuleTier | undefined
+const ruleMatchesDepth = (
+  metadata: ReturnType<typeof getWardenRuleMetadata>,
+  depth: WardenDepth | undefined
 ): boolean => {
-  if (!tier) {
+  if (!depth) {
     return true;
   }
 
+  if (!metadata) {
+    return false;
+  }
+
+  if (metadata.scope === 'advisory') {
+    return depth === 'all';
+  }
+
+  return depthIncludesTier(depth, metadata.tier);
+};
+
+const isSelectedRule = (
+  rule: WardenRule | TopoAwareWardenRule,
+  selector: WardenRuleSelector
+): boolean => {
   const metadata = getWardenRuleMetadata(rule);
-  return metadata ? ruleMatchesTier(metadata, tier) : tier === 'topo-aware';
+  return selector.tier
+    ? ruleMatchesTier(metadata, selector.tier)
+    : ruleMatchesDepth(metadata, selector.depth);
+};
+
+const isSelectedTopoRule = (
+  rule: TopoAwareWardenRule,
+  selector: WardenRuleSelector
+): boolean => {
+  const metadata = getWardenRuleMetadata(rule);
+  if (selector.tier) {
+    return metadata
+      ? ruleMatchesTier(metadata, selector.tier)
+      : selector.tier === 'topo-aware';
+  }
+
+  return metadata ? ruleMatchesDepth(metadata, selector.depth) : true;
 };
 
 const topoRuleFailureDiagnostic = (
@@ -690,13 +826,13 @@ const topoRuleFailureDiagnostic = (
 const lintTopo = async (
   appTopo: Topo,
   extraTopoRules: readonly TopoAwareWardenRule[],
-  tier: WardenRuleTier | undefined
+  selector: WardenRuleSelector
 ): Promise<readonly WardenDiagnostic[]> => {
   const diagnostics: WardenDiagnostic[] = [];
   const rules: readonly TopoAwareWardenRule[] = [
     ...wardenTopoRules.values(),
     ...extraTopoRules,
-  ].filter((rule) => isSelectedTopoRule(rule, tier));
+  ].filter((rule) => isSelectedTopoRule(rule, selector));
   for (const rule of rules) {
     try {
       diagnostics.push(...(await rule.checkTopo(appTopo)));
@@ -710,7 +846,7 @@ const lintTopo = async (
 const lintSourceFiles = (
   sourceFiles: readonly SourceFile[],
   context: ProjectContext,
-  tier: WardenRuleTier | undefined
+  selector: WardenRuleSelector
 ): readonly WardenDiagnostic[] => {
   const diagnostics: WardenDiagnostic[] = [];
   for (const sourceFile of sourceFiles) {
@@ -722,7 +858,7 @@ const lintSourceFiles = (
         continue;
       }
 
-      if (!isSelectedRule(rule, tier)) {
+      if (!isSelectedRule(rule, selector)) {
         continue;
       }
 
@@ -744,39 +880,255 @@ const lintSourceFiles = (
   return diagnostics;
 };
 
+const tagTopoDiagnostic = (
+  diagnostic: WardenDiagnostic,
+  topoName: string | undefined
+): WardenDiagnostic =>
+  topoName === undefined ? diagnostic : { ...diagnostic, topoName };
+
+const lintTopoTargets = async (
+  topoTargets: readonly WardenTopoTarget[],
+  extraTopoRules: readonly TopoAwareWardenRule[],
+  selector: WardenRuleSelector,
+  tagDiagnostics: boolean
+): Promise<readonly WardenDiagnostic[]> => {
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const target of topoTargets) {
+    const topoDiagnostics = await lintTopo(
+      target.topo,
+      extraTopoRules,
+      selector
+    );
+    const topoName = target.name ?? target.topo.name;
+    diagnostics.push(
+      ...(tagDiagnostics
+        ? topoDiagnostics.map((diagnostic) =>
+            tagTopoDiagnostic(diagnostic, topoName)
+          )
+        : topoDiagnostics)
+    );
+  }
+
+  return diagnostics;
+};
+
+const selectorIncludesTopoRules = (selector: WardenRuleSelector): boolean => {
+  if (selector.tier) {
+    return selector.tier === 'advisory';
+  }
+
+  return !selector.depth || depthIncludesTier(selector.depth, 'topo-aware');
+};
+
 /**
  * Lint all files against all warden rules.
  */
 const lintFiles = async (
   rootDir: string,
-  appTopo?: Topo | undefined,
-  extraTopoRules: readonly TopoAwareWardenRule[] = [],
-  tier?: WardenRuleTier | undefined
+  drafts: EffectiveWardenConfig['drafts'],
+  topoTargets: readonly WardenTopoTarget[],
+  extraTopoRules: readonly TopoAwareWardenRule[],
+  selector: WardenRuleSelector
 ): Promise<WardenDiagnostic[]> => {
-  if (tier === 'topo-aware') {
-    return appTopo ? [...(await lintTopo(appTopo, extraTopoRules, tier))] : [];
+  if (selector.tier === 'topo-aware') {
+    return [
+      ...(await lintTopoTargets(topoTargets, extraTopoRules, selector, true)),
+    ];
   }
 
-  const sourceFiles = await loadSourceFiles(rootDir);
-  const context = buildProjectContext(sourceFiles, appTopo);
+  const sourceFiles = filterSourceFilesByDraftMode(
+    await loadSourceFiles(rootDir),
+    drafts
+  );
+  const context = buildProjectContext(
+    sourceFiles,
+    topoTargets.map((target) => target.topo)
+  );
   const allDiagnostics: WardenDiagnostic[] = [
-    ...lintSourceFiles(sourceFiles, context, tier),
+    ...lintSourceFiles(sourceFiles, context, selector),
   ];
 
-  if (appTopo && (!tier || tier === 'advisory')) {
-    allDiagnostics.push(...(await lintTopo(appTopo, extraTopoRules, tier)));
+  if (
+    topoTargets.length > 0 &&
+    (selector.tier === undefined || selector.tier === 'advisory') &&
+    selectorIncludesTopoRules(selector)
+  ) {
+    allDiagnostics.push(
+      ...(await lintTopoTargets(
+        topoTargets,
+        extraTopoRules,
+        selector,
+        topoTargets.length > 1
+      ))
+    );
   }
 
   return allDiagnostics;
 };
 
+const topoTargetsFromOptions = (
+  options: WardenRunOptions
+): readonly WardenTopoTarget[] => {
+  if (options.topos !== undefined && options.topos.length > 0) {
+    return options.topos;
+  }
+
+  return options.topo ? [{ name: options.topo.name, topo: options.topo }] : [];
+};
+
+const aggregateDriftHash = (
+  topoTargets: readonly WardenTopoTarget[],
+  driftResults: readonly DriftResult[]
+): string => {
+  const currentHashes = new Set(
+    driftResults.map((result) => result.currentHash)
+  );
+  const [onlyHash] = currentHashes;
+  if (currentHashes.size === 1 && onlyHash !== undefined) {
+    return onlyHash;
+  }
+
+  const payload = driftResults
+    .map((result, index) => {
+      const target = topoTargets[index];
+      return {
+        currentHash: result.currentHash,
+        topoName: target?.name ?? target?.topo.name ?? `topo-${String(index)}`,
+      };
+    })
+    .toSorted((left, right) => left.topoName.localeCompare(right.topoName));
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(JSON.stringify(payload));
+  return hasher.digest('hex');
+};
+
+const describeTopoDriftHash = (
+  topoTargets: readonly WardenTopoTarget[],
+  driftResults: readonly DriftResult[]
+): string =>
+  driftResults
+    .map((result, index) => {
+      const target = topoTargets[index];
+      const topoName =
+        target?.name ?? target?.topo.name ?? `topo-${String(index)}`;
+      return `${topoName}=${result.committedHash ?? '<none>'}`;
+    })
+    .join(', ');
+
+const checkDriftForTopoTargets = async (
+  rootDir: string,
+  topoTargets: readonly WardenTopoTarget[]
+): Promise<DriftResult> => {
+  if (topoTargets.length <= 1) {
+    return checkDrift(rootDir, topoTargets[0]?.topo);
+  }
+
+  const driftResults = await Promise.all(
+    topoTargets.map((target) => checkDrift(rootDir, target.topo))
+  );
+  const committedHashes = new Set(
+    driftResults.map((result) => result.committedHash)
+  );
+  if (committedHashes.size > 1) {
+    return {
+      blockedReason: `multi-topo drift expected one committed trails.lock hash but found conflicting hashes: ${describeTopoDriftHash(topoTargets, driftResults)}`,
+      committedHash: null,
+      currentHash: 'blocked',
+      stale: true,
+    };
+  }
+  const committedHash = driftResults[0]?.committedHash ?? null;
+  const blockedReasons = driftResults.flatMap((result, index) => {
+    if (result.blockedReason === undefined) {
+      return [];
+    }
+    const target = topoTargets[index];
+    const topoName =
+      target?.name ?? target?.topo.name ?? `topo-${String(index)}`;
+    return [`${topoName}: ${result.blockedReason}`];
+  });
+
+  if (blockedReasons.length > 0) {
+    return {
+      blockedReason: blockedReasons.join('; '),
+      committedHash,
+      currentHash: 'blocked',
+      stale: true,
+    };
+  }
+
+  const currentHash = aggregateDriftHash(topoTargets, driftResults);
+  return {
+    committedHash,
+    currentHash,
+    stale: committedHash !== null && committedHash !== currentHash,
+  };
+};
+
+const shouldRunLint = (options: WardenRunOptions): boolean =>
+  options.tier ? options.tier !== 'drift' : !options.driftOnly;
+
+const shouldRunDrift = (
+  options: WardenRunOptions,
+  effectiveConfig: EffectiveWardenConfig
+): boolean => {
+  if (effectiveConfig.lock === 'skip') {
+    return false;
+  }
+
+  if (options.tier) {
+    return options.tier === 'drift';
+  }
+
+  if (options.lintOnly) {
+    return false;
+  }
+
+  return options.driftOnly || effectiveConfig.depth === 'all';
+};
+
+const reportPassed = ({
+  drift,
+  errorCount,
+  failOn,
+  warnCount,
+}: {
+  readonly drift: DriftResult | null;
+  readonly errorCount: number;
+  readonly failOn: WardenFailOn;
+  readonly warnCount: number;
+}): boolean =>
+  errorCount === 0 &&
+  (failOn === 'error' || warnCount === 0) &&
+  !(drift?.stale ?? false) &&
+  drift?.blockedReason === undefined;
+
+const buildCliConfigLayer = (options: WardenRunOptions): WardenConfigLayer => ({
+  ...(options.apps ? { apps: [...options.apps] } : {}),
+  ...(options.depth ? { depth: options.depth } : {}),
+  ...(options.drafts ? { drafts: options.drafts } : {}),
+  ...(options.failOn ? { failOn: options.failOn } : {}),
+  ...(options.format ? { format: options.format } : {}),
+  ...(options.lock ? { lock: options.lock } : {}),
+  ...(options.noLockMutation === undefined
+    ? {}
+    : { noLockMutation: options.noLockMutation }),
+});
+
 /**
  * Run all warden checks and return a structured report.
  */
 export const runWarden = async (
-  options: WardenOptions = {}
+  options: WardenRunOptions = {}
 ): Promise<WardenReport> => {
   const rootDir = resolve(options.rootDir ?? process.cwd());
+  const { diagnostics: configDiagnostics, effectiveConfig } =
+    resolveWardenConfig({
+      cli: buildCliConfigLayer(options),
+      config: options.config,
+      env: options.env,
+    });
   const optionDiagnostics =
     !options.tier && options.lintOnly && options.driftOnly
       ? [
@@ -785,21 +1137,30 @@ export const runWarden = async (
           ),
         ]
       : [];
-  const runLint = options.tier ? options.tier !== 'drift' : !options.driftOnly;
-  const runDrift = options.tier ? options.tier === 'drift' : !options.lintOnly;
+  const topoTargets = topoTargetsFromOptions(options);
+  const selector = {
+    depth: options.tier ? undefined : effectiveConfig.depth,
+    tier: options.tier,
+  } satisfies WardenRuleSelector;
+  const runLint = shouldRunLint(options);
+  const runDrift = shouldRunDrift(options, effectiveConfig);
 
   const allDiagnostics = [
+    ...configDiagnostics,
     ...optionDiagnostics,
     ...(runLint
       ? await lintFiles(
           rootDir,
-          options.topo,
+          effectiveConfig.drafts,
+          topoTargets,
           options.extraTopoRules ?? [],
-          options.tier
+          selector
         )
       : []),
   ];
-  const drift = runDrift ? await checkDrift(rootDir, options.topo) : null;
+  const drift = runDrift
+    ? await checkDriftForTopoTargets(rootDir, topoTargets)
+    : null;
 
   const errorCount = allDiagnostics.filter(
     (d) => d.severity === 'error'
@@ -809,11 +1170,15 @@ export const runWarden = async (
   return {
     diagnostics: allDiagnostics,
     drift,
+    effectiveConfig,
     errorCount,
-    passed:
-      errorCount === 0 &&
-      !(drift?.stale ?? false) &&
-      drift?.blockedReason === undefined,
+    passed: reportPassed({
+      drift,
+      errorCount,
+      failOn: effectiveConfig.failOn,
+      warnCount,
+    }),
+    topoNames: topoTargets.map((target) => target.name ?? target.topo.name),
     warnCount,
   };
 };
@@ -866,6 +1231,9 @@ const formatResultLine = (report: WardenReport): string => {
   const parts: string[] = [];
   if (report.errorCount > 0) {
     parts.push(`${report.errorCount} errors`);
+  }
+  if (report.warnCount > 0 && report.effectiveConfig?.failOn === 'warning') {
+    parts.push(`${report.warnCount} warnings`);
   }
   if (report.drift?.blockedReason !== undefined) {
     parts.push('established exports blocked');

--- a/packages/warden/src/config.ts
+++ b/packages/warden/src/config.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import type { WardenDiagnostic } from './rules/types.js';
+
 export const wardenDepthValues = ['source', 'project', 'topo', 'all'] as const;
 export const wardenFailOnValues = ['error', 'warning'] as const;
 export const wardenFormatValues = ['summary', 'github', 'json'] as const;
@@ -30,3 +32,153 @@ export type WardenDraftsMode = (typeof wardenDraftsValues)[number];
 export type WardenFailOn = (typeof wardenFailOnValues)[number];
 export type WardenFormat = (typeof wardenFormatValues)[number];
 export type WardenLockMode = (typeof wardenLockValues)[number];
+
+export interface WardenConfigLayer extends Partial<WardenConfig> {
+  readonly noLockMutation?: boolean | undefined;
+}
+
+export interface EffectiveWardenConfig extends WardenConfig {
+  readonly noLockMutation: boolean;
+}
+
+export interface ResolveWardenConfigOptions {
+  readonly cli?: WardenConfigLayer | undefined;
+  readonly config?: WardenConfigInput | undefined;
+  readonly defaults?: Partial<WardenConfig> | undefined;
+  readonly env?: Record<string, string | undefined> | undefined;
+}
+
+export interface WardenConfigResolution {
+  readonly diagnostics: readonly WardenDiagnostic[];
+  readonly effectiveConfig: EffectiveWardenConfig;
+}
+
+const baseWardenConfig = (): WardenConfig => {
+  const omittedSection: unknown = undefined;
+  return wardenConfigSchema.parse(omittedSection);
+};
+
+const cleanUndefinedValues = <T extends Record<string, unknown>>(
+  value: T
+): Partial<T> =>
+  Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  ) as Partial<T>;
+
+const splitApps = (value: string): readonly string[] =>
+  value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+const readEnvLayer = (
+  env: Record<string, string | undefined>
+): Partial<WardenConfig> =>
+  cleanUndefinedValues({
+    apps: env['TRAILS_APPS'] ? splitApps(env['TRAILS_APPS']) : undefined,
+    depth: env['TRAILS_DEPTH'],
+    drafts: env['TRAILS_DRAFTS'],
+    failOn: env['TRAILS_FAIL_ON'],
+    format: env['TRAILS_FORMAT'],
+    lock: env['TRAILS_LOCK'],
+  }) as Partial<WardenConfig>;
+
+const configDiagnostic = (message: string): WardenDiagnostic => ({
+  filePath: '<warden-config>',
+  line: 1,
+  message,
+  rule: 'warden-config',
+  severity: 'error',
+});
+
+const formatIssues = (error: z.ZodError): string =>
+  error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+      return `${path}: ${issue.message}`;
+    })
+    .join('; ');
+
+const parseConfigLayer = (
+  label: string,
+  value: WardenConfigInput | undefined
+): {
+  readonly data: Partial<WardenConfig>;
+  readonly diagnostics: readonly WardenDiagnostic[];
+} => {
+  if (value === undefined) {
+    return { data: {}, diagnostics: [] };
+  }
+
+  const parsed = wardenConfigSchema.safeParse(value);
+  if (parsed.success) {
+    if (typeof value !== 'object' || value === null) {
+      return { data: parsed.data, diagnostics: [] };
+    }
+
+    return {
+      data: Object.fromEntries(
+        Object.keys(value).map((key) => [
+          key,
+          parsed.data[key as keyof WardenConfig],
+        ])
+      ) as Partial<WardenConfig>,
+      diagnostics: [],
+    };
+  }
+
+  return {
+    data: {},
+    diagnostics: [
+      configDiagnostic(
+        `Invalid ${label} Warden config: ${formatIssues(parsed.error)}`
+      ),
+    ],
+  };
+};
+
+export const resolveWardenConfig = ({
+  cli,
+  config,
+  defaults,
+  env = {},
+}: ResolveWardenConfigOptions = {}): WardenConfigResolution => {
+  const { noLockMutation = false, ...cliConfig } = cli ?? {};
+  const defaultLayer = wardenConfigSchema.parse({
+    ...baseWardenConfig(),
+    ...defaults,
+  });
+  const configLayer = parseConfigLayer('file', config);
+  const envLayer = parseConfigLayer('environment', readEnvLayer(env));
+  const merged = {
+    ...defaultLayer,
+    ...configLayer.data,
+    ...envLayer.data,
+    ...cleanUndefinedValues(cliConfig),
+  };
+  const parsed = wardenConfigSchema.safeParse(merged);
+  const diagnostics = [...configLayer.diagnostics, ...envLayer.diagnostics];
+
+  if (!parsed.success) {
+    return {
+      diagnostics: [
+        ...diagnostics,
+        configDiagnostic(
+          `Invalid effective Warden config: ${formatIssues(parsed.error)}`
+        ),
+      ],
+      effectiveConfig: {
+        ...defaultLayer,
+        noLockMutation,
+      },
+    };
+  }
+
+  return {
+    diagnostics,
+    effectiveConfig: {
+      ...parsed.data,
+      noLockMutation,
+    },
+  };
+};

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -15,6 +15,7 @@ export type {
   TopoAwareWardenRule,
   WardenDiagnostic,
   WardenRule,
+  WardenRuleConcern,
   WardenRuleLifecycle,
   WardenRuleLifecycleState,
   WardenRuleMetadata,
@@ -28,6 +29,7 @@ export {
   builtinWardenRuleMetadata,
   getWardenRuleMetadata,
   listWardenRuleMetadata,
+  wardenRuleConcerns,
   wardenRuleLifecycleStates,
   wardenRuleScopes,
   wardenRuleTiers,
@@ -39,7 +41,12 @@ export {
 export { clearImplementationReturnsResultCache } from './rules/implementation-returns-result.js';
 
 // CLI runner
-export type { WardenOptions, WardenReport } from './cli.js';
+export type {
+  WardenOptions,
+  WardenReport,
+  WardenRunOptions,
+  WardenTopoTarget,
+} from './cli.js';
 export { formatWardenReport, runWarden } from './cli.js';
 
 // Config schema
@@ -59,7 +66,12 @@ export type {
   WardenFailOn,
   WardenFormat,
   WardenLockMode,
+  EffectiveWardenConfig,
+  ResolveWardenConfigOptions,
+  WardenConfigLayer,
+  WardenConfigResolution,
 } from './config.js';
+export { resolveWardenConfig } from './config.js';
 
 // CI formatters
 export {

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -49,6 +49,7 @@ import { webhookRouteCollision } from './webhook-route-collision.js';
 export type {
   WardenRuleLifecycle,
   WardenRuleLifecycleState,
+  WardenRuleConcern,
   WardenRuleMetadata,
   WardenRuleScope,
   ProjectAwareWardenRule,
@@ -64,6 +65,7 @@ export {
   builtinWardenRuleMetadata,
   getWardenRuleMetadata,
   listWardenRuleMetadata,
+  wardenRuleConcerns,
   wardenRuleLifecycleStates,
   wardenRuleScopes,
   wardenRuleTiers,

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -1,5 +1,6 @@
 import type {
   WardenRule,
+  WardenRuleConcern,
   WardenRuleLifecycleState,
   WardenRuleMetadata,
   WardenRuleScope,
@@ -23,11 +24,69 @@ export const wardenRuleScopes = [
   'advisory',
 ] as const satisfies readonly WardenRuleScope[];
 
+export const wardenRuleConcerns = [
+  'composition',
+  'general',
+  'lifecycle',
+  'meta',
+  'permits',
+  'resources',
+  'results',
+  'signals',
+] as const satisfies readonly WardenRuleConcern[];
+
 export const wardenRuleLifecycleStates = [
   'durable',
   'temporary',
   'deprecated',
 ] as const satisfies readonly WardenRuleLifecycleState[];
+
+type BuiltinWardenRuleMetadataInput = Omit<
+  WardenRuleMetadata,
+  'concern' | 'depth'
+> &
+  Partial<Pick<WardenRuleMetadata, 'concern' | 'depth'>>;
+
+const depthByTier = {
+  advisory: 'all',
+  drift: 'all',
+  'project-static': 'project',
+  'source-static': 'source',
+  'topo-aware': 'topo',
+} as const satisfies Record<WardenRuleTier, WardenRuleMetadata['depth']>;
+
+const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
+  'activation-orphan': 'signals',
+  'context-no-surface-types': 'composition',
+  'cross-declarations': 'composition',
+  'dead-internal-trail': 'composition',
+  'draft-file-marking': 'lifecycle',
+  'draft-visible-debt': 'lifecycle',
+  'error-mapping-completeness': 'results',
+  'fires-declarations': 'signals',
+  'implementation-returns-result': 'results',
+  'intent-propagation': 'composition',
+  'missing-reconcile': 'resources',
+  'missing-visibility': 'composition',
+  'no-dev-permit-in-source': 'permits',
+  'no-direct-implementation-call': 'composition',
+  'no-native-error-result': 'results',
+  'no-sync-result-assumption': 'results',
+  'no-throw-in-detour-recover': 'results',
+  'no-throw-in-implementation': 'results',
+  'on-references-exist': 'signals',
+  'orphaned-signal': 'signals',
+  'permit-governance': 'permits',
+  'read-intent-fires': 'signals',
+  'resource-declarations': 'resources',
+  'resource-exists': 'resources',
+  'resource-id-grammar': 'resources',
+  'scheduled-destroy-intent': 'lifecycle',
+  'signal-graph-coaching': 'signals',
+  'unmaterialized-activation-source': 'lifecycle',
+  'valid-detour-contract': 'results',
+  'webhook-route-collision': 'composition',
+};
 
 const durableExternal = {
   lifecycle: { state: 'durable' },
@@ -44,7 +103,7 @@ const durableRepoLocal = {
   scope: 'repo-local',
 } as const;
 
-export const builtinWardenRuleMetadata = {
+const builtinWardenRuleMetadataInput = {
   'activation-orphan': {
     ...durableExternal,
     invariant:
@@ -295,9 +354,25 @@ export const builtinWardenRuleMetadata = {
       'Webhook routes do not collide with each other or direct HTTP trail routes.',
     tier: 'topo-aware',
   },
-} as const satisfies Record<string, WardenRuleMetadata>;
+} as const satisfies Record<string, BuiltinWardenRuleMetadataInput>;
 
-export type BuiltinWardenRuleName = keyof typeof builtinWardenRuleMetadata;
+export type BuiltinWardenRuleName = keyof typeof builtinWardenRuleMetadataInput;
+
+const withFacetDefaults = (
+  name: string,
+  metadata: BuiltinWardenRuleMetadataInput
+): WardenRuleMetadata => ({
+  concern: concernByRuleName[name] ?? 'general',
+  depth: metadata.scope === 'advisory' ? 'all' : depthByTier[metadata.tier],
+  ...metadata,
+});
+
+export const builtinWardenRuleMetadata = Object.fromEntries(
+  Object.entries(builtinWardenRuleMetadataInput).map(([name, metadata]) => [
+    name,
+    withFacetDefaults(name, metadata),
+  ])
+) as Readonly<Record<BuiltinWardenRuleName, WardenRuleMetadata>>;
 
 const metadataByName: Readonly<Record<string, WardenRuleMetadata>> =
   builtinWardenRuleMetadata;

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -1,5 +1,7 @@
 import type { Intent, Topo } from '@ontrails/core';
 
+import type { WardenDepth } from '../config.js';
+
 /**
  * Severity level for warden diagnostics.
  */
@@ -36,6 +38,19 @@ export type WardenRuleScope =
 export type WardenRuleLifecycleState = 'deprecated' | 'durable' | 'temporary';
 
 /**
+ * Queryable concern dimension for Warden rule metadata.
+ */
+export type WardenRuleConcern =
+  | 'composition'
+  | 'general'
+  | 'lifecycle'
+  | 'meta'
+  | 'permits'
+  | 'resources'
+  | 'results'
+  | 'signals';
+
+/**
  * Lifecycle metadata for a Warden rule.
  */
 export interface WardenRuleLifecycle {
@@ -49,6 +64,10 @@ export interface WardenRuleLifecycle {
  * Stable metadata used to classify Warden rules before dispatch filtering.
  */
 export interface WardenRuleMetadata {
+  /** Cumulative Warden depth where this rule first becomes relevant. */
+  readonly depth: WardenDepth;
+  /** Queryable rule concern for agent-facing surfaces. */
+  readonly concern: WardenRuleConcern;
   /** One-line invariant the rule protects. */
   readonly invariant: string;
   /** Rule lifecycle. */
@@ -73,6 +92,8 @@ export interface WardenDiagnostic {
   readonly line: number;
   /** File path that was analyzed */
   readonly filePath: string;
+  /** Topo/app identity for diagnostics emitted during multi-topo runs. */
+  readonly topoName?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
## Context

Part of the Governance Maturity M1 stack. This branch turns `runWarden` into the shared orchestrator that later CLI, bin, local gate, and CI surfaces call.

Closes: TRL-666

## What Changed

- Extended `runWarden` with effective config resolution for CLI/env/config/defaults.
- Added depth, fail-on, lock, draft, app, topo target, no-lock-mutation, and formatter-facing report metadata.
- Added multi-topo execution support while keeping source diagnostics emitted once.
- Added draft-mode source filtering for `include`, `exclude`, and `only`.
- Added multi-topo drift aggregation so stale secondary topos are not missed.
- Added queryable Warden rule `depth` and `concern` metadata while preserving legacy tier behavior.
- Kept `WardenReport.diagnostics` readonly and adapted the built-in `trails warden` wrapper at the package boundary.

## Verification

- `bun test packages/warden/src/__tests__/cli.test.ts packages/warden/src/__tests__/command.test.ts packages/warden/src/__tests__/config.test.ts packages/warden/src/__tests__/public-api.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run --cwd packages/warden lint`
- `bun run --cwd packages/warden test`
- `bun run format:check`
- Stack-tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`.
- Local review fixed P1 draft filtering and P2 multi-topo drift on this branch. Pass 4 found no remaining P0/P1/P2.
- Remote review follow-up fixed the readonly diagnostics contract and corrected the env option documentation.

## Risks / Rollout Notes

- This is shared orchestration used by later surfaces, so behavior is intentionally covered at runner/config/report boundaries.
- Lock modes beyond `skip` are surfaced as config/API vocabulary; deeper `auto` / `cached` / `refresh` mutation semantics remain future drift-lock work.

## Changeset / Release Rationale

- Includes `.changeset/warden-shared-orchestrator.md` for `@ontrails/warden` public runner/config behavior and `@ontrails/trails` wrapper compatibility with the readonly report contract.
