### PR TITLE
refactor: move testing log types to observe

### DIFF
--- a/.changeset/testing-observe-log-types.md
+++ b/.changeset/testing-observe-log-types.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/testing": patch
+---
+
+Migrate testing logger types from the legacy `@ontrails/logging` package to `@ontrails/observe`.

--- a/bun.lock
+++ b/bun.lock
@@ -216,8 +216,8 @@
       "peerDependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
-        "@ontrails/logging": "workspace:^",
         "@ontrails/mcp": "workspace:^",
+        "@ontrails/observe": "workspace:^",
         "zod": "catalog:",
       },
     },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -28,8 +28,8 @@
   "peerDependencies": {
     "@ontrails/cli": "workspace:^",
     "@ontrails/core": "workspace:^",
-    "@ontrails/logging": "workspace:^",
     "@ontrails/mcp": "workspace:^",
+    "@ontrails/observe": "workspace:^",
     "zod": "catalog:"
   }
 }

--- a/packages/testing/src/logger.ts
+++ b/packages/testing/src/logger.ts
@@ -2,9 +2,11 @@
  * Test logger that captures log records for assertion.
  */
 
-import type { LogLevel, LogMetadata, LogRecord } from '@ontrails/logging';
+import type { LogLevel, LogRecord } from '@ontrails/observe';
 
 import type { TestLogger } from './types.js';
+
+type LogMetadata = Readonly<Record<string, unknown>>;
 
 // ---------------------------------------------------------------------------
 // Level ordering for filtering

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -11,7 +11,7 @@ import type {
   TraceFn,
   TrailContext,
 } from '@ontrails/core';
-import type { LogLevel, LogRecord } from '@ontrails/logging';
+import type { LogLevel, LogRecord } from '@ontrails/observe';
 
 // ---------------------------------------------------------------------------
 // Test Scenario (for testTrail)


### PR DESCRIPTION
## Context

`@ontrails/testing` still depended on the retired `@ontrails/logging` package for log record and level types.

## What Changed

- Replaced the testing package peer dependency on `@ontrails/logging` with `@ontrails/observe`.
- Updated testing logger type imports to use `LogLevel` and `LogRecord` from `@ontrails/observe`.
- Kept test-only metadata shape local to the testing package.
- Updated `bun.lock`.

## How To Test

- `rg -n "@ontrails/logging" packages/testing -S`
- `bun run --cwd packages/testing typecheck`
- `bun test packages/testing`
- Final stack-tip verification: `bun run typecheck`, `bun run test`, `bun run dead-code`, `bun run check`, `bun run publish:check`

## Risks / Rollout Notes

Low runtime risk. Consumers may need `@ontrails/observe` available where they consume testing logger contracts.

## Release / Changeset

Includes a changeset for `@ontrails/testing` because package dependencies and public testing logger type dependencies changed.

Closes: TRL-427
