### PR TITLE
fix: omit empty warden topo names

### DIFF
--- a/.changeset/warden-toponames-empty.md
+++ b/.changeset/warden-toponames-empty.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Omit `topoNames` from Warden reports when no topo targets were governed, matching the optional report contract.

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -121,6 +121,7 @@ describe('runWarden basics', () => {
       const report = await runWarden({ rootDir: dir });
       expect(report.errorCount).toBe(0);
       expect(report.passed).toBe(true);
+      expect(report.topoNames).toBeUndefined();
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -1166,6 +1166,10 @@ export const runWarden = async (
     (d) => d.severity === 'error'
   ).length;
   const warnCount = allDiagnostics.filter((d) => d.severity === 'warn').length;
+  const topoNames =
+    topoTargets.length > 0
+      ? topoTargets.map((target) => target.name ?? target.topo.name)
+      : undefined;
 
   return {
     diagnostics: allDiagnostics,
@@ -1178,7 +1182,7 @@ export const runWarden = async (
       failOn: effectiveConfig.failOn,
       warnCount,
     }),
-    topoNames: topoTargets.map((target) => target.name ?? target.topo.name),
+    ...(topoNames === undefined ? {} : { topoNames }),
     warnCount,
   };
 };


### PR DESCRIPTION
## Context

Follow-up from Greptile’s post-merge prompt on Governance Maturity M1. `WardenReport.topoNames` is optional, but `runWarden` was returning an empty array for runs without topo targets.

## What Changed

- Omits `topoNames` from reports when no topo targets were governed.
- Keeps named topo reports unchanged.
- Adds a regression assertion for the no-topo case.

## Verification

- `bun test packages/warden/src/__tests__/cli.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run --cwd packages/warden lint`
- `bun run format:check`
- `bun scripts/check-changeset-gate.ts --changed-files /tmp/trails-toponames-changed-files.txt`

## Risks / Rollout Notes

- Narrow report-shape cleanup. Consumers that incorrectly depended on `topoNames: []` should switch to treating absence as no topo targets.

## Changeset / Release Rationale

- Includes `.changeset/warden-toponames-empty.md` for the `@ontrails/warden` report-shape patch.