### PR TITLE
fix: reject ambiguous CLI value aliases

### DIFF
--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
@@ -63,7 +63,7 @@ ready and again before final handoff.
 | 6 | `TRL-692` | `trl-692-clarify-warden-guide-manifest-category-naming-before` | TBD | Implemented locally |
 | 7 | `TRL-690` | `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse` | TBD | Implemented locally |
 | 8 | `TRL-691` | `trl-691-polish-generated-warden-guide-headers-and-generator-tests` | TBD | Implemented locally |
-| 9 | `TRL-693` | `trl-693-tighten-cli-value-alias-conflicts-for-non-commander-callers` | TBD | Not started |
+| 9 | `TRL-693` | `trl-693-tighten-cli-value-alias-conflicts-for-non-commander-callers` | TBD | Implemented locally |
 | 10 | `TRL-694` | `trl-694-suppress-static-resource-accessor-warnings-when-string` | TBD | Not started |
 | 11 | `TRL-634` | `trl-634-audit-cross-surface-parity-coverage-gaps` | TBD | Not started |
 | 12 | `TRL-636` | `trl-636-audit-docs-and-examples-for-v1-readiness` | TBD | Not started |
@@ -172,6 +172,12 @@ ready waves, and remote review turns here.
   `Guide input command`, refreshed AGENTS and skill guide generated blocks, and
   added generator tests for the end-only orphaned marker case plus stable
   fixture-based rendering assertions.
+- 2026-05-12 16:12 EDT: Moved `TRL-693` to `In Progress`, created
+  `trl-693-tighten-cli-value-alias-conflicts-for-non-commander-callers`, and
+  tightened `applyCliFlagValueAliases()` for non-Commander callers. When an
+  active value alias is present without caller-supplied key tracking, any parsed
+  canonical key is treated as ambiguous and rejected instead of guessing whether
+  it was only a defaulted value.
 
 ## Verification Log
 
@@ -277,6 +283,14 @@ Branch `TRL-691` focused checks:
 - `bun run warden:skills:sync` - refreshed generated skill Warden references.
 - `bun run warden:agents:check` - passed.
 - `bun run warden:skills:check` - passed.
+- `bun run format:check` - passed.
+- `git diff --check` - passed.
+
+Branch `TRL-693` focused checks:
+
+- `bun test packages/cli` - passed, 221 tests / 561 expects.
+- `bun test adapters/commander` - passed, 43 tests / 84 expects.
+- `bun run typecheck` - passed.
 - `bun run format:check` - passed.
 - `git diff --check` - passed.
 

--- a/.changeset/trl-693-cli-alias-conflicts.md
+++ b/.changeset/trl-693-cli-alias-conflicts.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/cli": patch
+---
+
+Reject ambiguous CLI value-alias conflicts when non-Commander callers provide a
+defaulted canonical flag value without caller-supplied key tracking.

--- a/packages/cli/src/__tests__/flags.test.ts
+++ b/packages/cli/src/__tests__/flags.test.ts
@@ -144,6 +144,22 @@ describe('deriveFlags', () => {
       );
     });
 
+    test('rejects ambiguous canonical defaults combined with aliases without caller-supplied key tracking', () => {
+      const flags = deriveFlags(
+        z.object({ outputFormat: z.enum(['json', 'text']).default('text') }),
+        { outputFormat: { aliases: { json: 'json-output' } } }
+      );
+
+      expect(() =>
+        applyCliFlagValueAliases(flags, {
+          jsonOutput: true,
+          outputFormat: 'text',
+        })
+      ).toThrow(
+        'CLI flag "--output-format" cannot be combined with value alias "--json-output"'
+      );
+    });
+
     test('rejects multiple aliases for the same canonical flag', () => {
       const flags = deriveFlags(
         z.object({ format: z.enum(['json', 'summary', 'text']) }),

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -184,10 +184,13 @@ export const applyCliFlagValueAliases = (
     }
 
     const canonicalKey = toCamel(flag.name);
+    // Adapters should pass the exact user-supplied key set when they preserve
+    // defaulted canonical values in parsed flags. Without that set, an active
+    // value alias plus any parsed canonical key is ambiguous and must fail
+    // loudly instead of guessing whether the canonical value was a default.
     const canonicalWasSupplied =
       userSuppliedFlagKeys?.has(canonicalKey) ??
-      (normalized[canonicalKey] !== undefined &&
-        normalized[canonicalKey] !== flag.default);
+      Object.hasOwn(normalized, canonicalKey);
     const [activeAlias] = activeAliases;
     if (!activeAlias) {
       continue;


### PR DESCRIPTION
## Context

CLI value parsing already protects Commander callers, but non-Commander callers should get the same alias-conflict safety instead of accepting ambiguous inputs.

## Changes

- Tightens CLI value alias conflict detection outside Commander-specific paths.
- Adds coverage for ambiguous aliases in non-Commander invocation paths.
- Keeps error behavior explicit so callers fail loudly when aliases conflict.

## Verification

- Focused CLI parsing tests were run during local stack construction.
- Full stack tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run dead-code`, Warden guide sync/check commands, `bun run publish:check`, and `git diff --check`.
- Local review ran three full rounds plus a focused docs/vocab round 4; the latest review evidence is P3-only/clean.

## Risks / rollout notes

This can turn previously ambiguous non-Commander input into an explicit error. That is the intended safety behavior.

Closes: TRL-693