### PR TITLE
docs: close http observability wording

### DIFF
--- a/.agents/plans/2026-05-16-http-bun-observability-closeout/reports/local-review-round-1-http-kernel-security.md
+++ b/.agents/plans/2026-05-16-http-bun-observability-closeout/reports/local-review-round-1-http-kernel-security.md
@@ -1,0 +1,37 @@
+# Local Review Round 1: HTTP Kernel And Surface Security
+
+Date: 2026-05-16
+Stack tip reviewed: `trl-718-docs-close-http-and-observability-wording-before-versioning`
+
+## Scope
+
+- `packages/http/src/fetch.ts`
+- `packages/http/src/bun.ts`
+- `adapters/hono/src/surface.ts`
+- HTTP/Bun/Hono parity tests and public HTTP docs
+
+## Findings
+
+### P2 - Fixed: aborted JSON body reads projected as internal 500
+
+The Web Fetch kernel threw a native `Error('Request aborted')` while reading a JSON body from an already-aborted request. That native error flowed through the generic error path and projected as an internal 500 instead of the HTTP taxonomy's `cancelled` response.
+
+Fix landed on lowest owning branch `TRL-715`:
+
+- `packages/http/src/fetch.ts` now throws `CancelledError('Request aborted')`.
+- `packages/http/src/__tests__/fetch.test.ts` covers aborted body reads returning HTTP 499 with `category: "cancelled"`.
+- Graphite restacked every descendant branch.
+
+## Follow-up Review Result
+
+No remaining P0/P1/P2 findings in this lane after the fix.
+
+## Verification
+
+- `bun run --cwd packages/http test` — pass, 138 tests
+- `bun run --cwd adapters/hono test` — pass, 45 tests
+- `bun run --cwd packages/http typecheck` — pass
+- `bun run --cwd adapters/hono typecheck` — pass
+- `bun run --cwd packages/http lint` — pass
+- `bun run format:check` — pass
+- `git diff --check` — pass

--- a/.agents/plans/2026-05-16-http-bun-observability-closeout/reports/local-review-round-2-package-publish-readiness.md
+++ b/.agents/plans/2026-05-16-http-bun-observability-closeout/reports/local-review-round-2-package-publish-readiness.md
@@ -1,0 +1,43 @@
+# Local Review Round 2: Package And Publish Readiness
+
+Date: 2026-05-16
+Stack tip reviewed: `trl-718-docs-close-http-and-observability-wording-before-versioning`
+
+## Scope
+
+- `packages/pino`
+- Pino changesets and publish guidance
+- Package tarball checks for the full workspace
+- Publish-command wording in touched docs
+
+## Findings
+
+### P2 - Fixed: metadata could overwrite stable Pino payload category
+
+`createPinoSink` built the Pino payload with `category` before spreading metadata, so `record.metadata.category` could replace the canonical `record.category` in forwarded logs.
+
+Fix landed on lowest owning branch `TRL-721`:
+
+- `packages/pino/src/index.ts` now spreads metadata first and then writes stable `category` and `timestamp`.
+- `packages/pino/src/__tests__/pino.test.ts` covers metadata collisions for `category` and `timestamp`.
+- Graphite restacked every descendant branch.
+
+## Follow-up Review Result
+
+No remaining P0/P1/P2 findings in this lane after the fix.
+
+## Package Boundary Checks
+
+- `packages/pino/package.json` declares only the structural peer `@ontrails/observe`; it does not add a hard `pino` runtime dependency.
+- `bun.lock` contains the workspace `@ontrails/pino` package entry and no resolved external `pino` dependency.
+- Publish guidance uses `bun run publish:check` and `bun run publish:packages`.
+- `npm publish` and `changeset publish` appear only in explicit "do not use" guidance.
+
+## Verification
+
+- `bun run --cwd packages/pino test` — pass, 12 tests
+- `bun run --cwd packages/pino typecheck` — pass
+- `bun run --cwd packages/pino lint` — pass
+- `bun run format:check` — pass
+- `git diff --check` — pass
+- `bun run publish:check` — pass; all public package pack checks passed, including `@ontrails/pino`

--- a/.agents/plans/2026-05-16-http-bun-observability-closeout/reports/local-review-round-3-observability-docs-ci.md
+++ b/.agents/plans/2026-05-16-http-bun-observability-closeout/reports/local-review-round-3-observability-docs-ci.md
@@ -1,0 +1,35 @@
+# Local Review Round 3: Observability, Docs, And CI Hygiene
+
+Date: 2026-05-16
+Stack tip reviewed: `trl-718-docs-close-http-and-observability-wording-before-versioning`
+
+## Scope
+
+- `packages/tracing/src/adapters/otel.ts`
+- OTel lineage/status/buffering tests
+- OTel and observability package docs
+- ADR/package-boundary wording for Bun and OTel materializers
+- CI setup action optimization
+
+## Findings
+
+No P0/P1/P2 findings in this lane.
+
+## Review Notes
+
+- `@ontrails/tracing/otel` remains a subpath export on `@ontrails/tracing`; no standalone `@ontrails/otel` package is present.
+- `packages/tracing/package.json` has no OpenTelemetry SDK runtime dependency.
+- `@ontrails/http/bun` remains a subpath export on `@ontrails/http`; no standalone `@ontrails/bun` package is present.
+- ADR-0029 now distinguishes `derive*` projection APIs from `create*` runtime materializers and explicitly keeps platform-built runtime materializers under the owning surface package.
+- Forbidden package names and publish commands appear only in explicit "do not create" or "do not use" doctrine.
+- The scoped CI optimization only adds an `actions/cache@v4` step for Bun install artifacts before the existing `bun install --frozen-lockfile` step; it does not remove or weaken gates.
+
+## Verification
+
+- `bun run --cwd packages/tracing test` — pass, 135 tests
+- `bun run --cwd packages/tracing typecheck` — pass
+- `bun run --cwd packages/tracing lint` — pass
+- `bun run docs:links` — pass, 114 Markdown files
+- `bun run docs:snippets` — pass, 21 README files
+- `bunx actionlint -ignore 'SC2129' .github/workflows/ci.yml` — pass
+- `ruby -e "require 'yaml'; YAML.load_file('.github/actions/setup/action.yml')"` — pass

--- a/.changeset/trl-718-http-observability-docs.md
+++ b/.changeset/trl-718-http-observability-docs.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/http": patch
+"@ontrails/hono": patch
+---
+
+Close HTTP package documentation around the shared `@ontrails/http/fetch` kernel, Bun-native `@ontrails/http/bun` subpath, and Hono adapter boundary before versioning.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ await cliSurface(graph);      // CLI
 // await mcpSurface(graph);   // MCP — same trails, same run function
 ```
 
-The same topo can be opened on HTTP today with `@ontrails/hono`. WebSocket follows the same peer-surface model, but is still planned.
+The same topo can be opened on HTTP today with `@ontrails/hono` or Bun-native `@ontrails/http/bun`. WebSocket follows the same peer-surface model, but is still planned.
 
 ```bash
 $ myapp greet --name World
@@ -143,8 +143,8 @@ $ myapp greet --name World
 | [`@ontrails/cli`](./packages/cli) | CLI command model - flag derivation, output formatting |
 | [`@ontrails/commander`](./adapters/commander) | Commander adapter for the CLI surface |
 | [`@ontrails/mcp`](./packages/mcp) | MCP surface — tool generation, annotations, progress bridge |
-| [`@ontrails/http`](./packages/http) | HTTP surface model — route derivation, verb mapping, error responses |
-| [`@ontrails/hono`](./adapters/hono) | Hono adapter that opens a topo on the HTTP surface |
+| [`@ontrails/http`](./packages/http) | HTTP surface model — route derivation, Web Fetch kernel, Bun-native subpath |
+| [`@ontrails/hono`](./adapters/hono) | Hono adapter that opens a topo on the HTTP surface using the shared kernel |
 | [`@ontrails/store`](./packages/store) | Backend-agnostic store definitions, typed accessors, adapter-support helpers |
 | [`@ontrails/testing`](./packages/testing) | `testAll()`, `testTrail()`, `testCrosses()`, contract testing, surface harnesses |
 | [`@ontrails/topographer`](./packages/topographer) | Surface maps, semantic diffing, lock files for CI governance |

--- a/adapters/hono/README.md
+++ b/adapters/hono/README.md
@@ -1,6 +1,6 @@
 # @ontrails/hono
 
-Hono surface adapter for Trails. Use this package when you want to serve a topo over HTTP with Hono while keeping `@ontrails/http` focused on framework-agnostic route building.
+Hono surface adapter for Trails. Use this package when you want to serve a topo over HTTP with Hono while keeping `@ontrails/http` focused on framework-agnostic route building and the shared Web Fetch kernel.
 
 ## Usage
 
@@ -32,7 +32,7 @@ redacted diagnostic projection is written to server diagnostics. `TrailsError`
 responses keep their taxonomy category and class name but redact sensitive
 message fragments before writing the public body.
 
-For custom HTTP integrations or route inspection, keep using `deriveHttpRoutes()` from `@ontrails/http`.
+For custom HTTP integrations or route inspection, keep using `deriveHttpRoutes()` from `@ontrails/http`. For a framework-neutral runtime handler, use `createRouteHandler()` or `createFetchHandler()` from `@ontrails/http/fetch`. For Bun-native serving without Hono, use `@ontrails/http/bun`.
 
 ## Installation
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -202,6 +202,28 @@ DeriveHttpRoutesOptions, HttpMethod, HttpOperationMethod, HttpRouteDefinition, I
 OpenApiOptions, OpenApiSpec, OpenApiServer
 ```
 
+## `@ontrails/http/fetch`
+
+```typescript
+createRouteHandler(route, options?)    // materialize one Web Fetch Request -> Response handler
+createFetchHandler(graph, options?)    // materialize a full topo Web Fetch dispatcher
+
+CreateRouteHandlerOptions, CreateFetchHandlerOptions
+```
+
+The fetch kernel owns query/body parsing, content-length checks, public HTTP error projection, diagnostics, request ID/header forwarding, abort propagation, and webhook verification/parsing semantics for HTTP materializers.
+
+## `@ontrails/http/bun`
+
+```typescript
+createApp(graph, options?)             // create Bun routes + fetch fallback + onError handler
+surface(graph, options?)               // serve the topo with Bun.serve()
+
+BunHttpApp, CreateAppOptions, SurfaceHttpResult
+```
+
+Use this subpath for Bun-native serving without Hono or another third-party HTTP framework.
+
 ## `@ontrails/hono`
 
 ```typescript
@@ -486,6 +508,14 @@ MemorySinkOptions, MemoryTraceSink, PrettyFormatterOptions
 createLogtapeSink({ logger })         // forward observe LogRecord values to a LogTape-shaped logger
 
 LogtapeLoggerLike, LogtapeSinkOptions
+```
+
+## `@ontrails/pino`
+
+```typescript
+createPinoSink(logger, options?)       // forward observe LogRecord values to a Pino-shaped logger
+
+PinoLoggerLike, PinoSinkOptions
 ```
 
 ## `@ontrails/tracing`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,7 +149,7 @@ Overrides are escape hatches. They're visible in the TopoGraph as explicit devia
 | `@ontrails/cli` | Framework-agnostic command model, flag derivation, output formatting | None beyond core |
 | `@ontrails/commander` | Commander adapter, `surface()` | `commander` |
 | `@ontrails/mcp` | MCP tools, annotations, progress bridge, `surface()` | `@modelcontextprotocol/sdk` |
-| `@ontrails/http` | HTTP routes, error mapping, and OpenAPI generation | None beyond core |
+| `@ontrails/http` | HTTP routes, Web Fetch kernel, Bun-native subpath, and OpenAPI generation | None beyond core |
 | `@ontrails/hono` | Hono adapter, `surface()` | `hono` |
 | `@ontrails/vite` | Vite middleware adapter, `vite()` | None (node:stream only) |
 
@@ -164,6 +164,7 @@ Overrides are escape hatches. They're visible in the TopoGraph as explicit devia
 | `@ontrails/observe` | Production log and trace sink contracts, composition, and built-in sinks | None beyond core |
 | `@ontrails/tracing` | Tracing compatibility, query/status trails, `.trails/state/trails.db` dev-state storage, sampling helpers, OTel adapter | None beyond core |
 | `@ontrails/logtape` | LogTape sink adapter for `@ontrails/observe` | None (accepts any LogTape-shaped logger via a structural interface) |
+| `@ontrails/pino` | Pino sink adapter for `@ontrails/observe` | None (accepts any Pino-shaped logger via a structural interface) |
 
 ### Ecosystem
 
@@ -260,7 +261,8 @@ MCP tool call ({ name: "myapp_entity_show", arguments: { name: "Alpha" } })
 
 ```text
 HTTP request (GET /entity/show?name=Alpha)
-  -> Hono matches route derived from trail ID
+  -> Hono or Bun matches route derived from trail ID
+  -> Shared Web Fetch kernel parses the request
   -> Zod validates input (query params for GET, JSON body for POST/DELETE)
   -> TrailContext created
   -> Declared resources resolved into ctx

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -4,7 +4,7 @@
 
 ## Shipped
 
-**HTTP surface (`@ontrails/http`).** The third surface adapter. `intent: 'read'` maps to GET, mutations to POST, `'destroy'` to DELETE. Route paths derived from trail IDs. Error taxonomy maps to HTTP status codes. One `surface()` call, same pattern as CLI and MCP. Built on Hono.
+**HTTP surface (`@ontrails/http`).** The third surface adapter. `intent: 'read'` maps to GET, mutations to POST, `'destroy'` to DELETE. Route paths derived from trail IDs. Error taxonomy maps to HTTP status codes. `@ontrails/http` owns the framework-agnostic route projection and shared Web Fetch kernel; `@ontrails/hono` provides Hono portability, while `@ontrails/http/bun` provides Bun-native serving without a third-party framework.
 
 **OpenAPI generation (`@ontrails/http`).** `deriveOpenApiSpec()` produces a complete OpenAPI 3.1 spec from the topo for HTTP clients. The topo already carries everything OpenAPI needs; the HTTP package owns the surface-specific projection.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@
 
 - **[CLI Surface](./surfaces/cli.md)** — Shipped today. Flag derivation, output modes, exit codes, `--dry-run`
 - **[MCP Surface](./surfaces/mcp.md)** — Shipped today. Tool naming, annotations, progress bridge
-- **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, webhook activation, verb mapping, error responses, Hono adapter
+- **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, Web Fetch kernel, Hono adapter, Bun-native serving, webhook activation
 - **WebSocket Surface** — Planned, not yet implemented. See [Horizons](./horizons.md) for the current direction.
 
 ## Governing your codebase?

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -1,8 +1,8 @@
 # HTTP Surface
 
-The HTTP surface adapter turns every trail into an endpoint. Routes are derived from trail IDs, HTTP verbs from intent, input parsing from the method, and error responses from the error taxonomy. One `surface()` call starts a Hono server.
+The HTTP surface turns every trail into an endpoint. Routes are derived from trail IDs, HTTP verbs from intent, input parsing from the method, and error responses from the error taxonomy.
 
-The package separates framework-agnostic route building (`@ontrails/http`) from the Hono adapter (`@ontrails/hono`).
+The package separates framework-agnostic route building (`@ontrails/http`), shared Web Fetch request handling (`@ontrails/http/fetch`), the Hono adapter (`@ontrails/hono`), and Bun-native serving (`@ontrails/http/bun`).
 
 ## Setup
 
@@ -18,6 +18,40 @@ await surface(graph, { port: 3000 });
 ```
 
 That starts an HTTP server with every trail registered as a route.
+
+For Bun-native serving without Hono:
+
+```bash
+bun add @ontrails/http
+```
+
+```typescript
+import { surface } from '@ontrails/http/bun';
+import { graph } from './app';
+
+await surface(graph, { port: 3000 });
+```
+
+`@ontrails/hono` is the portable Hono integration. `@ontrails/http/bun` uses
+Bun's native `routes` fast path, keeps a Fetch fallback for unmatched requests,
+and adds no third-party HTTP framework dependency.
+
+## Projection and runtime materialization
+
+HTTP follows the surface naming split:
+
+- `deriveHttpRoutes()` and `deriveOpenApiSpec()` are `derive*` projections from
+  the topo. They do not open a server.
+- `createRouteHandler()` and `createFetchHandler()` from
+  `@ontrails/http/fetch` are `create*` runtime materializers. They return Web
+  Standard `Request` -> `Response` handlers without listening on a port.
+- `surface()` opens the boundary: `@ontrails/hono` starts Hono;
+  `@ontrails/http/bun` starts `Bun.serve()`.
+
+The shared Fetch kernel owns query/body parsing, content-length validation,
+public error projection, diagnostics, request ID/header forwarding, abort
+propagation, and webhook verification/parsing. Hono and Bun consume the same
+kernel so those behaviors stay in parity.
 
 ## How Trail IDs Map to Routes
 
@@ -55,7 +89,7 @@ Input parsing depends on the HTTP method:
 
 - **GET** -- Query parameters are parsed into an object. Repeated keys become arrays; single keys stay strings. The trail's input schema owns any coercion.
 - **POST / DELETE** -- The JSON request body is parsed via `req.json()`.
-- **Webhook routes** -- The Hono adapter reads the raw body first, runs the webhook `verify` hook if one is defined, parses JSON, then validates the parsed payload against the source's `parse` schema before executing the trail.
+- **Webhook routes** -- The shared Fetch kernel reads the raw body first, runs the webhook `verify` hook if one is defined, parses JSON, then validates the parsed payload against the source's `parse` schema before executing the trail.
 
 For direct routes, the parsed input is validated against the trail's Zod schema before the implementation runs. For webhook routes, the source `parse` schema validates the JSON payload first, then the receiving trail's `input` schema validates the value passed into the trail.
 
@@ -246,13 +280,26 @@ The handler reads `X-Request-ID` from inbound requests and passes it through to 
 
 ## Escape Hatch
 
-For custom setups, use `deriveHttpRoutes()` from the base package to get framework-agnostic route definitions. Each route has an `execute` function that validates input, composes Layers, and runs the trail -- you wire it into whatever HTTP framework you use:
+For custom setups, use `@ontrails/http/fetch` when you want Trails to keep
+owning the request/response semantics and your runtime to own the server:
 
 ```typescript
-import { isTrailsError, mapSurfaceError } from '@ontrails/core';
+import { createFetchHandler } from '@ontrails/http/fetch';
+
+const fetch = createFetchHandler(graph, { basePath: '/api' });
+
+export default {
+  fetch,
+};
+```
+
+If your framework needs route-by-route registration, combine
+`deriveHttpRoutes()` with `createRouteHandler()`:
+
+```typescript
 import { deriveHttpRoutes } from '@ontrails/http';
+import { createRouteHandler } from '@ontrails/http/fetch';
 import { Hono } from 'hono';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 const hono = new Hono();
 const routesResult = deriveHttpRoutes(graph, { basePath: '/api' });
@@ -261,91 +308,15 @@ if (routesResult.isErr()) {
   throw routesResult.error; // ValidationError if route collisions are detected
 }
 
-// Project any error onto an HTTP status using the shared error taxonomy.
-// `TrailsError` subclasses (validation, auth, permission, internal, ...) get
-// the documented status; anything else falls back to 500.
-const statusFor = (error: unknown): ContentfulStatusCode =>
-  isTrailsError(error)
-    ? (mapSurfaceError('http', error) as ContentfulStatusCode)
-    : 500;
-
 for (const route of routesResult.value) {
-  const method = route.method.toLowerCase() as
-    | 'delete'
-    | 'get'
-    | 'patch'
-    | 'post'
-    | 'put';
-  hono[method](route.path, async (c) => {
-    if (route.inputSource === 'webhook') {
-      const body = await c.req.text();
-      const verified = await route.verifyWebhook?.({
-        body,
-        headers: Object.fromEntries(c.req.raw.headers),
-        method: c.req.method,
-        path: new URL(c.req.url).pathname,
-      });
-      if (verified?.isErr()) {
-        // Route through the taxonomy: PermissionError -> 403, AuthError -> 401,
-        // wrapped InternalError -> 500, etc.
-        return c.json(
-          { error: { message: verified.error?.message } },
-          statusFor(verified.error)
-        );
-      }
-      let payload: unknown;
-      try {
-        payload = body.length === 0 ? {} : JSON.parse(body);
-      } catch {
-        return c.json({ error: { message: 'Invalid JSON in request body' } }, 400);
-      }
-      const parsed = route.parseWebhookInput?.(payload);
-      if (parsed === undefined) {
-        return c.json(
-          { error: { message: 'Webhook route is missing parse handler' } },
-          500
-        );
-      }
-      if (parsed.isErr()) {
-        return c.json(
-          { error: { message: parsed.error?.message } },
-          statusFor(parsed.error)
-        );
-      }
-      const result = await route.execute(
-        parsed.value,
-        undefined,
-        c.req.raw.signal,
-        { headers: c.req.raw.headers }
-      );
-      return result.isOk()
-        ? c.json({ data: result.value }, 200)
-        : c.json(
-            { error: { message: result.error?.message } },
-            statusFor(result.error)
-          );
-    }
-
-    const input =
-      route.inputSource === 'query'
-        ? Object.fromEntries(new URL(c.req.url).searchParams)
-        : await c.req.json();
-    const result = await route.execute(input, undefined, c.req.raw.signal, {
-      headers: c.req.raw.headers,
-    });
-    return result.isOk()
-      ? c.json({ data: result.value }, 200)
-      : c.json(
-          { error: { message: result.error?.message } },
-          statusFor(result.error)
-        );
-  });
+  const handler = createRouteHandler(route);
+  hono.on(route.method, route.path, (c) => handler(c.req.raw));
 }
 
 export default hono;
 ```
 
-This gives you full control over the HTTP framework while still deriving routes from the topo.
+This gives you full control over the HTTP framework while preserving the shared query/body parsing, error projection, diagnostics, abort propagation, and webhook behavior.
 
 `deriveHttpRoutes()` returns `Result<HttpRouteDefinition[], Error>`. If two trails resolve to the same method + path (e.g. two trails both map to `POST /entity/add`), it returns a `ValidationError` describing the collision instead of silently overwriting a route.
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -1,6 +1,6 @@
 # @ontrails/http
 
-Framework-agnostic HTTP route derivation for Trails. Pair this package with `@ontrails/hono` when you want the Hono surface adapter.
+Framework-agnostic HTTP route derivation and Web Fetch request handling for Trails. Pair this package with `@ontrails/hono` when you want Hono portability, or use `@ontrails/http/bun` when you want Bun-native serving without a third-party framework.
 
 ## Usage
 
@@ -22,7 +22,7 @@ await surface(graph, { port: 3000 });
 
 This starts a Hono-based HTTP server. The `greet` trail becomes `GET /greet?name=...` because its `intent` is `'read'`.
 
-For Bun-native HTTP without Hono, use the Bun materializer subpath:
+For Bun-native HTTP without Hono, use the Bun runtime materializer subpath:
 
 ```typescript
 import { surface } from '@ontrails/http/bun';
@@ -33,6 +33,24 @@ await surface(graph, { port: 3000 });
 `@ontrails/http/bun` uses Bun's native `Bun.serve({ routes })` fast path and
 keeps the shared Web Fetch handler as the fallback. It requires Bun `>=1.2.3`
 and does not add a third-party runtime dependency.
+
+## Projection and materialization
+
+The HTTP package follows the surface API naming split:
+
+- `derive*` exports are pure projections from the topo. Use
+  `deriveHttpRoutes()` for route definitions and `deriveOpenApiSpec()` for the
+  OpenAPI contract.
+- `create*` exports materialize runtime objects without opening a network
+  boundary. `@ontrails/http/fetch` exports `createRouteHandler()` for one
+  route and `createFetchHandler()` for a full topo dispatcher.
+- `surface()` opens the runtime boundary. `@ontrails/hono` opens a Hono server;
+  `@ontrails/http/bun` opens Bun's native HTTP server.
+
+The shared `@ontrails/http/fetch` kernel owns query/body parsing,
+content-length validation, public error projection, diagnostics, request IDs,
+headers, abort propagation, and webhook verification/parsing behavior. Hono and
+Bun both consume that kernel so route semantics stay aligned.
 
 For more control, build the routes yourself:
 
@@ -65,7 +83,7 @@ contracts used by `deriveHttpRoutes()`.
 | --- | --- |
 | `deriveHttpRoutes(graph, options?)` | Build framework-agnostic route definitions from a topo |
 | `deriveOpenApiSpec(graph, options?)` | Generate an OpenAPI 3.1 document for the HTTP surface |
-| `@ontrails/http/fetch` | Shared Web Fetch request/response kernel for route materializers |
+| `@ontrails/http/fetch` | Shared Web Fetch `createRouteHandler()` and `createFetchHandler()` kernel |
 | `@ontrails/http/bun` | Bun-native `createApp()` and `surface()` materializer |
 
 ## Route derivation


### PR DESCRIPTION
## Context

Linear: TRL-718
Stack position: 14/14

This is the final docs closeout branch before versioning. It ties together HTTP, Bun, Hono, Pino, OTel, and package publishing wording after the implementation branches land.

## Changes

- Updates root/API/architecture/horizons/index HTTP and observability wording.
- Documents `@ontrails/http/fetch`, `@ontrails/http/bun`, Hono-on-fetch, `@ontrails/pino`, and `@ontrails/tracing/otel` relationships.
- Adds the three local review reports for HTTP/security, package/publish readiness, and observability/docs/CI.
- Adds the branch-local changeset for the docs closeout.

## Verification

- Local review: three rounds from stack tip; latest pass clean/P3-only.
- Tip gates: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, `git diff --check`.
- Pre-push hook during `gt submit` reran tests, typecheck, and Warden successfully.
- Focused: docs link/snippet checks, full `bun run check`, and `bun run publish:check`.

## Risks / rollout notes

- This branch should remain draft until the full stack CI is green and remote P2+ review feedback is resolved bottom-up.
- No merge, package publish, registry mutation, or merge-queue action was performed.