### PR TITLE
feat: expose shipped surface inventory

### DIFF
--- a/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
+++ b/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
@@ -48,7 +48,7 @@ before handoff or merge readiness.
 | 7 | `TRL-708` | `trl-708-expand-readme-typescript-snippet-verification-beyond-tracing` | TBD | Focused checks passed |
 | 8 | `TRL-710` | `trl-710-create-public-api-example-coverage-inventory-and-gate` | TBD | Focused checks passed |
 | 9 | `TRL-704` | `trl-704-add-http-surface-harness-and-include-it-in` | TBD | Focused checks passed |
-| 10 | `TRL-706` | `trl-706-expose-complete-shipped-surface-projection-inventory-for` | TBD | Not started |
+| 10 | `TRL-706` | `trl-706-expose-complete-shipped-surface-projection-inventory-for` | TBD | Focused checks passed |
 | 11 | `TRL-705` | `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | TBD | Not started |
 
 ## Tracker Mutations
@@ -73,6 +73,7 @@ issues created or updated during execution.
 | `TRL-708` | Changed status to `In Progress`. | Branch execution started. |
 | `TRL-710` | Changed status to `In Progress`. | Branch execution started. |
 | `TRL-704` | Changed status to `In Progress`. | Branch execution started. |
+| `TRL-706` | Changed status to `In Progress`. | Branch execution started. |
 
 ## Local Review Reports
 
@@ -233,6 +234,16 @@ ready waves, and remote review turns here.
   projection validation alongside CLI and MCP. Updated testing docs, the
   package README, peer metadata, the README snippet checker stub, and a
   branch-local `@ontrails/testing` changeset.
+- 2026-05-13T17:07Z: Started `TRL-706` on
+  `trl-706-expose-complete-shipped-surface-projection-inventory-for` and added
+  a survey/report-time shipped surface inventory. The new helper keeps
+  `@ontrails/topographer`'s persisted `topo_surfaces` rows operational rather
+  than canonical, while app-level survey output now derives CLI command paths,
+  MCP tool names, and HTTP method/path projections for every surface-eligible
+  public trail. `survey.surfaces` exposes the inventory directly, trail detail
+  `surfaceProjections` now reports all shipped CLI/MCP/HTTP projections with
+  authored-vs-default provenance, and docs call out WebSocket as planned and
+  excluded until a public package/API exists.
 
 ## Verification Log
 
@@ -299,6 +310,16 @@ Record focused branch checks and full tip gate results here.
 | `trl-704-add-http-surface-harness-and-include-it-in` | `bun run check` | Passed; includes lint, ast-grep, vocab audit, format, typecheck, docs link/snippet/API example checks, scaffold checks, Warden, and dead-code gate. |
 | `trl-704-add-http-surface-harness-and-include-it-in` | `bun scripts/check-changeset-gate.ts --changed-files <(git diff --cached --name-only)` | Passed for `@ontrails/testing` with `.changeset/soft-http-harness.md`. |
 | `trl-704-add-http-surface-harness-and-include-it-in` | `git diff --check` | Passed. |
+| `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun test apps/trails/src/__tests__/survey.test.ts --bail` | Passed, 47 tests and 154 assertions. |
+| `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun run --cwd apps/trails typecheck` | Passed. |
+| `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun test packages/topographer` | Passed, 121 tests and 422 assertions. |
+| `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun run typecheck` | Passed; 21 packages. |
+| `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun run format:check` | Passed. |
+| `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun run docs:links` | Passed; checked 113 markdown files. |
+| `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `git diff --check` | Passed. |
+| `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun test apps/trails` | Passed, 381 tests and 1227 assertions. |
+| `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun scripts/check-changeset-gate.ts --changed-files <(git diff --cached --name-only)` | Passed for `@ontrails/trails` with `.changeset/bright-surface-inventory.md`. |
+| `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun run check` | Passed; includes lint, ast-grep, vocab audit, format, typecheck, docs link/snippet/API example checks, scaffold checks, Warden, and dead-code gate. |
 
 ## Review Feedback
 

--- a/.changeset/bright-surface-inventory.md
+++ b/.changeset/bright-surface-inventory.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Expose a shipped surface projection inventory through survey output and trail detail reports.

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -26,6 +26,8 @@
     "@ontrails/cli": "workspace:^",
     "@ontrails/commander": "workspace:^",
     "@ontrails/core": "workspace:^",
+    "@ontrails/http": "workspace:^",
+    "@ontrails/mcp": "workspace:^",
     "@ontrails/observe": "workspace:^",
     "@ontrails/permits": "workspace:^",
     "@ontrails/topographer": "workspace:^",

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -34,6 +34,7 @@ import { z } from 'zod';
 
 import {
   deriveBriefReport,
+  deriveShippedSurfaceProjectionInventory,
   deriveSignalDetail,
   deriveSurveyList,
   deriveTrailDetail,
@@ -41,6 +42,7 @@ import {
   surveyDiffTrail,
   surveyResourceTrail,
   surveySignalTrail,
+  surveySurfacesTrail,
   surveyTrail,
   surveyTrailDetailTrail,
 } from '../trails/survey.js';
@@ -50,10 +52,15 @@ import {
   buildCurrentTrailDetail,
   readSurfaceLayerNamesFromContext,
 } from '../trails/topo-read-support.js';
-import { trailDetailOutput } from '../trails/topo-output-schemas.js';
+import {
+  shippedSurfaceInventoryOutput,
+  surfaceProjectionOutput,
+  trailDetailOutput,
+} from '../trails/topo-output-schemas.js';
 import { topoCompileTrail } from '../trails/topo-compile.js';
 import type {
   BriefReport,
+  ShippedSurfaceInventoryReport,
   SignalDetailReport,
   SurveyListReport,
   TrailDetailReport,
@@ -376,6 +383,31 @@ describe('trails survey brief', () => {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+
+  test('survey.surfaces returns the shipped projection inventory directly', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+
+      const report = expectOk(
+        await surveySurfacesTrail.blaze({ module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      ) as ShippedSurfaceInventoryReport;
+
+      expect(report).toMatchObject({
+        count: 1,
+        shippedSurfaces: ['cli', 'mcp', 'http'],
+      });
+      expect(report.projections).toHaveLength(3);
+      expect(shippedSurfaceInventoryOutput.safeParse(report).success).toBe(
+        true
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });
 
 describe('trails survey detail', () => {
@@ -644,14 +676,7 @@ describe('trails survey detail', () => {
           scope: 'trail',
         },
       ],
-      surfaceProjections: [
-        {
-          derivedName: 'entity process',
-          method: null,
-          surface: 'cli',
-          trailId: 'entity.process',
-        },
-      ],
+      surfaceProjections: [],
       surfaces: [],
     });
     expect(detail.contourDetails).toEqual([
@@ -716,7 +741,7 @@ describe('trails survey detail', () => {
     ]);
   });
 
-  test('trail detail keeps non-CLI authored surfaces out of partial projection rows', () => {
+  test('trail detail reports complete shipped projections with authored provenance', () => {
     const httpVisible = trail('entity.http', {
       blaze: () => Result.ok({ ok: true }),
       input: z.object({}),
@@ -734,12 +759,118 @@ describe('trails survey detail', () => {
     expect(detail.surfaces).toEqual(['http']);
     expect(detail.surfaceProjections).toEqual([
       {
+        commandPath: ['entity', 'http'],
         derivedName: 'entity http',
         method: null,
+        source: 'default-derived',
         surface: 'cli',
         trailId: 'entity.http',
       },
+      {
+        derivedName: 'authored_surface_app_entity_http',
+        method: null,
+        source: 'default-derived',
+        surface: 'mcp',
+        toolName: 'authored_surface_app_entity_http',
+        trailId: 'entity.http',
+      },
+      {
+        derivedName: '/entity/http',
+        method: 'POST',
+        path: '/entity/http',
+        source: 'authored',
+        surface: 'http',
+        trailId: 'entity.http',
+      },
     ]);
+  });
+
+  test('surface projection output enforces surface-specific fields', () => {
+    expect(
+      surfaceProjectionOutput.safeParse({
+        commandPath: ['entity', 'show'],
+        derivedName: 'entity show',
+        method: null,
+        source: 'default-derived',
+        surface: 'cli',
+        trailId: 'entity.show',
+      }).success
+    ).toBe(true);
+    expect(
+      surfaceProjectionOutput.safeParse({
+        derivedName: '/entity/show',
+        method: 'GET',
+        source: 'default-derived',
+        surface: 'http',
+        trailId: 'entity.show',
+      }).success
+    ).toBe(false);
+  });
+
+  test('shipped surface inventory covers public trails and planned websocket exclusion', () => {
+    const internal = trail('entity.internal', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      visibility: 'internal',
+    });
+    const rebuildSchedule = schedule('schedule.entity.rebuild', {
+      cron: '0 5 * * *',
+    });
+    const activated = trail('entity.activated', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      on: [rebuildSchedule],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const show = trail('entity.show', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      intent: 'read',
+      output: z.object({ ok: z.boolean() }),
+      surfaces: ['mcp'],
+    } satisfies TrailSpec<unknown, { readonly ok: boolean }> & {
+      readonly surfaces: readonly string[];
+    });
+    const inventoryApp = topo('inventory-app', { activated, internal, show });
+
+    const report = deriveShippedSurfaceProjectionInventory(inventoryApp);
+
+    expect(report.shippedSurfaces).toEqual(['cli', 'mcp', 'http']);
+    expect(report.excludedSurfaces).toEqual([
+      expect.objectContaining({
+        status: 'planned',
+        surface: 'websocket',
+      }),
+    ]);
+    expect(report.trails.map((row) => row.trailId)).toEqual(['entity.show']);
+    expect(report.projections).toEqual([
+      {
+        commandPath: ['entity', 'show'],
+        derivedName: 'entity show',
+        method: null,
+        source: 'default-derived',
+        surface: 'cli',
+        trailId: 'entity.show',
+      },
+      {
+        derivedName: 'inventory_app_entity_show',
+        method: null,
+        source: 'authored',
+        surface: 'mcp',
+        toolName: 'inventory_app_entity_show',
+        trailId: 'entity.show',
+      },
+      {
+        derivedName: '/entity/show',
+        method: 'GET',
+        path: '/entity/show',
+        source: 'default-derived',
+        surface: 'http',
+        trailId: 'entity.show',
+      },
+    ]);
+    expect(shippedSurfaceInventoryOutput.safeParse(report).success).toBe(true);
   });
 
   test('trail detail clamps detour maxAttempts to the owner cap', () => {
@@ -799,6 +930,24 @@ describe('trails survey lookup', () => {
       expect(parsedOverview.data.rootDir).toBe(overviewInput?.rootDir);
       expect(parsedDetail.data.rootDir).toBe(detailInput?.rootDir);
       expect(parsedBrief.data.rootDir).toBe(briefInput?.rootDir);
+    }
+  });
+
+  test('surface inventory survey example keeps its rootDir through input validation', () => {
+    const example = surveySurfacesTrail.examples?.find(
+      (item) => item.name === 'Shipped surface inventory'
+    );
+    const input = example?.input as
+      | { readonly module?: string; readonly rootDir?: string }
+      | undefined;
+
+    expect(input?.rootDir).toBeDefined();
+
+    const parsed = surveySurfacesTrail.input.safeParse(input);
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.rootDir).toBe(input?.rootDir);
     }
   });
 
@@ -1442,6 +1591,11 @@ describe('trails survey output schema', () => {
     ).toBe(true);
     expect(
       surveyBriefTrail.output.safeParse(deriveBriefReport(app)).success
+    ).toBe(true);
+    expect(
+      surveySurfacesTrail.output.safeParse(
+        deriveShippedSurfaceProjectionInventory(app)
+      ).success
     ).toBe(true);
     expect(
       surveyDiffTrail.output.safeParse({

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -41,23 +41,30 @@ import {
 import {
   activationOverviewOutput,
   resourceDetailOutput,
+  shippedSurfaceInventoryOutput,
   signalDetailOutput,
   trailDetailOutput,
 } from './topo-output-schemas.js';
 import { createIsolatedExampleInput } from './topo-support.js';
-import { briefReportSchema } from './topo-reports.js';
+import {
+  briefReportSchema,
+  deriveShippedSurfaceProjectionInventory,
+} from './topo-reports.js';
 import type { SurfaceLayerNames } from './topo-reports.js';
 
 export {
   briefReportSchema,
   deriveBriefReport,
   deriveResourceDetail,
+  deriveShippedSurfaceProjectionInventory,
   deriveSignalDetail,
   deriveSurveyList,
   deriveTrailDetail,
 } from './topo-reports.js';
 export type {
   BriefReport,
+  ShippedSurfaceInventoryReport,
+  ShippedSurfaceProjection,
   SignalDetailReport,
   SurfaceLayerNames,
   SurveyListReport,
@@ -277,6 +284,9 @@ const buildSurveySignalDetail = (
     ? Result.err(new NotFoundError(`Signal not found: ${id}`))
     : Result.ok(detail);
 };
+
+const buildSurveySurfaceInventory = (app: Topo): Result<object, Error> =>
+  Result.ok(deriveShippedSurfaceProjectionInventory(app));
 
 interface SurveyInput {
   id?: string | undefined;
@@ -504,6 +514,24 @@ export const surveyBriefTrail = trail('survey.brief', {
   input: moduleInputSchema,
   intent: 'read',
   output: briefReportSchema,
+});
+
+export const surveySurfacesTrail = trail('survey.surfaces', {
+  blaze: async (input, ctx) =>
+    withResolvedSurveyApp(input, ctx.cwd, (app) =>
+      buildSurveySurfaceInventory(app)
+    ),
+  description: 'Inventory shipped surface projections',
+  examples: [
+    {
+      description: 'Show CLI, MCP, and HTTP projections for public trails',
+      input: createIsolatedExampleInput('survey-surfaces'),
+      name: 'Shipped surface inventory',
+    },
+  ],
+  input: moduleInputSchema,
+  intent: 'read',
+  output: shippedSurfaceInventoryOutput,
 });
 
 export const surveyDiffTrail = trail('survey.diff', {

--- a/apps/trails/src/trails/topo-output-schemas.ts
+++ b/apps/trails/src/trails/topo-output-schemas.ts
@@ -86,11 +86,55 @@ const contourDetailOutput = z.object({
   surfaces: z.array(z.string()).readonly(),
 });
 
-const surfaceProjectionOutput = z.object({
+const surfaceProjectionBaseOutput = {
   derivedName: z.string(),
-  method: z.string().nullable(),
-  surface: z.string(),
+  source: z.enum(['authored', 'default-derived']),
   trailId: z.string(),
+} as const;
+
+export const surfaceProjectionOutput = z.discriminatedUnion('surface', [
+  z.object({
+    ...surfaceProjectionBaseOutput,
+    commandPath: z.array(z.string()).readonly(),
+    method: z.null(),
+    surface: z.literal('cli'),
+  }),
+  z.object({
+    ...surfaceProjectionBaseOutput,
+    method: z.null(),
+    surface: z.literal('mcp'),
+    toolName: z.string(),
+  }),
+  z.object({
+    ...surfaceProjectionBaseOutput,
+    method: z.string(),
+    path: z.string(),
+    surface: z.literal('http'),
+  }),
+]);
+
+export const shippedSurfaceInventoryOutput = z.object({
+  count: z.number(),
+  excludedSurfaces: z
+    .array(
+      z.object({
+        reason: z.string(),
+        status: z.literal('planned'),
+        surface: z.literal('websocket'),
+      })
+    )
+    .readonly(),
+  projections: z.array(surfaceProjectionOutput).readonly(),
+  shippedSurfaces: z.array(z.enum(['cli', 'mcp', 'http'])).readonly(),
+  trails: z
+    .array(
+      z.object({
+        explicitSurfaces: z.array(z.string()).readonly(),
+        projections: z.array(surfaceProjectionOutput).readonly(),
+        trailId: z.string(),
+      })
+    )
+    .readonly(),
 });
 
 export const trailDetailOutput = z.object({

--- a/apps/trails/src/trails/topo-reports.ts
+++ b/apps/trails/src/trails/topo-reports.ts
@@ -1,5 +1,13 @@
-import { DETOUR_MAX_ATTEMPTS_CAP, zodToJsonSchema } from '@ontrails/core';
+import {
+  DETOUR_MAX_ATTEMPTS_CAP,
+  deriveCliPath,
+  filterSurfaceTrails,
+  zodToJsonSchema,
+} from '@ontrails/core';
 import type { AnyTrail, Signal, Topo } from '@ontrails/core';
+import { deriveHttpMethod } from '@ontrails/http';
+import type { HttpMethod } from '@ontrails/http';
+import { deriveToolName } from '@ontrails/mcp';
 import { deriveTopoGraph } from '@ontrails/topographer';
 import type {
   JsonSchema,
@@ -65,6 +73,52 @@ export type SurfaceLayerKey = 'cli' | 'http' | 'mcp';
 export type SurfaceLayerNames = Readonly<
   Record<SurfaceLayerKey, readonly string[]>
 >;
+
+export type ShippedSurfaceKey = 'cli' | 'mcp' | 'http';
+
+export type SurfaceProjectionSource = 'authored' | 'default-derived';
+
+export type ShippedSurfaceProjection =
+  | {
+      readonly commandPath: readonly string[];
+      readonly derivedName: string;
+      readonly method: null;
+      readonly source: SurfaceProjectionSource;
+      readonly surface: 'cli';
+      readonly trailId: string;
+    }
+  | {
+      readonly derivedName: string;
+      readonly method: null;
+      readonly source: SurfaceProjectionSource;
+      readonly surface: 'mcp';
+      readonly toolName: string;
+      readonly trailId: string;
+    }
+  | {
+      readonly derivedName: string;
+      readonly method: HttpMethod;
+      readonly path: string;
+      readonly source: SurfaceProjectionSource;
+      readonly surface: 'http';
+      readonly trailId: string;
+    };
+
+export interface ShippedSurfaceInventoryReport {
+  readonly count: number;
+  readonly excludedSurfaces: readonly {
+    readonly reason: string;
+    readonly status: 'planned';
+    readonly surface: 'websocket';
+  }[];
+  readonly projections: readonly ShippedSurfaceProjection[];
+  readonly shippedSurfaces: readonly ShippedSurfaceKey[];
+  readonly trails: readonly {
+    readonly explicitSurfaces: readonly string[];
+    readonly projections: readonly ShippedSurfaceProjection[];
+    readonly trailId: string;
+  }[];
+}
 
 type TopoGraphContourEntry = TopoGraphEntry & { readonly kind: 'contour' };
 
@@ -155,12 +209,7 @@ export interface TrailDetailReport {
   readonly pattern: string | null;
   readonly safety: string;
   readonly resources: readonly string[];
-  readonly surfaceProjections: readonly {
-    readonly derivedName: string;
-    readonly method: string | null;
-    readonly surface: string;
-    readonly trailId: string;
-  }[];
+  readonly surfaceProjections: readonly ShippedSurfaceProjection[];
   readonly surfaces: readonly string[];
 }
 
@@ -454,25 +503,158 @@ const trailActivationEdgesFromTopoGraph = (
   topoGraph?.activationGraph.edges.filter((edge) => edge.trailId === trailId) ??
   fallback;
 
-const deriveSurfaceProjections = (
+const SHIPPED_SURFACES = ['cli', 'mcp', 'http'] as const;
+
+const PLANNED_SURFACE_EXCLUSIONS = [
+  {
+    reason: 'WebSocket is planned, but no public package or API ships yet.',
+    status: 'planned' as const,
+    surface: 'websocket' as const,
+  },
+] as const;
+
+const surfaceOrder = (surface: ShippedSurfaceKey): number =>
+  SHIPPED_SURFACES.indexOf(surface);
+
+const sortSurfaceProjections = (
+  projections: readonly ShippedSurfaceProjection[]
+): readonly ShippedSurfaceProjection[] =>
+  projections.toSorted(
+    (a, b) =>
+      a.trailId.localeCompare(b.trailId) ||
+      surfaceOrder(a.surface) - surfaceOrder(b.surface)
+  );
+
+const explicitSurfacesForEntry = (
   entry: TopoGraphEntry | undefined
-): TrailDetailReport['surfaceProjections'] => {
-  if (entry === undefined) {
+): readonly string[] => entry?.surfaces ?? [];
+
+const projectionSource = (
+  entry: TopoGraphEntry | undefined,
+  surface: ShippedSurfaceKey
+): SurfaceProjectionSource =>
+  explicitSurfacesForEntry(entry).includes(surface)
+    ? 'authored'
+    : 'default-derived';
+
+const deriveHttpPath = (trailId: string): string =>
+  `/${trailId.replaceAll('.', '/')}`;
+
+const isSurfaceEligibleTrail = (app: Topo, trail: AnyTrail): boolean =>
+  filterSurfaceTrails([trail]).length > 0 &&
+  app.trails.get(trail.id) !== undefined;
+
+export const deriveShippedSurfaceProjectionsForTrail = (
+  app: Topo,
+  trail: AnyTrail,
+  topoGraph?: TopoGraph | undefined
+): readonly ShippedSurfaceProjection[] => {
+  if (!isSurfaceEligibleTrail(app, trail)) {
     return [];
   }
 
-  const cliProjection =
-    entry.cli === undefined
-      ? []
-      : [
-          {
-            derivedName: entry.cli.path.join(' '),
-            method: null,
-            surface: 'cli',
-            trailId: entry.id,
-          },
-        ];
-  return cliProjection.toSorted((a, b) => a.surface.localeCompare(b.surface));
+  const entry = findTopoEntry(
+    topoGraph ?? deriveTopoGraph(app),
+    trail.id,
+    'trail'
+  );
+  const commandPath = deriveCliPath(trail.id);
+  const httpMethod = deriveHttpMethod(trail.intent);
+  const httpPath = deriveHttpPath(trail.id);
+  const mcpToolName = deriveToolName(app.name, trail.id);
+
+  return sortSurfaceProjections([
+    {
+      commandPath,
+      derivedName: commandPath.join(' '),
+      method: null,
+      source: projectionSource(entry, 'cli'),
+      surface: 'cli',
+      trailId: trail.id,
+    },
+    {
+      derivedName: mcpToolName,
+      method: null,
+      source: projectionSource(entry, 'mcp'),
+      surface: 'mcp',
+      toolName: mcpToolName,
+      trailId: trail.id,
+    },
+    {
+      derivedName: httpPath,
+      method: httpMethod,
+      path: httpPath,
+      source: projectionSource(entry, 'http'),
+      surface: 'http',
+      trailId: trail.id,
+    },
+  ]);
+};
+
+const deriveFallbackSurfaceProjections = (
+  entry: TopoGraphEntry | undefined
+): readonly ShippedSurfaceProjection[] => {
+  if (entry?.cli === undefined) {
+    return [];
+  }
+
+  return [
+    {
+      commandPath: entry.cli.path,
+      derivedName: entry.cli.path.join(' '),
+      method: null,
+      source: projectionSource(entry, 'cli'),
+      surface: 'cli',
+      trailId: entry.id,
+    },
+  ];
+};
+
+export const deriveShippedSurfaceProjectionInventory = (
+  app: Topo
+): ShippedSurfaceInventoryReport => {
+  const topoGraph = deriveTopoGraph(app);
+  const trails = filterSurfaceTrails(app.list()).map((trail) => {
+    const entry = findTopoEntry(topoGraph, trail.id, 'trail');
+    const projections = deriveShippedSurfaceProjectionsForTrail(
+      app,
+      trail,
+      topoGraph
+    );
+
+    return {
+      explicitSurfaces: explicitSurfacesForEntry(entry),
+      projections,
+      trailId: trail.id,
+    };
+  });
+  const projections = sortSurfaceProjections(
+    trails.flatMap((trail) => trail.projections)
+  );
+
+  return {
+    count: trails.length,
+    excludedSurfaces: PLANNED_SURFACE_EXCLUSIONS,
+    projections,
+    shippedSurfaces: SHIPPED_SURFACES,
+    trails: trails.toSorted((a, b) => a.trailId.localeCompare(b.trailId)),
+  };
+};
+
+const deriveResolvedSurfaceProjections = (
+  app: Topo | undefined,
+  trailId: string,
+  topoEntry: TopoGraphEntry | undefined,
+  topoGraph: TopoGraph | undefined
+): readonly ShippedSurfaceProjection[] => {
+  if (app === undefined) {
+    return deriveFallbackSurfaceProjections(topoEntry);
+  }
+
+  const trail = app.trails.get(trailId);
+  return trail === undefined
+    ? deriveFallbackSurfaceProjections(topoEntry)
+    : deriveShippedSurfaceProjectionsForTrail(app, trail, topoGraph);
 };
 
 const deriveResolvedTrailGraphDetail = (
@@ -525,7 +707,12 @@ const deriveResolvedTrailGraphDetail = (
     input: topoEntry?.input ?? null,
     layers: topoEntry?.layers ?? [],
     output: topoEntry?.output ?? null,
-    surfaceProjections: deriveSurfaceProjections(topoEntry),
+    surfaceProjections: deriveResolvedSurfaceProjections(
+      app,
+      trailId,
+      topoEntry,
+      topoGraph
+    ),
     surfaces: topoEntry?.surfaces ?? [],
   };
 };

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,8 @@
         "@ontrails/cli": "workspace:^",
         "@ontrails/commander": "workspace:^",
         "@ontrails/core": "workspace:^",
+        "@ontrails/http": "workspace:^",
+        "@ontrails/mcp": "workspace:^",
         "@ontrails/observe": "workspace:^",
         "@ontrails/permits": "workspace:^",
         "@ontrails/topographer": "workspace:^",

--- a/docs/topo-store-reference.md
+++ b/docs/topo-store-reference.md
@@ -173,9 +173,12 @@ surface graph. In the current v1 posture it records CLI-derived rows only:
 `surface = 'cli'`, the CLI command name in `derived_name`, and `method = NULL`.
 Schema-rich contract detail lives in the saved `TopoGraph`
 (`topo_exports.topo_graph`) and the typed `store.topoGraph` / `store.entries`
-accessors. Today the TopoGraph's surface-related facts are the authored
-`surfaces` list and CLI path metadata; complete multi-surface projection rows
-remain future work.
+accessors. The TopoGraph's durable surface-related facts are the authored
+`surfaces` list and CLI path metadata. Complete shipped-surface projection
+inventory is derived at survey/report time from the loaded topo; use
+`trails survey surfaces` or trail detail `surfaceProjections` for the CLI, MCP,
+and HTTP projection matrix. WebSocket remains planned and excluded until a
+public package/API exists.
 
 ```sql
 CREATE TABLE topo_surfaces (
@@ -368,7 +371,9 @@ arrays. It also carries resolved `TopoGraph` contract facts for blind agents:
 `contourDetails`, `activationContext`, `activationEdges`, `activationSources`,
 `fieldOverrides`, `layers`, and `governance`. `surfaceProjections` are the
 operational rows from `topo_surfaces`; `surfaces` and the schema-rich contract
-fields come from the saved `TopoGraph`.
+fields come from the saved `TopoGraph`. For the complete shipped CLI/MCP/HTTP
+surface inventory, use the app-level survey projection instead of treating the
+operational rows as canonical.
 
 Detailed examples preserve `expected`, `expectedMatch`, and structured signal
 assertions when they are JSON-serializable. Detours preserve authored recovery

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -81,6 +81,13 @@ trails survey resource db.main
 trails survey signal user.created
 ```
 
+Use `trails survey surfaces` when a blind agent or parity check needs the
+complete shipped-surface projection inventory. The report lists every public
+trail eligible for CLI, MCP, and HTTP, including CLI command paths, MCP tool
+names, HTTP method/path pairs, and whether each projection came from explicit
+authored surface metadata or default derivation. WebSocket is still planned and
+is intentionally reported as excluded until a public package/API exists.
+
 ### `trails topo history`
 
 List saved topo states (pinned and recent autosaves).


### PR DESCRIPTION
## Context

Blind parity audits need a complete shipped surface projection inventory. The persisted topographer `topo_surfaces` rows remain operational, so the app-level reporting layer now derives the review-facing inventory.

## What Changed

- Added survey/report-time shipped surface projection derivation for CLI, MCP, and HTTP.
- Added `survey.surfaces`.
- Extended trail detail output with `surfaceProjections`.
- Documented authored-vs-default provenance and WebSocket exclusion until a public surface package/API exists.
- Added a branch-local changeset for `@ontrails/trails`.

## How To Test

- `bun test apps/trails/src/__tests__/survey.test.ts --bail`
- `bun run --cwd apps/trails typecheck`
- `bun test packages/topographer`
- `bun run typecheck`
- `bun run format:check`
- `bun run docs:links`
- `bun test apps/trails`
- `bun run check`
- `git diff --check`

## Risks / Rollout Notes

This intentionally does not redefine persisted topographer surface rows as canonical shipped-surface truth.