### PR TITLE
docs: refresh Trails skill taxonomy guidance

### DIFF
--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -3,7 +3,7 @@ name: trails
 description: Build with the Trails framework — define trail contracts, open CLI/MCP surfaces, test with examples, debug errors, migrate codebases, run governance. Use when creating trails, adding surfaces, testing, debugging Trails errors, migrating to Trails, running warden, or any work involving @ontrails/* packages.
 metadata:
   trails:
-    version: 1.0.0-beta.15
+    version: 1.0.0-beta.17
 ---
 
 # Trails
@@ -183,7 +183,7 @@ See [testing-patterns.md](references/testing-patterns.md) for the full testing A
 
 ## Error Taxonomy
 
-15 fixed-category error classes across 10 categories, plus the dynamic `RetryExhaustedError` wrapper, with deterministic mapping to exit codes, HTTP status, and JSON-RPC codes:
+16 fixed-category error classes across 10 categories, plus the dynamic `RetryExhaustedError` wrapper, with deterministic mapping to exit codes, HTTP status, and JSON-RPC codes:
 
 | Category | Classes | Exit | HTTP | Retry |
 |----------|---------|------|------|-------|
@@ -194,7 +194,7 @@ See [testing-patterns.md](references/testing-patterns.md) for the full testing A
 | timeout | TimeoutError | 5 | 504 | Yes |
 | rate_limit | RateLimitError | 6 | 429 | Yes |
 | network | NetworkError | 7 | 502 | Yes |
-| internal | InternalError, DerivationError, AssertionError | 8 | 500 | No |
+| internal | AssertionError, InternalError, DerivationError, RecoverableCompletionError | 8 | 500 | No |
 | auth | AuthError | 9 | 401 | No |
 | cancelled | CancelledError | 130 | 499 | No |
 

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -196,7 +196,7 @@ The implementation is identical across all paths. Only the edges change.
 
 ## Error Taxonomy
 
-15 fixed-category error classes across 10 categories, plus the dynamic
+16 fixed-category error classes across 10 categories, plus the dynamic
 `RetryExhaustedError` wrapper. All extend `TrailsError`. Pattern match with
 `instanceof` or `error.category`.
 
@@ -209,7 +209,7 @@ The implementation is identical across all paths. Only the edges change.
 | `timeout` | 5 | 504 | Yes | `TimeoutError` |
 | `rate_limit` | 6 | 429 | Yes | `RateLimitError` |
 | `network` | 7 | 502 | Yes | `NetworkError` |
-| `internal` | 8 | 500 | No | `InternalError`, `DerivationError`, `AssertionError` |
+| `internal` | 8 | 500 | No | `AssertionError`, `InternalError`, `DerivationError`, `RecoverableCompletionError` |
 | `auth` | 9 | 401 | No | `AuthError` |
 | `cancelled` | 130 | 499 | No | `CancelledError` |
 

--- a/plugin/skills/trails/references/error-taxonomy.md
+++ b/plugin/skills/trails/references/error-taxonomy.md
@@ -2,7 +2,7 @@
 
 ## Error Classes
 
-The taxonomy has 15 fixed-category classes across 10 categories, plus the
+The taxonomy has 16 fixed-category classes across 10 categories, plus the
 dynamic `RetryExhaustedError` wrapper.
 
 ### validation (exit 1, HTTP 400)
@@ -41,6 +41,7 @@ dynamic `RetryExhaustedError` wrapper.
 - **InternalError** — Unexpected failure. Catch-all for bugs. `new InternalError('unexpected null in pipeline')`
 - **DerivationError** — Framework or projection derivation failure. `new DerivationError('could not derive CLI fields from schema')`
 - **AssertionError** — Invariant violation. `new AssertionError('items array must not be empty after filter')`
+- **RecoverableCompletionError** — Internal completion failure used when recoverable runtime completion paths still need the shared internal category. `new RecoverableCompletionError('completion callback failed')`
 
 ### auth (exit 9, HTTP 401)
 


### PR DESCRIPTION
## Context

Trails package versions are now at `1.0.0-beta.17`, and the core error taxonomy registry includes `RecoverableCompletionError` as a fixed internal-category class. The Trails plugin skill guidance still taught beta.15 and counted only 15 fixed-category errors.

## Changes

- Update `plugin/skills/trails/SKILL.md` metadata to beta.17.
- Refresh Trails skill taxonomy summaries from 15 to 16 fixed-category classes.
- Add `RecoverableCompletionError` to the internal-category guidance in the skill reference docs.

## Validation

- `bun run vocab:audit`
- `bun run error-taxonomy:check`
- `bun run warden:skills:check`
- `bun run format:check`
- `bun run docs:snippets`

## Remaining noise

- `bun run docs:links` still fails on pre-existing draft ADR links to `.scratch/adr/wayfinding-and-signposts.md`; this PR does not touch those paths.
