### PR TITLE
refactor: clarify store topographer helper subpaths

### DIFF
--- a/.changeset/public-helper-subpaths.md
+++ b/.changeset/public-helper-subpaths.md
@@ -1,0 +1,10 @@
+---
+"@ontrails/store": major
+"@ontrails/topographer": major
+"@ontrails/core": patch
+"@ontrails/drizzle": patch
+"@ontrails/trails": patch
+"@ontrails/warden": patch
+---
+
+Move store adapter-binding helpers to `@ontrails/store/adapter-support` and topographer direct database/admin helpers to `@ontrails/topographer/backend-support`, keeping root exports focused on contract-level APIs.

--- a/adapters/drizzle/src/runtime.ts
+++ b/adapters/drizzle/src/runtime.ts
@@ -10,7 +10,8 @@ import {
   ValidationError,
   resource,
 } from '@ontrails/core';
-import { bindStoreDefinition, versionFieldName } from '@ontrails/store';
+import { versionFieldName } from '@ontrails/store';
+import { bindStoreDefinition } from '@ontrails/store/adapter-support';
 import type {
   AnyStoreDefinition,
   AnyStoreTable,

--- a/apps/trails/src/trails/dev-support.ts
+++ b/apps/trails/src/trails/dev-support.ts
@@ -12,7 +12,7 @@ import {
   countPrunableSnapshots,
   countTopoSnapshots,
   pruneUnpinnedSnapshots,
-} from '@ontrails/topographer';
+} from '@ontrails/topographer/backend-support';
 import {
   DEFAULT_MAX_AGE,
   DEFAULT_MAX_RECORDS,

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -15,17 +15,16 @@ import {
   Result,
 } from '@ontrails/core';
 import type {
-  StoredTopoExport,
   SurfaceLock,
   SurfaceMap,
   TopoSnapshot,
 } from '@ontrails/topographer';
+import type { StoredTopoExport } from '@ontrails/topographer/backend-support';
+import { writeSurfaceLock, writeSurfaceMap } from '@ontrails/topographer';
 import {
   createStoredTopoSnapshot,
   getStoredTopoExport,
-  writeSurfaceLock,
-  writeSurfaceMap,
-} from '@ontrails/topographer';
+} from '@ontrails/topographer/backend-support';
 
 import type { TopoExportReport } from './topo-support.js';
 import {

--- a/docs/adr/0042-core-topographer-boundary-doctrine.md
+++ b/docs/adr/0042-core-topographer-boundary-doctrine.md
@@ -136,7 +136,7 @@ countPinnedSnapshots
 countPrunableSnapshots
 countTopoSnapshots
 pruneUnpinnedSnapshots
-createStoredTopoSnapshot   // re-exported as createTopoSnapshot from internal/topo-store.js
+createStoredTopoSnapshot   // direct DB-handle helper on backend-support
 getStoredTopoExport
 
 // Types
@@ -161,6 +161,10 @@ Migration from teaching docs and consumer code is one-line per import:
 ```
 
 `docs/topo-store.md` and `docs/topo-store-reference.md` update accordingly. The changeset entry flags this as a breaking beta change with explicit migration notes. Core gains no dependency on Topographer. Downstream apps and packages that need the topo store import Topographer directly.
+
+Lower-level direct DB-handle helpers are intentionally public through
+`@ontrails/topographer/backend-support`; the root package remains focused on
+durable graph contracts and read-oriented topo-store conveniences.
 
 The `trails-db` helpers listed earlier ([above](#the-shared-database-primitive-is-not-the-topo-subsystem)) are explicitly out of scope for this relocation.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -223,15 +223,22 @@ writeSurfaceLock(lock, options?), readSurfaceLockData(options?), readSurfaceLock
 createTopoStore(options?), createMockTopoStore(seed?), topoStore
 createTopoSnapshot(topo, options?), listTopoSnapshots(options?)
 pinTopoSnapshot(id, name, options?), unpinTopoSnapshot(nameOrId, options?)
-createStoredTopoSnapshot(db, topo, input?), getStoredTopoExport(db, snapshotId)
-countTopoSnapshots(db), countPinnedSnapshots(db), countPrunableSnapshots(db, options?)
-pruneUnpinnedSnapshots(db, options?)
 
 SurfaceMap, SurfaceMapEntry, SurfaceMapContourReference, SurfaceLock, DiffResult, DiffEntry, JsonSchema
 WriteOptions, ReadOptions
 ReadOnlyTopoStore, MockTopoStoreSeed, TopoSnapshot, TopoStoreRef
 TopoStoreExportRecord, TopoStoreResourceRecord, TopoStoreTrailRecord, TopoStoreTrailDetailRecord
-CreateTopoSnapshotInput, ListTopoSnapshotsOptions, StoredTopoExport
+CreateTopoSnapshotInput, ListTopoSnapshotsOptions
+```
+
+### `@ontrails/topographer/backend-support`
+
+```typescript
+createStoredTopoSnapshot(db, topo, input?), getStoredTopoExport(db, snapshotId)
+countTopoSnapshots(db), countPinnedSnapshots(db), countPrunableSnapshots(db, options?)
+pruneUnpinnedSnapshots(db, options?)
+
+StoredTopoExport
 ```
 
 ## `@ontrails/store`
@@ -240,9 +247,6 @@ CreateTopoSnapshotInput, ListTopoSnapshotsOptions, StoredTopoExport
 store(tables)                      // backend-agnostic store definition
 crudOperations                     // canonical create/read/update/delete/list order
 crudAccessorExpectations           // canonical accessor methods/fallbacks per CRUD operation
-bindStoreDefinition(definition, scope) // bind derived store signals to a resource scope
-createStoreTableSignals(tableName, payload), composeStoreSignalId(scope, tableName, change)
-isValidResourceId(resourceId)
 // every normalized table exposes derived schemas and signals directly:
 // table.schema          — normalized full entity schema
 // table.insertSchema    — entity schema minus generated fields
@@ -257,11 +261,20 @@ FiltersOf<T>, StoreListOptions
 StoreConnection<T>, StoreTableConnection<T>, ReadOnlyStoreConnection<T>
 StoreAccessor<T>, StoreTableAccessor<T>, ReadOnlyStoreTableAccessor<T>
 CrudOperation, CrudAccessorExpectation
-StoreSignalChange
 
 // `versioned: true` on a store table adds a framework-managed integer `version`
 // field to returned entities and allows `upsert()` optimistic concurrency.
 // writable store resources fire canonical scoped signals when accessed through `db.from(ctx)`.
+```
+
+### `@ontrails/store/adapter-support`
+
+```typescript
+bindStoreDefinition(definition, scope) // bind derived store signals to a resource scope
+createStoreTableSignals(tableName, payload), composeStoreSignalId(scope, tableName, change)
+isValidResourceId(resourceId)
+
+StoreSignalChange
 ```
 
 ## `@ontrails/store/testing`

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -175,10 +175,11 @@ Update consumer imports:
 
 ```diff
 - import { topoStore, createTopoStore, createMockTopoStore, createTopoSnapshot, listTopoSnapshots, pinTopoSnapshot, unpinTopoSnapshot, createStoredTopoSnapshot, getStoredTopoExport, countTopoSnapshots, countPinnedSnapshots, countPrunableSnapshots, pruneUnpinnedSnapshots } from '@ontrails/core';
-+ import { topoStore, createTopoStore, createMockTopoStore, createTopoSnapshot, listTopoSnapshots, pinTopoSnapshot, unpinTopoSnapshot, createStoredTopoSnapshot, getStoredTopoExport, countTopoSnapshots, countPinnedSnapshots, countPrunableSnapshots, pruneUnpinnedSnapshots } from '@ontrails/topographer';
++ import { topoStore, createTopoStore, createMockTopoStore, createTopoSnapshot, listTopoSnapshots, pinTopoSnapshot, unpinTopoSnapshot } from '@ontrails/topographer';
++ import { createStoredTopoSnapshot, getStoredTopoExport, countTopoSnapshots, countPinnedSnapshots, countPrunableSnapshots, pruneUnpinnedSnapshots } from '@ontrails/topographer/backend-support';
 ```
 
-Types `ReadOnlyTopoStore`, `MockTopoStoreSeed`, `TopoSnapshot`, `TopoStoreRef`, `TopoStoreExportRecord`, `TopoStoreResourceRecord`, `TopoStoreTrailRecord`, `TopoStoreTrailDetailRecord`, `CreateTopoSnapshotInput`, `ListTopoSnapshotsOptions`, and `StoredTopoExport` follow the same move.
+Types `ReadOnlyTopoStore`, `MockTopoStoreSeed`, `TopoSnapshot`, `TopoStoreRef`, `TopoStoreExportRecord`, `TopoStoreResourceRecord`, `TopoStoreTrailRecord`, `TopoStoreTrailDetailRecord`, `CreateTopoSnapshotInput`, and `ListTopoSnapshotsOptions` move to `@ontrails/topographer`. `StoredTopoExport` moves to `@ontrails/topographer/backend-support`.
 
 ## Installation
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -144,6 +144,19 @@ created.id;
 // "db.main:gists.created"
 ```
 
+## Adapter Support Subpath
+
+Adapter authors who bind a `store(...)` definition to a concrete backend should
+import signal-binding helpers from `@ontrails/store/adapter-support`:
+
+```typescript
+import { bindStoreDefinition } from '@ontrails/store/adapter-support';
+```
+
+The subpath owns `bindStoreDefinition`, `createStoreTableSignals`,
+`composeStoreSignalId`, `isValidResourceId`, and `StoreSignalChange`. The root
+package stays focused on backend-agnostic store contracts.
+
 Writable bindings fire those canonical scoped signals automatically when you access the resource through `db.from(ctx)` inside a trail context.
 
 See [Store Signal Identity Migration](../../docs/store-signal-identity-migration.md) when updating existing `on:` clauses, surface-map fixtures, or custom resource wrappers from bare ids to scoped ids.

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -12,6 +12,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./adapter-support": "./src/adapter-support.ts",
     "./jsonfile": "./src/jsonfile/index.ts",
     "./trails": "./src/trails/index.ts",
     "./testing": "./src/testing.ts",

--- a/packages/store/src/__tests__/store.test.ts
+++ b/packages/store/src/__tests__/store.test.ts
@@ -11,7 +11,7 @@ import type {
   UpdateOf,
 } from '../index.js';
 import { store } from '../index.js';
-import { bindStoreDefinition } from '../internal/signal-identity.js';
+import { bindStoreDefinition } from '../adapter-support.js';
 
 const userSchema = z.object({
   email: z.string().email(),

--- a/packages/store/src/adapter-support.ts
+++ b/packages/store/src/adapter-support.ts
@@ -11,7 +11,7 @@ import type {
   AnyStoreDefinition,
   AnyStoreTable,
   StoreTableSignals,
-} from '../types.js';
+} from './types.js';
 
 type MutableTables<TStore extends AnyStoreDefinition> = {
   -readonly [TName in keyof TStore['tables']]: TStore['tables'][TName];

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -3,13 +3,6 @@ export type {
   CrudAccessorExpectation,
   CrudOperation,
 } from './crud-doctrine.js';
-export {
-  bindStoreDefinition,
-  composeStoreSignalId,
-  createStoreTableSignals,
-  isValidResourceId,
-} from './internal/signal-identity.js';
-export type { StoreSignalChange } from './internal/signal-identity.js';
 export { store, versionFieldName } from './store.js';
 export type {
   AnyStoreDefinition,

--- a/packages/store/src/jsonfile/runtime.ts
+++ b/packages/store/src/jsonfile/runtime.ts
@@ -10,7 +10,7 @@ import type {
   StoreListOptions,
   UpsertOf,
 } from '../types.js';
-import { bindStoreDefinition } from '../internal/signal-identity.js';
+import { bindStoreDefinition } from '../adapter-support.js';
 import { versionFieldName } from '../store.js';
 
 import type {

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -2,7 +2,7 @@ import { stripDefaultsFromShape, ValidationError } from '@ontrails/core';
 import type { AnySignal } from '@ontrails/core';
 import { z } from 'zod';
 
-import { createStoreTableSignals } from './internal/signal-identity.js';
+import { createStoreTableSignals } from './adapter-support.js';
 import type {
   StoreDefinition,
   StoreKind,

--- a/packages/topographer/README.md
+++ b/packages/topographer/README.md
@@ -70,8 +70,26 @@ The typical exported artifact pair is:
 | `createTopoSnapshot(topo, options?)` | Persist a new topo snapshot row plus its denormalized projections |
 | `listTopoSnapshots(options?)` | List historical topo snapshots (filterable by pinned status) |
 | `pinTopoSnapshot(id, name, options?)` / `unpinTopoSnapshot(nameOrId, options?)` | Manage human-named pins |
-| `countTopoSnapshots(db)` / `countPinnedSnapshots(db)` / `countPrunableSnapshots(db, options?)` / `pruneUnpinnedSnapshots(db, options?)` | Lower-level snapshot counters and pruning over an open `trails.db` handle |
-| `createStoredTopoSnapshot(db, topo, input?)` / `getStoredTopoExport(db, snapshotId)` | Direct DB-handle variants for callers that already hold an open writer |
+
+### Backend Support Subpath
+
+Direct `trails.db` helper APIs are public, but they are backend-support APIs
+rather than root graph contracts. Import them from
+`@ontrails/topographer/backend-support`:
+
+```typescript
+import {
+  countPinnedSnapshots,
+  countPrunableSnapshots,
+  countTopoSnapshots,
+  createStoredTopoSnapshot,
+  getStoredTopoExport,
+  pruneUnpinnedSnapshots,
+} from '@ontrails/topographer/backend-support';
+```
+
+This subpath owns lower-level snapshot counters, pruning helpers, and direct
+DB-handle variants for callers that already hold an open `trails.db` handle.
 
 ## Breaking change detection
 

--- a/packages/topographer/package.json
+++ b/packages/topographer/package.json
@@ -13,6 +13,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./backend-support": "./src/backend-support.ts",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/topographer/src/backend-support.ts
+++ b/packages/topographer/src/backend-support.ts
@@ -1,0 +1,11 @@
+export {
+  countPinnedSnapshots,
+  countPrunableSnapshots,
+  countTopoSnapshots,
+  pruneUnpinnedSnapshots,
+} from './internal/topo-snapshots.js';
+export {
+  createTopoSnapshot as createStoredTopoSnapshot,
+  getStoredTopoExport,
+} from './internal/topo-store.js';
+export type { StoredTopoExport } from './internal/topo-store.js';

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -83,14 +83,3 @@ export type {
   TopoStoreTrailDetailRecord,
   TopoStoreTrailRecord,
 } from './topo-store.js';
-export {
-  countPinnedSnapshots,
-  countPrunableSnapshots,
-  countTopoSnapshots,
-  pruneUnpinnedSnapshots,
-} from './internal/topo-snapshots.js';
-export {
-  createTopoSnapshot as createStoredTopoSnapshot,
-  getStoredTopoExport,
-} from './internal/topo-store.js';
-export type { StoredTopoExport } from './internal/topo-store.js';

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -11,12 +11,12 @@ import {
   Result,
 } from '@ontrails/core';
 import {
-  createStoredTopoSnapshot,
   createTopoStore,
   deriveSurfaceMapHash,
   deriveSurfaceMap,
   writeSurfaceLock,
 } from '@ontrails/topographer';
+import { createStoredTopoSnapshot } from '@ontrails/topographer/backend-support';
 import { z } from 'zod';
 
 import { checkDrift } from '../drift.js';

--- a/packages/warden/src/rules/public-internal-deep-imports.ts
+++ b/packages/warden/src/rules/public-internal-deep-imports.ts
@@ -21,9 +21,6 @@ import type { WardenPublicWorkspace } from '../workspaces.js';
 const RULE_NAME = 'public-internal-deep-imports';
 const ONTRAILS_SPECIFIER_PATTERN = /^(@ontrails\/[^/]+)(?:\/(.+))?$/;
 const ROOT_BARREL_INTERNAL_RE_EXPORT_ALLOWLIST = new Set([
-  '@ontrails/store:./internal/signal-identity.js',
-  '@ontrails/topographer:./internal/topo-snapshots.js',
-  '@ontrails/topographer:./internal/topo-store.js',
   '@ontrails/tracing:./internal/dev-state.js',
 ]);
 


### PR DESCRIPTION
## Context

Store adapter-binding helpers and Topographer direct DB/admin helpers were living on package roots, blurring the v1 public boundary.

## What Changed

- Added `@ontrails/store/adapter-support` for adapter-facing store binding helpers.
- Added `@ontrails/topographer/backend-support` for direct database/admin helpers.
- Updated Drizzle, Trails app code, Warden tests, package READMEs, and API docs to the new canonical subpaths.
- Removed root-barrel exceptions from Warden's public internal import guard.

## How To Test

- `bun run --cwd packages/store typecheck`
- `bun run --cwd packages/topographer typecheck`
- `bun test packages/store packages/topographer`
- `bun run --cwd adapters/drizzle typecheck`
- `bun test adapters/drizzle`
- Final stack-tip verification: `bun run typecheck`, `bun run test`, `bun run dead-code`, `bun run publish:check`

## Risks / Rollout Notes

This is a pre-v1 breaking root-export cleanup for helper APIs. The new subpaths are explicit and documented.

## Release / Changeset

Includes a major changeset for `@ontrails/store` and `@ontrails/topographer`, plus patch entries for first-party packages that consume the new subpaths.

Closes: TRL-644
