### PR TITLE
chore(core): tighten trail versioning api boundaries

### DIFF
--- a/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
+++ b/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
@@ -2,7 +2,7 @@
 
 Date started: 2026-05-20
 Date finalized: pending
-Status: Seeded
+Status: Executing
 Plan: `.agents/plans/2026-05-20-trail-versioning-m3-closeout/PLAN.md`
 Goal: `.agents/plans/2026-05-20-trail-versioning-m3-closeout/GOAL.md`
 
@@ -56,6 +56,9 @@ they represent real future work.
 | --- | --- | --- | --- |
 | Pending | `context-prime.sh` uses a `jq --argfile` invocation that fails in this environment. | Tooling hygiene, not Trail Versioning M3 implementation. | Pending follow-up if it remains reproducible. |
 | TRL-508 | Consumer codemod/migration path remains M4. | M3 must settle core lifecycle/surface/gates first. | <https://linear.app/outfitter/issue/TRL-508/codemod-path-scope-trails-migrate-and-align-with-ontrailstrailworks> |
+| Pending | HTTP/MCP/CLI do not yet carry trail-version requests or project lifecycle status, while no WebSocket surface was found. | In scope for TRL-117/TRL-118; recorded from local seam map before implementation. | Local explorer report summarized in execution log. |
+| Pending | `forces` exists in TopoGraph types only as a loose placeholder and is not populated by derive/versioning code. | In scope for TRL-732/TRL-730; recorded from local seam map before implementation. | Local explorer report summarized in execution log. |
+| Pending | Warden versioning rules will require manual rule registry, metadata, trail wrapper, and generated-guide updates. | In scope for TRL-120; recorded from local seam map before implementation. | Local explorer report summarized in execution log. |
 
 ## Tracker Mutations
 
@@ -79,6 +82,16 @@ Append meaningful state changes, especially before handoff points.
 - Result: Packet seeded; context-prime script produced useful context but failed on open-PR matching with jq --argfile.
 - Next: Commit packet on the lowest execution branch when the executor starts the stack.
 - Blockers: None for planning.
+
+2026-05-20 10:05 EDT - execution preflight and TRL-740 implementation
+- Changed: Synced `main`, pruned merged local planning branches, created the eight local Graphite branches in the requested order, and kept unrelated PR #531 / `trl-738-add-codex-clark-agent-wiring` as a sibling stack off `main`.
+- Changed: Implemented TRL-740 cleanup on `trl-740-chorecore-tighten-trail-versioning-publicinternal-api`: explicit absent-marker diagnostic in `deriveShortestUnambiguousTrailVersionMarkerPrefix`, clearer marker-resolution narrowing, public/internal split for executor cross-validation options, testing harness casts for internal cross validation, public API type assertion, and branch-local changeset.
+- Verified: Linear project and issues TRL-740, TRL-117, TRL-731, TRL-732, TRL-730, TRL-118, TRL-119, TRL-120 still match the packet at start; PR #539 and #540 are merged; live `main` is `2044e3721`.
+- Verified: Focused tests passed: `bun test packages/core/src/__tests__/version-marker.test.ts packages/core/src/__tests__/version-execution.test.ts packages/testing/src/__tests__/all.test.ts packages/testing/src/__tests__/contracts.test.ts packages/testing/src/__tests__/examples.test.ts` (82 pass).
+- Verified: `bun run --cwd packages/core typecheck`, `bun run --cwd packages/testing typecheck`, and `git diff --check` passed.
+- Result: TRL-740 is locally implemented and ready to commit at the bottom of the stack.
+- Next: Commit TRL-740, restack upward, then implement lifecycle status work in TRL-117/TRL-731.
+- Blockers: None. Local seam maps identified expected M3 gaps in surfaces, diff/forces, and Warden.
 ```
 
 ## Local Review Log
@@ -98,12 +111,15 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | --- | --- | --- | --- |
 | `bash /Users/mg/.agents/skills/goal-planning/scripts/context-prime.sh .` | Planning snapshot | Partial | Produced repo/plan context, then failed at open-PR matching with `jq: Unknown option --argfile`. |
 | `bun scripts/adr.ts check` | Execution tip | Pending | Required by goal. |
+| `bun test packages/core/src/__tests__/version-marker.test.ts packages/core/src/__tests__/version-execution.test.ts packages/testing/src/__tests__/all.test.ts packages/testing/src/__tests__/contracts.test.ts packages/testing/src/__tests__/examples.test.ts` | TRL-740 targeted tests | Passed | 82 pass, 0 fail. |
+| `bun run --cwd packages/core typecheck` | TRL-740 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun run --cwd packages/testing typecheck` | TRL-740 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run check` | Execution tip | Pending | Required by goal. |
 | `bun run build` | Execution tip | Pending | Required by goal. |
 | `bun run test` | Execution tip | Pending | Required by goal. |
 | `bun run lint:ast-grep` | Execution tip | Pending | Required by goal. |
 | `bun run publish:check` | Execution tip | Pending | Required by goal; Bun-based only. |
-| `git diff --check` | Planning branch and execution tip | Pending | Required before handoff. |
+| `git diff --check` | TRL-740 local diff | Passed | No whitespace/conflict-marker output. Required again before handoff. |
 
 ## Remote Review / CI Log
 

--- a/.changeset/trl-740-versioning-api-polish.md
+++ b/.changeset/trl-740-versioning-api-polish.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/core": patch
+"@ontrails/testing": patch
+---
+
+Tighten trail-versioning API polish by keeping executor cross-validation internals out of public options and improving absent marker diagnostics.

--- a/packages/core/src/__tests__/version-marker.test.ts
+++ b/packages/core/src/__tests__/version-marker.test.ts
@@ -81,6 +81,15 @@ describe('trail version markers', () => {
     expect(display).toBe('abcd');
   });
 
+  test('rejects display prefix derivation for markers outside the candidate set', () => {
+    expect(() =>
+      deriveShortestUnambiguousTrailVersionMarkerPrefix('abcd000000000000', [
+        'abce000000000000',
+        'f000000000000000',
+      ])
+    ).toThrow('not in the provided marker set');
+  });
+
   test('resolves marker prefixes and rejects invalid or ambiguous prefixes', () => {
     const markers = [
       { marker: 'abcd000000000000', version: 1 },

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -86,7 +86,7 @@ type MutableTrailContext = {
 };
 
 type CrossForwardOptions = Omit<
-  ExecuteTrailOptions,
+  ExecuteTrailInternalOptions,
   'createContext' | 'crossValidation' | 'validationSchema' | 'version'
 >;
 
@@ -174,6 +174,15 @@ export interface ExecuteTrailOptions {
    * content-addressed markers by unambiguous prefix.
    */
   readonly version?: TrailVersionReference | undefined;
+}
+
+/**
+ * Internal executor options used by framework-managed cross and fork dispatch.
+ *
+ * These fields intentionally stay out of the exported public
+ * {@link ExecuteTrailOptions} surface.
+ */
+interface ExecuteTrailInternalOptions extends ExecuteTrailOptions {
   /**
    * Marks this invocation as a `ctx.cross()` dispatch so versioned fork
    * entries validate against their own `crossInput`.
@@ -204,7 +213,7 @@ export interface ExecuteTrailOptions {
 
 const applyContextOverrides = (
   base: TrailContextInit,
-  options?: ExecuteTrailOptions
+  options?: ExecuteTrailInternalOptions
 ): TrailContextInit => {
   const withOverrides = options?.ctx
     ? {
@@ -251,7 +260,7 @@ const applyContextOverrides = (
 
 const bindResourceLookup = (
   resolved: TrailContextInit,
-  options?: ExecuteTrailOptions
+  options?: ExecuteTrailInternalOptions
 ): TrailContext => {
   if (
     options?.ctx?.extensions === undefined &&
@@ -280,7 +289,7 @@ const bindResourceLookup = (
  *    already carries.
  */
 const resolveContext = async (
-  options?: ExecuteTrailOptions
+  options?: ExecuteTrailInternalOptions
 ): Promise<TrailContext> => {
   const seed = options?.createContext
     ? await options.createContext()
@@ -365,7 +374,7 @@ const enforcePermitRequirement = (
 
 const prepareContext = async (
   trail: AnyTrail,
-  options?: ExecuteTrailOptions
+  options?: ExecuteTrailInternalOptions
 ): Promise<
   Result<
     { readonly ctx: TrailContext; readonly releaseResources: () => void },
@@ -721,7 +730,7 @@ const executeResolvedCrossTarget = async (
   version?: TrailVersionReference | undefined
 ): Promise<Result<unknown, Error>> =>
   await // eslint-disable-next-line no-use-before-define -- executor closure runs only after executeTrail is defined
-  executeTrail(target, input, {
+  executeTrailInternal(target, input, {
     ...forwarded,
     crossValidation: true,
     ctx,
@@ -875,7 +884,7 @@ const executeCrossBatch = async (
 const bindCrossToCtx = (
   ctx: TrailContext,
   topo: Topo | undefined,
-  options: ExecuteTrailOptions | undefined
+  options: ExecuteTrailInternalOptions | undefined
 ): TrailContext => {
   if (ctx.cross !== undefined) {
     return ctx;
@@ -925,7 +934,7 @@ const bindCrossToCtx = (
 const bindFireToCtx = (
   ctx: TrailContext,
   topo: Topo | undefined,
-  options: ExecuteTrailOptions | undefined,
+  options: ExecuteTrailInternalOptions | undefined,
   producerTrailId?: string | undefined
 ): TrailContext => {
   // Symmetric with bindCrossToCtx: a caller-supplied ctx.fire (e.g. test
@@ -960,7 +969,7 @@ const bindFireToCtx = (
     trackedCtx,
     (consumer, input, consumerCtx) =>
       // eslint-disable-next-line no-use-before-define -- executor closure runs only after executeTrail is defined
-      executeTrail(consumer, input, {
+      executeTrailInternal(consumer, input, {
         ...forwarded,
         ctx: consumerCtx,
         topo,
@@ -974,7 +983,7 @@ const bindCrossAtLayerBoundary =
   <I, O>(
     implementation: Implementation<I, O>,
     topo: Topo | undefined,
-    options: ExecuteTrailOptions | undefined
+    options: ExecuteTrailInternalOptions | undefined
   ): Implementation<I, O> =>
   (input, ctx) =>
     implementation(input, bindCrossToCtx(ctx, topo, options));
@@ -983,7 +992,7 @@ const bindFireAtLayerBoundary = <I, O>(
   implementation: Implementation<I, O>,
   trail: AnyTrail,
   topo: Topo | undefined,
-  options: ExecuteTrailOptions | undefined
+  options: ExecuteTrailInternalOptions | undefined
 ): Implementation<I, O> => {
   if (topo === undefined) {
     return implementation;
@@ -1169,7 +1178,7 @@ const prepareRunImpl = (
   ctx: TrailContext,
   layers: readonly Layer[],
   topo: Topo | undefined,
-  options: ExecuteTrailOptions | undefined
+  options: ExecuteTrailInternalOptions | undefined
 ): {
   readonly ctxWithIntrinsics: TrailContext;
   readonly impl: Implementation<unknown, unknown>;
@@ -1223,7 +1232,7 @@ const runImplWithoutTracing = async (
   ctx: TrailContext,
   layers: readonly Layer[],
   topo: Topo | undefined,
-  options: ExecuteTrailOptions | undefined
+  options: ExecuteTrailInternalOptions | undefined
 ): Promise<Result<unknown, Error>> => {
   const prepared = prepareRunImpl(
     trail,
@@ -1245,7 +1254,7 @@ const runTrailWithTracing = async (
   ctx: TrailContext,
   layers: readonly Layer[],
   topo: Topo | undefined,
-  options: ExecuteTrailOptions | undefined,
+  options: ExecuteTrailInternalOptions | undefined,
   sink: ReturnType<typeof getTraceSink>
 ): Promise<Result<unknown, Error>> => {
   const { record, tracedCtx } = buildTracedContext(trail, ctx, sink);
@@ -1278,7 +1287,7 @@ const runTrail = async (
   ctx: TrailContext,
   layers: readonly Layer[],
   topo: Topo | undefined,
-  options: ExecuteTrailOptions | undefined
+  options: ExecuteTrailInternalOptions | undefined
 ): Promise<Result<unknown, Error>> => {
   const sink = topo?.observe?.trace ?? getTraceSink();
   return isTracingDisabled(sink)
@@ -1300,7 +1309,7 @@ const runTrail = async (
  */
 const composeAttachedLayers = (
   trail: AnyTrail,
-  options: ExecuteTrailOptions | undefined
+  options: ExecuteTrailInternalOptions | undefined
 ): readonly Layer[] => [
   ...(options?.topoLayers ?? []),
   ...(options?.surfaceLayers ?? []),
@@ -1309,8 +1318,8 @@ const composeAttachedLayers = (
 ];
 
 const stripVersionOption = (
-  options?: ExecuteTrailOptions
-): Omit<ExecuteTrailOptions, 'version'> | undefined => {
+  options?: ExecuteTrailInternalOptions
+): Omit<ExecuteTrailInternalOptions, 'version'> | undefined => {
   if (options === undefined) {
     return undefined;
   }
@@ -1321,23 +1330,21 @@ const stripVersionOption = (
 const executeRequestedCurrentTrailVersion = async (
   trail: AnyTrail,
   rawInput: unknown,
-  options: ExecuteTrailOptions
+  options: ExecuteTrailInternalOptions
 ): Promise<Result<unknown, Error>> =>
   // eslint-disable-next-line no-use-before-define -- recursive dispatch strips version before re-entering the current pipeline
-  await executeTrail(trail, rawInput, stripVersionOption(options));
+  await executeTrailInternal(trail, rawInput, stripVersionOption(options));
 
-const executeCurrentTrailForRevision: TrailVersionCurrentExecutor = async (
-  trail,
-  input,
-  options
-) => {
+const executeCurrentTrailForRevision: TrailVersionCurrentExecutor<
+  ExecuteTrailInternalOptions
+> = async (trail, input, internalOptions) => {
   const {
     validationSchema: _validationSchema,
     version: _version,
     ...forwarded
-  } = options ?? {};
+  } = internalOptions ?? {};
   // eslint-disable-next-line no-use-before-define -- revision runtime calls back into current execution after options are normalized
-  return await executeTrail(trail, input, forwarded);
+  return await executeTrailInternal(trail, input, forwarded);
 };
 
 const createForkTrailVersion = (
@@ -1373,7 +1380,7 @@ const executeRequestedForkTrailVersion = async (
   trail: AnyTrail,
   entry: TrailVersionForkEntry,
   rawInput: unknown,
-  options: ExecuteTrailOptions
+  options: ExecuteTrailInternalOptions
 ): Promise<Result<unknown, Error>> => {
   const forkTrail = createForkTrailVersion(trail, entry);
   const validationSchema = options.crossValidation
@@ -1381,7 +1388,7 @@ const executeRequestedForkTrailVersion = async (
     : options.validationSchema;
 
   // eslint-disable-next-line no-use-before-define -- recursive dispatch strips version before re-entering the fork pipeline
-  return await executeTrail(forkTrail, rawInput, {
+  return await executeTrailInternal(forkTrail, rawInput, {
     ...stripVersionOption(options),
     validationSchema,
   });
@@ -1390,7 +1397,7 @@ const executeRequestedForkTrailVersion = async (
 const executeRequestedTrailVersion = async (
   trail: AnyTrail,
   rawInput: unknown,
-  options: ExecuteTrailOptions
+  options: ExecuteTrailInternalOptions
 ): Promise<Result<unknown, Error>> => {
   const reference = options.version;
   if (reference === undefined) {
@@ -1511,10 +1518,10 @@ const validateContextLayerInputs = (
  * The function never throws -- unexpected exceptions are caught and
  * returned as `Result.err(InternalError)`.
  */
-export const executeTrail = async (
+const executeTrailInternal = async (
   trail: AnyTrail,
   rawInput: unknown,
-  options?: ExecuteTrailOptions
+  options?: ExecuteTrailInternalOptions
 ): Promise<Result<unknown, Error>> => {
   try {
     if (options?.version !== undefined) {
@@ -1559,3 +1566,10 @@ export const executeTrail = async (
     return Result.err(new InternalError(message));
   }
 };
+
+export const executeTrail = async (
+  trail: AnyTrail,
+  rawInput: unknown,
+  options?: ExecuteTrailOptions
+): Promise<Result<unknown, Error>> =>
+  await executeTrailInternal(trail, rawInput, options);

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -11,6 +11,7 @@
 
 import type { Signal, SignalSpec } from './signal.js';
 import type { Trail, TrailSpec, TrailVersionRevisionEntry } from './trail.js';
+import type { ExecuteTrailOptions } from './execute.js';
 import type { ResourceSpec } from './resource.js';
 import type { ContourOptions } from './contour.js';
 import type { ScheduleSpec } from './schedule.js';
@@ -214,6 +215,21 @@ export type RevisionTransposeContract = [
 export type RevisionRuntimeFieldContract = [
   AssertRevisionNoCrossInput,
 ] extends [true]
+  ? 'pass'
+  : never;
+
+// ---------------------------------------------------------------------------
+// ExecuteTrailOptions keeps cross-validation internals out of the public API
+// ---------------------------------------------------------------------------
+
+type AssertExecuteOptionsHideCrossValidation =
+  'crossValidation' extends keyof ExecuteTrailOptions ? false : true;
+type AssertExecuteOptionsHideValidationSchema =
+  'validationSchema' extends keyof ExecuteTrailOptions ? false : true;
+export type ExecuteOptionsPublicBoundary = [
+  AssertExecuteOptionsHideCrossValidation,
+  AssertExecuteOptionsHideValidationSchema,
+] extends [true, true]
   ? 'pass'
   : never;
 

--- a/packages/core/src/version-marker.ts
+++ b/packages/core/src/version-marker.ts
@@ -361,6 +361,11 @@ export const deriveShortestUnambiguousTrailVersionMarkerPrefix = (
     assertTrailVersionMarker(candidate);
     return candidate;
   });
+  if (!normalizedMarkers.includes(marker)) {
+    throw new ValidationError(
+      `Trail version marker ${marker} is not in the provided marker set`
+    );
+  }
 
   for (
     let length = Math.max(minLength, TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH);

--- a/packages/core/src/version-resolution.ts
+++ b/packages/core/src/version-resolution.ts
@@ -209,10 +209,7 @@ const resolveMarkerReference = (
     );
   }
 
-  const [match] = matches;
-  if (match === undefined) {
-    return Result.err(unsupportedVersion(trail, requested, 'marker missing'));
-  }
+  const match = matches[0] as (typeof matches)[number];
 
   return Result.ok({ marker: match.marker, version: match.version });
 };

--- a/packages/core/src/version-runtime.ts
+++ b/packages/core/src/version-runtime.ts
@@ -5,10 +5,12 @@ import { getTrailVersionEntryKind } from './trail.js';
 import type { AnyTrail, TrailVersionEntry } from './trail.js';
 import { validateInput, validateOutput } from './validation.js';
 
-export type TrailVersionCurrentExecutor = (
+export type TrailVersionCurrentExecutor<
+  Options extends ExecuteTrailOptions = ExecuteTrailOptions,
+> = (
   trail: AnyTrail,
   input: unknown,
-  options?: ExecuteTrailOptions
+  options?: Options
 ) => Promise<Result<unknown, Error>>;
 
 const normalizeTransposeError = (
@@ -64,13 +66,15 @@ const runTransposeOutput = async (
   }
 };
 
-export const executeTrailRevision = async (
+export const executeTrailRevision = async <
+  Options extends ExecuteTrailOptions = ExecuteTrailOptions,
+>(
   trail: AnyTrail,
   version: number,
   entry: TrailVersionEntry,
   rawInput: unknown,
-  options: ExecuteTrailOptions | undefined,
-  executeCurrentTrail: TrailVersionCurrentExecutor
+  options: Options | undefined,
+  executeCurrentTrail: TrailVersionCurrentExecutor<Options>
 ): Promise<Result<unknown, Error>> => {
   if (getTrailVersionEntryKind(entry) !== 'revision') {
     return Result.err(

--- a/packages/testing/src/crosses.ts
+++ b/packages/testing/src/crosses.ts
@@ -10,6 +10,7 @@ import { describe, expect, test } from 'bun:test';
 import type {
   AnyTrail,
   CrossFn,
+  ExecuteTrailOptions,
   ResourceOverrideMap,
   TrailContext,
 } from '@ontrails/core';
@@ -29,6 +30,10 @@ import {
 } from './assertions.js';
 import { mergeResourceOverrides, mergeTestContext } from './context.js';
 import type { CrossScenario } from './types.js';
+
+type TestingExecuteTrailOptions = ExecuteTrailOptions & {
+  readonly validationSchema?: ReturnType<typeof buildCrossValidationSchema>;
+};
 
 // ---------------------------------------------------------------------------
 // Cross trace
@@ -158,11 +163,12 @@ const executeFromMap = (
   }
 
   const nestedCtx = cross ? { ...ctx, cross } : ctx;
-  return executeTrail(trailDef, input, {
+  const options: TestingExecuteTrailOptions = {
     ctx: nestedCtx,
     resources,
     validationSchema: buildCrossValidationSchema(trailDef),
-  });
+  };
+  return executeTrail(trailDef, input, options);
 };
 
 /** Extract trail ID from either a trail object or a string. */

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -12,6 +12,7 @@ import { describe, expect, test } from 'bun:test';
 import type {
   CrossFn,
   CrossOptions,
+  ExecuteTrailOptions,
   ResourceOverrideMap,
   Topo,
   TrailExample,
@@ -65,6 +66,10 @@ import {
 } from './effective-examples.js';
 import type { TrailExampleTarget } from './effective-examples.js';
 import { withSignalAssertions } from './signals.js';
+
+type TestingExecuteTrailOptions = ExecuteTrailOptions & {
+  readonly validationSchema?: ReturnType<typeof buildCrossValidationSchema>;
+};
 
 // ---------------------------------------------------------------------------
 // Error class name -> constructor map
@@ -277,12 +282,13 @@ const createCoverageCross = (
 
     const trailDef = topo.get(id);
     if (trailDef !== undefined) {
-      return await executeTrail(trailDef, input, {
+      const options: TestingExecuteTrailOptions = {
         ctx: { ...ctx, cross: self },
         resources,
         ...(version === undefined ? {} : { version }),
         validationSchema: buildCrossValidationSchema(trailDef),
-      });
+      };
+      return await executeTrail(trailDef, input, options);
     }
 
     return Result.ok();

--- a/packages/testing/src/scenario.ts
+++ b/packages/testing/src/scenario.ts
@@ -12,6 +12,7 @@ import type {
   AnyTrail,
   CrossBatchOptions,
   CrossFn,
+  ExecuteTrailOptions,
   ResourceOverrideMap,
   Result,
   Topo,
@@ -32,6 +33,9 @@ import type { RefToken, ScenarioStep } from './types.js';
 
 type ScenarioCrossTarget = string | { readonly id: string };
 type ScenarioCrossCall = readonly [ScenarioCrossTarget, unknown];
+type TestingExecuteTrailOptions = ExecuteTrailOptions & {
+  readonly validationSchema?: ReturnType<typeof buildCrossValidationSchema>;
+};
 
 // ---------------------------------------------------------------------------
 // ref() — cross-step reference marker
@@ -247,12 +251,13 @@ const createScenarioCross = (
       return R.err(new InternalError(`cross: trail "${id}" not found in topo`));
     }
     const baseCtx = createTestContext();
-    return await executeTrail(trailDef, input, {
+    const options: TestingExecuteTrailOptions = {
       ctx: { ...baseCtx, cross: self },
       resources,
       topo: app,
       validationSchema: buildCrossValidationSchema(trailDef),
-    });
+    };
+    return await executeTrail(trailDef, input, options);
   };
 
   const executeCrossBatch = async (


### PR DESCRIPTION
## Context

Trail Versioning M3 needs the M1/M2 public/internal API cleanup landed at the bottom of the stack before new lifecycle behavior piles on. This branch tightens the versioning surfaces without changing user-facing lifecycle semantics.

Linear: TRL-740
Stack: 1/8, base cleanup for Trail Versioning M3.

## What changed

- Split public `ExecuteTrailOptions` from internal cross-validation options so external callers do not see framework-only execution knobs.
- Tightened marker-prefix diagnostics when no version markers are available.
- Added focused type/test coverage for the public API boundary and marker-prefix behavior.
- Added a branch-local changeset for `@ontrails/core` / `@ontrails/testing` package-content changes.

## Verification

- `bun test packages/core/src/__tests__/version-marker.test.ts packages/core/src/__tests__/version-execution.test.ts packages/testing/src/__tests__/all.test.ts packages/testing/src/__tests__/contracts.test.ts packages/testing/src/__tests__/examples.test.ts` (82 pass)
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/testing typecheck`
- Stack-tip gates later passed: ADR check, typecheck, test, lint, ast-grep, build, format, check, publish dry-run, Warden guide checks, `git diff --check`.

## Risks / notes

Low-risk cleanup branch. The intent is to prevent internal execution details from becoming public API debt before the M3 lifecycle stack lands.