### PR TITLE
test: cover warden exit behavior

### DIFF
--- a/apps/trails/src/__tests__/warden.test.ts
+++ b/apps/trails/src/__tests__/warden.test.ts
@@ -4,9 +4,18 @@ import { describe, expect, test } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { tryWardenOutput } from '../run-warden.js';
 import { buildWardenCommandArgs, wardenTrail } from '../trails/warden.js';
+
+const wardenBinPath = fileURLToPath(
+  new URL('../../../../packages/warden/bin/warden.ts', import.meta.url)
+);
+const trailsBinPath = fileURLToPath(
+  new URL('../../bin/trails.ts', import.meta.url)
+);
+const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
 
 const makeTempDir = (): string => {
   const dir = join(
@@ -15,6 +24,80 @@ const makeTempDir = (): string => {
   );
   mkdirSync(dir, { recursive: true });
   return dir;
+};
+
+interface WardenJsonOutput {
+  readonly diagnostics: readonly {
+    readonly rule: string;
+    readonly severity: 'error' | 'warn';
+  }[];
+  readonly passed: boolean;
+  readonly summary: {
+    readonly errors: number;
+    readonly warnings: number;
+  };
+}
+
+interface CliRun {
+  readonly exitCode: number;
+  readonly json: WardenJsonOutput;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+const runCli = (
+  binPath: string,
+  args: readonly string[],
+  cwd: string
+): CliRun => {
+  const proc = Bun.spawnSync({
+    cmd: [process.execPath, binPath, ...args],
+    cwd,
+    env: { ...process.env, NO_COLOR: '1' } as Record<string, string>,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  const stdout = proc.stdout.toString();
+  const stderr = proc.stderr.toString();
+  let json: WardenJsonOutput;
+  try {
+    json = JSON.parse(stdout) as WardenJsonOutput;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse JSON output from ${binPath}\nstdout: ${stdout}\nstderr: ${stderr}`,
+      { cause: error }
+    );
+  }
+
+  return {
+    exitCode: proc.exitCode ?? -1,
+    json,
+    stderr,
+    stdout,
+  };
+};
+
+const writeProjectOnlyErrorFixture = (dir: string): void => {
+  writeFileSync(
+    join(dir, 'project-only.ts'),
+    `trail('entity.show', {
+  on: ['entity.changed'],
+  blaze: async () => Result.ok({ ok: true }),
+});`
+  );
+};
+
+const writeAllDepthWarningFixture = (dir: string): void => {
+  writeFileSync(
+    join(dir, 'warning-only.ts'),
+    `trail('entity.show', {
+  input: z.object({ firstName: z.string() }),
+  fields: {
+    firstName: { label: 'First Name' },
+  },
+  blaze: async () => Result.ok({ ok: true }),
+});`
+  );
 };
 
 describe('trails warden', () => {
@@ -136,4 +219,137 @@ describe('trails warden', () => {
       process.exitCode = originalExitCode ?? 0;
     }
   });
+
+  test.each([
+    {
+      depth: 'source',
+      expectedErrors: 0,
+      expectedExitCode: 0,
+      expectedRule: undefined,
+      expectedWarnings: 0,
+      failOn: 'error',
+      fixture: writeProjectOnlyErrorFixture,
+      name: 'source/error ignores project-only findings',
+    },
+    {
+      depth: 'source',
+      expectedErrors: 0,
+      expectedExitCode: 0,
+      expectedRule: undefined,
+      expectedWarnings: 0,
+      failOn: 'warning',
+      fixture: writeAllDepthWarningFixture,
+      name: 'source/warning ignores advisory findings',
+    },
+    {
+      depth: 'project',
+      expectedErrors: 1,
+      expectedExitCode: 1,
+      expectedRule: 'on-references-exist',
+      expectedWarnings: 0,
+      failOn: 'error',
+      fixture: writeProjectOnlyErrorFixture,
+      name: 'project/error fails on project findings',
+    },
+    {
+      depth: 'project',
+      expectedErrors: 1,
+      expectedExitCode: 1,
+      expectedRule: 'on-references-exist',
+      expectedWarnings: 0,
+      failOn: 'warning',
+      fixture: writeProjectOnlyErrorFixture,
+      name: 'project/warning still fails on errors',
+    },
+    {
+      depth: 'topo',
+      expectedErrors: 1,
+      expectedExitCode: 1,
+      expectedRule: 'on-references-exist',
+      expectedWarnings: 0,
+      failOn: 'error',
+      fixture: writeProjectOnlyErrorFixture,
+      name: 'topo/error includes shallower project findings',
+    },
+    {
+      depth: 'topo',
+      expectedErrors: 1,
+      expectedExitCode: 1,
+      expectedRule: 'on-references-exist',
+      expectedWarnings: 0,
+      failOn: 'warning',
+      fixture: writeProjectOnlyErrorFixture,
+      name: 'topo/warning still fails on errors',
+    },
+    {
+      depth: 'all',
+      expectedErrors: 0,
+      expectedExitCode: 0,
+      expectedRule: 'prefer-schema-inference',
+      expectedWarnings: 1,
+      failOn: 'error',
+      fixture: writeAllDepthWarningFixture,
+      name: 'all/error reports warnings without failing',
+    },
+    {
+      depth: 'all',
+      expectedErrors: 0,
+      expectedExitCode: 1,
+      expectedRule: 'prefer-schema-inference',
+      expectedWarnings: 1,
+      failOn: 'warning',
+      fixture: writeAllDepthWarningFixture,
+      name: 'all/warning fails on warning-only findings',
+    },
+  ] as const)(
+    'acceptance: $name across Warden bin and trails warden',
+    ({
+      depth,
+      expectedErrors,
+      expectedExitCode,
+      expectedRule,
+      expectedWarnings,
+      failOn,
+      fixture,
+    }) => {
+      const dir = makeTempDir();
+      try {
+        fixture(dir);
+        const args = [
+          '--depth',
+          depth,
+          '--fail-on',
+          failOn,
+          '--lock',
+          'skip',
+          '--format',
+          'json',
+          '--root-dir',
+          dir,
+        ];
+        const warden = runCli(wardenBinPath, args, repoRoot);
+        const trails = runCli(trailsBinPath, ['warden', ...args], repoRoot);
+
+        expect(warden.exitCode).toBe(expectedExitCode);
+        expect(trails.exitCode).toBe(expectedExitCode);
+        expect(warden.stderr).toBe('');
+        expect(trails.stderr).toBe('');
+        expect(warden.json).toEqual(trails.json);
+        expect(warden.json.passed).toBe(expectedExitCode === 0);
+        expect(warden.json.summary).toMatchObject({
+          errors: expectedErrors,
+          warnings: expectedWarnings,
+        });
+        if (expectedRule === undefined) {
+          expect(warden.json.diagnostics).toHaveLength(0);
+        } else {
+          expect(warden.json.diagnostics.map((entry) => entry.rule)).toContain(
+            expectedRule
+          );
+        }
+      } finally {
+        rmSync(dir, { force: true, recursive: true });
+      }
+    }
+  );
 });


### PR DESCRIPTION
## Context

Part of the Governance Maturity M1 stack. This branch adds acceptance coverage for Warden depth and exit-code behavior across both entrypoints.

Closes: TRL-670

## What Changed

- Added a subprocess acceptance matrix in `apps/trails/src/__tests__/warden.test.ts`.
- Runs the real `packages/warden/bin/warden.ts` entrypoint and real `trails warden` CLI against the same temp fixtures.
- Covers `--depth source|project|topo|all` and `--fail-on error|warning`.
- Proves shallower depth ignores deeper findings, warnings only fail under `--fail-on warning`, and both surfaces emit matching JSON reports / exit codes.

## Verification

- `bun test apps/trails/src/__tests__/warden.test.ts`
- `bun run --cwd apps/trails typecheck`
- `bun run --cwd apps/trails lint`
- `bun run format:check`
- Stack-tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`.
- Local review passes 1-4 found no remaining P0/P1/P2 blockers.

## Risks / Rollout Notes

- Test-only acceptance branch. It intentionally exercises the user-facing binaries, so failures here should catch drift between `warden` and `trails warden`.

## Changeset / Release Rationale

- `release:none`: test-only branch; no publishable package content changed.
