### PR TITLE
docs: canonicalize permits jwt subpath

### DIFF
--- a/.changeset/permits-jwt-subpath-posture.md
+++ b/.changeset/permits-jwt-subpath-posture.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/permits": patch
+---
+
+Document `@ontrails/permits/jwt` as the canonical JWT adapter import while keeping root JWT re-exports as intentional convenience exports.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -430,7 +430,8 @@ PermitExtractionInput                // surface-agnostic auth input
 
 // Adapters
 AuthAdapter                          // interface: authenticate(input) -> Result<Permit | null>
-createJwtAdapter(options)            // built-in HS256 JWT adapter (from @ontrails/permits/jwt)
+// The root also re-exports JWT adapter names for convenience.
+// Prefer the @ontrails/permits/jwt subpath for JWT adapter imports.
 
 // Trail definitions
 authVerify                           // verify a bearer token and return a permit
@@ -438,6 +439,13 @@ authVerify                           // verify a bearer token and return a permi
 // Governance
 validatePermits(trails)              // check trails against permit governance rules
 PermitDiagnostic
+```
+
+### `@ontrails/permits/jwt`
+
+```typescript
+createJwtAdapter(options)            // built-in HS256 JWT adapter
+JwtAlgorithm, JwtAdapterOptions
 ```
 
 ## `@ontrails/permits/testing`

--- a/packages/permits/README.md
+++ b/packages/permits/README.md
@@ -72,9 +72,10 @@ const adapter = createJwtAdapter({
 });
 ```
 
-`@ontrails/permits/jwt` is the stable built-in JWT adapter subpath. The root
-package also re-exports the JWT adapter names for convenience; the subpath keeps
-adapter-specific imports explicit in generated and documented examples.
+`@ontrails/permits/jwt` is the canonical built-in JWT adapter subpath. The root
+package intentionally keeps convenience re-exports for interactive discovery,
+but generated code, docs, and adapter-specific examples should import JWT names
+from the subpath.
 
 ### Custom adapters
 

--- a/packages/permits/src/__tests__/public-api.test.ts
+++ b/packages/permits/src/__tests__/public-api.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 
 import * as permits from '@ontrails/permits';
-import { authAdapterSchema, createJwtAdapter } from '@ontrails/permits';
+import { authAdapterSchema } from '@ontrails/permits';
 import { createJwtAdapter as createJwtAdapterFromSubpath } from '@ontrails/permits/jwt';
+import type { JwtAdapterOptions } from '@ontrails/permits/jwt';
 import {
   createPermitForTrail,
   createTestPermit,
@@ -23,8 +24,11 @@ describe('@ontrails/permits public API', () => {
     expect('authLayer' in permits).toBe(false);
   });
 
-  test('keeps JWT adapter APIs on the root and jwt subpath', () => {
-    expect(createJwtAdapter).toBe(createJwtAdapterFromSubpath);
+  test('keeps JWT adapter APIs canonical on the jwt subpath with root convenience', () => {
+    const options: JwtAdapterOptions = { secret: 'test-secret' };
+
+    expect(createJwtAdapterFromSubpath(options)).toBeDefined();
+    expect(permits.createJwtAdapter).toBe(createJwtAdapterFromSubpath);
     expect(
       authAdapterSchema.safeParse({ authenticate: () => {} }).success
     ).toBe(true);


### PR DESCRIPTION
## Context

JWT adapter docs and tests needed one canonical import posture before v1.

## What Changed

- Documented `@ontrails/permits/jwt` as the canonical JWT adapter import.
- Kept root JWT re-exports as intentional convenience exports.
- Updated README, API reference, and public API tests to match that posture.

## How To Test

- `bun run --cwd packages/permits typecheck`
- `bun test packages/permits`
- Final stack-tip verification: `bun run typecheck`, `bun run test`, `bun run check`, `bun run publish:check`

## Risks / Rollout Notes

No import break is intended. Existing root imports continue to work; docs steer adapter-specific usage to the subpath.

## Release / Changeset

Includes a changeset for `@ontrails/permits` because package docs and public API tests changed.

Closes: TRL-646
