### PR TITLE
docs: finalize adapter taxonomy docs

### DIFF
--- a/.changeset/taxonomy-docs-pass.md
+++ b/.changeset/taxonomy-docs-pass.md
@@ -1,0 +1,13 @@
+---
+"@ontrails/cli": patch
+"@ontrails/config": patch
+"@ontrails/drizzle": patch
+"@ontrails/hono": patch
+"@ontrails/http": patch
+"@ontrails/logging": patch
+"@ontrails/mcp": patch
+"@ontrails/observe": patch
+"@ontrails/store": patch
+---
+
+Refresh published package README taxonomy to use adapter language instead of retired connector vocabulary.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ const greet = trail('greet', {
 // 2. Collect into topo
 const graph = topo('myapp', { greet });
 
-// 3. Open surfaces in any connector
+// 3. Open surfaces with any adapter
 await cliSurface(graph);      // CLI
 // await mcpSurface(graph);   // MCP — same trails, same run function
 ```
@@ -140,16 +140,16 @@ $ myapp greet --name World
 | Package | What it does |
 |---------|-------------|
 | [`@ontrails/core`](./packages/core) | Result, errors, trail/signal/contour/topo, validation, schema derivation |
-| [`@ontrails/cli`](./packages/cli) | CLI surface — flag derivation, output formatting, Commander connector |
+| [`@ontrails/cli`](./packages/cli) | CLI surface — flag derivation, output formatting, Commander adapter |
 | [`@ontrails/mcp`](./packages/mcp) | MCP surface — tool generation, annotations, progress bridge |
 | [`@ontrails/http`](./packages/http) | HTTP surface model — route derivation, verb mapping, error responses |
-| [`@ontrails/hono`](./adapters/hono) | Hono connector that opens a topo on the HTTP surface |
+| [`@ontrails/hono`](./adapters/hono) | Hono adapter that opens a topo on the HTTP surface |
 | [`@ontrails/store`](./packages/store) | Schema-derived store definitions, typed accessors, Drizzle bindings, read-only stores |
 | [`@ontrails/testing`](./packages/testing) | `testAll()`, `testTrail()`, `testCrosses()`, contract testing, surface harnesses |
 | [`@ontrails/topographer`](./packages/topographer) | Surface maps, semantic diffing, lock files for CI governance |
 | [`@ontrails/tracing`](./packages/tracing) | Execution recording, `trails.db` dev-state storage, telemetry helpers |
 | [`@ontrails/warden`](./packages/warden) | AST-based convention rules, drift detection, CI formatters |
-| [`@ontrails/logging`](./packages/logging) | Structured logging — sinks, formatters, LogTape connector |
+| [`@ontrails/logging`](./packages/logging) | Structured logging — sinks, formatters, LogTape adapter |
 
 ## Documentation
 

--- a/adapters/drizzle/README.md
+++ b/adapters/drizzle/README.md
@@ -1,6 +1,6 @@
 # @ontrails/drizzle
 
-Drizzle connector for Trails stores. Use this package to bind a connector-agnostic `store(...)` definition from `@ontrails/store` to a concrete Drizzle runtime.
+Drizzle adapter for Trails stores. Use this package to bind a backend-agnostic `store(...)` definition from `@ontrails/store` to a concrete Drizzle runtime.
 
 ## Usage
 

--- a/adapters/hono/README.md
+++ b/adapters/hono/README.md
@@ -1,6 +1,6 @@
 # @ontrails/hono
 
-Hono surface connector for Trails. Use this package when you want to serve a topo over HTTP with Hono while keeping `@ontrails/http` focused on framework-agnostic route building.
+Hono surface adapter for Trails. Use this package when you want to serve a topo over HTTP with Hono while keeping `@ontrails/http` focused on framework-agnostic route building.
 
 ## Usage
 

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -495,7 +495,7 @@
           "fromPath": "docs/adr/0039-reactive-trail-activation.md"
         },
         {
-          "context": "- **[ADR-0005: Framework-Agnostic HTTP Route Model](./adr/0005-framework-agnostic-http-route-model.md)** — `HttpRoute[]` with thin connector subpaths",
+          "context": "- **[ADR-0005: Framework-Agnostic HTTP Route Model](./adr/0005-framework-agnostic-http-route-model.md)** — `HttpRoute[]` with thin adapter packages",
           "from": "index",
           "fromPath": "docs/index.md"
         }
@@ -958,7 +958,7 @@
           "fromPath": "docs/adr/0043-layer-evolution.md"
         },
         {
-          "context": "- **[ADR-0012: Connector-Agnostic Permits](./adr/0012-connector-agnostic-permits.md)** — Permission model independent of surface",
+          "context": "- **[ADR-0012: Adapter-Agnostic Permits](./adr/0012-connector-agnostic-permits.md)** — Permission model independent of surface",
           "from": "index",
           "fromPath": "docs/index.md"
         }
@@ -1219,7 +1219,7 @@
           "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
         },
         {
-          "context": "- **[ADR-0016: Schema-Derived Persistence](./adr/0016-schema-derived-persistence.md)** — `store()` declaration, connector binding, fixtures",
+          "context": "- **[ADR-0016: Schema-Derived Persistence](./adr/0016-schema-derived-persistence.md)** — `store()` declaration, adapter binding, fixtures",
           "from": "index",
           "fromPath": "docs/index.md"
         }
@@ -1448,7 +1448,7 @@
           "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
         },
         {
-          "context": "- **[ADR-0022: Drizzle Store Connector](./adr/0022-drizzle-store-connector.md)** — Drizzle binds schema-derived stores to SQLite",
+          "context": "- **[ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](./adr/0022-drizzle-store-connector.md)** — Drizzle binds schema-derived stores to SQLite",
           "from": "index",
           "fromPath": "docs/index.md"
         }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -237,7 +237,7 @@ CreateTopoSnapshotInput, ListTopoSnapshotsOptions, StoredTopoExport
 ## `@ontrails/store`
 
 ```typescript
-store(tables)                      // connector-agnostic store definition
+store(tables)                      // backend-agnostic store definition
 crudOperations                     // canonical create/read/update/delete/list order
 crudAccessorExpectations           // canonical accessor methods/fallbacks per CRUD operation
 bindStoreDefinition(definition, scope) // bind derived store signals to a resource scope

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Trails uses a hexagonal architecture. Core defines ports. Everything on the edges is a connector.
+Trails uses a hexagonal architecture. Core defines ports. Everything on the edges is an adapter.
 
 ## The Hexagonal Model
 
@@ -46,11 +46,11 @@ The left side is where the world calls in -- CLI commands, MCP tool calls, HTTP 
 
 **Drift is structurally harder than alignment.** One schema, one `Result` type, one error taxonomy. You cannot have different parameter names across surfaces because there is only one schema.
 
-**Surfaces are peers.** No surface is privileged. CLI, MCP, HTTP, and WebSocket are all equal connectors reading from the same topo. CLI, MCP, and HTTP ship today; WebSocket is still planned. Adding a surface is a `surface()` call, not an architecture change.
+**Surfaces are peers.** No surface is privileged. CLI, MCP, HTTP, and WebSocket are all equal adapters reading from the same topo. CLI, MCP, and HTTP ship today; WebSocket is still planned. Adding a surface is a `surface()` call, not an architecture change.
 
 **Implementations are pure functions.** Input in, `Result` out. No `process.exit()`, no `console.log()`, no `req.headers`. The implementation does not know which surface invoked it. Authoring can be sync or async; runtime execution is normalized to one awaitable shape before layers and surfaces run.
 
-**The framework defines ports -- everything concrete is a connector.** CLI framework (Commander, yargs), logging backend (LogTape, pino), storage engine, telemetry exporter -- all pluggable. The framework never imports a concrete implementation.
+**The framework defines ports -- everything concrete is an adapter.** CLI framework (Commander, yargs), logging backend (LogTape, pino), storage engine, telemetry exporter -- all pluggable. The framework never imports a concrete implementation.
 
 **The contract is machine-readable at runtime.** The topo, survey, guide, and committed lock artifacts make the trail system queryable by agents, tooling, and CI.
 
@@ -137,32 +137,32 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 
 ### Foundation
 
-`@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, `contour()`/`trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, execution pipeline utilities including `Layer`/`composeLayers()`, generic `trails-db` helpers (`openReadTrailsDb`, `ensureSubsystemSchema`, etc.), and connector port interfaces. Persistence of the resolved topo graph (the topo-store API) lives in `@ontrails/topographer` per ADR-0042.
+`@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, `contour()`/`trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, execution pipeline utilities including `Layer`/`composeLayers()`, generic `trails-db` helpers (`openReadTrailsDb`, `ensureSubsystemSchema`, etc.), and adapter port interfaces. Persistence of the resolved topo graph (the topo-store API) lives in `@ontrails/topographer` per ADR-0042.
 
-**The test:** if you are building a surface connector or ecosystem package, you should only need `@ontrails/core`.
+**The test:** if you are building a surface adapter or ecosystem package, you should only need `@ontrails/core`.
 
-### Surface Connectors (left side)
+### Surface Adapters (left side)
 
 | Package | What it does | External dep |
 | --- | --- | --- |
 | `@ontrails/cli` | Framework-agnostic command model, flag derivation, output formatting | None beyond core |
-| `@ontrails/cli/commander` | Commander connector, `surface()` | `commander` (optional peer) |
+| `@ontrails/cli/commander` | Commander adapter, `surface()` | `commander` (optional peer) |
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `surface()` | `@modelcontextprotocol/sdk` |
 | `@ontrails/http` | HTTP routes, error mapping, and OpenAPI generation | None beyond core |
-| `@ontrails/hono` | Hono connector, `surface()` | `hono` |
+| `@ontrails/hono` | Hono adapter, `surface()` | `hono` |
 | `@ontrails/vite` | Vite middleware adapter, `vite()` | None (node:stream only) |
 
-### Infrastructure Connectors (right side)
+### Infrastructure Adapters (right side)
 
 | Package | What it does | External dep |
 | --- | --- | --- |
 | `@ontrails/config` | Config resolution, profiles, resource config schemas, diagnostics | None beyond core |
-| `@ontrails/permits` | Auth layer, permit model, JWT connector, scope enforcement | None beyond core |
-| `@ontrails/store` | Connector-agnostic schema-derived store definitions | None beyond core |
-| `@ontrails/drizzle` | Drizzle SQLite connector, typed store bindings, read-only bindings | `drizzle-orm` |
+| `@ontrails/permits` | Auth layer, permit model, JWT adapter, scope enforcement | None beyond core |
+| `@ontrails/store` | Backend-agnostic schema-derived store definitions | None beyond core |
+| `@ontrails/drizzle` | Drizzle SQLite adapter, typed store bindings, read-only bindings | `drizzle-orm` |
 | `@ontrails/tracing` | Telemetry recording, trace context, `trails.db` dev-state sinks | None beyond core |
 | `@ontrails/logging` | Structured logging, sinks, formatters | None beyond core |
-| `@ontrails/logtape` | LogTape sink connector | None (accepts any LogTape-shaped logger via a structural interface) |
+| `@ontrails/logtape` | LogTape sink adapter | None (accepts any LogTape-shaped logger via a structural interface) |
 
 ### Ecosystem
 
@@ -205,7 +205,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 apps/trails (cli/commander, http, topographer, tracing)
 ```
 
-Clean DAG. Core at the center. No cycles. Surface connectors depend only on core. Framework connectors depend on their parent package.
+Clean DAG. Core at the center. No cycles. Surface adapters depend only on core. Framework adapters depend on their parent package.
 
 ## Data Flow
 
@@ -231,7 +231,7 @@ of sibling signal sequencing.
 ```text
 CLI input ("myapp entity show --name Alpha")
   -> Commander parses args/flags
-  -> CLI connector matches to trail via CliCommand model
+  -> CLI adapter matches to trail via CliCommand model
   -> Zod validates input against trail's schema
   -> TrailContext created (requestId, logger, abortSignal, env, cwd)
   -> Declared resources resolved into ctx
@@ -246,7 +246,7 @@ CLI input ("myapp entity show --name Alpha")
 
 ```text
 MCP tool call ({ name: "myapp_entity_show", arguments: { name: "Alpha" } })
-  -> MCP connector matches to trail
+  -> MCP adapter matches to trail
   -> Zod validates input
   -> TrailContext created
   -> Declared resources resolved into ctx
@@ -272,7 +272,7 @@ The implementation is identical. Only the edges change.
 
 ### Headless Execution via `run()`
 
-`run()` is the headless path -- no surface connector needed:
+`run()` is the headless path -- no surface adapter needed:
 
 ```text
 run(topo, 'entity.show', { name: 'Alpha' }, options?)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ bunx @ontrails/trails create
 # Or install manually
 bun add @ontrails/core @ontrails/cli
 
-# Add Commander connector (for the /commander subpath)
+# Add Commander adapter (for the /commander subpath)
 bun add commander
 
 # Add MCP surface (optional)
@@ -161,7 +161,7 @@ import { graph } from './app';
 await surface(graph, { port: 3000 });
 ```
 
-Same topo. Same implementation. Different shipped surface. The HTTP connector derives routes from trail IDs and verbs from `intent`:
+Same topo. Same implementation. Different shipped surface. The HTTP adapter derives routes from trail IDs and verbs from `intent`:
 
 - `greet` becomes `GET /greet` because the trail declares `intent: 'read'`
 - Input validation still comes from the same Zod schema

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -4,7 +4,7 @@
 
 ## Shipped
 
-**HTTP surface (`@ontrails/http`).** The third surface connector. `intent: 'read'` maps to GET, mutations to POST, `'destroy'` to DELETE. Route paths derived from trail IDs. Error taxonomy maps to HTTP status codes. One `surface()` call, same pattern as CLI and MCP. Built on Hono.
+**HTTP surface (`@ontrails/http`).** The third surface adapter. `intent: 'read'` maps to GET, mutations to POST, `'destroy'` to DELETE. Route paths derived from trail IDs. Error taxonomy maps to HTTP status codes. One `surface()` call, same pattern as CLI and MCP. Built on Hono.
 
 **OpenAPI generation (`@ontrails/http`).** `deriveOpenApiSpec()` produces a complete OpenAPI 3.1 spec from the topo for HTTP clients. The topo already carries everything OpenAPI needs; the HTTP package owns the surface-specific projection.
 
@@ -24,9 +24,9 @@
 
 **Implementation synthesis from examples.** For trails with comprehensive examples that fully specify behavior (pure transformations, mapping logic, validation rules), an agent could synthesize the implementation from the examples alone. The examples become the source of truth; the code becomes the derived artifact.
 
-**Cross-app composition (mount).** One Trails app consumes another's trails over a connector boundary. Contract compatibility verified at startup — input schemas match, expected errors exist, required trails are present. Version compatibility becomes structural, not documentary.
+**Cross-app composition (mount).** One Trails app consumes another's trails over an adapter boundary. Contract compatibility verified at startup — input schemas match, expected errors exist, required trails are present. Version compatibility becomes structural, not documentary.
 
-**Resource-level recovery declarations.** A mechanism for resources to declare their own recovery policies that apply uniformly to every trail using them — for cases where the recovery is not uniform retry (handled by the framework retry layer on `retryable` errors), not derivable from store declarations (handled by `deriveTrail` synthesis), and not domain-specific (handled by authored trail-level `detours:`). The motivating cases are third-party connectors with protocol-specific recovery semantics — OAuth token refresh on 401, idiosyncratic retry windows in API response bodies, credential-aware recovery actions. Deferred from ADR-0033 pending a concrete case; prerequisite is a backend-agnostic taxonomy extension. The `detours` vocabulary is trail-specific per ADR-0023 — if this lands, it needs its own word.
+**Resource-level recovery declarations.** A mechanism for resources to declare their own recovery policies that apply uniformly to every trail using them — for cases where the recovery is not uniform retry (handled by the framework retry layer on `retryable` errors), not derivable from store declarations (handled by `deriveTrail` synthesis), and not domain-specific (handled by authored trail-level `detours:`). The motivating cases are third-party adapters with protocol-specific recovery semantics — OAuth token refresh on 401, idiosyncratic retry windows in API response bodies, credential-aware recovery actions. Deferred from ADR-0033 pending a concrete case; prerequisite is a backend-agnostic taxonomy extension. The `detours` vocabulary is trail-specific per ADR-0023 — if this lands, it needs its own word.
 
 **Packs.** Distributable capability bundles. A pack carries trails, resources, signals, and config for a domain. The unit of sharing and reuse across apps.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@
 
 - **[CLI Surface](./surfaces/cli.md)** — Shipped today. Flag derivation, output modes, exit codes, `--dry-run`
 - **[MCP Surface](./surfaces/mcp.md)** — Shipped today. Tool naming, annotations, progress bridge
-- **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, webhook activation, verb mapping, error responses, Hono connector
+- **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, webhook activation, verb mapping, error responses, Hono adapter
 - **WebSocket Surface** — Planned, not yet implemented. See [Horizons](./horizons.md) for the current direction.
 
 ## Governing your codebase?
@@ -42,24 +42,24 @@
 - **[ADR-0002: Built-In Result Type](./adr/0002-built-in-result-type.md)** — Own the Result primitive, zero dependencies
 - **[ADR-0003: Unified Trail Primitive](./adr/0003-unified-trail-primitive.md)** — One `trail()`, composition as a property
 - **[ADR-0004: Intent as a First-Class Property](./adr/0004-intent-as-first-class-property.md)** — One field drives all surface behavior
-- **[ADR-0005: Framework-Agnostic HTTP Route Model](./adr/0005-framework-agnostic-http-route-model.md)** — `HttpRoute[]` with thin connector subpaths
+- **[ADR-0005: Framework-Agnostic HTTP Route Model](./adr/0005-framework-agnostic-http-route-model.md)** — `HttpRoute[]` with thin adapter packages
 - **[ADR-0006: Shared Execution Pipeline](./adr/0006-shared-execution-pipeline.md)** — One `executeTrail`, Result-returning builders
 - **[ADR-0007: Governance as Trails](./adr/0007-governance-as-trails.md)** — Warden rules are trails, AST-based analysis
 - **[ADR-0008: Deterministic Surface Derivation](./adr/0008-deterministic-trailhead-derivation.md)** — Explicit lookup tables for every surface
 - **[ADR-0009: First-Class Resources](./adr/0009-first-class-resources.md)** — Dependency declarations, lifecycle, testing, governance
 - **[ADR-0010: Trails-Native Infrastructure](./adr/0010-native-infrastructure.md)** — Workspace layout, `.trails/` directory, shared database
 - **[ADR-0011: Schema-Driven Config](./adr/0011-schema-driven-config.md)** — Typed configuration from schemas
-- **[ADR-0012: Connector-Agnostic Permits](./adr/0012-connector-agnostic-permits.md)** — Permission model independent of surface
+- **[ADR-0012: Adapter-Agnostic Permits](./adr/0012-connector-agnostic-permits.md)** — Permission model independent of surface
 - **[ADR-0013: Tracing](./adr/0013-tracing.md)** — Runtime recording primitive
 - **[ADR-0014: Core Database Primitive](./adr/0014-core-database-primitive.md)** — Shared `trails.db`, subsystem schema versioning
 - **[ADR-0015: Topo Store](./adr/0015-topo-store.md)** — Queryable relational projection of the resolved graph
-- **[ADR-0016: Schema-Derived Persistence](./adr/0016-schema-derived-persistence.md)** — `store()` declaration, connector binding, fixtures
+- **[ADR-0016: Schema-Derived Persistence](./adr/0016-schema-derived-persistence.md)** — `store()` declaration, adapter binding, fixtures
 - **[ADR-0017: The Serialized Topo Graph](./adr/0017-serialized-topo-graph.md)** — Lockfile as resolved graph
 - **[ADR-0018: Signal-Driven Governance](./adr/0018-signal-driven-governance.md)** — Governance through signals
 - **[ADR-0019: Hierarchical Command Trees](./adr/0019-hierarchical-command-trees-from-trail-ids.md)** — Full CLI path derivation from dotted trail IDs
 - **[ADR-0020: Structured CLI Input](./adr/0020-flags-for-fields-structured-input-on-the-cli.md)** — Flags for fields, JSON/file/stdin channels
 - **[ADR-0021: Draft State Containment](./adr/0021-draft-state-stays-out-of-the-resolved-graph.md)** — Draft state stays out of the resolved graph
-- **[ADR-0022: Drizzle Store Connector](./adr/0022-drizzle-store-connector.md)** — Drizzle binds schema-derived stores to SQLite
+- **[ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](./adr/0022-drizzle-store-connector.md)** — Drizzle binds schema-derived stores to SQLite
 - **[ADR-0023: Simplifying the Trails Lexicon](./adr/0023-simplifying-the-trails-lexicon.md)** — Brand-vs-plain heuristic, four pre-1.0 renames, vocabulary → lexicon
 
 ## Where to next?

--- a/docs/migration/connector-to-adapter.md
+++ b/docs/migration/connector-to-adapter.md
@@ -1,4 +1,4 @@
-# Connector To Adapter Migration Guide
+# Connector to Adapter Migration Guide
 
 How to migrate consumers from the retired `connector` vocabulary to the
 canonical `adapter` vocabulary. This is a clean cut: Trails does not ship
@@ -6,7 +6,8 @@ compatibility aliases for connector-era public names, source paths, or package
 subpaths.
 
 This guide is temporary. Deprecate it after first-party Trails projects and
-downstream consumers have migrated.
+downstream consumers have migrated. Until then, treat it as the rename checklist
+for current-facing docs, APIs, package README files, and workspace paths.
 
 ## Overview
 

--- a/docs/migration/layer-evolution.md
+++ b/docs/migration/layer-evolution.md
@@ -148,7 +148,7 @@ Run `bun run lint` after migration to verify stale references are gone.
 
 - [ADR-0043: Layer Evolution](../adr/0043-layer-evolution.md)
 - [ADR-0006: Shared Execution Pipeline](../adr/0006-shared-execution-pipeline.md)
-- [ADR-0012: Connector-Agnostic Permits](../adr/0012-connector-agnostic-permits.md)
+- [ADR-0012: Adapter-Agnostic Permits](../adr/0012-connector-agnostic-permits.md)
 - [ADR-0041: Unified Observability](../adr/0041-unified-observability.md)
 
 [TRL-473]: https://linear.app/outfitter/issue/TRL-473

--- a/docs/migration/trailhead-to-surface.md
+++ b/docs/migration/trailhead-to-surface.md
@@ -74,7 +74,7 @@ Custom `TraceSink` implementations should persist `surface` and should not accep
 
 ## Observability
 
-The OTel connector now emits `trails.surface`.
+The OTel adapter now emits `trails.surface`.
 
 ```diff
 -span.attributes['trails.trailhead']

--- a/docs/rule-design.md
+++ b/docs/rule-design.md
@@ -117,7 +117,7 @@ expiry plan.
 Does the rule duplicate framework data that an owner module already declares?
 
 Read owner exports for error classes, surface code mappings, intent values, CRUD
-doctrine, detour caps, Result accessor names, connector descriptors, and reserved
+doctrine, detour caps, Result accessor names, adapter descriptors, and reserved
 lexicon terms. If the owner does not expose the data cleanly, strengthen the
 owner first.
 
@@ -149,7 +149,7 @@ Framework values live in the module that owns the concept.
 | `DETOUR_MAX_ATTEMPTS_CAP` | Detour retry limit |
 | `resultAccessorNames` | Result accessors that imply sync assumptions |
 | Lexicon reserved terms | Retired vocabulary for source-file checks |
-| Connector descriptors, once formalized | Extension and surface declarations |
+| Adapter descriptors, once formalized | Extension and surface declarations |
 | Capability matrix, once formalized | Primitive lifecycle expectations |
 
 When a rule needs one of these values:

--- a/docs/store-signal-identity-migration.md
+++ b/docs/store-signal-identity-migration.md
@@ -16,7 +16,7 @@ created.id;
 // "users.created"
 ```
 
-After a connector binds the store to a resource, the canonical id includes the
+After an adapter binds the store to a resource, the canonical id includes the
 resource scope:
 
 ```typescript
@@ -56,7 +56,7 @@ trail('users.notify-identity', {
 });
 ```
 
-If an app wraps a connector resource in a custom resource, carry the connector
+If an app wraps an adapter resource in a custom resource, carry the adapter
 signals onto the wrapper so the topo can see the scoped store signals:
 
 ```typescript

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -1,6 +1,6 @@
 # CLI Surface
 
-The CLI surface connector turns every trail into a command. Flags are
+The CLI surface adapter turns every trail into a command. Flags are
 derived from faithfully representable Zod schema fields, and structured JSON
 channels are available when the input shape is richer than flags can express
 honestly. Output formatting, error handling, and exit codes are handled
@@ -25,8 +25,8 @@ That is the entire CLI setup. Every trail in the app becomes a command.
 > **Beta 15 package shape:** Commander is still exposed through the
 > `@ontrails/cli/commander` subpath, with `commander` installed as a peer
 > dependency. The planned beta.16 cleanup is to move Commander into a dedicated
-> `@ontrails/commander` connector package by direct cutover. Do not use that
-> future import path until the connector package exists.
+> `@ontrails/commander` adapter package by direct cutover. Do not use that
+> future import path until the adapter package exists.
 
 ## How Trail IDs Map to Commands
 
@@ -212,7 +212,7 @@ The `<TOPO>` prefix is derived from the topo name: uppercased, with non-alphanum
 
 ## Error Handling
 
-When a trail returns `Result.err()`, the Commander connector maps the error category to an exit code:
+When a trail returns `Result.err()`, the Commander adapter maps the error category to an exit code:
 
 | Category     | Exit code |
 | ------------ | --------- |
@@ -301,7 +301,7 @@ await surface(graph);
 ```
 
 To use a different CLI framework (yargs, oclif, etc.), consume the successful
-`CliCommand[]` result directly and write your own connector. The model carries
+`CliCommand[]` result directly and write your own adapter. The model carries
 everything needed: a full ordered command path, flags, args, and an
 `execute()` function.
 

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -1,8 +1,8 @@
 # HTTP Surface
 
-The HTTP surface connector turns every trail into an endpoint. Routes are derived from trail IDs, HTTP verbs from intent, input parsing from the method, and error responses from the error taxonomy. One `surface()` call starts a Hono server.
+The HTTP surface adapter turns every trail into an endpoint. Routes are derived from trail IDs, HTTP verbs from intent, input parsing from the method, and error responses from the error taxonomy. One `surface()` call starts a Hono server.
 
-The package separates framework-agnostic route building (`@ontrails/http`) from the Hono connector (`@ontrails/hono`).
+The package separates framework-agnostic route building (`@ontrails/http`) from the Hono adapter (`@ontrails/hono`).
 
 ## Setup
 
@@ -55,13 +55,13 @@ Input parsing depends on the HTTP method:
 
 - **GET** -- Query parameters are parsed into an object. Repeated keys become arrays; single keys stay strings. The trail's input schema owns any coercion.
 - **POST / DELETE** -- The JSON request body is parsed via `req.json()`.
-- **Webhook routes** -- The Hono connector reads the raw body first, runs the webhook `verify` hook if one is defined, parses JSON, then validates the parsed payload against the source's `parse` schema before executing the trail.
+- **Webhook routes** -- The Hono adapter reads the raw body first, runs the webhook `verify` hook if one is defined, parses JSON, then validates the parsed payload against the source's `parse` schema before executing the trail.
 
 For direct routes, the parsed input is validated against the trail's Zod schema before the implementation runs. For webhook routes, the source `parse` schema validates the JSON payload first, then the receiving trail's `input` schema validates the value passed into the trail.
 
 ## Webhook Activation Sources
 
-Webhook activation is declared in core with `webhook()` and materialized by the HTTP surface. The source is provider-agnostic: Stripe, GitHub, Slack, or an internal webhook connector should all produce the same universal source shape instead of inventing provider-specific activation kinds.
+Webhook activation is declared in core with `webhook()` and materialized by the HTTP surface. The source is provider-agnostic: Stripe, GitHub, Slack, or an internal webhook adapter should all produce the same universal source shape instead of inventing provider-specific activation kinds.
 
 ```typescript
 import { createHmac, timingSafeEqual } from 'node:crypto';
@@ -130,7 +130,7 @@ When `surface(graph)` runs, the source above becomes `POST /webhooks/payment`. A
 
 The `parse` schema describes the payload after JSON parsing and before the trail runs. Its output must be compatible with the receiving trail's `input` schema. The optional `verify` hook receives the raw body plus request headers, method, and path so signature checks can run before JSON parsing changes the bytes being signed.
 
-Provider connector helpers should wrap this shape, not replace it:
+Provider adapter helpers should wrap this shape, not replace it:
 
 ```typescript
 export const stripePaymentSucceeded = webhook(

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -1,6 +1,6 @@
 # MCP Surface
 
-The MCP surface connector turns every trail into an MCP tool. Annotations are auto-derived from trail intent, idempotency, and description. Progress callbacks bridge to MCP notifications. One `surface()` call starts a server.
+The MCP surface adapter turns every trail into an MCP tool. Annotations are auto-derived from trail intent, idempotency, and description. Progress callbacks bridge to MCP notifications. One `surface()` call starts a server.
 
 ## Setup
 

--- a/docs/why-trails.md
+++ b/docs/why-trails.md
@@ -149,7 +149,7 @@ One write, three reads. If someone changes the business rule, they change the ex
 
 Great tools already exist for each surface. tRPC, Hono, and Fastify are excellent for HTTP. Commander and oclif are battle-tested for CLIs. FastMCP and the official SDK make MCP server development straightforward. NestJS spans multiple transports with a mature ecosystem.
 
-Trails doesn't try to replace any of them. It occupies a different layer: the **contract layer** that sits above individual surface implementations. A trail definition captures the schema, examples, error types, intent and metadata, and composition graph in one place. Surface connectors — CLI, MCP, and HTTP today, with WebSocket planned — project that contract into whatever runtime format the surface needs.
+Trails doesn't try to replace any of them. It occupies a different layer: the **contract layer** that sits above individual surface implementations. A trail definition captures the schema, examples, error types, intent and metadata, and composition graph in one place. Surface adapters — CLI, MCP, and HTTP today, with WebSocket planned — project that contract into whatever runtime format the surface needs.
 
 The value isn't in being better at any single surface. It's in making the contract the source of truth so that every surface stays consistent with it — not because anyone was careful, but because the framework derives each surface from the same definition.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @ontrails/cli
 
-CLI surface model and Commander connector. Import framework-agnostic command
+CLI surface model and Commander adapter. Import framework-agnostic command
 derivation from `@ontrails/cli`; import the Commander runtime from
 `@ontrails/cli/commander`.
 
@@ -46,7 +46,7 @@ program.parse();
 ```
 
 `deriveCliCommands` returns `Result<CliCommand[], Error>`. Use `toCommander`
-with `commands.value` on success, or write your own connector.
+with `commands.value` on success, or write your own adapter.
 Invalid command models are rejected before adapter wiring, including duplicate
 CLI paths and executable parents that also declare positional args beneath child
 commands.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -2,7 +2,7 @@
 
 Schema-derived configuration for Trails.
 
-The root package owns the connector-agnostic config declaration and resolution engine. Schemas define the contract, and `configResource` exposes resolved values to trail execution.
+The root package owns the runtime-agnostic config declaration and resolution engine. Schemas define the contract, and `configResource` exposes resolved values to trail execution.
 
 ## The core pattern
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -1,6 +1,6 @@
 # @ontrails/http
 
-Framework-agnostic HTTP route derivation for Trails. Pair this package with `@ontrails/hono` when you want the Hono surface connector.
+Framework-agnostic HTTP route derivation for Trails. Pair this package with `@ontrails/hono` when you want the Hono surface adapter.
 
 ## Usage
 
@@ -107,7 +107,7 @@ Each route definition produced by `deriveHttpRoutes` includes:
 
 For GET routes on the Hono surface, repeated query keys are passed through as
 arrays (`?tag=one&tag=two` -> `{ tag: ['one', 'two'] }`) while a single
-occurrence stays a scalar string. The connector does not coerce singleton query
+occurrence stays a scalar string. The adapter does not coerce singleton query
 values into arrays.
 
 ## Installation

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -1,6 +1,6 @@
 # @ontrails/logging
 
-Structured logging for Trails. One entry point: `createLogger`. Built-in sinks and formatters, hierarchical category filtering, automatic redaction, and an optional LogTape connector.
+Structured logging for Trails. One entry point: `createLogger`. Built-in sinks and formatters, hierarchical category filtering, automatic redaction, and an optional LogTape adapter.
 
 ## Usage
 
@@ -72,7 +72,7 @@ logger.info('Auth', { user: 'admin', password: 'hunter2' });
 // password → "[REDACTED]"
 ```
 
-## LogTape connector
+## LogTape adapter
 
 Bridge to an existing LogTape setup via the dedicated `@ontrails/logtape` package:
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # @ontrails/mcp
 
-MCP surface connector. One `surface()` call turns a topo into an MCP server with tool definitions, annotations, and progress bridging -- all derived from the trail contracts.
+MCP surface adapter. One `surface()` call turns a topo into an MCP server with tool definitions, annotations, and progress bridging -- all derived from the trail contracts.
 
 ## Usage
 

--- a/packages/observe/README.md
+++ b/packages/observe/README.md
@@ -3,8 +3,8 @@
 Primitive observability contracts for Trails.
 
 This package is the public home for log and trace sink shapes used by Trails
-apps and connectors. It includes zero-dependency sinks for local and server
-baselines, plus connector composition for production observability.
+apps and adapters. It includes zero-dependency sinks for local and server
+baselines, plus adapter composition for production observability.
 
 ```typescript
 import {
@@ -22,4 +22,4 @@ const sink = combine(
 ```
 
 `createFileSink()` is append-only and does not rotate files. Use external log
-rotation or a production connector when retention policy matters.
+rotation or a production adapter when retention policy matters.

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -2,7 +2,7 @@
 
 Schema-derived persistence for Trails.
 
-The root package owns the connector-agnostic `store(...)` declaration. External connector packages such as `@ontrails/drizzle` bind that declaration to a concrete runtime, and first-party built-ins such as `@ontrails/store/jsonfile` live as opt-in subpaths on the same package.
+The root package owns the backend-agnostic `store(...)` declaration. External adapter packages such as `@ontrails/drizzle` bind that declaration to a concrete runtime, and first-party built-ins such as `@ontrails/store/jsonfile` live as opt-in subpaths on the same package.
 
 ## The two layers
 
@@ -100,7 +100,7 @@ export const db = jsonFile(definition, {
 
 ## Typed accessors
 
-Every writable table on a bound connection exposes the connector-agnostic accessor contract:
+Every writable table on a bound connection exposes the backend-agnostic accessor contract:
 
 ```typescript
 const conn = db.from(ctx);
@@ -135,7 +135,7 @@ const updatedHandle = definition.tables.gists.signals.updated;
 const removedHandle = definition.tables.gists.signals.removed;
 ```
 
-These pre-bind handles preserve payload shape, but the canonical signal id materializes only when a connector binds the store to a resource. The bound form is always `resource:table.change`:
+These pre-bind handles preserve payload shape, but the canonical signal id materializes only when an adapter binds the store to a resource. The bound form is always `resource:table.change`:
 
 ```typescript
 const created = db.store.tables.gists.signals.created;
@@ -148,7 +148,7 @@ Writable bindings fire those canonical scoped signals automatically when you acc
 
 See [Store Signal Identity Migration](../../docs/store-signal-identity-migration.md) when updating existing `on:` clauses, surface-map fixtures, or custom resource wrappers from bare ids to scoped ids.
 
-Tabular connectors such as `@ontrails/drizzle` also expose `insert()` and `update()` as convenience methods when the backend natively distinguishes create and patch operations.
+Tabular adapters such as `@ontrails/drizzle` also expose `insert()` and `update()` as convenience methods when the backend natively distinguishes create and patch operations.
 
 ## Fixtures and mocks
 
@@ -167,13 +167,13 @@ export const db = store({
 });
 ```
 
-When a connector binds the store, those fixtures feed the resource mock automatically. Connector options can also add or override seed data for tests.
+When an adapter binds the store, those fixtures feed the resource mock automatically. Adapter options can also add or override seed data for tests.
 
-That means `testAll(app)` can auto-resolve connector-bound store resources without extra ceremony, as long as the resource is registered in the topo.
+That means `testAll(app)` can auto-resolve adapter-bound store resources without extra ceremony, as long as the resource is registered in the topo.
 
 ## Read-only bindings
 
-Use the Drizzle connector's read-only binding when a trail should inspect persisted state without exposing writes:
+Use the Drizzle adapter's read-only binding when a trail should inspect persisted state without exposing writes:
 
 ```typescript
 import { connectReadOnlyDrizzle } from '@ontrails/drizzle';
@@ -188,17 +188,17 @@ Read-only bindings expose `get()`, `list()`, and `query()`, but not `upsert()`, 
 
 ## Accessor contract testing
 
-Connectors can reuse the shared writable-accessor contract tests from `@ontrails/store/testing`:
+Adapters can reuse the shared writable-accessor contract tests from `@ontrails/store/testing`:
 
 ```typescript
 import { createStoreAccessorContractCases } from '@ontrails/store/testing';
 ```
 
-That helper provides reusable cases for the baseline `get()`, `list()`, `upsert()`, and `remove()` behavior so connector suites only need to wrap them with their normal `test(...)` calls and add backend-specific coverage on top.
+That helper provides reusable cases for the baseline `get()`, `list()`, `upsert()`, and `remove()` behavior so adapter suites only need to wrap them with their normal `test(...)` calls and add backend-specific coverage on top.
 
 ## Drizzle escape hatch
 
-Complex queries use the connector-native query builder through `query()`:
+Complex queries use the adapter-native query builder through `query()`:
 
 ```typescript
 const conn = db.from(ctx);
@@ -210,9 +210,9 @@ const rows = await conn.query(({ drizzle, tables }) =>
 );
 ```
 
-This keeps the default happy path derived and typed, while still giving you full access to the underlying connector when the CRUD accessors are not enough.
+This keeps the default happy path derived and typed, while still giving you full access to the underlying adapter when the CRUD accessors are not enough.
 
-## Connector binding
+## Adapter binding
 
 `@ontrails/drizzle` keeps the durable `store(...)` declaration in
 `@ontrails/store` and binds it to a concrete runtime:
@@ -236,7 +236,7 @@ export const readonly = connectReadOnlyDrizzle(definition, {
 });
 ```
 
-The root package still owns the authored persistence model; connector packages
+The root package still owns the authored persistence model; adapter packages
 project that model into runnable resources.
 
 ## Schema export for external tooling
@@ -266,7 +266,7 @@ const schema = db.tables;
 bun add @ontrails/store zod
 ```
 
-Add Drizzle only when you want the external SQLite/ORM connector:
+Add Drizzle only when you want the external SQLite/ORM adapter:
 
 ```bash
 bun add @ontrails/drizzle
@@ -277,4 +277,4 @@ bun add @ontrails/drizzle
 The Drizzle binding now lives in `@ontrails/drizzle`.
 
 - Replace `import { ... } from '@ontrails/store/drizzle'` with `import { ... } from '@ontrails/drizzle'`
-- Keep connector-agnostic store declarations on `@ontrails/store`
+- Keep backend-agnostic store declarations on `@ontrails/store`

--- a/plugin/rules/lexicon.md
+++ b/plugin/rules/lexicon.md
@@ -20,12 +20,13 @@ Use Trails-branded terms consistently. These are non-negotiable in code, docs, a
 | `warden` | linter, checker, validator |
 | `survey` | introspect, inspect, describe |
 | `guide` | docs, help, manual |
-| `connector` | bridge, transport shim |
+| `adapter` | connector, bridge, transport shim |
 
 ## When Writing
 
 - The framework is "Trails" (capitalized). The primitive is "trail" (lowercase).
 - Lead with code: `trail()` -> `crosses` -> `resource()` -> `surface()` before explaining.
 - Do not overextend the metaphor. "Define a trail" is good. "Blaze a path through the wilderness" is not.
-- Standard terms stay standard: `config`, `Result`, `Error`, and `adapter` when it names a thin runtime-specific layer.
+- Standard terms stay standard: `config`, `Result`, and `Error`.
+- `connector` is retired public taxonomy. Use `adapter` for a thin runtime-specific layer.
 - `resource` is a branded term: `resource()` defines a typed infrastructure dependency. Use `resources: [...]` on trail specs to declare dependencies. Do not use "resource" for generic helpers or utility classes.

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -2,7 +2,7 @@
 
 ## Hexagonal Model
 
-Core defines ports. Everything on the edges is a connector.
+Core defines ports. Everything on the edges is an adapter.
 
 ```text
             LEFT SIDE (inbound)             RIGHT SIDE (outbound)
@@ -25,7 +25,7 @@ Core defines ports. Everything on the edges is a connector.
 
 - The trail is the product, not the surface. Surfaces are projections.
 - Drift is structurally harder than alignment — one schema, one Result type, one error taxonomy.
-- Surfaces are peers. CLI, MCP, and HTTP are shipped connectors. Adding a surface is a `surface()` call.
+- Surfaces are peers. CLI, MCP, and HTTP are shipped adapters. Adding a surface is a `surface()` call.
 - Implementations are pure functions. Input in, Result out. No surface awareness.
 - The contract is machine-readable at runtime via topo, survey, and guide.
 
@@ -79,28 +79,28 @@ Warden uses inference to verify declarations match actual code. The surface map 
 
 ### Foundation
 
-`@ontrails/core` — only external dependency is `zod`. Contains Result, error taxonomy, `trail()`/`signal()`, `topo()`, validation, layers, connector port interfaces, `executeTrail()` (the shared pipeline), and `run()` (headless execution by trail ID).
+`@ontrails/core` — only external dependency is `zod`. Contains Result, error taxonomy, `trail()`/`signal()`, `topo()`, validation, layers, adapter port interfaces, `executeTrail()` (the shared pipeline), and `run()` (headless execution by trail ID).
 
-### Surface Connectors (left side)
+### Surface Adapters (left side)
 
 | Package | Purpose | External dep |
 |---------|---------|-------------|
 | `@ontrails/cli` | Command model, flag derivation, output formatting | None beyond core |
-| `@ontrails/cli/commander` | Commander connector, `surface()` | `commander` (peer) |
+| `@ontrails/cli/commander` | Commander adapter, `surface()` | `commander` (peer) |
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `surface()` | `@modelcontextprotocol/sdk` |
 | `@ontrails/http` | HTTP route definitions (framework-agnostic) | None beyond core |
-| `@ontrails/hono` | Hono connector, `surface()` | `hono` |
+| `@ontrails/hono` | Hono adapter, `surface()` | `hono` |
 | `@ontrails/vite` | Vite dev server adapter | `vite` |
 
-### Infrastructure Connectors (right side)
+### Infrastructure Adapters (right side)
 
 | Package | Purpose | External dep |
 |---------|---------|-------------|
 | `@ontrails/config` | Config resolution, profiles, resource config schemas, diagnostics | None beyond core |
-| `@ontrails/permits` | Auth layer, permit model, JWT connector, scope enforcement | None beyond core |
+| `@ontrails/permits` | Auth layer, permit model, JWT adapter, scope enforcement | None beyond core |
 | `@ontrails/tracing` | Telemetry recording, trace context, memory/OTel sinks | None beyond core |
 | `@ontrails/logging` | Structured logging, sinks, formatters | None beyond core |
-| `@ontrails/logtape` | LogTape sink connector | None (accepts any LogTape-shaped logger via a structural interface) |
+| `@ontrails/logtape` | LogTape sink adapter | None (accepts any LogTape-shaped logger via a structural interface) |
 
 ### Ecosystem
 
@@ -155,7 +155,7 @@ Surfaces only differ in how they parse inbound requests and map Results to their
 ```text
 CLI input ("myapp entity show --name Alpha")
   -> Commander parses args/flags
-  -> CLI connector matches trail via CliCommand model
+  -> CLI adapter matches trail via CliCommand model
   -> Delegates to executeTrail(trail, parsedInput, { layers, ... })
   -> Result mapped to exit code + stdout
 ```
@@ -164,7 +164,7 @@ CLI input ("myapp entity show --name Alpha")
 
 ```text
 MCP tool call ({ name: "myapp_entity_show", arguments: { name: "Alpha" } })
-  -> MCP connector matches trail
+  -> MCP adapter matches trail
   -> Delegates to executeTrail(trail, args, { layers, signal, ... })
   -> Result mapped to MCP tool response (content[], isError)
 ```

--- a/plugin/skills/trails/references/common-pitfalls.md
+++ b/plugin/skills/trails/references/common-pitfalls.md
@@ -2,7 +2,7 @@
 
 ## 1. Throwing in implementations
 
-**Symptom:** Unhandled exception crashes the surface connector. Stack trace instead of structured error.
+**Symptom:** Unhandled exception crashes the surface adapter. Stack trace instead of structured error.
 
 **Why it's wrong:** Trail implementations must return `Result`, never throw. Surfaces expect `Result.ok` or `Result.err` — a thrown exception bypasses error mapping, exit codes, and serialization.
 

--- a/plugin/skills/trails/references/getting-started.md
+++ b/plugin/skills/trails/references/getting-started.md
@@ -10,7 +10,7 @@ bunx @ontrails/trails create
 
 # Or install manually
 bun add @ontrails/core @ontrails/cli zod
-bun add commander                    # Commander connector
+bun add commander                    # Commander adapter
 bun add @ontrails/mcp @modelcontextprotocol/sdk # MCP surface (optional)
 bun add -d @ontrails/testing         # Testing (dev)
 ```


### PR DESCRIPTION
## Context

This finishes the current-facing documentation sweep after the workspace-root
rename so READMEs and agent guidance consistently describe adapter packages.

## What Changed

- Updated repo docs, package READMEs, plugin rules, and skill references to use
  adapter-era taxonomy.
- Preserved historical connector mentions only where they are explicitly
  historical or migration context.
- Regenerated ADR decision-map metadata.

## Verification

- `bun run docs:snippets`
- `bun run format:check`
- `bun scripts/adr.ts check`
- `bun run lint`
- `git diff --check`
- Branch-local changeset gate for the touched published package docs

## Risks / Rollout

Docs/package README sweep. The main risk is over-correcting historical text;
accepted historical contexts remain in ADRs, releases, changelogs, and migration
notes.

## Release Metadata

Changeset: `.changeset/taxonomy-docs-pass.md`.

Closes: TRL-664
