### PR TITLE
feat(core): project content-addressed version markers

### DIFF
--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
@@ -17,29 +17,29 @@ handoff. Meaningful review-flow changes require a new retro entry.
 - Final outcome: pending
 - Final branch / stack tip: pending
 - Final PR range: pending
-- Final tracker state: pending
-- Final verification state: pending
-- Remaining risks / P3s: pending
-- Archive state: pending
+- Final tracker state: issues moved to In Progress; In Review pending ready PRs
+- Final verification state: branch-local checks passed through TRL-116; post-restack stack-tip gate pending
+- Remaining risks / P3s: pending local review
+- Archive state: previous HTTP/Bun observability packet archived on the lowest branch
 
 ## Branch / PR / Issue Ledger
 
 | Order | Issue | Branch | PR | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `TRL-728` | `trl-728-docsadr-supersede-adr-0044-with-trail-versioning-v3-doctrine` | pending | locally committed | ADR-0048 and ADR-0044 supersession; local commit `a2ca7b710`. |
-| 2 | `TRL-729` | `trl-729-feattrails-settle-top-level-cli-namespace-before-versioning` | pending | locally committed | Top-level CLI namespace; local commit `ecf7fa87a`. |
-| 3 | `TRL-113` | `trl-113-define-trail-version-versions-authoring-shape` | pending | locally committed | Source and graph authoring shape; local commit `f1a7284b2`. |
-| 4 | `TRL-114` | `trl-114-add-pure-transpose-transforms-for-revision-entries` | pending | locally committed | Pure `transpose:` revision transforms; local commit `ccaed90fa`. |
-| 5 | `TRL-739` | `trl-739-featcore-compute-content-addressed-version-markers` | pending | locally committed | Projected content-addressed markers; local commit `db49d4571`. |
-| 6 | `TRL-115` | `trl-115-resolve-trail-versions-during-execution` | pending | locally committed | Runtime version resolution; local commit `168416a5b`. |
-| 7 | `TRL-116` | `trl-116-run-examples-and-testall-across-live-version-entries` | pending | locally validated | Version-aware examples and `testAll`; branch-local commit pending. |
+| 1 | `TRL-728` | `trl-728-docsadr-supersede-adr-0044-with-trail-versioning-v3-doctrine` | pending | locally committed | ADR-0048, ADR-0044 supersession, plan packet, archive move, and ADR map formatting fix; current local commit `f76615916`. |
+| 2 | `TRL-729` | `trl-729-feattrails-settle-top-level-cli-namespace-before-versioning` | pending | locally built; restack in progress | Top-level `trails compile` / `trails validate` namespace and stale command cleanup. |
+| 3 | `TRL-113` | `trl-113-define-trail-version-versions-authoring-shape` | pending | locally built; restack in progress | Source and graph authoring shape for `version` / `versions`. |
+| 4 | `TRL-114` | `trl-114-add-pure-transpose-transforms-for-revision-entries` | pending | locally built; restack in progress | Pure `transpose:` revision transforms. |
+| 5 | `TRL-739` | `trl-739-featcore-compute-content-addressed-version-markers` | pending | locally built; restack pending | Projected content-addressed markers and prefix resolution. |
+| 6 | `TRL-115` | `trl-115-resolve-trail-versions-during-execution` | pending | locally built; restack pending | Runtime version resolution by number and marker prefix. |
+| 7 | `TRL-116` | `trl-116-run-examples-and-testall-across-live-version-entries` | pending | locally built; restack pending | Version-aware examples and `testAll`. |
 
 ## Planning Discoveries
 
 | Discovery | Evidence | Decision | Impact |
 | --- | --- | --- | --- |
-| `gt sync` pulled PR #530 on top of beta.18. | `git log --oneline -2`: `5d88104c6 docs: align Trails blaze language (#530)`, `4c9c26af3 chore: version packages to 1.0.0-beta.18 (#529)` | Preserve the new blaze-language styleguide in Trail Versioning docs and Linear. | Updated `TRL-728`, `TRL-120`, the project body, and M1 milestone to mention blaze grammar. |
-| Graphite cannot clean merged branch `trl-735-blaze-language-styleguide` because it is checked out in another worktree. | `gt sync` warning and `context-prime.sh` worktree list. | Treat as non-blocking for this stack. | Preflight tells executor to continue from clean `main`. |
+| `gt sync` pulled PR #530 on top of beta.18. | `git log --oneline -2`: `5d88104c6 docs: align Trails blaze language (#530)`, `4c9c26af3 chore: version packages to 1.0.0-beta.18 (#529)` | Preserve the new blaze-language styleguide in Trail Versioning docs and Linear. | Updated TRL-728 scope, TRL-120 wording, project body, and M1 milestone. |
+| Graphite cannot clean merged branch `trl-735-blaze-language-styleguide` because it is checked out in another worktree. | `gt sync` warning and `context-prime.sh` worktree list. | Treat as non-blocking for this stack. | Continued from clean `main`. |
 | Existing previous active packet was still tracked. | `git ls-files .agents/plans/2026-05-16-http-bun-observability-closeout` listed tracked files. | Move it to archive on the lowest execution branch because that stack was complete. | TRL-728 owns the archive move. |
 | `context-prime.sh` hit a known local jq option failure while scanning open PRs. | Command output: `jq: Unknown option --argfile`. | Treat primer as advisory; verify PR state directly. | PR #531 was verified directly and is not a base. |
 | Linear stale-term sweep was clean after updates. | Linear search returned no active issue hits for stale doctrine terms. | Proceed to packet. | No extra versioning follow-up issues needed before kickoff. |
@@ -83,59 +83,51 @@ Append meaningful state changes, especially before handoff points.
 - Blockers: none known.
 
 2026-05-19 18:20 EDT - preflight and TRL-728 branch start
-- Changed: Ran fresh `gt sync`, confirmed `main` at `5d88104c6`, created `trl-728-docsadr-supersede-adr-0044-with-trail-versioning-v3-doctrine`, moved the completed HTTP/Bun observability packet to `.agents/plans/archive/`, and added ADR-0048 plus ADR/lexicon/styleguide updates.
-- Verified: `git status --short --branch` on `main` showed only the new versioning packet before branching; PR #531 is draft, based on `main`, and not a required base; Linear issue text and branch names match the packet; `bun scripts/adr.ts map` and `bun scripts/adr.ts check` passed.
-- Result: Lowest execution branch owns the plan packet commit, previous completed packet archive move, and TRL-728 docs/ADR scope.
-- Next: Run focused TRL-728 docs checks, commit, then create the TRL-729 CLI namespace branch.
+- Changed: Ran fresh gt sync, confirmed main at 5d88104c6, created the TRL-728 branch, moved the completed HTTP/Bun observability packet to archive, and added ADR-0048 plus ADR/lexicon/styleguide updates.
+- Verified: main status, PR #531 base/unrelated state, Linear issue text/branch names, bun scripts/adr.ts map, and bun scripts/adr.ts check.
+- Result: Lowest execution branch owns the plan packet, previous packet archive move, and TRL-728 docs/ADR scope.
 - Blockers: none.
 
 2026-05-19 18:27 EDT - TRL-729 CLI namespace branch
-- Changed: Created `trl-729-feattrails-settle-top-level-cli-namespace-before-versioning`, promoted the app trails from `topo.compile`/`topo.verify` to top-level `compile`/`validate`, updated docs/tests/Warden/topographer stale-command copy, and added a branch-local changeset.
-- Verified: App, topographer, and Warden focused test suites passed; `trails --help`, `trails compile --help`, and `trails validate --help` expose the new top-level commands; stale current-facing command sweep returned no matches; formatting and `git diff --check` passed after a repo formatter pass.
-- Result: TRL-729 is locally committed as the second stack branch.
-- Next: Create the TRL-113 authoring-shape branch.
+- Changed: Promoted app trails from topo.compile/topo.verify to top-level compile/validate, updated docs/tests/Warden/topographer stale-command copy, and added a branch-local changeset.
+- Verified: App, topographer, and Warden focused tests; CLI help for trails, compile, and validate; stale command sweep; format and diff checks.
+- Result: TRL-729 locally built.
 - Blockers: none.
 
 2026-05-19 18:39 EDT - TRL-113 authoring-shape branch
-- Changed: Created `trl-113-define-trail-version-versions-authoring-shape`, added trail-only `version` / `versions` source shape, normalized version-entry runtime data, rejected authored `kind` and invalid historical contracts, reserved `version?: never` on non-trail specs, projected version entries into `TopoGraph`, and added core/topographer tests plus a branch-local changeset.
-- Verified: Core and topographer focused tests passed; package and root typechecks passed; `bun run format:check` and `git diff --check` passed; live-code sweep found no `.v*.ts` version-file discovery.
-- Result: TRL-113 is locally committed as the third stack branch.
-- Next: Create the TRL-114 pure-transpose branch.
+- Changed: Added trail-only version/versions source shape, normalized version-entry runtime data, rejected authored kind and invalid historical contracts, reserved version?: never on non-trail specs, projected entries into TopoGraph, and added tests/changeset.
+- Verified: Core/topographer tests, package and root typechecks, format, diff check, and no .v*.ts discovery sweep.
+- Result: TRL-113 locally built.
 - Blockers: none.
 
 2026-05-19 18:48 EDT - TRL-114 pure-transpose branch
-- Changed: Created `trl-114-add-pure-transpose-transforms-for-revision-entries`, added pure revision transpose validation and internal execution helpers, required `transpose:` for schema-changing revisions, kept same-schema metadata revisions zero-cost, added core runtime/type tests, and added a branch-local changeset.
-- Verified: Core focused tests and typecheck passed; root `bun run test` passed; `bun scripts/adr.ts check`, `bun run format:check`, and `git diff --check` passed; stale bridge/adapter/reroute vocabulary sweep found no live-code drift beyond explicit doctrine examples.
-- Result: TRL-114 is locally committed as the fourth stack branch.
-- Next: Create the TRL-739 marker branch.
+- Changed: Added pure revision transpose validation and execution helpers, required transpose for schema-changing revisions, kept same-schema metadata revisions zero-cost, and added tests/changeset.
+- Verified: Core focused tests/typecheck, root test, ADR check, format, diff check, and stale transpose vocabulary sweep.
+- Result: TRL-114 locally built.
 - Blockers: none.
 
 2026-05-19 18:59 EDT - TRL-739 marker branch
-- Changed: Created `trl-739-featcore-compute-content-addressed-version-markers`, added core marker hashing/prefix helpers, rejected authored `marker:` fields, projected 16-character markers into current and historical TopoGraph entries from the same core identity source runtime will use, added unambiguous marker-prefix resolution helpers, guarded unsupported empty schema projections, and added a branch-local changeset.
-- Verified: Core and topographer focused tests passed; root `bun run typecheck`, `bun run format:check`, and `git diff --check` passed.
-- Result: TRL-739 is locally committed as the fifth stack branch.
-- Next: Create the TRL-115 runtime resolution branch.
+- Changed: Added core marker hashing/prefix helpers, rejected authored marker fields, projected 16-character markers into current and historical TopoGraph entries, added unambiguous marker-prefix helpers, and added tests/changeset.
+- Verified: Core/topographer focused tests, root typecheck, format, and diff check.
+- Result: TRL-739 locally built.
 - Blockers: none.
 
 2026-05-19 19:25 EDT - TRL-115 runtime-resolution branch
-- Changed: Created `trl-115-resolve-trail-versions-during-execution`, added runtime version reference parsing/resolution, introduced `VersionNotSupportedError`, wired `executeTrail` and `run()` to resolve current/revision/fork versions by number or marker prefix, kept `ctx.cross()` current by default while allowing explicit version pins, preserved versioned fork cross validation, avoided an `execute.ts` / `version-runtime.ts` import cycle by passing the current executor as a callback, updated direct revision-runtime tests, and added a branch-local changeset.
-- Verified: Focused runtime/version tests passed; full `@ontrails/core` test suite passed; root `bun run typecheck`, `bun run format:check`, and `git diff --check` passed.
-- Result: TRL-115 is locally committed as the sixth stack branch.
-- Next: Create the TRL-116 examples/testAll branch.
+- Changed: Added runtime version reference parsing/resolution, VersionNotSupportedError, executeTrail/run version resolution, current-default ctx.cross(), explicit version pins, fork cross validation, and tests/changeset.
+- Verified: Focused runtime/version tests, full core tests, root typecheck, format, and diff check.
+- Result: TRL-115 locally built.
 - Blockers: none.
 
 2026-05-19 19:36 EDT - TRL-116 examples/testAll branch
-- Changed: Created `trl-116-run-examples-and-testall-across-live-version-entries`, made version-entry examples first-class on historical entries, validated them against historical schemas, projected version-entry examples into TopoGraph and survey/guide detail output, made `testExamples`, `testContracts`, and `testAll` run current plus live historical entries, preserved archived entries as non-live, forwarded version references through testing cross coverage, and added a branch-local changeset.
-- Verified: Focused core, testing, topographer, and Trails app suites passed; focused package/app typechecks passed; `bun run format:check` and `git diff --check` passed after one targeted formatter fix.
-- Result: TRL-116 is ready for commit as the seventh stack branch.
-- Next: Commit TRL-116, restack, then run full stack-tip verification before the required three local review rounds.
+- Changed: Added version-entry examples, historical example validation/projection, survey/guide version detail output, version-aware testExamples/testContracts/testAll, archived-entry skip behavior, and testing cross version forwarding.
+- Verified: Focused core/testing/topographer/Trails app suites, focused package/app typechecks, root format, root typecheck, root lint, root test, and diff check.
+- Result: TRL-116 locally built and committed before the owning-branch fix.
 - Blockers: none.
 
 2026-05-19 19:40 EDT - TRL-728 owning-branch verification fix
-- Changed: While running the stack-tip gate, `bun scripts/adr.ts map` exposed that the ADR decision-map generator could compact an ADR-0048 `depends_on` array in a way `bun run format:check` immediately expanded. Fixed the generator's inline primitive-array threshold on the lowest owning ADR branch so `adr map` and the repo formatter agree.
-- Verified: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run format:check`, and `git diff --check` passed on `trl-728-docsadr-supersede-adr-0044-with-trail-versioning-v3-doctrine`.
-- Result: TRL-728 is ready for `gt modify`; descendants need restack and the stack-tip verification must restart from `bun scripts/adr.ts map`.
-- Next: Amend TRL-728, restack descendants, then return to TRL-116.
+- Changed: Fixed ADR decision-map inline primitive-array formatting threshold on the lowest owning ADR branch so adr map and format:check agree.
+- Verified: bun scripts/adr.ts map, bun scripts/adr.ts check, bun run format:check, and git diff --check passed on TRL-728.
+- Result: TRL-728 amended to f76615916; descendants are being restacked.
 - Blockers: none.
 ```
 
@@ -155,26 +147,24 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 | `gt sync` | `main` | passed | Pulled PR #530; warned about merged branch in another worktree. |
 | `git status --short --branch` | `main` after sync | passed | `## main...origin/main` before packet creation. |
 | Linear stale-term search | Trail Versioning issues | passed | No active hits after updates for stale doctrine terms. |
-| `gt sync` | `main` goal preflight | passed | `ok synced`; same checked-out-worktree warning for merged `trl-735-blaze-language-styleguide`. |
-| `git status --short --branch` | `main` goal preflight | passed | `## main...origin/main`; only `.agents/plans/2026-05-19-trail-versioning-m1-m2/` untracked. |
 | `gh pr view 531 --json ...` | preflight | passed | PR #531 is `trl-738-add-codex-clark-agent-wiring`, draft/open, base `main`, unrelated to versioning stack. |
 | `bun scripts/adr.ts map` | TRL-728 | passed | Updated ADR decision map after ADR-0048 and supersession edits. |
 | `bun scripts/adr.ts check` | TRL-728 | passed | 0 errors, 0 warnings. |
-| `bun run format:check` | TRL-728 | passed | Passed after `bun run format:fix` normalized generated ADR map formatting. |
+| `bun run format:check` | TRL-728 | passed | Passed after generated ADR map formatting cleanup. |
 | `git diff --check` | TRL-728 | passed | No whitespace errors. |
 | `bun scripts/adr.ts map` | TRL-728 owning-branch fix | passed | Re-generated maps after aligning ADR JSON inline-array threshold with formatter expectations. |
 | `bun scripts/adr.ts check` | TRL-728 owning-branch fix | passed | 0 errors, 0 warnings. |
-| `bun run format:check` | TRL-728 owning-branch fix | passed | Passed after ADR generator threshold fix; no generated JSON formatter drift. |
+| `bun run format:check` | TRL-728 owning-branch fix | passed | Passed after ADR generator threshold fix. |
 | `git diff --check` | TRL-728 owning-branch fix | passed | No whitespace errors. |
 | `bun run --cwd apps/trails test` | TRL-729 | passed | 318 tests, 0 failures. |
 | `bun run --cwd apps/trails typecheck` | TRL-729 | passed | `tsc --noEmit` exited 0. |
 | `bun run --cwd packages/topographer test` | TRL-729 | passed | 121 tests, 0 failures. |
 | `bun run --cwd packages/warden test` | TRL-729 | passed | 888 tests, 0 failures. |
-| stale command `rg` sweep | TRL-729 | passed | No current-facing matches for retired `trails topo compile` / `trails topo verify` names outside historical ADR/draft/changelog exclusions. |
-| `bun apps/trails/bin/trails.ts --help` | TRL-729 | passed | Shows top-level `compile` and `validate`; no `topo compile`/`topo verify` commands. |
+| stale command `rg` sweep | TRL-729 | passed | No current-facing matches for retired topo compile/verify names outside historical exclusions. |
+| `bun apps/trails/bin/trails.ts --help` | TRL-729 | passed | Shows top-level compile and validate. |
 | `bun apps/trails/bin/trails.ts compile --help` | TRL-729 | passed | Top-level compile command renders expected help. |
 | `bun apps/trails/bin/trails.ts validate --help` | TRL-729 | passed | Top-level validate command renders expected help. |
-| `bun run format:check` | TRL-729 | passed | Initial check found two files; `bun run format:fix` applied mechanical cleanup, rerun passed. |
+| `bun run format:check` | TRL-729 | passed | Passed after formatter cleanup. |
 | `git diff --check` | TRL-729 | passed | No whitespace errors. |
 | `bun run --cwd packages/core test` | TRL-113 | passed | 1116 tests, 0 failures. |
 | `bun run --cwd packages/topographer test` | TRL-113 | passed | 122 tests, 0 failures. |
@@ -182,13 +172,13 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 | `bun run --cwd packages/topographer typecheck` | TRL-113 | passed | `tsc --noEmit` exited 0. |
 | `bun run typecheck` | TRL-113 | passed | 22 package tasks successful. |
 | `.v*.ts` live-code sweep | TRL-113 | passed | No current code matches for version-file discovery or `.vN.ts` filenames. |
-| `bun run format:check` | TRL-113 | passed | Initial check found format/lint issues; `bun run format:fix` plus minimal lint fix cleaned them, rerun passed. |
+| `bun run format:check` | TRL-113 | passed | Passed after formatter cleanup and minimal lint fix. |
 | `git diff --check` | TRL-113 | passed | No whitespace errors. |
 | `bun run --cwd packages/core test` | TRL-114 | passed | 1121 tests, 0 failures. |
 | `bun run --cwd packages/core typecheck` | TRL-114 | passed | `tsc --noEmit` exited 0. |
 | `bun scripts/adr.ts check` | TRL-114 | passed | 0 errors, 0 warnings. |
-| stale transpose vocabulary `rg` sweep | TRL-114 | passed | No live-code matches for stale bridge/adapter/reroute behavior beyond explicit doctrine examples. |
-| `bun run format:check` | TRL-114 | passed | Passed after `bun run format:fix` normalized touched files. |
+| stale transpose vocabulary `rg` sweep | TRL-114 | passed | No live-code matches for stale bridge/adapter/reroute behavior beyond doctrine examples. |
+| `bun run format:check` | TRL-114 | passed | Passed after formatter cleanup. |
 | `git diff --check` | TRL-114 | passed | No whitespace errors. |
 | `bun run test` | TRL-114 | passed | 37 package tasks successful. |
 | `bun run --cwd packages/core test` | TRL-739 | passed | 1126 tests, 0 failures. |
@@ -204,8 +194,11 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 | `bun run --cwd packages/core test` | TRL-116 | passed | 1149 tests, 0 failures. |
 | `bun run --cwd packages/testing test` | TRL-116 | passed | 176 tests, 0 failures. |
 | `bun run --cwd packages/topographer test` | TRL-116 | passed | 129 tests, 0 failures. |
-| `bun run --cwd apps/trails test` | TRL-116 | passed | 320 tests, 0 failures after updating the guide detail fixture for version fields. |
-| `bun run format:check` | TRL-116 | passed | Initial check found one formatting issue in `packages/testing/src/examples.ts`; targeted `bunx ultracite fix` applied; rerun passed. |
+| `bun run --cwd apps/trails test` | TRL-116 | passed | 320 tests, 0 failures. |
+| `bun run format:check` | TRL-116 | passed | Passed after targeted formatter cleanup. |
+| `bun run typecheck` | stack tip before owning fix | passed | 22 package tasks successful. |
+| `bun run lint` | stack tip before owning fix | passed | Root lint passed. |
+| `bun run test` | stack tip before owning fix | passed | 37 package tasks successful. |
 | `git diff --check` | TRL-116 | passed | No whitespace errors. |
 
 ## Remote Review / CI Log
@@ -227,5 +220,6 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 
 ## Final State
 
-Pending local review, draft PR submission, CI, ready-for-review, remote review,
-Linear In Review updates, and final handoff.
+Pending restack completion, stack-tip verification, local review, draft PR
+submission, CI, ready-for-review, remote review, Linear In Review updates, and
+final handoff.

--- a/.changeset/trail-version-markers.md
+++ b/.changeset/trail-version-markers.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/core": patch
+"@ontrails/topographer": patch
+---
+
+Project content-addressed trail version markers and marker-prefix resolution.

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -364,6 +364,26 @@ describe('trail()', () => {
       ).toThrow(ValidationError);
 
       expect(() =>
+        trail('bad.marker', {
+          ...base,
+          marker: 'abcd000000000000',
+        } as never)
+      ).toThrow(ValidationError);
+
+      expect(() =>
+        trail('bad.version-marker', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              marker: 'abcd000000000000',
+              output: z.object({ ok: z.boolean() }),
+            } as never,
+          },
+        })
+      ).toThrow(ValidationError);
+
+      expect(() =>
         trail('bad.current-duplicate', {
           ...base,
           versions: {

--- a/packages/core/src/__tests__/version-marker.test.ts
+++ b/packages/core/src/__tests__/version-marker.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { AmbiguousError, ValidationError } from '../errors.js';
+import {
+  TRAIL_VERSION_MARKER_LENGTH,
+  canonicalizeTrailVersionMarkerContent,
+  deriveCurrentTrailVersionMarker,
+  deriveCurrentTrailVersionMarkerContent,
+  deriveShortestUnambiguousTrailVersionMarkerPrefix,
+  deriveTrailVersionMarker,
+  resolveTrailVersionMarkerPrefix,
+} from '../version-marker.js';
+
+describe('trail version markers', () => {
+  test('hashes canonicalized content into a 16-character marker', () => {
+    const left = deriveTrailVersionMarker({
+      input: { properties: { id: { type: 'string' } }, type: 'object' },
+      output: { type: 'object' },
+    });
+    const right = deriveTrailVersionMarker({
+      input: { properties: { id: { type: 'string' } }, type: 'object' },
+      output: { type: 'object' },
+    });
+
+    expect(left).toBe(right);
+    expect(left).toHaveLength(TRAIL_VERSION_MARKER_LENGTH);
+    expect(left).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test('current marker content includes stable runtime contract references', () => {
+    class MarkerConflictError extends Error {}
+
+    const base = {
+      crosses: [],
+      detours: [],
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+      resources: [],
+    };
+    const current = {
+      ...base,
+      crosses: ['audit.log'],
+      detours: [{ maxAttempts: 3, on: MarkerConflictError, recover: () => {} }],
+      resources: [{ id: 'db.main' }],
+    };
+
+    const content = deriveCurrentTrailVersionMarkerContent(current as never);
+
+    expect(content).toMatchObject({
+      crosses: ['audit.log'],
+      detours: [{ maxAttempts: 3, on: 'MarkerConflictError' }],
+      resources: ['db.main'],
+    });
+    expect(deriveCurrentTrailVersionMarker(base as never)).not.toBe(
+      deriveCurrentTrailVersionMarker(current as never)
+    );
+  });
+
+  test('rejects unsupported marker content instead of stringifying it', () => {
+    expect(() =>
+      canonicalizeTrailVersionMarkerContent({ schema: undefined })
+    ).not.toThrow();
+    expect(() =>
+      canonicalizeTrailVersionMarkerContent({ parse: () => {} })
+    ).toThrow(ValidationError);
+    expect(() =>
+      canonicalizeTrailVersionMarkerContent({ createdAt: new Date() })
+    ).toThrow(ValidationError);
+  });
+
+  test('derives shortest unambiguous display prefixes with a length floor', () => {
+    const marker = 'abcd000000000000';
+    const display = deriveShortestUnambiguousTrailVersionMarkerPrefix(marker, [
+      marker,
+      'abce000000000000',
+      'f000000000000000',
+    ]);
+
+    expect(display).toBe('abcd');
+  });
+
+  test('resolves marker prefixes and rejects invalid or ambiguous prefixes', () => {
+    const markers = [
+      { marker: 'abcd000000000000', version: 1 },
+      { marker: 'abcd100000000000', version: 2 },
+      { marker: 'f000000000000000', version: 3 },
+    ];
+
+    expect(resolveTrailVersionMarkerPrefix(markers, 'f000')).toEqual({
+      marker: 'f000000000000000',
+      prefix: 'f000',
+      version: 3,
+    });
+    expect(resolveTrailVersionMarkerPrefix(markers, 'ABCD1')).toEqual({
+      marker: 'abcd100000000000',
+      prefix: 'abcd1',
+      version: 2,
+    });
+    expect(() => resolveTrailVersionMarkerPrefix(markers, 'abc')).toThrow(
+      ValidationError
+    );
+    expect(() => resolveTrailVersionMarkerPrefix(markers, 'abcf')).toThrow(
+      ValidationError
+    );
+    expect(() => resolveTrailVersionMarkerPrefix(markers, 'abcd')).toThrow(
+      AmbiguousError
+    );
+  });
+
+  test('reports full-marker ambiguity when duplicate markers exist', () => {
+    expect(() =>
+      deriveShortestUnambiguousTrailVersionMarkerPrefix('abcd000000000000', [
+        'abcd000000000000',
+        'abcd000000000000',
+      ])
+    ).toThrow(AmbiguousError);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -164,6 +164,22 @@ export {
   isArchivedTrailVersionEntry,
   trail,
 } from './trail.js';
+export {
+  TRAIL_VERSION_MARKER_LENGTH,
+  TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH,
+  assertTrailVersionMarker,
+  assertUniqueTrailVersionMarkers,
+  canonicalizeTrailVersionMarkerContent,
+  deriveCurrentTrailVersionMarker,
+  deriveCurrentTrailVersionMarkerContent,
+  deriveShortestUnambiguousTrailVersionMarkerPrefix,
+  deriveTrailVersionEntryMarker,
+  deriveTrailVersionEntryMarkerContent,
+  deriveTrailVersionMarker,
+  deriveTrailVersionMarkers,
+  normalizeTrailVersionMarkerPrefix,
+  resolveTrailVersionMarkerPrefix,
+} from './version-marker.js';
 export type {
   AnyTrail,
   BlazeInput,
@@ -185,6 +201,11 @@ export type {
   VersionContract,
   VersionEntry,
 } from './trail.js';
+export type {
+  TrailVersionMarkerBinding,
+  TrailVersionMarkerRecord,
+  TrailVersionMarkerResolution,
+} from './version-marker.js';
 export {
   filterSurfaceTrails,
   matchesTrailPattern,

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -104,6 +104,7 @@ export interface VersionEntry<
   TContract extends VersionContract = VersionContract,
 > {
   readonly input: z.ZodType<TContract['input']>;
+  readonly marker?: never;
   readonly output: z.ZodType<TContract['output']>;
   readonly status?: TrailVersionStatus | undefined;
 }
@@ -317,6 +318,8 @@ export interface TrailSpec<I, O, CI = never> {
   readonly version?: number | undefined;
   /** Explicit historical trail versions. Current stays top-level. */
   readonly versions?: TrailVersions<I, O> | undefined;
+  /** Version markers are projected into the resolved graph, not authored. */
+  readonly marker?: never;
 }
 
 // ---------------------------------------------------------------------------
@@ -669,6 +672,11 @@ const normalizeVersionEntry = <CurrentInput, CurrentOutput>(
       `Trail "${trailId}" version ${version} must not author kind; it is projected`
     );
   }
+  if (hasOwn(raw, 'marker')) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} must not author marker; it is projected`
+    );
+  }
 
   const hasBlaze = typeof raw['blaze'] === 'function';
   const hasTranspose = raw['transpose'] !== undefined;
@@ -864,6 +872,11 @@ export function trail<I, O, CI = never>(
 
   if (!resolved.spec) {
     throw new TypeError('trail() requires a spec when an id is provided');
+  }
+  if (hasOwn(resolved.spec as unknown as Record<string, unknown>, 'marker')) {
+    throw new ValidationError(
+      `Trail "${resolved.id}" must not author marker; it is projected`
+    );
   }
 
   const {

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -127,6 +127,16 @@ export type TrailVersionAllowed = [AssertTrailVersionAllowed] extends [true]
   ? 'pass'
   : never;
 
+type AssertTrailMarkerProjected = TrailSpec<
+  { name: string },
+  { id: string }
+>['marker'] extends never | undefined
+  ? true
+  : false;
+export type TrailMarkerProjected = [AssertTrailMarkerProjected] extends [true]
+  ? 'pass'
+  : never;
+
 type AssertVersionReserved<T extends { readonly version?: never }> =
   T['version'] extends never | undefined ? true : false;
 export type NonTrailVersionReservations = [
@@ -161,6 +171,20 @@ type RevisionTranspose = NonNullable<
     CurrentOutput
   >['transpose']
 >;
+
+type AssertRevisionMarkerProjected = TrailVersionRevisionEntry<
+  RevisionInput,
+  RevisionOutput,
+  CurrentInput,
+  CurrentOutput
+>['marker'] extends never | undefined
+  ? true
+  : false;
+export type RevisionMarkerProjected = [AssertRevisionMarkerProjected] extends [
+  true,
+]
+  ? 'pass'
+  : never;
 
 type AssertRevisionInputTranspose = RevisionTranspose['input'] extends (value: {
   readonly input: RevisionInput;

--- a/packages/core/src/version-marker.ts
+++ b/packages/core/src/version-marker.ts
@@ -1,0 +1,413 @@
+import { DETOUR_MAX_ATTEMPTS_CAP } from './detours.js';
+import { AmbiguousError, ValidationError } from './errors.js';
+import { isPlainObject } from './guards.js';
+import {
+  getTrailVersionEntryKind,
+  isArchivedTrailVersionEntry,
+} from './trail.js';
+import type { AnyTrail, TrailVersionEntry } from './trail.js';
+import { zodToJsonSchema } from './validation.js';
+
+export const TRAIL_VERSION_MARKER_LENGTH = 16;
+export const TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH = 4;
+
+export interface TrailVersionMarkerBinding {
+  readonly marker: string;
+  readonly version: number;
+}
+
+export interface TrailVersionMarkerResolution extends TrailVersionMarkerBinding {
+  readonly prefix: string;
+}
+
+export interface TrailVersionMarkerRecord extends TrailVersionMarkerBinding {
+  readonly current: boolean;
+  readonly kind: 'current' | 'fork' | 'revision';
+  readonly supported: boolean;
+}
+
+const markerPattern = /^[0-9a-f]{16}$/;
+const markerPrefixPattern = /^[0-9a-f]+$/;
+
+const markerValuePath = (path: readonly string[]): string =>
+  path.length === 0 ? '<root>' : path.join('.');
+
+const assertMarkerContentSupported = (
+  value: unknown,
+  path: readonly string[] = []
+): void => {
+  if (Array.isArray(value)) {
+    for (const [index, entry] of value.entries()) {
+      assertMarkerContentSupported(entry, [...path, String(index)]);
+    }
+    return;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length === 0 && path.at(-1) !== 'properties') {
+    throw new ValidationError(
+      `Trail version marker content at ${markerValuePath(path)} contains an unsupported empty schema projection`
+    );
+  }
+
+  for (const key of keys) {
+    assertMarkerContentSupported(record[key], [...path, key]);
+  }
+};
+
+const canonicalizeMarkerValue = (
+  value: unknown,
+  path: readonly string[],
+  seen: WeakSet<object>
+): unknown => {
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'number' ||
+    typeof value === 'string'
+  ) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry, index) =>
+      canonicalizeMarkerValue(entry, [...path, String(index)], seen)
+    );
+  }
+
+  if (value === undefined) {
+    throw new ValidationError(
+      `Trail version marker content cannot contain undefined at ${markerValuePath(path)}`
+    );
+  }
+
+  if (typeof value === 'bigint' || typeof value === 'function') {
+    throw new ValidationError(
+      `Trail version marker content cannot contain ${typeof value} at ${markerValuePath(path)}`
+    );
+  }
+
+  if (typeof value === 'symbol') {
+    throw new ValidationError(
+      `Trail version marker content cannot contain symbol at ${markerValuePath(path)}`
+    );
+  }
+
+  if (!isPlainObject(value)) {
+    throw new ValidationError(
+      `Trail version marker content must be JSON-compatible at ${markerValuePath(path)}`
+    );
+  }
+
+  if (seen.has(value)) {
+    throw new ValidationError(
+      `Trail version marker content cannot contain circular references at ${markerValuePath(path)}`
+    );
+  }
+  seen.add(value);
+
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).toSorted()) {
+    const next = value[key];
+    if (next !== undefined) {
+      sorted[key] = canonicalizeMarkerValue(next, [...path, key], seen);
+    }
+  }
+
+  seen.delete(value);
+  return sorted;
+};
+
+export const canonicalizeTrailVersionMarkerContent = (
+  content: unknown
+): unknown => canonicalizeMarkerValue(content, [], new WeakSet<object>());
+
+export const deriveTrailVersionMarker = (content: unknown): string => {
+  assertMarkerContentSupported(content);
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(JSON.stringify(canonicalizeTrailVersionMarkerContent(content)));
+  return hasher.digest('hex').slice(0, TRAIL_VERSION_MARKER_LENGTH);
+};
+
+const projectSchema = (schema: unknown): unknown =>
+  canonicalizeTrailVersionMarkerContent(zodToJsonSchema(schema as never));
+
+const projectVersionDetours = (
+  entry: unknown
+): readonly Record<string, unknown>[] | undefined => {
+  const raw = entry as unknown as Record<string, unknown>;
+  const { detours } = raw;
+  if (!Array.isArray(detours) || detours.length === 0) {
+    return undefined;
+  }
+
+  return detours.map((detour) => {
+    const candidate = detour as {
+      readonly maxAttempts?: number | undefined;
+      readonly on?: { readonly name?: string | undefined } | undefined;
+    };
+    return {
+      maxAttempts: Math.max(
+        1,
+        Math.min(candidate.maxAttempts ?? 1, DETOUR_MAX_ATTEMPTS_CAP)
+      ),
+      on: candidate.on?.name ?? 'Error',
+    };
+  });
+};
+
+const projectVersionRuntimeRefs = (
+  entry: unknown,
+  field: 'crosses' | 'resources'
+): readonly string[] | undefined => {
+  const raw = entry as unknown as Record<string, unknown>;
+  const values = raw[field];
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined;
+  }
+
+  const refs: string[] = [];
+  for (const value of values) {
+    if (typeof value === 'string') {
+      refs.push(value);
+      continue;
+    }
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as { readonly id?: unknown }).id === 'string'
+    ) {
+      refs.push((value as { readonly id: string }).id);
+    }
+  }
+
+  return refs.toSorted();
+};
+
+export const deriveCurrentTrailVersionMarkerContent = (
+  trail: Pick<
+    AnyTrail,
+    'crosses' | 'detours' | 'input' | 'output' | 'resources'
+  >
+): Readonly<Record<string, unknown>> => {
+  const content: Record<string, unknown> = {
+    input: projectSchema(trail.input),
+    kind: 'current',
+    ...(trail.output === undefined
+      ? {}
+      : { output: projectSchema(trail.output) }),
+  };
+
+  const crosses = projectVersionRuntimeRefs(trail, 'crosses');
+  const resources = projectVersionRuntimeRefs(trail, 'resources');
+  const detours = projectVersionDetours(trail);
+  if (crosses !== undefined) {
+    content['crosses'] = crosses;
+  }
+  if (resources !== undefined) {
+    content['resources'] = resources;
+  }
+  if (detours !== undefined) {
+    content['detours'] = detours;
+  }
+
+  return content;
+};
+
+export const deriveTrailVersionEntryMarkerContent = (
+  entry: TrailVersionEntry
+): Readonly<Record<string, unknown>> => {
+  const kind = getTrailVersionEntryKind(entry);
+  const content: Record<string, unknown> = {
+    input: projectSchema(entry.input),
+    kind,
+    output: projectSchema(entry.output),
+  };
+
+  if (kind === 'revision' && entry.transpose !== undefined) {
+    content['transpose'] = { input: true, output: true };
+  }
+
+  if (kind === 'fork') {
+    const crosses = projectVersionRuntimeRefs(entry, 'crosses');
+    const resources = projectVersionRuntimeRefs(entry, 'resources');
+    const detours = projectVersionDetours(entry);
+    if (crosses !== undefined) {
+      content['crosses'] = crosses;
+    }
+    if (resources !== undefined) {
+      content['resources'] = resources;
+    }
+    if (detours !== undefined) {
+      content['detours'] = detours;
+    }
+  }
+
+  return content;
+};
+
+export const deriveCurrentTrailVersionMarker = (
+  trail: Pick<
+    AnyTrail,
+    'crosses' | 'detours' | 'input' | 'output' | 'resources'
+  >
+): string =>
+  deriveTrailVersionMarker(deriveCurrentTrailVersionMarkerContent(trail));
+
+export const deriveTrailVersionEntryMarker = (
+  entry: TrailVersionEntry
+): string =>
+  deriveTrailVersionMarker(deriveTrailVersionEntryMarkerContent(entry));
+
+export const assertTrailVersionMarker = (marker: string): void => {
+  if (!markerPattern.test(marker)) {
+    throw new ValidationError(
+      `Trail version marker must be a ${TRAIL_VERSION_MARKER_LENGTH}-character lowercase SHA-256 prefix`
+    );
+  }
+};
+
+export const normalizeTrailVersionMarkerPrefix = (prefix: string): string => {
+  const normalized = prefix.toLowerCase();
+  if (
+    normalized.length < TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH ||
+    normalized.length > TRAIL_VERSION_MARKER_LENGTH ||
+    !markerPrefixPattern.test(normalized)
+  ) {
+    throw new ValidationError(
+      `Trail version marker prefix must be ${TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH}-${TRAIL_VERSION_MARKER_LENGTH} lowercase hexadecimal characters`
+    );
+  }
+  return normalized;
+};
+
+export const assertUniqueTrailVersionMarkers = (
+  trailId: string,
+  markers: readonly TrailVersionMarkerBinding[]
+): void => {
+  const byMarker = new Map<string, number[]>();
+  for (const { marker, version } of markers) {
+    assertTrailVersionMarker(marker);
+    const versions = byMarker.get(marker) ?? [];
+    versions.push(version);
+    byMarker.set(marker, versions);
+  }
+
+  for (const [marker, versions] of byMarker) {
+    if (versions.length > 1) {
+      throw new ValidationError(
+        `Trail "${trailId}" versions ${versions.join(', ')} project the same marker ${marker}`
+      );
+    }
+  }
+};
+
+export const deriveTrailVersionMarkers = (
+  trail: Pick<
+    AnyTrail,
+    | 'crosses'
+    | 'detours'
+    | 'id'
+    | 'input'
+    | 'output'
+    | 'resources'
+    | 'version'
+    | 'versions'
+  >
+): readonly TrailVersionMarkerRecord[] => {
+  if (trail.version === undefined) {
+    return [];
+  }
+
+  const records: TrailVersionMarkerRecord[] = [
+    {
+      current: true,
+      kind: 'current',
+      marker: deriveCurrentTrailVersionMarker(trail),
+      supported: true,
+      version: trail.version,
+    },
+  ];
+
+  for (const [rawVersion, entry] of Object.entries(
+    trail.versions ?? {}
+  ).toSorted(([left], [right]) => Number(left) - Number(right))) {
+    const kind = getTrailVersionEntryKind(entry);
+    records.push({
+      current: false,
+      kind,
+      marker: deriveTrailVersionEntryMarker(entry),
+      supported: !isArchivedTrailVersionEntry(entry),
+      version: Number(rawVersion),
+    });
+  }
+
+  assertUniqueTrailVersionMarkers(trail.id, records);
+  return Object.freeze(records);
+};
+
+export const deriveShortestUnambiguousTrailVersionMarkerPrefix = (
+  marker: string,
+  markers: readonly string[],
+  minLength = TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH
+): string => {
+  assertTrailVersionMarker(marker);
+  const normalizedMarkers = markers.map((candidate) => {
+    assertTrailVersionMarker(candidate);
+    return candidate;
+  });
+
+  for (
+    let length = Math.max(minLength, TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH);
+    length <= TRAIL_VERSION_MARKER_LENGTH;
+    length += 1
+  ) {
+    const prefix = marker.slice(0, length);
+    const matches = normalizedMarkers.filter((candidate) =>
+      candidate.startsWith(prefix)
+    );
+    if (matches.length === 1) {
+      return prefix;
+    }
+  }
+
+  throw new AmbiguousError(
+    `Trail version marker ${marker} has no unambiguous display prefix`
+  );
+};
+
+export const resolveTrailVersionMarkerPrefix = (
+  markers: readonly TrailVersionMarkerBinding[],
+  prefix: string
+): TrailVersionMarkerResolution => {
+  const normalized = normalizeTrailVersionMarkerPrefix(prefix);
+  const matches = markers.filter((candidate) =>
+    candidate.marker.startsWith(normalized)
+  );
+
+  if (matches.length === 0) {
+    throw new ValidationError(
+      `No trail version marker matches prefix ${normalized}`
+    );
+  }
+
+  if (matches.length > 1) {
+    throw new AmbiguousError(
+      `Trail version marker prefix ${normalized} is ambiguous across versions ${matches.map((candidate) => candidate.version).join(', ')}`
+    );
+  }
+
+  const [match] = matches;
+  if (match === undefined) {
+    throw new ValidationError(
+      `No trail version marker matches prefix ${normalized}`
+    );
+  }
+
+  return { ...match, prefix: normalized };
+};

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
 
 import { deriveTopoGraph } from '../derive.js';
 import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
+import { resolveTopoGraphVersionReference } from '../versioning.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -301,6 +302,206 @@ describe('deriveTopoGraph', () => {
       expect(entry?.versions?.['1']?.output).toMatchObject({ type: 'object' });
       expect(entry?.versions?.['2']?.input).toMatchObject({ type: 'object' });
       expect(entry?.versions?.['2']?.output).toMatchObject({ type: 'object' });
+    });
+
+    test('version markers ignore mutable examples and status', () => {
+      const makeVersioned = (statusReason: string, exampleName: string) =>
+        trail('marker.stable', {
+          blaze: () => Result.ok({ ok: true }),
+          examples: [{ expected: { ok: true }, input: {}, name: exampleName }],
+          input: z.object({}),
+          output: z.object({ ok: z.boolean() }),
+          version: 2,
+          versions: {
+            1: {
+              input: z.object({ legacy: z.string() }),
+              output: z.object({ ok: z.boolean() }),
+              status: { reason: statusReason, state: 'deprecated' },
+              transpose: {
+                input: () => ({}),
+                output: ({ output }) => output,
+              },
+            },
+          },
+        });
+
+      const left = getFirstEntry(
+        deriveTopoGraph(topoFrom({ versioned: makeVersioned('old', 'one') }))
+      );
+      const right = getFirstEntry(
+        deriveTopoGraph(topoFrom({ versioned: makeVersioned('new', 'two') }))
+      );
+
+      expect(left.marker).toBe(right.marker);
+      expect(left.versions?.['1']?.marker).toBe(right.versions?.['1']?.marker);
+    });
+
+    test('version markers change when resolved contract content changes', () => {
+      const makeVersioned = (required: boolean) =>
+        trail('marker.contract', {
+          blaze: () => Result.ok({ ok: true }),
+          input: required
+            ? z.object({ id: z.string(), required: z.boolean() })
+            : z.object({ id: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          version: 2,
+          versions: {
+            1: {
+              input: z.object({ legacy: z.string() }),
+              output: required
+                ? z.object({ ok: z.boolean(), required: z.boolean() })
+                : z.object({ ok: z.boolean() }),
+              status: { state: 'deprecated' },
+              transpose: {
+                input: () =>
+                  required
+                    ? { id: 'legacy', required: true }
+                    : { id: 'legacy' },
+                output: ({ output }) => output,
+              },
+            },
+          },
+        });
+
+      const left = getFirstEntry(
+        deriveTopoGraph(topoFrom({ versioned: makeVersioned(false) }))
+      );
+      const right = getFirstEntry(
+        deriveTopoGraph(topoFrom({ versioned: makeVersioned(true) }))
+      );
+
+      expect(left.marker).not.toBe(right.marker);
+      expect(left.versions?.['1']?.marker).not.toBe(
+        right.versions?.['1']?.marker
+      );
+    });
+
+    test('resolves version references by unambiguous marker prefix', () => {
+      const versioned = trail('marker.resolve', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({ id: z.string() }),
+        output: z.object({ ok: z.boolean() }),
+        version: 2,
+        versions: {
+          1: {
+            input: z.object({ legacy: z.string() }),
+            output: z.object({ ok: z.boolean() }),
+            transpose: {
+              input: ({ input }) => ({ id: input.legacy }),
+              output: ({ output }) => output,
+            },
+          },
+        },
+      });
+      const entry = getFirstEntry(deriveTopoGraph(topoFrom({ versioned })));
+      const marker = entry.versions?.['1']?.marker;
+      expect(marker).toBeDefined();
+
+      expect(
+        resolveTopoGraphVersionReference(entry, `@${marker?.slice(0, 4)}`)
+      ).toMatchObject({
+        marker,
+        version: 1,
+      });
+      expect(resolveTopoGraphVersionReference(entry, 2)).toMatchObject({
+        current: true,
+        marker: entry.marker,
+        version: 2,
+      });
+    });
+
+    test('resolves all-digit marker prefixes when they are not live version numbers', () => {
+      const entry = {
+        marker: 'abcd000000000000',
+        version: 2,
+        versions: {
+          1: { marker: '1234000000000000' },
+        },
+      } as unknown as Parameters<typeof resolveTopoGraphVersionReference>[0];
+
+      expect(resolveTopoGraphVersionReference(entry, '1234')).toMatchObject({
+        marker: '1234000000000000',
+        prefix: '1234',
+        version: 1,
+      });
+      expect(resolveTopoGraphVersionReference(entry, '2')).toMatchObject({
+        current: true,
+        marker: 'abcd000000000000',
+        prefix: '2',
+        version: 2,
+      });
+      expect(() => resolveTopoGraphVersionReference(entry, '5')).toThrow(
+        'Trail version 5 is not in the TopoGraph'
+      );
+    });
+
+    test('resolves numeric versions when graph markers are absent', () => {
+      const entry = {
+        version: 2,
+        versions: {
+          1: {},
+        },
+      } as unknown as Parameters<typeof resolveTopoGraphVersionReference>[0];
+
+      expect(resolveTopoGraphVersionReference(entry, 1)).toEqual({
+        current: false,
+        prefix: '1',
+        version: 1,
+      });
+      expect(resolveTopoGraphVersionReference(entry, '2')).toEqual({
+        current: true,
+        prefix: '2',
+        version: 2,
+      });
+      expect(() => resolveTopoGraphVersionReference(entry, '1234')).toThrow(
+        'No trail version marker matches prefix 1234'
+      );
+    });
+
+    test('rejects duplicate version markers within a trail', () => {
+      const versioned = trail('marker.collision', {
+        blaze: () => Result.ok({ ok: true }),
+        input: z.object({ id: z.string() }),
+        output: z.object({ ok: z.boolean() }),
+        version: 3,
+        versions: {
+          1: {
+            input: z.object({ id: z.string() }),
+            output: z.object({ ok: z.boolean() }),
+          },
+          2: {
+            input: z.object({ id: z.string() }),
+            output: z.object({ ok: z.boolean() }),
+          },
+        },
+      });
+
+      expect(() => deriveTopoGraph(topoFrom({ versioned }))).toThrow(
+        ValidationError
+      );
+    });
+
+    test('rejects unsupported marker schema projections', () => {
+      const versioned = trail('marker.unsupported', {
+        blaze: (input) => Result.ok({ value: input.value }),
+        input: z.object({ value: z.any() }),
+        output: z.object({ value: z.string() }),
+        version: 2,
+        versions: {
+          1: {
+            input: z.object({ value: z.string() }),
+            output: z.object({ value: z.string() }),
+            transpose: {
+              input: ({ input }) => input,
+              output: ({ output }) => output,
+            },
+          },
+        },
+      });
+
+      expect(() => deriveTopoGraph(topoFrom({ versioned }))).toThrow(
+        ValidationError
+      );
     });
 
     test('trail entries include crosses array when non-empty', () => {

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -471,11 +471,15 @@ const addVersioning = (
   entry: Record<string, unknown>,
   t: Trail<unknown, unknown, unknown>
 ): void => {
+  if (t.version === undefined) {
+    return;
+  }
   const projection = projectTrailVersions(t, toSortedJsonSchema);
   if (projection === undefined) {
     return;
   }
 
+  entry['marker'] = projection.marker;
   entry['supports'] = projection.supports;
   entry['version'] = projection.version;
   if (projection.versions !== undefined) {

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -7,6 +7,15 @@
 export { deriveTopoGraph } from './derive.js';
 export { deriveTopoGraphHash } from './hash.js';
 export { deriveTopoGraphDiff } from './diff.js';
+export {
+  collectTopoGraphVersionMarkers,
+  deriveTopoGraphVersionMarkerRecords,
+  resolveTopoGraphVersionReference,
+} from './versioning.js';
+export type {
+  TopoGraphVersionMarkerRecord,
+  TopoGraphVersionMarkerResolution,
+} from './versioning.js';
 
 // File I/O
 export {

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -1090,6 +1090,9 @@ const addVersioning = (
   entry: Record<string, unknown>,
   trail: AnyTrail
 ): void => {
+  if (trail.version === undefined) {
+    return;
+  }
   const projection = projectTrailVersions(
     trail,
     (schema) => sortedJsonSchema(schema as ZodSchemaInput).value
@@ -1098,6 +1101,7 @@ const addVersioning = (
     return;
   }
 
+  entry['marker'] = projection.marker;
   entry['supports'] = projection.supports;
   entry['version'] = projection.version;
   if (projection.versions !== undefined) {

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -103,6 +103,7 @@ export interface TopoGraphVersionDetour {
 export interface TopoGraphVersionEntry {
   readonly kind: 'revision' | 'fork';
   readonly input: JsonSchema;
+  readonly marker: string;
   readonly output: JsonSchema;
   readonly status?: TrailVersionStatus | undefined;
   readonly crosses?: readonly string[] | undefined;
@@ -126,6 +127,7 @@ export interface TopoGraphEntry {
       }
     | undefined;
   readonly input?: JsonSchema | undefined;
+  readonly marker?: string | undefined;
   readonly payload?: JsonSchema | undefined;
   readonly output?: JsonSchema | undefined;
   readonly version?: number | undefined;

--- a/packages/topographer/src/versioning.ts
+++ b/packages/topographer/src/versioning.ts
@@ -1,11 +1,26 @@
 import {
   DETOUR_MAX_ATTEMPTS_CAP,
+  TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH,
+  ValidationError,
+  deriveCurrentTrailVersionMarker,
+  deriveShortestUnambiguousTrailVersionMarkerPrefix,
   deriveSupportedTrailVersions,
+  deriveTrailVersionEntryMarker,
+  deriveTrailVersionMarkers,
   getTrailVersionEntryKind,
+  resolveTrailVersionMarkerPrefix,
 } from '@ontrails/core';
-import type { AnyTrail, TrailVersionEntry } from '@ontrails/core';
+import type {
+  AnyTrail,
+  TrailVersionEntry,
+  TrailVersionMarkerBinding,
+} from '@ontrails/core';
 
-import type { JsonSchema, TopoGraphVersionEntry } from './types.js';
+import type {
+  JsonSchema,
+  TopoGraphEntry,
+  TopoGraphVersionEntry,
+} from './types.js';
 
 type SchemaProjector = (schema: unknown) => JsonSchema;
 
@@ -73,9 +88,11 @@ export const projectTrailVersionEntry = (
   entry: TrailVersionEntry,
   projectSchema: SchemaProjector
 ): TopoGraphVersionEntry => {
+  const kind = getTrailVersionEntryKind(entry);
   const projected: Record<string, unknown> = {
     input: projectSchema(entry.input),
-    kind: getTrailVersionEntryKind(entry),
+    kind,
+    marker: deriveTrailVersionEntryMarker(entry),
     output: projectSchema(entry.output),
   };
 
@@ -83,7 +100,7 @@ export const projectTrailVersionEntry = (
     projected['status'] = sortPlainRecord({ ...entry.status });
   }
 
-  if (projected['kind'] === 'fork') {
+  if (kind === 'fork') {
     const crosses = projectVersionRuntimeRefs(entry, 'crosses');
     const resources = projectVersionRuntimeRefs(entry, 'resources');
     const detours = projectVersionDetours(entry);
@@ -101,11 +118,126 @@ export const projectTrailVersionEntry = (
   return sortPlainRecord(projected) as unknown as TopoGraphVersionEntry;
 };
 
+export interface TopoGraphVersionMarkerRecord {
+  readonly current: boolean;
+  readonly displayMarker?: string | undefined;
+  readonly marker?: string | undefined;
+  readonly version: number;
+}
+
+export interface TopoGraphVersionMarkerResolution extends TopoGraphVersionMarkerRecord {
+  readonly prefix: string;
+}
+
+export const collectTopoGraphVersionMarkers = (
+  entry: Pick<TopoGraphEntry, 'marker' | 'version' | 'versions'>
+): readonly TrailVersionMarkerBinding[] => {
+  if (entry.version === undefined) {
+    return [];
+  }
+
+  const markers: TrailVersionMarkerBinding[] = [];
+  if (entry.marker !== undefined) {
+    markers.push({ marker: entry.marker, version: entry.version });
+  }
+
+  for (const [version, versionEntry] of Object.entries(entry.versions ?? {})) {
+    const { marker } = versionEntry as { readonly marker?: unknown };
+    if (typeof marker === 'string') {
+      markers.push({ marker, version: Number(version) });
+    }
+  }
+
+  return markers.toSorted((left, right) => left.version - right.version);
+};
+
+export const deriveTopoGraphVersionMarkerRecords = (
+  entry: Pick<TopoGraphEntry, 'marker' | 'version' | 'versions'>
+): readonly TopoGraphVersionMarkerRecord[] => {
+  const markers = collectTopoGraphVersionMarkers(entry);
+  const markerValues = markers.map((candidate) => candidate.marker);
+
+  return markers.map((candidate) => ({
+    ...candidate,
+    current: candidate.version === entry.version,
+    displayMarker: deriveShortestUnambiguousTrailVersionMarkerPrefix(
+      candidate.marker,
+      markerValues
+    ),
+  }));
+};
+
+const hasTopoGraphVersion = (
+  entry: Pick<TopoGraphEntry, 'version' | 'versions'>,
+  version: number
+): boolean =>
+  entry.version === version || Object.hasOwn(entry.versions ?? {}, version);
+
+export const resolveTopoGraphVersionReference = (
+  entry: Pick<TopoGraphEntry, 'marker' | 'version' | 'versions'>,
+  reference: number | string
+): TopoGraphVersionMarkerResolution => {
+  const markers = collectTopoGraphVersionMarkers(entry);
+  const markerValues = markers.map((candidate) => candidate.marker);
+
+  if (typeof reference === 'number') {
+    const match = markers.find((candidate) => candidate.version === reference);
+    if (match !== undefined) {
+      return {
+        ...match,
+        current: match.version === entry.version,
+        displayMarker: deriveShortestUnambiguousTrailVersionMarkerPrefix(
+          match.marker,
+          markerValues
+        ),
+        prefix: String(reference),
+      };
+    }
+    if (!hasTopoGraphVersion(entry, reference)) {
+      throw new ValidationError(
+        `Trail version ${reference} is not in the TopoGraph`
+      );
+    }
+
+    return {
+      current: reference === entry.version,
+      prefix: String(reference),
+      version: reference,
+    };
+  }
+
+  if (/^\d+$/.test(reference)) {
+    const version = Number(reference);
+    if (hasTopoGraphVersion(entry, version)) {
+      return resolveTopoGraphVersionReference(entry, version);
+    }
+    if (reference.length < TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH) {
+      throw new ValidationError(
+        `Trail version ${version} is not in the TopoGraph`
+      );
+    }
+  }
+
+  const markerPrefix = reference.startsWith('@')
+    ? reference.slice(1)
+    : reference;
+  const resolved = resolveTrailVersionMarkerPrefix(markers, markerPrefix);
+  return {
+    ...resolved,
+    current: resolved.version === entry.version,
+    displayMarker: deriveShortestUnambiguousTrailVersionMarkerPrefix(
+      resolved.marker,
+      markerValues
+    ),
+  };
+};
+
 export const projectTrailVersions = (
   trail: AnyTrail,
   projectSchema: SchemaProjector
 ):
   | {
+      readonly marker: string;
       readonly supports: readonly number[];
       readonly version: number;
       readonly versions?: Readonly<Record<string, TopoGraphVersionEntry>>;
@@ -125,7 +257,11 @@ export const projectTrailVersions = (
     );
   }
 
+  const currentMarker = deriveCurrentTrailVersionMarker(trail);
+  deriveTrailVersionMarkers(trail);
+
   return {
+    marker: currentMarker,
     supports: deriveSupportedTrailVersions(trail),
     version: trail.version,
     ...(Object.keys(projectedEntries).length > 0


### PR DESCRIPTION
## Context

Stack position 5/7 for the Trail Versioning M1 + M2 stack. This PR makes version identities content-addressed and projected, not authored.

## Changes

- Computes projected 16-character SHA-256 marker prefixes for current and historical trail contracts.
- Canonicalizes resolved marker content for stable hashing.
- Supports shortest unambiguous marker-prefix display with minimum length 4.
- Supports numeric and marker-prefix version references in TopoGraph helpers.
- Rejects authored `marker:` fields.
- Fixes all-digit marker-prefix and markerless numeric-version resolution cases.
- Adds a branch-local changeset for core/topographer package impact.

## Verification

- `bun run --cwd packages/core test`
- `bun run --cwd packages/topographer test`
- `bun run typecheck`
- Focused marker and topographer derive tests.
- Full stack-tip gate later passed through `bun run publish:check`.

## Risks / Rollout

Markers are projected identities only. Authored marker fields stay invalid, and lifecycle/status semantics remain reserved for later phases except where M2 types leave room for them.

## Linear

- Linear: TRL-739
- Project: Trail Versioning