### PR TITLE
feat(core): add pure revision transpose runtime

### DIFF
--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
@@ -28,19 +28,11 @@ handoff. Meaningful review-flow changes require a new retro entry.
 | --- | --- | --- | --- | --- | --- |
 | 1 | `TRL-728` | `trl-728-docsadr-supersede-adr-0044-with-trail-versioning-v3-doctrine` | pending | locally committed | ADR-0048 and ADR-0044 supersession; local commit `a2ca7b710`. |
 | 2 | `TRL-729` | `trl-729-feattrails-settle-top-level-cli-namespace-before-versioning` | pending | locally committed | Top-level CLI namespace; local commit `ecf7fa87a`. |
-<<<<<<< HEAD
 | 3 | `TRL-113` | `trl-113-define-trail-version-versions-authoring-shape` | pending | locally committed | Source and graph authoring shape; local commit `f1a7284b2`. |
 | 4 | `TRL-114` | `trl-114-add-pure-transpose-transforms-for-revision-entries` | pending | locally committed | Pure `transpose:` revision transforms; local commit `ccaed90fa`. |
 | 5 | `TRL-739` | `trl-739-featcore-compute-content-addressed-version-markers` | pending | locally committed | Projected content-addressed markers; local commit `db49d4571`. |
 | 6 | `TRL-115` | `trl-115-resolve-trail-versions-during-execution` | pending | locally committed | Runtime version resolution; local commit `168416a5b`. |
 | 7 | `TRL-116` | `trl-116-run-examples-and-testall-across-live-version-entries` | pending | locally validated | Version-aware examples and `testAll`; branch-local commit pending. |
-=======
-| 3 | `TRL-113` | `trl-113-define-trail-version-versions-authoring-shape` | pending | in progress | Source and graph authoring shape; implementation verified and ready to commit. |
-| 4 | `TRL-114` | `trl-114-add-pure-transpose-transforms-for-revision-entries` | pending | planned | Pure `transpose:` revision transforms. |
-| 5 | `TRL-739` | `trl-739-featcore-compute-content-addressed-version-markers` | pending | planned | Projected content-addressed markers. |
-| 6 | `TRL-115` | `trl-115-resolve-trail-versions-during-execution` | pending | planned | Runtime version resolution. |
-| 7 | `TRL-116` | `trl-116-run-examples-and-testall-across-live-version-entries` | pending | planned | Version-aware examples and `testAll`. |
->>>>>>> f1a7284b2 (feat(core): add trail version authoring shape)
 
 ## Planning Discoveries
 
@@ -73,13 +65,10 @@ they represent real future work.
 | 2026-05-19 18:18 EDT | `TRL-728` | Moved to In Progress when the first execution branch started. | Linear issue update |
 | 2026-05-19 18:22 EDT | `TRL-729` | Moved to In Progress when the CLI namespace branch started. | Linear issue update |
 | 2026-05-19 18:32 EDT | `TRL-113` | Moved to In Progress when the authoring-shape branch started. | Linear issue update |
-<<<<<<< HEAD
 | 2026-05-19 18:42 EDT | `TRL-114` | Moved to In Progress when the pure-transpose branch started. | Linear issue update |
 | 2026-05-19 18:49 EDT | `TRL-739` | Moved to In Progress when the marker branch started. | Linear issue update |
 | 2026-05-19 19:03 EDT | `TRL-115` | Moved to In Progress when the runtime-resolution branch started. | Linear issue update |
 | 2026-05-19 19:26 EDT | `TRL-116` | Moved to In Progress when the examples/testAll branch started. | Linear issue update |
-=======
->>>>>>> f1a7284b2 (feat(core): add trail version authoring shape)
 
 ## Execution Log
 
@@ -148,13 +137,6 @@ Append meaningful state changes, especially before handoff points.
 - Result: TRL-728 is ready for `gt modify`; descendants need restack and the stack-tip verification must restart from `bun scripts/adr.ts map`.
 - Next: Amend TRL-728, restack descendants, then return to TRL-116.
 - Blockers: none.
-
-2026-05-19 18:39 EDT - TRL-113 authoring-shape branch
-- Changed: Created `trl-113-define-trail-version-versions-authoring-shape`, added trail-only `version` / `versions` source shape, normalized version-entry runtime data, rejected authored `kind` and invalid historical contracts, reserved `version?: never` on non-trail specs, projected version entries into `TopoGraph`, and added core/topographer tests plus a branch-local changeset.
-- Verified: Core and topographer focused tests passed; package and root typechecks passed; `bun run format:check` and `git diff --check` passed; live-code sweep found no `.v*.ts` version-file discovery.
-- Result: TRL-113 is ready for commit as the third stack branch.
-- Next: Commit TRL-113, then create the TRL-114 pure-transpose branch.
-- Blockers: none.
 ```
 
 ## Local Review Log
@@ -196,12 +178,18 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 | `git diff --check` | TRL-729 | passed | No whitespace errors. |
 | `bun run --cwd packages/core test` | TRL-113 | passed | 1116 tests, 0 failures. |
 | `bun run --cwd packages/topographer test` | TRL-113 | passed | 122 tests, 0 failures. |
-<<<<<<< HEAD
+| `bun run --cwd packages/core typecheck` | TRL-113 | passed | `tsc --noEmit` exited 0. |
+| `bun run --cwd packages/topographer typecheck` | TRL-113 | passed | `tsc --noEmit` exited 0. |
 | `bun run typecheck` | TRL-113 | passed | 22 package tasks successful. |
 | `.v*.ts` live-code sweep | TRL-113 | passed | No current code matches for version-file discovery or `.vN.ts` filenames. |
+| `bun run format:check` | TRL-113 | passed | Initial check found format/lint issues; `bun run format:fix` plus minimal lint fix cleaned them, rerun passed. |
+| `git diff --check` | TRL-113 | passed | No whitespace errors. |
 | `bun run --cwd packages/core test` | TRL-114 | passed | 1121 tests, 0 failures. |
 | `bun run --cwd packages/core typecheck` | TRL-114 | passed | `tsc --noEmit` exited 0. |
 | `bun scripts/adr.ts check` | TRL-114 | passed | 0 errors, 0 warnings. |
+| stale transpose vocabulary `rg` sweep | TRL-114 | passed | No live-code matches for stale bridge/adapter/reroute behavior beyond explicit doctrine examples. |
+| `bun run format:check` | TRL-114 | passed | Passed after `bun run format:fix` normalized touched files. |
+| `git diff --check` | TRL-114 | passed | No whitespace errors. |
 | `bun run test` | TRL-114 | passed | 37 package tasks successful. |
 | `bun run --cwd packages/core test` | TRL-739 | passed | 1126 tests, 0 failures. |
 | `bun run --cwd packages/topographer test` | TRL-739 | passed | 127 tests, 0 failures. |
@@ -219,14 +207,6 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 | `bun run --cwd apps/trails test` | TRL-116 | passed | 320 tests, 0 failures after updating the guide detail fixture for version fields. |
 | `bun run format:check` | TRL-116 | passed | Initial check found one formatting issue in `packages/testing/src/examples.ts`; targeted `bunx ultracite fix` applied; rerun passed. |
 | `git diff --check` | TRL-116 | passed | No whitespace errors. |
-=======
-| `bun run --cwd packages/core typecheck` | TRL-113 | passed | `tsc --noEmit` exited 0. |
-| `bun run --cwd packages/topographer typecheck` | TRL-113 | passed | `tsc --noEmit` exited 0. |
-| `bun run typecheck` | TRL-113 | passed | 22 package tasks successful. |
-| `.v*.ts` live-code sweep | TRL-113 | passed | No current code matches for version-file discovery or `.vN.ts` filenames. |
-| `bun run format:check` | TRL-113 | passed | Initial check found format/lint issues; `bun run format:fix` plus minimal lint fix cleaned them, rerun passed. |
-| `git diff --check` | TRL-113 | passed | No whitespace errors. |
->>>>>>> f1a7284b2 (feat(core): add trail version authoring shape)
 
 ## Remote Review / CI Log
 

--- a/.changeset/pure-transpose-revisions.md
+++ b/.changeset/pure-transpose-revisions.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/core": patch
+---
+
+Add pure revision transpose validation and execution helpers for trail versions.

--- a/docs/adr/0048-trail-versioning-v3.md
+++ b/docs/adr/0048-trail-versioning-v3.md
@@ -121,7 +121,8 @@ versions: {
 }
 ```
 
-A revision is a schema-only bridge between a historical contract and current.
+A revision is a schema-only translation path between a historical contract and
+current.
 The current blazed trail still runs. Transpose functions are pure data
 transforms: no `ctx`, no resources, no crosses, no signal firing, no permit
 state, and no surface state.

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -441,7 +441,7 @@ The schema-transform field on a revision entry. It is a pure
 `{ input, output }` pair for translating data between one historical contract
 and current.
 
-`transpose` is not an adapter. `adapter` names a package or subpath that bridges
+`transpose` is not an adapter. `adapter` names a package or subpath that connects
 Trails to an external library, framework, tool, platform, format, or ecosystem.
 `transpose` is local version-entry grammar.
 
@@ -524,7 +524,7 @@ projections; developers author the source.
 | `meta` | Annotations for tooling and filtering |
 | `Result` | Ok/Err return type |
 | `error` | Error types |
-| `adapter` | Canonical public category for a package or subpath that bridges Trails to a named external library, framework, tool, platform, format, or ecosystem |
+| `adapter` | Canonical public category for a package or subpath that connects Trails to a named external library, framework, tool, platform, format, or ecosystem |
 | `facet` | Projection slice of authored contract or surface data, such as a surface facet or schema facet; not a package category |
 | `integration (colloquial)` | Ordinary English for places Trails integrates with an external system; not a public taxonomy category |
 | `logger` / `logging` | Structured logging — framework provides the interface; developers bring their own |

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -148,6 +148,85 @@ describe('trail()', () => {
       expect('transpose' in (entry as Record<string, unknown>)).toBe(false);
     });
 
+    test('allows metadata-only revisions when equivalent schema arrays differ in order', () => {
+      const versioned = trail('metadata.reordered-schema', {
+        blaze: (input) => Result.ok({ state: input.state }),
+        input: z.object({
+          id: z.string(),
+          state: z.enum(['queued', 'sent']),
+        }),
+        output: z.object({
+          state: z.enum(['queued', 'sent']),
+        }),
+        version: 2,
+        versions: {
+          1: {
+            input: z.object({
+              id: z.string(),
+              state: z.enum(['sent', 'queued']),
+            }),
+            output: z.object({
+              state: z.enum(['sent', 'queued']),
+            }),
+          },
+        },
+      });
+
+      const entry = versioned.versions?.[1];
+      expect(entry && getTrailVersionEntryKind(entry)).toBe('revision');
+      expect('transpose' in (entry as Record<string, unknown>)).toBe(false);
+    });
+
+    test('allows metadata-only revisions when current output schema is absent', () => {
+      const versioned = trail('metadata.no-current-output', {
+        blaze: () => Result.ok(),
+        input: z.object({ id: z.string() }),
+        version: 2,
+        versions: {
+          1: {
+            input: z.object({ id: z.string() }),
+            output: z.void(),
+          },
+        },
+      });
+
+      const entry = versioned.versions?.[1];
+      expect(entry && getTrailVersionEntryKind(entry)).toBe('revision');
+      expect('transpose' in (entry as Record<string, unknown>)).toBe(false);
+    });
+
+    test('rejects schema-changing revision entries without transpose', () => {
+      expect(() =>
+        trail('missing.input.transpose', {
+          blaze: (input) => Result.ok({ id: input.id }),
+          input: z.object({ id: z.string(), requiredNow: z.string() }),
+          output: z.object({ id: z.string() }),
+          version: 2,
+          versions: {
+            1: {
+              input: z.object({ id: z.string() }),
+              output: z.object({ id: z.string() }),
+            },
+          },
+        })
+      ).toThrow(ValidationError);
+
+      expect(() =>
+        trail('missing.output.transpose', {
+          blaze: () => Result.ok({ state: 'queued' as const }),
+          input: z.object({}),
+          output: z.object({ state: z.enum(['queued', 'sent']) }),
+          version: 2,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ state: z.literal('sent') }),
+            },
+          },
+        })
+      ).toThrow(ValidationError);
+    });
+
     test('stores fork entries with normalized runtime references', () => {
       const target = trail('target.read', {
         blaze: () => Result.ok({ ok: true }),
@@ -253,6 +332,19 @@ describe('trail()', () => {
               input: z.object({}),
               output: z.object({ ok: z.boolean() }),
               resources: [dbResource],
+            } as never,
+          },
+        })
+      ).toThrow(ValidationError);
+
+      expect(() =>
+        trail('bad.revision-cross-input', {
+          ...base,
+          versions: {
+            1: {
+              crossInput: z.object({ caller: z.string() }),
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
             } as never,
           },
         })

--- a/packages/core/src/__tests__/version-runtime.test.ts
+++ b/packages/core/src/__tests__/version-runtime.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { executeTrailRevision } from '../version-runtime';
+import { Result } from '../result';
+import { trail } from '../trail';
+
+describe('executeTrailRevision', () => {
+  test('transposes historical input into current and current output back to historical', async () => {
+    let currentInput:
+      | { fullName: string; notify: boolean; source: string }
+      | undefined;
+    let inputArgCount = 0;
+    let outputArgCount = 0;
+    const createInvite = trail('invite.create', {
+      blaze: (input) => {
+        currentInput = input;
+        return Result.ok({
+          auditLevel: 'current' as const,
+          message: `Invited ${input.fullName}`,
+          state: 'sent' as const,
+        });
+      },
+      input: z.object({
+        fullName: z.string(),
+        notify: z.boolean(),
+        source: z.string(),
+      }),
+      output: z.object({
+        auditLevel: z.enum(['current', 'legacy']),
+        message: z.string(),
+        state: z.enum(['queued', 'sent']),
+      }),
+      version: 2,
+      versions: {
+        1: {
+          input: z.object({ name: z.string() }),
+          output: z.object({
+            message: z.string(),
+            state: z.literal('sent'),
+          }),
+          transpose: {
+            input(value) {
+              inputArgCount = arguments.length;
+              const historical = value.input as { name: string };
+              return {
+                fullName: historical.name,
+                notify: true,
+                source: 'v1',
+              };
+            },
+            output(value) {
+              outputArgCount = arguments.length;
+              const current = value.output as {
+                auditLevel: string;
+                message: string;
+                state: 'queued' | 'sent';
+              };
+              return { message: current.message, state: current.state };
+            },
+          },
+        },
+      },
+    });
+
+    const result = await executeTrailRevision(
+      createInvite,
+      1,
+      createInvite.versions?.[1] ?? expect.unreachable(),
+      { name: 'Ada' }
+    );
+
+    expect(result.unwrap()).toEqual({
+      message: 'Invited Ada',
+      state: 'sent',
+    });
+    expect(currentInput).toEqual({
+      fullName: 'Ada',
+      notify: true,
+      source: 'v1',
+    });
+    expect(inputArgCount).toBe(1);
+    expect(outputArgCount).toBe(1);
+  });
+
+  test('allows metadata-only revisions with matching schemas', async () => {
+    const echo = trail('echo.versioned', {
+      blaze: (input) => Result.ok({ value: input.value }),
+      input: z.object({ value: z.string() }),
+      output: z.object({ value: z.string() }),
+      version: 2,
+      versions: {
+        1: {
+          input: z.object({ value: z.string() }),
+          output: z.object({ value: z.string() }),
+        },
+      },
+    });
+
+    const result = await executeTrailRevision(
+      echo,
+      1,
+      echo.versions?.[1] ?? expect.unreachable(),
+      { value: 'stable' }
+    );
+
+    expect(result.unwrap()).toEqual({ value: 'stable' });
+  });
+
+  test('returns validation errors when transpose output violates historical output', async () => {
+    const stateTrail = trail('state.versioned', {
+      blaze: () => Result.ok({ state: 'queued' as const }),
+      input: z.object({}),
+      output: z.object({ state: z.enum(['queued', 'sent']) }),
+      version: 2,
+      versions: {
+        1: {
+          input: z.object({}),
+          output: z.object({ state: z.literal('sent') }),
+          transpose: {
+            input: ({ input }) => input,
+            output: ({ output }) => output,
+          },
+        },
+      },
+    });
+
+    const result = await executeTrailRevision(
+      stateTrail,
+      1,
+      stateTrail.versions?.[1] ?? expect.unreachable(),
+      {}
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error?.message).toContain('Output validation failed');
+  });
+
+  test('returns validation errors when transpose input violates current input', async () => {
+    const requiresCurrent = trail('requires.current', {
+      blaze: (input) => Result.ok({ id: input.id }),
+      input: z.object({ id: z.string(), requiredNow: z.string() }),
+      output: z.object({ id: z.string() }),
+      version: 2,
+      versions: {
+        1: {
+          input: z.object({ id: z.string() }),
+          output: z.object({ id: z.string() }),
+          transpose: {
+            input: ({ input }) => input,
+            output: ({ output }) => output,
+          },
+        },
+      },
+    });
+
+    const result = await executeTrailRevision(
+      requiresCurrent,
+      1,
+      requiresCurrent.versions?.[1] ?? expect.unreachable(),
+      { id: 'old' }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error?.message).toContain('requiredNow');
+  });
+});

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -28,6 +28,7 @@ import type {
   PermitRequirement,
   TrailContext,
 } from './types.js';
+import { zodToJsonSchema } from './validation.js';
 
 // ---------------------------------------------------------------------------
 // Trail example
@@ -133,6 +134,7 @@ export interface TrailVersionRevisionEntry<
   CurrentOutput = unknown,
 > extends VersionEntry<VersionContract<VersionInput, VersionOutput>> {
   readonly blaze?: never;
+  readonly crossInput?: never;
   readonly crosses?: never;
   readonly detours?: never;
   readonly kind?: never;
@@ -521,6 +523,45 @@ const assertVersionNumber = (
 const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
   Object.hasOwn(value, key);
 
+const ORDER_INSENSITIVE_SCHEMA_ARRAY_KEYS = new Set([
+  'allOf',
+  'anyOf',
+  'enum',
+  'oneOf',
+  'required',
+  'type',
+]);
+
+const canonicalizeVersionSchema = (
+  value: unknown,
+  parentKey?: string
+): unknown => {
+  if (Array.isArray(value)) {
+    const items = value.map((item) => canonicalizeVersionSchema(item));
+    return parentKey !== undefined &&
+      ORDER_INSENSITIVE_SCHEMA_ARRAY_KEYS.has(parentKey)
+      ? items.toSorted((left, right) =>
+          JSON.stringify(left).localeCompare(JSON.stringify(right))
+        )
+      : items;
+  }
+  if (value !== null && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).toSorted()) {
+      sorted[key] = canonicalizeVersionSchema(
+        (value as Record<string, unknown>)[key],
+        key
+      );
+    }
+    return sorted;
+  }
+  return value;
+};
+
+const schemasMatch = (left: z.ZodType, right: z.ZodType): boolean =>
+  JSON.stringify(canonicalizeVersionSchema(zodToJsonSchema(left))) ===
+  JSON.stringify(canonicalizeVersionSchema(zodToJsonSchema(right)));
+
 const assertZodSchema = (
   trailId: string,
   version: number,
@@ -597,7 +638,7 @@ const assertRevisionOwnsNoRuntimeFields = (
   version: number,
   entry: Record<string, unknown>
 ): void => {
-  const forbidden = ['crosses', 'resources', 'detours'];
+  const forbidden = ['crossInput', 'crosses', 'resources', 'detours'];
   const declared = forbidden.filter((field) => hasOwn(entry, field));
   if (declared.length > 0) {
     throw new ValidationError(
@@ -609,6 +650,8 @@ const assertRevisionOwnsNoRuntimeFields = (
 const normalizeVersionEntry = <CurrentInput, CurrentOutput>(
   trailId: string,
   version: number,
+  currentInput: z.ZodType<CurrentInput>,
+  currentOutput: z.ZodType<CurrentOutput> | undefined,
   entry: TrailVersionEntry<unknown, unknown, CurrentInput, CurrentOutput>
 ): TrailVersionEntry<unknown, unknown, CurrentInput, CurrentOutput> => {
   if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
@@ -671,6 +714,18 @@ const normalizeVersionEntry = <CurrentInput, CurrentOutput>(
   }
 
   assertRevisionOwnsNoRuntimeFields(trailId, version, raw);
+  const inputMatchesCurrent = schemasMatch(
+    raw['input'] as z.ZodType,
+    currentInput
+  );
+  const outputMatchesCurrent =
+    currentOutput === undefined ||
+    schemasMatch(raw['output'] as z.ZodType, currentOutput);
+  if (!hasTranspose && (!inputMatchesCurrent || !outputMatchesCurrent)) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} changes schema and must declare transpose`
+    );
+  }
 
   return Object.freeze({
     ...base,
@@ -682,6 +737,8 @@ const normalizeVersionEntry = <CurrentInput, CurrentOutput>(
 
 const normalizeTrailVersions = <CurrentInput, CurrentOutput>(
   trailId: string,
+  currentInput: z.ZodType<CurrentInput>,
+  currentOutput: z.ZodType<CurrentOutput> | undefined,
   currentVersion: number | undefined,
   versions: TrailVersions<CurrentInput, CurrentOutput> | undefined
 ): TrailVersions<CurrentInput, CurrentOutput> | undefined => {
@@ -732,6 +789,8 @@ const normalizeTrailVersions = <CurrentInput, CurrentOutput>(
     normalized[historicalVersion] = normalizeVersionEntry(
       trailId,
       historicalVersion,
+      currentInput,
+      currentOutput,
       entry
     );
   }
@@ -828,6 +887,8 @@ export function trail<I, O, CI = never>(
   const collections = normalizeCollections(resolved.spec);
   const versions = normalizeTrailVersions<I, O>(
     resolved.id,
+    resolved.spec.input,
+    resolved.spec.output,
     rawVersion,
     rawVersions
   );

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -10,7 +10,7 @@
  */
 
 import type { Signal, SignalSpec } from './signal.js';
-import type { Trail, TrailSpec } from './trail.js';
+import type { Trail, TrailSpec, TrailVersionRevisionEntry } from './trail.js';
 import type { ResourceSpec } from './resource.js';
 import type { ContourOptions } from './contour.js';
 import type { ScheduleSpec } from './schedule.js';
@@ -136,6 +136,60 @@ export type NonTrailVersionReservations = [
   AssertVersionReserved<ScheduleSpec>,
   AssertVersionReserved<WebhookSpec>,
 ] extends [true, true, true, true, true]
+  ? 'pass'
+  : never;
+
+interface RevisionInput {
+  readonly legacyName: string;
+}
+interface RevisionOutput {
+  readonly greeting: string;
+}
+interface CurrentInput {
+  readonly name: string;
+  readonly notify: boolean;
+}
+interface CurrentOutput {
+  readonly auditLevel: 'current' | 'legacy';
+  readonly greeting: string;
+}
+type RevisionTranspose = NonNullable<
+  TrailVersionRevisionEntry<
+    RevisionInput,
+    RevisionOutput,
+    CurrentInput,
+    CurrentOutput
+  >['transpose']
+>;
+
+type AssertRevisionInputTranspose = RevisionTranspose['input'] extends (value: {
+  readonly input: RevisionInput;
+}) => CurrentInput | Promise<CurrentInput>
+  ? true
+  : false;
+type AssertRevisionOutputTranspose =
+  RevisionTranspose['output'] extends (value: {
+    readonly output: CurrentOutput;
+  }) => RevisionOutput | Promise<RevisionOutput>
+    ? true
+    : false;
+type AssertRevisionNoCrossInput = TrailVersionRevisionEntry<
+  RevisionInput,
+  RevisionOutput,
+  CurrentInput,
+  CurrentOutput
+>['crossInput'] extends never | undefined
+  ? true
+  : false;
+export type RevisionTransposeContract = [
+  AssertRevisionInputTranspose,
+  AssertRevisionOutputTranspose,
+] extends [true, true]
+  ? 'pass'
+  : never;
+export type RevisionRuntimeFieldContract = [
+  AssertRevisionNoCrossInput,
+] extends [true]
   ? 'pass'
   : never;
 

--- a/packages/core/src/version-runtime.ts
+++ b/packages/core/src/version-runtime.ts
@@ -1,0 +1,119 @@
+import { InternalError, ValidationError } from './errors.js';
+import { Result } from './result.js';
+import { executeTrail } from './execute.js';
+import type { ExecuteTrailOptions } from './execute.js';
+import { getTrailVersionEntryKind } from './trail.js';
+import type { AnyTrail, TrailVersionEntry } from './trail.js';
+import { validateInput, validateOutput } from './validation.js';
+
+const normalizeTransposeError = (
+  trail: AnyTrail,
+  version: number,
+  phase: 'input' | 'output',
+  error: unknown
+): InternalError => {
+  const message = error instanceof Error ? error.message : String(error);
+  const options: { cause?: Error; context: Record<string, unknown> } = {
+    context: { phase, trailId: trail.id, version },
+  };
+  if (error instanceof Error) {
+    options.cause = error;
+  }
+  return new InternalError(
+    `Trail "${trail.id}" version ${version} transpose.${phase} failed: ${message}`,
+    options
+  );
+};
+
+const runTransposeInput = async (
+  trail: AnyTrail,
+  version: number,
+  entry: TrailVersionEntry,
+  input: unknown
+): Promise<Result<unknown, Error>> => {
+  if (entry.transpose === undefined) {
+    return Result.ok(input);
+  }
+
+  try {
+    return Result.ok(await entry.transpose.input({ input }));
+  } catch (error: unknown) {
+    return Result.err(normalizeTransposeError(trail, version, 'input', error));
+  }
+};
+
+const runTransposeOutput = async (
+  trail: AnyTrail,
+  version: number,
+  entry: TrailVersionEntry,
+  output: unknown
+): Promise<Result<unknown, Error>> => {
+  if (entry.transpose === undefined) {
+    return Result.ok(output);
+  }
+
+  try {
+    return Result.ok(await entry.transpose.output({ output }));
+  } catch (error: unknown) {
+    return Result.err(normalizeTransposeError(trail, version, 'output', error));
+  }
+};
+
+const executeCurrentTrail = async (
+  trail: AnyTrail,
+  input: unknown,
+  options?: ExecuteTrailOptions
+): Promise<Result<unknown, Error>> => {
+  const { validationSchema: _validationSchema, ...forwarded } = options ?? {};
+  return await executeTrail(trail, input, forwarded);
+};
+
+export const executeTrailRevision = async (
+  trail: AnyTrail,
+  version: number,
+  entry: TrailVersionEntry,
+  rawInput: unknown,
+  options?: ExecuteTrailOptions
+): Promise<Result<unknown, Error>> => {
+  if (getTrailVersionEntryKind(entry) !== 'revision') {
+    return Result.err(
+      new ValidationError(
+        `Trail "${trail.id}" version ${version} is not a revision entry`
+      )
+    );
+  }
+
+  const historicalInput = validateInput(entry.input, rawInput);
+  if (historicalInput.isErr()) {
+    return historicalInput;
+  }
+
+  const currentInput = await runTransposeInput(
+    trail,
+    version,
+    entry,
+    historicalInput.value
+  );
+  if (currentInput.isErr()) {
+    return currentInput;
+  }
+
+  const currentOutput = await executeCurrentTrail(
+    trail,
+    currentInput.value,
+    options
+  );
+  if (currentOutput.isErr()) {
+    return currentOutput;
+  }
+
+  const historicalOutput = await runTransposeOutput(
+    trail,
+    version,
+    entry,
+    currentOutput.value
+  );
+  return historicalOutput.isErr()
+    ? historicalOutput
+    : validateOutput(entry.output, historicalOutput.value);
+};


### PR DESCRIPTION
## Context

Stack position 4/7 for the Trail Versioning M1 + M2 stack. This PR gives historical revision entries their pure data-transform semantics before markers and runtime resolution are layered on.

## Changes

- Adds pure `transpose: { input, output }` revision transforms.
- Keeps revision transforms isolated from `ctx`, resources, crosses, detours, and surface state.
- Requires schema-changing revisions to define transpose behavior.
- Keeps same-schema metadata revisions zero-cost.
- Rejects revision-owned `crossInput` and other fork-only runtime declarations.
- Adds tests for transpose behavior and schema compatibility.
- Adds a branch-local changeset for core package impact.

## Verification

- `bun run --cwd packages/core test`
- `bun run --cwd packages/core typecheck`
- `bun scripts/adr.ts check`
- Stale transpose vocabulary sweep.
- Focused follow-up tests for revision `crossInput`, canonical schema array comparison, and absent current output-schema behavior.
- Full stack-tip gate later passed through `bun run publish:check`.

## Risks / Rollout

Revision entries remain pure transforms only. Fork entries retain `blaze:` as the place where a historical version can own runtime behavior.

## Linear

- Linear: TRL-114
- Project: Trail Versioning