### PR TITLE
feat(pino): add structural log sink

### DIFF
--- a/.changeset/trl-721-pino-sink.md
+++ b/.changeset/trl-721-pino-sink.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/pino': minor
+---
+
+Implement the structural Pino log sink.

--- a/packages/pino/CHANGELOG.md
+++ b/packages/pino/CHANGELOG.md
@@ -5,3 +5,4 @@
 ### Minor Changes
 
 - Initial publishable package scaffold.
+- Add structural Pino log sink.

--- a/packages/pino/README.md
+++ b/packages/pino/README.md
@@ -2,10 +2,17 @@
 
 Pino adapter package for `@ontrails/observe`.
 
-This package is the publishable home for Trails log forwarding into
-Pino-shaped loggers. It intentionally does not depend on `pino`; the sink uses
-a structural logger interface so applications can pass their existing logger.
+Use `createPinoSink(...)` when you already have a Pino-shaped logger and want
+Trails log records to flow into it:
 
-The structural sink implementation lands in the follow-up Pino issue. Until
-then, this package establishes the workspace, package exports, and publish
-checks for `@ontrails/pino`.
+```typescript
+import pino from 'pino';
+import { createPinoSink } from '@ontrails/pino';
+
+const sink = createPinoSink(pino());
+```
+
+The package does not depend on `pino`; it accepts any object shaped like a Pino
+logger through `PinoLoggerLike`. Records are forwarded in Pino's object-first
+style as `logger.info(payload, message)`, preserving the metadata already
+redacted by Trails.

--- a/packages/pino/src/__tests__/pino.test.ts
+++ b/packages/pino/src/__tests__/pino.test.ts
@@ -1,9 +1,167 @@
 import { describe, expect, test } from 'bun:test';
 
-import { pinoPackageName } from '../index.js';
+import { createPinoSink, pinoPackageName } from '../index.js';
+import type { PinoLoggerLike } from '../index.js';
+import type { LogRecord } from '@ontrails/observe';
 
-describe('@ontrails/pino scaffold', () => {
+interface PinoCall {
+  readonly level: string;
+  readonly message?: string | undefined;
+  readonly payload: Record<string, unknown>;
+}
+
+const createRecordingLogger = () => {
+  const calls: PinoCall[] = [];
+
+  const logger: PinoLoggerLike = {
+    debug(payload, message) {
+      calls.push({ level: 'debug', message, payload });
+    },
+    error(payload, message) {
+      calls.push({ level: 'error', message, payload });
+    },
+    fatal(payload, message) {
+      calls.push({ level: 'fatal', message, payload });
+    },
+    info(payload, message) {
+      calls.push({ level: 'info', message, payload });
+    },
+    trace(payload, message) {
+      calls.push({ level: 'trace', message, payload });
+    },
+    warn(payload, message) {
+      calls.push({ level: 'warn', message, payload });
+    },
+  };
+
+  return { calls, logger };
+};
+
+const createRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
+  category: 'app.http',
+  level: 'info',
+  message: 'request received',
+  metadata: { path: '/greet' },
+  timestamp: new Date('2026-05-16T00:00:00.000Z'),
+  ...overrides,
+});
+
+describe('@ontrails/pino', () => {
   test('exports the package identifier', () => {
     expect(pinoPackageName).toBe('@ontrails/pino');
+  });
+
+  test.each([
+    ['trace'],
+    ['debug'],
+    ['info'],
+    ['warn'],
+    ['error'],
+    ['fatal'],
+  ] as const)('forwards %s records to the matching pino method', (level) => {
+    const { calls, logger } = createRecordingLogger();
+    const sink = createPinoSink(logger);
+
+    sink.write(createRecord({ level }));
+
+    expect(calls).toEqual([
+      {
+        level,
+        message: 'request received',
+        payload: {
+          category: 'app.http',
+          path: '/greet',
+          timestamp: '2026-05-16T00:00:00.000Z',
+        },
+      },
+    ]);
+  });
+
+  test('forwards message and metadata in the pino object-first shape', () => {
+    const { calls, logger } = createRecordingLogger();
+    const sink = createPinoSink(logger, { name: 'pino-test' });
+
+    sink.write(
+      createRecord({
+        metadata: {
+          requestId: 'req-1',
+          status: 200,
+        },
+      })
+    );
+
+    expect(sink.name).toBe('pino-test');
+    expect(calls).toEqual([
+      {
+        level: 'info',
+        message: 'request received',
+        payload: {
+          category: 'app.http',
+          requestId: 'req-1',
+          status: 200,
+          timestamp: '2026-05-16T00:00:00.000Z',
+        },
+      },
+    ]);
+  });
+
+  test('keeps stable record fields when metadata uses the same keys', () => {
+    const { calls, logger } = createRecordingLogger();
+    const sink = createPinoSink(logger);
+
+    sink.write(
+      createRecord({
+        metadata: {
+          category: 'metadata.category',
+          timestamp: 'metadata-timestamp',
+        },
+      })
+    );
+
+    expect(calls[0]?.payload).toMatchObject({
+      category: 'app.http',
+      timestamp: '2026-05-16T00:00:00.000Z',
+    });
+  });
+
+  test('preserves redacted metadata without reconstructing hidden values', () => {
+    const { calls, logger } = createRecordingLogger();
+    const sink = createPinoSink(logger);
+
+    sink.write(
+      createRecord({
+        metadata: {
+          authorization: '[REDACTED]',
+          user: 'matt',
+        },
+      })
+    );
+
+    expect(calls[0]?.payload).toMatchObject({
+      authorization: '[REDACTED]',
+      user: 'matt',
+    });
+    expect(JSON.stringify(calls)).not.toContain('secret');
+  });
+
+  test('drops silent records without calling the logger', () => {
+    const { calls, logger } = createRecordingLogger();
+    const sink = createPinoSink(logger);
+
+    sink.write(createRecord({ level: 'silent' }));
+
+    expect(calls).toEqual([]);
+  });
+
+  test('fails loudly when the structural logger is missing a required method', () => {
+    const { logger } = createRecordingLogger();
+    const malformedLogger = {
+      ...logger,
+      warn: undefined,
+    } as unknown as PinoLoggerLike;
+
+    expect(() => createPinoSink(malformedLogger)).toThrow(
+      'Pino logger is missing "warn" method'
+    );
   });
 });

--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -1,15 +1,90 @@
-import type { LogSink } from '@ontrails/observe';
+import type { LogLevel, LogRecord, LogSink } from '@ontrails/observe';
 
 /**
  * Package identifier for the publishable Pino adapter package.
  */
 export const pinoPackageName = '@ontrails/pino';
 
+export type PinoLogMethod = (
+  payload: Record<string, unknown>,
+  message?: string
+) => void;
+
 /**
- * Placeholder sink type for the package scaffold.
- *
- * @remarks The structural Pino sink is implemented in the follow-up Pino
- * issue; this alias keeps the scaffold tied to the public observe contract
- * without adding a runtime dependency on `pino`.
+ * Structural subset of a Pino logger.
  */
-export type PinoLogSink = LogSink;
+export interface PinoLoggerLike {
+  debug: PinoLogMethod;
+  error: PinoLogMethod;
+  fatal: PinoLogMethod;
+  info: PinoLogMethod;
+  trace: PinoLogMethod;
+  warn: PinoLogMethod;
+}
+
+export interface PinoSinkOptions {
+  /** Sink name exposed to Trails observe configuration. Defaults to `pino`. */
+  readonly name?: string | undefined;
+}
+
+type ForwardMethod = Exclude<LogLevel, 'silent'>;
+
+const LEVEL_MAP: Record<LogLevel, ForwardMethod | undefined> = {
+  debug: 'debug',
+  error: 'error',
+  fatal: 'fatal',
+  info: 'info',
+  silent: undefined,
+  trace: 'trace',
+  warn: 'warn',
+};
+
+const buildPayload = (record: LogRecord): Record<string, unknown> => ({
+  ...record.metadata,
+  category: record.category,
+  timestamp: record.timestamp.toISOString(),
+});
+
+const resolveLoggerMethod = (
+  logger: PinoLoggerLike,
+  method: ForwardMethod
+): PinoLogMethod => {
+  const loggerMethod = logger[method];
+  if (typeof loggerMethod !== 'function') {
+    throw new TypeError(`Pino logger is missing "${method}" method`);
+  }
+  return loggerMethod.bind(logger);
+};
+
+const resolveLoggerMethods = (
+  logger: PinoLoggerLike
+): Record<ForwardMethod, PinoLogMethod> => ({
+  debug: resolveLoggerMethod(logger, 'debug'),
+  error: resolveLoggerMethod(logger, 'error'),
+  fatal: resolveLoggerMethod(logger, 'fatal'),
+  info: resolveLoggerMethod(logger, 'info'),
+  trace: resolveLoggerMethod(logger, 'trace'),
+  warn: resolveLoggerMethod(logger, 'warn'),
+});
+
+/**
+ * Create a Trails log sink that forwards records to a structural Pino logger.
+ */
+export const createPinoSink = (
+  logger: PinoLoggerLike,
+  options: PinoSinkOptions = {}
+): LogSink => {
+  const methods = resolveLoggerMethods(logger);
+
+  return {
+    name: options.name ?? 'pino',
+    write(record: LogRecord): void {
+      const method = LEVEL_MAP[record.level];
+      if (method === undefined) {
+        return;
+      }
+
+      methods[method](buildPayload(record), record.message);
+    },
+  };
+};


### PR DESCRIPTION
## Context

Linear: TRL-721
Stack position: 7/14

This makes the new Pino package useful while keeping the dependency boundary structural.

## Changes

- Defines `PinoLoggerLike`, `PinoSinkOptions`, and `createPinoSink`.
- Forwards Trails log records to Pino's object-first call shape while dropping `silent` records.
- Fails loudly when the supplied structural logger is missing a required method.
- Includes the local-review fix that prevents metadata from overriding stable `category` and `timestamp` payload fields.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: `bun run --cwd packages/pino test`, `bun run --cwd packages/pino typecheck`, `bun run --cwd packages/pino lint`.

## Risks / rollout notes

- Apps supply the actual Pino logger; this package does not add a hard runtime dependency.
- Metadata remains forwarded, but stable record fields win on key collisions.