### PR TITLE
chore: validate scaffold package pin drift

### DIFF
--- a/.agents/plans/2026-05-24-scaffold-forward-compat-seed/RETRO.md
+++ b/.agents/plans/2026-05-24-scaffold-forward-compat-seed/RETRO.md
@@ -33,7 +33,7 @@ handoff. Meaningful review-flow changes require a new retro entry.
 | --- | --- | --- | --- | --- | --- |
 | 1 | TRL-796 | `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel` | pending | implemented locally | Exact generated `@ontrails/*` beta pin; stable-cutover prerequisite docs; patch changeset. |
 | 2 | TRL-798 | `trl-798-stamp-scaffold-provenance-into-generated-projects-minimal` | pending | implemented locally | Minimal `.trails/scaffold.json` breadcrumb stacked above TRL-796; patch changeset. |
-| 3 | TRL-797 | `trl-797-internal-helper-for-clean-ontrails-version-bumps-in-scaffold` | pending | planned | Internal helper/check path so exact scaffold pins stay easy to bump. |
+| 3 | TRL-797 | `trl-797-internal-helper-for-clean-ontrails-version-bumps-in-scaffold` | pending | implemented locally | Internal helper/check path so exact scaffold pins stay easy to bump. |
 | 4 | TRL-799 | `trl-799-draft-adr-scaffold-forward-compatibility-upgrade-path-system` | pending | planned | Draft ADR grounded in the implemented breadcrumb/helper shape. |
 
 ## Planning Discoveries
@@ -110,6 +110,14 @@ handoff. Meaningful review-flow changes require a new retro entry.
 - Result: TRL-798 code/docs/test slice is ready to commit above TRL-796.
 - Next: commit TRL-798, restack descendants, then implement TRL-797 helper/check.
 - Blockers: none.
+
+2026-05-24 15:35 EDT - TRL-797 implementation
+- Changed: extended `scripts/sync-scaffold-versions.ts` so both sync and check modes validate that generated `@ontrails/*` pins match `@ontrails/trails` exactly; release docs now call `bun run scaffold-versions:sync` after Changesets versioning; added focused script tests for exact, caret, and missing-export cases.
+- Verified: `bun test scripts/__tests__/sync-scaffold-versions.test.ts` passed 3 tests / 3 assertions; `bun run scaffold-versions:check` passed.
+- Result: TRL-797 internal helper/check slice is ready to commit above TRL-798.
+- Next: commit TRL-797, restack, then draft TRL-799 ADR.
+- Blockers: none.
+- Changeset: not added; this branch changes internal repo scripts/tests and release docs, not publishable package contents.
 ```
 
 ## Local Review Log
@@ -132,6 +140,8 @@ handoff. Meaningful review-flow changes require a new retro entry.
 | `bun run scaffold-versions:check` | TRL-796 | pass | existing scaffold version drift check still passes after exact pin change. |
 | `bun test apps/trails/src/__tests__/create.test.ts` | TRL-798 | pass | 17 tests / 368 assertions. |
 | `bun --cwd apps/trails test` | TRL-798 | pass | 349 tests / 1402 assertions. |
+| `bun test scripts/__tests__/sync-scaffold-versions.test.ts` | TRL-797 | pass | 4 tests / 4 assertions. |
+| `bun run scaffold-versions:check` | TRL-797 | pass | validates generated third-party scaffold versions plus exact `@ontrails/*` pins. |
 
 ## Remote Review / CI Log
 

--- a/docs/releases/beta-channel-policy.md
+++ b/docs/releases/beta-channel-policy.md
@@ -99,8 +99,10 @@ After substantial stacks merge to `main`:
    `release:none` decision.
 2. Run `bunx changeset status --verbose` from clean, synced `main` to inspect
    the next beta plan.
-3. When the next beta is warranted, create a dedicated version branch and run
-   `bunx changeset version`.
+3. When the next beta is warranted, create a dedicated version branch, run
+   `bunx changeset version`, then run `bun run scaffold-versions:sync` so
+   generated third-party scaffold dependency versions and exact `@ontrails/*`
+   pins are checked together.
 4. Review package versions, changelogs, generated lockfile changes, and
    generated-app dependency ranges.
 5. Run the version-branch gates, including `bun run publish:check` and

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -140,6 +140,7 @@ Exit prerelease mode and compute the stable versions:
 ```bash
 bunx changeset pre exit
 bunx changeset version
+bun run scaffold-versions:sync
 ```
 
 Review the generated diff before committing:
@@ -154,6 +155,8 @@ Expected outcomes:
   Changesets according to its stable-exit behavior.
 - All public non-private `@ontrails/*` packages land on the same stable
   version.
+- The scaffold-version helper has rewritten generated dependency versions and
+  verified generated `@ontrails/*` pins match that stable version exactly.
 - Internal package ranges pack without unresolved `workspace:` or `catalog:`
   ranges.
 - Changelogs and release notes stop describing the release as beta.

--- a/scripts/__tests__/sync-scaffold-versions.test.ts
+++ b/scripts/__tests__/sync-scaffold-versions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+
+import { diagnoseOntrailsPackagePin } from '../sync-scaffold-versions.ts';
+
+describe('sync-scaffold-versions', () => {
+  test('accepts exact generated @ontrails package pins', () => {
+    expect(
+      diagnoseOntrailsPackagePin({
+        ontrailsPackageRange: '1.0.0-beta.18',
+        trailsPackageVersion: '1.0.0-beta.18',
+      })
+    ).toBeUndefined();
+  });
+
+  test('rejects caret prerelease ranges for generated @ontrails packages', () => {
+    expect(
+      diagnoseOntrailsPackagePin({
+        ontrailsPackageRange: '^1.0.0-beta.18',
+        trailsPackageVersion: '1.0.0-beta.18',
+      })
+    ).toContain('must be exact pins');
+  });
+
+  test('rejects plain version drift for generated @ontrails packages', () => {
+    expect(
+      diagnoseOntrailsPackagePin({
+        ontrailsPackageRange: '1.0.0-beta.17',
+        trailsPackageVersion: '1.0.0-beta.18',
+      })
+    ).toContain('must be exact pins');
+  });
+
+  test('requires both scaffold version exports', () => {
+    expect(diagnoseOntrailsPackagePin({})).toContain(
+      'must export `ontrailsPackageRange` and `trailsPackageVersion`'
+    );
+  });
+});

--- a/scripts/sync-scaffold-versions.ts
+++ b/scripts/sync-scaffold-versions.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env bun
 /**
  * Generates or validates `apps/trails/src/scaffold-versions.generated.ts`
- * from the root `package.json` catalog and devDependencies.
+ * from the root `package.json` catalog and devDependencies, and validates that
+ * generated `@ontrails/*` package pins track the `@ontrails/trails` version
+ * exactly.
  *
  * Usage:
  *   bun scripts/sync-scaffold-versions.ts            # write generated file
@@ -9,7 +11,7 @@
  */
 
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, '..');
@@ -18,11 +20,45 @@ const generatedFilePath = resolve(
   repoRoot,
   'apps/trails/src/scaffold-versions.generated.ts'
 );
+const scaffoldVersionsModulePath = resolve(
+  repoRoot,
+  'apps/trails/src/versions.ts'
+);
 
 interface RootPackageJson {
   readonly catalog?: Record<string, string>;
   readonly devDependencies?: Record<string, string>;
 }
+
+export interface OntrailsPackagePinState {
+  readonly ontrailsPackageRange?: string;
+  readonly trailsPackageVersion?: string;
+}
+
+type ScaffoldVersionsModule = OntrailsPackagePinState;
+
+export const diagnoseOntrailsPackagePin = ({
+  ontrailsPackageRange,
+  trailsPackageVersion,
+}: OntrailsPackagePinState): string | undefined => {
+  if (
+    typeof ontrailsPackageRange !== 'string' ||
+    typeof trailsPackageVersion !== 'string'
+  ) {
+    return (
+      'sync-scaffold-versions: apps/trails/src/versions.ts must export ' +
+      '`ontrailsPackageRange` and `trailsPackageVersion`.'
+    );
+  }
+  if (ontrailsPackageRange !== trailsPackageVersion) {
+    return (
+      'sync-scaffold-versions: scaffolded @ontrails/* packages must be exact ' +
+      `pins for @ontrails/trails (${trailsPackageVersion}); got ` +
+      `${ontrailsPackageRange}.`
+    );
+  }
+  return undefined;
+};
 
 const requireValue = (
   value: string | undefined,
@@ -97,15 +133,32 @@ const check = async (expected: string): Promise<void> => {
   process.exit(1);
 };
 
+const checkOntrailsPackagePin = async (): Promise<void> => {
+  const versionsModule = (await import(
+    pathToFileURL(scaffoldVersionsModulePath).href
+  )) as ScaffoldVersionsModule;
+  // Normally quiet because versions.ts derives both exports from one source;
+  // this trips only if future/manual drift breaks that invariant.
+  const diagnostic = diagnoseOntrailsPackagePin(versionsModule);
+  if (diagnostic !== undefined) {
+    console.error(diagnostic);
+    process.exit(1);
+  }
+};
+
 const run = async (): Promise<void> => {
   const versions = await loadScaffoldVersions();
   const expected = renderGeneratedFile(versions);
   if (process.argv.includes('--check')) {
     await check(expected);
+    await checkOntrailsPackagePin();
     return;
   }
   await Bun.write(generatedFilePath, expected);
+  await checkOntrailsPackagePin();
   console.log(`Wrote ${generatedFilePath}`);
 };
 
-await run();
+if (import.meta.main) {
+  await run();
+}


### PR DESCRIPTION
## Context

Once scaffolded projects use exact framework pins, release operators need an internal guard that keeps those generated pins bumpable after `bunx changeset version`. The existing scaffold-version script already handled template package drift, so this PR extends that internal path rather than creating public CLI surface.

## Changes

- Extend `scripts/sync-scaffold-versions.ts` so sync/check mode validates generated `@ontrails/*` pins against the current `@ontrails/trails` version.
- Add focused script tests for exact pins, caret drift, and missing generated exports.
- Update beta and stable release docs to run scaffold-version sync/check during versioning.

## Validation

- `bun test scripts/__tests__/sync-scaffold-versions.test.ts`
- `bun run scaffold-versions:check`
- Included in the stack-tip `bun run check` pass.

## Notes / Risks

- No changeset: this is internal release tooling plus docs/tests only.
- This does not publish packages or mutate registry/dist-tags.
- PR remains draft while the four-PR stack is kept together.

Closes: TRL-797
