### PR TITLE
docs: document beta channel install policy and version bump

### DIFF
--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/GOAL.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/GOAL.md
@@ -1,23 +1,31 @@
-# Goal Prompt: v1-release-readiness-closeout
+# Goal Prompt: v1-release-readiness-closeout (resume from Codex handoff)
+
+Resume context: prior executor (Codex) stopped 2026-05-22 18:57 EDT with TRL-767/766/756/757/758 committed and TRL-759 implementation drafted in the working tree but uncommitted. The pasteable `/goal` below is the resume prompt for a fresh executor session. Full execution contract lives in `PLAN.md`; `RETRO.md` is the durable ledger to read first.
 
 Paste this into the goal runtime:
 
 ````markdown
-/goal From cwd `<path-to-trails-repo>`, execute `.agents/plans/2026-05-22-v1-release-readiness-closeout/PLAN.md` end to end. Objective: build the 7-branch v1 release-readiness closeout stack: audits `TRL-767`, `TRL-766`, `TRL-756`, then implementation/docs `TRL-757`, `TRL-758`, `TRL-759`, `TRL-760`; one PR per issue; no merge.
+/goal From cwd `<path-to-trails-repo>`, resume `.agents/plans/2026-05-22-v1-release-readiness-closeout/PLAN.md` from Codex handoff at 2026-05-22 18:57 EDT.
 
-Read first: `AGENTS.md`, `.agents/plans/PLANNING.md`, packet `PLAN.md`/`REFS.md`/`RETRO.md`, and all listed Linear issues. Start with `gt sync --no-interactive`; verify main/open PR state. Commit the packet on the lowest branch. Use exact Linear branch names/order from `PLAN.md`; local branch chain is ok; do not push empty branches.
+State: branch `trl-759-...`; TRL-767/766/756/757/758 committed; TRL-759 drafted in working tree (uncommitted; 17 M files + new `.changeset/beta-install-policy.md` and `docs/releases/beta-channel-policy.md`); TRL-760 branch exists but empty. `.claude/worktrees/` untracked, unrelated.
 
-Work loop: checkpoint-by-checkpoint. After each turn report checkpoint, changed files/artifacts, exact checks run, result summary, remaining work, blocker status, next checkpoint. Shrink failing surface before retrying. Keep `RETRO.md` updated after tracker, branch, audit, implementation, verification, local review, remote review, PR-body, or final-state changes; touch it last before handoff states.
+Read first: packet `RETRO.md` (full Execution Log + Verification Log + Deferred Discoveries + Tracker Mutations; Final State is the completion contract), `PLAN.md`, `REFS.md`, `AGENTS.md`, `.agents/plans/PLANNING.md`. Confirm `git status --short --branch` and `gt log --stack --reverse --no-interactive` match the resume state before any write; stop/ask if not.
 
-Audit contract: `TRL-767`, `TRL-766`, `TRL-756` produce committed reports under the packet `reports/` dir, with verdicts, evidence, command snippets, source paths, and follow-up issue list. File focused Linear follow-ups for real out-of-goal discoveries. If an audit finds a stable-cutover blocker larger than a small in-stack fix, stop/ask after recording evidence.
+Sequence:
+1. `gt modify -m "docs: document beta channel install policy and version bump" --no-interactive` on `trl-759-...`; restack upward; verify the branch commit contains only intended TRL-759 changes (`.claude/worktrees/` stays untracked, not staged). Add Linear implementation summary comment to TRL-759 in the TRL-757/758 comment style (changed surfaces, docs, changeset, targeted checks).
+2. Check out `trl-760-add-beta15-to-beta18-downstream-migration-guide`; move TRL-760 → In Progress; execute PLAN.md Phase 5 (beta.15→beta.18 migration guide); link from `docs/index.md`; reuse existing focused migration guides via links; add changeset; verify per Phase 5 ladder. Commit and add Linear comment.
+3. Final stack-tip gate: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run publish:registry-check`, `git diff --check`.
+4. Local review: ≥3 scored passes from stack tip per PLAN.md Lanes 1/2/3. Each pass returns overall n/5, prose summary, P0/P1/P2/P3 with file:line evidence, Prompt To Fix per actionable finding. Fix P0/P1/P2 on owning branches bottom-up with `gt modify`, restack, re-review. Stop when latest pass is P3-only or clean.
+5. Submit draft stack with high-quality PR bodies (context, changes, verification, risks, `Closes TRL-###`). Ready only after CI + local review clean. After ~15m, up to 4 post-ready remote-review turns; resolve P0/P1/P2 + concrete lower-score code-review bot/agent feedback bottom-up; record scores, prose summaries, prompt-to-fix text, unresolved threads in RETRO.
 
-Implementation contract: `TRL-757` isolates `@ontrails/testing` surface harnesses behind subpaths, optionalizes surface peers, adds regression + changeset; `TRL-758` clarifies top-level Topographer CLI workflow and retired topo commands; `TRL-759` documents beta install/dist-tag/version cadence using Bun publish scripts only; `TRL-760` adds linked beta.15 -> beta.18 downstream migration guide.
+Each turn report: checkpoint, files changed, exact checks run, result summary, remaining work, blocker status, next checkpoint. Touch `RETRO.md` last before any local-complete / draft-submit / ready-for-review / remote-review-closeout / handoff state.
 
-Validation ladder: targeted checks per phase; then `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run publish:registry-check`, `git diff --check`; add docs/plugin/warden checks if touched. If skipped, say why and what would prove it.
+Carry forward (out of scope; do not re-litigate):
+- TRL-772 — TRL-766 audit verdict "stable-cutover blocker" (markers ignore Zod `.refine`/`.min`/`.email` etc.). Stable 1.0 gated on it; this stack ships independently.
+- TRL-769/770/771/773/774/775 — audit follow-ups filed; out of goal.
+- TRL-765 / TRL-508 — out of scope.
 
-Review loop: run >=3 scored local review passes from stack tip; request n/5, prose summary, P0-P3 findings, evidence, Prompt To Fix. Fix all P0/P1/P2 bottom-up before submit. Submit draft stack with high-quality PR bodies; mark ready only after CI/local review clean. After ready, wait ~15m; run max 4 post-ready remote-review turns; resolve P0/P1/P2 and concrete lower-score bot/agent feedback bottom-up; record scores/prompts/threads in `RETRO.md`.
+Hard rules: no merge; no merge queue label; no `bun run publish:packages`; no `npm publish` / `changeset publish`; no registry or dist-tag mutation; no `gt absorb`; no source-control writes by subagents; no TRL-508 / TRL-765 / TRL-772 implementation. Stop/ask if a verification fails for unrelated reasons after focused retry, if review surfaces a P0/P1/P2 needing more than a small in-stack fix, or if more than 4 post-ready remote-review turns elapse with P2+ unresolved.
 
-Hard rules: no npm publish, no `bun run publish:packages`, no registry/dist-tag mutation, no merge, no merge queue label, no `gt absorb`, no source-control writes by subagents, no `TRL-508`/`TRL-765` implementation unless explicitly authorized. Do not spin on Graphite mergeability lag alone if GitHub checks/reviews are otherwise clean.
-
-Done only when all 7 issues have PRs, audits/reports/docs/code are complete, checks pass, Linear and PR bodies are current, no unresolved P0/P1/P2 remains, forbidden-action audit is clean, `RETRO.md` final state is filled, and final transcript reports branch/PR range, verification, review scores, skipped checks, risks/P3s, and no-merge/no-publish confirmation.
+Done only when: TRL-759 and TRL-760 committed with draft PRs that moved through ready → CI clean → up-to-4 remote-review turns; all 7 Linear issues reflect reality (state, comments, PR links); final repo gate passes; no unresolved P0/P1/P2; forbidden-action audit clean; `RETRO.md` Final State + Local Review Log + Verification Log + Remote Review / CI Log + Review Feedback Resolutions + Forbidden Actions Audit are filled. Final transcript names the updated `RETRO.md`. Do not merge unless explicitly asked.
 ````

--- a/.agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md
+++ b/.agents/plans/2026-05-22-v1-release-readiness-closeout/RETRO.md
@@ -28,7 +28,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | 3 | `TRL-756` | `trl-756-audit-v1-doctrine-and-lexicon-drift-after-versioning-m3` | pending | In Progress | Audit/report drafted: minor doctrine and lexicon drift found. |
 | 4 | `TRL-757` | `trl-757-split-ontrailstesting-surface-harnesses-behind-subpaths` | pending | In Progress | Package/API implementation drafted: root contract helpers isolated, surface helpers moved behind subpaths, optional surface peers, regression coverage, docs, and changeset. |
 | 5 | `TRL-758` | `trl-758-clarify-topographer-artifact-cli-workflow-and-retired-topo` | pending | In Progress | CLI/docs implementation drafted: top-level artifact workflow clarified, retired `trails topo ...` diagnostic added, changeset included. |
-| 6 | `TRL-759` | `trl-759-document-beta-channel-install-policy-and-version-bump` | pending | Todo | Release docs/policy: beta install, dist-tag, bump cadence. |
+| 6 | `TRL-759` | `trl-759-document-beta-channel-install-policy-and-version-bump` | pending | In Progress | Release policy/docs implementation drafted: beta install policy, latest/beta registry reporting, version cadence, package install snippets, and changeset. |
 | 7 | `TRL-760` | `trl-760-add-beta15-to-beta18-downstream-migration-guide` | pending | Todo | Migration docs: beta.15 to beta.18 guide. |
 
 ## Planning Discoveries
@@ -85,6 +85,7 @@ Record issues, milestones, labels, dependency links, comments, and follow-up iss
 | 2026-05-22 18:44 EDT | `TRL-757` | Added implementation summary comment with changed surfaces, docs, changeset, and targeted checks. | Linear comment `6b7a972d-86b9-4698-bcc3-55fbb1734c50` |
 | 2026-05-22 18:45 EDT | `TRL-758` | Moved from Todo to In Progress before Topographer CLI workflow implementation. | Linear update |
 | 2026-05-22 18:50 EDT | `TRL-758` | Added implementation summary comment with retired-command diagnostic, docs, changeset, and targeted checks. | Linear comment `ee4176ff-aa16-44db-a3f4-a51a384e20b6` |
+| 2026-05-22 18:52 EDT | `TRL-759` | Moved from Todo to In Progress before beta channel policy implementation. | Linear update |
 
 ## Execution Log
 
@@ -188,6 +189,20 @@ YYYY-MM-DD HH:MM TZ - <branch/issue/checkpoint>
 - Result: Branch commit contains the retired-command diagnostic, Topographer workflow docs, changeset, and this retro entry; upper branches were restacked; unrelated `.claude/worktrees/` remains untracked only.
 - Next: Move to `TRL-759` beta channel install policy docs.
 - Blockers: None for `TRL-758`; `TRL-766` marker semantics remains the stable-cutover blocker already recorded.
+
+2026-05-22 18:57 EDT - TRL-759 beta channel install and version cadence policy
+- Changed: Added `docs/releases/beta-channel-policy.md`; linked it from docs index; updated root, getting-started, package, surface, and Trails skill install snippets to use `@beta`; documented exact beta pins vs `@beta`, intentional `latest` lag, prerelease default tag behavior, no `npm publish`/`changeset publish`, version-bump cadence, and future-channel scope; updated `publish:registry-check` output to print both `latest` and `beta`; added `.changeset/beta-install-policy.md`.
+- Verified: `bun test scripts/__tests__/check-registry-preflight.test.ts`; `bun run publish:registry-check`; representative `npm view <pkg> dist-tags --json` probes for `@ontrails/core`, `@ontrails/commander`, `@ontrails/testing`, and `@ontrails/topographer`; stale install-command sweep; `bun run docs:snippets`; `bun run docs:links`; `bun run warden:skills:check`; focused `markdownlint-cli2`; `bun run format:check`; `bun run publish:check`; `git diff --check`.
+- Result: All targeted checks passed. `publish:registry-check` now passes for `beta` and visibly reports most packages at `latest=1.0.0-beta.16, beta=1.0.0-beta.18`; representative npm probes confirm the same split for sampled packages. The final stale install sweep found no unqualified current `@ontrails/core`/CLI/MCP/HTTP/testing install commands in the checked docs/plugin/package targets.
+- Next: Commit `TRL-759`, add the Linear implementation summary comment, then move to `TRL-760`.
+- Blockers: None for `TRL-759`; `TRL-766` marker semantics remains the stable-cutover blocker already recorded.
+
+2026-05-22 (post-18:57) - Cross-session handoff prepared for fresh Claude executor
+- Changed: Updated packet `GOAL.md` with a resume-from-Codex `/goal` prompt that names current branch, working-tree state, and the next-steps sequence (commit TRL-759 → TRL-760 → final gate → local review → submit/ready/remote review). No source files changed; `RETRO.md` and `GOAL.md` only.
+- Verified: `git status --short --branch` (branch `trl-759-document-beta-channel-install-policy-and-version-bump`; 17 M files matching Codex's 18:57 entry; new `.changeset/beta-install-policy.md` and `docs/releases/beta-channel-policy.md` untracked as expected; `.claude/worktrees/` untracked and unrelated); `gt log --stack --reverse --no-interactive` (TRL-767 → TRL-758 committed in order; TRL-759 + TRL-760 branches exist; TRL-759 working tree carries the drafted changes).
+- Result: Working tree matches Codex's 18:57 EDT execution-log entry. Resume executor can commit TRL-759 without re-running drafted work. TRL-772 stable-cutover blocker is documented and intentionally out of scope for this stack.
+- Next: New executor session runs `gt modify` to commit TRL-759, adds the Linear implementation summary comment, then proceeds to TRL-760.
+- Blockers: None for the resume sequence. Stable 1.0 cutover remains gated on TRL-772, but this stack ships independently.
 ```
 
 ## Local Review Log
@@ -275,6 +290,20 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun run format:check` | `TRL-758` | pass | Repo format and Ultracite check exited 0 after TRL-758 edits. |
 | `bun run publish:check` | `TRL-758` | pass | Pack dry-run passed for all publishable workspaces; `@ontrails/trails` tarball includes `src/retired-topo-command.ts`; `@ontrails/topographer` README is included. |
 | `git diff --check` | `TRL-758` | pass | No whitespace or conflict-marker errors. |
+| `bun test scripts/__tests__/check-registry-preflight.test.ts` | `TRL-759` | pass | 7 pass, 0 fail; added coverage for formatting `latest` and `beta` tag summaries together. |
+| `bun run publish:registry-check` | `TRL-759` | pass | Read-only registry preflight checked `beta` by default from `.changeset/pre.json`; output now reports `expected beta=...` plus `tags latest=..., beta=...` for each package. |
+| `npm view @ontrails/core dist-tags --json` | `TRL-759` | pass | Read-only probe returned `latest=1.0.0-beta.16`, `beta=1.0.0-beta.18`. |
+| `npm view @ontrails/commander dist-tags --json` | `TRL-759` | pass | Read-only probe returned `latest=1.0.0-beta.16`, `beta=1.0.0-beta.18`. |
+| `npm view @ontrails/testing dist-tags --json` | `TRL-759` | pass | Read-only probe returned `latest=1.0.0-beta.16`, `beta=1.0.0-beta.18`. |
+| `npm view @ontrails/topographer dist-tags --json` | `TRL-759` | pass | Read-only probe returned `latest=1.0.0-beta.16`, `beta=1.0.0-beta.18`. |
+| `rg -n 'bun add (-d )?@ontrails/(core\|cli\|commander\|mcp\|http\|hono\|testing)(\\s\|$)\|bun add @ontrails/core @ontrails/cli' README.md docs plugin/skills packages/*/README.md --glob '!**/CHANGELOG.md'` | `TRL-759` | pass | Final sweep exited 1 with no matches, confirming checked current install docs no longer show unqualified core/CLI/MCP/HTTP/testing install commands. An earlier sweep with unescaped backticks emitted a zsh `latest` command-substitution error; rerun used single-quoted regex. |
+| `bun run docs:snippets` | `TRL-759` | pass | README snippet typecheck passed for 21 README files after package install snippet edits. |
+| `bun run docs:links` | `TRL-759` | pass | Markdown link check passed for 120 files after adding `docs/releases/beta-channel-policy.md`. |
+| `bun run warden:skills:check` | `TRL-759` | pass | Skill Warden guide sync check exited 0. |
+| `bunx markdownlint-cli2 README.md docs/index.md docs/getting-started.md docs/releases/beta-channel-policy.md docs/surfaces/cli.md docs/surfaces/mcp.md docs/surfaces/http.md packages/core/README.md packages/cli/README.md packages/http/README.md packages/testing/README.md packages/mcp/README.md plugin/skills/trails/SKILL.md plugin/skills/trails/references/getting-started.md plugin/skills/trails/references/http-surface.md .changeset/beta-install-policy.md` | `TRL-759` | pass | 0 markdownlint errors across changed docs, plugin guidance, package READMEs, and changeset. |
+| `bun run format:check` | `TRL-759` | pass | Repo format and Ultracite check exited 0 after TRL-759 edits. |
+| `bun run publish:check` | `TRL-759` | pass | Pack dry-run passed for all publishable workspaces after package README and changeset edits. |
+| `git diff --check` | `TRL-759` | pass | No whitespace or conflict-marker errors. |
 
 ## Remote Review / CI Log
 

--- a/.changeset/beta-install-policy.md
+++ b/.changeset/beta-install-policy.md
@@ -1,0 +1,14 @@
+---
+"@ontrails/core": patch
+"@ontrails/cli": patch
+"@ontrails/commander": patch
+"@ontrails/hono": patch
+"@ontrails/drizzle": patch
+"@ontrails/http": patch
+"@ontrails/mcp": patch
+"@ontrails/store": patch
+"@ontrails/testing": patch
+"@ontrails/trails": patch
+---
+
+Document beta-channel install guidance in package and adapter README install snippets so consumers use explicit `@beta` (or pinned `1.0.0-beta.N`) tags instead of accidental `latest` resolution during the prerelease line. Adds the policy doc at `docs/releases/beta-channel-policy.md`, prints both `latest` and `beta` dist-tags in `bun run publish:registry-check`, and aligns plugin/skill install snippets.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ Follow the prompts — pick a name, choose a starter, select your surfaces. The 
 Or install manually:
 
 ```bash
-bun add @ontrails/core @ontrails/cli @ontrails/commander zod
-bun add -d @ontrails/testing
+bun add @ontrails/core@beta @ontrails/cli@beta @ontrails/commander@beta zod
+bun add -d @ontrails/testing@beta
 ```
+
+During the active beta line, use `@beta` for the newest published beta or exact
+`1.0.0-beta.N` pins for reproducible handoffs. Do not rely on unqualified
+`latest` unless release notes explicitly say it has been advanced.
 
 ## Before and after
 

--- a/adapters/commander/README.md
+++ b/adapters/commander/README.md
@@ -39,7 +39,7 @@ const program = toCommander(commands.value, { name: 'myapp' });
 ## Installation
 
 ```bash
-bun add @ontrails/cli @ontrails/commander
+bun add @ontrails/cli@beta @ontrails/commander@beta
 ```
 
 ## Migration

--- a/adapters/drizzle/README.md
+++ b/adapters/drizzle/README.md
@@ -25,7 +25,7 @@ export const db = connectDrizzle(definition, {
 ## Installation
 
 ```bash
-bun add @ontrails/store @ontrails/drizzle zod
+bun add @ontrails/store@beta @ontrails/drizzle@beta zod
 ```
 
 ## Migration

--- a/adapters/hono/README.md
+++ b/adapters/hono/README.md
@@ -37,7 +37,7 @@ For custom HTTP integrations or route inspection, keep using `deriveHttpRoutes()
 ## Installation
 
 ```bash
-bun add @ontrails/http @ontrails/hono
+bun add @ontrails/http@beta @ontrails/hono@beta
 ```
 
 ## Migration

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,17 +13,21 @@ This guide demonstrates CLI and MCP first because they are the shortest path to 
 bunx @ontrails/trails create
 
 # Or install manually
-bun add @ontrails/core @ontrails/cli @ontrails/commander zod
+bun add @ontrails/core@beta @ontrails/cli@beta @ontrails/commander@beta zod
 
 # Add MCP surface (optional)
-bun add @ontrails/mcp
+bun add @ontrails/mcp@beta
 
 # Add HTTP surface (optional, shipped today)
-bun add @ontrails/http @ontrails/hono
+bun add @ontrails/http@beta @ontrails/hono@beta
 
 # Add testing (dev dependency)
-bun add -d @ontrails/testing
+bun add -d @ontrails/testing@beta
 ```
+
+During the active beta line, use `@beta` for the newest published beta or pin
+exact `1.0.0-beta.N` versions for reproducible handoffs. Do not rely on
+unqualified `latest` unless release notes explicitly say it has been advanced.
 
 ## Your First Trail
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 ## Release Notes
 
 - **[Stable Cutover Runbook](./releases/stable-cutover.md)** — Beta-to-1.0 cutover sequence, publish boundaries, and recovery checks
+- **[Beta Channel Policy](./releases/beta-channel-policy.md)** — Beta install tags, `latest` posture, version cadence, and read-only registry checks
 - **[Plugin Release Runbook](./releases/plugin-release.md)** — Claude plugin/skills refresh, dogfood, and manual publication checks
 - **[Beta 15](./releases/beta15.md)** — Current release-prep notes and known CLI follow-up work
 

--- a/docs/releases/beta-channel-policy.md
+++ b/docs/releases/beta-channel-policy.md
@@ -1,0 +1,106 @@
+# Beta Channel Policy
+
+This policy applies while Trails remains in the `1.0.0-beta.N` prerelease
+line.
+
+## Consumer Installs
+
+Use the beta channel deliberately:
+
+- Use explicit pins such as `@ontrails/core@1.0.0-beta.18` when a handoff,
+  fixture, generated app, or downstream migration must be reproducible.
+- Use `@beta` when you intentionally want the newest published beta.
+- Do not rely on unqualified `@ontrails/*` installs during the beta line unless
+  release notes explicitly say `latest` has been advanced.
+- Keep public `@ontrails/*` packages on the same beta number. Do not mix
+  `beta.15`, `beta.18`, and `@beta` ranges in one app.
+
+Example active-beta install:
+
+```bash
+bun add @ontrails/core@beta @ontrails/cli@beta @ontrails/commander@beta zod
+bun add @ontrails/mcp@beta
+bun add @ontrails/http@beta @ontrails/hono@beta
+bun add -d @ontrails/testing@beta
+```
+
+For fully reproducible docs, replace `@beta` with the exact beta version named
+by the release packet.
+
+## Dist-Tag Posture
+
+`.changeset/pre.json` is the channel source while it has `mode: "pre"`. The
+current prerelease tag is `beta`.
+
+The release scripts follow that source:
+
+- `bun run publish:check` is local and read-only.
+- `bun run publish:registry-check` defaults to `.changeset/pre.json`'s tag in
+  prerelease mode, so it checks `beta` today.
+- `bun run publish:packages` publishes with Bun and uses the same prerelease tag
+  by default.
+- `bun run publish:registry-check:published` verifies the expected dist-tag
+  after publication.
+
+During the beta line, `latest` may intentionally lag behind `beta`. Operators
+should not advance `latest` after every beta publication. Move `latest` only
+when leaving prerelease mode for the stable 1.x line, or after a separate
+explicit release decision that says a beta should become the unqualified
+default.
+
+Do not use `npm publish`, `changeset publish`, or ad hoc dist-tag mutation for
+normal Trails package releases.
+
+## Read-Only Registry Checks
+
+The standard beta posture check is:
+
+```bash
+bun run publish:registry-check
+```
+
+Its output validates the expected tag and prints both `latest` and `beta` for
+each published public workspace package, making tag lag visible.
+
+For a small representative spot check:
+
+```bash
+for pkg in @ontrails/core @ontrails/commander @ontrails/testing @ontrails/topographer; do
+  npm view "$pkg" dist-tags --json
+done
+```
+
+That command is read-only. It should show whether `latest` and `beta` point at
+different versions.
+
+## Version-Bump Cadence
+
+Every PR that changes publishable `@ontrails/*` package contents needs a
+branch-local changeset unless the PR is explicitly labeled `release:none`.
+
+After substantial stacks merge to `main`:
+
+1. Confirm all package-affecting PRs carried changesets or an explicit
+   `release:none` decision.
+2. Run `bunx changeset status --verbose` from clean, synced `main` to inspect
+   the next beta plan.
+3. When the next beta is warranted, create a dedicated version branch and run
+   `bunx changeset version`.
+4. Review package versions, changelogs, generated lockfile changes, and
+   generated-app dependency ranges.
+5. Run the version-branch gates, including `bun run publish:check` and
+   `bun run publish:registry-check`.
+6. Submit and merge the version PR only after CI and review are clean.
+7. Publish only from clean, synced `main` after the version PR merges:
+   `bun run publish:check`, `bun run publish:registry-check`,
+   `bun run publish:packages`, then
+   `bun run publish:registry-check:published`.
+
+Feature branches and release-readiness stacks may run read-only checks, but they
+must not publish.
+
+## Future Channels
+
+`next` and `canary` are out of scope for the pre-1.0 beta line. Introducing
+another prerelease channel needs a focused policy issue or ADR amendment before
+any script, docs, or release operator starts using it.

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -7,7 +7,7 @@ automatically.
 ## Setup
 
 ```bash
-bun add @ontrails/cli @ontrails/commander
+bun add @ontrails/cli@beta @ontrails/commander@beta
 ```
 
 ```typescript

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -7,7 +7,7 @@ The package separates framework-agnostic route building (`@ontrails/http`), shar
 ## Setup
 
 ```bash
-bun add @ontrails/http @ontrails/hono
+bun add @ontrails/http@beta @ontrails/hono@beta
 ```
 
 ```typescript
@@ -22,7 +22,7 @@ That starts an HTTP server with every exposed trail registered as a route.
 For Bun-native serving without Hono:
 
 ```bash
-bun add @ontrails/http
+bun add @ontrails/http@beta
 ```
 
 ```typescript

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -5,7 +5,7 @@ The MCP surface adapter turns every trail into an MCP tool. Annotations are auto
 ## Setup
 
 ```bash
-bun add @ontrails/mcp
+bun add @ontrails/mcp@beta
 ```
 
 ```typescript

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -223,7 +223,7 @@ wiring.
 ## Installation
 
 ```bash
-bun add @ontrails/cli @ontrails/commander
+bun add @ontrails/cli@beta @ontrails/commander@beta
 ```
 
 `@ontrails/cli` owns command derivation. `@ontrails/commander` owns Commander

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -196,5 +196,5 @@ Types `ReadOnlyTopoStore`, `MockTopoStoreSeed`, `TopoSnapshot`, `TopoStoreRef`, 
 ## Installation
 
 ```bash
-bun add @ontrails/core zod
+bun add @ontrails/core@beta zod
 ```

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -145,9 +145,9 @@ values into arrays.
 ## Installation
 
 ```bash
-bun add @ontrails/http @ontrails/hono
+bun add @ontrails/http@beta @ontrails/hono@beta
 # or, for Bun-native serving:
-bun add @ontrails/http
+bun add @ontrails/http@beta
 ```
 
 ## Migration

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -116,5 +116,5 @@ await surface(graph, { exclude: ['internal.debug'] });
 ## Installation
 
 ```bash
-bun add @ontrails/mcp
+bun add @ontrails/mcp@beta
 ```

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -276,13 +276,13 @@ const schema = db.tables;
 ## Installation
 
 ```bash
-bun add @ontrails/store zod
+bun add @ontrails/store@beta zod
 ```
 
 Add Drizzle only when you want the external SQLite/ORM adapter:
 
 ```bash
-bun add @ontrails/drizzle
+bun add @ontrails/drizzle@beta
 ```
 
 ## Migration

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -162,5 +162,5 @@ skipped.
 ## Installation
 
 ```bash
-bun add -d @ontrails/testing
+bun add -d @ontrails/testing@beta
 ```

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -62,6 +62,7 @@ Current public packages are lockstep at the same Trails framework version.
 - **Infrastructure:** `@ontrails/config`, `@ontrails/permits`, `@ontrails/store`, and `@ontrails/drizzle` cover config, authorization, schema-derived stores, and Drizzle SQLite bindings.
 - **Observability:** `@ontrails/observe` defines sink contracts; `@ontrails/tracing`, `@ontrails/logtape`, and `@ontrails/pino` provide tracing/dev-state and sink adapters.
 - **Ecosystem:** `@ontrails/testing` provides contract tests and surface harnesses; `@ontrails/topographer` owns TopoGraphs, semantic diffing, lock manifests, and topo-store persistence; `@ontrails/warden` owns governance rules; `@ontrails/wayfinder` is shell-only for future agent wayfinding trails and ships no trails yet.
+- **Beta install policy:** While `.changeset/pre.json` is in prerelease mode, install published Trails packages with exact `1.0.0-beta.N` pins or `@beta`; do not rely on unqualified `latest` unless release notes explicitly advance it.
 
 ## Creating Trails
 

--- a/plugin/skills/trails/references/getting-started.md
+++ b/plugin/skills/trails/references/getting-started.md
@@ -9,13 +9,17 @@
 bunx @ontrails/trails create
 
 # Or install manually
-bun add @ontrails/core @ontrails/cli @ontrails/commander zod
-bun add @ontrails/mcp @modelcontextprotocol/sdk # MCP surface (optional)
-bun add @ontrails/http @ontrails/hono       # Hono HTTP surface (optional)
+bun add @ontrails/core@beta @ontrails/cli@beta @ontrails/commander@beta zod
+bun add @ontrails/mcp@beta @modelcontextprotocol/sdk # MCP surface (optional)
+bun add @ontrails/http@beta @ontrails/hono@beta # Hono HTTP surface (optional)
 # or, for Bun-native HTTP without Hono:
-bun add @ontrails/http
-bun add -d @ontrails/testing         # Testing (dev)
+bun add @ontrails/http@beta
+bun add -d @ontrails/testing@beta # Testing (dev)
 ```
+
+During the active beta line, use `@beta` for the newest published beta or exact
+`1.0.0-beta.N` pins for reproducible handoffs. Do not rely on unqualified
+`latest` unless release notes explicitly say it has been advanced.
 
 ## Define Your First Trail
 

--- a/plugin/skills/trails/references/http-surface.md
+++ b/plugin/skills/trails/references/http-surface.md
@@ -10,9 +10,9 @@ Trails HTTP support has a shared core plus runtime materializers:
 ## Install
 
 ```bash
-bun add @ontrails/http @ontrails/hono
+bun add @ontrails/http@beta @ontrails/hono@beta
 # or, for Bun-native serving:
-bun add @ontrails/http
+bun add @ontrails/http@beta
 ```
 
 ## Open With Hono

--- a/scripts/__tests__/check-registry-preflight.test.ts
+++ b/scripts/__tests__/check-registry-preflight.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import {
   checkRegistryPosture,
   discoverRegistryWorkspaces,
+  formatDistTagSummary,
   registryPostureErrors,
 } from '../check-registry-preflight.ts';
 import type {
@@ -51,6 +52,20 @@ const staleTagRegistryView: RegistryView = async (name) => ({
 const failingRegistryView: RegistryView = async () => {
   throw new Error('registry unavailable');
 };
+
+describe('formatDistTagSummary', () => {
+  test('formats latest and beta dist-tags together for beta-channel audits', () => {
+    expect(
+      formatDistTagSummary({
+        beta: '1.0.0-beta.18',
+        latest: '1.0.0-beta.16',
+      })
+    ).toBe('latest=1.0.0-beta.16, beta=1.0.0-beta.18');
+    expect(formatDistTagSummary({ beta: '1.0.0-beta.18' })).toBe(
+      'latest=missing, beta=1.0.0-beta.18'
+    );
+  });
+});
 
 describe('checkRegistryPosture', () => {
   test('classifies published and first-time package candidates', async () => {

--- a/scripts/check-registry-preflight.ts
+++ b/scripts/check-registry-preflight.ts
@@ -4,6 +4,7 @@ import { readdir } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 
 const REPO_ROOT = resolve(import.meta.dir, '..');
+const SUMMARY_DIST_TAGS = ['latest', 'beta'] as const;
 
 interface Options {
   readonly requirePublished: boolean;
@@ -283,6 +284,13 @@ export const registryPostureErrors = (
   return errors;
 };
 
+export const formatDistTagSummary = (
+  distTags: Readonly<Record<string, string>>
+): string =>
+  SUMMARY_DIST_TAGS.map((tag) => `${tag}=${distTags[tag] ?? 'missing'}`).join(
+    ', '
+  );
+
 const printResults = (
   results: readonly RegistryResult[],
   expectedTag: string
@@ -291,7 +299,7 @@ const printResults = (
   for (const result of results) {
     if (result.status === 'published') {
       console.log(
-        `✓ ${result.name}@${result.workspaceVersion}: published (registry version ${result.version}, ${expectedTag}=${result.expectedTagVersion ?? 'missing'})`
+        `✓ ${result.name}@${result.workspaceVersion}: published (registry version ${result.version}, expected ${expectedTag}=${result.expectedTagVersion ?? 'missing'}, tags ${formatDistTagSummary(result.distTags)})`
       );
     } else if (result.status === 'missing') {
       console.log(


### PR DESCRIPTION
## Context

Implements [TRL-759](https://linear.app/outfitter/issue/TRL-759/document-beta-channel-install-policy-and-version-bump): make beta consumption and bump cadence unambiguous while preserving Trails' Bun publish doctrine. Driven by the PatchOS dogfood finding that `npm view` reports `latest=1.0.0-beta.16` while `beta=1.0.0-beta.18`, and the live docs/skills teach beta.18 — leaving a downstream consumer to decide which to follow.

Closes [TRL-759](https://linear.app/outfitter/issue/TRL-759/document-beta-channel-install-policy-and-version-bump).

## Changes

- New policy doc: `docs/releases/beta-channel-policy.md`. Covers explicit `1.0.0-beta.N` pins vs `@beta`, the intentional `latest` lag during beta, prerelease default tag behavior from `.changeset/pre.json`, the version-bump cadence, the no-`npm publish`/no-`changeset publish` Bun publish doctrine, read-only registry checks, and the out-of-scope future channels (`next`, `canary`). Linked from `docs/index.md`.
- Install snippets updated to use `@beta` across `README.md`, `docs/getting-started.md`, `docs/surfaces/{cli,http,mcp}.md`, `packages/{core,cli,http,mcp,testing}/README.md`, `plugin/skills/trails/SKILL.md`, and `plugin/skills/trails/references/{getting-started,http-surface}.md`.
- `scripts/check-registry-preflight.ts` now prints both `latest` and `beta` dist-tags per package, making the tag lag visible during `bun run publish:registry-check`. `scripts/__tests__/check-registry-preflight.test.ts` adds focused coverage for the combined tag summary.
- `.changeset/beta-install-policy.md` (`patch` for `@ontrails/trails`).

## Verification

- `bun test scripts/__tests__/check-registry-preflight.test.ts` → 7 pass, 0 fail.
- `bun run publish:registry-check` → all packages pass `beta` posture; output includes `expected beta=...` + `tags latest=..., beta=...`.
- `npm view @ontrails/core|@ontrails/commander|@ontrails/testing|@ontrails/topographer dist-tags --json` → confirms the `latest=beta.16` / `beta=beta.18` split for representative packages.
- Stale install-command sweep: no unqualified core/CLI/MCP/HTTP/testing install commands remain in checked docs.
- `bun run docs:snippets`, `bun run docs:links` → pass.
- `bun run warden:skills:check` → exit 0.
- `bunx markdownlint-cli2` on changed docs/plugin/package READMEs/changeset → 0 errors.
- `bun run format:check`, `bun run publish:check`, `git diff --check` → all clean.

## Risks / Rollout

Docs and policy change with a small read-only script update. No public API or runtime change. Downstream consumers should adopt `@beta` or exact pins as described in the new policy.

## Follow-ups

None on this branch. The downstream operator-level migration story for beta.15 → beta.18 lives in [TRL-760](https://linear.app/outfitter/issue/TRL-760/add-beta15-to-beta18-downstream-migration-guide) (top of stack).
