### PR TITLE
docs: audit release cutover process

### DIFF
--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
@@ -55,19 +55,19 @@ ready and again before final handoff.
 
 | Order | Issue | Branch | PR | Status |
 | --- | --- | --- | --- | --- |
-| 1 | `TRL-655` | `trl-655-add-typed-topo-store-views-over-topograph-saved-state` | TBD | Implemented locally |
-| 2 | `TRL-656` | `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial` | TBD | Implemented locally |
-| 3 | `TRL-657` | `trl-657-add-complete-resolved-contract-detail-view-for-blind-agents` | TBD | Implemented locally |
-| 4 | `TRL-653` | `trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph` | TBD | Implemented locally |
-| 5 | `TRL-702` | `trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces` | TBD | Implemented locally |
-| 6 | `TRL-692` | `trl-692-clarify-warden-guide-manifest-category-naming-before` | TBD | Implemented locally |
-| 7 | `TRL-690` | `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse` | TBD | Implemented locally |
-| 8 | `TRL-691` | `trl-691-polish-generated-warden-guide-headers-and-generator-tests` | TBD | Implemented locally |
-| 9 | `TRL-693` | `trl-693-tighten-cli-value-alias-conflicts-for-non-commander-callers` | TBD | Implemented locally |
-| 10 | `TRL-694` | `trl-694-suppress-static-resource-accessor-warnings-when-string` | TBD | Implemented locally |
-| 11 | `TRL-634` | `trl-634-audit-cross-surface-parity-coverage-gaps` | TBD | Implemented locally |
-| 12 | `TRL-636` | `trl-636-audit-docs-and-examples-for-v1-readiness` | TBD | Implemented locally |
-| 13 | `TRL-637` | `trl-637-audit-release-process-and-beta-to-10-cutover-requirements` | TBD | Not started |
+| 1 | `TRL-655` | `trl-655-add-typed-topo-store-views-over-topograph-saved-state` | [#488](https://github.com/outfitter-dev/trails/pull/488) | Ready; CI green; review clean |
+| 2 | `TRL-656` | `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial` | [#489](https://github.com/outfitter-dev/trails/pull/489) | Ready; CI green; review clean |
+| 3 | `TRL-657` | `trl-657-add-complete-resolved-contract-detail-view-for-blind-agents` | [#490](https://github.com/outfitter-dev/trails/pull/490) | Ready; CI green; review clean |
+| 4 | `TRL-653` | `trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph` | [#491](https://github.com/outfitter-dev/trails/pull/491) | Ready; CI green; review clean |
+| 5 | `TRL-702` | `trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces` | [#492](https://github.com/outfitter-dev/trails/pull/492) | Ready; CI green; review clean |
+| 6 | `TRL-692` | `trl-692-clarify-warden-guide-manifest-category-naming-before` | [#493](https://github.com/outfitter-dev/trails/pull/493) | Ready; CI green; review clean after changeset fix |
+| 7 | `TRL-690` | `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse` | [#494](https://github.com/outfitter-dev/trails/pull/494) | Ready; CI green; review neutral/clean |
+| 8 | `TRL-691` | `trl-691-polish-generated-warden-guide-headers-and-generator-tests` | [#495](https://github.com/outfitter-dev/trails/pull/495) | Ready; CI green; review clean |
+| 9 | `TRL-693` | `trl-693-tighten-cli-value-alias-conflicts-for-non-commander-callers` | [#496](https://github.com/outfitter-dev/trails/pull/496) | Ready; CI green; review clean |
+| 10 | `TRL-694` | `trl-694-suppress-static-resource-accessor-warnings-when-string` | [#497](https://github.com/outfitter-dev/trails/pull/497) | Ready; CI green; review neutral/clean |
+| 11 | `TRL-634` | `trl-634-audit-cross-surface-parity-coverage-gaps` | [#498](https://github.com/outfitter-dev/trails/pull/498) | Ready; CI green; review clean |
+| 12 | `TRL-636` | `trl-636-audit-docs-and-examples-for-v1-readiness` | [#499](https://github.com/outfitter-dev/trails/pull/499) | Ready; CI green; review clean after audit wording fix |
+| 13 | `TRL-637` | `trl-637-audit-release-process-and-beta-to-10-cutover-requirements` | [#500](https://github.com/outfitter-dev/trails/pull/500) | Ready; CI green; review clean after runbook fix |
 
 ## Tracker Mutations
 
@@ -89,6 +89,14 @@ issues created or updated during execution.
 | `TRL-709` | Created M5 follow-up for a code-fence-aware relative Markdown link integrity check. | [TRL-709](https://linear.app/outfitter/issue/TRL-709/add-markdown-link-integrity-check-for-docs-and-readmes) |
 | `TRL-710` | Created M5 follow-up for a public API `@example` coverage inventory/gate. | [TRL-710](https://linear.app/outfitter/issue/TRL-710/create-public-api-example-coverage-inventory-and-gate) |
 | `TRL-636` | Moved to `In Review` when PR #499 was marked ready. | [TRL-636](https://linear.app/outfitter/issue/TRL-636/audit-docs-and-examples-for-v1-readiness) |
+| `TRL-637` | Moved to `In Progress` when the release audit branch started. | [TRL-637](https://linear.app/outfitter/issue/TRL-637/audit-release-process-and-beta-to-10-cutover-requirements) |
+| `TRL-711` | Created M6 follow-up to codify the beta-to-1.0 release runbook. | [TRL-711](https://linear.app/outfitter/issue/TRL-711/codify-the-beta-to-10-release-runbook) |
+| `TRL-712` | Created M6 follow-up to author the stable 1.x release doctrine ADR. | [TRL-712](https://linear.app/outfitter/issue/TRL-712/author-stable-release-doctrine-adr-for-the-1x-line) |
+| `TRL-713` | Created M6 follow-up to repair stale Changesets references before stable cutover. | [TRL-713](https://linear.app/outfitter/issue/TRL-713/repair-stale-changesets-references-before-stable-cutover) |
+| `TRL-714` | Created M6 follow-up to add registry availability and dist-tag release preflights. | [TRL-714](https://linear.app/outfitter/issue/TRL-714/add-registry-availability-and-dist-tag-release-preflights) |
+| `TRL-634` | Moved to `In Review` when PR #498 was marked ready. | [TRL-634](https://linear.app/outfitter/issue/TRL-634/audit-cross-surface-parity-coverage-gaps) |
+| `TRL-637` | Moved to `In Review` when PR #500 was marked ready. | [TRL-637](https://linear.app/outfitter/issue/TRL-637/audit-release-process-and-beta-to-10-cutover-requirements) |
+| Stack issues | Confirmed all thirteen stack issues are `In Review` after ready waves; no issue was moved to `Done`. | `TRL-655`, `TRL-656`, `TRL-657`, `TRL-653`, `TRL-702`, `TRL-692`, `TRL-690`, `TRL-691`, `TRL-693`, `TRL-694`, `TRL-634`, `TRL-636`, `TRL-637` |
 
 ## Local Review Reports
 
@@ -97,22 +105,23 @@ Reports should live under
 
 | Round | Lane | Report | Result |
 | --- | --- | --- | --- |
-| 1 | Topographer API | `reports/local-review-topographer-round-1.md` | Pending |
-| 1 | Persistence honesty | `reports/local-review-persistence-round-1.md` | Pending |
-| 1 | Docs/vocab | `reports/local-review-docs-vocab-round-1.md` | Pending |
-| 1 | Warden/CLI polish | `reports/local-review-warden-cli-round-1.md` | Pending |
-| 1 | V1 audit | `reports/local-review-v1-audit-round-1.md` | Pending |
-| 2 | Topographer API | `reports/local-review-topographer-round-2.md` | Pending |
-| 2 | Persistence honesty | `reports/local-review-persistence-round-2.md` | Pending |
-| 2 | Docs/vocab | `reports/local-review-docs-vocab-round-2.md` | Pending |
-| 2 | Warden/CLI polish | `reports/local-review-warden-cli-round-2.md` | Pending |
-| 2 | V1 audit | `reports/local-review-v1-audit-round-2.md` | Pending |
-| 3 | Topographer API | `reports/local-review-topographer-round-3.md` | Pending |
-| 3 | Persistence honesty | `reports/local-review-persistence-round-3.md` | Pending |
-| 3 | Docs/vocab | `reports/local-review-docs-vocab-round-3.md` | Pending |
-| 3 | Warden/CLI polish | `reports/local-review-warden-cli-round-3.md` | Pending |
-| 3 | V1 audit | `reports/local-review-v1-audit-round-3.md` | Pending |
-| Doctrine | Post-execution verification | `reports/post-execution-verification.md` | Pending |
+| 1 | Topographer API | `reports/local-review-topographer-round-1.md` | P2 fixed on `TRL-657`; P3 carried |
+| 1 | Persistence honesty | `reports/local-review-persistence-round-1.md` | P2 fixed on `TRL-656` |
+| 1 | Docs/vocab | `reports/local-review-docs-vocab-round-1.md` | P2 fixed on `TRL-653`/`TRL-702`; P3 carried |
+| 1 | Warden/CLI polish | `reports/local-review-warden-cli-round-1.md` | Clean |
+| 1 | V1 audit | `reports/local-review-v1-audit-round-1.md` | P2 fixed on `TRL-634`; P3 tracked |
+| 2 | Topographer API | `reports/local-review-topographer-round-2.md` | P2 fixed on `TRL-657`; P3 carried |
+| 2 | Persistence honesty | `reports/local-review-persistence-round-2.md` | Clean |
+| 2 | Docs/vocab | `reports/local-review-docs-vocab-round-2.md` | P3-only |
+| 2 | Warden/CLI polish | `reports/local-review-warden-cli-round-2.md` | Clean |
+| 2 | V1 audit | `reports/local-review-v1-audit-round-2.md` | P2 fixed on `TRL-634` |
+| 3 | Topographer API | `reports/local-review-topographer-round-3.md` | P3-only |
+| 3 | Persistence honesty | `reports/local-review-persistence-round-3.md` | Clean |
+| 3 | Docs/vocab | `reports/local-review-docs-vocab-round-3.md` | P2 reported from stale evidence; superseded by round 4 |
+| 3 | Warden/CLI polish | `reports/local-review-warden-cli-round-3.md` | Clean |
+| 3 | V1 audit | `reports/local-review-v1-audit-round-3.md` | Clean |
+| 4 | Docs/vocab | `reports/local-review-docs-vocab-round-4.md` | Clean |
+| Doctrine | Post-execution verification | `reports/post-execution-verification.md` | Clean/P3-only after `TRL-702` fix |
 
 If round 3 still finds any P0/P1/P2 issue, add round 4+ rows and continue.
 
@@ -127,6 +136,10 @@ If round 3 still finds any P0/P1/P2 issue, add round 4+ rows and continue.
 | M5 docs | README TypeScript snippet verification covers only `packages/tracing/README.md` despite 21 consumer-facing package/app/adapter READMEs. | Audit-only branch; checker expansion belongs in follow-up. | [TRL-708](https://linear.app/outfitter/issue/TRL-708/expand-readme-typescript-snippet-verification-beyond-tracing) |
 | M5 docs | Ad hoc relative-link scan found broken docs/ADR links and one false positive from a code fence, proving the need for a proper Markdown-aware checker. | Audit-only branch; checker plus fixes belong in follow-up. | [TRL-709](https://linear.app/outfitter/issue/TRL-709/add-markdown-link-integrity-check-for-docs-and-readmes) |
 | M5 docs | Public API `@example` coverage is sparse and ungated, especially across shipped surface package entrypoints. | Needs M1 public-export inventory before a clean coverage gate. | [TRL-710](https://linear.app/outfitter/issue/TRL-710/create-public-api-example-coverage-inventory-and-gate) |
+| M6 release | Stable cutover lacks a durable runbook with preconditions, command order, post-publish verification, and partial-publish handling. | Audit-only branch; durable release docs belong in follow-up. | [TRL-711](https://linear.app/outfitter/issue/TRL-711/codify-the-beta-to-10-release-runbook) |
+| M6 release | Stable 1.x release doctrine is not captured in an ADR. | Needs a focused doctrine PR instead of being buried in an audit report. | [TRL-712](https://linear.app/outfitter/issue/TRL-712/author-stable-release-doctrine-adr-for-the-1x-line) |
+| M6 release | `bunx changeset status --verbose` fails because `.changeset/logtape-observe-target.md` references retired `@ontrails/logging`. | Audit-only branch; release-state repair belongs in follow-up. | [TRL-713](https://linear.app/outfitter/issue/TRL-713/repair-stale-changesets-references-before-stable-cutover) |
+| M6 release | `bun run publish:check` passes while registry probes show several non-private packages missing or inaccessible at `1.0.0-beta.15`. | Needs a release preflight/gate that complements local packability. | [TRL-714](https://linear.app/outfitter/issue/TRL-714/add-registry-availability-and-dist-tag-release-preflights) |
 
 ## Execution Log
 
@@ -215,22 +228,43 @@ ready waves, and remote review turns here.
   `TRL-709`, and `TRL-710`. The audit found one hard fresh-start blocker
   (`@ontrails/commander` missing from npm) plus README snippet, link-integrity,
   and `@example` coverage gaps.
+- 2026-05-12: Moved `TRL-637` to `In Progress`, created
+  `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`,
+  produced `reports/m6-release-process-audit.md`, and filed follow-ups
+  `TRL-711`, `TRL-712`, `TRL-713`, and `TRL-714`. The audit confirmed the Bun
+  publish script and prerelease dist-tag behavior, then found stable-runbook,
+  stable-doctrine, stale Changesets, and registry preflight gaps.
+- 2026-05-12: Completed three local review rounds from the stack tip. Round 1
+  P2 findings were fixed on owning branches `TRL-656`, `TRL-657`, `TRL-653`,
+  `TRL-702`, and `TRL-634`; round 2 P2 findings were fixed on `TRL-657` and
+  `TRL-634`; round 3 returned clean/P3-only in four lanes, while docs/vocab
+  reported a stale P2 against `TRL-702`.
+- 2026-05-12: Ran a focused round 4 docs/vocab verification from the live stack
+  tip. It confirmed `TRL-702` already uses exact line-scoped
+  `topographArtifactFamilyRetiredMatches` for active cleanup/migration seams
+  and returned clean for P0/P1/P2.
+- 2026-05-12: Ran the distinct post-execution doctrine verification pass. It
+  returned clean for P0/P1/P2, with only P3 internal generator variable naming,
+  compact API-reference polish, optional Linear readback, and absent physical
+  lock artifacts noted as residual context.
 
 ## Verification Log
 
 | Check | Result | Notes |
 | --- | --- | --- |
-| `bun scripts/adr.ts map` | Pending |  |
-| `bun scripts/adr.ts check` | Pending |  |
-| `bun run typecheck` | Pending |  |
-| `bun run test` | Pending |  |
-| `bun run lint` | Pending |  |
-| `bun run lint:ast-grep` | Pending |  |
-| `bun run build` | Pending |  |
-| `bun run format:check` | Pending |  |
-| `bun run check` | Pending |  |
-| `bun run dead-code` | Pending |  |
-| `git diff --check` | Pending |  |
+| `bun scripts/adr.ts map` | Passed | Refreshed ADR maps; no persisted diff remained. |
+| `bun scripts/adr.ts check` | Passed | 0 errors, 0 warnings. |
+| `bun run typecheck` | Passed | 21 successful tasks. |
+| `bun run test` | Passed | 36 successful tasks after the `TRL-657` guide schema fixture repair. |
+| `bun run lint` | Passed | 22 successful tasks. |
+| `bun run lint:ast-grep` | Passed | ast-grep scan completed cleanly. |
+| `bun run build` | Passed | 21 successful tasks. |
+| `bun run format:check` | Passed | Ultracite check clean. |
+| `bun run check` | Passed | Aggregate gate passed; Warden report remained PASS with known warnings. |
+| `bun run dead-code` | Passed | knip completed cleanly. |
+| `bun run warden:agents:sync && bun run warden:skills:sync && bun run warden:agents:check && bun run warden:skills:check` | Passed | Generated Warden guidance stayed synced. |
+| `bun run publish:check` | Passed | All non-private package pack checks passed. |
+| `git diff --check` | Passed | Whitespace check clean. |
 
 Branch `TRL-655` focused checks:
 
@@ -356,25 +390,49 @@ Branch `TRL-636` focused checks:
 - `bun run format:check` - passed.
 - `git diff --check` - passed.
 
+Branch `TRL-637` focused checks:
+
+- `bun run publish:check` - passed for every non-private packable workspace.
+- `bunx changeset status --verbose` - failed because
+  `.changeset/logtape-observe-target.md` references retired
+  `@ontrails/logging`; captured as release-process follow-up `TRL-713`, not a
+  branch implementation failure.
+- Read-only registry probe with `npm view <package> version --json` found
+  missing or inaccessible package versions for `@ontrails/commander`,
+  `@ontrails/observe`, `@ontrails/topographer`, and `@ontrails/wayfinder`;
+  captured as follow-up `TRL-714`.
+- `bun run check` - passed. Warden reported existing warnings only and still
+  returned `PASS`; no P0/P1/P2 branch implementation findings.
+- `bun run format:check` - passed.
+- `git diff --check` - passed.
+
 ## Review Feedback
 
 Record P0/P1/P2 feedback, owning branches, fixes, replies, and unresolved P3s.
 
 | Source | Branch | Severity | Finding | Resolution |
 | --- | --- | --- | --- | --- |
-|  |  |  |  |  |
+| Greptile PR #488 | `TRL-655` | P2 | Topo-store write-intent filtering, signal usage map allocation, and mock `.get` snapshot behavior diverged from the intended query contract. | Fixed in `032b2fd51e46`; replied to and resolved the review thread. |
+| Greptile PR #490 | `TRL-657` | P2 | Resolved trail detail mixed graph-wide activation context with per-trail records and rederived `TopoGraph` unnecessarily. | Fixed in `49ea3979d043`; new focused store/survey coverage passed. |
+| Greptile PR #491 | `TRL-653` | P2 | `decision-map.json` had a misleading ADR-0046 inbound context from `docs/topo-store-reference.md`. | Fixed in `34be13aaf331`; added explicit ADR-0046 link and regenerated the map, then replied/resolved the thread. |
+| Greptile PR #492 | `TRL-702` | P2 | Retired-vocabulary exclusions duplicated historical paths. | Fixed in `8444ff95dff3`; replied to and resolved the review thread. |
+| Greptile PR #493 | `TRL-692` | P2 | Warden guide `category` to `concern` contract rename was represented as a patch bump instead of a minor release bump. | Fixed in `4e85a96b7d7e`; changeset now marks `@ontrails/trails` and `@ontrails/warden` as minor, then replied to the review thread. |
+| Greptile PR #499 | `TRL-636` | P2 | M5 audit severity wording did not match the high-priority TRL-707 blocker, and `RETRO.md` missed the `TRL-636` In Review transition. | Fixed in `8e0afca06247`; replied to and resolved both review threads. |
+| Greptile PR #500 | `TRL-637` | P2 | Release runbook used hardcoded `/usr/bin/git` paths. | Fixed in `b497680720d8`; replied to and resolved the review thread. |
 
 ## Final State
 
-Do not mark complete until:
-
-- all thirteen PRs have been built and submitted;
-- local review is P3-only or clean;
-- post-execution doctrine verification is complete;
-- CI is green before ready;
-- ready waves have completed;
-- P2+ remote feedback is resolved or reported after the allowed review turns;
-- no merge queue label was added;
-- nothing was merged;
-- the final transcript contains branch/PR status, checks run, skipped checks,
-  remaining P3s/risks, and blocker status.
+- All thirteen PRs have been built, submitted, and marked ready in the planned
+  waves.
+- Local review completed with the latest pass clean or P3-only; post-execution
+  doctrine verification is clean/P3-only.
+- Core CI is green on every PR. Graphite `mergeability_check` remains pending
+  on stack descendants because the stack has not been merged.
+- P2+ remote feedback has been fixed and replied to; final review-thread scrape
+  showed no unresolved threads.
+- No merge queue label was added.
+- Nothing was merged.
+- Remaining P3s/risks: compact API docs omit some exported topo-store record
+  types; Warden guide internals still use local `category` variable names while
+  the public contract is `concern`; physical `.trails/trails.lock` and
+  `.trails/topo.lock` were not present in the local workspace snapshot.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-1.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-1.md
@@ -1,0 +1,153 @@
+# Local Review Round 1: Docs/Vocab Lane
+
+Date: 2026-05-12
+Branch reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+Scope: TRL-653 and TRL-702 docs/API/agent-guidance TopoGraph sweep and retired vocabulary guard.
+
+## Summary
+
+Round 1 is not clean. I found two P2 issues:
+
+1. TRL-653 leaves an active topo-store workflow telling users to commit only `.trails/trails.lock`, even though ADR-0046 makes `.trails/trails.lock` and `.trails/topo.lock` a committed artifact family.
+2. TRL-702 wires the retired-vocabulary guard into `bun run check`, but the rule exempts an entire active bootstrap config file that contains retired root-state paths. That exemption is broader than the plan's named legacy-reset exception and can hide future active drift in that file.
+
+I found no P0/P1 issues.
+
+## Findings
+
+### P2: Pre-deployment workflow omits `.trails/topo.lock`
+
+Owning branch: TRL-653 (`trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph`)
+
+Evidence:
+
+- ADR-0046 defines both files as committed artifacts:
+  - `docs/adr/0046-lock-v3-artifact-family.md:35-40`
+  - Quote: "Lock v3 is a committed artifact family:"
+  - Quote: "`-`.trails/trails.lock`is the compact manifest.`"
+  - Quote: "`-`.trails/topo.lock` is the serialized `TopoGraph`content artifact.`"
+  - Quote: "Both files are generated, committed, framework-owned `.lock` artifacts."
+- The active topo-store docs correctly say compile writes both files:
+  - `docs/topo-store.md:94`
+  - Quote: "Compile the current topo to `.trails/topo.lock` and `.trails/trails.lock`."
+- The same active workflow then tells users to commit only the manifest:
+  - `docs/topo-store.md:113-116`
+  - Quote: "1. Make topology changes"
+  - Quote: "2. Compile: `trails topo compile`"
+  - Quote: "3. Commit `.trails/trails.lock`"
+  - Quote: "4. In CI, verify: `trails topo verify`"
+
+Why this matters:
+
+This is current-facing workflow guidance, not historical context. Following it can leave the inspectable graph content artifact uncommitted while the doc still claims to follow the lock v3 flow. It contradicts ADR-0046's split-manifest doctrine and weakens the blind-agent inspection story.
+
+Recommended action:
+
+Update `docs/topo-store.md` to say commit both `.trails/trails.lock` and `.trails/topo.lock`. Consider wording the verify step as verifying the committed artifact family rather than only the manifest/lockfile.
+
+Validation:
+
+Targeted searches found no other active README/docs workflow with the same exact "commit only `.trails/trails.lock`" instruction. Older accepted ADRs still contain pre-ADR-0046 single-lock wording; see P3 residual note below.
+
+### P2: Retired vocabulary guard has an over-broad active-file exemption
+
+Owning branch: TRL-702 (`trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces`)
+
+Evidence:
+
+- The plan allows historical/migration mentions and names the intentional legacy cleanup seam:
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:249`
+  - Quote: "Historical release notes, old migrations, accepted ADR history, and superseded scratch plans can mention retired vocabulary when clearly historical."
+  - Quote: "The one-cycle legacy reset list in `apps/trails/src/trails/dev-support.ts` may mention old state paths as cleanup targets."
+- The plan also says exemptions must be explicit and scoped:
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:299-300`
+  - Quote: "The legacy reset-file cleanup list in `apps/trails/src/trails/dev-support.ts` is an intentional exemption."
+  - Quote: "Exemptions must be explicit and scoped."
+- The implemented TopoGraph retired-vocabulary rule excludes a whole active bootstrap config file:
+  - `scripts/vocab-cutover-map.ts:123-134`
+  - Quote: "`const topographArtifactFamilyRetiredMentionPaths = [`"
+  - Quote: "`'apps/trails/src/trails/dev-support.ts',`"
+  - Quote: "`'scripts/bootstrap/config.toml',`"
+- The audit engine excludes by entire path or directory prefix:
+  - `scripts/vocab-cutover-audit.ts:32-38`
+  - Quote: "`globallyExcludedPaths.has(path) ||`"
+  - Quote: "`path === excludedPath || path.startsWith(`${excludedPath}/`)`"
+- The active bootstrap config contains the retired paths:
+  - `scripts/bootstrap/config.toml:68-77`
+  - Quote: "`[cleanup]`"
+  - Quote: "`files = [`"
+  - Quote: "`\".trails/trails.db\",`"
+  - Quote: "`\".trails/dev/tracing.db\",`"
+
+Why this matters:
+
+The topograph rule reports clean, but it cannot inspect `scripts/bootstrap/config.toml` at all. That file is not a historical changelog, migration doc, accepted ADR, superseded plan, or the plan's named `apps/trails/src/trails/dev-support.ts` reset seam. A future active-target reference to `.trails/trails.db` or `.trails/dev/` in that config would pass the guard silently.
+
+Recommended action:
+
+Narrow the exemption. Options:
+
+- remove `scripts/bootstrap/config.toml` from the rule exclusion and update the config wording/shape so the old paths are clearly treated as legacy cleanup data;
+- add line/section-level allowlist support to `scripts/vocab-cutover-audit.ts`, then allow only the `[cleanup].files` legacy entries;
+- move the legacy cleanup entries behind a clearly named legacy cleanup source that can be exempted without hiding unrelated active config text.
+
+Validation:
+
+`bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term --json` returned zero matches because of the path-level exemption, not because the active config lacks retired terms.
+
+## P3 Residual Notes
+
+### P3: Older accepted ADRs still have single-lock lifecycle wording
+
+Owning branch: TRL-653, if the team wants total ADR text consistency.
+
+Evidence:
+
+- `docs/adr/0015-topo-store.md:289-294`
+  - Quote: "The lockfile (`.trails/trails.lock`) becomes a deterministic text export of the current topo state:"
+  - Quote: "`trails topo compile         # Write .trails/trails.lock from the current topo`"
+  - Quote: "`trails topo verify          # CI: fail if .trails/trails.lock is stale`"
+- `docs/adr/0017-serialized-topo-graph.md:110-123`
+  - Quote: "`trails topo compile          # write .trails/trails.lock from current topo`"
+  - Quote: "The lockfile is:"
+  - Quote: "Checked in to source control. A PR that changes trail contracts produces a lockfile diff."
+- ADR-0046 explicitly supersedes the single-file story:
+  - `docs/adr/0046-lock-v3-artifact-family.md:147-149`
+  - Quote: "ADR-0017 is partially superseded."
+  - Quote: "the story is expressed by a manifest plus content artifact instead of one all-purpose lockfile."
+
+Why this is P3:
+
+These are accepted ADR history and the dedicated ADR-0046 supersession note exists, so I would not block the stack on rewriting them. Still, they are easy for an agent to find and quote as current unless they read ADR-0046 first.
+
+Recommended action:
+
+Optionally add short local supersession notes to ADR-0015 and ADR-0017 command/lifecycle sections pointing readers to ADR-0046 for the current two-artifact lifecycle.
+
+## Positive Checks
+
+- `docs/lexicon.md:91-156` now defines `TopoGraph`, `topoGraph`, `topo_graph`, `lock_manifest`, `.trails/state/`, `.trails/cache/`, `.trails/config.local.{ts,js}`, and a retired vocabulary table with replacements.
+- `docs/migration/topograph-artifact-family.md:3-12` teaches the current manifest/content/state/cache/config layout, and `docs/migration/topograph-artifact-family.md:56-69` tells old `_surface.json` consumers to read `.trails/topo.lock` through `readTopoGraph()` or typed topo-store views.
+- `docs/topo-store-reference.md:171-176` explicitly says `topo_surfaces` is an operational CLI-derived projection and points complete surface detail to saved `TopoGraph` and typed accessors.
+- `docs/topo-store-reference.md:192-194` uses `topo_graph` and `lock_manifest` for stored graph/manifest exports.
+- `docs/api-reference.md:217-232` lists the current `@ontrails/topographer` TopoGraph/lock/topo-store public API and types.
+- `package.json:16` defines `vocab:audit`, and `package.json:38` includes it in `bun run check`.
+- `AGENTS.md:90` uses the current generated Warden guide header label: `Guide input command`.
+
+## Validation Run
+
+- `/usr/bin/git branch --show-current` -> `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+- `/usr/bin/git status --short` -> clean before writing this report
+- `bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term` -> passed
+- `bun scripts/vocab-cutover-audit.ts --rule connector-term` -> passed
+- `bun scripts/vocab-cutover-audit.ts --rule surface-term` -> passed
+- `bun scripts/vocab-cutover-audit.ts --list-rules` -> rule exists and shows the broad `scripts/bootstrap/config.toml` exclusion
+- `bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term --json` -> `fileCount: 0`, `total: 0`
+- `bun run lint:ast-grep` -> passed
+- `git diff --check` -> passed before writing this report
+- `qmd search "TopoGraph artifact family trails.lock topo.lock"` and `qmd search "SurfaceMap _surface.json .trails/trails.db retired vocabulary"` returned no results from the local qmd index, so I used targeted `rg`/file reads for exact token evidence.
+
+Checks intentionally not run:
+
+- `bun scripts/adr.ts map`: skipped because it writes generated ADR map output and this review is allowed to write only the requested report file.
+- `bun run format:check`: skipped because the script builds the private Oxlint plugin before checking and may write build outputs; this review is allowed to write only the requested report file.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-2.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-2.md
@@ -1,0 +1,217 @@
+# Local Review Round 2: Docs/Vocab Lane
+
+Date: 2026-05-12
+Branch reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+Scope: TRL-653 dual-lock docs, TRL-702 retired-vocabulary guard narrowing, and active docs/vocab consistency with ADR-0046.
+
+## Summary
+
+Round 2 is P3-only for this lane. I found no P0/P1/P2 issues.
+
+The two round 1 P2s are resolved:
+
+- TRL-653 now tells users to commit both `.trails/trails.lock` and `.trails/topo.lock`.
+- TRL-702 no longer excludes the whole `scripts/bootstrap/config.toml` file; it allows only the known legacy bootstrap cleanup lines.
+
+The active repo vocab audit is clean. The only residual notes are non-blocking: accepted historical ADR text still contains old single-lock lifecycle wording, and the vocab audit roots still omit `.agents/` planning artifacts, which is acceptable for this stack because the current `.agents` hits are source packet/reports or superseded planning archives rather than active product docs.
+
+## Resolved Round 1 P2 Checks
+
+### Resolved: Pre-deployment workflow now commits the full artifact family
+
+Previous severity: P2
+Owning branch: TRL-653 (`trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph`)
+Current status: resolved
+
+Evidence:
+
+- ADR-0046 requires both committed lock artifacts:
+  - `docs/adr/0046-lock-v3-artifact-family.md:35-40`
+  - Quote: "Lock v3 is a committed artifact family:"
+  - Quote: "- `.trails/trails.lock` is the compact manifest."
+  - Quote: "- `.trails/topo.lock` is the serialized `TopoGraph` content artifact."
+  - Quote: "Both files are generated, committed, framework-owned `.lock` artifacts."
+- The active topo-store workflow now matches that requirement:
+  - `docs/topo-store.md:114-117`
+  - Quote: "1. Make topology changes"
+  - Quote: "2. Compile: `trails topo compile`"
+  - Quote: "3. Commit `.trails/trails.lock` and `.trails/topo.lock`"
+  - Quote: "4. In CI, verify: `trails topo verify`"
+- The verify prose also names both artifacts:
+  - `docs/topo-store.md:102-103`
+  - Quote: "Check that the `.trails/trails.lock` / `.trails/topo.lock` artifact family"
+  - Quote: "matches your current topo. Fails if either committed artifact has drifted."
+
+Recommended action:
+
+No blocking action. This round 1 P2 is fixed.
+
+Validation:
+
+- Targeted search for current-facing "Commit `.trails/trails.lock`" guidance found the fixed `docs/topo-store.md:116` line and the historical round 1 report quote only.
+- Active retired-term sweep found no non-allowed current docs teaching the old root lock/state layout.
+
+### Resolved: Bootstrap config exemption is now line-scoped
+
+Previous severity: P2
+Owning branch: TRL-702 (`trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces`)
+Current status: resolved
+
+Evidence:
+
+- The plan requires explicit, scoped exemptions:
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:295-300`
+  - Quote: "Important guard nuance:"
+  - Quote: "Treat `.trails/trails.db` as retired current-target vocabulary."
+  - Quote: "The legacy reset-file cleanup list in `apps/trails/src/trails/dev-support.ts` is an intentional exemption."
+  - Quote: "Exemptions must be explicit and scoped."
+- The rule no longer includes `scripts/bootstrap/config.toml` in its path exclusion list:
+  - `scripts/vocab-cutover-map.ts:129-139`
+  - Quote: "const topographArtifactFamilyRetiredMentionPaths = ["
+  - Quote: "'apps/trails/src/trails/dev-support.ts',"
+  - Quote: "'packages/topographer/src/internal/topo-snapshots.ts',"
+- The bootstrap legacy cleanup entries are allowed by exact path and line:
+  - `scripts/vocab-cutover-map.ts:141-148`
+  - Quote: "const legacyBootstrapCleanupMatches = ["
+  - Quote: "{ line: 71, path: 'scripts/bootstrap/config.toml' },"
+  - Quote: "{ line: 76, path: 'scripts/bootstrap/config.toml' },"
+- The audit engine filters allowed matches by exact path and line:
+  - `scripts/vocab-cutover-audit.ts:40-46`
+  - Quote: "const isAllowedMatch = ("
+  - Quote: "(allowed) => allowed.path === match.path && allowed.line === match.line"
+- The only retired targets in the bootstrap config are the explicit cleanup file entries:
+  - `scripts/bootstrap/config.toml:68-77`
+  - Quote: "[cleanup]"
+  - Quote: "files = ["
+  - Quote: "\".trails/trails.db\","
+  - Quote: "\".trails/dev/tracing.db-wal\","
+
+Recommended action:
+
+No blocking action. This round 1 P2 is fixed. The line allowlist should fail loudly if the cleanup section moves without updating the allowlist, which is the right failure mode for this narrow exception.
+
+Validation:
+
+- `bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term --json` returned `fileCount: 0`, `total: 0`, and no matches after allowed-line filtering.
+- `bun scripts/vocab-cutover-audit.ts --list-rules` shows `scripts/bootstrap/config.toml:71` through `scripts/bootstrap/config.toml:76` under `allows`, not under `excludes`.
+
+## Active Docs/Vocab Check
+
+Status: clean at P2+.
+
+Evidence:
+
+- `docs/lexicon.md` defines the current artifact-family vocabulary:
+  - `docs/lexicon.md:91-118`
+  - Quote: "These names are the current durable artifact-family vocabulary established by"
+  - Quote: "The exported TypeScript type family for the serialized, inspectable graph"
+  - Quote: "The SQL/storage spelling for serialized TopoGraph content."
+  - Quote: "The SQL/storage spelling for the stored lock manifest export."
+- `docs/lexicon.md` marks the old terms as retired vocabulary:
+  - `docs/lexicon.md:136-156`
+  - Quote: "These names are historical or migration vocabulary, not current target-state"
+  - Quote: "| `SurfaceMap` | `TopoGraph` |"
+  - Quote: "| `.trails/trails.db` | `.trails/state/trails.db` |"
+  - Quote: "Active guidance should teach the current names."
+- The migration note teaches the current manifest/content/state/cache/config layout:
+  - `docs/migration/topograph-artifact-family.md:3-12`
+  - Quote: "The v1 topo artifact family uses a compact manifest plus an inspectable graph"
+  - Quote: "- `.trails/trails.lock` is the committed lock v3 manifest."
+  - Quote: "- `.trails/topo.lock` is the committed serialized `TopoGraph` content artifact."
+  - Quote: "- `.trails/state/trails.db` is ignored mutable SQLite state for snapshots,"
+- The active topo-store reference now avoids the earlier persistence overclaim:
+  - `docs/topo-store-reference.md:171-177`
+  - Quote: "This table is an operational query projection, not the canonical complete"
+  - Quote: "In the current v1 posture it records CLI-derived rows only:"
+  - Quote: "Today its surface-related facts are the authored `surfaces` list and"
+  - Quote: "complete multi-surface projection rows remain future work."
+
+Recommended action:
+
+No blocking action. Active docs/vocab match ADR-0046 for this lane.
+
+Validation:
+
+- `bun run vocab:audit` passed for the repo target set.
+- `bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term` passed.
+- `bun scripts/vocab-cutover-audit.ts --rule connector-term --rule surface-term` passed.
+- Exact active-doc search across `README.md`, `AGENTS.md`, `apps/`, `docs/`, `packages/`, `plugin/`, and `scripts/`, excluding changelogs/ADRs/migrations/releases, returned only the intentional retired vocabulary table in `docs/lexicon.md`.
+
+## P3 Residual Notes
+
+### P3: Accepted historical ADRs still contain pre-ADR-0046 single-lock wording
+
+Owning branch: TRL-653, if the team wants extra reader guardrails in accepted historical ADR text.
+
+Evidence:
+
+- `docs/adr/0015-topo-store.md:289-294`
+  - Quote: "The lockfile (`.trails/trails.lock`) becomes a deterministic text export of the current topo state:"
+  - Quote: "trails topo compile         # Write .trails/trails.lock from the current topo"
+  - Quote: "trails topo verify          # CI: fail if .trails/trails.lock is stale"
+- `docs/adr/0017-serialized-topo-graph.md:110-123`
+  - Quote: "trails topo compile          # write .trails/trails.lock from current topo"
+  - Quote: "The lockfile is:"
+  - Quote: "Checked in to source control. A PR that changes trail contracts produces a lockfile diff."
+- ADR-0046 already supersedes the old single-lock story:
+  - `docs/adr/0046-lock-v3-artifact-family.md:147-149`
+  - Quote: "ADR-0017 is partially superseded."
+  - Quote: "the story is expressed by a manifest plus content artifact instead of one"
+  - Quote: "all-purpose lockfile."
+
+Why this is P3:
+
+These are accepted ADR history, ADR-0046 has an explicit supersession note, and the retired-vocabulary rule intentionally exempts reviewed ADR history. This is not active docs guidance drift.
+
+Recommended action:
+
+Optional: add short local supersession callouts in ADR-0015 and ADR-0017 command/lifecycle sections pointing readers to ADR-0046 for the current two-artifact lifecycle.
+
+### P3: The vocab audit target set does not include `.agents/` planning artifacts
+
+Owning branch: TRL-702, only if future `.agents/` files become active agent guidance rather than source packets/reports/planning archives.
+
+Evidence:
+
+- The plan included `.agents` material in the TRL-653 manual sweep:
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:217-218`
+  - Quote: "- `.agents/**/*.md`"
+  - Quote: "- `.agents/plans/v1/*` where stale plans need an explicit superseded marker."
+- The automated vocab audit roots do not include `.agents/`:
+  - `scripts/vocab-cutover-map.ts:14-22`
+  - Quote: "export const auditRoots = ["
+  - Quote: "'AGENTS.md',"
+  - Quote: "'scripts/',"
+- The tracked v1 planning file that does contain retired terms is visibly marked superseded:
+  - `.agents/plans/v1/PLAN.md:3-8`
+  - Quote: "> **Superseded planning archive (2026-05-12):** this packet predates the"
+  - Quote: "> TopoGraph artifact-family cutover. Do not use its `SurfaceMap`,"
+  - Quote: "> `docs/adr/0046-lock-v3-artifact-family.md` for current artifact doctrine."
+
+Why this is P3:
+
+The active product/docs target set is covered by `bun run vocab:audit`, and the current `.agents` retired-term hits are either the tracked goal packet/reports or visibly superseded planning archives. I do not see an active `.agents` guidance file teaching retired target-state names as current.
+
+Recommended action:
+
+If `.agents/` becomes a durable tracked guidance surface rather than local notes/plans/reports, add a scoped `.agents` audit root with explicit exclusions for source packets, reports, and superseded archives.
+
+## Validation Run
+
+- `/usr/bin/git branch --show-current` -> `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+- `/usr/bin/git status --short` before this report showed only unrelated untracked round 2 reports from other lanes:
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-2.md`
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-2.md`
+- `bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term --json` -> passed with `fileCount: 0`, `total: 0`.
+- `bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term` -> passed.
+- `bun scripts/vocab-cutover-audit.ts --rule connector-term --rule surface-term` -> passed.
+- `bun run vocab:audit` -> passed.
+- `bun run lint:ast-grep` -> passed.
+- `/usr/bin/git diff --check` -> passed before writing this report.
+- `qmd search "TopoGraph artifact family trails.lock topo.lock commit"` -> no results from the local qmd index.
+- `qmd search "SurfaceMap _surface.json .trails/trails.db retired vocabulary"` -> no results from the local qmd index.
+
+Checks intentionally not run:
+
+- `bun scripts/adr.ts map`: skipped because it writes generated ADR map output and this review is allowed to write only the requested report file.
+- `bun run format:check`: skipped because the script builds the private Oxlint plugin before checking and may write build outputs; this review is allowed to write only the requested report file.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-3.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-3.md
@@ -1,0 +1,271 @@
+# Local Review Round 3: Docs/Vocab/Agent Guidance Lane
+
+Date: 2026-05-12
+Branch reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+Lane: Docs, lexicon, retired vocabulary guard, and agent guidance for the M4b/V1 stack tip.
+
+## Result
+
+Not clean for P0/P1/P2. I found one P2 in TRL-702: the TopoGraph retired-vocabulary guard is wired into `bun run check`, but it can still be bypassed by whole-file exemptions for active code/test files.
+
+The prior TRL-653 P2 is fixed: active topo-store workflow guidance now says to compile, verify, and commit both `.trails/trails.lock` and `.trails/topo.lock`.
+
+The prior bootstrap-config TRL-702 P2 is partly fixed: `scripts/bootstrap/config.toml` is now line-allowed instead of whole-file excluded. The remaining issue is the same failure mode in other active files.
+
+## Findings
+
+### P2: TopoGraph retired-vocabulary guard still excludes whole active code/test files
+
+Owning branch: TRL-702 (`trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces`)
+
+Recommended action: replace the whole-file TopoGraph retired-vocabulary exclusions for active files with exact line-level `allowMatches` or a similarly scoped legacy-context allowance. At minimum, scope the currently legitimate seams in:
+
+- `apps/trails/src/trails/dev-support.ts:263-270`
+- `packages/topographer/src/internal/topo-snapshots.ts:321-337`
+- `packages/topographer/src/__tests__/topo-store.test.ts:1321-1342`
+
+Keep historical/changelog/ADR/migration directory exclusions as broad historical allowances if desired, but active source and test files should fail loudly when new retired target-state vocabulary is added outside the known migration/reset lines.
+
+Evidence:
+
+- The plan says active docs and guidance must not teach retired names, and it names the legacy reset-file cleanup list as the intentional exemption:
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:249`
+  - Quote: "Active docs and agent guidance should not teach those names as current target state."
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:295-302`
+  - Quote: "Important guard nuance:"
+  - Quote: "The legacy reset-file cleanup list in `apps/trails/src/trails/dev-support.ts` is an intentional exemption."
+  - Quote: "Exemptions must be explicit and scoped."
+  - Quote: "Confirm the new guard is wired into a normal gate."
+- The TopoGraph rule still excludes active source/test files by whole path:
+  - `scripts/vocab-cutover-map.ts:129-139`
+  - Quote: "const topographArtifactFamilyRetiredMentionPaths = ["
+  - Quote: "'apps/trails/src/trails/dev-support.ts',"
+  - Quote: "'packages/topographer/src/**tests**/topo-store.test.ts',"
+  - Quote: "'packages/topographer/src/internal/topo-snapshots.ts',"
+- The same rule has line-scoped allowances only for `scripts/bootstrap/config.toml`, proving the engine can model the narrower shape:
+  - `scripts/vocab-cutover-map.ts:141-148`
+  - Quote: "const legacyBootstrapCleanupMatches = ["
+  - Quote: "{ line: 71, path: 'scripts/bootstrap/config.toml' },"
+  - Quote: "{ line: 76, path: 'scripts/bootstrap/config.toml' },"
+  - `scripts/vocab-cutover-map.ts:296-301`
+  - Quote: "allowMatches: legacyBootstrapCleanupMatches,"
+- The audit engine treats `excludePaths` as whole-path or directory-prefix exemptions:
+  - `scripts/vocab-cutover-audit.ts:32-38`
+  - Quote: "globallyExcludedPaths.has(path) ||"
+  - Quote: "path === excludedPath || path.startsWith(`${excludedPath}/`)"
+- The audit engine only line-scopes entries listed under `allowMatches`:
+  - `scripts/vocab-cutover-audit.ts:40-46`
+  - Quote: "(allowed) => allowed.path === match.path && allowed.line === match.line"
+  - `scripts/vocab-cutover-audit.ts:99-101`
+  - Quote: ".filter((match) => !isAllowedMatch(match, rule));"
+- Those whole-file excluded active files contain legitimate legacy seams today, which should be line-scoped rather than hiding the rest of each file:
+  - `apps/trails/src/trails/dev-support.ts:259-270`
+  - Quote: "const RESET_FILES = ["
+  - Quote: "Legacy paths (pre-state migration)"
+  - Quote: "'.trails/trails.db',"
+  - Quote: "'.trails/dev/tracing.db-wal',"
+  - `packages/topographer/src/internal/topo-snapshots.ts:321-337`
+  - Quote: "if (currentVersion < 12) {"
+  - Quote: "renameColumnIfNeeded(db, 'topo_exports', 'surface_map', 'topo_graph');"
+  - Quote: "'serialized_lock',"
+  - Quote: "'lock_manifest'"
+  - `packages/topographer/src/__tests__/topo-store.test.ts:1321-1342`
+  - Quote: "db.run(`CREATE TABLE topo_exports ("
+  - Quote: "surface_map TEXT NOT NULL,"
+  - Quote: "serialized_lock TEXT NOT NULL"
+  - Quote: "'lock_manifest',"
+  - Quote: "'surface_map',"
+  - Quote: "'serialized_lock',"
+- The false-clean behavior is observable:
+  - Command: `bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term --json`
+  - Output: `"fileCount": 0`, `"matches": []`, `"total": 0`
+  - Command: `rg -n "SurfaceMap|_surface\.json|surface_map|serialized_lock|\.trails/config/local|\.trails/trails\.db|\.trails/dev/|\.trails/generated/" apps/trails/src/trails/dev-support.ts packages/topographer/src/internal/topo-snapshots.ts packages/topographer/src/__tests__/topo-store.test.ts`
+  - Output includes `apps/trails/src/trails/dev-support.ts:265`, `packages/topographer/src/internal/topo-snapshots.ts:325`, and `packages/topographer/src/__tests__/topo-store.test.ts:1323`.
+- The guard is wired into `bun run check`, so this bypass affects the normal gate:
+  - `package.json:16-18`
+  - Quote: `"vocab:audit": "bun scripts/vocab-cutover-audit.ts",`
+  - `package.json:38`
+  - Quote: `"check": "bun run lint && bun run lint:ast-grep && bun run vocab:audit && bun run format:check ..."`
+
+Why this matters:
+
+Round 2 correctly confirmed that `scripts/bootstrap/config.toml` was no longer a whole-file exemption. But the predicate for this review is broader: the guard must not be bypassable by whole-file active-code exemptions. Today a new `.trails/trails.db`, `surface_map`, or `serialized_lock` use added anywhere else in those active files would be skipped before matching. That leaves `bun run check` with a clean signal even though the retired-vocabulary rule did not inspect the full active surface.
+
+## Resolved Checks
+
+### Resolved: active topo-store workflow commits the full artifact family
+
+Previous severity: P2
+Owning branch: TRL-653 (`trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph`)
+Current status: fixed
+
+Evidence:
+
+- ADR-0046 requires the two committed artifacts:
+  - `docs/adr/0046-lock-v3-artifact-family.md:35-40`
+  - Quote: "Lock v3 is a committed artifact family:"
+  - Quote: "- `.trails/trails.lock` is the compact manifest."
+  - Quote: "- `.trails/topo.lock` is the serialized `TopoGraph` content artifact."
+  - Quote: "Both files are generated, committed, framework-owned `.lock` artifacts."
+- The active topo-store guide now matches ADR-0046:
+  - `docs/topo-store.md:92-103`
+  - Quote: "Compile the current topo to `.trails/topo.lock` and `.trails/trails.lock`."
+  - Quote: "Check that the `.trails/trails.lock` / `.trails/topo.lock` artifact family"
+  - Quote: "Fails if either committed artifact has drifted."
+  - `docs/topo-store.md:112-117`
+  - Quote: "2. Compile: `trails topo compile`"
+  - Quote: "3. Commit `.trails/trails.lock` and `.trails/topo.lock`"
+  - Quote: "4. In CI, verify: `trails topo verify`"
+- Targeted current-doc search confirms the active instructions name both files:
+  - Command: targeted `rg` search for commit-only `.trails/trails.lock` guidance and for lines naming both committed lock artifacts across active Markdown docs.
+  - Output: `docs/topo-store.md:94`, `docs/topo-store.md:102`, `docs/topo-store.md:116`, and `packages/topographer/README.md:13`; no active current-facing "commit only `.trails/trails.lock`" instruction was found.
+
+### Resolved: bootstrap config is now line-allowed, not whole-file excluded
+
+Previous severity: P2
+Owning branch: TRL-702 (`trl-702-add-retired-vocabulary-guard-for-active-topograph-surfaces`)
+Current status: fixed for `scripts/bootstrap/config.toml`
+
+Evidence:
+
+- The rule has exact line allowances for bootstrap cleanup:
+  - `scripts/vocab-cutover-map.ts:141-148`
+  - Quote: "{ line: 71, path: 'scripts/bootstrap/config.toml' },"
+  - Quote: "{ line: 76, path: 'scripts/bootstrap/config.toml' },"
+- The actual bootstrap seam is limited to cleanup file entries:
+  - `scripts/bootstrap/config.toml:68-77`
+  - Quote: "[cleanup]"
+  - Quote: "files = ["
+  - Quote: "\".trails/trails.db\","
+  - Quote: "\".trails/dev/tracing.db-wal\","
+
+## Doctrine/Docs Evidence
+
+Active docs and agent guidance are aligned with ADR-0046 at P2+ except for the guard implementation issue above.
+
+- The plan requires current artifact-family vocabulary:
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:224-237`
+  - Quote: "Required vocabulary:"
+  - Quote: "`.trails/trails.lock` means manifest."
+  - Quote: "`.trails/topo.lock` means serialized `TopoGraph` content."
+  - Quote: "`.trails/state/trails.db` is ignored mutable SQLite state."
+- ADR-0046 defines artifact roles and retired names:
+  - `docs/adr/0046-lock-v3-artifact-family.md:77-87`
+  - Quote: "`topo.lock` is the graph content"
+  - Quote: "It contains the serialized `TopoGraph`"
+  - Quote: "The manifest's `version: 3` is the manifest schema version"
+  - `docs/adr/0046-lock-v3-artifact-family.md:94-125`
+  - Quote: "The public topographer API uses `TopoGraph` vocabulary"
+  - Quote: "SQL/export names use `topo_graph`"
+  - Quote: "The default local SQLite path is `.trails/state/trails.db`."
+  - `docs/adr/0046-lock-v3-artifact-family.md:147-160`
+  - Quote: "the story is expressed by a manifest plus content artifact"
+  - Quote: "The old `SurfaceMap`, `_surface.json`, `surface_map`, `serialized_lock`, `.trails/trails.db`, and `.trails/config/local.*` target-state names should retire"
+- The lexicon matches ADR-0046:
+  - `docs/lexicon.md:91-156`
+  - Quote: "These names are the current durable artifact-family vocabulary established by"
+  - Quote: "A TopoGraph contains trail, signal, resource, contour, activation, schema, layer, example, and surface-projection facts."
+  - Quote: "`topo_exports.topo_graph` holds the graph content"
+  - Quote: "The manifest is the compact `.trails/trails.lock` artifact"
+  - Quote: "These names are historical or migration vocabulary, not current target-state language"
+  - Quote: "Active guidance should teach the current names."
+- The migration guide matches the same roles:
+  - `docs/migration/topograph-artifact-family.md:3-12`
+  - Quote: "The v1 topo artifact family uses a compact manifest plus an inspectable graph content artifact"
+  - Quote: "- `.trails/trails.lock` is the committed lock v3 manifest."
+  - Quote: "- `.trails/topo.lock` is the committed serialized `TopoGraph` content artifact."
+  - Quote: "- `.trails/state/trails.db` is ignored mutable SQLite state"
+  - `docs/migration/topograph-artifact-family.md:26-39`
+  - Quote: "| `SurfaceMap` | `TopoGraph` |"
+  - Quote: "| `_surface.json` | `.trails/topo.lock` |"
+  - Quote: "| `.trails/trails.db` | `.trails/state/trails.db` |"
+  - `docs/migration/topograph-artifact-family.md:56-69`
+  - Quote: "Consumers that previously parsed `_surface.json` should read `.trails/topo.lock`"
+  - Quote: "Use `store.topoGraph`, `store.entries`, `store.trails`, `store.resources`, `store.signals`, and `store.contours`"
+- Agent guidance uses current surface vocabulary:
+  - `AGENTS.md:50-62`
+  - Quote: "`surface`, not transport terminology (the API function and user-facing noun)"
+  - Quote: "See `docs/lexicon.md` for the full lexicon."
+- Architecture uses current TopoGraph and surface vocabulary:
+  - `docs/architecture.md:46-56`
+  - Quote: "The trail is the product, not the surface."
+  - Quote: "Surfaces are peers."
+  - Quote: "The contract is machine-readable at runtime."
+  - `docs/architecture.md:108-114`
+  - Quote: "| TopoGraph entries and lock metadata | All of the above, canonicalized |"
+  - Quote: "The TopoGraph captures inferred information for CI governance."
+  - `docs/architecture.md:145-173`
+  - Quote: "Surface Adapters (left side)"
+  - Quote: "`@ontrails/topographer` | TopoGraphs, semantic diffing, lock manifest and `topo.lock` helpers"
+- Round 1 and round 2 status:
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-1.md:9-14`
+  - Quote: "Round 1 is not clean. I found two P2 issues"
+  - Quote: "I found no P0/P1 issues."
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-2.md:9-16`
+  - Quote: "Round 2 is P3-only for this lane. I found no P0/P1/P2 issues."
+  - Quote: "The two round 1 P2s are resolved"
+
+## Residual P3s / Unknowns
+
+### P3: accepted historical ADRs still contain pre-ADR-0046 single-lock wording
+
+Owning branch: TRL-653, only if accepted ADR reader guardrails are desired.
+
+Evidence remains as round 2 reported:
+
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-2.md:142-168`
+- Quote: "Accepted historical ADRs still contain pre-ADR-0046 single-lock wording"
+- Quote: "This is not active docs guidance drift."
+
+Recommended action: optional local supersession callouts in ADR-0015 and ADR-0017. Not blocking because ADR-0046 carries the current accepted doctrine.
+
+### P3: `.agents/` is still not in the automated vocab audit roots
+
+Owning branch: TRL-702, only if `.agents/` becomes a durable active guidance surface rather than source packets, reports, notes, or superseded archives.
+
+Evidence:
+
+- The plan included `.agents` in the manual sweep:
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:216-218`
+  - Quote: "- `.agents/**/*.md`"
+  - Quote: "- `.agents/plans/v1/*` where stale plans need an explicit superseded marker."
+- The automated audit roots omit `.agents/`:
+  - `scripts/vocab-cutover-map.ts:14-22`
+  - Quote: "export const auditRoots = ["
+  - Quote: "'AGENTS.md',"
+  - Quote: "'README.md',"
+  - Quote: "'scripts/',"
+
+Recommended action: optional future root addition if `.agents/` becomes active tracked guidance. Not blocking for this stack, because current `.agents` hits are this source packet/reports, audit reports, or superseded planning material.
+
+Unknowns:
+
+- I did not run aggregate `bun run check` because it includes `format:check`, which builds the private Oxlint plugin path and may write build outputs. This review was constrained to writing exactly one report file.
+- I did not run `bun run format:check` for the same reason.
+- I did not use the Trails skill.
+
+## Commands Run
+
+- `rg -n "local-review-docs-vocab|2026-05-12-topograph-query-docs-stack|ADR-0046|topograph" /Users/mg/.codex/memories/MEMORY.md`
+- `rg --files .agents/plans/2026-05-12-topograph-query-docs-stack docs scripts | sort | rg "(PLAN.md|local-review-docs-vocab-round-[12]\\.md|0046-lock-v3-artifact-family.md|lexicon.md|topograph-artifact-family.md|topo-store.md|architecture.md|vocab-cutover-(audit|map)\\.ts)$"`
+- `wc -l .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md docs/adr/0046-lock-v3-artifact-family.md docs/lexicon.md docs/migration/topograph-artifact-family.md docs/topo-store.md docs/architecture.md AGENTS.md scripts/vocab-cutover-audit.ts scripts/vocab-cutover-map.ts .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-1.md .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-2.md`
+- `nl -ba` reads of all required artifacts listed by this review prompt, plus `scripts/bootstrap/config.toml`, `apps/trails/src/trails/dev-support.ts`, `packages/topographer/src/internal/topo-snapshots.ts`, and `packages/topographer/src/__tests__/topo-store.test.ts`
+- `qmd search "TopoGraph artifact family trails.lock topo.lock"`
+- `qmd search "SurfaceMap _surface.json .trails/trails.db retired vocabulary"`
+- `bun scripts/vocab-cutover-audit.ts --list-rules`
+- `bun scripts/vocab-cutover-audit.ts --list-rules | rg -n "topograph-artifact-family-retired-term|apps/trails/src/trails/dev-support\\.ts|packages/topographer/src/internal/topo-snapshots\\.ts|scripts/bootstrap/config\\.toml:[0-9]+"`
+- `bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term --json`
+- `bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term`
+- `bun scripts/vocab-cutover-audit.ts --rule connector-term --rule surface-term`
+- `bun run vocab:audit`
+- `rg -n "SurfaceMap|_surface\\.json|surface_map|serialized_lock|\\.trails/config/local|\\.trails/trails\\.db|\\.trails/dev/|\\.trails/generated/" apps/trails/src/trails/dev-support.ts packages/topographer/src/internal/topo-snapshots.ts packages/topographer/src/__tests__/topo-store.test.ts`
+- `rg -n "SurfaceMap|_surface\\.json|surface_map|serialized_lock|\\.trails/config/local|\\.trails/trails\\.db|\\.trails/dev/|\\.trails/generated/|[Tt]railhead|root-state|root state" AGENTS.md README.md docs packages apps plugin scripts -g "*.md" -g "*.ts" -g "*.toml" -g "!**/CHANGELOG.md" -g "!docs/adr/**" -g "!docs/migration/**" -g "!docs/releases/**" -g "!scripts/vocab-cutover-*"`
+- targeted `rg` search for commit-only `.trails/trails.lock` guidance and for lines naming both committed lock artifacts across active Markdown docs
+- `rg -n "topo.lock|trails.lock|TopoGraph|topo_graph|lock_manifest|\\.trails/state/trails\\.db|\\.trails/cache|config\\.local" docs/lexicon.md docs/migration/topograph-artifact-family.md docs/topo-store.md docs/architecture.md AGENTS.md`
+- `rg -n "vocab:audit|\\\"check\\\"" package.json`
+- `/usr/bin/git branch --show-current`
+- `/usr/bin/git status --short`
+- `/usr/bin/git diff --check -- .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-3.md`
+- `/usr/bin/git status --short -- .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-3.md`
+
+No source-control write commands were run.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-4.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-4.md
@@ -1,0 +1,90 @@
+# Local Review Round 4: Docs/Vocab/Agent Guidance Lane
+
+Date: 2026-05-12
+Branch reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+Lane: Docs, lexicon, retired vocabulary guard, and agent guidance for the M4b/V1 stack tip.
+
+## Result
+
+Clean for P0/P1/P2 in this lane.
+
+Round 3 reported a P2 that the TopoGraph retired-vocabulary guard still excluded active source/test files by whole path. That finding does not reproduce against the live stack tip. The `topograph-artifact-family-retired-term` rule excludes only historical or migration documentation paths, and the active cleanup/migration seams are represented as exact line-level `allowMatches`.
+
+Residuals are P3-only:
+
+- accepted historical ADRs still contain pre-ADR-0046 single-lock wording, which is historical context rather than active guidance drift;
+- `.agents/` is not part of the automated vocab audit roots, which is acceptable while this packet and its reports are source artifacts rather than general active guidance.
+
+## Findings
+
+No P0/P1/P2 findings.
+
+## Evidence
+
+The TopoGraph rule's broad exclusions are historical/migration surfaces only:
+
+- `scripts/vocab-cutover-map.ts:129-136`
+  - `const topographArtifactFamilyRetiredMentionPaths = [`
+  - `'docs/adr/0042-core-topographer-boundary-doctrine.md',`
+  - `'docs/adr/0046-lock-v3-artifact-family.md',`
+  - `'docs/lexicon.md',`
+  - `'docs/migration',`
+  - `'docs/releases',`
+
+The active source/test cleanup seams are exact line allowances:
+
+- `scripts/vocab-cutover-map.ts:147-181`
+  - `const topographArtifactFamilyRetiredMatches = [`
+  - `{ line: 265, path: 'apps/trails/src/trails/dev-support.ts' },`
+  - `{ line: 270, path: 'apps/trails/src/trails/dev-support.ts' },`
+  - `path: 'packages/topographer/src/internal/topo-snapshots.ts',`
+  - `path: 'packages/topographer/src/__tests__/topo-store.test.ts',`
+
+The audit engine treats `excludePaths` as whole-file or directory-prefix skips, and `allowMatches` as line-scoped skips:
+
+- `scripts/vocab-cutover-audit.ts:32-38`
+  - `globallyExcludedPaths.has(path) ||`
+  - `path === excludedPath || path.startsWith(`${excludedPath}/`)`
+- `scripts/vocab-cutover-audit.ts:40-46`
+  - `rule.allowMatches?.some(`
+  - `(allowed) => allowed.path === match.path && allowed.line === match.line`
+
+The rule uses the line-scoped active seam list:
+
+- `scripts/vocab-cutover-map.ts:329-335`
+  - `allowMatches: topographArtifactFamilyRetiredMatches,`
+  - `excludePaths: topographArtifactFamilyRetiredMentionPaths,`
+  - `id: 'topograph-artifact-family-retired-term',`
+
+Targeted rule output confirms no non-allowed retired terms:
+
+```json
+[
+  {
+    "description": "Retired TopoGraph artifact-family vocabulary still appears outside history, migration notes, and legacy cleanup seams.",
+    "fileCount": 0,
+    "id": "topograph-artifact-family-retired-term",
+    "matches": [],
+    "total": 0
+  }
+]
+```
+
+The normal vocab gate also passes:
+
+```text
+vocab-cutover audit passed for entire repo target set: no legacy patterns found.
+```
+
+## Commands Run
+
+```bash
+/usr/bin/git branch --show-current
+/usr/bin/git status --short
+rg -n "apps/trails/src/trails/dev-support|topo-store.test|topo-snapshots|topographArtifactFamilyRetiredMentionPaths|topographArtifactFamilyRetiredMatches|allowMatches: topograph" scripts/vocab-cutover-map.ts
+nl -ba scripts/vocab-cutover-map.ts | sed -n '126,184p'
+nl -ba scripts/vocab-cutover-map.ts | sed -n '326,336p'
+nl -ba scripts/vocab-cutover-audit.ts | sed -n '28,48p'
+bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term --json
+bun run vocab:audit
+```

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-1.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-1.md
@@ -1,0 +1,152 @@
+# Local Review Round 1 - Persistence Honesty Lane
+
+Date: 2026-05-12
+Branch reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+Scope: TRL-656 persistence honesty plus interactions with TRL-655 and TRL-657.
+
+## Result
+
+Found 1 P2 documentation mismatch and 1 P3 polish note.
+
+The implementation separates partial SQL rows from saved TopoGraph detail in the API shape:
+
+- `TopoStoreTrailDetailRecord.surfaceProjections` is populated from `topo_surfaces`.
+- `TopoStoreTrailDetailRecord.surfaces` and the schema-rich fields are populated from the saved TopoGraph entry.
+- `store.trails.list()` does not expose surface facts, so the list API does not appear to promote partial rows as canonical complete surface data.
+
+Focused validation passed:
+
+```bash
+bun test packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/topo-store-read.test.ts
+```
+
+Result: 29 pass, 0 fail, 171 assertions.
+
+## P2 Findings
+
+### P2 - Topo store docs overclaim complete non-CLI surface detail in TopoGraph
+
+Owning branch: `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial` for the minimal docs fix. If the intended resolution is to add real complete non-CLI projection data, ownership moves to `trl-657-add-complete-resolved-contract-detail-view-for-blind-agents`.
+
+Finding:
+
+`docs/topo-store-reference.md:171-176` correctly says `topo_surfaces` is partial, but then claims the saved TopoGraph contains "non-CLI surface attachments and rich projection metadata." The current TopoGraph type and derivation do not support that full claim: surface-related fields are `surfaces` and optional `cli`, with no MCP or HTTP projection metadata in `TopoGraphEntry`.
+
+Verbatim quote:
+
+```text
+This table is an operational query projection, not the canonical complete
+surface graph. In the current v1 posture it records CLI-derived rows only:
+`surface = 'cli'`, the CLI command name in `derived_name`, and `method = NULL`.
+Complete resolved graph detail, including non-CLI surface attachments and rich
+projection metadata, lives in the saved `TopoGraph` (`topo_exports.topo_graph`)
+and the typed `store.topoGraph` / `store.entries` accessors.
+```
+
+Evidence:
+
+`packages/topographer/src/types.ts:98-106` only defines `surfaces` and optional `cli` as surface-adjacent TopoGraph entry fields:
+
+```text
+export interface TopoGraphEntry {
+  readonly id: string;
+  readonly kind: 'contour' | 'trail' | 'signal' | 'resource';
+  readonly surfaces: readonly string[];
+  readonly cli?:
+    | {
+        readonly path: readonly string[];
+      }
+    | undefined;
+```
+
+`packages/topographer/src/derive.ts:527-539` derives the same shape:
+
+```text
+const trailToEntry = (
+  t: Trail<unknown, unknown, unknown>,
+  topoLayers: readonly Layer[]
+): TopoGraphEntry => {
+  const raw = t as unknown as Record<string, unknown>;
+  const surfaces = extractSurfaces(raw);
+  const entry: Record<string, unknown> = {
+    cli: { path: deriveCliPath(t.id) },
+    exampleCount: Array.isArray(t.examples) ? t.examples.length : 0,
+    id: t.id,
+    kind: t.kind,
+    surfaces,
+  };
+```
+
+Recommended action:
+
+Narrow `docs/topo-store-reference.md:174-176` so it says the schema-rich contract detail lives in TopoGraph, while the current surface-related TopoGraph facts are the authored `surfaces` attachment list and CLI path. Do not describe non-CLI projection metadata as present until MCP/HTTP/WebSocket projection records actually exist in TopoGraph and are covered by tests.
+
+Suggested replacement shape:
+
+```text
+Schema-rich contract detail lives in the saved `TopoGraph`
+(`topo_exports.topo_graph`) and the typed `store.topoGraph` / `store.entries`
+accessors. Today its surface-related facts are the authored `surfaces` list and
+CLI path metadata; complete multi-surface projection rows remain future work.
+```
+
+Validation after fix:
+
+```bash
+bun test packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/topo-store-read.test.ts
+bun run format:check
+```
+
+## P3 Polish
+
+### P3 - ADR-0015 still reads like `topo_surfaces` is complete across shipped surfaces
+
+Owning branch: `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial` if touched, otherwise safe to leave as historical ADR text.
+
+Finding:
+
+`docs/adr/0015-topo-store.md` is historical accepted ADR text, so I am not treating this as a blocker. Still, it is an easy place for a future agent to rediscover the wrong posture because it describes `topo_surfaces` as if it includes CLI, MCP, and HTTP rows.
+
+Verbatim quote:
+
+`docs/adr/0015-topo-store.md:132-138`:
+
+```text
+-- Surface mappings (which surfaces expose which trails)
+CREATE TABLE topo_surfaces (
+  trail_id TEXT NOT NULL,
+  surface TEXT NOT NULL,          -- 'cli' | 'mcp' | 'http'
+  derived_name TEXT NOT NULL,     -- CLI command path, MCP tool name, HTTP route
+  method TEXT,                    -- HTTP method (null for CLI/MCP)
+  snapshot_id TEXT NOT NULL,
+```
+
+Recommended action:
+
+Optional docs polish: add a short note near this schema saying the current v1 implementation intentionally stores only CLI operational rows in `topo_surfaces`, with the active reference at `docs/topo-store-reference.md`.
+
+Validation after optional polish:
+
+```bash
+bun scripts/adr.ts check
+bun run format:check
+```
+
+## Clean Checks
+
+The following expectations were verified from the current stack tip:
+
+- `packages/topographer/src/internal/topo-store.ts:591-609` explicitly comments that SQL surface rows currently record only CLI-derived rows.
+- `packages/topographer/src/__tests__/topo-store.test.ts:252-271` reads `trail_id`, `surface`, `derived_name`, and `method`, then `packages/topographer/src/__tests__/topo-store.test.ts:375-388` asserts only CLI rows with `method: null`.
+- `packages/topographer/src/__tests__/topo-store-read.test.ts:681-725` proves consumers can distinguish the CLI row projection from richer saved TopoGraph detail.
+- `packages/topographer/src/internal/topo-store-read.ts:381-399` reads SQL rows into `TopoStoreSurfaceProjectionRecord`.
+- `packages/topographer/src/internal/topo-store-read.ts:499-543` builds trail graph detail by combining saved TopoGraph entry detail with `surfaceProjections`.
+- `packages/topographer/src/internal/topo-store-read.ts:816-835` returns both `surfaceProjections` and `surfaces` with distinct names.
+- `docs/topo-store-reference.md:367-369` explicitly says `surfaceProjections` are operational rows from `topo_surfaces`, while `surfaces` and schema-rich fields come from saved TopoGraph.
+- `docs/migration/topograph-artifact-family.md` and `docs/lexicon.md` use ADR-0046 vocabulary accurately for `.trails/trails.lock`, `.trails/topo.lock`, `topo_graph`, `lock_manifest`, `.trails/state/`, `.trails/cache/`, and `.trails/config.local.{ts,js}`.
+
+## Unknowns
+
+- I did not inspect every active doc in the repository, only the named anchors plus targeted `rg` evidence around `topo_surfaces`, `surfaceProjections`, and surface vocabulary.
+- I did not validate remote CI or review comments.
+- I did not change source files. This report is the only file written.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-2.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-2.md
@@ -1,0 +1,252 @@
+# Local Review Round 2 - Persistence Honesty Lane
+
+Date: 2026-05-12
+Branch reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+Scope: TRL-656 persistence-honesty fix after round 1, with the current stack tip visible.
+
+## Result
+
+No P0/P1/P2 findings.
+
+The round 1 P2 in `docs/topo-store-reference.md` is fixed. The reference now says `topo_surfaces` is an operational CLI-only row projection and narrows saved `TopoGraph` surface-related facts to the authored `surfaces` list plus CLI path metadata, with complete multi-surface projection rows left as future work.
+
+Focused validation passed:
+
+```bash
+bun test packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/topo-store-read.test.ts
+```
+
+Result: 29 pass, 0 fail, 171 assertions.
+
+## P0/P1/P2 Findings
+
+None.
+
+## Evidence
+
+### Round 1 P2 docs mismatch is fixed
+
+`docs/topo-store-reference.md:171-177` now explicitly distinguishes partial SQL rows from saved graph facts and avoids claiming complete non-CLI projection metadata exists today:
+
+```text
+This table is an operational query projection, not the canonical complete
+surface graph. In the current v1 posture it records CLI-derived rows only:
+`surface = 'cli'`, the CLI command name in `derived_name`, and `method = NULL`.
+Schema-rich contract detail lives in the saved `TopoGraph`
+(`topo_exports.topo_graph`) and the typed `store.topoGraph` / `store.entries`
+accessors. Today its surface-related facts are the authored `surfaces` list and
+CLI path metadata; complete multi-surface projection rows remain future work.
+```
+
+This matches the TRL-656 plan posture in `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:158-164`:
+
+```text
+Persisted `topo_surfaces` rows should be documented and tested as an operational query projection, not the canonical complete surface graph. The complete resolved surface detail lives in `TopoGraph`. This matches the current implementation comment in `normalizeSurfaceRows()`, avoids premature SQL schema expansion, and keeps the artifact doctrine honest.
+
+Implementation guidance:
+
+- Make the partial-row posture explicit in code comments/TSDoc and docs.
+- Tests should prove consumers can distinguish the row projection from full TopoGraph detail.
+- Do not imply SQL rows are complete unless the branch actually makes them complete across CLI/MCP/HTTP/WebSocket.
+```
+
+### Persisted `topo_surfaces` rows remain explicitly CLI-only
+
+`packages/topographer/src/internal/topo-store.ts:591-609` documents and implements the current row projection as CLI-derived:
+
+```text
+/**
+ * Project surface rows for stored topo.
+ *
+ * Currently records only CLI-derived rows. MCP, HTTP, and other surface
+ * projections are intentionally deferred until the topo-store schema supports
+ * multi-surface representation. The JSON export (`topo_graph` in
+ * `topo_exports`) is more faithful for now. See ADR-0015 for the target shape.
+ */
+const normalizeSurfaceRows = (
+  trails: readonly AnyTrail[],
+  snapshotId: string
+): readonly TopoSurfaceRow[] =>
+  trails.map((trail) => ({
+    derivedName: deriveCliPath(trail.id).join(' '),
+    method: null,
+    snapshotId,
+    surface: 'cli',
+    trailId: trail.id,
+  }));
+```
+
+`packages/topographer/src/__tests__/topo-store.test.ts:375-388` asserts those rows as CLI rows with `method: null`:
+
+```text
+expect(readSurfaceRows(db, snapshotId)).toEqual([
+  {
+    derived_name: 'entity add',
+    method: null,
+    surface: 'cli',
+    trail_id: 'entity.add',
+  },
+  {
+    derived_name: 'entity list',
+    method: null,
+    surface: 'cli',
+    trail_id: 'entity.list',
+  },
+]);
+```
+
+### Typed reads preserve the row-vs-graph distinction
+
+`packages/topographer/src/internal/topo-store-read.ts:381-399` maps SQL rows into `TopoStoreSurfaceProjectionRecord` only:
+
+```text
+const readTrailSurfaceProjections = (
+  db: Database,
+  snapshotId: string,
+  trailId: string
+): readonly TopoStoreSurfaceProjectionRecord[] =>
+  db
+    .query<TopoSurfaceProjectionRow, [string, string]>(
+      `SELECT trail_id, surface, derived_name, method
+       FROM topo_surfaces
+       WHERE snapshot_id = ? AND trail_id = ?
+       ORDER BY surface ASC, derived_name ASC`
+    )
+    .all(snapshotId, trailId)
+    .map((row) => ({
+      derivedName: row.derived_name,
+      method: row.method,
+      surface: row.surface,
+      trailId: row.trail_id,
+    }));
+```
+
+`packages/topographer/src/internal/topo-store-read.ts:520-542` keeps SQL row projections and saved `TopoGraph` facts in separate fields:
+
+```text
+const storedTopoGraph = readStoredTopoGraph(db, snapshotId);
+const storedEntry = findTopoGraphEntry(storedTopoGraph, 'trail', trailId);
+const entryDetail = mapStoredTrailEntryDetail(storedEntry);
+
+return {
+  activationContext: mapActivationContext(storedTopoGraph),
+  activationEdges: readTrailActivationEdges(storedTopoGraph, trailId),
+  activationSources: entryDetail.activationSources,
+  cli: entryDetail.cli,
+  contourDetails: readTrailContourDetails(
+    storedTopoGraph,
+    snapshotId,
+    entryDetail.contours
+  ),
+  contours: entryDetail.contours,
+  detours: entryDetail.detours,
+  fieldOverrides: entryDetail.fieldOverrides,
+  governance: entryDetail.governance,
+  input: entryDetail.input,
+  layers: entryDetail.layers,
+  output: entryDetail.output,
+  surfaceProjections: readTrailSurfaceProjections(db, snapshotId, trailId),
+  surfaces: entryDetail.surfaces,
+};
+```
+
+`docs/topo-store-reference.md:364-370` describes the same API distinction:
+
+```text
+Extends trail record with `crosses`, `detours`, `resources`, and `examples`
+arrays. It also carries resolved `TopoGraph` contract facts for blind agents:
+`input`, `output`, `cli`, `surfaces`, `surfaceProjections`, `contours`,
+`contourDetails`, `activationContext`, `activationEdges`, `activationSources`,
+`fieldOverrides`, `layers`, and `governance`. `surfaceProjections` are the
+operational rows from `topo_surfaces`; `surfaces` and the schema-rich contract
+fields come from the saved `TopoGraph`.
+```
+
+`packages/topographer/src/__tests__/topo-store-read.test.ts:681-725` covers that distinction from the consumer side:
+
+```text
+test('distinguishes CLI surface rows from canonical TopoGraph detail', async () => {
+  const rootDir = makeRoot();
+  const snapshot = await expectOk(
+    createTopoSnapshot(graphAttachmentApp(), {
+      createdAt: '2026-04-03T16:30:00.000Z',
+      gitSha: 'abc123',
+      rootDir,
+    })
+  );
+  const store = createTopoStore({ rootDir });
+
+  expect(
+    store.query<{
+      derived_name: string;
+      method: string | null;
+      surface: string;
+      trail_id: string;
+    }>(
+      `SELECT trail_id, surface, derived_name, method
+       FROM topo_surfaces
+       WHERE snapshot_id = ?
+       ORDER BY trail_id ASC, surface ASC`,
+      [snapshot.id]
+    )
+  ).toEqual([
+    {
+      derived_name: 'entity process',
+      method: null,
+      surface: 'cli',
+      trail_id: 'entity.process',
+    },
+  ]);
+
+  const graphDetail = store.entries.get('entity.process', {
+    kind: 'trail',
+    snapshot: { snapshotId: snapshot.id },
+  });
+  expect(graphDetail).toEqual(
+    expect.objectContaining({
+      activationSources: expect.any(Array),
+      fieldOverrides: expect.any(Array),
+      layers: expect.any(Array),
+      output: expect.objectContaining({ type: 'object' }),
+    })
+  );
+});
+```
+
+### ADR-0046 and migration docs stay aligned
+
+ADR-0046 keeps graph detail in `topo.lock` and typed topo-store query views, not in `trails.lock` or reverse-engineered row projections. `docs/adr/0046-lock-v3-artifact-family.md:150-155`:
+
+```text
+- Ordinary contract changes keep a small manifest diff while the inspectable
+  graph remains available in `topo.lock`.
+- CI and Warden verify the manifest-listed artifact hashes instead of comparing
+  one flat lock hash.
+- Agents inspect `topo.lock` or typed topo-store query views for graph detail.
+  They should not reverse-engineer graph facts from `trails.lock`.
+```
+
+The migration guide keeps the artifact family roles clear. `docs/migration/topograph-artifact-family.md:56-69`:
+
+````text
+Consumers that previously parsed `_surface.json` should read `.trails/topo.lock`
+through `readTopoGraph()` or use the typed topo-store views:
+
+```typescript
+import { createTopoStore, readTopoGraph } from '@ontrails/topographer';
+
+const topoGraph = await readTopoGraph({ dir: '.trails' });
+const store = createTopoStore();
+const detail = store.trails.get('auth.login');
+```
+
+Use `store.topoGraph`, `store.entries`, `store.trails`, `store.resources`,
+`store.signals`, and `store.contours` for queryable access instead of parsing
+serialized JSON in application code.
+````
+
+## Unknowns
+
+- I did not inspect remote CI, PR review threads, or branches below the current stack tip.
+- I did not run broad repository gates; only the focused persistence tests requested for this lane.
+- I did not change source files. This report is the only file written.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-3.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-3.md
@@ -1,0 +1,476 @@
+# Local Review Round 3 - Persistence Honesty Lane
+
+Date: 2026-05-12
+Branch reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+Scope: Persistence honesty and artifact-family claims at the current stack tip.
+
+## Result
+
+Clean for P0/P1/P2 in this lane.
+
+The current docs, implementation, and focused tests distinguish the SQL
+`topo_surfaces` operational projection from canonical saved `TopoGraph` contract
+detail. Agent-facing docs also keep `.trails/trails.lock` and
+`.trails/topo.lock` moving together for compile, verify, and pre-deployment
+workflows. Legacy root DB sidecars and stale `.trails/dev/` /
+`.trails/generated/` paths are treated as retired or cleanup-only vocabulary,
+not required current state.
+
+Round 1's P2 docs overclaim is fixed. The only residual from prior persistence
+rounds is the already-classified P3 historical ADR-0015 polish note; I did not
+promote that to a blocker.
+
+## Findings
+
+| Severity | Owning branch | Finding | Recommended action |
+| --- | --- | --- | --- |
+| None P0/P1/P2 | None | No blocking persistence-honesty issue found in the required artifacts. | No action required for this lane. |
+| P3 carried from round 1 | `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial` if touched | Round 1 noted that historical `docs/adr/0015-topo-store.md` still describes the aspirational `topo_surfaces` target shape. It was already classified P3 because active docs now teach the current v1 CLI-only row posture. ADR-0015 was not part of this round's required source-artifact list. | Optional follow-up only: add a historical note in ADR-0015 pointing readers to the active topo-store reference. |
+
+## Evidence
+
+### Predicate 1 - SQL rows are operational, saved TopoGraph is canonical detail
+
+The plan's required posture for TRL-656 is explicit:
+
+`.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:156-164`
+
+```text
+Persisted `topo_surfaces` rows should be documented and tested as an operational query projection, not the canonical complete surface graph. The complete resolved surface detail lives in `TopoGraph`. This matches the current implementation comment in `normalizeSurfaceRows()`, avoids premature SQL schema expansion, and keeps the artifact doctrine honest.
+
+Implementation guidance:
+
+- Make the partial-row posture explicit in code comments/TSDoc and docs.
+- Tests should prove consumers can distinguish the row projection from full TopoGraph detail.
+- Do not imply SQL rows are complete unless the branch actually makes them complete across CLI/MCP/HTTP/WebSocket.
+```
+
+The active reference doc now narrows the SQL table and avoids the round 1
+overclaim:
+
+`docs/topo-store-reference.md:171-177`
+
+```text
+This table is an operational query projection, not the canonical complete
+surface graph. In the current v1 posture it records CLI-derived rows only:
+`surface = 'cli'`, the CLI command name in `derived_name`, and `method = NULL`.
+Schema-rich contract detail lives in the saved `TopoGraph`
+(`topo_exports.topo_graph`) and the typed `store.topoGraph` / `store.entries`
+accessors. Today its surface-related facts are the authored `surfaces` list and
+CLI path metadata; complete multi-surface projection rows remain future work.
+```
+
+The detailed record docs keep the two fields separate:
+
+`docs/topo-store-reference.md:364-370`
+
+```text
+Extends trail record with `crosses`, `detours`, `resources`, and `examples`
+arrays. It also carries resolved `TopoGraph` contract facts for blind agents:
+`input`, `output`, `cli`, `surfaces`, `surfaceProjections`, `contours`,
+`contourDetails`, `activationContext`, `activationEdges`, `activationSources`,
+`fieldOverrides`, `layers`, and `governance`. `surfaceProjections` are the
+operational rows from `topo_surfaces`; `surfaces` and the schema-rich contract
+fields come from the saved `TopoGraph`.
+```
+
+Implementation matches the docs:
+
+`packages/topographer/src/internal/topo-store.ts:591-608`
+
+```text
+/**
+ * Project surface rows for stored topo.
+ *
+ * Currently records only CLI-derived rows. MCP, HTTP, and other surface
+ * projections are intentionally deferred until the topo-store schema supports
+ * multi-surface representation. The JSON export (`topo_graph` in
+ * `topo_exports`) is more faithful for now. See ADR-0015 for the target shape.
+ */
+const normalizeSurfaceRows = (
+  trails: readonly AnyTrail[],
+  snapshotId: string
+): readonly TopoSurfaceRow[] =>
+  trails.map((trail) => ({
+    derivedName: deriveCliPath(trail.id).join(' '),
+    method: null,
+    snapshotId,
+    surface: 'cli',
+```
+
+The read path pulls SQL surface rows into `surfaceProjections` and combines them
+with saved `TopoGraph` detail without making the rows canonical:
+
+`packages/topographer/src/internal/topo-store-read.ts:381-390`
+
+```text
+const readTrailSurfaceProjections = (
+  db: Database,
+  snapshotId: string,
+  trailId: string
+): readonly TopoStoreSurfaceProjectionRecord[] =>
+  db
+    .query<TopoSurfaceProjectionRow, [string, string]>(
+      `SELECT trail_id, surface, derived_name, method
+       FROM topo_surfaces
+```
+
+`packages/topographer/src/internal/topo-store-read.ts:520-542`
+
+```text
+const storedTopoGraph = readStoredTopoGraph(db, snapshotId);
+const storedEntry = findTopoGraphEntry(storedTopoGraph, 'trail', trailId);
+const entryDetail = mapStoredTrailEntryDetail(storedEntry);
+
+return {
+  activationContext: mapActivationContext(storedTopoGraph),
+  activationEdges: readTrailActivationEdges(storedTopoGraph, trailId),
+  activationSources: entryDetail.activationSources,
+  cli: entryDetail.cli,
+  contourDetails: readTrailContourDetails(
+    storedTopoGraph,
+    snapshotId,
+    entryDetail.contours
+  ),
+  contours: entryDetail.contours,
+  detours: entryDetail.detours,
+  fieldOverrides: entryDetail.fieldOverrides,
+  governance: entryDetail.governance,
+  input: entryDetail.input,
+  layers: entryDetail.layers,
+  output: entryDetail.output,
+  surfaceProjections: readTrailSurfaceProjections(db, snapshotId, trailId),
+  surfaces: entryDetail.surfaces,
+};
+```
+
+Tests lock the same distinction:
+
+`packages/topographer/src/__tests__/topo-store.test.ts:375-388`
+
+```text
+expect(readSurfaceRows(db, snapshotId)).toEqual([
+  {
+    derived_name: 'entity add',
+    method: null,
+    surface: 'cli',
+    trail_id: 'entity.add',
+  },
+  {
+    derived_name: 'entity list',
+    method: null,
+    surface: 'cli',
+    trail_id: 'entity.list',
+  },
+]);
+```
+
+`packages/topographer/src/__tests__/topo-store-read.test.ts:681-720`
+
+```text
+test('distinguishes CLI surface rows from canonical TopoGraph detail', async () => {
+  const rootDir = makeRoot();
+  const snapshot = await expectOk(
+    createTopoSnapshot(graphAttachmentApp(), {
+      createdAt: '2026-04-03T16:30:00.000Z',
+      gitSha: 'abc123',
+      rootDir,
+    })
+  );
+  const store = createTopoStore({ rootDir });
+
+  expect(
+    store.query<{
+      derived_name: string;
+      method: string | null;
+      surface: string;
+      trail_id: string;
+    }>(
+      `SELECT trail_id, surface, derived_name, method
+       FROM topo_surfaces
+       WHERE snapshot_id = ?
+       ORDER BY trail_id ASC, surface ASC`,
+      [snapshot.id]
+    )
+  ).toEqual([
+    {
+      derived_name: 'entity process',
+      method: null,
+      surface: 'cli',
+      trail_id: 'entity.process',
+    },
+```
+
+### Predicate 2 - Agent-facing docs move trails.lock and topo.lock together
+
+ADR-0046 defines the artifact family and the roles:
+
+`docs/adr/0046-lock-v3-artifact-family.md:35-40`
+
+```text
+Lock v3 is a committed artifact family:
+
+- `.trails/trails.lock` is the compact manifest.
+- `.trails/topo.lock` is the serialized `TopoGraph` content artifact.
+
+Both files are generated, committed, framework-owned `.lock` artifacts.
+```
+
+`docs/adr/0046-lock-v3-artifact-family.md:150-155`
+
+```text
+- Ordinary contract changes keep a small manifest diff while the inspectable
+  graph remains available in `topo.lock`.
+- CI and Warden verify the manifest-listed artifact hashes instead of comparing
+  one flat lock hash.
+- Agents inspect `topo.lock` or typed topo-store query views for graph detail.
+  They should not reverse-engineer graph facts from `trails.lock`.
+```
+
+The topo-store doc says compile writes both files, verify checks the family, and
+pre-deployment commits both:
+
+`docs/topo-store.md:92-117`
+
+````text
+### `trails topo compile`
+
+Compile the current topo to `.trails/topo.lock` and `.trails/trails.lock`.
+
+```bash
+trails topo compile
+```
+
+### `trails topo verify`
+
+Check that the `.trails/trails.lock` / `.trails/topo.lock` artifact family
+matches your current topo. Fails if either committed artifact has drifted.
+````
+
+```text
+1. Make topology changes
+2. Compile: `trails topo compile`
+3. Commit `.trails/trails.lock` and `.trails/topo.lock`
+4. In CI, verify: `trails topo verify`
+```
+
+The migration doc also introduces the same paired artifact family:
+
+`docs/migration/topograph-artifact-family.md:3-12`
+
+```text
+The v1 topo artifact family uses a compact manifest plus an inspectable graph
+content artifact:
+
+- `.trails/trails.lock` is the committed lock v3 manifest.
+- `.trails/topo.lock` is the committed serialized `TopoGraph` content artifact.
+- `.trails/state/trails.db` is ignored mutable SQLite state for snapshots,
+  pins, tracing, and other framework subsystems.
+- `.trails/cache/` is ignored rebuildable cache state.
+- `.trails/config.local.ts` and `.trails/config.local.js` are ignored local
+  override files.
+```
+
+Implementation persists the manifest and graph content together:
+
+`packages/topographer/src/internal/topo-store.ts:1315-1321`
+
+```text
+artifacts: [{ path: 'topo.lock', role: 'topo', sha256: hash }],
+scope: { app: topo.name },
+summary: {
+  contours: countEntriesForKind(topoGraph.entries, 'contour'),
+  resources: countEntriesForKind(topoGraph.entries, 'resource'),
+  signals: countEntriesForKind(topoGraph.entries, 'signal'),
+  trails: countEntriesForKind(topoGraph.entries, 'trail'),
+```
+
+`packages/topographer/src/internal/topo-store.ts:1541-1549`
+
+```text
+db.run(
+  `INSERT INTO topo_exports (
+    snapshot_id, topo_graph, topo_graph_hash, lock_manifest
+  ) VALUES (?, ?, ?, ?)`,
+  [
+    exportRow.snapshotId,
+    exportRow.topoGraph,
+    exportRow.topoGraphHash,
+    exportRow.lockManifest,
+```
+
+Tests assert the manifest artifact points at `topo.lock` with the stored graph
+hash:
+
+`packages/topographer/src/__tests__/topo-store.test.ts:699-707`
+
+```text
+const lock = JSON.parse(stored.lockManifestJson);
+expect(lock).toMatchObject({
+  artifacts: [
+    { path: 'topo.lock', role: 'topo', sha256: stored.topoGraphHash },
+  ],
+  scope: { app: 'projection-app' },
+  summary: { contours: 1, resources: 2, signals: 1, trails: 2 },
+  version: 3,
+});
+```
+
+### Predicate 3 - Legacy sidecars and stale directories are not required
+
+ADR-0046 makes `.trails/state/trails.db` the hard-cut path and rejects silent
+fallback to the old root DB:
+
+`docs/adr/0046-lock-v3-artifact-family.md:123-125`
+
+```text
+The default local SQLite path is `.trails/state/trails.db`. This is a pre-v1
+hard cut from `.trails/trails.db`; runtime and tooling should not silently read
+fallback data from the legacy root database path.
+```
+
+The migration doc treats old root DB files and stale directories as migration
+cleanup or rename-map entries:
+
+`docs/migration/topograph-artifact-family.md:37-52`
+
+````text
+| `.trails/trails.db` | `.trails/state/trails.db` |
+| `.trails/dev/` | `.trails/state/` |
+| `.trails/generated/` | `.trails/cache/` |
+
+## Local Cleanup
+
+Current builds create the shared database under `.trails/state/`. If an old
+workspace still has untracked root SQLite sidecars, remove only the legacy root
+files:
+
+```bash
+rm -f .trails/trails.db .trails/trails.db-shm .trails/trails.db-wal
+```
+
+Do not commit any `.trails/state/trails.db*` files.
+````
+
+The requested implementation and test artifacts do not require old root sidecar
+paths or stale workspace directories:
+
+```text
+$ rg -n '\.trails/trails\.db|\.trails/dev|\.trails/generated|trails\.db-shm|trails\.db-wal' packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/topo-store-read.test.ts packages/topographer/src/internal/topo-store.ts packages/topographer/src/internal/topo-store-read.ts
+<no matches>
+```
+
+Current local `.trails` state also has no stale `dev/` or `generated/`
+directories and no DB sidecars:
+
+```text
+$ /usr/bin/find .trails -maxdepth 3 -type d -print
+.trails
+.trails/config
+.trails/clark
+
+$ /usr/bin/find .trails -maxdepth 3 -type f -print
+.trails/.gitignore
+.trails/clark/survey-latest.md
+.trails/clark/decisions.md
+```
+
+`.trails/.gitignore:5-9`
+
+```text
+# Rebuildable cache
+cache/
+
+# Mutable runtime state
+state/
+```
+
+### Predicate 4 - Prior P0/P1/P2 closure
+
+Round 1 found one P2:
+
+`.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-1.md:25-33`
+
+```text
+## P2 Findings
+
+### P2 - Topo store docs overclaim complete non-CLI surface detail in TopoGraph
+
+Owning branch: `trl-656-make-persisted-surface-rows-complete-or-explicitly-partial` for the minimal docs fix. If the intended resolution is to add real complete non-CLI projection data, ownership moves to `trl-657-add-complete-resolved-contract-detail-view-for-blind-agents`.
+
+Finding:
+
+`docs/topo-store-reference.md:171-176` correctly says `topo_surfaces` is partial, but then claims the saved TopoGraph contains "non-CLI surface attachments and rich projection metadata."
+```
+
+Round 2 marked that fixed:
+
+`.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-2.md:7-11`
+
+```text
+## Result
+
+No P0/P1/P2 findings.
+
+The round 1 P2 in `docs/topo-store-reference.md` is fixed. The reference now says `topo_surfaces` is an operational CLI-only row projection and narrows saved `TopoGraph` surface-related facts to the authored `surfaces` list plus CLI path metadata, with complete multi-surface projection rows left as future work.
+```
+
+This round independently verified the fixed text in
+`docs/topo-store-reference.md:171-177` above.
+
+## Test Result
+
+```text
+$ bun test packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/topo-store-read.test.ts
+29 pass
+0 fail
+171 expect() calls
+Ran 29 tests across 2 files. [395.00ms]
+```
+
+## Commands Run
+
+```text
+rg -n "M4b|topograph|persistence|artifact-family|topo-store|local-review-persistence" /Users/mg/.codex/memories/MEMORY.md
+pwd
+rg --files .agents/plans/2026-05-12-topograph-query-docs-stack docs packages/topographer/src | rg "(PLAN.md|0046-lock-v3-artifact-family.md|topo-store.md|topo-store-reference.md|topograph-artifact-family.md|topo-store(-read)?\\.ts|topo-store(-read)?\\.test\\.ts|local-review-persistence-round-[12]\\.md|local-review-persistence-round-3\\.md)$"
+wc -l <required source artifacts and prior reports>
+rg -n -C 3 "persistence|persisted|topo.lock|trails.lock|topograph|TopoGraph|topo-store|artifact|verify|deploy|P0|P1|P2|local-review" .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-1.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-2.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-3.md
+qmd search "topo_surfaces operational CLI-derived TopoGraph"
+qmd search "topo.lock trails.lock artifact family verify deploy"
+qmd search "trails.db state generated sidecar"
+rg -n -C 4 <artifact-family patterns> docs/adr/0046-lock-v3-artifact-family.md docs/topo-store.md docs/topo-store-reference.md docs/migration/topograph-artifact-family.md
+rg -n -C 6 <persistence patterns> packages/topographer/src/internal/topo-store.ts packages/topographer/src/internal/topo-store-read.ts packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/topo-store-read.test.ts
+rg -n -C 3 "\\.trails/trails\\.db|\\.trails/dev|\\.trails/generated|\\.trails/state|trails\\.db-shm|trails\\.db-wal|sidecar|root SQLite" .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md docs/adr/0046-lock-v3-artifact-family.md docs/topo-store.md docs/topo-store-reference.md docs/migration/topograph-artifact-family.md packages/topographer/src/internal/topo-store.ts packages/topographer/src/internal/topo-store-read.ts packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/topo-store-read.test.ts
+rg -n "\\.trails/trails\\.db|\\.trails/dev|\\.trails/generated|trails\\.db-shm|trails\\.db-wal" packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/topo-store-read.test.ts packages/topographer/src/internal/topo-store.ts packages/topographer/src/internal/topo-store-read.ts
+rg -n "\\.trails/trails\\.db|\\.trails/dev|\\.trails/generated|trails\\.db-shm|trails\\.db-wal" docs/topo-store.md docs/topo-store-reference.md docs/migration/topograph-artifact-family.md docs/adr/0046-lock-v3-artifact-family.md
+bun test packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/topo-store-read.test.ts
+git status --short .trails .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-3.md
+git ls-files .trails
+/usr/bin/find .trails -maxdepth 3 -type d -print
+/usr/bin/find .trails -maxdepth 3 -type f -print
+git diff --cached --name-status
+git status --short --branch
+nl -ba .trails/.gitignore
+git diff -- .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-3.md
+git status --short --branch
+```
+
+Note: an initial docs `rg` pattern used unescaped Markdown backticks around
+`TopoGraph`, which made zsh emit `command not found: TopoGraph`. I discarded
+that attempt and reran the docs searches with quoted patterns; all evidence
+above comes from the successful reruns.
+
+## Unknowns
+
+- I did not inspect remote CI, PR review threads, or any remote branch state.
+- I did not audit every active doc in the repo; I read the required source
+  artifacts and used targeted searches for this lane's exact vocabulary.
+- I did not re-review ADR-0015 beyond the prior reports' P3 note because it was
+  not part of this round's required source-artifact list.
+- Final `git status --short --branch` showed other round-3 lane report changes
+  in this reports directory. I left those unrelated files untouched.
+- This report is the only file I intentionally wrote.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-1.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-1.md
@@ -1,0 +1,77 @@
+# Local Review Round 1: Topographer API Lane
+
+Scope: TRL-655 and TRL-657 TopoGraph/topo-store/query API implementation at stack tip `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`.
+
+## Result
+
+Latest pass found one P2 and one P3. Focused tests and typecheck pass, but the P2 should be fixed before the stack exits the local review loop.
+
+## Findings
+
+### P2: `survey.trail` drops activation source schemas that the TopoGraph contract preserves
+
+- Owning branch: `TRL-657` (`trl-657-add-complete-resolved-contract-detail-view-for-blind-agents`)
+- Evidence:
+  - `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:190-194`
+    > "Prefer extending the existing trail detail path (`topoStore.trails.get(...)` and `survey.trail`) if it can naturally become the complete resolved contract detail view."
+    > "Include trail id/kind, surfaces and projection metadata, input/output schemas, examples, intent, crosses, resources, activation sources/edges/context, contour/reference metadata, field overrides/layer context, and governance metadata needed by Warden or agent review."
+  - `packages/topographer/src/derive.ts:183-204`
+    > "if (Object.hasOwn(source, 'input')) {"
+    > "record['inputSchema'] = toSortedJsonSchema(source.input);"
+    > "record['parseOutputSchema'] = toSortedJsonSchema(parseOutput);"
+    > "record['payloadSchema'] = toSortedJsonSchema(source.payload);"
+  - `apps/trails/src/trails/topo-activation.ts:160-170`
+    > "record['input'] = canonicalize(source.input);"
+    > "record['hasParse'] = true;"
+    > "record['hasPayloadSchema'] = true;"
+  - `apps/trails/src/trails/topo-reports.ts:556-568`
+    > "const graphDetail = deriveResolvedTrailGraphDetail("
+    > "activationEdges: graphDetail.activationEdges,"
+    > "activationSources: activation.sources,"
+- Why this matters:
+  - The canonical `TopoGraph` activation source projection includes schema-bearing fields such as `inputSchema`, `parseOutputSchema`, and `payloadSchema`.
+  - The topo-store detail path preserves saved `TopoGraph` activation source detail through `processEntry?.activationSources` and asserts that in `packages/topographer/src/__tests__/topo-store-read.test.ts:604`.
+  - The survey-facing detail path keeps the richer TopoGraph edges/context but returns `activation.sources` from `apps/trails/src/trails/topo-activation.ts`, whose projection only keeps `hasParse`/`hasPayloadSchema` flags.
+  - I verified with an ad hoc Bun eval that a webhook activation source with both `parse.output` and `payload` produces `parseOutputSchema` and `payloadSchema` in `deriveTopoGraph(...)`, but `deriveTrailDetail(...).activationSources[0]` only contains `hasParse` and `hasPayloadSchema`.
+- Recommended action:
+  - Extend `apps/trails/src/trails/topo-activation.ts` source projection to preserve the same schema fields as the Topographer projection, or have `deriveTrailDetail` source its activation source records from the derived `TopoGraph` while preserving the current public flat shape.
+  - Add a focused `apps/trails/src/__tests__/survey.test.ts` case with a webhook activation source that has `parse.output` and `payload`, asserting `trailDetailOutput.safeParse(detail).success` and the presence of `parseOutputSchema`/`payloadSchema` in `detail.activationSources[0]`.
+- Focused validation:
+  - `bun test apps/trails/src/__tests__/survey.test.ts`
+  - `bun test packages/topographer/src/__tests__/topo-store-read.test.ts`
+  - `bun run typecheck`
+
+### P3: API reference omits several newly exported topo-store record types
+
+- Owning branch: `TRL-655` for the new typed topo-store accessors; `TRL-657` adds additional detail record types.
+- Evidence:
+  - `packages/topographer/src/index.ts:93-103`
+    > "TopoStoreActivationContextRecord,"
+    > "TopoStoreContourRecord,"
+    > "TopoStoreEntryKind,"
+    > "TopoStoreSignalDetailRecord,"
+    > "TopoStoreSignalRecord,"
+    > "TopoStoreSurfaceProjectionRecord,"
+    > "TopoStoreTopoGraphEntryRecord,"
+    > "TopoStoreTopoGraphRecord,"
+  - `docs/api-reference.md:229-232`
+    > "ReadOnlyTopoStore, MockTopoStoreSeed, TopoSnapshot, TopoStoreRef"
+    > "TopoStoreActivationContextRecord, TopoStoreExportRecord, TopoStoreResourceRecord"
+    > "TopoStoreSurfaceProjectionRecord, TopoStoreTrailRecord, TopoStoreTrailDetailRecord"
+- Why this matters:
+  - `docs/topo-store-reference.md` documents `TopoStoreTopoGraphRecord`, `TopoStoreTopoGraphEntryRecord`, and `TopoStoreContourRecord`, but the compact topographer API export list does not mention them.
+  - This is documentation/API-reference drift rather than an implementation break; the types are exported and `bun run typecheck` passes.
+- Recommended action:
+  - Add `TopoStoreContourRecord`, `TopoStoreEntryKind`, `TopoStoreSignalDetailRecord`, `TopoStoreSignalRecord`, `TopoStoreTopoGraphEntryRecord`, and `TopoStoreTopoGraphRecord` to the `@ontrails/topographer` list in `docs/api-reference.md`.
+- Focused validation:
+  - `bun run format:check`
+
+## Checks Run
+
+- `bun test packages/topographer/src/__tests__/topo-store-read.test.ts apps/trails/src/__tests__/survey.test.ts` - passed, 50 tests / 181 expectations.
+- `bun run typecheck` - passed, 21 cached package typecheck tasks.
+
+## Notes
+
+- I did not run any source-control write command.
+- I wrote only this report file.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-2.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-2.md
@@ -1,0 +1,139 @@
+# Local Review Round 2: Topographer API Lane
+
+Scope: stack tip `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`, focused on the round-1 TRL-657 `survey.trail` activation-source fix and TRL-655/TRL-657 TopoGraph/topo-store query API regressions.
+
+## Result
+
+Not clean. The round-1 `survey.trail` schema-bearing activation-source finding is fixed, and focused tests pass. I found one new P2 in the direct `deriveTopoGraph` projection path, plus the prior P3 compact API-reference omission remains.
+
+## Verified Round-1 Fix
+
+`survey.trail` now preserves schema-bearing activation source fields through the shared core projection helper.
+
+- `apps/trails/src/trails/topo-activation.ts:156-159`
+  > "const projectActivationSource = ("
+  > "source: ActivationSource"
+  > "): ActivationSourceReport =>"
+  > "projectActivationSourceDeclaration(source) as ActivationSourceReport;"
+- `packages/core/src/activation-source-projection.ts:143-160`
+  > "if (source.parse !== undefined) {"
+  > "record['hasParse'] = true;"
+  > "record['parseOutputSchema'] = toSortedJsonSchema(output);"
+  > "record['hasPayloadSchema'] = true;"
+  > "record['payloadSchema'] = toSortedJsonSchema(source.payload);"
+- `apps/trails/src/trails/topo-output-schemas.ts:24-26`
+  > "parseOutputSchema: jsonSchemaOutput.optional(),"
+  > "path: z.string().optional(),"
+  > "payloadSchema: jsonSchemaOutput.optional(),"
+- `apps/trails/src/__tests__/survey.test.ts:1007-1033`
+  > "expect(trailDetailOutput.safeParse(detail).success).toBe(true);"
+  > "parseOutputSchema: {"
+  > "path: '/webhooks/users/upsert',"
+  > "payloadSchema: {"
+
+## Findings
+
+### P2: Direct `deriveTopoGraph` activation sources still use the older local projection
+
+- Owning branch: `TRL-657` (`trl-657-add-complete-resolved-contract-detail-view-for-blind-agents`)
+- Evidence:
+  - `docs/adr/0046-lock-v3-artifact-family.md:77-83`
+    > "The content artifact answers: \"What is the resolved topo?\""
+    > "It contains the serialized `TopoGraph`: every trail, signal, resource, and"
+    > "contour with their schemas, examples, relationships, activation sources, governance"
+    > "metadata, and surface projections."
+  - `packages/core/src/activation-source-projection.ts:138-166`
+    > "if (source.kind === 'webhook') {"
+    > "record['method'] = normalizeWebhookMethod(source.method);"
+    > "record['path'] ="
+    > "record['hasVerify'] = true;"
+  - `packages/topographer/src/internal/topo-store.ts:436-439`
+    > "const projectActivationSource = ("
+    > "source: ActivationSource"
+    > "): ActivationSourceCatalogRecord =>"
+    > "projectActivationSourceDeclaration(source) as ActivationSourceCatalogRecord;"
+  - `packages/topographer/src/internal/topo-store.ts:922-929`
+    > "if (trail.activationSources.length > 0) {"
+    > "entry['activationSources'] = trail.activationSources.map((activation) =>"
+    > "source: projectActivationSource(activation.source),"
+  - `packages/topographer/src/derive.ts:171-210`
+    > "const projectActivationSource = ("
+    > "source: ActivationSource"
+    > "): TopoGraphActivationSource => {"
+    > "if (source.parse !== undefined) {"
+    > "if (source.payload !== undefined) {"
+    > "if (source.timezone !== undefined) {"
+  - `packages/topographer/src/derive.ts:683-690`
+    > "const activationSources = collectActivationSourceCatalog(topo);"
+    > "activationSources: Object.fromEntries("
+    > "activationSources.map((source) => [source.key, source])"
+  - `apps/trails/src/__tests__/survey.test.ts:1008-1033`
+    > "expect(detail.activationSources).toEqual(["
+    > "hasVerify: true,"
+    > "method: 'POST',"
+    > "path: '/webhooks/users/upsert',"
+  - `packages/topographer/src/__tests__/topo-store.test.ts:1161-1176`
+    > "expect(source).toMatchObject({"
+    > "hasVerify: true,"
+    > "method: 'POST',"
+    > "path: '/webhooks/users/upsert',"
+- Why this matters:
+  - The round-1 survey-facing bug is fixed by using `projectActivationSourceDeclaration`.
+  - The topo-store persistence path also uses `projectActivationSourceDeclaration`.
+  - The public direct `deriveTopoGraph(...)` path still has a separate projector in `packages/topographer/src/derive.ts` that preserves parse and payload schemas but not webhook `method`, `path`, or `hasVerify`.
+  - That means a direct `writeTopoGraph(deriveTopoGraph(app))` / `topo.lock` artifact can be less complete than the topo-store export for the same activation source, which undermines ADR-0046's contract that `topo.lock` is the canonical resolved graph content artifact.
+- Recommended action:
+  - Replace the local activation-source projection in `packages/topographer/src/derive.ts` with the shared `projectActivationSourceDeclaration`/`activationSourceKey` helper from `@ontrails/core`, or move the topographer derive path to the same shared helper used by `packages/topographer/src/internal/topo-store.ts`.
+  - Add a focused `packages/topographer/src/__tests__/derive.test.ts` assertion for a webhook source with `method`, `path`, `payload`, `parse.output`, and `verify`, matching the existing topo-store expectation for `method: 'POST'`, normalized `path`, and `hasVerify: true`.
+  - Consider making `method`, `path`, and `hasVerify` explicit optional fields on `TopoGraphActivationSource` so future omissions are type-visible instead of hidden behind `Readonly<Record<string, unknown>>`.
+- Focused validation:
+  - Current tests passed but do not catch this mismatch:
+    - `bun test packages/topographer/src/__tests__/derive.test.ts packages/topographer/src/__tests__/topo-store.test.ts -t "activation source"` - passed, 4 tests / 7 expectations.
+    - `bun test packages/topographer/src/__tests__/topo-store-read.test.ts apps/trails/src/__tests__/survey.test.ts` - passed, 51 tests / 183 expectations.
+    - `bun run typecheck` - passed, 21 cached package typecheck tasks.
+  - After the fix, rerun those commands and ensure the new derive-path webhook assertion fails before the change and passes after it.
+
+### P3: Compact API reference still omits several newly exported topo-store record types
+
+- Owning branch: `TRL-655` for the typed topo-store accessors; `TRL-657` for the detail record additions.
+- Evidence:
+  - `packages/topographer/src/index.ts:93-103`
+    > "TopoStoreActivationContextRecord,"
+    > "TopoStoreContourRecord,"
+    > "TopoStoreEntryKind,"
+    > "TopoStoreSignalDetailRecord,"
+    > "TopoStoreSignalRecord,"
+    > "TopoStoreSurfaceProjectionRecord,"
+    > "TopoStoreTopoGraphEntryRecord,"
+    > "TopoStoreTopoGraphRecord,"
+  - `docs/api-reference.md:227-232`
+    > "TopoGraph, TopoGraphEntry, TopoGraphContourReference, LockManifest, DiffResult, DiffEntry, JsonSchema"
+    > "ReadOnlyTopoStore, MockTopoStoreSeed, TopoSnapshot, TopoStoreRef"
+    > "TopoStoreActivationContextRecord, TopoStoreExportRecord, TopoStoreResourceRecord"
+    > "TopoStoreSurfaceProjectionRecord, TopoStoreTrailRecord, TopoStoreTrailDetailRecord"
+  - `docs/topo-store-reference.md:378-404`
+    > "### `TopoStoreTopoGraphRecord`"
+    > "### `TopoStoreTopoGraphEntryRecord`"
+    > "### `TopoStoreContourRecord`"
+- Why this matters:
+  - The types are exported and documented in the deeper topo-store reference, so this is not an implementation blocker.
+  - The compact API reference remains stale for blind API scanning.
+- Recommended action:
+  - Add `TopoStoreContourRecord`, `TopoStoreEntryKind`, `TopoStoreSignalDetailRecord`, `TopoStoreSignalRecord`, `TopoStoreTopoGraphEntryRecord`, and `TopoStoreTopoGraphRecord` to the `@ontrails/topographer` export list in `docs/api-reference.md`.
+- Focused validation:
+  - `bun run format:check`
+
+## Checks Run
+
+- `bun test packages/topographer/src/__tests__/topo-store-read.test.ts apps/trails/src/__tests__/survey.test.ts` - passed, 51 tests / 183 expectations.
+- `bun test packages/topographer/src/__tests__/derive.test.ts packages/topographer/src/__tests__/topo-store.test.ts -t "activation source"` - passed, 4 tests / 7 expectations.
+- `bun run typecheck` - passed, 21 cached package typecheck tasks.
+
+## Unknowns
+
+- I did not run a custom ad hoc output probe for `deriveTopoGraph`; the P2 is based on source-path comparison plus the current test coverage mismatch. The recommended derive-path test should be the executable proof.
+
+## Notes
+
+- I did not run any source-control write command.
+- I wrote only this report file.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-3.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-3.md
@@ -1,0 +1,136 @@
+# Local Review: Topographer Round 3
+
+Lane: Topographer API and persisted/direct projection consistency.
+
+Stack tip reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`.
+
+## Result
+
+Clean for P0/P1/P2. Round 1's survey-detail P2 is fixed, and round 2's direct `deriveTopoGraph` webhook projection P2 is fixed. I found one residual P3 docs-only export-list gap from rounds 1-2; it is not an implementation, schema, type, or test blocker.
+
+Unknowns:
+
+- I did not run the full repo `bun run check` or inspect remote PR/CI state.
+- This pass reviewed the local stack tip only. It did not validate Linear issue state or GitHub review threads.
+
+## Findings
+
+| Severity | Owning branch | Finding | Recommended action |
+| --- | --- | --- | --- |
+| P3 | `TRL-653` docs/API sweep, with exported type additions originating in `TRL-655`/`TRL-657` | Compact `docs/api-reference.md` still omits several public topo-store record types that are exported and documented in the deeper topo-store reference. This was reported in rounds 1-2 and remains docs-only. | Add `TopoStoreContourRecord`, `TopoStoreEntryKind`, `TopoStoreSignalDetailRecord`, `TopoStoreSignalRecord`, `TopoStoreTopoGraphEntryRecord`, and `TopoStoreTopoGraphRecord` to the compact `@ontrails/topographer` type list in `docs/api-reference.md`. |
+
+No P0/P1/P2 findings remain in this lane.
+
+## Evidence
+
+Representative file:line quotes anchoring the review:
+
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:190-194` quotes: "Prefer extending the existing trail detail path (`topoStore.trails.get(...)` and `survey.trail`)" and "CLI/MCP-facing output schemas must match actual returned shape."
+- `docs/adr/0046-lock-v3-artifact-family.md:81-83` quotes: "It contains the serialized `TopoGraph`: every trail, signal, resource, and contour with their schemas, examples, relationships, activation data, governance metadata, and surface projections."
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-2.md:36-38` quotes: "P2: Direct `deriveTopoGraph` activation sources still use the older local projection" and "Owning branch: `TRL-657`".
+- `packages/topographer/src/derive.ts:150-153` quotes: "const projectActivationSource = (" and "projectActivationSourceDeclaration(source) as TopoGraphActivationSource".
+- `apps/trails/src/trails/topo-output-schemas.ts:23-26` quotes: "method: z.string().optional(),", "parseOutputSchema: jsonSchemaOutput.optional(),", "path: z.string().optional(),", and "payloadSchema: jsonSchemaOutput.optional(),".
+- `packages/topographer/src/internal/topo-store-read.ts:87-107` quotes `TopoStoreTrailDetailRecord` fields including "activationContext", "activationSources", "fieldOverrides", "governance", "input", "layers", "output", "surfaceProjections", and "surfaces".
+
+### Review Brief And Prior Rounds
+
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:10` says: "Do not use the Trails skill for this work."
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:130-135` says typed topo-store views should stay accessors over canonical saved state, cover contours, surfaces, layers, activation metadata, field overrides, examples, schemas, and empty/missing cases.
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:156-165` says persisted `topo_surfaces` rows are an operational query projection and complete resolved surface detail lives in `TopoGraph`.
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:190-194` says the blind-agent detail view should include surfaces, schemas, examples, intent, crosses, resources, activation sources/edges/context, contours, field overrides/layer context, governance metadata, and matching CLI/MCP schemas.
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/REFS.md:37-40` identifies `TRL-655`, `TRL-656`, and `TRL-657` as the typed query, persisted-row honesty, and blind-agent detail branches.
+- `docs/adr/0046-lock-v3-artifact-family.md:81-83` says `topo.lock` contains serialized `TopoGraph` entries with schemas, examples, relationships, activation data, governance metadata, and surface projections.
+- `docs/adr/0046-lock-v3-artifact-family.md:154-157` says agents should inspect `topo.lock` or typed topo-store query views for graph detail, and Topographer owns query views.
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-1.md:11-38` reported a P2 where `survey.trail` dropped activation source schemas.
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-2.md:11-17` verified the round-1 survey fix through the shared projection helper.
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-2.md:36-88` then reported a P2 where direct `deriveTopoGraph` still used an older local projection.
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-2.md:96-122` carried forward the P3 compact API reference omission.
+
+### Predicate 1: Direct, Persisted, And Survey Webhook Projection Shape
+
+The current direct `deriveTopoGraph` path uses the shared core projector that includes webhook `method`, `path`, `hasVerify`, `parseOutputSchema`, and `payloadSchema`.
+
+- `packages/core/src/activation-source-projection.ts:138-166` says the shared projector sets webhook `method`, sets `hasParse` and `parseOutputSchema`, normalizes `path`, sets `hasPayloadSchema` and `payloadSchema`, and sets `hasVerify`.
+- `packages/topographer/src/derive.ts:5-16` imports `activationSourceKey` and `projectActivationSourceDeclaration` from `@ontrails/core`.
+- `packages/topographer/src/derive.ts:150-153` defines `projectActivationSource(source)` as `projectActivationSourceDeclaration(source) as TopoGraphActivationSource`.
+- `packages/topographer/src/derive.ts:178-188` collects direct `deriveTopoGraph` activation sources by calling that projector and storing them by `projected.key`.
+- `packages/topographer/src/derive.ts:347-354` stores per-entry trail activation source detail with `source: projectActivationSource(activation.source)`.
+- `packages/topographer/src/derive.ts:620-635` returns the `TopoGraph` with `activationGraph`, `activationSources`, `entries`, `generatedAt`, and `topoGraphSchemaVersion`.
+
+The persisted topo-store export also uses the same shared projector and writes the result into stored graph JSON.
+
+- `packages/topographer/src/internal/topo-store.ts:436-439` defines its activation source projector as `projectActivationSourceDeclaration(source)`.
+- `packages/topographer/src/internal/topo-store.ts:922-929` stores per-entry activation source detail with `source: projectActivationSource(activation.source)`.
+- `packages/topographer/src/internal/topo-store.ts:1247-1296` builds the stored `TopoGraph` with `activationSources` from `collectActivationSourceCatalog(trails)` plus the same entry family.
+- `packages/topographer/src/internal/topo-store.ts:1537-1549` inserts `topo_graph`, `topo_graph_hash`, and `lock_manifest` into `topo_exports`.
+- `packages/topographer/src/internal/topo-store.ts:1554-1574` reads persisted `topo_graph` back as `topoGraphJson`.
+
+The survey path exposes the same activation source shape and the output schema accepts it.
+
+- `apps/trails/src/trails/topo-activation.ts:21-37` defines `ActivationSourceReport` with `hasVerify`, `method`, `parseOutputSchema`, `path`, and `payloadSchema`.
+- `apps/trails/src/trails/topo-activation.ts:156-159` projects survey activation sources through `projectActivationSourceDeclaration`.
+- `apps/trails/src/trails/topo-activation.ts:184-194` collects activation sources by that projected `key`.
+- `apps/trails/src/trails/topo-output-schemas.ts:11-29` defines `activationSourceOutput` with `hasParse`, `hasPayloadSchema`, `hasVerify`, `method`, `parseOutputSchema`, `path`, and `payloadSchema`.
+- `apps/trails/src/__tests__/survey.test.ts:982-1034` asserts `deriveTrailDetail(...).activationSources` for a webhook includes `hasVerify: true`, `method: 'POST'`, `path`, `parseOutputSchema`, and `payloadSchema`, and passes `trailDetailOutput.safeParse`.
+- `packages/topographer/src/__tests__/derive.test.ts:417-464` asserts the direct `deriveTopoGraph` webhook source includes the same fields.
+- `packages/topographer/src/__tests__/topo-store.test.ts:1130-1183` asserts the persisted topo-store `topoGraph.activationSources` webhook source includes the same fields.
+
+### Predicate 2: TopoStore Typed Views Over Saved TopoGraph
+
+The typed store API is broad enough for blind agents across entries, contours, topoGraph, trail detail, surfaces, layers, activation, governance, and schemas.
+
+- `packages/topographer/src/internal/topo-store-read.ts:34-47` defines `TopoStoreTopoGraphRecord`, `TopoStoreTopoGraphEntryRecord`, and `TopoStoreContourRecord`.
+- `packages/topographer/src/internal/topo-store-read.ts:87-107` defines `TopoStoreTrailDetailRecord` with `activationContext`, `activationEdges`, `activationSources`, `cli`, `contourDetails`, `contours`, `crosses`, `detours`, `examples`, `fieldOverrides`, `governance`, `input`, `layers`, `output`, `resources`, `surfaceProjections`, and `surfaces`.
+- `packages/topographer/src/internal/topo-store-read.ts:246-288` parses saved `topoGraphJson` and maps saved graph entries into typed `TopoStoreTopoGraphEntryRecord`s.
+- `packages/topographer/src/internal/topo-store-read.ts:499-543` builds trail graph detail from the stored `TopoGraph`, including activation context/edges/sources, contour detail, field overrides, governance, input/output schemas, layers, surface projections, and surfaces.
+- `packages/topographer/src/internal/topo-store-read.ts:694-703` exposes `getTopoStoreTopoGraph(...)` as `{ snapshot, topoGraph }`.
+- `packages/topographer/src/internal/topo-store-read.ts:791-835` returns `store.trails.get(...)` detail by combining SQL row data with stored graph detail.
+- `packages/topographer/src/internal/topo-store-read.ts:1032-1040` reads signal detail examples and payload from the stored graph entry.
+- `packages/topographer/src/topo-store.ts:203-268` defines `ReadOnlyTopoStore` with typed `contours`, `entries`, `exports`, `resources`, `signals`, `snapshots`, `topoGraph`, and `trails` accessors.
+- `packages/topographer/src/topo-store.ts:320-346` derives mock `topoGraphs`, `entries`, and `contours` from seeded exports/topoGraph content.
+- `packages/topographer/src/topo-store.ts:535-633` wires the real store accessors to the read helpers.
+- `packages/topographer/src/__tests__/topo-store-read.test.ts:504-679` covers saved `topoGraph`, `entries`, `trails.get(...)`, contour detail, layers, field overrides, activation context/sources/edges, schemas, signal entries, and missing entries.
+- `packages/topographer/src/__tests__/topo-store-read.test.ts:681-725` proves SQL `topo_surfaces` is a CLI row projection while typed graph detail still exposes activation sources, field overrides, layers, and output schema.
+
+### Predicate 3: Claimed Detail Fields Are Covered By Types, Output Schemas, And Tests
+
+The direct and survey-facing claimed fields are covered by TypeScript interfaces, output schemas, and focused tests.
+
+- `packages/topographer/src/types.ts:48-66` makes activation source webhook fields type-visible: `hasVerify`, `method`, `parseOutputSchema`, `path`, and `payloadSchema`.
+- `packages/topographer/src/types.ts:101-155` defines `TopoGraphEntry` and `TopoGraph` fields for surfaces, CLI path, input/payload/output schemas, intent, permit, activation sources, crosses, contours, resources, fires/on, governance, field overrides, layers, detours, examples, and workspace metadata.
+- `apps/trails/src/trails/topo-reports.ts:108-164` defines `TrailDetailReport` with the blind-agent detail fields, including activation, contours, field overrides, governance, layers, schemas, resources, surface projections, and surfaces.
+- `apps/trails/src/trails/topo-reports.ts:421-525` derives graph detail from `deriveTopoGraph(app)` and returns activation context/edges, contour details, field overrides, governance, input/output schemas, layers, surface projections, and surfaces.
+- `apps/trails/src/trails/topo-reports.ts:539-595` returns those graph-detail fields from `deriveTrailDetail`.
+- `apps/trails/src/trails/topo-output-schemas.ts:96-151` defines `trailDetailOutput` with activation context/edges/sources, CLI, composed layers, contour details, crosses, detours, examples, field overrides, governance, input/output schemas, resources, surface projections, and surfaces.
+- `apps/trails/src/__tests__/survey.test.ts:547-670` asserts survey trail detail includes resolved TopoGraph contract fields for blind agents and passes `trailDetailOutput.safeParse`.
+
+I did not find a claimed direct-entry or survey-detail field missing from the relevant output schemas, TypeScript types, or focused tests.
+
+### Predicate 4: Prior P0/P1/P2 Status
+
+- Round 1 P2 (`survey.trail` activation source schemas) is fixed: `apps/trails/src/trails/topo-activation.ts:156-159` uses the shared projector, `apps/trails/src/trails/topo-output-schemas.ts:11-29` accepts the schema-bearing fields, and `apps/trails/src/__tests__/survey.test.ts:982-1034` covers the webhook shape.
+- Round 2 P2 (direct `deriveTopoGraph` missing webhook `method`/`path`/`hasVerify`) is fixed: `packages/topographer/src/derive.ts:150-153` uses the shared projector, and `packages/topographer/src/__tests__/derive.test.ts:417-464` covers the webhook shape.
+- No prior P0/P1 findings were present in the topographer round-1 or round-2 reports.
+- The P3 compact API reference omission remains: `packages/topographer/src/index.ts:87-106` exports the newer topo-store types, while `docs/api-reference.md:227-232` lists only a subset. `docs/topo-store-reference.md:378-404` documents the saved graph entry/contour types, so this is docs polish rather than missing implementation.
+
+## Commands Run
+
+Read-only evidence commands:
+
+- `nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md | sed -n '1,260p'`
+- `nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/REFS.md | sed -n '1,260p'`
+- `nl -ba docs/adr/0046-lock-v3-artifact-family.md | sed -n '1,260p'`
+- `nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-1.md | sed -n '1,260p'`
+- `nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-2.md | sed -n '1,320p'`
+- `rg -n "webhook|activation|payloadSchema|parseOutputSchema|hasVerify|method|path|TopoGraph|topoGraph|surfaces|layers|governance|schemas|contours|entries|detail|survey" packages/topographer/src/derive.ts packages/topographer/src/types.ts packages/topographer/src/internal/topo-store-read.ts packages/topographer/src/topo-store.ts apps/trails/src/trails/topo-reports.ts apps/trails/src/trails/topo-output-schemas.ts apps/trails/src/trails/topo-activation.ts`
+- `nl -ba` source slices from the required files plus `packages/core/src/activation-source-projection.ts`, `packages/topographer/src/internal/topo-store.ts`, `packages/topographer/src/index.ts`, `docs/api-reference.md`, `docs/topo-store-reference.md`, and focused test files.
+
+Verification commands:
+
+| Command | Output |
+| --- | --- |
+| `git status --short --branch` | `## trl-637-audit-release-process-and-beta-to-10-cutover-requirements` |
+| `bun test packages/core/src/__tests__/activation-source-projection.test.ts` | 6 pass, 0 fail, 10 expect calls. |
+| `bun test packages/topographer/src/__tests__/derive.test.ts packages/topographer/src/__tests__/topo-store.test.ts -t "activation source"` | 4 pass, 44 filtered out, 0 fail, 7 expect calls. |
+| `bun test packages/topographer/src/__tests__/topo-store-read.test.ts apps/trails/src/__tests__/survey.test.ts` | 51 pass, 0 fail, 183 expect calls. |
+| `bun run typecheck` | 21 successful tasks, 21 total; all cached. |

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-1.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-1.md
@@ -1,0 +1,149 @@
+# Local Review Round 1: V1 Audit Lane
+
+Date: 2026-05-12
+Reviewer lane: V1 audit
+Scope: TRL-634, TRL-636, TRL-637 audit reports and follow-ups
+Stack tip: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+
+## Result
+
+Found one P2 audit-correctness issue in the TRL-634 parity report. No P0/P1 findings. TRL-636 and TRL-637 are evidence-backed and their filed follow-ups match the live gaps I checked.
+
+## Findings
+
+### P2: TRL-634 misclassifies the demo signal consumer as internal
+
+Owning branch: `trl-634-audit-cross-surface-parity-coverage-gaps`
+
+The parity counts are correct, but the report says all three non-projected trails are internal. The demo non-projected trail is actually a public signal activation consumer; it is excluded from surface projection because `filterSurfaceTrails()` rejects trails with activation sources, not because its visibility is internal.
+
+Report evidence:
+
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:14`:
+  > The projection posture is structurally aligned for the three shipped surfaces. Every public, surface-eligible trail in both app topos derives a CLI command, MCP tool, and HTTP route. The three non-projected trails are intentionally internal:
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:104`:
+  > | `entity.notify-updated` | write | - | - | - | not shipped | internal activation consumer | n/a |
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:117`:
+  > - Internal trails remain absent from public surfaces unless explicitly included. This matches `create.scaffold`, `add.verify`, and `entity.notify-updated`.
+
+Source evidence:
+
+- `apps/trails-demo/src/trails/notify.ts:30`:
+  > export const notifyEntityUpdated = trail('entity.notify-updated', {
+- `apps/trails-demo/src/trails/notify.ts:66`:
+  > on: ['entity.updated'],
+- `packages/core/src/trail.ts:461`:
+  > visibility: rawVisibility ?? 'public',
+- `packages/core/src/surface-filter.ts:154-155`:
+  > if (trail.activationSources.length > 0) {
+  > return false;
+
+Validation:
+
+```bash
+bun --eval 'import { app } from "./apps/trails/src/app.ts"; import { graph as demo } from "./apps/trails-demo/src/app.ts"; import { deriveCliCommands } from "./packages/cli/src/index.ts"; import { deriveMcpTools } from "./packages/mcp/src/index.ts"; import { deriveHttpRoutes } from "./packages/http/src/index.ts"; const unwrap = (r) => r.isOk() ? r.value : (() => { throw r.error; })(); for (const [name, topo] of [["@ontrails/trails", app], ["trails-demo", demo]]) { const trails = topo.list(); const cli = unwrap(deriveCliCommands(topo)); const mcp = unwrap(deriveMcpTools(topo)); const http = unwrap(deriveHttpRoutes(topo)); const cliIds = new Set(cli.map((c) => c.trail.id)); const mcpIds = new Set(mcp.map((t) => t.trailId)); const httpIds = new Set(http.map((r) => r.trailId)); console.log(JSON.stringify({ name, storedTrails: trails.length, cli: cli.length, mcp: mcp.length, http: http.length, nonProjected: trails.filter((t) => !cliIds.has(t.id) && !mcpIds.has(t.id) && !httpIds.has(t.id)).map((t) => ({ id: t.id, visibility: t.visibility, on: t.on?.length ?? 0, activationSources: t.activationSources?.length ?? 0 })) }, null, 2)); }'
+```
+
+Observed result:
+
+```json
+{
+  "name": "@ontrails/trails",
+  "storedTrails": 29,
+  "cli": 27,
+  "mcp": 27,
+  "http": 27,
+  "nonProjected": [
+    { "id": "create.scaffold", "visibility": "internal", "on": 0, "activationSources": 0 },
+    { "id": "add.verify", "visibility": "internal", "on": 0, "activationSources": 0 }
+  ]
+}
+{
+  "name": "trails-demo",
+  "storedTrails": 8,
+  "cli": 7,
+  "mcp": 7,
+  "http": 7,
+  "nonProjected": [
+    { "id": "entity.notify-updated", "visibility": "public", "on": 1, "activationSources": 1 }
+  ]
+}
+```
+
+Recommended action:
+
+Update `m3-parity-audit.md` to distinguish:
+
+- 34 public, surface-eligible trails projected on CLI/MCP/HTTP.
+- 2 intentionally internal trails: `create.scaffold`, `add.verify`.
+- 1 public activation consumer excluded from callable surfaces: `entity.notify-updated`.
+
+Also adjust the intentional-differences and coverage-matrix wording so the future parity runner filters by shipped-surface eligibility, not by "internal" status alone. The existing TRL-704/705/706 follow-ups can remain, but their evidence should not inherit the false "internal" claim.
+
+### P3: TRL-634 includes a non-runnable probe placeholder
+
+Owning branch: `trl-634-audit-cross-surface-parity-coverage-gaps`
+
+The audit is otherwise backed by source and a live repro above, but one command block is not reproducible as written:
+
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:37`:
+  > bun --eval '/*createTopoSnapshot + createTopoStore + deriveCliCommands + deriveMcpTools + deriveHttpRoutes for @ontrails/trails and trails-demo*/'
+
+Recommended action:
+
+Replace the placeholder with the actual short probe, or add a checked-in scratch helper under the report directory if the command is too long. This is P3 because the key claims are independently verifiable, but the report should be restartable without reconstructing the probe.
+
+## Clean Checks
+
+TRL-636 docs/examples audit:
+
+- `bun run docs:snippets` still reports only `packages/tracing/README.md`, matching the TRL-708 finding.
+- The fresh-start blocker remains grounded: `npm view @ontrails/commander version --json` still returns E404, matching TRL-707.
+- Follow-ups TRL-707, TRL-708, TRL-709, and TRL-710 are focused, parented to TRL-636, and non-duplicative.
+
+TRL-637 release-process audit:
+
+- `bun run publish:check` passed for every non-private packable workspace, including packages that registry probes cannot resolve.
+- `bunx changeset status --verbose` still fails with `Found changeset logtape-observe-target for package @ontrails/logging which is not in the workspace`, matching TRL-713.
+- `.changeset/logtape-observe-target.md:2` still contains `"@ontrails/logging": patch`.
+- `.changeset/pre.json:2-3` is still prerelease mode with tag `beta`.
+- `scripts/publish.ts:153-170` uses `.changeset/pre.json` while in prerelease mode and falls back to `latest` outside prerelease mode.
+- `scripts/publish.ts:448-483` publishes with `bun publish --access public --tag <tag>` and aborts on first failure.
+- Follow-ups TRL-711, TRL-712, TRL-713, and TRL-714 are focused, parented to TRL-637, and use Bun publish language. The `npm view` usage is read-only registry verification, not publish guidance.
+
+Linear readback:
+
+- TRL-704 through TRL-714 exist, are open in Backlog, and are parented to their audit issues: TRL-704/705/706 under TRL-634, TRL-707/708/709/710 under TRL-636, and TRL-711/712/713/714 under TRL-637.
+
+## Commands Run
+
+```bash
+/usr/bin/git branch --show-current
+/usr/bin/git status --short
+/usr/bin/git log --oneline --decorate -20
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m5-docs-audit.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md
+nl -ba packages/testing/src/all.ts | sed -n '130,210p'
+nl -ba packages/testing/src/index.ts
+nl -ba docs/index.md | sed -n '1,80p'
+nl -ba docs/api-reference.md | sed -n '120,175p'
+nl -ba .changeset/pre.json
+nl -ba .changeset/config.json
+nl -ba .changeset/logtape-observe-target.md
+nl -ba scripts/publish.ts | sed -n '1,90p'
+nl -ba scripts/publish.ts | sed -n '140,185p'
+nl -ba scripts/publish.ts | sed -n '340,500p'
+bun --eval '<surface projection count probe>'
+bunx changeset status --verbose
+npm view @ontrails/commander version --json
+npm view @ontrails/observe version --json
+npm view @ontrails/topographer version --json
+npm view @ontrails/wayfinder version --json
+bun run docs:snippets
+bun run publish:check
+```
+
+Linear read tools were used only to fetch TRL-704 through TRL-714; no Linear mutation was performed.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-2.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-2.md
@@ -1,0 +1,178 @@
+# Local Review Round 2: V1 Audit Lane
+
+Date: 2026-05-12
+Reviewer lane: V1 audit
+Scope: TRL-634, TRL-636, TRL-637 audit reports and follow-up mapping
+Stack tip: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+
+## Result
+
+Not clean. I found one P2 audit-correctness issue. The TRL-634 parity report
+itself now distinguishes internal trails from public activation consumers and
+contains a runnable projection probe, but the execution retro still carries the
+old false summary.
+
+No P0/P1 findings. TRL-636 and TRL-637 remain evidence-backed, and the
+TRL-704 through TRL-714 follow-up mapping checks out against Linear readback.
+
+## Findings
+
+### P2: RETRO still says all three non-projected trails are internal
+
+Owning branch: `trl-634-audit-cross-surface-parity-coverage-gaps`
+
+The round 1 TRL-634 report finding was fixed in
+`reports/m3-parity-audit.md`, but the execution retro still repeats the old
+classification. That leaves the handoff artifact contradicting the canonical
+audit report and the live projection probe.
+
+Report evidence:
+
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md:213-216`:
+  > `reports/m3-parity-audit.md`, and filed follow-ups `TRL-704`, `TRL-705`, and
+  > `TRL-706`. The audit found 37 trails across `@ontrails/trails` and
+  > `trails-demo`: 34 public trails project on CLI/MCP/HTTP, 3 are intentionally
+  > internal, and WebSocket remains planned/not shipped.
+
+Corrected canonical report evidence:
+
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:16-23`:
+  > The projection posture is structurally aligned for the three shipped surfaces.
+  > Every public, surface-eligible trail in both app topos derives a CLI command,
+  > MCP tool, and HTTP route. The non-projected trails are either intentionally
+  > internal or activation-source consumers that are not callable surface trails:
+  >
+  > - `@ontrails/trails:create.scaffold`
+  > - `@ontrails/trails:add.verify`
+  > - `trails-demo:entity.notify-updated`
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:148`:
+  > | `entity.notify-updated` | write | - | - | - | not shipped | public activation consumer | n/a |
+- `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:163-165`:
+  > - Public activation consumers remain absent from callable surfaces because
+  >   `filterSurfaceTrails()` excludes trails with activation sources. This matches
+  >   `entity.notify-updated`.
+
+Validation:
+
+```bash
+bun --eval '<M3 surface projection count probe from reports/m3-parity-audit.md>'
+```
+
+Observed result:
+
+```json
+{
+  "name": "@ontrails/trails",
+  "storedTrails": 29,
+  "cli": 27,
+  "mcp": 27,
+  "http": 27,
+  "nonProjected": [
+    { "activationSources": 0, "id": "create.scaffold", "on": 0, "visibility": "internal" },
+    { "activationSources": 0, "id": "add.verify", "on": 0, "visibility": "internal" }
+  ]
+}
+{
+  "name": "trails-demo",
+  "storedTrails": 8,
+  "cli": 7,
+  "mcp": 7,
+  "http": 7,
+  "nonProjected": [
+    { "activationSources": 1, "id": "entity.notify-updated", "on": 1, "visibility": "public" }
+  ]
+}
+```
+
+Recommended action:
+
+Update the TRL-634 execution-log entry in `RETRO.md` to say the audit found
+34 public trails projected on CLI/MCP/HTTP, 2 intentionally internal trails
+(`create.scaffold`, `add.verify`), and 1 public activation consumer
+(`entity.notify-updated`) excluded from callable surfaces by activation-source
+filtering.
+
+## Clean Checks
+
+TRL-634 parity audit:
+
+- `reports/m3-parity-audit.md` now has a real `bun --eval` workspace index probe
+  and a real `bun --eval` surface-projection probe.
+- The report's matrix and intentional-differences section now classify
+  `entity.notify-updated` as a public activation consumer instead of internal.
+- The follow-ups remain appropriate: TRL-704 for HTTP testing harness coverage,
+  TRL-705 for example-driven CLI/MCP/HTTP parity execution, and TRL-706 for a
+  complete shipped-surface projection inventory.
+
+TRL-636 docs/examples audit:
+
+- `bun run docs:snippets` still passes and reports only
+  `packages/tracing/README.md`, matching TRL-708.
+- `docs/index.md:28-31` and `docs/api-reference.md:149` still describe
+  CLI/MCP/HTTP as shipped and WebSocket as planned, matching the audit posture.
+- Linear readback shows TRL-707 through TRL-710 are parented to TRL-636 in the
+  `v1 Release Prep` project.
+
+TRL-637 release-process audit:
+
+- `bun run publish:check` passed for all non-private packable workspaces.
+- `bunx changeset status --verbose` still fails with
+  `Found changeset logtape-observe-target for package @ontrails/logging which is not in the workspace`,
+  matching TRL-713.
+- `.changeset/logtape-observe-target.md:2` still contains
+  `"@ontrails/logging": patch`.
+- `.changeset/pre.json:2-3` is still prerelease mode with tag `beta`.
+- `scripts/publish.ts:153-170` resolves `beta` from `.changeset/pre.json` while
+  in prerelease mode and falls back to `latest` outside prerelease mode.
+- `scripts/publish.ts:448-483` publishes with `bun publish --access public --tag <tag>`
+  and aborts on the first package failure.
+- Read-only registry probes for `@ontrails/commander`, `@ontrails/observe`,
+  `@ontrails/topographer`, and `@ontrails/wayfinder` still return E404, matching
+  TRL-714 and the TRL-707 generated-project symptom.
+- Linear readback shows TRL-711 through TRL-714 are parented to TRL-637 in the
+  `v1 Release Prep` project.
+
+Linear readback:
+
+- TRL-704, TRL-705, and TRL-706 are parented to TRL-634.
+- TRL-707, TRL-708, TRL-709, and TRL-710 are parented to TRL-636.
+- TRL-711, TRL-712, TRL-713, and TRL-714 are parented to TRL-637.
+- No Linear mutation was performed.
+
+## Commands Run
+
+```bash
+pwd
+/usr/bin/git branch --show-current
+/usr/bin/git status --short
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m5-docs-audit.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-1.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md
+nl -ba packages/testing/src/all.ts | sed -n '130,215p'
+nl -ba packages/testing/src/index.ts
+nl -ba docs/index.md | sed -n '1,90p'
+nl -ba docs/api-reference.md | sed -n '130,175p'
+nl -ba scripts/publish.ts | sed -n '1,90p'
+nl -ba scripts/publish.ts | sed -n '145,175p'
+nl -ba scripts/publish.ts | sed -n '350,490p'
+nl -ba .changeset/pre.json
+nl -ba .changeset/config.json
+nl -ba .changeset/logtape-observe-target.md
+rg -n "entity.notify-updated|activation consumer|internal|runnable|bun --eval|TRL-704|TRL-705|TRL-706" .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md
+rg -n "3 are intentionally internal|public activation consumer|34 public trails|entity.notify-updated|TRL-704|TRL-707|TRL-711|logtape-observe-target|@ontrails/logging" .agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md .agents/plans/2026-05-12-topograph-query-docs-stack/reports/*.md
+bun --eval '<M3 surface projection count probe from reports/m3-parity-audit.md>'
+bun run docs:snippets
+bunx changeset status --verbose
+bun run publish:check
+npm view @ontrails/commander version --json
+npm view @ontrails/observe version --json
+npm view @ontrails/topographer version --json
+npm view @ontrails/wayfinder version --json
+/usr/bin/git diff --check
+```
+
+Linear read tools were used only to list children of TRL-634, TRL-636, and
+TRL-637. No source-control write commands and no Linear mutations were run.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-3.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-3.md
@@ -1,0 +1,187 @@
+# Local Review Round 3: V1 Audit Reports And Follow-Up Mapping
+
+Date: 2026-05-12
+Reviewer lane: V1 audit reports and Linear follow-up mapping
+Stack tip observed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+
+## Result
+
+Clean for P0/P1/P2 in this lane. The M3, M5, and M6 audit reports are evidence-backed against the local stack tip, the round 1 and round 2 P2s are fixed, and the RETRO no longer contradicts the canonical reports.
+
+Residuals are P3-only:
+
+- I did not re-query Linear live in this round. Local report/RETRO issue IDs and purposes are internally consistent, and round 2 records live Linear readback for TRL-704 through TRL-714, but current tracker parentage was not refreshed here.
+- M5 still records the relative-link scan as an ad hoc placeholder command, but the broken-link table is concrete and TRL-709 owns the durable Markdown-aware checker.
+
+## Findings
+
+| Severity | Owning branch | Finding | Recommended action |
+| --- | --- | --- | --- |
+| Clean | `trl-634-audit-cross-surface-parity-coverage-gaps` | M3 correctly distinguishes 34 public surface-eligible trails, two internal trails, one public activation consumer, and WebSocket as planned/not shipped. The two M3 `bun --eval` probes are runnable at the stack tip. | No P0/P1/P2 action. Keep TRL-704, TRL-705, and TRL-706 as focused follow-ups. |
+| Clean | `trl-636-audit-docs-and-examples-for-v1-readiness` | M5 uses concrete evidence for the generated-project install blocker, narrow README snippet coverage, relative-link gaps, and sparse public API `@example` coverage. Follow-ups TRL-707 through TRL-710 are focused. | No P0/P1/P2 action. TRL-709 should replace the ad hoc link scan with a durable code-fence-aware checker. |
+| Clean | `trl-637-audit-release-process-and-beta-to-10-cutover-requirements` | M6 uses the repo's Bun release language: `bun run publish:check` and `bun run publish:packages` are the release commands, while `npm view` is only a read-only registry probe. Follow-ups TRL-711 through TRL-714 are focused cutover gaps. | No P0/P1/P2 action. |
+| Clean | V1 audit tail | Round 1's M3 classification P2 and round 2's stale RETRO P2 are fixed in the canonical report and RETRO. | No further correction needed. |
+| P3 / unknown | V1 audit tail / tracker mapping | Live Linear parentage was not re-read in this round. Local artifacts consistently map M3 to TRL-704/705/706, M5 to TRL-707/708/709/710, and M6 to TRL-711/712/713/714. | If merge gating needs live tracker proof, run a read-only Linear readback for TRL-704 through TRL-714 before final handoff. |
+
+## Evidence
+
+### Scope And Expected Artifacts
+
+- `PLAN.md:38-40` says TRL-634/636/637 are audit/report branches, their reports live under `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/`, and TRL-637 uses Bun publish flow with `bun run publish:check` and `bun run publish:packages`, "not npm publish or changeset publish."
+- `PLAN.md:433-445` requires M3 to produce `reports/m3-parity-audit.md`, build a CLI/MCP/HTTP/WebSocket/internal matrix, and file focused follow-ups rather than implementing the parity harness.
+- `PLAN.md:455-468` requires M5 to produce `reports/m5-docs-audit.md`, include fresh-checkout failure output if anything breaks, audit `@example` coverage and snippet verification, and file focused follow-ups.
+- `PLAN.md:479-491` requires M6 to produce `reports/m6-release-process-audit.md`, use Bun publish language, inventory `.changeset/pre.json`, release scripts, CI gates, and beta-to-stable order, and not run the release.
+
+### M3 Parity Report
+
+- `m3-parity-audit.md:11-19` reports `@ontrails/trails` as 29 stored / 27 public surface-eligible projected trails, `trails-demo` as 8 stored / 7 public surface-eligible projected trails, and says non-projected trails are "either intentionally internal or activation-source consumers."
+- `m3-parity-audit.md:21-23` lists the three non-projected trails: `create.scaffold`, `add.verify`, and `entity.notify-updated`.
+- `m3-parity-audit.md:100-103` defines `internal` separately from `activation consumer`.
+- `m3-parity-audit.md:112`, `m3-parity-audit.md:116`, and `m3-parity-audit.md:148` classify `add.verify` and `create.scaffold` as internal, and `entity.notify-updated` as a public activation consumer.
+- `m3-parity-audit.md:161-166` says internal trails remain absent unless included, public activation consumers are excluded because `filterSurfaceTrails()` excludes activation sources, and WebSocket has no public surface package/API.
+- Source supports the filter: `packages/core/src/surface-filter.ts:154-155` returns false when `trail.activationSources.length > 0`; `packages/cli/src/build.ts:1186-1194`, `packages/mcp/src/build.ts:912-921`, and `packages/http/src/build.ts:773-782` all derive from `filterSurfaceTrails(...)`.
+- Source supports the harness gap: `packages/testing/src/all.ts:164-177` validates CLI and MCP only in `testAllEstablished()`, and `packages/testing/src/index.ts:33-35` exports CLI and MCP harnesses with no HTTP harness export.
+- Source supports WebSocket posture: `docs/index.md:28-31` lists CLI, MCP, and HTTP as shipped today and WebSocket as planned; `docs/api-reference.md:149` says WebSocket has no public package or API yet.
+
+M3 projection probe output from this round:
+
+```json
+{
+  "name": "@ontrails/trails",
+  "storedTrails": 29,
+  "cli": 27,
+  "mcp": 27,
+  "http": 27,
+  "nonProjected": [
+    { "activationSources": 0, "id": "create.scaffold", "on": 0, "visibility": "internal" },
+    { "activationSources": 0, "id": "add.verify", "on": 0, "visibility": "internal" }
+  ]
+}
+{
+  "name": "trails-demo",
+  "storedTrails": 8,
+  "cli": 7,
+  "mcp": 7,
+  "http": 7,
+  "nonProjected": [
+    { "activationSources": 1, "id": "entity.notify-updated", "on": 1, "visibility": "public" }
+  ]
+}
+```
+
+The workspace-index probe in `m3-parity-audit.md:36` also ran successfully. Its output showed `apps` as `["@ontrails/trails","trails-demo"]`, `collisions` as `[]`, `source` as `discovery`, and an `index` object containing 37 trail entries. It warned that no workspace topo lock exists in `.trails`, matching the report's discovery fallback.
+
+### M5 Docs/Examples Report
+
+- `m5-docs-audit.md:136-144` records the fresh generated-project failure: `@ontrails/commander@^1.0.0-beta.15 failed to resolve` after npm returned 404.
+- `m5-docs-audit.md:159-162` concludes the fresh-start path cannot pass dependency installation when CLI is included, and maps this to TRL-707.
+- `m5-docs-audit.md:169-177` records `bun run docs:snippets` output as `README snippet typecheck passed for: packages/tracing/README.md`; this round reran the command with the same output.
+- `m5-docs-audit.md:179-182` concludes the checker is too narrow and maps it to TRL-708.
+- `m5-docs-audit.md:194-211` lists concrete broken relative links and the code-fence false positive, then maps the durable checker to TRL-709.
+- `m5-docs-audit.md:256-271` lists high-value missing `@example` coverage across CLI, HTTP, MCP, Commander, and Hono entrypoints, then maps the inventory/gate to TRL-710.
+- `m5-docs-audit.md:286-293` lists focused follow-ups TRL-707, TRL-708, TRL-709, and TRL-710.
+
+Docs snippet output from this round:
+
+```text
+$ bun scripts/check-readme-snippets.ts
+README snippet typecheck passed for: packages/tracing/README.md
+```
+
+### M6 Release/Cutover Report
+
+- `m6-release-process-audit.md:14-21` says publishing is done with `bun run publish:packages`, not `changeset publish` or `npm publish`, and that `bun run publish:check` packs every non-private workspace.
+- `m6-release-process-audit.md:38-56` cites the repo release guidance, `.changeset/pre.json`, and `scripts/publish.ts` for the Bun publish flow, default prerelease tag, pack dry-run, and sequential `bun publish --access public --tag <tag>`.
+- `m6-release-process-audit.md:89-91` describes `npm view <package> version --json` as a read-only registry check, not a publish command.
+- `AGENTS.md:271-284` says Changesets owns versioning and changelogs, not `changeset publish`, and publishing goes through the Bun script with `bun run publish:check` then `bun run publish:packages`.
+- `AGENTS.md:296` says `publish:check` runs `bun pm pack --dry-run` and `publish:packages` uses the dist-tag from `.changeset/pre.json`, falling back to `latest` outside prerelease mode.
+- `scripts/publish.ts:4-9` states the script publishes public `@ontrails/*` workspaces using `bun publish`, sorts workspace dependency edges, and blocks unresolved range leakage.
+- `scripts/publish.ts:153-170` resolves `beta` from `.changeset/pre.json` in prerelease mode and refuses a silent fallback if the tag is missing.
+- `scripts/publish.ts:419-445` runs the pack check; `scripts/publish.ts:448-483` publishes sequentially with `bun publish --access public --tag <tag>` and aborts on the first failure.
+- `.changeset/pre.json:2-3` is still `mode: "pre"` with tag `beta`.
+- `.changeset/logtape-observe-target.md:2` still references retired `@ontrails/logging`, matching the TRL-713 finding.
+- `m6-release-process-audit.md:268-292` maps the stale Changesets failure to TRL-713.
+- `m6-release-process-audit.md:294-317` maps the registry readiness gap to TRL-714 while keeping it distinct from local packability.
+- `m6-release-process-audit.md:341-348` lists focused release follow-ups TRL-711 through TRL-714.
+
+Release check outputs from this round:
+
+```text
+bunx changeset status --verbose
+Found changeset logtape-observe-target for package @ontrails/logging which is not in the workspace
+```
+
+```text
+bun run publish:check
+...
+✓ All package pack checks passed!
+```
+
+```text
+npm view @ontrails/commander version --json -> E404
+npm view @ontrails/observe version --json -> E404
+npm view @ontrails/topographer version --json -> E404
+npm view @ontrails/wayfinder version --json -> E404
+```
+
+### RETRO And Prior Round Fixes
+
+- Round 1 P2: `local-review-v1-audit-round-1.md:14-18` found that M3 misclassified the demo signal consumer as internal. Current M3 report evidence above shows this is fixed.
+- Round 1 P3: `local-review-v1-audit-round-1.md:83-94` found that the M3 projection probe was a placeholder. Current `m3-parity-audit.md:36-79` contains runnable `bun --eval` probes, both rerun successfully here.
+- Round 2 P2: `local-review-v1-audit-round-2.md:20-27` found that RETRO still carried the old false "three internal trails" summary. Current `RETRO.md:211-219` now says 34 public surface-eligible trails project on CLI/MCP/HTTP, 2 are intentionally internal, 1 public activation consumer is excluded by activation-source filtering, and WebSocket remains planned/not shipped.
+- `RETRO.md:127-137` maps M3 follow-ups to TRL-704/705/706, M5 follow-ups to TRL-707/708/709/710, and M6 follow-ups to TRL-711/712/713/714.
+- `RETRO.md:357-387` records the branch-focused checks for TRL-634, TRL-636, and TRL-637.
+
+## Commands Run
+
+Read-only/source inspection:
+
+```bash
+rg -n "M4b|V1 audit|local-review-v1|m3-parity|m5-docs|m6-release|2026-05-12-topograph" /Users/mg/.codex/memories/MEMORY.md
+nl -ba /Users/mg/.codex/memories/MEMORY.md | sed -n '120,136p'
+rg --files .agents/plans/2026-05-12-topograph-query-docs-stack reports docs packages/testing/src scripts .changeset | rg '(^|/)(PLAN|RETRO)\.md$|local-review-v1-audit-round-[12]\.md$|m[356]-.*audit\.md$|docs/(index|api-reference)\.md$|packages/testing/src/all\.ts$|scripts/publish\.ts$|\.changeset/(pre\.json|logtape-observe-target\.md)$'
+pwd
+git branch --show-current
+git status --short
+wc -l .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md .agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m5-docs-audit.md .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-1.md .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-2.md .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-3.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-3.md | sed -n '1,220p'
+rg -n "report|reports|TRL-63[467]|TRL-70[4-9]|TRL-71[0-4]|M3|M5|M6|WebSocket|surface-eligible|internal|activation|publish:check|publish:packages|changeset publish|npm publish|\.scratch/v1-release-prep|RETRO" .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md .agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md
+rg -n "surface-eligible|internal|activation|WebSocket|websocket|runnable|bun --eval|testAll|HTTP|MCP|CLI|TRL-70[4-6]|Follow-up|Result|Conclusion" .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md
+rg -n "docs:snippets|snippet|link|example|TRL-70[7-9]|TRL-710|Follow-up|Result|Conclusion|readiness|gap|evidence|bun run check|format:check|git diff --check" .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m5-docs-audit.md
+rg -n "publish:check|publish:packages|bun publish|npm publish|changeset publish|changeset status|npm view|TRL-71[1-4]|Follow-up|Result|Conclusion|cutover|pre\.json|logtape|@ontrails/logging|registry|release" .agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-1.md | sed -n '1,180p'
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-2.md | sed -n '1,220p'
+nl -ba docs/index.md | sed -n '20,40p'
+nl -ba docs/api-reference.md | sed -n '140,160p'
+nl -ba packages/testing/src/all.ts | sed -n '155,185p'
+nl -ba packages/testing/src/index.ts | sed -n '25,42p'
+nl -ba packages/core/src/surface-filter.ts | sed -n '145,170p'
+nl -ba packages/cli/src/build.ts | sed -n '1180,1200p'
+nl -ba packages/mcp/src/build.ts | sed -n '906,926p'
+nl -ba packages/http/src/build.ts | sed -n '767,787p'
+nl -ba scripts/publish.ts | sed -n '1,12p;145,175p;410,490p'
+nl -ba .changeset/pre.json
+nl -ba .changeset/logtape-observe-target.md
+nl -ba AGENTS.md | sed -n '269,301p'
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md | sed -n '36,42p'
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md | sed -n '433,498p'
+nl -ba .agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md | sed -n '508,524p'
+/usr/bin/git status --porcelain=v1 -uall
+```
+
+Verification commands:
+
+```bash
+bun --eval 'import { buildWorkspaceTrailIndex } from "./packages/topographer/src/index.ts"; const result = await buildWorkspaceTrailIndex({ cwd: process.cwd() }); console.log(JSON.stringify(result, null, 2));'
+bun --eval '<M3 surface projection probe from m3-parity-audit.md:42-79>'
+bun run docs:snippets
+bunx changeset status --verbose
+bun run publish:check
+npm view @ontrails/commander version --json
+npm view @ontrails/observe version --json
+npm view @ontrails/topographer version --json
+npm view @ontrails/wayfinder version --json
+git diff --check
+```
+
+One exploratory reduced M3 workspace-index summary command failed because I incorrectly read the result as `result.trails.length`; the exact report command was rerun immediately after and passed. No source-control write commands, `gt` commands, merge commands, or Linear mutations were run.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-warden-cli-round-1.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-warden-cli-round-1.md
@@ -1,0 +1,405 @@
+# Local Review Round 1 - Warden/CLI Polish Lane
+
+Date: 2026-05-12
+Cwd: `/Users/mg/Developer/outfitter/trails`
+Stack tip reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements` at `7720a0d76`
+
+Scope reviewed: TRL-692, TRL-690, TRL-691, TRL-693, TRL-694.
+
+## Result
+
+No P0/P1/P2 findings.
+
+The Warden guide manifest/schema naming, generated guide source-of-truth, plain-text link rendering, shared diagnostic schema projection, CLI value-alias ambiguity handling, and static resource accessor shadowing behavior all match the packet intent at stack tip.
+
+## Findings
+
+None.
+
+## Evidence Reviewed
+
+### TRL-692 - Manifest/schema naming
+
+Severity: none
+Owning branch: `trl-692-clarify-warden-guide-manifest-category-naming-before`
+Action: none
+
+The public guide entry type exposes `concern`, not `category`.
+
+`packages/warden/src/guide.ts:25-36`
+
+```ts
+export interface WardenRuleGuideEntry {
+  readonly concern: WardenRuleConcern;
+  readonly depth: WardenDepth;
+  readonly description: string;
+  readonly docs: readonly WardenGuidanceLink[];
+  readonly guidance?: WardenGuidance | undefined;
+  readonly id: string;
+  readonly invariant: string;
+  readonly lifecycle: WardenRuleLifecycle;
+  readonly scope: WardenRuleScope;
+  readonly severity: WardenSeverity;
+  readonly tier: WardenRuleTier;
+}
+```
+
+The manifest builder sources that field directly from rule metadata.
+
+`packages/warden/src/guide.ts:85-97`
+
+```ts
+return {
+  concern: metadata.concern,
+  depth: metadata.depth,
+  description: rule?.description ?? '',
+  docs,
+  guidance: metadata.guidance,
+  id,
+  invariant: metadata.invariant,
+  lifecycle: metadata.lifecycle,
+  scope: metadata.scope,
+  severity: rule?.severity ?? 'warn',
+  tier: metadata.tier,
+} satisfies WardenRuleGuideEntry;
+```
+
+The Trails app output schema also expects `concern`, preserving the surface contract.
+
+`apps/trails/src/trails/warden-guide.ts:29-44`
+
+```ts
+const wardenRuleGuideEntrySchema = z.object({
+  concern: z.enum(wardenRuleConcerns),
+  depth: z.enum(wardenDepthValues),
+  description: z.string(),
+  docs: z.array(wardenGuidanceLinkSchema).readonly(),
+  guidance: wardenGuidanceSchema.optional(),
+  id: z.string(),
+  invariant: z.string(),
+  lifecycle: z.object({
+    retireWhen: z.string().optional(),
+    state: z.enum(wardenRuleLifecycleStates),
+  }),
+  scope: z.enum(wardenRuleScopes),
+  severity: z.enum(['error', 'warn']),
+  tier: z.enum(wardenRuleTiers),
+});
+```
+
+Validation command:
+
+```bash
+bun apps/trails/bin/trails.ts warden guide --manifest | jq '.rules[0] | keys'
+```
+
+Result included `concern` and did not include `category`.
+
+### TRL-690 - Link rendering and schema reuse
+
+Severity: none
+Owning branch: `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse`
+Action: none
+
+Plain report output renders label plus copyable target for links, while preserving label-only references.
+
+`packages/warden/src/cli.ts:1327-1333`
+
+```ts
+const formatPlainGuidanceLink = (link: WardenGuidanceLink): string => {
+  const target = link.path ?? link.url;
+  if (target === undefined || target === link.label) {
+    return link.label;
+  }
+  return `${link.label} (${target})`;
+};
+```
+
+The regression test covers paths, URLs, and label-only docs.
+
+`packages/warden/src/__tests__/cli.test.ts:1161-1190`
+
+```ts
+test('formats guidance docs with labels and copyable targets in the lint section', () => {
+  const output = formatWardenReport({
+    diagnostics: [
+      {
+        filePath: 'src/trails/entity.ts',
+        guidance: {
+          docs: [
+            { label: 'Trail Rules', path: 'AGENTS.md#trail-rules' },
+            {
+              label: 'Warden docs',
+              url: 'https://docs.example.test/warden',
+            },
+            { label: 'Label-only reference' },
+          ],
+          summary: 'Use the Warden guidance.',
+        },
+```
+
+The Trails app Warden output now reuses the shared Warden diagnostic schema instead of locally duplicating diagnostic fields.
+
+`apps/trails/src/trails/warden.ts:8-16`
+
+```ts
+import {
+  diagnosticSchema,
+  runWardenCommand,
+  wardenDepthValues,
+  wardenDraftsValues,
+  wardenFailOnValues,
+  wardenFormatValues,
+  wardenLockValues,
+} from '@ontrails/warden';
+```
+
+`apps/trails/src/trails/warden.ts:178-181`
+
+```ts
+output: z.object({
+  diagnostics: z.array(
+    diagnosticSchema.extend({ topoName: z.string().optional() })
+  ),
+```
+
+### TRL-691 - Generated guide source-of-truth
+
+Severity: none
+Owning branch: `trl-691-polish-generated-warden-guide-headers-and-generator-tests`
+Action: none
+
+The generated AGENTS block points at the Warden manifest command as its guide input.
+
+`scripts/sync-agents-warden-guide.ts:24-33`
+
+```ts
+const renderGeneratedHeader = (
+  manifest: WardenGuideManifest
+): readonly string[] => [
+  WARDEN_GUIDE_START,
+  '<!-- GENERATED: run `bun run warden:agents:sync`; check with `bun run warden:agents:check`. -->',
+  '',
+  'This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.',
+  '',
+  `- Guide input command: \`bun apps/trails/bin/trails.ts warden guide --manifest\``,
+  `- Rule count: ${manifest.ruleCount}`,
+];
+```
+
+The generated skill guide points at the agent-json command and tells prompts to reference the generated file instead of copying rule prose.
+
+`scripts/sync-skill-warden-guide.ts:43-53`
+
+```ts
+const renderGeneratedHeader = (
+  manifest: WardenGuideManifest
+): readonly string[] => [
+  '# Warden Guidance For Trails Skills',
+  '',
+  '<!-- GENERATED: run `bun run warden:skills:sync`; check with `bun run warden:skills:check`. -->',
+  '',
+  'This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.',
+  '',
+  `- Guide input command: \`bun apps/trails/bin/trails.ts warden guide --agent-json\``,
+```
+
+The generated checked-in blocks are current:
+
+`AGENTS.md:88-90`
+
+```md
+This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
+
+- Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
+```
+
+`.claude/skills/clark/references/warden-guide.md:5-7`
+
+```md
+This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
+
+- Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
+```
+
+### TRL-693 - CLI value-alias ambiguity
+
+Severity: none
+Owning branch: `trl-693-tighten-cli-value-alias-conflicts-for-non-commander-callers`
+Action: none
+
+Non-Commander callers that do not pass user-supplied key tracking now fail loudly when an active alias is combined with any parsed canonical key.
+
+`packages/cli/src/flags.ts:186-200`
+
+```ts
+const canonicalKey = toCamel(flag.name);
+// Adapters should pass the exact user-supplied key set when they preserve
+// defaulted canonical values in parsed flags. Without that set, an active
+// value alias plus any parsed canonical key is ambiguous and must fail
+// loudly instead of guessing whether the canonical value was a default.
+const canonicalWasSupplied =
+  userSuppliedFlagKeys?.has(canonicalKey) ??
+  Object.hasOwn(normalized, canonicalKey);
+const [activeAlias] = activeAliases;
+if (!activeAlias) {
+  continue;
+}
+if (canonicalWasSupplied) {
+  throw new ValidationError(
+```
+
+Commander preserves its existing behavior by passing explicit user-supplied key tracking into alias application.
+
+`adapters/commander/src/to-commander.ts:291-298`
+
+```ts
+await action.command.execute(
+  action.parsedArgs,
+  applyCliFlagValueAliases(
+    action.command.flags,
+    action.parsedFlags,
+    action.userSuppliedFlagKeys
+  )
+);
+```
+
+The direct package test covers the non-Commander ambiguity path.
+
+`packages/cli/src/__tests__/flags.test.ts:147-160`
+
+```ts
+test('rejects ambiguous canonical defaults combined with aliases without caller-supplied key tracking', () => {
+  const flags = deriveFlags(
+    z.object({ outputFormat: z.enum(['json', 'text']).default('text') }),
+    { outputFormat: { aliases: { json: 'json-output' } } }
+  );
+
+  expect(() =>
+    applyCliFlagValueAliases(flags, {
+      jsonOutput: true,
+      outputFormat: 'text',
+    })
+  ).toThrow(
+    'CLI flag "--output-format" cannot be combined with value alias "--json-output"'
+  );
+});
+```
+
+The Commander adapter test still rejects a user-supplied canonical flag plus alias at the surface boundary.
+
+`adapters/commander/src/__tests__/to-commander.test.ts:969-982`
+
+```ts
+await withMockedProcess(async () => {
+  await expect(
+    program.parseAsync([
+      'node',
+      'test',
+      'render',
+      '--json',
+      '--format',
+      'text',
+    ])
+  ).rejects.toThrow('EXIT');
+});
+
+expect(received).toBeUndefined();
+```
+
+### TRL-694 - Static resource accessor shadowing
+
+Severity: none
+Owning branch: `trl-694-suppress-static-resource-accessor-warnings-when-string`
+Action: none
+
+The rule tracks declared resource names through scoped walking and records whether a declared static resource binding is shadowed at the lookup site.
+
+`packages/warden/src/rules/static-resource-accessor-preference.ts:350-358`
+
+```ts
+walkWithScopes(
+  body,
+  (node, scopes) => {
+    const lookup = extractResourceLookup(node, ctxNames, resourceAliases);
+    if (lookup && !isShadowedModuleBinding(lookup.name, scopes)) {
+      lookups.push({
+        ...lookup,
+        shadowedDeclaredNames: collectShadowedNames(declaredNames, scopes),
+      });
+```
+
+It suppresses only after resolving the lookup to a declared resource whose declared binding is shadowed.
+
+`packages/warden/src/rules/static-resource-accessor-preference.ts:544-553`
+
+```ts
+for (const lookup of lookups) {
+  const resourceName =
+    (lookup.name && declaredNames.has(lookup.name) ? lookup.name : null) ??
+    (lookup.id ? (declaredNameById.get(lookup.id) ?? null) : null);
+
+  if (!resourceName) {
+    continue;
+  }
+  if (lookup.shadowedDeclaredNames.has(resourceName)) {
+    continue;
+```
+
+The tests cover both identifier shadowing and string lookup shadowing.
+
+`packages/warden/src/__tests__/static-resource-accessor-preference.test.ts:168-205`
+
+```ts
+test('does not warn when a local binding shadows a declared resource name', () => {
+  const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+```
+
+```ts
+test('does not warn when a string resource lookup resolves to a shadowed declared name', () => {
+  const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+```
+
+## Focused Validation
+
+Passed:
+
+```bash
+bun test packages/warden/src/__tests__/guide.test.ts packages/warden/src/__tests__/cli.test.ts apps/trails/src/__tests__/warden.test.ts scripts/__tests__/sync-agents-warden-guide.test.ts scripts/__tests__/sync-skill-warden-guide.test.ts packages/cli/src/__tests__/flags.test.ts adapters/commander/src/__tests__/to-commander.test.ts packages/warden/src/__tests__/static-resource-accessor-preference.test.ts
+```
+
+Result: 142 pass, 0 fail, 393 expectations.
+
+Passed:
+
+```bash
+bun run warden:agents:check
+bun run warden:skills:check
+bun run typecheck
+```
+
+`bun run typecheck` reported 21 successful tasks, 21 cached.
+
+Passed:
+
+```bash
+bun apps/trails/bin/trails.ts warden guide --manifest | jq '.rules[0] | keys'
+bun apps/trails/bin/trails.ts warden guide --agent-json | jq '.kind, (.rules[0] | keys)'
+```
+
+The manifest output exposed `concern` and no `category`; the agent-json output reported kind `trails-warden-agent-guide` and exposed `concern`.
+
+## Unknowns
+
+- I did not inspect remote CI or bot review output in this lane.
+- I did not run the full repository verification matrix; this lane ran focused Warden/CLI tests, generated guide checks, guide command smoke checks, and typecheck.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-warden-cli-round-2.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-warden-cli-round-2.md
@@ -1,0 +1,412 @@
+# Local Review Round 2 - Warden/CLI Polish Lane
+
+Date: 2026-05-12
+Cwd: `/Users/mg/Developer/outfitter/trails`
+Stack tip reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements` at `137521982`
+Scope reviewed: TRL-692, TRL-690, TRL-691, TRL-693, TRL-694 after downstack restacks and round 1 fixes.
+
+## Result
+
+Clean for P0/P1/P2.
+
+No Warden/CLI P0, P1, or P2 regressions found. I also did not identify a new P3 worth carrying in this lane.
+
+## Findings
+
+None.
+
+## Evidence Reviewed
+
+### TRL-692 - Warden guide manifest concern naming
+
+Severity: none
+Owning branch: `trl-692-clarify-warden-guide-manifest-category-naming-before`
+Recommended action: none
+
+The public guide manifest entry exposes `concern`, not `category`.
+
+`packages/warden/src/guide.ts:25-37`
+
+```ts
+export interface WardenRuleGuideEntry {
+  readonly concern: WardenRuleConcern;
+  readonly depth: WardenDepth;
+  readonly description: string;
+  readonly docs: readonly WardenGuidanceLink[];
+  readonly guidance?: WardenGuidance | undefined;
+  readonly id: string;
+  readonly invariant: string;
+  readonly lifecycle: WardenRuleLifecycle;
+  readonly scope: WardenRuleScope;
+  readonly severity: WardenSeverity;
+  readonly tier: WardenRuleTier;
+}
+```
+
+The manifest builder sources the field directly from rule metadata.
+
+`packages/warden/src/guide.ts:85-97`
+
+```ts
+return {
+  concern: metadata.concern,
+  depth: metadata.depth,
+  description: rule?.description ?? '',
+  docs,
+  guidance: metadata.guidance,
+  id,
+  invariant: metadata.invariant,
+  lifecycle: metadata.lifecycle,
+  scope: metadata.scope,
+  severity: rule?.severity ?? 'warn',
+  tier: metadata.tier,
+} satisfies WardenRuleGuideEntry;
+```
+
+The Trails wrapper schema preserves the same public field.
+
+`apps/trails/src/trails/warden-guide.ts:29-44`
+
+```ts
+const wardenRuleGuideEntrySchema = z.object({
+  concern: z.enum(wardenRuleConcerns),
+  depth: z.enum(wardenDepthValues),
+  description: z.string(),
+  docs: z.array(wardenGuidanceLinkSchema).readonly(),
+  guidance: wardenGuidanceSchema.optional(),
+  id: z.string(),
+  invariant: z.string(),
+  lifecycle: z.object({
+    retireWhen: z.string().optional(),
+    state: z.enum(wardenRuleLifecycleStates),
+  }),
+  scope: z.enum(wardenRuleScopes),
+  severity: z.enum(['error', 'warn']),
+  tier: z.enum(wardenRuleTiers),
+});
+```
+
+Regression tests assert that both manifest and agent JSON omit `category`.
+
+`packages/warden/src/__tests__/guide.test.ts:22-29`
+
+```ts
+expect(throwRule).toMatchObject({
+  concern: 'results',
+  depth: 'source',
+  severity: 'error',
+  tier: 'source-static',
+});
+expect(throwRule).not.toHaveProperty('category');
+```
+
+### TRL-690 - Warden guidance link rendering and schema reuse
+
+Severity: none
+Owning branch: `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse`
+Recommended action: none
+
+Plain Warden output renders a copyable target when the guidance link has a path or URL.
+
+`packages/warden/src/cli.ts:1327-1333`
+
+```ts
+const formatPlainGuidanceLink = (link: WardenGuidanceLink): string => {
+  const target = link.path ?? link.url;
+  if (target === undefined || target === link.label) {
+    return link.label;
+  }
+  return `${link.label} (${target})`;
+};
+```
+
+The report formatter test covers path, URL, and label-only guidance docs.
+
+`packages/warden/src/__tests__/cli.test.ts:1161-1190`
+
+```ts
+test('formats guidance docs with labels and copyable targets in the lint section', () => {
+  const output = formatWardenReport({
+    diagnostics: [
+      {
+        filePath: 'src/trails/entity.ts',
+        guidance: {
+          docs: [
+            { label: 'Trail Rules', path: 'AGENTS.md#trail-rules' },
+            {
+              label: 'Warden docs',
+              url: 'https://docs.example.test/warden',
+            },
+            { label: 'Label-only reference' },
+          ],
+          summary: 'Use the Warden guidance.',
+```
+
+The Trails `warden` trail reuses the shared Warden diagnostic schema and only extends it with the app-specific optional `topoName`.
+
+`apps/trails/src/trails/warden.ts:8-16`
+
+```ts
+import {
+  diagnosticSchema,
+  runWardenCommand,
+  wardenDepthValues,
+  wardenDraftsValues,
+  wardenFailOnValues,
+  wardenFormatValues,
+  wardenLockValues,
+} from '@ontrails/warden';
+```
+
+`apps/trails/src/trails/warden.ts:178-181`
+
+```ts
+output: z.object({
+  diagnostics: z.array(
+    diagnosticSchema.extend({ topoName: z.string().optional() })
+  ),
+```
+
+### TRL-691 - Generated guide source of truth
+
+Severity: none
+Owning branch: `trl-691-polish-generated-warden-guide-headers-and-generator-tests`
+Recommended action: none
+
+The generated AGENTS block names the manifest-producing command as its guide input.
+
+`scripts/sync-agents-warden-guide.ts:24-33`
+
+```ts
+const renderGeneratedHeader = (
+  manifest: WardenGuideManifest
+): readonly string[] => [
+  WARDEN_GUIDE_START,
+  '<!-- GENERATED: run `bun run warden:agents:sync`; check with `bun run warden:agents:check`. -->',
+  '',
+  'This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.',
+  '',
+  `- Guide input command: \`bun apps/trails/bin/trails.ts warden guide --manifest\``,
+  `- Rule count: ${manifest.ruleCount}`,
+];
+```
+
+The skill guide names the agent-json command and tells prompts to reference the generated file instead of copying rule prose.
+
+`scripts/sync-skill-warden-guide.ts:43-53`
+
+```ts
+const renderGeneratedHeader = (
+  manifest: WardenGuideManifest
+): readonly string[] => [
+  '# Warden Guidance For Trails Skills',
+  '',
+  '<!-- GENERATED: run `bun run warden:skills:sync`; check with `bun run warden:skills:check`. -->',
+  '',
+  'This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.',
+  '',
+  `- Guide input command: \`bun apps/trails/bin/trails.ts warden guide --agent-json\``,
+```
+
+Both guide generators group by `rule.concern`, so the generated sections are derived from the renamed manifest field.
+
+`scripts/sync-agents-warden-guide.ts:36-43`
+
+```ts
+const groupRulesByConcern = (
+  rules: readonly WardenRuleGuideEntry[]
+): ReadonlyMap<WardenRuleConcern, readonly WardenRuleGuideEntry[]> => {
+  const grouped = new Map<WardenRuleConcern, WardenRuleGuideEntry[]>();
+  for (const rule of rules) {
+    grouped.set(rule.concern, [...(grouped.get(rule.concern) ?? []), rule]);
+  }
+  return grouped;
+};
+```
+
+### TRL-693 - CLI value alias ambiguity
+
+Severity: none
+Owning branch: `trl-693-tighten-cli-value-alias-conflicts-for-non-commander-callers`
+Recommended action: none
+
+Non-Commander callers without explicit user-supplied key tracking now treat an active value alias plus any canonical parsed key as ambiguous.
+
+`packages/cli/src/flags.ts:186-204`
+
+```ts
+const canonicalKey = toCamel(flag.name);
+// Adapters should pass the exact user-supplied key set when they preserve
+// defaulted canonical values in parsed flags. Without that set, an active
+// value alias plus any parsed canonical key is ambiguous and must fail
+// loudly instead of guessing whether the canonical value was a default.
+const canonicalWasSupplied =
+  userSuppliedFlagKeys?.has(canonicalKey) ??
+  Object.hasOwn(normalized, canonicalKey);
+const [activeAlias] = activeAliases;
+if (!activeAlias) {
+  continue;
+}
+if (canonicalWasSupplied) {
+  throw new ValidationError(
+    `CLI flag "--${flag.name}" cannot be combined with value alias "--${activeAlias.name}"`
+  );
+}
+
+normalized[canonicalKey] = activeAlias.value;
+```
+
+The direct package regression test covers the non-Commander ambiguity path.
+
+`packages/cli/src/__tests__/flags.test.ts:147-160`
+
+```ts
+test('rejects ambiguous canonical defaults combined with aliases without caller-supplied key tracking', () => {
+  const flags = deriveFlags(
+    z.object({ outputFormat: z.enum(['json', 'text']).default('text') }),
+    { outputFormat: { aliases: { json: 'json-output' } } }
+  );
+
+  expect(() =>
+    applyCliFlagValueAliases(flags, {
+      jsonOutput: true,
+      outputFormat: 'text',
+    })
+  ).toThrow(
+    'CLI flag "--output-format" cannot be combined with value alias "--json-output"'
+  );
+});
+```
+
+Commander still preserves its caller-supplied key tracking boundary.
+
+`adapters/commander/src/to-commander.ts:291-298`
+
+```ts
+await action.command.execute(
+  action.parsedArgs,
+  applyCliFlagValueAliases(
+    action.command.flags,
+    action.parsedFlags,
+    action.userSuppliedFlagKeys
+  )
+);
+```
+
+### TRL-694 - Static resource accessor shadowing
+
+Severity: none
+Owning branch: `trl-694-suppress-static-resource-accessor-warnings-when-string`
+Recommended action: none
+
+The rule records whether a declared resource name is shadowed at the lookup site.
+
+`packages/warden/src/rules/static-resource-accessor-preference.ts:315-325`
+
+```ts
+const collectShadowedNames = (
+  names: ReadonlySet<string>,
+  scopes: readonly ReadonlySet<string>[]
+): ReadonlySet<string> => {
+  const shadowed = new Set<string>();
+  for (const name of names) {
+    if (isShadowedModuleBinding(name, scopes)) {
+      shadowed.add(name);
+    }
+  }
+  return shadowed;
+};
+```
+
+`packages/warden/src/rules/static-resource-accessor-preference.ts:350-358`
+
+```ts
+walkWithScopes(
+  body,
+  (node, scopes) => {
+    const lookup = extractResourceLookup(node, ctxNames, resourceAliases);
+    if (lookup && !isShadowedModuleBinding(lookup.name, scopes)) {
+      lookups.push({
+        ...lookup,
+        shadowedDeclaredNames: collectShadowedNames(declaredNames, scopes),
+      });
+```
+
+The diagnostic is suppressed only after resolving the lookup to a declared resource whose declared binding is shadowed.
+
+`packages/warden/src/rules/static-resource-accessor-preference.ts:544-553`
+
+```ts
+for (const lookup of lookups) {
+  const resourceName =
+    (lookup.name && declaredNames.has(lookup.name) ? lookup.name : null) ??
+    (lookup.id ? (declaredNameById.get(lookup.id) ?? null) : null);
+
+  if (!resourceName) {
+    continue;
+  }
+  if (lookup.shadowedDeclaredNames.has(resourceName)) {
+    continue;
+```
+
+The regression tests cover identifier and string lookup shadowing.
+
+`packages/warden/src/__tests__/static-resource-accessor-preference.test.ts:168-205`
+
+```ts
+test('does not warn when a local binding shadows a declared resource name', () => {
+  const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+```
+
+```ts
+test('does not warn when a string resource lookup resolves to a shadowed declared name', () => {
+  const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+```
+
+## Validation
+
+Passed:
+
+```bash
+bun test packages/warden/src/__tests__/guide.test.ts packages/warden/src/__tests__/cli.test.ts apps/trails/src/__tests__/warden.test.ts scripts/__tests__/sync-agents-warden-guide.test.ts scripts/__tests__/sync-skill-warden-guide.test.ts packages/cli/src/__tests__/flags.test.ts adapters/commander/src/__tests__/to-commander.test.ts packages/warden/src/__tests__/static-resource-accessor-preference.test.ts
+```
+
+Result: 142 pass, 0 fail, 393 expectations.
+
+Passed:
+
+```bash
+bun run warden:agents:check
+bun run warden:skills:check
+```
+
+Passed:
+
+```bash
+bun apps/trails/bin/trails.ts warden guide --manifest | jq '.rules[0] | keys, has("category"), has("concern")'
+bun apps/trails/bin/trails.ts warden guide --agent-json | jq '.kind, (.rules[0] | keys), (.rules[0] | has("category")), (.rules[0] | has("concern"))'
+```
+
+The manifest smoke check showed `concern`, did not show `category`, and returned `false` for `has("category")` / `true` for `has("concern")`. The agent-json smoke check returned `kind = "trails-warden-agent-guide"`, exposed `concern`, and returned `false` for `category` / `true` for `concern`.
+
+Passed:
+
+```bash
+/usr/bin/git diff --check
+```
+
+## Unknowns
+
+- I did not inspect remote CI or bot review output in this lane.
+- I did not run the full repository verification matrix; this round was limited to focused Warden/CLI tests, generated guide freshness checks, guide command smoke checks, and whitespace validation.
+- I did not run any source-control write commands.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-warden-cli-round-3.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-warden-cli-round-3.md
@@ -1,0 +1,579 @@
+# Local Review Round 3 - Warden/CLI Polish Lane
+
+Date: 2026-05-12
+Cwd: `/Users/mg/Developer/outfitter/trails`
+Stack tip reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements` at `971ccec06`
+
+Scope reviewed: TRL-692, TRL-690, TRL-691, TRL-693, and TRL-694 at the current stack tip. The current tree has `packages/warden/src/guide.ts`; there is no `packages/warden/src/guide/` directory.
+
+## Result
+
+P3-only. No P0/P1/P2 remain in this lane.
+
+The concern/category manifest rename is coherent, generated guide source-of-truth is current, focused guide/header/CLI/resource tests pass, non-Commander value-alias conflicts fail loudly, and static resource accessor suppression is limited to the resolved helper name being shadowed. I found one non-blocking schema-drift cleanup to consider in TRL-690.
+
+## Findings
+
+| Severity | Owning branch | Finding | Recommended action |
+| --- | --- | --- | --- |
+| P3 | `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse` | The `warden.guide` app trail still carries local Zod copies of Warden guide/guidance schema shape while the package owns the corresponding guide manifest TypeScript shape and guidance schemas. Current behavior is passing, but this leaves future manifest or guidance-link additions dependent on humans remembering to update the app schema. | After the stack is otherwise clear, consider exporting a package-owned `wardenGuideManifestSchema` or at least public `guidanceLinkSchema` / `guidanceSchema` from `@ontrails/warden`, then reuse it in `apps/trails/src/trails/warden-guide.ts`. Add an app-level output-schema parse test for the manifest returned by `buildWardenGuideManifest()`. |
+
+No P0/P1/P2 findings.
+
+## Evidence
+
+### Predicate 1 - manifest taxonomy uses `concern`
+
+`packages/warden/src/guide.ts:25-36`
+
+```ts
+export interface WardenRuleGuideEntry {
+  readonly concern: WardenRuleConcern;
+  readonly depth: WardenDepth;
+  readonly description: string;
+  readonly docs: readonly WardenGuidanceLink[];
+  readonly guidance?: WardenGuidance | undefined;
+  readonly id: string;
+  readonly invariant: string;
+  readonly lifecycle: WardenRuleLifecycle;
+  readonly scope: WardenRuleScope;
+  readonly severity: WardenSeverity;
+  readonly tier: WardenRuleTier;
+}
+```
+
+`packages/warden/src/guide.ts:85-97`
+
+```ts
+return {
+  concern: metadata.concern,
+  depth: metadata.depth,
+  description: rule?.description ?? '',
+  docs,
+  guidance: metadata.guidance,
+  id,
+  invariant: metadata.invariant,
+  lifecycle: metadata.lifecycle,
+  scope: metadata.scope,
+  severity: rule?.severity ?? 'warn',
+  tier: metadata.tier,
+} satisfies WardenRuleGuideEntry;
+```
+
+`packages/warden/src/__tests__/guide.test.ts:22-29`
+
+```ts
+expect(throwRule).toMatchObject({
+  concern: 'results',
+  depth: 'source',
+  severity: 'error',
+  tier: 'source-static',
+});
+expect(throwRule).not.toHaveProperty('category');
+```
+
+Command output:
+
+```text
+$ bun apps/trails/bin/trails.ts warden guide --manifest | jq '.rules[0] | keys, has("category"), has("concern")'
+[
+  "concern",
+  "depth",
+  "description",
+  "docs",
+  "id",
+  "invariant",
+  "lifecycle",
+  "scope",
+  "severity",
+  "tier"
+]
+false
+true
+```
+
+### Predicate 2 - guide rendering and schema reuse
+
+The plain Warden report link rendering keeps both useful labels and copyable targets.
+
+`packages/warden/src/cli.ts:1327-1333`
+
+```ts
+const formatPlainGuidanceLink = (link: WardenGuidanceLink): string => {
+  const target = link.path ?? link.url;
+  if (target === undefined || target === link.label) {
+    return link.label;
+  }
+  return `${link.label} (${target})`;
+};
+```
+
+`packages/warden/src/__tests__/cli.test.ts:1161-1191`
+
+```ts
+test('formats guidance docs with labels and copyable targets in the lint section', () => {
+  const output = formatWardenReport({
+    diagnostics: [
+      {
+        filePath: 'src/trails/entity.ts',
+        guidance: {
+          docs: [
+            { label: 'Trail Rules', path: 'AGENTS.md#trail-rules' },
+            {
+              label: 'Warden docs',
+              url: 'https://docs.example.test/warden',
+            },
+            { label: 'Label-only reference' },
+          ],
+          summary: 'Use the Warden guidance.',
+        },
+```
+
+The app `warden` trail reuses the shared diagnostic schema instead of duplicating the diagnostic/guidance shape.
+
+`apps/trails/src/trails/warden.ts:8-16`
+
+```ts
+import {
+  diagnosticSchema,
+  runWardenCommand,
+  wardenDepthValues,
+  wardenDraftsValues,
+  wardenFailOnValues,
+  wardenFormatValues,
+  wardenLockValues,
+} from '@ontrails/warden';
+```
+
+`apps/trails/src/trails/warden.ts:178-181`
+
+```ts
+output: z.object({
+  diagnostics: z.array(
+    diagnosticSchema.extend({ topoName: z.string().optional() })
+  ),
+```
+
+P3 evidence: `warden.guide` still duplicates schema shape locally.
+
+`apps/trails/src/trails/warden-guide.ts:15-27`
+
+```ts
+const wardenGuidanceLinkSchema = z.object({
+  label: z.string(),
+  path: z.string().optional(),
+  url: z.string().optional(),
+});
+
+const wardenGuidanceSchema = z.object({
+  commands: z.array(z.string()).readonly().optional(),
+  docs: z.array(wardenGuidanceLinkSchema).readonly().optional(),
+  relatedRules: z.array(z.string()).readonly().optional(),
+  steps: z.array(z.string()).readonly().optional(),
+  summary: z.string(),
+});
+```
+
+`apps/trails/src/trails/warden-guide.ts:46-59`
+
+```ts
+const wardenGuideManifestSchema = z.object({
+  generatedFrom: z.object({
+    package: z.literal('@ontrails/warden'),
+    registries: z.tuple([
+      z.literal('wardenRules'),
+      z.literal('wardenTopoRules'),
+    ]),
+    source: z.literal('builtin-rule-metadata'),
+  }),
+  kind: z.literal('trails-warden-guide-manifest'),
+  ruleCount: z.number(),
+  rules: z.array(wardenRuleGuideEntrySchema).readonly(),
+  version: z.literal(1),
+});
+```
+
+The package already owns adjacent guidance schemas and the guide manifest type/builder.
+
+`packages/warden/src/trails/schema.ts:13-25`
+
+```ts
+export const guidanceLinkSchema = z.object({
+  label: z.string(),
+  path: z.string().optional(),
+  url: z.string().optional(),
+});
+
+export const guidanceSchema = z.object({
+  commands: z.array(z.string()).readonly().optional(),
+  docs: z.array(guidanceLinkSchema).readonly().optional(),
+  relatedRules: z.array(z.string()).readonly().optional(),
+  steps: z.array(z.string()).readonly().optional(),
+  summary: z.string(),
+});
+```
+
+`packages/warden/src/guide.ts:39-49`
+
+```ts
+export interface WardenGuideManifest {
+  readonly generatedFrom: {
+    readonly package: '@ontrails/warden';
+    readonly registries: readonly ['wardenRules', 'wardenTopoRules'];
+    readonly source: 'builtin-rule-metadata';
+  };
+  readonly kind: 'trails-warden-guide-manifest';
+  readonly ruleCount: number;
+  readonly rules: readonly WardenRuleGuideEntry[];
+  readonly version: 1;
+}
+```
+
+### Predicate 3 - generated guide headers and orphan markers
+
+`scripts/sync-agents-warden-guide.ts:24-33`
+
+```ts
+const renderGeneratedHeader = (
+  manifest: WardenGuideManifest
+): readonly string[] => [
+  WARDEN_GUIDE_START,
+  '<!-- GENERATED: run `bun run warden:agents:sync`; check with `bun run warden:agents:check`. -->',
+  '',
+  'This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.',
+  '',
+  `- Guide input command: \`bun apps/trails/bin/trails.ts warden guide --manifest\``,
+  `- Rule count: ${manifest.ruleCount}`,
+];
+```
+
+`scripts/__tests__/sync-agents-warden-guide.test.ts:38-50`
+
+```ts
+test('renders a generated block from the Warden manifest', () => {
+  const block = renderAgentsWardenGuideBlock(manifestFixture);
+
+  expect(block).toStartWith(WARDEN_GUIDE_START);
+  expect(block).toContain(
+    '- Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`'
+  );
+  expect(block).toContain('- Rule count: 1');
+  expect(block).toContain('#### Results');
+  expect(block).toMatch(
+    /- `no-throw-in-implementation` \(error, source\/source-static, external\): Trail implementations return Result values\./
+  );
+  expect(block).toEndWith(WARDEN_GUIDE_END);
+});
+```
+
+`scripts/__tests__/sync-agents-warden-guide.test.ts:115-129`
+
+```ts
+test('rejects orphaned end-only generated block markers', () => {
+  const replacement = `${WARDEN_GUIDE_START}\nnew\n${WARDEN_GUIDE_END}`;
+  const source = [
+    '# AGENTS.md',
+    '',
+    WARDEN_GUIDE_END,
+    '',
+    '## Draft State',
+    '',
+    'Drafts.',
+  ].join('\n');
+
+  expect(() => replaceAgentsWardenGuideBlock(source, replacement)).toThrow(
+    'found only one Warden guide marker'
+  );
+});
+```
+
+Checked-in generated guide blocks point at the right source commands.
+
+`AGENTS.md:85-91`
+
+```md
+<!-- warden-guide:start -->
+<!-- GENERATED: run `bun run warden:agents:sync`; check with `bun run warden:agents:check`. -->
+
+This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
+
+- Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
+- Rule count: 49
+```
+
+`.claude/skills/clark/references/warden-guide.md:3-8`
+
+```md
+<!-- GENERATED: run `bun run warden:skills:sync`; check with `bun run warden:skills:check`. -->
+
+This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
+
+- Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
+- Rule count: 49
+```
+
+`plugin/skills/trails/references/warden-guide.md:3-8`
+
+```md
+<!-- GENERATED: run `bun run warden:skills:sync`; check with `bun run warden:skills:check`. -->
+
+This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
+
+- Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
+- Rule count: 49
+```
+
+### Predicate 4 - non-Commander value alias conflicts
+
+`packages/cli/src/flags.ts:186-204`
+
+```ts
+const canonicalKey = toCamel(flag.name);
+// Adapters should pass the exact user-supplied key set when they preserve
+// defaulted canonical values in parsed flags. Without that set, an active
+// value alias plus any parsed canonical key is ambiguous and must fail
+// loudly instead of guessing whether the canonical value was a default.
+const canonicalWasSupplied =
+  userSuppliedFlagKeys?.has(canonicalKey) ??
+  Object.hasOwn(normalized, canonicalKey);
+const [activeAlias] = activeAliases;
+if (!activeAlias) {
+  continue;
+}
+if (canonicalWasSupplied) {
+  throw new ValidationError(
+    `CLI flag "--${flag.name}" cannot be combined with value alias "--${activeAlias.name}"`
+  );
+}
+
+normalized[canonicalKey] = activeAlias.value;
+```
+
+`packages/cli/src/__tests__/flags.test.ts:147-160`
+
+```ts
+test('rejects ambiguous canonical defaults combined with aliases without caller-supplied key tracking', () => {
+  const flags = deriveFlags(
+    z.object({ outputFormat: z.enum(['json', 'text']).default('text') }),
+    { outputFormat: { aliases: { json: 'json-output' } } }
+  );
+
+  expect(() =>
+    applyCliFlagValueAliases(flags, {
+      jsonOutput: true,
+      outputFormat: 'text',
+    })
+  ).toThrow(
+    'CLI flag "--output-format" cannot be combined with value alias "--json-output"'
+  );
+});
+```
+
+`adapters/commander/src/to-commander.ts:175-185`
+
+```ts
+const getUserSuppliedFlagKeys = (
+  command: Command,
+  flags: readonly CliCommand['flags'][number][]
+): ReadonlySet<string> => {
+  const userSupplied = new Set<string>();
+  for (const key of getFlagOptionKeys(flags)) {
+    if (isUserSuppliedOption(command, key)) {
+      userSupplied.add(key);
+    }
+  }
+  return userSupplied;
+};
+```
+
+`adapters/commander/src/to-commander.ts:291-298`
+
+```ts
+await action.command.execute(
+  action.parsedArgs,
+  applyCliFlagValueAliases(
+    action.command.flags,
+    action.parsedFlags,
+    action.userSuppliedFlagKeys
+  )
+);
+```
+
+### Predicate 5 - static resource accessor warning suppression
+
+`packages/warden/src/rules/static-resource-accessor-preference.ts:328-335`
+
+```ts
+const buildDeclaredNameById = (
+  resources: readonly DeclaredStaticResource[]
+): ReadonlyMap<string, string> =>
+  new Map(
+    resources.flatMap((resource) =>
+      resource.id ? [[resource.id, resource.name] as const] : []
+    )
+  );
+```
+
+`packages/warden/src/rules/static-resource-accessor-preference.ts:350-358`
+
+```ts
+walkWithScopes(
+  body,
+  (node, scopes) => {
+    const lookup = extractResourceLookup(node, ctxNames, resourceAliases);
+    if (lookup && !isShadowedModuleBinding(lookup.name, scopes)) {
+      lookups.push({
+        ...lookup,
+        shadowedDeclaredNames: collectShadowedNames(declaredNames, scopes),
+      });
+```
+
+`packages/warden/src/rules/static-resource-accessor-preference.ts:544-553`
+
+```ts
+for (const lookup of lookups) {
+  const resourceName =
+    (lookup.name && declaredNames.has(lookup.name) ? lookup.name : null) ??
+    (lookup.id ? (declaredNameById.get(lookup.id) ?? null) : null);
+
+  if (!resourceName) {
+    continue;
+  }
+  if (lookup.shadowedDeclaredNames.has(resourceName)) {
+    continue;
+```
+
+Tests keep both sides of the behavior.
+
+`packages/warden/src/__tests__/static-resource-accessor-preference.test.ts:8-30`
+
+```ts
+test('warns when a same-file resource definition is looked up by id', () => {
+  const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+```
+
+`packages/warden/src/__tests__/static-resource-accessor-preference.test.ts:188-205`
+
+```ts
+test('does not warn when a string resource lookup resolves to a shadowed declared name', () => {
+  const code = `
+import { Result, resource, trail } from '@ontrails/core';
+
+const db = resource('db.main', {
+  create: () => Result.ok({ source: 'factory' }),
+});
+```
+
+### Predicate 6 - prior Round 1/2 blocker follow-up
+
+Rounds 1 and 2 reported no P0/P1/P2 in this lane, so there were no prior blocker findings to re-check as unresolved.
+
+`.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-warden-cli-round-1.md:9-13`
+
+```md
+## Result
+
+No P0/P1/P2 findings.
+
+The Warden guide manifest/schema naming, generated guide source-of-truth, plain-text link rendering, shared diagnostic schema projection, CLI value-alias ambiguity handling, and static resource accessor shadowing behavior all match the packet intent at stack tip.
+```
+
+`.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-warden-cli-round-2.md:8-12`
+
+```md
+## Result
+
+Clean for P0/P1/P2.
+
+No Warden/CLI P0, P1, or P2 regressions found. I also did not identify a new P3 worth carrying in this lane.
+```
+
+## Commands Run
+
+Passed:
+
+```bash
+bun test packages/warden/src/__tests__/guide.test.ts packages/warden/src/__tests__/cli.test.ts apps/trails/src/__tests__/warden.test.ts scripts/__tests__/sync-agents-warden-guide.test.ts scripts/__tests__/sync-skill-warden-guide.test.ts packages/cli/src/__tests__/flags.test.ts adapters/commander/src/__tests__/to-commander.test.ts packages/warden/src/__tests__/static-resource-accessor-preference.test.ts
+```
+
+Result:
+
+```text
+142 pass
+0 fail
+393 expect() calls
+Ran 142 tests across 8 files. [15.30s]
+```
+
+Passed:
+
+```bash
+bun run warden:agents:check
+bun run warden:skills:check
+```
+
+Passed with the output shown in Predicate 1:
+
+```bash
+bun apps/trails/bin/trails.ts warden guide --manifest | jq '.rules[0] | keys, has("category"), has("concern")'
+bun apps/trails/bin/trails.ts warden guide --agent-json | jq '.kind, (.rules[0] | keys), (.rules[0] | has("category")), (.rules[0] | has("concern"))'
+```
+
+Agent JSON smoke output:
+
+```text
+"trails-warden-agent-guide"
+[
+  "appliesAt",
+  "concern",
+  "id",
+  "invariant",
+  "severity"
+]
+false
+true
+```
+
+Passed:
+
+```bash
+bun run typecheck
+```
+
+Result:
+
+```text
+Tasks:    21 successful, 21 total
+Cached:    21 cached, 21 total
+```
+
+Passed:
+
+```bash
+bun run format:check
+```
+
+Result:
+
+```text
+All matched files use the correct format.
+Found 0 warnings and 0 errors.
+```
+
+Passed:
+
+```bash
+/usr/bin/git diff --check
+```
+
+Read-only inspection commands included `rg`, `fd`, `nl -ba ... | sed ...`, `/usr/bin/git status --short`, `/usr/bin/git branch --show-current`, and `/usr/bin/git rev-parse --short HEAD`. I did not run any source-control write command.
+
+## Unknowns
+
+- I did not inspect remote CI or bot review output.
+- I did not run the full repository matrix (`bun run test`, `bun run lint`, `bun run build`, `bun run check`, or `bun run dead-code`). This round used the focused Warden/CLI lane suite, generated guide checks, manifest smoke probes, full typecheck, format check, and whitespace check.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md
@@ -1,0 +1,360 @@
+# M6 Release Process And Beta-To-1.0 Cutover Audit
+
+Date: 2026-05-12
+Issue: TRL-637
+Branch: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+
+## Summary
+
+The repo has a workable beta release mechanism, but it is not yet a complete
+stable-cutover process.
+
+What is solid:
+
+- `@ontrails/*` packages are configured as a fixed Changesets group.
+- Publishing is intentionally done with `bun run publish:packages`, not
+  `changeset publish` or `npm publish`.
+- `bun run publish:check` packs every non-private workspace in dependency order
+  and verifies packed manifests do not leak `workspace:` or `catalog:` ranges.
+- The publish script uses the Changesets prerelease tag while
+  `.changeset/pre.json` is in prerelease mode, then falls back to `latest`
+  after prerelease mode exits.
+
+The stable cutover has four concrete gaps:
+
+- No durable beta-to-1.0 runbook exists yet.
+- No stable 1.x release doctrine ADR exists yet.
+- `bunx changeset status --verbose` currently fails on stale changeset
+  frontmatter for retired `@ontrails/logging`.
+- The local pack check passes even though registry visibility is incomplete for
+  several non-private packages.
+
+Follow-ups filed: TRL-711, TRL-712, TRL-713, and TRL-714.
+
+## Inventory
+
+Primary release guidance checked:
+
+- `AGENTS.md:271-296` documents lockstep `@ontrails/*` prerelease versioning,
+  forbids `changeset publish`/`npm publish`, names `bun run publish:check` and
+  `bun run publish:packages`, and says stable release starts with
+  `bunx changeset pre exit`.
+- `.changeset/config.json:3-10` keeps Changesets unmanaged by commits, fixes
+  `@ontrails/*` together, sets public access, uses `main` as base branch, and
+  updates internal dependencies at patch level.
+- `.changeset/pre.json:2-3` is still in prerelease mode with tag `beta`.
+- `scripts/publish.ts:4-9` states the script publishes public `@ontrails/*`
+  workspaces through `bun publish`, topo-sorts workspace dependency edges, and
+  enforces packed-manifest range cleanliness.
+- `scripts/publish.ts:153-170` resolves the default dist-tag from
+  `.changeset/pre.json` while in prerelease mode and falls back to `latest`
+  outside prerelease mode.
+- `scripts/publish.ts:360-445` runs `bun pm pack --dry-run`, extracts the
+  packed manifest, and rejects unresolved `workspace:` or `catalog:` ranges.
+- `scripts/publish.ts:448-483` publishes sequentially with
+  `bun publish --access public --tag <tag>` and aborts on the first package
+  failure.
+- `.github/workflows/ci.yml:103-133` gates PRs with the repo-local changeset
+  checker based on the immediate PR file list.
+- `scripts/check-changeset-gate.ts:147-266` detects package-affecting changes
+  under non-private `@ontrails/*` workspaces and requires changed changesets
+  unless `release:none` is explicitly present.
+- `docs/releases/beta15.md:236-250` says all `@ontrails/*` packages remain
+  lockstep at `1.0.0-beta.15` and lists newly publishable packages.
+
+Publishable workspace inventory from live package manifests:
+
+| Package | Local version | Registry probe |
+| --- | --- | --- |
+| `@ontrails/cli` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/commander` | `1.0.0-beta.15` | Missing or inaccessible |
+| `@ontrails/config` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/core` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/drizzle` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/hono` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/http` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/logtape` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/mcp` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/observe` | `1.0.0-beta.15` | Missing or inaccessible |
+| `@ontrails/permits` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/store` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/testing` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/topographer` | `1.0.0-beta.15` | Missing or inaccessible |
+| `@ontrails/tracing` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/trails` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/vite` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/warden` | `1.0.0-beta.15` | `1.0.0-beta.15` |
+| `@ontrails/wayfinder` | `1.0.0-beta.15` | Missing or inaccessible |
+
+The registry probe used `npm view <package> version --json` as a read-only
+registry check. It is not a publish command and does not change the repo's Bun
+publish posture.
+
+## Current Release Mechanics
+
+Beta flow, as documented today:
+
+```bash
+bunx changeset add
+bunx changeset version
+bun run publish:check
+bun run publish:packages
+```
+
+The repo-specific semantics are:
+
+- Changesets computes versions and changelogs.
+- `bun run publish:check` is the pre-publish packability gate.
+- `bun run publish:packages` is the only publish command.
+- `.changeset/pre.json` chooses the `beta` dist-tag while prerelease mode is
+  active.
+- Once prerelease mode exits, `scripts/publish.ts` defaults to `latest`.
+
+The PR-time changeset gate is useful but intentionally narrower than release
+cutover:
+
+- It protects per-PR package changes against missing changesets.
+- It honors `release:none` only when no changed changeset files are present.
+- It does not evaluate the full live Changesets release plan.
+- It does not verify registry ownership, package availability, or dist-tag
+  posture.
+
+## Stable Cutover Runbook
+
+This is the recommended execution order to codify in a durable runbook. Do not
+run it as part of TRL-637.
+
+### Preconditions
+
+1. All v1 release-prep milestones are closed or have explicitly accepted
+   exceptions.
+2. Main is green on CI.
+3. All active release-blocking PRs have merged.
+4. No generated local SQLite artifacts are staged:
+
+   ```bash
+   git status --short -- .trails
+   ```
+
+5. Legacy root DB sidecars are absent or intentionally removed only if
+   untracked:
+
+   ```bash
+   git status --short -- .trails/trails.db .trails/trails.db-shm .trails/trails.db-wal
+   ```
+
+6. The Changesets release plan computes:
+
+   ```bash
+   bunx changeset status --verbose
+   ```
+
+7. Every non-private `@ontrails/*` workspace has an explicit registry posture:
+   existing package, first-time package creation, or intentional non-release
+   exception.
+
+### Stable Version Branch
+
+```bash
+RTK_SHIM_BYPASS=1 gt sync
+RTK_SHIM_BYPASS=1 gt checkout main
+RTK_SHIM_BYPASS=1 gt create trl-711-beta-to-1-release-runbook --no-interactive
+
+bun scripts/adr.ts map
+bun scripts/adr.ts check
+bun run check
+bun run build
+bun run publish:check
+bunx changeset status --verbose
+
+bunx changeset pre exit
+bunx changeset version
+
+bun scripts/adr.ts map
+bun scripts/adr.ts check
+bun run typecheck
+bun run test
+bun run lint
+bun run lint:ast-grep
+bun run build
+bun run format:check
+bun run check
+bun run dead-code
+bun run publish:check
+git diff --check
+```
+
+Review the generated diff before committing:
+
+```bash
+git diff -- .changeset package.json bun.lock packages apps adapters
+```
+
+Expected versioning outcomes:
+
+- `.changeset/pre.json` should leave prerelease mode or be removed/rewritten by
+  Changesets according to its stable-exit behavior.
+- All fixed `@ontrails/*` packages should land on the same stable version.
+- Internal package ranges should resolve to stable semver ranges after packing.
+- Release notes should stop describing the current release as beta.
+
+Commit and submit as a normal reviewable PR:
+
+```bash
+git branch --show-current
+RTK_SHIM_BYPASS=1 gt modify -a -c -m "chore: version packages for 1.0.0" --no-interactive
+RTK_SHIM_BYPASS=1 gt submit --draft --stack --no-edit --no-interactive
+```
+
+Keep the PR draft until CI is green and review is complete.
+
+### Publish After Merge
+
+After the version PR merges:
+
+```bash
+RTK_SHIM_BYPASS=1 gt sync
+RTK_SHIM_BYPASS=1 gt checkout main
+
+bun run publish:check
+bun run publish:packages
+```
+
+Post-publish verification should check every non-private `@ontrails/*`
+workspace:
+
+```bash
+npm view @ontrails/core version --json
+npm view @ontrails/core dist-tags --json
+```
+
+Repeat for every published package or use a repo script once TRL-714 lands.
+
+If a package publish fails mid-sequence:
+
+1. Stop immediately. The script already aborts on first package failure.
+2. Record the last successfully published package and version.
+3. Do not rerun the whole matrix blindly.
+4. Use the script's `--only <name[,name]>` support only after confirming the
+   already-published packages have the expected version and dist-tag.
+5. File a release incident note with the package, version, command, failure
+   output, and chosen resume set.
+
+## Findings
+
+### F1: Stable cutover lacks a durable runbook
+
+Current release guidance documents beta mechanics and the existence of
+`bunx changeset pre exit`, but not a complete stable cutover sequence with
+preconditions, post-publish verification, and partial-publish handling.
+
+Impact: stable release execution still depends on operator memory and this
+audit packet.
+
+Follow-up: TRL-711.
+
+### F2: Stable 1.x doctrine is not captured in an ADR
+
+The repo needs a stable-line decision record before 1.0: whether lockstep
+continues, how breaking changes are handled, how retired package names are
+managed after stable, how generated apps stay installable, and what dist-tag
+policy governs future releases.
+
+Impact: without a durable ADR, release tooling and docs can drift after the
+first stable cut.
+
+Follow-up: TRL-712.
+
+### F3: Changesets release-plan computation is currently blocked
+
+Command:
+
+```bash
+bunx changeset status --verbose
+```
+
+Result:
+
+```text
+Found changeset logtape-observe-target for package @ontrails/logging which is not in the workspace
+```
+
+The offending changeset is `.changeset/logtape-observe-target.md`, which still
+contains:
+
+```text
+"@ontrails/logging": patch
+```
+
+Impact: stable cutover cannot safely run `bunx changeset pre exit` and
+`bunx changeset version` until stale frontmatter is repaired or removed.
+
+Follow-up: TRL-713.
+
+### F4: Packability passes while registry readiness is incomplete
+
+Command:
+
+```bash
+bun run publish:check
+```
+
+Result: passed for every non-private packable workspace.
+
+Read-only registry probes still reported these packages as missing or
+inaccessible at `1.0.0-beta.15`:
+
+- `@ontrails/commander`
+- `@ontrails/observe`
+- `@ontrails/topographer`
+- `@ontrails/wayfinder`
+
+Impact: local tarball cleanliness is necessary but not sufficient. A generated
+app or release note can reference a package that passes local pack checks but
+is not installable from the registry.
+
+Follow-up: TRL-714. TRL-707 remains the generated-project install blocker for
+the specific `@ontrails/commander` symptom.
+
+## Recommended Stable Doctrine ADR Shape
+
+The stable release ADR should answer these decisions explicitly:
+
+1. Package versioning: whether `@ontrails/*` remains fixed/lockstep for the
+   whole 1.x line.
+2. Dist-tags: `latest` for stable, prerelease tags only for explicit future
+   prerelease channels.
+3. Breaking changes: major-only after 1.0 unless an ADR defines an exception.
+4. Package retirements: package rename/removal must include migration docs,
+   deprecation posture, generated app updates, and release-note callouts.
+5. Generated apps: current stable scaffold dependencies must be installable
+   from the public registry.
+6. Changelogs: package changelogs must include user-visible API, package, and
+   surface changes for the package that ships them.
+7. Publication: Changesets owns version/changelog calculation; `bun run
+   publish:packages` owns publication.
+8. Recovery: partial-publish handling must be documented and must use explicit
+   resume sets.
+9. Governance: release PRs should cite the ADR and include the release
+   preflight checklist output.
+
+## Filed Follow-Ups
+
+| Issue | Priority | Purpose |
+| --- | --- | --- |
+| [TRL-711](https://linear.app/outfitter/issue/TRL-711/codify-the-beta-to-10-release-runbook) | High | Codify the beta-to-1.0 release runbook. |
+| [TRL-712](https://linear.app/outfitter/issue/TRL-712/author-stable-release-doctrine-adr-for-the-1x-line) | High | Author the stable 1.x release doctrine ADR. |
+| [TRL-713](https://linear.app/outfitter/issue/TRL-713/repair-stale-changesets-references-before-stable-cutover) | High | Repair stale Changesets references before stable cutover. |
+| [TRL-714](https://linear.app/outfitter/issue/TRL-714/add-registry-availability-and-dist-tag-release-preflights) | High | Add registry availability and dist-tag release preflights. |
+
+## Acceptance Check
+
+- Changesets state inventoried: yes.
+- Lockstep versioning inventoried: yes.
+- Dist-tag policy inventoried: yes.
+- Publish script inventoried: yes.
+- CI gates inventoried: yes.
+- Beta-to-stable command order recommended: yes.
+- Stable release doctrine ADR shape recommended: yes.
+- Release was not run: yes.
+- Follow-up issues filed: TRL-711, TRL-712, TRL-713, TRL-714.

--- a/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/post-execution-verification.md
+++ b/.agents/plans/2026-05-12-topograph-query-docs-stack/reports/post-execution-verification.md
@@ -1,0 +1,162 @@
+# Post-Execution Doctrine Verification
+
+Date: 2026-05-12
+Stack tip reviewed: `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`
+Scope: M4b TopoGraph Query + V1 Closeout stack doctrine gate before remote ready.
+
+## Verdict
+
+Pass for the doctrine gate. I found no P0/P1/P2 doctrine mismatches remaining in the current code/docs against ADR-0046 and the tracked stack plan.
+
+The active artifacts align on the lock v3 artifact-family doctrine:
+
+- `.trails/trails.lock` is the compact v3 manifest.
+- `.trails/topo.lock` is serialized `TopoGraph` content.
+- `.trails/state/trails.db`, `.trails/cache/`, and `.trails/config.local.{ts,js}` are ignored local/runtime state.
+- Stored export names use `topo_graph` and `lock_manifest`.
+- Retired vocabulary is either historical/migration context or exact line-scoped cleanup/migration seam.
+- The generated Warden guide public contract uses `concern`, not `category`, and generated headers say `Guide input command`.
+
+Unknowns:
+
+- I did not check remote PR state, CI state, GitHub review threads, or live Linear parentage in this pass.
+- Physical `.trails/trails.lock` and `.trails/topo.lock` files are absent locally. That is not a doctrine failure by itself because this branch does not claim to commit current workspace lock artifacts, and the M3 audit explicitly records discovery fallback because no workspace `.trails/topo.lock` was present at audit time.
+- I did not run the full ordinary CI matrix; this pass intentionally targeted the doctrine predicates distinct from CI and bot review.
+
+## Checks Run
+
+- `git status --short --branch`: confirmed the current branch as `trl-637-audit-release-process-and-beta-to-10-cutover-requirements`; only this report path was untracked at start of this pass.
+- `/usr/bin/find .trails -maxdepth 3 -print | sort`: found `.trails/.gitignore`, `.trails/clark/*`, and `.trails/config`; no `.trails/trails.lock`, `.trails/topo.lock`, `.trails/state/`, `.trails/cache/`, `.trails/dev/`, or `.trails/generated/`.
+- `git ls-files .trails`: tracked `.trails` files are `.trails/.gitignore` and Clark docs only; no tracked lock artifacts.
+- `git status --short .trails/trails.lock .trails/topo.lock .trails/state/trails.db ...`: no output.
+- `bun scripts/adr.ts check`: passed with `0 errors, 0 warnings`.
+- `bun run warden:agents:check`: passed.
+- `bun run warden:skills:check`: passed.
+- `bun apps/trails/bin/trails.ts warden guide --manifest | jq '.rules[0] | keys, has("category"), has("concern")'`: first rule keys include `concern`; `has("category")` returned `false`; `has("concern")` returned `true`.
+- `bun apps/trails/bin/trails.ts warden guide --agent-json | jq '.kind, (.rules[0] | keys), (.rules[0] | has("category")), (.rules[0] | has("concern"))'`: kind was `trails-warden-agent-guide`; first rule keys include `concern`; `category` false; `concern` true.
+- `bun scripts/vocab-cutover-audit.ts --rule topograph-artifact-family-retired-term --json`: returned `fileCount: 0`, `matches: []`, `total: 0`.
+- `bun run vocab:audit`: passed for the entire repo target set.
+- `git diff --check`: passed.
+
+## Predicate 1 - Workspace Layout
+
+Status: Pass, with local physical-artifact absence noted.
+
+Evidence:
+
+- ADR-0046 defines committed root `.lock` artifacts and ignored local state: `docs/adr/0046-lock-v3-artifact-family.md:112-127` says `.trails/trails.lock` and `.trails/topo.lock` are committed root `.lock` artifacts, `.trails/cache/` is ignored rebuildable cache, `.trails/state/` is ignored mutable runtime state, `.trails/config.local.ts` / `.trails/config.local.js` are ignored local overrides, and default SQLite is `.trails/state/trails.db`.
+- The tracked plan repeats the same vocabulary: `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:224-236` defines `.trails/trails.lock`, `.trails/topo.lock`, `.trails/config.local.{ts,js}`, `.trails/state/trails.db`, `.trails/state/`, and `.trails/cache/`.
+- The active topo-store guide teaches the current layout: `docs/topo-store.md:13-27` shows `cache/`, `state/trails.db`, `topo.lock`, and `trails.lock`, and says `state/trails.db` is not git-tracked while `topo.lock` and `trails.lock` are committed.
+- The migration guide says the same: `docs/migration/topograph-artifact-family.md:3-12` defines manifest, content artifact, ignored state, ignored cache, and ignored local config.
+- The current `.trails/.gitignore` ignores local config, `cache/`, and `state/`: `.trails/.gitignore:1-9`.
+- Local physical state is currently sparse: `/usr/bin/find .trails -maxdepth 3 -print | sort` showed no `.trails/trails.lock`, `.trails/topo.lock`, `.trails/state/`, or `.trails/cache/`; `git ls-files .trails` showed only `.trails/.gitignore` and Clark docs.
+- The M3 audit already handles this absence as discovery fallback, not as a committed-artifact claim: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:35-40` says the workspace index probe used discovery because no workspace `.trails/topo.lock` was present.
+
+Conclusion: current docs/code align with ADR-0046. Physical lock-file absence is not a doctrine failure unless a branch claims to commit regenerated lock artifacts; this stack does not.
+
+## Predicate 2 - Lock/Topo Artifact Shape
+
+Status: Pass.
+
+Evidence:
+
+- ADR-0046 separates responsibilities: `docs/adr/0046-lock-v3-artifact-family.md:35-40` says `.trails/trails.lock` is compact manifest and `.trails/topo.lock` is serialized `TopoGraph`; `docs/adr/0046-lock-v3-artifact-family.md:48-56` says the manifest has version/scope/artifact paths/hashes/summary and does not contain graph entries; `docs/adr/0046-lock-v3-artifact-family.md:77-90` says `topo.lock` contains serialized `TopoGraph` with `generatedAt` and `topoGraphSchemaVersion`.
+- Topographer types enforce the split: `packages/topographer/src/types.ts:146-155` defines `TopoGraph` with `topoGraphSchemaVersion`, activation graph/sources, `generatedAt`, `entries`, and optional `workspace`; `packages/topographer/src/types.ts:259-266` defines strict lock manifest fields as `artifacts`, `scope`, `summary`, and `version: 3`.
+- I/O helpers write and read separate files: `packages/topographer/src/io.ts:22-24` defines `trails.lock` and `topo.lock`; `packages/topographer/src/io.ts:111-131` writes/reads `TopoGraph` at `topo.lock`; `packages/topographer/src/io.ts:143-163` writes/reads lock manifest at `trails.lock`.
+- Stored exports use current names: `packages/topographer/src/internal/topo-store.ts:1537-1551` inserts `topo_graph`, `topo_graph_hash`, and `lock_manifest`; `packages/topographer/src/internal/topo-store.ts:1554-1574` reads those columns back.
+- The SQLite schema uses the same names: `packages/topographer/src/internal/topo-snapshots.ts:101-106` creates `topo_exports` with `topo_graph`, `topo_graph_hash`, and `lock_manifest`.
+- Legacy DB-column names are only migration seams: `packages/topographer/src/internal/topo-snapshots.ts:321-337` renames `surface_map` to `topo_graph`, `surface_hash` to `topo_graph_hash`, and `serialized_lock` to `lock_manifest`.
+- Active reference docs match: `docs/topo-store-reference.md:191-205` documents `topo_exports.topo_graph`, `topo_graph_hash`, and `lock_manifest`; `docs/topo-store-reference.md:378-390` says `store.topoGraph.get(ref?)` reads canonical saved graph content without parsing `topoGraphJson`.
+
+Conclusion: no old `SurfaceMap` / root DB target-state leakage remains in current implementation surfaces. Legacy names are confined to migration paths and line-scoped migration/test seams.
+
+## Predicate 3 - Lexicon And Retired Vocabulary
+
+Status: Pass.
+
+Evidence:
+
+- `AGENTS.md:50-62` states active lexicon: `trail`, `blaze`, `topo`, `cross`, `surface`, `resource`, and `layer`.
+- `docs/lexicon.md:91-118` defines the TopoGraph artifact-family terms: `TopoGraph`, `topoGraph`, `topo_graph`, and `lock_manifest`.
+- `docs/lexicon.md:120-156` defines `.trails/state/`, `.trails/cache/`, `.trails/config.local.{ts,js}`, and a retired vocabulary table mapping `SurfaceMap`, `_surface.json`, `surface_map`, `serialized_lock`, `.trails/config/local`, `.trails/trails.db*`, `.trails/dev/`, and `.trails/generated/` to current terms.
+- `docs/migration/topograph-artifact-family.md:26-39` carries retired vocabulary in explicit migration context, with current replacements.
+- `scripts/vocab-cutover-map.ts:147-182` line-scopes active cleanup/migration matches in `apps/trails/src/trails/dev-support.ts`, `packages/topographer/src/internal/topo-snapshots.ts`, and `packages/topographer/src/__tests__/topo-store.test.ts`.
+- `scripts/vocab-cutover-map.ts:330-335` wires `allowMatches: topographArtifactFamilyRetiredMatches` and `excludePaths: topographArtifactFamilyRetiredMentionPaths` into `topograph-artifact-family-retired-term`.
+- `scripts/vocab-cutover-audit.ts:32-46` treats `excludePaths` as whole-path/directory skips and `allowMatches` as exact path+line skips; `scripts/vocab-cutover-audit.ts:99-101` filters allowed matches after finding line-level matches.
+- The latest targeted guard check returned no non-allowed matches, and `bun run vocab:audit` passed for the whole target set.
+- The round 4 docs/vocab report confirms the earlier round 3 P2 no longer reproduces: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-4.md:7-17` and `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-4.md:24-58`.
+
+Conclusion: active guidance uses current vocabulary. Retired vocabulary remains only in historical/migration contexts or exact line-scoped cleanup/migration seams.
+
+## Predicate 4 - Generated Warden Guide Source Of Truth
+
+Status: Pass.
+
+Evidence:
+
+- The generated AGENTS block has the expected source-of-truth header: `AGENTS.md:83-91` includes generated markers, says it is generated from the live `@ontrails/warden` rule manifest, says `Guide input command`, and reports `Rule count: 49`.
+- The agent generator emits that header: `scripts/sync-agents-warden-guide.ts:24-34`.
+- The agent generator groups by `concern`: `scripts/sync-agents-warden-guide.ts:36-44` groups on `rule.concern`.
+- The skill generator also groups by `concern`: `scripts/sync-skill-warden-guide.ts:33-41`, and its header uses `Guide input command`: `scripts/sync-skill-warden-guide.ts:43-55`.
+- Generator tests assert the header and fixture shape: `scripts/__tests__/sync-agents-warden-guide.test.ts:38-50` and `scripts/__tests__/sync-skill-warden-guide.test.ts:12-31`.
+- The manifest type exposes `concern`: `packages/warden/src/guide.ts:25-37`.
+- The manifest builder sources `concern` from metadata: `packages/warden/src/guide.ts:79-111`.
+- Agent JSON projection keeps `concern`: `packages/warden/src/guide.ts:197-218`.
+- The Warden metadata type names this a queryable concern dimension: `packages/warden/src/rules/types.ts:42-53` and `packages/warden/src/rules/types.ts:97-108`.
+- The app wrapper output schema expects `concern`: `apps/trails/src/trails/warden-guide.ts:29-59`.
+- Warden guide tests reject stale `category`: `packages/warden/src/__tests__/guide.test.ts:22-30`, `packages/warden/src/__tests__/guide.test.ts:34-45`, and `packages/warden/src/__tests__/guide.test.ts:47-70`.
+- `bun run warden:agents:check` and `bun run warden:skills:check` both passed. Manifest and agent-json smoke checks returned `category=false`, `concern=true`.
+
+Conclusion: generated Warden blocks/checks align with the live manifest contract and header wording. The remaining internal identifiers named `CATEGORY_LABELS` / `renderCategorySections` are non-output implementation names and not a doctrine mismatch.
+
+## Predicate 5 - Audit Methodology
+
+Status: Pass.
+
+Evidence:
+
+- The plan scopes TRL-634/636/637 as audit/report branches and requires Bun publish language for TRL-637: `.agents/plans/2026-05-12-topograph-query-docs-stack/PLAN.md:37-40`.
+- The retro records the audit outputs and focused follow-ups: `.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md:211-231` maps M3 to TRL-704/705/706, M5 to TRL-707/708/709/710, and M6 to TRL-711/712/713/714.
+- M3 is evidence-backed and does not overclaim execution parity: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:29-40` records live probes; `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:96-166` marks projection status separately from execution parity; `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m3-parity-audit.md:186-215` files follow-ups instead of claiming implementation is complete.
+- M5 is evidence-backed and explicit about current blockers: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m5-docs-audit.md:97-162` records the generated-project install failure; `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m5-docs-audit.md:164-182` records narrow snippet coverage; `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m5-docs-audit.md:184-211` records link gaps; `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m5-docs-audit.md:286-293` files TRL-707 through TRL-710.
+- M6 uses Bun publish language and clearly separates read-only registry probes from publishing: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md:14-21`, `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md:36-56`, and `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md:89-91`.
+- M6 does not claim stable cutover is complete: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md:23-32` lists concrete stable gaps, and `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/m6-release-process-audit.md:268-348` maps those gaps to TRL-713 and TRL-714 plus stable-runbook/doctrine follow-ups.
+- The V1 audit local review confirms the report set is clean for P0/P1/P2 while preserving P3/unknowns: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-3.md:7-24`.
+
+Conclusion: M3/M5/M6 are audit reports, not hidden implementation claims. They file concrete follow-ups where implementation remains.
+
+## Predicate 6 - Latest Local Review Status
+
+Status: Pass.
+
+Evidence:
+
+- Topographer round 3 is P3-only: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-3.md:7-22`.
+- Persistence round 3 is clean for P0/P1/P2: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-persistence-round-3.md:7-28`.
+- Warden/CLI round 3 is P3-only: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-warden-cli-round-3.md:9-21`.
+- V1 audit round 3 is clean for P0/P1/P2: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-3.md:7-24`.
+- Docs/vocab round 3 reported a P2: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-3.md:7-27`.
+- Docs/vocab round 4 resolves that P2 and is clean for P0/P1/P2: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-docs-vocab-round-4.md:7-20`.
+- The RETRO correctly says local review must continue until the latest pass is P3-only or clean: `.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md:19-23`.
+- The RETRO records docs/vocab round 3 as a stale P2 and round 4 as the clean latest docs/vocab pass: `.agents/plans/2026-05-12-topograph-query-docs-stack/RETRO.md:102-121`.
+- The RETRO execution log records the same sequence: three full rounds, then a focused round 4 docs/vocab verification that returned clean for P0/P1/P2.
+
+Conclusion: the latest actual local review status is P3-only/clean, and the RETRO now matches that sequence.
+
+## Findings
+
+| Severity | Owning branch | Finding | Recommended action |
+| --- | --- | --- | --- |
+| P3 | `trl-690-polish-warden-guidance-link-rendering-and-schema-reuse` | The app `warden.guide` trail still carries local Zod copies of Warden guide/guidance schema shape while the package owns the manifest TypeScript shape. This is passing behavior, not a doctrine mismatch. Evidence: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-warden-cli-round-3.md:15-21` and `apps/trails/src/trails/warden-guide.ts:15-59`. | Optional post-stack cleanup: export/reuse package-owned Warden guide schemas or add a direct app output-schema parse test for `buildWardenGuideManifest()`. |
+| P3 | `trl-653-sweep-docs-api-references-and-agent-guidance-for-topograph` | The compact API reference omits several exported topo-store record types, while the deeper topo-store reference documents them. This is docs polish, not an implementation/schema/test blocker. Evidence: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-topographer-round-3.md:16-23` and `docs/topo-store-reference.md:378-404`. | Optional docs polish: add the exported topo-store record types to compact `docs/api-reference.md`. |
+| P3 / Unknown | V1 audit tail / tracker mapping | Live Linear parentage for TRL-704 through TRL-714 was not re-read in the latest V1 audit round. Local artifacts are internally consistent. Evidence: `.agents/plans/2026-05-12-topograph-query-docs-stack/reports/local-review-v1-audit-round-3.md:11-24`. | If remote-ready gating needs tracker proof, run a read-only Linear readback before final handoff. |
+
+No P0/P1/P2 doctrine mismatches remain.
+
+## Final Classification
+
+Doctrine classification: Remote-ready from the local doctrine-verification perspective, subject to ordinary remote CI/review gates and the explicit unknowns above.
+
+Blocking doctrine issues: none.
+
+Residuals: P3-only bookkeeping/docs/schema-polish items.


### PR DESCRIPTION
## Context

The v1 closeout needs the beta-to-1.0 release process audited with the current Bun publish flow and changeset policy before the stack can leave local execution.

## Changes

- Adds the canonical M6 release-process and beta-to-1.0 cutover audit report under the plan reports directory.
- Records confirmed publish commands: `bun run publish:check` and `bun run publish:packages`.
- Files focused Linear follow-up issues for release-process gaps.
- Records the local review reports and post-execution doctrine verification report.
- Keeps the stack retro current with implementation, review, and verification status.

## Verification

- Audit evidence was checked against the live repo during local stack construction.
- Full stack tip verification passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run dead-code`, Warden guide sync/check commands, `bun run publish:check`, and `git diff --check`.
- Local review ran three full rounds plus a focused docs/vocab round 4; the latest review evidence is P3-only/clean.
- Post-execution doctrine verification passed with no P0/P1/P2 findings.

## Risks / rollout notes

This is an audit/report branch plus execution retro. It intentionally stops short of merge and records follow-up release work in Linear for separate implementation.

Closes: TRL-637