### PR TITLE
feat: prefer static resource accessors

### DIFF
--- a/.changeset/warden-static-resource-accessor.md
+++ b/.changeset/warden-static-resource-accessor.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": minor
+---
+
+Add an advisory Warden rule that prefers static resource helpers over dynamic context resource lookups when the resource definition is already in scope.

--- a/packages/warden/src/__tests__/static-resource-accessor-preference.test.ts
+++ b/packages/warden/src/__tests__/static-resource-accessor-preference.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test } from 'bun:test';
+
+import { staticResourceAccessorPreference } from '../rules/static-resource-accessor-preference.js';
+
+const TEST_FILE = 'src/entity.trail.ts';
+
+describe('static-resource-accessor-preference', () => {
+  test('warns when a same-file resource definition is looked up by id', () => {
+    const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (_input, ctx) => {
+    return Result.ok(ctx.resource('db.main'));
+  },
+});
+`;
+
+    const diagnostics = staticResourceAccessorPreference.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.rule).toBe('static-resource-accessor-preference');
+    expect(diagnostics[0]?.message).toContain("ctx.resource('db.main')");
+    expect(diagnostics[0]?.message).toContain('Prefer db.from(ctx)');
+  });
+
+  test('warns when a declared resource definition is looked up by identifier', () => {
+    const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (_input, ctx) => {
+    return Result.ok(ctx.resource(db));
+  },
+});
+`;
+
+    const diagnostics = staticResourceAccessorPreference.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('ctx.resource(db)');
+    expect(diagnostics[0]?.message).toContain('Prefer db.from(ctx)');
+  });
+
+  test('warns for imported resource definitions looked up by identifier', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+import { db } from './resources';
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (_input, ctx) => {
+    return Result.ok(ctx.resource(db));
+  },
+});
+`;
+
+    const diagnostics = staticResourceAccessorPreference.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('ctx.resource(db)');
+    expect(diagnostics[0]?.message).toContain('Prefer db.from(ctx)');
+  });
+
+  test('recognizes destructured resource aliases', () => {
+    const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (_input, ctx) => {
+    const { resource: getResource } = ctx;
+    return Result.ok(getResource(db));
+  },
+});
+`;
+
+    const diagnostics = staticResourceAccessorPreference.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('getResource(db)');
+  });
+
+  test('does not warn when the static helper is already used', () => {
+    const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (_input, ctx) => {
+    return Result.ok(db.from(ctx));
+  },
+});
+`;
+
+    expect(staticResourceAccessorPreference.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not warn for unresolved imported resources looked up by id', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+import { db } from './resources';
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (_input, ctx) => {
+    return Result.ok(ctx.resource('db.main'));
+  },
+});
+`;
+
+    expect(staticResourceAccessorPreference.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not warn for string declarations without a static resource definition', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail('entity.show', {
+  resources: ['db.main'],
+  blaze: async (_input, ctx) => {
+    return Result.ok(ctx.resource('db.main'));
+  },
+});
+`;
+
+    expect(staticResourceAccessorPreference.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not warn for dynamic resource ids', () => {
+    const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (input, ctx) => {
+    return Result.ok(ctx.resource(input.resourceId));
+  },
+});
+`;
+
+    expect(staticResourceAccessorPreference.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not warn when a local binding shadows a declared resource name', () => {
+    const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (input, ctx) => {
+    const db = input.resourceId;
+    return Result.ok(ctx.resource(db));
+  },
+});
+`;
+
+    expect(staticResourceAccessorPreference.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not warn when a local constructor shadows an imported dependency constructor', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+import { PrismaClient } from '@prisma/client';
+
+trail('entity.show', {
+  blaze: async () => {
+    const PrismaClient = class LocalClient {};
+    const db = new PrismaClient();
+    return Result.ok(db);
+  },
+});
+`;
+
+    expect(staticResourceAccessorPreference.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not warn inside framework harness files', () => {
+    const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (_input, ctx) => Result.ok(ctx.resource(db)),
+});
+`;
+
+    expect(
+      staticResourceAccessorPreference.check(
+        code,
+        '/repo/packages/testing/src/harness.ts'
+      )
+    ).toEqual([]);
+  });
+
+  test('warns for obvious imported external client construction inside blaze', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+import { PrismaClient } from '@prisma/client';
+
+trail('entity.show', {
+  blaze: async () => {
+    const db = new PrismaClient();
+    return Result.ok(db);
+  },
+});
+`;
+
+    const diagnostics = staticResourceAccessorPreference.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('new PrismaClient(...)');
+    expect(diagnostics[0]?.message).toContain(
+      'Move the client behind a resource definition'
+    );
+  });
+
+  test('warns for renamed AWS SDK client constructors inside blaze', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+import { HeadBucketCommand, S3Client as Storage } from '@aws-sdk/client-s3';
+
+trail('entity.show', {
+  blaze: async () => {
+    const storage = new Storage({ region: 'us-east-1' });
+    const command = new HeadBucketCommand({ Bucket: 'docs' });
+    return Result.ok({ command, storage });
+  },
+});
+`;
+
+    const diagnostics = staticResourceAccessorPreference.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('new Storage(...)');
+    expect(diagnostics[0]?.message).not.toContain('HeadBucketCommand');
+  });
+
+  test('does not warn for arbitrary constructors without import provenance', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+class Client {}
+
+trail('entity.show', {
+  blaze: async () => {
+    const client = new Client();
+    return Result.ok(client);
+  },
+});
+`;
+
+    expect(staticResourceAccessorPreference.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -8,8 +8,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 48 rule trails', () => {
-    expect(wardenTopo.count).toBe(48);
+  test('contains all 49 rule trails', () => {
+    expect(wardenTopo.count).toBe(49);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -172,6 +172,7 @@ export {
   resourceExistsTrail,
   scheduledDestroyIntentTrail,
   signalGraphCoachingTrail,
+  staticResourceAccessorPreferenceTrail,
   unmaterializedActivationSourceTrail,
   topoAwareRuleInput,
   unreachableDetourShadowingTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -39,6 +39,7 @@ import { resourceExists } from './resource-exists.js';
 import { resourceIdGrammar } from './resource-id-grammar.js';
 import { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
 import { signalGraphCoaching } from './signal-graph-coaching.js';
+import { staticResourceAccessorPreference } from './static-resource-accessor-preference.js';
 import type { TopoAwareWardenRule, WardenRule } from './types.js';
 import { unmaterializedActivationSource } from './unmaterialized-activation-source.js';
 import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
@@ -117,6 +118,7 @@ export { resourceExists } from './resource-exists.js';
 export { resourceIdGrammar } from './resource-id-grammar.js';
 export { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
 export { signalGraphCoaching } from './signal-graph-coaching.js';
+export { staticResourceAccessorPreference } from './static-resource-accessor-preference.js';
 export { unmaterializedActivationSource } from './unmaterialized-activation-source.js';
 export { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 export { validDetourContract } from './valid-detour-contract.js';
@@ -155,6 +157,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [resourceIdGrammar.name, resourceIdGrammar],
   [resourceExists.name, resourceExists],
   [preferSchemaInference.name, preferSchemaInference],
+  [staticResourceAccessorPreference.name, staticResourceAccessorPreference],
   [validDescribeRefs.name, validDescribeRefs],
   [noDevPermitInSource.name, noDevPermitInSource],
   [noDirectImplementationCall.name, noDirectImplementationCall],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -85,6 +85,7 @@ const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'resource-id-grammar': 'resources',
   'scheduled-destroy-intent': 'lifecycle',
   'signal-graph-coaching': 'signals',
+  'static-resource-accessor-preference': 'resources',
   'unmaterialized-activation-source': 'lifecycle',
   'valid-detour-contract': 'results',
   'webhook-route-collision': 'composition',
@@ -405,6 +406,24 @@ const builtinWardenRuleMetadataInput = {
     invariant:
       'Typed signal contracts either declare a producer or participate in reactive consumption.',
     tier: 'topo-aware',
+  },
+  'static-resource-accessor-preference': {
+    ...durableExternal,
+    guidance: {
+      docs: [trailContractDocs],
+      relatedRules: ['resource-declarations', 'resource-exists'],
+      steps: [
+        'Replace ctx.resource(db) or ctx.resource("id") with db.from(ctx) when the resource definition is statically in scope.',
+        'Move external client construction behind resource() and declare that resource on the trail contract.',
+        'Keep ctx.resource(...) for dynamic IDs, generic framework code, or cases where the definition is not statically available.',
+      ],
+      summary:
+        'Use statically scoped resource helpers when the resource definition is already available.',
+    },
+    invariant:
+      'Trail logic should prefer static resource helpers over dynamic accessors.',
+    scope: 'advisory',
+    tier: 'source-static',
   },
   'unmaterialized-activation-source': {
     ...durableExternal,

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -47,6 +47,7 @@ import { resourceExists } from './resource-exists.js';
 import { resourceIdGrammar } from './resource-id-grammar.js';
 import { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
 import { signalGraphCoaching } from './signal-graph-coaching.js';
+import { staticResourceAccessorPreference } from './static-resource-accessor-preference.js';
 import { unmaterializedActivationSource } from './unmaterialized-activation-source.js';
 import { unreachableDetourShadowing } from './unreachable-detour-shadowing.js';
 import { validDetourContract } from './valid-detour-contract.js';
@@ -102,6 +103,7 @@ export const registeredRuleNames: readonly string[] = [
   resourceIdGrammar.name,
   scheduledDestroyIntent.name,
   signalGraphCoaching.name,
+  staticResourceAccessorPreference.name,
   unmaterializedActivationSource.name,
   unreachableDetourShadowing.name,
   validDetourContract.name,

--- a/packages/warden/src/rules/static-resource-accessor-preference.ts
+++ b/packages/warden/src/rules/static-resource-accessor-preference.ts
@@ -1,0 +1,635 @@
+/**
+ * Prefers static resource definition helpers over dynamic context lookups.
+ *
+ * The rule intentionally stays advisory and narrow: it only warns when the
+ * trail already has a statically declared resource definition in `resources`.
+ * Dynamic IDs and generic framework internals remain outside its scope.
+ */
+
+import {
+  collectNamedResourceIds,
+  extractFirstStringArg,
+  findBlazeBodies,
+  findConfigProperty,
+  findTrailDefinitions,
+  getStringValue,
+  identifierName,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  walk,
+  walkScope,
+  walkWithScopes,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { isFrameworkInternalFile, isTestFile } from './scan.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'static-resource-accessor-preference';
+
+const MEMBER_TYPES = new Set(['StaticMemberExpression', 'MemberExpression']);
+
+const NAMED_DEPENDENCY_CONSTRUCTORS = new Map<string, ReadonlySet<string>>([
+  ['@prisma/client', new Set(['PrismaClient'])],
+  ['pg', new Set(['Pool', 'Client'])],
+  ['mongodb', new Set(['MongoClient'])],
+  ['ioredis', new Set(['Redis'])],
+]);
+
+interface DeclaredStaticResource {
+  readonly id: string | null;
+  readonly name: string;
+}
+
+interface ResourceLookup {
+  readonly id: string | null;
+  readonly name: string | null;
+  readonly rendered: string;
+  readonly start: number;
+}
+
+interface InlineDependencyConstruction {
+  readonly name: string;
+  readonly rendered: string;
+  readonly start: number;
+}
+
+const isShadowedModuleBinding = (
+  name: string | null,
+  scopes: readonly ReadonlySet<string>[]
+): boolean => {
+  if (!name) {
+    return false;
+  }
+  for (let i = 0; i < scopes.length - 1; i += 1) {
+    const frame = scopes[i];
+    if (frame?.has(name)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const extractMemberPair = (
+  callee: AstNode
+): { readonly objName: string; readonly propName: string } | null => {
+  if (!MEMBER_TYPES.has(callee.type)) {
+    return null;
+  }
+
+  const objName = identifierName(
+    (callee as unknown as { object?: AstNode }).object
+  );
+  const propName = identifierName(
+    (callee as unknown as { property?: AstNode }).property
+  );
+
+  return objName && propName ? { objName, propName } : null;
+};
+
+const getResourceElements = (config: AstNode): readonly AstNode[] => {
+  const resourcesProp = findConfigProperty(config, 'resources');
+  if (!resourcesProp) {
+    return [];
+  }
+
+  const arrayNode = resourcesProp.value;
+  if (!arrayNode || (arrayNode as AstNode).type !== 'ArrayExpression') {
+    return [];
+  }
+
+  return (
+    ((arrayNode as AstNode)['elements'] as readonly AstNode[] | undefined) ?? []
+  );
+};
+
+const extractDeclaredStaticResources = (
+  config: AstNode,
+  resourceIdsByName: ReadonlyMap<string, string>
+): readonly DeclaredStaticResource[] =>
+  getResourceElements(config).flatMap((element) => {
+    if (element.type !== 'Identifier') {
+      return [];
+    }
+
+    const name = identifierName(element);
+    return name ? [{ id: resourceIdsByName.get(name) ?? null, name }] : [];
+  });
+
+const extractContextParamNode = (blazeBody: AstNode): AstNode | null => {
+  const params = blazeBody['params'] as readonly AstNode[] | undefined;
+  if (!params || params.length < 2) {
+    return null;
+  }
+  return params[1] ?? null;
+};
+
+const extractContextParamName = (blazeBody: AstNode): string | null => {
+  const param = extractContextParamNode(blazeBody);
+  if (!param) {
+    return null;
+  }
+  if (param.type === 'AssignmentPattern') {
+    return identifierName((param as unknown as { left?: AstNode }).left);
+  }
+  return identifierName(param);
+};
+
+const extractResourceAlias = (property: AstNode): string | null => {
+  if (property.type !== 'Property') {
+    return null;
+  }
+
+  const keyName = identifierName(
+    (property as unknown as { key?: AstNode }).key
+  );
+  if (keyName !== 'resource') {
+    return null;
+  }
+
+  return (
+    identifierName((property as unknown as { value?: AstNode }).value) ??
+    keyName
+  );
+};
+
+const collectParamResourceAliases = (body: AstNode): ReadonlySet<string> => {
+  const param = extractContextParamNode(body);
+  if (!param || param.type !== 'ObjectPattern') {
+    return new Set();
+  }
+
+  const aliases = new Set<string>();
+  const properties = param['properties'] as readonly AstNode[] | undefined;
+  for (const property of properties ?? []) {
+    const alias = extractResourceAlias(property);
+    if (alias) {
+      aliases.add(alias);
+    }
+  }
+  return aliases;
+};
+
+const buildCtxNames = (body: AstNode): ReadonlySet<string> => {
+  const ctxNames = new Set<string>();
+  const paramName = extractContextParamName(body);
+  if (paramName) {
+    ctxNames.add(paramName);
+  }
+  return ctxNames;
+};
+
+const extractObjectPatternAliases = (
+  pattern: AstNode | undefined
+): readonly string[] => {
+  if (pattern?.type !== 'ObjectPattern') {
+    return [];
+  }
+
+  const properties = pattern['properties'] as readonly AstNode[] | undefined;
+  return (properties ?? []).flatMap((property) => {
+    const alias = extractResourceAlias(property);
+    return alias ? [alias] : [];
+  });
+};
+
+const collectResourceAliases = (
+  body: AstNode,
+  ctxNames: ReadonlySet<string>
+): ReadonlySet<string> => {
+  const aliases = new Set<string>();
+
+  walkScope(body, (node) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+
+    const { id, init } = node as unknown as {
+      readonly id?: AstNode;
+      readonly init?: AstNode;
+    };
+    const initName = identifierName(init);
+    if (!initName || !ctxNames.has(initName)) {
+      return;
+    }
+
+    for (const alias of extractObjectPatternAliases(id)) {
+      aliases.add(alias);
+    }
+  });
+
+  return aliases;
+};
+
+const extractCallCallee = (node: AstNode): AstNode | null => {
+  if (node.type !== 'CallExpression') {
+    return null;
+  }
+  return ((node as unknown as { callee?: AstNode }).callee ??
+    null) as AstNode | null;
+};
+
+const extractFirstArg = (node: AstNode): AstNode | null => {
+  if (node.type !== 'CallExpression') {
+    return null;
+  }
+  const args = node['arguments'] as readonly AstNode[] | undefined;
+  return args?.[0] ?? null;
+};
+
+const renderStringArg = (value: string): string =>
+  `'${value.replaceAll("'", "\\'")}'`;
+
+const renderResourceArg = (node: AstNode | null): string | null => {
+  if (!node) {
+    return null;
+  }
+  const name = identifierName(node);
+  if (name) {
+    return name;
+  }
+  return isStringLiteral(node)
+    ? renderStringArg(getStringValue(node) ?? '')
+    : null;
+};
+
+const extractFirstIdentifierArg = (node: AstNode): string | null =>
+  identifierName(extractFirstArg(node) ?? undefined);
+
+const isMemberResourceCall = (
+  callee: AstNode,
+  ctxNames: ReadonlySet<string>
+): { readonly ctxName: string } | null => {
+  const pair = extractMemberPair(callee);
+  return pair && ctxNames.has(pair.objName) && pair.propName === 'resource'
+    ? { ctxName: pair.objName }
+    : null;
+};
+
+const extractResourceLookup = (
+  node: AstNode,
+  ctxNames: ReadonlySet<string>,
+  resourceAliases: ReadonlySet<string>
+): ResourceLookup | null => {
+  const callee = extractCallCallee(node);
+  if (!callee) {
+    return null;
+  }
+
+  const arg = extractFirstArg(node);
+  const renderedArg = renderResourceArg(arg);
+  if (!renderedArg) {
+    return null;
+  }
+
+  const memberCall = isMemberResourceCall(callee, ctxNames);
+  if (memberCall) {
+    return {
+      id: extractFirstStringArg(node),
+      name: extractFirstIdentifierArg(node),
+      rendered: `${memberCall.ctxName}.resource(${renderedArg})`,
+      start: node.start,
+    };
+  }
+
+  const calleeName = identifierName(callee);
+  if (calleeName && resourceAliases.has(calleeName)) {
+    return {
+      id: extractFirstStringArg(node),
+      name: extractFirstIdentifierArg(node),
+      rendered: `${calleeName}(${renderedArg})`,
+      start: node.start,
+    };
+  }
+
+  return null;
+};
+
+const buildDeclaredNameSet = (
+  resources: readonly DeclaredStaticResource[]
+): ReadonlySet<string> => new Set(resources.map((resource) => resource.name));
+
+const buildDeclaredNameById = (
+  resources: readonly DeclaredStaticResource[]
+): ReadonlyMap<string, string> =>
+  new Map(
+    resources.flatMap((resource) =>
+      resource.id ? [[resource.id, resource.name] as const] : []
+    )
+  );
+
+const collectResourceLookups = (
+  config: AstNode,
+  declaredNames: ReadonlySet<string>
+): readonly ResourceLookup[] => {
+  const lookups: ResourceLookup[] = [];
+
+  for (const body of findBlazeBodies(config)) {
+    const ctxNames = buildCtxNames(body);
+    const resourceAliases = new Set([
+      ...collectParamResourceAliases(body),
+      ...collectResourceAliases(body, ctxNames),
+    ]);
+
+    walkWithScopes(
+      body,
+      (node, scopes) => {
+        const lookup = extractResourceLookup(node, ctxNames, resourceAliases);
+        if (lookup && !isShadowedModuleBinding(lookup.name, scopes)) {
+          lookups.push(lookup);
+        }
+      },
+      {
+        initialScopes: [declaredNames],
+        stopAtNestedFunctions: true,
+      }
+    );
+  }
+
+  return lookups;
+};
+
+const getImportSourceValue = (node: AstNode): string | null => {
+  const sourceNode = (node as unknown as { source?: AstNode }).source;
+  const value = sourceNode
+    ? (sourceNode as unknown as { value?: unknown }).value
+    : null;
+  return typeof value === 'string' ? value : null;
+};
+
+const addNamedDependencyConstructors = (
+  source: string,
+  specifier: AstNode,
+  constructors: Set<string>
+): void => {
+  if (specifier.type !== 'ImportSpecifier') {
+    return;
+  }
+
+  const { imported, local } = specifier as unknown as {
+    readonly imported?: AstNode;
+    readonly local?: AstNode;
+  };
+  const importedName =
+    identifierName(imported) ??
+    (imported && isStringLiteral(imported) ? getStringValue(imported) : null);
+  const localName = identifierName(local);
+  if (!importedName || !localName) {
+    return;
+  }
+
+  if (
+    source.startsWith('@aws-sdk/client-') &&
+    importedName.endsWith('Client')
+  ) {
+    constructors.add(localName);
+    return;
+  }
+
+  const names = NAMED_DEPENDENCY_CONSTRUCTORS.get(source);
+  if (names?.has(importedName)) {
+    constructors.add(localName);
+  }
+};
+
+const addDefaultDependencyConstructors = (
+  source: string,
+  specifier: AstNode,
+  constructors: Set<string>
+): void => {
+  if (specifier.type !== 'ImportDefaultSpecifier' || source !== 'ioredis') {
+    return;
+  }
+
+  const localName = identifierName(
+    (specifier as unknown as { local?: AstNode }).local
+  );
+  if (localName) {
+    constructors.add(localName);
+  }
+};
+
+const collectDependencyConstructors = (ast: AstNode): ReadonlySet<string> => {
+  const constructors = new Set<string>();
+
+  walk(ast, (node) => {
+    if (node.type !== 'ImportDeclaration') {
+      return;
+    }
+
+    const source = getImportSourceValue(node);
+    if (!source) {
+      return;
+    }
+
+    const specifiers = node['specifiers'] as readonly AstNode[] | undefined;
+    for (const specifier of specifiers ?? []) {
+      addNamedDependencyConstructors(source, specifier, constructors);
+      addDefaultDependencyConstructors(source, specifier, constructors);
+    }
+  });
+
+  return constructors;
+};
+
+const extractInlineDependencyConstruction = (
+  node: AstNode,
+  dependencyConstructors: ReadonlySet<string>
+): InlineDependencyConstruction | null => {
+  if (node.type !== 'NewExpression') {
+    return null;
+  }
+
+  const ctorName = identifierName(
+    (node as unknown as { callee?: AstNode }).callee
+  );
+  return ctorName && dependencyConstructors.has(ctorName)
+    ? { name: ctorName, rendered: `new ${ctorName}(...)`, start: node.start }
+    : null;
+};
+
+const collectInlineDependencyConstructions = (
+  config: AstNode,
+  dependencyConstructors: ReadonlySet<string>
+): readonly InlineDependencyConstruction[] => {
+  const constructions: InlineDependencyConstruction[] = [];
+
+  for (const body of findBlazeBodies(config)) {
+    walkWithScopes(
+      body,
+      (node, scopes) => {
+        const construction = extractInlineDependencyConstruction(
+          node,
+          dependencyConstructors
+        );
+        if (
+          construction &&
+          !isShadowedModuleBinding(construction.name, scopes)
+        ) {
+          constructions.push(construction);
+        }
+      },
+      {
+        initialScopes: [dependencyConstructors],
+        stopAtNestedFunctions: true,
+      }
+    );
+  }
+
+  return constructions;
+};
+
+const buildAccessorDiagnostic = (
+  trailId: string,
+  lookup: ResourceLookup,
+  resourceName: string,
+  filePath: string,
+  sourceCode: string
+): WardenDiagnostic => ({
+  filePath,
+  line: offsetToLine(sourceCode, lookup.start),
+  message:
+    `Trail "${trailId}": ${lookup.rendered} uses a dynamic resource accessor ` +
+    `for statically declared resource '${resourceName}'. Prefer ${resourceName}.from(ctx) ` +
+    'so the dependency stays type-directed.',
+  rule: RULE_NAME,
+  severity: 'warn',
+});
+
+const buildInlineDependencyDiagnostic = (
+  trailId: string,
+  construction: InlineDependencyConstruction,
+  filePath: string,
+  sourceCode: string
+): WardenDiagnostic => ({
+  filePath,
+  line: offsetToLine(sourceCode, construction.start),
+  message:
+    `Trail "${trailId}": ${construction.rendered} constructs an external dependency ` +
+    'inside blaze logic. Move the client behind a resource definition and declare it in resources.',
+  rule: RULE_NAME,
+  severity: 'warn',
+});
+
+const reportAccessorLookups = (
+  trailId: string,
+  filePath: string,
+  sourceCode: string,
+  declaredResources: readonly DeclaredStaticResource[],
+  lookups: readonly ResourceLookup[],
+  diagnostics: WardenDiagnostic[]
+): void => {
+  const declaredNames = buildDeclaredNameSet(declaredResources);
+  const declaredNameById = buildDeclaredNameById(declaredResources);
+
+  for (const lookup of lookups) {
+    const resourceName =
+      (lookup.name && declaredNames.has(lookup.name) ? lookup.name : null) ??
+      (lookup.id ? (declaredNameById.get(lookup.id) ?? null) : null);
+
+    if (!resourceName) {
+      continue;
+    }
+
+    diagnostics.push(
+      buildAccessorDiagnostic(
+        trailId,
+        lookup,
+        resourceName,
+        filePath,
+        sourceCode
+      )
+    );
+  }
+};
+
+const reportInlineDependencyConstructions = (
+  trailId: string,
+  filePath: string,
+  sourceCode: string,
+  constructions: readonly InlineDependencyConstruction[],
+  diagnostics: WardenDiagnostic[]
+): void => {
+  for (const construction of constructions) {
+    diagnostics.push(
+      buildInlineDependencyDiagnostic(
+        trailId,
+        construction,
+        filePath,
+        sourceCode
+      )
+    );
+  }
+};
+
+const checkTrailDefinition = (
+  def: { readonly config: AstNode; readonly id: string },
+  filePath: string,
+  sourceCode: string,
+  resourceIdsByName: ReadonlyMap<string, string>,
+  dependencyConstructors: ReadonlySet<string>,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  const declaredResources = extractDeclaredStaticResources(
+    def.config,
+    resourceIdsByName
+  );
+  const lookups = collectResourceLookups(
+    def.config,
+    buildDeclaredNameSet(declaredResources)
+  );
+  reportAccessorLookups(
+    def.id,
+    filePath,
+    sourceCode,
+    declaredResources,
+    lookups,
+    diagnostics
+  );
+
+  const constructions = collectInlineDependencyConstructions(
+    def.config,
+    dependencyConstructors
+  );
+  reportInlineDependencyConstructions(
+    def.id,
+    filePath,
+    sourceCode,
+    constructions,
+    diagnostics
+  );
+};
+
+export const staticResourceAccessorPreference: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isTestFile(filePath) || isFrameworkInternalFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const diagnostics: WardenDiagnostic[] = [];
+    const resourceIdsByName = collectNamedResourceIds(ast);
+    const dependencyConstructors = collectDependencyConstructors(ast);
+
+    for (const def of findTrailDefinitions(ast)) {
+      checkTrailDefinition(
+        def,
+        filePath,
+        sourceCode,
+        resourceIdsByName,
+        dependencyConstructors,
+        diagnostics
+      );
+    }
+
+    return diagnostics;
+  },
+  description:
+    'Prefer static resource.from(ctx) helpers over dynamic ctx.resource() lookups when the resource definition is already in scope.',
+  name: RULE_NAME,
+  severity: 'warn',
+};

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -39,6 +39,7 @@ export { resourceIdGrammarTrail } from './resource-id-grammar.trail.js';
 export { resourceExistsTrail } from './resource-exists.trail.js';
 export { scheduledDestroyIntentTrail } from './scheduled-destroy-intent.trail.js';
 export { signalGraphCoachingTrail } from './signal-graph-coaching.trail.js';
+export { staticResourceAccessorPreferenceTrail } from './static-resource-accessor-preference.trail.js';
 export { unmaterializedActivationSourceTrail } from './unmaterialized-activation-source.trail.js';
 export { unreachableDetourShadowingTrail } from './unreachable-detour-shadowing.trail.js';
 export { validDetourContractTrail } from './valid-detour-contract.trail.js';

--- a/packages/warden/src/trails/static-resource-accessor-preference.trail.ts
+++ b/packages/warden/src/trails/static-resource-accessor-preference.trail.ts
@@ -1,0 +1,25 @@
+import { staticResourceAccessorPreference } from '../rules/static-resource-accessor-preference.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const staticResourceAccessorPreferenceTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        sourceCode: `const db = resource("db.main", {
+  create: () => Result.ok({ source: "factory" }),
+});
+
+trail("entity.show", {
+  resources: [db],
+  blaze: async (_input, ctx) => {
+    return Result.ok(db.from(ctx));
+  }
+})`,
+      },
+      name: 'Static resource helper access',
+    },
+  ],
+  rule: staticResourceAccessorPreference,
+});


### PR DESCRIPTION
## Context

This branch is stacked on #459 and closes TRL-689.

Trails doctrine prefers static `resource.from(ctx)` helpers when the resource definition is already in scope. This branch adds warning-level Warden coverage for reliable cases without trying to infer every dynamic dependency pattern.

## What changed

- Added the source-static `static-resource-accessor-preference` Warden rule.
- Warned for statically declared resource definitions accessed through dynamic `ctx.resource(...)` patterns when `.from(ctx)` is available.
- Added a narrow inline dependency-construction advisory for imported external client constructors inside blaze bodies.
- Suppressed diagnostics for tests, framework internals, dynamic IDs, string-only declarations, unresolved imports, and local bindings that shadow resource or client names.
- Added Warden metadata/guidance, a wrapped rule trail, and focused tests.

## How to test

- `bun test packages/warden/src/__tests__/static-resource-accessor-preference.test.ts packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/warden-export-symmetry.test.ts packages/warden/src/__tests__/trails.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run check`
- Final stack-tip gates also passed: `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run publish:check`, `git diff --check`.

## Risks/rollout notes

The rule is advisory and intentionally conservative. It should guide obvious static-resource cleanup while avoiding speculative findings for dynamic framework seams.

## Release

Changeset: `.changeset/warden-static-resource-accessor.md` for `@ontrails/warden`.

Closes: TRL-689
