### PR TITLE
feat: add registry release preflight

### DIFF
--- a/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
+++ b/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
@@ -40,7 +40,7 @@ before handoff or merge readiness.
 | Order | Issue | Branch | PR | Status |
 | --- | --- | --- | --- | --- |
 | 1 | `TRL-713` | `trl-713-repair-stale-changesets-references-before-stable-cutover` | TBD | Focused checks passed |
-| 2 | `TRL-714` | `trl-714-add-registry-availability-and-dist-tag-release-preflights` | TBD | Not started |
+| 2 | `TRL-714` | `trl-714-add-registry-availability-and-dist-tag-release-preflights` | TBD | Focused checks passed |
 | 3 | `TRL-707` | `trl-707-fix-fresh-start-install-blocker-for-generated-cli-projects` | TBD | Not started |
 | 4 | `TRL-712` | `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | TBD | Not started |
 | 5 | `TRL-711` | `trl-711-codify-the-beta-to-10-release-runbook` | TBD | Not started |
@@ -62,6 +62,7 @@ issues created or updated during execution.
 | `TRL-711` | Added blockers `TRL-712`, `TRL-713`, and `TRL-714`. | Planning alignment |
 | `TRL-707` | Related to `TRL-714`. | Planning alignment |
 | `TRL-713` | Changed status to `In Progress`. | Branch execution started. |
+| `TRL-714` | Changed status to `In Progress`. | Branch execution started. |
 
 ## Local Review Reports
 
@@ -116,6 +117,11 @@ ready waves, and remote review turns here.
   retired `@ontrails/logging` package from
   `.changeset/logtape-observe-target.md` while preserving the
   `@ontrails/logtape` release note.
+- 2026-05-13T13:15Z: Added `TRL-714` registry preflight script and package
+  scripts. `bun run publish:registry-check` performs read-only npm probes and
+  reports missing packages as first-time package candidates; the stricter
+  `bun run publish:registry-check:published` mode requires every package to be
+  present after publication.
 
 ## Verification Log
 
@@ -127,6 +133,11 @@ Record focused branch checks and full tip gate results here.
 | `trl-713-repair-stale-changesets-references-before-stable-cutover` | `bun run changeset:check` | Passed. |
 | `trl-713-repair-stale-changesets-references-before-stable-cutover` | `bun run format:check` | Passed. |
 | `trl-713-repair-stale-changesets-references-before-stable-cutover` | `git diff --check` | Passed. |
+| `trl-714-add-registry-availability-and-dist-tag-release-preflights` | `bun test scripts` | Passed, 35 tests. |
+| `trl-714-add-registry-availability-and-dist-tag-release-preflights` | `bun run publish:registry-check` | Passed; reported first-time package candidates `@ontrails/commander`, `@ontrails/observe`, `@ontrails/topographer`, and `@ontrails/wayfinder`; all other packages had `beta=1.0.0-beta.15`. |
+| `trl-714-add-registry-availability-and-dist-tag-release-preflights` | `bun run publish:check` | Passed. |
+| `trl-714-add-registry-availability-and-dist-tag-release-preflights` | `bun run format:check` | Passed. |
+| `trl-714-add-registry-availability-and-dist-tag-release-preflights` | `git diff --check` | Passed. |
 
 ## Review Feedback
 
@@ -144,7 +155,7 @@ confirmation.
 
 | Check | Result | Notes |
 | --- | --- | --- |
-| TBD | TBD | TBD |
+| `bun run publish:registry-check` | Read-only probe only; no publish. | First-time candidates: `@ontrails/commander`, `@ontrails/observe`, `@ontrails/topographer`, `@ontrails/wayfinder`. |
 
 ## Final State
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,7 +293,7 @@ truly do not ship user-visible package content.
 
 To exit pre-release mode for a stable release: `bunx changeset pre exit`, then version as usual.
 
-`bun run publish:check` auto-discovers every non-private workspace, topo-sorts by `workspace:` dep edges, runs `bun pm pack --dry-run` per package (required because `npm pack` does not resolve `catalog:`), and asserts the packed `package.json` contains no unresolved `workspace:` or `catalog:` ranges. `bun run publish:packages` uses the same discovery and applies the explicit dist-tag from `.changeset/pre.json` (falling back to `latest` outside prerelease mode). Packages intentionally ship source `.ts` files while their `exports` map points at `src`; test files, `dist`, `.turbo`, and `*.tsbuildinfo` should stay out of the published tarballs.
+`bun run publish:check` auto-discovers every non-private workspace, topo-sorts by `workspace:` dep edges, runs `bun pm pack --dry-run` per package (required because `npm pack` does not resolve `catalog:`), and asserts the packed `package.json` contains no unresolved `workspace:` or `catalog:` ranges. `bun run publish:registry-check` performs read-only registry/dist-tag probes before publication; missing packages are reported as first-time package candidates. After publishing, use `bun run publish:registry-check:published` to require every package and expected dist-tag to be present. `bun run publish:packages` uses the same discovery and applies the explicit dist-tag from `.changeset/pre.json` (falling back to `latest` outside prerelease mode). Packages intentionally ship source `.ts` files while their `exports` map points at `src`; test files, `dist`, `.turbo`, and `*.tsbuildinfo` should stay out of the published tarballs.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "clean": "turbo run clean --no-cache && rm -rf node_modules",
     "oxlint-plugin:build": "bun run --cwd packages/oxlint-plugin build:oxlint",
     "publish:check": "bun scripts/publish.ts --check",
+    "publish:registry-check": "bun scripts/check-registry-preflight.ts",
+    "publish:registry-check:published": "bun scripts/check-registry-preflight.ts --require-published",
     "publish:packages": "bun scripts/publish.ts"
   },
   "devDependencies": {

--- a/scripts/__tests__/check-registry-preflight.test.ts
+++ b/scripts/__tests__/check-registry-preflight.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  checkRegistryPosture,
+  discoverRegistryWorkspaces,
+  registryPostureErrors,
+} from '../check-registry-preflight.ts';
+import type {
+  RegistryView,
+  RegistryWorkspace,
+} from '../check-registry-preflight.ts';
+
+const workspaces: readonly RegistryWorkspace[] = [
+  {
+    name: '@ontrails/core',
+    path: 'packages/core',
+    version: '1.0.0-beta.15',
+  },
+  {
+    name: '@ontrails/commander',
+    path: 'adapters/commander',
+    version: '1.0.0-beta.15',
+  },
+  {
+    name: '@ontrails/http',
+    path: 'packages/http',
+    version: '1.0.0-beta.15',
+  },
+];
+
+const mixedRegistryView: RegistryView = async (name) => {
+  if (name === '@ontrails/commander') {
+    return null;
+  }
+  return {
+    'dist-tags': { beta: '1.0.0-beta.15' },
+    name,
+    version: '1.0.0-beta.15',
+  };
+};
+
+const staleTagRegistryView: RegistryView = async (name) => ({
+  'dist-tags': { beta: '1.0.0-beta.14' },
+  name,
+  version: '1.0.0-beta.14',
+});
+
+const failingRegistryView: RegistryView = async () => {
+  throw new Error('registry unavailable');
+};
+
+describe('checkRegistryPosture', () => {
+  test('classifies published and first-time package candidates', async () => {
+    const results = await checkRegistryPosture(
+      workspaces,
+      mixedRegistryView,
+      'beta'
+    );
+
+    expect(results.map((result) => [result.name, result.status])).toEqual([
+      ['@ontrails/core', 'published'],
+      ['@ontrails/commander', 'missing'],
+      ['@ontrails/http', 'published'],
+    ]);
+    expect(registryPostureErrors(results, 'beta', false)).toEqual([]);
+    expect(registryPostureErrors(results, 'beta', true)).toEqual([
+      '@ontrails/commander: package is missing from the registry',
+    ]);
+  });
+
+  test('fails when the expected dist-tag points at a different version', async () => {
+    const results = await checkRegistryPosture(
+      [workspaces[0]],
+      staleTagRegistryView,
+      'beta'
+    );
+
+    expect(registryPostureErrors(results, 'beta', false)).toEqual([
+      '@ontrails/core: dist-tag beta points to 1.0.0-beta.14, expected 1.0.0-beta.15',
+    ]);
+  });
+
+  test('surfaces registry probe failures', async () => {
+    const results = await checkRegistryPosture(
+      [workspaces[0]],
+      failingRegistryView,
+      'beta'
+    );
+
+    expect(registryPostureErrors(results, 'beta', false)).toEqual([
+      '@ontrails/core: registry probe failed: registry unavailable',
+    ]);
+  });
+
+  test('probes registry workspaces concurrently while preserving result order', async () => {
+    const started: string[] = [];
+    const concurrentRegistryView: RegistryView = async (name) => {
+      started.push(name);
+      await Bun.sleep(10);
+      return {
+        'dist-tags': { beta: '1.0.0-beta.15' },
+        name,
+        version: '1.0.0-beta.15',
+      };
+    };
+
+    const resultsPromise = checkRegistryPosture(
+      workspaces,
+      concurrentRegistryView,
+      'beta'
+    );
+    await Bun.sleep(0);
+
+    expect(started).toEqual(workspaces.map((workspace) => workspace.name));
+    const results = await resultsPromise;
+    expect(results.map((result) => result.name)).toEqual(
+      workspaces.map((workspace) => workspace.name)
+    );
+  });
+});
+
+describe('discoverRegistryWorkspaces', () => {
+  test('ignores missing workspace glob parents', async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), 'trails-registry-'));
+    await writeFile(
+      join(repoRoot, 'package.json'),
+      JSON.stringify({ workspaces: ['packages/*'] })
+    );
+
+    await expect(discoverRegistryWorkspaces(repoRoot)).resolves.toEqual([]);
+  });
+
+  test('fails loudly when workspace glob parents are unreadable', async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), 'trails-registry-'));
+    await writeFile(
+      join(repoRoot, 'package.json'),
+      JSON.stringify({ workspaces: ['packages/*'] })
+    );
+    await writeFile(join(repoRoot, 'packages'), '');
+
+    await expect(discoverRegistryWorkspaces(repoRoot)).rejects.toThrow(
+      'Unable to read workspace directory packages'
+    );
+  });
+});

--- a/scripts/check-registry-preflight.ts
+++ b/scripts/check-registry-preflight.ts
@@ -1,0 +1,337 @@
+#!/usr/bin/env bun
+/* oxlint-disable max-statements -- release preflight CLI with explicit reporting */
+import { readdir } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(import.meta.dir, '..');
+
+interface Options {
+  readonly requirePublished: boolean;
+  readonly tag: string | undefined;
+}
+
+interface PackageJson {
+  readonly name?: string;
+  readonly private?: boolean;
+  readonly version?: string;
+}
+
+export interface RegistryWorkspace {
+  readonly name: string;
+  readonly path: string;
+  readonly version: string;
+}
+
+interface NpmView {
+  readonly name?: string;
+  readonly version?: string;
+  readonly 'dist-tags'?: Record<string, string>;
+}
+
+export type RegistryResult =
+  | {
+      readonly distTags: Record<string, string>;
+      readonly expectedTagVersion: string | undefined;
+      readonly name: string;
+      readonly status: 'published';
+      readonly version: string;
+      readonly workspaceVersion: string;
+    }
+  | {
+      readonly name: string;
+      readonly status: 'missing';
+      readonly workspaceVersion: string;
+    }
+  | {
+      readonly error: string;
+      readonly name: string;
+      readonly status: 'inaccessible';
+      readonly workspaceVersion: string;
+    };
+
+const USAGE = `Usage: bun scripts/check-registry-preflight.ts [options]
+
+Read-only npm registry preflight for public @ontrails/* workspaces.
+
+Options:
+  --tag <tag>            Expected npm dist-tag. Defaults to .changeset/pre.json
+                         tag while in prerelease mode, otherwise "latest".
+  --require-published    Fail when any workspace package is missing from npm.
+                         Use after publication to verify every package exists.
+  -h, --help             Show this help and exit.
+
+Exit codes: 0 success, 1 registry posture failure, 2 arg-parse error.`;
+
+const parseArgs = (argv: readonly string[]): Options => {
+  let requirePublished = false;
+  let tag: string | undefined;
+
+  const needsValue = (flag: string, value: string | undefined): string => {
+    if (value === undefined || value.startsWith('--')) {
+      console.error(`${flag} requires a value`);
+      console.error(USAGE);
+      process.exit(2);
+    }
+    return value;
+  };
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i] as string;
+    if (arg === '--require-published') {
+      requirePublished = true;
+    } else if (arg === '--tag') {
+      i += 1;
+      tag = needsValue('--tag', argv[i]);
+    } else if (arg === '-h' || arg === '--help') {
+      console.log(USAGE);
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      console.error(USAGE);
+      process.exit(2);
+    }
+    i += 1;
+  }
+
+  return { requirePublished, tag };
+};
+
+const readJson = async <T>(path: string): Promise<T> => {
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    throw new Error(`File not found: ${path}`);
+  }
+  return (await file.json()) as T;
+};
+
+const errorCode = (error: unknown): string | undefined => {
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return undefined;
+  }
+  const { code } = error as { readonly code?: unknown };
+  return typeof code === 'string' ? code : undefined;
+};
+
+const resolveDefaultTag = async (): Promise<string> => {
+  const prePath = join(REPO_ROOT, '.changeset', 'pre.json');
+  if (!(await Bun.file(prePath).exists())) {
+    return 'latest';
+  }
+  const pre = await readJson<{ mode?: string; tag?: string }>(prePath);
+  if (pre.mode !== 'pre') {
+    return 'latest';
+  }
+  if (typeof pre.tag === 'string' && pre.tag.length > 0) {
+    return pre.tag;
+  }
+  throw new Error(`${prePath} is in prerelease mode but has no tag`);
+};
+
+const discoverWorkspaceDirs = async (
+  repoRoot: string,
+  patterns: readonly string[]
+): Promise<string[]> => {
+  const dirs: string[] = [];
+  for (const pattern of patterns) {
+    if (pattern.endsWith('/*')) {
+      const parent = join(repoRoot, pattern.slice(0, -2));
+      let names: string[] = [];
+      try {
+        const entries = await readdir(parent, { withFileTypes: true });
+        names = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+      } catch (error) {
+        if (errorCode(error) === 'ENOENT') {
+          continue;
+        }
+        throw new Error(
+          `Unable to read workspace directory ${relative(repoRoot, parent)}: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error }
+        );
+      }
+      for (const name of names) {
+        const dir = join(parent, name);
+        if (await Bun.file(join(dir, 'package.json')).exists()) {
+          dirs.push(dir);
+        }
+      }
+    } else {
+      const dir = join(repoRoot, pattern);
+      if (await Bun.file(join(dir, 'package.json')).exists()) {
+        dirs.push(dir);
+      }
+    }
+  }
+  return dirs;
+};
+
+export const discoverRegistryWorkspaces = async (
+  repoRoot = REPO_ROOT
+): Promise<RegistryWorkspace[]> => {
+  const root = await readJson<{ workspaces?: string[] }>(
+    join(repoRoot, 'package.json')
+  );
+  const dirs = await discoverWorkspaceDirs(repoRoot, root.workspaces ?? []);
+  const workspaces: RegistryWorkspace[] = [];
+
+  for (const dir of dirs) {
+    const pkg = await readJson<PackageJson>(join(dir, 'package.json'));
+    if (
+      pkg.private === true ||
+      typeof pkg.name !== 'string' ||
+      !pkg.name.startsWith('@ontrails/') ||
+      typeof pkg.version !== 'string'
+    ) {
+      continue;
+    }
+    workspaces.push({
+      name: pkg.name,
+      path: relative(repoRoot, dir),
+      version: pkg.version,
+    });
+  }
+
+  return workspaces.toSorted((a, b) => a.name.localeCompare(b.name));
+};
+
+export type RegistryView = (name: string) => Promise<NpmView | null>;
+
+export const npmRegistryView: RegistryView = async (name) => {
+  const proc = Bun.spawn(
+    ['npm', 'view', name, 'name', 'version', 'dist-tags', '--json'],
+    { stderr: 'pipe', stdin: 'ignore', stdout: 'pipe' }
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (exitCode === 0) {
+    return JSON.parse(stdout) as NpmView;
+  }
+  const combined = `${stdout}\n${stderr}`;
+  if (combined.includes('E404') || combined.includes('404 Not Found')) {
+    return null;
+  }
+  throw new Error(stderr.trim() || `npm view failed for ${name}`);
+};
+
+const checkWorkspaceRegistryPosture = async (
+  workspace: RegistryWorkspace,
+  view: RegistryView,
+  expectedTag: string
+): Promise<RegistryResult> => {
+  try {
+    const registry = await view(workspace.name);
+    if (!registry) {
+      return {
+        name: workspace.name,
+        status: 'missing',
+        workspaceVersion: workspace.version,
+      };
+    }
+    const distTags = registry['dist-tags'] ?? {};
+    return {
+      distTags,
+      expectedTagVersion: distTags[expectedTag],
+      name: workspace.name,
+      status: 'published',
+      version: registry.version ?? '(unknown)',
+      workspaceVersion: workspace.version,
+    };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+      name: workspace.name,
+      status: 'inaccessible',
+      workspaceVersion: workspace.version,
+    };
+  }
+};
+
+export const checkRegistryPosture = async (
+  workspaces: readonly RegistryWorkspace[],
+  view: RegistryView,
+  expectedTag: string
+): Promise<RegistryResult[]> =>
+  Promise.all(
+    workspaces.map((workspace) =>
+      checkWorkspaceRegistryPosture(workspace, view, expectedTag)
+    )
+  );
+
+export const registryPostureErrors = (
+  results: readonly RegistryResult[],
+  expectedTag: string,
+  requirePublished: boolean
+): string[] => {
+  const errors: string[] = [];
+  for (const result of results) {
+    if (result.status === 'inaccessible') {
+      errors.push(`${result.name}: registry probe failed: ${result.error}`);
+    } else if (result.status === 'missing') {
+      if (requirePublished) {
+        errors.push(`${result.name}: package is missing from the registry`);
+      }
+    } else if (result.expectedTagVersion !== result.workspaceVersion) {
+      errors.push(
+        `${result.name}: dist-tag ${expectedTag} points to ${result.expectedTagVersion ?? '(missing)'}, expected ${result.workspaceVersion}`
+      );
+    }
+  }
+  return errors;
+};
+
+const printResults = (
+  results: readonly RegistryResult[],
+  expectedTag: string
+): void => {
+  console.log(`Registry preflight for dist-tag "${expectedTag}"`);
+  for (const result of results) {
+    if (result.status === 'published') {
+      console.log(
+        `✓ ${result.name}@${result.workspaceVersion}: published (registry version ${result.version}, ${expectedTag}=${result.expectedTagVersion ?? 'missing'})`
+      );
+    } else if (result.status === 'missing') {
+      console.log(
+        `• ${result.name}@${result.workspaceVersion}: first-time package candidate (not found on registry)`
+      );
+    } else {
+      console.log(`✗ ${result.name}: registry probe failed: ${result.error}`);
+    }
+  }
+};
+
+export const runRegistryPreflight = async (
+  options: Options,
+  view: RegistryView = npmRegistryView
+): Promise<number> => {
+  const expectedTag = options.tag ?? (await resolveDefaultTag());
+  const workspaces = await discoverRegistryWorkspaces();
+  const results = await checkRegistryPosture(workspaces, view, expectedTag);
+  printResults(results, expectedTag);
+  const errors = registryPostureErrors(
+    results,
+    expectedTag,
+    options.requirePublished
+  );
+  if (errors.length > 0) {
+    console.error('\nRegistry preflight failed:');
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    return 1;
+  }
+  console.log('\nRegistry preflight passed.');
+  return 0;
+};
+
+if (import.meta.main) {
+  try {
+    process.exit(await runRegistryPreflight(parseArgs(process.argv.slice(2))));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Context

`bun run publish:check` proves local packability, but the release process also needs read-only evidence that public packages and dist-tags exist where generated projects will install them.

## What Changed

- Added a registry availability/dist-tag preflight for public `@ontrails/*` workspaces.
- Added deterministic tests for registry-response handling.
- Added `publish:registry-check` and `publish:registry-check:published` package scripts.
- Documented the new read-only preflight in the release guidance.

## How To Test

- `bun test scripts`
- `bun run publish:registry-check`
- `bun run publish:check`
- `bun run format:check`
- `git diff --check`

## Risks / Rollout Notes

The registry preflight is read-only. It does not publish packages or mutate dist-tags.