### PR TITLE
docs: clarify persisted surface row completeness

### DIFF
--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
@@ -56,7 +56,7 @@ ready and again before final handoff.
 | Order | Issue | Branch | PR | Status |
 | --- | --- | --- | --- | --- |
 | 1 | `TRL-655` | `trl-655-add-typed-topo-store-views-over-topograph-saved-state` | TBD | Implemented locally |
-| 2 | `TRL-656` | `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial` | TBD | Not started |
+| 2 | `TRL-656` | `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial` | TBD | Implemented locally |
 | 3 | `TRL-657` | `trl-657-add-complete-resolved-contract-detail-view-for-blind-agents` | TBD | Not started |
 | 4 | `TRL-653` | `trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph` | TBD | Not started |
 | 5 | `TRL-702` | `trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces` | TBD | Not started |
@@ -130,6 +130,11 @@ ready waves, and remote review turns here.
   payloads; existing resource/signal read paths share the helper instead of
   parsing `topoGraphJson` inline. Added topographer docs, tests, and a
   `@ontrails/topographer` patch changeset.
+- 2026-05-12 14:05 EDT: Moved `TRL-656` to `In Progress`, created
+  `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial`, and
+  implemented the explicit partial-row posture for `topo_surfaces`. The SQL
+  rows are documented and tested as CLI-only operational projections, while
+  complete graph detail stays in `TopoGraph` and typed entry views.
 
 ## Verification Log
 
@@ -154,6 +159,15 @@ Branch `TRL-655` focused checks:
 - `bun run typecheck` - passed.
 - `bun run format:check` - passed.
 - `bun run lint` - passed.
+- `git diff --check` - passed.
+
+Branch `TRL-656` focused checks:
+
+- `bun test packages/topographer/src/__tests__/topo-store.test.ts
+  packages/topographer/src/__tests__/topo-store-read.test.ts` - passed,
+  29 tests / 169 expects.
+- `bun run typecheck` - passed.
+- `bun run format:check` - passed.
 - `git diff --check` - passed.
 
 ## Review Feedback

--- a/docs/topo-store-reference.md
+++ b/docs/topo-store-reference.md
@@ -168,6 +168,15 @@ CREATE TABLE topo_examples (
 
 Which surfaces expose which trails.
 
+This table is an operational query projection, not the canonical complete
+surface graph. In the current v1 posture it records CLI-derived rows only:
+`surface = 'cli'`, the CLI command name in `derived_name`, and `method = NULL`.
+Schema-rich contract detail lives in the saved `TopoGraph`
+(`topo_exports.topo_graph`) and the typed `store.topoGraph` / `store.entries`
+accessors. Today the TopoGraph's surface-related facts are the authored
+`surfaces` list and CLI path metadata; complete multi-surface projection rows
+remain future work.
+
 ```sql
 CREATE TABLE topo_surfaces (
   trail_id TEXT NOT NULL,

--- a/packages/topographer/src/__tests__/topo-store-read.test.ts
+++ b/packages/topographer/src/__tests__/topo-store-read.test.ts
@@ -688,6 +688,53 @@ describe('read-only topo store', () => {
     ).toBeUndefined();
   });
 
+  test('distinguishes CLI surface rows from canonical TopoGraph detail', async () => {
+    const rootDir = makeRoot();
+    const snapshot = await expectOk(
+      createTopoSnapshot(graphAttachmentApp(), {
+        createdAt: '2026-04-03T16:30:00.000Z',
+        gitSha: 'abc123',
+        rootDir,
+      })
+    );
+    const store = createTopoStore({ rootDir });
+
+    expect(
+      store.query<{
+        derived_name: string;
+        method: string | null;
+        surface: string;
+        trail_id: string;
+      }>(
+        `SELECT trail_id, surface, derived_name, method
+         FROM topo_surfaces
+         WHERE snapshot_id = ?
+         ORDER BY trail_id ASC, surface ASC`,
+        [snapshot.id]
+      )
+    ).toEqual([
+      {
+        derived_name: 'entity process',
+        method: null,
+        surface: 'cli',
+        trail_id: 'entity.process',
+      },
+    ]);
+
+    const graphDetail = store.entries.get('entity.process', {
+      kind: 'trail',
+      snapshot: { snapshotId: snapshot.id },
+    });
+    expect(graphDetail).toEqual(
+      expect.objectContaining({
+        activationSources: expect.any(Array),
+        fieldOverrides: expect.any(Array),
+        layers: expect.any(Array),
+        output: expect.objectContaining({ type: 'object' }),
+      })
+    );
+  });
+
   test('defaults omitted detour maxAttempts to one in detailed views', async () => {
     const rootDir = makeRoot();
     const withDefaultDetour = trail('entity.with-default-detour', {

--- a/packages/topographer/src/__tests__/topo-store.test.ts
+++ b/packages/topographer/src/__tests__/topo-store.test.ts
@@ -254,11 +254,19 @@ const readSurfaceRows = (
   snapshotId: string
 ) =>
   db
-    .query<{ derived_name: string; trail_id: string }, [string]>(
-      `SELECT trail_id, derived_name
+    .query<
+      {
+        derived_name: string;
+        method: string | null;
+        surface: string;
+        trail_id: string;
+      },
+      [string]
+    >(
+      `SELECT trail_id, surface, derived_name, method
        FROM topo_surfaces
        WHERE snapshot_id = ?
-       ORDER BY trail_id ASC`
+       ORDER BY trail_id ASC, surface ASC`
     )
     .all(snapshotId);
 
@@ -365,8 +373,18 @@ const expectProjectedFixtureRows = (
     { signal_id: 'entity.added', trail_id: 'entity.add' },
   ]);
   expect(readSurfaceRows(db, snapshotId)).toEqual([
-    { derived_name: 'entity add', trail_id: 'entity.add' },
-    { derived_name: 'entity list', trail_id: 'entity.list' },
+    {
+      derived_name: 'entity add',
+      method: null,
+      surface: 'cli',
+      trail_id: 'entity.add',
+    },
+    {
+      derived_name: 'entity list',
+      method: null,
+      surface: 'cli',
+      trail_id: 'entity.list',
+    },
   ]);
   expect(readExampleRows(db, snapshotId)).toEqual([
     {


### PR DESCRIPTION
## Context

M4b needs persisted surface data to be honest about what it contains. `topo_surfaces` is an operational projection, not the complete resolved contract detail surface for blind agents.

## Changes

- Clarifies the persisted surface-row contract as intentionally partial.
- Aligns tests and docs around the CLI-oriented role of `topo_surfaces`.
- Points complete contract inspection at the TopoGraph/query-detail path rather than overloading persisted rows.
- Adds the branch-local changeset for publishable package docs/contract impact.

## Verification

- Focused branch tests were run during local stack construction.
- Full stack tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run dead-code`, Warden guide sync/check commands, `bun run publish:check`, and `git diff --check`.
- Local review ran three full rounds plus a focused docs/vocab round 4; the latest review evidence is P3-only/clean.
- Doctrine verification against ADR-0046 and the plan passed with no P0/P1/P2 findings.

## Risks / rollout notes

This intentionally does not make `topo_surfaces` a full contract-detail store. It narrows the contract to avoid false completeness claims while preserving the operational rows already used by the CLI.

Closes: TRL-656