### PR TITLE
feat: add resolved import boundary rule

### DIFF
--- a/.changeset/warden-resolved-import-boundary.md
+++ b/.changeset/warden-resolved-import-boundary.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/warden': patch
+---
+
+Add the resolver-backed `resolved-import-boundary` Warden rule for cross-package import boundary enforcement.

--- a/packages/warden/src/__tests__/resolved-import-boundary.test.ts
+++ b/packages/warden/src/__tests__/resolved-import-boundary.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  mkdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { collectProjectImportResolutions } from '../project-context.js';
+import { resolvedImportBoundary } from '../rules/resolved-import-boundary.js';
+import type { ProjectContext } from '../rules/types.js';
+
+const makeTempDir = (prefix: string): string => {
+  const dir = join(
+    tmpdir(),
+    `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+};
+
+const writeJson = (path: string, value: unknown): void => {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const writeSource = (path: string, source: string): void => {
+  writeFileSync(path, source.trimStart());
+};
+
+interface BoundaryFixture {
+  readonly appImporterPath: string;
+  readonly appRoot: string;
+  readonly coreRoot: string;
+  readonly rootDir: string;
+}
+
+const createBoundaryFixture = (sourceCode: string): BoundaryFixture => {
+  const rootDir = makeTempDir('warden-resolved-boundary');
+  const appRoot = join(rootDir, 'packages', 'app');
+  const coreRoot = join(rootDir, 'packages', 'core');
+  const appImporterPath = join(appRoot, 'src', 'app.ts');
+  mkdirSync(join(appRoot, 'src'), { recursive: true });
+  mkdirSync(join(coreRoot, 'src', 'internal'), { recursive: true });
+  mkdirSync(join(rootDir, 'node_modules', '@fixture'), { recursive: true });
+
+  writeJson(join(rootDir, 'package.json'), {
+    private: true,
+    type: 'module',
+    workspaces: ['packages/*'],
+  });
+  writeJson(join(appRoot, 'package.json'), {
+    dependencies: { '@fixture/core': 'workspace:*' },
+    name: '@fixture/app',
+    type: 'module',
+  });
+  writeJson(join(coreRoot, 'package.json'), {
+    exports: {
+      '.': './src/index.ts',
+      './public': './src/public.ts',
+    },
+    name: '@fixture/core',
+    type: 'module',
+  });
+  writeSource(join(coreRoot, 'src', 'index.ts'), 'export const value = 1;\n');
+  writeSource(join(coreRoot, 'src', 'public.ts'), 'export const pub = 1;\n');
+  writeSource(
+    join(coreRoot, 'src', 'internal', 'secret.ts'),
+    'export const secret = 1;\n'
+  );
+  writeSource(appImporterPath, sourceCode);
+  symlinkSync(
+    coreRoot,
+    join(rootDir, 'node_modules', '@fixture', 'core'),
+    'dir'
+  );
+
+  return { appImporterPath, appRoot, coreRoot, rootDir };
+};
+
+const collectContext = (
+  fixture: BoundaryFixture,
+  sourceCode: string,
+  filePath = fixture.appImporterPath
+): ProjectContext => {
+  const normalizedSourceCode = sourceCode.trimStart();
+  return {
+    importResolutionsByFile: collectProjectImportResolutions({
+      rootDir: fixture.rootDir,
+      sourceFiles: [
+        {
+          filePath,
+          kind: 'typescript',
+          sourceCode: normalizedSourceCode,
+        },
+      ],
+    }),
+    knownTrailIds: new Set<string>(),
+  };
+};
+
+const checkFixture = (
+  sourceCode: string,
+  options: { readonly filePath?: string } = {}
+) => {
+  const fixture = createBoundaryFixture(sourceCode);
+  try {
+    const filePath = options.filePath ?? fixture.appImporterPath;
+    const context = collectContext(fixture, sourceCode, filePath);
+    return resolvedImportBoundary.checkWithContext(
+      sourceCode.trimStart(),
+      filePath,
+      context
+    );
+  } finally {
+    rmSync(fixture.rootDir, { force: true, recursive: true });
+  }
+};
+
+describe('resolved-import-boundary', () => {
+  test('stays quiet without resolver-backed project context', () => {
+    const diagnostics = resolvedImportBoundary.checkWithContext(
+      "import { secret } from '@fixture/core/internal/secret';\n",
+      'packages/app/src/app.ts',
+      { knownTrailIds: new Set<string>() }
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('allows exported package roots and subpaths', () => {
+    const diagnostics = checkFixture(`
+      import { value } from '@fixture/core';
+      import { pub } from '@fixture/core/public';
+    `);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('flags package subpaths blocked by the target export map', () => {
+    const diagnostics = checkFixture(`
+      import { secret } from '@fixture/core/internal/secret';
+    `);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      line: 1,
+      message:
+        'Import "@fixture/core/internal/secret" is not exported by @fixture/core. Import the package root or an exported subpath instead.',
+      rule: 'resolved-import-boundary',
+      severity: 'error',
+    });
+  });
+
+  test('flags unrecognized failed cross-boundary bare specifiers', () => {
+    const filePath = 'packages/app/src/app.ts';
+    const diagnostics = resolvedImportBoundary.checkWithContext(
+      "import { value } from '@fixture/core/unknown';\n",
+      filePath,
+      {
+        importResolutionsByFile: new Map([
+          [
+            filePath,
+            [
+              {
+                crossesPackageBoundary: true,
+                errorKind: 'other',
+                importSource: '@fixture/core/unknown',
+                importerPath: filePath,
+                isInternalTarget: false,
+                line: 1,
+                packageName: '@fixture/core',
+                usesPublicExport: false,
+              },
+            ],
+          ],
+        ]),
+        knownTrailIds: new Set<string>(),
+      }
+    );
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        message:
+          'Import "@fixture/core/unknown" is not exported by @fixture/core. Import the package root or an exported subpath instead.',
+      }),
+    ]);
+  });
+
+  test('flags relative imports crossing into another package', () => {
+    const diagnostics = checkFixture(`
+      import { pub } from '../../core/src/public';
+    `);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toBe(
+      'Local import "../../core/src/public" crosses into @fixture/core. Import the target package public surface instead.'
+    );
+  });
+
+  test('labels absolute cross-package paths as local imports', () => {
+    const fixture = createBoundaryFixture('');
+    const absolutePublicPath = join(fixture.coreRoot, 'src', 'public.ts');
+    const sourceCode = `import { pub } from '${absolutePublicPath}';\n`;
+    writeSource(fixture.appImporterPath, sourceCode);
+
+    try {
+      const context = collectContext(fixture, sourceCode);
+      const diagnostics = resolvedImportBoundary.checkWithContext(
+        sourceCode,
+        fixture.appImporterPath,
+        context
+      );
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toBe(
+        `Local import "${absolutePublicPath}" crosses into @fixture/core. Import the target package public surface instead.`
+      );
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('flags cross-package imports into internal or private targets', () => {
+    const diagnostics = checkFixture(`
+      import { secret } from '../../core/src/internal/secret';
+    `);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toBe(
+      'Import "../../core/src/internal/secret" targets internal/private files in @fixture/core. Import the target package public surface instead.'
+    );
+  });
+
+  test('allows same-package relative imports into local internals', () => {
+    const sourceCode = `
+      import { helper } from './internal/helper';
+    `;
+    const fixture = createBoundaryFixture(sourceCode);
+    const helperPath = join(fixture.appRoot, 'src', 'internal', 'helper.ts');
+    mkdirSync(join(fixture.appRoot, 'src', 'internal'), { recursive: true });
+    writeSource(helperPath, 'export const helper = 1;\n');
+
+    try {
+      const context = collectContext(fixture, sourceCode);
+      const diagnostics = resolvedImportBoundary.checkWithContext(
+        sourceCode.trimStart(),
+        fixture.appImporterPath,
+        context
+      );
+
+      expect(diagnostics).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('allows test, fixture, and migration files as explicit local exceptions', () => {
+    const sourceCode = `
+      import { pub } from '../../core/src/public';
+    `;
+    const fixture = createBoundaryFixture(sourceCode);
+    const exceptionFiles = [
+      join(fixture.appRoot, 'src', 'app.test.ts'),
+      join(fixture.appRoot, 'fixtures', 'fixture.ts'),
+      join(fixture.appRoot, 'migrations', 'one.ts'),
+    ];
+
+    try {
+      for (const filePath of exceptionFiles) {
+        const context = collectContext(fixture, sourceCode, filePath);
+        const diagnostics = resolvedImportBoundary.checkWithContext(
+          sourceCode.trimStart(),
+          filePath,
+          context
+        );
+        expect(diagnostics).toEqual([]);
+      }
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('supports warden-ignore-next-line for intentional package seams', () => {
+    const diagnostics = checkFixture(`
+      // warden-ignore-next-line
+      import { pub } from '../../core/src/public';
+    `);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('uses the real package root when reporting workspace symlink imports', () => {
+    const sourceCode = `
+      import { pub } from '../../core/src/public';
+    `;
+    const fixture = createBoundaryFixture(sourceCode);
+
+    try {
+      const context = collectContext(fixture, sourceCode);
+      const [resolution] =
+        context.importResolutionsByFile?.get(fixture.appImporterPath) ?? [];
+      expect(resolution?.packageRoot).toBe(realpathSync(fixture.coreRoot));
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -7,8 +7,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 46 rule trails', () => {
-    expect(wardenTopo.count).toBe(46);
+  test('contains all 47 rule trails', () => {
+    expect(wardenTopo.count).toBe(47);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -161,6 +161,7 @@ export {
   publicUnionOutputDiscriminantsTrail,
   readIntentFiresTrail,
   referenceExistsTrail,
+  resolvedImportBoundaryTrail,
   ruleInput,
   ruleOutput,
   resourceDeclarationsTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -32,6 +32,7 @@ import { publicInternalDeepImports } from './public-internal-deep-imports.js';
 import { publicUnionOutputDiscriminants } from './public-union-output-discriminants.js';
 import { readIntentFires } from './read-intent-fires.js';
 import { referenceExists } from './reference-exists.js';
+import { resolvedImportBoundary } from './resolved-import-boundary.js';
 import { resourceDeclarations } from './resource-declarations.js';
 import { resourceExists } from './resource-exists.js';
 import { resourceIdGrammar } from './resource-id-grammar.js';
@@ -106,6 +107,7 @@ export { publicInternalDeepImports } from './public-internal-deep-imports.js';
 export { publicUnionOutputDiscriminants } from './public-union-output-discriminants.js';
 export { readIntentFires } from './read-intent-fires.js';
 export { referenceExists } from './reference-exists.js';
+export { resolvedImportBoundary } from './resolved-import-boundary.js';
 export { resourceDeclarations } from './resource-declarations.js';
 export { resourceExists } from './resource-exists.js';
 export { resourceIdGrammar } from './resource-id-grammar.js';
@@ -145,6 +147,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [resourceDeclarations.name, resourceDeclarations],
   [readIntentFires.name, readIntentFires],
   [referenceExists.name, referenceExists],
+  [resolvedImportBoundary.name, resolvedImportBoundary],
   [resourceIdGrammar.name, resourceIdGrammar],
   [resourceExists.name, resourceExists],
   [preferSchemaInference.name, preferSchemaInference],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -78,6 +78,7 @@ const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'orphaned-signal': 'signals',
   'permit-governance': 'permits',
   'read-intent-fires': 'signals',
+  'resolved-import-boundary': 'composition',
   'resource-declarations': 'resources',
   'resource-exists': 'resources',
   'resource-id-grammar': 'resources',
@@ -286,6 +287,11 @@ const builtinWardenRuleMetadataInput = {
   'reference-exists': {
     ...durableExternal,
     invariant: 'Reference declarations resolve to known contours.',
+    tier: 'project-static',
+  },
+  'resolved-import-boundary': {
+    ...durableExternal,
+    invariant: 'Cross-package imports resolve through public export maps.',
     tier: 'project-static',
   },
   'resource-declarations': {

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -40,6 +40,7 @@ import { publicInternalDeepImports } from './public-internal-deep-imports.js';
 import { publicUnionOutputDiscriminants } from './public-union-output-discriminants.js';
 import { readIntentFires } from './read-intent-fires.js';
 import { referenceExists } from './reference-exists.js';
+import { resolvedImportBoundary } from './resolved-import-boundary.js';
 import { resourceDeclarations } from './resource-declarations.js';
 import { resourceExists } from './resource-exists.js';
 import { resourceIdGrammar } from './resource-id-grammar.js';
@@ -93,6 +94,7 @@ export const registeredRuleNames: readonly string[] = [
   publicUnionOutputDiscriminants.name,
   readIntentFires.name,
   referenceExists.name,
+  resolvedImportBoundary.name,
   resourceDeclarations.name,
   resourceExists.name,
   resourceIdGrammar.name,

--- a/packages/warden/src/rules/resolved-import-boundary.ts
+++ b/packages/warden/src/rules/resolved-import-boundary.ts
@@ -1,0 +1,146 @@
+import { hasIgnoreCommentOnLine, splitSourceLines } from './ast.js';
+import { isTestFile } from './scan.js';
+import type { WardenImportResolution } from '../resolve.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+const RULE_NAME = 'resolved-import-boundary';
+
+const normalizePath = (path: string): string => path.replaceAll('\\', '/');
+
+const isLocalPathImport = (importSource: string): boolean =>
+  importSource.startsWith('.') || importSource.startsWith('/');
+
+const isFixtureOrMigrationFile = (filePath: string): boolean => {
+  const normalized = normalizePath(filePath);
+  return /(?:^|\/)(?:__fixtures__|fixtures?|migrations?)(?:\/|$)/.test(
+    normalized
+  );
+};
+
+const isAllowlistedFile = (filePath: string): boolean =>
+  isTestFile(filePath) || isFixtureOrMigrationFile(filePath);
+
+const resolutionLabel = (resolution: {
+  readonly importSource: string;
+  readonly packageName?: string | undefined;
+}): string => resolution.packageName ?? resolution.importSource;
+
+const publicSurfaceMessage = (resolution: {
+  readonly importSource: string;
+  readonly packageName?: string | undefined;
+}): string =>
+  `Import "${resolution.importSource}" is not exported by ${resolutionLabel(
+    resolution
+  )}. Import the package root or an exported subpath instead.`;
+
+const localPathBoundaryMessage = (resolution: {
+  readonly importSource: string;
+  readonly packageName?: string | undefined;
+}): string =>
+  `Local import "${resolution.importSource}" crosses into ${resolutionLabel(
+    resolution
+  )}. Import the target package public surface instead.`;
+
+const internalTargetMessage = (resolution: {
+  readonly importSource: string;
+  readonly packageName?: string | undefined;
+}): string =>
+  `Import "${resolution.importSource}" targets internal/private files in ${resolutionLabel(
+    resolution
+  )}. Import the target package public surface instead.`;
+
+const diagnosticForResolution = (
+  filePath: string,
+  resolution: WardenImportResolution
+): WardenDiagnostic | null => {
+  if (!resolution.crossesPackageBoundary) {
+    return null;
+  }
+
+  if (resolution.isInternalTarget) {
+    return {
+      filePath,
+      line: resolution.line,
+      message: internalTargetMessage(resolution),
+      rule: RULE_NAME,
+      severity: 'error',
+    };
+  }
+
+  if (isLocalPathImport(resolution.importSource)) {
+    return {
+      filePath,
+      line: resolution.line,
+      message: localPathBoundaryMessage(resolution),
+      rule: RULE_NAME,
+      severity: 'error',
+    };
+  }
+
+  if (resolution.errorKind === 'package-path-not-exported') {
+    return {
+      filePath,
+      line: resolution.line,
+      message: publicSurfaceMessage(resolution),
+      rule: RULE_NAME,
+      severity: 'error',
+    };
+  }
+
+  if (
+    resolution.errorKind &&
+    resolution.errorKind !== 'builtin' &&
+    resolution.errorKind !== 'ignored'
+  ) {
+    return {
+      filePath,
+      line: resolution.line,
+      message: publicSurfaceMessage(resolution),
+      rule: RULE_NAME,
+      severity: 'error',
+    };
+  }
+
+  return null;
+};
+
+const importResolutionsForFile = (context: ProjectContext, filePath: string) =>
+  context.importResolutionsByFile?.get(filePath) ?? [];
+
+export const resolvedImportBoundary: ProjectAwareWardenRule = {
+  check(): readonly WardenDiagnostic[] {
+    return [];
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    if (isAllowlistedFile(filePath)) {
+      return [];
+    }
+
+    const lines = splitSourceLines(sourceCode);
+    const diagnostics: WardenDiagnostic[] = [];
+
+    for (const resolution of importResolutionsForFile(context, filePath)) {
+      if (hasIgnoreCommentOnLine(lines, resolution.line)) {
+        continue;
+      }
+      const diagnostic = diagnosticForResolution(filePath, resolution);
+      if (diagnostic) {
+        diagnostics.push(diagnostic);
+      }
+    }
+
+    return diagnostics;
+  },
+  description:
+    'Ensure cross-package imports resolve through package-owned public exports.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -32,6 +32,7 @@ export { publicInternalDeepImportsTrail } from './public-internal-deep-imports.t
 export { publicUnionOutputDiscriminantsTrail } from './public-union-output-discriminants.trail.js';
 export { readIntentFiresTrail } from './read-intent-fires.trail.js';
 export { referenceExistsTrail } from './reference-exists.trail.js';
+export { resolvedImportBoundaryTrail } from './resolved-import-boundary.trail.js';
 export { resourceDeclarationsTrail } from './resource-declarations.trail.js';
 export { resourceIdGrammarTrail } from './resource-id-grammar.trail.js';
 export { resourceExistsTrail } from './resource-exists.trail.js';

--- a/packages/warden/src/trails/resolved-import-boundary.trail.ts
+++ b/packages/warden/src/trails/resolved-import-boundary.trail.ts
@@ -1,0 +1,109 @@
+import { resolvedImportBoundary } from '../rules/resolved-import-boundary.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const resolvedImportBoundaryTrail = wrapRule({
+  examples: [
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'packages/app/src/index.ts',
+            line: 1,
+            message:
+              'Import "@fixture/core/internal/secret" is not exported by @fixture/core. Import the package root or an exported subpath instead.',
+            rule: 'resolved-import-boundary',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        filePath: 'packages/app/src/index.ts',
+        importResolutionsByFile: {
+          'packages/app/src/index.ts': [
+            {
+              crossesPackageBoundary: true,
+              errorKind: 'package-path-not-exported',
+              importSource: '@fixture/core/internal/secret',
+              importerPath: 'packages/app/src/index.ts',
+              isInternalTarget: false,
+              line: 1,
+              packageName: '@fixture/core',
+              usesPublicExport: false,
+            },
+          ],
+        },
+        knownTrailIds: [],
+        sourceCode: "import { secret } from '@fixture/core/internal/secret';\n",
+      },
+      name: 'Cross-package imports must use exported package subpaths',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'packages/app/src/index.ts',
+            line: 1,
+            message:
+              'Local import "../../core/src/public" crosses into @fixture/core. Import the target package public surface instead.',
+            rule: 'resolved-import-boundary',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        filePath: 'packages/app/src/index.ts',
+        importResolutionsByFile: {
+          'packages/app/src/index.ts': [
+            {
+              crossesPackageBoundary: true,
+              importSource: '../../core/src/public',
+              importerPath: 'packages/app/src/index.ts',
+              isInternalTarget: false,
+              line: 1,
+              packageName: '@fixture/core',
+              usesPublicExport: false,
+            },
+          ],
+        },
+        knownTrailIds: [],
+        sourceCode: "import { pub } from '../../core/src/public';\n",
+      },
+      name: 'Relative imports must not cross package boundaries',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'packages/app/src/index.ts',
+            line: 1,
+            message:
+              'Import "../../core/src/internal/secret" targets internal/private files in @fixture/core. Import the target package public surface instead.',
+            rule: 'resolved-import-boundary',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        filePath: 'packages/app/src/index.ts',
+        importResolutionsByFile: {
+          'packages/app/src/index.ts': [
+            {
+              crossesPackageBoundary: true,
+              importSource: '../../core/src/internal/secret',
+              importerPath: 'packages/app/src/index.ts',
+              isInternalTarget: true,
+              line: 1,
+              packageName: '@fixture/core',
+              usesPublicExport: false,
+            },
+          ],
+        },
+        knownTrailIds: [],
+        sourceCode:
+          "import { secret } from '../../core/src/internal/secret';\n",
+      },
+      name: 'Cross-package imports must not target internals',
+    },
+  ],
+  rule: resolvedImportBoundary,
+});


### PR DESCRIPTION

Branch: `trl-678-land-resolved-import-boundary-as-first-resolver-backed`

### Context

M2 needs the first resolver-backed Warden rule to prove the shared substrate can
enforce real package boundaries without hand-rolled import heuristics.

### What changed

- Added `resolved-import-boundary` as a project-aware Warden rule and trail.
- Flags package subpaths blocked by export maps.
- Defensively flags failed cross-boundary bare package specifiers even if a
  future resolver error string no longer classifies as
  `package-path-not-exported`.
- Flags relative imports that cross package boundaries.
- Flags cross-package imports into internal/private targets.
- Keeps explicit exceptions for tests, fixtures, migrations, same-package local
  internals, and `warden-ignore-next-line`.
- Registered the rule in Warden metadata, registries, public exports, and trail
  topology.

### Verification

- `bun test packages/warden/src/__tests__/resolved-import-boundary.test.ts`
- `bun test packages/warden/src/__tests__/warden-export-symmetry.test.ts packages/warden/src/__tests__/trails.test.ts packages/warden/src/__tests__/warden-rule-metadata.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run --cwd packages/warden lint`
- `bun run --cwd packages/warden test`
- Stack-tip `bun run check`

### Risks / rollout

The rule is project-context dependent and returns no diagnostics without
resolver facts, which keeps legacy direct source-rule invocation stable.

### Changeset

Patch changeset: `.changeset/warden-resolved-import-boundary.md`.

Closes: TRL-678