### PR TITLE
docs: audit plugin package coverage

### DIFF
--- a/.agents/plans/2026-05-21-plugin-skills-m1-audit/GOAL.md
+++ b/.agents/plans/2026-05-21-plugin-skills-m1-audit/GOAL.md
@@ -1,0 +1,124 @@
+# Goal Prompt: plugin-skills-m1-audit
+
+> Note: this goal prompt is a machine-local execution packet for Matt's Trails checkout. Absolute `/Users/mg/...` paths are preserved as point-in-time audit coordinates, especially for TRL-743 installed-skill inspection; downstream implementation guidance should use repo-relative paths or `$HOME`-relative skill roots instead.
+
+Paste this into the goal runtime:
+
+`````markdown
+/goal Execute M1 of the Trails Plugin & Skills One-Stop Shop project end to end from cwd `/Users/mg/Developer/outfitter/trails`.
+
+Primary source of truth:
+`/Users/mg/Developer/outfitter/trails/.agents/plans/2026-05-21-plugin-skills-m1-audit/PLAN.md`
+
+Read first:
+- `AGENTS.md`
+- `.agents/plans/PLANNING.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/PLAN.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/REFS.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/RETRO.md`
+- Linear project `Trails Plugin & Skills One-Stop Shop`
+- Linear issues `TRL-741`, `TRL-742`, `TRL-743`, `TRL-744`, `TRL-745`, `TRL-754`
+- Downstream issues `TRL-746`, `TRL-747`, `TRL-748`, `TRL-749`, `TRL-750`, `TRL-751`, `TRL-752`, `TRL-753`
+
+Important tool constraint:
+Do not use the installed/global `trails` skill as doctrine for this goal. It is known to be stale and is itself an audited artifact. Use repo files, Linear, package exports, CLI help, Warden output, and this plan packet instead. Inspect `/Users/mg/.agents/skills/trails` and `/Users/mg/.config/claude/skills/trails` read-only only for TRL-743.
+
+Objective:
+Build, locally review, submit, and tracker-update the five-branch Graphite M1 audit stack. The end state is a source-backed truth map for the Trails plugin/skills ecosystem plus an exact downstream M2/M3 implementation stack, not plugin implementation.
+
+Branch order, bottom to top:
+1. TRL-745 - `trl-745-audit-plugin-coverage-for-current-packages-adapters-and`
+2. TRL-742 - `trl-742-audit-repo-plugin-and-skills-against-current-trails-doctrine`
+3. TRL-743 - `trl-743-audit-installed-and-distributed-trails-skill-surfaces`
+4. TRL-744 - `trl-744-audit-trails-plugin-hook-opportunities-and-integration`
+5. TRL-754 - `trl-754-synthesize-plugin-audits-into-an-executable-refresh-stack`
+
+Required outputs:
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-745-package-coverage.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-742-repo-plugin-doctrine.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-743-distribution-surfaces.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-744-hook-opportunities.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-754-synthesis.md`
+
+Source-control rules:
+- Run `gt sync` first and start from current `main`.
+- Use Graphite for branch and stack operations.
+- It is fine to create the local branch chain up front, but do not submit or push empty branches.
+- Commit this plan packet on the lowest branch in the stack.
+- Main agent owns all `git` and `gt` writes.
+- Subagents may inspect files, write report drafts, run checks, and provide local review, but they must not run `git add`, `git commit`, `git push`, `gt create`, `gt modify`, `gt restack`, `gt submit`, merge commands, or PR mutation commands.
+- Do not use `gt absorb`.
+- Do not add a merge queue label.
+- Do not merge.
+
+Scope:
+- TRL-745: package/subpath truth map and plugin coverage matrix for current `@ontrails/*` packages, adapters, and key exports, including `@ontrails/http/bun`, `@ontrails/pino`, and `@ontrails/wayfinder`.
+- TRL-742: repo plugin and skill doctrine audit against current lexicon, docs, ADRs, CLI help, Warden manifest, package exports, and generated guidance.
+- TRL-743: installed and distributed skill/plugin surface audit across repo plugin source, manifests, local installed skill paths, Codex/Claude-visible paths, and version metadata.
+- TRL-744: hook and integration audit for project detection, version drift warnings, Warden nudges, command suggestions, and Claude/Codex differences.
+- TRL-754: synthesis report, Linear issue refresh for TRL-746 through TRL-753, M2/M3 stack recommendation, and focused follow-up issue creation for real discoveries.
+
+Evidence rules:
+- Every report finding needs a path, line where practical, quoted text or command summary, and a recommended owner issue.
+- Use `qmd` for local documentation search when semantic docs lookup helps, and `rg` for exact stale vocabulary or file sweeps.
+- `unable to verify` is acceptable. Invented references are not.
+- Keep out-of-goal discoveries in `RETRO.md` first; create Linear follow-up issues only when the discovery is concrete and scoped.
+
+Local review:
+Before remote submission or final handoff, run local review over the reports and synthesis. Use subagents if useful. Require each reviewer to provide:
+
+```markdown
+Overall score: n/5
+
+Summary:
+<concise judgment>
+
+Findings:
+- P0/P1/P2/P3 - <artifact/path/line> - <finding>
+  Prompt To Fix With AI:
+  <concise fix prompt>
+```
+
+Review lanes:
+- Evidence integrity: report claims have support and unknowns are explicit.
+- Tracker alignment: every M1 finding routes to the correct issue, new issue, or deferral.
+- Implementation readiness: M2/M3 issues and stack order are precise enough for execution without redoing the audit.
+
+Fix every P0/P1/P2 finding before marking PRs ready or claiming final handoff. Documentation correctness is P2 by default; P3 is style-only.
+
+Verification:
+At minimum, surface transcript-visible summaries for:
+
+```bash
+git status --short --branch
+gt log --stack --reverse --no-interactive
+bun run warden:skills:check
+bun run warden:agents:check
+bun run clark:check
+bun run format:check
+git diff --check
+```
+
+If the work touches source, plugin hooks, generated guidance, package files, or scripts beyond reports/Linear updates, also run:
+
+```bash
+bun run check
+```
+
+Remote review:
+Submit PRs as draft after report completion, Linear updates, and local verification. Mark ready only after local review is clean or P3-only and checks pass. After ready, check CI, unresolved review threads, and code-review bot/agent summaries. Record numeric review scores, prose summaries, and prompt-to-fix text in `RETRO.md`; resolve all P0/P1/P2 findings. Treat a pending Graphite mergeability check by itself as external service lag when GitHub checks and review are otherwise clean, per `.agents/plans/PLANNING.md` and goal-planning source-control guidance.
+
+Completion condition:
+The goal is complete only when all five reports exist, M1 Linear issues and downstream M2/M3 issues are current, local review is clean or P3-only, PRs are submitted with high-quality bodies, required checks pass or skipped checks are explained, no implementation/publish/registry mutation/merge/merge queue label/global skill mutation occurred, and the final transcript reports branch/PR state, report paths, Linear mutations, verification commands/results, review state, remaining P3s/risks, and finalized `RETRO.md` state.
+
+Retro discipline:
+Maintain `/Users/mg/Developer/outfitter/trails/.agents/plans/2026-05-21-plugin-skills-m1-audit/RETRO.md` as the durable execution ledger. Touch it last before local completion, draft submission, ready-for-review, remote review closeout, merge readiness, archive, or final handoff. Any meaningful local or remote review change must be reflected in `RETRO.md` before claiming the review loop is complete.
+
+Stop and ask if:
+- The M1 Linear graph or branch names differ from this plan in a way that changes stack order.
+- A doctrine/API decision must be settled before downstream issues can be made executable.
+- The work requires mutating global installed skill paths, publishing the plugin, changing package releases, registry mutation, merge, or merge queue entry.
+- The goal would turn into implementing plugin refresh changes rather than auditing and routing them.
+- Linear writes are unavailable and tracker truth cannot be updated.
+- Verification fails for unrelated repo reasons after one focused retry.
+`````

--- a/.agents/plans/2026-05-21-plugin-skills-m1-audit/PLAN.md
+++ b/.agents/plans/2026-05-21-plugin-skills-m1-audit/PLAN.md
@@ -1,0 +1,438 @@
+# Goal Plan: plugin-skills-m1-audit
+
+Date: 2026-05-21
+Status: Ready for execution
+
+> Note: this packet intentionally records Matt's local checkout and installed-skill roots as point-in-time M1 evidence. Treat `/Users/mg/...` paths as audit coordinates, not portable implementation defaults; downstream scripts and docs should use repo-relative paths or `$HOME`-relative skill roots.
+
+## Objective
+
+Execute M1 of the Trails Plugin & Skills One-Stop Shop project: build a current, evidence-backed truth map for the repo plugin, installed skill surfaces, package/subpath coverage, and hook opportunities, then synthesize those findings into precise Linear updates and a ready implementation stack for M2/M3.
+
+This is an audit and planning sprint. The goal is to make the next implementation run obvious, not to refresh the plugin content yet.
+
+## Completion Condition
+
+The goal is complete only when:
+
+- Four source-backed audit reports exist under `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/`:
+  - `trl-745-package-coverage.md`
+  - `trl-742-repo-plugin-doctrine.md`
+  - `trl-743-distribution-surfaces.md`
+  - `trl-744-hook-opportunities.md`
+- `reports/trl-754-synthesis.md` exists and turns the audit findings into an exact M2/M3 execution stack, with issue IDs, branch names, file targets, acceptance criteria, and verification expectations.
+- Linear project `Trails Plugin & Skills One-Stop Shop` is current:
+  - `TRL-742`, `TRL-743`, `TRL-744`, `TRL-745`, and `TRL-754` have comments linking to their report paths and summarizing findings.
+  - Downstream issues `TRL-746` through `TRL-753` have been updated where the audits reveal stale scope, missing file targets, or incorrect assumptions.
+  - Any newly discovered follow-up has a focused Linear issue, or is explicitly recorded in `RETRO.md` as deferred/out of scope with a reason.
+- A local review of the audit packet and synthesis has run before remote submission, and every P0/P1/P2 report or tracker gap has been fixed.
+- The five-branch audit stack has been submitted as draft or ready according to the source-control plan, with high-quality PR bodies if PRs are created.
+- `git diff --check`, `bun run format:check`, `bun run warden:skills:check`, `bun run warden:agents:check`, and `bun run clark:check` pass, or any skipped check is justified in `RETRO.md`.
+- No plugin refresh implementation, publish, registry mutation, merge, merge queue label, or global installed skill mutation occurred.
+- `RETRO.md` has final tracker, branch/PR, review, verification, forbidden-action, remaining-risk, and archive-readiness state, and the final transcript reports the proof.
+
+## Non-Goals
+
+- Do not implement M2/M3/M4 plugin refresh work in this goal. Updating issue bodies and adding audit reports is in scope; changing the plugin guidance itself is not.
+- Do not republish the plugin or mutate any marketplace, npm, or registry state.
+- Do not mutate `~/.agents/skills/trails`, `~/.config/claude/skills/trails`, or other global installed skill paths. Inspect them read-only for `TRL-743`.
+- Do not treat the installed/global `trails` skill as doctrine. It is known to be stale; use it only as an audited artifact.
+- Do not rely on ignored `.scratch/` or local-only notes as source of truth unless the necessary evidence is copied or summarized into this tracked packet.
+- Do not merge. Do not add merge queue labels.
+
+## Source Of Truth
+
+Read first:
+
+1. `AGENTS.md`
+2. `.agents/plans/PLANNING.md`
+3. `.agents/plans/2026-05-21-plugin-skills-m1-audit/PLAN.md`
+4. `.agents/plans/2026-05-21-plugin-skills-m1-audit/REFS.md`
+5. Linear project: `Trails Plugin & Skills One-Stop Shop`
+6. Linear issues: `TRL-741`, `TRL-742`, `TRL-743`, `TRL-744`, `TRL-745`, `TRL-754`
+7. Downstream Linear issues to refresh from the synthesis: `TRL-746`, `TRL-747`, `TRL-748`, `TRL-749`, `TRL-750`, `TRL-751`, `TRL-752`, `TRL-753`
+8. Current repo docs and code:
+   - `README.md`
+   - `AGENTS.md`
+   - `docs/lexicon.md`
+   - `docs/architecture.md`
+   - `docs/contributing/language-styleguide.md`
+   - `docs/contributing/code-standards.md`
+   - `docs/warden.md`
+   - `docs/adr/README.md`
+   - accepted ADRs in `docs/adr/`
+   - package `package.json` files and public export maps
+   - `plugin/**`
+   - `.claude/skills/**`
+   - `.agents/skills/**` where tracked in this repo
+
+## Work Plan
+
+### Phase 0: Sync And Baseline
+
+Intent:
+
+- Ensure the executor starts from current `main` and records the live repo/PR/Linear state before auditing.
+
+Actions:
+
+- Run `gt sync`, then confirm branch and worktree cleanliness.
+- List open PRs and Graphite stack state.
+- Record the baseline in `RETRO.md`, including any existing plan-packet changes.
+- Confirm the M1 Linear issues are still assigned to milestone `M1: Audit and truth map` and that `TRL-754` is blocked by `TRL-742`, `TRL-743`, `TRL-744`, and `TRL-745`.
+
+Verification:
+
+- `git status --short --branch`
+- `gt log --stack --reverse --no-interactive`
+- `gh pr list --repo outfitter-dev/trails --state open --json number,title,headRefName,isDraft,mergeable,reviewDecision,updatedAt`
+
+Done when:
+
+- `RETRO.md` names the starting branch, stack state, open PRs, and any collision risks.
+
+### Phase 1: Create The Local Audit Stack
+
+Intent:
+
+- Keep M1 reviewable as one report-producing PR per audit issue, with synthesis last.
+
+Actions:
+
+- From current `main`, create the local Graphite stack in this bottom-to-top order:
+  1. `TRL-745` - `trl-745-audit-plugin-coverage-for-current-packages-adapters-and`
+  2. `TRL-742` - `trl-742-audit-repo-plugin-and-skills-against-current-trails-doctrine`
+  3. `TRL-743` - `trl-743-audit-installed-and-distributed-trails-skill-surfaces`
+  4. `TRL-744` - `trl-744-audit-trails-plugin-hook-opportunities-and-integration`
+  5. `TRL-754` - `trl-754-synthesize-plugin-audits-into-an-executable-refresh-stack`
+- It is fine to create the local branch chain up front. Do not submit or push empty branches.
+- Commit this plan packet on the lowest branch, either as its own docs commit or with the first report.
+- Main agent owns all `git` and `gt` writes. Subagents may inspect, edit report files, and run checks, but must not run source-control write commands.
+
+Verification:
+
+- `gt log --stack --reverse --no-interactive`
+- `git branch --show-current`
+
+Done when:
+
+- The five local branches exist in order and no empty branch has been submitted.
+
+### Phase 2: `TRL-745` Package And Subpath Truth Map
+
+Intent:
+
+- Establish the live package, adapter, subpath, and CLI/export facts that the plugin should teach.
+
+Actions:
+
+- Inventory current public packages and key subpaths:
+  - `@ontrails/core`
+  - `@ontrails/cli`
+  - `@ontrails/commander`
+  - `@ontrails/mcp`
+  - `@ontrails/http`
+  - `@ontrails/http/bun`
+  - `@ontrails/hono`
+  - `@ontrails/store`
+  - `@ontrails/drizzle`
+  - `@ontrails/config`
+  - `@ontrails/permits`
+  - `@ontrails/observe`
+  - `@ontrails/tracing`
+  - `@ontrails/logtape`
+  - `@ontrails/pino`
+  - `@ontrails/testing`
+  - `@ontrails/topographer`
+  - `@ontrails/warden`
+  - `@ontrails/wayfinder`
+  - `@ontrails/vite`
+- Compare package truth against:
+  - root `README.md`
+  - package READMEs
+  - `plugin/skills/trails/**`
+  - `plugin/agents/trail-engineer.md`
+  - `plugin/rules/**`
+- Capture missing, stale, or confusing coverage in `reports/trl-745-package-coverage.md`.
+- For each finding, include evidence: path, line, quoted text or command summary, and the downstream issue that should absorb it.
+
+Verification:
+
+- `fd package.json packages apps plugin -E node_modules -E .turbo`
+- `jq -r '.name + " " + .version' packages/*/package.json`
+- `jq '.exports // empty' packages/*/package.json`
+- `bun apps/trails/bin/trails.ts --help`
+- `rg -n "@ontrails/(core|cli|commander|mcp|http|hono|store|drizzle|config|permits|observe|tracing|logtape|pino|testing|topographer|warden|wayfinder|vite)|http/bun|Bun-native|adapter|surface|facet" README.md docs packages plugin .claude .agents`
+
+Done when:
+
+- `reports/trl-745-package-coverage.md` contains a package/subpath matrix, plugin coverage gaps, and exact downstream issue routing.
+
+### Phase 3: `TRL-742` Repo Plugin Doctrine Audit
+
+Intent:
+
+- Compare the repo-tracked plugin and skill bundle against current Trails doctrine and code reality.
+
+Actions:
+
+- Audit:
+  - `plugin/skills/trails/SKILL.md`
+  - `plugin/skills/trails/references/**`
+  - `plugin/skills/trails/templates/**`
+  - `plugin/skills/trails/examples/**`
+  - `plugin/skills/trails-*/*`
+  - `plugin/agents/trail-engineer.md`
+  - `plugin/rules/**`
+  - `plugin/hooks/**`
+  - tracked `.claude/skills/**` and `.agents/skills/**` surfaces in this repo
+- Compare against current doctrine:
+  - lexicon and language style
+  - trail/blaze/topo/surface/resource/layer/cross/signal/contour grammar
+  - adapters/facets/package taxonomy
+  - Warden generated guidance and rule IDs
+  - current CLI commands and surface names
+- Use `qmd` for local documentation search when it helps with semantic docs lookup, and `rg` for exact stale vocabulary sweeps.
+- Capture all findings in `reports/trl-742-repo-plugin-doctrine.md`.
+- Route each finding to one of:
+  - M2 main skill refresh (`TRL-746`)
+  - M2 references/templates/examples refresh (`TRL-747`)
+  - M2 agent/rules/advisory skill refresh (`TRL-748`)
+  - M3 metadata/drift/hook items (`TRL-749`, `TRL-750`, `TRL-751`)
+  - M4 dogfood/release items (`TRL-752`, `TRL-753`)
+  - new follow-up issue
+
+Verification:
+
+- `bun run warden:skills:check`
+- `bun run warden:agents:check`
+- `bun run clark:check`
+- `bun apps/trails/bin/trails.ts warden guide --manifest`
+- `rg -n "trailhead|transport|connector|topo\\.show|metadata|route|handler|impl|registry|middleware|service|dependency|follow" plugin .claude .agents README.md docs`
+
+Done when:
+
+- `reports/trl-742-repo-plugin-doctrine.md` names stale doctrine, missing doctrine, current-good areas, and downstream issue routing with source-backed evidence.
+
+### Phase 4: `TRL-743` Installed And Distributed Surface Audit
+
+Intent:
+
+- Map every place a Trails plugin/skill can be loaded from and identify drift between repo truth, local installs, and distribution metadata.
+
+Actions:
+
+- Inspect read-only:
+  - repo plugin source: `plugin/**`
+  - marketplace manifests: `.claude-plugin/marketplace.json`, `plugin/.claude-plugin/plugin.json`
+  - local installed skill surfaces such as `/Users/mg/.agents/skills/trails` and `/Users/mg/.config/claude/skills/trails`
+  - Codex-visible and Claude-visible symlink/copy paths where discoverable
+  - README or plugin install instructions for Claude Code, Codex, Cursor, and local development
+  - plugin version metadata versus `metadata.trails.version` and current package versions
+- Do not mutate global installed paths.
+- Produce a distribution matrix in `reports/trl-743-distribution-surfaces.md`.
+- Identify whether M3 should implement sync, check, symlink, or explicit decoupling behavior.
+
+Verification:
+
+- `ls -la plugin/skills/trails /Users/mg/.agents/skills/trails /Users/mg/.config/claude/skills/trails`
+- `readlink /Users/mg/.config/claude/skills/trails || true`
+- `diff -qr plugin/skills/trails /Users/mg/.agents/skills/trails || true`
+- `rg -n "version|metadata\\.trails|Claude|Codex|Cursor|install|plugin|skills/trails" README.md plugin .claude-plugin .agents .claude`
+
+Done when:
+
+- `reports/trl-743-distribution-surfaces.md` documents every known load surface, whether it is repo-owned or global/local, how it currently drifts, and exactly which follow-up issue owns correction.
+
+### Phase 5: `TRL-744` Hook And Integration Audit
+
+Intent:
+
+- Identify hook opportunities that make Trails agent support feel native without becoming noisy, surprising, or mutating broad surfaces.
+
+Actions:
+
+- Audit current and possible hooks around:
+  - Claude plugin `SessionStart` detection in `plugin/hooks/detect-trails.sh`
+  - version mismatch detection between plugin `metadata.trails.version` and installed `@ontrails/core`
+  - project detection via `package.json`, `trails.config.ts`, `.trails/`, and package imports
+  - Warden nudges or commands
+  - command suggestions after errors
+  - local development/dogfood hooks inside this repo
+  - Codex versus Claude hook differences
+- Evaluate noise risk, mutation risk, portability, and implementation difficulty.
+- Produce `reports/trl-744-hook-opportunities.md` with a prioritized recommendation set.
+
+Verification:
+
+- `fd . plugin/hooks .claude .agents -E node_modules`
+- `sed -n '1,220p' plugin/hooks/detect-trails.sh`
+- `rg -n "hook|SessionStart|detect-trails|warden|metadata\\.trails|@ontrails/core|trails.config|\\.trails|PreToolUse|PostToolUse|Stop" plugin .claude .agents README.md docs`
+
+Done when:
+
+- `reports/trl-744-hook-opportunities.md` distinguishes must-have M3 checks from optional ideas, and names exact files or scripts likely to change later.
+
+### Phase 6: `TRL-754` Synthesis And Linear Refresh
+
+Intent:
+
+- Convert the four audits into an executable M2/M3 plan and remove ambiguity from downstream Linear issues.
+
+Actions:
+
+- Read all four reports.
+- Write `reports/trl-754-synthesis.md` with:
+  - concise findings by domain;
+  - exact stack recommendation for M2/M3, bottom to top;
+  - which issues should be implemented one-PR-per-issue;
+  - file targets and expected diff shape per issue;
+  - verification ladder for the implementation stack;
+  - explicit deferred follow-ups and why they are not in the next stack.
+- Update Linear:
+  - Comment on `TRL-742`, `TRL-743`, `TRL-744`, `TRL-745`, and `TRL-754` with report path and key findings.
+  - Refresh descriptions or acceptance criteria for `TRL-746` through `TRL-753` when the audits supply concrete file targets, verification commands, or scope corrections.
+  - Create focused follow-up issues for real discoveries that are outside M2/M3 but should not be lost.
+  - Update `TRL-741` parent/project issue with an M1 summary comment.
+- Do not mark issues Done unless the corresponding branch has merged. If this stack is only submitted, use comments and PR links to show state.
+
+Verification:
+
+- Linear issue comments or mutation summaries are recorded in `RETRO.md`.
+- `reports/trl-754-synthesis.md` maps every P0/P1/P2 audit finding to an issue, an in-goal fix, or an explicit deferral.
+- Downstream issues are executable without chat history.
+
+Done when:
+
+- The M2/M3 execution path is clear enough that a future `/goal` can build it without rediscovering M1.
+
+## Tracker Plan
+
+- Project: `Trails Plugin & Skills One-Stop Shop`
+- Parent issue: `TRL-741`
+- M1 issues in this goal:
+  - `TRL-745`
+  - `TRL-742`
+  - `TRL-743`
+  - `TRL-744`
+  - `TRL-754`
+- Downstream issues to refresh from synthesis:
+  - M2: `TRL-746`, `TRL-747`, `TRL-748`
+  - M3: `TRL-749`, `TRL-750`, `TRL-751`
+  - M4 context only unless audit findings force clarification: `TRL-752`, `TRL-753`
+- Dependency shape:
+  - `TRL-742`, `TRL-743`, `TRL-744`, and `TRL-745` block `TRL-754`.
+  - `TRL-754` should block implementation work in M2/M3 until its synthesis is complete.
+- Follow-up creation rule:
+  - Create a new issue only for a concrete discovery with a clear owner, scope, and acceptance criteria.
+  - Record speculative or low-confidence ideas in `RETRO.md`, not Linear.
+
+## Source-Control Plan
+
+- Branching model: Graphite.
+- Branch order, bottom to top:
+  1. `trl-745-audit-plugin-coverage-for-current-packages-adapters-and`
+  2. `trl-742-audit-repo-plugin-and-skills-against-current-trails-doctrine`
+  3. `trl-743-audit-installed-and-distributed-trails-skill-surfaces`
+  4. `trl-744-audit-trails-plugin-hook-opportunities-and-integration`
+  5. `trl-754-synthesize-plugin-audits-into-an-executable-refresh-stack`
+- Commit shape:
+  - one report-producing commit per branch is enough;
+  - keep Linear/tracker comment summaries in `RETRO.md`;
+  - keep `RETRO.md` updates on the top synthesis branch when they summarize whole-stack state.
+- PR strategy:
+  - submit as draft after local audit reports and verification are clean;
+  - mark ready only after local review is clean/P3-only, PR bodies are clear, and checks pass;
+  - do not merge.
+- Cleanup before merge:
+  - before a future merge, final-update `RETRO.md`;
+  - after merge, move the packet to `.agents/plans/archive/` in a closeout branch if this repo convention is being followed.
+
+## Retro Discipline
+
+`RETRO.md` is part of the completion contract, not optional notes.
+
+- Update `RETRO.md` after meaningful tracker, report, verification, local review, remote review, CI, PR-body, or packaging state changes.
+- For stacked work, touch `RETRO.md` last before local completion, draft submission, ready-for-review, remote review closeout, merge readiness, or final handoff.
+- Every meaningful review-flow change must have a corresponding retro entry before claiming the review loop is complete.
+- Before completion, fill the final state, verification log, review state, tracker state, forbidden-action audit, remaining risks, and archive readiness.
+
+## Validation Ladder
+
+Run checks from narrow to broad:
+
+- Targeted report proof:
+  - `test -f .agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-745-package-coverage.md`
+  - `test -f .agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-742-repo-plugin-doctrine.md`
+  - `test -f .agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-743-distribution-surfaces.md`
+  - `test -f .agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-744-hook-opportunities.md`
+  - `test -f .agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-754-synthesis.md`
+- Generated guidance checks:
+  - `bun run warden:skills:check`
+  - `bun run warden:agents:check`
+  - `bun run clark:check`
+- Docs/format checks:
+  - `bun run format:check`
+  - `git diff --check`
+- Full repo check:
+  - Not required for reports-only branches.
+  - If the executor changes source, plugin hooks, generated guidance, package files, or scripts, run `bun run check` and any narrower relevant tests.
+
+## Local Review
+
+Run local review before submitting or marking ready. The review focus is audit correctness and downstream executability, not code behavior.
+
+- Lane 1: evidence integrity - every report claim has a path, quote, command summary, or explicit unknown.
+- Lane 2: tracker alignment - every M1 finding routes to the right Linear issue, new issue, or explicit deferral.
+- Lane 3: implementation readiness - M2/M3 issues are precise enough for an executor to implement without redoing the audit.
+
+Reviewer output contract:
+
+- Overall score: `n/5`
+- Prose summary: concise judgment
+- Findings: P0/P1/P2/P3, with file/line evidence where applicable
+- Prompt to fix: concise prompt for each actionable finding
+
+Fix all P0/P1/P2 findings before remote submission or final handoff.
+Summarize each round and its fix outcome in `RETRO.md`.
+
+For remote code-review bots/agents, also record summary scores, prose summaries, prompt-to-fix blocks, and whether any score below 5/5 reflects current unresolved debt, stale feedback, or an explicitly rejected recommendation.
+
+## Progress Reporting
+
+After each execution turn, report:
+
+- Current checkpoint
+- What changed
+- What was verified
+- Command/output summary
+- What remains
+- Blocker status
+- Next checkpoint
+
+## Stop / Pause Rules
+
+Stop and ask if:
+
+- The M1 Linear graph or branch names differ from this plan in a way that changes stack order.
+- The audits reveal a doctrine/API decision that must be settled before downstream issues can be made executable.
+- The work would require mutating global installed skill paths, publishing the plugin, changing package releases, or touching registries.
+- The executor would need to implement plugin/source changes rather than documenting and routing them.
+- Linear writes are unavailable and tracker truth cannot be updated.
+- Verification fails for unrelated repo reasons after one focused retry.
+- A code-review bot/agent error persists after rerun or cannot be explained.
+
+## Handoff Audit
+
+- [x] Objective is singular and end-to-end.
+- [x] Completion condition is objectively checkable.
+- [x] Tracker state was fetched during planning.
+- [x] Branch names/order are exact.
+- [x] Dependencies/blockers are represented.
+- [x] Ignored/untracked source docs are avoided as load-bearing inputs.
+- [x] Validation commands match repo conventions.
+- [x] `GOAL.md` requires transcript-visible proof.
+- [x] `GOAL.md` requires `RETRO.md` finalization before completion.
+- [x] Stop rules are concrete.
+- [x] `RETRO.md` has concrete sections for execution, tracker, review, verification, remote state, forbidden actions, final state, and archive readiness.
+- [x] Packet can be executed without chat history.

--- a/.agents/plans/2026-05-21-plugin-skills-m1-audit/REFS.md
+++ b/.agents/plans/2026-05-21-plugin-skills-m1-audit/REFS.md
@@ -1,0 +1,89 @@
+# References: plugin-skills-m1-audit
+
+> Note: absolute `/Users/mg/...` paths in this reference file are machine-local evidence from the M1 audit environment. They are not portable defaults for future implementation; use repo-relative paths or `$HOME`-relative skill roots when turning findings into scripts/docs.
+
+## Repo Guidance
+
+- `AGENTS.md` - Trails repo operating guidance, Graphite workflow, lexicon, Warden rule index, and release/testing expectations.
+- `.agents/plans/PLANNING.md` - repo-local goal-planning conventions, including tracked packets, Graphite rules, local review, remote review, and stop rules.
+
+## Tracker Records
+
+- Project: `Trails Plugin & Skills One-Stop Shop`
+  - URL: `https://linear.app/outfitter/project/trails-plugin-and-skills-one-stop-shop-9912d0c573e7`
+- Parent:
+  - `TRL-741` - `https://linear.app/outfitter/issue/TRL-741/project-trails-plugin-and-skills-one-stop-shop`
+- M1:
+  - `TRL-745` - `https://linear.app/outfitter/issue/TRL-745/audit-plugin-coverage-for-current-packages-adapters-and-subpaths`
+  - `TRL-742` - `https://linear.app/outfitter/issue/TRL-742/audit-repo-plugin-and-skills-against-current-trails-doctrine`
+  - `TRL-743` - `https://linear.app/outfitter/issue/TRL-743/audit-installed-and-distributed-trails-skill-surfaces`
+  - `TRL-744` - `https://linear.app/outfitter/issue/TRL-744/audit-trails-plugin-hook-opportunities-and-integration-points`
+  - `TRL-754` - `https://linear.app/outfitter/issue/TRL-754/synthesize-plugin-audits-into-an-executable-refresh-stack`
+- Downstream issues to refresh from M1 evidence:
+  - `TRL-746` - main Trails skill refresh.
+  - `TRL-747` - references/templates/examples refresh.
+  - `TRL-748` - agent/rules/advisory skills/hook messaging refresh.
+  - `TRL-749` - plugin metadata sync and drift checks.
+  - `TRL-750` - local installed skill sync/check path.
+  - `TRL-751` - plugin hook project detection and version guidance.
+  - `TRL-752` - fresh consumer dogfood smoke.
+  - `TRL-753` - plugin republish and release path.
+
+## Source Artifacts
+
+- `plugin/skills/trails/SKILL.md` - canonical repo plugin skill entrypoint to audit.
+- `plugin/skills/trails/references/**` - deep framework guidance for agents.
+- `plugin/skills/trails/templates/**` - generated or reusable scaffolding examples.
+- `plugin/skills/trails/examples/**` - examples that should match current Trails APIs.
+- `plugin/skills/trails-*/*` - advisory skills bundled with the plugin.
+- `plugin/agents/trail-engineer.md` - plugin agent profile.
+- `plugin/rules/**` - plugin rule guidance.
+- `plugin/hooks/**` - plugin integration hooks.
+- `.claude/skills/**` - repo-tracked Claude skill surfaces.
+- `.agents/skills/**` - repo-tracked Codex/agent skill surfaces.
+- `.claude-plugin/marketplace.json` - marketplace metadata.
+- `plugin/.claude-plugin/plugin.json` - plugin manifest metadata.
+- `README.md` - public package and usage overview.
+- `docs/lexicon.md` - canonical vocabulary.
+- `docs/architecture.md` - framework architecture.
+- `docs/contributing/language-styleguide.md` - public/contributor language rules.
+- `docs/contributing/code-standards.md` - code-shape and documentation conventions.
+- `docs/warden.md` - Warden user guidance.
+- `docs/adr/README.md` and accepted ADRs - architectural decisions to align with.
+- `packages/*/package.json` - package names, versions, exports, and dependencies.
+- `apps/trails/bin/trails.ts` - CLI entrypoint for live help and command inventory.
+
+## Commands
+
+- `gt sync` - refresh local Graphite state before branch work.
+- `git status --short --branch` - branch and dirtiness baseline.
+- `gt log --stack --reverse --no-interactive` - stack order proof.
+- `gh pr list --repo outfitter-dev/trails --state open --json number,title,headRefName,isDraft,mergeable,reviewDecision,updatedAt` - current open PR/collision state.
+- `fd package.json packages apps plugin -E node_modules -E .turbo` - workspace package map.
+- `jq -r '.name + " " + .version' packages/*/package.json` - package/version map.
+- `jq '.exports // empty' packages/*/package.json` - public export map.
+- `bun apps/trails/bin/trails.ts --help` - live CLI command inventory.
+- `bun apps/trails/bin/trails.ts warden guide --manifest` - live Warden manifest/guidance source.
+- `bun run warden:skills:check` - generated skill guidance drift check.
+- `bun run warden:agents:check` - generated agent guidance drift check.
+- `bun run clark:check` - Clark generated profile drift check.
+- `bun run format:check` - markdown and repo formatting check.
+- `git diff --check` - whitespace/conflict-marker check.
+
+## Known Starting Signals
+
+- Local planning observed `main` clean with Graphite showing only `main`; executor must re-run after `gt sync`.
+- Linear M1 issues are currently `TRL-742`, `TRL-743`, `TRL-744`, `TRL-745`, and `TRL-754`, with `TRL-754` as the synthesis capstone.
+- Previous inspection found `/Users/mg/.agents/skills/trails` and `/Users/mg/.config/claude/skills/trails` loading stale global Trails guidance with trailhead-era language. Treat that as a starting hypothesis and re-verify in `TRL-743`.
+- Previous inspection found repo plugin metadata at version `0.3.0` and `plugin/skills/trails/SKILL.md` `metadata.trails.version` at `1.0.0-beta.18`. Re-verify in `TRL-743`.
+- Previous inspection found `@ontrails/http` exporting `./bun`; ensure `@ontrails/http/bun` is covered in `TRL-745`.
+- Previous inspection found all non-private `@ontrails/*` package versions at `1.0.0-beta.18`; re-verify package versions in `TRL-745`.
+- Previous inspection found current `trails --help` commands including `compile`, `completions`, `create`, `deprecate`, `diff`, `doctor`, `guide`, `revise`, `run`, `survey`, `topo`, `validate`, `warden`, `add`, and `draft`; re-verify in `TRL-742`.
+
+## Report Paths
+
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-745-package-coverage.md` - package/subpath truth map and plugin coverage matrix.
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-742-repo-plugin-doctrine.md` - repo plugin/skills doctrine audit.
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-743-distribution-surfaces.md` - installed/distributed skill surface matrix.
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-744-hook-opportunities.md` - hook/integration opportunity audit.
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-754-synthesis.md` - M2/M3 issue refresh and implementation stack recommendation.

--- a/.agents/plans/2026-05-21-plugin-skills-m1-audit/RETRO.md
+++ b/.agents/plans/2026-05-21-plugin-skills-m1-audit/RETRO.md
@@ -1,0 +1,158 @@
+# Execution Retro: plugin-skills-m1-audit
+
+Date started: 2026-05-21
+Date finalized: pending
+Status: Seeded for execution
+Plan: `.agents/plans/2026-05-21-plugin-skills-m1-audit/PLAN.md`
+Goal: `.agents/plans/2026-05-21-plugin-skills-m1-audit/GOAL.md`
+
+Use this as the durable execution ledger. For stacked work, this should normally be the last meaningful file touched before local completion, draft submission, ready-for-review, remote review closeout, merge readiness, archive, or final handoff. Meaningful review-flow changes require a new retro entry.
+
+## Execution Summary
+
+- Objective: Execute M1 audit and synthesis for the Trails Plugin & Skills One-Stop Shop project.
+- Final outcome:
+- Final branch / stack tip:
+- Final PR range:
+- Final tracker state:
+- Final verification state:
+- Remaining risks / P3s:
+- Archive state:
+
+## Branch / PR / Issue Ledger
+
+| Order | Issue | Branch | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `TRL-745` | `trl-745-audit-plugin-coverage-for-current-packages-adapters-and` | #554 | Ready | Package/subpath truth map; CI/Greptile green |
+| 2 | `TRL-742` | `trl-742-audit-repo-plugin-and-skills-against-current-trails-doctrine` | | Planned | Repo plugin doctrine audit |
+| 3 | `TRL-743` | `trl-743-audit-installed-and-distributed-trails-skill-surfaces` | | Planned | Installed/distributed surfaces audit |
+| 4 | `TRL-744` | `trl-744-audit-trails-plugin-hook-opportunities-and-integration` | | Planned | Hook opportunity audit |
+| 5 | `TRL-754` | `trl-754-synthesize-plugin-audits-into-an-executable-refresh-stack` | | Planned | Synthesis and Linear refresh |
+
+## Planning Discoveries
+
+Record discoveries made while preparing or executing the packet.
+
+| Discovery | Evidence | Decision | Impact |
+| --- | --- | --- | --- |
+| M1 is audit-first, not implementation. | Linear project `Trails Plugin & Skills One-Stop Shop`; issues `TRL-742` through `TRL-745`, `TRL-754`. | Stack produces reports and issue refreshes before M2/M3 implementation. | Keeps plugin refresh agents from guessing. |
+| Installed/global Trails skill may be stale. | Prior local inspection found `~/.agents/skills/trails` and Claude symlink paths diverging from repo plugin. | Treat installed skill as audited artifact only; do not use it as doctrine. | Prevents stale trailhead-era instructions from contaminating M1. |
+
+## Deferred / Follow-Up Discoveries
+
+Out-of-goal discoveries belong here first. Create focused follow-up issues when they represent real future work.
+
+| Issue | Discovery | Why Out Of Goal | Link |
+| --- | --- | --- | --- |
+| | | | |
+
+## Tracker Mutations
+
+Record issues, milestones, labels, dependency links, comments, and follow-up issues created or updated during planning/execution.
+
+| Time | Tracker Item | Mutation | Evidence |
+| --- | --- | --- | --- |
+| 2026-05-21 | `TRL-741` project family | Planning packet created for M1. | `.agents/plans/2026-05-21-plugin-skills-m1-audit/` |
+| 2026-05-21 13:18 EDT | `TRL-741` | Added comment linking the M1 packet and naming the five-branch audit/synthesis order. | Comment `e4bb4d9d-b3ea-45c3-8649-94876809ce04` |
+| 2026-05-21 13:19 EDT | `TRL-754` | Added comment linking the M1 packet and clarifying the synthesis output. | Comment `8511d621-8720-4fd3-8e50-43cbb96e8e97` |
+| 2026-05-21 13:25 EDT | M1 Linear graph | Re-fetched project plus `TRL-741`, M1 issues, and downstream `TRL-746` through `TRL-753`; branch names and M1/M2/M3/M4 milestone split match the packet. | Linear project `Trails Plugin & Skills One-Stop Shop`; issue fetches in execution transcript. |
+
+## Report State
+
+| Report | Issue | Status | Notes |
+| --- | --- | --- | --- |
+| `reports/trl-745-package-coverage.md` | `TRL-745` | Complete | Package/subpath truth map; PR #554 |
+| `reports/trl-742-repo-plugin-doctrine.md` | `TRL-742` | Pending | Repo plugin doctrine audit |
+| `reports/trl-743-distribution-surfaces.md` | `TRL-743` | Pending | Distribution and local installed skill audit |
+| `reports/trl-744-hook-opportunities.md` | `TRL-744` | Pending | Hook opportunity audit |
+| `reports/trl-754-synthesis.md` | `TRL-754` | Pending | M2/M3 executable stack synthesis |
+
+## Execution Log
+
+Append meaningful state changes, especially before handoff points.
+
+```text
+YYYY-MM-DD HH:MM TZ - <branch/issue/checkpoint>
+- Changed:
+- Verified:
+- Result:
+- Next:
+- Blockers:
+```
+
+```text
+2026-05-21 13:19 EDT - planning packet
+- Changed: Created PLAN.md, GOAL.md, REFS.md, RETRO.md, and reports/README.md for M1.
+- Verified: Ran format, generated-guidance drift, and whitespace checks.
+- Result: Planning packet ready for execution.
+- Next: Execution agent should run gt sync, create the five-branch local stack, and begin TRL-745.
+- Blockers: None known.
+```
+
+```text
+2026-05-21 13:25 EDT - sync and baseline
+- Changed: Began M1 execution; ran Graphite sync and re-fetched the Linear project, parent, M1 issues, and downstream M2/M3/M4 issues.
+- Verified: `gt sync` returned `ok synced`; `gt checkout main --no-interactive` reported already on main; `git status --short --branch` showed `## main...origin/main` plus the untracked M1 packet; `gt log --stack --reverse --no-interactive` showed only `main` at `399a1ff06`.
+- Result: No open PR collisions were reported by `gh pr list`; M1 branch names from Linear match the packet.
+- Next: Create the five-branch local Graphite stack and commit the plan packet on `TRL-745`.
+- Blockers: None.
+```
+
+```text
+2026-05-21 13:49 EDT - trl-745-report
+- Changed: Completed `reports/trl-745-package-coverage.md` with the package/subpath truth map and recorded PR #554 as the owning branch output.
+- Verified: Report evidence covers local package manifests, export maps, CLI help, qmd search output, and plugin/package reference sweeps; PR #554 was submitted in the draft stack and is now ready with CI, Greptile, and Graphite mergeability checks green.
+- Result: `TRL-745` report work is complete and ready for review as PR #554.
+- Next: Continue the M1 stack with `TRL-742` through `TRL-754` and keep later whole-stack state on the synthesis branch.
+- Blockers: None.
+```
+
+## Local Review Log
+
+Record local review rounds, reports, P0/P1/P2 findings, fixes, and remaining P3s. Do not mark local review complete while P0/P1/P2 findings remain.
+
+| Round | Scope / Lanes | Report Paths | P0/P1/P2 Result | Fix Commits / Notes |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+## Remote Review
+
+Record CI, unresolved threads, and code-review bot/agent summaries after PR submission and ready-for-review.
+
+| PR | CI State | Review Scores / Summaries | Unresolved Threads | Fix Notes |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+## Verification Log
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `git status --short --branch` | Passed during planning | `main` with only the new packet untracked. |
+| `gt log --stack --reverse --no-interactive` | Passed during planning | Stack showed only `main`; executor must re-run after `gt sync`. |
+| `gt sync` | Passed during execution baseline | Returned `ok synced`. |
+| `git status --short --branch` | Passed during execution baseline | `## main...origin/main`; only untracked M1 packet. |
+| `gt log --stack --reverse --no-interactive` | Passed during execution baseline | Stack showed only `main` at `399a1ff06`. |
+| `gh pr list --repo outfitter-dev/trails --state open --json number,title,headRefName,isDraft,mergeable,reviewDecision,updatedAt` | Passed during execution baseline | Returned `[]`; no open PR collision. |
+| `bun run warden:skills:check` | Passed during planning | No generated skill guidance drift. |
+| `bun run warden:agents:check` | Passed during planning | No generated agent guidance drift. |
+| `bun run clark:check` | Passed during planning | Clark Codex wrapper up to date. |
+| `bun run format:check` | Passed during planning | Ultracite/Oxlint checks clean. |
+| `git diff --check` | Passed during planning | No whitespace/conflict-marker issues. |
+
+## Forbidden-Action Audit
+
+| Action | Status | Notes |
+| --- | --- | --- |
+| Merge | Confirmed not done | PR stack remains open; no merge command was run. |
+| Publish / registry mutation | Confirmed not done | No npm/plugin/marketplace publish or registry write was performed. |
+| Global installed skill mutation | Confirmed not done | Global skill paths were inspected read-only only. |
+| Merge queue label | Confirmed not done | No merge queue labels were added. |
+| Source-control writes by subagents | Confirmed not done | Subagents reported read-only evidence only; main agent performed source-control writes. |
+| Other irreversible actions | Confirmed not done | Linear comments/description updates were the only tracker writes. |
+
+## Final State
+
+- Completed:
+- Remaining risks:
+- Skipped checks:
+- Archive readiness:

--- a/.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/README.md
+++ b/.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/README.md
@@ -1,0 +1,30 @@
+# M1 Report Templates
+
+Use these reports as evidence artifacts. Keep them source-backed and concise enough that a future implementation agent can act without rediscovering M1.
+
+Each report should include:
+
+- issue ID and branch name;
+- scope inspected;
+- commands run;
+- findings table with severity, evidence, and owner issue;
+- explicit unknowns;
+- recommended downstream changes;
+- verification summary.
+
+For findings, use this shape:
+
+```markdown
+| Severity | Evidence | Finding | Owner |
+| --- | --- | --- | --- |
+| P2 | `path/to/file.md:42` - "<short quote>" | The plugin teaches stale trailhead vocabulary. | `TRL-746` |
+```
+
+Severity rules:
+
+- P0: cannot proceed safely.
+- P1: correctness, public contract, or doctrine contradiction.
+- P2: documentation correctness, misleading examples, missing coverage, noisy hook risk, or stale tracker scope.
+- P3: style-only or optional polish.
+
+Documentation correctness is P2 by default.

--- a/.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-745-package-coverage.md
+++ b/.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-745-package-coverage.md
@@ -1,0 +1,210 @@
+# TRL-745 Package Coverage Audit
+
+Date: 2026-05-21
+Branch: `trl-745-audit-plugin-coverage-for-current-packages-adapters-and`
+Scope: current `@ontrails/*` package, adapter, subpath, and key export truth that the Trails plugin/skills refresh must teach.
+
+## Executive Summary
+
+The live workspace has 19 non-private `@ontrails/*` packages at `1.0.0-beta.18`, plus the private repo-local `@ontrails/oxlint-plugin`. The repo plugin already teaches the core mental model, CLI/MCP/Hono surfaces, resources, testing, and Warden, but it is not yet a one-stop package map. The largest refresh gaps are:
+
+- `@ontrails/http/bun` is a real exported subpath and has package README coverage, but the main skill only shows Hono for HTTP.
+- `@ontrails/pino` and `@ontrails/wayfinder` are missing from the plugin architecture reference, and `@ontrails/wayfinder` must be taught as shell-only.
+- `@ontrails/store` and `@ontrails/drizzle` appear in the plugin dependency graph but not in the package layout tables.
+- The testing reference omits the shipped HTTP harness even though `@ontrails/testing` exports it and `testSurfaceParity()` runs CLI/MCP/HTTP semantics.
+- Package taxonomy is split across sources: `docs/architecture.md` is the strongest current package map; `README.md` and `plugin/skills/trails/references/architecture.md` are partial.
+
+Recommended owner routing:
+
+- `TRL-746`: refresh the main `trails` skill entrypoint and first-screen package/surface guidance.
+- `TRL-747`: refresh package references, templates, examples, HTTP docs, getting-started install guidance, and testing reference coverage.
+- `TRL-748`: use only for downstream advisory/agent/rules copy that repeats stale package names or Warden rule labels.
+- `TRL-749`: use for metadata/version checks, not package content.
+- `TRL-751`: use for hook-time package/version guidance only.
+
+## Evidence Commands
+
+- `jq -r '.name + " " + .version + " private=" + ((.private // false)|tostring)' adapters/*/package.json packages/*/package.json` found every package at `1.0.0-beta.18`; `@ontrails/oxlint-plugin` is the only private package.
+- `jq -r 'select(.private != true) | .name as $name | (.exports // {}) | to_entries[] | $name + " " + .key + " -> " + (.value|tostring)' adapters/*/package.json packages/*/package.json` found the public subpaths listed below.
+- `bun apps/trails/bin/trails.ts --help` listed current CLI commands: `compile`, `completions`, `create`, `deprecate`, `diff`, `doctor`, `guide`, `revise`, `run`, `survey`, `topo`, `validate`, `warden`, `add`, `dev`, `draft`, and `help`.
+- `QMD_FORCE_CPU=1 qmd search "@ontrails/http/bun wayfinder pino vite adapter" --line-numbers -n 8` returned no hits. A prior `qmd query "surface adapter package taxonomy HTTP Bun Hono Wayfinder Pino Trails architecture" --line-numbers --no-rerank -n 8` returned `docs/architecture.md` and `plugin/skills/trails/references/architecture.md`, but exited with a native cleanup warning after printing results. I treated the printed results only as search evidence and re-read the files with `nl -ba`.
+- `rg -n "@ontrails/(core|cli|commander|mcp|http|hono|store|drizzle|config|permits|observe|tracing|logtape|pino|testing|topographer|warden|wayfinder|vite)|http/bun|Bun-native" plugin/skills/trails plugin/agents plugin/rules plugin/README.md README.md docs/architecture.md` confirmed plugin references for core/CLI/MCP/Hono/testing/Warden but no plugin hits for `@ontrails/pino`, `@ontrails/wayfinder`, or `@ontrails/http/bun`.
+
+## Package And Subpath Truth Map
+
+### Surface And App Packages
+
+- `@ontrails/cli` - command model and output formatting. Export: `.`.
+  Evidence: `docs/architecture.md:149` says it is the "Framework-agnostic command model, flag derivation, output formatting".
+  Plugin status: present in `plugin/skills/trails/references/architecture.md:90`, but the main skill teaches the user-facing Commander adapter first.
+
+- `@ontrails/commander` - Commander CLI adapter. Export: `.`.
+  Evidence: `docs/architecture.md:150` says "Commander adapter, `surface()`"; `plugin/skills/trails/SKILL.md:104-109` shows `import { surface } from '@ontrails/commander'`.
+  Plugin status: covered.
+
+- `@ontrails/mcp` - MCP surface. Export: `.`.
+  Evidence: `docs/architecture.md:151` and `plugin/skills/trails/SKILL.md:111-116` both identify MCP as a `surface()` package.
+  Plugin status: covered.
+
+- `@ontrails/http` - framework-agnostic HTTP surface model. Exports: `.`, `./bun`, `./fetch`.
+  Evidence: `packages/http/package.json:13-17` exports `./bun` and `./fetch`; `packages/http/README.md:25-35` shows Bun-native use from `@ontrails/http/bun`; `docs/architecture.md:152` calls out "Bun-native subpath".
+  Plugin status: partially covered. The plugin main skill only shows `@ontrails/hono` for HTTP at `plugin/skills/trails/SKILL.md:118-123`, and there is no `plugin/skills/trails/references/http-surface.md`.
+
+- `@ontrails/hono` - Hono HTTP adapter. Export: `.`.
+  Evidence: `docs/architecture.md:153` and `packages/http/README.md:7-23` show Hono surface usage.
+  Plugin status: covered as the only HTTP example, which makes the `@ontrails/http/bun` gap more visible.
+
+- `@ontrails/vite` - Vite middleware adapter. Export: `.`.
+  Evidence: `adapters/vite/package.json:24-28` lists only dev dependencies, while `docs/architecture.md:154` says external dep is "None (node:stream only)".
+  Plugin status: stale in the plugin architecture reference. `plugin/skills/trails/references/architecture.md:95` says external dep `vite`.
+
+### Infrastructure And Observability Packages
+
+- `@ontrails/config` - config resolution, profiles, resource config schemas, diagnostics. Export: `.`.
+  Evidence: `docs/architecture.md:160`; current workspace has `trails.config.ts:1-13` using `defineConfig`.
+  Plugin status: present in `plugin/skills/trails/references/architecture.md:101`, not surfaced in the main skill.
+
+- `@ontrails/permits` - permit model and auth adapters. Exports: `.`, `./jwt`, `./testing`.
+  Evidence: command export summary; `docs/architecture.md:161` identifies the package.
+  Plugin status: present in the plugin architecture reference, not in the main skill's package orientation.
+
+- `@ontrails/store` - backend-agnostic store definitions. Exports: `.`, `./adapter-support`, `./jsonfile`, `./trails`, `./testing`.
+  Evidence: command export summary; `docs/architecture.md:162` identifies store as an infrastructure package.
+  Plugin status: missing from the plugin architecture table at `plugin/skills/trails/references/architecture.md:97-105`, even though the dependency graph later mentions it at `plugin/skills/trails/references/architecture.md:126`.
+
+- `@ontrails/drizzle` - Drizzle SQLite store adapter. Export: `.`.
+  Evidence: `docs/architecture.md:163`; package command summary shows `@ontrails/drizzle 1.0.0-beta.18`.
+  Plugin status: missing from the plugin infrastructure table at `plugin/skills/trails/references/architecture.md:97-105`, even though the dependency graph mentions it at `plugin/skills/trails/references/architecture.md:127`.
+
+- `@ontrails/observe` - production log/trace sink contracts. Export: `.`.
+  Evidence: `docs/architecture.md:164`.
+  Plugin status: covered in the plugin architecture table at `plugin/skills/trails/references/architecture.md:103`.
+
+- `@ontrails/tracing` - dev-state tracing and OTel support. Exports: `.`, `./otel`.
+  Evidence: command export summary; `docs/architecture.md:165`.
+  Plugin status: covered in the plugin architecture table but without the `./otel` subpath.
+
+- `@ontrails/logtape` - LogTape sink adapter. Export: `.`.
+  Evidence: `docs/architecture.md:166`.
+  Plugin status: covered in the plugin architecture table and graph.
+
+- `@ontrails/pino` - Pino sink adapter. Export: `.`.
+  Evidence: `packages/pino/package.json:1-15` and `packages/pino/README.md:1-12`; `docs/architecture.md:167` calls it a Pino sink adapter with no hard runtime dependency.
+  Plugin status: missing from `plugin/skills/trails/references/architecture.md:97-105` and `plugin/skills/trails/references/architecture.md:117-135`.
+
+### Ecosystem Packages
+
+- `@ontrails/core` - Result, errors, primitives, validation, execution pipeline, and adapter ports. Exports: `.`, `./patterns`, `./redaction`, `./store`, `./trails`.
+  Evidence: command export summary; `docs/architecture.md:141`.
+  Plugin status: covered.
+
+- `@ontrails/testing` - contract tests, examples, harnesses, surface parity. Export: `.`.
+  Evidence: `packages/testing/README.md:35-42` lists `testSurfaceParity`, CLI/MCP/HTTP harnesses; `packages/testing/src/index.ts:37-40` exports `createCliHarness`, `createHttpHarness`, and `createMcpHarness`.
+  Plugin status: partial. `plugin/skills/trails/SKILL.md:181` mentions only `createCliHarness()` and `createMcpHarness()`, and `plugin/skills/trails/references/testing-patterns.md:214-240` omits the HTTP harness.
+
+- `@ontrails/topographer` - TopoGraphs, semantic diffing, lock manifest, topo-store persistence. Exports: `.`, `./backend-support`.
+  Evidence: command export summary; `docs/architecture.md:174`.
+  Plugin status: covered at a high level.
+
+- `@ontrails/warden` - rule manifest and governance checks. Exports: `.`, `./ast`, `./resolve`.
+  Evidence: command export summary; `bun apps/trails/bin/trails.ts warden guide --manifest` returned `ruleCount: 56`.
+  Plugin status: covered, with one advisory-agent rule-label gap captured in `TRL-742`.
+
+- `@ontrails/wayfinder` - shell package for future agent wayfinding trails. Export: `.`.
+  Evidence: `packages/wayfinder/package.json:1-4` says "package shell only -- no trails ship yet"; `packages/wayfinder/README.md:9-17` says "**Status: shell only.** No trails ship yet."
+  Plugin status: missing. The refresh should mention it, but clearly as a reserved/shell package rather than shipped runtime capability.
+
+## Findings
+
+### P2 - Plugin architecture reference is no longer a complete package map
+
+Evidence:
+
+- Current architecture includes `@ontrails/store`, `@ontrails/drizzle`, `@ontrails/pino`, and Vite with no external runtime dependency at `docs/architecture.md:160-167` and `docs/architecture.md:201-205`.
+- Plugin architecture omits `store`, `drizzle`, and `pino` from the infrastructure table at `plugin/skills/trails/references/architecture.md:97-105`.
+- Plugin architecture says `@ontrails/vite` external dep is `vite` at `plugin/skills/trails/references/architecture.md:95`, while `docs/architecture.md:154` says "None (node:stream only)".
+
+Recommended owner issue: `TRL-747`.
+
+Prompt to fix with AI:
+
+> Refresh `plugin/skills/trails/references/architecture.md` from `docs/architecture.md` and package export maps. Include store, drizzle, pino, wayfinder shell status, current Vite dependency wording, and the current `@ontrails/http` `./bun` and `./fetch` subpaths without changing implementation code.
+
+### P2 - Main skill under-teaches HTTP by only showing Hono
+
+Evidence:
+
+- `packages/http/package.json:13-17` exports `./bun` and `./fetch`.
+- `packages/http/README.md:25-35` documents `@ontrails/http/bun` and says it uses Bun native serving with no third-party runtime dependency.
+- `plugin/skills/trails/SKILL.md:118-123` shows HTTP only through `@ontrails/hono`.
+- `plugin/skills/trails/SKILL.md:125` says to see "the HTTP surface docs", but `fd . plugin/skills/trails/references -t f` shows no HTTP surface reference file.
+
+Recommended owner issue: `TRL-746` for first-screen skill guidance, `TRL-747` for the missing reference file and examples.
+
+Prompt to fix with AI:
+
+> Update the main `trails` skill HTTP section to teach Hono and Bun-native HTTP as peer materializers over the same `@ontrails/http` route/fetch kernel. Add an HTTP surface reference covering `deriveHttpRoutes`, `deriveOpenApiSpec`, `@ontrails/http/fetch`, `@ontrails/http/bun`, Hono, route derivation, and error projection.
+
+### P2 - Getting-started install guidance does not cover shipped HTTP choices
+
+Evidence:
+
+- `plugin/skills/trails/references/getting-started.md:11-14` installs only core, CLI, Commander, MCP, and testing.
+- Current public getting-started docs include "Open an HTTP Surface" at `docs/getting-started.md:148-165`.
+- `packages/http/README.md:145-151` says to install `@ontrails/http @ontrails/hono`, or only `@ontrails/http` for Bun-native serving.
+
+Recommended owner issue: `TRL-747`.
+
+Prompt to fix with AI:
+
+> Refresh plugin getting-started install and walkthrough docs so CLI, MCP, Hono HTTP, Bun-native HTTP, and testing are represented as optional packages/surfaces with copy-pasteable imports. Keep the starter minimal but make the shipped HTTP path discoverable.
+
+### P2 - Testing reference omits the HTTP harness and surface parity coverage
+
+Evidence:
+
+- `packages/testing/README.md:35-42` lists `testSurfaceParity`, `createCliHarness`, `createMcpHarness`, and `createHttpHarness`.
+- `packages/testing/README.md:96-119` demonstrates CLI, MCP, and HTTP harnesses together.
+- `packages/testing/src/harness-http.ts:161-174` documents `createHttpHarness`.
+- `plugin/skills/trails/references/testing-patterns.md:214-240` has CLI and MCP harnesses only.
+- `plugin/skills/trails/SKILL.md:181` says "Surface integration uses `createCliHarness()` / `createMcpHarness()`."
+
+Recommended owner issue: `TRL-747`.
+
+Prompt to fix with AI:
+
+> Update the plugin testing reference and main skill testing paragraph to include `createHttpHarness()` and `testSurfaceParity()`. Keep examples concise and route deeper API details to the package README/API docs.
+
+### P2 - `@ontrails/wayfinder` needs explicit shell-only treatment
+
+Evidence:
+
+- `packages/wayfinder/package.json:4` describes the package as "shell only -- no trails ship yet".
+- `packages/wayfinder/README.md:9-17` says no trails ship yet and lists future trail IDs such as `wayfind.overview`, `wayfind.search`, `wayfind.trail`, and `wayfind.examples`.
+- `rg` found no plugin references to `@ontrails/wayfinder`.
+
+Recommended owner issue: `TRL-746` for the main package orientation and `TRL-747` for references.
+
+Prompt to fix with AI:
+
+> Add `@ontrails/wayfinder` to the plugin package map as a reserved shell package, not a shipped runtime feature. Link it to the draft wayfinding ADR and avoid teaching non-existent exported trails.
+
+### P3 - Source package tables disagree on the complete package list
+
+Evidence:
+
+- `README.md:142-155` lists core, CLI, Commander, MCP, HTTP, Hono, store, testing, topographer, observe, tracing, logtape, pino, and warden.
+- The same README table omits current packages `@ontrails/config`, `@ontrails/permits`, `@ontrails/drizzle`, `@ontrails/vite`, and `@ontrails/wayfinder`.
+- `docs/architecture.md:145-175` is more complete for current package layers.
+
+Recommended owner issue: `TRL-746` for plugin entrypoint source selection. If the implementation pass changes public README package taxonomy, create a separate docs follow-up rather than bundling it into plugin refresh.
+
+Prompt to fix with AI:
+
+> During `TRL-746`, treat `docs/architecture.md` plus package export maps as the package taxonomy source of truth. If public README package coverage should be made complete too, file a small docs follow-up rather than hiding that change in the plugin stack.
+
+## Unable To Verify
+
+- I did not check npm registry state or published package tarballs. The goal forbids registry mutation and the audit only needs local package/export truth.
+- I did not run `bun run publish:check`; no package contents are being changed in this M1 report branch.
+- The package map above uses local workspace package manifests and source docs after `gt sync`; it should be refreshed before M2 if the package line advances beyond `1.0.0-beta.18`.


### PR DESCRIPTION
## Context

Part of M1 for Linear `TRL-745` in the Trails Plugin & Skills One-Stop Shop project. This branch establishes the source-backed package/subpath truth map that downstream plugin refresh work should consume.

## What changed

- Adds the M1 planning packet under `.agents/plans/2026-05-21-plugin-skills-m1-audit/`.
- Adds `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-745-package-coverage.md`.
- Maps current `@ontrails/*` packages, adapters, key subpaths, and plugin coverage gaps, including `@ontrails/http/bun`, `@ontrails/pino`, and shell-only `@ontrails/wayfinder`.

## How to test

- `bun run warden:skills:check`
- `bun run warden:agents:check`
- `bun run clark:check`
- `bun run format:check`
- `git diff --check`

## Risks / rollout

Docs/report-only. No source, plugin hook, package, publish, registry, merge queue, or global installed skill mutation.