### PR TITLE
test: cover generated Warden guide headers

### DIFF
--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
@@ -62,7 +62,7 @@ ready and again before final handoff.
 | 5 | `TRL-702` | `trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces` | TBD | Implemented locally |
 | 6 | `TRL-692` | `trl-692-clarify-warden-guide-manifest-category-naming-before` | TBD | Implemented locally |
 | 7 | `TRL-690` | `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse` | TBD | Implemented locally |
-| 8 | `TRL-691` | `trl-691-polish-generated-warden-guide-headers-and-generator-tests` | TBD | Not started |
+| 8 | `TRL-691` | `trl-691-polish-generated-warden-guide-headers-and-generator-tests` | TBD | Implemented locally |
 | 9 | `TRL-693` | `trl-693-tighten-cli-value-alias-conflicts-for-non-commander-callers` | TBD | Not started |
 | 10 | `TRL-694` | `trl-694-suppress-static-resource-accessor-warnings-when-string` | TBD | Not started |
 | 11 | `TRL-634` | `trl-634-audit-cross-surface-parity-coverage-gaps` | TBD | Not started |
@@ -166,6 +166,12 @@ ready waves, and remote review turns here.
   labeled docs as `Label (path-or-url)` while keeping label-only docs intact,
   and the Trails app Warden wrapper reuses the package `diagnosticSchema`
   instead of duplicating the guidance schema.
+- 2026-05-12 16:00 EDT: Moved `TRL-691` to `In Progress`, created
+  `trl-691-polish-generated-warden-guide-headers-and-generator-tests`, renamed
+  generated guide header metadata from `Source command` to
+  `Guide input command`, refreshed AGENTS and skill guide generated blocks, and
+  added generator tests for the end-only orphaned marker case plus stable
+  fixture-based rendering assertions.
 
 ## Verification Log
 
@@ -260,6 +266,18 @@ Branch `TRL-690` focused checks:
 - `bun run typecheck` - passed.
 - `bun run format:check` - initially failed on app Warden wrapper/test wrapping;
   fixed with targeted Ultracite formatting and reran successfully.
+- `git diff --check` - passed.
+
+Branch `TRL-691` focused checks:
+
+- `bun test scripts/__tests__/sync-agents-warden-guide.test.ts
+  scripts/__tests__/sync-skill-warden-guide.test.ts` - passed, 8 tests /
+  24 expects.
+- `bun run warden:agents:sync` - refreshed generated AGENTS Warden block.
+- `bun run warden:skills:sync` - refreshed generated skill Warden references.
+- `bun run warden:agents:check` - passed.
+- `bun run warden:skills:check` - passed.
+- `bun run format:check` - passed.
 - `git diff --check` - passed.
 
 ## Review Feedback

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -4,7 +4,7 @@
 
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
-- Source command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
+- Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
 - Rule count: 49
 
 ## Agent Instructions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Use the project language consistently:
 
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
-- Source command: `bun apps/trails/bin/trails.ts warden guide --manifest`
+- Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
 - Rule count: 49
 
 ### Rule Index

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -4,7 +4,7 @@
 
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
-- Source command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
+- Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
 - Rule count: 49
 
 ## Agent Instructions

--- a/scripts/__tests__/sync-agents-warden-guide.test.ts
+++ b/scripts/__tests__/sync-agents-warden-guide.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
+import type { WardenGuideManifest } from '@ontrails/warden';
+
 import {
   WARDEN_GUIDE_END,
   WARDEN_GUIDE_START,
@@ -7,14 +9,44 @@ import {
   replaceAgentsWardenGuideBlock,
 } from '../sync-agents-warden-guide.js';
 
+const manifestFixture = {
+  generatedFrom: {
+    package: '@ontrails/warden',
+    registries: ['wardenRules', 'wardenTopoRules'],
+    source: 'builtin-rule-metadata',
+  },
+  kind: 'trails-warden-guide-manifest',
+  ruleCount: 1,
+  rules: [
+    {
+      concern: 'results',
+      depth: 'source',
+      description: 'Prevents thrown trail failures.',
+      docs: [],
+      id: 'no-throw-in-implementation',
+      invariant: 'Trail implementations return Result values.',
+      lifecycle: { state: 'durable' },
+      scope: 'external',
+      severity: 'error',
+      tier: 'source-static',
+    },
+  ],
+  version: 1,
+} satisfies WardenGuideManifest;
+
 describe('sync-agents-warden-guide', () => {
-  test('renders a generated block from the live Warden manifest', () => {
-    const block = renderAgentsWardenGuideBlock();
+  test('renders a generated block from the Warden manifest', () => {
+    const block = renderAgentsWardenGuideBlock(manifestFixture);
 
     expect(block).toStartWith(WARDEN_GUIDE_START);
-    expect(block).toMatch(/Rule count: \d+/);
+    expect(block).toContain(
+      '- Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`'
+    );
+    expect(block).toContain('- Rule count: 1');
     expect(block).toContain('#### Results');
-    expect(block).toContain('`no-throw-in-implementation`');
+    expect(block).toMatch(
+      /- `no-throw-in-implementation` \(error, source\/source-static, external\): Trail implementations return Result values\./
+    );
     expect(block).toEndWith(WARDEN_GUIDE_END);
   });
 
@@ -62,13 +94,30 @@ describe('sync-agents-warden-guide', () => {
     expect(updated).toContain(replacement);
   });
 
-  test('rejects orphaned generated block markers', () => {
+  test('rejects orphaned start-only generated block markers', () => {
     const replacement = `${WARDEN_GUIDE_START}\nnew\n${WARDEN_GUIDE_END}`;
     const source = [
       '# AGENTS.md',
       '',
       WARDEN_GUIDE_START,
       'old',
+      '',
+      '## Draft State',
+      '',
+      'Drafts.',
+    ].join('\n');
+
+    expect(() => replaceAgentsWardenGuideBlock(source, replacement)).toThrow(
+      'found only one Warden guide marker'
+    );
+  });
+
+  test('rejects orphaned end-only generated block markers', () => {
+    const replacement = `${WARDEN_GUIDE_START}\nnew\n${WARDEN_GUIDE_END}`;
+    const source = [
+      '# AGENTS.md',
+      '',
+      WARDEN_GUIDE_END,
       '',
       '## Draft State',
       '',

--- a/scripts/__tests__/sync-skill-warden-guide.test.ts
+++ b/scripts/__tests__/sync-skill-warden-guide.test.ts
@@ -20,6 +20,9 @@ describe('sync-skill-warden-guide', () => {
     );
     expect(SKILL_WARDEN_GUIDE_PATHS).toHaveLength(2);
     expect(guide).toStartWith('# Warden Guidance For Trails Skills');
+    expect(guide).toContain(
+      '- Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`'
+    );
     expect(guide).toMatch(/Rule count: \d+/);
     expect(guide).toContain('## Agent Instructions');
     expect(guide).toContain('Repo-tracked skills, agents, and plugin prompts');

--- a/scripts/sync-agents-warden-guide.ts
+++ b/scripts/sync-agents-warden-guide.ts
@@ -29,7 +29,7 @@ const renderGeneratedHeader = (
   '',
   'This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.',
   '',
-  `- Source command: \`bun apps/trails/bin/trails.ts warden guide --manifest\``,
+  `- Guide input command: \`bun apps/trails/bin/trails.ts warden guide --manifest\``,
   `- Rule count: ${manifest.ruleCount}`,
 ];
 

--- a/scripts/sync-skill-warden-guide.ts
+++ b/scripts/sync-skill-warden-guide.ts
@@ -49,7 +49,7 @@ const renderGeneratedHeader = (
   '',
   'This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.',
   '',
-  `- Source command: \`bun apps/trails/bin/trails.ts warden guide --agent-json\``,
+  `- Guide input command: \`bun apps/trails/bin/trails.ts warden guide --agent-json\``,
   `- Rule count: ${manifest.ruleCount}`,
   '',
 ];


### PR DESCRIPTION
## Context

Generated Warden guide headers need to be predictable and covered so future generator edits do not produce subtle agent-guidance drift.

## Changes

- Polishes generated Warden guide header output.
- Adds generator tests around the header shape and guide structure.
- Keeps agent and skill guide generation aligned with the shared source of truth.

## Verification

- Focused generator tests were run during local stack construction.
- Full stack tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run dead-code`, Warden guide sync/check commands, `bun run publish:check`, and `git diff --check`.
- Local review ran three full rounds plus a focused docs/vocab round 4; the latest review evidence is P3-only/clean.

## Risks / rollout notes

The generated files are expected to change with the generator. The sync/check commands are the rollout guard for this branch.

Closes: TRL-691