### PR TITLE
refactor: retarget logtape to observe

### DIFF
--- a/.changeset/logtape-observe-target.md
+++ b/.changeset/logtape-observe-target.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/logging": patch
+"@ontrails/logtape": major
+---
+
+Retarget the LogTape adapter to `@ontrails/observe` log sink types and use `createLogtapeSink` as the canonical factory name.
+Refresh the legacy logging README's LogTape forwarding example while the package remains present on the intermediate stack branch.

--- a/bun.lock
+++ b/bun.lock
@@ -160,7 +160,7 @@
       "name": "@ontrails/logtape",
       "version": "1.0.0-beta.15",
       "peerDependencies": {
-        "@ontrails/logging": "workspace:^",
+        "@ontrails/observe": "workspace:^",
       },
     },
     "packages/mcp": {

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -77,12 +77,12 @@ logger.info('Auth', { user: 'admin', password: 'hunter2' });
 Bridge to an existing LogTape setup via the dedicated `@ontrails/logtape` package:
 
 ```typescript
-import { logtapeSink } from '@ontrails/logtape';
+import { createLogtapeSink } from '@ontrails/logtape';
 import { getLogger } from '@logtape/logtape';
 
 const logger = createLogger({
   name: 'app',
-  sinks: [logtapeSink({ logger: getLogger('app') })],
+  sinks: [createLogtapeSink({ logger: getLogger('app') })],
 });
 ```
 

--- a/packages/logtape/README.md
+++ b/packages/logtape/README.md
@@ -1,3 +1,16 @@
 # @ontrails/logtape
 
-The logtape sink for `@ontrails/logging`. See `@ontrails/logging` for the logger API; this package only provides the optional logtape forwarding sink.
+LogTape adapter for `@ontrails/observe`.
+
+Use `createLogtapeSink(...)` when you already have a LogTape-shaped logger and
+want Trails log records to flow into it:
+
+```typescript
+import { getLogger } from '@logtape/logtape';
+import { createLogtapeSink } from '@ontrails/logtape';
+
+const sink = createLogtapeSink({ logger: getLogger('app') });
+```
+
+The package does not depend on `@logtape/logtape`; it accepts any object shaped
+like a LogTape logger through `LogtapeLoggerLike`.

--- a/packages/logtape/package.json
+++ b/packages/logtape/package.json
@@ -22,6 +22,6 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "peerDependencies": {
-    "@ontrails/logging": "workspace:^"
+    "@ontrails/observe": "workspace:^"
   }
 }

--- a/packages/logtape/src/__tests__/logtape.test.ts
+++ b/packages/logtape/src/__tests__/logtape.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { logtapeSink } from '../index.js';
+import { createLogtapeSink } from '../index.js';
 import type { LogtapeLoggerLike } from '../index.js';
 
 const createRecordingLogger = () => {
@@ -34,10 +34,10 @@ const createRecordingLogger = () => {
   return { calls, logger };
 };
 
-describe('logtapeSink', () => {
+describe('createLogtapeSink', () => {
   test('forwards records to the underlying logtape logger by level', () => {
     const { calls, logger } = createRecordingLogger();
-    const sink = logtapeSink({ logger });
+    const sink = createLogtapeSink({ logger });
 
     sink.write({
       category: 'app.http',
@@ -58,7 +58,7 @@ describe('logtapeSink', () => {
 
   test('ignores records whose level does not map to a logtape method', () => {
     const { calls, logger } = createRecordingLogger();
-    const sink = logtapeSink({ logger });
+    const sink = createLogtapeSink({ logger });
 
     sink.write({
       category: 'app',

--- a/packages/logtape/src/index.ts
+++ b/packages/logtape/src/index.ts
@@ -1,4 +1,4 @@
-import type { LogRecord, LogSink } from '@ontrails/logging';
+import type { LogRecord, LogSink } from '@ontrails/observe';
 
 // ---------------------------------------------------------------------------
 // Minimal logtape logger interface (avoids importing @logtape/logtape)
@@ -27,7 +27,7 @@ export interface LogtapeSinkOptions {
 }
 
 // ---------------------------------------------------------------------------
-// logtapeSink
+// createLogtapeSink
 // ---------------------------------------------------------------------------
 
 type ForwardMethod = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
@@ -46,7 +46,7 @@ const LEVEL_MAP: Record<string, ForwardMethod> = {
  * logger. Redaction runs _before_ the sink receives records, so sensitive
  * data is scrubbed regardless of the backend.
  */
-export const logtapeSink = (options: LogtapeSinkOptions): LogSink => {
+export const createLogtapeSink = (options: LogtapeSinkOptions): LogSink => {
   const { logger } = options;
 
   return {


### PR DESCRIPTION
## Context

`@ontrails/logtape` should remain the LogTape adapter package, but it should target the current observability boundary instead of the retired logging package.

## What Changed

- Replaced the LogTape adapter peer dependency on `@ontrails/logging` with `@ontrails/observe`.
- Updated imports to `LogRecord` and `LogSink` from `@ontrails/observe`.
- Made `createLogtapeSink(...)` the canonical factory and removed the duplicate legacy alias after Knip flagged it.
- Updated tests and README guidance.

## How To Test

- `rg -n "@ontrails/logging" packages/logtape -S`
- `bun run --cwd packages/logtape typecheck`
- `bun test packages/logtape`
- Final stack-tip verification: `bun run typecheck`, `bun run test`, `bun run dead-code`, `bun run check`, `bun run publish:check`

## Risks / Rollout Notes

Pre-v1 breaking cleanup for the duplicate factory alias. Consumers should use `createLogtapeSink(...)`.

## Release / Changeset

Includes a major changeset for `@ontrails/logtape` because the canonical factory shape changed and the duplicate alias was removed.

Closes: TRL-425
