### PR TITLE
docs: map agents coverage audits to rule homes

### DIFF
--- a/docs/rule-design.md
+++ b/docs/rule-design.md
@@ -49,6 +49,12 @@ facts.
 | Impossible-by-type constraints | TypeScript | Output schemas, typed `ctx.cross()`, `resource.from(ctx)`, and other compile-time contracts. |
 | Human and agent orientation | `AGENTS.md` | A map over the executable system, not the only enforcement point. |
 
+When auditing `AGENTS.md`, map each rule to the strongest current authority
+layer and file focused follow-ups for any enforceable rule that remains
+prose-only. The audit is not itself the durable authority; it is a queueing step
+that either points at existing enforcement, explains why prose is intentional, or
+turns the gap into Warden, TypeScript, `testAll`, Oxlint, or ast-grep work.
+
 Owner-first data beats duplicated rule lists. If Warden needs framework facts
 such as reserved lexicon terms, intent values, error categories, permit rules,
 or Result accessors, it should read them from the module that owns the fact. If


### PR DESCRIPTION

Branch: `trl-679-audit-agentsmd-trail-rules-against-executable-enforcement`

### Context

M3 requires every root `AGENTS.md` Trail Rule to be mapped against executable
enforcement so prose-only gaps become focused follow-ups rather than fuzzy
doctrine drift.

### What changed

- Wrote the AGENTS coverage audit to
  `.scratch/2026-05-08-governance-m2-m3/agents-md-coverage-audit.md`.
- Audited all 15 Trail Rule bullets, including the detour factory carve-out.
- Added `docs/rule-design.md` guidance for future AGENTS coverage audits.
- Identified and filed/link-followed TRL-680 outcomes:
  - TRL-688 for public MCP/HTTP output schema enforcement.
  - TRL-689 for static resource accessor preference.
  - TRL-685 as the existing resource mock opt-out marker dependency.

### Verification

- `bun run format:check`
- `git diff --check`
- Stack-tip `bun run check`

### Risks / rollout

The audit is a queueing artifact, not durable authority. Enforceable gaps are
tracked as separate issues so M3 does not overbuild unsettled rule families.

### Changeset

`release:none` - docs/audit guidance only.

Closes: TRL-679

