### PR TITLE
docs: codify stable cutover runbook

### DIFF
--- a/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
+++ b/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
@@ -43,7 +43,7 @@ before handoff or merge readiness.
 | 2 | `TRL-714` | `trl-714-add-registry-availability-and-dist-tag-release-preflights` | TBD | Focused checks passed |
 | 3 | `TRL-707` | `trl-707-fix-fresh-start-install-blocker-for-generated-cli-projects` | TBD | Fresh-start gate passed after beta.16 unblock |
 | 4 | `TRL-712` | `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | TBD | Focused checks passed |
-| 5 | `TRL-711` | `trl-711-codify-the-beta-to-10-release-runbook` | TBD | Not started |
+| 5 | `TRL-711` | `trl-711-codify-the-beta-to-10-release-runbook` | TBD | Focused checks passed |
 | 6 | `TRL-709` | `trl-709-add-markdown-link-integrity-check-for-docs-and-readmes` | TBD | Not started |
 | 7 | `TRL-708` | `trl-708-expand-readme-typescript-snippet-verification-beyond-tracing` | TBD | Not started |
 | 8 | `TRL-710` | `trl-710-create-public-api-example-coverage-inventory-and-gate` | TBD | Not started |
@@ -68,6 +68,7 @@ issues created or updated during execution.
 | `TRL-707` | Rechecked after packages were published. | Registry presence gate now passes, but fresh-start typecheck fails because published `@ontrails/commander@1.0.0-beta.15` imports public symbols absent from the published `@ontrails/core` and `@ontrails/cli` artifacts at the same version. Added Linear comment `f2c45844-1fe4-45e1-ba1b-eb2fd7d223ea`. |
 | `TRL-707` | Rechecked after PR #501 beta.16 unblock. | Fresh-start gate passed from clean Bun cache: generated app requested `@ontrails/*@^1.0.0-beta.16`, install selected `@ontrails/cli`, `@ontrails/commander`, `@ontrails/core`, `@ontrails/hono`, `@ontrails/http`, `@ontrails/mcp`, `@ontrails/testing`, and `@ontrails/warden` at `1.0.0-beta.16`, then `bun run typecheck` and `bun test` passed. Added Linear comment `b0c10985-12d8-4a24-adc6-7d2c9140833a`. |
 | `TRL-712` | Changed status to `In Progress`. | Branch execution started. |
+| `TRL-711` | Changed status to `In Progress`. | Branch execution started. |
 
 ## Local Review Reports
 
@@ -178,6 +179,14 @@ ready waves, and remote review turns here.
   generated-app installability a release gate, keeps Changesets as
   version/changelog authority and Bun as publish authority, and documents
   explicit partial-publish recovery and release PR evidence expectations.
+- 2026-05-13T16:17Z: Started `TRL-711` on
+  `trl-711-codify-the-beta-to-10-release-runbook` and added
+  `docs/releases/stable-cutover.md`. The runbook separates version PR work from
+  post-merge publication, cites ADR-0047, uses `bun run publish:check` and
+  `bun run publish:packages`, includes registry/dist-tag verification and
+  clean-cache generated-app smoke evidence, and documents partial-publish
+  recovery with explicit resume sets. Added narrow pointers from `docs/index.md`
+  and `AGENTS.md`.
 
 ## Verification Log
 
@@ -211,6 +220,10 @@ Record focused branch checks and full tip gate results here.
 | `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | `bun scripts/adr.ts check` | Passed; 0 errors, 0 warnings. |
 | `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | `bun run format:check` | Passed. |
 | `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | `git diff --check` | Passed. |
+| `trl-711-codify-the-beta-to-10-release-runbook` | `bun run publish:check` | Passed; all public package pack checks passed at `1.0.0-beta.16`. No publish command was run. |
+| `trl-711-codify-the-beta-to-10-release-runbook` | `bun scripts/adr.ts check` | Passed; 0 errors, 0 warnings. |
+| `trl-711-codify-the-beta-to-10-release-runbook` | `bun run format:check` | Passed. |
+| `trl-711-codify-the-beta-to-10-release-runbook` | `git diff --check` | Passed. |
 
 ## Review Feedback
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,7 @@ whole local stack. Use `release:none` only for package-touching changes that
 truly do not ship user-visible package content.
 
 To exit pre-release mode for a stable release: `bunx changeset pre exit`, then version as usual.
+Stable 1.x release doctrine is captured in [ADR-0047](docs/adr/0047-stable-release-line-discipline.md), and the copy-pasteable beta-to-1.0 operator sequence lives in [Stable Cutover Runbook](docs/releases/stable-cutover.md).
 
 `bun run publish:check` auto-discovers every non-private workspace, topo-sorts by `workspace:` dep edges, runs `bun pm pack --dry-run` per package (required because `npm pack` does not resolve `catalog:`), and asserts the packed `package.json` contains no unresolved `workspace:` or `catalog:` ranges. `bun run publish:registry-check` performs read-only registry/dist-tag probes before publication; missing packages are reported as first-time package candidates. After publishing, use `bun run publish:registry-check:published` to require every package and expected dist-tag to be present. `bun run publish:packages` uses the same discovery and applies the explicit dist-tag from `.changeset/pre.json` (falling back to `latest` outside prerelease mode). Packages intentionally ship source `.ts` files while their `exports` map points at `src`; test files, `dist`, `.turbo`, and `*.tsbuildinfo` should stay out of the published tarballs.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@
 
 ## Release Notes
 
+- **[Stable Cutover Runbook](./releases/stable-cutover.md)** — Beta-to-1.0 cutover sequence, publish boundaries, and recovery checks
 - **[Beta 15](./releases/beta15.md)** — Current release-prep notes and known CLI follow-up work
 
 ## Building something?

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -1,0 +1,330 @@
+# Stable Cutover Runbook
+
+This runbook is the operator checklist for leaving the beta prerelease line and
+publishing the first stable 1.x Trails release.
+
+It is governed by [ADR-0047: Stable Release Line Discipline](../adr/0047-stable-release-line-discipline.md).
+The short version: public `@ontrails/*` packages stay lockstep for 1.x,
+Changesets computes versions and changelogs, Bun publishes packages, generated
+apps must install from the public registry, and partial publishes are handled
+as release incidents.
+
+Do not run this from an in-progress feature stack. The versioning PR and the
+publish step are separate operations.
+
+## Release Boundaries
+
+There are two distinct phases:
+
+| Phase | What happens | Where |
+| --- | --- | --- |
+| Version PR | Exit prerelease mode, compute stable versions/changelogs, review the diff, and merge. | A normal Graphite branch and PR |
+| Publish | Publish already-merged package contents and verify registry/dist-tag state. | Clean `main` after the version PR merges |
+
+Never publish from an unmerged version PR. Never use `changeset publish`,
+`npm publish`, or ad hoc package publication for the normal stable cutover.
+
+## Preconditions
+
+Before creating the version PR:
+
+1. All v1 release-prep blockers are merged or have explicit accepted
+   exceptions.
+2. `main` is current and green in CI.
+3. No old release-blocking stack is still open underneath the stable branch.
+4. The stable release doctrine ADR exists and is accepted.
+5. Registry posture is known for every non-private public `@ontrails/*`
+   workspace:
+
+   ```bash
+   bun run publish:registry-check
+   ```
+
+6. The local package tarballs are clean:
+
+   ```bash
+   bun run publish:check
+   ```
+
+7. The Changesets release plan computes:
+
+   ```bash
+   bunx changeset status --verbose
+   ```
+
+8. No generated local SQLite artifacts are staged:
+
+   ```bash
+   git status --short -- .trails .trails-tmp
+   git status --short -- .trails/trails.db .trails/trails.db-shm .trails/trails.db-wal
+   ```
+
+9. The ADR and docs checks pass:
+
+   ```bash
+   bun scripts/adr.ts map
+   bun scripts/adr.ts check
+   bun run format:check
+   ```
+
+If any precondition fails, stop and fix that issue in its own branch before
+starting the stable version PR.
+
+## Version PR
+
+Start from clean, synced `main`:
+
+```bash
+gt sync
+gt checkout main
+git status --short --branch
+```
+
+Create a dedicated branch:
+
+```bash
+gt create chore/version-packages-for-1-0-0 --no-interactive
+```
+
+Run the pre-version checks:
+
+```bash
+bun scripts/adr.ts map
+bun scripts/adr.ts check
+bun run check
+bun run build
+bun run publish:check
+bun run publish:registry-check
+bunx changeset status --verbose
+```
+
+Run a registry-backed generated-app smoke before exiting prerelease mode. This
+proves the current published prerelease package set and the generator still agree:
+
+```bash
+tmp=$(mktemp -d /tmp/trails-preversion-smoke.XXXXXX)
+cache=$(mktemp -d /tmp/bun-cache-preversion.XXXXXX)
+
+bun apps/trails/bin/trails.ts create docs-smoke \
+  --dir "$tmp" \
+  --surfaces cli mcp http \
+  --verify \
+  --output json
+
+(
+  cd "$tmp/docs-smoke"
+  BUN_INSTALL_CACHE_DIR="$cache" bun install
+  bun run typecheck
+  bun test
+)
+```
+
+Exit prerelease mode and compute the stable versions:
+
+```bash
+bunx changeset pre exit
+bunx changeset version
+```
+
+Review the generated diff before committing:
+
+```bash
+git diff -- .changeset package.json bun.lock packages adapters apps docs
+```
+
+Expected outcomes:
+
+- `.changeset/pre.json` leaves prerelease mode or is removed/rewritten by
+  Changesets according to its stable-exit behavior.
+- All public non-private `@ontrails/*` packages land on the same stable
+  version.
+- Internal package ranges pack without unresolved `workspace:` or `catalog:`
+  ranges.
+- Changelogs and release notes stop describing the release as beta.
+- Generated app dependency ranges point at the intended stable package versions.
+  The post-publish smoke below proves those stable ranges are installable from
+  the registry after publication.
+
+Run the full version-PR gate:
+
+```bash
+bun scripts/adr.ts map
+bun scripts/adr.ts check
+bun run typecheck
+bun run test
+bun run lint
+bun run lint:ast-grep
+bun run build
+bun run format:check
+bun run check
+bun run dead-code
+bun run publish:check
+bun run publish:registry-check
+git diff --check
+```
+
+Generate a fresh app outside the monorepo and inspect its package ranges:
+
+```bash
+tmp=$(mktemp -d /tmp/trails-stable-smoke.XXXXXX)
+
+bun apps/trails/bin/trails.ts create docs-smoke \
+  --dir "$tmp" \
+  --surfaces cli mcp http \
+  --verify \
+  --output json
+```
+
+Do not run the install-backed registry smoke on the version PR branch after
+`bunx changeset version`. At that point generated apps request the intended
+stable range, but the stable packages are not on the public registry until the
+version PR merges and the publish step completes.
+
+Capture the generated `package.json` dependency ranges in the PR body. Remove
+the temp project after recording the evidence.
+
+Commit and submit:
+
+```bash
+git branch --show-current
+gt modify -a -c -m "chore: version packages for 1.0.0" --no-interactive
+gt submit --draft --stack --no-edit --no-interactive
+```
+
+Keep the PR draft until CI is green and review is complete. The PR body should
+include:
+
+- link to ADR-0047;
+- the intended stable version;
+- `bunx changeset status --verbose` summary;
+- `bun run publish:check` result;
+- `bun run publish:registry-check` result;
+- pre-version fresh-start generated-app smoke evidence;
+- generated stable dependency range evidence from the post-version scaffold;
+- a statement that no publish command was run from the PR branch.
+
+## Publish After Merge
+
+Only publish after the version PR has merged.
+
+Start from clean, synced `main`:
+
+```bash
+gt sync
+gt checkout main
+git status --short --branch
+```
+
+Confirm `main` contains the merged version commit and CI is green.
+
+Run final local pre-publish checks:
+
+```bash
+bun run publish:check
+bun run publish:registry-check
+```
+
+Publish with the repo script:
+
+```bash
+bun run publish:packages
+```
+
+The publish script discovers non-private workspaces, topo-sorts by workspace
+dependency edges, runs `bun publish --access public --tag <tag>`, and uses
+`latest` outside Changesets prerelease mode.
+
+Do not replace this with `npm publish`. Do not run `changeset publish`.
+
+## Post-Publish Verification
+
+After publish, require every public package and expected dist-tag to be visible:
+
+```bash
+bun run publish:registry-check:published
+```
+
+Spot-check representative packages directly when debugging:
+
+```bash
+npm view @ontrails/core version --json
+npm view @ontrails/core dist-tags --json
+npm view @ontrails/commander version --json
+npm view @ontrails/commander dist-tags --json
+```
+
+Then rerun the fresh generated-app smoke from a clean cache so the proof comes
+from the registry, not local workspace links:
+
+```bash
+tmp=$(mktemp -d /tmp/trails-stable-smoke.XXXXXX)
+cache=$(mktemp -d /tmp/bun-cache-stable.XXXXXX)
+
+bun apps/trails/bin/trails.ts create docs-smoke \
+  --dir "$tmp" \
+  --surfaces cli mcp http \
+  --verify \
+  --output json
+
+(
+  cd "$tmp/docs-smoke"
+  BUN_INSTALL_CACHE_DIR="$cache" bun install
+  bun run typecheck
+  bun test
+)
+```
+
+Record:
+
+- generated `@ontrails/*` dependency ranges;
+- selected `@ontrails/*` versions in `bun.lock`;
+- `bun run typecheck` result;
+- `bun test` result;
+- final registry/dist-tag check result.
+
+## Partial-Publish Recovery
+
+If `bun run publish:packages` fails after publishing one or more packages,
+stop immediately.
+
+Create a release incident note with:
+
+- exact command;
+- failure output;
+- intended version and dist-tag;
+- packages already published at that version;
+- package that failed;
+- package that should publish next;
+- selected resume set.
+
+Verify already-published packages before retrying:
+
+```bash
+bun run publish:registry-check:published
+```
+
+If that check fails because the release is incomplete, use targeted read-only
+registry probes for the packages already reported as published. Do not mutate
+dist-tags to hide an incomplete release.
+
+Resume only with an explicit package set after confirming which packages are
+already present:
+
+```bash
+bun run publish:packages -- --only @ontrails/package-a,@ontrails/package-b
+```
+
+Rerun the full post-publish verification after the resume completes.
+
+## Stable Release Completion
+
+The stable release is complete only when:
+
+- the version PR has merged;
+- `bun run publish:packages` completed or a documented partial-publish resume
+  completed;
+- `bun run publish:registry-check:published` passes;
+- fresh generated-app install, typecheck, and tests pass from a clean cache;
+- release notes and package changelogs reflect the stable release;
+- no generated `.trails` or `.trails-tmp` runtime state is staged;
+- the release issue or project update links to the final evidence.


### PR DESCRIPTION
## Context

The stable cutover needs a concrete operator runbook that follows ADR-0047 and the new registry preflight posture without reintroducing `changeset publish` or ad-hoc npm publishing.

## What Changed

- Added `docs/releases/stable-cutover.md`.
- Linked the runbook from the docs index and project guidance.
- Documented version PR, post-merge publish, registry verification, clean-cache generated-app smoke, and partial-publish recovery steps.

## How To Test

- `bun run publish:check`
- `bun scripts/adr.ts check`
- `bun run format:check`
- `git diff --check`

## Risks / Rollout Notes

Documentation only. The runbook intentionally keeps actual publishing as an explicit operator action outside this PR.