### PR TITLE
chore: dogfood warden config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,9 @@
       "devDependencies": {
         "@ast-grep/cli": "0.42.1",
         "@changesets/cli": "^2.29.8",
+        "@ontrails/config": "workspace:^",
         "@ontrails/oxlint-plugin": "workspace:*",
+        "@ontrails/warden": "workspace:^",
         "@types/bun": "^1.3.11",
         "@types/node": "^25.5.0",
         "drizzle-orm": "^0.45.2",
@@ -22,6 +24,7 @@
         "turbo": "^2.8.10",
         "typescript": "^5.9.3",
         "ultracite": "7.6.2",
+        "zod": "catalog:",
       },
     },
     "apps/trails": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
   "devDependencies": {
     "@ast-grep/cli": "0.42.1",
     "@changesets/cli": "^2.29.8",
+    "@ontrails/config": "workspace:*",
     "@ontrails/oxlint-plugin": "workspace:*",
+    "@ontrails/warden": "workspace:*",
     "@types/bun": "^1.3.11",
     "@types/node": "^25.5.0",
     "drizzle-orm": "^0.45.2",
@@ -52,7 +54,8 @@
     "oxlint": "1.62.0",
     "turbo": "^2.8.10",
     "typescript": "^5.9.3",
-    "ultracite": "7.6.2"
+    "ultracite": "7.6.2",
+    "zod": "catalog:"
   },
   "engines": {
     "bun": ">=1.3.0"

--- a/trails.config.ts
+++ b/trails.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@ontrails/config';
+import { wardenConfigSchema } from '@ontrails/warden';
+import { z } from 'zod';
+
+export default defineConfig({
+  base: {
+    warden: {
+      apps: ['trails', 'trails-demo'],
+    },
+  },
+  schema: z.object({
+    warden: wardenConfigSchema,
+  }),
+});


### PR DESCRIPTION
## Context

Part of the Governance Maturity M1 stack. This branch dogfoods the Warden config schema at the framework root.

Closes: TRL-673

## What Changed

- Added root `trails.config.ts`.
- Composed `defineConfig` with `wardenConfigSchema`.
- Set the framework Warden app list to `trails` and `trails-demo`.
- Added root dev dependencies needed by the config file.

## Verification

- `bun packages/warden/bin/warden.ts --depth source --lock skip --format summary`
- `bun apps/trails/bin/trails.ts warden --depth source --lock skip --summary`
- `bun run format:check`
- Stack-tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`.
- Local review passes 1-4 found no remaining P0/P1/P2 blockers.

## Risks / Rollout Notes

- Root-only dogfooding config. It does not add publishable package files.
- Warden source-depth smokes report 0 errors and the existing source warnings.

## Changeset / Release Rationale

- `release:none`: root config and root dev dependency wiring only; no publishable package content changed.
