### PR TITLE
feat: move workspace index to topo lock

### DIFF
--- a/.changeset/trl-701-workspace-index-topolock.md
+++ b/.changeset/trl-701-workspace-index-topolock.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/topographer': major
+---
+
+Move the workspace trail index out of the lock manifest and into the serialized TopoGraph artifact. Workspace index reads now consult `topo.lock` workspace metadata, and `buildWorkspaceTrailIndex()` exposes `topo-lock` cache hits through the artifact-family path.

--- a/apps/trails/src/__tests__/completions-example.test.ts
+++ b/apps/trails/src/__tests__/completions-example.test.ts
@@ -125,16 +125,27 @@ const writeBrokenWorkspace = (workspaceRoot: string): void => {
   );
 
   writeFixture(
-    join(workspaceRoot, '.trails', 'trails.lock'),
+    join(workspaceRoot, '.trails', 'topo.lock'),
     `${JSON.stringify(
       {
-        hash: 'deadbeef'.repeat(8),
-        version: '2',
-        workspaceTrails: {
-          'demo.alpha': {
-            appName: 'broken-app',
-            modulePath: 'apps/broken-app/src/missing.ts',
-            trailId: 'demo.alpha',
+        activationGraph: {
+          edgeCount: 0,
+          edges: [],
+          sourceCount: 0,
+          sourceKeys: [],
+          trailIds: [],
+        },
+        activationSources: {},
+        entries: [],
+        generatedAt: '2026-05-11T12:00:00.000Z',
+        topoGraphSchemaVersion: 1,
+        workspace: {
+          trails: {
+            'demo.alpha': {
+              appName: 'broken-app',
+              modulePath: 'apps/broken-app/src/missing.ts',
+              trailId: 'demo.alpha',
+            },
           },
         },
       },

--- a/docs/adr/0042-core-topographer-boundary-doctrine.md
+++ b/docs/adr/0042-core-topographer-boundary-doctrine.md
@@ -94,16 +94,16 @@ The architectural decision underneath the boundary is the split between *resolvi
 - **Resolution** — go from authored declarations to a fully validated, deduplicated, identity-stable in-memory graph. Happens every time `topo()` runs. Core.
 - **Persistence** — serialize that resolved graph to a stable, versioned, on-disk format that can be read back, diffed, and pinned. Topographer.
 
-`trails build` and `trails compile` call resolution (core) *and* persistence (Topographer). A surface connector calls only resolution. **The runtime never reads the lockfile to execute trails.** The lockfile is a tooling artifact, not a runtime artifact.
+`trails build` and `trails compile` call resolution (core) *and* persistence (Topographer). A surface connector calls only resolution. **The runtime never reads resolved topo artifacts to execute trails.** The committed artifact family is tooling state, not runtime state.
 
-This is the test that catches every subtle violation. If a feature requires reading the lockfile to dispatch a trail, the boundary has been crossed in the wrong direction.
+This is the test that catches every subtle violation. If a feature requires reading the committed manifest or `topo.lock` to dispatch a trail, the boundary has been crossed in the wrong direction.
 
 ### `trails run` is two different things along the same boundary
 
 The CLI's `run` subcommand splits cleanly along the same axis, and the split is what keeps Topographer off the runtime hot path:
 
 - **`trails run` against an already-loaded app graph** (in-process invocation of a known trail). Core only. No Topographer needed.
-- **`trails run <id>` with workspace-wide resolution** (CLI looks up which app owns this trail ID across the workspace). Topographer territory. This is exactly the workspace lockfile catalog [TRL-403] sketches: the CLI consults a persisted, cross-app artifact to resolve the ID *before* runtime execution begins. Once the right app is identified and loaded, execution is core-only.
+- **`trails run <id>` with workspace-wide resolution** (CLI looks up which app owns this trail ID across the workspace). Topographer territory. The CLI consults `topo.lock` workspace metadata to resolve the ID *before* runtime execution begins. Once the right app is identified and loaded, execution is core-only.
 
 Conflating these makes Topographer look like it's on the runtime path. It isn't. Workspace-wide resolution is a CLI-level lookup that happens against a tooling artifact. After that lookup, the in-process pipeline is the pipeline core has always owned.
 
@@ -223,7 +223,7 @@ This ADR does not:
 - Rename the `topo()` primitive or change what `topo()` returns.
 - Define a new package boundary for the database connection primitive established by [ADR-0014: Core Database Primitive](0014-core-database-primitive.md).
 - Define `Topographer`-side APIs for snapshots, pins, or diffs beyond what already exists in `@ontrails/schema` and the relocated topo-store. Maturation of those APIs is downstream work.
-- Specify the workspace lockfile catalog format from [TRL-403]. This ADR settles which package owns it; the schema evolution is a separate decision.
+- Specify every future workspace metadata field in `topo.lock`. This ADR settles which package owns persisted resolved-topo artifacts; schema evolution remains a separate decision.
 - Decide the public teaching path for build-time surfaces (SDK, OpenAPI, docs). [ADR-0035: Surface APIs Render the Graph](0035-surface-apis-render-the-graph.md) already establishes `surface(graph, { outDir })` as the convenience path; this ADR doesn't change that.
 - Move signposts, wayfinder trails, or warden rules into Topographer. Trails-over-data is a separate architectural layer and stays separate.
 

--- a/packages/topographer/README.md
+++ b/packages/topographer/README.md
@@ -11,7 +11,10 @@ Most applications reach this package through `trails topo compile` and `trails t
 - stable hashing for CI drift detection
 - semantic diffing between two TopoGraphs
 - file I/O helpers for `.trails/topo.lock` and `.trails/trails.lock`
-- the topo-store: queryable persistence of the resolved topo graph in `trails.db`, including snapshots, pinning, history, and read-only query accessors (relocated from `@ontrails/core` per ADR-0042)
+- the topo-store: queryable persistence of the resolved topo graph in the shared
+  `trails.db` at `.trails/state/trails.db`, including snapshots, pinning,
+  history, and read-only query accessors (relocated from `@ontrails/core` per
+  ADR-0042)
 
 `@ontrails/topographer` is the durable graph substrate for Trails. Generic `trails-db` plumbing (read/write SQLite handles, subsystem schema management, derived paths) stays in `@ontrails/core` so other subsystems (tracing, signals) can share it without depending on topographer.
 
@@ -68,7 +71,7 @@ The typical exported artifact pair is:
 | `readTopoGraph(options?)` | Read `.trails/topo.lock` |
 | `writeLockManifest(manifest, options?)` | Write `.trails/trails.lock` as a v3 manifest |
 | `readLockManifest(options?)` | Read the v3 manifest from `.trails/trails.lock` |
-| `createTopoStore(options?)` | Read-only query interface over the persisted topo state in `trails.db` |
+| `createTopoStore(options?)` | Read-only query interface over the persisted topo state in `.trails/state/trails.db` |
 | `createMockTopoStore(seed?)` | Seeded in-memory mock for tests that need a `ReadOnlyTopoStore` |
 | `topoStore` | Read-only `resource()` wrapper around `createTopoStore`, suitable for `resources: [...]` |
 | `createTopoSnapshot(topo, options?)` | Persist a new topo snapshot row plus its denormalized projections |
@@ -77,7 +80,7 @@ The typical exported artifact pair is:
 
 ### Backend Support Subpath
 
-Direct `trails.db` helper APIs are public, but they are backend-support APIs
+Direct shared database helper APIs are public, but they are backend-support APIs
 rather than root graph contracts. Import them from
 `@ontrails/topographer/backend-support`:
 

--- a/packages/topographer/src/__tests__/io.test.ts
+++ b/packages/topographer/src/__tests__/io.test.ts
@@ -9,7 +9,7 @@ import {
   isTopoArtifactRegenerationError,
   writeLockManifest,
   readLockManifest,
-  readWorkspaceLock,
+  readWorkspaceTrailIndex,
 } from '../io.js';
 import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
 import type { LockManifest, TopoGraph } from '../types.js';
@@ -298,18 +298,16 @@ describe('default directory', () => {
 // Workspace trail index
 // ---------------------------------------------------------------------------
 
-describe('readWorkspaceLock', () => {
-  test('returns null for a single-app structured lock without workspace metadata', async () => {
-    const hash = 'cafebabe'.repeat(8);
-    await writeLockManifest(makeLockManifest(hash), { dir: tempDir });
+describe('readWorkspaceTrailIndex', () => {
+  test('returns null for a single-app topo graph without workspace metadata', async () => {
+    await writeTopoGraph(makeTopoGraph(), { dir: tempDir });
 
-    const result = await readWorkspaceLock({ dir: tempDir });
+    const result = await readWorkspaceTrailIndex({ dir: tempDir });
     expect(result).toBeNull();
   });
 
-  test('returns the trail-id index for a multi-app workspace lock', async () => {
-    const hash = 'feedface'.repeat(8);
-    const workspaceTrails = {
+  test('returns the trail-id index from a multi-app workspace topo graph', async () => {
+    const workspaceIndex = {
       'a.trail': {
         appName: 'app-one',
         modulePath: 'apps/one/src/app.ts',
@@ -321,30 +319,29 @@ describe('readWorkspaceLock', () => {
         trailId: 'b.trail',
       },
     } as const;
-    const filePath = await writeLockManifest(
-      makeLockManifest(hash, { workspaceTrails }),
+    const filePath = await writeTopoGraph(
+      { ...makeTopoGraph(), workspace: { trails: workspaceIndex } },
       { dir: tempDir }
     );
 
-    const parsed = await readParsedLock(filePath);
-    expect(parsed.version).toBe(3);
-    expect(parsed.workspaceTrails).toEqual(workspaceTrails);
+    const parsed = JSON.parse(await readFile(filePath, 'utf8')) as TopoGraph;
+    expect(parsed.topoGraphSchemaVersion).toBe(TOPO_GRAPH_SCHEMA_VERSION);
+    expect(parsed.workspace?.trails).toEqual(workspaceIndex);
 
-    const result = await readWorkspaceLock({ dir: tempDir });
-    expect(result).toEqual(workspaceTrails);
+    const result = await readWorkspaceTrailIndex({ dir: tempDir });
+    expect(result).toEqual(workspaceIndex);
   });
 
-  test('rejects the legacy single-line hash file', async () => {
+  test('ignores the legacy trails.lock path when no topo graph exists', async () => {
     const hash = 'aaaaaaaa'.repeat(8);
     await Bun.write(join(tempDir, 'trails.lock'), `${hash}\n`);
 
-    await expect(readWorkspaceLock({ dir: tempDir })).rejects.toThrow(
-      'regenerate with `trails topo compile`'
-    );
+    const result = await readWorkspaceTrailIndex({ dir: tempDir });
+    expect(result).toBeNull();
   });
 
-  test('returns null when the lock file is missing', async () => {
-    const result = await readWorkspaceLock({
+  test('returns null when the topo graph file is missing', async () => {
+    const result = await readWorkspaceTrailIndex({
       dir: join(tempDir, 'nonexistent'),
     });
     expect(result).toBeNull();

--- a/packages/topographer/src/__tests__/workspace-topos.test.ts
+++ b/packages/topographer/src/__tests__/workspace-topos.test.ts
@@ -6,11 +6,13 @@ import { join } from 'node:path';
 import { topo } from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 
-import { writeLockManifest } from '../io.js';
+import { writeTopoGraph } from '../io.js';
+import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
+import type { WorkspaceTrailCollision, WorkspaceTrailIndex } from '../types.js';
 import { buildWorkspaceTrailIndex } from '../workspace-topos.js';
 import type { WorkspaceTopoLoader } from '../workspace-topos.js';
 
-const LOCKFILE_FALLBACK_WARNING = 'No workspace lockfile found';
+const TOPO_LOCK_FALLBACK_WARNING = 'No workspace topo.lock found';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -36,6 +38,29 @@ interface WorkspaceFixture {
 const writeJson = async (filePath: string, value: unknown): Promise<void> => {
   await Bun.write(filePath, `${JSON.stringify(value, null, 2)}\n`);
 };
+
+const writeWorkspaceTopoGraph = (
+  dir: string,
+  workspaceIndex: WorkspaceTrailIndex,
+  collisions?: readonly WorkspaceTrailCollision[]
+): Promise<string> =>
+  writeTopoGraph(
+    {
+      activationGraph: {
+        edgeCount: 0,
+        edges: [],
+        sourceCount: 0,
+        sourceKeys: [],
+        trailIds: [],
+      },
+      activationSources: {},
+      entries: [],
+      generatedAt: '2026-05-11T12:00:00.000Z',
+      topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
+      workspace: { collisions, trails: workspaceIndex },
+    },
+    { dir }
+  );
 
 const writeWorkspace = async (
   root: string,
@@ -161,7 +186,7 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
     expect(result.apps).toEqual(expect.arrayContaining(['app-a', 'app-b']));
     expect(result.apps.length).toBe(2);
     expect(result.warnings).toEqual([
-      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+      expect.stringContaining(TOPO_LOCK_FALLBACK_WARNING),
     ]);
     expect(result.collisions).toEqual([]);
   });
@@ -186,7 +211,7 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
     });
     expect(result.apps).toEqual(['only-app']);
     expect(result.warnings).toEqual([
-      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+      expect.stringContaining(TOPO_LOCK_FALLBACK_WARNING),
     ]);
   });
 
@@ -236,7 +261,7 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
     expect(result.index).toEqual({});
     expect(result.apps).toEqual([]);
     expect(result.warnings).toEqual([
-      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+      expect.stringContaining(TOPO_LOCK_FALLBACK_WARNING),
     ]);
   });
 
@@ -256,7 +281,7 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
     expect(result.index).toEqual({});
     expect(result.apps).toEqual([]);
     expect(result.warnings).toEqual([
-      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+      expect.stringContaining(TOPO_LOCK_FALLBACK_WARNING),
     ]);
     expect(result.collisions).toEqual([]);
   });
@@ -284,7 +309,7 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
     });
     expect(result.apps).toEqual(['good-app']);
     expect(result.warnings).toHaveLength(2);
-    expect(result.warnings[0]).toContain(LOCKFILE_FALLBACK_WARNING);
+    expect(result.warnings[0]).toContain(TOPO_LOCK_FALLBACK_WARNING);
     expect(result.warnings[1]).toContain('broken-app');
     expect(result.collisions).toEqual([]);
   });
@@ -336,7 +361,7 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
     ]);
     // Collisions are reported via the structured field, not the warnings list.
     expect(result.warnings).toEqual([
-      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+      expect.stringContaining(TOPO_LOCK_FALLBACK_WARNING),
     ]);
   });
 
@@ -382,39 +407,24 @@ describe('buildWorkspaceTrailIndex (discovery path)', () => {
       },
     ]);
     expect(result.warnings).toEqual([
-      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+      expect.stringContaining(TOPO_LOCK_FALLBACK_WARNING),
     ]);
   });
 });
 
-describe('buildWorkspaceTrailIndex (lockfile path)', () => {
-  test('reads the index from a fresh workspace lock without loading apps', async () => {
+describe('buildWorkspaceTrailIndex (topo.lock path)', () => {
+  test('reads the index from a fresh workspace topo.lock without loading apps', async () => {
     const fixtures = [{ name: 'lock-app', trailIds: ['lock.read'] }];
     const registry = new Map(fixtures.map((f) => [f.name, f]));
     await writeWorkspace(workspaceRoot, fixtures);
 
-    await writeLockManifest(
-      {
-        artifacts: [
-          {
-            path: 'topo.lock',
-            role: 'topo',
-            sha256: 'deadbeef'.repeat(8),
-          },
-        ],
-        scope: { workspace: 'test-workspace' },
-        summary: { contours: 0, resources: 0, signals: 0, trails: 1 },
-        version: 3,
-        workspaceTrails: {
-          'lock.entry': {
-            appName: 'lock-app',
-            modulePath: 'apps/lock-app/src/app.ts',
-            trailId: 'lock.entry',
-          },
-        },
+    await writeWorkspaceTopoGraph(join(workspaceRoot, '.trails'), {
+      'lock.entry': {
+        appName: 'lock-app',
+        modulePath: 'apps/lock-app/src/app.ts',
+        trailId: 'lock.entry',
       },
-      { dir: join(workspaceRoot, '.trails') }
-    );
+    });
 
     let loaderCalls = 0;
     const trackingLoader: WorkspaceTopoLoader = async (
@@ -430,7 +440,7 @@ describe('buildWorkspaceTrailIndex (lockfile path)', () => {
       loadTopo: trackingLoader,
     });
 
-    expect(result.source).toBe('lockfile');
+    expect(result.source).toBe('topo-lock');
     expect(result.index).toEqual({
       'lock.entry': {
         appName: 'lock-app',
@@ -442,37 +452,88 @@ describe('buildWorkspaceTrailIndex (lockfile path)', () => {
     expect(result.warnings).toEqual([]);
     expect(Object.isFrozen(result.index)).toBe(true);
     expect(result.collisions).toEqual([]);
-    // apps reflect what the lockfile asserts.
+    // apps reflect what the topo.lock workspace index asserts.
     expect(result.apps).toEqual(['lock-app']);
   });
 
-  test('resolves a relative lockDir against cwd', async () => {
+  test('reads collision ownership from a workspace topo.lock without loading apps', async () => {
+    const fixtures = [
+      { name: 'app-a', trailIds: ['shared.id'] },
+      { name: 'app-b', trailIds: ['shared.id'] },
+    ];
+    const registry = new Map(fixtures.map((f) => [f.name, f]));
+    await writeWorkspace(workspaceRoot, fixtures);
+
+    await writeWorkspaceTopoGraph(join(workspaceRoot, '.trails'), {}, [
+      {
+        apps: ['app-a', 'app-b'],
+        owners: [
+          {
+            appName: 'app-a',
+            modulePath: 'apps/app-a/src/app.ts',
+            trailId: 'shared.id',
+          },
+          {
+            appName: 'app-b',
+            modulePath: 'apps/app-b/src/app.ts',
+            trailId: 'shared.id',
+          },
+        ],
+        trailId: 'shared.id',
+      },
+    ]);
+
+    let loaderCalls = 0;
+    const trackingLoader: WorkspaceTopoLoader = async (
+      appDir: string,
+      root: string
+    ) => {
+      loaderCalls += 1;
+      return makeLoader(registry)(appDir, root);
+    };
+
+    const result = await buildWorkspaceTrailIndex({
+      cwd: workspaceRoot,
+      loadTopo: trackingLoader,
+    });
+
+    expect(result.source).toBe('topo-lock');
+    expect(result.index).toEqual({});
+    expect(result.collisions).toEqual([
+      {
+        apps: ['app-a', 'app-b'],
+        owners: [
+          {
+            appName: 'app-a',
+            modulePath: 'apps/app-a/src/app.ts',
+            trailId: 'shared.id',
+          },
+          {
+            appName: 'app-b',
+            modulePath: 'apps/app-b/src/app.ts',
+            trailId: 'shared.id',
+          },
+        ],
+        trailId: 'shared.id',
+      },
+    ]);
+    expect(result.apps).toEqual(['app-a', 'app-b']);
+    expect(loaderCalls).toBe(0);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test('resolves a relative artifactDir against cwd', async () => {
     const fixtures = [{ name: 'lock-app', trailIds: ['lock.read'] }];
     const registry = new Map(fixtures.map((f) => [f.name, f]));
     await writeWorkspace(workspaceRoot, fixtures);
 
-    await writeLockManifest(
-      {
-        artifacts: [
-          {
-            path: 'topo.lock',
-            role: 'topo',
-            sha256: 'cafebabe'.repeat(8),
-          },
-        ],
-        scope: { workspace: 'test-workspace' },
-        summary: { contours: 0, resources: 0, signals: 0, trails: 1 },
-        version: 3,
-        workspaceTrails: {
-          'relative.lock': {
-            appName: 'lock-app',
-            modulePath: 'apps/lock-app/src/app.ts',
-            trailId: 'relative.lock',
-          },
-        },
+    await writeWorkspaceTopoGraph(join(workspaceRoot, '.custom-trails'), {
+      'relative.lock': {
+        appName: 'lock-app',
+        modulePath: 'apps/lock-app/src/app.ts',
+        trailId: 'relative.lock',
       },
-      { dir: join(workspaceRoot, '.custom-trails') }
-    );
+    });
 
     let loaderCalls = 0;
     const trackingLoader: WorkspaceTopoLoader = async (
@@ -485,12 +546,12 @@ describe('buildWorkspaceTrailIndex (lockfile path)', () => {
     };
 
     const result = await buildWorkspaceTrailIndex({
+      artifactDir: '.custom-trails',
       cwd: workspaceRoot,
       loadTopo: trackingLoader,
-      lockDir: '.custom-trails',
     });
 
-    expect(result.source).toBe('lockfile');
+    expect(result.source).toBe('topo-lock');
     expect(result.index['relative.lock']).toEqual({
       appName: 'lock-app',
       modulePath: 'apps/lock-app/src/app.ts',
@@ -500,7 +561,7 @@ describe('buildWorkspaceTrailIndex (lockfile path)', () => {
     expect(result.warnings).toEqual([]);
   });
 
-  test('falls back to discovery when no workspace lock is present', async () => {
+  test('falls back to discovery when no workspace topo.lock is present', async () => {
     const fixtures = [{ name: 'app-only', trailIds: ['only.go'] }];
     const registry = new Map(fixtures.map((f) => [f.name, f]));
     await writeWorkspace(workspaceRoot, fixtures);
@@ -512,7 +573,7 @@ describe('buildWorkspaceTrailIndex (lockfile path)', () => {
 
     expect(result.source).toBe('discovery');
     expect(result.warnings).toEqual([
-      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+      expect.stringContaining(TOPO_LOCK_FALLBACK_WARNING),
     ]);
     expect(result.index).toEqual({
       'only.go': {
@@ -523,7 +584,7 @@ describe('buildWorkspaceTrailIndex (lockfile path)', () => {
     });
   });
 
-  test('preserves lockfile fallback warning when discovery has no workspace globs', async () => {
+  test('preserves topo.lock fallback warning when discovery has no workspace globs', async () => {
     await writeJson(join(workspaceRoot, 'package.json'), {
       name: 'no-workspaces',
       private: true,
@@ -539,7 +600,7 @@ describe('buildWorkspaceTrailIndex (lockfile path)', () => {
     expect(result.apps).toEqual([]);
     expect(result.index).toEqual({});
     expect(result.warnings).toEqual([
-      expect.stringContaining(LOCKFILE_FALLBACK_WARNING),
+      expect.stringContaining(TOPO_LOCK_FALLBACK_WARNING),
     ]);
   });
 });

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -15,6 +15,8 @@ export {
   isTopoArtifactRegenerationError,
   writeLockManifest,
   readLockManifest,
+  readWorkspaceTopoMetadata,
+  readWorkspaceTrailIndex,
   readWorkspaceLock,
 } from './io.js';
 export {
@@ -22,6 +24,8 @@ export {
   lockManifestSchema,
   lockManifestSummarySchema,
   TOPO_GRAPH_SCHEMA_VERSION,
+  workspaceTopoMetadataSchema,
+  workspaceTrailCollisionSchema,
   workspaceTrailEntrySchema,
   workspaceTrailIndexSchema,
 } from './types.js';
@@ -40,7 +44,6 @@ export type {
   BuildWorkspaceTrailIndexOptions,
   RootManifest,
   WorkspaceTopoLoader,
-  WorkspaceTrailCollision,
   WorkspaceTrailIndexResult,
 } from './workspace-topos.js';
 
@@ -54,6 +57,8 @@ export type {
   LockManifest,
   LockManifestArtifact,
   LockManifestSummary,
+  WorkspaceTopoMetadata,
+  WorkspaceTrailCollision,
   WorkspaceTrailEntry,
   WorkspaceTrailIndex,
   DiffEntry,

--- a/packages/topographer/src/io.ts
+++ b/packages/topographer/src/io.ts
@@ -9,6 +9,7 @@ import type {
   LockManifest,
   ReadOptions,
   TopoGraph,
+  WorkspaceTopoMetadata,
   WorkspaceTrailIndex,
   WriteOptions,
 } from './types.js';
@@ -163,18 +164,29 @@ export const readLockManifest = async (
 };
 
 /**
- * Read the workspace trail-id index from the current lock manifest.
+ * Read workspace metadata from the current topo graph artifact.
  */
-export const readWorkspaceLock = async (
+export const readWorkspaceTopoMetadata = async (
+  options?: ReadOptions
+): Promise<WorkspaceTopoMetadata | null> => {
+  const topoGraph = await readTopoGraph(options);
+  if (topoGraph === null) {
+    return null;
+  }
+  return topoGraph.workspace ?? null;
+};
+
+/**
+ * Read the workspace trail-id index from the current topo graph artifact.
+ */
+export const readWorkspaceTrailIndex = async (
   options?: ReadOptions
 ): Promise<WorkspaceTrailIndex | null> => {
-  const lock = await readLockManifest(options);
-  if (lock === null) {
-    return null;
-  }
-  const { workspaceTrails } = lock;
-  if (workspaceTrails === undefined) {
-    return null;
-  }
-  return workspaceTrails;
+  const workspace = await readWorkspaceTopoMetadata(options);
+  return workspace?.trails ?? null;
 };
+
+/** @deprecated Use {@link readWorkspaceTrailIndex}. */
+export const readWorkspaceLock = async (
+  options?: ReadOptions
+): Promise<WorkspaceTrailIndex | null> => readWorkspaceTrailIndex(options);

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -148,29 +148,32 @@ export interface TopoGraph {
   >;
   readonly generatedAt: string;
   readonly entries: readonly TopoGraphEntry[];
+  readonly workspace?: WorkspaceTopoMetadata | undefined;
 }
 
 // ---------------------------------------------------------------------------
 // Lock Manifest
 // ---------------------------------------------------------------------------
 
-/** Workspace-owned trail entry serialized into a workspace lock. */
-export const workspaceTrailEntrySchema = z.object({
-  appName: z.string(),
-  modulePath: z.string(),
-  trailId: z.string(),
-});
+/** Workspace-owned trail entry serialized into a workspace topo graph. */
+export const workspaceTrailEntrySchema = z
+  .object({
+    appName: z.string(),
+    modulePath: z.string(),
+    trailId: z.string(),
+  })
+  .strict();
 
 export type WorkspaceTrailEntry = z.infer<typeof workspaceTrailEntrySchema>;
 
 /**
- * Workspace-wide trail-id index serialized into a workspace lock.
+ * Workspace-wide trail-id index serialized into a workspace topo graph.
  *
  * Each key is a fully-qualified trail identifier. Each value carries the app
  * that owns it plus the app module path used by consumers that need to load
  * the owning topo without re-walking workspace manifests.
  *
- * @see LockManifest for the lock envelope that may carry this index.
+ * @see TopoGraph for the artifact envelope that may carry this index.
  */
 export const workspaceTrailIndexSchema = z.record(
   z.string(),
@@ -178,6 +181,29 @@ export const workspaceTrailIndexSchema = z.record(
 );
 
 export type WorkspaceTrailIndex = z.infer<typeof workspaceTrailIndexSchema>;
+
+/** A trail id exported by more than one app in a workspace topo graph. */
+export const workspaceTrailCollisionSchema = z
+  .object({
+    apps: z.array(z.string()).min(2),
+    owners: z.array(workspaceTrailEntrySchema).min(2),
+    trailId: z.string(),
+  })
+  .strict();
+
+export type WorkspaceTrailCollision = z.infer<
+  typeof workspaceTrailCollisionSchema
+>;
+
+/** Workspace metadata serialized into a workspace-scope TopoGraph. */
+export const workspaceTopoMetadataSchema = z
+  .object({
+    collisions: z.array(workspaceTrailCollisionSchema).optional(),
+    trails: workspaceTrailIndexSchema,
+  })
+  .strict();
+
+export type WorkspaceTopoMetadata = z.infer<typeof workspaceTopoMetadataSchema>;
 
 export const topoGraphSchema = z
   .object({
@@ -203,6 +229,7 @@ export const topoGraphSchema = z
     ),
     generatedAt: z.string(),
     topoGraphSchemaVersion: z.literal(TOPO_GRAPH_SCHEMA_VERSION),
+    workspace: workspaceTopoMetadataSchema.optional(),
   })
   .strict();
 
@@ -232,7 +259,6 @@ export const lockManifestSchema = z
     scope: z.record(z.string(), z.string()),
     summary: lockManifestSummarySchema,
     version: z.literal(3),
-    workspaceTrails: workspaceTrailIndexSchema.optional(),
   })
   .strict();
 

--- a/packages/topographer/src/workspace-topos.ts
+++ b/packages/topographer/src/workspace-topos.ts
@@ -3,7 +3,7 @@
  *
  * Builds a `{ trailId → appName }` index that lets `trails run <id>` resolve
  * a trail to its owning app without scanning every app's source. The index is
- * either read from a committed workspace lockfile (the cached, fast path) or
+ * either read from a committed `topo.lock` workspace index (the cached, fast path) or
  * discovered by walking the workspace's `workspaces` glob, loading each app's
  * topo, and reading its trail ids.
  *
@@ -15,12 +15,18 @@
  * unaware of workspace topology.
  */
 
+import { existsSync } from 'node:fs';
 import { basename, isAbsolute, join, relative } from 'node:path';
 
 import type { Topo } from '@ontrails/core';
 
-import { readWorkspaceLock } from './io.js';
-import type { WorkspaceTrailEntry, WorkspaceTrailIndex } from './types.js';
+import { readWorkspaceTopoMetadata } from './io.js';
+import type {
+  WorkspaceTopoMetadata,
+  WorkspaceTrailCollision,
+  WorkspaceTrailEntry,
+  WorkspaceTrailIndex,
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -53,29 +59,12 @@ export interface BuildWorkspaceTrailIndexOptions {
    */
   readonly loadTopo?: WorkspaceTopoLoader;
   /**
-   * Lock directory consulted before discovery runs. Defaults to `.trails`
-   * relative to `cwd` — matches {@link readWorkspaceLock}'s default.
+   * Topo artifact directory consulted before discovery runs. Defaults to `.trails`
+   * relative to `cwd` — matches {@link readWorkspaceTopoMetadata}'s default.
    */
+  readonly artifactDir?: string | undefined;
+  /** @deprecated Use `artifactDir`. */
   readonly lockDir?: string;
-}
-
-/**
- * A trail id exported by more than one app in the workspace.
- *
- * @remarks
- * Collisions are facts, not warnings. Callers (e.g. `trails run <id>`) decide
- * whether to prompt the user, error out, or honor an explicit `--app` override
- * — none of which the discovery layer can decide on its own.
- *
- * `owners` carries the same app/module-path entries as non-colliding index
- * values so consumers can resolve an explicit app override without repeating
- * workspace manifest discovery. `apps` is the stable, display-ready projection
- * of those owners and is guaranteed to contain at least two entries.
- */
-export interface WorkspaceTrailCollision {
-  readonly trailId: string;
-  readonly apps: readonly string[];
-  readonly owners: readonly WorkspaceTrailEntry[];
 }
 
 /**
@@ -87,16 +76,16 @@ export interface WorkspaceTrailCollision {
  * and recorded in `collisions` instead — callers must consult `collisions`
  * to resolve ambiguous ids deterministically.
  *
- * `source` distinguishes a cache hit (the lockfile already carried
- * `workspaceTrails`) from discovery (apps were walked and loaded). The
- * lockfile path cannot collide because the lockfile is itself a flat
+ * `source` distinguishes a cache hit (the topo artifact already carried the
+ * workspace trail index) from discovery (apps were walked and loaded). The
+ * topo artifact path cannot collide because the index is itself a flat
  * `{ trailId → appName }` map. `apps` lists the app names actually represented
  * in the index. `warnings` reports load failures and other non-collision
  * issues; collisions live in their own structured field.
  */
 export interface WorkspaceTrailIndexResult {
   readonly index: WorkspaceTrailIndex;
-  readonly source: 'lockfile' | 'discovery';
+  readonly source: 'topo-lock' | 'discovery';
   readonly apps: readonly string[];
   readonly warnings: readonly string[];
   readonly collisions: readonly WorkspaceTrailCollision[];
@@ -357,18 +346,25 @@ const resolveOwners = (
   return { collisions, index };
 };
 
-const buildFromLockfile = (
-  workspaceTrails: WorkspaceTrailIndex
+const buildFromTopoLock = (
+  workspace: WorkspaceTopoMetadata
 ): WorkspaceTrailIndexResult => {
   const apps = new Set<string>();
-  for (const entry of Object.values(workspaceTrails)) {
+  const collisions = Object.freeze([...(workspace.collisions ?? [])]);
+  const workspaceIndex = workspace.trails;
+  for (const entry of Object.values(workspaceIndex)) {
     apps.add(entry.appName);
+  }
+  for (const collision of collisions) {
+    for (const appName of collision.apps) {
+      apps.add(appName);
+    }
   }
   return {
     apps: [...apps].toSorted(),
-    collisions: [],
-    index: Object.freeze({ ...workspaceTrails }),
-    source: 'lockfile',
+    collisions,
+    index: Object.freeze({ ...workspaceIndex }),
+    source: 'topo-lock',
     warnings: [],
   };
 };
@@ -443,14 +439,14 @@ const buildFromDiscovery = async (
 /**
  * Build a workspace-wide trail-id-to-app-name index.
  *
- * Prefers a committed workspace lockfile (`.trails/trails.lock` carrying a
- * `workspaceTrails` entry) when present; otherwise walks the workspace's
+ * Prefers a committed topo artifact (`.trails/topo.lock` carrying a workspace
+ * trail index) when present; otherwise walks the workspace's
  * `workspaces` globs, loads each app's topo, and reads its trail ids.
  *
  * @example
  * ```ts
  * const result = await buildWorkspaceTrailIndex({ cwd: process.cwd() });
- * if (result.source === 'lockfile') {
+ * if (result.source === 'topo-lock') {
  *   // Cached path — no app loading happened.
  * }
  * const owningApp = result.index['my-app.do-thing'];
@@ -459,24 +455,29 @@ const buildFromDiscovery = async (
 export const buildWorkspaceTrailIndex = async (
   options: BuildWorkspaceTrailIndexOptions
 ): Promise<WorkspaceTrailIndexResult> => {
-  const { cwd, loadTopo = defaultLoadTopo, lockDir } = options;
+  const {
+    artifactDir = options.lockDir,
+    cwd,
+    loadTopo = defaultLoadTopo,
+  } = options;
 
-  let resolvedLockDir: string;
-  if (lockDir === undefined) {
-    resolvedLockDir = join(cwd, '.trails');
-  } else if (isAbsolute(lockDir)) {
-    resolvedLockDir = lockDir;
+  let resolvedArtifactDir: string;
+  if (artifactDir === undefined) {
+    resolvedArtifactDir = join(cwd, '.trails');
+  } else if (isAbsolute(artifactDir)) {
+    resolvedArtifactDir = artifactDir;
   } else {
-    resolvedLockDir = join(cwd, lockDir);
+    resolvedArtifactDir = join(cwd, artifactDir);
   }
-  const lockedIndex = await readWorkspaceLock({
-    dir: resolvedLockDir,
+  const workspace = await readWorkspaceTopoMetadata({
+    dir: resolvedArtifactDir,
   });
-  if (lockedIndex !== null) {
-    return buildFromLockfile(lockedIndex);
+  if (workspace !== null) {
+    return buildFromTopoLock(workspace);
   }
 
-  return await buildFromDiscovery(cwd, loadTopo, [
-    `No workspace lockfile found in "${resolvedLockDir}"; falling back to discovery.`,
-  ]);
+  const fallbackWarning = existsSync(join(resolvedArtifactDir, 'topo.lock'))
+    ? `Workspace topo.lock in "${resolvedArtifactDir}" does not include workspace metadata; falling back to discovery.`
+    : `No workspace topo.lock found in "${resolvedArtifactDir}"; falling back to discovery.`;
+  return await buildFromDiscovery(cwd, loadTopo, [fallbackWarning]);
 };


### PR DESCRIPTION
## Context

The last Stack 1 branch moves workspace trail ownership metadata to the artifact that actually serializes resolved topology.

This PR covers TRL-701. It is built on the corrected TRL-700 workspace layout: `trails.lock` stays a compact manifest, while `topo.lock` carries optional workspace metadata under `TopoGraph.workspace`.

## Changes

- Moves workspace trail index metadata out of the lock manifest and into `TopoGraph.workspace` in `topo.lock`.
- Adds strict schemas for workspace trail entries, workspace trail indexes, collision metadata, and workspace topo metadata.
- Adds `readWorkspaceTopoMetadata()` and `readWorkspaceTrailIndex()` over `topo.lock`, while keeping `readWorkspaceLock()` as a deprecated compatibility alias.
- Updates workspace index building to prefer `topo.lock` metadata, fall back to discovery when no workspace metadata exists, and distinguish missing `topo.lock` from a `topo.lock` without workspace metadata.
- Preserves structured collision metadata from persisted workspace topo graphs without reloading every app.
- Renames the workspace index source from `lockfile` to `topo-lock` in tests and docs.
- Updates completions, Topographer README, ADR-0042, and workspace-topos tests for the new artifact ownership.
- Adds a changeset for the workspace index relocation.

## Verification

Local verification in this review-feedback pass:

- `bun scripts/adr.ts check`
- `bun test packages/topographer/src/__tests__/io.test.ts packages/warden/src/__tests__/drift.test.ts apps/trails/src/__tests__/topo-dev.test.ts apps/trails/src/__tests__/run-watch.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run format:check`
- `bun run test`
- `bun run build`
- `bun run check`
- `git diff --check`

Remote CI, Greptile, and Graphite mergeability rerun on every push; use the PR check rollup for current remote status.

## Release / Risk

This is the final Stack 1 artifact-family alignment: `trails.lock` remains compact, and workspace topology belongs in `topo.lock`. Consumers still using the deprecated `readWorkspaceLock()` alias should move to `readWorkspaceTrailIndex()`.