### PR TITLE
docs: draft scaffold forward compatibility ADR

### DIFF
--- a/.agents/plans/2026-05-24-scaffold-forward-compat-seed/RETRO.md
+++ b/.agents/plans/2026-05-24-scaffold-forward-compat-seed/RETRO.md
@@ -1,8 +1,8 @@
 # Execution Retro: scaffold forward-compat seed
 
 Date started: 2026-05-24
-Date finalized: pending
-Status: In progress
+Date finalized: 2026-05-24
+Status: Draft PRs submitted; CI green; Linear in review
 Plan: `.agents/plans/2026-05-24-scaffold-forward-compat-seed/PLAN.md`
 Goal: `.agents/plans/2026-05-24-scaffold-forward-compat-seed/GOAL.md`
 
@@ -16,14 +16,18 @@ handoff. Meaningful review-flow changes require a new retro entry.
 - Objective: four-PR scaffold-forward stack for TRL-796 exact beta pins,
   TRL-798 scaffold provenance breadcrumb, TRL-797 internal bump/check helper,
   and TRL-799 draft scaffold forward-compatibility ADR.
-- Final outcome: pending.
+- Final outcome: four draft PRs submitted with green CI, clean merge state,
+  high-quality PR bodies, local review clean, and Linear updated.
 - Final branch / stack tip:
-  `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel`
-  attached as bottom branch; upper stack pending.
-- Final PR range: pending.
-- Final tracker state: pending.
-- Final verification state: pending.
-- Remaining risks / P3s: pending.
+  `trl-799-draft-adr-scaffold-forward-compatibility-upgrade-path-system`.
+- Final PR range: #589-#592, all draft/open, merge state clean, CI Gate green.
+- Final tracker state: TRL-796, TRL-798, TRL-797, and TRL-799 moved to
+  `In Review` with PR/check/local-review comments.
+- Final verification state: local checks passed, full `bun run check` passed,
+  and GitHub CI is green across all four PRs.
+- Remaining risks / P3s: optional temp-project `bun test` remains blocked by
+  current published beta skew for `@ontrails/testing/established`; local source
+  exposes the subpath and the generated app install/typecheck smoke passed.
 - Archive state: active packet; not ready to archive until the stack merges or
   Matt asks.
 
@@ -31,10 +35,10 @@ handoff. Meaningful review-flow changes require a new retro entry.
 
 | Order | Issue | Branch | PR | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| 1 | TRL-796 | `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel` | pending | implemented locally | Exact generated `@ontrails/*` beta pin; stable-cutover prerequisite docs; patch changeset. |
-| 2 | TRL-798 | `trl-798-stamp-scaffold-provenance-into-generated-projects-minimal` | pending | implemented locally | Minimal `.trails/scaffold.json` breadcrumb stacked above TRL-796; patch changeset. |
-| 3 | TRL-797 | `trl-797-internal-helper-for-clean-ontrails-version-bumps-in-scaffold` | pending | implemented locally | Internal helper/check path so exact scaffold pins stay easy to bump. |
-| 4 | TRL-799 | `trl-799-draft-adr-scaffold-forward-compatibility-upgrade-path-system` | pending | planned | Draft ADR grounded in the implemented breadcrumb/helper shape. |
+| 1 | TRL-796 | `trl-796-scaffold-emits-caret-range-that-floats-past-the-beta-channel` | #589 | draft/open; CI green; merge state clean | Exact generated `@ontrails/*` beta pin; stable-cutover prerequisite docs; patch changeset. |
+| 2 | TRL-798 | `trl-798-stamp-scaffold-provenance-into-generated-projects-minimal` | #590 | draft/open; CI green; merge state clean | Minimal `.trails/scaffold.json` breadcrumb stacked above TRL-796; patch changeset. |
+| 3 | TRL-797 | `trl-797-internal-helper-for-clean-ontrails-version-bumps-in-scaffold` | #591 | draft/open; CI green; merge state clean | Internal helper/check path so exact scaffold pins stay easy to bump. |
+| 4 | TRL-799 | `trl-799-draft-adr-scaffold-forward-compatibility-upgrade-path-system` | #592 | draft/open; CI green; merge state clean | Draft ADR grounded in the implemented breadcrumb/helper shape. |
 
 ## Planning Discoveries
 
@@ -65,6 +69,10 @@ handoff. Meaningful review-flow changes require a new retro entry.
 | --- | --- | --- | --- |
 | 2026-05-24 14:35 EDT | Linear TRL-796/797/798/799/801/803 | Read issue state during planning; no status changes made. | Linear fetch/search in planning session. |
 | 2026-05-24 14:39 EDT | Linear TRL-801 | Added planning comment recommending TRL-801 be treated as superseded/covered by TRL-796. | Linear comment `18461dd2-1947-4bd7-9017-3ae65358f1da`. |
+| 2026-05-24 16:01 EDT | Linear TRL-796 | Moved to `In Review` and added PR/check/local-review comment. | PR #589; Linear comment `cf557a9d-34a1-45ca-b8de-39e5a53d51ba`. |
+| 2026-05-24 16:01 EDT | Linear TRL-798 | Moved to `In Review` and added PR/check/local-review comment. | PR #590; Linear comment `984f5ddf-a8dd-489f-b44f-d49dbde850d6`. |
+| 2026-05-24 16:01 EDT | Linear TRL-797 | Moved to `In Review` and added PR/check/local-review comment. | PR #591; Linear comment `7049d1e3-5a9e-4195-90ee-0ec7c920673a`. |
+| 2026-05-24 16:02 EDT | Linear TRL-799 | Moved to `In Review` and added PR/check/local-review comment. | PR #592; Linear comment `66f9d88c-f47e-400b-856f-bbb72b2f1074`. |
 
 ## Execution Log
 
@@ -118,13 +126,46 @@ handoff. Meaningful review-flow changes require a new retro entry.
 - Next: commit TRL-797, restack, then draft TRL-799 ADR.
 - Blockers: none.
 - Changeset: not added; this branch changes internal repo scripts/tests and release docs, not publishable package contents.
+
+2026-05-24 15:36 EDT - TRL-799 implementation
+- Changed: added draft ADR `docs/adr/drafts/20260524-scaffold-forward-compatibility.md`; regenerated draft ADR README and decision map. The draft locks in exact generated `@ontrails/*` pins, minimal `.trails/scaffold.json` provenance, and the internal scaffold-version helper, while deferring readers, diffs, migrations, template hashes, and public `trails upgrade`.
+- Verified: `bun scripts/adr.ts map && bun scripts/adr.ts check` passed with 0 errors / 0 warnings.
+- Result: TRL-799 draft ADR slice is ready to commit at the stack tip.
+- Next: commit TRL-799, then run stack validation and local review lanes.
+- Blockers: none.
+- Changeset: not added; draft ADR and generated ADR indexes only.
+
+2026-05-24 15:40 EDT - validation gate cleanup
+- Changed: fixed two pre-existing generated/docs-gate blockers found by `bun run check`: converted stale Wayfinding draft links to an ignored scratch proto into plain path text, and regenerated AGENTS / skill Warden guide rule counts from 57 to 58.
+- Verified: `bun scripts/check-markdown-links.ts` passed after the Wayfinding link cleanup; `bun run warden:agents:check && bun run warden:skills:check` passed after Warden guide sync.
+- Result: docs-link and Warden generated-guide blockers are cleared at the stack tip.
+- Next: fix the remaining `bun run check` failure from Knip duplicate exports on the owning branches.
+- Blockers: `bun run check` still fails at `dead-code` because exact pins made `trailsPackageVersion` and `ontrailsPackageRange` duplicate exports in `apps/trails/src/versions.ts`.
+
+2026-05-24 15:53 EDT - validation closeout and local review
+- Changed: fixed the Knip duplicate-export failure bottom-up by keeping `trailsPackageVersion` for CLI `--version` while deriving `ontrailsPackageRange` directly from package metadata instead of aliasing it. Restacked TRL-798/797/799 and added three local review lane reports.
+- Verified: `bun test apps/trails/src/__tests__/create.test.ts` passed 17 tests / 349 assertions; `bun run dead-code` passed; `bun run scaffold-versions:check` passed; `bun run check` passed on the stack tip.
+- Smoke: temp scaffold at `/tmp/trails-scaffold-forward-smoke.s7qKGw/docs-smoke` emitted exact `1.0.0-beta.18` pins and `.trails/scaffold.json`; `bun install` and `bun run typecheck` passed. `bun test` in that temp app failed because published `@ontrails/testing@1.0.0-beta.18` does not expose `@ontrails/testing/established`; local source does expose the subpath, so this is recorded as registry-state skew pending the next beta publication, not a scaffold implementation failure.
+- Review: local lanes scored 5/5, 5/5, and 5/5 with no P0/P1/P2 findings.
+- Result: local implementation and review are clean for draft submission.
+- Next: submit draft PR stack and update Linear with PR/check state.
+- Blockers: no local blockers.
+
+2026-05-24 16:02 EDT - draft submission and tracker closeout
+- Changed: submitted the four-PR draft Graphite stack, edited all PR titles/bodies with scope, validation, risk, and closure lines, and updated Linear status/comments for TRL-796/798/797/799.
+- Verified: `gh pr view` reports #589-#592 draft/open, merge state clean, and no non-green checks; Linear comments created as cf557a9d-34a1-45ca-b8de-39e5a53d51ba, 984f5ddf-a8dd-489f-b44f-d49dbde850d6, 7049d1e3-5a9e-4195-90ee-0ec7c920673a, and 66f9d88c-f47e-400b-856f-bbb72b2f1074.
+- Result: goal stack is submitted as draft, CI-green, locally reviewed, and tracker-current.
+- Next: run final small checks after this RETRO update, commit/submit the RETRO closeout, then hand off without merge/publish/queue changes.
+- Blockers: none.
 ```
 
 ## Local Review Log
 
 | Round | Scope / Lanes | Report Paths | P0/P1/P2 Result | Fix Commits / Notes |
 | --- | --- | --- | --- | --- |
-| pending | scaffold package/provenance shape; bump-helper/tooling and generated-output coverage; release/docs/ADR doctrine fit | pending | pending | Required before draft submission. |
+| 2026-05-24 15:53 EDT | scaffold package/provenance shape | `.agents/plans/2026-05-24-scaffold-forward-compat-seed/local-review-lane-1-scaffold-shape.md` | clean; no P0/P1/P2 | Score 5/5. P3 registry-smoke caveat recorded for current published beta. |
+| 2026-05-24 15:53 EDT | bump-helper/tooling and generated-output coverage | `.agents/plans/2026-05-24-scaffold-forward-compat-seed/local-review-lane-2-helper-tooling.md` | clean; no P0/P1/P2 | Score 5/5. |
+| 2026-05-24 15:53 EDT | release/docs/ADR doctrine fit | `.agents/plans/2026-05-24-scaffold-forward-compat-seed/local-review-lane-3-docs-adr.md` | clean; no P0/P1/P2 | Score 5/5. |
 
 ## Verification Log
 
@@ -142,48 +183,87 @@ handoff. Meaningful review-flow changes require a new retro entry.
 | `bun --cwd apps/trails test` | TRL-798 | pass | 349 tests / 1402 assertions. |
 | `bun test scripts/__tests__/sync-scaffold-versions.test.ts` | TRL-797 | pass | 4 tests / 4 assertions. |
 | `bun run scaffold-versions:check` | TRL-797 | pass | validates generated third-party scaffold versions plus exact `@ontrails/*` pins. |
+| `bun scripts/adr.ts map && bun scripts/adr.ts check` | TRL-799 | pass | draft ADR indexes regenerated; checker reports 0 errors / 0 warnings. |
+| `bun run format:check` | stack tip | fail then pass | failed on committed formatting in `apps/trails/src/__tests__/create.test.ts`; fixed on TRL-798 and reran successfully. |
+| `bun run typecheck` | stack tip | pass | 22 packages successful. |
+| `bun scripts/check-markdown-links.ts` | stack tip | pass | cleared stale ignored-scratch Wayfinding draft links. |
+| `bun run warden:agents:check && bun run warden:skills:check` | stack tip | pass | regenerated AGENTS and skill Warden guide counts to 58. |
+| `bun run check` | stack tip | fail | after docs/Warden cleanup, remaining failure is Knip duplicate exports for `trailsPackageVersion` and `ontrailsPackageRange` in `apps/trails/src/versions.ts`. |
+| `bun test apps/trails/src/__tests__/create.test.ts` | stack tip after duplicate-export fix | pass | 17 tests / 349 assertions. |
+| `bun run dead-code` | stack tip after duplicate-export fix | pass | Knip duplicate-export failure resolved. |
+| `bun run scaffold-versions:check` | stack tip after duplicate-export fix | pass | exact `@ontrails/*` pin check still passes. |
+| `bun run check` | stack tip after duplicate-export fix | pass | full repo check passed; Warden reports 0 errors / 26 warnings. |
+| temp scaffold smoke | stack tip | partial | exact pins and `.trails/scaffold.json` verified; install and typecheck passed; temp app test blocked by current published beta missing `@ontrails/testing/established`. |
+| `gh pr view` status checks | draft PRs #589-#592 | pass | all four PRs draft/open, merge state clean, and no non-green checks. |
 
 ## Remote Review / CI Log
 
 | Time | PR | CI State | Review State | Scores / Signals | Unresolved P0/P1/P2 | Action |
 | --- | --- | --- | --- | --- | --- | --- |
-| pending | pending | pending | pending | pending | pending | Submit draft PRs only after local review and checks. |
+| 2026-05-24 16:02 EDT | #589 | green; merge state clean | draft, no remote review requested yet | CI Gate plus Build/Lint/Dead Code/Typecheck/Test/Governance/Changeset all green | none | keep draft with local review clean. |
+| 2026-05-24 16:02 EDT | #590 | green; merge state clean | draft, no remote review requested yet | CI Gate plus Build/Lint/Dead Code/Typecheck/Test/Governance/Changeset all green | none | keep draft with local review clean. |
+| 2026-05-24 16:02 EDT | #591 | green; merge state clean | draft, no remote review requested yet | CI Gate plus Build/Lint/Dead Code/Typecheck/Test/Governance/Changeset all green | none | keep draft with local review clean. |
+| 2026-05-24 16:02 EDT | #592 | green; merge state clean | draft, no remote review requested yet | CI Gate plus Build/Lint/Dead Code/Typecheck/Test/Governance/Changeset all green | none | keep draft with local review clean. |
 
 ## Review Feedback Resolutions
 
 | Source | Score / Signal | Severity | Finding | Prompt To Fix | Resolution | Evidence |
 | --- | --- | --- | --- | --- | --- | --- |
-| pending | pending | pending | pending | pending | pending | pending |
+| Local review lane 1 | 5/5 | P3 | Published beta smoke `bun test` fails because current registry package lacks `@ontrails/testing/established`. | Record as registry-state caveat, do not change scaffold implementation. | Deferred to next beta publish / registry freshness; not a P0/P1/P2. | Report file and temp smoke output recorded above. |
+| Local review lane 2 | 5/5 | none | No P0/P1/P2 findings. | n/a | No changes needed. | `local-review-lane-2-helper-tooling.md`. |
+| Local review lane 3 | 5/5 | none | No P0/P1/P2 findings. | n/a | No changes needed. | `local-review-lane-3-docs-adr.md`. |
 
 ## Forbidden Actions Audit
 
 | Action / Constraint | Status | Evidence |
 | --- | --- | --- |
-| No merge without explicit user approval | respected so far | Planning only; no merge commands run. |
-| No package publish / registry mutation unless authorized | respected so far | Planning only; no publish/registry commands run. |
-| No merge queue label unless authorized | respected so far | Planning only; no queue mutation. |
-| No source-control writes by subagents | respected so far | No subagents used in planning. |
-| No unrelated destructive changes | respected so far | Packet creation/update and shared-note update only. |
+| No merge without explicit user approval | respected | PRs remain draft/open; no merge commands run. |
+| No package publish / registry mutation unless authorized | respected | Only read-only smoke/install/check commands; no publish or registry mutation. |
+| No merge queue label unless authorized | respected | No queue label mutation. |
+| No source-control writes by subagents | respected | No subagents performed git/gt writes. |
+| No unrelated destructive changes | respected | Changes stayed in scaffold/version helper/docs/ADR packet lanes; docs-gate cleanup was required by `bun run check`. |
 
 ## Final State
 
-Fill before claiming completion, handoff, merge readiness, or archive.
-
-- Goal completion condition:
-- Graphite / branch state:
-- PR state:
-- Source-control host lag:
-- Tracker state:
-- Local review state:
-- Remote review state:
-- Remote review scores:
-- Verification:
-- Skipped checks:
-- Remaining P3s / risks:
-- Follow-up issues created:
-- Forbidden actions confirmation:
-- Packet archive readiness:
-- Final transcript proof:
+- Goal completion condition: met for draft-stack handoff; all four draft PRs
+  exist, CI is green, Linear is current, local review is clean, checks pass, and
+  scope constraints held.
+- Graphite / branch state: current stack tip is
+  `trl-799-draft-adr-scaffold-forward-compatibility-upgrade-path-system`;
+  bottom-to-top PRs are #589, #590, #591, #592.
+- PR state: #589-#592 are draft/open with clean GitHub merge state and green
+  status checks.
+- Source-control host lag: none observed for GitHub checks; Graphite stack is
+  submitted as draft.
+- Tracker state: TRL-796, TRL-798, TRL-797, and TRL-799 are `In Review` with
+  PR/check/local-review comments; TRL-801 remains superseded by TRL-796 comment.
+- Local review state: three local lanes scored 5/5 with no P0/P1/P2 findings.
+- Remote review state: not requested yet because PRs remain draft by goal
+  instruction; CI is green and ready for the next ready-for-review loop.
+- Remote review scores: none yet.
+- Verification: `bun test apps/trails/src/__tests__/create.test.ts`,
+  `bun --cwd apps/trails test`,
+  `bun test scripts/__tests__/sync-scaffold-versions.test.ts`,
+  `bun run scaffold-versions:check`,
+  `bun scripts/adr.ts map && bun scripts/adr.ts check`,
+  `bun scripts/check-markdown-links.ts`,
+  `bun run warden:agents:check && bun run warden:skills:check`,
+  `bun run format:check`, `git diff --check`, and `bun run check` passed before
+  this final RETRO touch; final small checks will be rerun after commit.
+- Skipped checks: no required local checks skipped. Optional temp scaffold
+  `bun test` did not pass because of current published-beta subpath skew; install
+  and typecheck passed.
+- Remaining P3s / risks: published `@ontrails/testing@1.0.0-beta.18` is stale
+  relative to local source for `@ontrails/testing/established`; next beta publish
+  should clear the optional smoke caveat.
+- Follow-up issues created: none; existing TRL-801/803/794/782/783 remain
+  tracked outside this goal.
+- Forbidden actions confirmation: no merge, no publish/registry mutation, no
+  merge queue label, no out-of-scope upgrade/diff/migration/public CLI work.
+- Packet archive readiness: not ready to archive until the stack merges or Matt
+  asks; packet remains active on the stack.
+- Final transcript proof: final response should name PRs #589-#592, green CI,
+  Linear in-review comments, final checks, and remaining P3 registry caveat.
 
 Do not mark complete until the goal completion condition has been proven, this
 section is filled or explicitly marked blocked, and the final transcript names

--- a/.agents/plans/2026-05-24-scaffold-forward-compat-seed/local-review-lane-1-scaffold-shape.md
+++ b/.agents/plans/2026-05-24-scaffold-forward-compat-seed/local-review-lane-1-scaffold-shape.md
@@ -1,0 +1,34 @@
+# Local Review Lane 1: Scaffold Shape
+
+Score: 5/5
+
+## Scope
+
+- TRL-796 exact generated `@ontrails/*` pins.
+- TRL-798 `.trails/scaffold.json` provenance shape.
+- Generated scaffold behavior in `apps/trails/src/trails/create-scaffold.ts`
+  and `apps/trails/src/__tests__/create.test.ts`.
+
+## Findings
+
+- P0: none.
+- P1: none.
+- P2: none.
+- P3: registry-backed smoke cannot run `bun test` to completion until the next
+  beta publication exposes `@ontrails/testing/established`; local source and
+  generated package shape are correct.
+
+## Evidence
+
+- `bun test apps/trails/src/__tests__/create.test.ts` passed 17 tests / 349
+  assertions on the stack tip.
+- Fresh temp scaffold emitted exact `1.0.0-beta.18` pins for every generated
+  `@ontrails/*` dependency/devDependency.
+- Fresh temp scaffold emitted `.trails/scaffold.json` with
+  `schemaVersion: 1`, `scaffoldVersion: 1.0.0-beta.18`,
+  `template: hello`, and an ISO `generatedAt`.
+- `bun install` and `bun run typecheck` passed in the temp scaffold.
+
+## Prompt To Fix
+
+No P0/P1/P2 fix prompt needed.

--- a/.agents/plans/2026-05-24-scaffold-forward-compat-seed/local-review-lane-2-helper-tooling.md
+++ b/.agents/plans/2026-05-24-scaffold-forward-compat-seed/local-review-lane-2-helper-tooling.md
@@ -1,0 +1,30 @@
+# Local Review Lane 2: Helper Tooling
+
+Score: 5/5
+
+## Scope
+
+- TRL-797 internal scaffold-version helper/check.
+- Generated-output coverage for exact `@ontrails/*` pins after version bumps.
+- Release docs that route operators through the helper.
+
+## Findings
+
+- P0: none.
+- P1: none.
+- P2: none.
+- P3: none.
+
+## Evidence
+
+- `bun test scripts/__tests__/sync-scaffold-versions.test.ts` passed 3 tests /
+  3 assertions.
+- `bun run scaffold-versions:check` passed on the stack tip.
+- `bun run dead-code` passed after the bottom-up duplicate-export fix.
+- `docs/releases/stable-cutover.md` and
+  `docs/releases/beta-channel-policy.md` now tell release operators to run
+  `bun run scaffold-versions:sync` after Changesets versioning.
+
+## Prompt To Fix
+
+No P0/P1/P2 fix prompt needed.

--- a/.agents/plans/2026-05-24-scaffold-forward-compat-seed/local-review-lane-3-docs-adr.md
+++ b/.agents/plans/2026-05-24-scaffold-forward-compat-seed/local-review-lane-3-docs-adr.md
@@ -1,0 +1,31 @@
+# Local Review Lane 3: Docs And ADR
+
+Score: 5/5
+
+## Scope
+
+- TRL-799 draft Scaffold Forward Compatibility ADR.
+- Release and getting-started docs.
+- Generated ADR indexes and docs gates.
+
+## Findings
+
+- P0: none.
+- P1: none.
+- P2: none.
+- P3: none.
+
+## Evidence
+
+- `bun scripts/adr.ts map && bun scripts/adr.ts check` passed with 0 errors /
+  0 warnings.
+- `bun scripts/check-markdown-links.ts` passed for 122 files after converting
+  the pre-existing ignored-scratch Wayfinding proto pointer into plain path
+  text.
+- `bun run check` passed on the stack tip.
+- The draft ADR explicitly defers readers, diffs, migrations, template hashes,
+  public `trails upgrade`, publication, and registry mutation.
+
+## Prompt To Fix
+
+No P0/P1/P2 fix prompt needed.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 57
+- Rule count: 58
 
 ## Agent Instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Use the project language consistently:
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
-- Rule count: 57
+- Rule count: 58
 
 ### Rule Index
 

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -935,6 +935,11 @@
           "fromPath": "docs/adr/0046-lock-v3-artifact-family.md"
         },
         {
+          "context": "- [ADR-0010: Trails-Native Infrastructure](../0010-native-infrastructure.md)",
+          "from": "20260524",
+          "fromPath": "docs/adr/drafts/20260524-scaffold-forward-compatibility.md"
+        },
+        {
           "context": "- **[ADR-0010: Trails-Native Infrastructure](./adr/0010-native-infrastructure.md)** — Workspace layout, `.trails/` directory, shared database",
           "from": "index",
           "fromPath": "docs/index.md"
@@ -2562,6 +2567,11 @@
           "fromPath": "docs/adr/0048-trail-versioning-v3.md"
         },
         {
+          "context": "- [ADR-0047: Stable Release Line Discipline](../0047-stable-release-line-discipline.md)",
+          "from": "20260524",
+          "fromPath": "docs/adr/drafts/20260524-scaffold-forward-compatibility.md"
+        },
+        {
           "context": "It is governed by [ADR-0047: Stable Release Line Discipline](../adr/0047-stable-release-line-discipline.md).",
           "from": "stable-cutover",
           "fromPath": "docs/releases/stable-cutover.md"
@@ -2601,6 +2611,11 @@
           "context": "> [ADR-0048: Trail Versioning v3](0048-trail-versioning-v3.md).",
           "from": "0044",
           "fromPath": "docs/adr/0044-trail-versioning.md"
+        },
+        {
+          "context": "- [ADR-0048: Trail Versioning v3](../0048-trail-versioning-v3.md)",
+          "from": "20260524",
+          "fromPath": "docs/adr/drafts/20260524-scaffold-forward-compatibility.md"
         }
       ],
       "number": "0048",

--- a/docs/adr/drafts/20260503-wayfinding.md
+++ b/docs/adr/drafts/20260503-wayfinding.md
@@ -13,7 +13,7 @@ depends_on: [17, 27, 42]
 > Companion: a separate signposts ADR is tracked but deliberately deferred.
 > Wayfinding does not depend on signposts; signposts will land later as a
 > narrower decision once the wayfinder shell exists to host name redirects.
-> Origin proto: [`.scratch/adr/wayfinding-and-signposts.md`](../../../.scratch/adr/wayfinding-and-signposts.md).
+> Origin proto: `.scratch/adr/wayfinding-and-signposts.md`.
 
 ## Context
 
@@ -273,7 +273,7 @@ parameter names where useful (e.g. `wayfind.neighborhood({ direction: 'in' })`).
 - [ADR-0013: Tracing](../0013-tracing.md) and
   [ADR-0041: Unified Observability](../0041-unified-observability.md) — the
   tracing primitive that captures wayfinding usage for free
-- Origin proto: [`.scratch/adr/wayfinding-and-signposts.md`](../../../.scratch/adr/wayfinding-and-signposts.md)
+- Origin proto: `.scratch/adr/wayfinding-and-signposts.md`
 
 [ADR-0013]: ../0013-tracing.md
 [ADR-0017]: ../0017-serialized-topo-graph.md

--- a/docs/adr/drafts/20260524-scaffold-forward-compatibility.md
+++ b/docs/adr/drafts/20260524-scaffold-forward-compatibility.md
@@ -1,0 +1,132 @@
+---
+slug: scaffold-forward-compatibility
+title: Scaffold Forward Compatibility
+status: draft
+created: 2026-05-24
+updated: 2026-05-24
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [10, 47, 48]
+---
+
+# ADR: Scaffold Forward Compatibility
+
+## Context
+
+`trails create` gives a new app its first authored project shape. That shape is
+not just example code: it chooses package ranges, scripts, local `.trails/`
+policy, test wiring, and the first agent guidance a developer sees.
+
+During the beta line, this creates two related problems:
+
+- A generated app that uses floating prerelease ranges can silently install a
+  newer beta than the one that generated it.
+- Once scaffolded code is owned by the app, future tooling needs a small clue
+  about where that owned source began.
+
+ADR-0047 already says fresh generated apps are a release gate. ADR-0048 says
+trail versioning is trail-only: it preserves capability contracts inside a topo,
+not project templates or package distribution. Scaffold forward compatibility
+therefore needs its own lightweight project-level posture.
+
+## Decision
+
+### Generated `@ontrails/*` dependencies are exact pins
+
+Generated apps pin public `@ontrails/*` dependencies and devDependencies to the
+exact `@ontrails/trails` package version that produced the scaffold.
+
+During the beta line, exact pins are safer than caret prerelease ranges because
+they make generated output reproducible. During stable cutover, exact pins make
+the release PR's generated-app inspection concrete: the scaffold names the
+intended stable package family exactly, and the post-publish smoke proves those
+packages exist.
+
+This rule covers Trails-owned packages only. Third-party packages continue to
+use the curated ranges captured by the internal scaffold-version helper.
+
+### Scaffolds stamp a minimal provenance breadcrumb
+
+Every generated app includes `.trails/scaffold.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "scaffoldVersion": "1.0.0-beta.18",
+  "template": "hello",
+  "generatedAt": "2026-05-24T19:34:00.000Z"
+}
+```
+
+The breadcrumb is informational in the current beta line. It records only the
+minimum facts future tooling needs before it can decide whether a project came
+from a known scaffold shape:
+
+- `schemaVersion` names the breadcrumb schema.
+- `scaffoldVersion` names the `@ontrails/trails` package that created the
+  project.
+- `template` names the starter selected by `trails create`.
+- `generatedAt` records when the project was generated.
+
+The file lives under `.trails/` because it is framework-owned project metadata,
+but it is not part of `.trails/trails.lock`, `.trails/topo.lock`, or the topo
+store. It does not describe the app's current resolved graph.
+
+### Version-bump tooling keeps the scaffold synchronized
+
+The internal `scaffold-versions` helper remains the operator path for keeping
+generated scaffold dependency versions current. Its check mode validates two
+things together:
+
+- generated third-party scaffold versions match the root catalog/devDependency
+  source of truth;
+- generated `@ontrails/*` pins match `@ontrails/trails` exactly.
+
+After `bunx changeset version`, release operators run
+`bun run scaffold-versions:sync` so the generated scaffold package story moves
+with the package version calculation instead of becoming hand-edit debt.
+
+### Upgrade tooling is deferred
+
+This ADR does not introduce any public upgrade command or migration system.
+
+Deferred work includes:
+
+- reading `.trails/scaffold.json`;
+- diffing current source against a scaffold baseline;
+- applying generated migrations;
+- template hashes or full source manifests;
+- a public `trails upgrade` command;
+- package or registry mutation.
+
+Those features may follow once there are real scaffold-to-scaffold migrations
+to design around. The breadcrumb is the seed, not the upgrade system.
+
+## Consequences
+
+- Freshly generated apps are more reproducible during beta and stable release
+  work.
+- Release operators have one internal check/sync path for both third-party
+  scaffold dependency versions and exact Trails package pins.
+- Future migration tooling has a small, stable starting point without requiring
+  a large manifest today.
+- Existing generated apps do not receive retroactive provenance unless a future
+  migration tool chooses to add it.
+
+## Non-Goals
+
+- This is not trail versioning, and it does not amend ADR-0048's trail-only
+  versioning doctrine.
+- This is not lockfile or TopoGraph metadata.
+- This does not make generated source framework-owned after scaffolding. The
+  app owns its source files.
+- This does not define package publication or dist-tag policy beyond the exact
+  pins emitted by the scaffolder.
+
+## References
+
+- [ADR-0010: Trails-Native Infrastructure](../0010-native-infrastructure.md)
+- [ADR-0047: Stable Release Line Discipline](../0047-stable-release-line-discipline.md)
+- [ADR-0048: Trail Versioning v3](../0048-trail-versioning-v3.md)
+- [`trails create` scaffold implementation](../../../apps/trails/src/trails/create-scaffold.ts)
+- [Stable Cutover Runbook](../../releases/stable-cutover.md)
+- [Beta Channel Policy](../../releases/beta-channel-policy.md)

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -33,3 +33,5 @@ Proposed decisions under discussion. Promoted to `docs/adr/` when accepted.
 
 - [Wayfinding](20260503-wayfinding.md)
   - depends on [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md), [ADR-0027: Trail Visibility and Surface Filtering](../0027-visibility-and-filtering.md), [ADR-0042: Core/Topographer Boundary Doctrine](../0042-core-topographer-boundary-doctrine.md)
+- [Scaffold Forward Compatibility](20260524-scaffold-forward-compatibility.md)
+  - depends on [ADR-0010: Trails-Native Infrastructure Pattern](../0010-native-infrastructure.md), [ADR-0047: Stable Release Line Discipline](../0047-stable-release-line-discipline.md), [ADR-0048: Trail Versioning v3](../0048-trail-versioning-v3.md)

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -191,6 +191,19 @@
       "superseded_by": null,
       "title": "Wayfinding",
       "updated": "2026-05-03"
+    },
+    {
+      "created": "2026-05-24",
+      "depends_on": ["10", "47", "48"],
+      "inbound": [],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260524-scaffold-forward-compatibility.md",
+      "slug": "scaffold-forward-compatibility",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Scaffold Forward Compatibility",
+      "updated": "2026-05-24"
     }
   ],
   "version": 1

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 57
+- Rule count: 58
 
 ## Agent Instructions
 


### PR DESCRIPTION
## Context

TRL-796, TRL-798, and TRL-797 establish the seed shape for scaffold forward compatibility: exact generated framework pins, a minimal provenance breadcrumb, and an internal release helper. This PR records that shape as draft doctrine while explicitly deferring the larger upgrade-path system.

## Changes

- Add draft ADR `docs/adr/drafts/20260524-scaffold-forward-compatibility.md`.
- Regenerate draft ADR indexes and decision maps.
- Keep the ADR grounded in the implemented exact-pin/provenance/helper shape.
- Explicitly defer scaffold reading, diffing, migrations, template hashing, upgrade application, and public `trails upgrade` surface.
- Clear two docs/generated-guide gates encountered by the full stack check:
  - make stale ignored-scratch Wayfinding proto references plain text instead of links;
  - sync generated Warden guide rule counts in AGENTS and skill references.
- Record local review reports for scaffold shape, helper/tooling coverage, and docs/ADR doctrine fit.

## Validation

- `bun scripts/adr.ts map && bun scripts/adr.ts check`
- `bun scripts/check-markdown-links.ts`
- `bun run warden:agents:check && bun run warden:skills:check`
- `bun run format:check`
- `git diff --check`
- `bun run check`

## Notes / Risks

- No changeset: docs, generated ADR indexes, generated Warden guides, and goal-packet review evidence only.
- Local review lanes scored 5/5, 5/5, and 5/5 with no P0/P1/P2 findings.
- Optional temp-project smoke verified scaffold output/install/typecheck and recorded one registry-state beta skew caveat for published `@ontrails/testing`.
- PR remains draft while the four-PR stack is kept together.

Closes: TRL-799
