### PR TITLE
docs: verify commander migration complete

### DIFF
--- a/.scratch/2026-05-08-adapter-commander-stack/final-verification.md
+++ b/.scratch/2026-05-08-adapter-commander-stack/final-verification.md
@@ -1,0 +1,69 @@
+# Final Commander Migration Verification
+
+Date: 2026-05-08
+Issue: TRL-642
+Branch: `trl-642-final-verification-ontrailscommander-migration-complete`
+
+## Scope
+
+This closes the local Commander cutover stack after TRL-638, TRL-639, TRL-640,
+and TRL-641 are present underneath this branch.
+
+## Active State
+
+- Active source imports use `@ontrails/commander`.
+- Active docs, scaffold output, app packages, and plugin references teach
+  `@ontrails/commander`.
+- `@ontrails/cli` no longer exports a `./commander` subpath.
+- `@ontrails/commander` owns the Commander runtime adapter package under
+  `adapters/commander`.
+- There is no `@ontrails/cli/commander` compatibility alias or package-export
+  bridge.
+
+## Accepted Residuals
+
+`rg -n "@ontrails/cli/commander" apps packages docs README.md .agents .claude --glob "*.ts" --glob "*.tsx" --glob "*.md" --glob "*.json"`
+returns only these accepted buckets:
+
+| Bucket | Paths | Reason |
+| --- | --- | --- |
+| Migration guidance | `docs/migration/connector-to-adapter.md` | Shows the before/after Commander import and states there is no long-lived compatibility subpath. |
+| Accepted ADR history | `docs/adr/0029-connector-extraction-and-the-with-packaging-model.md` | Records the pre-split adapter subpath and the beta.16 move to `@ontrails/commander`. |
+| Release history | `docs/releases/beta15.md` | Preserves beta.15 guidance and explicitly says the beta.16 split moves to `@ontrails/commander`. |
+| Local planning history | `.agents/plans/v1/**` | Historical local plans, not current package guidance or scaffold output. |
+
+`rg -ni "commander.*connector|connector.*commander" apps packages docs README.md .agents .claude --glob "*.md" --glob "*.ts" --glob "*.tsx"`
+returns only ADR/changelog history, not current-facing Commander package
+guidance.
+
+## Publishing And Merge Safety
+
+- Changesets in this stack are version/changelog metadata only.
+- `bun run publish:check` is the package verification command used here.
+- No real publish was run.
+- No PR or local command added a merge queue label.
+- The only `changeset publish` / `npm publish` wording in current docs is the
+  explicit prohibition in `docs/migration/connector-to-adapter.md`.
+
+## Verification Commands
+
+The following commands passed at the stack tip after this file was added:
+
+```bash
+rg -n "@ontrails/cli/commander" apps packages docs README.md .agents .claude --glob "*.ts" --glob "*.tsx" --glob "*.md" --glob "*.json"
+rg -ni "commander.*connector|connector.*commander" apps packages docs README.md .agents .claude --glob "*.md" --glob "*.ts" --glob "*.tsx"
+bun scripts/vocab-cutover-audit.ts --rule legacy-extracted-adapter-subpath
+bun scripts/vocab-cutover-audit.ts --rule connector-term
+bun run vocab:rewrite -- --list-rules
+bun scripts/adr.ts map
+bun scripts/adr.ts check
+bun run check
+bun run typecheck
+bun run test
+bun run lint
+bun run lint:ast-grep
+bun run build
+bun run format:check
+bun run publish:check
+git diff --check
+```

--- a/.scratch/2026-05-08-adapter-commander-stack/local-review-pass-1.md
+++ b/.scratch/2026-05-08-adapter-commander-stack/local-review-pass-1.md
@@ -1,0 +1,80 @@
+# Local Review Pass 1
+
+Date: 2026-05-08
+Scope: Bottom-to-top review of the Adapter Taxonomy + Commander Cutover stack.
+
+## Lanes Reviewed
+
+- Taxonomy/API: TRL-660, TRL-661, TRL-662, TRL-664.
+- Guardrail/audit: TRL-665, TRL-641, TRL-642.
+- Commander package: TRL-638, TRL-639, TRL-640.
+- Release/package metadata: branch-local changesets, package exports, package
+  manifests, and publish discipline.
+
+## Findings
+
+### P1 - TRL-663 missing changesets for moved adapter workspaces
+
+The branch-local changeset gate failed for TRL-663:
+
+```text
+Package-affecting changes need changeset entries for: @ontrails/drizzle, @ontrails/hono, @ontrails/vite
+Affected packages: @ontrails/drizzle, @ontrails/hono, @ontrails/vite
+```
+
+Fix applied on TRL-663: added `.changeset/adapter-workspace-root.md` covering
+`@ontrails/drizzle`, `@ontrails/hono`, and `@ontrails/vite` as patch metadata
+for the workspace-root move.
+
+Verification after fix:
+
+```text
+Changeset gate passed for: @ontrails/drizzle, @ontrails/hono, @ontrails/vite
+Changed changesets: .changeset/adapter-workspace-root.md
+```
+
+### P1 - TRL-661 missing changeset coverage for `@ontrails/trails`
+
+The branch-local changeset gate failed for TRL-661 because the branch updates
+`@ontrails/trails` source while the changeset only named `@ontrails/permits`:
+
+```text
+Package-affecting changes need changeset entries for: @ontrails/trails
+Affected packages: @ontrails/permits, @ontrails/trails
+Changed changesets: .changeset/permits-connector-to-adapter.md
+```
+
+Fix applied on TRL-661: updated `.changeset/permits-connector-to-adapter.md`
+to include `@ontrails/trails` patch metadata and explain the generated
+auth-resource config update to the new `adapter` discriminant.
+
+Verification after fix:
+
+```text
+Changeset gate passed for: @ontrails/permits, @ontrails/trails
+Changed changesets: .changeset/permits-connector-to-adapter.md
+```
+
+## Additional Checks
+
+No remaining P0/P1/P2 findings after the fixes above.
+
+Evidence commands:
+
+```bash
+rg -n "AuthConnector|authConnector|JwtConnector|createJwtConnector|OtelConnector|createOtelConnector|StoreConnectorOptions" packages adapters apps scripts --glob "*.ts" --glob "!**/CHANGELOG.md"
+rg -n "@ontrails/cli/commander|from ['\"]@ontrails/(http/hono|store/drizzle|cli/commander)['\"]|import\(['\"]@ontrails/(http/hono|store/drizzle|cli/commander)['\"]\)" apps packages adapters scripts --glob "*.ts" --glob "*.tsx" --glob "*.json"
+rg -n "connectors/|workspace:connectors|\"connectors/|src/connectors|/connectors" package.json bun.lock README.md apps packages adapters scripts docs .github .ast-grep --glob "!**/CHANGELOG.md" --glob "!.scratch/**"
+rg -n "changeset publish|npm publish|merge queue|merge-queue|merge_queue" .changeset docs README.md packages apps adapters --glob "*.md" --glob "*.json"
+rg -n "\./commander|@ontrails/cli/commander" packages/cli/package.json packages/cli/src adapters/commander apps packages --glob "*.json" --glob "*.ts"
+```
+
+Accepted residuals:
+
+- `AuthConnector` fixtures remain only in Oxlint guardrail tests.
+- `connectors/` residuals are migration docs, ADR history, or guardrail
+  predicates/fixtures.
+- `changeset publish` / `npm publish` appears only as explicit prohibition in
+  `docs/migration/connector-to-adapter.md`.
+- No active `@ontrails/cli/commander`, `@ontrails/http/hono`, or
+  `@ontrails/store/drizzle` imports remain in source.

--- a/.scratch/2026-05-08-adapter-commander-stack/local-review-pass-2.md
+++ b/.scratch/2026-05-08-adapter-commander-stack/local-review-pass-2.md
@@ -1,0 +1,68 @@
+# Local Review Pass 2
+
+Date: 2026-05-08
+Scope: Independent follow-up review after pass-1 fixes and restack.
+
+## Result
+
+No remaining P0/P1/P2 findings.
+
+## Branch-Local Release Gates
+
+All package-affecting branches pass the repo changeset gate:
+
+```text
+TRL-661: @ontrails/permits, @ontrails/trails
+TRL-662: @ontrails/tracing
+TRL-663: @ontrails/drizzle, @ontrails/hono, @ontrails/vite
+TRL-664: @ontrails/cli, @ontrails/config, @ontrails/drizzle, @ontrails/hono, @ontrails/http, @ontrails/logging, @ontrails/mcp, @ontrails/observe, @ontrails/store
+TRL-665: @ontrails/cli, @ontrails/core, @ontrails/drizzle, @ontrails/hono, @ontrails/http, @ontrails/logtape, @ontrails/mcp, @ontrails/observe, @ontrails/store
+TRL-639: @ontrails/cli, @ontrails/commander, @ontrails/trails
+TRL-640: @ontrails/trails
+```
+
+## Stack-Tip Verification
+
+The final stack tip passed:
+
+```bash
+bun scripts/adr.ts map
+bun scripts/adr.ts check
+bun run typecheck
+bun run test
+bun run lint
+bun run lint:ast-grep
+bun run build
+bun run format:check
+bun run check
+bun run publish:check
+bun scripts/vocab-cutover-audit.ts --rule connector-term
+bun scripts/vocab-cutover-audit.ts --rule legacy-extracted-adapter-subpath
+bun run vocab:rewrite -- --list-rules
+git diff --check
+```
+
+`bun run check` remains a Warden PASS with the existing 23 warnings.
+
+## Residual Classification
+
+`@ontrails/cli/commander` remains only in accepted buckets:
+
+- `docs/migration/connector-to-adapter.md` migration guidance.
+- `docs/adr/0029-connector-extraction-and-the-with-packaging-model.md`
+  historical ADR context.
+- `docs/releases/beta15.md` release history.
+- `.agents/plans/v1/**` local historical planning.
+
+`commander.*connector` / `connector.*commander` remains only in accepted ADR and
+changelog history. Current-facing Commander guidance teaches
+`@ontrails/commander`.
+
+`changeset publish` / `npm publish` appears only as the explicit prohibition in
+`docs/migration/connector-to-adapter.md`. No merge-queue wording appears in
+current docs, changesets, package manifests, or source.
+
+## Notes
+
+No real publish command was run. No Graphite submit has run yet. No merge queue
+label was added.


### PR DESCRIPTION
## Context

This is the terminal verification branch for the Commander package migration.

## What Changed

- Added final verification notes for the Commander cutover.
- Added two local review reports.
- Recorded accepted residual buckets for historical/migration references.
- Verified publishing and release-metadata safety without running a real
  publish.

## Verification

- `rg -n "@ontrails/cli/commander" apps packages docs README.md .agents .claude --glob "*.ts" --glob "*.tsx" --glob "*.md" --glob "*.json"`
- `rg -ni "commander.*connector|connector.*commander" apps packages docs README.md .agents .claude --glob "*.md" --glob "*.ts" --glob "*.tsx"`
- `bun scripts/vocab-cutover-audit.ts --rule legacy-extracted-adapter-subpath`
- `bun scripts/vocab-cutover-audit.ts --rule connector-term`
- `bun run vocab:rewrite -- --list-rules`
- `bun scripts/adr.ts map`
- `bun scripts/adr.ts check`
- `bun run check`
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run build`
- `bun run format:check`
- `bun run publish:check`
- Whole-stack changeset gate
- `git diff --check`

## Risks / Rollout

Verification artifacts only. The local review loop found and fixed two P1
issues before submit: missing branch-local changeset coverage on TRL-663 for
the moved adapter workspaces, and missing `@ontrails/trails` changeset coverage
on TRL-661. Both owning branches now pass their changeset gates.

## Release Metadata

No changeset: this branch adds verification and review artifacts only.

Closes: TRL-642
