### PR TITLE
feat(tracing)!: rename OTel connector APIs to adapters

### DIFF
--- a/.changeset/tracing-otel-connector-to-adapter.md
+++ b/.changeset/tracing-otel-connector-to-adapter.md
@@ -1,0 +1,11 @@
+---
+"@ontrails/tracing": major
+---
+
+BREAKING: rename the OpenTelemetry tracing connector API to adapter vocabulary.
+
+- `createOtelConnector` -> `createOtelAdapter`
+- `OtelConnectorOptions` -> `OtelAdapterOptions`
+
+The `@ontrails/tracing/otel` subpath is unchanged. The internal OTel source path
+moves from `src/connectors/otel.ts` to `src/adapters/otel.ts`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -459,7 +459,7 @@ writeSignalTraceRecord(ctx, name, attrs, status?, category?) // write a signal l
 createMemorySink(options?)           // bounded in-memory sink for testing
 createBoundedMemorySink(options?)    // explicit alias for createMemorySink
 createDevStore(options?)             // SQLite-backed persistent sink for development
-createOtelConnector(options?)        // OpenTelemetry span exporter
+createOtelAdapter(options?)          // OpenTelemetry span exporter
 toTraceStore(store)                  // read-only TraceStore view that does not own the writable connection
 countTraceRecords(db), previewTraceCleanup(db, options?), applyTraceCleanup(db, options?)
 withTraceStoreDb(options, run), ensureTraceSchema(db)

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -14,7 +14,7 @@
 
 **Auth and permit model (`@ontrails/permits`).** The `permit` field on trail specs declares scope requirements. Surface-specific extraction resolves credentials, `AuthAdapter` turns them into a `Permit` (identity, scopes, roles), and `executeTrail` enforces scope intrinsically before the implementation runs. Includes JWT adapter, governance rules (`validatePermits`), and test helpers through `@ontrails/permits/testing`.
 
-**Tracing (intrinsic in `@ontrails/core`, sinks in `@ontrails/tracing`).** With a real sink installed, `executeTrail` produces a `TraceRecord` automatically, `ctx.trace(label, fn)` records nested spans inside a trail blaze, and activation materializers record `activation.*` boundary entries. With `NOOP_SINK`, the tracing path short-circuits without layer attachment or per-trail wiring. Pluggable sinks register via `registerTraceSink()`: bounded `createMemorySink` for testing, `createDevStore` for local development, `createOtelConnector` for production OpenTelemetry export. Sampling configuration controls recording volume.
+**Tracing (intrinsic in `@ontrails/core`, sinks in `@ontrails/tracing`).** With a real sink installed, `executeTrail` produces a `TraceRecord` automatically, `ctx.trace(label, fn)` records nested spans inside a trail blaze, and activation materializers record `activation.*` boundary entries. With `NOOP_SINK`, the tracing path short-circuits without layer attachment or per-trail wiring. Pluggable sinks register via `registerTraceSink()`: bounded `createMemorySink` for testing, `createDevStore` for local development, `createOtelAdapter` for production OpenTelemetry export. Sampling configuration controls recording volume.
 
 ## Mid-term (v1.3+)
 

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -15,7 +15,7 @@ const sink = createMemorySink({ maxRecords: 1000 });
 registerTraceSink(sink);
 ```
 
-Sinks receive completed `TraceRecord` records. The default sink is `NOOP_SINK` — tracing APIs still work without configuration, but root/span/signal/activation record allocation is skipped until you register a real sink. Use a bounded memory sink for testing and local trace rendering, a dev store for local development, or an OTel connector to forward to your collector. Use `registerTraceSink(NOOP_SINK)` or `clearTraceSink()` to switch back to the silent baseline.
+Sinks receive completed `TraceRecord` records. The default sink is `NOOP_SINK` — tracing APIs still work without configuration, but root/span/signal/activation record allocation is skipped until you register a real sink. Use a bounded memory sink for testing and local trace rendering, a dev store for local development, or an OTel adapter to forward to your collector. Use `registerTraceSink(NOOP_SINK)` or `clearTraceSink()` to switch back to the silent baseline.
 
 Signal fan-out records use lexicon-aligned names: `signal.fired`, `signal.invalid`, `signal.handler.invoked`, `signal.handler.completed`, and `signal.handler.failed`. Signal record attrs carry IDs and redacted payload summaries, never raw payloads by default.
 
@@ -131,14 +131,14 @@ The dev store uses WAL mode and prunes automatically. Use `toTraceStore(store)`
 only when you need a read-only view for consumers that must not own the
 underlying writable connection.
 
-### OpenTelemetry connector
+### OpenTelemetry adapter
 
 Export traces to any OTel-compatible collector:
 
 ```typescript
-import { createOtelConnector, registerTraceSink } from '@ontrails/tracing';
+import { createOtelAdapter, registerTraceSink } from '@ontrails/tracing';
 
-const sink = createOtelConnector({
+const sink = createOtelAdapter({
   exporter: async (spans) => {
     await myOtelCollector.send(spans);
   },
@@ -147,7 +147,7 @@ const sink = createOtelConnector({
 registerTraceSink(sink);
 ```
 
-The connector translates `TraceRecord` records to OTel spans with Trails-namespaced attributes (`trails.trail.id`, `trails.intent`, `trails.surface`, `trails.permit.id`).
+The adapter translates `TraceRecord` records to OTel spans with Trails-namespaced attributes (`trails.trail.id`, `trails.intent`, `trails.surface`, `trails.permit.id`).
 
 ## Sampling
 

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./otel": "./src/connectors/otel.ts",
+    "./otel": "./src/adapters/otel.ts",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/tracing/src/__tests__/otel-adapter.test.ts
+++ b/packages/tracing/src/__tests__/otel-adapter.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { TraceRecord } from '../trace-record.js';
-import { createOtelConnector } from '../connectors/otel.js';
-import type { OtelSpan } from '../connectors/otel.js';
+import { createOtelAdapter } from '../adapters/otel.js';
+import type { OtelSpan } from '../adapters/otel.js';
 
 /** Build a minimal TraceRecord for testing with sensible defaults. */
 const makeRecord = (overrides: Partial<TraceRecord> = {}): TraceRecord => ({
@@ -18,17 +18,17 @@ const makeRecord = (overrides: Partial<TraceRecord> = {}): TraceRecord => ({
   ...overrides,
 });
 
-describe('otelConnector', () => {
+describe('otelAdapter', () => {
   describe('attribute mapping', () => {
     test('maps trailId to attributes["trails.trail.id"]', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(makeRecord({ trailId: 'greet' }));
+      await adapter.write(makeRecord({ trailId: 'greet' }));
 
       expect(spans).toHaveLength(1);
       expect(spans[0]?.attributes['trails.trail.id']).toBe('greet');
@@ -36,39 +36,39 @@ describe('otelConnector', () => {
 
     test('maps intent to attributes["trails.intent"]', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(makeRecord({ intent: 'write' }));
+      await adapter.write(makeRecord({ intent: 'write' }));
 
       expect(spans[0]?.attributes['trails.intent']).toBe('write');
     });
 
     test('maps surface to attributes["trails.surface"]', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(makeRecord({ surface: 'mcp' }));
+      await adapter.write(makeRecord({ surface: 'mcp' }));
 
       expect(spans[0]?.attributes['trails.surface']).toBe('mcp');
     });
 
     test('maps permit.id to attributes["trails.permit.id"]', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(
+      await adapter.write(
         makeRecord({ permit: { id: 'p-1', tenantId: 't-1' } })
       );
 
@@ -78,13 +78,13 @@ describe('otelConnector', () => {
 
     test('omits undefined attributes', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(
+      await adapter.write(
         makeRecord({
           intent: undefined,
           surface: undefined,
@@ -101,13 +101,13 @@ describe('otelConnector', () => {
 
     test('forwards OTel-safe custom attributes', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(
+      await adapter.write(
         makeRecord({
           attrs: {
             'db.operation': 'select',
@@ -128,39 +128,39 @@ describe('otelConnector', () => {
   describe('status mapping', () => {
     test('maps status "ok" to OTel "OK"', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(makeRecord({ status: 'ok' }));
+      await adapter.write(makeRecord({ status: 'ok' }));
 
       expect(spans[0]?.status).toBe('OK');
     });
 
     test('maps status "err" to OTel "ERROR"', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(makeRecord({ status: 'err' }));
+      await adapter.write(makeRecord({ status: 'err' }));
 
       expect(spans[0]?.status).toBe('ERROR');
     });
 
     test('maps status "cancelled" to OTel "UNSET"', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(makeRecord({ status: 'cancelled' }));
+      await adapter.write(makeRecord({ status: 'cancelled' }));
 
       expect(spans[0]?.status).toBe('UNSET');
     });
@@ -169,26 +169,26 @@ describe('otelConnector', () => {
   describe('kind mapping', () => {
     test('root trail (no parentId) gets kind "SERVER"', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(makeRecord({ parentId: undefined }));
+      await adapter.write(makeRecord({ parentId: undefined }));
 
       expect(spans[0]?.kind).toBe('SERVER');
     });
 
     test('child trail (has parentId) gets kind "INTERNAL"', async () => {
       const spans: OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           spans.push(...s);
         },
       });
 
-      await connector.write(makeRecord({ parentId: 'parent-1' }));
+      await adapter.write(makeRecord({ parentId: 'parent-1' }));
 
       expect(spans[0]?.kind).toBe('INTERNAL');
     });
@@ -197,13 +197,13 @@ describe('otelConnector', () => {
   describe('exporter integration', () => {
     test('calls exporter with translated spans', async () => {
       let exportedSpans: readonly OtelSpan[] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: (s) => {
           exportedSpans = s;
         },
       });
 
-      await connector.write(makeRecord({ id: 'span-42', traceId: 'trace-42' }));
+      await adapter.write(makeRecord({ id: 'span-42', traceId: 'trace-42' }));
 
       expect(exportedSpans).toHaveLength(1);
       expect(exportedSpans[0]?.spanId).toBe('span-42');
@@ -214,20 +214,20 @@ describe('otelConnector', () => {
   describe('flush', () => {
     test('sends buffered spans that have not yet reached batchSize', async () => {
       const exported: OtelSpan[][] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         batchSize: 5,
         exporter: (s) => {
           exported.push([...s]);
         },
       });
 
-      await connector.write(makeRecord({ id: 'span-a' }));
-      await connector.write(makeRecord({ id: 'span-b' }));
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await adapter.write(makeRecord({ id: 'span-b' }));
 
       // Not yet exported because batchSize is 5
       expect(exported).toHaveLength(0);
 
-      await connector.flush();
+      await adapter.flush();
 
       expect(exported).toHaveLength(1);
       expect(exported[0]).toHaveLength(2);
@@ -237,20 +237,20 @@ describe('otelConnector', () => {
 
     test('auto-flushes when batchSize is reached', async () => {
       const exported: OtelSpan[][] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         batchSize: 3,
         exporter: (s) => {
           exported.push([...s]);
         },
       });
 
-      await connector.write(makeRecord({ id: 'span-a' }));
-      await connector.write(makeRecord({ id: 'span-b' }));
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await adapter.write(makeRecord({ id: 'span-b' }));
 
       // Two writes — still buffered
       expect(exported).toHaveLength(0);
 
-      await connector.write(makeRecord({ id: 'span-c' }));
+      await adapter.write(makeRecord({ id: 'span-c' }));
 
       // Third write reaches batchSize=3, exporter must have been called
       expect(exported).toHaveLength(1);
@@ -260,7 +260,7 @@ describe('otelConnector', () => {
     test('rethrows exporter failures and restores the buffer', async () => {
       let shouldFail = true;
       const exported: OtelSpan[][] = [];
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         batchSize: 2,
         exporter: (s) => {
           // eslint-disable-next-line jest/no-conditional-in-test -- testing retry behavior requires toggling exporter success
@@ -274,29 +274,29 @@ describe('otelConnector', () => {
         },
       });
 
-      await connector.write(makeRecord({ id: 'span-a' }));
-      await expect(
-        connector.write(makeRecord({ id: 'span-b' }))
-      ).rejects.toThrow('exporter down');
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await expect(adapter.write(makeRecord({ id: 'span-b' }))).rejects.toThrow(
+        'exporter down'
+      );
 
       // First flush failed — spans should still be buffered
       expect(exported).toHaveLength(0);
 
       // Manual flush retries and succeeds
-      await connector.flush();
+      await adapter.flush();
       expect(exported).toHaveLength(1);
       expect(exported[0]).toHaveLength(2);
     });
 
     test('is a no-op when buffer is empty', async () => {
       let called = false;
-      const connector = createOtelConnector({
+      const adapter = createOtelAdapter({
         exporter: () => {
           called = true;
         },
       });
 
-      await connector.flush();
+      await adapter.flush();
 
       expect(called).toBe(false);
     });

--- a/packages/tracing/src/adapters/otel.ts
+++ b/packages/tracing/src/adapters/otel.ts
@@ -1,6 +1,6 @@
 import type { TraceRecord, TraceSink } from '@ontrails/core';
 
-/** OTel span representation produced by the connector. */
+/** OTel span representation produced by the adapter. */
 export interface OtelSpan {
   readonly traceId: string;
   readonly spanId: string;
@@ -16,8 +16,8 @@ export interface OtelSpan {
 /** Callback that receives translated OTel spans. */
 export type OtelExporter = (spans: readonly OtelSpan[]) => void | Promise<void>;
 
-/** Configuration for the OTel connector. */
-export interface OtelConnectorOptions {
+/** Configuration for the OTel adapter. */
+export interface OtelAdapterOptions {
   readonly exporter: OtelExporter;
   readonly batchSize?: number;
 }
@@ -90,16 +90,14 @@ export interface OtelSink extends TraceSink {
 /**
  * Create a TraceSink that translates Tracing to OTel spans.
  *
- * The connector maps Trails-native fields to OpenTelemetry span attributes
+ * The adapter maps Trails-native fields to OpenTelemetry span attributes
  * under a `trails.*` namespace. Pass any OTel-compatible exporter callback
  * to forward spans to your collector.
  *
  * Translates and exports spans on each write. Call `flush()` on shutdown
  * to send any remaining buffered spans.
  */
-export const createOtelConnector = (
-  options: OtelConnectorOptions
-): OtelSink => {
+export const createOtelAdapter = (options: OtelAdapterOptions): OtelSink => {
   const batchSize = options.batchSize ?? 1;
   const buffer: OtelSpan[] = [];
 

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -75,11 +75,11 @@ export {
 } from './internal/dev-state.js';
 export type { TraceCleanupReport } from './internal/dev-state.js';
 
-// OTel connector
+// OTel adapter
 export {
-  createOtelConnector,
-  type OtelConnectorOptions,
+  createOtelAdapter,
+  type OtelAdapterOptions,
   type OtelExporter,
   type OtelSink,
   type OtelSpan,
-} from './connectors/otel.js';
+} from './adapters/otel.js';

--- a/scripts/check-readme-snippets.ts
+++ b/scripts/check-readme-snippets.ts
@@ -74,7 +74,7 @@ declare module '@ontrails/tracing' {
     readonly path?: string;
   }): unknown;
   export function createMemorySink(options?: MemorySinkOptions): MemorySink;
-  export function createOtelConnector(options: {
+  export function createOtelAdapter(options: {
     readonly batchSize?: number;
     readonly exporter: (spans: unknown) => Promise<void>;
   }): unknown;


### PR DESCRIPTION
## Context

This applies the adapter taxonomy to the tracing OpenTelemetry integration
while keeping the existing built-in `@ontrails/tracing/otel` subpath.

## What Changed

- Renamed `createOtelConnector()` to `createOtelAdapter()`.
- Renamed `OtelConnectorOptions` to `OtelAdapterOptions`.
- Moved tracing OTel source from `src/connectors/otel.ts` to
  `src/adapters/otel.ts`.
- Updated README snippets, exports, tests, and package metadata.

## Verification

- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run build`
- `bun run format:check`
- `bun run check`
- `bun scripts/adr.ts map`
- `bun scripts/adr.ts check`

## Risks / Rollout

Breaking beta API rename. `OtelSpan`, `OtelExporter`, `OtelSink`, and the
`@ontrails/tracing/otel` public subpath stay unchanged.

## Release Metadata

Changeset: `.changeset/tracing-otel-connector-to-adapter.md`.

Closes: TRL-662
