### PR TITLE
feat: add cli value aliases

### DIFF
--- a/.changeset/cli-value-aliases.md
+++ b/.changeset/cli-value-aliases.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/cli": minor
+"@ontrails/commander": minor
+"@ontrails/warden": minor
+---
+
+Add generic enum value aliases for CLI flags and migrate Warden command aliases onto the shared alias model.

--- a/adapters/commander/src/__tests__/to-commander.test.ts
+++ b/adapters/commander/src/__tests__/to-commander.test.ts
@@ -253,6 +253,111 @@ describe('toCommander validation', () => {
     expect(() => toCommander(commands)).toThrow('Duplicate CLI path: topo pin');
   });
 
+  test('throws when a value alias collides with another flag', () => {
+    const commands: CliCommand[] = [
+      {
+        args: [],
+        execute: async () => await Result.ok('ok'),
+        flags: [
+          {
+            choices: ['json', 'text'],
+            name: 'format',
+            required: false,
+            type: 'string' as const,
+            valueAliases: [{ name: 'json', value: 'json' }],
+            variadic: false,
+          },
+          {
+            name: 'json',
+            required: false,
+            type: 'boolean' as const,
+            variadic: false,
+          },
+        ],
+        intent: 'read' as const,
+        path: ['render'] as const,
+        trail: trail('render', {
+          blaze: () => Result.ok('ok'),
+          input: z.object({}),
+        }),
+      },
+    ];
+
+    expect(() => toCommander(commands)).toThrow(
+      'CLI flag alias --json for --format collides on command render'
+    );
+  });
+
+  test('throws when a value alias collides with a normalized flag key', () => {
+    const commands: CliCommand[] = [
+      {
+        args: [],
+        execute: async () => await Result.ok('ok'),
+        flags: [
+          {
+            choices: ['json', 'text'],
+            name: 'format',
+            required: false,
+            type: 'string' as const,
+            valueAliases: [{ name: 'jsonOutput', value: 'json' }],
+            variadic: false,
+          },
+          {
+            name: 'json-output',
+            required: false,
+            type: 'boolean' as const,
+            variadic: false,
+          },
+        ],
+        intent: 'read' as const,
+        path: ['render'] as const,
+        trail: trail('render', {
+          blaze: () => Result.ok('ok'),
+          input: z.object({}),
+        }),
+      },
+    ];
+
+    expect(() => toCommander(commands)).toThrow(
+      'CLI flag alias --jsonOutput for --format collides on command render'
+    );
+  });
+
+  test('throws when a value alias collides with a boolean negation', () => {
+    const commands: CliCommand[] = [
+      {
+        args: [],
+        execute: async () => await Result.ok('ok'),
+        flags: [
+          {
+            choices: ['fresh', 'stale'],
+            name: 'mode',
+            required: false,
+            type: 'string' as const,
+            valueAliases: [{ name: 'no-cache', value: 'fresh' }],
+            variadic: false,
+          },
+          {
+            name: 'cache',
+            required: false,
+            type: 'boolean' as const,
+            variadic: false,
+          },
+        ],
+        intent: 'read' as const,
+        path: ['render'] as const,
+        trail: trail('render', {
+          blaze: () => Result.ok('ok'),
+          input: z.object({}),
+        }),
+      },
+    ];
+
+    expect(() => toCommander(commands)).toThrow(
+      'CLI flag alias --no-cache for --mode collides on command render'
+    );
+  });
+
   test('routes child commands before parent positional args', async () => {
     const calls: string[] = [];
     const commands = [
@@ -750,6 +855,131 @@ describe('toCommander option wiring', () => {
     const formatOpt = opts.find((entry) => entry.long === '--format');
     expect(formatOpt).toBeDefined();
     expect(formatOpt?.argChoices).toEqual(['json', 'text']);
+  });
+
+  test('value aliases parse as canonical enum flag values', async () => {
+    let received: Record<string, unknown> | undefined;
+    const commands: CliCommand[] = [
+      {
+        args: [],
+        execute: async (
+          _args: Record<string, unknown>,
+          opts: Record<string, unknown>
+        ) => {
+          received = opts;
+          return await Result.ok('ok');
+        },
+        flags: [
+          {
+            choices: ['json', 'text'],
+            name: 'format',
+            required: false,
+            type: 'string' as const,
+            valueAliases: [{ name: 'json', value: 'json' }],
+            variadic: false,
+          },
+        ],
+        intent: 'read' as const,
+        path: ['render'] as const,
+        trail: trail('render', {
+          blaze: () => Result.ok('ok'),
+          input: z.object({}),
+        }),
+      },
+    ];
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'render', '--json']);
+
+    expect(received).toEqual({ format: 'json' });
+  });
+
+  test('canonical enum flags still parse when value aliases exist', async () => {
+    let received: Record<string, unknown> | undefined;
+    const commands: CliCommand[] = [
+      {
+        args: [],
+        execute: async (
+          _args: Record<string, unknown>,
+          opts: Record<string, unknown>
+        ) => {
+          received = opts;
+          return await Result.ok('ok');
+        },
+        flags: [
+          {
+            choices: ['json', 'text'],
+            name: 'format',
+            required: false,
+            type: 'string' as const,
+            valueAliases: [{ name: 'json', value: 'json' }],
+            variadic: false,
+          },
+        ],
+        intent: 'read' as const,
+        path: ['render'] as const,
+        trail: trail('render', {
+          blaze: () => Result.ok('ok'),
+          input: z.object({}),
+        }),
+      },
+    ];
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'render', '--format', 'text']);
+
+    expect(received).toEqual({ format: 'text' });
+  });
+
+  test('value aliases reject simultaneous canonical enum flags', async () => {
+    let received: Record<string, unknown> | undefined;
+    const commands: CliCommand[] = [
+      {
+        args: [],
+        execute: async (
+          _args: Record<string, unknown>,
+          opts: Record<string, unknown>
+        ) => {
+          received = opts;
+          return await Result.ok('ok');
+        },
+        flags: [
+          {
+            choices: ['json', 'text'],
+            name: 'format',
+            required: false,
+            type: 'string' as const,
+            valueAliases: [{ name: 'json', value: 'json' }],
+            variadic: false,
+          },
+        ],
+        intent: 'read' as const,
+        path: ['render'] as const,
+        trail: trail('render', {
+          blaze: () => Result.ok('ok'),
+          input: z.object({}),
+        }),
+      },
+    ];
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    await withMockedProcess(async () => {
+      await expect(
+        program.parseAsync([
+          'node',
+          'test',
+          'render',
+          '--json',
+          '--format',
+          'text',
+        ])
+      ).rejects.toThrow('EXIT');
+    });
+
+    expect(received).toBeUndefined();
   });
 
   test('complex schemas expose structured input options instead of lossy nested flags', () => {

--- a/adapters/commander/src/to-commander.ts
+++ b/adapters/commander/src/to-commander.ts
@@ -4,7 +4,7 @@
 
 import { isTrailsError, mapSurfaceError } from '@ontrails/core';
 import type { CliCommand, CliFlag } from '@ontrails/cli';
-import { validateCliCommands } from '@ontrails/cli';
+import { applyCliFlagValueAliases, validateCliCommands } from '@ontrails/cli';
 import { Command, InvalidArgumentError, Option } from 'commander';
 
 // ---------------------------------------------------------------------------
@@ -67,14 +67,21 @@ const applyOptionModifiers = (opt: Option, flag: CliFlag): void => {
 const buildOptions = (flag: CliFlag): Option[] => {
   const opt = new Option(buildFlagString(flag), flag.description);
   applyOptionModifiers(opt, flag);
+  const valueAliasOptions = (flag.valueAliases ?? []).map(
+    (alias) =>
+      new Option(
+        `--${alias.name}`,
+        alias.description ?? `Shorthand for --${flag.name} ${alias.value}`
+      )
+  );
   if (flag.type === 'boolean') {
     const negation = new Option(
       `--no-${flag.name}`,
       flag.description ? `Negate ${flag.description}` : undefined
     );
-    return [opt, negation];
+    return [opt, negation, ...valueAliasOptions];
   }
-  return [opt];
+  return [opt, ...valueAliasOptions];
 };
 
 /** Add positional args to a Commander subcommand. */
@@ -151,6 +158,33 @@ const getActionTarget = (fallbackTarget: Command, actionArgs: unknown[]) => {
 const getParsedFlags = (command: Command): Record<string, unknown> =>
   command.optsWithGlobals() as Record<string, unknown>;
 
+const getFlagOptionKeys = (flags: readonly CliCommand['flags'][number][]) =>
+  new Set(
+    flags.flatMap((flag) => [
+      flag.name.replaceAll(/-([a-zA-Z0-9])/g, (_, ch: string) =>
+        ch.toUpperCase()
+      ),
+      ...(flag.valueAliases ?? []).map((alias) =>
+        alias.name.replaceAll(/-([a-zA-Z0-9])/g, (_, ch: string) =>
+          ch.toUpperCase()
+        )
+      ),
+    ])
+  );
+
+const getUserSuppliedFlagKeys = (
+  command: Command,
+  flags: readonly CliCommand['flags'][number][]
+): ReadonlySet<string> => {
+  const userSupplied = new Set<string>();
+  for (const key of getFlagOptionKeys(flags)) {
+    if (isUserSuppliedOption(command, key)) {
+      userSupplied.add(key);
+    }
+  }
+  return userSupplied;
+};
+
 const getFallbackParsedFlags = (
   parentTarget: Command,
   target: Command
@@ -164,6 +198,23 @@ const getFallbackParsedFlags = (
     }
   }
   return flags;
+};
+
+const getFallbackUserSuppliedFlagKeys = (
+  parentTarget: Command,
+  target: Command,
+  flags: readonly CliCommand['flags'][number][]
+): ReadonlySet<string> => {
+  const userSupplied = new Set<string>();
+  for (const key of getFlagOptionKeys(flags)) {
+    if (
+      isUserSuppliedOption(parentTarget, key) ||
+      isUserSuppliedOption(target, key)
+    ) {
+      userSupplied.add(key);
+    }
+  }
+  return userSupplied;
 };
 
 /** Handle execution errors with appropriate exit codes. */
@@ -195,6 +246,7 @@ const maybeUseBareChildFallback = (
   readonly command: CliCommand;
   readonly parsedArgs: Record<string, unknown>;
   readonly parsedFlags: Record<string, unknown>;
+  readonly userSuppliedFlagKeys: ReadonlySet<string>;
 } => {
   if (
     !fallback ||
@@ -205,6 +257,7 @@ const maybeUseBareChildFallback = (
       command: cmd,
       parsedArgs: { ...parsedArgs },
       parsedFlags: getParsedFlags(target),
+      userSuppliedFlagKeys: getUserSuppliedFlagKeys(target, cmd.flags),
     };
   }
 
@@ -212,6 +265,11 @@ const maybeUseBareChildFallback = (
     command: fallback.parentCommand,
     parsedArgs: { [fallback.argName]: fallback.argValue },
     parsedFlags: getFallbackParsedFlags(fallback.parentTarget, target),
+    userSuppliedFlagKeys: getFallbackUserSuppliedFlagKeys(
+      fallback.parentTarget,
+      target,
+      fallback.parentCommand.flags
+    ),
   };
 };
 
@@ -236,7 +294,14 @@ const wireAction = (
           }
     );
     try {
-      await action.command.execute(action.parsedArgs, action.parsedFlags);
+      await action.command.execute(
+        action.parsedArgs,
+        applyCliFlagValueAliases(
+          action.command.flags,
+          action.parsedFlags,
+          action.userSuppliedFlagKeys
+        )
+      );
     } catch (error: unknown) {
       handleError(error);
     }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -89,6 +89,19 @@ represented truthfully on the command line. No manual flag definitions.
 Nested objects and arrays of objects are intentionally omitted from automatic
 flag derivation. The CLI prefers fewer flags over dishonest flags.
 
+Enum flags can expose standalone boolean aliases when a surface wants
+pipe-friendly shortcuts without inventing parallel flags. The alias still
+normalizes to the canonical enum field before the trail input is validated:
+
+```typescript
+deriveFlags(z.object({ format: z.enum(['summary', 'json']) }), {
+  format: { aliases: { json: 'json' } },
+});
+```
+
+An adapter such as `@ontrails/commander` will parse `--json` as if the caller
+had passed `--format json`.
+
 ## Positional arguments
 
 When a trail's input schema has exactly one required `string` field with no

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -138,6 +138,27 @@ describe('buildCommands path derivation', () => {
     expect(limitFlag?.required).toBe(false);
   });
 
+  test('passes field value aliases into derived flags', () => {
+    const fields = {
+      format: { aliases: true },
+    } as const;
+    const t = trail('render', {
+      blaze: (input: { format: 'agent-json' | 'markdown' }) =>
+        Result.ok(input.format),
+      fields,
+      input: z.object({
+        format: z.enum(['markdown', 'agent-json']).default('markdown'),
+      }),
+    });
+    const app = makeApp(t);
+    const { flags } = requireCommand(buildCommands(app));
+
+    expect(flags.find((flag) => flag.name === 'format')?.valueAliases).toEqual([
+      { name: 'markdown', value: 'markdown' },
+      { name: 'agent-json', value: 'agent-json' },
+    ]);
+  });
+
   test('adds structured input flags for non-empty object schemas', () => {
     const t = trail('search', {
       blaze: () => Result.ok([]),

--- a/packages/cli/src/__tests__/flags.test.ts
+++ b/packages/cli/src/__tests__/flags.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from 'bun:test';
 import { z } from 'zod';
 
 import {
+  applyCliFlagValueAliases,
+  deriveCliFlagValueAliases,
   cwdPreset,
   deriveFlags,
   dryRunPreset,
@@ -46,6 +48,116 @@ describe('deriveFlags', () => {
       expect(flags).toHaveLength(1);
       expect(flag.type).toBe('boolean');
       expect(flag.required).toBe(true);
+    });
+  });
+
+  describe('value aliases', () => {
+    test('derives enum value aliases from a truthy override', () => {
+      const flags = deriveFlags(
+        z.object({ format: z.enum(['json', 'text']) }),
+        { format: { aliases: true } }
+      );
+      const flag = requireFlag(flags, 'format');
+
+      expect(flag.valueAliases).toEqual([
+        { name: 'json', value: 'json' },
+        { name: 'text', value: 'text' },
+      ]);
+    });
+
+    test('derives explicit enum value aliases', () => {
+      const flags = deriveFlags(
+        z.object({ drafts: z.enum(['include', 'exclude', 'only']) }),
+        {
+          drafts: {
+            aliases: {
+              include: {
+                description: 'Include draft state',
+                name: 'include-drafts',
+              },
+              only: 'only-drafts',
+            },
+          },
+        }
+      );
+      const flag = requireFlag(flags, 'drafts');
+
+      expect(flag.valueAliases).toEqual([
+        {
+          description: 'Include draft state',
+          name: 'include-drafts',
+          value: 'include',
+        },
+        { name: 'only-drafts', value: 'only' },
+      ]);
+    });
+
+    test('rejects aliases for values outside the flag choices', () => {
+      expect(() =>
+        deriveCliFlagValueAliases({
+          aliases: { csv: 'csv' },
+          choices: ['json', 'text'],
+          flagName: 'format',
+        })
+      ).toThrow('targets unknown value "csv"');
+    });
+
+    test('rejects aliases on non-enum fields', () => {
+      expect(() =>
+        deriveFlags(z.object({ verbose: z.boolean() }), {
+          verbose: { aliases: true },
+        })
+      ).toThrow('requires enum choices');
+    });
+
+    test('applies parsed aliases to canonical camelCase flag keys', () => {
+      const flags = deriveFlags(
+        z.object({ outputFormat: z.enum(['json', 'text']) }),
+        { outputFormat: { aliases: { json: 'json-output' } } }
+      );
+
+      expect(
+        applyCliFlagValueAliases(flags, {
+          jsonOutput: true,
+          untouched: 'yes',
+        })
+      ).toEqual({
+        outputFormat: 'json',
+        untouched: 'yes',
+      });
+    });
+
+    test('rejects aliases combined with user supplied canonical flags', () => {
+      const flags = deriveFlags(
+        z.object({ outputFormat: z.enum(['json', 'text']) }),
+        { outputFormat: { aliases: { json: 'json-output' } } }
+      );
+
+      expect(() =>
+        applyCliFlagValueAliases(
+          flags,
+          { jsonOutput: true, outputFormat: 'text' },
+          new Set(['jsonOutput', 'outputFormat'])
+        )
+      ).toThrow(
+        'CLI flag "--output-format" cannot be combined with value alias "--json-output"'
+      );
+    });
+
+    test('rejects multiple aliases for the same canonical flag', () => {
+      const flags = deriveFlags(
+        z.object({ format: z.enum(['json', 'summary', 'text']) }),
+        { format: { aliases: true } }
+      );
+
+      expect(() =>
+        applyCliFlagValueAliases(flags, {
+          json: true,
+          summary: true,
+        })
+      ).toThrow(
+        'CLI flag "--format" received multiple value aliases: --json, --summary'
+      );
     });
   });
 

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -1024,7 +1024,7 @@ const buildFlags = (
   intent: 'read' | 'write' | 'destroy',
   options?: DeriveCliCommandsOptions
 ): CliFlag[] => {
-  let flags = toFlags(fields);
+  let flags = toFlags(fields, t.fields);
   if (supportsStructuredInput(t.input)) {
     flags = mergeStructuredInputFlags(flags);
   }

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -24,6 +24,13 @@ export type AnyTrail = Trail<any, any, any>;
 // CliFlag
 // ---------------------------------------------------------------------------
 
+/** A standalone boolean alias that maps to a canonical enum flag value. */
+export interface CliFlagValueAlias {
+  readonly name: string;
+  readonly value: string;
+  readonly description?: string | undefined;
+}
+
 /** A single CLI flag derived from a Zod schema field or preset. */
 export interface CliFlag {
   readonly name: string;
@@ -33,6 +40,7 @@ export interface CliFlag {
   readonly required: boolean;
   readonly default?: unknown | undefined;
   readonly choices?: string[] | undefined;
+  readonly valueAliases?: readonly CliFlagValueAlias[] | undefined;
   readonly variadic: boolean;
 }
 

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -2,11 +2,11 @@
  * Flag derivation from surface-agnostic fields and reusable flag presets.
  */
 
-import { deriveFields } from '@ontrails/core';
+import { ValidationError, deriveFields } from '@ontrails/core';
 import type { Field, FieldOverride } from '@ontrails/core';
 import type { z } from 'zod';
 
-import type { CliFlag } from './command.js';
+import type { CliFlag, CliFlagValueAlias } from './command.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -16,10 +16,26 @@ import type { CliFlag } from './command.js';
 const toKebab = (str: string): string =>
   str.replaceAll(/[A-Z]/g, (ch) => `-${ch.toLowerCase()}`);
 
+const toCamel = (str: string): string =>
+  str.replaceAll(/-([a-zA-Z0-9])/g, (_, ch: string) => ch.toUpperCase());
+
 interface CliFlagShape {
   readonly choices?: string[] | undefined;
   readonly type: CliFlag['type'];
   readonly variadic: boolean;
+}
+
+interface CliFlagValueAliasSpec {
+  readonly description?: string | undefined;
+  readonly name: string;
+}
+
+export type CliFlagValueAliasDeclaration =
+  | true
+  | Readonly<Record<string, string | CliFlagValueAliasSpec>>;
+
+interface CliFieldOverride extends FieldOverride {
+  readonly aliases?: CliFlagValueAliasDeclaration | undefined;
 }
 
 const fieldTypeToCliFlag: Record<Field['type'], CliFlagShape> = {
@@ -32,16 +48,92 @@ const fieldTypeToCliFlag: Record<Field['type'], CliFlagShape> = {
   'string[]': { type: 'string[]', variadic: true },
 };
 
+const renderFlagName = (flagName: string): string => `--${flagName}`;
+
+const validateAliasName = (flagName: string, aliasName: string): void => {
+  if (aliasName.trim().length === 0) {
+    throw new ValidationError(
+      `CLI flag alias for ${renderFlagName(flagName)} cannot be empty`
+    );
+  }
+};
+
+const validateAliasValue = (
+  flagName: string,
+  value: string,
+  choices: readonly string[]
+): void => {
+  if (!choices.includes(value)) {
+    throw new ValidationError(
+      `CLI flag alias for ${renderFlagName(flagName)} targets unknown value "${value}". Expected one of: ${choices.join(', ')}.`
+    );
+  }
+};
+
+const normalizeAliasSpec = (
+  flagName: string,
+  choices: readonly string[],
+  value: string,
+  spec: string | CliFlagValueAliasSpec
+): CliFlagValueAlias => {
+  validateAliasValue(flagName, value, choices);
+  const alias =
+    typeof spec === 'string' ? { name: spec } : { ...spec, name: spec.name };
+  validateAliasName(flagName, alias.name);
+  return { ...alias, value };
+};
+
+export const deriveCliFlagValueAliases = ({
+  aliases,
+  choices,
+  flagName,
+}: {
+  readonly aliases?: CliFlagValueAliasDeclaration | undefined;
+  readonly choices: readonly string[];
+  readonly flagName: string;
+}): readonly CliFlagValueAlias[] | undefined => {
+  if (aliases === undefined) {
+    return undefined;
+  }
+
+  if (aliases === true) {
+    return choices.map((value) =>
+      normalizeAliasSpec(flagName, choices, value, value)
+    );
+  }
+
+  return Object.entries(aliases).map(([value, spec]) =>
+    normalizeAliasSpec(flagName, choices, value, spec)
+  );
+};
+
 /** Convert a derived field into a CLI flag descriptor. */
-const toCliFlag = (field: Field): CliFlag => {
+const toCliFlag = (
+  field: Field,
+  override?: CliFieldOverride | undefined
+): CliFlag => {
   const shape = fieldTypeToCliFlag[field.type];
+  const choices = field.options?.map((option) => option.value);
+  if (override?.aliases !== undefined && choices === undefined) {
+    throw new ValidationError(
+      `CLI flag alias for ${renderFlagName(toKebab(field.name))} requires enum choices`
+    );
+  }
   return {
-    choices: field.options?.map((option) => option.value),
+    choices,
     default: field.default,
     description: field.label,
     name: toKebab(field.name),
     required: field.required,
     type: shape.type,
+    valueAliases:
+      choices === undefined
+        ? undefined
+        : deriveCliFlagValueAliases({
+            aliases: override?.aliases,
+            choices,
+            flagName: toKebab(field.name),
+          }),
     variadic: shape.variadic,
   };
 };
@@ -51,14 +143,66 @@ const toCliFlag = (field: Field): CliFlag => {
 // ---------------------------------------------------------------------------
 
 /** Convert derived fields to CLI flags. */
-export const toFlags = (fields: readonly Field[]): CliFlag[] =>
-  fields.map(toCliFlag);
+export const toFlags = (
+  fields: readonly Field[],
+  overrides?: Readonly<Record<string, CliFieldOverride>> | undefined
+): CliFlag[] =>
+  fields.map((field) => toCliFlag(field, overrides?.[field.name]));
 
 /** Derive CLI flags from a Zod input schema. */
 export const deriveFlags = (
   schema: z.ZodType,
-  overrides?: Readonly<Record<string, FieldOverride>> | undefined
-): CliFlag[] => toFlags(deriveFields(schema, overrides));
+  overrides?: Readonly<Record<string, CliFieldOverride>> | undefined
+): CliFlag[] => toFlags(deriveFields(schema, overrides), overrides);
+
+export const applyCliFlagValueAliases = (
+  flags: readonly CliFlag[],
+  parsedFlags: Readonly<Record<string, unknown>>,
+  userSuppliedFlagKeys?: ReadonlySet<string> | undefined
+): Record<string, unknown> => {
+  const aliasKeys = new Set(
+    flags.flatMap((flag) =>
+      (flag.valueAliases ?? []).map((alias) => toCamel(alias.name))
+    )
+  );
+  const normalized = Object.fromEntries(
+    Object.entries(parsedFlags).filter(([key]) => !aliasKeys.has(key))
+  );
+
+  for (const flag of flags) {
+    const aliases = flag.valueAliases ?? [];
+    const activeAliases = aliases.filter(
+      (alias) => parsedFlags[toCamel(alias.name)] === true
+    );
+    if (activeAliases.length === 0) {
+      continue;
+    }
+    if (activeAliases.length > 1) {
+      throw new ValidationError(
+        `CLI flag "--${flag.name}" received multiple value aliases: ${activeAliases.map((alias) => `--${alias.name}`).join(', ')}`
+      );
+    }
+
+    const canonicalKey = toCamel(flag.name);
+    const canonicalWasSupplied =
+      userSuppliedFlagKeys?.has(canonicalKey) ??
+      (normalized[canonicalKey] !== undefined &&
+        normalized[canonicalKey] !== flag.default);
+    const [activeAlias] = activeAliases;
+    if (!activeAlias) {
+      continue;
+    }
+    if (canonicalWasSupplied) {
+      throw new ValidationError(
+        `CLI flag "--${flag.name}" cannot be combined with value alias "--${activeAlias.name}"`
+      );
+    }
+
+    normalized[canonicalKey] = activeAlias.value;
+  }
+
+  return normalized;
+};
 
 // ---------------------------------------------------------------------------
 // Presets

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,11 @@
 // Command model
-export type { AnyTrail, CliCommand, CliFlag, CliArg } from './command.js';
+export type {
+  AnyTrail,
+  CliCommand,
+  CliFlag,
+  CliArg,
+  CliFlagValueAlias,
+} from './command.js';
 
 // Build
 export { deriveCliCommands } from './build.js';
@@ -13,6 +19,8 @@ export { validateCliCommands } from './validate.js';
 
 // Flags
 export {
+  applyCliFlagValueAliases,
+  deriveCliFlagValueAliases,
   deriveFlags,
   outputModePreset,
   cwdPreset,
@@ -23,6 +31,7 @@ export {
   tracePreset,
   watchPreset,
 } from './flags.js';
+export type { CliFlagValueAliasDeclaration } from './flags.js';
 
 // Output
 export { output, deriveOutputMode } from './output.js';

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -1,10 +1,18 @@
 import { ValidationError } from '@ontrails/core';
 
-import type { CliCommand } from './command.js';
+import type { CliCommand, CliFlag } from './command.js';
 
 const renderPath = (path: readonly string[]): string => path.join(' ');
 
 const keyPath = (path: readonly string[]): string => path.join('\0');
+
+const toOptionKey = (name: string): string =>
+  name.replaceAll(/-([a-zA-Z0-9])/g, (_, ch: string) => ch.toUpperCase());
+
+interface SeenOptionNames {
+  readonly keys: Set<string>;
+  readonly names: Set<string>;
+}
 
 const validateCommandPath = (command: CliCommand): void => {
   if (command.path.length === 0) {
@@ -34,9 +42,101 @@ const validateUniquePaths = (commands: readonly CliCommand[]): void => {
   }
 };
 
+const validateFlagAlias = ({
+  aliasName,
+  command,
+  flag,
+  seen,
+}: {
+  readonly aliasName: string;
+  readonly command: CliCommand;
+  readonly flag: CliFlag;
+  readonly seen: SeenOptionNames;
+}): void => {
+  if (aliasName.trim().length === 0) {
+    throw new ValidationError(
+      `CLI flag alias for --${flag.name} on command ${renderPath(command.path)} cannot be empty`
+    );
+  }
+  if (seen.names.has(aliasName) || seen.keys.has(toOptionKey(aliasName))) {
+    throw new ValidationError(
+      `CLI flag alias --${aliasName} for --${flag.name} collides on command ${renderPath(command.path)}`
+    );
+  }
+};
+
+const validateFlagValueAliases = (
+  command: CliCommand,
+  flag: CliFlag,
+  seen: SeenOptionNames
+): void => {
+  const aliases = flag.valueAliases ?? [];
+  if (aliases.length === 0) {
+    return;
+  }
+
+  if (flag.choices === undefined || flag.choices.length === 0) {
+    throw new ValidationError(
+      `CLI flag --${flag.name} on command ${renderPath(command.path)} cannot define value aliases without choices`
+    );
+  }
+
+  for (const alias of aliases) {
+    validateFlagAlias({
+      aliasName: alias.name,
+      command,
+      flag,
+      seen,
+    });
+    if (!flag.choices.includes(alias.value)) {
+      throw new ValidationError(
+        `CLI flag alias --${alias.name} for --${flag.name} targets unknown value "${alias.value}" on command ${renderPath(command.path)}`
+      );
+    }
+    seen.names.add(alias.name);
+    seen.keys.add(toOptionKey(alias.name));
+  }
+};
+
+const addSeenFlagOption = (
+  command: CliCommand,
+  flag: CliFlag,
+  seen: SeenOptionNames,
+  name = flag.name
+): void => {
+  if (seen.names.has(name) || seen.keys.has(toOptionKey(name))) {
+    throw new ValidationError(
+      `Duplicate CLI flag --${flag.name} on command ${renderPath(command.path)}`
+    );
+  }
+  seen.names.add(name);
+  seen.keys.add(toOptionKey(name));
+};
+
+const validateCommandFlags = (command: CliCommand): void => {
+  const seen: SeenOptionNames = { keys: new Set(), names: new Set() };
+
+  for (const flag of command.flags) {
+    if (flag.name.trim().length === 0) {
+      throw new ValidationError(
+        `CLI flag name on command ${renderPath(command.path)} cannot be empty`
+      );
+    }
+    addSeenFlagOption(command, flag, seen);
+    if (flag.type === 'boolean') {
+      addSeenFlagOption(command, flag, seen, `no-${flag.name}`);
+    }
+  }
+
+  for (const flag of command.flags) {
+    validateFlagValueAliases(command, flag, seen);
+  }
+};
+
 export const validateCliCommands = (commands: readonly CliCommand[]): void => {
   for (const command of commands) {
     validateCommandPath(command);
+    validateCommandFlags(command);
   }
 
   validateUniquePaths(commands);

--- a/packages/warden/src/__tests__/command.test.ts
+++ b/packages/warden/src/__tests__/command.test.ts
@@ -10,7 +10,7 @@ const makeTempDir = (): string =>
   mkdtempSync(join(tmpdir(), 'warden-command-'));
 
 describe('parseWardenCommandArgs', () => {
-  test('expands presets and local aliases without @ontrails/cli alias generalization', () => {
+  test('expands presets and generic CLI value aliases', () => {
     const parsed = parseWardenCommandArgs([
       '--ci',
       '--json',
@@ -33,6 +33,32 @@ describe('parseWardenCommandArgs', () => {
       noLockMutation: true,
     });
     expect(parsed.diagnostics).toEqual([]);
+  });
+
+  test('accepts canonical enum flag values alongside value aliases', () => {
+    const parsed = parseWardenCommandArgs([
+      '--format',
+      'github',
+      '--lock',
+      'refresh',
+      '--drafts',
+      'only',
+    ]);
+
+    expect(parsed.cli).toMatchObject({
+      drafts: 'only',
+      format: 'github',
+      lock: 'refresh',
+    });
+    expect(parsed.diagnostics).toEqual([]);
+  });
+
+  test('reports invalid canonical enum flag values', () => {
+    const parsed = parseWardenCommandArgs(['--format', 'xml']);
+
+    expect(parsed.diagnostics[0]?.message).toContain(
+      'Invalid --format value "xml". Expected one of: summary, github, json.'
+    );
   });
 });
 

--- a/packages/warden/src/command.ts
+++ b/packages/warden/src/command.ts
@@ -3,7 +3,15 @@ import { isAbsolute, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 
-import { findAppModule, findAppModuleCandidates } from '@ontrails/cli';
+import {
+  deriveCliFlagValueAliases,
+  findAppModule,
+  findAppModuleCandidates,
+} from '@ontrails/cli';
+import type {
+  CliFlagValueAlias,
+  CliFlagValueAliasDeclaration,
+} from '@ontrails/cli';
 import type { Topo } from '@ontrails/core';
 import { AmbiguousError, NotFoundError } from '@ontrails/core';
 
@@ -148,23 +156,73 @@ interface CommandParserState {
   rootDir?: string | undefined;
 }
 
-const formatAliases: Readonly<Record<string, WardenFormat | undefined>> = {
-  github: 'github',
-  json: 'json',
-  summary: 'summary',
-};
+type AliasConfigKey = 'drafts' | 'format' | 'lock';
 
-const lockAliases: Readonly<Record<string, WardenLockMode | undefined>> = {
-  cached: 'cached',
-  refresh: 'refresh',
-  'skip-lock': 'skip',
-};
+interface WardenAliasSpec {
+  readonly aliases: CliFlagValueAliasDeclaration;
+  readonly choices: readonly string[];
+  readonly configKey: AliasConfigKey;
+  readonly flagName: string;
+}
 
-const draftAliases: Readonly<Record<string, WardenDraftsMode | undefined>> = {
-  'exclude-drafts': 'exclude',
-  'include-drafts': 'include',
-  'only-drafts': 'only',
-};
+interface WardenValueAliasTarget {
+  readonly alias: CliFlagValueAlias;
+  readonly configKey: AliasConfigKey;
+}
+
+const wardenAliasSpecs = [
+  {
+    aliases: true,
+    choices: wardenFormatValues,
+    configKey: 'format',
+    flagName: 'format',
+  },
+  {
+    aliases: {
+      cached: 'cached',
+      refresh: 'refresh',
+      skip: 'skip-lock',
+    },
+    choices: wardenLockValues,
+    configKey: 'lock',
+    flagName: 'lock',
+  },
+  {
+    aliases: {
+      exclude: 'exclude-drafts',
+      include: 'include-drafts',
+      only: 'only-drafts',
+    },
+    choices: wardenDraftsValues,
+    configKey: 'drafts',
+    flagName: 'drafts',
+  },
+] satisfies readonly WardenAliasSpec[];
+
+const wardenValueAliasTargets: readonly WardenValueAliasTarget[] =
+  wardenAliasSpecs.flatMap((spec) =>
+    (
+      deriveCliFlagValueAliases({
+        aliases: spec.aliases,
+        choices: spec.choices,
+        flagName: spec.flagName,
+      }) ?? []
+    ).map((alias) => ({
+      alias,
+      configKey: spec.configKey,
+    }))
+  );
+
+const wardenValueAliasTargetByName = new Map(
+  wardenValueAliasTargets.map((target) => [target.alias.name, target])
+);
+
+const valueAliasParseOptions = Object.fromEntries(
+  wardenValueAliasTargets.map((target) => [
+    target.alias.name,
+    { type: 'boolean' as const },
+  ])
+);
 
 const parseTokens = (
   args: readonly string[]
@@ -175,26 +233,18 @@ const parseTokens = (
       args: [...args],
       options: {
         apps: { multiple: true, short: 'a', type: 'string' },
-        cached: { type: 'boolean' },
         ci: { type: 'boolean' },
         'config-path': { type: 'string' },
         depth: { type: 'string' },
         drafts: { type: 'string' },
-        'exclude-drafts': { type: 'boolean' },
         'fail-on': { type: 'string' },
         format: { type: 'string' },
-        github: { type: 'boolean' },
-        'include-drafts': { type: 'boolean' },
-        json: { type: 'boolean' },
         lock: { type: 'string' },
         'no-lock-mutation': { type: 'boolean' },
-        'only-drafts': { type: 'boolean' },
         'pre-push': { type: 'boolean' },
-        refresh: { type: 'boolean' },
         'root-dir': { type: 'string' },
-        'skip-lock': { type: 'boolean' },
         strict: { type: 'boolean' },
-        summary: { type: 'boolean' },
+        ...valueAliasParseOptions,
       },
       strict: true,
       tokens: true,
@@ -237,25 +287,18 @@ const applyPresetToken = (
 };
 
 const applyAliasOption = (name: string, state: CommandParserState): boolean => {
-  const format = formatAliases[name];
-  if (format !== undefined) {
-    state.cli.format = format;
-    return true;
+  const target = wardenValueAliasTargetByName.get(name);
+  if (target === undefined) {
+    return false;
   }
-
-  const lock = lockAliases[name];
-  if (lock !== undefined) {
-    state.cli.lock = lock;
-    return true;
+  if (target.configKey === 'format') {
+    state.cli.format = target.alias.value as WardenFormat;
+  } else if (target.configKey === 'lock') {
+    state.cli.lock = target.alias.value as WardenLockMode;
+  } else {
+    state.cli.drafts = target.alias.value as WardenDraftsMode;
   }
-
-  const drafts = draftAliases[name];
-  if (drafts !== undefined) {
-    state.cli.drafts = drafts;
-    return true;
-  }
-
-  return false;
+  return true;
 };
 
 const applyEnumOption = (


### PR DESCRIPTION
## Context

This branch is stacked on #456 and closes TRL-686.

Warden had local shorthand handling for enum-like command values. The stack needs Warden guide aliases too, so the alias pattern now belongs in the generic `@ontrails/cli` projection and adapter layer rather than in Warden-specific code.

## What changed

- Added generic enum value-alias metadata to `CliFlag`.
- Derived aliases from trail field overrides and normalized parsed aliases back onto canonical camelCase input keys.
- Updated the Commander adapter to expose standalone alias options and normalize them before execution.
- Tightened validation for duplicate flags, raw alias collisions, normalized-key collisions, boolean negation collisions, invalid alias targets, and aliases on non-enum fields.
- Migrated Warden command aliases to the generic CLI alias path.
- Moved the generic `toFlags(fields, t.fields)` projection hookup onto this branch so downstream guide commands can declare aliases without owning CLI package changes.

## How to test

- `bun test packages/cli/src/__tests__/flags.test.ts adapters/commander/src/__tests__/to-commander.test.ts packages/warden/src/__tests__/command.test.ts`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd adapters/commander typecheck`
- `bun run --cwd packages/warden typecheck`
- Final stack-tip gates also passed: `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.

## Risks/rollout notes

The new alias machinery is generic and validation is intentionally strict. Existing canonical flag values keep working; invalid alias declarations now fail earlier instead of producing ambiguous command surfaces.

## Release

Changeset: `.changeset/cli-value-aliases.md` for `@ontrails/cli`, `@ontrails/commander`, and `@ontrails/warden`.

Closes: TRL-686
