### PR TITLE
feat(core): define trail version authoring shape

### DIFF
--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
@@ -28,11 +28,19 @@ handoff. Meaningful review-flow changes require a new retro entry.
 | --- | --- | --- | --- | --- | --- |
 | 1 | `TRL-728` | `trl-728-docsadr-supersede-adr-0044-with-trail-versioning-v3-doctrine` | pending | locally committed | ADR-0048 and ADR-0044 supersession; local commit `a2ca7b710`. |
 | 2 | `TRL-729` | `trl-729-feattrails-settle-top-level-cli-namespace-before-versioning` | pending | locally committed | Top-level CLI namespace; local commit `ecf7fa87a`. |
+<<<<<<< HEAD
 | 3 | `TRL-113` | `trl-113-define-trail-version-versions-authoring-shape` | pending | locally committed | Source and graph authoring shape; local commit `f1a7284b2`. |
 | 4 | `TRL-114` | `trl-114-add-pure-transpose-transforms-for-revision-entries` | pending | locally committed | Pure `transpose:` revision transforms; local commit `ccaed90fa`. |
 | 5 | `TRL-739` | `trl-739-featcore-compute-content-addressed-version-markers` | pending | locally committed | Projected content-addressed markers; local commit `db49d4571`. |
 | 6 | `TRL-115` | `trl-115-resolve-trail-versions-during-execution` | pending | locally committed | Runtime version resolution; local commit `168416a5b`. |
 | 7 | `TRL-116` | `trl-116-run-examples-and-testall-across-live-version-entries` | pending | locally validated | Version-aware examples and `testAll`; branch-local commit pending. |
+=======
+| 3 | `TRL-113` | `trl-113-define-trail-version-versions-authoring-shape` | pending | in progress | Source and graph authoring shape; implementation verified and ready to commit. |
+| 4 | `TRL-114` | `trl-114-add-pure-transpose-transforms-for-revision-entries` | pending | planned | Pure `transpose:` revision transforms. |
+| 5 | `TRL-739` | `trl-739-featcore-compute-content-addressed-version-markers` | pending | planned | Projected content-addressed markers. |
+| 6 | `TRL-115` | `trl-115-resolve-trail-versions-during-execution` | pending | planned | Runtime version resolution. |
+| 7 | `TRL-116` | `trl-116-run-examples-and-testall-across-live-version-entries` | pending | planned | Version-aware examples and `testAll`. |
+>>>>>>> f1a7284b2 (feat(core): add trail version authoring shape)
 
 ## Planning Discoveries
 
@@ -65,10 +73,13 @@ they represent real future work.
 | 2026-05-19 18:18 EDT | `TRL-728` | Moved to In Progress when the first execution branch started. | Linear issue update |
 | 2026-05-19 18:22 EDT | `TRL-729` | Moved to In Progress when the CLI namespace branch started. | Linear issue update |
 | 2026-05-19 18:32 EDT | `TRL-113` | Moved to In Progress when the authoring-shape branch started. | Linear issue update |
+<<<<<<< HEAD
 | 2026-05-19 18:42 EDT | `TRL-114` | Moved to In Progress when the pure-transpose branch started. | Linear issue update |
 | 2026-05-19 18:49 EDT | `TRL-739` | Moved to In Progress when the marker branch started. | Linear issue update |
 | 2026-05-19 19:03 EDT | `TRL-115` | Moved to In Progress when the runtime-resolution branch started. | Linear issue update |
 | 2026-05-19 19:26 EDT | `TRL-116` | Moved to In Progress when the examples/testAll branch started. | Linear issue update |
+=======
+>>>>>>> f1a7284b2 (feat(core): add trail version authoring shape)
 
 ## Execution Log
 
@@ -137,6 +148,13 @@ Append meaningful state changes, especially before handoff points.
 - Result: TRL-728 is ready for `gt modify`; descendants need restack and the stack-tip verification must restart from `bun scripts/adr.ts map`.
 - Next: Amend TRL-728, restack descendants, then return to TRL-116.
 - Blockers: none.
+
+2026-05-19 18:39 EDT - TRL-113 authoring-shape branch
+- Changed: Created `trl-113-define-trail-version-versions-authoring-shape`, added trail-only `version` / `versions` source shape, normalized version-entry runtime data, rejected authored `kind` and invalid historical contracts, reserved `version?: never` on non-trail specs, projected version entries into `TopoGraph`, and added core/topographer tests plus a branch-local changeset.
+- Verified: Core and topographer focused tests passed; package and root typechecks passed; `bun run format:check` and `git diff --check` passed; live-code sweep found no `.v*.ts` version-file discovery.
+- Result: TRL-113 is ready for commit as the third stack branch.
+- Next: Commit TRL-113, then create the TRL-114 pure-transpose branch.
+- Blockers: none.
 ```
 
 ## Local Review Log
@@ -178,6 +196,7 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 | `git diff --check` | TRL-729 | passed | No whitespace errors. |
 | `bun run --cwd packages/core test` | TRL-113 | passed | 1116 tests, 0 failures. |
 | `bun run --cwd packages/topographer test` | TRL-113 | passed | 122 tests, 0 failures. |
+<<<<<<< HEAD
 | `bun run typecheck` | TRL-113 | passed | 22 package tasks successful. |
 | `.v*.ts` live-code sweep | TRL-113 | passed | No current code matches for version-file discovery or `.vN.ts` filenames. |
 | `bun run --cwd packages/core test` | TRL-114 | passed | 1121 tests, 0 failures. |
@@ -200,6 +219,14 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 | `bun run --cwd apps/trails test` | TRL-116 | passed | 320 tests, 0 failures after updating the guide detail fixture for version fields. |
 | `bun run format:check` | TRL-116 | passed | Initial check found one formatting issue in `packages/testing/src/examples.ts`; targeted `bunx ultracite fix` applied; rerun passed. |
 | `git diff --check` | TRL-116 | passed | No whitespace errors. |
+=======
+| `bun run --cwd packages/core typecheck` | TRL-113 | passed | `tsc --noEmit` exited 0. |
+| `bun run --cwd packages/topographer typecheck` | TRL-113 | passed | `tsc --noEmit` exited 0. |
+| `bun run typecheck` | TRL-113 | passed | 22 package tasks successful. |
+| `.v*.ts` live-code sweep | TRL-113 | passed | No current code matches for version-file discovery or `.vN.ts` filenames. |
+| `bun run format:check` | TRL-113 | passed | Initial check found format/lint issues; `bun run format:fix` plus minimal lint fix cleaned them, rerun passed. |
+| `git diff --check` | TRL-113 | passed | No whitespace errors. |
+>>>>>>> f1a7284b2 (feat(core): add trail version authoring shape)
 
 ## Remote Review / CI Log
 

--- a/.changeset/trail-version-authoring-shape.md
+++ b/.changeset/trail-version-authoring-shape.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/core": patch
+"@ontrails/topographer": patch
+---
+
+Add trail-only `version` / `versions` authoring types and TopoGraph projection.

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -4,12 +4,17 @@ import { z } from 'zod';
 
 import { contour } from '../contour';
 import { createTrailContext } from '../context';
-import { ConflictError } from '../errors';
+import { ConflictError, ValidationError } from '../errors';
 import { Result } from '../result';
 import { resource } from '../resource';
 import { schedule } from '../schedule';
 import { signal } from '../signal';
-import { intentValues, trail } from '../trail';
+import {
+  deriveSupportedTrailVersions,
+  getTrailVersionEntryKind,
+  intentValues,
+  trail,
+} from '../trail';
 import type { TrailContext } from '../types';
 import { webhook } from '../webhook';
 
@@ -77,6 +82,232 @@ describe('trail()', () => {
       const result = await greet.blaze({ name: 'World' }, stubCtx);
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toEqual({ greeting: 'Hello, World!' });
+    });
+  });
+
+  describe('versioning', () => {
+    test('keeps unversioned trails current-only', () => {
+      const unversioned = trail('plain.current', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+
+      expect(unversioned.version).toBeUndefined();
+      expect(unversioned.versions).toBeUndefined();
+      expect(deriveSupportedTrailVersions(unversioned)).toEqual([]);
+    });
+
+    test('stores revision entries and derives live support', () => {
+      const v2Input = z.object({ name: z.string() });
+      const v2Output = z.object({ greeting: z.string() });
+      const versioned = trail('invite.create', {
+        blaze: (input) => Result.ok({ greeting: `Hello, ${input.name}!` }),
+        input: inputSchema,
+        output: outputSchema,
+        version: 3,
+        versions: {
+          2: {
+            input: v2Input,
+            output: v2Output,
+            status: { state: 'deprecated', successor: 3 },
+            transpose: {
+              input: ({ input }) => input,
+              output: ({ output }) => output,
+            },
+          },
+        },
+      });
+
+      const entry = versioned.versions?.[2];
+      expect(versioned.version).toBe(3);
+      expect(Object.isFrozen(versioned.versions)).toBe(true);
+      expect(entry?.input).toBe(v2Input);
+      expect(entry?.output).toBe(v2Output);
+      expect(entry?.status).toEqual({ state: 'deprecated', successor: 3 });
+      expect(entry && getTrailVersionEntryKind(entry)).toBe('revision');
+      expect(deriveSupportedTrailVersions(versioned)).toEqual([2, 3]);
+    });
+
+    test('allows metadata-only revision entries for unchanged schemas', () => {
+      const versioned = trail('metadata.revision', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({ id: z.string() }),
+        output: z.object({ ok: z.boolean() }),
+        version: 2,
+        versions: {
+          1: {
+            input: z.object({ id: z.string() }),
+            output: z.object({ ok: z.boolean() }),
+          },
+        },
+      });
+
+      const entry = versioned.versions?.[1];
+      expect(entry && getTrailVersionEntryKind(entry)).toBe('revision');
+      expect('transpose' in (entry as Record<string, unknown>)).toBe(false);
+    });
+
+    test('stores fork entries with normalized runtime references', () => {
+      const target = trail('target.read', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const versioned = trail('forked.run', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+        version: 2,
+        versions: {
+          1: {
+            blaze: () => Result.ok({ ok: true }),
+            crosses: [target],
+            detours: [
+              {
+                on: ConflictError,
+                recover: async () => Result.ok({ ok: true }),
+              },
+            ],
+            input: z.object({}),
+            output: z.object({ ok: z.boolean() }),
+            resources: [dbResource],
+          },
+        },
+      });
+
+      const entry = versioned.versions?.[1] as
+        | (Record<string, unknown> & { crosses: readonly string[] })
+        | undefined;
+      expect(entry && getTrailVersionEntryKind(entry)).toBe('fork');
+      expect(entry?.crosses).toEqual(['target.read']);
+      expect(entry?.resources).toEqual([dbResource]);
+      expect(entry?.detours).toHaveLength(1);
+      expect(Object.isFrozen(entry?.crosses)).toBe(true);
+    });
+
+    test('allows version gaps and excludes archived entries from support', () => {
+      const versioned = trail('gap.versioned', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+        version: 5,
+        versions: {
+          2: {
+            input: z.object({}),
+            output: z.object({ ok: z.boolean() }),
+          },
+          4: {
+            input: z.object({}),
+            output: z.object({ ok: z.boolean() }),
+            status: { reason: 'No callers remain.', state: 'archived' },
+          },
+        },
+      });
+
+      expect(Object.keys(versioned.versions ?? {})).toEqual(['2', '4']);
+      expect(deriveSupportedTrailVersions(versioned)).toEqual([2, 5]);
+    });
+
+    test('rejects invalid version entry shapes', () => {
+      const base = {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({}),
+        output: z.object({ ok: z.boolean() }),
+        version: 2,
+      };
+
+      expect(() =>
+        trail('bad.mixed', {
+          ...base,
+          versions: {
+            1: {
+              blaze: () => Result.ok({ ok: true }),
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              transpose: {
+                input: ({ input }: { input: unknown }) => input,
+                output: ({ output }: { output: unknown }) => output,
+              },
+            } as never,
+          },
+        })
+      ).toThrow(ValidationError);
+
+      expect(() =>
+        trail('bad.missing-output', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+            } as never,
+          },
+        })
+      ).toThrow(ValidationError);
+
+      expect(() =>
+        trail('bad.revision-runtime-fields', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              resources: [dbResource],
+            } as never,
+          },
+        })
+      ).toThrow(ValidationError);
+
+      expect(() =>
+        trail('bad.kind', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              kind: 'revision',
+              output: z.object({ ok: z.boolean() }),
+            } as never,
+          },
+        })
+      ).toThrow(ValidationError);
+
+      expect(() =>
+        trail('bad.current-duplicate', {
+          ...base,
+          versions: {
+            2: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+            },
+          },
+        })
+      ).toThrow(ValidationError);
+
+      expect(() =>
+        trail('bad.future-history', {
+          ...base,
+          versions: {
+            3: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+            },
+          },
+        })
+      ).toThrow('must be less than the current version');
+
+      expect(() =>
+        trail('bad.no-current', {
+          blaze: () => Result.ok({ ok: true }),
+          input: z.object({}),
+          output: z.object({ ok: z.boolean() }),
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+            },
+          },
+        } as never)
+      ).toThrow(ValidationError);
     });
   });
 

--- a/packages/core/src/__tests__/validate-topo.test.ts
+++ b/packages/core/src/__tests__/validate-topo.test.ts
@@ -116,6 +116,122 @@ describe('validateTopo', () => {
       expect(issues[0]?.message).toContain('entity.missing');
     });
 
+    test('live fork version crossing a non-existent trail fails', () => {
+      const ok = async () => Result.ok({ ok: true });
+      const app = topo('app', {
+        versioned: trail('entity.versioned', {
+          blaze: ok,
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          version: 2,
+          versions: {
+            1: {
+              blaze: ok,
+              crosses: ['entity.missing'],
+              input: z.object({ name: z.string() }),
+              output: z.object({ ok: z.boolean() }),
+            },
+          },
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isErr()).toBe(true);
+
+      const issues = extractIssues(result);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]?.rule).toBe('cross-exists');
+      expect(issues[0]?.trailId).toBe('entity.versioned');
+      expect(issues[0]?.message).toContain('Version 1');
+      expect(issues[0]?.message).toContain('entity.missing');
+    });
+
+    test('archived fork version crossing a missing trail is not live-validated', () => {
+      const ok = async () => Result.ok({ ok: true });
+      const app = topo('app', {
+        versioned: trail('entity.versioned', {
+          blaze: ok,
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          version: 2,
+          versions: {
+            1: {
+              blaze: ok,
+              crosses: ['entity.missing'],
+              input: z.object({ name: z.string() }),
+              output: z.object({ ok: z.boolean() }),
+              status: { state: 'archived' },
+            },
+          },
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isOk()).toBe(true);
+    });
+
+    test('live fork version crossings participate in cycle detection', () => {
+      const ok = async () => Result.ok({ ok: true });
+      const app = topo('app', {
+        a: trail('a', {
+          blaze: ok,
+          crosses: ['b'],
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+        }),
+        b: trail('b', {
+          blaze: ok,
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          version: 2,
+          versions: {
+            1: {
+              blaze: ok,
+              crosses: ['a'],
+              input: z.object({ name: z.string() }),
+              output: z.object({ ok: z.boolean() }),
+            },
+          },
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isErr()).toBe(true);
+
+      const issues = extractIssues(result);
+      expect(issues.some((issue) => issue.rule === 'cross-cycle')).toBe(true);
+    });
+
+    test('archived fork version crossings do not participate in cycle detection', () => {
+      const ok = async () => Result.ok({ ok: true });
+      const app = topo('app', {
+        a: trail('a', {
+          blaze: ok,
+          crosses: ['b'],
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+        }),
+        b: trail('b', {
+          blaze: ok,
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          version: 2,
+          versions: {
+            1: {
+              blaze: ok,
+              crosses: ['a'],
+              input: z.object({ name: z.string() }),
+              output: z.object({ ok: z.boolean() }),
+              status: { state: 'archived' },
+            },
+          },
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isOk()).toBe(true);
+    });
+
     test('trail crossing itself fails', () => {
       const app = topo('app', {
         loop: mockTrail('entity.loop', { crosses: ['entity.loop'] }),
@@ -211,6 +327,37 @@ describe('validateTopo', () => {
       const issues = extractIssues(result);
       expect(issues).toHaveLength(1);
       expect(issues[0]?.rule).toBe('resource-exists');
+      expect(issues[0]?.message).toContain('db.main');
+    });
+
+    test('live fork version declaring a missing resource fails', () => {
+      const db = mockResource('db.main');
+      const ok = async () => Result.ok({ ok: true });
+      const app = topo('app', {
+        versioned: trail('entity.versioned', {
+          blaze: ok,
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          version: 2,
+          versions: {
+            1: {
+              blaze: ok,
+              input: z.object({ name: z.string() }),
+              output: z.object({ ok: z.boolean() }),
+              resources: [db],
+            },
+          },
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isErr()).toBe(true);
+
+      const issues = extractIssues(result);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]?.rule).toBe('resource-exists');
+      expect(issues[0]?.trailId).toBe('entity.versioned');
+      expect(issues[0]?.message).toContain('Version 1');
       expect(issues[0]?.message).toContain('db.main');
     });
   });

--- a/packages/core/src/contour.ts
+++ b/packages/core/src/contour.ts
@@ -13,6 +13,8 @@ export interface ContourOptions<
   readonly identity: TIdentity;
   /** Example instances validated against the contour schema at declaration time. */
   readonly examples?: readonly z.output<z.ZodObject<TShape>>[] | undefined;
+  /** Reserved for future contour-specific design; trail versioning is trail-only. */
+  readonly version?: never;
 }
 
 /** Type-level brand name applied to a contour's identity schema. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,16 +157,33 @@ export {
   projectActivationSourceDeclaration,
 } from './activation-source-projection.js';
 export type { ActivationSourceProjection } from './activation-source-projection.js';
-export { intentValues, trail } from './trail.js';
+export {
+  deriveSupportedTrailVersions,
+  getTrailVersionEntryKind,
+  intentValues,
+  isArchivedTrailVersionEntry,
+  trail,
+} from './trail.js';
 export type {
   AnyTrail,
   BlazeInput,
   Intent,
   Trail,
+  TrailVersionEntry,
+  TrailVersionEntryKind,
+  TrailVersionForkEntry,
+  TrailVersionRevisionEntry,
+  TrailVersions,
+  TrailVersionStatus,
+  TrailVersionTranspose,
+  TrailVersionTransposeInput,
+  TrailVersionTransposeOutput,
   TrailSpec,
   TrailExample,
   TrailExampleSignalAssertion,
   TrailVisibility,
+  VersionContract,
+  VersionEntry,
 } from './trail.js';
 export {
   filterSurfaceTrails,

--- a/packages/core/src/resource.ts
+++ b/packages/core/src/resource.ts
@@ -54,6 +54,8 @@ export interface ResourceSpec<T, C = unknown> {
   readonly meta?: Readonly<Record<string, unknown>> | undefined;
   /** Signals projected or owned by this resource. */
   readonly signals?: readonly AnySignal[] | undefined;
+  /** Reserved for future resource-specific design; trail versioning is trail-only. */
+  readonly version?: never;
 }
 
 /** A typed resource definition. */

--- a/packages/core/src/schedule.ts
+++ b/packages/core/src/schedule.ts
@@ -11,6 +11,8 @@ export interface ScheduleSpec<TInput = unknown> {
   readonly input?: TInput | undefined;
   readonly meta?: ActivationSourceMeta | undefined;
   readonly timezone?: string | undefined;
+  /** Reserved for future schedule-specific design; trail versioning is trail-only. */
+  readonly version?: never;
 }
 
 export interface ScheduleSource<TInput = unknown> extends ActivationSource {

--- a/packages/core/src/signal.ts
+++ b/packages/core/src/signal.ts
@@ -39,6 +39,8 @@ export interface SignalSpec<T> {
   readonly meta?: Readonly<Record<string, unknown>> | undefined;
   /** Trail IDs that produce this signal (e.g. the trails it originates from). */
   readonly from?: readonly string[] | undefined;
+  /** Reserved for future signal-specific design; trail versioning is trail-only. */
+  readonly version?: never;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 
+import { ValidationError } from './errors.js';
 import type {
   ActivationEntry,
   ActivationEntrySpec,
@@ -80,6 +81,145 @@ export interface TrailExample<I, O> {
  * cast. Falls back to plain `I` when `CI` is `never` (the default).
  */
 export type BlazeInput<I, CI> = [CI] extends [never] ? I : I & CI;
+
+// ---------------------------------------------------------------------------
+// Trail versioning
+// ---------------------------------------------------------------------------
+
+/** Contract pair represented by a version entry. */
+export interface VersionContract<I = unknown, O = unknown> {
+  readonly input: I;
+  readonly output: O;
+}
+
+/** Shared lifecycle metadata for historical version entries. */
+export interface TrailVersionStatus {
+  readonly state: 'deprecated' | 'archived';
+  readonly [key: string]: unknown;
+}
+
+/** Shared base for version entries. Historical entries never inherit schemas. */
+export interface VersionEntry<
+  TContract extends VersionContract = VersionContract,
+> {
+  readonly input: z.ZodType<TContract['input']>;
+  readonly output: z.ZodType<TContract['output']>;
+  readonly status?: TrailVersionStatus | undefined;
+}
+
+export type TrailVersionTransposeInput<VersionInput, CurrentInput> = (value: {
+  readonly input: VersionInput;
+}) => CurrentInput | Promise<CurrentInput>;
+
+export type TrailVersionTransposeOutput<CurrentOutput, VersionOutput> =
+  (value: {
+    readonly output: CurrentOutput;
+  }) => VersionOutput | Promise<VersionOutput>;
+
+export interface TrailVersionTranspose<
+  VersionInput,
+  VersionOutput,
+  CurrentInput,
+  CurrentOutput,
+> {
+  readonly input: TrailVersionTransposeInput<VersionInput, CurrentInput>;
+  readonly output: TrailVersionTransposeOutput<CurrentOutput, VersionOutput>;
+}
+
+export interface TrailVersionRevisionEntry<
+  VersionInput = unknown,
+  VersionOutput = unknown,
+  CurrentInput = unknown,
+  CurrentOutput = unknown,
+> extends VersionEntry<VersionContract<VersionInput, VersionOutput>> {
+  readonly blaze?: never;
+  readonly crosses?: never;
+  readonly detours?: never;
+  readonly kind?: never;
+  readonly resources?: never;
+  readonly transpose?:
+    | TrailVersionTranspose<
+        VersionInput,
+        VersionOutput,
+        CurrentInput,
+        CurrentOutput
+      >
+    | undefined;
+}
+
+export interface TrailVersionForkEntry<
+  VersionInput = unknown,
+  VersionOutput = unknown,
+  CrossInput = never,
+> extends VersionEntry<VersionContract<VersionInput, VersionOutput>> {
+  readonly blaze: Implementation<
+    BlazeInput<VersionInput, CrossInput>,
+    VersionOutput
+  >;
+  readonly crosses?: readonly (string | AnyTrail)[] | undefined;
+  readonly crossInput?: z.ZodType<CrossInput> | undefined;
+  readonly detours?:
+    | readonly Detour<VersionInput, VersionOutput, TrailsError>[]
+    | undefined;
+  readonly kind?: never;
+  readonly resources?: readonly AnyResource[] | undefined;
+  readonly transpose?: never;
+}
+
+export type TrailVersionEntry<
+  VersionInput = unknown,
+  VersionOutput = unknown,
+  CurrentInput = unknown,
+  CurrentOutput = unknown,
+  CrossInput = never,
+> =
+  | TrailVersionRevisionEntry<
+      VersionInput,
+      VersionOutput,
+      CurrentInput,
+      CurrentOutput
+    >
+  | TrailVersionForkEntry<VersionInput, VersionOutput, CrossInput>;
+
+export type TrailVersionEntryKind = 'revision' | 'fork';
+
+export type TrailVersions<
+  CurrentInput = unknown,
+  CurrentOutput = unknown,
+> = Readonly<
+  Record<
+    number,
+    TrailVersionEntry<unknown, unknown, CurrentInput, CurrentOutput>
+  >
+>;
+
+export const getTrailVersionEntryKind = (
+  entry: TrailVersionEntry
+): TrailVersionEntryKind => {
+  const raw = entry as unknown as Record<string, unknown>;
+  return typeof raw['blaze'] === 'function' ? 'fork' : 'revision';
+};
+
+export const isArchivedTrailVersionEntry = (
+  entry: Pick<TrailVersionEntry, 'status'>
+): boolean => entry.status?.state === 'archived';
+
+export const deriveSupportedTrailVersions = (
+  trail: Pick<AnyTrail, 'version' | 'versions'>
+): readonly number[] => {
+  if (trail.version === undefined) {
+    return [];
+  }
+
+  const supported = new Set<number>([trail.version]);
+  for (const [rawVersion, entry] of Object.entries(trail.versions ?? {})) {
+    if (!isArchivedTrailVersionEntry(entry)) {
+      supported.add(Number(rawVersion));
+    }
+  }
+
+  return Object.freeze([...supported].toSorted((a, b) => a - b));
+};
 
 // ---------------------------------------------------------------------------
 // Trail spec
@@ -171,6 +311,10 @@ export interface TrailSpec<I, O, CI = never> {
   readonly permit?: PermitRequirement | undefined;
   /** Primary input fields and their order. CLI projects as positional args. */
   readonly args?: readonly string[] | false | undefined;
+  /** Current trail version number. Omit for current-only unversioned trails. */
+  readonly version?: number | undefined;
+  /** Explicit historical trail versions. Current stays top-level. */
+  readonly versions?: TrailVersions<I, O> | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -362,6 +506,239 @@ const extractSignalActivationIds = (
 const normalizeCrossRef = (entry: string | AnyTrail): string =>
   typeof entry === 'string' ? entry : entry.id;
 
+const assertVersionNumber = (
+  trailId: string,
+  label: string,
+  version: number
+): void => {
+  if (!Number.isSafeInteger(version) || version <= 0) {
+    throw new ValidationError(
+      `Trail "${trailId}" ${label} must be a positive integer`
+    );
+  }
+};
+
+const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
+  Object.hasOwn(value, key);
+
+const assertZodSchema = (
+  trailId: string,
+  version: number,
+  entry: Record<string, unknown>,
+  field: 'input' | 'output'
+): void => {
+  if (!hasOwn(entry, field) || entry[field] === undefined) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} must declare explicit ${field}`
+    );
+  }
+};
+
+const normalizeVersionStatus = (
+  trailId: string,
+  version: number,
+  status: unknown
+): TrailVersionStatus | undefined => {
+  if (status === undefined) {
+    return undefined;
+  }
+  if (typeof status !== 'object' || status === null || Array.isArray(status)) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} status must be an object`
+    );
+  }
+
+  const raw = status as Record<string, unknown>;
+  if (raw['state'] !== 'deprecated' && raw['state'] !== 'archived') {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} status.state must be "deprecated" or "archived"`
+    );
+  }
+
+  return Object.freeze({ ...raw, state: raw['state'] }) as TrailVersionStatus;
+};
+
+const normalizeTranspose = (
+  trailId: string,
+  version: number,
+  transpose: unknown
+): TrailVersionTranspose<unknown, unknown, unknown, unknown> | undefined => {
+  if (transpose === undefined) {
+    return undefined;
+  }
+  if (
+    typeof transpose !== 'object' ||
+    transpose === null ||
+    Array.isArray(transpose)
+  ) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} transpose must be an object`
+    );
+  }
+
+  const raw = transpose as Record<string, unknown>;
+  if (
+    typeof raw['input'] !== 'function' ||
+    typeof raw['output'] !== 'function'
+  ) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} transpose must define input and output functions`
+    );
+  }
+
+  return Object.freeze({
+    input: raw['input'],
+    output: raw['output'],
+  }) as TrailVersionTranspose<unknown, unknown, unknown, unknown>;
+};
+
+const assertRevisionOwnsNoRuntimeFields = (
+  trailId: string,
+  version: number,
+  entry: Record<string, unknown>
+): void => {
+  const forbidden = ['crosses', 'resources', 'detours'];
+  const declared = forbidden.filter((field) => hasOwn(entry, field));
+  if (declared.length > 0) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} is a revision and cannot declare ${declared.join(', ')}`
+    );
+  }
+};
+
+const normalizeVersionEntry = <CurrentInput, CurrentOutput>(
+  trailId: string,
+  version: number,
+  entry: TrailVersionEntry<unknown, unknown, CurrentInput, CurrentOutput>
+): TrailVersionEntry<unknown, unknown, CurrentInput, CurrentOutput> => {
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} must be an object`
+    );
+  }
+
+  const raw = entry as unknown as Record<string, unknown>;
+  assertZodSchema(trailId, version, raw, 'input');
+  assertZodSchema(trailId, version, raw, 'output');
+
+  if (hasOwn(raw, 'kind')) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} must not author kind; it is projected`
+    );
+  }
+
+  const hasBlaze = typeof raw['blaze'] === 'function';
+  const hasTranspose = raw['transpose'] !== undefined;
+  if (hasBlaze && hasTranspose) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} cannot declare both blaze and transpose`
+    );
+  }
+
+  const base = {
+    input: raw['input'],
+    output: raw['output'],
+    ...(raw['status'] === undefined
+      ? {}
+      : { status: normalizeVersionStatus(trailId, version, raw['status']) }),
+  };
+
+  if (hasBlaze) {
+    return Object.freeze({
+      ...base,
+      blaze: async (input: unknown, ctx: TrailContext) =>
+        await (raw['blaze'] as Implementation<unknown, unknown>)(input, ctx),
+      ...(raw['crossInput'] === undefined
+        ? {}
+        : { crossInput: raw['crossInput'] }),
+      crosses: Object.freeze(
+        (
+          (raw['crosses'] as readonly (string | AnyTrail)[] | undefined) ?? []
+        ).map(normalizeCrossRef)
+      ),
+      detours: Object.freeze([
+        ...(((raw['detours'] as readonly Detour<
+          unknown,
+          unknown,
+          TrailsError
+        >[]) ?? []) as readonly Detour<unknown, unknown, TrailsError>[]),
+      ]),
+      resources: Object.freeze([
+        ...(((raw['resources'] as readonly AnyResource[]) ??
+          []) as readonly AnyResource[]),
+      ]),
+    }) as TrailVersionEntry<unknown, unknown, CurrentInput, CurrentOutput>;
+  }
+
+  assertRevisionOwnsNoRuntimeFields(trailId, version, raw);
+
+  return Object.freeze({
+    ...base,
+    ...(hasTranspose
+      ? { transpose: normalizeTranspose(trailId, version, raw['transpose']) }
+      : {}),
+  }) as TrailVersionEntry<unknown, unknown, CurrentInput, CurrentOutput>;
+};
+
+const normalizeTrailVersions = <CurrentInput, CurrentOutput>(
+  trailId: string,
+  currentVersion: number | undefined,
+  versions: TrailVersions<CurrentInput, CurrentOutput> | undefined
+): TrailVersions<CurrentInput, CurrentOutput> | undefined => {
+  if (currentVersion === undefined) {
+    if (versions !== undefined) {
+      throw new ValidationError(
+        `Trail "${trailId}" declares versions without a current version`
+      );
+    }
+    return undefined;
+  }
+
+  assertVersionNumber(trailId, 'version', currentVersion);
+
+  if (versions === undefined) {
+    return undefined;
+  }
+  if (
+    typeof versions !== 'object' ||
+    versions === null ||
+    Array.isArray(versions)
+  ) {
+    throw new ValidationError(`Trail "${trailId}" versions must be an object`);
+  }
+
+  const normalized: Record<
+    number,
+    TrailVersionEntry<unknown, unknown, CurrentInput, CurrentOutput>
+  > = {};
+  for (const [rawVersion, entry] of Object.entries(versions)) {
+    const historicalVersion = Number(rawVersion);
+    if (`${historicalVersion}` !== rawVersion) {
+      throw new ValidationError(
+        `Trail "${trailId}" versions key "${rawVersion}" must be a positive integer`
+      );
+    }
+    assertVersionNumber(trailId, `versions.${rawVersion}`, historicalVersion);
+    if (historicalVersion === currentVersion) {
+      throw new ValidationError(
+        `Trail "${trailId}" version ${historicalVersion} is current and must stay top-level`
+      );
+    }
+    if (historicalVersion > currentVersion) {
+      throw new ValidationError(
+        `Trail "${trailId}" version ${historicalVersion} must be less than the current version (${currentVersion})`
+      );
+    }
+    normalized[historicalVersion] = normalizeVersionEntry(
+      trailId,
+      historicalVersion,
+      entry
+    );
+  }
+
+  return Object.freeze(normalized);
+};
+
 /** Freeze and normalize all collection fields from a trail spec. */
 const normalizeCollections = <I, O, CI>(
   spec: TrailSpec<I, O, CI>
@@ -444,9 +821,16 @@ export function trail<I, O, CI = never>(
     layers: _l,
     on: _o,
     resources: _r,
+    version: rawVersion,
+    versions: rawVersions,
     ...spec
   } = resolved.spec;
   const collections = normalizeCollections(resolved.spec);
+  const versions = normalizeTrailVersions<I, O>(
+    resolved.id,
+    rawVersion,
+    rawVersions
+  );
 
   return Object.freeze({
     ...spec,
@@ -458,6 +842,8 @@ export function trail<I, O, CI = never>(
     id: resolved.id,
     intent: rawIntent ?? 'write',
     kind: 'trail' as const,
+    ...(rawVersion === undefined ? {} : { version: rawVersion }),
+    ...(versions === undefined ? {} : { versions }),
     visibility: rawVisibility ?? 'public',
   });
 }

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -9,11 +9,16 @@
  * re-exported from the package index.
  */
 
-import type { Trail } from './trail.js';
-import type { Signal } from './signal.js';
+import type { Signal, SignalSpec } from './signal.js';
+import type { Trail, TrailSpec } from './trail.js';
+import type { ResourceSpec } from './resource.js';
+import type { ContourOptions } from './contour.js';
+import type { ScheduleSpec } from './schedule.js';
+import type { WebhookSpec } from './webhook.js';
 import type { BasePermit } from './permits.js';
 import type { FireFn } from './types.js';
 import type { CrossInput, TrailInput } from './type-utils.js';
+import type { z } from 'zod';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -107,6 +112,32 @@ type AssertDefault =
     ? true
     : false;
 export type Default = [AssertDefault] extends [true] ? 'pass' : never;
+
+// ---------------------------------------------------------------------------
+// Version field is trail-only for the v1 authoring shape
+// ---------------------------------------------------------------------------
+
+type AssertTrailVersionAllowed = TrailSpec<
+  { name: string },
+  { id: string }
+>['version'] extends number | undefined
+  ? true
+  : false;
+export type TrailVersionAllowed = [AssertTrailVersionAllowed] extends [true]
+  ? 'pass'
+  : never;
+
+type AssertVersionReserved<T extends { readonly version?: never }> =
+  T['version'] extends never | undefined ? true : false;
+export type NonTrailVersionReservations = [
+  AssertVersionReserved<ResourceSpec<unknown>>,
+  AssertVersionReserved<SignalSpec<unknown>>,
+  AssertVersionReserved<ContourOptions<{ readonly id: z.ZodString }, 'id'>>,
+  AssertVersionReserved<ScheduleSpec>,
+  AssertVersionReserved<WebhookSpec>,
+] extends [true, true, true, true, true]
+  ? 'pass'
+  : never;
 
 // ---------------------------------------------------------------------------
 // FireFn requires signal values and preserves payload inference

--- a/packages/core/src/validate-topo.ts
+++ b/packages/core/src/validate-topo.ts
@@ -22,7 +22,11 @@ import type { AnySignal } from './signal.js';
 import { validateScheduleSource } from './schedule.js';
 import { Result } from './result.js';
 import type { Topo } from './topo.js';
-import type { AnyTrail } from './trail.js';
+import type { AnyTrail, TrailVersionForkEntry } from './trail.js';
+import {
+  getTrailVersionEntryKind,
+  isArchivedTrailVersionEntry,
+} from './trail.js';
 import { validateInput } from './validation.js';
 import { validateWebhookSource } from './webhook.js';
 
@@ -58,9 +62,24 @@ const buildCrossGraph = (
   color: Map<string, number>;
 } => {
   const graph = new Map<string, readonly string[]>();
-  for (const [id, t] of trails) {
-    if (t.crosses.length > 0) {
-      graph.set(id, t.crosses);
+  for (const [id, trail] of trails) {
+    const crossedIds = new Set<string>(trail.crosses);
+    for (const entry of Object.values(trail.versions ?? {})) {
+      if (
+        isArchivedTrailVersionEntry(entry) ||
+        getTrailVersionEntryKind(entry) !== 'fork'
+      ) {
+        continue;
+      }
+
+      const fork = entry as TrailVersionForkEntry;
+      for (const crossed of fork.crosses ?? []) {
+        crossedIds.add(typeof crossed === 'string' ? crossed : crossed.id);
+      }
+    }
+
+    if (crossedIds.size > 0) {
+      graph.set(id, [...crossedIds]);
     }
   }
   const color = new Map<string, number>();
@@ -127,6 +146,33 @@ const checkCrosses = (
         });
       }
     }
+    for (const [rawVersion, entry] of Object.entries(trail.versions ?? {})) {
+      if (
+        isArchivedTrailVersionEntry(entry) ||
+        getTrailVersionEntryKind(entry) !== 'fork'
+      ) {
+        continue;
+      }
+
+      const version = Number(rawVersion);
+      const fork = entry as TrailVersionForkEntry;
+      for (const crossed of fork.crosses ?? []) {
+        const crossedId = typeof crossed === 'string' ? crossed : crossed.id;
+        if (crossedId === id) {
+          issues.push({
+            message: `Trail version ${version} crosses itself`,
+            rule: 'no-self-cross',
+            trailId: id,
+          });
+        } else if (!topo.has(crossedId) && !isDraftId(crossedId)) {
+          issues.push({
+            message: `Version ${version} crosses "${crossedId}" which is not in the topo`,
+            rule: 'cross-exists',
+            trailId: id,
+          });
+        }
+      }
+    }
   }
   issues.push(...detectCrossCycles(trails));
   return issues;
@@ -149,6 +195,29 @@ const checkResources = (
           rule: 'resource-exists',
           trailId: id,
         });
+      }
+    }
+    for (const [rawVersion, entry] of Object.entries(trail.versions ?? {})) {
+      if (
+        isArchivedTrailVersionEntry(entry) ||
+        getTrailVersionEntryKind(entry) !== 'fork'
+      ) {
+        continue;
+      }
+
+      const version = Number(rawVersion);
+      const fork = entry as TrailVersionForkEntry;
+      for (const declaredResource of fork.resources ?? []) {
+        if (
+          !topo.hasResource(declaredResource.id) &&
+          !isDraftId(declaredResource.id)
+        ) {
+          issues.push({
+            message: `Version ${version} resource "${declaredResource.id}" is not in the topo`,
+            rule: 'resource-exists',
+            trailId: id,
+          });
+        }
       }
     }
   }

--- a/packages/core/src/webhook.ts
+++ b/packages/core/src/webhook.ts
@@ -39,6 +39,8 @@ export interface WebhookSpec<TOutput = unknown> {
   readonly path: string;
   readonly payload?: ActivationSource['payload'] | undefined;
   readonly verify?: WebhookVerify | undefined;
+  /** Reserved for future webhook-specific design; trail versioning is trail-only. */
+  readonly version?: never;
 }
 
 export interface WebhookSource<TOutput = unknown> extends ActivationSource {

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -233,6 +233,76 @@ describe('deriveTopoGraph', () => {
       expect(map.entries[0]?.output).toBeUndefined();
     });
 
+    test('versioned trail entries project historical contracts and support', () => {
+      const audit = trail('audit.log', {
+        blaze: noop,
+        input: z.object({ id: z.string() }),
+        output: z.object({ ok: z.boolean() }),
+      });
+      const versioned = trail('invite.create', {
+        blaze: noop,
+        input: z.object({ email: z.string(), notify: z.boolean() }),
+        output: z.object({ inviteId: z.string(), status: z.string() }),
+        version: 3,
+        versions: {
+          1: {
+            blaze: noop,
+            crosses: [audit],
+            detours: [
+              {
+                maxAttempts: 100,
+                on: ConflictError,
+                /* oxlint-disable-next-line require-await -- test stub, no real async work */
+                recover: async () => Result.ok({ legacyId: 'i_1' }),
+              },
+            ],
+            input: z.object({ email: z.string() }),
+            output: z.object({ legacyId: z.string() }),
+            resources: [dbResource],
+            status: {
+              reason: 'No supported callers remain.',
+              state: 'archived',
+            },
+          },
+          2: {
+            input: z.object({ email: z.string() }),
+            output: z.object({ inviteId: z.string() }),
+            status: { state: 'deprecated', successor: 3 },
+            transpose: {
+              input: ({ input }) => ({ ...input, notify: true }),
+              output: ({ output }) => ({ inviteId: output.inviteId }),
+            },
+          },
+        },
+      });
+
+      const entry = deriveTopoGraph(
+        topoFrom({ audit, dbResource, versioned })
+      ).entries.find((candidate) => candidate.id === 'invite.create');
+
+      expect(entry).toMatchObject({
+        supports: [2, 3],
+        version: 3,
+      });
+      expect(entry?.versions?.['1']).toMatchObject({
+        crosses: ['audit.log'],
+        detours: [
+          { maxAttempts: DETOUR_MAX_ATTEMPTS_CAP, on: 'ConflictError' },
+        ],
+        kind: 'fork',
+        resources: ['db.main'],
+        status: { reason: 'No supported callers remain.', state: 'archived' },
+      });
+      expect(entry?.versions?.['2']).toMatchObject({
+        kind: 'revision',
+        status: { state: 'deprecated', successor: 3 },
+      });
+      expect(entry?.versions?.['1']?.input).toMatchObject({ type: 'object' });
+      expect(entry?.versions?.['1']?.output).toMatchObject({ type: 'object' });
+      expect(entry?.versions?.['2']?.input).toMatchObject({ type: 'object' });
+      expect(entry?.versions?.['2']?.output).toMatchObject({ type: 'object' });
+    });
+
     test('trail entries include crosses array when non-empty', () => {
       const base = trail('user.get', {
         blaze: noop,

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -28,6 +28,7 @@ import type {
 
 import { addPermitRequirement } from './permit.js';
 import { TOPO_GRAPH_SCHEMA_VERSION } from './types.js';
+import { projectTrailVersions } from './versioning.js';
 import type {
   JsonSchema,
   TopoGraph,
@@ -466,6 +467,22 @@ const addExamples = (
   }
 };
 
+const addVersioning = (
+  entry: Record<string, unknown>,
+  t: Trail<unknown, unknown, unknown>
+): void => {
+  const projection = projectTrailVersions(t, toSortedJsonSchema);
+  if (projection === undefined) {
+    return;
+  }
+
+  entry['supports'] = projection.supports;
+  entry['version'] = projection.version;
+  if (projection.versions !== undefined) {
+    entry['versions'] = projection.versions;
+  }
+};
+
 const trailToEntry = (
   t: Trail<unknown, unknown, unknown>,
   topoLayers: readonly Layer[]
@@ -487,6 +504,7 @@ const trailToEntry = (
   addLayerAttachments(entry, topoLayers, t);
   addFieldOverrides(entry, t);
   addExamples(entry, t);
+  addVersioning(entry, t);
 
   return sortKeys(entry) as unknown as TopoGraphEntry;
 };

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -51,9 +51,12 @@ export type {
 export type {
   TopoGraph,
   TopoGraphEntry,
+  TopoGraphForceEntry,
   TopoGraphFieldOverride,
   TopoGraphFieldOverrideKey,
   TopoGraphLayerReference,
+  TopoGraphVersionDetour,
+  TopoGraphVersionEntry,
   LockManifest,
   LockManifestArtifact,
   LockManifestSummary,

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -27,6 +27,7 @@ import type {
 
 import { addPermitRequirement } from '../permit.js';
 import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
+import { projectTrailVersions } from '../versioning.js';
 import type {
   LockManifest,
   TopoGraphFieldOverride,
@@ -1085,6 +1086,25 @@ const buildTrailEntryBase = (
   };
 };
 
+const addVersioning = (
+  entry: Record<string, unknown>,
+  trail: AnyTrail
+): void => {
+  const projection = projectTrailVersions(
+    trail,
+    (schema) => sortedJsonSchema(schema as ZodSchemaInput).value
+  );
+  if (projection === undefined) {
+    return;
+  }
+
+  entry['supports'] = projection.supports;
+  entry['version'] = projection.version;
+  if (projection.versions !== undefined) {
+    entry['versions'] = projection.versions;
+  }
+};
+
 const trailToEntryRecord = (
   trail: AnyTrail,
   topoLayers: readonly Layer[],
@@ -1100,6 +1120,7 @@ const trailToEntryRecord = (
   addTrailRelations(entry, trail);
   addLayerAttachments(entry, topoLayers, trail);
   addFieldOverrides(entry, trail);
+  addVersioning(entry, trail);
   return sortKeys(entry) as TopoGraphEntryRecord;
 };
 

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -5,6 +5,7 @@
 import type {
   StructuredSignalExample,
   StructuredTrailExample,
+  TrailVersionStatus,
 } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -94,6 +95,23 @@ export interface TopoGraphPermitRequirement {
   readonly scopes: readonly string[];
 }
 
+export interface TopoGraphVersionDetour {
+  readonly maxAttempts: number;
+  readonly on: string;
+}
+
+export interface TopoGraphVersionEntry {
+  readonly kind: 'revision' | 'fork';
+  readonly input: JsonSchema;
+  readonly output: JsonSchema;
+  readonly status?: TrailVersionStatus | undefined;
+  readonly crosses?: readonly string[] | undefined;
+  readonly detours?: readonly TopoGraphVersionDetour[] | undefined;
+  readonly resources?: readonly string[] | undefined;
+}
+
+export type TopoGraphForceEntry = Readonly<Record<string, unknown>>;
+
 // ---------------------------------------------------------------------------
 // TopoGraph
 // ---------------------------------------------------------------------------
@@ -110,6 +128,12 @@ export interface TopoGraphEntry {
   readonly input?: JsonSchema | undefined;
   readonly payload?: JsonSchema | undefined;
   readonly output?: JsonSchema | undefined;
+  readonly version?: number | undefined;
+  readonly versions?:
+    | Readonly<Record<string, TopoGraphVersionEntry>>
+    | undefined;
+  readonly supports?: readonly number[] | undefined;
+  readonly forces?: readonly TopoGraphForceEntry[] | undefined;
   readonly intent?: 'read' | 'write' | 'destroy' | undefined;
   readonly idempotent?: boolean | undefined;
   readonly dryRunCapable?: boolean | undefined;

--- a/packages/topographer/src/versioning.ts
+++ b/packages/topographer/src/versioning.ts
@@ -1,0 +1,135 @@
+import {
+  DETOUR_MAX_ATTEMPTS_CAP,
+  deriveSupportedTrailVersions,
+  getTrailVersionEntryKind,
+} from '@ontrails/core';
+import type { AnyTrail, TrailVersionEntry } from '@ontrails/core';
+
+import type { JsonSchema, TopoGraphVersionEntry } from './types.js';
+
+type SchemaProjector = (schema: unknown) => JsonSchema;
+
+const sortPlainRecord = <T extends Record<string, unknown>>(value: T): T => {
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).toSorted()) {
+    sorted[key] = value[key];
+  }
+  return sorted as T;
+};
+
+const projectVersionDetours = (
+  entry: TrailVersionEntry
+): TopoGraphVersionEntry['detours'] => {
+  const raw = entry as unknown as Record<string, unknown>;
+  const { detours } = raw;
+  if (!Array.isArray(detours) || detours.length === 0) {
+    return undefined;
+  }
+
+  return detours.map((detour) => {
+    const candidate = detour as {
+      readonly maxAttempts?: number | undefined;
+      readonly on?: { readonly name?: string | undefined } | undefined;
+    };
+    return {
+      maxAttempts: Math.max(
+        1,
+        Math.min(candidate.maxAttempts ?? 1, DETOUR_MAX_ATTEMPTS_CAP)
+      ),
+      on: candidate.on?.name ?? 'Error',
+    };
+  });
+};
+
+const projectVersionRuntimeRefs = (
+  entry: TrailVersionEntry,
+  field: 'crosses' | 'resources'
+): readonly string[] | undefined => {
+  const raw = entry as unknown as Record<string, unknown>;
+  const values = raw[field];
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined;
+  }
+
+  const refs: string[] = [];
+  for (const value of values) {
+    if (typeof value === 'string') {
+      refs.push(value);
+      continue;
+    }
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as { readonly id?: unknown }).id === 'string'
+    ) {
+      refs.push((value as { readonly id: string }).id);
+    }
+  }
+
+  return refs.toSorted();
+};
+
+export const projectTrailVersionEntry = (
+  entry: TrailVersionEntry,
+  projectSchema: SchemaProjector
+): TopoGraphVersionEntry => {
+  const projected: Record<string, unknown> = {
+    input: projectSchema(entry.input),
+    kind: getTrailVersionEntryKind(entry),
+    output: projectSchema(entry.output),
+  };
+
+  if (entry.status !== undefined) {
+    projected['status'] = sortPlainRecord({ ...entry.status });
+  }
+
+  if (projected['kind'] === 'fork') {
+    const crosses = projectVersionRuntimeRefs(entry, 'crosses');
+    const resources = projectVersionRuntimeRefs(entry, 'resources');
+    const detours = projectVersionDetours(entry);
+    if (crosses !== undefined) {
+      projected['crosses'] = crosses;
+    }
+    if (resources !== undefined) {
+      projected['resources'] = resources;
+    }
+    if (detours !== undefined) {
+      projected['detours'] = detours;
+    }
+  }
+
+  return sortPlainRecord(projected) as unknown as TopoGraphVersionEntry;
+};
+
+export const projectTrailVersions = (
+  trail: AnyTrail,
+  projectSchema: SchemaProjector
+):
+  | {
+      readonly supports: readonly number[];
+      readonly version: number;
+      readonly versions?: Readonly<Record<string, TopoGraphVersionEntry>>;
+    }
+  | undefined => {
+  if (trail.version === undefined) {
+    return undefined;
+  }
+
+  const projectedEntries: Record<string, TopoGraphVersionEntry> = {};
+  for (const [rawVersion, entry] of Object.entries(
+    trail.versions ?? {}
+  ).toSorted(([left], [right]) => Number(left) - Number(right))) {
+    projectedEntries[rawVersion] = projectTrailVersionEntry(
+      entry,
+      projectSchema
+    );
+  }
+
+  return {
+    supports: deriveSupportedTrailVersions(trail),
+    version: trail.version,
+    ...(Object.keys(projectedEntries).length > 0
+      ? { versions: projectedEntries }
+      : {}),
+  };
+};


### PR DESCRIPTION
## Context

Stack position 3/7 for the Trail Versioning M1 + M2 stack. This PR introduces the source and resolved graph shape that later transpose, marker, runtime, and testing work build on.

## Changes

- Adds trail-only `version: N` plus sibling `versions: { N: ... }` authoring.
- Adds historical version-entry types and validation.
- Keeps unversioned trails zero-cost.
- Projects version entries into `TopoGraph` with graph-only `kind`.
- Rejects authored `kind` and prevents `.v*.ts` discovery from becoming doctrine.
- Validates live fork-version `crosses` / `resources` against the topo while keeping archived entries inert.
- Adds a branch-local changeset for core/topographer package impact.

## Verification

- `bun run --cwd packages/core test`
- `bun run --cwd packages/topographer test`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/topographer typecheck`
- `.v*.ts` discovery sweep.
- Focused follow-up tests for fork dependency and cycle validation.
- Full stack-tip gate later passed through `bun run publish:check`.

## Risks / Rollout

This establishes the authoring shape but does not add runtime version selection yet. Lifecycle status behavior beyond archived/deprecated typing remains reserved for M3.

## Linear

- Linear: TRL-113
- Project: Trail Versioning