### PR TITLE
feat(core): resolve trail versions at runtime

### DIFF
--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
@@ -184,9 +184,13 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 | `bun run --cwd packages/core test` | TRL-739 | passed | 1126 tests, 0 failures. |
 | `bun run --cwd packages/topographer test` | TRL-739 | passed | 127 tests, 0 failures. |
 | `bun run typecheck` | TRL-739 | passed | 22 package tasks successful. |
+| `bun run format:check` | TRL-739 | passed | Passed after formatter cleanup. |
+| `git diff --check` | TRL-739 | passed | No whitespace errors. |
 | `bun test packages/core/src/__tests__/version-runtime.test.ts packages/core/src/__tests__/version-execution.test.ts` | TRL-115 | passed | 13 tests, 0 failures. |
 | `bun run --cwd packages/core test` | TRL-115 | passed | 1147 tests, 0 failures. |
 | `bun run typecheck` | TRL-115 | passed | 22 package tasks successful. |
+| `bun run format:check` | TRL-115 | passed | Passed after removing the runtime import cycle and updating direct unit tests. |
+| `git diff --check` | TRL-115 | passed | No whitespace errors. |
 | `bun run --cwd packages/core typecheck` | TRL-116 | passed | `tsc --noEmit` exited 0. |
 | `bun run --cwd packages/testing typecheck` | TRL-116 | passed | `tsc --noEmit` exited 0. |
 | `bun run --cwd packages/topographer typecheck` | TRL-116 | passed | `tsc --noEmit` exited 0. |

--- a/.changeset/trail-version-runtime.md
+++ b/.changeset/trail-version-runtime.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/core": patch
+---
+
+Resolve trail versions during execution, including live revisions, forks, marker references, and unsupported-version errors.

--- a/docs/adr/0002-built-in-result-type.md
+++ b/docs/adr/0002-built-in-result-type.md
@@ -94,6 +94,7 @@ contract.
 | `AmbiguousError` | `validation` | 400 | 1 | -32602 | No |
 | `AssertionError` | `internal` | 500 | 8 | -32603 | No |
 | `NotFoundError` | `not_found` | 404 | 2 | -32601 | No |
+| `VersionNotSupportedError` | `not_found` | 404 | 2 | -32601 | No |
 | `AlreadyExistsError` | `conflict` | 409 | 3 | -32603 | No |
 | `ConflictError` | `conflict` | 409 | 3 | -32603 | No |
 | `PermissionError` | `permission` | 403 | 4 | -32600 | No |

--- a/docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md
+++ b/docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md
@@ -57,6 +57,7 @@ Transports map these properties to their native representations. The framework p
 | `AmbiguousError` | `validation` | No | 400 | 1 | -32602 | nack -> dead-letter | drop + dead-event |
 | `AssertionError` | `internal` | No | 500 | 8 | -32603 | nack -> dead-letter | drop + dead-event |
 | `NotFoundError` | `not_found` | No | 404 | 2 | -32601 | nack -> dead-letter | drop + dead-event |
+| `VersionNotSupportedError` | `not_found` | No | 404 | 2 | -32601 | nack -> dead-letter | drop + dead-event |
 | `AlreadyExistsError` | `conflict` | No | 409 | 3 | -32603 | nack -> dead-letter | drop + dead-event |
 | `ConflictError` | `conflict` | No | 409 | 3 | -32603 | nack -> dead-letter | drop + dead-event |
 | `PermissionError` | `permission` | No | 403 | 4 | -32600 | nack -> dead-letter | drop + dead-event |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -313,7 +313,7 @@ category code maps in `@ontrails/core`.
 | Category | CLI Exit | HTTP | JSON-RPC | Retryable | Fixed Classes |
 | --- | --- | --- | --- | --- | --- |
 | `validation` | 1 | 400 | -32602 | No | `ValidationError`, `AmbiguousError` |
-| `not_found` | 2 | 404 | -32601 | No | `NotFoundError` |
+| `not_found` | 2 | 404 | -32601 | No | `NotFoundError`, `VersionNotSupportedError` |
 | `conflict` | 3 | 409 | -32603 | No | `AlreadyExistsError`, `ConflictError` |
 | `permission` | 4 | 403 | -32600 | No | `PermissionError`, `PermitError` |
 | `timeout` | 5 | 504 | -32603 | Yes | `TimeoutError` |

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -219,7 +219,7 @@ Status codes come directly from the error taxonomy -- the same mapping used acro
 | Category | HTTP Status | Retryable | Fixed Classes |
 | --- | --- | --- | --- |
 | `validation` | 400 | No | `ValidationError`, `AmbiguousError` |
-| `not_found` | 404 | No | `NotFoundError` |
+| `not_found` | 404 | No | `NotFoundError`, `VersionNotSupportedError` |
 | `conflict` | 409 | No | `AlreadyExistsError`, `ConflictError` |
 | `permission` | 403 | No | `PermissionError`, `PermitError` |
 | `timeout` | 504 | Yes | `TimeoutError` |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -124,7 +124,7 @@ category code maps in `@ontrails/core`.
 | Category | CLI Exit | HTTP | JSON-RPC | Retryable | Fixed Classes |
 | --- | --- | --- | --- | --- | --- |
 | `validation` | 1 | 400 | -32602 | No | `ValidationError`, `AmbiguousError` |
-| `not_found` | 2 | 404 | -32601 | No | `NotFoundError` |
+| `not_found` | 2 | 404 | -32601 | No | `NotFoundError`, `VersionNotSupportedError` |
 | `conflict` | 3 | 409 | -32603 | No | `AlreadyExistsError`, `ConflictError` |
 | `permission` | 4 | 403 | -32600 | No | `PermissionError`, `PermitError` |
 | `timeout` | 5 | 504 | -32603 | Yes | `TimeoutError` |

--- a/packages/core/src/__tests__/version-execution.test.ts
+++ b/packages/core/src/__tests__/version-execution.test.ts
@@ -1,0 +1,448 @@
+/* oxlint-disable require-await -- blazes satisfy async interface without awaiting */
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { executeTrail } from '../execute';
+import {
+  ConflictError,
+  ValidationError,
+  VersionNotSupportedError,
+} from '../errors';
+import type { Layer } from '../layer';
+import { Result } from '../result';
+import { resource } from '../resource';
+import { run } from '../run';
+import { topo } from '../topo';
+import { trail } from '../trail';
+import type { TrailContext } from '../types';
+import { deriveTrailVersionMarkers } from '../version-marker';
+
+const currentInput = z.object({
+  loud: z.boolean().optional(),
+  name: z.string(),
+});
+const currentOutput = z.object({
+  message: z.string(),
+  source: z.string(),
+});
+const legacyInput = z.object({ fullName: z.string() });
+const legacyOutput = z.object({ text: z.string() });
+const archivedInput = z.object({ archivedName: z.string() });
+const forkInput = z.object({ id: z.string() });
+const forkCrossInput = z.object({ source: z.string() });
+const forkOutput = z.object({ summary: z.string() });
+
+const suffixResource = resource('version.runtime.suffix', {
+  create: () => Result.ok({ value: 'resource' }),
+});
+
+const versionHelper = trail('version.runtime.helper', {
+  blaze: (input) => Result.ok({ value: `helper:${input.id}` }),
+  input: z.object({ id: z.string() }),
+  output: z.object({ value: z.string() }),
+  visibility: 'internal',
+});
+
+const requireCross = (
+  ctx: TrailContext
+): NonNullable<TrailContext['cross']> => {
+  expect(ctx.cross).toBeDefined();
+  return ctx.cross as NonNullable<TrailContext['cross']>;
+};
+
+const versionedTrail = trail('version.runtime.greet', {
+  blaze: (input) =>
+    Result.ok({
+      message: `${input.loud ? 'HELLO' : 'hello'} ${input.name}`,
+      source: 'current',
+    }),
+  input: currentInput,
+  output: currentOutput,
+  version: 6,
+  versions: {
+    1: {
+      input: legacyInput,
+      output: legacyOutput,
+      transpose: {
+        input: ({ input }) => ({ name: input.fullName }),
+        output: ({ output }) => ({ text: output.message }),
+      },
+    },
+    2: {
+      input: currentInput,
+      output: currentOutput,
+      status: { note: 'still live for migration', state: 'deprecated' },
+    },
+    4: {
+      input: archivedInput,
+      output: legacyOutput,
+      status: { state: 'archived' },
+      transpose: {
+        input: ({ input }) => ({ name: input.archivedName }),
+        output: ({ output }) => ({ text: output.message }),
+      },
+    },
+    5: {
+      blaze: async (input, ctx) => {
+        if (input.id === 'detour') {
+          return Result.err(new ConflictError('fork conflict'));
+        }
+        const helper = await requireCross(ctx)('version.runtime.helper', {
+          id: input.id,
+        });
+        if (helper.isErr()) {
+          return Result.err(helper.error);
+        }
+        return Result.ok({
+          summary: `${input.source}:${helper.value.value}:${suffixResource.from(ctx).value}`,
+        });
+      },
+      crossInput: forkCrossInput,
+      crosses: [versionHelper],
+      detours: [
+        {
+          on: ConflictError,
+          recover: ({ input }) =>
+            Result.ok({ summary: `detoured:${input.id}` }),
+        },
+      ],
+      input: forkInput,
+      output: forkOutput,
+      resources: [suffixResource],
+    },
+  },
+});
+
+const versionedTopo = topo('version-runtime-topo', {
+  versionHelper,
+  versionedTrail,
+});
+
+const numericMarkerTrail = trail('version.runtime.numeric-marker', {
+  blaze: (input) => Result.ok({ value: `current:${input.current}` }),
+  input: z.object({ current: z.string() }),
+  output: z.object({ value: z.string() }),
+  version: 2,
+  versions: {
+    1: {
+      input: z.object({ field3: z.string() }),
+      output: z.object({ value: z.string() }),
+      transpose: {
+        input: ({ input }) => ({ current: input.field3 }),
+        output: ({ output }) => output,
+      },
+    },
+  },
+});
+
+describe('trail version execution', () => {
+  test('runs the current contract when the current version is requested', async () => {
+    const result = await executeTrail(
+      versionedTrail,
+      { name: 'Ada' },
+      { version: 6 }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({
+      message: 'hello Ada',
+      source: 'current',
+    });
+  });
+
+  test('runs revision entries by transposing through the current contract', async () => {
+    const seenInputs: unknown[] = [];
+    const captureLayer: Layer = {
+      name: 'capture-current-input',
+      wrap(_trail, impl) {
+        return async (input, ctx) => {
+          seenInputs.push(input);
+          return await impl(input, ctx);
+        };
+      },
+    };
+
+    const result = await executeTrail(
+      versionedTrail,
+      { fullName: 'Ada' },
+      { layers: [captureLayer], version: 1 }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ text: 'hello Ada' });
+    expect(seenInputs).toEqual([{ name: 'Ada' }]);
+  });
+
+  test('keeps deprecated historical entries live', async () => {
+    const result = await executeTrail(
+      versionedTrail,
+      { loud: true, name: 'Ada' },
+      { version: 2 }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({
+      message: 'HELLO Ada',
+      source: 'current',
+    });
+  });
+
+  test('runs fork entries with their own blaze, resources, crosses, and detours', async () => {
+    const result = await executeTrail(
+      versionedTrail,
+      { id: 'forked', source: 'direct' },
+      {
+        topo: versionedTopo,
+        validationSchema: z.object({
+          id: z.string(),
+          source: z.string(),
+        }),
+        version: 5,
+      }
+    );
+    const detoured = await executeTrail(
+      versionedTrail,
+      { id: 'detour', source: 'direct' },
+      {
+        topo: versionedTopo,
+        validationSchema: z.object({
+          id: z.string(),
+          source: z.string(),
+        }),
+        version: 5,
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({
+      summary: 'direct:helper:forked:resource',
+    });
+    expect(detoured.isOk()).toBe(true);
+    expect(detoured.unwrap()).toEqual({ summary: 'detoured:detour' });
+  });
+
+  test('preserves caller validation schema for direct fork version execution', async () => {
+    const result = await executeTrail(
+      versionedTrail,
+      { id: 'forked', source: 'cross-only' },
+      {
+        topo: versionedTopo,
+        validationSchema: z.object({
+          id: z.string(),
+          source: z.literal('direct'),
+        }),
+        version: 5,
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result.error).toBeInstanceOf(ValidationError);
+  });
+
+  test('does not leak current crossInput validation into forks without crossInput', async () => {
+    const target = trail('version.runtime.fork.without-cross-input', {
+      blaze: (input) => Result.ok({ seen: `current:${input.id}` }),
+      crossInput: z.object({ source: z.literal('current') }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ seen: z.string() }),
+      version: 2,
+      versions: {
+        1: {
+          blaze: (input) => Result.ok({ seen: `fork:${input.source}` }),
+          input: z.object({
+            id: z.string(),
+            source: z.literal('fork'),
+          }),
+          output: z.object({ seen: z.string() }),
+        },
+      },
+    });
+    const parent = trail('version.runtime.fork.cross-input.parent', {
+      blaze: async (_input, ctx) => {
+        const crossed = await requireCross(ctx)(
+          'version.runtime.fork.without-cross-input',
+          {
+            id: 'forked',
+            source: 'fork',
+          },
+          { version: 1 }
+        );
+        return crossed.match({
+          err: (error) => Result.err(error),
+          ok: (value) => Result.ok(value),
+        });
+      },
+      crosses: [target],
+      input: z.object({}),
+      output: z.object({ seen: z.string() }),
+    });
+    const app = topo('version-runtime-fork-cross-input-topo', {
+      parent,
+      target,
+    });
+
+    const result = await executeTrail(parent, {}, { topo: app });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ seen: 'fork:fork' });
+  });
+
+  test('resolves marker-prefix references with the same projected markers', async () => {
+    const marker = deriveTrailVersionMarkers(versionedTrail).find(
+      (candidate) => candidate.version === 1
+    )?.marker;
+    expect(marker).toBeDefined();
+
+    const result = await executeTrail(
+      versionedTrail,
+      { fullName: 'Ada' },
+      { version: `@${marker?.slice(0, 4)}` }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ text: 'hello Ada' });
+  });
+
+  test('resolves all-digit marker prefixes when no matching numeric version exists', async () => {
+    const marker = deriveTrailVersionMarkers(numericMarkerTrail).find(
+      (candidate) => candidate.version === 1
+    )?.marker;
+    expect(marker).toMatch(/^\d{4}/);
+
+    const result = await executeTrail(
+      numericMarkerTrail,
+      { field3: 'Ada' },
+      { version: marker?.slice(0, 4) }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ value: 'current:Ada' });
+  });
+
+  test('rejects archived and missing version references', async () => {
+    const archived = await executeTrail(
+      versionedTrail,
+      { archivedName: 'Ada' },
+      { version: 4 }
+    );
+    const missing = await executeTrail(
+      versionedTrail,
+      { name: 'Ada' },
+      { version: 42 }
+    );
+
+    expect(archived.isErr()).toBe(true);
+    expect(archived.error).toBeInstanceOf(VersionNotSupportedError);
+    expect((archived.error as VersionNotSupportedError).reason).toBe(
+      'archived'
+    );
+    expect((archived.error as VersionNotSupportedError).context).toMatchObject({
+      reason: 'archived',
+      supported: [1, 2, 5, 6],
+    });
+    expect(missing.isErr()).toBe(true);
+    expect(missing.error).toBeInstanceOf(VersionNotSupportedError);
+    expect((missing.error as VersionNotSupportedError).reason).toBe('missing');
+    expect((missing.error as VersionNotSupportedError).context).toMatchObject({
+      reason: 'missing',
+    });
+  });
+
+  test('keeps ctx.cross() current by default and allows explicit version pins', async () => {
+    const parent = trail('version.runtime.parent', {
+      blaze: async (_input, ctx) => {
+        const cross = requireCross(ctx);
+        const current = await cross('version.runtime.greet', { name: 'Ada' });
+        const legacy = await cross(
+          'version.runtime.greet',
+          { fullName: 'Ada' },
+          { version: 1 }
+        );
+        const fork = await cross(
+          'version.runtime.greet',
+          { id: 'forked', source: 'parent' },
+          { version: 5 }
+        );
+        if (current.isErr()) {
+          return Result.err(current.error);
+        }
+        if (legacy.isErr()) {
+          return Result.err(legacy.error);
+        }
+        if (fork.isErr()) {
+          return Result.err(fork.error);
+        }
+        return Result.ok({
+          current: (current.value as { message: string }).message,
+          fork: (fork.value as { summary: string }).summary,
+          legacy: (legacy.value as { text: string }).text,
+        });
+      },
+      crosses: [versionedTrail],
+      input: z.object({}),
+      output: z.object({
+        current: z.string(),
+        fork: z.string(),
+        legacy: z.string(),
+      }),
+    });
+    const app = topo('version-runtime-cross-topo', {
+      parent,
+      versionHelper,
+      versionedTrail,
+    });
+
+    const result = await executeTrail(parent, {}, { topo: app });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({
+      current: 'hello Ada',
+      fork: 'parent:helper:forked:resource',
+      legacy: 'hello Ada',
+    });
+  });
+
+  test('supports run() references using id@version and id@marker', async () => {
+    const marker = deriveTrailVersionMarkers(versionedTrail).find(
+      (candidate) => candidate.version === 1
+    )?.marker;
+    expect(marker).toBeDefined();
+
+    const byNumber = await run(versionedTopo, 'version.runtime.greet@1', {
+      fullName: 'Ada',
+    });
+    const byMarker = await run(
+      versionedTopo,
+      `version.runtime.greet@${marker?.slice(0, 4)}`,
+      { fullName: 'Ada' }
+    );
+    const conflicting = await run(
+      versionedTopo,
+      'version.runtime.greet@1',
+      { fullName: 'Ada' },
+      { version: 2 }
+    );
+
+    expect(byNumber.isOk()).toBe(true);
+    expect(byNumber.unwrap()).toEqual({ text: 'hello Ada' });
+    expect(byMarker.isOk()).toBe(true);
+    expect(byMarker.unwrap()).toEqual({ text: 'hello Ada' });
+    expect(conflicting.isErr()).toBe(true);
+    expect(conflicting.error).toBeInstanceOf(ValidationError);
+  });
+
+  test('preserves literal run() trail ids containing @ without version suffixes', async () => {
+    const literal = trail('version.runtime.literal@alpha', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    });
+    const app = topo('version-runtime-literal-at-topo', { literal });
+
+    const result = await run(app, 'version.runtime.literal@alpha', {});
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual({ ok: true });
+  });
+});

--- a/packages/core/src/__tests__/version-runtime.test.ts
+++ b/packages/core/src/__tests__/version-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import { z } from 'zod';
 
+import { executeTrail } from '../execute';
 import { executeTrailRevision } from '../version-runtime';
 import { Result } from '../result';
 import { trail } from '../trail';
@@ -68,7 +69,9 @@ describe('executeTrailRevision', () => {
       createInvite,
       1,
       createInvite.versions?.[1] ?? expect.unreachable(),
-      { name: 'Ada' }
+      { name: 'Ada' },
+      undefined,
+      executeTrail
     );
 
     expect(result.unwrap()).toEqual({
@@ -102,7 +105,9 @@ describe('executeTrailRevision', () => {
       echo,
       1,
       echo.versions?.[1] ?? expect.unreachable(),
-      { value: 'stable' }
+      { value: 'stable' },
+      undefined,
+      executeTrail
     );
 
     expect(result.unwrap()).toEqual({ value: 'stable' });
@@ -130,7 +135,9 @@ describe('executeTrailRevision', () => {
       stateTrail,
       1,
       stateTrail.versions?.[1] ?? expect.unreachable(),
-      {}
+      {},
+      undefined,
+      executeTrail
     );
 
     expect(result.isErr()).toBe(true);
@@ -159,7 +166,9 @@ describe('executeTrailRevision', () => {
       requiresCurrent,
       1,
       requiresCurrent.versions?.[1] ?? expect.unreachable(),
-      { id: 'old' }
+      { id: 'old' },
+      undefined,
+      executeTrail
     );
 
     expect(result.isErr()).toBe(true);

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -68,6 +68,64 @@ export class NotFoundError extends TrailsError {
   readonly retryable = false as const;
 }
 
+export class VersionNotSupportedError extends NotFoundError {
+  readonly reason?: string | undefined;
+  readonly requested?: number | string | undefined;
+  readonly supported?: readonly number[] | undefined;
+  readonly trailId?: string | undefined;
+
+  constructor(
+    message: string,
+    options?: { cause?: Error; context?: Record<string, unknown> }
+  );
+  constructor(
+    trailId: string,
+    requested: number | string,
+    supported: readonly number[],
+    reason?: string | undefined
+  );
+  constructor(
+    messageOrTrailId: string,
+    optionsOrRequested?:
+      | { cause?: Error; context?: Record<string, unknown> }
+      | number
+      | string,
+    supported?: readonly number[],
+    reason?: string | undefined
+  ) {
+    if (supported === undefined) {
+      super(
+        messageOrTrailId,
+        optionsOrRequested as
+          | { cause?: Error; context?: Record<string, unknown> }
+          | undefined
+      );
+      this.name = 'VersionNotSupportedError';
+      return;
+    }
+
+    const requested = optionsOrRequested as number | string;
+    const supportedLabel =
+      supported.length === 0 ? 'none' : supported.join(', ');
+    super(
+      `Trail "${messageOrTrailId}" version ${String(requested)} is not supported (supported: ${supportedLabel})`,
+      {
+        context: {
+          ...(reason === undefined ? {} : { reason }),
+          requested,
+          supported,
+          trailId: messageOrTrailId,
+        },
+      }
+    );
+    this.name = 'VersionNotSupportedError';
+    this.reason = reason;
+    this.requested = requested;
+    this.supported = supported;
+    this.trailId = messageOrTrailId;
+  }
+}
+
 export class AlreadyExistsError extends TrailsError {
   readonly category = 'conflict' as const;
   readonly retryable = false as const;
@@ -236,6 +294,12 @@ export const errorClasses = [
     category: 'not_found',
     ctor: NotFoundError,
     name: 'NotFoundError',
+    retryable: false,
+  },
+  {
+    category: 'not_found',
+    ctor: VersionNotSupportedError,
+    name: 'VersionNotSupportedError',
     retryable: false,
   },
   {

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -8,11 +8,12 @@
 
 import type { z } from 'zod';
 
-import type { AnyTrail } from './trail.js';
+import type { AnyTrail, TrailVersionForkEntry } from './trail.js';
 import type { Layer } from './layer.js';
 import type { ResourceOverrideMap } from './resource.js';
 import type { TraceContext, TraceRecord } from './tracing.js';
 import type { Topo } from './topo.js';
+import type { TrailVersionReference } from './version-resolution.js';
 
 import {
   buildActivationProvenanceTraceAttrs,
@@ -27,6 +28,7 @@ import {
 import type { BasePermit } from './permits.js';
 import type {
   CrossBatchOptions,
+  CrossOptions,
   CrossFn,
   Detour,
   Implementation,
@@ -72,10 +74,21 @@ import { createResourceLookup } from './resource.js';
 import { createResources } from './resource-config.js';
 import { LAYER_INPUTS_KEY, SURFACE_KEY } from './types.js';
 import { validateInput, validateOutput } from './validation.js';
+import { executeTrailRevision } from './version-runtime.js';
+import type { TrailVersionCurrentExecutor } from './version-runtime.js';
+import {
+  parseTrailIdVersionReference,
+  resolveTrailVersion,
+} from './version-resolution.js';
 
 type MutableTrailContext = {
   -readonly [K in keyof TrailContext]: TrailContext[K];
 };
+
+type CrossForwardOptions = Omit<
+  ExecuteTrailOptions,
+  'createContext' | 'crossValidation' | 'validationSchema' | 'version'
+>;
 
 // ---------------------------------------------------------------------------
 // Options
@@ -153,6 +166,23 @@ export interface ExecuteTrailOptions {
    * @see TRL-473 for the CLI projection contract.
    */
   readonly layerInputs?: Readonly<Record<string, unknown>> | undefined;
+  /**
+   * Execute a specific live trail version.
+   *
+   * Omit for the current top-level contract. Number and numeric-string
+   * references select authored versions; marker references select projected
+   * content-addressed markers by unambiguous prefix.
+   */
+  readonly version?: TrailVersionReference | undefined;
+  /**
+   * Marks this invocation as a `ctx.cross()` dispatch so versioned fork
+   * entries validate against their own `crossInput`.
+   *
+   * Used by the cross execution path; not part of the public API.
+   *
+   * @internal
+   */
+  readonly crossValidation?: boolean | undefined;
   /**
    * Override the validation schema used for input validation.
    *
@@ -553,12 +583,22 @@ const runImplWithRootRecord = async (
   }
 };
 
+interface ResolvedCrossTarget {
+  readonly trail: AnyTrail;
+  readonly version?: TrailVersionReference | undefined;
+}
+
 const resolveCrossTarget = (
   trailOrId: AnyTrail | string,
   topo: Topo | undefined
-): Result<AnyTrail, Error> => {
+): Result<ResolvedCrossTarget, Error> => {
   if (typeof trailOrId !== 'string') {
-    return Result.ok(trailOrId);
+    return Result.ok({ trail: trailOrId });
+  }
+
+  const parsed = parseTrailIdVersionReference(trailOrId);
+  if (parsed.isErr()) {
+    return parsed;
   }
 
   if (topo === undefined) {
@@ -569,9 +609,9 @@ const resolveCrossTarget = (
     );
   }
 
-  const target = topo.get(trailOrId);
+  const target = topo.get(parsed.value.id);
   return target
-    ? Result.ok(target)
+    ? Result.ok({ trail: target, version: parsed.value.version })
     : Result.err(
         new NotFoundError(
           `Trail "${trailOrId}" not found in topo "${topo.name}"`
@@ -677,13 +717,16 @@ const executeResolvedCrossTarget = async (
   input: unknown,
   ctx: TrailContext,
   topo: Topo | undefined,
-  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>
+  forwarded: CrossForwardOptions,
+  version?: TrailVersionReference | undefined
 ): Promise<Result<unknown, Error>> =>
   await // eslint-disable-next-line no-use-before-define -- executor closure runs only after executeTrail is defined
   executeTrail(target, input, {
     ...forwarded,
+    crossValidation: true,
     ctx,
     topo,
+    ...(version === undefined ? {} : { version }),
     validationSchema: buildCrossValidationSchema(target),
   });
 
@@ -692,19 +735,31 @@ const executeCrossTarget = async (
   input: unknown,
   ctx: TrailContext,
   topo: Topo | undefined,
-  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>
+  forwarded: CrossForwardOptions,
+  crossOptions?: CrossOptions | undefined
 ): Promise<Result<unknown, Error>> => {
   const target = resolveCrossTarget(trailOrId, topo);
   if (target.isErr()) {
     return target;
   }
+  if (
+    target.value.version !== undefined &&
+    crossOptions?.version !== undefined
+  ) {
+    return Result.err(
+      new ValidationError(
+        `Trail "${target.value.trail.id}" version was provided both in the id reference and ctx.cross() options`
+      )
+    );
+  }
 
   return await executeResolvedCrossTarget(
-    target.value,
+    target.value.trail,
     input,
     ctx,
     topo,
-    forwarded
+    forwarded,
+    crossOptions?.version ?? target.value.version
   );
 };
 
@@ -715,7 +770,7 @@ const executeConcurrentCrossBatchCall = async (
   branchIndex: number,
   ctx: TrailContext,
   topo: Topo | undefined,
-  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>
+  forwarded: CrossForwardOptions
 ): Promise<Result<unknown, Error>> => {
   const [trailOrId, batchInput] = call;
   const target = resolveCrossTarget(trailOrId, topo);
@@ -724,11 +779,12 @@ const executeConcurrentCrossBatchCall = async (
   }
 
   return await executeResolvedCrossTarget(
-    target.value,
+    target.value.trail,
     batchInput,
-    buildConcurrentBranchContext(ctx, target.value, topo, branchIndex),
+    buildConcurrentBranchContext(ctx, target.value.trail, topo, branchIndex),
     topo,
-    forwarded
+    forwarded,
+    target.value.version
   );
 };
 
@@ -736,7 +792,7 @@ const executeUnlimitedCrossBatch = async (
   calls: readonly CrossBatchCall[],
   ctx: TrailContext,
   topo: Topo | undefined,
-  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>
+  forwarded: CrossForwardOptions
 ): Promise<Result<unknown, Error>[]> =>
   await Promise.all(
     calls.map((call, branchIndex) =>
@@ -753,7 +809,7 @@ const executeLimitedCrossBatch = async (
   calls: readonly CrossBatchCall[],
   ctx: TrailContext,
   topo: Topo | undefined,
-  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>,
+  forwarded: CrossForwardOptions,
   limit: number
 ): Promise<Result<unknown, Error>[]> => {
   const results = createCrossBatchResults(calls);
@@ -798,7 +854,7 @@ const executeCrossBatch = async (
   calls: readonly CrossBatchCall[],
   ctx: TrailContext,
   topo: Topo | undefined,
-  forwarded: Omit<ExecuteTrailOptions, 'createContext' | 'validationSchema'>,
+  forwarded: CrossForwardOptions,
   batchOptions?: CrossBatchOptions
 ): Promise<Result<unknown, Error>[]> => {
   if (calls.length === 0) {
@@ -827,7 +883,9 @@ const bindCrossToCtx = (
 
   const {
     createContext: _omit,
+    crossValidation: _omitCrossValidation,
     validationSchema: _omitSchema,
+    version: _omitVersion,
     ...forwarded
   } = options ?? {};
   const cross = (async (
@@ -835,7 +893,8 @@ const bindCrossToCtx = (
       | AnyTrail
       | string
       | readonly (readonly [AnyTrail | string, unknown])[],
-    inputOrOptions?: CrossBatchOptions | unknown
+    inputOrOptions?: unknown,
+    singleOptions?: CrossOptions
   ) => {
     if (Array.isArray(trailOrCalls)) {
       return await executeCrossBatch(
@@ -852,7 +911,8 @@ const bindCrossToCtx = (
       inputOrOptions,
       ctx,
       topo,
-      forwarded
+      forwarded,
+      singleOptions
     );
   }) as CrossFn;
 
@@ -889,7 +949,9 @@ const bindFireToCtx = (
   // (consumers validate against their own schema, not the producer's cross schema).
   const {
     createContext: _omit,
+    crossValidation: _omitCrossValidation,
     validationSchema: _omitSchema,
+    version: _omitVersion,
     ...forwarded
   } = options ?? {};
   const trackedCtx = withFireDispatchTracking(ctx);
@@ -1246,6 +1308,125 @@ const composeAttachedLayers = (
   ...(options?.layers ?? []),
 ];
 
+const stripVersionOption = (
+  options?: ExecuteTrailOptions
+): Omit<ExecuteTrailOptions, 'version'> | undefined => {
+  if (options === undefined) {
+    return undefined;
+  }
+  const { version: _version, ...forwarded } = options;
+  return forwarded;
+};
+
+const executeRequestedCurrentTrailVersion = async (
+  trail: AnyTrail,
+  rawInput: unknown,
+  options: ExecuteTrailOptions
+): Promise<Result<unknown, Error>> =>
+  // eslint-disable-next-line no-use-before-define -- recursive dispatch strips version before re-entering the current pipeline
+  await executeTrail(trail, rawInput, stripVersionOption(options));
+
+const executeCurrentTrailForRevision: TrailVersionCurrentExecutor = async (
+  trail,
+  input,
+  options
+) => {
+  const {
+    validationSchema: _validationSchema,
+    version: _version,
+    ...forwarded
+  } = options ?? {};
+  // eslint-disable-next-line no-use-before-define -- revision runtime calls back into current execution after options are normalized
+  return await executeTrail(trail, input, forwarded);
+};
+
+const createForkTrailVersion = (
+  trail: AnyTrail,
+  entry: TrailVersionForkEntry
+): AnyTrail => {
+  const {
+    blaze: _blaze,
+    crossInput: _crossInput,
+    crosses: _crosses,
+    detours: _detours,
+    input: _input,
+    output: _output,
+    resources: _resources,
+    version: _version,
+    versions: _versions,
+    ...base
+  } = trail;
+
+  return Object.freeze({
+    ...base,
+    blaze: entry.blaze,
+    crosses: Object.freeze([...(entry.crosses ?? [])]),
+    detours: Object.freeze([...(entry.detours ?? [])]),
+    ...(entry.crossInput === undefined ? {} : { crossInput: entry.crossInput }),
+    input: entry.input,
+    output: entry.output,
+    resources: Object.freeze([...(entry.resources ?? [])]),
+  }) as AnyTrail;
+};
+
+const executeRequestedForkTrailVersion = async (
+  trail: AnyTrail,
+  entry: TrailVersionForkEntry,
+  rawInput: unknown,
+  options: ExecuteTrailOptions
+): Promise<Result<unknown, Error>> => {
+  const forkTrail = createForkTrailVersion(trail, entry);
+  const validationSchema = options.crossValidation
+    ? buildCrossValidationSchema(forkTrail)
+    : options.validationSchema;
+
+  // eslint-disable-next-line no-use-before-define -- recursive dispatch strips version before re-entering the fork pipeline
+  return await executeTrail(forkTrail, rawInput, {
+    ...stripVersionOption(options),
+    validationSchema,
+  });
+};
+
+const executeRequestedTrailVersion = async (
+  trail: AnyTrail,
+  rawInput: unknown,
+  options: ExecuteTrailOptions
+): Promise<Result<unknown, Error>> => {
+  const reference = options.version;
+  if (reference === undefined) {
+    return Result.err(
+      new InternalError(
+        'unreachable: executeRequestedTrailVersion without reference'
+      )
+    );
+  }
+
+  const resolved = resolveTrailVersion(trail, reference);
+  if (resolved.isErr()) {
+    return Result.err(resolved.error);
+  }
+
+  if (resolved.value.current) {
+    return await executeRequestedCurrentTrailVersion(trail, rawInput, options);
+  }
+
+  return resolved.value.kind === 'revision'
+    ? await executeTrailRevision(
+        trail,
+        resolved.value.version,
+        resolved.value.entry,
+        rawInput,
+        options,
+        executeCurrentTrailForRevision
+      )
+    : await executeRequestedForkTrailVersion(
+        trail,
+        resolved.value.entry,
+        rawInput,
+        options
+      );
+};
+
 const isLayerInputMap = (
   value: unknown
 ): value is Readonly<Record<string, unknown>> =>
@@ -1336,6 +1517,10 @@ export const executeTrail = async (
   options?: ExecuteTrailOptions
 ): Promise<Result<unknown, Error>> => {
   try {
+    if (options?.version !== undefined) {
+      return await executeRequestedTrailVersion(trail, rawInput, options);
+    }
+
     const validated = validateInput(
       options?.validationSchema ?? trail.input,
       rawInput

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export {
   AmbiguousError,
   AssertionError,
   NotFoundError,
+  VersionNotSupportedError,
   AlreadyExistsError,
   ConflictError,
   PermissionError,
@@ -75,6 +76,7 @@ export type {
   TrailContext,
   TrailContextInit,
   CrossBatchOptions,
+  CrossOptions,
   CrossFn,
   FireFn,
   LogLevel,
@@ -180,6 +182,10 @@ export {
   normalizeTrailVersionMarkerPrefix,
   resolveTrailVersionMarkerPrefix,
 } from './version-marker.js';
+export {
+  parseTrailIdVersionReference,
+  resolveTrailVersion,
+} from './version-resolution.js';
 export type {
   AnyTrail,
   BlazeInput,
@@ -206,6 +212,11 @@ export type {
   TrailVersionMarkerRecord,
   TrailVersionMarkerResolution,
 } from './version-marker.js';
+export type {
+  ParsedTrailVersionReference,
+  ResolvedTrailVersion,
+  TrailVersionReference,
+} from './version-resolution.js';
 export {
   filterSurfaceTrails,
   matchesTrailPattern,

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -8,7 +8,8 @@
 import type { Topo } from './topo.js';
 import { executeTrail } from './execute.js';
 import type { ExecuteTrailOptions } from './execute.js';
-import { NotFoundError } from './errors.js';
+import { parseTrailIdVersionReference } from './version-resolution.js';
+import { NotFoundError, ValidationError } from './errors.js';
 import { Result } from './result.js';
 
 // ---------------------------------------------------------------------------
@@ -43,7 +44,21 @@ export const run = (
   input: unknown,
   options?: RunOptions
 ): Promise<Result<unknown, Error>> => {
-  const trail = topo.get(id);
+  const parsed = parseTrailIdVersionReference(id);
+  if (parsed.isErr()) {
+    return Promise.resolve(Result.err(parsed.error));
+  }
+  if (parsed.value.version !== undefined && options?.version !== undefined) {
+    return Promise.resolve(
+      Result.err(
+        new ValidationError(
+          `Trail "${parsed.value.id}" cannot combine an @version suffix with options.version`
+        )
+      )
+    );
+  }
+
+  const trail = topo.get(parsed.value.id);
   if (trail === undefined) {
     return Promise.resolve(
       Result.err(
@@ -51,5 +66,11 @@ export const run = (
       )
     );
   }
-  return executeTrail(trail, input, { ...options, topo });
+  return executeTrail(trail, input, {
+    ...options,
+    ...(parsed.value.version === undefined
+      ? {}
+      : { version: parsed.value.version }),
+    topo,
+  });
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,6 +5,7 @@ import type { Signal } from './signal.js';
 import type { AnyTrail } from './trail.js';
 import type { CrossInput, TrailOutput } from './type-utils.js';
 import type { ActivationProvenance } from './activation-provenance.js';
+import type { TrailVersionReference } from './version-resolution.js';
 
 // ---------------------------------------------------------------------------
 // Detour
@@ -62,6 +63,17 @@ export interface CrossBatchOptions {
   readonly concurrency?: number | undefined;
 }
 
+/** Runtime options for a single `ctx.cross(trail, input, options)` call. */
+export interface CrossOptions {
+  /**
+   * Execute a specific live version of the crossed trail.
+   *
+   * Omit to keep composition current by default. Historical revision entries
+   * transpose through the current trail; fork entries run their own blaze.
+   */
+  readonly version?: TrailVersionReference | undefined;
+}
+
 /**
  * Trail implementation — sync or async.
  *
@@ -95,9 +107,14 @@ export interface CrossFn {
   ): Promise<CrossBatchResults<TCalls>>;
   <T extends AnyTrail>(
     trail: T,
-    input: CrossInput<T>
+    input: CrossInput<T>,
+    options?: CrossOptions
   ): Promise<Result<TrailOutput<T>, Error>>;
-  <O = unknown>(id: string, input: unknown): Promise<Result<O, Error>>;
+  <O = unknown>(
+    id: string,
+    input: unknown,
+    options?: CrossOptions
+  ): Promise<Result<O, Error>>;
 }
 
 /**

--- a/packages/core/src/version-resolution.ts
+++ b/packages/core/src/version-resolution.ts
@@ -1,0 +1,311 @@
+import {
+  AmbiguousError,
+  TrailsError,
+  ValidationError,
+  VersionNotSupportedError,
+} from './errors.js';
+import { Result } from './result.js';
+import {
+  deriveSupportedTrailVersions,
+  getTrailVersionEntryKind,
+  isArchivedTrailVersionEntry,
+} from './trail.js';
+import type {
+  AnyTrail,
+  TrailVersionForkEntry,
+  TrailVersionRevisionEntry,
+} from './trail.js';
+import {
+  TRAIL_VERSION_MARKER_LENGTH,
+  TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH,
+  deriveTrailVersionMarkers,
+} from './version-marker.js';
+
+export type TrailVersionReference = number | string;
+
+export interface ParsedTrailVersionReference {
+  readonly id: string;
+  readonly version?: TrailVersionReference | undefined;
+}
+
+export type ResolvedTrailVersion =
+  | {
+      readonly current: true;
+      readonly kind: 'current';
+      readonly marker?: string | undefined;
+      readonly version?: number | undefined;
+    }
+  | {
+      readonly current: false;
+      readonly deprecated: boolean;
+      readonly entry: TrailVersionForkEntry;
+      readonly kind: 'fork';
+      readonly marker?: string | undefined;
+      readonly version: number;
+    }
+  | {
+      readonly current: false;
+      readonly deprecated: boolean;
+      readonly entry: TrailVersionRevisionEntry;
+      readonly kind: 'revision';
+      readonly marker?: string | undefined;
+      readonly version: number;
+    };
+
+interface ParsedVersionReference {
+  readonly display: number | string;
+  readonly markerPrefix?: string | undefined;
+  readonly number?: number | undefined;
+}
+
+type MarkerResolvableTrail = Pick<
+  AnyTrail,
+  | 'crosses'
+  | 'detours'
+  | 'id'
+  | 'input'
+  | 'output'
+  | 'resources'
+  | 'version'
+  | 'versions'
+>;
+
+const versionRefPattern = /^(.+)@(.+)$/;
+const positiveIntegerPattern = /^[1-9]\d*$/;
+const markerPrefixPattern = /^[0-9a-fA-F]+$/;
+
+const parsePositiveInteger = (value: string): number | undefined => {
+  if (!positiveIntegerPattern.test(value)) {
+    return undefined;
+  }
+  const version = Number(value);
+  return Number.isSafeInteger(version) ? version : undefined;
+};
+
+const isInlineVersionReference = (value: string): boolean =>
+  parsePositiveInteger(value) !== undefined ||
+  (value.length >= TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH &&
+    value.length <= TRAIL_VERSION_MARKER_LENGTH &&
+    markerPrefixPattern.test(value));
+
+const unsupportedVersion = (
+  trail: Pick<AnyTrail, 'id' | 'version' | 'versions'>,
+  requested: number | string,
+  reason: string
+): VersionNotSupportedError => {
+  const supported = deriveSupportedTrailVersions(trail);
+  return new VersionNotSupportedError(trail.id, requested, supported, reason);
+};
+
+export const parseTrailIdVersionReference = (
+  id: string
+): Result<ParsedTrailVersionReference, ValidationError> => {
+  const match = versionRefPattern.exec(id);
+  if (match === null) {
+    return Result.ok({ id });
+  }
+
+  const [, baseId, rawVersion] = match;
+  if (baseId === undefined || rawVersion === undefined) {
+    return Result.err(
+      new ValidationError(
+        'Trail version reference must use trail.id@N or trail.id@<marker-prefix>'
+      )
+    );
+  }
+  if (!isInlineVersionReference(rawVersion)) {
+    return Result.ok({ id });
+  }
+
+  return Result.ok({ id: baseId, version: rawVersion });
+};
+
+const parseVersionReference = (
+  reference: TrailVersionReference
+): Result<ParsedVersionReference, Error> => {
+  if (typeof reference === 'number') {
+    return Number.isSafeInteger(reference) && reference > 0
+      ? Result.ok({ display: reference, number: reference })
+      : Result.err(
+          new ValidationError(
+            'Trail version reference must be a positive integer'
+          )
+        );
+  }
+
+  const markerRequested = reference.startsWith('@');
+  const raw = markerRequested ? reference.slice(1) : reference;
+  if (raw.length === 0) {
+    return Result.err(
+      new ValidationError('Trail version reference must not be empty')
+    );
+  }
+
+  const number = parsePositiveInteger(raw);
+  if (!markerRequested && number !== undefined) {
+    return Result.ok({
+      display: reference,
+      markerPrefix:
+        raw.length >= TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH &&
+        raw.length <= TRAIL_VERSION_MARKER_LENGTH &&
+        markerPrefixPattern.test(raw)
+          ? raw.toLowerCase()
+          : undefined,
+      number,
+    });
+  }
+
+  if (
+    raw.length >= TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH &&
+    raw.length <= TRAIL_VERSION_MARKER_LENGTH &&
+    markerPrefixPattern.test(raw)
+  ) {
+    return Result.ok({
+      display: reference,
+      markerPrefix: raw.toLowerCase(),
+    });
+  }
+
+  return Result.err(
+    new ValidationError(
+      'Trail version reference must be a positive integer or marker prefix'
+    )
+  );
+};
+
+const trailHasVersion = (
+  trail: Pick<AnyTrail, 'version' | 'versions'>,
+  version: number
+): boolean =>
+  trail.version === version || trail.versions?.[version] !== undefined;
+
+const resolveMarkerReference = (
+  trail: MarkerResolvableTrail,
+  requested: number | string,
+  prefix: string
+): Result<{ readonly marker: string; readonly version: number }, Error> => {
+  let records: ReturnType<typeof deriveTrailVersionMarkers>;
+  try {
+    records = deriveTrailVersionMarkers(trail);
+  } catch (error: unknown) {
+    return Result.err(
+      error instanceof TrailsError
+        ? error
+        : new ValidationError(
+            `Trail version marker derivation failed: ${String(error)}`
+          )
+    );
+  }
+  const matches = records.filter((record) => record.marker.startsWith(prefix));
+
+  if (matches.length === 0) {
+    return Result.err(unsupportedVersion(trail, requested, 'marker missing'));
+  }
+  if (matches.length > 1) {
+    return Result.err(
+      new AmbiguousError(
+        `Trail version marker prefix ${prefix} is ambiguous across versions ${matches.map((record) => record.version).join(', ')}`
+      )
+    );
+  }
+
+  const [match] = matches;
+  if (match === undefined) {
+    return Result.err(unsupportedVersion(trail, requested, 'marker missing'));
+  }
+
+  return Result.ok({ marker: match.marker, version: match.version });
+};
+
+const resolveRequestedVersionNumber = (
+  trail: MarkerResolvableTrail,
+  reference: TrailVersionReference
+): Result<
+  { readonly marker?: string | undefined; readonly version: number },
+  Error
+> => {
+  const parsed = parseVersionReference(reference);
+  if (parsed.isErr()) {
+    return parsed;
+  }
+
+  const { display, markerPrefix, number } = parsed.value;
+  if (number !== undefined && trailHasVersion(trail, number)) {
+    return Result.ok({ version: number });
+  }
+
+  if (markerPrefix !== undefined) {
+    const marker = resolveMarkerReference(trail, display, markerPrefix);
+    if (marker.isOk()) {
+      return marker;
+    }
+    if (number === undefined) {
+      return marker;
+    }
+  }
+
+  return Result.err(unsupportedVersion(trail, display, 'missing'));
+};
+
+export const resolveTrailVersion = (
+  trail: MarkerResolvableTrail,
+  reference?: TrailVersionReference | undefined
+): Result<ResolvedTrailVersion, Error> => {
+  if (reference === undefined) {
+    return Result.ok({
+      current: true,
+      kind: 'current',
+      ...(trail.version === undefined ? {} : { version: trail.version }),
+    });
+  }
+
+  if (trail.version === undefined) {
+    return Result.err(unsupportedVersion(trail, reference, 'unversioned'));
+  }
+
+  const requested = resolveRequestedVersionNumber(trail, reference);
+  if (requested.isErr()) {
+    return requested;
+  }
+
+  if (requested.value.version === trail.version) {
+    return Result.ok({
+      current: true,
+      kind: 'current',
+      ...(requested.value.marker === undefined
+        ? {}
+        : { marker: requested.value.marker }),
+      version: trail.version,
+    });
+  }
+
+  const entry = trail.versions?.[requested.value.version];
+  if (entry === undefined) {
+    return Result.err(unsupportedVersion(trail, reference, 'missing'));
+  }
+  if (isArchivedTrailVersionEntry(entry)) {
+    return Result.err(unsupportedVersion(trail, reference, 'archived'));
+  }
+
+  const kind = getTrailVersionEntryKind(entry);
+  const base = {
+    current: false,
+    deprecated: entry.status?.state === 'deprecated',
+    ...(requested.value.marker === undefined
+      ? {}
+      : { marker: requested.value.marker }),
+    version: requested.value.version,
+  } as const;
+
+  return kind === 'fork'
+    ? Result.ok({
+        ...base,
+        entry: entry as TrailVersionForkEntry,
+        kind,
+      })
+    : Result.ok({
+        ...base,
+        entry: entry as TrailVersionRevisionEntry,
+        kind,
+      });
+};

--- a/packages/core/src/version-runtime.ts
+++ b/packages/core/src/version-runtime.ts
@@ -1,10 +1,15 @@
 import { InternalError, ValidationError } from './errors.js';
 import { Result } from './result.js';
-import { executeTrail } from './execute.js';
 import type { ExecuteTrailOptions } from './execute.js';
 import { getTrailVersionEntryKind } from './trail.js';
 import type { AnyTrail, TrailVersionEntry } from './trail.js';
 import { validateInput, validateOutput } from './validation.js';
+
+export type TrailVersionCurrentExecutor = (
+  trail: AnyTrail,
+  input: unknown,
+  options?: ExecuteTrailOptions
+) => Promise<Result<unknown, Error>>;
 
 const normalizeTransposeError = (
   trail: AnyTrail,
@@ -59,21 +64,13 @@ const runTransposeOutput = async (
   }
 };
 
-const executeCurrentTrail = async (
-  trail: AnyTrail,
-  input: unknown,
-  options?: ExecuteTrailOptions
-): Promise<Result<unknown, Error>> => {
-  const { validationSchema: _validationSchema, ...forwarded } = options ?? {};
-  return await executeTrail(trail, input, forwarded);
-};
-
 export const executeTrailRevision = async (
   trail: AnyTrail,
   version: number,
   entry: TrailVersionEntry,
   rawInput: unknown,
-  options?: ExecuteTrailOptions
+  options: ExecuteTrailOptions | undefined,
+  executeCurrentTrail: TrailVersionCurrentExecutor
 ): Promise<Result<unknown, Error>> => {
   if (getTrailVersionEntryKind(entry) !== 'revision') {
     return Result.err(


### PR DESCRIPTION
## Context

Stack position 6/7 for the Trail Versioning M1 + M2 stack. This PR turns the authored/projected model into runtime behavior while preserving current-by-default composition.

## Changes

- Resolves current, revision, fork, deprecated, archived, missing, and marker-requested trail versions during execution.
- Adds version reference parsing for `trail@N` and marker-prefix references while preserving literal trail IDs unless the suffix is a valid version reference.
- Keeps `ctx.cross()` current by default and requires explicit version pins for historical execution.
- Runs revisions through pure transpose and forks through their own `blaze`.
- Preserves fork-local cross validation without leaking current cross schemas.
- Adds `VersionNotSupportedError` coverage and runtime tests.
- Adds a branch-local changeset for core package impact.

## Verification

- `bun test packages/core/src/__tests__/version-runtime.test.ts packages/core/src/__tests__/version-execution.test.ts`
- `bun run --cwd packages/core test`
- `bun run --cwd packages/core typecheck`
- Focused follow-up tests for marker helper typing, literal `@` IDs, direct fork validation, and fork cross-schema isolation.
- Full stack-tip gate later passed through `bun run publish:check`.

## Risks / Rollout

This does not implement M3 lifecycle gates or surface-level version negotiation. Runtime defaults remain current-only unless a caller explicitly asks for a historical version.

## Linear

- Linear: TRL-115
- Project: Trail Versioning