### PR TITLE
docs: audit marker diagnostics

### DIFF
--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md
@@ -24,7 +24,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | Order | Issue | Branch | PR | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
 | 1 | `TRL-767` | `trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate` | pending | In Progress | Audit/report drafted: pending force events as stable cutover gate. |
-| 2 | `TRL-766` | `trl-766-audit-version-marker-failure-ux-and-bounded-zod-diagnostics` | pending | Todo | Audit/report: marker failure UX and bounded Zod diagnostics. |
+| 2 | `TRL-766` | `trl-766-audit-version-marker-failure-ux-and-bounded-zod-diagnostics` | pending | In Progress | Audit/report drafted: stable-cutover blocker found in marker handling for validation constraints. |
 | 3 | `TRL-756` | `trl-756-audit-v1-doctrine-and-lexicon-drift-after-versioning-m3` | pending | Todo | Audit/report: doctrine and lexicon drift. |
 | 4 | `TRL-757` | `trl-757-split-ontrailstesting-surface-harnesses-behind-subpaths` | pending | Todo | Package/API: testing harness subpaths and changeset. |
 | 5 | `TRL-758` | `trl-758-clarify-topographer-artifact-cli-workflow-and-retired-topo` | pending | Todo | CLI/docs: Topographer artifact workflow. |
@@ -50,6 +50,8 @@ Out-of-goal discoveries belong here first. Create focused follow-up issues when 
 | `TRL-769` | Stable cutover runbook does not name the pending-force gate. | Docs-only release-gate follow-up discovered by `TRL-767`; not part of the audit branch implementation contract. | <https://linear.app/outfitter/issue/TRL-769/document-pending-force-stable-cutover-gate> |
 | `TRL-770` | `trails doctor` force-event output is aggregate-only and appears to miss graph-level removed-entry forces. | Implementation polish discovered by `TRL-767`; larger than an audit report and should land as a focused follow-up. | <https://linear.app/outfitter/issue/TRL-770/make-trails-doctor-pending-force-output-complete-and-actionable> |
 | `TRL-771` | Accepted-exception semantics for pending force events are not artifact-backed. | Design/policy follow-up; the current hard zero-pending gate is usable, but named exceptions need their own decision. | <https://linear.app/outfitter/issue/TRL-771/define-accepted-exception-semantics-for-pending-force-events> |
+| `TRL-772` | Version markers accept Zod validation checks/refinements that do not affect marker content. | Stable-cutover blocker discovered by `TRL-766`; the fix requires a policy choice and implementation/tests beyond an audit report. | <https://linear.app/outfitter/issue/TRL-772/make-version-markers-account-for-or-reject-zod-validation-checks> |
+| `TRL-773` | Source Warden `marker-schema-unsupported` misses `lazy`, `intersection`, and `record` even though runtime marker projection rejects them. | Diagnostic coverage follow-up discovered by `TRL-766`; smaller than `TRL-772` but still out of the audit-report branch scope. | <https://linear.app/outfitter/issue/TRL-773/align-marker-schema-unsupported-warden-coverage-with-runtime-marker> |
 
 ## Tracker Mutations
 
@@ -69,6 +71,10 @@ Record issues, milestones, labels, dependency links, comments, and follow-up iss
 | 2026-05-22 18:01 EDT | `TRL-770` | Created follow-up issue for complete/actionable `trails doctor` pending-force output. | Linear create, related to `TRL-767` |
 | 2026-05-22 18:01 EDT | `TRL-771` | Created follow-up issue for accepted-exception semantics. | Linear create, related to `TRL-767` |
 | 2026-05-22 18:04 EDT | `TRL-767` | Added audit summary comment with report path, verdict, follow-ups, and targeted checks. | Linear comment `0316d7a9-e625-4067-8e76-b69c0bfec82f` |
+| 2026-05-22 18:05 EDT | `TRL-766` | Confirmed status In Progress before marker diagnostic audit. | Linear update |
+| 2026-05-22 18:11 EDT | `TRL-772` | Created follow-up issue for marker handling of validation checks/refinements. | Linear create, related to `TRL-766` |
+| 2026-05-22 18:11 EDT | `TRL-773` | Created follow-up issue for Warden parity with runtime marker failures. | Linear create, related to `TRL-766` |
+| 2026-05-22 18:14 EDT | `TRL-766` | Added audit summary comment with report path, verdict, follow-ups, and targeted checks. | Linear comment `082ab1bb-ce4b-4db2-875d-20b7f5c5cadd` |
 
 ## Execution Log
 
@@ -116,6 +122,20 @@ YYYY-MM-DD HH:MM TZ - <branch/issue/checkpoint>
 - Result: Comment `0316d7a9-e625-4067-8e76-b69c0bfec82f` created successfully.
 - Next: Move to `TRL-766` marker diagnostics audit.
 - Blockers: None.
+
+2026-05-22 18:14 EDT - TRL-766 marker diagnostics audit
+- Changed: Added `reports/trl-766-marker-diagnostics.md`; filed follow-ups `TRL-772` and `TRL-773`.
+- Verified: Zod construct matrix via `bun --eval` over `deriveTopoGraph` and `markerSchemaUnsupported`; Zod constraint-pair matrix via `bun --eval`; default projection check via `bun --eval`; Warden unsupported-call check via `bun --eval`; `bun test packages/core/src/__tests__/version-marker.test.ts packages/topographer/src/__tests__/derive.test.ts packages/warden/src/__tests__/trail-versioning-rules.test.ts`; `bunx markdownlint-cli2 .agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md`; `git diff --check`.
+- Result: Verdict is `stable-cutover blocker`; runtime projection rejects several unsupported constructs with pathful diagnostics, but Zod validation checks/refinements can change runtime validation semantics without changing markers or emitting Warden diagnostics.
+- Next: Commit the `TRL-766` audit report, comment on Linear, then stop/ask before continuing because the audit found a blocker larger than a small in-stack fix.
+- Blockers: `TRL-772` should be resolved or explicitly scoped out before stable markers are presented as content-addressed contract identities.
+
+2026-05-22 18:14 EDT - TRL-766 tracker comment and handoff stop
+- Changed: Added Linear comment `082ab1bb-ce4b-4db2-875d-20b7f5c5cadd`; amended the branch commit to keep unrelated `.claude/worktrees/` out of the branch.
+- Verified: `git status --short --branch`; `git show --stat --oneline --name-status HEAD`; `gt log --stack --reverse --no-interactive`.
+- Result: Branch commit `docs: audit marker diagnostics` contains only `RETRO.md` and `reports/trl-766-marker-diagnostics.md`; unrelated `.claude/worktrees/` is again untracked only; stack order remains intact.
+- Next: Ask whether to add `TRL-772` as a blocking implementation branch before continuing, narrow the stable marker guarantee, or continue the planned audit stack with the blocker recorded.
+- Blockers: Stable marker contract needs a decision before the goal can honestly proceed to "done".
 ```
 
 ## Local Review Log
@@ -154,6 +174,13 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun apps/trails/bin/trails.ts doctor --module apps/trails/src/app.ts --json` | `TRL-767` | failed | Returned `Error: Internal server error`; no artifacts created. |
 | `bun apps/trails/bin/trails.ts diff --module apps/trails/src/app.ts --forces --json` | `TRL-767` | failed | Returned `Error: Internal server error`; no artifacts created. |
 | `git status --short -- .trails .trails-tmp` | `TRL-767` | pass | No generated local topo artifacts present. |
+| `bun --eval` marker construct matrix | `TRL-766` | pass | Runtime rejects `transform`, `preprocess`, `lazy`, `intersection`, `any`, `unknown`, `custom`, and `record`; Warden misses `lazy`, `intersection`, and `record`. |
+| `bun --eval` marker constraint-pair matrix | `TRL-766` | pass | `.min()`, `.email()`, `.regex()`, `.int()`, array `.min()`, object `.strict()`, `.passthrough()`, `.catchall()`, `.refine()`, and `.superRefine()` did not change markers from the unconstrained schema. |
+| `bun --eval` marker default projection check | `TRL-766` | pass | Static defaults and stable object defaults remain deterministic; dynamic random defaults are omitted from marker content. |
+| `bun --eval` Warden unsupported-call check | `TRL-766` | pass | Warden emits no diagnostics for validation checks/refinements/object policy calls from the tested set. |
+| `bun test packages/core/src/__tests__/version-marker.test.ts packages/topographer/src/__tests__/derive.test.ts packages/warden/src/__tests__/trail-versioning-rules.test.ts` | `TRL-766` | pass | 55 pass, 0 fail. |
+| `bunx markdownlint-cli2 .agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md` | `TRL-766` | pass | 0 markdownlint errors. |
+| `git diff --check` | `TRL-766` | pass | No whitespace or conflict-marker errors. |
 
 ## Remote Review / CI Log
 

--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md
@@ -1,0 +1,284 @@
+# TRL-766 Audit: Version Marker Failure UX And Bounded Zod Diagnostics
+
+Date: 2026-05-22
+Branch: `trl-766-audit-version-marker-failure-ux-and-bounded-zod-diagnostics`
+Issue: `TRL-766`
+
+## Summary Verdict
+
+Verdict: `stable-cutover blocker`
+
+The marker projection is deterministic, pathful, and loud for several unsupported
+schema constructs, but it is not yet a safe v1 stable marker contract. The
+current implementation accepts common Zod validation constraints and refinements
+while projecting the same marker as the unconstrained schema. That means two
+validation contracts can be semantically different while sharing a version
+marker.
+
+This is larger than a report-only polish fix. Before stable cutover, Trails
+should either serialize those validation semantics into the canonical marker
+projection or reject them as unsupported bounded-Zod constructs with a clear
+diagnostic.
+
+Good existing behavior:
+
+- Authors cannot write `marker:` on source contracts.
+- Runtime marker derivation rejects unsupported empty schema projections with
+  pathful `ValidationError`s.
+- `marker-schema-unsupported` catches some high-risk source-level constructs
+  before graph derivation.
+- Supported primitive/object/array/enum/literal/optional/nullable/union/default
+  projections are deterministic in the tested paths.
+
+Release-blocking gap:
+
+- Zod checks and refinements such as `.min()`, `.email()`, `.regex()`, `.int()`,
+  array `.min()`, object `.strict()`, `.catchall()`, `.refine()`, and
+  `.superRefine()` currently do not affect marker content and do not produce a
+  marker diagnostic.
+
+Secondary diagnostic gap:
+
+- Runtime projection rejects `z.lazy()`, `z.intersection()`, and `z.record()`,
+  but the source Warden rule does not flag them early.
+
+## Evidence Map
+
+### Doctrine
+
+- `docs/adr/0048-trail-versioning-v3.md:157-180` says authors do not write
+  markers, markers are 16-character SHA-256 prefixes over canonicalized resolved
+  contract content, and unsupported schema features must fail loudly with a
+  clear diagnostic.
+- `docs/lexicon.md:456-467` defines `marker` as a framework-projected,
+  content-addressed contract identifier and says surfaces may resolve
+  `@<marker-prefix>` when the prefix is unambiguous.
+
+### Marker Projection
+
+- `packages/core/src/trail.ts:789-802` rejects authored `kind`/`marker` on
+  historical version entries.
+- `packages/core/src/trail.ts:1021-1024` rejects authored top-level
+  `marker`.
+- `packages/core/src/version-marker.ts:35-61` rejects unsupported empty schema
+  projections except the empty `properties` object.
+- `packages/core/src/version-marker.ts:63-128` canonicalizes JSON-compatible
+  marker content and rejects undefined, functions, symbols, non-plain objects,
+  and circular references with pathful messages.
+- `packages/core/src/version-marker.ts:130-138` derives the marker by hashing
+  canonicalized JSON over the projected schema content.
+- `packages/core/src/version-marker.ts:192-251` defines current and historical
+  marker content.
+- `packages/core/src/version-marker.ts:310-351` derives current and historical
+  marker records and enforces uniqueness.
+- `packages/topographer/src/derive.ts:470-488` projects marker fields onto the
+  resolved graph entry.
+- `packages/topographer/src/versioning.ts:90-125` projects historical version
+  entry schemas and markers.
+- `packages/topographer/src/versioning.ts:249-280` derives current and
+  historical markers during TopoGraph version projection.
+
+### Zod Projection Boundary
+
+- `packages/core/src/validation.ts:173-179` documents the intended common Zod
+  coverage: string, number, boolean, object, array, enum, optional, default,
+  union, literal, nullable, and describe.
+- `packages/core/src/validation.ts:217-262` implements converters for array,
+  boolean, default, enum, literal, nullable, number, object, optional, readonly,
+  string, and union.
+- `packages/core/src/validation.ts:264-270` falls back to an empty object when
+  no converter exists, then adds `description` when present. Runtime marker
+  support later rejects these empty projections in most nested schema positions.
+- The string, number, array, and object converters do not include Zod check
+  metadata or object unknown-key/catchall policy, so those validation semantics
+  are currently invisible to marker content.
+
+### Warden Diagnostics
+
+- `packages/warden/src/rules/trail-versioning-source.ts:18-24` lists the
+  current unsupported source call denylist: `any`, `custom`, `preprocess`,
+  `transform`, and `unknown`.
+- `packages/warden/src/rules/trail-versioning-source.ts:228-264` applies the
+  `marker-schema-unsupported` rule only to versioned trail `input`/`output`
+  schema nodes and historical version entries.
+- `packages/warden/src/__tests__/trail-versioning-rules.test.ts:110-129`
+  covers `z.any()` as an unsupported marker schema shape.
+- `packages/warden/src/__tests__/trail-versioning-rules.test.ts:131-151`
+  preserves the callback-scope guard so helper method names inside callbacks do
+  not create false positives.
+
+### Regression Tests Already Present
+
+- `packages/core/src/__tests__/version-marker.test.ts:17-30` verifies marker
+  hashing is canonical and 16 hexadecimal characters.
+- `packages/core/src/__tests__/version-marker.test.ts:61-71` verifies marker
+  canonicalization rejects unsupported non-JSON content instead of stringifying
+  it.
+- `packages/topographer/src/__tests__/derive.test.ts:321-351` verifies mutable
+  examples and status do not affect markers.
+- `packages/topographer/src/__tests__/derive.test.ts:353-391` verifies resolved
+  contract content changes can change current and historical markers.
+- `packages/topographer/src/__tests__/derive.test.ts:498-519` verifies
+  `z.any()` produces an unsupported marker schema projection failure.
+
+## Command Snippets
+
+The four `bun --eval` matrices below were run interactively against the
+in-repo APIs as one-off audit harnesses. The recorded **outputs** are the
+audit evidence. The script bodies are summarized inline as
+`<matrix omitted for length: …>` placeholders for readability; the next
+paragraph names exactly which existing regression tests do and do not cover
+the same matrix, so a future auditor knows whether they need to reproduce the
+matrix from scratch.
+
+Test coverage map for these matrices:
+
+- Construct matrix (first block): partially covered.
+  `packages/topographer/src/__tests__/derive.test.ts:498-519` covers `z.any()`
+  as an unsupported marker schema projection;
+  `packages/warden/src/__tests__/trail-versioning-rules.test.ts:110-152` covers
+  the Warden `marker-schema-unsupported` rule for the supported failure set.
+  The matrix in this report widens that coverage to `transform`, `preprocess`,
+  `lazy`, `intersection`, `record`, `any`, `unknown`, and `custom`; only
+  `z.any()` is directly tested today.
+- Constraint-pair matrix (second block): **not covered today**. No test in
+  `packages/core/src/__tests__/version-marker.test.ts` (129 lines) or in
+  `packages/warden/src/__tests__/trail-versioning-rules.test.ts` exercises
+  marker stability across `.min()`, `.email()`, `.regex()`, `.int()`, array
+  `.min()`, `.strict()`, `.passthrough()`, `.catchall()`, `.refine()`, or
+  `.superRefine()` pairs. This is exactly the stable-cutover blocker the
+  audit surfaces and TRL-772 carries.
+- Default-projection check (third block): partially covered.
+  `packages/core/src/__tests__/version-marker.test.ts:32-58` covers stable
+  runtime contract references in marker content. The matrix in this report
+  additionally distinguishes static vs dynamic defaults, which is not isolated
+  in a dedicated regression test today.
+- Warden unsupported-call check (fourth block):
+  `packages/warden/src/__tests__/trail-versioning-rules.test.ts:131-152`
+  covers `marker-schema-unsupported` ignoring callbacks. The matrix in this
+  report runs the rule across validation-check / refinement / object-policy
+  invocations and confirms no diagnostic is produced for any of them, which
+  is the gap TRL-773 carries.
+
+If a future audit needs the exact harness scripts, treat the omitted blocks
+as TODOs to lift into focused regression tests on TRL-772 / TRL-773 rather
+than as duplicates of existing coverage.
+
+```text
+$ bun --eval '<matrix omitted for length: derive markers for supported and unsupported Zod constructs through deriveTopoGraph and run markerSchemaUnsupported on equivalent source snippets>'
+{"name":"transform","projection":"error","error":"ValidationError: Trail version marker content at input.properties.value contains an unsupported empty schema projection","warden":["marker-schema-unsupported"]}
+{"name":"preprocess","projection":"error","error":"ValidationError: Trail version marker content at input.properties.value contains an unsupported empty schema projection","warden":["marker-schema-unsupported"]}
+{"name":"lazy","projection":"error","error":"ValidationError: Trail version marker content at input.properties.value contains an unsupported empty schema projection","warden":[]}
+{"name":"intersection","projection":"error","error":"ValidationError: Trail version marker content at input contains an unsupported empty schema projection","warden":[]}
+{"name":"record","projection":"error","error":"ValidationError: Trail version marker content at input.properties.value contains an unsupported empty schema projection","warden":[]}
+```
+
+```text
+$ bun --eval '<constraint-pair matrix omitted for length: compare base schema markers against constrained schema markers>'
+{"name":"string-min","left":"4562785c00880b6b","right":"4562785c00880b6b","changed":false}
+{"name":"string-email","left":"4562785c00880b6b","right":"4562785c00880b6b","changed":false}
+{"name":"string-regex","left":"4562785c00880b6b","right":"4562785c00880b6b","changed":false}
+{"name":"number-int","left":"46aa52f6c2cb6413","right":"46aa52f6c2cb6413","changed":false}
+{"name":"number-min","left":"46aa52f6c2cb6413","right":"46aa52f6c2cb6413","changed":false}
+{"name":"array-min","left":"6846115ebd8c1eee","right":"6846115ebd8c1eee","changed":false}
+{"name":"object-strict","left":"d9137a2387fd2bc0","right":"d9137a2387fd2bc0","changed":false}
+{"name":"object-passthrough","left":"d9137a2387fd2bc0","right":"d9137a2387fd2bc0","changed":false}
+{"name":"object-catchall","left":"d9137a2387fd2bc0","right":"d9137a2387fd2bc0","changed":false}
+{"name":"literal-change","left":"02cdf0d45dcb1bba","right":"b7cf1ca35da15c02","changed":true}
+{"name":"enum-change","left":"0c61671d9e6dbe6e","right":"28a2ed059facd78f","changed":true}
+```
+
+```text
+$ bun --eval '<default projection check omitted for length>'
+{"name":"staticDefault","same":true}
+{"name":"dynamicRandomDefault","same":true}
+{"name":"dynamicObjectDefault","same":true}
+```
+
+```text
+$ bun --eval '<Warden unsupported-call check omitted for length>'
+{"schema":"z.string().min(3)","diagnostics":[]}
+{"schema":"z.string().email()","diagnostics":[]}
+{"schema":"z.number().int()","diagnostics":[]}
+{"schema":"z.array(z.string()).min(1)","diagnostics":[]}
+{"schema":"z.object({ a: z.string() }).strict()","diagnostics":[]}
+{"schema":"z.object({ a: z.string() }).catchall(z.number())","diagnostics":[]}
+{"schema":"z.string().refine((v) => v.length > 0)","diagnostics":[]}
+{"schema":"z.string().superRefine(() => {})","diagnostics":[]}
+```
+
+## Current Behavior Matrix
+
+| Construct | Runtime Projection | Warden | Verdict |
+| --- | --- | --- | --- |
+| `z.string()`, `z.number()`, `z.boolean()` | Marker derives. | No diagnostic. | Supported primitive path. |
+| `z.object({ ... })` | Marker derives. | No diagnostic. | Supported structural path, but object policy is not represented. |
+| `z.array(...)` | Marker derives. | No diagnostic. | Supported structural path, but array checks are not represented. |
+| `z.enum(...)`, `z.literal(...)` | Marker derives and changes when enum/literal values change. | No diagnostic. | Supported. |
+| `z.union(...)`, `z.discriminatedUnion(...)` | Marker derives. | No diagnostic. | Supported via the union converter. |
+| `.optional()`, `.nullable()` | Marker derives. | No diagnostic. | Supported. |
+| `.default(...)` | Marker derives; stable defaults are included and dynamic defaults are omitted. | No diagnostic. | Supported enough for deterministic marker content. |
+| `.readonly()`, `.brand()` | Marker derives as the inner schema. | No diagnostic. | Likely acceptable if treated as non-runtime marker metadata, but should be explicit. |
+| `z.any()`, `z.unknown()`, `z.custom()` | Runtime rejects with pathful `ValidationError`. | Diagnostic emitted. | Good failure UX. |
+| `z.transform(...)`, `z.preprocess(...)` | Runtime rejects with pathful `ValidationError`. | Diagnostic emitted. | Good failure UX. |
+| `z.lazy(...)`, `z.intersection(...)`, `z.record(...)` | Runtime rejects with pathful `ValidationError`. | No diagnostic. | Needs source-level Warden coverage or explicit runtime-only policy. |
+| `.min()`, `.email()`, `.regex()`, `.int()`, array `.min()` | Marker derives unchanged from the unconstrained schema. | No diagnostic. | Release-blocking marker identity gap. |
+| `.strict()`, `.passthrough()`, `.catchall(...)` | Marker derives unchanged from the base object schema. | No diagnostic. | Release-blocking marker identity gap. |
+| `.refine(...)`, `.superRefine(...)` | Marker derives unchanged from the inner schema. | No diagnostic. | Release-blocking marker identity gap. |
+
+## Audit Questions
+
+### Do version-marker failures include enough context for agents to fix schemas?
+
+Partially. Runtime projection failures include the marker content path, for
+example `input.properties.value`, and identify the unsupported empty schema
+projection. That is enough to find the field, but not enough to name the
+original Zod construct after projection has collapsed to `{}`.
+
+Warden gives earlier, source-level feedback for `any`, `custom`, `preprocess`,
+`transform`, and `unknown`, but misses other runtime-failing constructs such as
+`lazy`, `intersection`, and `record`.
+
+### Does the bounded Zod subset fail loudly for unsupported features?
+
+Not consistently. Runtime projection fails loudly for constructs that project
+to empty schema objects, but several runtime validation features are accepted
+and ignored. Those accepted-but-ignored features are the stable-cutover problem.
+
+### Can stable cutover rely on version markers as content-addressed contract identities?
+
+Not yet for contracts that use Zod validation checks or refinements. Literal
+and enum value changes correctly change markers, and structural field additions
+are covered by existing tests. However, validation constraints can change the
+accepted input contract without changing the marker.
+
+### Is this small enough to fix inside the audit branch?
+
+No. The correct fix needs a policy choice:
+
+- expand marker projection to include supported Zod checks and object policy, or
+- treat those constructs as unsupported for versioned marker contracts and
+  reject them through runtime projection plus Warden.
+
+Either path needs tests, docs/ADR alignment, and likely Warden updates. That is
+larger than the committed audit-report scope.
+
+## Follow-Up Issues
+
+- `TRL-772`: Make version markers account for or reject Zod validation checks.
+- `TRL-773`: Align `marker-schema-unsupported` Warden coverage with runtime
+  marker failures.
+
+## Stable Cutover Recommendation
+
+Do not cut stable while version markers are advertised as content-addressed
+contract identifiers unless `TRL-772` is resolved or the stable runbook
+explicitly narrows the marker guarantee to the currently serialized subset.
+
+Recommended release gate text after `TRL-772` lands:
+
+```markdown
+- [ ] Version marker bounded-Zod gate is clean: all versioned trail schemas
+      either serialize supported validation semantics into marker content or
+      fail Warden/runtime diagnostics for unsupported constructs.
+```


### PR DESCRIPTION
## Context

Audit branch for [TRL-766](https://linear.app/outfitter/issue/TRL-766/audit-version-marker-failure-ux-and-bounded-zod-diagnostics): is the v1 version-marker failure UX good enough for stable cutover, and do Warden's bounded-Zod diagnostics match the marker runtime behavior?

Closes [TRL-766](https://linear.app/outfitter/issue/TRL-766/audit-version-marker-failure-ux-and-bounded-zod-diagnostics).

## Changes

- New audit report: `.agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md`. Verdict `stable-cutover blocker`: runtime projection rejects unsupported constructs with pathful diagnostics, but several Zod validation checks/refinements (`.min`, `.email`, `.regex`, `.int`, array `.min`, `.refine`, `.superRefine`, `.strict`, `.passthrough`, `.catchall`) change accepted input semantics without changing markers or emitting Warden diagnostics. The `## Command Snippets` section explains that the inline `<...omitted for length...>` placeholders are record-only and maps each block to the matching regression test in the Evidence Map.

## Verification

- `bun --eval` matrices over `deriveTopoGraph`, `markerSchemaUnsupported`, default projection, and Warden unsupported-call checks. Outputs recorded in the report.
- `bun test packages/core/src/__tests__/version-marker.test.ts packages/topographer/src/__tests__/derive.test.ts packages/warden/src/__tests__/trail-versioning-rules.test.ts` → 55 pass, 0 fail.
- `bunx markdownlint-cli2 .agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md` → 0 errors.
- `git diff --check` → clean.

## Risks / Rollout

Docs/audit-only change. The blocker verdict is intentionally documented and carried forward to a focused follow-up issue (TRL-772) rather than implemented in this stack — see Follow-ups.

## Follow-ups filed

- [TRL-772](https://linear.app/outfitter/issue/TRL-772/make-version-markers-account-for-or-reject-zod-validation-checks) — stable-cutover blocker. Stable 1.0 cutover is gated on this; this docs/audit/readiness stack ships independently.
- [TRL-773](https://linear.app/outfitter/issue/TRL-773/align-marker-schema-unsupported-warden-coverage-with-runtime-marker)
