### PR TITLE
chore: version packages to 1.0.0-beta.17

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -34,6 +34,7 @@
     "beta14-topo-store-stack",
     "beta15-trails-cli-release-prep",
     "beta9-consolidated",
+    "bright-surface-inventory",
     "bug-fixes-beta3",
     "cli-value-aliases",
     "codex-review-fixes",
@@ -42,8 +43,10 @@
     "connector-guardrail-source-comments",
     "core-error-serialization-identity",
     "core-internal-escape-hatches",
+    "curvy-readmes-verify",
     "error-redaction-policy",
     "error-taxonomy-docs-registry",
+    "fair-surface-parity",
     "fix-publish-bugs",
     "fix-workspace-publish",
     "graph-rename-harness",
@@ -65,6 +68,7 @@
     "remove-legacy-logging-package",
     "resource-unmockable-marker",
     "services-primitive",
+    "soft-http-harness",
     "store-adapter-options",
     "surface-map-layer-attachments",
     "survey-brief-trail",
@@ -141,6 +145,7 @@
     "warden-shared-orchestrator",
     "warden-static-resource-accessor",
     "warden-toponames-empty",
+    "warm-api-examples",
     "wayfinder-shell"
   ]
 }

--- a/adapters/commander/CHANGELOG.md
+++ b/adapters/commander/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ontrails/commander
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- 61497c5: Add v1-minimum public API examples for shipped surface entrypoints.
+- Updated dependencies [3dc8254]
+- Updated dependencies [61497c5]
+  - @ontrails/core@1.0.0-beta.17
+  - @ontrails/cli@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Minor Changes

--- a/adapters/commander/package.json
+++ b/adapters/commander/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/commander",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/drizzle/CHANGELOG.md
+++ b/adapters/drizzle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/drizzle
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+  - @ontrails/store@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Patch Changes

--- a/adapters/drizzle/package.json
+++ b/adapters/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/drizzle",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/hono/CHANGELOG.md
+++ b/adapters/hono/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ontrails/hono
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- 61497c5: Add v1-minimum public API examples for shipped surface entrypoints.
+- Updated dependencies [3dc8254]
+- Updated dependencies [61497c5]
+  - @ontrails/core@1.0.0-beta.17
+  - @ontrails/http@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Patch Changes

--- a/adapters/hono/package.json
+++ b/adapters/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/hono",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/vite/CHANGELOG.md
+++ b/adapters/vite/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/vite
 
+## 1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Patch Changes

--- a/adapters/vite/package.json
+++ b/adapters/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/vite",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/apps/trails/CHANGELOG.md
+++ b/apps/trails/CHANGELOG.md
@@ -1,5 +1,23 @@
 # trails
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- 41276d2: Expose a shipped surface projection inventory through survey output and trail detail reports.
+- Updated dependencies [3dc8254]
+- Updated dependencies [61497c5]
+  - @ontrails/core@1.0.0-beta.17
+  - @ontrails/cli@1.0.0-beta.17
+  - @ontrails/commander@1.0.0-beta.17
+  - @ontrails/http@1.0.0-beta.17
+  - @ontrails/mcp@1.0.0-beta.17
+  - @ontrails/observe@1.0.0-beta.17
+  - @ontrails/permits@1.0.0-beta.17
+  - @ontrails/topographer@1.0.0-beta.17
+  - @ontrails/tracing@1.0.0-beta.17
+  - @ontrails/warden@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Major Changes

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/trails",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "bin": {
     "trails": "./bin/trails.ts"
   },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/cli
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- 61497c5: Add v1-minimum public API examples for shipped surface entrypoints.
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/cli",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/config
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- 3dc8254: Fix README TypeScript snippets so the expanded documentation snippet gate can verify them.
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Major Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/config",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/core
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- 3dc8254: Fix README TypeScript snippets so the expanded documentation snippet gate can verify them.
+
 ## 1.0.0-beta.16
 
 ### Major Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/core",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/http
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- 61497c5: Add v1-minimum public API examples for shipped surface entrypoints.
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Minor Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/http",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/logtape/CHANGELOG.md
+++ b/packages/logtape/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/logtape
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- @ontrails/observe@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Major Changes

--- a/packages/logtape/package.json
+++ b/packages/logtape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/logtape",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/mcp
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- 61497c5: Add v1-minimum public API examples for shipped surface entrypoints.
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Minor Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/mcp",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/observe/CHANGELOG.md
+++ b/packages/observe/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/observe
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Minor Changes

--- a/packages/observe/package.json
+++ b/packages/observe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/observe",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/oxlint-plugin/CHANGELOG.md
+++ b/packages/oxlint-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/oxlint-plugin
 
+## 1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Patch Changes

--- a/packages/oxlint-plugin/package.json
+++ b/packages/oxlint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/oxlint-plugin",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/packages/permits/CHANGELOG.md
+++ b/packages/permits/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/permits
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Major Changes

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/permits",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/store/CHANGELOG.md
+++ b/packages/store/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/store
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Major Changes

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/store",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @ontrails/testing
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- ce42573: Add an example-driven CLI/MCP/HTTP surface parity helper.
+- e1eb4ee: Add an HTTP surface harness and include HTTP projection validation in `testAllEstablished`.
+- Updated dependencies [3dc8254]
+- Updated dependencies [61497c5]
+  - @ontrails/core@1.0.0-beta.17
+  - @ontrails/cli@1.0.0-beta.17
+  - @ontrails/http@1.0.0-beta.17
+  - @ontrails/mcp@1.0.0-beta.17
+  - @ontrails/observe@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Minor Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/testing",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/topographer/CHANGELOG.md
+++ b/packages/topographer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/topographer
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Major Changes

--- a/packages/topographer/package.json
+++ b/packages/topographer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/topographer",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "description": "Durable graph substrate for Trails: deterministic TopoGraphs, lockfile helpers, and semantic diffing.",
   "files": [
     "src/**/*.ts",

--- a/packages/tracing/CHANGELOG.md
+++ b/packages/tracing/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/tracing
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Major Changes

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/tracing",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/warden/CHANGELOG.md
+++ b/packages/warden/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ontrails/warden
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [3dc8254]
+- Updated dependencies [61497c5]
+  - @ontrails/core@1.0.0-beta.17
+  - @ontrails/cli@1.0.0-beta.17
+  - @ontrails/permits@1.0.0-beta.17
+  - @ontrails/store@1.0.0-beta.17
+  - @ontrails/topographer@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Minor Changes

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/warden",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "bin": {
     "warden": "./bin/warden.ts"
   },

--- a/packages/wayfinder/CHANGELOG.md
+++ b/packages/wayfinder/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/wayfinder
 
+## 1.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [3dc8254]
+  - @ontrails/core@1.0.0-beta.17
+  - @ontrails/topographer@1.0.0-beta.17
+
 ## 1.0.0-beta.16
 
 ### Major Changes

--- a/packages/wayfinder/package.json
+++ b/packages/wayfinder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/wayfinder",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "description": "Agent-shaped wayfinding trails over @ontrails/topographer artifacts. v0 trails defined in the wayfinding draft ADR; package shell only — no trails ship yet.",
   "files": [
     "src/**/*.ts",


### PR DESCRIPTION
## Summary

- Bump all publishable `@ontrails/*` packages from `1.0.0-beta.16` to `1.0.0-beta.17`.
- Update generated package changelogs from the pending Changesets entries.
- Advance `.changeset/pre.json` so the beta.17 release consumes the newly landed readiness changesets.

## Verification

- `bunx changeset version`
- `bun install --lockfile-only --force`
- `bun run publish:check`
- `bun run format:check`
- `bun run check`
- `git diff --check`

## CI Notes

- The `release:none` label is intentionally applied only as the Changeset gate bypass for this generated version PR.
- Adding a new `.changeset/*.md` entry here would incorrectly queue follow-up beta.18 release content.

## Release Notes

- This PR only versions the packages and changelogs for beta.17.
- No `bun publish`, registry mutation, merge, or merge queue label was performed.
