### PR TITLE
chore: version packages to 1.0.0-beta.18

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -23,7 +23,8 @@
     "@ontrails/vite": "1.0.0-beta.14",
     "@ontrails/logtape": "1.0.0-beta.14",
     "@ontrails/commander": "1.0.0-beta.15",
-    "@ontrails/oxlint-plugin": "1.0.0-beta.15"
+    "@ontrails/oxlint-plugin": "1.0.0-beta.15",
+    "@ontrails/pino": "1.0.0-beta.17"
   },
   "changesets": [
     "adapter-workspace-root",
@@ -131,6 +132,16 @@
     "trl-699-warden-lock-v3-drift",
     "trl-700-trails-workspace-layout",
     "trl-701-workspace-index-topolock",
+    "trl-715-http-fetch-kernel",
+    "trl-716-http-bun",
+    "trl-718-http-observability-docs",
+    "trl-719-hono-fetch-kernel",
+    "trl-720-pino-package",
+    "trl-721-pino-sink",
+    "trl-722-pino-docs",
+    "trl-723-otel-attribute-mapping",
+    "trl-725-otel-buffering",
+    "trl-726-tracing-otel-docs",
     "type-utils-and-follow-rule",
     "unified-observability-adr",
     "vocabulary-cutover",

--- a/adapters/commander/CHANGELOG.md
+++ b/adapters/commander/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/commander
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- @ontrails/cli@1.0.0-beta.18
+- @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/adapters/commander/package.json
+++ b/adapters/commander/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/commander",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/drizzle/CHANGELOG.md
+++ b/adapters/drizzle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/drizzle
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.18
+- @ontrails/store@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/adapters/drizzle/package.json
+++ b/adapters/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/drizzle",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/hono/CHANGELOG.md
+++ b/adapters/hono/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @ontrails/hono
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- bc2d327: Close HTTP package documentation around the shared `@ontrails/http/fetch` kernel, Bun-native `@ontrails/http/bun` subpath, and Hono adapter boundary before versioning.
+- 20cb72c: Refactor Hono route handling to delegate Web request parsing, response
+  projection, diagnostics, permits, and webhook handling through
+  `@ontrails/http/fetch`.
+- Updated dependencies [c0b2948]
+- Updated dependencies [fc3219c]
+- Updated dependencies [bc2d327]
+  - @ontrails/http@1.0.0-beta.18
+  - @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/adapters/hono/package.json
+++ b/adapters/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/hono",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/vite/CHANGELOG.md
+++ b/adapters/vite/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/vite
 
+## 1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ## 1.0.0-beta.16

--- a/adapters/vite/package.json
+++ b/adapters/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/vite",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/apps/trails/CHANGELOG.md
+++ b/apps/trails/CHANGELOG.md
@@ -1,5 +1,27 @@
 # trails
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- Updated dependencies [c0b2948]
+- Updated dependencies [fc3219c]
+- Updated dependencies [bc2d327]
+- Updated dependencies [bf44972]
+- Updated dependencies [57c8672]
+- Updated dependencies [510ea50]
+- Updated dependencies [e0ae995]
+  - @ontrails/http@1.0.0-beta.18
+  - @ontrails/observe@1.0.0-beta.18
+  - @ontrails/tracing@1.0.0-beta.18
+  - @ontrails/commander@1.0.0-beta.18
+  - @ontrails/cli@1.0.0-beta.18
+  - @ontrails/core@1.0.0-beta.18
+  - @ontrails/mcp@1.0.0-beta.18
+  - @ontrails/permits@1.0.0-beta.18
+  - @ontrails/topographer@1.0.0-beta.18
+  - @ontrails/warden@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/trails",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "bin": {
     "trails": "./bin/trails.ts"
   },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/cli
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/cli",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/config
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/config",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/core
 
+## 1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/core",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @ontrails/http
 
+## 1.0.0-beta.18
+
+### Minor Changes
+
+- c0b2948: Add `@ontrails/http/fetch`, a shared Web Fetch request/response kernel for HTTP
+  surface materializers.
+- fc3219c: Add `@ontrails/http/bun`, a Bun-native HTTP surface materializer backed by the
+  shared Web Fetch kernel.
+
+### Patch Changes
+
+- bc2d327: Close HTTP package documentation around the shared `@ontrails/http/fetch` kernel, Bun-native `@ontrails/http/bun` subpath, and Hono adapter boundary before versioning.
+  - @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/http",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/logtape/CHANGELOG.md
+++ b/packages/logtape/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/logtape
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- Updated dependencies [bf44972]
+- Updated dependencies [e0ae995]
+  - @ontrails/observe@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/logtape/package.json
+++ b/packages/logtape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/logtape",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/mcp
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/mcp",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/observe/CHANGELOG.md
+++ b/packages/observe/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/observe
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- bf44972: Document Pino sink usage and publish-readiness checks.
+- e0ae995: Document the v1 `@ontrails/tracing/otel` OpenTelemetry adapter boundary, including callback export, stable `trails.*` attributes, flush behavior, and the absence of a standalone `@ontrails/otel` package.
+  - @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/observe/package.json
+++ b/packages/observe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/observe",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/oxlint-plugin/CHANGELOG.md
+++ b/packages/oxlint-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/oxlint-plugin
 
+## 1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ## 1.0.0-beta.16

--- a/packages/oxlint-plugin/package.json
+++ b/packages/oxlint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/oxlint-plugin",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/packages/permits/CHANGELOG.md
+++ b/packages/permits/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/permits
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/permits",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/pino/CHANGELOG.md
+++ b/packages/pino/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @ontrails/pino
 
+## 1.0.0-beta.18
+
+### Minor Changes
+
+- e504e67: Add the publishable `@ontrails/pino` package scaffold.
+- 1a65022: Implement the structural Pino log sink.
+
+### Patch Changes
+
+- bf44972: Document Pino sink usage and publish-readiness checks.
+- Updated dependencies [bf44972]
+- Updated dependencies [e0ae995]
+  - @ontrails/observe@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Minor Changes

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/pino",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/store/CHANGELOG.md
+++ b/packages/store/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/store
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/store",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @ontrails/testing
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- Updated dependencies [c0b2948]
+- Updated dependencies [fc3219c]
+- Updated dependencies [bc2d327]
+- Updated dependencies [bf44972]
+- Updated dependencies [e0ae995]
+  - @ontrails/http@1.0.0-beta.18
+  - @ontrails/observe@1.0.0-beta.18
+  - @ontrails/cli@1.0.0-beta.18
+  - @ontrails/core@1.0.0-beta.18
+  - @ontrails/mcp@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/testing",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/topographer/CHANGELOG.md
+++ b/packages/topographer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/topographer
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/topographer/package.json
+++ b/packages/topographer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/topographer",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "description": "Durable graph substrate for Trails: deterministic TopoGraphs, lockfile helpers, and semantic diffing.",
   "files": [
     "src/**/*.ts",

--- a/packages/tracing/CHANGELOG.md
+++ b/packages/tracing/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ontrails/tracing
 
+## 1.0.0-beta.18
+
+### Minor Changes
+
+- 57c8672: Complete the stable `trails.*` OpenTelemetry attribute mapping for trace identity, lineage, status, timing, signal lifecycle, and activation boundary records while filtering raw payload and unredacted error-message custom attributes.
+
+### Patch Changes
+
+- 510ea50: Harden the OTel adapter flush lifecycle by validating batch sizes, sharing concurrent flush drains, and preserving failed batches for retry without silent record loss.
+- e0ae995: Document the v1 `@ontrails/tracing/otel` OpenTelemetry adapter boundary, including callback export, stable `trails.*` attributes, flush behavior, and the absence of a standalone `@ontrails/otel` package.
+  - @ontrails/core@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/tracing",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/warden/CHANGELOG.md
+++ b/packages/warden/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ontrails/warden
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- @ontrails/cli@1.0.0-beta.18
+- @ontrails/core@1.0.0-beta.18
+- @ontrails/permits@1.0.0-beta.18
+- @ontrails/store@1.0.0-beta.18
+- @ontrails/topographer@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/warden",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "bin": {
     "warden": "./bin/warden.ts"
   },

--- a/packages/wayfinder/CHANGELOG.md
+++ b/packages/wayfinder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/wayfinder
 
+## 1.0.0-beta.18
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.18
+- @ontrails/topographer@1.0.0-beta.18
+
 ## 1.0.0-beta.17
 
 ### Patch Changes

--- a/packages/wayfinder/package.json
+++ b/packages/wayfinder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/wayfinder",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "description": "Agent-shaped wayfinding trails over @ontrails/topographer artifacts. v0 trails defined in the wayfinding draft ADR; package shell only — no trails ship yet.",
   "files": [
     "src/**/*.ts",

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -3,7 +3,7 @@ name: trails
 description: Build with the Trails framework — define trail contracts, open CLI/MCP surfaces, test with examples, debug errors, migrate codebases, run governance. Use when creating trails, adding surfaces, testing, debugging Trails errors, migrating to Trails, running warden, or any work involving @ontrails/* packages.
 metadata:
   trails:
-    version: 1.0.0-beta.15
+    version: 1.0.0-beta.18
 ---
 
 # Trails

--- a/scripts/__tests__/check-changeset-gate.test.ts
+++ b/scripts/__tests__/check-changeset-gate.test.ts
@@ -124,6 +124,58 @@ describe('checkChangesetGate', () => {
     }
   });
 
+  test('allows generated version release changes from changeset version', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkChangesetGate({
+        changedFiles: [
+          '.changeset/pre.json',
+          'packages/core/CHANGELOG.md',
+          'packages/core/package.json',
+          'packages/http/CHANGELOG.md',
+          'packages/http/package.json',
+        ],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.versionRelease).toBe(true);
+      expect(result.affectedPackages).toEqual([
+        '@ontrails/core',
+        '@ontrails/http',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('does not treat prerelease state plus source edits as a generated version release', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkChangesetGate({
+        changedFiles: [
+          '.changeset/pre.json',
+          'packages/core/CHANGELOG.md',
+          'packages/core/package.json',
+          'packages/core/src/index.ts',
+        ],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.versionRelease).toBe(false);
+      expect(result.errors).toEqual([
+        'Package-affecting changes need changeset entries for: @ontrails/core',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
   test('ignores non-shipping package test artifacts and private workspaces', () => {
     const { repoRoot } = withTempRepo(() => {});
 

--- a/scripts/check-changeset-gate.ts
+++ b/scripts/check-changeset-gate.ts
@@ -28,6 +28,7 @@ export interface ChangesetGateResult {
   readonly errors: readonly string[];
   readonly passed: boolean;
   readonly releaseNone: boolean;
+  readonly versionRelease: boolean;
 }
 
 interface CliOptions {
@@ -50,7 +51,12 @@ const NON_SHIPPING_PACKAGE_PATTERNS = [
 const CHANGESET_PATH_PATTERN = /^\.changeset\/[^/]+\.md$/u;
 const CHANGESET_PACKAGE_PATTERN =
   /^['"]?(@ontrails\/[^'":]+)['"]?\s*:\s*(?:major|minor|patch)$/u;
+const CHANGESET_PRERELEASE_STATE_PATH = '.changeset/pre.json';
 const WORKSPACE_GLOB_SYNTAX_PATTERN = /[*?[\]{}]/u;
+const VERSION_RELEASE_WORKSPACE_FILES = new Set([
+  'CHANGELOG.md',
+  'package.json',
+]);
 
 const normalizePath = (path: string): string =>
   path.replaceAll('\\', '/').replace(/^\.\//u, '');
@@ -191,6 +197,47 @@ const findAffectedPackages = (
   return [...affected].toSorted();
 };
 
+const isVersionReleaseChangeSet = (
+  changedFiles: readonly string[],
+  workspaces: readonly WorkspaceInfo[]
+): boolean => {
+  const normalizedFiles = changedFiles.map(normalizePath);
+
+  if (!normalizedFiles.includes(CHANGESET_PRERELEASE_STATE_PATH)) {
+    return false;
+  }
+
+  const publishableWorkspaces = workspaces.filter(
+    isPublishableOnTrailsWorkspace
+  );
+  let hasWorkspaceVersionFile = false;
+
+  for (const file of normalizedFiles) {
+    for (const workspace of publishableWorkspaces) {
+      if (!isUnderWorkspace(file, workspace.relativePath)) {
+        continue;
+      }
+
+      const workspaceRelativePath = getWorkspaceRelativePath(
+        file,
+        workspace.relativePath
+      );
+
+      if (isNonShippingPackagePath(workspaceRelativePath)) {
+        continue;
+      }
+
+      if (!VERSION_RELEASE_WORKSPACE_FILES.has(workspaceRelativePath)) {
+        return false;
+      }
+
+      hasWorkspaceVersionFile = true;
+    }
+  }
+
+  return hasWorkspaceVersionFile;
+};
+
 const parseChangesetPackages = (content: string): readonly string[] => {
   const lines = content.split(/\r?\n/u);
 
@@ -249,6 +296,10 @@ export const checkChangesetGate = (
   const coveredPackages = [
     ...new Set(changesets.flatMap((changeset) => changeset.packages)),
   ].toSorted();
+  const versionRelease = isVersionReleaseChangeSet(
+    input.changedFiles,
+    input.workspaces
+  );
   const uncoveredPackages = affectedPackages.filter(
     (packageName) => !coveredPackages.includes(packageName)
   );
@@ -260,7 +311,7 @@ export const checkChangesetGate = (
     );
   }
 
-  if (!releaseNone && uncoveredPackages.length > 0) {
+  if (!releaseNone && !versionRelease && uncoveredPackages.length > 0) {
     errors.push(
       `Package-affecting changes need changeset entries for: ${uncoveredPackages.join(', ')}`
     );
@@ -273,6 +324,7 @@ export const checkChangesetGate = (
     errors,
     passed: errors.length === 0,
     releaseNone,
+    versionRelease,
   };
 };
 
@@ -372,6 +424,13 @@ const renderResult = (result: ChangesetGateResult): void => {
     if (result.releaseNone) {
       console.log(
         `Changeset gate passed via release:none for: ${result.affectedPackages.join(', ')}`
+      );
+      return;
+    }
+
+    if (result.versionRelease) {
+      console.log(
+        `Changeset gate passed for generated version release: ${result.affectedPackages.join(', ')}`
       );
       return;
     }


### PR DESCRIPTION
## Context

Final beta release candidate before stable cutover planning resumes. This consumes the pending HTTP/Bun surface, Hono fetch-kernel, Pino, and OTel hardening changesets into the lockstep prerelease line.

## What changed

- Versioned public `@ontrails/*` packages to `1.0.0-beta.18`.
- Updated changelogs from the pending changesets.
- Added `@ontrails/pino` to prerelease tracking.
- Updated repo-owned Trails plugin skill metadata to `1.0.0-beta.18`.
- Taught the changeset CI gate to recognize generated `changeset version` PRs: `.changeset/pre.json` plus package `package.json`/`CHANGELOG.md` changes only.

## Validation

- `bun run warden:skills:check`
- `bun run format:check`
- `git diff --check`
- `bun test scripts/__tests__/check-changeset-gate.test.ts`
- `bun run changeset:check`
- `bun run publish:check`
- `bun run check`
- `bun run build`

## Release notes

- Publish with `bun run publish:packages` after this PR lands on `main`.
- Post-publish verification should run `bun run publish:registry-check:published`.
- This is not the stable cutover; it keeps the package line in prerelease mode on the `beta` dist-tag.
