### PR TITLE
feat(adapters): add @ontrails/bun adapter

### DIFF
--- a/.changeset/bun-adapter-package.md
+++ b/.changeset/bun-adapter-package.md
@@ -1,0 +1,22 @@
+---
+'@ontrails/bun': major
+---
+
+Add `@ontrails/bun`, a Bun.serve adapter that projects `HttpRouteDefinition[]`
+from `@ontrails/http` directly onto Bun's native routes API. Mirrors the
+`createApp` + `surface` exported shape of `@ontrails/hono` but skips the Hono
+dependency for Bun-only deployments. v0 covers GET/POST happy paths, the
+documented JSON-body error sentinels (413, 400 for malformed Content-Length,
+400 for malformed JSON), redacted 500 for non-Trails errors, and a 404 fetch
+fallback. Webhook trails (`inputSource: 'webhook'`) are rejected at
+`createApp()` time with a `ValidationError` rather than silently 501-ing at
+request time; webhook support will land in a follow-up.
+
+The `major` bump keeps the package in lockstep with the rest of the
+`@ontrails/*` workspace (matching the precedent set by `wayfinder-shell` and
+`api-simplification-beta4`).
+
+Also adds `bun` to the `allowedPackages` list for the
+`trails-local/no-console-in-packages` oxlint rule, matching the precedent for
+`drizzle`, `hono`, `logging`, and `observe`. The adapter routes generic-error
+diagnostics through `console.error` at the same boundary the hono adapter uses.

--- a/adapters/bun/CHANGELOG.md
+++ b/adapters/bun/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @ontrails/bun
+
+## 1.0.0-beta.15
+
+Initial package placeholder.

--- a/adapters/bun/README.md
+++ b/adapters/bun/README.md
@@ -1,0 +1,69 @@
+# @ontrails/bun
+
+Bun.serve adapter for Trails. Use this package when you want to serve a topo over HTTP with Bun's native server while keeping `@ontrails/http` focused on framework-agnostic route building.
+
+## Usage
+
+```typescript
+import { surface } from '@ontrails/bun';
+import { graph } from './app';
+
+await surface(graph, { port: 3000 });
+```
+
+JSON request bodies are capped at 1 MiB by default. Override the cap with
+`maxJsonBodyBytes` when a surface intentionally accepts larger JSON payloads:
+
+```typescript
+await surface(graph, {
+  maxJsonBodyBytes: 2 * 1024 * 1024,
+  port: 3000,
+});
+```
+
+Generic non-TrailsError failures return a redacted 500 response while the
+original error is written to server diagnostics.
+
+For lower-level adapter wiring, derive routes with `@ontrails/http` and pass
+them to your own `Bun.serve` invocation:
+
+```typescript
+import { createApp } from '@ontrails/bun';
+import { graph } from './app';
+
+const handler = createApp(graph);
+
+Bun.serve({
+  error: handler.onError,
+  fetch: handler.fetch,
+  port: 3000,
+  routes: handler.routes,
+});
+```
+
+## Installation
+
+```bash
+bun add @ontrails/http @ontrails/bun
+```
+
+## Versus @ontrails/hono
+
+Both packages adapt `HttpRouteDefinition[]` from `@ontrails/http` onto an HTTP
+runtime. `@ontrails/hono` wraps Hono in front of `Bun.serve`, which keeps the
+deployment story portable across Workers, Deno, and Node. `@ontrails/bun` skips
+Hono and registers routes directly on `Bun.serve`'s native routes API. Use
+`@ontrails/hono` when runtime portability matters; use `@ontrails/bun` when the
+target is Bun and you want the smaller dependency tree.
+
+## Webhook trails
+
+Webhook input source (`inputSource: 'webhook'`) is not supported in v0.
+`createApp()` throws `ValidationError` at build time when any webhook trail is
+present, naming the offending trail. This is a deliberate loud-error posture
+rather than a silent runtime 501. Use `@ontrails/hono` if you have webhook
+trails today; this adapter will ship webhook support in a follow-up.
+
+## Bun version
+
+Requires Bun 1.2.3 or newer. Uses `Bun.serve`'s native routes API.

--- a/adapters/bun/package.json
+++ b/adapters/bun/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@ontrails/bun",
+  "version": "1.0.0-beta.15",
+  "description": "Bun.serve adapter for Trails. Project a topo onto Bun's native HTTP server with no Hono dependency.",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "dependencies": {
+    "@ontrails/core": "workspace:^"
+  },
+  "peerDependencies": {
+    "@ontrails/http": "workspace:^",
+    "zod": "catalog:"
+  },
+  "engines": {
+    "bun": ">=1.2.3"
+  }
+}

--- a/adapters/bun/src/__tests__/surface.test.ts
+++ b/adapters/bun/src/__tests__/surface.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import {
+  NotFoundError,
+  Result,
+  topo,
+  trail,
+  ValidationError,
+  webhook,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+import { createApp, surface } from '../surface.js';
+
+let originalConsoleError = console.error;
+let loggedErrors: unknown[][] = [];
+
+beforeEach(() => {
+  originalConsoleError = console.error;
+  loggedErrors = [];
+  console.error = mock((...args: unknown[]) => {
+    loggedErrors.push(args);
+  });
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+  loggedErrors = [];
+});
+
+const echoTrail = trail('echo', {
+  blaze: (input) => Result.ok({ reply: input.message }),
+  input: z.object({ message: z.string() }),
+  intent: 'read',
+  output: z.object({ reply: z.string() }),
+});
+
+const echoBodyTrail = trail('echo.body', {
+  blaze: (input) => Result.ok({ length: input.message.length }),
+  input: z.object({ message: z.string() }),
+  intent: 'write',
+  output: z.object({ length: z.number() }),
+});
+
+const notFoundTrail = trail('item.show', {
+  blaze: () => Result.err(new NotFoundError('item not found')),
+  input: z.object({ id: z.string() }),
+  intent: 'read',
+  output: z.object({ id: z.string() }),
+});
+
+const genericErrorTrail = trail('generic.error', {
+  blaze: () => Result.err(new Error('database password=secret')),
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+});
+
+const webhookSpec = webhook('webhook.payment', {
+  parse: z.object({ paymentId: z.string() }),
+  path: '/webhooks/payment',
+});
+
+const paymentWebhookTrail = trail('payment.receive', {
+  blaze: (input) => Result.ok({ paymentId: input.paymentId }),
+  input: z.object({ paymentId: z.string() }),
+  on: [webhookSpec],
+  output: z.object({ paymentId: z.string() }),
+});
+
+const buildRequest = (
+  path: string,
+  init: RequestInit & { url?: string } = {}
+): Request => {
+  const base = init.url ?? 'http://localhost:3000';
+  const url = new URL(path, base).toString();
+  return new Request(url, init);
+};
+
+const callRoute = async (
+  handler: ReturnType<typeof createApp>,
+  method: string,
+  path: string,
+  init: RequestInit = {}
+): Promise<Response> => {
+  const url = new URL(path, 'http://localhost:3000');
+  const route = handler.routes[url.pathname];
+  if (!route) {
+    return handler.fetch(buildRequest(path, init));
+  }
+  const methodHandler = route[method as keyof typeof route];
+  if (!methodHandler) {
+    return handler.fetch(buildRequest(path, init));
+  }
+  return methodHandler(buildRequest(path, init));
+};
+
+describe('@ontrails/bun adapter', () => {
+  describe('createApp', () => {
+    test('returns a route record keyed by trail path', () => {
+      const graph = topo('test', { echoTrail });
+      const handler = createApp(graph);
+      expect(handler.routes['/echo']).toBeDefined();
+      expect(handler.routes['/echo']?.GET).toBeTypeOf('function');
+    });
+
+    test('throws ValidationError when a webhook trail is present', () => {
+      const graph = topo('test', { paymentWebhookTrail });
+      expect(() => createApp(graph)).toThrow(ValidationError);
+    });
+
+    test('rejects an invalid maxJsonBodyBytes option', () => {
+      const graph = topo('test', { echoTrail });
+      expect(() => createApp(graph, { maxJsonBodyBytes: 0 })).toThrow(
+        ValidationError
+      );
+    });
+  });
+
+  describe('routing', () => {
+    test('GET with query params returns the trail Result', async () => {
+      const graph = topo('test', { echoTrail });
+      const handler = createApp(graph);
+
+      const response = await callRoute(handler, 'GET', '/echo?message=hi');
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { data: { reply: string } };
+      expect(body.data.reply).toBe('hi');
+    });
+
+    test('POST with JSON body returns the trail Result', async () => {
+      const graph = topo('test', { echoBodyTrail });
+      const handler = createApp(graph);
+
+      const response = await callRoute(handler, 'POST', '/echo/body', {
+        body: JSON.stringify({ message: 'hello' }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { data: { length: number } };
+      expect(body.data.length).toBe(5);
+    });
+
+    test('unmatched path returns 404 via fetch fallback', async () => {
+      const graph = topo('test', { echoTrail });
+      const handler = createApp(graph);
+
+      const response = await handler.fetch(buildRequest('/missing'));
+
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as {
+        error: { category: string; code: string };
+      };
+      expect(body.error.category).toBe('not_found');
+      expect(body.error.code).toBe('RouteNotFound');
+    });
+  });
+
+  describe('body validation', () => {
+    test('JSON body over the cap returns 413', async () => {
+      const graph = topo('test', { echoBodyTrail });
+      const handler = createApp(graph, { maxJsonBodyBytes: 32 });
+
+      const oversize = JSON.stringify({ message: 'x'.repeat(64) });
+      const response = await callRoute(handler, 'POST', '/echo/body', {
+        body: oversize,
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(413);
+      const body = (await response.json()) as {
+        error: { category: string; message: string };
+      };
+      expect(body.error.category).toBe('validation');
+      expect(body.error.message).toContain('exceeds');
+    });
+
+    test('malformed Content-Length returns 400', async () => {
+      const graph = topo('test', { echoBodyTrail });
+      const handler = createApp(graph);
+
+      const response = await callRoute(handler, 'POST', '/echo/body', {
+        body: JSON.stringify({ message: 'hi' }),
+        headers: {
+          'Content-Length': 'not-a-number',
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: { code: string } };
+      expect(body.error.code).toBe('ValidationError');
+    });
+
+    test('malformed JSON returns 400', async () => {
+      const graph = topo('test', { echoBodyTrail });
+      const handler = createApp(graph);
+
+      const response = await callRoute(handler, 'POST', '/echo/body', {
+        body: '{not valid json',
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: { message: string } };
+      expect(body.error.message).toContain('Invalid JSON');
+    });
+  });
+
+  describe('error mapping', () => {
+    test('NotFoundError result returns 404 with the projected category', async () => {
+      const graph = topo('test', { notFoundTrail });
+      const handler = createApp(graph);
+
+      const response = await callRoute(handler, 'GET', '/item/show?id=p_0');
+
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as {
+        error: { category: string; code: string };
+      };
+      expect(body.error.code).toBe('NotFoundError');
+    });
+
+    test('non-Trails error returns redacted 500 without leaking the message', async () => {
+      const graph = topo('test', { genericErrorTrail });
+      const handler = createApp(graph);
+
+      const response = await callRoute(handler, 'GET', '/generic/error');
+
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as {
+        error: { category: string; code: string; message: string };
+      };
+      expect(body.error.category).toBe('internal');
+      expect(body.error.code).toBe('InternalError');
+      expect(body.error.message).toBe('Internal server error');
+      expect(body.error.message).not.toContain('password=secret');
+
+      // Original error is logged to the diagnostic boundary
+      expect(loggedErrors.length).toBe(1);
+    });
+  });
+
+  describe('surface', () => {
+    test('starts a server, returns url and close, and serves requests', async () => {
+      const graph = topo('test', { echoTrail });
+      const result = await surface(graph, { port: 0 });
+
+      try {
+        expect(result.url).toContain('http://');
+        const response = await fetch(`${result.url}echo?message=ping`);
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as { data: { reply: string } };
+        expect(body.data.reply).toBe('ping');
+      } finally {
+        await result.close();
+      }
+    });
+  });
+});

--- a/adapters/bun/src/index.ts
+++ b/adapters/bun/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  createApp,
+  surface,
+  type CreateAppOptions,
+  type BunRouteRecord,
+  type SurfaceHttpResult,
+} from './surface.js';

--- a/adapters/bun/src/surface.ts
+++ b/adapters/bun/src/surface.ts
@@ -1,0 +1,568 @@
+/**
+ * Bun.serve adapter for Trails HTTP routes.
+ *
+ * Takes framework-agnostic `HttpRouteDefinition[]` and projects them onto
+ * `Bun.serve`'s native routes API with no Hono dependency.
+ *
+ * ```ts
+ * const graph = topo("myapp", entity);
+ * await surface(graph, { port: 3000 });
+ * ```
+ */
+
+import {
+  isTrailsError,
+  projectSurfaceError,
+  ValidationError,
+} from '@ontrails/core';
+import type {
+  BaseSurfaceOptions,
+  Layer,
+  ResourceOverrideMap,
+  Topo,
+  TrailContextInit,
+} from '@ontrails/core';
+import { deriveHttpRoutes } from '@ontrails/http';
+import type { HttpMethod, HttpRouteDefinition } from '@ontrails/http';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface CreateAppOptions extends BaseSurfaceOptions {
+  readonly basePath?: string | undefined;
+  readonly createContext?:
+    | (() => TrailContextInit | Promise<TrailContextInit>)
+    | undefined;
+  readonly hostname?: string | undefined;
+  readonly layers?: readonly Layer[] | undefined;
+  /** Maximum JSON request body size in bytes. Defaults to 1 MiB. */
+  readonly maxJsonBodyBytes?: number | undefined;
+  readonly name?: string | undefined;
+  readonly port?: number | undefined;
+  readonly resources?: ResourceOverrideMap | undefined;
+}
+
+interface RuntimeOptions {
+  readonly maxJsonBodyBytes: number;
+}
+
+const DEFAULT_MAX_JSON_BODY_BYTES = 1024 * 1024;
+
+export interface SurfaceHttpResult {
+  readonly close: () => Promise<void>;
+  readonly url: string;
+}
+
+type RouteHandler = (req: Request) => Response | Promise<Response>;
+
+/**
+ * Bun.serve `routes` shape produced by `createApp`. Indexed by static path
+ * (paths are derived from trail IDs and contain no dynamic segments), with
+ * per-method handlers that adapt the route's input source to a Web Standard
+ * `Request` and map the trail's `Result` to a `Response`.
+ */
+export type BunRouteRecord = Record<
+  string,
+  Partial<Record<HttpMethod, RouteHandler>>
+>;
+
+// ---------------------------------------------------------------------------
+// Request parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse query params into a plain object, preserving scalar-vs-array shape.
+ *
+ * A single `?tag=one` stays a scalar string, while repeated keys like
+ * `?tag=one&tag=two` become arrays. Schema validation owns whether that shape
+ * is accepted; the adapter does not coerce singleton values into arrays.
+ */
+const parseQueryParams = (req: Request): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  const url = new URL(req.url);
+  const seenKeys = new Set<string>();
+
+  for (const key of url.searchParams.keys()) {
+    if (seenKeys.has(key)) {
+      continue;
+    }
+    seenKeys.add(key);
+    const all = url.searchParams.getAll(key);
+    result[key] = all.length > 1 ? all : all[0];
+  }
+
+  return result;
+};
+
+/** Sentinel indicating a JSON parse failure. */
+const JSON_PARSE_ERROR = Symbol('JSON_PARSE_ERROR');
+
+/** Sentinel indicating a JSON body rejected before parsing. */
+const JSON_BODY_TOO_LARGE = Symbol('JSON_BODY_TOO_LARGE');
+
+/** Sentinel indicating malformed body metadata. */
+const JSON_BODY_INVALID_CONTENT_LENGTH = Symbol(
+  'JSON_BODY_INVALID_CONTENT_LENGTH'
+);
+
+interface JsonObject {
+  readonly [key: string]: JsonValue;
+}
+
+type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly JsonValue[]
+  | JsonObject;
+
+type JsonBodyReadResult =
+  | JsonValue
+  | typeof JSON_BODY_INVALID_CONTENT_LENGTH
+  | typeof JSON_PARSE_ERROR
+  | typeof JSON_BODY_TOO_LARGE;
+
+type InputReadResult = Record<string, unknown> | JsonBodyReadResult;
+
+const CONTENT_LENGTH_DECIMAL_PATTERN = /^\d+$/;
+
+type ParsedContentLength =
+  | number
+  | typeof JSON_BODY_INVALID_CONTENT_LENGTH
+  | undefined;
+
+const parseContentLength = (
+  contentLength: string | null | undefined
+): ParsedContentLength => {
+  if (contentLength === null || contentLength === undefined) {
+    return undefined;
+  }
+  if (!CONTENT_LENGTH_DECIMAL_PATTERN.test(contentLength)) {
+    return JSON_BODY_INVALID_CONTENT_LENGTH;
+  }
+  const size = Number(contentLength);
+  return Number.isSafeInteger(size) ? size : Number.MAX_SAFE_INTEGER;
+};
+
+/** Return true when the request has no body content. */
+const isEmptyBody = (req: Request): boolean => {
+  const contentLength = parseContentLength(req.headers.get('Content-Length'));
+  if (contentLength === JSON_BODY_INVALID_CONTENT_LENGTH) {
+    return false;
+  }
+  if (contentLength !== undefined) {
+    return contentLength === 0;
+  }
+  // No Content-Length header — treat as empty when Content-Type is also absent.
+  return req.headers.get('Content-Type') === null;
+};
+
+const resolveMaxJsonBodyBytes = (value: number | undefined): number => {
+  const maxJsonBodyBytes = value ?? DEFAULT_MAX_JSON_BODY_BYTES;
+
+  if (!Number.isFinite(maxJsonBodyBytes) || maxJsonBodyBytes < 1) {
+    throw new ValidationError(
+      'maxJsonBodyBytes must be a positive finite number'
+    );
+  }
+
+  return maxJsonBodyBytes;
+};
+
+const hasOversizedContentLength = (
+  req: Request,
+  maxJsonBodyBytes: number
+): boolean => {
+  const contentLength = req.headers.get('Content-Length');
+  const size = parseContentLength(contentLength);
+  if (size === JSON_BODY_INVALID_CONTENT_LENGTH || size === undefined) {
+    return false;
+  }
+  return size > maxJsonBodyBytes;
+};
+
+/**
+ * Stream the request body into a UTF-8 string, aborting mid-stream when the
+ * accumulated byte count exceeds `maxJsonBodyBytes`.
+ *
+ * Single-pass read with no `req.clone()` in the hot path. Cloning before the
+ * cap check would let an attacker double per-connection memory by sending
+ * chunked near-cap payloads; this function never clones.
+ */
+const readBodyText = async (
+  req: Request,
+  maxJsonBodyBytes: number
+): Promise<string | typeof JSON_BODY_TOO_LARGE> => {
+  const { body } = req;
+  if (body === null) {
+    return '';
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value === undefined) {
+        continue;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > maxJsonBodyBytes) {
+        await reader.cancel();
+        return JSON_BODY_TOO_LARGE;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new TextDecoder().decode(bytes);
+};
+
+const readJsonBody = async (
+  req: Request,
+  maxJsonBodyBytes: number
+): Promise<JsonBodyReadResult> => {
+  if (
+    parseContentLength(req.headers.get('Content-Length')) ===
+    JSON_BODY_INVALID_CONTENT_LENGTH
+  ) {
+    return JSON_BODY_INVALID_CONTENT_LENGTH;
+  }
+
+  if (hasOversizedContentLength(req, maxJsonBodyBytes)) {
+    return JSON_BODY_TOO_LARGE;
+  }
+
+  const text = await readBodyText(req, maxJsonBodyBytes);
+  if (text === JSON_BODY_TOO_LARGE) {
+    return JSON_BODY_TOO_LARGE;
+  }
+
+  try {
+    return JSON.parse(text) as JsonValue;
+  } catch {
+    return JSON_PARSE_ERROR;
+  }
+};
+
+const readInput = async (
+  req: Request,
+  inputSource: 'query' | 'body',
+  options: RuntimeOptions
+): Promise<InputReadResult> => {
+  if (inputSource === 'query') {
+    return parseQueryParams(req);
+  }
+  if (isEmptyBody(req)) {
+    return {};
+  }
+  return await readJsonBody(req, options.maxJsonBodyBytes);
+};
+
+// ---------------------------------------------------------------------------
+// Response mapping
+// ---------------------------------------------------------------------------
+
+const jsonResponse = (body: unknown, status: number): Response =>
+  Response.json(body, { status });
+
+const mapErrorResponse = (
+  error: Error
+): { body: Record<string, unknown>; status: number } => {
+  if (isTrailsError(error)) {
+    const projection = projectSurfaceError('http', error);
+    return {
+      body: {
+        error: {
+          category: projection.category,
+          code: projection.name,
+          message: projection.message,
+        },
+      },
+      status: projection.code,
+    };
+  }
+  return {
+    body: {
+      error: {
+        category: 'internal',
+        code: 'InternalError',
+        message: 'Internal server error',
+      },
+    },
+    status: 500,
+  };
+};
+
+const LOG_UNSAFE_LABEL_CHARACTERS = /[^\w:.-]/g;
+const MAX_DIAGNOSTIC_LABEL_VALUE_LENGTH = 128;
+
+const sanitizeDiagnosticLabelValue = (value: string): string =>
+  value
+    .replace(LOG_UNSAFE_LABEL_CHARACTERS, '_')
+    .slice(0, MAX_DIAGNOSTIC_LABEL_VALUE_LENGTH);
+
+const reportInternalDiagnostics = (error: Error, req?: Request): void => {
+  if (isTrailsError(error)) {
+    return;
+  }
+
+  const requestId = req?.headers.get('X-Request-ID') ?? undefined;
+  const safeRequestId =
+    requestId === null || requestId === undefined
+      ? undefined
+      : sanitizeDiagnosticLabelValue(requestId);
+  const label =
+    safeRequestId === undefined
+      ? '[ontrails:bun] Internal error'
+      : `[ontrails:bun] Internal error (${safeRequestId})`;
+  console.error(label, error);
+};
+
+const mapResultToResponse = (
+  result: { isOk(): boolean; value?: unknown; error?: Error },
+  req: Request
+): Response => {
+  if (result.isOk()) {
+    return jsonResponse({ data: result.value }, 200);
+  }
+  const error = result.error ?? new Error('Unknown error');
+  reportInternalDiagnostics(error, req);
+  const { body, status } = mapErrorResponse(error);
+  return jsonResponse(body, status);
+};
+
+const handleCaughtError = (error: unknown, req: Request): Response => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  reportInternalDiagnostics(err, req);
+  const { body, status } = mapErrorResponse(err);
+  return jsonResponse(body, status);
+};
+
+const invalidJsonResponse = (): Response =>
+  jsonResponse(
+    {
+      error: {
+        category: 'validation',
+        code: 'ValidationError',
+        message: 'Invalid JSON in request body',
+      },
+    },
+    400
+  );
+
+const invalidContentLengthResponse = (): Response =>
+  jsonResponse(
+    {
+      error: {
+        category: 'validation',
+        code: 'ValidationError',
+        message: 'Invalid Content-Length header',
+      },
+    },
+    400
+  );
+
+const oversizedJsonBodyResponse = (options: RuntimeOptions): Response =>
+  jsonResponse(
+    {
+      error: {
+        category: 'validation',
+        code: 'ValidationError',
+        message: `JSON request body exceeds ${options.maxJsonBodyBytes} bytes`,
+      },
+    },
+    413
+  );
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+const createRouteHandler =
+  (route: HttpRouteDefinition, options: RuntimeOptions): RouteHandler =>
+  async (req: Request): Promise<Response> => {
+    if (route.inputSource === 'webhook') {
+      // Defensive: createApp filters webhook routes at build time; this branch
+      // only fires if a caller wires a route definition directly into a Bun.serve
+      // routes object without going through createApp.
+      return jsonResponse(
+        {
+          error: {
+            category: 'internal',
+            code: 'WebhookNotSupported',
+            message:
+              'Webhook input source is not supported by @ontrails/bun. Use @ontrails/hono until webhook support lands.',
+          },
+        },
+        501
+      );
+    }
+
+    const rawInput = await readInput(req, route.inputSource, options);
+
+    if (rawInput === JSON_PARSE_ERROR) {
+      return invalidJsonResponse();
+    }
+
+    if (rawInput === JSON_BODY_INVALID_CONTENT_LENGTH) {
+      return invalidContentLengthResponse();
+    }
+
+    if (rawInput === JSON_BODY_TOO_LARGE) {
+      return oversizedJsonBodyResponse(options);
+    }
+
+    const requestId = req.headers.get('X-Request-ID') ?? undefined;
+
+    try {
+      const result = await route.execute(rawInput, requestId, req.signal);
+      return mapResultToResponse(result, req);
+    } catch (error: unknown) {
+      return handleCaughtError(error, req);
+    }
+  };
+
+const buildRouteRecord = (
+  routes: HttpRouteDefinition[],
+  options: RuntimeOptions
+): BunRouteRecord => {
+  const record: BunRouteRecord = {};
+  for (const route of routes) {
+    const handler = createRouteHandler(route, options);
+    const existing = record[route.path] ?? {};
+    existing[route.method] = handler;
+    record[route.path] = existing;
+  }
+  return record;
+};
+
+const findWebhookRoutes = (routes: HttpRouteDefinition[]): string[] =>
+  routes
+    .filter((route) => route.inputSource === 'webhook')
+    .map((route) => route.trailId);
+
+// ---------------------------------------------------------------------------
+// createApp
+// ---------------------------------------------------------------------------
+
+/**
+ * Build HTTP routes from a topo and project them onto a `Bun.serve` route
+ * record.
+ *
+ * v0 rejects webhook trails at build time with a `ValidationError` rather than
+ * silently 501-ing at request time. This is a deliberate departure from the
+ * "skeleton with TODOs" pattern: a loud build-time error is more contract-first
+ * than a runtime failure that ships to production unnoticed.
+ *
+ * @remarks This is a host materialization boundary. Derivation failures are
+ * thrown for HTTP bootstrap code after `deriveHttpRoutes` has already
+ * represented the framework error as a Result.
+ */
+export const createApp = (
+  graph: Topo,
+  options: CreateAppOptions = {}
+): {
+  routes: BunRouteRecord;
+  fetch: RouteHandler;
+  onError: (error: Error) => Response;
+} => {
+  const runtimeOptions: RuntimeOptions = {
+    maxJsonBodyBytes: resolveMaxJsonBodyBytes(options.maxJsonBodyBytes),
+  };
+
+  const routesResult = deriveHttpRoutes(graph, {
+    basePath: options.basePath,
+    configValues: options.configValues,
+    createContext: options.createContext,
+    exclude: options.exclude,
+    include: options.include,
+    intent: options.intent,
+    layers: options.layers,
+    resources: options.resources,
+    validate: options.validate,
+  });
+
+  if (routesResult.isErr()) {
+    throw routesResult.error;
+  }
+
+  const routes = routesResult.value;
+  const webhookTrails = findWebhookRoutes(routes);
+  if (webhookTrails.length > 0) {
+    throw new ValidationError(
+      `Webhook routes are not supported by @ontrails/bun v0. Trails with inputSource='webhook': ${webhookTrails.join(', ')}. Use @ontrails/hono until webhook support lands.`
+    );
+  }
+
+  const routeRecord = buildRouteRecord(routes, runtimeOptions);
+
+  const fetchFallback: RouteHandler = (_req: Request): Response =>
+    jsonResponse(
+      {
+        error: {
+          category: 'not_found',
+          code: 'RouteNotFound',
+          message: 'Route not found',
+        },
+      },
+      404
+    );
+
+  const onError = (error: Error): Response => {
+    reportInternalDiagnostics(error);
+    const { body, status } = mapErrorResponse(error);
+    return jsonResponse(body, status);
+  };
+
+  return { fetch: fetchFallback, onError, routes: routeRecord };
+};
+
+// ---------------------------------------------------------------------------
+// surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a route record from a topo and start serving it with `Bun.serve`.
+ *
+ * @remarks Always starts a Bun server. Use `createApp(graph)` for an unserved
+ * route record that you can wire into your own `Bun.serve` invocation.
+ */
+export const surface = async (
+  graph: Topo,
+  options: CreateAppOptions = {}
+): Promise<SurfaceHttpResult> => {
+  // oxlint-disable-next-line require-await -- async ensures createApp() throws become rejected promises, not uncaught exceptions
+  const handler = createApp(graph, options);
+
+  const server = Bun.serve({
+    error: handler.onError,
+    fetch: handler.fetch,
+    hostname: options.hostname ?? '0.0.0.0',
+    port: options.port ?? 3000,
+    routes: handler.routes,
+  });
+
+  return {
+    close: async () => {
+      await server.stop(true);
+    },
+    url: String(server.url),
+  };
+};

--- a/adapters/bun/tsconfig.json
+++ b/adapters/bun/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/adapters/bun/tsconfig.tests.json
+++ b/adapters/bun/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,17 @@
         "zod": "catalog:",
       },
     },
+    "adapters/bun": {
+      "name": "@ontrails/bun",
+      "version": "1.0.0-beta.15",
+      "dependencies": {
+        "@ontrails/core": "workspace:^",
+      },
+      "peerDependencies": {
+        "@ontrails/http": "workspace:^",
+        "zod": "catalog:",
+      },
+    },
     "adapters/commander": {
       "name": "@ontrails/commander",
       "version": "1.0.0-beta.15",
@@ -370,6 +381,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@ontrails/bun": ["@ontrails/bun@workspace:adapters/bun"],
 
     "@ontrails/cli": ["@ontrails/cli@workspace:packages/cli"],
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     'require-await': 'off',
     'trails-local/no-console-in-packages': [
       'error',
-      { allowedPackages: ['drizzle', 'hono', 'logging', 'observe'] },
+      { allowedPackages: ['bun', 'drizzle', 'hono', 'logging', 'observe'] },
     ],
     'trails-local/no-deep-relative-import': ['warn', { maxParentSegments: 2 }],
     'trails-local/no-nested-barrel': ['warn', { maxDepth: 2 }],


### PR DESCRIPTION
## Summary

`@ontrails/http` is framework-agnostic by ADR-0005. The current matrix has one HTTP adapter (`@ontrails/hono`) which adds Hono in front of `Bun.serve`. Hono earns its weight when portability across runtimes matters. For Bun-only deploys, the abstraction is overhead the framework's own design says we should be able to skip. This PR adds `@ontrails/bun`, a Bun-native adapter that reads `HttpRouteDefinition[]` straight onto `Bun.serve`'s native routes API and uses Web Standard `Request`/`Response` end to end.

This is an architectural-symmetry argument, not a user-friction one. Hono on Bun is fast and zero-config for production users. The case for shipping `@ontrails/bun` is whether the framework wants the adapter matrix to include a runtime-native option that exercises the framework-agnostic property of `@ontrails/http` directly. That decision is yours, see Open Question 1 below.

## Open Questions

1. **Direction.** Is the adapter matrix intended to grow by runtime (Bun-native, edge-native, etc.), or is Hono the canonical HTTP runtime and Bun-native is user-land? Happy to close this if the answer is the latter, the PR is a draft precisely so this question can land first.
2. **Webhook scope.** v0 throws `ValidationError` at `createApp()` time on any webhook trail (loud build-time deferral, not silent 501). Land webhooks in this PR for full parity, or accept v0 deferral and follow up in v0.1?

## What's in this PR

- `adapters/bun/` package: `package.json`, `tsconfig.json`, `tsconfig.tests.json`, `README.md`, `CHANGELOG.md`
- `src/surface.ts` (568 lines): `createApp(graph, options)` and `surface(graph, options)`. Mirrors the hono adapter's exported API shape (`createApp` + `surface` + `SurfaceHttpResult`). Single-pass streaming body read with mid-stream abort (no `req.clone()` in the hot path). Separate `fetch` and `error` Bun.serve callbacks for 404 unmatched and redacted 500 thrown.
- `src/__tests__/surface.test.ts` (266 lines, 12 tests): GET/POST happy paths, body cap (413), malformed Content-Length (400), malformed JSON (400), `NotFoundError` projection (404), redacted 500 invariant (no original message leaked), webhook build-time `ValidationError`, end-to-end `surface()` lifecycle.
- `oxlint.config.ts`: add `'bun'` to `allowedPackages` for `trails-local/no-console-in-packages`. Matches the hono/drizzle/logging/observe precedent. The adapter routes generic-error diagnostics through `console.error` at the same boundary the hono adapter uses.
- `.changeset/bun-adapter-package.md`: `@ontrails/bun: major` per the lockstep `@ontrails/*` versioning convention.

## What's out of scope

- Webhook support (`createApp` throws on webhook trails). See Open Question 2.
- A new `docs/surfaces/http-bun.md` page. Holding off until the package is accepted.
- Modifications to `@ontrails/http` or `@ontrails/hono`. This PR is purely additive. Body-parsing duplication is intentional, `@ontrails/http` is framework-agnostic per ADR-0005 and cannot host Web Standard `Request` machinery.
- Full hono test parity (scalar-vs-array query shape, full error-category matrix, all five HTTP method paths, layers composition). v0 ships smoke tests for happy paths and documented error sentinels; deeper parity in a follow-up.
- `gt`/Graphite was unavailable locally; this branch was pushed via plain `git`/`gh`. Happy to rebase through Graphite if needed.

## Test plan

- [x] `bun test` in `adapters/bun/` (12/12 pass)
- [x] `bun run check` at the repo root (lint, ast-grep, format, typecheck, docs:snippets, scaffold-versions all clean; pre-existing warnings only)
- [x] `bun run test` at the repo root (302 trails tests pass alongside the 12 new adapter tests)
- [ ] Greptile review clean
- [ ] CI green

The diff between `adapters/hono/` and `adapters/bun/` reads as a port (same body-parsing pipeline, same sentinel taxonomy, same error projection) onto a different runtime surface (Web Standard `Request`/`Response` and `Bun.serve` routes instead of Hono `Context` + `app.get`/`post`).