### PR TITLE
feat(warden): coach destructured ctx.cross usage

### DIFF
--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/GOAL.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/GOAL.md
@@ -1,0 +1,25 @@
+# Goal Prompt
+
+````text
+/goal
+cwd: /Users/mg/Developer/outfitter/trails
+packet: .agents/plans/2026-05-24-warden-as-coach-overnight-stack
+
+Objective: build as much of the Warden-as-Coach stack as can be safely cleared overnight, starting with TRL-791. Preserve Trails doctrine and vocabulary. Turn fieldwork learning into Warden guidance that steers agents/authors toward the happy path.
+
+Primary slice: TRL-791 on branch trl-791-warden-coach-against-destructured-ctxcross-new-reject-and. Add source-static warn rule no-destructured-cross. It must flag destructuring cross off the blaze context, including param destructuring ({ cross }, { cross: compose }) and body destructuring from the context identifier (const { cross } = ctx; const { cross: compose } = ctx). It must not flag direct ctx.cross(...), non-blaze code, or nested unrelated functions. Register the rule in Warden registries, metadata, trail wrapper exports, generated guide blocks, and add a patch changeset for @ontrails/warden.
+
+Stack order after TRL-791: TRL-793 only if diagnostic-only; TRL-785 before TRL-786; defer TRL-790 unless scaffold stack is landed or the edit set is isolated. Do not take TRL-784. Do not change public ctx.cross API or bridge destructured cross in implementation-returns-result.
+
+Loop: keep RETRO.md updated before each handoff; update Linear status/comments as branches/PRs move; use subagents for bounded review/research/coding tasks with exact file ownership; subagents must not run git/gt writes. Use Graphite for branch/commit/submit. Keep PRs draft until CI and local review are green.
+
+Validation: focused Warden tests first; run guide sync/check after metadata changes; run bun --cwd packages/warden test, bun run typecheck, bun run lint, bun run format:check, git diff --check, and bun run check before final handoff unless a blocker is logged. Run at least two local review lanes and fix all P0/P1/P2 before submit.
+
+Forbidden: no merge, no merge queue label, no publish/registry mutation, no destructive git commands, no unrelated scaffold edits, no undocumented divergence from Linear. Final proof must include branch/PR/status, changed artifacts, verification commands/results, local/remote review state, Linear updates, remaining risks, and forbidden-action audit.
+````
+
+## Completion Condition
+
+At minimum, `TRL-791` has a draft PR with CI green, Linear updated, local review clean or P3-only, generated Warden guides synced, and `RETRO.md` finalized for handoff.
+
+If additional slices are completed, each has its own branch/PR/Linear/retro evidence, and the stack order remains truthful.

--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/PLAN.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/PLAN.md
@@ -1,0 +1,122 @@
+# Warden-as-Coach Overnight Stack
+
+Date: 2026-05-24
+Owner: Lewis
+Branch root: `trl-791-warden-coach-against-destructured-ctxcross-new-reject-and`
+Tracker: Linear `TRL`, project `Fieldwork Loop`, milestone `Warden as Coach`
+
+## Objective
+
+Turn the Radio/Fieldwork learning into Warden guidance that keeps future Trails authors and agents on the happy path.
+
+The stack should favor small, reviewable slices:
+
+1. `TRL-791` - add a source-static Warden rule that coaches against destructuring `cross` off `ctx` inside blaze bodies.
+2. `TRL-793` - if time remains and the diff stays diagnostic-only, upgrade the 8 names-only Warden diagnostics to teach the fix.
+3. `TRL-785` - close the `implementation-returns-result` alias/provenance coverage gap from `TRL-333`.
+4. `TRL-786` - only after `TRL-785`, add redundant `Result.err(x.error)` re-wrap detection for provably safe cases.
+
+Do not take `TRL-790` in this first branch. The clean fix likely touches root lint/plugin config and scaffold-generated lint config, which overlaps the open scaffold stack. Revisit after the scaffold PRs land or intentionally stack it there.
+
+## Doctrine
+
+- Core premise: author what's new, derive what's known, override what's wrong.
+- Drift guard rung: Warden is the right layer for coaching canonical authored shapes that TypeScript cannot forbid cleanly.
+- Compound test: `ctx.cross(...)` is the runtime composition primitive; preserving the direct member-expression shape helps Warden recognize composed `Result` values and keeps composition visible to readers, docs, and future Ranger/fieldguide guidance.
+- Evaluation hierarchy: strengthen an existing primitive (`ctx.cross`) before broadening behavior or introducing aliases.
+- Vocabulary: say `trail`, `blaze`, `topo`, `cross`, `surface`, `resource`, `layer`. Do not call this a handler or middleware rule.
+
+## Current Tracker Truth
+
+`TRL-791` is Backlog at planning time. It already contains the OD-4 ruling: reject and coach, do not bridge destructured `cross` in `implementation-returns-result`.
+
+`TRL-793` is Backlog. Clark filed it from the Warden diagnostic-language audit. It is low risk only if limited to diagnostic strings and tests for names-only offenders.
+
+`TRL-785` is Backlog. Clark/Hume found it overlaps done issue `TRL-333`; current scope is a coverage-gap follow-up, not a fresh imported-helper implementation.
+
+`TRL-786` is Backlog. Do not implement before `TRL-785` creates enough provenance to avoid noisy syntactic false positives.
+
+## TRL-791 Acceptance Criteria
+
+- New rule id: `no-destructured-cross`.
+- Severity: `warn`.
+- Metadata: concern `composition`, tier `source-static`, scope `external`, lifecycle durable.
+- Flags both canonical shadow patterns inside trail blaze bodies:
+  - parameter destructuring: `blaze: async (input, { cross }) => ...`
+  - body destructuring from the context parameter: `const { cross } = ctx;`
+- Flags aliases too: `const { cross: compose } = ctx` and `({ cross: compose })`.
+- Stays quiet for direct `ctx.cross(...)`.
+- Stays quiet for non-blaze code and nested callbacks/functions unrelated to the blaze's context parameter.
+- Registers in `wardenRules`, `registry-names`, metadata, and Warden trail wrappers.
+- Regenerates Warden guide blocks with repo scripts.
+- Includes a patch changeset for `@ontrails/warden`.
+
+## Likely TRL-791 Edit Set
+
+- `packages/warden/src/rules/no-destructured-cross.ts`
+- `packages/warden/src/__tests__/no-destructured-cross.test.ts`
+- `packages/warden/src/rules/index.ts`
+- `packages/warden/src/rules/registry-names.ts`
+- `packages/warden/src/rules/metadata.ts`
+- `packages/warden/src/trails/no-destructured-cross.trail.ts`
+- `packages/warden/src/trails/index.ts`
+- `AGENTS.md`
+- `.claude/skills/clark/references/warden-guide.md`
+- `plugin/skills/trails/references/warden-guide.md`
+- `.changeset/<slug>.md`
+- This packet's `RETRO.md`
+
+## Validation Ladder
+
+Focused:
+
+```bash
+bun test packages/warden/src/__tests__/no-destructured-cross.test.ts
+bun test packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/guide.test.ts packages/warden/src/__tests__/warden-export-symmetry.test.ts
+bun run warden:agents:check
+bun run warden:skills:check
+```
+
+Branch:
+
+```bash
+bun --cwd packages/warden test
+bun run typecheck
+bun run lint
+bun run format:check
+git diff --check
+```
+
+Before PR handoff:
+
+```bash
+bun run check
+```
+
+## Review Protocol
+
+Use at least two local review lanes before submit:
+
+- Warden implementation/test lane: AST scope, false positives, registration, guide sync.
+- Doctrine/vocabulary lane: diagnostic teaches the fix and preserves `ctx.cross(...)` as canonical.
+
+If the first review pass finds P0/P1/P2, fix before submit. P3 can remain only if logged in `RETRO.md`.
+
+## Source Control
+
+- Use Graphite.
+- No merge.
+- No merge queue label.
+- No publish or registry mutation.
+- Subagents may inspect, test, and edit bounded files if delegated, but must not run git/gt write commands.
+- Keep PR draft until local review and CI are green.
+
+## Stop Rules
+
+Stop and ask Matt if:
+
+- The fix requires changing public `ctx.cross` typing or `implementation-returns-result` recognition semantics beyond adding the coaching rule.
+- `TRL-793` stops being diagnostic-only.
+- `TRL-785` requires a broad imported-module resolver rewrite.
+- `TRL-786` cannot prove re-wrap redundancy without noisy false positives.
+- Remote review finds a doctrine conflict rather than an implementation bug.

--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/REFS.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/REFS.md
@@ -1,0 +1,70 @@
+# References
+
+## Constitutional Sources
+
+- `docs/adr/0000-core-premise.md` - author what's new, derive what's known, override what's wrong.
+- `docs/tenets.md` - `cross()` / `crosses` as first-class composition, drift guard, compound value.
+- `docs/lexicon.md` - `cross` / `crosses`, `trail`, `blaze`, `topo`, `surface`, `resource`, `layer`.
+- `AGENTS.md` - Warden guide, Graphite workflow, subagent constraints.
+- `.agents/plans/PLANNING.md` - goal packet and retro discipline.
+
+## Tracker
+
+- `TRL-791` - Warden coach against destructured `ctx.cross`; OD-4 reject-and-coach ruling.
+- `TRL-793` - upgrade names-only diagnostics to teach the fix.
+- `TRL-785` - `implementation-returns-result` helper provenance coverage gap after `TRL-333`.
+- `TRL-786` - redundant `Result.err(x.error)` re-wrap detection, blocked on safer provenance.
+- `TRL-790` - fieldwork marker lint; defer due scaffold/lint config overlap.
+
+## Warden Implementation Anchors
+
+- `packages/warden/src/rules/implementation-returns-result.ts`
+  - Existing direct `ctx.cross` member-expression recognition lives in `isResultMemberCall`.
+  - Diagnostic style is trail-id anchored.
+- `packages/warden/src/rules/cross-declarations.ts`
+  - Existing cross extraction recognizes both member calls and destructured bare `cross(...)`, but TRL-791 should coach destructuring away rather than extend this tolerated shape.
+- `packages/warden/src/rules/no-direct-implementation-call.ts`
+  - Small source-static rule pattern and good teaching diagnostic model.
+- `packages/warden/src/rules/ast.ts`
+  - `findTrailDefinitions`, `findBlazeBodies`, `identifierName`, `offsetToLine`, `walkScope`, `walkWithScopes`.
+- `packages/warden/src/rules/metadata.ts`
+  - Built-in rule metadata and concern/tier defaults.
+- `packages/warden/src/rules/registry-names.ts`
+  - Snapshot used by `warden-export-symmetry`.
+- `packages/warden/src/trails/no-direct-implementation-call.trail.ts`
+  - Wrapper model for the new rule trail.
+
+## Audit Summary Imported From Trailblazing
+
+Clark's audit note lives outside this repo at:
+
+`/Users/mg/Developer/outfitter/trailblazing/plans/fieldwork-loop/warden-diagnostic-audit-20260523.md`
+
+Load-bearing summary copied here so the tracked packet does not depend on that external file:
+
+- 56 Warden rules audited.
+- 24 teach the fix, 13 partially teach, 8 are names-only, 11 were skipped as internal/repo-local/dynamic.
+- Highest-priority names-only offender is `implementation-returns-result`, because Radio showed the diagnostic can lead agents to cargo-cult `Result.err(x.error)` re-wraps.
+- `TRL-791` is the model for a good teaching diagnostic: name the violation, name the cost, and point at the canonical authoring shape.
+- `TRL-793` should start with names-only diagnostic strings and tests, not rule-logic changes.
+
+## Subagent Findings Imported Into Packet
+
+Gibbs on `TRL-791`:
+
+- Recommended rule id `no-destructured-cross`.
+- Register in rule index, metadata, registry-name snapshot, trail wrapper, and generated guides.
+- Detect parameter destructuring and body destructuring from the blaze context parameter.
+- Use a warning diagnostic that teaches direct `ctx.cross(...)`.
+
+Hume on `TRL-785` / `TRL-786`:
+
+- Current Warden already supports many imported Result helpers from `TRL-333`.
+- Current gap includes `Result as ResultType` aliases; helper facts are still name-heavy rather than provenance-rich.
+- Do `TRL-785` before `TRL-786`; a syntactic re-wrap rule would be too noisy.
+
+Boyle on `TRL-790`:
+
+- Native Oxlint config lacks a clean allowlist for `TODO[trails-*]`.
+- A clean fix likely requires custom lint rule/plugin behavior and possibly generated scaffold lint config.
+- Defer or stack intentionally on the scaffold branch; do not branch from main as a casual sidecar.

--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/RETRO.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/RETRO.md
@@ -1,0 +1,98 @@
+# Warden-as-Coach Overnight Stack Retro
+
+Date: 2026-05-24
+Owner: Lewis
+
+## Current State
+
+| Item | State | Notes |
+|---|---|---|
+| `TRL-791` | Draft PR, CI green | PR #582; branch root: `trl-791-warden-coach-against-destructured-ctxcross-new-reject-and`. |
+| `TRL-793` | Candidate next | Only take if diagnostic-only. |
+| `TRL-785` | Candidate later | Must precede `TRL-786`; overlaps `TRL-333`. |
+| `TRL-786` | Deferred until provenance | Do not implement syntactically. |
+| `TRL-790` | Deferred | Likely scaffold/lint config overlap. |
+
+## Discoveries
+
+- 2026-05-24 00:13 EDT - Clark and subagent findings converge on Warden-as-Coach order: `TRL-791` first; `TRL-793` if diagnostic-only; `TRL-785` before `TRL-786`; defer `TRL-790`.
+- 2026-05-24 00:13 EDT - `TRL-785` is a coverage-gap follow-up to done `TRL-333`, not a fresh imported-helper implementation.
+- 2026-05-24 00:13 EDT - Native Oxlint config cannot cleanly whitelist `TODO[trails-*]`; `TRL-790` likely needs plugin/custom-rule work and may overlap scaffold output.
+
+## Tracker Mutations
+
+| Time | Issue | Change |
+|---|---|---|
+| 2026-05-24 00:15 EDT | `TRL-791` | Moved to In Progress. |
+| 2026-05-24 00:15 EDT | `TRL-791` | Commented with branch, packet path, and scope note. |
+| 2026-05-24 00:30 EDT | `TRL-791` | Moved to In Review and attached draft PR #582. |
+| 2026-05-24 00:30 EDT | `TRL-791` | Commented with verification plus diagnostic-divergence note. |
+
+## Execution Log
+
+| Time | Event |
+|---|---|
+| 2026-05-24 00:13 EDT | Created active goal packet under `.agents/plans/2026-05-24-warden-as-coach-overnight-stack/`. |
+| 2026-05-24 00:13 EDT | Checked out `main` and created Graphite branch `trl-791-warden-coach-against-destructured-ctxcross-new-reject-and`. |
+| 2026-05-24 00:18 EDT | Implemented `no-destructured-cross`, registered metadata/exports/trail wrapper, added tests and a changeset. |
+| 2026-05-24 00:18 EDT | Updated the framework `create` trail to use `ctx.cross(...)` directly instead of destructuring `cross`. |
+| 2026-05-24 00:18 EDT | Regenerated Warden guide blocks in `AGENTS.md`, Clark's Warden guide reference, and the Trails plugin guide reference. |
+| 2026-05-24 00:32 EDT | Softened `no-destructured-cross` diagnostic after doctrine review: removed the absolute LSP/type-overload claim and kept the grounded Warden/result-recognition cost. |
+| 2026-05-24 00:34 EDT | Added assignment destructuring detection for `({ cross } = ctx)` after implementation review found it as a bypass. |
+| 2026-05-24 00:31 EDT | Submitted draft PR #582. |
+| 2026-05-24 00:32 EDT | Fixed Changeset CI failure by adding `@ontrails/trails` to the changeset; the framework `create` trail cleanup touches a publishable package too. |
+
+## Verification Log
+
+| Command | Result | Notes |
+|---|---|---|
+| `bun test packages/warden/src/__tests__/no-destructured-cross.test.ts` | pass | Initial focused rule run: 9 tests. |
+| `bun test packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/guide.test.ts packages/warden/src/__tests__/warden-export-symmetry.test.ts` | pass | 28 tests. |
+| `bun run warden:agents:sync` | pass | Regenerated `AGENTS.md`. |
+| `bun run warden:skills:sync` | pass | Regenerated Clark + plugin Warden guide references. |
+| `bun run warden:agents:check` | pass | Generated block in sync. |
+| `bun run warden:skills:check` | pass | Generated skill guides in sync. |
+| `bun --cwd packages/warden test` | failed, fixed | First run failed only because `trails.test.ts` still expected 56 rule trails; updated to 57. |
+| `bun run typecheck` | failed, fixed | First run caught a narrow `property.key` AST type mismatch in the new rule; fixed with an explicit cast. |
+| `bun run format:check` | failed, fixed | First run found formatting drift in `create.ts` and the new rule test. |
+| `bun run format:fix` | pass | Applied formatter and cleared Ultracite's `prefer-destructuring` complaint. |
+| `bun --cwd packages/warden test` | pass | 926 tests, 0 fail after updating rule trail count. |
+| `bun run typecheck` | failed, fixed | Second run exposed optional `ctx.cross` narrowing in `apps/trails/src/trails/create.ts`; added `hasCross` type guard so direct `ctx.cross(...)` remains type-safe. |
+| `bun test apps/trails/src/__tests__/create.test.ts` | pass | 15 tests, 0 fail after `ctx.cross` cleanup. |
+| `bun run typecheck` | pass | 22 packages. |
+| `bun run format:check` | pass | All matched files formatted; Ultracite 0 warnings/errors. |
+| `bun run lint` | pass | 23 tasks, 0 warnings/errors. |
+| `git diff --check` | pass | No whitespace errors. |
+| `bun test packages/warden/src/__tests__/no-destructured-cross.test.ts` | pass | Final focused rule run after review fixes: 12 tests, 0 fail. |
+| `bun --cwd packages/warden test` | pass | Final package run: 929 tests, 0 fail. |
+| `bun run format:check` | pass | Final format/Ultracite run: 0 warnings/errors. |
+| `bun run lint` | pass | Final repo lint: 23 tasks, 0 warnings/errors. |
+| `git diff --check` | pass | Final whitespace check. |
+| `bun run check` | pass | Full repo gate passed; Warden emitted only the known pre-existing warning set. |
+| `gh api --paginate repos/outfitter-dev/trails/pulls/582/files --jq '.[].filename' \| bun run changeset:check -- --changed-files /dev/stdin` | pass | Reproduced the Changeset gate locally after adding `@ontrails/trails`. |
+
+## Local Review Log
+
+| Pass | Result | Findings | Action |
+|---|---|---|---|
+| 2026-05-24 00:26 EDT | Implementation/registration review dispatched to Nash | pending | Review only; no git/gt writes. |
+| 2026-05-24 00:26 EDT | Doctrine/diagnostic review dispatched to McClintock | 4/5 | One P2: diagnostic overclaimed that destructuring breaks LSP typed-overload narrowing. Fixed by softening to visible composition + Warden Result recognition. |
+| 2026-05-24 00:34 EDT | Implementation/registration review returned from Nash | 4/5 | One P2: assignment destructuring bypass. Fixed by adding `AssignmentExpression` detection and tests. |
+
+## Remote Review / CI Log
+
+| PR | State | CI | Review |
+|---|---|---|---|
+| #582 | Draft, open | Green on amended run: Build, Lint & Format, Dead Code, Typecheck, Test, Governance, Changeset, CI Gate. | No reviews posted yet. |
+
+## Forbidden-Action Audit
+
+- Merge: not performed.
+- Merge queue label: not applied.
+- Publish/registry mutation: not performed.
+- Destructive git commands: not performed.
+- Subagent git/gt writes: not performed.
+
+## Final State
+
+Draft PR #582 is open and CI green. No merge, merge queue, or publish action performed.

--- a/.changeset/warden-destructured-cross.md
+++ b/.changeset/warden-destructured-cross.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/warden": patch
+"@ontrails/trails": patch
+---
+
+Add a Warden rule that coaches trail blazes to call `ctx.cross(...)` directly instead of destructuring `cross` from the context.
+
+Keep the generated `create` trail on the direct `ctx.cross(...)` shape so framework-authored trails follow the same composition guidance.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 56
+- Rule count: 57
 
 ## Agent Instructions
 
@@ -24,6 +24,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `dead-internal-trail` (warn, project/project-static, external): Internal trails should be reachable through declared crosses.
 - `intent-propagation` (warn, project/project-static, external): Composite trail intent cannot be safer than crossed trails.
 - `missing-visibility` (warn, project/project-static, external): Composition-only trails declare internal visibility.
+- `no-destructured-cross` (warn, source/source-static, external): Trail blazes compose through ctx.cross() directly instead of destructuring cross from the context.
 - `no-direct-implementation-call` (warn, source/source-static, external): Application code composes trails through ctx.cross().
 - `resolved-import-boundary` (error, project/project-static, external): Cross-package imports resolve through public export maps.
 - `version-pinned-cross` (warn, source/source-static, external): Version-pinned ctx.cross() calls stay visible migration debt.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Use the project language consistently:
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
-- Rule count: 56
+- Rule count: 57
 
 ### Rule Index
 
@@ -98,6 +98,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `dead-internal-trail` (warn, project/project-static, external): Internal trails should be reachable through declared crosses.
 - `intent-propagation` (warn, project/project-static, external): Composite trail intent cannot be safer than crossed trails.
 - `missing-visibility` (warn, project/project-static, external): Composition-only trails declare internal visibility.
+- `no-destructured-cross` (warn, source/source-static, external): Trail blazes compose through ctx.cross() directly instead of destructuring cross from the context.
 - `no-direct-implementation-call` (warn, source/source-static, external): Application code composes trails through ctx.cross().
 - `resolved-import-boundary` (error, project/project-static, external): Cross-package imports resolve through public export maps.
 - `version-pinned-cross` (warn, source/source-static, external): Version-pinned ctx.cross() calls stay visible migration debt.

--- a/apps/trails/src/trails/create.ts
+++ b/apps/trails/src/trails/create.ts
@@ -6,6 +6,7 @@
  */
 
 import { InternalError, Result, trail } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
 import {
@@ -51,6 +52,13 @@ interface SurfaceResult {
   readonly created: string;
   readonly dependency: string;
 }
+
+type TrailContextWithCross = TrailContext & {
+  readonly cross: NonNullable<TrailContext['cross']>;
+};
+
+const hasCross = (ctx: TrailContext): ctx is TrailContextWithCross =>
+  Boolean(ctx.cross);
 
 const buildScaffoldInput = (input: ScaffoldRequest) => ({
   ...(input.dir === undefined ? {} : { dir: input.dir }),
@@ -179,12 +187,11 @@ const writeReadme = async (
 
 export const createTrail = trail('create', {
   blaze: async (input: CreateInput, ctx) => {
-    if (!ctx.cross) {
+    if (!hasCross(ctx)) {
       return Result.err(new InternalError('create trail requires ctx.cross'));
     }
-    const { cross } = ctx;
 
-    const scaffolded = await cross<ScaffoldedProject>(
+    const scaffolded = await ctx.cross<ScaffoldedProject>(
       'create.scaffold',
       buildScaffoldInput(input)
     );
@@ -198,7 +205,7 @@ export const createTrail = trail('create', {
       const surfaceFiles = await collectSurfaceFiles(
         input.surfaces,
         (surface) =>
-          cross<SurfaceResult>(
+          ctx.cross<SurfaceResult>(
             'add.surface',
             buildSurfaceInput(scaffolded.value.dir, surface)
           )
@@ -208,7 +215,7 @@ export const createTrail = trail('create', {
       }
 
       const verifyFiles = await collectVerifyFiles(input.verify, () =>
-        cross<{ created: string[] }>('add.verify', buildVerifyInput(input))
+        ctx.cross<{ created: string[] }>('add.verify', buildVerifyInput(input))
       );
       if (verifyFiles.isErr()) {
         return Result.err(verifyFiles.error);

--- a/packages/warden/src/__tests__/no-destructured-cross.test.ts
+++ b/packages/warden/src/__tests__/no-destructured-cross.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test } from 'bun:test';
+
+import { noDestructuredCross } from '../rules/no-destructured-cross.js';
+
+describe('no-destructured-cross', () => {
+  test('flags body destructuring from the blaze context', () => {
+    const code = `
+import { trail, Result } from '@ontrails/core';
+
+export const onboard = trail('entity.onboard', {
+  crosses: ['entity.create'],
+  blaze: async (input, ctx) => {
+    const { cross } = ctx;
+    return cross('entity.create', input);
+  },
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/trails/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('no-destructured-cross');
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toContain('Use ctx.cross(...) directly');
+    expect(diagnostics[0]?.message).toContain('Warden can recognize');
+  });
+
+  test('flags aliased body destructuring from the blaze context', () => {
+    const code = `
+trail('entity.onboard', {
+  crosses: ['entity.create'],
+  blaze: async (input, ctx) => {
+    const { cross: compose } = ctx;
+    return compose('entity.create', input);
+  },
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/trails/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('entity.onboard');
+  });
+
+  test('flags assignment destructuring from the blaze context', () => {
+    const code = `
+trail('entity.onboard', {
+  crosses: ['entity.create'],
+  blaze: async (input, ctx) => {
+    let cross;
+    ({ cross } = ctx);
+    return cross('entity.create', input);
+  },
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/trails/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('ctx.cross');
+  });
+
+  test('flags aliased assignment destructuring from the blaze context', () => {
+    const code = `
+trail('entity.onboard', {
+  crosses: ['entity.create'],
+  blaze: async (input, ctx) => {
+    let compose;
+    ({ cross: compose } = ctx);
+    return compose('entity.create', input);
+  },
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/trails/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('flags parameter destructuring from the blaze context', () => {
+    const code = `
+trail('entity.onboard', {
+  crosses: ['entity.create'],
+  blaze: async (input, { cross }) => cross('entity.create', input),
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/trails/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('composition stays visible');
+  });
+
+  test('flags aliased parameter destructuring from the blaze context', () => {
+    const code = `
+trail('entity.onboard', {
+  crosses: ['entity.create'],
+  blaze: async (input, { cross: compose }) =>
+    compose('entity.create', input),
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/trails/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('allows direct ctx.cross calls', () => {
+    const code = `
+trail('entity.onboard', {
+  crosses: ['entity.create'],
+  blaze: async (input, ctx) => {
+    return ctx.cross('entity.create', input);
+  },
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/trails/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('ignores destructuring outside trail blazes', () => {
+    const code = `
+function run(ctx) {
+  const { cross } = ctx;
+  return cross('entity.create', {});
+}
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/routes/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('ignores nested functions that destructure unrelated values', () => {
+    const code = `
+trail('entity.onboard', {
+  crosses: ['entity.create'],
+  blaze: async (input, ctx) => {
+    const helper = (other) => {
+      const { cross } = other;
+      return cross;
+    };
+    return ctx.cross('entity.create', input);
+  },
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/trails/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('ignores destructuring from a shadowed context name', () => {
+    const code = `
+trail('entity.onboard', {
+  crosses: ['entity.create'],
+  blaze: async (input, ctx) => {
+    {
+      const ctx = { cross: () => null };
+      const { cross } = ctx;
+      cross();
+    }
+    return ctx.cross('entity.create', input);
+  },
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/trails/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('ignores assignment destructuring from a shadowed context name', () => {
+    const code = `
+trail('entity.onboard', {
+  crosses: ['entity.create'],
+  blaze: async (input, ctx) => {
+    {
+      const ctx = { cross: () => null };
+      let cross;
+      ({ cross } = ctx);
+      cross();
+    }
+    return ctx.cross('entity.create', input);
+  },
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/trails/onboard.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('ignores test files', () => {
+    const code = `
+trail('entity.onboard', {
+  blaze: async (input, ctx) => {
+    const { cross } = ctx;
+    return cross('entity.create', input);
+  },
+});
+`;
+
+    const diagnostics = noDestructuredCross.check(
+      code,
+      'src/__tests__/onboard.test.ts'
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -8,8 +8,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 56 rule trails', () => {
-    expect(wardenTopo.count).toBe(56);
+  test('contains all 57 rule trails', () => {
+    expect(wardenTopo.count).toBe(57);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -164,6 +164,7 @@ export {
   missingVisibilityTrail,
   missingReconcileTrail,
   noDevPermitInSourceTrail,
+  noDestructuredCrossTrail,
   noDirectImplementationCallTrail,
   noLegacyLayerImportsTrail,
   noNativeErrorResultTrail,

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -1100,7 +1100,7 @@ export const walkWithScopes = (
   walkNode(root, true);
 };
 
-const isShadowed = (
+export const isShadowed = (
   receiverName: string,
   scopeStack: readonly ReadonlySet<string>[]
 ): boolean => {

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -17,6 +17,7 @@ import { layerFieldNameDrift } from './layer-field-name-drift.js';
 import { missingVisibility } from './missing-visibility.js';
 import { missingReconcile } from './missing-reconcile.js';
 import { noDevPermitInSource } from './no-dev-permit-in-source.js';
+import { noDestructuredCross } from './no-destructured-cross.js';
 import { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noNativeErrorResult } from './no-native-error-result.js';
@@ -108,6 +109,7 @@ export { missingVisibility } from './missing-visibility.js';
 export { missingReconcile } from './missing-reconcile.js';
 export { onReferencesExist } from './on-references-exist.js';
 export { noDevPermitInSource } from './no-dev-permit-in-source.js';
+export { noDestructuredCross } from './no-destructured-cross.js';
 export { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 export { noDirectImplementationCall } from './no-direct-implementation-call.js';
 export { noNativeErrorResult } from './no-native-error-result.js';
@@ -182,6 +184,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [staticResourceAccessorPreference.name, staticResourceAccessorPreference],
   [validDescribeRefs.name, validDescribeRefs],
   [noDevPermitInSource.name, noDevPermitInSource],
+  [noDestructuredCross.name, noDestructuredCross],
   [noDirectImplementationCall.name, noDirectImplementationCall],
   [noLegacyLayerImports.name, noLegacyLayerImports],
   [noNativeErrorResult.name, noNativeErrorResult],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -71,6 +71,7 @@ const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'marker-schema-unsupported': 'lifecycle',
   'missing-reconcile': 'resources',
   'missing-visibility': 'composition',
+  'no-destructured-cross': 'composition',
   'no-dev-permit-in-source': 'permits',
   'no-direct-implementation-call': 'composition',
   'no-native-error-result': 'results',
@@ -240,6 +241,12 @@ const builtinWardenRuleMetadataInput = {
     ...durableExternal,
     invariant: 'Composition-only trails declare internal visibility.',
     tier: 'project-static',
+  },
+  'no-destructured-cross': {
+    ...durableExternal,
+    invariant:
+      'Trail blazes compose through ctx.cross() directly instead of destructuring cross from the context.',
+    tier: 'source-static',
   },
   'no-dev-permit-in-source': {
     ...durableExternal,

--- a/packages/warden/src/rules/no-destructured-cross.ts
+++ b/packages/warden/src/rules/no-destructured-cross.ts
@@ -1,0 +1,189 @@
+import {
+  findBlazeBodies,
+  findTrailDefinitions,
+  getStringValue,
+  identifierName,
+  isShadowed,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+  walkWithScopes,
+} from './ast.js';
+import { isFrameworkInternalFile, isTestFile } from './scan.js';
+import type { AstNode } from './ast.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'no-destructured-cross';
+
+const diagnosticMessage = (trailId: string): string =>
+  `Trail "${trailId}" destructures cross from the blaze context. Use ctx.cross(...) directly so composition stays visible and Warden can recognize composed Result values.`;
+
+const propertyKeyName = (property: AstNode): string | null => {
+  if ((property as unknown as { computed?: boolean }).computed === true) {
+    return null;
+  }
+
+  const key = property.key as AstNode | undefined;
+  if (!key) {
+    return null;
+  }
+
+  return (
+    identifierName(key) ?? (isStringLiteral(key) ? getStringValue(key) : null)
+  );
+};
+
+const findCrossBinding = (pattern: AstNode | undefined): AstNode | null => {
+  if (pattern?.type !== 'ObjectPattern') {
+    return null;
+  }
+
+  const properties =
+    (pattern as unknown as { properties?: readonly AstNode[] }).properties ??
+    [];
+
+  for (const property of properties) {
+    if (property.type === 'Property' && propertyKeyName(property) === 'cross') {
+      return property;
+    }
+  }
+
+  return null;
+};
+
+const blazeParams = (blaze: AstNode): readonly AstNode[] =>
+  (blaze as unknown as { params?: readonly AstNode[] }).params ?? [];
+
+const destructuredCrossFromVariableDeclarator = (
+  node: AstNode,
+  contextName: string
+): AstNode | null => {
+  if (node.type !== 'VariableDeclarator') {
+    return null;
+  }
+
+  const { id, init } = node as unknown as {
+    readonly id?: AstNode;
+    readonly init?: AstNode;
+  };
+
+  if (identifierName(init) !== contextName) {
+    return null;
+  }
+
+  return findCrossBinding(id);
+};
+
+const destructuredCrossFromAssignment = (
+  node: AstNode,
+  contextName: string
+): AstNode | null => {
+  if (node.type !== 'AssignmentExpression') {
+    return null;
+  }
+
+  const { left, operator, right } = node as unknown as {
+    readonly left?: AstNode;
+    readonly operator?: string;
+    readonly right?: AstNode;
+  };
+
+  if (operator !== '=' || identifierName(right) !== contextName) {
+    return null;
+  }
+
+  return findCrossBinding(left);
+};
+
+const checkBodyDestructuring = (
+  sourceCode: string,
+  filePath: string,
+  trailId: string,
+  blaze: AstNode,
+  contextName: string
+): WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+
+  walkWithScopes(
+    blaze,
+    (node, scopes) => {
+      if (isShadowed(contextName, scopes)) {
+        return;
+      }
+
+      const crossBinding =
+        destructuredCrossFromVariableDeclarator(node, contextName) ??
+        destructuredCrossFromAssignment(node, contextName);
+      if (!crossBinding) {
+        return;
+      }
+
+      diagnostics.push({
+        filePath,
+        line: offsetToLine(sourceCode, crossBinding.start),
+        message: diagnosticMessage(trailId),
+        rule: RULE_NAME,
+        severity: 'warn',
+      });
+    },
+    { stopAtNestedFunctions: true }
+  );
+
+  return diagnostics;
+};
+
+export const noDestructuredCross: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isTestFile(filePath) || isFrameworkInternalFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const diagnostics: WardenDiagnostic[] = [];
+
+    for (const definition of findTrailDefinitions(ast)) {
+      if (definition.kind !== 'trail') {
+        continue;
+      }
+
+      for (const blaze of findBlazeBodies(definition.config)) {
+        const params = blazeParams(blaze);
+        const [, contextParam] = params;
+        const paramCrossBinding = findCrossBinding(contextParam);
+
+        if (paramCrossBinding) {
+          diagnostics.push({
+            filePath,
+            line: offsetToLine(sourceCode, paramCrossBinding.start),
+            message: diagnosticMessage(definition.id),
+            rule: RULE_NAME,
+            severity: 'warn',
+          });
+        }
+
+        const contextName = identifierName(contextParam);
+        if (contextName) {
+          diagnostics.push(
+            ...checkBodyDestructuring(
+              sourceCode,
+              filePath,
+              definition.id,
+              blaze,
+              contextName
+            )
+          );
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+  description:
+    'Coach trail blazes to compose with ctx.cross(...) directly instead of destructuring cross from the context.',
+  name: RULE_NAME,
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -25,6 +25,7 @@ import { layerFieldNameDrift } from './layer-field-name-drift.js';
 import { missingReconcile } from './missing-reconcile.js';
 import { missingVisibility } from './missing-visibility.js';
 import { noDevPermitInSource } from './no-dev-permit-in-source.js';
+import { noDestructuredCross } from './no-destructured-cross.js';
 import { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noNativeErrorResult } from './no-native-error-result.js';
@@ -95,6 +96,7 @@ export const registeredRuleNames: readonly string[] = [
   missingReconcile.name,
   missingVisibility.name,
   noDevPermitInSource.name,
+  noDestructuredCross.name,
   noLegacyLayerImports.name,
   noDirectImplementationCall.name,
   noNativeErrorResult.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -21,6 +21,7 @@ export { missingVisibilityTrail } from './missing-visibility.trail.js';
 export { missingReconcileTrail } from './missing-reconcile.trail.js';
 export { onReferencesExistTrail } from './on-references-exist.trail.js';
 export { noDevPermitInSourceTrail } from './no-dev-permit-in-source.trail.js';
+export { noDestructuredCrossTrail } from './no-destructured-cross.trail.js';
 export { noLegacyLayerImportsTrail } from './no-legacy-layer-imports.trail.js';
 export { noDirectImplementationCallTrail } from './no-direct-implementation-call.trail.js';
 export { noNativeErrorResultTrail } from './no-native-error-result.trail.js';

--- a/packages/warden/src/trails/no-destructured-cross.trail.ts
+++ b/packages/warden/src/trails/no-destructured-cross.trail.ts
@@ -1,0 +1,44 @@
+import { noDestructuredCross } from '../rules/no-destructured-cross.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const noDestructuredCrossTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'clean.ts',
+        sourceCode: `trail("entity.onboard", {
+  crosses: ["entity.create"],
+  blaze: async (input, ctx) => ctx.cross("entity.create", input),
+});`,
+      },
+      name: 'Clean blaze using ctx.cross directly',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'destructured.ts',
+            line: 4,
+            message:
+              'Trail "entity.onboard" destructures cross from the blaze context. Use ctx.cross(...) directly so composition stays visible and Warden can recognize composed Result values.',
+            rule: 'no-destructured-cross',
+            severity: 'warn',
+          },
+        ],
+      },
+      input: {
+        filePath: 'destructured.ts',
+        sourceCode: `trail("entity.onboard", {
+  crosses: ["entity.create"],
+  blaze: async (input, ctx) => {
+    const { cross } = ctx;
+    return cross("entity.create", input);
+  },
+});`,
+      },
+      name: 'Warns when cross is destructured from the blaze context',
+    },
+  ],
+  rule: noDestructuredCross,
+});

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 56
+- Rule count: 57
 
 ## Agent Instructions
 
@@ -24,6 +24,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `dead-internal-trail` (warn, project/project-static, external): Internal trails should be reachable through declared crosses.
 - `intent-propagation` (warn, project/project-static, external): Composite trail intent cannot be safer than crossed trails.
 - `missing-visibility` (warn, project/project-static, external): Composition-only trails declare internal visibility.
+- `no-destructured-cross` (warn, source/source-static, external): Trail blazes compose through ctx.cross() directly instead of destructuring cross from the context.
 - `no-direct-implementation-call` (warn, source/source-static, external): Application code composes trails through ctx.cross().
 - `resolved-import-boundary` (error, project/project-static, external): Cross-package imports resolve through public export maps.
 - `version-pinned-cross` (warn, source/source-static, external): Version-pinned ctx.cross() calls stay visible migration debt.


### PR DESCRIPTION
## Context

TRL-791 turns the Radio/OD-4 `ctx.cross` destructuring lesson into Warden coaching. Direct `ctx.cross(...)` keeps composition visible and lets existing Warden rules recognize composed `Result` values; bare `cross(...)` makes that provenance harder to see.

## What changed

- Added `no-destructured-cross` as a warning-level Warden source rule.
- Covered parameter destructuring, variable destructuring, aliasing, and assignment destructuring from the blaze context.
- Registered the rule metadata, trail wrapper, public exports, and generated guide blocks.
- Updated the framework `create` trail to use direct `ctx.cross(...)` with an explicit type guard.
- Added a patch changeset for `@ontrails/warden` and `@ontrails/trails`.

## How to test

- `bun test packages/warden/src/__tests__/no-destructured-cross.test.ts`
- `bun --cwd packages/warden test`
- `bun run format:check`
- `bun run lint`
- `git diff --check`
- `bun run check`
- `gh api --paginate repos/outfitter-dev/trails/pulls/582/files --jq '.[].filename' | bun run changeset:check -- --changed-files /dev/stdin`

## Notes

The diagnostic intentionally avoids the earlier stronger LSP/type-overload claim. The grounded doctrine here is visibility: composition should remain recognizable as `ctx.cross(...)`, and Warden should be able to follow composed `Result` values.

Linear: TRL-791
