### PR TITLE
docs(adr,lexicon): retire connector taxonomy

### DIFF
--- a/docs/adr/0012-connector-agnostic-permits.md
+++ b/docs/adr/0012-connector-agnostic-permits.md
@@ -1,14 +1,18 @@
 ---
 id: 12
 slug: connector-agnostic-permits
-title: Connector-Agnostic Permits
+title: Adapter-Agnostic Permits
 status: accepted
 created: 2026-03-30
-updated: 2026-04-02
+updated: 2026-05-08
 owners: ['[galligan](https://github.com/galligan)']
 ---
 
-# ADR-0012: Connector-Agnostic Permits
+# ADR-0012: Adapter-Agnostic Permits
+
+The historical slug is preserved for reference stability. The 2026-05-08
+amendment renames the current auth boundary from connector vocabulary to
+adapter vocabulary.
 
 ## Context
 
@@ -62,7 +66,11 @@ interface Permit {
 }
 ```
 
-Core enforcement keys off `scopes` only. Roles are connector output — the auth connector resolves them, and implementations can read them, but the framework's own enforcement doesn't branch on roles. `metadata` stays `Record<string, unknown>` for v1. No generic `Permit<T>` — the complexity isn't justified until concrete use cases demand it.
+Core enforcement keys off `scopes` only. Roles are adapter output — the auth
+adapter resolves them, and implementations can read them, but the framework's
+own enforcement doesn't branch on roles. `metadata` stays
+`Record<string, unknown>` for v1. No generic `Permit<T>` — the complexity isn't
+justified until concrete use cases demand it.
 
 ### `ctx.permit` is `Permit | undefined`
 
@@ -90,19 +98,25 @@ interface PermitExtractionInput {
 }
 ```
 
-Surfaces do raw extraction — pulling tokens from headers, sessions, or environment. The auth connector receives this normalized input and returns a `Permit` or an error. Core auth never imports `Request`, `McpSession`, or any surface-specific type.
+Surfaces do raw extraction — pulling tokens from headers, sessions, or
+environment. The auth adapter receives this normalized input and returns a
+`Permit` or an error. Core auth never imports `Request`, `McpSession`, or any
+surface-specific type.
 
-### Auth connector interface
+### Auth adapter interface
 
 ```typescript
-interface AuthConnector {
+interface AuthAdapter {
   authenticate(
     credentials: AuthCredentials,
   ): Promise<Result<Permit | null, AuthError>>;
 }
 ```
 
-The port is deliberately narrow. No session management, no token refresh, no user lookup. Connectors can provide those as additional services outside the core interface. The framework needs exactly one capability: given credentials, produce a permit or an error.
+The port is deliberately narrow. No session management, no token refresh, no
+user lookup. Adapters can provide those as additional resources outside the core
+interface. The framework needs exactly one capability: given credentials,
+produce a permit or an error.
 
 ### Auth layer re-checks on every invocation including crosses
 
@@ -129,15 +143,19 @@ New rules for scope hygiene:
 
 Strict mode disables auto-minting entirely. Tests must provide explicit permits, which validates that the auth surface works end-to-end rather than being papered over by test conveniences.
 
-### Connector strategy
+### Adapter strategy
 
 Built-in: JWT/JWKS verification, provider-agnostic. Validates tokens, extracts claims, maps to `Permit`. No provider lock-in.
 
-First external connector target: BetterAuth or Clerk, depending on which ships a cleaner token contract. OpenAuth later, once the connector pattern is proven.
+First external adapter target: BetterAuth or Clerk, depending on which ships a
+cleaner token contract. OpenAuth later, once the adapter pattern is proven.
 
 ### Bearer-only for v1
 
-No cookies. No session-based auth at the framework level. Session management via cookies is a connector concern — a future connector can extract session tokens from cookies and feed them into the same `PermitExtractionInput`. The core model doesn't change; only the extraction surface does.
+No cookies. No session-based auth at the framework level. Session management
+via cookies is an adapter concern — a future adapter can extract session tokens
+from cookies and feed them into the same `PermitExtractionInput`. The core
+model doesn't change; only the extraction surface does.
 
 ## Consequences
 
@@ -151,12 +169,12 @@ No cookies. No session-based auth at the framework level. Session management via
 ### Tradeoffs
 
 - **Explicit scopes require more authoring than convention-derived.** Every trail that needs auth must declare its scopes. This is intentional — auth policy should be visible and authored, not inferred — but it's more work.
-- **Bearer-only limits session-based auth patterns in v1.** Cookie-based session auth is deferred to connectors. Apps that need it will build extraction logic outside the core model.
+- **Bearer-only limits session-based auth patterns in v1.** Cookie-based session auth is deferred to adapters. Apps that need it will build extraction logic outside the core model.
 - **`permit: 'public'` is another thing to learn.** The distinction between omitted and explicitly public adds a concept. The warden makes the distinction actionable rather than academic.
 
 ### What this does NOT decide
 
-- **Cookie/session auth.** An connector concern. The extraction input has the seam; the core model doesn't prescribe it.
+- **Cookie/session auth.** An adapter concern. The extraction input has the seam; the core model doesn't prescribe it.
 - **Resource-level authorization.** "Can this user access *this specific* entity?" is an implementation concern. The permit model covers capability scopes, not resource ownership.
 - **RBAC framework.** Role-based access control is an app-level pattern. `roles` on the Permit type is informational, not enforced by the framework.
 - **Scope derivation helpers.** Convenience functions that suggest scopes from trail ID patterns may ship later. They won't replace explicit declaration — they'll accelerate authoring it.
@@ -164,5 +182,11 @@ No cookies. No session-based auth at the framework level. Session management via
 ## References
 
 - [ADR-0004: Intent as a First-Class Property](0004-intent-as-first-class-property.md) — intent compounds with permit for governance; `destroy` + no permit is an error
-- [ADR-0009: Resources as a First-Class Primitive](0009-first-class-resources.md) — auth connector is a service; auth layer consumes it via `resource.from(ctx)`
+- [ADR-0009: Resources as a First-Class Primitive](0009-first-class-resources.md) — auth adapter is a resource; auth layer consumes it via `resource.from(ctx)`
 - [ADR-0010: Trails-Native Infrastructure Pattern](0010-native-infrastructure.md) — auth layer follows the shared layer model for cross-cutting enforcement
+
+## Amendment log
+
+- 2026-05-08: Connector-to-adapter taxonomy cutover — current permit docs and
+  examples use `AuthAdapter` and auth adapter vocabulary. Historical slug kept
+  stable.

--- a/docs/adr/0029-connector-extraction-and-the-with-packaging-model.md
+++ b/docs/adr/0029-connector-extraction-and-the-with-packaging-model.md
@@ -1,29 +1,33 @@
 ---
 id: 29
 slug: connector-extraction-and-the-with-packaging-model
-title: Connector Extraction and Composition Around Core Contracts
+title: Adapter Extraction and Composition Around Core Contracts
 status: accepted
 created: 2026-04-09
-updated: 2026-04-16
+updated: 2026-05-08
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [9, 16, 22, 23]
 ---
 
-# ADR-0029: Connector Extraction and Composition Around Core Contracts
+# ADR-0029: Adapter Extraction and Composition Around Core Contracts
+
+The historical slug is preserved for reference stability. The 2026-05-08
+amendment retires `connector` as the public package taxonomy term while
+preserving this ADR's extraction model.
 
 ## Context
 
 ### Extraction solved the coupling problem
 
-The original problem still stands: when connector code lives as a subpath inside
+The original problem still stands: when adapter code lives as a subpath inside
 an owning package, dependency and release boundaries blur. `@ontrails/store`
 should not need to ship Drizzle. `@ontrails/http` should not need to own every
-host framework. Extracting integrations into dedicated workspace packages fixed
+host framework. Extracting adapters into dedicated workspace packages fixed
 that part of the story, and the one-way dependency arrow remains correct.
 
 ### The `with-*` prefix did not survive the packaging sweep
 
-What did not survive was the idea that every extracted integration should use a
+What did not survive was the idea that every extracted adapter should use a
 `with-*` prefix. Once the repo gained sharper composition layers, the prefix
 stopped helping:
 
@@ -31,65 +35,70 @@ stopped helping:
 - `@ontrails/hono` is clearer than `@ontrails/with-hono`
 - `@ontrails/vite` is clearer than `@ontrails/with-vite`
 
-The important architectural fact is that the integration is extracted and
-composes around a core contract, not that its name can be read as a sentence.
+The important architectural fact is that the adapter is extracted and composes
+around a core contract, not that its name can be read as a sentence.
 
-### Connectors and adapters now layer around surfaces
+### Adapter is the public category
 
 Trails now has multiple composition layers around a graph:
 
 - pure contract packages such as `@ontrails/store` and `@ontrails/http`
-- extracted bindings such as `@ontrails/drizzle` and `@ontrails/hono`
-- runtime adapters such as `@ontrails/vite`, which layer on top of an
+- extracted adapters such as `@ontrails/drizzle` and `@ontrails/hono`
+- composed adapters such as `@ontrails/vite`, which layer on top of an
   already-created surface runtime
 
 The packaging model needs to describe those layers without inventing a new rule
 for every case.
 
-### What "connector" means
+### What "adapter" means
 
-A connector still bridges a Trails app with an external system, library, or
-platform. "Adapter" remains useful as a scope word for thinner runtime layers,
-but not as a separate top-level category with different governance rules. The
-repo can host both heavier connectors and thinner adapters inside the same
-extracted boundary model.
+An adapter bridges Trails contracts to a named external system, library,
+framework, tool, platform, format, or ecosystem. The distinction between
+materializing a surface and translating a record is descriptive, not
+categorical: Hono, Commander, Drizzle, LogTape, JWT, and OTel all sit at
+boundary points and follow the same packaging discipline.
+
+`integration` remains available as colloquial English. It is not a second
+public taxonomy category. `facet` remains reserved for projection slices of an
+authored contract or surface, not for package or subpath boundaries.
 
 ## Decision
 
-### Connectors stay extracted into `connectors/`
+### Adapters stay extracted into `adapters/`
 
-Extracted integrations that deserve their own dependency and release boundaries
-live as workspace packages under `connectors/`:
+Extracted adapters that deserve their own dependency and release boundaries
+live as workspace packages under `adapters/`. The 2026-05 connector-to-adapter
+cutover migrates the historical `connectors/` workspace root to this shape:
 
 ```text
 packages/       framework contracts and pure projections
-connectors/     extracted bindings and runtime adapters
+adapters/       extracted adapters and runtime adapters
 apps/           applications
 ```
 
 This provides:
 
-- **One-way dependency arrows.** Extracted integrations depend on core
-  contracts. Core contracts never depend on extracted integrations.
+- **One-way dependency arrows.** Extracted adapters depend on core contracts.
+  Core contracts never depend on extracted adapters.
 - **Independent release cadence.** A Hono or Drizzle change does not force a
   publish of the contract package that it binds to.
-- **Clearer contribution boundaries.** New integrations can land without
-  changing the owning contract package's exports or internals.
+- **Clearer contribution boundaries.** New adapters can land without changing
+  the owning contract package's exports or internals.
 
-### Names follow the owned integration, not a prefix
+### Names follow the owned adapter, not a prefix
 
-Extracted integration packages are named for the thing they bind to, not for a
+Extracted adapter packages are named for the thing they bind to, not for a
 `with-*` sentence pattern:
 
 ```text
-@ontrails/drizzle   Drizzle store binding
-@ontrails/hono      Hono HTTP surface
-@ontrails/vite      Vite runtime adapter
+@ontrails/drizzle    Drizzle store adapter
+@ontrails/hono       Hono HTTP adapter
+@ontrails/vite       Vite runtime adapter
 ```
 
-The repo location already tells us these are extracted integrations. The
-package name should answer "what integration is this?" rather than "can I put
-the word 'with' in front of it?"
+The repo location already tells us these are extracted adapters. The package
+name should answer "what does this adapt?" rather than "can I put the word
+'with' in front of it?"
 
 ### Composition follows responsibility, not symmetry
 
@@ -99,21 +108,21 @@ template.
 | Role | Package | Responsibility |
 | --- | --- | --- |
 | Core contract | `@ontrails/store` | Store declaration and schema-derived contract |
-| Extracted binding | `@ontrails/drizzle` | Bind the store contract to Drizzle |
+| Extracted adapter | `@ontrails/drizzle` | Bind the store contract to Drizzle |
 | Pure projection | `@ontrails/http` | Derive framework-agnostic route definitions |
 | Surface runtime | `@ontrails/hono` | Materialize and serve a Hono app from those routes |
 | Runtime adapter | `@ontrails/vite` | Adapt an already-created Hono app to Vite middleware |
-| Tight subpath binding | `@ontrails/cli/commander` | Commander-specific CLI runtime without another top-level package |
+| Adapter subpath, pre-split | `@ontrails/cli/commander` | Commander-specific CLI runtime; beta.16 moves this to `@ontrails/commander` |
 
-Some integrations are worth a standalone package. Some stay as subpaths because
+Some adapters are worth a standalone package. Some stay as subpaths because
 splitting them further would add ceremony without buying a new dependency or
 governance boundary. The rule is architectural clarity, not symmetry.
 
 ### First-party built-in store backends stay under `@ontrails/store/*`
 
 Some backends are part of the store story itself: local, first-party, opt-in
-backends that ship with no third-party integration boundary and primarily exist
-to make the contract useful quickly. Those stay as subpath exports on the
+backends that ship with no third-party adapter boundary and primarily exist to
+make the contract useful quickly. Those stay as subpath exports on the
 owning package:
 
 ```text
@@ -123,17 +132,17 @@ owning package:
 
 This is an explicit carve-out, not a loophole. The rule becomes:
 
-- `@ontrails/store` root stays connector-agnostic.
+- `@ontrails/store` root stays backend-agnostic.
 - `@ontrails/store/*` is reserved for first-party built-in backends owned by the
   store package.
-- `connectors/` packages are reserved for extracted integrations that bind core
-  contracts to external libraries or runtimes.
+- `adapters/` packages are reserved for extracted adapters that bind core
+  contracts to external libraries, frameworks, tools, or runtimes.
 
 That preserves the one-way dependency arrow at the root package while still
 letting Trails ship "quick win" backends as part of the first-party store
 experience.
 
-### Connectors and adapters can stack
+### Adapters can stack
 
 An extracted package can bind a core contract directly, or it can layer on top
 of another extracted surface:
@@ -146,7 +155,7 @@ server.middlewares.use('/api', vite(createApp(graph)));
 ```
 
 The Vite package does not invent a second HTTP contract. It adapts the Hono
-surface that already exists. This stacking model is part of the connector
+surface that already exists. This stacking model is part of the adapter
 composition story.
 
 ### Migration from subpaths to extracted packages
@@ -157,7 +166,7 @@ composition story.
 | `@ontrails/http/hono` | `@ontrails/hono` |
 | `@ontrails/with-jsonfile` | `@ontrails/store/jsonfile` |
 
-This is a breaking change in import paths for extracted integrations. First
+This is a breaking change in import paths for extracted adapters. First
 party built-in store backends remain available as opt-in `@ontrails/store/*`
 subpaths.
 
@@ -166,14 +175,14 @@ subpaths.
 The `resource()` primitive[^1] is still the stable seam for infrastructure.
 Extracted packages produce resources or materialize surfaces. Trails consume
 resources. Graphs still derive projections and open boundaries the same way.
-Nothing about trail contracts changes because connector code moved.
+Nothing about trail contracts changes because adapter code moved.
 
 ```typescript
-// Before: connector lives in store package
+// Before: adapter lives in store package
 import { connectDrizzle } from '@ontrails/store/drizzle';
 const notesDb = connectDrizzle(definition, { url: './notes.sqlite' });
 
-// After: connector lives in its own package
+// After: adapter lives in its own package
 import { connectDrizzle } from '@ontrails/drizzle';
 const notesDb = connectDrizzle(definition, { url: './notes.sqlite' });
 ```
@@ -182,15 +191,15 @@ The return type is identical. The topo registration is identical. The trail's `r
 
 ## Non-goals
 
-- **Defining the connector lifecycle contract.** How a connector declares what it bridges, what lifecycle hooks it supports, and how it reports health — that's a separate decision. This ADR moves the code. Resource bundling is covered by [ADR: Resource Bundles](drafts/20260409-resource-bundles.md) (draft); lifecycle hooks remain open.
-- **Connector scaffolding.** A `trails create connector` command is desirable but not part of this decision.
-- **Trail factories on connectors.** Connectors may eventually export trails via
+- **Defining the adapter lifecycle contract.** How an adapter declares what it bridges, what lifecycle hooks it supports, and how it reports health — that's a separate decision. This ADR moves package boundaries. Resource bundling is covered by [ADR: Resource Bundles](drafts/20260409-resource-bundles.md) (draft); lifecycle hooks remain open.
+- **Adapter scaffolding.** A `trails create adapter` command is desirable but not part of this decision.
+- **Trail factories on adapters.** Adapters may eventually export trails via
   a `/trails` subpath (for example `@ontrails/cloudflare/trails`). That's a
   separate decision that depends on the `deriveTrail()` design.
 - **Forcing every runtime binding into its own top-level package.** Some
   bindings may stay as subpaths when there is no meaningful architectural
   boundary to extract.
-- **Profile-based connector selection.** How a deployment profile chooses which connector backs which resource is a configuration concern, not a packaging concern.
+- **Profile-based adapter selection.** How a deployment profile chooses which adapter backs which resource is a configuration concern, not a packaging concern.
 
 ## Consequences
 
@@ -198,49 +207,50 @@ The return type is identical. The topo registration is identical. The trail's `r
 
 - **Core packages become cleaner contracts.** `@ontrails/store` owns the store
   contract. `@ontrails/http` owns the route projection contract. Extracted
-  integrations stop expanding those packages' dependency and release scope.
-- **Built-in backends stay discoverable.** A developer can start with `@ontrails/store/jsonfile` without learning the external connector catalog first.
-- **Independent release cadence.** Extracted integrations version and publish
+  adapters stop expanding those packages' dependency and release scope.
+- **Built-in backends stay discoverable.** A developer can start with `@ontrails/store/jsonfile` without learning the external adapter catalog first.
+- **Independent release cadence.** Extracted adapters version and publish
   independently. A Hono or Drizzle update does not block a contract change.
 - **Runtime adapters can stack.** Packages such as `@ontrails/vite` can compose
   above an extracted surface without inventing a second projection model.
-- **Clear dependency direction.** The one-way arrow from extracted integrations
+- **Clear dependency direction.** The one-way arrow from extracted adapters
   to core contracts is enforceable at the workspace level.
 
 ### Tradeoffs
 
-- **Migration cost.** Existing imports of extracted integrations must change.
+- **Migration cost.** Existing imports of extracted adapters must change.
   This is mechanical but repo-wide.
-- **More packages to maintain.** Each extracted integration is a workspace
+- **More packages to maintain.** Each extracted adapter is a workspace
   package with its own `package.json`, build config, and test suite.
 - **The package taxonomy is less mechanical.** There is no single prefix that
-  identifies every extracted integration. The payoff is that package names are
+  identifies every extracted adapter. The payoff is that package names are
   clearer, but the model must be explained in docs.
 
 ## Non-decisions
 
-- **Whether `connector()` becomes a framework primitive.** Platform connectors with shared lifecycle might benefit from framework-level support, but the bar for new primitives is high[^2]. This ADR extracts connectors without deciding their runtime shape.
-- **How trails subpaths work on connectors.** Connectors that contribute trails
+- **Whether `adapter()` becomes a framework primitive.** Platform adapters with shared lifecycle might benefit from framework-level support, but the bar for new primitives is high[^2]. This ADR extracts adapters without deciding their runtime shape.
+- **How trails subpaths work on adapters.** Adapters that contribute trails
   (health checks, platform-optimized operations) may export them at
-  `@ontrails/<connector>/trails`. The design depends on
+  `@ontrails/<adapter>/trails`. The design depends on
   [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md)
   and the `deriveTrail()` helper.
-- **Connector lifecycle hooks.** How connectors report readiness, perform health checks, and handle graceful shutdown. Resource bundling is addressed by [ADR: Resource Bundles](drafts/20260409-resource-bundles.md) (draft); lifecycle hooks remain deferred.
+- **Adapter lifecycle hooks.** How adapters report readiness, perform health checks, and handle graceful shutdown. Resource bundling is addressed by [ADR: Resource Bundles](drafts/20260409-resource-bundles.md) (draft); lifecycle hooks remain deferred.
 
 ## References
 
-- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the `resource()` primitive that connectors produce and trails consume
-- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store contract that connectors bind to concrete backends
+- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the `resource()` primitive that adapters produce and trails consume
+- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store contract that adapters bind to concrete backends
 - [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](0022-drizzle-store-connector.md) — the first extracted store binding that motivated the packaging model
-- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the naming heuristic that now favors clear owned-integration names over prefix magic
+- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the naming heuristic that now favors clear owned-adapter names over prefix magic
 - [ADR-0035: Surface APIs Render the Graph](0035-surface-apis-render-the-graph.md) — the surface composition ladder that extracted runtime adapters build on
-- [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md) — upstream of the `/trails` subpath design on connectors
+- [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md) — upstream of the `/trails` subpath design on adapters
 - [ADR-0031: Backend-Agnostic Store Schemas](0031-backend-agnostic-store-schemas.md) — the store-kind model that makes first-party backends meaningful
-- [ADR: Resource Bundles](drafts/20260409-resource-bundles.md) (draft) — the bundling mechanism for connector and pack resources
+- [ADR: Resource Bundles](drafts/20260409-resource-bundles.md) (draft) — the bundling mechanism for adapter and pack resources
 
 ### Amendment log
 
 - 2026-04-16: In-place vocabulary update per ADR-0035 Cutover 3 — title updated to drop `with-*` prefix convention, naming rules revised for extracted connectors, migration table and composition layer table aligned with surface API grammar.
+- 2026-05-08: Connector-to-adapter taxonomy cutover — `adapter` becomes the canonical public package category, `integration` is retained only as colloquial prose, `facet` is reserved for projection slices, and the historical `connectors/` workspace root is superseded by `adapters/`.
 
 [^1]: [ADR-0009: First-Class Resources](0009-first-class-resources.md)
 [^2]: See the evaluation hierarchy in [Tenets: Primitives](../tenets.md#the-bar-for-new-primitives)

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -796,7 +796,7 @@
           "fromPath": "docs/adr/0011-schema-driven-config.md"
         },
         {
-          "context": "- [ADR-0009: Resources as a First-Class Primitive](0009-first-class-resources.md) — auth connector is a service; auth layer consumes it via `resource.from(ctx)`",
+          "context": "- [ADR-0009: Resources as a First-Class Primitive](0009-first-class-resources.md) — auth adapter is a resource; auth layer consumes it via `resource.from(ctx)`",
           "from": "0012",
           "fromPath": "docs/adr/0012-connector-agnostic-permits.md"
         },
@@ -826,7 +826,7 @@
           "fromPath": "docs/adr/0023-simplifying-the-trails-lexicon.md"
         },
         {
-          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the `resource()` primitive that connectors produce and trails consume",
+          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md) — the `resource()` primitive that adapters produce and trails consume",
           "from": "0029",
           "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
         },
@@ -969,8 +969,8 @@
       "slug": "connector-agnostic-permits",
       "status": "accepted",
       "superseded_by": null,
-      "title": "Connector-Agnostic Permits",
-      "updated": "2026-04-02"
+      "title": "Adapter-Agnostic Permits",
+      "updated": "2026-05-08"
     },
     {
       "created": "2026-03-30",
@@ -1184,7 +1184,7 @@
           "fromPath": "docs/adr/0022-drizzle-store-connector.md"
         },
         {
-          "context": "- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store contract that connectors bind to concrete backends",
+          "context": "- [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — the store contract that adapters bind to concrete backends",
           "from": "0029",
           "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
         },
@@ -1477,7 +1477,7 @@
           "fromPath": "docs/adr/0013-tracing.md"
         },
         {
-          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the naming heuristic that now favors clear owned-integration names over prefix magic",
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the naming heuristic that now favors clear owned-adapter names over prefix magic",
           "from": "0029",
           "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
         },
@@ -1787,8 +1787,8 @@
       "slug": "connector-extraction-and-the-with-packaging-model",
       "status": "accepted",
       "superseded_by": null,
-      "title": "Connector Extraction and Composition Around Core Contracts",
-      "updated": "2026-04-16"
+      "title": "Adapter Extraction and Composition Around Core Contracts",
+      "updated": "2026-05-08"
     },
     {
       "created": "2026-04-09",

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -140,7 +140,7 @@
       ],
       "inbound": [
         {
-          "context": "- **Defining the connector lifecycle contract.** How a connector declares what it bridges, what lifecycle hooks it supports, and how it reports health — that's a separate decision. This ADR moves the ",
+          "context": "- **Defining the adapter lifecycle contract.** How an adapter declares what it bridges, what lifecycle hooks it supports, and how it reports health — that's a separate decision. This ADR moves package",
           "from": "0029",
           "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
         },

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -338,7 +338,7 @@ await surface(graph);
 
 ### `store`
 
-A persistence declaration. `store(definition)` declares what is persisted for a domain object — schema, identity, generated fields, relationships, and fixtures — without choosing how that persistence is realized. The store itself is connector-agnostic. A connector binding interprets it for a specific backend and persistence shape.
+A persistence declaration. `store(definition)` declares what is persisted for a domain object — schema, identity, generated fields, relationships, and fixtures — without choosing how that persistence is realized. The store itself is backend-agnostic. An adapter binding interprets it for a specific backend and persistence shape.
 
 ```typescript
 const db = store({
@@ -355,9 +355,9 @@ A store is infrastructure declared as data. A resource is how that infrastructur
 
 ### `kind`
 
-The plain word for the persistence shape a connector binds a store through. Current examples include `tabular`, `document`, `file`, `kv`, and `cache`.
+The plain word for the persistence shape an adapter binds a store through. Current examples include `tabular`, `document`, `file`, `kv`, and `cache`.
 
-The store declaration stays kind-agnostic. The connector or binding chooses the kind and interprets the store schema accordingly.
+The store declaration stays kind-agnostic. The adapter or binding chooses the kind and interprets the store schema accordingly.
 
 ### `projection`
 
@@ -377,8 +377,9 @@ projections; developers author the source.
 | `meta` | Annotations for tooling and filtering |
 | `Result` | Ok/Err return type |
 | `error` | Error types |
-| `adapter` | A thinner runtime-specific layer that composes on top of an existing surface or connector |
-| `connector` | Integration-specific bridge to third-party systems (e.g., Hono, Commander, Drizzle) |
+| `adapter` | Canonical public category for a package or subpath that bridges Trails to a named external library, framework, tool, platform, format, or ecosystem |
+| `facet` | Projection slice of authored contract or surface data, such as a surface facet or schema facet; not a package category |
+| `integration (colloquial)` | Ordinary English for places Trails integrates with an external system; not a public taxonomy category |
 | `logger` / `logging` | Structured logging — framework provides the interface; developers bring their own |
 | `health` | Health checks |
 | `derive*` | Mechanically project surface definitions from a graph |
@@ -407,6 +408,7 @@ These are directional. They should not be reused for unrelated concepts.
 | `depot` | Registry or distribution point for packs and shared assets |
 | `dispatch` | Activation/source fan-out from a source to consuming trails; not the direct execution helper |
 | `trailhead` | Historical boundary term retired from active user-facing vocabulary. Use `surface` in docs, examples, and public APIs. |
+| `connector` | Historical package-boundary term retired from active user-facing taxonomy. Use `adapter` in docs, examples, and public APIs. |
 | `_draft.` | Reserved ID prefix for draft state. Trails, signals, and other primitives with `_draft.` IDs are visible in source but excluded from the resolved graph, established surfaces, and graph exports. Draft state is visible debt — it must never leak into established outputs. See ADR-0021. |
 
 ## Grammar

--- a/docs/migration/connector-to-adapter.md
+++ b/docs/migration/connector-to-adapter.md
@@ -1,0 +1,130 @@
+# Connector To Adapter Migration Guide
+
+How to migrate consumers from the retired `connector` vocabulary to the
+canonical `adapter` vocabulary. This is a clean cut: Trails does not ship
+compatibility aliases for connector-era public names, source paths, or package
+subpaths.
+
+This guide is temporary. Deprecate it after first-party Trails projects and
+downstream consumers have migrated.
+
+## Overview
+
+`adapter` is now the public package and subpath category for code that bridges
+Trails to a named external library, framework, tool, platform, format, or
+ecosystem. Historical prose may still mention `connector`, but current APIs,
+generated examples, package docs, and workspace paths use `adapter`.
+
+`integration` remains ordinary English, not a taxonomy bucket. `facet` remains
+reserved for projection slices of authored contracts or surfaces.
+
+## Rename Map
+
+| Old | New | Action |
+| --- | --- | --- |
+| `AuthConnector` | `AuthAdapter` | Update auth adapter implementations and imports from `@ontrails/permits`. |
+| `authConnectorSchema` | `authAdapterSchema` | Update schema imports and tests. |
+| `JwtConnectorOptions` | `JwtAdapterOptions` | Update JWT option type imports from `@ontrails/permits/jwt`. |
+| `createJwtConnector(options)` | `createJwtAdapter(options)` | Update JWT auth factory imports from `@ontrails/permits/jwt`. |
+| auth resource config `{ connector: 'jwt' \| 'none' }` | `{ adapter: 'jwt' \| 'none' }` | Rename the discriminant in auth resource config and test fixtures. |
+| `createOtelConnector(options?)` | `createOtelAdapter(options?)` | Update OTel trace sink factory imports from `@ontrails/tracing/otel` or `@ontrails/tracing`. |
+| `OtelConnectorOptions` | `OtelAdapterOptions` | Update OTel option type imports. |
+| workspace root `connectors/` | `adapters/` | Update local workspace paths and regenerate `bun.lock` with `bun install`. |
+| `@ontrails/cli/commander` | `@ontrails/commander` | Move active Commander consumers to the dedicated adapter package once it exists. |
+| public taxonomy term `connector` | `adapter` | Rewrite current-facing package, subpath, and API prose. Keep historical, migration, and changelog mentions when clearly marked. |
+
+Built-in adapter subpaths remain intentionally scoped to their owning package
+when they are dependency-light:
+
+- `@ontrails/permits/jwt` remains the JWT auth adapter subpath.
+- `@ontrails/tracing/otel` remains the OpenTelemetry trace adapter subpath.
+
+Do not extract `@ontrails/jwt` or `@ontrails/otel` as part of this migration.
+
+## Code Imports
+
+Prefer direct imports of the canonical names:
+
+```typescript
+import type { AuthAdapter } from '@ontrails/permits';
+import { authAdapterSchema } from '@ontrails/permits';
+import { createJwtAdapter } from '@ontrails/permits/jwt';
+import type { JwtAdapterOptions } from '@ontrails/permits/jwt';
+import { createOtelAdapter } from '@ontrails/tracing/otel';
+import type { OtelAdapterOptions } from '@ontrails/tracing/otel';
+```
+
+Remove imports of `AuthConnector`, `authConnectorSchema`,
+`JwtConnectorOptions`, `createJwtConnector`, `OtelConnectorOptions`, and
+`createOtelConnector`.
+
+## Auth Resource Config
+
+Rename the auth resource discriminant:
+
+```diff
+ authResource.create({
+-  connector: 'jwt',
++  adapter: 'jwt',
+   secret: process.env.JWT_SECRET,
+ });
+```
+
+The same rename applies to the no-auth shape:
+
+```diff
+-{ connector: 'none' }
++{ adapter: 'none' }
+```
+
+## Workspace Paths
+
+The workspace-root package directory moves from `connectors/` to `adapters/`.
+After moving the directories and updating the root workspace glob, regenerate
+the lockfile:
+
+```bash
+bun install
+```
+
+Do not hand-edit `bun.lock`; the lockfile should record path-only workspace
+changes without version drift.
+
+## Commander Adapter
+
+The CLI contract model stays in `@ontrails/cli`. Commander-specific runtime
+materialization moves to the dedicated `@ontrails/commander` adapter package by
+direct cutover:
+
+```diff
+-import { surface } from '@ontrails/cli/commander';
++import { surface } from '@ontrails/commander';
+```
+
+There is no long-lived `@ontrails/cli/commander` compatibility subpath after
+the cutover.
+
+## Documentation And History
+
+Treat remaining `connector` mentions by role:
+
+- **Substitution-class:** current-facing package/API/docs prose that should say
+  `adapter`, `backend`, or `surface`.
+- **Mention-class:** migration notes, quotes, or explicitly historical context.
+- **Accepted-history:** ADR slugs, changelogs, and release notes that record the
+  old term as it existed when written.
+
+Do not run a broad automatic prose rewrite. Some sentences need `adapter`, some
+need `backend`, some need `surface`, and some should remain historical.
+
+## Changesets And Publishing
+
+Changesets in this cutover are version and changelog metadata only. Package
+publication later uses the repo's Bun publish flow:
+
+```bash
+bun run publish:check
+bun run publish:packages
+```
+
+Do not use `changeset publish` or `npm publish` for this migration.


### PR DESCRIPTION
## Context

This starts the adapter taxonomy cutover by retiring `connector` as public
taxonomy while preserving the historical package-boundary doctrine that older
ADRs recorded.

## What Changed

- Updated ADR-0012 and ADR-0029 to use adapter-era language.
- Updated the lexicon so `adapter` is the public category and `connector` is
  reserved for historical/mention-class context.
- Added `docs/migration/connector-to-adapter.md` with the full rename map.
- Regenerated ADR decision maps.

## Verification

- `bun scripts/adr.ts map`
- `bun scripts/adr.ts check`
- `bun run format:check`
- `bun run lint`

## Risks / Rollout

Docs-only doctrine change. The main risk is future wording drift, which later
branches in this stack guard with repo-local vocabulary checks.

## Release Metadata

No changeset: this branch only changes repo docs and ADR metadata, not
publishable package contents.

Closes: TRL-660
