### PR TITLE
feat(surfaces): negotiate trail versions

### DIFF
--- a/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
+++ b/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
@@ -129,6 +129,17 @@ Append meaningful state changes, especially before handoff points.
 - Result: TRL-730 local version-aware diff surface is implemented. Remaining branch-local checks still need formatting, `git diff --check`, and commit-hook validation before committing.
 - Next: Run branch formatting/whitespace checks, commit TRL-730, restack upward, then implement TRL-118 surface negotiation.
 - Blockers: None.
+
+2026-05-20 10:34 EDT - TRL-118 surface version negotiation
+- Changed: Committed TRL-730 as `f702dd59e feat(trails): add version-aware topo diff`; Graphite restacked the descendant branches.
+- Changed: Implemented TRL-118 on `trl-118-project-version-negotiation-across-http-mcp-cli-and`: added shared core live-version surface projections, exposed live version metadata from CLI/HTTP/MCP definitions, added CLI `--trail-version`, added HTTP `trailVersion` plus `X-Trails-Version` / `X-Trail-Version`, added MCP `trailVersion`, and threaded all three through `executeTrail` as the shared version reference.
+- Changed: Archived entries remain excluded from projected live surface metadata by `deriveSupportedTrailVersions`; deprecated entries remain projected with status metadata; unsupported/archived requests continue through core `VersionNotSupportedError` handling.
+- Note: No shipped WebSocket surface package exists in this repo; TRL-118 implementation covered the real shipped surfaces (`cli`, `http`, `mcp`) and left WebSocket as planned docs-only surface state.
+- Verified: Focused surface/runtime tests passed: `bun test packages/cli/src/__tests__/build.test.ts packages/http/src/__tests__/build.test.ts packages/mcp/src/__tests__/build.test.ts packages/core/src/__tests__/version-execution.test.ts` (211 pass).
+- Verified: `bun run --cwd packages/core typecheck`, `bun run --cwd packages/cli typecheck`, `bun run --cwd packages/http typecheck`, and `bun run --cwd packages/mcp typecheck` passed.
+- Result: TRL-118 local surface negotiation is implemented for shipped surfaces. Remaining branch-local checks still need formatting, `git diff --check`, and commit-hook validation before committing.
+- Next: Run branch formatting/whitespace checks, commit TRL-118, restack upward, then implement lifecycle CLI commands in TRL-119.
+- Blockers: None.
 ```
 
 ## Local Review Log
@@ -164,6 +175,11 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun test packages/topographer/src/__tests__/diff.test.ts apps/trails/src/__tests__/survey.test.ts` | TRL-730 targeted tests | Passed | 79 pass, 0 fail. |
 | `bun run --cwd packages/topographer typecheck` | TRL-730 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run --cwd apps/trails typecheck` | TRL-730 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun test packages/cli/src/__tests__/build.test.ts packages/http/src/__tests__/build.test.ts packages/mcp/src/__tests__/build.test.ts packages/core/src/__tests__/version-execution.test.ts` | TRL-118 targeted tests | Passed | 211 pass, 0 fail. |
+| `bun run --cwd packages/core typecheck` | TRL-118 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun run --cwd packages/cli typecheck` | TRL-118 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun run --cwd packages/http typecheck` | TRL-118 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun run --cwd packages/mcp typecheck` | TRL-118 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run check` | Execution tip | Pending | Required by goal. |
 | `bun run build` | Execution tip | Pending | Required by goal. |
 | `bun run test` | Execution tip | Pending | Required by goal. |

--- a/.changeset/trl-118-surface-version-negotiation.md
+++ b/.changeset/trl-118-surface-version-negotiation.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/core": patch
+"@ontrails/cli": patch
+"@ontrails/http": patch
+"@ontrails/mcp": patch
+---
+
+Project live trail-version metadata on CLI, HTTP, and MCP surfaces and thread explicit surface version selection into shared trail execution.

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -67,6 +67,10 @@ needed.
 Nested objects and arrays of objects are intentionally omitted from automatic
 flag derivation. The CLI prefers fewer flags over dishonest flags.
 
+Versioned trails also get a surface-owned `--trail-version <version>` flag. The
+flag accepts a live version number or unambiguous marker prefix and is stripped
+before trail input validation, so version negotiation stays at the CLI boundary.
+
 ```typescript
 const search = trail('search', {
   input: z.object({

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -53,6 +53,11 @@ public error projection, diagnostics, request ID/header forwarding, abort
 propagation, and webhook verification/parsing. Hono and Bun consume the same
 kernel so those behaviors stay in parity.
 
+Versioned trails expose a surface-owned `trailVersion` request field and also
+accept `X-Trails-Version` / `X-Trail-Version` headers. The selected version is
+stripped before trail input validation and forwarded to the shared execution
+pipeline.
+
 ## How Trail IDs Map to Routes
 
 Dots in trail IDs become path segments:

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -251,3 +251,10 @@ for (const tool of result.value) {
 ```
 
 Each `McpToolDefinition` includes a `trailId` field containing the original trail ID (e.g. `'entity.show'`). This is useful for logging, filtering, or routing when managing tool definitions outside of `surface()`.
+
+For versioned trails, the tool input schema includes a surface-owned
+`trailVersion` parameter. MCP handlers strip it before trail input validation
+and forward the selected live version or marker prefix to the shared execution
+pipeline. The `versions` field on each tool lists the live projected versions;
+archived historical entries remain inspectable through topo artifacts but are
+not runtime tool targets.

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -583,6 +583,56 @@ describe('buildCommands execution', () => {
     expect(result.isErr()).toBe(true);
     expect(result.error.message).toContain('unexpected kaboom');
   });
+
+  test('projects live versions and executes selected version flag', async () => {
+    const versioned = trail('versioned.greet', {
+      blaze: (input: { name: string }) =>
+        Result.ok({ message: `Hello, ${input.name}!` }),
+      input: z.object({ name: z.string() }),
+      output: z.object({ message: z.string() }),
+      version: 3,
+      versions: {
+        1: {
+          input: z.object({ firstName: z.string(), legacyId: z.string() }),
+          output: z.object({ message: z.string() }),
+          status: { state: 'archived' },
+          transpose: {
+            input: ({ input }) => ({ name: input.firstName }),
+            output: ({ output }) => output,
+          },
+        },
+        2: {
+          input: z.object({ firstName: z.string() }),
+          output: z.object({ message: z.string() }),
+          status: { note: 'Use name.', state: 'deprecated' },
+          transpose: {
+            input: ({ input }) => ({ name: input.firstName }),
+            output: ({ output }) => output,
+          },
+        },
+      },
+    });
+    const cmd = requireCommand(buildCommands(makeApp(versioned)));
+
+    expect(cmd.flags.map((flag) => flag.name)).toContain('trail-version');
+    expect(cmd.versions?.map((entry) => entry.version)).toEqual([2, 3]);
+    expect(cmd.versions?.[0]).toMatchObject({
+      current: false,
+      deprecated: true,
+      version: 2,
+    });
+
+    const result = await cmd.execute(
+      {},
+      {
+        firstName: 'Ada',
+        trailVersion: '2',
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.value).toEqual({ message: 'Hello, Ada!' });
+  });
 });
 
 describe('buildCommands resource overrides', () => {

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -9,6 +9,7 @@ import type {
   Layer,
   LayerInputSchema,
   ResourceOverrideMap,
+  TrailVersionReference,
   Topo,
   TrailContext,
   TrailContextInit,
@@ -20,6 +21,7 @@ import {
   collectAttachedTypedLayers as collectTypedLayers,
   deriveCliPath,
   deriveFields,
+  deriveSurfaceTrailVersionProjections,
   executeTrail,
   filterSurfaceTrails,
   LAYER_FIELD_RESERVED_NAMES,
@@ -36,7 +38,7 @@ import {
   expandDateShortcuts,
 } from './date-shortcuts.js';
 import type { DateShortcutKind } from './date-shortcuts.js';
-import { dryRunPreset, toFlags } from './flags.js';
+import { dryRunPreset, toFlags, trailVersionPreset } from './flags.js';
 import {
   inputHasCursorField,
   isPaginatedOutput,
@@ -452,6 +454,7 @@ const runTrailOnce = async (
   input: Record<string, unknown>,
   dryRun: boolean | undefined,
   permit: BasePermit | undefined,
+  version: TrailVersionReference | undefined,
   layerInputs: Readonly<Record<string, unknown>> | undefined
 ): Promise<Result<unknown, Error>> =>
   await executeTrail(t, input, {
@@ -467,6 +470,7 @@ const runTrailOnce = async (
     surfaceLayers: options?.layers,
     topo: graph,
     topoLayers: graph.layers,
+    ...(version === undefined ? {} : { version }),
   });
 
 /**
@@ -491,6 +495,19 @@ const readDryRunFlag = (
     return false;
   }
   return undefined;
+};
+
+const readTrailVersionFlag = (
+  parsedFlags: Record<string, unknown>,
+  metaFlagNames: ReadonlySet<string>
+): TrailVersionReference | undefined => {
+  if (!metaFlagNames.has('trailVersion')) {
+    return undefined;
+  }
+  const value = parsedFlags['trailVersion'] ?? parsedFlags['trail-version'];
+  return typeof value === 'string' || typeof value === 'number'
+    ? value
+    : undefined;
 };
 
 /**
@@ -532,6 +549,7 @@ const runPaginatedIteration = async (
   jsonl: boolean,
   dryRun: boolean | undefined,
   permit: BasePermit | undefined,
+  version: TrailVersionReference | undefined,
   layerInputs: Readonly<Record<string, unknown>> | undefined
 ): Promise<IterationOutcome> => {
   if (!inputHasCursorField(t)) {
@@ -558,6 +576,7 @@ const runPaginatedIteration = async (
         input,
         dryRun,
         permit,
+        version,
         layerInputs
       ),
   });
@@ -962,6 +981,10 @@ const createExecute =
     const layerInputs = buildLayerInputs(layerProjections, normalizedFlags);
 
     const dryRun = readDryRunFlag(parsedFlags, trailInputExcludeKeys);
+    const trailVersion = readTrailVersionFlag(
+      parsedFlags,
+      trailInputExcludeKeys
+    );
     let result: Result<unknown, Error>;
     let streamed = false;
     if (shouldIteratePages(t, parsedFlags, trailInputExcludeKeys)) {
@@ -974,6 +997,7 @@ const createExecute =
         isJsonlMode(parsedFlags),
         dryRun,
         permit,
+        trailVersion,
         layerInputs
       );
       ({ result } = outcome);
@@ -989,6 +1013,7 @@ const createExecute =
           : mergedInput,
         dryRun,
         permit,
+        trailVersion,
         layerInputs
       );
     }
@@ -1033,6 +1058,9 @@ const buildFlags = (
   }
   if (options?.presets) {
     flags = mergeFlags(options.presets.flat(), flags);
+  }
+  if (t.version !== undefined) {
+    flags = mergeFlags(trailVersionPreset(), flags);
   }
   if (intent === 'destroy' || intent === 'write') {
     flags = mergeFlags(dryRunPreset(), flags);
@@ -1159,6 +1187,7 @@ const toCliCommand = (
   );
   const dateFields = detectDateFields(t.input);
   const dateFieldKinds = detectDateFieldKinds(t.input);
+  const versions = deriveSurfaceTrailVersionProjections(t);
 
   return {
     args,
@@ -1180,6 +1209,7 @@ const toCliCommand = (
     layers: options?.layers,
     path: deriveCliPath(t.id),
     trail: t,
+    ...(versions === undefined ? {} : { versions }),
   };
 };
 

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -6,7 +6,13 @@
  * No Commander (or any other framework) imports here.
  */
 
-import type { Layer, Result, Trail, TrailContext } from '@ontrails/core';
+import type {
+  Layer,
+  Result,
+  SurfaceTrailVersionProjection,
+  Trail,
+  TrailContext,
+} from '@ontrails/core';
 
 // ---------------------------------------------------------------------------
 // AnyTrail -- type-erased trail for the CLI boundary
@@ -67,6 +73,7 @@ export interface CliCommand {
   readonly flags: CliFlag[];
   readonly args: CliArg[];
   readonly trail: AnyTrail;
+  readonly versions?: readonly SurfaceTrailVersionProjection[] | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly intent: 'read' | 'write' | 'destroy';
   readonly idempotent?: boolean | undefined;

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -283,6 +283,17 @@ export const dryRunPreset = (): CliFlag[] => [
   },
 ];
 
+/** Flag for selecting a live trail version: --trail-version */
+export const trailVersionPreset = (): CliFlag[] => [
+  {
+    description: 'Execute a live trail version by number or marker prefix',
+    name: 'trail-version',
+    required: false,
+    type: 'string',
+    variadic: false,
+  },
+];
+
 /**
  * Flag for trace collection: --trace
  *

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -228,6 +228,8 @@ export {
   shouldIncludeTrailForSurface,
 } from './surface-filter.js';
 export type { SurfaceFilterOptions } from './surface-filter.js';
+export { deriveSurfaceTrailVersionProjections } from './surface-versioning.js';
+export type { SurfaceTrailVersionProjection } from './surface-versioning.js';
 export {
   shouldValidateSurfaceTopo,
   validateSurfaceTopo,

--- a/packages/core/src/layer-projection.ts
+++ b/packages/core/src/layer-projection.ts
@@ -38,6 +38,7 @@ export const LAYER_FIELD_RESERVED_NAMES: ReadonlySet<string> = new Set([
   'permit',
   'quiet',
   'token',
+  'trailVersion',
   'trace',
   'watch',
 ]);

--- a/packages/core/src/surface-versioning.ts
+++ b/packages/core/src/surface-versioning.ts
@@ -1,0 +1,42 @@
+import type { AnyTrail, TrailVersionStatus } from './trail.js';
+import {
+  deriveSupportedTrailVersions,
+  isDeprecatedTrailVersionEntry,
+} from './trail.js';
+import { deriveTrailVersionMarkers } from './version-marker.js';
+
+export interface SurfaceTrailVersionProjection {
+  readonly current: boolean;
+  readonly deprecated: boolean;
+  readonly marker?: string | undefined;
+  readonly status?: TrailVersionStatus | undefined;
+  readonly version: number;
+}
+
+export const deriveSurfaceTrailVersionProjections = (
+  trail: AnyTrail
+): readonly SurfaceTrailVersionProjection[] | undefined => {
+  if (trail.version === undefined) {
+    return undefined;
+  }
+
+  const markers = new Map(
+    deriveTrailVersionMarkers(trail).map((record) => [
+      record.version,
+      record.marker,
+    ])
+  );
+
+  return deriveSupportedTrailVersions(trail).map((version) => {
+    const entry = trail.versions?.[version];
+    const marker = markers.get(version);
+    return {
+      current: version === trail.version,
+      deprecated:
+        entry === undefined ? false : isDeprecatedTrailVersionEntry(entry),
+      ...(marker === undefined ? {} : { marker }),
+      ...(entry?.status === undefined ? {} : { status: entry.status }),
+      version,
+    };
+  });
+};

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -1112,6 +1112,89 @@ describe('deriveHttpRoutes', () => {
       expect(result.value).toEqual({ reply: 'hello' });
     });
 
+    test('projects live versions and executes selected request version', async () => {
+      const versioned = trail('versioned.greet', {
+        blaze: (input: { name: string }) =>
+          Result.ok({ message: `Hello, ${input.name}!` }),
+        input: z.object({ name: z.string() }),
+        output: z.object({ message: z.string() }),
+        version: 3,
+        versions: {
+          1: {
+            input: z.object({ firstName: z.string(), legacyId: z.string() }),
+            output: z.object({ message: z.string() }),
+            status: { state: 'archived' },
+            transpose: {
+              input: ({ input }) => ({ name: input.firstName }),
+              output: ({ output }) => output,
+            },
+          },
+          2: {
+            input: z.object({ firstName: z.string() }),
+            output: z.object({ message: z.string() }),
+            status: { note: 'Use name.', state: 'deprecated' },
+            transpose: {
+              input: ({ input }) => ({ name: input.firstName }),
+              output: ({ output }) => output,
+            },
+          },
+        },
+      });
+      const buildResult = deriveHttpRoutes(topo('testapp', { versioned }));
+
+      expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
+      const [route] = buildResult.value;
+
+      expect(route?.inputSchema).toMatchObject({
+        properties: {
+          trailVersion: { type: 'string' },
+        },
+      });
+      expect(route?.versions?.map((entry) => entry.version)).toEqual([2, 3]);
+
+      const result = await route?.execute({
+        firstName: 'Ada',
+        trailVersion: '2',
+      });
+
+      expect(result?.isOk()).toBe(true);
+      if (!result?.isOk()) {
+        return;
+      }
+      expect(result.value).toEqual({ message: 'Hello, Ada!' });
+    });
+
+    test('ignores version headers on unversioned routes', async () => {
+      const app = topo('testapp', { echoTrail });
+      const buildResult = deriveHttpRoutes(app);
+
+      expect(buildResult.isOk()).toBe(true);
+      if (!buildResult.isOk()) {
+        return;
+      }
+      const [route] = buildResult.value;
+      expect(route?.versions).toBeUndefined();
+      expect(
+        route === undefined ? false : Object.hasOwn(route, 'versions')
+      ).toBe(false);
+
+      const result = await route?.execute(
+        { message: 'hello' },
+        undefined,
+        undefined,
+        { headers: { 'x-trails-version': '2' } }
+      );
+
+      expect(result?.isOk()).toBe(true);
+      if (!result?.isOk()) {
+        return;
+      }
+      expect(result.value).toEqual({ reply: 'hello' });
+    });
+
     test('returns err Result on invalid input', async () => {
       const app = topo('testapp', { echoTrail });
       const buildResult = deriveHttpRoutes(app);

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -12,6 +12,7 @@ import {
   ValidationError,
   buildActivationProvenanceTraceAttrs,
   collectAttachedTypedLayers,
+  deriveSurfaceTrailVersionProjections,
   executeTrail,
   filterSurfaceTrails,
   getActivationWherePredicate,
@@ -39,9 +40,11 @@ import type {
   BaseSurfaceOptions,
   Layer,
   ResourceOverrideMap,
+  SurfaceTrailVersionProjection,
   TraceContext,
   Topo,
   Trail,
+  TrailVersionReference,
   TrailContextInit,
   WebhookSource,
   WebhookVerifyRequest,
@@ -72,6 +75,7 @@ export type HttpHeaderSource =
 
 export interface HttpExecutionContext {
   readonly headers?: HttpHeaderSource | undefined;
+  readonly version?: TrailVersionReference | undefined;
 }
 
 export interface ResolveHttpPermitInput {
@@ -93,6 +97,7 @@ export interface HttpRouteDefinition {
   readonly trailId: string;
   readonly inputSource: InputSource;
   readonly trail: Trail<unknown, unknown, unknown>;
+  readonly versions?: readonly SurfaceTrailVersionProjection[] | undefined;
   /**
    * JSON Schema for the merged request input (trail input + projected layer
    * input fields). Empty/undefined when the trail declares no input and no
@@ -572,6 +577,67 @@ const mergeHttpInputSchemas = (
   return merged;
 };
 
+const TRAIL_VERSION_INPUT_FIELD = 'trailVersion';
+const TRAILS_VERSION_HEADERS = ['x-trails-version', 'x-trail-version'];
+
+const versionInputSchema = (): Record<string, unknown> => ({
+  properties: {
+    [TRAIL_VERSION_INPUT_FIELD]: {
+      description: 'Live trail version number or marker prefix',
+      type: 'string',
+    },
+  },
+  type: 'object',
+});
+
+const addVersionInputSchema = (
+  trail: Trail<unknown, unknown, unknown>,
+  schema: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined =>
+  trail.version === undefined
+    ? schema
+    : mergeHttpInputSchemas(schema, versionInputSchema());
+
+const readVersionFromHeaders = (
+  headers: HttpHeaderSource | undefined
+): TrailVersionReference | undefined => {
+  for (const name of TRAILS_VERSION_HEADERS) {
+    const value = readHeader(headers, name);
+    if (value !== undefined && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const splitHttpSurfaceVersion = (
+  input: unknown,
+  context: HttpExecutionContext | undefined,
+  supportsVersions: boolean
+): {
+  readonly input: unknown;
+  readonly version: TrailVersionReference | undefined;
+} => {
+  if (!supportsVersions) {
+    return { input, version: undefined };
+  }
+
+  const headerVersion =
+    context?.version ?? readVersionFromHeaders(context?.headers);
+  if (!isJsonObjectSchema(input)) {
+    return { input, version: headerVersion };
+  }
+
+  const record = input as Record<string, unknown>;
+  const { [TRAIL_VERSION_INPUT_FIELD]: fieldVersion, ...rest } = record;
+  const version =
+    headerVersion ??
+    (typeof fieldVersion === 'string' || typeof fieldVersion === 'number'
+      ? fieldVersion
+      : undefined);
+  return { input: rest, version };
+};
+
 /**
  * Partition a parsed request input into the trail input plus per-layer
  * inputs, using each layer's routing table.
@@ -639,8 +705,13 @@ const createExecute =
     layerProjections: readonly HttpLayerInputProjection[]
   ): HttpRouteDefinition['execute'] =>
   async (input, requestId, abortSignal, request) => {
-    const { trailInput, layerInputs } = partitionHttpInput(
+    const versionedInput = splitHttpSurfaceVersion(
       input,
+      request,
+      t.version !== undefined
+    );
+    const { trailInput, layerInputs } = partitionHttpInput(
+      versionedInput.input,
       layerProjections
     );
     const permitResolution = await resolveHttpPermit(
@@ -664,6 +735,9 @@ const createExecute =
       surfaceLayers: layers,
       topo: graph,
       topoLayers: graph.layers,
+      ...(versionedInput.version === undefined
+        ? {}
+        : { version: versionedInput.version }),
     });
   };
 
@@ -721,8 +795,13 @@ const createWebhookConsumerExecute =
       'activation.webhook',
       'ok'
     );
-    const { trailInput, layerInputs } = partitionHttpInput(
+    const versionedInput = splitHttpSurfaceVersion(
       input,
+      request,
+      t.version !== undefined
+    );
+    const { trailInput, layerInputs } = partitionHttpInput(
+      versionedInput.input,
       layerProjections
     );
     const permitResolution = await resolveHttpPermit(
@@ -746,6 +825,9 @@ const createWebhookConsumerExecute =
       surfaceLayers: layers,
       topo: graph,
       topoLayers: graph.layers,
+      ...(versionedInput.version === undefined
+        ? {}
+        : { version: versionedInput.version }),
     });
   };
 
@@ -836,6 +918,8 @@ const buildRoute = (
     options.layers
   );
   const inputProjection = projectHttpInputSchema(trail, attachedLayers);
+  const inputSchema = addVersionInputSchema(trail, inputProjection.schema);
+  const versions = deriveSurfaceTrailVersionProjections(trail);
   return {
     execute: createExecute(
       graph,
@@ -844,9 +928,7 @@ const buildRoute = (
       options,
       inputProjection.projections
     ),
-    ...(inputProjection.schema === undefined
-      ? {}
-      : { inputSchema: inputProjection.schema }),
+    ...(inputSchema === undefined ? {} : { inputSchema }),
     inputSource: deriveHttpInputSource(method),
     ...(inputProjection.projections.length === 0
       ? {}
@@ -855,6 +937,7 @@ const buildRoute = (
     path,
     trail,
     trailId: trail.id,
+    ...(versions === undefined ? {} : { versions }),
   };
 };
 
@@ -973,6 +1056,8 @@ const buildWebhookRoute = (
     options.layers
   );
   const inputProjection = projectHttpInputSchema(trail, attachedLayers);
+  const inputSchema = addVersionInputSchema(trail, inputProjection.schema);
+  const versions = deriveSurfaceTrailVersionProjections(trail);
   const consumerExecute = createWebhookConsumerExecute(
     graph,
     trail,
@@ -991,9 +1076,7 @@ const buildWebhookRoute = (
     [WEBHOOK_CONSUMERS]: [consumerExecute],
     [WEBHOOK_INVALID_RECORDERS]: [consumerInvalidRecorder],
     execute: createWebhookExecute(consumerExecute),
-    ...(inputProjection.schema === undefined
-      ? {}
-      : { inputSchema: inputProjection.schema }),
+    ...(inputSchema === undefined ? {} : { inputSchema }),
     inputSource: 'webhook',
     ...(inputProjection.projections.length === 0
       ? {}
@@ -1007,6 +1090,7 @@ const buildWebhookRoute = (
     trail,
     trailId: trail.id,
     verifyWebhook: (request) => verifyWebhookRequest(source.value, request),
+    ...(versions === undefined ? {} : { versions }),
     webhookSource: source.value,
   };
   return Result.ok(route);

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -365,6 +365,71 @@ describe('deriveMcpTools', () => {
       expect(result?.structuredContent).toEqual({ reply: 'hello' });
     });
 
+    test('handler ignores trailVersion args for unversioned tools', async () => {
+      const app = topo('myapp', { echoTrail });
+      const tool = requireOnlyTool(buildTools(app));
+
+      expect(
+        (tool.inputSchema['properties'] as Record<string, unknown>)[
+          'trailVersion'
+        ]
+      ).toBeUndefined();
+
+      const result = await tool.handler(
+        { message: 'hello', trailVersion: '2' },
+        noExtra
+      );
+
+      expect(result?.isError).toBeUndefined();
+      expect(result?.structuredContent).toEqual({ reply: 'hello' });
+    });
+
+    test('projects live versions and executes selected tool version', async () => {
+      const versioned = trail('versioned.greet', {
+        blaze: (input: { name: string }) =>
+          Result.ok({ message: `Hello, ${input.name}!` }),
+        input: z.object({ name: z.string() }),
+        output: z.object({ message: z.string() }),
+        version: 3,
+        versions: {
+          1: {
+            input: z.object({ firstName: z.string(), legacyId: z.string() }),
+            output: z.object({ message: z.string() }),
+            status: { state: 'archived' },
+            transpose: {
+              input: ({ input }) => ({ name: input.firstName }),
+              output: ({ output }) => output,
+            },
+          },
+          2: {
+            input: z.object({ firstName: z.string() }),
+            output: z.object({ message: z.string() }),
+            status: { note: 'Use name.', state: 'deprecated' },
+            transpose: {
+              input: ({ input }) => ({ name: input.firstName }),
+              output: ({ output }) => output,
+            },
+          },
+        },
+      });
+      const tool = requireOnlyTool(buildTools(topo('myapp', { versioned })));
+
+      expect(tool.inputSchema).toMatchObject({
+        properties: {
+          trailVersion: { type: 'string' },
+        },
+      });
+      expect(tool.versions?.map((entry) => entry.version)).toEqual([2, 3]);
+
+      const result = await tool.handler(
+        { firstName: 'Ada', trailVersion: '2' },
+        noExtra
+      );
+
+      expect(result?.isError).toBeUndefined();
+      expect(result?.structuredContent).toEqual({ message: 'Hello, Ada!' });
+    });
+
     test('handler wraps non-object outputs as structured content data', async () => {
       const listTrail = trail('items.list', {
         blaze: () => Result.ok(['one', 'two']),

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -11,6 +11,7 @@ import {
   Result,
   ValidationError,
   collectAttachedTypedLayers,
+  deriveSurfaceTrailVersionProjections,
   deriveStructuredTrailExamples,
   executeTrail,
   filterSurfaceTrails,
@@ -32,9 +33,11 @@ import type {
   Layer,
   ResourceOverrideMap,
   SurfaceErrorProjection,
+  SurfaceTrailVersionProjection,
   Topo,
   Trail,
   TrailContextInit,
+  TrailVersionReference,
 } from '@ontrails/core';
 
 import type { McpAnnotations } from './annotations.js';
@@ -84,6 +87,7 @@ export interface McpToolDefinition {
   readonly outputSchema?: Record<string, unknown> | undefined;
   /** The trail ID this tool was derived from. */
   readonly trailId: string;
+  readonly versions?: readonly SurfaceTrailVersionProjection[] | undefined;
 }
 
 export interface McpExtra {
@@ -602,6 +606,48 @@ const projectMcpInputSchema = (
   return { projections, schema: mergedSchema };
 };
 
+const TRAIL_VERSION_PARAM = 'trailVersion';
+
+const addMcpVersionInputSchema = (
+  trail: Trail<unknown, unknown, unknown>,
+  schema: Record<string, unknown>
+): Record<string, unknown> => {
+  if (trail.version === undefined) {
+    return schema;
+  }
+  const properties =
+    isJsonObjectSchema(schema) && schema.properties !== undefined
+      ? schema.properties
+      : undefined;
+  return {
+    ...schema,
+    properties: {
+      ...properties,
+      [TRAIL_VERSION_PARAM]: {
+        description: 'Live trail version number or marker prefix',
+        type: 'string',
+      },
+    },
+    type: 'object',
+  };
+};
+
+const splitMcpSurfaceVersion = (
+  args: Record<string, unknown>
+): {
+  readonly args: Record<string, unknown>;
+  readonly version: TrailVersionReference | undefined;
+} => {
+  const { [TRAIL_VERSION_PARAM]: rawVersion, ...rest } = args;
+  return {
+    args: rest,
+    version:
+      typeof rawVersion === 'string' || typeof rawVersion === 'number'
+        ? rawVersion
+        : undefined,
+  };
+};
+
 /**
  * Partition a parsed MCP `args` record into the trail input plus per-layer
  * inputs, using each layer's routing table.
@@ -750,8 +796,12 @@ const createHandler =
   ) => Promise<McpToolResult>) =>
   async (args, extra): Promise<McpToolResult> => {
     const progressCb = createMcpProgressCallback(extra);
+    const versionedArgs =
+      t.version === undefined
+        ? { args, version: undefined }
+        : splitMcpSurfaceVersion(args);
     const { trailInput, layerInputs } = partitionMcpArgs(
-      args,
+      versionedArgs.args,
       layerProjections
     );
     const permitResolution = await resolveMcpPermit(options, extra);
@@ -770,6 +820,9 @@ const createHandler =
       surfaceLayers: layers,
       topo: graph,
       topoLayers: graph.layers,
+      ...(versionedArgs.version === undefined
+        ? {}
+        : { version: versionedArgs.version }),
     });
     if (result.isOk()) {
       return {
@@ -867,6 +920,8 @@ const buildToolDefinition = (
     options.layers
   );
   const inputProjection = projectMcpInputSchema(trail, attachedLayers);
+  const inputSchema = addMcpVersionInputSchema(trail, inputProjection.schema);
+  const versions = deriveSurfaceTrailVersionProjections(trail);
   return {
     _meta: buildMeta(trail),
     annotations,
@@ -879,10 +934,11 @@ const buildToolDefinition = (
       projection?.wrapAsData ?? false,
       inputProjection.projections
     ),
-    inputSchema: inputProjection.schema,
+    inputSchema,
     name: deriveToolName(graph.name, trail.id),
     outputSchema: projection?.schema,
     trailId: trail.id,
+    ...(versions === undefined ? {} : { versions }),
   };
 };
 


### PR DESCRIPTION
## Context

This branch wires Trail Versioning into shipped runtime surfaces so clients can request a live historical version consistently across CLI, HTTP, and MCP. No WebSocket package is currently shipped in this repo, so the implementation covers the real surfaces present here.

Linear: TRL-118
Stack: 6/8, on top of TRL-730.

## What changed

- Added shared core helpers for live surface version projections.
- Exposed live version metadata from CLI, HTTP, and MCP derived definitions.
- Added CLI `--trail-version` and passed it through to `executeTrail`.
- Added HTTP `trailVersion` input plus `X-Trails-Version` / `X-Trail-Version` request headers.
- Added MCP `trailVersion` input support.
- Kept archived versions excluded from projected live surface metadata while deprecated versions remain visible with status guidance.
- Added branch-local changesets for core/CLI/HTTP/MCP changes.

## Verification

- `bun test packages/cli/src/__tests__/build.test.ts packages/http/src/__tests__/build.test.ts packages/mcp/src/__tests__/build.test.ts packages/core/src/__tests__/version-execution.test.ts` (211 pass)
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/http typecheck`
- `bun run --cwd packages/mcp typecheck`
- Stack-tip gates later passed: ADR check, typecheck, test, lint, ast-grep, build, format, check, publish dry-run, Warden guide checks, `git diff --check`.

## Risks / notes

Unsupported or archived version requests continue through core `VersionNotSupportedError` behavior; reviewers should check the surface-specific plumbing and metadata projection.