### PR TITLE
feat(trails): record forced topo break events

### DIFF
--- a/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
+++ b/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
@@ -111,6 +111,15 @@ Append meaningful state changes, especially before handoff points.
 - Result: TRL-731 archive status lifecycle is locally implemented on top of the already-landed runtime exclusion and graph visibility substrate.
 - Next: Commit TRL-731, restack upward, then implement shared break/force substrate for TRL-732.
 - Blockers: None.
+
+2026-05-20 10:15 EDT - TRL-732 compile break gate and force events
+- Changed: Committed TRL-731 as `7c4681a48 feat(core): expose archived version lifecycle helpers`; Graphite restacked the descendant branches.
+- Changed: Implemented TRL-732 substrate on `trl-732-feattrails-add-compilevalidate-break-detection-and-force`: formalized `TopoGraphForceEntry`, added topographer force annotation helpers, threaded `force` through `trails compile`, blocked unforced breaking topo diffs against existing `topo.lock`, annotated forced breaking entries as graph-only `forces`, recomputed the forced graph hash for `trails.lock`, and improved stale validate messaging with breaking-change counts.
+- Verified: Targeted tests passed: `bun test apps/trails/src/__tests__/survey.test.ts packages/topographer/src/__tests__/diff.test.ts packages/topographer/src/__tests__/derive.test.ts` (110 pass).
+- Verified: `bun run --cwd packages/topographer typecheck`, `bun run --cwd apps/trails typecheck`, and `git diff --check` passed.
+- Result: TRL-732 local compile/force substrate is implemented. The richer user-facing `trails diff` filtering/history surface remains for TRL-730.
+- Next: Commit TRL-732, restack upward, then promote/version-aware diff work on TRL-730.
+- Blockers: None.
 ```
 
 ## Local Review Log
@@ -140,6 +149,9 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun run --cwd apps/trails typecheck` | TRL-117 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun test packages/core/src/__tests__/trail.test.ts packages/core/src/__tests__/version-execution.test.ts packages/core/src/__tests__/validate-topo.test.ts packages/topographer/src/__tests__/derive.test.ts apps/trails/src/__tests__/survey.test.ts` | TRL-731 targeted tests | Passed | 218 pass, 0 fail. |
 | `bun run --cwd packages/core typecheck` | TRL-731 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun test apps/trails/src/__tests__/survey.test.ts packages/topographer/src/__tests__/diff.test.ts packages/topographer/src/__tests__/derive.test.ts` | TRL-732 targeted tests | Passed | 110 pass, 0 fail. |
+| `bun run --cwd packages/topographer typecheck` | TRL-732 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun run --cwd apps/trails typecheck` | TRL-732 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run check` | Execution tip | Pending | Required by goal. |
 | `bun run build` | Execution tip | Pending | Required by goal. |
 | `bun run test` | Execution tip | Pending | Required by goal. |

--- a/.changeset/trl-732-force-events.md
+++ b/.changeset/trl-732-force-events.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/topographer": patch
+"@ontrails/trails": patch
+---
+
+Add graph-only force event projection for forced compile break acceptance and block unforced breaking topo changes.

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -26,6 +26,7 @@ import {
   deriveTopoGraph,
   deriveTopoGraphHash,
   deriveTopoGraphDiff,
+  stripTopoGraphForces,
   TOPO_GRAPH_SCHEMA_VERSION,
   writeTopoGraph,
 } from '@ontrails/topographer';
@@ -58,6 +59,7 @@ import {
   trailDetailOutput,
 } from '../trails/topo-output-schemas.js';
 import { compileTrail } from '../trails/compile.js';
+import { validateTrail } from '../trails/validate.js';
 import type {
   BriefReport,
   ShippedSurfaceInventoryReport,
@@ -154,7 +156,7 @@ const expectOk = <T>(result: Result<T, Error>): T => {
 
 const writeSurveyAppFixture = (
   dir: string,
-  options?: { withBye?: boolean }
+  options?: { readonly helloNameRequired?: boolean; readonly withBye?: boolean }
 ) => {
   mkdirSync(join(dir, 'src'), { recursive: true });
   const byeSource = options?.withBye
@@ -177,7 +179,7 @@ import { z } from 'zod';
 
 const hello = trail('hello', {
   blaze: async (input) => Result.ok({ message: \`Hello, \${input.name ?? 'world'}!\` }),
-  input: z.object({ name: z.string().optional() }),
+  input: z.object({ name: z.string()${options?.helloNameRequired ? '' : '.optional()'} }),
   intent: 'read',
   output: z.object({ message: z.string() }),
   resources: [
@@ -1412,6 +1414,146 @@ describe('trails compile', () => {
         version: 3,
       });
       expect(compileTrail.output.safeParse(compiled).success).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('blocks breaking topo changes unless forced and records force events', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+      expectOk(
+        await compileTrail.blaze({ module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      );
+
+      writeSurveyAppFixture(dir, { helloNameRequired: true });
+      const blocked = await compileTrail.blaze({ module: './src/app.ts' }, {
+        cwd: dir,
+      } as never);
+      expect(blocked.isErr()).toBe(true);
+      expect(blocked.error).toBeInstanceOf(ConflictError);
+      expect(blocked.error?.message).toContain('breaking change');
+
+      const forced = expectOk(
+        await compileTrail.blaze({ force: true, module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      ) as {
+        readonly hash: string;
+        readonly lockPath: string;
+        readonly topoPath: string;
+      };
+      const graph = JSON.parse(
+        readFileSync(join(dir, '.trails', 'topo.lock'), 'utf8')
+      ) as TopoGraph;
+      const hello = graph.entries.find((entry) => entry.id === 'hello');
+
+      expect(hello?.forces?.[0]).toMatchObject({
+        severity: 'breaking',
+        source: 'trails compile --force',
+      });
+      expect(
+        JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
+      ).toMatchObject({
+        artifacts: [{ path: 'topo.lock', role: 'topo', sha256: forced.hash }],
+      });
+      const validated = expectOk(
+        await validateTrail.blaze({ module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      );
+      expect(validated.stale).toBe(false);
+      expect(validated.currentHash).toBe(
+        deriveTopoGraphHash(stripTopoGraphForces(graph))
+      );
+      expect(validated.currentHash).not.toBe(validated.committedHash);
+      const recompiled = expectOk(
+        await compileTrail.blaze({ module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      ) as {
+        readonly hash: string;
+      };
+      const recompiledGraph = JSON.parse(
+        readFileSync(join(dir, '.trails', 'topo.lock'), 'utf8')
+      ) as TopoGraph;
+      const recompiledHello = recompiledGraph.entries.find(
+        (entry) => entry.id === 'hello'
+      );
+
+      expect(recompiledHello?.forces?.[0]).toMatchObject({
+        severity: 'breaking',
+        source: 'trails compile --force',
+      });
+      expect(recompiled.hash).toBe(forced.hash);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('forced removed trails are recorded as graph force events', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir, { withBye: true });
+      expectOk(
+        await compileTrail.blaze({ module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      );
+
+      writeSurveyAppFixture(dir);
+      const forced = expectOk(
+        await compileTrail.blaze({ force: true, module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      ) as {
+        readonly hash: string;
+      };
+      const graph = JSON.parse(
+        readFileSync(join(dir, '.trails', 'topo.lock'), 'utf8')
+      ) as TopoGraph;
+
+      expect(graph.entries.some((entry) => entry.id === 'bye')).toBe(false);
+      expect(graph.forces?.[0]).toMatchObject({
+        change: 'removed',
+        id: 'bye',
+        kind: 'trail',
+        source: 'trails compile --force',
+      });
+      expect(
+        JSON.parse(readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8'))
+      ).toMatchObject({
+        artifacts: [{ path: 'topo.lock', role: 'topo', sha256: forced.hash }],
+      });
+      const validated = expectOk(
+        await validateTrail.blaze({ module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      );
+      expect(validated.stale).toBe(false);
+      const recompiled = expectOk(
+        await compileTrail.blaze({ module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      ) as {
+        readonly hash: string;
+      };
+      const recompiledGraph = JSON.parse(
+        readFileSync(join(dir, '.trails', 'topo.lock'), 'utf8')
+      ) as TopoGraph;
+
+      expect(recompiledGraph.forces?.[0]).toMatchObject({
+        change: 'removed',
+        id: 'bye',
+        kind: 'trail',
+        source: 'trails compile --force',
+      });
+      expect(recompiled.hash).toBe(forced.hash);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/apps/trails/src/trails/compile.ts
+++ b/apps/trails/src/trails/compile.ts
@@ -13,7 +13,7 @@ import {
 
 export const compileCurrentTopo = async (
   app: Topo,
-  options?: { readonly rootDir?: string }
+  options?: { readonly force?: boolean | undefined; readonly rootDir?: string }
 ): Promise<Result<TopoExportReport, Error>> => exportCurrentTopo(app, options);
 
 export const compileTrail = trail('compile', {
@@ -29,7 +29,10 @@ export const compileTrail = trail('compile', {
     }
     const lease = leaseResult.value;
     try {
-      return await compileCurrentTopo(lease.app, { rootDir });
+      return await compileCurrentTopo(lease.app, {
+        force: input.force,
+        rootDir,
+      });
     } finally {
       lease.release();
     }
@@ -42,6 +45,10 @@ export const compileTrail = trail('compile', {
     },
   ],
   input: z.object({
+    force: z
+      .boolean()
+      .optional()
+      .describe('Record graph-only force events for breaking changes'),
     module: z.string().optional().describe('Path to the app module'),
     rootDir: z.string().optional().describe('Workspace root directory'),
   }),

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -18,7 +18,15 @@ import {
   SURFACE_LAYER_NAMES_KEY,
   ValidationError,
 } from '@ontrails/core';
-import { deriveTopoGraph, readLockManifest } from '@ontrails/topographer';
+import {
+  deriveTopoGraph,
+  deriveTopoGraphDiff,
+  deriveTopoGraphHash,
+  readLockManifest,
+  readTopoGraph,
+  stripTopoGraphForces,
+} from '@ontrails/topographer';
+import type { TopoGraph } from '@ontrails/topographer';
 
 import type {
   BriefReport,
@@ -244,6 +252,9 @@ export const validateCurrentTopo = async (
   if (currentExport.isErr()) {
     return currentExport;
   }
+  const currentTopo = JSON.parse(
+    currentExport.value.topoGraphJson
+  ) as TopoGraph;
   const currentHash = currentExport.value.topoGraphHash;
   const topoArtifact = lockManifest.artifacts.find(
     (artifact) => artifact.role === 'topo' && artifact.path === 'topo.lock'
@@ -257,9 +268,38 @@ export const validateCurrentTopo = async (
   }
 
   if (topoArtifact.sha256 !== currentHash) {
+    const committedTopo = await readTopoGraph({
+      dir: deriveTrailsDir({ rootDir }),
+    });
+    if (committedTopo !== null) {
+      const committedHash = deriveTopoGraphHash(committedTopo);
+      const forceStrippedHash = deriveTopoGraphHash(
+        stripTopoGraphForces(committedTopo)
+      );
+      if (
+        committedHash === topoArtifact.sha256 &&
+        forceStrippedHash === currentHash
+      ) {
+        return Result.ok({
+          committedHash: topoArtifact.sha256,
+          currentHash,
+          lockPath: LOCK_PATH,
+          stale: false,
+        });
+      }
+    }
+    const breakingSummary =
+      committedTopo === null
+        ? ''
+        : (() => {
+            const diff = deriveTopoGraphDiff(committedTopo, currentTopo);
+            return diff.breaking.length > 0
+              ? ` Breaking changes detected: ${diff.breaking.length}.`
+              : '';
+          })();
     return Result.err(
       new ConflictError(
-        'trails.lock is stale. Run `trails compile` to refresh it.'
+        `trails.lock is stale. Run \`trails compile\` to refresh it.${breakingSummary}`
       )
     );
   }

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -9,6 +9,7 @@ import { Database } from 'bun:sqlite';
 
 import type { Topo } from '@ontrails/core';
 import {
+  ConflictError,
   deriveTrailsDir,
   InternalError,
   openWriteTrailsDb,
@@ -20,7 +21,15 @@ import type {
   TopoSnapshot,
 } from '@ontrails/topographer';
 import type { StoredTopoExport } from '@ontrails/topographer/backend-support';
-import { writeLockManifest, writeTopoGraph } from '@ontrails/topographer';
+import {
+  annotateTopoGraphForces,
+  carryForwardTopoGraphForces,
+  deriveTopoGraphDiff,
+  deriveTopoGraphHash,
+  readTopoGraph,
+  writeLockManifest,
+  writeTopoGraph,
+} from '@ontrails/topographer';
 import {
   createStoredTopoSnapshot,
   getStoredTopoExport,
@@ -85,19 +94,46 @@ export const deriveCurrentTopoExport = (
 
 const writeStoredExportArtifacts = async (
   storedExport: StoredTopoExport,
-  trailsDir: string
+  trailsDir: string,
+  options?: { readonly force?: boolean | undefined }
 ): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'topoPath'>> => {
-  const topoPath = await writeTopoGraph(
-    JSON.parse(storedExport.topoGraphJson) as TopoGraph,
-    { dir: trailsDir }
-  );
-  const lockPath = await writeLockManifest(
-    JSON.parse(storedExport.lockManifestJson) as LockManifest,
-    { dir: trailsDir }
-  );
+  const previousTopo = await readTopoGraph({ dir: trailsDir });
+  const nextTopo = JSON.parse(storedExport.topoGraphJson) as TopoGraph;
+  const diff =
+    previousTopo === null
+      ? undefined
+      : deriveTopoGraphDiff(previousTopo, nextTopo);
+  if (diff !== undefined && diff.breaking.length > 0 && !options?.force) {
+    throw new ConflictError(
+      `Topo contains ${diff.breaking.length} breaking change(s). Add a version entry, revert the change, or rerun with --force.`
+    );
+  }
+
+  const topoGraphBase =
+    previousTopo === null
+      ? nextTopo
+      : carryForwardTopoGraphForces(previousTopo, nextTopo);
+  const topoGraph =
+    diff === undefined || diff.breaking.length === 0
+      ? topoGraphBase
+      : annotateTopoGraphForces(topoGraphBase, diff.breaking);
+  const hash = deriveTopoGraphHash(topoGraph);
+  const lockManifest = {
+    ...(JSON.parse(storedExport.lockManifestJson) as LockManifest),
+    artifacts: [
+      {
+        path: 'topo.lock',
+        role: 'topo',
+        sha256: hash,
+      },
+    ],
+  } satisfies LockManifest;
+
+  const topoPath = await writeTopoGraph(topoGraph, { dir: trailsDir });
+  const lockPath = await writeLockManifest(lockManifest, { dir: trailsDir });
 
   return {
-    hash: storedExport.topoGraphHash,
+    hash,
     lockPath,
     topoPath,
   };
@@ -105,7 +141,7 @@ const writeStoredExportArtifacts = async (
 
 export const exportCurrentTopo = async (
   app: Topo,
-  options?: { readonly rootDir?: string }
+  options?: { readonly force?: boolean | undefined; readonly rootDir?: string }
 ): Promise<Result<TopoExportReport, Error>> => {
   const rootDir = deriveRootDir(options?.rootDir);
   const db = openWriteTrailsDb({ rootDir });
@@ -117,10 +153,20 @@ export const exportCurrentTopo = async (
     }
 
     const { snapshot, storedExport } = persisted.value;
-    const artifacts = await writeStoredExportArtifacts(
-      storedExport,
-      deriveTrailsDir({ rootDir })
-    );
+    let artifacts: Pick<TopoExportReport, 'hash' | 'lockPath' | 'topoPath'>;
+    try {
+      artifacts = await writeStoredExportArtifacts(
+        storedExport,
+        deriveTrailsDir({ rootDir }),
+        { force: options?.force }
+      );
+    } catch (error: unknown) {
+      return Result.err(
+        error instanceof Error
+          ? error
+          : new InternalError('Unable to write topo artifacts')
+      );
+    }
     return Result.ok({ ...artifacts, snapshot });
   } finally {
     db.close();

--- a/packages/topographer/src/__tests__/forces.test.ts
+++ b/packages/topographer/src/__tests__/forces.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test';
+
+import { annotateTopoGraphForces, stripTopoGraphForces } from '../forces.js';
+import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
+import type { DiffEntry, TopoGraph, TopoGraphEntry } from '../types.js';
+
+const entry = (
+  overrides: Partial<TopoGraphEntry> & { id: string }
+): TopoGraphEntry => ({
+  exampleCount: 0,
+  kind: 'trail',
+  surfaces: [],
+  ...overrides,
+});
+
+const topoGraph = (entries: TopoGraphEntry[]): TopoGraph => ({
+  activationGraph: {
+    edgeCount: 0,
+    edges: [],
+    sourceCount: 0,
+    sourceKeys: [],
+    trailIds: [],
+  },
+  activationSources: {},
+  entries,
+  generatedAt: '2026-05-20T00:00:00.000Z',
+  topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
+});
+
+describe('annotateTopoGraphForces', () => {
+  test('records modified force events on the affected entry', () => {
+    const graph = topoGraph([entry({ id: 'hello' })]);
+    const diff: DiffEntry = {
+      change: 'modified',
+      details: ['Required input field "name" added'],
+      id: 'hello',
+      kind: 'trail',
+      severity: 'breaking',
+    };
+
+    const annotated = annotateTopoGraphForces(graph, [diff], {
+      acceptedAt: '2026-05-20T00:00:00.000Z',
+    });
+
+    expect(annotated.entries[0]?.forces?.[0]).toMatchObject({
+      change: 'modified',
+      detail: 'Required input field "name" added',
+      id: 'hello',
+      kind: 'trail',
+    });
+    expect(annotated.forces).toBeUndefined();
+  });
+
+  test('records removed force events on the graph without tombstone entries', () => {
+    const graph = topoGraph([]);
+    const diff: DiffEntry = {
+      change: 'removed',
+      details: ['Trail "bye" removed'],
+      id: 'bye',
+      kind: 'trail',
+      severity: 'breaking',
+    };
+
+    const annotated = annotateTopoGraphForces(graph, [diff], {
+      acceptedAt: '2026-05-20T00:00:00.000Z',
+    });
+
+    expect(annotated.entries).toEqual([]);
+    expect(annotated.forces?.[0]).toMatchObject({
+      change: 'removed',
+      detail: 'Trail "bye" removed',
+      id: 'bye',
+      kind: 'trail',
+    });
+  });
+});
+
+describe('stripTopoGraphForces', () => {
+  test('removes entry and graph force metadata for live graph comparison', () => {
+    const graph = annotateTopoGraphForces(
+      topoGraph([entry({ id: 'hello' })]),
+      [
+        {
+          change: 'modified',
+          details: ['Required input field "name" added'],
+          id: 'hello',
+          kind: 'trail',
+          severity: 'breaking',
+        },
+      ],
+      { acceptedAt: '2026-05-20T00:00:00.000Z' }
+    );
+
+    const stripped = stripTopoGraphForces({
+      ...graph,
+      forces: [
+        {
+          acceptedAt: '2026-05-20T00:00:00.000Z',
+          change: 'removed',
+          detail: 'Trail "bye" removed',
+          id: 'bye',
+          kind: 'trail',
+          severity: 'breaking',
+          source: 'trails compile --force',
+        },
+      ],
+    });
+
+    expect(stripped.forces).toBeUndefined();
+    expect(stripped.entries[0]?.forces).toBeUndefined();
+  });
+});

--- a/packages/topographer/src/forces.ts
+++ b/packages/topographer/src/forces.ts
@@ -1,0 +1,118 @@
+import type {
+  DiffEntry,
+  TopoGraph,
+  TopoGraphEntry,
+  TopoGraphForceEntry,
+} from './types.js';
+
+export interface TopoGraphForceOptions {
+  readonly acceptedAt?: string | undefined;
+  readonly reason?: string | undefined;
+}
+
+const toForceEntry = (
+  diff: DiffEntry,
+  detail: string,
+  acceptedAt: string,
+  reason?: string | undefined
+): TopoGraphForceEntry => ({
+  acceptedAt,
+  change: diff.change === 'removed' ? 'removed' : 'modified',
+  detail,
+  id: diff.id,
+  kind: diff.kind,
+  ...(reason === undefined ? {} : { reason }),
+  severity: 'breaking',
+  source: 'trails compile --force',
+});
+
+export const deriveTopoGraphForceEntries = (
+  diff: DiffEntry,
+  options?: TopoGraphForceOptions
+): readonly TopoGraphForceEntry[] => {
+  if (diff.severity !== 'breaking') {
+    return [];
+  }
+
+  const acceptedAt = options?.acceptedAt ?? new Date().toISOString();
+  return diff.details.map((detail) =>
+    toForceEntry(diff, detail, acceptedAt, options?.reason)
+  );
+};
+
+export const annotateTopoGraphForces = (
+  graph: TopoGraph,
+  breaking: readonly DiffEntry[],
+  options?: TopoGraphForceOptions
+): TopoGraph => {
+  if (breaking.length === 0) {
+    return graph;
+  }
+
+  const removedForces = breaking
+    .filter((entry) => entry.change === 'removed')
+    .flatMap((entry) => deriveTopoGraphForceEntries(entry, options));
+  const byId = new Map(
+    breaking
+      .filter((entry) => entry.change !== 'removed')
+      .map((entry) => [entry.id, entry])
+  );
+  const entries: TopoGraphEntry[] = graph.entries.map((entry) => {
+    const diff = byId.get(entry.id);
+    if (diff === undefined) {
+      return entry;
+    }
+
+    const forces = deriveTopoGraphForceEntries(diff, options);
+    return forces.length === 0
+      ? entry
+      : { ...entry, forces: [...(entry.forces ?? []), ...forces] };
+  });
+
+  return {
+    ...graph,
+    entries,
+    ...(removedForces.length === 0
+      ? {}
+      : { forces: [...(graph.forces ?? []), ...removedForces] }),
+  };
+};
+
+export const carryForwardTopoGraphForces = (
+  previous: TopoGraph,
+  next: TopoGraph
+): TopoGraph => {
+  const previousEntryForces = new Map(
+    previous.entries
+      .filter((entry) => entry.forces !== undefined && entry.forces.length > 0)
+      .map((entry) => [entry.id, entry.forces ?? []])
+  );
+  const entries = next.entries.map((entry) => {
+    const carriedForces = previousEntryForces.get(entry.id);
+    if (carriedForces === undefined || carriedForces.length === 0) {
+      return entry;
+    }
+    return {
+      ...entry,
+      forces: [...carriedForces, ...(entry.forces ?? [])],
+    };
+  });
+  return {
+    ...next,
+    entries,
+    ...(previous.forces === undefined || previous.forces.length === 0
+      ? {}
+      : { forces: [...previous.forces, ...(next.forces ?? [])] }),
+  };
+};
+
+export const stripTopoGraphForces = (graph: TopoGraph): TopoGraph => {
+  const { forces: _graphForces, ...rest } = graph;
+  return {
+    ...rest,
+    entries: graph.entries.map((entry) => {
+      const { forces: _entryForces, ...entryRest } = entry;
+      return entryRest;
+    }),
+  };
+};

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -8,6 +8,13 @@ export { deriveTopoGraph } from './derive.js';
 export { deriveTopoGraphHash } from './hash.js';
 export { deriveTopoGraphDiff } from './diff.js';
 export {
+  annotateTopoGraphForces,
+  carryForwardTopoGraphForces,
+  deriveTopoGraphForceEntries,
+  stripTopoGraphForces,
+} from './forces.js';
+export type { TopoGraphForceOptions } from './forces.js';
+export {
   collectTopoGraphVersionMarkers,
   deriveTopoGraphVersionMarkerRecords,
   resolveTopoGraphVersionReference,

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -113,7 +113,16 @@ export interface TopoGraphVersionEntry {
   readonly resources?: readonly string[] | undefined;
 }
 
-export type TopoGraphForceEntry = Readonly<Record<string, unknown>>;
+export interface TopoGraphForceEntry {
+  readonly acceptedAt: string;
+  readonly change: 'modified' | 'removed';
+  readonly detail: string;
+  readonly id: string;
+  readonly kind: 'contour' | 'trail' | 'signal' | 'resource';
+  readonly reason?: string | undefined;
+  readonly severity: 'breaking';
+  readonly source: 'trails compile --force';
+}
 
 // ---------------------------------------------------------------------------
 // TopoGraph
@@ -179,6 +188,7 @@ export interface TopoGraph {
   >;
   readonly generatedAt: string;
   readonly entries: readonly TopoGraphEntry[];
+  readonly forces?: readonly TopoGraphForceEntry[] | undefined;
   readonly workspace?: WorkspaceTopoMetadata | undefined;
 }
 
@@ -236,6 +246,19 @@ export const workspaceTopoMetadataSchema = z
 
 export type WorkspaceTopoMetadata = z.infer<typeof workspaceTopoMetadataSchema>;
 
+const topoGraphForceEntrySchema = z
+  .object({
+    acceptedAt: z.string(),
+    change: z.enum(['modified', 'removed']),
+    detail: z.string(),
+    id: z.string(),
+    kind: z.enum(['contour', 'trail', 'signal', 'resource']),
+    reason: z.string().optional(),
+    severity: z.literal('breaking'),
+    source: z.literal('trails compile --force'),
+  })
+  .strict();
+
 export const topoGraphSchema = z
   .object({
     activationGraph: z
@@ -258,6 +281,7 @@ export const topoGraphSchema = z
         })
         .passthrough()
     ),
+    forces: z.array(topoGraphForceEntrySchema).optional(),
     generatedAt: z.string(),
     topoGraphSchemaVersion: z.literal(TOPO_GRAPH_SCHEMA_VERSION),
     workspace: workspaceTopoMetadataSchema.optional(),


### PR DESCRIPTION
## Context

This branch adds the compile/validate gate for breaking topo changes and the audit substrate that later `trails diff` and Warden rules can consume. It is deliberately graph-only: force events are persisted in the derived TopoGraph, not hand-written into source contracts.

Linear: TRL-732
Stack: 4/8, on top of TRL-731.

## What changed

- Added formal `TopoGraphForceEntry` typing and topographer helpers for force annotations.
- Threaded `force` through `trails compile`.
- Blocked unforced breaking topo diffs against an existing `topo.lock`.
- Recorded forced breaking entries as graph-only `forces` and recomputed lock hashes against the forced graph.
- Improved stale validation messaging with breaking-change counts.
- Added branch-local changesets for topographer/trails changes.

## Verification

- `bun test apps/trails/src/__tests__/survey.test.ts packages/topographer/src/__tests__/diff.test.ts packages/topographer/src/__tests__/derive.test.ts` (110 pass)
- `bun run --cwd packages/topographer typecheck`
- `bun run --cwd apps/trails typecheck`
- Stack-tip gates later passed: ADR check, typecheck, test, lint, ast-grep, build, format, check, publish dry-run, Warden guide checks, `git diff --check`.

## Risks / notes

Review the forced graph hashing path closely: the intent is for the lockfile to reflect the graph that includes explicit force audit events.