### PR TITLE
test(testing): run examples across live trail versions

### DIFF
--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/RETRO.md
@@ -1,8 +1,8 @@
 # Execution Retro: Trail Versioning M1 + M2 Stack
 
 Date started: 2026-05-19
-Date finalized: pending
-Status: In progress
+Date finalized: 2026-05-19 22:26 EDT
+Status: Complete for handoff: all seven PRs are submitted, ready, CI-clean, Graphite-ready, remote P2+ clean, and unmerged
 Plan: `.agents/plans/2026-05-19-trail-versioning-m1-m2/PLAN.md`
 Goal: `.agents/plans/2026-05-19-trail-versioning-m1-m2/GOAL.md`
 
@@ -14,45 +14,42 @@ handoff. Meaningful review-flow changes require a new retro entry.
 ## Execution Summary
 
 - Objective: Build and submit the seven-PR Trail Versioning M1 + M2 stack.
-- Final outcome: pending
-- Final branch / stack tip: pending
-- Final PR range: pending
-- Final tracker state: issues moved to In Progress; In Review pending ready PRs
-- Final verification state: branch-local checks passed through TRL-116; post-restack stack-tip gate pending
-- Remaining risks / P3s: pending local review
+- Final outcome: submitted, marked ready, CI-clean, Graphite-ready, remote P2+ review clean after four turns, and not merged
+- Final branch / stack tip: `trl-116-run-examples-and-testall-across-live-version-entries`
+- Final PR range: #532-#538
+- Final tracker state: Linear shows all seven execution issues as Ready to Merge; none are Done
+- Final verification state: required stack-tip gate passed after the latest Codex/Greptile P1/P2 fixes; latest GitHub CI is green on all seven PR heads
+- Remaining risks / P3s: a few docs still use non-command "topo compile" / "compile, verify" prose while runnable command guidance is correct; `TRL-740` tracks non-blocking public/internal API cleanup from residual Greptile prompts.
 - Archive state: previous HTTP/Bun observability packet archived on the lowest branch
 
 ## Branch / PR / Issue Ledger
 
 | Order | Issue | Branch | PR | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `TRL-728` | `trl-728-docsadr-supersede-adr-0044-with-trail-versioning-v3-doctrine` | pending | locally committed | ADR-0048, ADR-0044 supersession, plan packet, archive move, and ADR map formatting fix; current local commit `f76615916`. |
-| 2 | `TRL-729` | `trl-729-feattrails-settle-top-level-cli-namespace-before-versioning` | pending | locally built; restack in progress | Top-level `trails compile` / `trails validate` namespace and stale command cleanup. |
-| 3 | `TRL-113` | `trl-113-define-trail-version-versions-authoring-shape` | pending | locally built; restack in progress | Source and graph authoring shape for `version` / `versions`. |
-| 4 | `TRL-114` | `trl-114-add-pure-transpose-transforms-for-revision-entries` | pending | locally built; restack in progress | Pure `transpose:` revision transforms. |
-| 5 | `TRL-739` | `trl-739-featcore-compute-content-addressed-version-markers` | pending | locally built; restack pending | Projected content-addressed markers and prefix resolution. |
-| 6 | `TRL-115` | `trl-115-resolve-trail-versions-during-execution` | pending | locally built; restack pending | Runtime version resolution by number and marker prefix. |
-| 7 | `TRL-116` | `trl-116-run-examples-and-testall-across-live-version-entries` | pending | locally built; restack pending | Version-aware examples and `testAll`. |
+| 1 | `TRL-728` | `trl-728-docsadr-supersede-adr-0044-with-trail-versioning-v3-doctrine` | #532 | ready; CI/Greptile/Graphite clean | ADR-0048, ADR-0044 supersession, plan packet, archive move, ADR map formatting fix, direct ADR-0008 link, and reviewed historical filename vocab allowlist. |
+| 2 | `TRL-729` | `trl-729-feattrails-settle-top-level-cli-namespace-before-versioning` | #533 | ready; CI/Greptile clean; Graphite ready as stack | Top-level `trails compile` / `trails validate`; accepted ADR and agent-guidance P2 command cleanup applied; breaking changeset severity fixed. |
+| 3 | `TRL-113` | `trl-113-define-trail-version-versions-authoring-shape` | #534 | ready; CI/Greptile/Codex clean; Graphite ready as stack | Source/graph authoring shape; live fork dependency validation and live fork cycle detection P2s fixed. |
+| 4 | `TRL-114` | `trl-114-add-pure-transpose-transforms-for-revision-entries` | #535 | ready; CI/Greptile/Codex clean; Graphite ready as stack | Pure `transpose:` revision transforms; revision `crossInput`, schema array canonicalization, and absent current-output P2s fixed. |
+| 5 | `TRL-739` | `trl-739-featcore-compute-content-addressed-version-markers` | #536 | ready; CI/Greptile/Codex clean; Graphite ready as stack | Projected markers; all-digit prefix, current-marker canonicalization, short numeric missing-version diagnostic, and marker-absent numeric resolution P2s fixed. |
+| 6 | `TRL-115` | `trl-115-resolve-trail-versions-during-execution` | #537 | ready; CI/Greptile/Codex clean; Graphite ready as stack | Runtime version resolution; marker-resolution helper typing, direct fork validation schema propagation, literal `@` ID parsing, and fork-version cross-schema isolation P1 fixed. |
+| 7 | `TRL-116` | `trl-116-run-examples-and-testall-across-live-version-entries` | #538 | ready; CI/Greptile/Codex clean; Graphite ready as stack | Version-aware examples/testAll; guide live-example count, testContracts target narrowing, batch cross version semantics, and current-version fixture ordering fixed. |
 
 ## Planning Discoveries
 
 | Discovery | Evidence | Decision | Impact |
 | --- | --- | --- | --- |
 | `gt sync` pulled PR #530 on top of beta.18. | `git log --oneline -2`: `5d88104c6 docs: align Trails blaze language (#530)`, `4c9c26af3 chore: version packages to 1.0.0-beta.18 (#529)` | Preserve the new blaze-language styleguide in Trail Versioning docs and Linear. | Updated TRL-728 scope, TRL-120 wording, project body, and M1 milestone. |
-| Graphite cannot clean merged branch `trl-735-blaze-language-styleguide` because it is checked out in another worktree. | `gt sync` warning and `context-prime.sh` worktree list. | Treat as non-blocking for this stack. | Continued from clean `main`. |
+| Graphite cannot clean merged branch `trl-735-blaze-language-styleguide` because it is checked out in another worktree. | `gt sync` warning and worktree list. | Treat as non-blocking for this stack. | Continued from clean `main`. |
 | Existing previous active packet was still tracked. | `git ls-files .agents/plans/2026-05-16-http-bun-observability-closeout` listed tracked files. | Move it to archive on the lowest execution branch because that stack was complete. | TRL-728 owns the archive move. |
-| `context-prime.sh` hit a known local jq option failure while scanning open PRs. | Command output: `jq: Unknown option --argfile`. | Treat primer as advisory; verify PR state directly. | PR #531 was verified directly and is not a base. |
-| Linear stale-term sweep was clean after updates. | Linear search returned no active issue hits for stale doctrine terms. | Proceed to packet. | No extra versioning follow-up issues needed before kickoff. |
+| PR #531 is unrelated. | `gh pr view 531` showed branch `trl-738-add-codex-clark-agent-wiring`, base `main`, draft/open. | Do not use it as a base. | Stack remains based on `main`. |
 
 ## Deferred / Follow-Up Discoveries
-
-Out-of-goal discoveries belong here first. Create focused follow-up issues when
-they represent real future work.
 
 | Issue | Discovery | Why Out Of Goal | Link |
 | --- | --- | --- | --- |
 | pending | Any M3 lifecycle/surface/gate work discovered while implementing M2. | M3 is deliberately excluded from this stack. | pending |
 | pending | Any M4 consumer migration/codemod work discovered while implementing M1/M2. | `TRL-508` is the later consumer migration phase. | pending |
+| `TRL-740` | Greptile left P3 cleanup prompts for a clearer absent-marker diagnostic in `deriveShortestUnambiguousTrailVersionMarkerPrefix`, an unreachable defensive guard in version-resolution narrowing, and exported-but-internal execution option fields. | These are public-surface polish follow-ups after the stack was already CI-clean, Graphite-ready, and remote P2+ clean. | <https://linear.app/outfitter/issue/TRL-740/chorecore-tighten-trail-versioning-publicinternal-api-cleanup> |
 
 ## Tracker Mutations
 
@@ -69,147 +66,206 @@ they represent real future work.
 | 2026-05-19 18:49 EDT | `TRL-739` | Moved to In Progress when the marker branch started. | Linear issue update |
 | 2026-05-19 19:03 EDT | `TRL-115` | Moved to In Progress when the runtime-resolution branch started. | Linear issue update |
 | 2026-05-19 19:26 EDT | `TRL-116` | Moved to In Progress when the examples/testAll branch started. | Linear issue update |
+| 2026-05-19 20:22 EDT | `TRL-728`-`TRL-116` | Moved all seven execution issues to In Review after PRs #532-#538 were marked ready. | Linear issue updates |
+| 2026-05-19 21:16 EDT | `TRL-728`-`TRL-116` | Verified all seven now show Ready to Merge in Linear automation; none are Done. | Linear issue fetch/list |
+| 2026-05-19 22:25 EDT | `TRL-740` | Created a focused Backlog follow-up for residual P3 public/internal API cleanup from Greptile comments. | Linear issue create |
 
 ## Execution Log
 
-Append meaningful state changes, especially before handoff points.
-
 ```text
-2026-05-19 18:09 EDT - planning
-- Changed: Seeded PLAN.md, GOAL.md, REFS.md, and RETRO.md for Trail Versioning M1 + M2.
-- Verified: gt sync completed; main clean; Linear stale-term searches clean after tracker updates.
-- Result: Packet ready for goal kickoff.
-- Next: Goal executor should create the Graphite stack from TRL-728 upward.
-- Blockers: none known.
-
 2026-05-19 18:20 EDT - preflight and TRL-728 branch start
-- Changed: Ran fresh gt sync, confirmed main at 5d88104c6, created the TRL-728 branch, moved the completed HTTP/Bun observability packet to archive, and added ADR-0048 plus ADR/lexicon/styleguide updates.
+- Changed: Created the TRL-728 branch, archived the completed HTTP/Bun observability packet, and added ADR-0048 plus ADR/lexicon/styleguide updates.
 - Verified: main status, PR #531 base/unrelated state, Linear issue text/branch names, bun scripts/adr.ts map, and bun scripts/adr.ts check.
-- Result: Lowest execution branch owns the plan packet, previous packet archive move, and TRL-728 docs/ADR scope.
 - Blockers: none.
 
 2026-05-19 18:27 EDT - TRL-729 CLI namespace branch
-- Changed: Promoted app trails from topo.compile/topo.verify to top-level compile/validate, updated docs/tests/Warden/topographer stale-command copy, and added a branch-local changeset.
-- Verified: App, topographer, and Warden focused tests; CLI help for trails, compile, and validate; stale command sweep; format and diff checks.
-- Result: TRL-729 locally built.
+- Changed: Promoted topo.compile/topo.verify to top-level compile/validate, updated docs/tests/Warden/topographer stale-command copy, and added a branch-local changeset.
+- Verified: Focused app/topographer/Warden tests, CLI help, stale command sweep, format, and diff checks.
 - Blockers: none.
 
 2026-05-19 18:39 EDT - TRL-113 authoring-shape branch
 - Changed: Added trail-only version/versions source shape, normalized version-entry runtime data, rejected authored kind and invalid historical contracts, reserved version?: never on non-trail specs, projected entries into TopoGraph, and added tests/changeset.
-- Verified: Core/topographer tests, package and root typechecks, format, diff check, and no .v*.ts discovery sweep.
-- Result: TRL-113 locally built.
+- Verified: Core/topographer tests, typechecks, format, diff check, and no .v*.ts discovery sweep.
 - Blockers: none.
 
 2026-05-19 18:48 EDT - TRL-114 pure-transpose branch
 - Changed: Added pure revision transpose validation and execution helpers, required transpose for schema-changing revisions, kept same-schema metadata revisions zero-cost, and added tests/changeset.
 - Verified: Core focused tests/typecheck, root test, ADR check, format, diff check, and stale transpose vocabulary sweep.
-- Result: TRL-114 locally built.
 - Blockers: none.
 
 2026-05-19 18:59 EDT - TRL-739 marker branch
-- Changed: Added core marker hashing/prefix helpers, rejected authored marker fields, projected 16-character markers into current and historical TopoGraph entries, added unambiguous marker-prefix helpers, and added tests/changeset.
+- Changed: Added marker hashing/prefix helpers, rejected authored marker fields, projected 16-character markers, added prefix resolution helpers, and added tests/changeset.
 - Verified: Core/topographer focused tests, root typecheck, format, and diff check.
-- Result: TRL-739 locally built.
 - Blockers: none.
 
 2026-05-19 19:25 EDT - TRL-115 runtime-resolution branch
 - Changed: Added runtime version reference parsing/resolution, VersionNotSupportedError, executeTrail/run version resolution, current-default ctx.cross(), explicit version pins, fork cross validation, and tests/changeset.
 - Verified: Focused runtime/version tests, full core tests, root typecheck, format, and diff check.
-- Result: TRL-115 locally built.
 - Blockers: none.
 
 2026-05-19 19:36 EDT - TRL-116 examples/testAll branch
-- Changed: Added version-entry examples, historical example validation/projection, survey/guide version detail output, version-aware testExamples/testContracts/testAll, archived-entry skip behavior, and testing cross version forwarding.
-- Verified: Focused core/testing/topographer/Trails app suites, focused package/app typechecks, root format, root typecheck, root lint, root test, and diff check.
-- Result: TRL-116 locally built and committed before the owning-branch fix.
+- Changed: Added version-entry examples, validation/projection, survey/guide detail output, version-aware testExamples/testContracts/testAll, archived-entry skip behavior, and testing cross version forwarding.
+- Verified: Focused core/testing/topographer/Trails app suites, focused package/app typechecks, root format, and diff check.
 - Blockers: none.
 
 2026-05-19 19:40 EDT - TRL-728 owning-branch verification fix
 - Changed: Fixed ADR decision-map inline primitive-array formatting threshold on the lowest owning ADR branch so adr map and format:check agree.
 - Verified: bun scripts/adr.ts map, bun scripts/adr.ts check, bun run format:check, and git diff --check passed on TRL-728.
-- Result: TRL-728 amended to f76615916; descendants are being restacked.
 - Blockers: none.
+
+2026-05-19 20:10 EDT - stack-tip gate and local review round 1
+- Verified: Full stack-tip gate passed through bun run publish:check and Warden guidance checks.
+- Review: Three local review lanes produced reports under the packet. Latest round found P2s in docs/CLI, core validation/marker behavior, and guide example counts.
+- Result: Owning-branch P2 fix loop started.
+
+2026-05-19 20:20 EDT - owning-branch P2 fixes
+- Changed: Fixed TRL-116 guide live-version example counts; fixed TRL-729 accepted ADR command guidance; fixed TRL-113 live fork dependency validation.
+- Verified: Focused tests/checks passed on each owning branch before gt modify.
+- Result: First half of P2 fix loop completed.
+
+2026-05-19 20:42 EDT - marker/runtime P2 fixes
+- Changed: Fixed TRL-739 all-digit marker-prefix resolution and current marker runtime-field canonicalization; fixed TRL-115 marker helper typing after current markers began requiring full runtime declarations.
+- Verified: Core/topographer marker tests, runtime version tests, and package typechecks passed on owning branches and at the stack tip.
+- Result: All known local-review P2s fixed and restacked.
+
+2026-05-19 21:05 EDT - local review closeout and full tip gate
+- Changed: Rewrote local review reports to reflect initial findings, owning-branch fixes, and latest P3-only residuals.
+- Verified: Full tip gate passed: ADR map/check, typecheck, test, lint, ast-grep lint, build, format check, check, publish check, Warden sync/check pair, and git diff check.
+- Result: Local build/review/verification complete. Draft PR submission is next.
+
+2026-05-19 21:12 EDT - local review artifact stabilization
+- Changed: Removed an unstable stack-tip hash from the post-fix core/runtime review report so the report remains accurate after final amend.
+- Verified: format check and diff check remained clean.
+- Result: Local review artifacts are ready for draft submission.
+
+2026-05-19 21:25 EDT - draft PR submission
+- Changed: Submitted draft PRs #532-#538 and replaced generated PR titles/bodies with stack-aware context, changes, verification, risks, and Linear links.
+- Verified: GitHub CI Gate passed on all seven draft PRs; local review remained P3-only.
+- Result: Stack is ready to move from draft to ready once readiness bookkeeping is updated.
+
+2026-05-19 20:22 EDT - ready-for-review bookkeeping
+- Changed: Marked PRs #532-#538 ready for review and moved `TRL-728`, `TRL-729`, `TRL-113`, `TRL-114`, `TRL-739`, `TRL-115`, and `TRL-116` to In Review.
+- Verified: GitHub CI Gate remained green on all seven ready PRs; Greptile and Graphite mergeability checks were still in progress at the first ready-state poll.
+- Result: Remote review wait window and bot-comment sweep are next.
+
+2026-05-19 20:28 EDT - remote review turn 1, TRL-728 P1
+- Review: Greptile on #532 reported a P1 broken ADR-0008 reference in ADR-0048 and the corresponding missing ADR-0008 inbound decision-map edge.
+- Changed: Fixed ADR-0048's ADR-0008 link on the lowest owning branch and regenerated `docs/adr/decision-map.json`.
+- Verified: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run format:check`, and `git diff --check` passed after restacking to the tip.
+- Result: Remote P1 fixed locally; refreshed stack submission and bot re-check are next.
+
+2026-05-19 20:54 EDT - remote review turn 2, bottom-up P2+ fixes
+- Review: Greptile reported P1/P2 findings on #533, #536, #537, and #538 after the refreshed stack review.
+- Changed: Updated the `@ontrails/trails` CLI namespace changeset from patch to major on TRL-729; made short numeric strings fail as missing versions instead of marker-prefix errors on TRL-739; preserved caller `validationSchema` for direct fork-version execution on TRL-115; replaced the unreachable `testContracts` output-schema guard with a type guard on TRL-116.
+- Verified: Focused topographer/core/testing tests, package typechecks, `bun run format:check`, and `git diff --check` passed at the stack tip.
+- Result: Remote P2+ fixes are local and ready for refreshed submission.
+
+2026-05-19 20:59 EDT - remote review turn 2, local gate closeout
+- Review: The full post-fix gate exposed one local vocab-audit blocker from ADR-0048's direct link to ADR-0008's historical filename.
+- Changed: Added a narrow `surface-term` allowlist for the reviewed ADR-0048 link on TRL-728, then restacked through TRL-116.
+- Verified: Full stack-tip gate passed: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run build`, `bun run format:check`, `bun run check`, `bun run publish:check`, and `git diff --check`.
+- Result: Remote-review fixes and local gate closeout are complete locally; refreshed stack submission is next.
+
+2026-05-19 21:17 EDT - remote review closeout poll
+- Changed: Resubmitted the refreshed stack; no source edits after the reviewed code fixes.
+- Verified: `gh pr checks` shows active CI clean and Greptile no longer pending across #532-#538; GraphQL review-thread sweep found no unresolved active threads; latest Greptile comments contain no new P0/P1/P2 findings and #538 explicitly says the previous P1/P2 findings are resolved.
+- Tracker: Linear shows all seven execution issues as Ready to Merge, with no issue marked Done.
+- Blocker: Graphite mergeability remains pending on #533-#538 after the post-resubmit wait. Stop state is not merged/published and not merge-queue-labeled.
+
+2026-05-19 21:24 EDT - Graphite closeout
+- Verified: `gt branch info` reports #532 as "Ready to merge" and #533-#538 as "Ready to merge as stack".
+- Note: GitHub's raw check rollup still showed stale `Graphite / mergeability_check` pending rows on #533-#538, but Graphite's own branch metadata reports the stack ready.
+- Result: Stack is merge-ready from Graphite's perspective and still not merged, published, registry-mutated, or merge-queue-labeled.
+
+2026-05-19 21:26 EDT - requested Codex review triggers
+- Changed: Posted `@codex review` comments on PRs #532-#538 per Matt's request.
+- Verified: `gh pr comment` returned `ok commented` for all seven PRs.
+- Result: Codex review triggers are posted; stack remains unmerged, unpublished, registry-clean, and not merge-queue-labeled.
+
+2026-05-19 21:42 EDT - remote review turn 3, Codex P1/P2 follow-up fixes
+- Review: Codex follow-up comments after the final RETRO resubmit reported P1/P2 findings on #534, #535, #536, #537, and #538.
+- Changed: Fixed live fork-version cycle validation on TRL-113; canonicalized order-insensitive schema arrays and allowed explicit historical no-output entries when current output has no schema on TRL-114; allowed numeric TopoGraph version resolution without markers on TRL-739; preserved literal trail IDs containing `@` unless the suffix is a valid version reference on TRL-115; and aligned testing batch `ctx.cross([...])` semantics with runtime by using inline per-target version references on TRL-116.
+- Verified: Focused owning-branch tests and package typechecks passed for each fix.
+- Result: Latest remote P1/P2 findings are fixed locally. Required full stack-tip gate and refreshed submission are next.
+
+2026-05-19 22:10 EDT - remote review turn 4, Greptile P1 follow-up and fixture cleanup
+- Review: Greptile reported a new P1 on #537 where parent cross validation could leak into fork-version execution when the fork had no `crossInput`.
+- Changed: Fixed fork-version recursive execution to clear the validation override when the fork does not supply a cross schema, added regression coverage on TRL-115, and adjusted TRL-115/TRL-116 fixtures so historical entries remain below the current top-level version.
+- Verified: Focused core/testing tests and package typechecks passed on owning branches, then the full required stack-tip gate passed through `bun run publish:check` and `git diff --check`.
+- Result: Fourth post-ready remote-review turn is fixed locally. Refreshed stack submission and remote closeout poll are next.
+
+2026-05-19 22:26 EDT - final remote closeout
+- Changed: No source changes after the remote turn 4 fixes; this ledger was finalized to reflect the live remote state.
+- Verified: GitHub PR metadata shows #532-#538 open, non-draft, unmerged, with heads matching local branch heads and no labels; GitHub Actions CI is successful on all seven current head SHAs at the closeout poll; review-thread sweep shows no unresolved active threads; Graphite reports #532 Ready to merge and #533-#538 Ready to merge as stack; Linear shows all seven issues Ready to Merge and none Done.
+- Follow-up: Created `TRL-740` for residual P3 public/internal API cleanup from Greptile's safe-to-merge quality prompts.
+- Result: Completion condition is satisfied short of merge/publish, which are intentionally not performed.
 ```
 
 ## Local Review Log
 
-Record local review rounds, reports, P0/P1/P2 findings, fixes, and remaining
-P3s. Do not mark local review complete while P0/P1/P2 findings remain.
-
 | Round | Scope / Lanes | Report Paths | P0/P1/P2 Result | Fix Commits / Notes |
 | --- | --- | --- | --- | --- |
-| pending | pending | pending | pending | pending |
+| 1 | Docs/CLI and doctrine | `reports/local-review-round-1-docs-cli.md`; `reports/local-review-round-1-doctrine-cli.md` | P2s fixed; P3 residuals remain | TRL-729 owns command-doc and bundled guidance fixes. |
+| 2 | Core/runtime/markers | `reports/local-review-round-2-core-runtime-markers.md` | P2s fixed | TRL-113, TRL-114, TRL-739, and TRL-115 own fixes. |
+| 3 | Testing/API/changesets | `reports/local-review-round-3-testing-public-api-changesets.md` | P2 fixed | TRL-116 owns guide example-count fix. |
+| 4 | Post-fix clean sweep | `reports/local-review-round-4-final-clean-sweep.md`; `reports/local-review-round-4-post-fix-docs-cli.md`; `reports/local-review-round-5-post-fix-core-runtime-markers.md`; `reports/local-review-round-6-post-fix-testing-public-api-changesets.md` | P3-only | Latest local review can stop. |
 
 ## Verification Log
 
 | Command | Branch / Context | Result | Notes |
 | --- | --- | --- | --- |
-| `gt sync` | `main` | passed | Pulled PR #530; warned about merged branch in another worktree. |
-| `git status --short --branch` | `main` after sync | passed | `## main...origin/main` before packet creation. |
-| Linear stale-term search | Trail Versioning issues | passed | No active hits after updates for stale doctrine terms. |
-| `gh pr view 531 --json ...` | preflight | passed | PR #531 is `trl-738-add-codex-clark-agent-wiring`, draft/open, base `main`, unrelated to versioning stack. |
-| `bun scripts/adr.ts map` | TRL-728 | passed | Updated ADR decision map after ADR-0048 and supersession edits. |
-| `bun scripts/adr.ts check` | TRL-728 | passed | 0 errors, 0 warnings. |
-| `bun run format:check` | TRL-728 | passed | Passed after generated ADR map formatting cleanup. |
-| `git diff --check` | TRL-728 | passed | No whitespace errors. |
-| `bun scripts/adr.ts map` | TRL-728 owning-branch fix | passed | Re-generated maps after aligning ADR JSON inline-array threshold with formatter expectations. |
-| `bun scripts/adr.ts check` | TRL-728 owning-branch fix | passed | 0 errors, 0 warnings. |
-| `bun run format:check` | TRL-728 owning-branch fix | passed | Passed after ADR generator threshold fix. |
-| `git diff --check` | TRL-728 owning-branch fix | passed | No whitespace errors. |
-| `bun run --cwd apps/trails test` | TRL-729 | passed | 318 tests, 0 failures. |
-| `bun run --cwd apps/trails typecheck` | TRL-729 | passed | `tsc --noEmit` exited 0. |
-| `bun run --cwd packages/topographer test` | TRL-729 | passed | 121 tests, 0 failures. |
-| `bun run --cwd packages/warden test` | TRL-729 | passed | 888 tests, 0 failures. |
-| stale command `rg` sweep | TRL-729 | passed | No current-facing matches for retired topo compile/verify names outside historical exclusions. |
-| `bun apps/trails/bin/trails.ts --help` | TRL-729 | passed | Shows top-level compile and validate. |
-| `bun apps/trails/bin/trails.ts compile --help` | TRL-729 | passed | Top-level compile command renders expected help. |
-| `bun apps/trails/bin/trails.ts validate --help` | TRL-729 | passed | Top-level validate command renders expected help. |
-| `bun run format:check` | TRL-729 | passed | Passed after formatter cleanup. |
-| `git diff --check` | TRL-729 | passed | No whitespace errors. |
-| `bun run --cwd packages/core test` | TRL-113 | passed | 1116 tests, 0 failures. |
-| `bun run --cwd packages/topographer test` | TRL-113 | passed | 122 tests, 0 failures. |
-| `bun run --cwd packages/core typecheck` | TRL-113 | passed | `tsc --noEmit` exited 0. |
-| `bun run --cwd packages/topographer typecheck` | TRL-113 | passed | `tsc --noEmit` exited 0. |
-| `bun run typecheck` | TRL-113 | passed | 22 package tasks successful. |
-| `.v*.ts` live-code sweep | TRL-113 | passed | No current code matches for version-file discovery or `.vN.ts` filenames. |
-| `bun run format:check` | TRL-113 | passed | Passed after formatter cleanup and minimal lint fix. |
-| `git diff --check` | TRL-113 | passed | No whitespace errors. |
-| `bun run --cwd packages/core test` | TRL-114 | passed | 1121 tests, 0 failures. |
-| `bun run --cwd packages/core typecheck` | TRL-114 | passed | `tsc --noEmit` exited 0. |
-| `bun scripts/adr.ts check` | TRL-114 | passed | 0 errors, 0 warnings. |
-| stale transpose vocabulary `rg` sweep | TRL-114 | passed | No live-code matches for stale bridge/adapter/reroute behavior beyond doctrine examples. |
-| `bun run format:check` | TRL-114 | passed | Passed after formatter cleanup. |
-| `git diff --check` | TRL-114 | passed | No whitespace errors. |
-| `bun run test` | TRL-114 | passed | 37 package tasks successful. |
-| `bun run --cwd packages/core test` | TRL-739 | passed | 1126 tests, 0 failures. |
-| `bun run --cwd packages/topographer test` | TRL-739 | passed | 127 tests, 0 failures. |
-| `bun run typecheck` | TRL-739 | passed | 22 package tasks successful. |
-| `bun run format:check` | TRL-739 | passed | Passed after formatter cleanup. |
-| `git diff --check` | TRL-739 | passed | No whitespace errors. |
-| `bun test packages/core/src/__tests__/version-runtime.test.ts packages/core/src/__tests__/version-execution.test.ts` | TRL-115 | passed | 13 tests, 0 failures. |
-| `bun run --cwd packages/core test` | TRL-115 | passed | 1147 tests, 0 failures. |
-| `bun run typecheck` | TRL-115 | passed | 22 package tasks successful. |
-| `bun run format:check` | TRL-115 | passed | Passed after removing the runtime import cycle and updating direct unit tests. |
-| `git diff --check` | TRL-115 | passed | No whitespace errors. |
-| `bun run --cwd packages/core typecheck` | TRL-116 | passed | `tsc --noEmit` exited 0. |
-| `bun run --cwd packages/testing typecheck` | TRL-116 | passed | `tsc --noEmit` exited 0. |
-| `bun run --cwd packages/topographer typecheck` | TRL-116 | passed | `tsc --noEmit` exited 0. |
-| `bun run --cwd apps/trails typecheck` | TRL-116 | passed | `tsc --noEmit` exited 0. |
-| `bun run --cwd packages/core test` | TRL-116 | passed | 1149 tests, 0 failures. |
-| `bun run --cwd packages/testing test` | TRL-116 | passed | 176 tests, 0 failures. |
-| `bun run --cwd packages/topographer test` | TRL-116 | passed | 129 tests, 0 failures. |
-| `bun run --cwd apps/trails test` | TRL-116 | passed | 320 tests, 0 failures. |
-| `bun run format:check` | TRL-116 | passed | Passed after targeted formatter cleanup. |
-| `bun run typecheck` | stack tip before owning fix | passed | 22 package tasks successful. |
-| `bun run lint` | stack tip before owning fix | passed | Root lint passed. |
-| `bun run test` | stack tip before owning fix | passed | 37 package tasks successful. |
-| `git diff --check` | TRL-116 | passed | No whitespace errors. |
+| `gt sync` | `main` | passed | Pulled PR #530; PR #531 remained unrelated. |
+| `bun scripts/adr.ts map` | stack tip | passed | No drift after final rerun before local review. |
+| `bun scripts/adr.ts check` | stack tip | passed | 0 errors, 0 warnings. |
+| `bun run typecheck` | stack tip | passed | 22 package tasks successful. |
+| `bun run test` | stack tip | passed | 37 package tasks successful. |
+| `bun run lint` | stack tip | passed | Root lint passed. |
+| `bun run lint:ast-grep` | stack tip | passed | No findings. |
+| `bun run build` | stack tip | passed | 22 package tasks successful. |
+| `bun run format:check` | stack tip | passed | No formatting errors. |
+| `bun run check` | stack tip | passed | Warden warning-only report remained existing/non-blocking. |
+| `bun run publish:check` | stack tip | passed | Bun pack checks passed for public packages; no publish command run. |
+| `git diff --check` | stack tip | passed | No whitespace errors. |
+| `bun run warden:agents:sync` / `check` | stack tip | passed | No generated guidance diffs after sync. |
+| `bun run warden:skills:sync` / `check` | stack tip | passed | No generated guidance diffs after sync. |
+| `bun scripts/adr.ts check` / `bun run vocab:audit` / `bun run format:check` / `git diff --check` | TRL-729 P2 fix | passed | Accepted ADR command guidance updated to `trails compile`, `trails validate`, and current survey diff wording. |
+| `bun test packages/core/src/__tests__/validate-topo.test.ts` / `bun run --cwd packages/core typecheck` / `bun run format:check` / `git diff --check` | TRL-113 P2 fix | passed | Live non-archived fork version crosses/resources now validate against topo declarations. |
+| `bun test apps/trails/src/__tests__/guide.test.ts` / `bun run --cwd apps/trails typecheck` | TRL-116 P2 fix | passed | Guide list counts live historical examples and skips archived entries. |
+| `bun test packages/core/src/__tests__/version-marker.test.ts packages/topographer/src/__tests__/derive.test.ts` / package typechecks | TRL-739 P2 fix | passed | Current markers include stable runtime fields and numeric-looking marker prefixes resolve when no numeric version exists. |
+| `bun run --cwd packages/core typecheck` / focused runtime tests | TRL-115 P2 fix | passed | Runtime marker derivation now receives full current marker fields. |
+| focused tip tests for marker/runtime/validate/guide/testing | stack tip after restack | passed | 174 tests across 7 files after TRL-115 restack. |
+| `bun scripts/adr.ts map` / `bun scripts/adr.ts check` / `bun run format:check` / `git diff --check` | TRL-728 remote P1 fix and restacked tip | passed | ADR-0048 now links ADR-0008 directly and the decision map contains the ADR-0048 inbound edge for ADR-0008. |
+| focused remote-review tests / package typechecks / `bun run format:check` / `git diff --check` | remote turn 2 fixes | passed | Covered TRL-729 changeset severity, TRL-739 numeric reference diagnostics, TRL-115 fork validation schema propagation, and TRL-116 contract target narrowing. |
+| `bun scripts/vocab-cutover-audit.ts --rule surface-term` / `bun scripts/adr.ts check` / `bun run format:check` / `git diff --check` | TRL-728 historical filename allowlist | passed | ADR-0048 can link ADR-0008 directly without weakening the active surface-term vocab rule. |
+| `bun scripts/adr.ts map` / `bun scripts/adr.ts check` / `bun run typecheck` / `bun run test` / `bun run lint` / `bun run lint:ast-grep` / `bun run build` / `bun run format:check` / `bun run check` / `bun run publish:check` / `git diff --check` | stack tip after remote turn 2 local gate closeout | passed | Required tip gate is green after remote P2+ fixes; `publish:check` was dry-run pack verification only. |
+| `gt submit --stack --no-edit --no-interactive` | refreshed remote submission | passed | Branches #532-#538 updated; worktree was clean immediately after submit. |
+| `gh pr checks` / GraphQL review-thread sweep / latest Greptile comment sweep | remote closeout poll | passed | CI and Greptile clean; no unresolved active threads or new P2+ comments. GitHub's raw Graphite rows were stale/pending for #533-#538. |
+| `gt branch info` for all seven branches | Graphite closeout | passed | #532 reports Ready to merge; #533-#538 report Ready to merge as stack. |
+| `gh pr comment 532..538 --body '@codex review'` | requested Codex review triggers | passed | All seven PRs accepted the comment. |
+| Linear issue list/fetch | tracker closeout poll | passed | All seven execution issues show Ready to Merge; none are Done. |
+| `bun test packages/core/src/__tests__/validate-topo.test.ts` | TRL-113 Codex follow-up fix | passed | Live non-archived fork version crosses now participate in cycle detection; archived fork crosses remain inert. |
+| `bun test packages/core/src/__tests__/trail.test.ts packages/core/src/__tests__/version-runtime.test.ts` | TRL-114 Codex follow-up fix | passed | Equivalent schema arrays compare canonically; explicit no-output historical revisions work when current output schema is absent. |
+| `bun test packages/topographer/src/__tests__/derive.test.ts` / `bun run --cwd packages/topographer typecheck` | TRL-739 Codex follow-up fix | passed | Numeric version references resolve even when marker fields are absent. |
+| `bun test packages/core/src/__tests__/version-execution.test.ts` / `bun run --cwd packages/core typecheck` | TRL-115 Codex follow-up fix | passed | Literal `@` trail IDs without valid version suffixes are preserved. |
+| `bun test packages/testing/src/__tests__/examples.test.ts` / `bun run --cwd packages/testing typecheck` | TRL-116 Codex follow-up fix | passed | Batch `ctx.cross([...])` follows runtime semantics; inline target version references remain supported. |
+| `bun test packages/core/src/__tests__/version-execution.test.ts` / `bun run --cwd packages/core typecheck` | TRL-115 Greptile follow-up fix | passed | Fork versions without `crossInput` no longer inherit the parent current trail's cross-validation schema; runtime fixture current version is above live fork version 5. |
+| `bun test packages/testing/src/__tests__/all.test.ts packages/testing/src/__tests__/contracts.test.ts packages/testing/src/__tests__/examples.test.ts` / `bun run --cwd packages/testing typecheck` | TRL-116 fixture follow-up | passed | Version-aware testing fixtures keep archived historical entries below the current top-level version. |
+| `bun scripts/adr.ts map` / `bun scripts/adr.ts check` / `bun run typecheck` / `bun run test` / `bun run lint` / `bun run lint:ast-grep` / `bun run build` / `bun run format:check` / `bun run check` / `bun run publish:check` / `git diff --check` | stack tip after remote turn 4 local gate closeout | passed | Required tip gate is green after latest Codex/Greptile P1/P2 fixes; `publish:check` was dry-run pack verification only. |
+| GitHub PR metadata / workflow runs / review-thread sweep / issue metadata | final remote closeout | passed | #532-#538 are open, non-draft, unmerged, label-free, and current heads match local branch heads; CI is successful on all seven current head SHAs; no unresolved active review threads remain. |
+| `gt branch info` for all seven branches | final Graphite closeout | passed | #532 reports Ready to merge; #533-#538 report Ready to merge as stack on the final submitted commits. |
+| Linear issue fetch for `TRL-728`, `TRL-729`, `TRL-113`, `TRL-114`, `TRL-739`, `TRL-115`, `TRL-116` plus `TRL-740` creation | final tracker closeout | passed | All seven execution issues show Ready to Merge with PR attachments; none are Done; residual P3 API cleanup is tracked in Backlog as `TRL-740`. |
 
 ## Remote Review / CI Log
 
 | PR | Review Source | Status | P0/P1/P2 Actions | Notes |
 | --- | --- | --- | --- | --- |
-| pending | pending | pending | pending | pending |
+| #532 | Greptile / GitHub CI / Graphite | clean | P1 fixed on TRL-728 | ADR-0008 reference, decision-map inbound edge, and local vocab gate fixed. |
+| #533 | Greptile / GitHub CI / Graphite | clean; Graphite ready as stack | P1 fixed on TRL-729 | CLI namespace changeset severity and migration/ADR command guidance fixed. |
+| #534 | Greptile / Codex / GitHub CI / Graphite | clean; Graphite ready as stack | P2 fixed on TRL-113 | Live fork-version cross cycles are now detected. |
+| #535 | Greptile / Codex / GitHub CI / Graphite | clean; Graphite ready as stack | P2 fixed on TRL-114 | Revision schema comparison is order-insensitive for set-like schema arrays, and absent current output schemas are compatible with explicit historical no-output entries. |
+| #536 | Greptile / Codex / GitHub CI / Graphite | clean; Graphite ready as stack | P1/P2 fixed on TRL-739 | Short numeric strings now report missing versions; numeric versions resolve even when marker fields are absent. |
+| #537 | Greptile / Codex / GitHub CI / Graphite | clean; Graphite ready as stack | P1 fixed on TRL-115 | Direct fork-version execution preserves caller-provided validation schemas, literal IDs containing `@` are preserved unless the suffix is a valid version reference, and fork versions without `crossInput` clear parent cross schemas. |
+| #538 | Greptile / Codex / GitHub CI / Graphite | clean; Graphite ready as stack | P1/P2 fixed on TRL-116 | `testContracts` now uses a type guard, testing batch cross execution no longer forwards a single version option to every branch, and fixtures keep archived entries below current. |
 
 ## Forbidden Actions Audit
 
@@ -224,6 +280,11 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 
 ## Final State
 
-Pending restack completion, stack-tip verification, local review, draft PR
-submission, CI, ready-for-review, remote review, Linear In Review updates, and
-final handoff.
+Local build, local review, draft PR submission, ready-for-review transition,
+Linear tracker updates, Greptile/Codex P2+ fixes, Greptile/Codex closeout,
+Graphite closeout, requested Codex review trigger comments, final stack-tip
+gate, final remote closeout, and `TRL-740` P3 follow-up creation are complete.
+The latest submitted stack is CI-clean and Graphite-ready.
+
+The stack is not merged. No package publish, registry mutation, merge, or
+merge-queue label action was performed.

--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-1-docs-cli.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-1-docs-cli.md
@@ -1,0 +1,49 @@
+# Local Review Round 1: Docs / CLI
+
+Date: 2026-05-19
+Stack tip reviewed: `trl-116-run-examples-and-testall-across-live-version-entries`
+
+## Scope
+
+- ADR-0048 doctrine and ADR-0044 supersession.
+- ADR-0016 forward pointer.
+- Lexicon and language-styleguide versioning vocabulary.
+- CLI namespace cleanup after `trails compile` / `trails validate`.
+- Post-PR #530 blaze wording.
+
+## Initial Findings
+
+### P2: Accepted ADR docs still taught retired topo command grammar
+
+Accepted ADRs 0014, 0015, 0017, and 0019 still presented `trails topo compile`, `trails topo verify`, or `trails topo diff` as current operator guidance after TRL-729 promoted the namespace to top-level `trails compile`, `trails validate`, and `trails survey diff --against`.
+
+Resolution: fixed on `trl-729-feattrails-settle-top-level-cli-namespace-before-versioning`.
+
+### P2: Bundled agent guidance still used retired topo commands
+
+`plugin/skills/trails/SKILL.md`, `plugin/agents/trail-engineer.md`, and `plugin/skills/trails/references/migration-checklist.md` still instructed agents to run `trails topo compile` / `trails topo verify`.
+
+Resolution: fixed on `trl-729-feattrails-settle-top-level-cli-namespace-before-versioning`.
+
+## Latest Sweep
+
+No current-facing P0/P1/P2 findings remain in docs, apps, packages, plugin guidance, or the active packet. Remaining hits for retired command names are historical/supersession contexts:
+
+- ADR-0048 explicitly states that `trails topo compile` promotes to `trails compile` and `trails topo verify` is retired.
+- ADR drafts keep old names as historical proposal text.
+- The active plan/goal files preserve the original execution instructions.
+
+## P3 Residual
+
+- `docs/adr/0048-trail-versioning-v3.md` links ADR-0008 to `README.md` instead of `0008-deterministic-trailhead-derivation.md`. This is navigational, not doctrinal.
+- A few accepted-doc prose phrases still say "topo compile" or "compile, verify" as nouns rather than runnable command guidance. The post-fix docs/CLI report lists the exact lines.
+
+## Verification
+
+- `bun scripts/adr.ts check` passed after the command-guidance fixes.
+- `bun run format:check` passed after the command-guidance fixes.
+- `rg` stale-command sweeps show no unresolved current-facing hits outside reports, the packet instructions, historical drafts, and ADR-0048 retirement wording.
+
+## Result
+
+Round 1 initially found P2 docs/CLI drift. The P2s were fixed on the owning branch. Latest state is P3-only for this lane.

--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-1-doctrine-cli.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-1-doctrine-cli.md
@@ -1,0 +1,31 @@
+# Local Review Round 1: Doctrine / CLI
+
+Date: 2026-05-19
+Stack tip reviewed: `trl-116-run-examples-and-testall-across-live-version-entries`
+
+## Scope
+
+- Trail-only versioning doctrine.
+- Current top-level contract semantics.
+- Revision/fork vocabulary.
+- Pure `transpose:` wording.
+- Projected `marker:` and graph-only `kind`.
+- Blaze language from PR #530.
+
+## Findings
+
+No unresolved P0/P1/P2 doctrine findings remain.
+
+The initial docs/CLI pass found stale command names in accepted ADR snippets and bundled agent guidance. Those were fixed on `TRL-729`; see `local-review-round-1-docs-cli.md`.
+
+## Clean Checks
+
+- ADR-0048 is accepted and ADR-0044 is marked superseded.
+- ADR-0016 points forward from draft `mark()` vocabulary to projected `marker:` identities and later `trails revise` / `trails deprecate` work.
+- The lexicon and language styleguide use `version`, `versions`, `revision`, `fork`, `transpose`, `marker`, `@N`, and `(trail, version)` in the ADR-0048 shape.
+- Retired forms such as `.v*.ts`, `version.current`, `adapt:`, `version.markers`, `trails version`, and sunset-style commands appear only as historical or explicitly negative guidance.
+- Blaze wording preserves the PR #530 grammar: a `blaze` establishes how a trail runs; surfaces and composition do not call blazes directly.
+
+## Result
+
+Round 1 doctrine review is P3-only. The only accepted residual is the ADR-0048 ADR-0008 reference link noted in the docs/CLI report.

--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-2-core-runtime-markers.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-2-core-runtime-markers.md
@@ -1,0 +1,65 @@
+# Local Review Round 2: Core / Runtime / Markers
+
+Date: 2026-05-19
+Stack tip reviewed: `trl-116-run-examples-and-testall-across-live-version-entries`
+
+## Scope
+
+- Core `version` / `versions` authoring shape.
+- TopoGraph projection.
+- Pure revision `transpose:`.
+- Projected content-addressed markers.
+- Runtime version resolution.
+
+## Initial Findings
+
+### P2: Revision entries allowed ignored `crossInput`
+
+Revision entries rejected `crosses`, `resources`, and `detours`, but `crossInput` could still be authored and silently ignored. That violated the pure-revision rule.
+
+Resolution: fixed on `trl-114-add-pure-transpose-transforms-for-revision-entries` by making revision `crossInput` impossible in types and rejected at runtime.
+
+### P2: Live fork version dependencies were not topo-validated
+
+Fork entries project and execute fork-local `crosses` and `resources`, but `validateTopo()` only checked top-level trail dependencies.
+
+Resolution: fixed on `trl-113-define-trail-version-versions-authoring-shape` by validating non-archived fork version `crosses` / `resources` against the topo while preserving draft-id allowance and archived-entry inertness.
+
+### P2: TopoGraph marker resolution failed all-digit marker prefixes
+
+`resolveTopoGraphVersionReference(entry, "1234")` treated every all-digit string as a numeric version before trying marker-prefix resolution.
+
+Resolution: fixed on `trl-739-featcore-compute-content-addressed-version-markers` by using numeric resolution only when that version exists, then falling through to marker-prefix resolution.
+
+### P2: Current markers omitted stable top-level runtime contract fields
+
+Current marker content hashed only `input`, `output`, and `kind`, while fork marker content also included stable runtime declarations such as `crosses`, `resources`, and `detours`.
+
+Resolution: fixed on `trl-739-featcore-compute-content-addressed-version-markers` by projecting current `crosses`, `resources`, and `detours` through the same canonical helpers used for fork marker content.
+
+### P2: Runtime marker derivation helper type omitted current runtime fields
+
+After current markers began hashing top-level runtime declarations, `resolveTrailVersion()` still typed the marker derivation path as schema/version-only.
+
+Resolution: fixed on `trl-115-resolve-trail-versions-during-execution` by requiring the marker resolution helper to receive the full current marker contract fields.
+
+## Verification
+
+- `bun test packages/core/src/__tests__/validate-topo.test.ts` passed after fork dependency validation.
+- `bun run --cwd packages/core typecheck` passed after fork dependency validation.
+- `bun test packages/core/src/__tests__/trail.test.ts` and core type tests passed after pure-revision `crossInput` rejection.
+- `bun test packages/core/src/__tests__/version-marker.test.ts packages/topographer/src/__tests__/derive.test.ts` passed after marker fixes.
+- `bun run --cwd packages/core typecheck` and `bun run --cwd packages/topographer typecheck` passed after marker fixes.
+- Tip focused checks passed for runtime/version/topographer/guide/testing suites after restack.
+
+## Clean Checks
+
+- Revision transpose functions receive only `{ input }` / `{ output }`.
+- Authored `kind` and `marker` remain rejected.
+- Historical entries still require explicit `input` and `output`.
+- `ctx.cross()` remains current by default and requires explicit version pins.
+- Archived entries stay out of live default validation/example paths.
+
+## Result
+
+Round 2 initially found P2s. All P2s were fixed on the lowest owning branches and restacked. Latest state is clean for this lane.

--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-3-testing-public-api-changesets.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-3-testing-public-api-changesets.md
@@ -1,0 +1,40 @@
+# Local Review Round 3: Testing / Public API / Changesets
+
+Date: 2026-05-19
+Stack tip reviewed: `trl-116-run-examples-and-testall-across-live-version-entries`
+
+## Scope
+
+- Version-aware examples and `testAll`.
+- Survey and guide version-entry example counts.
+- Public exports for versioning helpers.
+- Branch-local changeset coverage for publishable packages.
+
+## Initial Finding
+
+### P2: `trails guide` undercounted live version-entry examples
+
+`buildCurrentGuideEntries()` counted only current `trail.examples`, while survey/test paths counted current examples plus live non-archived version-entry examples.
+
+Resolution: fixed on `trl-116-run-examples-and-testall-across-live-version-entries` by exporting and reusing `countTrailExamples()` and adding a guide regression test for deprecated examples plus archived-entry exclusion.
+
+## Verification
+
+- `bun test apps/trails/src/__tests__/guide.test.ts` passed after the guide fix.
+- `bun run --cwd apps/trails typecheck` passed after the guide fix.
+- Tip focused tests passed for guide, survey-adjacent projection, core validation, version execution, topographer marker projection, `testExamples`, and `testAll`.
+
+## Changesets
+
+Publishable package-touching branches have branch-local changesets:
+
+- `.changeset/trail-cli-namespace.md`
+- `.changeset/trail-version-authoring-shape.md`
+- `.changeset/pure-transpose-revisions.md`
+- `.changeset/trail-version-markers.md`
+- `.changeset/trail-version-runtime.md`
+- `.changeset/trail-version-live-examples.md`
+
+## Result
+
+Round 3 initially found one P2. It was fixed on the tip owning branch. Latest state is clean for this lane.

--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-4-final-clean-sweep.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-4-final-clean-sweep.md
@@ -1,0 +1,38 @@
+# Local Review Round 4: Final Clean Sweep
+
+Date: 2026-05-19
+Stack tip reviewed: `trl-116-run-examples-and-testall-across-live-version-entries`
+
+## Scope
+
+- Follow-up after all P2 owning-branch fixes.
+- Current-facing stale command and stale doctrine sweep.
+- Marker/runtime regression spot checks.
+- Guide/testAll live-entry behavior.
+- Changeset coverage.
+
+## Commands / Evidence
+
+- `rg -n "trails topo compile|trails topo verify|topo compile/verify|trails topo diff" docs plugin apps packages .agents/plans/2026-05-19-trail-versioning-m1-m2 --glob '!reports/*.md'`
+- `rg -n "trails version|trails sunset|trails mark|trails fork|trails archive|version\\.markers|adapt:|--preserve|kind: 'forced'|forced markers|fork-without-preserved-impl" docs plugin apps packages .agents/plans/2026-05-19-trail-versioning-m1-m2 --glob '!docs/adr/drafts/**' --glob '!reports/*.md'`
+- `rg -n "crossInput|deriveCurrentTrailVersionMarkerContent|resolveTopoGraphVersionReference|countTrailExamples|checkVersionExamples|Trail version .*crosses|Trail version .*resource" packages apps`
+- `git diff --name-only main...HEAD -- .changeset`
+- `bun test packages/core/src/__tests__/version-marker.test.ts packages/core/src/__tests__/version-execution.test.ts packages/core/src/__tests__/validate-topo.test.ts packages/topographer/src/__tests__/derive.test.ts apps/trails/src/__tests__/guide.test.ts packages/testing/src/__tests__/examples.test.ts packages/testing/src/__tests__/all.test.ts`
+- `bun run --cwd packages/core typecheck`
+- `bun run --cwd packages/topographer typecheck`
+- `bun run --cwd apps/trails typecheck`
+
+## Findings
+
+No P0/P1/P2 findings remain.
+
+## Accepted Residuals
+
+- P3: ADR-0048 links ADR-0008 to the ADR index instead of the ADR-0008 file.
+- P3: residual non-command prose still uses "topo compile" or "compile, verify" wording in a few current docs, while command snippets and CLI surfaces are correct.
+- Historical ADR/draft/packet/report text still contains retired command and versioning spellings as history, anti-patterns, or execution instructions.
+- `docs/contributing/language-styleguide.md` intentionally lists retired versioning shapes in the "avoid" section.
+
+## Result
+
+Latest local review pass is P3-only. Local review can stop once the full stack-tip verification gate remains clean and RETRO is updated.

--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-4-post-fix-docs-cli.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-4-post-fix-docs-cli.md
@@ -1,0 +1,70 @@
+# Local Review Round 4: Post-Fix Docs / CLI
+
+Review lane: ADR/doctrine/lexicon/blaze language plus CLI namespace/stale-command sweep.
+
+Reviewed from stack tip branch `trl-116-run-examples-and-testall-across-live-version-entries` at cwd `/Users/mg/Developer/outfitter/trails`.
+
+## Summary
+
+No P0, P1, or P2 findings.
+
+The round-1 P2 is fixed: accepted/current ADR snippets now use `trails compile` and `trails validate` instead of teaching `trails topo compile` / `trails topo verify` as current workflow. The live CLI exposes `compile` and `validate` as top-level commands, and `topo --help` lists only `history`, `pin`, and `unpin` children.
+
+Two P3 cleanup items remain. Neither revives the old command surface as runnable current guidance.
+
+## Findings
+
+### P3: ADR-0048 still links ADR-0008 to the ADR index
+
+Evidence:
+
+- `docs/adr/0048-trail-versioning-v3.md:327` links `ADR-0008: Deterministic Surface Derivation` to `README.md`.
+- `docs/adr/README.md:17` shows the canonical ADR-0008 target is `0008-deterministic-trailhead-derivation.md`.
+
+Fix recommendation: change the ADR-0048 reference target from `README.md` to `0008-deterministic-trailhead-derivation.md`. The filename still contains historical `trailhead` vocabulary, but the rendered ADR title is the current surface terminology.
+
+### P3: Residual non-command prose still says "topo compile" / "compile, verify"
+
+Evidence from `rg -n 'topo compile|topo verify|compile/verify' ...`:
+
+- `docs/index.md:37` describes Topographer as owning "topo compile helpers".
+- `docs/adr/0017-serialized-topo-graph.md:171` has the tradeoff heading "Requires topo compile to stay current."
+- `docs/adr/0018-signal-driven-governance.md:259` references ADR-0017 for "topo compile, verify, and lockfile-as-projection semantics."
+- `docs/adr/decision-map.json:1321` carries the same generated context from ADR-0018.
+
+These are not explicit `trails topo compile` / `trails topo verify` command instructions, and the command snippets around them are now corrected. Still, they preserve the old compile/verify noun phrase in current-facing navigation/ADR prose.
+
+Fix recommendation: reword to "topo artifact helpers", "Requires compile to stay current", and "topo artifact compilation, validation, and lockfile-as-projection semantics"; regenerate/check the ADR map afterward.
+
+## Verified Clean
+
+- ADR-0048 is accepted and carries the current v3 doctrine: trail-only versioning, top-level `version: N`, sibling `versions`, explicit historical `input`/`output`, pure `transpose:`, fork `blaze:`, projected markers, graph-only `forces`, and top-level CLI namespace (`docs/adr/0048-trail-versioning-v3.md:1`, `docs/adr/0048-trail-versioning-v3.md:10`, `docs/adr/0048-trail-versioning-v3.md:43`, `docs/adr/0048-trail-versioning-v3.md:107`, `docs/adr/0048-trail-versioning-v3.md:124`, `docs/adr/0048-trail-versioning-v3.md:160`, `docs/adr/0048-trail-versioning-v3.md:221`, `docs/adr/0048-trail-versioning-v3.md:260`, `docs/adr/0048-trail-versioning-v3.md:273`).
+- ADR-0044 is clearly superseded by ADR-0048 and marks `.v*.ts`, `version.current`, `adapt:`, sunset lifecycle, and `trails version` as no-longer-current doctrine (`docs/adr/0044-trail-versioning.md:5`, `docs/adr/0044-trail-versioning.md:6`, `docs/adr/0044-trail-versioning.md:16`, `docs/adr/0044-trail-versioning.md:21`).
+- ADR-0016 has the requested forward pointer: draft `mark()` is not versioning grammar; ADR-0048 uses projected `marker:` identities plus `trails revise` / `trails deprecate` (`docs/adr/0016-schema-derived-persistence.md:14`, `docs/adr/0016-schema-derived-persistence.md:17`).
+- ADR index/map are coherent: ADR-0044 is Superseded, ADR-0048 is Accepted, and `bun scripts/adr.ts check` passed with 0 errors and 0 warnings (`docs/adr/README.md:53`, `docs/adr/README.md:57`, `docs/adr/decision-map.json:2460`, `docs/adr/decision-map.json:2463`, `docs/adr/decision-map.json:2603`, `docs/adr/decision-map.json:2607`).
+- PR #530 blaze grammar is preserved: the styleguide says a `blaze` establishes the path and the runtime runs the blazed trail, and the lexicon says the runtime runs trails, not blazes (`docs/contributing/language-styleguide.md:16`, `docs/contributing/language-styleguide.md:17`, `docs/lexicon.md:170`, `docs/lexicon.md:178`).
+- Versioning lexicon/styleguide guidance matches ADR-0048 and explicitly rejects old versioning shapes (`docs/contributing/language-styleguide.md:275`, `docs/contributing/language-styleguide.md:288`, `docs/contributing/language-styleguide.md:290`, `docs/contributing/language-styleguide.md:298`, `docs/lexicon.md:404`, `docs/lexicon.md:473`).
+- Accepted ADR snippets that previously failed now use current CLI grammar (`docs/adr/0017-serialized-topo-graph.md:111`, `docs/adr/0017-serialized-topo-graph.md:113`, `docs/adr/0017-serialized-topo-graph.md:120`, `docs/adr/0017-serialized-topo-graph.md:122`, `docs/adr/0017-serialized-topo-graph.md:162`, `docs/adr/0014-core-database-primitive.md:152`, `docs/adr/0014-core-database-primitive.md:153`, `docs/adr/0015-topo-store.md:292`, `docs/adr/0015-topo-store.md:294`, `docs/adr/0019-hierarchical-command-trees-from-trail-ids.md:61`, `docs/adr/0019-hierarchical-command-trees-from-trail-ids.md:64`).
+- Live CLI source registers `compile` and `validate` at top level, and their trail IDs are top-level `compile` / `validate` (`apps/trails/src/app.ts:35`, `apps/trails/src/app.ts:39`, `apps/trails/src/trails/compile.ts:19`, `apps/trails/src/trails/validate.ts:8`).
+
+## Commands Run
+
+- `git status --short --branch` - confirmed stack tip branch `trl-116-run-examples-and-testall-across-live-version-entries` before writing this report.
+- `qmd search "trails topo verify trails compile validate ADR-0048"` - no results from the local index.
+- Broad `rg` stale-command sweep across docs/apps/packages/plugin/plan packet excluding generated reports found old command/versioning terms only in negative/do-not-use plan guidance, superseded ADR-0044, ADR-0048's retirement sentence, and old draft ADRs.
+- Refined `rg` current-facing sweep excluding drafts, ADR-0044, ADR-0048, reports, and plan packet files found no live current-facing hits for `trails topo compile`, `trails topo verify`, old versioning commands, `version.markers`, `adapt:`, `--preserve`, `kind: 'forced'`, `forced markers`, `fork-without-preserved-impl`, or `.v*.ts`; remaining hits were the styleguide's explicit "avoid" list and an unrelated `marked` substring in MCP docs.
+- `rg -n 'topo compile|topo verify|compile/verify' ...` found the P3 residual non-command prose listed above.
+- `bun apps/trails/bin/trails.ts --help` - shows top-level `compile` and `validate`; no `topo compile` / `topo verify`.
+- `bun apps/trails/bin/trails.ts topo --help` - shows `topo` children `history`, `pin`, and `unpin` only.
+- `bun apps/trails/bin/trails.ts compile --help` - renders top-level compile help.
+- `bun apps/trails/bin/trails.ts validate --help` - renders top-level validate help.
+- `bun scripts/adr.ts check` - passed with 0 errors, 0 warnings.
+- `git diff --check` - passed.
+
+## Unable To Verify
+
+- I did not verify live Linear issue bodies or remote PR state; this lane was limited to local stack-tip files, local CLI help, and local checks.
+
+## Forbidden Operations
+
+No git or gt write operations were run. No source files were edited. The only file written by this review lane is this report.

--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-5-post-fix-core-runtime-markers.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-5-post-fix-core-runtime-markers.md
@@ -1,0 +1,65 @@
+# Local Review Round 5: Post-Fix Core Runtime Markers
+
+Date: 2026-05-19
+Lane: core type/TopoGraph authoring shape, pure transpose, marker correctness, runtime version resolution
+Stack tip reviewed: `trl-116-run-examples-and-testall-across-live-version-entries`
+
+## Verdict
+
+Clean. I found no P0/P1/P2 findings.
+
+I also found no P3 findings in this scoped pass.
+
+## Checks Run
+
+- `bun test packages/core/src/__tests__/trail.test.ts packages/core/src/__tests__/version-marker.test.ts packages/core/src/__tests__/version-runtime.test.ts packages/core/src/__tests__/version-execution.test.ts packages/core/src/__tests__/validate-topo.test.ts packages/topographer/src/__tests__/derive.test.ts packages/topographer/src/__tests__/diff.test.ts` - pass, 193 tests, 0 failures.
+- `bun run --cwd packages/core typecheck` - pass.
+- `bun run --cwd packages/topographer typecheck` - pass.
+- `git diff --check origin/main...HEAD -- packages/core packages/topographer` - pass, no output.
+- `rg -n "trails version|trails sunset|trails mark|trails fork|trails archive|status: \{ state: ['\"]active|kind: ['\"]forced|pending-force|force-event|--force|version\.markers|adapt:" packages/core/src packages/topographer/src packages/core/package.json packages/topographer/package.json` - no matches, exit 1 as expected.
+- Broader M3 word sweep only found unrelated `force` usage in temp cleanup/tests/comments and the existing graph-only `TopoGraphEntry.forces?` type at `packages/topographer/src/types.ts:140`; I did not find source authoring or runtime implementation for M3 lifecycle/gates.
+
+## Evidence
+
+### Authoring Shape
+
+- Historical entries require explicit schemas: `VersionEntry` has required `input`/`output` and `marker?: never` at `packages/core/src/trail.ts:102`; runtime normalization throws when either schema is absent at `packages/core/src/trail.ts:552` and calls those checks before classifying the entry at `packages/core/src/trail.ts:670`.
+- Authored `kind` and `marker` are rejected: version entries reject both at `packages/core/src/trail.ts:674` and `packages/core/src/trail.ts:679`; top-level authored `marker` is rejected at `packages/core/src/trail.ts:880`. Regression coverage rejects `bad.kind`, top-level `bad.marker`, and version-entry `bad.version-marker` at `packages/core/src/__tests__/trail.test.ts:316`, `packages/core/src/__tests__/trail.test.ts:329`, and `packages/core/src/__tests__/trail.test.ts:336`.
+- Current stays top-level: historical entries matching the current version throw `"must stay top-level"` at `packages/core/src/trail.ts:795`; normalized trails return current `input`/`output`/`blaze` at top level and add only `version`/`versions` metadata at `packages/core/src/trail.ts:913`. Test coverage rejects `bad.current-duplicate` at `packages/core/src/__tests__/trail.test.ts:349`.
+
+### Pure Transpose
+
+- Revision entries cannot own runtime fields: `TrailVersionRevisionEntry` marks `blaze`, `crossInput`, `crosses`, `detours`, `kind`, and `resources` as `never` at `packages/core/src/trail.ts:134`; runtime normalization rejects revision-owned `crossInput`, `crosses`, `resources`, and `detours` at `packages/core/src/trail.ts:643`.
+- Transpose is pure by shape and execution: transpose functions receive only `{ input }` and `{ output }` in the type surface at `packages/core/src/trail.ts:115`; runtime calls them only with those single-field objects at `packages/core/src/version-runtime.ts:33` and `packages/core/src/version-runtime.ts:50`.
+- Revision execution validates historical input, transposes into current input, executes current, transposes output back, then validates historical output at `packages/core/src/version-runtime.ts:67`. Test coverage confirms revision execution transposes through current and captures the current input at `packages/core/src/__tests__/version-execution.test.ts:154`.
+
+### Fork Runtime Shape
+
+- Fork entries own their runtime surface: `TrailVersionForkEntry` requires `blaze` and may declare `crosses`, `crossInput`, `detours`, and `resources` at `packages/core/src/trail.ts:156`.
+- Fork execution materializes a fork trail with the fork's `blaze`, `crosses`, `detours`, `crossInput`, `input`, `output`, and `resources` at `packages/core/src/execute.ts:1343`.
+- Runtime coverage confirms a fork version runs its own blaze, resources, crosses, and detours at `packages/core/src/__tests__/version-execution.test.ts:191`.
+
+### Prior P2 Re-Checks
+
+- Live fork `crosses` validation is fixed: `validateTopo` now iterates live non-archived fork entries, checks each fork cross, and emits version-scoped diagnostics at `packages/core/src/validate-topo.ts:134`. Test coverage fails a live fork with `crosses: ['entity.missing']` at `packages/core/src/__tests__/validate-topo.test.ts:119` and confirms archived fork crosses are skipped at `packages/core/src/__tests__/validate-topo.test.ts:149`.
+- Live fork `resources` validation is fixed: `validateTopo` now iterates live non-archived fork entries and checks each fork resource against topo resources at `packages/core/src/validate-topo.ts:185`. Test coverage fails a live fork with a missing `db.main` resource at `packages/core/src/__tests__/validate-topo.test.ts:271`.
+- All-digit marker display/reference round-trip is fixed: TopoGraph display markers are bare prefixes at `packages/topographer/src/versioning.ts:154`, and string references are parsed as numeric versions only when the version actually exists before falling through to marker-prefix resolution at `packages/topographer/src/versioning.ts:195`. Test coverage resolves all-digit marker prefix `'1234'` to version 1 while preserving `'2'` as current version 2 at `packages/topographer/src/__tests__/derive.test.ts:427`.
+- Core runtime has the same all-digit marker behavior: version resolution tries numeric references first only when the number exists, then tries marker-prefix resolution when present at `packages/core/src/version-resolution.ts:211`. Runtime coverage resolves an all-digit marker prefix with no matching numeric version at `packages/core/src/__tests__/version-execution.test.ts:241`.
+- Current marker canonicalization now includes stable runtime refs: current marker content includes `crosses`, `resources`, and `detours` at `packages/core/src/version-marker.ts:192`; historical fork marker content includes the same runtime refs at `packages/core/src/version-marker.ts:222`. Test coverage asserts current marker content includes those refs and changes marker identity when they change at `packages/core/src/__tests__/version-marker.test.ts:32`.
+
+### Marker Projection and Resolution
+
+- Stored markers are 16-character lowercase SHA-256 prefixes by enforcement at `packages/core/src/version-marker.ts:267`; display prefixes floor at 4 chars and expand until unambiguous at `packages/core/src/version-marker.ts:354`.
+- Prefix resolution normalizes case, rejects invalid/short prefixes, rejects ambiguous prefixes, and returns the matched marker/version at `packages/core/src/version-marker.ts:384`. Test coverage for display floor and invalid/ambiguous prefixes lives at `packages/core/src/__tests__/version-marker.test.ts:73` and `packages/core/src/__tests__/version-marker.test.ts:84`.
+- TopoGraph projects version entry `kind`/`marker` and fork runtime refs at `packages/topographer/src/versioning.ts:87`, while current marker/support projection stays top-level at `packages/topographer/src/versioning.ts:216`.
+
+### Runtime Version Resolution
+
+- Omitted version resolves to current by default at `packages/core/src/version-resolution.ts:241`.
+- Explicit current re-enters the normal current pipeline with the version option stripped at `packages/core/src/execute.ts:1321`.
+- Historical resolution dispatches revision entries through `executeTrailRevision` and fork entries through fork materialization at `packages/core/src/execute.ts:1391`.
+- `ctx.cross()` remains current by default because bound cross forwarding strips the parent `version` option at `packages/core/src/execute.ts:875`. Test coverage exercises default current cross plus explicit revision/fork pins at `packages/core/src/__tests__/version-execution.test.ts:282`.
+
+## Unable To Verify
+
+No local claim above is unverified. I did not check remote CI or PR review state because this was scoped as a local post-fix review.

--- a/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-6-post-fix-testing-public-api-changesets.md
+++ b/.agents/plans/2026-05-19-trail-versioning-m1-m2/reports/local-review-round-6-post-fix-testing-public-api-changesets.md
@@ -1,0 +1,75 @@
+# Local Review Round 6: Post-Fix Testing / Public API / Changesets
+
+Date: 2026-05-19
+Stack tip reviewed: `trl-116-run-examples-and-testall-across-live-version-entries`
+
+## Result
+
+No P0/P1/P2 findings.
+
+No P3 findings.
+
+The prior round-3 P2 is resolved: `trails guide` and survey counts now include live historical version-entry examples and exclude archived entries.
+
+## Scope Reviewed
+
+- Examples and `testAll` across current plus live historical version entries.
+- Public API exports for versioning helpers and projected graph types.
+- Branch-local changesets for publishable `@ontrails/*` package changes.
+- Publish guidance wording around Bun publish scripts and forbidden publish paths.
+
+## Evidence
+
+### Examples and `testAll`
+
+- `packages/testing/src/effective-examples.ts:370` builds example targets from current trail examples, and `packages/testing/src/effective-examples.ts:387` iterates `trail.versions`; `packages/testing/src/effective-examples.ts:390` skips archived entries, while non-archived entries are targeted with `version` at `packages/testing/src/effective-examples.ts:398`.
+- `packages/testing/src/examples.ts:187` executes the owning trail and passes the target version into `executeTrail` at `packages/testing/src/examples.ts:190`.
+- `packages/testing/src/contracts.ts:63` derives contract entries with `deriveTrailExampleTargets`, and `packages/testing/src/contracts.ts:91` executes with the target version passed at `packages/testing/src/contracts.ts:95`.
+- `packages/testing/src/all.ts:87` wires `testExamples`, and `packages/testing/src/all.ts:89` wires `testContracts`, so `testAll` inherits the version-aware target selection.
+- `packages/testing/src/__tests__/examples.test.ts:499` defines a versioned example trail with current, revision, deprecated fork, and archived entries; the archived entry is marked at `packages/testing/src/__tests__/examples.test.ts:552`. The assertions at `packages/testing/src/__tests__/examples.test.ts:565` verify the current blaze ran twice and the fork blaze once, which covers current plus live historical entries while excluding archived.
+- `packages/testing/src/__tests__/all.test.ts:161` defines the `testAll` versioned trail; the archived invalid entry at `packages/testing/src/__tests__/all.test.ts:204` would fail if executed. The assertions at `packages/testing/src/__tests__/all.test.ts:362` verify only current plus live non-archived entries ran through examples and contracts.
+- `packages/testing/src/__tests__/contracts.test.ts:215` defines versioned contract coverage; the archived entry starts at `packages/testing/src/__tests__/contracts.test.ts:258`, and the assertions at `packages/testing/src/__tests__/contracts.test.ts:413` verify current plus live historical contract outputs only.
+
+### Guide, Survey, and Archived/Deprecated Behavior
+
+- `apps/trails/src/trails/topo-reports.ts:239` counts live version-entry examples and skips archived entries at `apps/trails/src/trails/topo-reports.ts:242`; `apps/trails/src/trails/topo-reports.ts:250` adds that live historical count to current examples.
+- `apps/trails/src/trails/topo-read-support.ts:120` builds guide entries, and `apps/trails/src/trails/topo-read-support.ts:133` now uses the shared `countTrailExamples` helper.
+- `apps/trails/src/__tests__/guide.test.ts:88` covers the prior P2 directly: deprecated version-entry examples count, archived version-entry examples do not, and the expected guide count is `1` at `apps/trails/src/__tests__/guide.test.ts:123`.
+- `apps/trails/src/__tests__/survey.test.ts:345` covers survey list/brief counting with deprecated plus archived historical entries; the expected survey count is `1` at `apps/trails/src/__tests__/survey.test.ts:381`.
+- `apps/trails/src/__tests__/survey.test.ts:501` covers detail projection for version-entry examples, including provenance `trail.versions.examples` at `apps/trails/src/__tests__/survey.test.ts:510`.
+- `packages/core/src/trail.ts:209` defines archived entries as `status.state === 'archived'`; `packages/core/src/trail.ts:213` derives supported versions and excludes archived entries at `packages/core/src/trail.ts:222`.
+- `packages/core/src/version-resolution.ts:277` rejects archived version resolution with an unsupported-version error, while `packages/core/src/version-resolution.ts:284` marks deprecated live entries as deprecated without skipping them.
+- `packages/topographer/src/versioning.ts:87` projects version-entry examples with provenance, `packages/topographer/src/versioning.ts:96` records per-entry example counts, and `packages/topographer/src/versioning.ts:244` projects `supports` from `deriveSupportedTrailVersions`, so archived entries remain visible history in `versions` while excluded from live `supports`.
+- `packages/topographer/src/__tests__/derive.test.ts:287` verifies historical projection, with `supports: [2, 3]` at `packages/topographer/src/__tests__/derive.test.ts:291`, archived version `1` retained as archived history at `packages/topographer/src/__tests__/derive.test.ts:295`, and deprecated version-entry example provenance verified at `packages/topographer/src/__tests__/derive.test.ts:304`.
+
+### Public API Exports
+
+- `packages/core/src/index.ts:162` exports version support helpers, marker helpers, and version-resolution helpers; associated version types are exported at `packages/core/src/index.ts:189` and `packages/core/src/index.ts:210`.
+- `packages/topographer/src/index.ts:10` exports version marker collection/resolution helpers, `packages/topographer/src/index.ts:15` exports their public types, and `packages/topographer/src/index.ts:59` exports `TopoGraphVersionEntry`.
+- `packages/testing/src/index.ts:1` continues to export the public testing surface (`testAll`, `testExamples`, `testContracts`, etc.); the new version-target derivation remains internal to the testing package.
+
+### Changesets and Publish Guidance
+
+- Publishable package changes were present under `apps/trails`, `packages/core`, `packages/testing`, `packages/topographer`, and `packages/warden`. Branch-local changesets cover those publishable package changes:
+  - `.changeset/pure-transpose-revisions.md:2` covers `@ontrails/core`.
+  - `.changeset/trail-cli-namespace.md:2` covers `@ontrails/trails`, `.changeset/trail-cli-namespace.md:3` covers `@ontrails/topographer`, and `.changeset/trail-cli-namespace.md:4` covers `@ontrails/warden`.
+  - `.changeset/trail-version-authoring-shape.md:2` covers `@ontrails/core`, and `.changeset/trail-version-authoring-shape.md:3` covers `@ontrails/topographer`.
+  - `.changeset/trail-version-live-examples.md:2` covers `@ontrails/core`, `.changeset/trail-version-live-examples.md:3` covers `@ontrails/testing`, `.changeset/trail-version-live-examples.md:4` covers `@ontrails/topographer`, and `.changeset/trail-version-live-examples.md:5` covers `@ontrails/trails`.
+  - `.changeset/trail-version-markers.md:2` covers `@ontrails/core`, and `.changeset/trail-version-markers.md:3` covers `@ontrails/topographer`.
+  - `.changeset/trail-version-runtime.md:2` covers `@ontrails/core`.
+- `AGENTS.md:270` says Changesets are for versioning/changelogs, not `changeset publish`, and explains Bun-based publishing. `AGENTS.md:282` uses `bun run publish:check`, and `AGENTS.md:283` uses `bun run publish:packages`.
+- The goal packet keeps the same rule: `.agents/plans/2026-05-19-trail-versioning-m1-m2/GOAL.md:65` requires `bun run publish:check` / `bun run publish:packages`, and `.agents/plans/2026-05-19-trail-versioning-m1-m2/GOAL.md:66` forbids `npm publish` / `changeset publish` guidance.
+- `git grep -n "npm publish\\|changeset publish" HEAD -- ':*.md' ':*.ts' ':*.json'` only found explicit prohibition or "do not use" wording, not new positive guidance to publish with npm or Changesets.
+
+## Commands Run
+
+- `git diff --check main...HEAD` - passed with no output.
+- `bun test apps/trails/src/__tests__/guide.test.ts apps/trails/src/__tests__/survey.test.ts packages/testing/src/__tests__/examples.test.ts packages/testing/src/__tests__/contracts.test.ts packages/testing/src/__tests__/all.test.ts packages/topographer/src/__tests__/derive.test.ts` - passed, 154 tests, 0 failures.
+- `git diff --name-only main...HEAD -- .changeset` - confirmed six branch-local changesets listed above.
+- `jq -r 'select(.private != true) | .name' packages/*/package.json apps/trails/package.json apps/trails-demo/package.json` - confirmed publishable `@ontrails/*` workspace package names.
+
+## Notes
+
+- I did not run publish or registry mutation commands.
+- I did not mutate source files or run git/gt write operations.
+- Final `git status --short --branch` showed pre-existing/report-lane dirt outside this report path; I did not modify those files.

--- a/.changeset/trail-version-live-examples.md
+++ b/.changeset/trail-version-live-examples.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/core": patch
+"@ontrails/testing": patch
+"@ontrails/topographer": patch
+"@ontrails/trails": patch
+---
+
+Run examples and contract checks across live trail version entries, and project version-entry example coverage into topo and survey reports.

--- a/apps/trails/src/__tests__/guide.test.ts
+++ b/apps/trails/src/__tests__/guide.test.ts
@@ -5,6 +5,7 @@ import { ConflictError, trail, topo, Result } from '@ontrails/core';
 import { z } from 'zod';
 
 import { guideTrail } from '../trails/guide.js';
+import { buildCurrentGuideEntries } from '../trails/topo-read-support.js';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -84,6 +85,49 @@ describe('trails guide', () => {
     expect(parsed['description']).toBe('Say hello');
   });
 
+  test('guide list counts live version-entry examples', () => {
+    const versioned = trail('guide.versioned', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ name: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+      version: 3,
+      versions: {
+        1: {
+          examples: [
+            {
+              expected: { ok: true },
+              input: { name: 'legacy' },
+              name: 'Legacy guide example',
+            },
+          ],
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          status: { state: 'deprecated' },
+        },
+        2: {
+          examples: [
+            {
+              expected: { ok: true },
+              input: { name: 'archived' },
+              name: 'Archived guide example',
+            },
+          ],
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          status: { state: 'archived' },
+        },
+      },
+    });
+    const versionedApp = topo('guide-versioned-app', { versioned });
+
+    expect(buildCurrentGuideEntries(versionedApp)).toEqual([
+      expect.objectContaining({
+        exampleCount: 1,
+        id: 'guide.versioned',
+      }),
+    ]);
+  });
+
   test('non-existent trail returns undefined from topo', () => {
     const item = app.get('does-not-exist');
     expect(item).toBeUndefined();
@@ -155,8 +199,11 @@ describe('trails guide', () => {
           pattern: null,
           resources: [],
           safety: 'read',
+          supports: [],
           surfaceProjections: [],
           surfaces: [],
+          version: null,
+          versions: {},
         },
         mode: 'detail',
       }).success

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -342,6 +342,47 @@ describe('trails survey brief', () => {
     expect(report.features.resources).toBe(true);
   });
 
+  test('detects and counts live version-entry examples', () => {
+    const versioned = trail('brief.versioned', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ name: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+      version: 3,
+      versions: {
+        1: {
+          examples: [
+            {
+              expected: { ok: true },
+              input: { name: 'legacy' },
+              name: 'Legacy brief example',
+            },
+          ],
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          status: { state: 'deprecated' },
+        },
+        2: {
+          examples: [
+            {
+              expected: { ok: true },
+              input: { name: 'archived' },
+              name: 'Archived brief example',
+            },
+          ],
+          input: z.object({ name: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          status: { state: 'archived' },
+        },
+      },
+    });
+    const versionedApp = topo('brief-versioned-app', { versioned });
+
+    expect(deriveBriefReport(versionedApp).features.examples).toBe(true);
+    expect(deriveSurveyList(versionedApp).entries).toEqual([
+      expect.objectContaining({ examples: 1, id: 'brief.versioned' }),
+    ]);
+  });
+
   test('JSON output is valid', () => {
     const report = deriveBriefReport(app);
     const json = JSON.stringify(report, null, 2);
@@ -430,6 +471,51 @@ describe('trails survey detail', () => {
       topo: [],
       trail: [],
     });
+  });
+
+  test('trail detail reports version-entry example coverage', () => {
+    const versioned = trail('survey.versioned', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+      version: 2,
+      versions: {
+        1: {
+          examples: [
+            {
+              expected: { ok: true },
+              input: { legacyId: 'old' },
+              name: 'Legacy survey example',
+            },
+          ],
+          input: z.object({ legacyId: z.string() }),
+          output: z.object({ ok: z.boolean() }),
+          status: { state: 'deprecated' },
+          transpose: {
+            input: ({ input }) => ({ id: input.legacyId }),
+            output: ({ output }) => output,
+          },
+        },
+      },
+    });
+    const detail = structuredClone(
+      deriveTrailDetail(versioned, topo('version-survey-app', { versioned }))
+    ) as TrailDetailReport;
+
+    expect(detail.version).toBe(2);
+    expect(detail.supports).toEqual([1, 2]);
+    expect(detail.versions['1']).toMatchObject({
+      exampleCount: 1,
+      examples: [
+        expect.objectContaining({
+          name: 'Legacy survey example',
+          provenance: { source: 'trail.versions.examples' },
+        }),
+      ],
+      kind: 'revision',
+      status: { state: 'deprecated' },
+    });
+    expect(trailDetailOutput.safeParse(detail).success).toBe(true);
   });
 
   test('trail detail surfaces composed layers from every scope', () => {

--- a/apps/trails/src/trails/topo-output-schemas.ts
+++ b/apps/trails/src/trails/topo-output-schemas.ts
@@ -137,6 +137,32 @@ export const shippedSurfaceInventoryOutput = z.object({
     .readonly(),
 });
 
+const trailVersionEntryOutput = z.object({
+  crosses: z.array(z.string()).readonly().optional(),
+  detours: z
+    .array(
+      z.object({
+        maxAttempts: z.number(),
+        on: z.string(),
+      })
+    )
+    .readonly()
+    .optional(),
+  exampleCount: z.number(),
+  examples: z.array(z.unknown()).readonly().optional(),
+  input: jsonSchemaOutput,
+  kind: z.enum(['revision', 'fork']),
+  marker: z.string(),
+  output: jsonSchemaOutput,
+  resources: z.array(z.string()).readonly().optional(),
+  status: z
+    .object({
+      state: z.enum(['deprecated', 'archived']),
+    })
+    .catchall(z.unknown())
+    .optional(),
+});
+
 export const trailDetailOutput = z.object({
   activatedBy: z.array(z.string()).readonly(),
   activates: z.array(z.string()).readonly(),
@@ -190,8 +216,11 @@ export const trailDetailOutput = z.object({
   pattern: z.string().nullable(),
   resources: z.array(z.string()).readonly(),
   safety: z.string(),
+  supports: z.array(z.number()).readonly(),
   surfaceProjections: z.array(surfaceProjectionOutput).readonly(),
   surfaces: z.array(z.string()).readonly(),
+  version: z.number().nullable(),
+  versions: z.record(z.string(), trailVersionEntryOutput),
 });
 
 export const resourceDetailOutput = z.object({

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -28,6 +28,7 @@ import type {
   TrailDetailReport,
 } from './topo-reports.js';
 import {
+  countTrailExamples,
   deriveBriefReport,
   deriveResourceDetail,
   deriveSignalDetail,
@@ -129,7 +130,7 @@ export const buildCurrentGuideEntries = (
     .list()
     .map((trail) => ({
       description: trail.description ?? '(no description)',
-      exampleCount: trail.examples?.length ?? 0,
+      exampleCount: countTrailExamples(trail),
       id: trail.id,
       kind: 'trail' as const,
     }))

--- a/apps/trails/src/trails/topo-reports.ts
+++ b/apps/trails/src/trails/topo-reports.ts
@@ -2,6 +2,7 @@ import {
   DETOUR_MAX_ATTEMPTS_CAP,
   deriveCliPath,
   filterSurfaceTrails,
+  isArchivedTrailVersionEntry,
   zodToJsonSchema,
 } from '@ontrails/core';
 import type { AnyTrail, Signal, Topo } from '@ontrails/core';
@@ -16,6 +17,7 @@ import type {
   TopoGraphEntry,
   TopoGraphFieldOverride,
   TopoGraphLayerReference,
+  TopoGraphVersionEntry,
 } from '@ontrails/topographer';
 import { z } from 'zod';
 
@@ -211,6 +213,9 @@ export interface TrailDetailReport {
   readonly resources: readonly string[];
   readonly surfaceProjections: readonly ShippedSurfaceProjection[];
   readonly surfaces: readonly string[];
+  readonly supports: readonly number[];
+  readonly version: number | null;
+  readonly versions: Readonly<Record<string, TopoGraphVersionEntry>>;
 }
 
 export interface SignalDetailReport {
@@ -231,12 +236,19 @@ export interface SignalDetailReport {
   readonly producers: readonly string[];
 }
 
-const trailHas = (raw: Record<string, unknown>, key: string): boolean => {
-  if (key === 'examples' || key === 'detours') {
-    return Array.isArray(raw[key]) && (raw[key] as unknown[]).length > 0;
+const countLiveTrailVersionExamples = (trail: AnyTrail): number => {
+  let count = 0;
+  for (const entry of Object.values(trail.versions ?? {})) {
+    if (isArchivedTrailVersionEntry(entry)) {
+      continue;
+    }
+    count += entry.examples?.length ?? 0;
   }
-  return Boolean(raw[key]);
+  return count;
 };
+
+export const countTrailExamples = (trail: AnyTrail): number =>
+  (trail.examples?.length ?? 0) + countLiveTrailVersionExamples(trail);
 
 const detectFeatures = (
   app: Topo
@@ -246,18 +258,12 @@ const detectFeatures = (
   hasOutputSchemas: boolean;
   hasResources: boolean;
 } => {
-  const trails = [...app.trails.values()].map(
-    (item) => item as unknown as Record<string, unknown>
-  );
+  const trails = [...app.trails.values()];
   return {
-    hasDetours: trails.some((r) => trailHas(r, 'detours')),
-    hasExamples: trails.some((r) => trailHas(r, 'examples')),
-    hasOutputSchemas: trails.some((r) => trailHas(r, 'output')),
-    hasResources: trails.some(
-      (r) =>
-        Array.isArray(r['resources']) &&
-        (r['resources'] as unknown[]).length > 0
-    ),
+    hasDetours: trails.some((trail) => trail.detours.length > 0),
+    hasExamples: trails.some((trail) => countTrailExamples(trail) > 0),
+    hasOutputSchemas: trails.some((trail) => trail.output !== undefined),
+    hasResources: trails.some((trail) => trail.resources.length > 0),
   };
 };
 
@@ -386,11 +392,7 @@ export const deriveSurveyList = (app: Topo): SurveyListReport => {
     const safety = safetyLabel(
       item as unknown as { intent?: 'read' | 'write' | 'destroy' }
     );
-    const examples = Array.isArray(
-      (item as unknown as { examples?: unknown[] }).examples
-    )
-      ? (item as unknown as { examples: unknown[] }).examples.length
-      : 0;
+    const examples = countTrailExamples(item);
 
     return {
       activatedBy: trailActivation.activatedBy,
@@ -657,6 +659,14 @@ const deriveResolvedSurfaceProjections = (
     : deriveShippedSurfaceProjectionsForTrail(app, trail, topoGraph);
 };
 
+const deriveResolvedTrailVersionDetail = (
+  topoEntry: TopoGraphEntry | undefined
+): Pick<TrailDetailReport, 'supports' | 'version' | 'versions'> => ({
+  supports: topoEntry?.supports ?? [],
+  version: topoEntry?.version ?? null,
+  versions: topoEntry?.versions ?? {},
+});
+
 const deriveResolvedTrailGraphDetail = (
   app: Topo | undefined,
   trailId: string,
@@ -676,6 +686,9 @@ const deriveResolvedTrailGraphDetail = (
   | 'output'
   | 'surfaceProjections'
   | 'surfaces'
+  | 'supports'
+  | 'version'
+  | 'versions'
 > => {
   const topoGraph =
     topoGraphOverride ?? (app === undefined ? undefined : deriveTopoGraph(app));
@@ -714,6 +727,7 @@ const deriveResolvedTrailGraphDetail = (
       topoGraph
     ),
     surfaces: topoEntry?.surfaces ?? [],
+    ...deriveResolvedTrailVersionDetail(topoEntry),
   };
 };
 
@@ -784,7 +798,10 @@ export const deriveTrailDetail = (
     pattern: item.pattern ?? null,
     resources: item.resources.map((resource) => resource.id).toSorted(),
     safety,
+    supports: graphDetail.supports,
     surfaceProjections: graphDetail.surfaceProjections,
     surfaces: graphDetail.surfaces,
+    version: graphDetail.version,
+    versions: graphDetail.versions,
   };
 };

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -101,6 +101,13 @@ describe('trail()', () => {
     test('stores revision entries and derives live support', () => {
       const v2Input = z.object({ name: z.string() });
       const v2Output = z.object({ greeting: z.string() });
+      const v2Examples = [
+        {
+          expected: { greeting: 'Hello, Ada!' },
+          input: { name: 'Ada' },
+          name: 'Legacy greeting',
+        },
+      ];
       const versioned = trail('invite.create', {
         blaze: (input) => Result.ok({ greeting: `Hello, ${input.name}!` }),
         input: inputSchema,
@@ -108,6 +115,7 @@ describe('trail()', () => {
         version: 3,
         versions: {
           2: {
+            examples: v2Examples,
             input: v2Input,
             output: v2Output,
             status: { state: 'deprecated', successor: 3 },
@@ -124,6 +132,8 @@ describe('trail()', () => {
       expect(Object.isFrozen(versioned.versions)).toBe(true);
       expect(entry?.input).toBe(v2Input);
       expect(entry?.output).toBe(v2Output);
+      expect(entry?.examples).toEqual(v2Examples);
+      expect(Object.isFrozen(entry?.examples)).toBe(true);
       expect(entry?.status).toEqual({ state: 'deprecated', successor: 3 });
       expect(entry && getTrailVersionEntryKind(entry)).toBe('revision');
       expect(deriveSupportedTrailVersions(versioned)).toEqual([2, 3]);
@@ -406,6 +416,19 @@ describe('trail()', () => {
           },
         })
       ).toThrow('must be less than the current version');
+
+      expect(() =>
+        trail('bad.version-examples', {
+          ...base,
+          versions: {
+            1: {
+              examples: { input: {}, name: 'not an array' },
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+            } as never,
+          },
+        })
+      ).toThrow(ValidationError);
 
       expect(() =>
         trail('bad.no-current', {

--- a/packages/core/src/__tests__/validate-topo.test.ts
+++ b/packages/core/src/__tests__/validate-topo.test.ts
@@ -454,6 +454,70 @@ describe('validateTopo', () => {
       const result = validateTopo(app);
       expect(result.isOk()).toBe(true);
     });
+
+    test('version entry examples validate against historical schemas', () => {
+      const versioned = trail('versioned.example', {
+        blaze: () => Result.ok({ current: true }),
+        input: z.object({ current: z.string() }),
+        output: z.object({ current: z.boolean() }),
+        version: 2,
+        versions: {
+          1: {
+            examples: [
+              {
+                expected: { legacy: true },
+                input: { legacy: 123 },
+                name: 'Invalid legacy input',
+              },
+            ],
+            input: z.object({ legacy: z.string() }),
+            output: z.object({ legacy: z.boolean() }),
+            transpose: {
+              input: () => ({ current: 'legacy' }),
+              output: () => ({ legacy: true }),
+            },
+          },
+        },
+      });
+
+      const result = validateTopo(topo('app', { versioned }));
+      expect(result.isErr()).toBe(true);
+
+      const issues = extractIssues(result);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]?.rule).toBe('example-input-valid');
+      expect(issues[0]?.message).toContain('version 1');
+      expect(issues[0]?.message).toContain('Invalid legacy input');
+    });
+
+    test('archived version entry examples are preserved but skipped by default validation', () => {
+      const versioned = trail('versioned.archived.example', {
+        blaze: () => Result.ok({ current: true }),
+        input: z.object({ current: z.string() }),
+        output: z.object({ current: z.boolean() }),
+        version: 2,
+        versions: {
+          1: {
+            examples: [
+              {
+                expected: { legacy: true },
+                input: { legacy: 123 },
+                name: 'Archived invalid legacy input',
+              },
+            ],
+            input: z.object({ legacy: z.string() }),
+            output: z.object({ legacy: z.boolean() }),
+            status: { state: 'archived' },
+            transpose: {
+              input: () => ({ current: 'legacy' }),
+              output: () => ({ legacy: true }),
+            },
+          },
+        },
+      });
+
+      expect(validateTopo(topo('app', { versioned })).isOk()).toBe(true);
+    });
   });
 
   describe('contour references', () => {

--- a/packages/core/src/structured-examples.ts
+++ b/packages/core/src/structured-examples.ts
@@ -1,7 +1,7 @@
 import type { TrailExample, TrailExampleSignalAssertion } from './trail.js';
 
 export interface StructuredTrailExampleProvenance {
-  readonly source: 'trail.examples';
+  readonly source: 'trail.examples' | 'trail.versions.examples';
 }
 
 export interface StructuredSignalExampleProvenance {
@@ -152,7 +152,8 @@ const projectSignalAssertions = (
 };
 
 const projectExample = (
-  example: TrailExample<unknown, unknown>
+  example: TrailExample<unknown, unknown>,
+  provenance: StructuredTrailExampleProvenance
 ): StructuredTrailExample | undefined => {
   const input = toJsonSerializable(example.input);
   if (input === undefined) {
@@ -163,7 +164,7 @@ const projectExample = (
     input,
     kind: example.error === undefined ? 'success' : 'error',
     name: example.name,
-    provenance: { source: 'trail.examples' },
+    provenance,
   };
 
   if (example.description !== undefined) {
@@ -213,14 +214,16 @@ const projectSignalExample = (
 };
 
 export const deriveStructuredTrailExamples = (
-  examples: readonly TrailExample<unknown, unknown>[] | undefined
+  examples: readonly TrailExample<unknown, unknown>[] | undefined,
+  options?: { readonly provenance?: StructuredTrailExampleProvenance }
 ): readonly StructuredTrailExample[] | undefined => {
   if (examples === undefined || examples.length === 0) {
     return undefined;
   }
 
+  const provenance = options?.provenance ?? { source: 'trail.examples' };
   const projected = examples
-    .map(projectExample)
+    .map((example) => projectExample(example, provenance))
     .filter(
       (example): example is StructuredTrailExample => example !== undefined
     );

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -103,6 +103,9 @@ export interface TrailVersionStatus {
 export interface VersionEntry<
   TContract extends VersionContract = VersionContract,
 > {
+  readonly examples?:
+    | readonly TrailExample<TContract['input'], TContract['output']>[]
+    | undefined;
   readonly input: z.ZodType<TContract['input']>;
   readonly marker?: never;
   readonly output: z.ZodType<TContract['output']>;
@@ -602,6 +605,26 @@ const normalizeVersionStatus = (
   return Object.freeze({ ...raw, state: raw['state'] }) as TrailVersionStatus;
 };
 
+const normalizeVersionExamples = (
+  trailId: string,
+  version: number,
+  examples: unknown
+): readonly TrailExample<unknown, unknown>[] | undefined => {
+  if (examples === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(examples)) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} examples must be an array`
+    );
+  }
+
+  return Object.freeze([...examples]) as readonly TrailExample<
+    unknown,
+    unknown
+  >[];
+};
+
 const normalizeTranspose = (
   trailId: string,
   version: number,
@@ -687,6 +710,11 @@ const normalizeVersionEntry = <CurrentInput, CurrentOutput>(
   }
 
   const base = {
+    ...(raw['examples'] === undefined
+      ? {}
+      : {
+          examples: normalizeVersionExamples(trailId, version, raw['examples']),
+        }),
     input: raw['input'],
     output: raw['output'],
     ...(raw['status'] === undefined

--- a/packages/core/src/validate-topo.ts
+++ b/packages/core/src/validate-topo.ts
@@ -234,20 +234,21 @@ const checkOneExample = (
     error?: string | undefined;
   },
   inputSchema: { safeParse: (data: unknown) => { success: boolean } },
-  hasOutput: boolean
+  hasOutput: boolean,
+  label = `Example "${example.name}"`
 ): TopoIssue[] => {
   const issues: TopoIssue[] = [];
   const result = validateInput(inputSchema as AnyTrail['input'], example.input);
   if (result.isErr() && example.error !== 'ValidationError') {
     issues.push({
-      message: `Example "${example.name}" input does not parse against schema`,
+      message: `${label} input does not parse against schema`,
       rule: 'example-input-valid',
       trailId: id,
     });
   }
   if (example.expected !== undefined && !hasOutput) {
     issues.push({
-      message: `Example "${example.name}" has expected output but trail has no output schema`,
+      message: `${label} has expected output but trail has no output schema`,
       rule: 'output-schema-present',
       trailId: id,
     });
@@ -255,15 +256,34 @@ const checkOneExample = (
   return issues;
 };
 
+const checkVersionExamples = (id: string, trail: AnyTrail): TopoIssue[] =>
+  Object.entries(trail.versions ?? {}).flatMap(([version, entry]) => {
+    if (isArchivedTrailVersionEntry(entry)) {
+      return [];
+    }
+
+    return (entry.examples ?? []).flatMap((example) =>
+      checkOneExample(
+        id,
+        example,
+        entry.input,
+        true,
+        `Example "${example.name}" on version ${version}`
+      )
+    );
+  });
+
 const checkExamples = (trails: ReadonlyMap<string, AnyTrail>): TopoIssue[] => {
   const issues: TopoIssue[] = [];
   for (const [id, trail] of trails) {
-    if (!trail.examples) {
-      continue;
+    if (trail.examples) {
+      for (const example of trail.examples) {
+        issues.push(
+          ...checkOneExample(id, example, trail.input, !!trail.output)
+        );
+      }
     }
-    for (const example of trail.examples) {
-      issues.push(...checkOneExample(id, example, trail.input, !!trail.output));
-    }
+    issues.push(...checkVersionExamples(id, trail));
   }
   return issues;
 };

--- a/packages/testing/src/__tests__/all.test.ts
+++ b/packages/testing/src/__tests__/all.test.ts
@@ -152,6 +152,74 @@ const contourDerivedTrail = trail('contour.derived.all', {
   output: contourFixture,
 });
 
+const versionAllCurrentBlaze = mock((input: { name: string }) =>
+  Result.ok({ message: `current:${input.name}` })
+);
+const versionAllForkBlaze = mock((input: { code: string }) =>
+  Result.ok({ message: `fork:${input.code}` })
+);
+const versionedAllTrail = trail('versioned.all', {
+  blaze: (input: { name: string }) => versionAllCurrentBlaze(input),
+  examples: [
+    {
+      expected: { message: 'current:Ada' },
+      input: { name: 'Ada' },
+      name: 'Current version example',
+    },
+  ],
+  input: z.object({ name: z.string() }),
+  output: z.object({ message: z.string() }),
+  version: 5,
+  versions: {
+    1: {
+      examples: [
+        {
+          expected: { message: 'legacy:Ada' },
+          input: { legacyName: 'Ada' },
+          name: 'Revision version example',
+        },
+      ],
+      input: z.object({ legacyName: z.string() }),
+      output: z.object({ message: z.string() }),
+      transpose: {
+        input: ({ input }) => ({ name: input.legacyName }),
+        output: ({ output }) => ({
+          message: output.message.replace('current:', 'legacy:'),
+        }),
+      },
+    },
+    2: {
+      blaze: (input: { code: string }) => versionAllForkBlaze(input),
+      examples: [
+        {
+          expected: { message: 'fork:beta' },
+          input: { code: 'beta' },
+          name: 'Deprecated fork version example',
+        },
+      ],
+      input: z.object({ code: z.string() }),
+      output: z.object({ message: z.string() }),
+      status: { state: 'deprecated' },
+    },
+    4: {
+      examples: [
+        {
+          expected: { message: 'archived' },
+          input: { archived: 42 },
+          name: 'Archived version example',
+        },
+      ],
+      input: z.object({ archived: z.boolean() }),
+      output: z.object({ message: z.string() }),
+      status: { state: 'archived' },
+      transpose: {
+        input: () => ({ name: 'archived' }),
+        output: () => ({ message: 'archived' }),
+      },
+    },
+  },
+});
+
 const repoTempDir = (): string =>
   join(
     resolve(import.meta.dir, '../..'),
@@ -284,6 +352,16 @@ describe('testAll contour-derived fixtures', () => {
 
   afterAll(() => {
     expect(contourDerivedBlaze).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('testAll version entries', () => {
+  // eslint-disable-next-line jest/require-hook
+  testAll(topo('test-all-versioned-app', { versionedAllTrail }));
+
+  afterAll(() => {
+    expect(versionAllCurrentBlaze).toHaveBeenCalledTimes(4);
+    expect(versionAllForkBlaze).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/testing/src/__tests__/contracts.test.ts
+++ b/packages/testing/src/__tests__/contracts.test.ts
@@ -206,6 +206,74 @@ const derivedContractTrail = trail('contract.derived', {
   output: derivedContractContour,
 });
 
+const versionContractCurrentBlaze = mock((input: { name: string }) =>
+  Result.ok({ message: `current:${input.name}` })
+);
+const versionContractForkBlaze = mock((input: { code: string }) =>
+  Result.ok({ message: `fork:${input.code}` })
+);
+const versionedContractTrail = trail('contract.versioned', {
+  blaze: (input: { name: string }) => versionContractCurrentBlaze(input),
+  examples: [
+    {
+      expected: { message: 'current:Ada' },
+      input: { name: 'Ada' },
+      name: 'Current contract example',
+    },
+  ],
+  input: z.object({ name: z.string() }),
+  output: z.object({ message: z.string() }),
+  version: 5,
+  versions: {
+    1: {
+      examples: [
+        {
+          expected: { legacyMessage: 'legacy:Ada' },
+          input: { legacyName: 'Ada' },
+          name: 'Revision contract example',
+        },
+      ],
+      input: z.object({ legacyName: z.string() }),
+      output: z.object({ legacyMessage: z.string() }),
+      transpose: {
+        input: ({ input }) => ({ name: input.legacyName }),
+        output: ({ output }) => ({
+          legacyMessage: output.message.replace('current:', 'legacy:'),
+        }),
+      },
+    },
+    2: {
+      blaze: (input: { code: string }) => versionContractForkBlaze(input),
+      examples: [
+        {
+          expected: { message: 'fork:beta' },
+          input: { code: 'beta' },
+          name: 'Fork contract example',
+        },
+      ],
+      input: z.object({ code: z.string() }),
+      output: z.object({ message: z.string() }),
+      status: { state: 'deprecated' },
+    },
+    4: {
+      examples: [
+        {
+          expected: { archivedMessage: 'skip' },
+          input: {},
+          name: 'Archived contract example',
+        },
+      ],
+      input: z.object({}),
+      output: z.object({ archivedMessage: z.string() }),
+      status: { state: 'archived' },
+      transpose: {
+        input: () => ({ name: 'archived' }),
+        output: () => ({ archivedMessage: 'skip' }),
+      },
+    },
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -335,5 +403,15 @@ describe('testContracts derives contour examples when trail examples are absent'
 
   afterAll(() => {
     expect(derivedContractBlaze).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('testContracts validates live version-entry outputs', () => {
+  // eslint-disable-next-line jest/require-hook
+  testContracts(topo('version-contract-app', { versionedContractTrail }));
+
+  afterAll(() => {
+    expect(versionContractCurrentBlaze).toHaveBeenCalledTimes(2);
+    expect(versionContractForkBlaze).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/testing/src/__tests__/examples.test.ts
+++ b/packages/testing/src/__tests__/examples.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, mock, test } from 'bun:test';
 
 import {
   ConflictError,
@@ -488,6 +488,145 @@ describe('testExamples resource mocks through cross', () => {
       crossRootTrail,
     } as Record<string, unknown>)
   );
+});
+
+const versionExampleCurrentBlaze = mock((input: { name: string }) =>
+  Result.ok({ message: `current:${input.name}` })
+);
+const versionExampleForkBlaze = mock((input: { code: string }) =>
+  Result.ok({ message: `fork:${input.code}` })
+);
+const versionedExampleTrail = trail('version.examples', {
+  blaze: (input: { name: string }) => versionExampleCurrentBlaze(input),
+  examples: [
+    {
+      expected: { message: 'current:Ada' },
+      input: { name: 'Ada' },
+      name: 'Current example',
+    },
+  ],
+  input: z.object({ name: z.string() }),
+  output: z.object({ message: z.string() }),
+  version: 5,
+  versions: {
+    1: {
+      examples: [
+        {
+          expected: { message: 'legacy:Ada' },
+          input: { legacyName: 'Ada' },
+          name: 'Revision example',
+        },
+      ],
+      input: z.object({ legacyName: z.string() }),
+      output: z.object({ message: z.string() }),
+      transpose: {
+        input: ({ input }) => ({ name: input.legacyName }),
+        output: ({ output }) => ({
+          message: output.message.replace('current:', 'legacy:'),
+        }),
+      },
+    },
+    2: {
+      blaze: (input: { code: string }) => versionExampleForkBlaze(input),
+      examples: [
+        {
+          expected: { message: 'fork:beta' },
+          input: { code: 'beta' },
+          name: 'Deprecated fork example',
+        },
+      ],
+      input: z.object({ code: z.string() }),
+      output: z.object({ message: z.string() }),
+      status: { state: 'deprecated' },
+    },
+    4: {
+      examples: [
+        {
+          expected: { message: 'archived should not run' },
+          input: { archived: true },
+          name: 'Archived example',
+        },
+      ],
+      input: z.object({ archived: z.boolean() }),
+      output: z.object({ message: z.string() }),
+      status: { state: 'archived' },
+      transpose: {
+        input: () => ({ name: 'archived' }),
+        output: ({ output }) => output,
+      },
+    },
+  },
+});
+
+describe('testExamples runs current plus live version-entry examples', () => {
+  // eslint-disable-next-line jest/require-hook
+  testExamples(topo('version-examples-app', { versionedExampleTrail }));
+
+  afterAll(() => {
+    expect(versionExampleCurrentBlaze).toHaveBeenCalledTimes(2);
+    expect(versionExampleForkBlaze).toHaveBeenCalledTimes(1);
+  });
+});
+
+const batchVersionChildBlaze = mock((input: { name: string }) =>
+  Result.ok({ message: `batch:${input.name}` })
+);
+const batchVersionChildTrail = trail('version.examples.batch.child', {
+  blaze: (input: { name: string }) => batchVersionChildBlaze(input),
+  input: z.object({ name: z.string() }),
+  output: z.object({ message: z.string() }),
+  version: 2,
+  versions: {
+    1: {
+      input: z.object({ legacyName: z.string() }),
+      output: z.object({ message: z.string() }),
+      transpose: {
+        input: ({ input }) => ({ name: input.legacyName }),
+        output: ({ output }) => output,
+      },
+    },
+  },
+});
+const batchVersionParentTrail = trail('version.examples.batch.parent', {
+  blaze: async (_input, ctx) => {
+    if (!ctx.cross) {
+      return Result.err(new Error('cross not available'));
+    }
+    const [child] = await ctx.cross([
+      ['version.examples.batch.child@1', { legacyName: 'Ada' }],
+    ]);
+    if (child === undefined) {
+      return Result.err(new Error('batch cross returned no result'));
+    }
+    if (child.isErr()) {
+      return child;
+    }
+    return Result.ok(child.value as { message: string });
+  },
+  crosses: [batchVersionChildTrail],
+  examples: [
+    {
+      expected: { message: 'batch:Ada' },
+      input: {},
+      name: 'Batch cross resolves inline version reference',
+    },
+  ],
+  input: z.object({}),
+  output: z.object({ message: z.string() }),
+});
+
+describe('testExamples resolves inline version references through batch cross', () => {
+  // eslint-disable-next-line jest/require-hook
+  testExamples(
+    topo('version-examples-batch-cross-app', {
+      batchVersionChildTrail,
+      batchVersionParentTrail,
+    })
+  );
+
+  afterAll(() => {
+    expect(batchVersionChildBlaze).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/testing/src/contracts.ts
+++ b/packages/testing/src/contracts.ts
@@ -20,7 +20,8 @@ import {
   createMockResources,
 } from './context.js';
 import type { TestExecutionOptions } from './context.js';
-import { deriveTrailExamples } from './effective-examples.js';
+import type { TrailExampleTarget } from './effective-examples.js';
+import { deriveTrailExampleTargets } from './effective-examples.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,6 +42,15 @@ const validateOutputSchema = (
   }
 };
 
+type ContractExampleTarget = TrailExampleTarget & {
+  readonly output: z.ZodType;
+};
+
+const hasContractExamples = (
+  target: TrailExampleTarget
+): target is ContractExampleTarget =>
+  target.output !== undefined && target.examples.length > 0;
+
 // ---------------------------------------------------------------------------
 // testContracts
 // ---------------------------------------------------------------------------
@@ -60,21 +70,12 @@ export const testContracts = (
 ): void => {
   const resolveInput =
     typeof ctxOrFactory === 'function' ? ctxOrFactory : () => ctxOrFactory;
-  const allEntries = (app.list() as Trail<unknown, unknown, unknown>[]).map(
-    (trailDef) => ({
-      ...trailDef,
-      examples: deriveTrailExamples(trailDef),
-    })
-  );
+  const allEntries = (app.list() as Trail<unknown, unknown, unknown>[])
+    .flatMap(deriveTrailExampleTargets)
+    .filter(hasContractExamples);
 
   describe('contracts', () => {
     describe.each(allEntries)('$id', (t) => {
-      if (t.output === undefined) {
-        return;
-      }
-      if (t.examples.length === 0) {
-        return;
-      }
       const { examples, output: outputSchema } = t;
       const successExamples = examples.filter((e) => e.error === undefined);
 
@@ -92,10 +93,11 @@ export const testContracts = (
           const validated = validateInput(t.input, example.input);
           expectOk(validated);
 
-          const result = await executeTrail(t, example.input, {
+          const result = await executeTrail(t.trail, example.input, {
             ctx: testCtx,
             resources,
             topo: app,
+            ...(t.version === undefined ? {} : { version: t.version }),
           });
           const resultValue = expectOk(result);
 

--- a/packages/testing/src/effective-examples.ts
+++ b/packages/testing/src/effective-examples.ts
@@ -1,8 +1,26 @@
 import type { AnyContour, Trail, TrailExample } from '@ontrails/core';
-import { getContourReferences } from '@ontrails/core';
+import {
+  getContourReferences,
+  getTrailVersionEntryKind,
+  isArchivedTrailVersionEntry,
+} from '@ontrails/core';
 import { z } from 'zod';
 
 type ExampleRecord = Readonly<Record<string, unknown>>;
+
+export interface TrailExampleTarget {
+  readonly crosses: readonly string[];
+  readonly current: boolean;
+  readonly examples: readonly TrailExample<unknown, unknown>[];
+  readonly id: string;
+  readonly input: Trail<unknown, unknown, unknown>['input'];
+  readonly output: Trail<unknown, unknown, unknown>['output'];
+  readonly trail: Trail<unknown, unknown, unknown>;
+  readonly version?: number | undefined;
+}
+
+const normalizeCrossRef = (value: string | { readonly id: string }): string =>
+  typeof value === 'string' ? value : value.id;
 
 /**
  * Tracks examples that `deriveTrailExamples` synthesizes from contour
@@ -347,4 +365,50 @@ export const deriveTrailExamples = (
     derivedExamples.add(derived);
     return [derived];
   });
+};
+
+export const deriveTrailExampleTargets = (
+  trail: Trail<unknown, unknown, unknown>
+): readonly TrailExampleTarget[] => {
+  const targets: TrailExampleTarget[] = [];
+  const currentExamples = deriveTrailExamples(trail);
+  if (currentExamples.length > 0) {
+    targets.push({
+      crosses: trail.crosses,
+      current: true,
+      examples: currentExamples,
+      id: trail.id,
+      input: trail.input,
+      output: trail.output,
+      trail,
+    });
+  }
+
+  for (const [rawVersion, entry] of Object.entries(
+    trail.versions ?? {}
+  ).toSorted(([left], [right]) => Number(left) - Number(right))) {
+    if (isArchivedTrailVersionEntry(entry)) {
+      continue;
+    }
+    const examples = entry.examples ?? [];
+    if (examples.length === 0) {
+      continue;
+    }
+    const kind = getTrailVersionEntryKind(entry);
+    targets.push({
+      crosses:
+        kind === 'fork'
+          ? (entry.crosses ?? []).map(normalizeCrossRef)
+          : trail.crosses,
+      current: false,
+      examples,
+      id: `${trail.id}@${rawVersion}`,
+      input: entry.input,
+      output: entry.output,
+      trail,
+      version: Number(rawVersion),
+    });
+  }
+
+  return targets;
 };

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -11,6 +11,7 @@ import { describe, expect, test } from 'bun:test';
 
 import type {
   CrossFn,
+  CrossOptions,
   ResourceOverrideMap,
   Topo,
   TrailExample,
@@ -35,6 +36,7 @@ import {
   RateLimitError,
   RetryExhaustedError,
   executeTrail,
+  parseTrailIdVersionReference,
   Result,
   TimeoutError,
   TrailsError,
@@ -57,7 +59,11 @@ import {
   createMockResources,
 } from './context.js';
 import type { PermittedTrail, TestExecutionOptions } from './context.js';
-import { isDerivedExample, deriveTrailExamples } from './effective-examples.js';
+import {
+  deriveTrailExampleTargets,
+  isDerivedExample,
+} from './effective-examples.js';
+import type { TrailExampleTarget } from './effective-examples.js';
 import { withSignalAssertions } from './signals.js';
 
 // ---------------------------------------------------------------------------
@@ -161,6 +167,32 @@ const applyAutoPermit = (
   return { ...ctx, permit };
 };
 
+const runTargetExample = async (
+  target: TrailExampleTarget,
+  example: TrailExample<unknown, unknown>,
+  testCtx: TrailContext,
+  resources?: ResourceOverrideMap,
+  opts?: TestExecutionOptions
+): Promise<void> => {
+  const { output, trail: t } = target;
+  const ctx = opts ? applyAutoPermit(testCtx, t, opts) : testCtx;
+  const signals = withSignalAssertions(ctx, example);
+  const validated = validateInput(target.input, example.input);
+
+  if (handleValidationError(validated, example)) {
+    signals.assert();
+    return;
+  }
+
+  const result = await executeTrail(t, example.input, {
+    ctx: signals.ctx,
+    resources: resources ?? opts?.resources,
+    ...(target.version === undefined ? {} : { version: target.version }),
+  });
+  assertProgressiveMatch(result, example, output);
+  signals.assert();
+};
+
 /**
  * Run a single example against a trail.
  * Handles validation, execution, and assertions.
@@ -173,21 +205,21 @@ export const runExample = async (
   resources?: ResourceOverrideMap,
   opts?: TestExecutionOptions
 ): Promise<void> => {
-  const ctx = opts ? applyAutoPermit(testCtx, t, opts) : testCtx;
-  const signals = withSignalAssertions(ctx, example);
-  const validated = validateInput(t.input, example.input);
-
-  if (handleValidationError(validated, example)) {
-    signals.assert();
-    return;
-  }
-
-  const result = await executeTrail(t, example.input, {
-    ctx: signals.ctx,
-    resources: resources ?? opts?.resources,
-  });
-  assertProgressiveMatch(result, example, output);
-  signals.assert();
+  await runTargetExample(
+    {
+      crosses: t.crosses,
+      current: true,
+      examples: [example],
+      id: t.id,
+      input: t.input,
+      output,
+      trail: t,
+    },
+    example,
+    testCtx,
+    resources,
+    opts
+  );
 };
 
 // ---------------------------------------------------------------------------
@@ -211,13 +243,36 @@ const createCoverageCross = (
   const invokeCross = async (
     idOrTrail: string | { readonly id: string },
     input: unknown,
-    self: CrossFn
+    self: CrossFn,
+    crossOptions?: CrossOptions | undefined
   ) => {
-    const id = typeof idOrTrail === 'string' ? idOrTrail : idOrTrail.id;
+    const parsed =
+      typeof idOrTrail === 'string'
+        ? parseTrailIdVersionReference(idOrTrail)
+        : Result.ok({ id: idOrTrail.id });
+    if (parsed.isErr()) {
+      return parsed;
+    }
+    const parsedVersion =
+      'version' in parsed.value ? parsed.value.version : undefined;
+    if (parsedVersion !== undefined && crossOptions?.version !== undefined) {
+      return Result.err(
+        new ValidationError(
+          `Trail "${parsed.value.id}" version was provided both in the id reference and ctx.cross() options`
+        )
+      );
+    }
+
+    const { id } = parsed.value;
     called.add(id);
+    const version = crossOptions?.version ?? parsedVersion;
 
     if (baseCross !== undefined) {
-      return await baseCross(id, input);
+      const forwardedOptions =
+        parsedVersion === undefined
+          ? crossOptions
+          : { ...crossOptions, version: parsedVersion };
+      return await baseCross(id, input, forwardedOptions);
     }
 
     const trailDef = topo.get(id);
@@ -225,6 +280,7 @@ const createCoverageCross = (
       return await executeTrail(trailDef, input, {
         ctx: { ...ctx, cross: self },
         resources,
+        ...(version === undefined ? {} : { version }),
         validationSchema: buildCrossValidationSchema(trailDef),
       });
     }
@@ -239,7 +295,8 @@ const createCoverageCross = (
       | string
       | { readonly id: string }
       | readonly (readonly [string | { readonly id: string }, unknown])[],
-    input?: unknown
+    inputOrOptions?: unknown,
+    singleOptions?: CrossOptions
   ) {
     if (Array.isArray(idOrTrail)) {
       return await Promise.all(
@@ -251,8 +308,9 @@ const createCoverageCross = (
 
     return await invokeCross(
       idOrTrail as string | { readonly id: string },
-      input,
-      cross as CrossFn
+      inputOrOptions,
+      cross as CrossFn,
+      singleOptions
     );
   } as CrossFn;
 
@@ -263,20 +321,20 @@ const createCoverageCross = (
  * Run a single example against a trail with crossings, recording cross calls.
  */
 const runCompositionExample = async (
-  trailDef: Trail<unknown, unknown, unknown>,
+  target: TrailExampleTarget,
   example: TrailExample<unknown, unknown>,
-  output: z.ZodType | undefined,
   baseCtx: TrailContext,
   called: Set<string>,
   topo: Topo,
   resources?: ResourceOverrideMap,
   opts?: TestExecutionOptions
 ): Promise<void> => {
+  const { output, trail: trailDef } = target;
   const permittedCtx = opts
     ? applyAutoPermit(baseCtx, trailDef, opts)
     : baseCtx;
   const signals = withSignalAssertions(permittedCtx, example);
-  const validated = validateInput(trailDef.input, example.input);
+  const validated = validateInput(target.input, example.input);
 
   if (handleValidationError(validated, example)) {
     signals.assert();
@@ -297,6 +355,7 @@ const runCompositionExample = async (
   const result = await executeTrail(trailDef, example.input, {
     ctx: testCtx,
     resources: resources ?? opts?.resources,
+    ...(target.version === undefined ? {} : { version: target.version }),
   });
   assertProgressiveMatch(result, example, output);
   signals.assert();
@@ -327,18 +386,15 @@ export const testExamples = (
   const resolveInput =
     typeof ctxOrFactory === 'function' ? ctxOrFactory : () => ctxOrFactory;
   const withExamples = (app.list() as Trail<unknown, unknown, unknown>[])
-    .map((trailDef) => ({
-      ...trailDef,
-      examples: deriveTrailExamples(trailDef),
-    }))
-    .filter((trailDef) => trailDef.examples.length > 0);
+    .flatMap(deriveTrailExampleTargets)
+    .filter((target) => target.examples.length > 0);
   const simpleTrails = withExamples.filter((t) => t.crosses.length === 0);
   const compositionTrails = withExamples.filter((t) => t.crosses.length > 0);
 
   // Simple trails: run examples directly
   if (simpleTrails.length > 0) {
     describe.each(simpleTrails)('$id', (t) => {
-      const { examples, output } = t;
+      const { examples } = t;
       if (!examples) {
         return;
       }
@@ -353,7 +409,7 @@ export const testExamples = (
             resolved.resources
           );
           const testCtx = mergeTestContext(resolved.ctx);
-          await runExample(t, example, output, testCtx, resources, resolved);
+          await runTargetExample(t, example, testCtx, resources, resolved);
         }
       );
     });
@@ -370,7 +426,7 @@ export const testExamples = (
   // execute, but they are not required to cover declared crossings.
   if (compositionTrails.length > 0) {
     describe.each(compositionTrails)('$id', (t) => {
-      const { examples, output } = t;
+      const { examples } = t;
       if (!examples) {
         return;
       }
@@ -403,7 +459,6 @@ export const testExamples = (
           await runCompositionExample(
             t,
             example,
-            output,
             baseCtx,
             pickCoverageSink(example),
             app,

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -266,6 +266,13 @@ describe('deriveTopoGraph', () => {
             },
           },
           2: {
+            examples: [
+              {
+                expected: { inviteId: 'i_2' },
+                input: { email: 'ada@example.test' },
+                name: 'Deprecated invite',
+              },
+            ],
             input: z.object({ email: z.string() }),
             output: z.object({ inviteId: z.string() }),
             status: { state: 'deprecated', successor: 3 },
@@ -295,6 +302,13 @@ describe('deriveTopoGraph', () => {
         status: { reason: 'No supported callers remain.', state: 'archived' },
       });
       expect(entry?.versions?.['2']).toMatchObject({
+        exampleCount: 1,
+        examples: [
+          expect.objectContaining({
+            name: 'Deprecated invite',
+            provenance: { source: 'trail.versions.examples' },
+          }),
+        ],
         kind: 'revision',
         status: { state: 'deprecated', successor: 3 },
       });

--- a/packages/topographer/src/__tests__/diff.test.ts
+++ b/packages/topographer/src/__tests__/diff.test.ts
@@ -437,6 +437,73 @@ describe('deriveTopoGraphDiff', () => {
       expect(resourceDetail).toContain('cache.main');
       expect(resourceDetail).toContain('search.index');
     });
+
+    test('new live version entries without examples produce a warning', () => {
+      const versionContract = {
+        input: { properties: {}, type: 'object' },
+        kind: 'revision' as const,
+        marker: 'abcd000000000000',
+        output: { properties: {}, type: 'object' },
+      };
+      const prev = topoGraph([
+        entry({
+          id: 'versioned.trail',
+          version: 2,
+          versions: {},
+        }),
+      ]);
+      const curr = topoGraph([
+        entry({
+          id: 'versioned.trail',
+          version: 3,
+          versions: {
+            2: {
+              ...versionContract,
+              exampleCount: 0,
+              status: { state: 'deprecated' },
+            },
+          },
+        }),
+      ]);
+
+      const result = deriveTopoGraphDiff(prev, curr);
+
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]?.details).toContain(
+        'Live version 2 added without examples'
+      );
+    });
+
+    test('version-entry example count changes are informational', () => {
+      const versionContract = {
+        input: { properties: {}, type: 'object' },
+        kind: 'revision' as const,
+        marker: 'abcd000000000000',
+        output: { properties: {}, type: 'object' },
+      };
+      const prev = topoGraph([
+        entry({
+          id: 'versioned.trail',
+          versions: {
+            1: { ...versionContract, exampleCount: 1 },
+          },
+        }),
+      ]);
+      const curr = topoGraph([
+        entry({
+          id: 'versioned.trail',
+          versions: {
+            1: { ...versionContract, exampleCount: 2 },
+          },
+        }),
+      ]);
+
+      const result = deriveTopoGraphDiff(prev, curr);
+
+      expect(result.info[0]?.details).toContain(
+        'Live version 1 examples: 1 -> 2'
+      );
+    });
   });
 
   describe('severity partitioning', () => {

--- a/packages/topographer/src/diff.ts
+++ b/packages/topographer/src/diff.ts
@@ -8,6 +8,7 @@ import type {
   JsonSchema,
   TopoGraph,
   TopoGraphEntry,
+  TopoGraphVersionEntry,
 } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -441,6 +442,56 @@ const diffResources = (
   }
 };
 
+const isLiveVersionEntry = (entry: TopoGraphVersionEntry): boolean =>
+  entry.status?.state !== 'archived';
+
+const diffVersionExampleCoverage = (
+  acc: DetailAccumulator,
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
+): void => {
+  const previousVersions = prev.versions ?? {};
+  for (const [version, entry] of Object.entries(curr.versions ?? {}).toSorted(
+    ([left], [right]) => Number(left) - Number(right)
+  )) {
+    if (!isLiveVersionEntry(entry)) {
+      continue;
+    }
+
+    const previous = previousVersions[version];
+    if (entry.exampleCount === 0 && previous === undefined) {
+      addDetail(
+        acc,
+        'warning',
+        `Live version ${version} added without examples`
+      );
+      continue;
+    }
+
+    if (
+      previous !== undefined &&
+      isLiveVersionEntry(previous) &&
+      previous.exampleCount > 0 &&
+      entry.exampleCount === 0
+    ) {
+      addDetail(
+        acc,
+        'warning',
+        `Live version ${version} example coverage removed`
+      );
+      continue;
+    }
+
+    if (previous?.exampleCount !== entry.exampleCount) {
+      addDetail(
+        acc,
+        'info',
+        `Live version ${version} examples: ${previous?.exampleCount ?? 0} -> ${entry.exampleCount}`
+      );
+    }
+  }
+};
+
 /** Diff declared contour arrays on trail entries. */
 const diffContours = (
   acc: DetailAccumulator,
@@ -528,6 +579,7 @@ const diffTrailEntryDetails = (
   diffCrosses(acc, prev, curr);
   diffContours(acc, prev, curr);
   diffResources(acc, prev, curr);
+  diffVersionExampleCoverage(acc, prev, curr);
 };
 
 const diffEntryDetails = (

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -101,6 +101,8 @@ export interface TopoGraphVersionDetour {
 }
 
 export interface TopoGraphVersionEntry {
+  readonly exampleCount: number;
+  readonly examples?: readonly StructuredTrailExample[] | undefined;
   readonly kind: 'revision' | 'fork';
   readonly input: JsonSchema;
   readonly marker: string;

--- a/packages/topographer/src/versioning.ts
+++ b/packages/topographer/src/versioning.ts
@@ -1,6 +1,7 @@
 import {
   DETOUR_MAX_ATTEMPTS_CAP,
   TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH,
+  deriveStructuredTrailExamples,
   ValidationError,
   deriveCurrentTrailVersionMarker,
   deriveShortestUnambiguousTrailVersionMarkerPrefix,
@@ -89,12 +90,20 @@ export const projectTrailVersionEntry = (
   projectSchema: SchemaProjector
 ): TopoGraphVersionEntry => {
   const kind = getTrailVersionEntryKind(entry);
+  const examples = deriveStructuredTrailExamples(entry.examples, {
+    provenance: { source: 'trail.versions.examples' },
+  });
   const projected: Record<string, unknown> = {
+    exampleCount: entry.examples?.length ?? 0,
     input: projectSchema(entry.input),
     kind,
     marker: deriveTrailVersionEntryMarker(entry),
     output: projectSchema(entry.output),
   };
+
+  if (examples !== undefined) {
+    projected['examples'] = examples;
+  }
 
   if (entry.status !== undefined) {
     projected['status'] = sortPlainRecord({ ...entry.status });


### PR DESCRIPTION
## Context

Stack position 7/7 for the Trail Versioning M1 + M2 stack. This PR makes examples and `testAll` exercise current plus live historical version entries.

## Changes

- Derives version-aware example targets for current trails and live non-archived historical entries.
- Runs revision examples through the current blaze with transpose-aware version execution.
- Runs fork examples through fork-local blaze behavior.
- Skips archived version entries in live example and contract testing.
- Updates `testExamples`, `testContracts`, and `testAll` for version-entry coverage.
- Adds version-aware guide/survey/topographer example-count behavior.
- Aligns testing batch `ctx.cross([...])` semantics with runtime by using inline per-target version references.
- Adds a branch-local changeset for testing/topographer/app package impact.

## Verification

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/testing typecheck`
- `bun run --cwd packages/topographer typecheck`
- `bun run --cwd apps/trails typecheck`
- `bun run --cwd packages/core test`
- `bun run --cwd packages/testing test`
- `bun run --cwd packages/topographer test`
- `bun run --cwd apps/trails test`
- Focused follow-up tests for guide counts, `testContracts`, batch cross semantics, and fixture ordering.
- Full stack-tip gate passed through `bun run publish:check`.

## Risks / Rollout

Additive testing behavior. Archived historical entries remain inert for live test/example execution. No package publishing is part of this PR.

## Linear

- Linear: TRL-116
- Project: Trail Versioning