### PR TITLE
fix: rename testAll suite label to contract

### DIFF
--- a/.changeset/testing-contract-suite-label.md
+++ b/.changeset/testing-contract-suite-label.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/testing': minor
+---
+
+Rename the generated `testAll` suite from `governance` to `contract`.

--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -157,7 +157,7 @@ testAll(graph, () => ({
 }));
 ```
 
-`testAll` runs the full governance suite in one call:
+`testAll` runs the full contract suite in one call:
 
 1. **`validateTopo`** -- structural validation (cross targets exist, declarations are consistent).
 2. **`testExamples`** -- progressive assertion over every trail example.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -182,7 +182,7 @@ Run it:
 ```bash
 $ bun test
  PASS  src/__tests__/app.test.ts
-  governance
+  contract
     topo validation
     greet
       example: Basic greeting
@@ -191,7 +191,7 @@ $ bun test
     detours
 ```
 
-That single `testAll(graph)` call runs the full governance suite:
+That single `testAll(graph)` call runs the full contract suite:
 
 1. **Topo validation** via `validateTopo` -- crosses exist, no recursive crossing, signal origins, example schema validation, output schema presence
 2. **Example execution** -- for each trail, validates input, runs the implementation, asserts the result matches `expected` (or validates against the output schema when no `expected` is declared)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,7 +50,7 @@ Red -> Green -> Refactor, with examples as the starting point:
 
 ## `testAll(graph)`
 
-One line runs the full governance suite -- structural validation, example execution, contract checks, and detour verification:
+One line runs the full contract suite -- structural validation, example execution, contract checks, and detour verification:
 
 ```typescript
 import { testAll } from '@ontrails/testing';
@@ -84,7 +84,7 @@ testAll(graph, () => ({
 
 Pass a factory when your explicit overrides contain mutable state, so each test gets a fresh instance.
 
-Generates a `governance` describe block containing:
+Generates a `contract` describe block containing:
 
 - **Topo validation** via `validateTopo` (crosses exist, no recursive crossing, signal origins, example schema validation, output schema presence)
 - **Example execution** via `testExamples`
@@ -416,7 +416,7 @@ src/
     entity.ts          # Trail definitions with examples
     search.ts
   __tests__/
-    governance.test.ts # testAll(graph) -- full governance suite
+    contract.test.ts   # testAll(graph) -- full contract suite
     entity.test.ts     # testTrail(show, [...]) -- edge cases
     cli.test.ts        # CLI harness integration tests
     mcp.test.ts        # MCP harness integration tests

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,6 +1,6 @@
 # @ontrails/testing
 
-Contract-driven testing for Trails. Add examples to your trails, then `testAll(graph)` runs them as assertions, validates output schemas, checks composition graphs, and verifies structural integrity. One line of test code, full governance.
+Contract-driven testing for Trails. Add examples to your trails, then `testAll(graph)` runs them as assertions, validates output schemas, checks composition graphs, and verifies structural integrity. One line of test code, full contract coverage.
 
 ## Usage
 
@@ -27,7 +27,7 @@ testDetours(graph);    // Validate detour constructor, recover, and ordering sem
 
 | Export | What it does |
 | --- | --- |
-| `testAll(topo, ctx?)` | Single-line governance suite: validation + examples + contracts + detours |
+| `testAll(topo, ctx?)` | Single-line contract suite: validation + examples + contracts + detours |
 | `testExamples(topo, ctx?)` | Run trail examples as `describe`/`test` blocks |
 | `testTrail(trail, scenarios)` | Custom scenarios for edge cases, error paths, and cross chains |
 | `testContracts(topo, ctx?)` | Validate output against declared schemas |

--- a/packages/testing/src/all.ts
+++ b/packages/testing/src/all.ts
@@ -1,5 +1,5 @@
 /**
- * testAll — single-line governance suite for any Topo.
+ * testAll — single-line contract suite for any Topo.
  *
  * Wraps topo validation, example execution, contract checks, and detour
  * contract validation into one describe block.
@@ -19,9 +19,9 @@ import { testExamples } from './examples.js';
 import type { TestAllEstablishedOptions } from './types.js';
 
 /**
- * Run the full governance test suite for a Topo.
+ * Run the full contract test suite for a Topo.
  *
- * Generates a `governance` describe block containing:
+ * Generates a `contract` describe block containing:
  * - Structural validation via `validateTopo`
  * - Example execution via `testExamples`
  * - Output contract checks via `testContracts`
@@ -73,12 +73,12 @@ const assertValidTopo = (result: ReturnType<typeof validateTopo>): void => {
   }
 };
 
-const registerGovernanceSuite = (
+const registerContractSuite = (
   topo: Topo,
   ctxOrFactory: TestAllInput | undefined,
   validate: (topo: Topo) => ReturnType<typeof validateTopo>
 ): void => {
-  describe('governance', () => {
+  describe('contract', () => {
     test('topo validates', () => {
       expect(() => assertValidTopo(validate(topo))).not.toThrow();
     });
@@ -93,7 +93,7 @@ const registerGovernanceSuite = (
 };
 
 export const testAll = (topo: Topo, ctxOrFactory?: TestAllInput): void => {
-  registerGovernanceSuite(topo, ctxOrFactory, validateTopo);
+  registerContractSuite(topo, ctxOrFactory, validateTopo);
 };
 
 type EstablishedInput =
@@ -187,7 +187,7 @@ export const testAllEstablished = (
       ? optionsOrFactory
       : () => optionsOrFactory;
 
-  registerGovernanceSuite(
+  registerContractSuite(
     topo,
     () => toExecutionOptions(normalizeEstablishedOptions(resolveInput())),
     validateEstablishedTopo

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -33,7 +33,7 @@ await surface(graph);        // CLI — from @ontrails/commander
 const result = await run(graph, 'greet', { name: 'Alice' });
 
 // 5. Test
-testAll(graph);            // Examples + governance in one line
+testAll(graph);            // Examples + contract suite in one line
 ```
 
 ## Lexicon
@@ -168,7 +168,7 @@ See [contract-patterns.md](references/contract-patterns.md) for declaration patt
 
 ## Testing
 
-`testAll(graph)` runs the full governance suite in one line:
+`testAll(graph)` runs the full contract suite in one line:
 
 1. Topo validation (crosses, schemas, signals, resources)
 2. Example execution (every example as an assertion)

--- a/plugin/skills/trails/examples/composition.md
+++ b/plugin/skills/trails/examples/composition.md
@@ -111,7 +111,7 @@ export const create = trail('order.create', {
 `testAll` checks that every declared cross was actually called:
 
 ```typescript
-// __tests__/governance.test.ts
+// __tests__/contract.test.ts
 import { testAll } from '@ontrails/testing';
 import { topo } from '@ontrails/core';
 import * as customer from '../trails/customer.js';

--- a/plugin/skills/trails/references/getting-started.md
+++ b/plugin/skills/trails/references/getting-started.md
@@ -118,7 +118,7 @@ Run it:
 ```bash
 $ bun test
  PASS  src/__tests__/app.test.ts
-  governance
+  contract
     topo validation
     greet
       example: Basic greeting

--- a/plugin/skills/trails/references/migration-checklist.md
+++ b/plugin/skills/trails/references/migration-checklist.md
@@ -54,7 +54,7 @@ For each handler:
 ## Phase 5: Testing
 
 - [ ] Add examples to every trail (happy path + key error cases)
-- [ ] Create `governance.test.ts` with `testAll(graph)`
+- [ ] Create `contract.test.ts` with `testAll(graph)`
 - [ ] Add edge-case tests with `testTrail()` for complex trails
 - [ ] Add surface integration tests with CLI/MCP harnesses
 - [ ] All tests pass

--- a/plugin/skills/trails/references/testing-patterns.md
+++ b/plugin/skills/trails/references/testing-patterns.md
@@ -1,8 +1,8 @@
 # Testing Patterns Reference
 
-## `testAll(graph)` -- One-Liner Governance Suite
+## `testAll(graph)` -- One-Liner Contract Suite
 
-Runs topo validation + example execution + contract checks + detour verification in a single `describe('governance')` block.
+Runs topo validation + example execution + contract checks + detour verification in a single `describe('contract')` block.
 
 ```typescript
 import { testAll } from '@ontrails/testing';
@@ -239,13 +239,13 @@ expect(result.isError).toBe(false);
 
 ```text
 src/__tests__/
-  governance.test.ts    # testAll(graph) -- the one-liner
+  contract.test.ts      # testAll(graph) -- the one-liner
   entity.test.ts        # testTrail edge cases per domain
   onboard.test.ts       # testCrosses composition scenarios
   cli.test.ts           # CLI harness integration
   mcp.test.ts           # MCP harness integration
 ```
 
-- `governance.test.ts` is the minimum. One file, one line, full coverage of examples and contracts.
+- `contract.test.ts` is the minimum. One file, one line, full coverage of examples and contracts.
 - Add `*.test.ts` files per domain when edge cases accumulate beyond what examples cover.
 - Surface harness tests are optional but valuable for verifying flag parsing, output formatting, and tool naming.


### PR DESCRIPTION

Branch: `trl-680-file-per-rule-enforcement-follow-ups-from-agentsmd-coverage`

### Context

The AGENTS coverage audit found that `testAll` was presenting contract
conformance as `governance`, even though it does not run Warden. M3 should keep
governance terminology reserved for Warden/rule authority.

### What changed

- Filed TRL-688 and TRL-689.
- Linked existing TRL-685 instead of duplicating resource mock marker work.
- Renamed the generated `testAll` suite from `describe('governance')` to
  `describe('contract')`.
- Updated package README, demo README, and getting-started/testing docs.
- Updated stale plugin reference/example docs to use `contract` and
  `contract.test.ts`.

### Verification

- `bun test packages/testing`
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run format:check`
- `git diff --check`
- Stack-tip `bun run check`

### Risks / rollout

This changes user-visible test output names only; it does not alter the
underlying test behavior.

### Changeset

Minor changeset: `.changeset/testing-contract-suite-label.md`, because the
generated `describe` label is visible public test output.

Closes: TRL-680