### PR TITLE
fix: pin scaffolded ontrails package ranges exactly

### DIFF
--- a/.agents/plans/2026-05-24-scaffold-forward-compat-seed/GOAL.md
+++ b/.agents/plans/2026-05-24-scaffold-forward-compat-seed/GOAL.md
@@ -1,0 +1,23 @@
+# Goal Prompt: scaffold forward-compat seed
+
+Paste this into the goal runtime:
+
+````markdown
+/goal From `/Users/mg/.codex/worktrees/0f7f/trails`, execute `.agents/plans/2026-05-24-scaffold-forward-compat-seed/PLAN.md` end to end. Use `.agents/plans/2026-05-24-scaffold-forward-compat-seed/RETRO.md` as the durable ledger and touch it last before each handoff.
+
+Read first: `AGENTS.md`, `.agents/plans/PLANNING.md`, packet `PLAN.md` + `REFS.md`, Linear TRL-796/798/797/799 plus the TRL-801 supersession comment, then the anchors in `REFS.md`: scaffold versions/source/tests, `scripts/sync-scaffold-versions.ts`, root `package.json`, release docs, and draft ADR docs.
+
+Objective: build one coherent four-PR Graphite stack in PLAN order: TRL-796 exact generated `@ontrails/*` beta pins -> TRL-798 minimal `.trails/scaffold.json` provenance -> TRL-797 internal scaffold-version bump/check helper -> TRL-799 draft scaffold forward-compatibility ADR.
+
+Scope: TRL-796 removes the caret prerelease range, updates scaffold tests and stable-cutover prerequisite docs, and adds a patch changeset. TRL-798 writes/documents/tests minimal provenance with `schemaVersion`, `scaffoldVersion`, `template`, `generatedAt` unless evidence forces narrower, and adds a patch changeset. TRL-797 extends existing internal scaffold-version tooling/checks so exact pins stay bumpable after `bunx changeset version`; keep it internal unless evidence proves otherwise. TRL-799 drafts the ADR under `docs/adr/drafts/`, grounded in the implemented breadcrumb/helper shape, explicitly deferring read/diff/migration/upgrade tooling.
+
+Work loop: checkpoint-by-checkpoint. Report checkpoint, changes, exact proof, checks, remaining work, blockers, and next checkpoint. Update `RETRO.md` after meaningful implementation, tracker, verification, review, PR, CI, or remote-review changes.
+
+Validation: run narrow relevant checks per branch: scaffold create tests, `bun --cwd apps/trails test`, `bun run scaffold-versions:check`, ADR/docs scripts when docs change, `bun run format:check`, `git diff --check`, and `bun run typecheck`. Before submission/final handoff run `bun run check`. Optional smoke: temp scaffold, inspect exact pins plus `.trails/scaffold.json`, then install/typecheck/test if registry/network state permits.
+
+Review: run local review from stack tip before submission across scaffold shape, helper/tooling coverage, and release/docs/ADR doctrine fit. Fix P0/P1/P2 on owning branches bottom-up by checking out the affected branch, `gt modify`, `gt restack`, then rechecking affected descendants. Record local/remote scores, summaries, prompt-to-fix text, CI, threads, and fixes in `RETRO.md`.
+
+Hard rules: do not implement TRL-803, TRL-794, TRL-782, TRL-783, or TRL-801 separately. Do not build scaffold diffing, migrations, template hashes, upgrade application, provenance readers, public `trails upgrade`, publication, registry/dist-tag mutation, stable versioning commands, merge, merge queue labels, or subagent git/gt writes. Keep PRs draft until CI green and local review clean.
+
+Done only when all four draft PRs exist, CI is green, Linear is current, tests/docs prove exact pins/provenance/helper/ADR shape, checks pass or skips are justified, constraints hold, and `RETRO.md` has final tracker, PR, review, verification, forbidden-action, risk, follow-up, and archive-readiness state. Stop/ask if repo/Linear truth diverges, exact-pin policy reopens, helper scope becomes release automation/public CLI, ADR requires a new public primitive/command now, unrelated verification fails after focused retry, protected actions are needed, or three focused attempts do not shrink the failure.
+````

--- a/.agents/plans/2026-05-24-scaffold-forward-compat-seed/PLAN.md
+++ b/.agents/plans/2026-05-24-scaffold-forward-compat-seed/PLAN.md
@@ -1,0 +1,443 @@
+# Goal Plan: scaffold forward-compat seed
+
+Date: 2026-05-24
+Status: Seeded
+
+## Objective
+
+Build the smallest scaffold-forward-compat stack after the merged scaffold and
+Warden work:
+
+1. TRL-796: generated projects pin `@ontrails/*` packages to the exact current
+   Trails beta version instead of a caret prerelease range.
+2. TRL-798: generated projects get a minimal scaffold provenance breadcrumb so
+   future upgrade tooling can identify their scaffold lineage.
+3. TRL-797: release operators get a clean helper/check path for bumping scaffold
+   output versions without hand-edit drift.
+4. TRL-799: the post-1.0 scaffold forward-compatibility direction is captured
+   in a draft ADR grounded in the implemented breadcrumb shape.
+
+This is the coherent scaffold-forward line. It is still not the full
+upgrade-path system.
+
+## Completion Condition
+
+The goal is complete only when:
+
+- TRL-796, TRL-798, TRL-797, and TRL-799 are implemented on separate stacked
+  Graphite branches in that order.
+- Draft PRs are open, CI is green, and Linear issues are current.
+- Generated `package.json` files use exact `@ontrails/*` beta pins.
+- Generated projects include a documented `.trails/scaffold.json` provenance
+  breadcrumb.
+- Scaffold tests assert both the exact-pin shape and provenance file.
+- A helper/check path exists for keeping scaffold output version pins and
+  `scaffold-versions.generated.ts` aligned after version bumps.
+- A draft ADR under `docs/adr/drafts/` captures the layer distinction, borrowed
+  versioning patterns, and phased path for scaffold forward compatibility.
+- `docs/releases/stable-cutover.md` records the exact-pin prerequisite.
+- Branch-local patch changesets exist for package-touching PRs that ship
+  `@ontrails/trails` behavior/tooling. Docs-only ADR work does not need a
+  changeset unless the diff touches publishable package content.
+- Local review finds no unresolved P0/P1/P2 findings.
+- No merge, merge queue label, publish, registry mutation, or stable-versioning
+  command is run.
+- `RETRO.md` has final tracker, PR, review, verification, forbidden-action,
+  risk, and archive-readiness state before handoff.
+
+## Non-Goals
+
+- Do not implement TRL-803 bootstrap/worktree hook tooling.
+- Do not execute TRL-801 separately; treat it as decision coverage superseded
+  by TRL-796 unless Matt reopens it.
+- Do not build scaffold diffing, migration, template hash markers, upgrade
+  application, provenance-reading tooling, or a public `trails upgrade` command.
+- Do not change package publication, dist-tags, release versions, or the
+  Changesets release flow.
+- Do not sweep historical beta release notes just because they show old caret
+  examples; only update active/current docs needed for this slice.
+
+## Source Of Truth
+
+Read first:
+
+1. `AGENTS.md`
+2. `.agents/plans/PLANNING.md`
+3. Linear TRL-796, TRL-798, TRL-797, and TRL-799
+4. `apps/trails/src/versions.ts`
+5. `apps/trails/src/trails/create-scaffold.ts`
+6. `apps/trails/src/__tests__/create.test.ts`
+7. `scripts/sync-scaffold-versions.ts`
+8. `package.json` script section
+9. `docs/releases/beta-channel-policy.md`
+10. `docs/releases/stable-cutover.md`
+11. `docs/adr/drafts/README.md`
+12. `.agents/plans/2026-05-23-scaffold-runway-overnight-stack/RETRO.md`
+
+## Work Plan
+
+### Phase 0: Preflight
+
+Intent:
+
+- Start from current `main`, confirm the merged baseline includes the previous
+  scaffold/Warden stack, and verify no stale plan assumption remains.
+
+Actions:
+
+- Run `gt sync` from a branch checkout, or fetch/switch as needed in a detached
+  worktree.
+- Inspect `git status --short --branch`.
+- Read TRL-796, TRL-798, TRL-797, TRL-799, and any newest comments.
+- Check whether TRL-801 has been closed, commented, or superseded.
+
+Verification:
+
+- `git log --oneline -8`
+- `git status --short --branch`
+
+Done when:
+
+- The executor is on current main or a clean branch based on it, and the issue
+  state still matches this packet.
+
+### Phase 1: TRL-796 Exact Beta Pin
+
+Intent:
+
+- Remove the stable-cutover footgun caused by caret prerelease ranges.
+
+Actions:
+
+- Create branch
+  `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel`.
+- Change the scaffolded `@ontrails/*` range owner in
+  `apps/trails/src/versions.ts` so `ontrailsPackageRange` is the exact
+  `trailsPackageVersion`, not `^${trailsPackageVersion}`.
+- Keep the public/local name `ontrailsPackageRange` unless a rename is needed
+  for clarity; unnecessary rename churn is out of scope.
+- Update scaffold tests to assert the emitted `@ontrails/*` range is exact and
+  does not start with `^`.
+- Add `docs/releases/stable-cutover.md` prerequisite language making exact
+  scaffold pins a stable-cutover blocker.
+- Add a patch changeset for `@ontrails/trails`.
+- Update Linear TRL-796 with any implementation divergence.
+
+Verification:
+
+- `bun test apps/trails/src/__tests__/create.test.ts`
+- `bun --cwd apps/trails test`
+- `bun run format:check`
+- `git diff --check`
+- `bun run typecheck`
+
+Done when:
+
+- The branch is locally clean, committed with a Conventional Commit message, and
+  the stack can support TRL-798 above it.
+
+### Phase 2: TRL-798 Scaffold Provenance Breadcrumb
+
+Intent:
+
+- Seed future scaffold upgrade tooling with lineage data that cannot be
+  recovered later for already-generated projects.
+
+Actions:
+
+- Create branch
+  `trl-798-stamp-scaffold-provenance-into-generated-projects-minimal` stacked
+  on TRL-796.
+- Generate `.trails/scaffold.json` during `create.scaffold`.
+- Prefer this minimal JSON shape unless implementation evidence forces a tweak:
+
+  ```json
+  {
+    "schemaVersion": 1,
+    "scaffoldVersion": "1.0.0-beta.N",
+    "template": "hello",
+    "generatedAt": "2026-05-24T00:00:00.000Z"
+  }
+  ```
+
+- `scaffoldVersion` must use the same source as `trailsPackageVersion`.
+- `template` is the starter id used by `create.scaffold`.
+- `generatedAt` is an ISO timestamp generated at scaffold time.
+- Add tests for default create, dry-run operation planning, and at least one
+  alternate starter where useful.
+- Document the provenance contract in a stable current-facing doc. Prefer a
+  small section in `docs/getting-started.md` or `docs/releases/stable-cutover.md`
+  over creating a new doc unless the text would get too large.
+- Add a patch changeset for `@ontrails/trails`.
+- Update Linear TRL-798 with any shape divergence.
+
+Verification:
+
+- `bun test apps/trails/src/__tests__/create.test.ts`
+- `bun --cwd apps/trails test`
+- `bun run format:check`
+- `git diff --check`
+- `bun run typecheck`
+
+Done when:
+
+- The branch is locally clean and committed above TRL-796.
+
+### Phase 3: TRL-797 Clean Scaffold Version Bump Helper
+
+Intent:
+
+- Keep exact pins ergonomic by making future bump work a one-command/checkable
+  path instead of scattered hand edits.
+
+Actions:
+
+- Create branch
+  `trl-797-internal-helper-for-clean-ontrails-version-bumps-in-scaffold` stacked
+  on TRL-798.
+- Inspect `scripts/sync-scaffold-versions.ts`, `package.json` scripts, and the
+  Changesets version flow before editing.
+- Prefer extending existing scaffold-version tooling over inventing a public
+  trail, surface, or release system.
+- The helper/check should compose with `bunx changeset version`; it may be a
+  script enhancement, package script, or check that validates the emitted
+  `@ontrails/*` pin against the CLI app version and validates
+  `scaffold-versions.generated.ts` drift.
+- Keep this internal/dev tooling. Do not expose it as public CLI grammar unless
+  implementation evidence proves that is the smallest honest path.
+- Add focused tests or a check path that fails when the emitted pin and intended
+  version drift.
+- Add a patch changeset for `@ontrails/trails` if the helper changes
+  publishable app/package behavior; document any no-changeset decision.
+- Update Linear TRL-797 with implementation notes and any scope divergence.
+
+Verification:
+
+- `bun run scaffold-versions:check`
+- Targeted test(s) for the helper/check if added
+- `bun test apps/trails/src/__tests__/create.test.ts`
+- `bun --cwd apps/trails test`
+- `bun run format:check`
+- `git diff --check`
+- `bun run typecheck`
+
+Done when:
+
+- The branch is locally clean, committed above TRL-798, and exact-pin bump
+  hygiene is checkable.
+
+### Phase 4: TRL-799 Draft ADR
+
+Intent:
+
+- Preserve the scaffold forward-compatibility direction without prematurely
+  implementing the post-1.0 system.
+
+Actions:
+
+- Create branch
+  `trl-799-draft-adr-scaffold-forward-compatibility-upgrade-path-system` stacked
+  on TRL-797.
+- Draft under `docs/adr/drafts/` using current draft ADR conventions.
+- Capture:
+  - why trail versioning is the wrong layer for scaffold lineage;
+  - what transfers from versioning as design pattern only;
+  - why `.trails/scaffold.json` is the minimal beta-window breadcrumb;
+  - phased path: breadcrumb now, read/diff later, file-level migration later;
+  - explicit non-goals for this pre-1.0 slice.
+- Update draft ADR indexes/maps only through repo scripts if required by the ADR
+  tooling.
+- No changeset unless publishable package content changes.
+- Update Linear TRL-799 with draft path and verification.
+
+Verification:
+
+- `bun scripts/adr.ts map`
+- `bun scripts/adr.ts check`
+- `bun run docs:links`
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- The ADR draft is present, linked by generated ADR metadata if required, and
+  committed above TRL-797.
+
+### Phase 5: Review, Submit, And Tracker Closeout
+
+Intent:
+
+- Ship this as a coherent, reviewable stack with enough proof for merge later.
+
+Actions:
+
+- Run local review from the stack tip before submission:
+  - Lane 1: scaffold package/range and provenance shape.
+  - Lane 2: bump-helper/tooling path and generated-output coverage.
+  - Lane 3: release/docs/ADR wording and doctrine fit.
+- Fix all P0/P1/P2 findings on the owning branch and restack upward.
+- Run final checks from the stack tip.
+- Submit draft PRs with clear PR bodies.
+- Keep PRs draft until CI is green and local review is clean.
+- Update Linear TRL-796, TRL-798, TRL-797, and TRL-799 with PR links,
+  verification, review state, and any out-of-scope follow-ups.
+- Comment on TRL-801 if not already done: TRL-796 subsumes its decision and
+  implementation path.
+
+Verification:
+
+- `bun run check`
+- `git diff --check`
+- PR CI for all PRs
+- Remote review summaries and unresolved threads checked after CI/reviews post
+
+Done when:
+
+- Draft PRs exist, CI is green, local review is P3-only or clean, and
+  `RETRO.md` final state is filled.
+
+## Tracker Plan
+
+- In-goal issues: TRL-796, TRL-798, TRL-797, TRL-799.
+- Related/superseded: TRL-801 should be treated as covered by TRL-796 unless
+  Matt wants a separate closure task.
+- Follow-up issues intentionally out of goal:
+  - TRL-803: bootstrap hook tooling in fresh worktrees.
+  - TRL-794: Warden partial diagnostics.
+  - TRL-782/TRL-783: type-safety lane.
+- Dependencies/blockers:
+  - TRL-798 depends on TRL-796 for the exact version source only loosely, but
+    stacking them keeps scaffold-output review coherent.
+  - TRL-797 follows TRL-796/798 because the helper should validate the real
+    exact-pin and scaffold-output state.
+  - TRL-799 follows TRL-798/797 because the ADR should point at the real
+    breadcrumb and operator-helper shape rather than speculate.
+- Project/status: preserve current Linear project/status assignments; do not
+  move issues unless Matt asks.
+
+## Source-Control Plan
+
+- Branching model: Graphite.
+- Branch order:
+  1. `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel`
+  2. `trl-798-stamp-scaffold-provenance-into-generated-projects-minimal`
+  3. `trl-797-internal-helper-for-clean-ontrails-version-bumps-in-scaffold`
+  4. `trl-799-draft-adr-scaffold-forward-compatibility-upgrade-path-system`
+- PR strategy:
+  - One PR per Linear issue.
+  - Submit as draft.
+  - Keep draft until CI is green and local review is clean.
+  - Do not merge or queue.
+- Downstack fixes:
+  - Check out the owning branch directly.
+  - Apply the fix there.
+  - `gt modify`.
+  - `gt restack`.
+  - Walk checks upward through affected descendants.
+  - Do not use `gt absorb` as the default workflow.
+- Packet commit policy:
+  - Commit this packet on the lowest branch if it is included in execution.
+  - Touch `RETRO.md` last before local completion, draft submission, review
+    closeout, or final handoff.
+- Cleanup before merge:
+  - Do not archive this packet until the PR stack is merged or Matt explicitly
+    asks.
+
+## Retro Discipline
+
+`RETRO.md` is part of the completion contract, not optional notes.
+
+- Update `RETRO.md` after meaningful implementation, tracker, verification,
+  local review, remote review, CI, PR-body, or packaging changes.
+- For stacked work, touch `RETRO.md` last before local completion, draft
+  submission, ready-for-review, remote review closeout, merge readiness, or
+  final handoff.
+- Every meaningful review-flow change must have a corresponding retro entry
+  before claiming the review loop is complete.
+- Before completion, fill final state, verification log, review state, tracker
+  state, forbidden-action audit, remaining risks, and archive readiness.
+
+## Validation Ladder
+
+Run checks from narrow to broad:
+
+- Targeted: `bun test apps/trails/src/__tests__/create.test.ts`
+- Helper: `bun run scaffold-versions:check`
+- ADR/docs: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`,
+  `bun run docs:links`
+- App/package: `bun --cwd apps/trails test`
+- Type/format: `bun run typecheck`, `bun run format:check`, `git diff --check`
+- Full repo before submission/final handoff: `bun run check`
+- Optional smoke if time permits:
+  - create a temp scaffold with `bun apps/trails/bin/trails.ts create ...`
+  - inspect `package.json` and `.trails/scaffold.json`
+  - run `bun install`, `bun run typecheck`, and `bun test` inside it if network
+    and registry state are available.
+
+## Local Review
+
+Required before draft submission.
+
+- Lane 1: scaffold package/range and provenance shape.
+- Lane 2: bump-helper/tooling path, tests, and generated-output coverage.
+- Lane 3: release/docs/ADR/changeset wording and doctrine fit.
+
+Reviewer output contract:
+
+- Overall score: `n/5`
+- Prose summary: concise judgment
+- Findings: P0/P1/P2/P3, with file/line evidence where applicable
+- Prompt to fix: concise prompt for each actionable finding
+
+Fix all P0/P1/P2 findings before remote submission or final handoff. Record
+review summaries, findings, fixes, and residual P3s in `RETRO.md`.
+
+For remote code-review bots/agents, also record summary scores, prose summaries,
+prompt-to-fix blocks, and whether any score below 5/5 reflects current
+unresolved debt, stale feedback, or an explicitly rejected recommendation.
+
+## Progress Reporting
+
+After each execution turn, report:
+
+- Current checkpoint
+- What changed
+- What was verified
+- Command/output summary
+- What remains
+- Blocker status
+- Next checkpoint
+
+## Stop / Pause Rules
+
+Stop and ask if:
+
+- Linear or repo state shows TRL-796/798/797/799 are already implemented or
+  materially reshaped.
+- The exact-pin decision reopens into `@beta` or another policy choice.
+- The provenance breadcrumb needs behavior beyond writing/documenting a file.
+- The bump-helper scope expands into release automation or publication.
+- The draft ADR requires accepting a new Trails primitive or public command now.
+- A public API, artifact-family doctrine, or stable-cutover doctrine change is
+  needed beyond this packet.
+- Verification fails for unrelated reasons after focused retry.
+- Secrets, credentials, publication, registry mutation, merge queue labels, or
+  a merge are needed.
+- More than three focused attempts do not shrink a failing surface.
+
+## Handoff Audit
+
+- [x] Objective is singular and end-to-end.
+- [x] Completion condition is objectively checkable.
+- [x] Tracker state is current as of planning.
+- [x] Branch names/order are exact.
+- [x] Dependencies/blockers are represented.
+- [x] Ignored/untracked source docs are summarized in `REFS.md`.
+- [x] Validation commands match repo conventions.
+- [x] `GOAL.md` requires transcript-visible proof.
+- [x] `GOAL.md` requires `RETRO.md` finalization before completion.
+- [x] Stop rules are concrete.
+- [x] `RETRO.md` has concrete sections for execution, tracker, review,
+      verification, remote state, forbidden actions, final state, and archive
+      readiness.
+- [x] Packet can be executed without chat history.

--- a/.agents/plans/2026-05-24-scaffold-forward-compat-seed/REFS.md
+++ b/.agents/plans/2026-05-24-scaffold-forward-compat-seed/REFS.md
@@ -1,0 +1,107 @@
+# References: scaffold forward-compat seed
+
+## Tracked / Portable Sources
+
+- `AGENTS.md` - repo commands, Graphite workflow, Trail rules, Warden guide,
+  changeset policy, and subagent constraints.
+- `.agents/plans/PLANNING.md` - goal-packet, review, source-control, tracker,
+  validation, and archive preferences.
+- `apps/trails/src/versions.ts` - owner of `trailsPackageVersion` and
+  `ontrailsPackageRange`; current line emits `^${trailsPackageVersion}`.
+- `apps/trails/src/scaffold-versions.generated.ts` - generated dependency
+  version table and regeneration command note.
+- `apps/trails/src/trails/create-scaffold.ts` - owns base generated files,
+  package JSON generation, `.trails/.gitignore`, and scaffold write operations.
+- `apps/trails/src/trails/create.ts` - outer create trail that composes
+  scaffold, surfaces, verify, and README generation.
+- `apps/trails/src/__tests__/create.test.ts` - scaffold assertions for package
+  ranges, generated files, dry-run operations, surfaces, verify mode, and
+  README/AGENTS output.
+- `scripts/sync-scaffold-versions.ts` - current internal scaffold dependency
+  version sync/check script; likely owner or sibling for TRL-797 helper work.
+- `package.json` - root script surface for scaffold-version sync/check and the
+  full `bun run check` gate.
+- `docs/releases/beta-channel-policy.md` - active beta install policy:
+  deliberate `@beta` or exact `1.0.0-beta.N`, no accidental latest.
+- `docs/releases/stable-cutover.md` - stable release runbook; TRL-796 must add
+  exact scaffold pins as a stable-cutover prerequisite.
+- `docs/adr/drafts/README.md` - generated draft ADR map; use ADR tooling rather
+  than hand-maintaining generated sections.
+- `docs/getting-started.md` - candidate current-facing doc for the provenance
+  breadcrumb contract if the executor needs a small user-visible placement.
+- `.agents/plans/2026-05-23-scaffold-runway-overnight-stack/RETRO.md` -
+  completed prior scaffold stack context for TRL-788/777/779/792.
+
+## Untracked / Local-Only Sources
+
+- `/Users/mg/Developer/outfitter/trailblazing/inbox/2026-05-24-lewis-clark-turnaround.md`
+  - shared Lewis/Clark note; used to capture Matt's widened-slice preference
+    and latest issue ordering context. Load-bearing details are copied into
+    `PLAN.md` and this `REFS.md`.
+- `/Users/mg/Developer/outfitter/trailblazing/plans/fieldwork-loop/README.md`
+  - canonical planning doc for fieldwork/Forge; background only. This packet
+    does not depend on that file at execution time.
+
+## Copied Or Summarized Sources
+
+- `PLAN.md` - summarizes the Linear issue state, candidate ranking, branch
+  order, non-goals, and validation ladder.
+- `RETRO.md` - records planning discoveries, including the current detached
+  worktree caveat, TRL-801 supersession judgment, and Matt's widened-slice
+  correction.
+
+## Tracker Records
+
+- TRL-796 - in-goal first branch. Exact beta package pin; stable-cutover
+  prerequisite.
+- TRL-798 - in-goal second branch. Minimal scaffold provenance breadcrumb.
+- TRL-797 - in-goal third branch. Internal helper/check for clean scaffold
+  version bumps after exact pins.
+- TRL-799 - in-goal fourth branch. Draft ADR for post-1.0 scaffold
+  forward-compatibility and upgrade path.
+- TRL-801 - related decision issue; treat as covered/superseded by TRL-796
+  unless Matt says otherwise.
+- TRL-803 - separate bootstrap/worktree hook tooling lane.
+- TRL-794 - separate Warden partial diagnostics lane.
+- TRL-782 / TRL-783 - separate type-safety lane.
+- TRL-759 - beta install policy antecedent for TRL-796.
+- ADR-0047 / `docs/releases/stable-cutover.md` - stable release doctrine and
+  runbook target.
+
+## PRs / Branches
+
+- Main baseline at planning: `2df73cc30 fix(trails): allow fieldwork lint markers (#587)`.
+- Merged prerequisite stack visible in `git log`: #581, #588, #582, #583,
+  #584, #585, #586, #587.
+- Planned branch 1:
+  `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel`.
+- Planned branch 2:
+  `trl-798-stamp-scaffold-provenance-into-generated-projects-minimal`.
+- Planned branch 3:
+  `trl-797-internal-helper-for-clean-ontrails-version-bumps-in-scaffold`.
+- Planned branch 4:
+  `trl-799-draft-adr-scaffold-forward-compatibility-upgrade-path-system`.
+
+## Prior Plans
+
+- `.agents/plans/2026-05-23-scaffold-runway-overnight-stack/` - current
+  historical reference; prior scaffold stack is merged into main.
+- `.agents/plans/2026-05-24-warden-as-coach-overnight-stack/` - current
+  historical reference; Warden stack is merged into main.
+
+## Validation Commands
+
+- `git status --short --branch` - branch cleanliness and detached/branch state.
+- `git log --oneline -8` - baseline confirmation.
+- `bun test apps/trails/src/__tests__/create.test.ts` - targeted scaffold
+  behavior and generated output assertions.
+- `bun --cwd apps/trails test` - app package regression check.
+- `bun run scaffold-versions:check` - generated scaffold version table drift.
+- Targeted helper tests if TRL-797 adds a testable helper.
+- `bun scripts/adr.ts map` - ADR map regeneration/check support.
+- `bun scripts/adr.ts check` - ADR metadata and link validation.
+- `bun run docs:links` - documentation link validation when ADR/docs change.
+- `bun run format:check` - repo formatter/lint wrapper.
+- `git diff --check` - whitespace/patch hygiene.
+- `bun run typecheck` - TypeScript contract check.
+- `bun run check` - final full repo gate before draft submission/final handoff.

--- a/.agents/plans/2026-05-24-scaffold-forward-compat-seed/RETRO.md
+++ b/.agents/plans/2026-05-24-scaffold-forward-compat-seed/RETRO.md
@@ -1,0 +1,171 @@
+# Execution Retro: scaffold forward-compat seed
+
+Date started: 2026-05-24
+Date finalized: pending
+Status: In progress
+Plan: `.agents/plans/2026-05-24-scaffold-forward-compat-seed/PLAN.md`
+Goal: `.agents/plans/2026-05-24-scaffold-forward-compat-seed/GOAL.md`
+
+Use this as the durable execution ledger. For stacked work, this should normally
+be the last meaningful file touched before local completion, draft submission,
+ready-for-review, remote review closeout, merge readiness, archive, or final
+handoff. Meaningful review-flow changes require a new retro entry.
+
+## Execution Summary
+
+- Objective: four-PR scaffold-forward stack for TRL-796 exact beta pins,
+  TRL-798 scaffold provenance breadcrumb, TRL-797 internal bump/check helper,
+  and TRL-799 draft scaffold forward-compatibility ADR.
+- Final outcome: pending.
+- Final branch / stack tip:
+  `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel`
+  attached as bottom branch; upper stack pending.
+- Final PR range: pending.
+- Final tracker state: pending.
+- Final verification state: pending.
+- Remaining risks / P3s: pending.
+- Archive state: active packet; not ready to archive until the stack merges or
+  Matt asks.
+
+## Branch / PR / Issue Ledger
+
+| Order | Issue | Branch | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | TRL-796 | `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel` | pending | implemented locally | Exact generated `@ontrails/*` beta pin; stable-cutover prerequisite docs; patch changeset. |
+| 2 | TRL-798 | `trl-798-stamp-scaffold-provenance-into-generated-projects-minimal` | pending | planned | Minimal `.trails/scaffold.json` breadcrumb stacked above TRL-796. |
+| 3 | TRL-797 | `trl-797-internal-helper-for-clean-ontrails-version-bumps-in-scaffold` | pending | planned | Internal helper/check path so exact scaffold pins stay easy to bump. |
+| 4 | TRL-799 | `trl-799-draft-adr-scaffold-forward-compatibility-upgrade-path-system` | pending | planned | Draft ADR grounded in the implemented breadcrumb/helper shape. |
+
+## Planning Discoveries
+
+| Discovery | Evidence | Decision | Impact |
+| --- | --- | --- | --- |
+| Worktree synced to latest merged baseline. | `git switch --detach origin/main` moved from `52e4e8f7d` to `2df73cc30`; `git log --oneline -8` shows #581-#588 and #582-#587 merged. | Plan from current merged main. | The previous scaffold/Warden stacks are no longer blockers. |
+| Current worktree is detached. | `git status --short --branch` reports `## HEAD (no branch)`; context-prime reports Graphite cannot operate without a branch checked out. | Goal executor must create/check out a real Graphite branch before source-control operations. | `gt ls/status` may fail during preflight until branch exists. |
+| TRL-796 is the first scaffold-forward rung. | Linear TRL-796: High priority, release-prep, exact pin over `@beta` decided by Matt; `versions.ts:26` still emits caret. | Put TRL-796 first. | Removes stable-cutover footgun before any future version work. |
+| TRL-798 composes with TRL-796. | Linear TRL-798 touches same scaffold output and is the smallest enabling step for future upgrade tooling. | Stack TRL-798 above TRL-796. | One coherent scaffold-output review without expanding into full upgrade tooling. |
+| Matt wants a larger crank slice. | Matt pushed back that if we are going to crank for a while, we should tack on more to get further along. | Expand from TRL-796/798 to TRL-796/798/797/799. | Keeps momentum while staying inside one scaffold-forward concept family. |
+| TRL-797 belongs in this widened slice. | TRL-797 depends on exact pins and can reuse existing scaffold-version tooling. | Stack TRL-797 after TRL-798. | Converts exact pins from future hand-edit debt into a checkable operator path. |
+| TRL-799 belongs after implementation shape exists. | TRL-799 should describe the real breadcrumb/helper shape, not speculation. | Stack TRL-799 after TRL-797. | Captures doctrine while deferring the full upgrade-path system. |
+| TRL-801 is redundant after TRL-796 decision. | Linear TRL-801 asks to decide package range; TRL-796 already records Matt's exact-pin decision and implementation acceptance criteria. | Treat TRL-801 as covered/superseded, not in-goal execution. | Tracker comment added so this is not silent duplicate backlog. |
+| TRL-803 is a separate bootstrap lane. | TRL-803 is about hook tooling in worktrees, not generated app scaffold package/provenance output. | Do not mix into scaffold-forward stack. | Avoids review and failure-mode sprawl. |
+
+## Deferred / Follow-Up Discoveries
+
+| Issue | Discovery | Why Out Of Goal | Link |
+| --- | --- | --- | --- |
+| TRL-801 | Package range decision issue is covered by TRL-796. | Needs status/closure judgment later, not implementation. | <https://linear.app/outfitter/issue/TRL-801/decide-scaffold-package-range-for-beta-releases> |
+| TRL-803 | Bootstrap must install hook tooling in worktrees. | Different lane and different failure mode. | <https://linear.app/outfitter/issue/TRL-803/bootstrap-must-install-hook-tooling-worktrees-hit-empty-node-modules> |
+| TRL-794 | Warden partial diagnostics remain useful. | Separate Warden coaching lane, not scaffold-forward work. | <https://linear.app/outfitter/issue/TRL-794> |
+| TRL-782 / TRL-783 | Type-safety work remains useful. | Separate type-safety lane; should not ride scaffold PRs. | pending exact links |
+
+## Tracker Mutations
+
+| Time | Tracker Item | Mutation | Evidence |
+| --- | --- | --- | --- |
+| 2026-05-24 14:35 EDT | Linear TRL-796/797/798/799/801/803 | Read issue state during planning; no status changes made. | Linear fetch/search in planning session. |
+| 2026-05-24 14:39 EDT | Linear TRL-801 | Added planning comment recommending TRL-801 be treated as superseded/covered by TRL-796. | Linear comment `18461dd2-1947-4bd7-9017-3ae65358f1da`. |
+
+## Execution Log
+
+```text
+2026-05-24 14:35 EDT - planning/preflight
+- Changed: synced Lewis worktree to origin/main at 2df73cc30; created this packet.
+- Verified: git status/log, Linear issue bodies, scaffold source/test anchors, stable-cutover docs.
+- Result: initially selected TRL-796 -> TRL-798 as next executable stack.
+- Next: widen if Matt wants a longer crank slice.
+- Blockers: none; detached worktree means executor must create/check out a branch before Graphite operations.
+
+2026-05-24 14:39 EDT - tracker hygiene
+- Changed: commented on TRL-801 that TRL-796 now carries the exact-pin decision and implementation path.
+- Verified: Linear comment created as 18461dd2-1947-4bd7-9017-3ae65358f1da.
+- Result: TRL-801 is no longer a silent duplicate in the planning surface.
+- Next: execution should treat TRL-801 as related/superseded unless Matt says otherwise.
+- Blockers: none.
+
+2026-05-24 14:50 EDT - slice expansion
+- Changed: expanded packet from two PRs to four PRs: TRL-796 -> TRL-798 -> TRL-797 -> TRL-799.
+- Verified: issue dependencies, source anchors, and validation ladder still keep the slice inside scaffold-forward compatibility.
+- Result: larger overnight-friendly stack without mixing in bootstrap hooks, Warden partial diagnostics, or type-safety work.
+- Next: goal executor should create the TRL-796 branch and implement bottom-up.
+- Blockers: none.
+
+2026-05-24 15:33 EDT - execution branch attach
+- Changed: created/tracked the bottom Graphite branch from the current main commit.
+- Verified: `git status --short --branch` reports `## trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel` with only this packet untracked; `gt log --stack --reverse` shows the branch stacked on `main` at `2df73cc30`.
+- Result: Graphite operations are now unblocked in the worktree.
+- Next: commit the packet on the bottom branch, then create the remaining local stack branches.
+- Blockers: none.
+
+2026-05-24 15:33 EDT - TRL-796 implementation
+- Changed: generated scaffold `@ontrails/*` package range now equals the `@ontrails/trails` package version exactly; create tests assert every generated `@ontrails/*` dependency/devDependency is exact and not caret-prefixed; stable-cutover prerequisites now include scaffold pin checking; added a patch changeset for `@ontrails/trails`.
+- Verified: `bun test apps/trails/src/__tests__/create.test.ts` passed 17 tests / 342 assertions; `bun run scaffold-versions:check` passed.
+- Result: TRL-796 code/docs/test slice is ready to commit on the bottom branch.
+- Next: commit TRL-796, restack descendants, then implement TRL-798 provenance.
+- Blockers: none.
+```
+
+## Local Review Log
+
+| Round | Scope / Lanes | Report Paths | P0/P1/P2 Result | Fix Commits / Notes |
+| --- | --- | --- | --- | --- |
+| pending | scaffold package/provenance shape; bump-helper/tooling and generated-output coverage; release/docs/ADR doctrine fit | pending | pending | Required before draft submission. |
+
+## Verification Log
+
+| Check | Scope | Result | Evidence / Notes |
+| --- | --- | --- | --- |
+| `git status --short --branch` | planning | pass | detached clean at current main. |
+| `git log --oneline -8` | planning | pass | latest commit `2df73cc30 fix(trails): allow fieldwork lint markers (#587)`. |
+| Linear fetch/search | planning | pass | TRL-796, 797, 798, 799, 801, 803, 782, 783, 794, 800 checked as needed. |
+| Packet markdown/retro checks | planning | pending | Run after widened packet edits. |
+| `git status --short --branch` | execution branch attach | pass | branch `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel`; packet untracked before packet commit. |
+| `gt log --stack --reverse` | execution branch attach | pass | branch stacked directly on `main` at `2df73cc30`. |
+| `bun test apps/trails/src/__tests__/create.test.ts` | TRL-796 | pass | 17 tests / 342 assertions. |
+| `bun run scaffold-versions:check` | TRL-796 | pass | existing scaffold version drift check still passes after exact pin change. |
+
+## Remote Review / CI Log
+
+| Time | PR | CI State | Review State | Scores / Signals | Unresolved P0/P1/P2 | Action |
+| --- | --- | --- | --- | --- | --- | --- |
+| pending | pending | pending | pending | pending | pending | Submit draft PRs only after local review and checks. |
+
+## Review Feedback Resolutions
+
+| Source | Score / Signal | Severity | Finding | Prompt To Fix | Resolution | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| pending | pending | pending | pending | pending | pending | pending |
+
+## Forbidden Actions Audit
+
+| Action / Constraint | Status | Evidence |
+| --- | --- | --- |
+| No merge without explicit user approval | respected so far | Planning only; no merge commands run. |
+| No package publish / registry mutation unless authorized | respected so far | Planning only; no publish/registry commands run. |
+| No merge queue label unless authorized | respected so far | Planning only; no queue mutation. |
+| No source-control writes by subagents | respected so far | No subagents used in planning. |
+| No unrelated destructive changes | respected so far | Packet creation/update and shared-note update only. |
+
+## Final State
+
+Fill before claiming completion, handoff, merge readiness, or archive.
+
+- Goal completion condition:
+- Graphite / branch state:
+- PR state:
+- Source-control host lag:
+- Tracker state:
+- Local review state:
+- Remote review state:
+- Remote review scores:
+- Verification:
+- Skipped checks:
+- Remaining P3s / risks:
+- Follow-up issues created:
+- Forbidden actions confirmation:
+- Packet archive readiness:
+- Final transcript proof:
+
+Do not mark complete until the goal completion condition has been proven, this
+section is filled or explicitly marked blocked, and the final transcript names
+the updated retro state.

--- a/.changeset/trl-796-exact-scaffold-pins.md
+++ b/.changeset/trl-796-exact-scaffold-pins.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/trails": patch
+---
+
+Generated projects now pin `@ontrails/*` packages to the exact scaffolded
+package version instead of emitting caret prerelease ranges.

--- a/apps/trails/src/__tests__/create.test.ts
+++ b/apps/trails/src/__tests__/create.test.ts
@@ -66,6 +66,11 @@ const expectCreatedPaths = (
   expect(created).toEqual(expect.arrayContaining(relativePaths));
 };
 
+const expectExactOntrailsPin = (value: string | undefined): void => {
+  expect(value).toBe(ontrailsPackageRange);
+  expect(value?.startsWith('^')).toBe(false);
+};
+
 const expectOk = <T>(result: Result<T, Error>): T => {
   if (result.isErr()) {
     throw result.error;
@@ -265,17 +270,17 @@ const assertCliPackage = (dir: string): void => {
   expect(pkg['name']).toBe(basename(dir));
 
   const deps = pkg['dependencies'] as Record<string, string>;
-  expect(deps['@ontrails/core']).toBe(ontrailsPackageRange);
-  expect(deps['@ontrails/cli']).toBe(ontrailsPackageRange);
-  expect(deps['@ontrails/commander']).toBe(ontrailsPackageRange);
+  expectExactOntrailsPin(deps['@ontrails/core']);
+  expectExactOntrailsPin(deps['@ontrails/cli']);
+  expectExactOntrailsPin(deps['@ontrails/commander']);
   expect(deps['commander']).toBeUndefined();
 };
 
 const assertVerifyPackage = (dir: string): void => {
   const pkg = readJson(dir, 'package.json');
   const devDeps = pkg['devDependencies'] as Record<string, string>;
-  expect(devDeps['@ontrails/testing']).toBe(ontrailsPackageRange);
-  expect(devDeps['@ontrails/warden']).toBe(ontrailsPackageRange);
+  expectExactOntrailsPin(devDeps['@ontrails/testing']);
+  expectExactOntrailsPin(devDeps['@ontrails/warden']);
   expect(devDeps['lefthook']).toBe(scaffoldDependencyVersions.lefthook);
   expect(readText(dir, 'lefthook.yml')).toContain('bunx trails warden');
   expect(readText(dir, 'lefthook.yml')).not.toContain('--exit-code');
@@ -284,7 +289,7 @@ const assertVerifyPackage = (dir: string): void => {
 const assertGeneratedToolingDeps = (dir: string): void => {
   const pkg = readJson(dir, 'package.json');
   const devDeps = pkg['devDependencies'] as Record<string, string>;
-  expect(devDeps['@ontrails/trails']).toBe(ontrailsPackageRange);
+  expectExactOntrailsPin(devDeps['@ontrails/trails']);
   expect(devDeps['@types/bun']).toBe(scaffoldDependencyVersions.bunTypes);
   expect(devDeps['oxfmt']).toBe(scaffoldDependencyVersions.oxfmt);
   expect(devDeps['oxlint']).toBe(scaffoldDependencyVersions.oxlint);
@@ -383,7 +388,7 @@ const assertMcpSurface = (dir: string): void => {
     string,
     string
   >;
-  expect(deps['@ontrails/mcp']).toBe(ontrailsPackageRange);
+  expectExactOntrailsPin(deps['@ontrails/mcp']);
   expect(deps['@ontrails/cli']).toBeUndefined();
 };
 
@@ -398,8 +403,8 @@ const assertHttpSurface = (dir: string): void => {
     string,
     string
   >;
-  expect(deps['@ontrails/hono']).toBe(ontrailsPackageRange);
-  expect(deps['@ontrails/http']).toBe(ontrailsPackageRange);
+  expectExactOntrailsPin(deps['@ontrails/hono']);
+  expectExactOntrailsPin(deps['@ontrails/http']);
 };
 
 const assertVerifySkipped = (dir: string): void => {
@@ -554,7 +559,7 @@ describe('trails create', () => {
           string,
           string
         >;
-        expect(deps['@ontrails/mcp']).toBe(ontrailsPackageRange);
+        expectExactOntrailsPin(deps['@ontrails/mcp']);
         assertReadme(dir, { surfaces: ['cli', 'mcp', 'http'] });
       });
     });
@@ -643,7 +648,7 @@ describe('trails create', () => {
           string,
           string
         >;
-        expect(deps['@ontrails/mcp']).toBe(ontrailsPackageRange);
+        expectExactOntrailsPin(deps['@ontrails/mcp']);
       });
     });
 

--- a/apps/trails/src/versions.ts
+++ b/apps/trails/src/versions.ts
@@ -23,6 +23,9 @@ export const trailsPackageVersion = requireVersion(
   '@ontrails/trails'
 );
 
-export const ontrailsPackageRange = `^${trailsPackageVersion}`;
+export const ontrailsPackageRange = requireVersion(
+  trailsPackageVersion,
+  '@ontrails/* scaffold package range'
+);
 
 export { scaffoldDependencyVersions };

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -57,14 +57,25 @@ Before creating the version PR:
    bunx changeset status --verbose
    ```
 
-8. No generated local SQLite artifacts are staged:
+8. Scaffolded project dependency pins are ready for the target package line:
+
+   ```bash
+   bun run scaffold-versions:check
+   ```
+
+   Generated apps must emit exact `@ontrails/*` pins for the current
+   `@ontrails/trails` package version, not caret prerelease ranges. The stable
+   version PR should update that package version through Changesets before the
+   post-version scaffold inspection below.
+
+9. No generated local SQLite artifacts are staged:
 
    ```bash
    git status --short -- .trails .trails-tmp
    git status --short -- .trails/trails.db .trails/trails.db-shm .trails/trails.db-wal
    ```
 
-9. The ADR and docs checks pass:
+10. The ADR and docs checks pass:
 
    ```bash
    bun scripts/adr.ts map
@@ -146,7 +157,8 @@ Expected outcomes:
 - Internal package ranges pack without unresolved `workspace:` or `catalog:`
   ranges.
 - Changelogs and release notes stop describing the release as beta.
-- Generated app dependency ranges point at the intended stable package versions.
+- Generated app dependency ranges point at exact intended stable package
+  versions.
   The post-publish smoke below proves those stable ranges are installable from
   the registry after publication.
 


### PR DESCRIPTION
## Context

Scaffolded Trails projects were emitted with caret prerelease ranges for `@ontrails/*` packages. On the beta channel that lets a fresh project float past the generator version, which breaks the stable-cutover prerequisite that generated apps stay on the exact framework version they were created from.

This is the bottom PR in the scaffold forward-compatibility seed stack. It also carries the tracked goal packet commit for `.agents/plans/2026-05-24-scaffold-forward-compat-seed/`.

## Changes

- Pin generated `@ontrails/*` package ranges exactly to the current `@ontrails/trails` package version.
- Strengthen scaffold create tests so every generated `@ontrails/*` dependency/devDependency is exact and not caret-prefixed.
- Document the exact-pin prerequisite in the stable cutover runbook.
- Add a patch changeset for `@ontrails/trails`.

## Validation

- `bun test apps/trails/src/__tests__/create.test.ts`
- `bun run scaffold-versions:check`
- Included in the stack-tip `bun run check` pass.

## Notes / Risks

- This intentionally does not introduce upgrade tooling or scaffold migration behavior; it only removes beta range drift from newly generated projects.
- PR remains draft while the four-PR stack is kept together.

Closes: TRL-796
