### PR TITLE
feat(trails): settle top-level compile and validate commands

### DIFF
--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
@@ -174,6 +174,8 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 | `bun apps/trails/bin/trails.ts --help` | TRL-729 | passed | Shows top-level `compile` and `validate`; no `topo compile`/`topo verify` commands. |
 | `bun apps/trails/bin/trails.ts compile --help` | TRL-729 | passed | Top-level compile command renders expected help. |
 | `bun apps/trails/bin/trails.ts validate --help` | TRL-729 | passed | Top-level validate command renders expected help. |
+| `bun run format:check` | TRL-729 | passed | Initial check found two files; `bun run format:fix` applied mechanical cleanup, rerun passed. |
+| `git diff --check` | TRL-729 | passed | No whitespace errors. |
 | `bun run --cwd packages/core test` | TRL-113 | passed | 1116 tests, 0 failures. |
 | `bun run --cwd packages/topographer test` | TRL-113 | passed | 122 tests, 0 failures. |
 | `bun run typecheck` | TRL-113 | passed | 22 package tasks successful. |

--- a/.changeset/trail-cli-namespace.md
+++ b/.changeset/trail-cli-namespace.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/trails": major
+"@ontrails/topographer": minor
+"@ontrails/warden": minor
+---
+
+Promote topo artifact commands to `trails compile` and `trails validate`.

--- a/apps/trails-demo/README.md
+++ b/apps/trails-demo/README.md
@@ -244,7 +244,7 @@ trails survey trail --module ./src/app.ts entity.show
 trails topo history --root-dir .
 
 # Compile the committed lock artifacts
-trails topo compile --module ./src/app.ts
+trails compile --module ./src/app.ts
 
 # Get the broader machine-readable report
 trails survey --module ./src/app.ts
@@ -252,7 +252,10 @@ trails survey brief --module ./src/app.ts
 trails survey diff --module ./src/app.ts
 ```
 
-Use `trails topo *` for the day-to-day operational flow: inspect the current topo, pin meaningful points, and compile or verify the committed lock artifacts. `survey` remains the broader introspection surface for list, detail, and diff output.
+Use `trails topo *` for topo history and pin management. Use `trails compile`
+to write committed lock artifacts and `trails validate` in CI to check them.
+`survey` remains the broader introspection surface for list, detail, and diff
+output.
 
 ## Signals
 

--- a/apps/trails/README.md
+++ b/apps/trails/README.md
@@ -14,7 +14,9 @@ Common workflows:
 - `trails create` starts a new Trails project with generated trail, topo, surface,
   and verification files.
 - `trails add surface` adds another surface entrypoint to an existing project.
-- `trails topo` inspects, exports, verifies, pins, and unpins topo state.
+- `trails topo` inspects topo state and manages pins/history.
+- `trails compile` writes committed topo artifacts.
+- `trails validate` checks committed topo artifacts for drift.
 - `trails warden` runs Trails governance checks for contract and architecture
   drift.
 - `trails guide` shows available trails and examples from a project.

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -57,7 +57,7 @@ import {
   surfaceProjectionOutput,
   trailDetailOutput,
 } from '../trails/topo-output-schemas.js';
-import { topoCompileTrail } from '../trails/topo-compile.js';
+import { compileTrail } from '../trails/compile.js';
 import type {
   BriefReport,
   ShippedSurfaceInventoryReport,
@@ -1297,7 +1297,7 @@ describe('trails survey signals section', () => {
   });
 });
 
-describe('trails topo compile', () => {
+describe('trails compile', () => {
   test('writes the structured topo artifacts', async () => {
     const dir = repoTempDir();
 
@@ -1305,7 +1305,7 @@ describe('trails topo compile', () => {
       writeSurveyAppFixture(dir);
 
       const compiled = expectOk(
-        await topoCompileTrail.blaze({ module: './src/app.ts' }, {
+        await compileTrail.blaze({ module: './src/app.ts' }, {
           cwd: dir,
         } as never)
       ) as {
@@ -1325,7 +1325,7 @@ describe('trails topo compile', () => {
         artifacts: [{ path: 'topo.lock', role: 'topo', sha256: compiled.hash }],
         version: 3,
       });
-      expect(topoCompileTrail.output.safeParse(compiled).success).toBe(true);
+      expect(compileTrail.output.safeParse(compiled).success).toBe(true);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
@@ -1357,7 +1357,7 @@ describe('trails survey diff', () => {
       } as never);
 
       expect(result.isErr()).toBe(true);
-      expect(result.error.message).toContain('Run `trails topo compile` first');
+      expect(result.error.message).toContain('Run `trails compile` first');
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
@@ -1608,7 +1608,7 @@ describe('trails survey output schema', () => {
       }).success
     ).toBe(true);
     expect(
-      topoCompileTrail.output.safeParse({
+      compileTrail.output.safeParse({
         hash: 'a'.repeat(64),
         lockPath: '.trails/trails.lock',
         snapshot: {

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -23,12 +23,12 @@ import {
   surveyTrail,
   surveyTrailDetailTrail,
 } from '../trails/survey.js';
-import { topoCompileTrail } from '../trails/topo-compile.js';
+import { compileTrail } from '../trails/compile.js';
 import { topoHistoryTrail } from '../trails/topo-history.js';
 import { topoPinTrail } from '../trails/topo-pin.js';
 import { topoTrail } from '../trails/topo.js';
 import { topoUnpinTrail } from '../trails/topo-unpin.js';
-import { topoVerifyTrail } from '../trails/topo-verify.js';
+import { validateTrail } from '../trails/validate.js';
 
 const repoTempDir = (): string =>
   join(
@@ -151,7 +151,7 @@ describe('topo and dev trails', () => {
       );
 
       const compileResult = expectOk(
-        await topoCompileTrail.blaze(moduleInput, { cwd: dir } as never)
+        await compileTrail.blaze(moduleInput, { cwd: dir } as never)
       );
       const snapshotCountAfterExport = countTopoSnapshots(dir);
       expect(compileResult.hash).toHaveLength(64);
@@ -172,7 +172,7 @@ describe('topo and dev trails', () => {
       expect(summaryAfterExport.lockExists).toBe(true);
 
       const verifyResult = expectOk(
-        await topoVerifyTrail.blaze(moduleInput, { cwd: dir } as never)
+        await validateTrail.blaze(moduleInput, { cwd: dir } as never)
       );
       expect(verifyResult.stale).toBe(false);
       expect(countTopoSnapshots(dir)).toBe(snapshotCountAfterExport);
@@ -200,7 +200,7 @@ describe('topo and dev trails', () => {
         )}\n`
       );
       const wrongArtifactError = expectErr(
-        await topoVerifyTrail.blaze(moduleInput, { cwd: dir } as never)
+        await validateTrail.blaze(moduleInput, { cwd: dir } as never)
       );
       expect(wrongArtifactError.message).toContain('topo.lock artifact');
 
@@ -219,7 +219,7 @@ describe('topo and dev trails', () => {
       );
 
       const driftError = expectErr(
-        await topoVerifyTrail.blaze(moduleInput, { cwd: dir } as never)
+        await validateTrail.blaze(moduleInput, { cwd: dir } as never)
       );
       expect(driftError.message).toContain('trails.lock is stale');
       expect(countTopoSnapshots(dir)).toBe(snapshotCountAfterExport);
@@ -229,11 +229,9 @@ describe('topo and dev trails', () => {
         `${JSON.stringify({ hash: '1'.repeat(64), version: 2 }, null, 2)}\n`
       );
       const verifyError = expectErr(
-        await topoVerifyTrail.blaze(moduleInput, { cwd: dir } as never)
+        await validateTrail.blaze(moduleInput, { cwd: dir } as never)
       );
-      expect(verifyError.message).toContain(
-        'regenerate with `trails topo compile`'
-      );
+      expect(verifyError.message).toContain('regenerate with `trails compile`');
       expect(countTopoSnapshots(dir)).toBe(snapshotCountAfterExport);
     } finally {
       rmSync(dir, { force: true, recursive: true });
@@ -351,10 +349,10 @@ describe('topo and dev trails', () => {
       expect(firstPin.snapshot.pinnedAs).toBe('before-auth');
 
       const firstCompile = expectOk(
-        await topoCompileTrail.blaze(moduleInput, { cwd: dir } as never)
+        await compileTrail.blaze(moduleInput, { cwd: dir } as never)
       );
       const secondCompile = expectOk(
-        await topoCompileTrail.blaze(moduleInput, { cwd: dir } as never)
+        await compileTrail.blaze(moduleInput, { cwd: dir } as never)
       );
       expect(firstCompile.hash).toBe(secondCompile.hash);
       expect(

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -3,6 +3,7 @@ import { topo } from '@ontrails/core';
 import * as addSurface from './trails/add-surface.js';
 import * as addTrail from './trails/add-trail.js';
 import * as addVerify from './trails/add-verify.js';
+import * as compile from './trails/compile.js';
 import * as completions from './trails/completions.js';
 import * as completionsComplete from './trails/completions-complete.js';
 import * as create from './trails/create.js';
@@ -16,12 +17,11 @@ import * as run from './trails/run.js';
 import * as runExample from './trails/run-example.js';
 import * as runExamples from './trails/run-examples.js';
 import * as survey from './trails/survey.js';
-import * as topoCompile from './trails/topo-compile.js';
 import * as topoHistory from './trails/topo-history.js';
 import * as topoPin from './trails/topo-pin.js';
 import * as topoCommand from './trails/topo.js';
 import * as topoUnpin from './trails/topo-unpin.js';
-import * as topoVerify from './trails/topo-verify.js';
+import * as validate from './trails/validate.js';
 import * as warden from './trails/warden.js';
 import * as wardenGuide from './trails/warden-guide.js';
 
@@ -32,11 +32,11 @@ export const app = topo(
   runExample,
   survey,
   topoCommand,
-  topoCompile,
+  compile,
   topoHistory,
   topoPin,
   topoUnpin,
-  topoVerify,
+  validate,
   devStats,
   devClean,
   devReset,

--- a/apps/trails/src/trails/compile.ts
+++ b/apps/trails/src/trails/compile.ts
@@ -16,7 +16,7 @@ export const compileCurrentTopo = async (
   options?: { readonly rootDir?: string }
 ): Promise<Result<TopoExportReport, Error>> => exportCurrentTopo(app, options);
 
-export const topoCompileTrail = trail('topo.compile', {
+export const compileTrail = trail('compile', {
   blaze: async (input, ctx) => {
     const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
     if (rootDirResult.isErr()) {
@@ -37,7 +37,7 @@ export const topoCompileTrail = trail('topo.compile', {
   description: 'Compile the current topo to .trails artifacts',
   examples: [
     {
-      input: createIsolatedExampleInput('topo-compile'),
+      input: createIsolatedExampleInput('compile'),
       name: 'Compile the current topo artifacts',
     },
   ],

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -191,7 +191,7 @@ const readAgainstTopoGraph = async (
     return map === null
       ? Result.err(
           new NotFoundError(
-            'No saved TopoGraph found. Run `trails topo compile` first.'
+            'No saved TopoGraph found. Run `trails compile` first.'
           )
         )
       : Result.ok({ against: 'saved', map });

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -36,7 +36,7 @@ import {
 } from './topo-reports.js';
 import type { ActivationGraphReport } from './topo-activation.js';
 import { deriveActivationGraph } from './topo-activation.js';
-import type { TopoSummaryReport, TopoVerifyReport } from './topo-support.js';
+import type { TopoSummaryReport, TopoValidateReport } from './topo-support.js';
 import { deriveRootDir, LOCK_PATH } from './topo-support.js';
 import { deriveCurrentTopoExport } from './topo-store-support.js';
 
@@ -209,10 +209,10 @@ export const buildCurrentTopoMatches = (
   return matches;
 };
 
-export const verifyCurrentTopo = async (
+export const validateCurrentTopo = async (
   app: Topo,
   options?: { readonly rootDir?: string }
-): Promise<Result<TopoVerifyReport, Error>> => {
+): Promise<Result<TopoValidateReport, Error>> => {
   const rootDir = deriveRootDir(options?.rootDir);
   let lockManifest: Awaited<ReturnType<typeof readLockManifest>>;
   try {
@@ -234,7 +234,7 @@ export const verifyCurrentTopo = async (
   if (lockManifest === null) {
     return Result.err(
       new NotFoundError(
-        'No committed trails.lock found. Run `trails topo compile` first.'
+        'No committed trails.lock found. Run `trails compile` first.'
       )
     );
   }
@@ -250,7 +250,7 @@ export const verifyCurrentTopo = async (
   if (topoArtifact === undefined) {
     return Result.err(
       new NotFoundError(
-        'No topo.lock artifact found in trails.lock. Run `trails topo compile` first.'
+        'No topo.lock artifact found in trails.lock. Run `trails compile` first.'
       )
     );
   }
@@ -258,7 +258,7 @@ export const verifyCurrentTopo = async (
   if (topoArtifact.sha256 !== currentHash) {
     return Result.err(
       new ConflictError(
-        'trails.lock is stale. Run `trails topo compile` to refresh it.'
+        'trails.lock is stale. Run `trails compile` to refresh it.'
       )
     );
   }

--- a/apps/trails/src/trails/topo-support.ts
+++ b/apps/trails/src/trails/topo-support.ts
@@ -62,7 +62,7 @@ export interface TopoExportReport {
   readonly topoPath: string;
 }
 
-export interface TopoVerifyReport {
+export interface TopoValidateReport {
   readonly committedHash: string;
   readonly currentHash: string;
   readonly lockPath: string;

--- a/apps/trails/src/trails/validate.ts
+++ b/apps/trails/src/trails/validate.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 
 import { tryLoadFreshAppLease } from './load-app.js';
 import { resolveTrailRootDir } from './root-dir.js';
-import { verifyCurrentTopo } from './topo-read-support.js';
+import { validateCurrentTopo } from './topo-read-support.js';
 
-export const topoVerifyTrail = trail('topo.verify', {
+export const validateTrail = trail('validate', {
   blaze: async (input, ctx) => {
     const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
     if (rootDirResult.isErr()) {
@@ -18,12 +18,12 @@ export const topoVerifyTrail = trail('topo.verify', {
     }
     const lease = leaseResult.value;
     try {
-      return await verifyCurrentTopo(lease.app, { rootDir });
+      return await validateCurrentTopo(lease.app, { rootDir });
     } finally {
       lease.release();
     }
   },
-  description: 'Verify that the committed lockfile matches the current topo',
+  description: 'Validate that committed topo artifacts match the current topo',
   input: z.object({
     module: z.string().optional().describe('Path to the app module'),
     rootDir: z.string().optional().describe('Workspace root directory'),

--- a/docs/adr/0014-core-database-primitive.md
+++ b/docs/adr/0014-core-database-primitive.md
@@ -119,7 +119,7 @@ Developers create **pins** to keep and name important topo states (setting `pinn
 ```bash
 trails topo pin "before auth refactor"
 trails topo history
-trails topo diff --since "before auth refactor"
+trails survey diff --against "before auth refactor"
 ```
 
 Pins are durable names on topo snapshots. They are not a second storage primitive. They are a retention and discovery affordance on top of autosaved topo history.
@@ -147,10 +147,10 @@ In production, the framework operates exactly as it does today: in-memory topo, 
 trails topo                         # Show the current topo summary
 trails topo history                 # List pins and recent autosaves
 trails topo pin "name"              # Pin the current topo snapshot
-trails topo diff --since "name"     # Structural diff since a pin or prior snapshot
+trails survey diff --against "name" # Structural diff since a pin or prior snapshot
 trails topo unpin "name"            # Remove a pin but keep the underlying snapshot eligible for pruning
-trails topo compile                 # Write .trails/trails.lock and .trails/topo.lock
-trails topo verify                  # Verify committed topo artifacts reflect the current topo
+trails compile                      # Write .trails/trails.lock and .trails/topo.lock
+trails validate                     # Verify committed topo artifacts reflect the current topo
 
 # Developer maintenance
 trails dev stats                    # Table sizes, row counts, file size, and retention overview

--- a/docs/adr/0015-topo-store.md
+++ b/docs/adr/0015-topo-store.md
@@ -282,16 +282,16 @@ FROM topo_crossings WHERE snapshot_id = :previous
 EXCEPT SELECT source_id, target_id, 'removed' FROM topo_crossings WHERE snapshot_id = :current;
 ```
 
-This is the `trails topo diff` concept made continuous. The lockfile captures the latest state as a text file for git. The topo store captures snapshot history and pins for queryable analysis.
+This is the `trails survey diff` concept made continuous. The lockfile captures the latest state as a text file for git. The topo store captures snapshot history and pins for queryable analysis.
 
 ### Lockfile as an export
 
 The lockfile (`.trails/trails.lock`) becomes a deterministic text export of the current topo state:
 
 ```bash
-trails topo compile         # Write .trails/trails.lock from the current topo
-trails topo diff --lock     # Compare current topo against .trails/trails.lock
-trails topo verify          # CI: fail if .trails/trails.lock is stale
+trails compile                      # Write .trails/trails.lock from the current topo
+trails survey diff --against saved  # Compare current topo against .trails/trails.lock
+trails validate                     # CI: fail if .trails/trails.lock is stale
 ```
 
 The topo store is the queryable source of truth. The lockfile is its text projection for git diffing. The database generates the lockfile, not the other way around.

--- a/docs/adr/0017-serialized-topo-graph.md
+++ b/docs/adr/0017-serialized-topo-graph.md
@@ -108,18 +108,18 @@ This means:
 ### Generation and lifecycle
 
 ```bash
-trails topo compile          # write .trails/trails.lock from current topo
-trails topo verify           # verify .trails/trails.lock matches current topo (CI mode)
-trails topo diff --lock      # show lockfile drift against current topo
+trails compile                      # write .trails/trails.lock from current topo
+trails validate                     # verify .trails/trails.lock matches current topo (CI mode)
+trails survey diff --against saved  # show lockfile drift against current topo
 ```
 
-`trails topo compile` replaces the old lock-focused command shape. The command now centers on the resolved topo artifacts rather than on only the lockfile. `trails topo export` remains a legacy alias for compile. `verify` is the CI layer. `diff --lock` is the developer feedback loop.
+`trails compile` replaces the old lock-focused command shape. The command now centers on the resolved topo artifacts rather than on only the lockfile. `trails validate` is the CI layer. `trails survey diff --against saved` is the developer feedback loop.
 
 The lockfile is:
 
-- **Generated** by `trails topo compile` from the current code. In manual workflows this is explicit, like `bun install` generating `bun.lock`. Signal-driven flows can invoke the same trail automatically from topo snapshots or pins.
+- **Generated** by `trails compile` from the current code. In manual workflows this is explicit, like `bun install` generating `bun.lock`. Signal-driven flows can invoke the same trail automatically from topo snapshots or pins.
 - **Checked in** to source control. A PR that changes trail contracts produces a lockfile diff.
-- **CI-diffable.** `trails topo verify` fails if the lockfile doesn't match the current code. Drift between code and lockfile is caught before merge.
+- **CI-diffable.** `trails validate` fails if the lockfile doesn't match the current code. Drift between code and lockfile is caught before merge.
 - **The saved record of resolved state.** Not a cache, not a convenience. A commitment: "this is the resolved state of the system at this point in time."
 
 Development commands (`trails run`, `trails guide`) should degrade gracefully without a lockfile in single-app projects by falling back to direct topo loading. In multi-app workspaces, the lockfile is required for cross-app trail ID resolution.
@@ -159,7 +159,7 @@ webhook:stripe → booking.confirm → booking.confirmed → notify.booking-conf
 ### Positive
 
 - **One file to commit.** A PR that changes trail schemas, adds activation sources, updates resources, and modifies config produces one lockfile diff.
-- **One CI check.** `trails topo verify` validates everything.
+- **One CI check.** `trails validate` validates everything.
 - **Agent-readable.** An agent reads the lockfile to understand the entire system without source code. The contract is queryable.
 - **Graph-native.** Cross-cutting queries (orphan signals, unreachable trails, activation cycles) are natural graph traversals.
 - **Multi-app resolution.** Trail IDs resolve workspace-wide. `trails run` and `trails guide` work across apps without specifying which app owns a trail.
@@ -168,13 +168,13 @@ webhook:stripe → booking.confirm → booking.confirmed → notify.booking-conf
 ### Tradeoffs
 
 - **Larger file over time.** As the topo grows, the lockfile grows. For most projects this is manageable. For very large workspaces, the graph structure helps: changes to one trail only affect that trail's node and its edges.
-- **Requires topo compile to stay current.** A stale lockfile means stale resolution. `trails topo verify` in CI catches this, but a manual workflow must still compile after contract changes unless a save- or pin-driven automation does it.
+- **Requires compile to stay current.** A stale lockfile means stale resolution. `trails validate` in CI catches this, but a manual workflow must still compile after contract changes unless a save- or pin-driven automation does it.
 - **Graph format is more complex than flat sections.** A section-per-concern format is simpler to understand at first glance. The graph format is more powerful but requires understanding the node/edge model. The tradeoff favors power: the lockfile is primarily machine-read (by agents, CI, framework commands), not human-read.
 
 ### What this does NOT decide
 
 - **The exact schema for each node type.** Trail nodes, signal nodes, and resource nodes will gain properties as their respective ADRs ship. The graph structure is stable; the node schemas evolve.
-- **Whether sections can be independently regenerated** (e.g., `trails topo compile --only surfaces`). Future ergonomic improvement if needed.
+- **Whether sections can be independently regenerated** (e.g., `trails compile --only surfaces`). Future ergonomic improvement if needed.
 - **Whether the format is JSON, JSONC, or another structured format.** JSON is the default for machine-generated artifacts. If comments become valuable, JSONC is a backward-compatible extension.
 - **Resource contract snapshots.** How provisioned packs record their contract state in the lockfile. The resources ADR defines this.
 - **Rig lock state.** How rigged external surfaces record their resolved state. The rig ADR defines this.

--- a/docs/adr/0019-hierarchical-command-trees-from-trail-ids.md
+++ b/docs/adr/0019-hierarchical-command-trees-from-trail-ids.md
@@ -60,7 +60,7 @@ That means `topo` and `topo pin` can coexist naturally.
 ```text
 trails topo
 trails topo pin --name before-auth
-trails topo verify
+trails topo history
 ```
 
 This is not a special case. It falls out of the path model directly.

--- a/docs/adr/0046-lock-v3-artifact-family.md
+++ b/docs/adr/0046-lock-v3-artifact-family.md
@@ -140,7 +140,7 @@ Workspace ownership is a projection over the graph, not an ordinary
 
 Lock v3 is the v1 target. Legacy v2 hash envelopes and hash-only files are not
 silently upgraded or interpreted as valid v3 manifests. Readers should fail
-loudly with an instruction to regenerate with `trails topo compile`.
+loudly with an instruction to regenerate with `trails compile`.
 
 ## Consequences
 

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -293,7 +293,7 @@ between the current resolved graph and a previous known-good state.
 
 ```bash
 trails topo pin --name v1.0
-trails topo verify
+trails validate
 ```
 
 Carries intent that "snapshot" doesn't — "this state is my reference point."

--- a/docs/migration/topograph-artifact-family.md
+++ b/docs/migration/topograph-artifact-family.md
@@ -14,13 +14,13 @@ content artifact:
 Regenerate the current artifact family with:
 
 ```bash
-trails topo compile
+trails compile
 ```
 
-Verify committed artifacts with:
+Validate committed artifacts with:
 
 ```bash
-trails topo verify
+trails validate
 ```
 
 ## Rename Map

--- a/docs/migration/trailhead-to-surface.md
+++ b/docs/migration/trailhead-to-surface.md
@@ -32,7 +32,9 @@ The framework now consistently uses `surface` for CLI, MCP, HTTP, and WebSocket 
 | `MapTransportError` | `typeof mapSurfaceError` | Use the canonical function type. |
 | `AuthCredentials` | `PermitExtractionInput` | Import `PermitExtractionInput` from `@ontrails/permits`. |
 | `isVisibleToTrailheads` | `isVisibleToSurfaces` | Update internal callers if you imported non-public helpers. |
-| `topo.export` / `topoExportTrail` | `topo.compile` | Call `topo.compile` for topo artifact generation. |
+| `topo.export` / `topoExportTrail` | `compile` | Call `compile` for topo artifact generation. |
+| `topo.compile` / `topoCompileTrail` | `compile` | Trail ID and export were renamed; update any programmatic lookups. |
+| `topo.verify` / `topoVerifyTrail` | `validate` | Trail ID and export were renamed; update any programmatic lookups. |
 
 ## Code Imports
 
@@ -140,21 +142,22 @@ surface-map artifacts used the same field after the trailhead cutover:
 Regenerate TopoGraph artifacts after upgrading. For the Trails app, use:
 
 ```bash
-trails topo compile
+trails compile
 ```
 
 Update any direct JSON consumers, fixtures, or snapshot assertions that read `entry.trailheads`.
 
-## Topo Compile
+## Compile
 
-The legacy `topo.export` trail has been removed. Use `topo.compile` for current topo artifacts:
+The legacy `topo.export` trail has been removed. Use `compile` for current topo
+artifacts:
 
 ```diff
 -trails topo export
-+trails topo compile
++trails compile
 ```
 
-Any programmatic lookup for `topo.export` should move to `topo.compile`.
+Any programmatic lookup for `topo.export` should move to `compile`.
 
 ## Warden And Comments
 

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -96,22 +96,22 @@ List saved topo states (pinned and recent autosaves).
 trails topo history --limit 20
 ```
 
-### `trails topo compile`
+### `trails compile`
 
 Compile the current topo to `.trails/topo.lock` and `.trails/trails.lock`.
 
 ```bash
-trails topo compile
+trails compile
 ```
 
-### `trails topo verify`
+### `trails validate`
 
 Check that the `.trails/trails.lock` / `.trails/topo.lock` artifact family
 matches your current topo. Fails if either committed artifact has drifted.
 
 ```bash
 # In CI
-trails topo verify || exit 1
+trails validate || exit 1
 ```
 
 ## Workflows
@@ -119,16 +119,16 @@ trails topo verify || exit 1
 ### Pre-deployment
 
 1. Make topology changes
-2. Compile: `trails topo compile`
+2. Compile: `trails compile`
 3. Commit `.trails/trails.lock` and `.trails/topo.lock`
-4. In CI, verify: `trails topo verify`
+4. In CI, validate: `trails validate`
 
 ### Pin before refactoring
 
 ```bash
 trails topo pin --name pre-refactor
 # ... make changes ...
-trails topo compile
+trails compile
 # Compare lockfile diff against the pinned baseline
 ```
 

--- a/packages/topographer/README.md
+++ b/packages/topographer/README.md
@@ -2,7 +2,9 @@
 
 Durable graph substrate for Trails: deterministic TopoGraphs, lockfile helpers, and semantic diffing.
 
-Most applications reach this package through `trails topo compile` and `trails topo verify`. Those CLI trails layer workspace and topo-store behavior on top of the building blocks in `@ontrails/topographer`.
+Most applications reach this package through `trails compile` and
+`trails validate`. Those CLI trails layer workspace and topo-store behavior on
+top of the building blocks in `@ontrails/topographer`.
 
 ## What it owns
 
@@ -58,7 +60,8 @@ The typical exported artifact pair is:
 - `.trails/topo.lock` — serialized TopoGraph, useful for inspection and diffing
 - `.trails/trails.lock` — compact v3 manifest that verifies the TopoGraph by hash
 
-`trails topo compile` writes both from the current topo. `trails topo verify` and `@ontrails/warden` use the lockfile helpers here to detect drift.
+`trails compile` writes both from the current topo. `trails validate` and
+`@ontrails/warden` use the lockfile helpers here to detect drift.
 
 ## API
 

--- a/packages/topographer/src/__tests__/io.test.ts
+++ b/packages/topographer/src/__tests__/io.test.ts
@@ -121,7 +121,7 @@ describe('writeTopoGraph / readTopoGraph', () => {
     );
 
     await expect(readTopoGraph({ dir: tempDir })).rejects.toThrow(
-      'regenerate with `trails topo compile`'
+      'regenerate with `trails compile`'
     );
   });
 
@@ -136,7 +136,7 @@ describe('writeTopoGraph / readTopoGraph', () => {
     );
 
     await expect(readTopoGraph({ dir: tempDir })).rejects.toThrow(
-      'regenerate with `trails topo compile`'
+      'regenerate with `trails compile`'
     );
   });
 });
@@ -190,7 +190,7 @@ describe('writeLockManifest / readLockManifest', () => {
     );
 
     await expect(readLockManifest({ dir: tempDir })).rejects.toThrow(
-      'regenerate with `trails topo compile`'
+      'regenerate with `trails compile`'
     );
   });
 
@@ -206,7 +206,7 @@ describe('writeLockManifest / readLockManifest', () => {
     );
 
     await expect(readLockManifest({ dir: tempDir })).rejects.toThrow(
-      'regenerate with `trails topo compile`'
+      'regenerate with `trails compile`'
     );
   });
 
@@ -232,7 +232,7 @@ describe('writeLockManifest / readLockManifest', () => {
     );
 
     await expect(readLockManifest({ dir: tempDir })).rejects.toThrow(
-      'regenerate with `trails topo compile`'
+      'regenerate with `trails compile`'
     );
   });
 
@@ -243,7 +243,7 @@ describe('writeLockManifest / readLockManifest', () => {
     );
 
     await expect(readLockManifest({ dir: tempDir })).rejects.toThrow(
-      'regenerate with `trails topo compile`'
+      'regenerate with `trails compile`'
     );
   });
 
@@ -251,7 +251,7 @@ describe('writeLockManifest / readLockManifest', () => {
     await Bun.write(join(tempDir, 'trails.lock'), `${'a'.repeat(64)}\n`);
 
     await expect(readLockManifest({ dir: tempDir })).rejects.toThrow(
-      'regenerate with `trails topo compile`'
+      'regenerate with `trails compile`'
     );
   });
 

--- a/packages/topographer/src/io.ts
+++ b/packages/topographer/src/io.ts
@@ -23,9 +23,9 @@ const DEFAULT_DIR = '.trails';
 const LOCK_MANIFEST_FILE = 'trails.lock';
 const TOPO_GRAPH_FILE = 'topo.lock';
 const REGENERATE_LOCK_MESSAGE =
-  'Unsupported trails.lock format; regenerate with `trails topo compile`.';
+  'Unsupported trails.lock format; regenerate with `trails compile`.';
 const REGENERATE_TOPO_GRAPH_MESSAGE =
-  'Unsupported topo.lock format; regenerate with `trails topo compile`.';
+  'Unsupported topo.lock format; regenerate with `trails compile`.';
 
 export const isTopoArtifactRegenerationError = (
   error: unknown

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -57,7 +57,7 @@ import { checkDrift } from '@ontrails/warden';
 
 const drift = await checkDrift(process.cwd(), graph);
 if (drift.stale) {
-  console.log('lock file is stale -- regenerate with `trails topo compile`');
+  console.log('lock file is stale -- regenerate with `trails compile`');
 }
 ```
 

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -170,7 +170,7 @@ describe('checkDrift', () => {
       const result = await checkDrift(dir, makeTopo());
       expect(result.stale).toBe(true);
       expect(result.blockedReason).toContain(
-        'regenerate with `trails topo compile`'
+        'regenerate with `trails compile`'
       );
       expect(result.currentHash).toBe('blocked');
       expect(result.committedHash).toBeNull();

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -1384,7 +1384,7 @@ const formatDriftSection = (drift: DriftResult | null): string[] => {
     return [`Drift: blocked (${drift.blockedReason})`, ''];
   }
   const label = drift.stale
-    ? 'Drift: trails.lock is stale (regenerate with `trails topo compile`)'
+    ? 'Drift: trails.lock is stale (regenerate with `trails compile`)'
     : 'Drift: clean';
   return [label, ''];
 };

--- a/packages/warden/src/drift.ts
+++ b/packages/warden/src/drift.ts
@@ -95,7 +95,7 @@ export const checkDrift = async (
       ) ?? null;
     if (lockManifest !== null && topoArtifact === null) {
       return blockedDrift(
-        'trails.lock does not contain a topo.lock artifact. Regenerate with `trails topo compile`.'
+        'trails.lock does not contain a topo.lock artifact. Regenerate with `trails compile`.'
       );
     }
     const readStoredHash = (): string | undefined => {

--- a/packages/warden/src/formatters.ts
+++ b/packages/warden/src/formatters.ts
@@ -36,7 +36,7 @@ export const formatGitHubAnnotations = (report: WardenReport): string => {
     lines.push(`::error::drift: ${report.drift.blockedReason}`);
   } else if (report.drift?.stale) {
     lines.push(
-      '::error::drift: trails.lock is stale (regenerate with `trails topo compile`)'
+      '::error::drift: trails.lock is stale (regenerate with `trails compile`)'
     );
   }
 
@@ -146,7 +146,7 @@ const driftSection = (drift: WardenReport['drift']): readonly string[] => {
   return [
     '',
     '### Drift',
-    '- trails.lock is stale (regenerate with `trails topo compile`)',
+    '- trails.lock is stale (regenerate with `trails compile`)',
   ];
 };
 

--- a/plugin/agents/trail-engineer.md
+++ b/plugin/agents/trail-engineer.md
@@ -96,8 +96,8 @@ If warden reports drift:
 
 ```bash
 trails warden --lock cached --no-lock-mutation
-trails topo compile
-trails topo verify
+trails compile
+trails validate
 ```
 
 Review the diff, update the lock if the change is intentional.

--- a/plugin/skills/trails-derive-from-source/SKILL.md
+++ b/plugin/skills/trails-derive-from-source/SKILL.md
@@ -21,7 +21,7 @@ Use this skill when a proposal adds a table, projection, metadata map, generated
 - `docs/adr/0037-owner-first-authority.md`
 - `docs/contributing/warden-rules.md`
 - Owner modules in `packages/core/src`, `packages/topographer/src`, `packages/warden/src/rules`, or the package that owns the primitive.
-- Projection consumers in CLI, MCP, HTTP/Hono, Warden, docs generation, or topo compile/verify paths.
+- Projection consumers in CLI, MCP, HTTP/Hono, Warden, docs generation, or topo artifact compile/validation paths.
 
 ## Advisory Context
 

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -225,8 +225,8 @@ The warden enforces conventions and detects drift:
 ```bash
 trails warden          # Convention checks
 trails warden --lock cached --no-lock-mutation # Governance against cached lock data
-trails topo compile        # Regenerate committed topo artifacts
-trails topo verify         # Verify committed topo artifacts
+trails compile        # Regenerate committed topo artifacts
+trails validate       # Verify committed topo artifacts
 ```
 
 For the current generated rule index, read [warden-guide.md](references/warden-guide.md) instead of relying on copied rule prose.

--- a/plugin/skills/trails/references/migration-checklist.md
+++ b/plugin/skills/trails/references/migration-checklist.md
@@ -62,8 +62,8 @@ For each handler:
 ## Phase 6: Governance
 
 - [ ] `trails warden` reports clean
-- [ ] Regenerate topo artifacts: `trails topo compile`
-- [ ] Verify topo artifacts: `trails topo verify`
+- [ ] Regenerate topo artifacts: `trails compile`
+- [ ] Verify topo artifacts: `trails validate`
 - [ ] Add lock check to CI
 
 ## Common Gotchas


### PR DESCRIPTION
## Context

Stack position 2/7 for the Trail Versioning M1 + M2 stack. This PR settles the public CLI namespace before version authoring and runtime commands depend on it.

## Changes

- Promotes `trails topo compile` to top-level `trails compile`.
- Adds top-level `trails validate`.
- Retires `trails topo verify` from the current CLI surface.
- Removes current-facing old versioning command guidance and updates docs, tests, Warden/plugin guidance, and CLI help expectations.
- Adds a branch-local changeset for the publishable CLI package impact.

## Verification

- Focused `apps/trails`, `packages/topographer`, and `packages/warden` tests.
- `bun apps/trails/bin/trails.ts --help`
- `bun apps/trails/bin/trails.ts compile --help`
- `bun apps/trails/bin/trails.ts validate --help`
- Stale-command sweeps for retired current-facing command names.
- Full stack-tip gate later passed through `bun run publish:check`.

## Risks / Rollout

This is an intentional breaking CLI namespace cleanup before 1.0. The stack does not add compatibility aliases or a transition period.

## Linear

- Linear: TRL-729
- Project: Trail Versioning