### PR TITLE
docs: audit pending force release gate as v1 stable cutover gate

### DIFF
--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/GOAL.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/GOAL.md
@@ -1,0 +1,23 @@
+# Goal Prompt: v1-release-readiness-closeout
+
+Paste this into the goal runtime:
+
+````markdown
+/goal From cwd `<path-to-trails-repo>`, execute `.agents/plans/2026-05-22-v1-release-readiness-closeout/PLAN.md` end to end. Objective: build the 7-branch v1 release-readiness closeout stack: audits `TRL-767`, `TRL-766`, `TRL-756`, then implementation/docs `TRL-757`, `TRL-758`, `TRL-759`, `TRL-760`; one PR per issue; no merge.
+
+Read first: `AGENTS.md`, `.agents/plans/PLANNING.md`, packet `PLAN.md`/`REFS.md`/`RETRO.md`, and all listed Linear issues. Start with `gt sync --no-interactive`; verify main/open PR state. Commit the packet on the lowest branch. Use exact Linear branch names/order from `PLAN.md`; local branch chain is ok; do not push empty branches.
+
+Work loop: checkpoint-by-checkpoint. After each turn report checkpoint, changed files/artifacts, exact checks run, result summary, remaining work, blocker status, next checkpoint. Shrink failing surface before retrying. Keep `RETRO.md` updated after tracker, branch, audit, implementation, verification, local review, remote review, PR-body, or final-state changes; touch it last before handoff states.
+
+Audit contract: `TRL-767`, `TRL-766`, `TRL-756` produce committed reports under the packet `reports/` dir, with verdicts, evidence, command snippets, source paths, and follow-up issue list. File focused Linear follow-ups for real out-of-goal discoveries. If an audit finds a stable-cutover blocker larger than a small in-stack fix, stop/ask after recording evidence.
+
+Implementation contract: `TRL-757` isolates `@ontrails/testing` surface harnesses behind subpaths, optionalizes surface peers, adds regression + changeset; `TRL-758` clarifies top-level Topographer CLI workflow and retired topo commands; `TRL-759` documents beta install/dist-tag/version cadence using Bun publish scripts only; `TRL-760` adds linked beta.15 -> beta.18 downstream migration guide.
+
+Validation ladder: targeted checks per phase; then `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run publish:registry-check`, `git diff --check`; add docs/plugin/warden checks if touched. If skipped, say why and what would prove it.
+
+Review loop: run >=3 scored local review passes from stack tip; request n/5, prose summary, P0-P3 findings, evidence, Prompt To Fix. Fix all P0/P1/P2 bottom-up before submit. Submit draft stack with high-quality PR bodies; mark ready only after CI/local review clean. After ready, wait ~15m; run max 4 post-ready remote-review turns; resolve P0/P1/P2 and concrete lower-score bot/agent feedback bottom-up; record scores/prompts/threads in `RETRO.md`.
+
+Hard rules: no npm publish, no `bun run publish:packages`, no registry/dist-tag mutation, no merge, no merge queue label, no `gt absorb`, no source-control writes by subagents, no `TRL-508`/`TRL-765` implementation unless explicitly authorized. Do not spin on Graphite mergeability lag alone if GitHub checks/reviews are otherwise clean.
+
+Done only when all 7 issues have PRs, audits/reports/docs/code are complete, checks pass, Linear and PR bodies are current, no unresolved P0/P1/P2 remains, forbidden-action audit is clean, `RETRO.md` final state is filled, and final transcript reports branch/PR range, verification, review scores, skipped checks, risks/P3s, and no-merge/no-publish confirmation.
+````

--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/PLAN.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/PLAN.md
@@ -1,0 +1,347 @@
+# Goal Plan: v1-release-readiness-closeout
+
+Date: 2026-05-22
+Status: Draft
+
+## Objective
+
+Execute the next v1 release-readiness closeout sprint from current `main`: prove the remaining release gates with three audit PRs, then land four targeted downstream-readiness fixes for testing subpaths, Topographer CLI docs, beta install policy, and beta.15 to beta.18 migration guidance.
+
+This is one end-to-end goal with one Graphite stack. The first three branches are audit/report branches that may file follow-up issues; the last four branches are implementation/docs branches. Keep the stack coherent, review locally first, submit as draft, then move ready and handle remote feedback without merging.
+
+## Completion Condition
+
+The goal is complete only when:
+
+- `TRL-767`, `TRL-766`, and `TRL-756` have committed audit reports with evidence-backed verdicts and any needed follow-up Linear issues filed.
+- `TRL-757`, `TRL-758`, `TRL-759`, and `TRL-760` are implemented as one PR per issue in the stack.
+- Every included Linear issue has current comments/status/PR links and any scope divergence recorded.
+- The Graphite stack is submitted with high-quality PR bodies, marked ready only after local review and CI are clean, and all remote P0/P1/P2 feedback is resolved or explicitly rejected with evidence.
+- Local review has run at least three scored passes, stopping only when the latest pass is P3-only or clean.
+- The final stack gate passes: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run publish:registry-check`, and `git diff --check`, plus targeted checks listed below.
+- No package publish, registry mutation, merge, merge queue label, or `gt absorb` occurs.
+- `RETRO.md` is updated as the durable ledger and the final transcript reports proof.
+
+## Non-Goals
+
+- Do not cut stable 1.0 or publish any packages.
+- Do not mutate npm dist-tags or run `bun run publish:packages`.
+- Do not implement `TRL-508` or design `trails migrate` / `@ontrails/trailworks`.
+- Do not implement `TRL-765`; keep it as a related future Trail Versioning v1.x audit unless an included audit proves it must block this sprint.
+- Do not add aliases for retired `trails topo compile`, `trails topo verify`, or `trails topo check`.
+- Do not merge the stack unless Matt explicitly asks after handoff.
+
+## Source Of Truth
+
+Read first:
+
+1. `AGENTS.md`
+2. `.agents/plans/PLANNING.md`
+3. `.agents/plans/2026-05-22-v1-release-readiness-closeout/PLAN.md`
+4. `.agents/plans/2026-05-22-v1-release-readiness-closeout/REFS.md`
+5. Linear issues `TRL-767`, `TRL-766`, `TRL-756`, `TRL-757`, `TRL-758`, `TRL-759`, `TRL-760`
+6. `docs/adr/0048-trail-versioning-v3.md`
+7. `docs/releases/stable-cutover.md`
+8. `docs/releases/beta15.md`
+9. `docs/migration/*.md`
+10. `/Users/mg/patch/.agents/plans/2026-05-21-patchos-trails-modernization/TRAILS-UPSTREAM-RETRO.md`
+
+Do not make the tracked packet depend on the PatchOS retro remaining available. Use it for evidence, then summarize any load-bearing findings in the migration guide or in this packet's `RETRO.md`.
+
+## Stack Order
+
+Create the local stack bottom-up from `main` after `gt sync`. It is fine to create the full local stack chain up front, but do not push empty branches.
+
+| Order | Issue | Exact branch | Kind | Why here |
+| --- | --- | --- | --- | --- |
+| 1 | `TRL-767` | `trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate` | Audit/report | Highest release gate priority; establishes whether pending force debt blocks stable. |
+| 2 | `TRL-766` | `trl-766-audit-version-marker-failure-ux-and-bounded-zod-diagnostics` | Audit/report | Adjacent versioning UX gate; can file docs/diagnostic follow-ups before downstream docs. |
+| 3 | `TRL-756` | `trl-756-audit-v1-doctrine-and-lexicon-drift-after-versioning-m3` | Audit/report | Broad doctrine sweep before docs and skill guidance changes. |
+| 4 | `TRL-757` | `trl-757-split-ontrailstesting-surface-harnesses-behind-subpaths` | Package/API | Main code slice; isolates testing root from optional surface peers. |
+| 5 | `TRL-758` | `trl-758-clarify-topographer-artifact-cli-workflow-and-retired-topo` | CLI/docs | Clears command ambiguity after audits and before migration guide. |
+| 6 | `TRL-759` | `trl-759-document-beta-channel-install-policy-and-version-bump` | Release docs/policy | Settles beta install/version cadence for the migration guide. |
+| 7 | `TRL-760` | `trl-760-add-beta15-to-beta18-downstream-migration-guide` | Migration docs | Caps the stack with downstream operator guidance reflecting all prior branches. |
+
+## Work Plan
+
+### Phase 0: Sync, Prime, And Commit Packet
+
+Intent:
+
+- Start from current `main`, not the post-merge ghost of an older stack.
+
+Actions:
+
+- Run `gt sync --no-interactive`.
+- Confirm no open PRs or local branches alter the assumptions.
+- Create the branch chain above using Graphite.
+- Commit this active packet on the lowest branch (`TRL-767`) before substantive work.
+
+Verification:
+
+- `git status --short --branch`
+- `gt log --stack --reverse --no-interactive`
+- `gh pr list --state open --json number,title,headRefName,isDraft,url`
+
+Done when:
+
+- Stack exists locally, active packet is committed at the base, no empty branches have been pushed.
+
+### Phase 1: Release-Gate Audits
+
+Intent:
+
+- Convert the three release-gate questions into durable evidence, not vibes.
+
+Actions:
+
+- `TRL-767`: create `reports/trl-767-pending-force-gate.md`.
+- `TRL-766`: create `reports/trl-766-marker-diagnostics.md`.
+- `TRL-756`: create `reports/trl-756-doctrine-lexicon-drift.md`.
+- File focused follow-up Linear issues for real out-of-goal findings.
+- If an audit finds a release-blocking P0/P1/P2 that is small and directly fixes the audited surface, add it to the stack only after updating Linear and `RETRO.md`; otherwise file the issue and stop/ask if it changes the stable-cutover path.
+
+Verification:
+
+- Each report includes verdict, evidence, command snippets, source paths, and follow-up issue list.
+- `git diff --check`
+- Relevant targeted commands from each Linear issue.
+
+Done when:
+
+- All three audit issues have committed reports and Linear comments linking the report/PR.
+
+### Phase 2: Testing Surface Subpaths (`TRL-757`)
+
+Intent:
+
+- Keep root `@ontrails/testing` useful without pulling CLI/MCP/HTTP surface peers into consumers that only want contract testing.
+
+Actions:
+
+- Add explicit subpaths for surface harness/parity APIs, likely `@ontrails/testing/http`, `@ontrails/testing/cli`, `@ontrails/testing/mcp`, and `@ontrails/testing/surface-parity` or equivalent.
+- Split public types so root exports do not import `@ontrails/http`, `@ontrails/cli`, or `@ontrails/mcp`.
+- Mark surface peers optional via `peerDependenciesMeta`.
+- Add a downstream import/type regression fixture.
+- Update `docs/api-reference.md`, `docs/testing.md`, `packages/testing/README.md`, and plugin testing guidance.
+- Add a changeset for `@ontrails/testing`.
+
+Verification:
+
+- Targeted import regression proves root contract helpers typecheck without surface peers.
+- `bun run --cwd packages/testing typecheck` if available, otherwise repo `bun run typecheck`.
+- `bun run test`
+- `bun run publish:check`
+
+Done when:
+
+- Root import path is surface-peer clean and surface harnesses remain available from explicit subpaths.
+
+### Phase 3: Topographer CLI Workflow (`TRL-758`)
+
+Intent:
+
+- Make the settled artifact workflow unmistakable: top-level `trails compile`, `trails validate`, and `trails diff`; `topo` subcommands are not compile/verify/check aliases.
+
+Actions:
+
+- Sweep public docs and plugin skill references for stale Topographer artifact wording.
+- Clarify programmatic `@ontrails/topographer` APIs versus CLI workflow.
+- Either add focused CLI diagnostics/tests for retired commands or explicitly document/test current parent-help fallback as intentional.
+
+Verification:
+
+- `bun apps/trails/bin/trails.ts --help`
+- `bun apps/trails/bin/trails.ts topo --help`
+- Targeted CLI tests if diagnostics change.
+- `rg -n "trails topo (compile|verify|check)|topo compile helpers|Surface maps" README.md docs plugin packages apps .agents .claude`
+
+Done when:
+
+- Current-facing guidance no longer teaches retired topo command shapes.
+
+### Phase 4: Beta Channel Policy (`TRL-759`)
+
+Intent:
+
+- Make beta consumption and bump cadence unambiguous while preserving Trails' Bun publish doctrine.
+
+Actions:
+
+- Update install/release docs and plugin/skill guidance to explain explicit `1.0.0-beta.N` pins and/or `@beta`.
+- Explain that prerelease mode uses `.changeset/pre.json` tag `beta` by default.
+- State whether `latest` intentionally lags during beta, or document the operator rule if it should be advanced.
+- Add/update read-only verification for `latest`/`beta` split if useful.
+
+Verification:
+
+- `bun run publish:registry-check`
+- `bun run publish:check`
+- `rg -n "npm publish|changeset publish|latest|@beta|1\\.0\\.0-beta" docs plugin .agents .claude README.md packages`
+
+Done when:
+
+- Downstream agents know what to install and operators know when to bump/cut the next beta.
+
+### Phase 5: Beta.15 To Beta.18 Migration Guide (`TRL-760`)
+
+Intent:
+
+- Give downstream apps a single operator-facing path from beta.15 to beta.18.
+
+Actions:
+
+- Add and link a migration/release guide from `docs/index.md`.
+- Cover install policy, Commander split, MCP include-list safety, public output schemas, contract testing, resource mocks/unmockable posture, error taxonomy, observability packages, Topographer artifact workflow, and when not to adopt trail versioning yet.
+- Link existing focused migration guides instead of duplicating all detail.
+
+Verification:
+
+- `bun run docs:links`
+- `bun run docs:snippets`
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- A downstream app can follow the guide without reconstructing beta.15 to beta.18 from scattered notes.
+
+### Phase 6: Local Review, Submit, Ready, Remote Review
+
+Intent:
+
+- Preserve the recent goal-execution success pattern: review locally before GitHub, then handle remote feedback seriously.
+
+Actions:
+
+- Run at least three local review passes from the stack tip. Use subagents if available, but subagents must not run source-control write commands.
+- Require each pass to provide overall `n/5`, prose summary, P0-P3 findings, evidence, and prompt-to-fix text.
+- Fix all P0/P1/P2 findings on the lowest owning branch, restack, and walk upward.
+- Submit draft stack only after local P0/P1/P2 is clean.
+- Use high-quality PR bodies: context, changes, verification, risks, `Closes TRL-###`.
+- Mark ready only after CI/local review are clean.
+- After ready, wait about 15 minutes, then run up to four post-ready remote-review turns. Resolve all P0/P1/P2 review comments and concrete lower-score review-bot feedback from the bottom of the stack upward. Do not merge.
+
+Verification:
+
+- `bun run check`
+- `bun run test`
+- `bun run build`
+- `bun run publish:check`
+- `bun run publish:registry-check`
+- `git diff --check`
+- GitHub CI/check summaries, unresolved thread queries, and review-bot summary scores captured in `RETRO.md`.
+
+Done when:
+
+- Stack is ready for Matt, with current `RETRO.md`, clean P0/P1/P2 state, and no forbidden actions.
+
+## Tracker Plan
+
+In-goal issues:
+
+- `TRL-767`, `TRL-766`, `TRL-756`, `TRL-757`, `TRL-758`, `TRL-759`, `TRL-760`
+
+Tracker mutations already made during planning:
+
+- Moved `TRL-756`, `TRL-766`, and `TRL-767` into `v1 Release Prep` and kept them in Todo.
+- Moved `TRL-757`, `TRL-758`, `TRL-759`, and `TRL-760` from Backlog to Todo.
+
+Follow-up policy:
+
+- Audit-discovered out-of-goal work belongs first in `RETRO.md`, then in focused Linear follow-up issues.
+- `TRL-765` remains related but out of this goal unless the audits prove it is a stable-cutover blocker.
+
+Dependencies/blockers:
+
+- No hard Linear blocker links are required at planning time. Stack order encodes execution order; add Linear dependencies only if an audit proves a hard dependency.
+
+## Source-Control Plan
+
+- Branching model: Graphite.
+- Commit packet on the bottom branch, `trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate`.
+- Use exact Linear branch names from the stack table.
+- Do not push empty branches.
+- Main agent owns all `git` and `gt` writes.
+- Subagents can read, edit files, run checks, and write reports; they must not run `git add`, `git commit`, `git push`, `gt create`, `gt modify`, `gt restack`, `gt submit`, merge commands, or PR mutation commands.
+- Do not use `gt absorb`; make fixes on owning branches with `gt modify`, then restack.
+- Submit draft PRs as a stack after local review passes.
+- Do not add merge queue labels.
+- Do not merge.
+
+## Retro Discipline
+
+`RETRO.md` is part of the completion contract, not optional notes.
+
+- Update `RETRO.md` after tracker changes, branch creation, each audit report, each meaningful implementation slice, local review, remote review, CI, PR-body changes, and final handoff.
+- For stacked work, touch `RETRO.md` last before local completion, draft submission, ready-for-review, remote review closeout, or final handoff.
+- Every meaningful review-flow change must have a corresponding retro entry before claiming the review loop is complete.
+- Before completion, fill the final state, verification log, review state, tracker state, forbidden-action audit, remaining risks, and archive readiness.
+
+## Validation Ladder
+
+Run checks from narrow to broad:
+
+- Targeted audit/CLI/docs commands listed in each phase.
+- Package/module: `bun run --cwd packages/testing typecheck` if available; package tests where available.
+- Docs: `bun run docs:links`, `bun run docs:snippets`, `bun run docs:api-examples`.
+- Repo: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run publish:registry-check`, `git diff --check`.
+- Warden/plugin/generated guide checks if touched: `bun run warden:agents:check`, `bun run warden:skills:check`, `bun run plugin:metadata:check`, `bun run plugin:installed-skill:check`.
+
+## Local Review
+
+Run at least three scored local review passes from the stack tip:
+
+- Lane 1: audit evidence, release-gate verdicts, follow-up issue quality.
+- Lane 2: `@ontrails/testing` package boundary, exports, peer deps, changeset, downstream type regression.
+- Lane 3: Topographer CLI guidance, beta install policy, migration guide completeness, docs/plugin drift.
+
+Reviewer output contract:
+
+- Overall score: `n/5`
+- Prose summary: concise judgment
+- Findings: P0/P1/P2/P3 with file/line evidence where applicable
+- Prompt To Fix With AI: concise fix prompt for each actionable finding
+
+Fix all P0/P1/P2 findings before remote submission or final handoff. Documentation correctness is P2 by default. Record review scores, summaries, findings, fixes, and remaining P3s in `RETRO.md`.
+
+For remote code-review bots/agents, also record summary scores, prose summaries, prompt-to-fix blocks, and whether any score below 5/5 reflects current unresolved debt, stale feedback, or an explicitly rejected recommendation.
+
+## Progress Reporting
+
+After each execution turn, report:
+
+- Current checkpoint
+- What changed
+- What was verified
+- Command/output summary
+- What remains
+- Blocker status
+- Next checkpoint
+
+## Stop / Pause Rules
+
+Stop and ask if:
+
+- The plan appears stale against `main`, Linear, or open PR state.
+- A public API, artifact layout, or stable-cutover doctrine decision must change beyond this packet.
+- Audit findings imply stable cutover is blocked by work larger than a small in-stack fix.
+- Verification fails for unrelated reasons after a focused retry.
+- Secrets, credentials, production systems, npm publish, registry mutation, or irreversible actions are needed.
+- More than four post-ready remote-review turns have elapsed and P2+ feedback remains unresolved.
+- Graphite reports a real conflict/failure; do not spin on Graphite mergeability lag alone when GitHub/Graphite otherwise indicate ready.
+
+## Handoff Audit
+
+- [x] Objective is singular and end-to-end.
+- [x] Completion condition is objectively checkable.
+- [x] Tracker state is current.
+- [x] Branch names/order are exact.
+- [x] Dependencies/blockers are represented.
+- [x] Ignored/untracked source docs are copied, summarized, moved, or avoided.
+- [x] Validation commands match repo conventions.
+- [x] `GOAL.md` requires transcript-visible proof.
+- [x] `GOAL.md` requires `RETRO.md` finalization before completion.
+- [x] Stop rules are concrete.
+- [x] `RETRO.md` has concrete sections for execution, tracker, review, verification, remote state, forbidden actions, final state, and archive readiness.
+- [x] Packet can be executed without chat history.

--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/REFS.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/REFS.md
@@ -1,0 +1,75 @@
+# References: v1-release-readiness-closeout
+
+## Tracked / Portable Sources
+
+- `AGENTS.md` - repo workflow, Graphite, Bun, Linear, release, Warden, and subagent rules.
+- `.agents/plans/PLANNING.md` - project-specific goal planning preferences.
+- `docs/adr/0048-trail-versioning-v3.md` - current trail-versioning doctrine for marker and force audits.
+- `docs/releases/stable-cutover.md` - stable release checklist that may need pending-force gate updates.
+- `docs/releases/beta15.md` - existing beta line release notes and migration entrypoint.
+- `docs/migration/trailhead-to-surface.md` - focused migration guide to link from beta.15 to beta.18 guide.
+- `docs/migration/connector-to-adapter.md` - focused migration guide to link from beta.15 to beta.18 guide.
+- `docs/migration/logging-to-observe.md` - observability/logging migration source.
+- `docs/migration/layer-evolution.md` - focused migration source.
+- `docs/migration/topograph-artifact-family.md` - Topographer artifact-family migration source.
+- `packages/testing/package.json` - export map, peer dependency, and changeset impact for `TRL-757`.
+- `packages/testing/src/index.ts` - current root export surface for `@ontrails/testing`.
+- `packages/testing/src/types.ts` - current surface-specific type import risk.
+- `packages/testing/src/all.ts` - current `testAllEstablished` surface harness coupling.
+- `packages/testing/src/harness-http.ts`, `packages/testing/src/harness-cli.ts`, `packages/testing/src/harness-mcp.ts`, `packages/testing/src/surface-parity.ts` - likely subpath owners.
+- `plugin/skills/trails/references/testing-patterns.md` - plugin testing guidance to update after `TRL-757`.
+- `plugin/skills/trails/references/architecture.md` - Topographer wording target for `TRL-758`.
+- `plugin/skills/trails/references/cli-surface.md` - CLI command guidance target.
+- `README.md`, `docs/index.md`, `docs/api-reference.md`, `docs/testing.md`, `docs/topo-store.md` - public docs affected by the sprint.
+
+## Untracked / Local-Only Sources
+
+- `/Users/mg/patch/.agents/plans/2026-05-21-patchos-trails-modernization/TRAILS-UPSTREAM-RETRO.md` - downstream dogfood evidence for `TRL-757` through `TRL-760`. Use as input only; summarize load-bearing details in tracked docs/reports.
+- `.claude/worktrees/` - unrelated local untracked worktree state observed during planning; ignore unless the executor intentionally uses that worktree.
+
+## Copied Or Summarized Sources
+
+- None yet. During execution, summarize any PatchOS-retro-only details that become load-bearing in `reports/` or the migration guide.
+
+## Tracker Records
+
+- `TRL-767` - pending force events as v1 stable cutover gate; Todo; v1 Release Prep; branch `trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate`.
+- `TRL-766` - version marker failure UX and bounded Zod diagnostics; Todo; v1 Release Prep; branch `trl-766-audit-version-marker-failure-ux-and-bounded-zod-diagnostics`.
+- `TRL-756` - v1 doctrine and lexicon drift audit; Todo; v1 Release Prep; branch `trl-756-audit-v1-doctrine-and-lexicon-drift-after-versioning-m3`.
+- `TRL-757` - split `@ontrails/testing` surface harnesses behind subpaths; Todo; v1 Release Prep; branch `trl-757-split-ontrailstesting-surface-harnesses-behind-subpaths`.
+- `TRL-758` - clarify Topographer artifact CLI workflow and retired topo commands; Todo; v1 Release Prep; branch `trl-758-clarify-topographer-artifact-cli-workflow-and-retired-topo`.
+- `TRL-759` - beta channel install policy and version bump cadence; Todo; v1 Release Prep; branch `trl-759-document-beta-channel-install-policy-and-version-bump`.
+- `TRL-760` - beta.15 to beta.18 downstream migration guide; Todo; v1 Release Prep; branch `trl-760-add-beta15-to-beta18-downstream-migration-guide`.
+- `TRL-765` - related versioning derivation pipeline audit; out of scope unless included audits prove stable cutover is blocked by it.
+- `TRL-508` - codemod/trailworks migration path; explicitly out of scope.
+
+## PRs / Branches
+
+- No open PRs at planning time.
+- `main` at planning time: `df16dfb33 docs: archive plugin skills refresh plan (#569)`.
+- Previously merged PR #569 archived the plugin skills refresh packet.
+
+## Prior Plans
+
+- `.agents/plans/2026-05-21-plugin-skills-refresh-stack/` - archived by PR #569; no longer active.
+- `.scratch/2026-05-12-topograph-query-docs-stack/PLAN.md` - historical Topographer artifact-family planning; use only as background if current docs/code are ambiguous.
+- `.scratch/2026-05-05-merge-readiness/fix-plan.md` - historical example of detailed goal packet style; not a source of truth for this work.
+
+## Validation Commands
+
+- `gt sync --no-interactive` - update local Graphite/main state before branching.
+- `git status --short --branch` - confirm current branch and local dirt.
+- `gt log --stack --reverse --no-interactive` - verify local stack order.
+- `gh pr list --state open --json number,title,headRefName,isDraft,url` - verify no conflicting open PRs.
+- `bun apps/trails/bin/trails.ts --help` - verify top-level CLI command grammar.
+- `bun apps/trails/bin/trails.ts topo --help` - verify retired topo subcommands are not advertised.
+- `bun run docs:links` - relative Markdown link integrity.
+- `bun run docs:snippets` - README snippet typecheck.
+- `bun run docs:api-examples` - public API example gate.
+- `bun run typecheck` - repo typecheck.
+- `bun run test` - repo test suite.
+- `bun run build` - repo build.
+- `bun run check` - broad repo gate.
+- `bun run publish:check` - dry-run pack/publish readiness without registry mutation.
+- `bun run publish:registry-check` - read-only registry/dist-tag preflight.
+- `git diff --check` - whitespace/conflict marker guard.

--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md
@@ -1,0 +1,206 @@
+# Execution Retro: v1-release-readiness-closeout
+
+Date started: 2026-05-22
+Date finalized: pending
+Status: Seeded
+Plan: `.agents/plans/2026-05-22-v1-release-readiness-closeout/PLAN.md`
+Goal: `.agents/plans/2026-05-22-v1-release-readiness-closeout/GOAL.md`
+
+Use this as the durable execution ledger. For stacked work, this should normally be the last meaningful file touched before local completion, draft submission, ready-for-review, remote review closeout, merge readiness, archive, or final handoff. Meaningful review-flow changes require a new retro entry.
+
+## Execution Summary
+
+- Objective: Build the 7-branch v1 release-readiness closeout stack: `TRL-767`, `TRL-766`, `TRL-756`, `TRL-757`, `TRL-758`, `TRL-759`, `TRL-760`.
+- Final outcome: pending
+- Final branch / stack tip: pending
+- Final PR range: pending
+- Final tracker state: pending
+- Final verification state: pending
+- Remaining risks / P3s: pending
+- Archive state: active packet seeded
+
+## Branch / PR / Issue Ledger
+
+| Order | Issue | Branch | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `TRL-767` | `trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate` | pending | In Progress | Audit/report drafted: pending force events as stable cutover gate. |
+| 2 | `TRL-766` | `trl-766-audit-version-marker-failure-ux-and-bounded-zod-diagnostics` | pending | Todo | Audit/report: marker failure UX and bounded Zod diagnostics. |
+| 3 | `TRL-756` | `trl-756-audit-v1-doctrine-and-lexicon-drift-after-versioning-m3` | pending | Todo | Audit/report: doctrine and lexicon drift. |
+| 4 | `TRL-757` | `trl-757-split-ontrailstesting-surface-harnesses-behind-subpaths` | pending | Todo | Package/API: testing harness subpaths and changeset. |
+| 5 | `TRL-758` | `trl-758-clarify-topographer-artifact-cli-workflow-and-retired-topo` | pending | Todo | CLI/docs: Topographer artifact workflow. |
+| 6 | `TRL-759` | `trl-759-document-beta-channel-install-policy-and-version-bump` | pending | Todo | Release docs/policy: beta install, dist-tag, bump cadence. |
+| 7 | `TRL-760` | `trl-760-add-beta15-to-beta18-downstream-migration-guide` | pending | Todo | Migration docs: beta.15 to beta.18 guide. |
+
+## Planning Discoveries
+
+| Discovery | Evidence | Decision | Impact |
+| --- | --- | --- | --- |
+| Repo is clean enough to plan from `main`; no open PRs. | `context-prime.sh`; `gh pr list` returned `[]`; `git status` showed only untracked `.claude/worktrees/`. | Plan from current `main` after an initial `gt sync`. | Executor should not inherit older-stack assumptions. |
+| The v1 Release Prep follow-ups were still Backlog while the next sprint intends to execute them. | Linear `TRL-757` through `TRL-760` fetched as Backlog. | Move them to Todo during planning. | Board now matches packet. |
+| Audit gates `TRL-756`, `TRL-766`, `TRL-767` were Todo but not all attached to v1 Release Prep. | Linear fetch showed `TRL-756`, `TRL-766`, `TRL-767` without project or outside project. | Attach them to `v1 Release Prep`. | Release-readiness project now contains the audit gates. |
+| `TRL-765` is related versioning audit work but broader and not needed for this sprint. | Linear `Trail Versioning v1.x` has `TRL-765` as Backlog. | Keep out of goal unless audit evidence proves it blocks stable cutover. | Prevents uncontrolled scope expansion. |
+
+## Deferred / Follow-Up Discoveries
+
+Out-of-goal discoveries belong here first. Create focused follow-up issues when they represent real future work.
+
+| Issue | Discovery | Why Out Of Goal | Link |
+| --- | --- | --- | --- |
+| `TRL-765` | Versioning derivation pipeline audit remains open. | Broader design/audit; not required for this seven-issue release-readiness packet unless included audits prove it blocks stable. | <https://linear.app/outfitter/issue/TRL-765/audit-gap-between-versioning-scaffolding-and-derivation-pipeline> |
+| `TRL-769` | Stable cutover runbook does not name the pending-force gate. | Docs-only release-gate follow-up discovered by `TRL-767`; not part of the audit branch implementation contract. | <https://linear.app/outfitter/issue/TRL-769/document-pending-force-stable-cutover-gate> |
+| `TRL-770` | `trails doctor` force-event output is aggregate-only and appears to miss graph-level removed-entry forces. | Implementation polish discovered by `TRL-767`; larger than an audit report and should land as a focused follow-up. | <https://linear.app/outfitter/issue/TRL-770/make-trails-doctor-pending-force-output-complete-and-actionable> |
+| `TRL-771` | Accepted-exception semantics for pending force events are not artifact-backed. | Design/policy follow-up; the current hard zero-pending gate is usable, but named exceptions need their own decision. | <https://linear.app/outfitter/issue/TRL-771/define-accepted-exception-semantics-for-pending-force-events> |
+
+## Tracker Mutations
+
+Record issues, milestones, labels, dependency links, comments, and follow-up issues created or updated during planning/execution.
+
+| Time | Tracker Item | Mutation | Evidence |
+| --- | --- | --- | --- |
+| 2026-05-22 17:48 EDT | `TRL-756` | Set project to `v1 Release Prep`; confirmed state Todo. | Linear update |
+| 2026-05-22 17:48 EDT | `TRL-766` | Set project to `v1 Release Prep`; confirmed state Todo. | Linear update |
+| 2026-05-22 17:48 EDT | `TRL-767` | Set project to `v1 Release Prep`; confirmed state Todo. | Linear update |
+| 2026-05-22 17:48 EDT | `TRL-757` | Moved from Backlog to Todo. | Linear update |
+| 2026-05-22 17:48 EDT | `TRL-758` | Moved from Backlog to Todo. | Linear update |
+| 2026-05-22 17:48 EDT | `TRL-759` | Moved from Backlog to Todo. | Linear update |
+| 2026-05-22 17:48 EDT | `TRL-760` | Moved from Backlog to Todo. | Linear update |
+| 2026-05-22 17:56 EDT | `TRL-767` | Moved from Todo to In Progress after bottom branch creation. | Linear update |
+| 2026-05-22 18:01 EDT | `TRL-769` | Created follow-up issue for stable cutover pending-force gate docs. | Linear create, related to `TRL-767` |
+| 2026-05-22 18:01 EDT | `TRL-770` | Created follow-up issue for complete/actionable `trails doctor` pending-force output. | Linear create, related to `TRL-767` |
+| 2026-05-22 18:01 EDT | `TRL-771` | Created follow-up issue for accepted-exception semantics. | Linear create, related to `TRL-767` |
+| 2026-05-22 18:04 EDT | `TRL-767` | Added audit summary comment with report path, verdict, follow-ups, and targeted checks. | Linear comment `0316d7a9-e625-4067-8e76-b69c0bfec82f` |
+
+## Execution Log
+
+Append meaningful state changes, especially before handoff points.
+
+```text
+YYYY-MM-DD HH:MM TZ - <branch/issue/checkpoint>
+- Changed:
+- Verified:
+- Result:
+- Next:
+- Blockers:
+
+2026-05-22 17:54 EDT - Phase 0 / sync and tracker prime
+- Changed: No source files changed yet; active packet remains untracked and will be committed on `trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate`.
+- Verified: `gt sync --no-interactive`; `git status --short --branch`; `gt log --stack --reverse --no-interactive`; `gh pr list --state open --json number,title,headRefName,isDraft,url,mergeStateStatus,statusCheckRollup`; Linear issue reads for `TRL-767`, `TRL-766`, `TRL-756`, `TRL-757`, `TRL-758`, `TRL-759`, and `TRL-760`.
+- Result: Sync returned `ok synced`; `main` is current at `df16dfb33`; GitHub open PR list is empty; Linear branch names and issue scopes match `PLAN.md`; unrelated untracked `.claude/worktrees/` remains ignored.
+- Next: Create the bottom Graphite branch and commit the active packet there.
+- Blockers: None.
+
+2026-05-22 17:56 EDT - Phase 0 / bottom branch created
+- Changed: Created `trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate`; committed the active packet as `docs: add v1 release readiness closeout packet`; moved `TRL-767` to In Progress.
+- Verified: `git status --short --branch`; `gt log --stack --reverse --no-interactive`; Linear `_save_issue` for `TRL-767`.
+- Result: Current branch is `trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate`; the packet is committed at the bottom of the stack; only unrelated `.claude/worktrees/` remains untracked.
+- Next: Create the rest of the local stack and begin `TRL-767` audit evidence collection.
+- Blockers: None.
+
+2026-05-22 17:57 EDT - Phase 0 / local stack chain created
+- Changed: Created local empty branches for `TRL-766`, `TRL-756`, `TRL-757`, `TRL-758`, `TRL-759`, and `TRL-760` above the committed `TRL-767` base branch; no branches were pushed.
+- Verified: `gt log --stack --reverse --no-interactive`; `git status --short --branch`.
+- Result: Stack order matches `PLAN.md`; current tip is `trl-760-add-beta15-to-beta18-downstream-migration-guide`; only unrelated `.claude/worktrees/` remains untracked.
+- Next: Check out `TRL-767` and produce `reports/trl-767-pending-force-gate.md`.
+- Blockers: None.
+
+2026-05-22 18:03 EDT - TRL-767 pending-force gate audit
+- Changed: Added `reports/trl-767-pending-force-gate.md`; filed follow-ups `TRL-769`, `TRL-770`, and `TRL-771`.
+- Verified: `bun test packages/topographer/src/__tests__/forces.test.ts packages/topographer/src/__tests__/diff.test.ts packages/warden/src/__tests__/trail-versioning-rules.test.ts`; `bun test apps/trails/src/__tests__/survey.test.ts -t force`; `bun test apps/trails/src/__tests__/version-lifecycle.test.ts -t doctor`; `bun apps/trails/bin/trails.ts diff --help`; `bun apps/trails/bin/trails.ts doctor --help`; `bun apps/trails/bin/trails.ts doctor --json`; `bun apps/trails/bin/trails.ts diff --forces --json`; `git status --short -- .trails .trails-tmp`.
+- Result: Verdict is `gate needs docs`; hard zero-pending-force gate is usable via Warden and diff evidence; `doctor` completeness/actionability and accepted-exception semantics need follow-up before softer exception policy; default monorepo `doctor`/`diff` commands require `--module`; explicit `--module apps/trails/src/app.ts` attempts returned `Error: Internal server error`; no `.trails` artifacts were created.
+- Next: Run report checks and commit the `TRL-767` audit report.
+- Blockers: None for the hard zero-pending-force release rule; exception policy remains follow-up work.
+
+2026-05-22 18:04 EDT - TRL-767 tracker comment
+- Changed: Added a Linear comment on `TRL-767` summarizing the report, verdict, follow-ups, and targeted checks.
+- Verified: Linear `_save_comment`.
+- Result: Comment `0316d7a9-e625-4067-8e76-b69c0bfec82f` created successfully.
+- Next: Move to `TRL-766` marker diagnostics audit.
+- Blockers: None.
+```
+
+## Local Review Log
+
+Record local review rounds, reports, P0/P1/P2 findings, fixes, and remaining P3s. Do not mark local review complete while P0/P1/P2 findings remain.
+
+| Round | Scope / Lanes | Report Paths | P0/P1/P2 Result | Fix Commits / Notes |
+| --- | --- | --- | --- | --- |
+| pending | Lane 1 audit gates; Lane 2 testing package; Lane 3 docs/release/migration | pending | pending | pending |
+
+## Verification Log
+
+Record exact commands and artifact checks. Include skipped checks with reasons.
+
+| Check | Scope | Result | Evidence / Notes |
+| --- | --- | --- | --- |
+| `/Users/mg/.agents/skills/goal-planning/scripts/context-prime.sh` | Planning | pass | Captured main/open PR/planning state. |
+| `jq '.scripts \| keys' package.json` | Planning | pass | Verified available docs/publish/check scripts. |
+| `git status --short --branch` | Planning | pass | `main...origin/main`; unrelated untracked `.claude/worktrees/`. |
+| `gt sync --no-interactive` | Phase 0 | pass | Returned `ok synced`. |
+| `git status --short --branch` | Phase 0 | pass | `## main...origin/main`; active packet and unrelated `.claude/worktrees/` untracked. |
+| `gt log --stack --reverse --no-interactive` | Phase 0 | pass | Current stack is `main` at `df16dfb33`; prior PR #569 is merged. |
+| `gh pr list --state open --json number,title,headRefName,isDraft,url,mergeStateStatus,statusCheckRollup` | Phase 0 | pass | Returned `[]`. |
+| Linear `_get_issue` for `TRL-767`, `TRL-766`, `TRL-756`, `TRL-757`, `TRL-758`, `TRL-759`, `TRL-760` | Phase 0 | pass | All issues are `Todo`, in `v1 Release Prep`, and expose branch names matching `PLAN.md`. |
+| `gt branch create trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate -m "docs: add v1 release readiness closeout packet" --no-interactive` | Phase 0 | pass | Created bottom branch and committed the packet after markdownlint auto-fix plus pipe escaping. |
+| Linear `_save_issue` for `TRL-767` | Phase 0 | pass | Status moved from Todo to In Progress. |
+| `gt branch create <branch> --no-interactive --no-ai` for the six upper branches | Phase 0 | pass | Created local empty branch chain in `PLAN.md` order; nothing pushed. |
+| `gt log --stack --reverse --no-interactive` | Phase 0 | pass | Shows `main` then `TRL-767`, `TRL-766`, `TRL-756`, `TRL-757`, `TRL-758`, `TRL-759`, `TRL-760`. |
+| `bun test packages/topographer/src/__tests__/forces.test.ts packages/topographer/src/__tests__/diff.test.ts packages/warden/src/__tests__/trail-versioning-rules.test.ts` | `TRL-767` | pass | 41 pass, 0 fail. |
+| `bun test apps/trails/src/__tests__/survey.test.ts -t force` | `TRL-767` | pass | 4 pass, 0 fail; covers forced compile and `diff --forces`. |
+| `bun test apps/trails/src/__tests__/version-lifecycle.test.ts -t doctor` | `TRL-767` | pass | 1 pass, 0 fail; confirms existing doctor count coverage but not force details. |
+| `bun apps/trails/bin/trails.ts diff --help` | `TRL-767` | pass | Help advertises `--forces` as `Only show graph force audit events`. |
+| `bun apps/trails/bin/trails.ts doctor --help` | `TRL-767` | pass | Help advertises `trails doctor` as `Diagnose trail versioning lifecycle state`. |
+| `bun apps/trails/bin/trails.ts doctor --json` | `TRL-767` | expected failure | Monorepo has multiple app entry points; command asks for `--module`. |
+| `bun apps/trails/bin/trails.ts diff --forces --json` | `TRL-767` | expected failure | Monorepo has multiple app entry points; command asks for `--module`. |
+| `bun apps/trails/bin/trails.ts doctor --module apps/trails/src/app.ts --json` | `TRL-767` | failed | Returned `Error: Internal server error`; no artifacts created. |
+| `bun apps/trails/bin/trails.ts diff --module apps/trails/src/app.ts --forces --json` | `TRL-767` | failed | Returned `Error: Internal server error`; no artifacts created. |
+| `git status --short -- .trails .trails-tmp` | `TRL-767` | pass | No generated local topo artifacts present. |
+
+## Remote Review / CI Log
+
+Record remote review state after submission and after each meaningful fix round. Treat code-review bot/agent errors and unresolved P0/P1/P2 comments as incomplete. Also record summary scores and prompt-to-fix text from code-review bots/agents; a lower score with concrete fixable feedback is review debt even if inline threads are resolved.
+
+| Time | PR | CI State | Review State | Scores / Signals | Unresolved P0/P1/P2 | Action |
+| --- | --- | --- | --- | --- | --- | --- |
+| pending | pending | pending | pending | pending | pending | pending |
+
+## Review Feedback Resolutions
+
+| Source | Score / Signal | Severity | Finding | Prompt To Fix | Resolution | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| pending | pending | pending | pending | pending | pending | pending |
+
+## Forbidden Actions Audit
+
+Record constraints that stayed true. Add or remove rows to match the goal.
+
+| Action / Constraint | Status | Evidence |
+| --- | --- | --- |
+| No merge without explicit user approval | pending | pending |
+| No package publish / registry mutation unless authorized | pending | pending |
+| No `bun run publish:packages` | pending | pending |
+| No merge queue label unless authorized | pending | pending |
+| No `gt absorb` | pending | pending |
+| No source-control writes by subagents | pending | pending |
+| No unrelated destructive changes | pending | pending |
+
+## Final State
+
+Fill before claiming completion, handoff, merge readiness, or archive.
+
+- Goal completion condition:
+- Graphite / branch state:
+- PR state:
+- Source-control host lag:
+- Tracker state:
+- Local review state:
+- Remote review state:
+- Remote review scores:
+- Verification:
+- Skipped checks:
+- Remaining P3s / risks:
+- Follow-up issues created:
+- Forbidden actions confirmation:
+- Packet archive readiness:
+- Final transcript proof:
+
+Do not mark complete until the goal completion condition has been proven, this section is filled or explicitly marked blocked, and the final transcript names the updated retro state.

--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-767-pending-force-gate.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-767-pending-force-gate.md
@@ -1,0 +1,234 @@
+# TRL-767 Audit: Pending Force Events As A V1 Stable Cutover Gate
+
+Date: 2026-05-22
+Branch: `trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate`
+Issue: `TRL-767`
+
+## Summary Verdict
+
+Verdict: `gate needs docs`
+
+The hard release rule is usable today: stable cutover can require zero pending
+force events before the version PR leaves draft. The implementation already
+blocks unforced breaking topo changes, records graph-only force events on
+`trails compile --force`, preserves forced graph hashes in `.trails/trails.lock`,
+keeps `trails validate` non-stale for force-only hash differences, exposes
+`trails diff --forces`, and reports graph-only force events through Warden's
+`pending-force` rule.
+
+The softer proposed exception rule is not fully tool-backed yet. `trails doctor`
+does not currently provide enough detail to be a standalone release gate and
+appears to count only entry-attached force events, not graph-level removed-entry
+force events. Warden also treats every attached force event as pending; there is
+no structured accepted-exception or resolved-historical state. The stable
+cutover runbook does not yet name the pending-force gate.
+
+Recommended v1 rule:
+
+> Stable cutover may proceed only when Warden `pending-force`, `trails diff
+> --forces`, and `trails doctor` show zero pending force events. If the project
+> wants accepted exceptions, those exceptions need a follow-up artifact and
+> Warden policy before they become more than PR prose.
+
+This does not block the current seven-issue closeout stack. It does block using
+a named-exception policy as an automated v1 gate until follow-ups land.
+
+## Evidence Map
+
+### Source Behavior
+
+- `apps/trails/src/trails/topo-store-support.ts:100-119` reads the previous
+  TopoGraph, diffs it, rejects breaking changes without `force`, carries
+  previous force metadata forward, and annotates breaking diffs as force events.
+- `apps/trails/src/trails/compile.ts:47-54` exposes the `force` input flag with
+  the description "Record graph-only force events for breaking changes".
+- `packages/topographer/src/types.ts:116-125` defines `TopoGraphForceEntry` with
+  `acceptedAt`, `change`, `detail`, `id`, `kind`, optional `reason`,
+  `severity`, and `source`.
+- `packages/topographer/src/types.ts:249-260` validates force entries in the
+  TopoGraph schema; `packages/topographer/src/types.ts:262-288` allows
+  graph-level `forces`.
+- `packages/topographer/src/forces.ts:43-79` attaches modified force events to
+  the affected entry and removed force events to graph-level `forces`.
+- `packages/topographer/src/forces.ts:81-118` carries force events forward and
+  strips them for live graph comparison.
+- `apps/trails/src/trails/topo-read-support.ts:270-288` treats a committed
+  forced graph as non-stale when the committed hash matches the force-bearing
+  artifact and the force-stripped graph matches the live current hash.
+- `packages/topographer/src/diff.ts:637-721` reports entry and graph-level
+  force-event additions/removals as audit warnings.
+- `apps/trails/src/trails/survey.ts:306-345` preserves force-event details when
+  `--forces` is used, including with version-range targets.
+- `packages/warden/src/rules/trail-versioning-topo.ts:154-172` reports
+  entry-level and graph-level force entries as `pending-force`.
+
+### Docs
+
+- `docs/adr/0048-trail-versioning-v3.md:219-240` says `forces` are graph-only
+  audit debt, not source, not authored version entries, and never runtime
+  resolution targets.
+- `docs/lexicon.md:469-473` says `forces:` appears only in the resolved graph,
+  not source, and is not a version entry.
+- `docs/topo-store.md` — the `### trails diff` section documents
+  `trails diff --forces` (lines 107-118 at the TRL-767 audit snapshot; later
+  TRL-758 documentation edits shift the exact line range, so navigate by
+  heading rather than line).
+- `docs/topo-store.md` — the `### trails doctor` section says `trails doctor`
+  summarizes deprecated, archived, and forced topo break audit state (lines
+  142-149 at the TRL-767 audit snapshot; same heading-anchored navigation note
+  applies).
+- `docs/releases/stable-cutover.md:27-76` lists stable cutover preconditions but
+  does not mention pending-force, `trails diff --forces`, `trails doctor`, or
+  Warden `pending-force`.
+
+### Tests
+
+- `apps/trails/src/__tests__/survey.test.ts:1472-1546` proves unforced breaking
+  changes fail, forced compile records force events in `.trails/topo.lock`, the
+  lock manifest points at the forced graph hash, validate is non-stale, and
+  recompilation preserves the forced hash.
+- `apps/trails/src/__tests__/survey.test.ts:1548-1610` proves removed trails are
+  recorded as graph-level force events and survive recompilation.
+- `apps/trails/src/__tests__/survey.test.ts:1618-1624` proves the top-level
+  `diff` command exposes a `forces` flag.
+- `apps/trails/src/__tests__/survey.test.ts:1745-1797` proves `diff --forces`
+  exposes graph-only force audit events even with a version-range target.
+- `packages/topographer/src/__tests__/forces.test.ts:30-112` covers modified,
+  removed, and force-stripping behavior.
+- `packages/topographer/src/__tests__/diff.test.ts:573-637` covers force event
+  warnings for entry-level and graph-level forces.
+- `packages/warden/src/__tests__/trail-versioning-rules.test.ts:295-383`
+  covers `pending-force` for entry-level forces, graph-level removed forces, and
+  deduplication.
+- `apps/trails/src/__tests__/version-lifecycle.test.ts:511-538` covers doctor
+  lifecycle counts, but not force-event counts or force-event details.
+
+## Command Snippets
+
+```text
+$ bun test packages/topographer/src/__tests__/forces.test.ts \
+>   packages/topographer/src/__tests__/diff.test.ts \
+>   packages/warden/src/__tests__/trail-versioning-rules.test.ts
+41 pass
+0 fail
+Ran 41 tests across 3 files.
+```
+
+```text
+$ bun test apps/trails/src/__tests__/survey.test.ts -t force
+(pass) trails compile > blocks breaking topo changes unless forced and records force events
+(pass) trails compile > forced removed trails are recorded as graph force events
+(pass) trails survey diff > top-level diff filters graph-only force audit events
+4 pass
+0 fail
+```
+
+```text
+$ bun apps/trails/bin/trails.ts diff --help
+Options:
+  --forces              Only show graph force audit events (default: false)
+```
+
+```text
+$ bun apps/trails/bin/trails.ts doctor --help
+Usage: trails doctor [options]
+Diagnose trail versioning lifecycle state
+```
+
+```text
+$ bun apps/trails/bin/trails.ts doctor --json
+Error: Found multiple Trails app entry points:
+  - apps/trails-demo/src/app.ts
+  - apps/trails/src/app.ts
+Use --module to select one explicitly.
+```
+
+The default command failure is expected in this monorepo because multiple app
+entry points exist. Follow-up command attempts with `--module apps/trails/src/app.ts`
+returned the generic `Error: Internal server error`; no `.trails` artifacts were
+created. The targeted tests above are the reliable workflow proof for this
+audit.
+
+## Current Behavior Matrix
+
+| Surface | Current Behavior | Evidence | Verdict |
+| --- | --- | --- | --- |
+| `trails compile` | Rejects breaking diffs unless `force` is true; forced compile writes force-bearing graph artifacts. | `apps/trails/src/trails/topo-store-support.ts:100-119`; `apps/trails/src/__tests__/survey.test.ts:1472-1546` | Ready for hard zero-pending gate. |
+| `.trails/topo.lock` / `.trails/trails.lock` | Force events live in TopoGraph; lock manifest stores the forced graph hash. | `apps/trails/src/__tests__/survey.test.ts:1500-1513`; `packages/topographer/src/types.ts:116-125` | Ready. |
+| `trails validate` | Accepts force-only committed graph differences when the force-stripped graph matches current. | `apps/trails/src/trails/topo-read-support.ts:270-288`; `apps/trails/src/__tests__/survey.test.ts:1514-1523` | Ready. |
+| `trails diff --forces` | Exposes and filters graph force audit events. | `apps/trails/src/trails/survey.ts:306-345`; `apps/trails/src/__tests__/survey.test.ts:1745-1797` | Ready. |
+| `trails doctor` | Exposes `forceEvents` count, but aggregate-only and appears to miss graph-level forces. | `apps/trails/src/trails/doctor.ts:20-27`; `apps/trails/src/trails/version-lifecycle-support.ts:826-865` | Needs implementation polish before standalone gate use. |
+| Warden `pending-force` | Warns for entry-level and graph-level force events and deduplicates overlaps. | `packages/warden/src/rules/trail-versioning-topo.ts:154-172`; `packages/warden/src/__tests__/trail-versioning-rules.test.ts:295-383` | Ready for hard zero-pending gate. |
+| Stable cutover docs | Runbook does not mention pending-force gate yet. | `docs/releases/stable-cutover.md:27-76` | Needs docs. |
+
+## Audit Questions
+
+### Are forced break events persisted only in the derived graph, not source contracts?
+
+Yes. ADR-0048 and the lexicon both define force events as graph-only, and the
+implementation annotates `TopoGraph` entries or graph-level `forces` during
+artifact writing. The source search found force literals in docs, tests, and
+Topographer implementation, not authored trail source.
+
+### Can an agent tell which trail/version/marker changed and why it was forced?
+
+Partially. A force entry carries `id`, `kind`, `change`, `detail`,
+`acceptedAt`, optional `reason`, `severity`, and `source`. That is enough to see
+the affected entity and diff text. It does not carry structured `version`,
+`marker`, `owner`, `plannedResolution`, or `resolved` fields, so version/marker
+semantics depend on the free-form diff detail and surrounding TopoGraph context.
+
+### Does the audit event carry enough metadata for release review?
+
+Enough for a hard zero-pending rule, not enough for a named exception rule. A
+release reviewer can identify pending force debt through Warden and diff output,
+but cannot encode an accepted exception or resolution lifecycle in the artifact
+itself.
+
+### Can `pending-force` distinguish new/active debt from accepted historical force events?
+
+No. Warden reports every attached force entry as pending, with deduplication for
+overlapping entry/graph records. There is no accepted or resolved state in
+`TopoGraphForceEntry`.
+
+### Does the stable cutover runbook mention pending force events?
+
+No. It should.
+
+### Should v1 require zero pending force events unless the version PR documents an accepted exception?
+
+Use the stricter first half for v1: require zero pending force events. If an
+exception path is desired, land follow-up semantics first so the exception is
+structured and Warden-visible rather than only PR prose.
+
+## Follow-Up Issues
+
+- `TRL-769`: Document pending-force stable cutover gate.
+- `TRL-770`: Make `trails doctor` pending-force output complete and actionable.
+- `TRL-771`: Define accepted-exception semantics for pending force events.
+
+## Stable Cutover Checklist Item
+
+Proposed immediate checklist text for the stable version PR:
+
+```markdown
+- [ ] Pending-force gate is clean: Warden reports no `pending-force`
+      diagnostics, `trails diff --forces` shows no force events, and
+      `trails doctor` reports `forceEvents: 0`.
+```
+
+If `TRL-771` later defines structured exceptions, extend the checklist with:
+
+```markdown
+- [ ] Any accepted force exception is named in the PR body with owner, reason,
+      planned resolution, and the corresponding Warden/doctor output.
+```
+
+## Blocker Assessment
+
+No large stable-cutover blocker was found for the hard zero-pending-force rule.
+The current system can enforce "no force events" through Warden and diff output.
+
+There is a blocker for the softer exception policy: accepted exceptions are not
+artifact-backed. That is filed as `TRL-771` and should be resolved before v1
+relies on exceptions as a routine release path.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 .agents/notes/
 .claude/agent-memory/
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 .npmrc
 .envrc
 .claude/settings.local.json


### PR DESCRIPTION
## Context

Audit branch for [TRL-767](https://linear.app/outfitter/issue/TRL-767/audit-pending-force-events-as-a-v1-stable-cutover-gate): can pending force events serve as a v1 stable cutover release gate? Bottom of the v1 release-readiness closeout stack; carries the goal packet for the full stack.

Closes [TRL-767](https://linear.app/outfitter/issue/TRL-767/audit-pending-force-events-as-a-v1-stable-cutover-gate).

## Changes

- New audit report: `.agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-767-pending-force-gate.md`. Verdict `gate needs docs`: the hard zero-pending-force release rule is usable today via Warden, `trails diff --forces`, and `trails doctor`, but the softer accepted-exception model needs follow-up work before it can replace the hard gate.
- Packet for the full closeout stack at `.agents/plans/2026-05-22-v1-release-readiness-closeout/{PLAN,GOAL,REFS,RETRO}.md`.
- Repo-hygiene: `.gitignore` now ignores `.claude/worktrees/` so the unrelated local worktree state stays out of every commit on the stack.

## Verification

- `bun test packages/topographer/src/__tests__/forces.test.ts packages/topographer/src/__tests__/diff.test.ts packages/warden/src/__tests__/trail-versioning-rules.test.ts` → 41 pass, 0 fail.
- `bun test apps/trails/src/__tests__/survey.test.ts -t force` → 4 pass, 0 fail.
- `bun test apps/trails/src/__tests__/version-lifecycle.test.ts -t doctor` → 1 pass, 0 fail.
- `bun apps/trails/bin/trails.ts diff --help` and `doctor --help` confirm `--forces` and `trails doctor` are advertised.
- `bun apps/trails/bin/trails.ts doctor --module apps/trails/src/app.ts --json` and `diff --module … --forces --json` returned `Error: Internal server error`; recorded as evidence in the report rather than treated as a stable-blocker.
- `git diff --check` → clean.

## Risks / Rollout

Docs/audit-only change; no public API or runtime behavior modified. The `.gitignore` line is purely additive and unrelated to runtime.

## Follow-ups filed

- [TRL-769](https://linear.app/outfitter/issue/TRL-769/document-pending-force-stable-cutover-gate)
- [TRL-770](https://linear.app/outfitter/issue/TRL-770/make-trails-doctor-pending-force-output-complete-and-actionable)
- [TRL-771](https://linear.app/outfitter/issue/TRL-771/define-accepted-exception-semantics-for-pending-force-events)
