### PR TITLE
docs: add plugin skills refresh plan

### DIFF
--- a/.agents/plans/2026-05-21-plugin-skills-refresh-stack/GOAL.md
+++ b/.agents/plans/2026-05-21-plugin-skills-refresh-stack/GOAL.md
@@ -1,0 +1,126 @@
+# Goal Prompt: plugin-skills-refresh-stack
+
+Paste this into the goal runtime:
+
+`````markdown
+/goal Execute the Trails Plugin & Skills One-Stop Shop refresh stack end to end from the Trails repo root.
+
+Primary source of truth:
+`.agents/plans/2026-05-21-plugin-skills-refresh-stack/PLAN.md`
+
+Read first:
+- `AGENTS.md`
+- `.agents/plans/PLANNING.md`
+- `.agents/plans/2026-05-21-plugin-skills-refresh-stack/PLAN.md`
+- `.agents/plans/2026-05-21-plugin-skills-refresh-stack/REFS.md`
+- `.agents/plans/2026-05-21-plugin-skills-refresh-stack/RETRO.md`
+- M1 audit packet at `.agents/plans/2026-05-21-plugin-skills-m1-audit/` before archive, then `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/` after the lowest branch archives it.
+- PatchOS upstream retro if accessible in the operator's PatchOS checkout; otherwise use the summarized PatchOS findings in this packet's `RETRO.md`.
+- Linear project `Trails Plugin & Skills One-Stop Shop`
+- Linear issues `TRL-755`, `TRL-746`, `TRL-747`, `TRL-748`, `TRL-749`, `TRL-750`, `TRL-751`, `TRL-752`, `TRL-753`
+- Adjacent PatchOS-derived Linear follow-ups `TRL-757`, `TRL-758`, `TRL-759`, `TRL-760`
+
+Objective:
+Build, locally review, submit, mark ready, and remote-review the nine-branch plugin refresh stack that turns the M1 audit into an updated Trails plugin/skills one-stop shop. Do not merge. Do not publish or mutate registries/marketplace/global skill paths without explicit operator approval.
+
+Start condition:
+Run `gt sync` first, check out `main`, and verify `main` includes PR #558 or later. Stop if the M1 audit stack has not landed.
+
+Branch order, bottom to top:
+1. TRL-755 - `trl-755-refresh-public-docs-drift-found-during-plugin-skills-audit`
+2. TRL-746 - `trl-746-refresh-the-main-trails-skill-into-the-canonical-one-stop`
+3. TRL-747 - `trl-747-refresh-trails-skill-references-templates-and-examples`
+4. TRL-748 - `trl-748-refresh-plugin-agent-rules-advisory-skills-and-hook`
+5. TRL-749 - `trl-749-add-plugin-metadata-sync-and-drift-checks`
+6. TRL-750 - `trl-750-add-local-installed-trails-skill-synccheck-path`
+7. TRL-751 - `trl-751-improve-trails-plugin-hooks-for-project-detection-and`
+8. TRL-752 - `trl-752-dogfood-refreshed-trails-plugin-with-a-fresh-consumer-smoke`
+9. TRL-753 - `trl-753-republish-trails-plugin-and-document-the-release-path`
+
+Lowest-branch cleanup:
+On `TRL-755`, move the completed M1 packet from `.agents/plans/2026-05-21-plugin-skills-m1-audit/` to `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/`. Update Linear descriptions or comments for issues that reference the M1 reports so future agents use the archived path. This refresh-stack packet is pre-seeded on `main`; only commit branch-local archive/path-reference updates on `TRL-755`.
+
+Scope:
+- TRL-755: fix public README/API docs drift from M1, including Topographer `TopoGraph`/lock wording, package-table completeness/intentional incompleteness, and `VersionNotSupportedError`.
+- TRL-746: refresh `plugin/skills/trails/SKILL.md` as the concise first-load briefing.
+- TRL-747: refresh skill references, templates, examples, and add HTTP/Bun guidance.
+- TRL-748: refresh plugin agent, rules, advisory skills, Clark calibration, and hook message copy.
+- TRL-749: define plugin metadata policy and add read-only check/sync tooling with tests.
+- TRL-750: add local installed skill drift checker with tests; no global mutation by default.
+- TRL-751: improve Claude hook detection/guidance with tests; document Codex parity as unknown unless verified.
+- TRL-752: dogfood the refreshed bundle in a disposable consumer project and commit a report at `.agents/plans/2026-05-21-plugin-skills-refresh-stack/reports/trl-752-dogfood.md`.
+- TRL-753: document and dry-run the release path, final project status, and operator-only publish blockers.
+- PatchOS retro: use it as downstream dogfood evidence. Record whether `TRL-757` testing subpath boundaries, `TRL-758` Topographer CLI/docs ergonomics, `TRL-759` beta channel policy, or `TRL-760` migration guide block plugin release or remain deferred follow-ups. Do not silently implement those adjacent issues unless I explicitly expand scope.
+
+Important constraints:
+- Do not use the installed/global `trails` skill as doctrine. It is a drift-check target only.
+- Do not publish, mutate npm/registry/marketplace state, run `npx skills outfitter-dev/trails` against a real global install target, or mutate global installed skill paths without explicit operator approval.
+- Do not use `gt absorb`.
+- Do not add merge queue labels.
+- Do not merge.
+
+Local review:
+Before remote submission, run at least three local review passes from the stack tip:
+1. Skill/docs doctrine: public docs, main skill, references, examples, package taxonomy, error/resource/testing/composition guidance.
+2. Tooling/hooks safety: metadata policy/checks, installed-skill checker, hook detection, no global mutation, no noisy non-Trails behavior.
+3. Dogfood/release readiness: smoke report, release runbook, stop rules, local/global install guidance, operator-only actions.
+
+Reviewer output must include:
+- Overall score: n/5
+- Summary
+- Findings with P0/P1/P2/P3 severity and evidence
+- Prompt To Fix With AI for each actionable finding
+
+Fix all P0/P1/P2 findings bottom-up before remote submission or ready-for-review. Documentation correctness is P2 by default; P3 is style-only.
+
+Verification:
+Run branch-appropriate targeted checks, then at the stack tip surface transcript-visible summaries for:
+
+```bash
+bun run warden:skills:check
+bun run warden:agents:check
+bun run clark:check
+bun test scripts/__tests__/sync-plugin-metadata.test.ts
+bun test scripts/__tests__/check-installed-trails-skill.test.ts
+bun test scripts/__tests__/detect-trails-hook.test.ts
+bun run typecheck
+bun run test
+bun run lint
+bun run build
+bun run check
+bun run format:check
+git diff --check
+```
+
+If generated Warden/agent content changes, run the corresponding sync commands before check commands:
+
+```bash
+bun run warden:skills:sync
+bun run warden:agents:sync
+```
+
+Release/dogfood rules:
+- Use `.trails-tmp/plugin-dogfood/` or a disposable tempdir for dogfood; do not commit the generated consumer project.
+- Record exact dogfood commands, versions, typecheck/test/Warden results, installed-skill check result, cleanup state, and skipped commands in `reports/trl-752-dogfood.md`.
+- Include PatchOS-style smoke coverage: explicit MCP include-list safety, output schemas, resource mocks or `unmockable`, error taxonomy normalization, opt-in observe/tracing without stdout pollution, `trails compile` / `trails validate`, and package install guidance for `@beta` or explicit beta.N versus accidental `latest`.
+- `bun run publish:check` is allowed as a dry/read-only packaging check if useful.
+- `bun run publish:packages`, marketplace publish, registry mutation, `npx skills` mutation, and global skill mutation are forbidden without explicit operator approval.
+
+Remote review:
+Submit draft PRs only after implementation, local verification, and local review are clean/P3-only. Mark ready only after CI and local review are clean. After ready, check CI, unresolved review threads, and code-review bot/agent summaries. Record numeric review scores, prose summaries, prompt-to-fix text, and fixes in `RETRO.md`. Resolve all P0/P1/P2 feedback from the owning lower branch upward. Treat pending Graphite mergeability by itself as service lag when GitHub checks/review are otherwise clean.
+
+Completion condition:
+The goal is complete only when all nine branches/PRs exist in the stated order, M1 packet cleanup is done, Linear is current, implementation is complete, dogfood/release reports exist, local review is clean or P3-only after at least three passes, PRs are marked ready with high-quality bodies, remote review/CI has no unresolved P0/P1/P2 findings or bot errors, required verification has passed or skipped checks are explained, no publish/registry/marketplace/global-skill mutation/merge/merge queue label/`gt absorb` happened, and the final transcript reports branch/PR state, changed artifacts, commands/results, skipped checks, remaining P3s/risks, tracker state, and finalized `RETRO.md` state.
+
+Retro discipline:
+Maintain `.agents/plans/2026-05-21-plugin-skills-refresh-stack/RETRO.md` as the durable execution ledger. Touch it last before local completion, draft submission, ready-for-review, remote review closeout, release handoff, merge readiness, archive, or final handoff. Any meaningful local or remote review change must be reflected in `RETRO.md` before claiming that review loop is complete.
+
+Stop and ask if:
+- The M1 audit stack is not present on `main`.
+- A public API or doctrine decision is required beyond M1 findings and issue bodies.
+- The work requires publish, registry mutation, marketplace mutation, `npx skills` mutation, global installed skill mutation, secrets, or credentials without explicit approval.
+- A hook would need to mutate files or run noisy checks by default.
+- Linear writes are unavailable and tracker references cannot be corrected after archiving M1.
+- Verification fails for unrelated reasons after one focused retry.
+- More than four post-ready remote-review turns pass and P2+ feedback remains unresolved.
+`````

--- a/.agents/plans/2026-05-21-plugin-skills-refresh-stack/PLAN.md
+++ b/.agents/plans/2026-05-21-plugin-skills-refresh-stack/PLAN.md
@@ -1,0 +1,507 @@
+# Goal Plan: plugin-skills-refresh-stack
+
+Date: 2026-05-21
+Status: Ready for execution
+
+## Objective
+
+Execute the Trails Plugin & Skills One-Stop Shop implementation stack from the merged M1 audit: refresh the public source docs and plugin skill bundle, add metadata and installed-skill drift checks, improve hook guidance, dogfood the result, and prepare the plugin release path without publishing unless explicitly approved.
+
+This stack starts with `TRL-755` because public docs are part of the source-of-truth surface that the plugin refresh will lean on. It also uses the lowest branch to archive the completed M1 packet and keep Linear paths current.
+
+PatchOS beta.15 -> beta.18 dogfood is now an additional upstream evidence source for this stack. It does not change the nine-branch plugin stack order, but it sharpens `TRL-752` and `TRL-753` and produced adjacent v1 follow-up issues: `TRL-757`, `TRL-758`, `TRL-759`, and `TRL-760`.
+
+## Completion Condition
+
+The goal is complete only when:
+
+- The nine-branch Graphite stack exists in this order:
+  1. `TRL-755`
+  2. `TRL-746`
+  3. `TRL-747`
+  4. `TRL-748`
+  5. `TRL-749`
+  6. `TRL-750`
+  7. `TRL-751`
+  8. `TRL-752`
+  9. `TRL-753`
+- The completed M1 audit packet has been moved from `.agents/plans/2026-05-21-plugin-skills-m1-audit/` to `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/` on the lowest branch, and Linear references that need the report paths have been updated or commented with the archived path.
+- `TRL-755` fixes the public-docs drift called out by M1, or explicitly documents any package-table incompleteness as intentional.
+- `TRL-746` through `TRL-748` make the repo plugin skill, references, templates, examples, agent, rules, advisory skills, and hook copy current.
+- `TRL-749` and `TRL-750` add check-first metadata and installed-skill drift tooling with tests.
+- `TRL-751` improves hook detection/guidance without global mutation or noisy non-Trails output.
+- `TRL-752` dogfoods the refreshed bundle in a disposable consumer project and commits a dogfood report.
+- `TRL-753` documents the release/republish path and runs dry/read-only release checks; actual publish/registry/marketplace/global-skill mutation happens only with explicit operator approval.
+- PatchOS-derived adjacent issues are logged and cross-referenced, and this stack records whether they block plugin release or remain deferred follow-ups.
+- Local review runs before remote submission and stops only when P0/P1/P2 findings are fixed.
+- PRs are submitted with high-quality bodies, marked ready only after local review and CI are clean, and post-ready remote review resolves P0/P1/P2 feedback.
+- Required verification passes, or skipped checks are explained in `RETRO.md`.
+- `RETRO.md` has final tracker, branch/PR, review, verification, forbidden-action, remaining-risk, and archive-readiness state, and the final transcript reports the proof.
+
+## Non-Goals
+
+- Do not publish the plugin, mutate a registry, mutate marketplace state, run `npx skills outfitter-dev/trails` against a real global install target, or mutate global installed skill paths without explicit operator approval at execution time.
+- Do not treat the installed/global `trails` skill as doctrine. It is known to have been stale; inspect it only as a drift-check target.
+- Do not implement unrelated Trails framework behavior beyond the plugin/docs/tooling surfaces named in the issues.
+- Do not absorb adjacent PatchOS-derived framework issues into this plugin stack unless Matt explicitly expands scope. `TRL-757`, `TRL-758`, `TRL-759`, and `TRL-760` are tracked follow-ups that this stack should reference and dogfood against, not silently implement wholesale.
+- Do not broaden `TRL-755` into a public docs rewrite. Fix the audited drift and keep larger docs IA decisions explicit.
+- Do not merge. Do not add merge queue labels.
+
+## Source Of Truth
+
+Read first:
+
+1. `AGENTS.md`
+2. `.agents/plans/PLANNING.md`
+3. `.agents/plans/2026-05-21-plugin-skills-refresh-stack/PLAN.md`
+4. `.agents/plans/2026-05-21-plugin-skills-refresh-stack/REFS.md`
+5. `.agents/plans/2026-05-21-plugin-skills-refresh-stack/RETRO.md`
+6. M1 audit packet at `.agents/plans/2026-05-21-plugin-skills-m1-audit/` before archive, then `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/` after Phase 1.
+7. PatchOS upstream retro if accessible in the operator's PatchOS checkout; otherwise use the summarized PatchOS findings in this packet's `RETRO.md`.
+8. Linear project `Trails Plugin & Skills One-Stop Shop`
+9. Linear issues: `TRL-755`, `TRL-746`, `TRL-747`, `TRL-748`, `TRL-749`, `TRL-750`, `TRL-751`, `TRL-752`, `TRL-753`
+10. Adjacent PatchOS-derived follow-ups: `TRL-757`, `TRL-758`, `TRL-759`, `TRL-760`
+
+## Branch Order
+
+Bottom to top:
+
+| Order | Issue | Branch |
+| --- | --- | --- |
+| 1 | `TRL-755` | `trl-755-refresh-public-docs-drift-found-during-plugin-skills-audit` |
+| 2 | `TRL-746` | `trl-746-refresh-the-main-trails-skill-into-the-canonical-one-stop` |
+| 3 | `TRL-747` | `trl-747-refresh-trails-skill-references-templates-and-examples` |
+| 4 | `TRL-748` | `trl-748-refresh-plugin-agent-rules-advisory-skills-and-hook` |
+| 5 | `TRL-749` | `trl-749-add-plugin-metadata-sync-and-drift-checks` |
+| 6 | `TRL-750` | `trl-750-add-local-installed-trails-skill-synccheck-path` |
+| 7 | `TRL-751` | `trl-751-improve-trails-plugin-hooks-for-project-detection-and` |
+| 8 | `TRL-752` | `trl-752-dogfood-refreshed-trails-plugin-with-a-fresh-consumer-smoke` |
+| 9 | `TRL-753` | `trl-753-republish-trails-plugin-and-document-the-release-path` |
+
+## Work Plan
+
+### Phase 0: Sync And Baseline
+
+Intent:
+
+- Ensure the executor starts after the M1 audit stack has landed on `main`.
+
+Actions:
+
+- Run `gt sync`.
+- Check out `main`.
+- Confirm `main` includes PR #558 or later.
+- Confirm the M1 audit PRs #554 through #558 are merged.
+- Confirm the worktree is clean.
+- Record baseline in `RETRO.md`.
+
+Verification:
+
+- `git status --short --branch`
+- `git log -1 --oneline`
+- `gt log --stack --reverse --no-interactive`
+- `gh pr list --repo outfitter-dev/trails --state open --json number,title,headRefName,isDraft,mergeable,updatedAt`
+
+Done when:
+
+- Baseline is clean and M1 is merged.
+
+### Phase 1: `TRL-755` Public Docs And M1 Packet Cleanup
+
+Intent:
+
+- Fix audited public-docs drift first, and archive the completed M1 packet before building the plugin refresh on top of it.
+
+Actions:
+
+- Create the bottom branch `trl-755-refresh-public-docs-drift-found-during-plugin-skills-audit`.
+- Move `.agents/plans/2026-05-21-plugin-skills-m1-audit/` to `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/`.
+- Update this packet's `REFS.md` or `RETRO.md` if any M1 report path changes during archive.
+- Update Linear issue descriptions or add comments for `TRL-746` through `TRL-753` and `TRL-755` so agents know the M1 reports now live under `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/`.
+- Fix audited public docs:
+  - `README.md` Topographer wording from surface-map language to current TopoGraph/lock terminology.
+  - `README.md` package table completeness or a clear statement that the table is intentionally curated.
+  - `docs/api-reference.md` error taxonomy to include `VersionNotSupportedError` if the page remains the public class list.
+- Cross-check PatchOS-derived `TRL-758` while editing Topographer public wording. Do not implement CLI diagnostics here unless the stack scope is explicitly expanded.
+- Preserve historical ADR/migration mentions when explicitly historical.
+
+Verification:
+
+- `rg -n "Surface maps|SurfaceMap|VersionNotSupportedError|@ontrails/config|@ontrails/permits|@ontrails/drizzle|@ontrails/vite|@ontrails/wayfinder" README.md docs/api-reference.md`
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- Public docs no longer contradict M1's package/error/topograph findings, and the completed M1 packet is archived.
+
+### Phase 2: `TRL-746` Main Skill Refresh
+
+Intent:
+
+- Make `plugin/skills/trails/SKILL.md` the accurate first-load briefing for agents building with Trails.
+
+Actions:
+
+- Preserve the first-screen teaching flow: `trail()` -> `blaze` -> `topo()` -> `surface()` -> `run()` -> `testAll()`.
+- Qualify WebSocket as planned, not shipped.
+- Teach HTTP as Hono plus Bun-native `@ontrails/http/bun` over the shared `@ontrails/http` route/fetch kernel.
+- Add compact package orientation for current package groups, including `@ontrails/pino` and shell-only `@ontrails/wayfinder`.
+- Mention `createHttpHarness()` and `testSurfaceParity()` at first-load level.
+- Keep `metadata.trails.version: 1.0.0-beta.18` unchanged unless `TRL-749` has already landed an explicit policy change on the stack.
+
+Verification:
+
+- `rg -n "trailhead|connector|transport|@ontrails/http/bun|@ontrails/pino|@ontrails/wayfinder|createHttpHarness|testSurfaceParity|WebSocket" plugin/skills/trails/SKILL.md`
+- `bun run warden:skills:check`
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- First-load guidance is correct, concise, and points to deep references for detail.
+
+### Phase 3: `TRL-747` References, Templates, And Examples
+
+Intent:
+
+- Update deep plugin guidance so agents have enough current examples to build correctly.
+
+Actions:
+
+- Refresh:
+  - `plugin/skills/trails/references/architecture.md`
+  - `plugin/skills/trails/references/getting-started.md`
+  - new `plugin/skills/trails/references/http-surface.md`
+  - `plugin/skills/trails/references/contract-patterns.md`
+  - `plugin/skills/trails/references/testing-patterns.md`
+  - `plugin/skills/trails/references/error-taxonomy.md`
+  - `plugin/skills/trails/references/common-pitfalls.md`
+  - `plugin/skills/trails/references/migration-checklist.md`
+  - `plugin/skills/trails/templates/*.md`
+  - `plugin/skills/trails/examples/*.md`
+- Rebuild architecture/package guidance from current docs and package export maps.
+- Replace active surface-map wording with `TopoGraph`, `TopoGraphEntry`, lock manifest, and `topo.lock`.
+- Add HTTP reference coverage for `deriveHttpRoutes`, `deriveOpenApiSpec`, `@ontrails/http/fetch`, `@ontrails/http/bun`, and Hono.
+- Add `VersionNotSupportedError`, `ResourceContext.config`, `unmockable`, `expectedMatch`, `createHttpHarness()`, and `testSurfaceParity()` guidance.
+- Add a note that surface-specific testing helpers may move behind subpaths in `TRL-757`; until that lands, plugin guidance should describe the current root imports accurately and avoid promising an isolation boundary that does not exist yet.
+- Prefer trail-object `crosses` and typed `ctx.cross(trail, input)` where in scope; keep string IDs as escape hatch.
+- Replace `Promise.all([ctx.cross(...)])` teaching examples with batch `ctx.cross([...])` where the goal is concurrent crossing.
+
+Verification:
+
+- `bun run warden:skills:check`
+- `bun run format:check`
+- `git diff --check`
+- Snippet/API example checks if available; otherwise record the manual snippet check in `RETRO.md`.
+
+Done when:
+
+- Deep references/templates/examples are current and progressive.
+
+### Phase 4: `TRL-748` Agent, Rules, Advisory Skills, And Hook Copy
+
+Intent:
+
+- Refresh non-main plugin guidance after the main skill and references are current.
+
+Actions:
+
+- Update:
+  - `plugin/agents/trail-engineer.md`
+  - `plugin/rules/lexicon.md`
+  - `plugin/rules/patterns.md`
+  - `plugin/hooks/detect-trails.sh` message text only unless tiny behavior-safe cleanup is forced
+  - advisory skill entrypoints under `plugin/skills/trails-*`
+  - `.claude/skills/clark/references/calibrate.md`
+- Replace stale Warden labels with current manifest IDs or generated Warden guide references.
+- Update resource copy for `ResourceContext.config` and `unmockable`.
+- Update Clark calibration from `metadata` to `meta`.
+- Replace hook `blaze:` command wording with plain shell-command guidance.
+- Make startup "load the trails skill" wording avoid stale global skill ambiguity.
+- Run sync commands if generated Clark/Warden guidance changes.
+
+Verification:
+
+- `bun run warden:agents:check`
+- `bun run clark:check`
+- `bun run warden:skills:check`
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- Advisory surfaces no longer contradict current repo doctrine.
+
+### Phase 5: `TRL-749` Plugin Metadata Policy And Checks
+
+Intent:
+
+- Define and enforce plugin metadata/version policy before hooks warn about drift.
+
+Actions:
+
+- Decide and document whether plugin semver `0.3.0` is independent from Trails framework target `1.0.0-beta.18`.
+- If independent, expose both values clearly.
+- Make the policy answer the PatchOS question: which Trails package line is this skill verified against, and how does an operator notice when package docs/skills are stale relative to the registry channel?
+- Add check-first tooling:
+  - proposed script: `scripts/sync-plugin-metadata.ts`
+  - proposed tests: `scripts/__tests__/sync-plugin-metadata.test.ts`
+  - proposed package scripts: `plugin:metadata:check` and `plugin:metadata:sync`
+- Check `.claude-plugin/marketplace.json`, `plugin/.claude-plugin/plugin.json`, and `plugin/skills/trails/SKILL.md`.
+- Add a sync/update command only if source of truth is clear.
+- Make errors actionable and avoid warning merely because independent versions differ.
+
+Verification:
+
+- `bun test scripts/__tests__/sync-plugin-metadata.test.ts`
+- `bun run warden:skills:check`
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- A read-only metadata check detects policy violations, and hook/release work can consume the policy.
+
+### Phase 6: `TRL-750` Installed Skill Drift Check
+
+Intent:
+
+- Prevent local/global installed Trails skills from silently diverging from repo plugin source.
+
+Actions:
+
+- Add check-first tooling:
+  - proposed script: `scripts/check-installed-trails-skill.ts`
+  - proposed tests: `scripts/__tests__/check-installed-trails-skill.test.ts`
+  - proposed package script: `plugin:installed-skill:check`
+- Compare `plugin/skills/trails` with installed skill paths when present.
+- Report symlink versus copy state, missing files, stale vocabulary hits, and `metadata.trails.version` drift.
+- Treat Codex-home skill path as optional/absent.
+- Keep sync/mutation as explicit operator action; no startup hook auto-sync.
+- Document local development strategy without hardcoding Matt-only paths as external defaults.
+
+Verification:
+
+- `bun test scripts/__tests__/check-installed-trails-skill.test.ts`
+- `bun run plugin:installed-skill:check` if added
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- The checker can detect the audited stale local state without mutating global paths.
+
+### Phase 7: `TRL-751` Hook Detection And Version Guidance
+
+Intent:
+
+- Improve Claude plugin startup guidance without noisy or mutating behavior, and document Codex parity as unknown unless verified.
+
+Actions:
+
+- Update:
+  - `plugin/hooks/detect-trails.sh`
+  - `plugin/hooks/hooks.json` only if schema needs adjustment
+  - proposed fixtures: `plugin/hooks/__fixtures__/detect-trails/`
+  - proposed tests: `scripts/__tests__/detect-trails-hook.test.ts`
+  - `plugin/README.md`
+- Detect likely Trails projects through dependency keys, `package.json.trails.module`, `trails.config.*`, `.trails/`, and guarded topo-source conventions.
+- Stay silent outside likely Trails projects.
+- Suggest non-mutating Warden probes only when actionable.
+- Warn about version drift only through `TRL-749` policy.
+- Consume installed-skill drift checks from `TRL-750`; do not reimplement sync.
+- Keep startup skill-load copy aligned with `TRL-748`.
+
+Verification:
+
+- `bun test scripts/__tests__/detect-trails-hook.test.ts`
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- Hook output is tested, quiet outside Trails projects, and explicit about Claude versus Codex support.
+
+### Phase 8: `TRL-752` Dogfood Smoke
+
+Intent:
+
+- Prove the refreshed plugin/skill bundle can guide a fresh agent through building with Trails from scratch.
+
+Actions:
+
+- Use `.trails-tmp/plugin-dogfood/` or a disposable tempdir. Do not commit the generated consumer project.
+- Commit a dogfood report at `.agents/plans/2026-05-21-plugin-skills-refresh-stack/reports/trl-752-dogfood.md`.
+- Exercise:
+  - install/scaffold path
+  - simple trail with input/output/examples
+  - CLI via `@ontrails/commander`
+  - MCP via `@ontrails/mcp`
+  - HTTP via Hono or `@ontrails/http/bun`
+  - resource with `mock` or documented `unmockable`
+  - `testAll()` plus `createHttpHarness()` or `testSurfaceParity()` where practical
+  - Warden check
+  - docs guidance for common errors including `VersionNotSupportedError`
+  - local installed skill currentness check from `TRL-750`
+  - PatchOS-retro checks: explicit MCP include-list safety, output schemas, resource mocks or `unmockable`, error taxonomy normalization, opt-in observe/tracing that keeps CLI/MCP output clean, `trails compile` / `trails validate`, and package install policy (`@beta` or explicit beta.N versus accidental `latest`)
+- Record whether adjacent PatchOS-derived issues `TRL-757` through `TRL-760` block plugin release or remain deferred follow-ups.
+- Clean generated runtime state, or record why it was preserved.
+
+Verification:
+
+- Dogfood app typecheck/test/Warden commands, recorded in the dogfood report.
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- Fresh dogfood is green, or every failed/skipped smoke is recorded with the smallest next action.
+
+### Phase 9: `TRL-753` Release Path And Dry Run
+
+Intent:
+
+- Document and prepare the release/republish path after the refreshed plugin is dogfooded.
+
+Actions:
+
+- Verify generated Warden guidance is current.
+- Verify local installed skill path is current or intentionally decoupled.
+- Verify Claude runtime precedence when repo plugin and global skill share `trails`, if safely possible.
+- Document `npx skills outfitter-dev/trails` behavior only in a disposable/approved target; otherwise mark externally/manual blocked.
+- Update `plugin/README.md`, root install docs, and release runbook.
+- Record what changed since plugin `0.3.0`.
+- Include `TRL-755` status in final project update.
+- Coordinate with `TRL-759`: release/install docs must not imply `latest` is the current beta. If the repo remains on the beta track with `latest` intentionally lagging, tell consumers to use explicit beta.N pins or the `beta` dist-tag.
+- Do not publish or mutate registries/marketplace/global installs unless Matt explicitly approves during the run.
+
+Verification:
+
+- `bun run plugin:metadata:check` if added.
+- `bun run plugin:installed-skill:check` if added.
+- `bun run warden:skills:check`
+- `bun run warden:agents:check`
+- `bun run clark:check`
+- `bun run format:check`
+- `git diff --check`
+- Release dry-run or explicit manual/external blocker recorded in `RETRO.md`.
+
+Done when:
+
+- The plugin is release-ready or explicitly blocked on an operator-only external action.
+
+## Validation Ladder
+
+Minimum per-branch checks:
+
+- `bun run format:check`
+- `git diff --check`
+
+Generated guidance checks whenever touched:
+
+- `bun run warden:skills:sync`
+- `bun run warden:agents:sync`
+- `bun run warden:skills:check`
+- `bun run warden:agents:check`
+- `bun run clark:check`
+
+Targeted tests:
+
+- `bun test scripts/__tests__/sync-plugin-metadata.test.ts`
+- `bun test scripts/__tests__/check-installed-trails-skill.test.ts`
+- `bun test scripts/__tests__/detect-trails-hook.test.ts`
+
+Stack-tip checks after implementation:
+
+- `bun run typecheck`
+- `bun run test`
+- `bun run lint`
+- `bun run build`
+- `bun run check`
+- `git diff --check`
+
+Release/dogfood checks:
+
+- `bun run publish:check` only if package/plugin release packaging assumptions are touched and it is useful as a dry check.
+- No `bun run publish:packages`, marketplace publish, registry mutation, `npx skills` mutation, or global installed skill mutation without explicit approval.
+
+## Local Review
+
+Run at least three local review passes from the stack tip before remote submission:
+
+1. Skill/docs doctrine: public docs, main skill, references, examples, package taxonomy, error/resource/testing/composition guidance.
+2. Tooling/hooks safety: metadata policy/checks, installed-skill checker, hook detection, no global mutation, no noisy non-Trails behavior.
+3. Dogfood/release readiness: smoke report, release runbook, stop rules, local/global install guidance, operator-only actions.
+
+Reviewer output contract:
+
+- Overall score: `n/5`
+- Prose summary
+- Findings with P0/P1/P2/P3 severity and evidence
+- Prompt To Fix With AI for each actionable finding
+
+Fix all P0/P1/P2 findings bottom-up before submitting or marking ready.
+
+## Source-Control Rules
+
+- Use Graphite.
+- Create the full local chain up front if useful, but do not submit or push empty branches.
+- This packet is pre-seeded on `main` via PR #559. `TRL-755` inherits it automatically; commit only branch-local archive/path-reference updates there.
+- Main agent owns all source-control writes.
+- Subagents may edit files and run checks but must not run `git`/`gt` write commands.
+- Do not use `gt absorb`.
+- Do not add merge queue labels.
+- Do not merge.
+
+## Tracker Plan
+
+- Keep `TRL-755` in the project as the base public-docs/source-truth cleanup; do not move it out unless a live Linear/project owner decision changes.
+- Ensure the Linear dependency chain is represented:
+  - `TRL-755` blocks `TRL-746`
+  - `TRL-746` blocks `TRL-747`
+  - `TRL-747` blocks `TRL-748`
+  - `TRL-748` blocks `TRL-749`
+  - `TRL-749` blocks `TRL-750`
+  - `TRL-750` blocks `TRL-751`
+  - `TRL-751` blocks `TRL-752`
+  - `TRL-752` blocks `TRL-753`
+- Update issue bodies/comments if M1 report paths move to archive.
+- Leave final project status update in Linear at the end of `TRL-753`.
+
+## Remote Review
+
+- Submit draft PRs only after implementation, local verification, and local review are clean/P3-only.
+- PR bodies must include context, changes, verification, risk/rollout notes, and Linear links.
+- Mark ready only after CI and local review are clean/P3-only.
+- After ready, check CI, unresolved review threads, and code-review bot/agent summaries.
+- Record numeric review scores, prose summaries, prompt-to-fix text, and fix outcomes in `RETRO.md`.
+- Resolve all P0/P1/P2 feedback from the owning lower branch upward.
+- Treat pending Graphite mergeability by itself as service lag when GitHub checks/review are otherwise clean.
+
+## Stop / Pause Rules
+
+Stop and ask if:
+
+- The M1 audit stack is not actually present on `main`.
+- A public API or doctrine decision is required beyond the M1 findings and issue bodies.
+- The work requires publish, registry mutation, marketplace mutation, `npx skills` mutation, global installed skill mutation, secrets, or credentials without explicit approval.
+- A hook would need to mutate files or run noisy checks by default.
+- Linear writes are unavailable and tracker references cannot be corrected after archiving M1.
+- Verification fails for unrelated reasons after one focused retry.
+- More than four post-ready remote-review turns pass and P2+ feedback remains unresolved.
+
+## Handoff Audit
+
+- [x] Objective is singular and end-to-end.
+- [x] Completion condition is objectively checkable.
+- [x] Tracker state was fetched after M1 merge.
+- [x] Branch names/order are exact.
+- [x] Dependencies/blockers are represented.
+- [x] Ignored/untracked source docs are avoided as load-bearing inputs.
+- [x] Validation commands match repo conventions.
+- [x] `GOAL.md` requires transcript-visible proof.
+- [x] `GOAL.md` requires `RETRO.md` finalization before completion.
+- [x] Stop rules are concrete.
+- [x] `RETRO.md` has concrete sections for execution, tracker, review, verification, remote state, forbidden actions, final state, and archive readiness.
+- [x] Packet can be executed without chat history.

--- a/.agents/plans/2026-05-21-plugin-skills-refresh-stack/REFS.md
+++ b/.agents/plans/2026-05-21-plugin-skills-refresh-stack/REFS.md
@@ -1,0 +1,111 @@
+# References: plugin-skills-refresh-stack
+
+## Repo Guidance
+
+- `AGENTS.md` - Trails repo guidance, Graphite workflow, lexicon, Warden rule index, and release/testing expectations.
+- `.agents/plans/PLANNING.md` - repo-local goal-planning conventions.
+
+## M1 Audit Sources
+
+Before Phase 1 archive:
+
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/PLAN.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/RETRO.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-745-package-coverage.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-742-repo-plugin-doctrine.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-743-distribution-surfaces.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-744-hook-opportunities.md`
+- `.agents/plans/2026-05-21-plugin-skills-m1-audit/reports/trl-754-synthesis.md`
+
+After Phase 1 archive:
+
+- `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/PLAN.md`
+- `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/RETRO.md`
+- `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/reports/trl-745-package-coverage.md`
+- `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/reports/trl-742-repo-plugin-doctrine.md`
+- `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/reports/trl-743-distribution-surfaces.md`
+- `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/reports/trl-744-hook-opportunities.md`
+- `.agents/plans/archive/2026-05-21-plugin-skills-m1-audit/reports/trl-754-synthesis.md`
+
+## Downstream Dogfood Evidence
+
+- PatchOS beta.15 -> beta.18 modernization retro - operator-local evidence from the PatchOS repo. If the PatchOS checkout is accessible, fetch `TRAILS-UPSTREAM-RETRO.md` from that repo; otherwise use the summarized PatchOS findings in this packet's `RETRO.md`. Relevant evidence areas: package install policy, skill freshness, testing helper boundaries, Topographer workflow, MCP include-list safety, resource mocks, error taxonomy, observe/tracing adoption, and migration docs.
+
+## Tracker Records
+
+- Project: `Trails Plugin & Skills One-Stop Shop`
+- `TRL-755` - public docs drift base branch.
+- `TRL-746` - main Trails skill refresh.
+- `TRL-747` - references/templates/examples refresh.
+- `TRL-748` - agent/rules/advisory skill/hook copy refresh.
+- `TRL-749` - plugin metadata sync and drift checks.
+- `TRL-750` - local installed skill sync/check path.
+- `TRL-751` - plugin hooks for project detection and version guidance.
+- `TRL-752` - fresh consumer dogfood.
+- `TRL-753` - plugin release path and dry run.
+
+Adjacent PatchOS-derived v1 follow-ups:
+
+- `TRL-757` - split `@ontrails/testing` surface harnesses behind subpaths.
+- `TRL-758` - clarify Topographer artifact CLI workflow and retired topo commands.
+- `TRL-759` - document beta channel install policy and version bump cadence.
+- `TRL-760` - add beta.15 to beta.18 downstream migration guide.
+
+## Source Artifacts
+
+- `README.md` - public package table and install docs.
+- `docs/api-reference.md` - public error taxonomy list.
+- `docs/architecture.md` - current package taxonomy source.
+- `docs/lexicon.md` - vocabulary source.
+- `docs/contributing/language-styleguide.md` - language/field names.
+- `plugin/skills/trails/SKILL.md` - main skill entrypoint.
+- `plugin/skills/trails/references/**` - deep skill docs.
+- `plugin/skills/trails/templates/**` - copyable templates.
+- `plugin/skills/trails/examples/**` - example snippets.
+- `plugin/agents/trail-engineer.md` - plugin agent profile.
+- `plugin/rules/**` - plugin rules.
+- `plugin/hooks/**` - Claude plugin hooks.
+- `.claude/skills/clark/references/calibrate.md` - Clark calibration vocabulary.
+- `.claude-plugin/marketplace.json` - marketplace metadata.
+- `plugin/.claude-plugin/plugin.json` - plugin manifest metadata.
+- `packages/*/package.json` and `adapters/*/package.json` - package/version/export maps.
+- `packages/core/src/errors.ts` - error taxonomy owner.
+- `packages/testing/**` - testing helpers and surface harnesses.
+- `scripts/publish.ts` and `scripts/check-registry-preflight.ts` - beta dist-tag and registry posture checks.
+- `.changeset/pre.json` - current prerelease channel source (`tag: beta`).
+- `docs/releases/stable-cutover.md` and `docs/adr/0047-stable-release-line-discipline.md` - release-channel doctrine and runbook.
+
+## Commands
+
+- `gt sync` - refresh local Graphite state.
+- `git status --short --branch` - branch/dirtiness baseline.
+- `gt log --stack --reverse --no-interactive` - stack order proof.
+- `bun run warden:skills:sync` - regenerate skill Warden guide when needed.
+- `bun run warden:agents:sync` - regenerate agent Warden guide when needed.
+- `bun run warden:skills:check` - skill guidance drift check.
+- `bun run warden:agents:check` - agent guidance drift check.
+- `bun run clark:check` - Clark generated wrapper drift check.
+- `bun test scripts/__tests__/sync-plugin-metadata.test.ts` - metadata policy tests.
+- `bun test scripts/__tests__/check-installed-trails-skill.test.ts` - installed skill drift checker tests.
+- `bun test scripts/__tests__/detect-trails-hook.test.ts` - hook detection tests.
+- `bun run typecheck` - full typecheck.
+- `bun run test` - full test suite.
+- `bun run lint` - lint.
+- `bun run build` - build.
+- `bun run check` - repo aggregate check.
+- `bun run format:check` - formatting check.
+- `git diff --check` - whitespace/conflict marker check.
+
+## Known Starting State
+
+- Current `main` after `gt sync`: `20564d6bc docs: synthesize plugin audit stack (#558)`.
+- The M1 audit packet is merged and active under `.agents/plans/2026-05-21-plugin-skills-m1-audit/`.
+- `TRL-755` remains in the plugin project and is intentionally included as the base branch.
+- `TRL-753` explicitly forbids publish/registry/marketplace/global-skill mutation without approval; preserve that stop rule.
+
+## Planned Report Paths
+
+- `.agents/plans/2026-05-21-plugin-skills-refresh-stack/reports/local-review-round-1-skill-docs.md`
+- `.agents/plans/2026-05-21-plugin-skills-refresh-stack/reports/local-review-round-2-tooling-hooks.md`
+- `.agents/plans/2026-05-21-plugin-skills-refresh-stack/reports/local-review-round-3-dogfood-release.md`
+- `.agents/plans/2026-05-21-plugin-skills-refresh-stack/reports/trl-752-dogfood.md`

--- a/.agents/plans/2026-05-21-plugin-skills-refresh-stack/RETRO.md
+++ b/.agents/plans/2026-05-21-plugin-skills-refresh-stack/RETRO.md
@@ -1,0 +1,128 @@
+# Execution Retro: plugin-skills-refresh-stack
+
+Date started: 2026-05-21
+Date finalized: pending
+Status: Seeded for execution
+Plan: `.agents/plans/2026-05-21-plugin-skills-refresh-stack/PLAN.md`
+Goal: `.agents/plans/2026-05-21-plugin-skills-refresh-stack/GOAL.md`
+
+Use this as the durable execution ledger. For stacked work, this should normally be the last meaningful file touched before local completion, draft submission, ready-for-review, remote review closeout, release handoff, merge readiness, archive, or final handoff.
+
+## Execution Summary
+
+- Objective: Execute the Trails Plugin & Skills One-Stop Shop refresh stack from public docs cleanup through release readiness.
+- Final outcome:
+- Final branch / stack tip:
+- Final PR range:
+- Final tracker state:
+- Final verification state:
+- Remaining risks / P3s:
+- Archive state:
+
+## Branch / PR / Issue Ledger
+
+| Order | Issue | Branch | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `TRL-755` | `trl-755-refresh-public-docs-drift-found-during-plugin-skills-audit` | | Planned | Public docs drift and M1 packet archive |
+| 2 | `TRL-746` | `trl-746-refresh-the-main-trails-skill-into-the-canonical-one-stop` | | Planned | Main skill entrypoint |
+| 3 | `TRL-747` | `trl-747-refresh-trails-skill-references-templates-and-examples` | | Planned | Deep references/templates/examples |
+| 4 | `TRL-748` | `trl-748-refresh-plugin-agent-rules-advisory-skills-and-hook` | | Planned | Agent/rules/advisory/hook copy |
+| 5 | `TRL-749` | `trl-749-add-plugin-metadata-sync-and-drift-checks` | | Planned | Metadata policy/checks |
+| 6 | `TRL-750` | `trl-750-add-local-installed-trails-skill-synccheck-path` | | Planned | Installed skill drift check |
+| 7 | `TRL-751` | `trl-751-improve-trails-plugin-hooks-for-project-detection-and` | | Planned | Hook detection/version guidance |
+| 8 | `TRL-752` | `trl-752-dogfood-refreshed-trails-plugin-with-a-fresh-consumer-smoke` | | Planned | Dogfood smoke |
+| 9 | `TRL-753` | `trl-753-republish-trails-plugin-and-document-the-release-path` | | Planned | Release path/dry run |
+
+## Planning Discoveries
+
+| Discovery | Evidence | Decision | Impact |
+| --- | --- | --- | --- |
+| M1 audit stack landed before this packet was written. | `main` at `20564d6bc docs: synthesize plugin audit stack (#558)`. | Start next work from current `main`. | Avoids planning against stale report paths. |
+| `TRL-755` is best kept in the plugin project. | M1 synthesis routes public docs drift to `TRL-755`; docs serve as plugin source truth. | Use `TRL-755` as bottom branch instead of moving it out. | Public docs are cleaned before plugin docs consume them. |
+| Completed M1 packet still lives active under `.agents/plans/2026-05-21-plugin-skills-m1-audit/`. | `fd` on current `main`. | Archive it on the lowest branch and update Linear paths. | Keeps active plan directory clean. |
+| PatchOS beta.15 -> beta.18 dogfood produced upstream evidence after this packet was seeded. | Operator-local PatchOS retro if accessible; summarized findings here cover `@ontrails/testing`, CLI help, registry posture, package install policy, skill freshness, Topographer workflow, MCP include-list safety, resource mocks, error taxonomy, observe/tracing adoption, and migration docs. | Keep the plugin stack order unchanged, but add PatchOS as dogfood evidence and file adjacent v1 follow-up issues. | `TRL-752` and `TRL-753` get sharper evidence; unrelated framework work is tracked without bloating this stack. |
+
+## Deferred / Follow-Up Discoveries
+
+| Issue | Discovery | Why Out Of Goal | Link |
+| --- | --- | --- | --- |
+| `TRL-757` | `@ontrails/testing` root export statically reaches surface harnesses and HTTP types, so root contract helpers can drag optional surface packages into downstream type graphs. | Framework package-boundary fix, not plugin refresh work. | <https://linear.app/outfitter/issue/TRL-757/split-ontrailstesting-surface-harnesses-behind-subpaths> |
+| `TRL-758` | Topographer consumer workflow is already `trails compile` / `trails validate`; remaining work is docs/diagnostics around retired `trails topo ...` shapes and stale Topographer wording. | Adjacent CLI/docs ergonomics issue; plugin stack should reference but not implement wholesale. | <https://linear.app/outfitter/issue/TRL-758/clarify-topographer-artifact-cli-workflow-and-retired-topo-commands> |
+| `TRL-759` | `beta` dist-tag is current at beta.18, while sampled `latest` dist-tags still point at beta.16; consumers need explicit beta install/version-bump policy. | Release policy/docs work beyond plugin republish mechanics. | <https://linear.app/outfitter/issue/TRL-759/document-beta-channel-install-policy-and-version-bump-cadence> |
+| `TRL-760` | No one-stop beta.15 -> beta.18 downstream migration guide exists; PatchOS had to stitch the path from scattered docs/changelogs/skills. | Migration docs likely need a separate rewind/worktree investigation. | <https://linear.app/outfitter/issue/TRL-760/add-beta15-to-beta18-downstream-migration-guide> |
+
+## Tracker Mutations
+
+| Time | Tracker Item | Mutation | Evidence |
+| --- | --- | --- | --- |
+| 2026-05-21 | `TRL-755` through `TRL-753` | Planning packet seeded from current Linear issue bodies and M1 synthesis. | This packet. |
+| 2026-05-21 17:43 EDT | `TRL-746` through `TRL-753` | Added Linear blocked-by chain matching the planned stack order: `TRL-755` -> `TRL-746` -> `TRL-747` -> `TRL-748` -> `TRL-749` -> `TRL-750` -> `TRL-751` -> `TRL-752` -> `TRL-753`. | Linear update payloads returned successfully. |
+| 2026-05-21 17:43 EDT | `TRL-741` | Added comment linking this goal packet and explaining why `TRL-755` remains the bottom branch. | Comment `621411c3-bb6b-4642-a9b3-68b082ddc3e8` |
+| 2026-05-21 17:44 EDT | `TRL-755` | Added comment naming the bottom-branch responsibility to archive the M1 packet and update downstream report-path references. | Comment `07128048-0e76-42df-9691-fc15d78c8939` |
+| 2026-05-21 17:45 EDT | `TRL-752` | Updated dogfood report path to this packet and noted pre/post archive M1 synthesis paths. | Linear issue update payload returned successfully. |
+| 2026-05-21 18:17 EDT | `TRL-757` through `TRL-760` | Filed four adjacent PatchOS-derived upstream follow-ups for testing subpaths, Topographer CLI/docs ergonomics, beta channel policy, and beta.15 -> beta.18 migration docs. | Linear create payloads returned successfully. |
+| 2026-05-21 18:18 EDT | `TRL-741`, `TRL-749`, `TRL-750`, `TRL-752`, `TRL-753` | Added PatchOS retro comments tying the new evidence back to plugin metadata, installed-skill drift, dogfood, and release/install docs. | Linear comment payloads returned successfully. |
+| 2026-05-21 18:18 EDT | `TRL-747`, `TRL-752`, `TRL-753`, `TRL-749`, `TRL-750` | Added related-issue links to PatchOS-derived follow-ups where relevant. | Linear update payloads returned successfully. |
+
+## Execution Log
+
+```text
+YYYY-MM-DD HH:MM TZ - <branch/issue/checkpoint>
+- Changed:
+- Verified:
+- Result:
+- Next:
+- Blockers:
+```
+
+## Local Review Log
+
+| Round | Scope / Lanes | Report Paths | P0/P1/P2 Result | Fix Commits / Notes |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+## Remote Review
+
+| PR | CI State | Review Scores / Summaries | Unresolved Threads | Fix Notes |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+## Verification Log
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `git status --short --branch` | | |
+| `gt log --stack --reverse --no-interactive` | | |
+| `bun run warden:skills:check` | | |
+| `bun run warden:agents:check` | | |
+| `bun run clark:check` | | |
+| `bun test scripts/__tests__/sync-plugin-metadata.test.ts` | | |
+| `bun test scripts/__tests__/check-installed-trails-skill.test.ts` | | |
+| `bun test scripts/__tests__/detect-trails-hook.test.ts` | | |
+| `bun run typecheck` | | |
+| `bun run test` | | |
+| `bun run lint` | | |
+| `bun run build` | | |
+| `bun run check` | | |
+| `bun run format:check` | | |
+| `git diff --check` | | |
+
+## Forbidden-Action Audit
+
+| Action | Status | Notes |
+| --- | --- | --- |
+| Merge | | |
+| Publish / registry mutation | | |
+| Marketplace mutation | | |
+| `npx skills` mutation | | |
+| Global installed skill mutation | | |
+| Merge queue label | | |
+| `gt absorb` | | |
+| Source-control writes by subagents | | |
+
+## Final State
+
+- Completed:
+- Remaining risks:
+- Skipped checks:
+- Archive readiness:

--- a/.agents/plans/2026-05-21-plugin-skills-refresh-stack/reports/README.md
+++ b/.agents/plans/2026-05-21-plugin-skills-refresh-stack/reports/README.md
@@ -1,0 +1,31 @@
+# Reports
+
+Expected execution reports:
+
+- `local-review-round-1-skill-docs.md`
+- `local-review-round-2-tooling-hooks.md`
+- `local-review-round-3-dogfood-release.md`
+- `trl-752-dogfood.md`
+
+Local review reports should use:
+
+```markdown
+Overall score: n/5
+
+Summary:
+<short prose judgment>
+
+Findings:
+- P0/P1/P2/P3 - <path:line or artifact> - <finding>
+  Prompt To Fix With AI:
+  <concise fix prompt>
+```
+
+Severity reminder:
+
+- P0: cannot proceed.
+- P1: correctness, public contract, or doctrine contradiction.
+- P2: documentation correctness, misleading examples, missing tests/checks, noisy hooks, or release safety issues.
+- P3: style-only polish.
+
+Documentation correctness is P2 by default.


### PR DESCRIPTION
## Context

Seeds the next Trails Plugin & Skills One-Stop Shop execution packet after the M1 audit stack landed on `main`. This gives future agents a durable plan, goal prompt, references, retro ledger, and expected report shapes before the implementation stack begins.

## What changed

- Added `.agents/plans/2026-05-21-plugin-skills-refresh-stack/PLAN.md` with the nine-branch Graphite stack and completion criteria.
- Added `GOAL.md`, `REFS.md`, `RETRO.md`, and `reports/README.md` so the execution lane has a copyable goal prompt, source map, ledger, and local-review report template.
- Removed machine-specific absolute paths from the copyable goal prompt and reframed PatchOS retro references as optional operator-local evidence with summarized findings in this repo.

## Verification

- Pre-commit hook: `markdownlint-cli2 --fix` on the staged Markdown files, 0 errors.
- `rg -n "/Users/mg/Developer/outfitter/trails|/Users/mg/patch" .agents/plans/2026-05-21-plugin-skills-refresh-stack || true`
- `git diff --check`
- `bun run format:check`

## Risks / rollout notes

- Planning-only change; no runtime/package behavior.
- No changeset needed because this only adds local agent planning docs under `.agents/plans/`.