### PR TITLE
docs: align adapter housekeeping guidance

### DIFF
--- a/.claude/rules/coding-conventions.md
+++ b/.claude/rules/coding-conventions.md
@@ -32,7 +32,7 @@ TSDoc explains the contract of exported APIs. Start there before reaching for in
 
 - Describe the contract a helper or surface exposes, especially derived names, validation boundaries, and `Result` behavior.
 - For APIs that return `Result`, document the success shape and the error types callers should expect.
-- Prefer examples that mirror how agents or surface connectors will actually consume the API.
+- Prefer examples that mirror how agents or surface adapters will actually consume the API.
 - For resource definitions, document the `create` factory's dependencies and the type it produces. Document `dispose` if cleanup is non-trivial. Skip `mock` TSDoc unless the mock behavior differs significantly from the real implementation.
 
 ## Cross-References in Source


### PR DESCRIPTION
## Summary

- Align active TSDoc guidance with the post-cutover adapter taxonomy by replacing the remaining current-facing "surface connectors" phrase.
- Keep the tracked branch intentionally small: no package code, no changesets, no merge queue label.
- Updated Linear TRL-684 separately so the Knip follow-up now scopes workspace discovery to `adapters/*` after the Adapter Taxonomy + Commander stack landed through PR #446.

## Local Scratch Notes

The ignored local scratch docs were also refreshed for continuity:

- `.scratch/2026-05-08-adapter-commander-stack/execution-retro.md` now has a post-merge addendum for PRs #436-#446.
- `.scratch/2026-05-06-governance-maturity/verification/dead-code-investigation.md` now uses `adapters/*` and `adapters/{drizzle,hono,vite}` in the Knip planning examples.

Those files are under `.scratch/`, which is gitignored, so they are not part of this PR diff.

## Verification

- `bun scripts/vocab-cutover-audit.ts --rule connector-term`
- `bun run format:check`
- `git diff --check`
