### PR TITLE
docs(tracing): document otel boundary

### DIFF
--- a/.changeset/trl-726-tracing-otel-docs.md
+++ b/.changeset/trl-726-tracing-otel-docs.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/observe": patch
+"@ontrails/tracing": patch
+---
+
+Document the v1 `@ontrails/tracing/otel` OpenTelemetry adapter boundary, including callback export, stable `trails.*` attributes, flush behavior, and the absence of a standalone `@ontrails/otel` package.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -515,7 +515,6 @@ createBoundedMemorySink(options?)    // explicit alias for createMemorySink
 createDevStore(options?)             // SQLite-backed persistent sink for development
 registerTraceStore(store)            // expose a store to tracing query/status trails
 registerTracingState(state)          // bootstrap full tracing state
-createOtelAdapter(options)           // OpenTelemetry span exporter; exporter is required
 toTraceStore(store)                  // read-only TraceStore view that does not own the writable connection
 countTraceRecords(db), previewTraceCleanup(db, options?), applyTraceCleanup(db, options?)
 withTraceStoreDb(options, run), ensureTraceSchema(db)
@@ -537,6 +536,23 @@ DEFAULT_SAMPLING                     // default sampling rates by intent
 
 TraceRecord, TraceSink, SamplingConfig, TraceContext, TraceFn, TraceCleanupReport
 ```
+
+For v1, OpenTelemetry trace export lives at `@ontrails/tracing/otel`; there is no standalone `@ontrails/otel` package. Use `@ontrails/pino` separately for Pino-shaped log forwarding.
+
+## `@ontrails/tracing/otel`
+
+`@ontrails/tracing/otel` is the v1 OpenTelemetry adapter home. It translates Trails-native `TraceRecord` values outward and does not require an OpenTelemetry SDK runtime dependency.
+
+```typescript
+createOtelAdapter(options)           // create a TraceSink with explicit flush()
+
+OtelAdapterOptions                   // { exporter, batchSize? }
+OtelExporter                         // (spans: readonly OtelSpan[]) => void | Promise<void>
+OtelSink                             // TraceSink plus flush()
+OtelSpan                             // OTel-shaped span record
+```
+
+The adapter emits stable `trails.*` attributes for trace identity, lineage, trail IDs, intent, surface, permits, status, timing, signal lifecycle, and activation boundaries. Custom primitive attrs are forwarded only when they are safe and cannot override stable `trails.*` fields. Call `sink.flush()` during shutdown after the app stops accepting work; failed exporter batches remain buffered for retry.
 
 ## Reserved
 

--- a/docs/migration/logging-to-observe.md
+++ b/docs/migration/logging-to-observe.md
@@ -55,8 +55,17 @@ const exporter = async (spans: unknown) => {
   // Forward spans to your collector.
 };
 
-registerTraceSink(createOtelAdapter({ exporter }));
+const sink = createOtelAdapter({ exporter });
+registerTraceSink(sink);
+
+// During shutdown, stop accepting work first, then:
+await sink.flush();
 ```
+
+There is no standalone `@ontrails/otel` package in v1. The adapter keeps the
+Trails-native `TraceRecord` model internal, emits stable `trails.*` attributes,
+and forwards OTel-shaped span batches through the exporter callback without
+forcing an OpenTelemetry SDK runtime dependency.
 
 Use `@ontrails/pino` when an app already owns a Pino logger:
 

--- a/packages/observe/README.md
+++ b/packages/observe/README.md
@@ -21,6 +21,12 @@ tracing-specific local tooling: query/status trails, the SQLite dev store,
 sampling helpers, and the supported `@ontrails/tracing/otel` OpenTelemetry
 adapter subpath.
 
+For v1, OpenTelemetry trace export lives at `@ontrails/tracing/otel`; there is
+no standalone `@ontrails/otel` package. That adapter translates Trails-native
+`TraceRecord` values to callback-delivered OTel-shaped spans without requiring
+the OpenTelemetry SDK as a runtime dependency. Use `@ontrails/pino` separately
+when forwarding log records to a Pino-shaped logger.
+
 ```typescript
 import {
   combine,

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -16,9 +16,12 @@ primitives or tracing-specific developer-state APIs such as `tracingResource`,
 `tracingStatus`, `tracingQuery`, `createDevStore`, sampling helpers, or
 dev-store cleanup helpers.
 
-The `@ontrails/tracing/otel` subpath remains the supported v1 OpenTelemetry
-adapter path. It exports adapter-named APIs such as `createOtelAdapter` and
-`OtelAdapterOptions`; no separate `@ontrails/otel` package is required for v1.
+The `@ontrails/tracing/otel` subpath is the supported v1 OpenTelemetry
+adapter path. It exports adapter-named APIs such as `createOtelAdapter`,
+`OtelAdapterOptions`, `OtelExporter`, and `OtelSpan`; no separate
+`@ontrails/otel` package exists for v1. Trails keeps the internal trace model
+native to `TraceRecord`, then translates outward at this subpath so the adapter
+does not force an OpenTelemetry SDK dependency on every tracing user.
 
 ## The core pattern
 
@@ -170,9 +173,58 @@ const sink = createOtelAdapter({
   batchSize: 50,
 });
 registerTraceSink(sink);
+
+// On shutdown, stop accepting work first, then flush queued spans.
+await sink.flush();
 ```
 
-The adapter translates `TraceRecord` records to OTel spans with Trails-namespaced attributes (`trails.trail.id`, `trails.intent`, `trails.surface`, `trails.permit.id`).
+The exporter callback receives `readonly OtelSpan[]` batches. `OtelSpan`
+contains the OTel-facing shape derived from each `TraceRecord`: `traceId`,
+`spanId`, optional `parentSpanId`, `operationName`, `startTime`, optional
+`endTime`, `status`, `kind`, and primitive `attributes`. The adapter is
+callback-based on purpose: applications can bridge this output to an OTel SDK,
+collector client, worker queue, or test double without this package importing
+the SDK.
+
+The stable `trails.*` attribute family includes:
+
+- Trace identity and lineage: `trails.trace.id`, `trails.span.id`,
+  `trails.span.root_id`, `trails.span.parent_id`, `trails.record.kind`, and
+  `trails.record.name`.
+- Trail execution context: `trails.trail.id`, `trails.intent`,
+  `trails.surface`, `trails.permit.id`, and `trails.permit.tenant_id`.
+- Status and timing: `trails.status`, `trails.error.category`,
+  `trails.sampled`, `trails.timing.started_at_ms`,
+  `trails.timing.ended_at_ms`, and `trails.timing.duration_ms`.
+- Signal and activation context: `trails.signal.*` and
+  `trails.activation.*` records, including lifecycle names such as
+  `trails.signal.event` and `trails.activation.event`.
+
+Custom primitive `record.attrs` are forwarded when they are OTel-safe, but they
+cannot override stable attributes. Raw payload/body/input/output fields,
+authorization/cookie/token/password/secret fields, and unredacted
+`error.message` or `exception.message` style fields are filtered. Signal payload
+summaries remain available through the redacted `trails.signal.payload.*`
+digest/shape/size attributes.
+
+Lineage follows the Trails-native `TraceRecord` fields. Root records without a
+parent map to OTel `SERVER`; child spans, crossed trails, signal lifecycle
+records, and activated trails with `parentId` map to `INTERNAL` and keep the
+same `traceId`. Status maps `ok` to `OK`, `err` to `ERROR`, and `cancelled` to
+`UNSET`; the Trails error category remains on `trails.error.category`.
+
+`batchSize` must be a positive integer and defaults to `1`, which means every
+write flushes immediately unless you set a higher value. Writes auto-flush when
+the buffer reaches that threshold, and `flush()` drains any remaining records.
+Concurrent `flush()` calls share the same in-flight drain. If the exporter
+rejects, the failed batch is restored ahead of newer queued records so a later
+`flush()` can retry without silent loss.
+
+Use `@ontrails/observe` for app-facing sink contracts, `combine(...)`, built-in
+console/file/memory sinks, and trace tree rendering. Use `@ontrails/pino` when
+you need to forward Trails log records to a Pino-shaped logger. The OTel adapter
+is trace export only; it complements those packages rather than replacing the
+observability boundary.
 
 ## Sampling
 


### PR DESCRIPTION
## Context

Linear: TRL-726
Stack position: 12/14

This closes the v1 documentation boundary for the OTel adapter.

## Changes

- Documents `@ontrails/tracing/otel` as the v1 OpenTelemetry adapter home.
- Covers callback export shape, stable `trails.*` attributes, lineage/status semantics, flush behavior, and observe/Pino relationships.
- Explicitly states that there is no standalone `@ontrails/otel` package for v1.
- Keeps docs clear that no OpenTelemetry SDK runtime dependency is required.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: docs link/snippet checks and tracing package checks.

## Risks / rollout notes

- Docs-only boundary clarification. Future extraction remains possible if a real dependency/release boundary appears.