### PR TITLE
docs: sweep TopoGraph references and agent guidance

### DIFF
--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
@@ -58,7 +58,7 @@ ready and again before final handoff.
 | 1 | `TRL-655` | `trl-655-add-typed-topo-store-views-over-topograph-saved-state` | TBD | Implemented locally |
 | 2 | `TRL-656` | `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial` | TBD | Implemented locally |
 | 3 | `TRL-657` | `trl-657-add-complete-resolved-contract-detail-view-for-blind-agents` | TBD | Implemented locally |
-| 4 | `TRL-653` | `trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph` | TBD | Not started |
+| 4 | `TRL-653` | `trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph` | TBD | Implemented locally |
 | 5 | `TRL-702` | `trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces` | TBD | Not started |
 | 6 | `TRL-692` | `trl-692-clarify-warden-guide-manifest-category-naming-before` | TBD | Not started |
 | 7 | `TRL-690` | `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse` | TBD | Not started |
@@ -142,6 +142,12 @@ ready waves, and remote review turns here.
   contour, activation, governance, and surface-projection facts; `survey.trail`
   exposes the same contract-facing shape through its output schema; docs and
   changesets were updated for the public package behavior.
+- 2026-05-12 14:55 EDT: Moved `TRL-653` to `In Progress`, created
+  `trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph`, and
+  completed the TopoGraph docs/API/agent-guidance sweep. Added lexicon entries
+  for current artifact-family vocabulary, a migration guide for retired
+  SurfaceMap/root-state names, a tracked archive note for ignored v1 plans, and
+  updated stale tenet citations plus draft wayfinding substrate wording.
 
 ## Verification Log
 
@@ -186,6 +192,17 @@ Branch `TRL-657` focused checks:
 - `bun run typecheck` - passed after aligning `CurrentTrailDetail` with
   `TrailDetailReport` and exporting the TopoGraph activation edge/source types
   used by the survey report.
+- `bun run format:check` - passed.
+- `git diff --check` - passed.
+
+Branch `TRL-653` focused checks:
+
+- `bun scripts/adr.ts map` - passed and refreshed ADR decision maps.
+- `bun scripts/adr.ts check` - passed with 0 errors / 0 warnings.
+- `bun scripts/vocab-cutover-audit.ts --rule connector-term` - passed.
+- Manual active stale-term sweep excluding historical/migration/retired-vocabulary
+  files - clean.
+- `bun run typecheck` - passed.
 - `bun run format:check` - passed.
 - `git diff --check` - passed.
 

--- a/.agents/plans/archive/2026-05-12-v1-plans-superseded.md
+++ b/.agents/plans/archive/2026-05-12-v1-plans-superseded.md
@@ -1,0 +1,18 @@
+# Superseded V1 Planning Archive
+
+The ignored `.agents/plans/v1/` packet predates the TopoGraph artifact-family
+cutover and should not be used as current implementation guidance.
+
+Use these current sources instead:
+
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md`
+- `docs/adr/0046-lock-v3-artifact-family.md`
+- `docs/lexicon.md`
+- `docs/migration/topograph-artifact-family.md`
+
+Known retired vocabulary in the old ignored packet includes `SurfaceMap`,
+`_surface.json`, `surface.lock`, `generateSurfaceMap()`, `hashSurfaceMap()`,
+`diffSurfaceMaps()`, `.trails/dev/`, and `.trails/generated/`.
+
+Those references are historical planning residue, not active target-state
+language.

--- a/docs/adr/0011-schema-driven-config.md
+++ b/docs/adr/0011-schema-driven-config.md
@@ -78,7 +78,7 @@ From this declaration, the framework derives:
 
 - **Discovery** — `config.resolve()` searches for `.myapprc.toml`, `.myapprc.jsonc`, `.myapprc.yaml` (walking up from cwd or a specified path). Bun native imports handle parsing with zero dependencies.
 - **Example generation** — `config.generateExample('toml')` produces a commented example file derived from the schema. Defaults shown, required fields marked, `.describe()` text as comments, `.deprecated()` fields annotated with migration guidance. Value constraints (min/max, regex patterns, enum options) are rendered as inline comments.
-- **JSON Schema generation** — `config.jsonSchema()` produces a standard JSON Schema derived from the Zod schema. Shippable as a generated artifact (`.trails/generated/myapp.schema.json`), publishable to a URL, or bundled in the package. IDEs that support `$schema` references get autocomplete and validation for free — the same experience developers get from `biome.json` or `tsconfig.json`.
+- **JSON Schema generation** — `config.jsonSchema()` produces a standard JSON Schema derived from the Zod schema. Shippable as a generated artifact (`.trails/cache/generated/myapp.schema.json`), publishable to a URL, or bundled in the package. IDEs that support `$schema` references get autocomplete and validation for free — the same experience developers get from `biome.json` or `tsconfig.json`.
 - **Introspection** — `config.describe()` returns a structured catalog of every field: path, type, default, description, deprecated status, env binding, and value constraints. Powers `myapp config options` on CLI and agent inspection via MCP. No config file needs to exist — this describes what's possible, not what's configured.
 - **Validation / doctor** — `config.check(path?)` finds the config, parses it, validates through the Zod schema, and returns structured diagnostics: which fields are valid, which are missing, which use defaults, which are deprecated. CLI renders a human-readable checklist. Agents consume the structured form.
 - **Init** — `config.init(dir?, format?)` writes the example file to the target directory. One command to bootstrap a config file for end users.
@@ -250,7 +250,7 @@ Testing auto-resolves the `test` profile when `TRAILS_ENV=test` (the default in 
 
 Every `appConfig` declaration generates three artifact types:
 
-**Example config files** in any supported format. For `defineConfig` (Trails' own config), the framework also generates `.trails/generated/.env.example` from composed resource config schemas:
+**Example config files** in any supported format. For `defineConfig` (Trails' own config), the framework also generates `.trails/cache/generated/.env.example` from composed resource config schemas:
 
 ```bash
 # DATABASE_URL=           # required, string, secret
@@ -276,7 +276,7 @@ For app-facing config, `config.generateExample('toml')` produces format-appropri
 
 JSONC format includes the same comments. Plain JSON omits them — the developer's `formats` declaration controls this.
 
-**JSON Schema** at `.trails/generated/<name>.schema.json`. Derived from the Zod schema. Publishable to a URL or bundled in the package's `exports`. IDEs with `$schema` support get autocomplete and inline validation — the config file lights up like `tsconfig.json` does.
+**JSON Schema** at `.trails/cache/generated/<name>.schema.json`. Derived from the Zod schema. Publishable to a URL or bundled in the package's `exports`. IDEs with `$schema` support get autocomplete and inline validation — the config file lights up like `tsconfig.json` does.
 
 **Introspection output** — not a file, but a queryable structure. `config.describe()` returns the full field catalog. CLI renders it as `myapp config options`. Survey includes it. Agents query it via MCP.
 

--- a/docs/adr/0014-core-database-primitive.md
+++ b/docs/adr/0014-core-database-primitive.md
@@ -14,7 +14,10 @@ owners: ['[galligan](https://github.com/galligan)']
 
 Trails is Bun-native. Bun ships `bun:sqlite` as a first-class built-in: in-process, zero-latency, WAL-capable, with prepared statements and transactions. It adds no dependency. It's the same non-dependency as `node:fs`.
 
-Today the framework has exactly one SQLite usage: the tracing DevStore in `@ontrails/tracing`, which records execution tracks to `.trails/dev/tracing.db`.[^devstore] It's an island. The tracing writes to it; nothing else reads from it or benefits from its existence.
+Before this ADR, the framework had exactly one SQLite usage: the tracing
+DevStore in `@ontrails/tracing`, which recorded execution tracks to a
+subsystem-local database.[^devstore] It was an island. The tracing wrote to it;
+nothing else read from it or benefited from its existence.
 
 Meanwhile, the framework generates and consumes several categories of structural and operational data that are persisted as JSON files or held in memory:
 
@@ -205,7 +208,9 @@ All values have sensible defaults. Zero configuration required.
 - [ADR-0018: Signal-Driven Governance](0018-signal-driven-governance.md) — the framework lifecycle as a topo
 - [ADR-0016: Schema-Derived Persistence](0016-schema-derived-persistence.md) — app-level persistence building on the patterns established here
 
-[^devstore]: The DevStore default path is `.trails/dev/tracing.db`. See `packages/tracing/src/stores/dev.ts`.
+[^devstore]: The current DevStore default path is `.trails/state/trails.db`,
+    shared with other framework subsystems through the core database primitive.
+    Older beta builds used a tracing-local `.trails/dev/tracing.db` path.
 
 ### Amendment log
 

--- a/docs/adr/0021-draft-state-stays-out-of-the-resolved-graph.md
+++ b/docs/adr/0021-draft-state-stays-out-of-the-resolved-graph.md
@@ -19,9 +19,9 @@ But the current validation path makes that hard in exactly the places where the 
 
 The obvious escape hatch in most frameworks is "just use a placeholder and
 clean it up later." Trails can do better than that, but it also cannot weaken
-the resolved graph to make authoring easier. The resolved graph is the story.
-The lock manifest, `topo.lock`, CI, and runtime surfaces all depend on it being
-fully established and queryable.[^tenets]
+the resolved graph to make authoring easier. The resolved topo artifact family
+is the story. The lock manifest, `topo.lock`, CI, and runtime surfaces all
+depend on it being fully established and queryable.[^tenets]
 
 This is one of the few places where Trails has unusually strong structural leverage. We already have:
 
@@ -158,7 +158,7 @@ Draft state is a deliberate sketching tool, not an invisible shortcut.
 
 - [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) — the resolved graph and lockfile must remain established and queryable
 - [ADR-0001: Naming Conventions](0001-naming-conventions.md) — trail IDs are meaningful authored artifacts, so the draft marker must be deliberate and visible
-- [Trails Design Tenets](../tenets.md) — especially "the resolved graph is the story" and "the contract is queryable"
+- [Trails Design Tenets](../tenets.md) — especially "the resolved topo artifact family is the story" and "the contract is queryable"
 
 [^retro]: The Stash dogfood retro identified eager validation of event `from` references as a barrier to incremental authoring.
-[^tenets]: [Trails Design Tenets](../tenets.md) states that the resolved graph is the story and that the contract must stay queryable.
+[^tenets]: [Trails Design Tenets](../tenets.md) states that the resolved topo artifact family is the story and that the contract must stay queryable.

--- a/docs/adr/0035-surface-apis-render-the-graph.md
+++ b/docs/adr/0035-surface-apis-render-the-graph.md
@@ -146,7 +146,7 @@ await surface(graph);
 ```
 
 `topo()` names the primitive. `graph` names the thing returned by it. That
-matches the tenet that the resolved graph is the story.
+matches the tenet that the resolved topo artifact family is the story.
 
 ### Runtime adapters compose on created surfaces, not by inventing new projections
 
@@ -205,7 +205,7 @@ concept count flat.
 ## References
 
 - [ADR-0000: Core Premise](0000-core-premise.md) — the trail is the product;
-  the resolved graph is the story
+  the resolved topo artifact family is the story
 - [ADR-0001: Naming Conventions](0001-naming-conventions.md) — the verb and
   grammar rules this ADR extends
 - [ADR-0005: Framework-Agnostic HTTP Route Model](0005-framework-agnostic-http-route-model.md)

--- a/docs/adr/0042-core-topographer-boundary-doctrine.md
+++ b/docs/adr/0042-core-topographer-boundary-doctrine.md
@@ -281,7 +281,7 @@ The following are deliberately deferred:
 - [ADR-0015: Topo Store](0015-topo-store.md) — the queryable relational projection. This ADR moves its public API into Topographer.
 - [ADR-0017: The Serialized Topo Graph](0017-serialized-topo-graph.md) — the lockfile as the resolved-graph artifact. This ADR keeps the lockfile firmly in tooling, not on the runtime path.
 - [ADR-0035: Surface APIs Render the Graph](0035-surface-apis-render-the-graph.md) — the accepted `derive*` / `create*` / `surface()` grammar. This ADR builds on the same lineage by clarifying which package owns the durable derivations.
-- [Trails Design Tenets](../tenets.md) — especially "the resolved graph is the story" and "the contract is queryable", which this ADR operationalizes as a package boundary.
+- [Trails Design Tenets](../tenets.md) — especially "the resolved topo artifact family is the story" and "the contract is queryable", which this ADR operationalizes as a package boundary.
 - [Lexicon](../lexicon.md) — adds `topographer` as the actor noun for the durable graph artifact role.
 
 [^schema-index]: See `packages/schema/src/index.ts`. The full export list is six functions plus types — no schema authoring helpers.

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -2318,7 +2318,7 @@
           "fromPath": "docs/adr/0046-lock-v3-artifact-family.md"
         },
         {
-          "context": "Extends trail record with `crosses`, `detours`, `resources`, and `examples` arrays. Detailed examples preserve `expected`, `expectedMatch`, and structured signal assertions when they are JSON-serializ",
+          "context": "see [ADR-0045](./adr/0045-v1-resolved-graph-error-scope.md).",
           "from": "topo-store-reference",
           "fromPath": "docs/topo-store-reference.md"
         },
@@ -2355,6 +2355,16 @@
           "context": "- [ADR-0046: Lock v3 Artifact Family](0046-lock-v3-artifact-family.md)",
           "from": "0045",
           "fromPath": "docs/adr/0045-v1-resolved-graph-error-scope.md"
+        },
+        {
+          "context": "[ADR-0046](adr/0046-lock-v3-artifact-family.md).",
+          "from": "lexicon",
+          "fromPath": "docs/lexicon.md"
+        },
+        {
+          "context": "[ADR-0046](./adr/0046-lock-v3-artifact-family.md):",
+          "from": "topo-store-reference",
+          "fromPath": "docs/topo-store-reference.md"
         }
       ],
       "number": "0046",

--- a/docs/adr/drafts/20260503-wayfinding.md
+++ b/docs/adr/drafts/20260503-wayfinding.md
@@ -39,17 +39,17 @@ memorize because go-to-definition did not exist for them.
   trail definitions. No new authoring is required from app developers.
 - **Surfaces are peers.** Wayfinding queries are trails, so CLI, MCP, and HTTP
   project them naturally.
-- **The resolved graph is the story.** Wayfinding makes the serialized graph
-  interactive.
+- **The resolved topo artifact family is the story.** Wayfinding makes the
+  serialized graph content interactive.
 
 ### Substrate honesty
 
-The serialized graph today is the surface map plus the topo store, not yet the
-full resolved topology described in [ADR-0017]. [ADR-0042] settled the
+The serialized graph today is the TopoGraph plus the topo store, not yet every
+possible runtime observation described in [ADR-0017]. [ADR-0042] settled the
 substrate boundary: durable graph artifacts live in `@ontrails/topographer`,
 core stays runtime-only. Wayfinding v0 sits on top of those artifacts, and must
 be honest about what they contain — every query must be answerable from the
-shipped `SurfaceMap` and topo-store record shapes, or be marked deferred.
+shipped `TopoGraph` and topo-store record shapes, or be marked deferred.
 
 ### The recursive property
 
@@ -67,7 +67,7 @@ the tools that traverse the graph.
 
 Wayfinding does not introduce a new primitive. The wayfinder is a package of
 trails whose blazes read the durable graph artifacts owned by
-`@ontrails/topographer`: `SurfaceMap`, `SurfaceLock`, `DiffResult`, and the
+`@ontrails/topographer`: `TopoGraph`, lock manifest helpers, `DiffResult`, and the
 read-only topo store records (`TopoStoreTrailRecord`,
 `TopoStoreTrailDetailRecord`, `TopoStoreResourceRecord`,
 `TopoStoreSignalRecord`).
@@ -88,22 +88,22 @@ This means:
 ### v0 query catalog
 
 The v0 catalog is deliberately narrow. The test for inclusion: every query
-must answer from the data already present in `SurfaceMap` and the topo-store
+must answer from the data already present in `TopoGraph` and the topo-store
 read API today. Queries that need substrate the graph does not yet expose are
 deferred, not ambitiously promised.
 
 | Trail ID | Purpose | Substrate today | Status |
 |---|---|---|---|
-| `wayfind.overview` | Summarize the topo: counts of trails, resources, signals, contours, surfaces, examples; intent distribution; activation source counts | `SurfaceMap.entries`, `SurfaceMap.activationGraph` | v0 |
-| `wayfind.search` | Find trails, contours, resources, or signals by ID, namespace pattern, or intent filter | `SurfaceMap.entries[].id`, `kind`, `intent` | v0 |
-| `wayfind.describe` | Return the full record for one entity by ID | `SurfaceMapEntry` plus `TopoStoreTrailDetailRecord` for the requested entity | v0 |
-| `wayfind.signature` | Tight input / output / intent / idempotent view for a trail | `SurfaceMapEntry.input`, `output`, `intent`, `idempotent` | v0 |
-| `wayfind.neighborhood` | Nearby graph: `crosses`, `crossed-by`, `contours`, `resources`, `signals` (one query, `direction` parameter) | `SurfaceMapEntry.crosses`, `producers`, `consumers`, `resources`, `contours` | v0 |
-| `wayfind.projections` | Show CLI, MCP, and HTTP projections for a trail | `SurfaceMapEntry.cli`, `SurfaceMapEntry.surfaces`, plus surface-derived projections | v0 |
-| `wayfind.examples` | Return examples for a trail or contour | `SurfaceMapEntry.examples`, `TopoStoreExampleRecord` | v0 |
-| `wayfind.diff` | Compare two graph snapshots (e.g. `main` vs branch) | `DiffResult` from `deriveSurfaceMapDiff` | v0 |
+| `wayfind.overview` | Summarize the topo: counts of trails, resources, signals, contours, surfaces, examples; intent distribution; activation source counts | `TopoGraph.entries`, `TopoGraph.activationGraph` | v0 |
+| `wayfind.search` | Find trails, contours, resources, or signals by ID, namespace pattern, or intent filter | `TopoGraph.entries[].id`, `kind`, `intent` | v0 |
+| `wayfind.describe` | Return the full record for one entity by ID | `TopoGraphEntry` plus `TopoStoreTrailDetailRecord` for the requested entity | v0 |
+| `wayfind.signature` | Tight input / output / intent / idempotent view for a trail | `TopoGraphEntry.input`, `output`, `intent`, `idempotent` | v0 |
+| `wayfind.neighborhood` | Nearby graph: `crosses`, `crossed-by`, `contours`, `resources`, `signals` (one query, `direction` parameter) | `TopoGraphEntry.crosses`, `producers`, `consumers`, `resources`, `contours` | v0 |
+| `wayfind.projections` | Show CLI, MCP, and HTTP projections for a trail | `TopoGraphEntry.cli`, `TopoGraphEntry.surfaces`, plus surface-derived projections | v0 |
+| `wayfind.examples` | Return examples for a trail or contour | `TopoGraphEntry.examples`, `TopoStoreExampleRecord` | v0 |
+| `wayfind.diff` | Compare two graph snapshots (e.g. `main` vs branch) | `DiffResult` from `deriveTopoGraphDiff` | v0 |
 
-The proto's `wayfind.errors` is **deferred**. Today's `SurfaceMapEntry` and
+The proto's `wayfind.errors` is **deferred**. Today's `TopoGraphEntry` and
 `TopoStoreTrailRecord` do not catalog declared error classes per trail; the
 error taxonomy ships per surface mapping but is not yet a node-level edge set.
 Reintroduce when the graph carries the data.

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -88,6 +88,73 @@ The durable graph substrate. `@ontrails/topographer` owns the artifacts derived 
 
 A package needs Topographer only when it crosses a process boundary or compares state across time. The runtime never reads Topographer artifacts to execute trails — every `topo()` call resolves entirely in core. See [ADR-0042](adr/0042-core-topographer-boundary-doctrine.md) for the boundary doctrine.
 
+### TopoGraph Artifact Family
+
+These names are the current durable artifact-family vocabulary established by
+[ADR-0046](adr/0046-lock-v3-artifact-family.md).
+
+#### `TopoGraph`
+
+The exported TypeScript type family for the serialized, inspectable graph
+content. A TopoGraph contains trail, signal, resource, contour, activation,
+schema, layer, example, and surface-projection facts. It is the content artifact
+written to `.trails/topo.lock`.
+
+#### `topoGraph`
+
+The JavaScript field and variable spelling for a TopoGraph value, for example
+`stored.topoGraph`, `topoGraphJson`, or `deriveTopoGraph(graph)`.
+
+#### `topo_graph`
+
+The SQL/storage spelling for serialized TopoGraph content. In the topo store,
+`topo_exports.topo_graph` holds the graph content that corresponds to
+`.trails/topo.lock`.
+
+#### `lock_manifest`
+
+The SQL/storage spelling for the stored lock manifest export. The manifest is
+the compact `.trails/trails.lock` artifact that points at `topo.lock` and
+verifies the TopoGraph hash; it is not a second copy of the graph.
+
+#### `.trails/state/`
+
+Ignored mutable runtime state. The default local SQLite database lives at
+`.trails/state/trails.db`; its `-wal` and `-shm` sidecars are transient local
+state and must not be committed.
+
+#### `.trails/cache/`
+
+Ignored rebuildable cache state. Generated helper artifacts that can be rebuilt
+from source contracts belong here rather than beside committed lock artifacts.
+
+#### `.trails/config.local.{ts,js}`
+
+Ignored per-developer config overrides. Use `.trails/config.local.ts` or
+`.trails/config.local.js`; do not create nested `.trails/config/local.*` files.
+
+#### Retired Vocabulary
+
+These names are historical or migration vocabulary, not current target-state
+language for active docs, examples, or agent guidance:
+
+| Retired | Current |
+| --- | --- |
+| `SurfaceMap` | `TopoGraph` |
+| `SurfaceMapEntry` | `TopoGraphEntry` |
+| `_surface.json` | `.trails/topo.lock` |
+| `surface_map` | `topo_graph` |
+| `serialized_lock` | `lock_manifest` when referring to stored manifest export content; `.trails/trails.lock` when referring to the committed manifest file |
+| `.trails/config/local` | `.trails/config.local.{ts,js}` |
+| `.trails/trails.db` | `.trails/state/trails.db` |
+| `.trails/trails.db-shm` / `.trails/trails.db-wal` | `.trails/state/trails.db-shm` / `.trails/state/trails.db-wal` |
+| `.trails/dev/` | `.trails/state/` for mutable runtime state |
+| `.trails/generated/` | `.trails/cache/` for rebuildable generated state |
+
+Historical release notes, old migrations, accepted ADR history, and explicitly
+superseded planning archives may mention retired names when the surrounding text
+clearly marks them as legacy. Active guidance should teach the current names.
+
 ### `permit`
 
 The resolved identity shape that authentication produces. A permit is the artifact the trail receives: identity, scopes, roles — typed and resolved. Auth is the boundary work; the permit is what the trail sees.
@@ -329,7 +396,8 @@ const result = await run(graph, 'entity.show', { id: '123' });
 ### `graph`
 
 The assembled, queryable value returned by `topo()`. The graph is the runtime
-shape that surfaces render, survey inspects, and the lockfile serializes.
+shape that surfaces render, survey inspects, and the TopoGraph artifact family
+serializes for review.
 
 ```typescript
 const graph = topo('myapp', entityModule, searchModule);

--- a/docs/migration/topograph-artifact-family.md
+++ b/docs/migration/topograph-artifact-family.md
@@ -1,0 +1,69 @@
+# TopoGraph Artifact Family Migration
+
+The v1 topo artifact family uses a compact manifest plus an inspectable graph
+content artifact:
+
+- `.trails/trails.lock` is the committed lock v3 manifest.
+- `.trails/topo.lock` is the committed serialized `TopoGraph` content artifact.
+- `.trails/state/trails.db` is ignored mutable SQLite state for snapshots,
+  pins, tracing, and other framework subsystems.
+- `.trails/cache/` is ignored rebuildable cache state.
+- `.trails/config.local.ts` and `.trails/config.local.js` are ignored local
+  override files.
+
+Regenerate the current artifact family with:
+
+```bash
+trails topo compile
+```
+
+Verify committed artifacts with:
+
+```bash
+trails topo verify
+```
+
+## Rename Map
+
+| Retired | Current |
+| --- | --- |
+| `SurfaceMap` | `TopoGraph` |
+| `SurfaceMapEntry` | `TopoGraphEntry` |
+| `deriveSurfaceMap()` / `hashSurfaceMap()` / `diffSurfaceMaps()` | `deriveTopoGraph()` / `deriveTopoGraphHash()` / `deriveTopoGraphDiff()` |
+| `_surface.json` | `.trails/topo.lock` |
+| `surface_map` | `topo_graph` |
+| `serialized_lock` | `lock_manifest` for stored manifest export content; `.trails/trails.lock` for the committed manifest file |
+| `.trails/config/local.*` | `.trails/config.local.ts` or `.trails/config.local.js` |
+| `.trails/trails.db` | `.trails/state/trails.db` |
+| `.trails/dev/` | `.trails/state/` |
+| `.trails/generated/` | `.trails/cache/` |
+
+## Local Cleanup
+
+Current builds create the shared database under `.trails/state/`. If an old
+workspace still has untracked root SQLite sidecars, remove only the legacy root
+files:
+
+```bash
+rm -f .trails/trails.db .trails/trails.db-shm .trails/trails.db-wal
+```
+
+Do not commit any `.trails/state/trails.db*` files. They are local runtime
+state and are ignored by the workspace `.trails/.gitignore`.
+
+## Consumer Updates
+
+Consumers that previously parsed `_surface.json` should read `.trails/topo.lock`
+through `readTopoGraph()` or use the typed topo-store views:
+
+```typescript
+import { createTopoStore, readTopoGraph } from '@ontrails/topographer';
+
+const topoGraph = await readTopoGraph({ dir: '.trails' });
+const store = createTopoStore();
+const detail = store.trails.get('auth.login');
+```
+
+Use `store.topoGraph`, `store.entries`, `store.trails`, `store.resources`,
+`store.signals`, and `store.contours` for queryable access instead of parsing
+serialized JSON in application code.

--- a/docs/migration/trailhead-to-surface.md
+++ b/docs/migration/trailhead-to-surface.md
@@ -18,7 +18,7 @@ The framework now consistently uses `surface` for CLI, MCP, HTTP, and WebSocket 
 | `tracing.query` record field `trailhead` | `surface` | Update CLI/MCP/HTTP/API consumers that inspect query results. |
 | Extension key value `__trails_trailhead` | `__trails_surface` | Update any direct `ctx.extensions` reads/writes to use `SURFACE_KEY`. |
 | `TRAILHEAD_KEY` | removed | Import `SURFACE_KEY` from `@ontrails/core`. |
-| `SurfaceMapEntry.trailheads` | `SurfaceMapEntry.surfaces` | Update surface-map JSON consumers and regenerate maps. |
+| Legacy `SurfaceMapEntry.trailheads` | `TopoGraphEntry.surfaces` | Update JSON consumers to the current TopoGraph artifact family and regenerate artifacts. |
 | `extractTrailheads` | `extractSurfaces` | Update internal imports if you reached into non-public helpers. |
 | `Trailhead "<name>" added/removed` | `Surface "<name>" added/removed` | Update diff-output tests or parsers. |
 | `transportNames` / `TransportName` | `surfaceNames` / `SurfaceName` | Import the surface-named error projection API. |
@@ -93,7 +93,7 @@ Reset local Trails state before upgrading:
 trails dev reset --yes
 ```
 
-If you manage the database manually, delete `.trails/trails.db` and its SQLite sidecar files (`.trails/trails.db-wal`, `.trails/trails.db-shm`) before recreating local state.
+If you manage the database manually on current builds, delete `.trails/state/trails.db` and its SQLite sidecar files (`.trails/state/trails.db-wal`, `.trails/state/trails.db-shm`) before recreating local state. Very old beta workspaces may also have legacy root files at `.trails/trails.db*`; remove those only as migration cleanup.
 
 ## Query Trail
 
@@ -124,9 +124,10 @@ Use `SURFACE_KEY` for surface identity in `ctx.extensions`.
 
 The runtime key value is now `__trails_surface`. Any persisted state keyed by `__trails_trailhead` is invalid after the cutover.
 
-## Surface Maps
+## TopoGraph Entries
 
-Surface maps now store `surfaces` on each entry:
+The current TopoGraph artifact stores `surfaces` on each entry. Historical
+surface-map artifacts used the same field after the trailhead cutover:
 
 ```diff
  {
@@ -136,7 +137,7 @@ Surface maps now store `surfaces` on each entry:
  }
 ```
 
-Regenerate surface maps and locks after upgrading. For the Trails app, use:
+Regenerate TopoGraph artifacts after upgrading. For the Trails app, use:
 
 ```bash
 trails topo compile

--- a/docs/topo-store-reference.md
+++ b/docs/topo-store-reference.md
@@ -378,7 +378,9 @@ see [ADR-0045](./adr/0045-v1-resolved-graph-error-scope.md).
 
 ### `TopoStoreTopoGraphRecord`
 
-Typed view over the saved `TopoGraph` content artifact for a snapshot:
+Typed view over the saved `TopoGraph` content artifact for a snapshot. This is
+the `topo_graph` member of the lock v3 artifact family defined in
+[ADR-0046](./adr/0046-lock-v3-artifact-family.md):
 
 ```typescript
 {

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -3,6 +3,8 @@
 The topo store is Trails' queryable database of your application's topology — every trail, signal, resource, and their relationships. It lives in `.trails/state/trails.db` and is created automatically when you run topo commands.
 
 For the full SQLite schema and programmatic query API, see the [Topo Store Reference](./topo-store-reference.md).
+If you are migrating from the old surface-map or root database layout, see the
+[TopoGraph Artifact Family Migration](./migration/topograph-artifact-family.md).
 
 ## The `.trails/` directory
 
@@ -97,7 +99,8 @@ trails topo compile
 
 ### `trails topo verify`
 
-Check that `.trails/trails.lock` matches your current topo. Fails if the lockfile has drifted.
+Check that the `.trails/trails.lock` / `.trails/topo.lock` artifact family
+matches your current topo. Fails if either committed artifact has drifted.
 
 ```bash
 # In CI
@@ -110,7 +113,7 @@ trails topo verify || exit 1
 
 1. Make topology changes
 2. Compile: `trails topo compile`
-3. Commit `.trails/trails.lock`
+3. Commit `.trails/trails.lock` and `.trails/topo.lock`
 4. In CI, verify: `trails topo verify`
 
 ### Pin before refactoring


### PR DESCRIPTION
## Context

After the artifact-family decision, docs and agent guidance need to describe TopoGraph, surfaces, and saved-state query paths consistently instead of carrying pre-M4b lock/topo vocabulary.

## Changes

- Sweeps API reference, architecture, lexicon, migration, and agent-facing guidance for current TopoGraph artifact-family language.
- Clarifies the role of saved TopoGraph state versus surface projections.
- Archives or annotates stale topo-state wording instead of leaving active guidance ambiguous.
- Keeps ADR-0046 as the doctrine source of truth.

## Verification

- Documentation checks were run during local stack construction.
- Full stack tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run dead-code`, Warden guide sync/check commands, `bun run publish:check`, and `git diff --check`.
- Local review ran three full rounds plus a focused docs/vocab round 4; the latest review evidence is P3-only/clean.
- Doctrine verification against ADR-0046 and the plan passed with no P0/P1/P2 findings.

## Risks / rollout notes

Docs-only drift is the main risk. The follow-on retired-vocabulary guard in the next PR makes active drift visible in CI so this sweep does not rely on memory.

Closes: TRL-653