### PR TITLE
fix(core): infer resource config types

### DIFF
--- a/.agents/plans/2026-05-26-fieldwork-compounding-stack/GOAL.md
+++ b/.agents/plans/2026-05-26-fieldwork-compounding-stack/GOAL.md
@@ -1,0 +1,27 @@
+# Goal Prompt: Fieldwork Compounding Stack
+
+Paste this into the goal runtime:
+
+````markdown
+/goal From `/Users/mg/Developer/outfitter/trails`, execute `.agents/plans/2026-05-26-fieldwork-compounding-stack/PLAN.md` as a stacked Trails framework sprint. Use `.agents/plans/2026-05-26-fieldwork-compounding-stack/RETRO.md` as the durable ledger and `.agents/plans/2026-05-26-fieldwork-compounding-stack/REFS.md` as the source map.
+
+Objective: build the Fieldwork compounding stack before Radio migration: `TRL-782` resource config type inference, `TRL-804` Warden top-level surface coaching, `TRL-781` `trails create` rerun reconciliation, `TRL-789` entity starter CRUD completeness, `TRL-816` post-compose current-facing cleanup, then prepare/stop at `TRL-814` Radio proof lane.
+
+Read first: `AGENTS.md`, `.agents/plans/PLANNING.md`, packet `PLAN.md`/`REFS.md`, `docs/adr/0000-core-premise.md`, `docs/tenets.md`, `docs/adr/0001-naming-conventions.md`, `docs/lexicon.md`, `docs/architecture.md`, and Linear `TRL-782`, `TRL-804`, `TRL-781`, `TRL-789`, `TRL-816`, `TRL-814`.
+
+Stack branches in order: `trl-782-resourcet-doesnt-flow-config-schemas-inferred-type-into`; `trl-804-warden-warn-topo-export-entry-should-not-open-a-surface-at`; `trl-781-trails-create-errors-hard-on-re-run-instead-of-reconciling`; `trl-789-trails-create-starter-entity-complete-the-crud-entitylist`; `trl-816-post-compose-cutover-cleanup-fix-current-facing-stragglers`. Treat `TRL-814` Radio as terminal proof lane, not an automatic Trails Graphite branch unless prerequisites are explicit.
+
+Before creating branches: sync main; inspect status; do not accidentally include the current local deletion of `scripts/import-scratch-to-notion.ts`. Isolate it by approved separate branch, stash, or explicit Matt approval to carry it.
+
+Loop: one issue per focused Graphite branch unless evidence proves branch boundaries cannot stay green. Report checkpoint, branch, changed files, commands/results, review state, blocker state, and next step. Use subagents everywhere possible; never use fast mode. For well-defined execution/coding work, use GPT 5.4 subagents on high reasoning. Main agent owns all `git`/`gt` writes.
+
+Validation: run focused tests for touched areas, then `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run format:check`, `git diff --check`, and `bun run check` before claiming local completion unless blocked. Run Warden sync/check commands when Warden guides or agent guidance change; run ADR/vocab checks when ADR/docs/vocabulary change. Record every skipped check in `RETRO.md`.
+
+Review: keep PRs draft until local review, CI, and required checks are green. Before ready-for-review, verify Greptile summary is 5/5 and there is no Greptile prompt-to-fix / "Prompt for AI"; treat bot errors as blockers. Fix P0/P1/P2 local or remote findings bottom-up on owning branches; record scores, prompts, fixes, and unresolved P3s in `RETRO.md`.
+
+Hard rules: no merge, publish, registry mutation, merge queue label, Radio source-control mutation, or subagent source-control write without Matt approval. Do not broaden into Hike/Forge/website work. File follow-up Linear issues for real discoveries outside scope.
+
+Done only when Trails-side stack PRs are submitted or stopped with evidence; Linear is current; CI/review states are recorded; `TRL-814` has precise ready/blocker state; forbidden actions are audited; and `RETRO.md` has final branch/PR/verification/review/risk/archive-readiness state. Final transcript must name proof.
+
+Stop/ask if dirty local state cannot be isolated, branch boundaries cannot stay green, `TRL-782` needs a public type redesign, `TRL-804` creates broad false positives, scaffold reconciliation requires destructive behavior, Radio needs package publication/local-link/source-control approval, or unrelated verification fails after focused retry.
+````

--- a/.agents/plans/2026-05-26-fieldwork-compounding-stack/PLAN.md
+++ b/.agents/plans/2026-05-26-fieldwork-compounding-stack/PLAN.md
@@ -1,0 +1,270 @@
+# Goal Plan: Fieldwork Compounding Stack
+
+Date: 2026-05-26
+Status: Planned
+
+## Objective
+
+Land a meaningful Trails framework stack that makes the next Radio migration cleaner and improves the repeatable fieldwork loop for future projects.
+
+This is not a single cleanup PR. It is a small stack of compounding framework fixes:
+
+1. infer resource config types at the authoring boundary;
+2. add Warden coaching for top-level surface side effects in app entry modules;
+3. make `trails create` reruns reconcile instead of half-mutating projects;
+4. make the entity starter satisfy the framework's own CRUD expectations;
+5. clean up current-facing compose vocabulary stragglers;
+6. use Radio as the downstream proof lane once the Trails-side stack is ready.
+
+## Completion Condition
+
+The goal is complete only when:
+
+- Trails-side stack branches for `TRL-782`, `TRL-804`, `TRL-781`, `TRL-789`, and `TRL-816` are submitted as draft PRs or the executor stops at the first blocked branch with evidence.
+- Each submitted PR has focused implementation, a branch-local changeset if publishable package content changed, current Linear comments, local review results, verification results, CI state, and review-bot state recorded in `RETRO.md`.
+- `TRL-814` Radio migration is either started only after a safe prerequisite decision, or explicitly left as the next proof lane with exact blocker/ready criteria.
+- Ready-for-review happens only after CI is green, local review is clean or P3-only, Greptile summary is 5/5, and there is no Greptile "Prompt for AI" / prompt-to-fix content.
+- No merge, package publish, registry mutation, merge queue label, or subagent source-control write occurs without explicit Matt approval.
+- `RETRO.md` is finalized as the durable execution ledger before any final handoff.
+
+## Non-Goals
+
+- Do not merge PRs.
+- Do not publish packages or mutate the registry.
+- Do not add merge queue labels.
+- Do not implement Hike/Fieldwork tooling, website/deck work, or Forge/Hike vocabulary work inside this stack.
+- Do not mutate Radio source control unless Matt explicitly clears the downstream lane.
+- Do not touch unrelated dirty local state in the main checkout. Current known unrelated state: `scripts/import-scratch-to-notion.ts` is deleted locally on `main`; resolve or isolate it before creating stack branches.
+
+## Source Of Truth
+
+Read first:
+
+1. `AGENTS.md`
+2. `.agents/plans/PLANNING.md`
+3. `docs/adr/0000-core-premise.md`
+4. `docs/tenets.md`
+5. `docs/adr/0001-naming-conventions.md`
+6. `docs/lexicon.md`
+7. `docs/architecture.md`
+8. Linear `TRL-782`, `TRL-804`, `TRL-781`, `TRL-789`, `TRL-816`, `TRL-814`
+9. This packet's `REFS.md`
+
+## Ruling Carried Into Execution
+
+This stack prioritizes framework fixes that help Radio and future fieldwork loops before publishing or migrating Radio.
+
+Basis:
+
+- ADR-0000 and the tenets: author what's new, derive what's known, override what's wrong.
+- `TRL-782` is a direct Radio-originated type-safety issue. The resource config schema already exists; the framework should derive the `ctx.config` type instead of forcing an annotation or cast.
+- `TRL-804` moves a real side-effect hazard into Warden coaching. Import-time surface opening during `survey`, `guide`, or compile breaks the "entry is the manifest" workflow.
+- `TRL-781` and `TRL-789` improve the factory/scaffold fieldwork loop. New and rerun scaffold attempts should converge toward a quiet Warden path instead of generating half-baked or self-warning projects.
+- `TRL-816` keeps the active vocabulary coherent after ADR-0049. Radio should migrate onto docs and agent guidance that teach the final `compose` shape, not stale `cross` residue.
+
+## Stack Order
+
+### 1. TRL-782: Resource config type inference
+
+Branch: `trl-782-resourcet-doesnt-flow-config-schemas-inferred-type-into`
+
+Intent:
+
+- Make a resource's `config` Zod schema flow into the `create` callback's `ctx.config` type without manual `ResourceContext<...>` annotation.
+
+Scope:
+
+- Preserve existing runtime behavior.
+- Update `resource()` and `Resource` typing so `ResourceSpec<T, C>` does not erase `C` at the definition boundary.
+- Add compile-time assertions in `packages/core/src/type-checks.test-d.ts`.
+- Add or tighten runtime tests only where they protect the type story from runtime regression.
+
+Acceptance:
+
+- A resource declared with `config: z.object(...)` gives `create(ctx)` a typed `ctx.config`.
+- A resource without config keeps `ctx.config` as `unknown` or equivalent safe default.
+- Existing resource users compile without broad annotation churn.
+
+### 2. TRL-804: Warden warning for top-level surface opening
+
+Branch: `trl-804-warden-warn-topo-export-entry-should-not-open-a-surface-at`
+
+Intent:
+
+- Coach app authors away from opening `surface()` at module top level in a topo-export entry that CLI introspection imports.
+
+Scope:
+
+- Add a Warden warning rule that detects a module-level `surface(...)` call in a likely app/topo entry context.
+- Avoid false positives for imported surface helpers that are only used under an explicit runtime guard, function, or CLI entrypoint.
+- Add diagnostics that explain why `survey`, `guide`, `compile`, and lock generation import the entry module.
+- Add tests and generated Warden guide updates.
+
+Acceptance:
+
+- The rule catches a top-level `await surface(graph)` or direct top-level surface open in an entry module.
+- The rule stays quiet for normal exported `graph = topo(...)` modules and guarded/manual runtime entrypoints.
+- `bun run warden:agents:sync`, `bun run warden:skills:sync`, and matching check commands pass when generated guidance changes.
+
+### 3. TRL-781: `trails create` rerun reconciliation
+
+Branch: `trl-781-trails-create-errors-hard-on-re-run-instead-of-reconciling`
+
+Intent:
+
+- Make rerunning `trails create` on an existing or partially scaffolded directory deterministic and non-destructive.
+
+Scope:
+
+- Audit current write order and failure behavior around `apps/trails/src/trails/create.ts`, `create-scaffold.ts`, and project write helpers.
+- Avoid overwriting unrelated user files before detecting blocking existing surface entries.
+- Prefer a structured plan/apply result over ad hoc writes where the existing code shape supports it.
+- Preserve existing first-run behavior and tests.
+
+Acceptance:
+
+- Rerun against partial scaffold state either reconciles safely or fails before writing unrelated files.
+- Tests cover the Radio-discovered half-baked state.
+- Existing scaffold scripts and verification behavior are preserved.
+
+### 4. TRL-789: Entity starter complete CRUD
+
+Branch: `trl-789-trails-create-starter-entity-complete-the-crud-entitylist`
+
+Intent:
+
+- Fresh entity starter projects should not trip Trails' own `incomplete-crud` Warden warning.
+
+Scope:
+
+- Extend generated entity starter trails with `entity.list` and `entity.delete` or the minimal canonical CRUD coverage the Warden rule expects.
+- Keep generated code small and teach the happy path: schema, `Result`, examples, output schemas, resources, and direct `ctx.compose()` if composition is used.
+- Update scaffold tests and smoke checks.
+
+Acceptance:
+
+- `trails create --starter entity` generates a project whose Warden run does not warn for incomplete CRUD.
+- Generated tests/examples still pass.
+- The starter remains beginner-readable.
+
+### 5. TRL-816: Post-compose current-facing cleanup
+
+Branch: `trl-816-post-compose-cutover-cleanup-fix-current-facing-stragglers`
+
+Intent:
+
+- Clean current-facing `cross` vocabulary residue after PR #596 without rewriting frozen history.
+
+Scope:
+
+- Fix active docs/API reference/accepted ADR examples/agent guidance that still teach `cross` as current vocabulary.
+- Rename low-risk local identifiers that already operate on compose concepts.
+- Update `.agents/memory/decisions.md` with a dated annotation if needed instead of rewriting old decisions.
+- Check whether `TRL-787` and `TRL-802` are now duplicate/superseded; comment or update them rather than leaving stale backlog ambiguity.
+
+Acceptance:
+
+- Active guidance teaches `compose`, `composes`, and `ctx.compose()`.
+- Historical/migration from-state mentions are left intact when clearly legacy.
+- Local review confirms no P0/P1/P2 current-facing vocabulary stragglers in the touched scope.
+
+### 6. TRL-814: Radio migration proof lane
+
+Branch: `trl-814-crosscompose-cutover-s6-radio-migration-follow-up`
+
+Intent:
+
+- Prove the framework stack against Radio once the Trails-side work is ready.
+
+Scope:
+
+- Verify `/Users/mg/Developer/outfitter/radio` exists, is the expected repo, and has a safe worktree state.
+- Decide whether Radio should consume a published beta, local package override, or wait for merge/publish. Stop for Matt if unclear.
+- Run the compose migration and remove workarounds made unnecessary by `TRL-782` and PR #596 where safe.
+- Regenerate Radio `.trails` artifacts and run Radio checks.
+
+Acceptance:
+
+- Radio is green on the final framework vocabulary and type behavior, or the blocker is precise and tracked.
+- No Radio source-control write occurs without explicit lane approval.
+
+## Source-Control Plan
+
+- Work from `/Users/mg/Developer/outfitter/trails`, not a detached Codex worktree.
+- Before branch creation, handle the existing local deletion of `scripts/import-scratch-to-notion.ts` intentionally: commit it in its own approved branch, stash it, or have Matt confirm it belongs in the lowest stack branch.
+- Use Graphite and exact Linear branch names.
+- Prefer one branch per issue in the listed order.
+- Fix downstack review findings on the owning branch, then restack and validate upward.
+- Do not use `gt absorb` as the normal review-fix workflow.
+- Main agent owns all `git` and `gt` writes. Subagents may edit files, run tests, and write reports, but must not run source-control write commands.
+
+## Subagent Strategy
+
+- Use subagents everywhere a task can be bounded by concrete files, predicates, and verification commands.
+- Do not use fast mode for any subagent.
+- For well-defined execution/coding tasks, use GPT 5.4 subagents with high reasoning.
+- Use Spark-style subagents for tightly scoped implementation, test, fixture, search, audit, and review tasks where the expected output can be stated precisely.
+- Keep ambiguous doctrine, branch-shape, tracker, source-control, and public API decisions in the main agent loop.
+- Give every subagent anchored briefs: issue ID, branch/scope, exact files or commands, allowed write targets, expected tests, and the rule that "unable to verify" is better than invented claims.
+- Run multiple subagents in parallel when branches or review lanes are independent; the main agent synthesizes findings, applies source-control writes, and updates `RETRO.md`.
+
+## Tracker Plan
+
+- Move issues to In Progress only when work starts on their branch.
+- Comment on each issue when a PR is opened, when local review finishes, when ready-for-review is attempted, and when remote review is resolved.
+- Comment/update `TRL-787` and `TRL-802` during `TRL-816` if they are superseded by PR #596 and `TRL-816`.
+- Keep `TRL-814` Backlog until the Radio lane is explicitly safe to mutate.
+- File follow-up issues for discoveries outside the stack rather than expanding scope silently.
+
+## Local Review Plan
+
+Use bounded subagents for local review after implementation and before ready-for-review. Prefer Spark reviewers when the review lane is concrete. Reviews must include scores and P0/P1/P2/P3 findings.
+
+Suggested lanes:
+
+- `TRL-782`: type inference seam, backwards-compatible resource authoring, runtime unchanged.
+- `TRL-804`: Warden rule precision, false positives, diagnostic coaching.
+- `TRL-781`/`TRL-789`: scaffold/rerun behavior, generated-project ergonomics, smoke adequacy.
+- `TRL-816`: vocabulary/doctrine precision, active-vs-historical split, generated skill/guide drift.
+- Whole stack: changesets, Linear hygiene, branch ownership, review gates.
+
+Fix P0/P1/P2 or record a hard blocker before ready-for-review.
+
+## Remote Review Plan
+
+- Keep PRs draft until local review and CI are green.
+- Before ready-for-review, verify Greptile summary is 5/5 and there is no prompt-to-fix / "Prompt for AI".
+- Treat Greptile errors as blockers.
+- Resolve review comments with concise replies and record meaningful changes in `RETRO.md`.
+
+## Validation Ladder
+
+Run focused tests per branch, then broaden up-stack:
+
+- `bun run typecheck`
+- `bun run test`
+- `bun run lint`
+- `bun run lint:ast-grep`
+- `bun run format:check`
+- `git diff --check`
+- `bun run check`
+
+Additional branch-specific checks:
+
+- `TRL-804`: focused Warden tests, `bun run warden:agents:sync`, `bun run warden:skills:sync`, `bun run warden:agents:check`, `bun run warden:skills:check`.
+- `TRL-816`: `bun scripts/adr.ts map`, `bun scripts/adr.ts check`, `bun run vocab:audit`, skillset/guidance sync checks if generated agent skills change.
+- Scaffold branches: focused `apps/trails/src/__tests__/create.test.ts`, generated project smoke checks where practical.
+
+Record skipped checks in `RETRO.md`.
+
+## Stop Rules
+
+Stop and ask Matt if:
+
+- The dirty `scripts/import-scratch-to-notion.ts` deletion cannot be isolated safely.
+- A branch boundary cannot stay buildable without collapsing the stack.
+- `TRL-782` requires a public type redesign beyond preserving resource API shape.
+- `TRL-804` cannot avoid broad false positives.
+- `TRL-781` requires a destructive migration or large scaffold rewrite beyond the issue's intent.
+- Radio requires source-control mutation, package publication, registry access, or local package-linking decisions not already approved.
+- CI, Greptile, or code-review bots report P2+ findings that would require scope expansion.

--- a/.agents/plans/2026-05-26-fieldwork-compounding-stack/REFS.md
+++ b/.agents/plans/2026-05-26-fieldwork-compounding-stack/REFS.md
@@ -1,0 +1,131 @@
+# References: Fieldwork Compounding Stack
+
+## Doctrine
+
+- `docs/adr/0000-core-premise.md` - contract-first source of truth; author what's new, derive what's known, override what's wrong.
+- `docs/tenets.md` - schema always exists, one write many reads, drift guard, evaluation hierarchy.
+- `docs/adr/0001-naming-conventions.md` - compose cutover log and API grammar.
+- `docs/lexicon.md` - current compose/resource/surface/topo vocabulary.
+- `docs/architecture.md` - surface import and shared execution pipeline context.
+- `AGENTS.md` - repo workflow, Graphite, subagent, review, and validation rules.
+- `.agents/plans/PLANNING.md` - goal packet, review, source-control, and validation discipline.
+
+## Linear
+
+- `TRL-782` - `resource<T>(...)` does not flow `config` schema inferred type into `create`'s `ctx.config`.
+- `TRL-804` - Warden warning for topo-export entry opening a surface at module top level.
+- `TRL-781` - `trails create` errors hard on rerun instead of reconciling.
+- `TRL-789` - entity starter should complete CRUD coverage.
+- `TRL-816` - post-compose current-facing straggler cleanup.
+- `TRL-814` - Radio compose migration follow-up.
+- `TRL-784` - parent compose cutover record.
+- `TRL-787` and `TRL-802` - likely duplicate/superseded guidance issues to inspect during `TRL-816`.
+
+## Live State Snapshot
+
+Captured 2026-05-26 around 13:30 EDT:
+
+- Main checkout: `/Users/mg/Developer/outfitter/trails`
+- `origin/main` / `main` head: `1eb5bdc06 feat: rename trail composition API to compose (#596)`
+- Open GitHub PRs: none.
+- Graphite stack: `main` only.
+- Known dirty state on main: `D scripts/import-scratch-to-notion.ts`.
+- Created tracker item: `TRL-816` with branch `trl-816-post-compose-cutover-cleanup-fix-current-facing-stragglers`.
+
+## TRL-782 Code Anchors
+
+- `packages/core/src/resource.ts`
+  - `ResourceContext<C = unknown>`
+  - `ResourceSpec<T, C = unknown>`
+  - `Resource<T> extends ResourceSpec<T>` currently erases config generic.
+  - `resource = <T>(id: string, spec: ResourceSpec<T>): Resource<T>` currently has only one generic.
+- `packages/core/src/__tests__/service-config.test.ts`
+  - runtime config behavior and current manual `ResourceContext<{...}>` annotations.
+- `packages/core/src/type-checks.test-d.ts`
+  - compile-time assertion home.
+- `docs/resources.md`
+  - resource config documentation if public type examples need adjustment.
+
+## TRL-804 Code Anchors
+
+- `apps/trails/src/trails/load-app.ts`
+  - `tryLoadFreshAppLease()` imports real app entries for introspection.
+- `apps/trails/src/trails/survey.ts`, `guide.ts`, `compile.ts`, `topo.ts`, `run.ts`
+  - commands that depend on app import behavior.
+- `packages/warden/src/rules/`
+  - rule implementation patterns.
+- `packages/warden/src/rules/index.ts`, `metadata.ts`, generated guide blocks
+  - registration and docs paths.
+- `packages/warden/src/__tests__/`
+  - rule test patterns.
+
+## TRL-781 / TRL-789 Code Anchors
+
+- `apps/trails/src/trails/create.ts`
+  - top-level `trails create` trail and compose flow.
+- `apps/trails/src/trails/create-scaffold.ts`
+  - starter content generation, including `generateEntityTrails()`.
+- `apps/trails/src/project-writes.ts`
+  - write helpers and overwrite behavior.
+- `apps/trails/src/__tests__/create.test.ts`
+  - scaffold and rerun behavior tests.
+- `packages/warden/src/rules/incomplete-crud.ts`
+  - entity starter acceptance target.
+
+## TRL-816 Audit Seeds
+
+From Clark's post-PR #596 audit, verify before editing because line numbers may drift:
+
+- `docs/api-reference.md` reserved/dead `validateCross`-style names.
+- `docs/adr/0018-signal-driven-governance.md` example using `conn.crossings`.
+- `docs/adr/0009-first-class-resources.md` example step using `createCross`.
+- `docs/adr/0023-simplifying-the-trails-lexicon.md` runtime verbs list.
+- `docs/adr/0006-shared-execution-pipeline.md` prose mentioning cross capability.
+- `docs/adr/0010-native-infrastructure.md` prose mentioning crossing declarations.
+- `docs/adr/0015-topo-store.md` SQL comment/prose around trail crossings.
+- `.claude/skills/trails-adrs/SKILL.md` and `.agents/skills/trails-adrs/SKILL.md` vocabulary line.
+- `plugin/README.md` lexicon summary.
+- Cosmetic local identifiers in `packages/core/src/execute.ts`, `packages/warden/src/rules/ast.ts`, `packages/tracing/src/__tests__/intrinsic-tracing.test.ts`, and `apps/trails-demo/__tests__/onboard.test.ts`.
+
+Do not rewrite frozen release history, from-state migrations, generated historical survey snapshots, or clearly legacy references.
+
+## Radio Lane
+
+- Radio repo path: `/Users/mg/Developer/outfitter/radio`
+- Previously observed dirty files: `src/trails/ensure-project.ts`, `src/trails/reply.ts`, `src/trails/transmit.ts`.
+- Previously observed dependency range: `@ontrails/*` `^1.0.0-beta.18`.
+- Radio source-control mutation requires explicit lane approval.
+
+## Verification Commands
+
+Base:
+
+```bash
+bun run typecheck
+bun run test
+bun run lint
+bun run lint:ast-grep
+bun run format:check
+git diff --check
+bun run check
+```
+
+Docs/guidance:
+
+```bash
+bun scripts/adr.ts map
+bun scripts/adr.ts check
+bun run vocab:audit
+bun run warden:agents:sync
+bun run warden:skills:sync
+bun run warden:agents:check
+bun run warden:skills:check
+```
+
+Scaffold:
+
+```bash
+bun test apps/trails/src/__tests__/create.test.ts
+```
+
+Use focused package tests first, then broaden as branches stabilize.

--- a/.agents/plans/2026-05-26-fieldwork-compounding-stack/RETRO.md
+++ b/.agents/plans/2026-05-26-fieldwork-compounding-stack/RETRO.md
@@ -1,0 +1,119 @@
+# Execution Retro: Fieldwork Compounding Stack
+
+Date started: 2026-05-26
+Date finalized:
+Status: In progress
+Plan: `.agents/plans/2026-05-26-fieldwork-compounding-stack/PLAN.md`
+Goal: `.agents/plans/2026-05-26-fieldwork-compounding-stack/GOAL.md`
+
+Use this as the durable execution ledger. Update it before any final handoff, draft submission, ready-for-review transition, remote review closeout, merge readiness claim, archive, or explicit stop.
+
+## Execution Summary
+
+- Objective:
+- Final outcome:
+- Final branch / stack tip:
+- Final PR range:
+- Final tracker state:
+- Final verification state:
+- Remaining risks / P3s:
+- Archive state:
+
+## Branch / PR / Issue Ledger
+
+| Order | Issue | Branch | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | TRL-782 | `trl-782-resourcet-doesnt-flow-config-schemas-inferred-type-into` | | In progress | Resource config type inference. |
+| 2 | TRL-804 | `trl-804-warden-warn-topo-export-entry-should-not-open-a-surface-at` | | Planned | Warden top-level surface warning. |
+| 3 | TRL-781 | `trl-781-trails-create-errors-hard-on-re-run-instead-of-reconciling` | | Planned | Scaffold rerun reconciliation. |
+| 4 | TRL-789 | `trl-789-trails-create-starter-entity-complete-the-crud-entitylist` | | Planned | Entity starter CRUD completion. |
+| 5 | TRL-816 | `trl-816-post-compose-cutover-cleanup-fix-current-facing-stragglers` | | Planned | Current-facing compose straggler cleanup. |
+| 6 | TRL-814 | `trl-814-crosscompose-cutover-s6-radio-migration-follow-up` | | Planned proof lane | Radio migration; separate source-control lane unless approved. |
+
+## Planning Discoveries
+
+| Discovery | Evidence | Decision | Impact |
+| --- | --- | --- | --- |
+| Main is clean of open PRs but not clean locally. | `gh pr list` returned none; `git status` showed `D scripts/import-scratch-to-notion.ts`. | Executor must isolate dirty deletion before creating stack branches. | Prevents accidental unrelated deletion in stack. |
+| Compose aftercare needed its own issue. | Clark audit found current-facing stragglers after PR #596. | Created `TRL-816` under `TRL-784`. | Stack gets a focused cleanup branch. |
+
+## Tracker Mutations
+
+| Time | Tracker Item | Mutation | Evidence |
+| --- | --- | --- | --- |
+| 2026-05-26 13:31 EDT | TRL-816 | Created issue under TRL-784 for post-compose current-facing cleanup. | Linear URL: <https://linear.app/outfitter/issue/TRL-816/post-compose-cutover-cleanup-fix-current-facing-stragglers-and-stale> |
+
+## Execution Log
+
+```text
+2026-05-26 13:31 EDT - planning packet seeded
+- Changed: created `.agents/plans/2026-05-26-fieldwork-compounding-stack/` with PLAN.md, GOAL.md, REFS.md, and RETRO.md.
+- Tracker: created TRL-816 for post-compose cleanup.
+- Verified: live repo has no open PRs and Graphite shows main only; Linear Fieldwork backlog has the target issues.
+- Result: packet ready for execution; implementation not started.
+- Blockers before execution: local deletion of `scripts/import-scratch-to-notion.ts` must be isolated or approved.
+
+2026-05-26 13:40 EDT - subagent strategy tightened
+- Changed: PLAN.md now explicitly directs the executor to use subagents everywhere a task can be bounded, with no fast mode for any subagent and GPT 5.4 high reasoning for well-defined execution/coding tasks.
+- Changed: GOAL.md pasteable prompt now carries the same instruction so it survives even if the executor only reads the prompt.
+- Guardrail: main agent still owns all `git`/`gt` writes, tracker mutation, branch-shape decisions, and public API/doctrine calls.
+
+2026-05-26 15:05 EDT - execution preflight
+- Read: `AGENTS.md`, `.agents/plans/PLANNING.md`, packet `PLAN.md`/`REFS.md`, `docs/adr/0000-core-premise.md`, `docs/tenets.md`, `docs/adr/0001-naming-conventions.md`, `docs/lexicon.md`, and `docs/architecture.md`.
+- Tracker: fetched Linear TRL-782, TRL-804, TRL-781, TRL-789, TRL-816, and TRL-814. All target Trails issues were Backlog at fetch time.
+- Dirty state: confirmed unrelated tracked deletion `D scripts/import-scratch-to-notion.ts`; isolated it with `git stash push -m "isolate import-scratch deletion before fieldwork stack" -- scripts/import-scratch-to-notion.ts`.
+- Dirty state after isolation: only untracked active packet files under `.agents/plans/2026-05-26-fieldwork-compounding-stack/`.
+- Sync: ran `gt sync` on `main`; result `ok synced`.
+- Branch state: `main`, `origin/main`, and local `main` all at `1eb5bdc06142d8886f3870801b2ef71a0c5f3844`.
+- Note: local Trails skill was read but found stale on pre-compose `cross` wording; repo docs and live Linear are authoritative.
+
+2026-05-26 15:25 EDT - TRL-782 implementation
+- Branch: `trl-782-resourcet-doesnt-flow-config-schemas-inferred-type-into`.
+- Tracker: moved TRL-782 to In Progress.
+- Changed: `packages/core/src/resource.ts` now preserves the resource config generic through `Resource<T, C>` and overloads `resource()` so a `config` Zod schema contextually types `create(ctx).config`.
+- Changed: `packages/core/src/__tests__/service-config.test.ts` removed manual `ResourceContext<{...}>` annotations in configured-resource factories so runtime tests exercise inferred authoring.
+- Changed: `packages/core/src/type-checks.test-d.ts` added compile-time assertions for inferred config, defaulted config, returned `Resource<T, C>`, and no-config `unknown`.
+- Changed: added `.changeset/resource-config-inference.md` for `@ontrails/core` patch.
+- Local review: subagent Bacon confirmed the live seam and recommended the same type-only fix plus no new runtime behavior.
+```
+
+## Verification Log
+
+| Time | Branch | Command | Result | Notes |
+| --- | --- | --- | --- | --- |
+| 2026-05-26 15:25 EDT | TRL-782 | `bun run --cwd packages/core typecheck` | Pass | Compile-time assertions include resource config inference. |
+| 2026-05-26 15:25 EDT | TRL-782 | `bun test packages/core/src/__tests__/service-config.test.ts packages/core/src/__tests__/resource.test.ts` | Pass | 25 tests passed. |
+| 2026-05-26 15:26 EDT | TRL-782 | `bun run lint:ast-grep` | Pass | Repo ast-grep scan passed. |
+| 2026-05-26 15:26 EDT | TRL-782 | `git diff --check` | Pass | No whitespace errors. |
+| 2026-05-26 15:28 EDT | TRL-782 | `bun run lint` | Pass after focused fix | Initial run failed on new type-check style (`prefer-destructuring`, `no-unused-expressions`, `consistent-type-definitions`); fixed and reran clean. |
+| 2026-05-26 15:29 EDT | TRL-782 | `bun run format:check` | Pass after formatting | Initial run flagged `packages/core/src/type-checks.test-d.ts`; formatted with `bunx ultracite fix packages/core/src/type-checks.test-d.ts`, then reran clean. |
+
+## Local Review Log
+
+| Time | Branch | Lane | Reviewer | Score | Findings | Outcome |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2026-05-26 15:25 EDT | TRL-782 | Type inference seam scout | Bacon (subagent) | Clean plan | Found the generic erasure in `Resource<T>` / `resource()` and recommended compile-time tests plus no runtime change. | Implemented matching fix. |
+
+## Remote Review / CI Log
+
+| Time | PR | Source | State | Details | Outcome |
+| --- | --- | --- | --- | --- | --- |
+| | | | | | |
+
+## Forbidden Actions Audit
+
+- Merge:
+- Package publish / registry mutation:
+- Merge queue label:
+- Subagent source-control write:
+- Radio source-control mutation:
+
+## Deferred / Follow-Up Discoveries
+
+| Issue | Discovery | Why Out Of Goal | Link |
+| --- | --- | --- | --- |
+| | | | |
+
+## Final State
+
+Not finalized.

--- a/.changeset/resource-config-inference.md
+++ b/.changeset/resource-config-inference.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/core": patch
+---
+
+Infer `resource()` create-context config types from resource config schemas.

--- a/packages/core/src/__tests__/service-config.test.ts
+++ b/packages/core/src/__tests__/service-config.test.ts
@@ -7,7 +7,6 @@ import { executeTrail } from '../execute.js';
 import { Result } from '../result.js';
 import { resource } from '../resource.js';
 import { trail } from '../trail.js';
-import type { ResourceContext } from '../resource.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,7 +19,7 @@ const createSingletonConfigTrail = (id: string) => {
   const captures = { createCalls: 0 };
   const svc = resource(id, {
     config: z.object({ key: z.string() }),
-    create: (ctx: ResourceContext<{ key: string }>) => {
+    create: (ctx) => {
       captures.createCalls += 1;
       return Result.ok({
         createCall: captures.createCalls,
@@ -55,7 +54,7 @@ describe('ResourceContext.config', () => {
 
     const db = resource(id, {
       config: z.object({ poolSize: z.number(), url: z.string().url() }),
-      create: (svc: ResourceContext<{ url: string; poolSize: number }>) => {
+      create: (svc) => {
         capturedConfig = svc.config;
         return Result.ok({ connected: true });
       },
@@ -159,7 +158,7 @@ describe('ResourceContext.config', () => {
 
     const svc = resource(id, {
       config: z.object({ mode: z.literal('noop') }).default({ mode: 'noop' }),
-      create: (ctx: ResourceContext<{ mode: 'noop' }>) => {
+      create: (ctx) => {
         capturedConfig = ctx.config;
         return Result.ok({ mode: ctx.config.mode });
       },
@@ -206,7 +205,7 @@ describe('ResourceContext.config', () => {
 
     const svc = resource(id, {
       config: z.object({ key: z.string() }),
-      create: (ctx: ResourceContext<{ key: string }>) => {
+      create: (ctx) => {
         captures.push(ctx.config);
         return Result.ok({ key: ctx.config.key });
       },

--- a/packages/core/src/resource.ts
+++ b/packages/core/src/resource.ts
@@ -58,8 +58,15 @@ export interface ResourceSpec<T, C = unknown> {
   readonly version?: never;
 }
 
+type ResourceSpecWithConfig<T, S extends z.ZodTypeAny> = Omit<
+  ResourceSpec<T, z.infer<S>>,
+  'config'
+> & {
+  readonly config: S;
+};
+
 /** A typed resource definition. */
-export interface Resource<T> extends ResourceSpec<T> {
+export interface Resource<T, C = unknown> extends ResourceSpec<T, C> {
   readonly kind: 'resource';
   readonly id: string;
   /** Read the resolved resource instance from a trail context. */
@@ -74,7 +81,7 @@ export interface Resource<T> extends ResourceSpec<T> {
  * existential here.
  */
 // oxlint-disable-next-line no-explicit-any -- existential type for heterogeneous resource collections
-export type AnyResource = Resource<any>;
+export type AnyResource = Resource<any, any>;
 
 /** Explicit runtime overrides keyed by resource ID. */
 export type ResourceOverrideMap = Readonly<Record<string, unknown>>;
@@ -116,37 +123,47 @@ export const createResourceLookup = (
  * The resource object is inert until a later execution branch resolves concrete
  * instances into TrailContext extensions.
  */
-export const resource = <T>(id: string, spec: ResourceSpec<T>): Resource<T> =>
-  (() => {
-    if (id.includes(':')) {
-      throw new InternalError(
-        `Resource "${id}" is invalid because resource ids may not contain ":"`
-      );
-    }
-    if (spec.mock !== undefined && spec.unmockable !== undefined) {
-      throw new InternalError(
-        `Resource "${id}" cannot define both mock and unmockable`
-      );
-    }
-    if (
-      spec.unmockable !== undefined &&
-      spec.unmockable.reason.trim().length === 0
-    ) {
-      throw new InternalError(
-        `Resource "${id}" is invalid because unmockable.reason must not be empty`
-      );
-    }
+export function resource<T, S extends z.ZodTypeAny>(
+  id: string,
+  spec: ResourceSpecWithConfig<T, S>
+): Resource<T, z.infer<S>>;
+export function resource<T, C = unknown>(
+  id: string,
+  spec: ResourceSpec<T, C>
+): Resource<T, C>;
+export function resource<T, C = unknown>(
+  id: string,
+  spec: ResourceSpec<T, C>
+): Resource<T, C> {
+  if (id.includes(':')) {
+    throw new InternalError(
+      `Resource "${id}" is invalid because resource ids may not contain ":"`
+    );
+  }
+  if (spec.mock !== undefined && spec.unmockable !== undefined) {
+    throw new InternalError(
+      `Resource "${id}" cannot define both mock and unmockable`
+    );
+  }
+  if (
+    spec.unmockable !== undefined &&
+    spec.unmockable.reason.trim().length === 0
+  ) {
+    throw new InternalError(
+      `Resource "${id}" is invalid because unmockable.reason must not be empty`
+    );
+  }
 
-    return Object.freeze({
-      ...spec,
-      from(ctx: TrailContext): T {
-        const lookup = ctx.resource ?? createResourceLookup(() => ctx);
-        return lookup(this);
-      },
-      id,
-      kind: 'resource' as const,
-    });
-  })();
+  return Object.freeze({
+    ...spec,
+    from(ctx: TrailContext): T {
+      const lookup = ctx.resource ?? createResourceLookup(() => ctx);
+      return lookup(this);
+    },
+    id,
+    kind: 'resource' as const,
+  });
+}
 
 /** Narrow unknown values to resource definitions during topo discovery. */
 export const isResource = (value: unknown): value is AnyResource => {

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -2,8 +2,9 @@
  * Compile-time type assertions for type-utils.
  *
  * This file lives in src/ (not __tests__/) so it is included in the
- * typecheck pass. It contains no runtime code — only type-level
- * assertions that fail the build when type inference regresses.
+ * typecheck pass. It contains type-level assertions that fail the build
+ * when type inference regresses, plus a small number of inert const
+ * declarations that verify contextual inference at call sites.
  *
  * Assertion types are exported to satisfy `noUnusedLocals` but are not
  * re-exported from the package index.
@@ -12,7 +13,8 @@
 import type { Signal, SignalSpec } from './signal.js';
 import type { Trail, TrailSpec, TrailVersionRevisionEntry } from './trail.js';
 import type { ExecuteTrailOptions } from './execute.js';
-import type { ResourceSpec } from './resource.js';
+import { resource } from './resource.js';
+import type { Resource, ResourceSpec } from './resource.js';
 import type { ContourOptions } from './contour.js';
 import type { ScheduleSpec } from './schedule.js';
 import type { WebhookSpec } from './webhook.js';
@@ -178,6 +180,102 @@ export type NonTrailVersionReservations = [
 ] extends [true, true, true, true, true]
   ? 'pass'
   : never;
+
+// ---------------------------------------------------------------------------
+// resource() carries config schema inference into create(ctx).config
+// ---------------------------------------------------------------------------
+
+type ResourceConfigSchema = z.ZodObject<{
+  readonly key: z.ZodString;
+  readonly poolSize: z.ZodNumber;
+}>;
+type ConfiguredResource = ReturnType<
+  typeof resource<{ readonly connected: true }, ResourceConfigSchema>
+>;
+type ConfiguredResourceConfig = Parameters<
+  ConfiguredResource['create']
+>[0]['config'];
+interface ExpectedResourceConfig {
+  readonly key: string;
+  readonly poolSize: number;
+}
+type AssertResourceConfigForward =
+  ConfiguredResourceConfig extends ExpectedResourceConfig ? true : false;
+type AssertResourceConfigReverse =
+  ExpectedResourceConfig extends ConfiguredResourceConfig ? true : false;
+type AssertResourceCarriesConfig =
+  ConfiguredResource extends Resource<
+    { readonly connected: true },
+    ExpectedResourceConfig
+  >
+    ? true
+    : false;
+export type ResourceConfigInference = [
+  AssertResourceConfigForward,
+  AssertResourceConfigReverse,
+  AssertResourceCarriesConfig,
+] extends [true, true, true]
+  ? 'pass'
+  : never;
+
+export const inferredConfiguredResource = resource('typecheck.configured', {
+  config: {} as ResourceConfigSchema,
+  create: (ctx) => {
+    const { key, poolSize }: ExpectedResourceConfig = ctx.config;
+    return { key, poolSize } as unknown as Result<
+      { readonly key: string; readonly poolSize: number },
+      Error
+    >;
+  },
+});
+export type InferredConfiguredResourceConfig = Parameters<
+  typeof inferredConfiguredResource.create
+>[0]['config'];
+type AssertInferredConfiguredResource =
+  InferredConfiguredResourceConfig extends ExpectedResourceConfig
+    ? true
+    : false;
+export type InferredResourceConfigInference = [
+  AssertInferredConfiguredResource,
+] extends [true]
+  ? 'pass'
+  : never;
+
+export const inferredDefaultedResource = resource(
+  'typecheck.defaulted-config',
+  {
+    config: {} as z.ZodDefault<
+      z.ZodObject<{
+        readonly mode: z.ZodLiteral<'noop'>;
+      }>
+    >,
+    create: (ctx) => {
+      const { mode }: { readonly mode: 'noop' } = ctx.config;
+      return { mode } as unknown as Result<{ readonly mode: 'noop' }, Error>;
+    },
+  }
+);
+
+type PlainResource = ReturnType<typeof resource<number>>;
+type PlainResourceConfig = Parameters<PlainResource['create']>[0]['config'];
+type AssertPlainResourceConfigUnknown = unknown extends PlainResourceConfig
+  ? PlainResourceConfig extends unknown
+    ? true
+    : false
+  : false;
+export type ResourceWithoutConfigDefault = [
+  AssertPlainResourceConfigUnknown,
+] extends [true]
+  ? 'pass'
+  : never;
+
+export const inferredPlainResource = resource('typecheck.plain', {
+  create: (ctx) => {
+    // @ts-expect-error config remains unknown when no config schema is authored.
+    const { key } = ctx.config;
+    return key as unknown as Result<number, Error>;
+  },
+});
 
 interface RevisionInput {
   readonly legacyName: string;


### PR DESCRIPTION
## Context

Part 1 of the Fieldwork compounding stack for TRL-782. Resource config schemas were not flowing into the inferred type of `ctx.config` inside resource factories, forcing authors to annotate `ResourceContext` manually.

## What changed

- Threads the resource config generic through `Resource<T, C>` and `AnyResource`.
- Adds overloads so `resource(id, { config: z.object(...) })` infers `ctx.config` from the Zod schema.
- Removes manual config-context annotations from configured-resource tests so runtime tests exercise inferred authoring.
- Adds compile-time assertions for configured, defaulted, and no-config resources.

## Verification

- `bun run --cwd packages/core typecheck`
- `bun test packages/core/src/__tests__/service-config.test.ts packages/core/src/__tests__/resource.test.ts`
- Stack-tip gate later passed: `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run format:check`, `git diff --check`, `bun run check`

## Risks / rollout

Type-only API inference change; no runtime behavior change intended. Changeset included for `@ontrails/core`.
