### PR TITLE
fix: scaffold agent guidance

### DIFF
--- a/.agents/plans/2026-05-23-scaffold-runway-overnight-stack/RETRO.md
+++ b/.agents/plans/2026-05-23-scaffold-runway-overnight-stack/RETRO.md
@@ -25,7 +25,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | --- | --- | --- | --- | --- | --- |
 | 0 | TRL-780 | `trl-780-scaffolded-projects-cant-run-most-framework-cli-subcommands` | #577 | Done / merged | Prerequisite merged at `52e4e8f7d`; packet archived during this planning pass. |
 | 1 | TRL-788 | `trl-788-trails-create-scaffold-tsconfigtestsjson-sibling-for-lsp` | pending | implemented locally | Local commit `fix: scaffold test tsconfig`; generated test TypeScript config. |
-| 2 | TRL-777 | `trl-777-trails-create-scaffolds-agentsmd-claudemd-minimal-trails` | pending | planned | Generated agent guidance. |
+| 2 | TRL-777 | `trl-777-trails-create-scaffolds-agentsmd-claudemd-minimal-trails` | pending | implemented locally | Generated `AGENTS.md` and `CLAUDE.md` shim guidance. |
 | 3 | TRL-779 | `trl-779-trails-create-scaffolds-readmemd-create-react-app-style` | pending | planned | Generated README. |
 | sidecar | TRL-792 | `trl-792-document-bun-runtime-requirement-for-consumers-beta-channel` | pending | planned | Docs-only runtime requirement; branch from `main`, not stacked on scaffold code. |
 
@@ -77,6 +77,13 @@ Use this as the durable execution ledger. For stacked work, this should normally
 - Result: TRL-788 is ready to support the next stacked branch locally.
 - Next: create TRL-777 branch.
 - Blockers: none.
+
+2026-05-23 23:48 EDT - TRL-777 implementation
+- Changed: generated project-level `AGENTS.md` and `CLAUDE.md`; used a thin `CLAUDE.md` compatibility shim instead of symlink support; added scaffold assertions and patch changeset.
+- Verified: `bun test apps/trails/src/__tests__/create.test.ts`; `bun --cwd apps/trails test`; `bun run format:check`; `git diff --check`; `bun run typecheck`.
+- Result: all checks passed.
+- Next: commit TRL-777 branch, then stack TRL-779 above it.
+- Blockers: none.
 ```
 
 ## Local Review Log
@@ -96,6 +103,11 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | `bun run format:check` | TRL-788 repo format/lint wrapper | pass | 0 warnings, 0 errors. |
 | `git diff --check` | TRL-788 patch hygiene | pass | no output. |
 | `bun run typecheck` | TRL-788 repo typecheck | pass | 22 successful, 22 total. |
+| `bun test apps/trails/src/__tests__/create.test.ts` | TRL-777 targeted | pass | 15 pass, 0 fail. |
+| `bun --cwd apps/trails test` | TRL-777 package | pass | 347 pass, 0 fail. |
+| `bun run format:check` | TRL-777 repo format/lint wrapper | pass | 0 warnings, 0 errors. |
+| `git diff --check` | TRL-777 patch hygiene | pass | no output. |
+| `bun run typecheck` | TRL-777 repo typecheck | pass | 22 successful, 22 total. |
 
 ## Remote Review / CI Log
 

--- a/.changeset/scaffold-agent-guidance.md
+++ b/.changeset/scaffold-agent-guidance.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/trails": patch
+---
+
+Generate project-level `AGENTS.md` and `CLAUDE.md` guidance so new Trails apps
+start with canonical agent instructions.

--- a/apps/trails/src/__tests__/create.test.ts
+++ b/apps/trails/src/__tests__/create.test.ts
@@ -144,6 +144,8 @@ const assertDefaultProjectFiles = (dir: string): void => {
     dir,
     [
       'package.json',
+      'AGENTS.md',
+      'CLAUDE.md',
       'tsconfig.json',
       'tsconfig.tests.json',
       '.gitignore',
@@ -173,6 +175,33 @@ const assertTsconfigTests = (dir: string): void => {
   expect(compilerOptions['noEmit']).toBe(true);
   expect(compilerOptions['rootDir']).toBe('.');
   expect(compilerOptions['types']).toEqual(['bun']);
+};
+
+const assertAgentGuidance = (dir: string): void => {
+  expectContainsAll(readText(dir, 'AGENTS.md'), [
+    'This is a Trails project.',
+    'agent-native, contract-first TypeScript framework',
+    '`trail`, not action or handler',
+    '`blaze`, not handler or impl',
+    '`topo`, not registry or collection',
+    '`cross`, not follow',
+    '`surface`, not transport',
+    '`resource`, not service or dependency',
+    '`layer`, for cross-cutting trail wrapping',
+    'Blazes return `Result`; never throw',
+    '`Result.ok()` and `Result.err()`',
+    '`ctx.cross(...)`',
+    '`resources: [...]`',
+    'bun run warden',
+    'bun run survey',
+    'bun run guide',
+  ]);
+  expectContainsAll(readText(dir, 'CLAUDE.md'), [
+    '# CLAUDE.md',
+    'Compatibility Shim',
+    'Keep shared project guidance in `./AGENTS.md`.',
+    '@AGENTS.md',
+  ]);
 };
 
 const assertCliPackage = (dir: string): void => {
@@ -344,8 +373,13 @@ describe('trails create', () => {
     test('generates project structure with defaults', async () => {
       await withTempProject(async (dir) => {
         const result = expectOk(await runCreate(dir));
-        expectCreatedPaths(result.created, ['tsconfig.tests.json']);
+        expectCreatedPaths(result.created, [
+          'AGENTS.md',
+          'CLAUDE.md',
+          'tsconfig.tests.json',
+        ]);
         assertDefaultProjectFiles(dir);
+        assertAgentGuidance(dir);
         assertTsconfigTests(dir);
         assertCliPackage(dir);
         assertVerifyPackage(dir);
@@ -374,6 +408,8 @@ describe('trails create', () => {
         expect(dryRun.plannedOperations).toEqual(
           expect.arrayContaining([
             { kind: 'write', path: 'package.json' },
+            { kind: 'write', path: 'AGENTS.md' },
+            { kind: 'write', path: 'CLAUDE.md' },
             { kind: 'write', path: 'src/app.ts' },
             { kind: 'write', path: '.trails/.gitignore' },
             { kind: 'write', path: 'tsconfig.tests.json' },
@@ -398,6 +434,8 @@ describe('trails create', () => {
           dir,
           [
             'package.json',
+            'AGENTS.md',
+            'CLAUDE.md',
             'tsconfig.json',
             'tsconfig.tests.json',
             '.gitignore',
@@ -437,6 +475,7 @@ describe('trails create', () => {
       await withTempProject(async (dir) => {
         expectOk(await runCreate(dir, { verify: false }));
         assertVerifySkipped(dir);
+        assertAgentGuidance(dir);
         assertTsconfigTests(dir);
         assertGeneratedToolingDeps(dir);
         assertFrameworkCliScripts(dir);

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -133,6 +133,59 @@ const TSCONFIG_TESTS_CONTENT = JSON.stringify(
   2
 );
 
+const AGENTS_CONTENT = `# AGENTS.md
+
+This is a Trails project. Trails is an agent-native, contract-first TypeScript framework: author a trail once with typed input, Result output, examples, intent, and meta; surface it through CLI, MCP, HTTP, or future WebSocket without rewriting the contract.
+
+## Commands
+
+Use the project scripts first:
+
+\`\`\`bash
+bun install
+bun run build
+bun test
+bun run typecheck
+bun run lint
+bun run format:check
+bun run warden
+bun run survey
+bun run guide
+\`\`\`
+
+## Lexicon
+
+- \`trail\`, not action or handler
+- \`blaze\`, not handler or impl
+- \`topo\`, not registry or collection
+- \`cross\`, not follow
+- \`surface\`, not transport
+- \`resource\`, not service or dependency
+- \`layer\`, for cross-cutting trail wrapping
+
+## Trail Rules
+
+- Blazes return \`Result\`; never throw from trail logic.
+- Use \`Result.ok()\` and \`Result.err()\`; branch with \`isOk()\`, \`isErr()\`, or \`match()\`.
+- Keep trail logic surface-agnostic. Do not import CLI, MCP, HTTP, request, or response types into blazes.
+- Public MCP or HTTP trails declare an \`output\` schema.
+- Trails that compose other trails declare \`crosses: [...]\` and invoke them with \`ctx.cross(...)\`.
+- Trails that use infrastructure declare \`resources: [...]\` and access them through the resource helpers.
+- Use \`detours\` for recovery strategies instead of inline retry logic.
+- Prefer examples for happy-path coverage, and add focused tests for edge cases.
+`;
+
+const CLAUDE_CONTENT = `# CLAUDE.md
+
+## Compatibility Shim
+
+Keep shared project guidance in \`./AGENTS.md\`. Only Claude-specific bootstrap notes belong here.
+
+## Agent Instructions
+
+@AGENTS.md
+`;
+
 const GITIGNORE_CONTENT = `node_modules/
 dist/
 *.tsbuildinfo
@@ -363,6 +416,8 @@ const collectScaffoldFiles = (
 ): Map<string, string> =>
   new Map([
     ['package.json', generatePackageJson(name)],
+    ['AGENTS.md', AGENTS_CONTENT],
+    ['CLAUDE.md', CLAUDE_CONTENT],
     ['tsconfig.json', TSCONFIG_CONTENT],
     ['tsconfig.tests.json', TSCONFIG_TESTS_CONTENT],
     ['.gitignore', GITIGNORE_CONTENT],


### PR DESCRIPTION
## Context

TRL-777: generated Trails apps should carry enough project-local agent guidance that the next agent starts with the framework vocabulary and rules, not generic TypeScript defaults.

## Changes

- Generate a compact `AGENTS.md` with Trails commands, lexicon, and trail rules.
- Generate `CLAUDE.md` as a thin compatibility shim pointing to `@AGENTS.md`.
- Keep the WebSocket mention honest as `future WebSocket`.
- Assert generated `AGENTS.md` / `CLAUDE.md` content and public `created` output.
- Add a patch changeset for `@ontrails/trails`.

## Verification

- `bun test apps/trails/src/__tests__/create.test.ts`
- `bun --cwd apps/trails test`
- `bun run vocab:audit`
- `bun run check`
- `git diff --check main..trl-779-trails-create-scaffolds-readmemd-create-react-app-style`

## Notes

The `CLAUDE.md` shim is intentionally a real file rather than a symlink. `ProjectWriteOperation` only supports `mkdir`, `rename`, and `write`; adding symlink support would widen the scaffold write model for a compatibility pointer.

## Stack

Stacked on #578. Stacked above: #580.
