### PR TITLE
feat: add http testing harness

### DIFF
--- a/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
+++ b/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
@@ -47,7 +47,7 @@ before handoff or merge readiness.
 | 6 | `TRL-709` | `trl-709-add-markdown-link-integrity-check-for-docs-and-readmes` | TBD | Focused checks passed |
 | 7 | `TRL-708` | `trl-708-expand-readme-typescript-snippet-verification-beyond-tracing` | TBD | Focused checks passed |
 | 8 | `TRL-710` | `trl-710-create-public-api-example-coverage-inventory-and-gate` | TBD | Focused checks passed |
-| 9 | `TRL-704` | `trl-704-add-http-surface-harness-and-include-it-in` | TBD | Not started |
+| 9 | `TRL-704` | `trl-704-add-http-surface-harness-and-include-it-in` | TBD | Focused checks passed |
 | 10 | `TRL-706` | `trl-706-expose-complete-shipped-surface-projection-inventory-for` | TBD | Not started |
 | 11 | `TRL-705` | `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | TBD | Not started |
 
@@ -72,6 +72,7 @@ issues created or updated during execution.
 | `TRL-709` | Changed status to `In Progress`. | Branch execution started. |
 | `TRL-708` | Changed status to `In Progress`. | Branch execution started. |
 | `TRL-710` | Changed status to `In Progress`. | Branch execution started. |
+| `TRL-704` | Changed status to `In Progress`. | Branch execution started. |
 
 ## Local Review Reports
 
@@ -223,6 +224,15 @@ ready waves, and remote review turns here.
   entrypoints and wired `bun run docs:api-examples` into `bun run check`.
   Remaining non-minimum missing examples are reported in the script output and
   recorded as residual inventory in this retro.
+- 2026-05-13T16:54Z: Started `TRL-704` on
+  `trl-704-add-http-surface-harness-and-include-it-in` and added a
+  framework-agnostic `createHttpHarness` to `@ontrails/testing`. The harness
+  derives HTTP routes from an established topo, executes read/write trails with
+  query or body input, projects public HTTP error envelopes, supports test
+  resource overrides, and is now included in `testAllEstablished` as the HTTP
+  projection validation alongside CLI and MCP. Updated testing docs, the
+  package README, peer metadata, the README snippet checker stub, and a
+  branch-local `@ontrails/testing` changeset.
 
 ## Verification Log
 
@@ -280,6 +290,15 @@ Record focused branch checks and full tip gate results here.
 | `trl-710-create-public-api-example-coverage-inventory-and-gate` | `bun run typecheck` | Passed. |
 | `trl-710-create-public-api-example-coverage-inventory-and-gate` | `bun run check` | Passed; includes the new `docs:api-examples` check alongside lint, ast-grep, vocab audit, format, typecheck, docs link/snippet checks, scaffold checks, Warden, and dead-code gate. |
 | `trl-710-create-public-api-example-coverage-inventory-and-gate` | `git diff --check` | Passed. |
+| `trl-704-add-http-surface-harness-and-include-it-in` | `bun test packages/testing/src/__tests__/harness-http.test.ts` | Passed, 4 tests and 11 assertions. |
+| `trl-704-add-http-surface-harness-and-include-it-in` | `bun test packages/testing/src/__tests__/all.test.ts --bail` | Passed, 12 tests and 24 assertions. |
+| `trl-704-add-http-surface-harness-and-include-it-in` | `bun run --cwd packages/testing typecheck` | Passed. |
+| `trl-704-add-http-surface-harness-and-include-it-in` | `bun test packages/testing` | Passed, 157 tests and 304 assertions. |
+| `trl-704-add-http-surface-harness-and-include-it-in` | `bun run docs:snippets` | Passed; checked all 21 package/app/adapter READMEs, including 92 TypeScript snippets and 3 explicit no-TypeScript-snippet classifications. |
+| `trl-704-add-http-surface-harness-and-include-it-in` | `bun run format:check` | Passed. |
+| `trl-704-add-http-surface-harness-and-include-it-in` | `bun run check` | Passed; includes lint, ast-grep, vocab audit, format, typecheck, docs link/snippet/API example checks, scaffold checks, Warden, and dead-code gate. |
+| `trl-704-add-http-surface-harness-and-include-it-in` | `bun scripts/check-changeset-gate.ts --changed-files <(git diff --cached --name-only)` | Passed for `@ontrails/testing` with `.changeset/soft-http-harness.md`. |
+| `trl-704-add-http-surface-harness-and-include-it-in` | `git diff --check` | Passed. |
 
 ## Review Feedback
 

--- a/.changeset/soft-http-harness.md
+++ b/.changeset/soft-http-harness.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/testing": patch
+---
+
+Add an HTTP surface harness and include HTTP projection validation in `testAllEstablished`.

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "adapters/commander": {
       "name": "@ontrails/commander",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "dependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
@@ -38,7 +38,7 @@
     },
     "adapters/drizzle": {
       "name": "@ontrails/drizzle",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "drizzle-orm": "^0.45.2",
@@ -50,7 +50,7 @@
     },
     "adapters/hono": {
       "name": "@ontrails/hono",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "hono": "^4.7.0",
@@ -62,7 +62,7 @@
     },
     "adapters/vite": {
       "name": "@ontrails/vite",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "devDependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/hono": "workspace:^",
@@ -71,7 +71,7 @@
     },
     "apps/trails": {
       "name": "@ontrails/trails",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "bin": {
         "trails": "./bin/trails.ts",
       },
@@ -117,7 +117,7 @@
     },
     "packages/cli": {
       "name": "@ontrails/cli",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -127,7 +127,7 @@
     },
     "packages/config": {
       "name": "@ontrails/config",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -135,14 +135,14 @@
     },
     "packages/core": {
       "name": "@ontrails/core",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "peerDependencies": {
         "zod": "catalog:",
       },
     },
     "packages/http": {
       "name": "@ontrails/http",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -152,14 +152,14 @@
     },
     "packages/logtape": {
       "name": "@ontrails/logtape",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "peerDependencies": {
         "@ontrails/observe": "workspace:^",
       },
     },
     "packages/mcp": {
       "name": "@ontrails/mcp",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -170,21 +170,21 @@
     },
     "packages/observe": {
       "name": "@ontrails/observe",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
       },
     },
     "packages/oxlint-plugin": {
       "name": "@ontrails/oxlint-plugin",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "dependencies": {
         "@oxlint/plugins": "1.62.0",
       },
     },
     "packages/permits": {
       "name": "@ontrails/permits",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -192,7 +192,7 @@
     },
     "packages/store": {
       "name": "@ontrails/store",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -202,7 +202,7 @@
     },
     "packages/testing": {
       "name": "@ontrails/testing",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "devDependencies": {
         "@ontrails/drizzle": "workspace:^",
         "@ontrails/store": "workspace:^",
@@ -210,6 +210,7 @@
       "peerDependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
+        "@ontrails/http": "workspace:^",
         "@ontrails/mcp": "workspace:^",
         "@ontrails/observe": "workspace:^",
         "zod": "catalog:",
@@ -217,7 +218,7 @@
     },
     "packages/topographer": {
       "name": "@ontrails/topographer",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -225,7 +226,7 @@
     },
     "packages/tracing": {
       "name": "@ontrails/tracing",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -233,7 +234,7 @@
     },
     "packages/warden": {
       "name": "@ontrails/warden",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "bin": {
         "warden": "./bin/warden.ts",
       },
@@ -256,7 +257,7 @@
     },
     "packages/wayfinder": {
       "name": "@ontrails/wayfinder",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/topographer": "workspace:^",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -373,6 +373,20 @@ const result = await harness.callTool('myapp_entity_show', { name: 'Alpha' });
 expect(result.isError).toBe(false);
 ```
 
+### HTTP Harness
+
+Execute derived HTTP routes in-process without Hono or a listening server:
+
+```typescript
+import { createHttpHarness } from '@ontrails/testing';
+
+const harness = createHttpHarness({ graph });
+const result = await harness.get('/entity/show', { name: 'Alpha' });
+
+expect(result.status).toBe(200);
+expect(result.data).toMatchObject({ name: 'Alpha' });
+```
+
 ## Testing with Infrastructure Resources
 
 The config, permits, and tracing packages each provide test-friendly primitives that work with `testAll(graph)` and `testExamples(graph)` without external dependencies.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -37,6 +37,7 @@ testDetours(graph);    // Validate detour constructor, recover, and ordering sem
 | `createTestLogger()` | Logger that captures entries in memory for assertions |
 | `createCliHarness(options)` | Execute CLI commands in-process, capture stdout/stderr |
 | `createMcpHarness(options)` | Invoke MCP tools directly without transport |
+| `createHttpHarness(options)` | Execute HTTP route projections in-process without a server |
 
 See the [API Reference](../../docs/api-reference.md) for the full list.
 
@@ -89,7 +90,11 @@ Calls to unregistered trail IDs return `Result.err` with a descriptive message, 
 ## Surface Harnesses
 
 ```typescript
-import { createCliHarness, createMcpHarness } from '@ontrails/testing';
+import {
+  createCliHarness,
+  createHttpHarness,
+  createMcpHarness,
+} from '@ontrails/testing';
 
 // CLI
 const cli = createCliHarness({ graph });
@@ -100,6 +105,11 @@ expect(result.exitCode).toBe(0);
 const mcp = createMcpHarness({ graph });
 const tool = await mcp.callTool('myapp_entity_show', { name: 'Alpha' });
 expect(tool.isError).toBe(false);
+
+// HTTP
+const http = createHttpHarness({ graph });
+const response = await http.get('/entity/show', { name: 'Alpha' });
+expect(response.status).toBe(200);
 ```
 
 ## Installation

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -28,6 +28,7 @@
   "peerDependencies": {
     "@ontrails/cli": "workspace:^",
     "@ontrails/core": "workspace:^",
+    "@ontrails/http": "workspace:^",
     "@ontrails/mcp": "workspace:^",
     "@ontrails/observe": "workspace:^",
     "zod": "catalog:"

--- a/packages/testing/src/__tests__/all.test.ts
+++ b/packages/testing/src/__tests__/all.test.ts
@@ -199,6 +199,55 @@ ${helperName}(topo('draft-topo', { draftTrail }));
   }
 };
 
+const runGeneratedEstablishedSuite = (): {
+  readonly exitCode: number;
+  readonly output: string;
+} => {
+  const dir = repoTempDir();
+  const testFile = join(dir, 'testAllEstablished-surfaces.test.ts');
+
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    testFile,
+    `import { Result, trail, topo } from '@ontrails/core';
+import { testAllEstablished } from '../../src/index.ts';
+import { z } from 'zod';
+
+const show = trail('entity.show', {
+  blaze: async (input) => Result.ok({ name: input.name }),
+  examples: [
+    {
+      expected: { name: 'Alpha' },
+      input: { name: 'Alpha' },
+      name: 'Show Alpha',
+    },
+  ],
+  input: z.object({ name: z.string() }),
+  intent: 'read',
+  output: z.object({ name: z.string() }),
+});
+
+testAllEstablished(topo('established-topo', { show }));
+`
+  );
+
+  try {
+    const proc = Bun.spawnSync({
+      cmd: ['bun', 'test', testFile],
+      cwd: resolve(import.meta.dir, '..', '..', '..'),
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
+
+    return {
+      exitCode: proc.exitCode,
+      output: `${proc.stdout.toString()}\n${proc.stderr.toString()}`,
+    };
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+};
+
 describe('testAll resource mocks', () => {
   // eslint-disable-next-line jest/require-hook
   testAll(
@@ -250,5 +299,20 @@ describe('testAllEstablished draft hygiene', () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('_draft.entity.prepare');
+  });
+
+  test('includes CLI, MCP, and HTTP surface projection checks', () => {
+    const result = runGeneratedEstablishedSuite();
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(
+      'CLI projection validates established topo'
+    );
+    expect(result.output).toContain(
+      'MCP projection validates established topo'
+    );
+    expect(result.output).toContain(
+      'HTTP projection validates established topo'
+    );
   });
 });

--- a/packages/testing/src/__tests__/harness-http.test.ts
+++ b/packages/testing/src/__tests__/harness-http.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resource, Result, topo, trail, webhook } from '@ontrails/core';
+import { z } from 'zod';
+
+import { createHttpHarness } from '../harness-http.js';
+
+describe('createHttpHarness', () => {
+  test('executes read trails through query input', async () => {
+    const show = trail('entity.show', {
+      blaze: (input: { name: string }) =>
+        Result.ok({ greeting: `Hello, ${input.name}!` }),
+      input: z.object({ name: z.string() }),
+      intent: 'read',
+      output: z.object({ greeting: z.string() }),
+    });
+    const harness = createHttpHarness({
+      graph: topo('test-app', { show }),
+    });
+
+    const result = await harness.get('/entity/show', { name: 'Trails' });
+
+    expect(result.status).toBe(200);
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({ greeting: 'Hello, Trails!' });
+    expect(result.body).toEqual({ data: { greeting: 'Hello, Trails!' } });
+  });
+
+  test('executes write trails through body input', async () => {
+    const create = trail('entity.create', {
+      blaze: (input: { name: string }) => Result.ok({ id: '1', ...input }),
+      input: z.object({ name: z.string() }),
+      intent: 'write',
+      output: z.object({ id: z.string(), name: z.string() }),
+    });
+    const harness = createHttpHarness({
+      graph: topo('test-app', { create }),
+    });
+
+    const result = await harness.post('/entity/create', { name: 'Alpha' });
+
+    expect(result.status).toBe(200);
+    expect(result.data).toEqual({ id: '1', name: 'Alpha' });
+  });
+
+  test('does not treat non-webhook body input as a parse Result', async () => {
+    const create = trail('entity.create', {
+      blaze: (input: { isErr: boolean; name: string }) => Result.ok(input),
+      input: z.object({ isErr: z.boolean(), name: z.string() }),
+      intent: 'write',
+      output: z.object({ isErr: z.boolean(), name: z.string() }),
+    });
+    const harness = createHttpHarness({
+      graph: topo('test-app', { create }),
+    });
+
+    const result = await harness.post('/entity/create', {
+      isErr: false,
+      name: 'Alpha',
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data).toEqual({ isErr: false, name: 'Alpha' });
+  });
+
+  test('executes PATCH webhook routes through the convenience helper', async () => {
+    const source = webhook('webhook.payment.received', {
+      method: 'PATCH',
+      parse: z.object({ paymentId: z.string() }),
+      path: '/webhooks/payment',
+    });
+    const receiver = trail('payment.receive', {
+      blaze: (input: { paymentId: string }) => Result.ok(input),
+      input: z.object({ paymentId: z.string() }),
+      on: [source],
+      output: z.object({ paymentId: z.string() }),
+    });
+    const harness = createHttpHarness({
+      graph: topo('test-app', { receiver }),
+    });
+
+    const result = await harness.patch('/webhooks/payment', {
+      paymentId: 'pay_1',
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.data).toEqual({ paymentId: 'pay_1' });
+  });
+
+  test('maps validation errors to the HTTP error envelope', async () => {
+    const show = trail('entity.show', {
+      blaze: (input: { name: string }) => Result.ok({ name: input.name }),
+      input: z.object({ name: z.string() }),
+      intent: 'read',
+      output: z.object({ name: z.string() }),
+    });
+    const harness = createHttpHarness({
+      graph: topo('test-app', { show }),
+    });
+
+    const result = await harness.get('/entity/show');
+
+    expect(result.status).toBe(400);
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('ValidationError');
+  });
+
+  test('threads resource overrides through HTTP projection options', async () => {
+    const dbResource = resource('db.main', {
+      create: () => Result.ok({ source: 'factory' }),
+    });
+    const readResource = trail('resource.read', {
+      blaze: (_input, ctx) =>
+        Result.ok({ source: dbResource.from(ctx).source as string }),
+      input: z.object({}),
+      intent: 'read',
+      output: z.object({ source: z.string() }),
+      resources: [dbResource],
+    });
+    const harness = createHttpHarness({
+      graph: topo('test-app', { dbResource, readResource }),
+      resources: {
+        'db.main': { source: 'override' },
+      },
+    });
+
+    const result = await harness.get('/resource/read');
+
+    expect(result.status).toBe(200);
+    expect(result.data).toEqual({ source: 'override' });
+  });
+});

--- a/packages/testing/src/all.ts
+++ b/packages/testing/src/all.ts
@@ -11,6 +11,7 @@ import type { Topo, TrailContext } from '@ontrails/core';
 import { validateEstablishedTopo, validateTopo } from '@ontrails/core';
 
 import { createCliHarness } from './harness-cli.js';
+import { createHttpHarness } from './harness-http.js';
 import { createMcpHarness } from './harness-mcp.js';
 import { testContracts } from './contracts.js';
 import type { TestExecutionOptions } from './context.js';
@@ -108,6 +109,7 @@ const isEstablishedOptions = (
   (Object.hasOwn(input, 'cli') ||
     Object.hasOwn(input, 'createPermit') ||
     Object.hasOwn(input, 'ctx') ||
+    Object.hasOwn(input, 'http') ||
     Object.hasOwn(input, 'mcp') ||
     Object.hasOwn(input, 'resources') ||
     Object.hasOwn(input, 'strictPermits'));
@@ -154,6 +156,22 @@ const toMcpHarnessOptions = (
   ...options.mcp,
 });
 
+const toHttpHarnessOptions = (
+  topo: Topo,
+  options: TestAllEstablishedOptions
+) => {
+  const httpOptions = {
+    graph: topo,
+    ...options.http,
+  };
+
+  if (options.ctx !== undefined) {
+    httpOptions.ctx = options.ctx;
+  }
+
+  return httpOptions;
+};
+
 const registerEstablishedSurfaceSuite = (
   topo: Topo,
   resolveInput: () =>
@@ -173,6 +191,13 @@ const registerEstablishedSurfaceSuite = (
       const options = normalizeEstablishedOptions(resolveInput());
       expect(() =>
         createMcpHarness(toMcpHarnessOptions(topo, options))
+      ).not.toThrow();
+    });
+
+    test('HTTP projection validates established topo', () => {
+      const options = normalizeEstablishedOptions(resolveInput());
+      expect(() =>
+        createHttpHarness(toHttpHarnessOptions(topo, options))
       ).not.toThrow();
     });
   });

--- a/packages/testing/src/harness-http.ts
+++ b/packages/testing/src/harness-http.ts
@@ -1,0 +1,263 @@
+/**
+ * HTTP integration test harness.
+ *
+ * Builds framework-agnostic HTTP routes from a graph and executes them
+ * directly, without Hono or a listening server.
+ */
+
+import { deriveHttpRoutes } from '@ontrails/http';
+import type { HttpMethod, HttpRouteDefinition } from '@ontrails/http';
+import type { TrailContext, TrailContextInit } from '@ontrails/core';
+import { NotFoundError, projectPublicSurfaceError } from '@ontrails/core';
+
+import { mergeTestContext } from './context.js';
+import type {
+  HttpHarness,
+  HttpHarnessOptions,
+  HttpHarnessRequest,
+  HttpHarnessRequestOptions,
+  HttpHarnessResult,
+} from './types.js';
+
+const TEST_ORIGIN = 'http://ontrails.test';
+
+const normalizeMethod = (method: HttpMethod): HttpMethod =>
+  method.toUpperCase() as HttpMethod;
+
+const collectQueryParams = (url: URL): Record<string, unknown> => {
+  const query: Record<string, unknown> = {};
+  const seen = new Set<string>();
+
+  for (const key of url.searchParams.keys()) {
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const values = url.searchParams.getAll(key);
+    query[key] = values.length > 1 ? values : values[0];
+  }
+
+  return query;
+};
+
+const findRoute = (
+  routes: readonly HttpRouteDefinition[],
+  method: HttpMethod,
+  path: string
+): HttpRouteDefinition | undefined =>
+  routes.find((route) => route.method === method && route.path === path);
+
+const mapError = (error: Error): HttpHarnessResult => {
+  const projection = projectPublicSurfaceError('http', error);
+  const body = {
+    error: {
+      category: projection.category,
+      code: projection.name,
+      message: projection.message,
+    },
+  };
+  return {
+    body,
+    error: body.error,
+    ok: false,
+    status: projection.code,
+  };
+};
+
+const mapSuccess = (data: unknown): HttpHarnessResult => ({
+  body: { data },
+  data,
+  ok: true,
+  status: 200,
+});
+
+const isWebhookParseResult = (
+  input: unknown
+): input is {
+  readonly error?: Error | undefined;
+  isErr(): boolean;
+  readonly value?: unknown | undefined;
+} =>
+  typeof input === 'object' &&
+  input !== null &&
+  'isErr' in input &&
+  typeof input.isErr === 'function';
+
+const mergeContextInit = (
+  base: TrailContextInit | undefined,
+  ctx: Partial<TrailContext> | undefined
+): TrailContextInit => ({
+  ...base,
+  ...mergeTestContext({ ...base, ...ctx }),
+});
+
+const createHarnessContextFactory = (
+  options: HttpHarnessOptions
+): (() => TrailContextInit | Promise<TrailContextInit>) => {
+  const { createContext, ctx } = options;
+  return async () => {
+    const base = await createContext?.();
+    return mergeContextInit(base, ctx);
+  };
+};
+
+const buildInput = (
+  route: HttpRouteDefinition,
+  url: URL,
+  request: HttpHarnessRequest
+): unknown => {
+  if (route.inputSource === 'query') {
+    return {
+      ...collectQueryParams(url),
+      ...request.query,
+    };
+  }
+  return request.body ?? {};
+};
+
+const executeRouteWithInput = async (
+  route: HttpRouteDefinition,
+  input: unknown,
+  request: HttpHarnessRequest
+): Promise<HttpHarnessResult> => {
+  const result = await route.execute(
+    input,
+    request.requestId,
+    request.abortSignal,
+    { headers: request.headers }
+  );
+
+  if (result.isErr()) {
+    return mapError(result.error);
+  }
+
+  return mapSuccess(result.value);
+};
+
+const executeRoute = async (
+  route: HttpRouteDefinition,
+  url: URL,
+  request: HttpHarnessRequest
+): Promise<HttpHarnessResult> => {
+  const parsedInput = buildInput(route, url, request);
+  if (route.inputSource === 'webhook' && route.parseWebhookInput) {
+    const parsed = route.parseWebhookInput(parsedInput);
+    if (isWebhookParseResult(parsed)) {
+      if (parsed.isErr()) {
+        return mapError(parsed.error ?? new Error('Invalid webhook input'));
+      }
+      return await executeRouteWithInput(route, parsed.value, request);
+    }
+    return await executeRouteWithInput(route, parsed, request);
+  }
+
+  return await executeRouteWithInput(route, parsedInput, request);
+};
+
+// ---------------------------------------------------------------------------
+// createHttpHarness
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an HTTP harness for integration testing.
+ *
+ * @example
+ * ```ts
+ * import { createHttpHarness } from '@ontrails/testing';
+ *
+ * const http = createHttpHarness({ graph });
+ * const result = await http.get('/entity/show', { name: 'Alpha' });
+ * expect(result.status).toBe(200);
+ * ```
+ */
+export const createHttpHarness = (
+  harnessOptions: HttpHarnessOptions
+): HttpHarness => {
+  const { ctx: _ctx, graph, ...deriveOptions } = harnessOptions;
+  const routesResult = deriveHttpRoutes(graph, {
+    ...deriveOptions,
+    createContext: createHarnessContextFactory(harnessOptions),
+  });
+  if (routesResult.isErr()) {
+    throw routesResult.error;
+  }
+  const routes = routesResult.value;
+
+  const request = async (
+    rawRequest: HttpHarnessRequest
+  ): Promise<HttpHarnessResult> => {
+    const method = normalizeMethod(rawRequest.method);
+    const url = new URL(rawRequest.path, TEST_ORIGIN);
+    const route = findRoute(routes, method, url.pathname);
+
+    if (!route) {
+      return mapError(
+        new NotFoundError(`No HTTP route found for ${method} ${url.pathname}`)
+      );
+    }
+
+    return await executeRoute(route, url, { ...rawRequest, method });
+  };
+
+  return {
+    delete: async (
+      path: string,
+      body?: unknown,
+      requestOptions?: HttpHarnessRequestOptions
+    ) =>
+      await request({
+        ...requestOptions,
+        body,
+        method: 'DELETE',
+        path,
+      }),
+    get: async (
+      path: string,
+      query?: Record<string, unknown>,
+      requestOptions?: HttpHarnessRequestOptions
+    ) =>
+      await request({
+        ...requestOptions,
+        method: 'GET',
+        path,
+        query: {
+          ...requestOptions?.query,
+          ...query,
+        },
+      }),
+    patch: async (
+      path: string,
+      body?: unknown,
+      requestOptions?: HttpHarnessRequestOptions
+    ) =>
+      await request({
+        ...requestOptions,
+        body,
+        method: 'PATCH',
+        path,
+      }),
+    post: async (
+      path: string,
+      body?: unknown,
+      requestOptions?: HttpHarnessRequestOptions
+    ) =>
+      await request({
+        ...requestOptions,
+        body,
+        method: 'POST',
+        path,
+      }),
+    put: async (
+      path: string,
+      body?: unknown,
+      requestOptions?: HttpHarnessRequestOptions
+    ) =>
+      await request({
+        ...requestOptions,
+        body,
+        method: 'PUT',
+        path,
+      }),
+    request,
+  };
+};

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -32,6 +32,7 @@ export { createTestLogger } from './logger.js';
 
 // Surface harnesses
 export { createCliHarness } from './harness-cli.js';
+export { createHttpHarness } from './harness-http.js';
 export { createMcpHarness } from './harness-mcp.js';
 
 // Types
@@ -54,6 +55,13 @@ export type {
   CliHarness,
   CliHarnessOptions,
   CliHarnessResult,
+  HttpHarness,
+  HttpHarnessErrorBody,
+  HttpHarnessOptions,
+  HttpHarnessRequest,
+  HttpHarnessRequestOptions,
+  HttpHarnessResult,
+  HttpHarnessSuccessBody,
   McpHarness,
   McpHarnessOptions,
   McpHarnessResult,

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -3,6 +3,11 @@
  */
 
 import type { DeriveCliCommandsOptions } from '@ontrails/cli';
+import type {
+  DeriveHttpRoutesOptions,
+  HttpHeaderSource,
+  HttpMethod,
+} from '@ontrails/http';
 import type { McpExtra, DeriveMcpToolsOptions } from '@ontrails/mcp';
 import type {
   AnyTrail,
@@ -131,6 +136,90 @@ export interface McpHarnessResult {
 }
 
 // ---------------------------------------------------------------------------
+// HTTP Harness
+// ---------------------------------------------------------------------------
+
+/** Options for creating an HTTP harness. */
+export interface HttpHarnessOptions extends DeriveHttpRoutesOptions {
+  readonly ctx?: Partial<TrailContext> | undefined;
+  readonly graph: Topo;
+}
+
+export interface HttpHarnessRequest {
+  readonly abortSignal?: AbortSignal | undefined;
+  readonly body?: unknown | undefined;
+  readonly headers?: HttpHeaderSource | undefined;
+  readonly method: HttpMethod;
+  readonly path: string;
+  readonly query?: Record<string, unknown> | undefined;
+  readonly requestId?: string | undefined;
+}
+
+export interface HttpHarnessRequestOptions extends Omit<
+  HttpHarnessRequest,
+  'body' | 'method' | 'path' | 'query'
+> {
+  readonly query?: Record<string, unknown> | undefined;
+}
+
+/** A test harness for HTTP route projections. */
+export interface HttpHarness {
+  /** Execute a raw HTTP-style harness request. */
+  request(request: HttpHarnessRequest): Promise<HttpHarnessResult>;
+  /** Execute a GET request, reading input from query params. */
+  get(
+    path: string,
+    query?: Record<string, unknown>,
+    options?: HttpHarnessRequestOptions
+  ): Promise<HttpHarnessResult>;
+  /** Execute a POST request, reading input from the JSON-like body value. */
+  post(
+    path: string,
+    body?: unknown,
+    options?: HttpHarnessRequestOptions
+  ): Promise<HttpHarnessResult>;
+  /** Execute a PUT request. */
+  put(
+    path: string,
+    body?: unknown,
+    options?: HttpHarnessRequestOptions
+  ): Promise<HttpHarnessResult>;
+  /** Execute a PATCH request. */
+  patch(
+    path: string,
+    body?: unknown,
+    options?: HttpHarnessRequestOptions
+  ): Promise<HttpHarnessResult>;
+  /** Execute a DELETE request. */
+  delete(
+    path: string,
+    body?: unknown,
+    options?: HttpHarnessRequestOptions
+  ): Promise<HttpHarnessResult>;
+}
+
+export interface HttpHarnessErrorBody {
+  readonly error: {
+    readonly category: string;
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+export interface HttpHarnessSuccessBody {
+  readonly data: unknown;
+}
+
+/** The result of an HTTP harness request. */
+export interface HttpHarnessResult {
+  readonly body: HttpHarnessErrorBody | HttpHarnessSuccessBody;
+  readonly data?: unknown | undefined;
+  readonly error?: HttpHarnessErrorBody['error'] | undefined;
+  readonly ok: boolean;
+  readonly status: number;
+}
+
+// ---------------------------------------------------------------------------
 // Established verification
 // ---------------------------------------------------------------------------
 
@@ -150,6 +239,7 @@ export interface TestAllEstablishedOptions {
         | undefined)
     | undefined;
   readonly ctx?: Partial<TrailContext> | undefined;
+  readonly http?: Omit<HttpHarnessOptions, 'graph'> | undefined;
   readonly mcp?: Omit<McpHarnessOptions, 'graph'> | undefined;
   readonly resources?: Record<string, unknown> | undefined;
   readonly strictPermits?: boolean | undefined;

--- a/scripts/check-readme-snippets.ts
+++ b/scripts/check-readme-snippets.ts
@@ -150,6 +150,7 @@ export const createConsoleSink: any;
 export const createCrossContext: any;
 export const createDevStore: any;
 export const createFileSink: any;
+export const createHttpHarness: any;
 export const createJwtAdapter: any;
 export const createLogtapeSink: any;
 export const createMcpHarness: any;


### PR DESCRIPTION
## Context

`@ontrails/testing` had first-party CLI and MCP harness coverage, but HTTP needed an equivalent projection harness before cross-surface parity could be made enforceable.

## What Changed

- Added `createHttpHarness` to `@ontrails/testing`.
- Included HTTP projection validation in `testAllEstablished`.
- Added HTTP harness tests and docs/README coverage.
- Updated peer metadata, README snippet stubs, lockfile state, and a branch-local changeset.

## How To Test

- `bun test packages/testing/src/__tests__/harness-http.test.ts`
- `bun test packages/testing/src/__tests__/all.test.ts --bail`
- `bun run --cwd packages/testing typecheck`
- `bun test packages/testing`
- `bun run docs:snippets`
- `bun run format:check`
- `bun run check`
- `git diff --check`

## Risks / Rollout Notes

The harness derives routes from established topo data and remains framework-agnostic; downstream users should verify custom HTTP surface conventions against their own apps.