### PR TITLE
docs: define v1 resolved graph error scope

### DIFF
--- a/docs/adr/0045-v1-resolved-graph-error-scope.md
+++ b/docs/adr/0045-v1-resolved-graph-error-scope.md
@@ -1,0 +1,149 @@
+---
+id: 45
+slug: v1-resolved-graph-error-scope
+title: v1 Resolved Graph Error Scope
+status: accepted
+created: 2026-05-10
+updated: 2026-05-10
+accepted: 2026-05-10
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [2, 15, 17, 26, 33, 42]
+---
+
+# ADR-0045: v1 Resolved Graph Error Scope
+
+## Context
+
+Trails' target architecture says the resolved graph should let blind agents
+inspect the system without guessing from source. ADR-0017 describes a future
+where `.trails/trails.lock` is the serialized topo graph, while ADR-0015 and
+ADR-0042 describe today's Topographer-owned artifact family: surface maps,
+hashes, semantic diffs, lock helpers, topo-store exports, and query views.
+
+The v1 implementation is narrower than the target. The richest inspectable
+artifact is the surface-map/export family:
+
+- `deriveSurfaceMap()`
+- `.trails/_surface.json`
+- `topo_exports.surface_map`
+- `topo_exports.serialized_lock`
+
+The committed `.trails/trails.lock` is currently a versioned hash envelope with
+an optional workspace trail index. It is a drift guard and resolution aid, not
+the full inspectable graph promised by the long-term ADR-0017 shape.
+
+The error contract closed in the TRL-649/TRL-651/TRL-652 stack establishes a
+clearer boundary:
+
+- [TRL-649] preserves specialized `TrailsError` identity through serialization,
+  including `RecoverableCompletionError` and dynamic `RetryExhaustedError`
+  wrappers.
+- [TRL-651] defines safe public and diagnostic projection/redaction for
+  `TrailsError` and unknown errors across surfaces, serialization, and logs.
+- [TRL-652] makes taxonomy docs and tests derive from the core `errorClasses`
+  registry, with dynamic `RetryExhaustedError` behavior handled explicitly.
+
+Those decisions make the taxonomy and projection behavior inspectable and
+checked. They do not make every trail's possible failures statically known.
+
+## Decision
+
+For v1, resolved graph error scope is:
+
+| Error information | v1 graph scope | Owner |
+| --- | --- | --- |
+| Taxonomy categories, retryability, and surface codes | Registry-owned, not duplicated per graph entry | `@ontrails/core` `errorClasses`, ADR-0026, TRL-652 |
+| Public and diagnostic redaction policy | Runtime projection contract, not graph payload | `@ontrails/core` projection helpers, ADR-0026, TRL-651 |
+| Serialized error identity | Runtime serialization contract, not graph payload | `serializeError()` / `deserializeError()`, TRL-649 |
+| Trail error examples | Authored example cases in surface maps and topo-store examples | `trail.examples` |
+| Trail detours | Authored recovery declarations: matched error class name and capped max attempts | `trail.detours`, ADR-0033 |
+| Exhaustive per-trail emitted errors | Deferred | Future authored or inferred error contract work |
+| Observed runtime failures | Deferred | Future trace or telemetry graph merge work |
+
+The v1 graph may expose error class names that the developer authored in
+examples and detours. These names are references into the taxonomy registry.
+They are not a copied taxonomy table, not a redaction policy snapshot, and not
+a proof that the listed classes are exhaustive for the trail.
+
+### Authored scope
+
+The graph records authored error-related facts that are already part of trail
+contracts:
+
+- Error examples keep their `error` class name in structured examples.
+- Detours keep the declared `on` error class name and effective capped
+  `maxAttempts`.
+
+These fields answer "what did the developer explicitly declare for examples
+or recovery?" They do not answer "what errors can this trail ever return?"
+
+### Derived scope
+
+The graph does not embed a taxonomy matrix on every trail. Agents derive class
+category, retryability, HTTP status, CLI exit code, and JSON-RPC code from the
+registry-backed taxonomy docs and core projection helpers.
+
+Dynamic classes stay dynamic. `RetryExhaustedError` inherits category and
+surface codes from the wrapped `TrailsError`, so a graph entry that only names
+`RetryExhaustedError` is insufficient to determine a fixed category. Agents
+must inspect serialized runtime errors or the wrapped cause when dynamic
+identity matters.
+
+### Inferred scope
+
+v1 does not infer emitted error contracts from blaze source, `ctx.cross()`
+propagation, resource factories, layers, or detour recovery functions. Whole
+program error inference is out of scope because it would require static
+analysis that Trails has not made a contract yet.
+
+Warden still validates local rules that are checkable today: implementations
+return `Result`, native throws are rejected, detour contracts are shaped
+correctly, and surface mappers cover taxonomy categories. Those checks support
+the error contract, but they do not create an inferred per-trail error graph.
+
+### Observed scope
+
+v1 does not merge runtime observations into the resolved graph. Traces, logs,
+serialized error payloads, and adapter responses may contain actual error
+identity after execution. They are evidence about a run, not stable resolved
+graph state.
+
+## Consequences
+
+- No new v1 graph field is added for exhaustive per-trail errors in this ADR.
+  Adding such a field would imply a contract Trails cannot yet keep.
+- Docs and agents should describe `.trails/trails.lock` as a drift guard and
+  optional workspace trail index for v1. Use `.trails/_surface.json`,
+  `deriveSurfaceMap()`, and topo-store exports when full JSON fidelity matters.
+- Surface maps and topo-store detail records can continue to expose `examples`
+  and `detours` as authored contract facts.
+- Public error bodies remain governed by the redaction/projection policy from
+  TRL-651, not by resolved graph artifacts.
+- Future error graph work should pick an explicit source of authority before
+  adding fields: authored declarations, registry-derived summaries, static
+  inference, observed runtime evidence, or a versioned combination.
+
+## Deferred Work
+
+- Add an authored per-trail error contract if Trails decides developers should
+  explicitly declare possible failures beyond examples and detours.
+- Add static inference only after the framework can explain and test propagation
+  through `Result.err`, `ctx.cross()`, resources, layers, and detour recovery.
+- Add typed topo-store accessors for error examples and detour projections if
+  agents need ergonomic error-specific queries instead of reading trail detail
+  records or surface-map JSON.
+- Decide whether a future lock v3 embeds the full graph or remains a hash
+  pointer to adjacent graph artifacts.
+
+## References
+
+- [ADR-0002: Built-In Result Type](0002-built-in-result-type.md)
+- [ADR-0015: Topo Store](0015-topo-store.md)
+- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md)
+- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md)
+- [ADR-0033: Detour Execution for Recovery](0033-detour-execution-for-recovery.md)
+- [ADR-0042: Core/Topographer Boundary Doctrine](0042-core-topographer-boundary-doctrine.md)
+
+[TRL-649]: https://linear.app/outfitter/issue/TRL-649
+[TRL-651]: https://linear.app/outfitter/issue/TRL-651
+[TRL-652]: https://linear.app/outfitter/issue/TRL-652

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,3 +51,4 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0042](0042-core-topographer-boundary-doctrine.md) | Core/Topographer Boundary Doctrine | Accepted |
 | [0043](0043-layer-evolution.md) | Layer Evolution | Accepted (amended 2026-05-04) |
 | [0044](0044-trail-versioning.md) | Trail Versioning | Accepted |
+| [0045](0045-v1-resolved-graph-error-scope.md) | v1 Resolved Graph Error Scope | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -313,6 +313,11 @@
           "fromPath": "docs/adr/0038-typed-signal-emission.md"
         },
         {
+          "context": "- [ADR-0002: Built-In Result Type](0002-built-in-result-type.md)",
+          "from": "0045",
+          "fromPath": "docs/adr/0045-v1-resolved-graph-error-scope.md"
+        },
+        {
           "context": "- **[ADR-0002: Built-In Result Type](./adr/0002-built-in-result-type.md)** — Own the Result primitive, zero dependencies",
           "from": "index",
           "fromPath": "docs/index.md"
@@ -1150,6 +1155,11 @@
           "fromPath": "docs/adr/0042-core-topographer-boundary-doctrine.md"
         },
         {
+          "context": "- [ADR-0015: Topo Store](0015-topo-store.md)",
+          "from": "0045",
+          "fromPath": "docs/adr/0045-v1-resolved-graph-error-scope.md"
+        },
+        {
           "context": "- **[ADR-0015: Topo Store](./adr/0015-topo-store.md)** — Queryable relational projection of the resolved graph",
           "from": "index",
           "fromPath": "docs/index.md"
@@ -1286,6 +1296,11 @@
           "context": "- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md)",
           "from": "0044",
           "fromPath": "docs/adr/0044-trail-versioning.md"
+        },
+        {
+          "context": "- [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md)",
+          "from": "0045",
+          "fromPath": "docs/adr/0045-v1-resolved-graph-error-scope.md"
         },
         {
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- rig state captured in the lockfile graph; rig lock state occupies a section in `trails.lock`",
@@ -1639,6 +1654,11 @@
           "fromPath": "docs/adr/0044-trail-versioning.md"
         },
         {
+          "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](0026-error-taxonomy-as-transport-independent-behavior-contract.md)",
+          "from": "0045",
+          "fromPath": "docs/adr/0045-v1-resolved-graph-error-scope.md"
+        },
+        {
           "context": "- [ADR-0026: Error Taxonomy as Transport-Independent Behavior Contract](../0026-error-taxonomy-as-transport-independent-behavior-contract.md) -- WebSocket close code mapping deferred there; the error ",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
@@ -1935,7 +1955,13 @@
     {
       "created": "2026-04-11",
       "depends_on": ["2", "6", "23", "32"],
-      "inbound": [],
+      "inbound": [
+        {
+          "context": "- [ADR-0033: Detour Execution for Recovery](0033-detour-execution-for-recovery.md)",
+          "from": "0045",
+          "fromPath": "docs/adr/0045-v1-resolved-graph-error-scope.md"
+        }
+      ],
       "number": "0033",
       "owners": ["[galligan](https://github.com/galligan)"],
       "path": "docs/adr/0033-detour-execution-for-recovery.md",
@@ -2186,6 +2212,11 @@
       "depends_on": ["14", "15", "17", "35"],
       "inbound": [
         {
+          "context": "- [ADR-0042: Core/Topographer Boundary Doctrine](0042-core-topographer-boundary-doctrine.md)",
+          "from": "0045",
+          "fromPath": "docs/adr/0045-v1-resolved-graph-error-scope.md"
+        },
+        {
           "context": "- [ADR-0042: Core/Topographer Boundary Doctrine](../0042-core-topographer-boundary-doctrine.md)",
           "from": "20260503",
           "fromPath": "docs/adr/drafts/20260503-wayfinding.md"
@@ -2251,6 +2282,30 @@
       "superseded_by": null,
       "title": "Trail Versioning",
       "updated": "2026-05-06"
+    },
+    {
+      "created": "2026-05-10",
+      "depends_on": ["2", "15", "17", "26", "33", "42"],
+      "inbound": [
+        {
+          "context": "Extends trail record with `crosses`, `detours`, `resources`, and `examples` arrays. Detailed examples preserve `expected`, `expectedMatch`, and structured signal assertions when they are JSON-serializ",
+          "from": "topo-store-reference",
+          "fromPath": "docs/topo-store-reference.md"
+        },
+        {
+          "context": "These fields are not exhaustive per-trail error contracts. Error categories, retryability, and surface codes stay owned by the core error taxonomy registry, while public body redaction stays owned by ",
+          "from": "topo-store",
+          "fromPath": "docs/topo-store.md"
+        }
+      ],
+      "number": "0045",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0045-v1-resolved-graph-error-scope.md",
+      "slug": "v1-resolved-graph-error-scope",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "v1 Resolved Graph Error Scope",
+      "updated": "2026-05-10"
     }
   ],
   "version": 1

--- a/docs/topo-store-reference.md
+++ b/docs/topo-store-reference.md
@@ -143,7 +143,9 @@ CREATE TABLE topo_trail_on (
 
 ### `topo_examples`
 
-Trail examples with input, expected output, and error cases.
+Trail examples with input, expected output, and authored error cases. The
+`error` column stores the example's declared error class name; it is not an
+exhaustive per-trail error contract.
 
 ```sql
 CREATE TABLE topo_examples (
@@ -180,7 +182,9 @@ CREATE TABLE topo_surfaces (
 
 ### `topo_exports`
 
-Serialized surface maps and lockfiles.
+Serialized surface maps and lockfiles. In v1, `surface_map` is the richer
+inspectable graph artifact. `serialized_lock` carries the committed lock
+payload used for drift/hash verification and workspace trail indexing.
 
 ```sql
 CREATE TABLE topo_exports (
@@ -345,7 +349,7 @@ interface TopoStoreRef {
 
 ### `TopoStoreTrailDetailRecord`
 
-Extends trail record with `crosses`, `detours`, `resources`, and `examples` arrays. Detailed examples preserve `expected`, `expectedMatch`, and structured signal assertions when they are JSON-serializable.
+Extends trail record with `crosses`, `detours`, `resources`, and `examples` arrays. Detailed examples preserve `expected`, `expectedMatch`, and structured signal assertions when they are JSON-serializable. Detours preserve authored recovery declarations, including the matched error class name and effective attempt count. Neither examples nor detours are exhaustive per-trail error inference; see [ADR-0045](./adr/0045-v1-resolved-graph-error-scope.md).
 
 ### `TopoStoreResourceRecord`
 

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -20,8 +20,8 @@ Trails creates a `.trails/` directory in your workspace root on first use:
 ```
 
 - **`trails.db`** — SQLite database containing all topo saves, pins, and schema cache. Not git-tracked.
-- **`trails.lock`** — Committed lockfile. Text format, git-tracked. This is your contract's current state for CI.
-- **`_surface.json`** — Full surface map with all metadata, written by `topo compile`.
+- **`trails.lock`** — Committed lockfile. Text format, git-tracked. In v1 this is a drift/hash guard plus optional workspace trail index, not the full inspectable graph.
+- **`_surface.json`** — Rich surface map with trail, signal, resource, relation, example, and detour metadata, written by `topo compile`.
 
 ## What trails.db contains
 
@@ -36,6 +36,15 @@ A **pin** is a durable, human-friendly name you assign to a save you care about.
 ### Metadata
 
 For each save, the database stores trail IDs, intents, descriptions, examples, crossings, signals, resources, and their relationships. The schema cache avoids recomputing `zodToJsonSchema()` when schemas haven't changed.
+
+### Error scope
+
+For v1, the topo store and surface map record authored error-related contract facts:
+
+- `examples` may include named error examples from `trail.examples`.
+- `detours` include the declared recovery error class name and effective capped attempt count.
+
+These fields are not exhaustive per-trail error contracts. Error categories, retryability, and surface codes stay owned by the core error taxonomy registry, while public body redaction stays owned by the shared error projection policy. See [ADR-0045](./adr/0045-v1-resolved-graph-error-scope.md).
 
 ## Commands
 


### PR DESCRIPTION
## Context

This is PR 5 of the v1 Error Contract Closure + Resolved Graph Capstone stack.

After TRL-649, TRL-651, and TRL-652 make serialization identity, redaction, and registry-driven taxonomy explicit, the remaining v1 question is what error information belongs in resolved graph artifacts. The important decision is to keep v1 honest: authored examples and detours are graph facts, but exhaustive emitted-error inference is not yet a framework contract.

## What Changed

- Add ADR-0045, `v1 Resolved Graph Error Scope`.
- Decide that v1 resolved graph artifacts may expose authored error examples and detour declarations, but do not claim:
  - exhaustive per-trail emitted errors,
  - whole-program error inference,
  - runtime observed error graph merging.
- Link the decision to ADR-0002, ADR-0026, ADR-0033, ADR-0042, and the TRL-649/651/652 stack.
- Clarify that taxonomy categories, retryability, and surface codes remain registry-owned.
- Clarify that public and diagnostic redaction remains runtime projection policy, not graph payload.
- Update topo-store docs to describe the v1 relationship between `trails.lock`, `_surface.json`, topo-store exports, examples, and detours.

## Tests

- `bun scripts/adr.ts map`
- `bun scripts/adr.ts check`
- `bun run docs:snippets`
- `bun run --cwd apps/trails typecheck`
- `bun test apps/trails/src/__tests__/topo-dev.test.ts apps/trails/src/__tests__/survey.test.ts apps/trails/src/__tests__/run-trace.test.ts`
- `bun run format:check`
- `git diff --check`

Full stack verification also passed at the tip after local review:

- `bun scripts/adr.ts map`
- `bun scripts/adr.ts check`
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run dead-code`
- `bun run build`
- `bun run docs:snippets`
- `bun run warden:agents:check`
- `bun run warden:skills:check`
- `bun run changeset:check`
- `bun run publish:check`
- `bun run format:check`
- `git diff --check`
- `bun run check`

## Risks / Rollout Notes

- This is intentionally docs-only. No resolved graph fields are added.
- Future exhaustive error graph work should be authored or inferred explicitly instead of being implied by examples, detours, or taxonomy tables.

## Changeset / Release Notes

- No changeset. This PR changes docs/ADR scope only and does not change publishable package behavior.

Closes: TRL-658
