### PR TITLE
test: guard retired TopoGraph artifact vocabulary

### DIFF
--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
@@ -59,7 +59,7 @@ ready and again before final handoff.
 | 2 | `TRL-656` | `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial` | TBD | Implemented locally |
 | 3 | `TRL-657` | `trl-657-add-complete-resolved-contract-detail-view-for-blind-agents` | TBD | Implemented locally |
 | 4 | `TRL-653` | `trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph` | TBD | Implemented locally |
-| 5 | `TRL-702` | `trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces` | TBD | Not started |
+| 5 | `TRL-702` | `trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces` | TBD | Implemented locally |
 | 6 | `TRL-692` | `trl-692-clarify-warden-guide-manifest-category-naming-before` | TBD | Not started |
 | 7 | `TRL-690` | `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse` | TBD | Not started |
 | 8 | `TRL-691` | `trl-691-polish-generated-warden-guide-headers-and-generator-tests` | TBD | Not started |
@@ -148,6 +148,12 @@ ready waves, and remote review turns here.
   for current artifact-family vocabulary, a migration guide for retired
   SurfaceMap/root-state names, a tracked archive note for ignored v1 plans, and
   updated stale tenet citations plus draft wayfinding substrate wording.
+- 2026-05-12 15:10 EDT: Moved `TRL-702` to `In Progress`, created
+  `trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces`, and
+  added the TopoGraph artifact-family retired-vocabulary guard to the repo vocab
+  audit. The normal `bun run check` gate now runs `bun run vocab:audit`, with
+  explicit exemptions for history, migration notes, accepted ADR context, and
+  legacy cleanup seams.
 
 ## Verification Log
 
@@ -203,6 +209,19 @@ Branch `TRL-653` focused checks:
 - Manual active stale-term sweep excluding historical/migration/retired-vocabulary
   files - clean.
 - `bun run typecheck` - passed.
+- `bun run format:check` - passed.
+- `git diff --check` - passed.
+
+Branch `TRL-702` focused checks:
+
+- `bun scripts/vocab-cutover-audit.ts --list-rules` - passed and showed the new
+  `topograph-artifact-family-retired-term` rule.
+- `bun scripts/vocab-cutover-audit.ts --rule
+  topograph-artifact-family-retired-term` - passed after keeping guard
+  documentation free of banned retired literals.
+- `bun scripts/vocab-cutover-audit.ts` - passed after adding
+  `docs/adr/0044-trail-versioning.md` to reviewed ADR mention paths.
+- `bun run lint:ast-grep` - passed.
 - `bun run format:check` - passed.
 - `git diff --check` - passed.
 

--- a/docs/rule-design.md
+++ b/docs/rule-design.md
@@ -210,6 +210,12 @@ local or `@ontrails/*` import paths, object keys, and literal member properties.
 It intentionally does not lint Markdown prose; docs and historical mention-class
 coverage stays in the vocabulary audit path so migration docs, changelogs, ADRs,
 and contrastive explanations can be classified instead of blindly rewritten.
+`bun run check` runs `bun run vocab:audit` so active docs, scripts, and package
+sources also fail when retired cutover vocabulary reappears outside explicit
+history, migration, or legacy-cleanup seams. The TopoGraph artifact-family guard
+uses this path for the retired artifact-family names listed in the lexicon's
+retired-vocabulary table, including legacy root DB paths and pre-M4b workspace
+directories.
 
 ## Ast-Grep Structural Rules
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "format:guard": "if git grep -nE \"(\\\\./)?node_modules/\\\\.bin/ultra[c]ite\" -- ':!bun.lock'; then echo 'Direct node_modules/.bin formatter invocation found'; exit 1; fi",
     "mdlint:fix": "./node_modules/.bin/markdownlint-cli2 --fix",
     "typecheck": "turbo run typecheck",
-    "check": "bun run lint && bun run lint:ast-grep && bun run format:check && bun run typecheck && bun run docs:snippets && bun run error-taxonomy:check && bun run scaffold-versions:check && bun run warden:agents:check && bun run warden:skills:check && bun run trails:check && bun run dead-code",
+    "check": "bun run lint && bun run lint:ast-grep && bun run vocab:audit && bun run format:check && bun run typecheck && bun run docs:snippets && bun run error-taxonomy:check && bun run scaffold-versions:check && bun run warden:agents:check && bun run warden:skills:check && bun run trails:check && bun run dead-code",
     "clean": "turbo run clean --no-cache && rm -rf node_modules",
     "oxlint-plugin:build": "bun run --cwd packages/oxlint-plugin build:oxlint",
     "publish:check": "bun scripts/publish.ts --check",

--- a/scripts/vocab-cutover-audit.ts
+++ b/scripts/vocab-cutover-audit.ts
@@ -37,6 +37,14 @@ const isExcludedFromRule = (path: string, rule: (typeof auditRules)[number]) =>
   ) ??
     false);
 
+const isAllowedMatch = (
+  match: MatchDetail,
+  rule: (typeof auditRules)[number]
+) =>
+  rule.allowMatches?.some(
+    (allowed) => allowed.path === match.path && allowed.line === match.line
+  ) ?? false;
+
 const getSelectedRules = () =>
   selectedRules.length > 0
     ? auditRules.filter((rule) => selectedRules.includes(rule.id))
@@ -88,11 +96,10 @@ const findRuleResult = async (
   const matches = await Promise.all(
     scopedFiles.map((path) => findMatchDetail(path, rule.pattern))
   );
-  const details = matches.flatMap((match) => match ?? []);
-  const fileCount = matches.reduce(
-    (sum, match) => sum + (match === undefined ? 0 : 1),
-    0
-  );
+  const details = matches
+    .flatMap((match) => match ?? [])
+    .filter((match) => !isAllowedMatch(match, rule));
+  const fileCount = new Set(details.map((match) => match.path)).size;
 
   return {
     description: rule.description,
@@ -117,7 +124,13 @@ const printRuleList = () => {
       (rule.excludePaths?.length ?? 0)
         ? ` (excludes: ${rule.excludePaths?.join(', ')})`
         : '';
-    console.log(`- ${rule.id}: ${rule.description}${exclusions}`);
+    const allowed =
+      (rule.allowMatches?.length ?? 0)
+        ? ` (allows: ${rule.allowMatches
+            ?.map((match) => `${match.path}:${match.line}`)
+            .join(', ')})`
+        : '';
+    console.log(`- ${rule.id}: ${rule.description}${exclusions}${allowed}`);
   }
 };
 

--- a/scripts/vocab-cutover-map.ts
+++ b/scripts/vocab-cutover-map.ts
@@ -1,5 +1,11 @@
+export interface VocabAuditAllowedMatch {
+  readonly line: number;
+  readonly path: string;
+}
+
 export interface VocabAuditRule {
   readonly id: string;
+  readonly allowMatches?: readonly VocabAuditAllowedMatch[];
   readonly description: string;
   readonly excludePaths?: readonly string[];
   readonly pattern: string;
@@ -62,6 +68,7 @@ const adrReviewedMentionPaths = [
   'docs/adr/0038-typed-signal-emission.md',
   'docs/adr/0041-unified-observability.md',
   'docs/adr/0043-layer-evolution.md',
+  'docs/adr/0044-trail-versioning.md',
   'docs/adr/README.md',
   'docs/adr/decision-map.json',
   'docs/adr/drafts/20260331-direct-invocation.md',
@@ -117,6 +124,59 @@ const legacyExtractedAdapterSubpathMentionPaths = [
   'docs/adr/0022-drizzle-store-connector.md',
   'packages/http/README.md',
   'packages/store/README.md',
+] as const;
+
+const topographArtifactFamilyRetiredMentionPaths = [
+  ...historicalMentionPaths,
+  'docs/adr/0042-core-topographer-boundary-doctrine.md',
+  'docs/adr/0046-lock-v3-artifact-family.md',
+  'docs/lexicon.md',
+] as const;
+
+const legacyBootstrapCleanupMatches = [
+  { line: 71, path: 'scripts/bootstrap/config.toml' },
+  { line: 72, path: 'scripts/bootstrap/config.toml' },
+  { line: 73, path: 'scripts/bootstrap/config.toml' },
+  { line: 74, path: 'scripts/bootstrap/config.toml' },
+  { line: 75, path: 'scripts/bootstrap/config.toml' },
+  { line: 76, path: 'scripts/bootstrap/config.toml' },
+] as const;
+
+const topographArtifactFamilyRetiredMatches = [
+  ...legacyBootstrapCleanupMatches,
+  // Legacy root DB and dev-state sidecars are still removed by dev.reset/dev.clean
+  // so upgraded workspaces do not leave stale local files behind.
+  { line: 265, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 266, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 267, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 268, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 269, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 270, path: 'apps/trails/src/trails/dev-support.ts' },
+  // The topo-store migration and fixture must name pre-v12 columns exactly.
+  {
+    line: 325,
+    path: 'packages/topographer/src/internal/topo-snapshots.ts',
+  },
+  {
+    line: 335,
+    path: 'packages/topographer/src/internal/topo-snapshots.ts',
+  },
+  {
+    line: 1323,
+    path: 'packages/topographer/src/__tests__/topo-store.test.ts',
+  },
+  {
+    line: 1325,
+    path: 'packages/topographer/src/__tests__/topo-store.test.ts',
+  },
+  {
+    line: 1339,
+    path: 'packages/topographer/src/__tests__/topo-store.test.ts',
+  },
+  {
+    line: 1341,
+    path: 'packages/topographer/src/__tests__/topo-store.test.ts',
+  },
 ] as const;
 
 export const auditRules: readonly VocabAuditRule[] = [
@@ -263,6 +323,14 @@ export const auditRules: readonly VocabAuditRule[] = [
     excludePaths: legacyExtractedAdapterSubpathMentionPaths,
     id: 'legacy-extracted-adapter-subpath',
     pattern: String.raw`@ontrails/(?:http/hono|store/drizzle|cli/commander)`,
+  },
+  {
+    allowMatches: topographArtifactFamilyRetiredMatches,
+    description:
+      'Retired TopoGraph artifact-family vocabulary still appears outside history, migration notes, and legacy cleanup seams.',
+    excludePaths: topographArtifactFamilyRetiredMentionPaths,
+    id: 'topograph-artifact-family-retired-term',
+    pattern: String.raw`\bSurfaceMap(?:Entry)?\b|_surface\.json|\bsurface_map\b|\bserialized_lock\b|\.trails/config/local(?:\.[tj]s)?|\.trails/trails\.db(?:-(?:shm|wal))?|\.trails/dev/|\.trails/generated/`,
   },
   {
     description:


### PR DESCRIPTION
## Context

The M4b docs sweep should stay locked. Active source and guidance need a guard against retired artifact-family vocabulary such as old topo-state phrasing returning without an explicit, narrow allowance.

## Changes

- Adds retired TopoGraph vocabulary checks to `vocab:audit` / `check`.
- Uses exact line-scoped allowances for legacy bootstrap, fixture, and internal snapshot references that remain intentional.
- Keeps broad active-file exclusions out of the guard so new drift is caught.
- Adds focused tests for the active vocabulary policy.

## Verification

- Focused vocabulary checks were run during local stack construction.
- Full stack tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run dead-code`, Warden guide sync/check commands, `bun run publish:check`, and `git diff --check`.
- Local review ran three full rounds plus a focused docs/vocab round 4; the latest review evidence is P3-only/clean.
- Doctrine verification initially caught a broad-exclusion P2; this PR was repaired on its owning branch and the rerun passed with no P0/P1/P2 findings.

## Risks / rollout notes

The guard can require explicit allowances for intentional historical language. That is deliberate: active artifact-family vocabulary should fail loudly rather than drift silently.

Closes: TRL-702