### PR TITLE
ci: cache bun install artifacts

### DIFF
--- a/.agents/plans/2026-05-16-http-bun-observability-closeout/reports/trl-365-ci-baseline.md
+++ b/.agents/plans/2026-05-16-http-bun-observability-closeout/reports/trl-365-ci-baseline.md
@@ -1,0 +1,30 @@
+# TRL-365 CI Baseline And Scoped Optimization
+
+Date: 2026-05-16
+
+## Measured Baseline
+
+Source: recent successful `CI` workflow runs on `main`, queried with `gh run view --json jobs`.
+
+| Run | Event | Build | Typecheck | Test | Lint & Format | Governance | Dead Code |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `25859151108` | `push` | 74s | 72s | 76s | 17s | 28s | 8s |
+| `25822675749` | `push` | 62s | 73s | 81s | 23s | 24s | 10s |
+
+The long poles are still `Build`, `Typecheck`, and `Test`. The shared setup path runs in every job and accounts for roughly 3-8 seconds per job in these samples, so install/cache work is the lowest-risk optimization that does not change required gates.
+
+## Implemented Change
+
+`./.github/actions/setup` now caches Bun's install cache at `~/.bun/install/cache`, keyed by:
+
+```text
+bun-install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bun-version', 'bun.lock') }}
+```
+
+This keeps `bun install --frozen-lockfile` as the correctness gate while reducing repeated dependency archive downloads across the fan-out jobs. The cache is scoped by OS, architecture, Bun version file, and lockfile.
+
+## Audited But Not Changed
+
+- `Build` remains a separate required job. Folding it into another job would change the required-check shape and risks weakening release signal.
+- `Lint & Format` remains one job with distinct `lint`, `lint:ast-grep`, and `format:check` steps. The commands overlap filesystem traversal, but they enforce different gates and the formatter path also builds the private Oxlint plugin before Ultracite runs.
+- Reusable workflows or a matrix would mostly reshape YAML right now; the current shared setup composite already gives one maintenance point for dependency setup.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,6 +14,14 @@ runs:
       with:
         bun-version-file: .bun-version
 
+    - name: Cache Bun dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bun-version', 'bun.lock') }}
+        restore-keys: |
+          bun-install-${{ runner.os }}-${{ runner.arch }}-
+
     - name: Install dependencies
       shell: bash
       run: bun install --frozen-lockfile


### PR DESCRIPTION
## Context

Linear: TRL-365
Stack position: 13/14

This implements the scoped CI optimization from the issue without weakening required gates.

## Changes

- Adds an `actions/cache@v4` step for `~/.bun/install/cache` in the shared setup action.
- Keys the cache on OS, architecture, `.bun-version`, and `bun.lock`.
- Leaves the existing `bun install --frozen-lockfile` step in place.
- Adds a baseline report under the stack planning packet.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: `bunx actionlint -ignore 'SC2129' .github/workflows/ci.yml` and YAML parse check for `.github/actions/setup/action.yml`.

## Risks / rollout notes

- This is cache-only; it does not remove or relax CI correctness gates.
- The existing shellcheck SC2129 warning is unrelated to this setup-action change and was ignored for focused actionlint validation.