### PR TITLE
fix(tracing): harden otel buffering

### DIFF
--- a/.changeset/trl-725-otel-buffering.md
+++ b/.changeset/trl-725-otel-buffering.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/tracing": patch
+---
+
+Harden the OTel adapter flush lifecycle by validating batch sizes, sharing concurrent flush drains, and preserving failed batches for retry without silent record loss.

--- a/packages/tracing/src/__tests__/otel-adapter.test.ts
+++ b/packages/tracing/src/__tests__/otel-adapter.test.ts
@@ -687,6 +687,18 @@ describe('otelAdapter', () => {
   });
 
   describe('flush', () => {
+    test.each([0, -1, 1.5, Number.NaN])(
+      'rejects invalid batchSize %p',
+      (batchSize) => {
+        expect(() =>
+          createOtelAdapter({
+            batchSize,
+            exporter: () => {},
+          })
+        ).toThrow('OTel adapter batchSize must be a positive integer');
+      }
+    );
+
     test('sends buffered spans that have not yet reached batchSize', async () => {
       const exported: OtelSpan[][] = [];
       const adapter = createOtelAdapter({
@@ -732,6 +744,97 @@ describe('otelAdapter', () => {
       expect(exported[0]).toHaveLength(3);
     });
 
+    test('concurrent flush calls await the same exporter drain', async () => {
+      const exported: OtelSpan[][] = [];
+      const exporterStarted = Promise.withResolvers<undefined>();
+      const exporterReleased = Promise.withResolvers<undefined>();
+      const adapter = createOtelAdapter({
+        batchSize: 10,
+        exporter: async (s) => {
+          exported.push([...s]);
+          exporterStarted.resolve();
+          await exporterReleased.promise;
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await adapter.write(makeRecord({ id: 'span-b' }));
+
+      const firstFlush = adapter.flush();
+      await exporterStarted.promise;
+      const secondFlush = adapter.flush();
+
+      exporterReleased.resolve();
+      await Promise.all([firstFlush, secondFlush]);
+
+      expect(exported).toHaveLength(1);
+      expect(exported[0]?.map((span) => span.spanId)).toEqual([
+        'span-a',
+        'span-b',
+      ]);
+    });
+
+    test('auto-flush drains records queued during an active export', async () => {
+      const exported: string[][] = [];
+      const exporterStarted = Promise.withResolvers<undefined>();
+      const exporterReleased = Promise.withResolvers<undefined>();
+      let exportCount = 0;
+      const adapter = createOtelAdapter({
+        batchSize: 1,
+        exporter: async (s) => {
+          exportCount += 1;
+          exported.push(s.map((span) => span.spanId));
+          // eslint-disable-next-line jest/no-conditional-in-test -- only the first export is held open
+          if (exportCount === 1) {
+            exporterStarted.resolve();
+            await exporterReleased.promise;
+          }
+        },
+      });
+
+      const firstWrite = adapter.write(makeRecord({ id: 'span-a' }));
+      await exporterStarted.promise;
+      const secondWrite = adapter.write(makeRecord({ id: 'span-b' }));
+
+      expect(exported).toEqual([['span-a']]);
+
+      exporterReleased.resolve();
+      await Promise.all([firstWrite, secondWrite]);
+
+      expect(exported).toEqual([['span-a'], ['span-b']]);
+    });
+
+    test('auto-flush leaves below-threshold records buffered', async () => {
+      const exported: string[][] = [];
+      const exporterStarted = Promise.withResolvers<undefined>();
+      const exporterReleased = Promise.withResolvers<undefined>();
+      const adapter = createOtelAdapter({
+        batchSize: 2,
+        exporter: async (s) => {
+          exported.push(s.map((span) => span.spanId));
+          // eslint-disable-next-line jest/no-conditional-in-test -- only the first export is held open
+          if (exported.length === 1) {
+            exporterStarted.resolve();
+            await exporterReleased.promise;
+          }
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      const secondWrite = adapter.write(makeRecord({ id: 'span-b' }));
+      await exporterStarted.promise;
+      await adapter.write(makeRecord({ id: 'span-c' }));
+
+      exporterReleased.resolve();
+      await secondWrite;
+
+      expect(exported).toEqual([['span-a', 'span-b']]);
+
+      await adapter.flush();
+
+      expect(exported).toEqual([['span-a', 'span-b'], ['span-c']]);
+    });
+
     test('rethrows exporter failures and restores the buffer', async () => {
       let shouldFail = true;
       const exported: OtelSpan[][] = [];
@@ -761,6 +864,60 @@ describe('otelAdapter', () => {
       await adapter.flush();
       expect(exported).toHaveLength(1);
       expect(exported[0]).toHaveLength(2);
+    });
+
+    test('restores failed batches ahead of queued records for retry', async () => {
+      let shouldFail = true;
+      const attempts: string[][] = [];
+      const exported: string[][] = [];
+      const adapter = createOtelAdapter({
+        batchSize: 3,
+        exporter: (s) => {
+          const spanIds = s.map((span) => span.spanId);
+          attempts.push(spanIds);
+          // eslint-disable-next-line jest/no-conditional-in-test -- exporter failure is the behavior under test
+          if (shouldFail) {
+            shouldFail = false;
+            throw new Error('partial exporter failure');
+          }
+          exported.push(spanIds);
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await adapter.write(makeRecord({ id: 'span-b' }));
+      await expect(adapter.write(makeRecord({ id: 'span-c' }))).rejects.toThrow(
+        'partial exporter failure'
+      );
+
+      await adapter.write(makeRecord({ id: 'span-d' }));
+
+      expect(attempts[0]).toEqual(['span-a', 'span-b', 'span-c']);
+      expect(attempts[1]).toEqual(['span-a', 'span-b', 'span-c', 'span-d']);
+      expect(exported).toHaveLength(1);
+      expect(exported.flat()).toEqual(['span-a', 'span-b', 'span-c', 'span-d']);
+    });
+
+    test('keeps explicit flush and auto-flush to one exporter call each', async () => {
+      const exported: string[][] = [];
+      const adapter = createOtelAdapter({
+        batchSize: 3,
+        exporter: (s) => {
+          exported.push(s.map((span) => span.spanId));
+        },
+      });
+
+      await adapter.write(makeRecord({ id: 'span-a' }));
+      await adapter.write(makeRecord({ id: 'span-b' }));
+      await adapter.flush();
+      await adapter.write(makeRecord({ id: 'span-c' }));
+      await adapter.write(makeRecord({ id: 'span-d' }));
+      await adapter.write(makeRecord({ id: 'span-e' }));
+
+      expect(exported).toEqual([
+        ['span-a', 'span-b'],
+        ['span-c', 'span-d', 'span-e'],
+      ]);
     });
 
     test('is a no-op when buffer is empty', async () => {

--- a/packages/tracing/src/adapters/otel.ts
+++ b/packages/tracing/src/adapters/otel.ts
@@ -179,7 +179,13 @@ const toOtelSpan = (record: TraceRecord): OtelSpan => ({
 
 /** A TraceSink extended with an explicit flush for shutdown. */
 export interface OtelSink extends TraceSink {
-  /** Flush any remaining buffered spans to the exporter. */
+  /**
+   * Flush any remaining buffered spans to the exporter.
+   *
+   * Call this during shutdown after the app stops accepting new work. Concurrent
+   * flush calls await the same in-flight export. If the exporter rejects, the
+   * failed batch is restored to the buffer so a later flush can retry it.
+   */
   readonly flush: () => Promise<void>;
 }
 
@@ -195,19 +201,66 @@ export interface OtelSink extends TraceSink {
  */
 export const createOtelAdapter = (options: OtelAdapterOptions): OtelSink => {
   const batchSize = options.batchSize ?? 1;
+  if (!(Number.isSafeInteger(batchSize) && batchSize > 0)) {
+    throw new RangeError('OTel adapter batchSize must be a positive integer');
+  }
   const buffer: OtelSpan[] = [];
+  let activeFlush: Promise<void> | undefined;
+  let flushAllRequested = false;
 
-  const flush = async (): Promise<void> => {
-    if (buffer.length === 0) {
-      return;
-    }
+  const exportBuffered = async (): Promise<void> => {
     const batch = buffer.splice(0);
     try {
       await options.exporter(batch);
     } catch (error) {
-      // Restore batch on exporter failure so data is not lost
+      // Restore batch on exporter failure so data is not lost.
       buffer.unshift(...batch);
       throw error;
+    }
+  };
+
+  const startFlush = (request?: {
+    readonly flushAll?: boolean;
+  }): Promise<void> => {
+    if (request?.flushAll === true) {
+      flushAllRequested = true;
+    }
+    if (activeFlush !== undefined) {
+      return activeFlush;
+    }
+    if (
+      buffer.length === 0 ||
+      (request?.flushAll !== true && buffer.length < batchSize)
+    ) {
+      if (buffer.length === 0) {
+        flushAllRequested = false;
+      }
+      return Promise.resolve();
+    }
+    activeFlush = (async () => {
+      try {
+        let shouldContinue = true;
+        do {
+          await exportBuffered();
+          shouldContinue =
+            buffer.length > 0 &&
+            (flushAllRequested || buffer.length >= batchSize);
+        } while (shouldContinue);
+      } finally {
+        activeFlush = undefined;
+        if (buffer.length === 0) {
+          flushAllRequested = false;
+        }
+      }
+    })();
+    return activeFlush;
+  };
+
+  const flush = (): Promise<void> => startFlush({ flushAll: true });
+
+  const maybeFlush = async (): Promise<void> => {
+    while (buffer.length >= batchSize) {
+      await startFlush();
     }
   };
 
@@ -215,9 +268,7 @@ export const createOtelAdapter = (options: OtelAdapterOptions): OtelSink => {
     flush,
     write: async (record: TraceRecord): Promise<void> => {
       buffer.push(toOtelSpan(record));
-      if (buffer.length >= batchSize) {
-        await flush();
-      }
+      await maybeFlush();
     },
   };
 };


### PR DESCRIPTION
## Context

Linear: TRL-725
Stack position: 11/14

This hardens OTel adapter buffering, flush, and exporter failure behavior.

## Changes

- Validates `batchSize` as a positive safe integer.
- Makes concurrent `flush()` calls share the active drain.
- Restores failed exporter batches to the front of the buffer before newer queued records.
- Documents shutdown expectations on the `flush` contract and adds failure/retry tests.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: `bun run --cwd packages/tracing test`, `bun run --cwd packages/tracing typecheck`, `bun run --cwd packages/tracing lint`.

## Risks / rollout notes

- Exporter failures are now retryable by later flush calls; callers still see the exporter rejection.
- No OpenTelemetry SDK runtime dependency is added.