### PR TITLE
refactor(hono): consume web fetch kernel

### DIFF
--- a/.changeset/trl-719-hono-fetch-kernel.md
+++ b/.changeset/trl-719-hono-fetch-kernel.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/hono': patch
+---
+
+Refactor Hono route handling to delegate Web request parsing, response
+projection, diagnostics, permits, and webhook handling through
+`@ontrails/http/fetch`.

--- a/adapters/hono/src/__tests__/surface.test.ts
+++ b/adapters/hono/src/__tests__/surface.test.ts
@@ -391,7 +391,7 @@ describe('surface API (Hono adapter)', () => {
     });
     expect(loggedErrors).toHaveLength(1);
     expect(loggedErrors[0]?.[0]).toBe(
-      '[ontrails:hono] Internal error (req-123)'
+      '[ontrails:http/fetch] Internal error (req-123)'
     );
     const loggedError = loggedErrors[0]?.[1];
     expect(loggedError).toMatchObject({
@@ -518,7 +518,9 @@ describe('surface API (Hono adapter)', () => {
     expect(response.status).toBe(500);
     expect(loggedErrors).toHaveLength(1);
     const label = loggedErrors[0]?.[0];
-    expect(label).toBe('[ontrails:hono] Internal error (req-123_forged_line)');
+    expect(label).toBe(
+      '[ontrails:http/fetch] Internal error (req-123_forged_line)'
+    );
     expect(String(label)).not.toContain('req-123 forged');
     expect(String(label)).not.toContain('forged/line');
   });
@@ -536,7 +538,7 @@ describe('surface API (Hono adapter)', () => {
     expect(response.status).toBe(500);
     expect(loggedErrors).toHaveLength(1);
     expect(loggedErrors[0]?.[0]).toBe(
-      `[ontrails:hono] Internal error (${'x'.repeat(128)})`
+      `[ontrails:http/fetch] Internal error (${'x'.repeat(128)})`
     );
   });
 
@@ -560,7 +562,7 @@ describe('surface API (Hono adapter)', () => {
       },
     });
     expect(loggedErrors).toHaveLength(1);
-    expect(loggedErrors[0]?.[0]).toBe('[ontrails:hono] Internal error');
+    expect(loggedErrors[0]?.[0]).toBe('[ontrails:http/fetch] Internal error');
     const loggedError = loggedErrors[0]?.[1];
     expect(loggedError).toMatchObject({
       message: '[REDACTED]',

--- a/adapters/hono/src/caught-error.ts
+++ b/adapters/hono/src/caught-error.ts
@@ -1,0 +1,65 @@
+import { InternalError, Result, trail } from '@ontrails/core';
+import type { Trail } from '@ontrails/core';
+import { createRouteHandler } from '@ontrails/http';
+import type { HttpRouteDefinition } from '@ontrails/http';
+import { z } from 'zod';
+
+const caughtErrors = new Map<string, Error>();
+const caughtErrorInput = z.object({ errorId: z.string() });
+const caughtErrorTrail = trail('__ontrails.hono.error', {
+  blaze: () =>
+    Result.err(new InternalError('Hono error fallback executed directly')),
+  input: caughtErrorInput,
+  intent: 'read',
+  output: z.object({}),
+}) as Trail<unknown, unknown, unknown>;
+
+const caughtErrorRoute: HttpRouteDefinition = {
+  execute: async (input) => {
+    const parsed = caughtErrorInput.safeParse(input);
+    if (!parsed.success) {
+      return Result.err(
+        new InternalError('Hono error fallback missing error id')
+      );
+    }
+    const error =
+      caughtErrors.get(parsed.data.errorId) ??
+      new Error('Hono error fallback missing caught error');
+    return Result.err(error);
+  },
+  inputSource: 'query',
+  method: 'GET',
+  path: '/__ontrails/hono/error',
+  trail: caughtErrorTrail,
+  trailId: '__ontrails.hono.error',
+};
+const caughtErrorHandler = createRouteHandler(caughtErrorRoute);
+
+const materializeCaughtErrorRequest = (
+  request: Request,
+  errorId: string
+): Request => {
+  const url = new URL('/__ontrails/hono/error', request.url);
+  url.searchParams.set('errorId', errorId);
+  return new Request(url, {
+    headers: request.headers,
+    method: 'GET',
+    signal: request.signal,
+  });
+};
+
+export const handleCaughtHonoError = async (
+  error: unknown,
+  request: Request
+): Promise<Response> => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  const errorId = crypto.randomUUID();
+  caughtErrors.set(errorId, err);
+  try {
+    return await caughtErrorHandler(
+      materializeCaughtErrorRequest(request, errorId)
+    );
+  } finally {
+    caughtErrors.delete(errorId);
+  }
+};

--- a/adapters/hono/src/surface.ts
+++ b/adapters/hono/src/surface.ts
@@ -10,12 +10,6 @@
  * ```
  */
 
-import {
-  isTrailsError,
-  projectErrorDiagnostics,
-  projectPublicSurfaceError,
-  ValidationError,
-} from '@ontrails/core';
 import type {
   BaseSurfaceOptions,
   Layer,
@@ -25,14 +19,13 @@ import type {
 } from '@ontrails/core';
 import { Hono } from 'hono';
 import type { Context as HonoContext } from 'hono';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
-import { deriveHttpRoutes } from '@ontrails/http';
+import { createRouteHandler, deriveHttpRoutes } from '@ontrails/http';
 import type {
-  HttpExecutionContext,
   HttpMethod,
   HttpRouteDefinition,
   ResolveHttpPermit,
 } from '@ontrails/http';
+import { handleCaughtHonoError } from './caught-error.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -54,10 +47,8 @@ export interface CreateAppOptions extends BaseSurfaceOptions {
 }
 
 interface RuntimeOptions {
-  readonly maxJsonBodyBytes: number;
+  readonly maxJsonBodyBytes?: number | undefined;
 }
-
-const DEFAULT_MAX_JSON_BODY_BYTES = 1024 * 1024;
 
 export interface SurfaceHttpResult {
   readonly close: () => Promise<void>;
@@ -65,508 +56,33 @@ export interface SurfaceHttpResult {
 }
 
 // ---------------------------------------------------------------------------
-// Request parsing
-// ---------------------------------------------------------------------------
-
-/**
- * Parse query params into a plain object, preserving scalar-vs-array shape.
- *
- * A single `?tag=one` stays a scalar string, while repeated keys like
- * `?tag=one&tag=two` become arrays. Schema validation owns whether that shape
- * is accepted; the adapter does not coerce singleton values into arrays.
- */
-const parseQueryParams = (c: HonoContext): Record<string, unknown> => {
-  const result: Record<string, unknown> = {};
-  const url = new URL(c.req.url);
-  const seenKeys = new Set<string>();
-
-  for (const key of url.searchParams.keys()) {
-    if (seenKeys.has(key)) {
-      continue;
-    }
-    seenKeys.add(key);
-    const all = url.searchParams.getAll(key);
-    result[key] = all.length > 1 ? all : all[0];
-  }
-
-  return result;
-};
-
-/** Sentinel indicating a JSON parse failure. */
-const JSON_PARSE_ERROR = Symbol('JSON_PARSE_ERROR');
-
-/** Sentinel indicating a JSON body rejected before parsing. */
-const JSON_BODY_TOO_LARGE = Symbol('JSON_BODY_TOO_LARGE');
-
-/** Sentinel indicating malformed body metadata. */
-const JSON_BODY_INVALID_CONTENT_LENGTH = Symbol(
-  'JSON_BODY_INVALID_CONTENT_LENGTH'
-);
-
-interface JsonObject {
-  readonly [key: string]: JsonValue;
-}
-
-type JsonValue =
-  | null
-  | boolean
-  | number
-  | string
-  | readonly JsonValue[]
-  | JsonObject;
-type JsonBodyReadResult =
-  | JsonValue
-  | typeof JSON_BODY_INVALID_CONTENT_LENGTH
-  | typeof JSON_PARSE_ERROR
-  | typeof JSON_BODY_TOO_LARGE;
-type JsonBodyTextReadResult = string | typeof JSON_BODY_TOO_LARGE;
-type InputReadResult = Record<string, unknown> | JsonBodyReadResult;
-
-const CONTENT_LENGTH_DECIMAL_PATTERN = /^\d+$/;
-
-/** Return true when the request has no body content. */
-type ParsedContentLength =
-  | number
-  | typeof JSON_BODY_INVALID_CONTENT_LENGTH
-  | undefined;
-
-const parseContentLength = (
-  contentLength: string | undefined
-): ParsedContentLength => {
-  if (contentLength === undefined) {
-    return undefined;
-  }
-  if (!CONTENT_LENGTH_DECIMAL_PATTERN.test(contentLength)) {
-    return JSON_BODY_INVALID_CONTENT_LENGTH;
-  }
-  const size = Number(contentLength);
-  return Number.isSafeInteger(size) ? size : Number.MAX_SAFE_INTEGER;
-};
-
-const isEmptyBody = (c: HonoContext): boolean => {
-  const contentLength = parseContentLength(c.req.header('Content-Length'));
-  if (contentLength === JSON_BODY_INVALID_CONTENT_LENGTH) {
-    return false;
-  }
-  if (contentLength !== undefined) {
-    return contentLength === 0;
-  }
-  // No Content-Length header — treat as empty when Content-Type is also absent.
-  return c.req.header('Content-Type') === undefined;
-};
-
-const resolveMaxJsonBodyBytes = (value: number | undefined): number => {
-  const maxJsonBodyBytes = value ?? DEFAULT_MAX_JSON_BODY_BYTES;
-
-  if (!Number.isFinite(maxJsonBodyBytes) || maxJsonBodyBytes < 1) {
-    throw new ValidationError(
-      'maxJsonBodyBytes must be a positive finite number'
-    );
-  }
-
-  return maxJsonBodyBytes;
-};
-
-const hasOversizedContentLength = (
-  c: HonoContext,
-  maxJsonBodyBytes: number
-): boolean => {
-  const contentLength = c.req.header('Content-Length');
-  if (contentLength === undefined) {
-    return false;
-  }
-  const size = parseContentLength(contentLength);
-  if (size === JSON_BODY_INVALID_CONTENT_LENGTH) {
-    return false;
-  }
-  return size !== undefined && size > maxJsonBodyBytes;
-};
-
-const measureBodyTextBytes = (text: string): number => new Blob([text]).size;
-
-const validateCachedBodyText = (
-  text: string,
-  maxJsonBodyBytes: number
-): JsonBodyTextReadResult =>
-  measureBodyTextBytes(text) > maxJsonBodyBytes ? JSON_BODY_TOO_LARGE : text;
-
-const readCachedBodyText = async (
-  c: HonoContext,
-  maxJsonBodyBytes: number
-): Promise<JsonBodyTextReadResult> =>
-  validateCachedBodyText(await c.req.text(), maxJsonBodyBytes);
-
-const readBodyText = async (
-  c: HonoContext,
-  maxJsonBodyBytes: number
-): Promise<string | typeof JSON_BODY_TOO_LARGE> => {
-  if (c.req.raw.bodyUsed) {
-    return await readCachedBodyText(c, maxJsonBodyBytes);
-  }
-
-  const { body } = c.req.raw;
-  if (body === null) {
-    return '';
-  }
-
-  const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
-  let totalBytes = 0;
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-      if (value === undefined) {
-        continue;
-      }
-      totalBytes += value.byteLength;
-      if (totalBytes > maxJsonBodyBytes) {
-        await reader.cancel();
-        return JSON_BODY_TOO_LARGE;
-      }
-      chunks.push(value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-
-  const bytes = new Uint8Array(totalBytes);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-
-  return new TextDecoder().decode(bytes);
-};
-
-const readJsonBody = async (
-  c: HonoContext,
-  maxJsonBodyBytes: number
-): Promise<JsonBodyReadResult> => {
-  if (
-    parseContentLength(c.req.header('Content-Length')) ===
-    JSON_BODY_INVALID_CONTENT_LENGTH
-  ) {
-    return JSON_BODY_INVALID_CONTENT_LENGTH;
-  }
-
-  if (hasOversizedContentLength(c, maxJsonBodyBytes)) {
-    return JSON_BODY_TOO_LARGE;
-  }
-
-  const text = await readBodyText(c, maxJsonBodyBytes);
-  if (text === JSON_BODY_TOO_LARGE) {
-    return JSON_BODY_TOO_LARGE;
-  }
-
-  try {
-    return JSON.parse(text) as JsonValue;
-  } catch {
-    return JSON_PARSE_ERROR;
-  }
-};
-
-const parseJsonBodyText = (text: string): JsonBodyReadResult => {
-  try {
-    return JSON.parse(text) as JsonValue;
-  } catch {
-    return JSON_PARSE_ERROR;
-  }
-};
-
-const parseWebhookBodyText = (
-  c: HonoContext,
-  text: string
-): JsonBodyReadResult =>
-  isEmptyBody(c) || text.length === 0 ? {} : parseJsonBodyText(text);
-
-const readWebhookBodyText = async (
-  c: HonoContext,
-  maxJsonBodyBytes: number
-): Promise<
-  string | typeof JSON_BODY_INVALID_CONTENT_LENGTH | typeof JSON_BODY_TOO_LARGE
-> => {
-  if (
-    parseContentLength(c.req.header('Content-Length')) ===
-    JSON_BODY_INVALID_CONTENT_LENGTH
-  ) {
-    return JSON_BODY_INVALID_CONTENT_LENGTH;
-  }
-  if (hasOversizedContentLength(c, maxJsonBodyBytes)) {
-    return JSON_BODY_TOO_LARGE;
-  }
-  return await readBodyText(c, maxJsonBodyBytes);
-};
-
-/** Read input from request based on input source. */
-const readInput = async (
-  c: HonoContext,
-  inputSource: 'query' | 'body',
-  options: RuntimeOptions
-): Promise<InputReadResult> => {
-  if (inputSource === 'query') {
-    return parseQueryParams(c);
-  }
-  if (isEmptyBody(c)) {
-    return {};
-  }
-  return await readJsonBody(c, options.maxJsonBodyBytes);
-};
-
-// ---------------------------------------------------------------------------
-// Response mapping
-// ---------------------------------------------------------------------------
-
-/** Map a TrailsError or generic Error to an HTTP error response. */
-const mapErrorResponse = (
-  error: Error
-): { body: Record<string, unknown>; status: ContentfulStatusCode } => {
-  const projection = projectPublicSurfaceError('http', error);
-  return {
-    body: {
-      error: {
-        category: projection.category,
-        code: projection.name,
-        message: projection.message,
-      },
-    },
-    status: projection.code as ContentfulStatusCode,
-  };
-};
-
-const LOG_UNSAFE_LABEL_CHARACTERS = /[^\w:.-]/g;
-const MAX_DIAGNOSTIC_LABEL_VALUE_LENGTH = 128;
-
-const sanitizeDiagnosticLabelValue = (value: string): string =>
-  value
-    .replace(LOG_UNSAFE_LABEL_CHARACTERS, '_')
-    .slice(0, MAX_DIAGNOSTIC_LABEL_VALUE_LENGTH);
-
-const reportInternalDiagnostics = (error: Error, c: HonoContext): void => {
-  if (isTrailsError(error)) {
-    return;
-  }
-
-  const requestId = c.req.header('X-Request-ID');
-  const safeRequestId =
-    requestId === undefined
-      ? undefined
-      : sanitizeDiagnosticLabelValue(requestId);
-  const label =
-    safeRequestId === undefined
-      ? '[ontrails:hono] Internal error'
-      : `[ontrails:hono] Internal error (${safeRequestId})`;
-  console.error(label, projectErrorDiagnostics(error));
-};
-
-// ---------------------------------------------------------------------------
 // Route registration
 // ---------------------------------------------------------------------------
 
-/** Map a Result to an HTTP response via Hono context. */
-const mapResultToResponse = (
-  result: { isOk(): boolean; value?: unknown; error?: Error },
-  c: HonoContext
-): Response => {
-  if (result.isOk()) {
-    return c.json({ data: result.value }, 200);
-  }
-  const error = result.error ?? new Error('Unknown error');
-  reportInternalDiagnostics(error, c);
-  const { body, status } = mapErrorResponse(error);
-  return c.json(body, status);
-};
-
-/** Convert a caught unknown value to an error response. */
-const handleCaughtError = (error: unknown, c: HonoContext): Response => {
-  const err = error instanceof Error ? error : new Error(String(error));
-  reportInternalDiagnostics(err, c);
-  const { body, status } = mapErrorResponse(err);
-  return c.json(body, status);
-};
-
-const invalidJsonResponse = (c: HonoContext): Response =>
-  c.json(
-    {
-      error: {
-        category: 'validation',
-        code: 'ValidationError',
-        message: 'Invalid JSON in request body',
-      },
-    },
-    400
-  );
-
-const invalidContentLengthResponse = (c: HonoContext): Response =>
-  c.json(
-    {
-      error: {
-        category: 'validation',
-        code: 'ValidationError',
-        message: 'Invalid Content-Length header',
-      },
-    },
-    400
-  );
-
-const oversizedJsonBodyResponse = (
-  c: HonoContext,
-  options: RuntimeOptions
-): Response =>
-  c.json(
-    {
-      error: {
-        category: 'validation',
-        code: 'ValidationError',
-        message: `JSON request body exceeds ${options.maxJsonBodyBytes} bytes`,
-      },
-    },
-    413
-  );
-
-const collectHeaders = (c: HonoContext): Record<string, string> => {
-  const headers: Record<string, string> = {};
-  for (const [key, value] of c.req.raw.headers) {
-    headers[key] = value;
-  }
-  return headers;
-};
-
-const createHttpExecutionContext = (c: HonoContext): HttpExecutionContext => ({
-  headers: c.req.raw.headers,
-});
-
-const createWebhookVerifyRequest = (
-  c: HonoContext,
-  body: string
-): {
-  readonly body: string;
-  readonly headers: Record<string, string>;
-  readonly method: string;
-  readonly path: string;
-} => ({
-  body,
-  headers: collectHeaders(c),
-  method: c.req.method,
-  path: new URL(c.req.url).pathname,
-});
-
-const recordInvalidWebhook = async (
-  route: HttpRouteDefinition,
-  errorCategory = 'validation'
-): Promise<void> => {
-  await route.recordWebhookInvalid?.(errorCategory);
-};
-
-const errorCategoryForWebhookFailure = (error: Error | undefined): string =>
-  error !== undefined && isTrailsError(error) ? error.category : 'internal';
-
-const handleWebhookRoute = async (
-  route: HttpRouteDefinition,
-  options: RuntimeOptions,
-  c: HonoContext
-): Promise<Response> => {
-  const rawBody = await readWebhookBodyText(c, options.maxJsonBodyBytes);
-
-  if (rawBody === JSON_BODY_INVALID_CONTENT_LENGTH) {
-    await recordInvalidWebhook(route);
-    return invalidContentLengthResponse(c);
+const materializeHonoRequest = async (c: HonoContext): Promise<Request> => {
+  if (!c.req.raw.bodyUsed) {
+    return c.req.raw;
   }
 
-  if (rawBody === JSON_BODY_TOO_LARGE) {
-    await recordInvalidWebhook(route);
-    return oversizedJsonBodyResponse(c, options);
-  }
-
-  const verified = await route.verifyWebhook?.(
-    createWebhookVerifyRequest(c, rawBody)
-  );
-  if (verified?.isErr()) {
-    await recordInvalidWebhook(
-      route,
-      errorCategoryForWebhookFailure(verified.error)
-    );
-    return mapResultToResponse(verified, c);
-  }
-
-  const jsonBody = parseWebhookBodyText(c, rawBody);
-  if (jsonBody === JSON_PARSE_ERROR) {
-    await recordInvalidWebhook(route);
-    return invalidJsonResponse(c);
-  }
-
-  const parsed = route.parseWebhookInput?.(jsonBody);
-  if (parsed === undefined) {
-    await recordInvalidWebhook(route);
-    return mapResultToResponse(
-      {
-        error: new ValidationError('Webhook route is missing parse handler'),
-        isOk: () => false,
-      },
-      c
-    );
-  }
-  if (parsed.isErr()) {
-    await recordInvalidWebhook(route);
-    return mapResultToResponse(parsed, c);
-  }
-
-  const requestId = c.req.header('X-Request-ID') ?? undefined;
-  const { signal: abortSignal } = c.req.raw;
-  const result = await route.execute(
-    parsed.value,
-    requestId,
-    abortSignal,
-    createHttpExecutionContext(c)
-  );
-  return mapResultToResponse(result, c);
+  const body = await c.req.text();
+  return new Request(c.req.raw.url, {
+    body,
+    headers: c.req.raw.headers,
+    method: c.req.raw.method,
+    signal: c.req.raw.signal,
+  });
 };
 
 /** Create a Hono handler from a route definition. */
-const createHonoHandler =
-  (route: HttpRouteDefinition, options: RuntimeOptions) =>
-  async (c: HonoContext): Promise<Response> => {
-    if (route.inputSource === 'webhook') {
-      try {
-        return await handleWebhookRoute(route, options, c);
-      } catch (error: unknown) {
-        return handleCaughtError(error, c);
-      }
-    }
-
-    const rawInput = await readInput(c, route.inputSource, options);
-
-    if (rawInput === JSON_PARSE_ERROR) {
-      return invalidJsonResponse(c);
-    }
-
-    if (rawInput === JSON_BODY_INVALID_CONTENT_LENGTH) {
-      return invalidContentLengthResponse(c);
-    }
-
-    if (rawInput === JSON_BODY_TOO_LARGE) {
-      return oversizedJsonBodyResponse(c, options);
-    }
-
-    const requestId = c.req.header('X-Request-ID') ?? undefined;
-    const { signal: abortSignal } = c.req.raw;
-
-    try {
-      const result = await route.execute(
-        rawInput,
-        requestId,
-        abortSignal,
-        createHttpExecutionContext(c)
-      );
-      return mapResultToResponse(result, c);
-    } catch (error: unknown) {
-      return handleCaughtError(error, c);
-    }
-  };
+const createHonoHandler = (
+  route: HttpRouteDefinition,
+  options: RuntimeOptions
+): ((c: HonoContext) => Promise<Response>) => {
+  const handler = createRouteHandler(route, {
+    maxJsonBodyBytes: options.maxJsonBodyBytes,
+  });
+  return async (c) => handler(await materializeHonoRequest(c));
+};
 
 /** Route registration keyed by HTTP method. */
 const routeRegistrars: Record<
@@ -609,6 +125,11 @@ const registerRoutes = (
 // Global error handler
 // ---------------------------------------------------------------------------
 
+const handleCaughtError = async (
+  error: unknown,
+  c: HonoContext
+): Promise<Response> => handleCaughtHonoError(error, c.req.raw);
+
 const registerErrorHandler = (hono: Hono): void => {
   // oxlint-disable-next-line prefer-await-to-callbacks -- Hono's onError API requires a callback
   hono.onError((err, c) => handleCaughtError(err, c));
@@ -643,7 +164,7 @@ export const createApp = (
 ): Hono => {
   const hono = new Hono();
   const runtimeOptions = {
-    maxJsonBodyBytes: resolveMaxJsonBodyBytes(options.maxJsonBodyBytes),
+    maxJsonBodyBytes: options.maxJsonBodyBytes,
   };
 
   registerErrorHandler(hono);


### PR DESCRIPTION
## Context

Linear: TRL-719
Stack position: 3/14

Hono should use the shared Web Fetch kernel without changing its public API, route order, Hono path semantics, or server lifecycle.

## Changes

- Refactors `@ontrails/hono` to route requests through `createRouteHandler` from `@ontrails/http/fetch`.
- Preserves `createApp` / `surface` public exports and Hono-owned server materialization.
- Keeps Hono-specific route registration and lifecycle behavior in the adapter while removing duplicated request parsing and error projection.
- Updates Hono tests for the kernel-backed behavior.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: `bun run --cwd adapters/hono test`, `bun run --cwd adapters/hono typecheck`, `bun run --cwd adapters/hono lint`.

## Risks / rollout notes

- The sensitive area is route behavior parity with the previous Hono implementation. The subsequent parity branch locks Hono/Bun behavior over shared cases.
- Hono unmatched-route behavior remains Hono-owned and is not forced into the kernel fallback shape.