### PR TITLE
feat: cut topo cli to v3 artifacts

### DIFF
--- a/.changeset/trl-698-cli-topo-v3-artifacts.md
+++ b/.changeset/trl-698-cli-topo-v3-artifacts.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': major
+---
+
+Cut CLI topo compile and survey diff surfaces over to the lock v3 artifact family. `topo.compile` now reports `topoPath` for `.trails/topo.lock`, survey diff accepts explicit `topo.lock` files and directories containing `topo.lock`, and new scaffolds no longer ignore committed root lock artifacts.

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -242,7 +242,7 @@ describe('trails survey', () => {
     expect(ids).toContain('db.main');
   });
 
-  test('surface map entries have expected fields', () => {
+  test('TopoGraph entries have expected fields', () => {
     const surfaceMap = deriveTopoGraph(app);
     const hello = surfaceMap.entries.find((e) => e.id === 'hello');
     expect(hello).toBeDefined();
@@ -906,11 +906,12 @@ describe('trails topo compile', () => {
       ) as {
         readonly hash: string;
         readonly lockPath: string;
-        readonly mapPath: string;
         readonly snapshot: unknown;
+        readonly topoPath: string;
       };
 
       expect(compiled.hash).toHaveLength(64);
+      expect(compiled.topoPath).toBe(join(dir, '.trails', 'topo.lock'));
       expect(existsSync(join(dir, '.trails', 'topo.lock'))).toBe(true);
       expect(existsSync(join(dir, '.trails', 'trails.lock'))).toBe(true);
       expect(
@@ -940,7 +941,7 @@ describe('trails survey diff', () => {
     }
   });
 
-  test('returns an error when no saved surface map exists yet', async () => {
+  test('returns an error when no saved TopoGraph exists yet', async () => {
     const dir = repoTempDir();
 
     try {
@@ -957,7 +958,7 @@ describe('trails survey diff', () => {
     }
   });
 
-  test('diffs against the saved local surface map', async () => {
+  test('diffs against the saved local TopoGraph', async () => {
     const dir = repoTempDir();
 
     try {
@@ -990,7 +991,7 @@ describe('trails survey diff', () => {
     }
   });
 
-  test('can diff against a workspace-relative surface map directory', async () => {
+  test('can diff against a workspace-relative TopoGraph directory', async () => {
     const dir = repoTempDir();
 
     try {
@@ -1020,7 +1021,7 @@ describe('trails survey diff', () => {
     }
   });
 
-  test('can diff against a workspace-relative JSON surface map file', async () => {
+  test('can diff against a workspace-relative JSON TopoGraph file', async () => {
     const dir = repoTempDir();
 
     try {
@@ -1055,6 +1056,40 @@ describe('trails survey diff', () => {
     }
   });
 
+  test('can diff against a workspace-relative topo.lock file', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+      const baselineApp = await loadApp('./src/app.ts', dir);
+      await writeTopoGraph(deriveTopoGraph(baselineApp), {
+        dir: join(dir, 'baseline-dir'),
+      });
+
+      writeSurveyAppFixture(dir, { withBye: true });
+
+      const result = await surveyDiffTrail.blaze(
+        { against: 'baseline-dir/topo.lock', module: './src/app.ts' },
+        { cwd: dir } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.value).toMatchObject({
+        against: 'baseline-dir/topo.lock',
+        hasBreaking: false,
+        info: [
+          expect.objectContaining({
+            change: 'added',
+            id: 'bye',
+          }),
+        ],
+        mode: 'diff',
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('reports attempted resolution strategies for missing diff targets', async () => {
     const dir = repoTempDir();
 
@@ -1068,10 +1103,10 @@ describe('trails survey diff', () => {
 
       expect(result.isErr()).toBe(true);
       expect(result.error.message).toContain(
-        'No surface map found for: baselins'
+        'No TopoGraph found for: baselins'
       );
       expect(result.error.message).toContain(
-        'workspace-relative directory containing _surface.json'
+        'workspace-relative directory containing topo.lock'
       );
       expect(result.error.message).toContain(
         'topo-store pin and snapshot references'
@@ -1166,7 +1201,6 @@ describe('trails survey output schema', () => {
       topoCompileTrail.output.safeParse({
         hash: 'a'.repeat(64),
         lockPath: '.trails/trails.lock',
-        mapPath: '.trails/topo.lock',
         snapshot: {
           createdAt: new Date(0).toISOString(),
           gitDirty: false,
@@ -1175,6 +1209,7 @@ describe('trails survey output schema', () => {
           signalCount: 0,
           trailCount: 2,
         },
+        topoPath: '.trails/topo.lock',
       }).success
     ).toBe(true);
     expect(

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -177,6 +177,38 @@ describe('topo and dev trails', () => {
       expect(verifyResult.stale).toBe(false);
       expect(countTopoSnapshots(dir)).toBe(snapshotCountAfterExport);
 
+      const committedLock = JSON.parse(
+        readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8')
+      ) as {
+        artifacts: { path: string; role: 'topo'; sha256: string }[];
+        scope: Record<string, string>;
+        summary: Record<string, number>;
+        version: 3;
+      };
+      writeFileSync(
+        join(dir, '.trails', 'trails.lock'),
+        `${JSON.stringify(
+          {
+            ...committedLock,
+            artifacts: committedLock.artifacts.map((artifact) => ({
+              ...artifact,
+              path: 'other.lock',
+            })),
+          },
+          null,
+          2
+        )}\n`
+      );
+      const wrongArtifactError = expectErr(
+        await topoVerifyTrail.blaze(moduleInput, { cwd: dir } as never)
+      );
+      expect(wrongArtifactError.message).toContain('topo.lock artifact');
+
+      writeFileSync(
+        join(dir, '.trails', 'trails.lock'),
+        `${JSON.stringify(committedLock, null, 2)}\n`
+      );
+
       writeAppFixture(dir, { includeAuthTrail: true });
       const currentSummary = expectOk(
         await topoTrail.blaze(moduleInput, { cwd: dir } as never)

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -101,7 +101,8 @@ const TSCONFIG_CONTENT = JSON.stringify(
 const GITIGNORE_CONTENT = `node_modules/
 dist/
 *.tsbuildinfo
-.trails/_surface.json
+.trails/trails.db
+.trails/config.local.ts
 `;
 
 const OXLINT_CONFIG_CONTENT = `import { defineConfig } from 'oxlint';

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -5,7 +5,7 @@
  * versions.
  */
 
-import { extname, join } from 'node:path';
+import { basename, extname, join } from 'node:path';
 
 import type { Topo } from '@ontrails/core';
 import {
@@ -156,20 +156,21 @@ const readPathTopoGraph = async (
   }
 
   return Result.ok(
-    extname(safePath.value) === '.json'
+    basename(safePath.value) === 'topo.lock' ||
+      extname(safePath.value) === '.json'
       ? await readTopoGraphFile(safePath.value)
       : await readTopoGraph({ dir: safePath.value })
   );
 };
 
 const describeAgainstPathTarget = (against: string): string =>
-  extname(against) === '.json'
-    ? 'workspace-relative JSON surface-map file'
-    : 'workspace-relative directory containing _surface.json';
+  basename(against) === 'topo.lock' || extname(against) === '.json'
+    ? 'workspace-relative TopoGraph file'
+    : 'workspace-relative directory containing topo.lock';
 
 const topoGraphNotFound = (against: string): NotFoundError =>
   new NotFoundError(
-    `No surface map found for: ${against}. Tried ${describeAgainstPathTarget(
+    `No TopoGraph found for: ${against}. Tried ${describeAgainstPathTarget(
       against
     )}, then topo-store pin and snapshot references.`
   );
@@ -183,7 +184,7 @@ const readAgainstTopoGraph = async (
     return map === null
       ? Result.err(
           new NotFoundError(
-            'No saved surface map found. Run `trails topo compile` first.'
+            'No saved TopoGraph found. Run `trails topo compile` first.'
           )
         )
       : Result.ok({ against: 'saved', map });
@@ -510,10 +511,10 @@ export const surveyDiffTrail = trail('survey.diff', {
     withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
       buildSurveyDiff(app, rootDir, input.breakingOnly, input.against)
     ),
-  description: 'Diff the current topo against a saved surface map',
+  description: 'Diff the current topo against a saved TopoGraph',
   examples: [
     {
-      description: 'Compare current topo to a saved surface map directory',
+      description: 'Compare current topo to a saved TopoGraph directory',
       input: createDiffExampleInput(),
       name: 'Diff against baseline',
     },
@@ -539,7 +540,7 @@ export const surveyDiffTrail = trail('survey.diff', {
       .min(1)
       .optional()
       .describe(
-        'Saved map target: "saved", a workspace path (.json file or directory with _surface.json), then a pin/snapshot id'
+        'Saved TopoGraph target: "saved", a workspace path (topo.lock, .json file, or directory with topo.lock), then a pin/snapshot id'
       ),
     breakingOnly: z
       .boolean()

--- a/apps/trails/src/trails/topo-compile.ts
+++ b/apps/trails/src/trails/topo-compile.ts
@@ -49,7 +49,7 @@ export const topoCompileTrail = trail('topo.compile', {
   output: z.object({
     hash: z.string(),
     lockPath: z.string(),
-    mapPath: z.string(),
     snapshot: topoSnapshotOutput,
+    topoPath: z.string(),
   }),
 });

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -277,7 +277,7 @@ export const verifyCurrentTopo = async (
   }
   const currentHash = currentExport.value.topoGraphHash;
   const topoArtifact = lockManifest.artifacts.find(
-    (artifact) => artifact.role === 'topo'
+    (artifact) => artifact.role === 'topo' && artifact.path === 'topo.lock'
   );
   if (topoArtifact === undefined) {
     return Result.err(

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -86,8 +86,8 @@ export const deriveCurrentTopoExport = (
 const writeStoredExportArtifacts = async (
   storedExport: StoredTopoExport,
   trailsDir: string
-): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'mapPath'>> => {
-  const mapPath = await writeTopoGraph(
+): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'topoPath'>> => {
+  const topoPath = await writeTopoGraph(
     JSON.parse(storedExport.topoGraphJson) as TopoGraph,
     { dir: trailsDir }
   );
@@ -99,7 +99,7 @@ const writeStoredExportArtifacts = async (
   return {
     hash: storedExport.topoGraphHash,
     lockPath,
-    mapPath,
+    topoPath,
   };
 };
 

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -58,8 +58,8 @@ export interface TopoHistoryReport {
 export interface TopoExportReport {
   readonly hash: string;
   readonly lockPath: string;
-  readonly mapPath: string;
   readonly snapshot: TopoSnapshot;
+  readonly topoPath: string;
 }
 
 export interface TopoVerifyReport {


### PR DESCRIPTION
## Context

Once the artifact family exists in Topographer, the CLI needs to generate, verify, and report the v3 artifacts instead of older lock/topo assumptions.

This PR covers TRL-698 by cutting `trails topo compile`, `trails topo verify`, and survey output over to the v3 artifact family.

## Changes

- Updates topo CLI support code so compile/verify flows use the compact manifest plus serialized `topo.lock` artifacts.
- Updates survey behavior and tests to report v3 artifact paths and drift correctly.
- Updates dev/topo tests for regenerated lock behavior and missing/stale artifact cases.
- Adjusts scaffold defaults that need to know about the new workspace artifact layout.
- Adds a changeset for the CLI artifact cutover.

## Verification

Local verification in this review-feedback pass:

- `bun scripts/adr.ts check`
- `bun test packages/topographer/src/__tests__/io.test.ts packages/warden/src/__tests__/drift.test.ts apps/trails/src/__tests__/topo-dev.test.ts apps/trails/src/__tests__/run-watch.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run format:check`
- `bun run test`
- `bun run build`
- `bun run check`
- `git diff --check`

Remote CI, Greptile, and Graphite mergeability rerun on every push; use the PR check rollup for current remote status.

## Release / Risk

This is the user-facing CLI cutover for lock v3. Existing stale artifacts should be regenerated with `trails topo compile`; silent acceptance of legacy lock shapes is intentionally not preserved.