### PR TITLE
feat: require public output schemas

### DIFF
--- a/.changeset/warden-public-output-schema.md
+++ b/.changeset/warden-public-output-schema.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": minor
+---
+
+Add a Warden topo-aware rule that requires public MCP/HTTP surface-eligible trails to declare output schemas.

--- a/packages/warden/src/__tests__/public-output-schema.test.ts
+++ b/packages/warden/src/__tests__/public-output-schema.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result, signal, topo, trail } from '@ontrails/core';
+import type { AnyTrail, TrailVisibility } from '@ontrails/core';
+import { z } from 'zod';
+
+import { runWarden } from '../cli.js';
+import { publicOutputSchema } from '../rules/public-output-schema.js';
+
+const emptyInput = z.object({});
+const outputSchema = z.object({ ok: z.boolean() });
+const changed = signal('entity.changed', {
+  payload: z.object({ id: z.string() }),
+});
+
+const buildTrail = (
+  id: string,
+  options: {
+    readonly meta?: Readonly<Record<string, unknown>>;
+    readonly on?: readonly (typeof changed)[];
+    readonly output?: typeof outputSchema;
+    readonly visibility?: TrailVisibility;
+  } = {}
+) =>
+  trail(id, {
+    blaze: () => Result.ok({ ok: true }),
+    input: emptyInput,
+    ...options,
+  });
+
+const buildTopo = (...trails: readonly AnyTrail[]) =>
+  topo(
+    'public-output-schema-fixture',
+    Object.fromEntries(
+      trails.map((trailValue, index) => [`trail${index}`, trailValue])
+    )
+  );
+
+const check = (...trails: readonly AnyTrail[]) =>
+  publicOutputSchema.checkTopo(buildTopo(...trails));
+
+describe('public-output-schema', () => {
+  test('flags public surface-eligible trails without output schemas', () => {
+    const diagnostics = check(buildTrail('report.read'));
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      filePath: '<topo>',
+      rule: 'public-output-schema',
+      severity: 'error',
+    });
+    expect(diagnostics[0]?.message).toContain(
+      'Trail "report.read" is visible to public MCP/HTTP surface projection'
+    );
+  });
+
+  test('allows public surface-eligible trails with output schemas', () => {
+    const diagnostics = check(
+      buildTrail('report.read', { output: outputSchema })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('ignores internal trails without output schemas', () => {
+    const diagnostics = check(
+      buildTrail('report.internal', { visibility: 'internal' })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('ignores legacy meta.internal trails without output schemas', () => {
+    const diagnostics = check(
+      buildTrail('report.legacyInternal', { meta: { internal: true } })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('ignores activation-source consumers because they are not direct surface routes', () => {
+    const diagnostics = check(
+      buildTrail('report.index', {
+        on: [changed],
+      })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('runWarden includes public output schema diagnostics when topo is supplied', async () => {
+    const report = await runWarden({
+      rootDir: process.cwd(),
+      topo: buildTopo(buildTrail('report.read')),
+    });
+
+    expect(
+      report.diagnostics.some(
+        (diagnostic) => diagnostic.rule === 'public-output-schema'
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -8,8 +8,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 47 rule trails', () => {
-    expect(wardenTopo.count).toBe(47);
+  test('contains all 48 rule trails', () => {
+    expect(wardenTopo.count).toBe(48);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -160,6 +160,7 @@ export {
   preferSchemaInferenceTrail,
   projectAwareRuleInput,
   publicInternalDeepImportsTrail,
+  publicOutputSchemaTrail,
   publicUnionOutputDiscriminantsTrail,
   readIntentFiresTrail,
   referenceExistsTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -29,6 +29,7 @@ import { ownerProjectionParity } from './owner-projection-parity.js';
 import { permitGovernance } from './permit-governance.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
 import { publicInternalDeepImports } from './public-internal-deep-imports.js';
+import { publicOutputSchema } from './public-output-schema.js';
 import { publicUnionOutputDiscriminants } from './public-union-output-discriminants.js';
 import { readIntentFires } from './read-intent-fires.js';
 import { referenceExists } from './reference-exists.js';
@@ -106,6 +107,7 @@ export { ownerProjectionParity } from './owner-projection-parity.js';
 export { permitGovernance } from './permit-governance.js';
 export { preferSchemaInference } from './prefer-schema-inference.js';
 export { publicInternalDeepImports } from './public-internal-deep-imports.js';
+export { publicOutputSchema } from './public-output-schema.js';
 export { publicUnionOutputDiscriminants } from './public-union-output-discriminants.js';
 export { readIntentFires } from './read-intent-fires.js';
 export { referenceExists } from './reference-exists.js';
@@ -184,6 +186,7 @@ export const wardenTopoRules: ReadonlyMap<string, TopoAwareWardenRule> =
     [activationOrphan.name, activationOrphan],
     [incompleteAccessorForStandardOp.name, incompleteAccessorForStandardOp],
     [permitGovernance.name, permitGovernance],
+    [publicOutputSchema.name, publicOutputSchema],
     [publicUnionOutputDiscriminants.name, publicUnionOutputDiscriminants],
     [scheduledDestroyIntent.name, scheduledDestroyIntent],
     [signalGraphCoaching.name, signalGraphCoaching],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -77,6 +77,7 @@ const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'on-references-exist': 'signals',
   'orphaned-signal': 'signals',
   'permit-governance': 'permits',
+  'public-output-schema': 'results',
   'read-intent-fires': 'signals',
   'resolved-import-boundary': 'composition',
   'resource-declarations': 'resources',
@@ -322,6 +323,21 @@ const builtinWardenRuleMetadataInput = {
     lifecycle: { state: 'durable' },
     scope: 'internal',
     tier: 'project-static',
+  },
+  'public-output-schema': {
+    ...durableExternal,
+    guidance: {
+      docs: [trailContractDocs, wardenDocs],
+      relatedRules: ['public-union-output-discriminants'],
+      steps: [
+        'Add an explicit output schema to public trails that can be projected onto MCP or HTTP surfaces.',
+        'If the trail is composition-only, mark it visibility: "internal" instead of exposing it by default.',
+      ],
+      summary:
+        'Make public surface result contracts explicit before MCP/HTTP projection.',
+    },
+    invariant: 'Public MCP/HTTP surface trails declare output schemas.',
+    tier: 'topo-aware',
   },
   'public-union-output-discriminants': {
     ...durableExternal,

--- a/packages/warden/src/rules/public-output-schema.ts
+++ b/packages/warden/src/rules/public-output-schema.ts
@@ -1,0 +1,29 @@
+import { filterSurfaceTrails } from '@ontrails/core';
+import type { AnyTrail, Topo } from '@ontrails/core';
+
+import type { TopoAwareWardenRule, WardenDiagnostic } from './types.js';
+
+const RULE_NAME = 'public-output-schema';
+const TOPO_FILE = '<topo>';
+
+const diagnosticForTrail = (trail: AnyTrail): WardenDiagnostic => ({
+  filePath: TOPO_FILE,
+  line: 1,
+  message:
+    `Trail "${trail.id}" is visible to public MCP/HTTP surface projection but does not declare an output schema. ` +
+    'Add an explicit output schema, or mark the trail visibility as internal if it is composition-only.',
+  rule: RULE_NAME,
+  severity: 'error',
+});
+
+export const publicOutputSchema: TopoAwareWardenRule = {
+  checkTopo(topo: Topo): readonly WardenDiagnostic[] {
+    return filterSurfaceTrails(topo.list()).flatMap((trail) =>
+      trail.output === undefined ? [diagnosticForTrail(trail)] : []
+    );
+  },
+  description:
+    'Require public MCP/HTTP surface-eligible trails to declare output schemas.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -37,6 +37,7 @@ import { ownerProjectionParity } from './owner-projection-parity.js';
 import { permitGovernance } from './permit-governance.js';
 import { preferSchemaInference } from './prefer-schema-inference.js';
 import { publicInternalDeepImports } from './public-internal-deep-imports.js';
+import { publicOutputSchema } from './public-output-schema.js';
 import { publicUnionOutputDiscriminants } from './public-union-output-discriminants.js';
 import { readIntentFires } from './read-intent-fires.js';
 import { referenceExists } from './reference-exists.js';
@@ -91,6 +92,7 @@ export const registeredRuleNames: readonly string[] = [
   permitGovernance.name,
   preferSchemaInference.name,
   publicInternalDeepImports.name,
+  publicOutputSchema.name,
   publicUnionOutputDiscriminants.name,
   readIntentFires.name,
   referenceExists.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -29,6 +29,7 @@ export { ownerProjectionParityTrail } from './owner-projection-parity.trail.js';
 export { permitGovernanceTrail } from './permit-governance.trail.js';
 export { preferSchemaInferenceTrail } from './prefer-schema-inference.trail.js';
 export { publicInternalDeepImportsTrail } from './public-internal-deep-imports.trail.js';
+export { publicOutputSchemaTrail } from './public-output-schema.trail.js';
 export { publicUnionOutputDiscriminantsTrail } from './public-union-output-discriminants.trail.js';
 export { readIntentFiresTrail } from './read-intent-fires.trail.js';
 export { referenceExistsTrail } from './reference-exists.trail.js';

--- a/packages/warden/src/trails/public-output-schema.trail.ts
+++ b/packages/warden/src/trails/public-output-schema.trail.ts
@@ -1,0 +1,55 @@
+import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { publicOutputSchema } from '../rules/public-output-schema.js';
+import { wrapTopoRule } from './wrap-rule.js';
+
+const cleanTrail = trail('report.read', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+});
+
+const cleanTopo = topo('public-output-schema-clean', {
+  cleanTrail,
+});
+
+const missingOutputTrail = trail('report.missing', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+});
+
+const missingOutputTopo = topo('public-output-schema-missing', {
+  missingOutputTrail,
+});
+
+export const publicOutputSchemaTrail = wrapTopoRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        topo: cleanTopo,
+      },
+      name: 'Public surface trails declare output schemas',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: '<topo>',
+            line: 1,
+            message:
+              'Trail "report.missing" is visible to public MCP/HTTP surface projection but does not declare an output schema. Add an explicit output schema, or mark the trail visibility as internal if it is composition-only.',
+            rule: 'public-output-schema',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        topo: missingOutputTopo,
+      },
+      name: 'Public surface trails without output schemas are flagged',
+    },
+  ],
+  rule: publicOutputSchema,
+});


### PR DESCRIPTION
## Context

This branch is stacked on #457 and closes TRL-688.

Public MCP and HTTP surfaces need explicit result contracts. This branch gives Warden topo-aware coverage for public trails that can be projected to those surfaces but do not declare an output schema.

## What changed

- Added the topo-aware `public-output-schema` Warden rule.
- Reused core `filterSurfaceTrails()` semantics so internal, legacy internal, and activation-consumer trails are not treated as direct public surface routes.
- Added structured Warden metadata/guidance and a wrapped `warden.rule.public-output-schema` trail.
- Exported the new rule trail and updated Warden registry-name coverage.
- Added focused tests for the rule, metadata, export symmetry, and rule-trail contract behavior.

## How to test

- `bun test packages/warden/src/__tests__/public-output-schema.test.ts packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/trails.test.ts`
- `bun test packages/warden/src/__tests__/warden-export-symmetry.test.ts packages/warden/src/__tests__/trails.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run check`
- Final stack-tip gates also passed: `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run publish:check`, `git diff --check`.

## Risks/rollout notes

This is a new Warden error for public MCP/HTTP-eligible trails. The current repo remains green; downstream projects may need to add output schemas or mark composition-only trails internal.

## Release

Changeset: `.changeset/warden-public-output-schema.md` for `@ontrails/warden`.

Closes: TRL-688
