### PR TITLE
fix: suppress shadowed static resource warnings

### DIFF
--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
@@ -64,7 +64,7 @@ ready and again before final handoff.
 | 7 | `TRL-690` | `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse` | TBD | Implemented locally |
 | 8 | `TRL-691` | `trl-691-polish-generated-warden-guide-headers-and-generator-tests` | TBD | Implemented locally |
 | 9 | `TRL-693` | `trl-693-tighten-cli-value-alias-conflicts-for-non-commander-callers` | TBD | Implemented locally |
-| 10 | `TRL-694` | `trl-694-suppress-static-resource-accessor-warnings-when-string` | TBD | Not started |
+| 10 | `TRL-694` | `trl-694-suppress-static-resource-accessor-warnings-when-string` | TBD | Implemented locally |
 | 11 | `TRL-634` | `trl-634-audit-cross-surface-parity-coverage-gaps` | TBD | Not started |
 | 12 | `TRL-636` | `trl-636-audit-docs-and-examples-for-v1-readiness` | TBD | Not started |
 | 13 | `TRL-637` | `trl-637-audit-release-process-and-beta-to-10-cutover-requirements` | TBD | Not started |
@@ -178,6 +178,12 @@ ready waves, and remote review turns here.
   active value alias is present without caller-supplied key tracking, any parsed
   canonical key is treated as ambiguous and rejected instead of guessing whether
   it was only a defaulted value.
+- 2026-05-12 16:22 EDT: Moved `TRL-694` to `In Progress`, created
+  `trl-694-suppress-static-resource-accessor-warnings-when-string`, and fixed
+  the `static-resource-accessor-preference` shadowing edge. String-literal
+  resource lookups now carry the declared resource names shadowed at the lookup
+  site so an ID-resolved warning is suppressed when its suggested static helper
+  name is locally rebound inside `blaze`.
 
 ## Verification Log
 
@@ -291,6 +297,15 @@ Branch `TRL-693` focused checks:
 - `bun test packages/cli` - passed, 221 tests / 561 expects.
 - `bun test adapters/commander` - passed, 43 tests / 84 expects.
 - `bun run typecheck` - passed.
+- `bun run format:check` - passed.
+- `git diff --check` - passed.
+
+Branch `TRL-694` focused checks:
+
+- `bun test
+  packages/warden/src/__tests__/static-resource-accessor-preference.test.ts` -
+  passed, 15 tests / 28 expects.
+- `bun run lint` - passed.
 - `bun run format:check` - passed.
 - `git diff --check` - passed.
 

--- a/.changeset/trl-694-static-resource-shadow.md
+++ b/.changeset/trl-694-static-resource-shadow.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/warden": patch
+---
+
+Suppress static resource accessor warnings when a string lookup resolves to a
+resource variable name shadowed inside `blaze`.

--- a/packages/warden/src/__tests__/static-resource-accessor-preference.test.ts
+++ b/packages/warden/src/__tests__/static-resource-accessor-preference.test.ts
@@ -185,6 +185,26 @@ trail('entity.show', {
     expect(staticResourceAccessorPreference.check(code, TEST_FILE)).toEqual([]);
   });
 
+  test('does not warn when a string resource lookup resolves to a shadowed declared name', () => {
+    const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+
+trail('entity.show', {
+  resources: [db],
+  blaze: async (input, ctx) => {
+    const db = input.override;
+    return Result.ok(ctx.resource('db.main'));
+  },
+});
+`;
+
+    expect(staticResourceAccessorPreference.check(code, TEST_FILE)).toEqual([]);
+  });
+
   test('does not warn when a local constructor shadows an imported dependency constructor', () => {
     const code = `
 import { Result, trail } from '@ontrails/core';

--- a/packages/warden/src/rules/static-resource-accessor-preference.ts
+++ b/packages/warden/src/rules/static-resource-accessor-preference.ts
@@ -45,6 +45,7 @@ interface ResourceLookup {
   readonly id: string | null;
   readonly name: string | null;
   readonly rendered: string;
+  readonly shadowedDeclaredNames: ReadonlySet<string>;
   readonly start: number;
 }
 
@@ -288,6 +289,7 @@ const extractResourceLookup = (
       id: extractFirstStringArg(node),
       name: extractFirstIdentifierArg(node),
       rendered: `${memberCall.ctxName}.resource(${renderedArg})`,
+      shadowedDeclaredNames: new Set(),
       start: node.start,
     };
   }
@@ -298,6 +300,7 @@ const extractResourceLookup = (
       id: extractFirstStringArg(node),
       name: extractFirstIdentifierArg(node),
       rendered: `${calleeName}(${renderedArg})`,
+      shadowedDeclaredNames: new Set(),
       start: node.start,
     };
   }
@@ -308,6 +311,19 @@ const extractResourceLookup = (
 const buildDeclaredNameSet = (
   resources: readonly DeclaredStaticResource[]
 ): ReadonlySet<string> => new Set(resources.map((resource) => resource.name));
+
+const collectShadowedNames = (
+  names: ReadonlySet<string>,
+  scopes: readonly ReadonlySet<string>[]
+): ReadonlySet<string> => {
+  const shadowed = new Set<string>();
+  for (const name of names) {
+    if (isShadowedModuleBinding(name, scopes)) {
+      shadowed.add(name);
+    }
+  }
+  return shadowed;
+};
 
 const buildDeclaredNameById = (
   resources: readonly DeclaredStaticResource[]
@@ -336,7 +352,10 @@ const collectResourceLookups = (
       (node, scopes) => {
         const lookup = extractResourceLookup(node, ctxNames, resourceAliases);
         if (lookup && !isShadowedModuleBinding(lookup.name, scopes)) {
-          lookups.push(lookup);
+          lookups.push({
+            ...lookup,
+            shadowedDeclaredNames: collectShadowedNames(declaredNames, scopes),
+          });
         }
       },
       {
@@ -528,6 +547,9 @@ const reportAccessorLookups = (
       (lookup.id ? (declaredNameById.get(lookup.id) ?? null) : null);
 
     if (!resourceName) {
+      continue;
+    }
+    if (lookup.shadowedDeclaredNames.has(resourceName)) {
       continue;
     }
 


### PR DESCRIPTION
## Context

The static resource accessor preference rule should coach real static-accessor opportunities, not warn when a string/dynamic lookup is intentionally shadowed or cannot use a statically scoped helper.

## Changes

- Suppresses false-positive static resource accessor warnings for string/dynamic resource lookup cases.
- Preserves warnings where a statically scoped resource helper is actually available.
- Adds focused Warden coverage for the corrected rule behavior.

## Verification

- Focused Warden rule tests were run during local stack construction.
- Full stack tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run dead-code`, Warden guide sync/check commands, `bun run publish:check`, and `git diff --check`.
- Local review ran three full rounds plus a focused docs/vocab round 4; the latest review evidence is P3-only/clean.

## Risks / rollout notes

The rule becomes less noisy for dynamic access while keeping the advisory path intact for real static-resource opportunities.

Closes: TRL-694