### PR TITLE
docs: cut consumers to commander adapter

### DIFF
--- a/.changeset/commander-consumer-cutover.md
+++ b/.changeset/commander-consumer-cutover.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Update generated CLI scaffolds and current-facing docs to use the dedicated `@ontrails/commander` adapter package.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Follow the prompts — pick a name, choose a starter, select your surfaces. The 
 Or install manually:
 
 ```bash
-bun add @ontrails/core @ontrails/cli commander zod
+bun add @ontrails/core @ontrails/cli @ontrails/commander zod
 bun add -d @ontrails/testing
 ```
 
@@ -108,7 +108,7 @@ The value isn't any single feature. It's that they multiply — each declaration
 
 ```typescript
 import { trail, topo, Result } from '@ontrails/core';
-import { surface as cliSurface } from '@ontrails/cli/commander';
+import { surface as cliSurface } from '@ontrails/commander';
 import { surface as mcpSurface } from '@ontrails/mcp';
 import { z } from 'zod';
 
@@ -140,7 +140,8 @@ $ myapp greet --name World
 | Package | What it does |
 |---------|-------------|
 | [`@ontrails/core`](./packages/core) | Result, errors, trail/signal/contour/topo, validation, schema derivation |
-| [`@ontrails/cli`](./packages/cli) | CLI surface — flag derivation, output formatting, Commander adapter |
+| [`@ontrails/cli`](./packages/cli) | CLI command model - flag derivation, output formatting |
+| [`@ontrails/commander`](./adapters/commander) | Commander adapter for the CLI surface |
 | [`@ontrails/mcp`](./packages/mcp) | MCP surface — tool generation, annotations, progress bridge |
 | [`@ontrails/http`](./packages/http) | HTTP surface model — route derivation, verb mapping, error responses |
 | [`@ontrails/hono`](./adapters/hono) | Hono adapter that opens a topo on the HTTP surface |

--- a/apps/trails/src/__tests__/create.test.ts
+++ b/apps/trails/src/__tests__/create.test.ts
@@ -159,7 +159,8 @@ const assertCliPackage = (dir: string): void => {
   const deps = pkg['dependencies'] as Record<string, string>;
   expect(deps['@ontrails/core']).toBe(ontrailsPackageRange);
   expect(deps['@ontrails/cli']).toBe(ontrailsPackageRange);
-  expect(deps['commander']).toBe(scaffoldDependencyVersions.commander);
+  expect(deps['@ontrails/commander']).toBe(ontrailsPackageRange);
+  expect(deps['commander']).toBeUndefined();
 };
 
 const assertVerifyPackage = (dir: string): void => {

--- a/apps/trails/src/trails/add-surface.ts
+++ b/apps/trails/src/trails/add-surface.ts
@@ -15,16 +15,13 @@ import {
   resolveProjectPath,
   writeProjectFile,
 } from '../project-writes.js';
-import {
-  ontrailsPackageRange,
-  scaffoldDependencyVersions,
-} from '../versions.js';
+import { ontrailsPackageRange } from '../versions.js';
 import { findTopoPath } from './project.js';
 
 type Surface = 'cli' | 'http' | 'mcp';
 
 const generateCliEntry = (appImportPath: string): string =>
-  `import { surface } from '@ontrails/cli/commander';
+  `import { surface } from '@ontrails/commander';
 
 import { app } from '${appImportPath}';
 
@@ -54,7 +51,7 @@ const surfaceEntryFiles = {
 } satisfies Record<Surface, string>;
 
 const surfaceDependencies = {
-  cli: ['@ontrails/cli'],
+  cli: ['@ontrails/cli', '@ontrails/commander'],
   http: ['@ontrails/hono', '@ontrails/http'],
   mcp: ['@ontrails/mcp'],
 } satisfies Record<Surface, readonly string[]>;
@@ -78,7 +75,6 @@ const patchPkgDeps = (
     deps[dependency] = ontrailsPackageRange;
   }
   if (surface === 'cli') {
-    deps['commander'] = scaffoldDependencyVersions.commander;
     pkg['bin'] = {
       [(pkg['name'] as string | undefined) ?? basename(cwd)]: './src/cli.ts',
     };

--- a/docs/adr/0019-hierarchical-command-trees-from-trail-ids.md
+++ b/docs/adr/0019-hierarchical-command-trees-from-trail-ids.md
@@ -145,4 +145,4 @@ No separate CLI authoring language is introduced. The override is still a projec
 - 2026-04-16: In-place vocabulary update per ADR-0035 Cutover 3 — `buildCliCommands` → `deriveCliCommands`, `trailhead map` → `surface map`.
 
 [^build-cli]: [`packages/cli/src/build.ts`](../../packages/cli/src/build.ts) previously parsed a trail ID into `{ group, name }` by splitting on the first dot. It will call `deriveCliPath` which splits on all dots to produce a full command path.
-[^to-commander]: [`packages/cli/src/commander/to-commander.ts`](../../packages/cli/src/commander/to-commander.ts) previously created only one parent layer keyed by `group`. It will build a full nested command tree via `ensureCommandNode`.
+[^to-commander]: [`adapters/commander/src/to-commander.ts`](../../adapters/commander/src/to-commander.ts) previously created only one parent layer keyed by `group`. It will build a full nested command tree via `ensureCommandNode`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -146,7 +146,7 @@ DeriveTrailSpec<TContour, TOp, TGenerated>
 
 ## `@ontrails/cli`
 
-Current shipped surface packages are `@ontrails/cli`, `@ontrails/mcp`, `@ontrails/http`, and `@ontrails/hono`. A WebSocket surface is planned but has no public package or API yet.
+Current shipped surface packages are `@ontrails/cli`, `@ontrails/commander`, `@ontrails/mcp`, `@ontrails/http`, and `@ontrails/hono`. A WebSocket surface is planned but has no public package or API yet.
 
 ```typescript
 deriveCliCommands(graph, options?)     // projection: Result-returning command definitions
@@ -162,7 +162,7 @@ defaultOnResult(ctx), passthroughResolver, isInteractive(options?)
 InputResolver, ResolveInputOptions
 ```
 
-## `@ontrails/cli/commander`
+## `@ontrails/commander`
 
 ```typescript
 surface(graph, options?)               // one-liner: parse argv, execute, return exit code

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 | Package | What it does | External dep |
 | --- | --- | --- |
 | `@ontrails/cli` | Framework-agnostic command model, flag derivation, output formatting | None beyond core |
-| `@ontrails/cli/commander` | Commander adapter, `surface()` | `commander` (optional peer) |
+| `@ontrails/commander` | Commander adapter, `surface()` | `commander` |
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `surface()` | `@modelcontextprotocol/sdk` |
 | `@ontrails/http` | HTTP routes, error mapping, and OpenAPI generation | None beyond core |
 | `@ontrails/hono` | Hono adapter, `surface()` | `hono` |
@@ -196,7 +196,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 @ontrails/testing (core, cli, mcp, logging)
 @ontrails/topographer (core)
      ^
-@ontrails/cli/commander (cli, commander)
+@ontrails/commander (cli, commander)
 @ontrails/hono (http, hono)
 @ontrails/vite (node:stream only, no workspace deps)
 @ontrails/logtape (logging)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,10 +13,7 @@ This guide demonstrates CLI and MCP first because they are the shortest path to 
 bunx @ontrails/trails create
 
 # Or install manually
-bun add @ontrails/core @ontrails/cli
-
-# Add Commander adapter (for the /commander subpath)
-bun add commander
+bun add @ontrails/core @ontrails/cli @ontrails/commander zod
 
 # Add MCP surface (optional)
 bun add @ontrails/mcp
@@ -93,7 +90,7 @@ export const graph = topo('myapp', greetModule);
 Create `src/cli.ts`:
 
 ```typescript
-import { surface } from '@ontrails/cli/commander';
+import { surface } from '@ontrails/commander';
 import { graph } from './app';
 
 await surface(graph);

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -40,7 +40,7 @@ The boundary-owned rendering where the outside world reaches the trail system.
 CLI, MCP, HTTP, and WebSocket are surfaces.
 
 ```typescript
-import { surface } from '@ontrails/cli/commander';
+import { surface } from '@ontrails/commander';
 await surface(graph);
 
 import { surface as surfaceMcp } from '@ontrails/mcp';

--- a/docs/releases/beta15.md
+++ b/docs/releases/beta15.md
@@ -27,7 +27,7 @@ The CLI surface still uses the current beta.15 import path:
 import { surface } from '@ontrails/cli/commander';
 ```
 
-Moving Commander into a dedicated `@ontrails/commander` connector package is planned for beta 16, not beta 15.
+Moving Commander into a dedicated `@ontrails/commander` adapter package is planned for beta 16, not beta 15.
 
 ### Generated project toolchain
 
@@ -108,7 +108,7 @@ Keep `commander` installed separately for CLI apps in beta.15:
 }
 ```
 
-Do not move CLI imports to `@ontrails/commander` yet. That connector split is planned for beta 16.
+Do not move CLI imports to `@ontrails/commander` yet. That adapter split is planned for beta 16.
 
 ### Existing generated projects
 
@@ -206,7 +206,7 @@ Beta 15 intentionally does not take on the larger CLI grammar and package-shape 
 
 - **Trails CLI improvements** — command grammar and authoring ergonomics for `add trail`, `add surface`, `draft promote`, dry-run plans, and flagless project discovery.
 - **Trails CLI schemas** — a framework-level `schema` command in `@ontrails/cli` so CLI apps can expose derived command contracts by default.
-- **Trails Commander connector** — beta.16 direct cutover from `@ontrails/cli/commander` to a dedicated `@ontrails/commander` connector package, with no compatibility subpath.
+- **Trails Commander adapter** — beta.16 direct cutover from `@ontrails/cli/commander` to a dedicated `@ontrails/commander` adapter package, with no compatibility subpath.
 
 ## Packages
 

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -9,12 +9,11 @@ automatically.
 ## Setup
 
 ```bash
-bun add @ontrails/cli
-bun add commander  # required for the /commander subpath
+bun add @ontrails/cli @ontrails/commander
 ```
 
 ```typescript
-import { surface } from '@ontrails/cli/commander';
+import { surface } from '@ontrails/commander';
 import { graph } from './app';
 
 await surface(graph);
@@ -22,11 +21,8 @@ await surface(graph);
 
 That is the entire CLI setup. Every trail in the app becomes a command.
 
-> **Beta 15 package shape:** Commander is still exposed through the
-> `@ontrails/cli/commander` subpath, with `commander` installed as a peer
-> dependency. The planned beta.16 cleanup is to move Commander into a dedicated
-> `@ontrails/commander` adapter package by direct cutover. Do not use that
-> future import path until the adapter package exists.
+`@ontrails/cli` owns command derivation; `@ontrails/commander` owns Commander
+program materialization and argv parsing.
 
 ## How Trail IDs Map to Commands
 
@@ -234,7 +230,7 @@ The error message is written to stderr. Non-`TrailsError` errors default to exit
 Override the default result handler for custom formatting, logging, or metrics:
 
 ```typescript
-import { surface } from '@ontrails/cli/commander';
+import { surface } from '@ontrails/commander';
 import { output, deriveOutputMode } from '@ontrails/cli';
 
 await surface(graph, {
@@ -278,8 +274,8 @@ strings into ISO 8601 dates before validation:
 ## The Two-Level Architecture
 
 `@ontrails/cli` is framework-agnostic. It produces a `Result<CliCommand[], Error>`
-projection that any CLI framework can consume. The `/commander` subpath
-connects that model to Commander specifically.
+projection that any CLI framework can consume. The `@ontrails/commander`
+adapter connects that model to Commander specifically.
 
 ```typescript
 // Framework-agnostic: build the model
@@ -288,7 +284,7 @@ const commands = deriveCliCommands(graph);
 if (commands.isErr()) throw commands.error;
 
 // Framework-specific: adapt to Commander
-import { toCommander } from '@ontrails/cli/commander';
+import { toCommander } from '@ontrails/commander';
 const program = toCommander(commands.value, { name: 'myapp' });
 program.parse();
 ```
@@ -296,7 +292,7 @@ program.parse();
 Or use `surface()` which does both in one call:
 
 ```typescript
-import { surface } from '@ontrails/cli/commander';
+import { surface } from '@ontrails/commander';
 await surface(graph);
 ```
 

--- a/docs/why-trails.md
+++ b/docs/why-trails.md
@@ -63,7 +63,7 @@ Collect trails into an app with `topo()`. Open it on any surface with `surface()
 const graph = topo('myapp', entityModule, searchModule);
 
 // CLI
-import { surface } from '@ontrails/cli/commander';
+import { surface } from '@ontrails/commander';
 await surface(graph);
 
 // MCP

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -26,7 +26,7 @@ const greet = trail('greet', {
 const graph = topo('myapp', greetModule);
 
 // 3. Open surfaces
-await surface(graph);        // CLI — from @ontrails/cli/commander
+await surface(graph);        // CLI — from @ontrails/commander
 // await surface(graph);     // MCP — from @ontrails/mcp
 
 // 4. Headless execution (no surface needed)
@@ -103,7 +103,7 @@ Adding a surface is a `surface()` call, not an architecture change. The framewor
 **CLI**: Flags from Zod, subcommands from dotted IDs, exit codes from error taxonomy.
 
 ```typescript
-import { surface } from '@ontrails/cli/commander';
+import { surface } from '@ontrails/commander';
 await surface(graph);
 ```
 

--- a/plugin/skills/trails/examples/cli-command.md
+++ b/plugin/skills/trails/examples/cli-command.md
@@ -74,7 +74,7 @@ Dotted IDs become subcommands. Flags derive from the Zod schema:
 ```typescript
 // cli.ts
 import { topo } from '@ontrails/core';
-import { surface } from '@ontrails/cli/commander';
+import { surface } from '@ontrails/commander';
 import * as deploy from './trails/deploy.js';
 
 const graph = topo('myapp', deploy);

--- a/plugin/skills/trails/examples/express-handler.md
+++ b/plugin/skills/trails/examples/express-handler.md
@@ -95,7 +95,7 @@ Wire to CLI or MCP with the same trails. The `db.mock()` factory is used automat
 ```typescript
 // cli.ts
 import { topo } from '@ontrails/core';
-import { surface } from '@ontrails/cli/commander';
+import { surface } from '@ontrails/commander';
 import * as project from './trails/project.js';
 import * as resources from './resources/db.js';
 

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -86,7 +86,7 @@ Warden uses inference to verify declarations match actual code. The surface map 
 | Package | Purpose | External dep |
 |---------|---------|-------------|
 | `@ontrails/cli` | Command model, flag derivation, output formatting | None beyond core |
-| `@ontrails/cli/commander` | Commander adapter, `surface()` | `commander` (peer) |
+| `@ontrails/commander` | Commander adapter, `surface()` | `commander` |
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `surface()` | `@modelcontextprotocol/sdk` |
 | `@ontrails/http` | HTTP route definitions (framework-agnostic) | None beyond core |
 | `@ontrails/hono` | Hono adapter, `surface()` | `hono` |
@@ -125,7 +125,7 @@ Warden uses inference to verify declarations match actual code. The surface map 
   <- @ontrails/drizzle (store, drizzle-orm)
   <- @ontrails/testing (core, cli, mcp, logging)
   <- @ontrails/topographer (core)
-     <- @ontrails/cli/commander (cli, commander)
+     <- @ontrails/commander (cli, commander)
      <- @ontrails/hono (http, hono)
      <- @ontrails/vite (node:stream only)
      <- @ontrails/logtape (logging)

--- a/plugin/skills/trails/references/cli-surface.md
+++ b/plugin/skills/trails/references/cli-surface.md
@@ -127,7 +127,7 @@ For full control over the Commander.js program, use `deriveCliCommands()` to get
 
 ```typescript
 import { deriveCliCommands } from '@ontrails/cli';
-import { toCommander } from '@ontrails/cli/commander';
+import { toCommander } from '@ontrails/commander';
 import { graph } from './app';
 
 const commands = deriveCliCommands(graph);

--- a/plugin/skills/trails/references/getting-started.md
+++ b/plugin/skills/trails/references/getting-started.md
@@ -9,8 +9,7 @@
 bunx @ontrails/trails create
 
 # Or install manually
-bun add @ontrails/core @ontrails/cli zod
-bun add commander                    # Commander adapter
+bun add @ontrails/core @ontrails/cli @ontrails/commander zod
 bun add @ontrails/mcp @modelcontextprotocol/sdk # MCP surface (optional)
 bun add -d @ontrails/testing         # Testing (dev)
 ```
@@ -72,7 +71,7 @@ export const graph = topo('myapp', greetModule);
 Create `src/cli.ts`:
 
 ```typescript
-import { surface } from '@ontrails/cli/commander';
+import { surface } from '@ontrails/commander';
 import { graph } from './app';
 
 await surface(graph);

--- a/plugin/skills/trails/references/migration-checklist.md
+++ b/plugin/skills/trails/references/migration-checklist.md
@@ -47,7 +47,7 @@ For each handler:
 ## Phase 4: Composition
 
 - [ ] Create topo: `topo('appname', ...modules)`
-- [ ] Open CLI surface: `await surface(graph)` from `@ontrails/cli/commander`
+- [ ] Open CLI surface: `await surface(graph)` from `@ontrails/commander`
 - [ ] Open MCP surface: `await surface(graph)` from `@ontrails/mcp`
 - [ ] Remove old routing/command setup code
 


### PR DESCRIPTION
## Context

This directly cuts current consumers and docs from `@ontrails/cli/commander` to
the new `@ontrails/commander` adapter package.

## What Changed

- Updated generated CLI scaffolds and add-surface output to depend on
  `@ontrails/commander`.
- Updated current-facing docs, README examples, plugin examples, and skill
  references.
- Left historical/release references only where clearly historical or migration
  context.

## Verification

- `bun run --cwd apps/trails typecheck`
- `bun run --cwd apps/trails test`
- Exact residual sweep for `@ontrails/cli/commander`
- `bun run check`
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run build`
- `bun run format:check`
- Branch-local changeset gate

## Risks / Rollout

Breaking beta consumer cutover. This intentionally does not keep a compatibility
subpath, so consumers must import from `@ontrails/commander`.

## Release Metadata

Changeset: `.changeset/commander-consumer-cutover.md`.

Closes: TRL-640
