### PR TITLE
fix: enforce safe error redaction policy

### DIFF
--- a/.changeset/error-redaction-policy.md
+++ b/.changeset/error-redaction-policy.md
@@ -1,0 +1,9 @@
+---
+"@ontrails/core": patch
+"@ontrails/hono": patch
+"@ontrails/mcp": patch
+"@ontrails/commander": patch
+"@ontrails/trails": patch
+---
+
+Enforce the shared safe error projection policy for public error bodies, diagnostics, serialized payloads, and CLI stderr.

--- a/adapters/commander/src/__tests__/to-commander.test.ts
+++ b/adapters/commander/src/__tests__/to-commander.test.ts
@@ -1202,4 +1202,32 @@ describe('toCommander option wiring', () => {
       expect(process.stderr.write).toHaveBeenCalledWith('Error: missing\n');
     });
   });
+
+  test('error handling hides unknown error messages from stderr', async () => {
+    await withMockedProcess(async () => {
+      const failTrail = trail('fail', {
+        blaze: () => Result.ok('ok'),
+        input: z.object({}),
+      });
+      const program = toCommander([
+        {
+          args: [],
+          execute: () => {
+            throw new Error('token=secret');
+          },
+          flags: [],
+          intent: 'read' as const,
+          path: ['fail'] as const,
+          trail: failTrail,
+        },
+      ]);
+
+      await expect(
+        program.parseAsync(['node', 'test', 'fail'], { from: 'node' })
+      ).rejects.toThrow('EXIT 8');
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        'Error: Internal server error\n'
+      );
+    });
+  });
 });

--- a/adapters/commander/src/to-commander.ts
+++ b/adapters/commander/src/to-commander.ts
@@ -2,7 +2,7 @@
  * Adapt framework-agnostic CliCommand[] to a Commander program.
  */
 
-import { isTrailsError, mapSurfaceError } from '@ontrails/core';
+import { projectPublicSurfaceError } from '@ontrails/core';
 import type { CliCommand, CliFlag } from '@ontrails/cli';
 import { applyCliFlagValueAliases, validateCliCommands } from '@ontrails/cli';
 import { Command, InvalidArgumentError, Option } from 'commander';
@@ -219,15 +219,10 @@ const getFallbackUserSuppliedFlagKeys = (
 
 /** Handle execution errors with appropriate exit codes. */
 const handleError = (error: unknown): void => {
-  if (error instanceof Error) {
-    process.stderr.write(`Error: ${error.message}\n`);
-    if (isTrailsError(error)) {
-      process.exit(mapSurfaceError('cli', error));
-    }
-  } else {
-    process.stderr.write(`Error: ${String(error)}\n`);
-  }
-  process.exit(8);
+  const err = error instanceof Error ? error : new Error(String(error));
+  const projection = projectPublicSurfaceError('cli', err);
+  process.stderr.write(`Error: ${projection.message}\n`);
+  process.exit(projection.code);
 };
 
 interface BareChildFallback {

--- a/adapters/hono/README.md
+++ b/adapters/hono/README.md
@@ -21,8 +21,10 @@ await surface(graph, {
 });
 ```
 
-Generic non-TrailsError failures return a redacted 500 response while the
-original error is written to server diagnostics.
+Generic non-TrailsError failures return a redacted 500 response while a
+redacted diagnostic projection is written to server diagnostics. `TrailsError`
+responses keep their taxonomy category and class name but redact sensitive
+message fragments before writing the public body.
 
 For custom HTTP integrations or route inspection, keep using `deriveHttpRoutes()` from `@ontrails/http`.
 

--- a/adapters/hono/src/__tests__/surface.test.ts
+++ b/adapters/hono/src/__tests__/surface.test.ts
@@ -59,6 +59,14 @@ const genericErrorTrail = trail('generic.error', {
   output: z.object({ ok: z.boolean() }),
 });
 
+const sensitivePermissionTrail = trail('sensitive.permission', {
+  blaze: () =>
+    Result.err(new PermissionError('Denied Bearer abcdefghijklmnop')),
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+});
+
 const webhookSecret = 'secret';
 const paymentWebhook = webhook('webhook.payment.received', {
   parse: z.object({ paymentId: z.string() }),
@@ -386,8 +394,30 @@ describe('surface API (Hono adapter)', () => {
       '[ontrails:hono] Internal error (req-123)'
     );
     const loggedError = loggedErrors[0]?.[1];
-    expect(loggedError).toBeInstanceOf(Error);
-    expect((loggedError as Error).message).toBe('database password=secret');
+    expect(loggedError).toMatchObject({
+      message: 'database [REDACTED]',
+      name: 'Error',
+    });
+    expect(JSON.stringify(loggedError)).not.toContain('secret');
+  });
+
+  test('TrailsError responses redact public error messages', async () => {
+    const graph = topo('surface-api', { sensitivePermissionTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/sensitive/permission', {
+      method: 'GET',
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'permission',
+        code: 'PermissionError',
+        message: 'Denied [REDACTED]',
+      },
+    });
+    expect(loggedErrors).toHaveLength(0);
   });
 
   test('sanitizes request ids before logging diagnostics', async () => {
@@ -446,7 +476,10 @@ describe('surface API (Hono adapter)', () => {
     expect(loggedErrors).toHaveLength(1);
     expect(loggedErrors[0]?.[0]).toBe('[ontrails:hono] Internal error');
     const loggedError = loggedErrors[0]?.[1];
-    expect(loggedError).toBeInstanceOf(Error);
-    expect((loggedError as Error).message).toBe('token=secret');
+    expect(loggedError).toMatchObject({
+      message: '[REDACTED]',
+      name: 'Error',
+    });
+    expect(JSON.stringify(loggedError)).not.toContain('secret');
   });
 });

--- a/adapters/hono/src/surface.ts
+++ b/adapters/hono/src/surface.ts
@@ -12,7 +12,8 @@
 
 import {
   isTrailsError,
-  projectSurfaceError,
+  projectErrorDiagnostics,
+  projectPublicSurfaceError,
   ValidationError,
 } from '@ontrails/core';
 import type {
@@ -318,28 +319,16 @@ const readInput = async (
 const mapErrorResponse = (
   error: Error
 ): { body: Record<string, unknown>; status: ContentfulStatusCode } => {
-  if (isTrailsError(error)) {
-    const projection = projectSurfaceError('http', error);
-    return {
-      body: {
-        error: {
-          category: projection.category,
-          code: projection.name,
-          message: projection.message,
-        },
-      },
-      status: projection.code as ContentfulStatusCode,
-    };
-  }
+  const projection = projectPublicSurfaceError('http', error);
   return {
     body: {
       error: {
-        category: 'internal',
-        code: 'InternalError',
-        message: 'Internal server error',
+        category: projection.category,
+        code: projection.name,
+        message: projection.message,
       },
     },
-    status: 500,
+    status: projection.code as ContentfulStatusCode,
   };
 };
 
@@ -365,7 +354,7 @@ const reportInternalDiagnostics = (error: Error, c: HonoContext): void => {
     safeRequestId === undefined
       ? '[ontrails:hono] Internal error'
       : `[ontrails:hono] Internal error (${safeRequestId})`;
-  console.error(label, error);
+  console.error(label, projectErrorDiagnostics(error));
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/trails/src/run-completions-install.ts
+++ b/apps/trails/src/run-completions-install.ts
@@ -12,8 +12,7 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import {
-  isTrailsError,
-  mapSurfaceError,
+  projectPublicSurfaceError,
   Result,
   ValidationError,
 } from '@ontrails/core';
@@ -138,12 +137,10 @@ export const runCompletionsInstall = async (
 };
 
 const handleCliError = (error: unknown): void => {
-  if (error instanceof Error) {
-    process.stderr.write(`Error: ${error.message}\n`);
-    process.exit(isTrailsError(error) ? mapSurfaceError('cli', error) : 8);
-  }
-  process.stderr.write(`Error: ${String(error)}\n`);
-  process.exit(8);
+  const err = error instanceof Error ? error : new Error(String(error));
+  const projection = projectPublicSurfaceError('cli', err);
+  process.stderr.write(`Error: ${projection.message}\n`);
+  process.exit(projection.code);
 };
 
 const findCompletionsCommand = (program: Command): Command | undefined =>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,7 @@ Overrides are escape hatches. They're visible in the surface map as explicit dev
 
 ### Foundation
 
-`@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, `contour()`/`trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, execution pipeline utilities including `Layer`/`composeLayers()`, generic `trails-db` helpers (`openReadTrailsDb`, `ensureSubsystemSchema`, etc.), and adapter port interfaces. Persistence of the resolved topo graph (the topo-store API) lives in `@ontrails/topographer` per ADR-0042.
+`@ontrails/core` is the only package with an external dependency: `zod`. It contains Result, error taxonomy, safe public and diagnostic error projection, `contour()`/`trail()`/`signal()`, `topo()`, validation, patterns, redaction, branded types, guards, collections, execution pipeline utilities including `Layer`/`composeLayers()`, generic `trails-db` helpers (`openReadTrailsDb`, `ensureSubsystemSchema`, etc.), and adapter port interfaces. Persistence of the resolved topo graph (the topo-store API) lives in `@ontrails/topographer` per ADR-0042.
 
 **The test:** if you are building a surface adapter or ecosystem package, you should only need `@ontrails/core`.
 

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -170,6 +170,10 @@ HTTP 200 for all successful responses.
 ```
 
 The `code` is the error class name. The `category` matches the error taxonomy.
+HTTP bodies use the shared public error projection: `TrailsError` messages are
+redacted before they are returned, internal-category errors are made opaque, and
+unknown native errors are reported as `InternalError` with `Internal server
+error`.
 
 ## Status Code Mapping
 

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -125,8 +125,13 @@ Result.err(new NotFoundError('Entity not found'));
 Trail failures are MCP tool-result errors, not JSON-RPC protocol errors. The
 model-visible payload stays text-only on error, while `_meta["ontrails/error"]`
 contains the same JSON-RPC-family code projection used by
-`mapSurfaceError('mcp', error)`. Protocol errors remain reserved for invalid
-MCP requests such as malformed methods or unknown tools.
+`mapSurfaceError('mcp', error)`. Both fields use the shared public error
+projection: `TrailsError` messages are redacted, and unknown native errors return
+the generic `Internal server error` text without framework error metadata.
+Internal-category `TrailsError` instances also use the generic public message
+while keeping their taxonomy metadata.
+Protocol errors remain reserved for invalid MCP requests such as malformed
+methods or unknown tools.
 
 **Binary data:**
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -134,6 +134,12 @@ status, and JSON-RPC codes on every surface.
 
 `RetryExhaustedError` wraps another `TrailsError`, inherits the wrapped error's category for surface mappings, and always reports `retryable: false`.
 
+Public surface projections redact sensitive substrings before exposing a
+non-internal `TrailsError` message. Internal-category `TrailsError` instances and
+unknown native errors project with the generic message `Internal server error`;
+diagnostics and serialized payloads keep their useful structure while redacting
+messages, context, and stack strings.
+
 The developer returns `Result.err(new NotFoundError(...))`. The framework maps it to the right code on every surface.
 
 ### Other exports
@@ -161,9 +167,10 @@ packages build on:
 - **Trails DB** -- `deriveTrailsDbPath`, `deriveTrailsDir`,
   `ensureSubsystemSchema`, `openReadTrailsDb`, and `openWriteTrailsDb` are the
   generic database primitive used by framework subsystems.
-- **Surface projection helpers** -- layer field projection, cross-batch
-  validation, late-bound signal references, and Zod default-wrapper stripping
-  are stable root exports for first-party surfaces, store helpers, and tests.
+- **Surface projection helpers** -- safe error projection, layer field
+  projection, cross-batch validation, late-bound signal references, and Zod
+  default-wrapper stripping are stable root exports for first-party surfaces,
+  store helpers, and tests.
 
 See the [API Reference](../../docs/api-reference.md) for the full list.
 

--- a/packages/core/src/__tests__/error-projection.test.ts
+++ b/packages/core/src/__tests__/error-projection.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+
+import { InternalError, PermissionError } from '../errors.js';
+import {
+  INTERNAL_ERROR_PUBLIC_MESSAGE,
+  projectErrorDiagnostics,
+  redactErrorString,
+} from '../error-projection.js';
+import { projectPublicSurfaceError } from '../transport-error-map.js';
+
+describe('error projection redaction', () => {
+  test('redacts key-value secrets embedded in strings', () => {
+    expect(redactErrorString('database password=secret')).toBe(
+      'database [REDACTED]'
+    );
+    expect(redactErrorString('token=secret')).toBe('[REDACTED]');
+    expect(
+      redactErrorString('Malformed Authorization header; expected Bearer token')
+    ).toBe('Malformed Authorization header; expected Bearer token');
+  });
+
+  test('projects TrailsError messages safely for public surfaces', () => {
+    const error = new PermissionError('Denied Bearer abcdefghijklmnop', {
+      context: { authorization: 'Bearer abcdefghijklmnop' },
+    });
+
+    expect(projectPublicSurfaceError('http', error)).toEqual({
+      category: 'permission',
+      code: 403,
+      message: 'Denied [REDACTED]',
+      name: 'PermissionError',
+      retryable: false,
+      surface: 'http',
+    });
+  });
+
+  test('uses a generic public projection for unknown errors', () => {
+    expect(projectPublicSurfaceError('mcp', new Error('token=secret'))).toEqual(
+      {
+        category: 'internal',
+        code: -32_603,
+        message: INTERNAL_ERROR_PUBLIC_MESSAGE,
+        name: 'InternalError',
+        retryable: false,
+        surface: 'mcp',
+      }
+    );
+  });
+
+  test('uses a generic public message for internal TrailsError instances', () => {
+    expect(
+      projectPublicSurfaceError('http', new InternalError('panic'))
+    ).toEqual({
+      category: 'internal',
+      code: 500,
+      message: INTERNAL_ERROR_PUBLIC_MESSAGE,
+      name: 'InternalError',
+      retryable: false,
+      surface: 'http',
+    });
+  });
+
+  test('redacts diagnostic message, context, and stack', () => {
+    const error = new PermissionError('Denied Bearer abcdefghijklmnop', {
+      context: {
+        authorization: 'Bearer abcdefghijklmnop',
+        requestId: 'req-1',
+      },
+    });
+    error.stack = 'PermissionError: Denied Bearer abcdefghijklmnop';
+
+    expect(projectErrorDiagnostics(error)).toEqual({
+      category: 'permission',
+      context: {
+        authorization: '[REDACTED]',
+        requestId: 'req-1',
+      },
+      message: 'Denied [REDACTED]',
+      name: 'PermissionError',
+      retryable: false,
+      stack: 'PermissionError: Denied [REDACTED]',
+    });
+  });
+});

--- a/packages/core/src/__tests__/serialization.test.ts
+++ b/packages/core/src/__tests__/serialization.test.ts
@@ -69,6 +69,34 @@ describe('serializeError', () => {
     const serialized = serializeError(err);
     expect(serialized.retryAfter).toBeUndefined();
   });
+
+  test('redacts serialized message, context, stack, and nested causes', () => {
+    const cause = new PermissionError('Denied Bearer abcdefghijklmnop', {
+      context: { authorization: 'Bearer abcdefghijklmnop', userId: 'u-1' },
+    });
+    cause.stack = 'PermissionError: Denied Bearer abcdefghijklmnop';
+    const err = new RetryExhaustedError(cause, {
+      attempts: 2,
+      detour: 'recoverSecret',
+    });
+    err.stack =
+      'RetryExhaustedError: Recovery exhausted after 2 attempts: Denied Bearer abcdefghijklmnop';
+
+    const serialized = serializeError(err);
+
+    expect(serialized.message).toBe(
+      'Recovery exhausted after 2 attempts: Denied [REDACTED]'
+    );
+    expect(serialized.stack).toBe(
+      'RetryExhaustedError: Recovery exhausted after 2 attempts: Denied [REDACTED]'
+    );
+    expect(serialized.cause).toMatchObject({
+      context: { authorization: '[REDACTED]', userId: 'u-1' },
+      message: 'Denied [REDACTED]',
+      stack: 'PermissionError: Denied [REDACTED]',
+    });
+    expect(JSON.stringify(serialized)).not.toContain('abcdefghijklmnop');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/error-projection.ts
+++ b/packages/core/src/error-projection.ts
@@ -1,0 +1,51 @@
+import type { ErrorCategory } from './errors.js';
+import { isTrailsError } from './errors.js';
+import { createRedactor } from './redaction/index.js';
+
+const errorRedactor = createRedactor();
+
+export const INTERNAL_ERROR_PUBLIC_MESSAGE = 'Internal server error';
+
+export interface ErrorDiagnosticsProjection {
+  readonly category?: ErrorCategory | undefined;
+  readonly context?: Record<string, unknown> | undefined;
+  readonly message: string;
+  readonly name: string;
+  readonly retryable?: boolean | undefined;
+  readonly stack?: string | undefined;
+}
+
+export const redactErrorString = (value: string): string =>
+  errorRedactor.redact(value);
+
+export const redactErrorContext = (
+  context: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined =>
+  context === undefined ? undefined : errorRedactor.redactObject(context);
+
+export const redactErrorStack = (
+  stack: string | undefined
+): string | undefined =>
+  stack === undefined ? undefined : redactErrorString(stack);
+
+export const projectErrorDiagnostics = (
+  error: Error
+): ErrorDiagnosticsProjection => {
+  const context = isTrailsError(error)
+    ? redactErrorContext(error.context)
+    : undefined;
+  const stack = redactErrorStack(error.stack);
+
+  return {
+    ...(isTrailsError(error)
+      ? {
+          category: error.category,
+          retryable: error.retryable,
+        }
+      : {}),
+    ...(context === undefined ? {} : { context }),
+    message: redactErrorString(error.message),
+    name: error.name || error.constructor.name || 'Error',
+    ...(stack === undefined ? {} : { stack }),
+  };
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export {
   createSurfaceErrorMapper,
   mapSurfaceError,
   projectErrorClassSurface,
+  projectPublicSurfaceError,
   projectSurfaceError,
   surfaceErrorMap,
   surfaceErrorRegistry,
@@ -57,6 +58,14 @@ export type {
   SurfaceErrorProjection,
   SurfaceName,
 } from './transport-error-map.js';
+export {
+  INTERNAL_ERROR_PUBLIC_MESSAGE,
+  projectErrorDiagnostics,
+  redactErrorContext,
+  redactErrorStack,
+  redactErrorString,
+} from './error-projection.js';
+export type { ErrorDiagnosticsProjection } from './error-projection.js';
 
 // Types
 export type {

--- a/packages/core/src/redaction/patterns.ts
+++ b/packages/core/src/redaction/patterns.ts
@@ -16,11 +16,14 @@ export const DEFAULT_PATTERNS: RegExp[] = [
   // SSN: XXX-XX-XXXX
   /\b\d{3}-\d{2}-\d{4}\b/g,
 
-  // Bearer tokens
-  /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g,
+  // Bearer tokens. Keep the threshold above short prose like "Bearer token".
+  /Bearer\s+[A-Za-z0-9\-._~+/=]{6,}/g,
 
   // Basic auth
-  /Basic\s+[A-Za-z0-9+/]+=*/g,
+  /Basic\s+[A-Za-z0-9+/=]{8,}/g,
+
+  // Common key/value secrets embedded in strings
+  /\b(?:password|secret|token|api[_-]?key|cookie)\s*[:=]\s*[^\s,;]+/gi,
 
   // API keys: sk-*, pk_*, sk_* prefixed tokens
   /\b(?:sk-|pk_|sk_)[A-Za-z0-9_-]{8,}\b/g,

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -21,6 +21,11 @@ import {
   errorClasses,
   isTrailsError,
 } from './errors.js';
+import {
+  redactErrorContext,
+  redactErrorStack,
+  redactErrorString,
+} from './error-projection.js';
 import { Result } from './result.js';
 
 // ---------------------------------------------------------------------------
@@ -143,16 +148,16 @@ const errorConstructorsByName: Readonly<Record<string, ErrorFactory>> =
 /** Extract structured data from an Error for transport. */
 export const serializeError = (error: Error): SerializedError => {
   const result: SerializedError = {
-    message: error.message,
+    message: redactErrorString(error.message),
     name: error.name,
-    stack: error.stack,
+    stack: redactErrorStack(error.stack),
   };
 
   if (isTrailsError(error)) {
     return {
       ...result,
       category: error.category,
-      context: error.context,
+      context: redactErrorContext(error.context),
       ...(error instanceof RetryExhaustedError
         ? {
             attempts: error.attempts,

--- a/packages/core/src/transport-error-map.ts
+++ b/packages/core/src/transport-error-map.ts
@@ -9,9 +9,14 @@ import {
   codesByCategory,
   errorClasses,
   exitCodeMap,
+  isTrailsError,
   jsonRpcCodeMap,
   statusCodeMap,
 } from './errors.js';
+import {
+  INTERNAL_ERROR_PUBLIC_MESSAGE,
+  redactErrorString,
+} from './error-projection.js';
 
 export const surfaceNames = ['cli', 'http', 'jsonRpc', 'mcp'] as const;
 
@@ -108,6 +113,31 @@ export const projectSurfaceError = (
   retryable: error.retryable,
   surface,
 });
+
+export const projectPublicSurfaceError = (
+  surface: SurfaceName,
+  error: Error
+): SurfaceErrorProjection => {
+  if (isTrailsError(error)) {
+    const projection = projectSurfaceError(surface, error);
+    return {
+      ...projection,
+      message:
+        projection.category === 'internal'
+          ? INTERNAL_ERROR_PUBLIC_MESSAGE
+          : redactErrorString(projection.message),
+    };
+  }
+
+  return {
+    category: 'internal',
+    code: codesByCategory.internal[surfaceCodeKeys[surface]],
+    message: INTERNAL_ERROR_PUBLIC_MESSAGE,
+    name: 'InternalError',
+    retryable: false,
+    surface,
+  };
+};
 
 const isFixedErrorClassEntry = (
   entry: ErrorClassRegistryEntry

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   NotFoundError,
+  PermissionError,
   Result,
   SURFACE_KEY,
   blobRefSchema,
@@ -50,6 +51,13 @@ const notFoundTrail = trail('item.find', {
   blaze: () => Result.err(new NotFoundError('Item not found')),
   description: 'Always fails with a TrailsError',
   input: z.object({ id: z.string() }),
+});
+
+const sensitivePermissionTrail = trail('secret.permission', {
+  blaze: () =>
+    Result.err(new PermissionError('Denied Bearer abcdefghijklmnop')),
+  description: 'Always fails with a sensitive TrailsError message',
+  input: z.object({}),
 });
 
 const exampleTrail = trail('with.examples', {
@@ -427,7 +435,7 @@ describe('deriveMcpTools', () => {
 
       const result = await tool.handler({ reason: 'broken' }, noExtra);
       expect(result?.isError).toBe(true);
-      expect(result?.content[0]?.text).toBe('broken');
+      expect(result?.content[0]?.text).toBe('Internal server error');
     });
 
     test('handler projects TrailsError metadata onto MCP tool-result errors', async () => {
@@ -451,6 +459,24 @@ describe('deriveMcpTools', () => {
       expect(result?.structuredContent).toBeUndefined();
     });
 
+    test('handler redacts TrailsError metadata and model-visible text', async () => {
+      const app = topo('myapp', { sensitivePermissionTrail });
+      const tool = requireOnlyTool(buildTools(app));
+
+      const result = await tool.handler({}, noExtra);
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content).toEqual([
+        { text: 'Denied [REDACTED]', type: 'text' },
+      ]);
+      expect(result?._meta?.[MCP_TOOL_ERROR_META_KEY]).toMatchObject({
+        category: 'permission',
+        message: 'Denied [REDACTED]',
+        name: 'PermissionError',
+      });
+      expect(JSON.stringify(result)).not.toContain('abcdefghijklmnop');
+    });
+
     test('handler catches thrown exceptions', async () => {
       const throwTrail = trail('throw', {
         blaze: () => {
@@ -463,7 +489,7 @@ describe('deriveMcpTools', () => {
       const result = await tool.handler({}, noExtra);
 
       expect(result?.isError).toBe(true);
-      expect(result?.content[0]?.text).toBe('unexpected crash');
+      expect(result?.content[0]?.text).toBe('Internal server error');
     });
   });
 

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -18,7 +18,7 @@ import {
   isTrailsError,
   LAYER_FIELD_RESERVED_NAMES,
   projectLayerFieldName,
-  projectSurfaceError,
+  projectPublicSurfaceError,
   toBlobRefDescriptor,
   validateSurfaceTopo,
   withSurfaceLayerNames,
@@ -654,12 +654,12 @@ const partitionMcpArgs = (
 // ---------------------------------------------------------------------------
 
 const buildMcpErrorMeta = (
-  error: Error
+  error: Error,
+  projection: SurfaceErrorProjection
 ): Record<string, McpToolErrorMeta> | undefined => {
   if (!isTrailsError(error)) {
     return undefined;
   }
-  const projection = projectSurfaceError('mcp', error);
   return {
     [MCP_TOOL_ERROR_META_KEY]: {
       ...projection,
@@ -670,10 +670,11 @@ const buildMcpErrorMeta = (
 
 /** Create an error result for MCP responses. */
 const mcpError = (error: Error): McpToolResult => {
-  const meta = buildMcpErrorMeta(error);
+  const projection = projectPublicSurfaceError('mcp', error);
+  const meta = buildMcpErrorMeta(error, projection);
   return {
     ...(meta === undefined ? {} : { _meta: meta }),
-    content: [{ text: error.message, type: 'text' }],
+    content: [{ text: projection.message, type: 'text' }],
     isError: true,
   };
 };


### PR DESCRIPTION
## Context

This is PR 2 of the v1 Error Contract Closure + Resolved Graph Capstone stack.

The audit found that public responses, diagnostics, logs, and serialized error payloads were using similar but separate error-handling behavior. In particular, some paths exposed raw `error.message`, raw stacks, or raw contexts, while unknown errors were handled more conservatively than known `TrailsError` instances.

## What Changed

- Add shared core error projection helpers:
  - `projectPublicSurfaceError()`
  - `projectErrorDiagnostics()`
  - `redactErrorString()`
  - `redactErrorContext()`
  - `redactErrorStack()`
- Enforce the public policy:
  - non-internal `TrailsError` messages are redacted and preserved,
  - internal-category `TrailsError` messages use `Internal server error`,
  - unknown native errors use generic internal public projections.
- Redact serialized error message, context, stack, and nested retry-exhaustion causes.
- Route Hono, MCP, Commander, and completions-install error output through the shared projection helpers.
- Extend default redaction patterns for embedded key/value secrets such as `password=...`, `token=...`, and `api_key=...`.
- Document the policy in HTTP/MCP/core/Hono docs.

## Tests

- `bun test packages/core/src/__tests__/error-projection.test.ts packages/core/src/__tests__/serialization.test.ts packages/core/src/__tests__/transport-error-map.test.ts adapters/hono/src/__tests__/surface.test.ts packages/mcp/src/__tests__/build.test.ts adapters/commander/src/__tests__/to-commander.test.ts`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd adapters/hono typecheck`
- `bun run --cwd packages/mcp typecheck`
- `bun run --cwd adapters/commander typecheck`
- `bun run --cwd apps/trails typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`

Full stack verification also passed at the tip after local review:

- `bun scripts/adr.ts map`
- `bun scripts/adr.ts check`
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run dead-code`
- `bun run build`
- `bun run docs:snippets`
- `bun run warden:agents:check`
- `bun run warden:skills:check`
- `bun run changeset:check`
- `bun run publish:check`
- `bun run format:check`
- `git diff --check`
- `bun run check`

## Risks / Rollout Notes

- Public CLI, HTTP, and MCP error text changes when an error previously exposed raw internal or secret-bearing text.
- Diagnostics remain useful but are now structured/redacted; logs should no longer rely on receiving a raw `Error` object from Hono diagnostics.

## Changeset / Release Notes

- Adds a patch changeset for `@ontrails/core`, `@ontrails/hono`, `@ontrails/mcp`, `@ontrails/commander`, and `@ontrails/trails`: `.changeset/error-redaction-policy.md`.

Closes: TRL-651
