### PR TITLE
refactor: rename topographer API to TopoGraph

### DIFF
--- a/.changeset/trl-695-topograph-api.md
+++ b/.changeset/trl-695-topograph-api.md
@@ -1,0 +1,8 @@
+---
+'@ontrails/topographer': major
+'@ontrails/trails': patch
+'@ontrails/warden': patch
+---
+
+Rename the public resolved graph API from `SurfaceMap` to `TopoGraph`, including
+the derive, hash, diff, and current graph artifact I/O helpers.

--- a/apps/trails-demo/__tests__/governance.test.ts
+++ b/apps/trails-demo/__tests__/governance.test.ts
@@ -4,7 +4,7 @@
  * Integration tests proving the full governance loop works end-to-end.
  *
  * The "five things" that make Trails real:
- * 1. Surface map generation
+ * 1. TopoGraph generation
  * 2. Deterministic hashing
  * 3. Breaking change detection
  * 4. Non-breaking change detection
@@ -15,9 +15,9 @@ import { describe, expect, test } from 'bun:test';
 
 import { Result, trail, topo, validateTopo } from '@ontrails/core';
 import {
-  deriveSurfaceMapDiff,
-  deriveSurfaceMap,
-  deriveSurfaceMapHash,
+  deriveTopoGraphDiff,
+  deriveTopoGraph,
+  deriveTopoGraphHash,
 } from '@ontrails/topographer';
 import { z } from 'zod';
 
@@ -32,14 +32,14 @@ import * as onboard from '../src/trails/onboard.js';
 import * as search from '../src/trails/search.js';
 
 // ---------------------------------------------------------------------------
-// 1. Surface map generation
+// 1. TopoGraph generation
 // ---------------------------------------------------------------------------
 
-describe('surface map generation', () => {
-  const surfaceMap = deriveSurfaceMap(graph);
+describe('TopoGraph generation', () => {
+  const topoGraph = deriveTopoGraph(graph);
 
   test('contains all expected trail, signal, and resource IDs', () => {
-    const ids = surfaceMap.entries.map((e) => e.id);
+    const ids = topoGraph.entries.map((e) => e.id);
 
     expect(ids).toContain('entity.show');
     expect(ids).toContain('entity.add');
@@ -56,21 +56,21 @@ describe('surface map generation', () => {
   });
 
   test('has exactly 14 entries (8 trails + 4 signals + 2 resources)', () => {
-    const ids = surfaceMap.entries.map((e) => e.id);
+    const ids = topoGraph.entries.map((e) => e.id);
 
-    expect(surfaceMap.entries).toHaveLength(14);
+    expect(topoGraph.entries).toHaveLength(14);
     expect(ids).toContain('entity.notify-updated');
     expect(ids).toContain('demo.notification-store');
   });
 
   test('entries are sorted alphabetically by id', () => {
-    const ids = surfaceMap.entries.map((e) => e.id);
+    const ids = topoGraph.entries.map((e) => e.id);
     const sorted = [...ids].toSorted();
     expect(ids).toEqual(sorted);
   });
 
   test('each entry has the expected fields', () => {
-    for (const entry of surfaceMap.entries) {
+    for (const entry of topoGraph.entries) {
       expect(entry.id).toBeString();
       expect(entry.kind).toBeOneOf(['trail', 'signal', 'resource']);
       expect(entry.exampleCount).toBeNumber();
@@ -79,7 +79,7 @@ describe('surface map generation', () => {
   });
 
   test('trail entries include input schema', () => {
-    const showEntry = surfaceMap.entries.find((e) => e.id === 'entity.show');
+    const showEntry = topoGraph.entries.find((e) => e.id === 'entity.show');
     expect(showEntry).toBeDefined();
     if (showEntry) {
       expect(showEntry.input).toBeDefined();
@@ -88,17 +88,15 @@ describe('surface map generation', () => {
   });
 
   test('safety markers are preserved', () => {
-    const showEntry = surfaceMap.entries.find((e) => e.id === 'entity.show');
-    const deleteEntry = surfaceMap.entries.find(
-      (e) => e.id === 'entity.delete'
-    );
+    const showEntry = topoGraph.entries.find((e) => e.id === 'entity.show');
+    const deleteEntry = topoGraph.entries.find((e) => e.id === 'entity.delete');
 
     expect(showEntry?.intent).toBe('read');
     expect(deleteEntry?.intent).toBe('destroy');
   });
 
   test('route entries include crosses', () => {
-    const onboardEntry = surfaceMap.entries.find(
+    const onboardEntry = topoGraph.entries.find(
       (e) => e.id === 'entity.onboard'
     );
     expect(onboardEntry).toBeDefined();
@@ -111,7 +109,7 @@ describe('surface map generation', () => {
   });
 
   test('signal entries include payload schema as input', () => {
-    const updatedEntry = surfaceMap.entries.find(
+    const updatedEntry = topoGraph.entries.find(
       (e) => e.id === 'entity.updated'
     );
     expect(updatedEntry).toBeDefined();
@@ -122,7 +120,7 @@ describe('surface map generation', () => {
   });
 
   test('resource entries include their description', () => {
-    const resourceEntry = surfaceMap.entries.find(
+    const resourceEntry = topoGraph.entries.find(
       (e) => e.id === 'demo.entity-store'
     );
     expect(resourceEntry).toBeDefined();
@@ -139,26 +137,26 @@ describe('surface map generation', () => {
 // 2. Deterministic hashing
 // ---------------------------------------------------------------------------
 
-describe('surface map hashing is deterministic', () => {
+describe('TopoGraph hashing is deterministic', () => {
   test('identical topos produce identical hashes', () => {
-    const map1 = deriveSurfaceMap(graph);
-    const map2 = deriveSurfaceMap(graph);
+    const map1 = deriveTopoGraph(graph);
+    const map2 = deriveTopoGraph(graph);
 
-    const hash1 = deriveSurfaceMapHash(map1);
-    const hash2 = deriveSurfaceMapHash(map2);
+    const hash1 = deriveTopoGraphHash(map1);
+    const hash2 = deriveTopoGraphHash(map2);
 
     expect(hash1).toBe(hash2);
   });
 
   test('hash is a valid 64-character hex string', () => {
-    const surfaceMap = deriveSurfaceMap(graph);
-    const hash = deriveSurfaceMapHash(surfaceMap);
+    const topoGraph = deriveTopoGraph(graph);
+    const hash = deriveTopoGraphHash(topoGraph);
 
     expect(hash).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test('generatedAt timestamp does not affect hash', () => {
-    const map1 = deriveSurfaceMap(graph);
+    const map1 = deriveTopoGraph(graph);
 
     // Manually create a copy with a different generatedAt
     const map2 = {
@@ -166,7 +164,7 @@ describe('surface map hashing is deterministic', () => {
       generatedAt: '2099-12-31T23:59:59.999Z',
     };
 
-    expect(deriveSurfaceMapHash(map1)).toBe(deriveSurfaceMapHash(map2));
+    expect(deriveTopoGraphHash(map1)).toBe(deriveTopoGraphHash(map2));
   });
 });
 
@@ -207,10 +205,10 @@ const makeModifiedShow = (inputSchema: z.ZodType) =>
 
 /** Diff the baseline app against a modified app. */
 const diffAgainst = (...modules: Record<string, unknown>[]) => {
-  const before = deriveSurfaceMap(graph);
+  const before = deriveTopoGraph(graph);
   const modifiedApp = topo('demo-modified', ...modules);
-  const after = deriveSurfaceMap(modifiedApp);
-  return deriveSurfaceMapDiff(before, after);
+  const after = deriveTopoGraph(modifiedApp);
+  return deriveTopoGraphDiff(before, after);
 };
 
 describe('breaking change detection', () => {
@@ -322,9 +320,9 @@ describe('non-breaking change detection', () => {
   });
 
   test('no changes produces empty diff', () => {
-    const map1 = deriveSurfaceMap(graph);
-    const map2 = deriveSurfaceMap(graph);
-    const diff = deriveSurfaceMapDiff(map1, map2);
+    const map1 = deriveTopoGraph(graph);
+    const map2 = deriveTopoGraph(graph);
+    const diff = deriveTopoGraphDiff(map1, map2);
 
     expect(diff.hasBreaking).toBe(false);
     expect(diff.entries).toHaveLength(0);

--- a/apps/trails/src/__tests__/run-watch-compose.test.ts
+++ b/apps/trails/src/__tests__/run-watch-compose.test.ts
@@ -103,11 +103,11 @@ describe('runWatchLoop with run.example', () => {
     // implementation flipping from a passing example to a failing one
     // by mutating a flag the stub reads each rerun.
     let nextMatch = true;
-    let surfaceHash = 'contract:v1';
+    let topoGraphEntryHash = 'contract:v1';
     const envelopes: { readonly match: boolean }[] = [];
 
     const watcher = createTrailWatcher({
-      initialSurfaceHash: surfaceHash,
+      initialTopoGraphEntryHash: topoGraphEntryHash,
       onRerun: () => {
         // Imagine the run trail produces a fresh comparison envelope
         // each invocation. The `run example --watch` contract is that
@@ -116,7 +116,7 @@ describe('runWatchLoop with run.example', () => {
         // the example.
         envelopes.push({ match: nextMatch });
       },
-      readSurfaceHash: () => surfaceHash,
+      readTopoGraphEntryHash: () => topoGraphEntryHash,
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
@@ -124,7 +124,7 @@ describe('runWatchLoop with run.example', () => {
       await Bun.sleep(WATCHER_SETTLE_MS);
 
       // First edit: example matches.
-      surfaceHash = 'contract:v2';
+      topoGraphEntryHash = 'contract:v2';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const v = 2;\n'
@@ -133,7 +133,7 @@ describe('runWatchLoop with run.example', () => {
 
       // Second edit: implementation drifts, example mismatches.
       nextMatch = false;
-      surfaceHash = 'contract:v3';
+      topoGraphEntryHash = 'contract:v3';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const v = 3;\n'
@@ -166,7 +166,7 @@ describe('runWatchLoop with --trace', () => {
   });
 
   test('each rerun gets a fresh trace sink (records do not bleed)', async () => {
-    let surfaceHash = 'contract:v1';
+    let topoGraphEntryHash = 'contract:v1';
     const recordCounts: number[] = [];
 
     // Simulate `runSurfaceOnce` under `--trace`: each invocation installs
@@ -184,23 +184,23 @@ describe('runWatchLoop with --trace', () => {
     };
 
     const watcher = createTrailWatcher({
-      initialSurfaceHash: surfaceHash,
+      initialTopoGraphEntryHash: topoGraphEntryHash,
       onRerun: performRun,
-      readSurfaceHash: () => surfaceHash,
+      readTopoGraphEntryHash: () => topoGraphEntryHash,
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
     try {
       await Bun.sleep(WATCHER_SETTLE_MS);
 
-      surfaceHash = 'contract:v2';
+      topoGraphEntryHash = 'contract:v2';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const v = 2;\n'
       );
       await waitFor(() => recordCounts.length >= 1, WATCH_DEBOUNCE_MS + 1000);
 
-      surfaceHash = 'contract:v3';
+      topoGraphEntryHash = 'contract:v3';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const v = 3;\n'
@@ -247,11 +247,11 @@ describe('runWatchLoop error recovery', () => {
 
   test('a thrown rerun does not exit the watch loop; subsequent saves still trigger reruns', async () => {
     let runs = 0;
-    let surfaceHash = 'contract:v1';
+    let topoGraphEntryHash = 'contract:v1';
     let throwOnNextRun = false;
 
     const watcher = createTrailWatcher({
-      initialSurfaceHash: surfaceHash,
+      initialTopoGraphEntryHash: topoGraphEntryHash,
       onRerun: () => {
         runs += 1;
         if (throwOnNextRun) {
@@ -259,7 +259,7 @@ describe('runWatchLoop error recovery', () => {
           throw new Error('synthetic syntax error');
         }
       },
-      readSurfaceHash: () => surfaceHash,
+      readTopoGraphEntryHash: () => topoGraphEntryHash,
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
@@ -268,7 +268,7 @@ describe('runWatchLoop error recovery', () => {
 
       // First save: rerun throws.
       throwOnNextRun = true;
-      surfaceHash = 'contract:v2';
+      topoGraphEntryHash = 'contract:v2';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const v = 2;\n'
@@ -276,7 +276,7 @@ describe('runWatchLoop error recovery', () => {
       await waitFor(() => runs >= 1, WATCH_DEBOUNCE_MS + 1000);
 
       // Watcher must still be live: a second save triggers another rerun.
-      surfaceHash = 'contract:v3';
+      topoGraphEntryHash = 'contract:v3';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const v = 3;\n'
@@ -294,12 +294,12 @@ describe('runWatchLoop error recovery', () => {
 
   test('runWatchLoop continues across a thrown run() and exits cleanly on SIGINT', async () => {
     let runs = 0;
-    let surfaceHash = 'contract:v1';
+    let topoGraphEntryHash = 'contract:v1';
     let throwOnNextRun = false;
 
     const loopPromise = runWatchLoop({
       clearScreen: false,
-      readSurfaceHash: () => surfaceHash,
+      readTopoGraphEntryHash: () => topoGraphEntryHash,
       run: async () => {
         runs += 1;
         if (throwOnNextRun) {
@@ -319,7 +319,7 @@ describe('runWatchLoop error recovery', () => {
 
       // First save throws.
       throwOnNextRun = true;
-      surfaceHash = 'contract:v2';
+      topoGraphEntryHash = 'contract:v2';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const v = 2;\n'
@@ -327,7 +327,7 @@ describe('runWatchLoop error recovery', () => {
       await waitFor(() => runs >= 2, WATCH_DEBOUNCE_MS + 1000);
 
       // Second save: loop is still alive, rerun succeeds.
-      surfaceHash = 'contract:v3';
+      topoGraphEntryHash = 'contract:v3';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const v = 3;\n'

--- a/apps/trails/src/__tests__/run-watch.test.ts
+++ b/apps/trails/src/__tests__/run-watch.test.ts
@@ -5,8 +5,8 @@ import { join } from 'node:path';
 
 import { Result, resource, signal, topo, trail } from '@ontrails/core';
 import type { Layer, Topo } from '@ontrails/core';
-import { deriveSurfaceMap } from '@ontrails/topographer';
-import type { SurfaceMapEntry } from '@ontrails/topographer';
+import { deriveTopoGraph } from '@ontrails/topographer';
+import type { TopoGraphEntry } from '@ontrails/topographer';
 import { z } from 'zod';
 
 import {
@@ -14,7 +14,7 @@ import {
   WATCH_WARMUP_MS,
   argvHasWatchFlag,
   createTrailWatcher,
-  hashSurfaceMapEntry,
+  hashTopoGraphEntry,
   readRunTrailId,
 } from '../run-watch.js';
 
@@ -127,8 +127,8 @@ const buildWatchedApp = (options: WatchedAppOptions = {}): Topo => {
   });
 };
 
-const watchedEntry = (app: Topo): SurfaceMapEntry => {
-  const entry = deriveSurfaceMap(app).entries.find(
+const watchedEntry = (app: Topo): TopoGraphEntry => {
+  const entry = deriveTopoGraph(app).entries.find(
     (candidate) => candidate.kind === 'trail' && candidate.id === 'entity.watch'
   );
   if (entry === undefined) {
@@ -138,7 +138,7 @@ const watchedEntry = (app: Topo): SurfaceMapEntry => {
 };
 
 const watchedEntryHash = (app: Topo): string =>
-  hashSurfaceMapEntry(watchedEntry(app));
+  hashTopoGraphEntry(watchedEntry(app));
 
 // ---------------------------------------------------------------------------
 // Argv detection
@@ -208,8 +208,8 @@ describe('createTrailWatcher', () => {
     expect(WATCH_DEBOUNCE_MS).toBeLessThanOrEqual(200);
   });
 
-  test('hashes a surface-map entry deterministically', () => {
-    const entry: SurfaceMapEntry = {
+  test('hashes a TopoGraph entry deterministically', () => {
+    const entry: TopoGraphEntry = {
       exampleCount: 0,
       id: 'entity.show',
       input: { type: 'object' },
@@ -219,9 +219,9 @@ describe('createTrailWatcher', () => {
       surfaces: ['cli'],
     } as const;
 
-    expect(hashSurfaceMapEntry(entry)).toBe(hashSurfaceMapEntry(entry));
-    expect(hashSurfaceMapEntry({ ...entry, intent: 'write' })).not.toBe(
-      hashSurfaceMapEntry(entry)
+    expect(hashTopoGraphEntry(entry)).toBe(hashTopoGraphEntry(entry));
+    expect(hashTopoGraphEntry({ ...entry, intent: 'write' })).not.toBe(
+      hashTopoGraphEntry(entry)
     );
   });
 
@@ -293,21 +293,21 @@ describe('createTrailWatcher', () => {
     expect(changedSibling).toBe(baseline);
   });
 
-  test('triggers a rerun when the watched surface-map entry changes', async () => {
+  test('triggers a rerun when the watched TopoGraph entry changes', async () => {
     const reruns: number[] = [];
-    let surfaceHash = 'contract:v1';
+    let topoGraphEntryHash = 'contract:v1';
     const watcher = createTrailWatcher({
-      initialSurfaceHash: surfaceHash,
+      initialTopoGraphEntryHash: topoGraphEntryHash,
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => surfaceHash,
+      readTopoGraphEntryHash: () => topoGraphEntryHash,
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
     try {
       await Bun.sleep(WATCHER_SETTLE_MS);
-      surfaceHash = 'contract:v2';
+      topoGraphEntryHash = 'contract:v2';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const v = 2;\n'
@@ -323,19 +323,19 @@ describe('createTrailWatcher', () => {
 
   test('triggers exactly one rerun for a derived contract hash change', async () => {
     const reruns: number[] = [];
-    let surfaceHash = watchedEntryHash(buildWatchedApp());
+    let topoGraphEntryHash = watchedEntryHash(buildWatchedApp());
     const watcher = createTrailWatcher({
-      initialSurfaceHash: surfaceHash,
+      initialTopoGraphEntryHash: topoGraphEntryHash,
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => surfaceHash,
+      readTopoGraphEntryHash: () => topoGraphEntryHash,
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
     try {
       await Bun.sleep(WATCHER_SETTLE_MS);
-      surfaceHash = watchedEntryHash(
+      topoGraphEntryHash = watchedEntryHash(
         buildWatchedApp({
           input: z.object({ id: z.string(), verbose: z.boolean() }),
         })
@@ -354,14 +354,14 @@ describe('createTrailWatcher', () => {
     }
   });
 
-  test('does not rerun for comment-only edits with the same surface hash', async () => {
+  test('does not rerun for comment-only edits with the same topo graph entry hash', async () => {
     const reruns: number[] = [];
     const watcher = createTrailWatcher({
-      initialSurfaceHash: 'contract:v1',
+      initialTopoGraphEntryHash: 'contract:v1',
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => 'contract:v1',
+      readTopoGraphEntryHash: () => 'contract:v1',
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
@@ -383,11 +383,11 @@ describe('createTrailWatcher', () => {
   test('does not rerun for sibling source edits when the watched contract is unchanged', async () => {
     const reruns: number[] = [];
     const watcher = createTrailWatcher({
-      initialSurfaceHash: 'contract:v1',
+      initialTopoGraphEntryHash: 'contract:v1',
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => 'contract:v1',
+      readTopoGraphEntryHash: () => 'contract:v1',
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
@@ -409,11 +409,11 @@ describe('createTrailWatcher', () => {
   test('does not rerun for non .ts/.js files', async () => {
     const reruns: number[] = [];
     const watcher = createTrailWatcher({
-      initialSurfaceHash: 'contract:v1',
+      initialTopoGraphEntryHash: 'contract:v1',
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => 'contract:v1',
+      readTopoGraphEntryHash: () => 'contract:v1',
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
@@ -433,11 +433,11 @@ describe('createTrailWatcher', () => {
   test('does not rerun for changes in unrelated directories', async () => {
     const reruns: number[] = [];
     const watcher = createTrailWatcher({
-      initialSurfaceHash: 'contract:v1',
+      initialTopoGraphEntryHash: 'contract:v1',
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => 'contract:v1',
+      readTopoGraphEntryHash: () => 'contract:v1',
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
@@ -458,13 +458,13 @@ describe('createTrailWatcher', () => {
 
   test('debounces rapid changes into a single rerun', async () => {
     const reruns: number[] = [];
-    let surfaceHash = 'contract:v1';
+    let topoGraphEntryHash = 'contract:v1';
     const watcher = createTrailWatcher({
-      initialSurfaceHash: surfaceHash,
+      initialTopoGraphEntryHash: topoGraphEntryHash,
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => surfaceHash,
+      readTopoGraphEntryHash: () => topoGraphEntryHash,
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
@@ -472,7 +472,7 @@ describe('createTrailWatcher', () => {
       await Bun.sleep(WATCHER_SETTLE_MS);
       // Burst of writes within the debounce window.
       for (let i = 0; i < 5; i += 1) {
-        surfaceHash = `contract:v${i + 2}`;
+        topoGraphEntryHash = `contract:v${i + 2}`;
         writeFileSync(
           join(fixture.watchedDir, 'trail.ts'),
           `export const v = ${i};\n`
@@ -489,20 +489,20 @@ describe('createTrailWatcher', () => {
     }
   });
 
-  test('skips invalid surface states and resumes on the next valid contract change', async () => {
+  test('skips invalid TopoGraph states and resumes on the next valid contract change', async () => {
     const reruns: number[] = [];
     let mode: 'invalid' | 'valid' = 'invalid';
-    let surfaceHash = 'contract:v1';
+    let topoGraphEntryHash = 'contract:v1';
     const watcher = createTrailWatcher({
-      initialSurfaceHash: surfaceHash,
+      initialTopoGraphEntryHash: topoGraphEntryHash,
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => {
+      readTopoGraphEntryHash: () => {
         if (mode === 'invalid') {
           throw new Error('schema invalid');
         }
-        return surfaceHash;
+        return topoGraphEntryHash;
       },
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
@@ -517,7 +517,7 @@ describe('createTrailWatcher', () => {
       expect(reruns.length).toBe(0);
 
       mode = 'valid';
-      surfaceHash = 'contract:v2';
+      topoGraphEntryHash = 'contract:v2';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const fixed = 1;\n'
@@ -531,13 +531,13 @@ describe('createTrailWatcher', () => {
 
   test('holds when the watched trail is removed and reruns once it returns changed', async () => {
     const reruns: number[] = [];
-    let surfaceHash: string | null = null;
+    let topoGraphEntryHash: string | null = null;
     const watcher = createTrailWatcher({
-      initialSurfaceHash: 'contract:v1',
+      initialTopoGraphEntryHash: 'contract:v1',
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => surfaceHash,
+      readTopoGraphEntryHash: () => topoGraphEntryHash,
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
@@ -547,7 +547,7 @@ describe('createTrailWatcher', () => {
       await Bun.sleep(WATCH_DEBOUNCE_MS + 200);
       expect(reruns.length).toBe(0);
 
-      surfaceHash = 'contract:v2';
+      topoGraphEntryHash = 'contract:v2';
       writeFileSync(
         join(fixture.watchedDir, 'trail.ts'),
         'export const restored = 1;\n'
@@ -565,7 +565,7 @@ describe('createTrailWatcher', () => {
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => 'contract:v1',
+      readTopoGraphEntryHash: () => 'contract:v1',
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 
@@ -581,17 +581,17 @@ describe('createTrailWatcher', () => {
     expect(reruns.length).toBe(0);
   });
 
-  test('close() suppresses rerun when surface hash read is already in flight', async () => {
+  test('close() suppresses rerun when topo graph entry hash read is already in flight', async () => {
     const reruns: number[] = [];
     const hashRead = Promise.withResolvers<string>();
     let readStarted = false;
     const watcher = createTrailWatcher({
       debounceMs: 10,
-      initialSurfaceHash: 'contract:v1',
+      initialTopoGraphEntryHash: 'contract:v1',
       onRerun: () => {
         reruns.push(Date.now());
       },
-      readSurfaceHash: () => {
+      readTopoGraphEntryHash: () => {
         readStarted = true;
         return hashRead.promise;
       },
@@ -621,7 +621,7 @@ describe('createTrailWatcher', () => {
       onRerun: () => {
         // no-op
       },
-      readSurfaceHash: () => 'contract:v1',
+      readTopoGraphEntryHash: () => 'contract:v1',
       sourcePath: join(fixture.watchedDir, 'trail.ts'),
     });
 

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -20,12 +20,12 @@ import {
   trail,
 } from '@ontrails/core';
 import {
-  deriveSurfaceMap,
-  deriveSurfaceMapHash,
-  deriveSurfaceMapDiff,
-  writeSurfaceMap,
+  deriveTopoGraph,
+  deriveTopoGraphHash,
+  deriveTopoGraphDiff,
+  writeTopoGraph,
 } from '@ontrails/topographer';
-import type { SurfaceMap } from '@ontrails/topographer';
+import type { TopoGraph } from '@ontrails/topographer';
 import { z } from 'zod';
 
 import {
@@ -232,8 +232,8 @@ const repoTempDir = (): string =>
 // ---------------------------------------------------------------------------
 
 describe('trails survey', () => {
-  test('deriveSurfaceMap includes all trails', () => {
-    const surfaceMap = deriveSurfaceMap(app);
+  test('deriveTopoGraph includes all trails', () => {
+    const surfaceMap = deriveTopoGraph(app);
     expect(surfaceMap.entries.length).toBe(3);
     const ids = surfaceMap.entries.map((e) => e.id);
     expect(ids).toContain('hello');
@@ -242,7 +242,7 @@ describe('trails survey', () => {
   });
 
   test('surface map entries have expected fields', () => {
-    const surfaceMap = deriveSurfaceMap(app);
+    const surfaceMap = deriveTopoGraph(app);
     const hello = surfaceMap.entries.find((e) => e.id === 'hello');
     expect(hello).toBeDefined();
     expect(hello?.cli?.path).toEqual(['hello']);
@@ -253,28 +253,28 @@ describe('trails survey', () => {
   });
 
   test('JSON output is valid JSON', () => {
-    const surfaceMap = deriveSurfaceMap(app);
+    const surfaceMap = deriveTopoGraph(app);
     const json = JSON.stringify(surfaceMap, null, 2);
-    const parsed = JSON.parse(json) as SurfaceMap;
+    const parsed = JSON.parse(json) as TopoGraph;
     expect(parsed.version).toBe('1.0');
     expect(parsed.entries.length).toBe(3);
   });
 
-  test('deriveSurfaceMapHash produces stable hash', () => {
-    const surfaceMap = deriveSurfaceMap(app);
-    const hash1 = deriveSurfaceMapHash(surfaceMap);
-    const hash2 = deriveSurfaceMapHash(surfaceMap);
+  test('deriveTopoGraphHash produces stable hash', () => {
+    const surfaceMap = deriveTopoGraph(app);
+    const hash1 = deriveTopoGraphHash(surfaceMap);
+    const hash2 = deriveTopoGraphHash(surfaceMap);
     expect(hash1).toBe(hash2);
     // SHA-256 hex
     expect(hash1.length).toBe(64);
   });
 
-  test('deriveSurfaceMapDiff detects added trails', () => {
-    const prev = deriveSurfaceMap(
+  test('deriveTopoGraphDiff detects added trails', () => {
+    const prev = deriveTopoGraph(
       topo('test', { dbResource, hello: helloTrail })
     );
-    const curr = deriveSurfaceMap(app);
-    const diff = deriveSurfaceMapDiff(prev, curr);
+    const curr = deriveTopoGraph(app);
+    const diff = deriveTopoGraphDiff(prev, curr);
 
     expect(diff.info.length).toBeGreaterThan(0);
     const addedBye = diff.info.find((e) => e.id === 'bye');
@@ -282,12 +282,12 @@ describe('trails survey', () => {
     expect(addedBye?.change).toBe('added');
   });
 
-  test('deriveSurfaceMapDiff detects removed trails', () => {
-    const prev = deriveSurfaceMap(app);
-    const curr = deriveSurfaceMap(
+  test('deriveTopoGraphDiff detects removed trails', () => {
+    const prev = deriveTopoGraph(app);
+    const curr = deriveTopoGraph(
       topo('test', { dbResource, hello: helloTrail })
     );
-    const diff = deriveSurfaceMapDiff(prev, curr);
+    const diff = deriveTopoGraphDiff(prev, curr);
 
     expect(diff.hasBreaking).toBe(true);
     const removedBye = diff.breaking.find((e) => e.id === 'bye');
@@ -295,9 +295,9 @@ describe('trails survey', () => {
     expect(removedBye?.change).toBe('removed');
   });
 
-  test('deriveSurfaceMapDiff returns empty for identical maps', () => {
-    const surfaceMap = deriveSurfaceMap(app);
-    const diff = deriveSurfaceMapDiff(surfaceMap, surfaceMap);
+  test('deriveTopoGraphDiff returns empty for identical maps', () => {
+    const surfaceMap = deriveTopoGraph(app);
+    const diff = deriveTopoGraphDiff(surfaceMap, surfaceMap);
     expect(diff.entries.length).toBe(0);
     expect(diff.hasBreaking).toBe(false);
   });
@@ -962,7 +962,7 @@ describe('trails survey diff', () => {
     try {
       writeSurveyAppFixture(dir);
       const baselineApp = await loadApp('./src/app.ts', dir);
-      await writeSurfaceMap(deriveSurfaceMap(baselineApp), {
+      await writeTopoGraph(deriveTopoGraph(baselineApp), {
         dir: join(dir, '.trails'),
       });
 
@@ -995,7 +995,7 @@ describe('trails survey diff', () => {
     try {
       writeSurveyAppFixture(dir);
       const baselineApp = await loadApp('./src/app.ts', dir);
-      await writeSurfaceMap(deriveSurfaceMap(baselineApp), {
+      await writeTopoGraph(deriveTopoGraph(baselineApp), {
         dir: join(dir, 'baselines'),
       });
 
@@ -1027,7 +1027,7 @@ describe('trails survey diff', () => {
       const baselineApp = await loadApp('./src/app.ts', dir);
       writeFileSync(
         join(dir, 'baseline.json'),
-        JSON.stringify(deriveSurfaceMap(baselineApp))
+        JSON.stringify(deriveTopoGraph(baselineApp))
       );
 
       writeSurveyAppFixture(dir, { withBye: true });
@@ -1086,7 +1086,7 @@ describe('trails survey diff', () => {
     try {
       writeSurveyAppFixture(dir);
       const baselineApp = await loadApp('./src/app.ts', dir);
-      await writeSurfaceMap(deriveSurfaceMap(baselineApp), {
+      await writeTopoGraph(deriveTopoGraph(baselineApp), {
         dir: join(dir, 'baselines'),
       });
       mkdirSync(join(dir, '.trails'), { recursive: true });

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -17,7 +17,7 @@ import type {
 } from '@ontrails/cli';
 import { createProgram } from '@ontrails/commander';
 import { resolvePermitFromBearerToken } from '@ontrails/permits';
-import { deriveSurfaceMap } from '@ontrails/topographer';
+import { deriveTopoGraph } from '@ontrails/topographer';
 
 import { app } from './app.js';
 import { resolveInputWithClack } from './clack.js';
@@ -35,7 +35,7 @@ import {
 import type { TraceSession } from './run-trace.js';
 import {
   argvHasWatchFlag,
-  hashSurfaceMapEntry,
+  hashTopoGraphEntry,
   readRunTrailId,
   runWatchLoop,
 } from './run-watch.js';
@@ -144,7 +144,7 @@ const resolveWatchRunTarget = (
 
 /**
  * Resolve the directory whose source-file events wake the `--watch` loop.
- * Reruns still depend on the resolved surface-map entry hash; this path is
+ * Reruns still depend on the resolved TopoGraph entry hash; this path is
  * only the cheap filesystem event source.
  */
 const toWatchSourcePath = (rootDir: string, modulePath: string): string => {
@@ -180,7 +180,7 @@ const resolveWatchDirectorySourcePath = async (
   return join(cwd, 'app.ts');
 };
 
-const readWatchSurfaceHash = async (
+const readWatchTopoGraphEntryHash = async (
   target: WatchRunTarget | null
 ): Promise<string | null> => {
   if (target === null) {
@@ -206,11 +206,11 @@ const readWatchSurfaceHash = async (
   }
   const lease = leaseResult.value;
   try {
-    const surfaceMap = deriveSurfaceMap(lease.app);
-    const entry = surfaceMap.entries.find(
+    const topoGraph = deriveTopoGraph(lease.app);
+    const entry = topoGraph.entries.find(
       (candidate) => candidate.kind === 'trail' && candidate.id === target.id
     );
-    return entry === undefined ? null : hashSurfaceMapEntry(entry);
+    return entry === undefined ? null : hashTopoGraphEntry(entry);
   } finally {
     lease.release();
   }
@@ -301,7 +301,7 @@ const watchTarget = argvHasWatchFlag(process.argv)
 
 await (argvHasWatchFlag(process.argv)
   ? runWatchLoop({
-      readSurfaceHash: () => readWatchSurfaceHash(watchTarget),
+      readTopoGraphEntryHash: () => readWatchTopoGraphEntryHash(watchTarget),
       run: runSurfaceOnce,
       sourcePath: await resolveWatchDirectorySourcePath(watchTarget),
     })

--- a/apps/trails/src/run-watch.ts
+++ b/apps/trails/src/run-watch.ts
@@ -4,14 +4,14 @@
  * `--watch` is a local-development ergonomics affordance for `trails run`.
  * After the first invocation completes, the CLI installs a filesystem
  * watcher as a cheap event source. On each debounced event, the watcher
- * re-derives the watched trail's resolved-contract hash from its surface-map
+ * re-derives the watched trail's resolved-contract hash from its TopoGraph
  * entry and invokes the supplied `onRerun` callback only when that hash
  * changes. The loop runs until the user sends `SIGINT`.
  *
  * Design notes:
  *
  * - **Scope.** Watching is intentionally narrow. Filesystem events only wake
- *   the loop; the rerun decision is the watched trail's surface-map entry.
+ *   the loop; the rerun decision is the watched trail's TopoGraph entry.
  *   Comments, whitespace, and unrelated sibling trail changes wake the loop
  *   but do not rerun unless the resolved contract changes.
  * - **Debounce.** Editor saves often produce multiple `fs.watch` events
@@ -27,7 +27,7 @@ import { watch as nodeWatch } from 'node:fs';
 import type { FSWatcher } from 'node:fs';
 import { dirname, extname } from 'node:path';
 
-import type { SurfaceMapEntry } from '@ontrails/topographer';
+import type { TopoGraphEntry } from '@ontrails/topographer';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -170,13 +170,16 @@ const canonicalize = (value: unknown): unknown => {
   return value;
 };
 
-export const hashSurfaceMapEntry = (entry: SurfaceMapEntry): string => {
+export const hashTopoGraphEntry = (entry: TopoGraphEntry): string => {
   const hasher = new Bun.CryptoHasher('sha256');
   hasher.update(JSON.stringify(canonicalize(entry)));
   return hasher.digest('hex');
 };
 
-export type ReadSurfaceHash = () => Promise<string | null> | string | null;
+export type ReadTopoGraphEntryHash = () =>
+  | Promise<string | null>
+  | string
+  | null;
 
 // ---------------------------------------------------------------------------
 // Watcher
@@ -199,14 +202,14 @@ export interface CreateTrailWatcherOptions {
   /**
    * Derive the watched trail's current resolved-contract hash. Return `null`
    * when the watched trail is temporarily absent. Throw when the current
-   * source state cannot produce a valid surface map.
+   * source state cannot produce a valid TopoGraph.
    */
-  readonly readSurfaceHash: ReadSurfaceHash;
+  readonly readTopoGraphEntryHash: ReadTopoGraphEntryHash;
   /**
    * Last known good resolved-contract hash captured after the initial run.
    * When omitted, the next valid changed hash becomes the first rerun signal.
    */
-  readonly initialSurfaceHash?: string | null | undefined;
+  readonly initialTopoGraphEntryHash?: string | null | undefined;
   /**
    * Override for the debounce window. Primarily a test seam; production
    * callers should rely on {@link WATCH_DEBOUNCE_MS}.
@@ -235,7 +238,7 @@ export interface TrailWatcher {
  * The watcher targets the directory of `sourcePath` (non-recursive). Events
  * are filtered to TypeScript/JavaScript file extensions and coalesced through
  * a short debounce window. Each debounced event re-reads the watched trail's
- * surface-map entry hash; only a hash change reruns the trail.
+ * TopoGraph entry hash; only a hash change reruns the trail.
  *
  * @remarks Reruns are not serialized. If a save lands while a previous
  * rerun is still awaiting `onRerun`, the new debounce window can fire
@@ -254,16 +257,18 @@ export const createTrailWatcher = (
   const startedAt = Date.now();
 
   let closed = false;
-  let currentSurfaceHash = options.initialSurfaceHash ?? null;
-  let invalidSurfaceWarned = false;
+  let currentTopoGraphEntryHash = options.initialTopoGraphEntryHash ?? null;
+  let invalidTopoGraphWarned = false;
   let trailRemovedWarned = false;
   let pending: ReturnType<typeof setTimeout> | undefined;
   let watcher: FSWatcher | undefined;
 
-  const readNextSurfaceHash = async (): Promise<string | null | undefined> => {
+  const readNextTopoGraphEntryHash = async (): Promise<
+    string | null | undefined
+  > => {
     try {
-      const nextHash = await options.readSurfaceHash();
-      invalidSurfaceWarned = false;
+      const nextHash = await options.readTopoGraphEntryHash();
+      invalidTopoGraphWarned = false;
       if (nextHash !== null) {
         trailRemovedWarned = false;
       } else if (!trailRemovedWarned) {
@@ -272,9 +277,9 @@ export const createTrailWatcher = (
       }
       return nextHash;
     } catch {
-      if (!invalidSurfaceWarned) {
+      if (!invalidTopoGraphWarned) {
         process.stderr.write(WATCH_SCHEMA_INVALID_MESSAGE);
-        invalidSurfaceWarned = true;
+        invalidTopoGraphWarned = true;
       }
       return undefined;
     }
@@ -285,17 +290,17 @@ export const createTrailWatcher = (
     if (closed) {
       return;
     }
-    const nextHash = await readNextSurfaceHash();
+    const nextHash = await readNextTopoGraphEntryHash();
     if (closed) {
       return;
     }
     if (nextHash === undefined || nextHash === null) {
       return;
     }
-    if (nextHash === currentSurfaceHash) {
+    if (nextHash === currentTopoGraphEntryHash) {
       return;
     }
-    currentSurfaceHash = nextHash;
+    currentTopoGraphEntryHash = nextHash;
     try {
       await options.onRerun();
     } catch (error: unknown) {
@@ -363,7 +368,7 @@ export interface RunWatchLoopOptions {
   /** Invoked once per debounced change burst (and once initially). */
   readonly run: () => Promise<void>;
   /** Derive the watched trail's current resolved-contract hash. */
-  readonly readSurfaceHash: ReadSurfaceHash;
+  readonly readTopoGraphEntryHash: ReadTopoGraphEntryHash;
   /**
    * Override for the debounce window. Primarily a test seam.
    */
@@ -403,18 +408,18 @@ export const runWatchLoop = async (
 
   await performRun();
 
-  let initialSurfaceHash: string | null = null;
+  let initialTopoGraphEntryHash: string | null = null;
   try {
-    initialSurfaceHash = await options.readSurfaceHash();
+    initialTopoGraphEntryHash = await options.readTopoGraphEntryHash();
   } catch {
     process.stderr.write(WATCH_SCHEMA_INVALID_MESSAGE);
   }
 
   const watcher = createTrailWatcher({
     debounceMs: options.debounceMs,
-    initialSurfaceHash,
+    initialTopoGraphEntryHash,
     onRerun: performRun,
-    readSurfaceHash: options.readSurfaceHash,
+    readTopoGraphEntryHash: options.readTopoGraphEntryHash,
     sourcePath: options.sourcePath,
   });
 

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -15,12 +15,12 @@ import {
   trail,
   ValidationError,
 } from '@ontrails/core';
-import type { DiffEntry, DiffResult, SurfaceMap } from '@ontrails/topographer';
+import type { DiffEntry, DiffResult, TopoGraph } from '@ontrails/topographer';
 import {
   createTopoStore,
-  deriveSurfaceMapDiff,
-  deriveSurfaceMap,
-  readSurfaceMap,
+  deriveTopoGraphDiff,
+  deriveTopoGraph,
+  readTopoGraph,
 } from '@ontrails/topographer';
 import { z } from 'zod';
 
@@ -103,7 +103,7 @@ const createDiffExampleInput = (): {
     entries: [],
     generatedAt: '2026-01-01T00:00:00.000Z',
     version: '1.0',
-  } satisfies SurfaceMap);
+  } satisfies TopoGraph);
   return { ...input, against: 'baseline' };
 };
 
@@ -112,11 +112,11 @@ const isNotFound = (error: unknown): boolean =>
   error !== null &&
   (error as NodeJS.ErrnoException).code === 'ENOENT';
 
-const readSurfaceMapFile = async (
+const readTopoGraphFile = async (
   filePath: string
-): Promise<SurfaceMap | null> => {
+): Promise<TopoGraph | null> => {
   try {
-    return (await Bun.file(filePath).json()) as SurfaceMap;
+    return (await Bun.file(filePath).json()) as TopoGraph;
   } catch (error: unknown) {
     if (isNotFound(error)) {
       return null;
@@ -125,10 +125,10 @@ const readSurfaceMapFile = async (
   }
 };
 
-const readStoredSurfaceMap = (
+const readStoredTopoGraph = (
   rootDir: string,
   against: string
-): SurfaceMap | undefined => {
+): TopoGraph | undefined => {
   try {
     const store = createTopoStore({ rootDir });
     const stored =
@@ -136,7 +136,7 @@ const readStoredSurfaceMap = (
       store.exports.get({ snapshotId: against });
     return stored === undefined
       ? undefined
-      : (JSON.parse(stored.surfaceMapJson) as SurfaceMap);
+      : (JSON.parse(stored.surfaceMapJson) as TopoGraph);
   } catch (error: unknown) {
     if (error instanceof NotFoundError) {
       return undefined;
@@ -145,10 +145,10 @@ const readStoredSurfaceMap = (
   }
 };
 
-const readPathSurfaceMap = async (
+const readPathTopoGraph = async (
   rootDir: string,
   against: string
-): Promise<Result<SurfaceMap | null, Error>> => {
+): Promise<Result<TopoGraph | null, Error>> => {
   const safePath = deriveSafePath(rootDir, against);
   if (safePath.isErr()) {
     return safePath;
@@ -156,8 +156,8 @@ const readPathSurfaceMap = async (
 
   return Result.ok(
     extname(safePath.value) === '.json'
-      ? await readSurfaceMapFile(safePath.value)
-      : await readSurfaceMap({ dir: safePath.value })
+      ? await readTopoGraphFile(safePath.value)
+      : await readTopoGraph({ dir: safePath.value })
   );
 };
 
@@ -166,19 +166,19 @@ const describeAgainstPathTarget = (against: string): string =>
     ? 'workspace-relative JSON surface-map file'
     : 'workspace-relative directory containing _surface.json';
 
-const surfaceMapNotFound = (against: string): NotFoundError =>
+const topoGraphNotFound = (against: string): NotFoundError =>
   new NotFoundError(
     `No surface map found for: ${against}. Tried ${describeAgainstPathTarget(
       against
     )}, then topo-store pin and snapshot references.`
   );
 
-const readAgainstSurfaceMap = async (
+const readAgainstTopoGraph = async (
   rootDir: string,
   against?: string | undefined
-): Promise<Result<{ against: string; map: SurfaceMap }, Error>> => {
+): Promise<Result<{ against: string; map: TopoGraph }, Error>> => {
   if (against === undefined || against === 'saved') {
-    const map = await readSurfaceMap({ dir: join(rootDir, '.trails') });
+    const map = await readTopoGraph({ dir: join(rootDir, '.trails') });
     return map === null
       ? Result.err(
           new NotFoundError(
@@ -190,7 +190,7 @@ const readAgainstSurfaceMap = async (
 
   // Treat explicit filesystem targets as the most local user intent; stored
   // pins and snapshot ids are fallback references when no path exists.
-  const pathMap = await readPathSurfaceMap(rootDir, against);
+  const pathMap = await readPathTopoGraph(rootDir, against);
   if (pathMap.isErr()) {
     return pathMap;
   }
@@ -198,12 +198,12 @@ const readAgainstSurfaceMap = async (
     return Result.ok({ against, map: pathMap.value });
   }
 
-  const storedMap = readStoredSurfaceMap(rootDir, against);
+  const storedMap = readStoredTopoGraph(rootDir, against);
   if (storedMap !== undefined) {
     return Result.ok({ against, map: storedMap });
   }
 
-  return Result.err(surfaceMapNotFound(against));
+  return Result.err(topoGraphNotFound(against));
 };
 
 const buildSurveyDiff = async (
@@ -212,13 +212,13 @@ const buildSurveyDiff = async (
   breakingOnly: boolean,
   against?: string | undefined
 ): Promise<Result<SurveyDiffReport, Error>> => {
-  const currentMap = deriveSurfaceMap(app);
-  const previous = await readAgainstSurfaceMap(rootDir, against);
+  const currentMap = deriveTopoGraph(app);
+  const previous = await readAgainstTopoGraph(rootDir, against);
   if (previous.isErr()) {
     return previous;
   }
 
-  const diff = deriveSurfaceMapDiff(previous.value.map, currentMap);
+  const diff = deriveTopoGraphDiff(previous.value.map, currentMap);
   return Result.ok(
     breakingOnly
       ? formatDiff({ ...diff, info: [], warnings: [] }, previous.value.against)

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -16,11 +16,11 @@ import {
 } from '@ontrails/core';
 import type {
   SurfaceLock,
-  SurfaceMap,
+  TopoGraph,
   TopoSnapshot,
 } from '@ontrails/topographer';
 import type { StoredTopoExport } from '@ontrails/topographer/backend-support';
-import { writeSurfaceLock, writeSurfaceMap } from '@ontrails/topographer';
+import { writeSurfaceLock, writeTopoGraph } from '@ontrails/topographer';
 import {
   createStoredTopoSnapshot,
   getStoredTopoExport,
@@ -87,8 +87,8 @@ const writeStoredExportArtifacts = async (
   storedExport: StoredTopoExport,
   trailsDir: string
 ): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'mapPath'>> => {
-  const mapPath = await writeSurfaceMap(
-    JSON.parse(storedExport.surfaceMapJson) as SurfaceMap,
+  const mapPath = await writeTopoGraph(
+    JSON.parse(storedExport.surfaceMapJson) as TopoGraph,
     { dir: trailsDir }
   );
   const lockPath = await writeSurfaceLock(

--- a/packages/topographer/README.md
+++ b/packages/topographer/README.md
@@ -1,16 +1,16 @@
 # @ontrails/topographer
 
-Durable graph substrate for Trails: deterministic surface maps, lockfile helpers, and semantic diffing.
+Durable graph substrate for Trails: deterministic TopoGraphs, lockfile helpers, and semantic diffing.
 
 Most applications reach this package through `trails topo compile` and `trails topo verify`. Those CLI trails layer workspace and topo-store behavior on top of the building blocks in `@ontrails/topographer`.
 
 ## What it owns
 
-- deterministic surface-map generation from an established topo
-- structured example and field-override provenance projection for surface-map entries
+- deterministic TopoGraph generation from an established topo
+- structured example and field-override provenance projection for TopoGraph entries
 - stable hashing for CI drift detection
-- semantic diffing between two surface maps
-- file I/O helpers for `.trails/_surface.json` and `.trails/trails.lock`
+- semantic diffing between two TopoGraphs
+- file I/O helpers for the current graph artifact and `.trails/trails.lock`
 - the topo-store: queryable persistence of the resolved topo graph in `trails.db`, including snapshots, pinning, history, and read-only query accessors (relocated from `@ontrails/core` per ADR-0042)
 
 `@ontrails/topographer` is the durable graph substrate for Trails. Generic `trails-db` plumbing (read/write SQLite handles, subsystem schema management, derived paths) stays in `@ontrails/core` so other subsystems (tracing, signals) can share it without depending on topographer.
@@ -19,35 +19,35 @@ Most applications reach this package through `trails topo compile` and `trails t
 
 ```typescript
 import {
-  deriveSurfaceMap,
-  deriveSurfaceMapDiff,
-  deriveSurfaceMapHash,
+  deriveTopoGraph,
+  deriveTopoGraphDiff,
+  deriveTopoGraphHash,
   writeSurfaceLock,
-  writeSurfaceMap,
+  writeTopoGraph,
 } from '@ontrails/topographer';
 
-const map = deriveSurfaceMap(graph);
-const hash = deriveSurfaceMapHash(map);
+const topoGraph = deriveTopoGraph(graph);
+const hash = deriveTopoGraphHash(topoGraph);
 
-await writeSurfaceMap(map);
+await writeTopoGraph(topoGraph);
 await writeSurfaceLock({ hash });
 
 // Later, after changes:
-const nextMap = deriveSurfaceMap(graph);
-const diff = deriveSurfaceMapDiff(map, nextMap);
+const nextTopoGraph = deriveTopoGraph(graph);
+const diff = deriveTopoGraphDiff(topoGraph, nextTopoGraph);
 
 if (diff.hasBreaking) {
   console.error('Breaking changes:', diff.breaking);
 }
 ```
 
-`deriveSurfaceMap()` rejects draft-contaminated topos. Only established state can be serialized into the committed artifacts.
+`deriveTopoGraph()` rejects draft-contaminated topos. Only established state can be serialized into the committed artifacts.
 
 ## File outputs
 
 The typical exported artifact pair is:
 
-- `.trails/_surface.json` — detailed derived map, useful for inspection and diffing
+- `.trails/_surface.json` — current detailed derived graph artifact, useful for inspection and diffing
 - `.trails/trails.lock` — committed lock artifact, stored as structured JSON or legacy hash-only text
 
 `trails topo compile` writes both from the current topo. `trails topo verify` and `@ontrails/warden` use the lockfile helpers here to detect drift.
@@ -56,11 +56,11 @@ The typical exported artifact pair is:
 
 | Export | What it does |
 | --- | --- |
-| `deriveSurfaceMap(topo)` | Deterministic surface map of every established trail, signal, and resource |
-| `deriveSurfaceMapHash(map)` | Stable SHA-256 hash of the map |
-| `deriveSurfaceMapDiff(prev, curr)` | Semantic diff with `breaking`, `warning`, and `info` classifications |
-| `writeSurfaceMap(map, options?)` | Write `.trails/_surface.json` |
-| `readSurfaceMap(options?)` | Read `.trails/_surface.json` |
+| `deriveTopoGraph(topo)` | Deterministic TopoGraph of every established trail, signal, resource, and contour |
+| `deriveTopoGraphHash(topoGraph)` | Stable SHA-256 hash of the TopoGraph |
+| `deriveTopoGraphDiff(prev, curr)` | Semantic diff with `breaking`, `warning`, and `info` classifications |
+| `writeTopoGraph(topoGraph, options?)` | Write the current graph artifact |
+| `readTopoGraph(options?)` | Read the current graph artifact |
 | `writeSurfaceLock(lock, options?)` | Write `.trails/trails.lock` as either structured JSON or legacy hash text |
 | `readSurfaceLockData(options?)` | Read the full normalized lock payload from `.trails/trails.lock` |
 | `readSurfaceLock(options?)` | Read just the committed lock hash |
@@ -117,9 +117,9 @@ Because CLI paths are now full hierarchical command paths, command-tree changes 
 ## Drift detection with warden
 
 ```typescript
-import { deriveSurfaceMap, deriveSurfaceMapHash, readSurfaceLock } from '@ontrails/topographer';
+import { deriveTopoGraph, deriveTopoGraphHash, readSurfaceLock } from '@ontrails/topographer';
 
-const current = deriveSurfaceMapHash(deriveSurfaceMap(graph));
+const current = deriveTopoGraphHash(deriveTopoGraph(graph));
 const committed = await readSurfaceLock();
 
 if (committed !== current) {

--- a/packages/topographer/package.json
+++ b/packages/topographer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ontrails/topographer",
   "version": "1.0.0-beta.15",
-  "description": "Durable graph substrate for Trails: deterministic surface maps, lockfile helpers, and semantic diffing.",
+  "description": "Durable graph substrate for Trails: deterministic TopoGraphs, lockfile helpers, and semantic diffing.",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -15,7 +15,7 @@ import {
 import type { Layer, Topo, TopoIssue } from '@ontrails/core';
 import { z } from 'zod';
 
-import { deriveSurfaceMap } from '../derive.js';
+import { deriveTopoGraph } from '../derive.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -54,11 +54,11 @@ const gistContour = contour(
   { identity: 'id' }
 );
 
-const getFirstEntry = (map: ReturnType<typeof deriveSurfaceMap>) => {
+const getFirstEntry = (map: ReturnType<typeof deriveTopoGraph>) => {
   const [entry] = map.entries;
   expect(entry).toBeDefined();
   if (!entry) {
-    throw new Error('Expected surface map entry');
+    throw new Error('Expected topo graph entry');
   }
   return entry;
 };
@@ -75,9 +75,9 @@ const expectSchemaProperties = (
   );
 };
 
-const expectSurfaceMapTopoIssue = (tp: Topo, rule: string) => {
+const expectTopoGraphTopoIssue = (tp: Topo, rule: string) => {
   try {
-    deriveSurfaceMap(tp);
+    deriveTopoGraph(tp);
   } catch (error) {
     expect(error).toBeInstanceOf(ValidationError);
     const issues = (error as ValidationError).context?.['issues'] as
@@ -87,14 +87,14 @@ const expectSurfaceMapTopoIssue = (tp: Topo, rule: string) => {
     return;
   }
 
-  throw new Error(`Expected deriveSurfaceMap to reject with ${rule}`);
+  throw new Error(`Expected deriveTopoGraph to reject with ${rule}`);
 };
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('deriveSurfaceMap', () => {
+describe('deriveTopoGraph', () => {
   describe('entries', () => {
     test('produces entries for all trails in the topo', () => {
       const a = trail('a.create', {
@@ -106,7 +106,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
       });
       const tp = topoFrom({ a, b });
-      const map = deriveSurfaceMap(tp);
+      const map = deriveTopoGraph(tp);
 
       expect(map.entries).toHaveLength(2);
       expect(map.entries.map((e) => e.id)).toEqual(['a.create', 'b.list']);
@@ -126,7 +126,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
       });
       const tp = topoFrom({ a2, m2, z2 });
-      const map = deriveSurfaceMap(tp);
+      const map = deriveTopoGraph(tp);
 
       expect(map.entries.map((e) => e.id)).toEqual([
         'a.trail',
@@ -142,7 +142,7 @@ describe('deriveSurfaceMap', () => {
         output: z.object({ id: z.string(), name: z.string() }),
         resources: [dbResource],
       });
-      const map = deriveSurfaceMap(topoFrom({ dbResource, t }));
+      const map = deriveTopoGraph(topoFrom({ dbResource, t }));
       const entry = map.entries.find(
         (candidate) => candidate.id === 'entity.create'
       );
@@ -176,7 +176,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
         layers: [trailLayer],
       });
-      const map = deriveSurfaceMap(
+      const map = deriveTopoGraph(
         topo('layered-app', { t }, { layers: [topoLayer] })
       );
       const entry = map.entries.find(
@@ -213,7 +213,7 @@ describe('deriveSurfaceMap', () => {
         contours: [gistContour, userContour],
         input: z.object({}),
       });
-      const entry = deriveSurfaceMap(topoFrom({ t })).entries.find(
+      const entry = deriveTopoGraph(topoFrom({ t })).entries.find(
         (candidate) => candidate.id === 'gist.create'
       );
 
@@ -226,7 +226,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({ msg: z.string() }),
       });
       const tp = topoFrom({ t });
-      const map = deriveSurfaceMap(tp);
+      const map = deriveTopoGraph(tp);
 
       expect(map.entries[0]?.output).toBeUndefined();
     });
@@ -242,7 +242,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({ id: z.string(), name: z.string() }),
       });
       const tp = topoFrom({ base, r });
-      const map = deriveSurfaceMap(tp);
+      const map = deriveTopoGraph(tp);
       const crossesEntry = map.entries.find((e) => e.id === 'user.update');
       expect(crossesEntry).toBeDefined();
 
@@ -262,7 +262,7 @@ describe('deriveSurfaceMap', () => {
         blaze: noop,
         input: z.object({}),
       });
-      const entry = deriveSurfaceMap(topoFrom({ createUser, e })).entries.find(
+      const entry = deriveTopoGraph(topoFrom({ createUser, e })).entries.find(
         (candidate) => candidate.id === 'user.created'
       );
 
@@ -300,7 +300,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
         on: [created],
       });
-      const entry = deriveSurfaceMap(
+      const entry = deriveTopoGraph(
         topoFrom({ consumer, created, producer })
       ).entries.find((candidate) => candidate.id === 'user.created');
 
@@ -354,7 +354,7 @@ describe('deriveSurfaceMap', () => {
         on: [nightly],
       });
 
-      const map = deriveSurfaceMap(
+      const map = deriveTopoGraph(
         topoFrom({ consumer, created, producer, scheduled })
       );
       const consumerEntry = map.entries.find(
@@ -430,7 +430,7 @@ describe('deriveSurfaceMap', () => {
         on: [webhookSource],
       });
 
-      const map = deriveSurfaceMap(topoFrom({ receiver }));
+      const map = deriveTopoGraph(topoFrom({ receiver }));
       const source = map.activationSources['webhook:webhook.user.upsert'];
 
       expect(source).toMatchObject({
@@ -455,7 +455,7 @@ describe('deriveSurfaceMap', () => {
     });
 
     test('resource entries are included with description and healthcheck metadata', () => {
-      const map = deriveSurfaceMap(topoFrom({ dbResource }));
+      const map = deriveTopoGraph(topoFrom({ dbResource }));
       const entry = getFirstEntry(map);
 
       expect(entry.kind).toBe('resource');
@@ -466,7 +466,7 @@ describe('deriveSurfaceMap', () => {
     });
 
     test('contour entries are included with schema and references', () => {
-      const entry = deriveSurfaceMap(
+      const entry = deriveTopoGraph(
         topoFrom({ gistContour, userContour })
       ).entries.find((candidate) => candidate.id === 'gist');
 
@@ -497,7 +497,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
         intent: 'read',
       });
-      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ t })));
+      const entry = getFirstEntry(deriveTopoGraph(topoFrom({ t })));
 
       expect(entry.intent).toBe('read');
       expect(entry.idempotent).toBe(true);
@@ -515,7 +515,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
         permit: 'public',
       });
-      const { entries } = deriveSurfaceMap(topoFrom({ publicTrail, scoped }));
+      const { entries } = deriveTopoGraph(topoFrom({ publicTrail, scoped }));
 
       expect(
         entries.find((entry) => entry.id === 'secure.write')?.permit
@@ -537,7 +537,7 @@ describe('deriveSurfaceMap', () => {
         output: z.object({ y: z.number() }),
       });
       const tp = topoFrom({ t });
-      const map = deriveSurfaceMap(tp);
+      const map = deriveTopoGraph(tp);
 
       expect(map.entries[0]?.exampleCount).toBe(3);
     });
@@ -570,7 +570,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({ x: z.number() }),
         output: z.object({ y: z.number() }),
       });
-      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ t })));
+      const entry = getFirstEntry(deriveTopoGraph(topoFrom({ t })));
 
       expect(entry.examples).toEqual([
         {
@@ -608,7 +608,7 @@ describe('deriveSurfaceMap', () => {
         ],
         input: z.any(),
       });
-      const map = deriveSurfaceMap(topoFrom({ t }));
+      const map = deriveTopoGraph(topoFrom({ t }));
       const entry = getFirstEntry(map);
 
       expect(entry.exampleCount).toBe(1);
@@ -633,7 +633,7 @@ describe('deriveSurfaceMap', () => {
           status: z.enum(['active', 'inactive']),
         }),
       });
-      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ t })));
+      const entry = getFirstEntry(deriveTopoGraph(topoFrom({ t })));
 
       expect(entry.fieldOverrides).toEqual([
         {
@@ -662,7 +662,7 @@ describe('deriveSurfaceMap', () => {
         ],
         input: z.object({}),
       });
-      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ t })));
+      const entry = getFirstEntry(deriveTopoGraph(topoFrom({ t })));
 
       expect(entry.detours).toEqual([
         { maxAttempts: DETOUR_MAX_ATTEMPTS_CAP, on: 'ConflictError' },
@@ -682,7 +682,7 @@ describe('deriveSurfaceMap', () => {
         ],
         input: z.object({}),
       });
-      const entry = getFirstEntry(deriveSurfaceMap(topoFrom({ t })));
+      const entry = getFirstEntry(deriveTopoGraph(topoFrom({ t })));
 
       expect(entry.detours).toEqual([{ maxAttempts: 2, on: 'ConflictError' }]);
     });
@@ -694,7 +694,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
       });
       const tp = topoFrom({ t });
-      const map = deriveSurfaceMap(tp);
+      const map = deriveTopoGraph(tp);
 
       expect(map.entries[0]?.description).toBe('A described trail');
     });
@@ -711,8 +711,8 @@ describe('deriveSurfaceMap', () => {
       });
       const tp = topoFrom({ t });
 
-      const map1 = deriveSurfaceMap(tp);
-      const map2 = deriveSurfaceMap(tp);
+      const map1 = deriveTopoGraph(tp);
+      const map2 = deriveTopoGraph(tp);
 
       expect(map1.entries).toEqual(map2.entries);
       expect(map1.version).toBe(map2.version);
@@ -724,7 +724,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
       });
       const tp = topoFrom({ t });
-      const map = deriveSurfaceMap(tp);
+      const map = deriveTopoGraph(tp);
 
       expect(map.version).toBe('1.0');
     });
@@ -735,7 +735,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
       });
       const tp = topoFrom({ t });
-      const map = deriveSurfaceMap(tp);
+      const map = deriveTopoGraph(tp);
 
       expect(new Date(map.generatedAt).toISOString()).toBe(map.generatedAt);
     });
@@ -749,7 +749,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
       });
 
-      expect(() => deriveSurfaceMap(topoFrom({ exportTrail }))).toThrowError(
+      expect(() => deriveTopoGraph(topoFrom({ exportTrail }))).toThrowError(
         /draft/i
       );
     });
@@ -761,7 +761,7 @@ describe('deriveSurfaceMap', () => {
         input: z.object({}),
       });
 
-      expectSurfaceMapTopoIssue(topoFrom({ producer }), 'signal-fire-exists');
+      expectTopoGraphTopoIssue(topoFrom({ producer }), 'signal-fire-exists');
     });
 
     test('rejects consumer references to missing signals', () => {
@@ -771,7 +771,7 @@ describe('deriveSurfaceMap', () => {
         on: ['entity.missing'],
       });
 
-      expectSurfaceMapTopoIssue(topoFrom({ consumer }), 'signal-on-exists');
+      expectTopoGraphTopoIssue(topoFrom({ consumer }), 'signal-on-exists');
     });
   });
 });

--- a/packages/topographer/src/__tests__/diff.test.ts
+++ b/packages/topographer/src/__tests__/diff.test.ts
@@ -1,22 +1,22 @@
 import { describe, test, expect } from 'bun:test';
 
-import { deriveSurfaceMapDiff } from '../diff.js';
-import type { SurfaceMap, SurfaceMapEntry } from '../types.js';
+import { deriveTopoGraphDiff } from '../diff.js';
+import type { TopoGraph, TopoGraphEntry } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 const entry = (
-  overrides: Partial<SurfaceMapEntry> & { id: string }
-): SurfaceMapEntry => ({
+  overrides: Partial<TopoGraphEntry> & { id: string }
+): TopoGraphEntry => ({
   exampleCount: 0,
   kind: 'trail',
   surfaces: [],
   ...overrides,
 });
 
-const surfaceMap = (entries: SurfaceMapEntry[]): SurfaceMap => ({
+const topoGraph = (entries: TopoGraphEntry[]): TopoGraph => ({
   activationGraph: {
     edgeCount: 0,
     edges: [],
@@ -34,20 +34,20 @@ const surfaceMap = (entries: SurfaceMapEntry[]): SurfaceMap => ({
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('deriveSurfaceMapDiff', () => {
+describe('deriveTopoGraphDiff', () => {
   describe('top-level changes', () => {
     test('empty diff for identical maps', () => {
       const e = entry({ id: 'user.create' });
-      const result = deriveSurfaceMapDiff(surfaceMap([e]), surfaceMap([e]));
+      const result = deriveTopoGraphDiff(topoGraph([e]), topoGraph([e]));
 
       expect(result.entries).toHaveLength(0);
       expect(result.hasBreaking).toBe(false);
     });
 
     test('added trail detected as info', () => {
-      const prev = surfaceMap([]);
-      const curr = surfaceMap([entry({ id: 'user.create' })]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const prev = topoGraph([]);
+      const curr = topoGraph([entry({ id: 'user.create' })]);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.entries).toHaveLength(1);
       expect(result.entries[0]?.change).toBe('added');
@@ -56,27 +56,27 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('added resource detected as info', () => {
-      const prev = surfaceMap([]);
-      const curr = surfaceMap([entry({ id: 'db.main', kind: 'resource' })]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const prev = topoGraph([]);
+      const curr = topoGraph([entry({ id: 'db.main', kind: 'resource' })]);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.entries[0]?.details).toContain('Resource "db.main" added');
       expect(result.info).toHaveLength(1);
     });
 
     test('added contour detected as info', () => {
-      const prev = surfaceMap([]);
-      const curr = surfaceMap([entry({ id: 'user', kind: 'contour' })]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const prev = topoGraph([]);
+      const curr = topoGraph([entry({ id: 'user', kind: 'contour' })]);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.entries[0]?.details).toContain('Contour "user" added');
       expect(result.info).toHaveLength(1);
     });
 
     test('removed trail detected as breaking', () => {
-      const prev = surfaceMap([entry({ id: 'user.delete' })]);
-      const curr = surfaceMap([]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const prev = topoGraph([entry({ id: 'user.delete' })]);
+      const curr = topoGraph([]);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.entries).toHaveLength(1);
       expect(result.entries[0]?.change).toBe('removed');
@@ -85,9 +85,9 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('removed resource detected as breaking', () => {
-      const prev = surfaceMap([entry({ id: 'db.main', kind: 'resource' })]);
-      const curr = surfaceMap([]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const prev = topoGraph([entry({ id: 'db.main', kind: 'resource' })]);
+      const curr = topoGraph([]);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.entries[0]?.details).toContain(
         'Resource "db.main" removed'
@@ -96,9 +96,9 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('DiffResult.hasBreaking is true when any breaking entries exist', () => {
-      const prev = surfaceMap([entry({ id: 'user.delete' })]);
-      const curr = surfaceMap([]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const prev = topoGraph([entry({ id: 'user.delete' })]);
+      const curr = topoGraph([]);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(result.breaking.length).toBeGreaterThan(0);
@@ -107,7 +107,7 @@ describe('deriveSurfaceMapDiff', () => {
 
   describe('schema changes', () => {
     test('required input field added classified as breaking', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({
           id: 'user.create',
           input: {
@@ -117,7 +117,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({
           id: 'user.create',
           input: {
@@ -130,7 +130,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(result.breaking).toHaveLength(1);
@@ -144,7 +144,7 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('optional input field added classified as info', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({
           id: 'user.create',
           input: {
@@ -154,7 +154,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({
           id: 'user.create',
           input: {
@@ -167,7 +167,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.info).toHaveLength(1);
       const [infoEntry] = result.info;
@@ -180,7 +180,7 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('output field removed classified as breaking', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({
           id: 'user.get',
           output: {
@@ -192,7 +192,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({
           id: 'user.get',
           output: {
@@ -203,7 +203,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(
@@ -214,7 +214,7 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('output field type changed classified as breaking', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({
           id: 'user.get',
           output: {
@@ -223,7 +223,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({
           id: 'user.get',
           output: {
@@ -232,7 +232,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(
@@ -245,11 +245,11 @@ describe('deriveSurfaceMapDiff', () => {
 
   describe('meta and surfaces', () => {
     test('surface removed classified as breaking', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({ id: 'user.list', surfaces: ['cli', 'mcp'] }),
       ]);
-      const curr = surfaceMap([entry({ id: 'user.list', surfaces: ['mcp'] })]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const curr = topoGraph([entry({ id: 'user.list', surfaces: ['mcp'] })]);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(
@@ -260,13 +260,13 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('CLI path change is classified as breaking', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({ cli: { path: ['topo', 'pin'] }, id: 'topo.pin' }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({ cli: { path: ['topo', 'save'] }, id: 'topo.pin' }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(
@@ -277,12 +277,12 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('safety marker changes partition by severity', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({ id: 'data.wipe', intent: 'read' }),
         entry({ id: 'data.preview' }),
         entry({ id: 'data.secure', permit: 'public' }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({ id: 'data.wipe', intent: 'destroy' }),
         entry({ dryRunCapable: true, id: 'data.preview' }),
         entry({
@@ -290,7 +290,7 @@ describe('deriveSurfaceMapDiff', () => {
           permit: { scopes: ['data:write'] },
         }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(2);
       expect(result.breaking).toHaveLength(1);
@@ -314,19 +314,19 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('adding permit scopes is classified as breaking', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({
           id: 'data.secure',
           permit: { scopes: ['data:read'] },
         }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({
           id: 'data.secure',
           permit: { scopes: ['data:read', 'data:write'] },
         }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.hasBreaking).toBe(true);
       expect(result.breaking[0]?.details).toContain(
@@ -335,32 +335,32 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('permit scope order does not produce a warning', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({
           id: 'data.secure',
           permit: { scopes: ['data:write', 'data:read'] },
         }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({
           id: 'data.secure',
           permit: { scopes: ['data:read', 'data:write'] },
         }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(0);
       expect(result.hasBreaking).toBe(false);
     });
 
     test('description change classified as info', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({ description: 'Get a user', id: 'user.get' }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({ description: 'Fetch a user by ID', id: 'user.get' }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.info).toHaveLength(1);
       expect(
@@ -369,15 +369,15 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('deprecation added classified as warning', () => {
-      const prev = surfaceMap([entry({ id: 'entity.list' })]);
-      const curr = surfaceMap([
+      const prev = topoGraph([entry({ id: 'entity.list' })]);
+      const curr = topoGraph([
         entry({
           deprecated: true,
           id: 'entity.list',
           replacedBy: 'entity.show',
         }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(1);
       expect(
@@ -388,21 +388,21 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('crosses changed produces warning', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({
           crosses: ['user.get', 'user.lookup'],
           id: 'user.update',
           kind: 'trail',
         }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({
           crosses: ['user.get', 'user.search'],
           id: 'user.update',
           kind: 'trail',
         }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(1);
       const crossesDetail = result.warnings[0]?.details.find((d) =>
@@ -414,19 +414,19 @@ describe('deriveSurfaceMapDiff', () => {
     });
 
     test('declared resources changed produces warning', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({
           id: 'user.update',
           resources: ['db.main', 'search.index'],
         }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({
           id: 'user.update',
           resources: ['db.main', 'cache.main'],
         }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.warnings).toHaveLength(1);
       const resourceDetail = result.warnings[0]?.details.find((detail) =>
@@ -440,7 +440,7 @@ describe('deriveSurfaceMapDiff', () => {
 
   describe('severity partitioning', () => {
     test('DiffResult partitions correctly into breaking, warnings, info', () => {
-      const prev = surfaceMap([
+      const prev = topoGraph([
         entry({
           description: 'old',
           id: 'a.trail',
@@ -451,7 +451,7 @@ describe('deriveSurfaceMapDiff', () => {
           },
         }),
       ]);
-      const curr = surfaceMap([
+      const curr = topoGraph([
         entry({
           description: 'new',
           id: 'a.trail',
@@ -463,7 +463,7 @@ describe('deriveSurfaceMapDiff', () => {
         }),
         entry({ id: 'b.trail' }),
       ]);
-      const result = deriveSurfaceMapDiff(prev, curr);
+      const result = deriveTopoGraphDiff(prev, curr);
 
       expect(result.entries.length).toBeGreaterThanOrEqual(2);
 

--- a/packages/topographer/src/__tests__/hash.test.ts
+++ b/packages/topographer/src/__tests__/hash.test.ts
@@ -1,13 +1,13 @@
 import { describe, test, expect } from 'bun:test';
 
-import { deriveSurfaceMapHash } from '../hash.js';
-import type { SurfaceMap } from '../types.js';
+import { deriveTopoGraphHash } from '../hash.js';
+import type { TopoGraph } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const makeSurfaceMap = (overrides?: Partial<SurfaceMap>): SurfaceMap => ({
+const makeTopoGraph = (overrides?: Partial<TopoGraph>): TopoGraph => ({
   activationGraph: {
     edgeCount: 0,
     edges: [],
@@ -43,22 +43,22 @@ const makeSurfaceMap = (overrides?: Partial<SurfaceMap>): SurfaceMap => ({
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('deriveSurfaceMapHash', () => {
+describe('deriveTopoGraphHash', () => {
   test('produces a valid SHA-256 hex string (64 characters)', () => {
-    const hash = deriveSurfaceMapHash(makeSurfaceMap());
+    const hash = deriveTopoGraphHash(makeTopoGraph());
     expect(hash).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  test('same surface map produces the same hash (deterministic)', () => {
-    const map = makeSurfaceMap();
-    const hash1 = deriveSurfaceMapHash(map);
-    const hash2 = deriveSurfaceMapHash(map);
+  test('same topo graph produces the same hash (deterministic)', () => {
+    const map = makeTopoGraph();
+    const hash1 = deriveTopoGraphHash(map);
+    const hash2 = deriveTopoGraphHash(map);
     expect(hash1).toBe(hash2);
   });
 
-  test('different surface maps produce different hashes', () => {
-    const map1 = makeSurfaceMap();
-    const map2 = makeSurfaceMap({
+  test('different topo graphs produce different hashes', () => {
+    const map1 = makeTopoGraph();
+    const map2 = makeTopoGraph({
       entries: [
         {
           exampleCount: 0,
@@ -70,26 +70,26 @@ describe('deriveSurfaceMapHash', () => {
       ],
     });
 
-    expect(deriveSurfaceMapHash(map1)).not.toBe(deriveSurfaceMapHash(map2));
+    expect(deriveTopoGraphHash(map1)).not.toBe(deriveTopoGraphHash(map2));
   });
 
   test('generatedAt does not affect the hash', () => {
-    const map1 = makeSurfaceMap({ generatedAt: '2025-01-01T00:00:00.000Z' });
-    const map2 = makeSurfaceMap({ generatedAt: '2099-12-31T23:59:59.999Z' });
+    const map1 = makeTopoGraph({ generatedAt: '2025-01-01T00:00:00.000Z' });
+    const map2 = makeTopoGraph({ generatedAt: '2099-12-31T23:59:59.999Z' });
 
-    expect(deriveSurfaceMapHash(map1)).toBe(deriveSurfaceMapHash(map2));
+    expect(deriveTopoGraphHash(map1)).toBe(deriveTopoGraphHash(map2));
   });
 
   test('hash is stable across invocations', () => {
-    const map = makeSurfaceMap();
-    const hashes = Array.from({ length: 10 }, () => deriveSurfaceMapHash(map));
+    const map = makeTopoGraph();
+    const hashes = Array.from({ length: 10 }, () => deriveTopoGraphHash(map));
     const unique = new Set(hashes);
     expect(unique.size).toBe(1);
   });
 
   test('key order in entry does not affect hash', () => {
     // Build two maps with same data but different insertion order
-    const map1 = makeSurfaceMap({
+    const map1 = makeTopoGraph({
       entries: [
         {
           exampleCount: 0,
@@ -103,7 +103,7 @@ describe('deriveSurfaceMapHash', () => {
         },
       ],
     });
-    const map2 = makeSurfaceMap({
+    const map2 = makeTopoGraph({
       entries: [
         {
           exampleCount: 0,
@@ -118,6 +118,6 @@ describe('deriveSurfaceMapHash', () => {
       ],
     });
 
-    expect(deriveSurfaceMapHash(map1)).toBe(deriveSurfaceMapHash(map2));
+    expect(deriveTopoGraphHash(map1)).toBe(deriveTopoGraphHash(map2));
   });
 });

--- a/packages/topographer/src/__tests__/io.test.ts
+++ b/packages/topographer/src/__tests__/io.test.ts
@@ -4,21 +4,21 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
-  writeSurfaceMap,
-  readSurfaceMap,
+  writeTopoGraph,
+  readTopoGraph,
   writeSurfaceLock,
   readSurfaceLockData,
   readSurfaceLock,
   readWorkspaceLock,
 } from '../io.js';
 import { surfaceLockSchema } from '../types.js';
-import type { SurfaceMap } from '../types.js';
+import type { TopoGraph } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const makeSurfaceMap = (): SurfaceMap => ({
+const makeTopoGraph = (): TopoGraph => ({
   activationGraph: {
     edgeCount: 0,
     edges: [],
@@ -69,10 +69,10 @@ afterEach(async () => {
 // Surface map tests
 // ---------------------------------------------------------------------------
 
-describe('writeSurfaceMap / readSurfaceMap', () => {
+describe('writeTopoGraph / readTopoGraph', () => {
   test('writes valid JSON to _surface.json', async () => {
-    const map = makeSurfaceMap();
-    const filePath = await writeSurfaceMap(map, { dir: tempDir });
+    const map = makeTopoGraph();
+    const filePath = await writeTopoGraph(map, { dir: tempDir });
 
     expect(filePath).toBe(join(tempDir, '_surface.json'));
 
@@ -83,15 +83,15 @@ describe('writeSurfaceMap / readSurfaceMap', () => {
   });
 
   test('reads it back and produces identical data', async () => {
-    const map = makeSurfaceMap();
-    await writeSurfaceMap(map, { dir: tempDir });
-    const result = await readSurfaceMap({ dir: tempDir });
+    const map = makeTopoGraph();
+    await writeTopoGraph(map, { dir: tempDir });
+    const result = await readTopoGraph({ dir: tempDir });
 
     expect(result).toEqual(map);
   });
 
   test('returns null for missing file', async () => {
-    const result = await readSurfaceMap({
+    const result = await readTopoGraph({
       dir: join(tempDir, 'nonexistent'),
     });
     expect(result).toBeNull();
@@ -165,13 +165,13 @@ describe('default directory', () => {
   test('defaults to .trails/', async () => {
     // We can't easily test the actual default without polluting the repo,
     // so we verify the custom directory option works and trust the default
-    const map = makeSurfaceMap();
+    const map = makeTopoGraph();
     const customDir = join(tempDir, 'custom-trails');
-    const filePath = await writeSurfaceMap(map, { dir: customDir });
+    const filePath = await writeTopoGraph(map, { dir: customDir });
 
     expect(filePath).toBe(join(customDir, '_surface.json'));
 
-    const result = await readSurfaceMap({ dir: customDir });
+    const result = await readTopoGraph({ dir: customDir });
     expect(result).toEqual(map);
   });
 

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -1,5 +1,5 @@
 /**
- * Derive a deterministic surface map from a Topo.
+ * Derive a deterministic topo graph from a Topo.
  */
 
 import {
@@ -27,13 +27,13 @@ import type {
 import { addPermitRequirement } from './permit.js';
 import type {
   JsonSchema,
-  SurfaceMap,
-  SurfaceMapActivationEdge,
-  SurfaceMapActivationGraph,
-  SurfaceMapActivationSource,
-  SurfaceMapEntry,
-  SurfaceMapFieldOverride,
-  SurfaceMapFieldOverrideKey,
+  TopoGraph,
+  TopoGraphActivationEdge,
+  TopoGraphActivationGraph,
+  TopoGraphActivationSource,
+  TopoGraphEntry,
+  TopoGraphFieldOverride,
+  TopoGraphFieldOverrideKey,
 } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -169,7 +169,7 @@ const activationParseOutputSchema = (
 
 const projectActivationSource = (
   source: ActivationSource
-): SurfaceMapActivationSource => {
+): TopoGraphActivationSource => {
   const record: Record<string, unknown> = {
     id: source.id,
     key: activationSourceKey(source),
@@ -206,13 +206,13 @@ const projectActivationSource = (
     record['timezone'] = source.timezone;
   }
 
-  return sortKeys(record) as SurfaceMapActivationSource;
+  return sortKeys(record) as TopoGraphActivationSource;
 };
 
 const projectActivationEdge = (
   trailId: string,
   activation: ActivationEntry
-): SurfaceMapActivationEdge => {
+): TopoGraphActivationEdge => {
   const sourceKey = activationSourceKey(activation.source);
   const edge: Record<string, unknown> = {
     hasWhere: activation.where !== undefined,
@@ -229,13 +229,13 @@ const projectActivationEdge = (
     edge['where'] = { predicate: true };
   }
 
-  return sortKeys(edge) as SurfaceMapActivationEdge;
+  return sortKeys(edge) as TopoGraphActivationEdge;
 };
 
 const collectActivationSourceCatalog = (
   topo: Topo
-): readonly SurfaceMapActivationSource[] => {
-  const sources = new Map<string, SurfaceMapActivationSource>();
+): readonly TopoGraphActivationSource[] => {
+  const sources = new Map<string, TopoGraphActivationSource>();
   for (const trail of topo.trails.values()) {
     for (const activation of trail.activationSources) {
       const projected = projectActivationSource(activation.source);
@@ -247,8 +247,8 @@ const collectActivationSourceCatalog = (
 
 const collectActivationGraphEdges = (
   topo: Topo
-): readonly SurfaceMapActivationEdge[] => {
-  const edges = new Map<string, SurfaceMapActivationEdge>();
+): readonly TopoGraphActivationEdge[] => {
+  const edges = new Map<string, TopoGraphActivationEdge>();
   for (const trail of topo.trails.values()) {
     for (const activation of trail.activationSources) {
       const edge = projectActivationEdge(trail.id, activation);
@@ -271,16 +271,16 @@ const collectActivationGraphEdges = (
 };
 
 const buildActivationGraph = (
-  edges: readonly SurfaceMapActivationEdge[],
-  sources: readonly SurfaceMapActivationSource[]
-): SurfaceMapActivationGraph =>
+  edges: readonly TopoGraphActivationEdge[],
+  sources: readonly TopoGraphActivationSource[]
+): TopoGraphActivationGraph =>
   sortKeys({
     edgeCount: edges.length,
     edges,
     sourceCount: sources.length,
     sourceKeys: sources.map((source) => source.key),
     trailIds: [...new Set(edges.map((edge) => edge.trailId))].toSorted(),
-  }) as SurfaceMapActivationGraph;
+  }) as TopoGraphActivationGraph;
 
 const collectSignalGraphRelations = (
   topo: Topo
@@ -465,7 +465,7 @@ const addLayerAttachments = (
   }
 };
 
-const FIELD_OVERRIDE_KEYS: readonly SurfaceMapFieldOverrideKey[] = [
+const FIELD_OVERRIDE_KEYS: readonly TopoGraphFieldOverrideKey[] = [
   'hint',
   'label',
   'message',
@@ -474,12 +474,12 @@ const FIELD_OVERRIDE_KEYS: readonly SurfaceMapFieldOverrideKey[] = [
 
 const collectFieldOverrideKeys = (
   override: FieldOverride
-): readonly SurfaceMapFieldOverrideKey[] =>
+): readonly TopoGraphFieldOverrideKey[] =>
   FIELD_OVERRIDE_KEYS.filter((key) => override[key] !== undefined);
 
 const deriveFieldOverrides = (
   fields: Readonly<Record<string, FieldOverride>> | undefined
-): readonly SurfaceMapFieldOverride[] | undefined => {
+): readonly TopoGraphFieldOverride[] | undefined => {
   if (fields === undefined) {
     return undefined;
   }
@@ -526,7 +526,7 @@ const addExamples = (
 const trailToEntry = (
   t: Trail<unknown, unknown, unknown>,
   topoLayers: readonly Layer[]
-): SurfaceMapEntry => {
+): TopoGraphEntry => {
   const raw = t as unknown as Record<string, unknown>;
   const surfaces = extractSurfaces(raw);
   const entry: Record<string, unknown> = {
@@ -545,7 +545,7 @@ const trailToEntry = (
   addFieldOverrides(entry, t);
   addExamples(entry, t);
 
-  return sortKeys(entry) as unknown as SurfaceMapEntry;
+  return sortKeys(entry) as unknown as TopoGraphEntry;
 };
 
 /** Add optional signal-specific fields. */
@@ -588,7 +588,7 @@ const addSignalFields = (
 const signalToEntry = (
   e: Signal<unknown>,
   relations: SignalGraphRelations
-): SurfaceMapEntry => {
+): TopoGraphEntry => {
   const raw = e as unknown as Record<string, unknown>;
   const surfaces = extractSurfaces(raw);
   const entry: Record<string, unknown> = {
@@ -598,10 +598,10 @@ const signalToEntry = (
     surfaces,
   };
   addSignalFields(entry, e, raw, relations);
-  return sortKeys(entry) as unknown as SurfaceMapEntry;
+  return sortKeys(entry) as unknown as TopoGraphEntry;
 };
 
-const resourceToEntry = (resource: AnyResource): SurfaceMapEntry => {
+const resourceToEntry = (resource: AnyResource): TopoGraphEntry => {
   const entry: Record<string, unknown> = {
     exampleCount: 0,
     id: resource.id,
@@ -616,10 +616,10 @@ const resourceToEntry = (resource: AnyResource): SurfaceMapEntry => {
     entry['healthcheck'] = true;
   }
 
-  return sortKeys(entry) as unknown as SurfaceMapEntry;
+  return sortKeys(entry) as unknown as TopoGraphEntry;
 };
 
-const contourToEntry = (contour: AnyContour): SurfaceMapEntry => {
+const contourToEntry = (contour: AnyContour): TopoGraphEntry => {
   const entry: Record<string, unknown> = {
     exampleCount: contour.examples?.length ?? 0,
     id: contour.name,
@@ -635,7 +635,7 @@ const contourToEntry = (contour: AnyContour): SurfaceMapEntry => {
     entry['references'] = references;
   }
 
-  return sortKeys(entry) as unknown as SurfaceMapEntry;
+  return sortKeys(entry) as unknown as TopoGraphEntry;
 };
 
 const assertEstablishedTopo = (topo: Topo): void => {
@@ -645,7 +645,7 @@ const assertEstablishedTopo = (topo: Topo): void => {
   }
 };
 
-const collectEntries = (topo: Topo): SurfaceMapEntry[] => {
+const collectEntries = (topo: Topo): TopoGraphEntry[] => {
   const signalRelations = collectSignalGraphRelations(topo);
   return [
     ...[...topo.contours.values()].map((contour) => contourToEntry(contour)),
@@ -669,12 +669,12 @@ const collectEntries = (topo: Topo): SurfaceMapEntry[] => {
 // ---------------------------------------------------------------------------
 
 /**
- * Derive a deterministic surface map from a Topo.
+ * Derive a deterministic topo graph from a Topo.
  *
  * Entries are sorted alphabetically by id. Object keys within each entry
  * are sorted lexicographically for stable serialization.
  */
-export const deriveSurfaceMap = (topo: Topo): SurfaceMap => {
+export const deriveTopoGraph = (topo: Topo): TopoGraph => {
   assertEstablishedTopo(topo);
   const sorted = collectEntries(topo).toSorted((a, b) =>
     a.id.localeCompare(b.id)

--- a/packages/topographer/src/diff.ts
+++ b/packages/topographer/src/diff.ts
@@ -1,13 +1,13 @@
 /**
- * Semantic diffing of surface maps.
+ * Semantic diffing of topo graphs.
  */
 
 import type {
   DiffEntry,
   DiffResult,
   JsonSchema,
-  SurfaceMap,
-  SurfaceMapEntry,
+  TopoGraph,
+  TopoGraphEntry,
 } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -44,7 +44,7 @@ const addDetail = (
 const capitalize = (s: string): string =>
   `${s.charAt(0).toUpperCase()}${s.slice(1)}`;
 
-const labelForKind = (kind: SurfaceMapEntry['kind']): string => {
+const labelForKind = (kind: TopoGraphEntry['kind']): string => {
   if (kind === 'contour') {
     return 'Contour';
   }
@@ -75,15 +75,15 @@ const stableStringify = (value: unknown): string =>
   });
 
 const permitScopes = (
-  permit: SurfaceMapEntry['permit'] | undefined
+  permit: TopoGraphEntry['permit'] | undefined
 ): ReadonlySet<string> | undefined =>
   permit === undefined || permit === 'public'
     ? undefined
     : new Set(permit.scopes);
 
 const permitChangeSeverity = (
-  prevPermit: SurfaceMapEntry['permit'] | undefined,
-  currPermit: SurfaceMapEntry['permit'] | undefined
+  prevPermit: TopoGraphEntry['permit'] | undefined,
+  currPermit: TopoGraphEntry['permit'] | undefined
 ): Severity => {
   const prevScopes = permitScopes(prevPermit);
   const currScopes = permitScopes(currPermit);
@@ -277,8 +277,8 @@ const diffSchemaFields = (
 /** Diff surface additions and removals. */
 const diffSurfaces = (
   acc: DetailAccumulator,
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): void => {
   const prevSurfaces = new Set(prev.surfaces);
   const currSurfaces = new Set(curr.surfaces);
@@ -297,8 +297,8 @@ const diffSurfaces = (
 /** Diff safety markers, description, and deprecation. */
 const diffMetadata = (
   acc: DetailAccumulator,
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): void => {
   if (prev.intent !== curr.intent) {
     addDetail(
@@ -345,8 +345,8 @@ const diffMetadata = (
 
 const diffCliPath = (
   acc: DetailAccumulator,
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): void => {
   const prevPath = prev.cli?.path.join(' ');
   const currPath = curr.cli?.path.join(' ');
@@ -406,8 +406,8 @@ const buildContoursMessage = (added: string[], removed: string[]): string => {
 /** Diff crosses arrays. */
 const diffCrosses = (
   acc: DetailAccumulator,
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): void => {
   const prevCrosses = new Set(prev.crosses);
   const currCrosses = new Set(curr.crosses);
@@ -425,8 +425,8 @@ const diffCrosses = (
 /** Diff declared resource arrays on trail entries. */
 const diffResources = (
   acc: DetailAccumulator,
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): void => {
   const prevResources = new Set(prev.resources);
   const currResources = new Set(curr.resources);
@@ -444,8 +444,8 @@ const diffResources = (
 /** Diff declared contour arrays on trail entries. */
 const diffContours = (
   acc: DetailAccumulator,
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): void => {
   const prevContours = new Set(prev.contours);
   const currContours = new Set(curr.contours);
@@ -462,8 +462,8 @@ const diffContours = (
 
 const diffContourSchema = (
   acc: DetailAccumulator,
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): void => {
   diffSchemaFields(acc, 'contour', prev.schema, curr.schema);
 
@@ -484,8 +484,8 @@ const referenceLabel = (reference: {
 
 const diffContourReferences = (
   acc: DetailAccumulator,
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): void => {
   const prevReferences = new Set(
     (prev.references ?? []).map((reference) => referenceLabel(reference))
@@ -519,8 +519,8 @@ const diffContourReferences = (
 
 const diffTrailEntryDetails = (
   acc: DetailAccumulator,
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): void => {
   diffSchemaFields(acc, 'input', prev.input, curr.input);
   diffSchemaFields(acc, 'output', prev.output, curr.output);
@@ -532,8 +532,8 @@ const diffTrailEntryDetails = (
 
 const diffEntryDetails = (
   acc: DetailAccumulator,
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): void => {
   diffSurfaces(acc, prev, curr);
   diffMetadata(acc, prev, curr);
@@ -548,8 +548,8 @@ const diffEntryDetails = (
 };
 
 const diffEntry = (
-  prev: SurfaceMapEntry,
-  curr: SurfaceMapEntry
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
 ): DiffEntry | undefined => {
   const acc: DetailAccumulator = { details: [], severity: 'info' };
 
@@ -573,7 +573,7 @@ const diffEntry = (
 // ---------------------------------------------------------------------------
 
 /**
- * Compute a semantic diff between two surface maps.
+ * Compute a semantic diff between two topo graphs.
  *
  * Classifies each change with a severity:
  * - `info`: new trail, optional field added, output field added, description change
@@ -582,8 +582,8 @@ const diffEntry = (
  */
 /** Find entries added in curr that don't exist in prev. */
 const findAdded = (
-  prevById: Map<string, SurfaceMapEntry>,
-  currById: Map<string, SurfaceMapEntry>
+  prevById: Map<string, TopoGraphEntry>,
+  currById: Map<string, TopoGraphEntry>
 ): DiffEntry[] =>
   [...currById.entries()]
     .filter(([id]) => !prevById.has(id))
@@ -597,8 +597,8 @@ const findAdded = (
 
 /** Find entries removed from prev that don't exist in curr. */
 const findRemoved = (
-  prevById: Map<string, SurfaceMapEntry>,
-  currById: Map<string, SurfaceMapEntry>
+  prevById: Map<string, TopoGraphEntry>,
+  currById: Map<string, TopoGraphEntry>
 ): DiffEntry[] =>
   [...prevById.entries()]
     .filter(([id]) => !currById.has(id))
@@ -612,8 +612,8 @@ const findRemoved = (
 
 /** Find entries modified between prev and curr. */
 const findModified = (
-  prevById: Map<string, SurfaceMapEntry>,
-  currById: Map<string, SurfaceMapEntry>
+  prevById: Map<string, TopoGraphEntry>,
+  currById: Map<string, TopoGraphEntry>
 ): DiffEntry[] => {
   const results: DiffEntry[] = [];
   for (const [id, currEntry] of currById) {
@@ -630,17 +630,17 @@ const findModified = (
 
 /** Collect all diff entries (added, removed, modified) between two maps. */
 const collectDiffEntries = (
-  prevById: Map<string, SurfaceMapEntry>,
-  currById: Map<string, SurfaceMapEntry>
+  prevById: Map<string, TopoGraphEntry>,
+  currById: Map<string, TopoGraphEntry>
 ): DiffEntry[] => [
   ...findAdded(prevById, currById),
   ...findRemoved(prevById, currById),
   ...findModified(prevById, currById),
 ];
 
-export const deriveSurfaceMapDiff = (
-  prev: SurfaceMap,
-  curr: SurfaceMap
+export const deriveTopoGraphDiff = (
+  prev: TopoGraph,
+  curr: TopoGraph
 ): DiffResult => {
   const prevById = new Map(prev.entries.map((e) => [e.id, e]));
   const currById = new Map(curr.entries.map((e) => [e.id, e]));

--- a/packages/topographer/src/hash.ts
+++ b/packages/topographer/src/hash.ts
@@ -1,10 +1,10 @@
 /**
- * SHA-256 hashing for surface maps.
+ * SHA-256 hashing for topo graphs.
  *
  * Uses Bun.CryptoHasher for native hashing.
  */
 
-import type { SurfaceMap } from './types.js';
+import type { TopoGraph } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,14 +33,14 @@ const canonicalize = (value: unknown): unknown => {
 // ---------------------------------------------------------------------------
 
 /**
- * Compute a SHA-256 hash of a surface map.
+ * Compute a SHA-256 hash of a topo graph.
  *
  * The `generatedAt` field is excluded so that identical topos always
  * produce the same hash regardless of when they were generated.
  */
-export const deriveSurfaceMapHash = (surfaceMap: SurfaceMap): string => {
+export const deriveTopoGraphHash = (topoGraph: TopoGraph): string => {
   // Strip generatedAt before hashing
-  const { generatedAt: _unused, ...rest } = surfaceMap;
+  const { generatedAt: _unused, ...rest } = topoGraph;
 
   const canonical = canonicalize(rest);
   const json = JSON.stringify(canonical);

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -4,14 +4,14 @@
 // in the wayfinding draft ADR at docs/adr/drafts/20260503-wayfinding.md.
 
 // Derivation
-export { deriveSurfaceMap } from './derive.js';
-export { deriveSurfaceMapHash } from './hash.js';
-export { deriveSurfaceMapDiff } from './diff.js';
+export { deriveTopoGraph } from './derive.js';
+export { deriveTopoGraphHash } from './hash.js';
+export { deriveTopoGraphDiff } from './diff.js';
 
 // File I/O
 export {
-  writeSurfaceMap,
-  readSurfaceMap,
+  writeTopoGraph,
+  readTopoGraph,
   writeSurfaceLock,
   readSurfaceLockData,
   readSurfaceLock,
@@ -43,18 +43,18 @@ export type {
 
 // Types
 export type {
-  SurfaceMap,
-  SurfaceMapEntry,
-  SurfaceMapFieldOverride,
-  SurfaceMapFieldOverrideKey,
-  SurfaceMapLayerReference,
+  TopoGraph,
+  TopoGraphEntry,
+  TopoGraphFieldOverride,
+  TopoGraphFieldOverrideKey,
+  TopoGraphLayerReference,
   SurfaceLock,
   WorkspaceTrailEntry,
   WorkspaceTrailIndex,
   DiffEntry,
   DiffResult,
   JsonSchema,
-  SurfaceMapContourReference,
+  TopoGraphContourReference,
   WriteOptions,
   ReadOptions,
 } from './types.js';

--- a/packages/topographer/src/internal/topo-store-read.ts
+++ b/packages/topographer/src/internal/topo-store-read.ts
@@ -141,7 +141,7 @@ interface TopoSignalRelationBatchRow extends TopoSignalRelationRow {
   readonly signal_id: string;
 }
 
-interface StoredSurfaceMapEntry {
+interface StoredTopoGraphEntry {
   readonly description?: string;
   readonly detours?: readonly {
     readonly on: string;
@@ -157,8 +157,8 @@ interface StoredSurfaceMapEntry {
   readonly kind: 'contour' | 'resource' | 'signal' | 'trail';
 }
 
-interface StoredSurfaceMap {
-  readonly entries: readonly StoredSurfaceMapEntry[];
+interface StoredTopoGraph {
+  readonly entries: readonly StoredTopoGraphEntry[];
 }
 
 const ensureSingleRefSelector = (ref?: TopoStoreRef): void => {
@@ -219,15 +219,15 @@ const readSnapshotRef = (
 const readStoredEntry = (
   db: Database,
   snapshotId: string,
-  kind: StoredSurfaceMapEntry['kind'],
+  kind: StoredTopoGraphEntry['kind'],
   id: string
-): StoredSurfaceMapEntry | undefined => {
+): StoredTopoGraphEntry | undefined => {
   const stored = getStoredTopoExport(db, snapshotId);
   if (stored === undefined) {
     return undefined;
   }
 
-  const map = JSON.parse(stored.surfaceMapJson) as StoredSurfaceMap;
+  const map = JSON.parse(stored.surfaceMapJson) as StoredTopoGraph;
   return map.entries.find((entry) => entry.id === id && entry.kind === kind);
 };
 
@@ -417,7 +417,7 @@ const signalExamplePayload = (example: unknown): unknown => {
 };
 
 const signalExamplesFromEntry = (
-  storedEntry: StoredSurfaceMapEntry | undefined
+  storedEntry: StoredTopoGraphEntry | undefined
 ): readonly unknown[] =>
   storedEntry?.examples?.map((example) => signalExamplePayload(example)) ?? [];
 
@@ -527,7 +527,7 @@ export const getTopoStoreTrail = (
 const mapResourceRow = (
   row: TopoResourceRow,
   usedBy: readonly string[],
-  storedEntry?: StoredSurfaceMapEntry
+  storedEntry?: StoredTopoGraphEntry
 ): TopoStoreResourceRecord => ({
   description: storedEntry?.description ?? null,
   hasHealth: row.has_health === 1,
@@ -564,7 +564,7 @@ export const listTopoStoreResources = (
 
   const stored = getStoredTopoExport(db, snapshot.id);
   const entries = stored
-    ? (JSON.parse(stored.surfaceMapJson) as StoredSurfaceMap).entries
+    ? (JSON.parse(stored.surfaceMapJson) as StoredTopoGraph).entries
     : [];
 
   return rows.map((row) =>
@@ -609,7 +609,7 @@ export const getTopoStoreResource = (
 
 const mapSignalRow = (
   row: TopoSignalRow,
-  storedEntry: StoredSurfaceMapEntry | undefined,
+  storedEntry: StoredTopoGraphEntry | undefined,
   relations: {
     readonly consumers: readonly string[];
     readonly from: readonly string[];
@@ -670,7 +670,7 @@ export const listTopoStoreSignals = (
 
   const stored = getStoredTopoExport(db, snapshot.id);
   const entries = stored
-    ? (JSON.parse(stored.surfaceMapJson) as StoredSurfaceMap).entries
+    ? (JSON.parse(stored.surfaceMapJson) as StoredTopoGraph).entries
     : [];
   const consumersBySignal = readSignalRelationUsage(
     db,

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -34,17 +34,17 @@ import {
   insertTopoSnapshotRecord,
 } from './topo-snapshots.js';
 
-type SurfaceMapEntryRecord = Readonly<Record<string, unknown>> & {
+type TopoGraphEntryRecord = Readonly<Record<string, unknown>> & {
   readonly id: string;
   readonly kind: 'contour' | 'resource' | 'signal' | 'trail';
 };
 
-type SurfaceMapRecord = Readonly<{
+type TopoGraphRecord = Readonly<{
   readonly activationGraph: ActivationGraphRecord;
   readonly activationSources: Readonly<
     Record<string, ActivationSourceCatalogRecord>
   >;
-  readonly entries: readonly SurfaceMapEntryRecord[];
+  readonly entries: readonly TopoGraphEntryRecord[];
   readonly generatedAt: string;
   readonly version: '1.0';
 }>;
@@ -1037,21 +1037,21 @@ const trailToEntryRecord = (
     readonly input: JsonRecord;
     readonly output?: JsonRecord;
   }>
-): SurfaceMapEntryRecord => {
+): TopoGraphEntryRecord => {
   const { entry, raw } = buildTrailEntryBase(trail, trailSchema);
   addSafetyMarkers(entry, trail);
   addPermitRequirement(entry, trail);
   addExtendedMetadata(entry, raw, trail);
   addTrailRelations(entry, trail);
   addLayerAttachments(entry, topoLayers, trail);
-  return sortKeys(entry) as SurfaceMapEntryRecord;
+  return sortKeys(entry) as TopoGraphEntryRecord;
 };
 
 const signalToEntryRecord = (
   signal: AnySignal,
   payloadSchema: JsonRecord,
   relations: SignalGraphRelations
-): SurfaceMapEntryRecord => {
+): TopoGraphEntryRecord => {
   const raw = signal as unknown as Record<string, unknown>;
   const examples = deriveStructuredSignalExamples(signal.examples);
   const entry: Record<string, unknown> = {
@@ -1091,12 +1091,10 @@ const signalToEntryRecord = (
     entry['replacedBy'] = raw['replacedBy'];
   }
 
-  return sortKeys(entry) as SurfaceMapEntryRecord;
+  return sortKeys(entry) as TopoGraphEntryRecord;
 };
 
-const resourceToEntryRecord = (
-  resource: AnyResource
-): SurfaceMapEntryRecord => {
+const resourceToEntryRecord = (resource: AnyResource): TopoGraphEntryRecord => {
   const entry: Record<string, unknown> = {
     exampleCount: 0,
     id: resource.id,
@@ -1112,10 +1110,10 @@ const resourceToEntryRecord = (
     entry['healthcheck'] = true;
   }
 
-  return sortKeys(entry) as SurfaceMapEntryRecord;
+  return sortKeys(entry) as TopoGraphEntryRecord;
 };
 
-const contourToEntryRecord = (contour: AnyContour): SurfaceMapEntryRecord => {
+const contourToEntryRecord = (contour: AnyContour): TopoGraphEntryRecord => {
   const schema = sortedJsonSchema(contour);
   const entry: Record<string, unknown> = {
     exampleCount: contour.examples?.length ?? 0,
@@ -1131,7 +1129,7 @@ const contourToEntryRecord = (contour: AnyContour): SurfaceMapEntryRecord => {
     entry['references'] = references;
   }
 
-  return sortKeys(entry) as SurfaceMapEntryRecord;
+  return sortKeys(entry) as TopoGraphEntryRecord;
 };
 
 const requireTrailSchema = (
@@ -1190,7 +1188,7 @@ const collectSignalGraphRelations = (
   );
 };
 
-const buildSurfaceMap = (
+const buildTopoGraph = (
   contours: readonly AnyContour[],
   generatedAt: string,
   resources: readonly AnyResource[],
@@ -1205,7 +1203,7 @@ const buildSurfaceMap = (
     }>
   >,
   trails: readonly AnyTrail[]
-): SurfaceMapRecord => {
+): TopoGraphRecord => {
   const signalRelations = collectSignalGraphRelations(signals, trails);
   const activationSources = collectActivationSourceCatalog(trails);
   const activationEdges = collectActivationGraphEdges(trails);
@@ -1242,21 +1240,21 @@ const buildSurfaceMap = (
   };
 };
 
-const hashSurfaceMapRecord = (surfaceMap: SurfaceMapRecord): string => {
+const hashTopoGraphRecord = (surfaceMap: TopoGraphRecord): string => {
   const { generatedAt: _unused, ...rest } = surfaceMap;
   return hashValue(rest);
 };
 
 const entryPayload = (
-  entry: SurfaceMapEntryRecord
+  entry: TopoGraphEntryRecord
 ): Readonly<Record<string, unknown>> => {
   const { id: _unusedId, kind: _unusedKind, ...rest } = entry;
   return sortKeys(rest);
 };
 
 const entriesForKind = (
-  entries: readonly SurfaceMapEntryRecord[],
-  kind: SurfaceMapEntryRecord['kind']
+  entries: readonly TopoGraphEntryRecord[],
+  kind: TopoGraphEntryRecord['kind']
 ): Readonly<Record<string, Readonly<Record<string, unknown>>>> =>
   Object.fromEntries(
     entries
@@ -1267,7 +1265,7 @@ const entriesForKind = (
 const buildSerializedLock = (
   hash: string,
   topo: Topo,
-  surfaceMap: SurfaceMapRecord
+  surfaceMap: TopoGraphRecord
 ): Readonly<Record<string, unknown>> =>
   sortKeys({
     apps: sortKeys({
@@ -1301,7 +1299,7 @@ const buildStoredTopoExport = (
     .listSignals()
     .toSorted((a, b) => a.id.localeCompare(b.id));
   const schemas = materializeSchemas(db, snapshot.id, signals, trails);
-  const surfaceMap = buildSurfaceMap(
+  const surfaceMap = buildTopoGraph(
     contours,
     snapshot.createdAt,
     resources,
@@ -1311,7 +1309,7 @@ const buildStoredTopoExport = (
     schemas.trailSchemas,
     trails
   );
-  const surfaceHash = hashSurfaceMapRecord(surfaceMap);
+  const surfaceHash = hashTopoGraphRecord(surfaceMap);
   const serializedLock = `${JSON.stringify(
     buildSerializedLock(surfaceHash, topo, surfaceMap),
     null,

--- a/packages/topographer/src/io.ts
+++ b/packages/topographer/src/io.ts
@@ -1,5 +1,5 @@
 /**
- * File I/O for surface maps and lock files.
+ * File I/O for topo graphs and lock files.
  */
 
 import { mkdir } from 'node:fs/promises';
@@ -8,7 +8,7 @@ import { join } from 'node:path';
 import type {
   ReadOptions,
   SurfaceLock,
-  SurfaceMap,
+  TopoGraph,
   WorkspaceTrailIndex,
   WriteOptions,
 } from './types.js';
@@ -19,7 +19,7 @@ import { surfaceLockSchema } from './types.js';
 // ---------------------------------------------------------------------------
 
 const DEFAULT_DIR = '.trails';
-const SURFACE_MAP_FILE = '_surface.json';
+const TOPO_GRAPH_FILE = '_surface.json';
 const SURFACE_LOCK_FILE = 'trails.lock';
 
 // ---------------------------------------------------------------------------
@@ -79,35 +79,35 @@ const parseSurfaceLock = (content: string): SurfaceLock => {
 };
 
 // ---------------------------------------------------------------------------
-// Surface Map
+// TopoGraph
 // ---------------------------------------------------------------------------
 
 /**
- * Write a surface map to `<dir>/_surface.json`.
+ * Write a topo graph to `<dir>/_surface.json`.
  *
  * Creates the directory if it doesn't exist. Returns the file path.
  */
-export const writeSurfaceMap = async (
-  surfaceMap: SurfaceMap,
+export const writeTopoGraph = async (
+  topoGraph: TopoGraph,
   options?: WriteOptions
 ): Promise<string> => {
   const dir = resolveDir(options);
   await ensureDir(dir);
-  const filePath = join(dir, SURFACE_MAP_FILE);
-  const json = `${JSON.stringify(surfaceMap, null, 2)}\n`;
+  const filePath = join(dir, TOPO_GRAPH_FILE);
+  const json = `${JSON.stringify(topoGraph, null, 2)}\n`;
   await Bun.write(filePath, json);
   return filePath;
 };
 
 /**
- * Read a surface map from `<dir>/_surface.json`.
+ * Read a topo graph from `<dir>/_surface.json`.
  */
-export const readSurfaceMap = async (
+export const readTopoGraph = async (
   options?: ReadOptions
-): Promise<SurfaceMap | null> => {
+): Promise<TopoGraph | null> => {
   const dir = resolveDir(options);
-  const content = await readTextIfExists(join(dir, SURFACE_MAP_FILE));
-  return content ? (JSON.parse(content) as SurfaceMap) : null;
+  const content = await readTextIfExists(join(dir, TOPO_GRAPH_FILE));
+  return content ? (JSON.parse(content) as TopoGraph) : null;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Types for surface maps, diffing, and lock files.
+ * Types for topo graphs, diffing, and lock files.
  */
 
 import type {
@@ -8,9 +8,7 @@ import type {
 } from '@ontrails/core';
 import { z } from 'zod';
 
-export type SurfaceMapExample =
-  | StructuredSignalExample
-  | StructuredTrailExample;
+export type TopoGraphExample = StructuredSignalExample | StructuredTrailExample;
 
 // ---------------------------------------------------------------------------
 // JSON Schema (lightweight alias)
@@ -19,33 +17,33 @@ export type SurfaceMapExample =
 /** A JSON Schema object produced by zodToJsonSchema. */
 export type JsonSchema = Readonly<Record<string, unknown>>;
 
-export interface SurfaceMapContourReference {
+export interface TopoGraphContourReference {
   readonly contour: string;
   readonly field: string;
   readonly identity: string;
 }
 
-export type SurfaceMapFieldOverrideKey =
+export type TopoGraphFieldOverrideKey =
   | 'hint'
   | 'label'
   | 'message'
   | 'options';
 
-export interface SurfaceMapFieldOverride {
+export interface TopoGraphFieldOverride {
   readonly field: string;
-  readonly overrides: readonly SurfaceMapFieldOverrideKey[];
+  readonly overrides: readonly TopoGraphFieldOverrideKey[];
   readonly provenance: {
     readonly source: 'trail.fields';
   };
 }
 
-export interface SurfaceMapLayerReference {
+export interface TopoGraphLayerReference {
   readonly input?: JsonSchema | undefined;
   readonly name: string;
   readonly scope: 'topo' | 'trail';
 }
 
-export interface SurfaceMapActivationSource extends Readonly<
+export interface TopoGraphActivationSource extends Readonly<
   Record<string, unknown>
 > {
   readonly cron?: string | undefined;
@@ -62,7 +60,7 @@ export interface SurfaceMapActivationSource extends Readonly<
   readonly timezone?: string | undefined;
 }
 
-export interface SurfaceMapActivationEdge extends Readonly<
+export interface TopoGraphActivationEdge extends Readonly<
   Record<string, unknown>
 > {
   readonly hasWhere: boolean;
@@ -73,29 +71,29 @@ export interface SurfaceMapActivationEdge extends Readonly<
   readonly where?: { readonly predicate: true } | undefined;
 }
 
-export interface SurfaceMapActivationGraph {
+export interface TopoGraphActivationGraph {
   readonly edgeCount: number;
-  readonly edges: readonly SurfaceMapActivationEdge[];
+  readonly edges: readonly TopoGraphActivationEdge[];
   readonly sourceCount: number;
   readonly sourceKeys: readonly string[];
   readonly trailIds: readonly string[];
 }
 
-export interface SurfaceMapActivationEntry {
+export interface TopoGraphActivationEntry {
   readonly meta?: Readonly<Record<string, unknown>> | undefined;
-  readonly source: SurfaceMapActivationSource;
+  readonly source: TopoGraphActivationSource;
   readonly where?: { readonly predicate: true } | undefined;
 }
 
-export interface SurfaceMapPermitRequirement {
+export interface TopoGraphPermitRequirement {
   readonly scopes: readonly string[];
 }
 
 // ---------------------------------------------------------------------------
-// Surface Map
+// TopoGraph
 // ---------------------------------------------------------------------------
 
-export interface SurfaceMapEntry {
+export interface TopoGraphEntry {
   readonly id: string;
   readonly kind: 'contour' | 'trail' | 'signal' | 'resource';
   readonly surfaces: readonly string[];
@@ -110,16 +108,16 @@ export interface SurfaceMapEntry {
   readonly intent?: 'read' | 'write' | 'destroy' | undefined;
   readonly idempotent?: boolean | undefined;
   readonly dryRunCapable?: boolean | undefined;
-  readonly permit?: 'public' | SurfaceMapPermitRequirement | undefined;
+  readonly permit?: 'public' | TopoGraphPermitRequirement | undefined;
   readonly pattern?: string | undefined;
   readonly deprecated?: boolean | undefined;
   readonly replacedBy?: string | undefined;
-  readonly activationSources?: readonly SurfaceMapActivationEntry[] | undefined;
+  readonly activationSources?: readonly TopoGraphActivationEntry[] | undefined;
   readonly crosses?: readonly string[] | undefined;
   readonly contours?: readonly string[] | undefined;
   readonly schema?: JsonSchema | undefined;
   readonly identity?: string | undefined;
-  readonly references?: readonly SurfaceMapContourReference[] | undefined;
+  readonly references?: readonly TopoGraphContourReference[] | undefined;
   readonly resources?: readonly string[] | undefined;
   readonly fires?: readonly string[] | undefined;
   readonly on?: readonly string[] | undefined;
@@ -129,25 +127,25 @@ export interface SurfaceMapEntry {
   readonly diagnostics?: Readonly<Record<string, unknown>> | undefined;
   readonly governance?: Readonly<Record<string, unknown>> | undefined;
   readonly meta?: Readonly<Record<string, unknown>> | undefined;
-  readonly fieldOverrides?: readonly SurfaceMapFieldOverride[] | undefined;
-  readonly layers?: readonly SurfaceMapLayerReference[] | undefined;
+  readonly fieldOverrides?: readonly TopoGraphFieldOverride[] | undefined;
+  readonly layers?: readonly TopoGraphLayerReference[] | undefined;
   readonly detours?:
     | readonly { readonly on: string; readonly maxAttempts: number }[]
     | undefined;
   readonly healthcheck?: boolean | undefined;
   readonly exampleCount: number;
-  readonly examples?: readonly SurfaceMapExample[] | undefined;
+  readonly examples?: readonly TopoGraphExample[] | undefined;
   readonly description?: string | undefined;
 }
 
-export interface SurfaceMap {
+export interface TopoGraph {
   readonly version: string;
-  readonly activationGraph: SurfaceMapActivationGraph;
+  readonly activationGraph: TopoGraphActivationGraph;
   readonly activationSources: Readonly<
-    Record<string, SurfaceMapActivationSource>
+    Record<string, TopoGraphActivationSource>
   >;
   readonly generatedAt: string;
-  readonly entries: readonly SurfaceMapEntry[];
+  readonly entries: readonly TopoGraphEntry[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -11,8 +11,8 @@ import {
   trail,
 } from '@ontrails/core';
 import {
-  deriveSurfaceMap,
-  deriveSurfaceMapHash,
+  deriveTopoGraph,
+  deriveTopoGraphHash,
   writeSurfaceLock,
 } from '@ontrails/topographer';
 import { z } from 'zod';
@@ -608,7 +608,7 @@ export const second = contour('second', {
         output: z.object({ value: z.string() }),
       });
       const admin = topo('fixture.admin', { adminTrail });
-      const primaryHash = deriveSurfaceMapHash(deriveSurfaceMap(primary));
+      const primaryHash = deriveTopoGraphHash(deriveTopoGraph(primary));
       await writeSurfaceLock(primaryHash, {
         dir: deriveTrailsDir({ rootDir: dir }),
       });

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -12,8 +12,8 @@ import {
 } from '@ontrails/core';
 import {
   createTopoStore,
-  deriveSurfaceMapHash,
-  deriveSurfaceMap,
+  deriveTopoGraphHash,
+  deriveTopoGraph,
   writeSurfaceLock,
 } from '@ontrails/topographer';
 import { createStoredTopoSnapshot } from '@ontrails/topographer/backend-support';
@@ -94,7 +94,7 @@ describe('checkDrift', () => {
     const dir = createTempDir();
     try {
       const tp = makeTopo();
-      const hash = deriveSurfaceMapHash(deriveSurfaceMap(tp));
+      const hash = deriveTopoGraphHash(deriveTopoGraph(tp));
       await writeSurfaceLock(
         { hash, version: 1 },
         { dir: committedLockDir(dir) }

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -2,7 +2,7 @@
  * Topo lock drift detection.
  *
  * Compares the committed `trails.lock` hash against a freshly generated
- * surface map hash to detect when the trail topology has changed without
+ * TopoGraph hash to detect when the trail topology has changed without
  * updating the lock file. The committed lock may be structured JSON or the
  * legacy single-line hash format.
  */
@@ -17,8 +17,8 @@ import {
 } from '@ontrails/core';
 import {
   createTopoStore,
-  deriveSurfaceMap,
-  deriveSurfaceMapHash,
+  deriveTopoGraph,
+  deriveTopoGraphHash,
   readSurfaceLockData,
 } from '@ontrails/topographer';
 
@@ -67,7 +67,7 @@ export const checkDrift = async (
       storedHash ??
       (topo === undefined
         ? 'unknown'
-        : deriveSurfaceMapHash(deriveSurfaceMap(topo)));
+        : deriveTopoGraphHash(deriveTopoGraph(topo)));
 
     return {
       committedHash: committedLock?.hash ?? null,


### PR DESCRIPTION
## Context

Stack 1 needs the public Topographer API to speak in resolved topo artifact-family terms before the lock v3 and `topo.lock` branches land on top of it.

This PR covers TRL-695 by renaming the former `SurfaceMap` public API language to `TopoGraph` language across `@ontrails/topographer` and its direct consumers.

## Changes

- Renames exported Topographer types, helpers, tests, and docs from `SurfaceMap`-style names to `TopoGraph` names.
- Updates derive, diff, hash, I/O, topo-store internals, and package README examples to use the new public vocabulary.
- Updates CLI survey/run-watch and Warden references that consume Topographer output.
- Adds a changeset for the package-facing API rename.

## Verification

Local verification in this review-feedback pass:

- `bun scripts/adr.ts check`
- `bun test packages/topographer/src/__tests__/io.test.ts packages/warden/src/__tests__/drift.test.ts apps/trails/src/__tests__/topo-dev.test.ts apps/trails/src/__tests__/run-watch.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run format:check`
- `bun run test`
- `bun run build`
- `bun run check`
- `git diff --check`

Remote CI, Greptile, and Graphite mergeability rerun on every push; use the PR check rollup for current remote status.

## Release / Risk

This is an intentional breaking API rename for the beta line. The behavioral goal is mostly semantic consistency: downstream branches depend on `TopoGraph` being the public artifact name before introducing `topo.lock` I/O.