### PR TITLE
feat(trails): add version lifecycle commands

### DIFF
--- a/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
+++ b/.agents/plans/2026-05-20-trail-versioning-m3-closeout/RETRO.md
@@ -33,8 +33,8 @@ handoff. Meaningful review-flow changes require a new retro entry.
 | 3 | TRL-731 | `trl-731-featcore-add-archive-status-lifecycle-for-version-entries` | Pending | Planned | Archive status lifecycle |
 | 4 | TRL-732 | `trl-732-feattrails-add-compilevalidate-break-detection-and-force` | Pending | Planned | Break classifier and graph-only force events |
 | 5 | TRL-730 | `trl-730-feattrails-add-version-and-marker-aware-trails-diff` | Pending | Planned | Version-aware `trails diff` |
-| 6 | TRL-118 | `trl-118-project-version-negotiation-across-http-mcp-cli-and` | Pending | Planned | Surface version negotiation |
-| 7 | TRL-119 | `trl-119-add-cli-lifecycle-commands-revise-deprecate-and-doctor` | Pending | Planned | CLI lifecycle commands |
+| 6 | TRL-118 | `trl-118-project-version-negotiation-across-http-mcp-cli-and` | Pending | Implemented locally | Surface version negotiation committed as `ecebbd416` |
+| 7 | TRL-119 | `trl-119-add-cli-lifecycle-commands-revise-deprecate-and-doctor` | Pending | Implemented locally | CLI lifecycle commands ready to commit |
 | 8 | TRL-120 | `trl-120-add-warden-rules-for-trail-version-entries-and-markers` | Pending | Planned | Warden capstone |
 
 ## Planning Discoveries
@@ -140,6 +140,16 @@ Append meaningful state changes, especially before handoff points.
 - Result: TRL-118 local surface negotiation is implemented for shipped surfaces. Remaining branch-local checks still need formatting, `git diff --check`, and commit-hook validation before committing.
 - Next: Run branch formatting/whitespace checks, commit TRL-118, restack upward, then implement lifecycle CLI commands in TRL-119.
 - Blockers: None.
+
+2026-05-20 10:43 EDT - TRL-119 lifecycle CLI commands
+- Changed: Committed TRL-118 as `ecebbd416 feat(surfaces): negotiate trail versions`; Graphite restacked the descendant branches.
+- Changed: Implemented TRL-119 on `trl-119-add-cli-lifecycle-commands-revise-deprecate-and-doctor`: added `trails revise`, `trails deprecate`, and `trails doctor`; registered them in the Trails app; added source lifecycle rewrite helpers; added a local lifecycle source IO boundary; documented the settled command grammar; and added a branch-local changeset.
+- Changed: `trails revise <trail>` scaffolds a revision entry and bumps current `version`; `trails revise <trail> --as fork` scaffolds a fork entry; `trails revise <trail>@<v> --as fork` upgrades an existing historical entry into a fork placeholder; `trails deprecate <trail>@<v>` writes deprecated status guidance; `trails deprecate <trail>@<v> --archive` writes archived status; `trails doctor` summarizes lifecycle counts and force-event audit state.
+- Verified: Focused lifecycle/survey tests passed: `bun test apps/trails/src/__tests__/version-lifecycle.test.ts apps/trails/src/__tests__/survey.test.ts` (57 pass).
+- Verified: `bun run --cwd apps/trails typecheck`, `bun run --cwd apps/trails lint`, and `git diff --check` passed; the lint run reported 0 warnings and 0 errors after routing raw source writes through `lifecycle-source-io.ts`.
+- Result: TRL-119 local lifecycle CLI commands are implemented and ready to commit. The command set intentionally does not add `trails version`, `trails sunset`, `trails mark`, `trails fork`, or `trails archive`.
+- Next: Commit TRL-119, restack upward, then implement Warden capstone rules on TRL-120.
+- Blockers: None.
 ```
 
 ## Local Review Log
@@ -180,6 +190,9 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun run --cwd packages/cli typecheck` | TRL-118 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run --cwd packages/http typecheck` | TRL-118 targeted typecheck | Passed | `tsc --noEmit` passed. |
 | `bun run --cwd packages/mcp typecheck` | TRL-118 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun test apps/trails/src/__tests__/version-lifecycle.test.ts apps/trails/src/__tests__/survey.test.ts` | TRL-119 targeted tests | Passed | 57 pass, 0 fail. |
+| `bun run --cwd apps/trails typecheck` | TRL-119 targeted typecheck | Passed | `tsc --noEmit` passed. |
+| `bun run --cwd apps/trails lint` | TRL-119 targeted lint | Passed | 0 warnings, 0 errors. |
 | `bun run check` | Execution tip | Pending | Required by goal. |
 | `bun run build` | Execution tip | Pending | Required by goal. |
 | `bun run test` | Execution tip | Pending | Required by goal. |

--- a/.changeset/trl-119-lifecycle-cli.md
+++ b/.changeset/trl-119-lifecycle-cli.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Add version lifecycle CLI trails for revising, deprecating, archiving, and diagnosing trail version entries.

--- a/apps/trails/src/__tests__/version-lifecycle.test.ts
+++ b/apps/trails/src/__tests__/version-lifecycle.test.ts
@@ -1,0 +1,540 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { deriveCliCommands } from '@ontrails/cli';
+
+import { app } from '../app.js';
+import {
+  readLifecycleSourceFile,
+  writeLifecycleSourceFile,
+} from '../lifecycle-source-io.js';
+import { deprecateTrail } from '../trails/deprecate.js';
+import { doctorTrail } from '../trails/doctor.js';
+import { reviseTrail } from '../trails/revise.js';
+
+const repoTempDir = (): string =>
+  mkdtempSync(join(resolve('.'), '.trails-life-'));
+
+const writeLifecycleFixture = (
+  dir: string,
+  options?: {
+    readonly nestedOutputField?: boolean;
+    readonly nestedTemplateBlaze?: boolean;
+  }
+): void => {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  const dollar = String.fromCodePoint(36);
+  const inputNameInterpolation = `${dollar}{input.name}`;
+  const input = options?.nestedOutputField
+    ? `z.object({
+    output: z.string(),
+    name: z.string(),
+  })`
+    : 'z.object({ name: z.string() })';
+  const blaze = options?.nestedTemplateBlaze
+    ? `async (input) => {
+    const nested = \`\${\`\${input.name}\`}\`;
+    return Result.ok({ message: \`Hello, \${nested}!\` });
+  }`
+    : `async (input) => Result.ok({ message: \`Hello, ${inputNameInterpolation}!\` })`;
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    `import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const hello = trail('hello', {
+  blaze: ${blaze},
+  input: ${input},
+  output: z.object({ message: z.string() }),
+});
+
+export const app = topo('life-fixture', { hello });
+`
+  );
+};
+
+const writeLifecycleNumericVersionKeyFixture = (dir: string): void => {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    `import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const hello = trail('hello', {
+  blaze: async (input) => Result.ok({ message: \`Hello, \${input.name}!\` }),
+  version: 3,
+  input: z.object({ name: z.string() }),
+  output: z.object({ message: z.string() }),
+  versions: {
+    1: {
+      input: z.object({
+        2: z.string().optional(),
+        name: z.string(),
+      }),
+      output: z.object({ message: z.string() }),
+      transpose: {
+        input: ({ input }) => input,
+        output: ({ output }) => output,
+      },
+    },
+    2: {
+      input: z.object({ name: z.string() }),
+      output: z.object({ message: z.string() }),
+      transpose: {
+        input: ({ input }) => input,
+        output: ({ output }) => output,
+      },
+    },
+  },
+});
+
+export const app = topo('life-fixture', { hello });
+`
+  );
+};
+
+const writeLifecycleLastVersionNoTrailingCommaFixture = (dir: string): void => {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    `import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const hello = trail('hello', {
+  blaze: async (input) => Result.ok({ message: \`Hello, \${input.name}!\` }),
+  version: 2,
+  input: z.object({ name: z.string() }),
+  output: z.object({ message: z.string() }),
+  versions: {
+    1: {
+      input: z.object({ name: z.string() }),
+      output: z.object({ message: z.string() }),
+      transpose: {
+        input: ({ input }) => input,
+        output: ({ output }) => output,
+      },
+    }
+  },
+});
+
+export const app = topo('life-fixture', { hello });
+`
+  );
+};
+
+const writeLifecycleNoResultFixture = (dir: string): void => {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    `import { topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const hello = trail('hello', {
+  blaze: async () => ({ ok: true }) as never,
+  version: 2,
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  versions: {
+    1: {
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      transpose: {
+        input: ({ input }) => input,
+        output: ({ output }) => output,
+      },
+    },
+  },
+});
+
+export const app = topo('life-fixture', { hello });
+`
+  );
+};
+
+const writeLifecycleResultImportShapeFixture = (
+  dir: string,
+  coreImport: string
+): void => {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    `${coreImport}
+import { z } from 'zod';
+
+const hello = trail('hello', {
+  blaze: async () => ({ ok: true }) as never,
+  version: 2,
+  input: z.object({}),
+  output: z.object({ ok: z.boolean() }),
+  versions: {
+    1: {
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      transpose: {
+        input: ({ input }) => input,
+        output: ({ output }) => output,
+      },
+    },
+  },
+});
+
+export const app = topo('life-fixture', { hello });
+`
+  );
+};
+
+const lifecycleCommand = (path: string) => {
+  const commands = deriveCliCommands(app);
+  if (commands.isErr()) {
+    throw commands.error;
+  }
+  const command = commands.value.find(
+    (candidate) => candidate.path.join(' ') === path
+  );
+  if (command === undefined) {
+    throw new Error(`Expected lifecycle command: ${path}`);
+  }
+  return command;
+};
+
+describe('trails lifecycle commands', () => {
+  test('project the settled lifecycle CLI grammar', () => {
+    const revise = lifecycleCommand('revise');
+    const deprecate = lifecycleCommand('deprecate');
+    const doctor = lifecycleCommand('doctor');
+
+    expect(revise.args.map((arg) => arg.name)).toEqual(['target']);
+    expect(revise.flags.map((flag) => flag.name)).toContain('as');
+    expect(deprecate.args.map((arg) => arg.name)).toEqual(['target']);
+    expect(deprecate.flags.map((flag) => flag.name)).toContain('archive');
+    expect(doctor.args).toEqual([]);
+
+    const paths = deriveCliCommands(app);
+    if (paths.isErr()) {
+      throw paths.error;
+    }
+    expect(paths.value.map((command) => command.path.join(' '))).not.toEqual(
+      expect.arrayContaining(['version', 'sunset', 'mark', 'fork', 'archive'])
+    );
+  });
+
+  test('revise scaffolds a historical version and deprecate sets status', async () => {
+    const dir = repoTempDir();
+    try {
+      writeLifecycleFixture(dir);
+
+      const revised = await reviseTrail.blaze(
+        { module: './src/app.ts', target: 'hello' },
+        { cwd: dir } as never
+      );
+
+      if (revised.isErr()) {
+        throw revised.error;
+      }
+      let source = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
+      expect(source).toContain('version: 2');
+      expect(source).toContain('versions: {');
+      expect(source).toContain('1: {');
+      expect(source).toContain('transpose: {');
+
+      const deprecated = await deprecateTrail.blaze(
+        {
+          module: './src/app.ts',
+          note: 'Use v2.',
+          successor: 2,
+          target: 'hello@1',
+        },
+        { cwd: dir } as never
+      );
+
+      if (deprecated.isErr()) {
+        throw deprecated.error;
+      }
+      source = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
+      expect(source).toContain(
+        '      status: { state: \'deprecated\', successor: 2, note: "Use v2." }'
+      );
+      expect(source).not.toMatch(/^status:/m);
+
+      const alreadyDeprecated = await deprecateTrail.blaze(
+        {
+          module: './src/app.ts',
+          note: 'Use v2.',
+          successor: 2,
+          target: 'hello@1',
+        },
+        { cwd: dir } as never
+      );
+
+      if (alreadyDeprecated.isErr()) {
+        throw alreadyDeprecated.error;
+      }
+      expect(alreadyDeprecated.value.updated).toBe(false);
+
+      const forked = await reviseTrail.blaze(
+        { as: 'fork', module: './src/app.ts', target: 'hello@1' },
+        { cwd: dir } as never
+      );
+
+      if (forked.isErr()) {
+        throw forked.error;
+      }
+      expect(forked.value.updated).toBe(true);
+      source = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
+      expect(source).toContain('      blaze: async () => Result.err');
+      expect(source).not.toMatch(/^blaze:/m);
+      expect(source).not.toContain('transpose: {');
+
+      const alreadyForked = await reviseTrail.blaze(
+        { as: 'fork', module: './src/app.ts', target: 'hello@1' },
+        { cwd: dir } as never
+      );
+
+      if (alreadyForked.isErr()) {
+        throw alreadyForked.error;
+      }
+      expect(alreadyForked.value.updated).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('revise preserves blaze values with nested template literals', async () => {
+    const dir = repoTempDir();
+    try {
+      writeLifecycleFixture(dir, { nestedTemplateBlaze: true });
+
+      const revised = await reviseTrail.blaze(
+        { as: 'fork', module: './src/app.ts', target: 'hello' },
+        { cwd: dir } as never
+      );
+
+      if (revised.isErr()) {
+        throw revised.error;
+      }
+      const source = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
+      const dollar = String.fromCodePoint(36);
+      const nestedTemplateSnippet = `const nested = \`${dollar}{\`${dollar}{input.name}\`}\`;`;
+      expect(source).toContain(nestedTemplateSnippet);
+      expect(source).toContain('version: 2');
+      expect(source).toContain('1: {');
+      expect(source).toContain('blaze: async (input) => {');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('revise reads top-level config keys when schemas reuse key names', async () => {
+    const dir = repoTempDir();
+    try {
+      writeLifecycleFixture(dir, { nestedOutputField: true });
+
+      const revised = await reviseTrail.blaze(
+        { module: './src/app.ts', target: 'hello' },
+        { cwd: dir } as never
+      );
+
+      if (revised.isErr()) {
+        throw revised.error;
+      }
+      const source = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
+      expect(source).toContain('version: 2');
+      expect(source).toContain('input: z.object({');
+      expect(source).toContain('output: z.string()');
+      expect(source).toContain(
+        '      output: z.object({ message: z.string() }),'
+      );
+      expect(source).not.toContain('      output: z.string(),');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('deprecate reads top-level version entries when schemas reuse numeric keys', async () => {
+    const dir = repoTempDir();
+    try {
+      writeLifecycleNumericVersionKeyFixture(dir);
+
+      const deprecated = await deprecateTrail.blaze(
+        {
+          module: './src/app.ts',
+          note: 'Use v3.',
+          successor: 3,
+          target: 'hello@2',
+        },
+        { cwd: dir } as never
+      );
+
+      if (deprecated.isErr()) {
+        throw deprecated.error;
+      }
+      const source = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
+      expect(source).toContain('        2: z.string().optional(),');
+      expect(source).toContain(`    2: {
+      input: z.object({ name: z.string() }),
+      output: z.object({ message: z.string() }),
+      transpose: {
+        input: ({ input }) => input,
+        output: ({ output }) => output,
+      },
+      status: { state: 'deprecated', successor: 3, note: "Use v3." },
+    },`);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('deprecate preserves comma-free last version entry boundaries', async () => {
+    const dir = repoTempDir();
+    try {
+      writeLifecycleLastVersionNoTrailingCommaFixture(dir);
+
+      const deprecated = await deprecateTrail.blaze(
+        {
+          module: './src/app.ts',
+          note: 'Use v2.',
+          successor: 2,
+          target: 'hello@1',
+        },
+        { cwd: dir } as never
+      );
+
+      if (deprecated.isErr()) {
+        throw deprecated.error;
+      }
+      const source = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
+      expect(source)
+        .toContain(`      status: { state: 'deprecated', successor: 2, note: "Use v2." },
+    }
+  },`);
+      expect(source).not.toContain(`  }
+      status:`);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('fork warns when the placeholder needs an unimported Result binding', async () => {
+    const dir = repoTempDir();
+    try {
+      writeLifecycleNoResultFixture(dir);
+
+      const forked = await reviseTrail.blaze(
+        { as: 'fork', module: './src/app.ts', target: 'hello@1' },
+        { cwd: dir } as never
+      );
+
+      if (forked.isErr()) {
+        throw forked.error;
+      }
+      expect(forked.value.updated).toBe(true);
+      expect(forked.value.warnings).toEqual([
+        'Fork blaze placeholder references Result.err, but this file does not import Result from @ontrails/core.',
+      ]);
+      const source = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
+      expect(source).toContain('      blaze: async () => Result.err');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('fork warns when Result is type-only or aliased', async () => {
+    const cases = [
+      {
+        coreImport: `import type { Result } from '@ontrails/core';
+import { topo, trail } from '@ontrails/core';`,
+        name: 'type-only Result import',
+      },
+      {
+        coreImport:
+          "import { Result as R, topo, trail } from '@ontrails/core';",
+        name: 'aliased Result import',
+      },
+    ];
+
+    for (const fixture of cases) {
+      const dir = repoTempDir();
+      try {
+        writeLifecycleResultImportShapeFixture(dir, fixture.coreImport);
+
+        const forked = await reviseTrail.blaze(
+          { as: 'fork', module: './src/app.ts', target: 'hello@1' },
+          { cwd: dir } as never
+        );
+
+        if (forked.isErr()) {
+          throw new Error(`${fixture.name}: ${forked.error.message}`);
+        }
+        expect(forked.value.warnings).toEqual([
+          'Fork blaze placeholder references Result.err, but this file does not import Result from @ontrails/core.',
+        ]);
+      } finally {
+        rmSync(dir, { force: true, recursive: true });
+      }
+    }
+  });
+
+  test('source write failures return Result errors', () => {
+    const dir = repoTempDir();
+    try {
+      const result = writeLifecycleSourceFile(
+        join(dir, 'missing', 'app.ts'),
+        ''
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(Error);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('source read failures return Result errors', () => {
+    const dir = repoTempDir();
+    try {
+      const result = readLifecycleSourceFile(join(dir, 'missing', 'app.ts'));
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBeInstanceOf(Error);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('doctor reports version lifecycle counts', async () => {
+    const dir = repoTempDir();
+    try {
+      writeLifecycleFixture(dir);
+      await reviseTrail.blaze({ module: './src/app.ts', target: 'hello' }, {
+        cwd: dir,
+      } as never);
+      await deprecateTrail.blaze(
+        { archive: true, module: './src/app.ts', target: 'hello@1' },
+        { cwd: dir } as never
+      );
+
+      const doctor = await doctorTrail.blaze({ module: './src/app.ts' }, {
+        cwd: dir,
+      } as never);
+
+      if (doctor.isErr()) {
+        throw doctor.error;
+      }
+      expect(doctor.value).toMatchObject({
+        archived: 1,
+        mode: 'doctor',
+        trails: 1,
+        versioned: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -8,11 +8,14 @@ import * as completions from './trails/completions.js';
 import * as completionsComplete from './trails/completions-complete.js';
 import * as create from './trails/create.js';
 import * as createScaffold from './trails/create-scaffold.js';
+import * as deprecate from './trails/deprecate.js';
 import * as devClean from './trails/dev-clean.js';
 import * as devReset from './trails/dev-reset.js';
 import * as devStats from './trails/dev-stats.js';
+import * as doctor from './trails/doctor.js';
 import * as draftPromote from './trails/draft-promote.js';
 import * as guide from './trails/guide.js';
+import * as revise from './trails/revise.js';
 import * as run from './trails/run.js';
 import * as runExample from './trails/run-example.js';
 import * as runExamples from './trails/run-examples.js';
@@ -37,6 +40,9 @@ export const app = topo(
   topoPin,
   topoUnpin,
   validate,
+  revise,
+  deprecate,
+  doctor,
   devStats,
   devClean,
   devReset,

--- a/apps/trails/src/lifecycle-source-io.ts
+++ b/apps/trails/src/lifecycle-source-io.ts
@@ -1,0 +1,33 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+import { InternalError, Result } from '@ontrails/core';
+
+export const readLifecycleSourceFile = (
+  filePath: string
+): Result<string, Error> => {
+  try {
+    return Result.ok(readFileSync(filePath, 'utf8'));
+  } catch (error: unknown) {
+    return Result.err(
+      error instanceof Error
+        ? error
+        : new InternalError(`Unable to read lifecycle source file ${filePath}`)
+    );
+  }
+};
+
+export const writeLifecycleSourceFile = (
+  filePath: string,
+  source: string
+): Result<void, Error> => {
+  try {
+    writeFileSync(filePath, source);
+    return Result.ok();
+  } catch (error: unknown) {
+    return Result.err(
+      error instanceof Error
+        ? error
+        : new InternalError(`Unable to write lifecycle source file ${filePath}`)
+    );
+  }
+};

--- a/apps/trails/src/trails/deprecate.ts
+++ b/apps/trails/src/trails/deprecate.ts
@@ -1,0 +1,58 @@
+import { trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  parseLifecycleTarget,
+  setVersionStatusSource,
+  withLifecycleApp,
+} from './version-lifecycle-support.js';
+
+export const deprecateTrail = trail('deprecate', {
+  args: ['target'],
+  blaze: async (input, ctx) =>
+    withLifecycleApp(input, ctx.cwd, async (_app, rootDir) => {
+      const target = parseLifecycleTarget(input.target);
+      if (target.isErr()) {
+        return target;
+      }
+      return setVersionStatusSource(
+        rootDir,
+        target.value,
+        input.archive ? 'archived' : 'deprecated',
+        {
+          migration: input.migration,
+          note: input.note,
+          reason: input.reason,
+          successor: input.successor,
+        }
+      );
+    }),
+  description: 'Mark a historical trail version deprecated or archived',
+  input: z.object({
+    archive: z
+      .boolean()
+      .default(false)
+      .describe('Archive instead of deprecate'),
+    migration: z
+      .array(z.string())
+      .default([])
+      .describe('Migration guidance entries'),
+    module: z.string().optional().describe('Path to the app module'),
+    note: z.string().optional().describe('Deprecation note'),
+    reason: z.string().optional().describe('Archive reason'),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+    successor: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe('Successor version'),
+    target: z.string().min(1).describe('Historical version target trail.id@N'),
+  }),
+  intent: 'write',
+  output: z.object({
+    file: z.string(),
+    trailId: z.string(),
+    updated: z.boolean(),
+  }),
+});

--- a/apps/trails/src/trails/doctor.ts
+++ b/apps/trails/src/trails/doctor.ts
@@ -1,0 +1,28 @@
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  deriveDoctorSummary,
+  withLifecycleApp,
+} from './version-lifecycle-support.js';
+
+export const doctorTrail = trail('doctor', {
+  blaze: async (input, ctx) =>
+    withLifecycleApp(input, ctx.cwd, async (app) =>
+      Result.ok(deriveDoctorSummary(app))
+    ),
+  description: 'Diagnose trail versioning lifecycle state',
+  input: z.object({
+    module: z.string().optional().describe('Path to the app module'),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+  }),
+  intent: 'read',
+  output: z.object({
+    archived: z.number(),
+    deprecated: z.number(),
+    forceEvents: z.number(),
+    mode: z.literal('doctor'),
+    trails: z.number(),
+    versioned: z.number(),
+  }),
+});

--- a/apps/trails/src/trails/revise.ts
+++ b/apps/trails/src/trails/revise.ts
@@ -1,0 +1,52 @@
+import { Result, ValidationError, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  findLifecycleTrail,
+  forkVersionEntrySource,
+  parseLifecycleTarget,
+  reviseTrailSource,
+  withLifecycleApp,
+} from './version-lifecycle-support.js';
+
+export const reviseTrail = trail('revise', {
+  args: ['target'],
+  blaze: async (input, ctx) =>
+    withLifecycleApp(input, ctx.cwd, async (app, rootDir) => {
+      const target = parseLifecycleTarget(input.target);
+      if (target.isErr()) {
+        return target;
+      }
+      if (target.value.version !== undefined) {
+        return input.as === 'fork'
+          ? forkVersionEntrySource(rootDir, target.value)
+          : Result.err(
+              new ValidationError(
+                'Revising a specific historical entry requires --as fork'
+              )
+            );
+      }
+      const found = findLifecycleTrail(app, target.value.trailId);
+      if (found.isErr()) {
+        return found;
+      }
+      return reviseTrailSource(rootDir, found.value, input.as);
+    }),
+  description: 'Scaffold the next trail version entry',
+  input: z.object({
+    as: z
+      .enum(['revision', 'fork'])
+      .default('revision')
+      .describe('Version entry shape to scaffold'),
+    module: z.string().optional().describe('Path to the app module'),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+    target: z.string().min(1).describe('Trail target, optionally trail.id@N'),
+  }),
+  intent: 'write',
+  output: z.object({
+    file: z.string(),
+    trailId: z.string(),
+    updated: z.boolean(),
+    warnings: z.array(z.string()).optional(),
+  }),
+});

--- a/apps/trails/src/trails/version-lifecycle-support.ts
+++ b/apps/trails/src/trails/version-lifecycle-support.ts
@@ -1,0 +1,865 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { Result, ValidationError } from '@ontrails/core';
+import type { AnyTrail, Topo } from '@ontrails/core';
+import { deriveTopoGraph } from '@ontrails/topographer';
+import { findTrailDefinitions, parse } from '@ontrails/warden/ast';
+
+import { tryLoadFreshAppLease } from './load-app.js';
+import {
+  readLifecycleSourceFile,
+  writeLifecycleSourceFile,
+} from '../lifecycle-source-io.js';
+import { resolveTrailRootDir } from './root-dir.js';
+
+export type LifecycleEntryKind = 'revision' | 'fork';
+export type LifecycleStatusKind = 'deprecated' | 'archived';
+
+export interface LifecycleCommandInput {
+  readonly module?: string | undefined;
+  readonly rootDir?: string | undefined;
+  readonly target?: string | undefined;
+}
+
+export interface LifecycleWriteResult {
+  readonly file: string;
+  readonly trailId: string;
+  readonly updated: boolean;
+  readonly warnings?: readonly string[] | undefined;
+}
+
+interface TrailSourceMatch {
+  readonly configEnd: number;
+  readonly configStart: number;
+  readonly filePath: string;
+  readonly source: string;
+}
+
+interface PropertyMatch {
+  readonly end: number;
+  readonly key: string;
+  readonly start: number;
+  readonly value: string;
+  readonly valueEnd: number;
+  readonly valueStart: number;
+}
+
+interface ParsedVersionTarget {
+  readonly trailId: string;
+  readonly version?: number | undefined;
+}
+
+const managedSourceGlob = new Bun.Glob('src/**/*.ts');
+
+const literal = (value: string): string => JSON.stringify(value);
+
+const parseVersionTarget = (
+  target: string
+): Result<ParsedVersionTarget, Error> => {
+  const separator = target.lastIndexOf('@');
+  if (separator === -1) {
+    return Result.ok({ trailId: target });
+  }
+  const trailId = target.slice(0, separator);
+  const rawVersion = target.slice(separator + 1);
+  const version = Number(rawVersion);
+  if (
+    trailId.length === 0 ||
+    !Number.isInteger(version) ||
+    version < 1 ||
+    String(version) !== rawVersion
+  ) {
+    return Result.err(
+      new ValidationError('Version target must use trail.id@positiveInteger')
+    );
+  }
+  return Result.ok({ trailId, version });
+};
+
+const scanManagedSourceFiles = (rootDir: string): readonly string[] =>
+  [...managedSourceGlob.scanSync({ cwd: rootDir, onlyFiles: true })]
+    .map((path) => join(rootDir, path))
+    .toSorted();
+
+const findTrailSource = (
+  rootDir: string,
+  trailId: string
+): Result<TrailSourceMatch, Error> => {
+  for (const filePath of scanManagedSourceFiles(rootDir)) {
+    if (!existsSync(filePath)) {
+      continue;
+    }
+    const source = readLifecycleSourceFile(filePath);
+    if (source.isErr()) {
+      return source;
+    }
+    if (!source.value.includes(trailId)) {
+      continue;
+    }
+    const ast = parse(filePath, source.value);
+    if (!ast) {
+      continue;
+    }
+    const match = findTrailDefinitions(ast).find(
+      (definition) => definition.kind === 'trail' && definition.id === trailId
+    );
+    if (match !== undefined) {
+      return Result.ok({
+        configEnd: match.config.end,
+        configStart: match.config.start,
+        filePath,
+        source: source.value,
+      });
+    }
+  }
+
+  return Result.err(
+    new ValidationError(`Could not find source trail definition for ${trailId}`)
+  );
+};
+
+const isWhitespace = (ch: string | undefined): boolean =>
+  ch === ' ' || ch === '\n' || ch === '\r' || ch === '\t';
+
+const scanPropertyValueEnd = (
+  source: string,
+  start: number,
+  end: number
+): number => {
+  const state: {
+    depth: number;
+    escaped: boolean;
+    quote: '"' | "'" | undefined;
+    skipNext: boolean;
+    templateStack: number[];
+  } = {
+    depth: 0,
+    escaped: false,
+    quote: undefined,
+    skipNext: false,
+    templateStack: [],
+  };
+  const currentTemplateDepth = (): number | undefined =>
+    state.templateStack.length === 0 ? undefined : state.templateStack.at(-1);
+  const consumeQuoted = (ch: string | undefined): boolean => {
+    if (state.quote === undefined) {
+      return false;
+    }
+    if (state.escaped) {
+      state.escaped = false;
+    } else if (ch === '\\') {
+      state.escaped = true;
+    } else if (ch === state.quote) {
+      state.quote = undefined;
+    }
+    return true;
+  };
+  const consumeTemplateText = (
+    ch: string | undefined,
+    next: string | undefined
+  ): boolean => {
+    if (currentTemplateDepth() !== 0) {
+      return false;
+    }
+    if (state.escaped) {
+      state.escaped = false;
+    } else if (ch === '\\') {
+      state.escaped = true;
+    } else if (ch === '`') {
+      state.templateStack.pop();
+    } else if (ch === '$' && next === '{') {
+      state.templateStack[state.templateStack.length - 1] = 1;
+      state.depth += 1;
+      state.skipNext = true;
+    }
+    return true;
+  };
+  const consumeOpen = (ch: string | undefined): boolean => {
+    if (ch !== '(' && ch !== '{' && ch !== '[') {
+      return false;
+    }
+    const templateDepth = currentTemplateDepth();
+    state.depth += 1;
+    if (templateDepth !== undefined && ch === '{') {
+      state.templateStack[state.templateStack.length - 1] = templateDepth + 1;
+    }
+    return true;
+  };
+  const consumeClose = (ch: string | undefined): boolean => {
+    if (ch !== ')' && ch !== '}' && ch !== ']') {
+      return false;
+    }
+    const templateDepth = currentTemplateDepth();
+    state.depth -= 1;
+    if (templateDepth !== undefined && ch === '}') {
+      state.templateStack[state.templateStack.length - 1] = templateDepth - 1;
+    }
+    return true;
+  };
+
+  for (let index = start; index < end; index += 1) {
+    const ch = source[index];
+    if (consumeQuoted(ch) || consumeTemplateText(ch, source[index + 1])) {
+      if (state.skipNext) {
+        state.skipNext = false;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      state.quote = ch;
+      continue;
+    }
+    if (ch === '`') {
+      state.templateStack.push(0);
+      continue;
+    }
+    if (consumeOpen(ch)) {
+      continue;
+    }
+    if (ch === ')' || ch === '}' || ch === ']') {
+      if (state.depth === 0) {
+        return index;
+      }
+      consumeClose(ch);
+      continue;
+    }
+    if (ch === ',' && state.depth === 0) {
+      return index;
+    }
+  }
+  let valueEnd = end;
+  while (valueEnd > start && isWhitespace(source[valueEnd - 1])) {
+    valueEnd -= 1;
+  }
+  return valueEnd;
+};
+
+const skipIgnored = (source: string, start: number, end: number): number => {
+  let index = start;
+  while (index < end) {
+    const ch = source[index];
+    if (isWhitespace(ch)) {
+      index += 1;
+      continue;
+    }
+    if (ch === '/' && source[index + 1] === '/') {
+      const nextLine = source.indexOf('\n', index + 2);
+      index = nextLine === -1 ? end : nextLine + 1;
+      continue;
+    }
+    if (ch === '/' && source[index + 1] === '*') {
+      const commentEnd = source.indexOf('*/', index + 2);
+      index = commentEnd === -1 ? end : commentEnd + 2;
+      continue;
+    }
+    break;
+  }
+  return index;
+};
+
+const isIdentifierStart = (ch: string | undefined): boolean =>
+  ch !== undefined && /^[A-Za-z_$]$/.test(ch);
+
+const isIdentifierPart = (ch: string | undefined): boolean =>
+  ch !== undefined && /^[A-Za-z0-9_$]$/.test(ch);
+
+const readIdentifierKey = (
+  source: string,
+  start: number
+): { readonly key: string; readonly keyEnd: number } | undefined => {
+  if (!isIdentifierStart(source[start])) {
+    return undefined;
+  }
+  let keyEnd = start + 1;
+  while (isIdentifierPart(source[keyEnd])) {
+    keyEnd += 1;
+  }
+  return { key: source.slice(start, keyEnd), keyEnd };
+};
+
+const readQuotedKey = (
+  source: string,
+  start: number,
+  end: number
+): { readonly key: string; readonly keyEnd: number } | undefined => {
+  const quote = source[start];
+  if (quote !== '"' && quote !== "'") {
+    return undefined;
+  }
+  let escaped = false;
+  let key = '';
+  for (let index = start + 1; index < end; index += 1) {
+    const ch = source[index];
+    if (escaped) {
+      key += ch ?? '';
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (ch === quote) {
+      return { key, keyEnd: index + 1 };
+    }
+    key += ch ?? '';
+  }
+  return undefined;
+};
+
+const readNumericKey = (
+  source: string,
+  start: number
+): { readonly key: string; readonly keyEnd: number } | undefined => {
+  if (source[start] === undefined || !/^\d$/.test(source[start] ?? '')) {
+    return undefined;
+  }
+  let keyEnd = start + 1;
+  while (/^\d$/.test(source[keyEnd] ?? '')) {
+    keyEnd += 1;
+  }
+  return { key: source.slice(start, keyEnd), keyEnd };
+};
+
+const readPropertyKey = (
+  source: string,
+  start: number,
+  end: number
+): { readonly key: string; readonly keyEnd: number } | undefined =>
+  readIdentifierKey(source, start) ??
+  readQuotedKey(source, start, end) ??
+  readNumericKey(source, start);
+
+const propertyLineStart = (source: string, keyStart: number): number => {
+  const lineStart = source.lastIndexOf('\n', keyStart) + 1;
+  return source.slice(lineStart, keyStart).trim().length === 0
+    ? lineStart
+    : keyStart;
+};
+
+const findConfigProperty = (
+  match: TrailSourceMatch,
+  key: string
+): PropertyMatch | undefined => {
+  const bodyStart = match.configStart + 1;
+  const bodyEnd =
+    match.source[match.configEnd - 1] === '}'
+      ? match.configEnd - 1
+      : match.configEnd;
+  let index = bodyStart;
+
+  while (index < bodyEnd) {
+    index = skipIgnored(match.source, index, bodyEnd);
+    if (match.source[index] === ',') {
+      index += 1;
+      continue;
+    }
+
+    const keyStart = index;
+    const propertyKey = readPropertyKey(match.source, keyStart, bodyEnd);
+    if (propertyKey === undefined) {
+      const valueEnd = scanPropertyValueEnd(match.source, keyStart, bodyEnd);
+      index = match.source[valueEnd] === ',' ? valueEnd + 1 : valueEnd;
+      continue;
+    }
+
+    const colon = skipIgnored(match.source, propertyKey.keyEnd, bodyEnd);
+    if (match.source[colon] !== ':') {
+      const valueEnd = scanPropertyValueEnd(match.source, keyStart, bodyEnd);
+      index = match.source[valueEnd] === ',' ? valueEnd + 1 : valueEnd;
+      continue;
+    }
+
+    const valueStart = colon + 1;
+    const valueEnd = scanPropertyValueEnd(match.source, valueStart, bodyEnd);
+    if (propertyKey.key === key) {
+      const end = match.source[valueEnd] === ',' ? valueEnd + 1 : valueEnd;
+      return {
+        end,
+        key,
+        start: propertyLineStart(match.source, keyStart),
+        value: match.source.slice(valueStart, valueEnd).trim(),
+        valueEnd,
+        valueStart,
+      };
+    }
+    index = match.source[valueEnd] === ',' ? valueEnd + 1 : valueEnd;
+  }
+
+  return undefined;
+};
+
+const replaceRange = (
+  source: string,
+  start: number,
+  end: number,
+  replacement: string
+): string => `${source.slice(0, start)}${replacement}${source.slice(end)}`;
+
+const coreNamedImportPattern =
+  /import\s+(?<importKind>type\s+)?\{(?<imports>[^}]*)\}\s*from\s*['"]@ontrails\/core['"]/g;
+
+const declaresRuntimeResultBinding = (specifier: string): boolean => {
+  const trimmed = specifier.trim();
+  if (trimmed.startsWith('type ')) {
+    return false;
+  }
+  const [imported, local] = trimmed.split(/\s+as\s+/);
+  return imported === 'Result' && (local === undefined || local === 'Result');
+};
+
+const hasDirectResultImport = (source: string): boolean => {
+  for (const match of source.matchAll(coreNamedImportPattern)) {
+    if (match.groups?.['importKind'] !== undefined) {
+      continue;
+    }
+    const imports = match.groups?.['imports'];
+    if (
+      imports
+        ?.split(',')
+        .some((specifier) => declaresRuntimeResultBinding(specifier)) === true
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const missingResultImportWarning = (source: string): readonly string[] =>
+  hasDirectResultImport(source)
+    ? []
+    : [
+        'Fork blaze placeholder references Result.err, but this file does not import Result from @ontrails/core.',
+      ];
+
+const lineIndentAt = (source: string, index: number): string => {
+  const lineStart = source.lastIndexOf('\n', index) + 1;
+  const nextLine = source.indexOf('\n', lineStart);
+  const lineEnd = nextLine === -1 ? source.length : nextLine;
+  return /^\s*/.exec(source.slice(lineStart, lineEnd))?.[0] ?? '';
+};
+
+const propertyObjectStart = (source: string, entry: PropertyMatch): number => {
+  const start = source.indexOf('{', entry.valueStart);
+  return start === -1 ? entry.valueStart : start;
+};
+
+const propertyObjectCloseLineStart = (
+  source: string,
+  entry: PropertyMatch
+): number => {
+  const close = source.lastIndexOf('}', entry.valueEnd);
+  return source.lastIndexOf('\n', close) + 1;
+};
+
+const buildVersionEntry = (
+  version: number,
+  kind: LifecycleEntryKind,
+  input: string,
+  output: string,
+  blaze: string | undefined
+): string => {
+  if (kind === 'fork') {
+    return `    ${version}: {
+      input: ${input},
+      output: ${output},
+      blaze: ${blaze ?? 'async () => Result.err(new Error("TODO: implement fork blaze"))'},
+    },`;
+  }
+
+  return `    ${version}: {
+      input: ${input},
+      output: ${output},
+      transpose: {
+        input: ({ input }) => input as never,
+        output: ({ output }) => output as never,
+      },
+    },`;
+};
+
+const insertVersionEntry = (
+  source: string,
+  match: TrailSourceMatch,
+  entry: string
+): string => {
+  const versions = findConfigProperty(match, 'versions');
+  if (versions === undefined) {
+    const insertAt = match.configEnd - 1;
+    return replaceRange(
+      source,
+      insertAt,
+      insertAt,
+      `  versions: {\n${entry}\n  },\n`
+    );
+  }
+
+  const open = source.indexOf('{', versions.valueStart);
+  return replaceRange(source, open + 1, open + 1, `\n${entry}`);
+};
+
+const upsertCurrentVersion = (
+  source: string,
+  match: TrailSourceMatch,
+  nextVersion: number
+): string => {
+  const existing = findConfigProperty(match, 'version');
+  if (existing !== undefined) {
+    return replaceRange(
+      source,
+      existing.valueStart,
+      existing.valueEnd,
+      ` ${nextVersion}`
+    );
+  }
+  const insertAt = match.configStart + 1;
+  return replaceRange(
+    source,
+    insertAt,
+    insertAt,
+    `\n  version: ${nextVersion},`
+  );
+};
+
+export const reviseTrailSource = (
+  rootDir: string,
+  trail: AnyTrail,
+  kind: LifecycleEntryKind
+): Result<LifecycleWriteResult, Error> => {
+  const match = findTrailSource(rootDir, trail.id);
+  if (match.isErr()) {
+    return match;
+  }
+  const input = findConfigProperty(match.value, 'input');
+  const output = findConfigProperty(match.value, 'output');
+  if (input === undefined || output === undefined) {
+    return Result.err(
+      new ValidationError(`Trail ${trail.id} must declare input and output`)
+    );
+  }
+
+  const currentVersion = trail.version ?? 1;
+  const nextVersion = currentVersion + 1;
+  const blaze = findConfigProperty(match.value, 'blaze');
+  const usesForkPlaceholder = kind === 'fork' && blaze?.value === undefined;
+  let nextSource = upsertCurrentVersion(
+    match.value.source,
+    match.value,
+    nextVersion
+  );
+  const shiftedMatch = {
+    ...match.value,
+    configEnd:
+      match.value.configEnd + (nextSource.length - match.value.source.length),
+    source: nextSource,
+  };
+  nextSource = insertVersionEntry(
+    nextSource,
+    shiftedMatch,
+    buildVersionEntry(
+      currentVersion,
+      kind,
+      input.value,
+      output.value,
+      blaze?.value
+    )
+  );
+  const written = writeLifecycleSourceFile(match.value.filePath, nextSource);
+  if (written.isErr()) {
+    return Result.err(written.error);
+  }
+
+  return Result.ok({
+    file: match.value.filePath,
+    trailId: trail.id,
+    updated: true,
+    ...(usesForkPlaceholder
+      ? { warnings: missingResultImportWarning(match.value.source) }
+      : {}),
+  });
+};
+
+interface ForkVersionEntryRewrite {
+  readonly source: string;
+  readonly usedPlaceholder: boolean;
+}
+
+const forkVersionEntry = (
+  source: string,
+  match: TrailSourceMatch,
+  entry: PropertyMatch
+): ForkVersionEntryRewrite => {
+  const entryMatch: TrailSourceMatch = {
+    ...match,
+    configEnd: entry.valueEnd,
+    configStart: propertyObjectStart(source, entry),
+  };
+  const forkBlaze =
+    'blaze: async () => Result.err(new Error("TODO: implement fork blaze"))';
+  const transpose = findConfigProperty(entryMatch, 'transpose');
+  if (transpose !== undefined) {
+    const indent = lineIndentAt(source, transpose.start);
+    return {
+      source: replaceRange(
+        source,
+        transpose.start,
+        transpose.end,
+        `${indent}${forkBlaze},`
+      ),
+      usedPlaceholder: true,
+    };
+  }
+  const blaze = findConfigProperty(entryMatch, 'blaze');
+  if (blaze !== undefined) {
+    return { source, usedPlaceholder: false };
+  }
+  return {
+    source: replaceRange(
+      source,
+      propertyObjectCloseLineStart(source, entry),
+      propertyObjectCloseLineStart(source, entry),
+      `      ${forkBlaze},\n`
+    ),
+    usedPlaceholder: true,
+  };
+};
+
+const statusBlock = (
+  status: LifecycleStatusKind,
+  input: {
+    readonly migration?: readonly string[] | undefined;
+    readonly note?: string | undefined;
+    readonly reason?: string | undefined;
+    readonly successor?: number | undefined;
+  }
+): string => {
+  if (status === 'archived') {
+    return `status: { state: 'archived'${input.reason ? `, reason: ${literal(input.reason)}` : ''} }`;
+  }
+  const migration =
+    input.migration === undefined || input.migration.length === 0
+      ? ''
+      : `, migration: [${input.migration.map(literal).join(', ')}]`;
+  const successor =
+    input.successor === undefined ? '' : `, successor: ${input.successor}`;
+  const note = input.note === undefined ? '' : `, note: ${literal(input.note)}`;
+  return `status: { state: 'deprecated'${successor}${migration}${note} }`;
+};
+
+const findVersionEntryProperty = (
+  match: TrailSourceMatch,
+  version: number
+): PropertyMatch | undefined => {
+  const versions = findConfigProperty(match, 'versions');
+  if (versions === undefined) {
+    return undefined;
+  }
+  const configStart = propertyObjectStart(match.source, versions);
+  const entry = findConfigProperty(
+    {
+      ...match,
+      configEnd: versions.valueEnd,
+      configStart,
+    },
+    String(version)
+  );
+  if (entry === undefined) {
+    return undefined;
+  }
+  return entry;
+};
+
+export const setVersionStatusSource = (
+  rootDir: string,
+  target: ParsedVersionTarget,
+  status: LifecycleStatusKind,
+  input: {
+    readonly migration?: readonly string[] | undefined;
+    readonly note?: string | undefined;
+    readonly reason?: string | undefined;
+    readonly successor?: number | undefined;
+  }
+): Result<LifecycleWriteResult, Error> => {
+  if (target.version === undefined) {
+    return Result.err(
+      new ValidationError(
+        'Deprecate requires an explicit trail.id@version target'
+      )
+    );
+  }
+  const match = findTrailSource(rootDir, target.trailId);
+  if (match.isErr()) {
+    return match;
+  }
+  const entry = findVersionEntryProperty(match.value, target.version);
+  if (entry === undefined) {
+    return Result.err(
+      new ValidationError(
+        `Trail ${target.trailId} does not declare version ${target.version}`
+      )
+    );
+  }
+  const fakeEntryMatch: TrailSourceMatch = {
+    ...match.value,
+    configEnd: entry.valueEnd,
+    configStart: propertyObjectStart(match.value.source, entry),
+  };
+  const existing = findConfigProperty(fakeEntryMatch, 'status');
+  const nextStatus = statusBlock(status, input);
+  const nextSource =
+    existing === undefined
+      ? replaceRange(
+          match.value.source,
+          propertyObjectCloseLineStart(match.value.source, entry),
+          propertyObjectCloseLineStart(match.value.source, entry),
+          `      ${nextStatus},\n`
+        )
+      : replaceRange(
+          match.value.source,
+          existing.start,
+          existing.end,
+          `${lineIndentAt(match.value.source, existing.start)}${nextStatus},`
+        );
+  if (nextSource === match.value.source) {
+    return Result.ok({
+      file: match.value.filePath,
+      trailId: target.trailId,
+      updated: false,
+    });
+  }
+  const written = writeLifecycleSourceFile(match.value.filePath, nextSource);
+  if (written.isErr()) {
+    return Result.err(written.error);
+  }
+
+  return Result.ok({
+    file: match.value.filePath,
+    trailId: target.trailId,
+    updated: true,
+  });
+};
+
+export const forkVersionEntrySource = (
+  rootDir: string,
+  target: ParsedVersionTarget
+): Result<LifecycleWriteResult, Error> => {
+  if (target.version === undefined) {
+    return Result.err(
+      new ValidationError(
+        'Forking a historical entry requires trail.id@version'
+      )
+    );
+  }
+  const match = findTrailSource(rootDir, target.trailId);
+  if (match.isErr()) {
+    return match;
+  }
+  const entry = findVersionEntryProperty(match.value, target.version);
+  if (entry === undefined) {
+    return Result.err(
+      new ValidationError(
+        `Trail ${target.trailId} does not declare version ${target.version}`
+      )
+    );
+  }
+  const rewrite = forkVersionEntry(match.value.source, match.value, entry);
+  const nextSource = rewrite.source;
+  if (nextSource === match.value.source) {
+    return Result.ok({
+      file: match.value.filePath,
+      trailId: target.trailId,
+      updated: false,
+    });
+  }
+  const written = writeLifecycleSourceFile(match.value.filePath, nextSource);
+  if (written.isErr()) {
+    return Result.err(written.error);
+  }
+
+  return Result.ok({
+    file: match.value.filePath,
+    trailId: target.trailId,
+    updated: true,
+    ...(rewrite.usedPlaceholder
+      ? { warnings: missingResultImportWarning(match.value.source) }
+      : {}),
+  });
+};
+
+export const parseLifecycleTarget = parseVersionTarget;
+
+export const withLifecycleApp = async <T>(
+  input: LifecycleCommandInput,
+  cwd: string | undefined,
+  consume: (
+    app: Topo,
+    rootDir: string
+  ) => Result<T, Error> | Promise<Result<T, Error>>
+): Promise<Result<T, Error>> => {
+  const root = resolveTrailRootDir(input.rootDir, cwd);
+  if (root.isErr()) {
+    return root;
+  }
+  const lease = await tryLoadFreshAppLease(input.module, root.value);
+  if (lease.isErr()) {
+    return Result.err(lease.error);
+  }
+  try {
+    return await consume(lease.value.app, root.value);
+  } finally {
+    lease.value.release();
+  }
+};
+
+export const findLifecycleTrail = (
+  app: Topo,
+  trailId: string
+): Result<AnyTrail, Error> => {
+  const found = app.get(trailId);
+  return found === undefined
+    ? Result.err(new ValidationError(`Trail not found: ${trailId}`))
+    : Result.ok(found as AnyTrail);
+};
+
+export const deriveDoctorSummary = (
+  app: Topo
+): {
+  readonly archived: number;
+  readonly deprecated: number;
+  readonly forceEvents: number;
+  readonly mode: 'doctor';
+  readonly trails: number;
+  readonly versioned: number;
+} => {
+  const graph = deriveTopoGraph(app);
+  let archived = 0;
+  let deprecated = 0;
+  let forceEvents = 0;
+  let versioned = 0;
+  for (const entry of graph.entries) {
+    if (entry.kind !== 'trail') {
+      continue;
+    }
+    if (entry.version !== undefined) {
+      versioned += 1;
+    }
+    forceEvents += entry.forces?.length ?? 0;
+    for (const version of Object.values(entry.versions ?? {})) {
+      if (version.status?.state === 'archived') {
+        archived += 1;
+      } else if (version.status?.state === 'deprecated') {
+        deprecated += 1;
+      }
+    }
+  }
+  return {
+    archived,
+    deprecated,
+    forceEvents,
+    mode: 'doctor',
+    trails: app.list().length,
+    versioned,
+  };
+};

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -117,6 +117,37 @@ trails diff --breaks
 trails diff --forces
 ```
 
+### `trails revise`
+
+Scaffold trail version lifecycle entries from source. The default shape creates a
+revision entry for the current version and bumps the trail to the next version.
+Use `--as fork` when the historical version needs its own preserved blaze.
+
+```bash
+trails revise billing.quote
+trails revise billing.quote --as fork
+trails revise billing.quote@1 --as fork
+```
+
+### `trails deprecate`
+
+Mark a historical version entry deprecated, or archived when the historical
+version should remain inspectable but leave default runtime negotiation.
+
+```bash
+trails deprecate billing.quote@1 --successor 2 --note "Use v2."
+trails deprecate billing.quote@1 --archive --reason "Superseded before GA."
+```
+
+### `trails doctor`
+
+Summarize version lifecycle state for the loaded app, including deprecated and
+archived historical entries plus forced topo break audit events.
+
+```bash
+trails doctor
+```
+
 ### `trails validate`
 
 Check that the `.trails/trails.lock` / `.trails/topo.lock` artifact family


### PR DESCRIPTION
## Context

This branch adds the operator-facing lifecycle commands for Trail Versioning M3. The grammar is intentionally narrow: revise, deprecate, and doctor are the settled commands; aliases like version/sunset/mark/fork/archive are intentionally not introduced here.

Linear: TRL-119
Stack: 7/8, on top of TRL-118.

## What changed

- Added `trails revise`, `trails deprecate`, and `trails doctor` to the Trails app.
- Added source lifecycle rewrite helpers and a lifecycle source I/O boundary.
- `revise <trail>` scaffolds a historical revision and bumps current version.
- `revise <trail> --as fork` scaffolds a fork entry; `revise <trail>@<v> --as fork` upgrades an existing historical entry into a fork placeholder.
- `deprecate <trail>@<v>` writes deprecated status guidance; `deprecate <trail>@<v> --archive` writes archived status.
- `doctor` summarizes lifecycle counts and force-event audit state.
- Documented the command grammar and added a branch-local changeset for `@ontrails/trails`.

## Verification

- `bun test apps/trails/src/__tests__/version-lifecycle.test.ts apps/trails/src/__tests__/survey.test.ts` (57 pass)
- `bun run --cwd apps/trails typecheck`
- `bun run --cwd apps/trails lint` (0 warnings, 0 errors)
- Stack-tip gates later passed: ADR check, typecheck, test, lint, ast-grep, build, format, check, publish dry-run, Warden guide checks, `git diff --check`.

## Risks / notes

The lifecycle source helper is intentionally split out of the command files; local review marked further decomposition as P3-only if that helper grows again.