### PR TITLE
docs: clarify topographer cli workflow

### DIFF
--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md
@@ -27,7 +27,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | 2 | `TRL-766` | `trl-766-audit-version-marker-failure-ux-and-bounded-zod-diagnostics` | pending | In Progress | Audit/report drafted: stable-cutover blocker found in marker handling for validation constraints. |
 | 3 | `TRL-756` | `trl-756-audit-v1-doctrine-and-lexicon-drift-after-versioning-m3` | pending | In Progress | Audit/report drafted: minor doctrine and lexicon drift found. |
 | 4 | `TRL-757` | `trl-757-split-ontrailstesting-surface-harnesses-behind-subpaths` | pending | In Progress | Package/API implementation drafted: root contract helpers isolated, surface helpers moved behind subpaths, optional surface peers, regression coverage, docs, and changeset. |
-| 5 | `TRL-758` | `trl-758-clarify-topographer-artifact-cli-workflow-and-retired-topo` | pending | Todo | CLI/docs: Topographer artifact workflow. |
+| 5 | `TRL-758` | `trl-758-clarify-topographer-artifact-cli-workflow-and-retired-topo` | pending | In Progress | CLI/docs implementation drafted: top-level artifact workflow clarified, retired `trails topo ...` diagnostic added, changeset included. |
 | 6 | `TRL-759` | `trl-759-document-beta-channel-install-policy-and-version-bump` | pending | Todo | Release docs/policy: beta install, dist-tag, bump cadence. |
 | 7 | `TRL-760` | `trl-760-add-beta15-to-beta18-downstream-migration-guide` | pending | Todo | Migration docs: beta.15 to beta.18 guide. |
 
@@ -83,6 +83,8 @@ Record issues, milestones, labels, dependency links, comments, and follow-up iss
 | 2026-05-22 18:28 EDT | `TRL-756` | Added audit summary comment with report path, verdict, follow-ups, checks, and stable-cutover assessment. | Linear comment `15bbfeef-de73-46c8-b572-1777e8d3e8ed` |
 | 2026-05-22 18:29 EDT | `TRL-757` | Moved from Todo to In Progress before package implementation. | Linear update |
 | 2026-05-22 18:44 EDT | `TRL-757` | Added implementation summary comment with changed surfaces, docs, changeset, and targeted checks. | Linear comment `6b7a972d-86b9-4698-bcc3-55fbb1734c50` |
+| 2026-05-22 18:45 EDT | `TRL-758` | Moved from Todo to In Progress before Topographer CLI workflow implementation. | Linear update |
+| 2026-05-22 18:50 EDT | `TRL-758` | Added implementation summary comment with retired-command diagnostic, docs, changeset, and targeted checks. | Linear comment `ee4176ff-aa16-44db-a3f4-a51a384e20b6` |
 
 ## Execution Log
 
@@ -172,6 +174,20 @@ YYYY-MM-DD HH:MM TZ - <branch/issue/checkpoint>
 - Result: Branch commit contains the package/API split, regression, docs/plugin guidance, changeset, and this retro entry; upper branches were restacked; unrelated `.claude/worktrees/` remains untracked only.
 - Next: Move to `TRL-758` Topographer CLI workflow docs.
 - Blockers: None for `TRL-757`; `TRL-766` marker semantics remains the stable-cutover blocker already recorded.
+
+2026-05-22 18:49 EDT - TRL-758 Topographer artifact command workflow
+- Changed: Added a small CLI bootstrap diagnostic for retired `trails topo compile`, `trails topo verify`, and `trails topo check` attempts; documented top-level `trails compile`, `trails validate`, and `trails diff` as the consumer artifact workflow; clarified `@ontrails/topographer` as programmatic APIs/no separate bin; refreshed README/index/plugin Topographer wording; added `.changeset/topographer-cli-workflow.md`.
+- Verified: `bun test apps/trails/src/__tests__/retired-topo-command.test.ts`; actual CLI attempts for `topo compile`, `topo verify`, and `topo check`; help snapshots for root, `topo`, `compile`, `validate`, and `diff`; `bun run --cwd apps/trails typecheck`; `bun run docs:snippets`; `bun run docs:api-examples`; `bun run docs:links`; `bun run warden:skills:check`; focused `markdownlint-cli2`; stale-command text sweep; `bun run format:check`; `bun run publish:check`; `git diff --check`.
+- Result: All targeted checks passed. Stale-command sweep found only intentional current-facing retirement notes in `docs/topo-store.md`, `docs/api-reference.md`, and `packages/topographer/README.md`; root/topo help remains on the current command grammar, with no retired children under `trails topo --help`.
+- Next: Commit `TRL-758`, add the Linear implementation summary comment, then move to `TRL-759`.
+- Blockers: None for `TRL-758`; `TRL-766` marker semantics remains the stable-cutover blocker already recorded.
+
+2026-05-22 18:50 EDT - TRL-758 tracker comment and branch verification
+- Changed: Committed `TRL-758` as `docs: clarify topographer cli workflow`; added Linear comment `ee4176ff-aa16-44db-a3f4-a51a384e20b6`.
+- Verified: `gt modify -m "docs: clarify topographer cli workflow" --no-interactive`; `git status --short --branch`; `gt log --stack --reverse --no-interactive`; `git show --stat --oneline --name-status HEAD`; Linear `_save_comment`.
+- Result: Branch commit contains the retired-command diagnostic, Topographer workflow docs, changeset, and this retro entry; upper branches were restacked; unrelated `.claude/worktrees/` remains untracked only.
+- Next: Move to `TRL-759` beta channel install policy docs.
+- Blockers: None for `TRL-758`; `TRL-766` marker semantics remains the stable-cutover blocker already recorded.
 ```
 
 ## Local Review Log
@@ -240,6 +256,25 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun run publish:check` | `TRL-757` | pass | Pack dry-run passed for all publishable workspaces; `@ontrails/testing` tarball includes new subpath source files. |
 | `bun run format:check` | `TRL-757` | pass after fix | First run found formatting issues in `public-subpaths.test.ts` and `types.ts`; `bun run format:fix` changed only formatted repo files, and rerun passed. |
 | `git diff --check` | `TRL-757` | pass | No whitespace or conflict-marker errors after formatting. |
+| `bun test apps/trails/src/__tests__/retired-topo-command.test.ts` | `TRL-758` | pass | 2 pass, 0 fail; covers replacements and live command exclusions. |
+| `bun apps/trails/bin/trails.ts topo compile` | `TRL-758` | expected failure | Exit 1 with diagnostic: use `trails compile`; top-level artifact commands are `compile`, `validate`, and `diff`. |
+| `bun apps/trails/bin/trails.ts topo verify` | `TRL-758` | expected failure | Exit 1 with diagnostic: use `trails validate`. |
+| `bun apps/trails/bin/trails.ts topo check` | `TRL-758` | expected failure | Exit 1 with diagnostic: use `trails validate`. |
+| `bun apps/trails/bin/trails.ts --help` | `TRL-758` | pass | Root help lists top-level `compile`, `diff`, `topo`, and `validate`. |
+| `bun apps/trails/bin/trails.ts topo --help` | `TRL-758` | pass | `topo` help lists only `history`, `pin`, and `unpin` children. |
+| `bun apps/trails/bin/trails.ts compile --help` | `TRL-758` | pass | Help describes top-level artifact compile command. |
+| `bun apps/trails/bin/trails.ts validate --help` | `TRL-758` | pass | Help describes top-level artifact validation command. |
+| `bun apps/trails/bin/trails.ts diff --help` | `TRL-758` | pass | Help describes top-level TopoGraph diff command. |
+| `bun run --cwd apps/trails typecheck` | `TRL-758` | pass | App package typecheck exited 0. |
+| `bun run docs:snippets` | `TRL-758` | pass | README snippet typecheck passed for 21 README files, including `packages/topographer/README.md`. |
+| `bun run docs:api-examples` | `TRL-758` | pass | Public API example coverage passed for the minimum export set; inventory-only missing examples remain pre-existing. |
+| `bun run docs:links` | `TRL-758` | pass | Markdown link check passed for 119 files. |
+| `bun run warden:skills:check` | `TRL-758` | pass | Skill Warden guide sync check exited 0. |
+| `bunx markdownlint-cli2 README.md docs/index.md docs/topo-store.md docs/api-reference.md packages/topographer/README.md plugin/skills/trails/references/architecture.md .changeset/topographer-cli-workflow.md` | `TRL-758` | pass | 0 markdownlint errors across changed docs and changeset. |
+| `rg -n "trails topo (compile\|verify\|check)\|topo compile helpers\|SurfaceMap\|Surface maps\|surface map entries" README.md docs/index.md docs/topo-store.md docs/api-reference.md packages/topographer/README.md plugin/skills/trails/references/architecture.md apps/trails/src --glob '!**/CHANGELOG.md'` | `TRL-758` | pass | Only intentional retirement notes remain in current docs; no root README/index/plugin active SurfaceMap wording found. |
+| `bun run format:check` | `TRL-758` | pass | Repo format and Ultracite check exited 0 after TRL-758 edits. |
+| `bun run publish:check` | `TRL-758` | pass | Pack dry-run passed for all publishable workspaces; `@ontrails/trails` tarball includes `src/retired-topo-command.ts`; `@ontrails/topographer` README is included. |
+| `git diff --check` | `TRL-758` | pass | No whitespace or conflict-marker errors. |
 
 ## Remote Review / CI Log
 

--- a/.changeset/topographer-cli-workflow.md
+++ b/.changeset/topographer-cli-workflow.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/trails": patch
+"@ontrails/topographer": patch
+---
+
+Clarify the Topographer artifact workflow around top-level `trails compile`, `trails validate`, and `trails diff` commands, including explicit diagnostics for retired `trails topo compile`, `trails topo verify`, and `trails topo check` attempts.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Each declaration you add to a trail unlocks derived behavior across every surfac
 | You add | You get for free |
 |---------|-----------------|
 | `input` (Zod schema) | CLI flags + `--help` text, MCP JSON Schema, input validation |
-| `output` (Zod schema) | Contract tests, MCP response typing, surface map entries |
+| `output` (Zod schema) | Contract tests, MCP response typing, TopoGraph surface entries |
 | `intent: 'read'` | MCP `readOnlyHint`, CLI skips confirmation, HTTP GET |
 | `intent: 'destroy'` | MCP `destructiveHint`, CLI auto-adds `--dry-run`, HTTP DELETE |
 | `examples` | Tests (happy + error path), agent guidance, documentation |
@@ -156,7 +156,7 @@ $ myapp greet --name World
 | [`@ontrails/store`](./packages/store) | Backend-agnostic store definitions, typed accessors, adapter-support helpers |
 | [`@ontrails/drizzle`](./adapters/drizzle) | Drizzle SQLite adapter, typed store bindings, read-only bindings |
 | [`@ontrails/testing`](./packages/testing) | `testAll()`, `testTrail()`, `testCrosses()`, contract testing, surface harnesses |
-| [`@ontrails/topographer`](./packages/topographer) | TopoGraphs, semantic diffing, lock manifest and `topo.lock` helpers |
+| [`@ontrails/topographer`](./packages/topographer) | TopoGraphs, semantic diffing, durable artifact helpers, lock manifests, topo-store persistence |
 | [`@ontrails/observe`](./packages/observe) | Log and trace sink contracts, sink composition, built-in sinks, trace rendering |
 | [`@ontrails/tracing`](./packages/tracing) | Tracing compatibility, query/status trails, `trails.db` dev-state storage, sampling helpers, OTel adapter |
 | [`@ontrails/logtape`](./packages/logtape) | Adapter that forwards Trails log records to a LogTape-shaped logger |

--- a/apps/trails/src/__tests__/retired-topo-command.test.ts
+++ b/apps/trails/src/__tests__/retired-topo-command.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+
+import { getRetiredTopoCommandDiagnostic } from '../retired-topo-command.js';
+
+describe('retired topo artifact command diagnostics', () => {
+  test('points retired topo artifact commands at top-level replacements', () => {
+    const cases = [
+      ['compile', 'trails compile'],
+      ['verify', 'trails validate'],
+      ['check', 'trails validate'],
+    ] as const;
+
+    for (const [command, replacement] of cases) {
+      const diagnostic = getRetiredTopoCommandDiagnostic([
+        'bun',
+        'trails',
+        'topo',
+        command,
+      ]);
+
+      expect(diagnostic).toMatchObject({
+        attempted: `trails topo ${command}`,
+        replacement,
+      });
+      expect(diagnostic?.message).toContain(
+        `"trails topo ${command}" was retired`
+      );
+      expect(diagnostic?.message).toContain(`Use "${replacement}" instead`);
+      expect(diagnostic?.message).toContain('"trails diff"');
+      expect(diagnostic?.message).toContain('history, pin, and unpin');
+    }
+  });
+
+  test('leaves current topo and top-level artifact commands alone', () => {
+    for (const argv of [
+      ['bun', 'trails', 'compile'],
+      ['bun', 'trails', 'validate'],
+      ['bun', 'trails', 'diff'],
+      ['bun', 'trails', 'topo'],
+      ['bun', 'trails', 'topo', 'history'],
+      ['bun', 'trails', 'topo', 'pin'],
+      ['bun', 'trails', 'topo', 'unpin'],
+    ]) {
+      expect(getRetiredTopoCommandDiagnostic(argv)).toBeNull();
+    }
+  });
+});

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -21,6 +21,7 @@ import { deriveTopoGraph } from '@ontrails/topographer';
 
 import { app } from './app.js';
 import { resolveInputWithClack } from './clack.js';
+import { getRetiredTopoCommandDiagnostic } from './retired-topo-command.js';
 import { attachCompletionsInstallCommand } from './run-completions-install.js';
 import { tryRecoverFromRunCollision } from './run-collision.js';
 import { tryExampleRunOutput } from './run-example.js';
@@ -267,6 +268,13 @@ const normalizeWardenArgv = (argv: readonly string[]): string[] => {
  * process-lifetime sink.
  */
 const runSurfaceOnce = async (): Promise<void> => {
+  const retiredTopoCommand = getRetiredTopoCommandDiagnostic(process.argv);
+  if (retiredTopoCommand !== null) {
+    process.stderr.write(`${retiredTopoCommand.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
   const session = maybeInstallTraceSession();
   try {
     const program = createProgram(app, {

--- a/apps/trails/src/retired-topo-command.ts
+++ b/apps/trails/src/retired-topo-command.ts
@@ -1,0 +1,36 @@
+const retiredTopoCommandReplacements = {
+  check: 'trails validate',
+  compile: 'trails compile',
+  verify: 'trails validate',
+} as const;
+
+export type RetiredTopoCommand = keyof typeof retiredTopoCommandReplacements;
+
+export interface RetiredTopoCommandDiagnostic {
+  readonly attempted: `trails topo ${RetiredTopoCommand}`;
+  readonly message: string;
+  readonly replacement: (typeof retiredTopoCommandReplacements)[RetiredTopoCommand];
+}
+
+const isRetiredTopoCommand = (
+  command: string | undefined
+): command is RetiredTopoCommand =>
+  command !== undefined && command in retiredTopoCommandReplacements;
+
+export const getRetiredTopoCommandDiagnostic = (
+  argv: readonly string[]
+): RetiredTopoCommandDiagnostic | null => {
+  const [command, subcommand] = argv.slice(2);
+  if (command !== 'topo' || !isRetiredTopoCommand(subcommand)) {
+    return null;
+  }
+
+  const replacement = retiredTopoCommandReplacements[subcommand];
+  const attempted = `trails topo ${subcommand}` as const;
+
+  return {
+    attempted,
+    message: `"${attempted}" was retired. Use "${replacement}" instead.\nTopographer artifact commands now live at the top level: "trails compile", "trails validate", and "trails diff". "trails topo" is for topo-store history, pin, and unpin.`,
+    replacement,
+  };
+};

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -235,6 +235,13 @@ CreateAppOptions, SurfaceHttpResult
 
 ## `@ontrails/topographer`
 
+These are programmatic Topographer APIs for deriving, hashing, diffing, reading,
+and writing TopoGraph artifacts. App authors usually run the artifact lifecycle
+through the top-level CLI commands instead: `trails compile`, `trails validate`,
+and `trails diff`. The package does not expose a separate CLI binary, and
+retired `trails topo compile` / `trails topo verify` / `trails topo check`
+forms are not aliases.
+
 ```typescript
 // TopoGraph and lock artifact helpers
 deriveTopoGraph(graph), deriveTopoGraphHash(topoGraph), deriveTopoGraphDiff(before, after)

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@
 ## Governing your codebase?
 
 - **[Warden](./warden.md)** — Trails correctness rules, rule-home boundaries, drift detection, CI integration
-- **[Topographer](../packages/topographer/README.md)** — TopoGraphs, topo compile helpers, semantic diffing, lock artifact helpers
+- **[Topographer](../packages/topographer/README.md)** — TopoGraphs, durable artifact helpers, semantic diffing, lock manifests, topo-store persistence
 
 ## Contributing to Trails?
 

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -51,6 +51,20 @@ These fields are not exhaustive per-trail error contracts. Error categories, ret
 
 ## Commands
 
+Artifact lifecycle commands are top-level `trails` commands:
+`trails compile`, `trails validate`, and `trails diff`. The `trails topo`
+namespace is reserved for topo-store history and pin management.
+
+Retired shapes such as `trails topo compile`, `trails topo verify`, and
+`trails topo check` are not aliases. Use the top-level commands instead:
+
+- `trails compile` writes `.trails/topo.lock` and `.trails/trails.lock`.
+- `trails validate` checks committed artifacts against the current topo.
+- `trails diff` compares the current topo against a saved TopoGraph target.
+
+Programmatic consumers use `@ontrails/topographer` APIs directly; the package
+does not ship a separate CLI binary.
+
 ### `trails topo pin`
 
 Create a named pin for the current topo state.

--- a/packages/topographer/README.md
+++ b/packages/topographer/README.md
@@ -2,9 +2,12 @@
 
 Durable graph substrate for Trails: deterministic TopoGraphs, lockfile helpers, and semantic diffing.
 
-Most applications reach this package through `trails compile` and
-`trails validate`. Those CLI trails layer workspace and topo-store behavior on
-top of the building blocks in `@ontrails/topographer`.
+Most applications reach this package through top-level `trails compile`,
+`trails validate`, and `trails diff`. Those CLI trails layer workspace and
+topo-store behavior on top of the building blocks in
+`@ontrails/topographer`. The package itself ships library entry points, not a
+separate CLI binary, and retired `trails topo compile`,
+`trails topo verify`, and `trails topo check` forms are not aliases.
 
 ## What it owns
 

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -77,7 +77,7 @@ Every piece of information has a clear ownership model.
 | Error types returned | `Result.err(new XError(...))` patterns |
 | TopoGraph entries and lock hash | All established trails, resources, signals, contours, examples, and derived fields, canonicalized |
 
-Warden uses inference to verify declarations match actual code. Topographer captures the resolved `TopoGraph`, semantic diff, lock manifest, and `topo.lock` artifacts for CI governance.
+Warden uses inference to verify declarations match actual code. Topographer captures the resolved `TopoGraph`, semantic diff, lock manifest, and `topo.lock` artifacts for CI governance. Consumer artifact workflow uses the top-level CLI commands `trails compile`, `trails validate`, and `trails diff`; `trails topo` is for topo-store history and pin management.
 
 ## Package Layout
 


### PR DESCRIPTION
## Context

Implements [TRL-758](https://linear.app/outfitter/issue/TRL-758/clarify-topographer-artifact-cli-workflow-and-retired-topo-commands): make the settled artifact workflow unmistakable. Top-level `trails compile` / `trails validate` / `trails diff` are the consumer commands; `@ontrails/topographer` ships library APIs (no separate bin); retired `trails topo compile` / `topo verify` / `topo check` shapes should not silently fall through to parent help.

Closes [TRL-758](https://linear.app/outfitter/issue/TRL-758/clarify-topographer-artifact-cli-workflow-and-retired-topo-commands).

## Changes

- New CLI bootstrap diagnostic: `apps/trails/src/retired-topo-command.ts`. Retired attempts (`trails topo compile|verify|check`) exit 1 with a message pointing at the top-level replacement instead of `parent --help` fallback or alias.
- Test: `apps/trails/src/__tests__/retired-topo-command.test.ts` (2 tests: replacement messages + live-command exclusions).
- Docs refresh: `README.md`, `docs/index.md`, `docs/topo-store.md`, `docs/api-reference.md`, `packages/topographer/README.md`, `plugin/skills/trails/references/architecture.md` — current docs no longer teach `trails topo compile|verify|check`; `@ontrails/topographer` clearly described as programmatic APIs.
- `.changeset/topographer-cli-workflow.md` (`patch` for `@ontrails/trails` and `@ontrails/topographer`).

## Verification

- `bun test apps/trails/src/__tests__/retired-topo-command.test.ts` → 2 pass, 0 fail.
- Live CLI: `bun apps/trails/bin/trails.ts topo compile|verify|check` → exit 1 with replacement diagnostic.
- Help snapshots: `--help`, `topo --help`, `compile --help`, `validate --help`, `diff --help` confirm current command grammar.
- `bun run --cwd apps/trails typecheck` → exit 0.
- `bun run docs:snippets`, `bun run docs:api-examples`, `bun run docs:links` → pass.
- `bun run warden:skills:check` → exit 0.
- `bunx markdownlint-cli2` on changed docs/changeset → 0 errors.
- Stale-command sweep: only intentional retirement notes remain in current docs.
- `bun run format:check` → clean.
- `bun run publish:check` → pack dry-run includes `src/retired-topo-command.ts` in `@ontrails/trails`.
- `git diff --check` → clean.

## Risks / Rollout

Behavior change for anyone still typing `trails topo compile|verify|check`: a hard exit 1 with a helpful diagnostic, not silent parent help. Intentional per the audit verdict from the related TRL-756 doctrine sweep and the TRL-760 migration guide.

## Follow-ups

None on this branch.
