### PR TITLE
feat: align trails warden surface

### DIFF
--- a/.changeset/trails-warden-surface.md
+++ b/.changeset/trails-warden-surface.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/trails": minor
+---
+
+Update `trails warden` to use the shared `@ontrails/warden` command surface and final Sprint 1 flags.
+
+The integrated CLI now projects `--ci`, `--pre-push`, `--depth`, `--fail-on`, `--strict`, `--format`, `--lock`, `--drafts`, `--apps`, `--no-lock-mutation`, and the local Warden aliases into the same runner used by the package `warden` bin. The old `lintOnly`, `driftOnly`, and `tier` inputs are replaced by `--depth` and `--lock` semantics.

--- a/apps/trails/src/__tests__/warden.test.ts
+++ b/apps/trails/src/__tests__/warden.test.ts
@@ -1,9 +1,12 @@
+import type { ActionResultContext } from '@ontrails/cli';
+import { Result } from '@ontrails/core';
 import { describe, expect, test } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { formatWardenReport, runWarden } from '@ontrails/warden';
+import { tryWardenOutput } from '../run-warden.js';
+import { buildWardenCommandArgs, wardenTrail } from '../trails/warden.js';
 
 const makeTempDir = (): string => {
   const dir = join(
@@ -15,60 +18,122 @@ const makeTempDir = (): string => {
 };
 
 describe('trails warden', () => {
-  test('runs lint + drift checks and produces a report', async () => {
-    const dir = makeTempDir();
-    try {
-      writeFileSync(
-        join(dir, 'good.ts'),
-        `trail("hello", {
-  blaze: async (input, ctx) => {
-    return Result.ok({ message: "hi" });
-  }
-})`
-      );
+  test('projects final Warden flags into the shared command surface', () => {
+    const args = buildWardenCommandArgs({
+      apps: ['trails', 'demo'],
+      cached: true,
+      ci: true,
+      depth: 'topo',
+      drafts: 'include',
+      excludeDrafts: true,
+      failOn: 'error',
+      format: 'summary',
+      github: true,
+      includeDrafts: false,
+      json: false,
+      lock: 'auto',
+      noLockMutation: true,
+      onlyDrafts: false,
+      prePush: false,
+      refresh: false,
+      skipLock: false,
+      strict: true,
+      summary: false,
+    });
 
-      const report = await runWarden({ rootDir: dir });
-      expect(report.diagnostics).toBeDefined();
-      expect(typeof report.errorCount).toBe('number');
-      expect(typeof report.warnCount).toBe('number');
-      expect(typeof report.passed).toBe('boolean');
-    } finally {
-      rmSync(dir, { force: true, recursive: true });
-    }
+    expect(args).toEqual([
+      '--ci',
+      '--depth',
+      'topo',
+      '--strict',
+      '--github',
+      '--cached',
+      '--exclude-drafts',
+      '--no-lock-mutation',
+      '--apps',
+      'trails,demo',
+    ]);
   });
 
-  test('lintOnly skips drift detection', async () => {
-    const dir = makeTempDir();
-    try {
-      writeFileSync(join(dir, 'empty.ts'), 'export {}');
-      const report = await runWarden({ lintOnly: true, rootDir: dir });
-      expect(report.drift).toBeNull();
-    } finally {
-      rmSync(dir, { force: true, recursive: true });
-    }
-  });
-
-  test('driftOnly skips lint rules', async () => {
+  test('runs through the shared Warden command and returns formatted output', async () => {
     const dir = makeTempDir();
     try {
       writeFileSync(
         join(dir, 'bad.ts'),
-        `trail("x", {
-  blaze: async () => { throw new Error("boom"); }
-})`
+        `trail("hello", {
+  blaze: async () => {
+    throw new Error("boom");
+  },
+});`
       );
-      const report = await runWarden({ driftOnly: true, rootDir: dir });
-      expect(report.diagnostics.length).toBe(0);
-      expect(report.drift).not.toBeNull();
+
+      const result = await wardenTrail.blaze(
+        { depth: 'source', format: 'summary', lock: 'skip', rootDir: dir },
+        { cwd: dir, env: {} } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.passed).toBe(false);
+      expect(result.value.errorCount).toBe(1);
+      expect(result.value.formatted).toContain('## Warden Report');
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
   });
 
-  test('formatWardenReport produces human-readable output', async () => {
-    const report = await runWarden({ rootDir: '/dev/null' });
-    const output = formatWardenReport(report);
-    expect(output).toContain('Warden Report');
-    expect(typeof output).toBe('string');
+  test('format aliases produce raw Warden formatter output', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, 'empty.ts'), 'export {};');
+
+      const result = await wardenTrail.blaze(
+        { depth: 'source', json: true, lock: 'skip', rootDir: dir },
+        { cwd: dir, env: {} } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(JSON.parse(result.value.formatted)).toMatchObject({
+        passed: true,
+        summary: { errors: 0, warnings: 0 },
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('onResult bridge writes formatted output and sets the exit code', () => {
+    const originalWrite = process.stdout.write;
+    const originalExitCode = process.exitCode;
+    let output = '';
+    process.stdout.write = ((chunk: string) => {
+      output += chunk;
+      return true;
+    }) as typeof process.stdout.write;
+    process.exitCode = undefined;
+
+    try {
+      const handled = tryWardenOutput({
+        args: {},
+        flags: {},
+        input: {},
+        result: Result.ok({ formatted: 'warden says no', passed: false }),
+        topoName: 'trails',
+        trail: wardenTrail as unknown as ActionResultContext['trail'],
+      });
+
+      expect(handled).toBe(true);
+      expect(output).toBe('warden says no\n');
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.stdout.write = originalWrite;
+      // Bun does not clear a non-zero exitCode when assigned undefined.
+      process.exitCode = originalExitCode ?? 0;
+    }
   });
 });

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -39,6 +39,7 @@ import {
   readRunTrailId,
   runWatchLoop,
 } from './run-watch.js';
+import { tryWardenOutput } from './run-warden.js';
 import { tryLoadFreshAppLease } from './trails/load-app.js';
 import { resolveRunModulePath } from './trails/run.js';
 import { resolveTrailRootDir } from './trails/root-dir.js';
@@ -74,6 +75,9 @@ const buildOnResult =
       return;
     }
     if (await tryQuietRunOutput(resolvedCtx)) {
+      return;
+    }
+    if (tryWardenOutput(resolvedCtx)) {
       return;
     }
     await defaultOnResult(resolvedCtx);
@@ -212,6 +216,47 @@ const readWatchSurfaceHash = async (
   }
 };
 
+const wardenValueFlags = new Set([
+  '--apps',
+  '--config-path',
+  '--depth',
+  '--drafts',
+  '--fail-on',
+  '--format',
+  '--lock',
+  '--root-dir',
+]);
+
+const normalizeWardenArgv = (argv: readonly string[]): string[] => {
+  if (argv[2] !== 'warden') {
+    return [...argv];
+  }
+
+  const normalized = [...argv];
+  let previousFlagConsumesValue = false;
+  for (let index = 3; index < normalized.length; index += 1) {
+    const arg = normalized[index];
+    if (arg === undefined) {
+      continue;
+    }
+
+    if (previousFlagConsumesValue) {
+      previousFlagConsumesValue = false;
+      continue;
+    }
+
+    if (arg === '-a') {
+      normalized[index] = '--apps';
+      previousFlagConsumesValue = true;
+      continue;
+    }
+
+    previousFlagConsumesValue = wardenValueFlags.has(arg);
+  }
+
+  return normalized;
+};
+
 /**
  * Invoke `surface()` once with an optional fresh trace session.
  *
@@ -241,7 +286,7 @@ const runSurfaceOnce = async (): Promise<void> => {
       version: trailsPackageVersion,
     });
     attachCompletionsInstallCommand(program);
-    await program.parseAsync();
+    await program.parseAsync(normalizeWardenArgv(process.argv));
   } finally {
     if (session !== undefined) {
       const records = session.finalize();

--- a/apps/trails/src/run-warden.ts
+++ b/apps/trails/src/run-warden.ts
@@ -1,0 +1,33 @@
+import type { ActionResultContext } from '@ontrails/cli';
+
+interface WardenResultValue {
+  readonly formatted: string;
+  readonly passed: boolean;
+}
+
+const isWardenResultValue = (value: unknown): value is WardenResultValue => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate['formatted'] === 'string' &&
+    typeof candidate['passed'] === 'boolean'
+  );
+};
+
+export const tryWardenOutput = (ctx: ActionResultContext): boolean => {
+  if (ctx.trail.id !== 'warden' || ctx.result.isErr()) {
+    return false;
+  }
+  const { value } = ctx.result;
+  if (!isWardenResultValue(value)) {
+    return false;
+  }
+
+  if (value.formatted.length > 0) {
+    process.stdout.write(`${value.formatted}\n`);
+  }
+  process.exitCode = value.passed ? 0 : 1;
+  return true;
+};

--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -1,27 +1,138 @@
 /**
  * `warden` trail -- Governance checks.
  *
- * Thin wrapper around `runWarden` and `formatWardenReport` from @ontrails/warden.
+ * Thin wrapper around the shared @ontrails/warden command surface.
  */
 
 import { Result, trail } from '@ontrails/core';
-import type { Topo } from '@ontrails/core';
 import {
-  formatGitHubAnnotations,
-  formatJson,
-  formatSummary,
-  formatWardenReport,
-  runWarden,
-  wardenRuleTiers,
+  runWardenCommand,
+  wardenDepthValues,
+  wardenDraftsValues,
+  wardenFailOnValues,
+  wardenFormatValues,
+  wardenLockValues,
 } from '@ontrails/warden';
 import { z } from 'zod';
 
-import { tryLoadApp } from './load-app.js';
 import { resolveTrailRootDir } from './root-dir.js';
 
 // ---------------------------------------------------------------------------
 // Trail definition
 // ---------------------------------------------------------------------------
+
+const wardenInputSchema = z.object({
+  apps: z
+    .array(z.string())
+    .optional()
+    .describe('App names or module paths to govern'),
+  cached: z.boolean().default(false).describe('Alias for --lock cached'),
+  ci: z.boolean().default(false).describe('Use the CI Warden preset'),
+  configPath: z.string().optional().describe('Path to trails.config.ts'),
+  depth: z
+    .enum(wardenDepthValues)
+    .optional()
+    .describe('Cumulative analysis depth'),
+  drafts: z.enum(wardenDraftsValues).optional().describe('Draft state mode'),
+  excludeDrafts: z
+    .boolean()
+    .default(false)
+    .describe('Alias for --drafts exclude'),
+  failOn: z.enum(wardenFailOnValues).optional().describe('Failure threshold'),
+  format: z.enum(wardenFormatValues).optional().describe('Output format'),
+  github: z.boolean().default(false).describe('Alias for --format github'),
+  includeDrafts: z
+    .boolean()
+    .default(false)
+    .describe('Alias for --drafts include'),
+  json: z.boolean().default(false).describe('Alias for --format json'),
+  lock: z.enum(wardenLockValues).optional().describe('Lockfile mode'),
+  noLockMutation: z
+    .boolean()
+    .default(false)
+    .describe('Suppress lockfile mutation'),
+  onlyDrafts: z.boolean().default(false).describe('Alias for --drafts only'),
+  prePush: z.boolean().default(false).describe('Use the pre-push preset'),
+  refresh: z.boolean().default(false).describe('Alias for --lock refresh'),
+  rootDir: z.string().optional().describe('Root directory to scan'),
+  skipLock: z.boolean().default(false).describe('Alias for --lock skip'),
+  strict: z.boolean().default(false).describe('Alias for --fail-on warning'),
+  summary: z.boolean().default(false).describe('Alias for --format summary'),
+});
+
+type WardenTrailInput = z.infer<typeof wardenInputSchema>;
+
+const pushFlag = (args: string[], condition: boolean, flag: string): void => {
+  if (condition) {
+    args.push(flag);
+  }
+};
+
+const pushValue = (
+  args: string[],
+  flag: string,
+  value: string | undefined
+): void => {
+  if (value !== undefined) {
+    args.push(flag, value);
+  }
+};
+
+const pushApps = (
+  args: string[],
+  apps: readonly string[] | undefined
+): void => {
+  if (apps !== undefined && apps.length > 0) {
+    args.push('--apps', apps.join(','));
+  }
+};
+
+export const buildWardenCommandArgs = (
+  input: WardenTrailInput
+): readonly string[] => {
+  const args: string[] = [];
+
+  pushFlag(args, input.prePush, '--pre-push');
+  pushFlag(args, input.ci, '--ci');
+  pushValue(args, '--depth', input.depth);
+  if (input.strict) {
+    args.push('--strict');
+  } else {
+    pushValue(args, '--fail-on', input.failOn);
+  }
+  if (input.github) {
+    args.push('--github');
+  } else if (input.json) {
+    args.push('--json');
+  } else if (input.summary) {
+    args.push('--summary');
+  } else {
+    pushValue(args, '--format', input.format);
+  }
+  if (input.skipLock) {
+    args.push('--skip-lock');
+  } else if (input.refresh) {
+    args.push('--refresh');
+  } else if (input.cached) {
+    args.push('--cached');
+  } else {
+    pushValue(args, '--lock', input.lock);
+  }
+  if (input.onlyDrafts) {
+    args.push('--only-drafts');
+  } else if (input.excludeDrafts) {
+    args.push('--exclude-drafts');
+  } else if (input.includeDrafts) {
+    args.push('--include-drafts');
+  } else {
+    pushValue(args, '--drafts', input.drafts);
+  }
+  pushFlag(args, input.noLockMutation, '--no-lock-mutation');
+  pushValue(args, '--config-path', input.configPath);
+  pushApps(args, input.apps);
+
+  return args;
+};
 
 export const wardenTrail = trail('warden', {
   blaze: async (input, ctx) => {
@@ -30,38 +141,18 @@ export const wardenTrail = trail('warden', {
       return Result.err(rootDirResult.error);
     }
     const rootDir = rootDirResult.value;
-    const loadedTopo = await tryLoadApp(input.module, rootDir);
-    let topo: Topo | undefined;
-    if (loadedTopo.isOk()) {
-      topo = loadedTopo.value;
-    } else {
-      ctx.logger?.warn('Could not load app for topo-aware governance', {
-        error: loadedTopo.error.message,
-      });
-    }
-
-    const report = await runWarden({
-      driftOnly: input.driftOnly,
-      lintOnly: input.lintOnly,
-      rootDir,
-      tier: input.tier,
-      topo,
+    const result = await runWardenCommand({
+      args: buildWardenCommandArgs(input),
+      cwd: rootDir,
+      env: ctx.env ?? {},
     });
-
-    const formatters: Record<string, (r: typeof report) => string> = {
-      github: formatGitHubAnnotations,
-      json: formatJson,
-      summary: formatSummary,
-      text: formatWardenReport,
-    };
-    const formatter = formatters[input.format] ?? formatWardenReport;
-    const formatted = formatter(report);
+    const { report } = result;
 
     return Result.ok({
       diagnostics: [...report.diagnostics],
       drift: report.drift,
       errorCount: report.errorCount,
-      formatted,
+      formatted: result.output,
       passed: report.passed,
       warnCount: report.warnCount,
     });
@@ -70,8 +161,7 @@ export const wardenTrail = trail('warden', {
   examples: [
     {
       input: {
-        driftOnly: false,
-        lintOnly: false,
+        lock: 'skip',
       },
       name: 'Default warden run',
     },
@@ -82,23 +172,7 @@ export const wardenTrail = trail('warden', {
       name: 'GitHub Actions annotations',
     },
   ],
-  input: z.object({
-    driftOnly: z.boolean().default(false).describe('Only run drift detection'),
-    format: z
-      .enum(['text', 'json', 'github', 'summary'])
-      .default('text')
-      .describe('Output format: text, json, github, or summary'),
-    lintOnly: z.boolean().default(false).describe('Only run lint rules'),
-    module: z
-      .string()
-      .optional()
-      .describe('App module path (auto-discovered if omitted)'),
-    rootDir: z.string().optional().describe('Root directory to scan'),
-    tier: z
-      .enum(wardenRuleTiers)
-      .optional()
-      .describe('Run only one Warden tier'),
-  }),
+  input: wardenInputSchema,
   intent: 'read',
   output: z.object({
     diagnostics: z.array(
@@ -108,6 +182,7 @@ export const wardenTrail = trail('warden', {
         message: z.string(),
         rule: z.string(),
         severity: z.enum(['error', 'warn']),
+        topoName: z.string().optional(),
       })
     ),
     drift: z


### PR DESCRIPTION
## Context

Part of the Governance Maturity M1 stack. This branch makes `trails warden` a feature-complete framework CLI surface over the shared Warden command runner.

Closes: TRL-669

## What Changed

- Replaced legacy `lintOnly` / `driftOnly` / `tier` wrapper behavior with the final `trails warden` flag surface.
- Projected `trails warden` into the shared `@ontrails/warden` command runner.
- Added formatted-output handling and exit-code propagation for the integrated CLI.
- Added local `-a` to `--apps` normalization for Warden only, without generalizing value-as-alias behavior in `@ontrails/cli`.

## Verification

- `bun test apps/trails/src/__tests__/warden.test.ts`
- `bun run --cwd apps/trails typecheck`
- `bun run --cwd apps/trails lint`
- `bun run --cwd apps/trails test`
- `bun apps/trails/bin/trails.ts warden --depth source --lock skip --root-dir <clean-temp> --summary`
- `bun run format:check`
- Stack-tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`.
- Local review passes 1-4 found no remaining P0/P1/P2 blockers.

## Risks / Rollout Notes

- The direct `warden` bin writes GitHub step summaries under `--ci`; `trails warden --ci` does not. Framework CI uses the direct bin, so this remains a P3 parity note.

## Changeset / Release Rationale

- Includes `.changeset/trails-warden-surface.md` for the `@ontrails/trails` CLI surface change.
