### PR TITLE
fix: preserve TrailsError serialization identity

### DIFF
--- a/.changeset/core-error-serialization-identity.md
+++ b/.changeset/core-error-serialization-identity.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/core": patch
+---
+
+Preserve specialized TrailsError identity and retry-exhaustion metadata when
+serializing and deserializing framework errors.

--- a/packages/core/src/__tests__/serialization.test.ts
+++ b/packages/core/src/__tests__/serialization.test.ts
@@ -6,6 +6,8 @@ import {
   AssertionError,
   NetworkError,
   RateLimitError,
+  RecoverableCompletionError,
+  RetryExhaustedError,
   InternalError,
   TimeoutError,
   NotFoundError,
@@ -182,6 +184,7 @@ describe('deserializeError', () => {
       { Ctor: TimeoutError, category: 'timeout' },
       { Ctor: NetworkError, category: 'network' },
       { Ctor: InternalError, category: 'internal' },
+      { Ctor: RecoverableCompletionError, category: 'internal' },
       { Ctor: AuthError, category: 'auth' },
       { Ctor: CancelledError, category: 'cancelled' },
     ] as const;
@@ -216,6 +219,56 @@ describe('deserializeError', () => {
       expect(restored.constructor.name).toBe('RateLimitError');
       expect((restored as RateLimitError).retryAfter).toBe(42);
       expect(restored.context).toEqual({ endpoint: '/api' });
+    });
+
+    test('RetryExhaustedError round-trips wrapped identity and metadata', () => {
+      const original = new RetryExhaustedError(
+        new NotFoundError('missing resource', {
+          context: { id: 'abc' },
+        }),
+        { attempts: 3, detour: 'recoverMissing' }
+      );
+
+      const serialized = serializeError(original);
+      const restored = deserializeError(serialized);
+
+      expect(serialized).toMatchObject({
+        attempts: 3,
+        category: 'not_found',
+        detour: 'recoverMissing',
+        name: 'RetryExhaustedError',
+        retryable: false,
+      });
+      expect(serialized.cause).toMatchObject({
+        category: 'not_found',
+        context: { id: 'abc' },
+        message: 'missing resource',
+        name: 'NotFoundError',
+      });
+      expect(restored).toBeInstanceOf(RetryExhaustedError);
+      expect(restored.category).toBe('not_found');
+      expect(restored.retryable).toBe(false);
+      const retryError = restored as RetryExhaustedError;
+      expect(retryError.attempts).toBe(3);
+      expect(retryError.detour).toBe('recoverMissing');
+      expect(retryError.cause).toBeInstanceOf(NotFoundError);
+      expect(retryError.cause.context).toEqual({ id: 'abc' });
+    });
+
+    test('legacy RetryExhaustedError payloads deserialize safely', () => {
+      const err = deserializeError({
+        category: 'conflict',
+        message: 'Recovery exhausted after 2 attempts: stale version',
+        name: 'RetryExhaustedError',
+      });
+
+      expect(err).toBeInstanceOf(RetryExhaustedError);
+      expect(err.category).toBe('conflict');
+      expect(err.message).toBe(
+        'Recovery exhausted after 2 attempts: stale version'
+      );
+      expect((err as RetryExhaustedError).attempts).toBe(0);
+      expect((err as RetryExhaustedError).detour).toBe('unknown');
     });
 
     test('falls back to category when name is unknown', () => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -7,21 +7,18 @@
 
 import type { ErrorCategory, TrailsError } from './errors.js';
 import {
-  ValidationError,
-  AmbiguousError,
-  AssertionError,
-  NotFoundError,
-  AlreadyExistsError,
-  ConflictError,
-  PermissionError,
-  PermitError,
-  TimeoutError,
-  RateLimitError,
-  NetworkError,
-  InternalError,
-  DerivationError,
   AuthError,
   CancelledError,
+  ConflictError,
+  ValidationError,
+  InternalError,
+  NetworkError,
+  NotFoundError,
+  PermissionError,
+  RateLimitError,
+  RetryExhaustedError,
+  TimeoutError,
+  errorClasses,
   isTrailsError,
 } from './errors.js';
 import { Result } from './result.js';
@@ -33,7 +30,10 @@ import { Result } from './result.js';
 export interface SerializedError {
   readonly name: string;
   readonly message: string;
+  readonly attempts?: number | undefined;
   readonly category?: ErrorCategory | undefined;
+  readonly cause?: SerializedError | undefined;
+  readonly detour?: string | undefined;
   readonly retryable?: boolean | undefined;
   readonly retryAfter?: number | undefined;
   readonly context?: Record<string, unknown> | undefined;
@@ -58,8 +58,13 @@ const buildOpts = (
 
 type ErrorFactory = (
   message: string,
-  opts: { context?: Record<string, unknown> },
+  opts: { cause?: Error; context?: Record<string, unknown> },
   retryAfter: number | undefined
+) => TrailsError;
+
+type FixedErrorConstructor = new (
+  message: string,
+  options?: { cause?: Error; context?: Record<string, unknown> }
 ) => TrailsError;
 
 const errorFactories: Record<ErrorCategory, ErrorFactory> = {
@@ -94,32 +99,42 @@ const createErrorByCategory = (
   return factory(message, opts, retryAfter);
 };
 
-/** Map error class names to their constructors for precise round-tripping. */
-const errorConstructorsByName: Record<string, ErrorFactory> = {
-  AlreadyExistsError: (msg, opts) => new AlreadyExistsError(msg, opts),
-  AmbiguousError: (msg, opts) => new AmbiguousError(msg, opts),
-  AssertionError: (msg, opts) => new AssertionError(msg, opts),
-  AuthError: (msg, opts) => new AuthError(msg, opts),
-  CancelledError: (msg, opts) => new CancelledError(msg, opts),
-  ConflictError: (msg, opts) => new ConflictError(msg, opts),
-  DerivationError: (msg, opts) => new DerivationError(msg, opts),
-  InternalError: (msg, opts) => new InternalError(msg, opts),
-  NetworkError: (msg, opts) => new NetworkError(msg, opts),
-  NotFoundError: (msg, opts) => new NotFoundError(msg, opts),
-  PermissionError: (msg, opts) => new PermissionError(msg, opts),
-  PermitError: (msg, opts) => new PermitError(msg, opts),
-  RateLimitError: (msg, opts, retryAfter) => {
-    const rlOpts: { context?: Record<string, unknown>; retryAfter?: number } = {
-      ...opts,
-    };
-    if (retryAfter !== undefined) {
-      rlOpts.retryAfter = retryAfter;
-    }
-    return new RateLimitError(msg, rlOpts);
-  },
-  TimeoutError: (msg, opts) => new TimeoutError(msg, opts),
-  ValidationError: (msg, opts) => new ValidationError(msg, opts),
-};
+/** Map fixed error class names to constructors for precise round-tripping. */
+const errorConstructorsByName: Readonly<Record<string, ErrorFactory>> =
+  Object.fromEntries(
+    errorClasses.flatMap((entry): [string, ErrorFactory][] => {
+      if (entry.category === 'dynamic') {
+        return [];
+      }
+      const ctor = entry.ctor as FixedErrorConstructor;
+      return [
+        [
+          entry.name,
+          (message, opts, retryAfter) => {
+            if (ctor === RateLimitError) {
+              const rateLimitOptions:
+                | {
+                    cause?: Error;
+                    context?: Record<string, unknown>;
+                    retryAfter?: number;
+                  }
+                | undefined =
+                opts.context === undefined &&
+                opts.cause === undefined &&
+                retryAfter === undefined
+                  ? undefined
+                  : {
+                      ...opts,
+                      ...(retryAfter === undefined ? {} : { retryAfter }),
+                    };
+              return new RateLimitError(message, rateLimitOptions);
+            }
+            return new ctor(message, opts);
+          },
+        ],
+      ];
+    })
+  );
 
 // ---------------------------------------------------------------------------
 // Error serialization
@@ -138,6 +153,13 @@ export const serializeError = (error: Error): SerializedError => {
       ...result,
       category: error.category,
       context: error.context,
+      ...(error instanceof RetryExhaustedError
+        ? {
+            attempts: error.attempts,
+            cause: serializeError(error.cause),
+            detour: error.detour,
+          }
+        : {}),
       retryAfter:
         error instanceof RateLimitError ? error.retryAfter : undefined,
       retryable: error.retryable,
@@ -150,6 +172,28 @@ export const serializeError = (error: Error): SerializedError => {
 /** Reconstruct a TrailsError from serialized data. */
 export const deserializeError = (data: SerializedError): TrailsError => {
   const opts = buildOpts(data.context);
+  if (data.name === 'RetryExhaustedError') {
+    const wrapped =
+      data.cause === undefined
+        ? createErrorByCategory(
+            data.category ?? 'internal',
+            data.message,
+            data.context,
+            data.retryAfter
+          )
+        : deserializeError(data.cause);
+    const error = new RetryExhaustedError(wrapped, {
+      attempts: data.attempts ?? 0,
+      detour: data.detour ?? 'unknown',
+    });
+    if (data.message !== error.message) {
+      error.message = data.message;
+    }
+    if (data.stack) {
+      error.stack = data.stack;
+    }
+    return error;
+  }
   const nameFactory = errorConstructorsByName[data.name];
 
   const error = nameFactory


### PR DESCRIPTION
## Context

This is PR 1 of the v1 Error Contract Closure + Resolved Graph Capstone stack.

`serializeError()` / `deserializeError()` previously preserved category-level behavior but could lose specialized `TrailsError` identity. The important gaps were `RecoverableCompletionError` and the dynamic `RetryExhaustedError` wrapper, whose category is inherited from its wrapped cause and whose attempts/detour metadata matter for recovery diagnostics.

## What Changed

- Derive fixed-class deserialization from the `errorClasses` owner registry instead of a hand-maintained class-name table.
- Preserve `RecoverableCompletionError` through the fixed-class registry path.
- Add explicit dynamic serialization/deserialization for `RetryExhaustedError`, including:
  - wrapper identity,
  - inherited category,
  - `retryable: false`,
  - wrapped serialized cause,
  - `attempts`,
  - `detour`.
- Keep legacy `RetryExhaustedError` payloads safe by reconstructing a wrapped category error when older payloads do not include `cause`.

## Tests

- `bun test packages/core/src/__tests__/serialization.test.ts`
- `bun test packages/core/src/__tests__/errors.test.ts`
- `bun run --cwd packages/core typecheck`
- `bun run format:check`
- `git diff --check`

Full stack verification also passed at the tip after local review:

- `bun scripts/adr.ts map`
- `bun scripts/adr.ts check`
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run dead-code`
- `bun run build`
- `bun run docs:snippets`
- `bun run warden:agents:check`
- `bun run warden:skills:check`
- `bun run changeset:check`
- `bun run publish:check`
- `bun run format:check`
- `git diff --check`
- `bun run check`

## Risks / Rollout Notes

- Serialized payloads gain optional `cause`, `attempts`, and `detour` fields for retry exhaustion. Older payloads remain deserializable.
- Unknown serialized class names still fall back to category reconstruction.

## Changeset / Release Notes

- Adds a patch changeset for `@ontrails/core`: `.changeset/core-error-serialization-identity.md`.

Closes: TRL-649
