### PR TITLE
feat: add warden resolver substrate

### DIFF
--- a/.changeset/warden-resolver-substrate.md
+++ b/.changeset/warden-resolver-substrate.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/warden': patch
+---
+
+Add Warden import-resolution substrate backed by `oxc-resolver`.

--- a/bun.lock
+++ b/bun.lock
@@ -255,6 +255,7 @@
         "@ontrails/permits": "workspace:^",
         "@ontrails/store": "workspace:^",
         "oxc-parser": "^0.121.0",
+        "oxc-resolver": "11.19.1",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -454,6 +455,46 @@
     "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.121.0", "", { "os": "win32", "cpu": "x64" }, "sha512-BOp1KCzdboB1tPqoCPXgntgFs0jjeSyOXHzgxVFR7B/qfr3F8r4YDacHkTOUNXtDgM8YwKnkf3rE5gwALYX7NA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
+
+    "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.19.1", "", { "os": "android", "cpu": "arm" }, "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg=="],
+
+    "@oxc-resolver/binding-android-arm64": ["@oxc-resolver/binding-android-arm64@11.19.1", "", { "os": "android", "cpu": "arm64" }, "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA=="],
+
+    "@oxc-resolver/binding-darwin-arm64": ["@oxc-resolver/binding-darwin-arm64@11.19.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ=="],
+
+    "@oxc-resolver/binding-darwin-x64": ["@oxc-resolver/binding-darwin-x64@11.19.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ=="],
+
+    "@oxc-resolver/binding-freebsd-x64": ["@oxc-resolver/binding-freebsd-x64@11.19.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw=="],
+
+    "@oxc-resolver/binding-linux-arm-gnueabihf": ["@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1", "", { "os": "linux", "cpu": "arm" }, "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A=="],
+
+    "@oxc-resolver/binding-linux-arm-musleabihf": ["@oxc-resolver/binding-linux-arm-musleabihf@11.19.1", "", { "os": "linux", "cpu": "arm" }, "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ=="],
+
+    "@oxc-resolver/binding-linux-arm64-gnu": ["@oxc-resolver/binding-linux-arm64-gnu@11.19.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig=="],
+
+    "@oxc-resolver/binding-linux-arm64-musl": ["@oxc-resolver/binding-linux-arm64-musl@11.19.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew=="],
+
+    "@oxc-resolver/binding-linux-ppc64-gnu": ["@oxc-resolver/binding-linux-ppc64-gnu@11.19.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ=="],
+
+    "@oxc-resolver/binding-linux-riscv64-gnu": ["@oxc-resolver/binding-linux-riscv64-gnu@11.19.1", "", { "os": "linux", "cpu": "none" }, "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w=="],
+
+    "@oxc-resolver/binding-linux-riscv64-musl": ["@oxc-resolver/binding-linux-riscv64-musl@11.19.1", "", { "os": "linux", "cpu": "none" }, "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw=="],
+
+    "@oxc-resolver/binding-linux-s390x-gnu": ["@oxc-resolver/binding-linux-s390x-gnu@11.19.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA=="],
+
+    "@oxc-resolver/binding-linux-x64-gnu": ["@oxc-resolver/binding-linux-x64-gnu@11.19.1", "", { "os": "linux", "cpu": "x64" }, "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ=="],
+
+    "@oxc-resolver/binding-linux-x64-musl": ["@oxc-resolver/binding-linux-x64-musl@11.19.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw=="],
+
+    "@oxc-resolver/binding-openharmony-arm64": ["@oxc-resolver/binding-openharmony-arm64@11.19.1", "", { "os": "none", "cpu": "arm64" }, "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA=="],
+
+    "@oxc-resolver/binding-wasm32-wasi": ["@oxc-resolver/binding-wasm32-wasi@11.19.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg=="],
+
+    "@oxc-resolver/binding-win32-arm64-msvc": ["@oxc-resolver/binding-win32-arm64-msvc@11.19.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ=="],
+
+    "@oxc-resolver/binding-win32-ia32-msvc": ["@oxc-resolver/binding-win32-ia32-msvc@11.19.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA=="],
+
+    "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.47.0", "", { "os": "android", "cpu": "arm" }, "sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw=="],
 
@@ -900,6 +941,8 @@
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
     "oxc-parser": ["oxc-parser@0.121.0", "", { "dependencies": { "@oxc-project/types": "^0.121.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.121.0", "@oxc-parser/binding-android-arm64": "0.121.0", "@oxc-parser/binding-darwin-arm64": "0.121.0", "@oxc-parser/binding-darwin-x64": "0.121.0", "@oxc-parser/binding-freebsd-x64": "0.121.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.121.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.121.0", "@oxc-parser/binding-linux-arm64-gnu": "0.121.0", "@oxc-parser/binding-linux-arm64-musl": "0.121.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.121.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.121.0", "@oxc-parser/binding-linux-riscv64-musl": "0.121.0", "@oxc-parser/binding-linux-s390x-gnu": "0.121.0", "@oxc-parser/binding-linux-x64-gnu": "0.121.0", "@oxc-parser/binding-linux-x64-musl": "0.121.0", "@oxc-parser/binding-openharmony-arm64": "0.121.0", "@oxc-parser/binding-wasm32-wasi": "0.121.0", "@oxc-parser/binding-win32-arm64-msvc": "0.121.0", "@oxc-parser/binding-win32-ia32-msvc": "0.121.0", "@oxc-parser/binding-win32-x64-msvc": "0.121.0" } }, "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg=="],
+
+    "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
 
     "oxfmt": ["oxfmt@0.47.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.47.0", "@oxfmt/binding-android-arm64": "0.47.0", "@oxfmt/binding-darwin-arm64": "0.47.0", "@oxfmt/binding-darwin-x64": "0.47.0", "@oxfmt/binding-freebsd-x64": "0.47.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.47.0", "@oxfmt/binding-linux-arm-musleabihf": "0.47.0", "@oxfmt/binding-linux-arm64-gnu": "0.47.0", "@oxfmt/binding-linux-arm64-musl": "0.47.0", "@oxfmt/binding-linux-ppc64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-musl": "0.47.0", "@oxfmt/binding-linux-s390x-gnu": "0.47.0", "@oxfmt/binding-linux-x64-gnu": "0.47.0", "@oxfmt/binding-linux-x64-musl": "0.47.0", "@oxfmt/binding-openharmony-arm64": "0.47.0", "@oxfmt/binding-win32-arm64-msvc": "0.47.0", "@oxfmt/binding-win32-ia32-msvc": "0.47.0", "@oxfmt/binding-win32-x64-msvc": "0.47.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA=="],
 

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -17,6 +17,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./ast": "./src/ast.ts",
+    "./resolve": "./src/resolve.ts",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -31,6 +32,7 @@
     "@ontrails/permits": "workspace:^",
     "@ontrails/store": "workspace:^",
     "oxc-parser": "^0.121.0",
+    "oxc-resolver": "11.19.1",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/warden/src/__tests__/public-api.test.ts
+++ b/packages/warden/src/__tests__/public-api.test.ts
@@ -11,6 +11,10 @@ import {
   walkScope,
 } from '@ontrails/warden/ast';
 import type { FrameworkNamespaceContext } from '@ontrails/warden/ast';
+import {
+  collectImportSpecifiers,
+  defaultWardenResolveOptions,
+} from '@ontrails/warden/resolve';
 
 describe('@ontrails/warden public API', () => {
   test('exports built-in rule metadata from the root entrypoint', () => {
@@ -44,6 +48,23 @@ describe('@ontrails/warden public API', () => {
       });
     }
     expect(visited).toBeGreaterThan(0);
+  });
+
+  test('keeps resolver helpers on the resolve entrypoint', () => {
+    expect('collectImportSpecifiers' in warden).toBe(true);
+    expect('defaultWardenResolveOptions' in warden).toBe(true);
+    expect(defaultWardenResolveOptions.conditionNames).toEqual([
+      'bun',
+      'node',
+      'import',
+      'default',
+    ]);
+    expect(
+      collectImportSpecifiers(
+        'example.ts',
+        "import { value } from '@ontrails/core';\n"
+      )
+    ).toEqual([{ importSource: '@ontrails/core', line: 1 }]);
   });
 
   test('exposes stable rule-authoring helpers on the ast entrypoint', () => {

--- a/packages/warden/src/__tests__/resolve.test.ts
+++ b/packages/warden/src/__tests__/resolve.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  realpathSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  collectImportSpecifiers,
+  createWardenResolver,
+  defaultWardenResolveOptions,
+  packagePathNotExportedErrorFragment,
+} from '../resolve.js';
+import { collectProjectImportResolutions } from '../project-context.js';
+
+const makeTempDir = (prefix: string): string => {
+  const dir = join(
+    tmpdir(),
+    `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+};
+
+const writeJson = (path: string, value: unknown): void => {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const writeSource = (path: string, source: string): void => {
+  writeFileSync(path, source.trimStart());
+};
+
+interface WorkspaceFixture {
+  readonly appRoot: string;
+  readonly coreRoot: string;
+  readonly importerPath: string;
+  readonly rootDir: string;
+}
+
+const createWorkspaceFixture = (): WorkspaceFixture => {
+  const rootDir = makeTempDir('warden-resolve-workspace');
+  const appRoot = join(rootDir, 'packages', 'app');
+  const coreRoot = join(rootDir, 'packages', 'core');
+  const importerPath = join(appRoot, 'src', 'app.ts');
+  mkdirSync(join(appRoot, 'src'), { recursive: true });
+  mkdirSync(join(coreRoot, 'src', 'internal'), { recursive: true });
+  mkdirSync(join(rootDir, 'node_modules', '@fixture'), { recursive: true });
+
+  writeJson(join(rootDir, 'package.json'), {
+    private: true,
+    type: 'module',
+    workspaces: ['packages/*'],
+  });
+  writeJson(join(appRoot, 'package.json'), {
+    dependencies: { '@fixture/core': 'workspace:*' },
+    name: '@fixture/app',
+    type: 'module',
+  });
+  writeJson(join(coreRoot, 'package.json'), {
+    exports: {
+      '.': './src/index.ts',
+      './public': './src/public.ts',
+    },
+    name: '@fixture/core',
+    type: 'module',
+  });
+  writeSource(join(coreRoot, 'src', 'index.ts'), 'export const value = 1;\n');
+  writeSource(join(coreRoot, 'src', 'public.ts'), 'export const pub = 1;\n');
+  writeSource(
+    join(coreRoot, 'src', 'internal', 'secret.ts'),
+    'export const secret = 1;\n'
+  );
+  writeSource(
+    importerPath,
+    `
+      import { value } from '@fixture/core';
+      import { pub } from '@fixture/core/public';
+      import { secret } from '@fixture/core/internal/secret';
+    `
+  );
+  symlinkSync(
+    coreRoot,
+    join(rootDir, 'node_modules', '@fixture', 'core'),
+    'dir'
+  );
+
+  return { appRoot, coreRoot, importerPath, rootDir };
+};
+
+const createPackedFixture = (): WorkspaceFixture => {
+  const rootDir = makeTempDir('warden-resolve-packed');
+  const appRoot = join(rootDir, 'app');
+  const coreRoot = join(rootDir, 'node_modules', '@fixture', 'core');
+  const importerPath = join(appRoot, 'src', 'app.ts');
+  mkdirSync(join(appRoot, 'src'), { recursive: true });
+  mkdirSync(join(coreRoot, 'src', 'internal'), { recursive: true });
+
+  writeJson(join(appRoot, 'package.json'), {
+    dependencies: { '@fixture/core': '1.0.0' },
+    name: '@fixture/app',
+    type: 'module',
+  });
+  writeJson(join(coreRoot, 'package.json'), {
+    exports: {
+      '.': './src/index.ts',
+    },
+    name: '@fixture/core',
+    type: 'module',
+  });
+  writeSource(join(coreRoot, 'src', 'index.ts'), 'export const value = 1;\n');
+  writeSource(
+    join(coreRoot, 'src', 'internal', 'secret.ts'),
+    'export const secret = 1;\n'
+  );
+  writeSource(
+    importerPath,
+    "import { secret } from '@fixture/core/internal/secret';\n"
+  );
+
+  return { appRoot, coreRoot, importerPath, rootDir };
+};
+
+describe('Warden resolver substrate', () => {
+  test('collects static import and re-export specifiers with source lines', () => {
+    const source = `
+      import { value } from '@fixture/core';
+      export { pub } from '@fixture/core/public';
+      export * from '@fixture/core/extra';
+      const lazy = import('@fixture/core/lazy');
+      type Hidden = import('@fixture/core/internal/hidden').Hidden;
+      const required = require('@fixture/core/required');
+      const dynamic = import(source);
+      const dynamicRequire = require(source);
+    `;
+
+    expect(collectImportSpecifiers('example.ts', source)).toEqual([
+      { importSource: '@fixture/core', line: 2 },
+      { importSource: '@fixture/core/public', line: 3 },
+      { importSource: '@fixture/core/extra', line: 4 },
+      { importSource: '@fixture/core/lazy', line: 5 },
+      { importSource: '@fixture/core/internal/hidden', line: 6 },
+      { importSource: '@fixture/core/required', line: 7 },
+    ]);
+  });
+
+  test('resolves Bun workspace package exports to real package roots', () => {
+    const fixture = createWorkspaceFixture();
+    try {
+      const resolver = createWardenResolver({ rootDir: fixture.rootDir });
+
+      const root = resolver.resolveImport(
+        fixture.importerPath,
+        '@fixture/core',
+        1
+      );
+      const publicSubpath = resolver.resolveImport(
+        fixture.importerPath,
+        '@fixture/core/public',
+        2
+      );
+
+      expect(root.resolvedPath).toBe(
+        realpathSync(join(fixture.coreRoot, 'src', 'index.ts'))
+      );
+      expect(root.packageName).toBe('@fixture/core');
+      expect(root.packageRoot).toBe(realpathSync(fixture.coreRoot));
+      expect(root.crossesPackageBoundary).toBe(true);
+      expect(root.usesPublicExport).toBe(true);
+      expect(root.isInternalTarget).toBe(false);
+
+      expect(publicSubpath.resolvedPath).toBe(
+        realpathSync(join(fixture.coreRoot, 'src', 'public.ts'))
+      );
+      expect(publicSubpath.usesPublicExport).toBe(true);
+      expect(publicSubpath.crossesPackageBoundary).toBe(true);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('classifies package subpaths blocked by the export map', () => {
+    const fixture = createWorkspaceFixture();
+    try {
+      const resolver = createWardenResolver({ rootDir: fixture.rootDir });
+
+      const blocked = resolver.resolveImport(
+        fixture.importerPath,
+        '@fixture/core/internal/secret',
+        3
+      );
+
+      expect(blocked.resolvedPath).toBeUndefined();
+      expect(blocked.packageName).toBe('@fixture/core');
+      expect(blocked.packageRoot).toBe(realpathSync(fixture.coreRoot));
+      expect(blocked.crossesPackageBoundary).toBe(true);
+      expect(blocked.usesPublicExport).toBe(false);
+      expect(blocked.errorKind).toBe('package-path-not-exported');
+      expect(blocked.errorMessage).toContain(
+        `"./internal/secret" ${packagePathNotExportedErrorFragment} ["bun", "node", "import", "default"] from package`
+      );
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('marks relative imports that cross package boundaries and target internals', () => {
+    const fixture = createWorkspaceFixture();
+    try {
+      const resolver = createWardenResolver({ rootDir: fixture.rootDir });
+
+      const relative = resolver.resolveImport(
+        fixture.importerPath,
+        '../../core/src/internal/secret.ts',
+        4
+      );
+
+      expect(relative.resolvedPath).toBe(
+        realpathSync(join(fixture.coreRoot, 'src', 'internal', 'secret.ts'))
+      );
+      expect(relative.packageName).toBe('@fixture/core');
+      expect(relative.packageRoot).toBe(realpathSync(fixture.coreRoot));
+      expect(relative.crossesPackageBoundary).toBe(true);
+      expect(relative.usesPublicExport).toBe(false);
+      expect(relative.isInternalTarget).toBe(true);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('preserves the published-package error when a packed file exists but is not exported', () => {
+    const fixture = createPackedFixture();
+    try {
+      const resolver = createWardenResolver({ rootDir: fixture.rootDir });
+      const internalPath = join(
+        fixture.coreRoot,
+        'src',
+        'internal',
+        'secret.ts'
+      );
+
+      const blocked = resolver.resolveImport(
+        fixture.importerPath,
+        '@fixture/core/internal/secret',
+        1
+      );
+
+      expect(existsSync(internalPath)).toBe(true);
+      expect(blocked.resolvedPath).toBeUndefined();
+      expect(blocked.packageRoot).toBe(realpathSync(fixture.coreRoot));
+      expect(blocked.errorKind).toBe('package-path-not-exported');
+      expect(blocked.errorMessage).toContain(
+        `"./internal/secret" ${packagePathNotExportedErrorFragment} ["bun", "node", "import", "default"] from package`
+      );
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('normalizes importer paths before cache lookup and result reporting', () => {
+    const fixture = createWorkspaceFixture();
+    try {
+      const linkedAppRoot = join(fixture.rootDir, 'linked-app');
+      symlinkSync(fixture.appRoot, linkedAppRoot, 'dir');
+      const linkedImporterPath = join(linkedAppRoot, 'src', 'app.ts');
+      const resolver = createWardenResolver({ rootDir: fixture.rootDir });
+
+      const viaLink = resolver.resolveImport(
+        linkedImporterPath,
+        '@fixture/core',
+        1
+      );
+      const viaRealPath = resolver.resolveImport(
+        fixture.importerPath,
+        '@fixture/core',
+        2
+      );
+
+      expect(viaLink.importerPath).toBe(realpathSync(fixture.importerPath));
+      expect(viaRealPath.importerPath).toBe(viaLink.importerPath);
+      expect(viaRealPath.resolvedPath).toBe(viaLink.resolvedPath);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('extends default resolver option arrays when callers add options', () => {
+    const resolver = createWardenResolver({
+      resolveOptions: {
+        conditionNames: ['custom'],
+        extensionAlias: {
+          '.js': ['.custom.js'],
+        },
+        extensions: ['.custom'],
+      },
+    });
+
+    expect(resolver.resolveOptions.conditionNames).toEqual([
+      ...defaultWardenResolveOptions.conditionNames,
+      'custom',
+    ]);
+    expect(resolver.resolveOptions.extensions).toContain('.custom');
+    expect(resolver.resolveOptions.extensionAlias?.['.js']).toEqual([
+      ...defaultWardenResolveOptions.extensionAlias['.js'],
+      '.custom.js',
+    ]);
+  });
+
+  test('collects import resolutions once into project context maps', () => {
+    const fixture = createWorkspaceFixture();
+    try {
+      const sourceCode = readFileSync(fixture.importerPath, 'utf8');
+      const resolutionsByFile = collectProjectImportResolutions({
+        rootDir: fixture.rootDir,
+        sourceFiles: [
+          {
+            filePath: fixture.importerPath,
+            kind: 'typescript',
+            sourceCode,
+          },
+        ],
+      });
+      const resolutions =
+        resolutionsByFile.get(fixture.importerPath) ??
+        (() => {
+          throw new Error('missing import resolutions for fixture importer');
+        })();
+
+      expect(resolutions.map((resolution) => resolution.importSource)).toEqual([
+        '@fixture/core',
+        '@fixture/core/public',
+        '@fixture/core/internal/secret',
+      ]);
+      expect(resolutions[2]?.errorKind).toBe('package-path-not-exported');
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('passes custom resolver options through project import collection', () => {
+    const fixture = createWorkspaceFixture();
+    try {
+      const importerPath = join(fixture.appRoot, 'src', 'custom.ts');
+      const targetPath = join(fixture.appRoot, 'src', 'local.custom');
+      writeSource(targetPath, 'export const local = 1;\n');
+      writeSource(importerPath, "import { local } from './local';\n");
+
+      const resolutionsByFile = collectProjectImportResolutions({
+        resolveOptions: { extensions: ['.custom'] },
+        rootDir: fixture.rootDir,
+        sourceFiles: [
+          {
+            filePath: importerPath,
+            kind: 'typescript',
+            sourceCode: readFileSync(importerPath, 'utf8'),
+          },
+        ],
+      });
+      const resolution = resolutionsByFile.get(importerPath)?.[0];
+
+      expect(resolution?.resolvedPath).toBe(realpathSync(targetPath));
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('keys project import resolutions by normalized real paths', () => {
+    const fixture = createWorkspaceFixture();
+    const linkedAppRoot = join(fixture.rootDir, 'linked-app');
+    try {
+      symlinkSync(fixture.appRoot, linkedAppRoot, 'dir');
+      const linkedImporterPath = join(linkedAppRoot, 'src', 'app.ts');
+      const realImporterPath = realpathSync(linkedImporterPath);
+      const sourceCode = readFileSync(linkedImporterPath, 'utf8');
+      const resolutionsByFile = collectProjectImportResolutions({
+        rootDir: fixture.rootDir,
+        sourceFiles: [
+          {
+            filePath: linkedImporterPath,
+            kind: 'typescript',
+            sourceCode,
+          },
+        ],
+      });
+
+      const normalizedResolutions = resolutionsByFile.get(realImporterPath);
+      expect(normalizedResolutions?.[0]?.importerPath).toBe(realImporterPath);
+      expect(resolutionsByFile.get(linkedImporterPath)).toBe(
+        normalizedResolutions
+      );
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -23,6 +23,7 @@ import { resolveWardenConfig } from './config.js';
 import { isDraftMarkedFile } from './draft.js';
 import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
+import { collectProjectImportResolutions } from './project-context.js';
 import {
   collectContourDefinitionIds,
   collectContourReferenceTargetsByName,
@@ -47,6 +48,7 @@ import type {
   WardenRule,
   WardenRuleTier,
 } from './rules/types.js';
+import type { WardenImportResolution } from './resolve.js';
 
 /**
  * Resolved topo input for Warden runs that govern multiple apps.
@@ -256,6 +258,7 @@ interface MutableProjectContext {
   knownResourceIds: Set<string>;
   knownSignalIds: Set<string>;
   knownTrailIds: Set<string>;
+  importResolutionsByFile: Map<string, readonly WardenImportResolution[]>;
   onTargetSignalIds: Set<string>;
   reconcileTableIds: Set<string>;
   trailIntentsById: Map<string, 'destroy' | 'read' | 'write'>;
@@ -266,6 +269,7 @@ const createMutableProjectContext = (): MutableProjectContext => ({
   crossTargetTrailIds: new Set<string>(),
   crudCoverageByEntity: new Map<string, Set<string>>(),
   crudTableIds: new Set<string>(),
+  importResolutionsByFile: new Map<string, readonly WardenImportResolution[]>(),
   knownContourIds: new Set<string>(),
   knownResourceIds: new Set<string>(),
   knownSignalIds: new Set<string>(),
@@ -321,6 +325,9 @@ const toProjectContext = (context: MutableProjectContext): ProjectContext => ({
   knownResourceIds: context.knownResourceIds,
   knownSignalIds: context.knownSignalIds,
   knownTrailIds: context.knownTrailIds,
+  ...(context.importResolutionsByFile.size > 0
+    ? { importResolutionsByFile: context.importResolutionsByFile }
+    : {}),
   ...(context.onTargetSignalIds.size > 0
     ? { onTargetSignalIds: context.onTargetSignalIds }
     : {}),
@@ -671,8 +678,23 @@ const collectFileContourReferences = (
   }
 };
 
+const collectFileImportResolutions = (
+  rootDir: string,
+  sourceFiles: readonly SourceFile[],
+  context: MutableProjectContext
+): void => {
+  const resolutionsByFile = collectProjectImportResolutions({
+    rootDir,
+    sourceFiles,
+  });
+  for (const [filePath, resolutions] of resolutionsByFile) {
+    context.importResolutionsByFile.set(filePath, resolutions);
+  }
+};
+
 const buildProjectContext = (
   sourceFiles: readonly SourceFile[],
+  rootDir: string,
   appTopos: readonly Topo[] = []
 ): ProjectContext => {
   const context = createMutableProjectContext();
@@ -696,6 +718,7 @@ const buildProjectContext = (
   for (const sourceFile of typeScriptSourceFiles) {
     collectFileContourReferences(sourceFile, context);
   }
+  collectFileImportResolutions(rootDir, typeScriptSourceFiles, context);
 
   return toProjectContext(context);
 };
@@ -943,6 +966,7 @@ const lintFiles = async (
   );
   const context = buildProjectContext(
     sourceFiles,
+    rootDir,
     topoTargets.map((target) => target.topo)
   );
   const allDiagnostics: WardenDiagnostic[] = [

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -98,6 +98,21 @@ export {
 export type { DriftResult } from './drift.js';
 export { checkDrift } from './drift.js';
 
+// Resolver helpers
+export {
+  collectImportResolutionsForFile,
+  collectImportSpecifiers,
+  createWardenResolver,
+  defaultWardenResolveOptions,
+} from './resolve.js';
+export type {
+  WardenImportResolution,
+  WardenImportResolutionErrorKind,
+  WardenImportSpecifier,
+  WardenProjectResolver,
+  WardenResolverOptions,
+} from './resolve.js';
+
 // Draft helpers
 export {
   DRAFT_FILE_PREFIX,

--- a/packages/warden/src/project-context.ts
+++ b/packages/warden/src/project-context.ts
@@ -1,0 +1,80 @@
+/**
+ * Project-context helpers shared by the Warden runner and resolver-backed
+ * rules.
+ */
+
+import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  collectImportResolutionsForFile,
+  createWardenResolver,
+  normalizePath,
+} from './resolve.js';
+import type {
+  WardenImportResolution,
+  WardenResolverOptions,
+} from './resolve.js';
+
+const normalizeRealPath = (path: string): string => {
+  try {
+    return normalizePath(realpathSync(path));
+  } catch {
+    return normalizePath(resolve(path));
+  }
+};
+
+const setResolutionsForFile = (
+  resolutionsByFile: Map<string, readonly WardenImportResolution[]>,
+  sourceFilePath: string,
+  resolutions: readonly WardenImportResolution[]
+): void => {
+  const normalizedFilePath =
+    resolutions[0]?.importerPath ?? normalizeRealPath(sourceFilePath);
+  resolutionsByFile.set(normalizedFilePath, resolutions);
+  if (normalizedFilePath !== sourceFilePath) {
+    resolutionsByFile.set(sourceFilePath, resolutions);
+  }
+};
+
+export interface WardenProjectContextSourceFile {
+  readonly filePath: string;
+  readonly kind: 'text' | 'typescript';
+  readonly sourceCode: string;
+}
+
+export const collectProjectImportResolutions = ({
+  resolveOptions,
+  rootDir,
+  sourceFiles,
+}: {
+  readonly resolveOptions?: WardenResolverOptions['resolveOptions'];
+  readonly rootDir: string;
+  readonly sourceFiles: readonly WardenProjectContextSourceFile[];
+}): ReadonlyMap<string, readonly WardenImportResolution[]> => {
+  const resolver = createWardenResolver({ resolveOptions, rootDir });
+  const resolutionsByFile = new Map<
+    string,
+    readonly WardenImportResolution[]
+  >();
+
+  for (const sourceFile of sourceFiles) {
+    if (sourceFile.kind !== 'typescript') {
+      continue;
+    }
+    const resolutions = collectImportResolutionsForFile({
+      filePath: sourceFile.filePath,
+      resolver,
+      sourceCode: sourceFile.sourceCode,
+    });
+    if (resolutions.length > 0) {
+      setResolutionsForFile(
+        resolutionsByFile,
+        sourceFile.filePath,
+        resolutions
+      );
+    }
+  }
+
+  return resolutionsByFile;
+};

--- a/packages/warden/src/resolve.ts
+++ b/packages/warden/src/resolve.ts
@@ -1,0 +1,530 @@
+/**
+ * Public Warden resolver helper surface.
+ *
+ * These helpers wrap `oxc-resolver` behind Warden-owned import-resolution
+ * facts so rules never depend on resolver binding internals directly.
+ */
+
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+
+import { ResolverFactory } from 'oxc-resolver';
+import type { NapiResolveOptions, ResolveResult } from 'oxc-resolver';
+
+import {
+  getStringValue,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  walk,
+} from './rules/ast.js';
+import type { AstNode } from './rules/ast.js';
+
+export const wardenImportResolutionErrorKinds = [
+  'builtin',
+  'ignored',
+  'not-found',
+  'package-path-not-exported',
+  'other',
+] as const;
+
+export type WardenImportResolutionErrorKind =
+  (typeof wardenImportResolutionErrorKinds)[number];
+
+export interface WardenImportResolution {
+  readonly importerPath: string;
+  readonly importSource: string;
+  readonly line: number;
+  readonly resolvedPath?: string | undefined;
+  readonly packageName?: string | undefined;
+  readonly packageRoot?: string | undefined;
+  readonly crossesPackageBoundary: boolean;
+  /**
+   * True when a bare package specifier resolves successfully while the target
+   * package declares an exports map. This is a coarse resolver fact; it does
+   * not prove the resolved file matched a specific export entry.
+   */
+  readonly usesPublicExport: boolean;
+  /**
+   * True when a resolved file lands inside an internal/private package path.
+   * Export-map-blocked internal specifiers do not have a resolved file path;
+   * combine this with errorKind/importSource checks when guarding specifiers.
+   */
+  readonly isInternalTarget: boolean;
+  readonly errorKind?: WardenImportResolutionErrorKind | undefined;
+  readonly errorMessage?: string | undefined;
+  readonly builtinModule?: string | undefined;
+}
+
+export interface WardenImportSpecifier {
+  readonly importSource: string;
+  readonly line: number;
+}
+
+export interface WardenResolverOptions {
+  readonly rootDir?: string | undefined;
+  readonly resolveOptions?: NapiResolveOptions | undefined;
+}
+
+export interface WardenProjectResolver {
+  readonly rootDir: string;
+  readonly resolveOptions: NapiResolveOptions;
+  clearCache(): void;
+  resolveImport(
+    importerPath: string,
+    importSource: string,
+    line?: number
+  ): WardenImportResolution;
+}
+
+interface PackageInfo {
+  readonly name?: string | undefined;
+  readonly packageJsonPath: string;
+  readonly root: string;
+  readonly exports?: unknown;
+}
+
+const conditionNames = ['bun', 'node', 'import', 'default'] as const;
+export const packagePathNotExportedErrorFragment =
+  'is not exported under the conditions';
+
+export const defaultWardenResolveOptions = {
+  builtinModules: true,
+  conditionNames: [...conditionNames],
+  extensionAlias: {
+    '.cjs': ['.cts', '.cjs'],
+    '.js': ['.ts', '.tsx', '.js'],
+    '.mjs': ['.mts', '.mjs'],
+  },
+  extensions: [
+    '.ts',
+    '.tsx',
+    '.mts',
+    '.cts',
+    '.js',
+    '.jsx',
+    '.mjs',
+    '.cjs',
+    '.json',
+  ],
+  moduleType: true,
+  symlinks: true,
+  tsconfig: 'auto',
+} satisfies NapiResolveOptions;
+
+export const normalizePath = (path: string): string =>
+  path.replaceAll('\\', '/');
+
+const mergeStringLists = (
+  base: readonly string[] = [],
+  override: readonly string[] = []
+): string[] => [...new Set([...base, ...override])];
+
+const mergeExtensionAlias = (
+  base: NonNullable<NapiResolveOptions['extensionAlias']>,
+  override: NapiResolveOptions['extensionAlias'] | undefined
+): NonNullable<NapiResolveOptions['extensionAlias']> => {
+  const merged: Record<string, string[]> = Object.fromEntries(
+    Object.entries(base).map(([extension, aliases]) => [
+      extension,
+      [...aliases],
+    ])
+  );
+
+  for (const [extension, aliases] of Object.entries(override ?? {})) {
+    merged[extension] = mergeStringLists(merged[extension], aliases);
+  }
+
+  return merged;
+};
+
+const mergeWardenResolveOptions = (
+  overrides: NapiResolveOptions | undefined
+): NapiResolveOptions => ({
+  ...defaultWardenResolveOptions,
+  ...overrides,
+  conditionNames: mergeStringLists(
+    defaultWardenResolveOptions.conditionNames,
+    overrides?.conditionNames
+  ),
+  extensionAlias: mergeExtensionAlias(
+    defaultWardenResolveOptions.extensionAlias,
+    overrides?.extensionAlias
+  ),
+  extensions: mergeStringLists(
+    defaultWardenResolveOptions.extensions,
+    overrides?.extensions
+  ),
+});
+
+const normalizeRealPath = (path: string): string => {
+  try {
+    return normalizePath(realpathSync(path));
+  } catch {
+    return normalizePath(resolve(path));
+  }
+};
+
+const readPackageJson = (
+  packageJsonPath: string
+): Record<string, unknown> | null => {
+  try {
+    return JSON.parse(readFileSync(packageJsonPath, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return null;
+  }
+};
+
+const packageInfoFromPackageJson = (
+  packageJsonPath: string
+): PackageInfo | null => {
+  if (!existsSync(packageJsonPath)) {
+    return null;
+  }
+  const json = readPackageJson(packageJsonPath);
+  if (!json) {
+    return null;
+  }
+  const root = normalizeRealPath(dirname(packageJsonPath));
+  return {
+    ...(json['exports'] === undefined ? {} : { exports: json['exports'] }),
+    ...(typeof json['name'] === 'string' ? { name: json['name'] } : {}),
+    packageJsonPath: normalizeRealPath(packageJsonPath),
+    root,
+  };
+};
+
+const findNearestPackageJson = (fromPath: string): string | null => {
+  let dir = dirname(resolve(fromPath));
+  while (true) {
+    const packageJsonPath = join(dir, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      return packageJsonPath;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+};
+
+const findPackageInfoForPath = (path: string): PackageInfo | null => {
+  const packageJsonPath = findNearestPackageJson(path);
+  return packageJsonPath ? packageInfoFromPackageJson(packageJsonPath) : null;
+};
+
+const parseBarePackageName = (specifier: string): string | null => {
+  if (
+    specifier.startsWith('.') ||
+    specifier.startsWith('/') ||
+    specifier.startsWith('#') ||
+    specifier.startsWith('node:') ||
+    /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(specifier)
+  ) {
+    return null;
+  }
+
+  const parts = specifier.split('/');
+  if (specifier.startsWith('@')) {
+    const [scope, name] = parts;
+    return scope && name ? `${scope}/${name}` : null;
+  }
+  return parts[0] ?? null;
+};
+
+const packageSpecifierParts = (
+  specifier: string
+): { readonly packageName: string; readonly subpath: string } | null => {
+  const packageName = parseBarePackageName(specifier);
+  if (!packageName) {
+    return null;
+  }
+  const suffix = specifier.slice(packageName.length);
+  return {
+    packageName,
+    subpath: suffix.length === 0 ? '.' : `.${suffix}`,
+  };
+};
+
+const findNodeModulesPackageInfo = (
+  importerPath: string,
+  packageName: string
+): PackageInfo | null => {
+  const packageSegments = packageName.split('/');
+  let dir = dirname(resolve(importerPath));
+  while (true) {
+    const packageJsonPath = join(
+      dir,
+      'node_modules',
+      ...packageSegments,
+      'package.json'
+    );
+    const info = packageInfoFromPackageJson(packageJsonPath);
+    if (info) {
+      return info;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+};
+
+const hasExportsMap = (info: PackageInfo | null): boolean =>
+  info?.exports !== undefined;
+
+const classifyResolverError = (
+  error: string
+): WardenImportResolutionErrorKind => {
+  if (error.includes(packagePathNotExportedErrorFragment)) {
+    return 'package-path-not-exported';
+  }
+  if (error.includes('ignored')) {
+    return 'ignored';
+  }
+  if (error.includes('not found') || error.includes('Cannot find')) {
+    return 'not-found';
+  }
+  return 'other';
+};
+
+const isInternalTargetPath = (
+  packageRoot: string | undefined,
+  resolvedPath: string | undefined
+): boolean => {
+  if (!packageRoot || !resolvedPath) {
+    return false;
+  }
+  const relativePath = normalizePath(relative(packageRoot, resolvedPath));
+  return /(?:^|\/)(?:src\/)?(?:internal|private|_internal|_private)(?:\/|$)/.test(
+    relativePath
+  );
+};
+
+const resolveResultPackageInfo = (
+  result: ResolveResult
+): PackageInfo | null => {
+  if (result.packageJsonPath) {
+    return packageInfoFromPackageJson(result.packageJsonPath);
+  }
+  if (result.path) {
+    return findPackageInfoForPath(result.path);
+  }
+  return null;
+};
+
+const resolveErrorKind = (
+  errorMessage: string | undefined,
+  builtinModule: string | undefined
+): WardenImportResolutionErrorKind | undefined => {
+  if (errorMessage) {
+    return classifyResolverError(errorMessage);
+  }
+  return builtinModule ? 'builtin' : undefined;
+};
+
+const optionalResolutionFields = ({
+  builtinModule,
+  errorKind,
+  errorMessage,
+  packageName,
+  packageRoot,
+  resolvedPath,
+}: {
+  readonly builtinModule: string | undefined;
+  readonly errorKind: WardenImportResolutionErrorKind | undefined;
+  readonly errorMessage: string | undefined;
+  readonly packageName: string | undefined;
+  readonly packageRoot: string | undefined;
+  readonly resolvedPath: string | undefined;
+}): Partial<WardenImportResolution> => ({
+  ...(builtinModule ? { builtinModule } : {}),
+  ...(errorKind ? { errorKind } : {}),
+  ...(errorMessage ? { errorMessage } : {}),
+  ...(packageName ? { packageName } : {}),
+  ...(packageRoot ? { packageRoot } : {}),
+  ...(resolvedPath ? { resolvedPath } : {}),
+});
+
+const buildResolution = ({
+  importSource,
+  importerPath,
+  line,
+  result,
+}: {
+  readonly importSource: string;
+  readonly importerPath: string;
+  readonly line: number;
+  readonly result: ResolveResult;
+}): WardenImportResolution => {
+  const normalizedImporter = normalizeRealPath(importerPath);
+  const importerInfo = findPackageInfoForPath(normalizedImporter);
+  const specifier = packageSpecifierParts(importSource);
+  const resolvedInfo = resolveResultPackageInfo(result);
+  const packageInfo =
+    resolvedInfo ??
+    (specifier
+      ? findNodeModulesPackageInfo(normalizedImporter, specifier.packageName)
+      : null);
+  const resolvedPath = result.path ? normalizeRealPath(result.path) : undefined;
+  const packageRoot = packageInfo?.root;
+  const packageName = packageInfo?.name ?? specifier?.packageName;
+  const errorMessage = result.error;
+  const builtinModule = result.builtin?.resolved;
+  const errorKind = resolveErrorKind(errorMessage, builtinModule);
+  const crossesPackageBoundary = Boolean(
+    importerInfo?.root && packageRoot && importerInfo.root !== packageRoot
+  );
+  const usesPublicExport = Boolean(
+    !errorMessage && specifier && hasExportsMap(packageInfo)
+  );
+  const isInternalTarget = isInternalTargetPath(packageRoot, resolvedPath);
+
+  return {
+    crossesPackageBoundary,
+    importSource,
+    importerPath: normalizedImporter,
+    isInternalTarget,
+    line,
+    usesPublicExport,
+    ...optionalResolutionFields({
+      builtinModule,
+      errorKind,
+      errorMessage,
+      packageName,
+      packageRoot,
+      resolvedPath,
+    }),
+  };
+};
+
+const getModuleSourceNode = (node: AstNode): AstNode | undefined =>
+  (node as unknown as { source?: AstNode }).source;
+
+const isStaticImportNode = (node: AstNode): boolean =>
+  node.type === 'ImportDeclaration' ||
+  node.type === 'ExportNamedDeclaration' ||
+  node.type === 'ExportAllDeclaration';
+
+const isDynamicImportExpression = (node: AstNode): boolean =>
+  node.type === 'ImportExpression';
+
+const isTypeImportNode = (node: AstNode): boolean =>
+  node.type === 'TSImportType';
+
+const isRequireCallExpression = (node: AstNode): boolean => {
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+  const { callee } = node as unknown as { callee?: AstNode };
+  return (
+    callee?.type === 'Identifier' &&
+    (callee as unknown as { name?: string }).name === 'require'
+  );
+};
+
+const getRequireSourceNode = (node: AstNode): AstNode | undefined =>
+  (node as unknown as { arguments?: readonly AstNode[] }).arguments?.[0];
+
+export const collectImportSpecifiers = (
+  filePath: string,
+  sourceCode: string
+): readonly WardenImportSpecifier[] => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  const specifiers: WardenImportSpecifier[] = [];
+  walk(ast, (node) => {
+    if (
+      !isStaticImportNode(node) &&
+      !isDynamicImportExpression(node) &&
+      !isTypeImportNode(node) &&
+      !isRequireCallExpression(node)
+    ) {
+      return;
+    }
+    const source = isRequireCallExpression(node)
+      ? getRequireSourceNode(node)
+      : getModuleSourceNode(node);
+    const importSource =
+      source && isStringLiteral(source) ? getStringValue(source) : null;
+    if (!importSource) {
+      return;
+    }
+    specifiers.push({
+      importSource,
+      line: offsetToLine(sourceCode, node.start),
+    });
+  });
+  return specifiers;
+};
+
+export const createWardenResolver = (
+  options: WardenResolverOptions = {}
+): WardenProjectResolver => {
+  const rootDir = normalizeRealPath(options.rootDir ?? process.cwd());
+  const resolveOptions = mergeWardenResolveOptions(options.resolveOptions);
+  const resolver = new ResolverFactory(resolveOptions);
+  const cache = new Map<string, ResolveResult>();
+
+  return {
+    clearCache: () => {
+      cache.clear();
+      resolver.clearCache();
+    },
+    resolveImport: (
+      importerPath: string,
+      importSource: string,
+      line = 1
+    ): WardenImportResolution => {
+      const absoluteImporterPath = isAbsolute(importerPath)
+        ? importerPath
+        : resolve(rootDir, importerPath);
+      const normalizedImporterPath = normalizeRealPath(absoluteImporterPath);
+      const key = `${normalizedImporterPath}\0${importSource}`;
+      const cached = cache.get(key);
+      if (cached) {
+        return buildResolution({
+          importSource,
+          importerPath: normalizedImporterPath,
+          line,
+          result: cached,
+        });
+      }
+      const result = resolver.resolveFileSync(
+        normalizedImporterPath,
+        importSource
+      );
+      const resolution = buildResolution({
+        importSource,
+        importerPath: normalizedImporterPath,
+        line,
+        result,
+      });
+      cache.set(key, result);
+      return resolution;
+    },
+    resolveOptions,
+    rootDir,
+  };
+};
+
+export const collectImportResolutionsForFile = ({
+  filePath,
+  resolver,
+  sourceCode,
+}: {
+  readonly filePath: string;
+  readonly resolver: WardenProjectResolver;
+  readonly sourceCode: string;
+}): readonly WardenImportResolution[] =>
+  collectImportSpecifiers(filePath, sourceCode).map((specifier) =>
+    resolver.resolveImport(filePath, specifier.importSource, specifier.line)
+  );

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -1,6 +1,7 @@
 import type { Intent, Topo } from '@ontrails/core';
 
 import type { WardenDepth } from '../config.js';
+import type { WardenImportResolution } from '../resolve.js';
 
 /**
  * Severity level for warden diagnostics.
@@ -141,6 +142,11 @@ export interface ProjectContext {
   readonly onTargetSignalIds?: ReadonlySet<string>;
   /** Store table IDs used with reconcile trails across the project. */
   readonly reconcileTableIds?: ReadonlySet<string>;
+  /** Resolved import facts keyed by importer file path across the project. */
+  readonly importResolutionsByFile?: ReadonlyMap<
+    string,
+    readonly WardenImportResolution[]
+  >;
   /** Normalized trail intents by trail ID across the project. */
   readonly trailIntentsById?: ReadonlyMap<string, Intent>;
   /**

--- a/packages/warden/src/trails/run.ts
+++ b/packages/warden/src/trails/run.ts
@@ -11,6 +11,7 @@ import { run } from '@ontrails/core';
 
 import { wardenTopoRules } from '../rules/index.js';
 import type { WardenDiagnostic } from '../rules/types.js';
+import type { WardenImportResolution } from '../resolve.js';
 import type { RuleOutput } from './schema.js';
 import { wardenTopo } from './topo.js';
 
@@ -39,6 +40,9 @@ interface ProjectRuleOptions {
   readonly crudTableIds?: readonly string[];
   readonly crudCoverageByEntity?: Readonly<Record<string, readonly string[]>>;
   readonly knownContourIds?: readonly string[];
+  readonly importResolutionsByFile?: Readonly<
+    Record<string, readonly WardenImportResolution[]>
+  >;
   readonly knownResourceIds?: readonly string[];
   readonly knownSignalIds?: readonly string[];
   readonly knownTrailIds?: readonly string[];
@@ -53,6 +57,7 @@ const PROJECT_OPTION_KEYS = [
   'crudTableIds',
   'crudCoverageByEntity',
   'knownContourIds',
+  'importResolutionsByFile',
   'knownResourceIds',
   'knownSignalIds',
   'knownTrailIds',

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -8,6 +8,7 @@
 import { intentValues } from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 import { z } from 'zod';
+import { wardenImportResolutionErrorKinds } from '../resolve.js';
 
 /** A single diagnostic emitted by a warden rule trail. */
 export const diagnosticSchema = z.object({
@@ -22,6 +23,21 @@ export const diagnosticSchema = z.object({
 export const ruleInput = z.object({
   filePath: z.string().describe('Path to the source file'),
   sourceCode: z.string().describe('Source code content'),
+});
+
+export const importResolutionSchema = z.object({
+  builtinModule: z.string().optional(),
+  crossesPackageBoundary: z.boolean(),
+  errorKind: z.enum(wardenImportResolutionErrorKinds).optional(),
+  errorMessage: z.string().optional(),
+  importSource: z.string(),
+  importerPath: z.string(),
+  isInternalTarget: z.boolean(),
+  line: z.number(),
+  packageName: z.string().optional(),
+  packageRoot: z.string().optional(),
+  resolvedPath: z.string().optional(),
+  usesPublicExport: z.boolean(),
 });
 
 /**
@@ -49,6 +65,10 @@ export const projectAwareRuleInput = ruleInput.extend({
     .array(z.string())
     .optional()
     .describe('Store table IDs used with CRUD factories across the project'),
+  importResolutionsByFile: z
+    .record(z.string(), z.array(importResolutionSchema))
+    .optional()
+    .describe('Resolved import facts keyed by importer file path'),
   knownContourIds: z
     .array(z.string())
     .optional()

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -74,6 +74,13 @@ const buildProjectContext = (input: ProjectAwareRuleInput): ProjectContext => ({
   ...(input.knownContourIds
     ? { knownContourIds: new Set(input.knownContourIds) }
     : {}),
+  ...(input.importResolutionsByFile
+    ? {
+        importResolutionsByFile: new Map(
+          Object.entries(input.importResolutionsByFile)
+        ),
+      }
+    : {}),
   knownTrailIds: input.knownTrailIds
     ? new Set(input.knownTrailIds)
     : new Set<string>(),


### PR DESCRIPTION

Branch: `trl-677-add-oxc-resolver-substrate-to-warden`

### Context

Resolver-backed Warden rules need one shared, Warden-owned import-resolution
fact model instead of each rule coupling directly to `oxc-resolver`.

### What changed

- Added `oxc-resolver` to `@ontrails/warden`.
- Added `packages/warden/src/resolve.ts` with `WardenImportResolution`,
  `WardenProjectResolver`, `collectImportSpecifiers`, and
  `collectImportResolutionsForFile`.
- Added `packages/warden/src/project-context.ts` helpers for project import
  resolution facts.
- Keyed project import-resolution maps by normalized real path while retaining
  the raw caller path alias for symlinked workspaces.
- Let project import collection accept custom resolver options.
- Shared the runtime error-kind tuple with the Warden trail schema.
- Documented the exact semantics of `usesPublicExport` and `isInternalTarget`
  so downstream rules treat them as resolver facts rather than exact export-map
  membership proof.
- Threaded resolver facts through `ProjectContext`, Warden CLI context
  creation, Warden trail schemas, and public exports.
- Covered static imports/re-exports, dynamic `import("...")`, TypeScript
  `import("...")` type nodes, and static `require("...")` calls.

### Verification

- `bun test packages/warden/src/__tests__/resolve.test.ts`
- `bun test packages/warden/src/__tests__/public-api.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run --cwd packages/warden lint`
- `bun run --cwd packages/warden test`
- Stack-tip `bun run check`

### Risks / rollout

Resolver facts are additive and currently consumed by later Warden rules in the
stack. The resolver is wrapped behind Warden types so future resolver upgrades
should stay localized. `usesPublicExport` is intentionally documented as a
coarse fact; exact public-surface checks live in the TRL-648 workspace/export
guard.

### Changeset

Patch changeset: `.changeset/warden-resolver-substrate.md`.

Closes: TRL-677