### PR TITLE
chore: guard retired connector vocabulary

### DIFF
--- a/.changeset/connector-guardrail-source-comments.md
+++ b/.changeset/connector-guardrail-source-comments.md
@@ -1,0 +1,11 @@
+---
+"@ontrails/cli": patch
+"@ontrails/core": patch
+"@ontrails/hono": patch
+"@ontrails/http": patch
+"@ontrails/logtape": patch
+"@ontrails/mcp": patch
+"@ontrails/observe": patch
+---
+
+Refresh source comments and test labels for retired connector terminology as adapter guardrails become strict.

--- a/.changeset/store-adapter-options.md
+++ b/.changeset/store-adapter-options.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/drizzle": patch
+"@ontrails/store": major
+---
+
+BREAKING: rename the shared store backend option type from `StoreConnectorOptions` to `StoreAdapterOptions`.

--- a/adapters/drizzle/src/__tests__/drizzle.test.ts
+++ b/adapters/drizzle/src/__tests__/drizzle.test.ts
@@ -924,7 +924,7 @@ describe('@ontrails/drizzle read-only resource access', () => {
     await db.dispose?.(mock as ReadonlyUserStoreRuntime);
   });
 
-  test('preserves connector metadata on the resource definition', () => {
+  test('preserves adapter metadata on the resource definition', () => {
     const db = createReadonlyUserStore(':memory:');
     expect(db.meta).toEqual({ domain: 'readonly-demo' });
   });
@@ -1007,7 +1007,7 @@ describe('@ontrails/drizzle edge cases', () => {
       try {
         run();
         throw new Error(
-          'expected connector binding to reject a non-tabular store'
+          'expected adapter binding to reject a non-tabular store'
         );
       } catch (error) {
         expect(error).toBeInstanceOf(ValidationError);

--- a/adapters/drizzle/src/runtime.ts
+++ b/adapters/drizzle/src/runtime.ts
@@ -195,7 +195,7 @@ const isVersionManagedField = <TTable extends AnyStoreTable>(
 /**
  * Synthesize a value for a generated field during insert.
  *
- * The connector recognizes these conventions for generated fields:
+ * The adapter recognizes these conventions for generated fields:
  *
  * - **Primary key** (`integer` type): auto-increment, left to SQLite.
  * - **Timestamp fields** (`createdAt`, `updatedAt`, `created_at`,
@@ -473,7 +473,7 @@ const ensureNotCyclic = (
   }
 
   throw new ValidationError(
-    `Store definition contains a reference cycle involving "${tableName}", which the SQLite connector cannot seed automatically`
+    `Store definition contains a reference cycle involving "${tableName}", which the SQLite adapter cannot seed automatically`
   );
 };
 
@@ -1234,7 +1234,7 @@ const connectionHealth = (
  * `Database` client is tracked via `WeakMap`).
  *
  * Note: the `search` field on `StoreTableInput` is not yet interpreted by
- * this connector — it is reserved for future full-text search support.
+ * this adapter — it is reserved for future full-text search support.
  */
 export const connectDrizzle = <const TStore extends AnyStoreDefinition>(
   definition: TStore,

--- a/adapters/drizzle/src/schema.ts
+++ b/adapters/drizzle/src/schema.ts
@@ -200,7 +200,7 @@ const inferFieldKind = (
     }
     default: {
       throw new ValidationError(
-        `Store field "${field}" uses unsupported schema type "${schema.def.type}" for the Drizzle SQLite connector`
+        `Store field "${field}" uses unsupported schema type "${schema.def.type}" for the Drizzle SQLite adapter`
       );
     }
   }

--- a/adapters/drizzle/src/types.ts
+++ b/adapters/drizzle/src/types.ts
@@ -3,7 +3,7 @@ import type {
   AnyStoreDefinition,
   ReadOnlyStoreConnection,
   StoreAccessMode,
-  StoreConnectorOptions,
+  StoreAdapterOptions,
   StoreMockSeed,
   StoreTableConnection,
 } from '@ontrails/store';
@@ -22,29 +22,29 @@ export interface DrizzleQueryContext<TStore extends AnyStoreDefinition> {
 }
 
 /**
- * Options accepted by the Drizzle store connector.
+ * Options accepted by the Drizzle store adapter.
  *
- * Extends {@link StoreConnectorOptions} with drizzle-specific fields. The
+ * Extends {@link StoreAdapterOptions} with drizzle-specific fields. The
  * read-only vs writable distinction is enforced by the factory that consumes
  * these options, not by the options type itself.
  */
 export interface DrizzleStoreOptions<
   TDef extends AnyStoreDefinition = AnyStoreDefinition,
-> extends StoreConnectorOptions<TDef> {
+> extends StoreAdapterOptions<TDef> {
   /** Path to the SQLite database file. Use `":memory:"` for ephemeral runs. */
   readonly url: string;
   /**
    * Optional fixture overrides applied when the writable runtime database is
    * first created.
    *
-   * Mirrors {@link StoreConnectorOptions.mockSeed} but for the `create`
-   * (runtime) path: when supplied, the connector seeds these rows into the
+   * Mirrors {@link StoreAdapterOptions.mockSeed} but for the `create`
+   * (runtime) path: when supplied, the adapter seeds these rows into the
    * writable database immediately after schema initialization. Use this for
    * demo/dogfood apps that want commands and examples to find pre-loaded
    * entities on a fresh `:memory:` boot. Defaults to `undefined` — runtime
    * databases are not auto-seeded from `table.fixtures`.
    *
-   * Has no effect on the read-only connector, which receives runtime data
+   * Has no effect on the read-only adapter, which receives runtime data
    * from disk rather than from fixtures.
    */
   readonly seed?: StoreMockSeed<TDef>;

--- a/adapters/hono/src/__tests__/surface.test.ts
+++ b/adapters/hono/src/__tests__/surface.test.ts
@@ -94,7 +94,7 @@ const createCapturingSink = (records: TraceRecord[]): TraceSink => ({
   },
 });
 
-describe('surface API (Hono connector)', () => {
+describe('surface API (Hono adapter)', () => {
   test('createApp materializes the Hono surface without serving', async () => {
     const graph = topo('surface-api', { echoTrail });
     const app = createApp(graph);

--- a/adapters/hono/src/surface.ts
+++ b/adapters/hono/src/surface.ts
@@ -1,5 +1,5 @@
 /**
- * Hono connector for Trails HTTP routes.
+ * Hono adapter for Trails HTTP routes.
  *
  * Takes framework-agnostic HttpRouteDefinition[] and wires them into a
  * Hono application, handling request parsing, response mapping, and errors.
@@ -66,7 +66,7 @@ export interface SurfaceHttpResult {
  *
  * A single `?tag=one` stays a scalar string, while repeated keys like
  * `?tag=one&tag=two` become arrays. Schema validation owns whether that shape
- * is accepted; the connector does not coerce singleton values into arrays.
+ * is accepted; the adapter does not coerce singleton values into arrays.
  */
 const parseQueryParams = (c: HonoContext): Record<string, unknown> => {
   const result: Record<string, unknown> = {};

--- a/docs/migration/connector-to-adapter.md
+++ b/docs/migration/connector-to-adapter.md
@@ -30,6 +30,7 @@ reserved for projection slices of authored contracts or surfaces.
 | auth resource config `{ connector: 'jwt' \| 'none' }` | `{ adapter: 'jwt' \| 'none' }` | Rename the discriminant in auth resource config and test fixtures. |
 | `createOtelConnector(options?)` | `createOtelAdapter(options?)` | Update OTel trace sink factory imports from `@ontrails/tracing/otel` or `@ontrails/tracing`. |
 | `OtelConnectorOptions` | `OtelAdapterOptions` | Update OTel option type imports. |
+| `StoreConnectorOptions` | `StoreAdapterOptions` | Update store adapter option type imports from `@ontrails/store`. |
 | workspace root `connectors/` | `adapters/` | Update local workspace paths and regenerate `bun.lock` with `bun install`. |
 | `@ontrails/cli/commander` | `@ontrails/commander` | Move active Commander consumers to the dedicated adapter package once it exists. |
 | public taxonomy term `connector` | `adapter` | Rewrite current-facing package, subpath, and API prose. Keep historical, migration, and changelog mentions when clearly marked. |

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
       'error',
       { allowedPackages: ['cli'] },
     ],
-    'trails-local/no-retired-lexicon-terms': 'warn',
+    'trails-local/no-retired-lexicon-terms': 'error',
     'trails-local/prefer-bun-api': 'warn',
     'trails-local/snapshot-location': 'warn',
     'trails-local/temp-audit-direct-framework-writes': 'warn',

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -625,7 +625,7 @@ const synthesizeDevPermit = (graph: Topo): BasePermit => ({
  *
  * The three flags are pairwise mutually exclusive: passing any
  * combination surfaces a `ValidationError` (exit 1). When only `--token`
- * is supplied the auth connector resolves it into a permit; failures map
+ * is supplied the auth adapter resolves it into a permit; failures map
  * to `AuthError` (exit 9). When `--dev-permit` is supplied, a synthetic
  * permit covering every scope declared on the topo is injected. When
  * none of the three registered meta flags are supplied the call returns

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -2,7 +2,7 @@
  * Framework-agnostic CLI command model.
  *
  * These interfaces are the intermediate representation that
- * `deriveCliCommands()` produces and framework connectors consume.
+ * `deriveCliCommands()` produces and framework adapters consume.
  * No Commander (or any other framework) imports here.
  */
 
@@ -13,7 +13,7 @@ import type { Layer, Result, Trail, TrailContext } from '@ontrails/core';
 // ---------------------------------------------------------------------------
 
 /**
- * Type-erased trail reference. At the CLI connector boundary we lose
+ * Type-erased trail reference. At the CLI adapter boundary we lose
  * generic type information since flags/args are parsed as strings.
  * Using `any` here is intentional -- the Zod schema validates at runtime.
  */

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -170,7 +170,7 @@ export const permitPreset = (): CliFlag[] => [
  * The surface caller supplies `resolvePermitFromToken` to turn the token into
  * a `Permit`, which is overlaid onto `ctx.permit`. The `apps/trails` binary
  * wires this to `@ontrails/permits`; the CLI package itself stays
- * connector-agnostic.
+ * adapter-agnostic.
  *
  * Mutually exclusive with `--permit`; passing both surfaces a
  * `ValidationError`. The flag is treated as a meta flag — it never routes

--- a/packages/core/src/store/accessor-protocol.ts
+++ b/packages/core/src/store/accessor-protocol.ts
@@ -10,8 +10,8 @@
  * allowing the derivation helper to call accessors by convention.
  *
  * Required methods (`get`, `list`, `upsert`, `remove`) match the
- * connector-agnostic write contract every bound store must expose. Optional
- * methods (`insert`, `update`) are declared by tabular connectors that
+ * backend-agnostic write contract every bound store must expose. Optional
+ * methods (`insert`, `update`) are declared by tabular adapters that
  * distinguish create-only and patch-only operations from the generalized
  * `upsert` contract.
  */
@@ -25,7 +25,7 @@ export interface StoreAccessorProtocol<
   get(id: TId): Promise<TEntity | null>;
   /** List entities, optionally filtered. Returns `[]` when no rows match. */
   list(filters?: TFilters): Promise<readonly TEntity[]>;
-  /** Create-or-replace one entity using the connector-agnostic contract. */
+  /** Create-or-replace one entity using the backend-agnostic contract. */
   upsert(input: TInput): Promise<TEntity>;
   /**
    * Remove an entity by identity. Returns `{ deleted: true }` when the row
@@ -34,13 +34,13 @@ export interface StoreAccessorProtocol<
    */
   remove(id: TId): Promise<{ readonly deleted: boolean }>;
   /**
-   * Optional insert — available on tabular connectors that distinguish
+   * Optional insert — available on tabular adapters that distinguish
    * create from update. When absent, synthesized blazes fall back to
    * `upsert`.
    */
   insert?(input: TInput): Promise<TEntity>;
   /**
-   * Optional patch-by-identity — available on tabular connectors. Returns
+   * Optional patch-by-identity — available on tabular adapters. Returns
    * `null` when no row with the given identity exists. When absent,
    * synthesized update blazes fall back to `get` + merge + `upsert`.
    */

--- a/packages/http/src/openapi.ts
+++ b/packages/http/src/openapi.ts
@@ -183,7 +183,7 @@ const buildInputSpec = (
   };
 };
 
-/** Wrap a raw output schema in the `{ data: ... }` envelope the HTTP connector uses. */
+/** Wrap a raw output schema in the `{ data: ... }` envelope the HTTP adapter uses. */
 const wrapInDataEnvelope = (outputSchema: JsonSchema): JsonSchema => ({
   properties: { data: outputSchema },
   required: ['data'],

--- a/packages/logtape/src/index.ts
+++ b/packages/logtape/src/index.ts
@@ -42,7 +42,7 @@ const LEVEL_MAP: Record<string, ForwardMethod> = {
 };
 
 /**
- * Sink connector that forwards `LogRecord` instances to an existing logtape
+ * Sink adapter that forwards `LogRecord` instances to an existing logtape
  * logger. Redaction runs _before_ the sink receives records, so sensitive
  * data is scrubbed regardless of the backend.
  */

--- a/packages/mcp/src/surface.ts
+++ b/packages/mcp/src/surface.ts
@@ -198,7 +198,7 @@ export const createServer = (
  * Build MCP tools from a topo, create a server, and connect via stdio.
  *
  * @remarks Opens the MCP server on stdio. For custom transports, use
- * `createServer(graph)` with `connectStdio` or your own connector.
+ * `createServer(graph)` with `connectStdio` or your own adapter.
  */
 export const surface = async (
   graph: Topo,

--- a/packages/observe/src/index.ts
+++ b/packages/observe/src/index.ts
@@ -2,7 +2,7 @@
  * Primitive observability API for Trails.
  *
  * `@ontrails/observe` is the public package for log and trace sink contracts.
- * Connector packages should build on these types instead of importing
+ * Adapter packages should build on these types instead of importing
  * framework internals directly.
  *
  * @see {@link https://github.com/outfitter-dev/trails/blob/main/docs/adr/0041-unified-observability.md | ADR-0041 Unified Observability}

--- a/packages/observe/src/sinks.ts
+++ b/packages/observe/src/sinks.ts
@@ -99,7 +99,7 @@ const toError = (value: unknown): Error =>
  *
  * @remarks
  * This zero-dependency sink does not rotate log files. Pair it with external
- * log rotation or use a production connector when retention policy matters.
+ * log rotation or use a production adapter when retention policy matters.
  */
 export function createFileSink(
   path: string,

--- a/packages/oxlint-plugin/src/__tests__/rules.test.ts
+++ b/packages/oxlint-plugin/src/__tests__/rules.test.ts
@@ -139,6 +139,7 @@ describe('repo-local rules', () => {
 | --- | --- |
 | \`trailhead\` | Historical boundary term retired from active user-facing vocabulary. Use \`surface\` in docs, examples, and public APIs. |
 | \`dispatch\` | Retired runtime wording; use \`cross\` in active APIs. |
+| \`connector\` | Historical package-boundary term retired from active user-facing taxonomy. Use \`adapter\` in docs, examples, and public APIs. |
 | \`pack\` | Distributable capability bundle |
 
 ## Grammar
@@ -155,6 +156,12 @@ describe('repo-local rules', () => {
         concept: 'Retired runtime wording; use `cross` in active APIs.',
         replacement: 'cross',
         term: 'dispatch',
+      },
+      {
+        concept:
+          'Historical package-boundary term retired from active user-facing taxonomy. Use `adapter` in docs, examples, and public APIs.',
+        replacement: 'adapter',
+        term: 'connector',
       },
     ]);
   });
@@ -266,6 +273,80 @@ describe('repo-local rules', () => {
     });
   });
 
+  test('reports connector terms in source-owned roles', () => {
+    const retiredTerms = [
+      {
+        replacement: 'adapter',
+        term: 'connector',
+      },
+    ];
+    const identifierReports = runRuleForEvent({
+      event: 'Identifier',
+      filename: 'packages/permits/src/auth.ts',
+      nodes: [{ name: 'AuthConnector', type: 'Identifier' }],
+      options: [{ retiredTerms }],
+      rule: noRetiredLexiconTermsRule,
+    });
+    const importReports = runRuleForEvent({
+      event: 'ImportDeclaration',
+      filename: 'packages/permits/src/auth.ts',
+      nodes: [createImportDeclarationNode('@ontrails/permits/connectors/jwt')],
+      options: [{ retiredTerms }],
+      rule: noRetiredLexiconTermsRule,
+    });
+    const objectKeyReports = runRuleForEvent({
+      event: 'Property',
+      filename: 'packages/core/src/runtime.ts',
+      nodes: [
+        {
+          computed: false,
+          key: {
+            type: 'Literal',
+            value: 'connector',
+          },
+          type: 'Property',
+        },
+      ],
+      options: [{ retiredTerms }],
+      rule: noRetiredLexiconTermsRule,
+    });
+    const memberReports = runRuleForEvent({
+      event: 'MemberExpression',
+      filename: 'packages/core/src/runtime.ts',
+      nodes: [
+        {
+          object: {
+            name: 'metadata',
+            type: 'Identifier',
+          },
+          property: {
+            type: 'Literal',
+            value: 'connector',
+          },
+          type: 'MemberExpression',
+        },
+      ],
+      options: [{ retiredTerms }],
+      rule: noRetiredLexiconTermsRule,
+    });
+
+    expect(identifierReports[0]?.data).toEqual({
+      replacement: " Use 'adapter'.",
+      role: 'identifier',
+      term: 'connector',
+      value: 'AuthConnector',
+    });
+    expect(importReports.map((report) => report.messageId)).toEqual([
+      'noRetiredLexiconTerms',
+    ]);
+    expect(objectKeyReports.map((report) => report.messageId)).toEqual([
+      'noRetiredLexiconTerms',
+    ]);
+    expect(memberReports.map((report) => report.messageId)).toEqual([
+      'noRetiredLexiconTerms',
+    ]);
+  });
+
   test('does not report retired terms outside source-owned roles', () => {
     const externalImportReports = runRuleForEvent({
       event: 'ImportDeclaration',
@@ -277,6 +358,22 @@ describe('repo-local rules', () => {
             {
               replacement: 'surface',
               term: 'trailhead',
+            },
+          ],
+        },
+      ],
+      rule: noRetiredLexiconTermsRule,
+    });
+    const externalConnectorImportReports = runRuleForEvent({
+      event: 'ImportDeclaration',
+      filename: 'packages/permits/src/auth.ts',
+      nodes: [createImportDeclarationNode('external-connector-sdk')],
+      options: [
+        {
+          retiredTerms: [
+            {
+              replacement: 'adapter',
+              term: 'connector',
             },
           ],
         },
@@ -351,6 +448,7 @@ describe('repo-local rules', () => {
     });
 
     expect(externalImportReports).toHaveLength(0);
+    expect(externalConnectorImportReports).toHaveLength(0);
     expect(docsPathReports).toHaveLength(0);
     expect(identifierObjectKeyReports).toHaveLength(0);
     expect(computedObjectKeyReports).toHaveLength(0);

--- a/packages/store/src/__tests__/jsonfile.test.ts
+++ b/packages/store/src/__tests__/jsonfile.test.ts
@@ -142,7 +142,7 @@ const stableGeneratedId = (): string => 'generated-id';
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('jsonfile connector', () => {
+describe('jsonfile adapter', () => {
   describe('upsert and get', () => {
     test('creates new entity', async () => {
       const conn = await connectJsonFile(itemStore, { dir });
@@ -422,7 +422,7 @@ describe('jsonfile connector', () => {
       await store.dispose?.(mock);
     });
 
-    test('preserves connector metadata on the resource definition', () => {
+    test('preserves adapter metadata on the resource definition', () => {
       const store = jsonFile(fixtureStore, {
         dir,
         meta: { domain: 'fixtures' },

--- a/packages/store/src/__tests__/store.test.ts
+++ b/packages/store/src/__tests__/store.test.ts
@@ -519,7 +519,7 @@ describe('@ontrails/store', () => {
     expect(db.tables.gists.indexes).toEqual(['ownerId']);
   });
 
-  test('type-level helpers expose connector-facing contracts', () => {
+  test('type-level helpers expose adapter-facing contracts', () => {
     const db = createTypeTestStore();
 
     type GistTable = typeof db.tables.gists;

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -32,7 +32,7 @@ export type {
   ReferencesOfInput,
   StoreAccessMode,
   StoreConnection,
-  StoreConnectorOptions,
+  StoreAdapterOptions,
   StoreDefinition,
   StoreFieldKey,
   StoreFixtureInput,

--- a/packages/store/src/jsonfile/runtime.ts
+++ b/packages/store/src/jsonfile/runtime.ts
@@ -448,7 +448,7 @@ const executeRemove = async <TTable extends AnyStoreTable>(
 
 // Module-level registry: ensures all connections to the same file share one
 // in-memory table instance. Keyed by resolved file path.
-// Note: entries are never evicted. This is acceptable for v1 — the connector
+// Note: entries are never evicted. This is acceptable for v1 — the adapter
 // targets single-process, short-lived servers where the number of distinct
 // table paths is bounded by the store definition.
 interface JsonFileTableRegistration<TTable extends AnyStoreTable> {
@@ -522,7 +522,7 @@ const buildAndRegisterTable = <TTable extends AnyStoreTable>(
  * @remarks
  * Tables are shared per resolved file path so multiple connections stay
  * coherent in-process. Reuse is only allowed when table-affecting config
- * matches exactly; otherwise the connector throws instead of silently
+ * matches exactly; otherwise the adapter throws instead of silently
  * inheriting the first connection's runtime semantics.
  */
 const createJsonFileTable = <TTable extends AnyStoreTable>(

--- a/packages/store/src/jsonfile/types.ts
+++ b/packages/store/src/jsonfile/types.ts
@@ -3,7 +3,7 @@ import type {
   AnyStoreDefinition,
   AnyStoreTable,
   StoreAccessor,
-  StoreConnectorOptions,
+  StoreAdapterOptions,
 } from '../types.js';
 
 /** Connection shape: one StoreAccessor per table name. */
@@ -13,7 +13,7 @@ export type JsonFileConnection<TStore extends Record<string, AnyStoreTable>> =
 /** Options for creating a jsonfile store. */
 export interface JsonFileStoreOptions<
   TStore extends AnyStoreDefinition = AnyStoreDefinition,
-> extends StoreConnectorOptions<TStore> {
+> extends StoreAdapterOptions<TStore> {
   /** Directory where JSON files are written. One `<tableName>.json` per table. */
   readonly dir: string;
   /**

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -18,7 +18,7 @@ const isStoreObjectSchema = (schema: z.ZodType): schema is StoreObjectSchema =>
 
 /**
  * Name of the framework-managed version column used by versioned tables for
- * optimistic concurrency control. Exported so connectors can gate their own
+ * optimistic concurrency control. Exported so adapters can gate their own
  * version-handling logic without duplicating the literal.
  */
 export const versionFieldName = 'version';
@@ -498,10 +498,10 @@ const collectStoreSignals = <const TTables extends StoreTablesInput>(
   );
 
 /**
- * Declare a connector-agnostic store definition from entity schemas and
+ * Declare a backend-agnostic store definition from entity schemas and
  * persistence metadata.
  *
- * The returned value is a normalized, read-only contract that connectors can
+ * The returned value is a normalized, read-only contract that adapters can
  * bind to a concrete runtime later.
  */
 export const store = <const TTables extends StoreTablesInput>(

--- a/packages/store/src/testing.ts
+++ b/packages/store/src/testing.ts
@@ -84,9 +84,9 @@ const seedExistingEntity = async <TTable extends AnyStoreTable>(
 };
 
 /**
- * Shared contract cases for connector-agnostic writable store accessors.
+ * Shared contract cases for backend-agnostic writable store accessors.
  *
- * Connectors can register these with their own `test(...)` wrappers so the
+ * Adapters can register these with their own `test(...)` wrappers so the
  * baseline `get/list/upsert/remove` contract stays aligned across runtimes
  * without fighting repository-specific test-lint rules.
  */

--- a/packages/store/src/trails/crud.ts
+++ b/packages/store/src/trails/crud.ts
@@ -319,7 +319,7 @@ const buildCrudTrails = <TTable extends AnyStoreTable>(
  * Produce the standard CRUD trail tuple for one normalized store table.
  *
  * The factory derives schemas, examples, resources, and contour linkage from
- * the table metadata. Blazes default to the connector-agnostic store accessor
+ * the table metadata. Blazes default to the backend-agnostic store accessor
  * contract via `deriveTrail()`'s single-resource synthesis path. Per-operation
  * blaze overrides stay available for callers that need custom persistence
  * behavior and are layered onto the derived trails in a single pass.

--- a/packages/store/src/trails/reconcile.ts
+++ b/packages/store/src/trails/reconcile.ts
@@ -164,7 +164,7 @@ const recoverConflict = async <TTable extends AnyStoreTable>(
  * Build the input schema for a reconcile trail.
  *
  * `fixtureSchema` makes generated fields (including `version` on versioned
- * tables) optional because connectors populate them. Reconcile, however,
+ * tables) optional because adapters populate them. Reconcile, however,
  * relies on optimistic concurrency: the caller must pass the expected
  * `version` so `assertExpectedVersionMatch` can detect stale payloads. We
  * therefore extend `fixtureSchema` with a required `version` field so
@@ -244,7 +244,7 @@ const createReconcileDetour = <
  * For versioned tables, the derived input schema requires an explicit
  * `version` field so callers cannot sidestep optimistic concurrency at the
  * input boundary. `fixtureSchema` alone makes `version` optional because
- * connectors populate it for writes; reconcile must reject that relaxed
+ * adapters populate it for writes; reconcile must reject that relaxed
  * shape.
  */
 export const reconcile = <

--- a/packages/store/src/trails/utils.ts
+++ b/packages/store/src/trails/utils.ts
@@ -23,7 +23,7 @@ export type TableContour<TTable extends AnyStoreTable> = Contour<
  * Contour validates every example against the shape passed in, so the shape
  * must match how fixtures are actually shaped. Store fixtures may omit
  * framework-generated fields (`createdAt`, `version`, ...) because the
- * connector populates them, so we mirror `fixtureSchema`'s treatment of
+ * adapter populates them, so we mirror `fixtureSchema`'s treatment of
  * generated fields: generated, non-identity fields are made optional; the
  * identity field stays required because read/delete/update all derive their
  * input from it. Previously reconcile.ts and sync.ts passed

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -3,7 +3,7 @@ import type { StoreAccessorProtocol } from '@ontrails/core/store';
 import type { z } from 'zod';
 
 /**
- * Backend-agnostic persistence shapes that a connector can interpret.
+ * Backend-agnostic persistence shapes that an adapter can interpret.
  */
 export type StoreKind = 'tabular' | 'document' | 'file' | 'kv' | 'cache';
 
@@ -133,10 +133,10 @@ export type StoreFixtureRow<
   : never;
 
 /**
- * Connector-owned search metadata.
+ * Adapter-owned search metadata.
  *
  * The core package keeps this opaque on purpose. Search behavior is declared
- * here and interpreted by a concrete connector later.
+ * here and interpreted by a concrete adapter later.
  */
 export type StoreSearchDefinition = Readonly<Record<string, unknown>>;
 
@@ -353,7 +353,7 @@ export interface StoreDefinition<
 /**
  * Structural view of any normalized store table.
  *
- * This stays broad on purpose so connector packages can accept concrete store
+ * This stays broad on purpose so adapter packages can accept concrete store
  * definitions returned by `store(...)` without erasing their table-specific
  * types back to one canonical generic instantiation.
  */
@@ -455,8 +455,8 @@ export type UpdateOf<TTable extends AnyStoreTable> = Partial<
 /**
  * Upsert shape: entity payload with generated fields remaining optional.
  *
- * This matches the connector-agnostic "create or replace" contract while
- * still allowing connectors to synthesize generated values like IDs and
+ * This matches the backend-agnostic "create or replace" contract while
+ * still allowing adapters to synthesize generated values like IDs and
  * timestamps when the caller omits them.
  */
 export type UpsertOf<TTable extends AnyStoreTable> = FixtureInputOf<TTable>;
@@ -502,7 +502,7 @@ export interface ReadOnlyStoreTableAccessor<TTable extends AnyStoreTable> {
 }
 
 /**
- * Connector-agnostic writable operations layered on top of the read contract.
+ * Backend-agnostic writable operations layered on top of the read contract.
  */
 export interface StoreAccessor<
   TTable extends AnyStoreTable,
@@ -513,11 +513,11 @@ export interface StoreAccessor<
    * @throws {AlreadyExistsError} On primary key or unique constraint violation.
    *
    * @remarks
-   * This is an intentional throw-based boundary: store connectors throw typed
+   * This is an intentional throw-based boundary: store adapters throw typed
    * errors (`AlreadyExistsError`) rather than returning `Result`. Trail
    * implementations that call store accessors should catch and convert to
    * `Result.err()` at their level. A future safe variant returning `Result`
-   * is planned but deferred to avoid cascading changes across all connectors.
+   * is planned but deferred to avoid cascading changes across all adapters.
    */
   upsert(input: UpsertOf<TTable>): Promise<EntityOf<TTable>>;
   /**
@@ -561,7 +561,7 @@ export type AssertStoreAccessorSatisfiesProtocol = AssertExtends<
 >;
 
 /**
- * Tabular writable operations layered on top of the connector-agnostic
+ * Tabular writable operations layered on top of the backend-agnostic
  * contract.
  */
 export interface StoreTableAccessor<
@@ -570,7 +570,7 @@ export interface StoreTableAccessor<
   /**
    * Insert a new entity.
    *
-   * Tabular connectors can expose this convenience when the backend has a
+   * Tabular adapters can expose this convenience when the backend has a
    * native distinction between create and update.
    */
   insert(input: InsertOf<TTable>): Promise<EntityOf<TTable>>;
@@ -582,8 +582,8 @@ export interface StoreTableAccessor<
    * On versioned tables, `update` does **not** participate in optimistic
    * concurrency control. The `UpdateOf<TTable>` shape is derived by omitting
    * generated fields — including the framework-managed `version` column — so
-   * any `version` value is dropped before reaching the connector and the
-   * connector always auto-increments without comparing. Callers that need
+   * any `version` value is dropped before reaching the adapter and the
+   * adapter always auto-increments without comparing. Callers that need
    * lost-update protection must use {@link StoreAccessor.upsert | `upsert`}
    * instead and pass the expected `version` in the payload.
    */
@@ -603,7 +603,7 @@ export type ReadOnlyStoreConnection<TStore extends AnyStoreDefinition> = {
 };
 
 /**
- * Connector-agnostic connection shape exposed by a writable bound store.
+ * Backend-agnostic connection shape exposed by a writable bound store.
  */
 export type StoreConnection<TStore extends AnyStoreDefinition> = {
   readonly [TName in keyof TStore['tables']]: StoreAccessor<
@@ -612,7 +612,7 @@ export type StoreConnection<TStore extends AnyStoreDefinition> = {
 };
 
 /**
- * Tabular connection shape exposed by connectors that distinguish insert and
+ * Tabular connection shape exposed by adapters that distinguish insert and
  * patch operations from the generalized `upsert` contract.
  */
 export type StoreTableConnection<TStore extends AnyStoreDefinition> = {
@@ -625,7 +625,7 @@ export type StoreTableConnection<TStore extends AnyStoreDefinition> = {
  * Optional fixture overrides used when building a mock store connection.
  *
  * The shape is a partial map keyed by table name; each entry is a list of
- * fixture inputs validated against the table's fixture schema. Connectors
+ * fixture inputs validated against the table's fixture schema. Adapters
  * share this type so every store backend seeds mocks the same way.
  */
 export type StoreMockSeed<TDef extends AnyStoreDefinition> = Partial<{
@@ -635,13 +635,13 @@ export type StoreMockSeed<TDef extends AnyStoreDefinition> = Partial<{
 }>;
 
 /**
- * Shared connector options every store backend accepts.
+ * Shared adapter options every store backend accepts.
  *
- * Concrete connectors extend this shape with their backend-specific fields
+ * Concrete adapters extend this shape with their backend-specific fields
  * (e.g. `url`, `dir`). Aligning the authored surface here lets the framework
- * reason about connector options uniformly — one shape, many projections.
+ * reason about adapter options uniformly — one shape, many projections.
  */
-export interface StoreConnectorOptions<TDef extends AnyStoreDefinition> {
+export interface StoreAdapterOptions<TDef extends AnyStoreDefinition> {
   /** Optional resource id override. Defaults to `"store"`. */
   readonly id?: string;
   /** Human-readable description surfaced on the resource definition. */

--- a/packages/testing/src/__tests__/all.test.ts
+++ b/packages/testing/src/__tests__/all.test.ts
@@ -88,7 +88,7 @@ const mockedTrail = trail('resource.mocked.all', {
     return Result.ok({ name: entity.name, source: entity.source });
   },
   description:
-    'Trail that uses a mocked connector-bound resource through testAll',
+    'Trail that uses a mocked adapter-bound resource through testAll',
   examples: [
     {
       expected: { name: 'Alpha', source: 'mock' },

--- a/scripts/vocab-cutover-map.ts
+++ b/scripts/vocab-cutover-map.ts
@@ -98,6 +98,17 @@ const reviewedSurfaceMentionPaths = [
   'scripts/rename-audit.sh',
 ] as const;
 
+const reviewedRetiredTaxonomyMentionPaths = [
+  ...changelogHistoryPaths,
+  'docs/adr',
+  'docs/index.md',
+  'docs/lexicon.md',
+  'docs/migration',
+  'docs/releases',
+  'packages/oxlint-plugin/src/__tests__/rules.test.ts',
+  'plugin/rules/lexicon.md',
+] as const;
+
 export const auditRules: readonly VocabAuditRule[] = [
   {
     description:
@@ -231,12 +242,10 @@ export const auditRules: readonly VocabAuditRule[] = [
   },
   {
     description:
-      'Semantic split from connector to runtime adapter requires manual review; mechanical matching is disabled.',
-    excludePaths: ['plugin/rules/vocabulary.md'],
-    id: 'adapter-term',
-    // Intentionally inert: `adapter` is allowed as a runtime-specific layer term.
-    // Connector-vs-adapter drift needs manual role-aware review, not a global regex.
-    pattern: String.raw`(?!)`,
+      'Retired package-boundary terminology still uses connector instead of adapter.',
+    excludePaths: reviewedRetiredTaxonomyMentionPaths,
+    id: 'connector-term',
+    pattern: String.raw`\b[Cc]onnector(s)?\b|[A-Za-z_$][\w$]*[Cc]onnector[A-Za-z_$\d]*|(?:^|/)connectors/`,
   },
   {
     description:

--- a/scripts/vocab-cutover-rewrite.ts
+++ b/scripts/vocab-cutover-rewrite.ts
@@ -778,29 +778,6 @@ const safeRules: readonly VocabRewriteRule[] = [
     apply: (context) =>
       context.isCodeFile
         ? []
-        : [
-            ...collectRegexEdits(
-              context.source,
-              'adapter-prose',
-              /\badapters\b/gi,
-              (match) =>
-                replaceMatchedCase(match[0], 'connectors', 'Connectors')
-            ),
-            ...collectRegexEdits(
-              context.source,
-              'adapter-prose',
-              /\badapter\b/gi,
-              (match) => replaceMatchedCase(match[0], 'connector', 'Connector')
-            ),
-          ],
-    description:
-      'Replace prose-only integration terminology from `adapter` / `adapters` to `connector` / `connectors` in non-code files.',
-    id: 'adapter-prose',
-  },
-  {
-    apply: (context) =>
-      context.isCodeFile
-        ? []
         : collectRegexEdits(
             context.source,
             'entity-prose',
@@ -1105,7 +1082,7 @@ const printRuleList = () => {
     console.log(`- ${rule.id}: ${rule.description}`);
   }
   console.log(
-    '\nAudit-only concepts still needing human review: trigger-call, on-field, layer-type, layers-term, broad surface-term, broad adapter-term.'
+    '\nAudit-only concepts still needing human review: trigger-call, on-field, layer-type, layers-term, broad surface-term, connector-term.'
   );
 };
 


### PR DESCRIPTION
## Context

This turns retired connector vocabulary into an enforceable guardrail now that
the taxonomy and workspace paths have moved to adapter language.

## What Changed

- Added the `connector-term` audit rule for retired connector-class vocabulary.
- Kept broad connector rewrites audit-only so humans review semantic context.
- Renamed the store backend option type to `StoreAdapterOptions`.
- Updated source comments, tests, Oxlint fixtures, and guardrail coverage.

## Verification

- `bun run --cwd packages/oxlint-plugin test`
- `bun scripts/vocab-cutover-audit.ts --rule connector-term`
- `bun run vocab:rewrite -- --list-rules`
- `bun run --cwd packages/store typecheck`
- `bun run --cwd adapters/drizzle typecheck`
- `bun run check`
- `bun run test`
- `bun run build`
- `git diff --check`
- Branch-local changeset gate

## Risks / Rollout

Guardrail branch. The rule is deliberately audit-only for broad prose; this
avoids unsafe mechanical rewrites while still making drift visible.

## Release Metadata

Changesets:

- `.changeset/connector-guardrail-source-comments.md`
- `.changeset/store-adapter-options.md`

Closes: TRL-665
