### PR TITLE
feat: add warden guide manifest

### DIFF
--- a/.changeset/warden-guide-manifest.md
+++ b/.changeset/warden-guide-manifest.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/warden": minor
+"@ontrails/trails": minor
+---
+
+Add a Warden guide manifest projection and expose it through `trails warden guide` in markdown, agent-json, and manifest formats.

--- a/apps/trails/src/__tests__/warden.test.ts
+++ b/apps/trails/src/__tests__/warden.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { tryWardenOutput } from '../run-warden.js';
+import { wardenGuideTrail } from '../trails/warden-guide.js';
 import { buildWardenCommandArgs, wardenTrail } from '../trails/warden.js';
 
 const wardenBinPath = fileURLToPath(
@@ -48,6 +49,51 @@ interface CliRun {
   readonly stderr: string;
   readonly stdout: string;
 }
+
+interface RawCliRun {
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+const runRawCli = (
+  binPath: string,
+  args: readonly string[],
+  cwd: string
+): RawCliRun => {
+  const command = [process.execPath, binPath, ...args];
+  const proc = Bun.spawnSync({
+    cmd: command,
+    cwd,
+    env: { ...process.env, NO_COLOR: '1' } as Record<string, string>,
+    stderr: 'pipe',
+    stdout: 'pipe',
+    timeout: cliTimeoutMs,
+  });
+  const stdout = proc.stdout.toString();
+  const stderr = proc.stderr.toString();
+  const signalCode = proc.signalCode ?? undefined;
+  if (proc.exitedDueToTimeout || signalCode !== undefined) {
+    throw new Error(
+      [
+        `Warden CLI subprocess ${proc.exitedDueToTimeout ? 'timed out' : 'terminated'} before producing raw output.`,
+        `command: ${command.join(' ')}`,
+        `cwd: ${cwd}`,
+        ...(proc.exitedDueToTimeout ? [`timeoutMs: ${cliTimeoutMs}`] : []),
+        `exitCode: ${proc.exitCode ?? 'null'}`,
+        `signal: ${signalCode ?? 'null'}`,
+        `stdout: ${stdout}`,
+        `stderr: ${stderr}`,
+      ].join('\n')
+    );
+  }
+
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stderr,
+    stdout,
+  };
+};
 
 const runCli = (
   binPath: string,
@@ -223,6 +269,45 @@ describe('trails warden', () => {
     }
   });
 
+  test('warden guide projects markdown from the Warden manifest', async () => {
+    const result = await wardenGuideTrail.blaze({ guideFormat: 'markdown' }, {
+      cwd: repoRoot,
+      env: {},
+    } as never);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.manifest.kind).toBe('trails-warden-guide-manifest');
+    expect(result.value.formatted).toContain('# Trails Warden Guide');
+    expect(result.value.formatted).toContain(
+      '### `no-throw-in-implementation`'
+    );
+    expect(result.value.formatted).toContain(
+      'Convert thrown implementation failures into explicit Result.err() outcomes.'
+    );
+  });
+
+  test('warden guide format aliases work through the CLI', () => {
+    const raw = runRawCli(
+      trailsBinPath,
+      ['warden', 'guide', '--agent-json'],
+      repoRoot
+    );
+    const parsed = JSON.parse(raw.stdout) as {
+      readonly kind: string;
+      readonly rules: readonly { readonly id: string }[];
+    };
+
+    expect(raw.exitCode).toBe(0);
+    expect(raw.stderr).toBe('');
+    expect(parsed.kind).toBe('trails-warden-agent-guide');
+    expect(parsed.rules.map((rule) => rule.id)).toContain(
+      'no-throw-in-implementation'
+    );
+  });
+
   test('onResult bridge writes formatted output and sets the exit code', () => {
     const originalWrite = process.stdout.write;
     const originalExitCode = process.exitCode;
@@ -231,7 +316,7 @@ describe('trails warden', () => {
       output += chunk;
       return true;
     }) as typeof process.stdout.write;
-    process.exitCode = undefined;
+    process.exitCode = 0;
 
     try {
       const handled = tryWardenOutput({
@@ -249,6 +334,35 @@ describe('trails warden', () => {
     } finally {
       process.stdout.write = originalWrite;
       // Bun does not clear a non-zero exitCode when assigned undefined.
+      process.exitCode = originalExitCode ?? 0;
+    }
+  });
+
+  test('onResult bridge writes guide output without changing exit code', () => {
+    const originalWrite = process.stdout.write;
+    const originalExitCode = process.exitCode;
+    let output = '';
+    process.stdout.write = ((chunk: string) => {
+      output += chunk;
+      return true;
+    }) as typeof process.stdout.write;
+    process.exitCode = 7;
+
+    try {
+      const handled = tryWardenOutput({
+        args: {},
+        flags: {},
+        input: {},
+        result: Result.ok({ formatted: '# Guide' }),
+        topoName: 'trails',
+        trail: wardenGuideTrail as unknown as ActionResultContext['trail'],
+      });
+
+      expect(handled).toBe(true);
+      expect(output).toBe('# Guide\n');
+      expect(process.exitCode).toBe(7);
+    } finally {
+      process.stdout.write = originalWrite;
       process.exitCode = originalExitCode ?? 0;
     }
   });

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -23,6 +23,7 @@ import * as topoCommand from './trails/topo.js';
 import * as topoUnpin from './trails/topo-unpin.js';
 import * as topoVerify from './trails/topo-verify.js';
 import * as warden from './trails/warden.js';
+import * as wardenGuide from './trails/warden-guide.js';
 
 export const app = topo(
   'trails',
@@ -42,6 +43,7 @@ export const app = topo(
   guide,
   draftPromote,
   warden,
+  wardenGuide,
   create,
   createScaffold,
   addSurface,

--- a/apps/trails/src/run-warden.ts
+++ b/apps/trails/src/run-warden.ts
@@ -2,7 +2,7 @@ import type { ActionResultContext } from '@ontrails/cli';
 
 interface WardenResultValue {
   readonly formatted: string;
-  readonly passed: boolean;
+  readonly passed?: boolean | undefined;
 }
 
 const isWardenResultValue = (value: unknown): value is WardenResultValue => {
@@ -12,12 +12,16 @@ const isWardenResultValue = (value: unknown): value is WardenResultValue => {
   const candidate = value as Record<string, unknown>;
   return (
     typeof candidate['formatted'] === 'string' &&
-    typeof candidate['passed'] === 'boolean'
+    (candidate['passed'] === undefined ||
+      typeof candidate['passed'] === 'boolean')
   );
 };
 
 export const tryWardenOutput = (ctx: ActionResultContext): boolean => {
-  if (ctx.trail.id !== 'warden' || ctx.result.isErr()) {
+  if (
+    (ctx.trail.id !== 'warden' && ctx.trail.id !== 'warden.guide') ||
+    ctx.result.isErr()
+  ) {
     return false;
   }
   const { value } = ctx.result;
@@ -28,6 +32,8 @@ export const tryWardenOutput = (ctx: ActionResultContext): boolean => {
   if (value.formatted.length > 0) {
     process.stdout.write(`${value.formatted}\n`);
   }
-  process.exitCode = value.passed ? 0 : 1;
+  if (typeof value.passed === 'boolean') {
+    process.exitCode = value.passed ? 0 : 1;
+  }
   return true;
 };

--- a/apps/trails/src/trails/warden-guide.ts
+++ b/apps/trails/src/trails/warden-guide.ts
@@ -1,0 +1,121 @@
+import type { FieldOverride } from '@ontrails/core';
+import { Result, trail } from '@ontrails/core';
+import {
+  buildWardenGuideManifest,
+  formatWardenGuide,
+  wardenDepthValues,
+  wardenGuideFormatValues,
+  wardenRuleConcerns,
+  wardenRuleLifecycleStates,
+  wardenRuleScopes,
+  wardenRuleTiers,
+} from '@ontrails/warden';
+import { z } from 'zod';
+
+const wardenGuidanceLinkSchema = z.object({
+  label: z.string(),
+  path: z.string().optional(),
+  url: z.string().optional(),
+});
+
+const wardenGuidanceSchema = z.object({
+  commands: z.array(z.string()).readonly().optional(),
+  docs: z.array(wardenGuidanceLinkSchema).readonly().optional(),
+  relatedRules: z.array(z.string()).readonly().optional(),
+  steps: z.array(z.string()).readonly().optional(),
+  summary: z.string(),
+});
+
+const wardenRuleGuideEntrySchema = z.object({
+  category: z.enum(wardenRuleConcerns),
+  depth: z.enum(wardenDepthValues),
+  description: z.string(),
+  docs: z.array(wardenGuidanceLinkSchema).readonly(),
+  guidance: wardenGuidanceSchema.optional(),
+  id: z.string(),
+  invariant: z.string(),
+  lifecycle: z.object({
+    retireWhen: z.string().optional(),
+    state: z.enum(wardenRuleLifecycleStates),
+  }),
+  scope: z.enum(wardenRuleScopes),
+  severity: z.enum(['error', 'warn']),
+  tier: z.enum(wardenRuleTiers),
+});
+
+const wardenGuideManifestSchema = z.object({
+  generatedFrom: z.object({
+    package: z.literal('@ontrails/warden'),
+    registries: z.tuple([
+      z.literal('wardenRules'),
+      z.literal('wardenTopoRules'),
+    ]),
+    source: z.literal('builtin-rule-metadata'),
+  }),
+  kind: z.literal('trails-warden-guide-manifest'),
+  ruleCount: z.number(),
+  rules: z.array(wardenRuleGuideEntrySchema).readonly(),
+  version: z.literal(1),
+});
+
+const wardenGuideInputSchema = z.object({
+  guideFormat: z
+    .enum(wardenGuideFormatValues)
+    .default('markdown')
+    .describe('Guide output format'),
+});
+
+const wardenGuideFields = {
+  guideFormat: {
+    aliases: true,
+    options: [
+      {
+        hint: 'Human-readable Warden guide',
+        label: 'Markdown',
+        value: 'markdown',
+      },
+      {
+        hint: 'Compact guidance for agent context',
+        label: 'Agent JSON',
+        value: 'agent-json',
+      },
+      {
+        hint: 'Full structured rule manifest',
+        label: 'Manifest',
+        value: 'manifest',
+      },
+    ],
+  },
+} satisfies Readonly<
+  Record<'guideFormat', FieldOverride & { readonly aliases: true }>
+>;
+
+export const wardenGuideTrail = trail('warden.guide', {
+  blaze: (input) => {
+    const manifest = buildWardenGuideManifest();
+    return Result.ok({
+      format: input.guideFormat,
+      formatted: formatWardenGuide(manifest, input.guideFormat),
+      manifest,
+    });
+  },
+  description: 'Project Warden rule guidance as markdown or JSON',
+  examples: [
+    {
+      input: { guideFormat: 'markdown' },
+      name: 'Markdown guide',
+    },
+    {
+      input: { guideFormat: 'agent-json' },
+      name: 'Agent JSON guide',
+    },
+  ],
+  fields: wardenGuideFields,
+  input: wardenGuideInputSchema,
+  intent: 'read',
+  output: z.object({
+    format: z.enum(wardenGuideFormatValues),
+    formatted: z.string(),
+    manifest: wardenGuideManifestSchema,
+  }),
+});

--- a/packages/warden/src/__tests__/guide.test.ts
+++ b/packages/warden/src/__tests__/guide.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildWardenAgentGuide,
+  buildWardenGuideManifest,
+  formatWardenGuide,
+  formatWardenGuideMarkdown,
+} from '../guide.js';
+
+describe('warden guide manifest', () => {
+  test('projects live Warden rule metadata into a deterministic manifest', () => {
+    const manifest = buildWardenGuideManifest();
+    const ids = manifest.rules.map((rule) => rule.id);
+
+    expect(manifest.kind).toBe('trails-warden-guide-manifest');
+    expect(manifest.ruleCount).toBe(manifest.rules.length);
+    expect(ids).toEqual([...ids].toSorted());
+
+    const throwRule = manifest.rules.find(
+      (rule) => rule.id === 'no-throw-in-implementation'
+    );
+    expect(throwRule).toMatchObject({
+      category: 'results',
+      depth: 'source',
+      severity: 'error',
+      tier: 'source-static',
+    });
+    expect(throwRule?.guidance?.summary).toBe(
+      'Convert thrown implementation failures into explicit Result.err() outcomes.'
+    );
+  });
+
+  test('markdown rendering includes stable guidance sections', () => {
+    const markdown = formatWardenGuideMarkdown(buildWardenGuideManifest());
+
+    expect(markdown).toContain('# Trails Warden Guide');
+    expect(markdown).toContain('### `no-throw-in-implementation`');
+    expect(markdown).toContain(
+      'Guidance: Convert thrown implementation failures into explicit Result.err() outcomes.'
+    );
+    expect(markdown).toContain('- Docs: [Trail Rules](AGENTS.md#trail-rules)');
+  });
+
+  test('agent-json rendering is stable and parseable', () => {
+    const manifest = buildWardenGuideManifest();
+    const agentGuide = buildWardenAgentGuide(manifest);
+    const formatted = formatWardenGuide(manifest, 'agent-json');
+    const parsed = JSON.parse(formatted) as typeof agentGuide;
+
+    expect(parsed.kind).toBe('trails-warden-agent-guide');
+    expect(parsed.rules).toHaveLength(manifest.ruleCount);
+    expect(parsed.rules[0]?.id).toBe(manifest.rules[0]?.id);
+  });
+
+  test('manifest rendering is stable and parseable', () => {
+    const manifest = buildWardenGuideManifest();
+    const formatted = formatWardenGuide(manifest, 'manifest');
+    const parsed = JSON.parse(formatted) as typeof manifest;
+
+    expect(parsed.kind).toBe('trails-warden-guide-manifest');
+    expect(parsed.ruleCount).toBe(manifest.ruleCount);
+    expect(parsed.rules.at(-1)?.id).toBe(manifest.rules.at(-1)?.id);
+  });
+});

--- a/packages/warden/src/guide.ts
+++ b/packages/warden/src/guide.ts
@@ -1,0 +1,234 @@
+import type {
+  WardenGuidance,
+  WardenGuidanceLink,
+  WardenRuleConcern,
+  WardenRuleLifecycle,
+  WardenRuleScope,
+  WardenRuleTier,
+  WardenSeverity,
+} from './rules/index.js';
+import {
+  listWardenRuleMetadata,
+  wardenRules,
+  wardenTopoRules,
+} from './rules/index.js';
+import type { WardenDepth } from './config.js';
+
+export const wardenGuideFormatValues = [
+  'markdown',
+  'agent-json',
+  'manifest',
+] as const;
+
+export type WardenGuideFormat = (typeof wardenGuideFormatValues)[number];
+
+export interface WardenRuleGuideEntry {
+  readonly category: WardenRuleConcern;
+  readonly depth: WardenDepth;
+  readonly description: string;
+  readonly docs: readonly WardenGuidanceLink[];
+  readonly guidance?: WardenGuidance | undefined;
+  readonly id: string;
+  readonly invariant: string;
+  readonly lifecycle: WardenRuleLifecycle;
+  readonly scope: WardenRuleScope;
+  readonly severity: WardenSeverity;
+  readonly tier: WardenRuleTier;
+}
+
+export interface WardenGuideManifest {
+  readonly generatedFrom: {
+    readonly package: '@ontrails/warden';
+    readonly registries: readonly ['wardenRules', 'wardenTopoRules'];
+    readonly source: 'builtin-rule-metadata';
+  };
+  readonly kind: 'trails-warden-guide-manifest';
+  readonly ruleCount: number;
+  readonly rules: readonly WardenRuleGuideEntry[];
+  readonly version: 1;
+}
+
+interface WardenAgentRuleGuide {
+  readonly appliesAt: {
+    readonly depth: WardenDepth;
+    readonly scope: WardenRuleScope;
+    readonly tier: WardenRuleTier;
+  };
+  readonly category: WardenRuleConcern;
+  readonly guidance?: WardenGuidance | undefined;
+  readonly id: string;
+  readonly invariant: string;
+  readonly severity: WardenSeverity;
+}
+
+interface WardenAgentGuide {
+  readonly instructions: readonly string[];
+  readonly kind: 'trails-warden-agent-guide';
+  readonly rules: readonly WardenAgentRuleGuide[];
+  readonly version: 1;
+}
+
+const lookupRule = (id: string) =>
+  wardenRules.get(id) ?? wardenTopoRules.get(id);
+
+const compareRuleEntries = (
+  [left]: readonly [string, unknown],
+  [right]: readonly [string, unknown]
+): number => left.localeCompare(right);
+
+export const buildWardenGuideManifest = (): WardenGuideManifest => {
+  const rules = listWardenRuleMetadata()
+    .toSorted(compareRuleEntries)
+    .map(([id, metadata]) => {
+      const rule = lookupRule(id);
+      const docs = metadata.guidance?.docs ?? [];
+      return {
+        category: metadata.concern,
+        depth: metadata.depth,
+        description: rule?.description ?? '',
+        docs,
+        guidance: metadata.guidance,
+        id,
+        invariant: metadata.invariant,
+        lifecycle: metadata.lifecycle,
+        scope: metadata.scope,
+        severity: rule?.severity ?? 'warn',
+        tier: metadata.tier,
+      } satisfies WardenRuleGuideEntry;
+    });
+
+  return {
+    generatedFrom: {
+      package: '@ontrails/warden',
+      registries: ['wardenRules', 'wardenTopoRules'],
+      source: 'builtin-rule-metadata',
+    },
+    kind: 'trails-warden-guide-manifest',
+    ruleCount: rules.length,
+    rules,
+    version: 1,
+  };
+};
+
+const formatGuideLink = (link: WardenGuidanceLink): string => {
+  if (link.path) {
+    return `[${link.label}](${link.path})`;
+  }
+  if (link.url) {
+    return `[${link.label}](${link.url})`;
+  }
+  return link.label;
+};
+
+const renderOptionalList = (
+  lines: string[],
+  label: string,
+  items: readonly string[] | undefined
+): void => {
+  if (items === undefined || items.length === 0) {
+    return;
+  }
+
+  lines.push(`- ${label}:`);
+  for (const [index, item] of items.entries()) {
+    lines.push(`  ${index + 1}. ${item}`);
+  }
+};
+
+const renderRuleMarkdown = (rule: WardenRuleGuideEntry): readonly string[] => {
+  const lines = [
+    `### \`${rule.id}\``,
+    '',
+    `- Severity: \`${rule.severity}\``,
+    `- Category: \`${rule.category}\``,
+    `- Depth: \`${rule.depth}\``,
+    `- Tier: \`${rule.tier}\``,
+    `- Scope: \`${rule.scope}\``,
+    `- Lifecycle: \`${rule.lifecycle.state}\``,
+    `- Invariant: ${rule.invariant}`,
+    `- Description: ${rule.description}`,
+  ];
+
+  if (rule.lifecycle.retireWhen) {
+    lines.push(`- Retire when: ${rule.lifecycle.retireWhen}`);
+  }
+
+  if (rule.guidance) {
+    lines.push('', `Guidance: ${rule.guidance.summary}`);
+    renderOptionalList(lines, 'Steps', rule.guidance.steps);
+    renderOptionalList(lines, 'Commands', rule.guidance.commands);
+    if (rule.docs.length > 0) {
+      lines.push(`- Docs: ${rule.docs.map(formatGuideLink).join(', ')}`);
+    }
+    if (rule.guidance.relatedRules && rule.guidance.relatedRules.length > 0) {
+      lines.push(
+        `- Related rules: ${rule.guidance.relatedRules.map((id) => `\`${id}\``).join(', ')}`
+      );
+    }
+  }
+
+  return lines;
+};
+
+export const formatWardenGuideMarkdown = (
+  manifest: WardenGuideManifest
+): string => {
+  const lines = [
+    '# Trails Warden Guide',
+    '',
+    'Generated from `@ontrails/warden` built-in rule metadata and live rule registries.',
+    '',
+    '## Summary',
+    '',
+    `- Rules: ${manifest.ruleCount}`,
+    `- Guided rules: ${manifest.rules.filter((rule) => rule.guidance).length}`,
+    '',
+    '## Rules',
+    '',
+  ];
+
+  for (const rule of manifest.rules) {
+    lines.push(...renderRuleMarkdown(rule), '');
+  }
+
+  return lines.join('\n').trimEnd();
+};
+
+export const buildWardenAgentGuide = (
+  manifest: WardenGuideManifest
+): WardenAgentGuide => ({
+  instructions: [
+    'Treat Warden rules as enforceable Trails doctrine when working in this repository.',
+    'Prefer the rule guidance summary and ordered steps over diagnostic prose when deciding how to remediate a finding.',
+    'When guidance is absent, use the invariant, category, tier, and scope as classification metadata rather than inventing a rule-specific fix.',
+  ],
+  kind: 'trails-warden-agent-guide',
+  rules: manifest.rules.map((rule) => ({
+    appliesAt: {
+      depth: rule.depth,
+      scope: rule.scope,
+      tier: rule.tier,
+    },
+    category: rule.category,
+    guidance: rule.guidance,
+    id: rule.id,
+    invariant: rule.invariant,
+    severity: rule.severity,
+  })),
+  version: 1,
+});
+
+export const formatWardenGuide = (
+  manifest: WardenGuideManifest,
+  format: WardenGuideFormat
+): string => {
+  if (format === 'markdown') {
+    return formatWardenGuideMarkdown(manifest);
+  }
+
+  if (format === 'agent-json') {
+    return JSON.stringify(buildWardenAgentGuide(manifest), null, 2);
+  }
+
+  return JSON.stringify(manifest, null, 2);
+};

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -100,6 +100,20 @@ export {
 export type { DriftResult } from './drift.js';
 export { checkDrift } from './drift.js';
 
+// Guide projection
+export type {
+  WardenGuideFormat,
+  WardenGuideManifest,
+  WardenRuleGuideEntry,
+} from './guide.js';
+export {
+  buildWardenAgentGuide,
+  buildWardenGuideManifest,
+  formatWardenGuide,
+  formatWardenGuideMarkdown,
+  wardenGuideFormatValues,
+} from './guide.js';
+
 // Resolver helpers
 export {
   collectImportResolutionsForFile,


### PR DESCRIPTION
## Context

This branch is stacked on #460 and closes TRL-681.

The generated AGENTS and skill guidance in the upper stack need one authoritative Warden manifest instead of copied rule prose. This branch adds that projection and exposes it through the Trails CLI.

## What changed

- Added Warden guide projection APIs: `buildWardenGuideManifest()`, `formatWardenGuide()`, `formatWardenGuideMarkdown()`, and `buildWardenAgentGuide()`.
- Built the manifest from live Warden rule metadata and registries rather than a copied list.
- Included rule IDs, severity, invariant, category/concern, depth, tier, scope, lifecycle, docs, and structured guidance.
- Added the `warden.guide` trail exposed as `trails warden guide`.
- Added `markdown`, `agent-json`, and `manifest` output formats, with CLI shorthand aliases wired through the generic value-alias path.

## How to test

- `bun test packages/cli/src/__tests__/build.test.ts packages/warden/src/__tests__/guide.test.ts apps/trails/src/__tests__/warden.test.ts`
- `bun apps/trails/bin/trails.ts warden guide --manifest`
- `bun apps/trails/bin/trails.ts warden guide --markdown`
- `bun apps/trails/bin/trails.ts warden guide --agent-json`
- `bun run --cwd packages/warden typecheck`
- `bun run --cwd apps/trails typecheck`
- Final stack-tip gates also passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.

## Risks/rollout notes

The new guide command is additive. The manifest is generated from rule metadata, so future rule guidance changes should flow into downstream docs without hand-maintained copies.

## Release

Changeset: `.changeset/warden-guide-manifest.md` for `@ontrails/warden` and `@ontrails/trails`.

Closes: TRL-681
