### PR TITLE
docs: refresh taxonomy and vocab audit metadata

### DIFF
--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -183,7 +183,7 @@ See [testing-patterns.md](references/testing-patterns.md) for the full testing A
 
 ## Error Taxonomy
 
-15 fixed-category error classes across 10 categories, plus the dynamic `RetryExhaustedError` wrapper, with deterministic mapping to exit codes, HTTP status, and JSON-RPC codes:
+16 fixed-category error classes across 10 categories, plus the dynamic `RetryExhaustedError` wrapper, with deterministic mapping to exit codes, HTTP status, and JSON-RPC codes:
 
 | Category | Classes | Exit | HTTP | Retry |
 |----------|---------|------|------|-------|
@@ -194,7 +194,7 @@ See [testing-patterns.md](references/testing-patterns.md) for the full testing A
 | timeout | TimeoutError | 5 | 504 | Yes |
 | rate_limit | RateLimitError | 6 | 429 | Yes |
 | network | NetworkError | 7 | 502 | Yes |
-| internal | InternalError, DerivationError, AssertionError | 8 | 500 | No |
+| internal | InternalError, DerivationError, RecoverableCompletionError, AssertionError | 8 | 500 | No |
 | auth | AuthError | 9 | 401 | No |
 | cancelled | CancelledError | 130 | 499 | No |
 

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -196,7 +196,7 @@ The implementation is identical across all paths. Only the edges change.
 
 ## Error Taxonomy
 
-15 fixed-category error classes across 10 categories, plus the dynamic
+16 fixed-category error classes across 10 categories, plus the dynamic
 `RetryExhaustedError` wrapper. All extend `TrailsError`. Pattern match with
 `instanceof` or `error.category`.
 
@@ -209,7 +209,7 @@ The implementation is identical across all paths. Only the edges change.
 | `timeout` | 5 | 504 | Yes | `TimeoutError` |
 | `rate_limit` | 6 | 429 | Yes | `RateLimitError` |
 | `network` | 7 | 502 | Yes | `NetworkError` |
-| `internal` | 8 | 500 | No | `InternalError`, `DerivationError`, `AssertionError` |
+| `internal` | 8 | 500 | No | `InternalError`, `DerivationError`, `RecoverableCompletionError`, `AssertionError` |
 | `auth` | 9 | 401 | No | `AuthError` |
 | `cancelled` | 130 | 499 | No | `CancelledError` |
 

--- a/plugin/skills/trails/references/error-taxonomy.md
+++ b/plugin/skills/trails/references/error-taxonomy.md
@@ -2,7 +2,7 @@
 
 ## Error Classes
 
-The taxonomy has 15 fixed-category classes across 10 categories, plus the
+The taxonomy has 16 fixed-category classes across 10 categories, plus the
 dynamic `RetryExhaustedError` wrapper.
 
 ### validation (exit 1, HTTP 400)
@@ -40,6 +40,7 @@ dynamic `RetryExhaustedError` wrapper.
 
 - **InternalError** — Unexpected failure. Catch-all for bugs. `new InternalError('unexpected null in pipeline')`
 - **DerivationError** — Framework or projection derivation failure. `new DerivationError('could not derive CLI fields from schema')`
+- **RecoverableCompletionError** — Internal completion failure where recovery may still run before the final result is reported. `new RecoverableCompletionError('trace sink flush failed')`
 - **AssertionError** — Invariant violation. `new AssertionError('items array must not be empty after filter')`
 
 ### auth (exit 9, HTTP 401)

--- a/plugin/skills/trails/references/testing-patterns.md
+++ b/plugin/skills/trails/references/testing-patterns.md
@@ -154,7 +154,7 @@ Applied automatically per example based on which fields are present:
 { name: 'Not found', input: { name: 'nope' }, error: 'NotFoundError' }
 ```
 
-Error class names: `ValidationError`, `NotFoundError`, `AlreadyExistsError`, `ConflictError`, `AuthError`, `PermissionError`, `PermitError`, `TimeoutError`, `NetworkError`, `RateLimitError`, `InternalError`, `DerivationError`, `AmbiguousError`, `CancelledError`, `AssertionError`, `RetryExhaustedError`.
+Error class names: `ValidationError`, `NotFoundError`, `AlreadyExistsError`, `ConflictError`, `AuthError`, `PermissionError`, `PermitError`, `TimeoutError`, `NetworkError`, `RateLimitError`, `InternalError`, `DerivationError`, `RecoverableCompletionError`, `AmbiguousError`, `CancelledError`, `AssertionError`, `RetryExhaustedError`.
 
 ## `createCrossContext()` -- Mock Cross for Composite Trails
 


### PR DESCRIPTION
## Context

This PR preserves the useful part of the stale docs-freshness audit after rebasing it onto current `main`. The generated ADR/error-taxonomy pieces from the original draft are already represented on `main`; the remaining gap is the repo-owned Trails plugin skill and references.

## What changed

- Updated the Trails plugin skill taxonomy references from 15 fixed-category classes to 16 fixed-category classes.
- Added `RecoverableCompletionError` to the plugin skill taxonomy tables and testing/error references.
- Left ADR/generated taxonomy output unchanged because current `main` already owns that generated snapshot.

## Validation

- `bun install`
- `bun run error-taxonomy:check`
- `bun run warden:skills:check`
- `bun run docs:snippets`
- `bun run format:check`
- `git diff --check`

## Notes

- No changeset: docs/plugin skill guidance only.
- PR #528 overlaps this same stale audit area and should be closed as redundant before the beta.18 version cut.
