### PR TITLE
feat(core): expose archived version lifecycle helpers

### DIFF
--- a/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
+++ b/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
@@ -102,6 +102,15 @@ Append meaningful state changes, especially before handoff points.
 - Result: TRL-117 core lifecycle status guidance is locally implemented. HTTP/MCP/CLI warning projection is still expected to attach when TRL-118 adds surface version negotiation.
 - Next: Commit TRL-117, restack upward, then isolate any remaining archive lifecycle polish on TRL-731.
 - Blockers: None.
+
+2026-05-20 10:11 EDT - TRL-731 archive lifecycle helpers
+- Changed: Committed TRL-117 as `c69c77903 feat(core): require deprecated version guidance`; Graphite restacked the descendant branches.
+- Changed: Implemented TRL-731 archive lifecycle polish on `trl-731-featcore-add-archive-status-lifecycle-for-version-entries`: exported `isLiveTrailVersionEntry`, routed supported-version derivation through it, validated archived `status.reason` when present, added archived/live helper assertions, and added a branch-local core changeset.
+- Verified: Targeted archive/runtime/topo/survey tests passed: `bun test packages/core/src/__tests__/trail.test.ts packages/core/src/__tests__/version-execution.test.ts packages/core/src/__tests__/validate-topo.test.ts packages/topographer/src/__tests__/derive.test.ts apps/trails/src/__tests__/survey.test.ts` (218 pass).
+- Verified: `bun run --cwd packages/core typecheck` and `git diff --check` passed.
+- Result: TRL-731 archive status lifecycle is locally implemented on top of the already-landed runtime exclusion and graph visibility substrate.
+- Next: Commit TRL-731, restack upward, then implement shared break/force substrate for TRL-732.
+- Blockers: None.
 ```
 
 ## Local Review Log
@@ -129,6 +138,8 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun run --cwd packages/topographer typecheck` | TRL-117 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run --cwd packages/testing typecheck` | TRL-117 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run --cwd apps/trails typecheck` | TRL-117 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun test packages/core/src/__tests__/trail.test.ts packages/core/src/__tests__/version-execution.test.ts packages/core/src/__tests__/validate-topo.test.ts packages/topographer/src/__tests__/derive.test.ts apps/trails/src/__tests__/survey.test.ts` | TRL-731 targeted tests | Passed | 218 pass, 0 fail. |
+| `bun run --cwd packages/core typecheck` | TRL-731 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run check` | Execution tip | Pending | Required by goal. |
 | `bun run build` | Execution tip | Pending | Required by goal. |
 | `bun run test` | Execution tip | Pending | Required by goal. |

--- a/.changeset/trl-731-archive-status-lifecycle.md
+++ b/.changeset/trl-731-archive-status-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/core": patch
+---
+
+Expose archived trail version lifecycle helpers and validate archived status reason metadata.

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -12,6 +12,8 @@ import { signal } from '../signal';
 import {
   deriveSupportedTrailVersions,
   getTrailVersionEntryKind,
+  isArchivedTrailVersionEntry,
+  isLiveTrailVersionEntry,
   intentValues,
   trail,
 } from '../trail';
@@ -286,6 +288,11 @@ describe('trail()', () => {
             input: z.object({}),
             output: z.object({ ok: z.boolean() }),
           },
+          3: {
+            input: z.object({}),
+            output: z.object({ ok: z.boolean() }),
+            status: { state: 'deprecated', successor: 5 },
+          },
           4: {
             input: z.object({}),
             output: z.object({ ok: z.boolean() }),
@@ -294,8 +301,25 @@ describe('trail()', () => {
         },
       });
 
-      expect(Object.keys(versioned.versions ?? {})).toEqual(['2', '4']);
-      expect(deriveSupportedTrailVersions(versioned)).toEqual([2, 5]);
+      expect(Object.keys(versioned.versions ?? {})).toEqual(['2', '3', '4']);
+      expect(deriveSupportedTrailVersions(versioned)).toEqual([2, 3, 5]);
+      const archivedEntry = versioned.versions?.[4];
+      const deprecatedEntry = versioned.versions?.[3];
+      const liveEntry = versioned.versions?.[2];
+      expect(archivedEntry).toBeDefined();
+      expect(deprecatedEntry).toBeDefined();
+      expect(liveEntry).toBeDefined();
+      if (
+        archivedEntry === undefined ||
+        deprecatedEntry === undefined ||
+        liveEntry === undefined
+      ) {
+        throw new Error('expected versioned entries to be normalized');
+      }
+      expect(isArchivedTrailVersionEntry(archivedEntry)).toBe(true);
+      expect(isLiveTrailVersionEntry(archivedEntry)).toBe(false);
+      expect(isLiveTrailVersionEntry(deprecatedEntry)).toBe(true);
+      expect(isLiveTrailVersionEntry(liveEntry)).toBe(true);
     });
 
     test('rejects invalid version entry shapes', () => {
@@ -555,6 +579,32 @@ describe('trail()', () => {
       ).toThrow(
         'status.successor must reference the current version or another known historical version'
       );
+
+      expect(() =>
+        trail('bad.archived-reason', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              status: { reason: 42, state: 'archived' },
+            } as never,
+          },
+        })
+      ).toThrow('status.reason must be a non-empty string');
+
+      expect(() =>
+        trail('bad.archived-blank-reason', {
+          ...base,
+          versions: {
+            1: {
+              input: z.object({}),
+              output: z.object({ ok: z.boolean() }),
+              status: { reason: '   ', state: 'archived' },
+            },
+          },
+        })
+      ).toThrow('status.reason must be a non-empty string');
     });
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -166,6 +166,7 @@ export {
   intentValues,
   isArchivedTrailVersionEntry,
   isDeprecatedTrailVersionEntry,
+  isLiveTrailVersionEntry,
   trail,
 } from './trail.js';
 export {

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -227,6 +227,10 @@ export const isDeprecatedTrailVersionEntry = (
   entry: Pick<TrailVersionEntry, 'status'>
 ): boolean => entry.status?.state === 'deprecated';
 
+export const isLiveTrailVersionEntry = (
+  entry: Pick<TrailVersionEntry, 'status'>
+): boolean => entry.status === undefined || entry.status.state === 'deprecated';
+
 export const hasDeprecatedTrailVersionGuidance = (
   status: Pick<TrailVersionDeprecatedStatus, 'migration' | 'note' | 'successor'>
 ): boolean =>
@@ -243,7 +247,7 @@ export const deriveSupportedTrailVersions = (
 
   const supported = new Set<number>([trail.version]);
   for (const [rawVersion, entry] of Object.entries(trail.versions ?? {})) {
-    if (!isArchivedTrailVersionEntry(entry)) {
+    if (isLiveTrailVersionEntry(entry)) {
       supported.add(Number(rawVersion));
     }
   }
@@ -687,6 +691,15 @@ const normalizeVersionStatus = (
       );
     }
     return normalized;
+  }
+
+  if (
+    raw['reason'] !== undefined &&
+    (typeof raw['reason'] !== 'string' || raw['reason'].trim().length === 0)
+  ) {
+    throw new ValidationError(
+      `Trail "${trailId}" version ${version} status.reason must be a non-empty string`
+    );
   }
 
   return Object.freeze({ ...raw, state: 'archived' }) as TrailVersionStatus;


### PR DESCRIPTION
## Context

This branch completes the archive lifecycle semantics needed before version negotiation and Warden gates. Deprecated versions can remain live with guidance; archived versions should remain visible in the graph but excluded from runtime support.

Linear: TRL-731
Stack: 3/8, on top of TRL-117.

## What changed

- Added `isLiveTrailVersionEntry` and routed supported-version derivation through it.
- Kept archived historical entries visible for topo/history while excluding them from runtime-supported versions.
- Validated optional archived status reason text.
- Added archive/live helper assertions and updated targeted runtime/topo tests.
- Added a branch-local changeset for `@ontrails/core`.

## Verification

- `bun test packages/core/src/__tests__/trail.test.ts packages/core/src/__tests__/version-execution.test.ts packages/core/src/__tests__/validate-topo.test.ts packages/topographer/src/__tests__/derive.test.ts apps/trails/src/__tests__/survey.test.ts` (218 pass)
- `bun run --cwd packages/core typecheck`
- Stack-tip gates later passed: ADR check, typecheck, test, lint, ast-grep, build, format, check, publish dry-run, Warden guide checks, `git diff --check`.

## Risks / notes

The key behavior to review is the split between graph visibility and runtime support: archived entries remain inspectable but no longer negotiate as live versions.