### PR TITLE
feat: add resource unmockable marker

### DIFF
--- a/.changeset/resource-unmockable-marker.md
+++ b/.changeset/resource-unmockable-marker.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/core": minor
+"@ontrails/testing": minor
+---
+
+Add an explicit `unmockable: { reason }` resource marker and have testing auto-mock resolution skip intentionally unmockable resources.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -117,6 +117,22 @@ import { graph } from '../app';
 testAll(graph);
 ```
 
+If a resource cannot honestly provide a mock, mark that explicitly instead of
+leaving the gap ambiguous:
+
+```typescript
+const hsm = resource('hsm.signer', {
+  create: () => connectToHsm(),
+  unmockable: {
+    reason: 'Signing depends on a hardware-backed key that has no faithful in-memory double.',
+  },
+});
+```
+
+Testing helpers skip `unmockable` resources during auto-mock resolution. Trails
+that need them still require explicit resource overrides when their examples or
+contracts execute.
+
 Override explicitly when you need specific behavior:
 
 ```typescript

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,6 +62,7 @@ testAll(graph);
 When trails declare resources, the testing helpers respect them in two ways:
 
 - Resources with a `mock` factory auto-resolve during `testAll`, `testExamples`, and `testContracts`.
+- Resources marked `unmockable: { reason }` are intentionally skipped during auto-mock resolution; provide an explicit override for examples or contracts that need them.
 - Explicit `resources` overrides let you inject a specific test double when you need one.
 
 ```typescript

--- a/packages/core/src/__tests__/resource.test.ts
+++ b/packages/core/src/__tests__/resource.test.ts
@@ -86,6 +86,17 @@ describe('resource types', () => {
     expect(disposedValue).toBe(3);
   });
 
+  test('ResourceSpec can document intentionally unmockable resources', () => {
+    const spec: ResourceSpec<number> = {
+      create: () => Result.ok(1),
+      unmockable: {
+        reason: 'Requires a hardware security module in integration tests.',
+      },
+    };
+
+    expect(spec.unmockable?.reason).toContain('hardware security module');
+  });
+
   test('ResourceSpec create can be async', async () => {
     const spec: ResourceSpec<number> = {
       create: async () => {
@@ -131,6 +142,31 @@ describe('resource()', () => {
   test('rejects resource ids containing a scope separator', () => {
     expect(() => resource('billing:primary', counterResourceSpec)).toThrow(
       'Resource "billing:primary" is invalid because resource ids may not contain ":"'
+    );
+  });
+
+  test('rejects unmockable resources without a reason', () => {
+    expect(() =>
+      resource('db.unmockable.empty', {
+        create: () => Result.ok({ ok: true }),
+        unmockable: { reason: '   ' },
+      })
+    ).toThrow(
+      'Resource "db.unmockable.empty" is invalid because unmockable.reason must not be empty'
+    );
+  });
+
+  test('rejects resources that define both mock and unmockable', () => {
+    expect(() =>
+      resource('db.unmockable.conflict', {
+        create: () => Result.ok({ ok: true }),
+        mock: () => ({ ok: true }),
+        unmockable: {
+          reason: 'The real dependency has no faithful local double.',
+        },
+      })
+    ).toThrow(
+      'Resource "db.unmockable.conflict" cannot define both mock and unmockable'
     );
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,6 +118,7 @@ export type {
   ResourceContext,
   ResourceOverrideMap,
   ResourceSpec,
+  ResourceUnmockable,
 } from './resource.js';
 
 // Trail

--- a/packages/core/src/resource.ts
+++ b/packages/core/src/resource.ts
@@ -18,6 +18,11 @@ export type ResourceContext<C = unknown> = Pick<
   readonly config: C;
 };
 
+/** Explicit marker for resources that intentionally cannot provide a mock. */
+export interface ResourceUnmockable {
+  readonly reason: string;
+}
+
 /**
  * Everything needed to describe a resource before a factory is introduced.
  *
@@ -41,6 +46,8 @@ export interface ResourceSpec<T, C = unknown> {
     | undefined;
   /** Optional test factory used by higher-level helpers. */
   readonly mock?: (() => T | Promise<T>) | undefined;
+  /** Document why this resource intentionally cannot provide a test mock. */
+  readonly unmockable?: ResourceUnmockable | undefined;
   /** Human-readable description. */
   readonly description?: string | undefined;
   /** Arbitrary meta for tooling and filtering. */
@@ -112,6 +119,19 @@ export const resource = <T>(id: string, spec: ResourceSpec<T>): Resource<T> =>
     if (id.includes(':')) {
       throw new InternalError(
         `Resource "${id}" is invalid because resource ids may not contain ":"`
+      );
+    }
+    if (spec.mock !== undefined && spec.unmockable !== undefined) {
+      throw new InternalError(
+        `Resource "${id}" cannot define both mock and unmockable`
+      );
+    }
+    if (
+      spec.unmockable !== undefined &&
+      spec.unmockable.reason.trim().length === 0
+    ) {
+      throw new InternalError(
+        `Resource "${id}" is invalid because unmockable.reason must not be empty`
       );
     }
 

--- a/packages/testing/src/__tests__/context.test.ts
+++ b/packages/testing/src/__tests__/context.test.ts
@@ -163,8 +163,21 @@ describe('createMockResources', () => {
     const plain = resource(`resource.plain.${Bun.randomUUIDv7()}`, {
       create: () => Result.ok({ source: 'factory' }),
     });
-    const app = topo('plain-app', { plain } as Record<string, unknown>);
+    const app = topo('plain-app', { plain });
 
+    expect(await createMockResources(app)).toEqual({});
+  });
+
+  test('skips resources marked intentionally unmockable', async () => {
+    const unmockable = resource(`resource.unmockable.${Bun.randomUUIDv7()}`, {
+      create: () => Result.ok({ source: 'factory' }),
+      unmockable: {
+        reason: 'Requires a live external service for integration tests.',
+      },
+    });
+    const app = topo('unmockable-app', { unmockable });
+
+    expect(unmockable.unmockable?.reason).toContain('external service');
     expect(await createMockResources(app)).toEqual({});
   });
 });

--- a/packages/testing/src/context.ts
+++ b/packages/testing/src/context.ts
@@ -184,6 +184,9 @@ export const mergeResourceOverrides = (
 const buildMockResources = async (app: Topo): Promise<ResourceOverrideMap> => {
   const resources: Record<string, unknown> = {};
   for (const declaredResource of app.listResources()) {
+    if (declaredResource.unmockable !== undefined) {
+      continue;
+    }
     if (!declaredResource.mock) {
       continue;
     }


### PR DESCRIPTION
## Context

This branch is stacked on #458 and closes TRL-685.

Before hard mock enforcement, Trails needs a typed way for resource authors to say a resource cannot provide a meaningful mock and explain why.

## What changed

- Added `unmockable: { reason: string }` to the resource definition contract.
- Validated that `unmockable.reason` is non-empty.
- Rejected resource definitions that specify both `mock` and `unmockable`.
- Updated `@ontrails/testing` auto-mock resolution to skip explicitly unmockable resources.
- Documented the opt-out marker and the need for explicit overrides when tests/examples require those resources.

## How to test

- `bun test packages/core/src/__tests__/resource.test.ts packages/testing/src/__tests__/context.test.ts packages/testing/src/__tests__/all.test.ts`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/testing typecheck`
- `bun run docs:snippets`
- Final stack-tip gates also passed: `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.

## Risks/rollout notes

This is additive for resource authors, but validation now rejects conflicting `mock` plus `unmockable` definitions and empty reasons. That is intentional because the marker should be explicit and auditable.

## Release

Changeset: `.changeset/resource-unmockable-marker.md` for `@ontrails/core` and `@ontrails/testing`.

Closes: TRL-685
