### PR TITLE
docs(adr): codify web fetch materializer boundary

### DIFF
--- a/docs/adr/0029-connector-extraction-and-the-with-packaging-model.md
+++ b/docs/adr/0029-connector-extraction-and-the-with-packaging-model.md
@@ -4,9 +4,9 @@ slug: connector-extraction-and-the-with-packaging-model
 title: Adapter Extraction and Composition Around Core Contracts
 status: accepted
 created: 2026-04-09
-updated: 2026-05-08
+updated: 2026-05-16
 owners: ['[galligan](https://github.com/galligan)']
-depends_on: [9, 16, 22, 23]
+depends_on: [5, 9, 16, 22, 23]
 ---
 
 # ADR-0029: Adapter Extraction and Composition Around Core Contracts
@@ -142,6 +142,51 @@ That preserves the one-way dependency arrow at the root package while still
 letting Trails ship "quick win" backends as part of the first-party store
 experience.
 
+### Built-in runtime materializers may stay under the owning surface package
+
+The same dependency test applies to runtime surface materializers:
+
+- A runtime materializer that depends only on platform built-ins may live as a
+  subpath of the owning projection package.
+- A runtime materializer that binds Trails to a third-party framework, library,
+  or ecosystem gets an extracted adapter package.
+
+That distinction keeps `derive*` projection APIs pure without forcing every
+`create*` helper into a top-level package. A projection answers, "what does this
+graph look like on this surface?" A materializer answers, "how do I run that
+projection on this host runtime?"
+
+For HTTP:
+
+```text
+@ontrails/http        deriveHttpRoutes(graph)
+@ontrails/http/fetch  createFetchHandler(graph), createRouteHandler(route)
+@ontrails/http/bun    createApp(graph), surface(graph)
+@ontrails/hono        createApp(graph), surface(graph)
+```
+
+`@ontrails/http/fetch` uses Web Standard `Request` and `Response`, which are
+runtime boundary types rather than a third-party framework. It can therefore
+live under `@ontrails/http` without weakening the HTTP route model:
+
+- [ADR-0005: Framework-Agnostic HTTP Route Model](0005-framework-agnostic-http-route-model.md) — `deriveHttpRoutes` continues to expose a framework-agnostic route projection, while the `./fetch` subpath exposes a reusable Web Fetch materializer for adapters and runtimes.
+
+`@ontrails/http/bun` uses Bun's built-in `Bun.serve` routes table. It adds a
+Bun runtime requirement but no package dependency on a third-party framework, so
+it stays as a subpath on `@ontrails/http`. A standalone `@ontrails/bun` package
+would add package ceremony without buying a new dependency or governance
+boundary.
+
+`@ontrails/hono` remains extracted because Hono is a third-party framework and a
+real dependency boundary. It composes over `@ontrails/http/fetch` rather than
+duplicating Web request parsing, error projection, webhook handling, or
+diagnostics.
+
+This rule does not imply a standalone package for every vendor-named adapter.
+For example, v1 OTel support remains at `@ontrails/tracing/otel` unless the
+implementation needs a hard OpenTelemetry SDK dependency or a separate release
+boundary.
+
 ### Adapters can stack
 
 An extracted package can bind a core contract directly, or it can layer on top
@@ -243,6 +288,7 @@ The return type is identical. The topo registration is identical. The trail's `r
 - [ADR-0022: Drizzle Binds Schema-Derived Stores to SQLite](0022-drizzle-store-connector.md) — the first extracted store binding that motivated the packaging model
 - [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md) — the naming heuristic that now favors clear owned-adapter names over prefix magic
 - [ADR-0035: Surface APIs Render the Graph](0035-surface-apis-render-the-graph.md) — the surface composition ladder that extracted runtime adapters build on
+- [ADR-0005: Framework-Agnostic HTTP Route Model](0005-framework-agnostic-http-route-model.md) — the HTTP projection model that `@ontrails/http/fetch` and `@ontrails/http/bun` now materialize without turning `deriveHttpRoutes` into a framework adapter
 - [ADR-0030: Contours as First-Class Domain Objects](0030-contours-as-first-class-domain-objects.md) — upstream of the `/trails` subpath design on adapters
 - [ADR-0031: Backend-Agnostic Store Schemas](0031-backend-agnostic-store-schemas.md) — the store-kind model that makes first-party backends meaningful
 - [ADR: Resource Bundles](drafts/20260409-resource-bundles.md) (draft) — the bundling mechanism for adapter and pack resources
@@ -251,6 +297,7 @@ The return type is identical. The topo registration is identical. The trail's `r
 
 - 2026-04-16: In-place vocabulary update per ADR-0035 Cutover 3 — title updated to drop `with-*` prefix convention, naming rules revised for extracted connectors, migration table and composition layer table aligned with surface API grammar.
 - 2026-05-08: Connector-to-adapter taxonomy cutover — `adapter` becomes the canonical public package category, `integration` is retained only as colloquial prose, `facet` is reserved for projection slices, and the historical `connectors/` workspace root is superseded by `adapters/`.
+- 2026-05-16: Web Fetch kernel amendment — runtime materializers with no third-party dependency may stay as subpaths on the owning projection package, covering `@ontrails/http/fetch` and `@ontrails/http/bun` while preserving `@ontrails/hono` as the extracted Hono adapter.
 
 [^1]: [ADR-0009: First-Class Resources](0009-first-class-resources.md)
 [^2]: See the evaluation hierarchy in [Tenets: Primitives](../tenets.md#the-bar-for-new-primitives)

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -490,6 +490,11 @@
           "fromPath": "docs/adr/0016-schema-derived-persistence.md"
         },
         {
+          "context": "- [ADR-0005: Framework-Agnostic HTTP Route Model](0005-framework-agnostic-http-route-model.md) — `deriveHttpRoutes` continues to expose a framework-agnostic route projection, while the `./fetch` subpa",
+          "from": "0029",
+          "fromPath": "docs/adr/0029-connector-extraction-and-the-with-packaging-model.md"
+        },
+        {
           "context": "- [ADR-0005: Framework-Agnostic HTTP Route Model](0005-framework-agnostic-http-route-model.md)",
           "from": "0035",
           "fromPath": "docs/adr/0035-surface-apis-render-the-graph.md"
@@ -1763,7 +1768,7 @@
     },
     {
       "created": "2026-04-09",
-      "depends_on": ["9", "16", "22", "23"],
+      "depends_on": ["5", "9", "16", "22", "23"],
       "inbound": [
         {
           "context": "The Hono connector lives in its own workspace package (originally shipped as the `@ontrails/http/hono` subpath; see [ADR-0029](./0029-connector-extraction-and-the-with-packaging-model.md)). Two functi",
@@ -1833,7 +1838,7 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Adapter Extraction and Composition Around Core Contracts",
-      "updated": "2026-05-08"
+      "updated": "2026-05-16"
     },
     {
       "created": "2026-04-09",


### PR DESCRIPTION
## Context

Linear: TRL-727
Stack position: 2/14

This codifies the package-boundary rule needed before introducing the Bun-native HTTP subpath.

## Changes

- Amends ADR-0029 to distinguish `derive*` projection APIs from `create*` runtime materializers.
- Documents why Web Fetch and Bun materializers stay under `@ontrails/http` while Hono remains an extracted adapter package.
- Explicitly rejects standalone `@ontrails/bun` for this stack and keeps v1 OTel at `@ontrails/tracing/otel` unless dependency boundaries change.
- Refreshes the ADR decision map.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, docs link/snippet checks.

## Risks / rollout notes

- This is doctrine, not runtime code. The main risk is wording drift; the local docs/ADR review found no P0/P1/P2 issues.
- No standalone `@ontrails/bun` or `@ontrails/otel` package is introduced.