### PR TITLE
feat: add surface parity testing

### DIFF
--- a/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
+++ b/.agents/plans/2026-05-13-v1-readiness-closure-stack/RETRO.md
@@ -39,17 +39,17 @@ before handoff or merge readiness.
 
 | Order | Issue | Branch | PR | Status |
 | --- | --- | --- | --- | --- |
-| 1 | `TRL-713` | `trl-713-repair-stale-changesets-references-before-stable-cutover` | TBD | Focused checks passed |
-| 2 | `TRL-714` | `trl-714-add-registry-availability-and-dist-tag-release-preflights` | TBD | Focused checks passed |
-| 3 | `TRL-707` | `trl-707-fix-fresh-start-install-blocker-for-generated-cli-projects` | TBD | Fresh-start gate passed after beta.16 unblock |
-| 4 | `TRL-712` | `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | TBD | Focused checks passed |
-| 5 | `TRL-711` | `trl-711-codify-the-beta-to-10-release-runbook` | TBD | Focused checks passed |
-| 6 | `TRL-709` | `trl-709-add-markdown-link-integrity-check-for-docs-and-readmes` | TBD | Focused checks passed |
-| 7 | `TRL-708` | `trl-708-expand-readme-typescript-snippet-verification-beyond-tracing` | TBD | Focused checks passed |
-| 8 | `TRL-710` | `trl-710-create-public-api-example-coverage-inventory-and-gate` | TBD | Focused checks passed |
-| 9 | `TRL-704` | `trl-704-add-http-surface-harness-and-include-it-in` | TBD | Focused checks passed |
-| 10 | `TRL-706` | `trl-706-expose-complete-shipped-surface-projection-inventory-for` | TBD | Focused checks passed |
-| 11 | `TRL-705` | `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | TBD | Not started |
+| 1 | `TRL-713` | `trl-713-repair-stale-changesets-references-before-stable-cutover` | #502 | Ready PR; no remote P2+ feedback. |
+| 2 | `TRL-714` | `trl-714-add-registry-availability-and-dist-tag-release-preflights` | #503 | Ready PR; Greptile P2 feedback addressed locally. |
+| 3 | `TRL-707` | `trl-707-fix-fresh-start-install-blocker-for-generated-cli-projects` | #504 | Ready PR; fresh-start gate passed after beta.16 unblock. |
+| 4 | `TRL-712` | `trl-712-author-stable-release-doctrine-adr-for-the-1x-line` | #505 | Ready PR; Greptile P2 feedback addressed locally. |
+| 5 | `TRL-711` | `trl-711-codify-the-beta-to-10-release-runbook` | #506 | Ready PR; Greptile P1 feedback addressed locally. |
+| 6 | `TRL-709` | `trl-709-add-markdown-link-integrity-check-for-docs-and-readmes` | #507 | Ready PR; Greptile P1/P2 feedback addressed locally. |
+| 7 | `TRL-708` | `trl-708-expand-readme-typescript-snippet-verification-beyond-tracing` | #508 | Ready PR; Greptile P2 feedback addressed locally. |
+| 8 | `TRL-710` | `trl-710-create-public-api-example-coverage-inventory-and-gate` | #509 | Ready PR; Greptile P2 feedback addressed locally. |
+| 9 | `TRL-704` | `trl-704-add-http-surface-harness-and-include-it-in` | #510 | Ready PR; Greptile P1/P2 feedback addressed locally. |
+| 10 | `TRL-706` | `trl-706-expose-complete-shipped-surface-projection-inventory-for` | #511 | Ready PR; Greptile P2 feedback addressed locally. |
+| 11 | `TRL-705` | `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | #512 | Ready PR; Greptile P1/P2 feedback addressed locally. |
 
 ## Tracker Mutations
 
@@ -74,6 +74,8 @@ issues created or updated during execution.
 | `TRL-710` | Changed status to `In Progress`. | Branch execution started. |
 | `TRL-704` | Changed status to `In Progress`. | Branch execution started. |
 | `TRL-706` | Changed status to `In Progress`. | Branch execution started. |
+| `TRL-705` | Changed status to `In Progress`. | Branch execution started. |
+| `TRL-704`-`TRL-714` | Changed status to `In Review`. | Stack PRs #502 through #512 submitted and attached through Linear/GitHub integration. |
 
 ## Local Review Reports
 
@@ -244,6 +246,45 @@ ready waves, and remote review turns here.
   `surfaceProjections` now reports all shipped CLI/MCP/HTTP projections with
   authored-vs-default provenance, and docs call out WebSocket as planned and
   excluded until a public package/API exists.
+- 2026-05-13T17:27Z: Started and completed the focused implementation for
+  `TRL-705` on
+  `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate`. Added
+  `testSurfaceParity` and `runSurfaceParityExample` to `@ontrails/testing`,
+  normalizing success payloads and public TrailsError category/code pairs
+  across CLI, MCP, and HTTP. Extended the CLI and MCP harness result shapes so
+  parity can read projected errors and MCP metadata without transport-specific
+  assertions. Wired `apps/trails-demo` into the new parity gate with
+  deterministic per-surface resources and explicit exclusions for generated
+  identity examples. Added a whitespace-in-JSON regression so the CLI leg does
+  not false-fail examples whose string input contains spaces. Updated the
+  testing README, README snippet checker stub, and branch-local
+  `@ontrails/testing` changeset.
+- 2026-05-13T17:31Z: Completed full tip-of-stack local verification at
+  `6fec6071f5f6e6dc3a17f46cda9273db861d3fb9`. `bun scripts/adr.ts map`
+  initially regenerated `docs/adr/decision-map.json` with cumulative stack
+  reference updates; the generated artifact was committed at the stack tip, and
+  rerunning the map left the worktree clean. The full gate list passed,
+  including ADR checks, typecheck, tests, lint, ast-grep, build, format, the
+  integrated `bun run check`, dead-code, no-publish `publish:check`, and
+  `git diff --check`.
+- 2026-05-13T17:58Z: Submitted the full stack as PRs #502 through #512, marked
+  each PR ready after CI went green, then processed Greptile P1/P2 feedback
+  bottom-up without `gt absorb`. Local fixes now cover registry preflight
+  concurrency and unreadable workspace handling (#503), ADR amended-status index
+  preservation (#505), subshell-scoped release-runbook smoke commands (#506),
+  fenced-code markdown anchor parsing and single-pass file discovery (#507),
+  duplicate README snippet config detection (#508), robust public API example
+  detection and unsupported re-export failures (#509), HTTP harness Result
+  narrowing and PUT/PATCH helpers (#510), discriminated surface projection
+  output schemas (#511), and per-surface context preservation plus MCP
+  structuredContent normalization (#512). No package publish, registry mutation,
+  merge, merge queue label, or `gt absorb` command was performed.
+- 2026-05-13T18:09Z: Processed a second Greptile P1 on PR #506 after the first
+  v2 resubmit. The stable-cutover runbook no longer asks the version PR branch
+  to run `bun install` against an unpublished stable package range. It now runs
+  the install-backed generated-app smoke before exiting prerelease mode, limits
+  the post-version PR branch smoke to scaffold/package-range inspection, and
+  keeps the registry-backed stable install proof in the post-publish section.
 
 ## Verification Log
 
@@ -320,6 +361,28 @@ Record focused branch checks and full tip gate results here.
 | `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun test apps/trails` | Passed, 381 tests and 1227 assertions. |
 | `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun scripts/check-changeset-gate.ts --changed-files <(git diff --cached --name-only)` | Passed for `@ontrails/trails` with `.changeset/bright-surface-inventory.md`. |
 | `trl-706-expose-complete-shipped-surface-projection-inventory-for` | `bun run check` | Passed; includes lint, ast-grep, vocab audit, format, typecheck, docs link/snippet/API example checks, scaffold checks, Warden, and dead-code gate. |
+| `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | `bun test packages/testing/src/__tests__/surface-parity.test.ts --bail` | Passed, 2 tests and 2 assertions, including a spaced-string `--input-json` regression. |
+| `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | `bun test apps/trails-demo/__tests__/surface-parity.test.ts --bail` | Passed, 10 tests, 2 explicit skips, and 20 assertions. |
+| `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | `bun test packages/testing` | Passed, 159 tests and 306 assertions. |
+| `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | `bun test apps/trails-demo` | Passed, 74 tests, 2 explicit skips, and 228 assertions. |
+| `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | `bun run --cwd packages/testing typecheck` | Passed. |
+| `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | `bun run typecheck` | Passed; 21 packages. |
+| `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | `bun run format:check` | Passed. |
+| `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | `bun run docs:snippets` | Passed; checked all 21 package/app/adapter READMEs after adding the new testing README example and stub export. |
+| `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | `bun run check` | Passed; includes lint, ast-grep, vocab audit, format, typecheck, docs link/snippet/API example checks, scaffold checks, Warden, and dead-code gate. |
+| `trl-705-add-example-driven-climcphttp-parity-runner-and-ci-gate` | `git diff --check` | Passed. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun scripts/adr.ts map` | Passed; after committing the regenerated `docs/adr/decision-map.json`, rerunning the map left the worktree clean. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun scripts/adr.ts check` | Passed; 0 errors, 0 warnings. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun run typecheck` | Passed; 21 packages. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun run test` | Passed; 36 Turbo tasks. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun run lint` | Passed; 22 Turbo tasks. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun run lint:ast-grep` | Passed. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun run build` | Passed; 21 Turbo tasks. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun run format:check` | Passed. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun run check` | Passed; includes lint, ast-grep, vocab audit, format, typecheck, docs link/snippet/API example checks, scaffold checks, Warden, and dead-code gate. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun run dead-code` | Passed. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `bun run publish:check` | Passed; all public package pack checks passed at `1.0.0-beta.16`. No publish command was run. |
+| `tip @ 6fec6071f5f6e6dc3a17f46cda9273db861d3fb9` | `git diff --check` | Passed. |
 
 ## Review Feedback
 
@@ -327,7 +390,16 @@ Record P0/P1/P2 feedback, owning branches, fixes, replies, and unresolved P3s.
 
 | Source | Branch | Severity | Finding | Resolution |
 | --- | --- | --- | --- | --- |
-| TBD | TBD | TBD | TBD | TBD |
+| Greptile | `TRL-714` / PR #503 | P2 | Registry preflight probed workspaces sequentially and silently skipped unreadable workspace directories. | Addressed locally with concurrent workspace probes, ENOENT-only missing-parent handling, and focused tests. |
+| Greptile | `TRL-712` / PR #505 | P2 | ADR index regeneration dropped amended status metadata for ADR-0043. | Addressed locally by preserving `amended` frontmatter in index status rendering and regenerating ADR indexes. |
+| Greptile | `TRL-711` / PR #506 | P1 | Stable-cutover smoke commands changed shell cwd for subsequent commands. | Addressed locally by wrapping both generated-app smoke sequences in subshells. |
+| Greptile | `TRL-711` / PR #506 | P1 | Version PR smoke would install generated `^1.0.0` dependencies before stable packages were published. | Addressed locally by moving the install-backed generated-app smoke before prerelease exit and keeping post-version scaffold inspection separate from the post-publish registry smoke. |
+| Greptile | `TRL-709` / PR #507 | P1/P2 | Markdown anchor collection counted fenced headings, tests depended on live repository files, and CLI scanned files twice. | Addressed locally with shared fence-state parsing, injectable filesystem hooks, single-pass file reuse, and focused tests. |
+| Greptile | `TRL-708` / PR #508 | P2 | Duplicate README snippet checker configs were not detected. | Addressed locally by failing coverage on duplicate config paths with focused tests. |
+| Greptile | `TRL-710` / PR #509 | P2 | Public API example detection only inspected the nearest leading comment and star exports were silently omitted. | Addressed locally by scanning all leading comments for examples and failing unsupported re-export forms. |
+| Greptile | `TRL-704` / PR #510 | P1/P2 | HTTP harness could misclassify user payloads as webhook parse Results and lacked PUT/PATCH helpers. | Addressed locally with webhook-route-only Result narrowing and PUT/PATCH helpers/tests. |
+| Greptile | `TRL-706` / PR #511 | P2 | Surface projection output schema flattened CLI/MCP/HTTP invariants. | Addressed locally with a discriminated union keyed by `surface` and survey tests. |
+| Greptile | `TRL-705` / PR #512 | P1/P2 | Surface parity runner clobbered per-surface contexts, ignored MCP structuredContent, and raised a parallelization suggestion. | Addressed locally by merging base and per-surface context, preferring MCP structuredContent with `{ data }` unwrapping, and documenting why CLI output capture keeps surface execution ordered. |
 
 ## Publish / Registry Safety
 

--- a/.changeset/fair-surface-parity.md
+++ b/.changeset/fair-surface-parity.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/testing": patch
+---
+
+Add an example-driven CLI/MCP/HTTP surface parity helper.

--- a/apps/trails-demo/__tests__/surface-parity.test.ts
+++ b/apps/trails-demo/__tests__/surface-parity.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Example-driven parity across shipped surfaces.
+ */
+
+import { testSurfaceParity } from '@ontrails/testing';
+
+import { graph } from '../src/app.js';
+import { createNotificationStore } from '../src/resources/notification-store.js';
+import { createStore } from '../src/store.js';
+
+// oxlint-disable-next-line require-hook -- testSurfaceParity registers tests at module level by design
+testSurfaceParity(graph, {
+  createResources: () => ({
+    'demo.entity-store': createStore([
+      {
+        createdAt: '2026-01-01T00:00:00.000Z',
+        id: 'entity-alpha',
+        name: 'Alpha',
+        tags: ['core'],
+        type: 'concept',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        createdAt: '2026-01-02T00:00:00.000Z',
+        id: 'entity-deletable',
+        name: 'Deletable',
+        tags: ['temp'],
+        type: 'tool',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      },
+    ]),
+    'demo.notification-store': createNotificationStore(),
+  }),
+  ctx: { permit: { id: 'test-permit', scopes: ['entity:delete'] } },
+  exclusions: [
+    {
+      example: 'Add a new entity',
+      reason:
+        'creates generated id/timestamp fields, so each fresh surface store returns different values',
+      trailId: 'entity.add',
+    },
+    {
+      example: 'Onboard a new entity',
+      reason:
+        'composes entity.add and returns generated entity identity from each fresh surface store',
+      trailId: 'entity.onboard',
+    },
+  ],
+});

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -1713,12 +1713,12 @@
           "fromPath": "docs/adr/0039-reactive-trail-activation.md"
         },
         {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
+          "context": "- [ADR-0027: Trail Visibility and Surface Filtering](../0027-visibility-and-filtering.md) -- `trails run` can invoke internal trails (it's programmatic, like `run()`)",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
         },
         {
-          "context": "- [ADR: Trail Visibility and Trailhead Filtering](0027-visibility-and-filtering.md) (draft) -- rigged SDK wrapper packs use `visibility: 'internal'`",
+          "context": "- [ADR-0027: Trail Visibility and Surface Filtering](../0027-visibility-and-filtering.md) -- rigged SDK wrapper packs use `visibility: 'internal'`",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
         },
@@ -1806,7 +1806,7 @@
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
         },
         {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) -- connectors move to `@ontrails/with-*` packages; affects how connector ",
+          "context": "- [ADR-0029: Adapter Extraction and Composition Around Core Contracts](../0029-connector-extraction-and-the-with-packaging-model.md) -- connectors move to `@ontrails/with-*` packages; affects how conn",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
         },
@@ -1816,12 +1816,12 @@
           "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
         },
         {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) -- connectors as `@ontrails/with-*` packages; compiled packs may depend o",
+          "context": "- [ADR-0029: Adapter Extraction and Composition Around Core Contracts](../0029-connector-extraction-and-the-with-packaging-model.md) -- connectors as `@ontrails/with-*` packages; compiled packs may de",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
         },
         {
-          "context": "- [ADR-0029: Connector Extraction and the `with-*` Packaging Model](0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model for connector bundles",
+          "context": "- [ADR-0029: Adapter Extraction and Composition Around Core Contracts](../0029-connector-extraction-and-the-with-packaging-model.md) — the packaging model for connector bundles",
           "from": "20260409",
           "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
         }
@@ -1966,6 +1966,16 @@
           "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](../0032-derivetrail-and-trail-factories.md) -- `ingest()` factory for webhook-to-trail flows that can feed signals to WebSocket subscribers",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-websocket-trailhead.md"
+        },
+        {
+          "context": "When search is declared on a store entity and the developer uses `crud()` (see [ADR-0032: `deriveTrail()` and Trail Factories](../0032-derivetrail-and-trail-factories.md)), a search trail is automatic",
+          "from": "20260401",
+          "fromPath": "docs/adr/drafts/20260401-declarative-search.md"
+        },
+        {
+          "context": "- [ADR-0032: `deriveTrail()` and Trail Factories](../0032-derivetrail-and-trail-factories.md) — trail factories that produce trails carried by pack bundles",
+          "from": "20260409",
+          "fromPath": "docs/adr/drafts/20260409-resource-bundles.md"
         }
       ],
       "number": "0032",
@@ -2405,7 +2415,13 @@
     {
       "created": "2026-05-13",
       "depends_on": ["29", "35", "37", "44", "46"],
-      "inbound": [],
+      "inbound": [
+        {
+          "context": "Stable 1.x release doctrine is captured in [ADR-0047](docs/adr/0047-stable-release-line-discipline.md), and the copy-pasteable beta-to-1.0 operator sequence lives in [Stable Cutover Runbook](docs/rele",
+          "from": "AGENTS",
+          "fromPath": "AGENTS.md"
+        }
+      ],
       "number": "0047",
       "owners": ["[galligan](https://github.com/galligan)"],
       "path": "docs/adr/0047-stable-release-line-discipline.md",

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -32,6 +32,7 @@ testDetours(graph);    // Validate detour constructor, recover, and ordering sem
 | `testTrail(trail, scenarios)` | Custom scenarios for edge cases, error paths, and cross chains |
 | `testContracts(topo, ctx?)` | Validate output against declared schemas |
 | `testDetours(topo)` | Validate detour constructor, recover, and shadowing semantics |
+| `testSurfaceParity(topo, options?)` | Run trail examples through CLI, MCP, and HTTP and compare normalized semantics |
 | `createCrossContext(options?)` | Mock `CrossFn` for testing composite trails; returns preconfigured `Result` values keyed by trail ID |
 | `createTestContext(options?)` | `TrailContext` with sensible test defaults |
 | `createTestLogger()` | Logger that captures entries in memory for assertions |
@@ -111,6 +112,39 @@ const http = createHttpHarness({ graph });
 const response = await http.get('/entity/show', { name: 'Alpha' });
 expect(response.status).toBe(200);
 ```
+
+## Surface Parity
+
+`testSurfaceParity()` is a focused gate for established apps that want to prove
+their examples behave the same through every shipped surface.
+
+```typescript
+import { testSurfaceParity } from '@ontrails/testing';
+import { graph } from '../app';
+
+const createDeterministicTestDb = () => ({});
+
+testSurfaceParity(graph, {
+  createResources: () => ({
+    'db.main': createDeterministicTestDb(),
+  }),
+  exclusions: [
+    {
+      example: 'Creates generated data',
+      reason: 'output includes generated IDs that intentionally differ per surface run',
+      trailId: 'entity.add',
+    },
+  ],
+});
+```
+
+The helper compares normalized success payloads and normalized TrailsError
+category/code pairs. CLI command names, MCP tool names, HTTP method/path values,
+transport envelopes, activation consumers, internal trails, and planned
+WebSocket work stay outside the equality check. Use `createResources` when
+examples need deterministic fixtures for each surface invocation, and use
+exclusions for intentional semantic differences that should not be silently
+skipped.
 
 ## Installation
 

--- a/packages/testing/src/__tests__/surface-parity.test.ts
+++ b/packages/testing/src/__tests__/surface-parity.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from 'bun:test';
+
+import { NotFoundError, Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { runSurfaceParityExample } from '../surface-parity.js';
+
+describe('runSurfaceParityExample', () => {
+  test('normalizes matching success payloads across CLI, MCP, and HTTP', async () => {
+    const show = trail('entity.show', {
+      blaze: (input: { name: string }) =>
+        Result.ok({ greeting: `Hello, ${input.name}` }),
+      examples: [
+        {
+          expected: { greeting: 'Hello, Ada Lovelace' },
+          input: { name: 'Ada Lovelace' },
+          name: 'Show Ada',
+        },
+      ],
+      input: z.object({ name: z.string() }),
+      intent: 'read',
+      output: z.object({ greeting: z.string() }),
+    });
+    const graph = topo('parity-app', { show });
+    const [example] = show.examples ?? [];
+    if (example === undefined) {
+      throw new Error('Expected show trail example');
+    }
+
+    const comparison = await runSurfaceParityExample(graph, show, example);
+
+    expect(comparison).toEqual({
+      cli: { ok: true, value: { greeting: 'Hello, Ada Lovelace' } },
+      http: { ok: true, value: { greeting: 'Hello, Ada Lovelace' } },
+      mcp: { ok: true, value: { greeting: 'Hello, Ada Lovelace' } },
+    });
+  });
+
+  test('merges per-surface context options instead of clobbering them', async () => {
+    const requestId = 'surface-request-123';
+    const show = trail('context.show', {
+      blaze: (_input, ctx) => Result.ok({ requestId: ctx.requestId }),
+      examples: [
+        {
+          expected: { requestId },
+          input: {},
+          name: 'Show request context',
+        },
+      ],
+      input: z.object({}),
+      intent: 'read',
+      output: z.object({ requestId: z.string() }),
+    });
+    const graph = topo('parity-app', { show });
+    const [example] = show.examples ?? [];
+    if (example === undefined) {
+      throw new Error('Expected show trail example');
+    }
+
+    const comparison = await runSurfaceParityExample(graph, show, example, {
+      cli: { ctx: { requestId } },
+      http: { ctx: { requestId } },
+      mcp: { createContext: () => ({ requestId }) },
+    });
+
+    expect(comparison).toEqual({
+      cli: { ok: true, value: { requestId } },
+      http: { ok: true, value: { requestId } },
+      mcp: { ok: true, value: { requestId } },
+    });
+  });
+
+  test('normalizes MCP structuredContent data envelopes for array output', async () => {
+    const list = trail('entity.list', {
+      blaze: () => Result.ok(['one', 'two']),
+      examples: [
+        {
+          expected: ['one', 'two'],
+          input: {},
+          name: 'List entities',
+        },
+      ],
+      input: z.object({}),
+      intent: 'read',
+      output: z.array(z.string()),
+    });
+    const graph = topo('parity-app', { list });
+    const [example] = list.examples ?? [];
+    if (example === undefined) {
+      throw new Error('Expected list trail example');
+    }
+
+    const comparison = await runSurfaceParityExample(graph, list, example);
+
+    expect(comparison).toEqual({
+      cli: { ok: true, value: ['one', 'two'] },
+      http: { ok: true, value: ['one', 'two'] },
+      mcp: { ok: true, value: ['one', 'two'] },
+    });
+  });
+
+  test('normalizes TrailsError category and code across surfaces', async () => {
+    const missing = trail('entity.missing', {
+      blaze: () => Result.err(new NotFoundError('Entity not found')),
+      examples: [
+        {
+          error: 'NotFoundError',
+          input: { name: 'Missing' },
+          name: 'Missing entity',
+        },
+      ],
+      input: z.object({ name: z.string() }),
+      intent: 'read',
+      output: z.object({ name: z.string() }),
+    });
+    const graph = topo('parity-app', { missing });
+    const [example] = missing.examples ?? [];
+    if (example === undefined) {
+      throw new Error('Expected missing trail example');
+    }
+
+    const comparison = await runSurfaceParityExample(graph, missing, example);
+
+    expect(comparison).toEqual({
+      cli: {
+        error: { category: 'not_found', code: 'NotFoundError' },
+        ok: false,
+      },
+      http: {
+        error: { category: 'not_found', code: 'NotFoundError' },
+        ok: false,
+      },
+      mcp: {
+        error: { category: 'not_found', code: 'NotFoundError' },
+        ok: false,
+      },
+    });
+  });
+});

--- a/packages/testing/src/harness-cli.ts
+++ b/packages/testing/src/harness-cli.ts
@@ -8,6 +8,7 @@
 import { deriveCliCommands } from '@ontrails/cli';
 import type { CliCommand } from '@ontrails/cli';
 import type { TrailContext } from '@ontrails/core';
+import { projectPublicSurfaceError } from '@ontrails/core';
 
 import { mergeTestContext } from './context.js';
 import type {
@@ -207,10 +208,16 @@ const buildErrorResult = (
   streams: CapturedStreams
 ): CliHarnessResult => {
   streams.restore();
-  const message = error instanceof Error ? error.message : String(error);
+  const actualError = error instanceof Error ? error : new Error(String(error));
+  const projection = projectPublicSurfaceError('cli', actualError);
   return {
+    error: {
+      category: projection.category,
+      code: projection.name,
+      message: projection.message,
+    },
     exitCode: 1,
-    stderr: streams.getStderr() || message,
+    stderr: streams.getStderr() || projection.message,
     stdout: streams.getStdout(),
   };
 };
@@ -227,9 +234,15 @@ const executeCommand = async (
   streams.restore();
 
   if (result.isErr()) {
+    const projection = projectPublicSurfaceError('cli', result.error);
     return {
+      error: {
+        category: projection.category,
+        code: projection.name,
+        message: projection.message,
+      },
       exitCode: 1,
-      stderr: streams.getStderr() || result.error.message,
+      stderr: streams.getStderr() || projection.message,
       stdout: streams.getStdout(),
     };
   }

--- a/packages/testing/src/harness-mcp.ts
+++ b/packages/testing/src/harness-mcp.ts
@@ -63,6 +63,8 @@ export const createMcpHarness = (options: McpHarnessOptions): McpHarness => {
       return {
         content: result.content,
         isError: result.isError ?? false,
+        meta: result._meta,
+        structuredContent: result.structuredContent,
       };
     },
   };

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -6,6 +6,10 @@ export { testCrosses } from './crosses.js';
 export { testTrail } from './trail.js';
 export { testContracts } from './contracts.js';
 export { testDetours } from './detours.js';
+export {
+  runSurfaceParityExample,
+  testSurfaceParity,
+} from './surface-parity.js';
 
 // Assertions
 export {
@@ -65,4 +69,9 @@ export type {
   McpHarness,
   McpHarnessOptions,
   McpHarnessResult,
+  NormalizedSurfaceParityResult,
+  SurfaceParityExclusion,
+  SurfaceParityOptions,
+  SurfaceParitySurface,
 } from './types.js';
+export type { SurfaceParityComparison } from './surface-parity.js';

--- a/packages/testing/src/surface-parity.ts
+++ b/packages/testing/src/surface-parity.ts
@@ -1,0 +1,356 @@
+/**
+ * Example-driven parity checks across shipped surfaces.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { deriveCliPath, filterSurfaceTrails } from '@ontrails/core';
+import type { Topo, Trail, TrailContext, TrailExample } from '@ontrails/core';
+import { deriveHttpInputSource, deriveHttpMethod } from '@ontrails/http';
+import type { HttpMethod } from '@ontrails/http';
+import { MCP_TOOL_ERROR_META_KEY, deriveToolName } from '@ontrails/mcp';
+
+import {
+  createMockResources,
+  defaultCreatePermit,
+  mergeResourceOverrides,
+  mergeTestContext,
+} from './context.js';
+import { deriveTrailExamples } from './effective-examples.js';
+import { createCliHarness } from './harness-cli.js';
+import { createHttpHarness } from './harness-http.js';
+import { createMcpHarness } from './harness-mcp.js';
+import type {
+  CliHarnessResult,
+  HttpHarnessResult,
+  McpHarnessResult,
+  NormalizedSurfaceParityResult,
+  SurfaceParityExclusion,
+  SurfaceParityOptions,
+} from './types.js';
+
+type ParityTrail = Trail<unknown, unknown, unknown>;
+
+export interface SurfaceParityComparison {
+  readonly cli: NormalizedSurfaceParityResult;
+  readonly http: NormalizedSurfaceParityResult;
+  readonly mcp: NormalizedSurfaceParityResult;
+}
+
+const httpPathForTrail = (trailId: string): string =>
+  `/${trailId.replaceAll('.', '/')}`;
+
+const escapeWhitespaceForCliToken = (value: string): string =>
+  value.replaceAll(/\s/gu, (char) => {
+    let escaped = '';
+
+    for (let index = 0; index < char.length; index += 1) {
+      const codePoint = char.codePointAt(index);
+
+      if (codePoint !== undefined) {
+        escaped += `\\u${codePoint.toString(16).padStart(4, '0')}`;
+      }
+    }
+
+    return escaped;
+  });
+
+const cliCommandForExample = (
+  trail: ParityTrail,
+  example: TrailExample<unknown, unknown>
+): string => {
+  const path = deriveCliPath(trail.id).join(' ');
+  const inputJson = escapeWhitespaceForCliToken(
+    JSON.stringify(example.input ?? {})
+  );
+  return `${path} --input-json ${inputJson} --output json`;
+};
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const readTextContent = (content: unknown): string | undefined => {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const firstText = content.find(
+    (item): item is { readonly text: string; readonly type: string } =>
+      isObjectRecord(item) &&
+      item['type'] === 'text' &&
+      typeof item['text'] === 'string'
+  );
+  return firstText?.text;
+};
+
+const parseJsonText = (text: string | undefined): unknown => {
+  if (text === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+const structuredContentValue = (
+  structuredContent: Record<string, unknown> | undefined
+): unknown => {
+  if (structuredContent === undefined) {
+    return undefined;
+  }
+  const keys = Object.keys(structuredContent);
+  return keys.length === 1 && keys[0] === 'data'
+    ? structuredContent['data']
+    : structuredContent;
+};
+
+const normalizeCliResult = (
+  result: CliHarnessResult
+): NormalizedSurfaceParityResult =>
+  result.exitCode === 0
+    ? { ok: true, value: result.json }
+    : {
+        error: {
+          category: result.error?.category ?? 'internal',
+          code: result.error?.code ?? 'InternalError',
+        },
+        ok: false,
+      };
+
+const normalizeHttpResult = (
+  result: HttpHarnessResult
+): NormalizedSurfaceParityResult =>
+  result.ok
+    ? { ok: true, value: result.data }
+    : {
+        error: {
+          category: result.error?.category ?? 'internal',
+          code: result.error?.code ?? 'InternalError',
+        },
+        ok: false,
+      };
+
+const readMcpError = (
+  result: McpHarnessResult
+): { readonly category: string; readonly code: string } => {
+  const errorMeta = result.meta?.[MCP_TOOL_ERROR_META_KEY];
+  if (isObjectRecord(errorMeta)) {
+    return {
+      category:
+        typeof errorMeta['category'] === 'string'
+          ? errorMeta['category']
+          : 'internal',
+      code:
+        typeof errorMeta['name'] === 'string'
+          ? errorMeta['name']
+          : 'InternalError',
+    };
+  }
+  return { category: 'internal', code: 'InternalError' };
+};
+
+const normalizeMcpResult = (
+  result: McpHarnessResult
+): NormalizedSurfaceParityResult =>
+  result.isError
+    ? { error: readMcpError(result), ok: false }
+    : {
+        ok: true,
+        value:
+          result.structuredContent === undefined
+            ? parseJsonText(readTextContent(result.content))
+            : structuredContentValue(result.structuredContent),
+      };
+
+const applyAutoPermit = (
+  ctx: TrailContext,
+  trail: ParityTrail,
+  options: SurfaceParityOptions
+): TrailContext => {
+  if (options.strictPermits || ctx.permit !== undefined) {
+    return ctx;
+  }
+  const permit = (options.createPermit ?? defaultCreatePermit)(trail);
+  return permit === undefined ? ctx : { ...ctx, permit };
+};
+
+const createInvocationContext = async (
+  app: Topo,
+  trail: ParityTrail,
+  options: SurfaceParityOptions
+) => {
+  const autoResources =
+    options.createResources === undefined
+      ? await createMockResources(app)
+      : await options.createResources();
+  const resources = mergeResourceOverrides(
+    autoResources,
+    options.ctx,
+    options.resources
+  );
+  const ctx = applyAutoPermit(mergeTestContext(options.ctx), trail, options);
+  return { ctx, resources };
+};
+
+const mergeSurfaceContext = (
+  ctx: TrailContext,
+  surfaceCtx: Partial<TrailContext> | undefined
+): TrailContext =>
+  surfaceCtx === undefined ? ctx : mergeTestContext({ ...ctx, ...surfaceCtx });
+
+const runCliExample = async (
+  app: Topo,
+  trail: ParityTrail,
+  example: TrailExample<unknown, unknown>,
+  options: SurfaceParityOptions
+): Promise<NormalizedSurfaceParityResult> => {
+  const { ctx, resources } = await createInvocationContext(app, trail, options);
+  const cliOptions = options.cli;
+  const harness = createCliHarness({
+    graph: app,
+    ...cliOptions,
+    ctx: mergeSurfaceContext(ctx, cliOptions?.ctx),
+    resources,
+  });
+  return normalizeCliResult(
+    await harness.run(cliCommandForExample(trail, example))
+  );
+};
+
+const runMcpExample = async (
+  app: Topo,
+  trail: ParityTrail,
+  example: TrailExample<unknown, unknown>,
+  options: SurfaceParityOptions
+): Promise<NormalizedSurfaceParityResult> => {
+  const { ctx, resources } = await createInvocationContext(app, trail, options);
+  const mcpOptions = options.mcp;
+  const harness = createMcpHarness({
+    graph: app,
+    ...mcpOptions,
+    createContext: async () =>
+      mergeSurfaceContext(ctx, await mcpOptions?.createContext?.()),
+    resources,
+  });
+  const toolName = deriveToolName(app.name, trail.id);
+  return normalizeMcpResult(
+    await harness.callTool(
+      toolName,
+      isObjectRecord(example.input) ? example.input : {}
+    )
+  );
+};
+
+const httpRequestForExample = (
+  method: HttpMethod,
+  trailId: string,
+  example: TrailExample<unknown, unknown>
+) => {
+  const input = isObjectRecord(example.input) ? example.input : {};
+  return deriveHttpInputSource(method) === 'query'
+    ? { method, path: httpPathForTrail(trailId), query: input }
+    : { body: input, method, path: httpPathForTrail(trailId) };
+};
+
+const runHttpExample = async (
+  app: Topo,
+  trail: ParityTrail,
+  example: TrailExample<unknown, unknown>,
+  options: SurfaceParityOptions
+): Promise<NormalizedSurfaceParityResult> => {
+  const { ctx, resources } = await createInvocationContext(app, trail, options);
+  const httpOptions = options.http;
+  const harness = createHttpHarness({
+    graph: app,
+    ...httpOptions,
+    ctx: mergeSurfaceContext(ctx, httpOptions?.ctx),
+    resources,
+  });
+  const method = deriveHttpMethod(trail.intent);
+  return normalizeHttpResult(
+    await harness.request(httpRequestForExample(method, trail.id, example))
+  );
+};
+
+export const runSurfaceParityExample = async (
+  app: Topo,
+  trail: ParityTrail,
+  example: TrailExample<unknown, unknown>,
+  options: SurfaceParityOptions = {}
+): Promise<SurfaceParityComparison> => {
+  // CLI harness output capture is process-scoped, so keep surface execution
+  // ordered even though MCP and HTTP do not share that constraint.
+  const cli = await runCliExample(app, trail, example, options);
+  const mcp = await runMcpExample(app, trail, example, options);
+  const http = await runHttpExample(app, trail, example, options);
+  return { cli, http, mcp };
+};
+
+const findExclusion = (
+  exclusions: readonly SurfaceParityExclusion[] | undefined,
+  trail: ParityTrail,
+  example: TrailExample<unknown, unknown>
+): SurfaceParityExclusion | undefined =>
+  exclusions?.find(
+    (exclusion) =>
+      exclusion.trailId === trail.id &&
+      (exclusion.example === undefined || exclusion.example === example.name)
+  );
+
+const parityTrails = (app: Topo): readonly ParityTrail[] =>
+  filterSurfaceTrails(app.list()).filter(
+    (trail) => deriveTrailExamples(trail).length > 0
+  );
+
+/**
+ * Register example-driven parity tests for CLI, MCP, and HTTP.
+ *
+ * @example
+ * ```ts
+ * import { testSurfaceParity } from '@ontrails/testing';
+ * import { graph } from '../src/app.js';
+ *
+ * testSurfaceParity(graph);
+ * ```
+ */
+export const testSurfaceParity = (
+  app: Topo,
+  optionsOrFactory?:
+    | SurfaceParityOptions
+    | (() => SurfaceParityOptions | undefined)
+): void => {
+  const resolveOptions =
+    typeof optionsOrFactory === 'function'
+      ? optionsOrFactory
+      : () => optionsOrFactory;
+
+  describe('surface parity', () => {
+    for (const trail of parityTrails(app)) {
+      describe(trail.id, () => {
+        for (const example of deriveTrailExamples(trail)) {
+          const options = resolveOptions() ?? {};
+          const exclusion = findExclusion(options.exclusions, trail, example);
+          const testName = `example: ${example.name}`;
+          if (exclusion !== undefined) {
+            test.skip(`${testName} (excluded: ${exclusion.reason})`, () => {
+              throw new Error('Skipped parity exclusion should not execute');
+            });
+            continue;
+          }
+
+          test(testName, async () => {
+            const comparison = await runSurfaceParityExample(
+              app,
+              trail,
+              example,
+              resolveOptions() ?? {}
+            );
+            expect(comparison.mcp).toEqual(comparison.cli);
+            expect(comparison.http).toEqual(comparison.cli);
+          });
+        }
+      });
+    }
+  });
+};

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -12,6 +12,7 @@ import type { McpExtra, DeriveMcpToolsOptions } from '@ontrails/mcp';
 import type {
   AnyTrail,
   Logger,
+  ResourceOverrideMap,
   Topo,
   TraceFn,
   TrailContext,
@@ -103,6 +104,13 @@ export interface CliHarness {
 
 /** The result of a CLI harness command execution. */
 export interface CliHarnessResult {
+  readonly error?:
+    | {
+        readonly category: string;
+        readonly code: string;
+        readonly message: string;
+      }
+    | undefined;
   readonly exitCode: number;
   /** Parsed JSON output if --output json was used. */
   readonly json?: unknown | undefined;
@@ -133,6 +141,8 @@ export interface McpHarness {
 export interface McpHarnessResult {
   readonly content: unknown;
   readonly isError: boolean;
+  readonly meta?: Record<string, unknown> | undefined;
+  readonly structuredContent?: Record<string, unknown> | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -218,6 +228,41 @@ export interface HttpHarnessResult {
   readonly ok: boolean;
   readonly status: number;
 }
+
+// ---------------------------------------------------------------------------
+// Surface parity
+// ---------------------------------------------------------------------------
+
+export type SurfaceParitySurface = 'cli' | 'mcp' | 'http';
+
+export interface SurfaceParityExclusion {
+  /** Optional example name. Omit to exclude every example for the trail. */
+  readonly example?: string | undefined;
+  /** Human-readable reason shown in the skipped test name. */
+  readonly reason: string;
+  /** Trail ID to exclude. */
+  readonly trailId: string;
+}
+
+export interface SurfaceParityOptions extends TestAllEstablishedOptions {
+  readonly createResources?:
+    | (() => ResourceOverrideMap | Promise<ResourceOverrideMap>)
+    | undefined;
+  readonly exclusions?: readonly SurfaceParityExclusion[] | undefined;
+}
+
+export type NormalizedSurfaceParityResult =
+  | {
+      readonly ok: true;
+      readonly value: unknown;
+    }
+  | {
+      readonly error: {
+        readonly category: string;
+        readonly code: string;
+      };
+      readonly ok: false;
+    };
 
 // ---------------------------------------------------------------------------
 // Established verification

--- a/scripts/check-readme-snippets.ts
+++ b/scripts/check-readme-snippets.ts
@@ -212,6 +212,7 @@ export const testAll: any;
 export const testContracts: any;
 export const testDetours: any;
 export const testExamples: any;
+export const testSurfaceParity: any;
 export const testTrail: any;
 export const toCommander: any;
 export const tokenPreset: any;


### PR DESCRIPTION
## Context

With HTTP harness coverage and a shipped projection inventory in place, Trails can enforce that authored examples behave consistently across CLI, MCP, and HTTP surfaces.

## What Changed

- Added `testSurfaceParity` and `runSurfaceParityExample` to `@ontrails/testing`.
- Normalized success payloads and public TrailsError category/code pairs across CLI, MCP, and HTTP.
- Extended CLI/MCP harness result shapes needed by parity.
- Added demo-app parity coverage with deterministic per-surface resources and explicit exclusions for generated identity examples.
- Added a CLI JSON whitespace regression test and a branch-local `@ontrails/testing` changeset.

## How To Test

- `bun test packages/testing/src/__tests__/surface-parity.test.ts --bail`
- `bun test apps/trails-demo/__tests__/surface-parity.test.ts --bail`
- `bun test packages/testing`
- `bun test apps/trails-demo`
- `bun run --cwd packages/testing typecheck`
- `bun run typecheck`
- `bun run format:check`
- `bun run docs:snippets`
- `bun run check`
- `git diff --check`

## Risks / Rollout Notes

Parity currently covers CLI/MCP/HTTP. WebSocket remains excluded until it has a public surface package/API.