### PR TITLE
feat: add warden guidance metadata

### DIFF
--- a/.changeset/warden-guidance-surface.md
+++ b/.changeset/warden-guidance-surface.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/warden": minor
+"@ontrails/trails": minor
+---
+
+Add structured Warden remediation guidance to rule metadata, diagnostics, report output, and the `trails warden` result schema.

--- a/apps/trails/src/__tests__/warden.test.ts
+++ b/apps/trails/src/__tests__/warden.test.ts
@@ -29,6 +29,9 @@ const makeTempDir = (): string => {
 
 interface WardenJsonOutput {
   readonly diagnostics: readonly {
+    readonly guidance?: {
+      readonly summary: string;
+    };
     readonly rule: string;
     readonly severity: 'error' | 'warn';
   }[];
@@ -188,6 +191,9 @@ describe('trails warden', () => {
       }
       expect(result.value.passed).toBe(false);
       expect(result.value.errorCount).toBe(1);
+      expect(result.value.diagnostics[0]?.guidance?.summary).toBe(
+        'Convert thrown implementation failures into explicit Result.err() outcomes.'
+      );
       expect(result.value.formatted).toContain('## Warden Report');
     } finally {
       rmSync(dir, { force: true, recursive: true });

--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -21,6 +21,20 @@ import { resolveTrailRootDir } from './root-dir.js';
 // Trail definition
 // ---------------------------------------------------------------------------
 
+const wardenGuidanceLinkSchema = z.object({
+  label: z.string(),
+  path: z.string().optional(),
+  url: z.string().optional(),
+});
+
+const wardenGuidanceSchema = z.object({
+  commands: z.array(z.string()).readonly().optional(),
+  docs: z.array(wardenGuidanceLinkSchema).readonly().optional(),
+  relatedRules: z.array(z.string()).readonly().optional(),
+  steps: z.array(z.string()).readonly().optional(),
+  summary: z.string(),
+});
+
 const wardenInputSchema = z.object({
   apps: z
     .array(z.string())
@@ -178,6 +192,7 @@ export const wardenTrail = trail('warden', {
     diagnostics: z.array(
       z.object({
         filePath: z.string(),
+        guidance: wardenGuidanceSchema.optional(),
         line: z.number(),
         message: z.string(),
         rule: z.string(),

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -212,6 +212,79 @@ describe('runWarden basics', () => {
     }
   });
 
+  test('applies default rule guidance to diagnostics from guided rules', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'trail.ts'),
+        `import { Result, trail } from '@ontrails/core';
+
+export const badTrail = trail('bad.throw', {
+  blaze: async () => {
+    throw new Error('boom');
+  },
+});
+`
+      );
+
+      const report = await runWarden({
+        rootDir: dir,
+        tier: 'source-static',
+      });
+      const diagnostic = report.diagnostics.find(
+        (entry) => entry.rule === 'no-throw-in-implementation'
+      );
+
+      expect(diagnostic?.guidance).toEqual(
+        expect.objectContaining({
+          relatedRules: [
+            'implementation-returns-result',
+            'no-native-error-result',
+          ],
+          summary:
+            'Convert thrown implementation failures into explicit Result.err() outcomes.',
+        })
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('leaves diagnostics from unguided rules unguided', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'contours.ts'),
+        `import { contour } from '@ontrails/core';
+import { z } from 'zod';
+
+export const first = contour('first', {
+  secondId: second.id(),
+  id: z.string().uuid(),
+}, { identity: 'id' });
+
+export const second = contour('second', {
+  firstId: first.id(),
+  id: z.string().uuid(),
+}, { identity: 'id' });
+`
+      );
+
+      const report = await runWarden({
+        rootDir: dir,
+        tier: 'project-static',
+      });
+      const diagnostic = report.diagnostics.find(
+        (entry) => entry.rule === 'circular-refs'
+      );
+
+      expect(diagnostic).toBeDefined();
+      expect(diagnostic?.guidance).toBeUndefined();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('source-static tier scans CI YAML and shell scripts for dev permit usage', async () => {
     const dir = makeTempDir();
     try {
@@ -1045,6 +1118,35 @@ describe('formatWardenReport', () => {
     expect(output).toContain('1 errors');
     expect(output).toContain('Result: FAIL');
     expect(output).toContain('entity.ts:3');
+  });
+
+  test('formats related guidance rules in the lint section', () => {
+    const output = formatWardenReport({
+      diagnostics: [
+        {
+          filePath: 'src/trails/entity.ts',
+          guidance: {
+            relatedRules: [
+              'implementation-returns-result',
+              'no-native-error-result',
+            ],
+            summary: 'Convert thrown failures into Result.err().',
+          },
+          line: 3,
+          message: 'Do not throw inside implementation.',
+          rule: 'no-throw-in-implementation',
+          severity: 'error',
+        },
+      ],
+      drift: { committedHash: null, currentHash: 'stub', stale: false },
+      errorCount: 1,
+      passed: false,
+      warnCount: 0,
+    });
+
+    expect(output).toContain(
+      'Related: implementation-returns-result, no-native-error-result'
+    );
   });
 
   test('formats a report with stale drift', () => {

--- a/packages/warden/src/__tests__/formatters.test.ts
+++ b/packages/warden/src/__tests__/formatters.test.ts
@@ -19,6 +19,13 @@ const reportWithDiagnostics: WardenReport = {
   diagnostics: [
     {
       filePath: 'packages/core/src/result.ts',
+      guidance: {
+        commands: ['bun test packages/core'],
+        docs: [{ label: 'Trail Rules', path: 'AGENTS.md#trail-rules' }],
+        relatedRules: ['implementation-returns-result'],
+        steps: ['Return Result.err() instead of throwing.'],
+        summary: 'Convert thrown implementation failures into Result.err().',
+      },
       line: 42,
       message: 'Throw statement found in trail implementation',
       rule: 'no-throw-in-implementation',
@@ -104,6 +111,18 @@ describe('formatJson', () => {
     expect(parsed.diagnostics[0].rule).toBe('no-throw-in-implementation');
   });
 
+  test('exposes diagnostic guidance as structured JSON', () => {
+    const parsed = JSON.parse(formatJson(reportWithDiagnostics));
+    expect(parsed.diagnostics[0].guidance).toMatchObject({
+      commands: ['bun test packages/core'],
+      docs: [{ label: 'Trail Rules', path: 'AGENTS.md#trail-rules' }],
+      relatedRules: ['implementation-returns-result'],
+      steps: ['Return Result.err() instead of throwing.'],
+      summary: 'Convert thrown implementation failures into Result.err().',
+    });
+    expect(parsed.diagnostics[1].guidance).toBeUndefined();
+  });
+
   test('includes null drift when absent', () => {
     const parsed = JSON.parse(formatJson(reportWithDiagnostics));
     expect(parsed.drift).toBeNull();
@@ -143,6 +162,18 @@ describe('formatSummary', () => {
   test('includes file:line in backticks', () => {
     const output = formatSummary(reportWithDiagnostics);
     expect(output).toContain('`packages/core/src/result.ts:42`');
+  });
+
+  test('renders guidance next steps when present', () => {
+    const output = formatSummary(reportWithDiagnostics);
+    expect(output).toContain(
+      'Next: Convert thrown implementation failures into Result.err().'
+    );
+    expect(output).toContain('Docs: [Trail Rules](AGENTS.md#trail-rules)');
+    expect(output).toContain('Commands: `bun test packages/core`');
+    expect(output).not.toContain(
+      'Trail "entity.show" has no output schema\n  - Next:'
+    );
   });
 
   test('includes drift section when stale', () => {

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { testAll } from '@ontrails/testing';
 
+import { diagnosticSchema } from '../trails/schema.js';
 import { wardenTopo } from '../trails/topo.js';
 
 // oxlint-disable-next-line jest/require-hook -- testAll generates describe/test blocks, not setup code
@@ -26,5 +27,38 @@ describe('wardenTopo', () => {
       expect(typeof metadata?.lifecycle?.state).toBe('string');
       expect(typeof metadata?.tier).toBe('string');
     }
+  });
+
+  test('diagnostic schema accepts structured guidance', () => {
+    expect(
+      diagnosticSchema.safeParse({
+        filePath: 'src/trail.ts',
+        guidance: {
+          docs: [{ label: 'Trail Rules', path: 'AGENTS.md#trail-rules' }],
+          steps: ['Return Result.err() instead of throwing.'],
+          summary: 'Convert thrown failures into Result outcomes.',
+        },
+        line: 1,
+        message: 'Do not throw inside implementation.',
+        rule: 'no-throw-in-implementation',
+        severity: 'error',
+      }).success
+    ).toBe(true);
+  });
+
+  test('diagnostic schema accepts label-only guidance links', () => {
+    expect(
+      diagnosticSchema.safeParse({
+        filePath: 'src/trail.ts',
+        guidance: {
+          docs: [{ label: 'Trail Rules' }],
+          summary: 'Read the nearby doctrine.',
+        },
+        line: 1,
+        message: 'Do not throw inside implementation.',
+        rule: 'no-throw-in-implementation',
+        severity: 'error',
+      }).success
+    ).toBe(true);
   });
 });

--- a/packages/warden/src/__tests__/warden-rule-metadata.test.ts
+++ b/packages/warden/src/__tests__/warden-rule-metadata.test.ts
@@ -67,4 +67,24 @@ describe('warden rule metadata', () => {
     );
     expect(listWardenRuleMetadata().length).toBe(allRuleNames.length);
   });
+
+  test('exposes structured guidance for guided built-in rules', () => {
+    expect(
+      getWardenRuleMetadata('no-throw-in-implementation')?.guidance
+    ).toEqual(
+      expect.objectContaining({
+        docs: [{ label: 'Trail Rules', path: 'AGENTS.md#trail-rules' }],
+        relatedRules: [
+          'implementation-returns-result',
+          'no-native-error-result',
+        ],
+        summary:
+          'Convert thrown implementation failures into explicit Result.err() outcomes.',
+      })
+    );
+  });
+
+  test('continues to allow unguided built-in rules', () => {
+    expect(getWardenRuleMetadata('circular-refs')?.guidance).toBeUndefined();
+  });
 });

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -918,6 +918,17 @@ const isSelectedTopoRule = (
   return metadata ? ruleMatchesDepth(metadata, selector.depth) : true;
 };
 
+const withDiagnosticGuidance = (
+  diagnostic: WardenDiagnostic
+): WardenDiagnostic => {
+  if (diagnostic.guidance !== undefined) {
+    return diagnostic;
+  }
+
+  const guidance = getWardenRuleMetadata(diagnostic.rule)?.guidance;
+  return guidance === undefined ? diagnostic : { ...diagnostic, guidance };
+};
+
 const topoRuleFailureDiagnostic = (
   rule: TopoAwareWardenRule,
   error: unknown
@@ -1269,7 +1280,7 @@ export const runWarden = async (
   const runLint = shouldRunLint(options);
   const runDrift = shouldRunDrift(options, effectiveConfig);
 
-  const allDiagnostics = [
+  const rawDiagnostics = [
     ...configDiagnostics,
     ...optionDiagnostics,
     ...(runLint
@@ -1282,6 +1293,7 @@ export const runWarden = async (
         )
       : []),
   ];
+  const allDiagnostics = rawDiagnostics.map(withDiagnosticGuidance);
   const drift = runDrift
     ? await checkDriftForTopoTargets(rootDir, topoTargets)
     : null;
@@ -1328,6 +1340,27 @@ const formatLintSection = (report: WardenReport): string[] => {
     lines.push(
       `  ${d.filePath}:${String(d.line)}  [${prefix}] ${d.rule}  ${d.message}`
     );
+    if (d.guidance !== undefined) {
+      lines.push(`    Next: ${d.guidance.summary}`);
+      for (const [index, step] of (d.guidance.steps ?? []).entries()) {
+        lines.push(`    ${String(index + 1)}. ${step}`);
+      }
+      if (d.guidance.commands !== undefined) {
+        lines.push(
+          `    Commands: ${d.guidance.commands.map((cmd) => `\`${cmd}\``).join(', ')}`
+        );
+      }
+      if (d.guidance.docs !== undefined) {
+        lines.push(
+          `    Docs: ${d.guidance.docs
+            .map((doc) => doc.path ?? doc.url ?? doc.label)
+            .join(', ')}`
+        );
+      }
+      if (d.guidance.relatedRules !== undefined) {
+        lines.push(`    Related: ${d.guidance.relatedRules.join(', ')}`);
+      }
+    }
   }
 
   return lines;

--- a/packages/warden/src/formatters.ts
+++ b/packages/warden/src/formatters.ts
@@ -7,7 +7,7 @@
  */
 
 import type { WardenReport } from './cli.js';
-import type { WardenSeverity } from './rules/types.js';
+import type { WardenGuidanceLink, WardenSeverity } from './rules/types.js';
 
 /** Map warden severity to GitHub Actions annotation level. */
 const ghLevel: Record<WardenSeverity, string> = {
@@ -68,9 +68,56 @@ export const formatJson = (report: WardenReport): string => {
   );
 };
 
-/** Format a diagnostic as a markdown list item. */
-const diagnosticLine = (d: WardenReport['diagnostics'][number]): string =>
-  `- \`${d.filePath}:${String(d.line)}\` — ${d.rule}: ${d.message}`;
+const formatGuidanceLink = (link: WardenGuidanceLink): string => {
+  if (link.path !== undefined) {
+    return `[${link.label}](${link.path})`;
+  }
+  if (link.url !== undefined) {
+    return `[${link.label}](${link.url})`;
+  }
+  return link.label;
+};
+
+/** Format diagnostic guidance as indented markdown lines. */
+const diagnosticGuidanceLines = (
+  d: WardenReport['diagnostics'][number]
+): readonly string[] => {
+  const { guidance } = d;
+  if (guidance === undefined) {
+    return [];
+  }
+
+  const lines = [`  - Next: ${guidance.summary}`];
+  if (guidance.steps !== undefined && guidance.steps.length > 0) {
+    lines.push(
+      `  - Steps: ${guidance.steps
+        .map((step, index) => `${String(index + 1)}. ${step}`)
+        .join(' ')}`
+    );
+  }
+  if (guidance.docs !== undefined && guidance.docs.length > 0) {
+    lines.push(`  - Docs: ${guidance.docs.map(formatGuidanceLink).join(', ')}`);
+  }
+  if (guidance.commands !== undefined && guidance.commands.length > 0) {
+    lines.push(
+      `  - Commands: ${guidance.commands.map((cmd) => `\`${cmd}\``).join(', ')}`
+    );
+  }
+  if (guidance.relatedRules !== undefined && guidance.relatedRules.length > 0) {
+    lines.push(
+      `  - Related: ${guidance.relatedRules.map((rule) => `\`${rule}\``).join(', ')}`
+    );
+  }
+  return lines;
+};
+
+/** Format a diagnostic as markdown lines. */
+const diagnosticLines = (
+  d: WardenReport['diagnostics'][number]
+): readonly string[] => [
+  `- \`${d.filePath}:${String(d.line)}\` — ${d.rule}: ${d.message}`,
+  ...diagnosticGuidanceLines(d),
+];
 
 /** Render a severity group as a headed markdown section, or empty array. */
 const severitySection = (
@@ -80,7 +127,7 @@ const severitySection = (
   if (diagnostics.length === 0) {
     return [];
   }
-  return ['', `### ${heading}`, ...diagnostics.map(diagnosticLine)];
+  return ['', `### ${heading}`, ...diagnostics.flatMap(diagnosticLines)];
 };
 
 /** Render a drift section if stale, otherwise empty array. */

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -14,6 +14,8 @@ export type {
   ProjectContext,
   TopoAwareWardenRule,
   WardenDiagnostic,
+  WardenGuidance,
+  WardenGuidanceLink,
   WardenRule,
   WardenRuleConcern,
   WardenRuleLifecycle,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -48,6 +48,8 @@ import { wardenRulesUseAst } from './warden-rules-use-ast.js';
 import { webhookRouteCollision } from './webhook-route-collision.js';
 
 export type {
+  WardenGuidance,
+  WardenGuidanceLink,
   WardenRuleLifecycle,
   WardenRuleLifecycleState,
   WardenRuleConcern,

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -104,6 +104,16 @@ const durableRepoLocal = {
   scope: 'repo-local',
 } as const;
 
+const trailContractDocs = {
+  label: 'Trail Rules',
+  path: 'AGENTS.md#trail-rules',
+} as const;
+
+const wardenDocs = {
+  label: 'Warden',
+  path: 'docs/warden.md',
+} as const;
+
 const builtinWardenRuleMetadataInput = {
   'activation-orphan': {
     ...durableExternal,
@@ -153,6 +163,14 @@ const builtinWardenRuleMetadataInput = {
   },
   'example-valid': {
     ...durableExternal,
+    guidance: {
+      docs: [trailContractDocs],
+      steps: [
+        'Update the example input, expected output, or schema so they describe the same contract.',
+        'Run the package tests that exercise the affected trail examples.',
+      ],
+      summary: 'Keep trail examples synchronized with their authored schemas.',
+    },
     invariant: 'Trail examples remain valid against their authored schema.',
     tier: 'source-static',
   },
@@ -237,6 +255,16 @@ const builtinWardenRuleMetadataInput = {
   },
   'no-throw-in-implementation': {
     ...durableExternal,
+    guidance: {
+      docs: [trailContractDocs],
+      relatedRules: ['implementation-returns-result', 'no-native-error-result'],
+      steps: [
+        'Return Result.err() with the most specific TrailsError subclass available.',
+        'Use detours for recoverable runtime strategies instead of throwing inside the blaze.',
+      ],
+      summary:
+        'Convert thrown implementation failures into explicit Result.err() outcomes.',
+    },
     invariant: 'Trail implementations return Result.err() instead of throwing.',
     tier: 'source-static',
   },
@@ -259,10 +287,31 @@ const builtinWardenRuleMetadataInput = {
   },
   'permit-governance': {
     ...durableExternal,
+    guidance: {
+      docs: [
+        trailContractDocs,
+        { label: 'Permits', path: 'packages/permits/README.md' },
+      ],
+      steps: [
+        'Declare the permit required for the destructive trail.',
+        'If the write is intentionally development-only, keep the dev permit out of committed runtime source.',
+      ],
+      summary:
+        'Make destructive trail authorization visible on the trail contract.',
+    },
     invariant: 'Destroy trails declare explicit permit requirements.',
     tier: 'topo-aware',
   },
   'prefer-schema-inference': {
+    guidance: {
+      docs: [trailContractDocs],
+      steps: [
+        'Remove field overrides that only repeat labels or enum options already inferable from the schema.',
+        'Keep field metadata only when it adds meaning the schema cannot derive.',
+      ],
+      summary:
+        'Let schemas remain the owner for field metadata unless an override adds new information.',
+    },
     invariant: 'Trail schemas should be inferred unless overrides add meaning.',
     lifecycle: { state: 'durable' },
     scope: 'advisory',
@@ -296,11 +345,31 @@ const builtinWardenRuleMetadataInput = {
   },
   'resource-declarations': {
     ...durableExternal,
+    guidance: {
+      docs: [trailContractDocs],
+      relatedRules: ['resource-exists'],
+      steps: [
+        'Declare each external dependency in the trail resources array.',
+        'Access statically known resources through the resource definition helper rather than constructing dependencies inline.',
+      ],
+      summary:
+        'Keep infrastructure dependencies declared on the trail contract.',
+    },
     invariant: 'Resource usage is declared on the trail contract.',
     tier: 'source-static',
   },
   'resource-exists': {
     ...durableExternal,
+    guidance: {
+      docs: [trailContractDocs, wardenDocs],
+      relatedRules: ['resource-declarations'],
+      steps: [
+        'Define the referenced resource in project source or import the existing resource definition.',
+        'When a resource is testable, include a mock factory so contract tests can run without real infrastructure.',
+      ],
+      summary:
+        'Make declared resources resolve to authored resource definitions.',
+    },
     invariant: 'Declared resources resolve to known resource definitions.',
     tier: 'project-static',
   },

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -63,6 +63,35 @@ export interface WardenRuleLifecycle {
 }
 
 /**
+ * Documentation or reference target for Warden remediation guidance.
+ */
+export interface WardenGuidanceLink {
+  /** Human-readable link label. */
+  readonly label: string;
+  /** Repository-relative documentation path, when the target is in-tree. */
+  readonly path?: string | undefined;
+  /** External documentation URL, when the target is outside the repo. */
+  readonly url?: string | undefined;
+}
+
+/**
+ * Structured remediation guidance that can be rendered for humans or projected
+ * into agent-facing manifests without scraping diagnostic prose.
+ */
+export interface WardenGuidance {
+  /** Concise next step for the finding or rule. */
+  readonly summary: string;
+  /** Ordered remediation steps, when the rule benefits from more detail. */
+  readonly steps?: readonly string[] | undefined;
+  /** Reference docs that explain the invariant. */
+  readonly docs?: readonly WardenGuidanceLink[] | undefined;
+  /** Example commands. These are guidance examples, not autofix contracts. */
+  readonly commands?: readonly string[] | undefined;
+  /** Related rule identifiers that help agents navigate nearby doctrine. */
+  readonly relatedRules?: readonly string[] | undefined;
+}
+
+/**
  * Stable metadata used to classify Warden rules before dispatch filtering.
  */
 export interface WardenRuleMetadata {
@@ -78,6 +107,8 @@ export interface WardenRuleMetadata {
   readonly scope: WardenRuleScope;
   /** Narrowest Warden tier that can answer the rule. */
   readonly tier: WardenRuleTier;
+  /** Structured remediation guidance for diagnostics emitted by this rule. */
+  readonly guidance?: WardenGuidance | undefined;
 }
 
 /**
@@ -96,6 +127,8 @@ export interface WardenDiagnostic {
   readonly filePath: string;
   /** Topo/app identity for diagnostics emitted during multi-topo runs. */
   readonly topoName?: string | undefined;
+  /** Optional finding-level guidance. Defaults from rule metadata when absent. */
+  readonly guidance?: WardenGuidance | undefined;
 }
 
 /**

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -10,9 +10,26 @@ import type { Topo } from '@ontrails/core';
 import { z } from 'zod';
 import { wardenImportResolutionErrorKinds } from '../resolve.js';
 
+export const guidanceLinkSchema = z.object({
+  label: z.string(),
+  path: z.string().optional(),
+  url: z.string().optional(),
+});
+
+export const guidanceSchema = z.object({
+  commands: z.array(z.string()).readonly().optional(),
+  docs: z.array(guidanceLinkSchema).readonly().optional(),
+  relatedRules: z.array(z.string()).readonly().optional(),
+  steps: z.array(z.string()).readonly().optional(),
+  summary: z.string(),
+});
+
 /** A single diagnostic emitted by a warden rule trail. */
 export const diagnosticSchema = z.object({
   filePath: z.string().describe('File path that was analyzed'),
+  guidance: guidanceSchema
+    .optional()
+    .describe('Structured remediation guidance'),
   line: z.number().describe('1-based line number'),
   message: z.string().describe('Human-readable diagnostic message'),
   rule: z.string().describe('Rule name'),


### PR DESCRIPTION
## Context

This is the bottom branch of the Warden Guidance + Knip Capstone stack and closes TRL-122.

Warden diagnostics already enforce Trails doctrine, but the actionable guidance was mostly prose rendered at the CLI edge. This branch makes rule guidance structured data so CLI, JSON, Trails command output, and downstream generated guides can all consume the same source.

## What changed

- Added structured `WardenGuidance` metadata and diagnostic exposure.
- Enriched Warden diagnostics from rule metadata when a rule does not provide custom guidance.
- Preserved guidance through CLI text, markdown summary, JSON output, rule-trail schemas, and `trails warden` output schemas.
- Added representative built-in guidance for examples, thrown implementations, permits, schema inference, and resources.
- Added tests for formatting, metadata, Warden CLI behavior, Warden rule trails, and the Trails Warden bridge.

## How to test

- `bun test packages/warden/src/__tests__/formatters.test.ts packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/cli.test.ts packages/warden/src/__tests__/trails.test.ts`
- `bun test apps/trails/src/__tests__/warden.test.ts`
- Final stack-tip gates also passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.

## Risks/rollout notes

The schema and JSON exposure are additive. Existing Warden output remains compatible while consumers can now opt into structured guidance.

## Release

Changeset: `.changeset/warden-guidance-surface.md` for `@ontrails/warden` and `@ontrails/trails`.

Closes: TRL-122
