### PR TITLE
docs: fix warden wraprule import path

### DIFF
--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -115,9 +115,14 @@ const diagnostics = await runWardenTrails(filePath, sourceCode, {
 const topoDiagnostics = await runTopoAwareWardenTrails(myApp);
 ```
 
-To wrap a custom rule as a trail, use `wrapRule` (imported from
-`@ontrails/warden/trails/wrap-rule`). This is the same factory used internally
-to build all built-in rule trails.
+To wrap a custom rule as a trail, import `wrapRule` from the root package
+entrypoint:
+
+```typescript
+import { wrapRule } from '@ontrails/warden';
+```
+
+This is the same factory used internally to build all built-in rule trails.
 
 ## API
 
@@ -136,6 +141,7 @@ to build all built-in rule trails.
 | `formatGitHubAnnotations(report)` | GitHub Actions annotation format |
 | `formatJson(report)` | Machine-readable JSON |
 | `formatSummary(report)` | Compact summary line |
+| `wrapRule(rule)` | Wrap a custom rule as a trail (same factory used for all built-in rule trails) |
 
 AST parser helpers are exported from `@ontrails/warden/ast`, not the root
 runtime barrel. The stable authoring surface includes `parse`, `walk`,


### PR DESCRIPTION

Branch: `trl-647-fix-warden-wraprule-docs-export-map-drift`

### Context

TRL-676 verified that `@ontrails/warden/trails/wrap-rule` is not a public
exported subpath. The Warden README still documented that stale path.

### What changed

- Updated `packages/warden/README.md` to import `wrapRule` from the root public
  package surface: `@ontrails/warden`.
- Added `wrapRule(rule)` to the README API table so the documented public
  surface matches the root export.
- Left the package export map unchanged.

### Verification

- `bun scripts/check-readme-snippets.ts`
- `bun run format:check`
- `git diff --check`
- Stack-tip `bun run check`

### Risks / rollout

Docs-only correction. No runtime behavior changes.

### Changeset

`release:none` - documentation only.

Closes: TRL-647