### PR TITLE
ci: add reusable warden action

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -1,0 +1,99 @@
+name: Trails Warden Check
+description: Run Trails Warden in CI using the published @ontrails/warden bin
+
+inputs:
+  fail-on:
+    description: 'Failure threshold: error or warning.'
+    required: false
+    default: ''
+  strict:
+    description: Alias for --fail-on warning.
+    required: false
+    default: 'false'
+  depth:
+    description: 'Cumulative analysis depth: source, project, topo, or all.'
+    required: false
+    default: ''
+  format:
+    description: 'Output format: summary, github, or json.'
+    required: false
+    default: ''
+  lock:
+    description: 'Lockfile mode: auto, cached, refresh, or skip.'
+    required: false
+    default: ''
+  drafts:
+    description: 'Draft mode: include, exclude, or only.'
+    required: false
+    default: ''
+  apps:
+    description: Comma-delimited app names or module paths to inspect.
+    required: false
+    default: ''
+  config-path:
+    description: Path to trails.config.ts, relative to the workflow working directory.
+    required: false
+    default: ''
+  warden-version:
+    description: Override the @ontrails/warden npm version. Defaults to the action ref with a leading v stripped.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Run Warden
+      shell: bash
+      env:
+        ACTION_REF: ${{ github.action_ref }}
+        INPUT_APPS: ${{ inputs.apps }}
+        INPUT_CONFIG_PATH: ${{ inputs.config-path }}
+        INPUT_DEPTH: ${{ inputs.depth }}
+        INPUT_DRAFTS: ${{ inputs.drafts }}
+        INPUT_FAIL_ON: ${{ inputs.fail-on }}
+        INPUT_FORMAT: ${{ inputs.format }}
+        INPUT_LOCK: ${{ inputs.lock }}
+        INPUT_STRICT: ${{ inputs.strict }}
+        INPUT_WARDEN_VERSION: ${{ inputs.warden-version }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "$INPUT_WARDEN_VERSION" ]; then
+          warden_version="$INPUT_WARDEN_VERSION"
+          warden_package="@ontrails/warden@$warden_version"
+        elif [ -z "$ACTION_REF" ] || [ "$ACTION_REF" = "main" ] || [ "$ACTION_REF" = "master" ]; then
+          warden_package="@ontrails/warden"
+        elif [[ "$ACTION_REF" =~ ^v?[0-9]+\.[0-9] ]]; then
+          warden_version="${ACTION_REF#v}"
+          warden_package="@ontrails/warden@$warden_version"
+        else
+          echo "::error::Unable to infer an @ontrails/warden npm version from action ref '$ACTION_REF'. Set the warden-version input when pinning the action by SHA or non-version branch."
+          exit 1
+        fi
+
+        args=(--ci)
+        if [ "$INPUT_STRICT" = "true" ]; then
+          args+=(--strict)
+        elif [ -n "$INPUT_FAIL_ON" ]; then
+          args+=(--fail-on "$INPUT_FAIL_ON")
+        fi
+        if [ -n "$INPUT_DEPTH" ]; then
+          args+=(--depth "$INPUT_DEPTH")
+        fi
+        if [ -n "$INPUT_FORMAT" ]; then
+          args+=(--format "$INPUT_FORMAT")
+        fi
+        if [ -n "$INPUT_LOCK" ]; then
+          args+=(--lock "$INPUT_LOCK")
+        fi
+        if [ -n "$INPUT_DRAFTS" ]; then
+          args+=(--drafts "$INPUT_DRAFTS")
+        fi
+        if [ -n "$INPUT_APPS" ]; then
+          args+=(--apps "$INPUT_APPS")
+        fi
+        if [ -n "$INPUT_CONFIG_PATH" ]; then
+          args+=(--config-path "$INPUT_CONFIG_PATH")
+        fi
+
+        bunx "$warden_package" "${args[@]}"

--- a/docs/warden.md
+++ b/docs/warden.md
@@ -44,6 +44,58 @@ lifecycle.
 `runWarden({ tier })` can execute one tier at a time; omitting `tier` preserves
 the full lint-plus-drift run.
 
+## Running Warden
+
+Local development usually goes through the integrated Trails CLI:
+
+```bash
+bun trails warden
+bun trails warden --pre-push
+```
+
+CI can use the direct Warden bin:
+
+```bash
+bunx @ontrails/warden --ci --apps trails,trails-demo
+```
+
+`--ci` is a preset on the Warden bin. It runs all depths, emits GitHub
+annotations by default, fails on errors, and suppresses lockfile mutation.
+Use `--fail-on warning` or `--strict` when warnings should block the run.
+
+GitHub adopters can use the reusable action after checkout, Bun setup, and
+dependency installation:
+
+```yaml
+jobs:
+  warden:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - uses: outfitter-dev/trails/.github/actions/check@v1.0.0
+        with:
+          apps: trails,trails-demo
+          depth: all
+          fail-on: error
+```
+
+The action wraps `bunx @ontrails/warden --ci`. When the action is used from a
+version tag such as `@v1.0.0`, it runs `@ontrails/warden@1.0.0` by default; use
+the `warden-version` input only when the action tag and npm package version must
+intentionally diverge. Workflows that pin the action by SHA or by a non-version
+branch must set `warden-version` explicitly because those refs do not identify an
+npm package version. Framework PR CI should keep using the local workspace bin so
+PRs test branch code rather than the latest published package.
+
+For non-GitHub CI, call the bin directly after installing Bun and project
+dependencies:
+
+```bash
+bunx @ontrails/warden@1.0.0 --ci --apps trails,trails-demo --fail-on error
+```
+
 ## Authoring Durable Rules
 
 Durable Warden rules should explain the doctrine they enforce. When adding one:


### PR DESCRIPTION
## Context

Part of the Governance Maturity M1 stack. This branch ships the adopter-facing reusable GitHub Action after the framework Warden bin and local gates are in place.

Closes: TRL-672

## What Changed

- Added `.github/actions/check/action.yml` composite action.
- The action wraps `bunx @ontrails/warden` with `args=(--ci)`.
- Mapped M1 inputs for `fail-on`, `strict`, `depth`, `format`, `lock`, `drafts`, `apps`, `config-path`, and `warden-version`.
- Defaults `warden-version` from the action ref with a leading `v` stripped, while allowing explicit override.
- Documented GitHub usage, non-GitHub CI usage, action/package version pairing, and why framework PR CI uses the local workspace bin.

## Verification

- Action metadata parsed with Ruby YAML.
- Embedded action shell passed `shellcheck`.
- `bun run docs:snippets`
- `bun run format:check`
- `bun packages/warden/bin/warden.ts --ci --apps trails,trails-demo`
- `bun run check`
- Stack-tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`.
- Local review pass 4 verified no separate CI package, adapter, or subpath bin was introduced.

## Risks / Rollout Notes

- The action depends on the published `@ontrails/warden` package version matching release tags.
- The action does not expose `--root-dir`; nested workspace users can invoke `bunx @ontrails/warden ... --root-dir ...` directly if needed.
- Existing workflow SC2129 style warning remains outside this action branch's scope.

## Changeset / Release Rationale

- `release:none`: action/docs-only branch; no publishable package content changed.
