### PR TITLE
docs(pino): document publish readiness

### DIFF
--- a/.changeset/trl-722-pino-docs.md
+++ b/.changeset/trl-722-pino-docs.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/observe': patch
+'@ontrails/pino': patch
+---
+
+Document Pino sink usage and publish-readiness checks.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ $ myapp greet --name World
 | [`@ontrails/observe`](./packages/observe) | Log and trace sink contracts, sink composition, built-in sinks, trace rendering |
 | [`@ontrails/tracing`](./packages/tracing) | Tracing compatibility, query/status trails, `trails.db` dev-state storage, sampling helpers, OTel adapter |
 | [`@ontrails/logtape`](./packages/logtape) | Adapter that forwards Trails log records to a LogTape-shaped logger |
+| [`@ontrails/pino`](./packages/pino) | Adapter that forwards Trails log records to a Pino-shaped logger |
 | [`@ontrails/warden`](./packages/warden) | AST-based convention rules, drift detection, CI formatters |
 
 ## Documentation

--- a/docs/migration/logging-to-observe.md
+++ b/docs/migration/logging-to-observe.md
@@ -11,6 +11,7 @@ v1 observability package graph.
 | Console/file log sinks and formatters | `@ontrails/observe` |
 | Bounded in-memory trace sink and trace rendering | `@ontrails/observe` |
 | LogTape forwarding | `@ontrails/logtape` |
+| Pino forwarding | `@ontrails/pino` |
 | Trace sink registry, `ctx.trace()`, and intrinsic execution records | `@ontrails/core` through `executeTrail`; registry helpers are re-exported by `@ontrails/tracing` |
 | Tracing query/status trails, SQLite dev store, sampling helpers | `@ontrails/tracing` |
 | OpenTelemetry export | `@ontrails/tracing/otel` |
@@ -57,6 +58,22 @@ const exporter = async (spans: unknown) => {
 registerTraceSink(createOtelAdapter({ exporter }));
 ```
 
+Use `@ontrails/pino` when an app already owns a Pino logger:
+
+```typescript
+import pino from 'pino';
+import { topo } from '@ontrails/core';
+import { createPinoSink } from '@ontrails/pino';
+
+const logger = pino();
+// trails is your application's array of Trail definitions.
+const graph = topo('app', trails, {
+  observe: {
+    log: createPinoSink(logger),
+  },
+});
+```
+
 ## Package Manifests
 
 Remove the old dependency and add the replacement packages you actually need.
@@ -66,8 +83,8 @@ For apps that only use console, file, or memory sinks:
 {
   "dependencies": {
 -   "@ontrails/logging": "^1.0.0-beta.15",
-+   "@ontrails/observe": "^1.0.0-beta.15",
-    "@ontrails/tracing": "^1.0.0-beta.15"
++   "@ontrails/observe": "^1.0.0-beta.17",
+    "@ontrails/tracing": "^1.0.0-beta.17"
   }
 }
 ```
@@ -79,9 +96,24 @@ alongside `@ontrails/observe`:
 {
   "dependencies": {
 -   "@ontrails/logging": "^1.0.0-beta.15",
-+   "@ontrails/observe": "^1.0.0-beta.15",
-+   "@ontrails/logtape": "^1.0.0-beta.15",
-    "@ontrails/tracing": "^1.0.0-beta.15"
++   "@ontrails/observe": "^1.0.0-beta.17",
++   "@ontrails/logtape": "^1.0.0-beta.17",
+    "@ontrails/tracing": "^1.0.0-beta.17"
+  }
+}
+```
+
+For apps that forward to a Pino-shaped logger, add `@ontrails/pino` alongside
+`@ontrails/observe`. Keep `pino` itself as an application dependency:
+
+```diff
+{
+  "dependencies": {
+-   "@ontrails/logging": "^1.0.0-beta.15",
++   "@ontrails/observe": "^1.0.0-beta.17",
++   "@ontrails/pino": "^1.0.0-beta.17",
++   "@ontrails/tracing": "^1.0.0-beta.17",
++   "pino": "^9.0.0"
   }
 }
 ```

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -40,6 +40,11 @@ Before creating the version PR:
    bun run publish:registry-check
    ```
 
+   First-time public packages can be reported as first-time package
+   candidates during this read-only probe. That is expected before their first
+   publication; after publishing, use `bun run publish:registry-check:published`
+   to require every package and dist-tag to exist.
+
 6. The local package tarballs are clean:
 
    ```bash

--- a/packages/observe/README.md
+++ b/packages/observe/README.md
@@ -43,5 +43,6 @@ rotation or a production adapter when retention policy matters.
 
 `@ontrails/logging` was retired before v1. Move sink contracts, console/file
 sinks, formatters, and bounded memory sinks to `@ontrails/observe`. Use
-`@ontrails/logtape` for LogTape forwarding and `@ontrails/tracing` for tracing
-registry, dev-store, query/status, sampling, and OTel adapter APIs.
+`@ontrails/logtape` for LogTape forwarding, `@ontrails/pino` for Pino
+forwarding, and `@ontrails/tracing` for tracing registry, dev-store,
+query/status, sampling, and OTel adapter APIs.

--- a/packages/pino/README.md
+++ b/packages/pino/README.md
@@ -2,6 +2,17 @@
 
 Pino adapter package for `@ontrails/observe`.
 
+## Installation
+
+```bash
+bun add @ontrails/observe @ontrails/pino pino
+```
+
+`pino` is supplied by your application. `@ontrails/pino` has no hard runtime
+dependency on it.
+
+## Usage
+
 Use `createPinoSink(...)` when you already have a Pino-shaped logger and want
 Trails log records to flow into it:
 
@@ -16,3 +27,48 @@ The package does not depend on `pino`; it accepts any object shaped like a Pino
 logger through `PinoLoggerLike`. Records are forwarded in Pino's object-first
 style as `logger.info(payload, message)`, preserving the metadata already
 redacted by Trails.
+
+```typescript
+import pino from 'pino';
+import { topo } from '@ontrails/core';
+import { createPinoSink } from '@ontrails/pino';
+
+const logger = pino();
+// trails is your application's array of Trail definitions.
+const graph = topo('app', trails, {
+  observe: {
+    log: createPinoSink(logger),
+  },
+});
+```
+
+## Structural Logger Shape
+
+`PinoLoggerLike` requires `trace`, `debug`, `info`, `warn`, `error`, and
+`fatal` methods that accept `(payload, message)`. The sink forwards:
+
+- `record.message` as the Pino message argument.
+- `record.category`, `record.timestamp`, and `record.metadata` in the payload.
+- `silent` records as no-ops.
+
+If a required method is missing at runtime, the sink throws instead of silently
+dropping the record.
+
+## Publishing
+
+`@ontrails/pino` participates in the standard Trails package publish checks:
+
+```bash
+bun run publish:check
+bun run publish:registry-check
+```
+
+`publish:registry-check` is read-only. Before the first registry publication it
+may report `@ontrails/pino` as a first-time package candidate. Actual package
+publication still goes through the repo script:
+
+```bash
+bun run publish:packages
+```
+
+Do not publish this package with `npm publish` or `changeset publish`.


### PR DESCRIPTION
## Context

Linear: TRL-722
Stack position: 8/14

This documents the new Pino adapter package and its release gates.

## Changes

- Updates `packages/pino` docs with usage, structural logger expectations, and publish checks.
- Updates observe/logging migration docs to position `@ontrails/pino` alongside `@ontrails/observe`.
- Keeps publishing guidance on `bun run publish:check` and `bun run publish:packages`.
- Explicitly warns against `npm publish` and `changeset publish` for Trails packages.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: docs link/snippet checks and `bun run publish:check`.

## Risks / rollout notes

- Docs-only package-boundary risk. Local review confirmed forbidden publish commands appear only as explicit "do not use" guidance.