### PR TITLE
test: guard multi-topo warden execution

### DIFF
--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -556,6 +556,49 @@ describe('runWarden basics', () => {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+
+  test('multi-topo runs do not multiply source-scoped diagnostics', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'bad-source.ts'),
+        `trail("entity.show", {
+  blaze: async () => {
+    throw new Error("boom");
+  },
+});`
+      );
+      const seen: string[] = [];
+      const report = await runWarden({
+        depth: 'topo',
+        extraTopoRules: [buildPlaceholderTopoRule(seen)],
+        rootDir: dir,
+        topos: [
+          { name: 'primary', topo: buildFixtureTopo('fixture.primary') },
+          { name: 'admin', topo: buildFixtureTopo('fixture.admin') },
+        ],
+      });
+
+      const sourceDiagnostics = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'no-throw-in-implementation'
+      );
+      const topoDiagnostics = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'placeholder-topo-aware'
+      );
+
+      expect(seen).toEqual(['fixture.primary', 'fixture.admin']);
+      expect(sourceDiagnostics).toHaveLength(1);
+      expect(sourceDiagnostics[0]?.topoName).toBeUndefined();
+      expect(topoDiagnostics).toHaveLength(2);
+      expect(topoDiagnostics.map((diagnostic) => diagnostic.topoName)).toEqual([
+        'primary',
+        'admin',
+      ]);
+      expect(report.topoNames).toEqual(['primary', 'admin']);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });
 
 describe('runWarden project context', () => {


### PR DESCRIPTION
## Context

Part of the Governance Maturity M1 stack. This branch protects the shared Warden runner's per-topo execution model from accidental source-rule multiplication.

Closes: TRL-674

## What Changed

- Added a regression test proving multi-topo Warden runs execute topo-aware checks per topo.
- Verified source-scoped diagnostics still run once and remain untagged by topo.

## Verification

- `bun test packages/warden/src/__tests__/cli.test.ts packages/warden/src/__tests__/topo-aware-rule.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run format:check`
- Stack-tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`.
- Local review passes 1-4 found no remaining P0/P1/P2 blockers.

## Risks / Rollout Notes

- Test-only guard branch. It intentionally depends on the shared runner behavior introduced below it.

## Changeset / Release Rationale

- `release:none`: test-only branch; no publishable package behavior changes beyond the behavior already changeset on TRL-666.
