### PR TITLE
fix: harden warden lock v3 drift checks

### DIFF
--- a/.changeset/trl-699-warden-lock-v3-drift.md
+++ b/.changeset/trl-699-warden-lock-v3-drift.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/warden': patch
+---
+
+Harden Warden drift checks for lock v3 manifests. Malformed legacy lock files and manifests without the `topo.lock` artifact now report blocked drift with a regenerate instruction instead of throwing or silently passing.

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -30,6 +30,15 @@ const makeTopo = () => {
   return topo('test-app', { t });
 };
 
+const makeChangedTopo = () => {
+  const t = trail('test.hello', {
+    blaze: () => Result.ok({ greeting: 'hi', punctuation: '!' }),
+    input: z.object({ name: z.string() }),
+    output: z.object({ greeting: z.string(), punctuation: z.string() }),
+  });
+  return topo('test-app', { t });
+};
+
 const createTempDir = (): string => {
   const dir = join(tmpdir(), `drift-test-${Date.now()}`);
   mkdirSync(dir, { recursive: true });
@@ -117,6 +126,25 @@ describe('checkDrift', () => {
     }
   });
 
+  test('uses the live topo hash even when a saved topo export exists', async () => {
+    const dir = createTempDir();
+    try {
+      const savedHash = seedSavedTopo(dir);
+      if (savedHash === undefined) {
+        throw new Error('expected saved hash');
+      }
+      await writeManifest(dir, savedHash);
+
+      const result = await checkDrift(dir, makeChangedTopo());
+
+      expect(result.stale).toBe(true);
+      expect(result.committedHash).toBe(savedHash);
+      expect(result.currentHash).not.toBe(savedHash);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('returns stale: true when lock does not match', async () => {
     const dir = createTempDir();
     try {
@@ -144,6 +172,35 @@ describe('checkDrift', () => {
       expect(result.blockedReason).toContain(
         'regenerate with `trails topo compile`'
       );
+      expect(result.currentHash).toBe('blocked');
+      expect(result.committedHash).toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('blocks drift calculation when the manifest lacks the topo.lock artifact', async () => {
+    const dir = createTempDir();
+    try {
+      await writeLockManifest(
+        {
+          artifacts: [
+            {
+              path: 'other.lock',
+              role: 'topo',
+              sha256: 'f'.repeat(64),
+            },
+          ],
+          scope: { app: 'test-app' },
+          summary: { contours: 0, resources: 0, signals: 0, trails: 1 },
+          version: 3,
+        },
+        { dir: committedLockDir(dir) }
+      );
+
+      const result = await checkDrift(dir, makeTopo());
+      expect(result.stale).toBe(true);
+      expect(result.blockedReason).toContain('topo.lock artifact');
       expect(result.currentHash).toBe('blocked');
       expect(result.committedHash).toBeNull();
     } finally {

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -21,6 +21,7 @@ import {
   isTopoArtifactRegenerationError,
   readLockManifest,
 } from '@ontrails/topographer';
+import type { LockManifest } from '@ontrails/topographer';
 
 /**
  * Result of a drift check comparing committed trails.lock against the current state.
@@ -36,6 +37,44 @@ export interface DriftResult {
   readonly currentHash: string;
 }
 
+interface BlockedLockRead {
+  readonly drift: DriftResult;
+  readonly kind: 'blocked-lock-read';
+}
+
+const blockedDrift = (reason: string): DriftResult => ({
+  blockedReason: reason,
+  committedHash: null,
+  currentHash: 'blocked',
+  stale: true,
+});
+
+const blockedLockRead = (reason: string): BlockedLockRead => ({
+  drift: blockedDrift(reason),
+  kind: 'blocked-lock-read',
+});
+
+const readCommittedLockManifest = async (
+  rootDir: string
+): Promise<BlockedLockRead | LockManifest | null> => {
+  const trailsDir = deriveTrailsDir({ rootDir });
+  try {
+    return existsSync(rootDir) && statSync(rootDir).isDirectory()
+      ? await readLockManifest({ dir: trailsDir })
+      : null;
+  } catch (error) {
+    if (isTopoArtifactRegenerationError(error)) {
+      return blockedLockRead(error.message);
+    }
+    throw error;
+  }
+};
+
+const isBlockedLockRead = (
+  result: BlockedLockRead | LockManifest | null
+): result is BlockedLockRead =>
+  result !== null && 'kind' in result && result.kind === 'blocked-lock-read';
+
 /**
  * Check whether the committed trails.lock is stale compared to the current topology.
  *
@@ -46,17 +85,20 @@ export const checkDrift = async (
   topo?: Topo | undefined
 ): Promise<DriftResult> => {
   try {
-    const trailsDir = deriveTrailsDir({ rootDir });
-    const lockManifest =
-      existsSync(rootDir) && statSync(rootDir).isDirectory()
-        ? await readLockManifest({ dir: trailsDir })
-        : null;
+    const lockManifest = await readCommittedLockManifest(rootDir);
+    if (isBlockedLockRead(lockManifest)) {
+      return lockManifest.drift;
+    }
     const topoArtifact =
-      lockManifest?.artifacts.find((artifact) => artifact.role === 'topo') ??
-      null;
-    // Prefer the stored hash (computed by the export pipeline) to avoid
-    // divergence between the schema and store hash pipelines.
-    const storedHash = (() => {
+      lockManifest?.artifacts.find(
+        (artifact) => artifact.role === 'topo' && artifact.path === 'topo.lock'
+      ) ?? null;
+    if (lockManifest !== null && topoArtifact === null) {
+      return blockedDrift(
+        'trails.lock does not contain a topo.lock artifact. Regenerate with `trails topo compile`.'
+      );
+    }
+    const readStoredHash = (): string | undefined => {
       try {
         return createTopoStore({ rootDir }).exports.get()?.topoGraphHash;
       } catch (error) {
@@ -65,12 +107,11 @@ export const checkDrift = async (
         }
         throw error;
       }
-    })();
+    };
     const currentHash =
-      storedHash ??
-      (topo === undefined
-        ? 'unknown'
-        : deriveTopoGraphHash(deriveTopoGraph(topo)));
+      topo === undefined
+        ? (readStoredHash() ?? 'unknown')
+        : deriveTopoGraphHash(deriveTopoGraph(topo));
 
     return {
       committedHash: topoArtifact?.sha256 ?? null,
@@ -88,11 +129,6 @@ export const checkDrift = async (
       throw error;
     }
 
-    return {
-      blockedReason: error.message,
-      committedHash: null,
-      currentHash: 'blocked',
-      stale: true,
-    };
+    return blockedDrift(error.message);
   }
 };


### PR DESCRIPTION
## Context

Warden drift checks need to understand the lock v3 artifact family before the workspace layout and workspace-index branches land on top.

This PR covers TRL-699 by hardening Warden drift behavior around `trails.lock` manifests and `topo.lock` graph artifacts.

## Changes

- Updates Warden drift checks to read lock v3 manifests and associated `TopoGraph` artifacts.
- Blocks unsupported legacy/v2 lock reads with the regenerate guidance expected by the artifact-family doctrine.
- Narrows error handling so expected lock-regeneration failures become actionable drift, while unrelated filesystem/runtime failures are not swallowed as drift.
- Adds focused drift tests for stale manifests, malformed manifests, legacy locks, missing artifacts, and strict artifact validation.
- Adds a changeset for the Warden lock v3 support.

## Verification

Local verification in this review-feedback pass:

- `bun scripts/adr.ts check`
- `bun test packages/topographer/src/__tests__/io.test.ts packages/warden/src/__tests__/drift.test.ts apps/trails/src/__tests__/topo-dev.test.ts apps/trails/src/__tests__/run-watch.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run format:check`
- `bun run test`
- `bun run build`
- `bun run check`
- `git diff --check`

Remote CI, Greptile, and Graphite mergeability rerun on every push; use the PR check rollup for current remote status.

## Release / Risk

This branch makes drift detection stricter. That is intentional: Warden should fail loudly when committed topo artifacts are missing, stale, malformed, or from a legacy lock format.