### PR TITLE
chore: add knip dead-code check

### DIFF
--- a/.changeset/knip-dead-code.md
+++ b/.changeset/knip-dead-code.md
@@ -1,0 +1,10 @@
+---
+"@ontrails/core": patch
+"@ontrails/observe": patch
+"@ontrails/store": patch
+"@ontrails/tracing": patch
+"@ontrails/trails": patch
+"@ontrails/warden": patch
+---
+
+Add repo-level Knip dead-code detection and remove stale internal exports and unused package dependencies surfaced by the new check.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,17 @@ jobs:
       - name: Format check
         run: bun run format:check
 
+  dead-code:
+    name: Dead Code
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+
+      - name: Knip
+        run: bun run dead-code
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
@@ -124,7 +135,7 @@ jobs:
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [build, lint, typecheck, test, governance, changeset]
+    needs: [build, lint, dead-code, typecheck, test, governance, changeset]
     runs-on: ubuntu-latest
     steps:
       - name: Summary
@@ -135,6 +146,7 @@ jobs:
           echo "|-----|--------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| Build | \`${{ needs.build.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Lint & Format | \`${{ needs.lint.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Dead Code | \`${{ needs.dead-code.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Typecheck | \`${{ needs.typecheck.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Test | \`${{ needs.test.result }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Governance | \`${{ needs.governance.result }}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/trails-demo/src/resources/entity-store.ts
+++ b/apps/trails-demo/src/resources/entity-store.ts
@@ -52,6 +52,8 @@ export const entityStoreResource = connectDrizzle(entityStoreDefinition, {
  *
  * Returned synchronously to keep example code paths terse. Tests that need a
  * differently-seeded mock should import `createStore` from `../store.js`.
+ *
+ * @public
  */
 export const createMockEntityStore = () => {
   const { mock } = entityStoreResource;

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -26,7 +26,6 @@
     "@ontrails/cli": "workspace:^",
     "@ontrails/commander": "workspace:^",
     "@ontrails/core": "workspace:^",
-    "@ontrails/http": "workspace:^",
     "@ontrails/logging": "workspace:^",
     "@ontrails/observe": "workspace:^",
     "@ontrails/permits": "workspace:^",

--- a/apps/trails/src/run-trace.ts
+++ b/apps/trails/src/run-trace.ts
@@ -141,8 +141,8 @@ export type TraceJsonEnvelope =
  *
  * The `value` and `error` properties may be present at the same time on a
  * Result instance (the discriminated union narrows by `isOk` / `isErr`),
- * so this interface keeps both optional and lets the builder branch on the
- * type guard rather than asserting either side.
+ * so this interface keeps both optional and lets the builder branch without
+ * asserting either side.
  */
 interface ResultLike {
   readonly isOk: () => boolean;
@@ -150,17 +150,6 @@ interface ResultLike {
   readonly value?: unknown;
   readonly error?: unknown;
 }
-
-const hasResultMethods = (value: unknown): value is ResultLike => {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-  const candidate: { isOk?: unknown; isErr?: unknown } = value;
-  return (
-    typeof candidate.isOk === 'function' &&
-    typeof candidate.isErr === 'function'
-  );
-};
 
 const errorFromUnknown = (
   value: unknown
@@ -282,9 +271,3 @@ export const tryTraceJsonOutput = (
   process.stdout.write(formatTraceJsonEnvelope(envelope));
   return true;
 };
-
-// ---------------------------------------------------------------------------
-// Result-shape detection helpers (re-exported for consumers in cli.ts)
-// ---------------------------------------------------------------------------
-
-export const isResultShape = hasResultMethods;

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -772,15 +772,3 @@ export const loadApp = async (
         )) as Record<string, unknown>);
   return resolveLoadedTopo(effectivePath, mod);
 };
-
-export const tryLoadApp = async (
-  modulePath: string | undefined,
-  cwd: string,
-  options: LoadAppOptions = {}
-): Promise<Result<Topo, Error>> => {
-  try {
-    return Result.ok(await loadApp(modulePath, cwd, options));
-  } catch (error) {
-    return Result.err(toLoadAppError(error));
-  }
-};

--- a/apps/trails/src/trails/topo-output-schemas.ts
+++ b/apps/trails/src/trails/topo-output-schemas.ts
@@ -102,9 +102,3 @@ export const signalDetailOutput = z.object({
   payload: z.record(z.string(), z.unknown()).nullable(),
   producers: z.array(z.string()).readonly(),
 });
-
-export const topoDetailOutput = z.discriminatedUnion('kind', [
-  trailDetailOutput,
-  resourceDetailOutput,
-  signalDetailOutput,
-]);

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -32,7 +32,6 @@ export const topoSnapshotOutput = z.object({
   trailCount: z.number(),
 });
 
-export const DEFAULT_APP_MODULE = './src/app.ts';
 export const DEFAULT_TOPO_HISTORY_LIMIT = 10;
 export const LOCK_PATH = '.trails/trails.lock';
 const EXAMPLE_APP_MODULE = fileURLToPath(new URL('../app.ts', import.meta.url));
@@ -150,21 +149,6 @@ export const createIsolatedExampleInput = (
     module: writeIsolatedExampleAppModule(rootDir, EXAMPLE_APP_MODULE),
     rootDir,
   };
-};
-
-export const createCurrentTopoSnapshot = (
-  app: Topo,
-  options?: { readonly rootDir?: string }
-): TopoSnapshot => {
-  const rootDir = deriveRootDir(options?.rootDir);
-  const result = persistTopoSnapshot(app, {
-    rootDir,
-    ...buildSnapshotInput(app, rootDir),
-  });
-  if (result.isErr()) {
-    throw result.error;
-  }
-  return result.value;
 };
 
 export const listTopoHistory = (options?: {

--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,6 @@
   "workspaces": {
     "": {
       "name": "trails",
-      "dependencies": {
-        "@ontrails/cli": "workspace:^",
-        "commander": "^14.0.0",
-      },
       "devDependencies": {
         "@ast-grep/cli": "0.42.1",
         "@changesets/cli": "^2.29.8",
@@ -16,7 +12,7 @@
         "@ontrails/warden": "workspace:*",
         "@types/bun": "^1.3.11",
         "@types/node": "^25.5.0",
-        "drizzle-orm": "^0.45.2",
+        "knip": "^6.12.2",
         "lefthook": "^2.1.1",
         "markdownlint-cli2": "^0.22.0",
         "oxfmt": "0.47.0",
@@ -83,7 +79,6 @@
         "@ontrails/cli": "workspace:^",
         "@ontrails/commander": "workspace:^",
         "@ontrails/core": "workspace:^",
-        "@ontrails/http": "workspace:^",
         "@ontrails/logging": "workspace:^",
         "@ontrails/observe": "workspace:^",
         "@ontrails/permits": "workspace:^",
@@ -261,7 +256,6 @@
       "devDependencies": {
         "@ontrails/config": "workspace:^",
         "@ontrails/testing": "workspace:^",
-        "@oxc-project/types": "^0.122.0",
       },
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
@@ -348,11 +342,11 @@
 
     "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
 
-    "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
@@ -454,7 +448,7 @@
 
     "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.121.0", "", { "os": "win32", "cpu": "x64" }, "sha512-BOp1KCzdboB1tPqoCPXgntgFs0jjeSyOXHzgxVFR7B/qfr3F8r4YDacHkTOUNXtDgM8YwKnkf3rE5gwALYX7NA=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
+    "@oxc-project/types": ["@oxc-project/types@0.121.0", "", {}, "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw=="],
 
     "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.19.1", "", { "os": "android", "cpu": "arm" }, "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg=="],
 
@@ -724,11 +718,17 @@
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
+    "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -743,6 +743,8 @@
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
@@ -798,6 +800,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
@@ -813,6 +817,8 @@
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
     "katex": ["katex@0.16.43", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-K7NL5JtGrFEglipOAjY4UYA69CnTuNmjArxeXF6+bw7h2OGySUPv6QWRjfb1gmutJ4Mw/qLeBqiROOEDULp4nA=="],
+
+    "knip": ["knip@6.12.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.128.0", "oxc-resolver": "^11.19.1", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-RcZpT1sVziKZgDk1F0hAcp+bq71VJAF8vg1Y9ZLXc1+UXQaMm1rjiUqpJQTIj+lqwmiBQT19/u7ikgazs23cvA=="],
 
     "lefthook": ["lefthook@2.1.4", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.4", "lefthook-darwin-x64": "2.1.4", "lefthook-freebsd-arm64": "2.1.4", "lefthook-freebsd-x64": "2.1.4", "lefthook-linux-arm64": "2.1.4", "lefthook-linux-x64": "2.1.4", "lefthook-openbsd-arm64": "2.1.4", "lefthook-openbsd-x64": "2.1.4", "lefthook-windows-arm64": "2.1.4", "lefthook-windows-x64": "2.1.4" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w=="],
 
@@ -920,6 +926,8 @@
 
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
@@ -978,7 +986,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
@@ -1005,6 +1013,8 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -1040,7 +1050,7 @@
 
     "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 
-    "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
+    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "^7.0.5", "signal-exit": "^4.0.1" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
 
@@ -1054,9 +1064,13 @@
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
@@ -1078,6 +1092,8 @@
 
     "ultracite": ["ultracite@7.6.2", "", { "dependencies": { "@clack/prompts": "^1.2.0", "commander": "^14.0.3", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.5", "yaml": "^2.8.3", "zod": "^4.3.6" }, "peerDependencies": { "oxfmt": ">=0.1.0", "oxlint": "^1.0.0" }, "optionalPeers": ["oxfmt", "oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-HonD+l9o8bFEUcVLlefpg5JuvaZH/UTB0jpCVtKAZ6xV1LGZj/hq4nGlz/eezIMmFfd6fe43LMxn1CaY/N/LaA=="],
 
+    "unbash": ["unbash@3.0.0", "", {}, "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA=="],
+
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
@@ -1087,6 +1103,8 @@
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1108,11 +1126,19 @@
 
     "@manypkg/get-packages/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
+    "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+
+    "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+
     "bun-types/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
-    "oxc-parser/@oxc-project/types": ["@oxc-project/types@0.121.0", "", {}, "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw=="],
+    "knip/oxc-parser": ["oxc-parser@0.128.0", "", { "dependencies": { "@oxc-project/types": "^0.128.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.128.0", "@oxc-parser/binding-android-arm64": "0.128.0", "@oxc-parser/binding-darwin-arm64": "0.128.0", "@oxc-parser/binding-darwin-x64": "0.128.0", "@oxc-parser/binding-freebsd-x64": "0.128.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.128.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.128.0", "@oxc-parser/binding-linux-arm64-gnu": "0.128.0", "@oxc-parser/binding-linux-arm64-musl": "0.128.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.128.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.128.0", "@oxc-parser/binding-linux-riscv64-musl": "0.128.0", "@oxc-parser/binding-linux-s390x-gnu": "0.128.0", "@oxc-parser/binding-linux-x64-gnu": "0.128.0", "@oxc-parser/binding-linux-x64-musl": "0.128.0", "@oxc-parser/binding-openharmony-arm64": "0.128.0", "@oxc-parser/binding-wasm32-wasi": "0.128.0", "@oxc-parser/binding-win32-arm64-msvc": "0.128.0", "@oxc-parser/binding-win32-ia32-msvc": "0.128.0", "@oxc-parser/binding-win32-x64-msvc": "0.128.0" } }, "sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw=="],
+
+    "markdownlint-cli2/smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
@@ -1122,8 +1148,54 @@
 
     "@manypkg/get-packages/globby/slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
+    "@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.128.0", "", { "os": "android", "cpu": "arm" }, "sha512-aca6ZvzmCBUGOANQRiRQRZuRKYI3ENhcit6GisnknOOmcezfQc7xJ4dxlPU7MV7mOvrC7RNR1u3LAD7xyaiCxA=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.128.0", "", { "os": "android", "cpu": "arm64" }, "sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.128.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tRUHPt80417QmvNpoSslJT1VY8NUbWdrWR+L14Zn+RbOTcaqB8E6PYE/ZGN8jjWBzqporiA/H4MfO50ew/NCNA=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.128.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.128.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hhpdVMaNCLgQxjgNPeeFzSeJMmZPc5lKfv0NGSI3egZq9EdnEGqeC8JsYsQjK7PoQgbvZ17xlj0SO5ziH5Obkg=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.128.0", "", { "os": "linux", "cpu": "arm" }, "sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.128.0", "", { "os": "linux", "cpu": "arm" }, "sha512-fq7DmKmfC+dvD97IXrgbph6Jzwe0EDu+PYMofmzZ6fv5X1k9vtaqLpDGMuICO9MmUnyKAQmVl+wIv2RNy4Dz8g=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.128.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.128.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.128.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.128.0", "", { "os": "linux", "cpu": "none" }, "sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.128.0", "", { "os": "linux", "cpu": "none" }, "sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.128.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.128.0", "", { "os": "linux", "cpu": "x64" }, "sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.128.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.128.0", "", { "os": "none", "cpu": "arm64" }, "sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.128.0", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-L38ojghJYHmgiz6fJd7jwLB/ESDBpB02NdFxh+smqVM6P2anCEvHn0jhaSrt5eVNR1Ak8+moOeftUlofeyvniA=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.128.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.128.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-OY+3eM2SN72prHKRB22mPz8o5A/7dJ+f5DFLBVvggyZhEaNDAH9IB+ElMjmOkOIwf5MDCUAowCK7pAncNxzpBA=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.128.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw=="],
+
+    "knip/oxc-parser/@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
+
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "knip/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
   }
 }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,0 +1,93 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { KnipConfig } from 'knip';
+
+type WorkspaceConfig = NonNullable<KnipConfig['workspaces']>[string];
+
+const ifFile = (workspace: string, pattern: string): string[] =>
+  existsSync(join(workspace, pattern)) ? [pattern] : [];
+
+const ifDirectory = (
+  workspace: string,
+  directory: string,
+  pattern: string
+): string[] => (existsSync(join(workspace, directory)) ? [pattern] : []);
+
+const packageWorkspaceDirs = (base: string): string[] => {
+  if (!existsSync(base)) {
+    throw new Error(
+      `knip config expected workspace directory "${base}" to exist`
+    );
+  }
+  return readdirSync(base, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        existsSync(join(base, entry.name, 'package.json'))
+    )
+    .map((entry) => `${base}/${entry.name}`)
+    .toSorted();
+};
+
+const createLibraryWorkspace = (workspace: string): WorkspaceConfig => ({
+  entry: [
+    ...ifFile(workspace, 'src/type-checks.test-d.ts'),
+    ...ifDirectory(workspace, 'src/__tests__', 'src/__tests__/**/*.ts'),
+    ...ifDirectory(workspace, 'bin', 'bin/**/*.ts'),
+    ...ifDirectory(workspace, 'scripts', 'scripts/**/*.ts'),
+    ...ifDirectory(workspace, '__tests__', '__tests__/**/*.ts'),
+  ],
+  project: [
+    ...ifDirectory(workspace, 'src', 'src/**/*.ts'),
+    ...ifDirectory(workspace, 'bin', 'bin/**/*.ts'),
+    ...ifDirectory(workspace, 'scripts', 'scripts/**/*.ts'),
+    ...ifDirectory(workspace, '__tests__', '__tests__/**/*.ts'),
+  ],
+});
+
+const createAppWorkspace = (workspace: string): WorkspaceConfig => ({
+  entry: [
+    ...ifDirectory(workspace, 'bin', 'bin/**/*.ts'),
+    ...ifFile(workspace, 'src/mcp.ts'),
+    ...ifDirectory(workspace, 'src/__tests__', 'src/__tests__/**/*.ts'),
+    ...ifDirectory(workspace, '__tests__', '__tests__/**/*.ts'),
+  ],
+  project: [
+    ...ifDirectory(workspace, 'src', 'src/**/*.ts'),
+    ...ifDirectory(workspace, 'bin', 'bin/**/*.ts'),
+    ...ifDirectory(workspace, '__tests__', '__tests__/**/*.ts'),
+  ],
+});
+
+const workspaceEntries = [
+  ...packageWorkspaceDirs('packages').map(
+    (workspace) => [workspace, createLibraryWorkspace(workspace)] as const
+  ),
+  ...packageWorkspaceDirs('adapters').map(
+    (workspace) => [workspace, createLibraryWorkspace(workspace)] as const
+  ),
+  ...packageWorkspaceDirs('apps').map(
+    (workspace) => [workspace, createAppWorkspace(workspace)] as const
+  ),
+];
+
+const config: KnipConfig = {
+  ignoreExportsUsedInFile: true,
+  treatConfigHintsAsErrors: true,
+  workspaces: {
+    '.': {
+      entry: [
+        'scripts/adr.ts',
+        'scripts/bootstrap/main.ts',
+        'scripts/verify-oxc-resolver-published.ts',
+        'scripts/__tests__/**/*.ts',
+        'trails.config.ts',
+      ],
+      project: ['scripts/**/*.ts'],
+    },
+    ...Object.fromEntries(workspaceEntries),
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "trails",
   "private": true,
-  "bin": {
-    "trails": "./src/cli.ts"
-  },
   "workspaces": [
     "packages/*",
     "adapters/*",
@@ -27,6 +24,7 @@
     "warden:agents:check": "bun scripts/sync-agents-warden-guide.ts --check",
     "warden:skills:sync": "bun scripts/sync-skill-warden-guide.ts",
     "warden:skills:check": "bun scripts/sync-skill-warden-guide.ts --check",
+    "dead-code": "knip --no-progress",
     "trails": "bun apps/trails/bin/trails.ts",
     "trails:check": "bun trails warden",
     "format:check": "bun run oxlint-plugin:build && bunx ultracite check .",
@@ -35,15 +33,11 @@
     "format:guard": "if git grep -nE \"(\\\\./)?node_modules/\\\\.bin/ultra[c]ite\" -- ':!bun.lock'; then echo 'Direct node_modules/.bin formatter invocation found'; exit 1; fi",
     "mdlint:fix": "./node_modules/.bin/markdownlint-cli2 --fix",
     "typecheck": "turbo run typecheck",
-    "check": "bun run lint && bun run lint:ast-grep && bun run format:check && bun run typecheck && bun run docs:snippets && bun run scaffold-versions:check && bun run warden:agents:check && bun run warden:skills:check && bun run trails:check",
+    "check": "bun run lint && bun run lint:ast-grep && bun run format:check && bun run typecheck && bun run docs:snippets && bun run scaffold-versions:check && bun run warden:agents:check && bun run warden:skills:check && bun run trails:check && bun run dead-code",
     "clean": "turbo run clean --no-cache && rm -rf node_modules",
     "oxlint-plugin:build": "bun run --cwd packages/oxlint-plugin build:oxlint",
     "publish:check": "bun scripts/publish.ts --check",
     "publish:packages": "bun scripts/publish.ts"
-  },
-  "dependencies": {
-    "@ontrails/cli": "workspace:^",
-    "commander": "^14.0.0"
   },
   "devDependencies": {
     "@ast-grep/cli": "0.42.1",
@@ -53,7 +47,7 @@
     "@ontrails/warden": "workspace:*",
     "@types/bun": "^1.3.11",
     "@types/node": "^25.5.0",
-    "drizzle-orm": "^0.45.2",
+    "knip": "^6.12.2",
     "lefthook": "^2.1.1",
     "markdownlint-cli2": "^0.22.0",
     "oxfmt": "0.47.0",

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -168,24 +168,6 @@ export const deserializeError = (data: SerializedError): TrailsError => {
   return error;
 };
 
-// ---------------------------------------------------------------------------
-// Safe JSON
-// ---------------------------------------------------------------------------
-
-/** Parse a JSON string, returning a Result instead of throwing. */
-export const safeParse = (json: string): Result<unknown, ValidationError> => {
-  try {
-    return Result.ok(JSON.parse(json) as unknown);
-  } catch (error) {
-    return Result.err(
-      new ValidationError('Invalid JSON', {
-        cause: error instanceof Error ? error : new Error(String(error)),
-        context: { input: json.slice(0, 200) },
-      })
-    );
-  }
-};
-
 /** Stringify a value, returning a Result. Handles circular references. */
 export const safeStringify = (
   value: unknown

--- a/packages/observe/src/memory.ts
+++ b/packages/observe/src/memory.ts
@@ -57,4 +57,5 @@ export const createMemorySink = (
   };
 };
 
+/** @alias */
 export const createBoundedMemorySink = createMemorySink;

--- a/packages/oxlint-plugin/src/rules/shared.ts
+++ b/packages/oxlint-plugin/src/rules/shared.ts
@@ -9,7 +9,6 @@ export type RuleContext = Context;
 export type RuleModule = CreateRule;
 
 const PACKAGES_SRC_PATTERN = /(?:^|\/)packages\/[^/]+\/src\//u;
-const PACKAGE_NAME_PATTERN = /(?:^|\/)packages\/([^/]+)\/src\//u;
 const PACKAGE_OR_ADAPTER_SRC_PATTERN =
   /(?:^|\/)(?:adapters|packages)\/[^/]+\/src\//u;
 const PACKAGE_OR_ADAPTER_NAME_PATTERN =
@@ -102,16 +101,6 @@ export const isRepoSourceFile = (filePath: string | undefined): boolean => {
   );
 };
 
-export const extractPackageName = (
-  filePath: string | undefined
-): string | undefined => {
-  if (!filePath) {
-    return undefined;
-  }
-
-  return normalizeFilePath(filePath).match(PACKAGE_NAME_PATTERN)?.[1];
-};
-
 export const extractPackageOrAdapterName = (
   filePath: string | undefined
 ): string | undefined => {
@@ -139,14 +128,6 @@ export const resolveAllowedPackages = (
     allowedPackages.filter(
       (packageName): packageName is string => typeof packageName === 'string'
     )
-  );
-};
-
-export const isAllowedPackage = (context: RuleContext): boolean => {
-  const packageName = extractPackageName(context.filename);
-  return (
-    typeof packageName === 'string' &&
-    resolveAllowedPackages(context.options).has(packageName)
   );
 };
 

--- a/packages/store/src/jsonfile/runtime.ts
+++ b/packages/store/src/jsonfile/runtime.ts
@@ -698,5 +698,3 @@ export const jsonFile = <TStore extends AnyStoreDefinition>(
     signals: store.signals,
   });
 };
-
-export { jsonFile as store };

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -545,12 +545,11 @@ type AssertExtends<TActual, TExpected> = TActual extends TExpected
 
 /**
  * Pins the structural relationship between `StoreAccessor` and the core
- * `StoreAccessorProtocol`. Exported so `noUnusedLocals` sees it as live; the
- * type is purely a compile-time marker and contributes no runtime shape. If
- * this type ever resolves to `never`, the protocol in core has drifted from
- * the store accessor contract — fix the protocol shape, not this assertion.
+ * `StoreAccessorProtocol`. If this check resolves to `never`, the protocol in
+ * core has drifted from the store accessor contract — fix the protocol shape,
+ * not this assertion.
  */
-export type AssertStoreAccessorSatisfiesProtocol = AssertExtends<
+const storeAccessorProtocolCheck: AssertExtends<
   StoreAccessor<AnyStoreTable>,
   StoreAccessorProtocol<
     UpsertOf<AnyStoreTable>,
@@ -558,7 +557,9 @@ export type AssertStoreAccessorSatisfiesProtocol = AssertExtends<
     StoreIdentifierOf<AnyStoreTable>,
     FiltersOf<AnyStoreTable>
   >
->;
+> = true;
+
+void storeAccessorProtocolCheck;
 
 /**
  * Tabular writable operations layered on top of the backend-agnostic

--- a/packages/tracing/src/memory-sink.ts
+++ b/packages/tracing/src/memory-sink.ts
@@ -60,4 +60,5 @@ export const createMemorySink = (
   };
 };
 
+/** @alias */
 export const createBoundedMemorySink = createMemorySink;

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -37,8 +37,7 @@
   },
   "devDependencies": {
     "@ontrails/config": "workspace:^",
-    "@ontrails/testing": "workspace:^",
-    "@oxc-project/types": "^0.122.0"
+    "@ontrails/testing": "workspace:^"
   },
   "peerDependencies": {
     "@ontrails/core": "workspace:^",

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -486,11 +486,6 @@ export const collectResourceDefinitionIds = (
   return ids;
 };
 
-/** Backward-compatible aliases while the migration is in flight. */
-export const collectNamedServiceIds = collectNamedResourceIds;
-/** Backward-compatible aliases while the migration is in flight. */
-export const collectServiceDefinitionIds = collectResourceDefinitionIds;
-
 // ---------------------------------------------------------------------------
 // Config property extraction helpers
 // ---------------------------------------------------------------------------
@@ -2484,25 +2479,6 @@ const collectStringIdsFromDeclaration = (
   }
 };
 
-/** Collect module-scope `const foo = signal('id', ...)` bindings from a file. */
-export const collectNamedSignalIds = (
-  ast: AstNode
-): ReadonlyMap<string, string> => {
-  const ids = new Map<string, string>();
-  const context = buildFrameworkNamespaceContext(ast);
-  const statements =
-    (ast as unknown as { body?: readonly AstNode[] }).body ?? [];
-
-  for (const statement of statements) {
-    const declaration = unwrapTopLevelDeclaration(statement);
-    if (declaration.type === 'VariableDeclaration') {
-      collectSignalIdsFromDeclaration(declaration, context, ids);
-    }
-  }
-
-  return ids;
-};
-
 export type SignalIdentifierResolution =
   | {
       readonly id: string;
@@ -2911,14 +2887,6 @@ export const extractStoreTableFromMember = (
 };
 
 /**
- * Back-compat shim for rule code that only needs the table name. Prefer
- * `extractStoreTableFromMember` so the caller can build a composite key.
- */
-export const extractStoreTableIdFromMember = (
-  node: AstNode | undefined
-): string | null => extractStoreTableFromMember(node)?.tableName ?? null;
-
-/**
  * Collect `const foo = <store>.tables.<name>` bindings from a parsed file,
  * keyed by the local binding name. Values are the composite table key
  * (`${storeBinding}:${tableName}`) so callers can dedupe across stores that
@@ -3056,15 +3024,6 @@ export const findStoreTableDefinitions = (
 
   return definitions;
 };
-
-export const collectVersionedStoreTableIds = (
-  ast: AstNode
-): ReadonlySet<string> =>
-  new Set(
-    findStoreTableDefinitions(ast).flatMap((definition) =>
-      definition.versioned ? [definition.key] : []
-    )
-  );
 
 export const collectCrudTableIds = (ast: AstNode): ReadonlySet<string> => {
   const ids = new Set<string>();

--- a/packages/warden/src/rules/scan.ts
+++ b/packages/warden/src/rules/scan.ts
@@ -9,11 +9,6 @@ const FRAMEWORK_INTERNAL_SEGMENTS = [
 const normalizeFilePath = (filePath: string): string =>
   filePath.replaceAll('\\', '/');
 
-const maskText = (text: string): string => text.replaceAll(/[^\n]/g, ' ');
-
-const stripPattern = (sourceCode: string, pattern: RegExp): string =>
-  sourceCode.replaceAll(pattern, (match) => maskText(match));
-
 export const isTestFile = (filePath: string): boolean =>
   TEST_FILE_PATTERN.test(normalizeFilePath(filePath));
 
@@ -22,25 +17,4 @@ export const isFrameworkInternalFile = (filePath: string): boolean => {
   return FRAMEWORK_INTERNAL_SEGMENTS.some((segment) =>
     normalized.includes(segment)
   );
-};
-
-/**
- * Replace quoted content and comments with whitespace while preserving line
- * breaks so simple line-based scanners do not match examples or messages.
- */
-export const stripQuotedContent = (sourceCode: string): string => {
-  let sanitized = sourceCode;
-  const patterns = [
-    /\/\/[^\n]*/g,
-    /\/\*[\s\S]*?\*\//g,
-    /'[^'\\\n]*(?:\\.[^'\\\n]*)*'/g,
-    /"[^"\\\n]*(?:\\.[^"\\\n]*)*"/g,
-    /`[\s\S]*?`/g,
-  ];
-
-  for (const pattern of patterns) {
-    sanitized = stripPattern(sanitized, pattern);
-  }
-
-  return sanitized;
 };


### PR DESCRIPTION
## Context

This is the top branch of the Warden Guidance + Knip Capstone stack and closes TRL-684.

The repo needed a real dead-code gate after the Warden guidance stack landed. This branch adopts Knip v6 with Bun, wires it into the root check, and cleans up actual findings instead of hiding them with broad ignores.

## What changed

- Added `knip@6.12.2` with Bun.
- Added root `knip.config.ts` using `packages/*`, `adapters/*`, and `apps/*`; no stale `connectors/*` workspace paths.
- Added `bun run dead-code` as `knip --no-progress`.
- Wired `dead-code` into root `bun run check`.
- Removed stale root package metadata and unused package dependencies surfaced by Knip.
- Removed stale unused internal exports and helper shims instead of masking them.
- Marked intentional documentation/public aliases with narrow Knip tags.

## How to test

- `bun run dead-code`
- `bun run check`
- `bun run publish:check`
- Final stack-tip gates also passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `git diff --check`.

## Risks/rollout notes

Knip is now part of the required local/CI check path. The config is intentionally narrow and should fail on new unused dependencies, exports, and files instead of allowing broad ignored drift.

## Release

Changeset: `.changeset/knip-dead-code.md` because Knip cleanup touches publishable package contents and package metadata.

Closes: TRL-684
