### PR TITLE
fix(warden): teach names-only diagnostics

### DIFF
--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/GOAL.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/GOAL.md
@@ -1,25 +1,25 @@
-# Goal Prompt
+# Goal Prompt: Warden As Coach Overnight Stack
 
-````text
-/goal
-cwd: /Users/mg/Developer/outfitter/trails
-packet: .agents/plans/2026-05-24-warden-as-coach-overnight-stack
+Paste this into the goal runtime:
 
-Objective: build as much of the Warden-as-Coach stack as can be safely cleared overnight, starting with TRL-791. Preserve Trails doctrine and vocabulary. Turn fieldwork learning into Warden guidance that steers agents/authors toward the happy path.
+````markdown
+/goal From `/Users/mg/Developer/outfitter/trails`, execute `.agents/plans/2026-05-24-warden-as-coach-overnight-stack/PLAN.md` end to end; use `.agents/plans/2026-05-24-warden-as-coach-overnight-stack/RETRO.md` as the durable ledger.
 
-Primary slice: TRL-791 on branch trl-791-warden-coach-against-destructured-ctxcross-new-reject-and. Add source-static warn rule no-destructured-cross. It must flag destructuring cross off the blaze context, including param destructuring ({ cross }, { cross: compose }) and body destructuring from the context identifier (const { cross } = ctx; const { cross: compose } = ctx). It must not flag direct ctx.cross(...), non-blaze code, or nested unrelated functions. Register the rule in Warden registries, metadata, trail wrapper exports, generated guide blocks, and add a patch changeset for @ontrails/warden.
+Read first: `AGENTS.md`, `.agents/plans/PLANNING.md`, the packet `PLAN.md` and `REFS.md`, `docs/tenets.md`, `docs/lexicon.md`, touched Warden rule/test files, and Linear issues `TRL-791`, `TRL-793`, `TRL-794`, `TRL-785`, `TRL-786`, `TRL-790`.
 
-Stack order after TRL-791: TRL-793 only if diagnostic-only; TRL-785 before TRL-786; defer TRL-790 unless scaffold stack is landed or the edit set is isolated. Do not take TRL-784. Do not change public ctx.cross API or bridge destructured cross in implementation-returns-result.
+Objective: clear as much Warden-as-coach work as safely possible overnight, turning Radio/Fieldwork learnings into Warden diagnostics/rules that lead agents toward Trails happy paths.
 
-Loop: keep RETRO.md updated before each handoff; update Linear status/comments as branches/PRs move; use subagents for bounded review/research/coding tasks with exact file ownership; subagents must not run git/gt writes. Use Graphite for branch/commit/submit. Keep PRs draft until CI and local review are green.
+Current known order: `TRL-791` is already draft PR #582 and should only need monitoring; finish `TRL-793` first (names-only diagnostics, no firing logic changes), keep `TRL-794` as the partial-diagnostics follow-up, then `TRL-785` (alias-aware Result helper provenance), then `TRL-786` (redundant `Result.err(x.error)` re-wrap detection after provenance exists), with `TRL-790` opportunistic and isolated.
 
-Validation: focused Warden tests first; run guide sync/check after metadata changes; run bun --cwd packages/warden test, bun run typecheck, bun run lint, bun run format:check, git diff --check, and bun run check before final handoff unless a blocker is logged. Run at least two local review lanes and fix all P0/P1/P2 before submit.
+Work loop: execute one issue per focused branch/PR unless inseparable. After each turn report checkpoint, changed files, exact checks/artifact proof, result summary, remaining work, blocker status, and next checkpoint. Use bounded subagents for review/research; main agent owns all `git` and `gt` writes.
 
-Forbidden: no merge, no merge queue label, no publish/registry mutation, no destructive git commands, no unrelated scaffold edits, no undocumented divergence from Linear. Final proof must include branch/PR/status, changed artifacts, verification commands/results, local/remote review state, Linear updates, remaining risks, and forbidden-action audit.
+Validation ladder: run focused touched tests after each slice; before draft PR run package/repo gates from `PLAN.md`, including `bun --cwd packages/warden test`, `bun run typecheck`, `bun run lint`, `bun run format:check`, `git diff --check`, and `bun run check` unless explicitly justified. After PR submission, watch CI and record state.
+
+Review loop: run local review lanes for any behavior change or broad diagnostic change. Fix P0/P1/P2 before remote handoff. Record local review, CI, remote review, and PR-body changes in `RETRO.md`.
+
+Hard rules: no merge, package publish, registry mutation, merge queue label, or subagent source-control write without Matt approval. Keep terminology sharp: `trail`, `blaze`, `topo`, `cross`, `surface`, `resource`, `layer`; prefer `ctx.cross(...)` provenance. Do not broaden public API or doctrine without stopping.
+
+Done only when completed slices have draft PRs, current Linear comments/status, green required checks/CI state recorded, forbidden actions respected, and `RETRO.md` has final tracker, PR, review, verification, forbidden-action, risk, and archive-readiness state. Final transcript must name proof.
+
+Stop/ask if plan/repo/tracker truth diverges, public API/scope changes are needed, required secrets/external systems are missing, unrelated verification fails after focused retry, or `TRL-785`/`TRL-786` needs broad provenance work beyond the Warden rule boundary.
 ````
-
-## Completion Condition
-
-At minimum, `TRL-791` has a draft PR with CI green, Linear updated, local review clean or P3-only, generated Warden guides synced, and `RETRO.md` finalized for handoff.
-
-If additional slices are completed, each has its own branch/PR/Linear/retro evidence, and the stack order remains truthful.

--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/PLAN.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/PLAN.md
@@ -1,122 +1,241 @@
-# Warden-as-Coach Overnight Stack
+# Goal Plan: Warden As Coach Overnight Stack
 
 Date: 2026-05-24
-Owner: Lewis
-Branch root: `trl-791-warden-coach-against-destructured-ctxcross-new-reject-and`
-Tracker: Linear `TRL`, project `Fieldwork Loop`, milestone `Warden as Coach`
+Status: In progress
 
 ## Objective
 
-Turn the Radio/Fieldwork learning into Warden guidance that keeps future Trails authors and agents on the happy path.
+Clear as much of the Warden-as-coach stack as safely possible overnight, turning Radio/Fieldwork learnings into concrete Trails guidance that leads agents toward the happy path.
 
-The stack should favor small, reviewable slices:
+## Completion Condition
 
-1. `TRL-791` - add a source-static Warden rule that coaches against destructuring `cross` off `ctx` inside blaze bodies.
-2. `TRL-793` - if time remains and the diff stays diagnostic-only, upgrade the 8 names-only Warden diagnostics to teach the fix.
-3. `TRL-785` - close the `implementation-returns-result` alias/provenance coverage gap from `TRL-333`.
-4. `TRL-786` - only after `TRL-785`, add redundant `Result.err(x.error)` re-wrap detection for provably safe cases.
+The goal is complete only when:
 
-Do not take `TRL-790` in this first branch. The clean fix likely touches root lint/plugin config and scaffold-generated lint config, which overlaps the open scaffold stack. Revisit after the scaffold PRs land or intentionally stack it there.
+- Each completed slice has a focused branch, draft PR, current Linear state, and updated `RETRO.md`.
+- P0/P1/P2 local review findings are fixed or explicitly blocked before submission.
+- Required checks pass for each submitted PR and CI state is recorded.
+- No merge, package publish, registry mutation, merge queue label, or subagent source-control write occurs without explicit Matt approval.
+- `RETRO.md` is updated as the durable execution record and final state ledger.
 
-## Doctrine
+## Non-Goals
 
-- Core premise: author what's new, derive what's known, override what's wrong.
-- Drift guard rung: Warden is the right layer for coaching canonical authored shapes that TypeScript cannot forbid cleanly.
-- Compound test: `ctx.cross(...)` is the runtime composition primitive; preserving the direct member-expression shape helps Warden recognize composed `Result` values and keeps composition visible to readers, docs, and future Ranger/fieldguide guidance.
-- Evaluation hierarchy: strengthen an existing primitive (`ctx.cross`) before broadening behavior or introducing aliases.
-- Vocabulary: say `trail`, `blaze`, `topo`, `cross`, `surface`, `resource`, `layer`. Do not call this a handler or middleware rule.
+- Do not merge PRs.
+- Do not publish packages or mutate registry state.
+- Do not broaden Warden doctrine, public API, or rule semantics beyond the active issue without a new issue/comment.
+- Do not fold unrelated scaffold or fieldguide work into the Warden stack.
 
-## Current Tracker Truth
+## Source Of Truth
 
-`TRL-791` is Backlog at planning time. It already contains the OD-4 ruling: reject and coach, do not bridge destructured `cross` in `implementation-returns-result`.
+Read first:
 
-`TRL-793` is Backlog. Clark filed it from the Warden diagnostic-language audit. It is low risk only if limited to diagnostic strings and tests for names-only offenders.
+1. `AGENTS.md`
+2. `.agents/plans/PLANNING.md`
+3. `docs/tenets.md`
+4. `docs/lexicon.md`
+5. `packages/warden/src/rules/*`
+6. `packages/warden/src/__tests__/*`
+7. `plans/fieldwork-loop/warden-diagnostic-audit-20260523.md` if present in `trailblazing`
+8. Linear `TRL-791`, `TRL-793`, `TRL-785`, `TRL-786`, `TRL-790`
 
-`TRL-785` is Backlog. Clark/Hume found it overlaps done issue `TRL-333`; current scope is a coverage-gap follow-up, not a fresh imported-helper implementation.
+## Stack Order
 
-`TRL-786` is Backlog. Do not implement before `TRL-785` creates enough provenance to avoid noisy syntactic false positives.
+### TRL-791: Reject destructured `ctx.cross`
 
-## TRL-791 Acceptance Criteria
+Status: draft PR submitted as #582.
 
-- New rule id: `no-destructured-cross`.
-- Severity: `warn`.
-- Metadata: concern `composition`, tier `source-static`, scope `external`, lifecycle durable.
-- Flags both canonical shadow patterns inside trail blaze bodies:
-  - parameter destructuring: `blaze: async (input, { cross }) => ...`
-  - body destructuring from the context parameter: `const { cross } = ctx;`
-- Flags aliases too: `const { cross: compose } = ctx` and `({ cross: compose })`.
-- Stays quiet for direct `ctx.cross(...)`.
-- Stays quiet for non-blaze code and nested callbacks/functions unrelated to the blaze's context parameter.
-- Registers in `wardenRules`, `registry-names`, metadata, and Warden trail wrappers.
-- Regenerates Warden guide blocks with repo scripts.
-- Includes a patch changeset for `@ontrails/warden`.
+Intent:
 
-## Likely TRL-791 Edit Set
+- Keep crossing provenance visible as `ctx.cross(...)` so Warden and future agents can see composition edges.
 
-- `packages/warden/src/rules/no-destructured-cross.ts`
-- `packages/warden/src/__tests__/no-destructured-cross.test.ts`
-- `packages/warden/src/rules/index.ts`
-- `packages/warden/src/rules/registry-names.ts`
-- `packages/warden/src/rules/metadata.ts`
-- `packages/warden/src/trails/no-destructured-cross.trail.ts`
-- `packages/warden/src/trails/index.ts`
-- `AGENTS.md`
-- `.claude/skills/clark/references/warden-guide.md`
-- `plugin/skills/trails/references/warden-guide.md`
-- `.changeset/<slug>.md`
-- This packet's `RETRO.md`
+Actions:
+
+- Add `no-destructured-cross`.
+- Wire rule metadata, registry, trail wrapper, generated guide surfaces, tests, and changeset.
+- Clean up any live examples that destructure `cross`.
+
+Verification:
+
+- Focused Warden tests.
+- `bun --cwd packages/warden test`
+- `bun run typecheck`
+- `bun run lint`
+- `bun run format:check`
+- `git diff --check`
+- `bun run check`
+- CI green.
+
+### TRL-793: Upgrade names-only diagnostics
+
+Status: draft PR submitted as #583.
+
+Intent:
+
+- Make existing Warden diagnostics teach the fix instead of only naming the violation.
+
+Actions:
+
+- Update names-only diagnostics for `implementation-returns-result`, `resource-declarations`, `resource-exists`, `cross-declarations`, `valid-detour-contract`, `circular-refs`, `on-references-exist`, plus same-family `contour-exists` and `reference-exists`.
+- Keep rule firing logic unchanged.
+- Update exact-message tests and generated rule-trail expectations as needed.
+- Record scope divergence honestly: partial diagnostics moved to `TRL-794`.
+
+Verification:
+
+- Focused touched-rule suite.
+- `bun --cwd packages/warden test`
+- `bun run typecheck`
+- `bun run lint`
+- `bun run format:check`
+- `git diff --check`
+- `bun run check`
+- CI after draft PR.
+
+### TRL-794: Upgrade partial diagnostics
+
+Status: follow-up filed.
+
+Intent:
+
+- Sharpen the 13 partial Warden diagnostics from the audit without bloating the names-only PR.
+
+Actions:
+
+- Keep as diagnostic language + tests unless a rule cannot be made honest without detection changes.
+- Sequence after the higher-priority provenance work unless Matt/Clark chooses wording cleanup first.
+
+Verification:
+
+- Focused touched-rule tests.
+- Warden package tests.
+- Repo gates.
+
+### TRL-785: Result helper provenance alias gap
+
+Status: next likely implementation slice after TRL-793.
+
+Intent:
+
+- Close the TRL-333 coverage hole where helper return annotations using `Result as ResultType` are invisible to `implementation-returns-result`.
+
+Actions:
+
+- Add failing fixtures for same-file and imported helpers using aliased `Result`.
+- Make `hasResultReturnType` alias-aware without re-implementing TRL-333.
+- Preserve `.js` to `.ts` import resolution; Clark's cause check ruled it out as the Radio failure.
+- Teach or document the single-import pattern if the code surface naturally exposes it.
+
+Verification:
+
+- `bun test packages/warden/src/__tests__/implementation-returns-result.test.ts`
+- `bun --cwd packages/warden test`
+- `bun run typecheck`
+- `bun run lint`
+- `bun run check`
+
+### TRL-786: Redundant `Result.err(x.error)` re-wrap detection
+
+Status: after TRL-785 unless new evidence says otherwise.
+
+Intent:
+
+- Coach agents away from re-wrapping Result errors when propagation is the right path.
+
+Actions:
+
+- Use provenance from TRL-785; avoid syntactic-only detection.
+- Add conservative fixtures for true redundant re-wraps and legitimate transformations.
+- Keep diagnostic language specific: preserve the original Result or intentionally transform the error with a new TrailsError.
+
+Verification:
+
+- Focused new rule tests.
+- Warden package tests.
+- Repo gates.
+
+### TRL-790: `TODO[trails-*]` lint marker carve-out
+
+Status: opportunistic low-risk slice.
+
+Intent:
+
+- Allow explicit Trails-tracked TODO markers without fighting repo lint.
+
+Actions:
+
+- Keep isolated because it may touch lint/generated config surfaces.
+- Verify it does not normalize generic TODO debt.
+
+Verification:
+
+- Focused lint/config check.
+- `bun run lint`
+- `bun run check`
+
+## Tracker Plan
+
+- In-goal issues: `TRL-791`, `TRL-793`, `TRL-794`, `TRL-785`, `TRL-786`, `TRL-790`.
+- Dependencies/blockers: `TRL-786` should follow `TRL-785`; `TRL-794` owns the partial diagnostics left out of TRL-793.
+- Keep Linear comments current after local verification, PR submission, and CI.
+- Do not mark issues Done before merge.
+
+## Source-Control Plan
+
+- Branching model: Graphite.
+- One issue per PR unless a tiny follow-up is explicitly inseparable.
+- Use Linear-recommended branch names.
+- Keep PRs draft until local checks and CI are green.
+- Main agent performs all `git`/`gt` write operations; subagents do not.
+- No merge without Matt approval.
+
+## Retro Discipline
+
+`RETRO.md` is part of the completion contract, not optional notes.
+
+- Update `RETRO.md` after meaningful implementation, tracker, verification, local review, remote review, CI, PR-body, or source-control changes.
+- Touch `RETRO.md` last before local completion, draft submission, ready-for-review, remote review closeout, merge readiness, or final handoff.
+- Every meaningful review-flow change must have a corresponding retro entry before claiming the review loop is complete.
 
 ## Validation Ladder
 
-Focused:
+Run checks from narrow to broad:
 
-```bash
-bun test packages/warden/src/__tests__/no-destructured-cross.test.ts
-bun test packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/guide.test.ts packages/warden/src/__tests__/warden-export-symmetry.test.ts
-bun run warden:agents:check
-bun run warden:skills:check
-```
+- Targeted: `bun test <touched warden test files>`
+- Package: `bun --cwd packages/warden test`
+- Repo: `bun run typecheck`, `bun run lint`, `bun run format:check`, `git diff --check`
+- Full gate: `bun run check`
+- CI: GitHub checks on draft PR
 
-Branch:
+## Local Review
 
-```bash
-bun --cwd packages/warden test
-bun run typecheck
-bun run lint
-bun run format:check
-git diff --check
-```
+Use subagents for bounded review lanes when a slice changes behavior or enough diagnostics to invite wording drift.
 
-Before PR handoff:
+- Lane 1: false positives / firing logic
+- Lane 2: diagnostic language and doctrine accuracy
+- Lane 3: tests, examples, generated artifacts, and changeset coverage
 
-```bash
-bun run check
-```
+Fix all P0/P1/P2 findings before remote submission or final handoff. Record each round and fix outcome in `RETRO.md`.
 
-## Review Protocol
+## Stop / Pause Rules
 
-Use at least two local review lanes before submit:
+Stop and ask if:
 
-- Warden implementation/test lane: AST scope, false positives, registration, guide sync.
-- Doctrine/vocabulary lane: diagnostic teaches the fix and preserves `ctx.cross(...)` as canonical.
+- Linear, PR, or repo state diverges from this packet.
+- A public API or doctrine change is needed beyond the active issue.
+- Verification fails for unrelated reasons after focused retry.
+- Secrets, credentials, production systems, merge, publish, or merge queue actions are needed.
+- `TRL-785` or `TRL-786` requires broad provenance work beyond the current Warden rule boundary.
 
-If the first review pass finds P0/P1/P2, fix before submit. P3 can remain only if logged in `RETRO.md`.
+## Handoff Audit
 
-## Source Control
-
-- Use Graphite.
-- No merge.
-- No merge queue label.
-- No publish or registry mutation.
-- Subagents may inspect, test, and edit bounded files if delegated, but must not run git/gt write commands.
-- Keep PR draft until local review and CI are green.
-
-## Stop Rules
-
-Stop and ask Matt if:
-
-- The fix requires changing public `ctx.cross` typing or `implementation-returns-result` recognition semantics beyond adding the coaching rule.
-- `TRL-793` stops being diagnostic-only.
-- `TRL-785` requires a broad imported-module resolver rewrite.
-- `TRL-786` cannot prove re-wrap redundancy without noisy false positives.
-- Remote review finds a doctrine conflict rather than an implementation bug.
+- [x] Objective is singular and end-to-end.
+- [x] Completion condition is objectively checkable.
+- [x] Tracker state requirements are represented.
+- [x] Branch names/order are exact where known.
+- [x] Dependencies/blockers are represented.
+- [x] Ignored/untracked source docs are summarized instead of required.
+- [x] Validation commands match repo conventions.
+- [x] `GOAL.md` requires transcript-visible proof.
+- [x] `GOAL.md` requires `RETRO.md` finalization before completion.
+- [x] Stop rules are concrete.
+- [x] `RETRO.md` has concrete sections for execution, tracker, review, verification, remote state, forbidden actions, final state, and archive readiness.
+- [x] Packet can be executed without chat history.

--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/REFS.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/REFS.md
@@ -1,70 +1,40 @@
-# References
+# References: Warden As Coach Overnight Stack
 
-## Constitutional Sources
+## Tracked / Portable Sources
 
-- `docs/adr/0000-core-premise.md` - author what's new, derive what's known, override what's wrong.
-- `docs/tenets.md` - `cross()` / `crosses` as first-class composition, drift guard, compound value.
-- `docs/lexicon.md` - `cross` / `crosses`, `trail`, `blaze`, `topo`, `surface`, `resource`, `layer`.
-- `AGENTS.md` - Warden guide, Graphite workflow, subagent constraints.
-- `.agents/plans/PLANNING.md` - goal packet and retro discipline.
+- `AGENTS.md` - repo guidance, Warden rules, Graphite workflow, subagent constraints.
+- `.agents/plans/PLANNING.md` - packet lifecycle, review, validation, and tracker preferences.
+- `docs/tenets.md` - doctrine basis for Warden guiding agents toward the happy path.
+- `docs/lexicon.md` - vocabulary basis for diagnostic wording.
+- `packages/warden/src/rules/` - Warden rule implementations.
+- `packages/warden/src/__tests__/` - focused rule fixtures and exact diagnostic expectations.
+- `packages/warden/src/trails/` - Warden rule trail examples and generated contract expectations.
 
-## Tracker
+## Untracked / Local-Only Sources
 
-- `TRL-791` - Warden coach against destructured `ctx.cross`; OD-4 reject-and-coach ruling.
-- `TRL-793` - upgrade names-only diagnostics to teach the fix.
-- `TRL-785` - `implementation-returns-result` helper provenance coverage gap after `TRL-333`.
-- `TRL-786` - redundant `Result.err(x.error)` re-wrap detection, blocked on safer provenance.
-- `TRL-790` - fieldwork marker lint; defer due scaffold/lint config overlap.
+- `/Users/mg/Developer/outfitter/trailblazing/inbox/2026-05-23-lewis-clark-turnaround.md` - Lewis/Clark shared note; summarized in this packet and `RETRO.md`.
+- `/Users/mg/Developer/outfitter/trailblazing/plans/fieldwork-loop/warden-diagnostic-audit-20260523.md` - Clark's Warden diagnostic audit if present; use as source context, but do not make this packet depend on it.
 
-## Warden Implementation Anchors
+## Tracker Records
 
-- `packages/warden/src/rules/implementation-returns-result.ts`
-  - Existing direct `ctx.cross` member-expression recognition lives in `isResultMemberCall`.
-  - Diagnostic style is trail-id anchored.
-- `packages/warden/src/rules/cross-declarations.ts`
-  - Existing cross extraction recognizes both member calls and destructured bare `cross(...)`, but TRL-791 should coach destructuring away rather than extend this tolerated shape.
-- `packages/warden/src/rules/no-direct-implementation-call.ts`
-  - Small source-static rule pattern and good teaching diagnostic model.
-- `packages/warden/src/rules/ast.ts`
-  - `findTrailDefinitions`, `findBlazeBodies`, `identifierName`, `offsetToLine`, `walkScope`, `walkWithScopes`.
-- `packages/warden/src/rules/metadata.ts`
-  - Built-in rule metadata and concern/tier defaults.
-- `packages/warden/src/rules/registry-names.ts`
-  - Snapshot used by `warden-export-symmetry`.
-- `packages/warden/src/trails/no-direct-implementation-call.trail.ts`
-  - Wrapper model for the new rule trail.
+- `TRL-791` - Warden coach against destructured `ctx.cross`.
+- `TRL-793` - Upgrade names-only Warden diagnostics to teach the fix.
+- `TRL-794` - Upgrade partial Warden diagnostics to teach the fix.
+- `TRL-785` - Close `implementation-returns-result` alias-aware Result helper provenance gap.
+- `TRL-786` - Detect redundant `Result.err(x.error)` re-wraps once provenance is strong enough.
+- `TRL-790` - Whitelist explicit `TODO[trails-*]` markers.
 
-## Audit Summary Imported From Trailblazing
+## PRs / Branches
 
-Clark's audit note lives outside this repo at:
+- PR #582 / `trl-791-warden-coach-against-destructured-ctxcross-new-reject-and` - TRL-791 draft PR, CI green as of 2026-05-24 00:34 EDT.
+- PR #583 / `trl-793-warden-upgrade-names-only-diagnostics-to-teach-the-fix-8` - TRL-793 draft PR, CI running as of 2026-05-24 00:55 EDT.
 
-`/Users/mg/Developer/outfitter/trailblazing/plans/fieldwork-loop/warden-diagnostic-audit-20260523.md`
+## Validation Commands
 
-Load-bearing summary copied here so the tracked packet does not depend on that external file:
-
-- 56 Warden rules audited.
-- 24 teach the fix, 13 partially teach, 8 are names-only, 11 were skipped as internal/repo-local/dynamic.
-- Highest-priority names-only offender is `implementation-returns-result`, because Radio showed the diagnostic can lead agents to cargo-cult `Result.err(x.error)` re-wraps.
-- `TRL-791` is the model for a good teaching diagnostic: name the violation, name the cost, and point at the canonical authoring shape.
-- `TRL-793` should start with names-only diagnostic strings and tests, not rule-logic changes.
-
-## Subagent Findings Imported Into Packet
-
-Gibbs on `TRL-791`:
-
-- Recommended rule id `no-destructured-cross`.
-- Register in rule index, metadata, registry-name snapshot, trail wrapper, and generated guides.
-- Detect parameter destructuring and body destructuring from the blaze context parameter.
-- Use a warning diagnostic that teaches direct `ctx.cross(...)`.
-
-Hume on `TRL-785` / `TRL-786`:
-
-- Current Warden already supports many imported Result helpers from `TRL-333`.
-- Current gap includes `Result as ResultType` aliases; helper facts are still name-heavy rather than provenance-rich.
-- Do `TRL-785` before `TRL-786`; a syntactic re-wrap rule would be too noisy.
-
-Boyle on `TRL-790`:
-
-- Native Oxlint config lacks a clean allowlist for `TODO[trails-*]`.
-- A clean fix likely requires custom lint rule/plugin behavior and possibly generated scaffold lint config.
-- Defer or stack intentionally on the scaffold branch; do not branch from main as a casual sidecar.
+- `bun test <touched files>` - focused rule/test proof.
+- `bun --cwd packages/warden test` - Warden package regression proof.
+- `bun run typecheck` - workspace type proof.
+- `bun run lint` - workspace lint proof.
+- `bun run format:check` - formatter/lint plugin proof.
+- `git diff --check` - whitespace proof.
+- `bun run check` - full repo gate before PR handoff.

--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/RETRO.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/RETRO.md
@@ -1,98 +1,150 @@
-# Warden-as-Coach Overnight Stack Retro
+# Execution Retro: Warden As Coach Overnight Stack
 
-Date: 2026-05-24
-Owner: Lewis
+Date started: 2026-05-24
+Date finalized: pending
+Status: In progress
+Plan: `.agents/plans/2026-05-24-warden-as-coach-overnight-stack/PLAN.md`
+Goal: `.agents/plans/2026-05-24-warden-as-coach-overnight-stack/GOAL.md`
 
-## Current State
+Use this as the durable execution ledger. For stacked work, this should normally be the last meaningful file touched before local completion, draft submission, ready-for-review, remote review closeout, merge readiness, archive, or final handoff.
 
-| Item | State | Notes |
-|---|---|---|
-| `TRL-791` | Draft PR, CI green | PR #582; branch root: `trl-791-warden-coach-against-destructured-ctxcross-new-reject-and`. |
-| `TRL-793` | Candidate next | Only take if diagnostic-only. |
-| `TRL-785` | Candidate later | Must precede `TRL-786`; overlaps `TRL-333`. |
-| `TRL-786` | Deferred until provenance | Do not implement syntactically. |
-| `TRL-790` | Deferred | Likely scaffold/lint config overlap. |
+## Execution Summary
 
-## Discoveries
+- Objective: clear Warden-as-coach slices that convert Radio/Fieldwork learnings into Trails guidance.
+- Final outcome: pending.
+- Final branch / stack tip: pending.
+- Final PR range: PR #582 for TRL-791; PR #583 for TRL-793.
+- Final tracker state: TRL-793 In Review; TRL-794 filed for partial diagnostics.
+- Final verification state: TRL-791 verified and CI green; TRL-793 locally verified through `bun run check`.
+- Remaining risks / P3s: TRL-794 partial diagnostics remain follow-up.
+- Archive state: active packet, not archive-ready.
 
-- 2026-05-24 00:13 EDT - Clark and subagent findings converge on Warden-as-Coach order: `TRL-791` first; `TRL-793` if diagnostic-only; `TRL-785` before `TRL-786`; defer `TRL-790`.
-- 2026-05-24 00:13 EDT - `TRL-785` is a coverage-gap follow-up to done `TRL-333`, not a fresh imported-helper implementation.
-- 2026-05-24 00:13 EDT - Native Oxlint config cannot cleanly whitelist `TODO[trails-*]`; `TRL-790` likely needs plugin/custom-rule work and may overlap scaffold output.
+## Branch / PR / Issue Ledger
+
+| Order | Issue | Branch | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | TRL-791 | `trl-791-warden-coach-against-destructured-ctxcross-new-reject-and` | #582 | Draft, CI green | New `no-destructured-cross` rule submitted. |
+| 2 | TRL-793 | `trl-793-warden-upgrade-names-only-diagnostics-to-teach-the-fix-8` | #583 | Draft, CI running | Names-only diagnostics upgraded. |
+| 3 | TRL-794 | pending | pending | Todo | Follow-up for 13 partial diagnostics. |
+| 4 | TRL-785 | pending | pending | Planned | Alias-aware Result helper provenance gap. |
+| 5 | TRL-786 | pending | pending | Planned | Should follow TRL-785 provenance work. |
+| 6 | TRL-790 | pending | pending | Optional | Keep isolated. |
+
+## Planning Discoveries
+
+| Discovery | Evidence | Decision | Impact |
+| --- | --- | --- | --- |
+| `TRL-785` overlaps prior `TRL-333` work. | Clark shared note and Linear comments. | Treat as a coverage-gap follow-up, not fresh capability. | Avoid re-implementing TRL-333. |
+| Radio helper provenance failure is alias-blindness, not `.js` to `.ts` import resolution. | Clark cause confirmation in shared note. | Fix `hasResultReturnType` alias recognition when working TRL-785. | Makes 785 the right predecessor for 786. |
+| `TRL-793` should stay separate from `TRL-791`. | Clark shared note 00:14 EDT. | Keep diagnostic-string work separate from new behavioral rule. | Clearer review surfaces. |
+
+## Deferred / Follow-Up Discoveries
+
+| Issue | Discovery | Why Out Of Goal | Link |
+| --- | --- | --- | --- |
+| TRL-794 | Partial diagnostics second wave. | First PR is names-only plus same-family omissions; partials are broader wording work. | Linear TRL-794 |
+| pending | Fieldguide should teach `import { Result }` rather than unnecessary `Result as ResultType` aliasing. | Docs/fieldguide work, not Warden rule change unless naturally surfaced in TRL-785. | pending |
 
 ## Tracker Mutations
 
-| Time | Issue | Change |
-|---|---|---|
-| 2026-05-24 00:15 EDT | `TRL-791` | Moved to In Progress. |
-| 2026-05-24 00:15 EDT | `TRL-791` | Commented with branch, packet path, and scope note. |
-| 2026-05-24 00:30 EDT | `TRL-791` | Moved to In Review and attached draft PR #582. |
-| 2026-05-24 00:30 EDT | `TRL-791` | Commented with verification plus diagnostic-divergence note. |
+| Time | Tracker Item | Mutation | Evidence |
+| --- | --- | --- | --- |
+| 2026-05-24 00:34 EDT | TRL-791 | Updated with final local verification and CI green PR state. | Linear comment; PR #582. |
+| 2026-05-24 00:35 EDT | TRL-793 | Moved to In Progress and commented branch/start state. | Linear comment. |
+| 2026-05-24 00:54 EDT | TRL-794 | Created follow-up for 13 partial diagnostics. | Linear TRL-794. |
+| 2026-05-24 00:54 EDT | TRL-793 | Narrowed title to names-only, moved to In Review, attached/commented PR #583 and verification. | Linear comment `27bd08bb-8f72-40cb-a363-60577aa6c7d7`. |
 
 ## Execution Log
 
-| Time | Event |
-|---|---|
-| 2026-05-24 00:13 EDT | Created active goal packet under `.agents/plans/2026-05-24-warden-as-coach-overnight-stack/`. |
-| 2026-05-24 00:13 EDT | Checked out `main` and created Graphite branch `trl-791-warden-coach-against-destructured-ctxcross-new-reject-and`. |
-| 2026-05-24 00:18 EDT | Implemented `no-destructured-cross`, registered metadata/exports/trail wrapper, added tests and a changeset. |
-| 2026-05-24 00:18 EDT | Updated the framework `create` trail to use `ctx.cross(...)` directly instead of destructuring `cross`. |
-| 2026-05-24 00:18 EDT | Regenerated Warden guide blocks in `AGENTS.md`, Clark's Warden guide reference, and the Trails plugin guide reference. |
-| 2026-05-24 00:32 EDT | Softened `no-destructured-cross` diagnostic after doctrine review: removed the absolute LSP/type-overload claim and kept the grounded Warden/result-recognition cost. |
-| 2026-05-24 00:34 EDT | Added assignment destructuring detection for `({ cross } = ctx)` after implementation review found it as a bypass. |
-| 2026-05-24 00:31 EDT | Submitted draft PR #582. |
-| 2026-05-24 00:32 EDT | Fixed Changeset CI failure by adding `@ontrails/trails` to the changeset; the framework `create` trail cleanup touches a publishable package too. |
+```text
+2026-05-24 00:13 EDT - planning / stack selection
+- Changed: selected Warden-as-coach order: 791, 793, 785, 786, 790 optional.
+- Verified: Clark/Hume dependency reasoning for 785 before 786.
+- Result: proceeded with TRL-791 first.
+- Next: implement TRL-791.
+- Blockers: none.
 
-## Verification Log
+2026-05-24 00:34 EDT - TRL-791 draft PR handoff
+- Changed: added no-destructured-cross rule, tests, metadata, trail wrapper, generated guide updates, changeset, and cleaned direct ctx.cross usage in scaffold code.
+- Verified: focused tests, Warden package tests, typecheck, lint, format, diff check, full check, and PR CI.
+- Result: PR #582 draft, CI green, Linear In Review.
+- Next: start TRL-793 separately.
+- Blockers: none.
 
-| Command | Result | Notes |
-|---|---|---|
-| `bun test packages/warden/src/__tests__/no-destructured-cross.test.ts` | pass | Initial focused rule run: 9 tests. |
-| `bun test packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/guide.test.ts packages/warden/src/__tests__/warden-export-symmetry.test.ts` | pass | 28 tests. |
-| `bun run warden:agents:sync` | pass | Regenerated `AGENTS.md`. |
-| `bun run warden:skills:sync` | pass | Regenerated Clark + plugin Warden guide references. |
-| `bun run warden:agents:check` | pass | Generated block in sync. |
-| `bun run warden:skills:check` | pass | Generated skill guides in sync. |
-| `bun --cwd packages/warden test` | failed, fixed | First run failed only because `trails.test.ts` still expected 56 rule trails; updated to 57. |
-| `bun run typecheck` | failed, fixed | First run caught a narrow `property.key` AST type mismatch in the new rule; fixed with an explicit cast. |
-| `bun run format:check` | failed, fixed | First run found formatting drift in `create.ts` and the new rule test. |
-| `bun run format:fix` | pass | Applied formatter and cleared Ultracite's `prefer-destructuring` complaint. |
-| `bun --cwd packages/warden test` | pass | 926 tests, 0 fail after updating rule trail count. |
-| `bun run typecheck` | failed, fixed | Second run exposed optional `ctx.cross` narrowing in `apps/trails/src/trails/create.ts`; added `hasCross` type guard so direct `ctx.cross(...)` remains type-safe. |
-| `bun test apps/trails/src/__tests__/create.test.ts` | pass | 15 tests, 0 fail after `ctx.cross` cleanup. |
-| `bun run typecheck` | pass | 22 packages. |
-| `bun run format:check` | pass | All matched files formatted; Ultracite 0 warnings/errors. |
-| `bun run lint` | pass | 23 tasks, 0 warnings/errors. |
-| `git diff --check` | pass | No whitespace errors. |
-| `bun test packages/warden/src/__tests__/no-destructured-cross.test.ts` | pass | Final focused rule run after review fixes: 12 tests, 0 fail. |
-| `bun --cwd packages/warden test` | pass | Final package run: 929 tests, 0 fail. |
-| `bun run format:check` | pass | Final format/Ultracite run: 0 warnings/errors. |
-| `bun run lint` | pass | Final repo lint: 23 tasks, 0 warnings/errors. |
-| `git diff --check` | pass | Final whitespace check. |
-| `bun run check` | pass | Full repo gate passed; Warden emitted only the known pre-existing warning set. |
-| `gh api --paginate repos/outfitter-dev/trails/pulls/582/files --jq '.[].filename' \| bun run changeset:check -- --changed-files /dev/stdin` | pass | Reproduced the Changeset gate locally after adding `@ontrails/trails`. |
+2026-05-24 00:50 EDT - TRL-793 local verification
+- Changed: upgraded names-only diagnostics for implementation-returns-result, resource-declarations, resource-exists, cross-declarations, valid-detour-contract, circular-refs, on-references-exist, contour-exists, and reference-exists; updated tests and valid-detour-contract trail expectation.
+- Verified: focused touched-rule suite 278 pass; `bun --cwd packages/warden test` 915 pass; `bun run typecheck`; `bun run lint`; `bun run format:check`; `git diff --check`; `bun run check`.
+- Result: local branch verified; draft PR not submitted yet.
+- Next: commit with Graphite, submit draft PR, update Linear, watch CI.
+- Blockers: none.
+
+2026-05-24 00:55 EDT - TRL-793 draft PR submission
+- Changed: committed `420a5fc9b`, submitted PR #583, wrote PR body, split partial diagnostics into TRL-794, updated TRL-793 title/status/comment.
+- Verified: PR opened as draft and CI started.
+- Result: TRL-793 is In Review with PR #583.
+- Next: watch CI and remote review; then continue to TRL-785 unless Matt/Clark redirects.
+- Blockers: none.
+```
 
 ## Local Review Log
 
-| Pass | Result | Findings | Action |
-|---|---|---|---|
-| 2026-05-24 00:26 EDT | Implementation/registration review dispatched to Nash | pending | Review only; no git/gt writes. |
-| 2026-05-24 00:26 EDT | Doctrine/diagnostic review dispatched to McClintock | 4/5 | One P2: diagnostic overclaimed that destructuring breaks LSP typed-overload narrowing. Fixed by softening to visible composition + Warden Result recognition. |
-| 2026-05-24 00:34 EDT | Implementation/registration review returned from Nash | 4/5 | One P2: assignment destructuring bypass. Fixed by adding `AssignmentExpression` detection and tests. |
+| Round | Scope / Lanes | Report Paths | P0/P1/P2 Result | Fix Commits / Notes |
+| --- | --- | --- | --- | --- |
+| TRL-791 | Rule behavior, docs/guides, tests | subagent reports in transcript | P0/P1/P2 fixed | PR #582 submitted after fixes. |
+| TRL-793 | Diagnostic wording and audit coverage | subagent reports in transcript | P2 fixed | Fixed valid-detour recover signature, softened trail-object cross guidance, added contour/reference rule family. |
+
+## Verification Log
+
+| Check | Scope | Result | Evidence / Notes |
+| --- | --- | --- | --- |
+| `bun test packages/warden/src/__tests__/implementation-returns-result.test.ts packages/warden/src/__tests__/resource-declarations.test.ts packages/warden/src/__tests__/resource-exists.test.ts packages/warden/src/__tests__/cross-declarations.test.ts packages/warden/src/__tests__/valid-detour-contract.test.ts packages/warden/src/__tests__/circular-refs.test.ts packages/warden/src/__tests__/on-references-exist.test.ts packages/warden/src/__tests__/contour-exists.test.ts packages/warden/src/__tests__/reference-exists.test.ts packages/warden/src/__tests__/trails.test.ts` | TRL-793 focused | Pass | 278 pass, 0 fail. |
+| `bun --cwd packages/warden test` | TRL-793 package | Pass | 915 pass, 0 fail. |
+| `bun run typecheck` | TRL-793 repo | Pass | 22 packages successful. |
+| `bun run lint` | TRL-793 repo | Pass | 23 tasks successful. |
+| `bun run format:check` | TRL-793 repo | Pass | 0 warnings/errors. |
+| `git diff --check` | TRL-793 repo | Pass | No whitespace errors. |
+| `bun run check` | TRL-793 repo | Pass | Full repo gate passed; known Warden warnings printed by `trails warden`. |
+| PR #583 CI | TRL-793 remote | Running | Started after draft submission. |
 
 ## Remote Review / CI Log
 
-| PR | State | CI | Review |
-|---|---|---|---|
-| #582 | Draft, open | Green on amended run: Build, Lint & Format, Dead Code, Typecheck, Test, Governance, Changeset, CI Gate. | No reviews posted yet. |
+| Time | PR | CI State | Review State | Scores / Signals | Unresolved P0/P1/P2 | Action |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2026-05-24 00:34 EDT | #582 | Green | Draft | Local reviews clean after fixes | 0 known | Monitor / ready when appropriate. |
+| 2026-05-24 00:55 EDT | #583 | Running | Draft | Local reviews clean after fixes | 0 known | Watch CI. |
 
-## Forbidden-Action Audit
+## Review Feedback Resolutions
 
-- Merge: not performed.
-- Merge queue label: not applied.
-- Publish/registry mutation: not performed.
-- Destructive git commands: not performed.
-- Subagent git/gt writes: not performed.
+| Source | Score / Signal | Severity | Finding | Prompt To Fix | Resolution | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| Clark local review | P2 | P2 | `valid-detour-contract` diagnostic taught wrong recover signature. | Use `(attempt, ctx)` and `attempt.error`. | Fixed in rule, tests, trail expectation. | TRL-793 local diff. |
+| Clark local review | P2 | P2 | `cross-declarations` softened trail-object guidance implied unsupported resolution. | Teach string id or same trail object form in both declaration and call. | Fixed in rule/tests. | TRL-793 local diff. |
+| Plato local review | P2 | P2 | Audit same-family contour reference rules were omitted. | Add teaching diagnostics for `contour-exists` and `reference-exists`. | Fixed in rules/tests. | TRL-793 local diff. |
+
+## Forbidden Actions Audit
+
+| Action / Constraint | Status | Evidence |
+| --- | --- | --- |
+| No merge without explicit user approval | Respected | PR #582 is draft; TRL-793 local only so far. |
+| No package publish / registry mutation unless authorized | Respected | No publish commands run. |
+| No merge queue label unless authorized | Respected | No merge queue label applied. |
+| No source-control writes by subagents | Respected | Subagents only reviewed/researched. |
+| No unrelated destructive changes | Respected | Diffs scoped to active Warden slices and this packet. |
 
 ## Final State
 
-Draft PR #582 is open and CI green. No merge, merge queue, or publish action performed.
+- Goal completion condition: pending.
+- Graphite / branch state: TRL-793 submitted v1 at `420a5fc9b`; packet update pending amend.
+- PR state: #582 draft CI green; #583 draft CI running.
+- Source-control host lag: none known.
+- Tracker state: TRL-791 In Review; TRL-793 In Review; TRL-794 Todo; later issues pending.
+- Local review state: TRL-793 P2 findings fixed.
+- Remote review state: #583 CI running; review pending.
+- Remote review scores: pending.
+- Verification: TRL-793 local gates passed through `bun run check`.
+- Skipped checks: none for TRL-793 local handoff.
+- Remaining P3s / risks: partial diagnostic second wave tracked separately in TRL-794.
+- Follow-up issues created: TRL-794.
+- Forbidden actions confirmation: no merge, publish, registry mutation, merge queue label, or subagent source-control write.
+- Packet archive readiness: not ready.
+- Final transcript proof: pending.

--- a/.changeset/warden-teaching-diagnostics.md
+++ b/.changeset/warden-teaching-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Improve Warden diagnostics so names-only findings teach the canonical fix instead of only naming the violation.

--- a/packages/warden/src/__tests__/circular-refs.test.ts
+++ b/packages/warden/src/__tests__/circular-refs.test.ts
@@ -44,6 +44,8 @@ const gist = contour('gist', {
     expect(diagnostics).toHaveLength(2);
     expect(diagnostics[0]?.rule).toBe('circular-refs');
     expect(diagnostics[0]?.message).toContain('user -> gist -> user');
+    expect(diagnostics[0]?.message).toContain('Break the cycle');
+    expect(diagnostics[0]?.message).toContain('shared shape');
   });
 
   test('warns on transitive cycles discovered through project context', () => {

--- a/packages/warden/src/__tests__/contour-exists.test.ts
+++ b/packages/warden/src/__tests__/contour-exists.test.ts
@@ -68,6 +68,8 @@ trail('user.create', {
       expect(diagnostics).toHaveLength(1);
       expect(diagnostics[0]?.rule).toBe('contour-exists');
       expect(diagnostics[0]?.message).toContain('user');
+      expect(diagnostics[0]?.message).toContain("contour('user'");
+      expect(diagnostics[0]?.message).toContain('include it in the topo');
     });
 
     test('resolves aliased imports to the original contour name', () => {

--- a/packages/warden/src/__tests__/cross-declarations.test.ts
+++ b/packages/warden/src/__tests__/cross-declarations.test.ts
@@ -80,6 +80,7 @@ trail('onboard', {
       expect(diagnostics[0]?.rule).toBe('cross-declarations');
       expect(diagnostics[0]?.message).toContain("ctx.cross('entity.add')");
       expect(diagnostics[0]?.message).toContain('not declared in crosses');
+      expect(diagnostics[0]?.message).toContain("crosses: ['entity.add', ...]");
     });
 
     test('undeclared batch crossings still report an error', () => {
@@ -380,6 +381,10 @@ trail('gist.fork', {
       expect(diagnostics.length).toBe(1);
       expect(diagnostics[0]?.severity).toBe('warn');
       expect(diagnostics[0]?.message).toContain('trail object references');
+      expect(diagnostics[0]?.message).toContain('Add the string id');
+      expect(diagnostics[0]?.message).toContain(
+        'same trail object form in both crosses and ctx.cross'
+      );
     });
 
     test('mixed string and trail object references: resolved string still validated', () => {

--- a/packages/warden/src/__tests__/implementation-returns-result.test.ts
+++ b/packages/warden/src/__tests__/implementation-returns-result.test.ts
@@ -54,6 +54,11 @@ trail("entity.show", {
     expect(diagnostics.length).toBe(1);
     expect(diagnostics[0]?.rule).toBe('implementation-returns-result');
     expect(diagnostics[0]?.severity).toBe('error');
+    expect(diagnostics[0]?.message).toContain(
+      'not a recognized Result expression'
+    );
+    expect(diagnostics[0]?.message).toContain('await ctx.cross(...)');
+    expect(diagnostics[0]?.message).toContain('add a Result return annotation');
   });
 
   test('allows Result.ok() and returning ctx.cross() results', () => {

--- a/packages/warden/src/__tests__/on-references-exist.test.ts
+++ b/packages/warden/src/__tests__/on-references-exist.test.ts
@@ -41,6 +41,8 @@ trail('notify', {
     expect(diagnostics[0]?.rule).toBe('on-references-exist');
     expect(diagnostics[0]?.severity).toBe('error');
     expect(diagnostics[0]?.message).toContain('entity.created');
+    expect(diagnostics[0]?.message).toContain("signal('entity.created'");
+    expect(diagnostics[0]?.message).toContain('include it in the topo');
   });
 
   test('passes when project context includes the referenced signal', () => {

--- a/packages/warden/src/__tests__/reference-exists.test.ts
+++ b/packages/warden/src/__tests__/reference-exists.test.ts
@@ -69,6 +69,8 @@ const gist = contour('gist', {
       expect(diagnostics).toHaveLength(1);
       expect(diagnostics[0]?.rule).toBe('reference-exists');
       expect(diagnostics[0]?.message).toContain('user');
+      expect(diagnostics[0]?.message).toContain("contour('user'");
+      expect(diagnostics[0]?.message).toContain('include it in the topo');
     });
 
     test('resolves aliased imports to the original contour id', () => {

--- a/packages/warden/src/__tests__/resource-declarations.test.ts
+++ b/packages/warden/src/__tests__/resource-declarations.test.ts
@@ -183,13 +183,14 @@ trail('entity.show', {
       expect(diagnostics[0]?.rule).toBe('resource-declarations');
       expect(diagnostics[0]?.message).toContain('db.from(ctx)');
       expect(diagnostics[0]?.message).toContain('not declared in resources');
+      expect(diagnostics[0]?.message).toContain('resources: [db]');
     });
 
     test('ctx.resource() without a declaration produces an error', () => {
       const code = `
 trail('entity.show', {
   blaze: async (_input, ctx) => {
-    return Result.ok(ctx.resource('db.main'));
+    return Result.ok(ctx.resource('billing.primary'));
   },
 });
 `;
@@ -198,7 +199,15 @@ trail('entity.show', {
 
       expect(diagnostics.length).toBe(1);
       expect(diagnostics[0]?.severity).toBe('error');
-      expect(diagnostics[0]?.message).toContain("ctx.resource('db.main')");
+      expect(diagnostics[0]?.message).toContain(
+        "ctx.resource('billing.primary')"
+      );
+      expect(diagnostics[0]?.message).toContain(
+        "resources: ['billing.primary']"
+      );
+      expect(diagnostics[0]?.message).toContain('.from(ctx)');
+      expect(diagnostics[0]?.message).not.toContain('resources: [db]');
+      expect(diagnostics[0]?.message).not.toContain('db.from(ctx)');
     });
 
     test('unresolved imported resource declarations do not suppress lookup diagnostics', () => {
@@ -245,6 +254,7 @@ trail('entity.show', {
       expect(diagnostics.length).toBe(1);
       expect(diagnostics[0]?.severity).toBe('error');
       expect(diagnostics[0]?.message).toContain('ctx.resource(db)');
+      expect(diagnostics[0]?.message).toContain('resources: [db]');
     });
   });
 
@@ -272,6 +282,7 @@ trail('entity.show', {
       expect(diagnostics[0]?.rule).toBe('resource-declarations');
       expect(diagnostics[0]?.message).toContain("'db' declared in resources");
       expect(diagnostics[0]?.message).toContain('never used');
+      expect(diagnostics[0]?.message).toContain('Remove it from resources');
     });
   });
 

--- a/packages/warden/src/__tests__/resource-exists.test.ts
+++ b/packages/warden/src/__tests__/resource-exists.test.ts
@@ -42,6 +42,8 @@ trail('entity.show', {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.rule).toBe('resource-exists');
     expect(diagnostics[0]?.message).toContain('db.main');
+    expect(diagnostics[0]?.message).toContain("resource('db.main'");
+    expect(diagnostics[0]?.message).toContain('included in the topo');
   });
 
   test('flags a declared resource missing from project context', () => {

--- a/packages/warden/src/__tests__/valid-detour-contract.test.ts
+++ b/packages/warden/src/__tests__/valid-detour-contract.test.ts
@@ -64,6 +64,9 @@ describe('valid-detour-contract', () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.rule).toBe('valid-detour-contract');
     expect(diagnostics[0]?.message).toContain('callable recover');
+    expect(diagnostics[0]?.message).toContain('recover: (attempt, ctx)');
+    expect(diagnostics[0]?.message).toContain('attempt.error');
+    expect(diagnostics[0]?.message).toContain('Result.err(...)');
   });
 
   test('reports both issues when on and recover are malformed', () => {

--- a/packages/warden/src/rules/circular-refs.ts
+++ b/packages/warden/src/rules/circular-refs.ts
@@ -82,7 +82,7 @@ const buildCircularReferenceDiagnostic = (
 ): WardenDiagnostic => ({
   filePath,
   line,
-  message: `Contour "${contourName}" participates in circular contour references: ${cyclePath.join(' -> ')}.`,
+  message: `Contour "${contourName}" participates in circular contour references: ${cyclePath.join(' -> ')}. Break the cycle by removing one contour reference, or extract the shared shape into a new contour neither side depends on.`,
   rule: 'circular-refs',
   severity: 'warn',
 });

--- a/packages/warden/src/rules/contour-exists.ts
+++ b/packages/warden/src/rules/contour-exists.ts
@@ -133,7 +133,7 @@ const buildMissingContourDiagnostic = (
 ): WardenDiagnostic => ({
   filePath,
   line,
-  message: `Trail "${trailId}" declares contour "${contourName}" which is not defined in the project.`,
+  message: `Trail "${trailId}" declares contour "${contourName}" which is not defined in the project. Define it with contour('${contourName}', ...) and include it in the topo, or fix the contours entry if this is a typo.`,
   rule: 'contour-exists',
   severity: 'error',
 });

--- a/packages/warden/src/rules/cross-declarations.ts
+++ b/packages/warden/src/rules/cross-declarations.ts
@@ -455,8 +455,8 @@ const buildUndeclaredDiagnostic = (
   filePath,
   line,
   message: softened
-    ? `Trail "${trailId}": ctx.cross('${crossedId}') called but '${crossedId}' is not declared in crosses (may be declared via trail object references)`
-    : `Trail "${trailId}": ctx.cross('${crossedId}') called but '${crossedId}' is not declared in crosses`,
+    ? `Trail "${trailId}": ctx.cross('${crossedId}') called but '${crossedId}' is not declared in crosses (may be declared via trail object references). Add the string id to crosses, or use the same trail object form in both crosses and ctx.cross(...).`
+    : `Trail "${trailId}": ctx.cross('${crossedId}') called but '${crossedId}' is not declared in crosses. Add it to the trail crosses array: crosses: ['${crossedId}', ...].`,
   rule: 'cross-declarations',
   severity: softened ? 'warn' : 'error',
 });

--- a/packages/warden/src/rules/implementation-returns-result.ts
+++ b/packages/warden/src/rules/implementation-returns-result.ts
@@ -23,6 +23,9 @@ import {
 import { isTestFile } from './scan.js';
 import type { WardenDiagnostic, WardenRule } from './types.js';
 
+const buildUnrecognizedResultMessage = (label: string, id: string): string =>
+  `${label} "${id}": return value is not a recognized Result expression. Return Result.ok(...), Result.err(...), or a Result-producing expression such as await ctx.cross(...). If you are returning a crossed/helper Result, keep the provenance visible or add a Result return annotation Warden can trace.`;
+
 // ---------------------------------------------------------------------------
 // Member expression helpers
 // ---------------------------------------------------------------------------
@@ -225,7 +228,7 @@ const checkReturnStatements = (
       diagnostics.push({
         filePath,
         line: offsetToLine(sourceCode, node.start),
-        message: `${trailInfo.label} "${trailInfo.id}" implementation must return Result.ok(...) or Result.err(...), not a raw value.`,
+        message: buildUnrecognizedResultMessage(trailInfo.label, trailInfo.id),
         rule: 'implementation-returns-result',
         severity: 'error',
       });
@@ -1259,7 +1262,7 @@ const checkImplementation = (
     diagnostics.push({
       filePath,
       line: offsetToLine(sourceCode, implValue.start),
-      message: `${info.label} "${info.id}" implementation must return Result.ok(...) or Result.err(...), not a raw value.`,
+      message: buildUnrecognizedResultMessage(info.label, info.id),
       rule: 'implementation-returns-result',
       severity: 'error',
     });

--- a/packages/warden/src/rules/on-references-exist.ts
+++ b/packages/warden/src/rules/on-references-exist.ts
@@ -99,7 +99,7 @@ const buildMissingSignalDiagnostic = (
 ): WardenDiagnostic => ({
   filePath,
   line,
-  message: `Trail "${trailId}" declares on: "${signalId}" which is not a known signal in the project.`,
+  message: `Trail "${trailId}" declares on: "${signalId}" which is not a known signal in the project. Define it with signal('${signalId}', ...), include it in the topo, or fix the on: id if this is a typo.`,
   rule: 'on-references-exist',
   severity: 'error',
 });

--- a/packages/warden/src/rules/reference-exists.ts
+++ b/packages/warden/src/rules/reference-exists.ts
@@ -22,7 +22,7 @@ const buildMissingReferenceDiagnostic = (
 ): WardenDiagnostic => ({
   filePath,
   line,
-  message: `Contour "${sourceContour}" field "${field}" references contour "${targetContour}" which is not defined in the project.`,
+  message: `Contour "${sourceContour}" field "${field}" references contour "${targetContour}" which is not defined in the project. Define it with contour('${targetContour}', ...) and include it in the topo, or fix the field reference if this is a typo.`,
   rule: 'reference-exists',
   severity: 'error',
 });

--- a/packages/warden/src/rules/resource-declarations.ts
+++ b/packages/warden/src/rules/resource-declarations.ts
@@ -426,7 +426,7 @@ const buildUndeclaredFromDiagnostic = (
 ): WardenDiagnostic => ({
   filePath,
   line,
-  message: `Trail "${trailId}": ${resourceName}.from(ctx) called but '${resourceName}' is not declared in resources`,
+  message: `Trail "${trailId}": ${resourceName}.from(ctx) called but '${resourceName}' is not declared in resources. Add it to the trail resources array: resources: [${resourceName}].`,
   rule: 'resource-declarations',
   severity: 'error',
 });
@@ -439,7 +439,7 @@ const buildUndeclaredLookupDiagnostic = (
 ): WardenDiagnostic => ({
   filePath,
   line,
-  message: `Trail "${trailId}": ctx.resource('${resourceId}') called but '${resourceId}' is not declared in resources`,
+  message: `Trail "${trailId}": ctx.resource('${resourceId}') called but '${resourceId}' is not declared in resources. Add it to the trail resources array: resources: ['${resourceId}'], or prefer the resource definition's .from(ctx) helper when it is statically in scope.`,
   rule: 'resource-declarations',
   severity: 'error',
 });
@@ -452,7 +452,7 @@ const buildUndeclaredLookupNameDiagnostic = (
 ): WardenDiagnostic => ({
   filePath,
   line,
-  message: `Trail "${trailId}": ctx.resource(${resourceName}) called but '${resourceName}' is not declared in resources`,
+  message: `Trail "${trailId}": ctx.resource(${resourceName}) called but '${resourceName}' is not declared in resources. Add it to the trail resources array: resources: [${resourceName}].`,
   rule: 'resource-declarations',
   severity: 'error',
 });
@@ -465,7 +465,7 @@ const buildUnusedDiagnostic = (
 ): WardenDiagnostic => ({
   filePath,
   line,
-  message: `Trail "${trailId}": '${renderDeclaredResource(declaredResource)}' declared in resources but never used`,
+  message: `Trail "${trailId}": '${renderDeclaredResource(declaredResource)}' declared in resources but never used. Remove it from resources, or access it through the resource's static .from(ctx) helper if the trail really depends on it.`,
   rule: 'resource-declarations',
   severity: 'warn',
 });

--- a/packages/warden/src/rules/resource-exists.ts
+++ b/packages/warden/src/rules/resource-exists.ts
@@ -78,7 +78,7 @@ const buildMissingResourceDiagnostic = (
 ): WardenDiagnostic => ({
   filePath,
   line,
-  message: `Trail "${trailId}" declares resource "${resourceId}" which is not defined in the project.`,
+  message: `Trail "${trailId}" declares resource "${resourceId}" which is not defined in the project. Define it with resource('${resourceId}', ...) and ensure that definition is included in the topo.`,
   rule: 'resource-exists',
   severity: 'error',
 });

--- a/packages/warden/src/rules/valid-detour-contract.ts
+++ b/packages/warden/src/rules/valid-detour-contract.ts
@@ -56,7 +56,7 @@ const collectTrailDiagnostics = (topo: Topo): readonly WardenDiagnostic[] => {
       if (typeof candidate.recover !== 'function') {
         diagnostics.push(
           buildDiagnostic(
-            `Trail "${trail.id}" detour[${index}] must declare a callable recover function.`,
+            `Trail "${trail.id}" detour[${index}] must declare a callable recover function. Expected recover: (attempt, ctx) => Promise<Result<...>>; inspect attempt.error for the matched error and return Result.err(...) for unrecoverable cases.`,
             'valid-detour-contract'
           )
         );

--- a/packages/warden/src/trails/valid-detour-contract.trail.ts
+++ b/packages/warden/src/trails/valid-detour-contract.trail.ts
@@ -53,7 +53,7 @@ export const validDetourContractTrail = wrapTopoRule({
             filePath: '<topo>',
             line: 1,
             message:
-              'Trail "entity.save" detour[0] must declare a callable recover function.',
+              'Trail "entity.save" detour[0] must declare a callable recover function. Expected recover: (attempt, ctx) => Promise<Result<...>>; inspect attempt.error for the matched error and return Result.err(...) for unrecoverable cases.',
             rule: 'valid-detour-contract',
             severity: 'error',
           },


### PR DESCRIPTION
## Context

TRL-793 is the next Warden-as-coach slice after TRL-791. The goal here is narrow: upgrade existing names-only diagnostics so Warden teaches the canonical fix instead of only naming the violation.

This PR intentionally keeps rule firing logic unchanged. It is diagnostic text, exact-message test coverage, a rule-trail expectation update, a changeset, and the overnight execution packet.

## What Changed

- Taught the fix in diagnostics for:
  - `implementation-returns-result`
  - `resource-declarations`
  - `resource-exists`
  - `cross-declarations`
  - `valid-detour-contract`
  - `circular-refs`
  - `on-references-exist`
  - `contour-exists`
  - `reference-exists`
- Fixed review catches before submission:
  - `valid-detour-contract` now teaches the real recover shape: `(attempt, ctx)` with `attempt.error`.
  - softened `cross-declarations` wording no longer implies Warden can resolve arbitrary trail-object references.
  - included the same contour-reference family (`contour-exists`, `reference-exists`) that the audit initially omitted.
- Updated focused tests and the `valid-detour-contract` rule trail expectation.
- Added a patch changeset for `@ontrails/warden`.
- Added the overnight goal packet under `.agents/plans/2026-05-24-warden-as-coach-overnight-stack/`.

## Verification

- `bun test packages/warden/src/__tests__/implementation-returns-result.test.ts packages/warden/src/__tests__/resource-declarations.test.ts packages/warden/src/__tests__/resource-exists.test.ts packages/warden/src/__tests__/cross-declarations.test.ts packages/warden/src/__tests__/valid-detour-contract.test.ts packages/warden/src/__tests__/circular-refs.test.ts packages/warden/src/__tests__/on-references-exist.test.ts packages/warden/src/__tests__/contour-exists.test.ts packages/warden/src/__tests__/reference-exists.test.ts packages/warden/src/__tests__/trails.test.ts`
- `bun --cwd packages/warden test`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`
- `bun run check`

## Scope Notes

The Warden diagnostic audit also identified 13 partial diagnostics. Those are not included here; this PR is the names-only pass plus the same-family contour-reference omissions found during local review. The partial diagnostics are tracked separately in TRL-794.

## Risks / Rollout

Low behavior risk: diagnostics and tests changed, rule firing semantics did not. The main review surface is whether the new wording teaches the right Trails-native fix.

Closes TRL-793.
