### PR TITLE
docs: define observability package boundary

### DIFF
--- a/.changeset/observability-v1-boundary.md
+++ b/.changeset/observability-v1-boundary.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/observe": patch
+"@ontrails/tracing": patch
+---
+
+Document the v1 observability package boundary: `@ontrails/observe` is the production sink contract package, while `@ontrails/tracing` remains the compatibility and developer-state package with the supported `@ontrails/tracing/otel` adapter subpath.

--- a/docs/adr/0041-unified-observability.md
+++ b/docs/adr/0041-unified-observability.md
@@ -4,7 +4,7 @@ slug: unified-observability
 title: Unified Observability
 status: accepted
 created: 2026-04-09
-updated: 2026-05-02
+updated: 2026-05-09
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [6, 13, 39]
 ---
@@ -120,7 +120,7 @@ This keeps activation visible in traces even when no normal trail record exists,
 
 ### Production observability in `@ontrails/observe`
 
-`@ontrails/observe` is the public package for production and durable observability adapters. The first shipped surface is intentionally small and dependency-free: root exports for log/trace sink contracts, `combine(...)`, console/file log sinks, and bounded memory trace sinks. Connector packages can build on those contracts without importing framework internals directly.
+`@ontrails/observe` is the public package for production and durable observability adapters. The first shipped surface is intentionally small and dependency-free: root exports for log/trace sink contracts, `combine(...)`, console/file log sinks, bounded memory trace sinks, and trace rendering helpers. Adapter packages can build on those contracts without importing framework internals directly.
 
 | Initial primitive | Purpose |
 | --- | --- |
@@ -129,20 +129,28 @@ This keeps activation visible in traces even when no normal trail record exists,
 | `createFileSink(options)` | Append log records to a file; retention and rotation stay external. |
 | `createMemorySink(options?)` | Retain bounded trace records for local tooling and tests. |
 
-Future connector exports, such as OpenTelemetry export or a SQLite dev store, remain packaging decisions. They belong in or beside `@ontrails/observe`, but this ADR does not canonize exact subpath names or the complete connector set.
+Future adapter exports beyond the v1 boundary remain packaging decisions. For v1, the dependency-light production sink contracts live in `@ontrails/observe`, while `@ontrails/tracing` intentionally owns tracing-specific developer-state tooling and the supported `@ontrails/tracing/otel` adapter subpath.
+
+### V1 package boundary
+
+For v1, `@ontrails/observe` is the canonical production observability package. App code and adapters that need log and trace sink contracts, sink composition, zero-dependency console/file/memory sinks, or trace rendering should import those APIs from `@ontrails/observe`.
+
+`@ontrails/tracing` remains an intentional compatibility and developer-state package. It re-exports core tracing primitives so existing imports continue to work, and it owns tracing-specific local tooling that is not just a sink contract: sampling helpers, the tracing resource, tracing query/status trails, the SQLite dev store, and dev-state maintenance helpers.
+
+`@ontrails/tracing/otel` remains the supported v1 OpenTelemetry adapter subpath. The API uses adapter vocabulary (`createOtelAdapter`, `OtelAdapterOptions`) and may move to a dedicated adapter package in a later release, but v1 does not require creating `@ontrails/otel`.
 
 ### Dev-time tracing vs production observability
 
 The split is deliberate. Core handles the inner development loop. `@ontrails/observe` handles production.
 
-| Concern | Core (intrinsic) | `@ontrails/observe` and connectors |
+| Concern | Core and `@ontrails/tracing` | `@ontrails/observe` and adapters |
 | --- | --- | --- |
-| Logging | Console logger, `ctx.logger` | OTel export, file sinks, pretty formatter |
-| Tracing | `TraceRecord`, `ctx.trace()`, propagation, sink registry, `NOOP_SINK` | Bounded memory sink, OTel export, SQLite dev store |
-| Configuration | Zero — works out of the box | Connector-level options (sampling, batching, levels) |
-| Dependencies | None beyond core | OpenTelemetry SDK, `bun:sqlite` |
+| Logging | Core logger contract, `ctx.logger` | Console/file sinks, pretty formatter, LogTape adapter |
+| Tracing | `TraceRecord`, `ctx.trace()`, propagation, sink registry, `NOOP_SINK`, sampling helpers, SQLite dev store, `@ontrails/tracing/otel` | Bounded memory sink, trace rendering, future production adapters |
+| Configuration | Zero — works out of the box; tracing dev-state bootstrap when query trails need a store | Adapter-level options for sinks, formatting, batching, and forwarding |
+| Dependencies | Core stays dependency-free; `@ontrails/tracing` owns `bun:sqlite` dev-state and the v1 OTel bridge | No dependencies beyond core for the shipped `@ontrails/observe` package |
 
-A developer never needs `@ontrails/observe` to build, test, or debug locally. They need it when traces and logs must leave the process.
+A developer never needs `@ontrails/observe` to define or run trails. They need it when app code wants an explicit sink, trace rendering, file/console log output, or durable/exported observability. `@ontrails/tracing` remains the v1 home for local tracing state and query tooling.
 
 ### Topo configuration
 
@@ -173,7 +181,7 @@ const app = topo('myapp', trails, {
 })
 ```
 
-The sink or connector owns the details: sampling rates, log levels, formatting, batching. These are connector configuration, not topo configuration. The topo says "observe with this." One declaration.
+The sink or adapter owns the details: sampling rates, log levels, formatting, batching. These are adapter configuration, not topo configuration. The topo says "observe with this." One declaration.
 
 ```typescript
 futureOtelConnector({
@@ -228,18 +236,18 @@ Logger, TrailContext, executeTrail
 
 // New in core:
 TraceRecord                          // one recorded execution footprint
-createConsoleLogger(options?)        // default logger, no deps
+createObserveLogger(options?)        // default structured logger, no deps
 ctx.trace(name, fn)                  // manual sub-step recording
 TraceSink, NOOP_SINK                 // sink contract and disabled baseline
 registerTraceSink, getTraceSink      // process-level sink registry
 // Built-in tracing intrinsic to executeTrail
 ```
 
-Everything else — developer-configurable memory sinks, OTel, file sinks, SQLite dev stores, pretty formatters, sampling configuration — belongs in `@ontrails/observe` or compatibility/connector packages that build on the same contracts.
+Everything else — developer-configurable memory sinks, OTel, file sinks, SQLite dev stores, pretty formatters, sampling configuration — belongs in `@ontrails/observe` or compatibility/adapter packages that build on the same contracts.
 
 ## Non-goals
 
-- **Metrics.** Core does not ship a metrics primitive. If metrics are needed, `@ontrails/observe` can add a metrics connector. Trace data (duration, error rates) can be derived into metrics at the OTel layer.
+- **Metrics.** Core does not ship a metrics primitive. If metrics are needed, `@ontrails/observe` can add a metrics adapter. Trace data (duration, error rates) can be derived into metrics at the OTel layer.
 - **Distributed tracing.** Trace context propagation across trail crossings within a single process is in scope. Propagation across network boundaries (cross-app) is a future concern for the mount/pack system.
 - **Replacing OpenTelemetry.** The framework maintains a Trails-native model internally. OTel is the export format, not the internal representation. An OTel connector translates outward from `TraceRecord` to OTel spans.
 
@@ -257,7 +265,7 @@ Everything else — developer-configurable memory sinks, OTel, file sinks, SQLit
 
 - **Core grows.** Adding built-in tracing, the trace record model, and console logger to core increases its surface area. This is justified because `executeTrail` is already in core and tracing wraps it — the natural home for automatic recording is next to the thing being recorded.
 - **Migration from earlier trace packaging.** Package imports and sink configuration restructure around `@ontrails/observe`. This is a pre-1.0 change, so the migration cost is limited to internal and early adopters.
-- **Connector owns config details.** Sampling, log level, and formatting are connector concerns, not topo concerns. This keeps the topo config surface minimal but means developers configure observability behavior through their connector, not through a central config object.
+- **Adapter owns config details.** Sampling, log level, and formatting are adapter concerns, not topo concerns. This keeps the topo config surface minimal but means developers configure observability behavior through their adapter, not through a central config object.
 
 ### Risks
 

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -2179,7 +2179,7 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Unified Observability",
-      "updated": "2026-05-02"
+      "updated": "2026-05-09"
     },
     {
       "created": "2026-05-02",

--- a/packages/observe/README.md
+++ b/packages/observe/README.md
@@ -6,6 +6,21 @@ This package is the public home for log and trace sink shapes used by Trails
 apps and adapters. It includes zero-dependency sinks for local and server
 baselines, plus adapter composition for production observability.
 
+## V1 package boundary
+
+Use `@ontrails/observe` for app-facing observability contracts and sinks:
+`LogSink`, `TraceSink`, `combine(...)`, console/file sinks, bounded memory
+sinks, and trace rendering.
+
+`@ontrails/core` owns intrinsic tracing execution: `TraceRecord`,
+`ctx.trace()`, trace context propagation, and the process-level trace sink
+registry.
+
+`@ontrails/tracing` remains a compatibility and developer-state package for
+tracing-specific local tooling: query/status trails, the SQLite dev store,
+sampling helpers, and the supported `@ontrails/tracing/otel` OpenTelemetry
+adapter subpath.
+
 ```typescript
 import {
   combine,

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -1,8 +1,24 @@
 # @ontrails/tracing
 
-Sinks and query trails for the intrinsic tracing that ships in `@ontrails/core`.
+Compatibility and developer-state tooling for the intrinsic tracing that ships
+in `@ontrails/core`.
 
-Tracing is built into `executeTrail`. When a real sink is installed, each trail execution writes a root `TraceRecord` automatically, `ctx.trace()` writes child spans, typed signal fan-out writes `signal.*` lifecycle records, and runtime materializers write activation boundary records. When `NOOP_SINK` is installed, the tracing path short-circuits and `ctx.trace()` remains a passthrough. This package provides the pluggable sinks, the `NOOP_SINK` sentinel, the manual span API via `ctx.trace()`, and query trails that let you inspect recorded history. See [ADR-0023](../../docs/adr/0023-simplifying-the-trails-lexicon.md) for the design rationale.
+Tracing is built into `executeTrail`. When a real sink is installed, each trail execution writes a root `TraceRecord` automatically, `ctx.trace()` writes child spans, typed signal fan-out writes `signal.*` lifecycle records, and runtime materializers write activation boundary records. When `NOOP_SINK` is installed, the tracing path short-circuits and `ctx.trace()` remains a passthrough. This package re-exports the core tracing primitives for compatibility and provides tracing-specific local tooling: sampling helpers, the tracing resource, query/status trails, the SQLite dev store, dev-state maintenance helpers, and the OpenTelemetry adapter. See [ADR-0041](../../docs/adr/0041-unified-observability.md) for the v1 observability boundary and [ADR-0023](../../docs/adr/0023-simplifying-the-trails-lexicon.md) for the rename history.
+
+## V1 package boundary
+
+Use `@ontrails/observe` for the production observability boundary: log and
+trace sink contracts, `combine(...)`, console/file sinks, bounded memory sinks,
+and trace tree rendering.
+
+Use `@ontrails/tracing` when you need compatibility imports for core tracing
+primitives or tracing-specific developer-state APIs such as `tracingResource`,
+`tracingStatus`, `tracingQuery`, `createDevStore`, sampling helpers, or
+dev-store cleanup helpers.
+
+The `@ontrails/tracing/otel` subpath remains the supported v1 OpenTelemetry
+adapter path. It exports adapter-named APIs such as `createOtelAdapter` and
+`OtelAdapterOptions`; no separate `@ontrails/otel` package is required for v1.
 
 ## The core pattern
 
@@ -15,7 +31,7 @@ const sink = createMemorySink({ maxRecords: 1000 });
 registerTraceSink(sink);
 ```
 
-Sinks receive completed `TraceRecord` records. The default sink is `NOOP_SINK` — tracing APIs still work without configuration, but root/span/signal/activation record allocation is skipped until you register a real sink. Use a bounded memory sink for testing and local trace rendering, a dev store for local development, or an OTel adapter to forward to your collector. Use `registerTraceSink(NOOP_SINK)` or `clearTraceSink()` to switch back to the silent baseline.
+Sinks receive completed `TraceRecord` records. The default sink is `NOOP_SINK` — tracing APIs still work without configuration, but root/span/signal/activation record allocation is skipped until you register a real sink. Use `@ontrails/observe` for app-level sink contracts and zero-dependency sinks, use this package's dev store for local tracing state, or use the OTel adapter to forward to your collector. Use `registerTraceSink(NOOP_SINK)` or `clearTraceSink()` to switch back to the silent baseline.
 
 Signal fan-out records use lexicon-aligned names: `signal.fired`, `signal.invalid`, `signal.handler.invoked`, `signal.handler.completed`, and `signal.handler.failed`. Signal record attrs carry IDs and redacted payload summaries, never raw payloads by default.
 
@@ -28,7 +44,7 @@ Tracing happens automatically when a real sink is installed. No layer attachment
 ```typescript
 await run(graph, 'user.create', { name: 'alice' });
 
-// sink.records now contains a root TraceRecord for the execution
+// sink.records() now contains a root TraceRecord for the execution
 ```
 
 ### 3. Manual spans inside a blaze
@@ -94,14 +110,16 @@ Invoke programmatically via `run()` or `ctx.cross('tracing.query', { trailId: 'u
 For testing and demos:
 
 ```typescript
-import { createMemorySink, registerTraceSink, clearTraceSink } from '@ontrails/tracing';
+import { createMemorySink } from '@ontrails/observe';
+import { registerTraceSink, clearTraceSink } from '@ontrails/tracing';
 
 const sink = createMemorySink({ maxRecords: 500 });
 registerTraceSink(sink);
 try {
   // ... run trails ...
-  expect(sink.records).toHaveLength(3);
-  expect(sink.records[0]?.status).toBe('ok');
+  const records = sink.records();
+  expect(records).toHaveLength(3);
+  expect(records[0]?.status).toBe('ok');
 } finally {
   clearTraceSink();
 }
@@ -117,7 +135,11 @@ same factory. `clearTraceSink()` restores `NOOP_SINK`.
 SQLite-backed persistence for local development:
 
 ```typescript
-import { createDevStore, registerTraceSink } from '@ontrails/tracing';
+import {
+  createDevStore,
+  registerTraceSink,
+  registerTraceStore,
+} from '@ontrails/tracing';
 
 const store = createDevStore({
   path: './debug.db',
@@ -125,6 +147,7 @@ const store = createDevStore({
   maxAge: 1000 * 60 * 60 * 24 * 30,
 });
 registerTraceSink(store);
+registerTraceStore(store);
 ```
 
 The dev store uses WAL mode and prunes automatically. Use `toTraceStore(store)`
@@ -136,7 +159,8 @@ underlying writable connection.
 Export traces to any OTel-compatible collector:
 
 ```typescript
-import { createOtelAdapter, registerTraceSink } from '@ontrails/tracing';
+import { createOtelAdapter } from '@ontrails/tracing/otel';
+import { registerTraceSink } from '@ontrails/tracing';
 
 const sink = createOtelAdapter({
   exporter: async (spans) => {
@@ -169,15 +193,17 @@ if (shouldSample('read', config)) {
 ## Testing
 
 ```typescript
-import { createMemorySink, registerTraceSink, clearTraceSink } from '@ontrails/tracing';
+import { createMemorySink } from '@ontrails/observe';
+import { registerTraceSink, clearTraceSink } from '@ontrails/tracing';
 import { testAll } from '@ontrails/testing';
 
 const sink = createMemorySink();
 registerTraceSink(sink);
 try {
   testAll(app);
-  expect(sink.records).toHaveLength(5);
-  expect(sink.records.filter((r) => r.status === 'err')).toHaveLength(0);
+  const records = sink.records();
+  expect(records).toHaveLength(5);
+  expect(records.filter((r) => r.status === 'err')).toHaveLength(0);
 } finally {
   clearTraceSink();
 }

--- a/scripts/check-readme-snippets.ts
+++ b/scripts/check-readme-snippets.ts
@@ -43,6 +43,21 @@ declare module '@ontrails/testing' {
   export function testAll(app: import('@ontrails/core').Topo): Promise<unknown>;
 }
 
+declare module '@ontrails/observe' {
+  export interface MemorySink {
+    readonly maxRecords: number;
+    readonly droppedCount: number;
+    readonly clear: () => void;
+    readonly records: () => readonly import('@ontrails/tracing').TraceRecord[];
+  }
+
+  export interface MemorySinkOptions {
+    readonly maxRecords?: number | undefined;
+  }
+
+  export function createMemorySink(options?: MemorySinkOptions): MemorySink;
+}
+
 declare module '@ontrails/tracing' {
   export interface TraceRecord {
     readonly status?: string;
@@ -78,6 +93,7 @@ declare module '@ontrails/tracing' {
     readonly batchSize?: number;
     readonly exporter: (spans: unknown) => Promise<void>;
   }): unknown;
+  export function registerTraceStore(store: unknown): void;
   export function registerTraceSink(sink: unknown): void;
   export function shouldSample(
     intent: 'destroy' | 'read' | 'write',
@@ -86,6 +102,13 @@ declare module '@ontrails/tracing' {
   export const tracingResource: {
     from(ctx: unknown): { active: boolean; store?: { count(): number } };
   };
+}
+
+declare module '@ontrails/tracing/otel' {
+  export function createOtelAdapter(options: {
+    readonly batchSize?: number;
+    readonly exporter: (spans: unknown) => Promise<void>;
+  }): unknown;
 }
 
 declare const app: import('@ontrails/core').Topo;


### PR DESCRIPTION
## Context

This starts the Public Surface + Observability Cleanup stack by settling the v1 package boundary between `@ontrails/observe`, `@ontrails/tracing`, and core-owned intrinsic tracing.

## What Changed

- Documented `@ontrails/observe` as the production log/trace sink contract package.
- Kept `@ontrails/tracing` as the compatibility and developer-state package for query/status trails, SQLite dev state, sampling helpers, and the supported `@ontrails/tracing/otel` adapter subpath.
- Updated ADR-0041 plus observe/tracing README guidance around memory sinks, registry helpers, OTel options, and dev-store registration.

## How To Test

- `bun run --cwd packages/tracing typecheck`
- `bun run --cwd packages/observe typecheck`
- `bun run docs:snippets`
- Final stack-tip verification: `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run dead-code`, `bun run build`, `bun run docs:snippets`, `bun run warden:agents:check`, `bun run warden:skills:check`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`

## Risks / Rollout Notes

Docs-only boundary decision. The main risk is future package confusion; this PR records the v1 split without moving the OTel adapter into a new package.

## Release / Changeset

Includes a changeset for `@ontrails/observe` and `@ontrails/tracing` because package READMEs and public boundary guidance changed.

Closes: TRL-645
