### PR TITLE
feat(trails): add version-aware topo diff

### DIFF
--- a/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
+++ b/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
@@ -120,6 +120,15 @@ Append meaningful state changes, especially before handoff points.
 - Result: TRL-732 local compile/force substrate is implemented. The richer user-facing `trails diff` filtering/history surface remains for TRL-730.
 - Next: Commit TRL-732, restack upward, then promote/version-aware diff work on TRL-730.
 - Blockers: None.
+
+2026-05-20 10:26 EDT - TRL-730 version-aware diff
+- Changed: Committed TRL-732 as `ce49e0b4d feat(trails): record forced topo break events`; Graphite restacked the descendant branches.
+- Changed: Implemented TRL-730 on `trl-730-feattrails-add-version-and-marker-aware-trails-diff`: extended the shared TopoGraph diff classifier to report current version, supported version set, projected marker, per-version lifecycle status, per-version marker, and graph-only force-event changes; added a top-level `diff` trail that shares the existing `survey.diff` reader, supports target filtering (`trail.id`, `trail.id@N`, `trail.id@N..M`, marker prefixes), `--breaks`, and `--forces`; documented the command grammar; and added a branch-local changeset.
+- Verified: Focused diff/survey tests passed: `bun test packages/topographer/src/__tests__/diff.test.ts apps/trails/src/__tests__/survey.test.ts` (79 pass).
+- Verified: `bun run --cwd packages/topographer typecheck` and `bun run --cwd apps/trails typecheck` passed.
+- Result: TRL-730 local version-aware diff surface is implemented. Remaining branch-local checks still need formatting, `git diff --check`, and commit-hook validation before committing.
+- Next: Run branch formatting/whitespace checks, commit TRL-730, restack upward, then implement TRL-118 surface negotiation.
+- Blockers: None.
 ```
 
 ## Local Review Log
@@ -152,6 +161,9 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun test apps/trails/src/__tests__/survey.test.ts packages/topographer/src/__tests__/diff.test.ts packages/topographer/src/__tests__/derive.test.ts` | TRL-732 targeted tests | Passed | 110 pass, 0 fail. |
 | `bun run --cwd packages/topographer typecheck` | TRL-732 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run --cwd apps/trails typecheck` | TRL-732 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun test packages/topographer/src/__tests__/diff.test.ts apps/trails/src/__tests__/survey.test.ts` | TRL-730 targeted tests | Passed | 79 pass, 0 fail. |
+| `bun run --cwd packages/topographer typecheck` | TRL-730 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun run --cwd apps/trails typecheck` | TRL-730 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run check` | Execution tip | Pending | Required by goal. |
 | `bun run build` | Execution tip | Pending | Required by goal. |
 | `bun run test` | Execution tip | Pending | Required by goal. |

--- a/.changeset/trl-730-version-aware-diff.md
+++ b/.changeset/trl-730-version-aware-diff.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/topographer": patch
+"@ontrails/trails": patch
+---
+
+Add a top-level `trails diff` command and extend TopoGraph diffs with version, marker, lifecycle status, support set, and force-event audit details.

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -22,6 +22,7 @@ import {
   webhook,
 } from '@ontrails/core';
 import type { TrailSpec } from '@ontrails/core';
+import { deriveCliCommands } from '@ontrails/cli';
 import {
   deriveTopoGraph,
   deriveTopoGraphHash,
@@ -39,6 +40,7 @@ import {
   deriveSignalDetail,
   deriveSurveyList,
   deriveTrailDetail,
+  diffTrail,
   surveyBriefTrail,
   surveyDiffTrail,
   surveyResourceTrail,
@@ -197,6 +199,54 @@ if (!dbMain) {
 ${byeSource}
 
 export const app = topo('survey-fixture', ${topoMembers});
+`
+  );
+};
+
+const writeVersionedDiffAppFixture = (
+  dir: string,
+  options?: {
+    readonly archiveV1?: boolean;
+    readonly deprecateV1?: boolean;
+    readonly deprecateV2?: boolean;
+    readonly omitV1?: boolean;
+  }
+) => {
+  const versionOneSource = options?.omitV1
+    ? ''
+    : `    1: {
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      ${options?.archiveV1 ? "status: { reason: 'No callers remain.', state: 'archived' }," : ''}
+      ${options?.deprecateV1 ? "status: { migration: ['Use v3.'], state: 'deprecated' }," : ''}
+    },
+`;
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    `import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const versioned = trail('versioned', {
+  blaze: async () => Result.ok({ ok: true }),
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  version: 3,
+  versions: {
+${versionOneSource}\
+    2: {
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      ${options?.deprecateV2 ? "status: { migration: ['Use v3.'], state: 'deprecated' }," : ''}
+      transpose: {
+        input: ({ input }) => input,
+        output: ({ output }) => output,
+      },
+    },
+  },
+});
+
+export const app = topo('versioned-diff-fixture', { versioned });
 `
   );
 };
@@ -1561,6 +1611,18 @@ describe('trails compile', () => {
 });
 
 describe('trails survey diff', () => {
+  test('top-level diff projects as a root CLI command with target arg', () => {
+    const commands = expectOk(
+      deriveCliCommands(topo('diff-cli', { diffTrail, surveyDiffTrail }))
+    );
+    const command = commands.find((candidate) => candidate.trail.id === 'diff');
+
+    expect(command?.path).toEqual(['diff']);
+    expect(command?.args.map((arg) => arg.name)).toContain('target');
+    expect(command?.flags.map((flag) => flag.name)).toContain('breaks');
+    expect(command?.flags.map((flag) => flag.name)).toContain('forces');
+  });
+
   test('input validation preserves an isolated example rootDir', () => {
     const parsed = surveyDiffTrail.input.safeParse({
       against: 'saved',
@@ -1624,6 +1686,116 @@ describe('trails survey diff', () => {
     }
   });
 
+  test('top-level diff filters by trail target', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+      const baselineApp = await loadApp('./src/app.ts', dir);
+      await writeTopoGraph(deriveTopoGraph(baselineApp), {
+        dir: join(dir, '.trails'),
+      });
+
+      writeSurveyAppFixture(dir, { withBye: true });
+
+      const byeDiff = await diffTrail.blaze(
+        { module: './src/app.ts', target: 'bye' },
+        { cwd: dir } as never
+      );
+      const helloDiff = await diffTrail.blaze(
+        { module: './src/app.ts', target: 'hello' },
+        { cwd: dir } as never
+      );
+
+      expect(byeDiff.isOk()).toBe(true);
+      expect(byeDiff.value.info).toEqual([
+        expect.objectContaining({ id: 'bye' }),
+      ]);
+      expect(helloDiff.isOk()).toBe(true);
+      expect(helloDiff.value.info).toEqual([]);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('top-level diff rejects unknown plain trail targets', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+      const baselineApp = await loadApp('./src/app.ts', dir);
+      await writeTopoGraph(deriveTopoGraph(baselineApp), {
+        dir: join(dir, '.trails'),
+      });
+
+      const result = await diffTrail.blaze(
+        { module: './src/app.ts', target: 'missing.plain' },
+        { cwd: dir } as never
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error.message).toContain(
+        'Trail not found for diff: missing.plain'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('top-level diff filters graph-only force audit events', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+      const baselineApp = await loadApp('./src/app.ts', dir);
+      const baseline = deriveTopoGraph(baselineApp);
+      const hello = baseline.entries.find((entry) => entry.id === 'hello');
+      if (hello === undefined) {
+        throw new Error('expected fixture topo entry');
+      }
+      writeFileSync(
+        join(dir, 'baseline.json'),
+        JSON.stringify({
+          ...baseline,
+          entries: [
+            {
+              ...hello,
+              forces: [
+                {
+                  acceptedAt: '2026-05-20T00:00:00.000Z',
+                  change: 'modified',
+                  detail: 'Required input field "name" added',
+                  id: 'hello',
+                  kind: 'trail',
+                  severity: 'breaking',
+                  source: 'trails compile --force',
+                },
+              ],
+            },
+          ],
+        } satisfies TopoGraph)
+      );
+
+      const result = await diffTrail.blaze(
+        {
+          against: 'baseline.json',
+          forces: true,
+          module: './src/app.ts',
+          target: 'hello@1..2',
+        },
+        { cwd: dir } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.value.warnings[0]?.details).toEqual([
+        'Force event removed: modified Required input field "name" added',
+      ]);
+      expect(result.value.info).toEqual([]);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('can diff against a workspace-relative TopoGraph directory', async () => {
     const dir = repoTempDir();
 
@@ -1649,6 +1821,154 @@ describe('trails survey diff', () => {
         mode: 'diff',
         warnings: [],
       });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('version-range diff keeps supported-version details in range', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeVersionedDiffAppFixture(dir);
+      const baselineApp = await loadApp('./src/app.ts', dir);
+      await writeTopoGraph(deriveTopoGraph(baselineApp), {
+        dir: join(dir, 'baselines'),
+      });
+
+      writeVersionedDiffAppFixture(dir, { archiveV1: true });
+
+      const result = await diffTrail.blaze(
+        {
+          against: 'baselines',
+          module: './src/app.ts',
+          target: 'versioned@1..1',
+        },
+        { cwd: dir } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.value.breaking[0]?.details).toContain(
+        'Supported versions removed: 1'
+      );
+      expect(result.value.breaking[0]?.details).toContain(
+        'Version 1 status changed: live -> archived'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('version-range diff recomputes severity after filtering details', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeVersionedDiffAppFixture(dir);
+      const baselineApp = await loadApp('./src/app.ts', dir);
+      await writeTopoGraph(deriveTopoGraph(baselineApp), {
+        dir: join(dir, 'baselines'),
+      });
+
+      writeVersionedDiffAppFixture(dir, {
+        archiveV1: true,
+        deprecateV2: true,
+      });
+
+      const result = await diffTrail.blaze(
+        {
+          against: 'baselines',
+          module: './src/app.ts',
+          target: 'versioned@2..2',
+        },
+        { cwd: dir } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.value).toMatchObject({
+        breaking: [],
+        hasBreaking: false,
+        warnings: [],
+      });
+      expect(result.value.info[0]).toMatchObject({
+        details: ['Version 2 status changed: live -> deprecated'],
+        severity: 'info',
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('version-range diff keeps removed deprecated versions breaking', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeVersionedDiffAppFixture(dir, { deprecateV1: true });
+      const baselineApp = await loadApp('./src/app.ts', dir);
+      const baselineGraph = deriveTopoGraph(baselineApp);
+      await writeTopoGraph(
+        {
+          ...baselineGraph,
+          entries: baselineGraph.entries.map((entry) =>
+            entry.id === 'versioned'
+              ? {
+                  ...entry,
+                  supports: entry.supports?.filter((version) => version !== 1),
+                }
+              : entry
+          ),
+        },
+        { dir: join(dir, 'baselines') }
+      );
+
+      writeVersionedDiffAppFixture(dir, { omitV1: true });
+
+      const result = await diffTrail.blaze(
+        {
+          against: 'baselines',
+          module: './src/app.ts',
+          target: 'versioned@1..1',
+        },
+        { cwd: dir } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(result.value).toMatchObject({
+        hasBreaking: true,
+        info: [],
+        warnings: [],
+      });
+      expect(result.value.breaking[0]).toMatchObject({
+        details: ['Version 1 removed (deprecated)'],
+        severity: 'breaking',
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('version-range diff rejects unknown trail ids', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeVersionedDiffAppFixture(dir);
+      const baselineApp = await loadApp('./src/app.ts', dir);
+      await writeTopoGraph(deriveTopoGraph(baselineApp), {
+        dir: join(dir, 'baselines'),
+      });
+
+      const result = await diffTrail.blaze(
+        {
+          against: 'baselines',
+          module: './src/app.ts',
+          target: 'missing.versioned@1..2',
+        },
+        { cwd: dir } as never
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error.message).toContain(
+        'Trail not found for diff: missing.versioned'
+      );
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
@@ -1827,6 +2147,16 @@ describe('trails survey output schema', () => {
     ).toBe(true);
     expect(
       surveyDiffTrail.output.safeParse({
+        against: 'saved',
+        breaking: [],
+        hasBreaking: false,
+        info: [],
+        mode: 'diff',
+        warnings: [],
+      }).success
+    ).toBe(true);
+    expect(
+      diffTrail.output.safeParse({
         against: 'saved',
         breaking: [],
         hasBreaking: false,

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -20,6 +20,7 @@ import {
   createTopoStore,
   deriveTopoGraphDiff,
   deriveTopoGraph,
+  resolveTopoGraphVersionReference,
   TOPO_GRAPH_SCHEMA_VERSION,
   readTopoGraph,
 } from '@ontrails/topographer';
@@ -84,6 +85,21 @@ interface SurveyDiffReport {
   readonly warnings: readonly DiffEntry[];
 }
 
+interface DiffInput {
+  readonly against?: string | undefined;
+  readonly breakingOnly?: boolean | undefined;
+  readonly breaks?: boolean | undefined;
+  readonly forces?: boolean | undefined;
+  readonly module?: string | undefined;
+  readonly rootDir?: string | undefined;
+  readonly target?: string | undefined;
+}
+
+interface ParsedDiffTarget {
+  readonly id: string;
+  readonly versions?: ReadonlySet<number> | undefined;
+}
+
 const formatDiff = (diff: DiffResult, against: string): SurveyDiffReport => ({
   against,
   breaking: diff.breaking,
@@ -92,6 +108,252 @@ const formatDiff = (diff: DiffResult, against: string): SurveyDiffReport => ({
   mode: 'diff',
   warnings: diff.warnings,
 });
+
+const partitionDiffEntries = (entries: readonly DiffEntry[]): DiffResult => {
+  const sorted = [...entries].toSorted((left, right) =>
+    left.id.localeCompare(right.id)
+  );
+  const breaking = sorted.filter((entry) => entry.severity === 'breaking');
+  const warnings = sorted.filter((entry) => entry.severity === 'warning');
+  const info = sorted.filter((entry) => entry.severity === 'info');
+
+  return {
+    breaking,
+    entries: sorted,
+    hasBreaking: breaking.length > 0,
+    info,
+    warnings,
+  };
+};
+
+const parseVersionRange = (
+  reference: string
+): ReadonlySet<number> | undefined => {
+  const match = /^(\d+)\.\.(\d+)$/.exec(reference);
+  if (match === null) {
+    return undefined;
+  }
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  if (start < 1 || end < start) {
+    throw new ValidationError(
+      `Diff version range must use ascending positive versions: ${reference}`
+    );
+  }
+
+  return new Set(
+    Array.from({ length: end - start + 1 }, (_value, index) => start + index)
+  );
+};
+
+const findDiffTargetEntry = (
+  previous: TopoGraph,
+  current: TopoGraph,
+  id: string
+) =>
+  current.entries.find((entry) => entry.id === id) ??
+  previous.entries.find((entry) => entry.id === id);
+
+const parseDiffTarget = (
+  previous: TopoGraph,
+  current: TopoGraph,
+  target: string | undefined
+): Result<ParsedDiffTarget | undefined, Error> => {
+  if (target === undefined || target.length === 0) {
+    return Result.ok();
+  }
+
+  const separator = target.lastIndexOf('@');
+  const id = separator === -1 ? target : target.slice(0, separator);
+  const reference =
+    separator === -1 ? undefined : target.slice(separator + 1).trim();
+  if (id.length === 0 || reference === '') {
+    return Result.err(
+      new ValidationError('Diff target must use trail.id or trail.id@version')
+    );
+  }
+
+  const entry = findDiffTargetEntry(previous, current, id);
+  if (entry === undefined) {
+    return Result.err(new NotFoundError(`Trail not found for diff: ${id}`));
+  }
+
+  if (reference === undefined) {
+    return Result.ok({ id });
+  }
+
+  try {
+    const range = parseVersionRange(reference);
+    if (range !== undefined) {
+      return Result.ok({ id, versions: range });
+    }
+
+    return Result.ok({
+      id,
+      versions: new Set([
+        resolveTopoGraphVersionReference(entry, reference).version,
+      ]),
+    });
+  } catch (error: unknown) {
+    return Result.err(
+      error instanceof Error ? error : new Error(String(error))
+    );
+  }
+};
+
+const detailVersions = (detail: string): readonly number[] => {
+  const match = /^(?:Live version|Version) (\d+)\b/.exec(detail);
+  if (match !== null) {
+    return [Number(match[1])];
+  }
+
+  const supportMatch = /^Supported versions (?:added|removed): (.+)$/.exec(
+    detail
+  );
+  if (supportMatch === null) {
+    return [];
+  }
+
+  return (supportMatch[1] ?? '')
+    .split(',')
+    .map((part) => Number(part.trim()))
+    .filter((version) => Number.isInteger(version) && version > 0);
+};
+
+type DiffSeverity = DiffEntry['severity'];
+
+const severityRank: Record<DiffSeverity, number> = {
+  breaking: 2,
+  info: 0,
+  warning: 1,
+};
+
+const higherSeverity = (
+  left: DiffSeverity,
+  right: DiffSeverity
+): DiffSeverity => (severityRank[right] > severityRank[left] ? right : left);
+
+const versionStatus = (detail: string): string | undefined =>
+  /^Version \d+ (?:added|removed) \(([^)]+)\)$/.exec(detail)?.[1];
+
+const visibleDetailSeverity = (detail: string): DiffSeverity => {
+  if (detail.startsWith('Force event ')) {
+    return 'warning';
+  }
+  if (detail.startsWith('Supported versions removed: ')) {
+    return 'breaking';
+  }
+  if (detail.startsWith('Supported versions added: ')) {
+    return 'info';
+  }
+  if (
+    /^Live version \d+ (?:added without examples|example coverage removed)$/.test(
+      detail
+    )
+  ) {
+    return 'warning';
+  }
+  if (detail.startsWith('Live version ') && detail.includes(' examples: ')) {
+    return 'info';
+  }
+  if (/^Version \d+ status changed: .+ -> archived$/.test(detail)) {
+    return 'warning';
+  }
+  if (detail.startsWith('Version ') && detail.includes(' status changed: ')) {
+    return 'info';
+  }
+
+  const status = versionStatus(detail);
+  if (detail.startsWith('Version ') && detail.includes(' removed (')) {
+    return status === 'archived' ? 'warning' : 'breaking';
+  }
+  if (detail.startsWith('Version ') && detail.includes(' added (')) {
+    return status === 'archived' ? 'info' : 'warning';
+  }
+  if (
+    /^Version \d+ (?:kind changed:|Required (?:input|contour) field ".+" added|(?:Input|Output|Contour) field ".+" (?:removed|type changed:|changed from optional to required))/.test(
+      detail
+    )
+  ) {
+    return 'breaking';
+  }
+  if (
+    /^Version \d+ (?:marker changed:|Optional (?:input|contour) field ".+" added|Output field ".+" added)/.test(
+      detail
+    )
+  ) {
+    return 'info';
+  }
+
+  return 'info';
+};
+
+const visibleDetailsSeverity = (details: readonly string[]): DiffSeverity => {
+  let severity: DiffSeverity = 'info';
+  for (const detail of details) {
+    severity = higherSeverity(severity, visibleDetailSeverity(detail));
+  }
+  return severity;
+};
+
+const detailsChanged = (
+  previous: readonly string[],
+  next: readonly string[]
+): boolean =>
+  previous.length !== next.length ||
+  previous.some((detail, index) => detail !== next[index]);
+
+const filterDetails = (
+  details: readonly string[],
+  target: ParsedDiffTarget | undefined,
+  forcesOnly: boolean
+): readonly string[] => {
+  const visible = forcesOnly
+    ? details.filter((detail) => detail.startsWith('Force event '))
+    : [...details];
+  if (target?.versions === undefined || forcesOnly) {
+    return visible;
+  }
+
+  return visible.filter((detail) => {
+    const versions = detailVersions(detail);
+    return versions.some((version) => target.versions?.has(version));
+  });
+};
+
+const filterDiff = (
+  diff: DiffResult,
+  target: ParsedDiffTarget | undefined,
+  options: Pick<DiffInput, 'breakingOnly' | 'breaks' | 'forces'>
+): DiffResult => {
+  const entries = diff.entries.flatMap((entry): DiffEntry[] => {
+    if (target !== undefined && entry.id !== target.id) {
+      return [];
+    }
+    const details = filterDetails(
+      entry.details,
+      target,
+      options.forces === true
+    );
+    if (details.length === 0) {
+      return [];
+    }
+    return [
+      {
+        ...entry,
+        details,
+        severity: detailsChanged(entry.details, details)
+          ? visibleDetailsSeverity(details)
+          : entry.severity,
+      },
+    ];
+  });
+
+  const partitioned = partitionDiffEntries(entries);
+  return options.breakingOnly === true || options.breaks === true
+    ? partitionDiffEntries(partitioned.breaking)
+    : partitioned;
+};
 
 const createDiffExampleInput = (): {
   readonly against: string;
@@ -218,21 +480,25 @@ const readAgainstTopoGraph = async (
 const buildSurveyDiff = async (
   app: Topo,
   rootDir: string,
-  breakingOnly: boolean,
-  against?: string | undefined
+  input: DiffInput
 ): Promise<Result<SurveyDiffReport, Error>> => {
   const currentMap = deriveTopoGraph(app);
-  const previous = await readAgainstTopoGraph(rootDir, against);
+  const previous = await readAgainstTopoGraph(rootDir, input.against);
   if (previous.isErr()) {
     return previous;
   }
 
-  const diff = deriveTopoGraphDiff(previous.value.map, currentMap);
-  return Result.ok(
-    breakingOnly
-      ? formatDiff({ ...diff, info: [], warnings: [] }, previous.value.against)
-      : formatDiff(diff, previous.value.against)
+  const target = parseDiffTarget(previous.value.map, currentMap, input.target);
+  if (target.isErr()) {
+    return target;
+  }
+
+  const diff = filterDiff(
+    deriveTopoGraphDiff(previous.value.map, currentMap),
+    target.value,
+    input
   );
+  return Result.ok(formatDiff(diff, previous.value.against));
 };
 
 const buildSurveyLookup = (
@@ -404,6 +670,32 @@ const diffOutput = z.object({
   warnings: z.array(diffEntryOutput),
 });
 
+const diffInputSchema = z.object({
+  against: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Saved TopoGraph target: "saved", a workspace path (topo.lock, .json file, or directory with topo.lock), then a pin/snapshot id'
+    ),
+  breakingOnly: z
+    .boolean()
+    .default(false)
+    .describe('Legacy alias for --breaks; only show breaking changes'),
+  breaks: z.boolean().default(false).describe('Only show breaking changes'),
+  forces: z
+    .boolean()
+    .default(false)
+    .describe('Only show graph force audit events'),
+  module: z.string().optional().describe('Path to the app module'),
+  rootDir: z.string().optional().describe('Workspace root directory'),
+  target: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Trail or trail version target, such as user.create@1..2'),
+});
+
 const surveyMatchOutput = z.discriminatedUnion('kind', [
   z.object({
     detail: trailDetailOutput,
@@ -537,7 +829,7 @@ export const surveySurfacesTrail = trail('survey.surfaces', {
 export const surveyDiffTrail = trail('survey.diff', {
   blaze: async (input, ctx) =>
     withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
-      buildSurveyDiff(app, rootDir, input.breakingOnly, input.against)
+      buildSurveyDiff(app, rootDir, input)
     ),
   description: 'Diff the current topo against a saved TopoGraph',
   examples: [
@@ -562,21 +854,36 @@ export const surveyDiffTrail = trail('survey.diff', {
       name: 'Reject empty breaking-only target',
     },
   ],
-  input: z.object({
-    against: z
-      .string()
-      .min(1)
-      .optional()
-      .describe(
-        'Saved TopoGraph target: "saved", a workspace path (topo.lock, .json file, or directory with topo.lock), then a pin/snapshot id'
-      ),
-    breakingOnly: z
-      .boolean()
-      .default(false)
-      .describe('Only show breaking changes'),
-    module: z.string().optional().describe('Path to the app module'),
-    rootDir: z.string().optional().describe('Workspace root directory'),
-  }),
+  input: diffInputSchema,
+  intent: 'read',
+  output: diffOutput,
+});
+
+export const diffTrail = trail('diff', {
+  args: ['target'],
+  blaze: async (input, ctx) =>
+    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
+      buildSurveyDiff(app, rootDir, input)
+    ),
+  description: 'Diff the current topo against a saved TopoGraph',
+  examples: [
+    {
+      description: 'Compare current topo to a saved TopoGraph directory',
+      input: createDiffExampleInput(),
+      name: 'Diff against baseline',
+    },
+    {
+      description: 'Show only breaking contract drift',
+      input: { ...createDiffExampleInput(), breaks: true },
+      name: 'Breaking changes',
+    },
+    {
+      description: 'Show graph-only force audit events',
+      input: { ...createDiffExampleInput(), forces: true },
+      name: 'Force audit events',
+    },
+  ],
+  input: diffInputSchema,
   intent: 'read',
   output: diffOutput,
 });

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -104,6 +104,19 @@ Compile the current topo to `.trails/topo.lock` and `.trails/trails.lock`.
 trails compile
 ```
 
+### `trails diff`
+
+Compare the current topo against a saved TopoGraph target. The default target is
+the committed `.trails/topo.lock`; explicit targets may be workspace-relative
+`topo.lock` files, JSON TopoGraphs, TopoGraph directories, pins, or snapshots.
+
+```bash
+trails diff
+trails diff user.create@1..2 --against pre-refactor
+trails diff --breaks
+trails diff --forces
+```
+
 ### `trails validate`
 
 Check that the `.trails/trails.lock` / `.trails/topo.lock` artifact family

--- a/packages/topographer/src/__tests__/diff.test.ts
+++ b/packages/topographer/src/__tests__/diff.test.ts
@@ -504,6 +504,137 @@ describe('deriveTopoGraphDiff', () => {
         'Live version 1 examples: 1 -> 2'
       );
     });
+
+    test('version markers, support removals, and archived status are visible', () => {
+      const versionContract = {
+        input: { properties: {}, type: 'object' },
+        kind: 'revision' as const,
+        output: { properties: {}, type: 'object' },
+      };
+      const prev = topoGraph([
+        entry({
+          id: 'versioned.trail',
+          marker: 'aaaa000000000000',
+          supports: [1, 2, 3],
+          version: 3,
+          versions: {
+            1: {
+              ...versionContract,
+              exampleCount: 1,
+              marker: 'bbbb000000000000',
+            },
+            2: {
+              ...versionContract,
+              exampleCount: 1,
+              marker: 'cccc000000000000',
+            },
+          },
+        }),
+      ]);
+      const curr = topoGraph([
+        entry({
+          id: 'versioned.trail',
+          marker: 'dddd000000000000',
+          supports: [2, 3],
+          version: 3,
+          versions: {
+            1: {
+              ...versionContract,
+              exampleCount: 1,
+              marker: 'eeee000000000000',
+              status: { state: 'archived' },
+            },
+            2: {
+              ...versionContract,
+              exampleCount: 1,
+              marker: 'cccc000000000000',
+            },
+          },
+        }),
+      ]);
+
+      const result = deriveTopoGraphDiff(prev, curr);
+
+      expect(result.hasBreaking).toBe(true);
+      expect(result.breaking[0]?.details).toContain(
+        'Supported versions removed: 1'
+      );
+      expect(result.breaking[0]?.details).toContain(
+        'Current marker changed: aaaa000000000000 -> dddd000000000000'
+      );
+      expect(result.breaking[0]?.details).toContain(
+        'Version 1 status changed: live -> archived'
+      );
+      expect(result.breaking[0]?.details).toContain(
+        'Version 1 marker changed: bbbb000000000000 -> eeee000000000000'
+      );
+    });
+
+    test('force event changes are reported as audit warnings', () => {
+      const prev = topoGraph([
+        entry({
+          id: 'versioned.trail',
+        }),
+      ]);
+      const curr = topoGraph([
+        entry({
+          forces: [
+            {
+              acceptedAt: '2026-05-20T00:00:00.000Z',
+              change: 'modified',
+              detail: 'Required input field "name" added',
+              id: 'versioned.trail',
+              kind: 'trail',
+              severity: 'breaking',
+              source: 'trails compile --force',
+            },
+          ],
+          id: 'versioned.trail',
+        }),
+      ]);
+
+      const result = deriveTopoGraphDiff(prev, curr);
+
+      expect(result.warnings[0]?.details).toContain(
+        'Force event recorded: modified Required input field "name" added'
+      );
+    });
+
+    test('graph-level force event changes are reported as audit warnings', () => {
+      const prev = topoGraph([
+        entry({
+          id: 'hello',
+        }),
+      ]);
+      const curr = {
+        ...topoGraph([
+          entry({
+            id: 'hello',
+          }),
+        ]),
+        forces: [
+          {
+            acceptedAt: '2026-05-20T00:00:00.000Z',
+            change: 'removed' as const,
+            detail: 'Trail "bye" removed',
+            id: 'bye',
+            kind: 'trail' as const,
+            severity: 'breaking' as const,
+            source: 'trails compile --force' as const,
+          },
+        ],
+      };
+
+      const result = deriveTopoGraphDiff(prev, curr);
+
+      expect(result.warnings[0]).toMatchObject({
+        id: 'bye',
+        kind: 'trail',
+      });
+      expect(result.warnings[0]?.details).toContain(
+        'Force event recorded: removed Trail "bye" removed'
+      );
+    });
   });
 
   describe('severity partitioning', () => {

--- a/packages/topographer/src/diff.ts
+++ b/packages/topographer/src/diff.ts
@@ -8,6 +8,7 @@ import type {
   JsonSchema,
   TopoGraph,
   TopoGraphEntry,
+  TopoGraphForceEntry,
   TopoGraphVersionEntry,
 } from './types.js';
 
@@ -445,6 +446,147 @@ const diffResources = (
 const isLiveVersionEntry = (entry: TopoGraphVersionEntry): boolean =>
   entry.status?.state !== 'archived';
 
+const statusLabel = (
+  status: TopoGraphVersionEntry['status'] | undefined
+): string => status?.state ?? 'live';
+
+const diffNumberSet = (
+  acc: DetailAccumulator,
+  label: string,
+  previous: readonly number[] | undefined,
+  current: readonly number[] | undefined,
+  removedSeverity: Severity
+): void => {
+  const prevValues = new Set(previous);
+  const currValues = new Set(current);
+  const added = [...currValues]
+    .filter((value) => !prevValues.has(value))
+    .toSorted((left, right) => left - right);
+  const removed = [...prevValues]
+    .filter((value) => !currValues.has(value))
+    .toSorted((left, right) => left - right);
+
+  if (added.length > 0) {
+    addDetail(acc, 'info', `${label} added: ${added.join(', ')}`);
+  }
+  if (removed.length > 0) {
+    addDetail(acc, removedSeverity, `${label} removed: ${removed.join(', ')}`);
+  }
+};
+
+const diffVersionSchemaFields = (
+  acc: DetailAccumulator,
+  version: string,
+  prev: TopoGraphVersionEntry,
+  curr: TopoGraphVersionEntry
+): void => {
+  const versionAcc: DetailAccumulator = { details: [], severity: 'info' };
+  diffSchemaFields(versionAcc, 'input', prev.input, curr.input);
+  diffSchemaFields(versionAcc, 'output', prev.output, curr.output);
+
+  for (const detail of versionAcc.details) {
+    addDetail(acc, versionAcc.severity, `Version ${version} ${detail}`);
+  }
+};
+
+const diffVersionEntry = (
+  acc: DetailAccumulator,
+  version: string,
+  prev: TopoGraphVersionEntry,
+  curr: TopoGraphVersionEntry
+): void => {
+  if (prev.kind !== curr.kind) {
+    addDetail(
+      acc,
+      'breaking',
+      `Version ${version} kind changed: ${prev.kind} -> ${curr.kind}`
+    );
+  }
+
+  const prevStatus = statusLabel(prev.status);
+  const currStatus = statusLabel(curr.status);
+  if (prevStatus !== currStatus) {
+    addDetail(
+      acc,
+      currStatus === 'archived' ? 'warning' : 'info',
+      `Version ${version} status changed: ${prevStatus} -> ${currStatus}`
+    );
+  }
+
+  if (prev.marker !== curr.marker) {
+    addDetail(
+      acc,
+      'info',
+      `Version ${version} marker changed: ${prev.marker} -> ${curr.marker}`
+    );
+  }
+
+  diffVersionSchemaFields(acc, version, prev, curr);
+};
+
+const diffVersionEntries = (
+  acc: DetailAccumulator,
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
+): void => {
+  diffNumberSet(
+    acc,
+    'Supported versions',
+    prev.supports,
+    curr.supports,
+    'breaking'
+  );
+
+  if (prev.version !== curr.version) {
+    addDetail(
+      acc,
+      'info',
+      `Current version changed: ${String(prev.version ?? '(none)')} -> ${String(curr.version ?? '(none)')}`
+    );
+  }
+
+  if (prev.marker !== curr.marker) {
+    addDetail(
+      acc,
+      'info',
+      `Current marker changed: ${String(prev.marker ?? '(none)')} -> ${String(curr.marker ?? '(none)')}`
+    );
+  }
+
+  const prevVersions = prev.versions ?? {};
+  const currVersions = curr.versions ?? {};
+  const versions = new Set([
+    ...Object.keys(prevVersions),
+    ...Object.keys(currVersions),
+  ]);
+
+  for (const version of [...versions].toSorted(
+    (left, right) => Number(left) - Number(right)
+  )) {
+    const previous = prevVersions[version];
+    const current = currVersions[version];
+    if (previous === undefined && current !== undefined) {
+      addDetail(
+        acc,
+        isLiveVersionEntry(current) ? 'warning' : 'info',
+        `Version ${version} added (${statusLabel(current.status)})`
+      );
+      continue;
+    }
+    if (previous !== undefined && current === undefined) {
+      addDetail(
+        acc,
+        isLiveVersionEntry(previous) ? 'breaking' : 'warning',
+        `Version ${version} removed (${statusLabel(previous.status)})`
+      );
+      continue;
+    }
+    if (previous !== undefined && current !== undefined) {
+      diffVersionEntry(acc, version, previous, current);
+    }
+  }
+};
+
 const diffVersionExampleCoverage = (
   acc: DetailAccumulator,
   prev: TopoGraphEntry,
@@ -490,6 +632,93 @@ const diffVersionExampleCoverage = (
       );
     }
   }
+};
+
+const forceKey = (force: TopoGraphForceEntry): string =>
+  stableStringify({
+    change: force.change,
+    detail: force.detail,
+    id: force.id,
+    kind: force.kind,
+    reason: force.reason,
+    severity: force.severity,
+    source: force.source,
+  });
+
+const diffForces = (
+  acc: DetailAccumulator,
+  prev: TopoGraphEntry,
+  curr: TopoGraphEntry
+): void => {
+  const prevForces = new Map(
+    (prev.forces ?? []).map((force) => [forceKey(force), force])
+  );
+  const currForces = new Map(
+    (curr.forces ?? []).map((force) => [forceKey(force), force])
+  );
+
+  for (const [key, force] of [...currForces].toSorted(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    if (!prevForces.has(key)) {
+      addDetail(
+        acc,
+        'warning',
+        `Force event recorded: ${force.change} ${force.detail}`
+      );
+    }
+  }
+
+  for (const [key, force] of [...prevForces].toSorted(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    if (!currForces.has(key)) {
+      addDetail(
+        acc,
+        'warning',
+        `Force event removed: ${force.change} ${force.detail}`
+      );
+    }
+  }
+};
+
+const forceDiffEntry = (
+  force: TopoGraphForceEntry,
+  direction: 'recorded' | 'removed'
+): DiffEntry => ({
+  change: 'modified',
+  details: [`Force event ${direction}: ${force.change} ${force.detail}`],
+  id: force.id,
+  kind: force.kind,
+  severity: 'warning',
+});
+
+const diffGraphForces = (prev: TopoGraph, curr: TopoGraph): DiffEntry[] => {
+  const prevForces = new Map(
+    (prev.forces ?? []).map((force) => [forceKey(force), force])
+  );
+  const currForces = new Map(
+    (curr.forces ?? []).map((force) => [forceKey(force), force])
+  );
+  const entries: DiffEntry[] = [];
+
+  for (const [key, force] of [...currForces].toSorted(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    if (!prevForces.has(key)) {
+      entries.push(forceDiffEntry(force, 'recorded'));
+    }
+  }
+
+  for (const [key, force] of [...prevForces].toSorted(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    if (!currForces.has(key)) {
+      entries.push(forceDiffEntry(force, 'removed'));
+    }
+  }
+
+  return entries;
 };
 
 /** Diff declared contour arrays on trail entries. */
@@ -579,7 +808,9 @@ const diffTrailEntryDetails = (
   diffCrosses(acc, prev, curr);
   diffContours(acc, prev, curr);
   diffResources(acc, prev, curr);
+  diffVersionEntries(acc, prev, curr);
   diffVersionExampleCoverage(acc, prev, curr);
+  diffForces(acc, prev, curr);
 };
 
 const diffEntryDetails = (
@@ -682,12 +913,15 @@ const findModified = (
 
 /** Collect all diff entries (added, removed, modified) between two maps. */
 const collectDiffEntries = (
+  prev: TopoGraph,
+  curr: TopoGraph,
   prevById: Map<string, TopoGraphEntry>,
   currById: Map<string, TopoGraphEntry>
 ): DiffEntry[] => [
   ...findAdded(prevById, currById),
   ...findRemoved(prevById, currById),
   ...findModified(prevById, currById),
+  ...diffGraphForces(prev, curr),
 ];
 
 export const deriveTopoGraphDiff = (
@@ -696,8 +930,8 @@ export const deriveTopoGraphDiff = (
 ): DiffResult => {
   const prevById = new Map(prev.entries.map((e) => [e.id, e]));
   const currById = new Map(curr.entries.map((e) => [e.id, e]));
-  const sorted = collectDiffEntries(prevById, currById).toSorted((a, b) =>
-    a.id.localeCompare(b.id)
+  const sorted = collectDiffEntries(prev, curr, prevById, currById).toSorted(
+    (a, b) => a.id.localeCompare(b.id)
   );
 
   const breaking = sorted.filter((e) => e.severity === 'breaking');


### PR DESCRIPTION
## Context

With lifecycle status and force events in place, this branch makes `trails diff` version-aware so review and release gates can talk about actual contract movement: current versions, historical entries, markers, status, and forced breaks.

Linear: TRL-730
Stack: 5/8, on top of TRL-732.

## What changed

- Extended TopoGraph diff details for current version, supported versions, projected marker, per-version lifecycle status, per-version marker, and graph-only force events.
- Added a top-level `diff` trail that shares the existing `survey.diff` reader.
- Added target filtering for `trail.id`, `trail.id@N`, `trail.id@N..M`, marker prefixes, `--breaks`, and `--forces`.
- Documented the command grammar in topo-store docs.
- Added branch-local changesets for topographer/trails changes.

## Verification

- `bun test packages/topographer/src/__tests__/diff.test.ts apps/trails/src/__tests__/survey.test.ts` (79 pass)
- `bun run --cwd packages/topographer typecheck`
- `bun run --cwd apps/trails typecheck`
- Stack-tip gates later passed: ADR check, typecheck, test, lint, ast-grep, build, format, check, publish dry-run, Warden guide checks, `git diff --check`.

## Risks / notes

Diff targets intentionally resolve through several strategies; the user-facing error reports attempted resolution strategies when a target cannot be found.