### PR TITLE
fix(warden): trace aliased Result helpers

### DIFF
--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/GOAL.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/GOAL.md
@@ -9,7 +9,7 @@ Read first: `AGENTS.md`, `.agents/plans/PLANNING.md`, the packet `PLAN.md` and `
 
 Objective: clear as much Warden-as-coach work as safely possible overnight, turning Radio/Fieldwork learnings into Warden diagnostics/rules that lead agents toward Trails happy paths.
 
-Current known order: `TRL-791` is already draft PR #582 and should only need monitoring; finish `TRL-793` first (names-only diagnostics, no firing logic changes), keep `TRL-794` as the partial-diagnostics follow-up, then `TRL-785` (alias-aware Result helper provenance), then `TRL-786` (redundant `Result.err(x.error)` re-wrap detection after provenance exists), with `TRL-790` opportunistic and isolated.
+Current known order: `TRL-791` is already draft PR #582 and should only need monitoring; `TRL-793` is draft PR #583; keep `TRL-794` as the partial-diagnostics follow-up; `TRL-785` is draft PR #584; next is `TRL-786` (redundant `Result.err(x.error)` re-wrap detection after provenance exists), with `TRL-790` opportunistic and isolated.
 
 Work loop: execute one issue per focused branch/PR unless inseparable. After each turn report checkpoint, changed files, exact checks/artifact proof, result summary, remaining work, blocker status, and next checkpoint. Use bounded subagents for review/research; main agent owns all `git` and `gt` writes.
 

--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/PLAN.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/PLAN.md
@@ -111,7 +111,7 @@ Verification:
 
 ### TRL-785: Result helper provenance alias gap
 
-Status: next likely implementation slice after TRL-793.
+Status: draft PR submitted as #584; CI running.
 
 Intent:
 

--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/REFS.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/REFS.md
@@ -27,7 +27,8 @@
 ## PRs / Branches
 
 - PR #582 / `trl-791-warden-coach-against-destructured-ctxcross-new-reject-and` - TRL-791 draft PR, CI green as of 2026-05-24 00:34 EDT.
-- PR #583 / `trl-793-warden-upgrade-names-only-diagnostics-to-teach-the-fix-8` - TRL-793 draft PR, CI running as of 2026-05-24 00:55 EDT.
+- PR #583 / `trl-793-warden-upgrade-names-only-diagnostics-to-teach-the-fix-8` - TRL-793 draft PR, CI green as of 2026-05-24 01:00 EDT.
+- PR #584 / `trl-785-warden-extend-implementation-returns-result-to-track-helper` - TRL-785 draft PR, CI running as of 2026-05-24 01:07 EDT.
 
 ## Validation Commands
 

--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/RETRO.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/RETRO.md
@@ -12,10 +12,10 @@ Use this as the durable execution ledger. For stacked work, this should normally
 
 - Objective: clear Warden-as-coach slices that convert Radio/Fieldwork learnings into Trails guidance.
 - Final outcome: pending.
-- Final branch / stack tip: pending.
-- Final PR range: PR #582 for TRL-791; PR #583 for TRL-793.
-- Final tracker state: TRL-793 In Review; TRL-794 filed for partial diagnostics.
-- Final verification state: TRL-791 verified and CI green; TRL-793 locally verified through `bun run check`.
+- Final branch / stack tip: `trl-785-warden-extend-implementation-returns-result-to-track-helper`.
+- Final PR range: PR #582 for TRL-791; PR #583 for TRL-793; PR #584 for TRL-785.
+- Final tracker state: TRL-793 In Review; TRL-794 filed for partial diagnostics; TRL-785 In Progress.
+- Final verification state: TRL-791 verified and CI green; TRL-793 CI green; TRL-785 locally verified through `bun run check`.
 - Remaining risks / P3s: TRL-794 partial diagnostics remain follow-up.
 - Archive state: active packet, not archive-ready.
 
@@ -26,7 +26,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | 1 | TRL-791 | `trl-791-warden-coach-against-destructured-ctxcross-new-reject-and` | #582 | Draft, CI green | New `no-destructured-cross` rule submitted. |
 | 2 | TRL-793 | `trl-793-warden-upgrade-names-only-diagnostics-to-teach-the-fix-8` | #583 | Draft, CI running | Names-only diagnostics upgraded. |
 | 3 | TRL-794 | pending | pending | Todo | Follow-up for 13 partial diagnostics. |
-| 4 | TRL-785 | pending | pending | Planned | Alias-aware Result helper provenance gap. |
+| 4 | TRL-785 | `trl-785-warden-extend-implementation-returns-result-to-track-helper` | #584 | Draft, CI running | Alias-aware Result helper provenance gap; local checks green. |
 | 5 | TRL-786 | pending | pending | Planned | Should follow TRL-785 provenance work. |
 | 6 | TRL-790 | pending | pending | Optional | Keep isolated. |
 
@@ -53,6 +53,9 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | 2026-05-24 00:35 EDT | TRL-793 | Moved to In Progress and commented branch/start state. | Linear comment. |
 | 2026-05-24 00:54 EDT | TRL-794 | Created follow-up for 13 partial diagnostics. | Linear TRL-794. |
 | 2026-05-24 00:54 EDT | TRL-793 | Narrowed title to names-only, moved to In Review, attached/commented PR #583 and verification. | Linear comment `27bd08bb-8f72-40cb-a363-60577aa6c7d7`. |
+| 2026-05-24 01:00 EDT | TRL-793 | Added CI green comment for PR #583. | Linear comment `c2b165e8-b261-4354-b127-7f3053a84aef`. |
+| 2026-05-24 00:57 EDT | TRL-785 | Moved to In Progress and commented implementation start/scope. | Linear comment `4752fcc9-ecc6-4288-bfa9-0f684cc87282`. |
+| 2026-05-24 01:07 EDT | TRL-785 | Moved to In Review and commented PR/local verification/review state. | Linear comment `6d2ed339-0c67-485c-930f-ea82373d7dd0`. |
 
 ## Execution Log
 
@@ -84,6 +87,27 @@ Use this as the durable execution ledger. For stacked work, this should normally
 - Result: TRL-793 is In Review with PR #583.
 - Next: watch CI and remote review; then continue to TRL-785 unless Matt/Clark redirects.
 - Blockers: none.
+
+2026-05-24 01:00 EDT - TRL-793 remote CI green
+- Changed: updated Linear and shared note with PR #583 green CI state.
+- Verified: Build, Lint & Format, Dead Code, Typecheck, Test, Governance, Changeset, and CI Gate all green.
+- Result: PR #583 remains draft with green CI.
+- Next: continue TRL-785.
+- Blockers: none.
+
+2026-05-24 01:04 EDT - TRL-785 local implementation
+- Changed: made `implementation-returns-result` recognize `Result` aliases imported from `@ontrails/core`; helper calls now seed Result-variable provenance; added local/imported alias fixtures and changeset.
+- Verified: focused test, Warden package test, typecheck, lint, format, diff check, full repo check.
+- Result: local checks green; waiting for local review agents.
+- Next: fix any P0/P1/P2 review findings, then commit/submit draft PR.
+- Blockers: none.
+
+2026-05-24 01:07 EDT - TRL-785 draft PR submission
+- Changed: committed `1e27b3ec8`, submitted PR #584, wrote PR body, moved TRL-785 to In Review, added Linear verification/review comment.
+- Verified: PR opened as draft and CI started.
+- Result: TRL-785 is In Review with PR #584.
+- Next: watch CI; if green, decide whether to start TRL-786.
+- Blockers: none.
 ```
 
 ## Local Review Log
@@ -92,6 +116,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | --- | --- | --- | --- | --- |
 | TRL-791 | Rule behavior, docs/guides, tests | subagent reports in transcript | P0/P1/P2 fixed | PR #582 submitted after fixes. |
 | TRL-793 | Diagnostic wording and audit coverage | subagent reports in transcript | P2 fixed | Fixed valid-detour recover signature, softened trail-object cross guidance, added contour/reference rule family. |
+| TRL-785 | Correctness/false-positive lane and Clark doctrine/scope lane | subagent reports in transcript | Clean | Both lanes reported no P0/P1/P2/P3 findings; Clark agreed helper-call variable provenance is in scope. |
 
 ## Verification Log
 
@@ -105,6 +130,14 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | `git diff --check` | TRL-793 repo | Pass | No whitespace errors. |
 | `bun run check` | TRL-793 repo | Pass | Full repo gate passed; known Warden warnings printed by `trails warden`. |
 | PR #583 CI | TRL-793 remote | Running | Started after draft submission. |
+| PR #583 CI | TRL-793 remote | Pass | Build, Lint & Format, Dead Code, Typecheck, Test, Governance, Changeset, CI Gate all green. |
+| `bun test packages/warden/src/__tests__/implementation-returns-result.test.ts` | TRL-785 focused | Pass | 40 pass, 0 fail. |
+| `bun --cwd packages/warden test` | TRL-785 package | Pass | 917 pass, 0 fail. |
+| `bun run typecheck` | TRL-785 repo | Pass | 22 packages successful. |
+| `bun run lint` | TRL-785 repo | Pass | 23 tasks successful after `replace` -> `replaceAll` lint fix. |
+| `bun run format:check` | TRL-785 repo | Pass | Passed after `bun run format:fix`. |
+| `git diff --check` | TRL-785 repo | Pass | No whitespace errors. |
+| `bun run check` | TRL-785 repo | Pass | Full repo gate passed; known Warden warnings printed by `trails warden`. |
 
 ## Remote Review / CI Log
 
@@ -112,6 +145,8 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | --- | --- | --- | --- | --- | --- | --- |
 | 2026-05-24 00:34 EDT | #582 | Green | Draft | Local reviews clean after fixes | 0 known | Monitor / ready when appropriate. |
 | 2026-05-24 00:55 EDT | #583 | Running | Draft | Local reviews clean after fixes | 0 known | Watch CI. |
+| 2026-05-24 01:00 EDT | #583 | Green | Draft | GitHub checks green | 0 known | Keep draft; no merge/queue action. |
+| 2026-05-24 01:07 EDT | #584 | Running | Draft | Local reviews clean; CI started | 0 known | Watch CI. |
 
 ## Review Feedback Resolutions
 
@@ -120,6 +155,8 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | Clark local review | P2 | P2 | `valid-detour-contract` diagnostic taught wrong recover signature. | Use `(attempt, ctx)` and `attempt.error`. | Fixed in rule, tests, trail expectation. | TRL-793 local diff. |
 | Clark local review | P2 | P2 | `cross-declarations` softened trail-object guidance implied unsupported resolution. | Teach string id or same trail object form in both declaration and call. | Fixed in rule/tests. | TRL-793 local diff. |
 | Plato local review | P2 | P2 | Audit same-family contour reference rules were omitted. | Add teaching diagnostics for `contour-exists` and `reference-exists`. | Fixed in rules/tests. | TRL-793 local diff. |
+| James local review | Clean | None | No false-positive/cache/import-resolution findings. | None. | Accepted. | TRL-785 subagent report. |
+| Clark local review | Clean | None | Helper-call variable provenance is in scope and alias recognition is Trails-shaped. | None. | Accepted. | TRL-785 subagent report. |
 
 ## Forbidden Actions Audit
 
@@ -134,14 +171,14 @@ Use this as the durable execution ledger. For stacked work, this should normally
 ## Final State
 
 - Goal completion condition: pending.
-- Graphite / branch state: TRL-793 submitted v1 at `420a5fc9b`; packet update pending amend.
-- PR state: #582 draft CI green; #583 draft CI running.
+- Graphite / branch state: TRL-785 submitted v1 at `1e27b3ec8`; TRL-793 submitted v2 at `2f9f57e94`.
+- PR state: #582 draft CI green; #583 draft CI green; #584 draft CI running.
 - Source-control host lag: none known.
-- Tracker state: TRL-791 In Review; TRL-793 In Review; TRL-794 Todo; later issues pending.
-- Local review state: TRL-793 P2 findings fixed.
-- Remote review state: #583 CI running; review pending.
+- Tracker state: TRL-791 In Review; TRL-793 In Review; TRL-794 Todo; TRL-785 In Review; later issues pending.
+- Local review state: TRL-793 P2 findings fixed; TRL-785 review agents running.
+- Remote review state: #583 CI green; #584 CI running; review pending.
 - Remote review scores: pending.
-- Verification: TRL-793 local gates passed through `bun run check`.
+- Verification: TRL-793 and TRL-785 local gates passed through `bun run check`; PR #583 CI green.
 - Skipped checks: none for TRL-793 local handoff.
 - Remaining P3s / risks: partial diagnostic second wave tracked separately in TRL-794.
 - Follow-up issues created: TRL-794.

--- a/.changeset/warden-result-helper-aliases.md
+++ b/.changeset/warden-result-helper-aliases.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Recognize Result-returning helper provenance when helpers use an imported Result type alias.

--- a/packages/warden/src/__tests__/implementation-returns-result.test.ts
+++ b/packages/warden/src/__tests__/implementation-returns-result.test.ts
@@ -188,6 +188,39 @@ trail("entity.report", {
       expect(diagnostics.length).toBe(0);
     });
 
+    test('allows imported helper with aliased Result return annotation assigned to a variable', () => {
+      writeFile(
+        'aliased-result-helper.ts',
+        `import type { Result as ResultType } from '@ontrails/core';
+
+export const parseAndValidateBody = (): ResultType<object, Error> =>
+  Result.ok({ ok: true });
+`
+      );
+      const caller = writeFile(
+        'caller-aliased-result.ts',
+        `import { parseAndValidateBody } from './aliased-result-helper.js';
+
+trail("message.transmit", {
+  blaze: async (input, ctx) => {
+    const validated = parseAndValidateBody();
+    if (validated.isErr()) {
+      return validated;
+    }
+
+    return Result.ok({ ok: true });
+  }
+})`
+      );
+
+      const diagnostics = implementationReturnsResult.check(
+        readFileSync(caller, 'utf8'),
+        caller
+      );
+
+      expect(diagnostics.length).toBe(0);
+    });
+
     test('flags imported helper without Result return annotation', () => {
       writeFile(
         'plain-helper.ts',
@@ -1138,6 +1171,29 @@ trail("survey", {
     }
 
     return buildDetail(input.trailId);
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(0);
+  });
+
+  test('allows variables produced by local helpers with aliased Result return annotations', () => {
+    const code = `
+import type { Result as ResultType } from '@ontrails/core';
+
+const validateReplyTo = (replyTo: string | undefined): ResultType<object, Error> =>
+  Result.ok({ replyTo });
+
+trail("message.transmit", {
+  blaze: async (input, ctx) => {
+    const replyToResult = validateReplyTo(input.replyTo);
+    if (replyToResult.isErr()) {
+      return replyToResult;
+    }
+
+    return Result.ok({ ok: true });
   }
 })`;
 

--- a/packages/warden/src/rules/implementation-returns-result.ts
+++ b/packages/warden/src/rules/implementation-returns-result.ts
@@ -167,12 +167,21 @@ const isAllowedReturnArgument = (
 // ---------------------------------------------------------------------------
 
 /** Track a VariableDeclarator, adding to resultVars if it produces a Result. */
-const trackResultVariable = (node: AstNode, resultVars: Set<string>): void => {
+const trackResultVariable = (
+  node: AstNode,
+  resultVars: Set<string>,
+  helperNames: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap,
+  scopes: readonly ReadonlySet<string>[]
+): void => {
   const { init } = node as unknown as { init?: AstNode };
   const { id } = node as unknown as { id?: AstNode };
   if (init && id?.type === 'Identifier') {
     const { name } = id as unknown as { name: string };
-    if (isResultExpression(init)) {
+    if (
+      isResultExpression(init) ||
+      isHelperCall(init, helperNames, namespaceHelpers, scopes)
+    ) {
       resultVars.add(name);
     }
   }
@@ -200,7 +209,13 @@ const checkReturnStatements = (
     blockBody,
     (node, currentScopes) => {
       if (node.type === 'VariableDeclarator') {
-        trackResultVariable(node, resultVars);
+        trackResultVariable(
+          node,
+          resultVars,
+          helperNames,
+          namespaceHelpers,
+          currentScopes
+        );
       }
 
       if (node.type !== 'ReturnStatement') {
@@ -241,14 +256,75 @@ const checkReturnStatements = (
 // Result helper name collection
 // ---------------------------------------------------------------------------
 
-/** Check if a return type annotation mentions Result. */
-const hasResultReturnType = (node: AstNode, sourceCode: string): boolean => {
+const getImportSourceValue = (node: AstNode): string | null => {
+  const sourceNode = (node as unknown as { source?: AstNode }).source;
+  const sourceValue = sourceNode
+    ? (sourceNode as unknown as { value?: unknown }).value
+    : undefined;
+  return typeof sourceValue === 'string' ? sourceValue : null;
+};
+
+const extractIdentifierName = (node: AstNode | undefined): string | null =>
+  node?.type === 'Identifier'
+    ? ((node as unknown as { name: string }).name ?? null)
+    : null;
+
+const DEFAULT_RESULT_TYPE_NAMES = new Set(['Result']);
+
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const hasGenericTypeReference = (
+  annotationText: string,
+  typeName: string
+): boolean =>
+  new RegExp(`(^|[^\\w$])${escapeRegExp(typeName)}\\s*<`).test(annotationText);
+
+const collectResultTypeNames = (ast: AstNode): ReadonlySet<string> => {
+  const names = new Set(DEFAULT_RESULT_TYPE_NAMES);
+  walk(ast, (node) => {
+    if (
+      node.type !== 'ImportDeclaration' ||
+      getImportSourceValue(node) !== '@ontrails/core'
+    ) {
+      return;
+    }
+    const specifiers =
+      (node['specifiers'] as readonly AstNode[] | undefined) ?? [];
+    for (const specifier of specifiers) {
+      if (specifier.type !== 'ImportSpecifier') {
+        continue;
+      }
+      const { imported, local } = specifier as unknown as {
+        imported?: AstNode;
+        local?: AstNode;
+      };
+      if (extractIdentifierName(imported) !== 'Result') {
+        continue;
+      }
+      names.add(extractIdentifierName(local) ?? 'Result');
+    }
+  });
+  return names;
+};
+
+/** Check if a return type annotation mentions Result or an imported Result alias. */
+const hasResultReturnType = (
+  node: AstNode,
+  sourceCode: string,
+  resultTypeNames: ReadonlySet<string> = DEFAULT_RESULT_TYPE_NAMES
+): boolean => {
   const { returnType } = node as unknown as { returnType?: AstNode };
   if (!returnType) {
     return false;
   }
   const annotationText = sourceCode.slice(returnType.start, returnType.end);
-  return /\bResult\s*</.test(annotationText);
+  for (const name of resultTypeNames) {
+    if (hasGenericTypeReference(annotationText, name)) {
+      return true;
+    }
+  }
+  return false;
 };
 
 const isFunctionLikeExpression = (node: AstNode): boolean =>
@@ -260,6 +336,7 @@ const collectResultHelperNames = (
   sourceCode: string
 ): ReadonlySet<string> => {
   const names = new Set<string>();
+  const resultTypeNames = collectResultTypeNames(ast);
 
   walk(ast, (node) => {
     if (node.type === 'VariableDeclarator') {
@@ -269,7 +346,7 @@ const collectResultHelperNames = (
         id?.type === 'Identifier' &&
         init &&
         isFunctionLikeExpression(init) &&
-        hasResultReturnType(init, sourceCode)
+        hasResultReturnType(init, sourceCode, resultTypeNames)
       ) {
         names.add((id as unknown as { name: string }).name);
       }
@@ -277,7 +354,10 @@ const collectResultHelperNames = (
 
     if (node.type === 'FunctionDeclaration') {
       const { id } = node as unknown as { id?: AstNode };
-      if (id?.type === 'Identifier' && hasResultReturnType(node, sourceCode)) {
+      if (
+        id?.type === 'Identifier' &&
+        hasResultReturnType(node, sourceCode, resultTypeNames)
+      ) {
         names.add((id as unknown as { name: string }).name);
       }
     }
@@ -324,19 +404,6 @@ interface ImportBinding {
   /** Raw import source specifier (e.g. './foo.js'). */
   readonly source: string;
 }
-
-const getImportSourceValue = (node: AstNode): string | null => {
-  const sourceNode = (node as unknown as { source?: AstNode }).source;
-  const sourceValue = sourceNode
-    ? (sourceNode as unknown as { value?: unknown }).value
-    : undefined;
-  return typeof sourceValue === 'string' ? sourceValue : null;
-};
-
-const extractIdentifierName = (node: AstNode | undefined): string | null =>
-  node?.type === 'Identifier'
-    ? ((node as unknown as { name: string }).name ?? null)
-    : null;
 
 const buildDefaultImportBinding = (
   specifier: AstNode,
@@ -468,7 +535,8 @@ const getExportedDeclaration = (node: AstNode): AstNode | null => {
 const addExportedVariableResultHelper = (
   decl: AstNode,
   source: string,
-  collected: Set<string>
+  collected: Set<string>,
+  resultTypeNames: ReadonlySet<string>
 ): void => {
   const declarations =
     (decl['declarations'] as readonly AstNode[] | undefined) ?? [];
@@ -482,7 +550,7 @@ const addExportedVariableResultHelper = (
       name &&
       init &&
       isFunctionLikeExpression(init) &&
-      hasResultReturnType(init, source)
+      hasResultReturnType(init, source, resultTypeNames)
     ) {
       collected.add(name);
     }
@@ -492,10 +560,11 @@ const addExportedVariableResultHelper = (
 const addExportedFunctionResultHelper = (
   decl: AstNode,
   source: string,
-  collected: Set<string>
+  collected: Set<string>,
+  resultTypeNames: ReadonlySet<string>
 ): void => {
   const name = extractIdentifierName((decl as unknown as { id?: AstNode }).id);
-  if (name && hasResultReturnType(decl, source)) {
+  if (name && hasResultReturnType(decl, source, resultTypeNames)) {
     collected.add(name);
   }
 };
@@ -642,16 +711,17 @@ const MAX_RERESOLVE_DEPTH = 1;
 /** Check whether a local declaration node has a `Result<...>` return annotation. */
 const isResultHelperDeclaration = (
   declarationNode: AstNode | undefined,
-  source: string
+  source: string,
+  resultTypeNames: ReadonlySet<string>
 ): boolean => {
   if (!declarationNode) {
     return false;
   }
   if (isFunctionLikeExpression(declarationNode)) {
-    return hasResultReturnType(declarationNode, source);
+    return hasResultReturnType(declarationNode, source, resultTypeNames);
   }
   if (declarationNode.type === 'FunctionDeclaration') {
-    return hasResultReturnType(declarationNode, source);
+    return hasResultReturnType(declarationNode, source, resultTypeNames);
   }
   return false;
 };
@@ -660,15 +730,16 @@ const isResultHelperDeclaration = (
 const checkDefaultDeclarationIsResultHelper = (
   defaultDecl: AstNode,
   targetSource: string,
-  targetLocalDeclarations: DeclarationIndex
+  targetLocalDeclarations: DeclarationIndex,
+  resultTypeNames: ReadonlySet<string>
 ): boolean => {
-  if (isResultHelperDeclaration(defaultDecl, targetSource)) {
+  if (isResultHelperDeclaration(defaultDecl, targetSource, resultTypeNames)) {
     return true;
   }
   if (defaultDecl.type === 'Identifier') {
     const name = extractIdentifierName(defaultDecl);
     const referenced = name ? targetLocalDeclarations.get(name) : undefined;
-    return isResultHelperDeclaration(referenced, targetSource);
+    return isResultHelperDeclaration(referenced, targetSource, resultTypeNames);
   }
   return false;
 };
@@ -677,6 +748,7 @@ interface LoadedTargetFile {
   readonly ast: AstNode;
   readonly source: string;
   readonly localDeclarations: DeclarationIndex;
+  readonly resultTypeNames: ReadonlySet<string>;
 }
 
 const loadTargetFile = (targetPath: string): LoadedTargetFile | null => {
@@ -689,6 +761,7 @@ const loadTargetFile = (targetPath: string): LoadedTargetFile | null => {
     return {
       ast,
       localDeclarations: indexLocalDeclarations(ast),
+      resultTypeNames: collectResultTypeNames(ast),
       source,
     };
   } catch {
@@ -717,7 +790,8 @@ const applyDefaultSpecifier = (
     checkDefaultDeclarationIsResultHelper(
       defaultDecl,
       loadedTarget.source,
-      loadedTarget.localDeclarations
+      loadedTarget.localDeclarations,
+      loadedTarget.resultTypeNames
     )
   ) {
     collected.add(info.exportedName);
@@ -826,7 +900,8 @@ const resolveReExportWithoutSource = (
   specifiers: readonly AstNode[],
   localDeclarations: DeclarationIndex,
   source: string,
-  collected: Set<string>
+  collected: Set<string>,
+  resultTypeNames: ReadonlySet<string>
 ): void => {
   for (const spec of specifiers) {
     const info = buildExportSpecifierInfo(spec);
@@ -834,7 +909,11 @@ const resolveReExportWithoutSource = (
       continue;
     }
     if (
-      isResultHelperDeclaration(localDeclarations.get(info.localName), source)
+      isResultHelperDeclaration(
+        localDeclarations.get(info.localName),
+        source,
+        resultTypeNames
+      )
     ) {
       collected.add(info.exportedName);
     }
@@ -844,14 +923,25 @@ const resolveReExportWithoutSource = (
 const processInlineExportedDeclaration = (
   exportedDecl: AstNode,
   source: string,
-  collected: Set<string>
+  collected: Set<string>,
+  resultTypeNames: ReadonlySet<string>
 ): boolean => {
   if (exportedDecl.type === 'VariableDeclaration') {
-    addExportedVariableResultHelper(exportedDecl, source, collected);
+    addExportedVariableResultHelper(
+      exportedDecl,
+      source,
+      collected,
+      resultTypeNames
+    );
     return true;
   }
   if (exportedDecl.type === 'FunctionDeclaration') {
-    addExportedFunctionResultHelper(exportedDecl, source, collected);
+    addExportedFunctionResultHelper(
+      exportedDecl,
+      source,
+      collected,
+      resultTypeNames
+    );
     return true;
   }
   return false;
@@ -864,12 +954,18 @@ const processExportNamedDeclaration = (
   visited: ReadonlySet<string>,
   depth: number,
   localDeclarations: DeclarationIndex,
-  collected: Set<string>
+  collected: Set<string>,
+  resultTypeNames: ReadonlySet<string>
 ): void => {
   const exportedDecl = getExportedDeclaration(node);
   if (
     exportedDecl &&
-    processInlineExportedDeclaration(exportedDecl, source, collected)
+    processInlineExportedDeclaration(
+      exportedDecl,
+      source,
+      collected,
+      resultTypeNames
+    )
   ) {
     return;
   }
@@ -893,7 +989,8 @@ const processExportNamedDeclaration = (
     specifiers,
     localDeclarations,
     source,
-    collected
+    collected,
+    resultTypeNames
   );
 };
 
@@ -901,7 +998,8 @@ const processExportDefaultDeclaration = (
   node: AstNode,
   source: string,
   localDeclarations: DeclarationIndex,
-  collected: Set<string>
+  collected: Set<string>,
+  resultTypeNames: ReadonlySet<string>
 ): void => {
   const defaultDecl = (node as unknown as { declaration?: AstNode })
     .declaration;
@@ -912,7 +1010,8 @@ const processExportDefaultDeclaration = (
     checkDefaultDeclarationIsResultHelper(
       defaultDecl,
       source,
-      localDeclarations
+      localDeclarations,
+      resultTypeNames
     )
   ) {
     collected.add('default');
@@ -925,13 +1024,16 @@ const collectExportedResultHelpersFromAst = (
   targetPath: string,
   visited: ReadonlySet<string>,
   depth: number,
-  preloadedLocalDeclarations: DeclarationIndex | null = null
+  preloadedLocalDeclarations: DeclarationIndex | null = null,
+  preloadedResultTypeNames: ReadonlySet<string> | null = null
 ): ReadonlySet<string> => {
   const collected = new Set<string>();
-  // Reuse the preloaded declaration index when available (e.g., threaded in
-  // from `loadTargetFile`) to avoid re-walking the same AST.
+  // Reuse preloaded indexes from `loadTargetFile` when available to avoid
+  // re-walking the same AST.
   const localDeclarations =
     preloadedLocalDeclarations ?? indexLocalDeclarations(ast);
+  const resultTypeNames =
+    preloadedResultTypeNames ?? collectResultTypeNames(ast);
   const program = ast as unknown as { body?: readonly AstNode[] };
   const bodyNodes = program.body ?? [];
 
@@ -944,14 +1046,16 @@ const collectExportedResultHelpersFromAst = (
         visited,
         depth,
         localDeclarations,
-        collected
+        collected,
+        resultTypeNames
       );
     } else if (node.type === 'ExportDefaultDeclaration') {
       processExportDefaultDeclaration(
         node,
         source,
         localDeclarations,
-        collected
+        collected,
+        resultTypeNames
       );
     } else if (node.type === 'ExportAllDeclaration') {
       // eslint-disable-next-line no-use-before-define
@@ -1021,7 +1125,8 @@ const parseTargetResultHelperNames = (
     targetPath,
     visited,
     depth,
-    loaded.localDeclarations
+    loaded.localDeclarations,
+    loaded.resultTypeNames
   );
 };
 


### PR DESCRIPTION
## Context

TRL-785 closes the Radio-discovered gap in `implementation-returns-result`: helpers with visible Result return annotations were already followed after TRL-333, but aliases like `import type { Result as ResultType }` were invisible, and Radio returned variables assigned from helper calls.

This PR keeps the rule bounded to visible Trails `Result` provenance. It does not add a general TypeScript type solver.

## What Changed

- Collect local names for `Result` imported from `@ontrails/core`, including aliases like `ResultType`.
- Match explicit helper return annotations against those Result names.
- Let known Result helper calls seed Result-variable provenance, so this shape is accepted:

```ts
const validated = parseAndValidateBody(input.body);
if (validated.isErr()) {
  return validated;
}
```

- Added fixtures for:
  - imported helper annotated with `ResultType<...>` and assigned to a variable
  - local helper annotated with `ResultType<...>` and assigned to a variable
- Added a patch changeset for `@ontrails/warden`.
- Updated the overnight execution packet retro.

## Verification

- `bun test packages/warden/src/__tests__/implementation-returns-result.test.ts`
- `bun --cwd packages/warden test`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`
- `bun run check`

## Local Review

- Correctness / false-positive lane: clean, no P0/P1/P2/P3.
- Clark doctrine / scope lane: clean, no P0/P1/P2/P3. Clark agreed helper-call variable provenance is in scope because the Radio failure shape returns assigned helper results.

## Risks / Rollout

Medium-low behavior risk: this broadens what the rule recognizes as a visible Result-producing helper, but only when the helper itself is already known through explicit return annotations and `Result` provenance from `@ontrails/core`. Existing `.js` to `.ts` resolution and re-export cache behavior are unchanged.

Closes TRL-785.
