### PR TITLE
feat(core): require deprecated version guidance

### DIFF
--- a/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
+++ b/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
@@ -92,6 +92,16 @@ Append meaningful state changes, especially before handoff points.
 - Result: TRL-740 is locally implemented and ready to commit at the bottom of the stack.
 - Next: Commit TRL-740, restack upward, then implement lifecycle status work in TRL-117/TRL-731.
 - Blockers: None. Local seam maps identified expected M3 gaps in surfaces, diff/forces, and Warden.
+
+2026-05-20 10:09 EDT - TRL-117 deprecated status guidance
+- Changed: Committed TRL-740 as `0248259a3 chore(core): tighten trail versioning api boundaries`; Graphite restacked the descendant branches.
+- Changed: Implemented TRL-117 deprecated lifecycle substrate on `trl-117-add-status-deprecation-metadata-and-surface-signals`: split typed deprecated/archived status shapes, exported deprecated-status helpers, required deprecated entries to declare `successor`, `migration`, or `note`, validated `successor` and `migration`, updated fixtures to carry actionable deprecation guidance, and added a branch-local core changeset.
+- Verified: First targeted run caught two expected lifecycle fixture/validation-order failures; fixed both.
+- Verified: Targeted lifecycle/app/topographer/testing suite passed: `bun test packages/core/src/__tests__/trail.test.ts packages/core/src/__tests__/version-execution.test.ts packages/testing/src/__tests__/all.test.ts packages/testing/src/__tests__/contracts.test.ts packages/testing/src/__tests__/examples.test.ts packages/topographer/src/__tests__/derive.test.ts packages/topographer/src/__tests__/diff.test.ts apps/trails/src/__tests__/guide.test.ts apps/trails/src/__tests__/survey.test.ts` (242 pass).
+- Verified: `bun run --cwd packages/core typecheck`, `bun run --cwd packages/topographer typecheck`, `bun run --cwd packages/testing typecheck`, `bun run --cwd apps/trails typecheck`, and `git diff --check` passed.
+- Result: TRL-117 core lifecycle status guidance is locally implemented. HTTP/MCP/CLI warning projection is still expected to attach when TRL-118 adds surface version negotiation.
+- Next: Commit TRL-117, restack upward, then isolate any remaining archive lifecycle polish on TRL-731.
+- Blockers: None.
 ```
 
 ## Local Review Log
@@ -114,6 +124,11 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun test packages/core/src/__tests__/version-marker.test.ts packages/core/src/__tests__/version-execution.test.ts packages/testing/src/__tests__/all.test.ts packages/testing/src/__tests__/contracts.test.ts packages/testing/src/__tests__/examples.test.ts` | TRL-740 targeted tests | Passed | 82 pass, 0 fail. |
 | `bun run --cwd packages/core typecheck` | TRL-740 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run --cwd packages/testing typecheck` | TRL-740 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun test packages/core/src/__tests__/trail.test.ts packages/core/src/__tests__/version-execution.test.ts packages/testing/src/__tests__/all.test.ts packages/testing/src/__tests__/contracts.test.ts packages/testing/src/__tests__/examples.test.ts packages/topographer/src/__tests__/derive.test.ts packages/topographer/src/__tests__/diff.test.ts apps/trails/src/__tests__/guide.test.ts apps/trails/src/__tests__/survey.test.ts` | TRL-117 targeted tests | Passed after fixture/validation-order fix | First run failed on two deprecated-guidance fallout cases; rerun passed with 242 pass, 0 fail. |
+| `bun run --cwd packages/core typecheck` | TRL-117 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun run --cwd packages/topographer typecheck` | TRL-117 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun run --cwd packages/testing typecheck` | TRL-117 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun run --cwd apps/trails typecheck` | TRL-117 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run check` | Execution tip | Pending | Required by goal. |
 | `bun run build` | Execution tip | Pending | Required by goal. |
 | `bun run test` | Execution tip | Pending | Required by goal. |

--- a/.changeset/trl-117-deprecated-status-guidance.md
+++ b/.changeset/trl-117-deprecated-status-guidance.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/core": patch
+---
+
+Require deprecated trail version entries to carry successor, migration, or note guidance and expose typed lifecycle helpers.

--- a/apps/trails/src/__tests__/guide.test.ts
+++ b/apps/trails/src/__tests__/guide.test.ts
@@ -102,7 +102,7 @@ describe('trails guide', () => {
           ],
           input: z.object({ name: z.string() }),
           output: z.object({ ok: z.boolean() }),
-          status: { state: 'deprecated' },
+          status: { note: 'Use the current version.', state: 'deprecated' },
         },
         2: {
           examples: [

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -359,7 +359,7 @@ describe('trails survey brief', () => {
           ],
           input: z.object({ name: z.string() }),
           output: z.object({ ok: z.boolean() }),
-          status: { state: 'deprecated' },
+          status: { note: 'Use the current version.', state: 'deprecated' },
         },
         2: {
           examples: [
@@ -490,7 +490,7 @@ describe('trails survey detail', () => {
           ],
           input: z.object({ legacyId: z.string() }),
           output: z.object({ ok: z.boolean() }),
-          status: { state: 'deprecated' },
+          status: { note: 'Use the current version.', state: 'deprecated' },
           transpose: {
             input: ({ input }) => ({ id: input.legacyId }),
             output: ({ output }) => output,
@@ -513,7 +513,7 @@ describe('trails survey detail', () => {
         }),
       ],
       kind: 'revision',
-      status: { state: 'deprecated' },
+      status: { note: 'Use the current version.', state: 'deprecated' },
     });
     expect(trailDetailOutput.safeParse(detail).success).toBe(true);
   });

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -443,6 +443,118 @@ describe('trail()', () => {
           },
         } as never)
       ).toThrow(ValidationError);
+
+      expect(() =>
+        trail('bad.deprecated-without-guidance', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              status: { state: 'deprecated' },
+            } as never,
+          },
+        })
+      ).toThrow('must declare successor, migration, or note guidance');
+
+      expect(() =>
+        trail('bad.deprecated-migration', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              status: { migration: 'Use v2.', state: 'deprecated' },
+            } as never,
+          },
+        })
+      ).toThrow('status.migration must be an array');
+
+      expect(() =>
+        trail('bad.deprecated-migration-item', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              status: { migration: ['Use v2.', 2], state: 'deprecated' },
+            } as never,
+          },
+        })
+      ).toThrow('status.migration[1] must be a non-empty string');
+
+      expect(() =>
+        trail('bad.deprecated-migration-blank', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              status: { migration: ['   '], state: 'deprecated' },
+            },
+          },
+        })
+      ).toThrow('status.migration[0] must be a non-empty string');
+
+      expect(() =>
+        trail('bad.deprecated-note', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              status: {
+                migration: ['Use v2.'],
+                note: 42,
+                state: 'deprecated',
+              },
+            } as never,
+          },
+        })
+      ).toThrow('status.note must be a string');
+
+      expect(() =>
+        trail('bad.deprecated-blank-note', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              status: { note: '   ', state: 'deprecated' },
+            },
+          },
+        })
+      ).toThrow('status.note must be a non-empty string');
+
+      expect(() =>
+        trail('bad.deprecated-successor', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              status: { state: 'deprecated', successor: 999 },
+            },
+          },
+        })
+      ).toThrow(
+        'status.successor must reference the current version or another known historical version'
+      );
+
+      expect(() =>
+        trail('bad.deprecated-self-successor', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              status: { state: 'deprecated', successor: 1 },
+            },
+          },
+        })
+      ).toThrow(
+        'status.successor must reference the current version or another known historical version'
+      );
     });
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -162,8 +162,10 @@ export type { ActivationSourceProjection } from './activation-source-projection.
 export {
   deriveSupportedTrailVersions,
   getTrailVersionEntryKind,
+  hasDeprecatedTrailVersionGuidance,
   intentValues,
   isArchivedTrailVersionEntry,
+  isDeprecatedTrailVersionEntry,
   trail,
 } from './trail.js';
 export {
@@ -193,6 +195,8 @@ export type {
   Trail,
   TrailVersionEntry,
   TrailVersionEntryKind,
+  TrailVersionArchivedStatus,
+  TrailVersionDeprecatedStatus,
   TrailVersionForkEntry,
   TrailVersionRevisionEntry,
   TrailVersions,

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -93,11 +93,24 @@ export interface VersionContract<I = unknown, O = unknown> {
   readonly output: O;
 }
 
-/** Shared lifecycle metadata for historical version entries. */
-export interface TrailVersionStatus {
-  readonly state: 'deprecated' | 'archived';
+export interface TrailVersionDeprecatedStatus {
+  readonly migration?: readonly string[] | undefined;
+  readonly note?: string | undefined;
+  readonly state: 'deprecated';
+  readonly successor?: number | undefined;
   readonly [key: string]: unknown;
 }
+
+export interface TrailVersionArchivedStatus {
+  readonly reason?: string | undefined;
+  readonly state: 'archived';
+  readonly [key: string]: unknown;
+}
+
+/** Shared lifecycle metadata for historical version entries. */
+export type TrailVersionStatus =
+  | TrailVersionArchivedStatus
+  | TrailVersionDeprecatedStatus;
 
 /** Shared base for version entries. Historical entries never inherit schemas. */
 export interface VersionEntry<
@@ -209,6 +222,17 @@ export const getTrailVersionEntryKind = (
 export const isArchivedTrailVersionEntry = (
   entry: Pick<TrailVersionEntry, 'status'>
 ): boolean => entry.status?.state === 'archived';
+
+export const isDeprecatedTrailVersionEntry = (
+  entry: Pick<TrailVersionEntry, 'status'>
+): boolean => entry.status?.state === 'deprecated';
+
+export const hasDeprecatedTrailVersionGuidance = (
+  status: Pick<TrailVersionDeprecatedStatus, 'migration' | 'note' | 'successor'>
+): boolean =>
+  status.successor !== undefined ||
+  (Array.isArray(status.migration) && status.migration.length > 0) ||
+  (typeof status.note === 'string' && status.note.trim().length > 0);
 
 export const deriveSupportedTrailVersions = (
   trail: Pick<AnyTrail, 'version' | 'versions'>
@@ -581,6 +605,32 @@ const assertZodSchema = (
   }
 };
 
+const normalizeVersionStatusMigration = (
+  trailId: string,
+  version: number,
+  migration: unknown
+): readonly string[] | undefined => {
+  if (migration === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(migration)) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} status.migration must be an array`
+    );
+  }
+
+  return Object.freeze(
+    migration.map((step, index) => {
+      if (typeof step !== 'string' || step.trim().length === 0) {
+        throw new ValidationError(
+          `Trail "${trailId}" version ${version} status.migration[${index}] must be a non-empty string`
+        );
+      }
+      return step;
+    })
+  );
+};
+
 const normalizeVersionStatus = (
   trailId: string,
   version: number,
@@ -601,8 +651,45 @@ const normalizeVersionStatus = (
       `Trail "${trailId}" version ${version} status.state must be "deprecated" or "archived"`
     );
   }
+  if (raw['state'] === 'deprecated') {
+    if (raw['successor'] !== undefined) {
+      assertVersionNumber(
+        trailId,
+        `version ${version} status.successor`,
+        raw['successor'] as number
+      );
+    }
+    if (raw['note'] !== undefined) {
+      if (typeof raw['note'] !== 'string') {
+        throw new ValidationError(
+          `Trail "${trailId}" version ${version} status.note must be a string`
+        );
+      }
+      if (raw['note'].trim().length === 0) {
+        throw new ValidationError(
+          `Trail "${trailId}" version ${version} status.note must be a non-empty string`
+        );
+      }
+    }
+    const migration = normalizeVersionStatusMigration(
+      trailId,
+      version,
+      raw['migration']
+    );
+    const normalized = Object.freeze({
+      ...raw,
+      ...(migration === undefined ? {} : { migration }),
+      state: 'deprecated',
+    }) as TrailVersionDeprecatedStatus;
+    if (!hasDeprecatedTrailVersionGuidance(normalized)) {
+      throw new ValidationError(
+        `Trail "${trailId}" version ${version} deprecated status must declare successor, migration, or note guidance`
+      );
+    }
+    return normalized;
+  }
 
-  return Object.freeze({ ...raw, state: raw['state'] }) as TrailVersionStatus;
+  return Object.freeze({ ...raw, state: 'archived' }) as TrailVersionStatus;
 };
 
 const normalizeVersionExamples = (
@@ -829,6 +916,23 @@ const normalizeTrailVersions = <CurrentInput, CurrentOutput>(
       currentOutput,
       entry
     );
+  }
+
+  const knownVersions = new Set([
+    currentVersion,
+    ...Object.keys(normalized).map(Number),
+  ]);
+  for (const [rawVersion, entry] of Object.entries(normalized)) {
+    if (
+      entry.status?.state === 'deprecated' &&
+      entry.status.successor !== undefined &&
+      (!knownVersions.has(entry.status.successor) ||
+        entry.status.successor === Number(rawVersion))
+    ) {
+      throw new ValidationError(
+        `Trail "${trailId}" version ${rawVersion} status.successor must reference the current version or another known historical version`
+      );
+    }
   }
 
   return Object.freeze(normalized);

--- a/packages/testing/src/__tests__/all.test.ts
+++ b/packages/testing/src/__tests__/all.test.ts
@@ -199,7 +199,7 @@ const versionedAllTrail = trail('versioned.all', {
       ],
       input: z.object({ code: z.string() }),
       output: z.object({ message: z.string() }),
-      status: { state: 'deprecated' },
+      status: { note: 'Use the current version.', state: 'deprecated' },
     },
     4: {
       examples: [

--- a/packages/testing/src/__tests__/contracts.test.ts
+++ b/packages/testing/src/__tests__/contracts.test.ts
@@ -253,7 +253,7 @@ const versionedContractTrail = trail('contract.versioned', {
       ],
       input: z.object({ code: z.string() }),
       output: z.object({ message: z.string() }),
-      status: { state: 'deprecated' },
+      status: { note: 'Use the current version.', state: 'deprecated' },
     },
     4: {
       examples: [

--- a/packages/testing/src/__tests__/examples.test.ts
+++ b/packages/testing/src/__tests__/examples.test.ts
@@ -537,7 +537,7 @@ const versionedExampleTrail = trail('version.examples', {
       ],
       input: z.object({ code: z.string() }),
       output: z.object({ message: z.string() }),
-      status: { state: 'deprecated' },
+      status: { note: 'Use the current version.', state: 'deprecated' },
     },
     4: {
       examples: [

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -330,7 +330,7 @@ describe('deriveTopoGraph', () => {
             1: {
               input: z.object({ legacy: z.string() }),
               output: z.object({ ok: z.boolean() }),
-              status: { reason: statusReason, state: 'deprecated' },
+              status: { note: statusReason, state: 'deprecated' },
               transpose: {
                 input: () => ({}),
                 output: ({ output }) => output,
@@ -365,7 +365,7 @@ describe('deriveTopoGraph', () => {
               output: required
                 ? z.object({ ok: z.boolean(), required: z.boolean() })
                 : z.object({ ok: z.boolean() }),
-              status: { state: 'deprecated' },
+              status: { note: 'Use the current version.', state: 'deprecated' },
               transpose: {
                 input: () =>
                   required

--- a/packages/topographer/src/__tests__/diff.test.ts
+++ b/packages/topographer/src/__tests__/diff.test.ts
@@ -460,7 +460,7 @@ describe('deriveTopoGraphDiff', () => {
             2: {
               ...versionContract,
               exampleCount: 0,
-              status: { state: 'deprecated' },
+              status: { note: 'Use the current version.', state: 'deprecated' },
             },
           },
         }),


### PR DESCRIPTION
## Context

This is the first lifecycle substrate branch for Trail Versioning M3. It adds typed deprecation metadata so surfaces and later Warden rules can reason about deprecated version entries without inventing per-surface conventions.

Linear: TRL-117
Stack: 2/8, on top of TRL-740.

## What changed

- Added typed `deprecated` and `archived` version status shapes in core.
- Required deprecated historical entries to include actionable guidance: `successor`, `migration`, or `note`.
- Added validation for deprecated successor and migration guidance.
- Exported deprecated-status helpers and updated fixtures/tests that now need guidance.
- Added a branch-local changeset for `@ontrails/core`.

## Verification

- Targeted lifecycle/app/topographer/testing suite passed after expected fixture and validation-order fixes: 242 pass, 0 fail.
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/topographer typecheck`
- `bun run --cwd packages/testing typecheck`
- `bun run --cwd apps/trails typecheck`
- Stack-tip gates later passed: ADR check, typecheck, test, lint, ast-grep, build, format, check, publish dry-run, Warden guide checks, `git diff --check`.

## Risks / notes

Surface warning projection is intentionally handled later in the stack by TRL-118, where version negotiation is added to CLI/HTTP/MCP.