### PR TITLE
feat(http): add bun-native surface

### DIFF
--- a/.changeset/trl-716-http-bun.md
+++ b/.changeset/trl-716-http-bun.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/http': minor
+---
+
+Add `@ontrails/http/bun`, a Bun-native HTTP surface materializer backed by the
+shared Web Fetch kernel.

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -22,6 +22,18 @@ await surface(graph, { port: 3000 });
 
 This starts a Hono-based HTTP server. The `greet` trail becomes `GET /greet?name=...` because its `intent` is `'read'`.
 
+For Bun-native HTTP without Hono, use the Bun materializer subpath:
+
+```typescript
+import { surface } from '@ontrails/http/bun';
+
+await surface(graph, { port: 3000 });
+```
+
+`@ontrails/http/bun` uses Bun's native `Bun.serve({ routes })` fast path and
+keeps the shared Web Fetch handler as the fallback. It requires Bun `>=1.2.3`
+and does not add a third-party runtime dependency.
+
 For more control, build the routes yourself:
 
 ```typescript
@@ -53,6 +65,8 @@ contracts used by `deriveHttpRoutes()`.
 | --- | --- |
 | `deriveHttpRoutes(graph, options?)` | Build framework-agnostic route definitions from a topo |
 | `deriveOpenApiSpec(graph, options?)` | Generate an OpenAPI 3.1 document for the HTTP surface |
+| `@ontrails/http/fetch` | Shared Web Fetch request/response kernel for route materializers |
+| `@ontrails/http/bun` | Bun-native `createApp()` and `surface()` materializer |
 
 ## Route derivation
 
@@ -114,6 +128,8 @@ values into arrays.
 
 ```bash
 bun add @ontrails/http @ontrails/hono
+# or, for Bun-native serving:
+bun add @ontrails/http
 ```
 
 ## Migration

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -12,6 +12,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./bun": "./src/bun.ts",
     "./fetch": "./src/fetch.ts",
     "./package.json": "./package.json"
   },

--- a/packages/http/src/__tests__/bun.test.ts
+++ b/packages/http/src/__tests__/bun.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import {
+  PermissionError,
+  Result,
+  clearTraceSink,
+  getWebhookHeader,
+  registerTraceSink,
+  trail,
+  topo,
+  webhook,
+} from '@ontrails/core';
+import type { TraceRecord, TraceSink } from '@ontrails/core';
+import { z } from 'zod';
+
+import { createApp, surface } from '../bun.js';
+
+let originalConsoleError = console.error;
+let loggedErrors: unknown[][] = [];
+
+beforeEach(() => {
+  originalConsoleError = console.error;
+  loggedErrors = [];
+  console.error = mock((...args: unknown[]) => {
+    loggedErrors.push(args);
+  });
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+  loggedErrors = [];
+  clearTraceSink();
+});
+
+const echoTrail = trail('echo', {
+  blaze: (input) => Result.ok({ reply: input.message }),
+  input: z.object({ message: z.string() }),
+  intent: 'read',
+  output: z.object({ reply: z.string() }),
+});
+
+const echoBodyTrail = trail('echo.body', {
+  blaze: (input) => Result.ok({ length: input.message.length }),
+  input: z.object({ message: z.string() }),
+  intent: 'write',
+  output: z.object({ length: z.number() }),
+});
+
+const tagsTrail = trail('tags', {
+  blaze: (input) => Result.ok({ tags: input.tags }),
+  input: z.object({ tags: z.array(z.string()) }),
+  intent: 'read',
+  output: z.object({ tags: z.array(z.string()) }),
+});
+
+const genericErrorTrail = trail('generic.error', {
+  blaze: () => Result.err(new Error('database password=secret')),
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+});
+
+const protectedTrail = trail('permit.scope', {
+  blaze: (_input, ctx) =>
+    Result.ok({
+      permitId: ctx.permit?.id,
+      requestId: ctx.requestId,
+    }),
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({
+    permitId: z.string().optional(),
+    requestId: z.string().optional(),
+  }),
+  permit: { scopes: ['thing:read'] },
+});
+
+const webhookSecret = 'secret';
+const paymentWebhook = webhook('webhook.payment.received', {
+  parse: z.object({ paymentId: z.string() }),
+  path: '/webhooks/payment',
+  verify: (request) =>
+    getWebhookHeader(request, 'x-webhook-secret') === webhookSecret
+      ? Result.ok()
+      : Result.err(new PermissionError('Invalid webhook secret')),
+});
+
+const paymentWebhookTrail = trail('payment.receive', {
+  blaze: (input) => Result.ok({ paymentId: input.paymentId }),
+  input: z.object({ paymentId: z.string() }),
+  on: [paymentWebhook],
+  output: z.object({ paymentId: z.string() }),
+});
+
+const buildRequest = (path: string, init: RequestInit = {}): Request =>
+  new Request(new URL(path, 'http://localhost').toString(), init);
+
+const createCapturingSink = (records: TraceRecord[]): TraceSink => ({
+  write(record) {
+    records.push(record);
+  },
+});
+
+describe('@ontrails/http/bun', () => {
+  test('materializes Bun native routes for derived HTTP trails', async () => {
+    const app = createApp(topo('bun-api', { echoTrail }));
+    const handler = app.routes['/echo']?.GET;
+
+    expect(handler).toBeDefined();
+    if (handler === undefined) {
+      return;
+    }
+
+    const response = await handler(buildRequest('/echo?message=hello'));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: { reply: 'hello' } });
+  });
+
+  test('uses the shared fetch kernel as fallback for unmatched requests', async () => {
+    const app = createApp(topo('bun-api', { echoTrail }));
+
+    const response = await app.fetch(buildRequest('/missing'));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'not_found',
+        code: 'NotFoundError',
+        message: 'HTTP route not found: /missing',
+      },
+    });
+  });
+
+  test('returns method not allowed when fallback sees a registered path', async () => {
+    const app = createApp(topo('bun-api', { echoTrail }));
+
+    const response = await app.fetch(buildRequest('/echo', { method: 'POST' }));
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('Allow')).toBe('GET, HEAD');
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'validation',
+        code: 'MethodNotAllowed',
+        message: 'HTTP method not allowed: POST /echo',
+      },
+    });
+  });
+
+  test('serves GET trails through bodyless HEAD handlers', async () => {
+    const app = createApp(topo('bun-api', { echoTrail }));
+    const handler = app.routes['/echo']?.HEAD;
+
+    expect(handler).toBeDefined();
+    if (handler === undefined) {
+      return;
+    }
+
+    const response = await handler(
+      buildRequest('/echo?message=hello', {
+        method: 'HEAD',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBeNull();
+    expect(await response.text()).toBe('');
+  });
+
+  test('keeps fallback HEAD responses bodyless', async () => {
+    const app = createApp(topo('bun-api', { echoBodyTrail }));
+
+    const missing = await app.fetch(
+      buildRequest('/missing', { method: 'HEAD' })
+    );
+    const methodMismatch = await app.fetch(
+      buildRequest('/echo/body', { method: 'HEAD' })
+    );
+
+    expect(missing.status).toBe(404);
+    expect(missing.body).toBeNull();
+    expect(await missing.text()).toBe('');
+    expect(methodMismatch.status).toBe(405);
+    expect(methodMismatch.headers.get('Allow')).toBe('POST');
+    expect(methodMismatch.body).toBeNull();
+    expect(await methodMismatch.text()).toBe('');
+  });
+
+  test('preserves query, body, and validation behavior through native routes', async () => {
+    const app = createApp(topo('bun-api', { echoBodyTrail, tagsTrail }), {
+      maxJsonBodyBytes: 20,
+    });
+    const tagsHandler = app.routes['/tags']?.GET;
+    const bodyHandler = app.routes['/echo/body']?.POST;
+
+    expect(tagsHandler).toBeDefined();
+    expect(bodyHandler).toBeDefined();
+    if (tagsHandler === undefined || bodyHandler === undefined) {
+      return;
+    }
+
+    const repeated = await tagsHandler(
+      buildRequest('/tags?tags=red&tags=blue')
+    );
+    const singleton = await tagsHandler(buildRequest('/tags?tags=solo'));
+    const oversized = await bodyHandler(
+      buildRequest('/echo/body', {
+        body: JSON.stringify({ message: 'too large' }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      })
+    );
+
+    expect(repeated.status).toBe(200);
+    expect(await repeated.json()).toEqual({
+      data: { tags: ['red', 'blue'] },
+    });
+    expect(singleton.status).toBe(400);
+    expect(await singleton.json()).toMatchObject({
+      error: { category: 'validation' },
+    });
+    expect(oversized.status).toBe(413);
+    expect(await oversized.json()).toEqual({
+      error: {
+        category: 'validation',
+        code: 'ValidationError',
+        message: 'JSON request body exceeds 20 bytes',
+      },
+    });
+  });
+
+  test('forwards permit headers, request id, and abort signals through native routes', async () => {
+    let observedHeader: string | null | undefined;
+    let observedSignalAborted: boolean | undefined;
+    const abortingTrail = trail('abort.check', {
+      blaze: (_input, ctx) => {
+        observedSignalAborted = ctx.abortSignal.aborted;
+        return Result.ok({ aborted: ctx.abortSignal.aborted });
+      },
+      input: z.object({}),
+      intent: 'read',
+      output: z.object({ aborted: z.boolean() }),
+    });
+    const app = createApp(topo('bun-api', { abortingTrail, protectedTrail }), {
+      resolvePermit: ({ headers }) => {
+        observedHeader =
+          headers instanceof Headers ? headers.get('x-tenant-id') : undefined;
+        return Result.ok({ id: 'user-1', scopes: ['thing:read'] });
+      },
+    });
+    const permitHandler = app.routes['/permit/scope']?.GET;
+    const abortHandler = app.routes['/abort/check']?.GET;
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(permitHandler).toBeDefined();
+    expect(abortHandler).toBeDefined();
+    if (permitHandler === undefined || abortHandler === undefined) {
+      return;
+    }
+
+    const permitResponse = await permitHandler(
+      buildRequest('/permit/scope', {
+        headers: {
+          Authorization: 'Bearer strong',
+          'X-Request-ID': 'req-1',
+          'X-Tenant-ID': 'tenant-1',
+        },
+      })
+    );
+    const abortResponse = await abortHandler(
+      buildRequest('/abort/check', { signal: controller.signal })
+    );
+
+    expect(permitResponse.status).toBe(200);
+    expect(await permitResponse.json()).toEqual({
+      data: { permitId: 'user-1', requestId: 'req-1' },
+    });
+    expect(observedHeader).toBe('tenant-1');
+    expect(abortResponse.status).toBe(200);
+    expect(await abortResponse.json()).toEqual({
+      data: { aborted: true },
+    });
+    expect(observedSignalAborted).toBe(true);
+  });
+
+  test('handles webhook verify, parse, and invalid recording behavior through native routes', async () => {
+    const records: TraceRecord[] = [];
+    const app = createApp(topo('bun-api', { paymentWebhookTrail }));
+    const handler = app.routes['/webhooks/payment']?.POST;
+
+    expect(handler).toBeDefined();
+    if (handler === undefined) {
+      return;
+    }
+
+    registerTraceSink(createCapturingSink(records));
+
+    const verified = await handler(
+      buildRequest('/webhooks/payment', {
+        body: JSON.stringify({ paymentId: 'pay_1' }),
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Secret': webhookSecret,
+        },
+        method: 'POST',
+      })
+    );
+    const denied = await handler(
+      buildRequest('/webhooks/payment', {
+        body: JSON.stringify({ paymentId: 'pay_1' }),
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Secret': 'wrong',
+        },
+        method: 'POST',
+      })
+    );
+    const invalidPayload = await handler(
+      buildRequest('/webhooks/payment', {
+        body: JSON.stringify({ paymentId: 123 }),
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Secret': webhookSecret,
+        },
+        method: 'POST',
+      })
+    );
+
+    expect(verified.status).toBe(200);
+    expect(await verified.json()).toEqual({
+      data: { paymentId: 'pay_1' },
+    });
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toMatchObject({
+      error: { category: 'permission' },
+    });
+    expect(invalidPayload.status).toBe(400);
+    expect(await invalidPayload.json()).toMatchObject({
+      error: { category: 'validation' },
+    });
+    expect(
+      records.filter(
+        (record) =>
+          record.kind === 'activation' &&
+          record.name === 'activation.webhook.invalid'
+      )
+    ).toHaveLength(2);
+  });
+
+  test('maps Bun onError failures through the shared error projection', async () => {
+    const app = createApp(topo('bun-api', { genericErrorTrail }));
+
+    const response = await app.onError(new Error('database password=secret'));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'internal',
+        code: 'InternalError',
+        message: 'Internal server error',
+      },
+    });
+    expect(loggedErrors).toHaveLength(1);
+    expect(JSON.stringify(loggedErrors[0])).not.toContain('secret');
+  });
+
+  test('surface starts Bun.serve with native routes and a close handle', async () => {
+    const handle = await surface(topo('bun-api', { echoTrail }), { port: 0 });
+
+    try {
+      const response = await fetch(new URL('/echo?message=served', handle.url));
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        data: { reply: 'served' },
+      });
+    } finally {
+      await handle.close();
+    }
+  });
+});

--- a/packages/http/src/bun.ts
+++ b/packages/http/src/bun.ts
@@ -1,0 +1,270 @@
+import {
+  InternalError,
+  NotFoundError,
+  Result,
+  projectPublicSurfaceError,
+  trail,
+} from '@ontrails/core';
+import type {
+  BaseSurfaceOptions,
+  Layer,
+  ResourceOverrideMap,
+  Topo,
+  Trail,
+  TrailContextInit,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+import { deriveHttpRoutes } from './build.js';
+import type {
+  HttpMethod,
+  HttpRouteDefinition,
+  ResolveHttpPermit,
+} from './build.js';
+import { createRouteHandler } from './fetch.js';
+import type { CreateRouteHandlerOptions } from './fetch.js';
+
+export interface CreateAppOptions extends BaseSurfaceOptions {
+  readonly basePath?: string | undefined;
+  readonly createContext?:
+    | (() => TrailContextInit | Promise<TrailContextInit>)
+    | undefined;
+  readonly hostname?: string | undefined;
+  readonly layers?: readonly Layer[] | undefined;
+  /** Maximum JSON request body size in bytes. Defaults to 1 MiB. */
+  readonly maxJsonBodyBytes?: number | undefined;
+  readonly port?: number | undefined;
+  readonly resources?: ResourceOverrideMap | undefined;
+  readonly resolvePermit?: ResolveHttpPermit | undefined;
+}
+
+export interface SurfaceHttpResult {
+  readonly close: () => Promise<void>;
+  readonly url: string;
+}
+
+type RouteHandler = (request: Request) => Promise<Response>;
+
+type BunRouteMethod = HttpMethod | 'HEAD';
+type BunRouteRecord = Record<
+  string,
+  Partial<Record<BunRouteMethod, RouteHandler>>
+>;
+
+export interface BunHttpApp {
+  readonly fetch: RouteHandler;
+  readonly onError: (error: Error) => Promise<Response>;
+  readonly routes: BunRouteRecord;
+}
+
+const json = (body: Record<string, unknown>, status: number): Response =>
+  Response.json(body, { status });
+
+const mapErrorResponse = (error: Error): Response => {
+  const projection = projectPublicSurfaceError('http', error);
+  return json(
+    {
+      error: {
+        category: projection.category,
+        code: projection.name,
+        message: projection.message,
+      },
+    },
+    projection.code
+  );
+};
+
+const notFoundResponse = (request: Request): Response => {
+  const path = new URL(request.url).pathname;
+  return mapErrorResponse(new NotFoundError(`HTTP route not found: ${path}`));
+};
+
+const methodNotAllowedResponse = (
+  request: Request,
+  route: Partial<Record<BunRouteMethod, RouteHandler>>
+): Response => {
+  const path = new URL(request.url).pathname;
+  return Response.json(
+    {
+      error: {
+        category: 'validation',
+        code: 'MethodNotAllowed',
+        message: `HTTP method not allowed: ${request.method.toUpperCase()} ${path}`,
+      },
+    },
+    {
+      headers: { Allow: Object.keys(route).toSorted().join(', ') },
+      status: 405,
+    }
+  );
+};
+
+const bodylessHeadResponse = (response: Response): Response =>
+  new Response(null, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+
+const caughtErrors = new Map<string, Error>();
+const caughtErrorInput = z.object({ errorId: z.string() });
+const caughtErrorTrail = trail('__ontrails.http.bun.error', {
+  blaze: () =>
+    Result.err(new InternalError('Bun error fallback executed directly')),
+  input: caughtErrorInput,
+  intent: 'read',
+  output: z.object({}),
+}) as Trail<unknown, unknown, unknown>;
+
+const caughtErrorRoute: HttpRouteDefinition = {
+  execute: async (input) => {
+    const parsed = caughtErrorInput.safeParse(input);
+    if (!parsed.success) {
+      return Result.err(
+        new InternalError('Bun error fallback missing error id')
+      );
+    }
+    const error =
+      caughtErrors.get(parsed.data.errorId) ??
+      new Error('Bun error fallback missing caught error');
+    return Result.err(error);
+  },
+  inputSource: 'query',
+  method: 'GET',
+  path: '/__ontrails/http/bun/error',
+  trail: caughtErrorTrail,
+  trailId: '__ontrails.http.bun.error',
+};
+const caughtErrorHandler = createRouteHandler(caughtErrorRoute);
+
+const materializeCaughtErrorRequest = (errorId: string): Request => {
+  const url = new URL('/__ontrails/http/bun/error', 'http://localhost');
+  url.searchParams.set('errorId', errorId);
+  return new Request(url);
+};
+
+const deriveOptions = (options: CreateAppOptions) => ({
+  basePath: options.basePath,
+  configValues: options.configValues,
+  createContext: options.createContext,
+  exclude: options.exclude,
+  include: options.include,
+  intent: options.intent,
+  layers: options.layers,
+  resolvePermit: options.resolvePermit,
+  resources: options.resources,
+  validate: options.validate,
+});
+
+const routeHandlerOptions = (
+  options: CreateAppOptions
+): CreateRouteHandlerOptions => ({
+  maxJsonBodyBytes: options.maxJsonBodyBytes,
+});
+
+const registerRoute = (
+  routes: BunRouteRecord,
+  route: HttpRouteDefinition,
+  options: CreateRouteHandlerOptions
+): void => {
+  const methods = routes[route.path] ?? {};
+  const handler = createRouteHandler(route, options);
+  methods[route.method] = handler;
+  if (route.method === 'GET') {
+    methods.HEAD = async (request) => {
+      const response = await handler(request);
+      return bodylessHeadResponse(response);
+    };
+  }
+  routes[route.path] = methods;
+};
+
+const routeForRequest = (
+  routes: BunRouteRecord,
+  request: Request
+): Partial<Record<BunRouteMethod, RouteHandler>> | undefined => {
+  const path = new URL(request.url).pathname;
+  return routes[path];
+};
+
+/**
+ * Build Bun-compatible HTTP route handlers from a topo.
+ *
+ * @remarks This materializes `deriveHttpRoutes` onto Bun's native `routes`
+ * table while preserving `fetch` as the fallback path for unmatched requests.
+ */
+export const createApp = (
+  graph: Topo,
+  options: CreateAppOptions = {}
+): BunHttpApp => {
+  const routesResult = deriveHttpRoutes(graph, deriveOptions(options));
+
+  if (routesResult.isErr()) {
+    throw routesResult.error;
+  }
+
+  const handlerOptions = routeHandlerOptions(options);
+  const routes: BunRouteRecord = {};
+  for (const route of routesResult.value) {
+    registerRoute(routes, route, handlerOptions);
+  }
+
+  return {
+    fetch: async (request) => {
+      const method = request.method.toUpperCase() as BunRouteMethod;
+      const route = routeForRequest(routes, request);
+      if (route === undefined) {
+        const response = notFoundResponse(request);
+        return method === 'HEAD' ? bodylessHeadResponse(response) : response;
+      }
+      const methodHandler = route[method];
+      const response =
+        methodHandler === undefined
+          ? methodNotAllowedResponse(request, route)
+          : await methodHandler(request);
+      return method === 'HEAD' ? bodylessHeadResponse(response) : response;
+    },
+    onError: async (error) => {
+      const errorId = crypto.randomUUID();
+      caughtErrors.set(errorId, error);
+      try {
+        return await caughtErrorHandler(materializeCaughtErrorRequest(errorId));
+      } finally {
+        caughtErrors.delete(errorId);
+      }
+    },
+    routes,
+  };
+};
+
+const startServer = (
+  app: BunHttpApp,
+  options: CreateAppOptions
+): SurfaceHttpResult => {
+  const server = Bun.serve({
+    error: app.onError,
+    fetch: app.fetch,
+    hostname: options.hostname ?? '0.0.0.0',
+    port: options.port ?? 3000,
+    routes: app.routes,
+  });
+
+  return {
+    close: async () => {
+      await server.stop(true);
+    },
+    url: String(server.url),
+  };
+};
+
+/**
+ * Build a Bun-native HTTP app from a topo and start serving it.
+ */
+export const surface = async (
+  graph: Topo,
+  options: CreateAppOptions = {}
+): Promise<SurfaceHttpResult> => {
+  // oxlint-disable-next-line require-await -- async ensures createApp() throws become rejected promises, not uncaught exceptions
+  const app = createApp(graph, options);
+  return startServer(app, options);
+};


### PR DESCRIPTION
## Context

Linear: TRL-716
Stack position: 4/14

This adds the Bun-native HTTP materializer as a subpath of `@ontrails/http`, following the ADR boundary from TRL-727.

## Changes

- Adds `@ontrails/http/bun` with `createApp` and `surface` helpers.
- Uses Bun `routes` as the fast path, a `fetch` fallback for unmatched requests, and `error`/`onError` handling for thrown Bun server errors.
- Adds Bun surface tests and README/API docs.
- Adds the package export and Bun engine boundary without creating `@ontrails/bun`.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: `bun run --cwd packages/http test`, `bun run --cwd packages/http typecheck`, `bun run --cwd packages/http lint`.

## Risks / rollout notes

- Runtime availability depends on Bun APIs, so this remains an `@ontrails/http/bun` subpath rather than a root package.
- No package publish was run; the branch includes a changeset and is covered by `bun run publish:check`.