### PR TITLE
chore(pino): scaffold publishable package

### DIFF
--- a/.changeset/trl-720-pino-package.md
+++ b/.changeset/trl-720-pino-package.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/pino': minor
+---
+
+Add the publishable `@ontrails/pino` package scaffold.

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "adapters/commander": {
       "name": "@ontrails/commander",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "dependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
@@ -38,7 +38,7 @@
     },
     "adapters/drizzle": {
       "name": "@ontrails/drizzle",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "drizzle-orm": "^0.45.2",
@@ -50,7 +50,7 @@
     },
     "adapters/hono": {
       "name": "@ontrails/hono",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "hono": "^4.7.0",
@@ -62,7 +62,7 @@
     },
     "adapters/vite": {
       "name": "@ontrails/vite",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "devDependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/hono": "workspace:^",
@@ -71,7 +71,7 @@
     },
     "apps/trails": {
       "name": "@ontrails/trails",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "bin": {
         "trails": "./bin/trails.ts",
       },
@@ -119,7 +119,7 @@
     },
     "packages/cli": {
       "name": "@ontrails/cli",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -129,7 +129,7 @@
     },
     "packages/config": {
       "name": "@ontrails/config",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -137,14 +137,14 @@
     },
     "packages/core": {
       "name": "@ontrails/core",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "peerDependencies": {
         "zod": "catalog:",
       },
     },
     "packages/http": {
       "name": "@ontrails/http",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -154,14 +154,14 @@
     },
     "packages/logtape": {
       "name": "@ontrails/logtape",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "peerDependencies": {
         "@ontrails/observe": "workspace:^",
       },
     },
     "packages/mcp": {
       "name": "@ontrails/mcp",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -172,29 +172,36 @@
     },
     "packages/observe": {
       "name": "@ontrails/observe",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
       },
     },
     "packages/oxlint-plugin": {
       "name": "@ontrails/oxlint-plugin",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "dependencies": {
         "@oxlint/plugins": "1.62.0",
       },
     },
     "packages/permits": {
       "name": "@ontrails/permits",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
       },
     },
+    "packages/pino": {
+      "name": "@ontrails/pino",
+      "version": "1.0.0-beta.17",
+      "peerDependencies": {
+        "@ontrails/observe": "workspace:^",
+      },
+    },
     "packages/store": {
       "name": "@ontrails/store",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -204,7 +211,7 @@
     },
     "packages/testing": {
       "name": "@ontrails/testing",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "devDependencies": {
         "@ontrails/drizzle": "workspace:^",
         "@ontrails/store": "workspace:^",
@@ -220,7 +227,7 @@
     },
     "packages/topographer": {
       "name": "@ontrails/topographer",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -228,7 +235,7 @@
     },
     "packages/tracing": {
       "name": "@ontrails/tracing",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -236,7 +243,7 @@
     },
     "packages/warden": {
       "name": "@ontrails/warden",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "bin": {
         "warden": "./bin/warden.ts",
       },
@@ -259,7 +266,7 @@
     },
     "packages/wayfinder": {
       "name": "@ontrails/wayfinder",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/topographer": "workspace:^",
@@ -384,6 +391,8 @@
     "@ontrails/oxlint-plugin": ["@ontrails/oxlint-plugin@workspace:packages/oxlint-plugin"],
 
     "@ontrails/permits": ["@ontrails/permits@workspace:packages/permits"],
+
+    "@ontrails/pino": ["@ontrails/pino@workspace:packages/pino"],
 
     "@ontrails/store": ["@ontrails/store@workspace:packages/store"],
 

--- a/packages/pino/CHANGELOG.md
+++ b/packages/pino/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ontrails/pino
+
+## 1.0.0-beta.17
+
+### Minor Changes
+
+- Initial publishable package scaffold.

--- a/packages/pino/README.md
+++ b/packages/pino/README.md
@@ -1,0 +1,11 @@
+# @ontrails/pino
+
+Pino adapter package for `@ontrails/observe`.
+
+This package is the publishable home for Trails log forwarding into
+Pino-shaped loggers. It intentionally does not depend on `pino`; the sink uses
+a structural logger interface so applications can pass their existing logger.
+
+The structural sink implementation lands in the follow-up Pino issue. Until
+then, this package establishes the workspace, package exports, and publish
+checks for `@ontrails/pino`.

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ontrails/pino",
+  "version": "1.0.0-beta.17",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@ontrails/observe": "workspace:^"
+  }
+}

--- a/packages/pino/src/__tests__/pino.test.ts
+++ b/packages/pino/src/__tests__/pino.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+
+import { pinoPackageName } from '../index.js';
+
+describe('@ontrails/pino scaffold', () => {
+  test('exports the package identifier', () => {
+    expect(pinoPackageName).toBe('@ontrails/pino');
+  });
+});

--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -1,0 +1,15 @@
+import type { LogSink } from '@ontrails/observe';
+
+/**
+ * Package identifier for the publishable Pino adapter package.
+ */
+export const pinoPackageName = '@ontrails/pino';
+
+/**
+ * Placeholder sink type for the package scaffold.
+ *
+ * @remarks The structural Pino sink is implemented in the follow-up Pino
+ * issue; this alias keeps the scaffold tied to the public observe contract
+ * without adding a runtime dependency on `pino`.
+ */
+export type PinoLogSink = LogSink;

--- a/packages/pino/tsconfig.json
+++ b/packages/pino/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/packages/pino/tsconfig.tests.json
+++ b/packages/pino/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Context

Linear: TRL-720
Stack position: 6/14

This creates the publishable `@ontrails/pino` package shell without taking a hard Pino dependency.

## Changes

- Adds `packages/pino` with package metadata, README, CHANGELOG, tsconfigs, package entrypoint, and a package identifier export.
- Adds workspace wiring and updates `bun.lock` via `bun install`.
- Adds a branch-local changeset for the new publishable package.
- Keeps `pino` as an application-supplied logger rather than a package dependency.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: `bun run --cwd packages/pino test`, `bun run --cwd packages/pino typecheck`, `bun run --cwd packages/pino lint`, `bun run publish:check`.

## Risks / rollout notes

- The package is intentionally structural and has no direct `pino` dependency.
- No registry mutation or package publish was run.