### PR TITLE
refactor: rename Warden guide category to concern

### DIFF
--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
@@ -60,7 +60,7 @@ ready and again before final handoff.
 | 3 | `TRL-657` | `trl-657-add-complete-resolved-contract-detail-view-for-blind-agents` | TBD | Implemented locally |
 | 4 | `TRL-653` | `trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph` | TBD | Implemented locally |
 | 5 | `TRL-702` | `trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces` | TBD | Implemented locally |
-| 6 | `TRL-692` | `trl-692-clarify-warden-guide-manifest-category-naming-before` | TBD | Not started |
+| 6 | `TRL-692` | `trl-692-clarify-warden-guide-manifest-category-naming-before` | TBD | Implemented locally |
 | 7 | `TRL-690` | `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse` | TBD | Not started |
 | 8 | `TRL-691` | `trl-691-polish-generated-warden-guide-headers-and-generator-tests` | TBD | Not started |
 | 9 | `TRL-693` | `trl-693-tighten-cli-value-alias-conflicts-for-non-commander-callers` | TBD | Not started |
@@ -154,6 +154,12 @@ ready waves, and remote review turns here.
   audit. The normal `bun run check` gate now runs `bun run vocab:audit`, with
   explicit exemptions for history, migration notes, accepted ADR context, and
   legacy cleanup seams.
+- 2026-05-12 15:30 EDT: Moved `TRL-692` to `In Progress`, created
+  `trl-692-clarify-warden-guide-manifest-category-naming-before`, and renamed
+  the Warden guide manifest grouping field from `category` to `concern` so it
+  matches the source `WardenRuleMetadata.concern` taxonomy. Updated package/app
+  schemas, generator grouping helpers, generated skill guide references, and
+  branch-local changeset metadata.
 
 ## Verification Log
 
@@ -222,6 +228,19 @@ Branch `TRL-702` focused checks:
 - `bun scripts/vocab-cutover-audit.ts` - passed after adding
   `docs/adr/0044-trail-versioning.md` to reviewed ADR mention paths.
 - `bun run lint:ast-grep` - passed.
+- `bun run format:check` - passed.
+- `git diff --check` - passed.
+
+Branch `TRL-692` focused checks:
+
+- `bun test packages/warden` - passed, 886 tests / 2180 expects.
+- `bun test apps/trails/src/__tests__/warden.test.ts` - passed, 15 tests /
+  87 expects.
+- `bun run typecheck` - passed.
+- `bun run warden:skills:sync` - refreshed generated skill Warden references
+  after the agent instruction wording changed from category to concern.
+- `bun run warden:agents:check` - passed.
+- `bun run warden:skills:check` - passed after sync.
 - `bun run format:check` - passed.
 - `git diff --check` - passed.
 

--- a/.changeset/trl-692-warden-guide-concern.md
+++ b/.changeset/trl-692-warden-guide-concern.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/trails": minor
+"@ontrails/warden": minor
+---
+
+Rename Warden guide manifest rule grouping from `category` to `concern` so the
+public JSON contract matches the source metadata field.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -11,7 +11,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 - Treat Warden rules as enforceable Trails doctrine when working in this repository.
 - Prefer the rule guidance summary and ordered steps over diagnostic prose when deciding how to remediate a finding.
-- When guidance is absent, use the invariant, category, tier, and scope as classification metadata rather than inventing a rule-specific fix.
+- When guidance is absent, use the invariant, concern, tier, and scope as classification metadata rather than inventing a rule-specific fix.
 - Treat `docs/tenets.md`, `docs/lexicon.md`, and `AGENTS.md` as higher-authority orientation when prose conflicts with generated rule summaries.
 - Do not manually duplicate the rule index into skill prompts. Refresh this file when Warden metadata changes.
 

--- a/apps/trails/src/trails/warden-guide.ts
+++ b/apps/trails/src/trails/warden-guide.ts
@@ -27,7 +27,7 @@ const wardenGuidanceSchema = z.object({
 });
 
 const wardenRuleGuideEntrySchema = z.object({
-  category: z.enum(wardenRuleConcerns),
+  concern: z.enum(wardenRuleConcerns),
   depth: z.enum(wardenDepthValues),
   description: z.string(),
   docs: z.array(wardenGuidanceLinkSchema).readonly(),

--- a/packages/warden/src/__tests__/guide.test.ts
+++ b/packages/warden/src/__tests__/guide.test.ts
@@ -20,11 +20,12 @@ describe('warden guide manifest', () => {
       (rule) => rule.id === 'no-throw-in-implementation'
     );
     expect(throwRule).toMatchObject({
-      category: 'results',
+      concern: 'results',
       depth: 'source',
       severity: 'error',
       tier: 'source-static',
     });
+    expect(throwRule).not.toHaveProperty('category');
     expect(throwRule?.guidance?.summary).toBe(
       'Convert thrown implementation failures into explicit Result.err() outcomes.'
     );
@@ -35,6 +36,8 @@ describe('warden guide manifest', () => {
 
     expect(markdown).toContain('# Trails Warden Guide');
     expect(markdown).toContain('### `no-throw-in-implementation`');
+    expect(markdown).toContain('- Concern: `results`');
+    expect(markdown).not.toContain('- Category: `results`');
     expect(markdown).toContain(
       'Guidance: Convert thrown implementation failures into explicit Result.err() outcomes.'
     );
@@ -50,6 +53,8 @@ describe('warden guide manifest', () => {
     expect(parsed.kind).toBe('trails-warden-agent-guide');
     expect(parsed.rules).toHaveLength(manifest.ruleCount);
     expect(parsed.rules[0]?.id).toBe(manifest.rules[0]?.id);
+    expect(parsed.rules[0]).toHaveProperty('concern');
+    expect(parsed.rules[0]).not.toHaveProperty('category');
   });
 
   test('manifest rendering is stable and parseable', () => {
@@ -60,5 +65,7 @@ describe('warden guide manifest', () => {
     expect(parsed.kind).toBe('trails-warden-guide-manifest');
     expect(parsed.ruleCount).toBe(manifest.ruleCount);
     expect(parsed.rules.at(-1)?.id).toBe(manifest.rules.at(-1)?.id);
+    expect(parsed.rules.at(-1)).toHaveProperty('concern');
+    expect(parsed.rules.at(-1)).not.toHaveProperty('category');
   });
 });

--- a/packages/warden/src/guide.ts
+++ b/packages/warden/src/guide.ts
@@ -23,7 +23,7 @@ export const wardenGuideFormatValues = [
 export type WardenGuideFormat = (typeof wardenGuideFormatValues)[number];
 
 export interface WardenRuleGuideEntry {
-  readonly category: WardenRuleConcern;
+  readonly concern: WardenRuleConcern;
   readonly depth: WardenDepth;
   readonly description: string;
   readonly docs: readonly WardenGuidanceLink[];
@@ -54,7 +54,7 @@ interface WardenAgentRuleGuide {
     readonly scope: WardenRuleScope;
     readonly tier: WardenRuleTier;
   };
-  readonly category: WardenRuleConcern;
+  readonly concern: WardenRuleConcern;
   readonly guidance?: WardenGuidance | undefined;
   readonly id: string;
   readonly invariant: string;
@@ -83,7 +83,7 @@ export const buildWardenGuideManifest = (): WardenGuideManifest => {
       const rule = lookupRule(id);
       const docs = metadata.guidance?.docs ?? [];
       return {
-        category: metadata.concern,
+        concern: metadata.concern,
         depth: metadata.depth,
         description: rule?.description ?? '',
         docs,
@@ -140,7 +140,7 @@ const renderRuleMarkdown = (rule: WardenRuleGuideEntry): readonly string[] => {
     `### \`${rule.id}\``,
     '',
     `- Severity: \`${rule.severity}\``,
-    `- Category: \`${rule.category}\``,
+    `- Concern: \`${rule.concern}\``,
     `- Depth: \`${rule.depth}\``,
     `- Tier: \`${rule.tier}\``,
     `- Scope: \`${rule.scope}\``,
@@ -200,7 +200,7 @@ export const buildWardenAgentGuide = (
   instructions: [
     'Treat Warden rules as enforceable Trails doctrine when working in this repository.',
     'Prefer the rule guidance summary and ordered steps over diagnostic prose when deciding how to remediate a finding.',
-    'When guidance is absent, use the invariant, category, tier, and scope as classification metadata rather than inventing a rule-specific fix.',
+    'When guidance is absent, use the invariant, concern, tier, and scope as classification metadata rather than inventing a rule-specific fix.',
   ],
   kind: 'trails-warden-agent-guide',
   rules: manifest.rules.map((rule) => ({
@@ -209,7 +209,7 @@ export const buildWardenAgentGuide = (
       scope: rule.scope,
       tier: rule.tier,
     },
-    category: rule.category,
+    concern: rule.concern,
     guidance: rule.guidance,
     id: rule.id,
     invariant: rule.invariant,

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -11,7 +11,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 - Treat Warden rules as enforceable Trails doctrine when working in this repository.
 - Prefer the rule guidance summary and ordered steps over diagnostic prose when deciding how to remediate a finding.
-- When guidance is absent, use the invariant, category, tier, and scope as classification metadata rather than inventing a rule-specific fix.
+- When guidance is absent, use the invariant, concern, tier, and scope as classification metadata rather than inventing a rule-specific fix.
 - Treat `docs/tenets.md`, `docs/lexicon.md`, and `AGENTS.md` as higher-authority orientation when prose conflicts with generated rule summaries.
 - Do not manually duplicate the rule index into skill prompts. Refresh this file when Warden metadata changes.
 

--- a/scripts/sync-agents-warden-guide.ts
+++ b/scripts/sync-agents-warden-guide.ts
@@ -33,12 +33,12 @@ const renderGeneratedHeader = (
   `- Rule count: ${manifest.ruleCount}`,
 ];
 
-const groupRulesByCategory = (
+const groupRulesByConcern = (
   rules: readonly WardenRuleGuideEntry[]
 ): ReadonlyMap<WardenRuleConcern, readonly WardenRuleGuideEntry[]> => {
   const grouped = new Map<WardenRuleConcern, WardenRuleGuideEntry[]>();
   for (const rule of rules) {
-    grouped.set(rule.category, [...(grouped.get(rule.category) ?? []), rule]);
+    grouped.set(rule.concern, [...(grouped.get(rule.concern) ?? []), rule]);
   }
   return grouped;
 };
@@ -49,7 +49,7 @@ const renderRule = (rule: WardenRuleGuideEntry): string =>
 const renderCategorySections = (
   manifest: WardenGuideManifest
 ): readonly string[] => {
-  const grouped = groupRulesByCategory(manifest.rules);
+  const grouped = groupRulesByConcern(manifest.rules);
   const lines = ['', '### Rule Index', ''];
 
   for (const category of Object.keys(CATEGORY_LABELS) as WardenRuleConcern[]) {

--- a/scripts/sync-skill-warden-guide.ts
+++ b/scripts/sync-skill-warden-guide.ts
@@ -30,12 +30,12 @@ const CATEGORY_LABELS: Record<WardenRuleConcern, string> = {
   signals: 'Signals',
 };
 
-const groupRulesByCategory = (
+const groupRulesByConcern = (
   rules: readonly WardenRuleGuideEntry[]
 ): ReadonlyMap<WardenRuleConcern, readonly WardenRuleGuideEntry[]> => {
   const grouped = new Map<WardenRuleConcern, WardenRuleGuideEntry[]>();
   for (const rule of rules) {
-    grouped.set(rule.category, [...(grouped.get(rule.category) ?? []), rule]);
+    grouped.set(rule.concern, [...(grouped.get(rule.concern) ?? []), rule]);
   }
   return grouped;
 };
@@ -76,7 +76,7 @@ const renderRule = (rule: WardenRuleGuideEntry): string => {
 };
 
 const renderRuleIndex = (manifest: WardenGuideManifest): readonly string[] => {
-  const grouped = groupRulesByCategory(manifest.rules);
+  const grouped = groupRulesByConcern(manifest.rules);
   const lines = ['## Rule Index', ''];
 
   for (const category of Object.keys(CATEGORY_LABELS) as WardenRuleConcern[]) {


### PR DESCRIPTION
## Context

Before the Warden guide polish lands, the manifest/output vocabulary should stop exposing `category` as the public grouping name where the guide doctrine now uses `concern`.

## Changes

- Renames Warden guide manifest category terminology to concern where it is part of the generated guide contract.
- Preserves behavior while making the output vocabulary match current guide naming.
- Adds coverage so the generated guide shape remains stable.

## Verification

- Focused Warden guide tests were run during local stack construction.
- Full stack tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run dead-code`, Warden guide sync/check commands, `bun run publish:check`, and `git diff --check`.
- Local review ran three full rounds plus a focused docs/vocab round 4; the latest review evidence is P3-only/clean.

## Risks / rollout notes

The public generated guide output moves to `concern`; internal helper names may still be polished separately when they are not part of the emitted contract.

Closes: TRL-692