### PR TITLE
feat: stamp scaffold provenance metadata

### DIFF
--- a/.agents/plans/2026-05-24-scaffold-forward-compat-seed/RETRO.md
+++ b/.agents/plans/2026-05-24-scaffold-forward-compat-seed/RETRO.md
@@ -32,7 +32,7 @@ handoff. Meaningful review-flow changes require a new retro entry.
 | Order | Issue | Branch | PR | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
 | 1 | TRL-796 | `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel` | pending | implemented locally | Exact generated `@ontrails/*` beta pin; stable-cutover prerequisite docs; patch changeset. |
-| 2 | TRL-798 | `trl-798-stamp-scaffold-provenance-into-generated-projects-minimal` | pending | planned | Minimal `.trails/scaffold.json` breadcrumb stacked above TRL-796. |
+| 2 | TRL-798 | `trl-798-stamp-scaffold-provenance-into-generated-projects-minimal` | pending | implemented locally | Minimal `.trails/scaffold.json` breadcrumb stacked above TRL-796; patch changeset. |
 | 3 | TRL-797 | `trl-797-internal-helper-for-clean-ontrails-version-bumps-in-scaffold` | pending | planned | Internal helper/check path so exact scaffold pins stay easy to bump. |
 | 4 | TRL-799 | `trl-799-draft-adr-scaffold-forward-compatibility-upgrade-path-system` | pending | planned | Draft ADR grounded in the implemented breadcrumb/helper shape. |
 
@@ -103,6 +103,13 @@ handoff. Meaningful review-flow changes require a new retro entry.
 - Result: TRL-796 code/docs/test slice is ready to commit on the bottom branch.
 - Next: commit TRL-796, restack descendants, then implement TRL-798 provenance.
 - Blockers: none.
+
+2026-05-24 15:34 EDT - TRL-798 implementation
+- Changed: generated scaffolds now include `.trails/scaffold.json` with `schemaVersion`, `scaffoldVersion`, `template`, and `generatedAt`; create tests assert the breadcrumb for default, `verify: false`, entity, and empty scaffolds plus dry-run planned operations; getting-started documents the breadcrumb as informational current-beta provenance; added a patch changeset for `@ontrails/trails`.
+- Verified: `bun test apps/trails/src/__tests__/create.test.ts` passed 17 tests / 368 assertions; `bun --cwd apps/trails test` passed 349 tests / 1402 assertions.
+- Result: TRL-798 code/docs/test slice is ready to commit above TRL-796.
+- Next: commit TRL-798, restack descendants, then implement TRL-797 helper/check.
+- Blockers: none.
 ```
 
 ## Local Review Log
@@ -123,6 +130,8 @@ handoff. Meaningful review-flow changes require a new retro entry.
 | `gt log --stack --reverse` | execution branch attach | pass | branch stacked directly on `main` at `2df73cc30`. |
 | `bun test apps/trails/src/__tests__/create.test.ts` | TRL-796 | pass | 17 tests / 342 assertions. |
 | `bun run scaffold-versions:check` | TRL-796 | pass | existing scaffold version drift check still passes after exact pin change. |
+| `bun test apps/trails/src/__tests__/create.test.ts` | TRL-798 | pass | 17 tests / 368 assertions. |
+| `bun --cwd apps/trails test` | TRL-798 | pass | 349 tests / 1402 assertions. |
 
 ## Remote Review / CI Log
 

--- a/.changeset/trl-798-scaffold-provenance.md
+++ b/.changeset/trl-798-scaffold-provenance.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/trails": patch
+---
+
+Generated projects now include a minimal `.trails/scaffold.json` provenance
+breadcrumb recording the scaffold schema version, package version, starter
+template, and generation timestamp.

--- a/apps/trails/src/__tests__/create.test.ts
+++ b/apps/trails/src/__tests__/create.test.ts
@@ -20,6 +20,7 @@ import { PROJECT_NAME_MESSAGE } from '../project-writes.js';
 import {
   ontrailsPackageRange,
   scaffoldDependencyVersions,
+  trailsPackageVersion,
 } from '../versions.js';
 
 type Starter = 'empty' | 'entity' | 'hello';
@@ -159,6 +160,7 @@ const assertDefaultProjectFiles = (dir: string): void => {
       '.oxfmtrc.jsonc',
       'src/app.ts',
       '.trails',
+      '.trails/scaffold.json',
       'src/cli.ts',
       'src/trails/hello.ts',
       '__tests__/examples.test.ts',
@@ -181,6 +183,21 @@ const assertTsconfigTests = (dir: string): void => {
   expect(compilerOptions['noEmit']).toBe(true);
   expect(compilerOptions['rootDir']).toBe('.');
   expect(compilerOptions['types']).toEqual(['bun']);
+};
+
+const assertScaffoldProvenance = (
+  dir: string,
+  starter: Starter = 'hello'
+): void => {
+  const provenance = readJson(dir, '.trails/scaffold.json');
+  expect(provenance['schemaVersion']).toBe(1);
+  expect(provenance['scaffoldVersion']).toBe(trailsPackageVersion);
+  expect(provenance['template']).toBe(starter);
+
+  const { generatedAt } = provenance;
+  expect(typeof generatedAt).toBe('string');
+  expect(Number.isNaN(Date.parse(generatedAt as string))).toBe(false);
+  expect(new Date(generatedAt as string).toISOString()).toBe(generatedAt);
 };
 
 const assertAgentGuidance = (dir: string): void => {
@@ -445,11 +462,13 @@ describe('trails create', () => {
           'AGENTS.md',
           'CLAUDE.md',
           'README.md',
+          '.trails/scaffold.json',
           'tsconfig.tests.json',
         ]);
         assertDefaultProjectFiles(dir);
         assertAgentGuidance(dir);
         assertReadme(dir);
+        assertScaffoldProvenance(dir);
         assertTsconfigTests(dir);
         assertCliPackage(dir);
         assertVerifyPackage(dir);
@@ -483,6 +502,7 @@ describe('trails create', () => {
             { kind: 'write', path: 'CLAUDE.md' },
             { kind: 'write', path: 'src/app.ts' },
             { kind: 'write', path: '.trails/.gitignore' },
+            { kind: 'write', path: '.trails/scaffold.json' },
             { kind: 'write', path: 'tsconfig.tests.json' },
           ])
         );
@@ -514,6 +534,7 @@ describe('trails create', () => {
             '.oxfmtrc.jsonc',
             'src/app.ts',
             '.trails',
+            '.trails/scaffold.json',
             'src/trails/hello.ts',
           ],
           true
@@ -524,6 +545,7 @@ describe('trails create', () => {
     test('generates with entity starter', async () => {
       await withTempProject(async (dir) => {
         expectOk(await runCreate(dir, { starter: 'entity' }));
+        assertScaffoldProvenance(dir, 'entity');
         assertEntityStarter(dir);
         assertReadme(dir, { starter: 'entity' });
       });
@@ -571,6 +593,7 @@ describe('trails create', () => {
         assertAgentGuidance(dir);
         assertReadme(dir, { verify: false });
         assertTsconfigTests(dir);
+        assertScaffoldProvenance(dir);
         assertGeneratedToolingDeps(dir);
         assertFieldworkLintMarkers(dir);
         assertFrameworkCliScripts(dir);
@@ -580,6 +603,7 @@ describe('trails create', () => {
     test('generates with empty starter', async () => {
       await withTempProject(async (dir) => {
         expectOk(await runCreate(dir, { starter: 'empty' }));
+        assertScaffoldProvenance(dir, 'empty');
         assertEmptyStarter(dir);
         assertReadme(dir, { starter: 'empty' });
       });

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -23,6 +23,7 @@ import type {
 import {
   ontrailsPackageRange,
   scaffoldDependencyVersions,
+  trailsPackageVersion,
 } from '../versions.js';
 
 // ---------------------------------------------------------------------------
@@ -97,6 +98,18 @@ const generatePackageJson = (name: string): string => {
 
   return JSON.stringify(pkg, null, 2);
 };
+
+const generateScaffoldProvenance = (starter: Starter): string =>
+  JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      scaffoldVersion: trailsPackageVersion,
+      schemaVersion: 1,
+      template: starter,
+    },
+    null,
+    2
+  );
 
 const TSCONFIG_CONTENT = JSON.stringify(
   {
@@ -433,6 +446,7 @@ const collectScaffoldFiles = (
     ['oxlint.config.ts', OXLINT_CONFIG_CONTENT],
     ['.oxfmtrc.jsonc', OXFMTRC_CONTENT],
     ['.trails/.gitignore', WORKSPACE_GITIGNORE_CONTENT],
+    ['.trails/scaffold.json', generateScaffoldProvenance(starter)],
     ['src/app.ts', generateAppTs(name, starter)],
     ...starterFileGenerators[starter](),
   ]);

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,6 +29,13 @@ During the active beta line, use `@beta` for the newest published beta or pin
 exact `1.0.0-beta.N` versions for reproducible handoffs. Do not rely on
 unqualified `latest` unless release notes explicitly say it has been advanced.
 
+Generated projects include `.trails/scaffold.json`, a minimal provenance
+breadcrumb with the scaffold schema version, the `@ontrails/trails` version that
+created the project, the selected starter template, and the generation
+timestamp. It is informational in the current beta line; future upgrade tooling
+can use it as a starting point without guessing which scaffold produced the
+project.
+
 ## Your First Trail
 
 A trail is the atomic unit of work in Trails. It has a Zod input schema, a `blaze` that establishes how the trail runs and returns `Result`, and optional examples that double as tests and agent documentation.


### PR DESCRIPTION
## Context

Exact pins make generated projects stable, but future upgrade tooling also needs a tiny breadcrumb that says which Trails scaffold created the app. This PR adds the minimal provenance file without building readers, diffing, migrations, or public upgrade commands.

## Changes

- Generate `.trails/scaffold.json` for new projects.
- Stamp `schemaVersion`, `scaffoldVersion`, `template`, and `generatedAt` in the provenance file.
- Cover default, `verify: false`, entity, empty, and dry-run scaffold paths in tests.
- Document the breadcrumb in getting-started guidance.
- Add a patch changeset for `@ontrails/trails`.

## Validation

- `bun test apps/trails/src/__tests__/create.test.ts`
- `bun --cwd apps/trails test`
- Included in the stack-tip `bun run check` pass.

## Notes / Risks

- The breadcrumb is intentionally informational in this slice. No scaffold readers, diffing, migrations, template hashes, or `trails upgrade` behavior ship here.
- Optional temp-project smoke verified exact pins, `.trails/scaffold.json`, install, and typecheck. The temp app test was blocked by current published beta skew: `@ontrails/testing@1.0.0-beta.18` does not expose `@ontrails/testing/established`, while local source already does.
- PR remains draft while the four-PR stack is kept together.

Closes: TRL-798
