### PR TITLE
docs: document Bun runtime requirement

### DIFF
--- a/docs/releases/beta-channel-policy.md
+++ b/docs/releases/beta-channel-policy.md
@@ -3,6 +3,21 @@
 This policy applies while Trails remains in the `1.0.0-beta.N` prerelease
 line.
 
+## Runtime Requirement
+
+Trails requires Bun. The published `trails` CLI bin uses
+`#!/usr/bin/env bun`; Node-only invocation through `npx` or `node` is not
+supported.
+
+For direct package invocation before a project has been scaffolded, use Bun:
+
+```bash
+bunx --bun --package @ontrails/trails@beta trails <subcommand>
+```
+
+Scaffolded projects should prefer their generated package scripts, such as
+`bun run warden`, `bun run survey`, and `bun run topo`.
+
 ## Consumer Installs
 
 Use the beta channel deliberately:


### PR DESCRIPTION
## Context

TRL-792: beta-channel consumer docs need to be explicit that the current `@ontrails/trails` CLI is Bun-run, not Node-run.

## Changes

- Add a Runtime Requirement section to the beta channel policy.
- Document that the published `trails` bin uses `#!/usr/bin/env bun`.
- Point direct package invocation at `bunx --bun --package @ontrails/trails@beta trails <subcommand>`.
- Recommend scaffolded project scripts such as `bun run warden`, `bun run survey`, and `bun run topo`.

## Verification

- `bun run docs:links`
- `bun run format:check`
- `git diff --check main..trl-792-document-bun-runtime-requirement-for-consumers-beta-channel`

## Notes

Docs-only branch; no changeset.
