### PR TITLE
feat: add public export map warden guard

### DIFF
--- a/.changeset/warden-public-export-map-guard.md
+++ b/.changeset/warden-public-export-map-guard.md
@@ -1,0 +1,11 @@
+---
+'@ontrails/commander': patch
+'@ontrails/drizzle': patch
+'@ontrails/hono': patch
+'@ontrails/http': patch
+'@ontrails/store': patch
+'@ontrails/warden': patch
+---
+
+Add project-aware public export-map governance for @ontrails workspace docs,
+imports, root barrels, and bin-only package surfaces.

--- a/adapters/commander/README.md
+++ b/adapters/commander/README.md
@@ -44,7 +44,9 @@ bun add @ontrails/cli @ontrails/commander
 
 ## Migration
 
+<!-- warden-ignore-next-line -->
 This package replaces the old `@ontrails/cli/commander` subpath.
 
+<!-- warden-ignore-next-line -->
 - Before: `import { surface } from '@ontrails/cli/commander'`
 - After: `import { surface } from '@ontrails/commander'`

--- a/adapters/drizzle/README.md
+++ b/adapters/drizzle/README.md
@@ -30,7 +30,9 @@ bun add @ontrails/store @ontrails/drizzle zod
 
 ## Migration
 
+<!-- warden-ignore-next-line -->
 This package replaces the old `@ontrails/store/drizzle` subpath.
 
+<!-- warden-ignore-next-line -->
 - Before: `import { connectDrizzle } from '@ontrails/store/drizzle'`
 - After: `import { connectDrizzle } from '@ontrails/drizzle'`

--- a/adapters/hono/README.md
+++ b/adapters/hono/README.md
@@ -34,7 +34,9 @@ bun add @ontrails/http @ontrails/hono
 
 ## Migration
 
+<!-- warden-ignore-next-line -->
 This package replaces the old `@ontrails/http/hono` subpath.
 
+<!-- warden-ignore-next-line -->
 - Before: `import { trailhead } from '@ontrails/http/hono'`
 - After: `import { surface } from '@ontrails/hono'`

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -120,5 +120,6 @@ bun add @ontrails/http @ontrails/hono
 
 Hono integration now lives in `@ontrails/hono`.
 
+<!-- warden-ignore-next-line -->
 - Replace `import { trailhead } from '@ontrails/http/hono'` with `import { surface } from '@ontrails/hono'`
 - Keep `deriveHttpRoutes()` and the route model imports on `@ontrails/http`

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -276,5 +276,6 @@ bun add @ontrails/drizzle
 
 The Drizzle binding now lives in `@ontrails/drizzle`.
 
+<!-- warden-ignore-next-line -->
 - Replace `import { ... } from '@ontrails/store/drizzle'` with `import { ... } from '@ontrails/drizzle'`
 - Keep backend-agnostic store declarations on `@ontrails/store`

--- a/packages/warden/src/__tests__/public-internal-deep-imports.test.ts
+++ b/packages/warden/src/__tests__/public-internal-deep-imports.test.ts
@@ -1,150 +1,618 @@
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { describe, expect, test } from 'bun:test';
+import {
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
-  __matchesExportPatternForTest,
-  publicInternalDeepImports,
-} from '../rules/public-internal-deep-imports.js';
+  collectProjectDocumentationImportResolutions,
+  collectProjectImportResolutions,
+  collectPublicWorkspaces,
+} from '../project-context.js';
+import { publicInternalDeepImports } from '../rules/public-internal-deep-imports.js';
+import type { ProjectContext } from '../rules/types.js';
+import type { WardenProjectContextSourceFile } from '../project-context.js';
 
-const WORKSPACE_ROOT = fileURLToPath(new URL('../../../../', import.meta.url));
-const workspaceFile = (...segments: readonly string[]) =>
-  resolve(WORKSPACE_ROOT, ...segments);
+const makeTempDir = (prefix: string): string => {
+  const dir = join(
+    tmpdir(),
+    `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+};
 
-const STORE_FILE = workspaceFile('packages/store/src/example.ts');
-const CORE_FILE = workspaceFile('packages/core/src/example.ts');
-const APP_FILE = workspaceFile('apps/trails/src/example.ts');
+const writeJson = (path: string, value: unknown): void => {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+};
 
-const check = (sourceCode: string, filePath = STORE_FILE) =>
-  publicInternalDeepImports.check(sourceCode, filePath);
+const writeSource = (path: string, source: string): void => {
+  writeFileSync(path, source.trimStart());
+};
+
+interface PublicSurfaceFixture {
+  readonly appImporterPath: string;
+  readonly coreImporterPath: string;
+  readonly coreRoot: string;
+  readonly readmePath: string;
+  readonly rootDir: string;
+  readonly storeRoot: string;
+  readonly trailsPackageJsonPath: string;
+  readonly trailsRoot: string;
+}
+
+const createFixture = (): PublicSurfaceFixture => {
+  const rootDir = makeTempDir('warden-public-surface');
+  const coreRoot = join(rootDir, 'packages', 'core');
+  const storeRoot = join(rootDir, 'packages', 'store');
+  const commanderRoot = join(rootDir, 'adapters', 'commander');
+  const trailsRoot = join(rootDir, 'apps', 'trails');
+  const privateRoot = join(rootDir, 'packages', 'oxlint-plugin');
+  const appImporterPath = join(storeRoot, 'src', 'app.ts');
+  const coreImporterPath = join(coreRoot, 'src', 'local.ts');
+  const readmePath = join(rootDir, 'packages', 'warden', 'README.md');
+  const trailsPackageJsonPath = join(trailsRoot, 'package.json');
+
+  mkdirSync(join(coreRoot, 'src', 'internal'), { recursive: true });
+  mkdirSync(join(storeRoot, 'src'), { recursive: true });
+  mkdirSync(join(commanderRoot, 'src'), { recursive: true });
+  mkdirSync(join(trailsRoot, 'bin'), { recursive: true });
+  mkdirSync(join(rootDir, 'packages', 'warden'), { recursive: true });
+  mkdirSync(privateRoot, { recursive: true });
+  mkdirSync(join(rootDir, 'node_modules', '@ontrails'), { recursive: true });
+
+  writeJson(join(rootDir, 'package.json'), {
+    private: true,
+    type: 'module',
+    workspaces: ['packages/*', 'adapters/*', 'apps/*'],
+  });
+  writeJson(join(coreRoot, 'package.json'), {
+    exports: {
+      '.': './src/index.ts',
+      './trails': './src/trails.ts',
+    },
+    name: '@ontrails/core',
+    type: 'module',
+  });
+  writeJson(join(storeRoot, 'package.json'), {
+    dependencies: { '@ontrails/core': 'workspace:*' },
+    exports: { '.': './src/index.ts' },
+    name: '@ontrails/store',
+    type: 'module',
+  });
+  writeJson(join(commanderRoot, 'package.json'), {
+    exports: { '.': './src/index.ts' },
+    name: '@ontrails/commander',
+    type: 'module',
+  });
+  writeJson(trailsPackageJsonPath, {
+    bin: { trails: './bin/trails.ts' },
+    files: ['bin/**/*.ts', 'README.md'],
+    name: '@ontrails/trails',
+    type: 'module',
+  });
+  writeJson(join(privateRoot, 'package.json'), {
+    name: '@ontrails/oxlint-plugin',
+    private: true,
+    type: 'module',
+  });
+
+  writeSource(join(coreRoot, 'src', 'index.ts'), 'export const value = 1;\n');
+  writeSource(join(coreRoot, 'src', 'trails.ts'), 'export const trail = 1;\n');
+  writeSource(
+    join(coreRoot, 'src', 'internal', 'secret.ts'),
+    'export const secret = 1;\n'
+  );
+  writeSource(join(storeRoot, 'src', 'index.ts'), 'export const store = 1;\n');
+  writeSource(
+    join(commanderRoot, 'src', 'index.ts'),
+    'export const commander = 1;\n'
+  );
+  writeSource(join(trailsRoot, 'bin', 'trails.ts'), 'export {};\n');
+
+  for (const [name, target] of [
+    ['core', coreRoot],
+    ['store', storeRoot],
+    ['commander', commanderRoot],
+    ['trails', trailsRoot],
+  ] as const) {
+    symlinkSync(
+      target,
+      join(rootDir, 'node_modules', '@ontrails', name),
+      'dir'
+    );
+  }
+
+  return {
+    appImporterPath,
+    coreImporterPath,
+    coreRoot,
+    readmePath,
+    rootDir,
+    storeRoot,
+    trailsPackageJsonPath,
+    trailsRoot,
+  };
+};
+
+const collectContext = (
+  fixture: PublicSurfaceFixture,
+  sourceFiles: readonly WardenProjectContextSourceFile[]
+): ProjectContext => ({
+  documentedImportResolutionsByFile:
+    collectProjectDocumentationImportResolutions({
+      rootDir: fixture.rootDir,
+      sourceFiles,
+    }),
+  importResolutionsByFile: collectProjectImportResolutions({
+    rootDir: fixture.rootDir,
+    sourceFiles,
+  }),
+  knownTrailIds: new Set<string>(),
+  publicWorkspaces: collectPublicWorkspaces(fixture.rootDir),
+});
+
+const checkFixture = (
+  fixture: PublicSurfaceFixture,
+  sourceFile: WardenProjectContextSourceFile
+) =>
+  publicInternalDeepImports.checkWithContext(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    collectContext(fixture, [sourceFile])
+  );
 
 describe('public-internal-deep-imports', () => {
-  test('wildcard exports match exactly one subpath segment', () => {
-    const extensionPattern = {
-      prefix: '@ontrails/example/',
-      suffix: '.js',
-    };
-    const suffixlessPattern = {
-      prefix: '@ontrails/example/',
-      suffix: '',
-    };
+  test('discovers public packages, adapters, and bin-only apps from root workspaces', () => {
+    const fixture = createFixture();
+    try {
+      const workspaces = collectPublicWorkspaces(fixture.rootDir);
 
-    expect(
-      __matchesExportPatternForTest(
-        '@ontrails/example/feature.js',
-        extensionPattern
-      )
-    ).toBe(true);
-    expect(
-      __matchesExportPatternForTest(
-        '@ontrails/example/feature/nested.js',
-        extensionPattern
-      )
-    ).toBe(false);
-    expect(
-      __matchesExportPatternForTest(
-        '@ontrails/example/feature',
-        suffixlessPattern
-      )
-    ).toBe(true);
-    expect(
-      __matchesExportPatternForTest(
-        '@ontrails/example/feature/nested',
-        suffixlessPattern
-      )
-    ).toBe(false);
-    expect(
-      __matchesExportPatternForTest('@ontrails/example/', suffixlessPattern)
-    ).toBe(false);
+      expect([...workspaces.keys()].toSorted()).toEqual([
+        '@ontrails/commander',
+        '@ontrails/core',
+        '@ontrails/store',
+        '@ontrails/trails',
+      ]);
+      expect(workspaces.get('@ontrails/trails')?.hasExports).toBe(false);
+      expect(workspaces.get('@ontrails/trails')?.bin).toEqual({
+        trails: './bin/trails.ts',
+      });
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
   });
 
-  test('allows package roots and exported package subpaths', () => {
-    const diagnostics = check(`
-import { trail } from '@ontrails/core';
-import { deriveTrail } from '@ontrails/core/trails';
-import { createJwtAdapter } from '@ontrails/permits/jwt';
-import { parse } from '@ontrails/warden/ast';
-`);
+  test('discovers nested conditional export targets', () => {
+    const fixture = createFixture();
+    try {
+      writeSource(
+        join(fixture.coreRoot, 'src', 'conditional.ts'),
+        'export const conditional = 1;\n'
+      );
+      writeJson(join(fixture.coreRoot, 'package.json'), {
+        exports: {
+          '.': './src/index.ts',
+          './conditional': { bun: { import: './src/conditional.ts' } },
+        },
+        name: '@ontrails/core',
+        type: 'module',
+      });
 
-    expect(diagnostics).toEqual([]);
+      const workspaces = collectPublicWorkspaces(fixture.rootDir);
+      const target =
+        workspaces.get('@ontrails/core')?.exportTargets?.[
+          '@ontrails/core/conditional'
+        ];
+
+      expect(target?.endsWith('/src/conditional.ts')).toBe(true);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
   });
 
-  test('allows package-local private imports', () => {
-    const diagnostics = check(
-      "import { hidden } from '@ontrails/core/src/internal/hidden';\n",
-      CORE_FILE
-    );
+  test('uses the unscoped local name for string-form scoped package bins', () => {
+    const fixture = createFixture();
+    try {
+      writeJson(fixture.trailsPackageJsonPath, {
+        bin: './bin/trails.ts',
+        files: ['bin/**/*.ts', 'README.md'],
+        name: '@ontrails/trails',
+        type: 'module',
+      });
 
-    expect(diagnostics).toEqual([]);
+      const workspaces = collectPublicWorkspaces(fixture.rootDir);
+
+      expect(workspaces.get('@ontrails/trails')?.bin).toEqual({
+        trails: './bin/trails.ts',
+      });
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
   });
 
-  test('flags cross-package imports into src internals', () => {
-    const diagnostics = check(
-      "import { hidden } from '@ontrails/core/src/internal/hidden';\n"
-    );
+  test('uses resolver facts to allow exported code subpaths', () => {
+    const fixture = createFixture();
+    try {
+      const sourceCode = "import { trail } from '@ontrails/core/trails';\n";
+      writeSource(fixture.appImporterPath, sourceCode);
 
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.message).toContain(
-      'cross-package import "@ontrails/core/src/internal/hidden" is not exported'
-    );
-    expect(diagnostics[0]?.message).toContain('owner export follow-up');
+      expect(
+        checkFixture(fixture, {
+          filePath: fixture.appImporterPath,
+          kind: 'typescript',
+          sourceCode,
+        })
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
   });
 
-  test('flags cross-package imports into non-exported internal subpaths', () => {
-    const diagnostics = check(
-      "import { openWriteTrailsDb } from '@ontrails/core/internal/trails-db';\n"
-    );
+  test('flags cross-package code subpaths blocked by the export map', () => {
+    const fixture = createFixture();
+    try {
+      const sourceCode =
+        "import { secret } from '@ontrails/core/internal/secret';\n";
+      writeSource(fixture.appImporterPath, sourceCode);
+      const diagnostics = checkFixture(fixture, {
+        filePath: fixture.appImporterPath,
+        kind: 'typescript',
+        sourceCode,
+      });
 
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.message).toContain(
-      '@ontrails/core/internal/trails-db'
-    );
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain(
+        '@ontrails/core/internal/secret'
+      );
+      expect(diagnostics[0]?.message).toContain('owner export follow-up');
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
   });
 
-  test('checks publishable app workspaces from the root workspace map', () => {
-    const diagnostics = check(
-      "import { hidden } from '@ontrails/trails/src/internal/hidden';\n"
-    );
+  test('flags type import and require subpaths blocked by the export map', () => {
+    const fixture = createFixture();
+    try {
+      const sourceCode = `
+        type Secret = import('@ontrails/core/internal/secret').Secret;
+        const secret = require('@ontrails/core/internal/secret');
+      `;
+      writeSource(fixture.appImporterPath, sourceCode);
+      const diagnostics = checkFixture(fixture, {
+        filePath: fixture.appImporterPath,
+        kind: 'typescript',
+        sourceCode: sourceCode.trimStart(),
+      });
 
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.message).toContain('@ontrails/trails');
+      expect(diagnostics).toHaveLength(2);
+      expect(diagnostics.map((diagnostic) => diagnostic.line)).toEqual([1, 2]);
+      expect(
+        diagnostics.every((diagnostic) =>
+          diagnostic.message.includes('@ontrails/core/internal/secret')
+        )
+      ).toBe(true);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
   });
 
-  test('allows local private imports inside publishable app workspaces', () => {
-    const diagnostics = check(
-      "import { hidden } from '@ontrails/trails/src/internal/hidden';\n",
-      APP_FILE
-    );
+  test('allows package-local private package imports in code', () => {
+    const fixture = createFixture();
+    try {
+      const sourceCode =
+        "import { secret } from '@ontrails/core/internal/secret';\n";
+      writeSource(fixture.coreImporterPath, sourceCode);
 
-    expect(diagnostics).toEqual([]);
+      expect(
+        checkFixture(fixture, {
+          filePath: fixture.coreImporterPath,
+          kind: 'typescript',
+          sourceCode,
+        })
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
   });
 
-  test('flags non-exported children below public subpaths', () => {
-    const diagnostics = check(
-      "import { deriveTrail } from '@ontrails/core/trails/derive-trail';\n"
-    );
+  test('flags documentation subpaths that are not public exports', () => {
+    const fixture = createFixture();
+    try {
+      const sourceCode =
+        'Use `@ontrails/core/internal/secret` only if it is public.\\n';
+      writeSource(fixture.readmePath, sourceCode);
+      const diagnostics = checkFixture(fixture, {
+        filePath: fixture.readmePath,
+        kind: 'documentation',
+        sourceCode,
+      });
 
-    expect(diagnostics).toHaveLength(1);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.line).toBe(1);
+      expect(diagnostics[0]?.message).toContain(
+        '@ontrails/core/internal/secret'
+      );
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
   });
 
-  test('checks export-from declarations and dynamic imports', () => {
-    const diagnostics = check(`
-export { hidden } from '@ontrails/core/src/internal/hidden';
-const hidden = await import('@ontrails/permits/src/internal/hidden');
-type Hidden = import('@ontrails/tracing/src/internal/hidden').Hidden;
-`);
+  test('allows documentation ignores for intentional legacy migration examples', () => {
+    const fixture = createFixture();
+    try {
+      const sourceCode = `
+<!-- warden-ignore-next-line -->
+- Before: \`import { x } from '@ontrails/core/internal/secret'\`
+`;
+      writeSource(fixture.readmePath, sourceCode);
 
-    expect(diagnostics).toHaveLength(3);
-    expect(diagnostics.map((diagnostic) => diagnostic.line)).toEqual([2, 3, 4]);
+      expect(
+        checkFixture(fixture, {
+          filePath: fixture.readmePath,
+          kind: 'documentation',
+          sourceCode: sourceCode.trimStart(),
+        })
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
   });
 
-  test('ignores relative imports and unknown external @ontrails packages', () => {
-    const diagnostics = check(
-      "import { helper } from './internal/helper.js';\nimport { x } from '@ontrails/with-example/internal/x';\n",
-      APP_FILE
-    );
+  test('flags root barrel re-exports from package internals', () => {
+    const fixture = createFixture();
+    try {
+      const indexPath = join(fixture.coreRoot, 'src', 'index.ts');
+      const sourceCode = "export { secret } from './internal/secret.js';\n";
+      writeSource(indexPath, sourceCode);
+      const diagnostics = checkFixture(fixture, {
+        filePath: indexPath,
+        kind: 'typescript',
+        sourceCode,
+      });
 
-    expect(diagnostics).toEqual([]);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('root barrel re-exports');
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('uses the resolved root export target for root barrel checks', () => {
+    const fixture = createFixture();
+    try {
+      const mainPath = join(fixture.coreRoot, 'src', 'main.ts');
+      const sourceCode = "export { secret } from './internal/secret.js';\n";
+      writeJson(join(fixture.coreRoot, 'package.json'), {
+        exports: { '.': './src/main.ts' },
+        name: '@ontrails/core',
+        type: 'module',
+      });
+      writeSource(mainPath, sourceCode);
+
+      const diagnostics = checkFixture(fixture, {
+        filePath: mainPath,
+        kind: 'typescript',
+        sourceCode,
+      });
+
+      expect(diagnostics[0]?.message).toContain('root barrel re-exports');
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('allows root barrel re-export ignores for intentional package seams', () => {
+    const fixture = createFixture();
+    try {
+      const indexPath = join(fixture.coreRoot, 'src', 'index.ts');
+      const sourceCode = `
+// warden-ignore-next-line
+export { secret } from './internal/secret.js';
+`;
+      writeSource(indexPath, sourceCode);
+
+      expect(
+        checkFixture(fixture, {
+          filePath: indexPath,
+          kind: 'typescript',
+          sourceCode: sourceCode.trimStart(),
+        })
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('accepts bin-only public app packages with included bin targets', () => {
+    const fixture = createFixture();
+    try {
+      const sourceCode = readFileSync(fixture.trailsPackageJsonPath, 'utf8');
+      expect(
+        checkFixture(fixture, {
+          filePath: fixture.trailsPackageJsonPath,
+          kind: 'text',
+          sourceCode,
+        })
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('accepts files lists that cover bin target directories by name', () => {
+    const fixture = createFixture();
+    try {
+      mkdirSync(join(fixture.trailsRoot, 'bin', 'sub'), { recursive: true });
+      writeSource(
+        join(fixture.trailsRoot, 'bin', 'sub', 'trails.ts'),
+        'export {};\n'
+      );
+      writeJson(fixture.trailsPackageJsonPath, {
+        bin: { trails: './bin/sub/trails.ts' },
+        files: ['bin', 'README.md'],
+        name: '@ontrails/trails',
+        type: 'module',
+      });
+      const sourceCode = readFileSync(fixture.trailsPackageJsonPath, 'utf8');
+
+      expect(
+        checkFixture(fixture, {
+          filePath: fixture.trailsPackageJsonPath,
+          kind: 'text',
+          sourceCode,
+        })
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('accepts files lists that cover bin targets with single-star wildcards', () => {
+    const fixture = createFixture();
+    try {
+      writeJson(fixture.trailsPackageJsonPath, {
+        bin: { trails: './bin/trails.ts' },
+        files: ['bin/*.ts', 'README.md'],
+        name: '@ontrails/trails',
+        type: 'module',
+      });
+      const sourceCode = readFileSync(fixture.trailsPackageJsonPath, 'utf8');
+
+      expect(
+        checkFixture(fixture, {
+          filePath: fixture.trailsPackageJsonPath,
+          kind: 'text',
+          sourceCode,
+        })
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('accepts files lists that cover nested bin targets with deep segment wildcards', () => {
+    const fixture = createFixture();
+    try {
+      mkdirSync(join(fixture.trailsRoot, 'bin', 'sub'), { recursive: true });
+      writeSource(
+        join(fixture.trailsRoot, 'bin', 'sub', 'trails.ts'),
+        'export {};\n'
+      );
+      writeJson(fixture.trailsPackageJsonPath, {
+        bin: { trails: './bin/sub/trails.ts' },
+        files: ['**/*.ts', 'README.md'],
+        name: '@ontrails/trails',
+        type: 'module',
+      });
+      const sourceCode = readFileSync(fixture.trailsPackageJsonPath, 'utf8');
+
+      expect(
+        checkFixture(fixture, {
+          filePath: fixture.trailsPackageJsonPath,
+          kind: 'text',
+          sourceCode,
+        })
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('flags files lists when deep wildcard concrete filenames do not match', () => {
+    const fixture = createFixture();
+    try {
+      mkdirSync(join(fixture.trailsRoot, 'bin', 'sub'), { recursive: true });
+      writeSource(
+        join(fixture.trailsRoot, 'bin', 'sub', 'entrails.ts'),
+        'export {};\n'
+      );
+      writeJson(fixture.trailsPackageJsonPath, {
+        bin: { trails: './bin/sub/entrails.ts' },
+        files: ['bin/**/trails.ts', 'README.md'],
+        name: '@ontrails/trails',
+        type: 'module',
+      });
+      const sourceCode = readFileSync(fixture.trailsPackageJsonPath, 'utf8');
+
+      expect(
+        checkFixture(fixture, {
+          filePath: fixture.trailsPackageJsonPath,
+          kind: 'text',
+          sourceCode,
+        })
+      ).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'the package files list does not include that target'
+          ),
+        }),
+      ]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('flags files lists when negation patterns exclude bin targets', () => {
+    const fixture = createFixture();
+    try {
+      writeSource(join(fixture.trailsRoot, 'bin', 'cli.ts'), 'export {};\n');
+      writeJson(fixture.trailsPackageJsonPath, {
+        bin: { trails: './bin/cli.ts' },
+        files: ['**/*.ts', '!bin/cli.ts', 'README.md'],
+        name: '@ontrails/trails',
+        type: 'module',
+      });
+      const sourceCode = readFileSync(fixture.trailsPackageJsonPath, 'utf8');
+
+      expect(
+        checkFixture(fixture, {
+          filePath: fixture.trailsPackageJsonPath,
+          kind: 'text',
+          sourceCode,
+        })
+      ).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'the package files list does not include that target'
+          ),
+        }),
+      ]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('accepts files lists that cover nested bin targets with trailing double-star wildcards', () => {
+    const fixture = createFixture();
+    try {
+      mkdirSync(join(fixture.trailsRoot, 'bin', 'sub'), { recursive: true });
+      writeSource(
+        join(fixture.trailsRoot, 'bin', 'sub', 'trails.ts'),
+        'export {};\n'
+      );
+      writeJson(fixture.trailsPackageJsonPath, {
+        bin: { trails: './bin/sub/trails.ts' },
+        files: ['bin/**', 'README.md'],
+        name: '@ontrails/trails',
+        type: 'module',
+      });
+      const sourceCode = readFileSync(fixture.trailsPackageJsonPath, 'utf8');
+
+      expect(
+        checkFixture(fixture, {
+          filePath: fixture.trailsPackageJsonPath,
+          kind: 'text',
+          sourceCode,
+        })
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
   });
 });

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -23,7 +23,11 @@ import { resolveWardenConfig } from './config.js';
 import { isDraftMarkedFile } from './draft.js';
 import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
-import { collectProjectImportResolutions } from './project-context.js';
+import {
+  collectProjectDocumentationImportResolutions,
+  collectProjectImportResolutions,
+  collectPublicWorkspaces,
+} from './project-context.js';
 import {
   collectContourDefinitionIds,
   collectContourReferenceTargetsByName,
@@ -243,9 +247,43 @@ const collectTextScanFiles = (dir: string): readonly string[] => [
   ...collectFilesMatching(dir, '**/package.json', true),
 ];
 
+const isDocumentationScanTarget = (match: string): boolean => {
+  if (match === 'README.md') {
+    return true;
+  }
+  if (/^(?:packages|adapters|apps)\/[^/]+\/README\.md$/.test(match)) {
+    return true;
+  }
+  return (
+    match.startsWith('docs/') &&
+    !match.startsWith('docs/adr/') &&
+    !match.startsWith('docs/migration/') &&
+    !match.startsWith('docs/releases/') &&
+    match.endsWith('.md')
+  );
+};
+
+const collectDocumentationFiles = (dir: string): readonly string[] => {
+  const glob = new Bun.Glob('**/*.md');
+  let matches: IterableIterator<string>;
+  try {
+    matches = glob.scanSync({ cwd: dir, onlyFiles: true });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const match of matches) {
+    if (isAllowedScanTarget(match) && isDocumentationScanTarget(match)) {
+      files.push(`${dir}/${match}`);
+    }
+  }
+  return files;
+};
+
 interface SourceFile {
   readonly filePath: string;
-  readonly kind: 'text' | 'typescript';
+  readonly kind: 'documentation' | 'text' | 'typescript';
   readonly sourceCode: string;
 }
 
@@ -259,7 +297,12 @@ interface MutableProjectContext {
   knownSignalIds: Set<string>;
   knownTrailIds: Set<string>;
   importResolutionsByFile: Map<string, readonly WardenImportResolution[]>;
+  documentedImportResolutionsByFile: Map<
+    string,
+    readonly WardenImportResolution[]
+  >;
   onTargetSignalIds: Set<string>;
+  publicWorkspaces: ReturnType<typeof collectPublicWorkspaces>;
   reconcileTableIds: Set<string>;
   trailIntentsById: Map<string, 'destroy' | 'read' | 'write'>;
 }
@@ -269,12 +312,17 @@ const createMutableProjectContext = (): MutableProjectContext => ({
   crossTargetTrailIds: new Set<string>(),
   crudCoverageByEntity: new Map<string, Set<string>>(),
   crudTableIds: new Set<string>(),
+  documentedImportResolutionsByFile: new Map<
+    string,
+    readonly WardenImportResolution[]
+  >(),
   importResolutionsByFile: new Map<string, readonly WardenImportResolution[]>(),
   knownContourIds: new Set<string>(),
   knownResourceIds: new Set<string>(),
   knownSignalIds: new Set<string>(),
   knownTrailIds: new Set<string>(),
   onTargetSignalIds: new Set<string>(),
+  publicWorkspaces: new Map(),
   reconcileTableIds: new Set<string>(),
   trailIntentsById: new Map<string, 'destroy' | 'read' | 'write'>(),
 });
@@ -328,8 +376,17 @@ const toProjectContext = (context: MutableProjectContext): ProjectContext => ({
   ...(context.importResolutionsByFile.size > 0
     ? { importResolutionsByFile: context.importResolutionsByFile }
     : {}),
+  ...(context.documentedImportResolutionsByFile.size > 0
+    ? {
+        documentedImportResolutionsByFile:
+          context.documentedImportResolutionsByFile,
+      }
+    : {}),
   ...(context.onTargetSignalIds.size > 0
     ? { onTargetSignalIds: context.onTargetSignalIds }
+    : {}),
+  ...(context.publicWorkspaces.size > 0
+    ? { publicWorkspaces: context.publicWorkspaces }
     : {}),
   ...(context.reconcileTableIds.size > 0
     ? { reconcileTableIds: context.reconcileTableIds }
@@ -506,6 +563,18 @@ const loadSourceFiles = async (
       sourceFiles.push({
         filePath,
         kind: 'text',
+        sourceCode: await Bun.file(filePath).text(),
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  for (const filePath of collectDocumentationFiles(rootDir)) {
+    try {
+      sourceFiles.push({
+        filePath,
+        kind: 'documentation',
         sourceCode: await Bun.file(filePath).text(),
       });
     } catch {
@@ -692,6 +761,20 @@ const collectFileImportResolutions = (
   }
 };
 
+const collectFileDocumentedImportResolutions = (
+  rootDir: string,
+  sourceFiles: readonly SourceFile[],
+  context: MutableProjectContext
+): void => {
+  const resolutionsByFile = collectProjectDocumentationImportResolutions({
+    rootDir,
+    sourceFiles,
+  });
+  for (const [filePath, resolutions] of resolutionsByFile) {
+    context.documentedImportResolutionsByFile.set(filePath, resolutions);
+  }
+};
+
 const buildProjectContext = (
   sourceFiles: readonly SourceFile[],
   rootDir: string,
@@ -701,6 +784,10 @@ const buildProjectContext = (
   const typeScriptSourceFiles = sourceFiles.filter(
     (sourceFile) => sourceFile.kind === 'typescript'
   );
+  const documentationSourceFiles = sourceFiles.filter(
+    (sourceFile) => sourceFile.kind === 'documentation'
+  );
+  context.publicWorkspaces = collectPublicWorkspaces(rootDir);
 
   if (appTopos.length > 0) {
     for (const appTopo of appTopos) {
@@ -719,6 +806,11 @@ const buildProjectContext = (
     collectFileContourReferences(sourceFile, context);
   }
   collectFileImportResolutions(rootDir, typeScriptSourceFiles, context);
+  collectFileDocumentedImportResolutions(
+    rootDir,
+    documentationSourceFiles,
+    context
+  );
 
   return toProjectContext(context);
 };
@@ -876,7 +968,15 @@ const lintSourceFiles = (
     for (const rule of wardenRules.values()) {
       if (
         sourceFile.kind === 'text' &&
-        rule.name !== 'no-dev-permit-in-source'
+        rule.name !== 'no-dev-permit-in-source' &&
+        rule.name !== 'public-internal-deep-imports'
+      ) {
+        continue;
+      }
+
+      if (
+        sourceFile.kind === 'documentation' &&
+        rule.name !== 'public-internal-deep-imports'
       ) {
         continue;
       }

--- a/packages/warden/src/project-context.ts
+++ b/packages/warden/src/project-context.ts
@@ -15,6 +15,12 @@ import type {
   WardenImportResolution,
   WardenResolverOptions,
 } from './resolve.js';
+import { offsetToLine } from './rules/ast.js';
+import { collectPublicWorkspaces } from './workspaces.js';
+import type { WardenPublicWorkspace } from './workspaces.js';
+
+const ONTRAILS_DOCUMENTATION_SPECIFIER_PATTERN =
+  /@ontrails\/[a-z0-9-]+(?:\/[A-Za-z0-9._~-]+)+/g;
 
 const normalizeRealPath = (path: string): string => {
   try {
@@ -39,9 +45,41 @@ const setResolutionsForFile = (
 
 export interface WardenProjectContextSourceFile {
   readonly filePath: string;
-  readonly kind: 'text' | 'typescript';
+  readonly kind: 'documentation' | 'text' | 'typescript';
   readonly sourceCode: string;
 }
+
+const collectDocumentationImportSpecifiers = (
+  sourceCode: string
+): readonly { readonly importSource: string; readonly line: number }[] => {
+  const specifiers: { importSource: string; line: number }[] = [];
+  for (const match of sourceCode.matchAll(
+    ONTRAILS_DOCUMENTATION_SPECIFIER_PATTERN
+  )) {
+    if (match.index === undefined) {
+      continue;
+    }
+    specifiers.push({
+      importSource: match[0],
+      line: offsetToLine(sourceCode, match.index),
+    });
+  }
+  return specifiers;
+};
+
+const exportAliasesForWorkspaces = (
+  workspaces: ReadonlyMap<string, WardenPublicWorkspace>
+): Record<string, string[]> => {
+  const aliases: Record<string, string[]> = {};
+  for (const workspace of workspaces.values()) {
+    for (const [specifier, target] of Object.entries(
+      workspace.exportTargets ?? {}
+    )) {
+      aliases[`${specifier}$`] = [target];
+    }
+  }
+  return aliases;
+};
 
 export const collectProjectImportResolutions = ({
   resolveOptions,
@@ -78,3 +116,48 @@ export const collectProjectImportResolutions = ({
 
   return resolutionsByFile;
 };
+
+export const collectProjectDocumentationImportResolutions = ({
+  rootDir,
+  sourceFiles,
+}: {
+  readonly rootDir: string;
+  readonly sourceFiles: readonly WardenProjectContextSourceFile[];
+}): ReadonlyMap<string, readonly WardenImportResolution[]> => {
+  const publicWorkspaces = collectPublicWorkspaces(rootDir);
+  const resolver = createWardenResolver({
+    resolveOptions: { alias: exportAliasesForWorkspaces(publicWorkspaces) },
+    rootDir,
+  });
+  const resolutionsByFile = new Map<
+    string,
+    readonly WardenImportResolution[]
+  >();
+
+  for (const sourceFile of sourceFiles) {
+    if (sourceFile.kind !== 'documentation') {
+      continue;
+    }
+    const resolutions = collectDocumentationImportSpecifiers(
+      sourceFile.sourceCode
+    ).map((specifier) =>
+      resolver.resolveImport(
+        sourceFile.filePath,
+        specifier.importSource,
+        specifier.line
+      )
+    );
+    if (resolutions.length > 0) {
+      setResolutionsForFile(
+        resolutionsByFile,
+        sourceFile.filePath,
+        resolutions
+      );
+    }
+  }
+
+  return resolutionsByFile;
+};
+
+export { collectPublicWorkspaces };
+export type { WardenPublicWorkspace } from './workspaces.js';

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -332,7 +332,10 @@ export const collectFrameworkDraftPrefixConstantOffsets = (
   return offsets;
 };
 
-const WARDEN_IGNORE_NEXT_LINE_PRAGMA = '// warden-ignore-next-line';
+const WARDEN_IGNORE_NEXT_LINE_PRAGMAS = new Set([
+  '// warden-ignore-next-line',
+  '<!-- warden-ignore-next-line -->',
+]);
 
 /**
  * Split source code into lines for pragma lookups. Callers should split once
@@ -345,7 +348,7 @@ export const splitSourceLines = (sourceCode: string): readonly string[] =>
 
 /**
  * Check whether the line immediately preceding `line` contains a
- * `// warden-ignore-next-line` pragma (leading/trailing whitespace tolerated).
+ * `warden-ignore-next-line` pragma (leading/trailing whitespace tolerated).
  * Pragma scope is strictly one line — an intervening blank line breaks it.
  *
  * Takes a pre-split `lines` array so callers can split the source once per
@@ -370,7 +373,7 @@ export const hasIgnoreCommentOnLine = (
     return false;
   }
 
-  return previous.trim() === WARDEN_IGNORE_NEXT_LINE_PRAGMA;
+  return WARDEN_IGNORE_NEXT_LINE_PRAGMAS.has(previous.trim());
 };
 
 export const findStringLiterals = (

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -272,7 +272,7 @@ const builtinWardenRuleMetadataInput = {
     invariant: 'Cross-package imports stay on package-owned public exports.',
     lifecycle: { state: 'durable' },
     scope: 'internal',
-    tier: 'source-static',
+    tier: 'project-static',
   },
   'public-union-output-discriminants': {
     ...durableExternal,

--- a/packages/warden/src/rules/public-internal-deep-imports.ts
+++ b/packages/warden/src/rules/public-internal-deep-imports.ts
@@ -1,297 +1,60 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join, resolve, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { existsSync, realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
 
 import {
   extractStringLiteral,
-  identifierName,
+  hasIgnoreCommentOnLine,
   offsetToLine,
   parse,
+  splitSourceLines,
   walk,
 } from './ast.js';
 import type { AstNode } from './ast.js';
-import type { WardenDiagnostic, WardenRule } from './types.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+import type { WardenImportResolution } from '../resolve.js';
+import type { WardenPublicWorkspace } from '../workspaces.js';
 
 const RULE_NAME = 'public-internal-deep-imports';
-const WORKSPACE_ROOT = resolve(
-  fileURLToPath(new URL('../../../../', import.meta.url))
-);
 const ONTRAILS_SPECIFIER_PATTERN = /^(@ontrails\/[^/]+)(?:\/(.+))?$/;
+const ROOT_BARREL_INTERNAL_RE_EXPORT_ALLOWLIST = new Set([
+  '@ontrails/core:./internal/cross-batch.js',
+  '@ontrails/core:./internal/layer-projection.js',
+  '@ontrails/core:./internal/signal-ref.js',
+  '@ontrails/core:./internal/tracing.js',
+  '@ontrails/core:./internal/trails-db.js',
+  '@ontrails/core:./internal/zod-wrappers.js',
+  '@ontrails/store:./internal/signal-identity.js',
+  '@ontrails/topographer:./internal/topo-snapshots.js',
+  '@ontrails/topographer:./internal/topo-store.js',
+  '@ontrails/tracing:./internal/dev-state.js',
+]);
 
-interface ExportPattern {
-  readonly prefix: string;
-  readonly suffix: string;
+interface ReExportSite {
+  readonly importSource: string;
+  readonly line: number;
 }
 
-interface WorkspacePackage {
-  readonly exportedSpecifiers: ReadonlySet<string>;
-  readonly name: string;
-  readonly patterns: readonly ExportPattern[];
-  readonly rootDir: string;
-}
+const normalizePath = (path: string): string => path.replaceAll('\\', '/');
 
-interface PackageManifest {
-  readonly exports?: unknown;
-  readonly name?: unknown;
-  readonly workspaces?: unknown;
-}
-
-interface ImportSite {
-  readonly node: AstNode;
-  readonly specifier: string;
-}
-
-/**
- * Workspace package metadata is stable during a normal Warden run, so cache it
- * once per process instead of re-reading every package manifest for each file.
- *
- * Long-running callers that mutate manifests or workspace layout between runs
- * should call `clearPublicInternalDeepImportsCache()` before checking again.
- */
-let workspacePackagesCache: ReadonlyMap<string, WorkspacePackage> | undefined;
-
-export const clearPublicInternalDeepImportsCache = (): void => {
-  workspacePackagesCache = undefined;
-};
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  Boolean(value && typeof value === 'object' && !Array.isArray(value));
-
-const readPackageManifest = (
-  packageDir: string
-): PackageManifest | undefined => {
-  const manifestPath = join(packageDir, 'package.json');
-  if (!existsSync(manifestPath)) {
-    return undefined;
-  }
-
+const normalizeRealPath = (path: string): string => {
   try {
-    return JSON.parse(readFileSync(manifestPath, 'utf8')) as PackageManifest;
+    return normalizePath(realpathSync(path));
   } catch {
-    return undefined;
+    return normalizePath(resolve(path));
   }
-};
-
-const exportKeys = (exportsValue: unknown): readonly string[] => {
-  if (!isRecord(exportsValue)) {
-    return [];
-  }
-  return Object.keys(exportsValue).filter((key) => key.startsWith('.'));
-};
-
-const exportPatternFromKey = (
-  packageName: string,
-  key: string
-): ExportPattern | undefined => {
-  if (!key.includes('*')) {
-    return undefined;
-  }
-  const subpath = key.slice(2);
-  const [prefix = '', suffix = ''] = subpath.split('*');
-  return {
-    prefix: `${packageName}/${prefix}`,
-    suffix,
-  };
-};
-
-const exportedSpecifierFromKey = (
-  packageName: string,
-  key: string
-): string | undefined => {
-  if (key === '.') {
-    return packageName;
-  }
-  if (key.includes('*')) {
-    return undefined;
-  }
-  if (!key.startsWith('./')) {
-    return undefined;
-  }
-  return `${packageName}/${key.slice(2)}`;
-};
-
-const buildWorkspacePackage = (
-  packageDir: string,
-  manifest: PackageManifest
-): WorkspacePackage | undefined => {
-  if (typeof manifest.name !== 'string') {
-    return undefined;
-  }
-  if (!manifest.name.startsWith('@ontrails/')) {
-    return undefined;
-  }
-
-  const exportedSpecifiers = new Set<string>([manifest.name]);
-  const patterns: ExportPattern[] = [];
-  for (const key of exportKeys(manifest.exports)) {
-    const exactSpecifier = exportedSpecifierFromKey(manifest.name, key);
-    if (exactSpecifier) {
-      exportedSpecifiers.add(exactSpecifier);
-      continue;
-    }
-    const pattern = exportPatternFromKey(manifest.name, key);
-    if (pattern) {
-      patterns.push(pattern);
-    }
-  }
-
-  return {
-    exportedSpecifiers,
-    name: manifest.name,
-    patterns,
-    rootDir: resolve(packageDir),
-  };
-};
-
-const workspacePatterns = (): readonly string[] => {
-  const rootManifest = readPackageManifest(WORKSPACE_ROOT);
-  const { workspaces } = rootManifest ?? {};
-  if (Array.isArray(workspaces)) {
-    return workspaces.filter(
-      (pattern): pattern is string => typeof pattern === 'string'
-    );
-  }
-  const workspacePackages = isRecord(workspaces)
-    ? workspaces['packages']
-    : undefined;
-  if (Array.isArray(workspacePackages)) {
-    return workspacePackages.filter(
-      (pattern): pattern is string => typeof pattern === 'string'
-    );
-  }
-  return [];
-};
-
-const packageDirsForPattern = (pattern: string): readonly string[] => {
-  if (!pattern.endsWith('/*')) {
-    const packageDir = join(WORKSPACE_ROOT, pattern);
-    return existsSync(packageDir) ? [packageDir] : [];
-  }
-
-  const groupDir = join(WORKSPACE_ROOT, pattern.slice(0, -2));
-  if (!existsSync(groupDir)) {
-    return [];
-  }
-  return readdirSync(groupDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => join(groupDir, entry.name))
-    .toSorted();
-};
-
-const collectWorkspacePackages = (): ReadonlyMap<string, WorkspacePackage> => {
-  const workspacePackages = new Map<string, WorkspacePackage>();
-
-  for (const packageDir of workspacePatterns().flatMap(packageDirsForPattern)) {
-    const manifest = readPackageManifest(packageDir);
-    if (!manifest) {
-      continue;
-    }
-    const workspacePackage = buildWorkspacePackage(packageDir, manifest);
-    if (workspacePackage) {
-      workspacePackages.set(workspacePackage.name, workspacePackage);
-    }
-  }
-
-  return workspacePackages;
-};
-
-const getWorkspacePackages = (): ReadonlyMap<string, WorkspacePackage> => {
-  workspacePackagesCache ??= collectWorkspacePackages();
-  return workspacePackagesCache;
 };
 
 const pathIsInside = (filePath: string, rootDir: string): boolean => {
-  const absoluteFilePath = resolve(filePath);
-  const absoluteRootDir = resolve(rootDir);
+  const absoluteFilePath = normalizeRealPath(filePath);
+  const absoluteRootDir = normalizeRealPath(rootDir);
   return (
     absoluteFilePath === absoluteRootDir ||
-    absoluteFilePath.startsWith(`${absoluteRootDir}${sep}`)
+    absoluteFilePath.startsWith(`${absoluteRootDir}/`)
   );
-};
-
-const sourcePackageNameForFile = (
-  filePath: string,
-  workspacePackages: ReadonlyMap<string, WorkspacePackage>
-): string | undefined => {
-  for (const workspacePackage of workspacePackages.values()) {
-    if (pathIsInside(filePath, workspacePackage.rootDir)) {
-      return workspacePackage.name;
-    }
-  }
-  return undefined;
-};
-
-const matchesExportPattern = (
-  specifier: string,
-  pattern: ExportPattern
-): boolean => {
-  if (!specifier.startsWith(pattern.prefix)) {
-    return false;
-  }
-  if (!specifier.endsWith(pattern.suffix)) {
-    return false;
-  }
-
-  const wildcardEnd =
-    pattern.suffix.length === 0
-      ? specifier.length
-      : specifier.length - pattern.suffix.length;
-  const wildcardSegment = specifier.slice(pattern.prefix.length, wildcardEnd);
-  return wildcardSegment.length > 0 && !wildcardSegment.includes('/');
-};
-
-export const __matchesExportPatternForTest = (
-  specifier: string,
-  pattern: { readonly prefix: string; readonly suffix: string }
-): boolean => matchesExportPattern(specifier, pattern);
-
-const isExportedSpecifier = (
-  specifier: string,
-  workspacePackage: WorkspacePackage
-): boolean => {
-  if (workspacePackage.exportedSpecifiers.has(specifier)) {
-    return true;
-  }
-  return workspacePackage.patterns.some((pattern) =>
-    matchesExportPattern(specifier, pattern)
-  );
-};
-
-const sourceFromModuleNode = (node: AstNode): string | null => {
-  if (
-    node.type === 'ExportAllDeclaration' ||
-    node.type === 'ExportNamedDeclaration' ||
-    node.type === 'ImportDeclaration' ||
-    node.type === 'ImportExpression' ||
-    node.type === 'TSImportType'
-  ) {
-    return extractStringLiteral(
-      (node as unknown as { source?: AstNode }).source
-    );
-  }
-
-  if (node.type !== 'CallExpression') {
-    return null;
-  }
-  const { arguments: args, callee } = node as unknown as {
-    arguments?: readonly AstNode[];
-    callee?: AstNode;
-  };
-  if (identifierName(callee) !== 'require') {
-    return null;
-  }
-  return extractStringLiteral(args?.[0]);
-};
-
-const collectImportSites = (ast: AstNode): readonly ImportSite[] => {
-  const sites: ImportSite[] = [];
-  walk(ast, (node) => {
-    const specifier = sourceFromModuleNode(node);
-    if (specifier) {
-      sites.push({ node, specifier });
-    }
-  });
-  return sites;
 };
 
 const packageNameFromSpecifier = (specifier: string): string | undefined => {
@@ -299,68 +62,465 @@ const packageNameFromSpecifier = (specifier: string): string | undefined => {
   return match?.[1];
 };
 
-const diagnosticForSite = (
-  site: ImportSite,
-  filePath: string,
-  sourceCode: string,
-  sourcePackageName: string | undefined,
-  workspacePackages: ReadonlyMap<string, WorkspacePackage>
-): WardenDiagnostic | undefined => {
-  const packageName = packageNameFromSpecifier(site.specifier);
-  if (!packageName) {
-    return undefined;
-  }
-  const workspacePackage = workspacePackages.get(packageName);
-  if (!workspacePackage) {
-    return undefined;
-  }
-  if (sourcePackageName === packageName) {
-    return undefined;
-  }
-  if (isExportedSpecifier(site.specifier, workspacePackage)) {
-    return undefined;
-  }
+const specifierHasSubpath = (specifier: string): boolean =>
+  Boolean(ONTRAILS_SPECIFIER_PATTERN.exec(specifier)?.[2]);
 
-  return {
-    filePath,
-    line: offsetToLine(sourceCode, site.node.start),
-    message:
-      `${RULE_NAME}: cross-package import "${site.specifier}" is not exported by ${packageName}. ` +
-      'Use the package root or an exported subpath; if the API is missing, add an owner export follow-up instead of importing internals.',
-    rule: RULE_NAME,
-    severity: 'error',
-  };
+const sourcePackageNameForFile = (
+  filePath: string,
+  workspaces: ReadonlyMap<string, WardenPublicWorkspace>
+): string | undefined => {
+  for (const workspace of workspaces.values()) {
+    if (pathIsInside(filePath, workspace.rootDir)) {
+      return workspace.name;
+    }
+  }
+  return undefined;
 };
 
-export const publicInternalDeepImports: WardenRule = {
-  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
-    const ast = parse(filePath, sourceCode);
-    if (!ast) {
-      return [];
+const importResolutionsForFile = (
+  context: ProjectContext,
+  filePath: string
+): readonly WardenImportResolution[] =>
+  context.importResolutionsByFile?.get(filePath) ?? [];
+
+const documentedImportResolutionsForFile = (
+  context: ProjectContext,
+  filePath: string
+): readonly WardenImportResolution[] =>
+  context.documentedImportResolutionsByFile?.get(filePath) ?? [];
+
+const diagnosticMessage = (
+  resolution: WardenImportResolution,
+  packageName: string
+): string => {
+  if (resolution.errorKind === 'not-found') {
+    return `@ontrails specifier "${resolution.importSource}" could not be resolved from the public workspace package ${packageName}. Use the package root, an exported subpath, or the package binary when the package is bin-only.`;
+  }
+
+  return (
+    `@ontrails specifier "${resolution.importSource}" is not exported by ${packageName}. ` +
+    'Use the package root or an exported subpath; if the API is missing, add an owner export follow-up instead of importing internals.'
+  );
+};
+
+const shouldReportResolution = (
+  resolution: WardenImportResolution,
+  workspace: WardenPublicWorkspace,
+  sourcePackageName: string | undefined,
+  isDocumentation: boolean
+): boolean => {
+  if (!isDocumentation && sourcePackageName === workspace.name) {
+    return false;
+  }
+
+  if (resolution.errorKind === 'package-path-not-exported') {
+    return true;
+  }
+
+  if (resolution.errorKind === 'not-found') {
+    return isDocumentation
+      ? specifierHasSubpath(resolution.importSource)
+      : resolution.importSource === workspace.name ||
+          specifierHasSubpath(resolution.importSource);
+  }
+
+  if (isDocumentation && specifierHasSubpath(resolution.importSource)) {
+    return !resolution.usesPublicExport;
+  }
+
+  return false;
+};
+
+const diagnosticsForResolutions = ({
+  context,
+  filePath,
+  isDocumentation,
+  sourceCode,
+}: {
+  readonly context: ProjectContext;
+  readonly filePath: string;
+  readonly isDocumentation: boolean;
+  readonly sourceCode: string;
+}): readonly WardenDiagnostic[] => {
+  const workspaces = context.publicWorkspaces;
+  if (!workspaces || workspaces.size === 0) {
+    return [];
+  }
+
+  const sourcePackageName = sourcePackageNameForFile(filePath, workspaces);
+  const lines = splitSourceLines(sourceCode);
+  const resolutions = isDocumentation
+    ? documentedImportResolutionsForFile(context, filePath)
+    : importResolutionsForFile(context, filePath);
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const resolution of resolutions) {
+    if (hasIgnoreCommentOnLine(lines, resolution.line)) {
+      continue;
     }
 
-    const workspacePackages = getWorkspacePackages();
-    if (workspacePackages.size === 0) {
-      return [];
+    const packageName =
+      resolution.packageName ??
+      packageNameFromSpecifier(resolution.importSource);
+    const workspace = packageName ? workspaces.get(packageName) : undefined;
+    if (!packageName || !workspace) {
+      continue;
     }
 
-    const sourcePackageName = sourcePackageNameForFile(
-      filePath,
-      workspacePackages
-    );
-    return collectImportSites(ast).flatMap((site) => {
-      const diagnostic = diagnosticForSite(
-        site,
-        filePath,
-        sourceCode,
+    if (
+      shouldReportResolution(
+        resolution,
+        workspace,
         sourcePackageName,
-        workspacePackages
-      );
-      return diagnostic ? [diagnostic] : [];
+        isDocumentation
+      )
+    ) {
+      diagnostics.push({
+        filePath,
+        line: resolution.line,
+        message: diagnosticMessage(resolution, packageName),
+        rule: RULE_NAME,
+        severity: 'error',
+      });
+    }
+  }
+
+  return diagnostics;
+};
+
+const isRootBarrel = (
+  filePath: string,
+  workspace: WardenPublicWorkspace
+): boolean => {
+  const rootExportTarget = workspace.exportTargets?.[workspace.name];
+  if (rootExportTarget) {
+    return normalizeRealPath(filePath) === rootExportTarget;
+  }
+  return (
+    normalizeRealPath(filePath) ===
+    normalizeRealPath(resolve(workspace.rootDir, 'src/index.ts'))
+  );
+};
+
+const rootBarrelWorkspace = (
+  filePath: string,
+  workspaces: ReadonlyMap<string, WardenPublicWorkspace>
+): WardenPublicWorkspace | undefined => {
+  for (const workspace of workspaces.values()) {
+    if (isRootBarrel(filePath, workspace)) {
+      return workspace;
+    }
+  }
+  return undefined;
+};
+
+const collectReExportSites = (
+  sourceCode: string,
+  filePath: string
+): readonly ReExportSite[] => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  const sites: ReExportSite[] = [];
+  walk(ast, (node) => {
+    if (
+      node.type !== 'ExportNamedDeclaration' &&
+      node.type !== 'ExportAllDeclaration'
+    ) {
+      return;
+    }
+
+    const { source } = node as unknown as { source?: AstNode };
+    const value = extractStringLiteral(source);
+    if (typeof value !== 'string') {
+      return;
+    }
+
+    sites.push({
+      importSource: value,
+      line: offsetToLine(sourceCode, node.start),
     });
+  });
+  return sites;
+};
+
+const reExportResolution = (
+  resolutions: readonly WardenImportResolution[],
+  site: ReExportSite
+): WardenImportResolution | undefined =>
+  resolutions.find(
+    (resolution) =>
+      resolution.importSource === site.importSource &&
+      resolution.line === site.line
+  );
+
+const isAllowlistedRootBarrelInternalExport = (
+  workspace: WardenPublicWorkspace,
+  importSource: string
+): boolean =>
+  ROOT_BARREL_INTERNAL_RE_EXPORT_ALLOWLIST.has(
+    `${workspace.name}:${importSource}`
+  );
+
+const rootBarrelDiagnostics = (
+  sourceCode: string,
+  filePath: string,
+  context: ProjectContext
+): readonly WardenDiagnostic[] => {
+  const workspaces = context.publicWorkspaces;
+  if (!workspaces || workspaces.size === 0) {
+    return [];
+  }
+
+  const workspace = rootBarrelWorkspace(filePath, workspaces);
+  if (!workspace) {
+    return [];
+  }
+
+  const resolutions = importResolutionsForFile(context, filePath);
+  const lines = splitSourceLines(sourceCode);
+  const diagnostics: WardenDiagnostic[] = [];
+  for (const site of collectReExportSites(sourceCode, filePath)) {
+    if (isAllowlistedRootBarrelInternalExport(workspace, site.importSource)) {
+      continue;
+    }
+    if (hasIgnoreCommentOnLine(lines, site.line)) {
+      continue;
+    }
+
+    const resolution = reExportResolution(resolutions, site);
+    if (!resolution?.isInternalTarget) {
+      continue;
+    }
+
+    diagnostics.push({
+      filePath,
+      line: site.line,
+      message:
+        `${workspace.name} root barrel re-exports internal target "${site.importSource}". ` +
+        'Move the symbol behind an explicit public module or keep it private to the package.',
+      rule: RULE_NAME,
+      severity: 'error',
+    });
+  }
+
+  return diagnostics;
+};
+
+const stripLeadingDotSlash = (path: string): string =>
+  path.startsWith('./') ? path.slice(2) : path;
+
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const wildcardPatternSource = (pattern: string): string => {
+  let regexSource = '';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === '*') {
+      if (pattern[index + 1] === '*') {
+        regexSource += '.*';
+        index += 1;
+      } else {
+        regexSource += '[^/]*';
+      }
+      continue;
+    }
+    regexSource += escapeRegExp(char ?? '');
+  }
+  return regexSource;
+};
+
+const segmentWildcardPatternCovers = (
+  filePath: string,
+  pattern: string
+): boolean => new RegExp(`^${wildcardPatternSource(pattern)}$`).test(filePath);
+
+const deepWildcardPatternCovers = (
+  filePath: string,
+  pattern: string,
+  globIndex: number
+): boolean => {
+  const prefix = pattern.slice(0, globIndex + 1);
+  if (!filePath.startsWith(prefix)) {
+    return false;
+  }
+  const suffixPattern = pattern.slice(globIndex + '/**/'.length);
+  if (suffixPattern.length === 0) {
+    return true;
+  }
+  const remainingPath = filePath.slice(prefix.length);
+  const regexSource = `^(?:.*/)?${wildcardPatternSource(suffixPattern)}$`;
+  return new RegExp(regexSource).test(remainingPath);
+};
+
+const filePatternCovers = (filePath: string, pattern: string): boolean => {
+  const normalizedFilePath = normalizePath(stripLeadingDotSlash(filePath));
+  const normalizedPattern = normalizePath(stripLeadingDotSlash(pattern));
+  if (normalizedPattern.startsWith('!')) {
+    return false;
+  }
+  if (normalizedPattern === normalizedFilePath) {
+    return true;
+  }
+  if (normalizedPattern === '**') {
+    return true;
+  }
+  if (normalizedPattern.endsWith('/**')) {
+    const prefix = normalizedPattern.slice(0, -2);
+    return normalizedFilePath.startsWith(prefix);
+  }
+
+  const globIndex = normalizedPattern.indexOf('/**/');
+  if (globIndex === -1) {
+    if (normalizedPattern.includes('*')) {
+      return segmentWildcardPatternCovers(
+        normalizedFilePath,
+        normalizedPattern
+      );
+    }
+    return normalizedFilePath.startsWith(`${normalizedPattern}/`);
+  }
+
+  return deepWildcardPatternCovers(
+    normalizedFilePath,
+    normalizedPattern,
+    globIndex
+  );
+};
+
+const filesCoverTarget = (
+  files: readonly string[] | undefined,
+  target: string
+): boolean => {
+  if (!files || files.length === 0) {
+    return true;
+  }
+  let covered = false;
+  for (const pattern of files) {
+    const normalizedPattern = normalizePath(stripLeadingDotSlash(pattern));
+    if (normalizedPattern.startsWith('!')) {
+      if (filePatternCovers(target, normalizedPattern.slice(1))) {
+        covered = false;
+      }
+      continue;
+    }
+    if (filePatternCovers(target, normalizedPattern)) {
+      covered = true;
+    }
+  }
+  return covered;
+};
+
+const workspaceForPackageJson = (
+  filePath: string,
+  workspaces: ReadonlyMap<string, WardenPublicWorkspace>
+): WardenPublicWorkspace | undefined => {
+  const normalizedFilePath = normalizeRealPath(filePath);
+  for (const workspace of workspaces.values()) {
+    if (normalizePath(workspace.packageJsonPath) === normalizedFilePath) {
+      return workspace;
+    }
+  }
+  return undefined;
+};
+
+const binSurfaceDiagnostics = (
+  filePath: string,
+  context: ProjectContext
+): readonly WardenDiagnostic[] => {
+  if (
+    !filePath.endsWith(`${sep}package.json`) &&
+    !filePath.endsWith('/package.json')
+  ) {
+    return [];
+  }
+
+  const workspaces = context.publicWorkspaces;
+  if (!workspaces || workspaces.size === 0) {
+    return [];
+  }
+
+  const workspace = workspaceForPackageJson(filePath, workspaces);
+  if (!workspace) {
+    return [];
+  }
+
+  const diagnostics: WardenDiagnostic[] = [];
+  const binEntries = Object.entries(workspace.bin ?? {});
+  if (!workspace.hasExports && binEntries.length === 0) {
+    diagnostics.push({
+      filePath,
+      line: 1,
+      message:
+        `Public workspace ${workspace.name} has no exports map and no bin surface. ` +
+        'Add an exports map for library APIs or declare the package binary surface explicitly.',
+      rule: RULE_NAME,
+      severity: 'error',
+    });
+  }
+
+  for (const [binName, target] of binEntries) {
+    const targetPath = resolve(workspace.rootDir, target);
+    if (!existsSync(targetPath)) {
+      diagnostics.push({
+        filePath,
+        line: 1,
+        message: `Bin "${binName}" for ${workspace.name} points at missing file ${target}.`,
+        rule: RULE_NAME,
+        severity: 'error',
+      });
+    }
+
+    if (!filesCoverTarget(workspace.files, target)) {
+      diagnostics.push({
+        filePath,
+        line: 1,
+        message:
+          `Bin "${binName}" for ${workspace.name} points at ${target}, ` +
+          'but the package files list does not include that target.',
+        rule: RULE_NAME,
+        severity: 'error',
+      });
+    }
+  }
+
+  return diagnostics;
+};
+
+export const publicInternalDeepImports: ProjectAwareWardenRule = {
+  check(): readonly WardenDiagnostic[] {
+    return [];
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    if (filePath.endsWith('.md')) {
+      return diagnosticsForResolutions({
+        context,
+        filePath,
+        isDocumentation: true,
+        sourceCode,
+      });
+    }
+
+    return [
+      ...diagnosticsForResolutions({
+        context,
+        filePath,
+        isDocumentation: false,
+        sourceCode,
+      }),
+      ...rootBarrelDiagnostics(sourceCode, filePath, context),
+      ...binSurfaceDiagnostics(filePath, context),
+    ];
   },
   description:
-    'Disallow cross-package @ontrails/* deep imports that bypass the owner package exports map.',
+    'Keep @ontrails/* imports, docs specifiers, root barrels, and bin-only surfaces aligned with public package exports.',
   name: RULE_NAME,
   severity: 'error',
 };

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -2,6 +2,7 @@ import type { Intent, Topo } from '@ontrails/core';
 
 import type { WardenDepth } from '../config.js';
 import type { WardenImportResolution } from '../resolve.js';
+import type { WardenPublicWorkspace } from '../workspaces.js';
 
 /**
  * Severity level for warden diagnostics.
@@ -147,6 +148,13 @@ export interface ProjectContext {
     string,
     readonly WardenImportResolution[]
   >;
+  /** Resolved docs/specifier facts keyed by documentation file path. */
+  readonly documentedImportResolutionsByFile?: ReadonlyMap<
+    string,
+    readonly WardenImportResolution[]
+  >;
+  /** Non-private published @ontrails workspaces discovered from the root manifest. */
+  readonly publicWorkspaces?: ReadonlyMap<string, WardenPublicWorkspace>;
   /** Normalized trail intents by trail ID across the project. */
   readonly trailIntentsById?: ReadonlyMap<string, Intent>;
   /**

--- a/packages/warden/src/trails/public-internal-deep-imports.trail.ts
+++ b/packages/warden/src/trails/public-internal-deep-imports.trail.ts
@@ -7,6 +7,36 @@ export const publicInternalDeepImportsTrail = wrapRule({
       expected: { diagnostics: [] },
       input: {
         filePath: 'packages/store/src/trails/example.ts',
+        importResolutionsByFile: {
+          'packages/store/src/trails/example.ts': [
+            {
+              crossesPackageBoundary: true,
+              importSource: '@ontrails/core/trails',
+              importerPath: 'packages/store/src/trails/example.ts',
+              isInternalTarget: false,
+              line: 1,
+              packageName: '@ontrails/core',
+              packageRoot: 'packages/core',
+              resolvedPath: 'packages/core/src/trails/index.ts',
+              usesPublicExport: true,
+            },
+          ],
+        },
+        knownTrailIds: [],
+        publicWorkspaces: {
+          '@ontrails/core': {
+            hasExports: true,
+            name: '@ontrails/core',
+            packageJsonPath: 'packages/core/package.json',
+            rootDir: 'packages/core',
+          },
+          '@ontrails/store': {
+            hasExports: true,
+            name: '@ontrails/store',
+            packageJsonPath: 'packages/store/package.json',
+            rootDir: 'packages/store',
+          },
+        },
         sourceCode: `import { deriveTrail } from '@ontrails/core/trails';\n`,
       },
       name: 'Allows exported package subpaths',
@@ -18,7 +48,7 @@ export const publicInternalDeepImportsTrail = wrapRule({
             filePath: 'packages/store/src/trails/example.ts',
             line: 1,
             message:
-              'public-internal-deep-imports: cross-package import "@ontrails/core/src/internal/hidden" is not exported by @ontrails/core. Use the package root or an exported subpath; if the API is missing, add an owner export follow-up instead of importing internals.',
+              '@ontrails specifier "@ontrails/core/src/internal/hidden" is not exported by @ontrails/core. Use the package root or an exported subpath; if the API is missing, add an owner export follow-up instead of importing internals.',
             rule: 'public-internal-deep-imports',
             severity: 'error',
           },
@@ -26,6 +56,35 @@ export const publicInternalDeepImportsTrail = wrapRule({
       },
       input: {
         filePath: 'packages/store/src/trails/example.ts',
+        importResolutionsByFile: {
+          'packages/store/src/trails/example.ts': [
+            {
+              crossesPackageBoundary: true,
+              errorKind: 'package-path-not-exported',
+              importSource: '@ontrails/core/src/internal/hidden',
+              importerPath: 'packages/store/src/trails/example.ts',
+              isInternalTarget: false,
+              line: 1,
+              packageName: '@ontrails/core',
+              usesPublicExport: false,
+            },
+          ],
+        },
+        knownTrailIds: [],
+        publicWorkspaces: {
+          '@ontrails/core': {
+            hasExports: true,
+            name: '@ontrails/core',
+            packageJsonPath: 'packages/core/package.json',
+            rootDir: 'packages/core',
+          },
+          '@ontrails/store': {
+            hasExports: true,
+            name: '@ontrails/store',
+            packageJsonPath: 'packages/store/package.json',
+            rootDir: 'packages/store',
+          },
+        },
         sourceCode: `import { hidden } from '@ontrails/core/src/internal/hidden';\n`,
       },
       name: 'Flags cross-package imports into owner internals',

--- a/packages/warden/src/trails/run.ts
+++ b/packages/warden/src/trails/run.ts
@@ -12,6 +12,7 @@ import { run } from '@ontrails/core';
 import { wardenTopoRules } from '../rules/index.js';
 import type { WardenDiagnostic } from '../rules/types.js';
 import type { WardenImportResolution } from '../resolve.js';
+import type { WardenPublicWorkspace } from '../workspaces.js';
 import type { RuleOutput } from './schema.js';
 import { wardenTopo } from './topo.js';
 
@@ -43,10 +44,14 @@ interface ProjectRuleOptions {
   readonly importResolutionsByFile?: Readonly<
     Record<string, readonly WardenImportResolution[]>
   >;
+  readonly documentedImportResolutionsByFile?: Readonly<
+    Record<string, readonly WardenImportResolution[]>
+  >;
   readonly knownResourceIds?: readonly string[];
   readonly knownSignalIds?: readonly string[];
   readonly knownTrailIds?: readonly string[];
   readonly onTargetSignalIds?: readonly string[];
+  readonly publicWorkspaces?: Readonly<Record<string, WardenPublicWorkspace>>;
   readonly reconcileTableIds?: readonly string[];
   readonly trailIntentsById?: TrailIntentMap;
 }
@@ -58,10 +63,12 @@ const PROJECT_OPTION_KEYS = [
   'crudCoverageByEntity',
   'knownContourIds',
   'importResolutionsByFile',
+  'documentedImportResolutionsByFile',
   'knownResourceIds',
   'knownSignalIds',
   'knownTrailIds',
   'onTargetSignalIds',
+  'publicWorkspaces',
   'reconcileTableIds',
   'trailIntentsById',
 ] as const satisfies readonly (keyof ProjectRuleOptions)[];

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -40,6 +40,16 @@ export const importResolutionSchema = z.object({
   usesPublicExport: z.boolean(),
 });
 
+export const publicWorkspaceSchema = z.object({
+  bin: z.record(z.string(), z.string()).optional(),
+  exportTargets: z.record(z.string(), z.string()).optional(),
+  files: z.array(z.string()).optional(),
+  hasExports: z.boolean(),
+  name: z.string(),
+  packageJsonPath: z.string(),
+  rootDir: z.string(),
+});
+
 /**
  * Extended input for project-aware warden rule trails.
  *
@@ -65,6 +75,10 @@ export const projectAwareRuleInput = ruleInput.extend({
     .array(z.string())
     .optional()
     .describe('Store table IDs used with CRUD factories across the project'),
+  documentedImportResolutionsByFile: z
+    .record(z.string(), z.array(importResolutionSchema))
+    .optional()
+    .describe('Resolved docs/specifier facts keyed by documentation file path'),
   importResolutionsByFile: z
     .record(z.string(), z.array(importResolutionSchema))
     .optional()
@@ -89,6 +103,10 @@ export const projectAwareRuleInput = ruleInput.extend({
     .array(z.string())
     .optional()
     .describe('Signal IDs referenced by trail on arrays across the project'),
+  publicWorkspaces: z
+    .record(z.string(), publicWorkspaceSchema)
+    .optional()
+    .describe('Non-private published @ontrails workspaces by package name'),
   reconcileTableIds: z
     .array(z.string())
     .optional()

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -81,6 +81,16 @@ const buildProjectContext = (input: ProjectAwareRuleInput): ProjectContext => ({
         ),
       }
     : {}),
+  ...(input.documentedImportResolutionsByFile
+    ? {
+        documentedImportResolutionsByFile: new Map(
+          Object.entries(input.documentedImportResolutionsByFile)
+        ),
+      }
+    : {}),
+  ...(input.publicWorkspaces
+    ? { publicWorkspaces: new Map(Object.entries(input.publicWorkspaces)) }
+    : {}),
   knownTrailIds: input.knownTrailIds
     ? new Set(input.knownTrailIds)
     : new Set<string>(),

--- a/packages/warden/src/workspaces.ts
+++ b/packages/warden/src/workspaces.ts
@@ -1,0 +1,238 @@
+/**
+ * Workspace-manifest discovery for Warden project-aware rules.
+ */
+
+import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+export interface WardenPublicWorkspace {
+  readonly name: string;
+  readonly rootDir: string;
+  readonly packageJsonPath: string;
+  readonly hasExports: boolean;
+  readonly bin?: Readonly<Record<string, string>> | undefined;
+  readonly exportTargets?: Readonly<Record<string, string>> | undefined;
+  readonly files?: readonly string[] | undefined;
+}
+
+interface RootManifest {
+  readonly workspaces?: unknown;
+}
+
+interface PackageManifest {
+  readonly bin?: unknown;
+  readonly exports?: unknown;
+  readonly files?: unknown;
+  readonly name?: unknown;
+  readonly private?: unknown;
+}
+
+const normalizePath = (path: string): string => path.replaceAll('\\', '/');
+
+const normalizeRealPath = (path: string): string => {
+  try {
+    return normalizePath(realpathSync(path));
+  } catch {
+    return normalizePath(resolve(path));
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const readJson = <T>(path: string): T | undefined => {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
+  } catch {
+    return undefined;
+  }
+};
+
+const workspacePatternsFromManifest = (
+  manifest: RootManifest | undefined
+): readonly string[] => {
+  const { workspaces } = manifest ?? {};
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  }
+
+  const packages = isRecord(workspaces) ? workspaces['packages'] : undefined;
+  return Array.isArray(packages)
+    ? packages.filter(
+        (pattern): pattern is string => typeof pattern === 'string'
+      )
+    : [];
+};
+
+const workspaceDirsForPattern = (
+  rootDir: string,
+  pattern: string
+): readonly string[] => {
+  if (!pattern.endsWith('/*')) {
+    const workspaceDir = join(rootDir, pattern);
+    return existsSync(workspaceDir) ? [workspaceDir] : [];
+  }
+
+  const groupDir = join(rootDir, pattern.slice(0, -2));
+  if (!existsSync(groupDir)) {
+    return [];
+  }
+
+  return readdirSync(groupDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(groupDir, entry.name))
+    .toSorted();
+};
+
+const packageLocalName = (name: string): string =>
+  name.split('/').at(-1) ?? name;
+
+const normalizeBin = (
+  name: string,
+  value: unknown
+): Readonly<Record<string, string>> | undefined => {
+  if (typeof value === 'string') {
+    return { [packageLocalName(name)]: value };
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string'
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
+const normalizeFiles = (value: unknown): readonly string[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const files = value.filter(
+    (entry): entry is string => typeof entry === 'string'
+  );
+  return files.length > 0 ? files : undefined;
+};
+
+const resolveExportTarget = (
+  target: unknown,
+  depth = 0
+): string | undefined => {
+  if (typeof target === 'string') {
+    return target;
+  }
+  if (!isRecord(target) || depth > 8) {
+    return undefined;
+  }
+
+  for (const condition of ['bun', 'import', 'default', 'require'] as const) {
+    const conditionalTarget = target[condition];
+    const resolvedTarget = resolveExportTarget(conditionalTarget, depth + 1);
+    if (resolvedTarget) {
+      return resolvedTarget;
+    }
+  }
+  return undefined;
+};
+
+const exportSpecifierFromKey = (
+  packageName: string,
+  key: string
+): string | undefined => {
+  if (key === '.') {
+    return packageName;
+  }
+  if (!key.startsWith('./') || key.includes('*')) {
+    return undefined;
+  }
+  return `${packageName}/${key.slice(2)}`;
+};
+
+const normalizeExportTargets = (
+  packageDir: string,
+  packageName: string,
+  exportsValue: unknown
+): Readonly<Record<string, string>> | undefined => {
+  if (!isRecord(exportsValue)) {
+    return undefined;
+  }
+
+  const targets: Record<string, string> = {};
+  for (const [key, value] of Object.entries(exportsValue)) {
+    const specifier = exportSpecifierFromKey(packageName, key);
+    const target = resolveExportTarget(value);
+    if (!specifier || !target) {
+      continue;
+    }
+    targets[specifier] = normalizeRealPath(join(packageDir, target));
+  }
+
+  return Object.keys(targets).length > 0 ? targets : undefined;
+};
+
+const publicWorkspaceFromManifest = (
+  packageJsonPath: string,
+  manifest: PackageManifest
+): WardenPublicWorkspace | undefined => {
+  if (typeof manifest.name !== 'string') {
+    return undefined;
+  }
+  if (!manifest.name.startsWith('@ontrails/')) {
+    return undefined;
+  }
+  if (manifest.private === true) {
+    return undefined;
+  }
+
+  const packageDir = dirname(packageJsonPath);
+  const bin = normalizeBin(manifest.name, manifest.bin);
+  const exportTargets = normalizeExportTargets(
+    packageDir,
+    manifest.name,
+    manifest.exports
+  );
+  const files = normalizeFiles(manifest.files);
+
+  return {
+    ...(bin ? { bin } : {}),
+    ...(exportTargets ? { exportTargets } : {}),
+    ...(files ? { files } : {}),
+    hasExports: manifest.exports !== undefined,
+    name: manifest.name,
+    packageJsonPath: normalizeRealPath(packageJsonPath),
+    rootDir: normalizeRealPath(dirname(packageJsonPath)),
+  };
+};
+
+export const collectPublicWorkspaces = (
+  rootDir: string
+): ReadonlyMap<string, WardenPublicWorkspace> => {
+  const normalizedRoot = normalizeRealPath(rootDir);
+  const rootManifest = readJson<RootManifest>(
+    join(normalizedRoot, 'package.json')
+  );
+  const workspaces = new Map<string, WardenPublicWorkspace>();
+
+  for (const pattern of workspacePatternsFromManifest(rootManifest)) {
+    for (const workspaceDir of workspaceDirsForPattern(
+      normalizedRoot,
+      pattern
+    )) {
+      const packageJsonPath = join(workspaceDir, 'package.json');
+      const manifest = readJson<PackageManifest>(packageJsonPath);
+      if (!manifest) {
+        continue;
+      }
+
+      const workspace = publicWorkspaceFromManifest(packageJsonPath, manifest);
+      if (workspace) {
+        workspaces.set(workspace.name, workspace);
+      }
+    }
+  }
+
+  return workspaces;
+};


### PR DESCRIPTION

Branch: `trl-648-add-public-export-map-warden-guard-for-docs-and-internal`

### Context

The `wrapRule` drift needs a reusable guard so current-facing docs, code
imports, internal root-barrel exports, and bin-only package surfaces stay
aligned with public package metadata.

### What changed

- Refactored `public-internal-deep-imports` into a project-aware rule while
  keeping the rule ID stable.
- Added public workspace discovery across `packages/*`, `adapters/*`, and
  `apps/*`, excluding private workspaces.
- Added documentation import-resolution facts for current-facing README/docs
  targets.
- Added resolver-backed checks for docs/code `@ontrails/*` subpaths blocked by
  export maps, including static import/export, dynamic import, TS import type,
  and static `require` forms.
- Added root-barrel internal re-export detection with a narrow allowlist for
  known v1 compatibility exports.
- Added bin-only package checks for public packages such as `@ontrails/trails`.
- Covered nested conditional export targets and npm `files` globs with deep
  wildcards, concrete filenames after `/**/`, bare directory entries, and
  negation patterns.
- Uses each workspace's resolved root export target for root-barrel checks
  instead of assuming `src/index.ts`.
- Added hidden `warden-ignore-next-line` pragmas to current migration examples
  that intentionally show legacy pre-migration imports.

### Verification

- `bun test packages/warden/src/__tests__/public-internal-deep-imports.test.ts packages/warden/src/__tests__/trails.test.ts packages/warden/src/__tests__/cli.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run --cwd packages/warden lint`
- `bun run --cwd packages/warden test`
- `bun trails warden`
- Stack-tip `bun run check`

### Risks / rollout

The scan intentionally excludes historical ADR/release/migration/scratch/skill
docs and keeps current legacy examples explicit through ignore comments. The
root-barrel allowlist is narrow and should be revisited as public APIs are
cleaned up.

### Changeset

Patch changeset: `.changeset/warden-public-export-map-guard.md` for
`@ontrails/warden` plus the README-touched publishable packages
`@ontrails/commander`, `@ontrails/drizzle`, `@ontrails/hono`,
`@ontrails/http`, and `@ontrails/store`.

Closes: TRL-648