### PR TITLE
fix: wire Hono HTTP permit resolution

### DIFF
--- a/.changeset/hono-http-permit-resolution.md
+++ b/.changeset/hono-http-permit-resolution.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/hono": patch
+"@ontrails/http": patch
+---
+
+Wire HTTP permit resolution through the Hono adapter, including request headers for Bearer Authorization handling.

--- a/adapters/hono/README.md
+++ b/adapters/hono/README.md
@@ -21,6 +21,12 @@ await surface(graph, {
 });
 ```
 
+Pass `resolvePermit` to resolve HTTP `Authorization: Bearer ...` credentials
+into `ctx.permit` before protected trails execute. The adapter forwards request
+headers to the framework-agnostic HTTP route executor, so malformed
+Authorization headers return `401` and resolved permits with insufficient scopes
+return `403`.
+
 Generic non-TrailsError failures return a redacted 500 response while a
 redacted diagnostic projection is written to server diagnostics. `TrailsError`
 responses keep their taxonomy category and class name but redact sensitive

--- a/adapters/hono/src/__tests__/surface.test.ts
+++ b/adapters/hono/src/__tests__/surface.test.ts
@@ -420,6 +420,92 @@ describe('surface API (Hono adapter)', () => {
     expect(loggedErrors).toHaveLength(0);
   });
 
+  test('malformed Authorization fails as 401 through Hono permit resolution', async () => {
+    let invoked = false;
+    const protectedTrail = trail('permit.malformed', {
+      blaze: () => {
+        invoked = true;
+        return Result.ok({ ok: true });
+      },
+      input: z.object({}),
+      intent: 'read',
+      output: z.object({ ok: z.boolean() }),
+      permit: { scopes: ['thing:read'] },
+    });
+    const graph = topo('surface-api', { protectedTrail });
+    const app = createApp(graph, {
+      resolvePermit: () => Result.ok({ id: 'user-1', scopes: ['thing:read'] }),
+    });
+
+    const response = await app.request('/permit/malformed', {
+      headers: { Authorization: 'Basic nope' },
+      method: 'GET',
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'auth',
+        code: 'AuthError',
+        message: 'Malformed Authorization header; expected Bearer token',
+      },
+    });
+    expect(invoked).toBe(false);
+  });
+
+  test('non-Bearer Authorization does not reject public Hono routes', async () => {
+    const graph = topo('surface-api', { echoTrail });
+    const app = createApp(graph);
+
+    const response = await app.request('/echo?message=hello', {
+      headers: { Authorization: 'Basic dXNlcjpwYXNz' },
+      method: 'GET',
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: { reply: 'hello' } });
+  });
+
+  test('resolved permits with missing scopes fail as 403 through Hono', async () => {
+    let observedBearerToken: string | undefined;
+    let observedHeaders: Headers | undefined;
+    const protectedTrail = trail('permit.scope', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      intent: 'read',
+      output: z.object({ ok: z.boolean() }),
+      permit: { scopes: ['thing:read'] },
+    });
+    const graph = topo('surface-api', { protectedTrail });
+    const app = createApp(graph, {
+      resolvePermit: ({ bearerToken, headers }) => {
+        observedBearerToken = bearerToken;
+        observedHeaders = headers instanceof Headers ? headers : undefined;
+        return Result.ok({ id: 'user-1', scopes: [] });
+      },
+    });
+
+    const response = await app.request('/permit/scope', {
+      headers: {
+        Authorization: 'Bearer weak',
+        'X-Tenant-ID': 'tenant-1',
+      },
+      method: 'GET',
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'permission',
+        code: 'PermitError',
+        message: 'Missing scopes: thing:read',
+      },
+    });
+    expect(observedBearerToken).toBe('weak');
+    expect(observedHeaders).toBeInstanceOf(Headers);
+    expect(observedHeaders?.get('x-tenant-id')).toBe('tenant-1');
+  });
+
   test('sanitizes request ids before logging diagnostics', async () => {
     const graph = topo('surface-api', { genericErrorTrail });
     const app = createApp(graph);

--- a/adapters/hono/src/surface.ts
+++ b/adapters/hono/src/surface.ts
@@ -27,7 +27,12 @@ import { Hono } from 'hono';
 import type { Context as HonoContext } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { deriveHttpRoutes } from '@ontrails/http';
-import type { HttpMethod, HttpRouteDefinition } from '@ontrails/http';
+import type {
+  HttpExecutionContext,
+  HttpMethod,
+  HttpRouteDefinition,
+  ResolveHttpPermit,
+} from '@ontrails/http';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -45,6 +50,7 @@ export interface CreateAppOptions extends BaseSurfaceOptions {
   readonly name?: string | undefined;
   readonly port?: number | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
+  readonly resolvePermit?: ResolveHttpPermit | undefined;
 }
 
 interface RuntimeOptions {
@@ -430,6 +436,10 @@ const collectHeaders = (c: HonoContext): Record<string, string> => {
   return headers;
 };
 
+const createHttpExecutionContext = (c: HonoContext): HttpExecutionContext => ({
+  headers: c.req.raw.headers,
+});
+
 const createWebhookVerifyRequest = (
   c: HonoContext,
   body: string
@@ -507,7 +517,12 @@ const handleWebhookRoute = async (
 
   const requestId = c.req.header('X-Request-ID') ?? undefined;
   const { signal: abortSignal } = c.req.raw;
-  const result = await route.execute(parsed.value, requestId, abortSignal);
+  const result = await route.execute(
+    parsed.value,
+    requestId,
+    abortSignal,
+    createHttpExecutionContext(c)
+  );
   return mapResultToResponse(result, c);
 };
 
@@ -541,7 +556,12 @@ const createHonoHandler =
     const { signal: abortSignal } = c.req.raw;
 
     try {
-      const result = await route.execute(rawInput, requestId, abortSignal);
+      const result = await route.execute(
+        rawInput,
+        requestId,
+        abortSignal,
+        createHttpExecutionContext(c)
+      );
       return mapResultToResponse(result, c);
     } catch (error: unknown) {
       return handleCaughtError(error, c);
@@ -628,6 +648,7 @@ export const createApp = (
     include: options.include,
     intent: options.intent,
     layers: options.layers,
+    resolvePermit: options.resolvePermit,
     resources: options.resources,
     validate: options.validate,
   });

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -1410,6 +1410,37 @@ describe('deriveHttpRoutes', () => {
       }
     });
 
+    test('non-Bearer Authorization on public routes is ignored before permit resolution', async () => {
+      let resolveCalled = false;
+      const app = topo('permit-http', { echoTrail });
+      const buildResult = deriveHttpRoutes(app, {
+        resolvePermit: () => {
+          resolveCalled = true;
+          return Result.ok({ id: 'user-1', scopes: [] });
+        },
+      });
+
+      expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
+      const [route] = buildResult.value;
+      const result = await route?.execute(
+        { message: 'hello' },
+        'req-1',
+        undefined,
+        {
+          headers: { authorization: 'Basic dXNlcjpwYXNz' },
+        }
+      );
+
+      expect(result?.isOk()).toBe(true);
+      if (result?.isOk()) {
+        expect(result.value).toEqual({ reply: 'hello' });
+      }
+      expect(resolveCalled).toBe(false);
+    });
+
     test('Bearer Authorization without a resolver still lets protected routes fail at the permit gate', async () => {
       const protectedTrail = trail('permit.no-resolver', {
         blaze: () => Result.ok({ ok: true }),

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -209,12 +209,27 @@ const parseBearerAuthorization = (
   return Result.ok(token);
 };
 
+const isBearerAuthorization = (authorization: string | undefined): boolean =>
+  authorization !== undefined && /^Bearer(?:\s|$)/i.test(authorization.trim());
+
+const shouldResolveHttpPermit = (
+  options: DeriveHttpRoutesOptions,
+  authorization: string | undefined,
+  requiresPermit: boolean
+): boolean =>
+  requiresPermit ||
+  (options.resolvePermit !== undefined && isBearerAuthorization(authorization));
+
 const resolveHttpPermit = async (
   options: DeriveHttpRoutesOptions,
   request: HttpExecutionContext | undefined,
-  requestId: string | undefined
+  requestId: string | undefined,
+  requiresPermit: boolean
 ): Promise<Result<BasePermit | undefined, Error>> => {
   const authorization = readHeader(request?.headers, 'authorization');
+  if (!shouldResolveHttpPermit(options, authorization, requiresPermit)) {
+    return Result.ok();
+  }
   const token = parseBearerAuthorization(authorization);
   if (token.isErr()) {
     return token;
@@ -631,7 +646,8 @@ const createExecute =
     const permitResolution = await resolveHttpPermit(
       options,
       request,
-      requestId
+      requestId,
+      t.permit !== undefined
     );
     if (permitResolution.isErr()) {
       return Result.err(permitResolution.error);
@@ -712,7 +728,8 @@ const createWebhookConsumerExecute =
     const permitResolution = await resolveHttpPermit(
       options,
       request,
-      requestId
+      requestId,
+      t.permit !== undefined
     );
     if (permitResolution.isErr()) {
       return Result.err(permitResolution.error);


### PR DESCRIPTION
## Context

This is PR 3 of the v1 Error Contract Closure + Resolved Graph Capstone stack.

The framework-agnostic HTTP route model already supported request-context permit resolution, but the Hono adapter did not expose `resolvePermit` or forward request headers into route execution. That meant Hono hosts could not resolve `Authorization: Bearer ...` credentials through the normal HTTP permit path.

The review pass also tightened the shared HTTP route guard so public routes ignore non-Bearer `Authorization` schemes instead of rejecting them before a permit is required.

## What Changed

- Add `resolvePermit?: ResolveHttpPermit` to Hono `CreateAppOptions`.
- Pass `resolvePermit` through to `deriveHttpRoutes()`.
- Forward the original Hono `Headers` object into ordinary route execution.
- Forward the same request headers into webhook-backed route execution.
- Preserve public-route behavior in `@ontrails/http` by parsing `Authorization` only when a route requires a permit, or when a public route receives Bearer credentials that can populate `ctx.permit`.
- Document the Hono `resolvePermit` behavior.
- Add adapter-level tests for:
  - malformed `Authorization` returning 401 before trail execution,
  - resolved permits missing required scopes returning 403,
  - request headers reaching the configured resolver,
  - public routes ignoring non-Bearer `Authorization` values.

## Tests

- `bun test adapters/hono/src/__tests__/surface.test.ts packages/http/src/__tests__/build.test.ts`
- `bun run --cwd adapters/hono typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`

Full stack verification also passed at the tip after local review:

- `bun scripts/adr.ts map`
- `bun scripts/adr.ts check`
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run dead-code`
- `bun run build`
- `bun run docs:snippets`
- `bun run warden:agents:check`
- `bun run warden:skills:check`
- `bun run changeset:check`
- `bun run publish:check`
- `bun run format:check`
- `git diff --check`
- `bun run check`

## Risks / Rollout Notes

- Hono hosts can now opt into HTTP Bearer permit resolution. Existing hosts without `resolvePermit` keep current behavior, and public routes continue to tolerate non-Bearer authorization schemes.
- Malformed Bearer headers on protected routes now fail before trail execution when sent through Hono.
- Public routes with a configured resolver can still receive Bearer permits for optional `ctx.permit` use.

## Changeset / Release Notes

- Adds a patch changeset for `@ontrails/hono` and `@ontrails/http`: `.changeset/hono-http-permit-resolution.md`.

Closes: TRL-650
