### PR TITLE
feat: add lock v3 manifest and topo.lock io

### DIFF
--- a/.changeset/trl-696-lock-v3-topolock-io.md
+++ b/.changeset/trl-696-lock-v3-topolock-io.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/topographer': major
+'@ontrails/trails': patch
+'@ontrails/warden': patch
+---
+
+Add lock v3 manifest and `topo.lock` I/O. `trails.lock` now reads as a compact v3 manifest that points at the serialized TopoGraph artifact, and legacy v2/hash-only lock inputs fail with a regenerate instruction.

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -23,6 +23,7 @@ import {
   deriveTopoGraph,
   deriveTopoGraphHash,
   deriveTopoGraphDiff,
+  TOPO_GRAPH_SCHEMA_VERSION,
   writeTopoGraph,
 } from '@ontrails/topographer';
 import type { TopoGraph } from '@ontrails/topographer';
@@ -256,7 +257,7 @@ describe('trails survey', () => {
     const surfaceMap = deriveTopoGraph(app);
     const json = JSON.stringify(surfaceMap, null, 2);
     const parsed = JSON.parse(json) as TopoGraph;
-    expect(parsed.version).toBe('1.0');
+    expect(parsed.topoGraphSchemaVersion).toBe(TOPO_GRAPH_SCHEMA_VERSION);
     expect(parsed.entries.length).toBe(3);
   });
 
@@ -910,13 +911,13 @@ describe('trails topo compile', () => {
       };
 
       expect(compiled.hash).toHaveLength(64);
-      expect(existsSync(join(dir, '.trails', '_surface.json'))).toBe(true);
+      expect(existsSync(join(dir, '.trails', 'topo.lock'))).toBe(true);
       expect(existsSync(join(dir, '.trails', 'trails.lock'))).toBe(true);
       expect(
         JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
       ).toMatchObject({
-        hash: compiled.hash,
-        version: '2',
+        artifacts: [{ path: 'topo.lock', role: 'topo', sha256: compiled.hash }],
+        version: 3,
       });
       expect(topoCompileTrail.output.safeParse(compiled).success).toBe(true);
     } finally {
@@ -1165,7 +1166,7 @@ describe('trails survey output schema', () => {
       topoCompileTrail.output.safeParse({
         hash: 'a'.repeat(64),
         lockPath: '.trails/trails.lock',
-        mapPath: '.trails/_surface.json',
+        mapPath: '.trails/topo.lock',
         snapshot: {
           createdAt: new Date(0).toISOString(),
           gitDirty: false,

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -155,13 +155,15 @@ describe('topo and dev trails', () => {
       );
       const snapshotCountAfterExport = countTopoSnapshots(dir);
       expect(compileResult.hash).toHaveLength(64);
-      expect(existsSync(join(dir, '.trails', '_surface.json'))).toBe(true);
+      expect(existsSync(join(dir, '.trails', 'topo.lock'))).toBe(true);
       expect(existsSync(join(dir, '.trails', 'trails.lock'))).toBe(true);
       expect(
         JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
       ).toMatchObject({
-        hash: compileResult.hash,
-        version: '2',
+        artifacts: [
+          { path: 'topo.lock', role: 'topo', sha256: compileResult.hash },
+        ],
+        version: 3,
       });
 
       const summaryAfterExport = expectOk(
@@ -190,11 +192,16 @@ describe('topo and dev trails', () => {
       expect(driftError.message).toContain('trails.lock is stale');
       expect(countTopoSnapshots(dir)).toBe(snapshotCountAfterExport);
 
-      writeFileSync(join(dir, '.trails', 'trails.lock'), 'stale\n');
+      writeFileSync(
+        join(dir, '.trails', 'trails.lock'),
+        `${JSON.stringify({ hash: '1'.repeat(64), version: 2 }, null, 2)}\n`
+      );
       const verifyError = expectErr(
         await topoVerifyTrail.blaze(moduleInput, { cwd: dir } as never)
       );
-      expect(verifyError.message).toContain('trails.lock is stale');
+      expect(verifyError.message).toContain(
+        'regenerate with `trails topo compile`'
+      );
       expect(countTopoSnapshots(dir)).toBe(snapshotCountAfterExport);
     } finally {
       rmSync(dir, { force: true, recursive: true });
@@ -321,8 +328,10 @@ describe('topo and dev trails', () => {
       expect(
         JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
       ).toMatchObject({
-        hash: secondCompile.hash,
-        version: '2',
+        artifacts: [
+          { path: 'topo.lock', role: 'topo', sha256: secondCompile.hash },
+        ],
+        version: 3,
       });
 
       const projectionDb = openReadTrailsDb({ rootDir: dir });

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -20,6 +20,7 @@ import {
   createTopoStore,
   deriveTopoGraphDiff,
   deriveTopoGraph,
+  TOPO_GRAPH_SCHEMA_VERSION,
   readTopoGraph,
 } from '@ontrails/topographer';
 import { z } from 'zod';
@@ -91,7 +92,7 @@ const createDiffExampleInput = (): {
   readonly rootDir: string;
 } => {
   const input = createIsolatedExampleInput('survey-diff');
-  writeIsolatedExampleJsonFile(input.rootDir, 'baseline/_surface.json', {
+  writeIsolatedExampleJsonFile(input.rootDir, 'baseline/topo.lock', {
     activationGraph: {
       edgeCount: 0,
       edges: [],
@@ -102,7 +103,7 @@ const createDiffExampleInput = (): {
     activationSources: {},
     entries: [],
     generatedAt: '2026-01-01T00:00:00.000Z',
-    version: '1.0',
+    topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
   } satisfies TopoGraph);
   return { ...input, against: 'baseline' };
 };

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -16,8 +16,9 @@ import {
   NotFoundError,
   Result,
   SURFACE_LAYER_NAMES_KEY,
+  ValidationError,
 } from '@ontrails/core';
-import { readSurfaceLockData } from '@ontrails/topographer';
+import { readLockManifest } from '@ontrails/topographer';
 
 import type {
   BriefReport,
@@ -245,11 +246,24 @@ export const verifyCurrentTopo = async (
   options?: { readonly rootDir?: string }
 ): Promise<Result<TopoVerifyReport, Error>> => {
   const rootDir = deriveRootDir(options?.rootDir);
-  const committedLock = await readSurfaceLockData({
-    dir: deriveTrailsDir({ rootDir }),
-  });
+  let lockManifest: Awaited<ReturnType<typeof readLockManifest>>;
+  try {
+    lockManifest = await readLockManifest({
+      dir: deriveTrailsDir({ rootDir }),
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Unable to read committed trails.lock manifest.';
+    return Result.err(
+      error instanceof Error
+        ? new ValidationError(message, { cause: error })
+        : new ValidationError(message)
+    );
+  }
 
-  if (committedLock === null) {
+  if (lockManifest === null) {
     return Result.err(
       new NotFoundError(
         'No committed trails.lock found. Run `trails topo compile` first.'
@@ -262,8 +276,18 @@ export const verifyCurrentTopo = async (
     return currentExport;
   }
   const currentHash = currentExport.value.surfaceHash;
+  const topoArtifact = lockManifest.artifacts.find(
+    (artifact) => artifact.role === 'topo'
+  );
+  if (topoArtifact === undefined) {
+    return Result.err(
+      new NotFoundError(
+        'No topo.lock artifact found in trails.lock. Run `trails topo compile` first.'
+      )
+    );
+  }
 
-  if (committedLock.hash !== currentHash) {
+  if (topoArtifact.sha256 !== currentHash) {
     return Result.err(
       new ConflictError(
         'trails.lock is stale. Run `trails topo compile` to refresh it.'
@@ -272,7 +296,7 @@ export const verifyCurrentTopo = async (
   }
 
   return Result.ok({
-    committedHash: committedLock.hash,
+    committedHash: topoArtifact.sha256,
     currentHash,
     lockPath: LOCK_PATH,
     stale: false,

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -15,12 +15,12 @@ import {
   Result,
 } from '@ontrails/core';
 import type {
-  SurfaceLock,
+  LockManifest,
   TopoGraph,
   TopoSnapshot,
 } from '@ontrails/topographer';
 import type { StoredTopoExport } from '@ontrails/topographer/backend-support';
-import { writeSurfaceLock, writeTopoGraph } from '@ontrails/topographer';
+import { writeLockManifest, writeTopoGraph } from '@ontrails/topographer';
 import {
   createStoredTopoSnapshot,
   getStoredTopoExport,
@@ -91,8 +91,8 @@ const writeStoredExportArtifacts = async (
     JSON.parse(storedExport.surfaceMapJson) as TopoGraph,
     { dir: trailsDir }
   );
-  const lockPath = await writeSurfaceLock(
-    JSON.parse(storedExport.lockContent) as SurfaceLock,
+  const lockPath = await writeLockManifest(
+    JSON.parse(storedExport.lockContent) as LockManifest,
     { dir: trailsDir }
   );
 

--- a/packages/topographer/README.md
+++ b/packages/topographer/README.md
@@ -10,7 +10,7 @@ Most applications reach this package through `trails topo compile` and `trails t
 - structured example and field-override provenance projection for TopoGraph entries
 - stable hashing for CI drift detection
 - semantic diffing between two TopoGraphs
-- file I/O helpers for the current graph artifact and `.trails/trails.lock`
+- file I/O helpers for `.trails/topo.lock` and `.trails/trails.lock`
 - the topo-store: queryable persistence of the resolved topo graph in `trails.db`, including snapshots, pinning, history, and read-only query accessors (relocated from `@ontrails/core` per ADR-0042)
 
 `@ontrails/topographer` is the durable graph substrate for Trails. Generic `trails-db` plumbing (read/write SQLite handles, subsystem schema management, derived paths) stays in `@ontrails/core` so other subsystems (tracing, signals) can share it without depending on topographer.
@@ -22,7 +22,7 @@ import {
   deriveTopoGraph,
   deriveTopoGraphDiff,
   deriveTopoGraphHash,
-  writeSurfaceLock,
+  writeLockManifest,
   writeTopoGraph,
 } from '@ontrails/topographer';
 
@@ -30,7 +30,12 @@ const topoGraph = deriveTopoGraph(graph);
 const hash = deriveTopoGraphHash(topoGraph);
 
 await writeTopoGraph(topoGraph);
-await writeSurfaceLock({ hash });
+await writeLockManifest({
+  artifacts: [{ path: 'topo.lock', role: 'topo', sha256: hash }],
+  scope: { app: 'demo' },
+  summary: { contours: 0, resources: 0, signals: 0, trails: 1 },
+  version: 3,
+});
 
 // Later, after changes:
 const nextTopoGraph = deriveTopoGraph(graph);
@@ -47,8 +52,8 @@ if (diff.hasBreaking) {
 
 The typical exported artifact pair is:
 
-- `.trails/_surface.json` — current detailed derived graph artifact, useful for inspection and diffing
-- `.trails/trails.lock` — committed lock artifact, stored as structured JSON or legacy hash-only text
+- `.trails/topo.lock` — serialized TopoGraph, useful for inspection and diffing
+- `.trails/trails.lock` — compact v3 manifest that verifies the TopoGraph by hash
 
 `trails topo compile` writes both from the current topo. `trails topo verify` and `@ontrails/warden` use the lockfile helpers here to detect drift.
 
@@ -59,11 +64,10 @@ The typical exported artifact pair is:
 | `deriveTopoGraph(topo)` | Deterministic TopoGraph of every established trail, signal, resource, and contour |
 | `deriveTopoGraphHash(topoGraph)` | Stable SHA-256 hash of the TopoGraph |
 | `deriveTopoGraphDiff(prev, curr)` | Semantic diff with `breaking`, `warning`, and `info` classifications |
-| `writeTopoGraph(topoGraph, options?)` | Write the current graph artifact |
-| `readTopoGraph(options?)` | Read the current graph artifact |
-| `writeSurfaceLock(lock, options?)` | Write `.trails/trails.lock` as either structured JSON or legacy hash text |
-| `readSurfaceLockData(options?)` | Read the full normalized lock payload from `.trails/trails.lock` |
-| `readSurfaceLock(options?)` | Read just the committed lock hash |
+| `writeTopoGraph(topoGraph, options?)` | Write `.trails/topo.lock` |
+| `readTopoGraph(options?)` | Read `.trails/topo.lock` |
+| `writeLockManifest(manifest, options?)` | Write `.trails/trails.lock` as a v3 manifest |
+| `readLockManifest(options?)` | Read the v3 manifest from `.trails/trails.lock` |
 | `createTopoStore(options?)` | Read-only query interface over the persisted topo state in `trails.db` |
 | `createMockTopoStore(seed?)` | Seeded in-memory mock for tests that need a `ReadOnlyTopoStore` |
 | `topoStore` | Read-only `resource()` wrapper around `createTopoStore`, suitable for `resources: [...]` |
@@ -117,12 +121,13 @@ Because CLI paths are now full hierarchical command paths, command-tree changes 
 ## Drift detection with warden
 
 ```typescript
-import { deriveTopoGraph, deriveTopoGraphHash, readSurfaceLock } from '@ontrails/topographer';
+import { deriveTopoGraph, deriveTopoGraphHash, readLockManifest } from '@ontrails/topographer';
 
 const current = deriveTopoGraphHash(deriveTopoGraph(graph));
-const committed = await readSurfaceLock();
+const committed = await readLockManifest();
+const topoArtifact = committed?.artifacts.find((artifact) => artifact.role === 'topo');
 
-if (committed !== current) {
+if (topoArtifact?.sha256 !== current) {
   // lock file is stale -- topo has changed
 }
 ```

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -16,6 +16,7 @@ import type { Layer, Topo, TopoIssue } from '@ontrails/core';
 import { z } from 'zod';
 
 import { deriveTopoGraph } from '../derive.js';
+import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -715,10 +716,10 @@ describe('deriveTopoGraph', () => {
       const map2 = deriveTopoGraph(tp);
 
       expect(map1.entries).toEqual(map2.entries);
-      expect(map1.version).toBe(map2.version);
+      expect(map1.topoGraphSchemaVersion).toBe(map2.topoGraphSchemaVersion);
     });
 
-    test('version is set to 1.0', () => {
+    test('schema version is set to 1', () => {
       const t = trail('v.check', {
         blaze: noop,
         input: z.object({}),
@@ -726,7 +727,7 @@ describe('deriveTopoGraph', () => {
       const tp = topoFrom({ t });
       const map = deriveTopoGraph(tp);
 
-      expect(map.version).toBe('1.0');
+      expect(map.topoGraphSchemaVersion).toBe(TOPO_GRAPH_SCHEMA_VERSION);
     });
 
     test('generatedAt is an ISO timestamp', () => {

--- a/packages/topographer/src/__tests__/diff.test.ts
+++ b/packages/topographer/src/__tests__/diff.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'bun:test';
 
 import { deriveTopoGraphDiff } from '../diff.js';
+import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
 import type { TopoGraph, TopoGraphEntry } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -27,7 +28,7 @@ const topoGraph = (entries: TopoGraphEntry[]): TopoGraph => ({
   activationSources: {},
   entries,
   generatedAt: new Date().toISOString(),
-  version: '1.0',
+  topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/topographer/src/__tests__/hash.test.ts
+++ b/packages/topographer/src/__tests__/hash.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'bun:test';
 
 import { deriveTopoGraphHash } from '../hash.js';
+import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
 import type { TopoGraph } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -35,7 +36,7 @@ const makeTopoGraph = (overrides?: Partial<TopoGraph>): TopoGraph => ({
     },
   ],
   generatedAt: '2025-01-01T00:00:00.000Z',
-  version: '1.0',
+  topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
   ...overrides,
 });
 

--- a/packages/topographer/src/__tests__/io.test.ts
+++ b/packages/topographer/src/__tests__/io.test.ts
@@ -6,13 +6,13 @@ import { join } from 'node:path';
 import {
   writeTopoGraph,
   readTopoGraph,
-  writeSurfaceLock,
-  readSurfaceLockData,
-  readSurfaceLock,
+  isTopoArtifactRegenerationError,
+  writeLockManifest,
+  readLockManifest,
   readWorkspaceLock,
 } from '../io.js';
-import { surfaceLockSchema } from '../types.js';
-import type { TopoGraph } from '../types.js';
+import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
+import type { LockManifest, TopoGraph } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -38,18 +38,35 @@ const makeTopoGraph = (): TopoGraph => ({
     },
   ],
   generatedAt: '2025-01-01T00:00:00.000Z',
-  version: '1.0',
+  topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
 });
 
-const makeStructuredLock = (hash: string) => ({
-  hash,
-  version: '2' as const,
+const makeLockManifest = (
+  hash: string,
+  overrides?: Partial<LockManifest>
+): LockManifest => ({
+  artifacts: [{ path: 'topo.lock', role: 'topo', sha256: hash }],
+  scope: { app: 'demo' },
+  summary: { contours: 0, resources: 0, signals: 0, trails: 1 },
+  version: 3,
+  ...overrides,
 });
 
 const readParsedLock = async (
   filePath: string
 ): Promise<Record<string, unknown>> =>
   JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
+
+const captureError = async (
+  operation: () => Promise<unknown>
+): Promise<unknown> => {
+  try {
+    await operation();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected operation to throw');
+};
 
 // ---------------------------------------------------------------------------
 // Setup / Teardown
@@ -66,19 +83,19 @@ afterEach(async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Surface map tests
+// TopoGraph tests
 // ---------------------------------------------------------------------------
 
 describe('writeTopoGraph / readTopoGraph', () => {
-  test('writes valid JSON to _surface.json', async () => {
+  test('writes valid JSON to topo.lock', async () => {
     const map = makeTopoGraph();
     const filePath = await writeTopoGraph(map, { dir: tempDir });
 
-    expect(filePath).toBe(join(tempDir, '_surface.json'));
+    expect(filePath).toBe(join(tempDir, 'topo.lock'));
 
     const content = await readFile(filePath, 'utf8');
     const parsed = JSON.parse(content);
-    expect(parsed.version).toBe('1.0');
+    expect(parsed.topoGraphSchemaVersion).toBe(TOPO_GRAPH_SCHEMA_VERSION);
     expect(parsed.entries).toHaveLength(1);
   });
 
@@ -96,61 +113,150 @@ describe('writeTopoGraph / readTopoGraph', () => {
     });
     expect(result).toBeNull();
   });
+
+  test('rejects topo.lock files with invalid shape', async () => {
+    await Bun.write(
+      join(tempDir, 'topo.lock'),
+      `${JSON.stringify({ entries: [] }, null, 2)}\n`
+    );
+
+    await expect(readTopoGraph({ dir: tempDir })).rejects.toThrow(
+      'regenerate with `trails topo compile`'
+    );
+  });
+
+  test('rejects legacy topo graph versions', async () => {
+    await Bun.write(
+      join(tempDir, 'topo.lock'),
+      `${JSON.stringify(
+        { ...makeTopoGraph(), topoGraphSchemaVersion: '1.0' },
+        null,
+        2
+      )}\n`
+    );
+
+    await expect(readTopoGraph({ dir: tempDir })).rejects.toThrow(
+      'regenerate with `trails topo compile`'
+    );
+  });
+});
+
+describe('isTopoArtifactRegenerationError', () => {
+  test('recognizes unsupported topo artifact read errors', async () => {
+    await Bun.write(join(tempDir, 'topo.lock'), '{}\n');
+    const topoError = await captureError(() => readTopoGraph({ dir: tempDir }));
+
+    await Bun.write(join(tempDir, 'trails.lock'), '{}\n');
+    const lockError = await captureError(() =>
+      readLockManifest({ dir: tempDir })
+    );
+
+    expect(isTopoArtifactRegenerationError(topoError)).toBe(true);
+    expect(isTopoArtifactRegenerationError(lockError)).toBe(true);
+    expect(isTopoArtifactRegenerationError(new Error('different'))).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
-// Surface Lock tests
+// Lock manifest tests
 // ---------------------------------------------------------------------------
 
-describe('writeSurfaceLock / readSurfaceLock', () => {
-  test('writes a single line with the hash', async () => {
-    const hash = 'abc123def456'.repeat(4);
-    const filePath = await writeSurfaceLock(hash, { dir: tempDir });
-
-    expect(filePath).toBe(join(tempDir, 'trails.lock'));
-
-    const content = await readFile(filePath, 'utf8');
-    expect(content.trim()).toBe(hash);
-    // Single line (content is hash + newline)
-    expect(content).toBe(`${hash}\n`);
-  });
-
-  test('writes and reads structured JSON locks', async () => {
+describe('writeLockManifest / readLockManifest', () => {
+  test('writes and reads v3 manifest JSON', async () => {
     const hash = 'deadbeef'.repeat(8);
-    const filePath = await writeSurfaceLock(makeStructuredLock(hash), {
+    const manifest = makeLockManifest(hash);
+    const filePath = await writeLockManifest(manifest, {
       dir: tempDir,
     });
 
     expect(filePath).toBe(join(tempDir, 'trails.lock'));
 
     const parsed = await readParsedLock(filePath);
-    expect(parsed.hash).toBe(hash);
-    expect(parsed.version).toBe('2');
+    expect(parsed.version).toBe(3);
+    expect(parsed.artifacts).toEqual([
+      { path: 'topo.lock', role: 'topo', sha256: hash },
+    ]);
 
-    const result = await readSurfaceLockData({ dir: tempDir });
+    const result = await readLockManifest({ dir: tempDir });
 
-    expect(result).toEqual(makeStructuredLock(hash));
-
-    const legacyResult = await readSurfaceLock({ dir: tempDir });
-    expect(legacyResult).toBe(hash);
+    expect(result).toEqual(manifest);
   });
 
-  test('normalizes legacy structured JSON locks with numeric versions', async () => {
+  test('rejects legacy structured JSON locks', async () => {
     const hash = 'facefeed'.repeat(8);
     await Bun.write(
       join(tempDir, 'trails.lock'),
       `${JSON.stringify({ hash, version: 1 }, null, 2)}\n`
     );
 
-    const data = await readSurfaceLockData({ dir: tempDir });
-    expect(data).toEqual({ hash });
+    await expect(readLockManifest({ dir: tempDir })).rejects.toThrow(
+      'regenerate with `trails topo compile`'
+    );
+  });
 
-    const result = await readSurfaceLock({ dir: tempDir });
-    expect(result).toBe(hash);
+  test('rejects v3 manifests with unknown top-level fields', async () => {
+    const hash = 'facefeed'.repeat(8);
+    await Bun.write(
+      join(tempDir, 'trails.lock'),
+      `${JSON.stringify(
+        { ...makeLockManifest(hash), generatedAt: '2026-05-11T12:00:00.000Z' },
+        null,
+        2
+      )}\n`
+    );
+
+    await expect(readLockManifest({ dir: tempDir })).rejects.toThrow(
+      'regenerate with `trails topo compile`'
+    );
+  });
+
+  test('rejects v3 artifacts with unknown fields', async () => {
+    const hash = 'facefeed'.repeat(8);
+    await Bun.write(
+      join(tempDir, 'trails.lock'),
+      `${JSON.stringify(
+        {
+          ...makeLockManifest(hash),
+          artifacts: [
+            {
+              generatedAt: '2026-05-11T12:00:00.000Z',
+              path: 'topo.lock',
+              role: 'topo',
+              sha256: hash,
+            },
+          ],
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    await expect(readLockManifest({ dir: tempDir })).rejects.toThrow(
+      'regenerate with `trails topo compile`'
+    );
+  });
+
+  test('rejects v3 artifacts with malformed sha256 values', async () => {
+    await Bun.write(
+      join(tempDir, 'trails.lock'),
+      `${JSON.stringify(makeLockManifest('not-a-sha'), null, 2)}\n`
+    );
+
+    await expect(readLockManifest({ dir: tempDir })).rejects.toThrow(
+      'regenerate with `trails topo compile`'
+    );
+  });
+
+  test('rejects legacy single-line hash locks', async () => {
+    await Bun.write(join(tempDir, 'trails.lock'), `${'a'.repeat(64)}\n`);
+
+    await expect(readLockManifest({ dir: tempDir })).rejects.toThrow(
+      'regenerate with `trails topo compile`'
+    );
   });
 
   test('returns null for missing file', async () => {
-    const result = await readSurfaceLock({
+    const result = await readLockManifest({
       dir: join(tempDir, 'nonexistent'),
     });
     expect(result).toBeNull();
@@ -169,7 +275,7 @@ describe('default directory', () => {
     const customDir = join(tempDir, 'custom-trails');
     const filePath = await writeTopoGraph(map, { dir: customDir });
 
-    expect(filePath).toBe(join(customDir, '_surface.json'));
+    expect(filePath).toBe(join(customDir, 'topo.lock'));
 
     const result = await readTopoGraph({ dir: customDir });
     expect(result).toEqual(map);
@@ -177,13 +283,14 @@ describe('default directory', () => {
 
   test('custom directory option works for lock files', async () => {
     const customDir = join(tempDir, 'custom-lock-dir');
-    const hash = 'a1b2c3d4e5f6'.repeat(5);
-    const filePath = await writeSurfaceLock(hash, { dir: customDir });
+    const hash = 'a1b2c3d4e5f67890'.repeat(4);
+    const manifest = makeLockManifest(hash);
+    const filePath = await writeLockManifest(manifest, { dir: customDir });
 
     expect(filePath).toBe(join(customDir, 'trails.lock'));
 
-    const result = await readSurfaceLock({ dir: customDir });
-    expect(result).toBe(hash);
+    const result = await readLockManifest({ dir: customDir });
+    expect(result).toEqual(manifest);
   });
 });
 
@@ -194,7 +301,7 @@ describe('default directory', () => {
 describe('readWorkspaceLock', () => {
   test('returns null for a single-app structured lock without workspace metadata', async () => {
     const hash = 'cafebabe'.repeat(8);
-    await writeSurfaceLock(makeStructuredLock(hash), { dir: tempDir });
+    await writeLockManifest(makeLockManifest(hash), { dir: tempDir });
 
     const result = await readWorkspaceLock({ dir: tempDir });
     expect(result).toBeNull();
@@ -214,36 +321,26 @@ describe('readWorkspaceLock', () => {
         trailId: 'b.trail',
       },
     } as const;
-    const filePath = await writeSurfaceLock(
-      { hash, workspaceTrails },
+    const filePath = await writeLockManifest(
+      makeLockManifest(hash, { workspaceTrails }),
       { dir: tempDir }
     );
 
     const parsed = await readParsedLock(filePath);
-    expect(parsed.hash).toBe(hash);
-    expect(parsed.version).toBe('2');
+    expect(parsed.version).toBe(3);
     expect(parsed.workspaceTrails).toEqual(workspaceTrails);
 
     const result = await readWorkspaceLock({ dir: tempDir });
     expect(result).toEqual(workspaceTrails);
   });
 
-  test('rejects out-of-band structured lock versions', () => {
-    const hash = '0badf00d'.repeat(8);
-    const result = surfaceLockSchema.safeParse({
-      hash,
-      version: 'banana',
-    });
-
-    expect(result.success).toBe(false);
-  });
-
-  test('returns null for the legacy single-line hash file', async () => {
+  test('rejects the legacy single-line hash file', async () => {
     const hash = 'aaaaaaaa'.repeat(8);
-    await writeSurfaceLock(hash, { dir: tempDir });
+    await Bun.write(join(tempDir, 'trails.lock'), `${hash}\n`);
 
-    const result = await readWorkspaceLock({ dir: tempDir });
-    expect(result).toBeNull();
+    await expect(readWorkspaceLock({ dir: tempDir })).rejects.toThrow(
+      'regenerate with `trails topo compile`'
+    );
   });
 
   test('returns null when the lock file is missing', async () => {

--- a/packages/topographer/src/__tests__/topo-store.test.ts
+++ b/packages/topographer/src/__tests__/topo-store.test.ts
@@ -20,6 +20,7 @@ import {
 import type { Layer } from '@ontrails/core';
 
 import { __topoStoreMigrationStats, createTopoStore } from '../topo-store.js';
+import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
 import {
   ensureTopoSnapshotSchema,
   pinTopoSnapshot,
@@ -633,7 +634,7 @@ describe('topo store projection', () => {
       expect(surfaceMap).toMatchObject({
         entries: expect.any(Array),
         generatedAt: '2026-04-03T12:00:00.000Z',
-        version: '1.0',
+        topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
       });
       expect(Array.isArray(entries)).toBe(true);
       expect(
@@ -678,34 +679,18 @@ describe('topo store projection', () => {
       expect(listEntry?.permit).toEqual({ scopes: ['entity:read'] });
 
       const lock = JSON.parse(stored.lockContent);
-      const lockTrail = lock.apps['projection-app'].trails['entity.add'];
       expect(lock).toMatchObject({
-        apps: {
-          'projection-app': {
-            contours: {
-              entity: expect.objectContaining({
-                identity: 'id',
-              }),
-            },
-            resources: expect.any(Object),
-            signals: expect.any(Object),
-            trails: expect.any(Object),
-          },
-        },
-        generatedAt: '2026-04-03T12:00:00.000Z',
-        hash: stored.surfaceHash,
-        version: 1,
+        artifacts: [
+          { path: 'topo.lock', role: 'topo', sha256: stored.surfaceHash },
+        ],
+        scope: { app: 'projection-app' },
+        summary: { contours: 1, resources: 2, signals: 1, trails: 2 },
+        version: 3,
       });
-      expect(lockTrail.examples?.[0]?.signals).toEqual([
-        {
-          payloadMatch: { id: 'ada' },
-          signalId: 'entity.added',
-        },
-      ]);
     });
   });
 
-  test('stored surface map and lock include trail signal and layer contract fields', () => {
+  test('stored TopoGraph includes trail signal and layer contract fields', () => {
     withProjectionDb((db) => {
       const topoPolicy: Layer = {
         input: z.object({ tenant: z.string() }),
@@ -790,12 +775,14 @@ describe('topo store projection', () => {
         },
       ]);
 
-      const lock = JSON.parse(stored.lockContent);
-      const lockTrail =
-        lock.apps['contract-export-app'].trails['entity.process'];
-      expect(lockTrail.fires).toEqual(['entity.created']);
-      expect(lockTrail.on).toEqual(['entity.updated']);
-      expect(lockTrail.layers).toEqual(entry?.layers);
+      expect(JSON.parse(stored.lockContent)).toMatchObject({
+        artifacts: [
+          { path: 'topo.lock', role: 'topo', sha256: stored.surfaceHash },
+        ],
+        scope: { app: 'contract-export-app' },
+        summary: { contours: 0, resources: 0, signals: 2, trails: 1 },
+        version: 3,
+      });
     });
   });
 
@@ -1042,27 +1029,22 @@ describe('topo store projection', () => {
         },
       ]);
 
-      const lock = JSON.parse(
-        requireStoredExport(db, snapshot.id).lockContent
+      const topoGraph = JSON.parse(
+        requireStoredExport(db, snapshot.id).surfaceMapJson
       ) as {
-        apps: Record<
-          string,
-          {
-            activationGraph: {
-              edges: readonly Record<string, unknown>[];
-              sourceKeys: readonly string[];
-            };
-            activationSources: Record<string, Record<string, unknown>>;
-            signals: Record<string, Record<string, unknown>>;
-            trails: Record<string, Record<string, unknown>>;
-          }
-        >;
+        activationGraph: {
+          edges: readonly Record<string, unknown>[];
+          sourceKeys: readonly string[];
+        };
+        activationSources: Record<string, Record<string, unknown>>;
+        entries: readonly Record<string, unknown>[];
       };
-      const createdLockEntry =
-        lock.apps['signal-edges-app']?.signals['entity.created'];
-      const indexLockEntry =
-        lock.apps['signal-edges-app']?.trails['entity.index'];
-      const appLock = lock.apps['signal-edges-app'];
+      const createdLockEntry = topoGraph.entries.find(
+        (entry) => entry.id === 'entity.created'
+      );
+      const indexLockEntry = topoGraph.entries.find(
+        (entry) => entry.id === 'entity.index'
+      );
       expect(createdLockEntry).toMatchObject({
         consumers: ['entity.audit', 'entity.index'],
         diagnostics: expect.objectContaining({
@@ -1079,7 +1061,7 @@ describe('topo store projection', () => {
         producers: ['entity.create'],
       });
       expect(createdLockEntry?.payload).toEqual(createdLockEntry?.input);
-      expect(appLock?.activationSources).toMatchObject({
+      expect(topoGraph.activationSources).toMatchObject({
         'schedule:schedule.entity.audit': {
           cron: '0 2 * * *',
           id: 'schedule.entity.audit',
@@ -1095,7 +1077,7 @@ describe('topo store projection', () => {
           kind: 'signal',
         },
       });
-      expect(appLock?.activationGraph).toMatchObject({
+      expect(topoGraph.activationGraph).toMatchObject({
         edgeCount: 4,
         sourceCount: 3,
         sourceKeys: [
@@ -1142,20 +1124,12 @@ describe('topo store projection', () => {
       const snapshot = unwrap(
         createTopoSnapshot(db, topo('webhook-app', { receiver }))
       );
-      const lock = JSON.parse(
-        requireStoredExport(db, snapshot.id).lockContent
+      const topoGraph = JSON.parse(
+        requireStoredExport(db, snapshot.id).surfaceMapJson
       ) as {
-        apps: Record<
-          string,
-          {
-            activationSources: Record<string, Record<string, unknown>>;
-          }
-        >;
+        activationSources: Record<string, Record<string, unknown>>;
       };
-      const source =
-        lock.apps['webhook-app']?.activationSources[
-          'webhook:webhook.user.upsert'
-        ];
+      const source = topoGraph.activationSources['webhook:webhook.user.upsert'];
 
       expect(source).toMatchObject({
         hasParse: true,

--- a/packages/topographer/src/__tests__/workspace-topos.test.ts
+++ b/packages/topographer/src/__tests__/workspace-topos.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { topo } from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 
-import { writeSurfaceLock } from '../io.js';
+import { writeLockManifest } from '../io.js';
 import { buildWorkspaceTrailIndex } from '../workspace-topos.js';
 import type { WorkspaceTopoLoader } from '../workspace-topos.js';
 
@@ -393,9 +393,18 @@ describe('buildWorkspaceTrailIndex (lockfile path)', () => {
     const registry = new Map(fixtures.map((f) => [f.name, f]));
     await writeWorkspace(workspaceRoot, fixtures);
 
-    await writeSurfaceLock(
+    await writeLockManifest(
       {
-        hash: 'deadbeef'.repeat(8),
+        artifacts: [
+          {
+            path: 'topo.lock',
+            role: 'topo',
+            sha256: 'deadbeef'.repeat(8),
+          },
+        ],
+        scope: { workspace: 'test-workspace' },
+        summary: { contours: 0, resources: 0, signals: 0, trails: 1 },
+        version: 3,
         workspaceTrails: {
           'lock.entry': {
             appName: 'lock-app',
@@ -442,9 +451,18 @@ describe('buildWorkspaceTrailIndex (lockfile path)', () => {
     const registry = new Map(fixtures.map((f) => [f.name, f]));
     await writeWorkspace(workspaceRoot, fixtures);
 
-    await writeSurfaceLock(
+    await writeLockManifest(
       {
-        hash: 'cafebabe'.repeat(8),
+        artifacts: [
+          {
+            path: 'topo.lock',
+            role: 'topo',
+            sha256: 'cafebabe'.repeat(8),
+          },
+        ],
+        scope: { workspace: 'test-workspace' },
+        summary: { contours: 0, resources: 0, signals: 0, trails: 1 },
+        version: 3,
         workspaceTrails: {
           'relative.lock': {
             appName: 'lock-app',

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -25,6 +25,7 @@ import type {
 } from '@ontrails/core';
 
 import { addPermitRequirement } from './permit.js';
+import { TOPO_GRAPH_SCHEMA_VERSION } from './types.js';
 import type {
   JsonSchema,
   TopoGraph,
@@ -689,6 +690,6 @@ export const deriveTopoGraph = (topo: Topo): TopoGraph => {
     ),
     entries: sorted,
     generatedAt: new Date().toISOString(),
-    version: '1.0',
+    topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
   };
 };

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -12,13 +12,16 @@ export { deriveTopoGraphDiff } from './diff.js';
 export {
   writeTopoGraph,
   readTopoGraph,
-  writeSurfaceLock,
-  readSurfaceLockData,
-  readSurfaceLock,
+  isTopoArtifactRegenerationError,
+  writeLockManifest,
+  readLockManifest,
   readWorkspaceLock,
 } from './io.js';
 export {
-  surfaceLockSchema,
+  lockManifestArtifactSchema,
+  lockManifestSchema,
+  lockManifestSummarySchema,
+  TOPO_GRAPH_SCHEMA_VERSION,
   workspaceTrailEntrySchema,
   workspaceTrailIndexSchema,
 } from './types.js';
@@ -48,7 +51,9 @@ export type {
   TopoGraphFieldOverride,
   TopoGraphFieldOverrideKey,
   TopoGraphLayerReference,
-  SurfaceLock,
+  LockManifest,
+  LockManifestArtifact,
+  LockManifestSummary,
   WorkspaceTrailEntry,
   WorkspaceTrailIndex,
   DiffEntry,

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -25,6 +25,8 @@ import type {
 } from '@ontrails/core';
 
 import { addPermitRequirement } from '../permit.js';
+import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
+import type { LockManifest } from '../types.js';
 import type {
   CreateTopoSnapshotInput,
   TopoSnapshot,
@@ -46,7 +48,7 @@ type TopoGraphRecord = Readonly<{
   >;
   readonly entries: readonly TopoGraphEntryRecord[];
   readonly generatedAt: string;
-  readonly version: '1.0';
+  readonly topoGraphSchemaVersion: typeof TOPO_GRAPH_SCHEMA_VERSION;
 }>;
 
 type JsonRecord = Readonly<Record<string, unknown>>;
@@ -1236,7 +1238,7 @@ const buildTopoGraph = (
     ),
     entries,
     generatedAt,
-    version: '1.0',
+    topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
   };
 };
 
@@ -1245,43 +1247,27 @@ const hashTopoGraphRecord = (surfaceMap: TopoGraphRecord): string => {
   return hashValue(rest);
 };
 
-const entryPayload = (
-  entry: TopoGraphEntryRecord
-): Readonly<Record<string, unknown>> => {
-  const { id: _unusedId, kind: _unusedKind, ...rest } = entry;
-  return sortKeys(rest);
-};
-
-const entriesForKind = (
+const countEntriesForKind = (
   entries: readonly TopoGraphEntryRecord[],
   kind: TopoGraphEntryRecord['kind']
-): Readonly<Record<string, Readonly<Record<string, unknown>>>> =>
-  Object.fromEntries(
-    entries
-      .filter((entry) => entry.kind === kind)
-      .map((entry) => [entry.id, entryPayload(entry)])
-  );
+): number => entries.filter((entry) => entry.kind === kind).length;
 
-const buildSerializedLock = (
+const buildLockManifest = (
   hash: string,
   topo: Topo,
   surfaceMap: TopoGraphRecord
-): Readonly<Record<string, unknown>> =>
+): LockManifest =>
   sortKeys({
-    apps: sortKeys({
-      [topo.name]: sortKeys({
-        activationGraph: surfaceMap.activationGraph,
-        activationSources: surfaceMap.activationSources,
-        contours: entriesForKind(surfaceMap.entries, 'contour'),
-        resources: entriesForKind(surfaceMap.entries, 'resource'),
-        signals: entriesForKind(surfaceMap.entries, 'signal'),
-        trails: entriesForKind(surfaceMap.entries, 'trail'),
-      }),
-    }),
-    generatedAt: surfaceMap.generatedAt,
-    hash,
-    version: 1,
-  });
+    artifacts: [{ path: 'topo.lock', role: 'topo', sha256: hash }],
+    scope: { app: topo.name },
+    summary: {
+      contours: countEntriesForKind(surfaceMap.entries, 'contour'),
+      resources: countEntriesForKind(surfaceMap.entries, 'resource'),
+      signals: countEntriesForKind(surfaceMap.entries, 'signal'),
+      trails: countEntriesForKind(surfaceMap.entries, 'trail'),
+    },
+    version: 3,
+  }) as LockManifest;
 
 const buildStoredTopoExport = (
   db: Database,
@@ -1311,7 +1297,7 @@ const buildStoredTopoExport = (
   );
   const surfaceHash = hashTopoGraphRecord(surfaceMap);
   const serializedLock = `${JSON.stringify(
-    buildSerializedLock(surfaceHash, topo, surfaceMap),
+    buildLockManifest(surfaceHash, topo, surfaceMap),
     null,
     2
   )}\n`;

--- a/packages/topographer/src/io.ts
+++ b/packages/topographer/src/io.ts
@@ -6,21 +6,32 @@ import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type {
+  LockManifest,
   ReadOptions,
-  SurfaceLock,
   TopoGraph,
   WorkspaceTrailIndex,
   WriteOptions,
 } from './types.js';
-import { surfaceLockSchema } from './types.js';
+import { lockManifestSchema, topoGraphSchema } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const DEFAULT_DIR = '.trails';
-const TOPO_GRAPH_FILE = '_surface.json';
-const SURFACE_LOCK_FILE = 'trails.lock';
+const LOCK_MANIFEST_FILE = 'trails.lock';
+const TOPO_GRAPH_FILE = 'topo.lock';
+const REGENERATE_LOCK_MESSAGE =
+  'Unsupported trails.lock format; regenerate with `trails topo compile`.';
+const REGENERATE_TOPO_GRAPH_MESSAGE =
+  'Unsupported topo.lock format; regenerate with `trails topo compile`.';
+
+export const isTopoArtifactRegenerationError = (
+  error: unknown
+): error is Error =>
+  error instanceof Error &&
+  (error.message.includes(REGENERATE_LOCK_MESSAGE) ||
+    error.message.includes(REGENERATE_TOPO_GRAPH_MESSAGE));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -49,33 +60,42 @@ const readTextIfExists = async (filePath: string): Promise<string | null> => {
   }
 };
 
-const parseLegacyStructuredLock = (value: unknown): SurfaceLock | null => {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    return null;
+const parseJson = (
+  content: string,
+  fileName: string,
+  regenerateMessage: string
+): unknown => {
+  try {
+    return JSON.parse(content) as unknown;
+  } catch {
+    throw new Error(`Invalid JSON in ${fileName}. ${regenerateMessage}`);
   }
-  const { hash } = value as { readonly hash?: unknown };
-  return typeof hash === 'string' ? { hash: hash.trim() } : null;
 };
 
-const parseSurfaceLock = (content: string): SurfaceLock => {
-  try {
-    const parsed: unknown = JSON.parse(content);
-    if (typeof parsed === 'string') {
-      return { hash: parsed.trim() };
-    }
-    const result = surfaceLockSchema.safeParse(parsed);
-    if (result.success) {
-      return result.data;
-    }
-    const legacyStructuredLock = parseLegacyStructuredLock(parsed);
-    if (legacyStructuredLock !== null) {
-      return legacyStructuredLock;
-    }
-  } catch {
-    // Fall through to the legacy hash-line format.
+const parseLockManifest = (content: string): LockManifest => {
+  const parsed = parseJson(
+    content,
+    LOCK_MANIFEST_FILE,
+    REGENERATE_LOCK_MESSAGE
+  );
+  const result = lockManifestSchema.safeParse(parsed);
+  if (result.success) {
+    return result.data;
   }
+  throw new Error(REGENERATE_LOCK_MESSAGE);
+};
 
-  return { hash: content.trim() };
+const parseTopoGraph = (content: string): TopoGraph => {
+  const parsed = parseJson(
+    content,
+    TOPO_GRAPH_FILE,
+    REGENERATE_TOPO_GRAPH_MESSAGE
+  );
+  const result = topoGraphSchema.safeParse(parsed);
+  if (result.success) {
+    return result.data as TopoGraph;
+  }
+  throw new Error(REGENERATE_TOPO_GRAPH_MESSAGE);
 };
 
 // ---------------------------------------------------------------------------
@@ -83,7 +103,7 @@ const parseSurfaceLock = (content: string): SurfaceLock => {
 // ---------------------------------------------------------------------------
 
 /**
- * Write a topo graph to `<dir>/_surface.json`.
+ * Write a topo graph to `<dir>/topo.lock`.
  *
  * Creates the directory if it doesn't exist. Returns the file path.
  */
@@ -100,94 +120,55 @@ export const writeTopoGraph = async (
 };
 
 /**
- * Read a topo graph from `<dir>/_surface.json`.
+ * Read a topo graph from `<dir>/topo.lock`.
  */
 export const readTopoGraph = async (
   options?: ReadOptions
 ): Promise<TopoGraph | null> => {
   const dir = resolveDir(options);
   const content = await readTextIfExists(join(dir, TOPO_GRAPH_FILE));
-  return content ? (JSON.parse(content) as TopoGraph) : null;
+  return content ? parseTopoGraph(content) : null;
 };
 
 // ---------------------------------------------------------------------------
-// Surface Lock
+// Lock Manifest
 // ---------------------------------------------------------------------------
 
 /**
- * Stamp a structured lock with the current lockfile version.
- */
-const versionStampLock = (lock: SurfaceLock): SurfaceLock =>
-  surfaceLockSchema.parse({ ...lock, version: '2' });
-
-/**
- * Write a committed lock to `<dir>/trails.lock`.
+ * Write a lock v3 manifest to `<dir>/trails.lock`.
  *
- * String input preserves the legacy single-line hash format. Structured input
- * is serialized as JSON. Creates the directory if it doesn't exist.
- *
- * @remarks
- * Structured locks are validated with {@link surfaceLockSchema} and stamped
- * with the current `version: '2'` envelope before serialization.
+ * Creates the directory if it doesn't exist. Returns the file path.
  */
-export const writeSurfaceLock = async (
-  lock: string | SurfaceLock,
+export const writeLockManifest = async (
+  lockManifest: LockManifest,
   options?: WriteOptions
 ): Promise<string> => {
   const dir = resolveDir(options);
   await ensureDir(dir);
-  const filePath = join(dir, SURFACE_LOCK_FILE);
-
-  if (typeof lock === 'string') {
-    await Bun.write(filePath, `${lock}\n`);
-    return filePath;
-  }
-
-  const stamped = versionStampLock(lock);
-  await Bun.write(filePath, `${JSON.stringify(stamped, null, 2)}\n`);
+  const filePath = join(dir, LOCK_MANIFEST_FILE);
+  const parsed = lockManifestSchema.parse(lockManifest);
+  await Bun.write(filePath, `${JSON.stringify(parsed, null, 2)}\n`);
   return filePath;
 };
 
 /**
- * Read the committed lock from `<dir>/trails.lock`.
- *
- * Structured JSON locks are normalized to expose their committed hash while
- * preserving additional metadata.
+ * Read a lock v3 manifest from `<dir>/trails.lock`.
  */
-export const readSurfaceLockData = async (
+export const readLockManifest = async (
   options?: ReadOptions
-): Promise<SurfaceLock | null> => {
+): Promise<LockManifest | null> => {
   const dir = resolveDir(options);
-  const content = await readTextIfExists(join(dir, SURFACE_LOCK_FILE));
-  return content ? parseSurfaceLock(content) : null;
+  const content = await readTextIfExists(join(dir, LOCK_MANIFEST_FILE));
+  return content ? parseLockManifest(content) : null;
 };
 
 /**
- * Read the committed lock hash from `<dir>/trails.lock`.
- */
-export const readSurfaceLock = async (
-  options?: ReadOptions
-): Promise<string | null> => {
-  const lock = await readSurfaceLockData(options);
-  return lock?.hash ?? null;
-};
-
-/**
- * Read the workspace trail-id index from `<dir>/trails.lock`.
- *
- * Returns the workspace trail index when the lock is a structured
- * JSON document carrying `workspaceTrails`, and `null` for legacy single-line
- * hash files, hash-only structured locks, or missing files.
- *
- * @remarks
- * This is the workspace-wide catalog consumed by `trails run <id>` to resolve
- * a trail to its owning app without scanning sources. Callers that need the
- * raw lock envelope (hash, version, etc.) should use {@link readSurfaceLockData}.
+ * Read the workspace trail-id index from the current lock manifest.
  */
 export const readWorkspaceLock = async (
   options?: ReadOptions
 ): Promise<WorkspaceTrailIndex | null> => {
-  const lock = await readSurfaceLockData(options);
+  const lock = await readLockManifest(options);
   if (lock === null) {
     return null;
   }

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -8,6 +8,8 @@ import type {
 } from '@ontrails/core';
 import { z } from 'zod';
 
+export const TOPO_GRAPH_SCHEMA_VERSION = 1;
+
 export type TopoGraphExample = StructuredSignalExample | StructuredTrailExample;
 
 // ---------------------------------------------------------------------------
@@ -139,7 +141,7 @@ export interface TopoGraphEntry {
 }
 
 export interface TopoGraph {
-  readonly version: string;
+  readonly topoGraphSchemaVersion: typeof TOPO_GRAPH_SCHEMA_VERSION;
   readonly activationGraph: TopoGraphActivationGraph;
   readonly activationSources: Readonly<
     Record<string, TopoGraphActivationSource>
@@ -149,7 +151,7 @@ export interface TopoGraph {
 }
 
 // ---------------------------------------------------------------------------
-// Surface Lock
+// Lock Manifest
 // ---------------------------------------------------------------------------
 
 /** Workspace-owned trail entry serialized into a workspace lock. */
@@ -168,7 +170,7 @@ export type WorkspaceTrailEntry = z.infer<typeof workspaceTrailEntrySchema>;
  * that owns it plus the app module path used by consumers that need to load
  * the owning topo without re-walking workspace manifests.
  *
- * @see SurfaceLock for the lock envelope that may carry this index.
+ * @see LockManifest for the lock envelope that may carry this index.
  */
 export const workspaceTrailIndexSchema = z.record(
   z.string(),
@@ -177,26 +179,66 @@ export const workspaceTrailIndexSchema = z.record(
 
 export type WorkspaceTrailIndex = z.infer<typeof workspaceTrailIndexSchema>;
 
-/**
- * Normalized lock data read from `trails.lock`.
- *
- * The file may be stored as structured JSON or legacy single-line text.
- * The normalized shape always exposes the committed hash and preserves any
- * extra structured metadata.
- *
- * @remarks
- * **Migration story.** Historical locks may be a single line containing a hash
- * or a JSON string hash. Structured lock envelopes authored by Topographer use
- * `version: '2'` and parse through {@link surfaceLockSchema}. Future lockfile
- * versions should update this schema and add an explicit migration path.
- */
-export const surfaceLockSchema = z.object({
-  hash: z.string(),
-  version: z.literal('2').optional(),
-  workspaceTrails: workspaceTrailIndexSchema.optional(),
-});
+export const topoGraphSchema = z
+  .object({
+    activationGraph: z
+      .object({
+        edgeCount: z.number().int().nonnegative(),
+        edges: z.array(z.unknown()),
+        sourceCount: z.number().int().nonnegative(),
+        sourceKeys: z.array(z.string()),
+        trailIds: z.array(z.string()),
+      })
+      .strict(),
+    activationSources: z.record(z.string(), z.unknown()),
+    entries: z.array(
+      z
+        .object({
+          exampleCount: z.number().int().nonnegative(),
+          id: z.string(),
+          kind: z.enum(['contour', 'trail', 'signal', 'resource']),
+          surfaces: z.array(z.string()),
+        })
+        .passthrough()
+    ),
+    generatedAt: z.string(),
+    topoGraphSchemaVersion: z.literal(TOPO_GRAPH_SCHEMA_VERSION),
+  })
+  .strict();
 
-export type SurfaceLock = z.infer<typeof surfaceLockSchema>;
+/**
+ * Lock v3 manifest artifact pointer.
+ */
+export const lockManifestArtifactSchema = z
+  .object({
+    path: z.string(),
+    role: z.literal('topo'),
+    sha256: z.string().regex(/^[0-9a-f]{64}$/),
+  })
+  .strict();
+
+export const lockManifestSummarySchema = z
+  .object({
+    contours: z.number().int().nonnegative(),
+    resources: z.number().int().nonnegative(),
+    signals: z.number().int().nonnegative(),
+    trails: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const lockManifestSchema = z
+  .object({
+    artifacts: z.array(lockManifestArtifactSchema).min(1),
+    scope: z.record(z.string(), z.string()),
+    summary: lockManifestSummarySchema,
+    version: z.literal(3),
+    workspaceTrails: workspaceTrailIndexSchema.optional(),
+  })
+  .strict();
+
+export type LockManifestArtifact = z.infer<typeof lockManifestArtifactSchema>;
+export type LockManifestSummary = z.infer<typeof lockManifestSummarySchema>;
+export type LockManifest = z.infer<typeof lockManifestSchema>;
 
 // ---------------------------------------------------------------------------
 // Diff

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -13,7 +13,7 @@ import {
 import {
   deriveTopoGraph,
   deriveTopoGraphHash,
-  writeSurfaceLock,
+  writeLockManifest,
 } from '@ontrails/topographer';
 import { z } from 'zod';
 
@@ -48,6 +48,17 @@ const makeTempDir = (): string => {
   mkdirSync(dir, { recursive: true });
   return dir;
 };
+
+const writeManifest = (rootDir: string, hash: string): Promise<string> =>
+  writeLockManifest(
+    {
+      artifacts: [{ path: 'topo.lock', role: 'topo', sha256: hash }],
+      scope: { app: 'fixture.primary' },
+      summary: { contours: 0, resources: 0, signals: 0, trails: 1 },
+      version: 3,
+    },
+    { dir: deriveTrailsDir({ rootDir }) }
+  );
 
 const buildFixtureTopo = (name = 'fixture') => {
   const echo = trail('fixture.echo', {
@@ -609,9 +620,7 @@ export const second = contour('second', {
       });
       const admin = topo('fixture.admin', { adminTrail });
       const primaryHash = deriveTopoGraphHash(deriveTopoGraph(primary));
-      await writeSurfaceLock(primaryHash, {
-        dir: deriveTrailsDir({ rootDir: dir }),
-      });
+      await writeManifest(dir, primaryHash);
 
       const report = await runWarden({
         depth: 'all',

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -14,7 +14,7 @@ import {
   createTopoStore,
   deriveTopoGraphHash,
   deriveTopoGraph,
-  writeSurfaceLock,
+  writeLockManifest,
 } from '@ontrails/topographer';
 import { createStoredTopoSnapshot } from '@ontrails/topographer/backend-support';
 import { z } from 'zod';
@@ -41,6 +41,17 @@ const committedLockDir = (dir: string): string => {
   mkdirSync(trailsDir, { recursive: true });
   return trailsDir;
 };
+
+const writeManifest = (dir: string, hash: string): Promise<string> =>
+  writeLockManifest(
+    {
+      artifacts: [{ path: 'topo.lock', role: 'topo', sha256: hash }],
+      scope: { app: 'test-app' },
+      summary: { contours: 0, resources: 0, signals: 0, trails: 1 },
+      version: 3,
+    },
+    { dir: committedLockDir(dir) }
+  );
 
 const seedSavedTopo = (dir: string): string | undefined => {
   const db = openWriteTrailsDb({ rootDir: dir });
@@ -95,10 +106,7 @@ describe('checkDrift', () => {
     try {
       const tp = makeTopo();
       const hash = deriveTopoGraphHash(deriveTopoGraph(tp));
-      await writeSurfaceLock(
-        { hash, version: 1 },
-        { dir: committedLockDir(dir) }
-      );
+      await writeManifest(dir, hash);
 
       const result = await checkDrift(dir, tp);
       expect(result.stale).toBe(false);
@@ -112,14 +120,32 @@ describe('checkDrift', () => {
   test('returns stale: true when lock does not match', async () => {
     const dir = createTempDir();
     try {
+      const outdatedHash = '0'.repeat(64);
+      await writeManifest(dir, outdatedHash);
+
+      const result = await checkDrift(dir, makeTopo());
+      expect(result.stale).toBe(true);
+      expect(result.committedHash).toBe(outdatedHash);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('blocks drift calculation for malformed legacy lock manifests', async () => {
+    const dir = createTempDir();
+    try {
       writeFileSync(
         join(committedLockDir(dir), 'trails.lock'),
-        'outdated-hash\n'
+        `${JSON.stringify({ hash: '1'.repeat(64), version: 2 }, null, 2)}\n`
       );
 
       const result = await checkDrift(dir, makeTopo());
       expect(result.stale).toBe(true);
-      expect(result.committedHash).toBe('outdated-hash');
+      expect(result.blockedReason).toContain(
+        'regenerate with `trails topo compile`'
+      );
+      expect(result.currentHash).toBe('blocked');
+      expect(result.committedHash).toBeNull();
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -1,10 +1,9 @@
 /**
  * Topo lock drift detection.
  *
- * Compares the committed `trails.lock` hash against a freshly generated
- * TopoGraph hash to detect when the trail topology has changed without
- * updating the lock file. The committed lock may be structured JSON or the
- * legacy single-line hash format.
+ * Compares the `topo.lock` artifact hash listed in `trails.lock` against a
+ * freshly generated TopoGraph hash to detect when the trail topology has
+ * changed without updating the artifact family.
  */
 
 import { existsSync, statSync } from 'node:fs';
@@ -19,7 +18,8 @@ import {
   createTopoStore,
   deriveTopoGraph,
   deriveTopoGraphHash,
-  readSurfaceLockData,
+  isTopoArtifactRegenerationError,
+  readLockManifest,
 } from '@ontrails/topographer';
 
 /**
@@ -47,10 +47,13 @@ export const checkDrift = async (
 ): Promise<DriftResult> => {
   try {
     const trailsDir = deriveTrailsDir({ rootDir });
-    const committedLock =
+    const lockManifest =
       existsSync(rootDir) && statSync(rootDir).isDirectory()
-        ? await readSurfaceLockData({ dir: trailsDir })
+        ? await readLockManifest({ dir: trailsDir })
         : null;
+    const topoArtifact =
+      lockManifest?.artifacts.find((artifact) => artifact.role === 'topo') ??
+      null;
     // Prefer the stored hash (computed by the export pipeline) to avoid
     // divergence between the schema and store hash pipelines.
     const storedHash = (() => {
@@ -70,15 +73,18 @@ export const checkDrift = async (
         : deriveTopoGraphHash(deriveTopoGraph(topo)));
 
     return {
-      committedHash: committedLock?.hash ?? null,
+      committedHash: topoArtifact?.sha256 ?? null,
       currentHash,
       stale:
-        committedLock !== null &&
+        topoArtifact !== null &&
         currentHash !== 'unknown' &&
-        committedLock.hash !== currentHash,
+        topoArtifact.sha256 !== currentHash,
     };
   } catch (error) {
-    if (!(error instanceof ValidationError)) {
+    if (
+      !(error instanceof ValidationError) &&
+      !isTopoArtifactRegenerationError(error)
+    ) {
       throw error;
     }
 


### PR DESCRIPTION
## Context

With the Topographer API renamed to `TopoGraph`, this branch introduces the two-file lock v3 artifact family that the rest of Stack 1 builds on.

This PR covers TRL-696. The target shape is:

- `.trails/trails.lock` is a compact committed manifest.
- `.trails/topo.lock` is the committed serialized `TopoGraph`.
- Legacy/v2 lock reads fail loudly with guidance to regenerate using `trails topo compile`.

## Changes

- Adds strict lock v3 manifest schemas and I/O for `trails.lock`.
- Adds strict serialized `TopoGraph` schemas and I/O for `topo.lock`.
- Keeps `generatedAt` and `topoGraphSchemaVersion` on `topo.lock`, while `trails.lock` stays compact and omits `generatedAt`.
- Validates lock artifact hashes as 64-character lowercase hex SHA-256 values.
- Updates Topographer docs and tests around derive, diff, hash, topo-store, workspace index, Warden, and CLI read paths.
- Adds a changeset for the new artifact-family I/O.

## Verification

Local verification in this review-feedback pass:

- `bun scripts/adr.ts check`
- `bun test packages/topographer/src/__tests__/io.test.ts packages/warden/src/__tests__/drift.test.ts apps/trails/src/__tests__/topo-dev.test.ts apps/trails/src/__tests__/run-watch.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run format:check`
- `bun run test`
- `bun run build`
- `bun run check`
- `git diff --check`

Remote CI, Greptile, and Graphite mergeability rerun on every push; use the PR check rollup for current remote status.

## Release / Risk

This is a pre-v1 artifact-format break by design. The strict read path is deliberately unforgiving so stale lockfiles do not silently masquerade as resolved topo state.