### PR TITLE
docs: audit doctrine lexicon drift

### DIFF
--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md
@@ -25,7 +25,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | --- | --- | --- | --- | --- | --- |
 | 1 | `TRL-767` | `trl-767-audit-pending-force-events-as-a-v1-stable-cutover-gate` | pending | In Progress | Audit/report drafted: pending force events as stable cutover gate. |
 | 2 | `TRL-766` | `trl-766-audit-version-marker-failure-ux-and-bounded-zod-diagnostics` | pending | In Progress | Audit/report drafted: stable-cutover blocker found in marker handling for validation constraints. |
-| 3 | `TRL-756` | `trl-756-audit-v1-doctrine-and-lexicon-drift-after-versioning-m3` | pending | Todo | Audit/report: doctrine and lexicon drift. |
+| 3 | `TRL-756` | `trl-756-audit-v1-doctrine-and-lexicon-drift-after-versioning-m3` | pending | In Progress | Audit/report drafted: minor doctrine and lexicon drift found. |
 | 4 | `TRL-757` | `trl-757-split-ontrailstesting-surface-harnesses-behind-subpaths` | pending | Todo | Package/API: testing harness subpaths and changeset. |
 | 5 | `TRL-758` | `trl-758-clarify-topographer-artifact-cli-workflow-and-retired-topo` | pending | Todo | CLI/docs: Topographer artifact workflow. |
 | 6 | `TRL-759` | `trl-759-document-beta-channel-install-policy-and-version-bump` | pending | Todo | Release docs/policy: beta install, dist-tag, bump cadence. |
@@ -52,6 +52,8 @@ Out-of-goal discoveries belong here first. Create focused follow-up issues when 
 | `TRL-771` | Accepted-exception semantics for pending force events are not artifact-backed. | Design/policy follow-up; the current hard zero-pending gate is usable, but named exceptions need their own decision. | <https://linear.app/outfitter/issue/TRL-771/define-accepted-exception-semantics-for-pending-force-events> |
 | `TRL-772` | Version markers accept Zod validation checks/refinements that do not affect marker content. | Stable-cutover blocker discovered by `TRL-766`; the fix requires a policy choice and implementation/tests beyond an audit report. | <https://linear.app/outfitter/issue/TRL-772/make-version-markers-account-for-or-reject-zod-validation-checks> |
 | `TRL-773` | Source Warden `marker-schema-unsupported` misses `lazy`, `intersection`, and `record` even though runtime marker projection rejects them. | Diagnostic coverage follow-up discovered by `TRL-766`; smaller than `TRL-772` but still out of the audit-report branch scope. | <https://linear.app/outfitter/issue/TRL-773/align-marker-schema-unsupported-warden-coverage-with-runtime-marker> |
+| `TRL-774` | Public resource factory docs/examples and tests still use `svc`, `service*`, and `provision*` residue around the resource context surface. | Cross-cutting mechanical lexicon cleanup discovered by `TRL-756`; not part of the report-only audit branch. | <https://linear.app/outfitter/issue/TRL-774/rename-resource-factory-svc-residue-to-current-resource-context-naming> |
+| `TRL-775` | `.trails/clark/survey-latest.md` is tracked and stale while still labeled as the latest survey. | Clark survey lifecycle cleanup discovered by `TRL-756`; out of scope for the audit report branch. | <https://linear.app/outfitter/issue/TRL-775/refresh-or-archive-stale-committed-clark-survey-snapshot> |
 
 ## Tracker Mutations
 
@@ -75,6 +77,10 @@ Record issues, milestones, labels, dependency links, comments, and follow-up iss
 | 2026-05-22 18:11 EDT | `TRL-772` | Created follow-up issue for marker handling of validation checks/refinements. | Linear create, related to `TRL-766` |
 | 2026-05-22 18:11 EDT | `TRL-773` | Created follow-up issue for Warden parity with runtime marker failures. | Linear create, related to `TRL-766` |
 | 2026-05-22 18:14 EDT | `TRL-766` | Added audit summary comment with report path, verdict, follow-ups, and targeted checks. | Linear comment `082ab1bb-ce4b-4db2-875d-20b7f5c5cadd` |
+| 2026-05-22 18:21 EDT | `TRL-756` | Moved from Todo to In Progress before doctrine/lexicon audit report writing. | Linear update |
+| 2026-05-22 18:23 EDT | `TRL-774` | Created follow-up issue for resource factory `svc` and related service/provision residue. | Linear create, related to `TRL-756` |
+| 2026-05-22 18:23 EDT | `TRL-775` | Created follow-up issue for stale committed Clark survey snapshot lifecycle. | Linear create, related to `TRL-756` |
+| 2026-05-22 18:28 EDT | `TRL-756` | Added audit summary comment with report path, verdict, follow-ups, checks, and stable-cutover assessment. | Linear comment `15bbfeef-de73-46c8-b572-1777e8d3e8ed` |
 
 ## Execution Log
 
@@ -136,6 +142,20 @@ YYYY-MM-DD HH:MM TZ - <branch/issue/checkpoint>
 - Result: Branch commit `docs: audit marker diagnostics` contains only `RETRO.md` and `reports/trl-766-marker-diagnostics.md`; unrelated `.claude/worktrees/` is again untracked only; stack order remains intact.
 - Next: Ask whether to add `TRL-772` as a blocking implementation branch before continuing, narrow the stable marker guarantee, or continue the planned audit stack with the blocker recorded.
 - Blockers: Stable marker contract needs a decision before the goal can honestly proceed to "done".
+
+2026-05-22 18:24 EDT - TRL-756 doctrine and lexicon drift audit
+- Changed: Added `reports/trl-756-doctrine-lexicon-drift.md`; filed follow-ups `TRL-774` and `TRL-775`.
+- Verified: Required retired-term search with `git grep`; active-target `rg` classification; `bun run vocab:audit`; `bun run vocab:audit:json`; `bun run lint:ast-grep`; `bun run warden:skills:check`; `bun run warden:agents:check`; `bun run plugin:installed-skill:check`.
+- Result: Verdict is `minor drift`; repo-enforced lexicon gates are clean; the remaining branch-source drift is resource factory `svc`/service/provision naming and the stale committed Clark survey snapshot; installed local skill drift is external operator state and the check remained read-only.
+- Next: Run report/retro markdown checks, commit the `TRL-756` audit report, then add the Linear audit summary comment.
+- Blockers: None for the lexicon cutover gate; `TRL-766` marker semantics remains the stable-cutover blocker already recorded.
+
+2026-05-22 18:28 EDT - TRL-756 tracker comment and branch verification
+- Changed: Committed the `TRL-756` audit report as `docs: audit doctrine lexicon drift`; added Linear comment `15bbfeef-de73-46c8-b572-1777e8d3e8ed`.
+- Verified: `gt modify -m "docs: audit doctrine lexicon drift" --no-interactive`; `git status --short --branch`; `gt log --stack --reverse --no-interactive`; `git show --stat --oneline --name-status HEAD`; Linear `_save_comment`.
+- Result: Branch commit contains only `RETRO.md` and `reports/trl-756-doctrine-lexicon-drift.md`; upper branches were restacked; unrelated `.claude/worktrees/` remains untracked only.
+- Next: Move to `TRL-757` testing package surface-harness subpath implementation.
+- Blockers: None for `TRL-756`; `TRL-766` marker semantics remains the stable-cutover blocker already recorded.
 ```
 
 ## Local Review Log
@@ -181,6 +201,19 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun test packages/core/src/__tests__/version-marker.test.ts packages/topographer/src/__tests__/derive.test.ts packages/warden/src/__tests__/trail-versioning-rules.test.ts` | `TRL-766` | pass | 55 pass, 0 fail. |
 | `bunx markdownlint-cli2 .agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md` | `TRL-766` | pass | 0 markdownlint errors. |
 | `git diff --check` | `TRL-766` | pass | No whitespace or conflict-marker errors. |
+| `git grep -nE '\b(trailhead\|trailheads\|provision\|provisions\|gate\|gates\|loadout\|tracker\|tracks\|vocabulary)\b' -- ':!bun.lock'` | `TRL-756` | pass | Required search form checked; Git ERE word-boundary behavior produced no useful hits, so the same term set was rerun with `-P` for classification. |
+| `git grep -nP '\b(trailhead\|trailheads\|provision\|provisions\|gate\|gates\|loadout\|tracker\|tracks\|vocabulary)\b' -- ':!bun.lock' \| wc -l` | `TRL-756` | pass | 1063 raw hits before classification. |
+| `rg -n 'trailhead\|trailheads\|provision\|provisions\|loadout\|tracker\|tracks\|\bgate\b\|\bgates\b\|vocabulary' packages/*/README.md adapters/*/README.md apps/*/README.md README.md docs/*.md docs/releases/*.md plugin/skills .claude/skills .agents/skills --glob '!**/CHANGELOG.md' \| wc -l` | `TRL-756` | pass | 69 active-target hits after changelog exclusion; classified as history/migration, false positives, compatibility coverage, or tracked follow-up drift. |
+| `rg -n '\bsvc\b\|provisionLeafTrail\|provisionRootTrail\|provisionTrailsMap\|service-config\|service.test\|tracing-provision' packages plugin/skills --glob '!**/CHANGELOG.md' \| head -80` | `TRL-756` | pass | Confirmed public `ResourceSpec.create`/skill examples and resource tests still carry `svc`, `service*`, and `provision*` residue; follow-up `TRL-774` created. |
+| `git ls-files packages/tracker .trails/clark/survey-latest.md` | `TRL-756` | pass | Only `.trails/clark/survey-latest.md` is tracked; no tracked `packages/tracker` files remain. |
+| `bun run vocab:audit` | `TRL-756` | pass | `vocab-cutover audit passed for entire repo target set: no legacy patterns found.` |
+| `bun run vocab:audit:json` | `TRL-756` | pass | All retired-vocabulary rules reported `total: 0`. |
+| `bun run lint:ast-grep` | `TRL-756` | pass | `ast-grep scan --config .ast-grep/sgconfig.yml` exited 0. |
+| `bun run warden:skills:check` | `TRL-756` | pass | `sync-skill-warden-guide.ts --check` exited 0. |
+| `bun run warden:agents:check` | `TRL-756` | pass | `sync-agents-warden-guide.ts --check` exited 0. |
+| `bun run plugin:installed-skill:check` | `TRL-756` | expected failure | Read-only external state check found content drift and stale vocabulary in `/Users/mg/.agents/skills/trails` and the symlinked Claude skill; no installed files changed. |
+| `bunx markdownlint-cli2 .agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md .agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-756-doctrine-lexicon-drift.md` | `TRL-756` | pass | 0 markdownlint errors after removing an extra trailing blank line. |
+| `git diff --check` | `TRL-756` | pass | No whitespace or conflict-marker errors. |
 
 ## Remote Review / CI Log
 

--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-756-doctrine-lexicon-drift.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-756-doctrine-lexicon-drift.md
@@ -1,0 +1,209 @@
+# TRL-756 Audit: Doctrine And Lexicon Drift After Versioning M3
+
+Date: 2026-05-22
+Branch: `trl-756-audit-v1-doctrine-and-lexicon-drift-after-versioning-m3`
+Issue: `TRL-756`
+
+## Summary Verdict
+
+Verdict: `minor drift`
+
+The active repo doctrine is mostly aligned with the post-versioning-M3 lexicon.
+The enforced gates are clean: `bun run vocab:audit`, `bun run
+vocab:audit:json`, `bun run lint:ast-grep`, `bun run warden:skills:check`, and
+`bun run warden:agents:check` all pass for the checked-out repo source.
+
+The audit did find two real follow-ups:
+
+- `TRL-774`: public resource factory docs and examples still use the `svc`
+  parameter name, and some test fixture names still use `provision*`.
+- `TRL-775`: the committed `.trails/clark/survey-latest.md` snapshot is stale
+  while still being named "latest".
+
+Neither is a stable-cutover blocker under the current release gate because the
+source vocabulary checks are clean and the remaining drift is narrow,
+classifiable, and tracked. If v1 stable adopts a stricter "zero known active
+lexicon residue in public TSDoc and agent skills" rule, then `TRL-774` should
+land before stable.
+
+The local installed Trails skill copy is also stale, but that is external
+operator state rather than branch source. The repo already has a read-only check
+for this path; refreshing local installed copies should remain an explicit
+operator action, not a hidden side effect of this audit branch.
+
+## Evidence Map
+
+### Governing Doctrine
+
+- `docs/lexicon.md:1-7` defines the lexicon as the contract and says code is
+  brought into alignment when the two diverge.
+- `docs/lexicon.md:136-156` allows retired names in historical release notes,
+  old migrations, accepted ADR history, and clearly marked legacy context.
+- `docs/lexicon.md:547-559` reserves `trailhead` and `connector` as historical
+  boundary/package terms and directs active docs, examples, and APIs to use
+  `surface` and `adapter`.
+- `docs/lexicon.md:605-612` says active writing should use the lexicon
+  consistently and prefer lexicon nouns for architecture explanations.
+- `docs/adr/0001-naming-conventions.md:57-63` lists the current branded and
+  plain terms, including `surface`, `resource`, `layer`, `tracing`, and `meta`.
+- `docs/adr/0001-naming-conventions.md:97-100` now teaches `resource()` and
+  `topo()` as frozen definitions, plus `createTrailContext()`, `createLogger()`,
+  and `createProgram()` as runtime instances.
+- `docs/adr/0001-naming-conventions.md:115-128` gives the current progression:
+  `trail()` to `blaze:` to `signal()` to `topo()` to `surface()` to `run()`.
+- `docs/adr/0001-naming-conventions.md:216-217` names the current vocabulary
+  family as trail, blaze, topo, surface, cross, resource, signal, layer,
+  tracing, and warden.
+
+### Enforcement And Classification Rules
+
+- `docs/contributing/warden-rules.md:194-219` explicitly scopes retired
+  vocabulary source rules to source-owned symbols and sends docs/history
+  classification through `bun run vocab:audit`.
+- `scripts/vocab-cutover-audit.ts:137-145` is the text-mode pass/fail gate for
+  the vocabulary audit.
+- `scripts/check-installed-trails-skill.ts:321-338` intentionally reports
+  installed-skill stale vocabulary as a read-only finding.
+
+## Command Snippets
+
+The required search pattern was checked with `git grep -nE`. Because Git's ERE
+handling of `\b` did not produce useful word-boundary matches in this checkout,
+the audit re-ran the same term set with `-P` and classified the resulting hits.
+
+```text
+$ git grep -nP '\b(trailhead|trailheads|provision|provisions|gate|gates|loadout|tracker|tracks|vocabulary)\b' -- ':!bun.lock' | wc -l
+1063
+```
+
+The active-target Markdown/package/skill subset, excluding changelogs, is much
+smaller and mostly historical or false-positive prose:
+
+```text
+$ rg -n 'trailhead|trailheads|provision|provisions|loadout|tracker|tracks|\bgate\b|\bgates\b|vocabulary' packages/*/README.md adapters/*/README.md apps/*/README.md README.md docs/*.md docs/releases/*.md plugin/skills .claude/skills .agents/skills --glob '!**/CHANGELOG.md' | wc -l
+69
+```
+
+```text
+$ bun run vocab:audit
+vocab-cutover audit passed for entire repo target set: no legacy patterns found.
+```
+
+```text
+$ bun run vocab:audit:json
+[
+  {"id":"run-field","total":0},
+  {"id":"service-factory","total":0},
+  {"id":"services-field","total":0},
+  {"id":"event-factory","total":0},
+  {"id":"surface-term","total":0},
+  {"id":"connector-term","total":0},
+  {"id":"topograph-artifact-family-retired-term","total":0}
+]
+```
+
+```text
+$ rg -n '\bsvc\b|provisionLeafTrail|provisionRootTrail|provisionTrailsMap|service-config|service.test|tracing-provision' packages plugin/skills --glob '!**/CHANGELOG.md' | head -80
+plugin/skills/trails/SKILL.md:151:  create: (svc) => Result.ok(openDatabase(svc.env?.DATABASE_URL)),
+plugin/skills/trails/references/common-pitfalls.md:160:**Fix:** Keep resource factories surface-agnostic. Use `svc.config` for declared resource config or `svc.env` for one-off environment values:
+packages/topographer/src/topo-store.ts:705:  create: (svc) =>
+packages/permits/src/auth-resource.ts:85:  create: (svc) => Result.ok(createAdapter(svc.config as AuthResourceConfig)),
+packages/testing/src/__tests__/crosses.test.ts:236:const provisionLeafTrail = trail('resource.leaf', {
+packages/testing/src/__tests__/crosses.test.ts:245:const provisionRootTrail = trail('resource.root', {
+packages/testing/src/__tests__/crosses.test.ts:271:const provisionTrailsMap = new Map<string, AnyTrail>([
+packages/core/src/resource.ts:12: * the validated config is passed as `svc.config`.
+packages/core/src/resource.ts:35:    svc: ResourceContext<C>
+packages/core/src/__tests__/service-config.test.ts:52:  test('resource with config schema receives validated config in svc.config', async () => {
+```
+
+```text
+$ git ls-files packages/tracker .trails/clark/survey-latest.md
+.trails/clark/survey-latest.md
+```
+
+```text
+$ bun run plugin:installed-skill:check
+Installed Trails skill drift report
+[error] agents-shared: <user-home>/.agents/skills/trails (copy)
+  - content-drift: 13 file drift item(s)
+  - stale-vocabulary: 5 stale vocabulary hit(s)
+[error] claude-home: <user-home>/.config/claude/skills/trails
+  - content-drift: 13 file drift item(s)
+  - stale-vocabulary: 5 stale vocabulary hit(s)
+[info] codex-home: <user-home>/.config/codex/skills/trails (missing)
+Read-only check: no installed skill files were changed.
+```
+
+## Classification Matrix
+
+| Class | Representative Hits | Evidence | Verdict |
+| --- | --- | --- | --- |
+| Allowed historical context | Beta.15 release note migration map for `trailhead`, `provision`, `gate`, `loadout`, and `tracker`. | `docs/releases/beta15.md:57-85`, `docs/releases/beta15.md:223-248` | Allowed; clearly migration/history. |
+| Allowed migration docs | Hono and HTTP READMEs contrast old `trailhead` imports with current `surface` imports. | `adapters/hono/README.md:43-50`, `packages/http/README.md:153-159` | Allowed; warden-ignore annotated migration prose. |
+| Allowed ADR/index history | ADR index keeps the historical ADR-0008 slug and names the vocabulary-to-lexicon ADR. | `docs/index.md:58-79` | Allowed; accepted history and migration links. |
+| False positive prose | `gate` as a release/test gate and `tracker` as an issue tracker concept. | `docs/releases/stable-cutover.md`, `packages/testing/README.md`, packet docs | False positive; not Trails lexicon target-state drift. |
+| Code/API compatibility surface | Legacy topo-store schema/table names such as `topo_trailheads` in migration tests. | `packages/topographer/src/__tests__/topo-store.test.ts` | Allowed compatibility coverage. |
+| Active guidance drift | Resource factory examples and TSDoc use `svc`; resource tests use `service*` and `provision*` names. | `packages/core/src/resource.ts:7-36`, `plugin/skills/trails/SKILL.md:149-158`, `packages/testing/src/__tests__/crosses.test.ts:236-273` | Real follow-up: `TRL-774`. |
+| Active operational artifact drift | `.trails/clark/survey-latest.md` still reports already-fixed ADR/source findings. | `.trails/clark/survey-latest.md:7-44` versus `docs/adr/0001-naming-conventions.md:97-100` | Real follow-up: `TRL-775`. |
+| External installed-copy drift | Local installed Trails skill copies differ from repo plugin source and include stale vocabulary findings. | `bun run plugin:installed-skill:check` | External/operator action; not branch source. |
+
+## Audit Questions
+
+### Do current docs teach the current lexicon?
+
+Yes for the primary docs inspected. `docs/lexicon.md`, `docs/architecture.md`,
+`docs/index.md`, `docs/why-trails.md`, `docs/getting-started.md`,
+`docs/horizons.md`, release docs, public package READMEs, ADR index material,
+and the repo plugin skill source mostly teach `trail`, `blaze`, `topo`,
+`surface`, `cross`, `resource`, `layer`, `signal`, `tracing`, and `meta`.
+
+Remaining retired-term hits in those paths are either migration/history, ordinary
+English false positives, or the narrow `svc`/resource-factory residue filed as
+`TRL-774`.
+
+### Is there active code/API compatibility drift?
+
+Only minor drift. `ResourceSpec.create` exposes a public callback parameter named
+`svc`, and public TSDoc says config is passed as `svc.config`. That does not
+change runtime behavior, but it is visible in IDE hovers and copied into agent
+skill examples. The fix is mechanical but cross-cutting enough to keep out of
+the report-only audit branch.
+
+### Are committed agent artifacts current?
+
+Not completely. The repo plugin skill source is current enough for the checked
+audit, but `.trails/clark/survey-latest.md` is stale and committed. It still
+claims ADR-0001 teaches `provision()` and `createTrackerGate()` even though the
+current ADR is updated, and it references `packages/tracker/` even though no
+tracked files remain there. Because the file is named `latest`, agents can treat
+outdated conclusions as live evidence. This is filed as `TRL-775`.
+
+### Did the installed global skill state match the repo source?
+
+No. `bun run plugin:installed-skill:check` reports content drift and stale
+vocabulary in `<user-home>/.agents/skills/trails` and the symlinked
+`<user-home>/.config/claude/skills/trails`. The command is read-only and made
+no changes. This should be refreshed through an explicit operator action, not
+by this branch.
+
+## Follow-Up Issues
+
+- `TRL-774`: Rename Resource factory `svc` residue to current resource context
+  naming.
+- `TRL-775`: Refresh or archive stale committed Clark survey snapshot.
+
+## Stable Cutover Recommendation
+
+For the v1 stable cutover lexicon gate:
+
+```markdown
+- [ ] Doctrine/lexicon gate is clean: `bun run vocab:audit`, `bun run
+      vocab:audit:json` (machine-readable output for CI graders),
+      `bun run lint:ast-grep`, `bun run warden:skills:check`, and `bun run
+      warden:agents:check` pass, and any active public docs/API/agent guidance
+      retired-term hits are either fixed or filed as explicitly accepted
+      non-blocking release follow-ups.
+```
+
+Current state: pass with minor drift, assuming `TRL-774` and `TRL-775` are
+accepted as post-audit follow-ups rather than release blockers.


### PR DESCRIPTION
## Context

Audit branch for [TRL-756](https://linear.app/outfitter/issue/TRL-756/audit-v1-doctrine-and-lexicon-drift-after-versioning-m3): sweep current-facing docs, plugin guidance, and package surface for lexicon drift after the M3 versioning work.

Closes [TRL-756](https://linear.app/outfitter/issue/TRL-756/audit-v1-doctrine-and-lexicon-drift-after-versioning-m3).

## Changes

- New audit report: `.agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-756-doctrine-lexicon-drift.md`. Verdict `minor drift`: repo-enforced lexicon gates are clean (vocab audit, ast-grep, Warden agents/skills). Remaining branch-source drift narrows to (a) resource factory `svc`/service/provision residue in public docs and tests and (b) the stale committed Clark survey snapshot. Installed local skill drift is external operator state and the check stayed read-only.

## Verification

- `git grep -nE` and `rg` retired-term sweeps over current-facing docs, plugin/skills, package READMEs, and source.
- `bun run vocab:audit` → entire repo target set, no legacy patterns.
- `bun run vocab:audit:json` → all retired-vocabulary rules `total: 0`.
- `bun run lint:ast-grep` → exit 0.
- `bun run warden:skills:check` and `bun run warden:agents:check` → exit 0.
- `bun run plugin:installed-skill:check` → expected failure (external operator state, read-only).
- `bunx markdownlint-cli2 ...` → 0 errors after blank-line cleanup.
- `git diff --check` → clean.

## Risks / Rollout

Docs/audit-only change. The two real-drift findings are filed as focused follow-ups so this branch stays scoped.

## Follow-ups filed

- [TRL-774](https://linear.app/outfitter/issue/TRL-774/rename-resource-factory-svc-residue-to-current-resource-context-naming)
- [TRL-775](https://linear.app/outfitter/issue/TRL-775/refresh-or-archive-stale-committed-clark-survey-snapshot)
