### PR TITLE
feat: rename topo store exports to topo graph

### DIFF
--- a/.changeset/trl-697-topo-store-topo-graph-export.md
+++ b/.changeset/trl-697-topo-store-topo-graph-export.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/topographer': major
+'@ontrails/trails': patch
+'@ontrails/warden': patch
+---
+
+Rename topo-store export artifacts from surface-era names to TopoGraph names. The `topo_exports` table now stores `topo_graph`, `topo_graph_hash`, and `lock_manifest`, and backend-support export records expose `topoGraphJson`, `topoGraphHash`, and `lockManifestJson`.

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -137,7 +137,7 @@ const readStoredTopoGraph = (
       store.exports.get({ snapshotId: against });
     return stored === undefined
       ? undefined
-      : (JSON.parse(stored.surfaceMapJson) as TopoGraph);
+      : (JSON.parse(stored.topoGraphJson) as TopoGraph);
   } catch (error: unknown) {
     if (error instanceof NotFoundError) {
       return undefined;

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -275,7 +275,7 @@ export const verifyCurrentTopo = async (
   if (currentExport.isErr()) {
     return currentExport;
   }
-  const currentHash = currentExport.value.surfaceHash;
+  const currentHash = currentExport.value.topoGraphHash;
   const topoArtifact = lockManifest.artifacts.find(
     (artifact) => artifact.role === 'topo'
   );

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -88,16 +88,16 @@ const writeStoredExportArtifacts = async (
   trailsDir: string
 ): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'mapPath'>> => {
   const mapPath = await writeTopoGraph(
-    JSON.parse(storedExport.surfaceMapJson) as TopoGraph,
+    JSON.parse(storedExport.topoGraphJson) as TopoGraph,
     { dir: trailsDir }
   );
   const lockPath = await writeLockManifest(
-    JSON.parse(storedExport.lockContent) as LockManifest,
+    JSON.parse(storedExport.lockManifestJson) as LockManifest,
     { dir: trailsDir }
   );
 
   return {
-    hash: storedExport.surfaceHash,
+    hash: storedExport.topoGraphHash,
     lockPath,
     mapPath,
   };

--- a/packages/topographer/src/__tests__/topo-store-read.test.ts
+++ b/packages/topographer/src/__tests__/topo-store-read.test.ts
@@ -412,7 +412,7 @@ describe('read-only topo store', () => {
 
     const exported = store.exports.get({ pin: 'baseline' });
     expect(exported?.snapshot.id).toBe(snapshot.id);
-    expect(exported?.surfaceHash).toHaveLength(64);
+    expect(exported?.topoGraphHash).toHaveLength(64);
 
     const signalDetail = store.signals.get('entity.added', {
       snapshot: { snapshotId: snapshot.id },

--- a/packages/topographer/src/__tests__/topo-store.test.ts
+++ b/packages/topographer/src/__tests__/topo-store.test.ts
@@ -629,9 +629,9 @@ describe('topo store projection', () => {
       expectProjectedFixtureRows(db, snapshot.id);
 
       const stored = requireStoredExport(db, snapshot.id);
-      const surfaceMap = JSON.parse(stored.surfaceMapJson);
-      const { entries } = surfaceMap as { entries?: unknown[] };
-      expect(surfaceMap).toMatchObject({
+      const topoGraph = JSON.parse(stored.topoGraphJson);
+      const { entries } = topoGraph as { entries?: unknown[] };
+      expect(topoGraph).toMatchObject({
         entries: expect.any(Array),
         generatedAt: '2026-04-03T12:00:00.000Z',
         topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
@@ -678,10 +678,10 @@ describe('topo store projection', () => {
       expect(listEntry?.dryRunCapable).toBe(true);
       expect(listEntry?.permit).toEqual({ scopes: ['entity:read'] });
 
-      const lock = JSON.parse(stored.lockContent);
+      const lock = JSON.parse(stored.lockManifestJson);
       expect(lock).toMatchObject({
         artifacts: [
-          { path: 'topo.lock', role: 'topo', sha256: stored.surfaceHash },
+          { path: 'topo.lock', role: 'topo', sha256: stored.topoGraphHash },
         ],
         scope: { app: 'projection-app' },
         summary: { contours: 1, resources: 2, signals: 1, trails: 2 },
@@ -710,6 +710,7 @@ describe('topo store projection', () => {
       });
       const process = trail('entity.process', {
         blaze: () => Result.ok({ ok: true }),
+        fields: { id: { hint: 'Entity id to process' } },
         fires: [created],
         input: z.object({ id: z.string() }),
         layers: [trailAudit],
@@ -734,16 +735,17 @@ describe('topo store projection', () => {
       );
 
       const stored = requireStoredExport(db, snapshot.id);
-      const surfaceMap = JSON.parse(stored.surfaceMapJson) as {
+      const topoGraph = JSON.parse(stored.topoGraphJson) as {
         entries: readonly unknown[];
       };
-      const entry = surfaceMap.entries.find(
+      const entry = topoGraph.entries.find(
         (candidate) =>
           typeof candidate === 'object' &&
           candidate !== null &&
           (candidate as { id?: unknown }).id === 'entity.process'
       ) as
         | {
+            fieldOverrides?: unknown;
             fires?: unknown;
             layers?: readonly {
               readonly input?: { readonly properties?: unknown };
@@ -774,10 +776,17 @@ describe('topo store projection', () => {
           scope: 'trail',
         },
       ]);
+      expect(entry?.fieldOverrides).toEqual([
+        {
+          field: 'id',
+          overrides: ['hint'],
+          provenance: { source: 'trail.fields' },
+        },
+      ]);
 
-      expect(JSON.parse(stored.lockContent)).toMatchObject({
+      expect(JSON.parse(stored.lockManifestJson)).toMatchObject({
         artifacts: [
-          { path: 'topo.lock', role: 'topo', sha256: stored.surfaceHash },
+          { path: 'topo.lock', role: 'topo', sha256: stored.topoGraphHash },
         ],
         scope: { app: 'contract-export-app' },
         summary: { contours: 0, resources: 0, signals: 2, trails: 1 },
@@ -809,8 +818,8 @@ describe('topo store projection', () => {
         'entity.add',
         'entity.list',
       ]);
-      expect(requireStoredExport(db, firstSnapshot.id).surfaceHash).not.toBe(
-        requireStoredExport(db, secondSnapshot.id).surfaceHash
+      expect(requireStoredExport(db, firstSnapshot.id).topoGraphHash).not.toBe(
+        requireStoredExport(db, secondSnapshot.id).topoGraphHash
       );
     });
   });
@@ -1030,7 +1039,7 @@ describe('topo store projection', () => {
       ]);
 
       const topoGraph = JSON.parse(
-        requireStoredExport(db, snapshot.id).surfaceMapJson
+        requireStoredExport(db, snapshot.id).topoGraphJson
       ) as {
         activationGraph: {
           edges: readonly Record<string, unknown>[];
@@ -1125,7 +1134,7 @@ describe('topo store projection', () => {
         createTopoSnapshot(db, topo('webhook-app', { receiver }))
       );
       const topoGraph = JSON.parse(
-        requireStoredExport(db, snapshot.id).surfaceMapJson
+        requireStoredExport(db, snapshot.id).topoGraphJson
       ) as {
         activationSources: Record<string, Record<string, unknown>>;
       };
@@ -1229,7 +1238,7 @@ describe('topo store projection', () => {
               "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
             )
             .get()?.version
-        ).toBe(11);
+        ).toBe(12);
         expect(countRows(db, 'topo_snapshots')).toBe(0);
       });
     });
@@ -1280,7 +1289,47 @@ describe('topo store projection', () => {
               "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
             )
             .get()?.version
-        ).toBe(11);
+        ).toBe(12);
+      });
+    });
+
+    test('ensureTopoSnapshotSchema migrates v11 export artifact columns', () => {
+      withProjectionDb((db) => {
+        db.run(
+          `INSERT INTO meta_schema_versions (subsystem, version, updated_at)
+           VALUES ('topo', 11, ?)`,
+          ['2026-05-11T11:00:00.000Z']
+        );
+        db.run(`CREATE TABLE topo_exports (
+          snapshot_id TEXT PRIMARY KEY,
+          surface_map TEXT NOT NULL,
+          surface_hash TEXT NOT NULL,
+          serialized_lock TEXT NOT NULL
+        )`);
+
+        ensureTopoSnapshotSchema(db);
+
+        expect(tableColumns(db, 'topo_exports')).toEqual(
+          expect.arrayContaining([
+            'topo_graph',
+            'topo_graph_hash',
+            'lock_manifest',
+          ])
+        );
+        expect(tableColumns(db, 'topo_exports')).not.toEqual(
+          expect.arrayContaining([
+            'surface_map',
+            'surface_hash',
+            'serialized_lock',
+          ])
+        );
+        expect(
+          db
+            .query<{ version: number }, []>(
+              "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
+            )
+            .get()?.version
+        ).toBe(12);
       });
     });
 
@@ -1321,7 +1370,7 @@ describe('topo store projection', () => {
             "SELECT version FROM meta_schema_versions WHERE subsystem = 'topo'"
           )
           .get()?.version
-      ).toBe(11);
+      ).toBe(12);
       for (const table of [
         'topo_activation_edges',
         'topo_activation_sources',

--- a/packages/topographer/src/internal/topo-snapshots.ts
+++ b/packages/topographer/src/internal/topo-snapshots.ts
@@ -100,9 +100,9 @@ const TOPO_TABLE_STATEMENTS = [
   )`,
   `CREATE TABLE IF NOT EXISTS topo_exports (
     snapshot_id TEXT PRIMARY KEY,
-    surface_map TEXT NOT NULL,
-    surface_hash TEXT NOT NULL,
-    serialized_lock TEXT NOT NULL,
+    topo_graph TEXT NOT NULL,
+    topo_graph_hash TEXT NOT NULL,
+    lock_manifest TEXT NOT NULL,
     FOREIGN KEY (snapshot_id) REFERENCES topo_snapshots(id) ON DELETE CASCADE
   )`,
   `CREATE TABLE IF NOT EXISTS topo_trail_fires (
@@ -251,6 +251,21 @@ const addColumnIfMissing = (
   }
 };
 
+const renameColumnIfNeeded = (
+  db: Database,
+  tableName: string,
+  from: string,
+  to: string
+): void => {
+  if (
+    tableExists(db, tableName) &&
+    columnExists(db, tableName, from) &&
+    !columnExists(db, tableName, to)
+  ) {
+    db.run(`ALTER TABLE ${tableName} RENAME COLUMN ${from} TO ${to}`);
+  }
+};
+
 const runStatements = (db: Database, statements: readonly string[]): void => {
   for (const statement of statements) {
     db.run(statement);
@@ -264,6 +279,10 @@ const createAllTopoTables = (db: Database): void => {
 
 /**
  * Current topo subsystem schema version.
+ *
+ * Version 12 renames the serialized export columns from surface-era names to
+ * topo-graph artifact-family names: `topo_graph`, `topo_graph_hash`, and
+ * `lock_manifest`.
  *
  * Version 11 adds optional `app_name` attribution to `topo_snapshots` so a
  * single trails-db can host snapshots from multiple apps in workspace-aware
@@ -281,7 +300,7 @@ const createAllTopoTables = (db: Database): void => {
  * tables and advance the subsystem version without translating or deleting
  * legacy rows.
  */
-export const TOPO_SCHEMA_VERSION = 11;
+export const TOPO_SCHEMA_VERSION = 12;
 
 export const ensureTopoSnapshotSchema = (db: Database): void => {
   ensureSubsystemSchema(db, {
@@ -301,6 +320,21 @@ export const ensureTopoSnapshotSchema = (db: Database): void => {
       }
       if (currentVersion >= 7 && currentVersion < 11) {
         addColumnIfMissing(db, 'topo_snapshots', 'app_name', 'app_name TEXT');
+      }
+      if (currentVersion < 12) {
+        renameColumnIfNeeded(db, 'topo_exports', 'surface_map', 'topo_graph');
+        renameColumnIfNeeded(
+          db,
+          'topo_exports',
+          'surface_hash',
+          'topo_graph_hash'
+        );
+        renameColumnIfNeeded(
+          db,
+          'topo_exports',
+          'serialized_lock',
+          'lock_manifest'
+        );
       }
     },
     subsystem: TOPO_SUBSYSTEM,

--- a/packages/topographer/src/internal/topo-store-read.ts
+++ b/packages/topographer/src/internal/topo-store-read.ts
@@ -227,7 +227,7 @@ const readStoredEntry = (
     return undefined;
   }
 
-  const map = JSON.parse(stored.surfaceMapJson) as StoredTopoGraph;
+  const map = JSON.parse(stored.topoGraphJson) as StoredTopoGraph;
   return map.entries.find((entry) => entry.id === id && entry.kind === kind);
 };
 
@@ -564,7 +564,7 @@ export const listTopoStoreResources = (
 
   const stored = getStoredTopoExport(db, snapshot.id);
   const entries = stored
-    ? (JSON.parse(stored.surfaceMapJson) as StoredTopoGraph).entries
+    ? (JSON.parse(stored.topoGraphJson) as StoredTopoGraph).entries
     : [];
 
   return rows.map((row) =>
@@ -670,7 +670,7 @@ export const listTopoStoreSignals = (
 
   const stored = getStoredTopoExport(db, snapshot.id);
   const entries = stored
-    ? (JSON.parse(stored.surfaceMapJson) as StoredTopoGraph).entries
+    ? (JSON.parse(stored.topoGraphJson) as StoredTopoGraph).entries
     : [];
   const consumersBySignal = readSignalRelationUsage(
     db,

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -20,13 +20,18 @@ import type {
   AnyResource,
   AnySignal,
   AnyTrail,
+  FieldOverride,
   Layer,
   Topo,
 } from '@ontrails/core';
 
 import { addPermitRequirement } from '../permit.js';
 import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
-import type { LockManifest } from '../types.js';
+import type {
+  LockManifest,
+  TopoGraphFieldOverride,
+  TopoGraphFieldOverrideKey,
+} from '../types.js';
 import type {
   CreateTopoSnapshotInput,
   TopoSnapshot,
@@ -161,21 +166,21 @@ interface TopoSchemaRow {
 
 interface StoredTopoExportRow {
   readonly snapshotId: string;
-  readonly serializedLock: string;
-  readonly surfaceHash: string;
-  readonly surfaceMap: string;
+  readonly lockManifest: string;
+  readonly topoGraphHash: string;
+  readonly topoGraph: string;
 }
 
 interface StoredTopoExportDbRow {
-  readonly serialized_lock: string;
-  readonly surface_hash: string;
-  readonly surface_map: string;
+  readonly lock_manifest: string;
+  readonly topo_graph: string;
+  readonly topo_graph_hash: string;
 }
 
 export interface StoredTopoExport {
-  readonly lockContent: string;
-  readonly surfaceHash: string;
-  readonly surfaceMapJson: string;
+  readonly lockManifestJson: string;
+  readonly topoGraphHash: string;
+  readonly topoGraphJson: string;
 }
 
 interface MaterializedSchemas {
@@ -588,7 +593,7 @@ const normalizeTrailSignalRows = (
  *
  * Currently records only CLI-derived rows. MCP, HTTP, and other surface
  * projections are intentionally deferred until the topo-store schema supports
- * multi-surface representation. The JSON export (`surface_map` in
+ * multi-surface representation. The JSON export (`topo_graph` in
  * `topo_exports`) is more faithful for now. See ADR-0015 for the target shape.
  */
 const normalizeSurfaceRows = (
@@ -989,6 +994,54 @@ const addLayerAttachments = (
   }
 };
 
+const FIELD_OVERRIDE_KEYS: readonly TopoGraphFieldOverrideKey[] = [
+  'hint',
+  'label',
+  'message',
+  'options',
+];
+
+const collectFieldOverrideKeys = (
+  override: FieldOverride
+): readonly TopoGraphFieldOverrideKey[] =>
+  FIELD_OVERRIDE_KEYS.filter((key) => override[key] !== undefined);
+
+const deriveFieldOverrides = (
+  fields: Readonly<Record<string, FieldOverride>> | undefined
+): readonly TopoGraphFieldOverride[] | undefined => {
+  if (fields === undefined) {
+    return undefined;
+  }
+
+  const overrides = Object.entries(fields)
+    .flatMap(([field, override]) => {
+      const overrideKeys = collectFieldOverrideKeys(override);
+      if (overrideKeys.length === 0) {
+        return [];
+      }
+      return [
+        {
+          field,
+          overrides: overrideKeys,
+          provenance: { source: 'trail.fields' as const },
+        },
+      ];
+    })
+    .toSorted((a, b) => a.field.localeCompare(b.field));
+
+  return overrides.length > 0 ? overrides : undefined;
+};
+
+const addFieldOverrides = (
+  entry: Record<string, unknown>,
+  trail: AnyTrail
+): void => {
+  const fieldOverrides = deriveFieldOverrides(trail.fields);
+  if (fieldOverrides !== undefined) {
+    entry['fieldOverrides'] = fieldOverrides;
+  }
+};
+
 const buildTrailEntryBase = (
   trail: AnyTrail,
   trailSchema: Readonly<{
@@ -1046,6 +1099,7 @@ const trailToEntryRecord = (
   addExtendedMetadata(entry, raw, trail);
   addTrailRelations(entry, trail);
   addLayerAttachments(entry, topoLayers, trail);
+  addFieldOverrides(entry, trail);
   return sortKeys(entry) as TopoGraphEntryRecord;
 };
 
@@ -1242,8 +1296,8 @@ const buildTopoGraph = (
   };
 };
 
-const hashTopoGraphRecord = (surfaceMap: TopoGraphRecord): string => {
-  const { generatedAt: _unused, ...rest } = surfaceMap;
+const hashTopoGraphRecord = (topoGraph: TopoGraphRecord): string => {
+  const { generatedAt: _unused, ...rest } = topoGraph;
   return hashValue(rest);
 };
 
@@ -1255,16 +1309,16 @@ const countEntriesForKind = (
 const buildLockManifest = (
   hash: string,
   topo: Topo,
-  surfaceMap: TopoGraphRecord
+  topoGraph: TopoGraphRecord
 ): LockManifest =>
   sortKeys({
     artifacts: [{ path: 'topo.lock', role: 'topo', sha256: hash }],
     scope: { app: topo.name },
     summary: {
-      contours: countEntriesForKind(surfaceMap.entries, 'contour'),
-      resources: countEntriesForKind(surfaceMap.entries, 'resource'),
-      signals: countEntriesForKind(surfaceMap.entries, 'signal'),
-      trails: countEntriesForKind(surfaceMap.entries, 'trail'),
+      contours: countEntriesForKind(topoGraph.entries, 'contour'),
+      resources: countEntriesForKind(topoGraph.entries, 'resource'),
+      signals: countEntriesForKind(topoGraph.entries, 'signal'),
+      trails: countEntriesForKind(topoGraph.entries, 'trail'),
     },
     version: 3,
   }) as LockManifest;
@@ -1285,7 +1339,7 @@ const buildStoredTopoExport = (
     .listSignals()
     .toSorted((a, b) => a.id.localeCompare(b.id));
   const schemas = materializeSchemas(db, snapshot.id, signals, trails);
-  const surfaceMap = buildTopoGraph(
+  const topoGraph = buildTopoGraph(
     contours,
     snapshot.createdAt,
     resources,
@@ -1295,19 +1349,19 @@ const buildStoredTopoExport = (
     schemas.trailSchemas,
     trails
   );
-  const surfaceHash = hashTopoGraphRecord(surfaceMap);
-  const serializedLock = `${JSON.stringify(
-    buildLockManifest(surfaceHash, topo, surfaceMap),
+  const topoGraphHash = hashTopoGraphRecord(topoGraph);
+  const lockManifest = `${JSON.stringify(
+    buildLockManifest(topoGraphHash, topo, topoGraph),
     null,
     2
   )}\n`;
 
   return {
     exportRow: {
-      serializedLock,
+      lockManifest,
       snapshotId: snapshot.id,
-      surfaceHash,
-      surfaceMap: `${JSON.stringify(surfaceMap, null, 2)}\n`,
+      topoGraph: `${JSON.stringify(topoGraph, null, 2)}\n`,
+      topoGraphHash,
     },
     schemaRows: schemas.rows,
   };
@@ -1486,13 +1540,13 @@ const insertStoredExport = (
 ): void => {
   db.run(
     `INSERT INTO topo_exports (
-      snapshot_id, surface_map, surface_hash, serialized_lock
+      snapshot_id, topo_graph, topo_graph_hash, lock_manifest
     ) VALUES (?, ?, ?, ?)`,
     [
       exportRow.snapshotId,
-      exportRow.surfaceMap,
-      exportRow.surfaceHash,
-      exportRow.serializedLock,
+      exportRow.topoGraph,
+      exportRow.topoGraphHash,
+      exportRow.lockManifest,
     ]
   );
 };
@@ -1503,7 +1557,7 @@ export const getStoredTopoExport = (
 ): StoredTopoExport | undefined => {
   const row = db
     .query<StoredTopoExportDbRow, [string]>(
-      `SELECT surface_map, surface_hash, serialized_lock
+      `SELECT topo_graph, topo_graph_hash, lock_manifest
        FROM topo_exports
        WHERE snapshot_id = ?`
     )
@@ -1514,9 +1568,9 @@ export const getStoredTopoExport = (
   }
 
   return {
-    lockContent: row.serialized_lock,
-    surfaceHash: row.surface_hash,
-    surfaceMapJson: row.surface_map,
+    lockManifestJson: row.lock_manifest,
+    topoGraphHash: row.topo_graph_hash,
+    topoGraphJson: row.topo_graph,
   };
 };
 

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -66,7 +66,7 @@ const seedSavedTopo = (dir: string): string | undefined => {
     db.close();
   }
 
-  return createTopoStore({ rootDir: dir }).exports.get()?.surfaceHash;
+  return createTopoStore({ rootDir: dir }).exports.get()?.topoGraphHash;
 };
 
 describe('checkDrift', () => {

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -58,7 +58,7 @@ export const checkDrift = async (
     // divergence between the schema and store hash pipelines.
     const storedHash = (() => {
       try {
-        return createTopoStore({ rootDir }).exports.get()?.surfaceHash;
+        return createTopoStore({ rootDir }).exports.get()?.topoGraphHash;
       } catch (error) {
         if (error instanceof NotFoundError) {
           return;


### PR DESCRIPTION
## Context

After lock v3 introduces `TopoGraph` as the committed graph artifact, the topo-store saved-state schema needs matching storage names.

This PR covers TRL-697 by moving topo-store exports from `surface_map` vocabulary to `topo_graph` vocabulary.

## Changes

- Renames topo-store export state from `surface_map` to `topo_graph`.
- Updates read/write paths, snapshot helpers, Warden drift expectations, and CLI support code to use the new storage names.
- Keeps compatibility tests around saved topo-store state and export loading behavior.
- Expands topo-store test coverage for the renamed export payload and provenance preservation.
- Adds a changeset for the persisted export schema rename.

## Verification

Local verification in this review-feedback pass:

- `bun scripts/adr.ts check`
- `bun test packages/topographer/src/__tests__/io.test.ts packages/warden/src/__tests__/drift.test.ts apps/trails/src/__tests__/topo-dev.test.ts apps/trails/src/__tests__/run-watch.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run format:check`
- `bun run test`
- `bun run build`
- `bun run check`
- `git diff --check`

Remote CI, Greptile, and Graphite mergeability rerun on every push; use the PR check rollup for current remote status.

## Release / Risk

This is an intentional beta storage-schema rename. The main risk is stale `surface_map` saved state, which is why the branch keeps the rename narrow and test-covered.