### PR TITLE
docs: add stable release doctrine adr

### DIFF
--- a/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
+++ b/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
@@ -42,7 +42,7 @@ before handoff or merge readiness.
 | 1 | `TRL-713` | `trl-713-repair-stale-changesets-references-before-stable-cutover` | TBD | Focused checks passed |
 | 2 | `TRL-714` | `trl-714-add-registry-availability-and-dist-tag-release-preflights` | TBD | Focused checks passed |
 | 3 | `TRL-707` | `trl-707-fix-fresh-start-install-blocker-for-generated-cli-projects` | TBD | Fresh-start gate passed after beta.16 unblock |
-| 4 | `TRL-712` | `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | TBD | Not started |
+| 4 | `TRL-712` | `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | TBD | Focused checks passed |
 | 5 | `TRL-711` | `trl-711-codify-the-beta-to-10-release-runbook` | TBD | Not started |
 | 6 | `TRL-709` | `trl-709-add-markdown-link-integrity-check-for-docs-and-readmes` | TBD | Not started |
 | 7 | `TRL-708` | `trl-708-expand-readme-typescript-snippet-verification-beyond-tracing` | TBD | Not started |
@@ -67,6 +67,7 @@ issues created or updated during execution.
 | `TRL-707` | Added Linear blocker comment. | Comment `58a5e8c5-74b9-4378-963b-c404368b9696` records the npm 404 evidence and smallest publish action. |
 | `TRL-707` | Rechecked after packages were published. | Registry presence gate now passes, but fresh-start typecheck fails because published `@ontrails/commander@1.0.0-beta.15` imports public symbols absent from the published `@ontrails/core` and `@ontrails/cli` artifacts at the same version. Added Linear comment `f2c45844-1fe4-45e1-ba1b-eb2fd7d223ea`. |
 | `TRL-707` | Rechecked after PR #501 beta.16 unblock. | Fresh-start gate passed from clean Bun cache: generated app requested `@ontrails/*@^1.0.0-beta.16`, install selected `@ontrails/cli`, `@ontrails/commander`, `@ontrails/core`, `@ontrails/hono`, `@ontrails/http`, `@ontrails/mcp`, `@ontrails/testing`, and `@ontrails/warden` at `1.0.0-beta.16`, then `bun run typecheck` and `bun test` passed. Added Linear comment `b0c10985-12d8-4a24-adc6-7d2c9140833a`. |
+| `TRL-712` | Changed status to `In Progress`. | Branch execution started. |
 
 ## Local Review Reports
 
@@ -169,6 +170,14 @@ ready waves, and remote review turns here.
   The beta.16 fresh-start smoke then passed from
   `/tmp/trails-docs-smoke-beta16.DtBa2o/docs-smoke` with clean Bun cache
   `/tmp/bun-cache-beta16.cuxqcC`.
+- 2026-05-13T16:14Z: Started `TRL-712` on
+  `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` and added
+  accepted ADR-0047, "Stable Release Line Discipline." The ADR keeps public
+  `@ontrails/*` packages lockstep for the 1.x line, separates package semver
+  from trail versioning, sets stable/prerelease dist-tag posture, makes
+  generated-app installability a release gate, keeps Changesets as
+  version/changelog authority and Bun as publish authority, and documents
+  explicit partial-publish recovery and release PR evidence expectations.
 
 ## Verification Log
 
@@ -198,6 +207,10 @@ Record focused branch checks and full tip gate results here.
 | `trl-707-fix-fresh-start-install-blocker-for-generated-cli-projects` | `BUN_INSTALL_CACHE_DIR=/tmp/bun-cache-beta16.cuxqcC bun install` | Passed from a clean Bun cache; install selected `@ontrails/cli@1.0.0-beta.16`, `@ontrails/commander@1.0.0-beta.16`, `@ontrails/core@1.0.0-beta.16`, `@ontrails/hono@1.0.0-beta.16`, `@ontrails/http@1.0.0-beta.16`, `@ontrails/mcp@1.0.0-beta.16`, `@ontrails/testing@1.0.0-beta.16`, and `@ontrails/warden@1.0.0-beta.16`. The lock also resolved transitive `@ontrails/observe`, `@ontrails/permits`, `@ontrails/store`, and `@ontrails/topographer` at `1.0.0-beta.16`. |
 | `trl-707-fix-fresh-start-install-blocker-for-generated-cli-projects` | `bun run typecheck` | Passed in the generated app. |
 | `trl-707-fix-fresh-start-install-blocker-for-generated-cli-projects` | `bun test` | Passed in the generated app: 7 tests, 11 assertions. |
+| `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | `bun scripts/adr.ts map` | Passed; regenerated `docs/adr/decision-map.json` and draft ADR indexes. |
+| `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | `bun scripts/adr.ts check` | Passed; 0 errors, 0 warnings. |
+| `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | `bun run format:check` | Passed. |
+| `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | `git diff --check` | Passed. |
 
 ## Review Feedback
 

--- a/.claude/skills/trails-adrs/scripts/lib/index.ts
+++ b/.claude/skills/trails-adrs/scripts/lib/index.ts
@@ -2,6 +2,14 @@ import { writeFileSync } from 'node:fs';
 import { INDEX_PATH } from './paths.ts';
 import { listNumberedAdrs, parseAdrNumber, padNumber } from './discovery.ts';
 
+const formatStatus = (status: string, amended: unknown): string => {
+  const capitalStatus = status.charAt(0).toUpperCase() + status.slice(1);
+  if (typeof amended !== 'string' || amended.length === 0) {
+    return capitalStatus;
+  }
+  return `${capitalStatus} (amended ${amended})`;
+};
+
 export const rebuildIndex = (): void => {
   const adrs = listNumberedAdrs();
   const rows = adrs.map((adr) => {
@@ -9,8 +17,8 @@ export const rebuildIndex = (): void => {
     const displayNum = num === null ? '????' : padNumber(num);
     const title = adr.title.replace(/^ADR-\d+:\s*/, '');
     const status = String(adr.frontmatter.status ?? 'unknown');
-    const capitalStatus = status.charAt(0).toUpperCase() + status.slice(1);
-    return `| [${displayNum}](${adr.filename}) | ${title} | ${capitalStatus} |`;
+    const displayStatus = formatStatus(status, adr.frontmatter.amended);
+    return `| [${displayNum}](${adr.filename}) | ${title} | ${displayStatus} |`;
   });
 
   const content = `# Architecture Decision Records

--- a/docs/adr/0047-stable-release-line-discipline.md
+++ b/docs/adr/0047-stable-release-line-discipline.md
@@ -1,0 +1,297 @@
+---
+id: 47
+slug: stable-release-line-discipline
+title: Stable Release Line Discipline
+status: accepted
+created: 2026-05-13
+updated: 2026-05-13
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [29, 35, 37, 44, 46]
+---
+
+# ADR-0047: Stable Release Line Discipline
+
+## Context
+
+### Stable changes the meaning of a release
+
+During the beta line, Trails could use each release to finish the shape of the
+framework. Package boundaries moved, `connector` became `adapter`, surface APIs
+settled into the `derive` -> `create` -> `surface` ladder, and generated apps
+tracked those moves.
+
+The 1.x line has a different promise. A stable release is not just "the next
+publish." It is the public distribution contract for the framework family.
+Developers should be able to create a fresh app, install the generated
+dependencies from the registry, and trust that the packages they received
+belong to the same release story.
+
+### The package graph is one framework family
+
+Trails now ships pure contract packages, extracted adapters, tooling packages,
+and the `trails` CLI. ADR-0029 keeps adapter package boundaries sharp, and
+ADR-0035 keeps surface projection, materialization, and ownership layers
+distinct.
+
+Those boundaries are architectural. They do not require independent public
+version numbers in the first stable line. In fact, the beta.16 unblock showed
+the opposite risk: if a generated app can see one package version while another
+public package is missing or stale, the user experiences the framework as
+broken even though each local package may pack cleanly.
+
+### Release mechanics exist, but doctrine was implicit
+
+The repo already has a workable release mechanism:
+
+- Changesets computes versions and changelogs.
+- `.changeset/config.json` fixes `@ontrails/*` packages together.
+- `bun run publish:check` packs public workspaces and rejects unresolved
+  `workspace:` or `catalog:` ranges.
+- `bun run publish:packages` publishes through Bun and derives the dist-tag
+  from `.changeset/pre.json`.
+- `bun run publish:registry-check` and
+  `bun run publish:registry-check:published` verify registry availability and
+  dist-tag posture without mutating the registry.
+
+What was missing was the stable-line decision those tools enforce. Without an
+ADR, release docs can drift back toward operator memory: "run the right thing,
+publish the right packages, recover carefully." Stable needs that memory turned
+into a contract.
+
+## Decision
+
+### The 1.x package line stays lockstep
+
+All non-private public `@ontrails/*` packages remain fixed together for the
+1.x line.
+
+This means:
+
+- one stable release version names the whole public framework family;
+- generated apps may depend on multiple `@ontrails/*` packages without solving
+  a compatibility puzzle;
+- adapter package extraction still owns dependency and responsibility
+  boundaries, but not independent 1.x version numbers;
+- moving an adapter to an independent cadence requires a future ADR amendment.
+
+The test: if a public `@ontrails/*` package ships as part of the stable
+framework family, a release PR should make it available at the same version as
+the rest of that family or explicitly document why it is not part of the
+published set.
+
+### Package semver and trail versioning answer different questions
+
+Package semver describes distribution compatibility for npm consumers.
+ADR-0044 trail versioning describes capability compatibility inside a topo.
+
+Do not use package versions as a substitute for trail versions. A package
+minor may add new framework APIs. A trail version may preserve an old contract
+inside the same package version. The release line carries the framework bits;
+the trail contract carries the app capability.
+
+### Stable uses `latest`; prereleases use explicit channels
+
+The stable 1.x channel publishes to `latest`.
+
+Prereleases after 1.0 use explicit prerelease dist-tags such as `beta`,
+`next`, or `canary`. A prerelease must not fall through to `latest` because a
+tag was omitted.
+
+The publish script is the authority for this default:
+
+- while Changesets prerelease mode is active, use `.changeset/pre.json`'s
+  explicit tag;
+- after prerelease mode exits, default to `latest`;
+- if prerelease mode is active but no usable tag exists, fail loudly.
+
+Release PRs and runbooks should verify the intended dist-tag before publish
+and verify the actual dist-tag after publish.
+
+### Breaking changes after 1.0 are major-line decisions
+
+After 1.0, a breaking public API change requires one of these:
+
+- a new major release line;
+- an accepted ADR that defines a narrower exception and its migration path.
+
+Public API includes package exports, generated app dependencies and imports,
+surface helper contracts, stable CLI command grammar, documented runtime
+behavior, and generated artifact contracts promised by accepted ADRs.
+
+Pre-1.0 cleanup can still land before the stable cut. Once 1.0 is published,
+the stable line stops using "we are still in beta" as the migration plan.
+
+### Package retirement is visible and migratable
+
+A public package rename, retirement, or extraction must include a migration
+posture before the stable line can depend on it.
+
+This means:
+
+- generated scaffolds stop referencing the retired name before release;
+- docs and release notes name the replacement;
+- old packages already published to npm are deprecated with a visible message
+  when that package name should not be used anymore;
+- package removal from the public set is called out in the release PR;
+- the release preflight distinguishes "intentionally retired" from "missing or
+  inaccessible."
+
+Retiring a package silently is a release failure. It makes drift visible only
+to the next person who tries a fresh install.
+
+### Fresh generated apps are a release gate
+
+The current stable scaffold must install from the public registry with a clean
+package-manager cache.
+
+For a release that changes generated app dependencies or public surface
+packages, the release evidence must include a fresh-start smoke outside the
+monorepo:
+
+```bash
+tmp=$(mktemp -d /tmp/trails-docs-smoke.XXXXXX)
+bun apps/trails/bin/trails.ts create docs-smoke \
+  --dir "$tmp" \
+  --surfaces cli mcp http \
+  --verify \
+  --output json
+
+cache=$(mktemp -d /tmp/bun-cache.XXXXXX)
+cd "$tmp/docs-smoke"
+BUN_INSTALL_CACHE_DIR="$cache" bun install
+bun run typecheck
+bun test
+```
+
+The point is not just that the scaffold command runs. The generated
+`package.json`, selected lockfile versions, typecheck, and tests together
+prove that a new user can consume the published framework family.
+
+### Changesets computes; Bun publishes
+
+Changesets owns version and changelog calculation. Bun owns publication.
+
+The stable flow keeps these responsibilities separate:
+
+- use `bunx changeset add` or an equivalent changeset file for package-facing
+  changes;
+- use `bunx changeset version` to update package versions and changelogs;
+- use `bun run publish:check` to prove the package tarballs are clean;
+- use `bun run publish:packages` to publish.
+
+Do not use `changeset publish`, `npm publish`, or ad hoc package publication
+for the normal release path. If an emergency requires a different operation,
+that operation is an incident with written evidence, not a new default.
+
+### Changelogs and release notes are part of the contract
+
+Every package-facing change needs a truthful changeset unless the PR is
+explicitly `release:none` and the issue or PR explains why no user-visible
+package content changed.
+
+Package changelogs should name user-visible API, package, surface, and
+generated-app changes in the package that ships them. Release notes should
+explain the framework-family story: new packages, retired names, scaffold
+changes, known migrations, and release preflight results.
+
+### Partial publish recovery is explicit
+
+If publication fails after one or more packages have been published, stop.
+
+Recovery requires:
+
+- the failed command and output;
+- the target version and intended dist-tag;
+- the list of packages already published at that version;
+- registry verification for those packages;
+- an explicit resume set for any retry.
+
+Do not rerun the whole publish matrix blindly. Do not mutate dist-tags to hide
+an incomplete release. A partial publish is a release incident until the public
+package set and dist-tags are coherent again.
+
+### Release PRs carry preflight evidence
+
+A release PR that changes package versions or prepares a stable cutover should
+cite this ADR and include the relevant evidence:
+
+- `bunx changeset status --verbose`;
+- `bun run publish:check`;
+- `bun run publish:registry-check`;
+- fresh-start generated app smoke when scaffolds or generated dependencies are
+  in scope;
+- ADR and runbook checks when release doctrine or procedure changes.
+
+The review question is not "does this diff look plausible?" It is "does the
+evidence prove the public release line will be coherent?"
+
+## Consequences
+
+### Positive
+
+- A stable version names a coherent framework family instead of a loose set of
+  packages that happen to share a scope.
+- Generated apps become a first-class release signal, matching the "one write,
+  many reads" doctrine: scaffold metadata, package manifests, registry state,
+  and tests all have to agree.
+- The runbook can stay procedural because this ADR owns the policy.
+- Registry preflight failures become actionable: missing package, wrong tag,
+  intentional retirement, or partial-publish incident.
+- Adapter extraction keeps its architectural value without forcing
+  independent package cadence before the stable line is ready for it.
+
+### Tradeoffs
+
+- Lockstep versioning publishes packages that did not materially change in a
+  given release. That is acceptable for 1.x because coherence is more valuable
+  than granular package history at this stage.
+- Independent adapter cadence is deferred. Adapter packages have clean
+  dependency boundaries, but their public versions stay tied to the framework
+  family until a future ADR changes the line policy.
+- Release PRs carry more evidence. The added ceremony is intentional: stable
+  releases are externally visible operations, not local build checks.
+
+### Risks
+
+- A broad lockstep line can hide which package actually changed. Changesets
+  and package changelogs mitigate this by keeping package-local release notes.
+- `release:none` can be abused to bypass package evidence. CI and review
+  should treat it as a claim requiring explanation, not as a shortcut.
+- Partial-publish recovery remains operator-sensitive. The mitigation is to
+  make the stop-and-resume protocol explicit and to keep improving read-only
+  registry probes.
+
+## Non-goals
+
+- This ADR does not execute the 1.0 cutover.
+- This ADR does not choose the exact calendar support window for 1.x.
+- This ADR does not make adapter packages independently versioned.
+- This ADR does not define customer support policy outside package and
+  generated-app compatibility.
+
+## Non-decisions
+
+- Whether a future 2.x line keeps lockstep or lets some adapters use an
+  independent cadence.
+- Whether Trails eventually publishes additional prerelease channels beyond
+  `beta`.
+- Whether package provenance, signing, or npm ownership automation becomes a
+  first-party release primitive.
+
+## References
+
+- [ADR-0029: Adapter Extraction and Composition Around Core Contracts](0029-connector-extraction-and-the-with-packaging-model.md)
+  — package boundaries and adapter extraction remain intact under lockstep 1.x
+  versioning
+- [ADR-0035: Surface APIs Render the Graph](0035-surface-apis-render-the-graph.md)
+  — generated apps and surface packages consume the shared projection ladder
+- [ADR-0037: Owner-First Authority](0037-owner-first-authority.md) — release
+  tools should read package and framework facts from their natural owners
+- [ADR-0044: Trail Versioning](0044-trail-versioning.md) — trail contract
+  versions are separate from package semver
+- [ADR-0046: Lock v3 Artifact Family](0046-lock-v3-artifact-family.md) — stable
+  artifact contracts are part of the public release line
+- [Release Process And Beta-To-1.0 Cutover Audit](../../.agents/plans/2026-05-13-v1-readiness-closure-stack/reports/source-m6-release-process-audit.md)
+  — source audit that identified the missing doctrine
+- [Releasing](../../AGENTS.md#releasing) — current repo release commands and
+  publish posture

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,7 +18,7 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0009](0009-first-class-resources.md) | First-Class Resources | Accepted |
 | [0010](0010-native-infrastructure.md) | Trails-Native Infrastructure Pattern | Accepted |
 | [0011](0011-schema-driven-config.md) | Schema-Driven Config | Accepted |
-| [0012](0012-connector-agnostic-permits.md) | Connector-Agnostic Permits | Accepted |
+| [0012](0012-connector-agnostic-permits.md) | Adapter-Agnostic Permits | Accepted |
 | [0013](0013-tracing.md) | Tracing — Runtime Recording Primitive | Partially-superseded |
 | [0014](0014-core-database-primitive.md) | Core Database Primitive | Accepted |
 | [0015](0015-topo-store.md) | Topo Store | Accepted |
@@ -35,7 +35,7 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0026](0026-error-taxonomy-as-transport-independent-behavior-contract.md) | Error Taxonomy as Transport-Independent Behavior Contract | Accepted |
 | [0027](0027-visibility-and-filtering.md) | Trail Visibility and Surface Filtering | Accepted |
 | [0028](0028-concurrent-crossing.md) | Concurrent Trail Crossing | Accepted |
-| [0029](0029-connector-extraction-and-the-with-packaging-model.md) | Connector Extraction and Composition Around Core Contracts | Accepted |
+| [0029](0029-connector-extraction-and-the-with-packaging-model.md) | Adapter Extraction and Composition Around Core Contracts | Accepted |
 | [0030](0030-contours-as-first-class-domain-objects.md) | Contours as First-Class Domain Objects | Accepted |
 | [0031](0031-backend-agnostic-store-schemas.md) | Backend-Agnostic Store Schemas | Accepted |
 | [0032](0032-derivetrail-and-trail-factories.md) | deriveTrail() and Trail Factories | Accepted |
@@ -53,3 +53,4 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0044](0044-trail-versioning.md) | Trail Versioning | Accepted |
 | [0045](0045-v1-resolved-graph-error-scope.md) | v1 Resolved Graph Error Scope | Accepted |
 | [0046](0046-lock-v3-artifact-family.md) | Lock v3 Artifact Family | Accepted |
+| [0047](0047-stable-release-line-discipline.md) | Stable Release Line Discipline | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -1796,6 +1796,11 @@
           "fromPath": "docs/adr/0035-surface-apis-render-the-graph.md"
         },
         {
+          "context": "- [ADR-0029: Adapter Extraction and Composition Around Core Contracts](0029-connector-extraction-and-the-with-packaging-model.md)",
+          "from": "0047",
+          "fromPath": "docs/adr/0047-stable-release-line-discipline.md"
+        },
+        {
           "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](../0029-connector-extraction-and-the-with-packaging-model.md) -- the packaging model for connector-contributed capabilities that rig",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
@@ -2032,6 +2037,11 @@
           "context": "- [ADR-0035: Surface APIs Render the Graph](0035-surface-apis-render-the-graph.md)",
           "from": "0044",
           "fromPath": "docs/adr/0044-trail-versioning.md"
+        },
+        {
+          "context": "- [ADR-0035: Surface APIs Render the Graph](0035-surface-apis-render-the-graph.md)",
+          "from": "0047",
+          "fromPath": "docs/adr/0047-stable-release-line-discipline.md"
         }
       ],
       "number": "0035",
@@ -2076,6 +2086,11 @@
       "created": "2026-04-30",
       "depends_on": ["0", "7", "26", "35", "36"],
       "inbound": [
+        {
+          "context": "- [ADR-0037: Owner-First Authority](0037-owner-first-authority.md) — release",
+          "from": "0047",
+          "fromPath": "docs/adr/0047-stable-release-line-discipline.md"
+        },
         {
           "context": "and [ADR-0037](./adr/0037-owner-first-authority.md).",
           "from": "rule-design",
@@ -2298,7 +2313,13 @@
     {
       "created": "2026-04-09",
       "depends_on": ["3", "6", "8", "13", "17", "24", "26", "35"],
-      "inbound": [],
+      "inbound": [
+        {
+          "context": "- [ADR-0044: Trail Versioning](0044-trail-versioning.md) — trail contract",
+          "from": "0047",
+          "fromPath": "docs/adr/0047-stable-release-line-discipline.md"
+        }
+      ],
       "number": "0044",
       "owners": ["[galligan](https://github.com/galligan)"],
       "path": "docs/adr/0044-trail-versioning.md",
@@ -2357,6 +2378,11 @@
           "fromPath": "docs/adr/0045-v1-resolved-graph-error-scope.md"
         },
         {
+          "context": "- [ADR-0046: Lock v3 Artifact Family](0046-lock-v3-artifact-family.md) — stable",
+          "from": "0047",
+          "fromPath": "docs/adr/0047-stable-release-line-discipline.md"
+        },
+        {
           "context": "[ADR-0046](adr/0046-lock-v3-artifact-family.md).",
           "from": "lexicon",
           "fromPath": "docs/lexicon.md"
@@ -2375,6 +2401,19 @@
       "superseded_by": null,
       "title": "Lock v3 Artifact Family",
       "updated": "2026-05-11"
+    },
+    {
+      "created": "2026-05-13",
+      "depends_on": ["29", "35", "37", "44", "46"],
+      "inbound": [],
+      "number": "0047",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0047-stable-release-line-discipline.md",
+      "slug": "stable-release-line-discipline",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Stable Release Line Discipline",
+      "updated": "2026-05-13"
     }
   ],
   "version": 1


### PR DESCRIPTION
## Context

Before cutting a stable 1.x line, Trails needs an accepted release doctrine that separates package semver, trail versioning, dist-tag behavior, and generated-app installability gates.

## What Changed

- Added accepted ADR-0047: Stable Release Line Discipline.
- Updated the ADR index and decision map.
- Captured lockstep public package versioning, prerelease/stable dist-tag posture, partial-publish recovery, and release PR evidence expectations.

## How To Test

- `bun scripts/adr.ts map`
- `bun scripts/adr.ts check`
- `bun run format:check`
- `git diff --check`

## Risks / Rollout Notes

Documentation/doctrine only. This does not change package code or publish behavior by itself.