### PR TITLE
fix(warden): warn on redundant Result.err re-wraps

### DIFF
--- a/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/RETRO.md
+++ b/.agents/plans/2026-05-24-warden-as-coach-overnight-stack/RETRO.md
@@ -12,11 +12,11 @@ Use this as the durable execution ledger. For stacked work, this should normally
 
 - Objective: clear Warden-as-coach slices that convert Radio/Fieldwork learnings into Trails guidance.
 - Final outcome: pending.
-- Final branch / stack tip: `trl-785-warden-extend-implementation-returns-result-to-track-helper`.
-- Final PR range: PR #582 for TRL-791; PR #583 for TRL-793; PR #584 for TRL-785.
-- Final tracker state: TRL-793 In Review; TRL-794 filed for partial diagnostics; TRL-785 In Progress.
-- Final verification state: TRL-791 verified and CI green; TRL-793 CI green; TRL-785 locally verified through `bun run check`.
-- Remaining risks / P3s: TRL-794 partial diagnostics remain follow-up.
+- Final branch / stack tip: `trl-786-warden-detect-redundant-resulterrxerror-re-wraps-inverse-of`.
+- Final PR range: PR #582 for TRL-791; PR #583 for TRL-793; PR #584 for TRL-785; TRL-786 pending submission.
+- Final tracker state: TRL-793 In Review; TRL-794 filed for partial diagnostics; TRL-785 In Review; TRL-786 local verified, tracker update pending.
+- Final verification state: TRL-791 verified and CI green; TRL-793 CI green; TRL-785 CI green; TRL-786 locally verified through `bun run check`.
+- Remaining risks / P3s: TRL-794 partial diagnostics remain follow-up; TRL-786 surfaces existing redundant re-wrap warnings for a separate cleanup lane.
 - Archive state: active packet, not archive-ready.
 
 ## Branch / PR / Issue Ledger
@@ -27,7 +27,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | 2 | TRL-793 | `trl-793-warden-upgrade-names-only-diagnostics-to-teach-the-fix-8` | #583 | Draft, CI running | Names-only diagnostics upgraded. |
 | 3 | TRL-794 | pending | pending | Todo | Follow-up for 13 partial diagnostics. |
 | 4 | TRL-785 | `trl-785-warden-extend-implementation-returns-result-to-track-helper` | #584 | Draft, CI running | Alias-aware Result helper provenance gap; local checks green. |
-| 5 | TRL-786 | pending | pending | Planned | Should follow TRL-785 provenance work. |
+| 5 | TRL-786 | `trl-786-warden-detect-redundant-resulterrxerror-re-wraps-inverse-of` | pending | Local verified | New redundant `Result.err(x.error)` re-wrap detector; draft PR pending. |
 | 6 | TRL-790 | pending | pending | Optional | Keep isolated. |
 
 ## Planning Discoveries
@@ -108,6 +108,14 @@ Use this as the durable execution ledger. For stacked work, this should normally
 - Result: TRL-785 is In Review with PR #584.
 - Next: watch CI; if green, decide whether to start TRL-786.
 - Blockers: none.
+
+2026-05-24 01:30 EDT - TRL-786 local verification
+- Changed: added `no-redundant-result-error-wrap` as a Warden warning rule with rule metadata, trail wrapper, registry exports, generated guide updates, tests, and changeset.
+- Changed: reused `implementation-returns-result` helper provenance and tightened it with scoped Result-helper tracking so local Result helpers count while plain shadows still fail.
+- Verified: focused rule/provenance tests, Warden package suite, repo lint, full repo check with explicit `CHECK_EXIT:0`, and whitespace diff check.
+- Result: local branch verified and ready to commit/submit as draft PR.
+- Next: commit with Graphite, submit draft PR, update Linear/shared note, then decide whether the next branch should clean existing warning sites or move to TRL-790.
+- Blockers: none.
 ```
 
 ## Local Review Log
@@ -117,6 +125,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | TRL-791 | Rule behavior, docs/guides, tests | subagent reports in transcript | P0/P1/P2 fixed | PR #582 submitted after fixes. |
 | TRL-793 | Diagnostic wording and audit coverage | subagent reports in transcript | P2 fixed | Fixed valid-detour recover signature, softened trail-object cross guidance, added contour/reference rule family. |
 | TRL-785 | Correctness/false-positive lane and Clark doctrine/scope lane | subagent reports in transcript | Clean | Both lanes reported no P0/P1/P2/P3 findings; Clark agreed helper-call variable provenance is in scope. |
+| TRL-786 | Firing logic, scoped provenance, wiring/tests | subagent report in transcript | P2 fixed | Fixed provenance leakage across scopes and direct helper shadow handling; added regression tests. |
 
 ## Verification Log
 
@@ -138,6 +147,12 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | `bun run format:check` | TRL-785 repo | Pass | Passed after `bun run format:fix`. |
 | `git diff --check` | TRL-785 repo | Pass | No whitespace errors. |
 | `bun run check` | TRL-785 repo | Pass | Full repo gate passed; known Warden warnings printed by `trails warden`. |
+| `bun test packages/warden/src/__tests__/implementation-returns-result.test.ts packages/warden/src/__tests__/no-redundant-result-error-wrap.test.ts` | TRL-786 focused | Pass | 53 pass, 0 fail. |
+| `bun --cwd packages/warden test` | TRL-786 package | Pass | 932 pass, 0 fail. |
+| `bun run lint` | TRL-786 repo | Pass | 23 tasks successful. |
+| `bun trails warden` | TRL-786 repo | Pass | 0 errors, 62 warnings. New rule reports existing redundant re-wrap warnings; detector remains warning-only. |
+| `git diff --check` | TRL-786 repo | Pass | No whitespace errors. |
+| `bun run check` | TRL-786 repo | Pass | Captured with explicit `CHECK_EXIT:0`; Warden warning set printed during `trails:check`. |
 
 ## Remote Review / CI Log
 
@@ -157,12 +172,14 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | Plato local review | P2 | P2 | Audit same-family contour reference rules were omitted. | Add teaching diagnostics for `contour-exists` and `reference-exists`. | Fixed in rules/tests. | TRL-793 local diff. |
 | James local review | Clean | None | No false-positive/cache/import-resolution findings. | None. | Accepted. | TRL-785 subagent report. |
 | Clark local review | Clean | None | Helper-call variable provenance is in scope and alias recognition is Trails-shaped. | None. | Accepted. | TRL-785 subagent report. |
+| Herschel local review | P2 | P2 | Function-wide provenance set could leak block-scoped Result variables or lose outer provenance through inner shadows. | Key Result provenance by lexical binding scope. | Fixed with scope-frame provenance map and regression tests. | TRL-786 local diff. |
+| Herschel local review | P2 | P2 | Direct helper-call detection treated shadowed helper names as Result provenance. | Reject plain local shadows while preserving scoped helpers with explicit Result return annotations. | Fixed with scoped helper map and regression tests. | TRL-786 local diff. |
 
 ## Forbidden Actions Audit
 
 | Action / Constraint | Status | Evidence |
 | --- | --- | --- |
-| No merge without explicit user approval | Respected | PR #582 is draft; TRL-793 local only so far. |
+| No merge without explicit user approval | Respected | PRs #582, #583, and #584 are draft; TRL-786 local only so far. |
 | No package publish / registry mutation unless authorized | Respected | No publish commands run. |
 | No merge queue label unless authorized | Respected | No merge queue label applied. |
 | No source-control writes by subagents | Respected | Subagents only reviewed/researched. |
@@ -171,16 +188,16 @@ Use this as the durable execution ledger. For stacked work, this should normally
 ## Final State
 
 - Goal completion condition: pending.
-- Graphite / branch state: TRL-785 submitted v1 at `1e27b3ec8`; TRL-793 submitted v2 at `2f9f57e94`.
-- PR state: #582 draft CI green; #583 draft CI green; #584 draft CI running.
+- Graphite / branch state: TRL-786 local verified on top of TRL-785; TRL-785 submitted v1 at `1e27b3ec8`; TRL-793 submitted v2 at `2f9f57e94`.
+- PR state: #582 draft CI green; #583 draft CI green; #584 draft CI green; TRL-786 pending submission.
 - Source-control host lag: none known.
-- Tracker state: TRL-791 In Review; TRL-793 In Review; TRL-794 Todo; TRL-785 In Review; later issues pending.
-- Local review state: TRL-793 P2 findings fixed; TRL-785 review agents running.
-- Remote review state: #583 CI green; #584 CI running; review pending.
+- Tracker state: TRL-791 In Review; TRL-793 In Review; TRL-794 Todo; TRL-785 In Review; TRL-786 update pending.
+- Local review state: TRL-793 P2 findings fixed; TRL-785 clean; TRL-786 P2 findings fixed.
+- Remote review state: #583 CI green; #584 CI green; TRL-786 not submitted yet.
 - Remote review scores: pending.
-- Verification: TRL-793 and TRL-785 local gates passed through `bun run check`; PR #583 CI green.
+- Verification: TRL-793, TRL-785, and TRL-786 local gates passed through `bun run check`; PR #583 and #584 CI green.
 - Skipped checks: none for TRL-793 local handoff.
-- Remaining P3s / risks: partial diagnostic second wave tracked separately in TRL-794.
+- Remaining P3s / risks: partial diagnostic second wave tracked separately in TRL-794; existing redundant re-wrap warning cleanup should stay separate from detector PR.
 - Follow-up issues created: TRL-794.
 - Forbidden actions confirmation: no merge, publish, registry mutation, merge queue label, or subagent source-control write.
 - Packet archive readiness: not ready.

--- a/.changeset/warden-redundant-result-error-wrap.md
+++ b/.changeset/warden-redundant-result-error-wrap.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Add a warning for blazes that re-wrap an existing Result error with Result.err(result.error) instead of returning the original Result.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -80,6 +80,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `error-mapping-completeness` (error, source/source-static, extension): Registered surface error mappers cover every error category.
 - `implementation-returns-result` (error, source/source-static, external): Blazes return Result values.
 - `no-native-error-result` (error, source/source-static, external): Result error boundaries carry specific TrailsError subclasses.
+- `no-redundant-result-error-wrap` (warn, source/source-static, external): Result error pass-throughs preserve the original Result boundary.
 - `no-sync-result-assumption` (error, source/source-static, external): Result accessors are not used before async results are awaited.
 - `no-throw-in-detour-recover` (error, source/source-static, external): Detour recovery returns Result instead of throwing.
 - `no-throw-in-implementation` (error, source/source-static, external): Blazes return Result.err() instead of throwing. Guidance: Convert thrown failures in blazes into explicit Result.err() outcomes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `error-mapping-completeness` (error, source/source-static, extension): Registered surface error mappers cover every error category.
 - `implementation-returns-result` (error, source/source-static, external): Blazes return Result values.
 - `no-native-error-result` (error, source/source-static, external): Result error boundaries carry specific TrailsError subclasses.
+- `no-redundant-result-error-wrap` (warn, source/source-static, external): Result error pass-throughs preserve the original Result boundary.
 - `no-sync-result-assumption` (error, source/source-static, external): Result accessors are not used before async results are awaited.
 - `no-throw-in-detour-recover` (error, source/source-static, external): Detour recovery returns Result instead of throwing.
 - `no-throw-in-implementation` (error, source/source-static, external): Blazes return Result.err() instead of throwing.

--- a/packages/warden/src/__tests__/implementation-returns-result.test.ts
+++ b/packages/warden/src/__tests__/implementation-returns-result.test.ts
@@ -1201,4 +1201,42 @@ trail("message.transmit", {
 
     expect(diagnostics.length).toBe(0);
   });
+
+  test('flags helper calls when a local binding shadows a Result helper name', () => {
+    const code = `
+const parseInput = (): Result<object, Error> =>
+  Result.ok({ ok: true });
+
+trail("message.transmit", {
+  blaze: async (input, ctx) => {
+    const parseInput = () => ({ ok: true });
+    return parseInput();
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.message).toContain(
+      'not a recognized Result expression'
+    );
+  });
+
+  test('allows helper calls when the local binding has a Result return annotation', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail("message.transmit", {
+  blaze: async () => {
+    const finishCreate = async (): Promise<Result<object, Error>> =>
+      Result.ok({ ok: true });
+
+    return finishCreate();
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(0);
+  });
 });

--- a/packages/warden/src/__tests__/no-redundant-result-error-wrap.test.ts
+++ b/packages/warden/src/__tests__/no-redundant-result-error-wrap.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from 'bun:test';
+
+import { noRedundantResultErrorWrap } from '../rules/no-redundant-result-error-wrap.js';
+
+const TEST_FILE = 'src/trails/entity.ts';
+
+describe('no-redundant-result-error-wrap', () => {
+  test('flags Result.err(result.error) for ctx.cross results', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail('entity.load', {
+  crosses: ['entity.fetch'],
+  blaze: async (input, ctx) => {
+    const fetched = await ctx.cross('entity.fetch', input);
+    if (fetched.isErr()) {
+      return Result.err(fetched.error);
+    }
+    return Result.ok(fetched.value);
+  },
+});
+`;
+
+    const diagnostics = noRedundantResultErrorWrap.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('no-redundant-result-error-wrap');
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toContain('entity.load');
+    expect(diagnostics[0]?.message).toContain('Return fetched directly');
+  });
+
+  test('flags Result.err(result.error) for Result helper variables', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+import type { Result as ResultType } from '@ontrails/core';
+
+const parseInput = (): ResultType<{ readonly id: string }, Error> =>
+  Result.err(new Error('bad'));
+
+trail('entity.load', {
+  blaze: async (input, ctx) => {
+    const parsed = parseInput();
+    if (parsed.isErr()) {
+      return Result.err(parsed.error);
+    }
+    return Result.ok(parsed.value);
+  },
+});
+`;
+
+    const diagnostics = noRedundantResultErrorWrap.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('Return parsed directly');
+  });
+
+  test('allows returning the Result directly', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail('entity.load', {
+  crosses: ['entity.fetch'],
+  blaze: async (input, ctx) => {
+    const fetched = await ctx.cross('entity.fetch', input);
+    if (fetched.isErr()) {
+      return fetched;
+    }
+    return Result.ok(fetched.value);
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not flag transformed errors', () => {
+    const code = `
+import { InternalError, Result, trail } from '@ontrails/core';
+
+trail('entity.load', {
+  crosses: ['entity.fetch'],
+  blaze: async (input, ctx) => {
+    const fetched = await ctx.cross('entity.fetch', input);
+    if (fetched.isErr()) {
+      return Result.err(new InternalError(fetched.error.message));
+    }
+    return Result.ok(fetched.value);
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not flag variables without visible Result provenance', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail('entity.load', {
+  blaze: async (input, ctx) => {
+    const response = await fetch(input.url);
+    if (!response.ok) {
+      return Result.err(response.error);
+    }
+    return Result.ok(response);
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('clears provenance after reassignment', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail('entity.load', {
+  crosses: ['entity.fetch'],
+  blaze: async (input, ctx) => {
+    let fetched = await ctx.cross('entity.fetch', input);
+    fetched = { error: new Error('different') };
+    return Result.err(fetched.error);
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('keeps block-scoped Result provenance from leaking to outer shadows', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail('entity.load', {
+  crosses: ['entity.fetch'],
+  blaze: async (input, ctx) => {
+    const fetched = { error: new Error('plain') };
+    if (input.fetch) {
+      const fetched = await ctx.cross('entity.fetch', input);
+      if (fetched.isErr()) {
+        return fetched;
+      }
+    }
+    return Result.err(fetched.error);
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('block-scoped shadows do not erase outer Result provenance', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail('entity.load', {
+  crosses: ['entity.fetch'],
+  blaze: async (input, ctx) => {
+    const fetched = await ctx.cross('entity.fetch', input);
+    if (input.local) {
+      const fetched = { error: new Error('plain') };
+      void fetched;
+    }
+    if (fetched.isErr()) {
+      return Result.err(fetched.error);
+    }
+    return Result.ok(fetched.value);
+  },
+});
+`;
+
+    const diagnostics = noRedundantResultErrorWrap.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('Return fetched directly');
+  });
+
+  test('does not treat a shadowed helper name as Result provenance', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+import type { Result as ResultType } from '@ontrails/core';
+
+const parseInput = (): ResultType<{ readonly id: string }, Error> =>
+  Result.err(new Error('bad'));
+
+trail('entity.load', {
+  blaze: async (input, ctx) => {
+    const parseInput = () => ({ error: new Error('plain') });
+    const parsed = parseInput();
+    return Result.err(parsed.error);
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('tracks scoped Result helper calls as Result provenance', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+import type { Result as ResultType } from '@ontrails/core';
+
+trail('entity.load', {
+  blaze: async (input, ctx) => {
+    const parseInput = (): ResultType<{ readonly id: string }, Error> =>
+      Result.err(new Error('bad'));
+    const parsed = parseInput();
+    return Result.err(parsed.error);
+  },
+});
+`;
+
+    const diagnostics = noRedundantResultErrorWrap.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('Return parsed directly');
+  });
+
+  test('ignores return statements inside nested callbacks', () => {
+    const code = `
+import { Result, trail } from '@ontrails/core';
+
+trail('entity.load', {
+  crosses: ['entity.fetch'],
+  blaze: async (input, ctx) => {
+    const fetched = await ctx.cross('entity.fetch', input);
+    input.items.map(() => {
+      return Result.err(fetched.error);
+    });
+    return fetched;
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -8,8 +8,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 57 rule trails', () => {
-    expect(wardenTopo.count).toBe(57);
+  test('contains all 58 rule trails', () => {
+    expect(wardenTopo.count).toBe(58);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -168,6 +168,7 @@ export {
   noDirectImplementationCallTrail,
   noLegacyLayerImportsTrail,
   noNativeErrorResultTrail,
+  noRedundantResultErrorWrapTrail,
   noSyncResultAssumptionTrail,
   noThrowInDetourRecoverTrail,
   noThrowInImplementationTrail,

--- a/packages/warden/src/rules/implementation-returns-result.ts
+++ b/packages/warden/src/rules/implementation-returns-result.ts
@@ -51,7 +51,7 @@ const isResultMemberCall = (callee: AstNode): boolean => {
 // ---------------------------------------------------------------------------
 
 /** Check if an expression node is an allowed Result-returning expression. */
-const isResultExpression = (node: AstNode): boolean => {
+export const isResultExpression = (node: AstNode): boolean => {
   if (node.type === 'CallExpression') {
     const callee = node['callee'] as AstNode | undefined;
     if (!callee) {
@@ -69,7 +69,27 @@ const isResultExpression = (node: AstNode): boolean => {
 };
 
 /** Map of namespace-import local name to the set of Result-helper names exported by the target module. */
-type NamespaceHelperMap = ReadonlyMap<string, ReadonlySet<string>>;
+export type NamespaceHelperMap = ReadonlyMap<string, ReadonlySet<string>>;
+
+/** Map of lexical scope frames to local helper bindings with explicit Result return types. */
+export type ScopedHelperMap = ReadonlyMap<
+  ReadonlySet<string>,
+  ReadonlySet<string>
+>;
+
+export type MutableScopedHelperMap = Map<ReadonlySet<string>, Set<string>>;
+
+export const findNearestBindingScope = (
+  name: string,
+  scopes: readonly ReadonlySet<string>[]
+): ReadonlySet<string> | null =>
+  scopes.find((scope) => scope.has(name)) ?? null;
+
+const isScopedHelperBinding = (
+  name: string,
+  scope: ReadonlySet<string>,
+  scopedHelpers: ScopedHelperMap
+): boolean => scopedHelpers.get(scope)?.has(name) ?? false;
 
 /**
  * Check whether a namespace-member call like `ns.helper(...)` resolves to a
@@ -103,11 +123,12 @@ const isNamespaceHelperMemberCall = (
 };
 
 /** Check if a node is a call to a known Result-returning helper. */
-const isHelperCall = (
+export const isHelperCall = (
   node: AstNode,
   helperNames: ReadonlySet<string>,
   namespaceHelpers: NamespaceHelperMap = new Map(),
-  scopes: readonly ReadonlySet<string>[] = []
+  scopes: readonly ReadonlySet<string>[] = [],
+  scopedHelpers: ScopedHelperMap = new Map()
 ): boolean => {
   const target =
     node.type === 'AwaitExpression'
@@ -121,6 +142,13 @@ const isHelperCall = (
   const callee = target['callee'] as AstNode | undefined;
   if (callee?.type === 'Identifier') {
     const { name } = callee as unknown as { name: string };
+    const bindingScope = findNearestBindingScope(name, scopes);
+    if (
+      bindingScope &&
+      !isScopedHelperBinding(name, bindingScope, scopedHelpers)
+    ) {
+      return false;
+    }
     return helperNames.has(name);
   }
 
@@ -149,107 +177,20 @@ const isAllowedReturnArgument = (
   helperNames: ReadonlySet<string>,
   resultVars: ReadonlySet<string>,
   namespaceHelpers: NamespaceHelperMap,
-  scopes: readonly ReadonlySet<string>[] = []
+  scopes: readonly ReadonlySet<string>[] = [],
+  scopedHelpers: ScopedHelperMap = new Map()
 ): boolean => {
   if (isResultExpression(argument)) {
     return true;
   }
-  if (isHelperCall(argument, helperNames, namespaceHelpers, scopes)) {
+  if (
+    isHelperCall(argument, helperNames, namespaceHelpers, scopes, scopedHelpers)
+  ) {
     return true;
   }
 
   const varName = resolveIdentifierName(argument);
   return varName !== null && resultVars.has(varName);
-};
-
-// ---------------------------------------------------------------------------
-// Variable tracking
-// ---------------------------------------------------------------------------
-
-/** Track a VariableDeclarator, adding to resultVars if it produces a Result. */
-const trackResultVariable = (
-  node: AstNode,
-  resultVars: Set<string>,
-  helperNames: ReadonlySet<string>,
-  namespaceHelpers: NamespaceHelperMap,
-  scopes: readonly ReadonlySet<string>[]
-): void => {
-  const { init } = node as unknown as { init?: AstNode };
-  const { id } = node as unknown as { id?: AstNode };
-  if (init && id?.type === 'Identifier') {
-    const { name } = id as unknown as { name: string };
-    if (
-      isResultExpression(init) ||
-      isHelperCall(init, helperNames, namespaceHelpers, scopes)
-    ) {
-      resultVars.add(name);
-    }
-  }
-};
-
-// ---------------------------------------------------------------------------
-// Return statement checking
-// ---------------------------------------------------------------------------
-
-/** Check return statements in a block body for non-Result returns. */
-const checkReturnStatements = (
-  blockBody: AstNode,
-  trailInfo: { id: string; label: string },
-  filePath: string,
-  sourceCode: string,
-  helperNames: ReadonlySet<string>,
-  namespaceHelpers: NamespaceHelperMap,
-  diagnostics: WardenDiagnostic[],
-  implScope: ReadonlySet<string> = new Set<string>()
-): void => {
-  const resultVars = new Set<string>();
-  const initialScopes = implScope.size > 0 ? [implScope] : [];
-
-  walkWithScopes(
-    blockBody,
-    (node, currentScopes) => {
-      if (node.type === 'VariableDeclarator') {
-        trackResultVariable(
-          node,
-          resultVars,
-          helperNames,
-          namespaceHelpers,
-          currentScopes
-        );
-      }
-
-      if (node.type !== 'ReturnStatement') {
-        return;
-      }
-
-      const { argument } = node as unknown as { argument?: AstNode };
-      // Bare return — not a value return
-      if (!argument) {
-        return;
-      }
-
-      if (
-        isAllowedReturnArgument(
-          argument,
-          helperNames,
-          resultVars,
-          namespaceHelpers,
-          currentScopes
-        )
-      ) {
-        return;
-      }
-
-      diagnostics.push({
-        filePath,
-        line: offsetToLine(sourceCode, node.start),
-        message: buildUnrecognizedResultMessage(trailInfo.label, trailInfo.id),
-        rule: 'implementation-returns-result',
-        severity: 'error',
-      });
-    },
-    { initialScopes, stopAtNestedFunctions: true }
-  );
 };
 
 // ---------------------------------------------------------------------------
@@ -280,7 +221,7 @@ const hasGenericTypeReference = (
 ): boolean =>
   new RegExp(`(^|[^\\w$])${escapeRegExp(typeName)}\\s*<`).test(annotationText);
 
-const collectResultTypeNames = (ast: AstNode): ReadonlySet<string> => {
+export const collectResultTypeNames = (ast: AstNode): ReadonlySet<string> => {
   const names = new Set(DEFAULT_RESULT_TYPE_NAMES);
   walk(ast, (node) => {
     if (
@@ -329,6 +270,146 @@ const hasResultReturnType = (
 
 const isFunctionLikeExpression = (node: AstNode): boolean =>
   node.type === 'ArrowFunctionExpression' || node.type === 'FunctionExpression';
+
+const addScopedHelper = (
+  scopedHelpers: MutableScopedHelperMap,
+  scope: ReadonlySet<string>,
+  name: string
+): void => {
+  const existing = scopedHelpers.get(scope);
+  if (existing) {
+    existing.add(name);
+    return;
+  }
+  scopedHelpers.set(scope, new Set([name]));
+};
+
+/** Record `const helper = (): Result<...> => ...` declarations for the current lexical scope. */
+export const trackScopedResultHelperDeclaration = (
+  node: AstNode,
+  scopes: readonly ReadonlySet<string>[],
+  sourceCode: string,
+  resultTypeNames: ReadonlySet<string>,
+  scopedHelpers: MutableScopedHelperMap
+): void => {
+  if (node.type !== 'VariableDeclarator') {
+    return;
+  }
+  const { id, init } = node as unknown as { id?: AstNode; init?: AstNode };
+  const name = extractIdentifierName(id);
+  if (!(name && init && isFunctionLikeExpression(init))) {
+    return;
+  }
+  if (!hasResultReturnType(init, sourceCode, resultTypeNames)) {
+    return;
+  }
+  const bindingScope = findNearestBindingScope(name, scopes);
+  if (bindingScope) {
+    addScopedHelper(scopedHelpers, bindingScope, name);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Variable tracking
+// ---------------------------------------------------------------------------
+
+/** Track a VariableDeclarator, adding to resultVars if it produces a Result. */
+const trackResultVariable = (
+  node: AstNode,
+  resultVars: Set<string>,
+  helperNames: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap,
+  scopes: readonly ReadonlySet<string>[],
+  scopedHelpers: ScopedHelperMap
+): void => {
+  const { init } = node as unknown as { init?: AstNode };
+  const { id } = node as unknown as { id?: AstNode };
+  if (init && id?.type === 'Identifier') {
+    const { name } = id as unknown as { name: string };
+    if (
+      isResultExpression(init) ||
+      isHelperCall(init, helperNames, namespaceHelpers, scopes, scopedHelpers)
+    ) {
+      resultVars.add(name);
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Return statement checking
+// ---------------------------------------------------------------------------
+
+/** Check return statements in a block body for non-Result returns. */
+const checkReturnStatements = (
+  blockBody: AstNode,
+  trailInfo: { id: string; label: string },
+  filePath: string,
+  sourceCode: string,
+  helperNames: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap,
+  resultTypeNames: ReadonlySet<string>,
+  diagnostics: WardenDiagnostic[],
+  implScope: ReadonlySet<string> = new Set<string>()
+): void => {
+  const resultVars = new Set<string>();
+  const scopedHelpers: MutableScopedHelperMap = new Map();
+  const initialScopes = implScope.size > 0 ? [implScope] : [];
+
+  walkWithScopes(
+    blockBody,
+    (node, currentScopes) => {
+      if (node.type === 'VariableDeclarator') {
+        trackScopedResultHelperDeclaration(
+          node,
+          currentScopes,
+          sourceCode,
+          resultTypeNames,
+          scopedHelpers
+        );
+        trackResultVariable(
+          node,
+          resultVars,
+          helperNames,
+          namespaceHelpers,
+          currentScopes,
+          scopedHelpers
+        );
+      }
+
+      if (node.type !== 'ReturnStatement') {
+        return;
+      }
+
+      const { argument } = node as unknown as { argument?: AstNode };
+      // Bare return is not a value return.
+      if (!argument) {
+        return;
+      }
+
+      if (
+        isAllowedReturnArgument(
+          argument,
+          helperNames,
+          resultVars,
+          namespaceHelpers,
+          currentScopes,
+          scopedHelpers
+        )
+      ) {
+        return;
+      }
+
+      diagnostics.push({
+        filePath,
+        line: offsetToLine(sourceCode, node.start),
+        message: buildUnrecognizedResultMessage(trailInfo.label, trailInfo.id),
+        rule: 'implementation-returns-result',
+        severity: 'error',
+      });
+    },
+    { initialScopes, stopAtNestedFunctions: true }
+  );
+};
 
 /** Collect names of top-level functions/consts with explicit Result return types. */
 const collectResultHelperNames = (
@@ -1283,7 +1364,7 @@ const namespaceEntriesFromImport = (
  * resolved target module. Returns an empty map if no namespace imports are
  * found or none resolve to local files.
  */
-const collectNamespaceHelperImports = (
+export const collectNamespaceHelperImports = (
   ast: AstNode,
   filePath: string
 ): NamespaceHelperMap => {
@@ -1305,7 +1386,7 @@ const collectNamespaceHelperImports = (
 /**
  * Combine same-file helper names with helpers imported from relative modules.
  */
-const collectAllResultHelperNames = (
+export const collectAllResultHelperNames = (
   ast: AstNode,
   sourceCode: string,
   filePath: string
@@ -1333,6 +1414,7 @@ const checkImplementation = (
   sourceCode: string,
   helperNames: ReadonlySet<string>,
   namespaceHelpers: NamespaceHelperMap,
+  resultTypeNames: ReadonlySet<string>,
   diagnostics: WardenDiagnostic[]
 ): void => {
   const fnBody = (implValue as unknown as { body?: AstNode }).body;
@@ -1352,6 +1434,7 @@ const checkImplementation = (
       sourceCode,
       helperNames,
       namespaceHelpers,
+      resultTypeNames,
       diagnostics,
       implScope
     );
@@ -1386,6 +1469,7 @@ const checkAllDefinitions = (
   const diagnostics: WardenDiagnostic[] = [];
   const helperNames = collectAllResultHelperNames(ast, sourceCode, filePath);
   const namespaceHelpers = collectNamespaceHelperImports(ast, filePath);
+  const resultTypeNames = collectResultTypeNames(ast);
 
   for (const def of findTrailDefinitions(ast)) {
     const info = { id: def.id, label: 'Trail' };
@@ -1397,6 +1481,7 @@ const checkAllDefinitions = (
         sourceCode,
         helperNames,
         namespaceHelpers,
+        resultTypeNames,
         diagnostics
       );
     }

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -21,6 +21,7 @@ import { noDestructuredCross } from './no-destructured-cross.js';
 import { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noNativeErrorResult } from './no-native-error-result.js';
+import { noRedundantResultErrorWrap } from './no-redundant-result-error-wrap.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
@@ -113,6 +114,7 @@ export { noDestructuredCross } from './no-destructured-cross.js';
 export { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 export { noDirectImplementationCall } from './no-direct-implementation-call.js';
 export { noNativeErrorResult } from './no-native-error-result.js';
+export { noRedundantResultErrorWrap } from './no-redundant-result-error-wrap.js';
 export { noSyncResultAssumption } from './no-sync-result-assumption.js';
 export { implementationReturnsResult } from './implementation-returns-result.js';
 export { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
@@ -188,6 +190,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [noDirectImplementationCall.name, noDirectImplementationCall],
   [noLegacyLayerImports.name, noLegacyLayerImports],
   [noNativeErrorResult.name, noNativeErrorResult],
+  [noRedundantResultErrorWrap.name, noRedundantResultErrorWrap],
   [noSyncResultAssumption.name, noSyncResultAssumption],
   [implementationReturnsResult.name, implementationReturnsResult],
   [noThrowInDetourRecover.name, noThrowInDetourRecover],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -75,6 +75,7 @@ const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'no-dev-permit-in-source': 'permits',
   'no-direct-implementation-call': 'composition',
   'no-native-error-result': 'results',
+  'no-redundant-result-error-wrap': 'results',
   'no-sync-result-assumption': 'results',
   'no-throw-in-detour-recover': 'results',
   'no-throw-in-implementation': 'results',
@@ -273,6 +274,12 @@ const builtinWardenRuleMetadataInput = {
   'no-native-error-result': {
     ...durableExternal,
     invariant: 'Result error boundaries carry specific TrailsError subclasses.',
+    tier: 'source-static',
+  },
+  'no-redundant-result-error-wrap': {
+    ...durableExternal,
+    invariant:
+      'Result error pass-throughs preserve the original Result boundary.',
     tier: 'source-static',
   },
   'no-sync-result-assumption': {

--- a/packages/warden/src/rules/no-redundant-result-error-wrap.ts
+++ b/packages/warden/src/rules/no-redundant-result-error-wrap.ts
@@ -1,0 +1,331 @@
+import {
+  collectScopeFrameBindings,
+  findBlazeBodies,
+  findTrailDefinitions,
+  getMemberExpression,
+  identifierName,
+  isMemberAccessNonComputed,
+  offsetToLine,
+  parse,
+  walkWithScopes,
+} from './ast.js';
+import {
+  collectAllResultHelperNames,
+  collectNamespaceHelperImports,
+  collectResultTypeNames,
+  findNearestBindingScope,
+  isHelperCall,
+  isResultExpression,
+  trackScopedResultHelperDeclaration,
+} from './implementation-returns-result.js';
+import { isTestFile } from './scan.js';
+import type { AstNode } from './ast.js';
+import type {
+  MutableScopedHelperMap,
+  NamespaceHelperMap,
+  ScopedHelperMap,
+} from './implementation-returns-result.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'no-redundant-result-error-wrap';
+
+const getStaticMemberName = (node: AstNode | undefined): string | null => {
+  if (!node || !isMemberAccessNonComputed(node)) {
+    return null;
+  }
+  return identifierName((node as unknown as { property?: AstNode }).property);
+};
+
+const isResultObject = (node: AstNode | undefined): boolean => {
+  if (!node) {
+    return false;
+  }
+  if (identifierName(node) === 'Result') {
+    return true;
+  }
+  return getStaticMemberName(node) === 'Result';
+};
+
+const isResultErrCall = (node: AstNode): boolean => {
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+  const { callee } = node as unknown as { callee?: AstNode };
+  const member = getMemberExpression(callee);
+  if (!member || getStaticMemberName(callee) !== 'err') {
+    return false;
+  }
+  return isResultObject(member.object);
+};
+
+const getSingleArgument = (node: AstNode): AstNode | null => {
+  const args = (node as unknown as { arguments?: readonly AstNode[] })
+    .arguments;
+  return args?.length === 1 ? (args[0] ?? null) : null;
+};
+
+const getErrorSourceVariable = (node: AstNode | null): string | null => {
+  if (!node || getStaticMemberName(node) !== 'error') {
+    return null;
+  }
+  const member = getMemberExpression(node);
+  return identifierName(member?.object);
+};
+
+const isResultProducingExpression = (
+  node: AstNode,
+  helperNames: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap,
+  scopes: readonly ReadonlySet<string>[],
+  scopedHelpers: ScopedHelperMap
+): boolean =>
+  isResultExpression(node) ||
+  isHelperCall(node, helperNames, namespaceHelpers, scopes, scopedHelpers);
+
+type ResultProvenance = Map<ReadonlySet<string>, Set<string>>;
+
+const markResultVariable = (
+  provenance: ResultProvenance,
+  scope: ReadonlySet<string>,
+  name: string
+): void => {
+  const names = provenance.get(scope);
+  if (names) {
+    names.add(name);
+    return;
+  }
+  provenance.set(scope, new Set([name]));
+};
+
+const clearResultVariable = (
+  provenance: ResultProvenance,
+  scope: ReadonlySet<string>,
+  name: string
+): void => {
+  provenance.get(scope)?.delete(name);
+};
+
+const hasResultProvenance = (
+  provenance: ResultProvenance,
+  scope: ReadonlySet<string>,
+  name: string
+): boolean => provenance.get(scope)?.has(name) ?? false;
+
+const createDiagnostic = (
+  filePath: string,
+  sourceCode: string,
+  node: AstNode,
+  trailId: string,
+  variableName: string
+): WardenDiagnostic => ({
+  filePath,
+  line: offsetToLine(sourceCode, node.start),
+  message: `Trail "${trailId}": Result.err(${variableName}.error) re-wraps a Result that already carries that error. Return ${variableName} directly to preserve the original Result boundary.`,
+  rule: RULE_NAME,
+  severity: 'warn',
+});
+
+const trackVariableDeclarator = (
+  node: AstNode,
+  provenance: ResultProvenance,
+  helperNames: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap,
+  scopedHelpers: ScopedHelperMap,
+  scopes: readonly ReadonlySet<string>[]
+): void => {
+  const { id, init } = node as unknown as { id?: AstNode; init?: AstNode };
+  const name = identifierName(id);
+  if (!name) {
+    return;
+  }
+  const scope = findNearestBindingScope(name, scopes);
+  if (!scope) {
+    return;
+  }
+  if (
+    init &&
+    isResultProducingExpression(
+      init,
+      helperNames,
+      namespaceHelpers,
+      scopes,
+      scopedHelpers
+    )
+  ) {
+    markResultVariable(provenance, scope, name);
+    return;
+  }
+  clearResultVariable(provenance, scope, name);
+};
+
+const trackAssignmentExpression = (
+  node: AstNode,
+  provenance: ResultProvenance,
+  helperNames: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap,
+  scopedHelpers: ScopedHelperMap,
+  scopes: readonly ReadonlySet<string>[]
+): void => {
+  const { left, operator, right } = node as unknown as {
+    left?: AstNode;
+    operator?: string;
+    right?: AstNode;
+  };
+  const name = identifierName(left);
+  if (!name) {
+    return;
+  }
+  const scope = findNearestBindingScope(name, scopes);
+  if (!scope) {
+    return;
+  }
+  if (
+    operator === '=' &&
+    right &&
+    isResultProducingExpression(
+      right,
+      helperNames,
+      namespaceHelpers,
+      scopes,
+      scopedHelpers
+    )
+  ) {
+    markResultVariable(provenance, scope, name);
+    return;
+  }
+  clearResultVariable(provenance, scope, name);
+};
+
+const checkReturnStatement = (
+  node: AstNode,
+  provenance: ResultProvenance,
+  scopes: readonly ReadonlySet<string>[],
+  filePath: string,
+  sourceCode: string,
+  trailId: string,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  const { argument } = node as unknown as { argument?: AstNode };
+  if (!argument || !isResultErrCall(argument)) {
+    return;
+  }
+  const variableName = getErrorSourceVariable(getSingleArgument(argument));
+  if (!variableName) {
+    return;
+  }
+  const scope = findNearestBindingScope(variableName, scopes);
+  if (!scope || !hasResultProvenance(provenance, scope, variableName)) {
+    return;
+  }
+  diagnostics.push(
+    createDiagnostic(filePath, sourceCode, argument, trailId, variableName)
+  );
+};
+
+const checkBlazeBody = (
+  blaze: AstNode,
+  trailId: string,
+  filePath: string,
+  sourceCode: string,
+  helperNames: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap,
+  resultTypeNames: ReadonlySet<string>,
+  diagnostics: WardenDiagnostic[]
+): void => {
+  const { body } = blaze as unknown as { body?: AstNode };
+  if (
+    !body ||
+    (body.type !== 'BlockStatement' && body.type !== 'FunctionBody')
+  ) {
+    return;
+  }
+
+  const provenance: ResultProvenance = new Map();
+  const scopedHelpers: MutableScopedHelperMap = new Map();
+  const implScope = collectScopeFrameBindings(blaze);
+  const initialScopes = implScope.size > 0 ? [implScope] : [];
+
+  walkWithScopes(
+    body,
+    (node, scopes) => {
+      if (node.type === 'VariableDeclarator') {
+        trackScopedResultHelperDeclaration(
+          node,
+          scopes,
+          sourceCode,
+          resultTypeNames,
+          scopedHelpers
+        );
+        trackVariableDeclarator(
+          node,
+          provenance,
+          helperNames,
+          namespaceHelpers,
+          scopedHelpers,
+          scopes
+        );
+        return;
+      }
+      if (node.type === 'AssignmentExpression') {
+        trackAssignmentExpression(
+          node,
+          provenance,
+          helperNames,
+          namespaceHelpers,
+          scopedHelpers,
+          scopes
+        );
+        return;
+      }
+      if (node.type === 'ReturnStatement') {
+        checkReturnStatement(
+          node,
+          provenance,
+          scopes,
+          filePath,
+          sourceCode,
+          trailId,
+          diagnostics
+        );
+      }
+    },
+    { initialScopes, stopAtNestedFunctions: true }
+  );
+};
+
+export const noRedundantResultErrorWrap: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isTestFile(filePath)) {
+      return [];
+    }
+
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const diagnostics: WardenDiagnostic[] = [];
+    const helperNames = collectAllResultHelperNames(ast, sourceCode, filePath);
+    const namespaceHelpers = collectNamespaceHelperImports(ast, filePath);
+    const resultTypeNames = collectResultTypeNames(ast);
+    for (const def of findTrailDefinitions(ast)) {
+      for (const blaze of findBlazeBodies(def.config)) {
+        checkBlazeBody(
+          blaze,
+          def.id,
+          filePath,
+          sourceCode,
+          helperNames,
+          namespaceHelpers,
+          resultTypeNames,
+          diagnostics
+        );
+      }
+    }
+    return diagnostics;
+  },
+  description:
+    'Warn when blazes re-wrap an existing Result error with Result.err(x.error) instead of returning the Result directly.',
+  name: RULE_NAME,
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -29,6 +29,7 @@ import { noDestructuredCross } from './no-destructured-cross.js';
 import { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noNativeErrorResult } from './no-native-error-result.js';
+import { noRedundantResultErrorWrap } from './no-redundant-result-error-wrap.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
@@ -100,6 +101,7 @@ export const registeredRuleNames: readonly string[] = [
   noLegacyLayerImports.name,
   noDirectImplementationCall.name,
   noNativeErrorResult.name,
+  noRedundantResultErrorWrap.name,
   noSyncResultAssumption.name,
   noThrowInDetourRecover.name,
   noThrowInImplementation.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -25,6 +25,7 @@ export { noDestructuredCrossTrail } from './no-destructured-cross.trail.js';
 export { noLegacyLayerImportsTrail } from './no-legacy-layer-imports.trail.js';
 export { noDirectImplementationCallTrail } from './no-direct-implementation-call.trail.js';
 export { noNativeErrorResultTrail } from './no-native-error-result.trail.js';
+export { noRedundantResultErrorWrapTrail } from './no-redundant-result-error-wrap.trail.js';
 export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.js';
 export { noThrowInDetourRecoverTrail } from './no-throw-in-detour-recover.trail.js';
 export { noThrowInImplementationTrail } from './no-throw-in-implementation.trail.js';

--- a/packages/warden/src/trails/no-redundant-result-error-wrap.trail.ts
+++ b/packages/warden/src/trails/no-redundant-result-error-wrap.trail.ts
@@ -1,0 +1,55 @@
+import { noRedundantResultErrorWrap } from '../rules/no-redundant-result-error-wrap.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const noRedundantResultErrorWrapTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'entity.ts',
+        sourceCode: `import { Result, trail } from "@ontrails/core";
+
+trail("entity.load", {
+  blaze: async (input, ctx) => {
+    const loaded = await ctx.cross("entity.fetch", input);
+    if (loaded.isErr()) {
+      return loaded;
+    }
+    return Result.ok(loaded.value);
+  },
+});`,
+      },
+      name: 'Existing Result values pass through directly',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'entity.ts',
+            line: 7,
+            message:
+              'Trail "entity.load": Result.err(loaded.error) re-wraps a Result that already carries that error. Return loaded directly to preserve the original Result boundary.',
+            rule: 'no-redundant-result-error-wrap',
+            severity: 'warn',
+          },
+        ],
+      },
+      input: {
+        filePath: 'entity.ts',
+        sourceCode: `import { Result, trail } from "@ontrails/core";
+
+trail("entity.load", {
+  blaze: async (input, ctx) => {
+    const loaded = await ctx.cross("entity.fetch", input);
+    if (loaded.isErr()) {
+      return Result.err(loaded.error);
+    }
+    return Result.ok(loaded.value);
+  },
+});`,
+      },
+      name: 'Warns when an existing Result error is re-wrapped',
+    },
+  ],
+  rule: noRedundantResultErrorWrap,
+});

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -80,6 +80,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `error-mapping-completeness` (error, source/source-static, extension): Registered surface error mappers cover every error category.
 - `implementation-returns-result` (error, source/source-static, external): Blazes return Result values.
 - `no-native-error-result` (error, source/source-static, external): Result error boundaries carry specific TrailsError subclasses.
+- `no-redundant-result-error-wrap` (warn, source/source-static, external): Result error pass-throughs preserve the original Result boundary.
 - `no-sync-result-assumption` (error, source/source-static, external): Result accessors are not used before async results are awaited.
 - `no-throw-in-detour-recover` (error, source/source-static, external): Detour recovery returns Result instead of throwing.
 - `no-throw-in-implementation` (error, source/source-static, external): Blazes return Result.err() instead of throwing. Guidance: Convert thrown failures in blazes into explicit Result.err() outcomes.


### PR DESCRIPTION
## Summary

- Add `no-redundant-result-error-wrap` as a Warden warning rule for `Result.err(x.error)` pass-throughs where `x` has visible Result provenance.
- Reuse `implementation-returns-result` helper provenance, including scoped helper tracking so explicit local Result helpers count while plain shadows do not.
- Wire the rule metadata, registry names, public exports, rule trail, generated Warden guides, focused tests, and changeset.

## Verification

- `bun test packages/warden/src/__tests__/implementation-returns-result.test.ts packages/warden/src/__tests__/no-redundant-result-error-wrap.test.ts`
- `bun --cwd packages/warden test`
- `bun run lint`
- `bun trails warden`
- `git diff --check`
- `bun run check` (`CHECK_EXIT:0`)

## Notes

- `bun trails warden` now passes with 0 errors and 62 warnings. The new rule reports existing redundant re-wraps in `apps/trails` and `apps/trails-demo`; cleanup is intentionally left for a follow-up PR so this detector stays reviewable.
