### PR TITLE
feat(tracing): complete otel attribute mapping

### DIFF
--- a/.changeset/trl-723-otel-attribute-mapping.md
+++ b/.changeset/trl-723-otel-attribute-mapping.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/tracing": minor
+---
+
+Complete the stable `trails.*` OpenTelemetry attribute mapping for trace identity, lineage, status, timing, signal lifecycle, and activation boundary records while filtering raw payload and unredacted error-message custom attributes.

--- a/packages/tracing/src/__tests__/otel-adapter.test.ts
+++ b/packages/tracing/src/__tests__/otel-adapter.test.ts
@@ -123,6 +123,209 @@ describe('otelAdapter', () => {
       expect(spans[0]?.attributes.sampled).toBe(true);
       expect(spans[0]?.attributes.skipped).toBeUndefined();
     });
+
+    test('maps stable trace identity, lineage, status, and timing attributes', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({
+          endedAt: 175,
+          errorCategory: 'validation',
+          id: 'span-child',
+          intent: 'destroy',
+          parentId: 'span-parent',
+          permit: { id: 'permit-1', tenantId: 'tenant-1' },
+          rootId: 'span-root',
+          sampled: false,
+          startedAt: 125,
+          status: 'err',
+          surface: 'http',
+          traceId: 'trace-stable',
+          trailId: 'orders.destroy',
+        })
+      );
+
+      expect(spans[0]?.attributes).toMatchObject({
+        'trails.error.category': 'validation',
+        'trails.intent': 'destroy',
+        'trails.permit.id': 'permit-1',
+        'trails.permit.tenant_id': 'tenant-1',
+        'trails.record.kind': 'trail',
+        'trails.record.name': 'test.echo',
+        'trails.sampled': false,
+        'trails.span.id': 'span-child',
+        'trails.span.parent_id': 'span-parent',
+        'trails.span.root_id': 'span-root',
+        'trails.status': 'err',
+        'trails.surface': 'http',
+        'trails.timing.duration_ms': 50,
+        'trails.timing.ended_at_ms': 175,
+        'trails.timing.started_at_ms': 125,
+        'trails.trace.id': 'trace-stable',
+        'trails.trail.id': 'orders.destroy',
+      });
+    });
+
+    test('preserves stable fields when custom attrs try to override them', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({
+          attrs: {
+            'trails.error.category': 'forged-validation',
+            'trails.intent': 'destroy',
+            'trails.record.kind': 'forged',
+            'trails.sampled': false,
+            'trails.span.parent_id': 'forged-parent',
+            'trails.surface': 'http',
+            'trails.timing.ended_at_ms': 1234,
+            'trails.trace.id': 'forged-trace',
+            'trails.trail.id': 'orders.destroy',
+          },
+          endedAt: undefined,
+          kind: 'trail',
+          traceId: 'trace-real',
+        })
+      );
+
+      expect(spans[0]?.attributes['trails.record.kind']).toBe('trail');
+      expect(spans[0]?.attributes['trails.trace.id']).toBe('trace-real');
+      expect(spans[0]?.attributes['trails.error.category']).toBeUndefined();
+      expect(spans[0]?.attributes['trails.intent']).toBeUndefined();
+      expect(spans[0]?.attributes['trails.sampled']).toBeUndefined();
+      expect(spans[0]?.attributes['trails.span.parent_id']).toBeUndefined();
+      expect(spans[0]?.attributes['trails.surface']).toBeUndefined();
+      expect(spans[0]?.attributes['trails.timing.ended_at_ms']).toBeUndefined();
+      expect(spans[0]?.attributes['trails.trail.id']).toBeUndefined();
+    });
+
+    test('drops raw payload and unredacted error message attributes', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({
+          attrs: {
+            authorization: 'Bearer secret',
+            body: '{"secret":true}',
+            'error.message': 'card number leaked',
+            'http.response.body.byte_length': 128,
+            input: '{"secret":true}',
+            output: '{"secret":true}',
+            payload: '{"secret":true}',
+            'trails.input.schema_hash': 'sha256:input',
+            'trails.output.schema_hash': 'sha256:output',
+            'trails.signal.payload.byte_length': 42,
+            'trails.signal.payload.digest': 'sha256:abc',
+            'trails.signal.payload.preview': 'redacted?',
+            'trails.signal.payload.redacted': true,
+            'trails.signal.payload.top_level_entry_count': 3,
+          },
+        })
+      );
+
+      expect(spans[0]?.attributes.authorization).toBeUndefined();
+      expect(spans[0]?.attributes.body).toBeUndefined();
+      expect(spans[0]?.attributes['error.message']).toBeUndefined();
+      expect(spans[0]?.attributes.input).toBeUndefined();
+      expect(spans[0]?.attributes.output).toBeUndefined();
+      expect(spans[0]?.attributes.payload).toBeUndefined();
+      expect(spans[0]?.attributes['http.response.body.byte_length']).toBe(128);
+      expect(spans[0]?.attributes['trails.input.schema_hash']).toBe(
+        'sha256:input'
+      );
+      expect(spans[0]?.attributes['trails.output.schema_hash']).toBe(
+        'sha256:output'
+      );
+      expect(spans[0]?.attributes['trails.signal.payload.byte_length']).toBe(
+        42
+      );
+      expect(spans[0]?.attributes['trails.signal.payload.digest']).toBe(
+        'sha256:abc'
+      );
+      expect(
+        spans[0]?.attributes['trails.signal.payload.preview']
+      ).toBeUndefined();
+      expect(spans[0]?.attributes['trails.signal.payload.redacted']).toBe(true);
+      expect(
+        spans[0]?.attributes['trails.signal.payload.top_level_entry_count']
+      ).toBe(3);
+    });
+
+    test('maps signal lifecycle attributes without payload leakage', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({
+          attrs: {
+            'trails.signal.id': 'order.placed',
+            'trails.signal.payload.shape': 'object',
+            'trails.signal.producer_trail.id': 'orders.create',
+          },
+          kind: 'signal',
+          name: 'signal.fired',
+        })
+      );
+
+      expect(spans[0]?.attributes).toMatchObject({
+        'trails.record.kind': 'signal',
+        'trails.record.name': 'signal.fired',
+        'trails.signal.event': 'signal.fired',
+        'trails.signal.id': 'order.placed',
+        'trails.signal.payload.shape': 'object',
+        'trails.signal.producer_trail.id': 'orders.create',
+      });
+    });
+
+    test('maps activation boundary attributes without error message leakage', async () => {
+      const spans: OtelSpan[] = [];
+      const adapter = createOtelAdapter({
+        exporter: (s) => {
+          spans.push(...s);
+        },
+      });
+
+      await adapter.write(
+        makeRecord({
+          attrs: {
+            'exception.message': 'includes raw webhook body',
+            'trails.activation.source.id': 'webhook.payment.received',
+            'trails.activation.source.kind': 'webhook',
+            'trails.activation.target_trail.id': 'payments.receive',
+          },
+          kind: 'activation',
+          name: 'activation.webhook',
+        })
+      );
+
+      expect(spans[0]?.attributes).toMatchObject({
+        'trails.activation.event': 'activation.webhook',
+        'trails.activation.source.id': 'webhook.payment.received',
+        'trails.activation.source.kind': 'webhook',
+        'trails.activation.target_trail.id': 'payments.receive',
+        'trails.record.kind': 'activation',
+      });
+      expect(spans[0]?.attributes['exception.message']).toBeUndefined();
+    });
   });
 
   describe('status mapping', () => {

--- a/packages/tracing/src/adapters/otel.ts
+++ b/packages/tracing/src/adapters/otel.ts
@@ -1,5 +1,7 @@
 import type { TraceRecord, TraceSink } from '@ontrails/core';
 
+type OtelAttributeValue = string | number | boolean;
+
 /** OTel span representation produced by the adapter. */
 export interface OtelSpan {
   readonly traceId: string;
@@ -10,7 +12,7 @@ export interface OtelSpan {
   readonly endTime?: number | undefined;
   readonly status: 'OK' | 'ERROR' | 'UNSET';
   readonly kind: 'INTERNAL' | 'SERVER';
-  readonly attributes: Readonly<Record<string, string | number | boolean>>;
+  readonly attributes: Readonly<Record<string, OtelAttributeValue>>;
 }
 
 /** Callback that receives translated OTel spans. */
@@ -33,23 +35,116 @@ const STATUS_MAP: Record<TraceRecord['status'], OtelSpan['status']> = {
 const deriveKind = (parentId: string | undefined): OtelSpan['kind'] =>
   parentId === undefined ? 'SERVER' : 'INTERNAL';
 
+const SAFE_SIGNAL_PAYLOAD_ATTRIBUTE_KEYS = new Set([
+  'trails.signal.payload.byte_length',
+  'trails.signal.payload.digest',
+  'trails.signal.payload.redacted',
+  'trails.signal.payload.shape',
+  'trails.signal.payload.top_level_entry_count',
+]);
+
+const UNSAFE_SENSITIVE_ATTRIBUTE_SEGMENTS = new Set([
+  'authorization',
+  'cookie',
+  'password',
+  'secret',
+  'token',
+]);
+const UNSAFE_RAW_ATTRIBUTE_NAMES = new Set([
+  'body',
+  'input',
+  'output',
+  'payload',
+]);
+
+const UNSAFE_ATTRIBUTE_KEYS = new Set([
+  'error.message',
+  'error.stack',
+  'exception.message',
+  'exception.stacktrace',
+  'message',
+  'stack',
+  'stacktrace',
+]);
+
+const normalizeAttributeKey = (key: string): string =>
+  key.replaceAll(/([a-z\d])([A-Z])/g, '$1_$2').toLowerCase();
+
+const splitAttributeKey = (key: string): readonly string[] =>
+  normalizeAttributeKey(key).split(/[._-]+/u);
+
+const isUnsafeCustomAttributeKey = (key: string): boolean => {
+  const normalized = normalizeAttributeKey(key);
+  if (SAFE_SIGNAL_PAYLOAD_ATTRIBUTE_KEYS.has(normalized)) {
+    return false;
+  }
+  if (
+    UNSAFE_ATTRIBUTE_KEYS.has(normalized) ||
+    normalized.endsWith('.error.message') ||
+    normalized.endsWith('.error.stack') ||
+    normalized.endsWith('.exception.message') ||
+    normalized.endsWith('.exception.stacktrace')
+  ) {
+    return true;
+  }
+  const parts = splitAttributeKey(normalized);
+  if (parts.some((part) => UNSAFE_SENSITIVE_ATTRIBUTE_SEGMENTS.has(part))) {
+    return true;
+  }
+  const last = parts.at(-1);
+  if (last !== undefined && UNSAFE_RAW_ATTRIBUTE_NAMES.has(last)) {
+    return true;
+  }
+  return parts.includes('payload');
+};
+
+const isOtelAttributeValue = (value: unknown): value is OtelAttributeValue =>
+  typeof value === 'string' ||
+  typeof value === 'number' ||
+  typeof value === 'boolean';
+
 /** Attribute mapping: record field → OTel attribute key + extractor. */
 const ATTR_MAP: readonly {
   key: string;
-  get: (r: TraceRecord) => string | undefined;
+  get: (r: TraceRecord) => OtelAttributeValue | undefined;
 }[] = [
-  { get: (r) => r.trailId, key: 'trails.trail.id' },
+  {
+    get: (r) => (r.kind === 'activation' ? r.name : undefined),
+    key: 'trails.activation.event',
+  },
+  { get: (r) => r.errorCategory, key: 'trails.error.category' },
   { get: (r) => r.intent, key: 'trails.intent' },
-  { get: (r) => r.surface, key: 'trails.surface' },
   { get: (r) => r.permit?.id, key: 'trails.permit.id' },
   { get: (r) => r.permit?.tenantId, key: 'trails.permit.tenant_id' },
+  { get: (r) => r.kind, key: 'trails.record.kind' },
+  { get: (r) => r.name, key: 'trails.record.name' },
+  { get: (r) => r.sampled, key: 'trails.sampled' },
+  {
+    get: (r) => (r.kind === 'signal' ? r.name : undefined),
+    key: 'trails.signal.event',
+  },
+  { get: (r) => r.id, key: 'trails.span.id' },
+  { get: (r) => r.parentId, key: 'trails.span.parent_id' },
+  { get: (r) => r.rootId, key: 'trails.span.root_id' },
+  { get: (r) => r.status, key: 'trails.status' },
+  { get: (r) => r.surface, key: 'trails.surface' },
+  {
+    get: (r) => (r.endedAt === undefined ? undefined : r.endedAt - r.startedAt),
+    key: 'trails.timing.duration_ms',
+  },
+  { get: (r) => r.endedAt, key: 'trails.timing.ended_at_ms' },
+  { get: (r) => r.startedAt, key: 'trails.timing.started_at_ms' },
+  { get: (r) => r.traceId, key: 'trails.trace.id' },
+  { get: (r) => r.trailId, key: 'trails.trail.id' },
 ];
+
+const STABLE_ATTRIBUTE_KEYS = new Set(ATTR_MAP.map(({ key }) => key));
 
 /** Build the trails-namespaced attributes from a TraceRecord. */
 const buildAttributes = (
   record: TraceRecord
-): Record<string, string | number | boolean> => {
-  const attrs: Record<string, string | number | boolean> = {};
+): Record<string, OtelAttributeValue> => {
+  const attrs: Record<string, OtelAttributeValue> = {};
   for (const { key, get } of ATTR_MAP) {
     const val = get(record);
     if (val !== undefined) {
@@ -58,9 +153,10 @@ const buildAttributes = (
   }
   for (const [key, val] of Object.entries(record.attrs)) {
     if (
-      typeof val === 'string' ||
-      typeof val === 'number' ||
-      typeof val === 'boolean'
+      attrs[key] === undefined &&
+      !STABLE_ATTRIBUTE_KEYS.has(key) &&
+      !isUnsafeCustomAttributeKey(key) &&
+      isOtelAttributeValue(val)
     ) {
       attrs[key] = val;
     }


### PR DESCRIPTION
## Context

Linear: TRL-723
Stack position: 9/14

This hardens the v1 OTel adapter's stable `trails.*` attribute mapping without adding an OpenTelemetry SDK dependency.

## Changes

- Maps stable Trails trace, span, trail, intent, surface, status, timing, permit, signal, and activation fields to `trails.*` attributes.
- Preserves stable attributes when custom attrs try to override them.
- Filters unsafe custom attributes and avoids leaking raw payload/error message/stack content.
- Adds OTel attribute mapping tests for stable fields, signal payload summaries, activation data, and redaction behavior.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: `bun run --cwd packages/tracing test`, `bun run --cwd packages/tracing typecheck`, `bun run --cwd packages/tracing lint`.

## Risks / rollout notes

- Attribute naming is the main review surface. This branch keeps the adapter callback-shaped and dependency-light.